### PR TITLE
Add beta update channel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,4 +47,12 @@ jobs:
 
       # No NODE_AUTH_TOKEN: auth comes from the OIDC trusted publisher.
       # Provenance is attached automatically; --provenance makes it explicit.
-      - run: npm publish --provenance --access public
+      - name: Publish to npm
+        env:
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          tag=latest
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            tag=beta
+          fi
+          npm publish --provenance --access public --tag "$tag"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ New to Threadnote? Ask your agent **"what can I do with Threadnote?"** — it ca
 (server health, configured share teams, seeded projects) and offers to run each step
 with you. The walkthrough only loads when you ask, so it never sits in context otherwise.
 
+## Updates
+
+```bash
+threadnote update         # latest stable release
+threadnote update --beta  # latest beta release
+```
+
+Stable installs only report and install stable releases. After opting into a beta, ordinary `threadnote version` and
+`threadnote update` calls stay on the beta channel until a stable Threadnote version is installed again.
+
 ## Why Not Just Markdown Files?
 
 Use Markdown files. Threadnote makes them operational.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1282,7 +1282,9 @@ worksets:
               </div>
               <p class="muted" style="font-size: 0.9rem; margin-top: 0.75rem">
                 <code>update --check</code> reports what's available. <code>update --dry-run</code> shows the plan.
-                Releases may include post-update memory migrations that prompt before applying.
+                <code>update --beta</code> opts into beta releases; after that, ordinary version and update checks stay
+                on the beta channel. Stable installs do not advertise betas. Releases may include post-update memory
+                migrations that prompt before applying.
               </p>
             </div>
 

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -209,6 +209,7 @@ const update = Command.make(
       'allow-untrusted-registry',
       'Allow a non-default npm registry without package signature verification',
     ),
+    beta: boolean('beta', 'Update to the latest beta release'),
     check: boolean('check', 'Only check whether a newer version is available'),
     dryRun: boolean('dry-run', 'Print update and repair commands without running them'),
     force: boolean('force', 'Run package-manager update even if this version is already current'),

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -43,6 +43,7 @@ import {
 import {collectDoctorChecks, runRepair, runStart} from './lifecycle.js';
 import {runSeed, runSeedSkills} from './seeding.js';
 import {currentPackageVersion, fetchLatestVersion, updateRegistry} from './update.js';
+import {selectUpdateChannel} from './update_channel.js';
 import type {
   AgentClient,
   ConsolidationAgent,
@@ -320,7 +321,10 @@ function handleRequestEffect(
       const latest = yield* Effect.try({
         try: updateRegistry,
         catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-      }).pipe(Effect.flatMap(fetchLatestVersion), Effect.match({onFailure: Result.fail, onSuccess: Result.succeed}));
+      }).pipe(
+        Effect.flatMap(registry => fetchLatestVersion(registry, selectUpdateChannel(version))),
+        Effect.match({onFailure: Result.fail, onSuccess: Result.succeed}),
+      );
       writeJson(response, 200, {
         agents,
         config: publicConfig(context.config),

--- a/src/release_notes.ts
+++ b/src/release_notes.ts
@@ -12,7 +12,13 @@ export interface ReleaseNote {
   readonly version: string;
 }
 
-export const fetchThreadnoteReleaseNotes = Effect.fn('fetchThreadnoteReleaseNotes')(function* () {
+interface ReleaseNotesOptions {
+  readonly includePrereleases?: boolean;
+}
+
+export const fetchThreadnoteReleaseNotes = Effect.fn('fetchThreadnoteReleaseNotes')(function* (
+  options: ReleaseNotesOptions = {},
+) {
   const response = yield* getJsonEffect(GITHUB_RELEASES_URL, {
     headers: {
       accept: 'application/vnd.github+json',
@@ -23,7 +29,7 @@ export const fetchThreadnoteReleaseNotes = Effect.fn('fetchThreadnoteReleaseNote
   if (!Array.isArray(response.body)) {
     return yield* Effect.fail(new Error('GitHub releases response was not an array.'));
   }
-  return response.body.flatMap(parseGithubRelease);
+  return response.body.flatMap(value => parseGithubRelease(value, options.includePrereleases === true));
 });
 
 export function releasesBetween(
@@ -57,21 +63,23 @@ export function formatWhatsNew(releases: readonly ReleaseNote[]): readonly strin
   return lines;
 }
 
-export const whatsNewLinesForVersion = Effect.fn('whatsNewLinesForVersion')((version: string) =>
-  fetchThreadnoteReleaseNotes().pipe(
-    Effect.map(releases => {
-      const lines = formatWhatsNew(releaseForVersion(releases, version));
-      return lines.length > 0 ? lines : ["What's new:", `No GitHub release notes found for ${version}.`];
-    }),
-    Effect.catch(error => Effect.succeed([`What's new: unavailable (${errorMessage(error)})`])),
-  ),
+export const whatsNewLinesForVersion = Effect.fn('whatsNewLinesForVersion')(
+  (version: string, options: ReleaseNotesOptions = {}) =>
+    fetchThreadnoteReleaseNotes(options).pipe(
+      Effect.map(releases => {
+        const lines = formatWhatsNew(releaseForVersion(releases, version));
+        return lines.length > 0 ? lines : ["What's new:", `No GitHub release notes found for ${version}.`];
+      }),
+      Effect.catch(error => Effect.succeed([`What's new: unavailable (${errorMessage(error)})`])),
+    ),
 );
 
 export const whatsNewLinesForVersionRange = Effect.fn('whatsNewLinesForVersionRange')(function (
   currentVersion: string,
   latestVersion: string,
+  options: ReleaseNotesOptions = {},
 ) {
-  return fetchThreadnoteReleaseNotes().pipe(
+  return fetchThreadnoteReleaseNotes(options).pipe(
     Effect.map(releases => {
       const lines = formatWhatsNew(releasesBetween(releases, currentVersion, latestVersion));
       return lines.length > 0 ? lines : ["What's new:", 'No GitHub release notes found for this version range.'];
@@ -80,8 +88,8 @@ export const whatsNewLinesForVersionRange = Effect.fn('whatsNewLinesForVersionRa
   );
 });
 
-function parseGithubRelease(value: unknown): readonly ReleaseNote[] {
-  if (!isJsonObject(value) || value.draft === true || value.prerelease === true) {
+function parseGithubRelease(value: unknown, includePrereleases: boolean): readonly ReleaseNote[] {
+  if (!isJsonObject(value) || value.draft === true || (!includePrereleases && value.prerelease === true)) {
     return [];
   }
   const tagName = typeof value.tag_name === 'string' ? value.tag_name : '';

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,7 @@ export interface UninstallOptions {
 
 export interface UpdateOptions {
   readonly allowUntrustedRegistry?: boolean;
+  readonly beta?: boolean;
   readonly check?: boolean;
   readonly dryRun?: boolean;
   readonly force?: boolean;

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -4,16 +4,18 @@ import {dirname} from 'node:path';
 import {Effect} from 'effect';
 import {getJsonEffect} from './effect/http.js';
 import {fromPromiseError} from './effect/errors.js';
+import {selectUpdateChannel, type UpdateChannel} from './update_channel.js';
 import {compareVersions, isJsonObject} from './utils.js';
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-const NPM_LATEST_URL = 'https://registry.npmjs.org/threadnote/latest';
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org/threadnote/';
 const FETCH_TIMEOUT_MS = 3000;
 
 interface UpdateCacheFile {
+  readonly channel: UpdateChannel;
   readonly checkedAt: string;
   readonly latestVersion: string;
-  readonly version: 1;
+  readonly version: 2;
 }
 
 export interface UpdateCheckResult {
@@ -39,22 +41,25 @@ export function checkForThreadnoteUpdate(args: {readonly cachePath: string; read
     return Effect.succeed(undefined);
   }
   return Effect.gen(function* () {
+    const channel = selectUpdateChannel(args.currentVersion);
     const cached = yield* fromPromiseError(() => readUpdateCache(args.cachePath));
-    if (cached && isCacheFresh(cached)) {
-      return toUpdateCheckResult(args.currentVersion, cached.latestVersion);
+    const channelCache = cached?.channel === channel ? cached : undefined;
+    if (channelCache && isCacheFresh(channelCache)) {
+      return toUpdateCheckResult(args.currentVersion, channelCache.latestVersion);
     }
-    const fresh = yield* fetchLatestVersionEffect();
+    const fresh = yield* fetchLatestVersionEffect(channel);
     if (fresh) {
       yield* fromPromiseError(() =>
         writeUpdateCache(args.cachePath, {
+          channel,
           checkedAt: new Date().toISOString(),
           latestVersion: fresh,
-          version: 1,
+          version: 2,
         }),
       );
       return toUpdateCheckResult(args.currentVersion, fresh);
     }
-    return cached ? toUpdateCheckResult(args.currentVersion, cached.latestVersion) : undefined;
+    return channelCache ? toUpdateCheckResult(args.currentVersion, channelCache.latestVersion) : undefined;
   });
 }
 
@@ -100,10 +105,20 @@ async function readUpdateCache(cachePath: string): Promise<UpdateCacheFile | und
   try {
     const raw = await readFile(cachePath, 'utf8');
     const parsed = JSON.parse(raw) as Partial<UpdateCacheFile>;
-    if (parsed.version !== 1 || typeof parsed.latestVersion !== 'string' || typeof parsed.checkedAt !== 'string') {
+    if (
+      parsed.version !== 2 ||
+      (parsed.channel !== 'beta' && parsed.channel !== 'latest') ||
+      typeof parsed.latestVersion !== 'string' ||
+      typeof parsed.checkedAt !== 'string'
+    ) {
       return undefined;
     }
-    return {checkedAt: parsed.checkedAt, latestVersion: parsed.latestVersion, version: 1};
+    return {
+      channel: parsed.channel,
+      checkedAt: parsed.checkedAt,
+      latestVersion: parsed.latestVersion,
+      version: 2,
+    };
   } catch {
     return undefined;
   }
@@ -118,8 +133,11 @@ async function writeUpdateCache(cachePath: string, contents: UpdateCacheFile): P
   }
 }
 
-const fetchLatestVersionEffect = Effect.fn('fetchLatestHookVersion')(() =>
-  getJsonEffect(NPM_LATEST_URL, {headers: {accept: 'application/json'}, timeoutMs: FETCH_TIMEOUT_MS}).pipe(
+const fetchLatestVersionEffect = Effect.fn('fetchLatestHookVersion')((channel: UpdateChannel) =>
+  getJsonEffect(`${NPM_REGISTRY_URL}${channel}`, {
+    headers: {accept: 'application/json'},
+    timeoutMs: FETCH_TIMEOUT_MS,
+  }).pipe(
     Effect.map(response =>
       isJsonObject(response.body) && typeof response.body.version === 'string' && response.body.version.length > 0
         ? response.body.version

--- a/src/update.ts
+++ b/src/update.ts
@@ -13,6 +13,7 @@ import {pollUntilEffect} from './effect/time.js';
 import {hasLegacyLifecycleHandoffCandidates, hasProjectNameMigrationCandidates} from './memory.js';
 import {whatsNewLinesForVersionRange} from './release_notes.js';
 import type {JsonObject, PostUpdateOptions, RuntimeConfig, UpdateOptions, UpdateRuntime} from './types.js';
+import {selectUpdateChannel, type UpdateChannel} from './update_channel.js';
 import {
   compareVersions,
   ensureDirectory,
@@ -39,6 +40,7 @@ const POST_UPDATE_MIGRATIONS_FILE = 'post-update-migrations.json';
 const POST_UPDATE_STATE_FILE = 'post-update-state.json';
 
 interface UpdateInfo {
+  readonly channel: UpdateChannel;
   readonly currentVersion: string;
   readonly isUpdateAvailable: boolean;
   readonly latestVersion: string;
@@ -46,6 +48,7 @@ interface UpdateInfo {
 }
 
 interface UpdateCache {
+  readonly channel: UpdateChannel;
   readonly checkedAt: string;
   readonly latestVersion: string;
   readonly registry: string;
@@ -81,6 +84,7 @@ export function maybeNotifyUpdate(config: RuntimeConfig, options: {readonly dryR
     Effect.flatMap(registry =>
       getUpdateInfo(config, {
         allowCacheWrite: options.dryRun !== true,
+        betaRequested: false,
         preferFresh: false,
         registry,
       }),
@@ -107,6 +111,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     'Checking npm for latest threadnote version',
     getUpdateInfo(config, {
       allowCacheWrite: options.dryRun !== true,
+      betaRequested: options.beta === true,
       preferFresh: true,
       registry,
     }),
@@ -114,19 +119,22 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
 
   yield* syncWithConsole(() => {
     consoleOutput.log(keyValue('Current version', infoText(info.currentVersion)));
-    consoleOutput.log(keyValue('Latest version', infoText(info.latestVersion)));
+    consoleOutput.log(
+      keyValue(info.channel === 'beta' ? 'Latest beta version' : 'Latest version', infoText(info.latestVersion)),
+    );
     consoleOutput.log(keyValue('Registry', info.registry));
   });
 
   if (options.check === true) {
     if (info.isUpdateAvailable) {
-      yield* syncWithConsole(() => consoleOutput.log(warning('Update available. Run: threadnote update')));
+      const command = options.beta === true ? 'threadnote update --beta' : 'threadnote update';
+      yield* syncWithConsole(() => consoleOutput.log(warning(`Update available. Run: ${command}`)));
       yield* printWhatsNewIfAvailable(info);
     } else {
       yield* syncWithConsole(() =>
         consoleOutput.log(
           compareVersions(info.currentVersion, info.latestVersion) > 0
-            ? warning('Current version is newer than npm latest.')
+            ? warning(`Current version is newer than npm ${info.channel}.`)
             : success('Threadnote is up to date.'),
         ),
       );
@@ -140,7 +148,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   }
 
   const runtime = yield* fromPromise('resolve update runtime', () => resolveUpdateRuntime(options.runtime ?? 'auto'));
-  const updateCommand = updatePackageCommand(runtime, registry);
+  const updateCommand = updatePackageCommand(runtime, registry, info.channel);
   yield* runStreamingSubcommand(options.dryRun === true, updateCommand.executable, updateCommand.args);
 
   if (options.repair === false) {
@@ -188,7 +196,9 @@ function printWhatsNewIfAvailable(info: UpdateInfo) {
     yield* syncWithConsole(() => consoleOutput.log(''));
     const whatsNew = yield* withSpinnerEffect(
       'Fetching GitHub release notes',
-      whatsNewLinesForVersionRange(info.currentVersion, info.latestVersion),
+      whatsNewLinesForVersionRange(info.currentVersion, info.latestVersion, {
+        includePrereleases: info.channel === 'beta',
+      }),
     );
     yield* syncWithConsole(() => {
       for (const line of whatsNew) {
@@ -471,22 +481,30 @@ function getUpdateInfo(
   config: RuntimeConfig,
   options: {
     readonly allowCacheWrite: boolean;
+    readonly betaRequested: boolean;
     readonly preferFresh: boolean;
     readonly registry: string;
   },
 ) {
   return Effect.gen(function* () {
     const currentVersion = yield* fromPromise('read current package version', currentPackageVersion);
+    const channel = selectUpdateChannel(currentVersion, options.betaRequested);
     const cached = options.preferFresh
       ? undefined
-      : yield* fromPromise('read update cache', () => readFreshCache(config, options.registry));
-    const latestVersion = cached?.latestVersion ?? (yield* fetchLatestVersion(options.registry));
+      : yield* fromPromise('read update cache', () => readFreshCache(config, options.registry, channel));
+    const latestVersion = cached?.latestVersion ?? (yield* fetchLatestVersion(options.registry, channel));
     if (!cached && options.allowCacheWrite) {
       yield* fromPromise('write update cache', () =>
-        writeUpdateCache(config, {checkedAt: new Date().toISOString(), latestVersion, registry: options.registry}),
+        writeUpdateCache(config, {
+          channel,
+          checkedAt: new Date().toISOString(),
+          latestVersion,
+          registry: options.registry,
+        }),
       );
     }
     return {
+      channel,
       currentVersion,
       isUpdateAvailable: compareVersions(currentVersion, latestVersion) < 0,
       latestVersion,
@@ -497,10 +515,13 @@ function getUpdateInfo(
 
 export {currentPackageVersion};
 
-export const fetchLatestVersion = Effect.fn('fetchLatestVersion')(function* (registry: string) {
+export const fetchLatestVersion = Effect.fn('fetchLatestVersion')(function* (
+  registry: string,
+  channel: UpdateChannel = 'latest',
+) {
   const url = yield* fromSync(
     'build npm registry URL',
-    () => new URL(`${NPM_PACKAGE_NAME}/latest`, normalizeRegistry(registry)),
+    () => new URL(`${NPM_PACKAGE_NAME}/${channel}`, normalizeRegistry(registry)),
   );
   const response = yield* getJsonEffect(url, {headers: {accept: 'application/json'}, timeoutMs: 2500}).pipe(
     Effect.mapError(cause =>
@@ -518,7 +539,11 @@ export const fetchLatestVersion = Effect.fn('fetchLatestVersion')(function* (reg
   return response.body.version;
 });
 
-async function readFreshCache(config: RuntimeConfig, registry: string): Promise<UpdateCache | undefined> {
+async function readFreshCache(
+  config: RuntimeConfig,
+  registry: string,
+  channel: UpdateChannel,
+): Promise<UpdateCache | undefined> {
   const rawCache = await readFileIfExists(updateCachePath(config));
   if (!rawCache) {
     return undefined;
@@ -527,6 +552,7 @@ async function readFreshCache(config: RuntimeConfig, registry: string): Promise<
     const parsed: unknown = JSON.parse(rawCache);
     if (
       !isJsonObject(parsed) ||
+      parsed.channel !== channel ||
       typeof parsed.checkedAt !== 'string' ||
       typeof parsed.latestVersion !== 'string' ||
       parsed.registry !== registry
@@ -537,7 +563,7 @@ async function readFreshCache(config: RuntimeConfig, registry: string): Promise<
     if (!Number.isFinite(checkedAt) || Date.now() - checkedAt > UPDATE_CHECK_TTL_MS) {
       return undefined;
     }
-    return {checkedAt: parsed.checkedAt, latestVersion: parsed.latestVersion, registry};
+    return {channel, checkedAt: parsed.checkedAt, latestVersion: parsed.latestVersion, registry};
   } catch (_err: unknown) {
     return undefined;
   }
@@ -784,15 +810,17 @@ async function runtimeThreadnoteBin(runtime: Exclude<UpdateRuntime, 'auto'>): Pr
 function updatePackageCommand(
   runtime: Exclude<UpdateRuntime, 'auto'>,
   registry: string,
+  channel: UpdateChannel,
 ): {
   readonly args: readonly string[];
   readonly executable: string;
 } {
+  const packageSpec = `${NPM_PACKAGE_NAME}@${channel}`;
   if (runtime === 'npm') {
-    return {executable: 'npm', args: ['install', '--global', `${NPM_PACKAGE_NAME}@latest`, `--registry=${registry}`]};
+    return {executable: 'npm', args: ['install', '--global', packageSpec, `--registry=${registry}`]};
   }
   if (runtime === 'bun') {
-    return {executable: 'bun', args: ['install', '--global', `${NPM_PACKAGE_NAME}@latest`, `--registry=${registry}`]};
+    return {executable: 'bun', args: ['install', '--global', packageSpec, `--registry=${registry}`]};
   }
   return {
     executable: 'env',
@@ -809,7 +837,7 @@ function updatePackageCommand(
       '--allow-run',
       '--allow-env',
       '--allow-net',
-      `npm:${NPM_PACKAGE_NAME}@latest`,
+      `npm:${packageSpec}`,
     ],
   };
 }

--- a/src/update_channel.ts
+++ b/src/update_channel.ts
@@ -1,0 +1,10 @@
+export type UpdateChannel = 'beta' | 'latest';
+
+export function isBetaVersion(version: string): boolean {
+  const normalized = version.trim().replace(/^v/i, '').split('+', 1)[0] ?? '';
+  return /-beta(?:[.-]?\d+)?(?:[.-]|$)/i.test(normalized);
+}
+
+export function selectUpdateChannel(currentVersion: string, betaRequested = false): UpdateChannel {
+  return betaRequested || isBetaVersion(currentVersion) ? 'beta' : 'latest';
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -501,8 +501,9 @@ export function compareVersions(a: string, b: string): number {
   if (left.suffix === right.suffix) {
     return 0;
   }
-  // Same rank class with distinct suffixes (e.g. rc1 vs rc2) — order lexically.
-  return (left.suffix ?? '').localeCompare(right.suffix ?? '');
+  // Same rank class with distinct suffixes (e.g. beta.2 vs beta.10) — use
+  // numeric collation so multi-digit prerelease identifiers keep semver order.
+  return (left.suffix ?? '').localeCompare(right.suffix ?? '', 'en', {numeric: true});
 }
 
 /** PEP 440 post-releases sort after the release; pre/dev releases before it. */

--- a/src/version_command.ts
+++ b/src/version_command.ts
@@ -3,24 +3,31 @@ import {heading, info, keyValue, success, warning, withSpinnerEffect} from './cl
 import {applicationError, fromPromise} from './effect/errors.js';
 import type {RuntimeConfig, VersionOptions} from './types.js';
 import {currentPackageVersion, fetchLatestVersion, resolveUpdateRegistry} from './update.js';
+import {selectUpdateChannel} from './update_channel.js';
 import {compareVersions, errorMessage} from './utils.js';
 import {whatsNewLinesForVersion, whatsNewLinesForVersionRange} from './release_notes.js';
 
 export const runVersion = Effect.fn('runVersion')(function* (config: RuntimeConfig, options: VersionOptions) {
   const currentVersion = yield* fromPromise('read current package version', currentPackageVersion);
+  const channel = selectUpdateChannel(currentVersion);
   const registry = yield* Effect.try({
     try: () => resolveUpdateRegistry(options.registry, options.allowUntrustedRegistry),
     catch: cause => applicationError('resolve update registry', cause),
   });
   const latest = yield* withSpinnerEffect(
     'Checking npm for latest threadnote version',
-    fetchLatestVersion(registry),
+    fetchLatestVersion(registry, channel),
   ).pipe(Effect.match({onFailure: Result.fail, onSuccess: Result.succeed}));
   const latestVersion = Result.isSuccess(latest) ? latest.success : undefined;
   const latestWarning = Result.isFailure(latest) ? errorMessage(latest.failure) : undefined;
 
   yield* Console.log(keyValue('Current version', info(currentVersion)));
-  yield* Console.log(keyValue('Latest version', latestVersion ? info(latestVersion) : warning('unavailable')));
+  yield* Console.log(
+    keyValue(
+      channel === 'beta' ? 'Latest beta version' : 'Latest version',
+      latestVersion ? info(latestVersion) : warning('unavailable'),
+    ),
+  );
   if (latestWarning) {
     yield* Console.log(warning(`Warning: ${latestWarning}`));
   }
@@ -31,10 +38,13 @@ export const runVersion = Effect.fn('runVersion')(function* (config: RuntimeConf
   const comparison = compareVersions(currentVersion, latestVersion);
   if (comparison >= 0) {
     yield* Console.log(
-      success(comparison > 0 ? 'Current version is newer than npm latest.' : 'Threadnote is up to date.'),
+      success(comparison > 0 ? `Current version is newer than npm ${channel}.` : 'Threadnote is up to date.'),
     );
     yield* Console.log('');
-    const whatsNew = yield* withSpinnerEffect('Fetching GitHub release notes', whatsNewLinesForVersion(currentVersion));
+    const whatsNew = yield* withSpinnerEffect(
+      'Fetching GitHub release notes',
+      whatsNewLinesForVersion(currentVersion, {includePrereleases: channel === 'beta'}),
+    );
     yield* printWhatsNew(whatsNew);
     return;
   }
@@ -42,7 +52,7 @@ export const runVersion = Effect.fn('runVersion')(function* (config: RuntimeConf
   yield* Console.log('');
   const whatsNew = yield* withSpinnerEffect(
     'Fetching GitHub release notes',
-    whatsNewLinesForVersionRange(currentVersion, latestVersion),
+    whatsNewLinesForVersionRange(currentVersion, latestVersion, {includePrereleases: channel === 'beta'}),
   );
   yield* printWhatsNew(whatsNew);
 });

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -19,6 +19,11 @@ describe('Effect CLI', () => {
     expect(result.stdout).toContain('threadnote migrate-project-names [flags]');
   });
 
+  it('exposes beta updates as an explicit opt-in', async () => {
+    const result = await runCli(['update', '--help']);
+    expect(result.stdout).toContain('--beta');
+  });
+
   it('accepts shared runtime flags after the subcommand', async () => {
     const home = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-'));
     try {

--- a/test/unit/release_notes.test.ts
+++ b/test/unit/release_notes.test.ts
@@ -1,5 +1,13 @@
-import {describe, expect, it} from 'vitest';
-import {formatWhatsNew, releaseForVersion, releasesBetween, type ReleaseNote} from '../../src/release_notes.js';
+import {Effect} from 'effect';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {
+  fetchThreadnoteReleaseNotes,
+  formatWhatsNew,
+  releaseForVersion,
+  releasesBetween,
+  type ReleaseNote,
+} from '../../src/release_notes.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 
 const releases: readonly ReleaseNote[] = [
   {
@@ -23,6 +31,44 @@ const releases: readonly ReleaseNote[] = [
     version: '0.7.7',
   },
 ];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchThreadnoteReleaseNotes', () => {
+  it('includes GitHub prereleases only when the beta channel requests them', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json([
+          {
+            body: '- Beta change.',
+            draft: false,
+            name: '3.0.0-beta.1',
+            prerelease: true,
+            tag_name: 'v3.0.0-beta.1',
+          },
+          {
+            body: '- Stable change.',
+            draft: false,
+            name: '2.0.4',
+            prerelease: false,
+            tag_name: 'v2.0.4',
+          },
+        ]),
+      ),
+    );
+
+    const stable = await Effect.runPromise(fetchThreadnoteReleaseNotes().pipe(Effect.provide(ApplicationLayer)));
+    const beta = await Effect.runPromise(
+      fetchThreadnoteReleaseNotes({includePrereleases: true}).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    expect(stable.map(release => release.version)).toEqual(['2.0.4']);
+    expect(beta.map(release => release.version)).toEqual(['3.0.0-beta.1', '2.0.4']);
+  });
+});
 
 describe('releasesBetween', () => {
   it('returns newer releases up to latest in ascending order', () => {

--- a/test/unit/update-check.test.ts
+++ b/test/unit/update-check.test.ts
@@ -27,7 +27,7 @@ describe('Effect update check', () => {
     const cachePath = join(directory, 'update.json');
     await writeFile(
       cachePath,
-      JSON.stringify({checkedAt: new Date().toISOString(), latestVersion: '2.0.0', version: 1}),
+      JSON.stringify({channel: 'latest', checkedAt: new Date().toISOString(), latestVersion: '2.0.0', version: 2}),
       'utf8',
     );
     const fetch = vi.fn();
@@ -44,17 +44,37 @@ describe('Effect update check', () => {
   it('fetches through HttpService and persists a successful result', async () => {
     const directory = await temporaryDirectory();
     const cachePath = join(directory, 'update.json');
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => Response.json({version: '1.2.0'})),
-    );
+    const fetch = vi.fn(async (_url: string | URL) => Response.json({version: '1.2.0'}));
+    vi.stubGlobal('fetch', fetch);
 
     await expect(runCheck(cachePath, '1.1.0')).resolves.toEqual({
       currentVersion: '1.1.0',
       latestVersion: '1.2.0',
       outdated: true,
     });
+    expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/latest'))).toBe(true);
+    await expect(readFile(cachePath, 'utf8')).resolves.toContain('"channel":"latest"');
     await expect(readFile(cachePath, 'utf8')).resolves.toContain('"latestVersion":"1.2.0"');
+  });
+
+  it('uses and caches the beta channel for an installed beta', async () => {
+    const directory = await temporaryDirectory();
+    const cachePath = join(directory, 'update.json');
+    await writeFile(
+      cachePath,
+      JSON.stringify({channel: 'latest', checkedAt: new Date().toISOString(), latestVersion: '2.0.4', version: 2}),
+      'utf8',
+    );
+    const fetch = vi.fn(async (_url: string | URL) => Response.json({version: '3.0.0-beta.2'}));
+    vi.stubGlobal('fetch', fetch);
+
+    await expect(runCheck(cachePath, '3.0.0-beta.1')).resolves.toEqual({
+      currentVersion: '3.0.0-beta.1',
+      latestVersion: '3.0.0-beta.2',
+      outdated: true,
+    });
+    expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/beta'))).toBe(true);
+    await expect(readFile(cachePath, 'utf8')).resolves.toContain('"channel":"beta"');
   });
 });
 

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -70,17 +70,17 @@ async function makeRuntime(): Promise<RuntimeConfig> {
 
 function mockRegistryVersions(latest: string, beta: string) {
   const fetch = vi.fn(async (url: string | URL) => {
-    const href = String(url);
-    if (href.includes('/health')) {
+    const parsed = new URL(url);
+    if (parsed.pathname.includes('/health')) {
       return new Response('healthy');
     }
-    if (href.includes('/threadnote/beta')) {
+    if (parsed.pathname.endsWith('/threadnote/beta')) {
       return Response.json({version: beta});
     }
-    if (href.includes('/threadnote/latest')) {
+    if (parsed.pathname.endsWith('/threadnote/latest')) {
       return Response.json({version: latest});
     }
-    if (href.includes('api.github.com')) {
+    if (parsed.hostname === 'api.github.com') {
       return Response.json([]);
     }
     return new Response('Not found', {status: 404});

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();
   return {
     ...actual,
+    currentPackageVersion: vi.fn(actual.currentPackageVersion),
     findExecutable: vi.fn(),
     findOpenVikingCli: vi.fn(),
     isExecutable: vi.fn(),
@@ -27,6 +28,8 @@ import {
   runPostUpdate,
   runUpdate,
 } from '../../src/update.js';
+import {runVersion} from '../../src/version_command.js';
+import {captureConsole} from '../../src/effect/console.js';
 import * as utils from '../../src/utils.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 
@@ -65,16 +68,25 @@ async function makeRuntime(): Promise<RuntimeConfig> {
   };
 }
 
-function mockLatestVersion(version: string): void {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async (url: string | URL) => {
-      if (String(url).includes('/health')) {
-        return new Response('healthy');
-      }
-      return Response.json({version});
-    }),
-  );
+function mockRegistryVersions(latest: string, beta: string) {
+  const fetch = vi.fn(async (url: string | URL) => {
+    const href = String(url);
+    if (href.includes('/health')) {
+      return new Response('healthy');
+    }
+    if (href.includes('/threadnote/beta')) {
+      return Response.json({version: beta});
+    }
+    if (href.includes('/threadnote/latest')) {
+      return Response.json({version: latest});
+    }
+    if (href.includes('api.github.com')) {
+      return Response.json([]);
+    }
+    return new Response('Not found', {status: 404});
+  });
+  vi.stubGlobal('fetch', fetch);
+  return fetch;
 }
 
 describe('parseUpdateRuntime', () => {
@@ -87,6 +99,7 @@ describe('parseUpdateRuntime', () => {
     vi.mocked(utils.runCommand).mockReset();
     vi.mocked(utils.runInteractive).mockReset();
     vi.mocked(utils.sleep).mockReset();
+    vi.mocked(utils.currentPackageVersion).mockResolvedValue('2.0.4');
     vi.mocked(utils.maybeRun).mockResolvedValue(ok());
     vi.mocked(utils.findOpenVikingCli).mockResolvedValue(undefined);
     vi.mocked(utils.runCommand).mockResolvedValue(ok());
@@ -127,6 +140,7 @@ describe('runUpdate', () => {
     vi.mocked(utils.runCommand).mockReset();
     vi.mocked(utils.runInteractive).mockReset();
     vi.mocked(utils.sleep).mockReset();
+    vi.mocked(utils.currentPackageVersion).mockResolvedValue('2.0.4');
     vi.mocked(utils.findExecutable).mockImplementation(async commands => {
       if (commands.includes('npm')) {
         return '/usr/bin/npm';
@@ -167,10 +181,11 @@ describe('runUpdate', () => {
   it('streams the package update and repair output instead of buffering it', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
-    mockLatestVersion('99.0.0');
+    const fetch = mockRegistryVersions('99.0.0', '100.0.0-beta.1');
 
     await runTestEffect(runUpdate(config, {postUpdate: false, runtime: 'npm'}).pipe(Effect.provide(ApplicationLayer)));
 
+    expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/latest'))).toBe(true);
     expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(
       'npm',
       expect.arrayContaining(['install', '--global', 'threadnote@latest']),
@@ -180,6 +195,63 @@ describe('runUpdate', () => {
       '--no-post-update',
     ]);
     expect(vi.mocked(utils.maybeRun)).not.toHaveBeenCalled();
+  });
+
+  it('updates to the beta dist-tag when --beta is requested', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const fetch = mockRegistryVersions('2.0.4', '3.0.0-beta.1');
+
+    await runTestEffect(
+      runUpdate(config, {beta: true, dryRun: true, repair: false, runtime: 'npm'}).pipe(
+        Effect.provide(ApplicationLayer),
+      ),
+    );
+
+    expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/beta'))).toBe(true);
+    expect(vi.mocked(utils.maybeRun)).toHaveBeenCalledWith(
+      true,
+      'npm',
+      expect.arrayContaining(['install', '--global', 'threadnote@beta']),
+    );
+  });
+
+  it('keeps an installed beta on the beta channel without another flag', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    vi.mocked(utils.currentPackageVersion).mockResolvedValue('3.0.0-beta.1');
+    const fetch = mockRegistryVersions('2.0.4', '3.0.0-beta.2');
+
+    await runTestEffect(
+      runUpdate(config, {dryRun: true, repair: false, runtime: 'npm'}).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/beta'))).toBe(true);
+    expect(vi.mocked(utils.maybeRun)).toHaveBeenCalledWith(
+      true,
+      'npm',
+      expect.arrayContaining(['install', '--global', 'threadnote@beta']),
+    );
+  });
+
+  it('shows beta versions in version output only for an installed beta', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const stableFetch = mockRegistryVersions('2.0.4', '3.0.0-beta.2');
+
+    const stable = await runTestEffect(captureConsole(runVersion(config, {}).pipe(Effect.provide(ApplicationLayer))));
+
+    expect(stableFetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/latest'))).toBe(true);
+    expect(stable.output).toContain('Latest version');
+    expect(stable.output).not.toContain('3.0.0-beta.2');
+
+    vi.mocked(utils.currentPackageVersion).mockResolvedValue('3.0.0-beta.1');
+    const betaFetch = mockRegistryVersions('2.0.4', '3.0.0-beta.2');
+    const beta = await runTestEffect(captureConsole(runVersion(config, {}).pipe(Effect.provide(ApplicationLayer))));
+
+    expect(betaFetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/beta'))).toBe(true);
+    expect(beta.output).toContain('Latest beta version');
+    expect(beta.output).toContain('3.0.0-beta.2');
   });
 
   it('rejects custom npm registries unless explicitly allowed', () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -70,6 +70,10 @@ describe('compareVersions', () => {
     expect(compareVersions('1.0.0-rc1', '1.0.0-rc1')).toBe(0);
   });
 
+  it('orders numeric prerelease identifiers numerically', () => {
+    expect(compareVersions('1.0.0-beta.10', '1.0.0-beta.2')).toBeGreaterThan(0);
+  });
+
   it('coerces missing or non-numeric components to 0', () => {
     expect(compareVersions('1', '1.0.0')).toBe(0);
     expect(compareVersions('1.2', '1.2.0')).toBe(0);


### PR DESCRIPTION
## Summary

- Add `threadnote update --beta` to resolve and install the npm `beta` dist-tag.
- Keep installed beta versions on the beta channel for ordinary version, update, hook, auto-update, and manager checks.
- Keep stable users on `latest`, with channel-specific caches and prerelease release-note filtering.
- Publish GitHub prereleases to npm under `beta` while stable releases continue to use `latest`.
- Document the stable and beta update workflows.

## Why

Threadnote previously hard-coded npm's `latest` dist-tag throughout its update surfaces, so users could not opt into
beta builds. Channel-aware selection is also required to ensure beta versions never appear in normal stable update
output.

## User impact

Stable behavior is unchanged. Users can opt in with `threadnote update --beta`; once a beta is installed, normal
`threadnote version` and `threadnote update` calls continue tracking beta updates.

## Validation

- `npm run lint`
- `npm run prettier:check`
- `npm run typecheck`
- `npm run test:coverage` (473 tests)
- `npm run build`
- `npm run check:bundle-size`
- `npm run pack:dry-run`
- `npm run test:e2e:local-bins` (9 packaged-binary/OpenViking scenarios)
