### PR TITLE
1.1.1: recall-index repair fix and full update streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "commonjs",
   "main": "dist/threadnote.cjs",
   "description": "Shared local context and handoffs for development agents",

--- a/src/index_repair.ts
+++ b/src/index_repair.ts
@@ -11,6 +11,7 @@ const MAX_SCAN_DEPTH = 5;
 const MAX_REPAIR_TARGETS = 4;
 export const MAINTENANCE_COLLAPSE_DEPTH = 3;
 export const MAINTENANCE_MAX_REPAIR_TARGETS = 512;
+export const MAINTENANCE_CONSECUTIVE_FAILURE_LIMIT = 5;
 
 interface RecallIndexRepairConfig {
   readonly account: string;
@@ -70,6 +71,7 @@ export async function repairStaleRecallIndex(
   options: {
     readonly collapseToRoots?: boolean;
     readonly collapseDepth?: number;
+    readonly consecutiveFailureLimit?: number;
     readonly dryRun?: boolean;
     readonly ignoreBackoff?: boolean;
     readonly includeAgentSkills?: boolean;
@@ -83,6 +85,7 @@ export async function repairStaleRecallIndex(
   options.onProgress?.({type: 'scan-start'});
   const targets = await findStaleRecallIndexTargets(config, options);
   const repairTargets = targets.slice(0, options.maxTargets ?? MAX_REPAIR_TARGETS);
+  const consecutiveFailureLimit = options.consecutiveFailureLimit;
   options.onProgress?.({
     repairTargetCount: repairTargets.length,
     totalTargets: targets.length,
@@ -97,6 +100,7 @@ export async function repairStaleRecallIndex(
   const repairedUris: string[] = [];
   const skippedRecentUris: string[] = [];
   const warnings: string[] = [];
+  let consecutiveFailures = 0;
 
   for (const [targetIndex, target] of repairTargets.entries()) {
     const progressBase = {index: targetIndex + 1, target, total: repairTargets.length};
@@ -125,11 +129,21 @@ export async function repairStaleRecallIndex(
       {allowFailure: true},
     );
     if (result.exitCode === 0) {
+      consecutiveFailures = 0;
       repairedUris.push(target.uri);
       state.entries[target.uri] = {repairedAt: new Date(now).toISOString(), signature: target.signature};
     } else {
+      consecutiveFailures += 1;
       warnings.push(indexRepairWarning(target.uri, result));
       await options.onRepairFailure?.(target, result);
+      const remaining = repairTargets.length - (targetIndex + 1);
+      if (consecutiveFailureLimit !== undefined && consecutiveFailures >= consecutiveFailureLimit && remaining > 0) {
+        warnings.push(
+          `Stopped recall index repair after ${consecutiveFailures} consecutive reindex failures; ` +
+            `skipped ${remaining} remaining scope(s). Re-run \`threadnote repair\` once OpenViking is idle.`,
+        );
+        break;
+      }
     }
   }
 
@@ -150,6 +164,9 @@ export async function findStaleRecallIndexTargets(
     readonly query?: string;
   } = {},
 ): Promise<readonly StaleIndexTarget[]> {
+  if (await summaryAutoGenerationDisabled(config)) {
+    return [];
+  }
   const roots = await scanRoots(config, options);
   const byUri = new Map<string, {parts: string[]; staleCount: number; uri: string}>();
   for (const root of roots) {
@@ -350,6 +367,30 @@ async function staleSidecars(rootPath: string, rootUri: string): Promise<readonl
 
 function isSummarySidecar(name: string): boolean {
   return name === '.abstract.md' || name === '.overview.md';
+}
+
+/**
+ * `[Directory ... not ready]` sidecars only become "ready" when OpenViking
+ * generates Level 0/1 directory summaries. Threadnote's shipped `ov.conf`
+ * template sets `auto_generate_l0` and `auto_generate_l1` to false, and
+ * `ov reindex` (vectors_only / semantic_and_vectors) never regenerates those
+ * summaries. So when both are disabled the placeholders are permanent by
+ * design — treating them as stale would reindex every scope on every recall
+ * forever without ever clearing a single placeholder. Recall itself relies on
+ * the semantic + vector index, not these summaries, so skipping the scan is
+ * safe. Unknown/unparseable config is treated as enabled to preserve behavior.
+ */
+export async function summaryAutoGenerationDisabled(config: RecallIndexRepairConfig): Promise<boolean> {
+  const raw = await readFileIfExists(join(config.agentContextHome, 'ov.conf'));
+  if (!raw) {
+    return false;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isJsonObject(parsed) && parsed.auto_generate_l0 === false && parsed.auto_generate_l1 === false;
+  } catch (_err: unknown) {
+    return false;
+  }
 }
 
 function isStaleSummary(content: string): boolean {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -26,8 +26,10 @@ import {
   findStaleRecallIndexTargets,
   formatRecallIndexRepairMessages,
   MAINTENANCE_COLLAPSE_DEPTH,
+  MAINTENANCE_CONSECUTIVE_FAILURE_LIMIT,
   MAINTENANCE_MAX_REPAIR_TARGETS,
   repairStaleRecallIndex,
+  summaryAutoGenerationDisabled,
 } from './index_repair.js';
 import {readSeedManifest} from './manifest.js';
 import {removeMcpConfigs, removeMcpSnippets, resolveMcpClients, runMcpInstall} from './mcp.js';
@@ -347,15 +349,12 @@ async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promis
     const result = await repairStaleRecallIndex(config, ov, {
       collapseDepth: MAINTENANCE_COLLAPSE_DEPTH,
       collapseToRoots: true,
+      consecutiveFailureLimit: MAINTENANCE_CONSECUTIVE_FAILURE_LIMIT,
       dryRun,
       ignoreBackoff: true,
       includeAgentSkills: true,
       includeManifestResources: true,
       maxTargets: MAINTENANCE_MAX_REPAIR_TARGETS,
-      onRepairFailure: async () => {
-        progress.update('A recall index reindex failed; checking OpenViking health before continuing.');
-        await repairServerHealth(config, dryRun);
-      },
       onProgress: event => {
         if (event.type === 'scan-complete') {
           if (event.totalTargets === 0) {
@@ -808,6 +807,15 @@ async function manifestCheck(path: string): Promise<DoctorCheck> {
 
 async function recallIndexFreshnessCheck(config: RuntimeConfig): Promise<DoctorCheck> {
   try {
+    if (await summaryAutoGenerationDisabled(config)) {
+      return {
+        name: 'recall index freshness',
+        status: 'ok',
+        detail:
+          'OpenViking L0/L1 summary auto-generation disabled in ov.conf; ' +
+          'directory summary placeholders are expected and not reindexed',
+      };
+    }
     const targets = await findStaleRecallIndexTargets(config, {
       collapseToRoots: true,
       includeAgentSkills: true,

--- a/src/update.ts
+++ b/src/update.ts
@@ -124,7 +124,7 @@ export async function runUpdate(config: RuntimeConfig, options: UpdateOptions): 
 
   const runtime = await resolveUpdateRuntime(options.runtime ?? 'auto');
   const updateCommand = updatePackageCommand(runtime, registry);
-  await maybeRun(options.dryRun === true, updateCommand.executable, updateCommand.args);
+  await runStreamingSubcommand(options.dryRun === true, updateCommand.executable, updateCommand.args);
 
   if (options.repair === false) {
     console.log('Skipping repair because --no-repair was provided.');
@@ -135,7 +135,7 @@ export async function runUpdate(config: RuntimeConfig, options: UpdateOptions): 
   const threadnoteCommand = await installedThreadnoteCommand(runtime);
   console.log('');
   console.log('Repairing local Threadnote setup after package update.');
-  await runThreadnoteSubcommand(options.dryRun === true, threadnoteCommand, ['repair', '--no-post-update']);
+  await runStreamingSubcommand(options.dryRun === true, threadnoteCommand, ['repair', '--no-post-update']);
   if (options.postUpdate !== false) {
     const postUpdateArgs = [
       'post-update',
@@ -145,7 +145,7 @@ export async function runUpdate(config: RuntimeConfig, options: UpdateOptions): 
       info.latestVersion,
       ...(options.yes === true ? ['--yes'] : []),
     ];
-    await runThreadnoteSubcommand(options.dryRun === true, threadnoteCommand, postUpdateArgs);
+    await runStreamingSubcommand(options.dryRun === true, threadnoteCommand, postUpdateArgs);
   } else {
     console.log('Skipping post-update migration prompts because --no-post-update was provided.');
   }
@@ -267,7 +267,7 @@ async function ensurePinnedOpenVikingInstalled(
 
   const threadnoteCommand =
     currentThreadnoteCommand() ?? (await findExecutable([NPM_PACKAGE_NAME])) ?? NPM_PACKAGE_NAME;
-  await maybeRun(options.dryRun, threadnoteCommand, ['install', '--force', '--no-start']);
+  await runStreamingSubcommand(options.dryRun, threadnoteCommand, ['install', '--force', '--no-start']);
 
   if (options.dryRun) {
     if (wasRunning || usingLaunchd) {
@@ -287,9 +287,9 @@ async function ensurePinnedOpenVikingInstalled(
     await waitForOpenVikingPortClosed(config, 15_000);
     await runCommand('launchctl', ['load', launchAgentPath], {allowFailure: true});
   } else {
-    await maybeRun(false, threadnoteCommand, ['stop']);
+    await runStreamingSubcommand(false, threadnoteCommand, ['stop']);
     await waitForOpenVikingPortClosed(config, 15_000);
-    await maybeRun(false, threadnoteCommand, ['start']);
+    await runStreamingSubcommand(false, threadnoteCommand, ['start']);
   }
   const healthyAfter = await waitForOpenVikingHealthy(config, 10_000);
   if (!healthyAfter) {
@@ -300,7 +300,14 @@ async function ensurePinnedOpenVikingInstalled(
   }
 }
 
-async function runThreadnoteSubcommand(dryRun: boolean, executable: string, args: readonly string[]): Promise<void> {
+/**
+ * Run a subprocess with its stdout/stderr inherited so the user sees output
+ * live, instead of buffering through `runCommand`/`maybeRun` (which also
+ * imposes the 10-minute command timeout — fatal for long-running steps like a
+ * package install, an OpenViking reinstall, or a churning repair). Dry-run
+ * defers to `maybeRun` so it only prints the command it would run.
+ */
+async function runStreamingSubcommand(dryRun: boolean, executable: string, args: readonly string[]): Promise<void> {
   if (dryRun) {
     await maybeRun(true, executable, args);
     return;
@@ -516,7 +523,7 @@ async function runApplicablePostUpdateMigrations(
       console.log(`  ${formatMigrationCommand(threadnoteCommand, migration.commandArgs)}`);
       continue;
     }
-    await maybeRun(options.dryRun, threadnoteCommand, migration.commandArgs);
+    await runStreamingSubcommand(options.dryRun, threadnoteCommand, migration.commandArgs);
     if (!options.dryRun) {
       handledMigrationIds.add(migration.id);
       for (const instruction of migration.instructions) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -326,6 +326,12 @@ export async function resolveRepoName(cwd = getInvocationCwd()): Promise<string 
 export async function runInteractive(executable: string, args: readonly string[]): Promise<number> {
   return new Promise(resolvePromise => {
     const child = spawn(executable, args, {stdio: 'inherit'});
+    // `error` fires instead of `close` when the binary cannot be spawned
+    // (e.g. ENOENT). Resolve non-zero so callers surface a failure rather than
+    // hanging forever waiting for a `close` that never comes.
+    child.on('error', () => {
+      resolvePromise(1);
+    });
     child.on('close', code => {
       resolvePromise(code ?? 1);
     });

--- a/test/unit/index_repair.test.ts
+++ b/test/unit/index_repair.test.ts
@@ -267,6 +267,128 @@ describe('recall index auto repair', () => {
     expect(failures).toEqual(['viking://user/denys/memories/durable/projects/threadnote']);
   });
 
+  it('treats not-ready summaries as fresh when OV summary auto-generation is disabled', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    await writeFile(
+      join(config.agentContextHome, 'ov.conf'),
+      JSON.stringify({auto_generate_l0: false, auto_generate_l1: false}),
+    );
+    const summaryDir = join(
+      config.agentContextHome,
+      'data',
+      'viking',
+      'local',
+      'user',
+      'denys',
+      'memories',
+      'durable',
+      'projects',
+      'threadnote',
+    );
+    await mkdir(summaryDir, {recursive: true});
+    await writeFile(join(summaryDir, '.overview.md'), '# threadnote\n\n[Directory overview is not ready]');
+
+    const targets = await findStaleRecallIndexTargets(config, {query: 'threadnote latest handoff'});
+    const result = await repairStaleRecallIndex(config, '/ov', {query: 'threadnote latest handoff'});
+
+    expect(targets).toEqual([]);
+    expect(result.repairedUris).toEqual([]);
+    expect(vi.mocked(utils.runCommand)).not.toHaveBeenCalled();
+  });
+
+  it('stops maintenance repair after the consecutive failure limit is reached', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    for (const project of ['alpha', 'beta', 'gamma', 'delta']) {
+      const summaryDir = join(
+        config.agentContextHome,
+        'data',
+        'viking',
+        'local',
+        'user',
+        'denys',
+        'memories',
+        'durable',
+        'projects',
+        project,
+      );
+      await mkdir(summaryDir, {recursive: true});
+      await writeFile(join(summaryDir, '.overview.md'), `# ${project}\n\n[Directory overview is not ready]`);
+    }
+    vi.mocked(utils.runCommand).mockResolvedValue({
+      exitCode: 1,
+      stderr: 'CONFLICT: Failed to acquire tree lock',
+      stdout: '',
+    });
+
+    const result = await repairStaleRecallIndex(config, '/ov', {consecutiveFailureLimit: 2, ignoreBackoff: true});
+
+    expect(vi.mocked(utils.runCommand)).toHaveBeenCalledTimes(2);
+    expect(result.repairedUris).toEqual([]);
+    expect(result.warnings.some(warning => warning.includes('Stopped recall index repair after 2'))).toBe(true);
+  });
+
+  it('still scans when only one summary auto-generation flag is disabled', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    await writeFile(
+      join(config.agentContextHome, 'ov.conf'),
+      JSON.stringify({auto_generate_l0: false, auto_generate_l1: true}),
+    );
+    const summaryDir = join(
+      config.agentContextHome,
+      'data',
+      'viking',
+      'local',
+      'user',
+      'denys',
+      'memories',
+      'durable',
+      'projects',
+      'threadnote',
+    );
+    await mkdir(summaryDir, {recursive: true});
+    await writeFile(join(summaryDir, '.overview.md'), '# threadnote\n\n[Directory overview is not ready]');
+
+    const targets = await findStaleRecallIndexTargets(config, {query: 'threadnote latest handoff'});
+
+    expect(targets.map(target => target.uri)).toEqual(['viking://user/denys/memories/durable/projects/threadnote']);
+  });
+
+  it('resets the consecutive failure counter on success and does not warn when the last target fails', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    for (const project of ['alpha', 'beta', 'gamma', 'delta']) {
+      const summaryDir = join(
+        config.agentContextHome,
+        'data',
+        'viking',
+        'local',
+        'user',
+        'denys',
+        'memories',
+        'durable',
+        'projects',
+        project,
+      );
+      await mkdir(summaryDir, {recursive: true});
+      await writeFile(join(summaryDir, '.overview.md'), `# ${project}\n\n[Directory overview is not ready]`);
+    }
+    const conflict = {exitCode: 1, stderr: 'CONFLICT: Failed to acquire tree lock', stdout: ''};
+    vi.mocked(utils.runCommand)
+      .mockResolvedValueOnce(conflict)
+      .mockResolvedValueOnce(ok('reindexed'))
+      .mockResolvedValueOnce(conflict)
+      .mockResolvedValueOnce(conflict);
+
+    const result = await repairStaleRecallIndex(config, '/ov', {consecutiveFailureLimit: 2, ignoreBackoff: true});
+
+    expect(vi.mocked(utils.runCommand)).toHaveBeenCalledTimes(4);
+    expect(result.repairedUris).toHaveLength(1);
+    expect(result.warnings.some(warning => warning.includes('Stopped recall index repair'))).toBe(false);
+  });
+
   it('does not write repair state in dry-run mode', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -121,15 +121,14 @@ describe('runUpdate', () => {
     await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
   });
 
-  it('streams repair output after updating instead of buffering it', async () => {
+  it('streams the package update and repair output instead of buffering it', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     mockLatestVersion('99.0.0');
 
     await runUpdate(config, {postUpdate: false, runtime: 'npm'});
 
-    expect(vi.mocked(utils.maybeRun)).toHaveBeenCalledWith(
-      false,
+    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(
       'npm',
       expect.arrayContaining(['install', '--global', 'threadnote@latest']),
     );
@@ -137,6 +136,7 @@ describe('runUpdate', () => {
       'repair',
       '--no-post-update',
     ]);
+    expect(vi.mocked(utils.maybeRun)).not.toHaveBeenCalled();
   });
 });
 
@@ -190,15 +190,15 @@ describe('runPostUpdate', () => {
 
     await runPostUpdate(config, {fromVersion: '1.1.0', toVersion: '1.1.0'});
 
-    const stopCall = vi.mocked(utils.maybeRun).mock.calls.find(call => call[2][0] === 'stop');
-    const startCall = vi.mocked(utils.maybeRun).mock.calls.find(call => call[2][0] === 'start');
+    const stopCall = vi.mocked(utils.runInteractive).mock.calls.find(call => call[1][0] === 'stop');
+    const startCall = vi.mocked(utils.runInteractive).mock.calls.find(call => call[1][0] === 'start');
 
     expect(stopCall).toBeDefined();
     expect(startCall).toBeDefined();
     expect(vi.mocked(utils.isTcpPortOpen)).toHaveBeenCalledWith('127.0.0.1', 1933, 300);
     expect(vi.mocked(utils.isTcpPortOpen).mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(utils.maybeRun).mock.invocationCallOrder[
-        vi.mocked(utils.maybeRun).mock.calls.findIndex(call => call[2][0] === 'start')
+      vi.mocked(utils.runInteractive).mock.invocationCallOrder[
+        vi.mocked(utils.runInteractive).mock.calls.findIndex(call => call[1][0] === 'start')
       ],
     );
   });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -17,6 +17,7 @@ import {
   recallQueryRequestsWorkspaceContext,
   redactText,
   runCommand,
+  runInteractive,
   shellQuote,
   suggestedShellRc,
   uniqueUsefulWorkspaceTerms,
@@ -150,6 +151,17 @@ describe('runCommand guardrails', () => {
     const result = await runCommand(process.execPath, ['-e', script], {allowFailure: true, timeoutMs: 20});
     expect(result.exitCode).toBe(124);
     expect(result.stderr).toContain('timed out after 20ms');
+  });
+});
+
+describe('runInteractive', () => {
+  it('returns the child exit code', async () => {
+    expect(await runInteractive(process.execPath, ['-e', 'process.exit(0)'])).toBe(0);
+    expect(await runInteractive(process.execPath, ['-e', 'process.exit(3)'])).toBe(3);
+  });
+
+  it('resolves non-zero instead of hanging when the binary cannot be spawned', async () => {
+    expect(await runInteractive('threadnote-nonexistent-binary-xyz', ['--version'])).toBe(1);
   });
 });
 


### PR DESCRIPTION
Fixes the recall-index repair regression in 1.1.0 and finishes streaming the `threadnote update` flow.

1.1.0 reindexed every `[Directory ... not ready]` summary placeholder it found. But those placeholders only clear when OpenViking generates L0/L1 directory summaries, and threadnote's shipped `ov.conf` template disables that (`auto_generate_l0`/`l1` = false). `ov reindex` never regenerates summaries, so repair reindexed hundreds of scopes (~44s each) that could never converge, contended on tree locks under concurrent MCP servers, and spammed a useless per-failure health check that garbled the terminal. 1.1.0 also still buffered most of the `threadnote update` subprocesses, so they looked stuck and could hit the 10-minute command timeout.

What's changed:

- Gates the recall-index freshness scan on OpenViking summary auto-generation: when `auto_generate_l0`/`l1` are disabled, the "not ready" placeholders are expected and permanent, so repair, recall auto-repair, and `doctor` no longer treat them as stale or reindex them.
- Adds a consecutive-failure circuit breaker to recall-index repair and removes the per-failure health-check spam that interleaved with the progress spinner on tree-lock conflicts.
- `threadnote doctor` reports recall-index freshness as OK with a clear note when summary auto-generation is disabled, instead of a misleading "stale summaries" warning.
- Streams the entire `threadnote update` flow — package update, repair, post-update, pinned-OpenViking reinstall, server restart, and migrations — via `runInteractive` instead of buffered `maybeRun`, so nothing looks stuck and none of it is subject to the 10-minute command timeout.
- Hardens `runInteractive` to resolve non-zero on spawn error instead of hanging when a subprocess binary cannot be spawned.