### PR TITLE
Fix share sync dirty worktrees

### DIFF
--- a/docs/share.md
+++ b/docs/share.md
@@ -194,12 +194,15 @@ threadnote share sync --team friends   # other team
 threadnote share sync --no-push        # pull only
 ```
 
-`share sync` will auto-commit any uncommitted edits in the worktree, fetch and
-rebase from the remote, reindex pulled markdown files into OpenViking (so
-`recall` finds them immediately), and push. Pass `--no-auto-commit` to refuse
-syncing when the worktree is dirty. Automatic recall/read sync never commits a
-dirty shared worktree; it warns and leaves that case for explicit
-`threadnote share sync`.
+`share sync` will auto-commit edits in Threadnote-managed share paths, fetch and
+rebase onto the configured upstream, reindex pulled markdown files into
+OpenViking (so `recall` finds them immediately), and push. Managed share paths
+are root guidance/metadata files (`README.md`, `AGENTS.md`, `CLAUDE.md`,
+`SKILL.md`, `.gitignore`) plus `durable/` and `agent-artifacts/`. If other dirty
+files remain after staging those paths, sync stops before rebase so you can
+commit, remove, or ignore them. Pass `--no-auto-commit` to refuse syncing when
+the worktree is dirty. Automatic recall/read sync never commits a dirty shared
+worktree; it warns and leaves that case for explicit `threadnote share sync`.
 
 ### Take a memory back
 
@@ -280,8 +283,8 @@ updates the git `origin` URL and verifies it with `git fetch`.
 
 ## Conflict resolution
 
-`share sync` uses `git pull --rebase` against the remote. When git can't merge
-cleanly:
+`share sync` fetches the remote, then rebases onto the branch's configured
+upstream. When git can't merge cleanly:
 
 1. The pull command reports the conflict and leaves the worktree in a
    rebase-in-progress state.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "commonjs",
   "main": "dist/threadnote.cjs",
   "description": "Shared local context and handoffs for development agents",

--- a/src/share.ts
+++ b/src/share.ts
@@ -48,6 +48,7 @@ const SHARED_SEGMENT = 'shared';
 const SHAREABLE_MEMORY_KIND_DIRS = ['durable'];
 const SHAREABLE_ARTIFACT_DIR = 'agent-artifacts';
 const SHAREABLE_TOP_LEVEL_DIRS = [...SHAREABLE_MEMORY_KIND_DIRS, SHAREABLE_ARTIFACT_DIR];
+const SHAREABLE_ROOT_FILES = ['README.md', 'AGENTS.md', 'CLAUDE.md', 'SKILL.md', '.gitignore'];
 const ARTIFACT_INSTALL_METADATA_VERSION = 1;
 const AUTO_SHARE_FETCH_INTERVAL_MS = 5 * 60 * 1000;
 export const DEFAULT_GIT_REMOTE_NAME = 'origin';
@@ -588,16 +589,35 @@ export async function runShareSync(config: ShareRuntime, options: ShareSyncOptio
     }
     const message = options.message ?? `share: sync ${new Date().toISOString()}`;
     await stageShareableChanges(dryRun, git, worktree);
-    await maybeRun(dryRun, git, ['-C', worktree, 'commit', '-m', message], {allowFailure: true});
+    const commitResult = await maybeRun(dryRun, git, ['-C', worktree, 'commit', '-m', message], {allowFailure: true});
+    if (!dryRun && commitResult && commitResult.exitCode !== 0) {
+      if (await hasUncommittedChanges(worktree)) {
+        throw new Error(
+          `Worktree ${worktree} has uncommitted changes that Threadnote did not auto-commit. Commit, remove, or ignore the remaining files, then rerun \`threadnote share sync\`.\nGit said: ${
+            commitResult.stderr.trim() || commitResult.stdout.trim() || 'unknown git commit error'
+          }`,
+        );
+      }
+      throw new Error(
+        `Could not auto-commit share worktree changes in ${worktree}: ${
+          commitResult.stderr.trim() || commitResult.stdout.trim() || 'unknown git commit error'
+        }`,
+      );
+    }
+    if (!dryRun && (await hasUncommittedChanges(worktree))) {
+      throw new Error(
+        `Worktree ${worktree} still has uncommitted changes after staging Threadnote shareable files. Commit, remove, or ignore the remaining files, then rerun \`threadnote share sync\`.`,
+      );
+    }
   }
 
   const beforeRev = await gitOutput(worktree, ['rev-parse', 'HEAD'], dryRun);
   await maybeRun(dryRun, git, ['-C', worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME]);
   const pullResult = dryRun
     ? undefined
-    : await runCommand(git, ['-C', worktree, 'pull', '--rebase', DEFAULT_GIT_REMOTE_NAME], {allowFailure: true});
+    : await runCommand(git, ['-C', worktree, 'rebase', '@{u}'], {allowFailure: true});
   if (dryRun) {
-    console.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'pull', '--rebase', DEFAULT_GIT_REMOTE_NAME])}`);
+    console.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'rebase', '@{u}'])}`);
   } else if (pullResult && pullResult.exitCode !== 0) {
     // Detect mid-rebase state via filesystem markers rather than parsing git's
     // output — both because git's English phrasing varies by version and
@@ -613,7 +633,7 @@ export async function runShareSync(config: ShareRuntime, options: ShareSyncOptio
       );
     }
     throw new Error(
-      `git pull --rebase failed in ${worktree}: ${pullResult.stderr.trim() || pullResult.stdout.trim() || 'unknown error'}`,
+      `git rebase @{u} failed in ${worktree}: ${pullResult.stderr.trim() || pullResult.stdout.trim() || 'unknown error'}`,
     );
   }
   const afterRev = await gitOutput(worktree, ['rev-parse', 'HEAD'], dryRun);
@@ -709,12 +729,37 @@ async function runShareSyncQuiet(
 }
 
 async function stageShareableChanges(dryRun: boolean, git: string, worktree: string): Promise<void> {
-  // Stage repo metadata plus every shareable top-level dir.
+  // Stage repo guidance/metadata plus every shareable top-level dir.
   // OpenViking-generated summaries (.abstract.md, .overview.md) are excluded
   // via the repo's .gitignore (ensureSharedGitignore self-heals it on every
   // sync), so they never get staged even by an unscoped `git add`.
-  const pathspecs = [':(top)README.md', ':(top).gitignore', ...SHAREABLE_TOP_LEVEL_DIRS.map(dir => `:(top)${dir}`)];
-  await maybeRun(dryRun, git, ['-C', worktree, 'add', '--', ...pathspecs], {allowFailure: true});
+  const pathspecs = await existingShareablePathspecs(git, worktree);
+  if (pathspecs.length === 0) {
+    return;
+  }
+  await maybeRun(dryRun, git, ['-C', worktree, 'add', '-A', '--', ...pathspecs], {allowFailure: true});
+}
+
+async function existingShareablePathspecs(git: string, worktree: string): Promise<readonly string[]> {
+  const rootFiles = await Promise.all(
+    SHAREABLE_ROOT_FILES.map(async file =>
+      (await hasWorktreeOrTrackedPath(git, worktree, file)) ? `:(top)${file}` : undefined,
+    ),
+  );
+  const topLevelDirs = await Promise.all(
+    SHAREABLE_TOP_LEVEL_DIRS.map(async dir =>
+      (await hasWorktreeOrTrackedPath(git, worktree, dir)) ? `:(top)${dir}` : undefined,
+    ),
+  );
+  return [...rootFiles, ...topLevelDirs].filter((pathspec): pathspec is string => pathspec !== undefined);
+}
+
+async function hasWorktreeOrTrackedPath(git: string, worktree: string, relativePath: string): Promise<boolean> {
+  if (await exists(join(worktree, relativePath))) {
+    return true;
+  }
+  const result = await runCommand(git, ['-C', worktree, 'ls-files', '--', relativePath], {allowFailure: true});
+  return result.exitCode === 0 && result.stdout.trim().length > 0;
 }
 
 export async function publishShareGitChange(

--- a/test/integration/share.sync.test.ts
+++ b/test/integration/share.sync.test.ts
@@ -1,0 +1,133 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {runShareSync} from '../../src/share.js';
+import type {ShareRuntime, ShareTeamsFile} from '../../src/types.js';
+import {runCommand} from '../../src/utils.js';
+
+interface TestShareRepo {
+  readonly config: ShareRuntime;
+  readonly home: string;
+  readonly worktree: string;
+}
+
+const homes: string[] = [];
+const GIT_ENV_KEYS = [
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_PREFIX',
+  'GIT_COMMON_DIR',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_QUARANTINE_PATH',
+] as const;
+const savedGitEnv = new Map<string, string | undefined>();
+
+async function git(args: readonly string[], cwd?: string): Promise<void> {
+  await runCommand('git', args, {cwd});
+}
+
+async function gitOutput(args: readonly string[], cwd?: string): Promise<string> {
+  const result = await runCommand('git', args, {cwd});
+  return result.stdout.trim();
+}
+
+async function makeShareRepo(): Promise<TestShareRepo> {
+  const root = await mkdtemp(join(tmpdir(), 'threadnote-share-sync-'));
+  homes.push(root);
+
+  const remote = join(root, 'remote.git');
+  const seed = join(root, 'seed');
+  await mkdir(seed, {recursive: true});
+  await git(['init', '--bare', remote]);
+  await git(['init'], seed);
+  await git(['checkout', '-b', 'main'], seed);
+  await git(['config', 'user.email', 'threadnote-test@example.com'], seed);
+  await git(['config', 'user.name', 'Threadnote Test'], seed);
+  await writeFile(join(seed, 'README.md'), '# Shared memories\n', 'utf8');
+  await git(['add', 'README.md'], seed);
+  await git(['commit', '-m', 'initial'], seed);
+  await git(['remote', 'add', 'origin', remote], seed);
+  await git(['push', '-u', 'origin', 'main'], seed);
+  await git(['checkout', '-b', 'other'], seed);
+  await writeFile(join(seed, 'other.md'), 'other branch\n', 'utf8');
+  await git(['add', 'other.md'], seed);
+  await git(['commit', '-m', 'other branch'], seed);
+  await git(['push', 'origin', 'other'], seed);
+  await git(['--git-dir', remote, 'symbolic-ref', 'HEAD', 'refs/heads/main']);
+
+  const home = join(root, 'home');
+  const worktree = join(home, 'data', 'viking', 'local', 'user', 'denys', 'memories', 'shared', 'default');
+  const gitdir = join(home, 'share', 'teams', 'default.gitdir');
+  await mkdir(dirname(worktree), {recursive: true});
+  await mkdir(dirname(gitdir), {recursive: true});
+  await git(['clone', `--separate-git-dir=${gitdir}`, '--branch', 'main', '--', remote, worktree]);
+  await git(['config', 'user.email', 'threadnote-test@example.com'], worktree);
+  await git(['config', 'user.name', 'Threadnote Test'], worktree);
+
+  const config: ShareRuntime = {account: 'local', agentContextHome: home, agentId: 'threadnote', user: 'denys'};
+  const teams: ShareTeamsFile = {
+    defaultTeam: 'default',
+    teams: {
+      default: {
+        addedAt: new Date(0).toISOString(),
+        gitdir,
+        name: 'default',
+        remote,
+        worktree,
+      },
+    },
+    version: 1,
+  };
+  await mkdir(join(home, 'share'), {recursive: true});
+  await writeFile(join(home, 'share', 'teams.json'), `${JSON.stringify(teams, undefined, 2)}\n`, 'utf8');
+  return {config, home, worktree};
+}
+
+describe('share sync git handling', () => {
+  beforeEach(() => {
+    savedGitEnv.clear();
+    for (const key of GIT_ENV_KEYS) {
+      savedGitEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+    for (const key of GIT_ENV_KEYS) {
+      const value = savedGitEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    savedGitEnv.clear();
+  });
+
+  it('auto-commits root Claude guidance and rebases onto the configured upstream', async () => {
+    const {config, worktree} = await makeShareRepo();
+    await writeFile(join(worktree, 'CLAUDE.md'), '# Shared Claude guidance\n', 'utf8');
+
+    await runShareSync(config, {message: 'share: test sync', push: false});
+
+    await expect(gitOutput(['status', '--porcelain'], worktree)).resolves.toBe('');
+    await expect(gitOutput(['ls-files', 'CLAUDE.md'], worktree)).resolves.toBe('CLAUDE.md');
+    await expect(gitOutput(['log', '-1', '--format=%s', '--', 'CLAUDE.md'], worktree)).resolves.toBe(
+      'share: test sync',
+    );
+  });
+
+  it('stops before rebase when non-shareable untracked files remain', async () => {
+    const {config, worktree} = await makeShareRepo();
+    await writeFile(join(worktree, 'local.txt'), 'local only\n', 'utf8');
+
+    await expect(runShareSync(config, {message: 'share: test sync', push: false})).rejects.toThrow(
+      /did not auto-commit/,
+    );
+    await expect(gitOutput(['status', '--porcelain'], worktree)).resolves.toContain('?? local.txt');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes manual `threadnote share sync` when a shared repo has root guidance changes like `CLAUDE.md` and the remote has multiple branches.

## Detail
Root cause: manual sync staged only `README.md`, `.gitignore`, `durable/`, and `agent-artifacts/`, so root guidance files such as `CLAUDE.md` stayed untracked. The commit step could become a no-op, then sync continued into `git pull --rebase origin`, which can fail with `fatal: Cannot rebase onto multiple branches`.

Changes:
- stages existing/tracked root guidance files (`README.md`, `AGENTS.md`, `CLAUDE.md`, `SKILL.md`, `.gitignore`) plus managed share dirs
- stops before fetch/rebase if unrelated dirty files remain after staging
- uses `git fetch origin` + `git rebase @{u}` for manual sync
- bumps package version to `1.1.5`

## Test plan
- `npm run lint --silent`
- `npm run prettier:check --silent`
- `npm run typecheck --silent`
- `npm run test -- --run test/integration/share.sync.test.ts`
- `npm run test --silent`
- `npm run build --silent`
