### PR TITLE
Fix macOS launchd autostart lifecycle

### DIFF
--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -72,7 +72,7 @@ export const maybeRunEffect = Effect.fn('maybeRunEffect')(function* (
   dryRun: boolean,
   executable: string,
   args: readonly string[],
-  options: Pick<CommandOptions, 'allowFailure' | 'cwd'> = {},
+  options: Pick<CommandOptions, 'allowFailure' | 'cwd' | 'timeoutMs'> = {},
 ) {
   const cwdSuffix = options.cwd ? ` (cwd: ${options.cwd})` : '';
   const label = dryRun ? warning('Would run') : info('Running');

--- a/src/effect/http.ts
+++ b/src/effect/http.ts
@@ -67,7 +67,6 @@ const execute = <A>(
   }
   const response = client.execute(request).pipe(
     Effect.provideService(FetchHttpClient.Fetch, dynamicFetch),
-    Effect.timeout(options?.timeoutMs ?? 3000),
     Effect.mapError(
       cause =>
         new HttpRequestFailed({
@@ -78,7 +77,7 @@ const execute = <A>(
         }),
     ),
   );
-  return Effect.gen(function* () {
+  const completeResponse = Effect.gen(function* () {
     const current = yield* response;
     if (current.status < 200 || current.status >= 300) {
       return yield* new HttpStatusError({
@@ -101,6 +100,19 @@ const execute = <A>(
     );
     return {body, status: current.status};
   });
+  return completeResponse.pipe(
+    Effect.timeout(options?.timeoutMs ?? 3000),
+    Effect.mapError(cause =>
+      cause instanceof HttpRequestFailed || cause instanceof HttpStatusError
+        ? cause
+        : new HttpRequestFailed({
+            cause,
+            message: `GET ${urlText} failed`,
+            method: 'GET',
+            url: urlText,
+          }),
+    ),
+  );
 };
 
 const executeStatus = (

--- a/src/launchd.ts
+++ b/src/launchd.ts
@@ -1,0 +1,133 @@
+import {homedir} from 'node:os';
+import {join} from 'node:path';
+import {Clock, Effect} from 'effect';
+import {LAUNCHD_LABEL} from './constants.js';
+import {maybeRunEffect, runCommandEffect} from './effect/command.js';
+import {applicationError} from './effect/errors.js';
+
+export interface LaunchAgentStatus {
+  readonly loaded: boolean;
+  readonly pid?: number;
+  readonly running: boolean;
+}
+
+export function launchAgentPath(): string {
+  return join(homedir(), 'Library', 'LaunchAgents', `${LAUNCHD_LABEL}.plist`);
+}
+
+export function launchAgentDomainTarget(uid: number): string {
+  return `gui/${uid}`;
+}
+
+export function launchAgentServiceTarget(uid: number): string {
+  return `${launchAgentDomainTarget(uid)}/${LAUNCHD_LABEL}`;
+}
+
+export const bootoutLaunchAgent = Effect.fn('bootoutLaunchAgent')(function* (
+  dryRun: boolean,
+  uid?: number,
+  timeoutMs?: number,
+) {
+  const resolvedUid = yield* resolveUserId(uid);
+  const serviceTarget = launchAgentServiceTarget(resolvedUid);
+  if (dryRun) {
+    yield* maybeRunEffect(true, 'launchctl', ['bootout', serviceTarget]);
+    return true;
+  }
+
+  const deadline = yield* deadlineFromTimeout(timeoutMs);
+  if (!(yield* readLaunchAgentStatus(resolvedUid, yield* remainingTimeout(deadline))).loaded) {
+    return false;
+  }
+  yield* maybeRunEffect(false, 'launchctl', ['bootout', serviceTarget], {
+    timeoutMs: yield* remainingTimeout(deadline),
+  });
+  if ((yield* readLaunchAgentStatus(resolvedUid, yield* remainingTimeout(deadline))).loaded) {
+    return yield* Effect.fail(new Error(`launchctl bootout did not unload ${serviceTarget}.`));
+  }
+  return true;
+});
+
+export const bootstrapLaunchAgent = Effect.fn('bootstrapLaunchAgent')(function* (
+  plistPath: string,
+  dryRun: boolean,
+  uid?: number,
+  timeoutMs?: number,
+) {
+  const resolvedUid = yield* resolveUserId(uid);
+  const domainTarget = launchAgentDomainTarget(resolvedUid);
+  const serviceTarget = launchAgentServiceTarget(resolvedUid);
+  const deadline = yield* deadlineFromTimeout(timeoutMs);
+  yield* maybeRunEffect(dryRun, 'launchctl', ['enable', serviceTarget], {
+    timeoutMs: yield* remainingTimeout(deadline),
+  });
+  yield* maybeRunEffect(dryRun, 'launchctl', ['bootstrap', domainTarget, plistPath], {
+    timeoutMs: yield* remainingTimeout(deadline),
+  });
+});
+
+export const readLaunchAgentStatus = Effect.fn('readLaunchAgentStatus')(function* (uid?: number, timeoutMs?: number) {
+  const resolvedUid = yield* resolveUserId(uid);
+  const result = yield* runCommandEffect('launchctl', ['print', launchAgentServiceTarget(resolvedUid)], {
+    allowFailure: true,
+    ...(timeoutMs !== undefined ? {timeoutMs} : {}),
+  });
+  return yield* Effect.try({
+    try: () => parseLaunchAgentStatus(`${result.stdout}\n${result.stderr}`, result.exitCode),
+    catch: cause => applicationError('read launchd service status', cause),
+  });
+});
+
+export function parseLaunchAgentStatus(output: string, exitCode: number): LaunchAgentStatus {
+  if (exitCode !== 0) {
+    if (exitCode === 113 && output.includes('Could not find service')) {
+      return {loaded: false, running: false};
+    }
+    throw new Error(`launchctl print failed with exit code ${exitCode}: ${output.trim()}`);
+  }
+  const pidMatch = output.match(/^\s*pid = (\d+)\s*$/m);
+  const pid = pidMatch ? Number(pidMatch[1]) : undefined;
+  return {
+    loaded: true,
+    ...(pid !== undefined ? {pid} : {}),
+    running: /^\s*state = running\s*$/m.test(output) && pid !== undefined,
+  };
+}
+
+export const isLaunchAgentRunning = Effect.fn('isLaunchAgentRunning')(function* (uid?: number) {
+  return (yield* readLaunchAgentStatus(uid)).running;
+});
+
+const resolveUserId = Effect.fn('resolveLaunchdUserId')(function* (uid?: number) {
+  if (uid !== undefined) {
+    return uid;
+  }
+  return yield* Effect.try({
+    try: () => {
+      const current = process.getuid?.();
+      if (current === undefined) {
+        throw new Error('Cannot resolve the current user id for launchd.');
+      }
+      return current;
+    },
+    catch: cause => applicationError('resolve current user id for launchd', cause),
+  });
+});
+
+const deadlineFromTimeout = Effect.fn('launchdDeadlineFromTimeout')(function* (timeoutMs?: number) {
+  if (timeoutMs === undefined) {
+    return undefined;
+  }
+  return (yield* Clock.currentTimeMillis) + timeoutMs;
+});
+
+const remainingTimeout = Effect.fn('launchdRemainingTimeout')(function* (deadline?: number) {
+  if (deadline === undefined) {
+    return undefined;
+  }
+  const remaining = deadline - (yield* Clock.currentTimeMillis);
+  if (remaining <= 0) {
+    return yield* Effect.fail(new Error('launchctl operation timed out.'));
+  }
+  return remaining;
+});

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -2,10 +2,10 @@ import {spawn} from 'node:child_process';
 import {closeSync, openSync} from 'node:fs';
 import {chmod, readdir, readFile, realpath, writeFile} from 'node:fs/promises';
 import {platform} from 'node:os';
-import {basename, dirname, join, sep} from 'node:path';
+import {basename, delimiter, dirname, join, sep} from 'node:path';
 import {stderr as processStderr, stdin as processStdin, stdout as processStdout} from 'node:process';
 import {createInterface} from 'node:readline/promises';
-import {Effect, FileSystem} from 'effect';
+import {Cause, Clock, Console, Effect, Exit, FileSystem, Option} from 'effect';
 import yaml from 'js-yaml';
 import {
   LAUNCHD_LABEL,
@@ -23,9 +23,10 @@ import {
   USER_INSTRUCTIONS_START_MARKER,
 } from './constants.js';
 import {hasManagedClaudeHooks, runHooksInstall} from './hooks.js';
-import {maybeRunEffect} from './effect/command.js';
+import {CommandExecutor, maybeRunEffect, runCommandEffect} from './effect/command.js';
 import {consoleOutput, syncWithConsole} from './effect/console.js';
 import {applicationError, fromPromise} from './effect/errors.js';
+import {getTextEffect, HttpService} from './effect/http.js';
 import {startProgress} from './cli_ui.js';
 import {
   findStaleRecallIndexTargets,
@@ -37,6 +38,13 @@ import {
   summaryAutoGenerationDisabled,
 } from './index_repair.js';
 import {readSeedManifest, uriSegment} from './manifest.js';
+import {
+  bootoutLaunchAgent,
+  bootstrapLaunchAgent,
+  launchAgentPath,
+  readLaunchAgentStatus,
+  type LaunchAgentStatus,
+} from './launchd.js';
 import {removeMcpConfigs, removeMcpSnippets, resolveMcpClients, runMcpInstall} from './mcp.js';
 import {maybeRunPostUpdateAfterRepair, readOpenVikingCliVersion} from './update.js';
 import {
@@ -99,6 +107,7 @@ import {
 
 const INSTALL_OUTPUT_TAIL_CHARS = 64_000;
 const MINIMUM_UV_SYSTEM_CERTS_VERSION = '0.11.0';
+const STOP_SERVER_TIMEOUT_MS = 10_000;
 
 interface UvExecutable {
   readonly executable: string;
@@ -108,6 +117,33 @@ interface UvExecutable {
 interface InstallCommandRetry {
   readonly command: MappedCommand;
   readonly env: Readonly<Record<string, string>>;
+}
+
+export interface LaunchAgentActivationEffects<R = never> {
+  readonly bootout: (timeoutMs: number) => Effect.Effect<boolean, unknown, R>;
+  readonly bootstrap: (plistPath: string, timeoutMs: number) => Effect.Effect<void, unknown, R>;
+  readonly isPortOpen: (config: RuntimeConfig, timeoutMs: number) => Effect.Effect<boolean, unknown, R>;
+  readonly stagePlist: (
+    plistPath: string,
+    content: string,
+  ) => Effect.Effect<LaunchAgentPlistTransaction<R>, unknown, R>;
+  readonly stopDetached: (config: RuntimeConfig, timeoutMs: number) => Effect.Effect<boolean, unknown, R>;
+  readonly restartDetached: (config: RuntimeConfig, timeoutMs: number) => Effect.Effect<void, unknown, R>;
+  readonly waitForHealth: (config: RuntimeConfig, timeoutMs: number) => Effect.Effect<string | undefined, unknown, R>;
+  readonly waitForShutdown: (config: RuntimeConfig, timeoutMs: number) => Effect.Effect<boolean, unknown, R>;
+}
+
+export interface LaunchAgentPlistTransaction<R = never> {
+  readonly hadPrevious: boolean;
+  readonly commit: Effect.Effect<void, unknown, R>;
+  readonly release: Effect.Effect<void, unknown, R>;
+  readonly rollback: Effect.Effect<void, unknown, R>;
+}
+
+export interface LaunchAgentHealthEffects<R = never> {
+  readonly ownsPort: (pid: number, config: RuntimeConfig, timeoutMs: number) => Effect.Effect<boolean, unknown, R>;
+  readonly readHealth: (config: RuntimeConfig, timeoutMs: number) => Effect.Effect<string | undefined, unknown, R>;
+  readonly readStatus: (timeoutMs: number) => Effect.Effect<LaunchAgentStatus, unknown, R>;
 }
 
 type UserAgentInstructionTarget = (typeof USER_AGENT_INSTRUCTION_TARGETS)[number];
@@ -345,7 +381,7 @@ export const runUninstall = Effect.fn('runUninstall')(function* (config: Runtime
   yield* fromPromise('remove OpenViking pid file', () =>
     removePathIfExists(join(config.agentContextHome, 'openviking-server.pid'), 'pid file', dryRun),
   );
-  yield* fromPromise('remove OpenViking launch agent', () => removeLaunchAgent(dryRun));
+  yield* removeLaunchAgent(dryRun);
   yield* fromPromise('remove MCP configurations', () => removeMcpConfigs(options.mcp ?? 'available', dryRun));
   yield* fromPromise('remove MCP snippets', () => removeMcpSnippets(config, dryRun));
   if (yield* fromPromise('check managed Claude hooks', hasManagedClaudeHooks)) {
@@ -520,6 +556,74 @@ export async function findOpenVikingServer(): Promise<string | undefined> {
   return undefined;
 }
 
+const findOpenVikingServerEffectCore = Effect.fn('findOpenVikingServer')(function* (timeoutMs: number) {
+  const fs = yield* FileSystem.FileSystem;
+  const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+  const pathDirectories = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  for (const directory of pathDirectories) {
+    const candidate = join(directory, OPENVIKING_SERVER_COMMAND);
+    if (yield* isExecutableFileEffect(fs, candidate)) {
+      return candidate;
+    }
+  }
+
+  const candidateDirectories: string[] = [];
+  const uv = yield* findExecutableInDirectoriesEffect(fs, 'uv', pathDirectories);
+  if (uv) {
+    const result = yield* runCommandEffect(uv, ['tool', 'dir', '--bin'], {
+      allowFailure: true,
+      timeoutMs: yield* remainingBudget(deadline, timeoutMs),
+    });
+    if (result.exitCode === 0 && result.stdout.trim()) {
+      candidateDirectories.push(result.stdout.trim());
+    }
+  }
+  if (process.env.UV_TOOL_BIN_DIR) {
+    candidateDirectories.push(process.env.UV_TOOL_BIN_DIR);
+  }
+  candidateDirectories.push(expandPath('~/.local/bin'));
+  for (const directory of new Set(candidateDirectories)) {
+    const candidate = join(directory, OPENVIKING_SERVER_COMMAND);
+    if (yield* isExecutableFileEffect(fs, candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+});
+
+export function findOpenVikingServerEffect(timeoutMs: number) {
+  return findOpenVikingServerEffectCore(timeoutMs).pipe(
+    Effect.timeoutOrElse({
+      duration: timeoutMs,
+      orElse: () => Effect.fail(new Error(`OpenViking server discovery timed out after ${timeoutMs / 1000}s.`)),
+    }),
+  );
+}
+
+const findExecutableInDirectoriesEffect = Effect.fn('findExecutableInDirectories')(function* (
+  fs: FileSystem.FileSystem,
+  name: string,
+  directories: readonly string[],
+) {
+  for (const directory of directories) {
+    const candidate = join(directory, name);
+    if (yield* isExecutableFileEffect(fs, candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+});
+
+const isExecutableFileEffect = Effect.fn('isExecutableFile')(function* (fs: FileSystem.FileSystem, path: string) {
+  const info = yield* fs.stat(path).pipe(
+    Effect.catchIf(
+      error => error.reason._tag === 'NotFound',
+      () => Effect.succeed(undefined),
+    ),
+  );
+  return info?.type === 'File' && (info.mode & 0o111) !== 0;
+});
+
 let candidateDirsPromise: Promise<readonly string[]> | undefined;
 
 async function openVikingServerCandidateDirs(): Promise<readonly string[]> {
@@ -604,7 +708,7 @@ function repairServerHealth(config: RuntimeConfig, dryRun: boolean) {
 export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, options: StartOptions) {
   const fs = yield* FileSystem.FileSystem;
   if (options.launchd === true) {
-    yield* fromPromise('install OpenViking launch agent', () => installLaunchAgent(config, options.dryRun === true));
+    yield* installLaunchAgent(config, options.dryRun === true);
     return;
   }
 
@@ -687,15 +791,45 @@ function spawnDetachedServer(server: string, args: readonly string[], logFd: num
   });
 }
 
+const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServer')(function* (
+  config: RuntimeConfig,
+  server: string,
+  timeoutMs: number,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const logPath = openVikingLogPath(config);
+  yield* fs.makeDirectory(dirname(logPath), {recursive: true});
+  const child = yield* Effect.try({
+    try: () => {
+      const logFd = openSync(logPath, 'a');
+      const spawned = spawnDetachedServerWithLog(server, openVikingServerArgs(config), logFd);
+      spawned.unref();
+      return spawned;
+    },
+    catch: cause => applicationError('restore detached OpenViking server', cause),
+  });
+  if (child.pid === undefined) {
+    return yield* Effect.fail(new Error('Restored detached OpenViking server did not report a pid.'));
+  }
+  yield* fs.writeFileString(join(config.agentContextHome, 'openviking-server.pid'), `${child.pid}\n`);
+  const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+  while ((yield* Clock.currentTimeMillis) < deadline) {
+    const remainingMs = deadline - (yield* Clock.currentTimeMillis);
+    if (yield* readOpenVikingHealthEffect(config, Math.max(1, Math.min(500, remainingMs)))) {
+      return;
+    }
+    yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
+  }
+  yield* signalProcessEffect(child.pid, 'SIGTERM').pipe(Effect.ignore);
+  return yield* Effect.fail(
+    new Error(`Restored detached OpenViking server did not become healthy within ${timeoutMs}ms.`),
+  );
+});
+
 export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, options: ForgetOptions) {
   const fs = yield* FileSystem.FileSystem;
-  const launchAgentPath = expandPath(`~/Library/LaunchAgents/${LAUNCHD_LABEL}.plist`);
   if (platform() === 'darwin') {
-    if (options.dryRun === true || (yield* fs.exists(launchAgentPath))) {
-      yield* maybeRunEffect(options.dryRun === true, 'launchctl', ['unload', launchAgentPath], {allowFailure: true});
-    } else {
-      yield* syncWithConsole(() => consoleOutput.log(`No LaunchAgent found: ${launchAgentPath}`));
-    }
+    yield* bootoutLaunchAgent(options.dryRun === true, undefined, STOP_SERVER_TIMEOUT_MS);
   }
 
   const pidPath = join(config.agentContextHome, 'openviking-server.pid');
@@ -727,6 +861,192 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
     }
   });
 });
+
+const stopDetachedOpenVikingServerForLaunchdCore = Effect.fn('stopDetachedOpenVikingServerForLaunchd')(function* (
+  config: RuntimeConfig,
+  dryRun: boolean,
+  timeoutMs: number = STOP_SERVER_TIMEOUT_MS,
+  resolvedServer?: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const pidPath = join(config.agentContextHome, 'openviking-server.pid');
+  const pidText = yield* fs.readFileString(pidPath).pipe(
+    Effect.catchIf(
+      error => error.reason._tag === 'NotFound',
+      () => Effect.succeed(undefined),
+    ),
+  );
+  if (pidText === undefined) {
+    yield* Console.log('No pid file found for detached OpenViking server.');
+    return false;
+  }
+  const pid = Number(pidText.trim());
+  if (!Number.isInteger(pid) || pid <= 0) {
+    yield* Console.log(`Invalid pid file: ${pidPath}`);
+    if (!dryRun) {
+      yield* fs.remove(pidPath, {force: true});
+    }
+    return false;
+  }
+  if (dryRun) {
+    yield* Console.log(`Would stop detached OpenViking process ${pid}`);
+    return true;
+  }
+  const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+  if (!(yield* isProcessRunningEffect(pid))) {
+    yield* fs.remove(pidPath, {force: true});
+    return false;
+  }
+  const server = resolvedServer ?? (yield* findOpenVikingServerEffect(yield* remainingBudget(deadline, timeoutMs)));
+  if (!server) {
+    return yield* Effect.fail(new Error(`Refusing to stop process ${pid}: OpenViking server path is unavailable.`));
+  }
+  const expectedProcess = {
+    args: openVikingServerArgs(config),
+    server,
+    shebangInterpreter: yield* fs.readFileString(server).pipe(
+      Effect.map(parseShebangInterpreter),
+      Effect.catch(() => Effect.succeed(undefined)),
+    ),
+  };
+  if (!(yield* isManagedDetachedOpenVikingProcess(pid, pidPath, config, expectedProcess, deadline, timeoutMs))) {
+    return yield* Effect.fail(
+      new Error(`Refusing to stop process ${pid}: the pid file does not identify this Threadnote OpenViking server.`),
+    );
+  }
+  if (!(yield* isManagedDetachedOpenVikingProcess(pid, pidPath, config, expectedProcess, deadline, timeoutMs))) {
+    return yield* Effect.fail(new Error(`Refusing to stop process ${pid}: its identity changed before signaling.`));
+  }
+  const signaled = yield* signalProcessEffect(pid, 'SIGTERM');
+  if (!signaled) {
+    yield* fs.remove(pidPath, {force: true});
+    return false;
+  }
+  while (yield* isProcessRunningEffect(pid)) {
+    const remainingMs = deadline - (yield* Clock.currentTimeMillis);
+    if (remainingMs <= 0) {
+      return yield* Effect.fail(
+        new Error(`Detached OpenViking process ${pid} did not stop within ${timeoutMs / 1000}s.`),
+      );
+    }
+    yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
+  }
+  yield* fs.remove(pidPath, {force: true});
+  yield* Console.log(`Stopped detached OpenViking process ${pid}`);
+  return true;
+});
+
+export function stopDetachedOpenVikingServerForLaunchd(
+  config: RuntimeConfig,
+  dryRun: boolean,
+  timeoutMs: number = STOP_SERVER_TIMEOUT_MS,
+  resolvedServer?: string,
+) {
+  return stopDetachedOpenVikingServerForLaunchdCore(config, dryRun, timeoutMs, resolvedServer).pipe(
+    Effect.timeoutOrElse({
+      duration: timeoutMs,
+      orElse: () =>
+        Effect.fail(new Error(`Stopping the detached OpenViking server timed out after ${timeoutMs / 1000}s.`)),
+    }),
+  );
+}
+
+interface ExpectedOpenVikingProcess {
+  readonly args: readonly string[];
+  readonly server: string;
+  readonly shebangInterpreter?: string;
+}
+
+const isManagedDetachedOpenVikingProcess = Effect.fn('isManagedDetachedOpenVikingProcess')(function* (
+  pid: number,
+  pidPath: string,
+  config: RuntimeConfig,
+  expected: ExpectedOpenVikingProcess,
+  deadline: number,
+  timeoutMs: number,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const result = yield* runCommandEffect('/bin/ps', ['-ww', '-p', String(pid), '-o', 'lstart=', '-o', 'command='], {
+    allowFailure: true,
+    timeoutMs: yield* remainingBudget(deadline, timeoutMs),
+  });
+  if (result.exitCode !== 0) {
+    return false;
+  }
+  const output = result.stdout.trim();
+  const processStartedAt = Date.parse(output.slice(0, 24));
+  const pidFile = yield* fs.stat(pidPath);
+  const pidFileMtime = Option.getOrUndefined(pidFile.mtime)?.getTime();
+  if (
+    !Number.isFinite(processStartedAt) ||
+    pidFileMtime === undefined ||
+    Math.abs(pidFileMtime - processStartedAt) > 2000
+  ) {
+    return false;
+  }
+  const command = output.slice(24).trim();
+  if (!isExpectedLaunchdProcessCommand(command, expected.server, expected.args, expected.shebangInterpreter)) {
+    return false;
+  }
+  return yield* launchdProcessOwnsPort(pid, config, Math.min(yield* remainingBudget(deadline, timeoutMs), 2000));
+});
+
+export function isExpectedLaunchdProcessCommand(
+  command: string,
+  server: string,
+  args: readonly string[],
+  shebangInterpreter?: string,
+): boolean {
+  const directCommand = [server, ...args].join(' ');
+  return (
+    command === directCommand ||
+    (shebangInterpreter !== undefined && command === `${shebangInterpreter} ${directCommand}`)
+  );
+}
+
+function parseShebangInterpreter(content: string): string | undefined {
+  const first = content.split(/\r?\n/, 1)[0];
+  const interpreter = first?.startsWith('#!') ? first.slice(2).trim() : '';
+  return interpreter && !/\s/.test(interpreter) ? interpreter : undefined;
+}
+
+const isProcessRunningEffect = Effect.fn('isProcessRunning')(function* (pid: number) {
+  return yield* Effect.try({
+    try: () => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (cause: unknown) {
+        if (isNodeError(cause) && cause.code === 'ESRCH') {
+          return false;
+        }
+        throw cause;
+      }
+    },
+    catch: cause => applicationError(`check process ${pid}`, cause),
+  });
+});
+
+const signalProcessEffect = Effect.fn('signalProcess')(function* (pid: number, signal: NodeJS.Signals) {
+  return yield* Effect.try({
+    try: () => {
+      try {
+        process.kill(pid, signal);
+        return true;
+      } catch (cause: unknown) {
+        if (isNodeError(cause) && cause.code === 'ESRCH') {
+          return false;
+        }
+        throw cause;
+      }
+    },
+    catch: cause => applicationError(`signal process ${pid}`, cause),
+  });
+});
+
+function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error && 'code' in value;
+}
 
 async function commandCheck(name: string, args: readonly string[]): Promise<DoctorCheck> {
   const executable = await findExecutable([name]);
@@ -1912,70 +2232,393 @@ function isManagedCommandShim(content: string): boolean {
   return content.includes(SHIM_MARKER);
 }
 
-async function installLaunchAgent(config: RuntimeConfig, dryRun: boolean): Promise<void> {
+const installLaunchAgent = Effect.fn('installLaunchAgent')(function* (config: RuntimeConfig, dryRun: boolean) {
+  const fs = yield* FileSystem.FileSystem;
   if (platform() !== 'darwin') {
-    throw new Error('launchd autostart is only supported on macOS.');
+    return yield* Effect.fail(new Error('launchd autostart is only supported on macOS.'));
   }
   // launchd uses a minimal default PATH (/usr/bin:/bin:/usr/sbin:/sbin) and
   // does not source the user's shell rc, so the plist must reference the
   // absolute path to openviking-server — otherwise a LaunchAgent on a fresh
   // macOS box would exit 127.
-  const resolvedServer = await findOpenVikingServer();
+  const installDeadline = (yield* Clock.currentTimeMillis) + START_HEALTH_TIMEOUT_MS;
+  const resolvedServer = yield* findOpenVikingServerEffect(
+    yield* remainingBudget(installDeadline, START_HEALTH_TIMEOUT_MS),
+  );
   if (!resolvedServer && !dryRun) {
-    throw new Error(
-      `Cannot install LaunchAgent: ${OPENVIKING_SERVER_COMMAND} was not found in PATH, ` +
-        'uv tool bin dir, $UV_TOOL_BIN_DIR, or ~/.local/bin. Run `threadnote install` first.',
+    return yield* Effect.fail(
+      new Error(
+        `Cannot install LaunchAgent: ${OPENVIKING_SERVER_COMMAND} was not found in PATH, ` +
+          'uv tool bin dir, $UV_TOOL_BIN_DIR, or ~/.local/bin. Run `threadnote install` first.',
+      ),
     );
   }
   const source = join(toolRoot(), 'config', 'launchd', `${LAUNCHD_LABEL}.plist.template`);
-  const destination = expandPath(`~/Library/LaunchAgents/${LAUNCHD_LABEL}.plist`);
-  const rendered = renderTemplate(await readFile(source, 'utf8'), config, {
+  const destination = launchAgentPath();
+  const rendered = renderTemplate(yield* fs.readFileString(source), config, {
     OPENVIKING_SERVER_PATH: resolvedServer ?? OPENVIKING_SERVER_COMMAND,
   });
   if (dryRun) {
     const resolutionDetail = resolvedServer ?? `<not found; would use bare \`${OPENVIKING_SERVER_COMMAND}\`>`;
-    consoleOutput.log(`Resolved openviking-server: ${resolutionDetail}`);
-    consoleOutput.log(`Would write ${destination}`);
-    consoleOutput.log(`Would run: launchctl unload ${destination}`);
-    consoleOutput.log(`Would run: launchctl load ${destination}`);
-    consoleOutput.log(`Would run: launchctl start ${LAUNCHD_LABEL}`);
+    yield* Console.log(`Resolved openviking-server: ${resolutionDetail}`);
+    yield* Console.log(`Would write ${destination}`);
+    yield* bootoutLaunchAgent(true);
+    yield* stopDetachedOpenVikingServerForLaunchd(config, true);
+    yield* bootstrapLaunchAgent(destination, true);
     return;
   }
-  await ensureDirectory(dirname(destination), false);
-  await ensureDirectory(dirname(openVikingLogPath(config)), false);
-  await writeFile(destination, rendered, 'utf8');
-  await maybeRun(false, 'launchctl', ['unload', destination], {allowFailure: true});
-  await maybeRun(false, 'launchctl', ['load', destination]);
-  await maybeRun(false, 'launchctl', ['start', LAUNCHD_LABEL]);
+  yield* fs.makeDirectory(dirname(destination), {recursive: true});
+  yield* fs.makeDirectory(dirname(openVikingLogPath(config)), {recursive: true});
   const healthUrl = openVikingHealthUrl(config);
-  const health = await waitForOpenVikingHealth(
+  const activationTimeoutMs = yield* remainingBudget(installDeadline, START_HEALTH_TIMEOUT_MS);
+  const health = yield* activateLaunchAgent<CommandExecutor | FileSystem.FileSystem | HttpService>(
     config,
-    START_HEALTH_TIMEOUT_MS,
-    `Waiting for OpenViking health at ${healthUrl}.`,
+    destination,
+    rendered,
+    activationTimeoutMs,
+    {
+      bootout: timeoutMs => bootoutLaunchAgent(false, undefined, timeoutMs),
+      bootstrap: (plistPath, timeoutMs) => bootstrapLaunchAgent(plistPath, false, undefined, timeoutMs),
+      isPortOpen: (current, timeoutMs) => isTcpPortOpenEffect(current.host, current.port, Math.min(500, timeoutMs)),
+      stagePlist: (plistPath, content) => stageLaunchAgentPlist(plistPath, content),
+      stopDetached: (current, timeoutMs) =>
+        stopDetachedOpenVikingServerForLaunchd(current, false, timeoutMs, resolvedServer),
+      restartDetached: (current, timeoutMs) => restartDetachedOpenVikingServer(current, resolvedServer!, timeoutMs),
+      waitForHealth: (current, timeoutMs) =>
+        waitForLaunchAgentHealth(current, timeoutMs, `Waiting for OpenViking health at ${healthUrl}.`),
+      waitForShutdown: waitForOpenVikingShutdown,
+    },
   );
   if (health) {
-    consoleOutput.log(`Installed and started ${LAUNCHD_LABEL}. Health OK at ${healthUrl}`);
+    yield* Console.log(`Installed and started ${LAUNCHD_LABEL}. Health OK at ${healthUrl}`);
     return;
   }
-  throw new Error(
-    `Installed and started ${LAUNCHD_LABEL}, but ${healthUrl} did not become healthy within ` +
-      `${START_HEALTH_TIMEOUT_MS / 1000}s. Logs: ${openVikingLogPath(config)}`,
+  return yield* Effect.fail(
+    new Error(
+      `Installed and started ${LAUNCHD_LABEL}, but ${healthUrl} did not become healthy within ` +
+        `${START_HEALTH_TIMEOUT_MS / 1000}s. Logs: ${openVikingLogPath(config)}`,
+    ),
+  );
+});
+
+export function activateLaunchAgent<R>(
+  config: RuntimeConfig,
+  plistPath: string,
+  plistContent: string,
+  timeoutMs: number,
+  effects: LaunchAgentActivationEffects<R>,
+): Effect.Effect<string | undefined, unknown, R> {
+  const timedOut = new Error(`LaunchAgent activation timed out after ${timeoutMs / 1000}s.`);
+  const recoveryTimeoutMs = Math.min(2000, timeoutMs);
+  let transaction: LaunchAgentPlistTransaction<R> | undefined;
+  let launchAgentWasLoaded = false;
+  let detachedServerWasStopped = false;
+  let replacementCommitted = false;
+  let serviceHealthy = false;
+  const operation = Effect.gen(function* () {
+    const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+    const remaining = () => remainingBudget(deadline, timeoutMs);
+    transaction = yield* effects.stagePlist(plistPath, plistContent);
+    yield* Effect.uninterruptibleMask(restore =>
+      Effect.gen(function* () {
+        launchAgentWasLoaded = yield* restore(effects.bootout(yield* remaining()));
+      }),
+    );
+    yield* Effect.uninterruptibleMask(restore =>
+      Effect.gen(function* () {
+        detachedServerWasStopped = yield* restore(effects.stopDetached(config, yield* remaining()));
+      }),
+    );
+    if (!(yield* effects.waitForShutdown(config, yield* remaining()))) {
+      return yield* Effect.fail(
+        new Error(
+          `OpenViking at ${openVikingHealthUrl(config)} is still running outside Threadnote's managed process. ` +
+            'Stop that process before enabling launchd autostart.',
+        ),
+      );
+    }
+    if (yield* effects.isPortOpen(config, yield* remaining())) {
+      return yield* Effect.fail(
+        new Error(
+          `Port ${config.host}:${config.port} is still in use after stopping the managed OpenViking server. ` +
+            'Stop the process using that port before enabling launchd autostart.',
+        ),
+      );
+    }
+    yield* transaction.commit;
+    replacementCommitted = true;
+    yield* effects.bootstrap(plistPath, yield* remaining());
+    const health = yield* effects.waitForHealth(config, yield* remaining());
+    if (health === undefined) {
+      return yield* Effect.fail(timedOut);
+    }
+    serviceHealthy = true;
+    yield* transaction.release;
+    return health;
+  });
+  const boundedOperation = operation.pipe(
+    Effect.timeoutOrElse({
+      duration: timeoutMs,
+      orElse: () => Effect.fail(timedOut),
+    }),
+  );
+  return boundedOperation.pipe(
+    Effect.onExit(exit => {
+      if (Exit.isSuccess(exit) || !transaction) {
+        return Effect.void;
+      }
+      const activeTransaction = transaction;
+      if (serviceHealthy) {
+        return boundedRecovery(activeTransaction.release, recoveryTimeoutMs, exit);
+      }
+      const recovery = Effect.gen(function* () {
+        if (replacementCommitted) {
+          yield* effects.bootout(recoveryTimeoutMs);
+        }
+        yield* activeTransaction.rollback;
+        if (launchAgentWasLoaded) {
+          yield* effects.bootstrap(plistPath, recoveryTimeoutMs);
+        } else if (detachedServerWasStopped) {
+          yield* effects.restartDetached(config, recoveryTimeoutMs);
+        }
+      }).pipe(Effect.ensuring(activeTransaction.release.pipe(Effect.orDie)));
+      return boundedRecovery(recovery, recoveryTimeoutMs, exit);
+    }),
   );
 }
 
-async function removeLaunchAgent(dryRun: boolean): Promise<void> {
-  const launchAgentPath = expandPath(`~/Library/LaunchAgents/${LAUNCHD_LABEL}.plist`);
-  const content = await readFileIfExists(launchAgentPath);
+function boundedRecovery<R>(
+  recovery: Effect.Effect<void, unknown, R>,
+  timeoutMs: number,
+  activationExit: Exit.Exit<unknown, unknown>,
+): Effect.Effect<void, Error, R> {
+  const activationFailure = Exit.isFailure(activationExit) ? Cause.pretty(activationExit.cause) : 'unknown failure';
+  return recovery.pipe(
+    Effect.interruptible,
+    Effect.timeoutOrElse({
+      duration: timeoutMs,
+      orElse: () => Effect.fail(new Error(`LaunchAgent recovery timed out after ${timeoutMs / 1000}s.`)),
+    }),
+    Effect.mapError(
+      recoveryError =>
+        new Error(
+          `LaunchAgent activation failed: ${activationFailure}\nRecovery also failed: ${errorMessage(recoveryError)}`,
+        ),
+    ),
+  );
+}
+
+export const stageLaunchAgentPlist = Effect.fn('stageLaunchAgentPlist')(function* (plistPath: string, content: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* stageLaunchAgentPlistWithFileSystem(fs, plistPath, content);
+});
+
+function stageLaunchAgentPlistWithFileSystem(
+  fs: FileSystem.FileSystem,
+  plistPath: string,
+  content: string,
+): Effect.Effect<LaunchAgentPlistTransaction, unknown> {
+  return Effect.gen(function* () {
+    const stagePath = `${plistPath}.threadnote-stage-${process.pid}`;
+    const rollbackPath = `${plistPath}.threadnote-rollback-${process.pid}`;
+    const lockPath = `${plistPath}.threadnote-lock`;
+    yield* fs.makeDirectory(lockPath);
+    const prepare = Effect.gen(function* () {
+      const previous = yield* readOptionalFileEffect(fs, plistPath);
+      let committed = false;
+      yield* fs.writeFileString(stagePath, content, {mode: 0o600});
+      return {
+        hadPrevious: previous !== undefined,
+        commit: Effect.gen(function* () {
+          const current = yield* readOptionalFileEffect(fs, plistPath);
+          if (current !== previous) {
+            return yield* Effect.fail(new Error(`LaunchAgent plist changed while activation was staged: ${plistPath}`));
+          }
+          yield* fs.rename(stagePath, plistPath);
+          committed = true;
+        }),
+        release: fs.remove(lockPath, {force: true, recursive: true}),
+        rollback: Effect.gen(function* () {
+          yield* fs.remove(stagePath, {force: true});
+          const current = yield* readOptionalFileEffect(fs, plistPath);
+          const expected = committed ? content : previous;
+          if (current !== expected) {
+            return yield* Effect.fail(
+              new Error(`LaunchAgent plist changed before activation could roll back: ${plistPath}`),
+            );
+          }
+          if (!committed) {
+            return;
+          }
+          if (previous === undefined) {
+            yield* fs.remove(plistPath, {force: true});
+            return;
+          }
+          yield* fs.writeFileString(rollbackPath, previous, {mode: 0o600});
+          yield* fs.rename(rollbackPath, plistPath);
+        }),
+      } satisfies LaunchAgentPlistTransaction;
+    });
+    return yield* prepare.pipe(
+      Effect.onError(() => fs.remove(lockPath, {force: true, recursive: true}).pipe(Effect.orDie)),
+    );
+  });
+}
+
+const readOptionalFileEffect = Effect.fn('readOptionalFile')(function* (fs: FileSystem.FileSystem, path: string) {
+  return yield* fs.readFileString(path).pipe(
+    Effect.catchIf(
+      error => error.reason._tag === 'NotFound',
+      () => Effect.succeed(undefined),
+    ),
+  );
+});
+
+const waitForOpenVikingShutdown = Effect.fn('waitForOpenVikingShutdown')(function* (
+  config: RuntimeConfig,
+  timeoutMs: number,
+) {
+  const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+  while ((yield* Clock.currentTimeMillis) <= deadline) {
+    const remainingMs = deadline - (yield* Clock.currentTimeMillis);
+    if (!(yield* readOpenVikingHealthEffect(config, Math.max(1, Math.min(500, remainingMs))))) {
+      return true;
+    }
+    if (remainingMs <= 0) {
+      break;
+    }
+    yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
+  }
+  return false;
+});
+
+export function waitForLaunchAgentHealth(
+  config: RuntimeConfig,
+  timeoutMs: number,
+  progressMessage: string,
+): Effect.Effect<string | undefined, unknown, CommandExecutor | HttpService> {
+  return waitForLaunchAgentHealthWithEffects(config, timeoutMs, progressMessage, liveLaunchAgentHealthEffects());
+}
+
+export function waitForLaunchAgentHealthWithEffects<R>(
+  config: RuntimeConfig,
+  timeoutMs: number,
+  progressMessage: string,
+  effects: LaunchAgentHealthEffects<R>,
+): Effect.Effect<string | undefined, unknown, R> {
+  return Effect.gen(function* () {
+    yield* Console.log(progressMessage);
+    const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+    while ((yield* Clock.currentTimeMillis) <= deadline) {
+      const statusTimeoutMs = Math.max(1, Math.min(1000, deadline - (yield* Clock.currentTimeMillis)));
+      const status = yield* effects.readStatus(statusTimeoutMs);
+      if (status.running && status.pid !== undefined) {
+        const preOwnershipTimeoutMs = Math.max(1, Math.min(1000, deadline - (yield* Clock.currentTimeMillis)));
+        if (yield* effects.ownsPort(status.pid, config, preOwnershipTimeoutMs)) {
+          const requestTimeoutMs = Math.max(1, Math.min(1000, deadline - (yield* Clock.currentTimeMillis)));
+          const health = yield* effects.readHealth(config, requestTimeoutMs);
+          if (health !== undefined) {
+            const postOwnershipTimeoutMs = Math.max(1, Math.min(1000, deadline - (yield* Clock.currentTimeMillis)));
+            const ownsPort = yield* effects.ownsPort(status.pid, config, postOwnershipTimeoutMs);
+            const confirmationTimeoutMs = Math.max(1, Math.min(1000, deadline - (yield* Clock.currentTimeMillis)));
+            const confirmedStatus = yield* effects.readStatus(confirmationTimeoutMs);
+            if (ownsPort && launchAgentHealthIsStable(status, health, confirmedStatus)) {
+              return health;
+            }
+          }
+        }
+      }
+      const remainingMs = deadline - (yield* Clock.currentTimeMillis);
+      if (remainingMs <= 0) {
+        break;
+      }
+      yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
+    }
+    return undefined;
+  });
+}
+
+const launchdProcessOwnsPort = Effect.fn('launchdProcessOwnsPort')(function* (
+  pid: number,
+  config: RuntimeConfig,
+  timeoutMs: number,
+) {
+  const result = yield* runCommandEffect(
+    '/usr/sbin/lsof',
+    ['-nP', '-a', '-p', String(pid), `-iTCP@${config.host}:${config.port}`, '-sTCP:LISTEN', '-Fp'],
+    {allowFailure: true, timeoutMs},
+  );
+  return result.exitCode === 0 && result.stdout.split('\n').includes(`p${pid}`);
+});
+
+const readOpenVikingHealthEffect = Effect.fn('readOpenVikingHealth')(function* (
+  config: RuntimeConfig,
+  timeoutMs: number,
+) {
+  return yield* getTextEffect(openVikingHealthUrl(config), {timeoutMs}).pipe(
+    Effect.map(response => response.body),
+    Effect.catch(() => Effect.succeed(undefined)),
+  );
+});
+
+function liveLaunchAgentHealthEffects(): LaunchAgentHealthEffects<CommandExecutor | HttpService> {
+  return {
+    ownsPort: (pid, config, timeoutMs) => launchdProcessOwnsPort(pid, config, timeoutMs),
+    readHealth: readOpenVikingHealthEffect,
+    readStatus: timeoutMs => readLaunchAgentStatus(undefined, timeoutMs),
+  };
+}
+
+const isTcpPortOpenEffect = Effect.fn('isTcpPortOpen')(function* (host: string, port: number, timeoutMs: number) {
+  return yield* fromPromise(`check TCP port ${host}:${port}`, () => isTcpPortOpen(host, port, timeoutMs));
+});
+
+const remainingBudget = Effect.fn('remainingLaunchAgentBudget')(function* (deadline: number, timeoutMs: number) {
+  const remaining = deadline - (yield* Clock.currentTimeMillis);
+  if (remaining <= 0) {
+    return yield* Effect.fail(new Error(`LaunchAgent activation timed out after ${timeoutMs / 1000}s.`));
+  }
+  return remaining;
+});
+
+export function launchAgentHealthIsStable(
+  initial: LaunchAgentStatus,
+  health: string | undefined,
+  confirmed: LaunchAgentStatus,
+): health is string {
+  return (
+    health !== undefined &&
+    initial.running &&
+    confirmed.running &&
+    initial.pid !== undefined &&
+    initial.pid === confirmed.pid
+  );
+}
+
+const removeLaunchAgent = Effect.fn('removeLaunchAgent')(function* (dryRun: boolean) {
+  const fs = yield* FileSystem.FileSystem;
+  const agentPath = launchAgentPath();
+  const content = yield* fs.readFileString(agentPath).pipe(
+    Effect.catchIf(
+      error => error.reason._tag === 'NotFound',
+      () => Effect.succeed(undefined),
+    ),
+  );
   if (content === undefined) {
-    consoleOutput.log(`Already absent: ${launchAgentPath}`);
+    yield* Console.log(`Already absent: ${agentPath}`);
     return;
   }
   if (!content.includes(LAUNCHD_LABEL) || !content.includes(OPENVIKING_SERVER_COMMAND)) {
-    consoleOutput.log(`WARN not removing unmanaged LaunchAgent: ${launchAgentPath}`);
+    yield* Console.log(`WARN not removing unmanaged LaunchAgent: ${agentPath}`);
     return;
   }
-  await removePath(launchAgentPath, 'LaunchAgent', dryRun);
-}
+  if (dryRun) {
+    yield* Console.log(`Would remove LaunchAgent: ${agentPath}`);
+    return;
+  }
+  yield* fs.remove(agentPath);
+  yield* Console.log(`Removed LaunchAgent: ${agentPath}`);
+});
 
 async function eraseThreadnoteHome(path: string, dryRun: boolean): Promise<void> {
   assertSafeThreadnoteHomeForErase(path);

--- a/test/unit/effect-http.test.ts
+++ b/test/unit/effect-http.test.ts
@@ -52,4 +52,20 @@ describe('Effect HttpService', () => {
       expect(result.failure._tag).toBe('HttpStatusError');
     }
   });
+
+  it('times out while a successful response body is still streaming', async () => {
+    nextResponse = () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('partial'));
+          },
+        }),
+        {status: 200},
+      );
+
+    await expect(
+      pipe(getTextEffect('http://localhost/health', {timeoutMs: 20}), Effect.provide(ApplicationLayer), runTestEffect),
+    ).rejects.toThrow('GET http://localhost/health failed');
+  });
 });

--- a/test/unit/launchd.test.ts
+++ b/test/unit/launchd.test.ts
@@ -1,0 +1,188 @@
+import {chmod, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {delimiter, join} from 'node:path';
+import {expect as effectExpect, it as effectIt} from '@effect/vitest';
+import {Effect, Layer} from 'effect';
+import {TestClock} from 'effect/testing';
+import {afterEach, describe, expect, it} from 'vitest';
+import {
+  bootoutLaunchAgent,
+  bootstrapLaunchAgent,
+  isLaunchAgentRunning,
+  launchAgentDomainTarget,
+  launchAgentServiceTarget,
+  parseLaunchAgentStatus,
+} from '../../src/launchd.js';
+import {CommandExecutor} from '../../src/effect/command.js';
+
+const originalPath = process.env.PATH;
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, {force: true, recursive: true})));
+});
+
+async function fakeLaunchctl(): Promise<{executable: string; logPath: string}> {
+  const directory = await mkdtemp(join(tmpdir(), 'threadnote-launchctl-test-'));
+  temporaryDirectories.push(directory);
+  const executable = join(directory, 'launchctl');
+  const logPath = join(directory, 'commands.log');
+  const statePath = join(directory, 'loaded');
+  await writeFile(statePath, '1\n');
+  await writeFile(
+    executable,
+    [
+      '#!/bin/sh',
+      `log=${JSON.stringify(logPath)}`,
+      `state=${JSON.stringify(statePath)}`,
+      'printf \'%s\\n\' "$*" >> "$log"',
+      'if [ "$1" = "print" ]; then',
+      '  if [ "$(/bin/cat "$state")" = "1" ]; then',
+      "    printf 'state = running\\npid = 123\\n'",
+      '    exit 0',
+      '  fi',
+      "  printf 'Could not find service\\n' >&2",
+      '  exit 113',
+      'fi',
+      'if [ "$1" = "bootout" ]; then',
+      '  printf \'0\\n\' > "$state"',
+      'fi',
+      '',
+    ].join('\n'),
+  );
+  await chmod(executable, 0o755);
+  process.env.PATH = [directory, ...(originalPath ? [originalPath] : [])].join(delimiter);
+  return {executable, logPath};
+}
+
+describe('macOS LaunchAgent lifecycle', () => {
+  it('builds explicit per-user launchctl targets', () => {
+    expect(launchAgentDomainTarget(502)).toBe('gui/502');
+    expect(launchAgentServiceTarget(502)).toBe('gui/502/io.threadnote.openviking');
+  });
+
+  it('uses bootout, enable, and bootstrap for a persistent user agent', async () => {
+    const {logPath} = await fakeLaunchctl();
+    const plistPath = '/Users/test/Library/LaunchAgents/io.threadnote.openviking.plist';
+
+    await Effect.runPromise(bootoutLaunchAgent(false, 502).pipe(Effect.provide(CommandExecutor.layer)));
+    await Effect.runPromise(bootstrapLaunchAgent(plistPath, false, 502).pipe(Effect.provide(CommandExecutor.layer)));
+
+    expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
+      'print gui/502/io.threadnote.openviking',
+      'bootout gui/502/io.threadnote.openviking',
+      'print gui/502/io.threadnote.openviking',
+      'enable gui/502/io.threadnote.openviking',
+      `bootstrap gui/502 ${plistPath}`,
+    ]);
+  });
+
+  it('requires launchctl to report a running process', async () => {
+    await fakeLaunchctl();
+
+    expect(await Effect.runPromise(isLaunchAgentRunning(502).pipe(Effect.provide(CommandExecutor.layer)))).toBe(true);
+  });
+
+  it('does not treat a loaded job without a running pid as ready', () => {
+    expect(parseLaunchAgentStatus('state = running\n', 0)).toEqual({
+      loaded: true,
+      running: false,
+    });
+    expect(parseLaunchAgentStatus('state = waiting\nlast exit code = 1\n', 0)).toEqual({
+      loaded: true,
+      running: false,
+    });
+    expect(parseLaunchAgentStatus('Could not find service', 113)).toEqual({loaded: false, running: false});
+    expect(() => parseLaunchAgentStatus('Not privileged', 1)).toThrow('launchctl print failed');
+  });
+
+  effectIt.effect('threads one decreasing timeout through bootout commands', () =>
+    Effect.gen(function* () {
+      const timeouts: number[] = [];
+      let call = 0;
+      const executor = Layer.succeed(
+        CommandExecutor,
+        CommandExecutor.of({
+          execute: (_executable, _args, options) =>
+            Effect.gen(function* () {
+              timeouts.push(options?.timeoutMs ?? -1);
+              yield* TestClock.adjust(10);
+              call += 1;
+              if (call === 1) {
+                return {exitCode: 0, stderr: '', stdout: 'state = running\npid = 123\n'};
+              }
+              if (call === 3) {
+                return {exitCode: 113, stderr: 'Could not find service', stdout: ''};
+              }
+              return {exitCode: 0, stderr: '', stdout: ''};
+            }),
+        }),
+      );
+
+      yield* bootoutLaunchAgent(false, 502, 1000).pipe(Effect.provide(executor));
+
+      effectExpect(timeouts).toEqual([1000, 990, 980]);
+    }),
+  );
+
+  effectIt.effect('threads one decreasing timeout through bootstrap commands', () =>
+    Effect.gen(function* () {
+      const timeouts: number[] = [];
+      const executor = Layer.succeed(
+        CommandExecutor,
+        CommandExecutor.of({
+          execute: (_executable, _args, options) =>
+            Effect.gen(function* () {
+              timeouts.push(options?.timeoutMs ?? -1);
+              yield* TestClock.adjust(10);
+              return {exitCode: 0, stderr: '', stdout: ''};
+            }),
+        }),
+      );
+
+      yield* bootstrapLaunchAgent('/tmp/agent.plist', false, 502, 1000).pipe(Effect.provide(executor));
+
+      effectExpect(timeouts).toEqual([1000, 990]);
+    }),
+  );
+
+  effectIt.effect('fails when bootout leaves the service loaded', () =>
+    Effect.gen(function* () {
+      const executor = Layer.succeed(
+        CommandExecutor,
+        CommandExecutor.of({
+          execute: (_executable, args) =>
+            Effect.succeed(
+              args[0] === 'print'
+                ? {exitCode: 0, stderr: '', stdout: 'state = running\npid = 123\n'}
+                : {exitCode: 0, stderr: '', stdout: ''},
+            ),
+        }),
+      );
+
+      const error = yield* bootoutLaunchAgent(false, 502, 1000).pipe(Effect.provide(executor), Effect.flip);
+
+      effectExpect(String(error)).toContain('did not unload');
+    }),
+  );
+
+  effectIt.effect('treats an absent service as an idempotent bootout success', () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      const executor = Layer.succeed(
+        CommandExecutor,
+        CommandExecutor.of({
+          execute: () => {
+            calls += 1;
+            return Effect.succeed({exitCode: 113, stderr: 'Could not find service', stdout: ''});
+          },
+        }),
+      );
+
+      yield* bootoutLaunchAgent(false, 502, 1000).pipe(Effect.provide(executor));
+
+      effectExpect(calls).toBe(1);
+    }),
+  );
+});

--- a/test/unit/lifecycle.install.test.ts
+++ b/test/unit/lifecycle.install.test.ts
@@ -1,10 +1,13 @@
-import {chmod, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {spawn, type ChildProcess} from 'node:child_process';
+import {access, chmod, mkdir, mkdtemp, rm, stat, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {delimiter, join} from 'node:path';
-import {Effect} from 'effect';
+import {NodeFileSystem} from '@effect/platform-node';
+import {Effect, Layer} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {
   ensureSupportedUvExecutable as ensureSupportedUvExecutablePromise,
+  findOpenVikingServerEffect,
   findSupportedUvExecutable,
   getInstallCommands,
   isLlamaWheelArchiveExtractionFailure,
@@ -13,15 +16,20 @@ import {
   openVikingSourceBuildRetryForArchiveFailure,
   openVikingToolPython,
   resolveOpenVikingInstallCommand,
+  stopDetachedOpenVikingServerForLaunchd,
 } from '../../src/lifecycle.js';
 import {fromPromise} from '../../src/effect/errors.js';
+import {CommandExecutor} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import type {RuntimeConfig} from '../../src/types.js';
 
 const WHEEL_INDEX_ENV = 'THREADNOTE_LLAMA_WHEEL_INDEX';
 const TOOL_PYTHON_ENV = 'THREADNOTE_OPENVIKING_PYTHON';
 const TEST_INDEX = 'https://wheels.example/whl/cpu';
 const METAL_INDEX = 'https://abetlen.github.io/llama-cpp-python/whl/metal';
+const posixIt = process.platform === 'win32' ? it.skip : it;
 const originalPath = process.env.PATH;
+const childProcesses: ChildProcess[] = [];
 const temporaryDirectories: string[] = [];
 const ensureSupportedUvExecutable = () =>
   Effect.runPromise(fromPromise('ensure supported uv executable', ensureSupportedUvExecutablePromise));
@@ -67,8 +75,70 @@ function restoreEnv(name: string, original: string | undefined): void {
 
 afterEach(async () => {
   restoreEnv('PATH', originalPath);
+  await Promise.all(childProcesses.splice(0).map(stopChild));
   await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, {force: true, recursive: true})));
 });
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill('SIGTERM');
+  if (await waitForChildExit(child, 1000)) {
+    return;
+  }
+  child.kill('SIGKILL');
+  if (!(await waitForChildExit(child, 1000))) {
+    throw new Error(`Could not stop test child ${child.pid ?? '<unknown>'}.`);
+  }
+}
+
+function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise(resolve => {
+    const timeout = setTimeout(() => {
+      child.off('exit', onExit);
+      resolve(false);
+    }, timeoutMs);
+    const onExit = (): void => {
+      clearTimeout(timeout);
+      resolve(true);
+    };
+    child.once('exit', onExit);
+  });
+}
+
+function formatPsStart(date: Date): string {
+  const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const time = [date.getHours(), date.getMinutes(), date.getSeconds()]
+    .map(value => String(value).padStart(2, '0'))
+    .join(':');
+  return `${weekdays[date.getDay()]} ${months[date.getMonth()]} ${String(date.getDate()).padStart(2, ' ')} ${time} ${date.getFullYear()}`;
+}
+
+function launchdProcessTestLayer(processStart: string, commands: string | readonly string[], pid: number) {
+  let psCalls = 0;
+  const executor = Layer.succeed(
+    CommandExecutor,
+    CommandExecutor.of({
+      execute: executable => {
+        if (executable === '/bin/ps') {
+          const command = typeof commands === 'string' ? commands : (commands[psCalls] ?? commands.at(-1) ?? '');
+          psCalls += 1;
+          return Effect.succeed({exitCode: 0, stderr: '', stdout: `${processStart} ${command}\n`});
+        }
+        if (executable === '/usr/sbin/lsof') {
+          return Effect.succeed({exitCode: 0, stderr: '', stdout: `p${pid}\n`});
+        }
+        return Effect.succeed({exitCode: 127, stderr: 'unexpected command', stdout: ''});
+      },
+    }),
+  );
+  return Layer.merge(NodeFileSystem.layer, executor);
+}
 
 function runtime(): RuntimeConfig {
   return {
@@ -307,5 +377,136 @@ describe('getInstallCommands', () => {
       'pip-system-certs',
       SPEC,
     ]);
+  });
+});
+
+describe('findOpenVikingServerEffect', () => {
+  it('interrupts Effect-native uv discovery at the supplied deadline', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'threadnote-server-discovery-test-'));
+    temporaryDirectories.push(home);
+    const uv = join(home, 'uv');
+    await writeFile(uv, '#!/bin/sh\n');
+    await chmod(uv, 0o755);
+    process.env.PATH = home;
+    const layer = Layer.merge(
+      NodeFileSystem.layer,
+      Layer.succeed(
+        CommandExecutor,
+        CommandExecutor.of({
+          execute: () => Effect.never,
+        }),
+      ),
+    );
+
+    await expect(Effect.runPromise(findOpenVikingServerEffect(20).pipe(Effect.provide(layer)))).rejects.toThrow(
+      'discovery timed out',
+    );
+  });
+});
+
+describe('stopDetachedOpenVikingServerForLaunchd', () => {
+  posixIt('stops an identity-checked process through Effect command services', async () => {
+    const config = runtime();
+    const home = await mkdtemp(join(tmpdir(), 'threadnote-detached-test-'));
+    temporaryDirectories.push(home);
+    const server = join(home, 'openviking-server');
+    await writeFile(server, `#!${process.execPath}\n`);
+    await chmod(server, 0o755);
+    process.env.PATH = home;
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {stdio: 'ignore'});
+    childProcesses.push(child);
+    const pidPath = join(home, 'openviking-server.pid');
+    await writeFile(pidPath, `${child.pid}\n`);
+    const current = {...config, agentContextHome: home};
+    const processStart = formatPsStart((await stat(pidPath)).mtime);
+    const expectedCommand = [
+      process.execPath,
+      server,
+      '--config',
+      join(home, 'ov.conf'),
+      '--host',
+      current.host,
+      '--port',
+      String(current.port),
+    ].join(' ');
+
+    await Effect.runPromise(
+      stopDetachedOpenVikingServerForLaunchd(current, false, 2000).pipe(
+        Effect.provide(launchdProcessTestLayer(processStart, expectedCommand, child.pid!)),
+      ),
+    );
+
+    expect(child.signalCode).toBe('SIGTERM');
+    await expect(access(pidPath)).rejects.toThrow();
+  });
+
+  posixIt('refuses to signal a process when Effect inspection rejects its identity', async () => {
+    const config = runtime();
+    const home = await mkdtemp(join(tmpdir(), 'threadnote-detached-test-'));
+    temporaryDirectories.push(home);
+    const server = join(home, 'openviking-server');
+    await writeFile(server, `#!${process.execPath}\n`);
+    await chmod(server, 0o755);
+    process.env.PATH = home;
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {stdio: 'ignore'});
+    childProcesses.push(child);
+    const pidPath = join(home, 'openviking-server.pid');
+    await writeFile(pidPath, `${child.pid}\n`);
+    const processStart = formatPsStart((await stat(pidPath)).mtime);
+    const expectedCommand = [
+      process.execPath,
+      server,
+      '--config',
+      join(home, 'ov.conf'),
+      '--host',
+      config.host,
+      '--port',
+      String(config.port),
+    ].join(' ');
+
+    await expect(
+      Effect.runPromise(
+        stopDetachedOpenVikingServerForLaunchd({...config, agentContextHome: home}, false, 2000).pipe(
+          Effect.provide(
+            launchdProcessTestLayer(processStart, [expectedCommand, '/usr/bin/unrelated --malicious'], child.pid!),
+          ),
+        ),
+      ),
+    ).rejects.toThrow('Refusing to stop process');
+
+    expect(child.exitCode).toBeNull();
+  });
+
+  it('removes a malformed pid file without signaling a process', async () => {
+    const config = runtime();
+    const home = await mkdtemp(join(tmpdir(), 'threadnote-detached-test-'));
+    temporaryDirectories.push(home);
+    const pidPath = join(home, 'openviking-server.pid');
+    await writeFile(pidPath, '');
+
+    const stopped = await Effect.runPromise(
+      stopDetachedOpenVikingServerForLaunchd({...config, agentContextHome: home}, false).pipe(
+        Effect.provide(ApplicationLayer),
+      ),
+    );
+
+    expect(stopped).toBe(false);
+    await expect(access(pidPath)).rejects.toThrow();
+  });
+
+  posixIt('propagates pid file read failures', async () => {
+    const config = runtime();
+    const home = await mkdtemp(join(tmpdir(), 'threadnote-detached-test-'));
+    temporaryDirectories.push(home);
+    const pidPath = join(home, 'openviking-server.pid');
+    await mkdir(pidPath);
+
+    await expect(
+      Effect.runPromise(
+        stopDetachedOpenVikingServerForLaunchd({...config, agentContextHome: home}, false).pipe(
+          Effect.provide(ApplicationLayer),
+        ),
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/test/unit/lifecycle.launchd.test.ts
+++ b/test/unit/lifecycle.launchd.test.ts
@@ -1,0 +1,503 @@
+import {access, mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {NodeFileSystem} from '@effect/platform-node';
+import {expect, it} from '@effect/vitest';
+import {Effect, Fiber} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe} from 'vitest';
+import {
+  activateLaunchAgent,
+  isExpectedLaunchdProcessCommand,
+  launchAgentHealthIsStable,
+  stageLaunchAgentPlist,
+  waitForLaunchAgentHealthWithEffects,
+  type LaunchAgentActivationEffects,
+  type LaunchAgentHealthEffects,
+} from '../../src/lifecycle.js';
+import type {RuntimeConfig} from '../../src/types.js';
+
+function runtime(): RuntimeConfig {
+  return {
+    account: 'local',
+    agentContextHome: '/tmp/threadnote-launchd-test',
+    agentId: 'threadnote',
+    host: '127.0.0.1',
+    manifestPath: '/tmp/threadnote-launchd-test/seed-manifest.yaml',
+    openVikingVersion: '0.4.10',
+    port: 1933,
+    user: 'denys',
+  };
+}
+
+function activationEffects(
+  events: string[],
+  overrides: Partial<LaunchAgentActivationEffects> = {},
+): LaunchAgentActivationEffects {
+  const record = <A>(event: string, value: A): Effect.Effect<A> =>
+    Effect.sync(() => {
+      events.push(event);
+      return value;
+    });
+  return {
+    bootout: () => record('bootout', true),
+    bootstrap: () => record('bootstrap', undefined),
+    isPortOpen: () => record('port', false),
+    stagePlist: () =>
+      record('stage', {
+        hadPrevious: false,
+        commit: record('commit', undefined),
+        release: record('release', undefined),
+        rollback: record('rollback', undefined),
+      }),
+    stopDetached: () => record('stop-detached', false),
+    restartDetached: () => record('restart-detached', undefined),
+    waitForHealth: () => record('health', 'healthy'),
+    waitForShutdown: () => record('shutdown', true),
+    ...overrides,
+  };
+}
+
+describe('activateLaunchAgent', () => {
+  it.effect('moves a loaded detached server to launchd before accepting health', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const health = yield* activateLaunchAgent(
+        runtime(),
+        '/tmp/threadnote.plist',
+        '<plist/>',
+        60_000,
+        activationEffects(events),
+      );
+
+      expect(health).toBe('healthy');
+      expect(events).toEqual([
+        'stage',
+        'bootout',
+        'stop-detached',
+        'shutdown',
+        'port',
+        'commit',
+        'bootstrap',
+        'health',
+        'release',
+      ]);
+    }),
+  );
+
+  it.effect('refuses to bootstrap while another healthy server remains', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const effects = activationEffects(events, {
+        waitForShutdown: () =>
+          Effect.sync(() => {
+            events.push('shutdown');
+            return false;
+          }),
+      });
+
+      const error = yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 60_000, effects).pipe(
+        Effect.flip,
+      );
+      expect(String(error)).toContain('still running outside Threadnote');
+      expect(events).toEqual(['stage', 'bootout', 'stop-detached', 'shutdown', 'rollback', 'bootstrap', 'release']);
+    }),
+  );
+
+  it.effect('refuses to bootstrap while the configured port remains occupied', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const effects = activationEffects(events, {
+        isPortOpen: () =>
+          Effect.sync(() => {
+            events.push('port');
+            return true;
+          }),
+      });
+
+      const error = yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 60_000, effects).pipe(
+        Effect.flip,
+      );
+      expect(String(error)).toContain('Port 127.0.0.1:1933 is still in use');
+      expect(events).toEqual([
+        'stage',
+        'bootout',
+        'stop-detached',
+        'shutdown',
+        'port',
+        'rollback',
+        'bootstrap',
+        'release',
+      ]);
+    }),
+  );
+
+  it.effect('passes one decreasing timeout budget through activation', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const timeouts: number[] = [];
+      const timed = <A>(event: string, timeoutMs: number, value: A) =>
+        Effect.gen(function* () {
+          timeouts.push(timeoutMs);
+          events.push(event);
+          yield* TestClock.adjust(10);
+          return value;
+        });
+      const effects = activationEffects(events, {
+        bootout: timeoutMs => timed('bootout', timeoutMs, true),
+        bootstrap: (_plistPath, timeoutMs) => timed('bootstrap', timeoutMs, undefined),
+        stopDetached: (_config, timeoutMs) => timed('stop-detached', timeoutMs, false),
+        waitForShutdown: (_config, timeoutMs) => timed('shutdown', timeoutMs, true),
+        isPortOpen: (_config, timeoutMs) => timed('port', timeoutMs, false),
+        waitForHealth: (_config, timeoutMs) => timed('health', timeoutMs, 'healthy'),
+      });
+
+      yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 1000, effects);
+
+      expect(timeouts).toHaveLength(6);
+      expect(timeouts.every(timeoutMs => timeoutMs > 0 && timeoutMs <= 1000)).toBe(true);
+      expect(timeouts.every((timeoutMs, index) => index === 0 || timeoutMs < timeouts[index - 1]!)).toBe(true);
+      expect(events).toEqual([
+        'stage',
+        'bootout',
+        'stop-detached',
+        'shutdown',
+        'port',
+        'commit',
+        'bootstrap',
+        'health',
+        'release',
+      ]);
+    }),
+  );
+
+  it.effect('enforces the outer deadline and does not start the next activation boundary', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const effects = activationEffects(events, {
+        bootout: () =>
+          Effect.gen(function* () {
+            events.push('bootout');
+            yield* Effect.never;
+            return true;
+          }),
+      });
+      const fiber = yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 1000, effects).pipe(
+        Effect.flip,
+        Effect.forkChild,
+      );
+
+      yield* TestClock.adjust(1000);
+
+      expect(String(yield* Fiber.join(fiber))).toContain('timed out');
+      expect(events).toEqual(['stage', 'bootout', 'rollback', 'release']);
+    }),
+  );
+
+  it.effect('rolls back the staged plist and restores the previous service after bootstrap fails', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const record = (event: string) =>
+        Effect.sync(() => {
+          events.push(event);
+        });
+      const effects = activationEffects(events, {
+        bootstrap: () => record('bootstrap').pipe(Effect.andThen(Effect.fail(new Error('bootstrap failed')))),
+        stagePlist: () =>
+          Effect.succeed({
+            hadPrevious: true,
+            commit: record('commit'),
+            release: record('release'),
+            rollback: record('rollback'),
+          }),
+      });
+
+      const error = yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 60_000, effects).pipe(
+        Effect.flip,
+      );
+
+      expect(String(error)).toContain('bootstrap failed');
+      expect(events).toEqual([
+        'bootout',
+        'stop-detached',
+        'shutdown',
+        'port',
+        'commit',
+        'bootstrap',
+        'bootout',
+        'rollback',
+        'bootstrap',
+        'release',
+      ]);
+    }),
+  );
+
+  it.effect('does not start a previously unloaded launch agent during recovery', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const effects = activationEffects(events, {
+        bootout: () =>
+          Effect.sync(() => {
+            events.push('bootout');
+            return events.filter(event => event === 'bootout').length > 1;
+          }),
+        bootstrap: () => Effect.fail(new Error('bootstrap failed')),
+      });
+
+      yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 60_000, effects).pipe(Effect.flip);
+
+      expect(events).toEqual([
+        'stage',
+        'bootout',
+        'stop-detached',
+        'shutdown',
+        'port',
+        'commit',
+        'bootout',
+        'rollback',
+        'release',
+      ]);
+    }),
+  );
+
+  it.effect('restarts a detached server that the failed migration stopped', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const effects = activationEffects(events, {
+        bootout: () =>
+          Effect.sync(() => {
+            events.push('bootout');
+            return false;
+          }),
+        bootstrap: () => Effect.fail(new Error('bootstrap failed')),
+        stopDetached: () =>
+          Effect.sync(() => {
+            events.push('stop-detached');
+            return true;
+          }),
+      });
+
+      yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 60_000, effects).pipe(Effect.flip);
+
+      expect(events).toContain('restart-detached');
+      expect(events).not.toContain('bootstrap');
+    }),
+  );
+
+  it.effect('surfaces recovery failure together with the activation failure', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const effects = activationEffects(events, {
+        bootstrap: () => Effect.fail(new Error('bootstrap failed')),
+        stagePlist: () =>
+          Effect.succeed({
+            hadPrevious: true,
+            commit: Effect.void,
+            release: Effect.void,
+            rollback: Effect.fail(new Error('rollback failed')),
+          }),
+      });
+
+      const error = yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 60_000, effects).pipe(
+        Effect.flip,
+      );
+
+      expect(String(error)).toContain('bootstrap failed');
+      expect(String(error)).toContain('rollback failed');
+    }),
+  );
+
+  it.effect('bounds stalled recovery with a separate cleanup timeout', () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const effects = activationEffects(events, {
+        bootstrap: () => Effect.fail(new Error('bootstrap failed')),
+        stagePlist: () =>
+          Effect.succeed({
+            hadPrevious: true,
+            commit: Effect.void,
+            release: Effect.void,
+            rollback: Effect.never,
+          }),
+      });
+      const fiber = yield* activateLaunchAgent(runtime(), '/tmp/threadnote.plist', '<plist/>', 60_000, effects).pipe(
+        Effect.flip,
+        Effect.forkChild,
+      );
+
+      yield* TestClock.adjust(2000);
+
+      expect(String(yield* Fiber.join(fiber))).toContain('recovery timed out');
+    }),
+  );
+});
+
+describe('stageLaunchAgentPlist', () => {
+  it('atomically commits and restores a mode-0600 staged plist', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'threadnote-plist-test-'));
+    const plistPath = join(directory, 'agent.plist');
+    const stagePath = `${plistPath}.threadnote-stage-${process.pid}`;
+    await writeFile(plistPath, 'previous');
+    try {
+      const transaction = await Effect.runPromise(
+        stageLaunchAgentPlist(plistPath, 'replacement').pipe(Effect.provide(NodeFileSystem.layer)),
+      );
+      expect((await stat(stagePath)).mode & 0o777).toBe(0o600);
+      await Effect.runPromise(transaction.commit);
+      expect(await readFile(plistPath, 'utf8')).toBe('replacement');
+      await Effect.runPromise(transaction.rollback);
+      expect(await readFile(plistPath, 'utf8')).toBe('previous');
+      await Effect.runPromise(transaction.release);
+      await expect(access(`${plistPath}.threadnote-lock`)).rejects.toThrow();
+    } finally {
+      await rm(directory, {force: true, recursive: true});
+    }
+  });
+
+  it('refuses to overwrite a concurrent destination edit', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'threadnote-plist-test-'));
+    const plistPath = join(directory, 'agent.plist');
+    await writeFile(plistPath, 'previous');
+    try {
+      const transaction = await Effect.runPromise(
+        stageLaunchAgentPlist(plistPath, 'replacement').pipe(Effect.provide(NodeFileSystem.layer)),
+      );
+      await writeFile(plistPath, 'external edit');
+
+      await expect(Effect.runPromise(transaction.commit)).rejects.toThrow('changed while activation was staged');
+      expect(await readFile(plistPath, 'utf8')).toBe('external edit');
+      await expect(Effect.runPromise(transaction.rollback)).rejects.toThrow(
+        'changed before activation could roll back',
+      );
+      expect(await readFile(plistPath, 'utf8')).toBe('external edit');
+      await Effect.runPromise(transaction.release);
+    } finally {
+      await rm(directory, {force: true, recursive: true});
+    }
+  });
+});
+
+describe('launchAgentHealthIsStable', () => {
+  it('requires the same running launchd pid before and after health responds', () => {
+    expect(
+      launchAgentHealthIsStable({loaded: true, pid: 42, running: true}, 'healthy', {
+        loaded: true,
+        pid: 42,
+        running: true,
+      }),
+    ).toBe(true);
+    expect(
+      launchAgentHealthIsStable({loaded: true, pid: 42, running: true}, 'healthy', {
+        loaded: true,
+        pid: 43,
+        running: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isExpectedLaunchdProcessCommand', () => {
+  const server = '/Users/test/.local/bin/openviking-server';
+  const interpreter = '/usr/bin/python3';
+  const args = ['--config', '/Users/test/.openviking/ov.conf', '--host', '127.0.0.1', '--port', '1933'];
+
+  it('accepts only a direct command or its verified shebang interpreter', () => {
+    const direct = [server, ...args].join(' ');
+
+    expect(isExpectedLaunchdProcessCommand(direct, server, args, interpreter)).toBe(true);
+    expect(isExpectedLaunchdProcessCommand(`${interpreter} ${direct}`, server, args, interpreter)).toBe(true);
+    expect(isExpectedLaunchdProcessCommand(`/usr/bin/ruby ${direct}`, server, args, interpreter)).toBe(false);
+  });
+
+  it('rejects an unrelated process padded with the expected arguments', () => {
+    const direct = [server, ...args].join(' ');
+
+    expect(isExpectedLaunchdProcessCommand(`/usr/bin/node -e malicious 1933 ${direct}`, server, args)).toBe(false);
+  });
+});
+
+describe('waitForLaunchAgentHealth', () => {
+  it.effect('retries a pid change and requires the launchd pid to own the port', () =>
+    Effect.gen(function* () {
+      const timeouts: number[] = [];
+      const statuses = [
+        {loaded: true, pid: 42, running: true},
+        {loaded: true, pid: 43, running: true},
+        {loaded: true, pid: 43, running: true},
+        {loaded: true, pid: 43, running: true},
+      ];
+      const effects: LaunchAgentHealthEffects = {
+        ownsPort: (_pid, _config, timeoutMs) =>
+          Effect.gen(function* () {
+            timeouts.push(timeoutMs);
+            yield* Effect.sleep(10);
+            return true;
+          }),
+        readHealth: (_config, timeoutMs) =>
+          Effect.gen(function* () {
+            timeouts.push(timeoutMs);
+            yield* Effect.sleep(10);
+            return 'healthy';
+          }),
+        readStatus: timeoutMs =>
+          Effect.gen(function* () {
+            timeouts.push(timeoutMs);
+            yield* Effect.sleep(10);
+            return statuses.shift() ?? {loaded: true, pid: 43, running: true};
+          }),
+      };
+      const fiber = yield* waitForLaunchAgentHealthWithEffects(runtime(), 2000, 'waiting', effects).pipe(
+        Effect.forkChild,
+      );
+
+      yield* TestClock.adjust(1000);
+
+      expect(yield* Fiber.join(fiber)).toBe('healthy');
+      expect(timeouts).toHaveLength(10);
+      expect(timeouts.every(timeoutMs => timeoutMs > 0 && timeoutMs <= 1000)).toBe(true);
+      expect(timeouts.every((timeoutMs, index) => index === 0 || timeoutMs <= timeouts[index - 1]!)).toBe(true);
+    }),
+  );
+
+  it.effect('retries healthy responses until the launchd pid owns the port before and after the request', () =>
+    Effect.gen(function* () {
+      let ownershipChecks = 0;
+      let healthChecks = 0;
+      const effects: LaunchAgentHealthEffects = {
+        ownsPort: () => Effect.succeed(++ownershipChecks > 1),
+        readHealth: () =>
+          Effect.sync(() => {
+            healthChecks += 1;
+            return 'healthy';
+          }),
+        readStatus: () => Effect.succeed({loaded: true, pid: 42, running: true}),
+      };
+      const fiber = yield* waitForLaunchAgentHealthWithEffects(runtime(), 2000, 'waiting', effects).pipe(
+        Effect.forkChild,
+      );
+
+      yield* TestClock.adjust(500);
+
+      expect(yield* Fiber.join(fiber)).toBe('healthy');
+      expect(ownershipChecks).toBe(3);
+      expect(healthChecks).toBe(1);
+    }),
+  );
+
+  it.effect('stops polling when the deadline expires', () =>
+    Effect.gen(function* () {
+      const effects: LaunchAgentHealthEffects = {
+        ownsPort: () => Effect.succeed(false),
+        readHealth: () => Effect.succeed(undefined),
+        readStatus: () => Effect.succeed({loaded: true, running: false}),
+      };
+      const fiber = yield* waitForLaunchAgentHealthWithEffects(runtime(), 1000, 'waiting', effects).pipe(
+        Effect.forkChild,
+      );
+
+      yield* TestClock.adjust(1000);
+
+      expect(yield* Fiber.join(fiber)).toBeUndefined();
+    }),
+  );
+});


### PR DESCRIPTION
## What changed

- migrate the macOS launchd lifecycle to Effect-native orchestration with bounded `launchctl` commands
- transition safely from a managed detached server and verify process/socket ownership
- apply full-response HTTP timeouts and add focused launchd lifecycle tests

## Why

`threadnote start --launchd` could leave a detached OpenViking server holding the data lock while launchd failed, then incorrectly accept health from that unrelated process. This prevented reliable startup after a macOS reboot.

## Validation

- 466 tests across 43 files
- TypeScript checks for source and tests
- oxlint
- Prettier
- build and bundle-size checks
- `threadnote start --launchd --dry-run`

## Review status

Draft: the capped local dev-cycle review still reports unresolved issues around transactional cleanup, Effect interruption races, and lock ownership/release. Those findings require follow-up review and fixes before merge.
