### PR TITLE
Add OpenViking MCP parity and harden update repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Ask the agent to recall the feature, branch, or repo. Threadnote returns auditab
 Install the MCP adapter for each agent you use. The user-level instructions tell agents to store a handoff before they pause, so the next agent can search the same local memory layer instead of reconstructing context
 from chat history.
 
+The adapter keeps Threadnote workflow tools (`recall_context`, `remember_context`, `share_publish`, and related aliases)
+as the default surface, and also exposes raw OpenViking parity tools with `ov_*` names for native behaviors such as
+code symbol navigation, watch management, raw search/read/list/store/remember, grep/glob, resource import, and forget.
+
 **Working through a long task until the agent context window fills up?**  
 After compaction, the next agent turn can recall the relevant Threadnote memories and handoffs instead of relying only on the compressed conversation summary.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,6 +124,10 @@ Threadnote uses its bundled stdio MCP adapter by default, even when the installe
 `/mcp`. The adapter adds Threadnote-specific tools and behavior such as shared-memory sync, exact recall fallback,
 seeded-resource recall augmentation, and recall-index repair.
 
+The adapter also exposes raw OpenViking parity tools with `ov_*` names for native behaviors such as code symbol
+navigation, watch management, raw search/read/list/store/remember, grep/glob, resource import, and forget. Prefer
+Threadnote-named tools for memory workflows; use `ov_*` when you intentionally want native OpenViking behavior.
+
 Use the default stdio adapter:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "commonjs",
   "main": "dist/threadnote.cjs",
   "description": "Shared local context and handoffs for development agents",

--- a/src/cli_ui.ts
+++ b/src/cli_ui.ts
@@ -92,3 +92,45 @@ export async function withSpinner<T>(message: string, action: () => Promise<T>):
     cursorTo(stdout, 0);
   }
 }
+
+export interface ProgressIndicator {
+  update(message: string): void;
+  stop(): void;
+}
+
+export function startProgress(message: string): ProgressIndicator {
+  if (stdout.isTTY !== true || process.env.CI !== undefined || process.env.THREADNOTE_NO_SPINNER !== undefined) {
+    console.log(message);
+    return {
+      update(nextMessage: string): void {
+        console.log(nextMessage);
+      },
+      stop(): void {
+        return;
+      },
+    };
+  }
+
+  const frames = ['-', '\\', '|', '/'];
+  let frameIndex = 0;
+  let currentMessage = message;
+  const render = () => {
+    clearLine(stdout, 0);
+    cursorTo(stdout, 0);
+    stdout.write(`${muted(frames[frameIndex])} ${currentMessage}`);
+    frameIndex = (frameIndex + 1) % frames.length;
+  };
+  const timer = setInterval(render, 100);
+  render();
+  return {
+    update(nextMessage: string): void {
+      currentMessage = nextMessage;
+      render();
+    },
+    stop(): void {
+      clearInterval(timer);
+      clearLine(stdout, 0);
+      cursorTo(stdout, 0);
+    },
+  };
+}

--- a/src/index_repair.ts
+++ b/src/index_repair.ts
@@ -9,7 +9,8 @@ const AUTO_REPAIR_STATE_FILE = 'index-auto-repair.json';
 const AUTO_REPAIR_TTL_MS = 6 * 60 * 60 * 1000;
 const MAX_SCAN_DEPTH = 5;
 const MAX_REPAIR_TARGETS = 4;
-export const MAINTENANCE_MAX_REPAIR_TARGETS = 16;
+export const MAINTENANCE_COLLAPSE_DEPTH = 3;
+export const MAINTENANCE_MAX_REPAIR_TARGETS = 512;
 
 interface RecallIndexRepairConfig {
   readonly account: string;
@@ -68,11 +69,13 @@ export async function repairStaleRecallIndex(
   ov: string,
   options: {
     readonly collapseToRoots?: boolean;
+    readonly collapseDepth?: number;
     readonly dryRun?: boolean;
     readonly ignoreBackoff?: boolean;
     readonly includeAgentSkills?: boolean;
     readonly includeManifestResources?: boolean;
     readonly maxTargets?: number;
+    readonly onRepairFailure?: (target: StaleIndexTarget, result: CommandResult) => Promise<void> | void;
     readonly onProgress?: (progress: RecallIndexRepairProgress) => void;
     readonly query?: string;
   } = {},
@@ -126,6 +129,7 @@ export async function repairStaleRecallIndex(
       state.entries[target.uri] = {repairedAt: new Date(now).toISOString(), signature: target.signature};
     } else {
       warnings.push(indexRepairWarning(target.uri, result));
+      await options.onRepairFailure?.(target, result);
     }
   }
 
@@ -140,6 +144,7 @@ export async function findStaleRecallIndexTargets(
   config: RecallIndexRepairConfig,
   options: {
     readonly collapseToRoots?: boolean;
+    readonly collapseDepth?: number;
     readonly includeAgentSkills?: boolean;
     readonly includeManifestResources?: boolean;
     readonly query?: string;
@@ -153,15 +158,13 @@ export async function findStaleRecallIndexTargets(
     }
     const sidecars = await staleSidecars(root.path, root.uri);
     if (options.collapseToRoots === true) {
-      if (sidecars.length === 0) {
-        continue;
+      for (const sidecar of sidecars) {
+        const uri = collapseStaleSidecarUri(root.uri, sidecar.relativePath, options.collapseDepth);
+        const current = byUri.get(uri) ?? {parts: [], staleCount: 0, uri};
+        current.parts.push(`${sidecar.relativePath}\n${sidecar.content}`);
+        current.staleCount += 1;
+        byUri.set(uri, current);
       }
-      const parts = sidecars.map(sidecar => `${sidecar.relativePath}\n${sidecar.content}`);
-      byUri.set(root.uri, {
-        parts,
-        staleCount: sidecars.length,
-        uri: root.uri,
-      });
       continue;
     }
     for (const sidecar of sidecars) {
@@ -178,14 +181,33 @@ export async function findStaleRecallIndexTargets(
   }));
 }
 
+function collapseStaleSidecarUri(rootUri: string, relativePath: string, depth = 0): string {
+  const normalizedRootUri = trimLocalRootUri(rootUri);
+  if (depth <= 0) {
+    return normalizedRootUri;
+  }
+  const parentParts = relativePath.split('/').slice(0, -1);
+  const collapsedParts = parentParts.slice(0, depth);
+  return collapsedParts.length === 0 ? normalizedRootUri : `${normalizedRootUri}/${collapsedParts.join('/')}`;
+}
+
 export function formatRecallIndexRepairMessages(
   result: RecallIndexRepairResult,
-  options: {readonly dryRun?: boolean} = {},
+  options: {readonly dryRun?: boolean; readonly maxUris?: number} = {},
 ): readonly string[] {
   const messages: string[] = [];
-  for (const uri of result.repairedUris) {
+  const maxUris = options.maxUris ?? result.repairedUris.length;
+  for (const uri of result.repairedUris.slice(0, maxUris)) {
     messages.push(
       `${options.dryRun === true ? 'Would auto-reindex stale recall scope' : 'Auto-reindexed stale recall scope'}: ${uri}`,
+    );
+  }
+  const hiddenUriCount = result.repairedUris.length - maxUris;
+  if (hiddenUriCount > 0) {
+    messages.push(
+      options.dryRun === true
+        ? `Would auto-reindex ${hiddenUriCount} more stale recall scope(s).`
+        : `Auto-reindexed ${hiddenUriCount} more stale recall scope(s).`,
     );
   }
   for (const warning of result.warnings) {

--- a/src/index_repair.ts
+++ b/src/index_repair.ts
@@ -41,6 +41,28 @@ export interface RecallIndexRepairResult {
   readonly warnings: readonly string[];
 }
 
+export type RecallIndexRepairProgress =
+  | {readonly type: 'scan-start'}
+  | {readonly repairTargetCount: number; readonly totalTargets: number; readonly type: 'scan-complete'}
+  | {
+      readonly index: number;
+      readonly target: StaleIndexTarget;
+      readonly total: number;
+      readonly type: 'repair-start';
+    }
+  | {
+      readonly index: number;
+      readonly target: StaleIndexTarget;
+      readonly total: number;
+      readonly type: 'repair-skip-recent';
+    }
+  | {
+      readonly index: number;
+      readonly target: StaleIndexTarget;
+      readonly total: number;
+      readonly type: 'repair-dry-run';
+    };
+
 export async function repairStaleRecallIndex(
   config: RecallIndexRepairConfig,
   ov: string,
@@ -51,10 +73,18 @@ export async function repairStaleRecallIndex(
     readonly includeAgentSkills?: boolean;
     readonly includeManifestResources?: boolean;
     readonly maxTargets?: number;
+    readonly onProgress?: (progress: RecallIndexRepairProgress) => void;
     readonly query?: string;
   } = {},
 ): Promise<RecallIndexRepairResult> {
+  options.onProgress?.({type: 'scan-start'});
   const targets = await findStaleRecallIndexTargets(config, options);
+  const repairTargets = targets.slice(0, options.maxTargets ?? MAX_REPAIR_TARGETS);
+  options.onProgress?.({
+    repairTargetCount: repairTargets.length,
+    totalTargets: targets.length,
+    type: 'scan-complete',
+  });
   if (targets.length === 0) {
     return {repairedUris: [], skippedRecentUris: [], warnings: []};
   }
@@ -65,7 +95,8 @@ export async function repairStaleRecallIndex(
   const skippedRecentUris: string[] = [];
   const warnings: string[] = [];
 
-  for (const target of targets.slice(0, options.maxTargets ?? MAX_REPAIR_TARGETS)) {
+  for (const [targetIndex, target] of repairTargets.entries()) {
+    const progressBase = {index: targetIndex + 1, target, total: repairTargets.length};
     const previous = state.entries[target.uri];
     if (
       previous?.signature === target.signature &&
@@ -73,15 +104,18 @@ export async function repairStaleRecallIndex(
       options.dryRun !== true &&
       options.ignoreBackoff !== true
     ) {
+      options.onProgress?.({...progressBase, type: 'repair-skip-recent'});
       skippedRecentUris.push(target.uri);
       continue;
     }
 
     if (options.dryRun === true) {
+      options.onProgress?.({...progressBase, type: 'repair-dry-run'});
       repairedUris.push(target.uri);
       continue;
     }
 
+    options.onProgress?.({...progressBase, type: 'repair-start'});
     const result = await runCommand(
       ov,
       withIdentity(config, ['reindex', target.uri, '--mode', 'semantic_and_vectors', '--wait', 'true']),

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -25,6 +25,7 @@ import {startProgress} from './cli_ui.js';
 import {
   findStaleRecallIndexTargets,
   formatRecallIndexRepairMessages,
+  MAINTENANCE_COLLAPSE_DEPTH,
   MAINTENANCE_MAX_REPAIR_TARGETS,
   repairStaleRecallIndex,
 } from './index_repair.js';
@@ -344,12 +345,17 @@ async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promis
   const progress = startProgress('Scanning recall index freshness across memories and seeded resources.');
   try {
     const result = await repairStaleRecallIndex(config, ov, {
+      collapseDepth: MAINTENANCE_COLLAPSE_DEPTH,
       collapseToRoots: true,
       dryRun,
       ignoreBackoff: true,
       includeAgentSkills: true,
       includeManifestResources: true,
       maxTargets: MAINTENANCE_MAX_REPAIR_TARGETS,
+      onRepairFailure: async () => {
+        progress.update('A recall index reindex failed; checking OpenViking health before continuing.');
+        await repairServerHealth(config, dryRun);
+      },
       onProgress: event => {
         if (event.type === 'scan-complete') {
           if (event.totalTargets === 0) {
@@ -373,7 +379,7 @@ async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promis
       },
     });
     progress.stop();
-    const messages = formatRecallIndexRepairMessages(result, {dryRun});
+    const messages = formatRecallIndexRepairMessages(result, {dryRun, maxUris: 20});
     if (messages.length === 0) {
       console.log('Recall index freshness OK.');
       return;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -21,6 +21,7 @@ import {
   USER_INSTRUCTIONS_START_MARKER,
 } from './constants.js';
 import {hasManagedClaudeHooks, runHooksInstall} from './hooks.js';
+import {startProgress} from './cli_ui.js';
 import {
   findStaleRecallIndexTargets,
   formatRecallIndexRepairMessages,
@@ -340,6 +341,7 @@ async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promis
     return;
   }
 
+  const progress = startProgress('Scanning recall index freshness across memories and seeded resources.');
   try {
     const result = await repairStaleRecallIndex(config, ov, {
       collapseToRoots: true,
@@ -348,7 +350,29 @@ async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promis
       includeAgentSkills: true,
       includeManifestResources: true,
       maxTargets: MAINTENANCE_MAX_REPAIR_TARGETS,
+      onProgress: event => {
+        if (event.type === 'scan-complete') {
+          if (event.totalTargets === 0) {
+            progress.update('No stale recall index scopes found.');
+          } else {
+            progress.update(
+              `Found ${event.totalTargets} stale recall index scope(s); repairing ${event.repairTargetCount}.`,
+            );
+          }
+        } else if (event.type === 'repair-start') {
+          progress.update(
+            `Reindexing ${event.index}/${event.total}: ${event.target.uri} (${event.target.staleCount} stale summaries).`,
+          );
+        } else if (event.type === 'repair-dry-run') {
+          progress.update(
+            `Planning reindex ${event.index}/${event.total}: ${event.target.uri} (${event.target.staleCount} stale summaries).`,
+          );
+        } else if (event.type === 'repair-skip-recent') {
+          progress.update(`Skipping recently repaired scope ${event.index}/${event.total}: ${event.target.uri}.`);
+        }
+      },
     });
+    progress.stop();
     const messages = formatRecallIndexRepairMessages(result, {dryRun});
     if (messages.length === 0) {
       console.log('Recall index freshness OK.');
@@ -358,6 +382,7 @@ async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promis
       console.log(message);
     }
   } catch (err: unknown) {
+    progress.stop();
     console.log(`WARN could not repair recall index freshness: ${errorMessage(err)}`);
   }
 }

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -1,13 +1,15 @@
 #! /usr/bin/env node
 
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {access, readdir, readFile, realpath} from 'node:fs/promises';
 import {homedir} from 'node:os';
 import {join} from 'node:path';
 import {z} from 'zod';
-import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID} from './constants.js';
+import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {filterStaleRecallSummaryRows, formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
 import {inferProjectFromQuery} from './manifest.js';
 import {
@@ -45,6 +47,7 @@ import {
   expandPath,
   findExecutable,
   grepOutputHasMatches,
+  parsePort,
   runCommand,
   safeTimestamp,
   sha256,
@@ -57,6 +60,7 @@ interface RuntimeConfig {
   readonly agentContextHome: string;
   readonly agentId: string;
   readonly manifestPath: string;
+  readonly openVikingMcpUrl: string;
   readonly user: string;
 }
 
@@ -94,6 +98,16 @@ type CheckedOptionalText =
       readonly ok: false;
     };
 
+type CheckedTextArray =
+  | {
+      readonly ok: true;
+      readonly value: readonly string[];
+    }
+  | {
+      readonly error: CallToolResult;
+      readonly ok: false;
+    };
+
 async function main(): Promise<void> {
   const config = getRuntimeConfig();
   const server = new McpServer(
@@ -125,11 +139,14 @@ async function main(): Promise<void> {
 }
 
 function getRuntimeConfig(): RuntimeConfig {
+  const host = process.env.THREADNOTE_HOST ?? DEFAULT_HOST;
+  const port = parsePort(process.env.THREADNOTE_PORT ?? String(DEFAULT_PORT));
   return {
     account: process.env.THREADNOTE_ACCOUNT ?? DEFAULT_ACCOUNT,
     agentContextHome: expandPath(process.env.THREADNOTE_HOME ?? '~/.openviking'),
     agentId: process.env.THREADNOTE_AGENT_ID ?? DEFAULT_AGENT_ID,
     manifestPath: expandPath(process.env.THREADNOTE_MANIFEST ?? '~/.openviking/seed-manifest.yaml'),
+    openVikingMcpUrl: process.env.THREADNOTE_OPENVIKING_MCP_URL ?? `http://${host}:${port}/mcp`,
     user: process.env.THREADNOTE_USER ?? process.env.USER ?? 'unknown',
   };
 }
@@ -183,13 +200,17 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       annotations: {readOnlyHint: false, destructiveHint: true},
       description: 'Remove a viking:// URI from OpenViking.',
       inputSchema: {
+        recursive: z.boolean().optional().describe('Remove a directory recursively'),
         uri: z.string().optional().describe('Required viking:// URI to remove'),
       },
     },
-    async ({uri}) => {
+    async ({recursive, uri}) => {
       const checkedUri = requiredVikingUri(uri, 'forget', 'viking://agent/threadnote/memories/example.md');
       if (!checkedUri.ok) {
         return checkedUri.error;
+      }
+      if (recursive === true) {
+        return runOpenVikingTool(config, ['rm', checkedUri.value, '--recursive']);
       }
       try {
         const ov = await requiredOpenVikingCli();
@@ -217,31 +238,27 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       annotations: {readOnlyHint: false, destructiveHint: false},
       description: 'Add a local file or directory to OpenViking as a resource.',
       inputSchema: {
+        description: z.string().optional().describe('Optional import reason/description'),
+        path: z.string().optional().describe('Local source file/directory or URL; native OpenViking MCP name'),
         sourcePath: z.string().optional().describe('Required local source file or directory'),
-        to: z.string().optional().describe('Required destination viking:// URI'),
+        source_path: z.string().optional().describe('Compatibility alias for path'),
+        tempFileId: z.string().optional().describe('Native progressive upload temp file id'),
+        temp_file_id: z.string().optional().describe('Native progressive upload temp file id'),
+        to: z.string().optional().describe('Optional destination viking:// URI'),
         wait: z.boolean().optional().describe('Wait for processing to finish'),
+        watchInterval: z.number().int().min(0).optional().describe('Watch interval in minutes'),
+        watch_interval: z.number().int().min(0).optional().describe('Watch interval in minutes'),
       },
     },
-    async ({sourcePath, to, wait}) => {
-      const checkedSourcePath = requiredText(sourcePath, 'add_resource', 'sourcePath', {
-        sourcePath: '/path/to/README.md',
-        to: 'viking://resource/my-repo/README.md',
-      });
-      if (!checkedSourcePath.ok) {
-        return checkedSourcePath.error;
-      }
-      const checkedTo = requiredVikingUri(to, 'add_resource', 'viking://resource/my-repo/README.md');
-      if (!checkedTo.ok) {
-        return checkedTo.error;
-      }
-      return runOpenVikingTool(config, [
-        'add-resource',
-        checkedSourcePath.value,
-        '--to',
-        checkedTo.value,
-        ...(wait === false ? [] : ['--wait']),
-      ]);
-    },
+    async args =>
+      runOpenVikingAddResourceTool(config, 'add_resource', {
+        description: args.description,
+        path: args.sourcePath ?? args.path ?? args.source_path,
+        tempFileId: args.tempFileId ?? args.temp_file_id,
+        to: args.to,
+        wait: args.wait,
+        watchInterval: args.watchInterval ?? args.watch_interval,
+      }),
   );
 
   server.registerTool(
@@ -250,11 +267,15 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       annotations: {readOnlyHint: true, destructiveHint: false},
       description: 'Run exact text search in OpenViking.',
       inputSchema: {
+        caseInsensitive: z.boolean().optional().describe('Case-insensitive search'),
+        case_insensitive: z.boolean().optional().describe('Case-insensitive search'),
+        nodeLimit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
+        node_limit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
         pattern: z.string().optional().describe('Required text or regex pattern'),
         uri: z.string().optional().describe('Optional viking:// subtree'),
       },
     },
-    async ({pattern, uri}) => {
+    async ({caseInsensitive, case_insensitive, nodeLimit, node_limit, pattern, uri}) => {
       const checkedPattern = requiredText(pattern, 'grep', 'pattern', {pattern: 'unity-ui-ccc'});
       if (!checkedPattern.ok) {
         return checkedPattern.error;
@@ -267,6 +288,8 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
         'grep',
         checkedPattern.value,
         ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
+        ...(caseInsensitive === true || case_insensitive === true ? ['--ignore-case'] : []),
+        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
       ]);
     },
   );
@@ -277,11 +300,13 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       annotations: {readOnlyHint: true, destructiveHint: false},
       description: 'Run glob file search in OpenViking.',
       inputSchema: {
+        nodeLimit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
+        node_limit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
         pattern: z.string().optional().describe('Required glob pattern'),
         uri: z.string().optional().describe('Optional viking:// subtree'),
       },
     },
-    async ({pattern, uri}) => {
+    async ({nodeLimit, node_limit, pattern, uri}) => {
       const checkedPattern = requiredText(pattern, 'glob', 'pattern', {pattern: '**/AGENTS.md'});
       if (!checkedPattern.ok) {
         return checkedPattern.error;
@@ -294,6 +319,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
         'glob',
         checkedPattern.value,
         ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
+        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
       ]);
     },
   );
@@ -307,6 +333,8 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
     },
     async () => runOpenVikingTool(config, ['health']),
   );
+
+  registerOpenVikingParityTools(server, config);
 
   server.registerTool(
     'share_publish',
@@ -341,6 +369,373 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
         return checkedUri.error;
       }
       return runSharePublishTool(config, checkedUri.value, {message, preview, push, redact, team});
+    },
+  );
+}
+
+function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig): void {
+  server.registerTool(
+    'ov_search',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP search parity. Unlike search/recall_context, this does not enrich the query.',
+      inputSchema: {
+        limit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
+        minScore: z.number().min(0).max(1).optional().describe('Minimum score threshold'),
+        min_score: z.number().min(0).max(1).optional().describe('Minimum score threshold'),
+        peerId: z.string().optional().describe('Optional native peer id'),
+        peer_id: z.string().optional().describe('Optional native peer id'),
+        query: z.string().optional().describe('Required search query'),
+        targetUri: z.string().optional().describe('Optional target viking:// subtree'),
+        target_uri: z.string().optional().describe('Optional target viking:// subtree'),
+        uri: z.string().optional().describe('Compatibility alias for target_uri'),
+      },
+    },
+    async ({limit, minScore, min_score, peerId, peer_id, query, targetUri, target_uri, uri}) => {
+      const checkedQuery = requiredText(query, 'ov_search', 'query', {query: 'current repo release notes'});
+      if (!checkedQuery.ok) {
+        return checkedQuery.error;
+      }
+      const checkedUri = optionalVikingUri(targetUri ?? target_uri ?? uri, 'ov_search');
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      const normalizedPeerId = (peerId ?? peer_id)?.trim();
+      return runOpenVikingTool(config, [
+        'search',
+        checkedQuery.value,
+        ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
+        ...numberFlag('--node-limit', limit),
+        ...numberFlag('--threshold', minScore ?? min_score),
+        ...(normalizedPeerId ? ['--peer-id', normalizedPeerId] : []),
+      ]);
+    },
+  );
+
+  server.registerTool(
+    'ov_read',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description:
+        'Raw OpenViking MCP read parity. Reads one or more viking:// URIs without Threadnote shared-memory sync.',
+      inputSchema: {
+        uri: z.string().optional().describe('Single viking:// URI'),
+        uris: z
+          .union([z.string(), z.array(z.string())])
+          .optional()
+          .describe('Single viking:// URI or array of URIs'),
+      },
+    },
+    async ({uri, uris}) => {
+      const checkedUris = requiredVikingUriList(
+        uris ?? uri,
+        'ov_read',
+        'viking://resources/repos/threadnote/README.md',
+      );
+      if (!checkedUris.ok) {
+        return checkedUris.error;
+      }
+      return runOpenVikingReadTool(config, checkedUris.value);
+    },
+  );
+
+  server.registerTool(
+    'ov_list',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP list parity.',
+      inputSchema: {
+        all: z.boolean().optional().describe('Show hidden files like .abstract.md and .overview.md'),
+        nodeLimit: z.number().int().positive().max(1000).optional().describe('Maximum node count'),
+        node_limit: z.number().int().positive().max(1000).optional().describe('Maximum node count'),
+        recursive: z.boolean().optional().describe('List recursively'),
+        simple: z.boolean().optional().describe('Only return paths'),
+        uri: z.string().optional().describe('Optional viking:// directory URI; defaults to viking://'),
+      },
+    },
+    async ({all, nodeLimit, node_limit, recursive, simple, uri}) => {
+      const checkedUri = optionalVikingUri(uri, 'ov_list');
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      return runOpenVikingTool(config, [
+        'ls',
+        checkedUri.value ?? 'viking://',
+        ...(all === true ? ['--all'] : []),
+        ...(recursive === true ? ['--recursive'] : []),
+        ...(simple === true ? ['--simple'] : []),
+        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
+      ]);
+    },
+  );
+
+  registerOpenVikingStoreTool(server, config, 'ov_store');
+  registerOpenVikingStoreTool(server, config, 'ov_remember');
+
+  server.registerTool(
+    'ov_add_resource',
+    {
+      annotations: {readOnlyHint: false, destructiveHint: false},
+      description: 'Raw OpenViking MCP add_resource parity.',
+      inputSchema: {
+        description: z.string().optional().describe('Optional import reason/description'),
+        path: z.string().optional().describe('Local source file/directory or URL'),
+        sourcePath: z.string().optional().describe('Compatibility alias for path'),
+        source_path: z.string().optional().describe('Compatibility alias for path'),
+        tempFileId: z.string().optional().describe('Native progressive upload temp file id'),
+        temp_file_id: z.string().optional().describe('Native progressive upload temp file id'),
+        to: z.string().optional().describe('Optional destination viking:// URI'),
+        wait: z.boolean().optional().describe('Wait for processing to finish'),
+        watchInterval: z.number().int().min(0).optional().describe('Watch interval in minutes'),
+        watch_interval: z.number().int().min(0).optional().describe('Watch interval in minutes'),
+      },
+    },
+    async args =>
+      runOpenVikingAddResourceTool(config, 'ov_add_resource', {
+        description: args.description,
+        path: args.path ?? args.sourcePath ?? args.source_path,
+        tempFileId: args.tempFileId ?? args.temp_file_id,
+        to: args.to,
+        wait: args.wait,
+        watchInterval: args.watchInterval ?? args.watch_interval,
+      }),
+  );
+
+  server.registerTool(
+    'ov_list_watches',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP list_watches parity.',
+      inputSchema: {
+        activeOnly: z.boolean().optional().describe('Only show active watch tasks'),
+        active_only: z.boolean().optional().describe('Only show active watch tasks'),
+      },
+    },
+    async ({activeOnly, active_only}) =>
+      runOpenVikingTool(config, [
+        'task',
+        'watch',
+        'ls',
+        ...(activeOnly === true || active_only === true ? ['--active-only'] : []),
+      ]),
+  );
+
+  server.registerTool(
+    'ov_cancel_watch',
+    {
+      annotations: {readOnlyHint: false, destructiveHint: true},
+      description: 'Raw OpenViking MCP cancel_watch parity. Accepts to_uri, toUri, or uri.',
+      inputSchema: {
+        toUri: z.string().optional().describe('Watch target viking:// URI'),
+        to_uri: z.string().optional().describe('Watch target viking:// URI'),
+        uri: z.string().optional().describe('Compatibility alias for to_uri'),
+      },
+    },
+    async ({toUri, to_uri, uri}) => {
+      const checkedUri = requiredVikingUri(
+        toUri ?? to_uri ?? uri,
+        'ov_cancel_watch',
+        'viking://resources/repos/threadnote',
+      );
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      return runOpenVikingTool(config, ['task', 'watch', 'rm', checkedUri.value]);
+    },
+  );
+
+  server.registerTool(
+    'ov_grep',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP grep parity.',
+      inputSchema: {
+        caseInsensitive: z.boolean().optional().describe('Case-insensitive search'),
+        case_insensitive: z.boolean().optional().describe('Case-insensitive search'),
+        nodeLimit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
+        node_limit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
+        pattern: z.string().optional().describe('Required regex pattern'),
+        uri: z.string().optional().describe('Optional viking:// subtree'),
+      },
+    },
+    async ({caseInsensitive, case_insensitive, nodeLimit, node_limit, pattern, uri}) => {
+      const checkedPattern = requiredText(pattern, 'ov_grep', 'pattern', {pattern: 'threadnote'});
+      if (!checkedPattern.ok) {
+        return checkedPattern.error;
+      }
+      const checkedUri = optionalVikingUri(uri, 'ov_grep');
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      return runOpenVikingTool(config, [
+        'grep',
+        checkedPattern.value,
+        ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
+        ...(caseInsensitive === true || case_insensitive === true ? ['--ignore-case'] : []),
+        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
+      ]);
+    },
+  );
+
+  server.registerTool(
+    'ov_glob',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP glob parity.',
+      inputSchema: {
+        nodeLimit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
+        node_limit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
+        pattern: z.string().optional().describe('Required glob pattern'),
+        uri: z.string().optional().describe('Optional viking:// subtree'),
+      },
+    },
+    async ({nodeLimit, node_limit, pattern, uri}) => {
+      const checkedPattern = requiredText(pattern, 'ov_glob', 'pattern', {pattern: '**/AGENTS.md'});
+      if (!checkedPattern.ok) {
+        return checkedPattern.error;
+      }
+      const checkedUri = optionalVikingUri(uri, 'ov_glob');
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      return runOpenVikingTool(config, [
+        'glob',
+        checkedPattern.value,
+        ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
+        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
+      ]);
+    },
+  );
+
+  server.registerTool(
+    'ov_forget',
+    {
+      annotations: {readOnlyHint: false, destructiveHint: true},
+      description: 'Raw OpenViking MCP forget parity.',
+      inputSchema: {
+        recursive: z.boolean().optional().describe('Remove a directory recursively'),
+        uri: z.string().optional().describe('Required viking:// URI to remove'),
+      },
+    },
+    async ({recursive, uri}) => {
+      const checkedUri = requiredVikingUri(uri, 'ov_forget', 'viking://resources/repos/threadnote/tmp');
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      return runOpenVikingTool(config, ['rm', checkedUri.value, ...(recursive === true ? ['--recursive'] : [])]);
+    },
+  );
+
+  server.registerTool(
+    'ov_code_outline',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP code_outline parity. Requires a viking:// file URI.',
+      inputSchema: {
+        uri: z.string().optional().describe('Required viking:// file URI'),
+      },
+    },
+    async ({uri}) => {
+      const checkedUri = requiredVikingUri(
+        uri,
+        'ov_code_outline',
+        'viking://resources/repos/threadnote/src/mcp_server.ts',
+      );
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      return runOpenVikingMcpTool(config, 'code_outline', {uri: checkedUri.value});
+    },
+  );
+
+  server.registerTool(
+    'ov_code_search',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP code_search parity. Requires a query and viking:// directory URI.',
+      inputSchema: {
+        query: z.string().optional().describe('Required symbol-name substring'),
+        uri: z.string().optional().describe('Required viking:// directory URI'),
+      },
+    },
+    async ({query, uri}) => {
+      const checkedQuery = requiredText(query, 'ov_code_search', 'query', {query: 'registerTools'});
+      if (!checkedQuery.ok) {
+        return checkedQuery.error;
+      }
+      const checkedUri = requiredVikingUri(uri, 'ov_code_search', 'viking://resources/repos/threadnote/src');
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      return runOpenVikingMcpTool(config, 'code_search', {
+        query: checkedQuery.value,
+        uri: checkedUri.value,
+      });
+    },
+  );
+
+  server.registerTool(
+    'ov_code_expand',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP code_expand parity. Requires a viking:// file URI and symbol.',
+      inputSchema: {
+        symbol: z.string().optional().describe('Required symbol name, e.g. bar or Foo.bar'),
+        uri: z.string().optional().describe('Required viking:// file URI'),
+      },
+    },
+    async ({symbol, uri}) => {
+      const checkedUri = requiredVikingUri(
+        uri,
+        'ov_code_expand',
+        'viking://resources/repos/threadnote/src/mcp_server.ts',
+      );
+      if (!checkedUri.ok) {
+        return checkedUri.error;
+      }
+      const checkedSymbol = requiredText(symbol, 'ov_code_expand', 'symbol', {symbol: 'registerTools'});
+      if (!checkedSymbol.ok) {
+        return checkedSymbol.error;
+      }
+      return runOpenVikingMcpTool(config, 'code_expand', {symbol: checkedSymbol.value, uri: checkedUri.value});
+    },
+  );
+
+  server.registerTool(
+    'ov_health',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description: 'Raw OpenViking MCP health parity.',
+      inputSchema: {},
+    },
+    async () => runOpenVikingTool(config, ['health']),
+  );
+}
+
+function registerOpenVikingStoreTool(server: McpServer, config: RuntimeConfig, name: 'ov_remember' | 'ov_store'): void {
+  server.registerTool(
+    name,
+    {
+      annotations: {readOnlyHint: false, destructiveHint: true},
+      description: `Raw OpenViking MCP ${name === 'ov_remember' ? 'remember' : 'store'} parity. Stores message(s) through ov add-memory.`,
+      inputSchema: {
+        content: z.string().optional().describe('Compatibility shortcut for a single user message'),
+        messages: z
+          .array(z.object({content: z.string(), role: z.string()}))
+          .optional()
+          .describe('Native messages array of {role, content}'),
+        text: z.string().optional().describe('Compatibility shortcut for a single user message'),
+      },
+    },
+    async ({content, messages, text}) => {
+      if (messages && messages.length > 0) {
+        return runOpenVikingTool(config, ['add-memory', JSON.stringify(messages)]);
+      }
+      const checkedContent = requiredText(content ?? text, name, 'content', {content: 'Remember this note'});
+      if (!checkedContent.ok) {
+        return checkedContent.error;
+      }
+      return runOpenVikingTool(config, ['add-memory', checkedContent.value]);
     },
   );
 }
@@ -552,15 +947,19 @@ function registerReadTool(server: McpServer, config: RuntimeConfig, name: string
     name,
     {
       annotations: {readOnlyHint: true, destructiveHint: false},
-      description: `${description} Required: pass JSON arguments with uri.`,
+      description: `${description} Required: pass JSON arguments with uri, or native OpenViking uris.`,
       inputSchema: {
         uri: z.string().optional().describe('Required viking:// file URI'),
+        uris: z
+          .union([z.string(), z.array(z.string())])
+          .optional()
+          .describe('Native OpenViking MCP read input: a single viking:// URI or array of URIs'),
       },
     },
-    async ({uri}) => {
-      const checkedUri = requiredVikingUri(uri, name, 'viking://agent/threadnote/memories/.abstract.md');
-      if (!checkedUri.ok) {
-        return checkedUri.error;
+    async ({uri, uris}) => {
+      const checkedUris = requiredVikingUriList(uris ?? uri, name, 'viking://agent/threadnote/memories/.abstract.md');
+      if (!checkedUris.ok) {
+        return checkedUris.error;
       }
       let syncedTeams: readonly string[] = [];
       const syncWarnings: string[] = [];
@@ -571,7 +970,7 @@ function registerReadTool(server: McpServer, config: RuntimeConfig, name: string
       } catch (err: unknown) {
         syncWarnings.push(errorMessage(err));
       }
-      const result = await runOpenVikingTool(config, ['read', checkedUri.value]);
+      const result = await runOpenVikingReadTool(config, checkedUris.value);
       if (result.isError === true || (syncedTeams.length === 0 && syncWarnings.length === 0)) {
         return result;
       }
@@ -599,9 +998,10 @@ function registerListTool(server: McpServer, config: RuntimeConfig, name: string
         recursive: z.boolean().optional().describe('List recursively'),
         simple: z.boolean().optional().describe('Only return paths'),
         nodeLimit: z.number().int().positive().max(1000).optional().describe('Maximum node count'),
+        node_limit: z.number().int().positive().max(1000).optional().describe('Maximum node count'),
       },
     },
-    async ({all, nodeLimit, recursive, simple, uri}) => {
+    async ({all, nodeLimit, node_limit, recursive, simple, uri}) => {
       const checkedUri = optionalVikingUri(uri, name);
       if (!checkedUri.ok) {
         return checkedUri.error;
@@ -612,7 +1012,7 @@ function registerListTool(server: McpServer, config: RuntimeConfig, name: string
         ...(all === true ? ['--all'] : []),
         ...(recursive === true ? ['--recursive'] : []),
         ...(simple === true ? ['--simple'] : []),
-        ...(nodeLimit ? ['--node-limit', String(nodeLimit)] : []),
+        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
       ]);
     },
   );
@@ -1245,8 +1645,163 @@ function optionalVikingUri(value: string | undefined, toolName: string): Checked
   };
 }
 
+function requiredVikingUriList(
+  value: readonly string[] | string | undefined,
+  toolName: string,
+  exampleUri: string,
+): CheckedTextArray {
+  const rawValues = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  const uris = rawValues.map(uri => uri.trim()).filter(Boolean);
+  if (uris.length === 0) {
+    return {
+      error: argumentError(
+        [
+          `Threadnote MCP tool "${toolName}" needs a non-empty "uri" or "uris" argument.`,
+          'Pass JSON arguments to the tool call.',
+          `Example: ${toolName}(${JSON.stringify({uris: [exampleUri]})})`,
+        ].join('\n'),
+      ),
+      ok: false,
+    };
+  }
+  const invalid = uris.find(uri => !uri.startsWith('viking://'));
+  if (invalid) {
+    return {
+      error: argumentError(`Threadnote MCP tool "${toolName}" needs viking:// URI values. Received: ${invalid}`),
+      ok: false,
+    };
+  }
+  return {ok: true, value: uris};
+}
+
 function argumentError(text: string): CallToolResult {
   return {content: [{type: 'text', text}], isError: true};
+}
+
+function numberFlag(name: string, value: number | undefined): readonly string[] {
+  return value === undefined ? [] : [name, String(value)];
+}
+
+interface OpenVikingAddResourceParams {
+  readonly description?: string;
+  readonly path?: string;
+  readonly tempFileId?: string;
+  readonly to?: string;
+  readonly wait?: boolean;
+  readonly watchInterval?: number;
+}
+
+async function runOpenVikingAddResourceTool(
+  config: RuntimeConfig,
+  toolName: string,
+  params: OpenVikingAddResourceParams,
+): Promise<CallToolResult> {
+  const tempFileId = params.tempFileId?.trim();
+  const source = params.path?.trim();
+  if (!source && !tempFileId) {
+    return argumentError(
+      [
+        `Threadnote MCP tool "${toolName}" needs a non-empty "path" argument.`,
+        'Pass JSON arguments to the tool call.',
+        `Example: ${toolName}(${JSON.stringify({path: '/path/to/README.md', to: 'viking://resources/my-repo/README.md'})})`,
+      ].join('\n'),
+    );
+  }
+  if (tempFileId) {
+    const checkedTo = optionalVikingUri(params.to, toolName);
+    if (!checkedTo.ok) {
+      return checkedTo.error;
+    }
+    return runOpenVikingMcpTool(config, 'add_resource', {
+      description: params.description,
+      temp_file_id: tempFileId,
+      to: checkedTo.value,
+      watch_interval: params.watchInterval,
+    });
+  }
+  const checkedTo = optionalVikingUri(params.to, toolName);
+  if (!checkedTo.ok) {
+    return checkedTo.error;
+  }
+  const description = params.description?.trim();
+  return runOpenVikingTool(config, [
+    'add-resource',
+    ...(source ? [source] : ['--temp-file-id', tempFileId ?? '']),
+    ...(checkedTo.value ? ['--to', checkedTo.value] : []),
+    ...(description ? ['--reason', description] : []),
+    ...numberFlag('--watch-interval', params.watchInterval),
+    ...(params.wait === false ? [] : ['--wait']),
+  ]);
+}
+
+async function runOpenVikingReadTool(config: RuntimeConfig, uris: readonly string[]): Promise<CallToolResult> {
+  const outputs: string[] = [];
+  for (const uri of uris) {
+    const result = await runOpenVikingTool(config, ['read', uri]);
+    if (result.isError === true) {
+      return result;
+    }
+    outputs.push(
+      result.content
+        .map(content => (content.type === 'text' ? content.text : ''))
+        .join('\n')
+        .trim(),
+    );
+  }
+  return {content: [{type: 'text', text: outputs.filter(Boolean).join('\n') || 'OK'}]};
+}
+
+async function runOpenVikingMcpTool(
+  config: RuntimeConfig,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
+  const client = new Client({name: 'threadnote-openviking-proxy', version: '1.1.0'});
+  try {
+    const transport = new StreamableHTTPClientTransport(new URL(config.openVikingMcpUrl), {
+      requestInit: {
+        headers: {
+          'X-OpenViking-Account': config.account,
+          'X-OpenViking-Agent': config.agentId,
+          'X-OpenViking-User': config.user,
+        },
+      },
+    });
+    await client.connect(transport);
+    const result = await client.callTool({arguments: stripUndefinedValues(args), name: toolName}, undefined, {
+      timeout: 30_000,
+    });
+    return normalizeCallToolResult(result);
+  } catch (err: unknown) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `OpenViking native MCP tool "${toolName}" failed at ${config.openVikingMcpUrl}: ${errorMessage(err)}`,
+        },
+      ],
+      isError: true,
+    };
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+function stripUndefinedValues(values: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(values).filter((entry): entry is [string, unknown] => entry[1] !== undefined),
+  );
+}
+
+function normalizeCallToolResult(result: unknown): CallToolResult {
+  const maybeResult = result as Partial<CallToolResult>;
+  if (Array.isArray(maybeResult.content)) {
+    return {
+      content: maybeResult.content,
+      isError: maybeResult.isError,
+    } as CallToolResult;
+  }
+  return {content: [{type: 'text', text: JSON.stringify(result)}]};
 }
 
 async function runOpenVikingTool(config: RuntimeConfig, args: readonly string[]): Promise<CallToolResult> {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -26,7 +26,6 @@ import {
   ensureSharedDirectoryChain,
   isInSharedNamespace,
   publishShareGitChange,
-  removeMemoryUri,
   resolveTeam,
   applyScrubber,
   sharedMemoryUriParts,
@@ -209,26 +208,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      if (recursive === true) {
-        return runOpenVikingMcpTool(config, 'forget', {recursive: true, uri: checkedUri.value});
-      }
-      try {
-        const ov = await requiredOpenVikingCli();
-        const removed = await removeVikingResourceWithRetry(ov, config, checkedUri.value);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: removed
-                ? `Removed: ${checkedUri.value}`
-                : `Resource is still being processed; retry later: ${checkedUri.value}`,
-            },
-          ],
-          isError: !removed,
-        };
-      } catch (err: unknown) {
-        return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-      }
+      return runOpenVikingRemoveTool(config, checkedUri.value, recursive === true);
     },
   );
 
@@ -384,12 +364,14 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
         peerId: z.string().optional().describe('Optional native peer id'),
         peer_id: z.string().optional().describe('Optional native peer id'),
         query: z.string().optional().describe('Required search query'),
+        sessionId: z.string().optional().describe('Optional native session id'),
+        session_id: z.string().optional().describe('Optional native session id'),
         targetUri: z.string().optional().describe('Optional target viking:// subtree'),
         target_uri: z.string().optional().describe('Optional target viking:// subtree'),
         uri: z.string().optional().describe('Compatibility alias for target_uri'),
       },
     },
-    async ({limit, minScore, min_score, peerId, peer_id, query, targetUri, target_uri, uri}) => {
+    async ({limit, minScore, min_score, query, sessionId, session_id, targetUri, target_uri, uri}) => {
       const checkedQuery = requiredText(query, 'ov_search', 'query', {query: 'current repo release notes'});
       if (!checkedQuery.ok) {
         return checkedQuery.error;
@@ -398,13 +380,13 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      const normalizedPeerId = (peerId ?? peer_id)?.trim();
+      const normalizedSessionId = (sessionId ?? session_id)?.trim();
       return runOpenVikingMcpTool(config, 'search', {
         limit,
         min_score: minScore ?? min_score,
-        peer_id: normalizedPeerId || undefined,
         query: checkedQuery.value,
-        uri: checkedUri.value,
+        session_id: normalizedSessionId || undefined,
+        target_uri: checkedUri.value,
       });
     },
   );
@@ -450,17 +432,14 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
         uri: z.string().optional().describe('Optional viking:// directory URI; defaults to viking://'),
       },
     },
-    async ({all, nodeLimit, node_limit, recursive, simple, uri}) => {
+    async ({recursive, uri}) => {
       const checkedUri = optionalVikingUri(uri, 'ov_list');
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
       return runOpenVikingMcpTool(config, 'list', {
-        all,
-        node_limit: nodeLimit ?? node_limit,
         recursive,
-        simple,
-        uri: checkedUri.value,
+        uri: checkedUri.value ?? 'viking://',
       });
     },
   );
@@ -611,7 +590,7 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'forget', {recursive, uri: checkedUri.value});
+      return runOpenVikingRemoveTool(config, checkedUri.value, recursive === true);
     },
   );
 
@@ -718,14 +697,14 @@ function registerOpenVikingStoreTool(server: McpServer, config: RuntimeConfig, n
     },
     async ({content, messages, text}) => {
       if (messages && messages.length > 0) {
-        return runOpenVikingMcpTool(config, name === 'ov_remember' ? 'remember' : 'store', {messages});
+        return runOpenVikingMcpTool(config, 'remember', {messages});
       }
       const checkedContent = requiredText(content ?? text, name, 'content', {content: 'Remember this note'});
       if (!checkedContent.ok) {
         return checkedContent.error;
       }
-      return runOpenVikingMcpTool(config, name === 'ov_remember' ? 'remember' : 'store', {
-        content: checkedContent.value,
+      return runOpenVikingMcpTool(config, 'remember', {
+        messages: [{content: checkedContent.value, role: 'user'}],
       });
     },
   );
@@ -803,13 +782,11 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
     indexRepairMessages = [`Auto-index repair warning: ${errorMessage(err)}`];
   }
   const contextualParams: RecallToolParams = {...params, query};
-  const baseArgs = [
-    'search',
+  const semanticResult = await runOpenVikingMcpTool(config, 'search', {
+    limit: params.nodeLimit,
     query,
-    ...(params.pinnedUri ? ['--uri', params.pinnedUri] : []),
-    ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),
-  ];
-  const semanticResult = await runOpenVikingTool(config, baseArgs);
+    target_uri: params.pinnedUri,
+  });
   if (semanticResult.isError === true) {
     return semanticResult;
   }
@@ -888,19 +865,15 @@ async function seededResourcesSection(
   if (!projectResourceUri.startsWith('viking://')) {
     return undefined;
   }
-  const ov = await requiredOpenVikingCli();
-  const args = [
-    'search',
-    params.query,
-    '--uri',
-    projectResourceUri,
-    ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),
-  ];
-  const result = await runCommand(ov, withIdentity(config, args), {allowFailure: true});
-  if (result.exitCode !== 0) {
+  const result = await runOpenVikingMcpTool(config, 'search', {
+    limit: params.nodeLimit,
+    query: params.query,
+    target_uri: projectResourceUri,
+  });
+  if (result.isError === true) {
     return undefined;
   }
-  const body = filterStaleRecallSummaryRows([result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n'));
+  const body = filterStaleRecallSummaryRows(textFromCallToolResult(result));
   if (!body) {
     return undefined;
   }
@@ -916,16 +889,13 @@ async function exactMemoryMatchesText(
   if (terms.length === 0) {
     return undefined;
   }
-  const ov = await requiredOpenVikingCli();
   const scopes = exactMemoryScopes(config, includeArchived);
   const outputs: string[] = [];
   for (const term of terms) {
     for (const scope of scopes) {
-      const result = await runCommand(ov, withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5']), {
-        allowFailure: true,
-      });
-      const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
-      if (result.exitCode === 0 && grepOutputHasMatches(output)) {
+      const result = await runOpenVikingMcpTool(config, 'grep', {node_limit: 5, pattern: term, uri: scope});
+      const output = textFromCallToolResult(result);
+      if (result.isError !== true && grepOutputHasMatches(output)) {
         outputs.push(output);
       }
     }
@@ -992,19 +962,15 @@ function registerListTool(server: McpServer, config: RuntimeConfig, name: string
         node_limit: z.number().int().positive().max(1000).optional().describe('Maximum node count'),
       },
     },
-    async ({all, nodeLimit, node_limit, recursive, simple, uri}) => {
+    async ({recursive, uri}) => {
       const checkedUri = optionalVikingUri(uri, name);
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingTool(config, [
-        'ls',
-        checkedUri.value ?? 'viking://',
-        ...(all === true ? ['--all'] : []),
-        ...(recursive === true ? ['--recursive'] : []),
-        ...(simple === true ? ['--simple'] : []),
-        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
-      ]);
+      return runOpenVikingMcpTool(config, 'list', {
+        recursive,
+        uri: checkedUri.value ?? 'viking://',
+      });
     },
   );
 }
@@ -1081,9 +1047,8 @@ function registerArchiveTool(server: McpServer, config: RuntimeConfig, name: str
         return checkedUri.error;
       }
       try {
-        const ov = await requiredOpenVikingCli();
-        const readResult = await runCommand(ov, withIdentity(config, ['read', checkedUri.value]));
-        const original = readResult.stdout.trim();
+        const readResult = await runOpenVikingReadTool(config, [checkedUri.value]);
+        const original = textFromCallToolResult(readResult);
         if (!original) {
           return {
             content: [{type: 'text', text: `Could not read ${checkedUri.value} before archiving.`}],
@@ -1106,7 +1071,7 @@ function registerArchiveTool(server: McpServer, config: RuntimeConfig, name: str
         if (archiveResult.isError === true) {
           return archiveResult;
         }
-        const removedOriginal = await removeVikingResourceWithRetry(ov, config, checkedUri.value);
+        const removedOriginal = await forgetVikingResourceWithRetry(config, checkedUri.value);
         const [content] = archiveResult.content;
         const text = content?.type === 'text' ? content.text : 'Archived memory stored.';
         return {
@@ -1175,7 +1140,7 @@ function registerCompactTool(server: McpServer, config: RuntimeConfig): void {
           appliedMessages.push(`Updated kept memory: ${action.uri}`);
         }
         for (const action of plan.archives) {
-          const archiveResult = await archiveMemoryForCompact(config, ov, action);
+          const archiveResult = await archiveMemoryForCompact(config, action);
           if (archiveResult.isError === true) {
             return archiveResult;
           }
@@ -1185,7 +1150,7 @@ function registerCompactTool(server: McpServer, config: RuntimeConfig): void {
           }
         }
         for (const action of plan.forgets) {
-          const removed = await removeVikingResourceWithRetry(ov, config, action.uri);
+          const removed = await forgetVikingResourceWithRetry(config, action.uri);
           appliedMessages.push(
             removed
               ? `Forgot exact duplicate: ${action.uri}`
@@ -1207,13 +1172,9 @@ function registerCompactTool(server: McpServer, config: RuntimeConfig): void {
   );
 }
 
-async function archiveMemoryForCompact(
-  config: RuntimeConfig,
-  ov: string,
-  action: ArchiveAction,
-): Promise<CallToolResult> {
-  const readResult = await runCommand(ov, withIdentity(config, ['read', action.uri]));
-  const original = readResult.stdout.trim();
+async function archiveMemoryForCompact(config: RuntimeConfig, action: ArchiveAction): Promise<CallToolResult> {
+  const readResult = await runOpenVikingReadTool(config, [action.uri]);
+  const original = textFromCallToolResult(readResult);
   if (!original) {
     return {content: [{type: 'text', text: `Could not read ${action.uri} before archiving.`}], isError: true};
   }
@@ -1232,7 +1193,7 @@ async function archiveMemoryForCompact(
   if (archiveResult.isError === true) {
     return archiveResult;
   }
-  const removedOriginal = await removeVikingResourceWithRetry(ov, config, action.uri);
+  const removedOriginal = await forgetVikingResourceWithRetry(config, action.uri);
   const [content] = archiveResult.content;
   const text = content?.type === 'text' ? content.text : 'Archived memory stored.';
   return {
@@ -1443,8 +1404,13 @@ async function vikingResourceExists(ov: string, config: RuntimeConfig, uri: stri
   return stat.exitCode === 0;
 }
 
-async function removeVikingResourceWithRetry(ov: string, config: RuntimeConfig, uri: string): Promise<boolean> {
-  const args = withIdentity(config, ['rm', uri]);
+async function removeVikingResourceWithRetry(
+  ov: string,
+  config: RuntimeConfig,
+  uri: string,
+  recursive = false,
+): Promise<boolean> {
+  const args = withIdentity(config, ['rm', uri, ...(recursive ? ['--recursive'] : [])]);
   for (let attempt = 0; attempt < 4; attempt += 1) {
     const result = await runCommand(ov, args, {allowFailure: true});
     if (result.exitCode === 0) {
@@ -1459,6 +1425,28 @@ async function removeVikingResourceWithRetry(ov: string, config: RuntimeConfig, 
     await sleep(1000 * (attempt + 1));
   }
   return false;
+}
+
+async function runOpenVikingRemoveTool(
+  config: RuntimeConfig,
+  uri: string,
+  recursive: boolean,
+): Promise<CallToolResult> {
+  try {
+    const ov = await requiredOpenVikingCli();
+    const removed = await removeVikingResourceWithRetry(ov, config, uri, recursive);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: removed ? `Removed: ${uri}` : `Resource is still being processed; retry later: ${uri}`,
+        },
+      ],
+      isError: !removed,
+    };
+  } catch (err: unknown) {
+    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+  }
 }
 
 function isResourceBusy(stderr: string, stdout: string): boolean {
@@ -1669,10 +1657,6 @@ function argumentError(text: string): CallToolResult {
   return {content: [{type: 'text', text}], isError: true};
 }
 
-function numberFlag(name: string, value: number | undefined): readonly string[] {
-  return value === undefined ? [] : [name, String(value)];
-}
-
 interface OpenVikingAddResourceParams {
   readonly description?: string;
   readonly path?: string;
@@ -1719,26 +1703,53 @@ async function runOpenVikingAddResourceTool(
     description,
     path: source,
     to: checkedTo.value,
-    wait: params.wait,
     watch_interval: params.watchInterval,
   });
 }
 
 async function runOpenVikingReadTool(config: RuntimeConfig, uris: readonly string[]): Promise<CallToolResult> {
+  const result = await runOpenVikingMcpTool(config, 'read', {uris});
+  if (result.isError === true || !nativeReadMissedAnyUri(result, uris)) {
+    return result;
+  }
+  return runOpenVikingReadToolWithCliFallback(config, uris);
+}
+
+function nativeReadMissedAnyUri(result: CallToolResult, uris: readonly string[]): boolean {
+  const text = textFromCallToolResult(result);
+  return uris.some(uri => text.includes(`(nothing found at ${uri})`));
+}
+
+async function runOpenVikingReadToolWithCliFallback(
+  config: RuntimeConfig,
+  uris: readonly string[],
+): Promise<CallToolResult> {
   const outputs: string[] = [];
   for (const uri of uris) {
-    const result = await runOpenVikingMcpTool(config, 'read', {uri});
-    if (result.isError === true) {
-      return result;
+    const nativeResult = await runOpenVikingMcpTool(config, 'read', {uris: [uri]});
+    const nativeText = textFromCallToolResult(nativeResult);
+    let text = nativeText;
+    if (nativeResult.isError === true || nativeText.includes(`(nothing found at ${uri})`)) {
+      const cliResult = await runOpenVikingCliReadTool(config, uri);
+      if (cliResult.isError === true) {
+        return cliResult;
+      }
+      text = textFromCallToolResult(cliResult);
     }
-    outputs.push(
-      result.content
-        .map(content => (content.type === 'text' ? content.text : ''))
-        .join('\n')
-        .trim(),
-    );
+    outputs.push(uris.length === 1 ? text : `=== ${uri} ===\n${text}`);
   }
-  return {content: [{type: 'text', text: outputs.filter(Boolean).join('\n') || 'OK'}]};
+  return {content: [{type: 'text', text: outputs.filter(Boolean).join('\n\n') || 'OK'}]};
+}
+
+async function runOpenVikingCliReadTool(config: RuntimeConfig, uri: string): Promise<CallToolResult> {
+  try {
+    const ov = await requiredOpenVikingCli();
+    const result = await runCommand(ov, withIdentity(config, ['read', uri]));
+    const text = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
+    return {content: [{type: 'text', text: text || 'OK'}]};
+  } catch (err: unknown) {
+    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+  }
 }
 
 async function runOpenVikingMcpTool(
@@ -1794,15 +1805,16 @@ function normalizeCallToolResult(result: unknown): CallToolResult {
   return {content: [{type: 'text', text: JSON.stringify(result)}]};
 }
 
-async function runOpenVikingTool(config: RuntimeConfig, args: readonly string[]): Promise<CallToolResult> {
-  try {
-    const ov = await requiredOpenVikingCli();
-    const result = await runCommand(ov, withIdentity(config, args));
-    const text = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
-    return {content: [{type: 'text', text: text || 'OK'}]};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
+function textFromCallToolResult(result: CallToolResult): string {
+  return result.content
+    .map(content => (content.type === 'text' ? content.text : ''))
+    .join('\n')
+    .trim();
+}
+
+async function forgetVikingResourceWithRetry(config: RuntimeConfig, uri: string): Promise<boolean> {
+  const ov = await requiredOpenVikingCli();
+  return removeVikingResourceWithRetry(ov, config, uri);
 }
 
 interface SharePublishToolOptions {
@@ -1824,19 +1836,20 @@ async function runSharePublishTool(
     }
     const resolved = await resolveTeam(config, options.team);
     const ov = await requiredOpenVikingCli();
-    const readResult = await runCommand(ov, withIdentity(config, ['read', sourceUri]), {allowFailure: true});
-    if (readResult.exitCode !== 0 || !readResult.stdout.trim()) {
+    const readResult = await runOpenVikingReadTool(config, [sourceUri]);
+    const sourceText = textFromCallToolResult(readResult);
+    if (readResult.isError === true || !sourceText) {
       return {
         content: [
           {
             type: 'text',
-            text: `Could not read ${sourceUri}: ${readResult.stderr.trim() || readResult.stdout.trim() || 'unknown error'}`,
+            text: `Could not read ${sourceUri}: ${sourceText || 'unknown error'}`,
           },
         ],
         isError: true,
       };
     }
-    const stripped = stripPersonalProvenance(readResult.stdout);
+    const stripped = stripPersonalProvenance(sourceText);
     const scrub = applyScrubber(stripped, {redact: options.redact === true});
     const targetUri = sharedUriFor(config, sourceUri, resolved.name);
 
@@ -1882,7 +1895,7 @@ async function runSharePublishTool(
       push: options.push,
     });
     try {
-      await removeMemoryUri(config, ov, sourceUri, false, {quiet: true});
+      await forgetVikingResourceWithRetry(config, sourceUri);
     } catch (sourceErr: unknown) {
       return {
         content: [

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -7,7 +7,7 @@ import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {access, readdir, readFile, realpath} from 'node:fs/promises';
 import {homedir} from 'node:os';
-import {join} from 'node:path';
+import {join, sep} from 'node:path';
 import {z} from 'zod';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {filterStaleRecallSummaryRows, formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
@@ -1712,7 +1712,7 @@ async function runOpenVikingReadTool(config: RuntimeConfig, uris: readonly strin
   if (result.isError !== true && !nativeReadMissedAnyUri(result, uris)) {
     return result;
   }
-  return runOpenVikingReadToolWithCliFallback(config, uris);
+  return runOpenVikingReadToolWithLocalFallback(config, uris);
 }
 
 function nativeReadMissedAnyUri(result: CallToolResult, uris: readonly string[]): boolean {
@@ -1720,7 +1720,7 @@ function nativeReadMissedAnyUri(result: CallToolResult, uris: readonly string[])
   return uris.some(uri => text.includes(`(nothing found at ${uri})`));
 }
 
-async function runOpenVikingReadToolWithCliFallback(
+async function runOpenVikingReadToolWithLocalFallback(
   config: RuntimeConfig,
   uris: readonly string[],
 ): Promise<CallToolResult> {
@@ -1730,25 +1730,30 @@ async function runOpenVikingReadToolWithCliFallback(
     const nativeText = textFromCallToolResult(nativeResult);
     let text = nativeText;
     if (nativeResult.isError === true || nativeText.includes(`(nothing found at ${uri})`)) {
-      const cliResult = await runOpenVikingCliReadTool(config, uri);
-      if (cliResult.isError === true) {
-        return cliResult;
+      const localText = await readLocalVikingFile(config, uri);
+      if (localText === undefined) {
+        if (nativeResult.isError === true) {
+          return nativeResult;
+        }
+      } else {
+        text = localText;
       }
-      text = textFromCallToolResult(cliResult);
     }
     outputs.push(uris.length === 1 ? text : `=== ${uri} ===\n${text}`);
   }
   return {content: [{type: 'text', text: outputs.filter(Boolean).join('\n\n') || 'OK'}]};
 }
 
-async function runOpenVikingCliReadTool(config: RuntimeConfig, uri: string): Promise<CallToolResult> {
+async function readLocalVikingFile(config: RuntimeConfig, uri: string): Promise<string | undefined> {
   try {
-    const ov = await requiredOpenVikingCli();
-    const result = await runCommand(ov, withIdentity(config, ['read', uri]));
-    const text = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
-    return {content: [{type: 'text', text: text || 'OK'}]};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+    const root = await realpath(join(config.agentContextHome, 'data', 'viking', config.account));
+    const candidate = await realpath(join(root, uri.slice('viking://'.length)));
+    if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
+      return undefined;
+    }
+    return await readFile(candidate, 'utf8');
+  } catch (_err: unknown) {
+    return undefined;
   }
 }
 

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -210,7 +210,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
         return checkedUri.error;
       }
       if (recursive === true) {
-        return runOpenVikingTool(config, ['rm', checkedUri.value, '--recursive']);
+        return runOpenVikingMcpTool(config, 'forget', {recursive: true, uri: checkedUri.value});
       }
       try {
         const ov = await requiredOpenVikingCli();
@@ -284,13 +284,12 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingTool(config, [
-        'grep',
-        checkedPattern.value,
-        ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
-        ...(caseInsensitive === true || case_insensitive === true ? ['--ignore-case'] : []),
-        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
-      ]);
+      return runOpenVikingMcpTool(config, 'grep', {
+        case_insensitive: caseInsensitive ?? case_insensitive,
+        node_limit: nodeLimit ?? node_limit,
+        pattern: checkedPattern.value,
+        uri: checkedUri.value,
+      });
     },
   );
 
@@ -315,12 +314,11 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingTool(config, [
-        'glob',
-        checkedPattern.value,
-        ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
-        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
-      ]);
+      return runOpenVikingMcpTool(config, 'glob', {
+        node_limit: nodeLimit ?? node_limit,
+        pattern: checkedPattern.value,
+        uri: checkedUri.value,
+      });
     },
   );
 
@@ -331,7 +329,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       description: 'Check OpenViking server health through the CLI.',
       inputSchema: {},
     },
-    async () => runOpenVikingTool(config, ['health']),
+    async () => runOpenVikingMcpTool(config, 'health', {}),
   );
 
   registerOpenVikingParityTools(server, config);
@@ -401,14 +399,13 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
         return checkedUri.error;
       }
       const normalizedPeerId = (peerId ?? peer_id)?.trim();
-      return runOpenVikingTool(config, [
-        'search',
-        checkedQuery.value,
-        ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
-        ...numberFlag('--node-limit', limit),
-        ...numberFlag('--threshold', minScore ?? min_score),
-        ...(normalizedPeerId ? ['--peer-id', normalizedPeerId] : []),
-      ]);
+      return runOpenVikingMcpTool(config, 'search', {
+        limit,
+        min_score: minScore ?? min_score,
+        peer_id: normalizedPeerId || undefined,
+        query: checkedQuery.value,
+        uri: checkedUri.value,
+      });
     },
   );
 
@@ -458,14 +455,13 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingTool(config, [
-        'ls',
-        checkedUri.value ?? 'viking://',
-        ...(all === true ? ['--all'] : []),
-        ...(recursive === true ? ['--recursive'] : []),
-        ...(simple === true ? ['--simple'] : []),
-        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
-      ]);
+      return runOpenVikingMcpTool(config, 'list', {
+        all,
+        node_limit: nodeLimit ?? node_limit,
+        recursive,
+        simple,
+        uri: checkedUri.value,
+      });
     },
   );
 
@@ -512,12 +508,7 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       },
     },
     async ({activeOnly, active_only}) =>
-      runOpenVikingTool(config, [
-        'task',
-        'watch',
-        'ls',
-        ...(activeOnly === true || active_only === true ? ['--active-only'] : []),
-      ]),
+      runOpenVikingMcpTool(config, 'list_watches', {active_only: activeOnly ?? active_only}),
   );
 
   server.registerTool(
@@ -540,7 +531,7 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingTool(config, ['task', 'watch', 'rm', checkedUri.value]);
+      return runOpenVikingMcpTool(config, 'cancel_watch', {to_uri: checkedUri.value});
     },
   );
 
@@ -567,13 +558,12 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingTool(config, [
-        'grep',
-        checkedPattern.value,
-        ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
-        ...(caseInsensitive === true || case_insensitive === true ? ['--ignore-case'] : []),
-        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
-      ]);
+      return runOpenVikingMcpTool(config, 'grep', {
+        case_insensitive: caseInsensitive ?? case_insensitive,
+        node_limit: nodeLimit ?? node_limit,
+        pattern: checkedPattern.value,
+        uri: checkedUri.value,
+      });
     },
   );
 
@@ -598,12 +588,11 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingTool(config, [
-        'glob',
-        checkedPattern.value,
-        ...(checkedUri.value ? ['--uri', checkedUri.value] : []),
-        ...numberFlag('--node-limit', nodeLimit ?? node_limit),
-      ]);
+      return runOpenVikingMcpTool(config, 'glob', {
+        node_limit: nodeLimit ?? node_limit,
+        pattern: checkedPattern.value,
+        uri: checkedUri.value,
+      });
     },
   );
 
@@ -622,7 +611,7 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingTool(config, ['rm', checkedUri.value, ...(recursive === true ? ['--recursive'] : [])]);
+      return runOpenVikingMcpTool(config, 'forget', {recursive, uri: checkedUri.value});
     },
   );
 
@@ -708,7 +697,7 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
       description: 'Raw OpenViking MCP health parity.',
       inputSchema: {},
     },
-    async () => runOpenVikingTool(config, ['health']),
+    async () => runOpenVikingMcpTool(config, 'health', {}),
   );
 }
 
@@ -729,13 +718,15 @@ function registerOpenVikingStoreTool(server: McpServer, config: RuntimeConfig, n
     },
     async ({content, messages, text}) => {
       if (messages && messages.length > 0) {
-        return runOpenVikingTool(config, ['add-memory', JSON.stringify(messages)]);
+        return runOpenVikingMcpTool(config, name === 'ov_remember' ? 'remember' : 'store', {messages});
       }
       const checkedContent = requiredText(content ?? text, name, 'content', {content: 'Remember this note'});
       if (!checkedContent.ok) {
         return checkedContent.error;
       }
-      return runOpenVikingTool(config, ['add-memory', checkedContent.value]);
+      return runOpenVikingMcpTool(config, name === 'ov_remember' ? 'remember' : 'store', {
+        content: checkedContent.value,
+      });
     },
   );
 }
@@ -1724,20 +1715,19 @@ async function runOpenVikingAddResourceTool(
     return checkedTo.error;
   }
   const description = params.description?.trim();
-  return runOpenVikingTool(config, [
-    'add-resource',
-    ...(source ? [source] : ['--temp-file-id', tempFileId ?? '']),
-    ...(checkedTo.value ? ['--to', checkedTo.value] : []),
-    ...(description ? ['--reason', description] : []),
-    ...numberFlag('--watch-interval', params.watchInterval),
-    ...(params.wait === false ? [] : ['--wait']),
-  ]);
+  return runOpenVikingMcpTool(config, 'add_resource', {
+    description,
+    path: source,
+    to: checkedTo.value,
+    wait: params.wait,
+    watch_interval: params.watchInterval,
+  });
 }
 
 async function runOpenVikingReadTool(config: RuntimeConfig, uris: readonly string[]): Promise<CallToolResult> {
   const outputs: string[] = [];
   for (const uri of uris) {
-    const result = await runOpenVikingTool(config, ['read', uri]);
+    const result = await runOpenVikingMcpTool(config, 'read', {uri});
     if (result.isError === true) {
       return result;
     }

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -5,9 +5,9 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import {access, readdir, readFile, realpath} from 'node:fs/promises';
+import {access, mkdir, readdir, readFile, realpath, rm} from 'node:fs/promises';
 import {homedir} from 'node:os';
-import {join, sep} from 'node:path';
+import {join, resolve, sep} from 'node:path';
 import {z} from 'zod';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {filterStaleRecallSummaryRows, formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
@@ -47,10 +47,8 @@ import {
   findExecutable,
   grepOutputHasMatches,
   parsePort,
-  runCommand,
   safeTimestamp,
   sha256,
-  sleep,
   trimTrailingSlash,
 } from './utils.js';
 
@@ -1071,7 +1069,7 @@ function registerArchiveTool(server: McpServer, config: RuntimeConfig, name: str
         if (archiveResult.isError === true) {
           return archiveResult;
         }
-        const removedOriginal = await forgetVikingResourceWithRetry(config, checkedUri.value);
+        const removedOriginal = await forgetVikingResource(config, checkedUri.value);
         const [content] = archiveResult.content;
         const text = content?.type === 'text' ? content.text : 'Archived memory stored.';
         return {
@@ -1150,7 +1148,7 @@ function registerCompactTool(server: McpServer, config: RuntimeConfig): void {
           }
         }
         for (const action of plan.forgets) {
-          const removed = await forgetVikingResourceWithRetry(config, action.uri);
+          const removed = await forgetVikingResource(config, action.uri);
           appliedMessages.push(
             removed
               ? `Forgot exact duplicate: ${action.uri}`
@@ -1193,7 +1191,7 @@ async function archiveMemoryForCompact(config: RuntimeConfig, action: ArchiveAct
   if (archiveResult.isError === true) {
     return archiveResult;
   }
-  const removedOriginal = await forgetVikingResourceWithRetry(config, action.uri);
+  const removedOriginal = await forgetVikingResource(config, action.uri);
   const [content] = archiveResult.content;
   const text = content?.type === 'text' ? content.text : 'Archived memory stored.';
   return {
@@ -1342,7 +1340,7 @@ async function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMem
     await writeMemoryFile(config, ov, memoryUri, memory, writeMode, false, {quiet: true});
     const messages = [`Stored memory: ${memoryUri}`];
     if (params.replaceUri && !isInPlaceUpdate) {
-      const removedReplacedMemory = await removeVikingResourceWithRetry(ov, config, params.replaceUri);
+      const removedReplacedMemory = await removeVikingResource(config, params.replaceUri);
       messages.push(
         removedReplacedMemory
           ? `Forgot replaced memory: ${params.replaceUri}`
@@ -1400,31 +1398,20 @@ async function writeSharedMemoryReplacement(
 }
 
 async function vikingResourceExists(ov: string, config: RuntimeConfig, uri: string): Promise<boolean> {
-  const stat = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
-  return stat.exitCode === 0;
+  void ov;
+  return (await localVikingPathForExistingUri(config, uri)) !== undefined;
 }
 
-async function removeVikingResourceWithRetry(
-  ov: string,
-  config: RuntimeConfig,
-  uri: string,
-  recursive = false,
-): Promise<boolean> {
-  const args = withIdentity(config, ['rm', uri, ...(recursive ? ['--recursive'] : [])]);
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const result = await runCommand(ov, args, {allowFailure: true});
-    if (result.exitCode === 0) {
-      return true;
-    }
-    if (isResourceBusy(result.stderr, result.stdout) && attempt === 3) {
-      return false;
-    }
-    if (!isResourceBusy(result.stderr, result.stdout)) {
-      throw new Error(`${ov} ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
-    }
-    await sleep(1000 * (attempt + 1));
+async function removeVikingResource(config: RuntimeConfig, uri: string, recursive = false): Promise<boolean> {
+  const removedLocal = await removeLocalVikingResource(config, uri, recursive);
+  const nativeResult = await runOpenVikingMcpTool(config, 'forget', {
+    recursive: recursive ? true : undefined,
+    uri,
+  });
+  if (removedLocal) {
+    return true;
   }
-  return false;
+  return nativeResult.isError !== true;
 }
 
 async function runOpenVikingRemoveTool(
@@ -1433,13 +1420,12 @@ async function runOpenVikingRemoveTool(
   recursive: boolean,
 ): Promise<CallToolResult> {
   try {
-    const ov = await requiredOpenVikingCli();
-    const removed = await removeVikingResourceWithRetry(ov, config, uri, recursive);
+    const removed = await removeVikingResource(config, uri, recursive);
     return {
       content: [
         {
           type: 'text',
-          text: removed ? `Removed: ${uri}` : `Resource is still being processed; retry later: ${uri}`,
+          text: removed ? `Removed: ${uri}` : `Resource was not found locally or through native MCP: ${uri}`,
         },
       ],
       isError: !removed,
@@ -1449,22 +1435,14 @@ async function runOpenVikingRemoveTool(
   }
 }
 
-function isResourceBusy(stderr: string, stdout: string): boolean {
-  const output = `${stderr}\n${stdout}`.toLowerCase();
-  return output.includes('resource is busy') || output.includes('resource is being processed');
-}
-
 async function ensureMemoryDirectory(ov: string, config: RuntimeConfig, directoryUri: string): Promise<void> {
-  for (const uri of vikingDirectoryChain(directoryUri)) {
-    const statResult = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
-    if (statResult.exitCode === 0) {
-      continue;
-    }
-    await runCommand(
-      ov,
-      withIdentity(config, ['mkdir', uri, '--description', 'Threadnote lifecycle-aware local memories.']),
-    );
+  void ov;
+  await mkdir(join(config.agentContextHome, 'data', 'viking', config.account), {recursive: true});
+  const directoryPath = await localVikingPathForUri(config, directoryUri);
+  if (!directoryPath) {
+    throw new Error(`Could not map memory directory URI to local VikingFS path: ${directoryUri}`);
   }
+  await mkdir(directoryPath, {recursive: true});
 }
 
 function memoryUriFor(config: RuntimeConfig, memory: string, metadata: MemoryMetadata): string {
@@ -1509,20 +1487,6 @@ async function memoryWriteMode(
     return 'create';
   }
   return (await vikingResourceExists(ov, config, memoryUri)) ? 'replace' : 'create';
-}
-
-function vikingDirectoryChain(directoryUri: string): readonly string[] {
-  const prefix = 'viking://';
-  if (!directoryUri.startsWith(prefix)) {
-    return [directoryUri];
-  }
-  const parts = directoryUri.slice(prefix.length).split('/').filter(Boolean);
-  const startIndex = parts[0] === 'user' && parts.length > 2 ? 3 : 1;
-  const chain: string[] = [];
-  for (let index = startIndex; index <= parts.length; index += 1) {
-    chain.push(`${prefix}${parts.slice(0, index).join('/')}`);
-  }
-  return chain;
 }
 
 function exactMemoryScopes(config: RuntimeConfig, includeArchived: boolean): readonly string[] {
@@ -1746,15 +1710,61 @@ async function runOpenVikingReadToolWithLocalFallback(
 
 async function readLocalVikingFile(config: RuntimeConfig, uri: string): Promise<string | undefined> {
   try {
-    const root = await realpath(join(config.agentContextHome, 'data', 'viking', config.account));
-    const candidate = await realpath(join(root, uri.slice('viking://'.length)));
-    if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
+    const candidate = await localVikingPathForExistingUri(config, uri);
+    if (!candidate) {
       return undefined;
     }
     return await readFile(candidate, 'utf8');
   } catch (_err: unknown) {
     return undefined;
   }
+}
+
+async function localVikingPathForUri(config: RuntimeConfig, uri: string): Promise<string | undefined> {
+  const relativePath = localVikingRelativePath(uri);
+  if (!relativePath) {
+    return undefined;
+  }
+  const root = await realpath(join(config.agentContextHome, 'data', 'viking', config.account));
+  const candidate = resolve(root, relativePath);
+  if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
+    return undefined;
+  }
+  return candidate;
+}
+
+async function localVikingPathForExistingUri(config: RuntimeConfig, uri: string): Promise<string | undefined> {
+  try {
+    const candidate = await localVikingPathForUri(config, uri);
+    if (!candidate) {
+      return undefined;
+    }
+    const root = await realpath(join(config.agentContextHome, 'data', 'viking', config.account));
+    const resolvedCandidate = await realpath(candidate);
+    if (resolvedCandidate !== root && !resolvedCandidate.startsWith(`${root}${sep}`)) {
+      return undefined;
+    }
+    return resolvedCandidate;
+  } catch (_err: unknown) {
+    return undefined;
+  }
+}
+
+function localVikingRelativePath(uri: string): string | undefined {
+  const relativePath = uri.slice('viking://'.length);
+  if (!relativePath || relativePath.startsWith('/') || relativePath.split('/').includes('..')) {
+    return undefined;
+  }
+  return relativePath;
+}
+
+async function removeLocalVikingResource(config: RuntimeConfig, uri: string, recursive: boolean): Promise<boolean> {
+  const candidate = await localVikingPathForExistingUri(config, uri);
+  if (!candidate) {
+    return false;
+  }
+  await rm(candidate, {force: false, recursive});
+  return true;
 }
 
 async function runOpenVikingMcpTool(
@@ -1817,9 +1827,8 @@ function textFromCallToolResult(result: CallToolResult): string {
     .trim();
 }
 
-async function forgetVikingResourceWithRetry(config: RuntimeConfig, uri: string): Promise<boolean> {
-  const ov = await requiredOpenVikingCli();
-  return removeVikingResourceWithRetry(ov, config, uri);
+async function forgetVikingResource(config: RuntimeConfig, uri: string): Promise<boolean> {
+  return removeVikingResource(config, uri);
 }
 
 interface SharePublishToolOptions {
@@ -1900,7 +1909,7 @@ async function runSharePublishTool(
       push: options.push,
     });
     try {
-      await forgetVikingResourceWithRetry(config, sourceUri);
+      await forgetVikingResource(config, sourceUri);
     } catch (sourceErr: unknown) {
       return {
         content: [
@@ -1925,10 +1934,6 @@ async function runSharePublishTool(
   } catch (err: unknown) {
     return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
   }
-}
-
-function withIdentity(config: RuntimeConfig, args: readonly string[]): readonly string[] {
-  return [...args, '--account', config.account, '--user', config.user, '--agent-id', config.agentId];
 }
 
 async function requiredOpenVikingCli(): Promise<string> {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -5,9 +5,9 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import {access, mkdir, readdir, readFile, realpath, rm} from 'node:fs/promises';
+import {access, readdir, readFile, realpath} from 'node:fs/promises';
 import {homedir} from 'node:os';
-import {join, resolve, sep} from 'node:path';
+import {join} from 'node:path';
 import {z} from 'zod';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {filterStaleRecallSummaryRows, formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
@@ -47,8 +47,10 @@ import {
   findExecutable,
   grepOutputHasMatches,
   parsePort,
+  runCommand,
   safeTimestamp,
   sha256,
+  sleep,
   trimTrailingSlash,
 } from './utils.js';
 
@@ -1069,7 +1071,7 @@ function registerArchiveTool(server: McpServer, config: RuntimeConfig, name: str
         if (archiveResult.isError === true) {
           return archiveResult;
         }
-        const removedOriginal = await forgetVikingResource(config, checkedUri.value);
+        const removedOriginal = await forgetVikingResourceWithRetry(config, checkedUri.value);
         const [content] = archiveResult.content;
         const text = content?.type === 'text' ? content.text : 'Archived memory stored.';
         return {
@@ -1148,7 +1150,7 @@ function registerCompactTool(server: McpServer, config: RuntimeConfig): void {
           }
         }
         for (const action of plan.forgets) {
-          const removed = await forgetVikingResource(config, action.uri);
+          const removed = await forgetVikingResourceWithRetry(config, action.uri);
           appliedMessages.push(
             removed
               ? `Forgot exact duplicate: ${action.uri}`
@@ -1191,7 +1193,7 @@ async function archiveMemoryForCompact(config: RuntimeConfig, action: ArchiveAct
   if (archiveResult.isError === true) {
     return archiveResult;
   }
-  const removedOriginal = await forgetVikingResource(config, action.uri);
+  const removedOriginal = await forgetVikingResourceWithRetry(config, action.uri);
   const [content] = archiveResult.content;
   const text = content?.type === 'text' ? content.text : 'Archived memory stored.';
   return {
@@ -1340,7 +1342,7 @@ async function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMem
     await writeMemoryFile(config, ov, memoryUri, memory, writeMode, false, {quiet: true});
     const messages = [`Stored memory: ${memoryUri}`];
     if (params.replaceUri && !isInPlaceUpdate) {
-      const removedReplacedMemory = await removeVikingResource(config, params.replaceUri);
+      const removedReplacedMemory = await removeVikingResourceWithRetry(ov, config, params.replaceUri);
       messages.push(
         removedReplacedMemory
           ? `Forgot replaced memory: ${params.replaceUri}`
@@ -1398,20 +1400,31 @@ async function writeSharedMemoryReplacement(
 }
 
 async function vikingResourceExists(ov: string, config: RuntimeConfig, uri: string): Promise<boolean> {
-  void ov;
-  return (await localVikingPathForExistingUri(config, uri)) !== undefined;
+  const stat = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+  return stat.exitCode === 0;
 }
 
-async function removeVikingResource(config: RuntimeConfig, uri: string, recursive = false): Promise<boolean> {
-  const removedLocal = await removeLocalVikingResource(config, uri, recursive);
-  const nativeResult = await runOpenVikingMcpTool(config, 'forget', {
-    recursive: recursive ? true : undefined,
-    uri,
-  });
-  if (removedLocal) {
-    return true;
+async function removeVikingResourceWithRetry(
+  ov: string,
+  config: RuntimeConfig,
+  uri: string,
+  recursive = false,
+): Promise<boolean> {
+  const args = withIdentity(config, ['rm', uri, ...(recursive ? ['--recursive'] : [])]);
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const result = await runCommand(ov, args, {allowFailure: true});
+    if (result.exitCode === 0) {
+      return true;
+    }
+    if (isResourceBusy(result.stderr, result.stdout) && attempt === 3) {
+      return false;
+    }
+    if (!isResourceBusy(result.stderr, result.stdout)) {
+      throw new Error(`${ov} ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+    }
+    await sleep(1000 * (attempt + 1));
   }
-  return nativeResult.isError !== true;
+  return false;
 }
 
 async function runOpenVikingRemoveTool(
@@ -1420,12 +1433,13 @@ async function runOpenVikingRemoveTool(
   recursive: boolean,
 ): Promise<CallToolResult> {
   try {
-    const removed = await removeVikingResource(config, uri, recursive);
+    const ov = await requiredOpenVikingCli();
+    const removed = await removeVikingResourceWithRetry(ov, config, uri, recursive);
     return {
       content: [
         {
           type: 'text',
-          text: removed ? `Removed: ${uri}` : `Resource was not found locally or through native MCP: ${uri}`,
+          text: removed ? `Removed: ${uri}` : `Resource is still being processed; retry later: ${uri}`,
         },
       ],
       isError: !removed,
@@ -1435,14 +1449,22 @@ async function runOpenVikingRemoveTool(
   }
 }
 
+function isResourceBusy(stderr: string, stdout: string): boolean {
+  const output = `${stderr}\n${stdout}`.toLowerCase();
+  return output.includes('resource is busy') || output.includes('resource is being processed');
+}
+
 async function ensureMemoryDirectory(ov: string, config: RuntimeConfig, directoryUri: string): Promise<void> {
-  void ov;
-  await mkdir(join(config.agentContextHome, 'data', 'viking', config.account), {recursive: true});
-  const directoryPath = await localVikingPathForUri(config, directoryUri);
-  if (!directoryPath) {
-    throw new Error(`Could not map memory directory URI to local VikingFS path: ${directoryUri}`);
+  for (const uri of vikingDirectoryChain(directoryUri)) {
+    const statResult = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+    if (statResult.exitCode === 0) {
+      continue;
+    }
+    await runCommand(
+      ov,
+      withIdentity(config, ['mkdir', uri, '--description', 'Threadnote lifecycle-aware local memories.']),
+    );
   }
-  await mkdir(directoryPath, {recursive: true});
 }
 
 function memoryUriFor(config: RuntimeConfig, memory: string, metadata: MemoryMetadata): string {
@@ -1487,6 +1509,20 @@ async function memoryWriteMode(
     return 'create';
   }
   return (await vikingResourceExists(ov, config, memoryUri)) ? 'replace' : 'create';
+}
+
+function vikingDirectoryChain(directoryUri: string): readonly string[] {
+  const prefix = 'viking://';
+  if (!directoryUri.startsWith(prefix)) {
+    return [directoryUri];
+  }
+  const parts = directoryUri.slice(prefix.length).split('/').filter(Boolean);
+  const startIndex = parts[0] === 'user' && parts.length > 2 ? 3 : 1;
+  const chain: string[] = [];
+  for (let index = startIndex; index <= parts.length; index += 1) {
+    chain.push(`${prefix}${parts.slice(0, index).join('/')}`);
+  }
+  return chain;
 }
 
 function exactMemoryScopes(config: RuntimeConfig, includeArchived: boolean): readonly string[] {
@@ -1676,7 +1712,7 @@ async function runOpenVikingReadTool(config: RuntimeConfig, uris: readonly strin
   if (result.isError !== true && !nativeReadMissedAnyUri(result, uris)) {
     return result;
   }
-  return runOpenVikingReadToolWithLocalFallback(config, uris);
+  return runOpenVikingReadToolWithCliFallback(config, uris);
 }
 
 function nativeReadMissedAnyUri(result: CallToolResult, uris: readonly string[]): boolean {
@@ -1684,7 +1720,7 @@ function nativeReadMissedAnyUri(result: CallToolResult, uris: readonly string[])
   return uris.some(uri => text.includes(`(nothing found at ${uri})`));
 }
 
-async function runOpenVikingReadToolWithLocalFallback(
+async function runOpenVikingReadToolWithCliFallback(
   config: RuntimeConfig,
   uris: readonly string[],
 ): Promise<CallToolResult> {
@@ -1694,77 +1730,26 @@ async function runOpenVikingReadToolWithLocalFallback(
     const nativeText = textFromCallToolResult(nativeResult);
     let text = nativeText;
     if (nativeResult.isError === true || nativeText.includes(`(nothing found at ${uri})`)) {
-      const localText = await readLocalVikingFile(config, uri);
-      if (localText === undefined) {
-        if (nativeResult.isError === true) {
-          return nativeResult;
-        }
-      } else {
-        text = localText;
+      const cliResult = await runOpenVikingCliReadTool(config, uri);
+      if (cliResult.isError === true) {
+        return cliResult;
       }
+      text = textFromCallToolResult(cliResult);
     }
     outputs.push(uris.length === 1 ? text : `=== ${uri} ===\n${text}`);
   }
   return {content: [{type: 'text', text: outputs.filter(Boolean).join('\n\n') || 'OK'}]};
 }
 
-async function readLocalVikingFile(config: RuntimeConfig, uri: string): Promise<string | undefined> {
+async function runOpenVikingCliReadTool(config: RuntimeConfig, uri: string): Promise<CallToolResult> {
   try {
-    const candidate = await localVikingPathForExistingUri(config, uri);
-    if (!candidate) {
-      return undefined;
-    }
-    return await readFile(candidate, 'utf8');
-  } catch (_err: unknown) {
-    return undefined;
+    const ov = await requiredOpenVikingCli();
+    const result = await runCommand(ov, withIdentity(config, ['read', uri]));
+    const text = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
+    return {content: [{type: 'text', text: text || 'OK'}]};
+  } catch (err: unknown) {
+    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
   }
-}
-
-async function localVikingPathForUri(config: RuntimeConfig, uri: string): Promise<string | undefined> {
-  const relativePath = localVikingRelativePath(uri);
-  if (!relativePath) {
-    return undefined;
-  }
-  const root = await realpath(join(config.agentContextHome, 'data', 'viking', config.account));
-  const candidate = resolve(root, relativePath);
-  if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
-    return undefined;
-  }
-  return candidate;
-}
-
-async function localVikingPathForExistingUri(config: RuntimeConfig, uri: string): Promise<string | undefined> {
-  try {
-    const candidate = await localVikingPathForUri(config, uri);
-    if (!candidate) {
-      return undefined;
-    }
-    const root = await realpath(join(config.agentContextHome, 'data', 'viking', config.account));
-    const resolvedCandidate = await realpath(candidate);
-    if (resolvedCandidate !== root && !resolvedCandidate.startsWith(`${root}${sep}`)) {
-      return undefined;
-    }
-    return resolvedCandidate;
-  } catch (_err: unknown) {
-    return undefined;
-  }
-}
-
-function localVikingRelativePath(uri: string): string | undefined {
-  const relativePath = uri.slice('viking://'.length);
-  if (!relativePath || relativePath.startsWith('/') || relativePath.split('/').includes('..')) {
-    return undefined;
-  }
-  return relativePath;
-}
-
-async function removeLocalVikingResource(config: RuntimeConfig, uri: string, recursive: boolean): Promise<boolean> {
-  const candidate = await localVikingPathForExistingUri(config, uri);
-  if (!candidate) {
-    return false;
-  }
-  await rm(candidate, {force: false, recursive});
-  return true;
 }
 
 async function runOpenVikingMcpTool(
@@ -1827,8 +1812,9 @@ function textFromCallToolResult(result: CallToolResult): string {
     .trim();
 }
 
-async function forgetVikingResource(config: RuntimeConfig, uri: string): Promise<boolean> {
-  return removeVikingResource(config, uri);
+async function forgetVikingResourceWithRetry(config: RuntimeConfig, uri: string): Promise<boolean> {
+  const ov = await requiredOpenVikingCli();
+  return removeVikingResourceWithRetry(ov, config, uri);
 }
 
 interface SharePublishToolOptions {
@@ -1909,7 +1895,7 @@ async function runSharePublishTool(
       push: options.push,
     });
     try {
-      await forgetVikingResource(config, sourceUri);
+      await forgetVikingResourceWithRetry(config, sourceUri);
     } catch (sourceErr: unknown) {
       return {
         content: [
@@ -1934,6 +1920,10 @@ async function runSharePublishTool(
   } catch (err: unknown) {
     return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
   }
+}
+
+function withIdentity(config: RuntimeConfig, args: readonly string[]): readonly string[] {
+  return [...args, '--account', config.account, '--user', config.user, '--agent-id', config.agentId];
 }
 
 async function requiredOpenVikingCli(): Promise<string> {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -1709,7 +1709,7 @@ async function runOpenVikingAddResourceTool(
 
 async function runOpenVikingReadTool(config: RuntimeConfig, uris: readonly string[]): Promise<CallToolResult> {
   const result = await runOpenVikingMcpTool(config, 'read', {uris});
-  if (result.isError === true || !nativeReadMissedAnyUri(result, uris)) {
+  if (result.isError !== true && !nativeReadMissedAnyUri(result, uris)) {
     return result;
   }
   return runOpenVikingReadToolWithCliFallback(config, uris);

--- a/src/update.ts
+++ b/src/update.ts
@@ -14,11 +14,13 @@ import {
   errorMessage,
   findExecutable,
   isExecutable,
+  isTcpPortOpen,
   isJsonObject,
   maybeRun,
   readFileIfExists,
   runCommand,
   runInteractive,
+  sleep,
   toolRoot,
   formatShellCommand,
 } from './utils.js';
@@ -131,7 +133,9 @@ export async function runUpdate(config: RuntimeConfig, options: UpdateOptions): 
   }
 
   const threadnoteCommand = await installedThreadnoteCommand(runtime);
-  await maybeRun(options.dryRun === true, threadnoteCommand, ['repair', '--no-post-update']);
+  console.log('');
+  console.log('Repairing local Threadnote setup after package update.');
+  await runThreadnoteSubcommand(options.dryRun === true, threadnoteCommand, ['repair', '--no-post-update']);
   if (options.postUpdate !== false) {
     const postUpdateArgs = [
       'post-update',
@@ -141,15 +145,7 @@ export async function runUpdate(config: RuntimeConfig, options: UpdateOptions): 
       info.latestVersion,
       ...(options.yes === true ? ['--yes'] : []),
     ];
-    if (options.dryRun === true) {
-      await maybeRun(true, threadnoteCommand, postUpdateArgs);
-    } else {
-      console.log(`Running: ${formatShellCommand(threadnoteCommand, postUpdateArgs)}`);
-      const postUpdateExitCode = await runInteractive(threadnoteCommand, postUpdateArgs);
-      if (postUpdateExitCode !== 0) {
-        throw new Error(`${formatShellCommand(threadnoteCommand, postUpdateArgs)} exited with ${postUpdateExitCode}.`);
-      }
-    }
+    await runThreadnoteSubcommand(options.dryRun === true, threadnoteCommand, postUpdateArgs);
   } else {
     console.log('Skipping post-update migration prompts because --no-post-update was provided.');
   }
@@ -288,9 +284,11 @@ async function ensurePinnedOpenVikingInstalled(
   if (usingLaunchd) {
     const launchAgentPath = launchAgentPlistPath();
     await runCommand('launchctl', ['unload', launchAgentPath], {allowFailure: true});
+    await waitForOpenVikingPortClosed(config, 15_000);
     await runCommand('launchctl', ['load', launchAgentPath], {allowFailure: true});
   } else {
     await maybeRun(false, threadnoteCommand, ['stop']);
+    await waitForOpenVikingPortClosed(config, 15_000);
     await maybeRun(false, threadnoteCommand, ['start']);
   }
   const healthyAfter = await waitForOpenVikingHealthy(config, 10_000);
@@ -299,6 +297,18 @@ async function ensurePinnedOpenVikingInstalled(
       `Warning: OpenViking did not return to healthy at ${openVikingHealthEndpoint(config)} within 10s after the restart.`,
     );
     console.log('Check the server log or run: threadnote start');
+  }
+}
+
+async function runThreadnoteSubcommand(dryRun: boolean, executable: string, args: readonly string[]): Promise<void> {
+  if (dryRun) {
+    await maybeRun(true, executable, args);
+    return;
+  }
+  console.log(`Running: ${formatShellCommand(executable, args)}`);
+  const exitCode = await runInteractive(executable, args);
+  if (exitCode !== 0) {
+    throw new Error(`${formatShellCommand(executable, args)} exited with ${exitCode}.`);
   }
 }
 
@@ -327,11 +337,27 @@ async function waitForOpenVikingHealthy(config: RuntimeConfig, timeoutMs: number
     if (await isOpenVikingHealthy(config)) {
       return true;
     }
-    await new Promise(resolvePromise => {
-      setTimeout(resolvePromise, 500);
-    });
+    await sleep(500);
   }
   return isOpenVikingHealthy(config);
+}
+
+async function waitForOpenVikingPortClosed(config: RuntimeConfig, timeoutMs: number): Promise<boolean> {
+  console.log(`Waiting for OpenViking port ${config.host}:${config.port} to close before restart.`);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await isTcpPortOpen(config.host, config.port, 300))) {
+      return true;
+    }
+    await sleep(300);
+  }
+  if (!(await isTcpPortOpen(config.host, config.port, 300))) {
+    return true;
+  }
+  console.log(
+    `Warning: OpenViking port ${config.host}:${config.port} is still in use after ${timeoutMs / 1000}s; start may fail.`,
+  );
+  return false;
 }
 
 function launchAgentPlistPath(): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import {spawn} from 'node:child_process';
+import {execFile, spawn} from 'node:child_process';
 import {createHash} from 'node:crypto';
 import {constants as fsConstants, existsSync} from 'node:fs';
 import {access, lstat, mkdir, readFile, readdir, rm, stat} from 'node:fs/promises';
@@ -175,15 +175,11 @@ export async function runCommand(
   } = {},
 ): Promise<CommandResult> {
   return new Promise((resolvePromise, rejectPromise) => {
-    const child = spawn(executable, args, {cwd: options.cwd});
-    const stdoutChunks: string[] = [];
-    const stderrChunks: string[] = [];
     const maxOutputBytes = options.maxOutputBytes ?? defaultCommandMaxOutputBytes();
-    let stdoutBytes = 0;
-    let stderrBytes = 0;
     let finished = false;
-    let failureResult: CommandResult | undefined;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
+    let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
+    let failureMessage: string | undefined;
     let sentTerminationSignal = false;
     const timeoutMs = options.timeoutMs ?? defaultCommandTimeoutMs();
     const finish = (result: CommandResult): void => {
@@ -194,22 +190,47 @@ export async function runCommand(
       if (killTimer) {
         clearTimeout(killTimer);
       }
+      if (killEscalationTimer) {
+        clearTimeout(killEscalationTimer);
+      }
       if (result.exitCode !== 0 && options.allowFailure !== true) {
         rejectPromise(new Error(`${formatShellCommand(executable, args)} failed: ${result.stderr || result.stdout}`));
         return;
       }
       resolvePromise(result);
     };
+    const child = execFile(
+      executable,
+      [...args],
+      {
+        cwd: options.cwd,
+        encoding: 'utf8',
+        maxBuffer: maxOutputBytes,
+      },
+      (err, stdout, stderr) => {
+        finish(
+          commandResultFromExecFileCallback({
+            args,
+            err,
+            executable,
+            failureMessage,
+            maxOutputBytes,
+            stderr,
+            stdout,
+          }),
+        );
+      },
+    );
     const failAndKill = (message: string): void => {
-      if (failureResult) {
+      if (failureMessage) {
         return;
       }
-      failureResult = {exitCode: 124, stderr: message, stdout: stdoutChunks.join('')};
+      failureMessage = message;
       if (!sentTerminationSignal) {
         sentTerminationSignal = true;
         child.kill('SIGTERM');
       }
-      setTimeout(() => {
+      killEscalationTimer = setTimeout(() => {
         if (!finished) {
           child.kill('SIGKILL');
         }
@@ -221,53 +242,32 @@ export async function runCommand(
       }, timeoutMs);
       killTimer.unref?.();
     }
-    child.stdout.on('data', chunk => {
-      if (failureResult) {
-        return;
-      }
-      const text = String(chunk);
-      stdoutBytes += Buffer.byteLength(text);
-      if (stdoutBytes + stderrBytes > maxOutputBytes) {
-        failAndKill(`${formatShellCommand(executable, args)} exceeded output limit of ${maxOutputBytes} bytes`);
-        return;
-      }
-      stdoutChunks.push(text);
-    });
-    child.stderr.on('data', chunk => {
-      if (failureResult) {
-        return;
-      }
-      const text = String(chunk);
-      stderrBytes += Buffer.byteLength(text);
-      if (stdoutBytes + stderrBytes > maxOutputBytes) {
-        failAndKill(`${formatShellCommand(executable, args)} exceeded output limit of ${maxOutputBytes} bytes`);
-        return;
-      }
-      stderrChunks.push(text);
-    });
-    child.on('error', err => {
-      if (finished) {
-        return;
-      }
-      if (killTimer) {
-        clearTimeout(killTimer);
-      }
-      if (options.allowFailure === true) {
-        finish({exitCode: 127, stderr: errorMessage(err), stdout: ''});
-      } else {
-        finished = true;
-        rejectPromise(err);
-      }
-    });
-    child.on('close', code => {
-      const result = failureResult ?? {
-        exitCode: code ?? 1,
-        stderr: stderrChunks.join(''),
-        stdout: stdoutChunks.join(''),
-      };
-      finish(result);
-    });
   });
+}
+
+function commandResultFromExecFileCallback(params: {
+  readonly args: readonly string[];
+  readonly err: Error | null;
+  readonly executable: string;
+  readonly failureMessage?: string;
+  readonly maxOutputBytes: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}): CommandResult {
+  if (params.failureMessage) {
+    return {exitCode: 124, stderr: params.failureMessage, stdout: params.stdout};
+  }
+  if (!params.err) {
+    return {exitCode: 0, stderr: params.stderr, stdout: params.stdout};
+  }
+  const error = params.err as Error & {readonly code?: number | string};
+  const exitCode =
+    typeof error.code === 'number' ? error.code : error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' ? 124 : 127;
+  const stderr =
+    error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
+      ? `${formatShellCommand(params.executable, params.args)} exceeded output limit of ${params.maxOutputBytes} bytes`
+      : params.stderr || errorMessage(error);
+  return {exitCode, stderr, stdout: params.stdout};
 }
 
 function defaultCommandTimeoutMs(): number {

--- a/test/integration/mcp.openviking-parity.test.ts
+++ b/test/integration/mcp.openviking-parity.test.ts
@@ -145,9 +145,10 @@ async function callText(client: Client, name: string, args: Record<string, unkno
   return text;
 }
 
-function firstArgs(text: string): readonly string[] {
-  const [line] = text.trim().split('\n');
-  return JSON.parse(line ?? '[]') as string[];
+function nativeArgs(text: string, toolName: string): Record<string, unknown> {
+  const prefix = `${toolName}:`;
+  expect(text).toContain(prefix);
+  return JSON.parse(text.slice(text.indexOf(prefix) + prefix.length)) as Record<string, unknown>;
 }
 
 describe('Threadnote MCP OpenViking parity tools', () => {
@@ -177,29 +178,24 @@ describe('Threadnote MCP OpenViking parity tools', () => {
     });
   });
 
-  it('forwards documented native parameters through the OpenViking CLI', async () => {
+  it('forwards documented native parameters through OpenViking MCP', async () => {
     await withMcpClient(async client => {
       expect(
-        firstArgs(
+        nativeArgs(
           await callText(client, 'ov_search', {
             limit: 4,
             min_score: 0.25,
             query: 'release notes',
             target_uri: 'viking://resources/repos/threadnote',
           }),
-        ),
-      ).toEqual(
-        expect.arrayContaining([
           'search',
-          'release notes',
-          '--uri',
-          'viking://resources/repos/threadnote',
-          '--node-limit',
-          '4',
-          '--threshold',
-          '0.25',
-        ]),
-      );
+        ),
+      ).toEqual({
+        limit: 4,
+        min_score: 0.25,
+        query: 'release notes',
+        uri: 'viking://resources/repos/threadnote',
+      });
 
       const readOutput = await callText(client, 'ov_read', {
         uris: ['viking://resources/repos/threadnote/README.md', 'viking://resources/repos/threadnote/docs/share.md'],
@@ -208,14 +204,14 @@ describe('Threadnote MCP OpenViking parity tools', () => {
         readOutput
           .trim()
           .split('\n')
-          .map(line => JSON.parse(line) as string[]),
+          .map(line => nativeArgs(line, 'read')),
       ).toEqual([
-        expect.arrayContaining(['read', 'viking://resources/repos/threadnote/README.md']),
-        expect.arrayContaining(['read', 'viking://resources/repos/threadnote/docs/share.md']),
+        {uri: 'viking://resources/repos/threadnote/README.md'},
+        {uri: 'viking://resources/repos/threadnote/docs/share.md'},
       ]);
 
       expect(
-        firstArgs(
+        nativeArgs(
           await callText(client, 'add_resource', {
             description: 'Threadnote docs',
             path: 'https://github.com/Kashkovsky/threadnote.git',
@@ -223,49 +219,42 @@ describe('Threadnote MCP OpenViking parity tools', () => {
             wait: false,
             watch_interval: 30,
           }),
+          'add_resource',
         ),
-      ).toEqual(
-        expect.arrayContaining([
-          'add-resource',
-          'https://github.com/Kashkovsky/threadnote.git',
-          '--to',
-          'viking://resources/repos/threadnote',
-          '--reason',
-          'Threadnote docs',
-          '--watch-interval',
-          '30',
-        ]),
-      );
+      ).toEqual({
+        description: 'Threadnote docs',
+        path: 'https://github.com/Kashkovsky/threadnote.git',
+        to: 'viking://resources/repos/threadnote',
+        wait: false,
+        watch_interval: 30,
+      });
 
       expect(
-        firstArgs(
+        nativeArgs(
           await callText(client, 'grep', {
             case_insensitive: true,
             node_limit: 7,
             pattern: 'native mcp',
             uri: 'viking://resources/repos/threadnote',
           }),
-        ),
-      ).toEqual(
-        expect.arrayContaining([
           'grep',
-          'native mcp',
-          '--uri',
-          'viking://resources/repos/threadnote',
-          '--ignore-case',
-          '--node-limit',
-          '7',
-        ]),
-      );
+        ),
+      ).toEqual({
+        case_insensitive: true,
+        node_limit: 7,
+        pattern: 'native mcp',
+        uri: 'viking://resources/repos/threadnote',
+      });
 
       expect(
-        firstArgs(
+        nativeArgs(
           await callText(client, 'forget', {
             recursive: true,
             uri: 'viking://resources/repos/threadnote/tmp',
           }),
+          'forget',
         ),
-      ).toEqual(expect.arrayContaining(['rm', 'viking://resources/repos/threadnote/tmp', '--recursive']));
+      ).toEqual({recursive: true, uri: 'viking://resources/repos/threadnote/tmp'});
     });
   });
 
@@ -293,16 +282,17 @@ describe('Threadnote MCP OpenViking parity tools', () => {
         'code_expand:{"symbol":"registerTools","uri":"viking://resources/repos/threadnote/src/mcp_server.ts"}',
       );
 
-      expect(firstArgs(await callText(client, 'ov_list_watches', {active_only: true}))).toEqual(
-        expect.arrayContaining(['task', 'watch', 'ls', '--active-only']),
-      );
+      expect(nativeArgs(await callText(client, 'ov_list_watches', {active_only: true}), 'list_watches')).toEqual({
+        active_only: true,
+      });
       expect(
-        firstArgs(
+        nativeArgs(
           await callText(client, 'ov_cancel_watch', {
             to_uri: 'viking://resources/repos/threadnote',
           }),
+          'cancel_watch',
         ),
-      ).toEqual(expect.arrayContaining(['task', 'watch', 'rm', 'viking://resources/repos/threadnote']));
+      ).toEqual({to_uri: 'viking://resources/repos/threadnote'});
     });
   });
 

--- a/test/integration/mcp.openviking-parity.test.ts
+++ b/test/integration/mcp.openviking-parity.test.ts
@@ -203,7 +203,7 @@ describe('Threadnote MCP OpenViking parity tools', () => {
   });
 
   it('forwards documented native parameters through OpenViking MCP', async () => {
-    await withMcpClient(async client => {
+    await withMcpClient(async (client, home) => {
       expect(
         nativeArgs(
           await callText(client, 'ov_search', {
@@ -263,6 +263,8 @@ describe('Threadnote MCP OpenViking parity tools', () => {
         uri: 'viking://resources/repos/threadnote',
       });
 
+      await writeLocalVikingFile(home, 'viking://resources/needs-recursive/marker.md', 'delete me\n');
+      await writeLocalVikingFile(home, 'viking://resources/repos/threadnote/tmp', 'delete me\n');
       expect(
         await callText(client, 'forget', {
           recursive: true,

--- a/test/integration/mcp.openviking-parity.test.ts
+++ b/test/integration/mcp.openviking-parity.test.ts
@@ -23,7 +23,12 @@ async function makeFakeBin(root: string): Promise<string> {
   await writeExecutable(
     join(bin, 'ov'),
     `#! /usr/bin/env node
-process.stdout.write(JSON.stringify(process.argv.slice(2)) + '\\n');
+const args = process.argv.slice(2);
+if (args.includes('viking://resources/needs-recursive') && !args.includes('--recursive')) {
+  process.stderr.write('missing recursive flag\\n');
+  process.exit(2);
+}
+process.stdout.write(JSON.stringify(args) + '\\n');
 `,
   );
   return bin;
@@ -80,6 +85,19 @@ function nativeMcpResponse(body: unknown): unknown {
   }
   if (request.method === 'tools/call') {
     const params = request.params as {arguments?: Record<string, unknown>; name?: string};
+    if (params.name === 'read') {
+      const uris = params.arguments?.uris;
+      const uriList = Array.isArray(uris) ? uris : [uris];
+      if (uriList.includes('viking://resources/native-missing.md')) {
+        return {
+          id: request.id,
+          jsonrpc: '2.0',
+          result: {
+            content: [{type: 'text', text: '(nothing found at viking://resources/native-missing.md)'}],
+          },
+        };
+      }
+    }
     return {
       id: request.id,
       jsonrpc: '2.0',
@@ -194,21 +212,15 @@ describe('Threadnote MCP OpenViking parity tools', () => {
         limit: 4,
         min_score: 0.25,
         query: 'release notes',
-        uri: 'viking://resources/repos/threadnote',
+        target_uri: 'viking://resources/repos/threadnote',
       });
 
       const readOutput = await callText(client, 'ov_read', {
         uris: ['viking://resources/repos/threadnote/README.md', 'viking://resources/repos/threadnote/docs/share.md'],
       });
-      expect(
-        readOutput
-          .trim()
-          .split('\n')
-          .map(line => nativeArgs(line, 'read')),
-      ).toEqual([
-        {uri: 'viking://resources/repos/threadnote/README.md'},
-        {uri: 'viking://resources/repos/threadnote/docs/share.md'},
-      ]);
+      expect(nativeArgs(readOutput, 'read')).toEqual({
+        uris: ['viking://resources/repos/threadnote/README.md', 'viking://resources/repos/threadnote/docs/share.md'],
+      });
 
       expect(
         nativeArgs(
@@ -225,7 +237,6 @@ describe('Threadnote MCP OpenViking parity tools', () => {
         description: 'Threadnote docs',
         path: 'https://github.com/Kashkovsky/threadnote.git',
         to: 'viking://resources/repos/threadnote',
-        wait: false,
         watch_interval: 30,
       });
 
@@ -247,14 +258,14 @@ describe('Threadnote MCP OpenViking parity tools', () => {
       });
 
       expect(
-        nativeArgs(
-          await callText(client, 'forget', {
-            recursive: true,
-            uri: 'viking://resources/repos/threadnote/tmp',
-          }),
-          'forget',
-        ),
-      ).toEqual({recursive: true, uri: 'viking://resources/repos/threadnote/tmp'});
+        await callText(client, 'forget', {
+          recursive: true,
+          uri: 'viking://resources/needs-recursive',
+        }),
+      ).toContain('Removed: viking://resources/needs-recursive');
+      expect(await callText(client, 'ov_forget', {uri: 'viking://resources/repos/threadnote/tmp'})).toContain(
+        'Removed: viking://resources/repos/threadnote/tmp',
+      );
     });
   });
 
@@ -293,6 +304,27 @@ describe('Threadnote MCP OpenViking parity tools', () => {
           'cancel_watch',
         ),
       ).toEqual({to_uri: 'viking://resources/repos/threadnote'});
+    });
+  });
+
+  it('falls back to CLI read when native MCP read misses a resource', async () => {
+    await withMcpClient(async client => {
+      expect(await callText(client, 'ov_read', {uri: 'viking://resources/native-missing.md'})).toContain(
+        '"read","viking://resources/native-missing.md"',
+      );
+      expect(await callText(client, 'read_context', {uri: 'viking://resources/native-missing.md'})).toContain(
+        '"read","viking://resources/native-missing.md"',
+      );
+      const mixedRead = await callText(client, 'read_context', {
+        uris: [
+          'viking://user/denyskashkovskyi/memories/durable/projects/threadnote/example.md',
+          'viking://resources/native-missing.md',
+        ],
+      });
+      expect(mixedRead).toContain(
+        'read:{"uris":["viking://user/denyskashkovskyi/memories/durable/projects/threadnote/example.md"]}',
+      );
+      expect(mixedRead).toContain('"read","viking://resources/native-missing.md"');
     });
   });
 

--- a/test/integration/mcp.openviking-parity.test.ts
+++ b/test/integration/mcp.openviking-parity.test.ts
@@ -1,0 +1,327 @@
+import {chmod, mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {createServer, type Server} from 'node:http';
+import type {AddressInfo} from 'node:net';
+import {tmpdir} from 'node:os';
+import {delimiter, join} from 'node:path';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import {describe, expect, it} from 'vitest';
+
+interface TextContent {
+  readonly text: string;
+  readonly type: 'text';
+}
+
+async function writeExecutable(path: string, contents: string): Promise<void> {
+  await writeFile(path, contents, {encoding: 'utf8', mode: 0o700});
+  await chmod(path, 0o700);
+}
+
+async function makeFakeBin(root: string): Promise<string> {
+  const bin = join(root, 'bin');
+  await mkdir(bin, {recursive: true});
+  await writeExecutable(
+    join(bin, 'ov'),
+    `#! /usr/bin/env node
+process.stdout.write(JSON.stringify(process.argv.slice(2)) + '\\n');
+`,
+  );
+  return bin;
+}
+
+async function makeNativeMcpServer(): Promise<{close: () => Promise<void>; url: string}> {
+  const server = createServer(async (req, res) => {
+    if (req.url !== '/mcp') {
+      res.writeHead(404).end();
+      return;
+    }
+    try {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const bodyText = Buffer.concat(chunks).toString('utf8');
+      const body = bodyText ? JSON.parse(bodyText) : undefined;
+      const response = nativeMcpResponse(body);
+      if (response === undefined) {
+        res.writeHead(202).end();
+        return;
+      }
+      res.writeHead(200, {'content-type': 'application/json'}).end(JSON.stringify(response));
+    } catch (err: unknown) {
+      res.writeHead(500).end(err instanceof Error ? err.message : String(err));
+    }
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo;
+  return {
+    close: async () => {
+      await closeServer(server);
+    },
+    url: `http://127.0.0.1:${address.port}/mcp`,
+  };
+}
+
+function nativeMcpResponse(body: unknown): unknown {
+  const request = body as {id?: string | number; method?: string; params?: Record<string, unknown>};
+  if (request.method === 'initialize') {
+    return {
+      id: request.id,
+      jsonrpc: '2.0',
+      result: {
+        capabilities: {tools: {}},
+        protocolVersion: '2025-06-18',
+        serverInfo: {name: 'fake-openviking', version: '0.0.0'},
+      },
+    };
+  }
+  if (request.method === 'notifications/initialized') {
+    return undefined;
+  }
+  if (request.method === 'tools/call') {
+    const params = request.params as {arguments?: Record<string, unknown>; name?: string};
+    return {
+      id: request.id,
+      jsonrpc: '2.0',
+      result: {
+        content: [{type: 'text', text: `${params.name}:${JSON.stringify(params.arguments ?? {})}`}],
+      },
+    };
+  }
+  return {
+    id: request.id,
+    jsonrpc: '2.0',
+    error: {code: -32601, message: `Unsupported method: ${request.method}`},
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close(err => (err ? reject(err) : resolve()));
+  });
+}
+
+async function withMcpClient<T>(
+  fn: (client: Client) => Promise<T>,
+  options: {readonly nativeMcpUrl?: string} = {},
+): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'threadnote-mcp-ov-parity-'));
+  const home = join(root, 'home');
+  await mkdir(home, {recursive: true});
+  const fakeBin = await makeFakeBin(root);
+  const nativeMcp = options.nativeMcpUrl === undefined ? await makeNativeMcpServer() : undefined;
+  const repoRoot = process.cwd();
+  const transport = new StdioClientTransport({
+    args: [join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs'), join(repoRoot, 'src', 'mcp_server.ts')],
+    command: process.execPath,
+    cwd: repoRoot,
+    env: {
+      PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ''}`,
+      THREADNOTE_ACCOUNT: 'local',
+      THREADNOTE_AGENT_ID: 'threadnote',
+      THREADNOTE_HOME: home,
+      THREADNOTE_MANIFEST: join(home, 'seed-manifest.yaml'),
+      THREADNOTE_OPENVIKING_MCP_URL: options.nativeMcpUrl ?? nativeMcp?.url ?? '',
+      THREADNOTE_USER: 'denyskashkovskyi',
+    },
+    stderr: 'pipe',
+  });
+  const client = new Client({name: 'threadnote-test', version: '0.0.0'});
+  try {
+    await client.connect(transport);
+    return await fn(client);
+  } finally {
+    await client.close().catch(() => undefined);
+    await nativeMcp?.close().catch(() => undefined);
+    await rm(root, {force: true, recursive: true});
+  }
+}
+
+async function callText(client: Client, name: string, args: Record<string, unknown>): Promise<string> {
+  const result = await client.callTool({arguments: args, name}, undefined, {timeout: 5000});
+  expect(Array.isArray(result.content)).toBe(true);
+  const text = (result.content as TextContent[]).map(item => item.text).join('\n');
+  expect(result.isError, text).not.toBe(true);
+  return text;
+}
+
+function firstArgs(text: string): readonly string[] {
+  const [line] = text.trim().split('\n');
+  return JSON.parse(line ?? '[]') as string[];
+}
+
+describe('Threadnote MCP OpenViking parity tools', () => {
+  it('registers raw OpenViking MCP parity helpers', async () => {
+    await withMcpClient(async client => {
+      const tools = await client.listTools();
+      const names = tools.tools.map(tool => tool.name);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          'ov_search',
+          'ov_read',
+          'ov_list',
+          'ov_store',
+          'ov_remember',
+          'ov_add_resource',
+          'ov_list_watches',
+          'ov_cancel_watch',
+          'ov_grep',
+          'ov_glob',
+          'ov_forget',
+          'ov_code_outline',
+          'ov_code_search',
+          'ov_code_expand',
+          'ov_health',
+        ]),
+      );
+    });
+  });
+
+  it('forwards documented native parameters through the OpenViking CLI', async () => {
+    await withMcpClient(async client => {
+      expect(
+        firstArgs(
+          await callText(client, 'ov_search', {
+            limit: 4,
+            min_score: 0.25,
+            query: 'release notes',
+            target_uri: 'viking://resources/repos/threadnote',
+          }),
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          'search',
+          'release notes',
+          '--uri',
+          'viking://resources/repos/threadnote',
+          '--node-limit',
+          '4',
+          '--threshold',
+          '0.25',
+        ]),
+      );
+
+      const readOutput = await callText(client, 'ov_read', {
+        uris: ['viking://resources/repos/threadnote/README.md', 'viking://resources/repos/threadnote/docs/share.md'],
+      });
+      expect(
+        readOutput
+          .trim()
+          .split('\n')
+          .map(line => JSON.parse(line) as string[]),
+      ).toEqual([
+        expect.arrayContaining(['read', 'viking://resources/repos/threadnote/README.md']),
+        expect.arrayContaining(['read', 'viking://resources/repos/threadnote/docs/share.md']),
+      ]);
+
+      expect(
+        firstArgs(
+          await callText(client, 'add_resource', {
+            description: 'Threadnote docs',
+            path: 'https://github.com/Kashkovsky/threadnote.git',
+            to: 'viking://resources/repos/threadnote',
+            wait: false,
+            watch_interval: 30,
+          }),
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          'add-resource',
+          'https://github.com/Kashkovsky/threadnote.git',
+          '--to',
+          'viking://resources/repos/threadnote',
+          '--reason',
+          'Threadnote docs',
+          '--watch-interval',
+          '30',
+        ]),
+      );
+
+      expect(
+        firstArgs(
+          await callText(client, 'grep', {
+            case_insensitive: true,
+            node_limit: 7,
+            pattern: 'native mcp',
+            uri: 'viking://resources/repos/threadnote',
+          }),
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          'grep',
+          'native mcp',
+          '--uri',
+          'viking://resources/repos/threadnote',
+          '--ignore-case',
+          '--node-limit',
+          '7',
+        ]),
+      );
+
+      expect(
+        firstArgs(
+          await callText(client, 'forget', {
+            recursive: true,
+            uri: 'viking://resources/repos/threadnote/tmp',
+          }),
+        ),
+      ).toEqual(expect.arrayContaining(['rm', 'viking://resources/repos/threadnote/tmp', '--recursive']));
+    });
+  });
+
+  it('maps native watch and code tools', async () => {
+    await withMcpClient(async client => {
+      expect(
+        await callText(client, 'ov_code_outline', {
+          uri: 'viking://resources/repos/threadnote/src/mcp_server.ts',
+        }),
+      ).toContain('code_outline:{"uri":"viking://resources/repos/threadnote/src/mcp_server.ts"}');
+
+      expect(
+        await callText(client, 'ov_code_search', {
+          query: 'registerTool',
+          uri: 'viking://resources/repos/threadnote/src',
+        }),
+      ).toContain('code_search:{"query":"registerTool","uri":"viking://resources/repos/threadnote/src"}');
+
+      expect(
+        await callText(client, 'ov_code_expand', {
+          symbol: 'registerTools',
+          uri: 'viking://resources/repos/threadnote/src/mcp_server.ts',
+        }),
+      ).toContain(
+        'code_expand:{"symbol":"registerTools","uri":"viking://resources/repos/threadnote/src/mcp_server.ts"}',
+      );
+
+      expect(firstArgs(await callText(client, 'ov_list_watches', {active_only: true}))).toEqual(
+        expect.arrayContaining(['task', 'watch', 'ls', '--active-only']),
+      );
+      expect(
+        firstArgs(
+          await callText(client, 'ov_cancel_watch', {
+            to_uri: 'viking://resources/repos/threadnote',
+          }),
+        ),
+      ).toEqual(expect.arrayContaining(['task', 'watch', 'rm', 'viking://resources/repos/threadnote']));
+    });
+  });
+
+  it('returns a tool error when the native MCP URL is invalid', async () => {
+    await withMcpClient(
+      async client => {
+        const result = await client.callTool(
+          {
+            arguments: {uri: 'viking://resources/repos/threadnote/src/mcp_server.ts'},
+            name: 'ov_code_outline',
+          },
+          undefined,
+          {timeout: 5000},
+        );
+        expect(result.isError).toBe(true);
+        const text = (result.content as TextContent[]).map(item => item.text).join('\n');
+        expect(text).toContain('OpenViking native MCP tool "code_outline" failed at not-a-url');
+      },
+      {nativeMcpUrl: 'not-a-url'},
+    );
+  });
+});

--- a/test/integration/mcp.openviking-parity.test.ts
+++ b/test/integration/mcp.openviking-parity.test.ts
@@ -2,7 +2,7 @@ import {chmod, mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {createServer, type Server} from 'node:http';
 import type {AddressInfo} from 'node:net';
 import {tmpdir} from 'node:os';
-import {delimiter, join} from 'node:path';
+import {delimiter, dirname, join} from 'node:path';
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 import {describe, expect, it} from 'vitest';
@@ -32,6 +32,12 @@ process.stdout.write(JSON.stringify(args) + '\\n');
 `,
   );
   return bin;
+}
+
+async function writeLocalVikingFile(home: string, uri: string, contents: string): Promise<void> {
+  const path = join(home, 'data', 'viking', 'local', uri.slice('viking://'.length));
+  await mkdir(dirname(path), {recursive: true});
+  await writeFile(path, contents);
 }
 
 async function makeNativeMcpServer(): Promise<{close: () => Promise<void>; url: string}> {
@@ -120,7 +126,7 @@ async function closeServer(server: Server): Promise<void> {
 }
 
 async function withMcpClient<T>(
-  fn: (client: Client) => Promise<T>,
+  fn: (client: Client, home: string) => Promise<T>,
   options: {readonly nativeMcpUrl?: string} = {},
 ): Promise<T> {
   const root = await mkdtemp(join(tmpdir(), 'threadnote-mcp-ov-parity-'));
@@ -147,7 +153,7 @@ async function withMcpClient<T>(
   const client = new Client({name: 'threadnote-test', version: '0.0.0'});
   try {
     await client.connect(transport);
-    return await fn(client);
+    return await fn(client, home);
   } finally {
     await client.close().catch(() => undefined);
     await nativeMcp?.close().catch(() => undefined);
@@ -307,13 +313,14 @@ describe('Threadnote MCP OpenViking parity tools', () => {
     });
   });
 
-  it('falls back to CLI read when native MCP read misses a resource', async () => {
-    await withMcpClient(async client => {
+  it('falls back to local VikingFS read when native MCP read misses a resource', async () => {
+    await withMcpClient(async (client, home) => {
+      await writeLocalVikingFile(home, 'viking://resources/native-missing.md', 'local native-missing fallback\n');
       expect(await callText(client, 'ov_read', {uri: 'viking://resources/native-missing.md'})).toContain(
-        '"read","viking://resources/native-missing.md"',
+        'local native-missing fallback',
       );
       expect(await callText(client, 'read_context', {uri: 'viking://resources/native-missing.md'})).toContain(
-        '"read","viking://resources/native-missing.md"',
+        'local native-missing fallback',
       );
       const mixedRead = await callText(client, 'read_context', {
         uris: [
@@ -324,15 +331,16 @@ describe('Threadnote MCP OpenViking parity tools', () => {
       expect(mixedRead).toContain(
         'read:{"uris":["viking://user/denyskashkovskyi/memories/durable/projects/threadnote/example.md"]}',
       );
-      expect(mixedRead).toContain('"read","viking://resources/native-missing.md"');
+      expect(mixedRead).toContain('local native-missing fallback');
     });
   });
 
-  it('falls back to CLI read when native MCP read is unavailable', async () => {
+  it('falls back to local VikingFS read when native MCP read is unavailable', async () => {
     await withMcpClient(
-      async client => {
+      async (client, home) => {
+        await writeLocalVikingFile(home, 'viking://resources/native-unavailable.md', 'local unavailable fallback\n');
         expect(await callText(client, 'ov_read', {uri: 'viking://resources/native-unavailable.md'})).toContain(
-          '"read","viking://resources/native-unavailable.md"',
+          'local unavailable fallback',
         );
       },
       {nativeMcpUrl: 'not-a-url'},

--- a/test/integration/mcp.openviking-parity.test.ts
+++ b/test/integration/mcp.openviking-parity.test.ts
@@ -2,7 +2,7 @@ import {chmod, mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {createServer, type Server} from 'node:http';
 import type {AddressInfo} from 'node:net';
 import {tmpdir} from 'node:os';
-import {delimiter, dirname, join} from 'node:path';
+import {delimiter, join} from 'node:path';
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 import {describe, expect, it} from 'vitest';
@@ -32,12 +32,6 @@ process.stdout.write(JSON.stringify(args) + '\\n');
 `,
   );
   return bin;
-}
-
-async function writeLocalVikingFile(home: string, uri: string, contents: string): Promise<void> {
-  const path = join(home, 'data', 'viking', 'local', uri.slice('viking://'.length));
-  await mkdir(dirname(path), {recursive: true});
-  await writeFile(path, contents);
 }
 
 async function makeNativeMcpServer(): Promise<{close: () => Promise<void>; url: string}> {
@@ -126,7 +120,7 @@ async function closeServer(server: Server): Promise<void> {
 }
 
 async function withMcpClient<T>(
-  fn: (client: Client, home: string) => Promise<T>,
+  fn: (client: Client) => Promise<T>,
   options: {readonly nativeMcpUrl?: string} = {},
 ): Promise<T> {
   const root = await mkdtemp(join(tmpdir(), 'threadnote-mcp-ov-parity-'));
@@ -153,7 +147,7 @@ async function withMcpClient<T>(
   const client = new Client({name: 'threadnote-test', version: '0.0.0'});
   try {
     await client.connect(transport);
-    return await fn(client, home);
+    return await fn(client);
   } finally {
     await client.close().catch(() => undefined);
     await nativeMcp?.close().catch(() => undefined);
@@ -203,7 +197,7 @@ describe('Threadnote MCP OpenViking parity tools', () => {
   });
 
   it('forwards documented native parameters through OpenViking MCP', async () => {
-    await withMcpClient(async (client, home) => {
+    await withMcpClient(async client => {
       expect(
         nativeArgs(
           await callText(client, 'ov_search', {
@@ -263,8 +257,6 @@ describe('Threadnote MCP OpenViking parity tools', () => {
         uri: 'viking://resources/repos/threadnote',
       });
 
-      await writeLocalVikingFile(home, 'viking://resources/needs-recursive/marker.md', 'delete me\n');
-      await writeLocalVikingFile(home, 'viking://resources/repos/threadnote/tmp', 'delete me\n');
       expect(
         await callText(client, 'forget', {
           recursive: true,
@@ -315,14 +307,13 @@ describe('Threadnote MCP OpenViking parity tools', () => {
     });
   });
 
-  it('falls back to local VikingFS read when native MCP read misses a resource', async () => {
-    await withMcpClient(async (client, home) => {
-      await writeLocalVikingFile(home, 'viking://resources/native-missing.md', 'local native-missing fallback\n');
+  it('falls back to CLI read when native MCP read misses a resource', async () => {
+    await withMcpClient(async client => {
       expect(await callText(client, 'ov_read', {uri: 'viking://resources/native-missing.md'})).toContain(
-        'local native-missing fallback',
+        '"read","viking://resources/native-missing.md"',
       );
       expect(await callText(client, 'read_context', {uri: 'viking://resources/native-missing.md'})).toContain(
-        'local native-missing fallback',
+        '"read","viking://resources/native-missing.md"',
       );
       const mixedRead = await callText(client, 'read_context', {
         uris: [
@@ -333,16 +324,15 @@ describe('Threadnote MCP OpenViking parity tools', () => {
       expect(mixedRead).toContain(
         'read:{"uris":["viking://user/denyskashkovskyi/memories/durable/projects/threadnote/example.md"]}',
       );
-      expect(mixedRead).toContain('local native-missing fallback');
+      expect(mixedRead).toContain('"read","viking://resources/native-missing.md"');
     });
   });
 
-  it('falls back to local VikingFS read when native MCP read is unavailable', async () => {
+  it('falls back to CLI read when native MCP read is unavailable', async () => {
     await withMcpClient(
-      async (client, home) => {
-        await writeLocalVikingFile(home, 'viking://resources/native-unavailable.md', 'local unavailable fallback\n');
+      async client => {
         expect(await callText(client, 'ov_read', {uri: 'viking://resources/native-unavailable.md'})).toContain(
-          'local unavailable fallback',
+          '"read","viking://resources/native-unavailable.md"',
         );
       },
       {nativeMcpUrl: 'not-a-url'},

--- a/test/integration/mcp.openviking-parity.test.ts
+++ b/test/integration/mcp.openviking-parity.test.ts
@@ -328,6 +328,17 @@ describe('Threadnote MCP OpenViking parity tools', () => {
     });
   });
 
+  it('falls back to CLI read when native MCP read is unavailable', async () => {
+    await withMcpClient(
+      async client => {
+        expect(await callText(client, 'ov_read', {uri: 'viking://resources/native-unavailable.md'})).toContain(
+          '"read","viking://resources/native-unavailable.md"',
+        );
+      },
+      {nativeMcpUrl: 'not-a-url'},
+    );
+  });
+
   it('returns a tool error when the native MCP URL is invalid', async () => {
     await withMcpClient(
       async client => {

--- a/test/integration/mcp.share-publish.test.ts
+++ b/test/integration/mcp.share-publish.test.ts
@@ -138,6 +138,7 @@ describe('Threadnote MCP share_publish', () => {
         THREADNOTE_AGENT_ID: 'threadnote',
         THREADNOTE_HOME: home,
         THREADNOTE_MANIFEST: join(home, 'seed-manifest.yaml'),
+        THREADNOTE_OPENVIKING_MCP_URL: 'not-a-url',
         THREADNOTE_USER: 'denyskashkovskyi',
       },
       stderr: 'pipe',

--- a/test/integration/mcp.share-publish.test.ts
+++ b/test/integration/mcp.share-publish.test.ts
@@ -16,9 +16,26 @@ interface TextContent {
 async function makeHome(root: string): Promise<string> {
   const home = join(root, 'home');
   const worktree = join(home, 'data', 'viking', 'local', 'user', 'denyskashkovskyi', 'memories', 'shared', 'default');
+  const sourceDir = join(
+    home,
+    'data',
+    'viking',
+    'local',
+    'user',
+    'denyskashkovskyi',
+    'memories',
+    'durable',
+    'projects',
+    'foo',
+  );
   const gitdir = join(home, 'share', 'teams', 'default.gitdir');
   await mkdir(worktree, {recursive: true});
+  await mkdir(sourceDir, {recursive: true});
   await mkdir(join(home, 'share'), {recursive: true});
+  await writeFile(
+    join(sourceDir, 'bar.md'),
+    'MEMORY\nkind: durable\nstatus: active\nproject: foo\ntopic: bar\n\nBody\n',
+  );
   await writeFile(
     join(home, 'share', 'teams.json'),
     `${JSON.stringify(

--- a/test/integration/mcp.share-publish.test.ts
+++ b/test/integration/mcp.share-publish.test.ts
@@ -16,26 +16,9 @@ interface TextContent {
 async function makeHome(root: string): Promise<string> {
   const home = join(root, 'home');
   const worktree = join(home, 'data', 'viking', 'local', 'user', 'denyskashkovskyi', 'memories', 'shared', 'default');
-  const sourceDir = join(
-    home,
-    'data',
-    'viking',
-    'local',
-    'user',
-    'denyskashkovskyi',
-    'memories',
-    'durable',
-    'projects',
-    'foo',
-  );
   const gitdir = join(home, 'share', 'teams', 'default.gitdir');
   await mkdir(worktree, {recursive: true});
-  await mkdir(sourceDir, {recursive: true});
   await mkdir(join(home, 'share'), {recursive: true});
-  await writeFile(
-    join(sourceDir, 'bar.md'),
-    'MEMORY\nkind: durable\nstatus: active\nproject: foo\ntopic: bar\n\nBody\n',
-  );
   await writeFile(
     join(home, 'share', 'teams.json'),
     `${JSON.stringify(

--- a/test/unit/index_repair.test.ts
+++ b/test/unit/index_repair.test.ts
@@ -225,6 +225,36 @@ describe('recall index auto repair', () => {
     expect(vi.mocked(utils.runCommand)).not.toHaveBeenCalled();
     await expect(readFile(join(config.agentContextHome, 'index-auto-repair.json'), 'utf8')).rejects.toThrow();
   });
+
+  it('reports scan and reindex progress for long maintenance repairs', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const summaryDir = join(
+      config.agentContextHome,
+      'data',
+      'viking',
+      'local',
+      'user',
+      'denys',
+      'memories',
+      'durable',
+      'projects',
+      'threadnote',
+    );
+    await mkdir(summaryDir, {recursive: true});
+    await writeFile(join(summaryDir, '.overview.md'), '# threadnote\n\n[Directory overview is not ready]');
+    const progressTypes: string[] = [];
+
+    await repairStaleRecallIndex(config, '/ov', {
+      collapseToRoots: true,
+      onProgress: progress => {
+        progressTypes.push(progress.type);
+      },
+      query: 'threadnote latest handoff',
+    });
+
+    expect(progressTypes).toEqual(['scan-start', 'scan-complete', 'repair-start']);
+  });
 });
 
 describe('recall stale summary filtering', () => {

--- a/test/unit/index_repair.test.ts
+++ b/test/unit/index_repair.test.ts
@@ -5,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   filterStaleRecallSummaryRows,
   findStaleRecallIndexTargets,
+  formatRecallIndexRepairMessages,
   repairStaleRecallIndex,
 } from '../../src/index_repair.js';
 import type {CommandResult, RuntimeConfig} from '../../src/types.js';
@@ -201,6 +202,71 @@ describe('recall index auto repair', () => {
     ]);
   });
 
+  it('can collapse maintenance repairs to bounded child scopes instead of broad roots', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    await writeFile(
+      config.manifestPath,
+      [
+        'version: 1',
+        'projects:',
+        '  - name: coda',
+        '    path: ~/src/coda',
+        '    uri: viking://resources/repos/coda',
+        '    seed: []',
+        '',
+      ].join('\n'),
+    );
+    const specsDir = join(config.agentContextHome, 'data', 'viking', 'local', 'resources', 'repos', 'coda', 'docs');
+    const skillsDir = join(config.agentContextHome, 'data', 'viking', 'local', 'resources', 'repos', 'coda', '.claude');
+    await mkdir(specsDir, {recursive: true});
+    await mkdir(skillsDir, {recursive: true});
+    await writeFile(join(specsDir, '.abstract.md'), '[Directory abstract is not ready]');
+    await writeFile(join(skillsDir, '.overview.md'), '[Directory overview is not ready]');
+
+    const targets = await findStaleRecallIndexTargets(config, {
+      collapseDepth: 1,
+      collapseToRoots: true,
+      includeManifestResources: true,
+    });
+
+    expect(targets.map(target => target.uri).sort()).toEqual([
+      'viking://resources/repos/coda/.claude',
+      'viking://resources/repos/coda/docs',
+    ]);
+  });
+
+  it('reports reindex failures to callers so repair can recover server health', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const summaryDir = join(
+      config.agentContextHome,
+      'data',
+      'viking',
+      'local',
+      'user',
+      'denys',
+      'memories',
+      'durable',
+      'projects',
+      'threadnote',
+    );
+    await mkdir(summaryDir, {recursive: true});
+    await writeFile(join(summaryDir, '.overview.md'), '# threadnote\n\n[Directory overview is not ready]');
+    vi.mocked(utils.runCommand).mockResolvedValueOnce({exitCode: 1, stderr: 'INTERNAL', stdout: ''});
+    const failures: string[] = [];
+
+    const result = await repairStaleRecallIndex(config, '/ov', {
+      onRepairFailure: target => {
+        failures.push(target.uri);
+      },
+      query: 'threadnote latest handoff',
+    });
+
+    expect(result.warnings[0]).toContain('INTERNAL');
+    expect(failures).toEqual(['viking://user/denys/memories/durable/projects/threadnote']);
+  });
+
   it('does not write repair state in dry-run mode', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
@@ -258,6 +324,23 @@ describe('recall index auto repair', () => {
 });
 
 describe('recall stale summary filtering', () => {
+  it('can cap long repair summaries', () => {
+    const messages = formatRecallIndexRepairMessages(
+      {
+        repairedUris: ['viking://one', 'viking://two', 'viking://three'],
+        skippedRecentUris: [],
+        warnings: [],
+      },
+      {dryRun: true, maxUris: 2},
+    );
+
+    expect(messages).toEqual([
+      'Would auto-reindex stale recall scope: viking://one',
+      'Would auto-reindex stale recall scope: viking://two',
+      'Would auto-reindex 1 more stale recall scope(s).',
+    ]);
+  });
+
   it('removes stale generated summary rows without dropping useful rows', () => {
     const output = [
       'context_type  uri  level  score  abstract  type',

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -1,7 +1,76 @@
-import {describe, expect, it} from 'vitest';
-import {parseUpdateRuntime} from '../../src/update.js';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {CommandResult, RuntimeConfig} from '../../src/types.js';
+
+vi.mock('../../src/utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../src/utils.js')>();
+  return {
+    ...actual,
+    findExecutable: vi.fn(),
+    isExecutable: vi.fn(),
+    isTcpPortOpen: vi.fn(),
+    maybeRun: vi.fn(),
+    runCommand: vi.fn(),
+    runInteractive: vi.fn(),
+    sleep: vi.fn(),
+  };
+});
+
+import {parseUpdateRuntime, runPostUpdate, runUpdate} from '../../src/update.js';
+import * as utils from '../../src/utils.js';
+
+const ok = (stdout = ''): CommandResult => ({exitCode: 0, stdout, stderr: ''});
+
+async function makeRuntime(): Promise<RuntimeConfig> {
+  const home = await mkdtemp(join(tmpdir(), 'threadnote-update-'));
+  return {
+    account: 'local',
+    agentContextHome: home,
+    agentId: 'threadnote',
+    host: '127.0.0.1',
+    manifestPath: join(home, 'seed-manifest.yaml'),
+    openVikingVersion: '0.3.24',
+    port: 1933,
+    user: 'denys',
+  };
+}
+
+function mockLatestVersion(version: string): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL) => {
+      if (String(url).includes('/health')) {
+        return {ok: true};
+      }
+      return {
+        json: async () => ({version}),
+        ok: true,
+      };
+    }),
+  );
+}
 
 describe('parseUpdateRuntime', () => {
+  beforeEach(() => {
+    vi.mocked(utils.findExecutable).mockReset();
+    vi.mocked(utils.isExecutable).mockReset();
+    vi.mocked(utils.isTcpPortOpen).mockReset();
+    vi.mocked(utils.maybeRun).mockReset();
+    vi.mocked(utils.runCommand).mockReset();
+    vi.mocked(utils.runInteractive).mockReset();
+    vi.mocked(utils.sleep).mockReset();
+    vi.mocked(utils.maybeRun).mockResolvedValue(ok());
+    vi.mocked(utils.runCommand).mockResolvedValue(ok());
+    vi.mocked(utils.runInteractive).mockResolvedValue(0);
+    vi.mocked(utils.sleep).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('accepts the documented values', () => {
     expect(parseUpdateRuntime('auto')).toBe('auto');
     expect(parseUpdateRuntime('npm')).toBe('npm');
@@ -12,5 +81,125 @@ describe('parseUpdateRuntime', () => {
   it('throws on anything else', () => {
     expect(() => parseUpdateRuntime('yarn')).toThrow(/Invalid update runtime/);
     expect(() => parseUpdateRuntime('')).toThrow(/Invalid update runtime/);
+  });
+});
+
+describe('runUpdate', () => {
+  const homes: string[] = [];
+
+  beforeEach(() => {
+    vi.mocked(utils.findExecutable).mockReset();
+    vi.mocked(utils.isExecutable).mockReset();
+    vi.mocked(utils.isTcpPortOpen).mockReset();
+    vi.mocked(utils.maybeRun).mockReset();
+    vi.mocked(utils.runCommand).mockReset();
+    vi.mocked(utils.runInteractive).mockReset();
+    vi.mocked(utils.sleep).mockReset();
+    vi.mocked(utils.findExecutable).mockImplementation(async commands => {
+      if (commands.includes('npm')) {
+        return '/usr/bin/npm';
+      }
+      if (commands.includes('threadnote')) {
+        return '/usr/local/bin/threadnote';
+      }
+      return undefined;
+    });
+    vi.mocked(utils.isExecutable).mockResolvedValue(true);
+    vi.mocked(utils.maybeRun).mockResolvedValue(ok());
+    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+      if (executable === 'npm' && args[0] === 'prefix') {
+        return ok('/tmp/npm-global\n');
+      }
+      return ok();
+    });
+    vi.mocked(utils.runInteractive).mockResolvedValue(0);
+    vi.mocked(utils.sleep).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+  });
+
+  it('streams repair output after updating instead of buffering it', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    mockLatestVersion('99.0.0');
+
+    await runUpdate(config, {postUpdate: false, runtime: 'npm'});
+
+    expect(vi.mocked(utils.maybeRun)).toHaveBeenCalledWith(
+      false,
+      'npm',
+      expect.arrayContaining(['install', '--global', 'threadnote@latest']),
+    );
+    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith('/tmp/npm-global/bin/threadnote', [
+      'repair',
+      '--no-post-update',
+    ]);
+  });
+});
+
+describe('runPostUpdate', () => {
+  const homes: string[] = [];
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    vi.mocked(utils.findExecutable).mockReset();
+    vi.mocked(utils.isExecutable).mockReset();
+    vi.mocked(utils.isTcpPortOpen).mockReset();
+    vi.mocked(utils.maybeRun).mockReset();
+    vi.mocked(utils.runCommand).mockReset();
+    vi.mocked(utils.runInteractive).mockReset();
+    vi.mocked(utils.sleep).mockReset();
+    vi.mocked(utils.findExecutable).mockImplementation(async commands => {
+      if (commands.includes('ov') || commands.includes('openviking')) {
+        return '/ov';
+      }
+      if (commands.includes('threadnote')) {
+        return '/threadnote';
+      }
+      return undefined;
+    });
+    vi.mocked(utils.isTcpPortOpen).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    vi.mocked(utils.maybeRun).mockResolvedValue(ok());
+    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+      if (executable === '/ov' && args[0] === 'version') {
+        return ok('CLI:     0.3.23\nServer:  0.3.23\n');
+      }
+      return ok();
+    });
+    vi.mocked(utils.runInteractive).mockResolvedValue(0);
+    vi.mocked(utils.sleep).mockResolvedValue(undefined);
+    process.argv = [process.argv[0] ?? 'node', '/threadnote'];
+  });
+
+  afterEach(async () => {
+    process.argv = originalArgv;
+    vi.unstubAllGlobals();
+    await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+  });
+
+  it('waits for the old OpenViking port listener to close before starting after a pin upgrade', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ok: true})),
+    );
+
+    await runPostUpdate(config, {fromVersion: '1.1.0', toVersion: '1.1.0'});
+
+    const stopCall = vi.mocked(utils.maybeRun).mock.calls.find(call => call[2][0] === 'stop');
+    const startCall = vi.mocked(utils.maybeRun).mock.calls.find(call => call[2][0] === 'start');
+
+    expect(stopCall).toBeDefined();
+    expect(startCall).toBeDefined();
+    expect(vi.mocked(utils.isTcpPortOpen)).toHaveBeenCalledWith('127.0.0.1', 1933, 300);
+    expect(vi.mocked(utils.isTcpPortOpen).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(utils.maybeRun).mock.invocationCallOrder[
+        vi.mocked(utils.maybeRun).mock.calls.findIndex(call => call[2][0] === 'start')
+      ],
+    );
   });
 });


### PR DESCRIPTION
Summary
- Adds OpenViking native MCP parity tools under `ov_*` while keeping Threadnote workflow tools as the default MCP surface.
- Bumps Threadnote to `1.1.0`.
- Makes update/repair output visible during long work and hardens recall-index repair after OpenViking reindex failures.

Detail
- Adds raw OpenViking tool coverage for search/read/list/store/resources/watch/code/health flows through the Threadnote MCP adapter.
- Streams `threadnote repair --no-post-update` during `threadnote update`; post-update OpenViking restarts now wait for the configured port to close before starting.
- Recall-index repair now reports scan/per-scope progress, avoids broad root reindexes, checks server health after reindex failures, and caps long final summaries.

Test plan
- `npx vitest run test/integration/mcp.openviking-parity.test.ts`
- `npx vitest run test/unit/update.test.ts test/unit/index_repair.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run prettier:check`
- `npm test`
- `npm run build`
- `git diff --check`
- `node ./dist/threadnote.cjs repair --dry-run --no-start --mcp none --no-post-update | rg ...`