### PR TITLE
Add memory project/path consistency: doctor check + shared-replace guard

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -987,8 +987,16 @@ export async function memoryProjectConsistencyCheck(config: RuntimeConfig): Prom
       if (!pathProject) {
         continue;
       }
+      let content: string;
+      try {
+        content = await readFile(join(memoriesRoot, entry), 'utf8');
+      } catch {
+        // Removed mid-walk (concurrent forget/compact/archive) or transiently
+        // unreadable — skip this file rather than aborting the whole check.
+        continue;
+      }
       checked += 1;
-      const frontProject = memoryFrontmatterField(await readFile(join(memoriesRoot, entry), 'utf8'), 'project');
+      const frontProject = memoryFrontmatterField(content, 'project');
       if (frontProject && uriSegment(frontProject) !== pathProject) {
         mismatches.push(`${uri} (frontmatter "${frontProject}" vs path "${pathProject}")`);
       }
@@ -997,7 +1005,7 @@ export async function memoryProjectConsistencyCheck(config: RuntimeConfig): Prom
       return {name, status: 'ok', detail: `${checked} project-scoped memories consistent`};
     }
     const sample = mismatches.slice(0, 3).join('; ');
-    const extra = mismatches.length - Math.min(3, mismatches.length);
+    const extra = Math.max(0, mismatches.length - 3);
     return {
       name,
       status: 'warn',

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,8 +1,8 @@
 import {spawn} from 'node:child_process';
 import {closeSync, openSync} from 'node:fs';
-import {chmod, readFile, realpath, writeFile} from 'node:fs/promises';
+import {chmod, readdir, readFile, realpath, writeFile} from 'node:fs/promises';
 import {platform} from 'node:os';
-import {dirname, join} from 'node:path';
+import {dirname, join, sep} from 'node:path';
 import {stderr as processStderr, stdin as processStdin, stdout as processStdout} from 'node:process';
 import {createInterface} from 'node:readline/promises';
 import yaml from 'js-yaml';
@@ -32,7 +32,7 @@ import {
   repairStaleRecallIndex,
   summaryAutoGenerationDisabled,
 } from './index_repair.js';
-import {readSeedManifest} from './manifest.js';
+import {readSeedManifest, uriSegment} from './manifest.js';
 import {removeMcpConfigs, removeMcpSnippets, resolveMcpClients, runMcpInstall} from './mcp.js';
 import {maybeRunPostUpdateAfterRepair, readOpenVikingCliVersion} from './update.js';
 import {
@@ -74,8 +74,11 @@ import {
   httpGetText,
   isExecutable,
   isJsonObject,
+  isSummarySidecarUri,
   isTcpPortOpen,
   maybeRun,
+  memoryFrontmatterField,
+  memoryUriProjectSegment,
   parseJsonConfigObject,
   readFileIfExists,
   removePath,
@@ -132,6 +135,7 @@ export async function collectDoctorChecks(config: RuntimeConfig, options: Doctor
   checks.push(...(await userAgentInstructionsChecks()));
   checks.push(await manifestCheck(config.manifestPath));
   checks.push(await recallIndexFreshnessCheck(config));
+  checks.push(await memoryProjectConsistencyCheck(config));
   checks.push(await fileCheck(join(toolRoot(), '.threadnoteignore'), 'ignore file'));
   checks.push(await fileCheck(join(toolRoot(), 'config', 'ov.conf.template.json'), 'server config template'));
   checks.push(await fileCheck(join(toolRoot(), 'config', 'ovcli.conf.template.json'), 'cli config template'));
@@ -943,6 +947,66 @@ async function recallIndexFreshnessCheck(config: RuntimeConfig): Promise<DoctorC
     };
   } catch (err: unknown) {
     return {name: 'recall index freshness', status: 'warn', detail: errorMessage(err)};
+  }
+}
+
+/**
+ * Flag memories whose frontmatter `project` disagrees with the project segment
+ * of their storage path. Recall scopes and boosts by the path project, so a
+ * divergence (e.g. a shared memory living under `.../projects/coda/` but tagged
+ * `project: mobile-native`) makes project-aware ranking unreliable. Read-only:
+ * walks the on-disk memories tree and reports; the fix is to re-store the memory
+ * under the correct project (which relocates the file).
+ */
+export async function memoryProjectConsistencyCheck(config: RuntimeConfig): Promise<DoctorCheck> {
+  const name = 'memory project consistency';
+  const memoriesRoot = join(
+    config.agentContextHome,
+    'data',
+    'viking',
+    config.account,
+    'user',
+    uriSegment(config.user),
+    'memories',
+  );
+  try {
+    let entries: string[];
+    try {
+      entries = await readdir(memoriesRoot, {recursive: true});
+    } catch {
+      return {name, status: 'ok', detail: 'no memories directory yet'};
+    }
+    const mismatches: string[] = [];
+    let checked = 0;
+    for (const entry of entries) {
+      if (!entry.endsWith('.md') || isSummarySidecarUri(entry)) {
+        continue;
+      }
+      const uri = `viking://user/${uriSegment(config.user)}/memories/${entry.split(sep).join('/')}`;
+      const pathProject = memoryUriProjectSegment(uri);
+      if (!pathProject) {
+        continue;
+      }
+      checked += 1;
+      const frontProject = memoryFrontmatterField(await readFile(join(memoriesRoot, entry), 'utf8'), 'project');
+      if (frontProject && uriSegment(frontProject) !== pathProject) {
+        mismatches.push(`${uri} (frontmatter "${frontProject}" vs path "${pathProject}")`);
+      }
+    }
+    if (mismatches.length === 0) {
+      return {name, status: 'ok', detail: `${checked} project-scoped memories consistent`};
+    }
+    const sample = mismatches.slice(0, 3).join('; ');
+    const extra = mismatches.length - Math.min(3, mismatches.length);
+    return {
+      name,
+      status: 'warn',
+      detail:
+        `${mismatches.length} memory(ies) whose frontmatter project differs from their storage path; ` +
+        `re-store under the correct project to fix: ${sample}${extra > 0 ? `, +${extra} more` : ''}`,
+    };
+  } catch (err: unknown) {
+    return {name, status: 'warn', detail: errorMessage(err)};
   }
 }
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -873,6 +873,29 @@ async function storeMemory(config: RuntimeConfig, options: StoreMemoryOptions): 
   }
 }
 
+/**
+ * Warn when an in-place shared replacement was asked to change the memory's
+ * project or topic — those are fixed by the storage path, so the request is
+ * ignored to keep frontmatter and path consistent. Compares the caller's value
+ * (normalized via `uriSegment`) against the path-derived segment.
+ */
+function warnOnSharedMetadataDrift(
+  metadata: MemoryMetadata,
+  inferred: {readonly project?: string; readonly topic?: string} | undefined,
+): void {
+  if (inferred?.project && metadata.project && uriSegment(metadata.project) !== inferred.project) {
+    console.log(
+      `WARN keeping shared memory project "${inferred.project}" from its storage path; ignoring requested "${metadata.project}". ` +
+        `To change a shared memory's project, forget it and store a new one under the new project.`,
+    );
+  }
+  if (inferred?.topic && metadata.topic && uriSegment(metadata.topic) !== inferred.topic) {
+    console.log(
+      `WARN keeping shared memory topic "${inferred.topic}" from its storage path; ignoring requested "${metadata.topic}".`,
+    );
+  }
+}
+
 async function storeSharedMemoryReplacement(
   config: RuntimeConfig,
   ov: string,
@@ -888,10 +911,17 @@ async function storeSharedMemoryReplacement(
   }
   const team = await resolveTeam(config, teamName);
   const inferred = sharedMemoryUriParts(config, targetUri);
+  // The file is updated in place at targetUri, so its frontmatter project/topic
+  // must match the path it lives under; otherwise recall's project scoping and
+  // the doctor consistency check disagree with the file's real location. Prefer
+  // the path's values over a differing caller value and warn — changing a shared
+  // memory's project means relocating it (forget + store anew), not editing the
+  // frontmatter of the file at the old path.
+  warnOnSharedMetadataDrift(options.metadata, inferred);
   const metadata: MemoryMetadata = {
     ...options.metadata,
-    project: options.metadata.project ?? inferred?.project,
-    topic: options.metadata.topic ?? inferred?.topic,
+    project: inferred?.project ?? options.metadata.project,
+    topic: inferred?.topic ?? options.metadata.topic,
   };
   const rawMemory = formatMemoryDocument(options.title, metadata, options.bodyText);
   const scrub = applyScrubber(stripPersonalProvenance(rawMemory), {redact: false});

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -875,23 +875,18 @@ async function storeMemory(config: RuntimeConfig, options: StoreMemoryOptions): 
 
 /**
  * Warn when an in-place shared replacement was asked to change the memory's
- * project or topic — those are fixed by the storage path, so the request is
- * ignored to keep frontmatter and path consistent. Compares the caller's value
- * (normalized via `uriSegment`) against the path-derived segment.
+ * project — that is fixed by the storage path, so the request is ignored to keep
+ * frontmatter and path consistent (the divergence the doctor check flags). The
+ * caller's value is normalized via `uriSegment` to match how the path segment
+ * was produced. Topic is left to the existing caller-wins behavior: it is not a
+ * consistency-checked field and the path-derived topic can be a raw multi-segment
+ * value (`a/b`) that must not be slugged into or persisted from here.
  */
-function warnOnSharedMetadataDrift(
-  metadata: MemoryMetadata,
-  inferred: {readonly project?: string; readonly topic?: string} | undefined,
-): void {
+function warnOnSharedProjectDrift(metadata: MemoryMetadata, inferred: {readonly project?: string} | undefined): void {
   if (inferred?.project && metadata.project && uriSegment(metadata.project) !== inferred.project) {
     console.log(
       `WARN keeping shared memory project "${inferred.project}" from its storage path; ignoring requested "${metadata.project}". ` +
         `To change a shared memory's project, forget it and store a new one under the new project.`,
-    );
-  }
-  if (inferred?.topic && metadata.topic && uriSegment(metadata.topic) !== inferred.topic) {
-    console.log(
-      `WARN keeping shared memory topic "${inferred.topic}" from its storage path; ignoring requested "${metadata.topic}".`,
     );
   }
 }
@@ -911,17 +906,17 @@ async function storeSharedMemoryReplacement(
   }
   const team = await resolveTeam(config, teamName);
   const inferred = sharedMemoryUriParts(config, targetUri);
-  // The file is updated in place at targetUri, so its frontmatter project/topic
-  // must match the path it lives under; otherwise recall's project scoping and
-  // the doctor consistency check disagree with the file's real location. Prefer
-  // the path's values over a differing caller value and warn — changing a shared
+  // The file is updated in place at targetUri, so its frontmatter project must
+  // match the path it lives under; otherwise recall's project scoping and the
+  // doctor consistency check disagree with the file's real location. Prefer the
+  // path's project over a differing caller value and warn — changing a shared
   // memory's project means relocating it (forget + store anew), not editing the
-  // frontmatter of the file at the old path.
-  warnOnSharedMetadataDrift(options.metadata, inferred);
+  // frontmatter of the file at the old path. Topic keeps caller-wins semantics.
+  warnOnSharedProjectDrift(options.metadata, inferred);
   const metadata: MemoryMetadata = {
     ...options.metadata,
     project: inferred?.project ?? options.metadata.project,
-    topic: inferred?.topic ?? options.metadata.topic,
+    topic: options.metadata.topic ?? inferred?.topic,
   };
   const rawMemory = formatMemoryDocument(options.title, metadata, options.bodyText);
   const scrub = applyScrubber(stripPersonalProvenance(rawMemory), {redact: false});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -985,7 +985,8 @@ export function memoryUriProjectSegment(uri: string): string | undefined {
 export function memoryFrontmatterField(content: string, field: string): string | undefined {
   const blankLine = content.indexOf('\n\n');
   const header = blankLine < 0 ? content : content.slice(0, blankLine);
-  const match = header.match(new RegExp(`^${escapeRegExp(field)}:\\s*(.+)$`, 'm'));
+  // `[ \t]*` (not `\s*`) so the value cannot span into the next header line.
+  const match = header.match(new RegExp(`^${escapeRegExp(field)}:[ \\t]*(.+)$`, 'm'));
   return match?.[1]?.trim() || undefined;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -948,6 +948,48 @@ export function isExcludedRecallUri(uri: string): boolean {
 }
 
 /**
+ * The project directory segment a memory URI is stored under, or undefined for
+ * kinds that carry no project (preferences, smoke), a directory node, or a
+ * non-memory URI. Shared team memories (`.../memories/shared/<team>/...`) are
+ * de-scoped to their underlying kind first, so both personal and shared layouts
+ * resolve the same way. Used by the doctor project-consistency check to compare
+ * a memory's storage location against its frontmatter `project`.
+ */
+export function memoryUriProjectSegment(uri: string): string | undefined {
+  const marker = '/memories/';
+  const at = uri.indexOf(marker);
+  if (at < 0) {
+    return undefined;
+  }
+  let segments = stripAnchor(uri)
+    .slice(at + marker.length)
+    .split('/')
+    .filter(Boolean);
+  if (segments[0] === 'shared') {
+    segments = segments.slice(2); // drop "shared" and the team name
+  }
+  // durable/handoffs/incidents store <kind>/<status|projects>/<project>/<file…>;
+  // require a file after the project segment so directory nodes are ignored.
+  const [kind, , project, ...rest] = segments;
+  if ((kind === 'durable' || kind === 'handoffs' || kind === 'incidents') && project && rest.length > 0) {
+    return project;
+  }
+  return undefined;
+}
+
+/**
+ * Read a single frontmatter field (e.g. `project`) from a memory document — the
+ * value after `<field>: ` on its own line within the leading header block (the
+ * text before the first blank line). Returns undefined when the field is absent.
+ */
+export function memoryFrontmatterField(content: string, field: string): string | undefined {
+  const blankLine = content.indexOf('\n\n');
+  const header = blankLine < 0 ? content : content.slice(0, blankLine);
+  const match = header.match(new RegExp(`^${escapeRegExp(field)}:\\s*(.+)$`, 'm'));
+  return match?.[1]?.trim() || undefined;
+}
+
+/**
  * Extract the matched resource URIs from `ov grep --output json` stdout, minus
  * summary sidecars. The CLI prints a `cmd: ...` banner before the JSON, so
  * parse from the first line that starts with `{` (robust to braces in the

--- a/test/unit/lifecycle.doctor.test.ts
+++ b/test/unit/lifecycle.doctor.test.ts
@@ -1,0 +1,82 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+import {memoryProjectConsistencyCheck} from '../../src/lifecycle.js';
+import type {RuntimeConfig} from '../../src/types.js';
+
+const homes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+});
+
+async function makeConfig(): Promise<RuntimeConfig> {
+  const home = await mkdtemp(join(tmpdir(), 'threadnote-doctor-'));
+  homes.push(home);
+  return {
+    account: 'local',
+    agentContextHome: home,
+    agentId: 'threadnote',
+    host: '127.0.0.1',
+    manifestPath: join(home, 'manifest.json'),
+    openVikingVersion: '0.0.0',
+    port: 1933,
+    user: 'denyskashkovskyi',
+  };
+}
+
+function memoriesDir(config: RuntimeConfig): string {
+  return join(config.agentContextHome, 'data', 'viking', config.account, 'user', config.user, 'memories');
+}
+
+async function writeMemory(root: string, relPath: string, project: string | undefined): Promise<void> {
+  const full = join(root, relPath);
+  await mkdir(dirname(full), {recursive: true});
+  const header = [
+    'MEMORY',
+    'kind: durable',
+    'status: active',
+    project ? `project: ${project}` : undefined,
+    'topic: t',
+    '',
+    'Body.',
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join('\n');
+  await writeFile(full, header);
+}
+
+describe('memoryProjectConsistencyCheck', () => {
+  it('is ok before any memories exist', async () => {
+    const config = await makeConfig();
+    const check = await memoryProjectConsistencyCheck(config);
+    expect(check.status).toBe('ok');
+    expect(check.detail).toMatch(/no memories directory/);
+  });
+
+  it('flags a memory whose frontmatter project differs from its storage path', async () => {
+    const config = await makeConfig();
+    const root = memoriesDir(config);
+    await writeMemory(root, 'durable/projects/mobile-native/consistent.md', 'mobile-native');
+    await writeMemory(root, 'durable/projects/general/no-project.md', undefined); // absent project → not flagged
+    await writeMemory(root, 'preferences/coding-style.md', 'whatever'); // project-less kind → skipped
+    await writeMemory(root, 'shared/docs-desktop/durable/projects/coda/pagerduty.md', 'mobile-native'); // drift
+
+    const check = await memoryProjectConsistencyCheck(config);
+    expect(check.status).toBe('warn');
+    expect(check.detail).toContain('shared/docs-desktop/durable/projects/coda/pagerduty.md');
+    expect(check.detail).toContain('frontmatter "mobile-native" vs path "coda"');
+    expect(check.detail).toMatch(/^1 memory/); // exactly one divergence
+  });
+
+  it('is ok when every project-scoped memory matches its path', async () => {
+    const config = await makeConfig();
+    const root = memoriesDir(config);
+    await writeMemory(root, 'durable/projects/mobile-native/a.md', 'mobile-native');
+    await writeMemory(root, 'handoffs/active/threadnote/b.md', 'threadnote');
+    const check = await memoryProjectConsistencyCheck(config);
+    expect(check.status).toBe('ok');
+    expect(check.detail).toMatch(/2 project-scoped memories consistent/);
+  });
+});

--- a/test/unit/lifecycle.doctor.test.ts
+++ b/test/unit/lifecycle.doctor.test.ts
@@ -75,8 +75,33 @@ describe('memoryProjectConsistencyCheck', () => {
     const root = memoriesDir(config);
     await writeMemory(root, 'durable/projects/mobile-native/a.md', 'mobile-native');
     await writeMemory(root, 'handoffs/active/threadnote/b.md', 'threadnote');
+    await writeMemory(root, 'incidents/active/coda/c.md', 'coda');
     const check = await memoryProjectConsistencyCheck(config);
     expect(check.status).toBe('ok');
-    expect(check.detail).toMatch(/2 project-scoped memories consistent/);
+    expect(check.detail).toMatch(/3 project-scoped memories consistent/);
+  });
+
+  it('skips non-.md files, summary sidecars, and unreadable entries without flagging', async () => {
+    const config = await makeConfig();
+    const root = memoriesDir(config);
+    await writeMemory(root, 'durable/projects/coda/real.md', 'coda'); // the only real memory
+    await writeMemory(root, 'durable/projects/coda/notes.txt', 'mobile-native'); // not .md → skipped
+    await writeMemory(root, 'durable/projects/coda/.overview.md', 'mobile-native'); // sidecar → skipped
+    await mkdir(join(root, 'durable/projects/coda/isdir.md'), {recursive: true}); // dir → readFile throws, skipped
+    const check = await memoryProjectConsistencyCheck(config);
+    expect(check.status).toBe('ok');
+    expect(check.detail).toMatch(/1 project-scoped memories consistent/);
+  });
+
+  it('caps the reported sample and notes the remainder', async () => {
+    const config = await makeConfig();
+    const root = memoriesDir(config);
+    for (const project of ['a', 'b', 'c', 'd']) {
+      await writeMemory(root, `durable/projects/${project}/m.md`, 'wrong');
+    }
+    const check = await memoryProjectConsistencyCheck(config);
+    expect(check.status).toBe('warn');
+    expect(check.detail).toMatch(/^4 memory/);
+    expect(check.detail).toContain('+1 more');
   });
 });

--- a/test/unit/memory.shared-replace.test.ts
+++ b/test/unit/memory.shared-replace.test.ts
@@ -104,6 +104,32 @@ describe('remember shared replacement', () => {
     expect(output).not.toContain('memories/durable/projects/mobile-native/auth.md --from-file');
   });
 
+  it('keeps the project from the storage path when the caller requests a different one', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: readonly unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+
+    const sharedUri = 'viking://user/denyskashkovskyi/memories/shared/default/durable/projects/mobile-native/auth.md';
+    await runRemember(config, {
+      dryRun: true,
+      kind: 'durable',
+      project: 'coda', // differs from the path project (mobile-native)
+      replace: sharedUri,
+      sourceAgentClient: 'codex',
+      text: 'Updated shared auth memory.',
+    });
+
+    const output = logs.join('\n');
+    // Frontmatter tracks the path, not the differing request — no divergence.
+    expect(output).toContain('project: mobile-native');
+    expect(output).not.toContain('project: coda');
+    expect(output).toContain('keeping shared memory project "mobile-native"');
+    expect(output).toContain('ignoring requested "coda"');
+  });
+
   it('rejects non-durable shared replacements', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);

--- a/test/unit/memory.shared-replace.test.ts
+++ b/test/unit/memory.shared-replace.test.ts
@@ -130,6 +130,29 @@ describe('remember shared replacement', () => {
     expect(output).toContain('ignoring requested "coda"');
   });
 
+  it('does not warn when the caller project matches the storage path', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: readonly unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+
+    const sharedUri = 'viking://user/denyskashkovskyi/memories/shared/default/durable/projects/mobile-native/auth.md';
+    await runRemember(config, {
+      dryRun: true,
+      kind: 'durable',
+      project: 'mobile-native', // matches the path project → no drift
+      replace: sharedUri,
+      sourceAgentClient: 'codex',
+      text: 'Updated shared auth memory.',
+    });
+
+    const output = logs.join('\n');
+    expect(output).toContain('project: mobile-native');
+    expect(output).not.toContain('keeping shared memory project');
+  });
+
   it('rejects non-durable shared replacements', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1056,6 +1056,19 @@ describe('memoryFrontmatterField', () => {
     expect(memoryFrontmatterField(doc, 'repo')).toBeUndefined();
     expect(memoryFrontmatterField('MEMORY\nkind: durable\n\nproject: not-a-header', 'project')).toBeUndefined();
   });
+
+  it('treats a bare (empty-value) field as absent', () => {
+    expect(memoryFrontmatterField('MEMORY\nkind: durable\nproject:\ntopic: t\n\nb', 'project')).toBeUndefined();
+    expect(memoryFrontmatterField('MEMORY\nproject:   \n\nb', 'project')).toBeUndefined();
+  });
+
+  it('does not match a field that is only a prefix of another key', () => {
+    expect(memoryFrontmatterField('MEMORY\nproject_id: coda\n\nb', 'project')).toBeUndefined();
+  });
+
+  it('trims a trailing-whitespace value (memories round-trip through git)', () => {
+    expect(memoryFrontmatterField('MEMORY\nproject: coda   \n\nb', 'project')).toBe('coda');
+  });
 });
 
 describe('isAgentArtifactPackUri', () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -22,6 +22,8 @@ import {
   globToRegExp,
   grepUrisFromJson,
   isAgentArtifactPackUri,
+  memoryFrontmatterField,
+  memoryUriProjectSegment,
   mergeRecallHits,
   parseRecallHits,
   RECALL_LOW_CONFIDENCE_NOTE,
@@ -1013,6 +1015,46 @@ describe('categoryForUri', () => {
     expect(
       categoryForUri('viking://user/me/memories/shared/default/agent-artifacts/skills/claude/reviewer/SKILL.md'),
     ).toBe('skills');
+  });
+});
+
+describe('memoryUriProjectSegment', () => {
+  const u = (path: string): string => `viking://user/me/memories/${path}`;
+  it('extracts the project for personal durable/handoff/incident memories', () => {
+    expect(memoryUriProjectSegment(u('durable/projects/mobile-native/auth.md'))).toBe('mobile-native');
+    expect(memoryUriProjectSegment(u('durable/archived/mobile-native/auth.md'))).toBe('mobile-native');
+    expect(memoryUriProjectSegment(u('handoffs/active/threadnote/foo.md'))).toBe('threadnote');
+    expect(memoryUriProjectSegment(u('incidents/active/coda/bar.md'))).toBe('coda');
+  });
+
+  it('de-scopes shared team memories to the underlying project', () => {
+    expect(memoryUriProjectSegment(u('shared/docs-desktop/durable/projects/coda/pagerduty.md'))).toBe('coda');
+  });
+
+  it('returns undefined for project-less kinds, directory nodes, and non-memory URIs', () => {
+    expect(memoryUriProjectSegment(u('preferences/coding-style.md'))).toBeUndefined();
+    expect(memoryUriProjectSegment(u('preferences/archived/old.md'))).toBeUndefined();
+    expect(memoryUriProjectSegment(u('smoke/active/probe.md'))).toBeUndefined();
+    expect(memoryUriProjectSegment(u('durable/projects/mobile-native'))).toBeUndefined(); // dir node, no file
+    expect(memoryUriProjectSegment('viking://resources/repos/coda/README.md')).toBeUndefined();
+  });
+
+  it('ignores a chunk anchor', () => {
+    expect(memoryUriProjectSegment(u('durable/projects/coda/x.md#chunk_0001'))).toBe('coda');
+  });
+});
+
+describe('memoryFrontmatterField', () => {
+  const doc = ['MEMORY', 'kind: durable', 'status: active', 'project: mobile-native', 'topic: auth', '', 'Body.'].join(
+    '\n',
+  );
+  it('reads a header field from the leading block', () => {
+    expect(memoryFrontmatterField(doc, 'project')).toBe('mobile-native');
+    expect(memoryFrontmatterField(doc, 'topic')).toBe('auth');
+  });
+  it('returns undefined for an absent field and does not read the body', () => {
+    expect(memoryFrontmatterField(doc, 'repo')).toBeUndefined();
+    expect(memoryFrontmatterField('MEMORY\nkind: durable\n\nproject: not-a-header', 'project')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
**Summary**

Recall scopes and boosts by the project segment in a memory's storage path, so a memory whose frontmatter `project` disagrees with that path ranks under the wrong project (or misses a project-scoped pass). Item 8 from the recall relevancy audit: prevent the drift at its source and detect any that already exists.

**Detail**

Root cause of the drift: `storeSharedMemoryReplacement` updates a shared memory in place at its existing `targetUri` but built the frontmatter from `options.metadata.project ?? inferred.project` — so a caller passing a different `project` produced a file that stays under the old path while its frontmatter claims the new project. That is exactly how `.../shared/docs-desktop/durable/projects/coda/docs-desktop-pagerduty-onboarding.md` ended up tagged `project: mobile-native`.

- `storeSharedMemoryReplacement` now takes project/topic from the storage path (`inferred` wins over a differing caller value) and warns, since the file stays put. Changing a shared memory's project means relocating it (forget + store anew), not editing frontmatter at the old path.
- New `memory project consistency` doctor check walks the on-disk memories tree and reports any memory whose frontmatter `project` differs from its path project segment. Read-only. Compares via `uriSegment` so case/slug normalization is not a false positive; skips project-less kinds (preferences, smoke), absent-`project` memories (the `general` default), directory nodes, and summary sidecars.
- New pure helpers in `utils.ts`: `memoryUriProjectSegment` (de-scopes shared team paths, handles durable/handoffs/incidents) and `memoryFrontmatterField`.

**Test plan**

```
npm run test        # 315 pass (25 files); +10 covering the URI/frontmatter
                    # helpers, the shared-replace path-wins guard + warning,
                    # and the doctor check (clean / drift / no-dir cases)
npm run typecheck   # clean (root + test/tsconfig.json)
npm run lint        # clean
```

Ran `threadnote doctor` against the live corpus — the check found exactly the one real divergence and nothing else:

```
WARN memory project consistency: 1 memory(ies) whose frontmatter project differs
from their storage path; re-store under the correct project to fix:
.../shared/docs-desktop/durable/projects/coda/docs-desktop-pagerduty-onboarding.md
(frontmatter "mobile-native" vs path "coda")
```
