### PR TITLE
Finalize Effect 4 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ CLAUDE.md
 AGENTS.md
 .claude/settings.json
 .codex/hooks.json
-
+.context/dev-cycle/

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -45,6 +45,10 @@ Keep these invariants intact:
 - Library workflows return and compose Effects. Do not introduce internal `runPromise`, `runFork`, or repeated runtime
   boundaries.
 - Expected failures belong in typed Effect error channels. Use defects for truly unexpected programmer errors.
+- Use the shared `fromPromise`/`fromSync` adapters in `src/effect/errors.ts` for compatibility helpers; do not add
+  module-local Promise-lifting helpers or a generic Promise bridge in the CLI.
+- Use Effect's `Console` service for application output. Promise compatibility code must use the scoped adapter in
+  `src/effect/console.ts`; raw `console.*` calls are rejected by the architecture tests.
 - Use `Scope` or `acquireRelease` for servers, temporary directories, child processes, and other resources that require
   cleanup.
 - MCP inputs use Effect Schema as the source for types, runtime validation, descriptions, and emitted JSON Schema.

--- a/bin/threadnote-mcp-server.cjs
+++ b/bin/threadnote-mcp-server.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
 void import('../dist/mcp_server.js').catch(err => {
-  console.error(err instanceof Error ? err.message : String(err));
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
   process.exitCode = 1;
 });

--- a/bin/threadnote.cjs
+++ b/bin/threadnote.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
 void import('../dist/threadnote.js').catch(err => {
-  console.error(err instanceof Error ? err.message : String(err));
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
   process.exitCode = 1;
 });

--- a/docs/effect.md
+++ b/docs/effect.md
@@ -22,6 +22,16 @@ upgrades are explicit and must pass the protocol and bundle gates below.
 - Promise-based filesystem and compatibility helpers are lifted with `Effect.tryPromise` at composition points. The
   manager's Node HTTP callback submits request Effects to a scoped `FiberSet` runtime created by its entry Effect, so
   in-flight requests are interrupted when the manager scope closes.
+- Application Promise lifting is centralized in `src/effect/errors.ts`; production modules use its `fromPromise` and
+  `fromSync` adapters with an operation label rather than declaring local copies. The CLI has no generic legacy-Promise
+  command bridge: every command composes an Effect-returning workflow.
+- Application output uses Effect's `Console` service. `src/effect/console.ts` carries the current service across the
+  remaining Promise compatibility boundary and captures scoped output without mutating process-global handlers.
+- Graph manifest reads, seeding, MCP installation, hook installation, lifecycle commands, recall, memory migration,
+  pack I/O, and command execution compose through the application layer. Pure graph parsing, edge resolution, and
+  Markdown rendering remain plain TypeScript.
+- `src/effect/share.ts` is the Effect-facing adapter for the transaction-oriented sharing implementation. This keeps
+  the CLI error channel and runtime boundary uniform while the lower-level rollback callbacks remain Promise-based.
 - Long-lived servers and Effect-owned temporary directories use `Scope`/`acquireRelease`, so interruption closes
   servers and removes staged files.
 

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,4 +1,7 @@
 import {stat} from 'node:fs/promises';
+import {Console, Effect} from 'effect';
+
+const output = Effect.runSync(Console.Console);
 
 const budgets = [
   {bytes: 1_700_000, path: 'dist/threadnote.js'},
@@ -10,7 +13,7 @@ let exceeded = false;
 for (const budget of budgets) {
   const {size} = await stat(budget.path);
   const status = size <= budget.bytes ? 'OK' : 'OVER';
-  console.log(`${status} ${budget.path}: ${size.toLocaleString()} / ${budget.bytes.toLocaleString()} bytes`);
+  output.log(`${status} ${budget.path}: ${size.toLocaleString()} / ${budget.bytes.toLocaleString()} bytes`);
   exceeded ||= size > budget.bytes;
 }
 

--- a/scripts/install-e2e-openviking.mjs
+++ b/scripts/install-e2e-openviking.mjs
@@ -2,6 +2,9 @@ import {spawnSync} from 'node:child_process';
 import {mkdtemp, readFile, rm} from 'node:fs/promises';
 import {platform, tmpdir} from 'node:os';
 import {join, resolve} from 'node:path';
+import {Console, Effect} from 'effect';
+
+const output = Effect.runSync(Console.Console);
 
 const root = resolve(import.meta.dirname, '..');
 const constants = await readFile(resolve(root, 'src', 'constants.ts'), 'utf8');
@@ -20,7 +23,7 @@ if (
   isCompatibleCliVersion(installedVersion, version) &&
   installedServerVersion === version
 ) {
-  console.log(`OpenViking ${version} is already installed for local-bin E2E.`);
+  output.log(`OpenViking ${version} is already installed for local-bin E2E.`);
   process.exit(0);
 }
 
@@ -45,11 +48,11 @@ const args = [
   ...(installed.status === 0 ? ['--force'] : []),
   `openviking[local-embed]==${version}`,
 ];
-console.log(`Installing pinned OpenViking ${version} for local-bin E2E...`);
+output.log(`Installing pinned OpenViking ${version} for local-bin E2E...`);
 let result = spawnSync('uv', args, {cwd: root, stdio: 'inherit'});
 if (result.status !== 0) {
-  console.warn('The prebuilt llama-cpp-python wheel failed; retrying with a local source build.');
-  console.warn('This fallback can take 10-20 minutes.');
+  output.warn('The prebuilt llama-cpp-python wheel failed; retrying with a local source build.');
+  output.warn('This fallback can take 10-20 minutes.');
   const sourceArgs = args.filter((arg, index) => {
     const previous = args[index - 1];
     return (
@@ -85,7 +88,7 @@ if (
     `Expected OpenViking server ${version} and a compatible ${majorMinor(version)}.x CLI after installation, got CLI ${verifiedVersion ?? 'unavailable'} and server ${verifiedServerVersion ?? 'unavailable'}.`,
   );
 }
-console.log(`OpenViking ${version} is ready for local-bin E2E.`);
+output.log(`OpenViking ${version} is ready for local-bin E2E.`);
 
 async function readInstalledCliVersion() {
   const home = await mkdtemp(join(tmpdir(), 'threadnote-e2e-ov-version-'));

--- a/src/cli_ui.ts
+++ b/src/cli_ui.ts
@@ -1,6 +1,7 @@
 import {clearLine, cursorTo} from 'node:readline';
 import {stdout} from 'node:process';
 import {Effect} from 'effect';
+import {consoleOutput} from './effect/console.js';
 
 type ColorName = 'blue' | 'cyan' | 'dim' | 'green' | 'red' | 'yellow';
 
@@ -108,10 +109,10 @@ export interface ProgressIndicator {
 
 export function startProgress(message: string): ProgressIndicator {
   if (stdout.isTTY !== true || process.env.CI !== undefined || process.env.THREADNOTE_NO_SPINNER !== undefined) {
-    console.log(message);
+    consoleOutput.log(message);
     return {
       update(nextMessage: string): void {
-        console.log(nextMessage);
+        consoleOutput.log(nextMessage);
       },
       stop(): void {
         return;

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -1,4 +1,4 @@
-import {Config, Effect, Option, Schema} from 'effect';
+import {Config, Console, Effect, Option, Schema} from 'effect';
 import {Argument, CliError, Command, Flag} from 'effect/unstable/cli';
 import {OPENVIKING_MCP_NAME} from '../constants.js';
 import {runHooksInstall, runPreCompactHook, runSessionStartHook} from '../hooks.js';
@@ -37,7 +37,7 @@ import {
   runShareStatus,
   runShareSync,
   runShareUnpublish,
-} from '../share.js';
+} from './share.js';
 import type {RuntimeConfig} from '../types.js';
 import {maybeNotifyUpdate, runPostUpdate, runUpdate} from '../update.js';
 import {runVersion} from '../version_command.js';
@@ -109,9 +109,6 @@ const argument = (name: string, description: string): Argument.Argument<string> 
 const optionalArgument = (name: string, description: string, fallback: string): Argument.Argument<string> =>
   argument(name, description).pipe(Argument.withDefault(fallback));
 
-const legacy = <A>(operation: string, evaluate: () => Promise<A>): Effect.Effect<A, ApplicationError> =>
-  Effect.tryPromise({try: evaluate, catch: cause => applicationError(operation, cause)});
-
 const root = Command.make('threadnote').pipe(
   Command.withSharedFlags({
     home: optionalString('home', 'Override THREADNOTE_HOME for this invocation'),
@@ -134,12 +131,6 @@ const withRuntimeEffect = <E, R>(
       catch: cause => applicationError('load runtime configuration', cause),
     }).pipe(Effect.flatMap(effect)),
   );
-
-const withRuntimePromise = (
-  operation: string,
-  evaluate: (config: RuntimeConfig) => Promise<void>,
-  manifestOverride?: string,
-) => withRuntimeEffect(config => legacy(operation, () => evaluate(config)), manifestOverride);
 
 const manage = Command.make(
   'manage',
@@ -164,7 +155,7 @@ const doctor = Command.make(
   options =>
     withRuntimeEffect(config =>
       Effect.gen(function* () {
-        yield* legacy('doctor', () => runDoctor(config, options));
+        yield* runDoctor(config, options);
         yield* maybeNotifyUpdate(config, {dryRun: options.dryRun});
       }),
     ),
@@ -185,13 +176,11 @@ const install = Command.make(
   options =>
     withRuntimeEffect(config =>
       Effect.gen(function* () {
-        yield* legacy('install', () => runInstall(config, options));
+        yield* runInstall(config, options);
         if (options.withHooks) {
           for (const agent of ['claude', 'codex', 'cursor', 'copilot'] as const) {
-            yield* Effect.sync(() => console.log(`\n--- ${agent} hooks ---`));
-            yield* legacy(`install ${agent} hooks`, () =>
-              runHooksInstall(config, agent, {apply: !options.dryRun, dryRun: options.dryRun}),
-            );
+            yield* Console.log(`\n--- ${agent} hooks ---`);
+            yield* runHooksInstall(config, agent, {apply: !options.dryRun, dryRun: options.dryRun});
           }
         }
         yield* maybeNotifyUpdate(config, {dryRun: options.dryRun});
@@ -277,7 +266,7 @@ const start = Command.make(
   options =>
     withRuntimeEffect(config =>
       Effect.gen(function* () {
-        yield* legacy('start', () => runStart(config, options));
+        yield* runStart(config, options);
         yield* maybeNotifyUpdate(config, {dryRun: options.dryRun});
       }),
     ),
@@ -286,7 +275,7 @@ const start = Command.make(
 const stop = Command.make(
   'stop',
   {dryRun: boolean('dry-run', 'Print the stop actions without running them')},
-  options => withRuntimePromise('stop', config => runStop(config, options)),
+  options => withRuntimeEffect(config => runStop(config, options)),
 ).pipe(Command.withDescription('Stop the local OpenViking server or LaunchAgent'));
 
 const uninstall = Command.make(
@@ -301,7 +290,7 @@ const uninstall = Command.make(
     ),
     preserveMemories: boolean('preserve-memories', 'Preserve THREADNOTE_HOME and OpenViking memories (default)'),
   },
-  options => withRuntimePromise('uninstall', config => runUninstall(config, options)),
+  options => withRuntimeEffect(config => runUninstall(config, options)),
 ).pipe(Command.withDescription('Remove Threadnote setup and optionally erase local memories'));
 
 const seed = Command.make(
@@ -312,7 +301,7 @@ const seed = Command.make(
     graph: boolean('graph', 'Also seed per-project dependency facts with cross-repo edges'),
     only: repeatedString('only', 'Restrict seeding to one or more manifest projects; repeat for multiple'),
   },
-  options => withRuntimePromise('seed', config => runSeed(config, options)),
+  options => withRuntimeEffect(config => runSeed(config, options)),
 ).pipe(Command.withDescription('Seed curated context from the manifest; never indexes whole repos by default'));
 
 const initManifest = Command.make(
@@ -323,7 +312,7 @@ const initManifest = Command.make(
     replace: boolean('replace', 'Replace the manifest instead of merging with existing projects'),
     repo: repeatedString('repo', 'Repo root to include; repeat for multiple repos'),
   },
-  options => withRuntimePromise('init-manifest', config => runInitManifest(config, options)),
+  options => withRuntimeEffect(config => runInitManifest(config, options)),
 ).pipe(Command.withDescription('Create or update a per-developer seed manifest from one or more repo roots'));
 
 const seedSkills = Command.make(
@@ -332,7 +321,7 @@ const seedSkills = Command.make(
     dryRun: boolean('dry-run', 'Print skill files and ov commands without importing'),
     native: boolean('native', 'Use native OpenViking skill ingestion; requires a working VLM config'),
   },
-  options => withRuntimePromise('seed-skills', config => runSeedSkills(config, options)),
+  options => withRuntimeEffect(config => runSeedSkills(config, options)),
 ).pipe(Command.withDescription('Seed Codex/Claude skills and Claude command markdown files as a searchable catalog'));
 
 const mcpInstall = Command.make(
@@ -349,7 +338,7 @@ const mcpInstall = Command.make(
     toolset: optionalChoice('toolset', ['core', 'full'], 'Stdio adapter toolset'),
     url: optionalString('url', 'OpenViking native HTTP MCP URL'),
   },
-  ({agent, ...options}) => withRuntimePromise('mcp-install', config => runMcpInstall(config, agent, options)),
+  ({agent, ...options}) => withRuntimeEffect(config => runMcpInstall(config, agent, options)),
 ).pipe(Command.withDescription('Install OpenViking MCP config for a supported agent'));
 
 const installHooks = Command.make(
@@ -362,7 +351,7 @@ const installHooks = Command.make(
     dryRun: boolean('dry-run', 'Print the planned change without applying it'),
     remove: boolean('remove', 'Remove threadnote-managed hook entries instead of adding them'),
   },
-  ({agent, ...options}) => withRuntimePromise('install-hooks', config => runHooksInstall(config, agent, options)),
+  ({agent, ...options}) => withRuntimeEffect(config => runHooksInstall(config, agent, options)),
 ).pipe(Command.withDescription('Install deterministic agent lifecycle hooks'));
 
 const preCompactHook = Command.make(
@@ -406,7 +395,7 @@ const migrateMemories = Command.make(
     limit: optionalString('limit', 'Maximum number of memories to migrate'),
     sourceAccount: repeatedString('source-account', 'Source OpenViking account; repeat for multiple accounts'),
   },
-  options => withRuntimePromise('migrate-memories', config => runMigrateMemories(config, options)),
+  options => withRuntimeEffect(config => runMigrateMemories(config, options)),
 ).pipe(Command.withDescription('Migrate legacy session-only memories into durable memory files'));
 
 const migrateLifecycle = Command.make(
@@ -447,15 +436,15 @@ const recall = Command.make(
     uri: optionalString('uri', 'Restrict search to a viking:// URI'),
     workset: optionalString('workset', 'Recall across a named seed-manifest workset'),
   },
-  options => withRuntimePromise('recall', config => runRecall(config, options)),
+  options => withRuntimeEffect(config => runRecall(config, options)),
 ).pipe(Command.withDescription('Search shared OpenViking context'));
 
-const worksetList = Command.make('list', {}, () =>
-  withRuntimePromise('workset list', config => runWorksetList(config)),
-).pipe(Command.withDescription('List worksets defined in the seed manifest'));
+const worksetList = Command.make('list', {}, () => withRuntimeEffect(config => runWorksetList(config))).pipe(
+  Command.withDescription('List worksets defined in the seed manifest'),
+);
 
 const worksetShow = Command.make('show', {name: argument('name', 'Workset name')}, ({name}) =>
-  withRuntimePromise('workset show', config => runWorksetShow(config, name)),
+  withRuntimeEffect(config => runWorksetShow(config, name)),
 ).pipe(Command.withDescription('Show the member projects of a workset'));
 
 const workset = Command.make('workset').pipe(
@@ -478,7 +467,7 @@ const compact = Command.make(
 const read = Command.make(
   'read',
   {dryRun: boolean('dry-run', 'Print ov command without reading'), uri: argument('uri', 'viking:// URI to read')},
-  ({uri, ...options}) => withRuntimePromise('read', config => runRead(config, uri, options)),
+  ({uri, ...options}) => withRuntimeEffect(config => runRead(config, uri, options)),
 ).pipe(Command.withDescription('Read a viking:// URI returned by recall or list'));
 
 const list = Command.make(
@@ -491,7 +480,7 @@ const list = Command.make(
     simple: boolean('simple', 'Print only paths').pipe(Flag.withAlias('s')),
     uri: optionalArgument('uri', 'viking:// directory URI', 'viking://'),
   },
-  ({uri, ...options}) => withRuntimePromise('list', config => runList(config, uri, options)),
+  ({uri, ...options}) => withRuntimeEffect(config => runList(config, uri, options)),
 ).pipe(Command.withDescription('List a viking:// directory'), Command.withAlias('ls'));
 
 const handoff = Command.make(
@@ -542,13 +531,13 @@ const shareInit = Command.make(
     setDefault: boolean('set-default', 'Mark this team as the default'),
     team: optionalString('team', 'Team name; defaults to default'),
   },
-  ({remoteUrl, ...options}) => withRuntimePromise('share init', config => runShareInit(config, remoteUrl, options)),
+  ({remoteUrl, ...options}) => withRuntimeEffect(config => runShareInit(config, remoteUrl, options)),
 ).pipe(Command.withDescription('Configure a shared memories repo for a team'));
 
 const shareStatus = Command.make(
   'status',
   {dryRun: boolean('dry-run', 'Print git commands'), team: optionalString('team', 'Team name')},
-  options => withRuntimePromise('share status', config => runShareStatus(config, options)),
+  options => withRuntimeEffect(config => runShareStatus(config, options)),
 ).pipe(Command.withDescription('Show git status and ahead/behind counts for a shared team'));
 
 const shareSync = Command.make(
@@ -560,13 +549,13 @@ const shareSync = Command.make(
     push: negatedBoolean('push', 'Skip the push step'),
     team: optionalString('team', 'Team name; omit to sync all teams'),
   },
-  options => withRuntimePromise('share sync', config => runShareSync(config, options)),
+  options => withRuntimeEffect(config => runShareSync(config, options)),
 ).pipe(Command.withDescription('Pull, reindex, and push shared memories repos'));
 
 const shareConflicts = Command.make(
   'conflicts',
   {team: optionalString('team', 'Team name; defaults to all teams')},
-  options => withRuntimePromise('share conflicts', config => runShareConflicts(config, options)),
+  options => withRuntimeEffect(config => runShareConflicts(config, options)),
 ).pipe(Command.withDescription('List pending shared memory conflicts'));
 
 const conflictShow = Command.make(
@@ -575,8 +564,7 @@ const conflictShow = Command.make(
     conflictId: argument('conflict-id', 'Conflict id, relative path, or shared viking:// URI'),
     team: optionalString('team', 'Team name for a relative path'),
   },
-  ({conflictId, ...options}) =>
-    withRuntimePromise('share conflict show', config => runShareConflictShow(config, conflictId, options)),
+  ({conflictId, ...options}) => withRuntimeEffect(config => runShareConflictShow(config, conflictId, options)),
 ).pipe(Command.withDescription('Show local/shared content for one conflict'));
 
 const conflictResolve = Command.make(
@@ -590,8 +578,7 @@ const conflictResolve = Command.make(
     take: optionalChoice('take', ['shared', 'local'], 'Resolution side'),
     team: optionalString('team', 'Team name for a relative path'),
   },
-  ({conflictId, ...options}) =>
-    withRuntimePromise('share conflict resolve', config => runShareConflictResolve(config, conflictId, options)),
+  ({conflictId, ...options}) => withRuntimeEffect(config => runShareConflictResolve(config, conflictId, options)),
 ).pipe(Command.withDescription('Resolve one pending shared memory conflict'));
 
 const shareConflict = Command.make('conflict').pipe(
@@ -611,7 +598,7 @@ const publishFlags = {
 const sharePublish = Command.make(
   'publish',
   {...publishFlags, uri: argument('viking-uri', 'Personal viking:// memory URI')},
-  ({uri, ...options}) => withRuntimePromise('share publish', config => runSharePublish(config, uri, options)),
+  ({uri, ...options}) => withRuntimeEffect(config => runSharePublish(config, uri, options)),
 ).pipe(Command.withDescription('Move a personal memory into the shared team namespace, commit and push'));
 
 const artifactFlags = {
@@ -626,15 +613,13 @@ const artifactFlags = {
 const sharePublishArtifact = Command.make(
   'publish-artifact',
   {...artifactFlags, path: argument('path', 'Path to SKILL.md or a Claude command file')},
-  ({path, ...options}) =>
-    withRuntimePromise('share publish-artifact', config => runSharePublishArtifact(config, path, options)),
+  ({path, ...options}) => withRuntimeEffect(config => runSharePublishArtifact(config, path, options)),
 ).pipe(Command.withDescription('Publish a local agent skill or command into the shared team repo'));
 
 const sharePublishBundle = Command.make(
   'publish-bundle',
   {...artifactFlags, manifest: argument('manifest', 'Path to a threadnote-bundle.json manifest')},
-  ({manifest, ...options}) =>
-    withRuntimePromise('share publish-bundle', config => runSharePublishBundle(config, manifest, options)),
+  ({manifest, ...options}) => withRuntimeEffect(config => runSharePublishBundle(config, manifest, options)),
 ).pipe(Command.withDescription('Publish a multi-skill constellation declared by a bundle manifest'));
 
 const shareInstallArtifacts = Command.make(
@@ -649,7 +634,7 @@ const shareInstallArtifacts = Command.make(
     sync: negatedBoolean('sync', 'Skip pulling shared updates first'),
     team: optionalString('team', 'Team name'),
   },
-  options => withRuntimePromise('share install-artifacts', config => runShareInstallArtifacts(config, options)),
+  options => withRuntimeEffect(config => runShareInstallArtifacts(config, options)),
 ).pipe(Command.withDescription('Install shared agent skills and commands from a team repo'));
 
 const shareUnpublish = Command.make(
@@ -661,11 +646,11 @@ const shareUnpublish = Command.make(
     team: optionalString('team', 'Team name'),
     uri: argument('viking-uri', 'Shared viking:// memory URI'),
   },
-  ({uri, ...options}) => withRuntimePromise('share unpublish', config => runShareUnpublish(config, uri, options)),
+  ({uri, ...options}) => withRuntimeEffect(config => runShareUnpublish(config, uri, options)),
 ).pipe(Command.withDescription('Pull a shared memory back into the personal namespace'));
 
 const shareList = Command.make('list', {dryRun: boolean('dry-run', 'Print without side effects')}, options =>
-  withRuntimePromise('share list', config => runShareList(config, options)),
+  withRuntimeEffect(config => runShareList(config, options)),
 ).pipe(Command.withDescription('List configured shared teams'));
 
 const shareRename = Command.make(
@@ -675,7 +660,7 @@ const shareRename = Command.make(
     team: requiredString('team', 'Existing team name'),
     to: requiredString('to', 'New team name'),
   },
-  options => withRuntimePromise('share rename', config => runShareRename(config, options)),
+  options => withRuntimeEffect(config => runShareRename(config, options)),
 ).pipe(Command.withDescription('Rename a configured shared team'));
 
 const shareSetUrl = Command.make(
@@ -685,8 +670,7 @@ const shareSetUrl = Command.make(
     remoteUrl: argument('remote-url', 'New git remote URL'),
     team: optionalString('team', 'Team name'),
   },
-  ({remoteUrl, ...options}) =>
-    withRuntimePromise('share set-url', config => runShareSetUrl(config, remoteUrl, options)),
+  ({remoteUrl, ...options}) => withRuntimeEffect(config => runShareSetUrl(config, remoteUrl, options)),
 ).pipe(Command.withDescription('Change a shared team git remote URL'));
 
 const shareRemove = Command.make(
@@ -697,7 +681,7 @@ const shareRemove = Command.make(
     preserveLocal: boolean('preserve-local', 'Copy durable memories into the personal tree first'),
     team: optionalString('team', 'Team name'),
   },
-  options => withRuntimePromise('share remove', config => runShareRemove(config, options)),
+  options => withRuntimeEffect(config => runShareRemove(config, options)),
 ).pipe(Command.withDescription('Forget a configured team and optionally delete its files'));
 
 const share = Command.make('share').pipe(
@@ -727,7 +711,7 @@ const exportPack = Command.make(
     path: optionalString('path', 'Output .ovpack path'),
     uri: optionalString('uri', 'Source viking:// URI; defaults to the current user memories'),
   },
-  options => withRuntimePromise('export-pack', config => runExportPack(config, options)),
+  options => withRuntimeEffect(config => runExportPack(config, options)),
 ).pipe(Command.withDescription('Export local OpenViking context to an .ovpack'));
 
 const importPack = Command.make(
@@ -737,7 +721,7 @@ const importPack = Command.make(
     path: requiredString('path', 'Input .ovpack path'),
     targetUri: optionalString('target-uri', 'Target parent viking:// URI; defaults to the current user'),
   },
-  options => withRuntimePromise('import-pack', config => runImportPack(config, options)),
+  options => withRuntimeEffect(config => runImportPack(config, options)),
 ).pipe(Command.withDescription('Import an .ovpack into local OpenViking context'));
 
 export const threadnoteCommand = root.pipe(

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -1,6 +1,8 @@
 import {execFile, type ChildProcess} from 'node:child_process';
 import {basename} from 'node:path';
-import {Context, Effect, Layer, Schema} from 'effect';
+import {Console, Context, Effect, Layer, Schema} from 'effect';
+import {command as commandText, info, warning} from '../cli_ui.js';
+import {redactSensitiveText} from '../scrubber.js';
 import type {CommandResult} from '../types.js';
 
 export interface CommandOptions {
@@ -66,6 +68,28 @@ export const runCommandEffect = Effect.fn('runCommandEffect')(function* (
   return yield* command.execute(executable, args, options);
 });
 
+export const maybeRunEffect = Effect.fn('maybeRunEffect')(function* (
+  dryRun: boolean,
+  executable: string,
+  args: readonly string[],
+  options: Pick<CommandOptions, 'allowFailure' | 'cwd'> = {},
+) {
+  const cwdSuffix = options.cwd ? ` (cwd: ${options.cwd})` : '';
+  const label = dryRun ? warning('Would run') : info('Running');
+  yield* Console.log(`${label}: ${commandText(formatShellCommand(executable, args))}${cwdSuffix}`);
+  if (dryRun) {
+    return undefined;
+  }
+  const result = yield* runCommandEffect(executable, args, options);
+  if (result.stdout.trim()) {
+    yield* Console.log(result.stdout.trim());
+  }
+  if (result.stderr.trim()) {
+    yield* Console.error(result.stderr.trim());
+  }
+  return result;
+});
+
 const executeCommand = Effect.fn('CommandExecutor.execute')((
   executable: string,
   args: readonly string[],
@@ -73,7 +97,9 @@ const executeCommand = Effect.fn('CommandExecutor.execute')((
 ) => {
   const maxOutputBytes = options.maxOutputBytes ?? commandMaxOutputBytes();
   const timeoutMs = options.timeoutMs ?? commandTimeoutMs();
-  const command = formatCommand(executable, args);
+  const command = formatShellCommand(executable, args);
+  const safeArgs = redactCommandArgs(args);
+  const safeExecutable = redactSensitiveText(executable);
   const run = Effect.callback<CommandResult, CommandExecutionError>(resume => {
     let child: ChildProcess | undefined;
     let finished = false;
@@ -127,31 +153,31 @@ const executeCommand = Effect.fn('CommandExecutor.execute')((
           const error = cause as Error & {readonly code?: number | string};
           if (error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
             const outputError = new CommandOutputLimitExceeded({
-              args: [...args],
-              executable,
+              args: safeArgs,
+              executable: safeExecutable,
               maxOutputBytes,
-              message: `${formatCommand(executable, args)} exceeded output limit of ${maxOutputBytes} bytes`,
+              message: `${command} exceeded output limit of ${maxOutputBytes} bytes`,
             });
             complete({exitCode: 124, stderr: outputError.message, stdout}, outputError);
             return;
           }
           if (typeof error.code !== 'number') {
             const spawnError = new CommandSpawnFailed({
-              args: [...args],
-              cause,
-              executable,
-              message: `${formatCommand(executable, args)} failed to start: ${error.message}`,
+              args: safeArgs,
+              cause: redactedError(error),
+              executable: safeExecutable,
+              message: redactSensitiveText(`${command} failed to start: ${error.message}`),
             });
             complete({exitCode: 127, stderr: error.message, stdout}, spawnError);
             return;
           }
           const failed = new CommandFailed({
-            args: [...args],
-            executable,
+            args: safeArgs,
+            executable: safeExecutable,
             exitCode: error.code,
-            message: `${formatCommand(executable, args)} failed: ${stderr || stdout}`,
-            stderr,
-            stdout,
+            message: redactSensitiveText(`${command} failed: ${stderr || stdout}`),
+            stderr: redactSensitiveText(stderr),
+            stdout: redactSensitiveText(stdout),
           });
           complete({exitCode: error.code, stderr, stdout}, failed);
         },
@@ -159,10 +185,10 @@ const executeCommand = Effect.fn('CommandExecutor.execute')((
     } catch (cause: unknown) {
       const error = cause instanceof Error ? cause : new Error(String(cause));
       const spawnError = new CommandSpawnFailed({
-        args: [...args],
-        cause,
-        executable,
-        message: `${formatCommand(executable, args)} failed to start: ${error.message}`,
+        args: safeArgs,
+        cause: redactedError(error),
+        executable: safeExecutable,
+        message: redactSensitiveText(`${command} failed to start: ${error.message}`),
       });
       complete({exitCode: 127, stderr: error.message, stdout: ''}, spawnError);
     }
@@ -178,8 +204,8 @@ const executeCommand = Effect.fn('CommandExecutor.execute')((
     return run;
   }
   const timedOut = new CommandTimedOut({
-    args: [...args],
-    executable,
+    args: safeArgs,
+    executable: safeExecutable,
     message: `${command} timed out after ${timeoutMs}ms`,
     timeoutMs,
   });
@@ -217,6 +243,17 @@ function commandEnvironment(executable: string, env: NodeJS.ProcessEnv | undefin
   return basename(executable) === 'git' ? withoutGitEnvironment(env ?? process.env) : env;
 }
 
+export function formatShellCommand(executable: string, args: readonly string[]): string {
+  return redactSensitiveText([executable, ...args].map(shellQuote).join(' '));
+}
+
+export function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:@=-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
 export function commandTimeoutMs(): number {
   return positiveIntegerFromEnv('THREADNOTE_COMMAND_TIMEOUT_MS') ?? 10 * 60 * 1000;
 }
@@ -234,6 +271,14 @@ function positiveIntegerFromEnv(name: string): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-function formatCommand(executable: string, args: readonly string[]): string {
-  return [executable, ...args].join(' ');
+function redactCommandArgs(args: readonly string[]): readonly string[] {
+  const combined = args.join(' ');
+  if (redactSensitiveText(combined) !== combined) {
+    return ['[REDACTED]'];
+  }
+  return args.map(redactSensitiveText);
+}
+
+function redactedError(error: Error): Error {
+  return new Error(redactSensitiveText(error.message));
 }

--- a/src/effect/console.ts
+++ b/src/effect/console.ts
@@ -1,0 +1,84 @@
+import {AsyncLocalStorage} from 'node:async_hooks';
+import {Console, Effect} from 'effect';
+
+const consoleScope = new AsyncLocalStorage<Console.Console>();
+
+type OutputMethod = 'debug' | 'error' | 'info' | 'log' | 'warn';
+
+function forward(method: OutputMethod, args: readonly unknown[]): void {
+  const service = consoleScope.getStore();
+  if (!service) {
+    throw new Error('Console output escaped its Effect Console scope.');
+  }
+  service[method](...args);
+}
+
+/**
+ * Synchronous view of the current Effect Console service for Promise-based
+ * compatibility code. New Effect code should use Console.log / warn / error
+ * directly; fromPromise installs this scope at the compatibility boundary.
+ */
+export const consoleOutput = {
+  debug: (...args: readonly unknown[]) => forward('debug', args),
+  error: (...args: readonly unknown[]) => forward('error', args),
+  info: (...args: readonly unknown[]) => forward('info', args),
+  log: (...args: readonly unknown[]) => forward('log', args),
+  warn: (...args: readonly unknown[]) => forward('warn', args),
+} as const;
+
+export function runWithConsole<A>(service: Console.Console, evaluate: () => A): A {
+  return consoleScope.run(service, evaluate);
+}
+
+export function syncWithConsole<A>(evaluate: () => A): Effect.Effect<A> {
+  return Console.consoleWith(service => Effect.sync(() => runWithConsole(service, evaluate)));
+}
+
+function capturingConsole(parent: Console.Console, lines: string[]): Console.Console {
+  const append = (...args: readonly unknown[]): void => {
+    lines.push(args.map(String).join(' '));
+  };
+  return Object.assign(Object.create(parent) as Console.Console, {
+    error: append,
+    log: append,
+    warn: append,
+  });
+}
+
+export function tryPromiseWithConsole<A, E>(options: {
+  readonly catch: (cause: unknown) => E;
+  readonly try: () => PromiseLike<A>;
+}): Effect.Effect<A, E> {
+  return Console.consoleWith(service =>
+    Effect.tryPromise({
+      catch: options.catch,
+      try: () => runWithConsole(service, options.try),
+    }),
+  );
+}
+
+export function captureConsole<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<{readonly output: string; readonly value: A}, E, R> {
+  return Console.consoleWith(parent => {
+    const lines: string[] = [];
+    const service = capturingConsole(parent, lines);
+    return effect.pipe(
+      Effect.provideService(Console.Console, service),
+      Effect.map(value => ({output: lines.join('\n'), value})),
+    );
+  });
+}
+
+export async function capturePromiseConsole<A>(
+  evaluate: () => Promise<A>,
+): Promise<{readonly output: string; readonly value: A}> {
+  const parent = consoleScope.getStore();
+  if (!parent) {
+    throw new Error('Console capture escaped its Effect Console scope.');
+  }
+  const lines: string[] = [];
+  const service = capturingConsole(parent, lines);
+  const value = await runWithConsole(service, evaluate);
+  return {output: lines.join('\n'), value};
+}

--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -1,4 +1,5 @@
-import {Schema} from 'effect';
+import {Effect, Schema} from 'effect';
+import {tryPromiseWithConsole} from './console.js';
 
 export class ApplicationError extends Schema.TaggedErrorClass<ApplicationError>()('ApplicationError', {
   cause: Schema.Defect(),
@@ -13,3 +14,15 @@ export function applicationError(operation: string, cause: unknown): Application
     operation,
   });
 }
+
+export const fromPromise = <A>(operation: string, evaluate: () => Promise<A>) =>
+  tryPromiseWithConsole({try: evaluate, catch: cause => applicationError(operation, cause)});
+
+export const fromPromiseError = <A>(evaluate: () => PromiseLike<A>) =>
+  tryPromiseWithConsole({
+    try: evaluate,
+    catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
+  });
+
+export const fromSync = <A>(operation: string, evaluate: () => A) =>
+  Effect.try({try: evaluate, catch: cause => applicationError(operation, cause)});

--- a/src/effect/mcp.ts
+++ b/src/effect/mcp.ts
@@ -1,6 +1,8 @@
 import {NodeStdio} from '@effect/platform-node';
-import {Context, Effect, Layer, Logger, Schema, Sink, Stdio} from 'effect';
+import {Console, Context, Effect, Layer, Logger, Schema, Sink, Stdio} from 'effect';
 import {McpSchema, McpServer} from 'effect/unstable/ai';
+import {runWithConsole} from './console.js';
+import {fromPromiseError} from './errors.js';
 import type {ApplicationServices} from './runtime.js';
 
 interface ToolAnnotations {
@@ -88,16 +90,7 @@ export class EffectMcpServerAdapter {
                   }),
                 );
               }
-              const effect = Effect.try({
-                try: () => registration.handle(parsed),
-                catch: normalizeError,
-              }).pipe(
-                Effect.flatMap(handled =>
-                  Effect.try({try: () => toolHandlerEffect(handled, applicationServices), catch: normalizeError}).pipe(
-                    Effect.flatten,
-                  ),
-                ),
-              );
+              const effect = toolHandlerEffect(() => registration.handle(parsed), applicationServices);
               return effect.pipe(
                 Effect.match({
                   onFailure: error =>
@@ -159,16 +152,26 @@ function flattenJsonSchemaConstraints(value: unknown): unknown {
 }
 
 function toolHandlerEffect(
-  handled: ToolHandlerResult,
+  evaluate: () => ToolHandlerResult,
   applicationServices: Context.Context<ApplicationServices>,
 ): Effect.Effect<ToolResult, unknown> {
-  if (Effect.isEffect(handled)) {
-    return handled.pipe(Effect.provideContext(applicationServices));
-  }
-  if (isPromiseLike(handled)) {
-    return Effect.tryPromise({try: () => Promise.resolve(handled), catch: normalizeError});
-  }
-  return Effect.succeed(handled);
+  return Console.consoleWith(output =>
+    Effect.suspend(() => {
+      let handled: ToolHandlerResult;
+      try {
+        handled = runWithConsole(output, evaluate);
+      } catch (cause: unknown) {
+        return Effect.fail(normalizeError(cause));
+      }
+      if (Effect.isEffect(handled)) {
+        return handled.pipe(Effect.provideContext(applicationServices));
+      }
+      if (isPromiseLike(handled)) {
+        return fromPromiseError(() => Promise.resolve(handled));
+      }
+      return Effect.succeed(handled);
+    }),
+  );
 }
 
 function isPromiseLike(value: unknown): value is PromiseLike<ToolResult> {

--- a/src/effect/share.ts
+++ b/src/effect/share.ts
@@ -1,0 +1,50 @@
+import {fromPromise} from './errors.js';
+import {
+  installSharedAgentArtifacts as installSharedAgentArtifactsPromise,
+  listSharedAgentArtifacts as listSharedAgentArtifactsPromise,
+  removeMemoryUri as removeMemoryUriPromise,
+  resolveShareConflict as resolveShareConflictPromise,
+  runShareConflictResolve as runShareConflictResolvePromise,
+  runShareConflicts as runShareConflictsPromise,
+  runShareConflictShow as runShareConflictShowPromise,
+  runShareInit as runShareInitPromise,
+  runShareInstallArtifacts as runShareInstallArtifactsPromise,
+  runShareList as runShareListPromise,
+  runSharePublish as runSharePublishPromise,
+  runSharePublishArtifact as runSharePublishArtifactPromise,
+  runSharePublishBundle as runSharePublishBundlePromise,
+  runShareRemove as runShareRemovePromise,
+  runShareRename as runShareRenamePromise,
+  runShareSetUrl as runShareSetUrlPromise,
+  runShareStatus as runShareStatusPromise,
+  runShareSync as runShareSyncPromise,
+  runShareUnpublish as runShareUnpublishPromise,
+} from '../share.js';
+
+const effectify =
+  <Args extends readonly unknown[], A>(operation: string, evaluate: (...args: Args) => Promise<A>) =>
+  (...args: Args) =>
+    fromPromise(operation, () => evaluate(...args));
+
+export const runShareInit = effectify('initialize shared memory repository', runShareInitPromise);
+export const runShareStatus = effectify('read shared memory status', runShareStatusPromise);
+export const runShareSync = effectify('synchronize shared memory repository', runShareSyncPromise);
+export const runShareConflicts = effectify('list shared memory conflicts', runShareConflictsPromise);
+export const runShareConflictShow = effectify('show shared memory conflict', runShareConflictShowPromise);
+export const runShareConflictResolve = effectify('resolve shared memory conflict', runShareConflictResolvePromise);
+export const runSharePublish = effectify('publish shared memory', runSharePublishPromise);
+export const runSharePublishArtifact = effectify('publish shared artifact', runSharePublishArtifactPromise);
+export const runSharePublishBundle = effectify('publish shared artifact bundle', runSharePublishBundlePromise);
+export const runShareInstallArtifacts = effectify('install shared artifacts', runShareInstallArtifactsPromise);
+export const runShareUnpublish = effectify('unpublish shared memory', runShareUnpublishPromise);
+export const runShareList = effectify('list shared memory teams', runShareListPromise);
+export const runShareRename = effectify('rename shared memory team', runShareRenamePromise);
+export const runShareSetUrl = effectify('set shared memory remote URL', runShareSetUrlPromise);
+export const runShareRemove = effectify('remove shared memory team', runShareRemovePromise);
+export const resolveShareConflict = effectify('resolve shared memory conflict', resolveShareConflictPromise);
+export const listSharedAgentArtifacts = effectify('list shared agent artifacts', listSharedAgentArtifactsPromise);
+export const installSharedAgentArtifacts = effectify(
+  'install shared agent artifacts',
+  installSharedAgentArtifactsPromise,
+);
+export const removeMemoryUri = effectify('remove shared memory', removeMemoryUriPromise);

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,5 +1,5 @@
-import {readFile} from 'node:fs/promises';
 import {join} from 'node:path';
+import {Effect, FileSystem} from 'effect';
 
 export interface DependencyFacts {
   readonly dependencies: readonly string[];
@@ -13,13 +13,15 @@ export interface GraphEdge {
   readonly project: string;
 }
 
-async function readIfExists(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, 'utf8');
-  } catch {
-    return undefined;
-  }
-}
+const readIfExists = Effect.fn('graph.readIfExists')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readFileString(path).pipe(
+    Effect.catchIf(
+      error => error.reason._tag === 'NotFound',
+      () => Effect.succeed(undefined),
+    ),
+  );
+});
 
 function parsePackageJson(
   content: string,
@@ -88,37 +90,39 @@ function parseGoMod(content: string): {readonly dependencies: readonly string[];
  * Deterministic formats only (npm package.json + go.mod) so we never emit wrong
  * edges; unparseable files are ignored. No AST, lockfiles, or API analysis.
  */
-export async function extractDependencyFacts(projectRoot: string): Promise<DependencyFacts> {
-  const dependencies = new Set<string>();
-  const ecosystems: string[] = [];
-  const manifestFiles: string[] = [];
-  let publishedName: string | undefined;
+export function extractDependencyFacts(projectRoot: string) {
+  return Effect.gen(function* () {
+    const dependencies = new Set<string>();
+    const ecosystems: string[] = [];
+    const manifestFiles: string[] = [];
+    let publishedName: string | undefined;
 
-  const packageJson = await readIfExists(join(projectRoot, 'package.json'));
-  if (packageJson !== undefined) {
-    const parsed = parsePackageJson(packageJson);
-    if (parsed) {
-      manifestFiles.push('package.json');
-      ecosystems.push('npm');
+    const packageJson = yield* readIfExists(join(projectRoot, 'package.json'));
+    if (packageJson !== undefined) {
+      const parsed = parsePackageJson(packageJson);
+      if (parsed) {
+        manifestFiles.push('package.json');
+        ecosystems.push('npm');
+        publishedName = publishedName ?? parsed.publishedName;
+        for (const dependency of parsed.dependencies) {
+          dependencies.add(dependency);
+        }
+      }
+    }
+
+    const goMod = yield* readIfExists(join(projectRoot, 'go.mod'));
+    if (goMod !== undefined) {
+      const parsed = parseGoMod(goMod);
+      manifestFiles.push('go.mod');
+      ecosystems.push('go');
       publishedName = publishedName ?? parsed.publishedName;
       for (const dependency of parsed.dependencies) {
         dependencies.add(dependency);
       }
     }
-  }
 
-  const goMod = await readIfExists(join(projectRoot, 'go.mod'));
-  if (goMod !== undefined) {
-    const parsed = parseGoMod(goMod);
-    manifestFiles.push('go.mod');
-    ecosystems.push('go');
-    publishedName = publishedName ?? parsed.publishedName;
-    for (const dependency of parsed.dependencies) {
-      dependencies.add(dependency);
-    }
-  }
-
-  return {dependencies: [...dependencies].sort(), ecosystems, manifestFiles, publishedName};
+    return {dependencies: [...dependencies].sort(), ecosystems, manifestFiles, publishedName};
+  });
 }
 
 /**

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,6 @@
-import {chmod, mkdir, readFile, writeFile} from 'node:fs/promises';
+import {readFile} from 'node:fs/promises';
 import {dirname, join} from 'node:path';
-import {Effect} from 'effect';
+import {Console, Effect, FileSystem} from 'effect';
 import {
   CLAUDE_SETTINGS_PATH,
   HOOK_AUTO_PRECOMPACT_TOPIC,
@@ -10,6 +10,7 @@ import {
   THREADNOTE_HOOK_MARKER_VALUE,
 } from './constants.js';
 import {parseAgentClient} from './mcp.js';
+import {fromPromiseError} from './effect/errors.js';
 import {runHandoff, runRecall} from './memory.js';
 import {applyScrubber} from './share.js';
 import {distillTrace} from './trace.js';
@@ -41,56 +42,57 @@ const MANAGED_HOOKS: readonly ManagedHookEntry[] = [
 
 export {parseAgentClient as parseHookClient};
 
-export async function runHooksInstall(
-  config: RuntimeConfig,
-  agent: AgentClient,
-  options: HooksInstallOptions,
-): Promise<void> {
-  const apply = options.apply === true && options.dryRun !== true;
-  const remove = options.remove === true;
-  switch (agent) {
-    case 'claude':
-      await runClaudeHooksInstall({apply, remove});
-      return;
-    case 'codex':
-      printCodexHooksNotice(remove);
-      return;
-    case 'cursor':
-      printNoHooksSupported('cursor', remove);
-      return;
-    case 'copilot':
-      printNoHooksSupported('copilot', remove);
-      return;
-  }
+export function runHooksInstall(config: RuntimeConfig, agent: AgentClient, options: HooksInstallOptions) {
+  return Effect.gen(function* () {
+    const apply = options.apply === true && options.dryRun !== true;
+    const remove = options.remove === true;
+    switch (agent) {
+      case 'claude':
+        yield* runClaudeHooksInstall({apply, remove});
+        return;
+      case 'codex':
+        yield* printCodexHooksNotice(remove);
+        return;
+      case 'cursor':
+        yield* printNoHooksSupported('cursor', remove);
+        return;
+      case 'copilot':
+        yield* printNoHooksSupported('copilot', remove);
+        return;
+    }
+  });
 }
 
-async function runClaudeHooksInstall(options: {readonly apply: boolean; readonly remove: boolean}): Promise<void> {
-  const path = expandPath(CLAUDE_SETTINGS_PATH);
-  const existingRaw = (await exists(path)) ? await readFile(path, 'utf8') : '{}';
-  const parsed = parseJsonConfigObject(existingRaw) ?? {};
-  const next = options.remove ? withoutThreadnoteHooks(parsed) : withThreadnoteHooks(parsed);
-  const before = JSON.stringify(parsed);
-  const after = JSON.stringify(next);
-  if (before === after) {
-    console.log(`Claude hooks already ${options.remove ? 'absent' : 'managed'} in ${path}.`);
-    return;
-  }
+function runClaudeHooksInstall(options: {readonly apply: boolean; readonly remove: boolean}) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = expandPath(CLAUDE_SETTINGS_PATH);
+    const existingRaw = (yield* fs.exists(path)) ? yield* fs.readFileString(path) : '{}';
+    const parsed = parseJsonConfigObject(existingRaw) ?? {};
+    const next = options.remove ? withoutThreadnoteHooks(parsed) : withThreadnoteHooks(parsed);
+    const before = JSON.stringify(parsed);
+    const after = JSON.stringify(next);
+    if (before === after) {
+      yield* Console.log(`Claude hooks already ${options.remove ? 'absent' : 'managed'} in ${path}.`);
+      return;
+    }
 
-  console.log(`${options.apply ? 'Updating' : 'Would update'} ${path}:`);
-  for (const entry of MANAGED_HOOKS) {
-    console.log(`  ${options.remove ? '-' : '+'} ${entry.event}: ${entry.command}`);
-  }
+    yield* Console.log(`${options.apply ? 'Updating' : 'Would update'} ${path}:`);
+    for (const entry of MANAGED_HOOKS) {
+      yield* Console.log(`  ${options.remove ? '-' : '+'} ${entry.event}: ${entry.command}`);
+    }
 
-  if (!options.apply) {
-    console.log('\nRe-run with --apply to actually modify the file.');
-    return;
-  }
+    if (!options.apply) {
+      yield* Console.log('\nRe-run with --apply to actually modify the file.');
+      return;
+    }
 
-  await mkdir(dirname(path), {recursive: true});
-  const serialized = `${JSON.stringify(next, undefined, 2)}\n`;
-  await writeFile(path, serialized, {encoding: 'utf8', mode: 0o600});
-  await chmod(path, 0o600);
-  console.log(`${options.remove ? 'Removed' : 'Installed'} threadnote-managed Claude hooks.`);
+    yield* fs.makeDirectory(dirname(path), {recursive: true});
+    const serialized = `${JSON.stringify(next, undefined, 2)}\n`;
+    yield* fs.writeFileString(path, serialized, {mode: 0o600});
+    yield* fs.chmod(path, 0o600);
+    yield* Console.log(`${options.remove ? 'Removed' : 'Installed'} threadnote-managed Claude hooks.`);
+  });
 }
 
 function withThreadnoteHooks(input: JsonObject): JsonObject {
@@ -142,12 +144,11 @@ function ensureMutableArray(value: unknown): unknown[] {
   return Array.isArray(value) ? [...value] : [];
 }
 
-function printCodexHooksNotice(remove: boolean): void {
+function printCodexHooksNotice(remove: boolean) {
   if (remove) {
-    console.log('Codex CLI does not expose a managed hook surface today, so there is nothing to remove.');
-    return;
+    return Console.log('Codex CLI does not expose a managed hook surface today, so there is nothing to remove.');
   }
-  console.log(
+  return Console.log(
     [
       'Codex CLI does not currently expose lifecycle hooks (no PreCompact or SessionStart analog).',
       'Threadnote already installs Codex user instructions at ~/.codex/AGENTS.md; that remains the active guidance surface.',
@@ -156,12 +157,11 @@ function printCodexHooksNotice(remove: boolean): void {
   );
 }
 
-function printNoHooksSupported(agent: AgentClient, remove: boolean): void {
+function printNoHooksSupported(agent: AgentClient, remove: boolean) {
   if (remove) {
-    console.log(`${agent} does not expose a hook surface; nothing to remove.`);
-    return;
+    return Console.log(`${agent} does not expose a hook surface; nothing to remove.`);
   }
-  console.log(
+  return Console.log(
     [
       `${agent} does not expose agent-mode hooks today.`,
       'Threadnote already installs user-level instructions for this agent; that remains the active guidance surface.',
@@ -195,12 +195,8 @@ export function runPreCompactHook(config: RuntimeConfig, options: HookRunnerOpti
   // Hooks must never block compaction. Anything that throws here gets swallowed
   // and the process still exits 0 — the worst-case is a missed snapshot.
   return Effect.gen(function* () {
-    const project =
-      (yield* Effect.tryPromise({
-        try: () => resolveRepoName(),
-        catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-      })) ?? 'general';
-    const {sessionId, trace} = yield* Effect.promise(() => captureTraceContext());
+    const project = (yield* fromPromiseError(() => resolveRepoName())) ?? 'general';
+    const {sessionId, trace} = yield* fromPromiseError(() => captureTraceContext());
     yield* runHandoff(config, {
       blockers: '- none recorded',
       dryRun: options.dryRun === true,
@@ -229,25 +225,18 @@ export function runSessionStartHook(config: RuntimeConfig, options: HookRunnerOp
   // Hooks must never block session start. Failures fall through quietly so the
   // user just gets a normal session without injected context.
   return Effect.gen(function* () {
-    const project = yield* Effect.tryPromise({
-      try: () => resolveRepoName(),
-      catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-    });
+    const project = yield* fromPromiseError(() => resolveRepoName());
     if (!project) {
       return;
     }
     yield* emitUpdateBannerIfOutdated(config);
     yield* Effect.sync(() => process.stdout.write(`## Threadnote — latest context for ${project}\n\n`));
-    yield* Effect.tryPromise({
-      try: () =>
-        runRecall(config, {
-          dryRun: options.dryRun === true,
-          inferScope: true,
-          nodeLimit: '5',
-          // Keep "current branch" here so recall enriches the query with local git/workspace terms.
-          query: `${project} current branch latest handoff durable feature memory`,
-        }),
-      catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
+    yield* runRecall(config, {
+      dryRun: options.dryRun === true,
+      inferScope: true,
+      nodeLimit: '5',
+      // Keep "current branch" here so recall enriches the query with local git/workspace terms.
+      query: `${project} current branch latest handoff durable feature memory`,
     });
   }).pipe(
     Effect.catch(error =>

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -5,7 +5,7 @@ import {platform} from 'node:os';
 import {basename, dirname, join, sep} from 'node:path';
 import {stderr as processStderr, stdin as processStdin, stdout as processStdout} from 'node:process';
 import {createInterface} from 'node:readline/promises';
-import {Effect} from 'effect';
+import {Effect, FileSystem} from 'effect';
 import yaml from 'js-yaml';
 import {
   LAUNCHD_LABEL,
@@ -23,6 +23,9 @@ import {
   USER_INSTRUCTIONS_START_MARKER,
 } from './constants.js';
 import {hasManagedClaudeHooks, runHooksInstall} from './hooks.js';
+import {maybeRunEffect} from './effect/command.js';
+import {consoleOutput, syncWithConsole} from './effect/console.js';
+import {applicationError, fromPromise} from './effect/errors.js';
 import {startProgress} from './cli_ui.js';
 import {
   findStaleRecallIndexTargets,
@@ -109,20 +112,22 @@ interface InstallCommandRetry {
 
 type UserAgentInstructionTarget = (typeof USER_AGENT_INSTRUCTION_TARGETS)[number];
 
-export async function runDoctor(config: RuntimeConfig, options: DoctorOptions): Promise<void> {
-  const checks = await collectDoctorChecks(config, options);
+export const runDoctor = Effect.fn('runDoctor')(function* (config: RuntimeConfig, options: DoctorOptions) {
+  const checks = yield* fromPromise('collect doctor checks', () => collectDoctorChecks(config, options));
 
-  for (const check of checks) {
-    console.log(`${formatStatus(check.status)} ${check.name}: ${check.detail}`);
-  }
+  yield* syncWithConsole(() => {
+    for (const check of checks) {
+      consoleOutput.log(`${formatStatus(check.status)} ${check.name}: ${check.detail}`);
+    }
 
-  const failureCount = checks.filter(check => check.status === 'fail').length;
-  const warningCount = checks.filter(check => check.status === 'warn').length;
-  console.log(`\nSummary: ${failureCount} failure(s), ${warningCount} warning(s)`);
-  if (options.strict === true && failureCount > 0) {
-    process.exitCode = 1;
-  }
-}
+    const failureCount = checks.filter(check => check.status === 'fail').length;
+    const warningCount = checks.filter(check => check.status === 'warn').length;
+    consoleOutput.log(`\nSummary: ${failureCount} failure(s), ${warningCount} warning(s)`);
+    if (options.strict === true && failureCount > 0) {
+      process.exitCode = 1;
+    }
+  });
+});
 
 export async function collectDoctorChecks(config: RuntimeConfig, options: DoctorOptions = {}): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
@@ -151,29 +156,45 @@ export async function collectDoctorChecks(config: RuntimeConfig, options: Doctor
   return checks;
 }
 
-export async function runInstall(config: RuntimeConfig, options: InstallOptions): Promise<void> {
+export const runInstall = Effect.fn('runInstall')(function* (config: RuntimeConfig, options: InstallOptions) {
   const repairInvalidConfigs = options.repairInvalidConfigs === true;
   const dryRun = options.dryRun === true;
-  await ensureDirectory(config.agentContextHome, dryRun);
-  await ensureDirectory(join(config.agentContextHome, 'logs'), dryRun);
-  await ensureDirectory(join(config.agentContextHome, 'redacted'), dryRun);
-  await ensureDirectory(join(config.agentContextHome, 'mcp'), dryRun);
-  await installCommandShim(dryRun);
-  await installUserAgentInstructions(dryRun);
+  yield* fromPromise('create Threadnote home', () => ensureDirectory(config.agentContextHome, dryRun));
+  yield* fromPromise('create Threadnote logs directory', () =>
+    ensureDirectory(join(config.agentContextHome, 'logs'), dryRun),
+  );
+  yield* fromPromise('create Threadnote redacted directory', () =>
+    ensureDirectory(join(config.agentContextHome, 'redacted'), dryRun),
+  );
+  yield* fromPromise('create Threadnote MCP directory', () =>
+    ensureDirectory(join(config.agentContextHome, 'mcp'), dryRun),
+  );
+  yield* fromPromise('install command shim', () => installCommandShim(dryRun));
+  yield* fromPromise('install user agent instructions', () => installUserAgentInstructions(dryRun));
 
-  const serverPath = await findOpenVikingServer();
+  const serverPath = yield* fromPromise('find OpenViking server', findOpenVikingServer);
   // True only when an install/repair could have moved or created the
   // openviking-server binary itself. The python-certs branch patches the
   // existing Python env in place, so it does not flip this — the server
   // path is unchanged and the earlier resolution is still valid.
   let serverInstallRan = false;
   if (serverPath) {
-    console.log(`OpenViking server already installed: ${serverPath}`);
-    const localEmbeddingMissing = (await hasLocalEmbeddingDependency(serverPath)) === false;
-    const pythonSystemCertificatesMissing = (await hasPythonSystemCertificatesPatch(serverPath)) === false;
+    yield* syncWithConsole(() => consoleOutput.log(`OpenViking server already installed: ${serverPath}`));
+    const localEmbeddingMissing =
+      (yield* fromPromise('check OpenViking local embedding dependency', () =>
+        hasLocalEmbeddingDependency(serverPath),
+      )) === false;
+    const pythonSystemCertificatesMissing =
+      (yield* fromPromise('check OpenViking Python certificate bridge', () =>
+        hasPythonSystemCertificatesPatch(serverPath),
+      )) === false;
     if (options.force === true) {
-      console.log(`Reinstalling OpenViking at pinned version ${config.openVikingVersion} (--force).`);
-      await runInstallCommands(config, options.packageManager, true, dryRun);
+      yield* syncWithConsole(() =>
+        consoleOutput.log(`Reinstalling OpenViking at pinned version ${config.openVikingVersion} (--force).`),
+      );
+      yield* fromPromise('reinstall OpenViking', () =>
+        runInstallCommands(config, options.packageManager, true, dryRun),
+      );
       serverInstallRan = true;
     } else if (localEmbeddingMissing) {
       const repairReasons: string[] = [];
@@ -181,19 +202,27 @@ export async function runInstall(config: RuntimeConfig, options: InstallOptions)
       if (pythonSystemCertificatesMissing) {
         repairReasons.push('Python system certificate bridge is missing');
       }
-      console.log(`OpenViking install needs repair: ${repairReasons.join('; ')}.`);
-      await runInstallCommands(config, options.packageManager, true, dryRun);
+      yield* syncWithConsole(() => consoleOutput.log(`OpenViking install needs repair: ${repairReasons.join('; ')}.`));
+      yield* fromPromise('repair OpenViking installation', () =>
+        runInstallCommands(config, options.packageManager, true, dryRun),
+      );
       serverInstallRan = true;
     } else if (pythonSystemCertificatesMissing) {
-      console.log('OpenViking install needs repair: Python system certificate bridge is missing.');
-      const installCommand = await getPythonSystemCertificatesInstallCommand(serverPath);
-      await maybeRun(dryRun, installCommand.executable, installCommand.args);
+      yield* syncWithConsole(() =>
+        consoleOutput.log('OpenViking install needs repair: Python system certificate bridge is missing.'),
+      );
+      const installCommand = yield* fromPromise('resolve Python certificate bridge install command', () =>
+        getPythonSystemCertificatesInstallCommand(serverPath),
+      );
+      yield* maybeRunEffect(dryRun, installCommand.executable, installCommand.args);
     }
   } else {
-    await runInstallCommands(config, options.packageManager, false, dryRun);
+    yield* fromPromise('install OpenViking', () => runInstallCommands(config, options.packageManager, false, dryRun));
     serverInstallRan = true;
   }
-  const resolvedServerPath = serverInstallRan ? await findOpenVikingServer() : serverPath;
+  const resolvedServerPath = serverInstallRan
+    ? yield* fromPromise('find installed OpenViking server', findOpenVikingServer)
+    : serverPath;
   if (serverInstallRan && !resolvedServerPath && !dryRun) {
     // The install command reported success but the binary is unresolvable.
     // Fail loudly for `install`; for `repair` (requireServerBinary === false)
@@ -202,146 +231,162 @@ export async function runInstall(config: RuntimeConfig, options: InstallOptions)
       `OpenViking install ran but ${OPENVIKING_SERVER_COMMAND} was not found on PATH, in the uv tool bin dir, or ~/.local/bin. ` +
       'Re-run `threadnote install --force` (it streams the full build), then `threadnote doctor`.';
     if (options.requireServerBinary === false) {
-      console.warn(`WARN ${message}`);
+      yield* syncWithConsole(() => consoleOutput.warn(`WARN ${message}`));
     } else {
-      throw new Error(message);
+      return yield* Effect.fail(new Error(message));
     }
   }
   if (resolvedServerPath && !dryRun) {
-    await maybePrintOpenVikingPathHint(resolvedServerPath);
+    yield* fromPromise('print OpenViking path hint', () => maybePrintOpenVikingPathHint(resolvedServerPath));
   }
 
-  await writeTemplateIfMissing({
-    config,
-    destinationPath: join(config.agentContextHome, 'ov.conf'),
-    dryRun,
-    shouldRepair: content =>
-      shouldRepairOpenVikingConfig(content, config) ||
-      (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
-    templatePath: join(toolRoot(), 'config', 'ov.conf.template.json'),
-  });
-  await writeTemplateIfMissing({
-    config,
-    destinationPath: join(config.agentContextHome, 'ovcli.conf'),
-    dryRun,
-    shouldRepair: content =>
-      shouldRepairLegacyOvCliConfig(content) || (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
-    templatePath: join(toolRoot(), 'config', 'ovcli.conf.template.json'),
-  });
-  await configureOpenVikingCliLanguage(config, dryRun);
+  yield* fromPromise('write OpenViking server configuration', () =>
+    writeTemplateIfMissing({
+      config,
+      destinationPath: join(config.agentContextHome, 'ov.conf'),
+      dryRun,
+      shouldRepair: content =>
+        shouldRepairOpenVikingConfig(content, config) ||
+        (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
+      templatePath: join(toolRoot(), 'config', 'ov.conf.template.json'),
+    }),
+  );
+  yield* fromPromise('write OpenViking CLI configuration', () =>
+    writeTemplateIfMissing({
+      config,
+      destinationPath: join(config.agentContextHome, 'ovcli.conf'),
+      dryRun,
+      shouldRepair: content =>
+        shouldRepairLegacyOvCliConfig(content) ||
+        (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
+      templatePath: join(toolRoot(), 'config', 'ovcli.conf.template.json'),
+    }),
+  );
+  yield* fromPromise('configure OpenViking CLI language', () => configureOpenVikingCliLanguage(config, dryRun));
 
   if (options.start !== false) {
-    const healthy = await repairServerHealth(config, dryRun);
+    const healthy = yield* repairServerHealth(config, dryRun);
     if (!healthy && !dryRun) {
-      throw new Error(`OpenViking did not become healthy. Check logs: ${openVikingLogPath(config)}`);
+      return yield* Effect.fail(
+        new Error(`OpenViking did not become healthy. Check logs: ${openVikingLogPath(config)}`),
+      );
     }
   }
 
   if (options.printNextSteps !== false) {
-    printInstallNextSteps({dryRun, startsServer: options.start !== false});
+    yield* syncWithConsole(() => printInstallNextSteps({dryRun, startsServer: options.start !== false}));
   }
-}
+});
 
 export const runRepair = Effect.fn('runRepair')(function* (config: RuntimeConfig, options: RepairOptions) {
-  yield* Effect.tryPromise({
-    try: () => runRepairCore(config, options),
-    catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-  });
+  yield* runRepairCore(config, options);
   if (options.postUpdate !== false) {
     yield* maybeRunPostUpdateAfterRepair(config, {dryRun: options.dryRun === true});
   }
 });
 
-async function runRepairCore(config: RuntimeConfig, options: RepairOptions): Promise<void> {
-  const dryRun = options.dryRun === true;
-  console.log('Repairing local OpenViking agent context from this checkout.');
+function runRepairCore(config: RuntimeConfig, options: RepairOptions) {
+  return Effect.gen(function* () {
+    const dryRun = options.dryRun === true;
+    yield* syncWithConsole(() => consoleOutput.log('Repairing local OpenViking agent context from this checkout.'));
 
-  await runInstall(config, {
-    dryRun,
-    packageManager: options.packageManager,
-    printNextSteps: false,
-    repairInvalidConfigs: true,
-    requireServerBinary: false,
-    start: false,
-  });
-  await repairManifest(config, dryRun);
+    yield* runInstall(config, {
+      dryRun,
+      packageManager: options.packageManager,
+      printNextSteps: false,
+      repairInvalidConfigs: true,
+      requireServerBinary: false,
+      start: false,
+    });
+    yield* fromPromise('repair seed manifest', () => repairManifest(config, dryRun));
 
-  if (options.start !== false) {
-    await repairServerHealth(config, dryRun);
-  } else {
-    console.log('Skipping server health repair because --no-start was provided.');
-  }
-  await repairRecallIndex(config, dryRun);
-
-  const mcpClients = await resolveMcpClients(options.mcp ?? 'available', 'repair');
-  if (mcpClients.length === 0) {
-    console.log('Skipping MCP config repair.');
-  } else {
-    for (const client of mcpClients) {
-      console.log(`Repairing ${client} MCP config for ${OPENVIKING_MCP_NAME}.`);
-      await runMcpInstall(config, client, {apply: !dryRun, name: OPENVIKING_MCP_NAME});
+    if (options.start !== false) {
+      yield* repairServerHealth(config, dryRun);
+    } else {
+      yield* syncWithConsole(() => consoleOutput.log('Skipping server health repair because --no-start was provided.'));
     }
-  }
+    yield* fromPromise('repair recall index', () => repairRecallIndex(config, dryRun));
 
-  // Re-install agent hooks only if the user opted in previously (a managed
-  // entry already exists). Never adds them unsolicited — `install-hooks` or
-  // `install --with-hooks` is the opt-in.
-  if (await hasManagedClaudeHooks()) {
-    console.log('\nRepairing claude hooks (re-asserting threadnote-managed entries).');
-    await runHooksInstall(config, 'claude', {apply: !dryRun, dryRun});
-  }
+    const mcpClients = yield* fromPromise('resolve MCP clients for repair', () =>
+      resolveMcpClients(options.mcp ?? 'available', 'repair'),
+    );
+    if (mcpClients.length === 0) {
+      yield* syncWithConsole(() => consoleOutput.log('Skipping MCP config repair.'));
+    } else {
+      for (const client of mcpClients) {
+        yield* syncWithConsole(() => consoleOutput.log(`Repairing ${client} MCP config for ${OPENVIKING_MCP_NAME}.`));
+        yield* runMcpInstall(config, client, {apply: !dryRun, name: OPENVIKING_MCP_NAME});
+      }
+    }
 
-  console.log('\nPost-repair doctor:');
-  await runDoctor(config, {dryRun, strict: false});
+    // Re-install agent hooks only if the user opted in previously (a managed
+    // entry already exists). Never adds them unsolicited — `install-hooks` or
+    // `install --with-hooks` is the opt-in.
+    if (yield* fromPromise('check managed Claude hooks', hasManagedClaudeHooks)) {
+      yield* syncWithConsole(() =>
+        consoleOutput.log('\nRepairing claude hooks (re-asserting threadnote-managed entries).'),
+      );
+      yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun});
+    }
+
+    yield* syncWithConsole(() => consoleOutput.log('\nPost-repair doctor:'));
+    yield* runDoctor(config, {dryRun, strict: false});
+  });
 }
 
-export async function runUninstall(config: RuntimeConfig, options: UninstallOptions): Promise<void> {
+export const runUninstall = Effect.fn('runUninstall')(function* (config: RuntimeConfig, options: UninstallOptions) {
   const dryRun = options.dryRun === true;
   if (options.eraseMemories === true && options.preserveMemories === true) {
-    throw new Error('Use either --erase-memories or --preserve-memories, not both.');
+    yield* Effect.fail(new Error('Use either --erase-memories or --preserve-memories, not both.'));
   }
 
-  console.log('Uninstalling local Threadnote setup.');
-  await runStop(config, {dryRun});
-  await removePathIfExists(join(config.agentContextHome, 'openviking-server.pid'), 'pid file', dryRun);
-  await removeLaunchAgent(dryRun);
-  await removeMcpConfigs(options.mcp ?? 'available', dryRun);
-  await removeMcpSnippets(config, dryRun);
-  if (await hasManagedClaudeHooks()) {
-    await runHooksInstall(config, 'claude', {apply: !dryRun, dryRun, remove: true});
+  yield* syncWithConsole(() => consoleOutput.log('Uninstalling local Threadnote setup.'));
+  yield* runStop(config, {dryRun});
+  yield* fromPromise('remove OpenViking pid file', () =>
+    removePathIfExists(join(config.agentContextHome, 'openviking-server.pid'), 'pid file', dryRun),
+  );
+  yield* fromPromise('remove OpenViking launch agent', () => removeLaunchAgent(dryRun));
+  yield* fromPromise('remove MCP configurations', () => removeMcpConfigs(options.mcp ?? 'available', dryRun));
+  yield* fromPromise('remove MCP snippets', () => removeMcpSnippets(config, dryRun));
+  if (yield* fromPromise('check managed Claude hooks', hasManagedClaudeHooks)) {
+    yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun, remove: true});
   }
-  await removeCommandShim(dryRun);
-  await removeUserAgentInstructions(dryRun);
+  yield* fromPromise('remove command shim', () => removeCommandShim(dryRun));
+  yield* fromPromise('remove user agent instructions', () => removeUserAgentInstructions(dryRun));
 
   if (options.eraseMemories === true) {
-    await eraseThreadnoteHome(config.agentContextHome, dryRun);
+    yield* fromPromise('erase Threadnote home', () => eraseThreadnoteHome(config.agentContextHome, dryRun));
   } else {
-    console.log(`Preserving local memories and OpenViking home: ${config.agentContextHome}`);
-    console.log('Use --erase-memories to delete this directory during uninstall.');
+    yield* syncWithConsole(() => {
+      consoleOutput.log(`Preserving local memories and OpenViking home: ${config.agentContextHome}`);
+      consoleOutput.log('Use --erase-memories to delete this directory during uninstall.');
+    });
   }
 
-  console.log('Uninstall complete.');
-  console.log('The package remains installed. Remove it with your package manager if desired.');
-}
+  yield* syncWithConsole(() => {
+    consoleOutput.log('Uninstall complete.');
+    consoleOutput.log('The package remains installed. Remove it with your package manager if desired.');
+  });
+});
 
 async function repairManifest(config: RuntimeConfig, dryRun: boolean): Promise<void> {
   try {
     await readSeedManifest(config.manifestPath);
-    console.log(`Manifest OK: ${config.manifestPath}`);
+    consoleOutput.log(`Manifest OK: ${config.manifestPath}`);
     return;
   } catch (err: unknown) {
     if (config.manifestPath === builtInExampleManifestPath()) {
-      console.log(`WARN built-in manifest is not readable: ${errorMessage(err)}`);
+      consoleOutput.log(`WARN built-in manifest is not readable: ${errorMessage(err)}`);
       return;
     }
-    console.log(`Manifest needs repair: ${config.manifestPath} (${errorMessage(err)})`);
+    consoleOutput.log(`Manifest needs repair: ${config.manifestPath} (${errorMessage(err)})`);
   }
 
   let repoRoot: string;
   try {
     repoRoot = await resolveRepoRoot(getInvocationCwd());
   } catch (err: unknown) {
-    console.log(`WARN cannot create replacement manifest from current directory: ${errorMessage(err)}`);
+    consoleOutput.log(`WARN cannot create replacement manifest from current directory: ${errorMessage(err)}`);
     return;
   }
 
@@ -362,8 +407,8 @@ async function repairManifest(config: RuntimeConfig, dryRun: boolean): Promise<v
   );
 
   if (dryRun) {
-    console.log(`# Would write replacement manifest: ${config.manifestPath}`);
-    console.log(output.trimEnd());
+    consoleOutput.log(`# Would write replacement manifest: ${config.manifestPath}`);
+    consoleOutput.log(output.trimEnd());
     return;
   }
 
@@ -373,18 +418,18 @@ async function repairManifest(config: RuntimeConfig, dryRun: boolean): Promise<v
     const backupPath = `${config.manifestPath}.legacy-${safeTimestamp()}`;
     await writeFile(backupPath, currentContent, {encoding: 'utf8', mode: 0o600});
     await chmod(backupPath, 0o600);
-    console.log(`Backup: ${backupPath}`);
+    consoleOutput.log(`Backup: ${backupPath}`);
   }
   await writeFile(config.manifestPath, output, {encoding: 'utf8', mode: 0o600});
   await chmod(config.manifestPath, 0o600);
-  console.log(`Wrote replacement manifest: ${config.manifestPath}`);
+  consoleOutput.log(`Wrote replacement manifest: ${config.manifestPath}`);
 }
 
 async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promise<void> {
-  console.log('\nRepairing recall index freshness.');
+  consoleOutput.log('\nRepairing recall index freshness.');
   const ov = dryRun ? ((await findOpenVikingCli()) ?? 'ov') : await findOpenVikingCli();
   if (!ov) {
-    console.log('Skipping recall index repair: neither ov nor openviking was found.');
+    consoleOutput.log('Skipping recall index repair: neither ov nor openviking was found.');
     return;
   }
 
@@ -424,15 +469,15 @@ async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promis
     progress.stop();
     const messages = formatRecallIndexRepairMessages(result, {dryRun, maxUris: 20});
     if (messages.length === 0) {
-      console.log('Recall index freshness OK.');
+      consoleOutput.log('Recall index freshness OK.');
       return;
     }
     for (const message of messages) {
-      console.log(message);
+      consoleOutput.log(message);
     }
   } catch (err: unknown) {
     progress.stop();
-    console.log(`WARN could not repair recall index freshness: ${errorMessage(err)}`);
+    consoleOutput.log(`WARN could not repair recall index freshness: ${errorMessage(err)}`);
   }
 }
 
@@ -521,84 +566,111 @@ async function maybePrintOpenVikingPathHint(serverPath: string): Promise<void> {
   }
   const binDir = dirname(serverPath);
   const rcHint = suggestedShellRc(process.env.SHELL, platform());
-  console.log(
+  consoleOutput.log(
     `Note: ${serverPath} is installed but ${binDir} is not on this shell's PATH. ` +
       `Add \`export PATH="${binDir}:$PATH"\` to ${rcHint} so other tools can find openviking-server.`,
   );
 }
 
-async function repairServerHealth(config: RuntimeConfig, dryRun: boolean): Promise<boolean> {
-  const existingHealth = await readOpenVikingHealthIfAvailable(config, 800);
-  if (existingHealth) {
-    console.log(`OpenViking health OK at http://${config.host}:${config.port}/health`);
-    return true;
-  }
+function repairServerHealth(config: RuntimeConfig, dryRun: boolean) {
+  return Effect.gen(function* () {
+    const existingHealth = yield* fromPromise('check OpenViking health', () =>
+      readOpenVikingHealthIfAvailable(config, 800),
+    );
+    if (existingHealth) {
+      yield* syncWithConsole(() =>
+        consoleOutput.log(`OpenViking health OK at http://${config.host}:${config.port}/health`),
+      );
+      return true;
+    }
 
-  console.log(`OpenViking health is not responding at http://${config.host}:${config.port}/health; starting server.`);
-  try {
-    await runStart(config, {dryRun});
-    return true;
-  } catch (err: unknown) {
-    console.log(`WARN could not repair OpenViking health: ${errorMessage(err)}`);
-    return false;
-  }
+    yield* syncWithConsole(() =>
+      consoleOutput.log(
+        `OpenViking health is not responding at http://${config.host}:${config.port}/health; starting server.`,
+      ),
+    );
+    return yield* runStart(config, {dryRun}).pipe(
+      Effect.as(true),
+      Effect.catch(error =>
+        syncWithConsole(() => {
+          consoleOutput.log(`WARN could not repair OpenViking health: ${errorMessage(error)}`);
+          return false;
+        }),
+      ),
+    );
+  });
 }
 
-export async function runStart(config: RuntimeConfig, options: StartOptions): Promise<void> {
+export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, options: StartOptions) {
+  const fs = yield* FileSystem.FileSystem;
   if (options.launchd === true) {
-    await installLaunchAgent(config, options.dryRun === true);
+    yield* fromPromise('install OpenViking launch agent', () => installLaunchAgent(config, options.dryRun === true));
     return;
   }
 
   const server =
     options.dryRun === true
-      ? ((await findOpenVikingServer()) ?? OPENVIKING_SERVER_COMMAND)
-      : await requireOpenVikingServer();
+      ? ((yield* fromPromise('find OpenViking server', findOpenVikingServer)) ?? OPENVIKING_SERVER_COMMAND)
+      : yield* fromPromise('require OpenViking server', requireOpenVikingServer);
   const args = openVikingServerArgs(config);
   if (options.dryRun === true) {
-    console.log(formatShellCommand(server, args));
+    yield* syncWithConsole(() => consoleOutput.log(formatShellCommand(server, args)));
     return;
   }
 
-  const existingHealth = await readOpenVikingHealthIfAvailable(config, 500);
+  const existingHealth = yield* fromPromise('check existing OpenViking health', () =>
+    readOpenVikingHealthIfAvailable(config, 500),
+  );
   const healthUrl = openVikingHealthUrl(config);
   if (existingHealth) {
-    console.log(`OpenViking is already healthy at ${healthUrl}`);
+    yield* syncWithConsole(() => consoleOutput.log(`OpenViking is already healthy at ${healthUrl}`));
     return;
   }
-  if (await isTcpPortOpen(config.host, config.port, 500)) {
-    throw new Error(
-      `Port ${config.host}:${config.port} is already in use, but it is not a healthy OpenViking server. ` +
-        'Set THREADNOTE_PORT or pass --port to use a different port.',
+  if (yield* fromPromise('check OpenViking TCP port', () => isTcpPortOpen(config.host, config.port, 500))) {
+    return yield* Effect.fail(
+      new Error(
+        `Port ${config.host}:${config.port} is already in use, but it is not a healthy OpenViking server. ` +
+          'Set THREADNOTE_PORT or pass --port to use a different port.',
+      ),
     );
   }
 
   const logPath = openVikingLogPath(config);
-  await ensureDirectory(dirname(logPath), false);
+  yield* fs.makeDirectory(dirname(logPath), {recursive: true});
   if (options.foreground === true) {
-    const result = await runInteractive(server, args);
-    process.exitCode = result;
+    const result = yield* fromPromise('run OpenViking in foreground', () => runInteractive(server, args));
+    yield* syncWithConsole(() => {
+      process.exitCode = result;
+    });
     return;
   }
 
-  const logFd = openSync(logPath, 'a');
-  const child = spawnDetachedServerWithLog(server, args, logFd);
-  child.unref();
-  await writeFile(join(config.agentContextHome, 'openviking-server.pid'), `${child.pid}\n`, 'utf8');
-  const health = await waitForOpenVikingHealth(
-    config,
-    START_HEALTH_TIMEOUT_MS,
-    `Waiting for OpenViking health at ${healthUrl}.`,
+  const child = yield* Effect.try({
+    try: () => {
+      const logFd = openSync(logPath, 'a');
+      const spawned = spawnDetachedServerWithLog(server, args, logFd);
+      spawned.unref();
+      return spawned;
+    },
+    catch: cause => applicationError('start detached OpenViking server', cause),
+  });
+  yield* fs.writeFileString(join(config.agentContextHome, 'openviking-server.pid'), `${child.pid}\n`);
+  const health = yield* fromPromise('wait for OpenViking health', () =>
+    waitForOpenVikingHealth(config, START_HEALTH_TIMEOUT_MS, `Waiting for OpenViking health at ${healthUrl}.`),
   );
   if (health) {
-    console.log(`Started OpenViking with pid ${child.pid}. Health OK at ${healthUrl}. Logs: ${logPath}`);
+    yield* syncWithConsole(() =>
+      consoleOutput.log(`Started OpenViking with pid ${child.pid}. Health OK at ${healthUrl}. Logs: ${logPath}`),
+    );
     return;
   }
-  throw new Error(
-    `Started OpenViking with pid ${child.pid}, but ${healthUrl} did not become healthy within ` +
-      `${START_HEALTH_TIMEOUT_MS / 1000}s. Logs: ${logPath}`,
+  return yield* Effect.fail(
+    new Error(
+      `Started OpenViking with pid ${child.pid}, but ${healthUrl} did not become healthy within ` +
+        `${START_HEALTH_TIMEOUT_MS / 1000}s. Logs: ${logPath}`,
+    ),
   );
-}
+});
 
 function spawnDetachedServerWithLog(server: string, args: readonly string[], logFd: number): ReturnType<typeof spawn> {
   try {
@@ -615,38 +687,46 @@ function spawnDetachedServer(server: string, args: readonly string[], logFd: num
   });
 }
 
-export async function runStop(config: RuntimeConfig, options: ForgetOptions): Promise<void> {
+export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, options: ForgetOptions) {
+  const fs = yield* FileSystem.FileSystem;
   const launchAgentPath = expandPath(`~/Library/LaunchAgents/${LAUNCHD_LABEL}.plist`);
   if (platform() === 'darwin') {
-    if (options.dryRun === true || (await exists(launchAgentPath))) {
-      await maybeRun(options.dryRun === true, 'launchctl', ['unload', launchAgentPath], {allowFailure: true});
+    if (options.dryRun === true || (yield* fs.exists(launchAgentPath))) {
+      yield* maybeRunEffect(options.dryRun === true, 'launchctl', ['unload', launchAgentPath], {allowFailure: true});
     } else {
-      console.log(`No LaunchAgent found: ${launchAgentPath}`);
+      yield* syncWithConsole(() => consoleOutput.log(`No LaunchAgent found: ${launchAgentPath}`));
     }
   }
 
   const pidPath = join(config.agentContextHome, 'openviking-server.pid');
-  const pidText = await readFileIfExists(pidPath);
+  const pidText = yield* fs.readFileString(pidPath).pipe(
+    Effect.catchIf(
+      error => error.reason._tag === 'NotFound',
+      () => Effect.succeed(undefined),
+    ),
+  );
   if (!pidText) {
-    console.log('No pid file found for detached OpenViking server.');
+    yield* syncWithConsole(() => consoleOutput.log('No pid file found for detached OpenViking server.'));
     return;
   }
   const pid = Number(pidText.trim());
   if (!Number.isInteger(pid) || pid <= 0) {
-    console.log(`Invalid pid file: ${pidPath}`);
+    yield* syncWithConsole(() => consoleOutput.log(`Invalid pid file: ${pidPath}`));
     return;
   }
   if (options.dryRun === true) {
-    console.log(`Would stop process ${pid}`);
+    yield* syncWithConsole(() => consoleOutput.log(`Would stop process ${pid}`));
     return;
   }
-  try {
-    process.kill(pid, 'SIGTERM');
-    console.log(`Stopped process ${pid}`);
-  } catch (err: unknown) {
-    console.log(`Could not stop process ${pid}: ${errorMessage(err)}`);
-  }
-}
+  yield* syncWithConsole(() => {
+    try {
+      process.kill(pid, 'SIGTERM');
+      consoleOutput.log(`Stopped process ${pid}`);
+    } catch (err: unknown) {
+      consoleOutput.log(`Could not stop process ${pid}: ${errorMessage(err)}`);
+    }
+  });
+});
 
 async function commandCheck(name: string, args: readonly string[]): Promise<DoctorCheck> {
   const executable = await findExecutable([name]);
@@ -1115,18 +1195,18 @@ async function runInstallCommands(
     // legitimate build. Because uv/pipx --force removes the existing tool env
     // first, a killed reinstall leaves openviking-server missing — so we also
     // print recovery guidance before failing.
-    console.log(`Running: ${formatShellCommand(resolvedInstallCommand.executable, resolvedInstallCommand.args)}`);
+    consoleOutput.log(`Running: ${formatShellCommand(resolvedInstallCommand.executable, resolvedInstallCommand.args)}`);
     const result = await runInstallCommand(resolvedInstallCommand);
     if (result.exitCode !== 0) {
       const commandOutput = `${result.stderr}\n${result.stdout}`;
       const retry = openVikingSourceBuildRetryForArchiveFailure(resolvedInstallCommand, commandOutput);
       if (retry) {
-        console.error('');
-        console.error(
+        consoleOutput.error('');
+        consoleOutput.error(
           'The prebuilt llama-cpp-python wheel failed ZIP archive validation; retrying with a local source build.',
         );
-        console.error('This avoids the rejected wheel and can take 10-20 minutes.');
-        console.log(`Running: ${formatInstallCommand(retry.command, retry.env)}`);
+        consoleOutput.error('This avoids the rejected wheel and can take 10-20 minutes.');
+        consoleOutput.log(`Running: ${formatInstallCommand(retry.command, retry.env)}`);
         const retryResult = await runInstallCommand(retry.command, retry.env);
         if (retryResult.exitCode === 0) {
           continue;
@@ -1194,7 +1274,7 @@ function appendInstallOutputTail(current: string, chunk: string): string {
 
 function printOpenVikingInstallFailureHelp(failedCommand: MappedCommand, commandOutput: string): void {
   for (const line of openVikingInstallFailureHelpLines(failedCommand, commandOutput)) {
-    console.error(line);
+    consoleOutput.error(line);
   }
 }
 
@@ -1304,7 +1384,7 @@ function extraIndexUrl(command: MappedCommand): string | undefined {
 
 async function offerToInstallUv(): Promise<boolean> {
   if (processStdin.isTTY !== true || processStdout.isTTY !== true) {
-    console.warn(
+    consoleOutput.warn(
       'Neither uv nor pipx was found on PATH. Falling back to `python3 -m pip install --user`, which fails on PEP 668 (Homebrew/system) Python.\n' +
         'Re-run with --package-manager uv after installing uv (brew install uv), or pass --package-manager pipx.',
     );
@@ -1324,7 +1404,9 @@ async function offerToInstallUv(): Promise<boolean> {
     readline.close();
   }
   if (answer === 'n' || answer === 'no') {
-    console.log('Continuing with `python3 -m pip install --user`. You may hit PEP 668 errors on managed Pythons.');
+    consoleOutput.log(
+      'Continuing with `python3 -m pip install --user`. You may hit PEP 668 errors on managed Pythons.',
+    );
     return false;
   }
   return await installUv();
@@ -1333,11 +1415,11 @@ async function offerToInstallUv(): Promise<boolean> {
 async function installUv(): Promise<boolean> {
   const brew = await findExecutable(['brew']);
   if (brew) {
-    console.log('Installing uv via Homebrew...');
+    consoleOutput.log('Installing uv via Homebrew...');
     const result = await runCommand(brew, ['install', 'uv'], {allowFailure: true});
     if (result.exitCode === 0) {
       if (result.stdout.trim()) {
-        console.log(result.stdout.trim());
+        consoleOutput.log(result.stdout.trim());
       }
       if (await findExecutable(['uv'])) {
         // Drop the candidate-dirs cache so subsequent openviking-server
@@ -1346,32 +1428,34 @@ async function installUv(): Promise<boolean> {
         return true;
       }
     } else {
-      console.warn(`brew install uv failed: ${(result.stderr || result.stdout).trim()}`);
+      consoleOutput.warn(`brew install uv failed: ${(result.stderr || result.stdout).trim()}`);
     }
   }
   // Fall back to the official install script. Requires curl + sh; honors any
   // proxy env vars the user already has.
   if ((await findExecutable(['curl'])) && (await findExecutable(['sh']))) {
-    console.log('Installing uv via the official install script (curl -LsSf https://astral.sh/uv/install.sh | sh)...');
+    consoleOutput.log(
+      'Installing uv via the official install script (curl -LsSf https://astral.sh/uv/install.sh | sh)...',
+    );
     const result = await runCommand('sh', ['-c', 'curl -LsSf https://astral.sh/uv/install.sh | sh'], {
       allowFailure: true,
     });
     if (result.exitCode === 0) {
       if (result.stdout.trim()) {
-        console.log(result.stdout.trim());
+        consoleOutput.log(result.stdout.trim());
       }
       if (await findExecutable(['uv'])) {
         candidateDirsPromise = undefined;
         return true;
       }
-      console.warn(
+      consoleOutput.warn(
         'uv installed, but the new binary is not yet on this shell PATH. Open a new shell (or `source ~/.zshrc` / `source ~/.bashrc`) and re-run `threadnote install`.',
       );
       return false;
     }
-    console.warn(`uv install script failed: ${(result.stderr || result.stdout).trim()}`);
+    consoleOutput.warn(`uv install script failed: ${(result.stderr || result.stdout).trim()}`);
   }
-  console.warn(
+  consoleOutput.warn(
     'Could not install uv automatically. Install it manually (brew install uv) and re-run threadnote install.',
   );
   return false;
@@ -1409,7 +1493,7 @@ export async function ensureSupportedUvExecutable(): Promise<string | undefined>
     return undefined;
   }
 
-  console.log(`Updating uv to ${MINIMUM_UV_SYSTEM_CERTS_VERSION} or newer for system certificate support.`);
+  consoleOutput.log(`Updating uv to ${MINIMUM_UV_SYSTEM_CERTS_VERSION} or newer for system certificate support.`);
   for (const candidate of candidates) {
     const result = await runCommand(candidate.executable, ['self', 'update'], {allowFailure: true});
     if (result.exitCode === 0) {
@@ -1576,19 +1660,19 @@ async function detectPackageManager(): Promise<PackageManager> {
 
 function printInstallNextSteps(options: {readonly dryRun: boolean; readonly startsServer: boolean}): void {
   if (options.dryRun) {
-    console.log('Dry run complete. Run without --dry-run to install and start OpenViking.');
+    consoleOutput.log('Dry run complete. Run without --dry-run to install and start OpenViking.');
     return;
   }
 
   if (options.startsServer) {
-    console.log('Install complete. OpenViking health is ready. Next:');
-    console.log('  threadnote doctor --dry-run');
+    consoleOutput.log('Install complete. OpenViking health is ready. Next:');
+    consoleOutput.log('  threadnote doctor --dry-run');
     return;
   }
 
-  console.log('Install complete. Run start, then doctor:');
-  console.log('  threadnote start');
-  console.log('  threadnote doctor --dry-run');
+  consoleOutput.log('Install complete. Run start, then doctor:');
+  consoleOutput.log('  threadnote start');
+  consoleOutput.log('  threadnote doctor --dry-run');
 }
 
 async function writeTemplateIfMissing(options: {
@@ -1601,12 +1685,12 @@ async function writeTemplateIfMissing(options: {
   if (await exists(options.destinationPath)) {
     const currentContent = await readFile(options.destinationPath, 'utf8');
     if (options.shouldRepair?.(currentContent) !== true) {
-      console.log(`Already exists: ${options.destinationPath}`);
+      consoleOutput.log(`Already exists: ${options.destinationPath}`);
       return;
     }
     const rendered = renderTemplate(await readFile(options.templatePath, 'utf8'), options.config);
     if (options.dryRun) {
-      console.log(`Would repair generated config: ${options.destinationPath}`);
+      consoleOutput.log(`Would repair generated config: ${options.destinationPath}`);
       return;
     }
     const backupPath = `${options.destinationPath}.legacy-${safeTimestamp()}`;
@@ -1614,19 +1698,19 @@ async function writeTemplateIfMissing(options: {
     await chmod(backupPath, 0o600);
     await writeFile(options.destinationPath, rendered, {encoding: 'utf8', mode: 0o600});
     await chmod(options.destinationPath, 0o600);
-    console.log(`Repaired generated config: ${options.destinationPath}`);
-    console.log(`Backup: ${backupPath}`);
+    consoleOutput.log(`Repaired generated config: ${options.destinationPath}`);
+    consoleOutput.log(`Backup: ${backupPath}`);
     return;
   }
   const rendered = renderTemplate(await readFile(options.templatePath, 'utf8'), options.config);
   if (options.dryRun) {
-    console.log(`Would write ${options.destinationPath}`);
+    consoleOutput.log(`Would write ${options.destinationPath}`);
     return;
   }
   await ensureDirectory(dirname(options.destinationPath), false);
   await writeFile(options.destinationPath, rendered, {encoding: 'utf8', mode: 0o600});
   await chmod(options.destinationPath, 0o600);
-  console.log(`Wrote ${options.destinationPath}`);
+  consoleOutput.log(`Wrote ${options.destinationPath}`);
 }
 
 async function installCommandShim(dryRun: boolean): Promise<void> {
@@ -1634,34 +1718,34 @@ async function installCommandShim(dryRun: boolean): Promise<void> {
   const shimPath = join(binDir, 'threadnote');
   const existingContent = await readFileIfExists(shimPath);
   if (existingContent && !isManagedCommandShim(existingContent)) {
-    console.log(`WARN not overwriting existing command shim: ${shimPath}`);
+    consoleOutput.log(`WARN not overwriting existing command shim: ${shimPath}`);
     return;
   }
 
   const content = renderCommandShim();
   if (existingContent === content) {
-    console.log(`Already exists: ${shimPath}`);
+    consoleOutput.log(`Already exists: ${shimPath}`);
     return;
   }
   if (dryRun) {
-    console.log(`Would write command shim: ${shimPath}`);
+    consoleOutput.log(`Would write command shim: ${shimPath}`);
     return;
   }
   await ensureDirectory(binDir, false);
   await writeFile(shimPath, content, {encoding: 'utf8', mode: 0o755});
   await chmod(shimPath, 0o755);
-  console.log(`Wrote command shim: ${shimPath}`);
+  consoleOutput.log(`Wrote command shim: ${shimPath}`);
 }
 
 async function removeCommandShim(dryRun: boolean): Promise<void> {
   const shimPath = join(expandPath(process.env.THREADNOTE_BIN_DIR ?? '~/.local/bin'), 'threadnote');
   const content = await readFileIfExists(shimPath);
   if (content === undefined) {
-    console.log(`Already absent: ${shimPath}`);
+    consoleOutput.log(`Already absent: ${shimPath}`);
     return;
   }
   if (!isManagedCommandShim(content)) {
-    console.log(`WARN not removing unmanaged command shim: ${shimPath}`);
+    consoleOutput.log(`WARN not removing unmanaged command shim: ${shimPath}`);
     return;
   }
   await removePath(shimPath, 'command shim', dryRun);
@@ -1673,25 +1757,25 @@ async function installUserAgentInstructions(dryRun: boolean): Promise<void> {
     const targetPath = expandPath(target.path);
     const currentContent = await readFileIfExists(targetPath);
     if (target.kind === 'file' && currentContent !== undefined && extractManagedBlock(currentContent) === undefined) {
-      console.log(`WARN ${targetPath} is not managed by threadnote; not modifying it`);
+      consoleOutput.log(`WARN ${targetPath} is not managed by threadnote; not modifying it`);
       continue;
     }
     const nextContent = target.kind === 'file' ? instructions : upsertManagedBlock(currentContent ?? '', instructions);
     if (nextContent === undefined) {
-      console.log(`WARN ${targetPath} has partial threadnote markers; not modifying it`);
+      consoleOutput.log(`WARN ${targetPath} has partial threadnote markers; not modifying it`);
       continue;
     }
     if (currentContent === nextContent) {
-      console.log(`Already exists: ${targetPath}`);
+      consoleOutput.log(`Already exists: ${targetPath}`);
       continue;
     }
     if (dryRun) {
-      console.log(currentContent === undefined ? `Would write ${targetPath}` : `Would update ${targetPath}`);
+      consoleOutput.log(currentContent === undefined ? `Would write ${targetPath}` : `Would update ${targetPath}`);
       continue;
     }
     await ensureDirectory(dirname(targetPath), false);
     await writeFile(targetPath, nextContent, {encoding: 'utf8', mode: 0o644});
-    console.log(currentContent === undefined ? `Wrote ${targetPath}` : `Updated ${targetPath}`);
+    consoleOutput.log(currentContent === undefined ? `Wrote ${targetPath}` : `Updated ${targetPath}`);
   }
 }
 
@@ -1700,12 +1784,12 @@ async function removeUserAgentInstructions(dryRun: boolean): Promise<void> {
     const targetPath = expandPath(target.path);
     const currentContent = await readFileIfExists(targetPath);
     if (currentContent === undefined) {
-      console.log(`Already absent: ${targetPath}`);
+      consoleOutput.log(`Already absent: ${targetPath}`);
       continue;
     }
     if (target.kind === 'file') {
       if (extractManagedBlock(currentContent) === undefined) {
-        console.log(`WARN ${targetPath} is not managed by threadnote; not removing it`);
+        consoleOutput.log(`WARN ${targetPath} is not managed by threadnote; not removing it`);
         continue;
       }
       await removePath(targetPath, target.label, dryRun);
@@ -1713,11 +1797,11 @@ async function removeUserAgentInstructions(dryRun: boolean): Promise<void> {
     }
     const nextContent = removeManagedBlock(currentContent);
     if (nextContent === undefined) {
-      console.log(`WARN ${targetPath} has partial threadnote markers; not modifying it`);
+      consoleOutput.log(`WARN ${targetPath} has partial threadnote markers; not modifying it`);
       continue;
     }
     if (nextContent === currentContent) {
-      console.log(`No threadnote block found: ${targetPath}`);
+      consoleOutput.log(`No threadnote block found: ${targetPath}`);
       continue;
     }
     if (nextContent.trim().length === 0) {
@@ -1725,11 +1809,11 @@ async function removeUserAgentInstructions(dryRun: boolean): Promise<void> {
       continue;
     }
     if (dryRun) {
-      console.log(`Would update ${targetPath}`);
+      consoleOutput.log(`Would update ${targetPath}`);
       continue;
     }
     await writeFile(targetPath, nextContent, {encoding: 'utf8', mode: 0o644});
-    console.log(`Updated ${targetPath}`);
+    consoleOutput.log(`Updated ${targetPath}`);
   }
 }
 
@@ -1850,11 +1934,11 @@ async function installLaunchAgent(config: RuntimeConfig, dryRun: boolean): Promi
   });
   if (dryRun) {
     const resolutionDetail = resolvedServer ?? `<not found; would use bare \`${OPENVIKING_SERVER_COMMAND}\`>`;
-    console.log(`Resolved openviking-server: ${resolutionDetail}`);
-    console.log(`Would write ${destination}`);
-    console.log(`Would run: launchctl unload ${destination}`);
-    console.log(`Would run: launchctl load ${destination}`);
-    console.log(`Would run: launchctl start ${LAUNCHD_LABEL}`);
+    consoleOutput.log(`Resolved openviking-server: ${resolutionDetail}`);
+    consoleOutput.log(`Would write ${destination}`);
+    consoleOutput.log(`Would run: launchctl unload ${destination}`);
+    consoleOutput.log(`Would run: launchctl load ${destination}`);
+    consoleOutput.log(`Would run: launchctl start ${LAUNCHD_LABEL}`);
     return;
   }
   await ensureDirectory(dirname(destination), false);
@@ -1870,7 +1954,7 @@ async function installLaunchAgent(config: RuntimeConfig, dryRun: boolean): Promi
     `Waiting for OpenViking health at ${healthUrl}.`,
   );
   if (health) {
-    console.log(`Installed and started ${LAUNCHD_LABEL}. Health OK at ${healthUrl}`);
+    consoleOutput.log(`Installed and started ${LAUNCHD_LABEL}. Health OK at ${healthUrl}`);
     return;
   }
   throw new Error(
@@ -1883,11 +1967,11 @@ async function removeLaunchAgent(dryRun: boolean): Promise<void> {
   const launchAgentPath = expandPath(`~/Library/LaunchAgents/${LAUNCHD_LABEL}.plist`);
   const content = await readFileIfExists(launchAgentPath);
   if (content === undefined) {
-    console.log(`Already absent: ${launchAgentPath}`);
+    consoleOutput.log(`Already absent: ${launchAgentPath}`);
     return;
   }
   if (!content.includes(LAUNCHD_LABEL) || !content.includes(OPENVIKING_SERVER_COMMAND)) {
-    console.log(`WARN not removing unmanaged LaunchAgent: ${launchAgentPath}`);
+    consoleOutput.log(`WARN not removing unmanaged LaunchAgent: ${launchAgentPath}`);
     return;
   }
   await removePath(launchAgentPath, 'LaunchAgent', dryRun);

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -2,9 +2,11 @@ import {createServer, type IncomingMessage, type Server, type ServerResponse} fr
 import {randomBytes, randomUUID} from 'node:crypto';
 import {lstat, readFile, readdir, rm} from 'node:fs/promises';
 import {join, relative, sep} from 'node:path';
-import {Effect, FiberSet, FileSystem, Result} from 'effect';
+import {Console, Effect, FiberSet, FileSystem, Result} from 'effect';
 import {effectAiConfiguration, runEffectAiConsolidation} from './effect/ai-consolidator.js';
 import {runCommandEffect} from './effect/command.js';
+import {captureConsole, capturePromiseConsole, consoleOutput} from './effect/console.js';
+import {fromPromiseError} from './effect/errors.js';
 import type {ApplicationServices} from './effect/runtime.js';
 import {uriSegment} from './manifest.js';
 import {
@@ -93,11 +95,6 @@ interface ApiContext {
 type ManagerOperation<A> = Effect.Effect<A, unknown, ApplicationServices>;
 type ManagerEffectPromise = <A>(effect: ManagerOperation<A>) => Promise<A>;
 
-// Capturing legacy console output mutates process-global state. Serialize these
-// compatibility operations so concurrent manager requests cannot steal or
-// restore one another's console handlers.
-let capturedOutputQueue: Promise<void> = Promise.resolve();
-
 type ConsolidationStatus = 'completed' | 'failed' | 'running';
 
 interface ConsolidationJob {
@@ -150,22 +147,17 @@ export function runManage(config: RuntimeConfig, options: ManageOptions) {
       const server = createManagerServer({config, jobs: new Map(), token}, runEffect);
       const port = options.uiPort ?? 0;
       yield* Effect.acquireRelease(
-        Effect.tryPromise({
-          try: async () => {
-            await listen(server, port);
-            return server;
-          },
-          catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
+        fromPromiseError(async () => {
+          await listen(server, port);
+          return server;
         }),
         closeManagerServer,
       );
       const address = server.address();
       const actualPort = typeof address === 'object' && address ? address.port : port;
       const url = `http://127.0.0.1:${actualPort}/?token=${encodeURIComponent(token)}`;
-      yield* Effect.sync(() => {
-        console.log(`Threadnote manager: ${url}`);
-        console.log('Press Ctrl-C to stop the manager.');
-      });
+      yield* Console.log(`Threadnote manager: ${url}`);
+      yield* Console.log('Press Ctrl-C to stop the manager.');
       if (options.open !== false) {
         yield* runCommandEffect('open', [url], {allowFailure: true});
       }
@@ -264,6 +256,7 @@ export async function readManagedMemory(
 export async function readContextUri(
   config: RuntimeConfig,
   uri: string,
+  runEffect?: ManagerEffectPromise,
 ): Promise<{
   readonly content: string;
   readonly localMemory?: Awaited<ReturnType<typeof readManagedMemory>>;
@@ -274,7 +267,7 @@ export async function readContextUri(
     const localMemory = await readManagedMemory(config, uri);
     return {content: localMemory.content, localMemory, output: localMemory.content};
   } catch {
-    const result = await runCaptured(() => runRead(config, uri, {}));
+    const result = await runCaptured(() => runRead(config, uri, {}), runEffect);
     return {content: result.output, output: result.output};
   }
 }
@@ -321,10 +314,9 @@ function handleRequestEffect(
         writeJson(response, 401, {error: 'Unauthorized'});
         return;
       }
-      const [agents, version] = yield* Effect.tryPromise({
-        try: () => Promise.all([detectConsolidationAgents(), currentPackageVersion()]),
-        catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-      });
+      const [agents, version] = yield* fromPromiseError(() =>
+        Promise.all([detectConsolidationAgents(), currentPackageVersion()]),
+      );
       const latest = yield* Effect.try({
         try: updateRegistry,
         catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
@@ -343,18 +335,12 @@ function handleRequestEffect(
         writeJson(response, 401, {error: 'Unauthorized'});
         return;
       }
-      const body = yield* Effect.tryPromise({
-        try: () => readJsonBody(request),
-        catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-      });
+      const body = yield* fromPromiseError(() => readJsonBody(request));
       const job = yield* createConsolidation(context, body);
       writeJson(response, 200, {job});
     });
   } else {
-    requestEffect = Effect.tryPromise({
-      try: () => handleRequestLegacy(context, request, response),
-      catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-    });
+    requestEffect = fromPromiseError(() => handleRequestLegacy(context, request, response));
   }
 
   return requestEffect.pipe(
@@ -396,7 +382,7 @@ async function handleRequestLegacy(
     return;
   }
   if (request.method === 'GET' && url.pathname === '/api/read') {
-    writeJson(response, 200, await readContextUri(context.config, requiredQuery(url, 'uri')));
+    writeJson(response, 200, await readContextUri(context.config, requiredQuery(url, 'uri'), context.runEffect));
     return;
   }
   if (request.method === 'GET' && url.pathname === '/api/shares') {
@@ -495,10 +481,7 @@ async function handleRequestLegacy(
         await runCaptured(
           () =>
             Effect.gen(function* () {
-              yield* Effect.tryPromise({
-                try: () => runCompactDiagnostics(context.config, body),
-                catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-              });
+              yield* fromPromiseError(() => runCompactDiagnostics(context.config, body));
               yield* runCompact(context.config, body);
             }),
           context.runEffect,
@@ -509,17 +492,19 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() =>
-          runRecall(context.config, {
-            query: requireString(body.query, 'query'),
-            nodeLimit: optionalString(body.nodeLimit),
-            project: optionalString(body.project),
-          }),
+        await runCaptured(
+          () =>
+            runRecall(context.config, {
+              query: requireString(body.query, 'query'),
+              nodeLimit: optionalString(body.nodeLimit),
+              project: optionalString(body.project),
+            }),
+          context.runEffect,
         ),
       );
       return;
     case '/api/read':
-      writeJson(response, 200, await readContextUri(context.config, requireString(body.uri, 'uri')));
+      writeJson(response, 200, await readContextUri(context.config, requireString(body.uri, 'uri'), context.runEffect));
       return;
     case '/api/shares/init':
       requireConfirm(body);
@@ -573,7 +558,7 @@ async function handleRequestLegacy(
       );
       return;
     case '/api/doctor/start':
-      writeJson(response, 200, await runCaptured(() => runStart(context.config, {})));
+      writeJson(response, 200, await runCaptured(() => runStart(context.config, {}), context.runEffect));
       return;
     case '/api/doctor/repair-dry-run':
       writeJson(response, 200, await runCaptured(() => runRepair(context.config, {dryRun: true}), context.runEffect));
@@ -587,15 +572,19 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() => runImportPack(context.config, {path: requireString(body.path, 'path')})),
+        await runCaptured(
+          () => runImportPack(context.config, {path: requireString(body.path, 'path')}),
+          context.runEffect,
+        ),
       );
       return;
     case '/api/export-pack':
       writeJson(
         response,
         200,
-        await runCaptured(() =>
-          runExportPack(context.config, {path: optionalString(body.path), uri: optionalString(body.uri)}),
+        await runCaptured(
+          () => runExportPack(context.config, {path: optionalString(body.path), uri: optionalString(body.uri)}),
+          context.runEffect,
         ),
       );
       return;
@@ -604,10 +593,12 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() =>
-          body.skills === true
-            ? runSeedSkills(context.config, {dryRun: body.dryRun === true})
-            : runSeed(context.config, {dryRun: body.dryRun === true}),
+        await runCaptured(
+          () =>
+            body.skills === true
+              ? runSeedSkills(context.config, {dryRun: body.dryRun === true})
+              : runSeed(context.config, {dryRun: body.dryRun === true}),
+          context.runEffect,
         ),
       );
       return;
@@ -895,8 +886,8 @@ async function removeManagedFolder(
     await runEffect(runForget(config, fileUri, {}));
   }
   await rm(path, {force: true, recursive: true});
-  console.log(`Removed folder: ${uri}`);
-  console.log(`Forgot ${fileUris.length} file${fileUris.length === 1 ? '' : 's'}.`);
+  consoleOutput.log(`Removed folder: ${uri}`);
+  consoleOutput.log(`Forgot ${fileUris.length} file${fileUris.length === 1 ? '' : 's'}.`);
 }
 
 async function fileUrisUnderFolder(config: RuntimeConfig, folderPath: string): Promise<readonly string[]> {
@@ -961,10 +952,9 @@ function createConsolidation(context: ApiContext, body: Record<string, unknown>)
     };
     context.jobs.set(job.id, job);
     yield* Effect.gen(function* () {
-      const sources = yield* Effect.tryPromise({
-        try: () => Promise.all(input.sourceUris.map(uri => readManagedMemory(context.config, uri))),
-        catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-      });
+      const sources = yield* fromPromiseError(() =>
+        Promise.all(input.sourceUris.map(uri => readManagedMemory(context.config, uri))),
+      );
       job.draft = yield* runConsolidationAgent(input.agent, sources);
       job.status = 'completed';
     }).pipe(
@@ -1042,10 +1032,7 @@ function runConsolidationAgent(
     return Effect.fail(new Error(`${agent} does not expose a supported non-interactive consolidation mode.`));
   }
   return Effect.gen(function* () {
-    const executable = yield* Effect.tryPromise({
-      try: () => findExecutable([agent]),
-      catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-    });
+    const executable = yield* fromPromiseError(() => findExecutable([agent]));
     if (!executable) {
       return yield* Effect.fail(new Error(`${agent} executable was not found.`));
     }
@@ -1192,34 +1179,18 @@ async function runCaptured(
   action: () => Promise<void> | ManagerOperation<void>,
   runEffect?: ManagerEffectPromise,
 ): Promise<{readonly output: string}> {
-  const queued = capturedOutputQueue.then(async () => {
-    const lines: string[] = [];
-    const originalLog = console.log;
-    const originalWarn = console.warn;
-    const originalError = console.error;
-    console.log = (...args: readonly unknown[]) => lines.push(args.map(String).join(' '));
-    console.warn = (...args: readonly unknown[]) => lines.push(args.map(String).join(' '));
-    console.error = (...args: readonly unknown[]) => lines.push(args.map(String).join(' '));
-    try {
-      const operation = action();
-      if (Effect.isEffect(operation)) {
-        if (!runEffect) throw new Error('Manager Effect runtime is unavailable.');
-        await runEffect(operation);
-      } else {
-        await operation;
-      }
-    } finally {
-      console.log = originalLog;
-      console.warn = originalWarn;
-      console.error = originalError;
+  const captured = await capturePromiseConsole(async () => {
+    const operation = action();
+    if (!Effect.isEffect(operation)) {
+      await operation;
+      return undefined;
     }
-    return {output: lines.join('\n')};
+    if (!runEffect) throw new Error('Manager Effect runtime is unavailable.');
+    return runEffect(captureConsole(operation));
   });
-  capturedOutputQueue = queued.then(
-    () => undefined,
-    () => undefined,
-  );
-  return queued;
+  return {
+    output: [captured.output, captured.value?.output].filter(Boolean).join('\n'),
+  };
 }
 
 function memoryUriFor(

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,7 +2,11 @@ import {statSync} from 'node:fs';
 import {writeFile} from 'node:fs/promises';
 import {dirname, join} from 'node:path';
 import {platform} from 'node:os';
+import {Console, Effect} from 'effect';
 import {OPENVIKING_MCP_NAME} from './constants.js';
+import {maybeRunEffect} from './effect/command.js';
+import {consoleOutput, syncWithConsole} from './effect/console.js';
+import {applicationError, fromPromise} from './effect/errors.js';
 import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset} from './mcp_toolset.js';
 import type {
   AgentClient,
@@ -29,79 +33,92 @@ import {
   toolRoot,
 } from './utils.js';
 
-export async function runMcpInstall(
-  config: RuntimeConfig,
-  agent: AgentClient,
-  options: McpInstallOptions,
-): Promise<void> {
-  const name = options.name ?? OPENVIKING_MCP_NAME;
-  const url = options.url ?? `http://${config.host}:${config.port}/mcp`;
-  const apply = options.apply === true;
-  const nativeHttp = options.nativeHttp === true;
-  const toolset = options.toolset ?? DEFAULT_MCP_TOOLSET;
+export function runMcpInstall(config: RuntimeConfig, agent: AgentClient, options: McpInstallOptions) {
+  return Effect.gen(function* () {
+    const name = options.name ?? OPENVIKING_MCP_NAME;
+    const url = options.url ?? `http://${config.host}:${config.port}/mcp`;
+    const apply = options.apply === true;
+    const nativeHttp = options.nativeHttp === true;
+    const toolset = options.toolset ?? DEFAULT_MCP_TOOLSET;
 
-  if (nativeHttp) {
-    const mcpStatus = await readHttpStatus(url, 1200);
-    const unavailable = mcpStatus === undefined || mcpStatus === 404;
-    if (unavailable && apply) {
-      throw new Error(
-        `OpenViking native MCP endpoint is not available at ${url}. ` +
-          'Use the default stdio adapter, or install an OpenViking build that exposes /mcp.',
+    if (nativeHttp) {
+      const mcpStatus = yield* fromPromise('probe native OpenViking MCP endpoint', () => readHttpStatus(url, 1200));
+      const unavailable = mcpStatus === undefined || mcpStatus === 404;
+      if (unavailable && apply) {
+        return yield* Effect.fail(
+          applicationError(
+            'install native MCP configuration',
+            new Error(
+              `OpenViking native MCP endpoint is not available at ${url}. ` +
+                'Use the default stdio adapter, or install an OpenViking build that exposes /mcp.',
+            ),
+          ),
+        );
+      }
+      if (unavailable) {
+        yield* Console.log(
+          `WARN OpenViking native MCP endpoint is not available at ${url}; default mcp-install uses stdio.`,
+        );
+      }
+    }
+
+    if (agent === 'cursor') {
+      yield* fromPromise('install Cursor MCP configuration', () =>
+        runCursorMcpInstall(config, name, {
+          apply,
+          bearerTokenEnvVar: options.bearerTokenEnvVar,
+          nativeHttp,
+          toolset,
+          url,
+        }),
       );
+      return;
     }
-    if (unavailable) {
-      console.log(`WARN OpenViking native MCP endpoint is not available at ${url}; default mcp-install uses stdio.`);
+    if (agent === 'copilot') {
+      yield* fromPromise('install GitHub Copilot MCP configuration', () =>
+        runCopilotMcpInstall(config, name, {
+          apply,
+          bearerTokenEnvVar: options.bearerTokenEnvVar,
+          nativeHttp,
+          toolset,
+          url,
+        }),
+      );
+      return;
     }
-  }
 
-  if (agent === 'cursor') {
-    await runCursorMcpInstall(config, name, {
-      apply,
+    const agentExecutable = apply
+      ? yield* fromPromise(`find ${agent} executable`, () => requiredMcpAgentExecutable(agent))
+      : agent;
+
+    const command = buildMcpInstallCommand(config, agent, agentExecutable, name, {
       bearerTokenEnvVar: options.bearerTokenEnvVar,
       nativeHttp,
+      scope: options.scope,
       toolset,
       url,
     });
-    return;
-  }
-  if (agent === 'copilot') {
-    await runCopilotMcpInstall(config, name, {
-      apply,
-      bearerTokenEnvVar: options.bearerTokenEnvVar,
-      nativeHttp,
-      toolset,
-      url,
-    });
-    return;
-  }
+    const removeCommand = buildMcpRemoveCommand(agent, agentExecutable, name);
 
-  const agentExecutable = apply ? await requiredMcpAgentExecutable(agent) : agent;
-
-  const command = buildMcpInstallCommand(config, agent, agentExecutable, name, {
-    bearerTokenEnvVar: options.bearerTokenEnvVar,
-    nativeHttp,
-    scope: options.scope,
-    toolset,
-    url,
-  });
-  const removeCommand = buildMcpRemoveCommand(agent, agentExecutable, name);
-
-  if (!apply) {
-    console.log('Dry run. Re-run with --apply to modify the selected agent config.');
-    if (removeCommand.cwd || command.cwd) {
-      console.log(`Command working directory: ${removeCommand.cwd ?? command.cwd}`);
+    if (!apply) {
+      yield* syncWithConsole(() => {
+        consoleOutput.log('Dry run. Re-run with --apply to modify the selected agent config.');
+        if (removeCommand.cwd || command.cwd) {
+          consoleOutput.log(`Command working directory: ${removeCommand.cwd ?? command.cwd}`);
+        }
+        consoleOutput.log(formatShellCommand(removeCommand.executable, removeCommand.args));
+        consoleOutput.log(formatShellCommand(command.executable, command.args));
+        printMcpSnippet(config, agent, name, {nativeHttp, scope: options.scope, toolset, url});
+      });
+      return;
     }
-    console.log(formatShellCommand(removeCommand.executable, removeCommand.args));
-    console.log(formatShellCommand(command.executable, command.args));
-    printMcpSnippet(config, agent, name, {nativeHttp, scope: options.scope, toolset, url});
-    return;
-  }
 
-  await maybeRun(false, removeCommand.executable, removeCommand.args, {
-    allowFailure: true,
-    cwd: removeCommand.cwd,
+    yield* maybeRunEffect(false, removeCommand.executable, removeCommand.args, {
+      allowFailure: true,
+      cwd: removeCommand.cwd,
+    });
+    yield* maybeRunEffect(false, command.executable, command.args, {cwd: command.cwd});
   });
-  await maybeRun(false, command.executable, command.args, {cwd: command.cwd});
 }
 
 async function runCursorMcpInstall(
@@ -126,7 +143,7 @@ async function runCursorMcpInstall(
   const nextContent = renderCursorMcpConfig(currentContent, name, serverConfig);
 
   if (!options.apply) {
-    console.log('Dry run. Re-run with --apply to modify Cursor MCP config.');
+    consoleOutput.log('Dry run. Re-run with --apply to modify Cursor MCP config.');
     printCursorMcpSnippet(config, name, {
       bearerTokenEnvVar: options.bearerTokenEnvVar,
       nativeHttp: options.nativeHttp,
@@ -137,12 +154,14 @@ async function runCursorMcpInstall(
   }
 
   if (currentContent === nextContent) {
-    console.log(`Already configured: ${path}`);
+    consoleOutput.log(`Already configured: ${path}`);
     return;
   }
   await ensureDirectory(dirname(path), false);
   await writeFile(path, nextContent, {encoding: 'utf8', mode: 0o644});
-  console.log(currentContent === undefined ? `Wrote Cursor MCP config: ${path}` : `Updated Cursor MCP config: ${path}`);
+  consoleOutput.log(
+    currentContent === undefined ? `Wrote Cursor MCP config: ${path}` : `Updated Cursor MCP config: ${path}`,
+  );
 }
 
 async function runCopilotMcpInstall(
@@ -167,7 +186,7 @@ async function runCopilotMcpInstall(
   const nextContent = renderCopilotMcpConfig(currentContent, name, serverConfig);
 
   if (!options.apply) {
-    console.log('Dry run. Re-run with --apply to modify GitHub Copilot MCP config.');
+    consoleOutput.log('Dry run. Re-run with --apply to modify GitHub Copilot MCP config.');
     printCopilotMcpSnippet(config, name, {
       bearerTokenEnvVar: options.bearerTokenEnvVar,
       nativeHttp: options.nativeHttp,
@@ -178,12 +197,12 @@ async function runCopilotMcpInstall(
   }
 
   if (currentContent === nextContent) {
-    console.log(`Already configured: ${path}`);
+    consoleOutput.log(`Already configured: ${path}`);
     return;
   }
   await ensureDirectory(dirname(path), false);
   await writeFile(path, nextContent, {encoding: 'utf8', mode: 0o644});
-  console.log(
+  consoleOutput.log(
     currentContent === undefined
       ? `Wrote GitHub Copilot MCP config: ${path}`
       : `Updated GitHub Copilot MCP config: ${path}`,
@@ -193,7 +212,7 @@ async function runCopilotMcpInstall(
 export async function removeMcpConfigs(value: string, dryRun: boolean): Promise<void> {
   const clients = await resolveMcpClients(value, 'remove');
   if (clients.length === 0) {
-    console.log('Skipping MCP config removal.');
+    consoleOutput.log('Skipping MCP config removal.');
     return;
   }
   for (const client of clients) {
@@ -285,7 +304,7 @@ function buildMcpInstallCommand(
     if (token) {
       args.push('--header', `Authorization: Bearer ${token}`);
     } else {
-      console.log(
+      consoleOutput.log(
         `WARN ${options.bearerTokenEnvVar} is not set; installing Claude MCP without an Authorization header.`,
       );
     }
@@ -435,16 +454,16 @@ async function removeCursorMcpConfig(name: string, dryRun: boolean): Promise<voi
   const path = cursorMcpConfigPath();
   const currentContent = await readFileIfExists(path);
   if (isEmptyConfigContent(currentContent)) {
-    console.log(`Already absent: ${path}`);
+    consoleOutput.log(`Already absent: ${path}`);
     return;
   }
   const parsed = parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
-    console.log(`WARN ${path} exists but is not a JSON object; not modifying it.`);
+    consoleOutput.log(`WARN ${path} exists but is not a JSON object; not modifying it.`);
     return;
   }
   if (!isJsonObject(parsed.mcpServers) || parsed.mcpServers[name] === undefined) {
-    console.log(`No Cursor MCP config found: ${path}`);
+    consoleOutput.log(`No Cursor MCP config found: ${path}`);
     return;
   }
   const nextConfig: Record<string, unknown> = {...parsed};
@@ -453,27 +472,27 @@ async function removeCursorMcpConfig(name: string, dryRun: boolean): Promise<voi
   nextConfig.mcpServers = mcpServers;
   const nextContent = `${JSON.stringify(nextConfig, null, 2)}\n`;
   if (dryRun) {
-    console.log(`Would update Cursor MCP config: ${path}`);
+    consoleOutput.log(`Would update Cursor MCP config: ${path}`);
     return;
   }
   await writeFile(path, nextContent, {encoding: 'utf8', mode: 0o644});
-  console.log(`Updated Cursor MCP config: ${path}`);
+  consoleOutput.log(`Updated Cursor MCP config: ${path}`);
 }
 
 async function removeCopilotMcpConfig(name: string, dryRun: boolean): Promise<void> {
   const path = copilotMcpConfigPath();
   const currentContent = await readFileIfExists(path);
   if (isEmptyConfigContent(currentContent)) {
-    console.log(`Already absent: ${path}`);
+    consoleOutput.log(`Already absent: ${path}`);
     return;
   }
   const parsed = parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
-    console.log(`WARN ${path} exists but is not a JSON object; not modifying it.`);
+    consoleOutput.log(`WARN ${path} exists but is not a JSON object; not modifying it.`);
     return;
   }
   if (!isJsonObject(parsed.servers) || parsed.servers[name] === undefined) {
-    console.log(`No GitHub Copilot MCP config found: ${path}`);
+    consoleOutput.log(`No GitHub Copilot MCP config found: ${path}`);
     return;
   }
   const nextConfig: Record<string, unknown> = {...parsed};
@@ -482,11 +501,11 @@ async function removeCopilotMcpConfig(name: string, dryRun: boolean): Promise<vo
   nextConfig.servers = servers;
   const nextContent = `${JSON.stringify(nextConfig, null, 2)}\n`;
   if (dryRun) {
-    console.log(`Would update GitHub Copilot MCP config: ${path}`);
+    consoleOutput.log(`Would update GitHub Copilot MCP config: ${path}`);
     return;
   }
   await writeFile(path, nextContent, {encoding: 'utf8', mode: 0o644});
-  console.log(`Updated GitHub Copilot MCP config: ${path}`);
+  consoleOutput.log(`Updated GitHub Copilot MCP config: ${path}`);
 }
 
 function printMcpSnippet(
@@ -524,7 +543,7 @@ function printMcpSnippet(
     url: options.url,
   });
   const snippet = `${formatShellCommand(command.executable, command.args)}\n`;
-  console.log(`\nSnippet (${snippetPath}):\n${snippet}`);
+  consoleOutput.log(`\nSnippet (${snippetPath}):\n${snippet}`);
 }
 
 function printCursorMcpSnippet(
@@ -539,7 +558,7 @@ function printCursorMcpSnippet(
 ): void {
   const snippetPath = join(config.agentContextHome, 'mcp', `${name}.cursor.json`);
   const snippet = JSON.stringify({mcpServers: {[name]: buildCursorMcpServerConfig(config, options)}}, null, 2);
-  console.log(`\nSnippet (${snippetPath}; merge into ${cursorMcpConfigPath()}):\n${snippet}`);
+  consoleOutput.log(`\nSnippet (${snippetPath}; merge into ${cursorMcpConfigPath()}):\n${snippet}`);
 }
 
 function printCopilotMcpSnippet(
@@ -554,7 +573,7 @@ function printCopilotMcpSnippet(
 ): void {
   const snippetPath = join(config.agentContextHome, 'mcp', `${name}.copilot.json`);
   const snippet = JSON.stringify({servers: {[name]: buildCopilotMcpServerConfig(config, options)}}, null, 2);
-  console.log(`\nSnippet (${snippetPath}; merge into ${copilotMcpConfigPath()}):\n${snippet}`);
+  consoleOutput.log(`\nSnippet (${snippetPath}; merge into ${copilotMcpConfigPath()}):\n${snippet}`);
 }
 
 function cursorMcpConfigPath(): string {
@@ -615,7 +634,7 @@ export async function resolveMcpClients(value: string, action: 'remove' | 'repai
   for (const client of requested) {
     if (client === 'cursor') {
       if (!(await isCursorAvailable())) {
-        console.log(`WARN Cursor config not found; cannot ${action} cursor MCP config.`);
+        consoleOutput.log(`WARN Cursor config not found; cannot ${action} cursor MCP config.`);
         continue;
       }
       if (!clients.includes(client)) {
@@ -625,7 +644,7 @@ export async function resolveMcpClients(value: string, action: 'remove' | 'repai
     }
     if (client === 'copilot') {
       if (!(await isCopilotAvailable())) {
-        console.log(`WARN VS Code/Copilot config not found; cannot ${action} copilot MCP config.`);
+        consoleOutput.log(`WARN VS Code/Copilot config not found; cannot ${action} copilot MCP config.`);
         continue;
       }
       if (!clients.includes(client)) {
@@ -635,7 +654,7 @@ export async function resolveMcpClients(value: string, action: 'remove' | 'repai
     }
     if (!(await findMcpAgentExecutable(client))) {
       const discovered = await findExecutable([client]);
-      console.log(
+      consoleOutput.log(
         discovered
           ? `WARN ${client} command at ${discovered} is not working; cannot ${action} ${client} MCP config. ` +
               `Repair or reinstall ${client}, then run threadnote mcp-install ${client} --apply.`

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -6,7 +6,7 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {readdir, readFile} from 'node:fs/promises';
 import {join} from 'node:path';
-import {Effect, pipe} from 'effect';
+import {Console, Effect, pipe} from 'effect';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset, parseMcpToolset} from './mcp_toolset.js';
 import {formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
@@ -75,6 +75,8 @@ import {
 } from './utils.js';
 import {withIdentity} from './runtime.js';
 import {EffectMcpServerAdapter, McpInput} from './effect/mcp.js';
+import {runWithConsole} from './effect/console.js';
+import {fromPromiseError as attemptPromise} from './effect/errors.js';
 import {removeOpenVikingResourceEffect} from './effect/openviking.js';
 import {ApplicationLayer} from './effect/runtime.js';
 
@@ -186,16 +188,15 @@ const mainEffect = Effect.gen(function* () {
     try: () => parseMcpToolset(process.env[MCP_TOOLSET_ENV] ?? DEFAULT_MCP_TOOLSET),
     catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
   });
-  mcpStartupVersion = yield* Effect.tryPromise(currentPackageVersion).pipe(
-    Effect.catch(() => Effect.succeed(undefined)),
-  );
+  mcpStartupVersion = yield* attemptPromise(currentPackageVersion).pipe(Effect.catch(() => Effect.succeed(undefined)));
   const instructions =
     'Threadnote provides local context. On non-trivial work, call `recall_context` with repo/project in `query` and absolute `callerCwd`; read relevant `viking://` URIs. Store reusable facts as durable and progress as handoff with stable project/topic; replace instead of duplicate. Do not store secrets, credentials, customer data, or raw production logs. Confirm before publishing durable memories; never publish handoffs or preferences. Use `threadnote_guide` for capabilities and CLI for absent advanced tools.';
   const server = new EffectMcpServerAdapter('threadnote-local-adapter', '0.2.0', instructions);
 
   registerTools(server, config, toolset);
+  const output = yield* Console.Console;
   yield* Effect.acquireRelease(
-    Effect.sync(() => startShareBackgroundFetch(config)),
+    Effect.sync(() => runWithConsole(output, () => startShareBackgroundFetch(config))),
     () => Effect.sync(() => stopShareBackgroundFetch(config)),
   );
   yield* Effect.sync(() => process.stderr.write('Threadnote local MCP adapter running\n'));
@@ -1757,9 +1758,6 @@ interface WriteDurableMemoryParams {
   readonly replaceUri?: string;
 }
 
-const attemptPromise = <A>(evaluate: () => Promise<A>) =>
-  Effect.tryPromise({try: evaluate, catch: cause => (cause instanceof Error ? cause : new Error(String(cause)))});
-
 function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryParams) {
   return Effect.gen(function* () {
     const ov = yield* attemptPromise(requiredOpenVikingCli);
@@ -1858,10 +1856,7 @@ function removeVikingResourceWithRetry(ov: string, config: RuntimeConfig, uri: s
 
 function runOpenVikingRemoveTool(config: RuntimeConfig, uri: string, recursive: boolean) {
   return Effect.gen(function* () {
-    const ov = yield* Effect.tryPromise({
-      try: requiredOpenVikingCli,
-      catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-    });
+    const ov = yield* attemptPromise(requiredOpenVikingCli);
     const removed = yield* removeVikingResourceWithRetry(ov, config, uri, recursive);
     return {
       content: [
@@ -2339,10 +2334,9 @@ function textFromCallToolResult(result: CallToolResult): string {
 }
 
 function forgetVikingResourceWithRetry(config: RuntimeConfig, uri: string) {
-  return Effect.tryPromise({
-    try: requiredOpenVikingCli,
-    catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-  }).pipe(Effect.flatMap(ov => removeVikingResourceWithRetry(ov, config, uri)));
+  return attemptPromise(requiredOpenVikingCli).pipe(
+    Effect.flatMap(ov => removeVikingResourceWithRetry(ov, config, uri)),
+  );
 }
 
 interface SharePublishToolOptions {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,7 +1,10 @@
 import {chmod, readFile, readdir, rm, stat, writeFile} from 'node:fs/promises';
 import {basename, dirname, join, sep} from 'node:path';
 import yaml from 'js-yaml';
-import {Effect, pipe} from 'effect';
+import {Console, Effect, FileSystem, pipe} from 'effect';
+import {maybeRunEffect} from './effect/command.js';
+import {consoleOutput, syncWithConsole} from './effect/console.js';
+import {fromPromiseError as attempt} from './effect/errors.js';
 import {removeOpenVikingResourceEffect} from './effect/openviking.js';
 import {
   inferProjectFromQuery,
@@ -174,9 +177,6 @@ export function parseCompactKind(value: string): CompactableMemoryKind {
   throw new Error(`Unsupported compact kind "${value}". Expected durable, handoff, or incident.`);
 }
 
-const attempt = <A>(evaluate: () => Promise<A>) =>
-  Effect.tryPromise({try: evaluate, catch: cause => (cause instanceof Error ? cause : new Error(String(cause)))});
-
 const attemptSync = <A>(evaluate: () => A) =>
   Effect.try({try: evaluate, catch: cause => (cause instanceof Error ? cause : new Error(String(cause)))});
 
@@ -205,28 +205,34 @@ export const runRemember = Effect.fn('runRemember')(function* (config: RuntimeCo
   });
 });
 
-export async function runMigrateMemories(config: RuntimeConfig, options: MigrateMemoriesOptions): Promise<void> {
+export const runMigrateMemories = Effect.fn('runMigrateMemories')(function* (
+  config: RuntimeConfig,
+  options: MigrateMemoriesOptions,
+) {
+  const fs = yield* FileSystem.FileSystem;
   const dryRun = options.dryRun === true;
-  const limit = options.limit ? parsePositiveInteger(options.limit, 'migration limit') : undefined;
-  const sourceAccounts = await legacySourceAccounts(config, options);
+  const limit = options.limit
+    ? yield* attemptSync(() => parsePositiveInteger(options.limit!, 'migration limit'))
+    : undefined;
+  const sourceAccounts = yield* attempt(() => legacySourceAccounts(config, options));
   if (sourceAccounts.length === 0) {
-    console.log('No local OpenViking accounts found to scan.');
+    yield* syncWithConsole(() => consoleOutput.log('No local OpenViking accounts found to scan.'));
     return;
   }
 
-  const candidates = await legacyMemoryCandidates(config, sourceAccounts);
-  const existingHashes = await existingDurableMemoryHashes(config);
-  const ov = await openVikingCliForMode(dryRun);
+  const candidates = yield* attempt(() => legacyMemoryCandidates(config, sourceAccounts));
+  const existingHashes = yield* attempt(() => existingDurableMemoryHashes(config));
+  const ov = yield* attempt(() => openVikingCliForMode(dryRun));
   const migrationPath = join(config.agentContextHome, 'legacy-memory-migration.txt');
 
   let duplicateCount = 0;
   let migratedCount = 0;
   let sensitiveCount = 0;
   if (!dryRun && candidates.length > 0) {
-    await ensureDurableMemoryDirectory(ov, config);
+    yield* attempt(() => ensureDurableMemoryDirectory(ov, config));
   }
 
-  try {
+  const migrate = Effect.gen(function* () {
     for (const candidate of candidates) {
       if (existingHashes.has(candidate.hash)) {
         duplicateCount += 1;
@@ -239,8 +245,10 @@ export async function runMigrateMemories(config: RuntimeConfig, options: Migrate
       const sensitiveReason = sensitiveMemoryReason(candidate.text);
       if (sensitiveReason) {
         sensitiveCount += 1;
-        console.log(
-          `SKIP ${legacySourceLabel(candidate)}: possible ${sensitiveReason}; inspect the source archive manually if needed.`,
+        yield* syncWithConsole(() =>
+          consoleOutput.log(
+            `SKIP ${legacySourceLabel(candidate)}: possible ${sensitiveReason}; inspect the source archive manually if needed.`,
+          ),
         );
         continue;
       }
@@ -249,37 +257,38 @@ export async function runMigrateMemories(config: RuntimeConfig, options: Migrate
       }
 
       const memoryUri = migratedDurableMemoryUri(config, candidate.hash);
-      if (!dryRun && (await vikingResourceExists(ov, config, memoryUri))) {
+      if (!dryRun && (yield* attempt(() => vikingResourceExists(ov, config, memoryUri)))) {
         duplicateCount += 1;
         existingHashes.add(candidate.hash);
         continue;
       }
 
-      console.log(`${dryRun ? 'Would migrate' : 'Migrating'} ${legacySourceLabel(candidate)} -> ${memoryUri}`);
+      yield* syncWithConsole(() =>
+        consoleOutput.log(`${dryRun ? 'Would migrate' : 'Migrating'} ${legacySourceLabel(candidate)} -> ${memoryUri}`),
+      );
       if (!dryRun) {
-        await writeFile(migrationPath, candidate.text, {encoding: 'utf8', mode: 0o600});
-        await chmod(migrationPath, 0o600);
-        await writeDurableMemoryFile(ov, config, memoryUri, migrationPath, 'create');
+        yield* fs.writeFileString(migrationPath, candidate.text, {mode: 0o600});
+        yield* fs.chmod(migrationPath, 0o600);
+        yield* attempt(() => writeDurableMemoryFile(ov, config, memoryUri, migrationPath, 'create'));
         existingHashes.add(candidate.hash);
       }
       migratedCount += 1;
     }
-  } finally {
-    if (!dryRun) {
-      await rm(migrationPath, {force: true});
-    }
-  }
+  }).pipe(Effect.ensuring(dryRun ? Effect.void : Effect.ignore(fs.remove(migrationPath, {force: true}))));
 
-  console.log(
-    [
-      `Migration summary: ${migratedCount} ${dryRun ? 'would be migrated' : 'migrated'}`,
-      `${duplicateCount} duplicate(s) skipped`,
-      `${sensitiveCount} sensitive-looking item(s) skipped`,
-      `${candidates.length} legacy Threadnote item(s) scanned`,
-      `source account(s): ${sourceAccounts.join(', ')}`,
-    ].join('; '),
+  yield* migrate;
+  yield* syncWithConsole(() =>
+    consoleOutput.log(
+      [
+        `Migration summary: ${migratedCount} ${dryRun ? 'would be migrated' : 'migrated'}`,
+        `${duplicateCount} duplicate(s) skipped`,
+        `${sensitiveCount} sensitive-looking item(s) skipped`,
+        `${candidates.length} legacy Threadnote item(s) scanned`,
+        `source account(s): ${sourceAccounts.join(', ')}`,
+      ].join('; '),
+    ),
   );
-}
+});
 
 export const runMigrateLifecycle = Effect.fn('runMigrateLifecycle')(function* (
   config: RuntimeConfig,
@@ -306,11 +315,11 @@ export const runMigrateLifecycle = Effect.fn('runMigrateLifecycle')(function* (
         ['Migrated legacy handoff from the historical events trail.', '', candidate.original.trim()].join('\n'),
       );
 
-      console.log(`${dryRun ? 'Would migrate' : 'Migrating'} ${candidate.sourceUri} -> ${destinationUri}`);
+      yield* Console.log(`${dryRun ? 'Would migrate' : 'Migrating'} ${candidate.sourceUri} -> ${destinationUri}`);
       if (!dryRun) {
         if (yield* attempt(() => vikingResourceExists(ov, config, destinationUri))) {
           existingCount += 1;
-          console.log(`Archived copy already exists; cleaning up legacy source: ${candidate.sourceUri}`);
+          yield* Console.log(`Archived copy already exists; cleaning up legacy source: ${candidate.sourceUri}`);
         } else {
           yield* attempt(() => writeFile(migrationPath, migratedMemory, {encoding: 'utf8', mode: 0o600}));
           yield* attempt(() => chmod(migrationPath, 0o600));
@@ -319,7 +328,7 @@ export const runMigrateLifecycle = Effect.fn('runMigrateLifecycle')(function* (
         }
         const removedOriginal = yield* removeVikingResourceWithRetry(ov, config, candidate.sourceUri);
         if (!removedOriginal) {
-          console.error(
+          yield* Console.error(
             `Migrated copy stored, but original is still processing. Retry later: threadnote forget ${candidate.sourceUri}`,
           );
           skippedCount += 1;
@@ -333,7 +342,7 @@ export const runMigrateLifecycle = Effect.fn('runMigrateLifecycle')(function* (
     ),
   );
 
-  console.log(
+  yield* Console.log(
     [
       `Lifecycle migration summary: ${migratedCount} clear legacy handoff(s) ${dryRun ? 'would be migrated' : 'migrated'}`,
       `${existingCount} existing archived copy/copies reused`,
@@ -354,7 +363,7 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
   const limit = options.limit ? parsePositiveInteger(options.limit, 'project-name migration limit') : undefined;
   const contexts = yield* attempt(() => projectNameMigrationContexts(config));
   if (contexts.length === 0) {
-    console.log('No git remote project-name changes apply across configured projects.');
+    yield* Console.log('No git remote project-name changes apply across configured projects.');
     return;
   }
 
@@ -373,7 +382,7 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
   }
   const seedManifestMigration = yield* attempt(() => seedManifestProjectNameMigration(config, contexts));
   if (!plans.some(plan => plan.candidates.length > 0) && !seedManifestMigration) {
-    console.log('No project-name migration candidates found across configured projects.');
+    yield* Console.log('No project-name migration candidates found across configured projects.');
     return;
   }
 
@@ -394,7 +403,7 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
         : dryRun
           ? 'Would migrate'
           : 'Migrating';
-      console.log(`${action} ${candidate.sourceUri} -> ${candidate.destinationUri}`);
+      yield* Console.log(`${action} ${candidate.sourceUri} -> ${candidate.destinationUri}`);
       if (!dryRun) {
         if (candidate.destinationExistsWithSameContent) {
           existingCount += 1;
@@ -406,7 +415,7 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
         }
         const removedOriginal = yield* removeVikingResourceWithRetry(ov, config, candidate.sourceUri);
         if (!removedOriginal) {
-          console.error(
+          yield* Console.error(
             `Migrated copy stored, but original is still processing. Retry later: threadnote forget ${candidate.sourceUri}`,
           );
           skippedCount += 1;
@@ -418,7 +427,7 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
   const activeContexts = projectNameMigrationActiveContexts(plans, seedManifestMigration);
   const newProjectsToSeed = [...new Set(seedManifestMigration?.newProjects ?? [])];
 
-  console.log(
+  yield* Console.log(
     [
       projectNameMigrationSummary(migratedCount, dryRun, activeContexts),
       seedManifestUpdated ? `seed manifest ${dryRun ? 'would be updated' : 'updated'}` : 'seed manifest unchanged',
@@ -732,8 +741,8 @@ async function migrateSeedManifestProjectNames(
     return false;
   }
   if (dryRun) {
-    console.log(`Would update seed manifest: ${config.manifestPath}`);
-    console.log(migration.output.trimEnd());
+    consoleOutput.log(`Would update seed manifest: ${config.manifestPath}`);
+    consoleOutput.log(migration.output.trimEnd());
     return true;
   }
   await ensureDirectory(dirname(config.manifestPath), false);
@@ -742,11 +751,11 @@ async function migrateSeedManifestProjectNames(
     const backupPath = `${config.manifestPath}.project-name-${safeTimestamp()}`;
     await writeFile(backupPath, currentContent, {encoding: 'utf8', mode: 0o600});
     await chmod(backupPath, 0o600);
-    console.log(`Backup: ${backupPath}`);
+    consoleOutput.log(`Backup: ${backupPath}`);
   }
   await writeFile(config.manifestPath, migration.output, {encoding: 'utf8', mode: 0o600});
   await chmod(config.manifestPath, 0o600);
-  console.log(`Updated seed manifest: ${config.manifestPath}`);
+  consoleOutput.log(`Updated seed manifest: ${config.manifestPath}`);
   return true;
 }
 
@@ -918,36 +927,44 @@ function projectMemoryLocations(): readonly ProjectMemoryLocation[] {
   ];
 }
 
-export async function runRecall(config: RuntimeConfig, options: RecallOptions): Promise<void> {
+export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig, options: RecallOptions) {
   if (options.dryRun !== true) {
-    await syncSharedReposAndLog(config);
+    yield* attempt(() => syncSharedReposAndLog(config));
   }
-  const ov = await openVikingCliForMode(options.dryRun === true);
+  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
   const workspaceOptions = options.callerCwd
     ? {cwd: options.callerCwd, includeProcessCwd: false}
     : {includeProcessCwd: true};
-  const query = await enrichRecallQueryWithWorkspaceContext(options.query, workspaceOptions);
-  const projectQuery = await enrichRecallQueryWithWorkspaceProjectContext(options.query, workspaceOptions);
-  let indexRepairMessages: readonly string[];
-  try {
-    const indexRepair = await repairStaleRecallIndex(config, ov, {
+  const query = yield* attempt(() => enrichRecallQueryWithWorkspaceContext(options.query, workspaceOptions));
+  const projectQuery = yield* attempt(() =>
+    enrichRecallQueryWithWorkspaceProjectContext(options.query, workspaceOptions),
+  );
+  const indexRepairMessages = yield* attempt(() =>
+    repairStaleRecallIndex(config, ov, {
       dryRun: options.dryRun === true,
       query: projectQuery,
-    });
-    indexRepairMessages = formatRecallIndexRepairMessages(indexRepair, {dryRun: options.dryRun === true});
-  } catch (err: unknown) {
-    indexRepairMessages = [`Auto-index repair warning: ${err instanceof Error ? err.message : String(err)}`];
-  }
-  for (const message of indexRepairMessages) {
-    console.log(message);
-  }
+    }),
+  ).pipe(
+    Effect.map(indexRepair => formatRecallIndexRepairMessages(indexRepair, {dryRun: options.dryRun === true})),
+    Effect.catch(error => Effect.succeed([`Auto-index repair warning: ${error.message}`])),
+  );
+  yield* syncWithConsole(() => {
+    for (const message of indexRepairMessages) {
+      consoleOutput.log(message);
+    }
+  });
   const dryRun = options.dryRun === true;
   const inferredUri =
-    options.uri ?? (options.inferScope === false ? undefined : await inferRecallUri(config, projectQuery));
-  const project = await inferProjectFromQuery(config.manifestPath, options.project ?? projectQuery);
-  const projectMemoryName = await recallProjectMemoryName(options.project, workspaceOptions);
-  const nodeLimit = options.nodeLimit ? parsePositiveInteger(options.nodeLimit, 'node limit') : undefined;
-  const explicitWorkset = options.workset ? await requireWorkset(config.manifestPath, options.workset) : undefined;
+    options.uri ??
+    (options.inferScope === false ? undefined : yield* attempt(() => inferRecallUri(config, projectQuery)));
+  const project = yield* attempt(() => inferProjectFromQuery(config.manifestPath, options.project ?? projectQuery));
+  const projectMemoryName = yield* attempt(() => recallProjectMemoryName(options.project, workspaceOptions));
+  const nodeLimit = options.nodeLimit
+    ? yield* attemptSync(() => parsePositiveInteger(options.nodeLimit!, 'node limit'))
+    : undefined;
+  const explicitWorkset = options.workset
+    ? yield* attempt(() => requireWorkset(config.manifestPath, options.workset!))
+    : undefined;
   const searchArgs = (scopeUri: string | undefined): readonly string[] => [
     'search',
     query,
@@ -964,29 +981,31 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
   // repeated by the scoped passes (and multiple chunks of one document collapse
   // to a single entry).
   if (inferredUri) {
-    console.log(`Recall scope: ${inferredUri}`);
+    yield* syncWithConsole(() => consoleOutput.log(`Recall scope: ${inferredUri}`));
   }
   const includeArchived = options.includeArchived === true;
   const passes: Array<readonly RecallHit[]> = [
-    await recallSearchHits(config, ov, searchArgs(inferredUri), {dryRun, includeArchived}),
+    yield* attempt(() => recallSearchHits(config, ov, searchArgs(inferredUri), {dryRun, includeArchived})),
   ];
   const scopedRecallUris = new Set([inferredUri].filter((uri): uri is string => uri !== undefined));
   if (options.project && project) {
     const projectMemoryUri = `viking://user/${uriSegment(config.user)}/memories/durable/projects/${uriSegment(project.name)}`;
     if (!scopedRecallUris.has(projectMemoryUri)) {
       scopedRecallUris.add(projectMemoryUri);
-      passes.push(await recallSearchHits(config, ov, searchArgs(projectMemoryUri), {dryRun, includeArchived}));
+      passes.push(
+        yield* attempt(() => recallSearchHits(config, ov, searchArgs(projectMemoryUri), {dryRun, includeArchived})),
+      );
     }
   }
   for (const scope of projectMemoryScopeUris(config, projectMemoryName, includeArchived)) {
     if (!scopedRecallUris.has(scope)) {
       scopedRecallUris.add(scope);
-      passes.push(await recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived}));
+      passes.push(yield* attempt(() => recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived})));
     }
   }
   const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
   if (seededUri?.startsWith('viking://') && seededUri !== inferredUri && !options.uri && options.inferScope !== false) {
-    passes.push(await recallSearchHits(config, ov, searchArgs(seededUri), {dryRun, includeArchived}));
+    passes.push(yield* attempt(() => recallSearchHits(config, ov, searchArgs(seededUri), {dryRun, includeArchived})));
   }
 
   // Workset expansion: a named set of manifest projects recalled as one working
@@ -996,10 +1015,12 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
     !options.uri && explicitWorkset
       ? explicitWorkset
       : !options.uri && options.inferScope !== false
-        ? await inferWorksetFromQuery(config.manifestPath, projectQuery)
+        ? yield* attempt(() => inferWorksetFromQuery(config.manifestPath, projectQuery))
         : undefined;
   if (workset && workset.projects.length > 0) {
-    console.log(`Workset scope: ${workset.name} (${workset.projects.map(member => member.name).join(', ')})`);
+    yield* syncWithConsole(() =>
+      consoleOutput.log(`Workset scope: ${workset.name} (${workset.projects.map(member => member.name).join(', ')})`),
+    );
     const alreadyScoped = new Set(
       [inferredUri, seededUri, ...scopedRecallUris].filter((uri): uri is string => uri !== undefined),
     );
@@ -1007,28 +1028,30 @@ export async function runRecall(config: RuntimeConfig, options: RecallOptions): 
       .filter(uri => !alreadyScoped.has(uri))
       .slice(0, MAX_WORKSET_PASSES);
     for (const scope of worksetScopes) {
-      passes.push(await recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived}));
+      passes.push(yield* attempt(() => recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived})));
     }
   }
 
   const recallOutputs: string[] = [];
-  const exactMatches = await collectExactMemoryMatches(config, ov, query, {dryRun, includeArchived, project});
+  const exactMatches = yield* attempt(() =>
+    collectExactMemoryMatches(config, ov, query, {dryRun, includeArchived, project}),
+  );
   const {semanticSection, exactTail} = buildRecallSections(passes, exactMatches, nodeLimit ?? 12);
   if (semanticSection) {
-    console.log(`\n${semanticSection}`);
+    yield* syncWithConsole(() => consoleOutput.log(`\n${semanticSection}`));
     recallOutputs.push(semanticSection);
   }
   if (exactTail) {
-    console.log(`\n${exactTail}`);
+    yield* syncWithConsole(() => consoleOutput.log(`\n${exactTail}`));
     recallOutputs.push(exactTail);
   }
-  const referencedSection = await referencedContextSection(config, recallOutputs.join('\n'));
+  const referencedSection = yield* attempt(() => referencedContextSection(config, recallOutputs.join('\n')));
   if (referencedSection) {
-    console.log(`\n${referencedSection}`);
+    yield* syncWithConsole(() => consoleOutput.log(`\n${referencedSection}`));
     recallOutputs.push(referencedSection);
   }
-  await printRecallHygieneNudges(config, recallOutputs.join('\n'));
-}
+  yield* attempt(() => printRecallHygieneNudges(config, recallOutputs.join('\n')));
+});
 
 const MAX_REFERENCED_CONTEXT = 5;
 const REFERENCED_EXCERPT_LINES = 12;
@@ -1083,7 +1106,7 @@ async function recallSearchHits(
   options: {readonly dryRun: boolean; readonly includeArchived: boolean},
 ): Promise<readonly RecallHit[]> {
   const jsonArgs = withIdentity(config, [...args, '--output', 'json']);
-  console.log(`${options.dryRun ? 'Would run' : 'Running'}: ${formatShellCommand(ov, jsonArgs)}`);
+  consoleOutput.log(`${options.dryRun ? 'Would run' : 'Running'}: ${formatShellCommand(ov, jsonArgs)}`);
   if (options.dryRun) {
     return [];
   }
@@ -1094,7 +1117,9 @@ async function recallSearchHits(
     });
   }
   if (result.exitCode !== 0) {
-    console.log(`WARN recall search failed: ${result.stderr.trim() || result.stdout.trim() || 'ov search error'}`);
+    consoleOutput.log(
+      `WARN recall search failed: ${result.stderr.trim() || result.stdout.trim() || 'ov search error'}`,
+    );
     return [];
   }
   return parseRecallHits(result.stdout, {includeArchived: options.includeArchived});
@@ -1112,35 +1137,39 @@ export function stripAdvancedSearchFlags(args: readonly string[]): readonly stri
   return stripped;
 }
 
-export async function runRead(config: RuntimeConfig, uri: string, options: ReadOptions): Promise<void> {
-  assertVikingUri(uri);
+export const runRead = Effect.fn('runRead')(function* (config: RuntimeConfig, uri: string, options: ReadOptions) {
+  yield* attemptSync(() => assertVikingUri(uri));
   if (options.dryRun !== true) {
-    await syncSharedReposAndLog(config);
+    yield* attempt(() => syncSharedReposAndLog(config));
   }
-  const ov = await openVikingCliForMode(options.dryRun === true);
-  const result = await maybeRun(options.dryRun === true, ov, withIdentity(config, ['read', uri]));
+  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
+  const result = yield* maybeRunEffect(options.dryRun === true, ov, withIdentity(config, ['read', uri]));
   if (
     result &&
     result.stdout.includes('[Directory overview is not ready]') &&
     (uri.endsWith('/.overview.md') || uri.endsWith('/.abstract.md'))
   ) {
     const parentUri = parentVikingUri(uri);
-    console.log('\nThis is a generated summary placeholder. To read the underlying content, inspect leaf nodes:');
-    console.log(`  threadnote list ${parentUri} --all --recursive`);
+    yield* syncWithConsole(() => {
+      consoleOutput.log(
+        '\nThis is a generated summary placeholder. To read the underlying content, inspect leaf nodes:',
+      );
+      consoleOutput.log(`  threadnote list ${parentUri} --all --recursive`);
+    });
   }
-}
+});
 
 async function syncSharedReposAndLog(config: RuntimeConfig): Promise<void> {
   try {
     const syncResult = await syncSharedReposBeforeAgentRead(config);
     if (syncResult.syncedTeams.length > 0) {
-      console.error(`Auto-synced shared memories: ${syncResult.syncedTeams.join(', ')}`);
+      consoleOutput.error(`Auto-synced shared memories: ${syncResult.syncedTeams.join(', ')}`);
     }
     for (const warning of syncResult.warnings) {
-      console.error(`Auto-sync warning: ${warning}`);
+      consoleOutput.error(`Auto-sync warning: ${warning}`);
     }
   } catch (err: unknown) {
-    console.error(`Auto-sync warning: ${err instanceof Error ? err.message : String(err)}`);
+    consoleOutput.error(`Auto-sync warning: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
@@ -1154,9 +1183,9 @@ async function printRecallHygieneNudges(config: RuntimeConfig, recallOutput: str
   if (nudges.length === 0) {
     return;
   }
-  console.log('\nMemory hygiene hints:');
+  consoleOutput.log('\nMemory hygiene hints:');
   for (const nudge of nudges) {
-    console.log(`- ${nudge}`);
+    consoleOutput.log(`- ${nudge}`);
   }
 }
 
@@ -1180,7 +1209,7 @@ export const runCompact = Effect.fn('runCompact')(function* (config: RuntimeConf
     project,
     topic: normalizeOptionalMetadata(options.topic),
   });
-  console.log(formatCompactPlan(plan, {apply}));
+  yield* Console.log(formatCompactPlan(plan, {apply}));
   if (!apply) {
     return;
   }
@@ -1227,7 +1256,7 @@ export async function runCompactDiagnostics(config: RuntimeConfig, options: Comp
       counts.set(kind, (counts.get(kind) ?? 0) + 1);
     }
   }
-  console.log(
+  consoleOutput.log(
     [
       'Scope summary:',
       `- project: ${project}`,
@@ -1339,9 +1368,9 @@ function localMemoryPathForUri(config: RuntimeConfig, uri: string): string | und
   return join(localUserMemoriesRoot(config), ...relative.split('/'));
 }
 
-export async function runList(config: RuntimeConfig, uri: string, options: ListOptions): Promise<void> {
-  assertVikingUri(uri);
-  const ov = await openVikingCliForMode(options.dryRun === true);
+export const runList = Effect.fn('runList')(function* (config: RuntimeConfig, uri: string, options: ListOptions) {
+  yield* attemptSync(() => assertVikingUri(uri));
+  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
   const args = ['ls', uri];
   if (options.all === true) {
     args.push('--all');
@@ -1353,10 +1382,11 @@ export async function runList(config: RuntimeConfig, uri: string, options: ListO
     args.push('--simple');
   }
   if (options.nodeLimit) {
-    args.push('--node-limit', String(parsePositiveInteger(options.nodeLimit, 'node limit')));
+    const nodeLimit = yield* attemptSync(() => parsePositiveInteger(options.nodeLimit!, 'node limit'));
+    args.push('--node-limit', String(nodeLimit));
   }
-  await maybeRun(options.dryRun === true, ov, withIdentity(config, args));
-}
+  yield* maybeRunEffect(options.dryRun === true, ov, withIdentity(config, args));
+});
 
 export const runHandoff = Effect.fn('runHandoff')(function* (config: RuntimeConfig, options: HandoffOptions) {
   const {bodyText, metadata} = yield* attempt(() => buildHandoff(options));
@@ -1394,7 +1424,7 @@ export const runArchive = Effect.fn('runArchive')(function* (
       metadata: fallbackMetadata,
       title: 'MEMORY',
     });
-    console.log(formatShellCommand(ov, withIdentity(config, ['rm', uri])));
+    yield* Console.log(formatShellCommand(ov, withIdentity(config, ['rm', uri])));
     return;
   }
   const originalMemory = yield* requireValue(original, `Could not read ${uri} before archiving.`);
@@ -1417,9 +1447,11 @@ export const runArchive = Effect.fn('runArchive')(function* (
   });
   const removedOriginal = yield* removeVikingResourceWithRetry(ov, config, uri);
   if (removedOriginal) {
-    console.log(`Archived original memory: ${uri}`);
+    yield* Console.log(`Archived original memory: ${uri}`);
   } else {
-    console.error(`Archive stored, but original memory is still processing. Retry later: threadnote forget ${uri}`);
+    yield* Console.error(
+      `Archive stored, but original memory is still processing. Retry later: threadnote forget ${uri}`,
+    );
   }
 });
 
@@ -1436,22 +1468,26 @@ export const runForget = Effect.fn('runForget')(function* (config: RuntimeConfig
   }
 });
 
-export async function runExportPack(config: RuntimeConfig, options: PackOptions): Promise<void> {
-  const ov = await openVikingCliForMode(options.dryRun === true);
+export const runExportPack = Effect.fn('runExportPack')(function* (config: RuntimeConfig, options: PackOptions) {
+  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
   const defaultPath = join(config.agentContextHome, `threadnote-${safeTimestamp()}.ovpack`);
   const outputPath = expandPath(options.path ?? defaultPath);
   const sourceUri = options.uri ?? `viking://user/${uriSegment(config.user)}/memories`;
-  await maybeRun(options.dryRun === true, ov, withIdentity(config, ['export', sourceUri, outputPath]));
-}
+  yield* maybeRunEffect(options.dryRun === true, ov, withIdentity(config, ['export', sourceUri, outputPath]));
+});
 
-export async function runImportPack(config: RuntimeConfig, options: PackOptions): Promise<void> {
+export const runImportPack = Effect.fn('runImportPack')(function* (config: RuntimeConfig, options: PackOptions) {
   if (!options.path) {
-    throw new Error('Provide --path for import-pack.');
+    yield* Effect.fail(new Error('Provide --path for import-pack.'));
   }
-  const ov = await openVikingCliForMode(options.dryRun === true);
+  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
   const targetUri = options.targetUri ?? `viking://user/${uriSegment(config.user)}`;
-  await maybeRun(options.dryRun === true, ov, withIdentity(config, ['import', expandPath(options.path), targetUri]));
-}
+  yield* maybeRunEffect(
+    options.dryRun === true,
+    ov,
+    withIdentity(config, ['import', expandPath(options.path!), targetUri]),
+  );
+});
 
 async function inferRecallUri(config: RuntimeConfig, query: string): Promise<string | undefined> {
   // Only scope the base search when the query has an explicit "skills" intent —
@@ -1502,8 +1538,8 @@ async function collectExactMemoryMatches(
     withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5', '--output', 'json']);
   if (options.dryRun) {
     const planned = terms.flatMap(term => scopes.map(scope => formatShellCommand(ov, grepArgs(term, scope))));
-    console.log('\nExact memory/resource matches:');
-    console.log(planned.join('\n'));
+    consoleOutput.log('\nExact memory/resource matches:');
+    consoleOutput.log(planned.join('\n'));
     return [];
   }
   return collectExactMatches(terms, scopes, async (term, scope) => {
@@ -1540,9 +1576,9 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
     : candidateMemory;
   const writeMode = yield* attempt(() => memoryWriteMode(ov, config, memoryUri, finalMetadata));
   if (options.dryRun) {
-    console.log(memory);
-    console.log('\nWould run:');
-    console.log(
+    yield* Console.log(memory);
+    yield* Console.log('\nWould run:');
+    yield* Console.log(
       formatShellCommand(
         ov,
         withIdentity(config, [
@@ -1559,7 +1595,7 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
       ),
     );
     if (options.replaceUri && !isInPlaceUpdate) {
-      console.log(formatShellCommand(ov, withIdentity(config, ['rm', options.replaceUri])));
+      yield* Console.log(formatShellCommand(ov, withIdentity(config, ['rm', options.replaceUri])));
     }
     return;
   }
@@ -1567,18 +1603,18 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
   yield* attempt(() => chmod(memoryPath, 0o600));
   yield* attempt(() => ensureMemoryDirectory(ov, config, memoryDirectoryUri(config, finalMetadata)));
   yield* attempt(() => writeDurableMemoryFile(ov, config, memoryUri, memoryPath, writeMode));
-  console.log(`Stored memory: ${memoryUri}`);
+  yield* Console.log(`Stored memory: ${memoryUri}`);
   if (options.replaceUri && !isInPlaceUpdate) {
     const removedReplacedMemory = yield* removeVikingResourceWithRetry(ov, config, options.replaceUri);
     if (removedReplacedMemory) {
-      console.log(`Forgot replaced memory: ${options.replaceUri}`);
+      yield* Console.log(`Forgot replaced memory: ${options.replaceUri}`);
     } else {
-      console.error(
+      yield* Console.error(
         `Replacement stored, but the superseded memory is still processing. Retry later: threadnote forget ${options.replaceUri}`,
       );
     }
   } else if (isInPlaceUpdate) {
-    console.log(`Updated existing memory in place: ${memoryUri}`);
+    yield* Console.log(`Updated existing memory in place: ${memoryUri}`);
   }
 });
 
@@ -1593,7 +1629,7 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
  */
 function warnOnSharedProjectDrift(metadata: MemoryMetadata, inferred: {readonly project?: string} | undefined): void {
   if (inferred?.project && metadata.project && uriSegment(metadata.project) !== inferred.project) {
-    console.log(
+    consoleOutput.log(
       `WARN keeping shared memory project "${inferred.project}" from its storage path; ignoring requested "${metadata.project}". ` +
         `To change a shared memory's project, forget it and store a new one under the new project.`,
     );
@@ -1638,8 +1674,8 @@ async function storeSharedMemoryReplacement(
   const relativePath = vikingUriToWorktreeRelative(config, targetUri, team.name);
 
   if (options.dryRun) {
-    console.log(memory);
-    console.log('\nWould run:');
+    consoleOutput.log(memory);
+    consoleOutput.log('\nWould run:');
   }
   await ensureSharedDirectoryChain(config, ov, targetUri, options.dryRun);
   await writeMemoryFile(config, ov, targetUri, memory, 'replace', options.dryRun);
@@ -1648,13 +1684,13 @@ async function storeSharedMemoryReplacement(
     dryRun: options.dryRun,
   });
   for (const message of gitMessages) {
-    console.log(message);
+    consoleOutput.log(message);
   }
 
   for (const redaction of scrub.redactions) {
-    console.log(`Redacted ${redaction.count}× ${redaction.name} before shared update.`);
+    consoleOutput.log(`Redacted ${redaction.count}× ${redaction.name} before shared update.`);
   }
-  console.log(`Updated shared memory: ${targetUri}`);
+  consoleOutput.log(`Updated shared memory: ${targetUri}`);
 }
 
 async function writeDurableMemoryFile(
@@ -1670,17 +1706,19 @@ async function writeDurableMemoryFile(
 
 function removeVikingResourceWithRetry(ov: string, config: RuntimeConfig, uri: string) {
   const args = withIdentity(config, ['rm', uri]);
-  return pipe(
-    removeOpenVikingResourceEffect(ov, args, {
-      isBusy: isResourceBusy,
-      onAttempt: attempt => console.log(`${attempt === 0 ? 'Running' : 'Retrying'}: ${formatShellCommand(ov, args)}`),
-    }),
-    Effect.map(result => {
-      if (!result) return false;
-      if (result.stdout.trim()) console.log(result.stdout.trim());
-      if (result.stderr.trim()) console.error(result.stderr.trim());
-      return true;
-    }),
+  return Console.consoleWith(output =>
+    pipe(
+      removeOpenVikingResourceEffect(ov, args, {
+        isBusy: isResourceBusy,
+        onAttempt: attempt => output.log(`${attempt === 0 ? 'Running' : 'Retrying'}: ${formatShellCommand(ov, args)}`),
+      }),
+      Effect.map(result => {
+        if (!result) return false;
+        if (result.stdout.trim()) output.log(result.stdout.trim());
+        if (result.stderr.trim()) output.error(result.stderr.trim());
+        return true;
+      }),
+    ),
   );
 }
 

--- a/src/seeding.ts
+++ b/src/seeding.ts
@@ -1,5 +1,6 @@
 import {chmod, readFile, realpath, stat, writeFile} from 'node:fs/promises';
 import {basename, dirname, join, relative} from 'node:path';
+import {Console, Effect, FileSystem} from 'effect';
 import yaml from 'js-yaml';
 import {
   DEFAULT_SEED_PATTERNS,
@@ -9,6 +10,9 @@ import {
   USER_MANIFEST_NAME,
 } from './constants.js';
 import {buildGraphDocument, type DependencyFacts, extractDependencyFacts, resolveGraphEdges} from './graph.js';
+import {maybeRunEffect} from './effect/command.js';
+import {consoleOutput} from './effect/console.js';
+import {applicationError, fromPromise} from './effect/errors.js';
 import {readSeedManifest, uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
 import {detectSecretMatches} from './scrubber.js';
@@ -34,7 +38,6 @@ import {
   isDirectory,
   isFile,
   isJsonObject,
-  maybeRun,
   openVikingCliForMode,
   portablePath,
   redactText,
@@ -90,69 +93,81 @@ export function seedWatchArgs(params: {
   return ['--watch-interval', String(params.watchIntervalMinutes)];
 }
 
-export async function runSeed(config: RuntimeConfig, options: SeedOptions): Promise<void> {
-  const manifest = await readSeedManifest(config.manifestPath);
-  const ignorePatterns = await loadIgnorePatterns();
-  const ov = await openVikingCliForMode(options.dryRun === true);
-  const watchIntervalMinutes = parseSeedWatchIntervalMinutes(process.env[SEED_WATCH_INTERVAL_ENV]);
-  const statePath = join(config.agentContextHome, SEED_STATE_FILE);
-  const state: {files: Record<string, SeedStateEntry>; version: 1} =
-    options.force === true ? {files: {}, version: 1} : await readSeedState(statePath);
-  const projects = filterProjects(manifest.projects, options.only);
-  let importedCount = 0;
-  let skippedCount = 0;
-  let unchangedCount = 0;
+const log = Console.log;
 
-  for (const project of projects) {
-    const projectRoot = expandPath(project.path);
-    if (!(await exists(projectRoot))) {
-      console.log(`WARN project missing: ${project.name} (${projectRoot})`);
-      continue;
-    }
+export function runSeed(config: RuntimeConfig, options: SeedOptions) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const manifest = yield* fromPromise('read seed manifest', () => readSeedManifest(config.manifestPath));
+    const ignorePatterns = yield* fromPromise('read seed ignore patterns', loadIgnorePatterns);
+    const ov = yield* fromPromise('find OpenViking CLI for seed', () => openVikingCliForMode(options.dryRun === true));
+    const watchIntervalMinutes = parseSeedWatchIntervalMinutes(process.env[SEED_WATCH_INTERVAL_ENV]);
+    const statePath = join(config.agentContextHome, SEED_STATE_FILE);
+    const state: {files: Record<string, SeedStateEntry>; version: 1} =
+      options.force === true ? {files: {}, version: 1} : yield* readSeedState(statePath);
+    const projects = yield* Effect.try({
+      try: () => filterProjects(manifest.projects, options.only),
+      catch: cause => applicationError('filter seed projects', cause),
+    });
+    let importedCount = 0;
+    let skippedCount = 0;
+    let unchangedCount = 0;
 
-    const candidates = await collectSeedCandidates(project, projectRoot, ignorePatterns);
-    for (const candidate of candidates) {
-      const fileStat = await statSeedFile(candidate.filePath);
-      const recorded = state.files[candidate.destinationUri];
-      if (fileStat && recorded && recorded.mtimeMs === fileStat.mtimeMs && recorded.size === fileStat.size) {
-        unchangedCount += 1;
+    for (const project of projects) {
+      const projectRoot = expandPath(project.path);
+      if (!(yield* fs.exists(projectRoot))) {
+        yield* log(`WARN project missing: ${project.name} (${projectRoot})`);
         continue;
       }
-      const importPath = await prepareSeedFile(config, candidate, options.dryRun === true);
-      if (!importPath) {
-        skippedCount += 1;
-        continue;
-      }
-      const args = withIdentity(config, [
-        'add-resource',
-        importPath,
-        '--to',
-        candidate.destinationUri,
-        ...seedWatchArgs({
-          watchIntervalMinutes,
-          importedOriginal: importPath === candidate.filePath,
-          redactionProne: shouldRedactPath(candidate.relativePath),
-        }),
-        '--wait',
-      ]);
-      await maybeRun(options.dryRun === true, ov, args);
-      importedCount += 1;
-      if (fileStat && options.dryRun !== true) {
-        state.files[candidate.destinationUri] = {mtimeMs: fileStat.mtimeMs, size: fileStat.size};
+
+      const candidates = yield* fromPromise('collect seed candidates', () =>
+        collectSeedCandidates(project, projectRoot, ignorePatterns),
+      );
+      for (const candidate of candidates) {
+        const fileStat = yield* statSeedFile(candidate.filePath);
+        const recorded = state.files[candidate.destinationUri];
+        if (fileStat && recorded && recorded.mtimeMs === fileStat.mtimeMs && recorded.size === fileStat.size) {
+          unchangedCount += 1;
+          continue;
+        }
+        const importPath = yield* fromPromise('prepare seed file', () =>
+          prepareSeedFile(config, candidate, options.dryRun === true),
+        );
+        if (!importPath) {
+          skippedCount += 1;
+          continue;
+        }
+        const args = withIdentity(config, [
+          'add-resource',
+          importPath,
+          '--to',
+          candidate.destinationUri,
+          ...seedWatchArgs({
+            watchIntervalMinutes,
+            importedOriginal: importPath === candidate.filePath,
+            redactionProne: shouldRedactPath(candidate.relativePath),
+          }),
+          '--wait',
+        ]);
+        yield* maybeRunEffect(options.dryRun === true, ov, args);
+        importedCount += 1;
+        if (fileStat && options.dryRun !== true) {
+          state.files[candidate.destinationUri] = {mtimeMs: fileStat.mtimeMs, size: fileStat.size};
+        }
       }
     }
-  }
 
-  if (options.dryRun !== true) {
-    await writeSeedState(statePath, state);
-  }
-  console.log(
-    `Seed complete: ${importedCount} candidate(s), ${unchangedCount} unchanged, ${skippedCount} skipped for safety.`,
-  );
+    if (options.dryRun !== true) {
+      yield* writeSeedState(statePath, state);
+    }
+    yield* log(
+      `Seed complete: ${importedCount} candidate(s), ${unchangedCount} unchanged, ${skippedCount} skipped for safety.`,
+    );
 
-  if (options.graph === true) {
-    await seedDependencyGraphs(config, ov, manifest, projects, options.dryRun === true);
-  }
+    if (options.graph === true) {
+      yield* seedDependencyGraphs(config, ov, manifest, projects, options.dryRun === true);
+    }
+  });
 }
 
 /**
@@ -163,63 +178,74 @@ export async function runSeed(config: RuntimeConfig, options: SeedOptions): Prom
  * every other seeded file before it can reach OpenViking. Stored as a plain
  * resource, never a memory.
  */
-export async function seedDependencyGraphs(
+export function seedDependencyGraphs(
   config: RuntimeConfig,
   ov: string,
   manifest: SeedManifest,
   targetProjects: readonly ProjectManifest[],
   dryRun: boolean,
-): Promise<void> {
-  const factsByProject = new Map<string, DependencyFacts>();
-  for (const project of manifest.projects) {
-    const projectRoot = expandPath(project.path);
-    if (!(await exists(projectRoot))) {
-      continue;
+) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const factsByProject = new Map<string, DependencyFacts>();
+    for (const project of manifest.projects) {
+      const projectRoot = expandPath(project.path);
+      if (!(yield* fs.exists(projectRoot))) {
+        continue;
+      }
+      factsByProject.set(project.name, yield* extractDependencyFacts(projectRoot));
     }
-    factsByProject.set(project.name, await extractDependencyFacts(projectRoot));
-  }
-  const projectByPublishedName = new Map<string, string>();
-  for (const [name, facts] of factsByProject) {
-    if (facts.publishedName) {
-      projectByPublishedName.set(facts.publishedName.toLowerCase(), name);
+    const projectByPublishedName = new Map<string, string>();
+    for (const [name, facts] of factsByProject) {
+      if (facts.publishedName) {
+        projectByPublishedName.set(facts.publishedName.toLowerCase(), name);
+      }
     }
-  }
 
-  let written = 0;
-  let skipped = 0;
-  for (const project of targetProjects) {
-    const facts = factsByProject.get(project.name);
-    if (!facts || facts.manifestFiles.length === 0) {
-      continue;
-    }
-    const {externalCount, internalEdges} = resolveGraphEdges(project.name, facts.dependencies, projectByPublishedName);
-    const document = buildGraphDocument({externalCount, facts, internalEdges, projectName: project.name});
-    const secretMatches = detectSecretMatches(document);
-    if (secretMatches.length > 0) {
-      skipped += 1;
-      console.log(
-        `SKIP ${project.name}/.graph.md: possible secret (${secretMatches
-          .slice(0, MAX_SECRET_MATCHES_TO_PRINT)
-          .join(', ')})`,
+    let written = 0;
+    let skipped = 0;
+    for (const project of targetProjects) {
+      const facts = factsByProject.get(project.name);
+      if (!facts || facts.manifestFiles.length === 0) {
+        continue;
+      }
+      const {externalCount, internalEdges} = resolveGraphEdges(
+        project.name,
+        facts.dependencies,
+        projectByPublishedName,
       );
-      continue;
-    }
-    const destinationUri = `${trimTrailingSlash(project.uri)}/.graph.md`;
-    if (dryRun) {
-      console.log(`Would seed dependency facts: ${destinationUri} (${internalEdges.length} in-workspace edge(s))`);
+      const document = buildGraphDocument({externalCount, facts, internalEdges, projectName: project.name});
+      const secretMatches = detectSecretMatches(document);
+      if (secretMatches.length > 0) {
+        skipped += 1;
+        yield* log(
+          `SKIP ${project.name}/.graph.md: possible secret (${secretMatches
+            .slice(0, MAX_SECRET_MATCHES_TO_PRINT)
+            .join(', ')})`,
+        );
+        continue;
+      }
+      const destinationUri = `${trimTrailingSlash(project.uri)}/.graph.md`;
+      if (dryRun) {
+        yield* log(`Would seed dependency facts: ${destinationUri} (${internalEdges.length} in-workspace edge(s))`);
+        written += 1;
+        continue;
+      }
+      const graphPath = join(config.agentContextHome, 'graph', graphCacheFileName(project.name));
+      yield* fs.makeDirectory(dirname(graphPath), {recursive: true});
+      yield* fs.writeFileString(graphPath, document, {mode: 0o600});
+      yield* fs.chmod(graphPath, 0o600);
+      yield* maybeRunEffect(
+        false,
+        ov,
+        withIdentity(config, ['add-resource', graphPath, '--to', destinationUri, '--wait']),
+      );
       written += 1;
-      continue;
     }
-    const graphPath = join(config.agentContextHome, 'graph', graphCacheFileName(project.name));
-    await ensureDirectory(dirname(graphPath), false);
-    await writeFile(graphPath, document, {encoding: 'utf8', mode: 0o600});
-    await chmod(graphPath, 0o600);
-    await maybeRun(false, ov, withIdentity(config, ['add-resource', graphPath, '--to', destinationUri, '--wait']));
-    written += 1;
-  }
-  console.log(
-    `Dependency graph seed complete: ${written} .graph.md resource(s)${skipped > 0 ? `, ${skipped} skipped for safety` : ''}.`,
-  );
+    yield* log(
+      `Dependency graph seed complete: ${written} .graph.md resource(s)${skipped > 0 ? `, ${skipped} skipped for safety` : ''}.`,
+    );
+  });
 }
 
 function filterProjects(
@@ -239,166 +265,198 @@ function filterProjects(
   return projects.filter(project => want.has(project.name));
 }
 
-async function statSeedFile(path: string): Promise<{readonly mtimeMs: number; readonly size: number} | undefined> {
-  try {
-    const result = await stat(path);
-    return {mtimeMs: result.mtimeMs, size: result.size};
-  } catch (_err: unknown) {
-    return undefined;
-  }
-}
-
-async function readSeedState(path: string): Promise<{files: Record<string, SeedStateEntry>; version: 1}> {
-  try {
-    const raw = await readFile(path, 'utf8');
-    const parsed = JSON.parse(raw) as Partial<SeedStateFile>;
-    if (parsed.version !== 1 || !isJsonObject(parsed.files)) {
-      return {files: {}, version: 1};
-    }
-    const files: Record<string, SeedStateEntry> = {};
-    for (const [uri, entry] of Object.entries(parsed.files)) {
-      if (isJsonObject(entry) && typeof entry.mtimeMs === 'number' && typeof entry.size === 'number') {
-        files[uri] = {mtimeMs: entry.mtimeMs, size: entry.size};
-      }
-    }
-    return {files, version: 1};
-  } catch (_err: unknown) {
-    return {files: {}, version: 1};
-  }
-}
-
-async function writeSeedState(path: string, state: SeedStateFile): Promise<void> {
-  await ensureDirectory(dirname(path), false);
-  await writeFile(path, `${JSON.stringify(state, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
-}
-
-export async function runInitManifest(config: RuntimeConfig, options: InitManifestOptions): Promise<void> {
-  const manifestPath = expandPath(
-    options.path ?? process.env.THREADNOTE_MANIFEST ?? join(config.agentContextHome, USER_MANIFEST_NAME),
+function statSeedFile(path: string) {
+  return fromPromise('stat seed file', () => stat(path)).pipe(
+    Effect.map(result => ({mtimeMs: result.mtimeMs, size: result.size})),
+    Effect.catchIf(
+      error => (error.cause as NodeJS.ErrnoException | undefined)?.code === 'ENOENT',
+      () => Effect.succeed(undefined),
+    ),
   );
-  const repoInputs = options.repo && options.repo.length > 0 ? options.repo : [getInvocationCwd()];
-  const existingManifest =
-    options.replace === true || !(await exists(manifestPath)) ? undefined : await readSeedManifest(manifestPath);
-  const existingProjects = existingManifest?.projects ?? [];
-  const projects = [...existingProjects];
-  const seen = new Set<string>();
-
-  for (const project of existingProjects) {
-    seen.add(await projectIdentity(project.path));
-  }
-
-  for (const repoInput of repoInputs) {
-    const repoRoot = await resolveRepoRoot(repoInput);
-    const identity = await projectIdentity(repoRoot);
-    if (seen.has(identity)) {
-      console.log(`Already in manifest: ${repoRoot}`);
-      continue;
-    }
-    seen.add(identity);
-    projects.push(await projectManifestForRepo(repoRoot, projects));
-  }
-
-  const outputManifest: Record<string, unknown> = {
-    version: 1,
-    projects: projects.map(project => ({
-      name: project.name,
-      path: project.path,
-      uri: project.uri,
-      seed: [...project.seed],
-    })),
-  };
-  if (existingManifest?.futureMonorepo) {
-    const futureMonorepoKey = 'future_monorepo';
-    const pathCandidatesKey = 'path_candidates';
-    outputManifest[futureMonorepoKey] = {
-      [pathCandidatesKey]: [...existingManifest.futureMonorepo.pathCandidates],
-      uri: existingManifest.futureMonorepo.uri,
-    };
-  }
-  if (existingManifest?.worksets) {
-    outputManifest.worksets = existingManifest.worksets.map(workset => ({
-      name: workset.name,
-      ...(workset.description !== undefined ? {description: workset.description} : {}),
-      projects: [...workset.projects],
-    }));
-  }
-  const output = yaml.dump(outputManifest, {lineWidth: 120, noRefs: true});
-
-  if (options.dryRun === true) {
-    console.log(`# Would write ${manifestPath}`);
-    console.log(output.trimEnd());
-    return;
-  }
-
-  await ensureDirectory(dirname(manifestPath), false);
-  await writeFile(manifestPath, output, {encoding: 'utf8', mode: 0o600});
-  await chmod(manifestPath, 0o600);
-  console.log(`Wrote manifest: ${manifestPath}`);
-  console.log('Seed with:');
-  console.log('  threadnote seed --dry-run');
-  console.log('  threadnote seed');
 }
 
-export async function runWorksetList(config: RuntimeConfig): Promise<void> {
-  const manifest = await readSeedManifest(config.manifestPath);
-  const worksets = manifest.worksets ?? [];
-  if (worksets.length === 0) {
-    console.log(
-      'No worksets defined. Add a top-level `worksets:` list to the seed manifest to group related projects.',
+function readSeedState(path: string) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const raw = yield* fs.readFileString(path).pipe(
+      Effect.catchIf(
+        error => error.reason._tag === 'NotFound',
+        () => Effect.succeed(undefined),
+      ),
     );
-    return;
-  }
-  console.log(`Worksets (${worksets.length}):`);
-  for (const workset of worksets) {
-    const summary = workset.description ? ` — ${workset.description}` : '';
-    console.log(`- ${workset.name} (${workset.projects.length} project(s))${summary}`);
-  }
-}
-
-export async function runWorksetShow(config: RuntimeConfig, name: string): Promise<void> {
-  const manifest = await readSeedManifest(config.manifestPath);
-  const workset = manifest.worksets?.find(entry => entry.name.toLowerCase() === name.toLowerCase());
-  if (!workset) {
-    throw new Error(`No workset named "${name}" in ${config.manifestPath}.`);
-  }
-  console.log(`Workset: ${workset.name}`);
-  if (workset.description) {
-    console.log(workset.description);
-  }
-  console.log('Projects:');
-  for (const memberName of workset.projects) {
-    const project = manifest.projects.find(entry => entry.name.toLowerCase() === memberName.toLowerCase());
-    console.log(project ? `- ${project.name} (${project.uri})` : `- ${memberName} [not found in manifest projects]`);
-  }
-}
-
-export async function runSeedSkills(config: RuntimeConfig, options: SeedOptions): Promise<void> {
-  const ov = await openVikingCliForMode(options.dryRun === true);
-  const catalogItems = await collectSkillCandidates(config);
-  const nativeMode = options.native === true;
-  console.log(
-    nativeMode
-      ? 'Skill seed mode: native OpenViking skills. This requires a working VLM config.'
-      : 'Skill seed mode: resource catalog. Use --native only after configuring a working VLM provider.',
-  );
-  let skippedCount = 0;
-  for (const skill of catalogItems) {
-    console.log(`${skill.kind === 'command' ? 'Command' : 'Skill'} ${skill.source}: ${skill.filePath}`);
-    if (nativeMode && skill.kind === 'command') {
-      skippedCount += 1;
-      console.log(`SKIP command in native skill mode: ${skill.filePath}`);
-      continue;
+    if (raw === undefined) {
+      return {files: {}, version: 1} as const;
     }
-    const args = nativeMode
-      ? ['add-skill', skill.filePath, '--wait']
-      : ['add-resource', skill.filePath, '--to', skillResourceUri(skill), '--wait'];
-    await maybeRun(options.dryRun === true, ov, withIdentity(config, args));
-  }
-  console.log(
-    `Skill seed complete: ${catalogItems.length - skippedCount} unique catalog item(s)${
-      skippedCount > 0 ? `, ${skippedCount} skipped` : ''
-    }.`,
-  );
+    try {
+      const parsed = JSON.parse(raw) as Partial<SeedStateFile>;
+      if (parsed.version !== 1 || !isJsonObject(parsed.files)) {
+        return {files: {}, version: 1} as const;
+      }
+      const files: Record<string, SeedStateEntry> = {};
+      for (const [uri, entry] of Object.entries(parsed.files)) {
+        if (isJsonObject(entry) && typeof entry.mtimeMs === 'number' && typeof entry.size === 'number') {
+          files[uri] = {mtimeMs: entry.mtimeMs, size: entry.size};
+        }
+      }
+      return {files, version: 1 as const};
+    } catch (_err: unknown) {
+      return {files: {}, version: 1} as const;
+    }
+  });
+}
+
+function writeSeedState(path: string, state: SeedStateFile) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.makeDirectory(dirname(path), {recursive: true});
+    yield* fs.writeFileString(path, `${JSON.stringify(state, undefined, 2)}\n`, {mode: 0o600});
+  });
+}
+
+export function runInitManifest(config: RuntimeConfig, options: InitManifestOptions) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const manifestPath = expandPath(
+      options.path ?? process.env.THREADNOTE_MANIFEST ?? join(config.agentContextHome, USER_MANIFEST_NAME),
+    );
+    const repoInputs = options.repo && options.repo.length > 0 ? options.repo : [getInvocationCwd()];
+    const existingManifest =
+      options.replace === true || !(yield* fs.exists(manifestPath))
+        ? undefined
+        : yield* fromPromise('read existing seed manifest', () => readSeedManifest(manifestPath));
+    const existingProjects = existingManifest?.projects ?? [];
+    const projects = [...existingProjects];
+    const seen = new Set<string>();
+
+    for (const project of existingProjects) {
+      seen.add(yield* fromPromise('resolve project identity', () => projectIdentity(project.path)));
+    }
+
+    for (const repoInput of repoInputs) {
+      const repoRoot = yield* fromPromise('resolve repository root', () => resolveRepoRoot(repoInput));
+      const identity = yield* fromPromise('resolve project identity', () => projectIdentity(repoRoot));
+      if (seen.has(identity)) {
+        yield* log(`Already in manifest: ${repoRoot}`);
+        continue;
+      }
+      seen.add(identity);
+      projects.push(
+        yield* fromPromise('build project manifest entry', () => projectManifestForRepo(repoRoot, projects)),
+      );
+    }
+
+    const outputManifest: Record<string, unknown> = {
+      version: 1,
+      projects: projects.map(project => ({
+        name: project.name,
+        path: project.path,
+        uri: project.uri,
+        seed: [...project.seed],
+      })),
+    };
+    if (existingManifest?.futureMonorepo) {
+      const futureMonorepoKey = 'future_monorepo';
+      const pathCandidatesKey = 'path_candidates';
+      outputManifest[futureMonorepoKey] = {
+        [pathCandidatesKey]: [...existingManifest.futureMonorepo.pathCandidates],
+        uri: existingManifest.futureMonorepo.uri,
+      };
+    }
+    if (existingManifest?.worksets) {
+      outputManifest.worksets = existingManifest.worksets.map(workset => ({
+        name: workset.name,
+        ...(workset.description !== undefined ? {description: workset.description} : {}),
+        projects: [...workset.projects],
+      }));
+    }
+    const output = yaml.dump(outputManifest, {lineWidth: 120, noRefs: true});
+
+    if (options.dryRun === true) {
+      yield* log(`# Would write ${manifestPath}`);
+      yield* log(output.trimEnd());
+      return;
+    }
+
+    yield* fs.makeDirectory(dirname(manifestPath), {recursive: true});
+    yield* fs.writeFileString(manifestPath, output, {mode: 0o600});
+    yield* fs.chmod(manifestPath, 0o600);
+    yield* log(`Wrote manifest: ${manifestPath}`);
+    yield* log('Seed with:');
+    yield* log('  threadnote seed --dry-run');
+    yield* log('  threadnote seed');
+  });
+}
+
+export function runWorksetList(config: RuntimeConfig) {
+  return Effect.gen(function* () {
+    const manifest = yield* fromPromise('read seed manifest', () => readSeedManifest(config.manifestPath));
+    const worksets = manifest.worksets ?? [];
+    if (worksets.length === 0) {
+      yield* log(
+        'No worksets defined. Add a top-level `worksets:` list to the seed manifest to group related projects.',
+      );
+      return;
+    }
+    yield* log(`Worksets (${worksets.length}):`);
+    for (const workset of worksets) {
+      const summary = workset.description ? ` — ${workset.description}` : '';
+      yield* log(`- ${workset.name} (${workset.projects.length} project(s))${summary}`);
+    }
+  });
+}
+
+export function runWorksetShow(config: RuntimeConfig, name: string) {
+  return Effect.gen(function* () {
+    const manifest = yield* fromPromise('read seed manifest', () => readSeedManifest(config.manifestPath));
+    const workset = manifest.worksets?.find(entry => entry.name.toLowerCase() === name.toLowerCase());
+    if (!workset) {
+      return yield* Effect.fail(
+        applicationError('show workset', new Error(`No workset named "${name}" in ${config.manifestPath}.`)),
+      );
+    }
+    yield* log(`Workset: ${workset.name}`);
+    if (workset.description) {
+      yield* log(workset.description);
+    }
+    yield* log('Projects:');
+    for (const memberName of workset.projects) {
+      const project = manifest.projects.find(entry => entry.name.toLowerCase() === memberName.toLowerCase());
+      yield* log(project ? `- ${project.name} (${project.uri})` : `- ${memberName} [not found in manifest projects]`);
+    }
+  });
+}
+
+export function runSeedSkills(config: RuntimeConfig, options: SeedOptions) {
+  return Effect.gen(function* () {
+    const ov = yield* fromPromise('find OpenViking CLI for skill seed', () =>
+      openVikingCliForMode(options.dryRun === true),
+    );
+    const catalogItems = yield* fromPromise('collect skill candidates', () => collectSkillCandidates(config));
+    const nativeMode = options.native === true;
+    yield* log(
+      nativeMode
+        ? 'Skill seed mode: native OpenViking skills. This requires a working VLM config.'
+        : 'Skill seed mode: resource catalog. Use --native only after configuring a working VLM provider.',
+    );
+    let skippedCount = 0;
+    for (const skill of catalogItems) {
+      yield* log(`${skill.kind === 'command' ? 'Command' : 'Skill'} ${skill.source}: ${skill.filePath}`);
+      if (nativeMode && skill.kind === 'command') {
+        skippedCount += 1;
+        yield* log(`SKIP command in native skill mode: ${skill.filePath}`);
+        continue;
+      }
+      const args = nativeMode
+        ? ['add-skill', skill.filePath, '--wait']
+        : ['add-resource', skill.filePath, '--to', skillResourceUri(skill), '--wait'];
+      yield* maybeRunEffect(options.dryRun === true, ov, withIdentity(config, args));
+    }
+    yield* log(
+      `Skill seed complete: ${catalogItems.length - skippedCount} unique catalog item(s)${
+        skippedCount > 0 ? `, ${skippedCount} skipped` : ''
+      }.`,
+    );
+  });
 }
 
 export async function resolveRepoRoot(repoInput: string): Promise<string> {
@@ -494,7 +552,7 @@ async function prepareSeedFile(
     : content;
   const secretMatches = detectSecretMatches(redactedContent);
   if (secretMatches.length > 0) {
-    console.log(
+    consoleOutput.log(
       `SKIP ${candidate.projectName}/${candidate.relativePath}: possible secret (${secretMatches
         .slice(0, MAX_SECRET_MATCHES_TO_PRINT)
         .join(', ')})`,
@@ -508,7 +566,7 @@ async function prepareSeedFile(
 
   const redactedPath = join(config.agentContextHome, 'redacted', candidate.projectName, candidate.relativePath);
   if (dryRun) {
-    console.log(`Would write redacted copy: ${redactedPath}`);
+    consoleOutput.log(`Would write redacted copy: ${redactedPath}`);
     return redactedPath;
   }
   await ensureDirectory(dirname(redactedPath), false);
@@ -548,7 +606,7 @@ async function collectSkillCandidates(config: RuntimeConfig): Promise<readonly S
       });
     }
   } catch (err: unknown) {
-    console.log(`WARN cannot read manifest for repo-local skill/command discovery: ${errorMessage(err)}`);
+    consoleOutput.log(`WARN cannot read manifest for repo-local skill/command discovery: ${errorMessage(err)}`);
   }
 
   const seenHashes = new Set<string>();
@@ -559,7 +617,7 @@ async function collectSkillCandidates(config: RuntimeConfig): Promise<readonly S
       const content = await readFile(filePath, 'utf8');
       const matches = detectSecretMatches(content);
       if (matches.length > 0) {
-        console.log(`SKIP skill with possible secret: ${filePath}`);
+        consoleOutput.log(`SKIP skill with possible secret: ${filePath}`);
         continue;
       }
       const hash = sha256(content);

--- a/src/share.ts
+++ b/src/share.ts
@@ -2,6 +2,7 @@ import {lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile} from 'n
 import {homedir, tmpdir} from 'node:os';
 import {basename, dirname, isAbsolute, join, relative, sep} from 'node:path';
 import {TextDecoder} from 'node:util';
+import {consoleOutput} from './effect/console.js';
 import {uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
 import {applyScrubber, credentialScrubberBlocker, SCRUBBER_PATTERNS} from './scrubber.js';
@@ -290,17 +291,17 @@ export async function runShareInit(config: ShareRuntime, remoteUrl: string, opti
     version: TEAMS_FILE_VERSION,
   };
   if (dryRun) {
-    console.log(`Would write teams file: ${teamsFilePath(config)}`);
-    console.log(`Would set ${teamName} as default? ${updatedTeams.defaultTeam === teamName}`);
+    consoleOutput.log(`Would write teams file: ${teamsFilePath(config)}`);
+    consoleOutput.log(`Would set ${teamName} as default? ${updatedTeams.defaultTeam === teamName}`);
   } else {
     await writeTeamsFile(config, updatedTeams);
-    console.log(`Configured shared team "${teamName}" -> ${portablePath(worktree)}`);
+    consoleOutput.log(`Configured shared team "${teamName}" -> ${portablePath(worktree)}`);
   }
 
   if (!dryRun) {
     await ensureSharedGitignore(worktree, git, options.push !== false);
     const ingested = await ingestWorktreeFiles(config, newConfig, 'create');
-    console.log(`Ingested ${ingested} shared file(s) into OpenViking.`);
+    consoleOutput.log(`Ingested ${ingested} shared file(s) into OpenViking.`);
   }
 }
 
@@ -336,7 +337,7 @@ async function ensureSharedGitignore(worktree: string, git: string, push: boolea
   }
   segments.push(missingPatterns.join('\n'), '\n');
   await writeFile(gitignorePath, `${existing}${segments.join('')}`, {encoding: 'utf8'});
-  console.log(`Added ${missingPatterns.join(', ')} to ${portablePath(gitignorePath)}`);
+  consoleOutput.log(`Added ${missingPatterns.join(', ')} to ${portablePath(gitignorePath)}`);
   await maybeRun(false, git, ['-C', worktree, 'add', '.gitignore']);
   const commitResult = await runCommand(
     git,
@@ -346,7 +347,7 @@ async function ensureSharedGitignore(worktree: string, git: string, push: boolea
   if (commitResult.exitCode !== 0) {
     const detail = commitResult.stderr.trim() || commitResult.stdout.trim();
     if (!/nothing to commit|no changes added/i.test(detail)) {
-      console.warn(
+      consoleOutput.warn(
         `.gitignore housekeeping commit was rejected (${detail || 'unknown'}); it will be retried on the next share sync.`,
       );
       return;
@@ -360,10 +361,10 @@ async function ensureSharedGitignore(worktree: string, git: string, push: boolea
 export async function runShareStatus(config: ShareRuntime, options: ShareStatusOptions): Promise<void> {
   const team = await resolveTeam(config, options.team);
   const git = await requiredExecutable('git');
-  console.log(`Team: ${team.name}`);
-  console.log(`Remote: ${team.config.remote}`);
-  console.log(`Worktree: ${portablePath(team.config.worktree)}`);
-  console.log(`Gitdir: ${portablePath(team.config.gitdir)}`);
+  consoleOutput.log(`Team: ${team.name}`);
+  consoleOutput.log(`Remote: ${team.config.remote}`);
+  consoleOutput.log(`Worktree: ${portablePath(team.config.worktree)}`);
+  consoleOutput.log(`Gitdir: ${portablePath(team.config.gitdir)}`);
   await maybeRun(options.dryRun === true, git, ['-C', team.config.worktree, 'status', '--short', '--branch']);
   await maybeRun(options.dryRun === true, git, ['-C', team.config.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME], {
     allowFailure: true,
@@ -371,10 +372,10 @@ export async function runShareStatus(config: ShareRuntime, options: ShareStatusO
   const ahead = await gitOutput(team.config.worktree, ['rev-list', '--count', '@{u}..HEAD'], options.dryRun === true);
   const behind = await gitOutput(team.config.worktree, ['rev-list', '--count', 'HEAD..@{u}'], options.dryRun === true);
   if (ahead !== undefined) {
-    console.log(`Ahead of upstream: ${ahead}`);
+    consoleOutput.log(`Ahead of upstream: ${ahead}`);
   }
   if (behind !== undefined) {
-    console.log(`Behind upstream: ${behind}`);
+    consoleOutput.log(`Behind upstream: ${behind}`);
   }
 }
 
@@ -384,11 +385,11 @@ export function startShareBackgroundFetch(config: ShareRuntime): void {
     return;
   }
   void refreshShareUpdateState(config, {force: true}).catch(err => {
-    console.error(`share auto-fetch failed: ${err instanceof Error ? err.message : String(err)}`);
+    consoleOutput.error(`share auto-fetch failed: ${err instanceof Error ? err.message : String(err)}`);
   });
   state.timer = setInterval(() => {
     void refreshShareUpdateState(config, {force: false}).catch(err => {
-      console.error(`share auto-fetch failed: ${err instanceof Error ? err.message : String(err)}`);
+      consoleOutput.error(`share auto-fetch failed: ${err instanceof Error ? err.message : String(err)}`);
     });
   }, AUTO_SHARE_FETCH_INTERVAL_MS);
   state.timer.unref?.();
@@ -514,7 +515,7 @@ async function refreshShareUpdateState(config: ShareRuntime, options: {readonly 
     refreshShareUpdateStateLocked(config, state, options),
   );
   for (const warning of warnings) {
-    console.error(warning);
+    consoleOutput.error(warning);
   }
 }
 
@@ -603,7 +604,7 @@ export async function runShareSync(config: ShareRuntime, options: ShareSyncOptio
   const failures: string[] = [];
   for (const [index, team] of teams.entries()) {
     if (teams.length > 1) {
-      console.log(`Syncing shared team "${team.name}" (${index + 1}/${teams.length})...`);
+      consoleOutput.log(`Syncing shared team "${team.name}" (${index + 1}/${teams.length})...`);
     }
     try {
       await runShareSyncForTeam(config, team, options);
@@ -668,7 +669,7 @@ async function runShareSyncForTeam(config: ShareRuntime, team: ResolvedTeam, opt
     ? undefined
     : await runCommand(git, ['-C', worktree, 'rebase', '@{u}'], {allowFailure: true});
   if (dryRun) {
-    console.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'rebase', '@{u}'])}`);
+    consoleOutput.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'rebase', '@{u}'])}`);
   } else if (pullResult && pullResult.exitCode !== 0) {
     // Detect mid-rebase state via filesystem markers rather than parsing git's
     // output — both because git's English phrasing varies by version and
@@ -697,16 +698,16 @@ async function runShareSyncForTeam(config: ShareRuntime, team: ResolvedTeam, opt
       beforeRev && afterRev && beforeRev !== afterRev ? await listChangedFiles(worktree, beforeRev, afterRev) : [];
     const combined = mergeChanges(previouslyPending, newChanges);
     if (combined.length === 0) {
-      console.log('No upstream changes to reindex.');
+      consoleOutput.log('No upstream changes to reindex.');
     } else {
       const result = await applyAndPersistChanges(config, team.config, state, combined);
       const succeeded = combined.length - result.failed.length;
-      console.log(`Reindexed ${succeeded} file change(s) into OpenViking.`);
+      consoleOutput.log(`Reindexed ${succeeded} file change(s) into OpenViking.`);
       if (result.failed.length > 0) {
-        console.warn(
+        consoleOutput.warn(
           `share sync: ${result.failed.length} file(s) could not be ingested on this run; they are persisted and will be retried on the next sync or agent recall/read.`,
         );
-        console.warn(formatShareConflictNextSteps(team.name, result.failed));
+        consoleOutput.warn(formatShareConflictNextSteps(team.name, result.failed));
       }
     }
   }
@@ -716,7 +717,7 @@ async function runShareSyncForTeam(config: ShareRuntime, team: ResolvedTeam, opt
       ? undefined
       : await runCommand(git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME], {allowFailure: true});
     if (dryRun) {
-      console.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME])}`);
+      consoleOutput.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME])}`);
     } else if (pushResult && pushResult.exitCode !== 0) {
       throw new Error(
         `git push failed in ${worktree}: ${pushResult.stderr.trim() || pushResult.stdout.trim() || 'unknown error'}`,
@@ -729,20 +730,20 @@ export async function runShareConflicts(config: ShareRuntime, options: ShareConf
   const conflicts = await listShareConflicts(config, options);
   if (conflicts.length === 0) {
     const team = options.team ? ` for team "${options.team}"` : '';
-    console.log(`No pending shared memory conflicts${team}.`);
+    consoleOutput.log(`No pending shared memory conflicts${team}.`);
     return;
   }
-  console.log(`Pending shared memory conflicts: ${conflicts.length}`);
+  consoleOutput.log(`Pending shared memory conflicts: ${conflicts.length}`);
   for (const conflict of conflicts) {
-    console.log('');
-    console.log(`${conflict.id}`);
-    console.log(`  uri: ${conflict.uri}`);
-    console.log(`  status: ${conflict.status}`);
-    console.log(`  reason: ${conflict.reason}`);
-    console.log(`  show: threadnote share conflict show ${conflict.id}`);
-    console.log(`  take shared: threadnote share conflict resolve ${conflict.id} --take shared`);
-    console.log(`  take local: threadnote share conflict resolve ${conflict.id} --take local`);
-    console.log(`  merged file: threadnote share conflict resolve ${conflict.id} --from-file merged.md`);
+    consoleOutput.log('');
+    consoleOutput.log(`${conflict.id}`);
+    consoleOutput.log(`  uri: ${conflict.uri}`);
+    consoleOutput.log(`  status: ${conflict.status}`);
+    consoleOutput.log(`  reason: ${conflict.reason}`);
+    consoleOutput.log(`  show: threadnote share conflict show ${conflict.id}`);
+    consoleOutput.log(`  take shared: threadnote share conflict resolve ${conflict.id} --take shared`);
+    consoleOutput.log(`  take local: threadnote share conflict resolve ${conflict.id} --take local`);
+    consoleOutput.log(`  merged file: threadnote share conflict resolve ${conflict.id} --from-file merged.md`);
   }
 }
 
@@ -752,16 +753,16 @@ export async function runShareConflictShow(
   options: ShareConflictShowOptions,
 ): Promise<void> {
   const detail = await showShareConflict(config, reference, options);
-  console.log(`Conflict: ${detail.id}`);
-  console.log(`URI: ${detail.uri}`);
-  console.log(`Status: ${detail.status}`);
-  console.log(`Reason: ${detail.reason}`);
-  console.log('');
-  console.log(detail.diff);
-  console.log('');
-  console.log('Resolve:');
+  consoleOutput.log(`Conflict: ${detail.id}`);
+  consoleOutput.log(`URI: ${detail.uri}`);
+  consoleOutput.log(`Status: ${detail.status}`);
+  consoleOutput.log(`Reason: ${detail.reason}`);
+  consoleOutput.log('');
+  consoleOutput.log(detail.diff);
+  consoleOutput.log('');
+  consoleOutput.log('Resolve:');
   for (const line of detail.resolutionGuidance) {
-    console.log(`  ${line}`);
+    consoleOutput.log(`  ${line}`);
   }
 }
 
@@ -772,15 +773,15 @@ export async function runShareConflictResolve(
 ): Promise<void> {
   const result = await resolveShareConflict(config, reference, options);
   for (const message of result.messages) {
-    console.log(message);
+    consoleOutput.log(message);
   }
   if (result.backupPath) {
-    console.log(`Backup: ${portablePath(result.backupPath)}`);
+    consoleOutput.log(`Backup: ${portablePath(result.backupPath)}`);
   }
   for (const message of result.gitMessages) {
-    console.log(message);
+    consoleOutput.log(message);
   }
-  console.log(`Resolved shared memory conflict: ${result.id}`);
+  consoleOutput.log(`Resolved shared memory conflict: ${result.id}`);
 }
 
 export async function listShareConflicts(
@@ -1187,7 +1188,7 @@ async function writeSharedConflictFile(
 ): Promise<void> {
   const filePath = join(team.config.worktree, conflict.relativePath);
   if (dryRun) {
-    console.log(`Would write shared file: ${portablePath(filePath)}`);
+    consoleOutput.log(`Would write shared file: ${portablePath(filePath)}`);
     return;
   }
   await mkdir(dirname(filePath), {recursive: true});
@@ -1357,7 +1358,7 @@ async function removeOrphanPackIndexes(dryRun: boolean, git: string, worktree: s
       if (tracked.exitCode === 0 && tracked.stdout.trim().length > 0) {
         continue;
       }
-      console.warn(
+      consoleOutput.warn(
         `${dryRun ? 'Would remove' : 'Removing'} incomplete shared pack (missing ${nameEntry.name}${PACK_MANIFEST_SUFFIX}): ${indexRelative}`,
       );
       if (!dryRun) {
@@ -1412,7 +1413,7 @@ export async function publishShareGitChange(
   }
 
   if (dryRun) {
-    console.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'commit', '-m', commitMessage])}`);
+    consoleOutput.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'commit', '-m', commitMessage])}`);
   } else {
     const commitResult = await runCommand(git, ['-C', worktree, 'commit', '-m', commitMessage], {allowFailure: true});
     if (commitResult.exitCode !== 0) {
@@ -1450,7 +1451,7 @@ async function runGitCommand(
   failureLabel: string,
 ): Promise<CommandResult | undefined> {
   if (dryRun) {
-    console.log(`Would run: ${formatShellCommand(git, args)}`);
+    consoleOutput.log(`Would run: ${formatShellCommand(git, args)}`);
     return undefined;
   }
   const result = await runCommand(git, args, {allowFailure: true});
@@ -1479,20 +1480,20 @@ export async function runSharePublish(
   const targetUri = sharedUriFor(config, sourceUri, team.name);
 
   if (preview) {
-    console.log(`PREVIEW source: ${sourceUri}`);
-    console.log(`PREVIEW destination: ${targetUri}`);
+    consoleOutput.log(`PREVIEW source: ${sourceUri}`);
+    consoleOutput.log(`PREVIEW destination: ${targetUri}`);
     if (scrub.blocker) {
-      console.log(
+      consoleOutput.log(
         `PREVIEW BLOCKED: ${scrub.blocker}. Strip the sensitive value or rerun with --redact for soft-leak patterns.`,
       );
       return;
     }
     for (const redaction of scrub.redactions) {
-      console.log(`PREVIEW redact: ${redaction.count}× ${redaction.name}`);
+      consoleOutput.log(`PREVIEW redact: ${redaction.count}× ${redaction.name}`);
     }
-    console.log('-----BEGIN PREVIEW-----');
-    console.log(scrub.cleaned);
-    console.log('-----END PREVIEW-----');
+    consoleOutput.log('-----BEGIN PREVIEW-----');
+    consoleOutput.log(scrub.cleaned);
+    consoleOutput.log('-----END PREVIEW-----');
     return;
   }
 
@@ -1502,7 +1503,7 @@ export async function runSharePublish(
     );
   }
   for (const redaction of scrub.redactions) {
-    console.log(`Redacted ${redaction.count}× ${redaction.name} before publish.`);
+    consoleOutput.log(`Redacted ${redaction.count}× ${redaction.name} before publish.`);
   }
   const content = scrub.cleaned;
 
@@ -1522,7 +1523,7 @@ export async function runSharePublish(
     push: options.push,
   });
   for (const gitMessage of gitMessages) {
-    console.log(gitMessage);
+    consoleOutput.log(gitMessage);
   }
   try {
     await removeMemoryUri(config, ov, sourceUri, dryRun);
@@ -1532,7 +1533,7 @@ export async function runSharePublish(
       {cause: err},
     );
   }
-  console.log(`Published ${sourceUri} -> ${targetUri}`);
+  consoleOutput.log(`Published ${sourceUri} -> ${targetUri}`);
 }
 
 export async function runSharePublishArtifact(
@@ -2560,13 +2561,13 @@ export async function runShareInstallArtifacts(
 ): Promise<void> {
   const result = await installSharedAgentArtifacts(config, options);
   if (result.syncedTeams.length > 0) {
-    console.log(`Synced shared teams: ${result.syncedTeams.join(', ')}`);
+    consoleOutput.log(`Synced shared teams: ${result.syncedTeams.join(', ')}`);
   }
   for (const warning of result.warnings) {
-    console.warn(`Warning: ${warning}`);
+    consoleOutput.warn(`Warning: ${warning}`);
   }
   for (const message of result.messages) {
-    console.log(message);
+    consoleOutput.log(message);
   }
 }
 
@@ -2694,7 +2695,7 @@ export async function runShareUnpublish(
     verb: 'rm',
   });
   for (const gitMessage of gitMessages) {
-    console.log(gitMessage);
+    consoleOutput.log(gitMessage);
   }
   try {
     await removeMemoryUri(config, ov, sourceUri, dryRun);
@@ -2704,23 +2705,23 @@ export async function runShareUnpublish(
       {cause: err},
     );
   }
-  console.log(`Unpublished ${sourceUri} -> ${targetUri}`);
+  consoleOutput.log(`Unpublished ${sourceUri} -> ${targetUri}`);
 }
 
 export async function runShareList(config: ShareRuntime, _options: ShareListOptions): Promise<void> {
   const teams = await readTeamsFile(config);
   const entries = Object.values(teams.teams);
   if (entries.length === 0) {
-    console.log('No shared teams configured. Run: threadnote share init <remote-url>');
+    consoleOutput.log('No shared teams configured. Run: threadnote share init <remote-url>');
     return;
   }
   for (const team of entries) {
     const marker = team.name === teams.defaultTeam ? ' (default)' : '';
-    console.log(`- ${team.name}${marker}`);
-    console.log(`    remote: ${team.remote}`);
-    console.log(`    worktree: ${portablePath(team.worktree)}`);
-    console.log(`    gitdir: ${portablePath(team.gitdir)}`);
-    console.log(`    added: ${team.addedAt}`);
+    consoleOutput.log(`- ${team.name}${marker}`);
+    consoleOutput.log(`    remote: ${team.remote}`);
+    consoleOutput.log(`    worktree: ${portablePath(team.worktree)}`);
+    consoleOutput.log(`    gitdir: ${portablePath(team.gitdir)}`);
+    consoleOutput.log(`    added: ${team.addedAt}`);
   }
 }
 
@@ -2761,11 +2762,13 @@ export async function runShareRename(config: ShareRuntime, options: ShareRenameO
   };
 
   if (dryRun) {
-    console.log(`Would rename worktree: ${portablePath(oldTeam.config.worktree)} -> ${portablePath(newWorktree)}`);
-    console.log(`Would rename gitdir: ${portablePath(oldTeam.config.gitdir)} -> ${portablePath(newGitdir)}`);
-    console.log(`Would update git core.worktree and the worktree .git pointer for team "${newName}".`);
-    console.log(`Would reindex shared context under team "${newName}" and remove old shared URI tree.`);
-    console.log(`Would write teams file: ${teamsFilePath(config)}`);
+    consoleOutput.log(
+      `Would rename worktree: ${portablePath(oldTeam.config.worktree)} -> ${portablePath(newWorktree)}`,
+    );
+    consoleOutput.log(`Would rename gitdir: ${portablePath(oldTeam.config.gitdir)} -> ${portablePath(newGitdir)}`);
+    consoleOutput.log(`Would update git core.worktree and the worktree .git pointer for team "${newName}".`);
+    consoleOutput.log(`Would reindex shared context under team "${newName}" and remove old shared URI tree.`);
+    consoleOutput.log(`Would write teams file: ${teamsFilePath(config)}`);
     return;
   }
 
@@ -2810,8 +2813,8 @@ export async function runShareRename(config: ShareRuntime, options: ShareRenameO
     `viking://user/${uriSegment(config.user)}/memories/${SHARED_SEGMENT}/${oldTeam.name}`,
     false,
   );
-  console.log(`Renamed shared team "${oldTeam.name}" -> "${newName}".`);
-  console.log(`Reindexed ${ingested} shared file(s).`);
+  consoleOutput.log(`Renamed shared team "${oldTeam.name}" -> "${newName}".`);
+  consoleOutput.log(`Reindexed ${ingested} shared file(s).`);
 }
 
 export async function runShareSetUrl(
@@ -2826,13 +2829,13 @@ export async function runShareSetUrl(
   const dryRun = options.dryRun === true;
   const git = await requiredExecutable('git');
   if (dryRun) {
-    console.log(
+    consoleOutput.log(
       `Would run: ${formatShellCommand(git, ['-C', team.config.worktree, 'remote', 'set-url', DEFAULT_GIT_REMOTE_NAME, '--', remoteUrl])}`,
     );
-    console.log(
+    consoleOutput.log(
       `Would run: ${formatShellCommand(git, ['-C', team.config.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME])}`,
     );
-    console.log(`Would write teams file: ${teamsFilePath(config)}`);
+    consoleOutput.log(`Would write teams file: ${teamsFilePath(config)}`);
     return;
   }
   await runCommand(git, ['-C', team.config.worktree, 'remote', 'set-url', DEFAULT_GIT_REMOTE_NAME, '--', remoteUrl]);
@@ -2843,7 +2846,7 @@ export async function runShareSetUrl(
     ...teamsFile,
     teams: {...teamsFile.teams, [team.name]: updatedTeam},
   });
-  console.log(`Updated shared team "${team.name}" remote: ${remoteUrl}`);
+  consoleOutput.log(`Updated shared team "${team.name}" remote: ${remoteUrl}`);
 }
 
 export async function runShareRemove(config: ShareRuntime, options: ShareRemoveOptions): Promise<void> {
@@ -2851,7 +2854,7 @@ export async function runShareRemove(config: ShareRuntime, options: ShareRemoveO
   const dryRun = options.dryRun === true;
   if (options.preserveLocal === true) {
     const preserved = await preserveSharedMemoriesLocally(config, team.config, dryRun);
-    console.log(`${dryRun ? 'Would preserve' : 'Preserved'} ${preserved} shared durable memory file(s) locally.`);
+    consoleOutput.log(`${dryRun ? 'Would preserve' : 'Preserved'} ${preserved} shared durable memory file(s) locally.`);
   }
   const teamsFile = await readTeamsFile(config);
   const remaining: Record<string, ShareTeamConfig> = {};
@@ -2864,16 +2867,16 @@ export async function runShareRemove(config: ShareRuntime, options: ShareRemoveO
   const nextDefault = teamsFile.defaultTeam === team.name ? remainingNames[0] : teamsFile.defaultTeam;
   const updated: ShareTeamsFile = {defaultTeam: nextDefault, teams: remaining, version: TEAMS_FILE_VERSION};
   if (dryRun) {
-    console.log(`Would update teams file: ${teamsFilePath(config)}`);
+    consoleOutput.log(`Would update teams file: ${teamsFilePath(config)}`);
   } else {
     await writeTeamsFile(config, updated);
-    console.log(`Removed team "${team.name}" from teams.json.`);
+    consoleOutput.log(`Removed team "${team.name}" from teams.json.`);
   }
   if (options.keepFiles !== true) {
     await removePath(team.config.worktree, 'shared worktree', dryRun);
     await removePath(team.config.gitdir, 'shared gitdir', dryRun);
   } else {
-    console.log(`Keeping files at ${portablePath(team.config.worktree)} and ${portablePath(team.config.gitdir)}`);
+    consoleOutput.log(`Keeping files at ${portablePath(team.config.worktree)} and ${portablePath(team.config.gitdir)}`);
   }
 }
 
@@ -2899,7 +2902,7 @@ async function preserveSharedMemoriesLocally(
     const targetUri = `viking://user/${uriSegment(config.user)}/memories/${rel}`;
     const content = await readFile(file, 'utf8');
     if (dryRun) {
-      console.log(`Would preserve ${rel} -> ${targetUri}`);
+      consoleOutput.log(`Would preserve ${rel} -> ${targetUri}`);
     } else {
       await ensurePersonalDirectoryChain(config, ov, parentUri(targetUri));
       await writeMemoryFile(config, ov, targetUri, content, 'create', false);
@@ -2979,12 +2982,12 @@ export async function readTeamsFile(config: ShareRuntime): Promise<ShareTeamsFil
   if (typeof parsed.teams === 'object' && parsed.teams !== null && !Array.isArray(parsed.teams)) {
     for (const [name, value] of Object.entries(parsed.teams)) {
       if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-        console.warn(`Skipping non-object team entry "${name}" in ${path}.`);
+        consoleOutput.warn(`Skipping non-object team entry "${name}" in ${path}.`);
         continue;
       }
       const entry = value as Record<string, unknown>;
       if (typeof entry.remote !== 'string' || entry.remote.length === 0) {
-        console.warn(`Skipping team entry "${name}" in ${path}: missing or empty "remote" field.`);
+        consoleOutput.warn(`Skipping team entry "${name}" in ${path}: missing or empty "remote" field.`);
         continue;
       }
       teams[name] = {
@@ -3072,7 +3075,9 @@ async function walkMemoryFiles(root: string): Promise<readonly string[]> {
     try {
       entries = await readdir(path, {withFileTypes: true});
     } catch (err: unknown) {
-      console.warn(`Skipping ${path} during shared-tree walk: ${err instanceof Error ? err.message : String(err)}`);
+      consoleOutput.warn(
+        `Skipping ${path} during shared-tree walk: ${err instanceof Error ? err.message : String(err)}`,
+      );
       return;
     }
     for (const entry of entries) {
@@ -3285,7 +3290,7 @@ async function collectSharedArtifacts(worktree: string, team: string): Promise<r
       // An orphaned pack index without its .pack.json is an incomplete/partial
       // publish; skip it so it neither pollutes the catalog nor breaks discovery.
       if (artifact.kind === 'pack' && !(await isFile(join(artifactDir, `${artifact.name}${PACK_MANIFEST_SUFFIX}`)))) {
-        console.warn(
+        consoleOutput.warn(
           `Skipping incomplete shared pack (missing ${artifact.name}${PACK_MANIFEST_SUFFIX}): ${relativePath}`,
         );
         continue;
@@ -3302,7 +3307,9 @@ async function collectSharedArtifacts(worktree: string, team: string): Promise<r
           team,
         });
       } catch (err: unknown) {
-        console.warn(`Skipping shared artifact ${relativePath}: ${err instanceof Error ? err.message : String(err)}`);
+        consoleOutput.warn(
+          `Skipping shared artifact ${relativePath}: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
   }
@@ -3886,15 +3893,15 @@ function sharedArtifactInstallPath(team: string, artifact: ShareArtifactMetadata
 
 function printShareArtifactResult(result: ShareArtifactResult, preview: boolean): void {
   for (const message of result.messages) {
-    console.log(message);
+    consoleOutput.log(message);
   }
   for (const gitMessage of result.gitMessages) {
-    console.log(gitMessage);
+    consoleOutput.log(gitMessage);
   }
   if (preview && result.previewContent !== undefined) {
-    console.log('-----BEGIN PREVIEW-----');
-    console.log(result.previewContent);
-    console.log('-----END PREVIEW-----');
+    consoleOutput.log('-----BEGIN PREVIEW-----');
+    consoleOutput.log(result.previewContent);
+    consoleOutput.log('-----END PREVIEW-----');
   }
 }
 
@@ -3937,7 +3944,7 @@ export function stripPersonalProvenance(content: string): string {
 async function readMemoryContent(config: ShareRuntime, ov: string, uri: string, dryRun: boolean): Promise<string> {
   const args = withIdentity(config, ['read', uri]);
   if (dryRun) {
-    console.log(`Would run: ${formatShellCommand(ov, args)}`);
+    consoleOutput.log(`Would run: ${formatShellCommand(ov, args)}`);
     return '<dry-run memory body>';
   }
   const result = await runCommand(ov, args);
@@ -3959,7 +3966,7 @@ export async function ensureSharedDirectoryChain(
     const args = withIdentity(config, ['stat', uri]);
     if (dryRun) {
       if (options.quiet !== true) {
-        console.log(`Would run: ${formatShellCommand(ov, args)}`);
+        consoleOutput.log(`Would run: ${formatShellCommand(ov, args)}`);
       }
       continue;
     }
@@ -4015,7 +4022,7 @@ export async function writeMemoryFile(
       '120',
     ]);
     if (options.quiet !== true) {
-      console.log(`Would run: ${formatShellCommand(ov, args)}`);
+      consoleOutput.log(`Would run: ${formatShellCommand(ov, args)}`);
     }
     return;
   }
@@ -4073,15 +4080,15 @@ async function writeOvFileWithRetry(
       '120',
     ]);
     if (options.quiet !== true) {
-      console.log(`${attempt === 0 ? 'Running' : 'Retrying'}: ${formatShellCommand(ov, args)}`);
+      consoleOutput.log(`${attempt === 0 ? 'Running' : 'Retrying'}: ${formatShellCommand(ov, args)}`);
     }
     const result = await runCommand(ov, args, {allowFailure: true});
     if (result.exitCode === 0) {
       if (options.quiet !== true && result.stdout.trim()) {
-        console.log(result.stdout.trim());
+        consoleOutput.log(result.stdout.trim());
       }
       if (options.quiet !== true && result.stderr.trim()) {
-        console.error(result.stderr.trim());
+        consoleOutput.error(result.stderr.trim());
       }
       return;
     }
@@ -4094,7 +4101,7 @@ async function writeOvFileWithRetry(
       // this call started) even though OV returned an error before the --wait
       // completed. Drain the queue and treat the write as durable.
       if (options.quiet !== true) {
-        console.log(
+        consoleOutput.log(
           'OpenViking accepted the write but returned an error before the wait completed; draining the queue.',
         );
       }
@@ -4142,15 +4149,15 @@ async function refreshMemoryIndex(
   );
   if (result.exitCode === 0) {
     if (options.quiet !== true && result.stdout.trim()) {
-      console.log(result.stdout.trim());
+      consoleOutput.log(result.stdout.trim());
     }
     if (options.quiet !== true && result.stderr.trim()) {
-      console.error(result.stderr.trim());
+      consoleOutput.error(result.stderr.trim());
     }
     return;
   }
   if (options.quiet !== true) {
-    console.error(
+    consoleOutput.error(
       `Memory stored, but index refresh failed for ${uri}: ${result.stderr.trim() || result.stdout.trim()}`,
     );
   }
@@ -4163,10 +4170,10 @@ async function waitForOvQueue(
 ): Promise<void> {
   const result = await runCommand(ov, withIdentity(config, ['wait', '--timeout', '120']), {allowFailure: true});
   if (options.quiet !== true && result.stdout.trim()) {
-    console.log(result.stdout.trim());
+    consoleOutput.log(result.stdout.trim());
   }
   if (options.quiet !== true && result.stderr.trim()) {
-    console.error(result.stderr.trim());
+    consoleOutput.error(result.stderr.trim());
   }
 }
 
@@ -4227,7 +4234,7 @@ export async function removeMemoryUri(
   const args = withIdentity(config, ['rm', uri]);
   if (dryRun) {
     if (options.quiet !== true) {
-      console.log(`Would run: ${formatShellCommand(ov, args)}`);
+      consoleOutput.log(`Would run: ${formatShellCommand(ov, args)}`);
     }
     return;
   }
@@ -4236,7 +4243,7 @@ export async function removeMemoryUri(
     const result = await runCommand(ov, args, {allowFailure: true});
     if (result.exitCode === 0) {
       if (options.quiet !== true && result.stdout.trim()) {
-        console.log(result.stdout.trim());
+        consoleOutput.log(result.stdout.trim());
       }
       return;
     }
@@ -4430,7 +4437,7 @@ async function applyChangesToOpenViking(
             ? 'updating from upstream after verifying local content matches the previous shared version'
             : 'aligning OV to upstream (resource pre-existed in OV, likely from an earlier local publish or sync)';
         if (options.quiet !== true) {
-          console.warn(`share sync: ${uri}: ${reason}.`);
+          consoleOutput.warn(`share sync: ${uri}: ${reason}.`);
         }
       }
       await ensureSharedDirectoryChain(config, ov, uri, false, options);
@@ -4439,7 +4446,7 @@ async function applyChangesToOpenViking(
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       if (options.quiet !== true) {
-        console.warn(`share sync: ${uri}: ingest failed — will retry on the next sync. ${message}`);
+        consoleOutput.warn(`share sync: ${uri}: ingest failed — will retry on the next sync. ${message}`);
       }
       failed.push(change);
     }

--- a/src/threadnote.ts
+++ b/src/threadnote.ts
@@ -1,7 +1,7 @@
 #! /usr/bin/env node
 
 import {NodeRuntime, NodeServices} from '@effect/platform-node';
-import {Effect} from 'effect';
+import {Console, Effect} from 'effect';
 import {Command} from 'effect/unstable/cli';
 import {errorMessage} from './utils.js';
 import {getThreadnoteVersion} from './version.js';
@@ -17,7 +17,7 @@ const program = Command.runWith(threadnoteCommand, {version: getThreadnoteVersio
   Effect.tapError(error =>
     CliError.isCliError(error)
       ? Effect.void
-      : Effect.sync(() => console.error(errorMessage(error instanceof ApplicationError ? error.cause : error))),
+      : Console.error(errorMessage(error instanceof ApplicationError ? error.cause : error)),
   ),
   Effect.catch(() =>
     Effect.sync(() => {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -3,6 +3,7 @@ import {mkdir, readFile, writeFile} from 'node:fs/promises';
 import {dirname} from 'node:path';
 import {Effect} from 'effect';
 import {getJsonEffect} from './effect/http.js';
+import {fromPromiseError} from './effect/errors.js';
 import {compareVersions, isJsonObject} from './utils.js';
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -38,13 +39,13 @@ export function checkForThreadnoteUpdate(args: {readonly cachePath: string; read
     return Effect.succeed(undefined);
   }
   return Effect.gen(function* () {
-    const cached = yield* Effect.promise(() => readUpdateCache(args.cachePath));
+    const cached = yield* fromPromiseError(() => readUpdateCache(args.cachePath));
     if (cached && isCacheFresh(cached)) {
       return toUpdateCheckResult(args.currentVersion, cached.latestVersion);
     }
     const fresh = yield* fetchLatestVersionEffect();
     if (fresh) {
-      yield* Effect.promise(() =>
+      yield* fromPromiseError(() =>
         writeUpdateCache(args.cachePath, {
           checkedAt: new Date().toISOString(),
           latestVersion: fresh,

--- a/src/update.ts
+++ b/src/update.ts
@@ -6,7 +6,8 @@ import {createInterface} from 'node:readline/promises';
 import {stdin as input, stdout as output} from 'node:process';
 import {Effect, pipe} from 'effect';
 import {heading, info as infoText, keyValue, success, warning, withSpinnerEffect} from './cli_ui.js';
-import {applicationError} from './effect/errors.js';
+import {consoleOutput, syncWithConsole} from './effect/console.js';
+import {applicationError, fromPromise, fromSync} from './effect/errors.js';
 import {getJsonEffect, getStatusEffect} from './effect/http.js';
 import {pollUntilEffect} from './effect/time.js';
 import {hasLegacyLifecycleHandoffCandidates, hasProjectNameMigrationCandidates} from './memory.js';
@@ -65,12 +66,6 @@ interface PostUpdateState {
   readonly handledMigrationIds: readonly string[];
 }
 
-const fromPromise = <A>(operation: string, evaluate: () => Promise<A>) =>
-  Effect.tryPromise({try: evaluate, catch: cause => applicationError(operation, cause)});
-
-const fromSync = <A>(operation: string, evaluate: () => A) =>
-  Effect.try({try: evaluate, catch: cause => applicationError(operation, cause)});
-
 export function parseUpdateRuntime(value: string): UpdateRuntime {
   if (value === 'auto' || value === 'npm' || value === 'bun' || value === 'deno') {
     return value;
@@ -92,10 +87,10 @@ export function maybeNotifyUpdate(config: RuntimeConfig, options: {readonly dryR
     ),
     Effect.tap(info =>
       info.isUpdateAvailable
-        ? Effect.sync(() => {
-            console.log('');
-            console.log(warning(`Update available: threadnote ${info.currentVersion} -> ${info.latestVersion}`));
-            console.log(`Run: ${infoText('threadnote update')}`);
+        ? syncWithConsole(() => {
+            consoleOutput.log('');
+            consoleOutput.log(warning(`Update available: threadnote ${info.currentVersion} -> ${info.latestVersion}`));
+            consoleOutput.log(`Run: ${infoText('threadnote update')}`);
           })
         : Effect.void,
     ),
@@ -117,19 +112,19 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     }),
   );
 
-  yield* Effect.sync(() => {
-    console.log(keyValue('Current version', infoText(info.currentVersion)));
-    console.log(keyValue('Latest version', infoText(info.latestVersion)));
-    console.log(keyValue('Registry', info.registry));
+  yield* syncWithConsole(() => {
+    consoleOutput.log(keyValue('Current version', infoText(info.currentVersion)));
+    consoleOutput.log(keyValue('Latest version', infoText(info.latestVersion)));
+    consoleOutput.log(keyValue('Registry', info.registry));
   });
 
   if (options.check === true) {
     if (info.isUpdateAvailable) {
-      yield* Effect.sync(() => console.log(warning('Update available. Run: threadnote update')));
+      yield* syncWithConsole(() => consoleOutput.log(warning('Update available. Run: threadnote update')));
       yield* printWhatsNewIfAvailable(info);
     } else {
-      yield* Effect.sync(() =>
-        console.log(
+      yield* syncWithConsole(() =>
+        consoleOutput.log(
           compareVersions(info.currentVersion, info.latestVersion) > 0
             ? warning('Current version is newer than npm latest.')
             : success('Threadnote is up to date.'),
@@ -140,7 +135,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   }
 
   if (!info.isUpdateAvailable && options.force !== true) {
-    yield* Effect.sync(() => console.log(success('Threadnote is up to date.')));
+    yield* syncWithConsole(() => consoleOutput.log(success('Threadnote is up to date.')));
     return;
   }
 
@@ -149,7 +144,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   yield* runStreamingSubcommand(options.dryRun === true, updateCommand.executable, updateCommand.args);
 
   if (options.repair === false) {
-    yield* Effect.sync(() => console.log('Skipping repair because --no-repair was provided.'));
+    yield* syncWithConsole(() => consoleOutput.log('Skipping repair because --no-repair was provided.'));
     yield* printWhatsNewIfAvailable(info);
     return;
   }
@@ -157,9 +152,9 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   const threadnoteCommand = yield* fromPromise('resolve installed threadnote command', () =>
     installedThreadnoteCommand(runtime),
   );
-  yield* Effect.sync(() => {
-    console.log('');
-    console.log('Repairing local Threadnote setup after package update.');
+  yield* syncWithConsole(() => {
+    consoleOutput.log('');
+    consoleOutput.log('Repairing local Threadnote setup after package update.');
   });
   yield* runStreamingSubcommand(options.dryRun === true, threadnoteCommand, ['repair', '--no-post-update']);
   if (options.postUpdate !== false) {
@@ -173,12 +168,12 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     ];
     yield* runStreamingSubcommand(options.dryRun === true, threadnoteCommand, postUpdateArgs);
   } else {
-    yield* Effect.sync(() =>
-      console.log('Skipping post-update migration prompts because --no-post-update was provided.'),
+    yield* syncWithConsole(() =>
+      consoleOutput.log('Skipping post-update migration prompts because --no-post-update was provided.'),
     );
   }
-  yield* Effect.sync(() =>
-    console.log(
+  yield* syncWithConsole(() =>
+    consoleOutput.log(
       'Update complete. Restart Cursor, Copilot, Codex, Claude, or open a fresh agent session so MCP tools reload.',
     ),
   );
@@ -190,14 +185,14 @@ function printWhatsNewIfAvailable(info: UpdateInfo) {
     return Effect.void;
   }
   return Effect.gen(function* () {
-    yield* Effect.sync(() => console.log(''));
+    yield* syncWithConsole(() => consoleOutput.log(''));
     const whatsNew = yield* withSpinnerEffect(
       'Fetching GitHub release notes',
       whatsNewLinesForVersionRange(info.currentVersion, info.latestVersion),
     );
-    yield* Effect.sync(() => {
+    yield* syncWithConsole(() => {
       for (const line of whatsNew) {
-        console.log(line === "What's new:" ? heading(line) : line);
+        consoleOutput.log(line === "What's new:" ? heading(line) : line);
       }
     });
   });
@@ -244,18 +239,22 @@ export function maybeRunPostUpdateAfterRepair(config: RuntimeConfig, options: {r
     if (migrations.length === 0) {
       return;
     }
-    yield* Effect.sync(() => {
-      console.log('');
-      console.log('Repair found package post-update migrations.');
-      console.log('This also covers updates launched by older Threadnote versions that only knew how to run repair.');
+    yield* syncWithConsole(() => {
+      consoleOutput.log('');
+      consoleOutput.log('Repair found package post-update migrations.');
+      consoleOutput.log(
+        'This also covers updates launched by older Threadnote versions that only knew how to run repair.',
+      );
     });
     if (!interactive) {
-      console.log(
-        'This process is non-interactive, so Threadnote will print the manual migration command instead of prompting.',
-      );
-      console.log(
-        `Run the prompt manually with: threadnote post-update --from-version 0.0.0 --to-version ${toVersion}`,
-      );
+      yield* syncWithConsole(() => {
+        consoleOutput.log(
+          'This process is non-interactive, so Threadnote will print the manual migration command instead of prompting.',
+        );
+        consoleOutput.log(
+          `Run the prompt manually with: threadnote post-update --from-version 0.0.0 --to-version ${toVersion}`,
+        );
+      });
     }
     yield* fromPromise('run post-update migrations after repair', () =>
       runApplicablePostUpdateMigrations(config, {
@@ -295,8 +294,10 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
     }
     const installedVersion = yield* fromPromise('read OpenViking CLI version', () => readOpenVikingCliVersion(ov));
     if (!installedVersion) {
-      yield* Effect.sync(() =>
-        console.log(`Could not detect OpenViking CLI version via \`${ov} version\`; skipping pinned-version check.`),
+      yield* syncWithConsole(() =>
+        consoleOutput.log(
+          `Could not detect OpenViking CLI version via \`${ov} version\`; skipping pinned-version check.`,
+        ),
       );
       return;
     }
@@ -304,10 +305,10 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
     if (compareVersions(installedVersion, pinned) >= 0) {
       return;
     }
-    yield* Effect.sync(() => {
-      console.log('');
-      console.log(`Upgrading OpenViking ${installedVersion} -> ${pinned} (pinned by Threadnote).`);
-      console.log('Picks up upstream CLI, resource-ingestion, and index reliability fixes.');
+    yield* syncWithConsole(() => {
+      consoleOutput.log('');
+      consoleOutput.log(`Upgrading OpenViking ${installedVersion} -> ${pinned} (pinned by Threadnote).`);
+      consoleOutput.log('Picks up upstream CLI, resource-ingestion, and index reliability fixes.');
     });
 
     // Capture the server state BEFORE we swap binaries so we know what to
@@ -326,7 +327,9 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
 
     if (options.dryRun) {
       if (wasRunning || usingLaunchd) {
-        yield* Effect.sync(() => console.log('Would restart OpenViking server so the new binary takes effect.'));
+        yield* syncWithConsole(() =>
+          consoleOutput.log('Would restart OpenViking server so the new binary takes effect.'),
+        );
       }
       return;
     }
@@ -335,7 +338,7 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
       return;
     }
 
-    yield* Effect.sync(() => console.log('Restarting OpenViking server so the new binary takes effect.'));
+    yield* syncWithConsole(() => consoleOutput.log('Restarting OpenViking server so the new binary takes effect.'));
     if (usingLaunchd) {
       const launchAgentPath = launchAgentPlistPath();
       yield* fromPromise('unload OpenViking launch agent', () =>
@@ -352,11 +355,11 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
     }
     const healthyAfter = yield* waitForOpenVikingHealthy(config, 10_000);
     if (!healthyAfter) {
-      yield* Effect.sync(() => {
-        console.log(
+      yield* syncWithConsole(() => {
+        consoleOutput.log(
           `Warning: OpenViking did not return to healthy at ${openVikingHealthEndpoint(config)} within 10s after the restart.`,
         );
-        console.log('Check the server log or run: threadnote start');
+        consoleOutput.log('Check the server log or run: threadnote start');
       });
     }
   });
@@ -374,7 +377,7 @@ function runStreamingSubcommand(dryRun: boolean, executable: string, args: reado
     return fromPromise('print subcommand', () => maybeRun(true, executable, args)).pipe(Effect.asVoid);
   }
   return Effect.gen(function* () {
-    yield* Effect.sync(() => console.log(`Running: ${formatShellCommand(executable, args)}`));
+    yield* syncWithConsole(() => consoleOutput.log(`Running: ${formatShellCommand(executable, args)}`));
     const exitCode = yield* fromPromise('run interactive subcommand', () => runInteractive(executable, args));
     if (exitCode !== 0) {
       return yield* Effect.fail(
@@ -413,8 +416,8 @@ function waitForOpenVikingHealthy(config: RuntimeConfig, timeoutMs: number) {
 
 function waitForOpenVikingPortClosed(config: RuntimeConfig, timeoutMs: number) {
   return Effect.gen(function* () {
-    yield* Effect.sync(() =>
-      console.log(`Waiting for OpenViking port ${config.host}:${config.port} to close before restart.`),
+    yield* syncWithConsole(() =>
+      consoleOutput.log(`Waiting for OpenViking port ${config.host}:${config.port} to close before restart.`),
     );
     const closed = yield* pipe(
       pollUntilEffect(
@@ -428,8 +431,8 @@ function waitForOpenVikingPortClosed(config: RuntimeConfig, timeoutMs: number) {
     if (closed) {
       return true;
     }
-    yield* Effect.sync(() =>
-      console.log(
+    yield* syncWithConsole(() =>
+      consoleOutput.log(
         `Warning: OpenViking port ${config.host}:${config.port} is still in use after ${timeoutMs / 1000}s; start may fail.`,
       ),
     );
@@ -567,12 +570,12 @@ async function runApplicablePostUpdateMigrations(
     toVersion: options.toVersion,
   });
   if (migrations.length === 0) {
-    console.log('No post-update memory migrations apply.');
+    consoleOutput.log('No post-update memory migrations apply.');
     return;
   }
 
-  console.log('');
-  console.log('Post-update memory migrations are available.');
+  consoleOutput.log('');
+  consoleOutput.log('Post-update memory migrations are available.');
   const threadnoteCommand =
     currentThreadnoteCommand() ?? (await findExecutable([NPM_PACKAGE_NAME])) ?? NPM_PACKAGE_NAME;
   const handledMigrationIds = new Set(state.handledMigrationIds);
@@ -583,20 +586,20 @@ async function runApplicablePostUpdateMigrations(
       options.yes ||
       (options.interactive && (await confirmPostUpdateMigration('Apply this migration now? [y/N] ')));
     if (!accepted) {
-      console.log('Skipped. Run manually later:');
-      console.log(`  ${formatMigrationCommand(threadnoteCommand, migration.commandArgs)}`);
+      consoleOutput.log('Skipped. Run manually later:');
+      consoleOutput.log(`  ${formatMigrationCommand(threadnoteCommand, migration.commandArgs)}`);
       continue;
     }
     await runStreamingSubcommand(options.dryRun, threadnoteCommand, migration.commandArgs);
     if (!options.dryRun) {
       handledMigrationIds.add(migration.id);
       for (const instruction of migration.instructions) {
-        console.log(instruction);
+        consoleOutput.log(instruction);
       }
     } else {
-      console.log('After this migration succeeds, Threadnote will print:');
+      consoleOutput.log('After this migration succeeds, Threadnote will print:');
       for (const instruction of migration.instructions) {
-        console.log(`  ${instruction}`);
+        consoleOutput.log(`  ${instruction}`);
       }
     }
   }
@@ -683,10 +686,10 @@ function stringArray(value: JsonObject, key: string): readonly string[] {
 }
 
 function printPostUpdateMigration(migration: PostUpdateMigration): void {
-  console.log('');
-  console.log(`${migration.title} (${migration.introducedIn})`);
+  consoleOutput.log('');
+  consoleOutput.log(`${migration.title} (${migration.introducedIn})`);
   for (const line of migration.description) {
-    console.log(`- ${line}`);
+    consoleOutput.log(`- ${line}`);
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,11 +8,18 @@ import {homedir} from 'node:os';
 import {basename, delimiter, dirname, isAbsolute, join, resolve, sep} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {command as commandText, failure, info, success, warning} from './cli_ui.js';
-import {commandMaxOutputBytes, commandTimeoutMs, type CommandOptions, withoutGitEnvironment} from './effect/command.js';
+import {consoleOutput} from './effect/console.js';
+import {
+  commandMaxOutputBytes,
+  commandTimeoutMs,
+  formatShellCommand,
+  type CommandOptions,
+  withoutGitEnvironment,
+} from './effect/command.js';
 import {redactSensitiveText} from './scrubber.js';
 import type {CommandResult, CommandStatus, JsonObject} from './types.js';
 
-export {withoutGitEnvironment} from './effect/command.js';
+export {formatShellCommand, shellQuote, withoutGitEnvironment} from './effect/command.js';
 
 const moduleDirectory = dirname(fileURLToPath(import.meta.url));
 
@@ -239,16 +246,16 @@ export async function maybeRun(
 ): Promise<CommandResult | undefined> {
   const cwdSuffix = options.cwd ? ` (cwd: ${options.cwd})` : '';
   const label = dryRun ? warning('Would run') : info('Running');
-  console.log(`${label}: ${commandText(formatShellCommand(executable, args))}${cwdSuffix}`);
+  consoleOutput.log(`${label}: ${commandText(formatShellCommand(executable, args))}${cwdSuffix}`);
   if (dryRun) {
     return undefined;
   }
   const result = await runCommand(executable, args, {allowFailure: options.allowFailure === true, cwd: options.cwd});
   if (result.stdout.trim()) {
-    console.log(result.stdout.trim());
+    consoleOutput.log(result.stdout.trim());
   }
   if (result.stderr.trim()) {
-    console.error(result.stderr.trim());
+    consoleOutput.error(result.stderr.trim());
   }
   return result;
 }
@@ -617,7 +624,7 @@ export async function getInputText(optionText: string | undefined, useStdin: boo
 
 export async function ensureDirectory(path: string, dryRun: boolean): Promise<void> {
   if (dryRun) {
-    console.log(`Would create directory: ${path}`);
+    consoleOutput.log(`Would create directory: ${path}`);
     return;
   }
   await mkdir(path, {recursive: true});
@@ -681,7 +688,7 @@ export async function readFileIfExists(path: string): Promise<string | undefined
 
 export async function removePathIfExists(path: string, label: string, dryRun: boolean): Promise<void> {
   if (!(await exists(path))) {
-    console.log(`Already absent: ${path}`);
+    consoleOutput.log(`Already absent: ${path}`);
     return;
   }
   await removePath(path, label, dryRun);
@@ -689,11 +696,11 @@ export async function removePathIfExists(path: string, label: string, dryRun: bo
 
 export async function removePath(path: string, label: string, dryRun: boolean): Promise<void> {
   if (dryRun) {
-    console.log(`Would remove ${label}: ${path}`);
+    consoleOutput.log(`Would remove ${label}: ${path}`);
     return;
   }
   await rm(path, {force: true, recursive: true});
-  console.log(`Removed ${label}: ${path}`);
+  consoleOutput.log(`Removed ${label}: ${path}`);
 }
 
 export function parsePort(value: string): number {
@@ -1670,17 +1677,6 @@ export function formatStatus(status: CommandStatus): string {
     return warning('WARN');
   }
   return failure('FAIL');
-}
-
-export function formatShellCommand(executable: string, args: readonly string[]): string {
-  return redactText([executable, ...args].map(shellQuote).join(' '));
-}
-
-export function shellQuote(value: string): string {
-  if (/^[A-Za-z0-9_./:@=-]+$/.test(value)) {
-    return value;
-  }
-  return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }
 
 export function toolRoot(): string {

--- a/src/version_command.ts
+++ b/src/version_command.ts
@@ -1,16 +1,13 @@
-import {Effect, Result} from 'effect';
+import {Console, Effect, Result} from 'effect';
 import {heading, info, keyValue, success, warning, withSpinnerEffect} from './cli_ui.js';
-import {applicationError} from './effect/errors.js';
+import {applicationError, fromPromise} from './effect/errors.js';
 import type {RuntimeConfig, VersionOptions} from './types.js';
 import {currentPackageVersion, fetchLatestVersion, resolveUpdateRegistry} from './update.js';
 import {compareVersions, errorMessage} from './utils.js';
 import {whatsNewLinesForVersion, whatsNewLinesForVersionRange} from './release_notes.js';
 
 export const runVersion = Effect.fn('runVersion')(function* (config: RuntimeConfig, options: VersionOptions) {
-  const currentVersion = yield* Effect.tryPromise({
-    try: currentPackageVersion,
-    catch: cause => applicationError('read current package version', cause),
-  });
+  const currentVersion = yield* fromPromise('read current package version', currentPackageVersion);
   const registry = yield* Effect.try({
     try: () => resolveUpdateRegistry(options.registry, options.allowUntrustedRegistry),
     catch: cause => applicationError('resolve update registry', cause),
@@ -22,12 +19,10 @@ export const runVersion = Effect.fn('runVersion')(function* (config: RuntimeConf
   const latestVersion = Result.isSuccess(latest) ? latest.success : undefined;
   const latestWarning = Result.isFailure(latest) ? errorMessage(latest.failure) : undefined;
 
-  yield* Effect.sync(() => {
-    console.log(keyValue('Current version', info(currentVersion)));
-    console.log(keyValue('Latest version', latestVersion ? info(latestVersion) : warning('unavailable')));
-  });
+  yield* Console.log(keyValue('Current version', info(currentVersion)));
+  yield* Console.log(keyValue('Latest version', latestVersion ? info(latestVersion) : warning('unavailable')));
   if (latestWarning) {
-    yield* Effect.sync(() => console.log(warning(`Warning: ${latestWarning}`)));
+    yield* Console.log(warning(`Warning: ${latestWarning}`));
   }
 
   if (!latestVersion) {
@@ -35,25 +30,25 @@ export const runVersion = Effect.fn('runVersion')(function* (config: RuntimeConf
   }
   const comparison = compareVersions(currentVersion, latestVersion);
   if (comparison >= 0) {
-    yield* Effect.sync(() => {
-      console.log(success(comparison > 0 ? 'Current version is newer than npm latest.' : 'Threadnote is up to date.'));
-      console.log('');
-    });
+    yield* Console.log(
+      success(comparison > 0 ? 'Current version is newer than npm latest.' : 'Threadnote is up to date.'),
+    );
+    yield* Console.log('');
     const whatsNew = yield* withSpinnerEffect('Fetching GitHub release notes', whatsNewLinesForVersion(currentVersion));
-    yield* Effect.sync(() => printWhatsNew(whatsNew));
+    yield* printWhatsNew(whatsNew);
     return;
   }
 
-  yield* Effect.sync(() => console.log(''));
+  yield* Console.log('');
   const whatsNew = yield* withSpinnerEffect(
     'Fetching GitHub release notes',
     whatsNewLinesForVersionRange(currentVersion, latestVersion),
   );
-  yield* Effect.sync(() => printWhatsNew(whatsNew));
+  yield* printWhatsNew(whatsNew);
 });
 
-function printWhatsNew(whatsNew: readonly string[]): void {
+const printWhatsNew = Effect.fn('printWhatsNew')(function* (whatsNew: readonly string[]) {
   for (const line of whatsNew) {
-    console.log(line === "What's new:" ? heading(line) : line);
+    yield* Console.log(line === "What's new:" ? heading(line) : line);
   }
-}
+});

--- a/test/integration/share.retry.test.ts
+++ b/test/integration/share.retry.test.ts
@@ -1,5 +1,7 @@
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {removeMemoryUri, writeMemoryFile} from '../../src/share.js';
+import {writeMemoryFile} from '../../src/share.js';
+import {removeMemoryUri as removeMemoryUriEffect} from '../../src/effect/share.js';
 import * as utils from '../../src/utils.js';
 import type {CommandResult, ShareRuntime} from '../../src/types.js';
 
@@ -21,6 +23,8 @@ const runtime: ShareRuntime = {
 
 const ok = (stdout = ''): CommandResult => ({exitCode: 0, stdout, stderr: ''});
 const fail = (stderr: string): CommandResult => ({exitCode: 1, stdout: '', stderr});
+const removeMemoryUri = (...args: Parameters<typeof removeMemoryUriEffect>) =>
+  Effect.runPromise(removeMemoryUriEffect(...args));
 
 function commandSequence(...results: readonly CommandResult[]): void {
   const runCommand = vi.mocked(utils.runCommand);

--- a/test/integration/share.sync.test.ts
+++ b/test/integration/share.sync.test.ts
@@ -1,16 +1,21 @@
 import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {listShareConflicts, showShareConflict} from '../../src/share.js';
 import {
-  listShareConflicts,
-  resolveShareConflict,
-  runShareInit,
-  runShareSync,
-  showShareConflict,
-} from '../../src/share.js';
+  resolveShareConflict as resolveShareConflictEffect,
+  runShareInit as runShareInitEffect,
+  runShareSync as runShareSyncEffect,
+} from '../../src/effect/share.js';
 import type {ShareRuntime, ShareTeamsFile} from '../../src/types.js';
 import {runCommand} from '../../src/utils.js';
+
+const runShareInit = (...args: Parameters<typeof runShareInitEffect>) => Effect.runPromise(runShareInitEffect(...args));
+const runShareSync = (...args: Parameters<typeof runShareSyncEffect>) => Effect.runPromise(runShareSyncEffect(...args));
+const resolveShareConflict = (...args: Parameters<typeof resolveShareConflictEffect>) =>
+  Effect.runPromise(resolveShareConflictEffect(...args));
 
 interface TestShareRepo {
   readonly config: ShareRuntime;

--- a/test/unit/effect-architecture.test.ts
+++ b/test/unit/effect-architecture.test.ts
@@ -1,0 +1,71 @@
+import {readFile, readdir} from 'node:fs/promises';
+import {dirname, join, relative} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, it} from 'vitest';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const sourceRoot = join(repoRoot, 'src');
+const codeRoots = ['bin', 'scripts', 'src', 'test'].map(path => join(repoRoot, path));
+
+async function codeFiles(path: string): Promise<readonly string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(path, {withFileTypes: true})) {
+    const entryPath = join(path, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await codeFiles(entryPath)));
+    } else if (/\.(?:[cm]?js|tsx?)$/.test(entry.name)) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+const sourceFiles = () => codeFiles(sourceRoot);
+
+describe('Effect architecture boundaries', () => {
+  it('keeps the CLI free of generic Promise workflow bridges', async () => {
+    const cli = await readFile(join(sourceRoot, 'effect', 'cli.ts'), 'utf8');
+    expect(cli).not.toContain('withRuntimePromise');
+    expect(cli).not.toMatch(/\blegacy\s*\(/);
+  });
+
+  it('centralizes application Promise lifting in the Effect error adapter', async () => {
+    const declarations: string[] = [];
+    for (const path of await sourceFiles()) {
+      const source = await readFile(path, 'utf8');
+      if (/\b(?:const|function)\s+fromPromise\b/.test(source)) {
+        declarations.push(relative(repoRoot, path));
+      }
+    }
+    expect(declarations).toEqual(['src/effect/errors.ts']);
+  });
+
+  it('keeps raw Promise lifting primitives inside the shared adapters', async () => {
+    const allowed = new Set(['src/effect/console.ts', 'src/effect/errors.ts']);
+    for (const path of await sourceFiles()) {
+      const source = await readFile(path, 'utf8');
+      const relativePath = relative(repoRoot, path);
+      if (allowed.has(relativePath)) {
+        continue;
+      }
+      expect(source, relativePath).not.toContain('tryPromiseWithConsole');
+      expect(source, relativePath).not.toMatch(/\bEffect\.(?:promise|tryPromise)\b/);
+    }
+  });
+
+  it('does not create internal Effect runtimes in production source', async () => {
+    for (const path of await sourceFiles()) {
+      const source = await readFile(path, 'utf8');
+      expect(source, relative(repoRoot, path)).not.toMatch(/Effect\.(?:runPromise|runFork)\s*\(/);
+    }
+  });
+
+  it('routes console output through the Effect Console service', async () => {
+    for (const root of codeRoots) {
+      for (const path of await codeFiles(root)) {
+        const source = await readFile(path, 'utf8');
+        expect(source, relative(repoRoot, path)).not.toMatch(/\bconsole\.(?:debug|error|info|log|warn)\s*\(/);
+      }
+    }
+  });
+});

--- a/test/unit/effect-command.test.ts
+++ b/test/unit/effect-command.test.ts
@@ -26,6 +26,23 @@ describe('Effect CommandExecutor', () => {
     }
   });
 
+  it('redacts sensitive command arguments from typed failures', async () => {
+    const secret = 'manager-bearer-token-value';
+    const result = await run(
+      runCommandEffect(process.execPath, [
+        '-e',
+        'process.stderr.write(process.argv[1]); process.exit(7)',
+        `Authorization: Bearer ${secret}`,
+      ]).pipe(Effect.match({onFailure: Result.fail, onSuccess: Result.succeed})),
+    );
+
+    expect(Result.isFailure(result)).toBe(true);
+    if (Result.isFailure(result)) {
+      expect(JSON.stringify(result.failure)).not.toContain(secret);
+      expect(result.failure.message).toContain('[REDACTED]');
+    }
+  });
+
   it('models timeouts without throwing an untyped Error', async () => {
     const result = await run(
       runCommandEffect(process.execPath, ['-e', 'setTimeout(() => undefined, 5000)'], {timeoutMs: 25}).pipe(

--- a/test/unit/graph.test.ts
+++ b/test/unit/graph.test.ts
@@ -1,8 +1,13 @@
 import {mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {NodeFileSystem} from '@effect/platform-node';
+import {Effect, FileSystem} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {buildGraphDocument, extractDependencyFacts, resolveGraphEdges} from '../../src/graph.js';
+
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(NodeFileSystem.layer)));
 
 describe('extractDependencyFacts', () => {
   let dir: string;
@@ -25,7 +30,7 @@ describe('extractDependencyFacts', () => {
       }),
       'utf8',
     );
-    const facts = await extractDependencyFacts(dir);
+    const facts = await run(extractDependencyFacts(dir));
     expect(facts.publishedName).toBe('@acme/web-app');
     expect(facts.ecosystems).toEqual(['npm']);
     expect(facts.manifestFiles).toEqual(['package.json']);
@@ -48,16 +53,16 @@ describe('extractDependencyFacts', () => {
       ].join('\n'),
       'utf8',
     );
-    const facts = await extractDependencyFacts(dir);
+    const facts = await run(extractDependencyFacts(dir));
     expect(facts.publishedName).toBe('github.com/acme/service');
     expect(facts.ecosystems).toEqual(['go']);
     expect(facts.dependencies).toEqual(['github.com/acme/lib', 'github.com/pkg/errors']);
   });
 
   it('returns empty facts when no manifests exist and ignores malformed package.json', async () => {
-    expect(await extractDependencyFacts(dir)).toEqual({dependencies: [], ecosystems: [], manifestFiles: []});
+    expect(await run(extractDependencyFacts(dir))).toEqual({dependencies: [], ecosystems: [], manifestFiles: []});
     await writeFile(join(dir, 'package.json'), '{not valid json', 'utf8');
-    const facts = await extractDependencyFacts(dir);
+    const facts = await run(extractDependencyFacts(dir));
     expect(facts.manifestFiles).toEqual([]);
   });
 });

--- a/test/unit/lifecycle.install.test.ts
+++ b/test/unit/lifecycle.install.test.ts
@@ -1,9 +1,10 @@
 import {chmod, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {delimiter, join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {
-  ensureSupportedUvExecutable,
+  ensureSupportedUvExecutable as ensureSupportedUvExecutablePromise,
   findSupportedUvExecutable,
   getInstallCommands,
   isLlamaWheelArchiveExtractionFailure,
@@ -13,6 +14,7 @@ import {
   openVikingToolPython,
   resolveOpenVikingInstallCommand,
 } from '../../src/lifecycle.js';
+import {fromPromise} from '../../src/effect/errors.js';
 import type {RuntimeConfig} from '../../src/types.js';
 
 const WHEEL_INDEX_ENV = 'THREADNOTE_LLAMA_WHEEL_INDEX';
@@ -21,6 +23,8 @@ const TEST_INDEX = 'https://wheels.example/whl/cpu';
 const METAL_INDEX = 'https://abetlen.github.io/llama-cpp-python/whl/metal';
 const originalPath = process.env.PATH;
 const temporaryDirectories: string[] = [];
+const ensureSupportedUvExecutable = () =>
+  Effect.runPromise(fromPromise('ensure supported uv executable', ensureSupportedUvExecutablePromise));
 
 async function fakeUv(version: string, selfUpdateVersion?: string): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'threadnote-uv-test-'));

--- a/test/unit/manager.test.ts
+++ b/test/unit/manager.test.ts
@@ -1,7 +1,7 @@
 import {mkdir, mkdtemp, rm, stat, symlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {Effect} from 'effect';
+import {Console, Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   consolidationAgentScript,
@@ -22,9 +22,7 @@ vi.mock('../../src/lifecycle.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/lifecycle.js')>();
   return {
     ...actual,
-    runRepair: vi.fn((_config, options) =>
-      Effect.sync(() => console.log(options.dryRun ? 'repair dry run' : 'repair applied')),
-    ),
+    runRepair: vi.fn((_config, options) => Console.log(options.dryRun ? 'repair dry run' : 'repair applied')),
   };
 });
 
@@ -34,6 +32,7 @@ vi.mock('../../src/memory.js', async importOriginal => {
     ...actual,
     runArchive: vi.fn(() => Effect.void),
     runForget: vi.fn(() => Effect.void),
+    runRecall: vi.fn((_config, options) => Console.log(`recall result: ${options.query}`)),
   };
 });
 
@@ -41,12 +40,12 @@ vi.mock('../../src/seeding.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/seeding.js')>();
   return {
     ...actual,
-    runSeed: vi.fn(async (_config: RuntimeConfig, options: {readonly dryRun?: boolean}) => {
-      console.log(options.dryRun ? 'seed dry run' : 'seed applied');
-    }),
-    runSeedSkills: vi.fn(async (_config: RuntimeConfig, options: {readonly dryRun?: boolean}) => {
-      console.log(options.dryRun ? 'seed skills dry run' : 'seed skills applied');
-    }),
+    runSeed: vi.fn((_config: RuntimeConfig, options: {readonly dryRun?: boolean}) =>
+      Console.log(options.dryRun ? 'seed dry run' : 'seed applied'),
+    ),
+    runSeedSkills: vi.fn((_config: RuntimeConfig, options: {readonly dryRun?: boolean}) =>
+      Console.log(options.dryRun ? 'seed skills dry run' : 'seed skills applied'),
+    ),
   };
 });
 
@@ -123,6 +122,9 @@ describe('manager catalog', () => {
     await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
     vi.mocked(memory.runArchive).mockReset();
     vi.mocked(memory.runForget).mockReset();
+    vi.mocked(memory.runRecall)
+      .mockReset()
+      .mockImplementation((_config, options) => Console.log(`recall result: ${options.query}`));
   });
 
   it('maps local memory files into viking URIs with parsed metadata', async () => {
@@ -242,9 +244,7 @@ describe('manager http API', () => {
   beforeEach(() => {
     vi.mocked(lifecycle.runRepair)
       .mockReset()
-      .mockImplementation((_config, options) =>
-        Effect.sync(() => console.log(options.dryRun ? 'repair dry run' : 'repair applied')),
-      );
+      .mockImplementation((_config, options) => Console.log(options.dryRun ? 'repair dry run' : 'repair applied'));
     vi.mocked(memory.runArchive).mockReset();
     vi.mocked(memory.runForget).mockReset();
     vi.mocked(seeding.runSeed).mockClear();
@@ -325,6 +325,30 @@ describe('manager http API', () => {
       expect(response.status).toBe(200);
       expect(body.content).toContain('Manager UI feature notes.');
       expect(body.localMemory?.node.uri).toBe('viking://user/denys/memories/durable/projects/threadnote/manager-ui.md');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('runs recall through the scoped manager Effect runtime', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const server = await startServer(config, 'secret');
+    try {
+      const response = await fetch(`${server.url}/api/recall`, {
+        body: JSON.stringify({query: 'manager context'}),
+        headers: {authorization: 'Bearer secret', 'content-type': 'application/json'},
+        method: 'POST',
+      });
+      const body = (await response.json()) as {readonly output: string};
+
+      expect(response.status).toBe(200);
+      expect(body.output).toBe('recall result: manager context');
+      expect(vi.mocked(memory.runRecall)).toHaveBeenCalledWith(config, {
+        nodeLimit: undefined,
+        project: undefined,
+        query: 'manager context',
+      });
     } finally {
       await server.close();
     }
@@ -431,9 +455,9 @@ describe('manager http API', () => {
     vi.mocked(lifecycle.runRepair).mockImplementation((_config, options) =>
       Effect.gen(function* () {
         const label = options.dryRun ? 'dry run' : 'applied';
-        yield* Effect.sync(() => console.log(`${label} start`));
+        yield* Console.log(`${label} start`);
         yield* Effect.sleep('10 millis');
-        yield* Effect.sync(() => console.log(`${label} end`));
+        yield* Console.log(`${label} end`);
       }),
     );
     const server = await startServer(config, 'secret');

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -1,10 +1,17 @@
 import {chmod, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {delimiter, join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, describe, expect, it, vi} from 'vitest';
+import {captureConsole} from '../../src/effect/console.js';
+import {fromPromise} from '../../src/effect/errors.js';
+import {ApplicationLayer, type ApplicationServices} from '../../src/effect/runtime.js';
 import {resolveMcpClients, runMcpInstall} from '../../src/mcp.js';
 import {parseMcpToolset} from '../../src/mcp_toolset.js';
 import type {RuntimeConfig} from '../../src/types.js';
+
+const run = <A, E>(effect: Effect.Effect<A, E, ApplicationServices>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(ApplicationLayer)));
 
 function runtime(): RuntimeConfig {
   return {
@@ -22,7 +29,7 @@ function runtime(): RuntimeConfig {
 async function dryRunOutput(toolset?: 'core' | 'full'): Promise<string> {
   const lines: string[] = [];
   vi.spyOn(console, 'log').mockImplementation(value => lines.push(String(value)));
-  await runMcpInstall(runtime(), 'codex', {toolset});
+  await run(runMcpInstall(runtime(), 'codex', {toolset}));
   return lines.join('\n');
 }
 
@@ -71,7 +78,7 @@ describe('MCP agent executable resolution', () => {
     );
     process.env.PATH = [join(broken, '..'), join(healthy, '..')].join(delimiter);
 
-    await runMcpInstall(runtime(), 'codex', {apply: true});
+    await run(runMcpInstall(runtime(), 'codex', {apply: true}));
 
     const calls = await readFile(callsPath, 'utf8');
     expect(calls).toContain('mcp remove threadnote');
@@ -82,12 +89,13 @@ describe('MCP agent executable resolution', () => {
   it('skips a broken Codex launcher during repair and gives explicit installs an actionable error', async () => {
     const broken = await codexLauncher("printf '%s\\n' 'missing native binary' >&2\nexit 1");
     process.env.PATH = [join(broken, '..'), '/usr/bin', '/bin'].join(delimiter);
-    const lines: string[] = [];
-    vi.spyOn(console, 'log').mockImplementation(value => lines.push(String(value)));
 
-    await expect(resolveMcpClients('codex', 'repair')).resolves.toEqual([]);
-    expect(lines.join('\n')).toMatch(/codex command.*not working/i);
-    await expect(runMcpInstall(runtime(), 'codex', {apply: true})).rejects.toThrow(
+    const resolution = await run(
+      captureConsole(fromPromise('resolve MCP clients', () => resolveMcpClients('codex', 'repair'))),
+    );
+    expect(resolution.value).toEqual([]);
+    expect(resolution.output).toMatch(/codex command.*not working/i);
+    await expect(run(runMcpInstall(runtime(), 'codex', {apply: true}))).rejects.toThrow(
       /repair or reinstall codex.*threadnote mcp-install codex --apply/i,
     );
   });

--- a/test/unit/memory.recall.test.ts
+++ b/test/unit/memory.recall.test.ts
@@ -1,11 +1,16 @@
 import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ApplicationLayer, type ApplicationServices} from '../../src/effect/runtime.js';
 import {hasAgentSkillCatalogIntent, runRecall, stripAdvancedSearchFlags} from '../../src/memory.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import * as indexRepair from '../../src/index_repair.js';
 import * as utils from '../../src/utils.js';
+
+const run = <A, E>(effect: Effect.Effect<A, E, ApplicationServices>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(ApplicationLayer)));
 
 vi.mock('../../src/index_repair.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/index_repair.js')>();
@@ -68,7 +73,7 @@ describe('runRecall index repair fallback', () => {
     vi.mocked(indexRepair.repairStaleRecallIndex).mockRejectedValue(new Error('repair failed'));
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
-    await runRecall(runtime, {dryRun: true, query: 'availability check'});
+    await run(runRecall(runtime, {dryRun: true, query: 'availability check'}));
 
     const output = log.mock.calls.map(call => call.join(' ')).join('\n');
     expect(output).toContain('Auto-index repair warning: repair failed');
@@ -95,9 +100,11 @@ describe('runRecall index repair fallback', () => {
       });
       process.env.THREADNOTE_CALLER_CWD = repoRoot;
 
-      await runRecall(
-        {...runtime, manifestPath: join(dir, 'missing-seed-manifest.yaml')},
-        {dryRun: true, query: 'current repo latest handoff'},
+      await run(
+        runRecall(
+          {...runtime, manifestPath: join(dir, 'missing-seed-manifest.yaml')},
+          {dryRun: true, query: 'current repo latest handoff'},
+        ),
       );
     } finally {
       if (previousCallerCwd === undefined) {
@@ -160,9 +167,11 @@ describe('runRecall index repair fallback', () => {
       );
       process.env.THREADNOTE_CALLER_CWD = repoRoot;
 
-      await runRecall(
-        {...runtime, manifestPath},
-        {dryRun: true, query: 'current repo latest handoff', workset: 'platform'},
+      await run(
+        runRecall(
+          {...runtime, manifestPath},
+          {dryRun: true, query: 'current repo latest handoff', workset: 'platform'},
+        ),
       );
     } finally {
       if (previousCallerCwd === undefined) {
@@ -208,14 +217,16 @@ describe('runRecall index repair fallback', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     try {
-      await runRecall(
-        {...runtime, manifestPath},
-        {
-          dryRun: true,
-          inferScope: false,
-          query: 'current status',
-          workset: 'platform',
-        },
+      await run(
+        runRecall(
+          {...runtime, manifestPath},
+          {
+            dryRun: true,
+            inferScope: false,
+            query: 'current status',
+            workset: 'platform',
+          },
+        ),
       );
     } finally {
       await rm(dir, {force: true, recursive: true});
@@ -249,13 +260,15 @@ describe('runRecall index repair fallback', () => {
 
     try {
       await expect(
-        runRecall(
-          {...runtime, manifestPath},
-          {
-            dryRun: true,
-            query: 'current status',
-            workset: 'platfrom',
-          },
+        run(
+          runRecall(
+            {...runtime, manifestPath},
+            {
+              dryRun: true,
+              query: 'current status',
+              workset: 'platfrom',
+            },
+          ),
         ),
       ).rejects.toThrow(`No workset named "platfrom" in ${manifestPath}.`);
     } finally {
@@ -287,14 +300,16 @@ describe('runRecall index repair fallback', () => {
 
     try {
       await expect(
-        runRecall(
-          {...runtime, manifestPath},
-          {
-            dryRun: true,
-            query: 'current status',
-            uri: 'viking://resources/repos/alpha',
-            workset: 'platfrom',
-          },
+        run(
+          runRecall(
+            {...runtime, manifestPath},
+            {
+              dryRun: true,
+              query: 'current status',
+              uri: 'viking://resources/repos/alpha',
+              workset: 'platfrom',
+            },
+          ),
         ),
       ).rejects.toThrow(`No workset named "platfrom" in ${manifestPath}.`);
     } finally {

--- a/test/unit/seeding.test.ts
+++ b/test/unit/seeding.test.ts
@@ -1,6 +1,7 @@
-import {chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile} from 'node:fs/promises';
+import {chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, describe, expect, it} from 'vitest';
 import {
   parseSeedWatchIntervalMinutes,
@@ -11,27 +12,18 @@ import {
   seedWatchArgs,
 } from '../../src/seeding.js';
 import {readSeedManifest} from '../../src/manifest.js';
+import {captureConsole as captureEffectConsole} from '../../src/effect/console.js';
+import {ApplicationLayer, type ApplicationServices} from '../../src/effect/runtime.js';
 import type {RuntimeConfig, SeedManifest} from '../../src/types.js';
 import {runCommand} from '../../src/utils.js';
 
 const GIT_ENV_KEYS = ['GIT_COMMON_DIR', 'GIT_DIR', 'GIT_INDEX_FILE', 'GIT_WORK_TREE'] as const;
 
-async function captureConsole(action: () => Promise<void>): Promise<string> {
-  const lines: string[] = [];
-  const originalLog = console.log;
-  const originalWarn = console.warn;
-  const originalError = console.error;
-  console.log = (...args: readonly unknown[]) => lines.push(args.map(String).join(' '));
-  console.warn = (...args: readonly unknown[]) => lines.push(args.map(String).join(' '));
-  console.error = (...args: readonly unknown[]) => lines.push(args.map(String).join(' '));
-  try {
-    await action();
-  } finally {
-    console.log = originalLog;
-    console.warn = originalWarn;
-    console.error = originalError;
-  }
-  return lines.join('\n');
+const run = <A, E>(effect: Effect.Effect<A, E, ApplicationServices>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(ApplicationLayer)));
+
+async function captureConsole<E>(effect: Effect.Effect<void, E, ApplicationServices>): Promise<string> {
+  return (await run(captureEffectConsole(effect))).output;
 }
 
 describe('parseSeedWatchIntervalMinutes', () => {
@@ -105,13 +97,68 @@ describe('runSeed', () => {
       user: 'denys',
     };
 
-    const output = await captureConsole(() => runSeed(config, {dryRun: true}));
+    const output = await captureConsole(runSeed(config, {dryRun: true}));
 
     expect(output).toContain('add-resource');
     expect(output).toContain('viking://resources/repos/sample-repo/README.md');
     expect(output).toContain('--wait');
     expect(output).not.toContain('--reason');
     expect(output).not.toContain('Project guidance for');
+  });
+
+  it('does not skip same-size files changed within the recorded millisecond', async () => {
+    const contextHome = await mkdtemp(join(tmpdir(), 'threadnote-seed-context-'));
+    const repo = await mkdtemp(join(tmpdir(), 'threadnote-seed-repo-'));
+    homes.push(contextHome, repo);
+    const readmePath = join(repo, 'README.md');
+    await writeFile(readmePath, '# Sample\n', 'utf8');
+    const fractionalSeconds = 1_700_000_000.123456;
+    await utimes(readmePath, fractionalSeconds, fractionalSeconds);
+    const readmeStat = await stat(readmePath);
+    const recordedMtimeMs = readmeStat.mtime.getTime();
+    expect(readmeStat.mtimeMs).not.toBe(recordedMtimeMs);
+
+    const manifestPath = join(contextHome, 'seed-manifest.yaml');
+    await writeFile(
+      manifestPath,
+      [
+        'version: 1',
+        'projects:',
+        '  - name: sample-repo',
+        `    path: ${repo}`,
+        '    uri: viking://resources/repos/sample-repo',
+        '    seed:',
+        '      - README.md',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      join(contextHome, 'seed-state.json'),
+      JSON.stringify({
+        files: {
+          'viking://resources/repos/sample-repo/README.md': {
+            mtimeMs: recordedMtimeMs,
+            size: readmeStat.size,
+          },
+        },
+        version: 1,
+      }),
+    );
+    const config: RuntimeConfig = {
+      account: 'local',
+      agentContextHome: contextHome,
+      agentId: 'threadnote',
+      host: '127.0.0.1',
+      manifestPath,
+      openVikingVersion: '0.0.0',
+      port: 1933,
+      user: 'denys',
+    };
+
+    const output = await captureConsole(runSeed(config, {dryRun: true}));
+
+    expect(output).toContain('add-resource');
+    expect(output).toContain('Seed complete: 1 candidate(s), 0 unchanged, 0 skipped for safety.');
   });
 
   it('uses the publish scrubber patterns when skipping seed files', async () => {
@@ -144,7 +191,7 @@ describe('runSeed', () => {
       user: 'denys',
     };
 
-    const output = await captureConsole(() => runSeed(config, {dryRun: true}));
+    const output = await captureConsole(runSeed(config, {dryRun: true}));
 
     expect(output).toContain('SKIP sample-repo/README.md: possible secret (database URI)');
     expect(output).toContain('Seed complete: 0 candidate(s), 0 unchanged, 1 skipped for safety.');
@@ -200,7 +247,7 @@ describe('seed-skills', () => {
       user: 'denys',
     };
 
-    const output = await captureConsole(() => runSeedSkills(config, {dryRun: true}));
+    const output = await captureConsole(runSeedSkills(config, {dryRun: true}));
 
     expect(output).toContain(`Command claude-commands-global: ${join(home, '.claude', 'commands', 'weekly.md')}`);
     expect(output).toContain(
@@ -257,7 +304,7 @@ describe('init-manifest', () => {
       user: 'denys',
     };
 
-    await captureConsole(() => runInitManifest(config, {path: manifestPath, repo: [newRepo]}));
+    await captureConsole(runInitManifest(config, {path: manifestPath, repo: [newRepo]}));
 
     const manifest = await readSeedManifest(manifestPath);
     expect(manifest.projects).toHaveLength(2);
@@ -296,7 +343,7 @@ describe('init-manifest', () => {
         user: 'denys',
       };
 
-      await captureConsole(() => runInitManifest(config, {path: manifestPath, repo: [repo]}));
+      await captureConsole(runInitManifest(config, {path: manifestPath, repo: [repo]}));
 
       const manifest = await readSeedManifest(manifestPath);
       expect(manifest.projects[0]?.name).toBe('threadnote');
@@ -356,7 +403,7 @@ describe('seedDependencyGraphs', () => {
       user: 'denys',
     };
 
-    await captureConsole(() => seedDependencyGraphs(config, ov, manifest, manifest.projects, false));
+    await captureConsole(seedDependencyGraphs(config, ov, manifest, manifest.projects, false));
 
     const graphFiles = await readdir(join(contextHome, 'graph'));
     expect(graphFiles).toHaveLength(1);

--- a/test/unit/share.admin.test.ts
+++ b/test/unit/share.admin.test.ts
@@ -1,10 +1,23 @@
 import {access, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {publishShareGitChange, runShareRemove, runShareRename, runShareSetUrl} from '../../src/share.js';
+import {publishShareGitChange} from '../../src/share.js';
+import {
+  runShareRemove as runShareRemoveEffect,
+  runShareRename as runShareRenameEffect,
+  runShareSetUrl as runShareSetUrlEffect,
+} from '../../src/effect/share.js';
 import type {CommandResult, ShareRuntime, ShareTeamsFile} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
+
+const runShareRemove = (...args: Parameters<typeof runShareRemoveEffect>) =>
+  Effect.runPromise(runShareRemoveEffect(...args));
+const runShareRename = (...args: Parameters<typeof runShareRenameEffect>) =>
+  Effect.runPromise(runShareRenameEffect(...args));
+const runShareSetUrl = (...args: Parameters<typeof runShareSetUrlEffect>) =>
+  Effect.runPromise(runShareSetUrlEffect(...args));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();

--- a/test/unit/share.artifacts.test.ts
+++ b/test/unit/share.artifacts.test.ts
@@ -1,16 +1,23 @@
 import {mkdtemp, mkdir, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {shareAgentArtifact, shareBundlePack} from '../../src/share.js';
 import {
-  installSharedAgentArtifacts,
-  listSharedAgentArtifacts,
-  runShareInstallArtifacts,
-  shareAgentArtifact,
-  shareBundlePack,
-} from '../../src/share.js';
+  installSharedAgentArtifacts as installSharedAgentArtifactsEffect,
+  listSharedAgentArtifacts as listSharedAgentArtifactsEffect,
+  runShareInstallArtifacts as runShareInstallArtifactsEffect,
+} from '../../src/effect/share.js';
 import type {CommandResult, ShareRuntime} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
+
+const runShareInstallArtifacts = (...args: Parameters<typeof runShareInstallArtifactsEffect>) =>
+  Effect.runPromise(runShareInstallArtifactsEffect(...args));
+const listSharedAgentArtifacts = (...args: Parameters<typeof listSharedAgentArtifactsEffect>) =>
+  Effect.runPromise(listSharedAgentArtifactsEffect(...args));
+const installSharedAgentArtifacts = (...args: Parameters<typeof installSharedAgentArtifactsEffect>) =>
+  Effect.runPromise(installSharedAgentArtifactsEffect(...args));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();

--- a/test/unit/share.publish.test.ts
+++ b/test/unit/share.publish.test.ts
@@ -1,10 +1,14 @@
 import {mkdtemp, mkdir, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {runSharePublish} from '../../src/share.js';
+import {runSharePublish as runSharePublishEffect} from '../../src/effect/share.js';
 import type {CommandResult, ShareRuntime} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
+
+const runSharePublish = (...args: Parameters<typeof runSharePublishEffect>) =>
+  Effect.runPromise(runSharePublishEffect(...args));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();


### PR DESCRIPTION
## Summary

- migrate the remaining CLI, graph, lifecycle, manager, MCP, memory, seeding, sharing, update, and utility workflows to Effect 4
- route application output through the Effect Console service and remove raw `console.*` calls
- centralize Promise lifting and Console scoping in shared adapters instead of duplicating local `fromPromise`-style bridges
- add typed Effect facades for command execution and share operations, plus architecture tests that enforce runtime, Promise, and Console boundaries
- harden command error redaction, manager recall runtime handling, and seed timestamp precision

## Why

The initial Effect 4 migration left vanilla Promise workflows, raw Console access, and duplicated compatibility helpers in several paths. Those mixed boundaries weakened cancellation and error composition, allowed Console scope escapes, and made the migration rules difficult to enforce consistently.

## Impact

Threadnote now has one application runtime boundary, scoped and concurrency-safe output capture, centralized Promise compatibility, typed failures, and regression coverage for the remaining migration gaps. Command failures scrub sensitive arguments and output before exposing typed errors.

## Validation

- `npm run lint`
- `npm run prettier:check`
- `npm run typecheck`
- `npm test` — 41 files, 434 tests
- `npm run test:coverage`
- `npm run build`
- `npm run check:bundle-size`
- `npm run pack:dry-run`
- `npm run test:e2e:local-bins` — 9/9 live OpenViking E2E tests
- one dev-cycle review round — 6/6 validated findings addressed
