### PR TITLE
1.1.2: keep OpenViking upgrades from stalling on a from-source build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "commonjs",
   "main": "dist/threadnote.cjs",
   "description": "Shared local context and handoffs for development agents",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,14 @@
 export const DEFAULT_HOST = '127.0.0.1';
 export const DEFAULT_PORT = 1933;
 export const DEFAULT_OPENVIKING_VERSION = '0.3.24';
+// CPython minor the OpenViking tool is pinned to. openviking[local-embed] pulls
+// in llama-cpp-python, whose prebuilt wheels (PyPI is sdist-only; wheels live on
+// the abetlen community index) top out at 3.12 as of 2026. On newer interpreters
+// (3.13/3.14) there is no wheel, so install falls back to a 10-20 min, memory-
+// heavy CMake/C++ build that can be OOM-killed or trip command timeouts. Pinning
+// the tool to this version keeps installs fast and reliable. Bump when upstream
+// ships wheels for a newer minor (abetlen/llama-cpp-python#2103, #2136).
+export const OPENVIKING_TOOL_PYTHON = '3.12';
 export const DEFAULT_ACCOUNT = 'local';
 export const DEFAULT_AGENT_ID = 'threadnote';
 export const OPENVIKING_PACKAGE_NAME = 'openviking[local-embed]';

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -11,6 +11,7 @@ import {
   OPENVIKING_MCP_NAME,
   OPENVIKING_PACKAGE_NAME,
   OPENVIKING_SERVER_COMMAND,
+  OPENVIKING_TOOL_PYTHON,
   PYTHON_SYSTEM_CERTS_MODULE,
   PYTHON_SYSTEM_CERTS_PACKAGE,
   SHIM_MARKER,
@@ -169,6 +170,19 @@ export async function runInstall(config: RuntimeConfig, options: InstallOptions)
     serverInstallRan = true;
   }
   const resolvedServerPath = serverInstallRan ? await findOpenVikingServer() : serverPath;
+  if (serverInstallRan && !resolvedServerPath && !dryRun) {
+    // The install command reported success but the binary is unresolvable.
+    // Fail loudly for `install`; for `repair` (requireServerBinary === false)
+    // warn and continue so config/manifest/MCP/hook repairs still run.
+    const message =
+      `OpenViking install ran but ${OPENVIKING_SERVER_COMMAND} was not found on PATH, in the uv tool bin dir, or ~/.local/bin. ` +
+      'Re-run `threadnote install --force` (it streams the full build), then `threadnote doctor`.';
+    if (options.requireServerBinary === false) {
+      console.warn(`WARN ${message}`);
+    } else {
+      throw new Error(message);
+    }
+  }
   if (resolvedServerPath && !dryRun) {
     await maybePrintOpenVikingPathHint(resolvedServerPath);
   }
@@ -213,6 +227,7 @@ export async function runRepair(config: RuntimeConfig, options: RepairOptions): 
     packageManager: options.packageManager,
     printNextSteps: false,
     repairInvalidConfigs: true,
+    requireServerBinary: false,
     start: false,
   });
   await repairManifest(config, dryRun);
@@ -628,7 +643,12 @@ async function openVikingServerCheck(): Promise<DoctorCheck> {
   const name = OPENVIKING_SERVER_COMMAND;
   const executable = await findOpenVikingServer();
   if (!executable) {
-    return {name, status: 'fail', detail: 'missing; install will fetch it via uv or pipx'};
+    return {
+      name,
+      status: 'fail',
+      detail:
+        'missing; run `threadnote install` to fetch it via uv or pipx (local-embed may compile from source on first install)',
+    };
   }
   const result = await runCommand(executable, ['--help'], {allowFailure: true});
   const onPath = await findExecutable([OPENVIKING_SERVER_COMMAND]);
@@ -904,7 +924,43 @@ async function runInstallCommands(
   }
   const installCommands = await getInstallCommands(config, manager, force);
   for (const installCommand of installCommands) {
-    await maybeRun(dryRun, installCommand.executable, installCommand.args);
+    if (dryRun) {
+      await maybeRun(true, installCommand.executable, installCommand.args);
+      continue;
+    }
+    // Stream live instead of buffering through runCommand. openviking[local-embed]
+    // can compile llama-cpp-python from source (10-20 min, memory-heavy); buffering
+    // hides all progress and the 10-minute command timeout would SIGKILL a
+    // legitimate build. Because uv/pipx --force removes the existing tool env
+    // first, a killed reinstall leaves openviking-server missing — so we also
+    // print recovery guidance before failing.
+    console.log(`Running: ${formatShellCommand(installCommand.executable, installCommand.args)}`);
+    const exitCode = await runInteractive(installCommand.executable, installCommand.args);
+    if (exitCode !== 0) {
+      printOpenVikingInstallFailureHelp(installCommand);
+      throw new Error(`${formatShellCommand(installCommand.executable, installCommand.args)} exited with ${exitCode}.`);
+    }
+  }
+}
+
+function printOpenVikingInstallFailureHelp(failedCommand: MappedCommand): void {
+  console.error('');
+  console.error('OpenViking install did not complete.');
+  console.error(
+    'openviking[local-embed] includes llama-cpp-python, which compiles from source when no prebuilt wheel matches your Python/platform — that build can run 10-20 minutes and is memory-heavy, so it may be killed by the OS (out of memory) or look stuck.',
+  );
+  console.error('Re-run it directly to see full output without any wrapper timeout:');
+  console.error(`  ${formatShellCommand(failedCommand.executable, failedCommand.args)}`);
+  console.error('Cap memory use during the compile with: CMAKE_BUILD_PARALLEL_LEVEL=2 <command above>');
+  if (failedCommand.executable === 'uv') {
+    if (failedCommand.args.includes('--python')) {
+      console.error(
+        'If uv could not fetch a managed CPython (offline or restricted network), drop the version pin and retry: THREADNOTE_OPENVIKING_PYTHON= threadnote install --force',
+      );
+    }
+    console.error('If it was killed mid-build, clear the partial install first, then retry:');
+    console.error('  uv cache clean');
+    console.error('  rm -rf "$(uv tool dir)/openviking"');
   }
 }
 
@@ -998,16 +1054,55 @@ async function getPythonSystemCertificatesInstallCommand(serverPath: string): Pr
   return {executable: pythonPath, args: ['-m', 'pip', 'install', PYTHON_SYSTEM_CERTS_PACKAGE]};
 }
 
-async function getInstallCommands(
+/**
+ * Prebuilt llama-cpp-python wheel index for openviking[local-embed]. PyPI ships
+ * only an sdist, so without this every install compiles the native extension
+ * from source. The abetlen community index publishes per-backend wheels; we pick
+ * a sensible CPU/Metal default by platform. CUDA/ROCm users (or anyone needing
+ * to disable it, e.g. air-gapped) can override via THREADNOTE_LLAMA_WHEEL_INDEX;
+ * setting it empty turns the extra index off and restores a from-source build.
+ */
+export function localEmbedWheelIndexUrl(): string | undefined {
+  const override = process.env.THREADNOTE_LLAMA_WHEEL_INDEX;
+  if (override !== undefined) {
+    return override.trim() === '' ? undefined : override.trim();
+  }
+  const base = 'https://abetlen.github.io/llama-cpp-python/whl';
+  return platform() === 'darwin' ? `${base}/metal` : `${base}/cpu`;
+}
+
+/**
+ * CPython version the uv-managed OpenViking tool is pinned to, so local-embed
+ * resolves a prebuilt llama-cpp-python wheel instead of compiling. Defaults to
+ * the pinned {@link OPENVIKING_TOOL_PYTHON}. Override via THREADNOTE_OPENVIKING_PYTHON
+ * (e.g. a specific interpreter); set it empty to drop the pin and let uv use its
+ * default interpreter — useful in locked or offline environments where a managed
+ * CPython cannot be fetched.
+ */
+export function openVikingToolPython(): string | undefined {
+  const override = process.env.THREADNOTE_OPENVIKING_PYTHON;
+  if (override !== undefined) {
+    return override.trim() === '' ? undefined : override.trim();
+  }
+  return OPENVIKING_TOOL_PYTHON;
+}
+
+export async function getInstallCommands(
   config: RuntimeConfig,
   preferred: PackageManager | undefined,
   force: boolean,
 ): Promise<readonly MappedCommand[]> {
   const packageSpec = `${OPENVIKING_PACKAGE_NAME}==${config.openVikingVersion}`;
+  const wheelIndex = localEmbedWheelIndexUrl();
   const manager = preferred ?? (await detectPackageManager());
   if (manager === 'pipx') {
+    const installArgs = force ? ['install', '--force'] : ['install'];
+    if (wheelIndex) {
+      installArgs.push('--pip-args', `--extra-index-url ${wheelIndex}`);
+    }
+    installArgs.push(packageSpec);
     return [
-      {executable: 'pipx', args: force ? ['install', '--force', packageSpec] : ['install', packageSpec]},
+      {executable: 'pipx', args: installArgs},
       {
         executable: 'pipx',
         args: force
@@ -1017,7 +1112,19 @@ async function getInstallCommands(
     ];
   }
   if (manager === 'uv') {
-    const uvArgs = ['tool', 'install', '--native-tls', '--with', PYTHON_SYSTEM_CERTS_PACKAGE];
+    // --python pins the tool to a wheel-supported interpreter (uv fetches a
+    // managed CPython when none is present), so local-embed resolves a prebuilt
+    // wheel instead of compiling. --extra-index-url points at that wheel index.
+    const toolPython = openVikingToolPython();
+    const uvArgs = [
+      'tool',
+      'install',
+      '--native-tls',
+      ...(toolPython ? ['--python', toolPython] : []),
+      '--with',
+      PYTHON_SYSTEM_CERTS_PACKAGE,
+      ...(wheelIndex ? ['--extra-index-url', wheelIndex] : []),
+    ];
     return [
       {
         executable: 'uv',
@@ -1028,6 +1135,9 @@ async function getInstallCommands(
   const pipArgs = ['-m', 'pip', 'install', '--user'];
   if (force) {
     pipArgs.push('--upgrade', '--force-reinstall');
+  }
+  if (wheelIndex) {
+    pipArgs.push('--extra-index-url', wheelIndex);
   }
   pipArgs.push(PYTHON_SYSTEM_CERTS_PACKAGE);
   pipArgs.push(packageSpec);

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -733,7 +733,7 @@ function registerSearchTool(server: McpServer, config: RuntimeConfig, name: stri
           .optional()
           .describe('Optional absolute caller workspace path used to resolve this/current branch queries'),
         nodeLimit: z.number().int().positive().max(100).optional().describe('Maximum result count'),
-        includeArchived: z.boolean().optional().describe('Include archived memories in exact memory/resource matches'),
+        includeArchived: z.boolean().optional().describe('Include archived memories in recall results'),
         threshold: z
           .number()
           .min(0)
@@ -808,7 +808,12 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   // pass only adds project docs the base missed. --level 2 keeps Level-2
   // content and drops the L0/L1 .overview/.abstract summary sidecars.
   const pinnedArgs = params.pinnedUri ? ['--uri', params.pinnedUri] : [];
-  const base = await recallSearchHits(config, ['search', query, ...pinnedArgs, ...limitArgs], threshold);
+  const base = await recallSearchHits(
+    config,
+    ['search', query, ...pinnedArgs, ...limitArgs],
+    threshold,
+    params.includeArchived,
+  );
   const passes: Array<readonly RecallHit[]> = [base.hits];
   const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
   if (seededUri?.startsWith('viking://') && seededUri !== params.pinnedUri) {
@@ -816,6 +821,7 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
       config,
       ['search', params.query, '--uri', seededUri, ...limitArgs],
       threshold,
+      params.includeArchived,
     );
     passes.push(seeded.hits);
   }
@@ -862,6 +868,7 @@ async function recallSearchHits(
   config: RuntimeConfig,
   searchArgs: readonly string[],
   threshold: string,
+  includeArchived: boolean,
 ): Promise<{readonly errorText: string; readonly hits: readonly RecallHit[]; readonly ok: boolean}> {
   let result = await runOpenVikingTool(config, [
     ...searchArgs,
@@ -880,7 +887,7 @@ async function recallSearchHits(
   if (result.isError === true) {
     return {errorText: text.trim(), hits: [], ok: false};
   }
-  return {errorText: '', hits: parseRecallHits(text), ok: true};
+  return {errorText: '', hits: parseRecallHits(text, {includeArchived}), ok: true};
 }
 
 async function recallHygieneHintsSection(config: RuntimeConfig, recallText: string): Promise<string | undefined> {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -334,14 +334,17 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   if (inferredUri) {
     console.log(`Recall scope: ${inferredUri}`);
   }
-  const passes: Array<readonly RecallHit[]> = [await recallSearchHits(config, ov, searchArgs(inferredUri), {dryRun})];
+  const includeArchived = options.includeArchived === true;
+  const passes: Array<readonly RecallHit[]> = [
+    await recallSearchHits(config, ov, searchArgs(inferredUri), {dryRun, includeArchived}),
+  ];
   if (options.project && project) {
     const projectMemoryUri = `viking://user/${uriSegment(config.user)}/memories/durable/projects/${uriSegment(project.name)}`;
-    passes.push(await recallSearchHits(config, ov, searchArgs(projectMemoryUri), {dryRun}));
+    passes.push(await recallSearchHits(config, ov, searchArgs(projectMemoryUri), {dryRun, includeArchived}));
   }
   const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
   if (seededUri?.startsWith('viking://') && seededUri !== inferredUri && !options.uri && options.inferScope !== false) {
-    passes.push(await recallSearchHits(config, ov, searchArgs(seededUri), {dryRun}));
+    passes.push(await recallSearchHits(config, ov, searchArgs(seededUri), {dryRun, includeArchived}));
   }
 
   const recallOutputs: string[] = [];
@@ -352,7 +355,7 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   }
   const exactOutput = await printExactMemoryMatches(config, ov, query, {
     dryRun,
-    includeArchived: options.includeArchived === true,
+    includeArchived,
     project,
   });
   if (exactOutput) {
@@ -372,7 +375,7 @@ async function recallSearchHits(
   config: RuntimeConfig,
   ov: string,
   args: readonly string[],
-  options: {readonly dryRun: boolean},
+  options: {readonly dryRun: boolean; readonly includeArchived: boolean},
 ): Promise<readonly RecallHit[]> {
   const jsonArgs = withIdentity(config, [...args, '--output', 'json']);
   console.log(`${options.dryRun ? 'Would run' : 'Running'}: ${formatShellCommand(ov, jsonArgs)}`);
@@ -389,7 +392,7 @@ async function recallSearchHits(
     console.log(`WARN recall search failed: ${result.stderr.trim() || result.stdout.trim() || 'ov search error'}`);
     return [];
   }
-  return parseRecallHits(result.stdout);
+  return parseRecallHits(result.stdout, {includeArchived: options.includeArchived});
 }
 
 export function stripAdvancedSearchFlags(args: readonly string[]): readonly string[] {

--- a/src/threadnote.ts
+++ b/src/threadnote.ts
@@ -350,7 +350,7 @@ async function main(): Promise<void> {
     .description('Search shared OpenViking context')
     .requiredOption('--query <query>', 'Search query')
     .option('--dry-run', 'Print ov command without searching')
-    .option('--include-archived', 'Include archived memories in exact memory/resource matches')
+    .option('--include-archived', 'Include archived memories in recall results')
     .option('-n, --node-limit <count>', 'Maximum number of search results')
     .option('--no-infer-scope', 'Disable query-based scope inference')
     .option('--project <name>', 'Prioritize a project: add a scoped pass over its memories alongside the global search')

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,10 @@ export interface InstallOptions {
   readonly packageManager?: PackageManager;
   readonly printNextSteps?: boolean;
   readonly repairInvalidConfigs?: boolean;
+  // When an install ran but openviking-server is still unresolvable, throw
+  // (default) so `threadnote install` fails loudly. Repair sets this false to
+  // warn-and-continue so config/manifest/MCP/hook repairs still run.
+  readonly requireServerBinary?: boolean;
   readonly start?: boolean;
   readonly withHooks?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -851,6 +851,10 @@ export interface RecallHit {
   readonly uri: string;
 }
 
+interface ParseRecallHitsOptions {
+  readonly includeArchived?: boolean;
+}
+
 function recallSnippet(value: unknown): string {
   if (typeof value !== 'string') {
     return '';
@@ -859,13 +863,20 @@ function recallSnippet(value: unknown): string {
   return oneLine.length > 180 ? `${oneLine.slice(0, 180)}…` : oneLine;
 }
 
+function isArchivedMemoryUri(uri: string): boolean {
+  const documentUri = uri.replace(/#.*$/, '');
+  return /^viking:\/\/user\/[^/]+\/memories\/(?:durable|handoffs|incidents|preferences|smoke)\/archived(?:\/|$)/.test(
+    documentUri,
+  );
+}
+
 /**
  * Parse `ov search --output json` stdout into recall hits across the memories,
  * resources, and skills result arrays, dropping summary sidecars and trimming
  * each abstract to a short snippet. Tolerant of the leading `cmd:` banner and
  * shape drift; returns [] on parse failure.
  */
-export function parseRecallHits(output: string): readonly RecallHit[] {
+export function parseRecallHits(output: string, options: ParseRecallHitsOptions = {}): readonly RecallHit[] {
   const start = output.search(/^\{/m);
   if (start < 0) {
     return [];
@@ -884,6 +895,9 @@ export function parseRecallHits(output: string): readonly RecallHit[] {
       }
       for (const item of items) {
         if (!isJsonObject(item) || typeof item.uri !== 'string' || isSummarySidecarUri(item.uri)) {
+          continue;
+        }
+        if (options.includeArchived !== true && isArchivedMemoryUri(item.uri)) {
           continue;
         }
         hits.push({

--- a/test/unit/lifecycle.install.test.ts
+++ b/test/unit/lifecycle.install.test.ts
@@ -1,0 +1,163 @@
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {getInstallCommands, localEmbedWheelIndexUrl, openVikingToolPython} from '../../src/lifecycle.js';
+import type {RuntimeConfig} from '../../src/types.js';
+
+const WHEEL_INDEX_ENV = 'THREADNOTE_LLAMA_WHEEL_INDEX';
+const TOOL_PYTHON_ENV = 'THREADNOTE_OPENVIKING_PYTHON';
+const TEST_INDEX = 'https://wheels.example/whl/cpu';
+
+function restoreEnv(name: string, original: string | undefined): void {
+  if (original === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = original;
+  }
+}
+
+function runtime(): RuntimeConfig {
+  return {
+    account: 'local',
+    agentContextHome: '/tmp/threadnote-test',
+    agentId: 'threadnote',
+    host: '127.0.0.1',
+    manifestPath: '/tmp/threadnote-test/seed-manifest.yaml',
+    openVikingVersion: '0.3.24',
+    port: 1933,
+    user: 'denys',
+  };
+}
+
+const SPEC = 'openviking[local-embed]==0.3.24';
+
+describe('localEmbedWheelIndexUrl', () => {
+  const original = process.env[WHEEL_INDEX_ENV];
+  afterEach(() => restoreEnv(WHEEL_INDEX_ENV, original));
+
+  it('defaults to the abetlen wheel index', () => {
+    delete process.env[WHEEL_INDEX_ENV];
+    expect(localEmbedWheelIndexUrl()).toContain('abetlen.github.io/llama-cpp-python/whl/');
+  });
+
+  it('honors an override', () => {
+    process.env[WHEEL_INDEX_ENV] = TEST_INDEX;
+    expect(localEmbedWheelIndexUrl()).toBe(TEST_INDEX);
+  });
+
+  it('treats an empty override as disabled', () => {
+    process.env[WHEEL_INDEX_ENV] = '   ';
+    expect(localEmbedWheelIndexUrl()).toBeUndefined();
+  });
+});
+
+describe('openVikingToolPython', () => {
+  const original = process.env[TOOL_PYTHON_ENV];
+  afterEach(() => restoreEnv(TOOL_PYTHON_ENV, original));
+
+  it('defaults to the pinned tool Python', () => {
+    delete process.env[TOOL_PYTHON_ENV];
+    expect(openVikingToolPython()).toBe('3.12');
+  });
+
+  it('honors an override', () => {
+    process.env[TOOL_PYTHON_ENV] = '3.11';
+    expect(openVikingToolPython()).toBe('3.11');
+  });
+
+  it('treats an empty override as no pin', () => {
+    process.env[TOOL_PYTHON_ENV] = '';
+    expect(openVikingToolPython()).toBeUndefined();
+  });
+});
+
+describe('getInstallCommands', () => {
+  const originalIndex = process.env[WHEEL_INDEX_ENV];
+  const originalPython = process.env[TOOL_PYTHON_ENV];
+  beforeEach(() => {
+    process.env[WHEEL_INDEX_ENV] = TEST_INDEX;
+    delete process.env[TOOL_PYTHON_ENV];
+  });
+  afterEach(() => {
+    restoreEnv(WHEEL_INDEX_ENV, originalIndex);
+    restoreEnv(TOOL_PYTHON_ENV, originalPython);
+  });
+
+  it('pins uv to a wheel-supported Python and adds the wheel index', async () => {
+    const [command, ...rest] = await getInstallCommands(runtime(), 'uv', false);
+    expect(rest).toHaveLength(0);
+    expect(command.executable).toBe('uv');
+    expect(command.args).toEqual([
+      'tool',
+      'install',
+      '--native-tls',
+      '--python',
+      '3.12',
+      '--with',
+      'pip-system-certs',
+      '--extra-index-url',
+      TEST_INDEX,
+      SPEC,
+    ]);
+  });
+
+  it('appends --force for a uv forced reinstall', async () => {
+    const [command] = await getInstallCommands(runtime(), 'uv', true);
+    expect(command.args).toContain('--force');
+    expect(command.args.indexOf('--force')).toBe(command.args.indexOf(SPEC) - 1);
+  });
+
+  it('omits the wheel index for uv when disabled', async () => {
+    process.env[WHEEL_INDEX_ENV] = '';
+    const [command] = await getInstallCommands(runtime(), 'uv', false);
+    expect(command.args).not.toContain('--extra-index-url');
+    expect(command.args).toEqual([
+      'tool',
+      'install',
+      '--native-tls',
+      '--python',
+      '3.12',
+      '--with',
+      'pip-system-certs',
+      SPEC,
+    ]);
+  });
+
+  it('drops the uv --python pin when disabled', async () => {
+    process.env[TOOL_PYTHON_ENV] = '';
+    const [command] = await getInstallCommands(runtime(), 'uv', false);
+    expect(command.args).not.toContain('--python');
+    expect(command.args).toEqual([
+      'tool',
+      'install',
+      '--native-tls',
+      '--with',
+      'pip-system-certs',
+      '--extra-index-url',
+      TEST_INDEX,
+      SPEC,
+    ]);
+  });
+
+  it('passes the wheel index to pipx via --pip-args', async () => {
+    const [install, inject] = await getInstallCommands(runtime(), 'pipx', false);
+    expect(install.executable).toBe('pipx');
+    expect(install.args).toEqual(['install', '--pip-args', `--extra-index-url ${TEST_INDEX}`, SPEC]);
+    expect(inject.args).toEqual(['inject', 'openviking', 'pip-system-certs']);
+  });
+
+  it('adds the wheel index to the pip --user fallback', async () => {
+    const [command] = await getInstallCommands(runtime(), 'pip', true);
+    expect(command.executable).toBe('python3');
+    expect(command.args).toEqual([
+      '-m',
+      'pip',
+      'install',
+      '--user',
+      '--upgrade',
+      '--force-reinstall',
+      '--extra-index-url',
+      TEST_INDEX,
+      'pip-system-certs',
+      SPEC,
+    ]);
+  });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -554,6 +554,53 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
     ]);
   });
 
+  it('omits archived lifecycle memories by default', () => {
+    const hits = parseRecallHits(
+      json({
+        ok: true,
+        result: {
+          memories: [
+            {
+              context_type: 'memory',
+              uri: 'viking://user/denys/memories/handoffs/archived/threadnote/old.md#chunk_0000',
+              score: 0.8,
+              abstract: 'old',
+            },
+            {
+              context_type: 'memory',
+              uri: 'viking://user/denys/memories/durable/projects/threadnote/current.md',
+              score: 0.7,
+              abstract: 'current',
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(hits.map(hit => hit.uri)).toEqual(['viking://user/denys/memories/durable/projects/threadnote/current.md']);
+  });
+
+  it('keeps archived lifecycle memories when includeArchived is set', () => {
+    const hits = parseRecallHits(
+      json({
+        ok: true,
+        result: {
+          memories: [
+            {
+              context_type: 'memory',
+              uri: 'viking://user/denys/memories/durable/archived/threadnote/old.md',
+              score: 0.8,
+              abstract: 'old',
+            },
+          ],
+        },
+      }),
+      {includeArchived: true},
+    );
+
+    expect(hits.map(hit => hit.uri)).toEqual(['viking://user/denys/memories/durable/archived/threadnote/old.md']);
+  });
+
   it('merges passes, collapses chunks to one document, keeps the best score, ranks desc', () => {
     const base = parseRecallHits(
       json({ok: true, result: {memories: [{uri: 'viking://doc.md#chunk_0000', score: 0.5, abstract: 'x'}]}}),


### PR DESCRIPTION
## Summary
- **OpenViking upgrades no longer stall or self-destruct.** `threadnote update`'s pinned OpenViking reinstall could hang for 10–20 min and then leave `openviking-server` missing, with `repair` looping on the same build. Root cause: the inner `uv tool install` ran buffered through `runCommand` with the 10-minute command timeout and a 5 MB output cap, while `openviking[local-embed]`'s `llama-cpp-python` compiles from source whenever no prebuilt wheel matches the active Python (PyPI is sdist-only; e.g. CPython 3.14 has no wheel). A legitimate long build was silenced and then killed, and because `uv --force` removes the old tool env first, the kill left the server gone.
- Recall now omits archived lifecycle memories from semantic hits unless `--include-archived` / `includeArchived` is set.

## Detail

**OpenViking upgrade**
- Stream the uv/pipx/pip install via `runInteractive` instead of buffered `maybeRun` — output is live and no longer subject to the command timeout or output cap. On failure, print recovery guidance (re-run directly, `CMAKE_BUILD_PARALLEL_LEVEL`, `uv cache clean` / remove the partial tool env).
- Pin the uv-managed tool to a wheel-supported Python (`--python 3.12`) and add a platform-appropriate prebuilt-wheel `--extra-index-url`, so `local-embed` resolves a wheel instead of compiling. Overridable via `THREADNOTE_OPENVIKING_PYTHON` and `THREADNOTE_LLAMA_WHEEL_INDEX` (empty disables each) for locked/offline/CUDA setups.
- After an install ran, verify `openviking-server` resolves: fail loudly for `install`, warn-and-continue for `repair` so config/manifest/MCP/hook repairs still run. Doctor's "missing" hint now names the first-install compile.

**Recall**
- `parseRecallHits` filters archived personal lifecycle memory URIs (`memories/*/archived/*`) by default; CLI and MCP recall both pass `includeArchived` through semantic parsing. Help text describes the full recall behavior instead of only exact matches.

## Test plan
- `npm run typecheck`, `npm run lint`, `npm run prettier:check`
- `npm test` — 205 passing; new `test/unit/lifecycle.install.test.ts` covers install-command construction (uv `--python` pin, wheel index, force) and the env overrides
- `npm run build`
- `node dist/threadnote.cjs install --dry-run --force` → `uv tool install --native-tls --python 3.12 --with pip-system-certs --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/metal --force 'openviking[local-embed]==0.3.24'`
