### PR TITLE
Rank recall memories above resources and skills

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -886,7 +886,16 @@ export interface ExactMatch {
   readonly uri: string;
 }
 
+/**
+ * Result buckets in the order recall presents them: memories first, then seeded
+ * resources, then skills. The index doubles as the primary sort key so a
+ * lower-scoring memory still ranks above a higher-scoring resource or skill.
+ */
+export const RECALL_CATEGORY_ORDER = ['memories', 'resources', 'skills'] as const;
+export type RecallCategory = (typeof RECALL_CATEGORY_ORDER)[number];
+
 export interface RecallHit {
+  readonly category: RecallCategory;
   readonly contextType: string;
   readonly score: number;
   readonly snippet: string;
@@ -930,7 +939,7 @@ export function parseRecallHits(output: string, options: ParseRecallHitsOptions 
       return [];
     }
     const hits: RecallHit[] = [];
-    for (const key of ['memories', 'resources', 'skills']) {
+    for (const key of RECALL_CATEGORY_ORDER) {
       const items = result[key];
       if (!Array.isArray(items)) {
         continue;
@@ -943,6 +952,7 @@ export function parseRecallHits(output: string, options: ParseRecallHitsOptions 
           continue;
         }
         hits.push({
+          category: key,
           contextType: typeof item.context_type === 'string' ? item.context_type : 'result',
           score: typeof item.score === 'number' ? item.score : 0,
           snippet: recallSnippet(item.abstract ?? item.overview),
@@ -961,6 +971,10 @@ export function parseRecallHits(output: string, options: ParseRecallHitsOptions 
  * one entry per document (chunk anchors stripped), keeping the highest-scoring
  * chunk. Lets the scoped project/seeded passes contribute only documents the
  * global pass missed, and collapses multiple chunks of the same document.
+ *
+ * Ranking is category-first (memories, then resources, then skills per
+ * `RECALL_CATEGORY_ORDER`), then by score within each category, so personal
+ * memories always lead and seeded resources/skills only follow.
  */
 export function mergeRecallHits(passes: ReadonlyArray<readonly RecallHit[]>): readonly RecallHit[] {
   const byDocument = new Map<string, RecallHit>();
@@ -973,7 +987,11 @@ export function mergeRecallHits(passes: ReadonlyArray<readonly RecallHit[]>): re
       }
     }
   }
-  return [...byDocument.values()].sort((left, right) => right.score - left.score);
+  return [...byDocument.values()].sort(
+    (left, right) =>
+      RECALL_CATEGORY_ORDER.indexOf(left.category) - RECALL_CATEGORY_ORDER.indexOf(right.category) ||
+      right.score - left.score,
+  );
 }
 
 export function formatRecallHits(hits: readonly RecallHit[], maxHits: number): string | undefined {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -586,8 +586,8 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
       }),
     );
     expect(hits).toEqual([
-      {contextType: 'memory', uri: 'viking://m.md#chunk_0001', score: 0.7, snippet: 'a b c'},
-      {contextType: 'resource', uri: 'viking://r.md', score: 0.6, snippet: 'doc'},
+      {category: 'memories', contextType: 'memory', uri: 'viking://m.md#chunk_0001', score: 0.7, snippet: 'a b c'},
+      {category: 'resources', contextType: 'resource', uri: 'viking://r.md', score: 0.6, snippet: 'doc'},
     ]);
   });
 
@@ -660,8 +660,25 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
     ]);
   });
 
+  it('ranks memories above resources and skills regardless of score', () => {
+    const merged = mergeRecallHits([
+      parseRecallHits(
+        json({
+          ok: true,
+          result: {
+            memories: [{context_type: 'memory', uri: 'viking://mem.md', score: 0.5, abstract: 'm'}],
+            resources: [{context_type: 'resource', uri: 'viking://res.md', score: 0.9, abstract: 'r'}],
+            skills: [{context_type: 'skill', uri: 'viking://skill.md', score: 0.8, abstract: 's'}],
+          },
+        }),
+      ),
+    ]);
+    expect(merged.map(hit => hit.uri)).toEqual(['viking://mem.md', 'viking://res.md', 'viking://skill.md']);
+  });
+
   it('formats a capped numbered list with overflow note', () => {
     const hits = Array.from({length: 4}, (_unused, index) => ({
+      category: 'memories' as const,
       contextType: 'memory',
       score: 0.5,
       snippet: '',


### PR DESCRIPTION
Recall merged all hits into one list sorted purely by `score`, so a high-scoring seeded resource or skill could outrank actual memories. The fix makes ranking category-first: memories, then resources, then skills, with score ordering only *within* each category.

**Detail:**
- `RecallHit` (`src/utils.ts`) now carries a `category: RecallCategory` derived from the authoritative `ov search` JSON bucket key (`memories`/`resources`/`skills`), not the looser `context_type` string.
- New exported `RECALL_CATEGORY_ORDER = ['memories', 'resources', 'skills']` is the single source of truth — `parseRecallHits` iterates it to tag each hit, and `mergeRecallHits` sorts by `RECALL_CATEGORY_ORDER.indexOf(category)` then `score` desc.
- Both consumers flow through `mergeRecallHits` → `formatRecallHits` (`src/memory.ts:351`, `src/mcp_server.ts:917`), so CLI recall and MCP `recall_context` inherit the ordering with no call-site changes.

So a 0.50 memory now ranks above a 0.90 resource.

**Test plan:**
- Updated `parseRecallHits` assertion for the new `category` field.
- Added a test proving memories rank above higher-scoring resources/skills.
- `vitest run`: 217 passed. `tsc --noEmit` and `eslint` clean.