### PR TITLE
Avoid semantic reindex for memory files

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -3564,9 +3564,12 @@ async function refreshMemoryIndex(
   uri: string,
   options: {readonly quiet?: boolean} = {},
 ): Promise<void> {
+  // This runs after a successful file write. OpenViking's semantic memory
+  // reindex path expects a directory URI, but vectors_only supports memory
+  // files and refreshes the leaf recall records without poisoning the queue.
   const result = await runCommand(
     ov,
-    withIdentity(config, ['reindex', uri, '--mode', 'semantic_and_vectors', '--wait', 'true']),
+    withIdentity(config, ['reindex', uri, '--mode', 'vectors_only', '--wait', 'true']),
     {allowFailure: true},
   );
   if (result.exitCode === 0) {

--- a/test/integration/share.retry.test.ts
+++ b/test/integration/share.retry.test.ts
@@ -119,7 +119,7 @@ describe('writeMemoryFile index refresh', () => {
     vi.restoreAllMocks();
   });
 
-  it('runs a file-level semantic/vector reindex after a successful write', async () => {
+  it('runs a file-level vector reindex after a successful write', async () => {
     commandSequence(
       fail('not found'), // stat before write
       ok('written'),
@@ -142,7 +142,7 @@ describe('writeMemoryFile index refresh', () => {
         'reindex',
         'viking://user/me/memories/durable/projects/threadnote/x.md',
         '--mode',
-        'semantic_and_vectors',
+        'vectors_only',
       ]),
     );
   });


### PR DESCRIPTION
## Summary
- Switch the defensive post-write memory-file refresh to `ov reindex --mode vectors_only`.
- Update the retry test to assert file-level writes no longer invoke `semantic_and_vectors`.

## Detail
`semantic_and_vectors` on a `viking://user/.../memories/.../*.md` URI sends OpenViking through the memory semantic processor, which expects a directory and can try to `ls()` the file URI. `vectors_only` is the file-safe refresh path and still rebuilds the leaf/detail recall vectors after a successful `ov write --wait`.

Directory-level recall index repair is unchanged and still uses `semantic_and_vectors` on directory URIs.

## Test plan
- `npx vitest run test/integration/share.retry.test.ts`
- `npm run typecheck --silent`
- `npm run build --silent`
- `npm test --silent`
- precommit: `npm run lint && npm run prettier:write && npm run test`