### PR TITLE
feat(mcp): threadnote_guide onboarding tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ threadnote mcp-install claude --apply   # or codex / cursor / copilot
 threadnote doctor --dry-run
 ```
 
+New to Threadnote? Ask your agent **"what can I do with Threadnote?"** — it calls the
+`threadnote_guide` MCP tool, which returns a short walkthrough tailored to your setup
+(server health, configured share teams, seeded projects) and offers to run each step
+with you. The walkthrough only loads when you ask, so it never sits in context otherwise.
+
 ## Real-World Uses
+
+**Not sure what Threadnote can do?**  
+Ask your agent _"what can I do with Threadnote?"_ — it calls `threadnote_guide`, which returns a tour tailored to your setup and offers to run each step (recall a handoff, save a durable note, set up team sharing). The walkthrough loads only when you ask.
 
 **Want to continue work in a fresh agent session?**  
 `threadnote install` adds user-level Codex, Claude, Cursor, and Copilot instructions so new agents automatically recall recent handoffs and relevant memories before they start changing code.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1475,6 +1475,17 @@ threadnote remember \
 
           <div class="vignettes">
             <div class="vignette reveal">
+              <div class="v-say">What can I do with Threadnote?</div>
+              <pre class="v-call">threadnote_guide({})</pre>
+              <pre class="v-response">→ a short, setup-aware tour: recall · capture · tidy · share · skills</pre>
+              <div class="v-answer">
+                The agent calls the onboarding tool and walks you through Threadnote one capability at a time — offering
+                to run each (recall your last handoff, save a durable note, set up team sharing) rather than dumping a
+                manual. The walkthrough loads only when you ask, so it never sits in your context otherwise.
+              </div>
+            </div>
+
+            <div class="vignette reveal">
               <div class="v-say">Continue where we left off on this branch.</div>
               <pre class="v-call">recall_context({query: "&lt;branch&gt; latest handoff durable feature memory"})</pre>
               <pre class="v-response">

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -11,6 +11,7 @@ import {z} from 'zod';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
 import {inferProjectFromQuery} from './manifest.js';
+import {buildOnboardingGuide, gatherOnboardingContext} from './onboarding.js';
 import type {ProjectManifest} from './types.js';
 import {
   activePersonalMemoryUrisFromText,
@@ -205,6 +206,17 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
   registerArchiveTool(server, config, 'archive', 'Compatibility alias for archive_context.');
 
   registerCompactTool(server, config);
+
+  server.registerTool(
+    'threadnote_guide',
+    {
+      annotations: {readOnlyHint: true, destructiveHint: false},
+      description:
+        "Onboard the user to Threadnote. Call this when the user asks what they can do with Threadnote, how to get started, for a feature tour/overview, or how Threadnote works — anything exploratory about Threadnote's capabilities. Returns a state-aware walkthrough (tailored to the user's server health, configured share teams, and seeded projects) written as guidance for YOU to present conversationally and offer to run step by step, not a message to paste. Prefer calling this over describing Threadnote from memory, so the guidance matches the user's actual setup. Takes no arguments.",
+      inputSchema: {},
+    },
+    async () => runThreadnoteGuideTool(config),
+  );
 
   server.registerTool(
     'forget',
@@ -2159,6 +2171,22 @@ async function runShareBundleTool(
     return {content: [{type: 'text', text: lines.join('\n')}], isError: false};
   } catch (err: unknown) {
     return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
+  }
+}
+
+async function runThreadnoteGuideTool(config: RuntimeConfig): Promise<CallToolResult> {
+  const serverUp = await probeServerUp(config);
+  const context = await gatherOnboardingContext(config);
+  const text = buildOnboardingGuide({...context, serverUp});
+  return {content: [{type: 'text', text}], isError: false};
+}
+
+async function probeServerUp(config: RuntimeConfig): Promise<boolean | undefined> {
+  try {
+    const result = await runOpenVikingMcpTool(config, 'health', {});
+    return result.isError !== true;
+  } catch (_err: unknown) {
+    return false;
   }
 }
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,0 +1,123 @@
+import {readSeedManifest} from './manifest.js';
+import {readTeamsFile} from './share.js';
+
+// Minimal config shape the onboarding probes need, structurally satisfied by
+// both the CLI and the MCP-adapter RuntimeConfig variants.
+interface OnboardingConfig {
+  readonly account: string;
+  readonly agentContextHome: string;
+  readonly agentId: string;
+  readonly manifestPath: string;
+  readonly user: string;
+}
+
+// State the onboarding guide tailors itself to. All fields are best-effort: a
+// probe that fails leaves its field empty/undefined so the guide still renders.
+export interface OnboardingState {
+  readonly seededProjects: readonly string[];
+  // true = OpenViking responded healthy, false = it errored, undefined = unknown
+  // (not probed / timed out). Only `false` shows the "start the server" nudge.
+  readonly serverUp?: boolean;
+  readonly teams: readonly string[];
+}
+
+// Reads the local, cheap pieces of onboarding state (configured share teams and
+// seeded projects). Server health is probed separately by the caller, since that
+// requires the OpenViking adapter the MCP server owns.
+export async function gatherOnboardingContext(
+  config: OnboardingConfig,
+): Promise<Pick<OnboardingState, 'seededProjects' | 'teams'>> {
+  return {seededProjects: await safeSeededProjects(config), teams: await safeTeams(config)};
+}
+
+async function safeTeams(config: OnboardingConfig): Promise<readonly string[]> {
+  try {
+    return Object.keys((await readTeamsFile(config)).teams ?? {}).sort();
+  } catch (_err: unknown) {
+    return [];
+  }
+}
+
+async function safeSeededProjects(config: OnboardingConfig): Promise<readonly string[]> {
+  try {
+    return (await readSeedManifest(config.manifestPath)).projects.map(project => project.name);
+  } catch (_err: unknown) {
+    return [];
+  }
+}
+
+// Builds the agent-facing onboarding walkthrough. Pure and deterministic so it is
+// unit-testable without the MCP/OpenViking plumbing. The text is instructions FOR
+// the agent (present conversationally, offer to run), not a message to paste.
+export function buildOnboardingGuide(state: OnboardingState): string {
+  const serverLine =
+    state.serverUp === false
+      ? 'OpenViking is NOT responding — recall/remember will fail until the user runs `threadnote start`. Offer to walk them through that first.'
+      : state.serverUp === true
+        ? 'OpenViking is running.'
+        : 'OpenViking status unknown — if recall/remember return connection errors, the fix is `threadnote start`.';
+
+  const teamLine =
+    state.teams.length > 0
+      ? `Team sharing is configured: ${state.teams.join(', ')}. They can publish memories and skills to teammates.`
+      : 'No share team configured yet — team sharing is available but needs a one-time `threadnote share init <git-remote>`.';
+
+  const seedLine =
+    state.seededProjects.length > 0
+      ? `Seeded project guidance is available for: ${state.seededProjects.join(', ')} (recall surfaces it when the query names the project).`
+      : 'No seeded project guidance yet — recall draws on personal memories and shared team memories.';
+
+  const hasTeam = state.teams.length > 0;
+
+  return [
+    '# Threadnote — what you can do here',
+    '',
+    'You are onboarding the user to Threadnote. Do NOT paste this list verbatim. Read it,',
+    'then guide the user conversationally: lead with what is most useful given the state',
+    'below, explain one capability in a sentence, and OFFER to run it for them (with their',
+    'go-ahead) instead of only describing it. Start small.',
+    '',
+    '## Current setup',
+    `- ${serverLine}`,
+    `- ${teamLine}`,
+    `- ${seedLine}`,
+    '',
+    '## Capabilities to offer',
+    '',
+    'Recall context — pull back the last handoff and durable knowledge for the current',
+    'repo+branch before starting work, so the session continues where the last one left off.',
+    '  Run: recall_context({"query":"<repo> latest handoff","callerCwd":"<abs cwd>"}), then',
+    '  read_context the most relevant viking:// URI it returns.',
+    '',
+    'Capture work — save a durable fact (a decision, interface, gotcha) or a handoff (current',
+    'status + next step) so the next session or a teammate inherits it.',
+    '  Run: remember_context({"text":"...","kind":"durable","project":"<repo>","topic":"<feature>"})',
+    '  or a handoff with kind:"handoff". Reuse the same project/topic to keep one memory current.',
+    '',
+    'Tidy memory — when recall surfaces overlapping notes for one topic, preview a scoped merge.',
+    '  Run: compact_context({"project":"<repo>","topic":"<topic>","dryRun":true}) and review before applying.',
+    '',
+    'Share with your team — publish a durable memory teammates’ agents can recall. Secrets are',
+    'scrubbed/blocked; handoffs/preferences/local-path notes are never shared.',
+    hasTeam
+      ? '  Run: share_publish({"uri":"viking://user/<you>/memories/durable/projects/<p>/<m>.md"}).'
+      : '  First (one-time): `threadnote share init git@github.com:org/team-memories.git`, then share_publish({"uri":"..."}).',
+    '',
+    'Share skills & packs — publish a Codex/Claude skill, or a multi-skill pack (skills + shared',
+    'scripts), into the team catalog; teammates install them on demand.',
+    '  Run: share_skill({"path":"~/.claude/skills/<name>/SKILL.md"}) or',
+    '  share_bundle({"path":"<repo>/threadnote-bundle.json"}). Teammates: list_shared_skills({})',
+    '  then install_shared_skill({"name":"<name>"}).',
+    '',
+    'Setup & health — verify the local install and server.',
+    state.serverUp === false
+      ? '  Run: `threadnote start` to bring OpenViking up.'
+      : '  Run: `threadnote doctor` to check prerequisites.',
+    '',
+    '## How to proceed',
+    'Pick the single most useful step for right now given the setup above (if the server is',
+    'down, that first; otherwise a recall for the current repo is the usual starting point),',
+    'describe it in one sentence, and ask whether to run it. Then chain into the others as the',
+    'user shows interest. Keep it interactive — one offer at a time, not a wall of options.',
+  ].join('\n');
+}

--- a/test/unit/onboarding.test.ts
+++ b/test/unit/onboarding.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest';
+import {buildOnboardingGuide} from '../../src/onboarding.js';
+
+describe('buildOnboardingGuide', () => {
+  it('lists the core capabilities with runnable calls', () => {
+    const guide = buildOnboardingGuide({seededProjects: [], teams: []});
+    expect(guide).toContain('# Threadnote — what you can do here');
+    for (const call of ['recall_context(', 'remember_context(', 'compact_context(', 'share_publish(', 'share_skill(']) {
+      expect(guide).toContain(call);
+    }
+    // It instructs the agent to present + offer, not to paste verbatim.
+    expect(guide).toMatch(/OFFER to run it/);
+    expect(guide).toMatch(/Do NOT paste this list verbatim/);
+  });
+
+  it('nudges first-time team setup when no team is configured', () => {
+    const guide = buildOnboardingGuide({seededProjects: [], teams: []});
+    expect(guide).toContain('No share team configured yet');
+    expect(guide).toContain('threadnote share init');
+  });
+
+  it('names configured teams and offers direct publish', () => {
+    const guide = buildOnboardingGuide({seededProjects: [], teams: ['default', 'friends']});
+    expect(guide).toContain('Team sharing is configured: default, friends');
+    expect(guide).toContain('share_publish({"uri":"viking://');
+  });
+
+  it('lists seeded projects when present', () => {
+    const guide = buildOnboardingGuide({seededProjects: ['coda', 'mobile-native'], teams: []});
+    expect(guide).toContain('Seeded project guidance is available for: coda, mobile-native');
+  });
+
+  it('leads with starting the server when it is down', () => {
+    const guide = buildOnboardingGuide({seededProjects: [], serverUp: false, teams: []});
+    expect(guide).toContain('OpenViking is NOT responding');
+    expect(guide).toContain('threadnote start');
+  });
+
+  it('says the server is running when healthy', () => {
+    const guide = buildOnboardingGuide({seededProjects: [], serverUp: true, teams: []});
+    expect(guide).toContain('OpenViking is running.');
+    expect(guide).toContain('threadnote doctor');
+  });
+});


### PR DESCRIPTION
Adds a `threadnote_guide` MCP tool so a newcomer can ask their agent "what can I do with Threadnote?" and get walked through the features — with the agent offering to run each step — instead of reading docs or having the agent guess from memory.

The constraint was: don't pay for this in context by default, only when asked. So the only always-loaded footprint is the tool's one-line description (the trigger); the walkthrough is returned **only when the tool is invoked**, and nothing was added to the always-loaded MCP `instructions` block.

**State-aware.** The handler best-effort-probes OpenViking health, configured share teams, and seeded projects, then tailors the opening and the next-step nudges:
- server down → leads with `threadnote start`
- no share team → nudges the one-time `threadnote share init`
- teams configured → names them and offers a direct `share_publish`
Each probe degrades to empty/unknown on failure, so the guide always renders.

**Output is agent-facing**, not a message to paste: a capability menu (recall · capture/handoff · compact · share memories · share skills/packs · setup), each with the exact call, plus an instruction to present it conversationally and offer to run one step at a time.

**Structure**
- `src/onboarding.ts` — `buildOnboardingGuide(state)` is pure/deterministic (unit-tested without the MCP/ov plumbing); `gatherOnboardingContext(config)` does the best-effort probes. A minimal structural `OnboardingConfig` keeps it decoupled from both the CLI and MCP-adapter `RuntimeConfig` variants.
- `src/mcp_server.ts` — registers `threadnote_guide` (no args); the handler probes health, gathers state, renders the guide.
- README + `docs/index.html` (landing page) surface it.

**Tested.** `test/unit/onboarding.test.ts` (6 cases) covers the state variants; full suite 272 pass, tsc + eslint clean. The tool is present in the built `dist/mcp_server.cjs`.

Tradeoff named: it's MCP-only for now (no `threadnote guide` CLI wrapper) and the state probes are the cheap three (health, teams, seeded projects) — richer signals (memory count, installed hooks) are a follow-up if useful. Can't smoke-test over a live MCP connection until the package is rebuilt/reinstalled; build + unit tests cover the logic.
