### PR TITLE
Share team skills and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Ask the agent to remember it. Threadnote keeps that memory local and searchable 
 **Have reusable agent workflows already installed as skills?**\
 Run `threadnote seed-skills` to make local `SKILL.md` guidance discoverable through recall. Agents can find relevant testing, release, on-call, debugging, or plugin-provided workflows without you reopening the same skill files by hand.
 
+**Want teammates to use the same skill or command?**\
+Publish it into a shared team repo with `threadnote share publish-artifact <path>`. Teammates can recall the shared
+artifact immediately after sync, then opt in to local installation with `threadnote share install-artifacts --apply`.
+
 **Recall returned several overlapping memories?**
 Run `threadnote compact --project <repo> --topic <issue> --dry-run` or ask the agent to use
 `compact_context({"project":"<repo>","topic":"<issue>","dryRun":true})`. Threadnote produces a scoped plan first:

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -119,11 +119,12 @@ compact_context({"project":"my-repo","topic":"active-bug","dryRun":true})
 
 Never compact secrets, credentials, customer data, raw production logs, or checked-in canonical docs into memory.
 
-## Sharing memories with teammates
+## Sharing context with teammates
 
-Threadnote can publish a curated subset of durable memories into a team git repo so other engineers' agents can pull them.
-The mechanism lives under the `viking://user/<you>/memories/shared/<team>/...` subtree; only memories that are explicitly
-published leave the machine. Personal handoffs, preferences, and unpublished durable notes always stay local.
+Threadnote can publish a curated subset of durable memories and agent artifacts (Codex/Claude skills and Claude
+commands) into a team git repo so other engineers' agents can pull them. The mechanism lives under the
+`viking://user/<you>/memories/shared/<team>/...` subtree; only content that is explicitly published leaves the machine.
+Personal handoffs, preferences, and unpublished durable notes always stay local.
 
 Publish a durable memory when its content is useful to other engineers working on the same project (intended behavior,
 design decisions, API contracts, gotchas) and is safe to share. Do NOT publish:
@@ -136,6 +137,16 @@ The MCP tool `share_publish` runs the same scrubber as the CLI and refuses to pu
 patterns (PEM private keys, `sk-...`, `gh[pousr]_...`, `Bearer ...`, `AKIA...`, `xox[abprs]-...`). It writes and pushes
 the shared copy first, then removes the personal copy after the push succeeds.
 
+The MCP tool `share_skill` shares a local Codex/Claude `SKILL.md` file or Claude command markdown file into the team's
+`agent-artifacts/` catalog after the same scrubber checks. Shared artifacts are recallable after sync, but local
+installation remains opt-in with `threadnote share install-artifacts --apply`.
+
+When the user asks whether shared skills exist, call `list_shared_skills`. When the user asks to install one, call
+`install_shared_skill` with the selected `name`; include `agent` and `kind` from the list result when available.
+`list_shared_skills` syncs shared repos before listing and reports `not_installed`, `current`, `update_available`,
+`local_modified`, or `remote_changed_and_local_modified`. Install/update selected shared skills only when the user asks;
+use `force:true` only when the user explicitly accepts overwriting local modifications.
+
 Incoming shared memories are normally fetched and synced automatically before MCP `recall_context` / `read_context` and
 CLI `threadnote recall` / `threadnote read` return. If automatic sync reports a dirty worktree, a conflict, or another
 git issue, run `threadnote share sync` after resolving the local state to pull, reindex, and push explicitly.
@@ -144,9 +155,13 @@ git issue, run `threadnote share sync` after resolving the local state to pull, 
 # MCP call shape
 share_publish({"uri":"viking://user/you/memories/durable/projects/foo/bar.md"})
 share_publish({"uri":"viking://user/you/memories/durable/projects/foo/bar.md","team":"friends","push":false})
+share_skill({"path":"~/.codex/skills/reviewer/SKILL.md"})
+list_shared_skills({})
+install_shared_skill({"name":"reviewer","agent":"codex","kind":"skill"})
 ```
 
-Before publishing, confirm with the user unless they have already instructed you to share durable memories autonomously.
+Before publishing, confirm with the user unless they have already instructed you to share durable memories or agent
+artifacts autonomously.
 
 ## Handoff
 
@@ -184,5 +199,7 @@ threadnote forget viking://user/example/memories/events/duplicate.md
 threadnote handoff --project example --topic active-issue --task "short task summary" --tests "checks run" --next-step "what to do next"
 threadnote share init git@github.com:org/team-memories.git
 threadnote share publish viking://user/example/memories/durable/projects/foo/bar.md
+threadnote share publish-artifact ~/.codex/skills/example/SKILL.md
+threadnote share install-artifacts --name example --agent codex --kind skill --apply
 threadnote share sync
 ```

--- a/docs/share.md
+++ b/docs/share.md
@@ -1,9 +1,9 @@
-# Sharing memories with teammates
+# Sharing context with teammates
 
-`threadnote share` lets a small team keep a curated set of durable memories in a
-git repository so every member's local agent can recall them. Personal handoffs,
-preferences, and unpublished durable notes stay local; only memories you
-explicitly publish leave your machine.
+`threadnote share` lets a small team keep curated durable memories and agent
+artifacts in a git repository so every member's local agent can recall them.
+Personal handoffs, preferences, and unpublished durable notes stay local; only
+content you explicitly publish leaves your machine.
 
 ## Model in one screen
 
@@ -34,7 +34,7 @@ threadnote share init --team friends git@github.com:you/friends-memories.git
 ```
 
 `share init` clones the remote into your local memory tree and ingests any
-existing markdown memories into OpenViking.
+existing shareable markdown into OpenViking.
 
 ### See what's configured
 
@@ -85,6 +85,95 @@ For MCP, pass the same shared URI as `replaceUri` to `remember_context`.
 Threadnote rewrites the shared memory in place, strips local-only provenance
 headers, commits, and pushes the shared repo. You do not need to store a
 personal replacement and run `share publish` again.
+
+### Share a skill or command
+
+Shared agent artifacts live in the same team repo, but outside `durable/`:
+
+```text
+agent-artifacts/
+  skills/codex/<name>/SKILL.md
+  skills/claude/<name>/SKILL.md
+  commands/claude/<name>.md
+```
+
+Publish a local artifact:
+
+```bash
+threadnote share publish-artifact ~/.codex/skills/reviewer/SKILL.md
+threadnote share publish-artifact ~/.claude/skills/triage/SKILL.md
+threadnote share publish-artifact ~/.claude/commands/review-pr.md
+```
+
+Path inference handles the common Codex and Claude locations. If the file is
+somewhere else, pass metadata explicitly:
+
+```bash
+threadnote share publish-artifact ./SKILL.md --agent codex --kind skill --name reviewer
+```
+
+Useful flags:
+
+```bash
+threadnote share publish-artifact <path> --preview
+threadnote share publish-artifact <path> --redact
+threadnote share publish-artifact <path> --force
+threadnote share publish-artifact <path> --no-push
+```
+
+`publish-artifact` runs the same scrubber as memory publish, writes the artifact
+under `agent-artifacts/`, ingests it into OpenViking under the shared team
+namespace, commits, and pushes. Existing artifacts with different content are
+not overwritten unless `--force` is passed.
+
+Agents can do the same through MCP:
+
+```text
+share_skill({"path":"~/.codex/skills/reviewer/SKILL.md"})
+```
+
+Agents can also list and install shared artifacts through MCP:
+
+```text
+list_shared_skills({})
+install_shared_skill({"name":"reviewer","agent":"codex","kind":"skill"})
+```
+
+`list_shared_skills` syncs configured shared repos before listing and reports
+one of:
+
+- `not_installed`
+- `current`
+- `update_available`
+- `local_modified`
+- `remote_changed_and_local_modified`
+
+### Install shared artifacts locally
+
+Shared artifacts are recallable after sync, but they are not installed into
+agent-native locations automatically. Installation is opt-in:
+
+```bash
+threadnote share install-artifacts          # preview only
+threadnote share install-artifacts --apply  # write files locally
+threadnote share install-artifacts --name reviewer --agent codex --kind skill --apply
+```
+
+Install targets are namespaced by Threadnote team to avoid colliding with
+personal files:
+
+```text
+~/.codex/skills/threadnote/<team>/<name>/SKILL.md
+~/.claude/skills/threadnote/<team>/<name>/SKILL.md
+~/.claude/commands/threadnote/<team>/<name>.md
+```
+
+If a target already exists with different content, installation refuses to
+overwrite local modifications unless `--force` is passed. Remote updates are
+applied by running the same install command again; Threadnote tracks the last
+installed shared hash in a sidecar metadata file next to the installed
+artifact. Start a new agent session after installing if that agent snapshots
+skills or commands at startup.
 
 ### Keep teammates' updates current
 
@@ -176,10 +265,11 @@ updates the git `origin` URL and verifies it with `git fetch`.
   - linux home paths (`/home/<you>/...`) → `<local-path>`
 - The scrubber complements but does not replace human review. Strip the value,
   preview with `--preview`, and then publish.
-- Only the `durable/` kind is shareable. `handoffs/`, `preferences/`,
-  `incidents/`, and other lifecycle kinds stay local by construction — both
-  the initial ingest (`share init`) and the sync-pull reindex (`share sync`)
-  skip any file outside `durable/`.
+- Only `durable/` memories and `agent-artifacts/` markdown files are
+  shareable. `handoffs/`, `preferences/`, `incidents/`, and other lifecycle
+  kinds stay local by construction — both the initial ingest (`share init`) and
+  the sync-pull reindex (`share sync`) skip any file outside the shareable
+  top-level directories.
 - `share publish` deletes the personal copy after publishing. If you want to
   keep both, copy the memory to a new URI first (`ov read` then
   `threadnote remember`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "commonjs",
   "main": "dist/threadnote.cjs",
   "description": "Shared local context and handoffs for development agents",

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -25,13 +25,16 @@ import {
 } from './memory_hygiene.js';
 import {
   ensureSharedDirectoryChain,
+  installSharedAgentArtifacts,
   isInSharedNamespace,
+  listSharedAgentArtifacts,
   publishShareGitChange,
   resolveTeam,
   applyScrubber,
   sharedMemoryUriParts,
   sharedTeamNameForUri,
   sharedUriFor,
+  shareAgentArtifact,
   startShareBackgroundFetch,
   stripPersonalProvenance,
   syncSharedReposBeforeAgentRead,
@@ -135,6 +138,8 @@ async function main(): Promise<void> {
         'When updating the same active issue, pass project/topic or replaceUri to remember_context so duplicate durable memories or handoffs do not accumulate.',
         'Use compact_context with dryRun=true for scoped memory hygiene when recall surfaces overlapping active memories.',
         'To share a durable memory with teammates, call `share_publish` with its viking:// URI. share_publish scrubs for secrets, writes and pushes the shared copy first, then removes the personal copy after the push succeeds. Do not publish handoffs, preferences, or anything carrying machine-local paths or in-flight task context.',
+        'To share a local Codex/Claude skill or Claude command with teammates, call `share_skill` with the local file path. It publishes into the shared artifact catalog after the same scrubber checks.',
+        'To use a team shared skill as a native local skill, call `list_shared_skills` first, then `install_shared_skill` for the selected name/agent/kind.',
         'Do not store secrets, customer data, raw production logs, or credentials.',
       ].join('\n'),
     },
@@ -356,6 +361,89 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
         return checkedUri.error;
       }
       return runSharePublishTool(config, checkedUri.value, {message, preview, push, redact, team});
+    },
+  );
+
+  server.registerTool(
+    'share_skill',
+    {
+      annotations: {readOnlyHint: false, destructiveHint: true},
+      description:
+        "Publish a local Codex/Claude skill or Claude command markdown file into a team's shared artifact catalog. Path inference handles ~/.codex/skills/**/SKILL.md, ~/.claude/skills/**/SKILL.md, and ~/.claude/commands/**/*.md; pass agent/kind/name when sharing from another path. Default team is used unless team is provided. Pass preview=true to inspect bytes without writing or committing.",
+      inputSchema: {
+        agent: z.enum(['codex', 'claude']).optional().describe('Agent owner when path inference is ambiguous'),
+        force: z.boolean().optional().describe('Replace an existing shared artifact with different content'),
+        kind: z.enum(['skill', 'command']).optional().describe('Artifact kind when path inference is ambiguous'),
+        message: z.string().optional().describe('Commit message override; defaults to "share: publish <path>"'),
+        name: z.string().optional().describe('Shared artifact name; defaults to skill directory or command file stem'),
+        path: z.string().optional().describe('Required local path to SKILL.md or a Claude command markdown file'),
+        preview: z.boolean().optional().describe('Return the bytes that would land in the shared git repo'),
+        push: z.boolean().optional().describe('Push to remote after committing; defaults to true'),
+        redact: z
+          .boolean()
+          .optional()
+          .describe('Replace soft-leak matches (local paths) with placeholders and continue; credentials still block.'),
+        team: z.string().optional().describe('Team name; defaults to the configured default team'),
+      },
+    },
+    async ({agent, force, kind, message, name, path, preview, push, redact, team}) => {
+      const checkedPath = requiredText(path, 'share_skill', 'path', {
+        path: '~/.codex/skills/example/SKILL.md',
+      });
+      if (!checkedPath.ok) {
+        return checkedPath.error;
+      }
+      return runShareSkillTool(config, checkedPath.value, {
+        agent,
+        force,
+        kind,
+        message,
+        name,
+        preview,
+        push,
+        redact,
+        team,
+      });
+    },
+  );
+
+  server.registerTool(
+    'list_shared_skills',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description:
+        'List shared Codex/Claude skills and Claude commands available in a configured Threadnote team repo, including whether each one is already installed locally.',
+      inputSchema: {
+        agent: z.enum(['codex', 'claude']).optional().describe('Optional agent filter'),
+        kind: z.enum(['skill', 'command']).optional().describe('Optional kind filter'),
+        name: z.string().optional().describe('Optional shared artifact name filter'),
+        team: z.string().optional().describe('Team name; defaults to the configured default team'),
+      },
+    },
+    async ({agent, kind, name, team}) => runListSharedSkillsTool(config, {agent, kind, name, team}),
+  );
+
+  server.registerTool(
+    'install_shared_skill',
+    {
+      annotations: {readOnlyHint: false, destructiveHint: true},
+      description:
+        'Install one shared Codex/Claude skill or Claude command from a configured Threadnote team repo into the local agent skill/command directory. Use list_shared_skills first to find names and disambiguate agent/kind.',
+      inputSchema: {
+        agent: z.enum(['codex', 'claude']).optional().describe('Agent owner; required when name is ambiguous'),
+        dryRun: z.boolean().optional().describe('Preview install without writing local files'),
+        force: z.boolean().optional().describe('Replace an existing installed artifact with different content'),
+        kind: z.enum(['skill', 'command']).optional().describe('Artifact kind; required when name is ambiguous'),
+        name: z.string().optional().describe('Required shared artifact name to install'),
+        team: z.string().optional().describe('Team name; defaults to the configured default team'),
+      },
+    },
+    async ({agent, dryRun, force, kind, name, team}) => {
+      const checkedName = requiredText(name, 'install_shared_skill', 'name', {name: 'reviewer'});
+      if (!checkedName.ok) {
+        return checkedName.error;
+      }
+      return runInstallSharedSkillTool(config, checkedName.value, {agent, dryRun, force, kind, team});
     },
   );
 }
@@ -1860,6 +1948,33 @@ interface SharePublishToolOptions {
   readonly team?: string;
 }
 
+interface ShareSkillToolOptions {
+  readonly agent?: 'claude' | 'codex';
+  readonly force?: boolean;
+  readonly kind?: 'command' | 'skill';
+  readonly message?: string;
+  readonly name?: string;
+  readonly preview?: boolean;
+  readonly push?: boolean;
+  readonly redact?: boolean;
+  readonly team?: string;
+}
+
+interface SharedSkillFilterOptions {
+  readonly agent?: 'claude' | 'codex';
+  readonly kind?: 'command' | 'skill';
+  readonly name?: string;
+  readonly team?: string;
+}
+
+interface InstallSharedSkillToolOptions {
+  readonly agent?: 'claude' | 'codex';
+  readonly dryRun?: boolean;
+  readonly force?: boolean;
+  readonly kind?: 'command' | 'skill';
+  readonly team?: string;
+}
+
 async function runSharePublishTool(
   config: RuntimeConfig,
   sourceUri: string,
@@ -1955,6 +2070,90 @@ async function runSharePublishTool(
   } catch (err: unknown) {
     return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
   }
+}
+
+async function runShareSkillTool(
+  config: RuntimeConfig,
+  sourcePath: string,
+  options: ShareSkillToolOptions,
+): Promise<CallToolResult> {
+  try {
+    const result = await shareAgentArtifact(config, sourcePath, options);
+    const lines = [...result.messages, ...result.gitMessages];
+    if (result.previewContent !== undefined) {
+      lines.push('-----BEGIN PREVIEW-----');
+      lines.push(result.previewContent);
+      lines.push('-----END PREVIEW-----');
+    }
+    return {content: [{type: 'text', text: lines.join('\n')}], isError: false};
+  } catch (err: unknown) {
+    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+  }
+}
+
+async function runListSharedSkillsTool(
+  config: RuntimeConfig,
+  options: SharedSkillFilterOptions,
+): Promise<CallToolResult> {
+  try {
+    const result = await listSharedAgentArtifacts(config, options);
+    if (result.artifacts.length === 0) {
+      const lines = shareArtifactToolHeader(result.team, result.syncedTeams, result.warnings);
+      lines.push(`No shared skills or commands found for team "${result.team}".`);
+      return {content: [{type: 'text', text: lines.join('\n')}]};
+    }
+    const lines = shareArtifactToolHeader(result.team, result.syncedTeams, result.warnings);
+    lines.push(`Shared skills and commands for team "${result.team}":`);
+    for (const artifact of result.artifacts) {
+      lines.push(
+        `- ${artifact.artifact.kind} ${artifact.artifact.agent}/${artifact.artifact.name} (${artifact.installStatus})`,
+      );
+      lines.push(
+        `  install: install_shared_skill({"name":"${artifact.artifact.name}","agent":"${artifact.artifact.agent}","kind":"${artifact.artifact.kind}"})`,
+      );
+    }
+    return {content: [{type: 'text', text: lines.join('\n')}], isError: false};
+  } catch (err: unknown) {
+    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+  }
+}
+
+async function runInstallSharedSkillTool(
+  config: RuntimeConfig,
+  name: string,
+  options: InstallSharedSkillToolOptions,
+): Promise<CallToolResult> {
+  try {
+    const result = await installSharedAgentArtifacts(config, {
+      ...options,
+      apply: options.dryRun !== true,
+      name,
+    });
+    return {
+      content: [
+        {
+          type: 'text',
+          text: [...shareArtifactToolHeader(result.team, result.syncedTeams, result.warnings), ...result.messages].join(
+            '\n',
+          ),
+        },
+      ],
+      isError: false,
+    };
+  } catch (err: unknown) {
+    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+  }
+}
+
+function shareArtifactToolHeader(team: string, syncedTeams: readonly string[], warnings: readonly string[]): string[] {
+  const lines = [`Team: ${team}`];
+  if (syncedTeams.length > 0) {
+    lines.push(`Synced shared teams: ${syncedTeams.join(', ')}`);
+  }
+  for (const warning of warnings) {
+    lines.push(`Warning: ${warning}`);
+  }
+  return lines;
 }
 
 function withIdentity(config: RuntimeConfig, args: readonly string[]): readonly string[] {

--- a/src/share.ts
+++ b/src/share.ts
@@ -1,12 +1,17 @@
-import {mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile} from 'node:fs/promises';
-import {tmpdir} from 'node:os';
-import {dirname, join, relative, sep} from 'node:path';
+import {lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile} from 'node:fs/promises';
+import {homedir, tmpdir} from 'node:os';
+import {basename, dirname, join, relative, sep} from 'node:path';
 import {uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
 import type {
   CommandResult,
+  ShareAgentArtifactAgent,
+  ShareAgentArtifactKind,
+  ShareInstallArtifactsOptions,
   ShareInitOptions,
+  ShareListArtifactsOptions,
   ShareListOptions,
+  SharePublishArtifactOptions,
   SharePublishOptions,
   ShareRenameOptions,
   ShareRemoveOptions,
@@ -22,6 +27,7 @@ import {
   assertVikingUri,
   ensureDirectory,
   exists,
+  expandPath,
   formatShellCommand,
   isDirectory,
   isFile,
@@ -33,12 +39,16 @@ import {
   removePath,
   requiredExecutable,
   runCommand,
+  sha256,
   sleep,
 } from './utils.js';
 
 const TEAMS_FILE_VERSION = 1;
 const SHARED_SEGMENT = 'shared';
 const SHAREABLE_MEMORY_KIND_DIRS = ['durable'];
+const SHAREABLE_ARTIFACT_DIR = 'agent-artifacts';
+const SHAREABLE_TOP_LEVEL_DIRS = [...SHAREABLE_MEMORY_KIND_DIRS, SHAREABLE_ARTIFACT_DIR];
+const ARTIFACT_INSTALL_METADATA_VERSION = 1;
 const AUTO_SHARE_FETCH_INTERVAL_MS = 5 * 60 * 1000;
 export const DEFAULT_GIT_REMOTE_NAME = 'origin';
 
@@ -83,6 +93,76 @@ export interface ScrubberResult {
   readonly blocker?: string;
   readonly cleaned: string;
   readonly redactions: ReadonlyArray<{readonly count: number; readonly name: string}>;
+}
+
+export interface ShareArtifactMetadata {
+  readonly agent: ShareAgentArtifactAgent;
+  readonly kind: ShareAgentArtifactKind;
+  readonly name: string;
+}
+
+export interface ShareArtifactResult {
+  readonly artifact: ShareArtifactMetadata;
+  readonly gitMessages: readonly string[];
+  readonly messages: readonly string[];
+  readonly previewContent?: string;
+  readonly sourcePath: string;
+  readonly targetPath: string;
+  readonly targetUri: string;
+}
+
+export interface SharedArtifactFile {
+  readonly artifact: ShareArtifactMetadata;
+  readonly installPath: string;
+  readonly sourceRelativePath: string;
+  readonly sourcePath: string;
+  readonly team: string;
+}
+
+export type SharedArtifactInstallStatus =
+  | 'current'
+  | 'local_modified'
+  | 'not_installed'
+  | 'remote_changed_and_local_modified'
+  | 'update_available';
+
+export interface SharedArtifactSummary extends SharedArtifactFile {
+  readonly installStatus: SharedArtifactInstallStatus;
+  readonly metadataPath: string;
+}
+
+export interface SharedArtifactListResult {
+  readonly artifacts: readonly SharedArtifactSummary[];
+  readonly syncedTeams: readonly string[];
+  readonly team: string;
+  readonly warnings: readonly string[];
+}
+
+export interface SharedArtifactInstallResult {
+  readonly installedCount: number;
+  readonly messages: readonly string[];
+  readonly syncedTeams: readonly string[];
+  readonly team: string;
+  readonly warnings: readonly string[];
+}
+
+interface SharedArtifactInstallMetadata {
+  readonly artifact: ShareArtifactMetadata;
+  readonly installedAt: string;
+  readonly installedSha256: string;
+  readonly source: string;
+  readonly sourceSha256: string;
+  readonly team: string;
+  readonly version: number;
+}
+
+interface SharedArtifactInstallState {
+  readonly existingContent?: string;
+  readonly existingSha?: string;
+  readonly metadata?: SharedArtifactInstallMetadata;
+  readonly sourceContent: string;
+  readonly sourceSha: string;
+  readonly status: SharedArtifactInstallStatus;
 }
 
 /**
@@ -214,7 +294,7 @@ export async function runShareInit(config: ShareRuntime, remoteUrl: string, opti
   if (!dryRun) {
     await ensureSharedGitignore(worktree, git, options.push !== false);
     const ingested = await ingestWorktreeFiles(config, newConfig, 'create');
-    console.log(`Ingested ${ingested} shared memory file(s) into OpenViking.`);
+    console.log(`Ingested ${ingested} shared file(s) into OpenViking.`);
   }
 }
 
@@ -629,11 +709,11 @@ async function runShareSyncQuiet(
 }
 
 async function stageShareableChanges(dryRun: boolean, git: string, worktree: string): Promise<void> {
-  // Stage repo metadata (README, .gitignore) plus every shareable kind dir.
+  // Stage repo metadata plus every shareable top-level dir.
   // OpenViking-generated summaries (.abstract.md, .overview.md) are excluded
   // via the repo's .gitignore (ensureSharedGitignore self-heals it on every
   // sync), so they never get staged even by an unscoped `git add`.
-  const pathspecs = [':(top)README.md', ':(top).gitignore', ...SHAREABLE_MEMORY_KIND_DIRS.map(dir => `:(top)${dir}`)];
+  const pathspecs = [':(top)README.md', ':(top).gitignore', ...SHAREABLE_TOP_LEVEL_DIRS.map(dir => `:(top)${dir}`)];
   await maybeRun(dryRun, git, ['-C', worktree, 'add', '--', ...pathspecs], {allowFailure: true});
 }
 
@@ -782,6 +862,208 @@ export async function runSharePublish(
   console.log(`Published ${sourceUri} -> ${targetUri}`);
 }
 
+export async function runSharePublishArtifact(
+  config: ShareRuntime,
+  sourcePath: string,
+  options: SharePublishArtifactOptions,
+): Promise<void> {
+  const result = await shareAgentArtifact(config, sourcePath, options);
+  printShareArtifactResult(result, options.preview === true);
+}
+
+export async function shareAgentArtifact(
+  config: ShareRuntime,
+  sourcePath: string,
+  options: SharePublishArtifactOptions,
+): Promise<ShareArtifactResult> {
+  const team = await resolveTeam(config, options.team);
+  const dryRun = options.dryRun === true;
+  const preview = options.preview === true;
+  const resolvedSourcePath = expandPath(sourcePath);
+  if (!(await isRegularFileNoSymlink(resolvedSourcePath))) {
+    throw new Error(`Agent artifact source is not a regular file: ${resolvedSourcePath}`);
+  }
+
+  const artifact = inferShareArtifact(resolvedSourcePath, options);
+  const rawContent = await readFile(resolvedSourcePath, 'utf8');
+  if (!rawContent.trim()) {
+    throw new Error(`Refusing to share empty agent artifact: ${resolvedSourcePath}`);
+  }
+  const scrub = applyScrubber(rawContent, {redact: options.redact === true});
+  const relativePath = sharedArtifactRelativePath(artifact);
+  const targetPath = join(team.config.worktree, ...relativePath.split('/'));
+  const targetUri = workfileToVikingUri(config, team.config, targetPath);
+  const messages: string[] = [
+    `${preview ? 'Previewing' : dryRun ? 'Would share' : 'Sharing'} ${artifact.kind} ${artifact.agent}/${artifact.name}`,
+    `Source: ${portablePath(resolvedSourcePath)}`,
+    `Destination: ${targetUri}`,
+  ];
+
+  if (preview) {
+    if (scrub.blocker) {
+      messages.push(`PREVIEW BLOCKED: ${scrub.blocker}. Strip the sensitive value or pass --redact.`);
+      return {
+        artifact,
+        gitMessages: [],
+        messages,
+        sourcePath: resolvedSourcePath,
+        targetPath,
+        targetUri,
+      };
+    }
+    for (const redaction of scrub.redactions) {
+      messages.push(`PREVIEW redact: ${redaction.count}× ${redaction.name}`);
+    }
+    return {
+      artifact,
+      gitMessages: [],
+      messages,
+      previewContent: scrub.cleaned,
+      sourcePath: resolvedSourcePath,
+      targetPath,
+      targetUri,
+    };
+  }
+
+  if (scrub.blocker) {
+    throw new Error(
+      `Refusing to share ${resolvedSourcePath}: possible ${scrub.blocker}. Strip the sensitive value or pass --redact for soft-leak patterns.`,
+    );
+  }
+  for (const redaction of scrub.redactions) {
+    messages.push(`Redacted ${redaction.count}× ${redaction.name} before sharing.`);
+  }
+  const content = scrub.cleaned;
+  const existingContent = (await readFileIfExists(targetPath)) ?? undefined;
+  if (existingContent !== undefined && existingContent !== content && options.force !== true) {
+    throw new Error(
+      `Shared artifact already exists with different content: ${portablePath(targetPath)}. Pass --force to replace it.`,
+    );
+  }
+
+  if (dryRun) {
+    messages.push(`Would write shared artifact: ${portablePath(targetPath)}`);
+  }
+
+  const ov = await openVikingCliForMode(dryRun);
+  const ovHasResource = !dryRun && (await vikingResourceExists(ov, config, targetUri));
+  await ensureSharedDirectoryChain(config, ov, targetUri, dryRun, {quiet: true});
+  await writeMemoryFile(config, ov, targetUri, content, ovHasResource ? 'replace' : 'create', dryRun, {quiet: true});
+
+  const message = options.message ?? `share: publish ${relativePath}`;
+  const gitMessages = await publishShareGitChange(team.config.worktree, relativePath, message, {
+    dryRun,
+    push: options.push,
+  });
+  return {artifact, gitMessages, messages, sourcePath: resolvedSourcePath, targetPath, targetUri};
+}
+
+export async function runShareInstallArtifacts(
+  config: ShareRuntime,
+  options: ShareInstallArtifactsOptions,
+): Promise<void> {
+  const result = await installSharedAgentArtifacts(config, options);
+  if (result.syncedTeams.length > 0) {
+    console.log(`Synced shared teams: ${result.syncedTeams.join(', ')}`);
+  }
+  for (const warning of result.warnings) {
+    console.warn(`Warning: ${warning}`);
+  }
+  for (const message of result.messages) {
+    console.log(message);
+  }
+}
+
+export async function listSharedAgentArtifacts(
+  config: ShareRuntime,
+  options: ShareListArtifactsOptions = {},
+): Promise<SharedArtifactListResult> {
+  const syncResult = await maybeSyncSharedArtifacts(config, options);
+  const team = await resolveTeam(config, options.team);
+  const artifacts = filterSharedArtifacts(await collectSharedArtifacts(team.config.worktree, team.name), options);
+  const summaries: SharedArtifactSummary[] = [];
+  for (const artifact of artifacts) {
+    summaries.push({
+      ...artifact,
+      installStatus: await sharedArtifactInstallStatus(artifact),
+      metadataPath: sharedArtifactMetadataPath(artifact),
+    });
+  }
+  return {artifacts: summaries, syncedTeams: syncResult.syncedTeams, team: team.name, warnings: syncResult.warnings};
+}
+
+export async function installSharedAgentArtifacts(
+  config: ShareRuntime,
+  options: ShareInstallArtifactsOptions,
+): Promise<SharedArtifactInstallResult> {
+  const syncResult = await maybeSyncSharedArtifacts(config, options);
+  const team = await resolveTeam(config, options.team);
+  const dryRun = options.dryRun === true || options.apply !== true;
+  const allArtifacts = await collectSharedArtifacts(team.config.worktree, team.name);
+  const artifacts = filterSharedArtifacts(allArtifacts, options);
+  const messages: string[] = [];
+  if (artifacts.length === 0) {
+    const filters = sharedArtifactFilterLabel(options);
+    if (filters) {
+      throw new Error(`No shared agent artifacts found for team "${team.name}" matching ${filters}.`);
+    }
+    return {
+      installedCount: 0,
+      messages: [`No shared agent artifacts found for team "${team.name}".`],
+      syncedTeams: syncResult.syncedTeams,
+      team: team.name,
+      warnings: syncResult.warnings,
+    };
+  }
+  if (
+    options.name !== undefined &&
+    artifacts.length > 1 &&
+    (options.agent === undefined || options.kind === undefined)
+  ) {
+    throw new Error(
+      `Shared artifact "${options.name}" is ambiguous. Specify agent and kind. Matches: ${artifacts
+        .map(artifact => sharedArtifactLabel(artifact.artifact))
+        .join(', ')}`,
+    );
+  }
+  let installedCount = 0;
+  for (const artifact of artifacts) {
+    const label = sharedArtifactLabel(artifact.artifact);
+    const state = await sharedArtifactInstallState(artifact);
+    if (dryRun) {
+      const verb = sharedArtifactDryRunVerb(state.status, options.force === true);
+      const suffix = sharedArtifactDryRunSuffix(state.status, options.force === true);
+      messages.push(`${verb} ${label}: ${portablePath(artifact.installPath)}${suffix}`);
+      continue;
+    }
+    if (
+      (state.status === 'local_modified' || state.status === 'remote_changed_and_local_modified') &&
+      options.force !== true
+    ) {
+      throw new Error(`Refusing to overwrite ${portablePath(artifact.installPath)}. Pass force=true or --force.`);
+    }
+    if (state.status === 'current') {
+      await writeSharedArtifactMetadata(artifact, state.sourceSha);
+      messages.push(`Already installed ${label}: ${portablePath(artifact.installPath)}`);
+      continue;
+    }
+    await ensureDirectory(dirname(artifact.installPath), false);
+    await writeFile(artifact.installPath, state.sourceContent, {encoding: 'utf8', mode: 0o600});
+    await writeSharedArtifactMetadata(artifact, state.sourceSha);
+    installedCount += 1;
+    messages.push(
+      `${sharedArtifactInstallVerb(state.status, options.force === true)} ${label}: ${portablePath(artifact.installPath)}`,
+    );
+  }
+  return {
+    installedCount,
+    messages,
+    syncedTeams: syncResult.syncedTeams,
+    team: team.name,
+    warnings: syncResult.warnings,
+  };
+}
+
 export async function runShareUnpublish(
   config: ShareRuntime,
   sourceUri: string,
@@ -882,7 +1164,7 @@ export async function runShareRename(config: ShareRuntime, options: ShareRenameO
     console.log(`Would rename worktree: ${portablePath(oldTeam.config.worktree)} -> ${portablePath(newWorktree)}`);
     console.log(`Would rename gitdir: ${portablePath(oldTeam.config.gitdir)} -> ${portablePath(newGitdir)}`);
     console.log(`Would update git core.worktree for team "${newName}".`);
-    console.log(`Would reindex shared memories under team "${newName}" and remove old shared URI tree.`);
+    console.log(`Would reindex shared context under team "${newName}" and remove old shared URI tree.`);
     console.log(`Would write teams file: ${teamsFilePath(config)}`);
     return;
   }
@@ -901,7 +1183,7 @@ export async function runShareRename(config: ShareRuntime, options: ShareRenameO
     false,
   );
   console.log(`Renamed shared team "${oldTeam.name}" -> "${newName}".`);
-  console.log(`Reindexed ${ingested} shared memory file(s).`);
+  console.log(`Reindexed ${ingested} shared file(s).`);
 }
 
 export async function runShareSetUrl(
@@ -1171,7 +1453,7 @@ async function walkMemoryFiles(root: string): Promise<readonly string[]> {
       }
       const full = join(path, entry.name);
       if (entry.isDirectory()) {
-        if (depth === 0 && !SHAREABLE_MEMORY_KIND_DIRS.includes(entry.name)) {
+        if (depth === 0 && !SHAREABLE_TOP_LEVEL_DIRS.includes(entry.name)) {
           continue;
         }
         await visit(full, depth + 1);
@@ -1262,6 +1544,321 @@ export function vikingUriToWorktreeRelative(config: ShareRuntime, uri: string, t
   return uri.slice(prefix.length);
 }
 
+async function isRegularFileNoSymlink(path: string): Promise<boolean> {
+  try {
+    const stat = await lstat(path);
+    return stat.isFile();
+  } catch (_err: unknown) {
+    return false;
+  }
+}
+
+function inferShareArtifact(path: string, options: SharePublishArtifactOptions): ShareArtifactMetadata {
+  const normalizedPath = path.split(sep).join('/');
+  const fileName = basename(path);
+  const lowerFileName = fileName.toLowerCase();
+  const lowerPath = normalizedPath.toLowerCase();
+  const inferredKind: ShareAgentArtifactKind | undefined =
+    lowerFileName === 'skill.md'
+      ? 'skill'
+      : lowerPath.includes('/.claude/commands/') && lowerFileName.endsWith('.md')
+        ? 'command'
+        : undefined;
+  const inferredAgent: ShareAgentArtifactAgent | undefined = lowerPath.includes('/.codex/skills/')
+    ? 'codex'
+    : lowerPath.includes('/.claude/skills/') || lowerPath.includes('/.claude/commands/')
+      ? 'claude'
+      : undefined;
+  const extensionIndex = fileName.lastIndexOf('.');
+  const stem = extensionIndex > 0 ? fileName.slice(0, extensionIndex) : fileName;
+  const inferredName = lowerFileName === 'skill.md' ? basename(dirname(path)) : stem;
+  const kind = options.kind ?? inferredKind;
+  const agent = options.agent ?? inferredAgent;
+  const name = options.name ?? inferredName;
+
+  if (kind !== 'skill' && kind !== 'command') {
+    throw new Error('Could not infer artifact kind. Pass --kind skill or --kind command.');
+  }
+  if (agent !== 'codex' && agent !== 'claude') {
+    throw new Error('Could not infer artifact agent. Pass --agent codex or --agent claude.');
+  }
+  if (kind === 'skill' && lowerFileName !== 'skill.md') {
+    throw new Error('Skill artifacts must point at a SKILL.md file.');
+  }
+  if (kind === 'command' && !lowerFileName.endsWith('.md')) {
+    throw new Error('Command artifacts must be Markdown files.');
+  }
+  if (kind === 'command' && agent !== 'claude') {
+    throw new Error('Only Claude command artifacts are supported.');
+  }
+  if (name.trim().length === 0) {
+    throw new Error('Artifact name cannot be empty.');
+  }
+  return {agent, kind, name: uriSegment(name)};
+}
+
+function sharedArtifactRelativePath(artifact: ShareArtifactMetadata): string {
+  if (artifact.kind === 'skill') {
+    return `${SHAREABLE_ARTIFACT_DIR}/skills/${artifact.agent}/${artifact.name}/SKILL.md`;
+  }
+  return `${SHAREABLE_ARTIFACT_DIR}/commands/${artifact.agent}/${artifact.name}.md`;
+}
+
+function sharedArtifactFromRelativePath(relativePath: string): ShareArtifactMetadata | undefined {
+  const parts = relativePath.split('/');
+  if (parts[0] !== SHAREABLE_ARTIFACT_DIR) {
+    return undefined;
+  }
+  if (
+    parts.length === 5 &&
+    parts[1] === 'skills' &&
+    (parts[2] === 'codex' || parts[2] === 'claude') &&
+    parts[4] === 'SKILL.md'
+  ) {
+    return {agent: parts[2], kind: 'skill', name: parts[3]};
+  }
+  if (parts.length === 4 && parts[1] === 'commands' && parts[2] === 'claude' && parts[3].endsWith('.md')) {
+    return {agent: 'claude', kind: 'command', name: parts[3].slice(0, -'.md'.length)};
+  }
+  return undefined;
+}
+
+async function collectSharedArtifacts(worktree: string, team: string): Promise<readonly SharedArtifactFile[]> {
+  const root = join(worktree, SHAREABLE_ARTIFACT_DIR);
+  if (!(await isDirectory(root))) {
+    return [];
+  }
+  const out: SharedArtifactFile[] = [];
+  async function visit(path: string): Promise<void> {
+    const entries = await readdir(path, {withFileTypes: true});
+    for (const entry of entries) {
+      const full = join(path, entry.name);
+      if (entry.isDirectory()) {
+        await visit(full);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.md')) {
+        continue;
+      }
+      const relativePath = relative(worktree, full).split(sep).join('/');
+      const artifact = sharedArtifactFromRelativePath(relativePath);
+      if (artifact === undefined) {
+        continue;
+      }
+      out.push({
+        artifact,
+        installPath: sharedArtifactInstallPath(team, artifact),
+        sourcePath: full,
+        sourceRelativePath: relativePath,
+        team,
+      });
+    }
+  }
+  await visit(root);
+  return out.sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
+}
+
+function filterSharedArtifacts(
+  artifacts: readonly SharedArtifactFile[],
+  options: ShareInstallArtifactsOptions | ShareListArtifactsOptions,
+): readonly SharedArtifactFile[] {
+  const name = options.name === undefined ? undefined : uriSegment(options.name);
+  return artifacts.filter(artifact => {
+    if (options.agent !== undefined && artifact.artifact.agent !== options.agent) {
+      return false;
+    }
+    if (options.kind !== undefined && artifact.artifact.kind !== options.kind) {
+      return false;
+    }
+    if (name !== undefined && artifact.artifact.name !== name) {
+      return false;
+    }
+    return true;
+  });
+}
+
+async function maybeSyncSharedArtifacts(
+  config: ShareRuntime,
+  options: ShareInstallArtifactsOptions | ShareListArtifactsOptions,
+): Promise<AutoShareSyncResult> {
+  if (options.sync === false) {
+    return {syncedTeams: [], warnings: []};
+  }
+  return syncSharedReposBeforeAgentRead(config);
+}
+
+async function sharedArtifactInstallStatus(artifact: SharedArtifactFile): Promise<SharedArtifactInstallStatus> {
+  return (await sharedArtifactInstallState(artifact)).status;
+}
+
+async function sharedArtifactInstallState(artifact: SharedArtifactFile): Promise<SharedArtifactInstallState> {
+  const sourceContent = await readFile(artifact.sourcePath, 'utf8');
+  const sourceSha = sha256(sourceContent);
+  const existingContent = (await readFileIfExists(artifact.installPath)) ?? undefined;
+  if (existingContent === undefined) {
+    return {sourceContent, sourceSha, status: 'not_installed'};
+  }
+  const existingSha = sha256(existingContent);
+  const metadata = await readSharedArtifactMetadata(artifact);
+  if (existingSha === sourceSha) {
+    return {existingContent, existingSha, metadata, sourceContent, sourceSha, status: 'current'};
+  }
+  if (metadata === undefined) {
+    return {existingContent, existingSha, sourceContent, sourceSha, status: 'local_modified'};
+  }
+  const remoteChanged = metadata.sourceSha256 !== sourceSha;
+  const localChanged = metadata.installedSha256 !== existingSha;
+  if (remoteChanged && localChanged) {
+    return {
+      existingContent,
+      existingSha,
+      metadata,
+      sourceContent,
+      sourceSha,
+      status: 'remote_changed_and_local_modified',
+    };
+  }
+  if (remoteChanged) {
+    return {existingContent, existingSha, metadata, sourceContent, sourceSha, status: 'update_available'};
+  }
+  return {existingContent, existingSha, metadata, sourceContent, sourceSha, status: 'local_modified'};
+}
+
+async function readSharedArtifactMetadata(
+  artifact: SharedArtifactFile,
+): Promise<SharedArtifactInstallMetadata | undefined> {
+  const raw = await readFileIfExists(sharedArtifactMetadataPath(artifact));
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = parseJsonConfigObject(raw);
+  if (parsed === undefined || parsed.version !== ARTIFACT_INSTALL_METADATA_VERSION) {
+    return undefined;
+  }
+  const artifactValue = parsed.artifact;
+  if (
+    typeof parsed.team !== 'string' ||
+    typeof parsed.source !== 'string' ||
+    typeof parsed.sourceSha256 !== 'string' ||
+    typeof parsed.installedSha256 !== 'string' ||
+    typeof parsed.installedAt !== 'string' ||
+    typeof artifactValue !== 'object' ||
+    artifactValue === null ||
+    Array.isArray(artifactValue)
+  ) {
+    return undefined;
+  }
+  const metadataArtifact = artifactValue as Partial<ShareArtifactMetadata>;
+  if (
+    metadataArtifact.agent !== artifact.artifact.agent ||
+    metadataArtifact.kind !== artifact.artifact.kind ||
+    metadataArtifact.name !== artifact.artifact.name
+  ) {
+    return undefined;
+  }
+  return {
+    artifact: artifact.artifact,
+    installedAt: parsed.installedAt,
+    installedSha256: parsed.installedSha256,
+    source: parsed.source,
+    sourceSha256: parsed.sourceSha256,
+    team: parsed.team,
+    version: ARTIFACT_INSTALL_METADATA_VERSION,
+  };
+}
+
+async function writeSharedArtifactMetadata(artifact: SharedArtifactFile, sourceSha: string): Promise<void> {
+  const metadata: SharedArtifactInstallMetadata = {
+    artifact: artifact.artifact,
+    installedAt: new Date().toISOString(),
+    installedSha256: sourceSha,
+    source: artifact.sourceRelativePath,
+    sourceSha256: sourceSha,
+    team: artifact.team,
+    version: ARTIFACT_INSTALL_METADATA_VERSION,
+  };
+  const metadataPath = sharedArtifactMetadataPath(artifact);
+  await ensureDirectory(dirname(metadataPath), false);
+  await writeFile(metadataPath, `${JSON.stringify(metadata, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
+}
+
+function sharedArtifactMetadataPath(artifact: SharedArtifactFile): string {
+  return `${artifact.installPath}.threadnote-install.json`;
+}
+
+function sharedArtifactDryRunVerb(status: SharedArtifactInstallStatus, force: boolean): string {
+  switch (status) {
+    case 'not_installed':
+      return 'Would install';
+    case 'current':
+      return 'Already installed';
+    case 'update_available':
+      return 'Would update';
+    case 'local_modified':
+    case 'remote_changed_and_local_modified':
+      return force ? 'Would replace' : 'Would skip modified';
+  }
+}
+
+function sharedArtifactDryRunSuffix(status: SharedArtifactInstallStatus, force: boolean): string {
+  if ((status === 'local_modified' || status === 'remote_changed_and_local_modified') && !force) {
+    return ' (pass --force to replace local changes)';
+  }
+  return '';
+}
+
+function sharedArtifactInstallVerb(status: SharedArtifactInstallStatus, force: boolean): string {
+  if (force && (status === 'local_modified' || status === 'remote_changed_and_local_modified')) {
+    return 'Replaced';
+  }
+  if (status === 'update_available') {
+    return 'Updated';
+  }
+  return 'Installed';
+}
+
+function sharedArtifactFilterLabel(options: ShareInstallArtifactsOptions | ShareListArtifactsOptions): string {
+  const filters: string[] = [];
+  if (options.kind !== undefined) {
+    filters.push(`kind=${options.kind}`);
+  }
+  if (options.agent !== undefined) {
+    filters.push(`agent=${options.agent}`);
+  }
+  if (options.name !== undefined) {
+    filters.push(`name=${uriSegment(options.name)}`);
+  }
+  return filters.join(', ');
+}
+
+function sharedArtifactLabel(artifact: ShareArtifactMetadata): string {
+  return `${artifact.kind} ${artifact.agent}/${artifact.name}`;
+}
+
+function sharedArtifactInstallPath(team: string, artifact: ShareArtifactMetadata): string {
+  if (artifact.kind === 'skill' && artifact.agent === 'codex') {
+    return join(homedir(), '.codex', 'skills', 'threadnote', team, artifact.name, 'SKILL.md');
+  }
+  if (artifact.kind === 'skill' && artifact.agent === 'claude') {
+    return join(homedir(), '.claude', 'skills', 'threadnote', team, artifact.name, 'SKILL.md');
+  }
+  return join(homedir(), '.claude', 'commands', 'threadnote', team, `${artifact.name}.md`);
+}
+
+function printShareArtifactResult(result: ShareArtifactResult, preview: boolean): void {
+  for (const message of result.messages) {
+    console.log(message);
+  }
+  for (const gitMessage of result.gitMessages) {
+    console.log(gitMessage);
+  }
+  if (preview && result.previewContent !== undefined) {
+    console.log('-----BEGIN PREVIEW-----');
+    console.log(result.previewContent);
+    console.log('-----END PREVIEW-----');
+  }
+}
+
 export function scrubberBlocker(content: string): string | undefined {
   return applyScrubber(content, {redact: false}).blocker;
 }
@@ -1336,9 +1933,9 @@ export async function ensureSharedDirectoryChain(
       continue;
     }
     if (options.quiet === true) {
-      await runCommand(ov, withIdentity(config, ['mkdir', uri, '--description', 'Threadnote shared memories.']));
+      await runCommand(ov, withIdentity(config, ['mkdir', uri, '--description', 'Threadnote shared context.']));
     } else {
-      await maybeRun(false, ov, withIdentity(config, ['mkdir', uri, '--description', 'Threadnote shared memories.']));
+      await maybeRun(false, ov, withIdentity(config, ['mkdir', uri, '--description', 'Threadnote shared context.']));
     }
   }
 }
@@ -1666,13 +2263,13 @@ interface ApplyChangesResult {
   readonly failed: readonly ChangedFile[];
 }
 
-// applyChangesToOpenViking only reflects changes to files under the shareable
-// kind directories (currently just `durable/`). For renames that cross kind
-// directories (e.g., handoffs/x.md -> durable/y.md), listChangedFiles emits a
+// applyChangesToOpenViking only reflects changes to files under shareable
+// top-level directories. For renames that cross those directories
+// (e.g., handoffs/x.md -> durable/y.md), listChangedFiles emits a
 // 'removed' for the old path and an 'added' for the new path; both are
-// processed independently here. The 'removed' entry for a non-shareable kind
+// processed independently here. The 'removed' entry for a non-shareable path
 // is filtered out by the firstSegment check, which is the desired outcome
-// because non-shareable kinds are never reflected into OV's shared subtree.
+// because non-shareable files are never reflected into OV's shared subtree.
 //
 // Per-change failures are non-fatal: we log a warning and continue with the
 // other changes, returning the failed list so the caller can re-persist them
@@ -1692,7 +2289,7 @@ async function applyChangesToOpenViking(
       continue;
     }
     const firstSegment = change.relativePath.split('/')[0];
-    if (!SHAREABLE_MEMORY_KIND_DIRS.includes(firstSegment)) {
+    if (!SHAREABLE_TOP_LEVEL_DIRS.includes(firstSegment)) {
       continue;
     }
     const uri = workfileToVikingUri(config, team, change.path);

--- a/src/threadnote.ts
+++ b/src/threadnote.ts
@@ -24,8 +24,10 @@ import type {
   RememberOptions,
   RepairOptions,
   SeedOptions,
+  ShareInstallArtifactsOptions,
   ShareInitOptions,
   ShareListOptions,
+  SharePublishArtifactOptions,
   SharePublishOptions,
   ShareRenameOptions,
   ShareRemoveOptions,
@@ -62,8 +64,10 @@ import {
 import {runInitManifest, runSeed, runSeedSkills} from './seeding.js';
 import {
   runShareInit,
+  runShareInstallArtifacts,
   runShareList,
   runSharePublish,
+  runSharePublishArtifact,
   runShareRename,
   runShareRemove,
   runShareSetUrl,
@@ -491,6 +495,42 @@ async function main(): Promise<void> {
     )
     .action(async (uri: string, options: SharePublishOptions) => {
       await runSharePublish(getRuntimeConfig(program), uri, options);
+    });
+
+  share
+    .command('publish-artifact')
+    .description('Publish a local Codex/Claude skill or Claude command into the shared team repo')
+    .argument('<path>', 'Path to SKILL.md or a Claude command markdown file')
+    .option('--team <name>', 'Team name; defaults to the configured default team')
+    .option('--agent <agent>', 'Agent owner when path inference is ambiguous: codex or claude')
+    .option('--kind <kind>', 'Artifact kind when path inference is ambiguous: skill or command')
+    .option('--name <name>', 'Shared artifact name; defaults to skill directory or command file stem')
+    .option('--message <text>', 'Commit message override')
+    .option('--force', 'Replace an existing shared artifact with different content')
+    .option('--no-push', 'Skip the push step')
+    .option('--dry-run', 'Print actions without running them')
+    .option('--preview', 'Print the exact artifact bytes that would land in the shared git repo')
+    .option(
+      '--redact',
+      'Replace soft-leak matches (local paths) with placeholders and continue; credentials still block',
+    )
+    .action(async (path: string, options: SharePublishArtifactOptions) => {
+      await runSharePublishArtifact(getRuntimeConfig(program), path, options);
+    });
+
+  share
+    .command('install-artifacts')
+    .description('Install shared Codex/Claude skills and Claude commands from a team repo')
+    .option('--team <name>', 'Team name; defaults to the configured default team')
+    .option('--agent <agent>', 'Install only artifacts for this agent: codex or claude')
+    .option('--kind <kind>', 'Install only artifacts of this kind: skill or command')
+    .option('--name <name>', 'Install only this shared artifact name')
+    .option('--apply', 'Actually write files into local agent skill/command directories')
+    .option('--force', 'Replace existing installed artifacts with different content')
+    .option('--no-sync', 'Skip pulling shared team updates before listing/installing artifacts')
+    .option('--dry-run', 'Preview install actions without writing files')
+    .action(async (options: ShareInstallArtifactsOptions) => {
+      await runShareInstallArtifacts(getRuntimeConfig(program), options);
     });
 
   share

--- a/src/types.ts
+++ b/src/types.ts
@@ -307,6 +307,41 @@ export interface SharePublishOptions {
   readonly team?: string;
 }
 
+export type ShareAgentArtifactAgent = 'claude' | 'codex';
+export type ShareAgentArtifactKind = 'command' | 'skill';
+
+export interface SharePublishArtifactOptions {
+  readonly agent?: ShareAgentArtifactAgent;
+  readonly dryRun?: boolean;
+  readonly force?: boolean;
+  readonly kind?: ShareAgentArtifactKind;
+  readonly message?: string;
+  readonly name?: string;
+  readonly preview?: boolean;
+  readonly push?: boolean;
+  readonly redact?: boolean;
+  readonly team?: string;
+}
+
+export interface ShareInstallArtifactsOptions {
+  readonly agent?: ShareAgentArtifactAgent;
+  readonly apply?: boolean;
+  readonly dryRun?: boolean;
+  readonly force?: boolean;
+  readonly kind?: ShareAgentArtifactKind;
+  readonly name?: string;
+  readonly sync?: boolean;
+  readonly team?: string;
+}
+
+export interface ShareListArtifactsOptions {
+  readonly agent?: ShareAgentArtifactAgent;
+  readonly kind?: ShareAgentArtifactKind;
+  readonly name?: string;
+  readonly sync?: boolean;
+  readonly team?: string;
+}
+
 export interface ShareUnpublishOptions {
   readonly dryRun?: boolean;
   readonly message?: string;

--- a/test/unit/share.artifacts.test.ts
+++ b/test/unit/share.artifacts.test.ts
@@ -1,0 +1,399 @@
+import {mkdtemp, mkdir, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  installSharedAgentArtifacts,
+  listSharedAgentArtifacts,
+  runShareInstallArtifacts,
+  shareAgentArtifact,
+} from '../../src/share.js';
+import type {CommandResult, ShareRuntime} from '../../src/types.js';
+import * as utils from '../../src/utils.js';
+
+vi.mock('../../src/utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../src/utils.js')>();
+  return {
+    ...actual,
+    maybeRun: vi.fn(),
+    openVikingCliForMode: vi.fn().mockResolvedValue('/ov'),
+    requiredExecutable: vi.fn().mockResolvedValue('git'),
+    runCommand: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const ok = (stdout = ''): CommandResult => ({exitCode: 0, stdout, stderr: ''});
+const fail = (stderr = '[NOT_FOUND]'): CommandResult => ({exitCode: 1, stdout: '', stderr});
+
+async function makeRuntime(): Promise<ShareRuntime> {
+  const home = await mkdtemp(join(tmpdir(), 'threadnote-share-artifacts-'));
+  const worktree = join(home, 'shared', 'default');
+  const gitdir = join(home, 'share', 'teams', 'default.gitdir');
+  await mkdir(join(home, 'share'), {recursive: true});
+  await mkdir(worktree, {recursive: true});
+  await writeFile(
+    join(home, 'share', 'teams.json'),
+    `${JSON.stringify(
+      {
+        defaultTeam: 'default',
+        teams: {
+          default: {
+            addedAt: '2026-06-10T00:00:00.000Z',
+            gitdir,
+            name: 'default',
+            remote: 'git@example.com:team/memories.git',
+            worktree,
+          },
+        },
+        version: 1,
+      },
+      undefined,
+      2,
+    )}\n`,
+  );
+  return {
+    account: 'local',
+    agentContextHome: home,
+    agentId: 'threadnote',
+    user: 'denyskashkovskyi',
+  };
+}
+
+function mockPublishCommands(): void {
+  vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+    if (executable === '/ov' && args[0] === 'stat') {
+      return fail();
+    }
+    if (executable === '/ov' && (args[0] === 'mkdir' || args[0] === 'write')) {
+      return ok('ok');
+    }
+    if (executable === 'git' && (args.includes('add') || args.includes('commit') || args.includes('push'))) {
+      return ok('ok');
+    }
+    return ok();
+  });
+  vi.mocked(utils.maybeRun).mockImplementation(async (dryRun, executable, args, options) =>
+    dryRun ? undefined : vi.mocked(utils.runCommand)(executable, args, options),
+  );
+}
+
+describe('shared agent artifacts', () => {
+  const homes: string[] = [];
+  const originalHome = process.env.HOME;
+
+  beforeEach(() => {
+    vi.mocked(utils.runCommand).mockReset();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    vi.restoreAllMocks();
+    await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+  });
+
+  it('publishes a Codex skill into the shared artifact catalog and indexes it', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const sourcePath = join(config.agentContextHome, '.codex', 'skills', 'reviewer', 'SKILL.md');
+    await mkdir(join(sourcePath, '..'), {recursive: true});
+    await writeFile(sourcePath, '# Reviewer\n\nReview local diffs.\n');
+    mockPublishCommands();
+
+    const result = await shareAgentArtifact(config, sourcePath, {});
+
+    expect(result.targetUri).toBe(
+      'viking://user/denyskashkovskyi/memories/shared/default/agent-artifacts/skills/codex/reviewer/SKILL.md',
+    );
+    expect(vi.mocked(utils.runCommand).mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          '/ov',
+          expect.arrayContaining([
+            'write',
+            'viking://user/denyskashkovskyi/memories/shared/default/agent-artifacts/skills/codex/reviewer/SKILL.md',
+          ]),
+          {allowFailure: true},
+        ],
+        [
+          'git',
+          [
+            '-C',
+            join(config.agentContextHome, 'shared', 'default'),
+            'add',
+            '--',
+            'agent-artifacts/skills/codex/reviewer/SKILL.md',
+          ],
+          {allowFailure: true},
+        ],
+      ]),
+    );
+  });
+
+  it('refuses to overwrite a different shared artifact unless forced', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const sourcePath = join(config.agentContextHome, '.claude', 'commands', 'review.md');
+    const sharedPath = join(config.agentContextHome, 'shared', 'default', 'agent-artifacts', 'commands', 'claude');
+    await mkdir(join(sourcePath, '..'), {recursive: true});
+    await mkdir(sharedPath, {recursive: true});
+    await writeFile(sourcePath, 'new command\n');
+    await writeFile(join(sharedPath, 'review.md'), 'old command\n');
+    mockPublishCommands();
+
+    await expect(shareAgentArtifact(config, sourcePath, {})).rejects.toThrow(/already exists with different content/);
+    await expect(readFile(join(sharedPath, 'review.md'), 'utf8')).resolves.toBe('old command\n');
+  });
+
+  it('does not leave a shared artifact file behind when OpenViking write fails', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const sourcePath = join(config.agentContextHome, '.codex', 'skills', 'reviewer', 'SKILL.md');
+    await mkdir(join(sourcePath, '..'), {recursive: true});
+    await writeFile(sourcePath, '# Reviewer\n');
+    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+      if (executable === '/ov' && args[0] === 'stat') {
+        return fail();
+      }
+      if (executable === '/ov' && args[0] === 'mkdir') {
+        return ok('ok');
+      }
+      if (executable === '/ov' && args[0] === 'write') {
+        return fail('write failed');
+      }
+      return ok();
+    });
+
+    await expect(shareAgentArtifact(config, sourcePath, {})).rejects.toThrow(/write failed/);
+
+    await expect(
+      readFile(
+        join(
+          config.agentContextHome,
+          'shared',
+          'default',
+          'agent-artifacts',
+          'skills',
+          'codex',
+          'reviewer',
+          'SKILL.md',
+        ),
+        'utf8',
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('installs shared artifacts into namespaced local agent paths only when applied', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-artifact-install-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const sharedSkill = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'claude',
+      'triage',
+      'SKILL.md',
+    );
+    await mkdir(join(sharedSkill, '..'), {recursive: true});
+    await writeFile(sharedSkill, '# Triage\n');
+
+    await runShareInstallArtifacts(config, {apply: true, sync: false});
+
+    await expect(
+      readFile(join(installHome, '.claude', 'skills', 'threadnote', 'default', 'triage', 'SKILL.md'), 'utf8'),
+    ).resolves.toBe('# Triage\n');
+  });
+
+  it('lists shared artifacts with install status', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-artifact-list-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const sharedSkill = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'codex',
+      'reviewer',
+      'SKILL.md',
+    );
+    await mkdir(join(sharedSkill, '..'), {recursive: true});
+    await writeFile(sharedSkill, '# Reviewer\n');
+
+    const result = await listSharedAgentArtifacts(config, {sync: false});
+
+    expect(result.team).toBe('default');
+    expect(result.artifacts).toMatchObject([
+      {
+        artifact: {agent: 'codex', kind: 'skill', name: 'reviewer'},
+        installStatus: 'not_installed',
+      },
+    ]);
+  });
+
+  it('requires disambiguation when installing a shared artifact name with multiple matches', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-artifact-ambiguous-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const codexSkill = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'codex',
+      'reviewer',
+      'SKILL.md',
+    );
+    const claudeSkill = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'claude',
+      'reviewer',
+      'SKILL.md',
+    );
+    await mkdir(join(codexSkill, '..'), {recursive: true});
+    await mkdir(join(claudeSkill, '..'), {recursive: true});
+    await writeFile(codexSkill, '# Codex Reviewer\n');
+    await writeFile(claudeSkill, '# Claude Reviewer\n');
+
+    await expect(installSharedAgentArtifacts(config, {apply: true, name: 'reviewer', sync: false})).rejects.toThrow(
+      /ambiguous/,
+    );
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'codex',
+      apply: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    await expect(
+      readFile(join(installHome, '.codex', 'skills', 'threadnote', 'default', 'reviewer', 'SKILL.md'), 'utf8'),
+    ).resolves.toBe('# Codex Reviewer\n');
+  });
+
+  it('reports update available when the shared artifact changes after install', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-artifact-update-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const sharedSkill = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'codex',
+      'reviewer',
+      'SKILL.md',
+    );
+    await mkdir(join(sharedSkill, '..'), {recursive: true});
+    await writeFile(sharedSkill, '# Reviewer v1\n');
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'codex',
+      apply: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+    await writeFile(sharedSkill, '# Reviewer v2\n');
+
+    const listed = await listSharedAgentArtifacts(config, {sync: false});
+
+    expect(listed.artifacts).toMatchObject([
+      {
+        artifact: {agent: 'codex', kind: 'skill', name: 'reviewer'},
+        installStatus: 'update_available',
+      },
+    ]);
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'codex',
+      apply: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    await expect(
+      readFile(join(installHome, '.codex', 'skills', 'threadnote', 'default', 'reviewer', 'SKILL.md'), 'utf8'),
+    ).resolves.toBe('# Reviewer v2\n');
+  });
+
+  it('protects local modifications when the shared artifact changes too', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-artifact-local-mod-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const sharedSkill = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'codex',
+      'reviewer',
+      'SKILL.md',
+    );
+    const installPath = join(installHome, '.codex', 'skills', 'threadnote', 'default', 'reviewer', 'SKILL.md');
+    await mkdir(join(sharedSkill, '..'), {recursive: true});
+    await writeFile(sharedSkill, '# Reviewer v1\n');
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'codex',
+      apply: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+    await writeFile(sharedSkill, '# Reviewer v2\n');
+    await writeFile(installPath, '# Local edit\n');
+
+    const listed = await listSharedAgentArtifacts(config, {sync: false});
+
+    expect(listed.artifacts[0]?.installStatus).toBe('remote_changed_and_local_modified');
+    await expect(
+      installSharedAgentArtifacts(config, {
+        agent: 'codex',
+        apply: true,
+        kind: 'skill',
+        name: 'reviewer',
+        sync: false,
+      }),
+    ).rejects.toThrow(/Refusing to overwrite/);
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'codex',
+      apply: true,
+      force: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    await expect(readFile(installPath, 'utf8')).resolves.toBe('# Reviewer v2\n');
+  });
+});


### PR DESCRIPTION
Summary

- Add a shared `agent-artifacts/` lane for Codex/Claude skills and Claude commands.
- Add MCP tools to share, list, and install team shared skills.
- Bump the package version to `1.1.3` for the GitHub release.

Detail

- Shared artifacts live next to shared memories but outside `durable/`, so executable agent affordances keep a separate lifecycle.
- `list_shared_skills` syncs shared repos before reporting `not_installed`, `current`, `update_available`, `local_modified`, or `remote_changed_and_local_modified`.
- Installs write sidecar metadata next to local skill files so remote updates can be detected without overwriting local edits silently.
- `install_shared_skill` / `threadnote share install-artifacts` require explicit install/update and protect local modifications unless `force:true` / `--force` is used.

Test plan

- `npm run typecheck --silent`
- `npx vitest run test/unit/share.artifacts.test.ts test/unit/share*.test.ts test/integration/mcp.share-publish.test.ts test/unit/seeding.test.ts`
- `npm run build --silent`
- `npm test --silent`
- `git diff --check`
