### PR TITLE
Fix OV 0.4.4 recall breakage (--agent-id) and bound the reindex hang

### DIFF
--- a/src/index_repair.ts
+++ b/src/index_repair.ts
@@ -3,7 +3,16 @@ import {dirname, join, relative} from 'node:path';
 import {inferProjectFromQuery, readSeedManifest, uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
 import type {CommandResult} from './types.js';
-import {ensureDirectory, exists, isJsonObject, readFileIfExists, runCommand, sha256, toPosixPath} from './utils.js';
+import {
+  ensureDirectory,
+  exists,
+  isJsonObject,
+  readFileIfExists,
+  reindexWaitTimeoutMs,
+  runCommand,
+  sha256,
+  toPosixPath,
+} from './utils.js';
 
 const AUTO_REPAIR_STATE_FILE = 'index-auto-repair.json';
 const AUTO_REPAIR_TTL_MS = 6 * 60 * 60 * 1000;
@@ -126,7 +135,11 @@ export async function repairStaleRecallIndex(
     const result = await runCommand(
       ov,
       withIdentity(config, ['reindex', target.uri, '--mode', 'semantic_and_vectors', '--wait', 'true']),
-      {allowFailure: true},
+      // Bound the wait: `ov reindex` has no --timeout, so a stuck/poisoned
+      // semantic queue would block each target for the full 10-min command
+      // timeout. A timed-out target counts as a failure and trips the
+      // consecutive-failure stop instead of hanging the whole repair.
+      {allowFailure: true, timeoutMs: reindexWaitTimeoutMs()},
     );
     if (result.exitCode === 0) {
       consecutiveFailures = 0;

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -1937,8 +1937,9 @@ async function runOpenVikingMcpTool(
     const transport = new StreamableHTTPClientTransport(new URL(config.openVikingMcpUrl), {
       requestInit: {
         headers: {
+          // OpenViking 0.4.x dropped agent_id as an identity input; only
+          // account + user are honored (mirrors withIdentity in runtime.ts).
           'X-OpenViking-Account': config.account,
-          'X-OpenViking-Agent': config.agentId,
           'X-OpenViking-User': config.user,
         },
       },

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -64,7 +64,11 @@ export interface AgentIdentity {
 }
 
 export function withIdentity(config: AgentIdentity, args: readonly string[]): readonly string[] {
-  return [...args, '--account', config.account, '--user', config.user, '--agent-id', config.agentId];
+  // OpenViking 0.4.x removed the `--agent-id` CLI flag (every subcommand rejects
+  // it with "Unexpected argument"); identity is now just account + user, and the
+  // legacy agent_id maps to a request-level peer shim that the CLI no longer
+  // takes. Passing it broke every `ov` call (recall included) on 0.4.4.
+  return [...args, '--account', config.account, '--user', config.user];
 }
 
 export function renderTemplate(

--- a/src/share.ts
+++ b/src/share.ts
@@ -37,6 +37,7 @@ import {
   parseJsonConfigObject,
   portablePath,
   readFileIfExists,
+  reindexWaitTimeoutMs,
   removePath,
   requiredExecutable,
   runCommand,
@@ -3567,10 +3568,14 @@ async function refreshMemoryIndex(
   // This runs after a successful file write. OpenViking's semantic memory
   // reindex path expects a directory URI, but vectors_only supports memory
   // files and refreshes the leaf recall records without poisoning the queue.
+  // `ov reindex` has no --timeout and --wait true blocks on the whole queue,
+  // so a stuck/poisoned semantic queue would otherwise hang this inline call
+  // for the full 10-min command timeout; reindexWaitTimeoutMs bounds it (the
+  // write already succeeded, so a timed-out refresh only defers freshness).
   const result = await runCommand(
     ov,
     withIdentity(config, ['reindex', uri, '--mode', 'vectors_only', '--wait', 'true']),
-    {allowFailure: true},
+    {allowFailure: true, timeoutMs: reindexWaitTimeoutMs()},
   );
   if (result.exitCode === 0) {
     if (options.quiet !== true && result.stdout.trim()) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -316,6 +316,20 @@ function defaultCommandTimeoutMs(): number {
   return positiveIntegerFromEnv('THREADNOTE_COMMAND_TIMEOUT_MS') ?? 10 * 60 * 1000;
 }
 
+/**
+ * Upper bound (ms) for an `ov reindex --wait true` call. `ov reindex` has no
+ * `--timeout` flag, so without a client-side bound a stuck or poisoned semantic
+ * queue makes the wait block until the 10-minute default command timeout — the
+ * AGFS memory-reindex hang (a `context_type=memory` queue entry pointed at a
+ * memory *file* fails on `ls`, re-enqueues forever, and starves the queue). A
+ * healthy memory reindex finishes well under this bound; if it doesn't, the
+ * queue is stuck and we bail rather than hang (the write already succeeded).
+ * Override with THREADNOTE_REINDEX_TIMEOUT_MS.
+ */
+export function reindexWaitTimeoutMs(): number {
+  return positiveIntegerFromEnv('THREADNOTE_REINDEX_TIMEOUT_MS') ?? 120_000;
+}
+
 function defaultCommandMaxOutputBytes(): number {
   return positiveIntegerFromEnv('THREADNOTE_COMMAND_MAX_OUTPUT_BYTES') ?? 5 * 1024 * 1024;
 }

--- a/test/unit/index_repair.test.ts
+++ b/test/unit/index_repair.test.ts
@@ -77,7 +77,7 @@ describe('recall index auto repair', () => {
         '--mode',
         'semantic_and_vectors',
       ]),
-      {allowFailure: true},
+      expect.objectContaining({allowFailure: true, timeoutMs: 120_000}),
     );
   });
 

--- a/test/unit/runtime.test.ts
+++ b/test/unit/runtime.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, it} from 'vitest';
+import {withIdentity} from '../../src/runtime.js';
+
+const IDENTITY = {account: 'local', agentId: 'threadnote', user: 'denys'} as const;
+
+describe('withIdentity', () => {
+  it('appends only account and user (OpenViking 0.4.x removed the --agent-id flag)', () => {
+    expect(withIdentity(IDENTITY, ['find', 'query'])).toEqual([
+      'find',
+      'query',
+      '--account',
+      'local',
+      '--user',
+      'denys',
+    ]);
+  });
+
+  it('never passes --agent-id, which 0.4.x rejects with "Unexpected argument"', () => {
+    expect(withIdentity(IDENTITY, ['search', 'q'])).not.toContain('--agent-id');
+    expect(withIdentity(IDENTITY, ['search', 'q'])).not.toContain('threadnote');
+  });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -29,6 +29,7 @@ import {
   parseJsonConfigObject,
   recallQueryRequestsWorkspaceContext,
   redactText,
+  reindexWaitTimeoutMs,
   runCommand,
   runInteractive,
   shellQuote,
@@ -80,6 +81,35 @@ describe('compareVersions', () => {
     expect(compareVersions('0.4.4', '0.4.4.post1')).toBeLessThan(0);
     expect(compareVersions('0.4.4rc1', '0.4.4')).toBeLessThan(0);
     expect(compareVersions('0.4.4.dev0', '0.4.4')).toBeLessThan(0);
+  });
+});
+
+describe('reindexWaitTimeoutMs', () => {
+  const ENV = 'THREADNOTE_REINDEX_TIMEOUT_MS';
+  const original = process.env[ENV];
+  afterAll(() => {
+    if (original === undefined) {
+      delete process.env[ENV];
+    } else {
+      process.env[ENV] = original;
+    }
+  });
+
+  it('defaults to a bounded 2-minute wait', () => {
+    delete process.env[ENV];
+    expect(reindexWaitTimeoutMs()).toBe(120_000);
+  });
+
+  it('honors a positive integer override', () => {
+    process.env[ENV] = '30000';
+    expect(reindexWaitTimeoutMs()).toBe(30_000);
+  });
+
+  it('falls back to the default for non-positive or invalid overrides', () => {
+    process.env[ENV] = '0';
+    expect(reindexWaitTimeoutMs()).toBe(120_000);
+    process.env[ENV] = 'nope';
+    expect(reindexWaitTimeoutMs()).toBe(120_000);
   });
 });
 


### PR DESCRIPTION
Two fixes for OpenViking interop, both surfaced after the 1.4.0 / OpenViking 0.4.4 pin.

**Fix 1 — recall (and every `ov` call) broken on OpenViking 0.4.4**

OpenViking 0.4.x removed the `--agent-id` flag from every `ov` subcommand — each rejects it with `Unexpected argument: --agent-id` — and dropped `agent_id` as an HTTP identity input. `withIdentity` appended `--agent-id` to every CLI call and the MCP proxy sent `X-OpenViking-Agent`, so on the 0.4.4 pin every `ov` invocation failed. Reported from a 1.4.0 user:

```
Running: ov search '...' --threshold 0.45 --level 2 --output json --account local --user denyskashkovskyi --agent-id threadnote
WARN recall search failed: ... Unexpected argument: --agent-id.
```

Identity is now `--account` + `--user` only; `config.agentId` stays for the legacy `viking://agent/` read scope and config templates. Verified against ov 0.4.4:

```
ov find "test" --account local --user X --agent-id threadnote   # → Usage: ov find <query>  (rejected)
ov find "test" --account local --user X                          # → {"ok":true,"result":{...}}
```

This is a regression from #40 (the 0.4.4 pin); the compat analysis there trusted the changelog's "agent_id stays a shim" wording, but the 0.4.4 CLI removed the flag, and local `ov` was still 0.3.24 at the time so it wasn't caught empirically.

**Fix 2 — AGFS memory-reindex hang**

A `context_type=memory` semantic queue entry pointed at a memory *file* (e.g. `.../android-dual-host.md`) fails OpenViking's `_process_memory_directory` `ls` ("not a directory"), is caught as transient, and re-enqueued forever — starving the semantic queue:

```
RuntimeError: Failed to list memory directory viking://user/.../coda-mobile-native/android-dual-host.md: Directory not found
```

`ov reindex` has no `--timeout` and `--wait true` blocks on the whole queue, so the post-write refresh (`refreshMemoryIndex`) and recall index repair would block until the 10-minute command timeout (observed ~31 min across an agent's memory ops). `reindexWaitTimeoutMs` (default 120s, override `THREADNOTE_REINDEX_TIMEOUT_MS`) now bounds both reindex waits via `runCommand`'s `timeoutMs`: a healthy reindex finishes well under it; a stuck one bails (the write already succeeded) instead of hanging.

threadnote already stopped *creating* the poison in 1.3.3 (memory files use `vectors_only`, which doesn't enqueue semantic work; `_reindex_memory` only enqueues `context_type=memory` for `semantic_and_vectors`). Clearing an *already*-poisoned queue still needs an OpenViking-side guard (`_process_memory_directory` should skip non-directory URIs) or queue surgery — the entry is AGFS-persisted and survives a server restart. This PR stops threadnote from hanging on it.

**Test plan**
- `npm run typecheck`, `npm run lint`, `npm test` (284 tests / 24 files) green on each commit via husky precommit.
- New tests: `withIdentity` omits `--agent-id` (`runtime.test.ts`); `reindexWaitTimeoutMs` default + env override (`utils.test.ts`); updated index_repair reindex options assertion.
- Fix 1 verified end-to-end against the installed ov 0.4.4 (above).
