### PR TITLE
Release 3.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "2.0.5",
+  "version": "3.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "2.0.5",
+      "version": "3.0.0-beta.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "2.0.5",
+  "version": "3.0.0-beta.1",
   "type": "module",
   "main": "dist/threadnote.js",
   "description": "Shared local context and handoffs for development agents",


### PR DESCRIPTION
## What changed

- set the package and lockfile version to `3.0.0-beta.1`

## Why

This prepares the first 3.0 prerelease containing hybrid recall, confidence and ranking explanations, and reviewed
task-closeout memory suggestions.

Publishing a GitHub prerelease at `v3.0.0-beta.1` will use the repository's trusted npm publisher and the `beta`
dist-tag. The stable `latest` channel remains on `2.0.5`.

## Checks

- lint and 547 unit/integration tests through the commit gate
- TypeScript source and test typechecks
- build and bundle-size gates
- clean-tree npm package preview confirming version `3.0.0-beta.1` and excluding local planning documents
