### PR TITLE
Pin OpenViking 0.4.4, harden version/drift handling, opt-in seed watches

### DIFF
--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -193,8 +193,8 @@ Use these only when MCP tools are not available:
 threadnote start
 threadnote recall --query "last handoff for this branch"
 threadnote recall --query "durable feature knowledge for this branch"
-threadnote read viking://agent/threadnote/memories/.abstract.md
-threadnote list viking://agent/threadnote/memories --all --recursive
+threadnote read viking://user/example/memories/.abstract.md
+threadnote list viking://user/example/memories --all --recursive
 threadnote remember --kind durable --project example --topic workflow --text "Durable engineering note..."
 threadnote remember --kind durable --project example --topic active-issue --text "Feature knowledge..."
 threadnote remember --replace viking://user/example/memories/durable/projects/example/workflow.md --text "Updated durable engineering note..."

--- a/docs/index.html
+++ b/docs/index.html
@@ -1147,7 +1147,7 @@
 <span class="out">--user`, which fails on PEP 668 setups.</span>
 <span class="out">Install uv now? [Y/n] </span><span class="out-strong">Y</span>
 <span class="out">Installing uv via Homebrew…</span>
-<span class="out-strong">OK   openviking 0.3.24 ready · server healthy</span></pre>
+<span class="out-strong">OK   openviking 0.4.4 ready · server healthy</span></pre>
               </div>
               <p class="muted" style="margin-top: 0.75rem; font-size: 0.9rem">
                 Or manually: <code>npm install -g threadnote && threadnote install</code>. On a fresh macOS / modern
@@ -1651,7 +1651,7 @@ threadnote doctor --dry-run</code></pre>
           </div>
 
           <p class="colophon">
-            threadnote · AGPL-3.0-or-later · built on OpenViking 0.3.24 · use <span class="kbd">↑</span>
+            threadnote · AGPL-3.0-or-later · built on OpenViking 0.4.4 · use <span class="kbd">↑</span>
             <span class="kbd">↓</span> / <span class="kbd">j</span> <span class="kbd">k</span> to navigate
           </p>
         </div>

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -108,6 +108,12 @@ paths.
    threadnote seed
    ```
 
+   Seeded docs refresh on the next `threadnote seed`/`repair`, which re-runs the
+   secret scan. To let OpenViking auto-refresh them between runs, opt in with
+   `THREADNOTE_SEED_WATCH_INTERVAL=<minutes> threadnote seed`. Watches attach
+   only to original, non-redaction-prone files, since an OpenViking-managed
+   refresh re-ingests the file without Threadnote's per-import secret scan.
+
 7. Inspect and seed shared skills:
 
    ```bash

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_HOST = '127.0.0.1';
 export const DEFAULT_PORT = 1933;
-export const DEFAULT_OPENVIKING_VERSION = '0.3.24';
+export const DEFAULT_OPENVIKING_VERSION = '0.4.4';
 // CPython minor the OpenViking tool is pinned to. openviking[local-embed] pulls
 // in llama-cpp-python, whose prebuilt wheels (PyPI is sdist-only; wheels live on
 // the abetlen community index) top out at 3.12 as of 2026. On newer interpreters

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,10 @@ export const USER_INSTRUCTIONS_START_MARKER = '<!-- BEGIN THREADNOTE USER INSTRU
 export const USER_INSTRUCTIONS_END_MARKER = '<!-- END THREADNOTE USER INSTRUCTIONS -->';
 export const USER_MANIFEST_NAME = 'seed-manifest.yaml';
 export const SEED_STATE_FILE = 'seed-state.json';
+// Opt-in: minutes between OpenViking auto-refreshes of seeded repo docs. Unset
+// (the default) leaves watches off, so seeded content only refreshes on the
+// next `threadnote seed`/`repair` — which re-runs Threadnote's secret scan.
+export const SEED_WATCH_INTERVAL_ENV = 'THREADNOTE_SEED_WATCH_INTERVAL';
 export const USER_AGENT_INSTRUCTION_TARGETS = [
   {kind: 'block', label: 'codex user instructions', path: '~/.codex/AGENTS.md'},
   {kind: 'block', label: 'claude user instructions', path: '~/.claude/CLAUDE.md'},

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -34,13 +34,14 @@ import {
 } from './index_repair.js';
 import {readSeedManifest} from './manifest.js';
 import {removeMcpConfigs, removeMcpSnippets, resolveMcpClients, runMcpInstall} from './mcp.js';
-import {maybeRunPostUpdateAfterRepair} from './update.js';
+import {maybeRunPostUpdateAfterRepair, readOpenVikingCliVersion} from './update.js';
 import {
   builtInExampleManifestPath,
   openVikingHealthUrl,
   openVikingLogPath,
   openVikingServerArgs,
   renderTemplate,
+  withIdentity,
 } from './runtime.js';
 import {projectManifestForRepo, resolveRepoRoot} from './seeding.js';
 import type {
@@ -112,6 +113,8 @@ export async function collectDoctorChecks(config: RuntimeConfig, options: Doctor
   checks.push(await commandCheck('python3', ['--version']));
   checks.push(await openVikingServerCheck());
   checks.push(await openVikingCliCheck());
+  checks.push(await openVikingVersionCheck(config));
+  checks.push(await recallShapeCheck(config));
   checks.push(await localEmbeddingCheck());
   checks.push(await pythonSystemCertificatesCheck());
   checks.push(await firstCommandCheck('python installer', ['pipx', 'uv', 'pip3'], ['--version']));
@@ -419,15 +422,6 @@ async function configureOpenVikingCliLanguage(config: RuntimeConfig, dryRun: boo
   await maybeRun(dryRun, ov, ['language', 'en'], {allowFailure: true});
 }
 
-async function readOpenVikingCliVersion(ov: string): Promise<string | undefined> {
-  const result = await runCommand(ov, ['version'], {allowFailure: true});
-  if (result.exitCode !== 0) {
-    return undefined;
-  }
-  const match = result.stdout.match(/^\s*CLI:\s*(\S+)/m);
-  return match ? match[1] : undefined;
-}
-
 /**
  * Locate the openviking-server binary even when its install directory is not on
  * PATH — which is the default state on a fresh macOS shell after `uv tool install`.
@@ -707,6 +701,73 @@ async function openVikingCliCheck(): Promise<DoctorCheck> {
     status: result.exitCode === 0 ? 'ok' : 'warn',
     detail: result.exitCode === 0 ? detail : firstLine(result.stderr || result.stdout) || detail,
   };
+}
+
+/**
+ * Warns when the installed OpenViking CLI is older than the version Threadnote
+ * pins. `install`/`doctor` (unlike `repair`/`update`) don't upgrade OpenViking,
+ * so without this a healthy-but-stale server silently stays behind the pin.
+ */
+async function openVikingVersionCheck(config: RuntimeConfig): Promise<DoctorCheck> {
+  const executable = await findOpenVikingCli();
+  const pinned = config.openVikingVersion;
+  if (!executable) {
+    return {name: 'openviking version', status: 'warn', detail: `CLI not found; pinned ${pinned}`};
+  }
+  const installed = await readOpenVikingCliVersion(executable);
+  if (!installed) {
+    return {
+      name: 'openviking version',
+      status: 'warn',
+      detail: `could not detect via \`${executable} version\`; pinned ${pinned}`,
+    };
+  }
+  if (compareVersions(installed, pinned) < 0) {
+    return {
+      name: 'openviking version',
+      status: 'warn',
+      detail: `installed ${installed} is older than pinned ${pinned}; run \`threadnote repair\` or \`threadnote update\` to upgrade`,
+    };
+  }
+  return {name: 'openviking version', status: 'ok', detail: `${installed} (pinned ${pinned})`};
+}
+
+/**
+ * Recall reads its hits from a JSON object with `memories`/`resources`/`skills`
+ * arrays (see parseRecallHits). If a future OpenViking renames those buckets,
+ * parseRecallHits would return zero hits with no error, silently degrading
+ * recall. This probe asserts the shape is intact — empty buckets are fine, only
+ * a missing/renamed bucket structure (or non-JSON output) warns.
+ */
+async function recallShapeCheck(config: RuntimeConfig): Promise<DoctorCheck> {
+  const executable = await findOpenVikingCli();
+  if (!executable) {
+    return {name: 'recall shape', status: 'warn', detail: 'CLI not found'};
+  }
+  const args = withIdentity(config, ['find', 'threadnote', '--node-limit', '1', '--output', 'json']);
+  const result = await runCommand(executable, args, {allowFailure: true});
+  if (result.exitCode !== 0) {
+    return {name: 'recall shape', status: 'warn', detail: 'search failed; run threadnote repair'};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout.trim());
+  } catch {
+    return {
+      name: 'recall shape',
+      status: 'warn',
+      detail: 'search output is not JSON; recall may silently return nothing',
+    };
+  }
+  const buckets = ['memories', 'resources', 'skills'];
+  if (!isJsonObject(parsed) || !buckets.some(key => Array.isArray(parsed[key]))) {
+    return {
+      name: 'recall shape',
+      status: 'warn',
+      detail: `search JSON missing ${buckets.join('/')} buckets; recall parsing is out of sync with this OpenViking`,
+    };
+  }
+  return {name: 'recall shape', status: 'ok', detail: 'memories/resources/skills buckets present'};
 }
 
 async function localEmbeddingCheck(): Promise<DoctorCheck> {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -65,6 +65,7 @@ import {
   sleep,
   trimTrailingSlash,
 } from './utils.js';
+import {withIdentity} from './runtime.js';
 
 interface RuntimeConfig {
   readonly account: string;
@@ -229,7 +230,7 @@ function registerTools(server: McpServer, config: RuntimeConfig): void {
       },
     },
     async ({recursive, uri}) => {
-      const checkedUri = requiredVikingUri(uri, 'forget', 'viking://agent/threadnote/memories/example.md');
+      const checkedUri = requiredVikingUri(uri, 'forget', 'viking://user/you/memories/example.md');
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
@@ -512,8 +513,6 @@ function registerOpenVikingParityTools(server: McpServer, config: RuntimeConfig)
         limit: z.number().int().positive().max(1000).optional().describe('Maximum result count'),
         minScore: z.number().min(0).max(1).optional().describe('Minimum score threshold'),
         min_score: z.number().min(0).max(1).optional().describe('Minimum score threshold'),
-        peerId: z.string().optional().describe('Optional native peer id'),
-        peer_id: z.string().optional().describe('Optional native peer id'),
         query: z.string().optional().describe('Required search query'),
         sessionId: z.string().optional().describe('Optional native session id'),
         session_id: z.string().optional().describe('Optional native session id'),
@@ -1079,7 +1078,7 @@ function registerReadTool(server: McpServer, config: RuntimeConfig, name: string
       },
     },
     async ({uri, uris}) => {
-      const checkedUris = requiredVikingUriList(uris ?? uri, name, 'viking://agent/threadnote/memories/.abstract.md');
+      const checkedUris = requiredVikingUriList(uris ?? uri, name, 'viking://user/you/memories/.abstract.md');
       if (!checkedUris.ok) {
         return checkedUris.error;
       }
@@ -2253,10 +2252,6 @@ function shareArtifactToolHeader(team: string, syncedTeams: readonly string[], w
     lines.push(`Warning: ${warning}`);
   }
   return lines;
-}
-
-function withIdentity(config: RuntimeConfig, args: readonly string[]): readonly string[] {
-  return [...args, '--account', config.account, '--user', config.user, '--agent-id', config.agentId];
 }
 
 async function requiredOpenVikingCli(): Promise<string> {

--- a/src/seeding.ts
+++ b/src/seeding.ts
@@ -1,7 +1,13 @@
 import {chmod, readFile, realpath, stat, writeFile} from 'node:fs/promises';
 import {basename, dirname, join, relative} from 'node:path';
 import yaml from 'js-yaml';
-import {DEFAULT_SEED_PATTERNS, MAX_SECRET_MATCHES_TO_PRINT, SEED_STATE_FILE, USER_MANIFEST_NAME} from './constants.js';
+import {
+  DEFAULT_SEED_PATTERNS,
+  MAX_SECRET_MATCHES_TO_PRINT,
+  SEED_STATE_FILE,
+  SEED_WATCH_INTERVAL_ENV,
+  USER_MANIFEST_NAME,
+} from './constants.js';
 import {readSeedManifest, uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
 import type {
@@ -46,10 +52,45 @@ interface SeedStateFile {
   readonly version: 1;
 }
 
+/**
+ * Reads the opt-in auto-refresh cadence (minutes) for seeded resources from
+ * THREADNOTE_SEED_WATCH_INTERVAL. Returns undefined (watches off) unless the
+ * value is a positive integer. When set, OpenViking re-ingests watched paths on
+ * this cadence so seeded repo docs stay indexed without a manual `threadnote
+ * seed`.
+ */
+export function parseSeedWatchIntervalMinutes(rawValue: string | undefined): number | undefined {
+  if (rawValue === undefined) {
+    return undefined;
+  }
+  const minutes = Number.parseInt(rawValue.trim(), 10);
+  return Number.isInteger(minutes) && minutes > 0 ? minutes : undefined;
+}
+
+/**
+ * `--watch-interval` args for a seed import, or [] when no watch should attach.
+ * A watch only goes on the ORIGINAL file (importedOriginal) that is NOT
+ * redaction-prone: OpenViking refreshes a watched path on its own schedule,
+ * bypassing Threadnote's per-import secret scan/redaction. So we never watch a
+ * redacted temp copy (its contents are frozen anyway) or a redaction-prone
+ * path, and watches stay off entirely unless the user opted in via the env.
+ */
+export function seedWatchArgs(params: {
+  readonly watchIntervalMinutes: number | undefined;
+  readonly importedOriginal: boolean;
+  readonly redactionProne: boolean;
+}): readonly string[] {
+  if (params.watchIntervalMinutes === undefined || !params.importedOriginal || params.redactionProne) {
+    return [];
+  }
+  return ['--watch-interval', String(params.watchIntervalMinutes)];
+}
+
 export async function runSeed(config: RuntimeConfig, options: SeedOptions): Promise<void> {
   const manifest = await readSeedManifest(config.manifestPath);
   const ignorePatterns = await loadIgnorePatterns();
   const ov = await openVikingCliForMode(options.dryRun === true);
+  const watchIntervalMinutes = parseSeedWatchIntervalMinutes(process.env[SEED_WATCH_INTERVAL_ENV]);
   const statePath = join(config.agentContextHome, SEED_STATE_FILE);
   const state: {files: Record<string, SeedStateEntry>; version: 1} =
     options.force === true ? {files: {}, version: 1} : await readSeedState(statePath);
@@ -85,6 +126,11 @@ export async function runSeed(config: RuntimeConfig, options: SeedOptions): Prom
         candidate.destinationUri,
         '--reason',
         seedResourceReason(candidate),
+        ...seedWatchArgs({
+          watchIntervalMinutes,
+          importedOriginal: importPath === candidate.filePath,
+          redactionProne: shouldRedactPath(candidate.relativePath),
+        }),
         '--wait',
       ]);
       await maybeRun(options.dryRun === true, ov, args);

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,6 +1,7 @@
 import {spawn} from 'node:child_process';
 import {mkdir, readFile, writeFile} from 'node:fs/promises';
 import {dirname} from 'node:path';
+import {compareVersions} from './utils.js';
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const NPM_LATEST_URL = 'https://registry.npmjs.org/threadnote/latest';
@@ -39,7 +40,7 @@ export async function checkForThreadnoteUpdate(args: {
   }
   const cached = await readUpdateCache(args.cachePath);
   if (cached && isCacheFresh(cached)) {
-    return compareVersions(args.currentVersion, cached.latestVersion);
+    return toUpdateCheckResult(args.currentVersion, cached.latestVersion);
   }
   const fresh = await fetchLatestVersion();
   if (fresh) {
@@ -48,10 +49,10 @@ export async function checkForThreadnoteUpdate(args: {
       latestVersion: fresh,
       version: 1,
     });
-    return compareVersions(args.currentVersion, fresh);
+    return toUpdateCheckResult(args.currentVersion, fresh);
   }
   if (cached) {
-    return compareVersions(args.currentVersion, cached.latestVersion);
+    return toUpdateCheckResult(args.currentVersion, cached.latestVersion);
   }
   return undefined;
 }
@@ -81,28 +82,12 @@ export function spawnDetachedAutoUpdate(): void {
   }
 }
 
-function compareVersions(currentVersion: string, latestVersion: string): UpdateCheckResult {
+function toUpdateCheckResult(currentVersion: string, latestVersion: string): UpdateCheckResult {
   return {
     currentVersion,
     latestVersion,
-    outdated: isNewerVersion(latestVersion, currentVersion),
+    outdated: compareVersions(latestVersion, currentVersion) > 0,
   };
-}
-
-function isNewerVersion(candidate: string, baseline: string): boolean {
-  const candidateParts = parseVersion(candidate);
-  const baselineParts = parseVersion(baseline);
-  for (let index = 0; index < 3; index += 1) {
-    if (candidateParts[index] !== baselineParts[index]) {
-      return candidateParts[index] > baselineParts[index];
-    }
-  }
-  return false;
-}
-
-function parseVersion(value: string): readonly [number, number, number] {
-  const parts = value.split('.').map(part => parseInt(part, 10));
-  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
 }
 
 function isCacheFresh(cache: UpdateCacheFile): boolean {

--- a/src/update.ts
+++ b/src/update.ts
@@ -390,8 +390,8 @@ async function readOpenVikingCliVersion(ov: string): Promise<string | undefined>
     return undefined;
   }
   // `ov version` output:
-  //   CLI:     0.3.24
-  //   Server:  0.3.24
+  //   CLI:     0.4.4
+  //   Server:  0.4.4
   // Match the CLI line specifically; ignore the server line in case the
   // server is briefly out of sync with the CLI during an upgrade.
   const match = result.stdout.match(/^\s*CLI:\s*(\S+)/m);

--- a/src/update.ts
+++ b/src/update.ts
@@ -384,7 +384,7 @@ async function isLaunchAgentInstalled(): Promise<boolean> {
   }
 }
 
-async function readOpenVikingCliVersion(ov: string): Promise<string | undefined> {
+export async function readOpenVikingCliVersion(ov: string): Promise<string | undefined> {
   const result = await runCommand(ov, ['version'], {allowFailure: true});
   if (result.exitCode !== 0) {
     return undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -410,10 +410,12 @@ export async function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Compare two semver-ish versions. Returns positive if `a > b`, negative if
- * `a < b`, zero if equal. Handles a single dash-prefixed prerelease segment
- * (e.g., `1.2.3-rc1`); a missing prerelease is treated as newer than any
- * prerelease, matching npm semver semantics.
+ * Compare two semver-ish / PEP 440 versions. Returns positive if `a > b`,
+ * negative if `a < b`, zero if equal. Build metadata (`+local...`) carries no
+ * precedence and is ignored. Pre-releases (`1.2.3-rc1`, `0.4.4rc1`, `.dev0`)
+ * sort before the matching release; post-releases (`0.4.4.post1`) sort after
+ * it. A non-integer or extra version segment never NaN-collapses a core number
+ * to 0 — important so a locally-built `0.4.4+local` is not misread as `0.4.0`.
  */
 export function compareVersions(a: string, b: string): number {
   const left = parseVersion(a);
@@ -424,28 +426,48 @@ export function compareVersions(a: string, b: string): number {
       return difference;
     }
   }
-  if (left.prerelease === right.prerelease) {
+  const rankDelta = suffixRank(left.suffix) - suffixRank(right.suffix);
+  if (rankDelta !== 0) {
+    return rankDelta;
+  }
+  if (left.suffix === right.suffix) {
     return 0;
   }
-  if (left.prerelease === undefined) {
-    return 1;
+  // Same rank class with distinct suffixes (e.g. rc1 vs rc2) — order lexically.
+  return (left.suffix ?? '').localeCompare(right.suffix ?? '');
+}
+
+/** PEP 440 post-releases sort after the release; pre/dev releases before it. */
+function suffixRank(suffix: string | undefined): number {
+  if (suffix === undefined) {
+    return 0;
   }
-  if (right.prerelease === undefined) {
-    return -1;
-  }
-  return left.prerelease.localeCompare(right.prerelease);
+  return /^post/i.test(suffix) ? 1 : -1;
 }
 
 function parseVersion(version: string): {
   readonly numbers: readonly [number, number, number];
-  readonly prerelease?: string;
+  readonly suffix?: string;
 } {
-  const normalized = version.trim().replace(/^v/, '');
-  const [core, prerelease] = normalized.split('-', 2);
-  const parts = core.split('.').map(part => Number(part));
+  // Drop a leading `v` and build metadata (`+local...`), then split the numeric
+  // core off any pre/post/dev suffix. PEP 440 attaches the suffix without a
+  // separator (`0.4.4rc1`, `0.4.4.post1`); semver uses a dash (`0.4.4-rc1`).
+  // Parsing each core segment as a leading integer keeps a non-numeric tail
+  // from collapsing the segment to 0.
+  const normalized = version.trim().replace(/^v/, '').split('+', 1)[0];
+  const core = normalized.match(/^\d+(?:\.\d+){0,2}/)?.[0] ?? '';
+  const rawSuffix = normalized.slice(core.length).replace(/^[-_.]/, '');
+  // Only a string with a numeric core can carry a meaningful suffix; a fully
+  // non-numeric version (e.g. `abc`) coerces to 0.0.0 with no suffix.
+  const suffix = core.length > 0 && rawSuffix.length > 0 ? rawSuffix : undefined;
+  const parts = core.split('.');
   return {
-    numbers: [safeVersionNumber(parts[0]), safeVersionNumber(parts[1]), safeVersionNumber(parts[2])],
-    prerelease,
+    numbers: [
+      safeVersionNumber(Number.parseInt(parts[0] ?? '', 10)),
+      safeVersionNumber(Number.parseInt(parts[1] ?? '', 10)),
+      safeVersionNumber(Number.parseInt(parts[2] ?? '', 10)),
+    ],
+    suffix,
   };
 }
 

--- a/test/unit/lifecycle.install.test.ts
+++ b/test/unit/lifecycle.install.test.ts
@@ -21,13 +21,13 @@ function runtime(): RuntimeConfig {
     agentId: 'threadnote',
     host: '127.0.0.1',
     manifestPath: '/tmp/threadnote-test/seed-manifest.yaml',
-    openVikingVersion: '0.3.24',
+    openVikingVersion: '0.4.4',
     port: 1933,
     user: 'denys',
   };
 }
 
-const SPEC = 'openviking[local-embed]==0.3.24';
+const SPEC = 'openviking[local-embed]==0.4.4';
 
 describe('localEmbedWheelIndexUrl', () => {
   const original = process.env[WHEEL_INDEX_ENV];

--- a/test/unit/seeding.test.ts
+++ b/test/unit/seeding.test.ts
@@ -2,7 +2,7 @@ import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {afterEach, describe, expect, it} from 'vitest';
-import {runSeedSkills} from '../../src/seeding.js';
+import {parseSeedWatchIntervalMinutes, runSeedSkills, seedWatchArgs} from '../../src/seeding.js';
 import type {RuntimeConfig} from '../../src/types.js';
 
 async function captureConsole(action: () => Promise<void>): Promise<string> {
@@ -22,6 +22,40 @@ async function captureConsole(action: () => Promise<void>): Promise<string> {
   }
   return lines.join('\n');
 }
+
+describe('parseSeedWatchIntervalMinutes', () => {
+  it('returns undefined when unset or not a positive integer', () => {
+    expect(parseSeedWatchIntervalMinutes(undefined)).toBeUndefined();
+    expect(parseSeedWatchIntervalMinutes('')).toBeUndefined();
+    expect(parseSeedWatchIntervalMinutes('0')).toBeUndefined();
+    expect(parseSeedWatchIntervalMinutes('-5')).toBeUndefined();
+    expect(parseSeedWatchIntervalMinutes('abc')).toBeUndefined();
+  });
+
+  it('parses a positive integer cadence', () => {
+    expect(parseSeedWatchIntervalMinutes('60')).toBe(60);
+    expect(parseSeedWatchIntervalMinutes(' 1440 ')).toBe(1440);
+  });
+});
+
+describe('seedWatchArgs', () => {
+  it('attaches a watch only on the original, non-redaction-prone file when opted in', () => {
+    expect(seedWatchArgs({watchIntervalMinutes: 60, importedOriginal: true, redactionProne: false})).toEqual([
+      '--watch-interval',
+      '60',
+    ]);
+  });
+
+  it('never watches when the cadence is unset', () => {
+    expect(seedWatchArgs({watchIntervalMinutes: undefined, importedOriginal: true, redactionProne: false})).toEqual([]);
+  });
+
+  it('never watches a redacted temp copy or a redaction-prone path', () => {
+    // Bypassing Threadnote's per-import secret scan would be unsafe here.
+    expect(seedWatchArgs({watchIntervalMinutes: 60, importedOriginal: false, redactionProne: false})).toEqual([]);
+    expect(seedWatchArgs({watchIntervalMinutes: 60, importedOriginal: true, redactionProne: true})).toEqual([]);
+  });
+});
 
 describe('seed-skills', () => {
   const homes: string[] = [];

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -32,7 +32,7 @@ async function makeRuntime(): Promise<RuntimeConfig> {
     agentId: 'threadnote',
     host: '127.0.0.1',
     manifestPath: join(home, 'seed-manifest.yaml'),
-    openVikingVersion: '0.3.24',
+    openVikingVersion: '0.4.4',
     port: 1933,
     user: 'denys',
   };

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -69,6 +69,18 @@ describe('compareVersions', () => {
     expect(compareVersions('1.2', '1.2.0')).toBe(0);
     expect(compareVersions('abc', '0.0.0')).toBe(0);
   });
+
+  it('ignores build metadata so a local build is not misread as an older minor', () => {
+    expect(compareVersions('0.4.4+local.1', '0.4.4')).toBe(0);
+    expect(compareVersions('0.4.4+local', '0.4.3')).toBeGreaterThan(0);
+  });
+
+  it('treats PEP 440 post-releases as newer and pre-releases as older', () => {
+    expect(compareVersions('0.4.4.post1', '0.4.4')).toBeGreaterThan(0);
+    expect(compareVersions('0.4.4', '0.4.4.post1')).toBeLessThan(0);
+    expect(compareVersions('0.4.4rc1', '0.4.4')).toBeLessThan(0);
+    expect(compareVersions('0.4.4.dev0', '0.4.4')).toBeLessThan(0);
+  });
 });
 
 describe('parseJsonConfigObject', () => {


### PR DESCRIPTION
Bumps the pinned OpenViking from 0.3.24 to 0.4.4 and hardens the integration around the 0.3.x→0.4.x transition. The 0.4.x line crosses one notionally-breaking release (0.4.1, the User/Peer identity model), but threadnote is compatible as-is — verified against the changelog and the code:

- memories already write to `viking://user/<user>/memories/...` (`memoryDirectoryUri`), the namespace 0.4.x prescribes for new writes
- `--agent-id` stays a supported transition shim; only the `agent_id`+`actor_peer_id` combination is forbidden, and threadnote never sends `actor_peer_id`/`peer_id`
- `ov version` output and the `find`/`search` JSON buckets are unchanged 0.3.24→0.4.4
- 0.4.4 auth (dev/trusted on 127.0.0.1) is backward compatible

No code change is required for the bump itself; the rest is hardening plus one harness.

**Detail**

`chore: pin OpenViking 0.4.4` — `DEFAULT_OPENVIKING_VERSION`, docs, and the version-string fixtures.

`chore: harden version parsing and OpenViking drift detection`:
- `compareVersions` now ignores `+build` metadata, parses core segments as leading integers, and ranks PEP 440 post/pre-releases. Before, a locally-built `0.4.4+local` parsed as `0.4.0` (`Number('4+local')`→NaN→0) and would trigger a spurious re-upgrade loop.
- consolidated the duplicate version parser (`update-check.ts`) and the duplicate `readOpenVikingCliVersion` (`lifecycle.ts` → `update.ts`).
- `doctor`: warns when the installed OpenViking is older than the pin. `install`/`doctor` don't upgrade it (only `repair`/`update` do), so a healthy-but-stale server was previously unflagged.
- `doctor`: probes that `ov find --output json` still returns the `memories`/`resources`/`skills` buckets `parseRecallHits` depends on — that parser returns empty (not an error) on shape drift, so a future rename would silently degrade recall.
- removed the dead `ov_search` `peerId`/`peer_id` params (declared at `mcp_server.ts:515-516`, never destructured or forwarded) and de-duplicated `withIdentity` (`mcp_server` → `runtime`).
- refreshed stale `viking://agent/` example URIs to `viking://user/`.

`feat: opt-in auto-refresh of seeded docs via OpenViking watches`:
- harnesses `--watch-interval` so seeded repo docs stay indexed between `threadnote seed`/`repair` runs. Off by default; opt in with `THREADNOTE_SEED_WATCH_INTERVAL=<minutes>`.
- Tradeoff, handled: an OpenViking-managed refresh re-ingests the file without threadnote's per-import secret scan, so a watch attaches only to the original (not a redacted temp copy), non-redaction-prone file.

**Deferred harness items** (need a live 0.4.4 server or carry a behavior risk, so out of scope here):
- `context_type` as a retrieval input — no `--context-type` CLI flag exists in 0.3.24 and I can't confirm one in 0.4.4 without a live server.
- `actor_peer_id` isolation — the forward-compat replacement for the `agent_id` shim, but the flag is unconfirmed and it's a ~40-site identity change; the shim works until OpenViking removes it.
- recency `--after` recall bias — `--after` is a hard filter that would drop valid older durable memories, not a soft boost.

**Test plan**
- `npm run typecheck`, `npm run lint`, `npm test` (279 tests / 23 files) green on each commit via the husky precommit.
- New unit tests: `compareVersions` build-metadata + post/pre-release ordering (`utils.test.ts`); `parseSeedWatchIntervalMinutes` and `seedWatchArgs` gating (`seeding.test.ts`).
- Not validated against a live 0.4.4 server — the installed `ov` here is 0.3.24; the bump installs 0.4.4 at runtime via `repair`/`update`.
