### PR TITLE
Recall ranking: fold in exact matches, reserve per-category window slots

### DIFF
--- a/.threadnoteignore
+++ b/.threadnoteignore
@@ -1,5 +1,7 @@
 .git/
 node_modules/
+.claude/worktrees/
+.worktrees/
 bazel-*/
 dist/
 build/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "1.1.6",
+      "version": "1.2.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "type": "commonjs",
   "main": "dist/threadnote.cjs",
   "description": "Shared local context and handoffs for development agents",

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -42,7 +42,7 @@ import {
   writeMemoryFile,
 } from './share.js';
 import {
-  applyExactMatchBoost,
+  buildRecallSections,
   collectExactMatches,
   type ExactMatch,
   errorMessage,
@@ -53,9 +53,6 @@ import {
   exactRecallTerms,
   expandPath,
   findOpenVikingCli,
-  formatExactMatchPointers,
-  formatRecallHits,
-  mergeRecallHits,
   parsePort,
   parseRecallHits,
   type RecallHit,
@@ -918,9 +915,7 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
 
   const sections: string[] = [];
   const exactMatches = await collectExactMemoryMatches(config, query, params.includeArchived, project);
-  const limit = params.nodeLimit ?? 12;
-  const ranked = applyExactMatchBoost(mergeRecallHits(passes), exactMatches);
-  const semanticSection = formatRecallHits(ranked, limit);
+  const {semanticSection, exactTail} = buildRecallSections(passes, exactMatches, params.nodeLimit ?? 12);
   if (semanticSection) {
     sections.push(semanticSection);
   } else if (!base.ok) {
@@ -931,10 +926,8 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   if (indexRepairMessages.length > 0) {
     sections.push(indexRepairMessages.join('\n'));
   }
-  const shownUris = new Set(ranked.slice(0, limit).map(hit => hit.uri));
-  const exactSection = formatExactMatchPointers(exactMatches.filter(match => !shownUris.has(match.uri)));
-  if (exactSection) {
-    sections.push(exactSection);
+  if (exactTail) {
+    sections.push(exactTail);
   }
   const hygieneHints = await recallHygieneHintsSection(config, sections.join('\n\n'));
   if (hygieneHints) {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -42,7 +42,9 @@ import {
   writeMemoryFile,
 } from './share.js';
 import {
+  applyExactMatchBoost,
   collectExactMatches,
+  type ExactMatch,
   errorMessage,
   enrichRecallQueryWithWorkspaceContext,
   enrichRecallQueryWithWorkspaceProjectContext,
@@ -258,14 +260,15 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
     'grep',
     {
       annotations: {readOnlyHint: true, destructiveHint: false},
-      description: 'Run exact text search in OpenViking.',
+      description:
+        'Run exact text search in OpenViking. Defaults to your memories subtree when uri is omitted (OpenViking grep requires a scope).',
       inputSchema: {
         caseInsensitive: z.boolean().optional().describe('Case-insensitive search'),
         case_insensitive: z.boolean().optional().describe('Case-insensitive search'),
         nodeLimit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
         node_limit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
         pattern: z.string().optional().describe('Required text or regex pattern'),
-        uri: z.string().optional().describe('Optional viking:// subtree'),
+        uri: z.string().optional().describe('Optional viking:// subtree (defaults to your memories root)'),
       },
     },
     async ({caseInsensitive, case_insensitive, nodeLimit, node_limit, pattern, uri}) => {
@@ -281,7 +284,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
         case_insensitive: caseInsensitive ?? case_insensitive,
         node_limit: nodeLimit ?? node_limit,
         pattern: checkedPattern.value,
-        uri: checkedUri.value,
+        uri: checkedUri.value ?? `viking://user/${uriSegment(config.user)}/memories`,
       });
     },
   );
@@ -914,7 +917,10 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   }
 
   const sections: string[] = [];
-  const semanticSection = formatRecallHits(mergeRecallHits(passes), params.nodeLimit ?? 12);
+  const exactMatches = await collectExactMemoryMatches(config, query, params.includeArchived, project);
+  const limit = params.nodeLimit ?? 12;
+  const ranked = applyExactMatchBoost(mergeRecallHits(passes), exactMatches);
+  const semanticSection = formatRecallHits(ranked, limit);
   if (semanticSection) {
     sections.push(semanticSection);
   } else if (!base.ok) {
@@ -925,9 +931,10 @@ async function runRecallTool(config: RuntimeConfig, params: RecallToolParams): P
   if (indexRepairMessages.length > 0) {
     sections.push(indexRepairMessages.join('\n'));
   }
-  const exactMatches = await exactMemoryMatchesText(config, query, params.includeArchived, project);
-  if (exactMatches) {
-    sections.push(exactMatches);
+  const shownUris = new Set(ranked.slice(0, limit).map(hit => hit.uri));
+  const exactSection = formatExactMatchPointers(exactMatches.filter(match => !shownUris.has(match.uri)));
+  if (exactSection) {
+    sections.push(exactSection);
   }
   const hygieneHints = await recallHygieneHintsSection(config, sections.join('\n\n'));
   if (hygieneHints) {
@@ -987,19 +994,19 @@ async function recallHygieneHintsSection(config: RuntimeConfig, recallText: stri
   return nudges.length > 0 ? ['Memory hygiene hints:', ...nudges.map(nudge => `- ${nudge}`)].join('\n') : undefined;
 }
 
-async function exactMemoryMatchesText(
+async function collectExactMemoryMatches(
   config: RuntimeConfig,
   query: string,
   includeArchived: boolean,
   project: ProjectManifest | undefined,
-): Promise<string | undefined> {
+): Promise<readonly ExactMatch[]> {
   const terms = exactRecallTerms(query);
   if (terms.length === 0) {
-    return undefined;
+    return [];
   }
   const ov = await requiredOpenVikingCli();
   const scopes = exactMemoryScopes(config, includeArchived, query, project);
-  const matches = await collectExactMatches(terms, scopes, async (term, scope) => {
+  return collectExactMatches(terms, scopes, async (term, scope) => {
     const result = await runCommand(
       ov,
       withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5', '--output', 'json']),
@@ -1007,7 +1014,6 @@ async function exactMemoryMatchesText(
     );
     return result.exitCode === 0 ? result.stdout : undefined;
   });
-  return formatExactMatchPointers(matches);
 }
 
 function registerReadTool(server: McpServer, config: RuntimeConfig, name: string, description: string): void {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -33,24 +33,21 @@ import type {
 } from './types.js';
 import {
   assertVikingUri,
+  buildRecallSections,
   enrichRecallQueryWithWorkspaceContext,
   enrichRecallQueryWithWorkspaceProjectContext,
-  applyExactMatchBoost,
   expandPath,
   type ExactMatch,
   exactMemoryScopeUris,
   exactRecallScopeIntents,
   exactRecallTerms,
   collectExactMatches,
-  formatExactMatchPointers,
-  formatRecallHits,
   formatShellCommand,
   getInputText,
   getInvocationCwd,
   gitValue,
   isJsonObject,
   maybeRun,
-  mergeRecallHits,
   openVikingCliForMode,
   parentVikingUri,
   parsePositiveInteger,
@@ -351,18 +348,14 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
 
   const recallOutputs: string[] = [];
   const exactMatches = await collectExactMemoryMatches(config, ov, query, {dryRun, includeArchived, project});
-  const limit = nodeLimit ?? 12;
-  const ranked = applyExactMatchBoost(mergeRecallHits(passes), exactMatches);
-  const semanticSection = formatRecallHits(ranked, limit);
+  const {semanticSection, exactTail} = buildRecallSections(passes, exactMatches, nodeLimit ?? 12);
   if (semanticSection) {
     console.log(`\n${semanticSection}`);
     recallOutputs.push(semanticSection);
   }
-  const shownUris = new Set(ranked.slice(0, limit).map(hit => hit.uri));
-  const exactOutput = formatExactMatchPointers(exactMatches.filter(match => !shownUris.has(match.uri)));
-  if (exactOutput) {
-    console.log(`\n${exactOutput}`);
-    recallOutputs.push(exactOutput);
+  if (exactTail) {
+    console.log(`\n${exactTail}`);
+    recallOutputs.push(exactTail);
   }
   await printRecallHygieneNudges(config, recallOutputs.join('\n'));
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -35,7 +35,9 @@ import {
   assertVikingUri,
   enrichRecallQueryWithWorkspaceContext,
   enrichRecallQueryWithWorkspaceProjectContext,
+  applyExactMatchBoost,
   expandPath,
+  type ExactMatch,
   exactMemoryScopeUris,
   exactRecallScopeIntents,
   exactRecallTerms,
@@ -348,17 +350,18 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   }
 
   const recallOutputs: string[] = [];
-  const semanticSection = formatRecallHits(mergeRecallHits(passes), nodeLimit ?? 12);
+  const exactMatches = await collectExactMemoryMatches(config, ov, query, {dryRun, includeArchived, project});
+  const limit = nodeLimit ?? 12;
+  const ranked = applyExactMatchBoost(mergeRecallHits(passes), exactMatches);
+  const semanticSection = formatRecallHits(ranked, limit);
   if (semanticSection) {
     console.log(`\n${semanticSection}`);
     recallOutputs.push(semanticSection);
   }
-  const exactOutput = await printExactMemoryMatches(config, ov, query, {
-    dryRun,
-    includeArchived,
-    project,
-  });
+  const shownUris = new Set(ranked.slice(0, limit).map(hit => hit.uri));
+  const exactOutput = formatExactMatchPointers(exactMatches.filter(match => !shownUris.has(match.uri)));
   if (exactOutput) {
+    console.log(`\n${exactOutput}`);
     recallOutputs.push(exactOutput);
   }
   await printRecallHygieneNudges(config, recallOutputs.join('\n'));
@@ -782,15 +785,15 @@ export function hasAgentSkillCatalogIntent(query: string): boolean {
   );
 }
 
-async function printExactMemoryMatches(
+async function collectExactMemoryMatches(
   config: RuntimeConfig,
   ov: string,
   query: string,
   options: {readonly dryRun: boolean; readonly includeArchived: boolean; readonly project: ProjectManifest | undefined},
-): Promise<string | undefined> {
+): Promise<readonly ExactMatch[]> {
   const terms = exactRecallTerms(query);
   if (terms.length === 0) {
-    return undefined;
+    return [];
   }
   const scopes = exactMemoryScopes(config, options.includeArchived, query, options.project);
   const grepArgs = (term: string, scope: string): readonly string[] =>
@@ -799,18 +802,12 @@ async function printExactMemoryMatches(
     const planned = terms.flatMap(term => scopes.map(scope => formatShellCommand(ov, grepArgs(term, scope))));
     console.log('\nExact memory/resource matches:');
     console.log(planned.join('\n'));
-    return planned.join('\n');
+    return [];
   }
-  const matches = await collectExactMatches(terms, scopes, async (term, scope) => {
+  return collectExactMatches(terms, scopes, async (term, scope) => {
     const result = await runCommand(ov, grepArgs(term, scope), {allowFailure: true});
     return result.exitCode === 0 ? result.stdout : undefined;
   });
-  const text = formatExactMatchPointers(matches);
-  if (!text) {
-    return undefined;
-  }
-  console.log(`\n${text}`);
-  return text;
 }
 
 async function storeMemory(config: RuntimeConfig, options: StoreMemoryOptions): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -897,10 +897,27 @@ export type RecallCategory = (typeof RECALL_CATEGORY_ORDER)[number];
 export interface RecallHit {
   readonly category: RecallCategory;
   readonly contextType: string;
+  /**
+   * Query terms this document matched exactly (lexically) via grep. Present when
+   * an exact-match pass corroborates a semantic hit, or when the document was
+   * promoted into the ranked list from the exact-match pass alone (in which case
+   * `score` is 0 — there was no semantic hit). Empty/undefined for plain
+   * semantic hits.
+   */
+  readonly exactTerms?: readonly string[];
   readonly score: number;
   readonly snippet: string;
   readonly uri: string;
 }
+
+/**
+ * Score assigned to a document promoted into the ranked list from the
+ * exact-match pass alone (no semantic hit). It is never displayed as a score —
+ * `formatRecallHits` renders these as `exact match` — and the category-then-
+ * exact-term-count sort keys place them ahead of unmatched semantic hits in
+ * their category regardless of this value.
+ */
+const RECALL_PROMOTED_EXACT_SCORE = 0;
 
 interface ParseRecallHitsOptions {
   readonly includeArchived?: boolean;
@@ -987,9 +1004,106 @@ export function mergeRecallHits(passes: ReadonlyArray<readonly RecallHit[]>): re
       }
     }
   }
-  return [...byDocument.values()].sort(
+  const ranked = [...byDocument.values()].sort(
     (left, right) =>
       RECALL_CATEGORY_ORDER.indexOf(left.category) - RECALL_CATEGORY_ORDER.indexOf(right.category) ||
+      right.score - left.score,
+  );
+  return dedupeByContent(ranked);
+}
+
+/**
+ * Collapse resource/skill hits that share identical snippet content but live at
+ * different URIs — e.g. a repo that keeps the same SKILL.md under both
+ * `.agents/skills/` and `.claude/skills/`, which would otherwise consume several
+ * ranked slots for one logical document. Keeps the first (highest-ranked, since
+ * the input is already sorted) occurrence. Memories are never collapsed: their
+ * templated `MEMORY kind: ... project: ... topic: ...` header makes truncated
+ * snippets prone to colliding across genuinely distinct memories.
+ */
+function dedupeByContent(hits: readonly RecallHit[]): readonly RecallHit[] {
+  const seen = new Set<string>();
+  const kept: RecallHit[] = [];
+  for (const hit of hits) {
+    if (hit.category !== 'memories' && hit.snippet.length > 0) {
+      const key = `${hit.category}\n${hit.snippet}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+    }
+    kept.push(hit);
+  }
+  return kept;
+}
+
+/**
+ * Infer a recall category for a document URI, used to place exact-match-only
+ * documents (promoted into the ranked list without a semantic hit) into the
+ * right group. Mirrors how OpenViking buckets search results: personal/shared
+ * memories under `.../memories/...`, the global skill catalog under
+ * `resources/agent-skills/`, everything else (including repo-embedded skills) as
+ * a resource.
+ */
+export function categoryForUri(uri: string): RecallCategory {
+  if (uri.includes('/memories/')) {
+    return 'memories';
+  }
+  if (uri.startsWith('viking://resources/agent-skills/')) {
+    return 'skills';
+  }
+  return 'resources';
+}
+
+function contextTypeForCategory(category: RecallCategory): string {
+  if (category === 'memories') {
+    return 'memory';
+  }
+  return category === 'skills' ? 'skill' : 'resource';
+}
+
+/**
+ * Fold exact (lexical) matches into the semantically-ranked hits so the lexical
+ * signal drives ranking rather than sitting in a separate afterthought section.
+ * Semantic hits that a term also matched are annotated with `exactTerms`;
+ * exact-match documents with no semantic hit are promoted in as fresh hits with
+ * `score` 0. The result is re-sorted category-first, then by number of exact
+ * terms matched, then by semantic score — so within each category, exact matches
+ * lead (most terms first) and only then come unmatched semantic hits. This fixes
+ * canonical docs being buried under higher-scored-but-irrelevant noise in the
+ * compressed semantic score band.
+ */
+export function applyExactMatchBoost(
+  hits: readonly RecallHit[],
+  exactMatches: readonly ExactMatch[],
+): readonly RecallHit[] {
+  if (exactMatches.length === 0) {
+    return hits;
+  }
+  const termsByUri = new Map(exactMatches.map(match => [match.uri.replace(/#.*$/, ''), match.terms]));
+  const annotated = hits.map(hit => {
+    const terms = termsByUri.get(hit.uri);
+    return terms ? {...hit, exactTerms: terms} : hit;
+  });
+  const present = new Set(annotated.map(hit => hit.uri));
+  const promoted: RecallHit[] = exactMatches
+    .map(match => match.uri.replace(/#.*$/, ''))
+    .filter(uri => !present.has(uri))
+    .map(uri => {
+      const category = categoryForUri(uri);
+      return {
+        category,
+        contextType: contextTypeForCategory(category),
+        exactTerms: termsByUri.get(uri) ?? [],
+        score: RECALL_PROMOTED_EXACT_SCORE,
+        snippet: '',
+        uri,
+      };
+    });
+  return [...annotated, ...promoted].sort(
+    (left, right) =>
+      RECALL_CATEGORY_ORDER.indexOf(left.category) - RECALL_CATEGORY_ORDER.indexOf(right.category) ||
+      (right.exactTerms?.length ?? 0) - (left.exactTerms?.length ?? 0) ||
       right.score - left.score,
   );
 }
@@ -1000,7 +1114,10 @@ export function formatRecallHits(hits: readonly RecallHit[], maxHits: number): s
   }
   const shown = hits.slice(0, maxHits);
   const lines = shown.flatMap((hit, index) => {
-    const head = `${index + 1}. ${hit.contextType} · score ${hit.score.toFixed(2)} · ${hit.uri}`;
+    const hasExact = hit.exactTerms !== undefined && hit.exactTerms.length > 0;
+    const scorePart = hit.score > 0 ? `score ${hit.score.toFixed(2)}` : hasExact ? undefined : 'exact match';
+    const exactPart = hasExact ? `exact: ${hit.exactTerms?.join(', ')}` : undefined;
+    const head = `${index + 1}. ${[hit.contextType, scorePart, exactPart].filter(Boolean).join(' · ')} · ${hit.uri}`;
     return hit.snippet ? [head, `   ${hit.snippet}`] : [head];
   });
   if (hits.length > maxHits) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -983,6 +983,11 @@ export function parseRecallHits(output: string, options: ParseRecallHitsOptions 
   }
 }
 
+/** Drop a chunk anchor (`#chunk_0001`) so a URI addresses its document. */
+function stripAnchor(uri: string): string {
+  return uri.replace(/#.*$/, '');
+}
+
 /**
  * Merge recall hits from several search passes into one ranked list, deduped to
  * one entry per document (chunk anchors stripped), keeping the highest-scoring
@@ -991,25 +996,33 @@ export function parseRecallHits(output: string, options: ParseRecallHitsOptions 
  *
  * Ranking is category-first (memories, then resources, then skills per
  * `RECALL_CATEGORY_ORDER`), then by score within each category, so personal
- * memories always lead and seeded resources/skills only follow.
+ * memories always lead and seeded resources/skills only follow. Content-level
+ * dedup is applied later by `buildRecallSections`, after exact-match boosting,
+ * so a collapsed twin never strips the exact-matched copy.
  */
 export function mergeRecallHits(passes: ReadonlyArray<readonly RecallHit[]>): readonly RecallHit[] {
   const byDocument = new Map<string, RecallHit>();
   for (const pass of passes) {
     for (const hit of pass) {
-      const documentUri = hit.uri.replace(/#.*$/, '');
+      const documentUri = stripAnchor(hit.uri);
       const existing = byDocument.get(documentUri);
       if (!existing || hit.score > existing.score) {
         byDocument.set(documentUri, {...hit, uri: documentUri});
       }
     }
   }
-  const ranked = [...byDocument.values()].sort(
-    (left, right) =>
-      RECALL_CATEGORY_ORDER.indexOf(left.category) - RECALL_CATEGORY_ORDER.indexOf(right.category) ||
-      right.score - left.score,
+  return [...byDocument.values()].sort(
+    (left, right) => recallCategoryRank(left.category) - recallCategoryRank(right.category) || right.score - left.score,
   );
-  return dedupeByContent(ranked);
+}
+
+/**
+ * Sort index for a category. Unknown categories rank last so a future bucket
+ * never silently jumps ahead of memories.
+ */
+function recallCategoryRank(category: RecallCategory): number {
+  const index = RECALL_CATEGORY_ORDER.indexOf(category);
+  return index === -1 ? RECALL_CATEGORY_ORDER.length : index;
 }
 
 /**
@@ -1072,6 +1085,13 @@ function contextTypeForCategory(category: RecallCategory): string {
  * lead (most terms first) and only then come unmatched semantic hits. This fixes
  * canonical docs being buried under higher-scored-but-irrelevant noise in the
  * compressed semantic score band.
+ *
+ * Intentional trade-off: an exact (lexical) match is treated as a stronger
+ * relevance signal than semantic proximity, so a promoted exact-only document
+ * (score 0) outranks an unmatched semantic hit in the same category and can
+ * occupy a slot in the shown window. `exactRecallTerms` only keeps distinctive
+ * tokens, so a literal match is high precision; surfacing it over a fuzzy
+ * neighbour is the desired behaviour.
  */
 export function applyExactMatchBoost(
   hits: readonly RecallHit[],
@@ -1080,14 +1100,13 @@ export function applyExactMatchBoost(
   if (exactMatches.length === 0) {
     return hits;
   }
-  const termsByUri = new Map(exactMatches.map(match => [match.uri.replace(/#.*$/, ''), match.terms]));
+  const termsByUri = new Map(exactMatches.map(match => [stripAnchor(match.uri), match.terms]));
   const annotated = hits.map(hit => {
-    const terms = termsByUri.get(hit.uri);
+    const terms = termsByUri.get(stripAnchor(hit.uri));
     return terms ? {...hit, exactTerms: terms} : hit;
   });
-  const present = new Set(annotated.map(hit => hit.uri));
-  const promoted: RecallHit[] = exactMatches
-    .map(match => match.uri.replace(/#.*$/, ''))
+  const present = new Set(annotated.map(hit => stripAnchor(hit.uri)));
+  const promoted: RecallHit[] = [...termsByUri.keys()]
     .filter(uri => !present.has(uri))
     .map(uri => {
       const category = categoryForUri(uri);
@@ -1102,28 +1121,112 @@ export function applyExactMatchBoost(
     });
   return [...annotated, ...promoted].sort(
     (left, right) =>
-      RECALL_CATEGORY_ORDER.indexOf(left.category) - RECALL_CATEGORY_ORDER.indexOf(right.category) ||
+      recallCategoryRank(left.category) - recallCategoryRank(right.category) ||
       (right.exactTerms?.length ?? 0) - (left.exactTerms?.length ?? 0) ||
       right.score - left.score,
   );
 }
 
 export function formatRecallHits(hits: readonly RecallHit[], maxHits: number): string | undefined {
-  if (hits.length === 0) {
+  return renderRecallHits(hits.slice(0, maxHits), Math.max(0, hits.length - maxHits));
+}
+
+/**
+ * Render an already-decided shown window into the numbered recall list. Keeping
+ * the slice out of here lets `buildRecallSections` compute the shown set once and
+ * feed both the rendering and the exact-tail "already shown" filter from the same
+ * list. `overflow` is the count of hits beyond the window, for the trailing note.
+ */
+function renderRecallHits(shown: readonly RecallHit[], overflow: number): string | undefined {
+  if (shown.length === 0) {
     return undefined;
   }
-  const shown = hits.slice(0, maxHits);
   const lines = shown.flatMap((hit, index) => {
-    const hasExact = hit.exactTerms !== undefined && hit.exactTerms.length > 0;
-    const scorePart = hit.score > 0 ? `score ${hit.score.toFixed(2)}` : hasExact ? undefined : 'exact match';
-    const exactPart = hasExact ? `exact: ${hit.exactTerms?.join(', ')}` : undefined;
+    const scorePart = hit.score > 0 ? `score ${hit.score.toFixed(2)}` : undefined;
+    const exactPart = hit.exactTerms?.length ? `exact: ${hit.exactTerms.join(', ')}` : undefined;
     const head = `${index + 1}. ${[hit.contextType, scorePart, exactPart].filter(Boolean).join(' · ')} · ${hit.uri}`;
     return hit.snippet ? [head, `   ${hit.snippet}`] : [head];
   });
-  if (hits.length > maxHits) {
-    lines.push(`(+${hits.length - maxHits} more — refine the query or read a URI above)`);
+  if (overflow > 0) {
+    lines.push(`(+${overflow} more — refine the query or read a URI above)`);
   }
   return lines.join('\n');
+}
+
+export interface RecallSections {
+  /**
+   * Final ranked hits (merged, exact-boosted, content-deduped). Exposed for
+   * tests and inspection; the CLI and MCP callers emit the rendered sections.
+   */
+  readonly ranked: readonly RecallHit[];
+  /** Rendered ranked list, capped at `limit`. Undefined when there are no hits. */
+  readonly semanticSection: string | undefined;
+  /** Exact-match pointer list for matches not already shown in the ranked window. */
+  readonly exactTail: string | undefined;
+}
+
+/**
+ * Slots reserved per category in the shown window so a memory-heavy result set
+ * does not crowd seeded resources and skills out of view entirely. Memories
+ * still lead and still take every slot the reserve pass leaves over.
+ */
+export const RECALL_CATEGORY_RESERVE = 2;
+
+/**
+ * Pick which `limit` hits fill the shown window. A reserve pass first takes up
+ * to `reserve` hits from each category in `RECALL_CATEGORY_ORDER` priority, so
+ * lower-priority categories keep guaranteed visibility; a fill pass then tops
+ * the window up from the global rank order (memories first). The selection is
+ * returned in the original ranked order — the reserve only changes which hits
+ * are shown, never the category-first display order.
+ */
+function selectShownHits(ranked: readonly RecallHit[], limit: number, reserve: number): readonly RecallHit[] {
+  if (ranked.length <= limit) {
+    return ranked;
+  }
+  const selected = new Set<string>();
+  for (const category of RECALL_CATEGORY_ORDER) {
+    let taken = 0;
+    for (const hit of ranked) {
+      if (selected.size >= limit || taken >= reserve) {
+        break;
+      }
+      if (hit.category === category && !selected.has(hit.uri)) {
+        selected.add(hit.uri);
+        taken += 1;
+      }
+    }
+  }
+  for (const hit of ranked) {
+    if (selected.size >= limit) {
+      break;
+    }
+    selected.add(hit.uri);
+  }
+  return ranked.filter(hit => selected.has(hit.uri));
+}
+
+/**
+ * Assemble the two recall output sections shared by the CLI (`runRecall`) and
+ * the MCP tool (`runRecallTool`): the ranked semantic list and the exact-match
+ * tail. Centralises the ordering — merge → exact-boost → content-dedup — the
+ * per-category reserve that decides the shown window, and the rule that the tail
+ * only lists exact matches not already surfaced in that window, so the two entry
+ * points cannot drift. Callers decide only how to emit.
+ */
+export function buildRecallSections(
+  passes: ReadonlyArray<readonly RecallHit[]>,
+  exactMatches: readonly ExactMatch[],
+  limit: number,
+): RecallSections {
+  const ranked = dedupeByContent(applyExactMatchBoost(mergeRecallHits(passes), exactMatches));
+  const shown = selectShownHits(ranked, limit, RECALL_CATEGORY_RESERVE);
+  const shownUris = new Set(shown.map(hit => stripAnchor(hit.uri)));
+  return {
+    exactTail: formatExactMatchPointers(exactMatches.filter(match => !shownUris.has(stripAnchor(match.uri)))),
+    ranked,
+    semanticSection: renderRecallHits(shown, ranked.length - shown.length),
+  };
 }
 
 /**

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -4,6 +4,7 @@ import {join} from 'node:path';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
 import {
   applyExactMatchBoost,
+  buildRecallSections,
   categoryForUri,
   collectExactMatches,
   compareVersions,
@@ -21,6 +22,7 @@ import {
   grepUrisFromJson,
   mergeRecallHits,
   parseRecallHits,
+  type RecallHit,
   hasGlob,
   isExecutable,
   isJsonObject,
@@ -693,29 +695,166 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
   });
 
   it('collapses resource hits with identical snippets but keeps distinct memories', () => {
-    const merged = mergeRecallHits([
-      parseRecallHits(
-        json({
-          ok: true,
-          result: {
-            resources: [
-              {context_type: 'resource', uri: 'viking://r/.agents/skills/x/SKILL.md', score: 0.7, abstract: 'same'},
-              {context_type: 'resource', uri: 'viking://r/.claude/skills/x/SKILL.md', score: 0.6, abstract: 'same'},
-            ],
-            memories: [
-              {context_type: 'memory', uri: 'viking://m1.md', score: 0.8, abstract: 'dup'},
-              {context_type: 'memory', uri: 'viking://m2.md', score: 0.75, abstract: 'dup'},
-            ],
-          },
-        }),
-      ),
-    ]);
+    const {ranked} = buildRecallSections(
+      [
+        parseRecallHits(
+          json({
+            ok: true,
+            result: {
+              resources: [
+                {context_type: 'resource', uri: 'viking://r/.agents/skills/x/SKILL.md', score: 0.7, abstract: 'same'},
+                {context_type: 'resource', uri: 'viking://r/.claude/skills/x/SKILL.md', score: 0.6, abstract: 'same'},
+              ],
+              memories: [
+                {context_type: 'memory', uri: 'viking://m1.md', score: 0.8, abstract: 'dup'},
+                {context_type: 'memory', uri: 'viking://m2.md', score: 0.75, abstract: 'dup'},
+              ],
+            },
+          }),
+        ),
+      ],
+      [],
+      12,
+    );
     // One resource kept (highest score), both memories kept despite identical snippet.
-    expect(merged.map(hit => hit.uri)).toEqual([
+    expect(ranked.map(hit => hit.uri)).toEqual([
       'viking://m1.md',
       'viking://m2.md',
       'viking://r/.agents/skills/x/SKILL.md',
     ]);
+  });
+
+  it('does not collapse resource hits with empty snippets', () => {
+    const {ranked} = buildRecallSections(
+      [
+        parseRecallHits(
+          json({
+            ok: true,
+            result: {
+              resources: [
+                {context_type: 'resource', uri: 'viking://r/a.md', score: 0.7, abstract: ''},
+                {context_type: 'resource', uri: 'viking://r/b.md', score: 0.6, abstract: ''},
+              ],
+            },
+          }),
+        ),
+      ],
+      [],
+      12,
+    );
+    expect(ranked.map(hit => hit.uri)).toEqual(['viking://r/a.md', 'viking://r/b.md']);
+  });
+
+  it('keeps the exact-matched twin when a content-duplicate would otherwise be dropped', () => {
+    // Lower-scored .claude copy is the exact match; it must survive dedup and lead.
+    const {ranked} = buildRecallSections(
+      [
+        parseRecallHits(
+          json({
+            ok: true,
+            result: {
+              resources: [
+                {context_type: 'resource', uri: 'viking://r/.agents/skills/x/SKILL.md', score: 0.7, abstract: 'same'},
+                {context_type: 'resource', uri: 'viking://r/.claude/skills/x/SKILL.md', score: 0.6, abstract: 'same'},
+              ],
+            },
+          }),
+        ),
+      ],
+      [{terms: ['chaos'], uri: 'viking://r/.claude/skills/x/SKILL.md'}],
+      12,
+    );
+    expect(ranked.map(hit => hit.uri)).toEqual(['viking://r/.claude/skills/x/SKILL.md']);
+  });
+
+  it('builds an exact tail that excludes matches already shown in the ranked window', () => {
+    const sections = buildRecallSections(
+      [parseRecallHits(json({ok: true, result: {memories: [{uri: 'viking://shown.md', score: 0.8, abstract: 'x'}]}}))],
+      [
+        {terms: ['a'], uri: 'viking://shown.md'},
+        {terms: ['a'], uri: 'viking://resources/repos/coda/only-exact.md'},
+      ],
+      12,
+    );
+    // shown.md is in the ranked window, so it is filtered out of the tail; the
+    // exact-only doc was promoted into the window too, so the tail is empty.
+    expect(sections.exactTail).toBeUndefined();
+    expect(sections.ranked.map(hit => hit.uri)).toContain('viking://resources/repos/coda/only-exact.md');
+  });
+});
+
+describe('buildRecallSections per-category reserve', () => {
+  const mk = (category: 'memories' | 'resources' | 'skills', index: number, score: number): RecallHit => ({
+    category,
+    contextType: category === 'memories' ? 'memory' : category === 'skills' ? 'skill' : 'resource',
+    score,
+    snippet: '',
+    uri: `viking://${category}/${index}`,
+  });
+  const numberedLines = (section: string | undefined): number =>
+    (section ?? '').split('\n').filter(line => /^\d+\. /.test(line)).length;
+
+  it('reserves window slots for resources and skills in a memory-heavy result', () => {
+    const hits = [
+      ...Array.from({length: 12}, (_unused, i) => mk('memories', i, 0.9 - i * 0.01)),
+      ...Array.from({length: 3}, (_unused, i) => mk('resources', i, 0.5 - i * 0.01)),
+      ...Array.from({length: 2}, (_unused, i) => mk('skills', i, 0.4 - i * 0.01)),
+    ];
+    const {semanticSection} = buildRecallSections([hits], [], 12);
+    const text = semanticSection ?? '';
+    // RECALL_CATEGORY_RESERVE = 2 → two resources and two skills are guaranteed visibility.
+    expect(text).toContain('viking://resources/0');
+    expect(text).toContain('viking://resources/1');
+    expect(text).not.toContain('viking://resources/2');
+    expect(text).toContain('viking://skills/0');
+    expect(text).toContain('viking://skills/1');
+    // Memories still take every remaining slot: 12 - 2 - 2 = 8.
+    expect((text.match(/viking:\/\/memories\//g) ?? []).length).toBe(8);
+    // Display stays fully category-first: every memory precedes every resource,
+    // which precedes every skill.
+    const lines = text.split('\n').filter(line => /^\d+\. /.test(line));
+    const lastMemory = lines.map(l => l.includes('memories/')).lastIndexOf(true);
+    const firstResource = lines.findIndex(l => l.includes('resources/'));
+    const lastResource = lines.map(l => l.includes('resources/')).lastIndexOf(true);
+    const firstSkill = lines.findIndex(l => l.includes('skills/'));
+    expect(firstResource).toBeGreaterThan(lastMemory);
+    expect(firstSkill).toBeGreaterThan(lastResource);
+    expect(numberedLines(semanticSection)).toBe(12);
+  });
+
+  it('shows every hit in category-first order when the result fits the window', () => {
+    const hits = [mk('skills', 0, 0.4), mk('memories', 0, 0.9), mk('resources', 0, 0.5)];
+    const {semanticSection} = buildRecallSections([hits], [], 12);
+    const lines = (semanticSection ?? '').split('\n').filter(line => /^\d+\. /.test(line));
+    expect(lines.map(l => l.replace(/^\d+\. .* · /, ''))).toEqual([
+      'viking://memories/0',
+      'viking://resources/0',
+      'viking://skills/0',
+    ]);
+  });
+
+  it('applies the reserve best-effort by priority when the window is smaller than reserve x categories', () => {
+    // limit 4 < RECALL_CATEGORY_RESERVE (2) * 3 categories: the two higher-priority
+    // categories claim their reserve first, and the lowest (skills) is squeezed out.
+    const hits = [
+      ...Array.from({length: 2}, (_unused, i) => mk('memories', i, 0.9 - i * 0.01)),
+      ...Array.from({length: 2}, (_unused, i) => mk('resources', i, 0.5 - i * 0.01)),
+      ...Array.from({length: 2}, (_unused, i) => mk('skills', i, 0.4 - i * 0.01)),
+    ];
+    const text = buildRecallSections([hits], [], 4).semanticSection ?? '';
+    expect(numberedLines(text)).toBe(4);
+    expect(text).toContain('viking://memories/0');
+    expect(text).toContain('viking://memories/1');
+    expect(text).toContain('viking://resources/0');
+    expect(text).toContain('viking://resources/1');
+    expect(text).not.toContain('viking://skills/');
+  });
+
+  it('does not starve a memory-only result of slots', () => {
+    const hits = Array.from({length: 15}, (_unused, i) => mk('memories', i, 0.9 - i * 0.01));
+    const {semanticSection} = buildRecallSections([hits], [], 12);
+    expect(numberedLines(semanticSection)).toBe(12);
+    expect((semanticSection ?? '').match(/viking:\/\/memories\//g)?.length).toBe(12);
   });
 });
 
@@ -730,10 +869,14 @@ describe('categoryForUri', () => {
 });
 
 describe('applyExactMatchBoost', () => {
-  const hit = (over: Partial<ReturnType<typeof baseHit>> = {}): ReturnType<typeof baseHit> => ({...baseHit(), ...over});
-  function baseHit() {
-    return {category: 'resources' as const, contextType: 'resource', score: 0.6, snippet: 's', uri: 'viking://x'};
-  }
+  const hit = (over: Partial<RecallHit> = {}): RecallHit => ({
+    category: 'resources',
+    contextType: 'resource',
+    score: 0.6,
+    snippet: 's',
+    uri: 'viking://x',
+    ...over,
+  });
 
   it('returns hits unchanged when there are no exact matches', () => {
     const hits = [hit()];
@@ -786,6 +929,18 @@ describe('applyExactMatchBoost', () => {
     ]);
   });
 
+  it('breaks ties by score when exact-term counts are equal', () => {
+    const ranked = applyExactMatchBoost(
+      [hit({uri: 'viking://lo', score: 0.5}), hit({uri: 'viking://hi', score: 0.8})],
+      [
+        {terms: ['a'], uri: 'viking://lo'},
+        {terms: ['a'], uri: 'viking://hi'},
+      ],
+    );
+    // Same single-term match → higher semantic score wins.
+    expect(ranked.map(entry => entry.uri)).toEqual(['viking://hi', 'viking://lo']);
+  });
+
   it('renders promoted exact-only hits without a score and annotates boosted hits', () => {
     const ranked = applyExactMatchBoost(
       [hit({uri: 'viking://sem', score: 0.62})],
@@ -794,8 +949,13 @@ describe('applyExactMatchBoost', () => {
         {terms: ['y', 'z'], uri: 'viking://resources/repos/coda/CLAUDE.md'},
       ],
     );
-    const text = formatRecallHits(ranked, 5) ?? '';
-    expect(text).toContain('resource · exact: y, z · viking://resources/repos/coda/CLAUDE.md');
-    expect(text).toContain('resource · score 0.62 · exact: x · viking://sem');
+    const lines = (formatRecallHits(ranked, 5) ?? '').split('\n');
+    const promotedIndex = lines.findIndex(line => line.includes('CLAUDE.md'));
+    // Promoted exact-only line carries no "score" token and is not followed by a
+    // wrapped (3-space indented) snippet line, since its snippet is empty.
+    expect(lines[promotedIndex]).toContain('resource · exact: y, z · viking://resources/repos/coda/CLAUDE.md');
+    expect(lines[promotedIndex]).not.toContain('score');
+    expect(lines[promotedIndex + 1] ?? '').not.toMatch(/^ {3}/);
+    expect(lines.join('\n')).toContain('resource · score 0.62 · exact: x · viking://sem');
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -3,6 +3,8 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
 import {
+  applyExactMatchBoost,
+  categoryForUri,
   collectExactMatches,
   compareVersions,
   enrichRecallQueryWithWorkspaceContext,
@@ -688,5 +690,112 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
     expect(text).toContain('1. memory · score 0.50 · viking://m0.md');
     expect(text).toContain('(+2 more');
     expect(formatRecallHits([], 5)).toBeUndefined();
+  });
+
+  it('collapses resource hits with identical snippets but keeps distinct memories', () => {
+    const merged = mergeRecallHits([
+      parseRecallHits(
+        json({
+          ok: true,
+          result: {
+            resources: [
+              {context_type: 'resource', uri: 'viking://r/.agents/skills/x/SKILL.md', score: 0.7, abstract: 'same'},
+              {context_type: 'resource', uri: 'viking://r/.claude/skills/x/SKILL.md', score: 0.6, abstract: 'same'},
+            ],
+            memories: [
+              {context_type: 'memory', uri: 'viking://m1.md', score: 0.8, abstract: 'dup'},
+              {context_type: 'memory', uri: 'viking://m2.md', score: 0.75, abstract: 'dup'},
+            ],
+          },
+        }),
+      ),
+    ]);
+    // One resource kept (highest score), both memories kept despite identical snippet.
+    expect(merged.map(hit => hit.uri)).toEqual([
+      'viking://m1.md',
+      'viking://m2.md',
+      'viking://r/.agents/skills/x/SKILL.md',
+    ]);
+  });
+});
+
+describe('categoryForUri', () => {
+  it('classifies memories, skill catalog, and resources', () => {
+    expect(categoryForUri('viking://user/me/memories/durable/projects/x/y.md')).toBe('memories');
+    expect(categoryForUri('viking://user/me/memories/shared/default/durable/x.md')).toBe('memories');
+    expect(categoryForUri('viking://resources/agent-skills/codex-global/foo/SKILL.md')).toBe('skills');
+    expect(categoryForUri('viking://resources/repos/coda/CLAUDE.md')).toBe('resources');
+    expect(categoryForUri('viking://resources/repos/coda/.claude/skills/x/SKILL.md')).toBe('resources');
+  });
+});
+
+describe('applyExactMatchBoost', () => {
+  const hit = (over: Partial<ReturnType<typeof baseHit>> = {}): ReturnType<typeof baseHit> => ({...baseHit(), ...over});
+  function baseHit() {
+    return {category: 'resources' as const, contextType: 'resource', score: 0.6, snippet: 's', uri: 'viking://x'};
+  }
+
+  it('returns hits unchanged when there are no exact matches', () => {
+    const hits = [hit()];
+    expect(applyExactMatchBoost(hits, [])).toBe(hits);
+  });
+
+  it('annotates a semantic hit that an exact term also matched', () => {
+    const ranked = applyExactMatchBoost(
+      [hit({uri: 'viking://a', score: 0.6}), hit({uri: 'viking://b', score: 0.9})],
+      [{terms: ['release', 'test'], uri: 'viking://a'}],
+    );
+    const a = ranked.find(entry => entry.uri === 'viking://a');
+    expect(a?.exactTerms).toEqual(['release', 'test']);
+    // Exact match leads its category despite lower semantic score.
+    expect(ranked[0]?.uri).toBe('viking://a');
+  });
+
+  it('promotes an exact-only document into the ranked list with score 0', () => {
+    const ranked = applyExactMatchBoost(
+      [hit({uri: 'viking://sem', score: 0.9})],
+      [{terms: ['conventions'], uri: 'viking://resources/repos/coda/CLAUDE.md'}],
+    );
+    const promoted = ranked.find(entry => entry.uri === 'viking://resources/repos/coda/CLAUDE.md');
+    expect(promoted).toMatchObject({
+      category: 'resources',
+      contextType: 'resource',
+      score: 0,
+      exactTerms: ['conventions'],
+    });
+    // Promoted exact match outranks the unmatched higher-scoring semantic hit in the same category.
+    expect(ranked[0]?.uri).toBe('viking://resources/repos/coda/CLAUDE.md');
+  });
+
+  it('orders by category, then exact-term count, then score', () => {
+    const ranked = applyExactMatchBoost(
+      [
+        hit({category: 'memories', contextType: 'memory', uri: 'viking://user/me/memories/m.md', score: 0.5}),
+        hit({uri: 'viking://r-one-term', score: 0.6}),
+        hit({uri: 'viking://r-two-terms', score: 0.55}),
+      ],
+      [
+        {terms: ['a'], uri: 'viking://r-one-term'},
+        {terms: ['a', 'b'], uri: 'viking://r-two-terms'},
+      ],
+    );
+    expect(ranked.map(entry => entry.uri)).toEqual([
+      'viking://user/me/memories/m.md',
+      'viking://r-two-terms',
+      'viking://r-one-term',
+    ]);
+  });
+
+  it('renders promoted exact-only hits without a score and annotates boosted hits', () => {
+    const ranked = applyExactMatchBoost(
+      [hit({uri: 'viking://sem', score: 0.62})],
+      [
+        {terms: ['x'], uri: 'viking://sem'},
+        {terms: ['y', 'z'], uri: 'viking://resources/repos/coda/CLAUDE.md'},
+      ],
+    );
+    const text = formatRecallHits(ranked, 5) ?? '';
+    expect(text).toContain('resource · exact: y, z · viking://resources/repos/coda/CLAUDE.md');
+    expect(text).toContain('resource · score 0.62 · exact: x · viking://sem');
   });
 });


### PR DESCRIPTION
Reworks recall ranking so the most relevant context leads, across both the CLI `recall` and the MCP `recall_context` — they now share one pipeline. Targets 1.2.0.

**Exact-match ranking.** Exact (lexical) grep matches were collected separately and printed as an unranked, snippetless "Exact term matches" sidecar after the semantic top-N, burying canonical docs that scored below the semantic threshold or sat in the compressed ~0.6–0.7 band.
- Semantic hits an exact term also matched are annotated (`exact: <terms>`).
- Exact-match docs with no semantic hit are promoted into the ranked list (rendered `exact:`), categorized from their URI via `categoryForUri`.
- Ranking is category-first → exact-term count → semantic score; exact matches lead within their category. The sidecar now lists only matches not already shown.

**Per-category reserve (1.2.0 feature).** A memory-heavy result used to crowd seeded resources/skills entirely out of the visible window. `selectShownHits` reserves up to `RECALL_CATEGORY_RESERVE` (2) slots per category before filling the rest by global rank; memories still lead and take every leftover slot. Best-effort under tight `nodeLimit`: higher-priority categories claim their reserve first.

**Consolidation.** `buildRecallSections` is one pure helper owning the whole pipeline (merge → exact-boost → content-dedup → shown-window → exact tail) for both entry points, so they can't drift. The shown window is computed once and feeds both the rendered list and the tail filter.

**Also:**
- `mergeRecallHits` keeps memories ahead of resources ahead of skills; `dedupeByContent` collapses resource/skill hits with identical snippets (memories never collapsed) and runs after exact-boost so an exact-matched twin survives.
- Seeding ignores `.claude/worktrees/` and `.worktrees/`.
- MCP `grep` defaults `uri` to the caller's memories root instead of erroring.

**Verified end-to-end (built CLI + MCP over stdio):** the canonical `coda/CLAUDE.md` docs move from rank ~29 into the default 12-window (ranks 11–12) while memories keep 10 of 12 slots; shared `README.md` leads the threadnote-share query.

**Test plan:** 232 unit tests pass (exact-boost annotate/promote/order/render, category inference, content-dedup, per-category reserve incl. the tight-`nodeLimit` degradation contract, exact-tail filtering). `tsc --noEmit` and `eslint` clean. Bumps version to 1.2.0.