### PR TITLE
feat(share): share skills as multi-file bundles and constellation packs

### DIFF
--- a/docs/share.md
+++ b/docs/share.md
@@ -154,8 +154,71 @@ Notes:
   them; pass `--allow-binary` (CLI) / `allowBinary: true` (MCP) to include them.
   A credential detected in the bytes still blocks regardless.
 - A skill whose helpers live **outside** its own directory (a multi-skill
-  constellation with shared code at the repo root) is not yet captured — that is
-  a follow-up.
+  constellation with shared code at the repo root) is shared as a **pack** — see
+  below.
+
+#### Constellation packs
+
+When several skills share code that lives outside any single skill directory
+(e.g. repo-root `scripts/` and `lib/`), publish them together as a **pack** from
+a `threadnote-bundle.json` manifest at the repo root:
+
+```json
+{
+  "version": 1,
+  "name": "review-pr-suite",
+  "agent": "claude",
+  "description": "PR/MR review constellation.",
+  "skills": [".claude/skills/review-pr", ".claude/skills/pr-action"],
+  "include": ["scripts", "lib", "package.json", "tsconfig.json"],
+  "deps": {"runtime": ["bun"], "cli": ["gh", "glab", "jq"], "mcp": ["mcp__pal__clink"]},
+  "pathRewrites": [{"from": "/Users/alex/code/reviewer"}]
+}
+```
+
+```bash
+threadnote share publish-bundle ./threadnote-bundle.json --preview
+threadnote share publish-bundle ./threadnote-bundle.json
+threadnote share install-artifacts --kind pack --name review-pr-suite --apply
+```
+
+```text
+share_bundle({"path":"~/src/reviewer/threadnote-bundle.json"})
+```
+
+How packs work:
+
+- Every declared skill plus the `include` paths are gathered, preserving the
+  author's repo-relative layout, and written under
+  `agent-artifacts/packs/<agent>/<name>/files/...` next to a generated
+  `<name>.pack.md` recall index and a `<name>.pack.json` manifest.
+- Install materializes the **whole tree under one root**
+  (`~/.{codex,claude}/skills/threadnote-packs/<team>/<name>/` — a dedicated
+  namespace so a pack and a same-named skill never share an install directory),
+  preserving the source repo layout (so a skill declared at
+  `.claude/skills/<name>` lands at `<root>/.claude/skills/<name>/SKILL.md` beside
+  `<root>/scripts/...`). This keeps **file-anchored** references working
+  unchanged: relative imports (`../lib/types`) and `import.meta.dir`-relative
+  paths resolve exactly as they did in the source repo.
+- **CWD-relative invocations do not auto-resolve.** A bare `bun run scripts/...`
+  in a skill body is resolved against the agent's working directory, not the
+  pack root, so anchor such paths to the token:
+  `bun run ${THREADNOTE_PACK_ROOT}/scripts/vcs-detect.ts`. The token is expanded
+  to the absolute install root in every text member at install.
+- Hardcoded absolute repo-root paths are rewritten to that
+  `${THREADNOTE_PACK_ROOT}` token at publish (the manifest dir plus any declared
+  `pathRewrites`, which must be absolute repo-root paths) and expanded back to
+  the real install directory at install. A residual `/Users` or `/home` path
+  that no rewrite covers trips the scrubber and blocks the publish. Other
+  machine-local absolute paths (`/opt`, `/srv`, `/private`, Windows `C:\…`) are
+  **not** auto-detected — declare them in `pathRewrites` or strip them, and
+  `--preview` before publishing. Binary members included via `--allow-binary`
+  are scanned for embedded home paths and declared roots but are otherwise
+  shipped byte-for-byte with no rewrite.
+- `deps` are declared, not bundled: Threadnote installs files, not runtimes or
+  MCP servers. After install it prints a loud "this pack will NOT run until these
+  exist" notice listing the runtime/CLI/OS tools and any MCP servers to
+  configure separately.
 
 Agents can do the same through MCP:
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -126,6 +126,37 @@ under `agent-artifacts/`, ingests it into OpenViking under the shared team
 namespace, commits, and pushes. Existing artifacts with different content are
 not overwritten unless `--force` is passed.
 
+#### Multi-file skills (bundles)
+
+A skill is shared as its **whole directory**, not just `SKILL.md`. When companion
+files sit beside the `SKILL.md` (reference docs, scripts, templates), they travel
+with the skill:
+
+```text
+agent-artifacts/skills/codex/<name>/
+  SKILL.md                 # recall anchor (OpenViking-ingested)
+  scripts/run.ts           # companion, carried in git
+  reference.md
+  .threadnote-bundle.json  # generated member manifest (sha + binary flags)
+```
+
+Notes:
+
+- A lone `SKILL.md` with no companions publishes exactly as before — no manifest,
+  one file.
+- Every **text** member runs through the scrubber, so a leaked credential or local
+  path in a companion script blocks the publish just like it would in `SKILL.md`.
+- Only `SKILL.md` (and any sibling `.md`) is OpenViking-ingested for recall;
+  companions ride in git and are materialized on install.
+- Runtime/scratch dirs and local junk are never bundled: `reviews/`, `repos/`,
+  `node_modules/`, `.git/`, `.DS_Store`, `*.log`.
+- **Binary** members are blocked by default because the scrubber cannot inspect
+  them; pass `--allow-binary` (CLI) / `allowBinary: true` (MCP) to include them.
+  A credential detected in the bytes still blocks regardless.
+- A skill whose helpers live **outside** its own directory (a multi-skill
+  constellation with shared code at the repo root) is not yet captured — that is
+  a follow-up.
+
 Agents can do the same through MCP:
 
 ```text
@@ -174,6 +205,14 @@ applied by running the same install command again; Threadnote tracks the last
 installed shared hash in a sidecar metadata file next to the installed
 artifact. Start a new agent session after installing if that agent snapshots
 skills or commands at startup.
+
+For a multi-file skill, the whole `~/.{codex,claude}/skills/threadnote/<team>/<name>/`
+tree is installed (companions included) and the install is atomic — it is staged
+in a temporary directory and swapped into place, so an interrupted install never
+leaves a half-written, mixed-version skill. Bundle status folds every member into
+one verdict: a local edit to any member plus an upstream change to a different
+member reports `remote_changed_and_local_modified` and refuses to overwrite
+without `--force`.
 
 ### Keep teammates' updates current
 

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -368,9 +368,13 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
     {
       annotations: {readOnlyHint: false, destructiveHint: true},
       description:
-        "Publish a local Codex/Claude skill or Claude command markdown file into a team's shared artifact catalog. Path inference handles ~/.codex/skills/**/SKILL.md, ~/.claude/skills/**/SKILL.md, and ~/.claude/commands/**/*.md; pass agent/kind/name when sharing from another path. Default team is used unless team is provided. Pass preview=true to inspect bytes without writing or committing.",
+        "Publish a local Codex/Claude skill or Claude command markdown file into a team's shared artifact catalog. Path inference handles ~/.codex/skills/**/SKILL.md, ~/.claude/skills/**/SKILL.md, and ~/.claude/commands/**/*.md; pass agent/kind/name when sharing from another path. A skill is shared as its whole directory: companion files (scripts, references, assets) beside the SKILL.md travel with it. Default team is used unless team is provided. Pass preview=true to inspect what would land without writing or committing.",
       inputSchema: {
         agent: z.enum(['codex', 'claude']).optional().describe('Agent owner when path inference is ambiguous'),
+        allowBinary: z
+          .boolean()
+          .optional()
+          .describe('Include binary skill files (unscannable by the scrubber); blocked by default'),
         force: z.boolean().optional().describe('Replace an existing shared artifact with different content'),
         kind: z.enum(['skill', 'command']).optional().describe('Artifact kind when path inference is ambiguous'),
         message: z.string().optional().describe('Commit message override; defaults to "share: publish <path>"'),
@@ -385,7 +389,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
         team: z.string().optional().describe('Team name; defaults to the configured default team'),
       },
     },
-    async ({agent, force, kind, message, name, path, preview, push, redact, team}) => {
+    async ({agent, allowBinary, force, kind, message, name, path, preview, push, redact, team}) => {
       const checkedPath = requiredText(path, 'share_skill', 'path', {
         path: '~/.codex/skills/example/SKILL.md',
       });
@@ -394,6 +398,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       }
       return runShareSkillTool(config, checkedPath.value, {
         agent,
+        allowBinary,
         force,
         kind,
         message,
@@ -1948,6 +1953,7 @@ interface SharePublishToolOptions {
 
 interface ShareSkillToolOptions {
   readonly agent?: 'claude' | 'codex';
+  readonly allowBinary?: boolean;
   readonly force?: boolean;
   readonly kind?: 'command' | 'skill';
   readonly message?: string;

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -34,6 +34,7 @@ import {
   sharedTeamNameForUri,
   sharedUriFor,
   shareAgentArtifact,
+  shareBundlePack,
   startShareBackgroundFetch,
   stripPersonalProvenance,
   syncSharedReposBeforeAgentRead,
@@ -412,14 +413,48 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
   );
 
   server.registerTool(
+    'share_bundle',
+    {
+      annotations: {readOnlyHint: false, destructiveHint: true},
+      description:
+        "Publish a multi-skill constellation (pack) into a team's shared artifact catalog from a threadnote-bundle.json manifest. Use this when several skills share code that lives outside any single skill directory (e.g. repo-root scripts/lib). The manifest declares name, agent, skills, include paths, external deps, and pathRewrites. Hardcoded repo-root paths are rewritten to a portable token and expanded on install. Pass preview=true to inspect what would land without writing or committing.",
+      inputSchema: {
+        allowBinary: z
+          .boolean()
+          .optional()
+          .describe('Include binary files (unscannable by the scrubber); blocked by default'),
+        force: z.boolean().optional().describe('Replace existing shared pack files with different content'),
+        message: z.string().optional().describe('Commit message override'),
+        path: z.string().optional().describe('Required local path to a threadnote-bundle.json manifest'),
+        preview: z.boolean().optional().describe('Return what would land in the shared git repo without writing'),
+        push: z.boolean().optional().describe('Push to remote after committing; defaults to true'),
+        redact: z
+          .boolean()
+          .optional()
+          .describe('Replace soft-leak matches (local paths) with placeholders and continue; credentials still block.'),
+        team: z.string().optional().describe('Team name; defaults to the configured default team'),
+      },
+    },
+    async ({allowBinary, force, message, path, preview, push, redact, team}) => {
+      const checkedPath = requiredText(path, 'share_bundle', 'path', {
+        path: '~/src/reviewer/threadnote-bundle.json',
+      });
+      if (!checkedPath.ok) {
+        return checkedPath.error;
+      }
+      return runShareBundleTool(config, checkedPath.value, {allowBinary, force, message, preview, push, redact, team});
+    },
+  );
+
+  server.registerTool(
     'list_shared_skills',
     {
       annotations: {readOnlyHint: true, destructiveHint: false},
       description:
-        'List shared Codex/Claude skills and Claude commands available in a configured Threadnote team repo, including whether each one is already installed locally.',
+        'List shared Codex/Claude skills, Claude commands, and skill packs available in a configured Threadnote team repo, including whether each one is already installed locally.',
       inputSchema: {
         agent: z.enum(['codex', 'claude']).optional().describe('Optional agent filter'),
-        kind: z.enum(['skill', 'command']).optional().describe('Optional kind filter'),
+        kind: z.enum(['skill', 'command', 'pack']).optional().describe('Optional kind filter'),
         name: z.string().optional().describe('Optional shared artifact name filter'),
         team: z.string().optional().describe('Team name; defaults to the configured default team'),
       },
@@ -437,7 +472,10 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
         agent: z.enum(['codex', 'claude']).optional().describe('Agent owner; required when name is ambiguous'),
         dryRun: z.boolean().optional().describe('Preview install without writing local files'),
         force: z.boolean().optional().describe('Replace an existing installed artifact with different content'),
-        kind: z.enum(['skill', 'command']).optional().describe('Artifact kind; required when name is ambiguous'),
+        kind: z
+          .enum(['skill', 'command', 'pack'])
+          .optional()
+          .describe('Artifact kind; required when name is ambiguous'),
         name: z.string().optional().describe('Required shared artifact name to install'),
         team: z.string().optional().describe('Team name; defaults to the configured default team'),
       },
@@ -1955,7 +1993,7 @@ interface ShareSkillToolOptions {
   readonly agent?: 'claude' | 'codex';
   readonly allowBinary?: boolean;
   readonly force?: boolean;
-  readonly kind?: 'command' | 'skill';
+  readonly kind?: 'command' | 'pack' | 'skill';
   readonly message?: string;
   readonly name?: string;
   readonly preview?: boolean;
@@ -1966,7 +2004,7 @@ interface ShareSkillToolOptions {
 
 interface SharedSkillFilterOptions {
   readonly agent?: 'claude' | 'codex';
-  readonly kind?: 'command' | 'skill';
+  readonly kind?: 'command' | 'pack' | 'skill';
   readonly name?: string;
   readonly team?: string;
 }
@@ -1975,7 +2013,7 @@ interface InstallSharedSkillToolOptions {
   readonly agent?: 'claude' | 'codex';
   readonly dryRun?: boolean;
   readonly force?: boolean;
-  readonly kind?: 'command' | 'skill';
+  readonly kind?: 'command' | 'pack' | 'skill';
   readonly team?: string;
 }
 
@@ -2083,6 +2121,35 @@ async function runShareSkillTool(
 ): Promise<CallToolResult> {
   try {
     const result = await shareAgentArtifact(config, sourcePath, options);
+    const lines = [...result.messages, ...result.gitMessages];
+    if (result.previewContent !== undefined) {
+      lines.push('-----BEGIN PREVIEW-----');
+      lines.push(result.previewContent);
+      lines.push('-----END PREVIEW-----');
+    }
+    return {content: [{type: 'text', text: lines.join('\n')}], isError: false};
+  } catch (err: unknown) {
+    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+  }
+}
+
+interface ShareBundleToolOptions {
+  readonly allowBinary?: boolean;
+  readonly force?: boolean;
+  readonly message?: string;
+  readonly preview?: boolean;
+  readonly push?: boolean;
+  readonly redact?: boolean;
+  readonly team?: string;
+}
+
+async function runShareBundleTool(
+  config: RuntimeConfig,
+  manifestPath: string,
+  options: ShareBundleToolOptions,
+): Promise<CallToolResult> {
+  try {
+    const result = await shareBundlePack(config, manifestPath, options);
     const lines = [...result.messages, ...result.gitMessages];
     if (result.previewContent !== undefined) {
       lines.push('-----BEGIN PREVIEW-----');

--- a/src/share.ts
+++ b/src/share.ts
@@ -1,6 +1,7 @@
 import {lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
 import {basename, dirname, join, relative, sep} from 'node:path';
+import {TextDecoder} from 'node:util';
 import {uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
 import type {
@@ -50,6 +51,18 @@ const SHAREABLE_ARTIFACT_DIR = 'agent-artifacts';
 const SHAREABLE_TOP_LEVEL_DIRS = [...SHAREABLE_MEMORY_KIND_DIRS, SHAREABLE_ARTIFACT_DIR];
 const SHAREABLE_ROOT_FILES = ['README.md', 'AGENTS.md', 'CLAUDE.md', 'SKILL.md', '.gitignore'];
 const ARTIFACT_INSTALL_METADATA_VERSION = 1;
+const BUNDLE_MANIFEST_VERSION = 1;
+// A shared skill carries its whole directory. These metadata files describe the
+// bundle in the team repo (BUNDLE_MANIFEST_FILE) and track a local install
+// (BUNDLE_INSTALL_METADATA_FILE); neither is treated as skill content.
+const BUNDLE_MANIFEST_FILE = '.threadnote-bundle.json';
+const BUNDLE_INSTALL_METADATA_FILE = '.threadnote-bundle-install.json';
+// OpenViking writes these summaries into the worktree; they are gitignored and
+// must never be packed as skill members.
+const OV_SUMMARY_FILES: readonly string[] = ['.abstract.md', '.overview.md'];
+// Directories and files that are skill runtime artifacts or local junk, never
+// part of a shared skill bundle. `reviews/` and `repos/` are skill scratch dirs.
+const BUNDLE_IGNORE_DIR_NAMES: readonly string[] = ['.git', 'node_modules', 'reviews', 'repos'];
 const AUTO_SHARE_FETCH_INTERVAL_MS = 5 * 60 * 1000;
 export const DEFAULT_GIT_REMOTE_NAME = 'origin';
 
@@ -115,9 +128,17 @@ export interface ShareArtifactResult {
 export interface SharedArtifactFile {
   readonly artifact: ShareArtifactMetadata;
   readonly installPath: string;
+  // Present for skill artifacts: every file in the shared skill directory,
+  // relative to it. A length > 1 means this is a multi-file bundle.
+  readonly members?: readonly BundleMemberFile[];
   readonly sourceRelativePath: string;
   readonly sourcePath: string;
   readonly team: string;
+}
+
+interface BundleMemberFile {
+  readonly absolutePath: string;
+  readonly relativePath: string;
 }
 
 export type SharedArtifactInstallStatus =
@@ -764,7 +785,7 @@ async function hasWorktreeOrTrackedPath(git: string, worktree: string, relativeP
 
 export async function publishShareGitChange(
   worktree: string,
-  relativePath: string,
+  relativePath: string | readonly string[],
   commitMessage: string,
   options: {
     readonly dryRun?: boolean;
@@ -777,7 +798,8 @@ export async function publishShareGitChange(
   const verb = options.verb ?? 'add';
   const git = await requiredExecutable('git');
   const messages: string[] = [];
-  const stageArgs = verb === 'rm' ? ['-C', worktree, 'rm', relativePath] : ['-C', worktree, 'add', '--', relativePath];
+  const paths = typeof relativePath === 'string' ? [relativePath] : [...relativePath];
+  const stageArgs = verb === 'rm' ? ['-C', worktree, 'rm', ...paths] : ['-C', worktree, 'add', '--', ...paths];
   const stageResult = await runGitCommand(dryRun, git, stageArgs, `git ${verb} failed`);
   if (stageResult) {
     messages.push(`git ${verb}: ${stageResult.stdout.trim() || 'ok'}`);
@@ -922,14 +944,36 @@ export async function shareAgentArtifact(
   options: SharePublishArtifactOptions,
 ): Promise<ShareArtifactResult> {
   const team = await resolveTeam(config, options.team);
-  const dryRun = options.dryRun === true;
-  const preview = options.preview === true;
   const resolvedSourcePath = expandPath(sourcePath);
   if (!(await isRegularFileNoSymlink(resolvedSourcePath))) {
     throw new Error(`Agent artifact source is not a regular file: ${resolvedSourcePath}`);
   }
 
   const artifact = inferShareArtifact(resolvedSourcePath, options);
+  // A skill carries its whole directory. When companion files sit beside the
+  // SKILL.md it is shared as a multi-file bundle; a lone SKILL.md takes the same
+  // single-file path as before, byte-for-byte.
+  if (artifact.kind === 'skill') {
+    const skillDir = dirname(resolvedSourcePath);
+    const members = await collectBundleMemberFiles(skillDir);
+    if (members.length > 1) {
+      return shareBundleArtifact(config, team, artifact, skillDir, members, options);
+    }
+  }
+  return shareSingleArtifact(config, team, resolvedSourcePath, artifact, options);
+}
+
+type ResolvedShareTeam = Awaited<ReturnType<typeof resolveTeam>>;
+
+async function shareSingleArtifact(
+  config: ShareRuntime,
+  team: ResolvedShareTeam,
+  resolvedSourcePath: string,
+  artifact: ShareArtifactMetadata,
+  options: SharePublishArtifactOptions,
+): Promise<ShareArtifactResult> {
+  const dryRun = options.dryRun === true;
+  const preview = options.preview === true;
   const rawContent = await readFile(resolvedSourcePath, 'utf8');
   if (!rawContent.trim()) {
     throw new Error(`Refusing to share empty agent artifact: ${resolvedSourcePath}`);
@@ -1003,6 +1047,296 @@ export async function shareAgentArtifact(
   return {artifact, gitMessages, messages, sourcePath: resolvedSourcePath, targetPath, targetUri};
 }
 
+interface PreparedBundleMember {
+  readonly binary: boolean;
+  readonly blocker?: string;
+  readonly content: Buffer | string;
+  readonly redactions: ReadonlyArray<{readonly count: number; readonly name: string}>;
+  readonly relativePath: string;
+  readonly sha256: string;
+  readonly targetPath: string;
+  readonly targetUri: string;
+}
+
+async function shareBundleArtifact(
+  config: ShareRuntime,
+  team: ResolvedShareTeam,
+  artifact: ShareArtifactMetadata,
+  skillDir: string,
+  members: readonly BundleMemberFile[],
+  options: SharePublishArtifactOptions,
+): Promise<ShareArtifactResult> {
+  const dryRun = options.dryRun === true;
+  const preview = options.preview === true;
+  const skillRootRelative = `${SHAREABLE_ARTIFACT_DIR}/skills/${artifact.agent}/${artifact.name}`;
+  const skillRootTargetDir = join(team.config.worktree, ...skillRootRelative.split('/'));
+  const skillMdTargetPath = join(skillRootTargetDir, 'SKILL.md');
+  const skillMdTargetUri = workfileToVikingUri(config, team.config, skillMdTargetPath);
+  const skillRootTargetUri = parentUri(skillMdTargetUri);
+  const skillMdSourcePath = join(skillDir, 'SKILL.md');
+
+  const prepared = await Promise.all(
+    members.map(member => prepareBundleMember(config, team, member, skillRootTargetDir, options)),
+  );
+  const skillMd = prepared.find(entry => entry.relativePath === 'SKILL.md');
+  if (skillMd === undefined) {
+    throw new Error(`Skill bundle ${artifact.agent}/${artifact.name} is missing SKILL.md.`);
+  }
+  if (!skillMd.binary && typeof skillMd.content === 'string' && !skillMd.content.trim()) {
+    throw new Error(`Refusing to share empty agent artifact: ${skillMdSourcePath}`);
+  }
+
+  const messages: string[] = [
+    `${preview ? 'Previewing' : dryRun ? 'Would share' : 'Sharing'} skill ${artifact.agent}/${artifact.name} bundle (${prepared.length} files)`,
+    `Source: ${portablePath(skillDir)}`,
+    `Destination: ${skillRootTargetUri}/`,
+  ];
+
+  const blockers = prepared.filter(entry => entry.blocker !== undefined);
+  if (preview) {
+    for (const entry of prepared) {
+      const flags = entry.binary ? ['binary'] : [];
+      for (const redaction of entry.redactions) {
+        flags.push(`redact ${redaction.count}× ${redaction.name}`);
+      }
+      const note = entry.blocker !== undefined ? ` BLOCKED: ${entry.blocker}` : '';
+      messages.push(`  ${entry.relativePath}${flags.length > 0 ? ` [${flags.join(', ')}]` : ''}${note}`);
+    }
+    return {
+      artifact,
+      gitMessages: [],
+      messages,
+      previewContent: skillMd.binary ? undefined : (skillMd.content as string),
+      sourcePath: skillMdSourcePath,
+      targetPath: skillMdTargetPath,
+      targetUri: skillMdTargetUri,
+    };
+  }
+
+  if (blockers.length > 0) {
+    throw new Error(
+      `Refusing to share skill ${artifact.agent}/${artifact.name}: ${blockers
+        .map(entry => `${entry.relativePath} (${entry.blocker})`)
+        .join('; ')}. Strip the value, pass --redact for local paths, or --allow-binary for binary files.`,
+    );
+  }
+  for (const entry of prepared) {
+    for (const redaction of entry.redactions) {
+      messages.push(`Redacted ${redaction.count}× ${redaction.name} in ${entry.relativePath} before sharing.`);
+    }
+  }
+
+  for (const entry of prepared) {
+    const existing = await readFileBytesIfExists(entry.targetPath);
+    if (existing !== undefined && sha256(existing) !== entry.sha256 && options.force !== true) {
+      throw new Error(
+        `Shared artifact already exists with different content: ${portablePath(entry.targetPath)}. Pass --force to replace it.`,
+      );
+    }
+  }
+
+  if (dryRun) {
+    messages.push(`Would write ${prepared.length} files under ${portablePath(skillRootTargetDir)}`);
+    return {
+      artifact,
+      gitMessages: [],
+      messages,
+      sourcePath: skillMdSourcePath,
+      targetPath: skillMdTargetPath,
+      targetUri: skillMdTargetUri,
+    };
+  }
+
+  // Safety invariant: OpenViking-managed markdown is written first (SKILL.md
+  // leading), so a failed OV write never leaves a worktree tree that a later
+  // share sync would auto-commit without ingestion. Companion files and the
+  // manifest are materialized only after every markdown write succeeds.
+  const ov = await openVikingCliForMode(dryRun);
+  const markdownMembers = orderSkillMdFirst(prepared.filter(entry => entry.relativePath.endsWith('.md')));
+  const otherMembers = prepared.filter(entry => !entry.relativePath.endsWith('.md'));
+  for (const entry of markdownMembers) {
+    const ovHasResource = await vikingResourceExists(ov, config, entry.targetUri);
+    await ensureSharedDirectoryChain(config, ov, entry.targetUri, dryRun, {quiet: true});
+    await writeMemoryFile(
+      config,
+      ov,
+      entry.targetUri,
+      entry.content as string,
+      ovHasResource ? 'replace' : 'create',
+      dryRun,
+      {quiet: true},
+    );
+  }
+  await ensureDirectory(skillRootTargetDir, false);
+  for (const entry of otherMembers) {
+    await ensureDirectory(dirname(entry.targetPath), false);
+    await writeFile(entry.targetPath, entry.content, entry.binary ? {mode: 0o600} : {encoding: 'utf8', mode: 0o600});
+  }
+  await writeFile(join(skillRootTargetDir, BUNDLE_MANIFEST_FILE), buildBundleManifest(artifact, prepared), {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+
+  const stagedPaths = [
+    ...prepared.map(entry => `${skillRootRelative}/${entry.relativePath}`),
+    `${skillRootRelative}/${BUNDLE_MANIFEST_FILE}`,
+  ];
+  const message =
+    options.message ?? `share: publish skill ${artifact.agent}/${artifact.name} (${prepared.length} files)`;
+  const gitMessages = await publishShareGitChange(team.config.worktree, stagedPaths, message, {
+    dryRun,
+    push: options.push,
+  });
+  return {
+    artifact,
+    gitMessages,
+    messages,
+    sourcePath: skillMdSourcePath,
+    targetPath: skillMdTargetPath,
+    targetUri: skillMdTargetUri,
+  };
+}
+
+async function prepareBundleMember(
+  config: ShareRuntime,
+  team: ResolvedShareTeam,
+  member: BundleMemberFile,
+  skillRootTargetDir: string,
+  options: SharePublishArtifactOptions,
+): Promise<PreparedBundleMember> {
+  const buffer = await readFile(member.absolutePath);
+  const targetPath = join(skillRootTargetDir, ...member.relativePath.split('/'));
+  const targetUri = workfileToVikingUri(config, team.config, targetPath);
+  if (isProbablyBinary(buffer)) {
+    const credential = detectBinaryCredential(buffer);
+    const blocker =
+      credential !== undefined
+        ? `possible ${credential} embedded in binary file`
+        : options.allowBinary === true
+          ? undefined
+          : 'binary file (pass --allow-binary to include it unscanned)';
+    return {
+      binary: true,
+      blocker,
+      content: buffer,
+      redactions: [],
+      relativePath: member.relativePath,
+      sha256: sha256(buffer),
+      targetPath,
+      targetUri,
+    };
+  }
+  const scrub = applyScrubber(buffer.toString('utf8'), {redact: options.redact === true});
+  return {
+    binary: false,
+    blocker: scrub.blocker,
+    content: scrub.cleaned,
+    redactions: scrub.redactions,
+    relativePath: member.relativePath,
+    sha256: sha256(scrub.cleaned),
+    targetPath,
+    targetUri,
+  };
+}
+
+function orderSkillMdFirst(entries: readonly PreparedBundleMember[]): readonly PreparedBundleMember[] {
+  return [...entries].sort((a, b) => {
+    if (a.relativePath === 'SKILL.md') {
+      return -1;
+    }
+    if (b.relativePath === 'SKILL.md') {
+      return 1;
+    }
+    return compareStrings(a.relativePath, b.relativePath);
+  });
+}
+
+function buildBundleManifest(artifact: ShareArtifactMetadata, prepared: readonly PreparedBundleMember[]): string {
+  const manifest = {
+    artifact,
+    members: prepared
+      .map(entry => ({binary: entry.binary, path: entry.relativePath, sha256: entry.sha256}))
+      .sort((a, b) => compareStrings(a.path, b.path)),
+    version: BUNDLE_MANIFEST_VERSION,
+  };
+  return `${JSON.stringify(manifest, undefined, 2)}\n`;
+}
+
+async function collectBundleMemberFiles(skillDir: string): Promise<readonly BundleMemberFile[]> {
+  const out: BundleMemberFile[] = [];
+  async function visit(dir: string): Promise<void> {
+    const entries = await readdir(dir, {withFileTypes: true});
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!BUNDLE_IGNORE_DIR_NAMES.includes(entry.name)) {
+          await visit(full);
+        }
+        continue;
+      }
+      if (!entry.isFile() || isIgnoredBundleFile(entry.name)) {
+        continue;
+      }
+      out.push({absolutePath: full, relativePath: relative(skillDir, full).split(sep).join('/')});
+    }
+  }
+  await visit(skillDir);
+  return out.sort((a, b) => compareStrings(a.relativePath, b.relativePath));
+}
+
+function isIgnoredBundleFile(name: string): boolean {
+  if (name === '.DS_Store' || name === BUNDLE_MANIFEST_FILE || name === BUNDLE_INSTALL_METADATA_FILE) {
+    return true;
+  }
+  if (OV_SUMMARY_FILES.includes(name)) {
+    return true;
+  }
+  return name.endsWith('.log') || name.endsWith('.threadnote-install.json');
+}
+
+function isProbablyBinary(buffer: Buffer): boolean {
+  if (buffer.includes(0)) {
+    return true;
+  }
+  try {
+    new TextDecoder('utf-8', {fatal: true}).decode(buffer);
+    return false;
+  } catch (_err: unknown) {
+    return true;
+  }
+}
+
+function detectBinaryCredential(buffer: Buffer): string | undefined {
+  const latin1 = buffer.toString('latin1');
+  for (const pattern of SCRUBBER_PATTERNS) {
+    if (pattern.placeholder === undefined && pattern.regex.test(latin1)) {
+      return pattern.name;
+    }
+  }
+  return undefined;
+}
+
+async function readFileBytesIfExists(path: string): Promise<Buffer | undefined> {
+  try {
+    return await readFile(path);
+  } catch (_err: unknown) {
+    return undefined;
+  }
+}
+
+function isBundleArtifact(artifact: SharedArtifactFile): boolean {
+  return artifact.members !== undefined && artifact.members.length > 1;
+}
+
+// Locale-independent ordering so manifests and git diffs are reproducible
+// across machines regardless of the host locale.
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 export async function runShareInstallArtifacts(
   config: ShareRuntime,
   options: ShareInstallArtifactsOptions,
@@ -1073,6 +1407,10 @@ export async function installSharedAgentArtifacts(
   }
   let installedCount = 0;
   for (const artifact of artifacts) {
+    if (isBundleArtifact(artifact)) {
+      installedCount += await installBundleArtifact(artifact, options, dryRun, messages);
+      continue;
+    }
     const label = sharedArtifactLabel(artifact.artifact);
     const state = await sharedArtifactInstallState(artifact);
     if (dryRun) {
@@ -1693,6 +2031,7 @@ async function collectSharedArtifacts(worktree: string, team: string): Promise<r
       out.push({
         artifact,
         installPath: sharedArtifactInstallPath(team, artifact),
+        members: artifact.kind === 'skill' ? await collectSharedBundleMembers(dirname(full)) : undefined,
         sourcePath: full,
         sourceRelativePath: relativePath,
         team,
@@ -1701,6 +2040,30 @@ async function collectSharedArtifacts(worktree: string, team: string): Promise<r
   }
   await visit(root);
   return out.sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
+}
+
+// Members of a shared skill directory. Prefers the published manifest as the
+// authoritative member list; falls back to walking the directory when it is a
+// legacy single-file skill or the manifest is unreadable.
+async function collectSharedBundleMembers(skillDir: string): Promise<readonly BundleMemberFile[]> {
+  const manifestRaw = await readFileIfExists(join(skillDir, BUNDLE_MANIFEST_FILE));
+  if (manifestRaw !== undefined) {
+    const parsed = parseJsonConfigObject(manifestRaw);
+    const rawMembers = parsed?.members;
+    if (Array.isArray(rawMembers)) {
+      const fromManifest: BundleMemberFile[] = [];
+      for (const entry of rawMembers) {
+        const path = (entry as {path?: unknown})?.path;
+        if (typeof path === 'string' && path.length > 0) {
+          fromManifest.push({absolutePath: join(skillDir, ...path.split('/')), relativePath: path});
+        }
+      }
+      if (fromManifest.length > 0) {
+        return fromManifest.sort((a, b) => compareStrings(a.relativePath, b.relativePath));
+      }
+    }
+  }
+  return collectBundleMemberFiles(skillDir);
 }
 
 function filterSharedArtifacts(
@@ -1733,7 +2096,173 @@ async function maybeSyncSharedArtifacts(
 }
 
 async function sharedArtifactInstallStatus(artifact: SharedArtifactFile): Promise<SharedArtifactInstallStatus> {
+  if (isBundleArtifact(artifact)) {
+    return sharedBundleInstallStatus(artifact);
+  }
   return (await sharedArtifactInstallState(artifact)).status;
+}
+
+interface BundleInstallMemberMetadata {
+  readonly installedSha256: string;
+  readonly sourceSha256: string;
+}
+
+function bundleInstallRoot(artifact: SharedArtifactFile): string {
+  return dirname(artifact.installPath);
+}
+
+function bundleInstallMetadataPath(artifact: SharedArtifactFile): string {
+  return join(bundleInstallRoot(artifact), BUNDLE_INSTALL_METADATA_FILE);
+}
+
+async function readBundleInstallMetadata(
+  artifact: SharedArtifactFile,
+): Promise<Map<string, BundleInstallMemberMetadata> | undefined> {
+  const raw = await readFileIfExists(bundleInstallMetadataPath(artifact));
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = parseJsonConfigObject(raw);
+  if (parsed === undefined || parsed.version !== ARTIFACT_INSTALL_METADATA_VERSION || !Array.isArray(parsed.members)) {
+    return undefined;
+  }
+  const map = new Map<string, BundleInstallMemberMetadata>();
+  for (const entry of parsed.members) {
+    const path = (entry as {path?: unknown})?.path;
+    const sourceSha256 = (entry as {sourceSha256?: unknown})?.sourceSha256;
+    const installedSha256 = (entry as {installedSha256?: unknown})?.installedSha256;
+    if (typeof path === 'string' && typeof sourceSha256 === 'string' && typeof installedSha256 === 'string') {
+      map.set(path, {installedSha256, sourceSha256});
+    }
+  }
+  return map;
+}
+
+// Folds per-member 3-way comparison (source vs installed vs recorded) into one
+// bundle status. A local edit to one member and an upstream change to a
+// different member both surface as remote_changed_and_local_modified so install
+// refuses to silently clobber local work.
+async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<SharedArtifactInstallStatus> {
+  const members = artifact.members ?? [];
+  const installRoot = bundleInstallRoot(artifact);
+  const metadata = await readBundleInstallMetadata(artifact);
+  let installedCount = 0;
+  let localChanged = false;
+  let remoteChanged = false;
+  const memberPaths = new Set<string>();
+  for (const member of members) {
+    memberPaths.add(member.relativePath);
+    const sourceSha = sha256(await readFile(member.absolutePath));
+    const installedBytes = await readFileBytesIfExists(join(installRoot, ...member.relativePath.split('/')));
+    if (installedBytes === undefined) {
+      remoteChanged = true;
+      continue;
+    }
+    installedCount += 1;
+    const installedSha = sha256(installedBytes);
+    const recorded = metadata?.get(member.relativePath);
+    if (recorded === undefined) {
+      if (installedSha !== sourceSha) {
+        localChanged = true;
+      }
+      continue;
+    }
+    if (installedSha !== recorded.installedSha256) {
+      localChanged = true;
+    }
+    if (sourceSha !== recorded.sourceSha256) {
+      remoteChanged = true;
+    }
+  }
+  if (metadata !== undefined) {
+    for (const recordedPath of metadata.keys()) {
+      if (!memberPaths.has(recordedPath)) {
+        remoteChanged = true;
+      }
+    }
+  }
+  if (installedCount === 0 && metadata === undefined) {
+    return 'not_installed';
+  }
+  if (localChanged && remoteChanged) {
+    return 'remote_changed_and_local_modified';
+  }
+  if (remoteChanged) {
+    return 'update_available';
+  }
+  if (localChanged) {
+    return 'local_modified';
+  }
+  return 'current';
+}
+
+async function installBundleArtifact(
+  artifact: SharedArtifactFile,
+  options: ShareInstallArtifactsOptions,
+  dryRun: boolean,
+  messages: string[],
+): Promise<number> {
+  const members = artifact.members ?? [];
+  const installRoot = bundleInstallRoot(artifact);
+  const label = `${sharedArtifactLabel(artifact.artifact)} bundle (${members.length} files)`;
+  const status = await sharedBundleInstallStatus(artifact);
+  if (dryRun) {
+    const verb = sharedArtifactDryRunVerb(status, options.force === true);
+    const suffix = sharedArtifactDryRunSuffix(status, options.force === true);
+    messages.push(`${verb} ${label}: ${portablePath(installRoot)}${suffix}`);
+    return 0;
+  }
+  if ((status === 'local_modified' || status === 'remote_changed_and_local_modified') && options.force !== true) {
+    throw new Error(`Refusing to overwrite ${portablePath(installRoot)}. Pass force=true or --force.`);
+  }
+  if (status === 'current') {
+    await writeFile(bundleInstallMetadataPath(artifact), await buildBundleInstallMetadata(artifact, members), {
+      mode: 0o600,
+    });
+    messages.push(`Already installed ${label}: ${portablePath(installRoot)}`);
+    return 0;
+  }
+
+  // Materialize into a sibling staging directory, then swap atomically so an
+  // interrupted install can never leave a half-written, mixed-version bundle.
+  const stagingRoot = `${installRoot}.threadnote-staging`;
+  await rm(stagingRoot, {force: true, recursive: true});
+  for (const member of members) {
+    const dest = join(stagingRoot, ...member.relativePath.split('/'));
+    await ensureDirectory(dirname(dest), false);
+    await writeFile(dest, await readFile(member.absolutePath), {mode: 0o600});
+  }
+  await writeFile(
+    join(stagingRoot, BUNDLE_INSTALL_METADATA_FILE),
+    await buildBundleInstallMetadata(artifact, members),
+    {
+      mode: 0o600,
+    },
+  );
+  await rm(installRoot, {force: true, recursive: true});
+  await ensureDirectory(dirname(installRoot), false);
+  await rename(stagingRoot, installRoot);
+  messages.push(`${sharedArtifactInstallVerb(status, options.force === true)} ${label}: ${portablePath(installRoot)}`);
+  return 1;
+}
+
+async function buildBundleInstallMetadata(
+  artifact: SharedArtifactFile,
+  members: readonly BundleMemberFile[],
+): Promise<string> {
+  const recordedMembers: Array<{installedSha256: string; path: string; sourceSha256: string}> = [];
+  for (const member of members) {
+    const sha = sha256(await readFile(member.absolutePath));
+    recordedMembers.push({installedSha256: sha, path: member.relativePath, sourceSha256: sha});
+  }
+  const metadata = {
+    artifact: artifact.artifact,
+    installedAt: new Date().toISOString(),
+    members: recordedMembers.sort((a, b) => compareStrings(a.path, b.path)),
+    team: artifact.team,
+    version: ARTIFACT_INSTALL_METADATA_VERSION,
+  };
+  return `${JSON.stringify(metadata, undefined, 2)}\n`;
 }
 
 async function sharedArtifactInstallState(artifact: SharedArtifactFile): Promise<SharedArtifactInstallState> {

--- a/src/share.ts
+++ b/src/share.ts
@@ -1,6 +1,6 @@
 import {lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
-import {basename, dirname, join, relative, sep} from 'node:path';
+import {basename, dirname, isAbsolute, join, relative, sep} from 'node:path';
 import {TextDecoder} from 'node:util';
 import {uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
@@ -63,6 +63,16 @@ const OV_SUMMARY_FILES: readonly string[] = ['.abstract.md', '.overview.md'];
 // Directories and files that are skill runtime artifacts or local junk, never
 // part of a shared skill bundle. `reviews/` and `repos/` are skill scratch dirs.
 const BUNDLE_IGNORE_DIR_NAMES: readonly string[] = ['.git', 'node_modules', 'reviews', 'repos'];
+// Constellation packs: multiple skills plus shared code that lives outside any
+// single skill directory, published together so relative paths resolve once
+// installed under one root. Authored from a `threadnote-bundle.json` manifest.
+const PACK_INDEX_SUFFIX = '.pack.md';
+const PACK_MANIFEST_SUFFIX = '.pack.json';
+const PACK_FILES_DIR = 'files';
+// Replaced into the author's absolute repo-root references at publish, expanded
+// back to the real install directory at install time so hardcoded paths resolve
+// on a teammate's machine.
+const PACK_ROOT_TOKEN = '${THREADNOTE_PACK_ROOT}';
 const AUTO_SHARE_FETCH_INTERVAL_MS = 5 * 60 * 1000;
 export const DEFAULT_GIT_REMOTE_NAME = 'origin';
 
@@ -100,7 +110,10 @@ const SCRUBBER_PATTERNS: readonly ScrubberPattern[] = [
   // so redaction collapses an entire path to a single placeholder rather than
   // leaving the subpath visible.
   {name: 'macOS home path', placeholder: '<local-path>', regex: /\/Users\/[^\s)>"'`,]+/},
-  {name: 'linux home path', placeholder: '<local-path>', regex: /\b\/home\/[^\s)>"'`,]+/},
+  // No leading \b: it only matches when a word char precedes the slash, which
+  // misses the common cases (after =, :, whitespace, or line start). Mirror the
+  // macOS pattern so /home/... is caught in every position.
+  {name: 'linux home path', placeholder: '<local-path>', regex: /\/home\/[^\s)>"'`,]+/},
 ];
 
 export interface ScrubberResult {
@@ -754,11 +767,53 @@ async function stageShareableChanges(dryRun: boolean, git: string, worktree: str
   // OpenViking-generated summaries (.abstract.md, .overview.md) are excluded
   // via the repo's .gitignore (ensureSharedGitignore self-heals it on every
   // sync), so they never get staged even by an unscoped `git add`.
+  // First drop any incomplete pack orphaned by a killed publish, so the blanket
+  // `git add -A` below never commits a pack index without its manifest.
+  await removeOrphanPackIndexes(dryRun, git, worktree);
   const pathspecs = await existingShareablePathspecs(git, worktree);
   if (pathspecs.length === 0) {
     return;
   }
   await maybeRun(dryRun, git, ['-C', worktree, 'add', '-A', '--', ...pathspecs], {allowFailure: true});
+}
+
+// A pack whose <name>.pack.md index exists but whose <name>.pack.json manifest
+// is missing is an incomplete publish (e.g. interrupted by SIGKILL). Discovery
+// already skips such packs; this removes the UNTRACKED leftover before staging so
+// `git add -A` cannot commit/push it. Tracked trees are never touched.
+async function removeOrphanPackIndexes(dryRun: boolean, git: string, worktree: string): Promise<void> {
+  const packsRoot = join(worktree, SHAREABLE_ARTIFACT_DIR, 'packs');
+  if (!(await isDirectory(packsRoot))) {
+    return;
+  }
+  for (const agentEntry of await readdir(packsRoot, {withFileTypes: true})) {
+    if (!agentEntry.isDirectory()) {
+      continue;
+    }
+    const agentDir = join(packsRoot, agentEntry.name);
+    for (const nameEntry of await readdir(agentDir, {withFileTypes: true})) {
+      if (!nameEntry.isDirectory()) {
+        continue;
+      }
+      const packDir = join(agentDir, nameEntry.name);
+      const indexPath = join(packDir, `${nameEntry.name}${PACK_INDEX_SUFFIX}`);
+      const manifestPath = join(packDir, `${nameEntry.name}${PACK_MANIFEST_SUFFIX}`);
+      if (!(await isFile(indexPath)) || (await isFile(manifestPath))) {
+        continue;
+      }
+      const indexRelative = relative(worktree, indexPath).split(sep).join('/');
+      const tracked = await runCommand(git, ['-C', worktree, 'ls-files', '--', indexRelative], {allowFailure: true});
+      if (tracked.exitCode === 0 && tracked.stdout.trim().length > 0) {
+        continue;
+      }
+      console.warn(
+        `${dryRun ? 'Would remove' : 'Removing'} incomplete shared pack (missing ${nameEntry.name}${PACK_MANIFEST_SUFFIX}): ${indexRelative}`,
+      );
+      if (!dryRun) {
+        await rm(packDir, {force: true, recursive: true});
+      }
+    }
+  }
 }
 
 async function existingShareablePathspecs(git: string, worktree: string): Promise<readonly string[]> {
@@ -1319,6 +1374,24 @@ function detectBinaryCredential(buffer: Buffer): string | undefined {
   return undefined;
 }
 
+// Scans binary bytes for a machine-local path that the pack rewriter would
+// neutralize in text — a declared repo root, or a home-path soft-leak — so an
+// --allow-binary member cannot silently carry one.
+function detectBinaryLocalPath(buffer: Buffer, rewriteRoots: readonly string[]): string | undefined {
+  const latin1 = buffer.toString('latin1');
+  for (const root of rewriteRoots) {
+    if (root.length > 0 && latin1.includes(root)) {
+      return 'machine-local path';
+    }
+  }
+  for (const pattern of SCRUBBER_PATTERNS) {
+    if (pattern.placeholder !== undefined && pattern.regex.test(latin1)) {
+      return pattern.name;
+    }
+  }
+  return undefined;
+}
+
 async function readFileBytesIfExists(path: string): Promise<Buffer | undefined> {
   try {
     return await readFile(path);
@@ -1328,6 +1401,9 @@ async function readFileBytesIfExists(path: string): Promise<Buffer | undefined> 
 }
 
 function isBundleArtifact(artifact: SharedArtifactFile): boolean {
+  if (artifact.artifact.kind === 'pack') {
+    return true;
+  }
   return artifact.members !== undefined && artifact.members.length > 1;
 }
 
@@ -1335,6 +1411,602 @@ function isBundleArtifact(artifact: SharedArtifactFile): boolean {
 // across machines regardless of the host locale.
 function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
+}
+
+interface PackManifest {
+  readonly agent: ShareAgentArtifactAgent;
+  readonly deps: {
+    readonly cli: readonly string[];
+    readonly mcp: readonly string[];
+    readonly os: readonly string[];
+    readonly runtime: readonly string[];
+  };
+  readonly description?: string;
+  readonly include: readonly string[];
+  readonly name: string;
+  readonly pathRewrites: readonly string[];
+  readonly skills: readonly string[];
+}
+
+export async function runSharePublishBundle(
+  config: ShareRuntime,
+  manifestPath: string,
+  options: SharePublishArtifactOptions,
+): Promise<void> {
+  const result = await shareBundlePack(config, manifestPath, options);
+  printShareArtifactResult(result, options.preview === true);
+}
+
+function parsePackManifest(raw: string, manifestPath: string): PackManifest {
+  const parsed = parseJsonConfigObject(raw);
+  if (parsed === undefined) {
+    throw new Error(`Invalid pack manifest (not a JSON object): ${manifestPath}`);
+  }
+  const name = parsed.name;
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    throw new Error(`Pack manifest must set a non-empty "name": ${manifestPath}`);
+  }
+  const agent = parsed.agent;
+  if (agent !== 'codex' && agent !== 'claude') {
+    throw new Error(`Pack manifest "agent" must be "codex" or "claude": ${manifestPath}`);
+  }
+  const stringArray = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  const skills = stringArray(parsed.skills);
+  if (skills.length === 0) {
+    throw new Error(`Pack manifest must list at least one skill in "skills": ${manifestPath}`);
+  }
+  const depsValue = (parsed.deps ?? {}) as Record<string, unknown>;
+  const pathRewrites = Array.isArray(parsed.pathRewrites)
+    ? parsed.pathRewrites
+        .map(entry => (typeof entry === 'string' ? entry : (entry as {from?: unknown})?.from))
+        .filter((item): item is string => typeof item === 'string')
+        // Strip trailing slashes so a declared "/repo/" still matches a bare
+        // "/repo" reference (otherwise the slash-suffixed root never appears and
+        // the path leaks past tokenize + the residual check).
+        .map(rewrite => rewrite.replace(/\/+$/, ''))
+    : [];
+  // pathRewrites are matched as whole repo-root prefixes; a short or relative
+  // value would corrupt unrelated content via substring replacement.
+  for (const rewrite of pathRewrites) {
+    if (!isAbsolute(rewrite) || rewrite.split('/').filter(Boolean).length < 2) {
+      throw new Error(
+        `Pack manifest pathRewrites entry must be an absolute repo-root path (got "${rewrite}"): ${manifestPath}`,
+      );
+    }
+  }
+  return {
+    agent,
+    deps: {
+      cli: stringArray(depsValue.cli),
+      mcp: stringArray(depsValue.mcp),
+      os: stringArray(depsValue.os),
+      runtime: stringArray(depsValue.runtime),
+    },
+    description: typeof parsed.description === 'string' ? parsed.description : undefined,
+    include: stringArray(parsed.include),
+    name,
+    pathRewrites,
+    skills,
+  };
+}
+
+// Resolves manifest skill + include entries into a flat, deduplicated member
+// list whose relative paths preserve the author's repo layout so relative
+// imports and CWD-relative invocations resolve once installed under one root.
+async function collectPackMembers(manifestDir: string, manifest: PackManifest): Promise<readonly BundleMemberFile[]> {
+  const members = new Map<string, BundleMemberFile>();
+  const addEntry = async (entry: string): Promise<void> => {
+    const normalized = entry.split('/').filter(Boolean).join('/');
+    if (normalized.split('/').includes('..')) {
+      throw new Error(`Pack manifest entries must stay within the pack root (got "${entry}").`);
+    }
+    const absolute = join(manifestDir, ...normalized.split('/'));
+    if (absolute !== manifestDir && !absolute.startsWith(manifestDir + sep)) {
+      throw new Error(`Pack manifest entry escapes the pack root: ${entry}`);
+    }
+    if (await isDirectory(absolute)) {
+      for (const member of await collectBundleMemberFiles(absolute)) {
+        const relativePath = `${normalized}/${member.relativePath}`;
+        members.set(relativePath, {absolutePath: member.absolutePath, relativePath});
+      }
+      return;
+    }
+    if (await isRegularFileNoSymlink(absolute)) {
+      members.set(normalized, {absolutePath: absolute, relativePath: normalized});
+      return;
+    }
+    throw new Error(`Pack manifest references a missing path: ${entry}`);
+  };
+  for (const skill of manifest.skills) {
+    // Accept either a skill directory or a path to its SKILL.md.
+    const skillRel = skill.replace(/\/SKILL\.md$/i, '');
+    const skillDir = join(manifestDir, ...skillRel.split('/'));
+    if (!(await isFile(join(skillDir, 'SKILL.md')))) {
+      throw new Error(`Pack skill "${skill}" must be a directory containing SKILL.md.`);
+    }
+    await addEntry(skillRel);
+  }
+  for (const include of manifest.include) {
+    await addEntry(include);
+  }
+  return [...members.values()].sort((a, b) => compareStrings(a.relativePath, b.relativePath));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Replaces each repo-root prefix with the portable token, anchored on BOTH
+// sides to a path boundary: the left lookbehind stops a root from matching when
+// it is embedded as a path-segment suffix of a longer path (e.g. inside
+// "/backup/Users/alice/reviewer"); the right lookahead stops it from matching a
+// longer token ("/repo" must not rewrite inside "/repository") and accepts the
+// common path terminators (`/ \\ " ' ` whitespace ) , > : ] } ; =`).
+function tokenizePackPaths(text: string, rewriteRoots: readonly string[]): string {
+  let out = text;
+  for (const root of rewriteRoots) {
+    if (root.length > 0) {
+      out = out.replace(
+        new RegExp(`(?<![A-Za-z0-9/._~-])${escapeRegExp(root)}(?=[/\\\\]|["'\`\\s),>:\\]};=]|$)`, 'g'),
+        PACK_ROOT_TOKEN,
+      );
+    }
+  }
+  return out;
+}
+
+// A declared rewrite root still present after tokenization (e.g. followed by a
+// non-boundary char like '-' so the prefix wasn't rewritten) is a residual
+// machine-local path. Text members rely on this to match the substring check
+// detectBinaryLocalPath already applies to binary members.
+function residualRewriteRoot(content: string, rewriteRoots: readonly string[]): string | undefined {
+  return rewriteRoots.find(root => root.length > 0 && content.includes(root));
+}
+
+// Absolute path prefixes that are portable across machines (system/tool paths),
+// so a surviving reference to them is not flagged as a machine-local leak.
+const PORTABLE_PATH_PREFIXES: readonly string[] = [
+  '/usr/',
+  '/bin/',
+  '/sbin/',
+  '/lib/',
+  '/lib64/',
+  '/etc/',
+  '/opt/homebrew/',
+  '/tmp/',
+  '/var/',
+  '/private/var/',
+  '/dev/',
+  '/proc/',
+  '/run/',
+  '/sys/',
+  '/Library/',
+  '/System/',
+  '/Applications/',
+];
+
+// Best-effort detector of machine-local absolute paths that tokenization and the
+// scrubber do not catch (anything that isn't /Users, /home, a rewrite root, or a
+// portable system prefix). Advisory only — used to WARN, never to block, because
+// many absolute paths (/usr/bin, /bin/sh) are legitimately portable.
+function unportableAbsolutePaths(content: string): readonly string[] {
+  // Drop the portable pack-root token (and the path that follows it) so paths
+  // anchored to the install root are not mistaken for machine-local leaks.
+  const scan = content.split(`${PACK_ROOT_TOKEN}/`).join('').split(PACK_ROOT_TOKEN).join('');
+  const found = new Set<string>();
+  for (const path of scan.match(/(?<![A-Za-z0-9._~$-])\/[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+/g) ?? []) {
+    if (!PORTABLE_PATH_PREFIXES.some(prefix => path.startsWith(prefix))) {
+      found.add(path);
+    }
+  }
+  for (const path of scan.match(/[A-Za-z]:\\[^\s"']+/g) ?? []) {
+    found.add(path);
+  }
+  return [...found].sort((a, b) => compareStrings(a, b));
+}
+
+async function preparePackMember(
+  config: ShareRuntime,
+  team: ResolvedShareTeam,
+  member: BundleMemberFile,
+  filesTargetDir: string,
+  rewriteRoots: readonly string[],
+  options: SharePublishArtifactOptions,
+): Promise<PreparedBundleMember> {
+  const buffer = await readFile(member.absolutePath);
+  const targetPath = join(filesTargetDir, ...member.relativePath.split('/'));
+  const targetUri = workfileToVikingUri(config, team.config, targetPath);
+  if (isProbablyBinary(buffer)) {
+    // Binary members cannot be tokenized or scrubbed, so an embedded credential
+    // or machine-local path can never be neutralized — block rather than ship it
+    // silently, even with --allow-binary.
+    const credential = detectBinaryCredential(buffer);
+    const localPath = credential === undefined ? detectBinaryLocalPath(buffer, rewriteRoots) : undefined;
+    let blocker: string | undefined;
+    if (credential !== undefined) {
+      blocker = `possible ${credential} embedded in binary file`;
+    } else if (options.allowBinary !== true) {
+      blocker = 'binary file (pass --allow-binary to include it unscanned)';
+    } else if (localPath !== undefined) {
+      blocker = `possible ${localPath} embedded in binary file (cannot be rewritten)`;
+    }
+    return {
+      binary: true,
+      blocker,
+      content: buffer,
+      redactions: [],
+      relativePath: member.relativePath,
+      sha256: sha256(buffer),
+      targetPath,
+      targetUri,
+    };
+  }
+  const text = buffer.toString('utf8');
+  // A member that already contains the reserved token would have it expanded to
+  // the installer's absolute path at install — block it as an authoring error.
+  if (text.includes(PACK_ROOT_TOKEN)) {
+    return {
+      binary: false,
+      blocker: `contains the reserved ${PACK_ROOT_TOKEN} token`,
+      content: text,
+      redactions: [],
+      relativePath: member.relativePath,
+      sha256: sha256(text),
+      targetPath,
+      targetUri,
+    };
+  }
+  // Rewrite hardcoded repo-root paths to the portable token BEFORE scrubbing.
+  // The residual net is PARTIAL: a surviving declared/auto rewrite root
+  // (residualRewriteRoot) and /Users or /home paths (scrubber) block the publish,
+  // but other machine-local absolute paths (/opt, /srv, /Volumes, Windows C:\\)
+  // are NOT auto-detected — authors must declare them in pathRewrites or strip
+  // them. See docs/share.md and the known-limitations follow-up.
+  const tokenized = tokenizePackPaths(text, rewriteRoots);
+  // Honor --redact only for prose (.md). Redacting a soft-leak path inside an
+  // executable member would silently rewrite it to <local-path> and break the
+  // file at runtime, so code members always block on a residual path instead.
+  const isMarkdown = member.relativePath.toLowerCase().endsWith('.md');
+  const scrub = applyScrubber(tokenized, {redact: isMarkdown && options.redact === true});
+  const residual = residualRewriteRoot(scrub.cleaned, rewriteRoots);
+  const blocker =
+    scrub.blocker ?? (residual !== undefined ? `machine-local path "${residual}" not rewritten` : undefined);
+  return {
+    binary: false,
+    blocker,
+    content: scrub.cleaned,
+    redactions: scrub.redactions,
+    relativePath: member.relativePath,
+    sha256: sha256(scrub.cleaned),
+    targetPath,
+    targetUri,
+  };
+}
+
+function buildPackIndex(
+  artifact: ShareArtifactMetadata,
+  manifest: PackManifest,
+  skillNames: readonly string[],
+  memberCount: number,
+): string {
+  const lines = [
+    '---',
+    `name: ${artifact.name}`,
+    `agent: ${artifact.agent}`,
+    'kind: pack',
+    `skills: [${skillNames.join(', ')}]`,
+    '---',
+    '',
+    `# ${artifact.name} (skill pack)`,
+    '',
+    manifest.description ??
+      `A Threadnote skill pack bundling ${skillNames.length} skill(s) and their shared support files (${memberCount} files total).`,
+    '',
+    '## Skills',
+    ...skillNames.map(skill => `- ${skill}`),
+    '',
+    '## Requirements',
+    'Threadnote installs files only. Ensure these exist on the target machine before running:',
+  ];
+  if (manifest.deps.runtime.length > 0) {
+    lines.push(`- runtime: ${manifest.deps.runtime.join(', ')}`);
+  }
+  if (manifest.deps.cli.length > 0) {
+    lines.push(`- CLI: ${manifest.deps.cli.join(', ')}`);
+  }
+  if (manifest.deps.os.length > 0) {
+    lines.push(`- OS: ${manifest.deps.os.join(', ')}`);
+  }
+  if (manifest.deps.mcp.length > 0) {
+    lines.push(`- MCP (configure separately): ${manifest.deps.mcp.join(', ')}`);
+  }
+  lines.push('', `Install: threadnote share install-artifacts --kind pack --name ${artifact.name} --apply`, '');
+  return lines.join('\n');
+}
+
+function buildPackManifestJson(
+  artifact: ShareArtifactMetadata,
+  manifest: PackManifest,
+  prepared: readonly PreparedBundleMember[],
+): string {
+  const data = {
+    artifact,
+    deps: manifest.deps,
+    members: prepared
+      .map(entry => ({binary: entry.binary, path: entry.relativePath, sha256: entry.sha256}))
+      .sort((a, b) => compareStrings(a.path, b.path)),
+    version: BUNDLE_MANIFEST_VERSION,
+  };
+  return `${JSON.stringify(data, undefined, 2)}\n`;
+}
+
+function packSkillName(skillEntry: string): string {
+  const trimmed = skillEntry.replace(/\/SKILL\.md$/i, '');
+  return basename(trimmed);
+}
+
+export async function shareBundlePack(
+  config: ShareRuntime,
+  manifestPath: string,
+  options: SharePublishArtifactOptions,
+): Promise<ShareArtifactResult> {
+  const team = await resolveTeam(config, options.team);
+  const dryRun = options.dryRun === true;
+  const preview = options.preview === true;
+  const resolvedManifest = expandPath(manifestPath);
+  if (!(await isRegularFileNoSymlink(resolvedManifest))) {
+    throw new Error(`Pack manifest is not a regular file: ${resolvedManifest}`);
+  }
+  const manifest = parsePackManifest(await readFile(resolvedManifest, 'utf8'), resolvedManifest);
+  const manifestDir = dirname(resolvedManifest);
+  const artifact: ShareArtifactMetadata = {agent: manifest.agent, kind: 'pack', name: uriSegment(manifest.name)};
+  const skillNames = manifest.skills.map(packSkillName);
+
+  const members = await collectPackMembers(manifestDir, manifest);
+  // Auto-derive the manifest dir as a rewrite root only when it is a plausible
+  // repo root (>= 2 path segments); a short top-level dir like /tmp would
+  // substring-corrupt unrelated paths. Declared pathRewrites are already guarded.
+  const autoRoots = manifestDir.split('/').filter(Boolean).length >= 2 ? [manifestDir] : [];
+  // Longest-first so a nested declared root rewrites before its parent.
+  const rewriteRoots = [...new Set([...autoRoots, ...manifest.pathRewrites])].sort((a, b) => b.length - a.length);
+
+  const packRootRelative = `${SHAREABLE_ARTIFACT_DIR}/packs/${artifact.agent}/${artifact.name}`;
+  const filesRelative = `${packRootRelative}/${PACK_FILES_DIR}`;
+  const indexRelative = `${packRootRelative}/${artifact.name}${PACK_INDEX_SUFFIX}`;
+  const manifestRelative = `${packRootRelative}/${artifact.name}${PACK_MANIFEST_SUFFIX}`;
+  const filesTargetDir = join(team.config.worktree, ...filesRelative.split('/'));
+  const packRootTargetDir = join(team.config.worktree, ...packRootRelative.split('/'));
+  const indexTargetPath = join(team.config.worktree, ...indexRelative.split('/'));
+  const indexTargetUri = workfileToVikingUri(config, team.config, indexTargetPath);
+
+  const prepared = await Promise.all(
+    members.map(member => preparePackMember(config, team, member, filesTargetDir, rewriteRoots, options)),
+  );
+  // Tokenize the generated index + manifest too (not just member files) so an
+  // author repo-root path embedded in description/deps is normalized to the
+  // portable token rather than leaking or noisily blocking.
+  const indexContent = tokenizePackPaths(buildPackIndex(artifact, manifest, skillNames, prepared.length), rewriteRoots);
+  const indexScrub = applyScrubber(indexContent, {redact: options.redact === true});
+
+  const messages: string[] = [
+    `${preview ? 'Previewing' : dryRun ? 'Would share' : 'Sharing'} pack ${artifact.agent}/${artifact.name} (${prepared.length} files, ${skillNames.length} skills)`,
+    `Source: ${portablePath(manifestDir)}`,
+    `Destination: ${indexTargetUri}`,
+  ];
+
+  const blockers = prepared.filter(entry => entry.blocker !== undefined);
+  if (preview) {
+    for (const entry of prepared) {
+      const flags = entry.binary ? ['binary'] : [];
+      for (const redaction of entry.redactions) {
+        flags.push(`redact ${redaction.count}× ${redaction.name}`);
+      }
+      const note = entry.blocker !== undefined ? ` BLOCKED: ${entry.blocker}` : '';
+      messages.push(`  ${entry.relativePath}${flags.length > 0 ? ` [${flags.join(', ')}]` : ''}${note}`);
+    }
+    return {
+      artifact,
+      gitMessages: [],
+      messages,
+      previewContent: indexScrub.cleaned,
+      sourcePath: resolvedManifest,
+      targetPath: indexTargetPath,
+      targetUri: indexTargetUri,
+    };
+  }
+
+  const indexResidual = residualRewriteRoot(indexScrub.cleaned, rewriteRoots);
+  if (indexScrub.blocker !== undefined || indexResidual !== undefined) {
+    throw new Error(
+      `Refusing to share pack ${artifact.agent}/${artifact.name}: index ${indexScrub.blocker ?? `machine-local path "${indexResidual}" not rewritten`}.`,
+    );
+  }
+  if (blockers.length > 0) {
+    throw new Error(
+      `Refusing to share pack ${artifact.agent}/${artifact.name}: ${blockers
+        .map(entry => `${entry.relativePath} (${entry.blocker})`)
+        .join('; ')}. Strip the value, pass --redact for local paths, or --allow-binary for binary files.`,
+    );
+  }
+  // The generated .pack.json is shared text too — tokenize then route it through
+  // the scrubber so no field can leak a secret or local path past the chokepoint.
+  const packJson = applyScrubber(tokenizePackPaths(buildPackManifestJson(artifact, manifest, prepared), rewriteRoots), {
+    redact: options.redact === true,
+  });
+  const packJsonResidual = residualRewriteRoot(packJson.cleaned, rewriteRoots);
+  if (packJson.blocker !== undefined || packJsonResidual !== undefined) {
+    throw new Error(
+      `Refusing to share pack ${artifact.agent}/${artifact.name}: manifest ${packJson.blocker ?? `machine-local path "${packJsonResidual}" not rewritten`}.`,
+    );
+  }
+  for (const entry of prepared) {
+    for (const redaction of entry.redactions) {
+      messages.push(`Redacted ${redaction.count}× ${redaction.name} in ${entry.relativePath} before sharing.`);
+    }
+  }
+  // Advisory: surface machine-local absolute paths the rewriter/scrubber cannot
+  // auto-detect (e.g. /opt, /srv, /Volumes, Windows C:\) so the author can add a
+  // pathRewrite or strip them. Non-blocking — many absolute paths are portable.
+  const unportable = new Set<string>();
+  for (const entry of prepared) {
+    if (!entry.binary && typeof entry.content === 'string') {
+      for (const path of unportableAbsolutePaths(entry.content)) {
+        unportable.add(`${entry.relativePath}: ${path}`);
+      }
+    }
+  }
+  for (const path of unportableAbsolutePaths(indexScrub.cleaned)) {
+    unportable.add(`${artifact.name}${PACK_INDEX_SUFFIX}: ${path}`);
+  }
+  for (const path of unportableAbsolutePaths(packJson.cleaned)) {
+    unportable.add(`${artifact.name}${PACK_MANIFEST_SUFFIX}: ${path}`);
+  }
+  if (unportable.size > 0) {
+    messages.push(
+      `Warning: possible machine-local absolute path(s) that will not resolve on a teammate's machine (declare in pathRewrites or strip if not portable): ${[...unportable].join('; ')}`,
+    );
+  }
+  for (const entry of prepared) {
+    const existing = await readFileBytesIfExists(entry.targetPath);
+    if (existing !== undefined && sha256(existing) !== entry.sha256 && options.force !== true) {
+      throw new Error(
+        `Shared pack file already exists with different content: ${portablePath(entry.targetPath)}. Pass --force to replace it.`,
+      );
+    }
+  }
+
+  if (dryRun) {
+    messages.push(`Would write ${prepared.length} files under ${portablePath(packRootTargetDir)}`);
+    return {
+      artifact,
+      gitMessages: [],
+      messages,
+      sourcePath: resolvedManifest,
+      targetPath: indexTargetPath,
+      targetUri: indexTargetUri,
+    };
+  }
+
+  // Safety invariant: OpenViking-managed markdown is written first (the index
+  // leads), so a failed OV write never leaves a worktree tree that a later share
+  // sync would auto-commit without ingestion.
+  const ov = await openVikingCliForMode(dryRun);
+  // Restore-capable rollback: before overwriting any resource, snapshot its prior
+  // bytes; on a mid-publish failure, undo in reverse — newly-created resources are
+  // removed and replaced ones (a --force re-publish) are restored to their prior
+  // content. This leaves the previously-published pack intact and nothing
+  // inconsistent for a later share sync to auto-commit.
+  const rollbacks: Array<() => Promise<void>> = [];
+  const manifestTargetPath = join(team.config.worktree, ...manifestRelative.split('/'));
+  try {
+    const writeMarkdownMember = async (uri: string, content: string, worktreePath: string): Promise<void> => {
+      const priorBytes = await readFileBytesIfExists(worktreePath);
+      const hadResource = await vikingResourceExists(ov, config, uri);
+      await ensureSharedDirectoryChain(config, ov, uri, dryRun, {quiet: true});
+      await writeMemoryFile(config, ov, uri, content, hadResource ? 'replace' : 'create', dryRun, {quiet: true});
+      rollbacks.push(async () => {
+        if (priorBytes !== undefined) {
+          await writeMemoryFile(config, ov, uri, priorBytes.toString('utf8'), 'replace', false, {quiet: true});
+        } else if (await vikingResourceExists(ov, config, uri)) {
+          await removeMemoryUri(config, ov, uri, false, {quiet: true});
+        }
+      });
+    };
+    await writeMarkdownMember(indexTargetUri, indexScrub.cleaned, indexTargetPath);
+    for (const entry of prepared.filter(member => member.relativePath.endsWith('.md'))) {
+      await writeMarkdownMember(entry.targetUri, entry.content as string, entry.targetPath);
+    }
+    await ensureDirectory(filesTargetDir, false);
+    for (const entry of prepared.filter(member => !member.relativePath.endsWith('.md'))) {
+      const priorBytes = await readFileBytesIfExists(entry.targetPath);
+      await ensureDirectory(dirname(entry.targetPath), false);
+      await writeFile(entry.targetPath, entry.content, entry.binary ? {mode: 0o600} : {encoding: 'utf8', mode: 0o600});
+      rollbacks.push(async () => {
+        if (priorBytes !== undefined) {
+          await writeFile(entry.targetPath, priorBytes, {mode: 0o600});
+        } else {
+          await rm(entry.targetPath, {force: true});
+        }
+      });
+    }
+    await ensureDirectory(packRootTargetDir, false);
+    const priorManifest = await readFileBytesIfExists(manifestTargetPath);
+    await writeFile(manifestTargetPath, packJson.cleaned, {encoding: 'utf8', mode: 0o600});
+    rollbacks.push(async () => {
+      if (priorManifest !== undefined) {
+        await writeFile(manifestTargetPath, priorManifest, {mode: 0o600});
+      } else {
+        await rm(manifestTargetPath, {force: true});
+      }
+    });
+
+    // Prune files orphaned by a re-publish (members dropped from the manifest) so
+    // stale code is neither carried in the shared repo nor installed by teammates.
+    const currentFiles = new Set(prepared.map(entry => `${filesRelative}/${entry.relativePath}`));
+    const git = await requiredExecutable('git');
+    const tracked = await runCommand(git, ['-C', team.config.worktree, 'ls-files', '--', filesRelative], {
+      allowFailure: true,
+    });
+    const stalePaths =
+      tracked.exitCode === 0
+        ? tracked.stdout
+            .split('\n')
+            .map(line => line.trim())
+            .filter(line => line.length > 0 && !currentFiles.has(line))
+        : [];
+    for (const stale of stalePaths) {
+      await runCommand(git, ['-C', team.config.worktree, 'rm', '-f', '--ignore-unmatch', '--', stale], {
+        allowFailure: true,
+      });
+      // Nested .md members are OV-ingested, so drop their resource too — keep the
+      // OpenViking index and the git tree in lockstep on the publisher's machine.
+      // Best-effort: the `git rm` deletion is already staged, so a single OV
+      // removal failure must not abort the publish (which would leave a staged
+      // deletion behind for a later sync); surface it as a warning instead.
+      if (stale.endsWith('.md')) {
+        const staleUri = workfileToVikingUri(config, team.config, join(team.config.worktree, ...stale.split('/')));
+        try {
+          if (await vikingResourceExists(ov, config, staleUri)) {
+            await removeMemoryUri(config, ov, staleUri, dryRun, {quiet: true});
+          }
+        } catch (pruneErr: unknown) {
+          messages.push(
+            `Warning: could not remove stale OpenViking resource ${staleUri}: ${pruneErr instanceof Error ? pruneErr.message : String(pruneErr)}`,
+          );
+        }
+      }
+    }
+  } catch (publishErr: unknown) {
+    for (const undo of rollbacks.reverse()) {
+      try {
+        await undo();
+      } catch (_cleanupErr: unknown) {
+        // Best-effort rollback; surface the original failure regardless.
+      }
+    }
+    throw publishErr;
+  }
+
+  const stagedPaths = [
+    indexRelative,
+    manifestRelative,
+    ...prepared.map(entry => `${filesRelative}/${entry.relativePath}`),
+  ];
+  const message =
+    options.message ?? `share: publish pack ${artifact.agent}/${artifact.name} (${prepared.length} files)`;
+  const gitMessages = await publishShareGitChange(team.config.worktree, stagedPaths, message, {
+    dryRun,
+    push: options.push,
+  });
+  return {
+    artifact,
+    gitMessages,
+    messages,
+    sourcePath: resolvedManifest,
+    targetPath: indexTargetPath,
+    targetUri: indexTargetUri,
+  };
 }
 
 export async function runShareInstallArtifacts(
@@ -2003,6 +2675,14 @@ function sharedArtifactFromRelativePath(relativePath: string): ShareArtifactMeta
   if (parts.length === 4 && parts[1] === 'commands' && parts[2] === 'claude' && parts[3].endsWith('.md')) {
     return {agent: 'claude', kind: 'command', name: parts[3].slice(0, -'.md'.length)};
   }
+  if (
+    parts.length === 5 &&
+    parts[1] === 'packs' &&
+    (parts[2] === 'codex' || parts[2] === 'claude') &&
+    parts[4] === `${parts[3]}${PACK_INDEX_SUFFIX}`
+  ) {
+    return {agent: parts[2], kind: 'pack', name: parts[3]};
+  }
   return undefined;
 }
 
@@ -2028,18 +2708,91 @@ async function collectSharedArtifacts(worktree: string, team: string): Promise<r
       if (artifact === undefined) {
         continue;
       }
-      out.push({
-        artifact,
-        installPath: sharedArtifactInstallPath(team, artifact),
-        members: artifact.kind === 'skill' ? await collectSharedBundleMembers(dirname(full)) : undefined,
-        sourcePath: full,
-        sourceRelativePath: relativePath,
-        team,
-      });
+      const artifactDir = dirname(full);
+      // An orphaned pack index without its .pack.json is an incomplete/partial
+      // publish; skip it so it neither pollutes the catalog nor breaks discovery.
+      if (artifact.kind === 'pack' && !(await isFile(join(artifactDir, `${artifact.name}${PACK_MANIFEST_SUFFIX}`)))) {
+        console.warn(
+          `Skipping incomplete shared pack (missing ${artifact.name}${PACK_MANIFEST_SUFFIX}): ${relativePath}`,
+        );
+        continue;
+      }
+      // Isolate per-artifact discovery failures so one malformed artifact never
+      // denies listing/install of the rest of the team's catalog.
+      try {
+        out.push({
+          artifact,
+          installPath: sharedArtifactInstallPath(team, artifact),
+          members: await collectArtifactMembers(artifact, artifactDir),
+          sourcePath: full,
+          sourceRelativePath: relativePath,
+          team,
+        });
+      } catch (err: unknown) {
+        console.warn(`Skipping shared artifact ${relativePath}: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
   await visit(root);
   return out.sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
+}
+
+async function collectArtifactMembers(
+  artifact: ShareArtifactMetadata,
+  artifactDir: string,
+): Promise<readonly BundleMemberFile[] | undefined> {
+  if (artifact.kind === 'skill') {
+    return collectSharedBundleMembers(artifactDir);
+  }
+  if (artifact.kind === 'pack') {
+    return collectSharedPackMembers(artifact, artifactDir);
+  }
+  return undefined;
+}
+
+// A pack's installable members come from its published .pack.json (the
+// authoritative list), so files orphaned in files/ by a removal are not
+// installed. Falls back to walking files/ when the manifest is missing.
+// A manifest member path must stay within its base directory: the .pack.json /
+// bundle manifest is git-carried (not scrubbed), so a malicious or corrupted
+// shared repo could otherwise use `..` or an absolute path to read/write outside
+// the install root.
+function isContainedMemberPath(baseDir: string, relativePath: string): boolean {
+  if (isAbsolute(relativePath) || relativePath.split('/').includes('..')) {
+    return false;
+  }
+  const resolved = join(baseDir, ...relativePath.split('/'));
+  return resolved === baseDir || resolved.startsWith(baseDir + sep);
+}
+
+async function collectSharedPackMembers(
+  artifact: ShareArtifactMetadata,
+  packDir: string,
+): Promise<readonly BundleMemberFile[]> {
+  const filesDir = join(packDir, PACK_FILES_DIR);
+  if (!(await isDirectory(filesDir))) {
+    return [];
+  }
+  const manifestRaw = await readFileIfExists(join(packDir, `${artifact.name}${PACK_MANIFEST_SUFFIX}`));
+  if (manifestRaw !== undefined) {
+    const rawMembers = parseJsonConfigObject(manifestRaw)?.members;
+    if (Array.isArray(rawMembers)) {
+      const fromManifest: BundleMemberFile[] = [];
+      for (const entry of rawMembers) {
+        const path = (entry as {path?: unknown})?.path;
+        if (typeof path === 'string' && path.length > 0) {
+          if (!isContainedMemberPath(filesDir, path)) {
+            throw new Error(`Refusing pack member with an unsafe path that escapes the pack root: ${path}`);
+          }
+          fromManifest.push({absolutePath: join(filesDir, ...path.split('/')), relativePath: path});
+        }
+      }
+      if (fromManifest.length > 0) {
+        return fromManifest.sort((a, b) => compareStrings(a.relativePath, b.relativePath));
+      }
+    }
+  }
+  return collectBundleMemberFiles(filesDir);
 }
 
 // Members of a shared skill directory. Prefers the published manifest as the
@@ -2055,6 +2808,9 @@ async function collectSharedBundleMembers(skillDir: string): Promise<readonly Bu
       for (const entry of rawMembers) {
         const path = (entry as {path?: unknown})?.path;
         if (typeof path === 'string' && path.length > 0) {
+          if (!isContainedMemberPath(skillDir, path)) {
+            throw new Error(`Refusing skill member with an unsafe path that escapes the skill root: ${path}`);
+          }
           fromManifest.push({absolutePath: join(skillDir, ...path.split('/')), relativePath: path});
         }
       }
@@ -2108,7 +2864,9 @@ interface BundleInstallMemberMetadata {
 }
 
 function bundleInstallRoot(artifact: SharedArtifactFile): string {
-  return dirname(artifact.installPath);
+  // A pack installs as a whole tree, so its installPath is already the root; a
+  // skill bundle's installPath is the SKILL.md, so the root is its parent.
+  return artifact.artifact.kind === 'pack' ? artifact.installPath : dirname(artifact.installPath);
 }
 
 function bundleInstallMetadataPath(artifact: SharedArtifactFile): string {
@@ -2124,6 +2882,17 @@ async function readBundleInstallMetadata(
   }
   const parsed = parseJsonConfigObject(raw);
   if (parsed === undefined || parsed.version !== ARTIFACT_INSTALL_METADATA_VERSION || !Array.isArray(parsed.members)) {
+    return undefined;
+  }
+  // Only trust metadata this artifact wrote for itself; a file left by a
+  // different artifact sharing the install root must not be read as our state.
+  const recordedArtifact = parsed.artifact as Partial<ShareArtifactMetadata> | undefined;
+  if (
+    recordedArtifact?.agent !== artifact.artifact.agent ||
+    recordedArtifact?.kind !== artifact.artifact.kind ||
+    recordedArtifact?.name !== artifact.artifact.name ||
+    parsed.team !== artifact.team
+  ) {
     return undefined;
   }
   const map = new Map<string, BundleInstallMemberMetadata>();
@@ -2146,13 +2915,24 @@ async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<
   const members = artifact.members ?? [];
   const installRoot = bundleInstallRoot(artifact);
   const metadata = await readBundleInstallMetadata(artifact);
+  // Expected on-disk bytes after the same transform install applies, so the
+  // no-metadata fallback can recognize a pristine (token-expanded) install as
+  // current instead of misreading it as a local modification.
+  const expanded = await prepareInstallMembers(members, installRoot, artifact.artifact.kind === 'pack');
+  const expectedByPath = new Map(expanded.map(entry => [entry.relativePath, entry]));
   let installedCount = 0;
   let localChanged = false;
   let remoteChanged = false;
   const memberPaths = new Set<string>();
   for (const member of members) {
     memberPaths.add(member.relativePath);
-    const sourceSha = sha256(await readFile(member.absolutePath));
+    const expected = expectedByPath.get(member.relativePath);
+    if (expected === undefined) {
+      // Shared source is missing (partial sync / corrupt repo): not pristine, so
+      // surface it as an available update rather than crashing the whole listing.
+      remoteChanged = true;
+      continue;
+    }
     const installedBytes = await readFileBytesIfExists(join(installRoot, ...member.relativePath.split('/')));
     if (installedBytes === undefined) {
       remoteChanged = true;
@@ -2162,7 +2942,12 @@ async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<
     const installedSha = sha256(installedBytes);
     const recorded = metadata?.get(member.relativePath);
     if (recorded === undefined) {
-      if (installedSha !== sourceSha) {
+      // No recorded baseline (sidecar lost or a future-version sidecar): a byte
+      // mismatch is ambiguous (local edit vs upstream change). Treat it as a
+      // local modification — like the single-file path — so install blocks until
+      // --force rather than silently clobbering possible local work. A pristine
+      // install still matches expected.installedSha256, so it stays `current`.
+      if (installedSha !== expected?.installedSha256) {
         localChanged = true;
       }
       continue;
@@ -2170,14 +2955,21 @@ async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<
     if (installedSha !== recorded.installedSha256) {
       localChanged = true;
     }
-    if (sourceSha !== recorded.sourceSha256) {
+    if (expected?.sourceSha256 !== recorded.sourceSha256) {
       remoteChanged = true;
     }
   }
   if (metadata !== undefined) {
-    for (const recordedPath of metadata.keys()) {
-      if (!memberPaths.has(recordedPath)) {
-        remoteChanged = true;
+    for (const [recordedPath, recorded] of metadata) {
+      if (memberPaths.has(recordedPath)) {
+        continue;
+      }
+      remoteChanged = true;
+      // The member was dropped upstream; if the user edited the now-orphaned
+      // local copy, flag it so the install refuses to delete it without --force.
+      const installedBytes = await readFileBytesIfExists(join(installRoot, ...recordedPath.split('/')));
+      if (installedBytes !== undefined && sha256(installedBytes) !== recorded.installedSha256) {
+        localChanged = true;
       }
     }
   }
@@ -2196,6 +2988,68 @@ async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<
   return 'current';
 }
 
+interface PreparedInstallMember {
+  readonly installedBytes: Buffer;
+  readonly installedSha256: string;
+  readonly relativePath: string;
+  readonly sourceSha256: string;
+}
+
+function expandPackRoot(text: string, installRoot: string): string {
+  return text.split(PACK_ROOT_TOKEN).join(installRoot);
+}
+
+// Resolves what each member will actually look like on disk. Pack-root token
+// expansion applies ONLY to packs (the kinds that tokenize at publish); skill
+// bundles are copied byte-for-byte so a literal token in skill content is never
+// rewritten. installedSha256 is the on-disk sha (post-expansion), sourceSha256
+// the shared-repo sha — the split keeps update vs local-edit detection correct
+// even when expansion changes the bytes.
+async function prepareInstallMembers(
+  members: readonly BundleMemberFile[],
+  installRoot: string,
+  expandTokens: boolean,
+): Promise<readonly PreparedInstallMember[]> {
+  const prepared = await Promise.all(
+    members.map(async (member): Promise<PreparedInstallMember | undefined> => {
+      // A member declared in the manifest but absent from files/ (partial sync /
+      // corrupt repo) is skipped rather than crashing the whole list/install.
+      const sourceBytes = await readFileBytesIfExists(member.absolutePath);
+      if (sourceBytes === undefined) {
+        return undefined;
+      }
+      const installedBytes =
+        expandTokens && !isProbablyBinary(sourceBytes)
+          ? Buffer.from(expandPackRoot(sourceBytes.toString('utf8'), installRoot), 'utf8')
+          : sourceBytes;
+      return {
+        installedBytes,
+        installedSha256: sha256(installedBytes),
+        relativePath: member.relativePath,
+        sourceSha256: sha256(sourceBytes),
+      };
+    }),
+  );
+  return prepared.filter((member): member is PreparedInstallMember => member !== undefined);
+}
+
+function serializeInstallMetadata(artifact: SharedArtifactFile, prepared: readonly PreparedInstallMember[]): string {
+  const metadata = {
+    artifact: artifact.artifact,
+    installedAt: new Date().toISOString(),
+    members: prepared
+      .map(entry => ({
+        installedSha256: entry.installedSha256,
+        path: entry.relativePath,
+        sourceSha256: entry.sourceSha256,
+      }))
+      .sort((a, b) => compareStrings(a.path, b.path)),
+    team: artifact.team,
+    version: ARTIFACT_INSTALL_METADATA_VERSION,
+  };
+  return `${JSON.stringify(metadata, undefined, 2)}\n`;
+}
+
 async function installBundleArtifact(
   artifact: SharedArtifactFile,
   options: ShareInstallArtifactsOptions,
@@ -2204,7 +3058,8 @@ async function installBundleArtifact(
 ): Promise<number> {
   const members = artifact.members ?? [];
   const installRoot = bundleInstallRoot(artifact);
-  const label = `${sharedArtifactLabel(artifact.artifact)} bundle (${members.length} files)`;
+  const kindLabel = artifact.artifact.kind === 'pack' ? 'pack' : 'bundle';
+  const label = `${sharedArtifactLabel(artifact.artifact)} ${kindLabel} (${members.length} files)`;
   const status = await sharedBundleInstallStatus(artifact);
   if (dryRun) {
     const verb = sharedArtifactDryRunVerb(status, options.force === true);
@@ -2215,54 +3070,86 @@ async function installBundleArtifact(
   if ((status === 'local_modified' || status === 'remote_changed_and_local_modified') && options.force !== true) {
     throw new Error(`Refusing to overwrite ${portablePath(installRoot)}. Pass force=true or --force.`);
   }
+  const prepared = await prepareInstallMembers(members, installRoot, artifact.artifact.kind === 'pack');
+  // A declared member whose shared source is unreadable (partial sync / corrupt
+  // repo) must not silently drop from the install — that would delete the prior
+  // installed copy on a routine update. Refuse unless forced.
+  if (prepared.length < members.length && options.force !== true) {
+    throw new Error(
+      `Refusing to install ${portablePath(installRoot)}: ${members.length - prepared.length} declared member(s) are unreadable in the shared pack (the shared worktree may be mid-sync). Retry after sync, or pass force=true / --force.`,
+    );
+  }
   if (status === 'current') {
-    await writeFile(bundleInstallMetadataPath(artifact), await buildBundleInstallMetadata(artifact, members), {
-      mode: 0o600,
-    });
+    await writeFile(bundleInstallMetadataPath(artifact), serializeInstallMetadata(artifact, prepared), {mode: 0o600});
     messages.push(`Already installed ${label}: ${portablePath(installRoot)}`);
+    await surfacePackRequirements(artifact, messages);
     return 0;
   }
 
   // Materialize into a sibling staging directory, then swap atomically so an
-  // interrupted install can never leave a half-written, mixed-version bundle.
+  // interrupted install can never leave a half-written, mixed-version tree.
   const stagingRoot = `${installRoot}.threadnote-staging`;
   await rm(stagingRoot, {force: true, recursive: true});
-  for (const member of members) {
-    const dest = join(stagingRoot, ...member.relativePath.split('/'));
+  for (const entry of prepared) {
+    const dest = join(stagingRoot, ...entry.relativePath.split('/'));
     await ensureDirectory(dirname(dest), false);
-    await writeFile(dest, await readFile(member.absolutePath), {mode: 0o600});
+    await writeFile(dest, entry.installedBytes, {mode: 0o600});
   }
-  await writeFile(
-    join(stagingRoot, BUNDLE_INSTALL_METADATA_FILE),
-    await buildBundleInstallMetadata(artifact, members),
-    {
-      mode: 0o600,
-    },
-  );
-  await rm(installRoot, {force: true, recursive: true});
+  await writeFile(join(stagingRoot, BUNDLE_INSTALL_METADATA_FILE), serializeInstallMetadata(artifact, prepared), {
+    mode: 0o600,
+  });
+  // Swap via a backup rename so the prior install is never lost: if the final
+  // rename fails (or the process dies mid-swap), the old tree is either still in
+  // place or recoverable from the backup, never gone with nothing to replace it.
   await ensureDirectory(dirname(installRoot), false);
-  await rename(stagingRoot, installRoot);
+  const backupRoot = `${installRoot}.threadnote-old`;
+  await rm(backupRoot, {force: true, recursive: true});
+  const hadPriorInstall = await exists(installRoot);
+  if (hadPriorInstall) {
+    await rename(installRoot, backupRoot);
+  }
+  try {
+    await rename(stagingRoot, installRoot);
+  } catch (swapErr: unknown) {
+    if (hadPriorInstall) {
+      await rename(backupRoot, installRoot);
+    }
+    throw swapErr;
+  }
+  await rm(backupRoot, {force: true, recursive: true});
   messages.push(`${sharedArtifactInstallVerb(status, options.force === true)} ${label}: ${portablePath(installRoot)}`);
+  await surfacePackRequirements(artifact, messages);
   return 1;
 }
 
-async function buildBundleInstallMetadata(
-  artifact: SharedArtifactFile,
-  members: readonly BundleMemberFile[],
-): Promise<string> {
-  const recordedMembers: Array<{installedSha256: string; path: string; sourceSha256: string}> = [];
-  for (const member of members) {
-    const sha = sha256(await readFile(member.absolutePath));
-    recordedMembers.push({installedSha256: sha, path: member.relativePath, sourceSha256: sha});
+// Threadnote ships files, not runtimes or MCP servers. After installing a pack,
+// surface its declared external dependencies so the teammate knows what they
+// must provision before it will actually run.
+async function surfacePackRequirements(artifact: SharedArtifactFile, messages: string[]): Promise<void> {
+  if (artifact.artifact.kind !== 'pack') {
+    return;
   }
-  const metadata = {
-    artifact: artifact.artifact,
-    installedAt: new Date().toISOString(),
-    members: recordedMembers.sort((a, b) => compareStrings(a.path, b.path)),
-    team: artifact.team,
-    version: ARTIFACT_INSTALL_METADATA_VERSION,
-  };
-  return `${JSON.stringify(metadata, undefined, 2)}\n`;
+  const raw = await readFileIfExists(
+    join(dirname(artifact.sourcePath), `${artifact.artifact.name}${PACK_MANIFEST_SUFFIX}`),
+  );
+  if (raw === undefined) {
+    return;
+  }
+  const deps = parseJsonConfigObject(raw)?.deps;
+  if (deps === undefined || typeof deps !== 'object') {
+    return;
+  }
+  const stringList = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  const depsRecord = deps as Record<string, unknown>;
+  const tooling = [...stringList(depsRecord.runtime), ...stringList(depsRecord.cli), ...stringList(depsRecord.os)];
+  const mcp = stringList(depsRecord.mcp);
+  if (tooling.length > 0) {
+    messages.push(`This pack will NOT run until these exist (Threadnote installs files only): ${tooling.join(', ')}.`);
+  }
+  if (mcp.length > 0) {
+    messages.push(`Configure these MCP server(s) separately: ${mcp.join(', ')}.`);
+  }
 }
 
 async function sharedArtifactInstallState(artifact: SharedArtifactFile): Promise<SharedArtifactInstallState> {
@@ -2410,11 +3297,16 @@ function sharedArtifactLabel(artifact: ShareArtifactMetadata): string {
 }
 
 function sharedArtifactInstallPath(team: string, artifact: ShareArtifactMetadata): string {
-  if (artifact.kind === 'skill' && artifact.agent === 'codex') {
-    return join(homedir(), '.codex', 'skills', 'threadnote', team, artifact.name, 'SKILL.md');
+  const agentDir = artifact.agent === 'codex' ? '.codex' : '.claude';
+  if (artifact.kind === 'pack') {
+    // Packs install under a dedicated `threadnote-packs` namespace so a pack and
+    // a same-named skill can never share an install root or metadata file. The
+    // `threadnote`/`threadnote-packs` segment is Threadnote-controlled, never a
+    // user skill name, so the two trees are structurally disjoint.
+    return join(homedir(), agentDir, 'skills', 'threadnote-packs', team, artifact.name);
   }
-  if (artifact.kind === 'skill' && artifact.agent === 'claude') {
-    return join(homedir(), '.claude', 'skills', 'threadnote', team, artifact.name, 'SKILL.md');
+  if (artifact.kind === 'skill') {
+    return join(homedir(), agentDir, 'skills', 'threadnote', team, artifact.name, 'SKILL.md');
   }
   return join(homedir(), '.claude', 'commands', 'threadnote', team, `${artifact.name}.md`);
 }

--- a/src/threadnote.ts
+++ b/src/threadnote.ts
@@ -507,9 +507,10 @@ async function main(): Promise<void> {
     .option('--name <name>', 'Shared artifact name; defaults to skill directory or command file stem')
     .option('--message <text>', 'Commit message override')
     .option('--force', 'Replace an existing shared artifact with different content')
+    .option('--allow-binary', 'Include binary skill files (unscannable by the scrubber); blocked by default')
     .option('--no-push', 'Skip the push step')
     .option('--dry-run', 'Print actions without running them')
-    .option('--preview', 'Print the exact artifact bytes that would land in the shared git repo')
+    .option('--preview', 'Print what would land in the shared git repo without writing or committing')
     .option(
       '--redact',
       'Replace soft-leak matches (local paths) with placeholders and continue; credentials still block',

--- a/src/threadnote.ts
+++ b/src/threadnote.ts
@@ -68,6 +68,7 @@ import {
   runShareList,
   runSharePublish,
   runSharePublishArtifact,
+  runSharePublishBundle,
   runShareRename,
   runShareRemove,
   runShareSetUrl,
@@ -517,6 +518,25 @@ async function main(): Promise<void> {
     )
     .action(async (path: string, options: SharePublishArtifactOptions) => {
       await runSharePublishArtifact(getRuntimeConfig(program), path, options);
+    });
+
+  share
+    .command('publish-bundle')
+    .description('Publish a multi-skill constellation (pack) declared by a threadnote-bundle.json manifest')
+    .argument('<manifest>', 'Path to a threadnote-bundle.json manifest')
+    .option('--team <name>', 'Team name; defaults to the configured default team')
+    .option('--message <text>', 'Commit message override')
+    .option('--force', 'Replace existing shared pack files with different content')
+    .option('--allow-binary', 'Include binary files (unscannable by the scrubber); blocked by default')
+    .option('--no-push', 'Skip the push step')
+    .option('--dry-run', 'Print actions without running them')
+    .option('--preview', 'Print what would land in the shared git repo without writing or committing')
+    .option(
+      '--redact',
+      'Replace soft-leak matches (local paths) with placeholders and continue; credentials still block',
+    )
+    .action(async (manifest: string, options: SharePublishArtifactOptions) => {
+      await runSharePublishBundle(getRuntimeConfig(program), manifest, options);
     });
 
   share

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,6 +312,7 @@ export type ShareAgentArtifactKind = 'command' | 'skill';
 
 export interface SharePublishArtifactOptions {
   readonly agent?: ShareAgentArtifactAgent;
+  readonly allowBinary?: boolean;
   readonly dryRun?: boolean;
   readonly force?: boolean;
   readonly kind?: ShareAgentArtifactKind;

--- a/src/types.ts
+++ b/src/types.ts
@@ -308,7 +308,7 @@ export interface SharePublishOptions {
 }
 
 export type ShareAgentArtifactAgent = 'claude' | 'codex';
-export type ShareAgentArtifactKind = 'command' | 'skill';
+export type ShareAgentArtifactKind = 'command' | 'pack' | 'skill';
 
 export interface SharePublishArtifactOptions {
   readonly agent?: ShareAgentArtifactAgent;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -744,7 +744,7 @@ export function parentVikingUri(uri: string): string {
   return slashIndex <= 'viking://'.length ? trimmedUri : trimmedUri.slice(0, slashIndex);
 }
 
-export function sha256(content: string): string {
+export function sha256(content: string | Buffer): string {
   return createHash('sha256').update(content).digest('hex');
 }
 

--- a/test/unit/share.artifacts.test.ts
+++ b/test/unit/share.artifacts.test.ts
@@ -396,4 +396,252 @@ describe('shared agent artifacts', () => {
 
     await expect(readFile(installPath, 'utf8')).resolves.toBe('# Reviewer v2\n');
   });
+
+  function findGitAddArgs(): readonly string[] | undefined {
+    const call = vi
+      .mocked(utils.runCommand)
+      .mock.calls.find(([executable, args]) => executable === 'git' && args.includes('add'));
+    return call?.[1];
+  }
+
+  it('publishes a multi-file skill as a bundle with a manifest', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const skillDir = join(config.agentContextHome, '.codex', 'skills', 'reviewer');
+    await mkdir(join(skillDir, 'scripts'), {recursive: true});
+    await writeFile(join(skillDir, 'SKILL.md'), '# Reviewer\n\nRun scripts/run.ts.\n');
+    await writeFile(join(skillDir, 'scripts', 'run.ts'), 'export const run = () => 1;\n');
+    mockPublishCommands();
+
+    const result = await shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {});
+
+    expect(result.targetUri).toBe(
+      'viking://user/denyskashkovskyi/memories/shared/default/agent-artifacts/skills/codex/reviewer/SKILL.md',
+    );
+    const sharedRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'codex',
+      'reviewer',
+    );
+    await expect(readFile(join(sharedRoot, 'scripts', 'run.ts'), 'utf8')).resolves.toBe(
+      'export const run = () => 1;\n',
+    );
+    const manifest = JSON.parse(await readFile(join(sharedRoot, '.threadnote-bundle.json'), 'utf8'));
+    expect(manifest.members.map((m: {path: string}) => m.path)).toEqual(['SKILL.md', 'scripts/run.ts']);
+    const addArgs = findGitAddArgs();
+    expect(addArgs).toContain('agent-artifacts/skills/codex/reviewer/SKILL.md');
+    expect(addArgs).toContain('agent-artifacts/skills/codex/reviewer/scripts/run.ts');
+    expect(addArgs).toContain('agent-artifacts/skills/codex/reviewer/.threadnote-bundle.json');
+  });
+
+  it('ignores runtime artifact dirs and local junk when bundling a skill', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const skillDir = join(config.agentContextHome, '.codex', 'skills', 'reviewer');
+    await mkdir(join(skillDir, 'reviews', 'mobile', '1'), {recursive: true});
+    await mkdir(join(skillDir, 'repos', 'coda'), {recursive: true});
+    await writeFile(join(skillDir, 'SKILL.md'), '# Reviewer\n');
+    await writeFile(join(skillDir, 'run.ts'), 'export const run = () => 1;\n');
+    await writeFile(join(skillDir, '.DS_Store'), 'junk');
+    await writeFile(join(skillDir, 'debug.log'), 'noise');
+    await writeFile(join(skillDir, 'reviews', 'mobile', '1', 'state.json'), '{}');
+    await writeFile(join(skillDir, 'repos', 'coda', 'CLAUDE.md'), '# nope\n');
+    mockPublishCommands();
+
+    await shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {});
+
+    const sharedRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'codex',
+      'reviewer',
+    );
+    const manifest = JSON.parse(await readFile(join(sharedRoot, '.threadnote-bundle.json'), 'utf8'));
+    expect(manifest.members.map((m: {path: string}) => m.path)).toEqual(['SKILL.md', 'run.ts']);
+    await expect(readFile(join(sharedRoot, 'reviews', 'mobile', '1', 'state.json'), 'utf8')).rejects.toThrow();
+    await expect(readFile(join(sharedRoot, 'repos', 'coda', 'CLAUDE.md'), 'utf8')).rejects.toThrow();
+  });
+
+  it('blocks a binary skill member by default and includes it with allowBinary', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const skillDir = join(config.agentContextHome, '.codex', 'skills', 'reviewer');
+    await mkdir(join(skillDir, 'assets'), {recursive: true});
+    await writeFile(join(skillDir, 'SKILL.md'), '# Reviewer\n');
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x00, 0x01, 0x02, 0xff]);
+    await writeFile(join(skillDir, 'assets', 'logo.png'), png);
+    mockPublishCommands();
+
+    await expect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {})).rejects.toThrow(/binary file/);
+
+    await shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {allowBinary: true});
+    const sharedRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'codex',
+      'reviewer',
+    );
+    await expect(readFile(join(sharedRoot, 'assets', 'logo.png'))).resolves.toEqual(png);
+  });
+
+  it('blocks a credential embedded in a binary member even with allowBinary', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const skillDir = join(config.agentContextHome, '.codex', 'skills', 'reviewer');
+    await mkdir(skillDir, {recursive: true});
+    await writeFile(join(skillDir, 'SKILL.md'), '# Reviewer\n');
+    const secretBlob = Buffer.concat([Buffer.from([0x00, 0x01]), Buffer.from(`sk-${'a'.repeat(24)}`)]);
+    await writeFile(join(skillDir, 'helper.bin'), secretBlob);
+    mockPublishCommands();
+
+    await expect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {allowBinary: true})).rejects.toThrow(
+      /embedded in binary file/,
+    );
+  });
+
+  it('scrubs companion files and blocks a leaked credential in a script', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const skillDir = join(config.agentContextHome, '.codex', 'skills', 'reviewer');
+    await mkdir(join(skillDir, 'scripts'), {recursive: true});
+    await writeFile(join(skillDir, 'SKILL.md'), '# Reviewer\n');
+    await writeFile(join(skillDir, 'scripts', 'run.ts'), `const token = "ghp_${'b'.repeat(36)}";\n`);
+    mockPublishCommands();
+
+    await expect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {})).rejects.toThrow(/scripts\/run\.ts/);
+  });
+
+  it('does not materialize bundle companions when the SKILL.md OpenViking write fails', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const skillDir = join(config.agentContextHome, '.codex', 'skills', 'reviewer');
+    await mkdir(join(skillDir, 'scripts'), {recursive: true});
+    await writeFile(join(skillDir, 'SKILL.md'), '# Reviewer\n');
+    await writeFile(join(skillDir, 'scripts', 'run.ts'), 'export const run = () => 1;\n');
+    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+      if (executable === '/ov' && args[0] === 'stat') {
+        return fail();
+      }
+      if (executable === '/ov' && args[0] === 'mkdir') {
+        return ok('ok');
+      }
+      if (executable === '/ov' && args[0] === 'write') {
+        return fail('write failed');
+      }
+      return ok();
+    });
+
+    await expect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {})).rejects.toThrow(/write failed/);
+    const sharedRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'codex',
+      'reviewer',
+    );
+    await expect(readFile(join(sharedRoot, 'scripts', 'run.ts'), 'utf8')).rejects.toThrow();
+  });
+
+  async function seedSharedBundle(config: ShareRuntime): Promise<string> {
+    const root = join(config.agentContextHome, 'shared', 'default', 'agent-artifacts', 'skills', 'claude', 'reviewer');
+    await mkdir(join(root, 'scripts'), {recursive: true});
+    await writeFile(join(root, 'SKILL.md'), '# Reviewer v1\n');
+    await writeFile(join(root, 'scripts', 'run.ts'), 'export const run = () => 1;\n');
+    return root;
+  }
+
+  it('installs a multi-file bundle tree and tracks it with a bundle sidecar', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-bundle-install-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    await seedSharedBundle(config);
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    const installRoot = join(installHome, '.claude', 'skills', 'threadnote', 'default', 'reviewer');
+    await expect(readFile(join(installRoot, 'SKILL.md'), 'utf8')).resolves.toBe('# Reviewer v1\n');
+    await expect(readFile(join(installRoot, 'scripts', 'run.ts'), 'utf8')).resolves.toBe(
+      'export const run = () => 1;\n',
+    );
+    await expect(readFile(join(installRoot, '.threadnote-bundle-install.json'), 'utf8')).resolves.toMatch(
+      /scripts\/run\.ts/,
+    );
+  });
+
+  it('updates a bundle member and protects local edits across members', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-bundle-update-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const sharedRoot = await seedSharedBundle(config);
+    const installRoot = join(installHome, '.claude', 'skills', 'threadnote', 'default', 'reviewer');
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    // Upstream changes one member; reinstall adopts it.
+    await writeFile(join(sharedRoot, 'scripts', 'run.ts'), 'export const run = () => 2;\n');
+    expect((await listSharedAgentArtifacts(config, {sync: false})).artifacts[0]?.installStatus).toBe(
+      'update_available',
+    );
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+    await expect(readFile(join(installRoot, 'scripts', 'run.ts'), 'utf8')).resolves.toBe(
+      'export const run = () => 2;\n',
+    );
+
+    // Local edit to one member + upstream edit to a different member -> conflict.
+    await writeFile(join(installRoot, 'SKILL.md'), '# Locally edited\n');
+    await writeFile(join(sharedRoot, 'scripts', 'run.ts'), 'export const run = () => 3;\n');
+    expect((await listSharedAgentArtifacts(config, {sync: false})).artifacts[0]?.installStatus).toBe(
+      'remote_changed_and_local_modified',
+    );
+    await expect(
+      installSharedAgentArtifacts(config, {agent: 'claude', apply: true, kind: 'skill', name: 'reviewer', sync: false}),
+    ).rejects.toThrow(/Refusing to overwrite/);
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      force: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+    await expect(readFile(join(installRoot, 'SKILL.md'), 'utf8')).resolves.toBe('# Reviewer v1\n');
+    await expect(readFile(join(installRoot, 'scripts', 'run.ts'), 'utf8')).resolves.toBe(
+      'export const run = () => 3;\n',
+    );
+  });
 });

--- a/test/unit/share.artifacts.test.ts
+++ b/test/unit/share.artifacts.test.ts
@@ -7,6 +7,7 @@ import {
   listSharedAgentArtifacts,
   runShareInstallArtifacts,
   shareAgentArtifact,
+  shareBundlePack,
 } from '../../src/share.js';
 import type {CommandResult, ShareRuntime} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
@@ -643,5 +644,753 @@ describe('shared agent artifacts', () => {
     await expect(readFile(join(installRoot, 'scripts', 'run.ts'), 'utf8')).resolves.toBe(
       'export const run = () => 3;\n',
     );
+  });
+
+  const PACK_TOKEN = '${THREADNOTE_PACK_ROOT}';
+
+  async function makeReviewerManifestRepo(): Promise<string> {
+    const repo = await mkdtemp(join(tmpdir(), 'threadnote-pack-src-'));
+    homes.push(repo);
+    await mkdir(join(repo, '.claude', 'skills', 'review-pr'), {recursive: true});
+    await mkdir(join(repo, '.claude', 'skills', 'pr-status'), {recursive: true});
+    await mkdir(join(repo, 'scripts'), {recursive: true});
+    await mkdir(join(repo, 'lib'), {recursive: true});
+    await writeFile(join(repo, '.claude', 'skills', 'review-pr', 'SKILL.md'), '# Review PR\n\nRun scripts/vcs.ts.\n');
+    await writeFile(join(repo, '.claude', 'skills', 'pr-status', 'SKILL.md'), '# PR Status\n');
+    await writeFile(
+      join(repo, 'scripts', 'vcs.ts'),
+      `const foreign = "/Users/yaroslavvoloshchuk/code/reviewer/scripts";\nconst here = "${repo}/scripts";\nimport "../lib/types";\n`,
+    );
+    await writeFile(join(repo, 'lib', 'types.ts'), 'export type T = string;\n');
+    await writeFile(
+      join(repo, 'threadnote-bundle.json'),
+      `${JSON.stringify({
+        agent: 'claude',
+        deps: {cli: ['gh', 'glab'], mcp: ['mcp__pal__clink'], runtime: ['bun']},
+        description: 'PR review constellation',
+        include: ['scripts', 'lib'],
+        name: 'reviewer',
+        pathRewrites: [{from: '/Users/yaroslavvoloshchuk/code/reviewer'}],
+        skills: ['.claude/skills/review-pr', '.claude/skills/pr-status'],
+        version: 1,
+      })}\n`,
+    );
+    return repo;
+  }
+
+  it('publishes a constellation pack, tokenizing hardcoded repo-root paths', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    mockPublishCommands();
+
+    const result = await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+
+    expect(result.targetUri).toBe(
+      'viking://user/denyskashkovskyi/memories/shared/default/agent-artifacts/packs/claude/reviewer/reviewer.pack.md',
+    );
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    const sharedVcs = await readFile(join(packRoot, 'files', 'scripts', 'vcs.ts'), 'utf8');
+    expect(sharedVcs).toContain(`${PACK_TOKEN}/scripts`);
+    expect(sharedVcs).not.toContain('/Users/yaroslavvoloshchuk');
+    expect(sharedVcs).not.toContain(repo);
+    const packJson = JSON.parse(await readFile(join(packRoot, 'reviewer.pack.json'), 'utf8'));
+    expect(packJson.deps.mcp).toEqual(['mcp__pal__clink']);
+    expect(packJson.members.map((m: {path: string}) => m.path)).toContain('scripts/vcs.ts');
+    const addArgs = findGitAddArgs();
+    expect(addArgs).toContain('agent-artifacts/packs/claude/reviewer/reviewer.pack.md');
+    expect(addArgs).toContain('agent-artifacts/packs/claude/reviewer/files/scripts/vcs.ts');
+  });
+
+  it('blocks a residual local path that no pathRewrite covers', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(join(repo, 'scripts', 'leak.ts'), 'const home = "/Users/someone/secret/notes";\n');
+    mockPublishCommands();
+
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+      /scripts\/leak\.ts/,
+    );
+  });
+
+  async function seedSharedPack(config: ShareRuntime): Promise<string> {
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    await mkdir(join(packRoot, 'files', '.claude', 'skills', 'review-pr'), {recursive: true});
+    await mkdir(join(packRoot, 'files', 'scripts'), {recursive: true});
+    await writeFile(join(packRoot, 'reviewer.pack.md'), '---\nname: reviewer\nkind: pack\n---\n\n# reviewer\n');
+    await writeFile(
+      join(packRoot, 'reviewer.pack.json'),
+      `${JSON.stringify({
+        artifact: {agent: 'claude', kind: 'pack', name: 'reviewer'},
+        deps: {cli: ['gh'], mcp: ['mcp__pal__clink'], os: [], runtime: ['bun']},
+        members: [],
+        version: 1,
+      })}\n`,
+    );
+    await writeFile(join(packRoot, 'files', '.claude', 'skills', 'review-pr', 'SKILL.md'), '# Review PR\n');
+    await writeFile(join(packRoot, 'files', 'scripts', 'vcs.ts'), 'const root = "${THREADNOTE_PACK_ROOT}/scripts";\n');
+    return packRoot;
+  }
+
+  it('installs a pack tree, expands the pack-root token, and surfaces requirements', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-pack-install-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    await seedSharedPack(config);
+
+    const result = await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'pack',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    const installRoot = join(installHome, '.claude', 'skills', 'threadnote-packs', 'default', 'reviewer');
+    await expect(readFile(join(installRoot, '.claude', 'skills', 'review-pr', 'SKILL.md'), 'utf8')).resolves.toBe(
+      '# Review PR\n',
+    );
+    const installedVcs = await readFile(join(installRoot, 'scripts', 'vcs.ts'), 'utf8');
+    expect(installedVcs).toBe(`const root = "${installRoot}/scripts";\n`);
+    expect(installedVcs.includes('${THREADNOTE_PACK_ROOT}')).toBe(false);
+    await expect(readFile(join(installRoot, '.threadnote-bundle-install.json'), 'utf8')).resolves.toMatch(
+      /scripts\/vcs\.ts/,
+    );
+    expect(result.messages.join('\n')).toContain('mcp__pal__clink');
+  });
+
+  it('reports current after install despite token expansion, and update_available on change', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-pack-status-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const packRoot = await seedSharedPack(config);
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'pack',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    // Token expansion changes installed bytes vs shared bytes; status must still
+    // read as current (not perpetually update_available).
+    expect((await listSharedAgentArtifacts(config, {sync: false})).artifacts[0]?.installStatus).toBe('current');
+
+    await writeFile(join(packRoot, 'files', 'scripts', 'vcs.ts'), 'const root = "${THREADNOTE_PACK_ROOT}/scripts2";\n');
+    expect((await listSharedAgentArtifacts(config, {sync: false})).artifacts[0]?.installStatus).toBe(
+      'update_available',
+    );
+  });
+
+  it('does not expand the pack-root token in a multi-file skill bundle', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-skill-token-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const root = join(config.agentContextHome, 'shared', 'default', 'agent-artifacts', 'skills', 'claude', 'docskill');
+    await mkdir(join(root, 'scripts'), {recursive: true});
+    await writeFile(join(root, 'SKILL.md'), '# Doc skill\n');
+    await writeFile(join(root, 'scripts', 'note.ts'), 'const t = "${THREADNOTE_PACK_ROOT}";\n');
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'skill',
+      name: 'docskill',
+      sync: false,
+    });
+
+    const installRoot = join(installHome, '.claude', 'skills', 'threadnote', 'default', 'docskill');
+    await expect(readFile(join(installRoot, 'scripts', 'note.ts'), 'utf8')).resolves.toBe(
+      'const t = "${THREADNOTE_PACK_ROOT}";\n',
+    );
+  });
+
+  it('reads a pristine pack as current even when the install sidecar is missing', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-pack-nosidecar-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    await seedSharedPack(config);
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'pack',
+      name: 'reviewer',
+      sync: false,
+    });
+    const installRoot = join(installHome, '.claude', 'skills', 'threadnote-packs', 'default', 'reviewer');
+    await rm(join(installRoot, '.threadnote-bundle-install.json'), {force: true});
+
+    expect((await listSharedAgentArtifacts(config, {sync: false})).artifacts[0]?.installStatus).toBe('current');
+  });
+
+  it('installs only the .pack.json member list, not files orphaned in files/', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-pack-orphan-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    await mkdir(join(packRoot, 'files', 'scripts'), {recursive: true});
+    await writeFile(join(packRoot, 'reviewer.pack.md'), '---\nname: reviewer\nkind: pack\n---\n\n# reviewer\n');
+    await writeFile(
+      join(packRoot, 'reviewer.pack.json'),
+      `${JSON.stringify({
+        artifact: {agent: 'claude', kind: 'pack', name: 'reviewer'},
+        deps: {cli: [], mcp: [], os: [], runtime: []},
+        members: [{binary: false, path: 'scripts/keep.ts', sha256: 'x'}],
+        version: 1,
+      })}\n`,
+    );
+    await writeFile(join(packRoot, 'files', 'scripts', 'keep.ts'), 'keep\n');
+    await writeFile(join(packRoot, 'files', 'scripts', 'orphan.ts'), 'orphan\n');
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'pack',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    const installRoot = join(installHome, '.claude', 'skills', 'threadnote-packs', 'default', 'reviewer');
+    await expect(readFile(join(installRoot, 'scripts', 'keep.ts'), 'utf8')).resolves.toBe('keep\n');
+    await expect(readFile(join(installRoot, 'scripts', 'orphan.ts'), 'utf8')).rejects.toThrow();
+  });
+
+  it('rejects a pack manifest with a non-absolute pathRewrite', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(
+      join(repo, 'threadnote-bundle.json'),
+      `${JSON.stringify({
+        agent: 'claude',
+        include: ['scripts', 'lib'],
+        name: 'reviewer',
+        pathRewrites: [{from: 'lib'}],
+        skills: ['.claude/skills/review-pr'],
+        version: 1,
+      })}\n`,
+    );
+    mockPublishCommands();
+
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+      /absolute repo-root path/,
+    );
+  });
+
+  it('blocks publishing a pack whose member already contains the reserved token', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(join(repo, 'scripts', 'tok.ts'), 'const x = "${THREADNOTE_PACK_ROOT}/y";\n');
+    mockPublishCommands();
+
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(/reserved/);
+  });
+
+  it('rejects a pack manifest include entry that escapes the pack root', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(
+      join(repo, 'threadnote-bundle.json'),
+      `${JSON.stringify({
+        agent: 'claude',
+        include: ['../secret'],
+        name: 'reviewer',
+        skills: ['.claude/skills/review-pr'],
+        version: 1,
+      })}\n`,
+    );
+    mockPublishCommands();
+
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+      /within the pack root/,
+    );
+  });
+
+  it('keeps a pack and a same-named skill in separate install roots', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-collision-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    await seedSharedBundle(config); // skills/claude/reviewer (multi-file skill)
+    await seedSharedPack(config); // packs/claude/reviewer (pack)
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'pack',
+      name: 'reviewer',
+      sync: false,
+    });
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'skill',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    const skillRoot = join(installHome, '.claude', 'skills', 'threadnote', 'default', 'reviewer');
+    const packRoot = join(installHome, '.claude', 'skills', 'threadnote-packs', 'default', 'reviewer');
+    // Installing the skill must not have destroyed the pack tree (separate roots).
+    await expect(readFile(join(packRoot, 'scripts', 'vcs.ts'), 'utf8')).resolves.toContain('/scripts');
+    await expect(readFile(join(skillRoot, 'scripts', 'run.ts'), 'utf8')).resolves.toBe('export const run = () => 1;\n');
+  });
+
+  it('skips an incomplete pack index (no .pack.json) without breaking discovery of other artifacts', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-ghost-pack-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const skill = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'skills',
+      'claude',
+      'triage',
+      'SKILL.md',
+    );
+    await mkdir(join(skill, '..'), {recursive: true});
+    await writeFile(skill, '# Triage\n');
+    const ghost = join(config.agentContextHome, 'shared', 'default', 'agent-artifacts', 'packs', 'claude', 'ghost');
+    await mkdir(ghost, {recursive: true});
+    await writeFile(join(ghost, 'ghost.pack.md'), '---\nname: ghost\nkind: pack\n---\n');
+
+    const result = await listSharedAgentArtifacts(config, {sync: false});
+    const names = result.artifacts.map(entry => entry.artifact.name);
+    expect(names).toContain('triage');
+    expect(names).not.toContain('ghost');
+  });
+
+  it('does not crash listing when a .pack.json member is missing from files/', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-missing-member-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    await mkdir(join(packRoot, 'files', 'scripts'), {recursive: true});
+    await writeFile(join(packRoot, 'reviewer.pack.md'), '---\nname: reviewer\nkind: pack\n---\n');
+    await writeFile(
+      join(packRoot, 'reviewer.pack.json'),
+      `${JSON.stringify({
+        artifact: {agent: 'claude', kind: 'pack', name: 'reviewer'},
+        deps: {cli: [], mcp: [], os: [], runtime: []},
+        members: [{binary: false, path: 'scripts/missing.ts', sha256: 'x'}],
+        version: 1,
+      })}\n`,
+    );
+
+    const result = await listSharedAgentArtifacts(config, {sync: false});
+    expect(result.artifacts.map(entry => entry.artifact.name)).toContain('reviewer');
+  });
+
+  it('blocks a residual /home path in a pack member', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(join(repo, 'scripts', 'deploy.ts'), 'const key = "/home/deploy/.ssh/id_rsa";\n');
+    mockPublishCommands();
+
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+      /scripts\/deploy\.ts/,
+    );
+  });
+
+  it('blocks a residual local path in a code member even with --redact', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(join(repo, 'scripts', 'leak.ts'), 'const home = "/Users/someone/secret/x";\n');
+    mockPublishCommands();
+
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {redact: true})).rejects.toThrow(
+      /scripts\/leak\.ts/,
+    );
+  });
+
+  it('flags a locally-edited member removed upstream as a conflict, not a silent update', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-removed-member-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    await mkdir(join(packRoot, 'files', 'scripts'), {recursive: true});
+    await writeFile(join(packRoot, 'reviewer.pack.md'), '---\nname: reviewer\nkind: pack\n---\n');
+    const writeManifest = async (members: Array<{path: string}>): Promise<void> =>
+      writeFile(
+        join(packRoot, 'reviewer.pack.json'),
+        `${JSON.stringify({artifact: {agent: 'claude', kind: 'pack', name: 'reviewer'}, deps: {}, members, version: 1})}\n`,
+      );
+    await writeManifest([{path: 'scripts/a.ts'}, {path: 'scripts/b.ts'}]);
+    await writeFile(join(packRoot, 'files', 'scripts', 'a.ts'), 'a\n');
+    await writeFile(join(packRoot, 'files', 'scripts', 'b.ts'), 'b\n');
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'pack',
+      name: 'reviewer',
+      sync: false,
+    });
+
+    const installRoot = join(installHome, '.claude', 'skills', 'threadnote-packs', 'default', 'reviewer');
+    await writeFile(join(installRoot, 'scripts', 'b.ts'), 'b-local-edit\n');
+    await writeManifest([{path: 'scripts/a.ts'}]);
+    await rm(join(packRoot, 'files', 'scripts', 'b.ts'), {force: true});
+
+    expect((await listSharedAgentArtifacts(config, {sync: false})).artifacts[0]?.installStatus).toBe(
+      'remote_changed_and_local_modified',
+    );
+    await expect(
+      installSharedAgentArtifacts(config, {agent: 'claude', apply: true, kind: 'pack', name: 'reviewer', sync: false}),
+    ).rejects.toThrow(/Refusing to overwrite/);
+  });
+
+  it('rolls back a pack publish, materializing nothing when an OpenViking write fails', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+      if (executable === '/ov' && args[0] === 'stat') {
+        return fail();
+      }
+      if (executable === '/ov' && args[0] === 'mkdir') {
+        return ok('ok');
+      }
+      if (executable === '/ov' && args[0] === 'write') {
+        return fail('write failed');
+      }
+      return ok();
+    });
+
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(/write failed/);
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    await expect(readFile(join(packRoot, 'reviewer.pack.json'), 'utf8')).rejects.toThrow();
+    await expect(readFile(join(packRoot, 'files', 'scripts', 'vcs.ts'), 'utf8')).rejects.toThrow();
+  });
+
+  it('tokenizes a repo-root path embedded in pack deps', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(
+      join(repo, 'threadnote-bundle.json'),
+      `${JSON.stringify({
+        agent: 'claude',
+        deps: {cli: [`${repo}/bin/tool`]},
+        include: ['scripts', 'lib'],
+        name: 'reviewer',
+        pathRewrites: [{from: '/Users/yaroslavvoloshchuk/code/reviewer'}],
+        skills: ['.claude/skills/review-pr'],
+        version: 1,
+      })}\n`,
+    );
+    mockPublishCommands();
+
+    await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    const json = await readFile(join(packRoot, 'reviewer.pack.json'), 'utf8');
+    expect(json).toContain('${THREADNOTE_PACK_ROOT}/bin/tool');
+    expect(json).not.toContain(repo);
+  });
+
+  it('protects work when the sidecar is gone and a member differs: blocks without --force, applies with it', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-nosidecar-update-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const packRoot = await seedSharedPack(config);
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      kind: 'pack',
+      name: 'reviewer',
+      sync: false,
+    });
+    const installRoot = join(installHome, '.claude', 'skills', 'threadnote-packs', 'default', 'reviewer');
+    await rm(join(installRoot, '.threadnote-bundle-install.json'), {force: true});
+    await writeFile(
+      join(packRoot, 'files', 'scripts', 'vcs.ts'),
+      'const root = "${THREADNOTE_PACK_ROOT}/scripts-v2";\n',
+    );
+
+    // Without a baseline the mismatch is ambiguous (local edit vs upstream
+    // change), so it is treated protectively and blocked until --force.
+    expect((await listSharedAgentArtifacts(config, {sync: false})).artifacts[0]?.installStatus).toBe('local_modified');
+    await expect(
+      installSharedAgentArtifacts(config, {agent: 'claude', apply: true, kind: 'pack', name: 'reviewer', sync: false}),
+    ).rejects.toThrow(/Refusing to overwrite/);
+
+    await installSharedAgentArtifacts(config, {
+      agent: 'claude',
+      apply: true,
+      force: true,
+      kind: 'pack',
+      name: 'reviewer',
+      sync: false,
+    });
+    await expect(readFile(join(installRoot, 'scripts', 'vcs.ts'), 'utf8')).resolves.toContain('/scripts-v2');
+  });
+
+  it('blocks a text member whose residual rewrite-root path the tokenizer leaves intact', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    // `${repo}-logs` is a sibling of the repo root: the tokenizer will not rewrite
+    // it (the `-` is not a path boundary), so the residual-root check must block.
+    await writeFile(join(repo, 'scripts', 'log.ts'), `const dir = "${repo}-logs/run";\n`);
+    mockPublishCommands();
+
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(/scripts\/log\.ts/);
+  });
+
+  it('accepts a skill entry given as a path to SKILL.md', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(
+      join(repo, 'threadnote-bundle.json'),
+      `${JSON.stringify({
+        agent: 'claude',
+        include: [],
+        name: 'reviewer',
+        pathRewrites: [{from: '/Users/yaroslavvoloshchuk/code/reviewer'}],
+        skills: ['.claude/skills/review-pr/SKILL.md'],
+        version: 1,
+      })}\n`,
+    );
+    mockPublishCommands();
+
+    const result = await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+    expect(result.targetUri).toContain('packs/claude/reviewer/reviewer.pack.md');
+  });
+
+  it('refuses to install a pack with an unreadable declared member without --force', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-incomplete-pack-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    await mkdir(join(packRoot, 'files', 'scripts'), {recursive: true});
+    await writeFile(join(packRoot, 'reviewer.pack.md'), '---\nname: reviewer\nkind: pack\n---\n');
+    await writeFile(
+      join(packRoot, 'reviewer.pack.json'),
+      `${JSON.stringify({
+        artifact: {agent: 'claude', kind: 'pack', name: 'reviewer'},
+        deps: {cli: [], mcp: [], os: [], runtime: []},
+        members: [
+          {binary: false, path: 'scripts/a.ts', sha256: 'x'},
+          {binary: false, path: 'scripts/missing.ts', sha256: 'y'},
+        ],
+        version: 1,
+      })}\n`,
+    );
+    await writeFile(join(packRoot, 'files', 'scripts', 'a.ts'), 'a\n');
+    // scripts/missing.ts is declared but absent from files/.
+
+    await expect(
+      installSharedAgentArtifacts(config, {agent: 'claude', apply: true, kind: 'pack', name: 'reviewer', sync: false}),
+    ).rejects.toThrow(/unreadable|Retry after sync/);
+  });
+
+  it('warns (without blocking) about a non-home machine-local path it cannot rewrite', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(join(repo, 'scripts', 'deploy.ts'), 'const dir = "/opt/work/secrets/run";\n');
+    mockPublishCommands();
+
+    const result = await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+    expect(result.messages.join('\n')).toContain('/opt/work/secrets/run');
+    expect(result.messages.join('\n')).toMatch(/machine-local/);
+  });
+
+  it('re-publishes a changed pack with --force, leaving the new version in place', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    mockPublishCommands();
+    await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+
+    await writeFile(
+      join(repo, 'scripts', 'vcs.ts'),
+      `const v = 2;\nconst here = "${repo}/scripts";\nimport '../lib/types';\n`,
+    );
+    // Differing content must be refused without --force, then replace cleanly with it.
+    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+      /already exists with different content/,
+    );
+    await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {force: true});
+
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    const sharedVcs = await readFile(join(packRoot, 'files', 'scripts', 'vcs.ts'), 'utf8');
+    expect(sharedVcs).toContain('v = 2');
+    expect(sharedVcs).toContain('${THREADNOTE_PACK_ROOT}/scripts');
+    expect(sharedVcs).not.toContain(repo);
+  });
+
+  it('skips a pack whose .pack.json member path escapes the pack root (no traversal write)', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const installHome = await mkdtemp(join(tmpdir(), 'threadnote-traversal-home-'));
+    homes.push(installHome);
+    process.env.HOME = installHome;
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    await mkdir(join(packRoot, 'files'), {recursive: true});
+    await writeFile(join(packRoot, 'reviewer.pack.md'), '---\nname: reviewer\nkind: pack\n---\n');
+    await writeFile(
+      join(packRoot, 'reviewer.pack.json'),
+      `${JSON.stringify({
+        artifact: {agent: 'claude', kind: 'pack', name: 'reviewer'},
+        deps: {cli: [], mcp: [], os: [], runtime: []},
+        members: [{binary: false, path: '../../../../../../escape.ts', sha256: 'x'}],
+        version: 1,
+      })}\n`,
+    );
+    await writeFile(join(packRoot, 'files', 'a.ts'), 'a\n');
+
+    // The unsafe member path makes discovery skip the whole pack, so install finds
+    // nothing to install — and crucially writes nothing outside the install root.
+    await expect(
+      installSharedAgentArtifacts(config, {agent: 'claude', apply: true, kind: 'pack', name: 'reviewer', sync: false}),
+    ).rejects.toThrow(/No shared agent artifacts/);
+    await expect(readFile(join(installHome, 'escape.ts'), 'utf8')).rejects.toThrow();
+  });
+
+  it('normalizes a trailing-slash pathRewrites entry so a bare-directory reference is rewritten', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repo = await makeReviewerManifestRepo();
+    await writeFile(
+      join(repo, 'threadnote-bundle.json'),
+      `${JSON.stringify({
+        agent: 'claude',
+        include: ['scripts', 'lib'],
+        name: 'reviewer',
+        pathRewrites: [{from: '/Users/yaroslavvoloshchuk/code/reviewer'}, {from: '/opt/acme/reviewer/'}],
+        skills: ['.claude/skills/review-pr'],
+        version: 1,
+      })}\n`,
+    );
+    await writeFile(join(repo, 'scripts', 'opt.ts'), 'const d = "/opt/acme/reviewer";\n');
+    mockPublishCommands();
+
+    await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+
+    const packRoot = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'agent-artifacts',
+      'packs',
+      'claude',
+      'reviewer',
+    );
+    const sharedOpt = await readFile(join(packRoot, 'files', 'scripts', 'opt.ts'), 'utf8');
+    expect(sharedOpt).toContain('${THREADNOTE_PACK_ROOT}');
+    expect(sharedOpt).not.toContain('/opt/acme/reviewer');
   });
 });


### PR DESCRIPTION
Shares agent skills as bundles, not just a single `SKILL.md`. Today `share_skill` ships one `SKILL.md` and silently drops every sibling (companion scripts, references, assets) and every other skill in a multi-skill set. This adds two layers on top of the existing single-file artifact lane.

**Phase 1 — multi-file skills.** A skill is shared as its whole directory. `share_skill` on a `SKILL.md` gathers its sibling files recursively under `agent-artifacts/skills/<agent>/<name>/`, recorded in a generated `.threadnote-bundle.json`. A lone `SKILL.md` publishes byte-for-byte as before.

**Phase 2 — constellation packs.** For skills whose shared code lives outside any skill dir (e.g. a repo's root `scripts/`/`lib/`, like the `reviewer` set), a `threadnote-bundle.json` manifest declares the skills, shared `include` paths, deps, and path rewrites. Publish writes `agent-artifacts/packs/<agent>/<name>/{<name>.pack.md, <name>.pack.json, files/<verbatim tree>}` and install materializes the whole tree under one root so relative imports and CWD-relative `bun run scripts/...` resolve.

**CLI / MCP**
- `threadnote share publish-artifact <SKILL.md>` — unchanged entry point, now carries the whole skill dir; `--allow-binary`.
- `threadnote share publish-bundle <manifest>` — new; constellation packs.
- `threadnote share install-artifacts --kind pack …` — installs packs.
- MCP: `share_bundle`; `share_skill` / `list_shared_skills` / `install_shared_skill` extended for packs.

**Safety / invariants**
- Scrubber sees every text member, the index, and the manifest; a leaked credential or `/Users`/`/home` path blocks publish. Binary members are blocked by default (`--allow-binary`), byte-scanned for embedded credentials and local paths.
- Hardcoded repo-root paths rewrite to a `${THREADNOTE_PACK_ROOT}` token at publish and expand at install. A residual declared/auto rewrite root left in content blocks publish; other non-home absolute paths (`/opt`, `/srv`, `/Volumes`, `C:\`) are surfaced as a warning, not auto-detected — declare them in `pathRewrites` or strip them.
- Install member paths are validated against `..`/absolute traversal, so a tampered shared repo cannot write outside the install root.
- Publish rolls back this run's writes on failure (restoring a replaced pack on `--force`); install swaps via backup-rename so a failed swap never loses the prior install.
- Packs install under `threadnote-packs/`, disjoint from `threadnote/` skills, so a pack and a same-named skill never share an install root.
- Per-member status folds to one verdict and refuses to clobber a local edit without `--force`.
- Only `<name>.pack.md` / `SKILL.md` is OpenViking-ingested (recall); the file tree is git-carried, not recallable.

**Tested.** `test/unit/share.artifacts.test.ts` grew 8 → 42; full suite 266 pass; tsc + eslint clean. Verified end-to-end with `publish-bundle --preview` over the real `reviewer` repo (5 skills + scripts/lib, 13 files, hardcoded `/Users/...` path tokenized, no false block).

Reviewed across 6 adversarial passes. Two narrow follow-ups remain — both require an uncatchable hard kill (SIGKILL/OOM), are local-recoverable, and neither lets install run broken code:
- SIGKILL during a `--force` re-publish of an already-tracked pack can leave its index/manifest mismatched until a clean re-publish; the orphan guard only covers the manifest-absent case. Fix: a publish sentinel-lock.
- SIGKILL during a first publish can leave OpenViking resources ingested for a worktree pack that orphan cleanup then deletes; recover with `threadnote forget`. Fix: drop those resources in the orphan cleanup.

External/runtime deps (`bun`, `gh`/`glab`/`jq`, the PAL `mcp__pal__clink` MCP) are declared and surfaced at install, not installed — Threadnote ships files, not runtimes.
