### PR TITLE
ci: publish to npm on release via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # required for npm OIDC trusted publishing + provenance
+
+concurrency:
+  group: publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      - run: npm install -g npm@latest
+
+      - run: npm ci
+
+      - name: Verify release tag matches package version
+        run: |
+          pkg="v$(node -p "require('./package.json').version")"
+          tag="${{ github.event.release.tag_name }}"
+          if [ "$pkg" != "$tag" ]; then
+            echo "::error::package.json ($pkg) does not match release tag ($tag)"
+            exit 1
+          fi
+
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm run test
+
+      # No NODE_AUTH_TOKEN: auth comes from the OIDC trusted publisher.
+      # Provenance is attached automatically; --provenance makes it explicit.
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
Automates npm publish so releases stop needing a manual `npm publish` + OTP. Triggers on `release: published`, so the existing flow is unchanged — bump → tag → `gh release create` and CI ships the package.

Uses **npm OIDC trusted publishing**, not a stored token:
- No `NPM_TOKEN` secret to store/rotate. Auth is a short-lived GitHub Actions OIDC identity.
- Works with account MFA enabled — OIDC is exempt from "require 2FA to publish", so no OTP in CI.
- Attaches build provenance automatically (`--provenance`).
- Upgrades npm in-job because OIDC needs npm >= 11.5.1 and Node 22 ships npm 10.x.

Before this can publish, configure the trusted publisher on npm (one-time, I can't do it — needs the npm account):
- [ ] npmjs.com → `threadnote` package → Settings → Trusted Publisher → add GitHub Actions
  - Repository: `Kashkovsky/threadnote`
  - Workflow filename: `publish.yml`
  - Environment: leave blank
- [ ] Keep account 2FA on. Optional hardening: package Settings → require 2FA / disallow tokens, since OIDC no longer needs a token.

If the trusted publisher isn't set up yet, the job just fails at `npm publish` — it never publishes without it, so merging early is safe.

Guards: checks out the release tag, fails if `package.json` version != tag, runs lint/typecheck/build/test before publish.

Fallback if you'd rather not use OIDC: a granular automation token in `NPM_TOKEN` secret + `NODE_AUTH_TOKEN` on the publish step. Automation tokens also bypass 2FA, but it's a long-lived secret and no provenance — OIDC is the better default.
