### PR TITLE
1.1.1: compact, scope-intelligent recall

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -400,6 +400,7 @@ async function handleRequest(context: ApiContext, request: IncomingMessage, resp
           runRecall(context.config, {
             query: requireString(body.query, 'query'),
             nodeLimit: optionalString(body.nodeLimit),
+            project: optionalString(body.project),
           }),
         ),
       );

--- a/src/manager_ui.tsx
+++ b/src/manager_ui.tsx
@@ -166,6 +166,7 @@ function App(): React.ReactElement {
   const [toast, setToast] = useState('');
   const [output, setOutput] = useState('');
   const [recallQuery, setRecallQuery] = useState('');
+  const [recallProject, setRecallProject] = useState('');
   const [readUri, setReadUri] = useState('');
   const [compactProject, setCompactProject] = useState('');
   const [compactTopic, setCompactTopic] = useState('');
@@ -1139,10 +1140,18 @@ function App(): React.ReactElement {
                     onChange={event => setRecallQuery(event.target.value)}
                     placeholder="Search memories and seeded resources"
                   />
+                  <input
+                    value={recallProject}
+                    onChange={event => setRecallProject(event.target.value)}
+                    placeholder="project scope (blank = all)"
+                  />
                   <button
                     onClick={() =>
                       void runAction('Recall complete', () =>
-                        api('/api/recall', {query: recallQuery}).then(result => result as {output: string}),
+                        api('/api/recall', {
+                          query: recallQuery,
+                          ...(recallProject.trim() ? {project: recallProject.trim()} : {}),
+                        }).then(result => result as {output: string}),
                       )
                     }
                   >

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -782,11 +782,12 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
     indexRepairMessages = [`Auto-index repair warning: ${errorMessage(err)}`];
   }
   const contextualParams: RecallToolParams = {...params, query};
-  const semanticResult = await runOpenVikingMcpTool(config, 'search', {
-    limit: params.nodeLimit,
+  const semanticResult = await runOpenVikingTool(config, [
+    'search',
     query,
-    target_uri: params.pinnedUri,
-  });
+    ...(params.pinnedUri ? ['--uri', params.pinnedUri] : []),
+    ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),
+  ]);
   if (semanticResult.isError === true) {
     return semanticResult;
   }
@@ -865,15 +866,19 @@ async function seededResourcesSection(
   if (!projectResourceUri.startsWith('viking://')) {
     return undefined;
   }
-  const result = await runOpenVikingMcpTool(config, 'search', {
-    limit: params.nodeLimit,
-    query: params.query,
-    target_uri: projectResourceUri,
-  });
-  if (result.isError === true) {
+  const ov = await requiredOpenVikingCli();
+  const args = [
+    'search',
+    params.query,
+    '--uri',
+    projectResourceUri,
+    ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),
+  ];
+  const result = await runCommand(ov, withIdentity(config, args), {allowFailure: true});
+  if (result.exitCode !== 0) {
     return undefined;
   }
-  const body = filterStaleRecallSummaryRows(textFromCallToolResult(result));
+  const body = filterStaleRecallSummaryRows([result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n'));
   if (!body) {
     return undefined;
   }
@@ -889,13 +894,16 @@ async function exactMemoryMatchesText(
   if (terms.length === 0) {
     return undefined;
   }
+  const ov = await requiredOpenVikingCli();
   const scopes = exactMemoryScopes(config, includeArchived);
   const outputs: string[] = [];
   for (const term of terms) {
     for (const scope of scopes) {
-      const result = await runOpenVikingMcpTool(config, 'grep', {node_limit: 5, pattern: term, uri: scope});
-      const output = textFromCallToolResult(result);
-      if (result.isError !== true && grepOutputHasMatches(output)) {
+      const result = await runCommand(ov, withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5']), {
+        allowFailure: true,
+      });
+      const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
+      if (result.exitCode === 0 && grepOutputHasMatches(output)) {
         outputs.push(output);
       }
     }
@@ -1745,6 +1753,24 @@ async function runOpenVikingCliReadTool(config: RuntimeConfig, uri: string): Pro
   try {
     const ov = await requiredOpenVikingCli();
     const result = await runCommand(ov, withIdentity(config, ['read', uri]));
+    const text = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
+    return {content: [{type: 'text', text: text || 'OK'}]};
+  } catch (err: unknown) {
+    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+  }
+}
+
+/**
+ * Run an `ov` CLI subcommand and wrap its output as a CallToolResult. Used by
+ * the enriched recall path (`recall_context`) so semantic search returns the
+ * compact ranked list (URI + score + short snippet) instead of the native
+ * `/mcp` search, which returns full Level-2 bodies and bloats recall ~15x.
+ * Goes through `runCommand` (no-shell `execFile`), so it stays injection-safe.
+ */
+async function runOpenVikingTool(config: RuntimeConfig, args: readonly string[]): Promise<CallToolResult> {
+  try {
+    const ov = await requiredOpenVikingCli();
+    const result = await runCommand(ov, withIdentity(config, args));
     const text = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
     return {content: [{type: 'text', text: text || 'OK'}]};
   } catch (err: unknown) {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -160,7 +160,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
     server,
     config,
     'recall_context',
-    'Search Threadnote context across personal memories and seeded project resources. Returns semantic hits from indexed Threadnote context (handoffs, durable feature memories, preferences, shared team memories) — and, when the query mentions a project name from the seed manifest, also from that project\'s seeded guidance (README, AGENTS.md, CLAUDE.md, SKILL.md, docs/**) under viking://resources/repos/<project>. Queries that mention this/current branch are enriched with local git/workspace terms when callerCwd is provided. Include the repo or project name in the query to make the project-guidance pass fire. Required: pass JSON arguments with a non-empty query, for example {"query":"unity-ui-ccc latest handoff"}.',
+    'Search Threadnote context across personal memories and seeded project resources. Returns semantic hits from indexed Threadnote context (handoffs, durable feature memories, preferences, shared team memories) — and, when the query mentions a project name from the seed manifest, also from that project\'s seeded guidance (README, AGENTS.md, CLAUDE.md, SKILL.md, docs/**) under viking://resources/repos/<project>. Queries that mention this/current branch are enriched with local git/workspace terms when callerCwd is provided. Include the repo or project name in the query to make the project-guidance pass fire. Results are filtered by a default relevance threshold (0.5); if a recall comes back empty or too sparse, retry with a lower threshold (e.g. {"query":"...","threshold":0.2}) to broaden. Required: pass JSON arguments with a non-empty query, for example {"query":"unity-ui-ccc latest handoff"}.',
   );
   registerSearchTool(
     server,
@@ -730,9 +730,17 @@ function registerSearchTool(server: McpServer, config: RuntimeConfig, name: stri
           .describe('Optional absolute caller workspace path used to resolve this/current branch queries'),
         nodeLimit: z.number().int().positive().max(100).optional().describe('Maximum result count'),
         includeArchived: z.boolean().optional().describe('Include archived memories in exact memory/resource matches'),
+        threshold: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe(
+            'Minimum relevance score 0-1 (default 0.5); lower it (toward 0) to broaden when a recall comes back empty',
+          ),
       },
     },
-    async ({callerCwd, includeArchived, nodeLimit, query, uri}) => {
+    async ({callerCwd, includeArchived, nodeLimit, query, threshold, uri}) => {
       const checkedQuery = requiredText(query, name, 'query', {query: 'unity-ui-ccc latest handoff'});
       if (!checkedQuery.ok) {
         return checkedQuery.error;
@@ -747,6 +755,7 @@ function registerSearchTool(server: McpServer, config: RuntimeConfig, name: stri
         pinnedUri: checkedUri.value,
         nodeLimit,
         includeArchived: includeArchived === true,
+        threshold: threshold === undefined ? undefined : String(threshold),
       });
     },
   );
@@ -758,6 +767,7 @@ interface RecallToolParams {
   readonly nodeLimit: number | undefined;
   readonly pinnedUri: string | undefined;
   readonly query: string;
+  readonly threshold: string | undefined;
 }
 
 async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): Promise<CallToolResult> {
@@ -788,14 +798,26 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   }
   const contextualParams: RecallToolParams = {...params, query};
   const project = params.pinnedUri ? undefined : await inferProjectFromQuery(config.manifestPath, projectQuery);
-  const semanticResult = await runOpenVikingTool(config, [
+  const pinnedArgs = params.pinnedUri ? ['--uri', params.pinnedUri] : [];
+  const limitArgs = params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : [];
+  // --level 2 keeps real Level-2 content and drops the L0/L1 ".overview"/
+  // ".abstract" summary sidecars (permanent "[not ready]" placeholders when
+  // auto-generation is off), which are noise in recall.
+  let semanticResult = await runOpenVikingTool(config, [
     'search',
     query,
     '--threshold',
-    RECALL_SCORE_THRESHOLD,
-    ...(params.pinnedUri ? ['--uri', params.pinnedUri] : []),
-    ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),
+    params.threshold ?? RECALL_SCORE_THRESHOLD,
+    '--level',
+    '2',
+    ...pinnedArgs,
+    ...limitArgs,
   ]);
+  if (semanticResult.isError === true) {
+    // Older ov builds may not support --threshold/--level; degrade to a plain
+    // search so one unsupported flag does not abort the entire recall.
+    semanticResult = await runOpenVikingTool(config, ['search', query, ...pinnedArgs, ...limitArgs]);
+  }
   if (semanticResult.isError === true) {
     return semanticResult;
   }
@@ -875,7 +897,9 @@ async function seededResourcesSection(
     'search',
     params.query,
     '--threshold',
-    RECALL_SCORE_THRESHOLD,
+    params.threshold ?? RECALL_SCORE_THRESHOLD,
+    '--level',
+    '2',
     '--uri',
     projectResourceUri,
     ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -12,6 +12,7 @@ import {z} from 'zod';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {filterStaleRecallSummaryRows, formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
 import {inferProjectFromQuery} from './manifest.js';
+import type {ProjectManifest} from './types.js';
 import {
   activePersonalMemoryUrisFromText,
   type ArchiveAction,
@@ -39,14 +40,18 @@ import {
   writeMemoryFile,
 } from './share.js';
 import {
+  collectExactMatches,
   errorMessage,
   enrichRecallQueryWithWorkspaceContext,
   enrichRecallQueryWithWorkspaceProjectContext,
+  exactMemoryScopeUris,
+  exactRecallScopeIntents,
   exactRecallTerms,
   expandPath,
   findExecutable,
-  grepOutputHasMatches,
+  formatExactMatchPointers,
   parsePort,
+  RECALL_SCORE_THRESHOLD,
   runCommand,
   safeTimestamp,
   sha256,
@@ -782,9 +787,12 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
     indexRepairMessages = [`Auto-index repair warning: ${errorMessage(err)}`];
   }
   const contextualParams: RecallToolParams = {...params, query};
+  const project = params.pinnedUri ? undefined : await inferProjectFromQuery(config.manifestPath, projectQuery);
   const semanticResult = await runOpenVikingTool(config, [
     'search',
     query,
+    '--threshold',
+    RECALL_SCORE_THRESHOLD,
     ...(params.pinnedUri ? ['--uri', params.pinnedUri] : []),
     ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),
   ]);
@@ -804,13 +812,13 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   if (indexRepairMessages.length > 0) {
     sections.push(indexRepairMessages.join('\n'));
   }
-  const seededSection = await seededResourcesSection(config, contextualParams, projectQuery);
+  const seededSection = await seededResourcesSection(config, contextualParams, project);
   if (seededSection) {
     sections.push(seededSection);
   }
-  const exactMatches = await exactMemoryMatchesText(config, query, params.includeArchived);
+  const exactMatches = await exactMemoryMatchesText(config, query, params.includeArchived, project);
   if (exactMatches) {
-    sections.push(`Exact memory/resource matches:\n${exactMatches}`);
+    sections.push(exactMatches);
   }
   const hygieneHints = await recallHygieneHintsSection(config, sections.join('\n\n'));
   if (hygieneHints) {
@@ -853,13 +861,9 @@ async function recallHygieneHintsSection(config: RuntimeConfig, recallText: stri
 async function seededResourcesSection(
   config: RuntimeConfig,
   params: RecallToolParams,
-  projectQuery: string,
+  project: ProjectManifest | undefined,
 ): Promise<string | undefined> {
-  if (params.pinnedUri) {
-    return undefined;
-  }
-  const project = await inferProjectFromQuery(config.manifestPath, projectQuery);
-  if (!project) {
+  if (params.pinnedUri || !project) {
     return undefined;
   }
   const projectResourceUri = trimTrailingSlash(project.uri);
@@ -870,6 +874,8 @@ async function seededResourcesSection(
   const args = [
     'search',
     params.query,
+    '--threshold',
+    RECALL_SCORE_THRESHOLD,
     '--uri',
     projectResourceUri,
     ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),
@@ -889,26 +895,23 @@ async function exactMemoryMatchesText(
   config: RuntimeConfig,
   query: string,
   includeArchived: boolean,
+  project: ProjectManifest | undefined,
 ): Promise<string | undefined> {
   const terms = exactRecallTerms(query);
   if (terms.length === 0) {
     return undefined;
   }
   const ov = await requiredOpenVikingCli();
-  const scopes = exactMemoryScopes(config, includeArchived);
-  const outputs: string[] = [];
-  for (const term of terms) {
-    for (const scope of scopes) {
-      const result = await runCommand(ov, withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5']), {
-        allowFailure: true,
-      });
-      const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
-      if (result.exitCode === 0 && grepOutputHasMatches(output)) {
-        outputs.push(output);
-      }
-    }
-  }
-  return outputs.length > 0 ? outputs.join('\n\n') : undefined;
+  const scopes = exactMemoryScopes(config, includeArchived, query, project);
+  const matches = await collectExactMatches(terms, scopes, async (term, scope) => {
+    const result = await runCommand(
+      ov,
+      withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5', '--output', 'json']),
+      {allowFailure: true},
+    );
+    return result.exitCode === 0 ? result.stdout : undefined;
+  });
+  return formatExactMatchPointers(matches);
 }
 
 function registerReadTool(server: McpServer, config: RuntimeConfig, name: string, description: string): void {
@@ -1533,23 +1536,20 @@ function vikingDirectoryChain(directoryUri: string): readonly string[] {
   return chain;
 }
 
-function exactMemoryScopes(config: RuntimeConfig, includeArchived: boolean): readonly string[] {
-  const userBase = `viking://user/${uriSegment(config.user)}/memories`;
-  const scopes = [
-    `${userBase}/preferences`,
-    `${userBase}/durable/projects`,
-    `${userBase}/handoffs/active`,
-    `${userBase}/incidents/active`,
-    `${userBase}/shared`,
-    `viking://agent/${uriSegment(config.agentId)}/memories`,
-    // Seeded project resources live outside the user/memories tree. Include
-    // them so exact-term grep surfaces matches in seeded READMEs, AGENTS.md,
-    // SKILL.md, and docs/** alongside personal memory hits.
-    'viking://resources/repos',
-  ];
-  return includeArchived
-    ? [...scopes, `${userBase}/durable/archived`, `${userBase}/handoffs/archived`, `${userBase}/incidents/archived`]
-    : scopes;
+function exactMemoryScopes(
+  config: RuntimeConfig,
+  includeArchived: boolean,
+  query: string,
+  project: ProjectManifest | undefined,
+): readonly string[] {
+  return exactMemoryScopeUris({
+    agentMemoriesUri: `viking://agent/${uriSegment(config.agentId)}/memories`,
+    includeArchived,
+    intents: exactRecallScopeIntents(query),
+    projectName: project ? uriSegment(project.name) : undefined,
+    projectResourceUri: project ? trimTrailingSlash(project.uri) : undefined,
+    userBase: `viking://user/${uriSegment(config.user)}/memories`,
+  });
 }
 
 function formatMemoryDocument(title: 'MEMORY', metadata: MemoryMetadata, body: string): string {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -818,18 +818,22 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
     // search so one unsupported flag does not abort the entire recall.
     semanticResult = await runOpenVikingTool(config, ['search', query, ...pinnedArgs, ...limitArgs]);
   }
-  if (semanticResult.isError === true) {
-    return semanticResult;
-  }
-  const [firstContent] = semanticResult.content;
-  if (firstContent?.type !== 'text') {
-    return semanticResult;
-  }
+  const firstContent = semanticResult.content[0];
+  const semanticRaw = firstContent?.type === 'text' ? firstContent.text : '';
+  const semanticOk = semanticResult.isError !== true && firstContent?.type === 'text';
   const sections: string[] = [];
-  const semanticText = filterStaleRecallSummaryRows(firstContent.text);
-  const filteredSemanticText = semanticText !== firstContent.text.trim();
-  if (semanticText) {
-    sections.push(semanticText);
+  let filteredSemanticText = false;
+  if (semanticOk) {
+    const semanticText = filterStaleRecallSummaryRows(semanticRaw);
+    filteredSemanticText = semanticText !== semanticRaw.trim();
+    if (semanticText) {
+      sections.push(semanticText);
+    }
+  } else {
+    // Semantic search failed even after the plain fallback (e.g. ov is down).
+    // Degrade rather than abort: note it and still run seeded/exact so any
+    // available context is returned, matching the CLI recall path.
+    sections.push(`Recall semantic search unavailable: ${semanticRaw.trim() || 'ov search failed'}`);
   }
   if (indexRepairMessages.length > 0) {
     sections.push(indexRepairMessages.join('\n'));
@@ -852,10 +856,12 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   for (const warning of syncWarnings) {
     sections.push(`Auto-sync warning: ${warning}`);
   }
+  // Nothing beyond the (possibly failed) semantic section — return the raw
+  // result so a genuine failure still surfaces as isError to the caller.
   if (sections.length <= 1 && !filteredSemanticText) {
     return semanticResult;
   }
-  return {...semanticResult, content: [{type: 'text', text: sections.join('\n\n')}]};
+  return {content: [{type: 'text', text: sections.join('\n\n')}], isError: false};
 }
 
 async function recallHygieneHintsSection(config: RuntimeConfig, recallText: string): Promise<string | undefined> {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -10,7 +10,7 @@ import {homedir} from 'node:os';
 import {join} from 'node:path';
 import {z} from 'zod';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
-import {filterStaleRecallSummaryRows, formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
+import {formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
 import {inferProjectFromQuery} from './manifest.js';
 import type {ProjectManifest} from './types.js';
 import {
@@ -50,7 +50,11 @@ import {
   expandPath,
   findExecutable,
   formatExactMatchPointers,
+  formatRecallHits,
+  mergeRecallHits,
   parsePort,
+  parseRecallHits,
+  type RecallHit,
   RECALL_SCORE_THRESHOLD,
   runCommand,
   safeTimestamp,
@@ -796,51 +800,37 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   } catch (err: unknown) {
     indexRepairMessages = [`Auto-index repair warning: ${errorMessage(err)}`];
   }
-  const contextualParams: RecallToolParams = {...params, query};
   const project = params.pinnedUri ? undefined : await inferProjectFromQuery(config.manifestPath, projectQuery);
-  const pinnedArgs = params.pinnedUri ? ['--uri', params.pinnedUri] : [];
   const limitArgs = params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : [];
-  // --level 2 keeps real Level-2 content and drops the L0/L1 ".overview"/
-  // ".abstract" summary sidecars (permanent "[not ready]" placeholders when
-  // auto-generation is off), which are noise in recall.
-  let semanticResult = await runOpenVikingTool(config, [
-    'search',
-    query,
-    '--threshold',
-    params.threshold ?? RECALL_SCORE_THRESHOLD,
-    '--level',
-    '2',
-    ...pinnedArgs,
-    ...limitArgs,
-  ]);
-  if (semanticResult.isError === true) {
-    // Older ov builds may not support --threshold/--level; degrade to a plain
-    // search so one unsupported flag does not abort the entire recall.
-    semanticResult = await runOpenVikingTool(config, ['search', query, ...pinnedArgs, ...limitArgs]);
+  const threshold = params.threshold ?? RECALL_SCORE_THRESHOLD;
+  // Run the global base pass plus a seeded project pass, then merge into one
+  // deduped ranked list (per document, chunk anchors stripped) so the seeded
+  // pass only adds project docs the base missed. --level 2 keeps Level-2
+  // content and drops the L0/L1 .overview/.abstract summary sidecars.
+  const pinnedArgs = params.pinnedUri ? ['--uri', params.pinnedUri] : [];
+  const base = await recallSearchHits(config, ['search', query, ...pinnedArgs, ...limitArgs], threshold);
+  const passes: Array<readonly RecallHit[]> = [base.hits];
+  const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
+  if (seededUri?.startsWith('viking://') && seededUri !== params.pinnedUri) {
+    const seeded = await recallSearchHits(
+      config,
+      ['search', params.query, '--uri', seededUri, ...limitArgs],
+      threshold,
+    );
+    passes.push(seeded.hits);
   }
-  const firstContent = semanticResult.content[0];
-  const semanticRaw = firstContent?.type === 'text' ? firstContent.text : '';
-  const semanticOk = semanticResult.isError !== true && firstContent?.type === 'text';
+
   const sections: string[] = [];
-  let filteredSemanticText = false;
-  if (semanticOk) {
-    const semanticText = filterStaleRecallSummaryRows(semanticRaw);
-    filteredSemanticText = semanticText !== semanticRaw.trim();
-    if (semanticText) {
-      sections.push(semanticText);
-    }
-  } else {
-    // Semantic search failed even after the plain fallback (e.g. ov is down).
-    // Degrade rather than abort: note it and still run seeded/exact so any
-    // available context is returned, matching the CLI recall path.
-    sections.push(`Recall semantic search unavailable: ${semanticRaw.trim() || 'ov search failed'}`);
+  const semanticSection = formatRecallHits(mergeRecallHits(passes), params.nodeLimit ?? 12);
+  if (semanticSection) {
+    sections.push(semanticSection);
+  } else if (!base.ok) {
+    // Semantic search failed even after the plain fallback (e.g. ov down).
+    // Degrade rather than abort: note it and still run exact below.
+    sections.push(`Recall semantic search unavailable: ${base.errorText || 'ov search failed'}`);
   }
   if (indexRepairMessages.length > 0) {
     sections.push(indexRepairMessages.join('\n'));
-  }
-  const seededSection = await seededResourcesSection(config, contextualParams, project);
-  if (seededSection) {
-    sections.push(seededSection);
   }
   const exactMatches = await exactMemoryMatchesText(config, query, params.includeArchived, project);
   if (exactMatches) {
@@ -856,12 +846,41 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   for (const warning of syncWarnings) {
     sections.push(`Auto-sync warning: ${warning}`);
   }
-  // Nothing beyond the (possibly failed) semantic section — return the raw
-  // result so a genuine failure still surfaces as isError to the caller.
-  if (sections.length <= 1 && !filteredSemanticText) {
-    return semanticResult;
+  if (sections.length === 0) {
+    return {content: [{type: 'text', text: 'No recall results found.'}]};
   }
-  return {content: [{type: 'text', text: sections.join('\n\n')}], isError: false};
+  const onlyErrorNote = !base.ok && !semanticSection && sections.length === 1;
+  return {content: [{type: 'text', text: sections.join('\n\n')}], isError: onlyErrorNote || undefined};
+}
+
+/**
+ * Run one recall search pass with `--output json` via the ov CLI and return
+ * parsed hits, falling back to a plain search (no --threshold/--level) on a
+ * non-zero exit so an older ov does not fail the recall.
+ */
+async function recallSearchHits(
+  config: RuntimeConfig,
+  searchArgs: readonly string[],
+  threshold: string,
+): Promise<{readonly errorText: string; readonly hits: readonly RecallHit[]; readonly ok: boolean}> {
+  let result = await runOpenVikingTool(config, [
+    ...searchArgs,
+    '--threshold',
+    threshold,
+    '--level',
+    '2',
+    '--output',
+    'json',
+  ]);
+  if (result.isError === true) {
+    result = await runOpenVikingTool(config, [...searchArgs, '--output', 'json']);
+  }
+  const firstContent = result.content[0];
+  const text = firstContent?.type === 'text' ? firstContent.text : '';
+  if (result.isError === true) {
+    return {errorText: text.trim(), hits: [], ok: false};
+  }
+  return {errorText: '', hits: parseRecallHits(text), ok: true};
 }
 
 async function recallHygieneHintsSection(config: RuntimeConfig, recallText: string): Promise<string | undefined> {
@@ -872,53 +891,6 @@ async function recallHygieneHintsSection(config: RuntimeConfig, recallText: stri
   const records = await readMemoryRecordsByUri(config, uris);
   const nudges = recallHygieneNudges(recallText, {records, user: config.user});
   return nudges.length > 0 ? ['Memory hygiene hints:', ...nudges.map(nudge => `- ${nudge}`)].join('\n') : undefined;
-}
-
-/**
- * Runs a second `ov search` scoped to the seeded project's resources when the
- * query mentions a project name from the manifest. The base semantic search
- * tends to rank memory-shaped hits above seeded READMEs/AGENTS.md/SKILL.md, so
- * this parallel pass guarantees that seeded guidance surfaces alongside
- * memories on every agent's recall — not only Claude's via the SessionStart
- * hook. Skipped when the caller pinned a URI (they asked for that scope;
- * honor it). The MCP server doesn't currently do scope inference of its own
- * the way the CLI's `runRecall` does, so there's no `inferredUri`-vs-
- * `projectResourceUri` dedupe check here — if MCP later grows inference, mirror
- * the CLI's `augmentRecallWithSeededResources` guard.
- */
-async function seededResourcesSection(
-  config: RuntimeConfig,
-  params: RecallToolParams,
-  project: ProjectManifest | undefined,
-): Promise<string | undefined> {
-  if (params.pinnedUri || !project) {
-    return undefined;
-  }
-  const projectResourceUri = trimTrailingSlash(project.uri);
-  if (!projectResourceUri.startsWith('viking://')) {
-    return undefined;
-  }
-  const ov = await requiredOpenVikingCli();
-  const args = [
-    'search',
-    params.query,
-    '--threshold',
-    params.threshold ?? RECALL_SCORE_THRESHOLD,
-    '--level',
-    '2',
-    '--uri',
-    projectResourceUri,
-    ...(params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : []),
-  ];
-  const result = await runCommand(ov, withIdentity(config, args), {allowFailure: true});
-  if (result.exitCode !== 0) {
-    return undefined;
-  }
-  const body = filterStaleRecallSummaryRows([result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n'));
-  if (!body) {
-    return undefined;
-  }
-  return `Seeded project resources (${projectResourceUri}):\n${body}`;
 }
 
 async function exactMemoryMatchesText(

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -25,6 +25,7 @@ import type {
   MemoryStatus,
   MigrateMemoriesOptions,
   PackOptions,
+  ProjectManifest,
   ReadOptions,
   RecallOptions,
   RememberOptions,
@@ -35,17 +36,21 @@ import {
   enrichRecallQueryWithWorkspaceContext,
   enrichRecallQueryWithWorkspaceProjectContext,
   expandPath,
+  exactMemoryScopeUris,
+  exactRecallScopeIntents,
   exactRecallTerms,
+  collectExactMatches,
+  formatExactMatchPointers,
   formatShellCommand,
   getInputText,
   getInvocationCwd,
   gitValue,
-  grepOutputHasMatches,
   isJsonObject,
   maybeRun,
   openVikingCliForMode,
   parentVikingUri,
   parsePositiveInteger,
+  RECALL_SCORE_THRESHOLD,
   resolveRepoName,
   runCommand,
   safeTimestamp,
@@ -304,7 +309,8 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   }
   const inferredUri =
     options.uri ?? (options.inferScope === false ? undefined : await inferRecallUri(config, projectQuery));
-  const args = ['search', query];
+  const project = await inferProjectFromQuery(config.manifestPath, options.project ?? projectQuery);
+  const args = ['search', query, '--threshold', RECALL_SCORE_THRESHOLD];
   if (inferredUri) {
     args.push('--uri', inferredUri);
     console.log(`Recall scope: ${inferredUri}`);
@@ -317,19 +323,14 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   if (baseOutput) {
     recallOutputs.push(baseOutput);
   }
-  const seededOutput = await augmentRecallWithSeededResources(
-    config,
-    ov,
-    {...options, query},
-    inferredUri,
-    projectQuery,
-  );
+  const seededOutput = await augmentRecallWithSeededResources(config, ov, {...options, query}, inferredUri, project);
   if (seededOutput) {
     recallOutputs.push(seededOutput);
   }
   const exactOutput = await printExactMemoryMatches(config, ov, query, {
     dryRun: options.dryRun === true,
     includeArchived: options.includeArchived === true,
+    project,
   });
   if (exactOutput) {
     recallOutputs.push(exactOutput);
@@ -354,24 +355,20 @@ async function augmentRecallWithSeededResources(
   ov: string,
   options: RecallOptions,
   inferredUri: string | undefined,
-  projectQuery = options.query,
+  project: ProjectManifest | undefined,
 ): Promise<string | undefined> {
   // `--no-infer-scope` (options.inferScope === false) disables the base scope
   // inference; honoring it here too keeps the flag's meaning consistent —
   // augmenting with a project-scoped search would silently re-introduce what
   // the user disabled. A caller-pinned --uri is also explicit intent we honor.
-  if (options.uri || options.inferScope === false) {
-    return undefined;
-  }
-  const project = await inferProjectFromQuery(config.manifestPath, projectQuery);
-  if (!project) {
+  if (options.uri || options.inferScope === false || !project) {
     return undefined;
   }
   const projectResourceUri = trimTrailingSlash(project.uri);
   if (!projectResourceUri.startsWith('viking://') || projectResourceUri === inferredUri) {
     return undefined;
   }
-  const args = ['search', options.query, '--uri', projectResourceUri];
+  const args = ['search', options.query, '--threshold', RECALL_SCORE_THRESHOLD, '--uri', projectResourceUri];
   if (options.nodeLimit) {
     args.push('--node-limit', String(parsePositiveInteger(options.nodeLimit, 'node limit')));
   }
@@ -777,35 +774,31 @@ async function printExactMemoryMatches(
   config: RuntimeConfig,
   ov: string,
   query: string,
-  options: {readonly dryRun: boolean; readonly includeArchived: boolean},
+  options: {readonly dryRun: boolean; readonly includeArchived: boolean; readonly project: ProjectManifest | undefined},
 ): Promise<string | undefined> {
   const terms = exactRecallTerms(query);
   if (terms.length === 0) {
     return undefined;
   }
-  const scopes = exactMemoryScopes(config, options.includeArchived);
-  const outputs: string[] = [];
-  for (const term of terms) {
-    for (const scope of scopes) {
-      const args = withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5']);
-      if (options.dryRun) {
-        outputs.push(formatShellCommand(ov, args));
-        continue;
-      }
-      const result = await runCommand(ov, args, {allowFailure: true});
-      const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
-      if (result.exitCode === 0 && grepOutputHasMatches(output)) {
-        outputs.push(output);
-      }
-    }
+  const scopes = exactMemoryScopes(config, options.includeArchived, query, options.project);
+  const grepArgs = (term: string, scope: string): readonly string[] =>
+    withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5', '--output', 'json']);
+  if (options.dryRun) {
+    const planned = terms.flatMap(term => scopes.map(scope => formatShellCommand(ov, grepArgs(term, scope))));
+    console.log('\nExact memory/resource matches:');
+    console.log(planned.join('\n'));
+    return planned.join('\n');
   }
-  if (outputs.length === 0) {
+  const matches = await collectExactMatches(terms, scopes, async (term, scope) => {
+    const result = await runCommand(ov, grepArgs(term, scope), {allowFailure: true});
+    return result.exitCode === 0 ? result.stdout : undefined;
+  });
+  const text = formatExactMatchPointers(matches);
+  if (!text) {
     return undefined;
   }
-  console.log('\nExact memory/resource matches:');
-  const output = outputs.join('\n\n');
-  console.log(output);
-  return output;
+  console.log(`\n${text}`);
+  return text;
 }
 
 async function storeMemory(config: RuntimeConfig, options: StoreMemoryOptions): Promise<void> {
@@ -1045,23 +1038,20 @@ function lifecycleMigrationUri(config: RuntimeConfig, metadata: MemoryMetadata, 
   return `${memoryDirectoryUri(config, metadata)}/legacy-${hash.slice(0, 16)}.md`;
 }
 
-function exactMemoryScopes(config: RuntimeConfig, includeArchived: boolean): readonly string[] {
-  const userBase = `viking://user/${uriSegment(config.user)}/memories`;
-  const scopes = [
-    `${userBase}/preferences`,
-    `${userBase}/durable/projects`,
-    `${userBase}/handoffs/active`,
-    `${userBase}/incidents/active`,
-    `${userBase}/shared`,
-    `viking://agent/${uriSegment(config.agentId)}/memories`,
-    // Seeded project resources (READMEs, AGENTS.md, SKILL.md, docs/**) live
-    // under viking://resources/repos/<project>. Include them so an exact-term
-    // grep in a recall surfaces matches in seeded guidance, not only memories.
-    'viking://resources/repos',
-  ];
-  return includeArchived
-    ? [...scopes, `${userBase}/durable/archived`, `${userBase}/handoffs/archived`, `${userBase}/incidents/archived`]
-    : scopes;
+function exactMemoryScopes(
+  config: RuntimeConfig,
+  includeArchived: boolean,
+  query: string,
+  project: ProjectManifest | undefined,
+): readonly string[] {
+  return exactMemoryScopeUris({
+    agentMemoriesUri: `viking://agent/${uriSegment(config.agentId)}/memories`,
+    includeArchived,
+    intents: exactRecallScopeIntents(query),
+    projectName: project ? uriSegment(project.name) : undefined,
+    projectResourceUri: project ? trimTrailingSlash(project.uri) : undefined,
+    userBase: `viking://user/${uriSegment(config.user)}/memories`,
+  });
 }
 
 function memoryUriFor(config: RuntimeConfig, memory: string, metadata: MemoryMetadata): string {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -310,7 +310,7 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   const inferredUri =
     options.uri ?? (options.inferScope === false ? undefined : await inferRecallUri(config, projectQuery));
   const project = await inferProjectFromQuery(config.manifestPath, options.project ?? projectQuery);
-  const args = ['search', query, '--threshold', RECALL_SCORE_THRESHOLD];
+  const args = ['search', query, '--threshold', options.threshold ?? RECALL_SCORE_THRESHOLD, '--level', '2'];
   if (inferredUri) {
     args.push('--uri', inferredUri);
     console.log(`Recall scope: ${inferredUri}`);
@@ -368,7 +368,16 @@ async function augmentRecallWithSeededResources(
   if (!projectResourceUri.startsWith('viking://') || projectResourceUri === inferredUri) {
     return undefined;
   }
-  const args = ['search', options.query, '--threshold', RECALL_SCORE_THRESHOLD, '--uri', projectResourceUri];
+  const args = [
+    'search',
+    options.query,
+    '--threshold',
+    options.threshold ?? RECALL_SCORE_THRESHOLD,
+    '--level',
+    '2',
+    '--uri',
+    projectResourceUri,
+  ];
   if (options.nodeLimit) {
     args.push('--node-limit', String(parsePositiveInteger(options.nodeLimit, 'node limit')));
   }
@@ -387,12 +396,33 @@ async function runRecallSearch(
   if (options.dryRun) {
     return undefined;
   }
-  const result = await runCommand(ov, fullArgs);
+  let result = await runCommand(ov, fullArgs, {allowFailure: true});
+  if (result.exitCode !== 0) {
+    // Older ov builds may not support --threshold/--level; retry without them
+    // rather than failing the whole recall.
+    result = await runCommand(ov, withIdentity(config, stripAdvancedSearchFlags(args)), {allowFailure: true});
+  }
+  if (result.exitCode !== 0) {
+    console.log(`WARN recall search failed: ${result.stderr.trim() || result.stdout.trim() || 'ov search error'}`);
+    return undefined;
+  }
   const output = filterStaleRecallSummaryRows([result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n'));
   if (output) {
     console.log(output);
   }
   return output || undefined;
+}
+
+function stripAdvancedSearchFlags(args: readonly string[]): readonly string[] {
+  const stripped: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === '--threshold' || args[index] === '--level') {
+      index += 1;
+      continue;
+    }
+    stripped.push(args[index]);
+  }
+  return stripped;
 }
 
 export async function runRead(config: RuntimeConfig, uri: string, options: ReadOptions): Promise<void> {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,7 +1,7 @@
 import {chmod, readFile, readdir, rm, stat, writeFile} from 'node:fs/promises';
 import {basename, join, sep} from 'node:path';
 import {inferProjectFromQuery, uriSegment} from './manifest.js';
-import {filterStaleRecallSummaryRows, formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
+import {formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
 import {
   activePersonalMemoryUrisFromText,
   buildCompactPlan,
@@ -41,15 +41,19 @@ import {
   exactRecallTerms,
   collectExactMatches,
   formatExactMatchPointers,
+  formatRecallHits,
   formatShellCommand,
   getInputText,
   getInvocationCwd,
   gitValue,
   isJsonObject,
   maybeRun,
+  mergeRecallHits,
   openVikingCliForMode,
   parentVikingUri,
   parsePositiveInteger,
+  parseRecallHits,
+  type RecallHit,
   RECALL_SCORE_THRESHOLD,
   resolveRepoName,
   runCommand,
@@ -307,32 +311,47 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   for (const message of indexRepairMessages) {
     console.log(message);
   }
+  const dryRun = options.dryRun === true;
   const inferredUri =
     options.uri ?? (options.inferScope === false ? undefined : await inferRecallUri(config, projectQuery));
   const project = await inferProjectFromQuery(config.manifestPath, options.project ?? projectQuery);
-  const args = ['search', query, '--threshold', options.threshold ?? RECALL_SCORE_THRESHOLD, '--level', '2'];
+  const nodeLimit = options.nodeLimit ? parsePositiveInteger(options.nodeLimit, 'node limit') : undefined;
+  const searchArgs = (scopeUri: string | undefined): readonly string[] => [
+    'search',
+    query,
+    '--threshold',
+    options.threshold ?? RECALL_SCORE_THRESHOLD,
+    '--level',
+    '2',
+    ...(scopeUri ? ['--uri', scopeUri] : []),
+    ...(nodeLimit ? ['--node-limit', String(nodeLimit)] : []),
+  ];
+
+  // Run the global base pass plus any scoped passes, then merge into one
+  // deduped ranked list so resources/memories the base already surfaced are not
+  // repeated by the scoped passes (and multiple chunks of one document collapse
+  // to a single entry).
   if (inferredUri) {
-    args.push('--uri', inferredUri);
     console.log(`Recall scope: ${inferredUri}`);
   }
-  if (options.nodeLimit) {
-    args.push('--node-limit', String(parsePositiveInteger(options.nodeLimit, 'node limit')));
+  const passes: Array<readonly RecallHit[]> = [await recallSearchHits(config, ov, searchArgs(inferredUri), {dryRun})];
+  if (options.project && project) {
+    const projectMemoryUri = `viking://user/${uriSegment(config.user)}/memories/durable/projects/${uriSegment(project.name)}`;
+    passes.push(await recallSearchHits(config, ov, searchArgs(projectMemoryUri), {dryRun}));
   }
+  const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
+  if (seededUri?.startsWith('viking://') && seededUri !== inferredUri && !options.uri && options.inferScope !== false) {
+    passes.push(await recallSearchHits(config, ov, searchArgs(seededUri), {dryRun}));
+  }
+
   const recallOutputs: string[] = [];
-  const baseOutput = await runRecallSearch(config, ov, args, {dryRun: options.dryRun === true});
-  if (baseOutput) {
-    recallOutputs.push(baseOutput);
-  }
-  const projectMemoryOutput = await augmentRecallWithProjectMemories(config, ov, {...options, query}, project);
-  if (projectMemoryOutput) {
-    recallOutputs.push(projectMemoryOutput);
-  }
-  const seededOutput = await augmentRecallWithSeededResources(config, ov, {...options, query}, inferredUri, project);
-  if (seededOutput) {
-    recallOutputs.push(seededOutput);
+  const semanticSection = formatRecallHits(mergeRecallHits(passes), nodeLimit ?? 12);
+  if (semanticSection) {
+    console.log(`\n${semanticSection}`);
+    recallOutputs.push(semanticSection);
   }
   const exactOutput = await printExactMemoryMatches(config, ov, query, {
-    dryRun: options.dryRun === true,
+    dryRun,
     includeArchived: options.includeArchived === true,
     project,
   });
@@ -343,113 +362,34 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
 }
 
 /**
- * If the query mentions a seeded project, run a second search scoped to that
- * project's resources URI and print results below the base search. The base
- * search is biased toward memory-shaped vocabulary ("handoff", "durable") and
- * with a small node-limit it crowds out seeded README/AGENTS.md/SKILL.md
- * content — running a scoped pass guarantees that seeded guidance surfaces
- * alongside personal memories on every recall.
- *
- * Skips the augmentation when the caller pinned the search to a specific URI
- * (they asked for that scope; honor it) or when the inferred scope already
- * targets the same resources subtree (no need to duplicate).
+ * Run one recall search pass with `--output json` and return parsed hits.
+ * Falls back to a plain search (without --threshold/--level) on a non-zero
+ * exit so an older ov does not fail the whole recall. The merge in `runRecall`
+ * dedupes hits across passes, so scoped passes only contribute what the base
+ * pass missed.
  */
-/**
- * When the caller explicitly scopes recall to a project (the manager Project
- * field or `recall --project`), run an extra semantic pass over that project's
- * durable memories so project context is prioritized — without dropping the
- * global base pass that surfaces cross-project hits. A project merely inferred
- * from the workspace/query does NOT trigger this; only an explicit
- * `options.project` does.
- */
-async function augmentRecallWithProjectMemories(
-  config: RuntimeConfig,
-  ov: string,
-  options: RecallOptions,
-  project: ProjectManifest | undefined,
-): Promise<string | undefined> {
-  if (!options.project || !project) {
-    return undefined;
-  }
-  const scope = `viking://user/${uriSegment(config.user)}/memories/durable/projects/${uriSegment(project.name)}`;
-  const args = [
-    'search',
-    options.query,
-    '--threshold',
-    options.threshold ?? RECALL_SCORE_THRESHOLD,
-    '--level',
-    '2',
-    '--uri',
-    scope,
-  ];
-  if (options.nodeLimit) {
-    args.push('--node-limit', String(parsePositiveInteger(options.nodeLimit, 'node limit')));
-  }
-  console.log(`\nAlso searching ${project.name} project memories: ${scope}`);
-  return runRecallSearch(config, ov, args, {dryRun: options.dryRun === true});
-}
-
-async function augmentRecallWithSeededResources(
-  config: RuntimeConfig,
-  ov: string,
-  options: RecallOptions,
-  inferredUri: string | undefined,
-  project: ProjectManifest | undefined,
-): Promise<string | undefined> {
-  // `--no-infer-scope` (options.inferScope === false) disables the base scope
-  // inference; honoring it here too keeps the flag's meaning consistent —
-  // augmenting with a project-scoped search would silently re-introduce what
-  // the user disabled. A caller-pinned --uri is also explicit intent we honor.
-  if (options.uri || options.inferScope === false || !project) {
-    return undefined;
-  }
-  const projectResourceUri = trimTrailingSlash(project.uri);
-  if (!projectResourceUri.startsWith('viking://') || projectResourceUri === inferredUri) {
-    return undefined;
-  }
-  const args = [
-    'search',
-    options.query,
-    '--threshold',
-    options.threshold ?? RECALL_SCORE_THRESHOLD,
-    '--level',
-    '2',
-    '--uri',
-    projectResourceUri,
-  ];
-  if (options.nodeLimit) {
-    args.push('--node-limit', String(parsePositiveInteger(options.nodeLimit, 'node limit')));
-  }
-  console.log(`\nAlso searching seeded resources: ${projectResourceUri}`);
-  return runRecallSearch(config, ov, args, {dryRun: options.dryRun === true});
-}
-
-async function runRecallSearch(
+async function recallSearchHits(
   config: RuntimeConfig,
   ov: string,
   args: readonly string[],
   options: {readonly dryRun: boolean},
-): Promise<string | undefined> {
-  const fullArgs = withIdentity(config, args);
-  console.log(`${options.dryRun ? 'Would run' : 'Running'}: ${formatShellCommand(ov, fullArgs)}`);
+): Promise<readonly RecallHit[]> {
+  const jsonArgs = withIdentity(config, [...args, '--output', 'json']);
+  console.log(`${options.dryRun ? 'Would run' : 'Running'}: ${formatShellCommand(ov, jsonArgs)}`);
   if (options.dryRun) {
-    return undefined;
+    return [];
   }
-  let result = await runCommand(ov, fullArgs, {allowFailure: true});
+  let result = await runCommand(ov, jsonArgs, {allowFailure: true});
   if (result.exitCode !== 0) {
-    // Older ov builds may not support --threshold/--level; retry without them
-    // rather than failing the whole recall.
-    result = await runCommand(ov, withIdentity(config, stripAdvancedSearchFlags(args)), {allowFailure: true});
+    result = await runCommand(ov, withIdentity(config, [...stripAdvancedSearchFlags(args), '--output', 'json']), {
+      allowFailure: true,
+    });
   }
   if (result.exitCode !== 0) {
     console.log(`WARN recall search failed: ${result.stderr.trim() || result.stdout.trim() || 'ov search error'}`);
-    return undefined;
+    return [];
   }
-  const output = filterStaleRecallSummaryRows([result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n'));
-  if (output) {
-    console.log(output);
-  }
-  return output || undefined;
+  return parseRecallHits(result.stdout);
 }
 
 export function stripAdvancedSearchFlags(args: readonly string[]): readonly string[] {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -452,7 +452,7 @@ async function runRecallSearch(
   return output || undefined;
 }
 
-function stripAdvancedSearchFlags(args: readonly string[]): readonly string[] {
+export function stripAdvancedSearchFlags(args: readonly string[]): readonly string[] {
   const stripped: string[] = [];
   for (let index = 0; index < args.length; index += 1) {
     if (args[index] === '--threshold' || args[index] === '--level') {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -323,6 +323,10 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   if (baseOutput) {
     recallOutputs.push(baseOutput);
   }
+  const projectMemoryOutput = await augmentRecallWithProjectMemories(config, ov, {...options, query}, project);
+  if (projectMemoryOutput) {
+    recallOutputs.push(projectMemoryOutput);
+  }
   const seededOutput = await augmentRecallWithSeededResources(config, ov, {...options, query}, inferredUri, project);
   if (seededOutput) {
     recallOutputs.push(seededOutput);
@@ -350,6 +354,41 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
  * (they asked for that scope; honor it) or when the inferred scope already
  * targets the same resources subtree (no need to duplicate).
  */
+/**
+ * When the caller explicitly scopes recall to a project (the manager Project
+ * field or `recall --project`), run an extra semantic pass over that project's
+ * durable memories so project context is prioritized — without dropping the
+ * global base pass that surfaces cross-project hits. A project merely inferred
+ * from the workspace/query does NOT trigger this; only an explicit
+ * `options.project` does.
+ */
+async function augmentRecallWithProjectMemories(
+  config: RuntimeConfig,
+  ov: string,
+  options: RecallOptions,
+  project: ProjectManifest | undefined,
+): Promise<string | undefined> {
+  if (!options.project || !project) {
+    return undefined;
+  }
+  const scope = `viking://user/${uriSegment(config.user)}/memories/durable/projects/${uriSegment(project.name)}`;
+  const args = [
+    'search',
+    options.query,
+    '--threshold',
+    options.threshold ?? RECALL_SCORE_THRESHOLD,
+    '--level',
+    '2',
+    '--uri',
+    scope,
+  ];
+  if (options.nodeLimit) {
+    args.push('--node-limit', String(parsePositiveInteger(options.nodeLimit, 'node limit')));
+  }
+  console.log(`\nAlso searching ${project.name} project memories: ${scope}`);
+  return runRecallSearch(config, ov, args, {dryRun: options.dryRun === true});
+}
+
 async function augmentRecallWithSeededResources(
   config: RuntimeConfig,
   ov: string,

--- a/src/threadnote.ts
+++ b/src/threadnote.ts
@@ -353,7 +353,8 @@ async function main(): Promise<void> {
     .option('--include-archived', 'Include archived memories in exact memory/resource matches')
     .option('-n, --node-limit <count>', 'Maximum number of search results')
     .option('--no-infer-scope', 'Disable query-based scope inference')
-    .option('--threshold <score>', 'Minimum relevance score 0-1 (default 0.5); lower to broaden when recall is empty')
+    .option('--project <name>', 'Prioritize a project: add a scoped pass over its memories alongside the global search')
+    .option('--threshold <score>', 'Minimum relevance score 0-1 (default 0.45); lower to broaden when recall is empty')
     .option('--uri <uri>', 'Restrict search to a viking:// URI')
     .action(async (options: RecallOptions) => {
       await runRecall(getRuntimeConfig(program), options);

--- a/src/threadnote.ts
+++ b/src/threadnote.ts
@@ -353,6 +353,7 @@ async function main(): Promise<void> {
     .option('--include-archived', 'Include archived memories in exact memory/resource matches')
     .option('-n, --node-limit <count>', 'Maximum number of search results')
     .option('--no-infer-scope', 'Disable query-based scope inference')
+    .option('--threshold <score>', 'Minimum relevance score 0-1 (default 0.5); lower to broaden when recall is empty')
     .option('--uri <uri>', 'Restrict search to a viking:// URI')
     .action(async (options: RecallOptions) => {
       await runRecall(getRuntimeConfig(program), options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,7 @@ export interface RecallOptions {
   readonly nodeLimit?: string;
   readonly project?: string;
   readonly query: string;
+  readonly threshold?: string;
   readonly uri?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,7 @@ export interface RecallOptions {
   readonly inferScope?: boolean;
   readonly includeArchived?: boolean;
   readonly nodeLimit?: string;
+  readonly project?: string;
   readonly query: string;
   readonly uri?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -844,6 +844,97 @@ export interface ExactMatch {
   readonly uri: string;
 }
 
+export interface RecallHit {
+  readonly contextType: string;
+  readonly score: number;
+  readonly snippet: string;
+  readonly uri: string;
+}
+
+function recallSnippet(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const oneLine = value.replace(/\s+/g, ' ').trim();
+  return oneLine.length > 180 ? `${oneLine.slice(0, 180)}…` : oneLine;
+}
+
+/**
+ * Parse `ov search --output json` stdout into recall hits across the memories,
+ * resources, and skills result arrays, dropping summary sidecars and trimming
+ * each abstract to a short snippet. Tolerant of the leading `cmd:` banner and
+ * shape drift; returns [] on parse failure.
+ */
+export function parseRecallHits(output: string): readonly RecallHit[] {
+  const start = output.search(/^\{/m);
+  if (start < 0) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(output.slice(start));
+    const result = isJsonObject(parsed) ? parsed.result : undefined;
+    if (!isJsonObject(result)) {
+      return [];
+    }
+    const hits: RecallHit[] = [];
+    for (const key of ['memories', 'resources', 'skills']) {
+      const items = result[key];
+      if (!Array.isArray(items)) {
+        continue;
+      }
+      for (const item of items) {
+        if (!isJsonObject(item) || typeof item.uri !== 'string' || isSummarySidecarUri(item.uri)) {
+          continue;
+        }
+        hits.push({
+          contextType: typeof item.context_type === 'string' ? item.context_type : 'result',
+          score: typeof item.score === 'number' ? item.score : 0,
+          snippet: recallSnippet(item.abstract ?? item.overview),
+          uri: item.uri,
+        });
+      }
+    }
+    return hits;
+  } catch (_err: unknown) {
+    return [];
+  }
+}
+
+/**
+ * Merge recall hits from several search passes into one ranked list, deduped to
+ * one entry per document (chunk anchors stripped), keeping the highest-scoring
+ * chunk. Lets the scoped project/seeded passes contribute only documents the
+ * global pass missed, and collapses multiple chunks of the same document.
+ */
+export function mergeRecallHits(passes: ReadonlyArray<readonly RecallHit[]>): readonly RecallHit[] {
+  const byDocument = new Map<string, RecallHit>();
+  for (const pass of passes) {
+    for (const hit of pass) {
+      const documentUri = hit.uri.replace(/#.*$/, '');
+      const existing = byDocument.get(documentUri);
+      if (!existing || hit.score > existing.score) {
+        byDocument.set(documentUri, {...hit, uri: documentUri});
+      }
+    }
+  }
+  return [...byDocument.values()].sort((left, right) => right.score - left.score);
+}
+
+export function formatRecallHits(hits: readonly RecallHit[], maxHits: number): string | undefined {
+  if (hits.length === 0) {
+    return undefined;
+  }
+  const shown = hits.slice(0, maxHits);
+  const lines = shown.flatMap((hit, index) => {
+    const head = `${index + 1}. ${hit.contextType} · score ${hit.score.toFixed(2)} · ${hit.uri}`;
+    return hit.snippet ? [head, `   ${hit.snippet}`] : [head];
+  });
+  if (hits.length > maxHits) {
+    lines.push(`(+${hits.length - maxHits} more — refine the query or read a URI above)`);
+  }
+  return lines.join('\n');
+}
+
 /**
  * Build the exact-term grep scopes for a recall. Intent (from
  * `exactRecallScopeIntents`) selects which scope types to search; a resolved

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -760,22 +760,25 @@ export function grepOutputHasMatches(output: string): boolean {
 }
 
 /**
- * Minimum `ov search` relevance score for recall. Drops the low-signal tail so
- * recall returns fewer, higher-quality candidates. Passed to `ov search
- * --threshold`. Tuned against observed scores: strong hits sit ~0.70+, noise
- * trails below ~0.6.
+ * Minimum `ov search` relevance score for recall. A conservative floor that
+ * drops only the clearly-irrelevant tail while keeping mid-relevance hits;
+ * passed to `ov search --threshold`. Observed strong hits sit ~0.70+, so 0.5
+ * trims noise without risking useful results on lower-scoring queries.
+ * Overridable per-call (recall `--threshold` / the `threshold` MCP arg) and
+ * globally via THREADNOTE_RECALL_THRESHOLD, matching the THREADNOTE_* env
+ * convention used for command timeout/output caps.
  */
-export const RECALL_SCORE_THRESHOLD = '0.6';
+export const RECALL_SCORE_THRESHOLD = process.env.THREADNOTE_RECALL_THRESHOLD?.trim() || '0.5';
 
 export type ExactScopeIntent = 'durable' | 'handoffs' | 'incidents' | 'preferences';
 
+// Patterns favour specific, intentful phrasing over common dev vocabulary so an
+// incidental "design"/"interface" mention does not narrow the grep to durable
+// only. The semantic pass stays unscoped, so a missed intent never hides a hit.
 const EXACT_SCOPE_INTENT_PATTERNS: ReadonlyArray<readonly [ExactScopeIntent, RegExp]> = [
   ['preferences', /\b(preferences?|prefer|styles?|tone|voice|writing|persona|communication)\b/i],
   ['handoffs', /\b(handoffs?|status|next step|in progress|wip|current work|where .* left)\b/i],
-  [
-    'durable',
-    /\b(durable|feature knowledge|design|decisions?|invariants?|contract|architecture|interface|gotchas?)\b/i,
-  ],
+  ['durable', /\b(durable|feature knowledge|design decisions?|invariants?|api contract|gotchas?)\b/i],
   ['incidents', /\b(incidents?|outage|post-?mortem|on-?call|escalation)\b/i],
 ];
 
@@ -797,12 +800,23 @@ export function exactRecallScopeIntents(query: string): ReadonlySet<ExactScopeIn
 }
 
 /**
- * Extract the matched resource URIs from `ov grep --output json` stdout. The
- * CLI prints a `cmd: ...` banner before the JSON, so parse from the first `{`.
- * Returns [] on any shape mismatch — exact matches are best-effort.
+ * A `.overview.md` (Level 1) or `.abstract.md` (Level 0) summary sidecar. With
+ * OpenViking summary auto-generation off (Threadnote's default) these are
+ * permanent "[Directory ... not ready]" placeholders, so they are noise in
+ * recall and must never surface as results or pointers.
+ */
+export function isSummarySidecarUri(uri: string): boolean {
+  return /\.(?:overview|abstract)\.md(?:#|$)/.test(uri);
+}
+
+/**
+ * Extract the matched resource URIs from `ov grep --output json` stdout, minus
+ * summary sidecars. The CLI prints a `cmd: ...` banner before the JSON, so
+ * parse from the first line that starts with `{` (robust to braces in the
+ * banner). Returns [] on any shape mismatch — exact matches are best-effort.
  */
 export function grepUrisFromJson(output: string): readonly string[] {
-  const start = output.indexOf('{');
+  const start = output.search(/^\{/m);
   if (start < 0) {
     return [];
   }
@@ -815,7 +829,7 @@ export function grepUrisFromJson(output: string): readonly string[] {
     }
     const uris: string[] = [];
     for (const match of matches) {
-      if (isJsonObject(match) && typeof match.uri === 'string') {
+      if (isJsonObject(match) && typeof match.uri === 'string' && !isSummarySidecarUri(match.uri)) {
         uris.push(match.uri);
       }
     }
@@ -863,6 +877,9 @@ export function exactMemoryScopeUris(params: {
     if (intents.has('incidents')) {
       scopes.push(incidents);
     }
+    // Shared team memories are cross-cutting (durable knowledge published by
+    // teammates), so always include them alongside the intent-specific scopes.
+    scopes.push(`${userBase}/shared`);
     if (includeArchived) {
       if (intents.has('durable')) {
         scopes.push(`${userBase}/durable/archived`);
@@ -902,22 +919,24 @@ export async function collectExactMatches(
   scopes: readonly string[],
   runGrep: (term: string, scope: string) => Promise<string | undefined>,
 ): Promise<readonly ExactMatch[]> {
+  // Run all term×scope greps concurrently, then fold the results in a fixed
+  // order so dedup ranking stays deterministic regardless of completion order.
+  const pairs = terms.flatMap(term => scopes.map(scope => ({scope, term})));
+  const outputs = await Promise.all(pairs.map(pair => runGrep(pair.term, pair.scope)));
   const byUri = new Map<string, {order: number; terms: Set<string>}>();
   let order = 0;
-  for (const term of terms) {
-    for (const scope of scopes) {
-      const json = await runGrep(term, scope);
-      if (!json) {
-        continue;
-      }
-      for (const raw of grepUrisFromJson(json)) {
-        const uri = raw.replace(/#chunk_\d+$/, '');
-        const existing = byUri.get(uri);
-        if (existing) {
-          existing.terms.add(term);
-        } else {
-          byUri.set(uri, {order: order++, terms: new Set([term])});
-        }
+  for (const [index, pair] of pairs.entries()) {
+    const json = outputs[index];
+    if (!json) {
+      continue;
+    }
+    for (const raw of grepUrisFromJson(json)) {
+      const uri = raw.replace(/#.*$/, '');
+      const existing = byUri.get(uri);
+      if (existing) {
+        existing.terms.add(pair.term);
+      } else {
+        byUri.set(uri, {order: order++, terms: new Set([pair.term])});
       }
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -847,9 +847,12 @@ export interface ExactMatch {
 /**
  * Build the exact-term grep scopes for a recall. Intent (from
  * `exactRecallScopeIntents`) selects which scope types to search; a resolved
- * project narrows the project-specific scopes (durable, handoffs, incidents,
- * seeded resources) to that project, while preferences and shared stay global.
- * Empty intent falls back to the broad personal + shared + seeded set.
+ * project narrows the project-specific scopes (durable, handoffs, incidents) to
+ * that project, while preferences and shared stay global. Seeded resources
+ * (`viking://resources/repos`) are intentionally NOT exact-grepped for
+ * intent-classified queries — those are covered by the unscoped base semantic
+ * pass plus the project-scoped seeded pass, and grepping every repo per term is
+ * broad and low-signal. The broad fallback (unclear intent) does include them.
  */
 export function exactMemoryScopeUris(params: {
   readonly agentMemoriesUri: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -762,13 +762,13 @@ export function grepOutputHasMatches(output: string): boolean {
 /**
  * Minimum `ov search` relevance score for recall. A conservative floor that
  * drops only the clearly-irrelevant tail while keeping mid-relevance hits;
- * passed to `ov search --threshold`. Observed strong hits sit ~0.70+, so 0.5
+ * passed to `ov search --threshold`. Observed strong hits sit ~0.70+, so 0.45
  * trims noise without risking useful results on lower-scoring queries.
  * Overridable per-call (recall `--threshold` / the `threshold` MCP arg) and
  * globally via THREADNOTE_RECALL_THRESHOLD, matching the THREADNOTE_* env
  * convention used for command timeout/output caps.
  */
-export const RECALL_SCORE_THRESHOLD = process.env.THREADNOTE_RECALL_THRESHOLD?.trim() || '0.5';
+export const RECALL_SCORE_THRESHOLD = process.env.THREADNOTE_RECALL_THRESHOLD?.trim() || '0.45';
 
 export type ExactScopeIntent = 'durable' | 'handoffs' | 'incidents' | 'preferences';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -759,6 +759,185 @@ export function grepOutputHasMatches(output: string): boolean {
   );
 }
 
+/**
+ * Minimum `ov search` relevance score for recall. Drops the low-signal tail so
+ * recall returns fewer, higher-quality candidates. Passed to `ov search
+ * --threshold`. Tuned against observed scores: strong hits sit ~0.70+, noise
+ * trails below ~0.6.
+ */
+export const RECALL_SCORE_THRESHOLD = '0.6';
+
+export type ExactScopeIntent = 'durable' | 'handoffs' | 'incidents' | 'preferences';
+
+const EXACT_SCOPE_INTENT_PATTERNS: ReadonlyArray<readonly [ExactScopeIntent, RegExp]> = [
+  ['preferences', /\b(preferences?|prefer|styles?|tone|voice|writing|persona|communication)\b/i],
+  ['handoffs', /\b(handoffs?|status|next step|in progress|wip|current work|where .* left)\b/i],
+  [
+    'durable',
+    /\b(durable|feature knowledge|design|decisions?|invariants?|contract|architecture|interface|gotchas?)\b/i,
+  ],
+  ['incidents', /\b(incidents?|outage|post-?mortem|on-?call|escalation)\b/i],
+];
+
+/**
+ * Infer which personal-memory scopes a recall query is actually about, so the
+ * exact-term grep targets e.g. `preferences` for a "writing style" query
+ * instead of every scope. Empty set means "intent unclear" — the caller should
+ * fall back to a broad search. The semantic pass stays unscoped regardless, so
+ * a wrong guess here only narrows the exact-match pointers, not retrieval.
+ */
+export function exactRecallScopeIntents(query: string): ReadonlySet<ExactScopeIntent> {
+  const intents = new Set<ExactScopeIntent>();
+  for (const [intent, pattern] of EXACT_SCOPE_INTENT_PATTERNS) {
+    if (pattern.test(query)) {
+      intents.add(intent);
+    }
+  }
+  return intents;
+}
+
+/**
+ * Extract the matched resource URIs from `ov grep --output json` stdout. The
+ * CLI prints a `cmd: ...` banner before the JSON, so parse from the first `{`.
+ * Returns [] on any shape mismatch — exact matches are best-effort.
+ */
+export function grepUrisFromJson(output: string): readonly string[] {
+  const start = output.indexOf('{');
+  if (start < 0) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(output.slice(start));
+    const result = isJsonObject(parsed) ? parsed.result : undefined;
+    const matches = isJsonObject(result) ? result.matches : undefined;
+    if (!Array.isArray(matches)) {
+      return [];
+    }
+    const uris: string[] = [];
+    for (const match of matches) {
+      if (isJsonObject(match) && typeof match.uri === 'string') {
+        uris.push(match.uri);
+      }
+    }
+    return uris;
+  } catch (_err: unknown) {
+    return [];
+  }
+}
+
+export interface ExactMatch {
+  readonly terms: readonly string[];
+  readonly uri: string;
+}
+
+/**
+ * Build the exact-term grep scopes for a recall. Intent (from
+ * `exactRecallScopeIntents`) selects which scope types to search; a resolved
+ * project narrows the project-specific scopes (durable, handoffs, incidents,
+ * seeded resources) to that project, while preferences and shared stay global.
+ * Empty intent falls back to the broad personal + shared + seeded set.
+ */
+export function exactMemoryScopeUris(params: {
+  readonly agentMemoriesUri: string;
+  readonly includeArchived: boolean;
+  readonly intents: ReadonlySet<ExactScopeIntent>;
+  readonly projectName?: string;
+  readonly projectResourceUri?: string;
+  readonly userBase: string;
+}): readonly string[] {
+  const {agentMemoriesUri, includeArchived, intents, projectName, projectResourceUri, userBase} = params;
+  const durable = projectName ? `${userBase}/durable/projects/${projectName}` : `${userBase}/durable/projects`;
+  const handoffs = projectName ? `${userBase}/handoffs/active/${projectName}` : `${userBase}/handoffs/active`;
+  const incidents = projectName ? `${userBase}/incidents/active/${projectName}` : `${userBase}/incidents/active`;
+  if (intents.size > 0) {
+    const scopes: string[] = [];
+    if (intents.has('preferences')) {
+      scopes.push(`${userBase}/preferences`);
+    }
+    if (intents.has('durable')) {
+      scopes.push(durable);
+    }
+    if (intents.has('handoffs')) {
+      scopes.push(handoffs);
+    }
+    if (intents.has('incidents')) {
+      scopes.push(incidents);
+    }
+    if (includeArchived) {
+      if (intents.has('durable')) {
+        scopes.push(`${userBase}/durable/archived`);
+      }
+      if (intents.has('handoffs')) {
+        scopes.push(`${userBase}/handoffs/archived`);
+      }
+      if (intents.has('incidents')) {
+        scopes.push(`${userBase}/incidents/archived`);
+      }
+    }
+    return scopes;
+  }
+  const scopes = [
+    `${userBase}/preferences`,
+    durable,
+    handoffs,
+    incidents,
+    `${userBase}/shared`,
+    agentMemoriesUri,
+    projectResourceUri ?? 'viking://resources/repos',
+  ];
+  return includeArchived
+    ? [...scopes, `${userBase}/durable/archived`, `${userBase}/handoffs/archived`, `${userBase}/incidents/archived`]
+    : scopes;
+}
+
+/**
+ * Run exact-term greps over scopes and collapse them to a deduped, ranked
+ * pointer list: one entry per matched URI (chunk anchors stripped), tagged with
+ * the terms that hit it, ranked by distinct-term count then first-seen. Keeps
+ * recall an index of pointers rather than a dump of matching lines. `runGrep`
+ * returns `ov grep --output json` stdout (or undefined on failure).
+ */
+export async function collectExactMatches(
+  terms: readonly string[],
+  scopes: readonly string[],
+  runGrep: (term: string, scope: string) => Promise<string | undefined>,
+): Promise<readonly ExactMatch[]> {
+  const byUri = new Map<string, {order: number; terms: Set<string>}>();
+  let order = 0;
+  for (const term of terms) {
+    for (const scope of scopes) {
+      const json = await runGrep(term, scope);
+      if (!json) {
+        continue;
+      }
+      for (const raw of grepUrisFromJson(json)) {
+        const uri = raw.replace(/#chunk_\d+$/, '');
+        const existing = byUri.get(uri);
+        if (existing) {
+          existing.terms.add(term);
+        } else {
+          byUri.set(uri, {order: order++, terms: new Set([term])});
+        }
+      }
+    }
+  }
+  return [...byUri.entries()]
+    .sort((left, right) => right[1].terms.size - left[1].terms.size || left[1].order - right[1].order)
+    .map(([uri, value]) => ({terms: [...value.terms], uri}));
+}
+
+export function formatExactMatchPointers(matches: readonly ExactMatch[], maxUris = 8): string | undefined {
+  if (matches.length === 0) {
+    return undefined;
+  }
+  const shown = matches.slice(0, maxUris);
+  const lines = shown.map(match => `- ${match.uri} (${match.terms.join(', ')})`);
+  if (matches.length > maxUris) {
+    lines.push(`(+${matches.length - maxUris} more exact matches — refine the query to narrow)`);
+  }
+  return ['Exact term matches (read the URI for full content):', ...lines].join('\n');
+}
+
 function exactRecallTermScore(term: string): number {
   let score = term.length;
   if (/[A-Z]/.test(term)) {

--- a/test/unit/memory.recall.test.ts
+++ b/test/unit/memory.recall.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {hasAgentSkillCatalogIntent, runRecall} from '../../src/memory.js';
+import {hasAgentSkillCatalogIntent, runRecall, stripAdvancedSearchFlags} from '../../src/memory.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import * as indexRepair from '../../src/index_repair.js';
 import * as utils from '../../src/utils.js';
@@ -71,5 +71,22 @@ describe('runRecall index repair fallback', () => {
     expect(output).toContain('Auto-index repair warning: repair failed');
     expect(output).toContain('Would run: /ov search');
     expect(output).toContain('availability check');
+  });
+});
+
+describe('stripAdvancedSearchFlags', () => {
+  it('removes --threshold and --level with their values, keeping the rest', () => {
+    expect(
+      stripAdvancedSearchFlags(['search', 'q', '--threshold', '0.45', '--level', '2', '--uri', 'viking://x']),
+    ).toEqual(['search', 'q', '--uri', 'viking://x']);
+  });
+
+  it('is a no-op when no advanced flags are present', () => {
+    expect(stripAdvancedSearchFlags(['search', 'q', '--node-limit', '5'])).toEqual([
+      'search',
+      'q',
+      '--node-limit',
+      '5',
+    ]);
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -393,6 +393,17 @@ describe('exactRecallScopeIntents', () => {
     expect([...exactRecallScopeIntents('incident outage postmortem on-call')]).toEqual(['incidents']);
   });
 
+  it('accumulates multiple intents', () => {
+    expect([...exactRecallScopeIntents('writing style preference for the latest handoff status')].sort()).toEqual([
+      'handoffs',
+      'preferences',
+    ]);
+  });
+
+  it('does not classify incidental dev vocabulary as durable intent', () => {
+    expect(exactRecallScopeIntents('refactor the auth design and interface').size).toBe(0);
+  });
+
   it('returns an empty set when intent is unclear', () => {
     expect(exactRecallScopeIntents('threadnote release notes commit').size).toBe(0);
   });
@@ -404,13 +415,13 @@ describe('exactMemoryScopeUris', () => {
     userBase: 'viking://user/denys/memories',
   };
 
-  it('returns only the preferences scope for a preferences intent', () => {
+  it('searches preferences and shared for a preferences intent', () => {
     expect(exactMemoryScopeUris({...base, includeArchived: false, intents: new Set(['preferences'] as const)})).toEqual(
-      ['viking://user/denys/memories/preferences'],
+      ['viking://user/denys/memories/preferences', 'viking://user/denys/memories/shared'],
     );
   });
 
-  it('narrows project-specific scopes to the resolved project, leaving preferences global', () => {
+  it('narrows project-specific scopes to the resolved project, leaving preferences and shared global', () => {
     expect(
       exactMemoryScopeUris({
         ...base,
@@ -423,6 +434,15 @@ describe('exactMemoryScopeUris', () => {
       'viking://user/denys/memories/preferences',
       'viking://user/denys/memories/durable/projects/threadnote',
       'viking://user/denys/memories/handoffs/active/threadnote',
+      'viking://user/denys/memories/shared',
+    ]);
+  });
+
+  it('appends archived scopes for the present intents when includeArchived is set', () => {
+    expect(exactMemoryScopeUris({...base, includeArchived: true, intents: new Set(['durable'] as const)})).toEqual([
+      'viking://user/denys/memories/durable/projects',
+      'viking://user/denys/memories/shared',
+      'viking://user/denys/memories/durable/archived',
     ]);
   });
 
@@ -454,6 +474,12 @@ describe('grepUrisFromJson', () => {
     expect(grepUrisFromJson(output)).toEqual(['viking://a.md', 'viking://b.md']);
   });
 
+  it('drops .overview/.abstract summary sidecars', () => {
+    const output =
+      '{"ok":true,"result":{"matches":[{"line":1,"uri":"viking://a/.overview.md","content":"x"},{"line":2,"uri":"viking://a/real.md","content":"y"},{"line":3,"uri":"viking://a/.abstract.md","content":"z"}]}}';
+    expect(grepUrisFromJson(output)).toEqual(['viking://a/real.md']);
+  });
+
   it('returns [] on malformed output', () => {
     expect(grepUrisFromJson('cmd: ov grep\nnot json')).toEqual([]);
     expect(grepUrisFromJson('')).toEqual([]);
@@ -479,6 +505,15 @@ describe('collectExactMatches + formatExactMatchPointers', () => {
     const text = formatExactMatchPointers(matches);
     expect(text).toContain('Exact term matches (read the URI for full content):');
     expect(text).toContain('- viking://prefs.md (style, tone)');
+  });
+
+  it('does not double-count a term when the same URI matches it in two scopes', async () => {
+    const runGrep = async (term: string, scope: string): Promise<string> => {
+      const uris = scope === 'viking://a' ? ['viking://dup.md'] : scope === 'viking://b' ? ['viking://dup.md'] : [];
+      return JSON.stringify({ok: true, result: {matches: uris.map((uri, line) => ({line, uri, content: ''}))}});
+    };
+    const matches = await collectExactMatches(['term'], ['viking://a', 'viking://b'], runGrep);
+    expect(matches).toEqual([{uri: 'viking://dup.md', terms: ['term']}]);
   });
 
   it('caps the pointer list and notes the overflow', () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -11,10 +11,13 @@ import {
   exactRecallScopeIntents,
   exactRecallTerms,
   formatExactMatchPointers,
+  formatRecallHits,
   formatShellCommand,
   getGlobBase,
   globToRegExp,
   grepUrisFromJson,
+  mergeRecallHits,
+  parseRecallHits,
   hasGlob,
   isExecutable,
   isJsonObject,
@@ -525,5 +528,64 @@ describe('collectExactMatches + formatExactMatchPointers', () => {
 
   it('returns undefined when there are no matches', () => {
     expect(formatExactMatchPointers([])).toBeUndefined();
+  });
+});
+
+describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
+  const json = (obj: unknown): string => `cmd: ov search ...\n${JSON.stringify(obj)}`;
+
+  it('parses memories + resources, drops sidecars, and trims snippets', () => {
+    const hits = parseRecallHits(
+      json({
+        ok: true,
+        result: {
+          memories: [{context_type: 'memory', uri: 'viking://m.md#chunk_0001', score: 0.7, abstract: 'a  b\n c'}],
+          resources: [
+            {context_type: 'resource', uri: 'viking://r.md', score: 0.6, abstract: 'doc'},
+            {context_type: 'resource', uri: 'viking://r/.overview.md', score: 0.9, abstract: 'sidecar'},
+          ],
+          skills: [],
+        },
+      }),
+    );
+    expect(hits).toEqual([
+      {contextType: 'memory', uri: 'viking://m.md#chunk_0001', score: 0.7, snippet: 'a b c'},
+      {contextType: 'resource', uri: 'viking://r.md', score: 0.6, snippet: 'doc'},
+    ]);
+  });
+
+  it('merges passes, collapses chunks to one document, keeps the best score, ranks desc', () => {
+    const base = parseRecallHits(
+      json({ok: true, result: {memories: [{uri: 'viking://doc.md#chunk_0000', score: 0.5, abstract: 'x'}]}}),
+    );
+    const scoped = parseRecallHits(
+      json({
+        ok: true,
+        result: {
+          memories: [
+            {uri: 'viking://doc.md#chunk_0009', score: 0.8, abstract: 'y'},
+            {uri: 'viking://other.md', score: 0.6, abstract: 'z'},
+          ],
+        },
+      }),
+    );
+    const merged = mergeRecallHits([base, scoped]);
+    expect(merged.map(hit => ({score: hit.score, uri: hit.uri}))).toEqual([
+      {score: 0.8, uri: 'viking://doc.md'},
+      {score: 0.6, uri: 'viking://other.md'},
+    ]);
+  });
+
+  it('formats a capped numbered list with overflow note', () => {
+    const hits = Array.from({length: 4}, (_unused, index) => ({
+      contextType: 'memory',
+      score: 0.5,
+      snippet: '',
+      uri: `viking://m${index}.md`,
+    }));
+    const text = formatRecallHits(hits, 2) ?? '';
+    expect(text).toContain('1. memory · score 0.50 · viking://m0.md');
+    expect(text).toContain('(+2 more');
+    expect(formatRecallHits([], 5)).toBeUndefined();
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -3,13 +3,18 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
 import {
+  collectExactMatches,
   compareVersions,
   enrichRecallQueryWithWorkspaceContext,
   escapeRegExp,
+  exactMemoryScopeUris,
+  exactRecallScopeIntents,
   exactRecallTerms,
+  formatExactMatchPointers,
   formatShellCommand,
   getGlobBase,
   globToRegExp,
+  grepUrisFromJson,
   hasGlob,
   isExecutable,
   isJsonObject,
@@ -374,5 +379,116 @@ describe('suggestedShellRc', () => {
     expect(suggestedShellRc(undefined, 'darwin')).toBe('your shell rc');
     expect(suggestedShellRc('', 'linux')).toBe('your shell rc');
     expect(suggestedShellRc('/usr/local/bin/something-else', 'darwin')).toBe('your shell rc');
+  });
+});
+
+describe('exactRecallScopeIntents', () => {
+  it('routes a writing-style query to preferences only', () => {
+    expect([...exactRecallScopeIntents('Denys writing style tone for PR replies')]).toEqual(['preferences']);
+  });
+
+  it('routes handoff, durable, and incident intents', () => {
+    expect([...exactRecallScopeIntents('latest handoff status and next step')]).toEqual(['handoffs']);
+    expect([...exactRecallScopeIntents('durable feature design decision and invariants')]).toEqual(['durable']);
+    expect([...exactRecallScopeIntents('incident outage postmortem on-call')]).toEqual(['incidents']);
+  });
+
+  it('returns an empty set when intent is unclear', () => {
+    expect(exactRecallScopeIntents('threadnote release notes commit').size).toBe(0);
+  });
+});
+
+describe('exactMemoryScopeUris', () => {
+  const base = {
+    agentMemoriesUri: 'viking://agent/threadnote/memories',
+    userBase: 'viking://user/denys/memories',
+  };
+
+  it('returns only the preferences scope for a preferences intent', () => {
+    expect(exactMemoryScopeUris({...base, includeArchived: false, intents: new Set(['preferences'] as const)})).toEqual(
+      ['viking://user/denys/memories/preferences'],
+    );
+  });
+
+  it('narrows project-specific scopes to the resolved project, leaving preferences global', () => {
+    expect(
+      exactMemoryScopeUris({
+        ...base,
+        includeArchived: false,
+        intents: new Set(['durable', 'handoffs', 'preferences'] as const),
+        projectName: 'threadnote',
+        projectResourceUri: 'viking://resources/repos/threadnote',
+      }),
+    ).toEqual([
+      'viking://user/denys/memories/preferences',
+      'viking://user/denys/memories/durable/projects/threadnote',
+      'viking://user/denys/memories/handoffs/active/threadnote',
+    ]);
+  });
+
+  it('falls back to the broad set when intent is unclear, narrowing project scopes', () => {
+    expect(
+      exactMemoryScopeUris({
+        ...base,
+        includeArchived: false,
+        intents: new Set(),
+        projectName: 'threadnote',
+        projectResourceUri: 'viking://resources/repos/threadnote',
+      }),
+    ).toEqual([
+      'viking://user/denys/memories/preferences',
+      'viking://user/denys/memories/durable/projects/threadnote',
+      'viking://user/denys/memories/handoffs/active/threadnote',
+      'viking://user/denys/memories/incidents/active/threadnote',
+      'viking://user/denys/memories/shared',
+      'viking://agent/threadnote/memories',
+      'viking://resources/repos/threadnote',
+    ]);
+  });
+});
+
+describe('grepUrisFromJson', () => {
+  it('extracts match URIs past the cmd: banner', () => {
+    const output =
+      'cmd: ov grep --uri=x\n{"ok":true,"result":{"matches":[{"line":1,"uri":"viking://a.md","content":"x"},{"line":2,"uri":"viking://b.md","content":"y"}],"count":2}}';
+    expect(grepUrisFromJson(output)).toEqual(['viking://a.md', 'viking://b.md']);
+  });
+
+  it('returns [] on malformed output', () => {
+    expect(grepUrisFromJson('cmd: ov grep\nnot json')).toEqual([]);
+    expect(grepUrisFromJson('')).toEqual([]);
+  });
+});
+
+describe('collectExactMatches + formatExactMatchPointers', () => {
+  it('dedupes by URI, strips chunk anchors, and ranks by distinct-term count', async () => {
+    const runGrep = async (term: string): Promise<string> => {
+      const uris =
+        term === 'style'
+          ? ['viking://prefs.md#chunk_0001', 'viking://other.md']
+          : term === 'tone'
+            ? ['viking://prefs.md#chunk_0002']
+            : [];
+      return JSON.stringify({ok: true, result: {matches: uris.map((uri, line) => ({line, uri, content: ''}))}});
+    };
+    const matches = await collectExactMatches(['style', 'tone'], ['viking://scope'], runGrep);
+    expect(matches).toEqual([
+      {uri: 'viking://prefs.md', terms: ['style', 'tone']},
+      {uri: 'viking://other.md', terms: ['style']},
+    ]);
+    const text = formatExactMatchPointers(matches);
+    expect(text).toContain('Exact term matches (read the URI for full content):');
+    expect(text).toContain('- viking://prefs.md (style, tone)');
+  });
+
+  it('caps the pointer list and notes the overflow', () => {
+    const matches = Array.from({length: 10}, (_unused, index) => ({terms: ['t'], uri: `viking://m${index}.md`}));
+    const text = formatExactMatchPointers(matches, 3) ?? '';
+    expect(text.split('\n').filter(line => line.startsWith('- ')).length).toBe(3);
+    expect(text).toContain('(+7 more exact matches');
+  });
+
+  it('returns undefined when there are no matches', () => {
+    expect(formatExactMatchPointers([])).toBeUndefined();
   });
 });


### PR DESCRIPTION
Finishes the 1.1.1 recall work: reverts the 1.1.0 `recall_context` bloat and makes recall a lean, scope-aware index of pointers.

1.1.0 routed `recall_context` through native OpenViking `/mcp`, which returned full Level-2 bodies (~54 KB for a typical query) and grepped exact terms across all 7-10 memory scopes. This restores compact recall and makes it intelligent about where it looks.

What's changed:

- Reverts `recall_context`'s semantic search (and the seeded-resource and exact-grep passes) from native `/mcp` back to the compact `ov search` CLI. The CodeQL fix is `runCommand`'s no-shell `execFile`, so the CLI path stays injection-safe; raw `ov_*` parity tools keep using native `/mcp`.
- Routes the exact-term grep to the scopes the query is about (writing/tone → preferences, handoff/status → handoffs, durable/design → durable, incident → incidents) instead of every scope.
- Respects project scope by default: project-specific scopes (durable, handoffs, incidents, seeded resources) narrow to the resolved project, while preferences and shared stay global.
- Renders exact matches as a deduped, capped pointer list (URI + matched terms) from `ov grep --output json`, instead of dumping full matching lines.
- Adds `ov search --threshold` to drop the low-relevance tail.
- Adds a Project scope field to the manager Tools/Recall panel (blank = all projects).

A writing-style recall now greps preferences only and returns ~6.4 KB, down from ~54 KB in 1.1.0. Both the CLI and MCP recall paths are verified end-to-end.