### PR TITLE
Harden recall and shared memory transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "type": "module",
   "main": "dist/threadnote.js",
   "description": "Shared local context and handoffs for development agents",

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -4,7 +4,7 @@ import {Console, Effect} from 'effect';
 const output = Effect.runSync(Console.Console);
 
 const budgets = [
-  {bytes: 1_725_000, path: 'dist/threadnote.js'},
+  {bytes: 1_750_000, path: 'dist/threadnote.js'},
   {bytes: 1_800_000, path: 'dist/mcp_server.js'},
   {bytes: 450_000, path: 'manager/app.js'},
 ];

--- a/src/effect/share.ts
+++ b/src/effect/share.ts
@@ -1,10 +1,13 @@
-import {Effect, FileSystem} from 'effect';
+import {Console, Effect, FileSystem} from 'effect';
 import {fromPromise, fromSync} from './errors.js';
 import {withMemoryUriLocks} from './memory_lock.js';
+import {withSharedRepositoryLock} from './share_lock.js';
 import {
   installSharedAgentArtifacts as installSharedAgentArtifactsPromise,
   listSharedAgentArtifacts as listSharedAgentArtifactsPromise,
+  listShareConflicts as listShareConflictsPromise,
   removeMemoryUri as removeMemoryUriPromise,
+  refreshSharedReposInBackground as refreshSharedReposInBackgroundPromise,
   resolveShareConflict as resolveShareConflictPromise,
   runShareConflictResolve as runShareConflictResolvePromise,
   runShareConflicts as runShareConflictsPromise,
@@ -22,7 +25,12 @@ import {
   runShareSync as runShareSyncPromise,
   runShareUnpublish as runShareUnpublishPromise,
   resolveTeam,
+  shareAgentArtifact as shareAgentArtifactPromise,
+  shareBundlePack as shareBundlePackPromise,
+  showShareConflict as showShareConflictPromise,
+  SHARED_BACKGROUND_FETCH_INTERVAL_MILLISECONDS,
   sharedUriFor,
+  syncSharedReposBeforeAgentRead as syncSharedReposBeforeAgentReadPromise,
 } from '../share.js';
 import type {SharePublishOptions, ShareRuntime} from '../types.js';
 
@@ -31,12 +39,47 @@ const effectify =
   (...args: Args) =>
     fromPromise(operation, () => evaluate(...args));
 
-export const runShareInit = effectify('initialize shared memory repository', runShareInitPromise);
-export const runShareStatus = effectify('read shared memory status', runShareStatusPromise);
-export const runShareSync = effectify('synchronize shared memory repository', runShareSyncPromise);
-export const runShareConflicts = effectify('list shared memory conflicts', runShareConflictsPromise);
-export const runShareConflictShow = effectify('show shared memory conflict', runShareConflictShowPromise);
-export const runShareConflictResolve = effectify('resolve shared memory conflict', runShareConflictResolvePromise);
+const effectifyLocked =
+  <Args extends readonly unknown[], A>(
+    operation: string,
+    evaluate: (config: ShareRuntime, ...args: Args) => Promise<A>,
+  ) =>
+  (config: ShareRuntime, ...args: Args) =>
+    withSharedRepositoryLock(
+      config,
+      fromPromise(operation, () => evaluate(config, ...args)),
+    );
+
+export const runShareInit = effectifyLocked('initialize shared memory repository', runShareInitPromise);
+export const runShareStatus = effectifyLocked('read shared memory status', runShareStatusPromise);
+export const runShareSync = effectifyLocked('synchronize shared memory repository', runShareSyncPromise);
+export const monitorSharedRepositories = Effect.fn('share.monitorRepositories')(function* (config: ShareRuntime) {
+  const refresh = (force: boolean) =>
+    effectifyLocked('refresh shared memory repositories', refreshSharedReposInBackgroundPromise)(config, force).pipe(
+      Effect.catch(error =>
+        Console.error(`share auto-fetch failed: ${error instanceof Error ? error.message : String(error)}`),
+      ),
+    );
+  yield* refresh(true);
+  while (true) {
+    yield* Effect.sleep(SHARED_BACKGROUND_FETCH_INTERVAL_MILLISECONDS);
+    yield* refresh(false);
+  }
+});
+export const syncSharedReposBeforeAgentRead = Effect.fn('share.syncBeforeAgentRead')(function* (config: ShareRuntime) {
+  return yield* withSharedRepositoryLock(
+    config,
+    fromPromise('synchronize shared memories before agent read', () => syncSharedReposBeforeAgentReadPromise(config)),
+  );
+});
+export const runShareConflicts = effectifyLocked('list shared memory conflicts', runShareConflictsPromise);
+export const runShareConflictShow = effectifyLocked('show shared memory conflict', runShareConflictShowPromise);
+export const listShareConflicts = effectifyLocked('list shared memory conflicts', listShareConflictsPromise);
+export const showShareConflict = effectifyLocked('show shared memory conflict', showShareConflictPromise);
+export const runShareConflictResolve = effectifyLocked(
+  'resolve shared memory conflict',
+  runShareConflictResolvePromise,
+);
 export const runSharePublish = Effect.fn('share.publish')(function* (
   config: ShareRuntime,
   sourceUri: string,
@@ -46,25 +89,34 @@ export const runSharePublish = Effect.fn('share.publish')(function* (
   if (options.dryRun === true || options.preview === true) {
     return yield* publish;
   }
-  const team = yield* fromPromise('resolve shared memory team', () => resolveTeam(config, options.team));
-  const targetUri = yield* fromSync('resolve shared memory target', () => sharedUriFor(config, sourceUri, team.name));
-  const fs = yield* FileSystem.FileSystem;
-  const resolvedPublish = fromPromise('publish shared memory', () =>
-    runSharePublishPromise(config, sourceUri, {...options, team: team.name}),
+  return yield* withSharedRepositoryLock(
+    config,
+    Effect.gen(function* () {
+      const team = yield* fromPromise('resolve shared memory team', () => resolveTeam(config, options.team));
+      const targetUri = yield* fromSync('resolve shared memory target', () =>
+        sharedUriFor(config, sourceUri, team.name),
+      );
+      const fs = yield* FileSystem.FileSystem;
+      const resolvedPublish = fromPromise('publish shared memory', () =>
+        runSharePublishPromise(config, sourceUri, {...options, team: team.name}),
+      );
+      return yield* withMemoryUriLocks(fs, config.agentContextHome, [sourceUri, targetUri], resolvedPublish);
+    }),
   );
-  return yield* withMemoryUriLocks(fs, config.agentContextHome, [sourceUri, targetUri], resolvedPublish);
 });
-export const runSharePublishArtifact = effectify('publish shared artifact', runSharePublishArtifactPromise);
-export const runSharePublishBundle = effectify('publish shared artifact bundle', runSharePublishBundlePromise);
-export const runShareInstallArtifacts = effectify('install shared artifacts', runShareInstallArtifactsPromise);
-export const runShareUnpublish = effectify('unpublish shared memory', runShareUnpublishPromise);
+export const runSharePublishArtifact = effectifyLocked('publish shared artifact', runSharePublishArtifactPromise);
+export const runSharePublishBundle = effectifyLocked('publish shared artifact bundle', runSharePublishBundlePromise);
+export const shareAgentArtifact = effectifyLocked('publish shared artifact', shareAgentArtifactPromise);
+export const shareBundlePack = effectifyLocked('publish shared artifact bundle', shareBundlePackPromise);
+export const runShareInstallArtifacts = effectifyLocked('install shared artifacts', runShareInstallArtifactsPromise);
+export const runShareUnpublish = effectifyLocked('unpublish shared memory', runShareUnpublishPromise);
 export const runShareList = effectify('list shared memory teams', runShareListPromise);
-export const runShareRename = effectify('rename shared memory team', runShareRenamePromise);
-export const runShareSetUrl = effectify('set shared memory remote URL', runShareSetUrlPromise);
-export const runShareRemove = effectify('remove shared memory team', runShareRemovePromise);
-export const resolveShareConflict = effectify('resolve shared memory conflict', resolveShareConflictPromise);
-export const listSharedAgentArtifacts = effectify('list shared agent artifacts', listSharedAgentArtifactsPromise);
-export const installSharedAgentArtifacts = effectify(
+export const runShareRename = effectifyLocked('rename shared memory team', runShareRenamePromise);
+export const runShareSetUrl = effectifyLocked('set shared memory remote URL', runShareSetUrlPromise);
+export const runShareRemove = effectifyLocked('remove shared memory team', runShareRemovePromise);
+export const resolveShareConflict = effectifyLocked('resolve shared memory conflict', resolveShareConflictPromise);
+export const listSharedAgentArtifacts = effectifyLocked('list shared agent artifacts', listSharedAgentArtifactsPromise);
+export const installSharedAgentArtifacts = effectifyLocked(
   'install shared agent artifacts',
   installSharedAgentArtifactsPromise,
 );

--- a/src/effect/share_lock.ts
+++ b/src/effect/share_lock.ts
@@ -1,0 +1,26 @@
+import {Effect, FileSystem, Path} from 'effect';
+import type {ShareRuntime} from '../types.js';
+import {withExclusiveFileLock} from './file_lock.js';
+
+const SHARED_REPOSITORY_LOCK_STALE_MILLISECONDS = 10 * 60 * 1_000;
+const SHARED_REPOSITORY_LOCK_RETRY_MILLISECONDS = 25;
+const SHARED_REPOSITORY_LOCK_WAIT_TIMEOUT_MILLISECONDS = 30_000;
+const SHARED_REPOSITORY_LOCK_OPTIONS = {
+  retryIntervalMilliseconds: SHARED_REPOSITORY_LOCK_RETRY_MILLISECONDS,
+  staleAfterMilliseconds: SHARED_REPOSITORY_LOCK_STALE_MILLISECONDS,
+  waitTimeoutMilliseconds: SHARED_REPOSITORY_LOCK_WAIT_TIMEOUT_MILLISECONDS,
+} as const;
+
+export function withSharedRepositoryLock<A, E, R>(config: ShareRuntime, criticalSection: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const pathService = yield* Path.Path;
+    const lockPath = pathService.join(config.agentContextHome, 'threadnote', 'shared-repository.lock');
+    return yield* withExclusiveFileLock(
+      fs,
+      lockPath,
+      SHARED_REPOSITORY_LOCK_OPTIONS,
+      Effect.uninterruptible(criticalSection),
+    );
+  });
+}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -8,7 +8,16 @@ import {runCommandEffect} from './effect/command.js';
 import {captureConsole, capturePromiseConsole, consoleOutput} from './effect/console.js';
 import {fromPromiseError} from './effect/errors.js';
 import type {ApplicationServices} from './effect/runtime.js';
-import {runSharePublish} from './effect/share.js';
+import {withSharedRepositoryLock} from './effect/share_lock.js';
+import {
+  runShareInit,
+  runSharePublish,
+  runShareRemove,
+  runShareRename,
+  runShareSetUrl,
+  runShareSync,
+  runShareUnpublish,
+} from './effect/share.js';
 import {uriSegment} from './manifest.js';
 import {
   runArchive,
@@ -30,12 +39,6 @@ import {
   readTeamsFile,
   removeMemoryUri,
   resolveTeam,
-  runShareInit,
-  runShareRemove,
-  runShareRename,
-  runShareSetUrl,
-  runShareSync,
-  runShareUnpublish,
   sharedTeamNameForUri,
   vikingUriToWorktreeRelative,
   writeMemoryFile,
@@ -460,8 +463,9 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() =>
-          runShareUnpublish(context.config, requireString(body.uri, 'uri'), {team: optionalString(body.team)}),
+        await runCaptured(
+          () => runShareUnpublish(context.config, requireString(body.uri, 'uri'), {team: optionalString(body.team)}),
+          context.runEffect,
         ),
       );
       return;
@@ -517,8 +521,12 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() =>
-          runShareInit(context.config, requireString(body.remoteUrl, 'remoteUrl'), {team: optionalString(body.team)}),
+        await runCaptured(
+          () =>
+            runShareInit(context.config, requireString(body.remoteUrl, 'remoteUrl'), {
+              team: optionalString(body.team),
+            }),
+          context.runEffect,
         ),
       );
       return;
@@ -527,8 +535,13 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() =>
-          runShareRename(context.config, {team: requireString(body.team, 'team'), to: requireString(body.to, 'to')}),
+        await runCaptured(
+          () =>
+            runShareRename(context.config, {
+              team: requireString(body.team, 'team'),
+              to: requireString(body.to, 'to'),
+            }),
+          context.runEffect,
         ),
       );
       return;
@@ -537,8 +550,12 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() =>
-          runShareSetUrl(context.config, requireString(body.remoteUrl, 'remoteUrl'), {team: optionalString(body.team)}),
+        await runCaptured(
+          () =>
+            runShareSetUrl(context.config, requireString(body.remoteUrl, 'remoteUrl'), {
+              team: optionalString(body.team),
+            }),
+          context.runEffect,
         ),
       );
       return;
@@ -547,12 +564,14 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() =>
-          runShareRemove(context.config, {
-            keepFiles: body.keepFiles === true,
-            preserveLocal: body.preserveLocal === true,
-            team: optionalString(body.team),
-          }),
+        await runCaptured(
+          () =>
+            runShareRemove(context.config, {
+              keepFiles: body.keepFiles === true,
+              preserveLocal: body.preserveLocal === true,
+              team: optionalString(body.team),
+            }),
+          context.runEffect,
         ),
       );
       return;
@@ -560,7 +579,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() => runShareSync(context.config, {team: optionalString(body.team)})),
+        await runCaptured(() => runShareSync(context.config, {team: optionalString(body.team)}), context.runEffect),
       );
       return;
     case '/api/doctor/start':
@@ -696,7 +715,10 @@ async function saveMemory(
   const text = requireString(body.text, 'text');
   const replaceUri = optionalString(body.replaceUri);
   if (replaceUri && isRawMemoryDocument(text)) {
-    return runCaptured(() => writeRawMemory(config, replaceUri, text));
+    return runCaptured(() => {
+      const write = fromPromiseError(() => writeRawMemory(config, replaceUri, text));
+      return isInSharedNamespace(config, replaceUri) ? withSharedRepositoryLock(config, write) : write;
+    }, runEffect);
   }
   return runCaptured(
     () =>
@@ -760,8 +782,15 @@ async function moveMemory(
         );
       }
       const sharedTargetUri = sharedMemoryUriFor(config, targetTeam, metadata);
-      const output = await runCaptured(() =>
-        moveSharedWithinTeam(config, sourceUri, sharedTargetUri, source.content, targetTeam),
+      const output = await runCaptured(
+        () =>
+          withSharedRepositoryLock(
+            config,
+            fromPromiseError(() =>
+              moveSharedWithinTeam(config, sourceUri, sharedTargetUri, source.content, targetTeam),
+            ),
+          ),
+        runEffect,
       );
       return {...output, targetUri: sharedTargetUri};
     }
@@ -800,7 +829,14 @@ async function moveMemory(
         }),
       runEffect,
     );
-    const removed = await runCaptured(() => removeSharedSource(config, sourceUri));
+    const removed = await runCaptured(
+      () =>
+        withSharedRepositoryLock(
+          config,
+          fromPromiseError(() => removeSharedSource(config, sourceUri)),
+        ),
+      runEffect,
+    );
     return {output: [saved.output, removed.output].filter(Boolean).join('\n'), targetUri: personalTargetUri};
   }
   const output = await runCaptured(

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -6,7 +6,7 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {readdir, readFile} from 'node:fs/promises';
 import {join} from 'node:path';
-import {Clock, Console, Effect, FileSystem, pipe} from 'effect';
+import {Clock, Effect, FileSystem, pipe} from 'effect';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset, parseMcpToolset} from './mcp_toolset.js';
 import {formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
@@ -27,24 +27,14 @@ import {
 } from './memory_hygiene.js';
 import {
   ensureSharedDirectoryChain,
-  listShareConflicts,
-  installSharedAgentArtifacts,
   isInSharedNamespace,
-  listSharedAgentArtifacts,
   publishShareGitChange,
   resolveTeam,
-  resolveShareConflict,
   applyScrubber,
-  showShareConflict,
   sharedMemoryUriParts,
   sharedTeamNameForUri,
   sharedUriFor,
-  shareAgentArtifact,
-  shareBundlePack,
-  startShareBackgroundFetch,
-  stopShareBackgroundFetch,
   stripPersonalProvenance,
-  syncSharedReposBeforeAgentRead,
   vikingResourceExists as sharedVikingResourceExists,
   vikingUriToWorktreeRelative,
   writeMemoryFile,
@@ -74,12 +64,23 @@ import {
 } from './utils.js';
 import {withIdentity} from './runtime.js';
 import {EffectMcpServerAdapter, McpInput} from './effect/mcp.js';
-import {runWithConsole} from './effect/console.js';
 import {sha256Hex} from './effect/digest.js';
 import {fromPromiseError as attemptPromise} from './effect/errors.js';
 import {removeOpenVikingResourceEffect} from './effect/openviking.js';
 import {withMemoryUriLocks} from './effect/memory_lock.js';
 import {ApplicationLayer} from './effect/runtime.js';
+import {
+  installSharedAgentArtifacts,
+  listShareConflicts,
+  listSharedAgentArtifacts,
+  monitorSharedRepositories,
+  resolveShareConflict,
+  shareAgentArtifact,
+  shareBundlePack,
+  showShareConflict,
+  syncSharedReposBeforeAgentRead,
+} from './effect/share.js';
+import {withSharedRepositoryLock} from './effect/share_lock.js';
 import {
   canonicalMemoryDocumentContent,
   formatMemoryDocument,
@@ -205,11 +206,7 @@ const mainEffect = Effect.gen(function* () {
   const server = new EffectMcpServerAdapter('threadnote-local-adapter', '0.2.0', instructions);
 
   registerTools(server, config, toolset);
-  const output = yield* Console.Console;
-  yield* Effect.acquireRelease(
-    Effect.sync(() => runWithConsole(output, () => startShareBackgroundFetch(config))),
-    () => Effect.sync(() => stopShareBackgroundFetch(config)),
-  );
+  yield* Effect.forkScoped(monitorSharedRepositories(config));
   yield* Effect.sync(() => process.stderr.write('Threadnote local MCP adapter running\n'));
   return yield* server.run();
 });
@@ -469,7 +466,7 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         team: McpInput.string('Team name; omit to inspect all configured teams'),
       },
     },
-    async ({team}) => runShareConflictsTool(config, {team}),
+    ({team}) => runShareConflictsTool(config, {team}),
   );
 
   server.registerTool(
@@ -485,7 +482,7 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         team: McpInput.string('Team name when id is only a relative path'),
       },
     },
-    async ({id, team}) => {
+    ({id, team}) => {
       const checkedId = requiredText(id, 'share_conflict_show', 'id', {
         id: 'default:durable/projects/foo/bar.md',
       });
@@ -516,7 +513,7 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         team: McpInput.string('Team name when id is only a relative path'),
       },
     },
-    async ({dryRun, id, mergedContent, message, push, take, team}) => {
+    ({dryRun, id, mergedContent, message, push, take, team}) => {
       const checkedId = requiredText(id, 'share_conflict_resolve', 'id', {
         id: 'default:durable/projects/foo/bar.md',
       });
@@ -556,7 +553,7 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         team: McpInput.string('Team name; defaults to the configured default team'),
       },
     },
-    async ({agent, allowBinary, force, kind, message, name, path, preview, push, redact, team}) => {
+    ({agent, allowBinary, force, kind, message, name, path, preview, push, redact, team}) => {
       const checkedPath = requiredText(path, 'share_skill', 'path', {
         path: '~/.codex/skills/example/SKILL.md',
       });
@@ -597,7 +594,7 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         team: McpInput.string('Team name; defaults to the configured default team'),
       },
     },
-    async ({allowBinary, force, message, path, preview, push, redact, team}) => {
+    ({allowBinary, force, message, path, preview, push, redact, team}) => {
       const checkedPath = requiredText(path, 'share_bundle', 'path', {
         path: '~/src/reviewer/threadnote-bundle.json',
       });
@@ -621,7 +618,7 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         team: McpInput.string('Team name; defaults to the configured default team'),
       },
     },
-    async ({agent, kind, name, team}) => runListSharedSkillsTool(config, {agent, kind, name, team}),
+    ({agent, kind, name, team}) => runListSharedSkillsTool(config, {agent, kind, name, team}),
   );
 
   server.registerTool(
@@ -639,7 +636,7 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         team: McpInput.string('Team name; defaults to the configured default team'),
       },
     },
-    async ({agent, dryRun, force, kind, name, team}) => {
+    ({agent, dryRun, force, kind, name, team}) => {
       const checkedName = requiredText(name, 'install_shared_skill', 'name', {name: 'reviewer'});
       if (!checkedName.ok) {
         return checkedName.error;
@@ -1619,7 +1616,7 @@ interface RecallToolParams {
 function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
   return Effect.gen(function* () {
     const syncWarnings: string[] = [];
-    const syncedTeams = yield* attemptPromise(() => syncSharedReposBeforeAgentRead(config)).pipe(
+    const syncedTeams = yield* syncSharedReposBeforeAgentRead(config).pipe(
       Effect.map(syncResult => {
         syncWarnings.push(...syncResult.warnings);
         return syncResult.syncedTeams;
@@ -1711,6 +1708,7 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
       collectExactMemoryMatches(config, query, params.includeArchived, project),
     );
     const recallSections = yield* prepareRecallSections(config, {
+      allowExactRescue: params.threshold === undefined,
       allowedUriScopes: params.pinnedUri ? [params.pinnedUri] : undefined,
       exactMatches,
       feedbackQuery: params.query,
@@ -1735,11 +1733,11 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
     if (exactTail) {
       sections.push(exactTail);
     }
-    const referencedContext = yield* attemptPromise(() => referencedContextSection(config, sections.join('\n\n')));
+    const referencedContext = yield* attemptPromise(() => referencedContextSection(config, semanticSection ?? ''));
     if (referencedContext) {
       sections.push(referencedContext);
     }
-    const hygieneHints = yield* attemptPromise(() => recallHygieneHintsSection(config, sections.join('\n\n')));
+    const hygieneHints = yield* attemptPromise(() => recallHygieneHintsSection(config, semanticSection ?? ''));
     if (hygieneHints) {
       sections.push(hygieneHints);
     }
@@ -1889,32 +1887,36 @@ function registerReadTool(
         uris: McpInput.stringOrStrings('Native OpenViking MCP read input: a single viking:// URI or array of URIs'),
       },
     },
-    async ({uri, uris}) => {
+    ({uri, uris}) => {
       const checkedUris = requiredVikingUriList(uris ?? uri, name, 'viking://user/you/memories/.abstract.md');
       if (!checkedUris.ok) {
         return checkedUris.error;
       }
-      let syncedTeams: readonly string[] = [];
-      const syncWarnings: string[] = [];
-      try {
-        const syncResult = await syncSharedReposBeforeAgentRead(config);
-        syncedTeams = syncResult.syncedTeams;
-        syncWarnings.push(...syncResult.warnings);
-      } catch (err: unknown) {
-        syncWarnings.push(errorMessage(err));
-      }
-      const result = await runOpenVikingReadTool(config, checkedUris.value);
-      if (result.isError === true || (syncedTeams.length === 0 && syncWarnings.length === 0)) {
-        return result;
-      }
-      const syncMessages = [
-        syncedTeams.length > 0 ? `Auto-synced shared memories: ${syncedTeams.join(', ')}` : undefined,
-        ...syncWarnings.map(warning => `Auto-sync warning: ${warning}`),
-      ].filter((part): part is string => part !== undefined);
-      return {
-        ...result,
-        content: [...result.content, {type: 'text', text: syncMessages.join('\n')}],
-      };
+      return Effect.gen(function* () {
+        const syncWarnings: string[] = [];
+        const syncedTeams = yield* syncSharedReposBeforeAgentRead(config).pipe(
+          Effect.map(result => {
+            syncWarnings.push(...result.warnings);
+            return result.syncedTeams;
+          }),
+          Effect.catch(error => {
+            syncWarnings.push(error instanceof Error ? error.message : String(error));
+            return Effect.succeed([] as readonly string[]);
+          }),
+        );
+        const result = yield* attemptPromise(() => runOpenVikingReadTool(config, checkedUris.value));
+        if (result.isError === true || (syncedTeams.length === 0 && syncWarnings.length === 0)) {
+          return result;
+        }
+        const syncMessages = [
+          syncedTeams.length > 0 ? `Auto-synced shared memories: ${syncedTeams.join(', ')}` : undefined,
+          ...syncWarnings.map(warning => `Auto-sync warning: ${warning}`),
+        ].filter((part): part is string => part !== undefined);
+        return {
+          ...result,
+          content: [...result.content, {type: 'text', text: syncMessages.join('\n')}],
+        };
+      });
     },
   );
 }
@@ -2647,7 +2649,7 @@ interface PreparedPersonalMemoryWrite {
 }
 
 function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryParams) {
-  return Effect.gen(function* () {
+  const write = Effect.gen(function* () {
     const prepared = params.prepared ?? preparePersonalMemoryWrite(config, params);
     const fs = yield* FileSystem.FileSystem;
     return yield* withMemoryUriLocks(
@@ -2724,7 +2726,12 @@ function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryPar
         };
       }),
     );
-  }).pipe(
+  });
+  const serializedWrite =
+    params.replaceUri && isInSharedNamespace(config, params.replaceUri)
+      ? withSharedRepositoryLock(config, write)
+      : write;
+  return serializedWrite.pipe(
     Effect.catch(error =>
       Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
     ),
@@ -3373,55 +3380,49 @@ interface InstallSharedSkillToolOptions {
   readonly team?: string;
 }
 
-async function runShareConflictsTool(
-  config: RuntimeConfig,
-  options: ShareConflictToolOptions,
-): Promise<CallToolResult> {
-  try {
-    const conflicts = await listShareConflicts(config, options);
-    if (conflicts.length === 0) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: options.team
-              ? `No pending shared memory conflicts for team "${options.team}".`
-              : 'No pending shared memory conflicts.',
-          },
-        ],
-      };
-    }
-    const lines = [`Pending shared memory conflicts: ${conflicts.length}`];
-    for (const conflict of conflicts) {
-      lines.push(
-        '',
-        conflict.id,
-        `uri: ${conflict.uri}`,
-        `status: ${conflict.status}`,
-        `reason: ${conflict.reason}`,
-        `show: share_conflict_show({"id":${JSON.stringify(conflict.id)}})`,
-        `take shared: share_conflict_resolve({"id":${JSON.stringify(conflict.id)},"take":"shared"})`,
-        `take local: share_conflict_resolve({"id":${JSON.stringify(conflict.id)},"take":"local"})`,
-        `merged: share_conflict_resolve({"id":${JSON.stringify(conflict.id)},"mergedContent":"<merged MEMORY markdown>"})`,
-      );
-    }
-    return {content: [{type: 'text', text: lines.join('\n')}]};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
+function runShareConflictsTool(config: RuntimeConfig, options: ShareConflictToolOptions) {
+  return listShareConflicts(config, options).pipe(
+    Effect.map(conflicts => {
+      if (conflicts.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: options.team
+                ? `No pending shared memory conflicts for team "${options.team}".`
+                : 'No pending shared memory conflicts.',
+            },
+          ],
+        };
+      }
+      const lines = [`Pending shared memory conflicts: ${conflicts.length}`];
+      for (const conflict of conflicts) {
+        lines.push(
+          '',
+          conflict.id,
+          `uri: ${conflict.uri}`,
+          `status: ${conflict.status}`,
+          `reason: ${conflict.reason}`,
+          `show: share_conflict_show({"id":${JSON.stringify(conflict.id)}})`,
+          `take shared: share_conflict_resolve({"id":${JSON.stringify(conflict.id)},"take":"shared"})`,
+          `take local: share_conflict_resolve({"id":${JSON.stringify(conflict.id)},"take":"local"})`,
+          `merged: share_conflict_resolve({"id":${JSON.stringify(conflict.id)},"mergedContent":"<merged MEMORY markdown>"})`,
+        );
+      }
+      return {content: [{type: 'text' as const, text: lines.join('\n')}]};
+    }),
+    Effect.catch(error =>
+      Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
+    ),
+  );
 }
 
-async function runShareConflictShowTool(
-  config: RuntimeConfig,
-  id: string,
-  options: ShareConflictToolOptions,
-): Promise<CallToolResult> {
-  try {
-    const detail = await showShareConflict(config, id, options);
-    return {
+function runShareConflictShowTool(config: RuntimeConfig, id: string, options: ShareConflictToolOptions) {
+  return showShareConflict(config, id, options).pipe(
+    Effect.map(detail => ({
       content: [
         {
-          type: 'text',
+          type: 'text' as const,
           text: [
             `Conflict: ${detail.id}`,
             `URI: ${detail.uri}`,
@@ -3437,35 +3438,34 @@ async function runShareConflictShowTool(
           ].join('\n'),
         },
       ],
-    };
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
+    })),
+    Effect.catch(error =>
+      Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
+    ),
+  );
 }
 
-async function runShareConflictResolveTool(
-  config: RuntimeConfig,
-  id: string,
-  options: ShareConflictResolveToolOptions,
-): Promise<CallToolResult> {
-  try {
-    const result = await resolveShareConflict(config, id, {
-      dryRun: options.dryRun,
-      mergedContent: options.mergedContent,
-      message: options.message,
-      push: options.push,
-      take: options.take,
-      team: options.team,
-    });
-    const lines = [...result.messages];
-    if (result.backupPath) {
-      lines.push(`Backup: ${result.backupPath}`);
-    }
-    lines.push(...result.gitMessages, `Resolved shared memory conflict: ${result.id}`);
-    return {content: [{type: 'text', text: lines.join('\n')}]};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
+function runShareConflictResolveTool(config: RuntimeConfig, id: string, options: ShareConflictResolveToolOptions) {
+  return resolveShareConflict(config, id, {
+    dryRun: options.dryRun,
+    mergedContent: options.mergedContent,
+    message: options.message,
+    push: options.push,
+    take: options.take,
+    team: options.team,
+  }).pipe(
+    Effect.map(result => {
+      const lines = [...result.messages];
+      if (result.backupPath) {
+        lines.push(`Backup: ${result.backupPath}`);
+      }
+      lines.push(...result.gitMessages, `Resolved shared memory conflict: ${result.id}`);
+      return {content: [{type: 'text' as const, text: lines.join('\n')}]};
+    }),
+    Effect.catch(error =>
+      Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
+    ),
+  );
 }
 
 function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: SharePublishToolOptions) {
@@ -3473,7 +3473,6 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
     if (isInSharedNamespace(config, sourceUri)) {
       return argumentError(`Memory ${sourceUri} is already in the shared namespace.`);
     }
-    const resolved = yield* attemptPromise(() => resolveTeam(config, options.team));
     const ov = yield* attemptPromise(requiredOpenVikingCli);
     const readResult = yield* attemptPromise(() => runOpenVikingReadTool(config, [sourceUri]));
     const sourceText = textFromCallToolResult(readResult);
@@ -3490,9 +3489,10 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
     }
     const stripped = stripPersonalProvenance(sourceText);
     const scrub = applyScrubber(stripped, {redact: options.redact === true});
-    const targetUri = sharedUriFor(config, sourceUri, resolved.name);
 
     if (options.preview === true) {
+      const resolved = yield* attemptPromise(() => resolveTeam(config, options.team));
+      const targetUri = sharedUriFor(config, sourceUri, resolved.name);
       const previewLines = [`PREVIEW source: ${sourceUri}`, `PREVIEW destination: ${targetUri}`];
       if (scrub.blocker) {
         previewLines.push(
@@ -3514,60 +3514,69 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
         `Refusing to publish ${sourceUri}: possible ${scrub.blocker}. Strip the sensitive value or pass redact=true for soft-leak patterns.`,
       );
     }
-    const fs = yield* FileSystem.FileSystem;
-    const relativePath = vikingUriToWorktreeRelative(config, targetUri, resolved.name);
-    const commitMessage = options.message ?? `share: publish ${relativePath}`;
-    const publication = yield* withMemoryUriLocks(
-      fs,
-      config.agentContextHome,
-      [sourceUri, targetUri],
+    const {publication, targetUri} = yield* withSharedRepositoryLock(
+      config,
       Effect.gen(function* () {
-        const [currentSource] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [sourceUri]));
-        if (!currentSource) {
-          return {kind: 'source_missing' as const};
-        }
-        const currentScrub = applyScrubber(
-          stripPersonalProvenance(canonicalMemoryDocumentContent(currentSource.content)),
-          {
-            redact: options.redact === true,
-          },
+        const resolved = yield* attemptPromise(() => resolveTeam(config, options.team));
+        const targetUri = sharedUriFor(config, sourceUri, resolved.name);
+        const relativePath = vikingUriToWorktreeRelative(config, targetUri, resolved.name);
+        const commitMessage = options.message ?? `share: publish ${relativePath}`;
+        const fs = yield* FileSystem.FileSystem;
+        const publication = yield* withMemoryUriLocks(
+          fs,
+          config.agentContextHome,
+          [sourceUri, targetUri],
+          Effect.gen(function* () {
+            const [currentSource] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [sourceUri]));
+            if (!currentSource) {
+              return {kind: 'source_missing' as const};
+            }
+            const currentScrub = applyScrubber(
+              stripPersonalProvenance(canonicalMemoryDocumentContent(currentSource.content)),
+              {
+                redact: options.redact === true,
+              },
+            );
+            if (currentScrub.blocker) {
+              return {blocker: currentScrub.blocker, kind: 'blocked' as const};
+            }
+            // Refuse to silently overwrite an existing shared memory (e.g., a
+            // teammate already published the same project/topic).
+            if (yield* attemptPromise(() => sharedVikingResourceExists(ov, config, targetUri))) {
+              return {kind: 'target_conflict' as const};
+            }
+            yield* attemptPromise(() => ensureSharedDirectoryChain(config, ov, targetUri, false, {quiet: true}));
+            yield* attemptPromise(() =>
+              writeMemoryFile(config, ov, targetUri, currentScrub.cleaned, 'create', false, {quiet: true}),
+            );
+            const [storedTarget] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [targetUri]));
+            if (
+              !storedTarget ||
+              canonicalMemoryDocumentContent(storedTarget.content) !==
+                canonicalMemoryDocumentContent(currentScrub.cleaned)
+            ) {
+              return {kind: 'target_verification_failed' as const};
+            }
+            const gitMessages = yield* attemptPromise(() =>
+              publishShareGitChange(resolved.config.worktree, relativePath, commitMessage, {push: options.push}),
+            );
+            const [sourceBeforeRemoval] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [sourceUri]));
+            if (!sourceBeforeRemoval || sourceBeforeRemoval.content !== currentSource.content) {
+              return {
+                gitMessages,
+                kind: 'source_changed' as const,
+                redactions: currentScrub.redactions,
+              };
+            }
+            const removed = yield* removeVikingResourceWithRetry(ov, config, sourceUri);
+            return {
+              gitMessages,
+              kind: removed ? ('published' as const) : ('cleanup_pending' as const),
+              redactions: currentScrub.redactions,
+            };
+          }),
         );
-        if (currentScrub.blocker) {
-          return {blocker: currentScrub.blocker, kind: 'blocked' as const};
-        }
-        // Refuse to silently overwrite an existing shared memory (e.g., a
-        // teammate already published the same project/topic).
-        if (yield* attemptPromise(() => sharedVikingResourceExists(ov, config, targetUri))) {
-          return {kind: 'target_conflict' as const};
-        }
-        yield* attemptPromise(() => ensureSharedDirectoryChain(config, ov, targetUri, false, {quiet: true}));
-        yield* attemptPromise(() =>
-          writeMemoryFile(config, ov, targetUri, currentScrub.cleaned, 'create', false, {quiet: true}),
-        );
-        const [storedTarget] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [targetUri]));
-        if (
-          !storedTarget ||
-          canonicalMemoryDocumentContent(storedTarget.content) !== canonicalMemoryDocumentContent(currentScrub.cleaned)
-        ) {
-          return {kind: 'target_verification_failed' as const};
-        }
-        const gitMessages = yield* attemptPromise(() =>
-          publishShareGitChange(resolved.config.worktree, relativePath, commitMessage, {push: options.push}),
-        );
-        const [sourceBeforeRemoval] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [sourceUri]));
-        if (!sourceBeforeRemoval || sourceBeforeRemoval.content !== currentSource.content) {
-          return {
-            gitMessages,
-            kind: 'source_changed' as const,
-            redactions: currentScrub.redactions,
-          };
-        }
-        const removed = yield* removeVikingResourceWithRetry(ov, config, sourceUri);
-        return {
-          gitMessages,
-          kind: removed ? ('published' as const) : ('cleanup_pending' as const),
-          redactions: currentScrub.redactions,
-        };
+        return {publication, targetUri};
       }),
     );
     if (publication.kind === 'source_missing') {
@@ -3624,23 +3633,21 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
   );
 }
 
-async function runShareSkillTool(
-  config: RuntimeConfig,
-  sourcePath: string,
-  options: ShareSkillToolOptions,
-): Promise<CallToolResult> {
-  try {
-    const result = await shareAgentArtifact(config, sourcePath, options);
-    const lines = [...result.messages, ...result.gitMessages];
-    if (result.previewContent !== undefined) {
-      lines.push('-----BEGIN PREVIEW-----');
-      lines.push(result.previewContent);
-      lines.push('-----END PREVIEW-----');
-    }
-    return {content: [{type: 'text', text: lines.join('\n')}], isError: false};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
+function runShareSkillTool(config: RuntimeConfig, sourcePath: string, options: ShareSkillToolOptions) {
+  return shareAgentArtifact(config, sourcePath, options).pipe(
+    Effect.map(result => {
+      const lines = [...result.messages, ...result.gitMessages];
+      if (result.previewContent !== undefined) {
+        lines.push('-----BEGIN PREVIEW-----');
+        lines.push(result.previewContent);
+        lines.push('-----END PREVIEW-----');
+      }
+      return {content: [{type: 'text' as const, text: lines.join('\n')}], isError: false};
+    }),
+    Effect.catch(error =>
+      Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
+    ),
+  );
 }
 
 interface ShareBundleToolOptions {
@@ -3653,23 +3660,21 @@ interface ShareBundleToolOptions {
   readonly team?: string;
 }
 
-async function runShareBundleTool(
-  config: RuntimeConfig,
-  manifestPath: string,
-  options: ShareBundleToolOptions,
-): Promise<CallToolResult> {
-  try {
-    const result = await shareBundlePack(config, manifestPath, options);
-    const lines = [...result.messages, ...result.gitMessages];
-    if (result.previewContent !== undefined) {
-      lines.push('-----BEGIN PREVIEW-----');
-      lines.push(result.previewContent);
-      lines.push('-----END PREVIEW-----');
-    }
-    return {content: [{type: 'text', text: lines.join('\n')}], isError: false};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
+function runShareBundleTool(config: RuntimeConfig, manifestPath: string, options: ShareBundleToolOptions) {
+  return shareBundlePack(config, manifestPath, options).pipe(
+    Effect.map(result => {
+      const lines = [...result.messages, ...result.gitMessages];
+      if (result.previewContent !== undefined) {
+        lines.push('-----BEGIN PREVIEW-----');
+        lines.push(result.previewContent);
+        lines.push('-----END PREVIEW-----');
+      }
+      return {content: [{type: 'text' as const, text: lines.join('\n')}], isError: false};
+    }),
+    Effect.catch(error =>
+      Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
+    ),
+  );
 }
 
 async function runThreadnoteGuideTool(config: RuntimeConfig, toolset: McpToolset): Promise<CallToolResult> {
@@ -3688,58 +3693,52 @@ async function probeServerUp(config: RuntimeConfig): Promise<boolean | undefined
   }
 }
 
-async function runListSharedSkillsTool(
-  config: RuntimeConfig,
-  options: SharedSkillFilterOptions,
-): Promise<CallToolResult> {
-  try {
-    const result = await listSharedAgentArtifacts(config, options);
-    if (result.artifacts.length === 0) {
+function runListSharedSkillsTool(config: RuntimeConfig, options: SharedSkillFilterOptions) {
+  return listSharedAgentArtifacts(config, options).pipe(
+    Effect.map(result => {
       const lines = shareArtifactToolHeader(result.team, result.syncedTeams, result.warnings);
-      lines.push(`No shared skills or commands found for team "${result.team}".`);
-      return {content: [{type: 'text', text: lines.join('\n')}]};
-    }
-    const lines = shareArtifactToolHeader(result.team, result.syncedTeams, result.warnings);
-    lines.push(`Shared skills and commands for team "${result.team}":`);
-    for (const artifact of result.artifacts) {
-      lines.push(
-        `- ${artifact.artifact.kind} ${artifact.artifact.agent}/${artifact.artifact.name} (${artifact.installStatus})`,
-      );
-      lines.push(
-        `  install: install_shared_skill({"name":"${artifact.artifact.name}","agent":"${artifact.artifact.agent}","kind":"${artifact.artifact.kind}"})`,
-      );
-    }
-    return {content: [{type: 'text', text: lines.join('\n')}], isError: false};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
+      if (result.artifacts.length === 0) {
+        lines.push(`No shared skills or commands found for team "${result.team}".`);
+      } else {
+        lines.push(`Shared skills and commands for team "${result.team}":`);
+        for (const artifact of result.artifacts) {
+          lines.push(
+            `- ${artifact.artifact.kind} ${artifact.artifact.agent}/${artifact.artifact.name} (${artifact.installStatus})`,
+          );
+          lines.push(
+            `  install: install_shared_skill({"name":"${artifact.artifact.name}","agent":"${artifact.artifact.agent}","kind":"${artifact.artifact.kind}"})`,
+          );
+        }
+      }
+      return {content: [{type: 'text' as const, text: lines.join('\n')}], isError: false};
+    }),
+    Effect.catch(error =>
+      Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
+    ),
+  );
 }
 
-async function runInstallSharedSkillTool(
-  config: RuntimeConfig,
-  name: string,
-  options: InstallSharedSkillToolOptions,
-): Promise<CallToolResult> {
-  try {
-    const result = await installSharedAgentArtifacts(config, {
-      ...options,
-      apply: options.dryRun !== true,
-      name,
-    });
-    return {
+function runInstallSharedSkillTool(config: RuntimeConfig, name: string, options: InstallSharedSkillToolOptions) {
+  return installSharedAgentArtifacts(config, {
+    ...options,
+    apply: options.dryRun !== true,
+    name,
+  }).pipe(
+    Effect.map(result => ({
       content: [
         {
-          type: 'text',
+          type: 'text' as const,
           text: [...shareArtifactToolHeader(result.team, result.syncedTeams, result.warnings), ...result.messages].join(
             '\n',
           ),
         },
       ],
       isError: false,
-    };
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
+    })),
+    Effect.catch(error =>
+      Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
+    ),
+  );
 }
 
 function shareArtifactToolHeader(team: string, syncedTeams: readonly string[], warnings: readonly string[]): string[] {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -7,6 +7,8 @@ import {consoleOutput, syncWithConsole} from './effect/console.js';
 import {fromPromiseError as attempt} from './effect/errors.js';
 import {withMemoryUriLocks} from './effect/memory_lock.js';
 import {removeOpenVikingResourceEffect} from './effect/openviking.js';
+import {syncSharedReposBeforeAgentRead} from './effect/share.js';
+import {withSharedRepositoryLock} from './effect/share_lock.js';
 import {
   inferProjectFromQuery,
   inferWorksetFromQuery,
@@ -28,13 +30,7 @@ import {
   topicForRecord,
   type MemoryRecord,
 } from './memory_hygiene.js';
-import {
-  formatMemoryDocument,
-  inferMemoryMetadata,
-  isSharedMemoryUri,
-  memoryHeaderValue,
-  type MemoryMetadata,
-} from './memory_document.js';
+import {formatMemoryDocument, inferMemoryMetadata, memoryHeaderValue, type MemoryMetadata} from './memory_document.js';
 import {prepareRecallSections} from './recall/runtime.js';
 import {withIdentity} from './runtime.js';
 import type {
@@ -98,7 +94,6 @@ import {
   sharedMemoryUriParts,
   sharedTeamNameForUri,
   stripPersonalProvenance,
-  syncSharedReposBeforeAgentRead,
   vikingUriToWorktreeRelative,
   writeMemoryFile,
 } from './share.js';
@@ -933,7 +928,7 @@ function projectMemoryLocations(): readonly ProjectMemoryLocation[] {
 
 export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig, options: RecallOptions) {
   if (options.dryRun !== true) {
-    yield* attempt(() => syncSharedReposAndLog(config));
+    yield* syncSharedReposAndLog(config);
   }
   const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
   const workspaceOptions = options.callerCwd
@@ -1036,11 +1031,11 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
     }
   }
 
-  const recallOutputs: string[] = [];
   const exactMatches = yield* attempt(() =>
     collectExactMemoryMatches(config, ov, query, {dryRun, includeArchived, project}),
   );
   const {semanticSection, exactTail} = yield* prepareRecallSections(config, {
+    allowExactRescue: options.threshold === undefined,
     allowedUriScopes: options.uri ? [options.uri] : undefined,
     exactMatches,
     feedbackQuery: options.query,
@@ -1055,18 +1050,15 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
   });
   if (semanticSection) {
     yield* syncWithConsole(() => consoleOutput.log(`\n${semanticSection}`));
-    recallOutputs.push(semanticSection);
   }
   if (exactTail) {
     yield* syncWithConsole(() => consoleOutput.log(`\n${exactTail}`));
-    recallOutputs.push(exactTail);
   }
-  const referencedSection = yield* attempt(() => referencedContextSection(config, recallOutputs.join('\n')));
+  const referencedSection = yield* attempt(() => referencedContextSection(config, semanticSection ?? ''));
   if (referencedSection) {
     yield* syncWithConsole(() => consoleOutput.log(`\n${referencedSection}`));
-    recallOutputs.push(referencedSection);
   }
-  yield* attempt(() => printRecallHygieneNudges(config, recallOutputs.join('\n')));
+  yield* attempt(() => printRecallHygieneNudges(config, semanticSection ?? ''));
 });
 
 const MAX_REFERENCED_CONTEXT = 5;
@@ -1122,8 +1114,8 @@ async function recallSearchHits(
   options: {readonly dryRun: boolean; readonly includeArchived: boolean},
 ): Promise<readonly RecallHit[]> {
   const jsonArgs = withIdentity(config, [...args, '--output', 'json']);
-  consoleOutput.log(`${options.dryRun ? 'Would run' : 'Running'}: ${formatShellCommand(ov, jsonArgs)}`);
   if (options.dryRun) {
+    consoleOutput.log(`Would run: ${formatShellCommand(ov, jsonArgs)}`);
     return [];
   }
   let result = await runCommand(ov, jsonArgs, {allowFailure: true});
@@ -1156,7 +1148,7 @@ export function stripAdvancedSearchFlags(args: readonly string[]): readonly stri
 export const runRead = Effect.fn('runRead')(function* (config: RuntimeConfig, uri: string, options: ReadOptions) {
   yield* attemptSync(() => assertVikingUri(uri));
   if (options.dryRun !== true) {
-    yield* attempt(() => syncSharedReposAndLog(config));
+    yield* syncSharedReposAndLog(config);
   }
   const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
   const result = yield* maybeRunEffect(options.dryRun === true, ov, withIdentity(config, ['read', uri]));
@@ -1175,19 +1167,25 @@ export const runRead = Effect.fn('runRead')(function* (config: RuntimeConfig, ur
   }
 });
 
-async function syncSharedReposAndLog(config: RuntimeConfig): Promise<void> {
-  try {
-    const syncResult = await syncSharedReposBeforeAgentRead(config);
+const syncSharedReposAndLog = Effect.fn('memory.syncSharedReposAndLog')(function* (config: RuntimeConfig) {
+  const syncResult = yield* syncSharedReposBeforeAgentRead(config).pipe(
+    Effect.catch(error => {
+      const message = error instanceof Error ? error.message : String(error);
+      return syncWithConsole(() => consoleOutput.error(`Auto-sync warning: ${message}`)).pipe(Effect.as(undefined));
+    }),
+  );
+  if (!syncResult) {
+    return;
+  }
+  yield* syncWithConsole(() => {
     if (syncResult.syncedTeams.length > 0) {
       consoleOutput.error(`Auto-synced shared memories: ${syncResult.syncedTeams.join(', ')}`);
     }
     for (const warning of syncResult.warnings) {
       consoleOutput.error(`Auto-sync warning: ${warning}`);
     }
-  } catch (err: unknown) {
-    consoleOutput.error(`Auto-sync warning: ${err instanceof Error ? err.message : String(err)}`);
-  }
-}
+  });
+});
 
 async function printRecallHygieneNudges(config: RuntimeConfig, recallOutput: string): Promise<void> {
   const uris = activePersonalMemoryUrisFromText(recallOutput, config.user);
@@ -1374,7 +1372,7 @@ function memoryUriDirectoryForCompact(config: RuntimeConfig, kind: CompactableMe
 
 function localMemoryPathForUri(config: RuntimeConfig, uri: string): string | undefined {
   const prefix = `viking://user/${uriSegment(config.user)}/memories/`;
-  if (!uri.startsWith(prefix) || isSharedMemoryUri(uri)) {
+  if (!uri.startsWith(prefix)) {
     return undefined;
   }
   const relative = uri.slice(prefix.length);
@@ -1581,11 +1579,14 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
       return;
     }
     const fs = yield* FileSystem.FileSystem;
-    yield* withMemoryUriLocks(
-      fs,
-      config.agentContextHome,
-      [options.replaceUri],
-      attempt(() => storeSharedMemoryReplacement(config, ov, options, options.replaceUri as string)),
+    yield* withSharedRepositoryLock(
+      config,
+      withMemoryUriLocks(
+        fs,
+        config.agentContextHome,
+        [options.replaceUri],
+        attempt(() => storeSharedMemoryReplacement(config, ov, options, options.replaceUri as string)),
+      ),
     );
     return;
   }

--- a/src/recall/rank.ts
+++ b/src/recall/rank.ts
@@ -1,7 +1,7 @@
 import type {MemoryAuthority, MemoryRelation, MemoryTrust} from '../memory_document.js';
 import type {MemoryKind, MemoryStatus} from '../types.js';
 
-export const RECALL_RANKER_VERSION = 'hybrid-v1';
+export const RECALL_RANKER_VERSION = 'hybrid-v2';
 
 export interface RecallFields {
   readonly identifiers?: readonly string[];
@@ -12,6 +12,7 @@ export interface RecallFields {
 
 export interface RecallCandidate {
   readonly authority?: MemoryAuthority;
+  readonly exactTerms?: readonly string[];
   readonly feedback?: number;
   readonly fields?: RecallFields;
   readonly kind?: MemoryKind;
@@ -27,6 +28,7 @@ export interface RecallCandidate {
 }
 
 export interface RecallRankContext {
+  readonly allowExactRescue?: boolean;
   readonly corpusStatistics?: RecallCorpusStatistics;
   readonly includeInactive?: boolean;
   readonly includeTemporallyInvalid?: boolean;
@@ -46,10 +48,12 @@ export interface RecallCorpusStatistics {
 export interface RecallSignals {
   readonly authority: number;
   readonly bm25: number;
+  readonly exact: number;
   readonly feedback: number;
   readonly field: number;
   readonly freshness: number;
   readonly graph: number;
+  readonly kindIntent: number;
   readonly lifecycle: number;
   readonly scope: number;
   readonly semantic: number;
@@ -89,14 +93,16 @@ export interface RankedRecallSet {
 
 const SIGNAL_WEIGHTS = {
   authority: 0.04,
-  bm25: 0.23,
+  bm25: 0.18,
+  exact: 0.18,
   feedback: 0.03,
-  field: 0.14,
-  freshness: 0.05,
+  field: 0.16,
+  freshness: 0.04,
   graph: 0.07,
+  kindIntent: 0.04,
   lifecycle: 0.05,
-  scope: 0.05,
-  semantic: 0.32,
+  scope: 0.03,
+  semantic: 0.16,
   temporal: 0.02,
 } as const;
 
@@ -110,13 +116,33 @@ const FIELD_WEIGHTS = {
 const BM25_SATURATION = 1.2;
 const BM25_LENGTH_NORMALIZATION = 0.75;
 const BM25_IDF_SMOOTHING = 0.5;
+const FIELD_QUERY_COVERAGE_WEIGHT = 0.4;
+const FIELD_VALUE_PRECISION_WEIGHT = 0.6;
+const FIELD_EXACT_SUBSET_BONUS = 0.2;
 const RELEVANCE_GATE_MINIMUM = 0.08;
+const EXACT_TERM_RESCUE_MINIMUM = 0.75;
+const EXACT_TERM_RESCUE_FIELD_MINIMUM = 0.35;
+const EXACT_CONTEXTUAL_TERM_SCORE = 1;
+const EXACT_MULTI_TERM_BASE_SCORE = 0.4;
+const EXACT_MULTI_TERM_IDF_COVERAGE_WEIGHT = 0.6;
+const EXACT_IDENTIFIER_SCORE = 0.9;
+const EXACT_MULTI_TERM_MINIMUM = 2;
 const NO_ANSWER_SCORE_MINIMUM = 0.2;
 const LEXICAL_ONLY_ANSWER_MINIMUM = 0.5;
 const SIGNAL_ABSENCE_MAXIMUM = 0.05;
 const TEMPORALLY_INVALID_SCORE_MULTIPLIER = 0.25;
 const UNKNOWN_FRESHNESS_SCORE = 0.5;
 const UNKNOWN_SCOPE_SCORE = 0.5;
+
+const intentTerms = (terms: string): ReadonlySet<string> => new Set(terms.split(' '));
+
+const MEMORY_KIND_INTENT_TERMS: Readonly<Record<MemoryKind, ReadonlySet<string>>> = {
+  durable: intentTerms('contract decision invariant policy unsupported'),
+  handoff: intentTerms('branch current handoff status'),
+  incident: intentTerms('failure incident outage regression'),
+  preference: intentTerms('preference style tone'),
+  smoke: intentTerms('smoke'),
+};
 
 const FRESHNESS_HALF_LIFE_DAYS: Readonly<Record<MemoryKind, number>> = {
   durable: 180,
@@ -207,7 +233,13 @@ export function rankRecallCandidates(
     .filter(
       result =>
         result.passedRelevanceGate &&
-        (context.minimumScore === undefined || result.relevanceScore >= context.minimumScore) &&
+        (context.minimumScore === undefined ||
+          result.relevanceScore >= context.minimumScore ||
+          (context.allowExactRescue === true &&
+            result.signals.exact >= EXACT_TERM_RESCUE_MINIMUM &&
+            (result.signals.kindIntent === 1 ||
+              result.signals.field >= EXACT_TERM_RESCUE_FIELD_MINIMUM ||
+              qualifyingExactTerms(result.candidate).some(term => /[0-9_.-]/.test(term))))) &&
         (context.includeInactive === true || result.signals.lifecycle === LIFECYCLE_SCORES.active) &&
         (context.includeTemporallyInvalid === true || result.signals.temporal === 1),
     )
@@ -234,9 +266,15 @@ function scoreCandidate(
 ): RankedRecallCandidate {
   const semantic = clamp(candidate.semantic ?? 0);
   const bm25 = normalizedBm25(queryTerms, documentTerms, corpusStatistics);
-  const field = fieldScore(queryTerms, candidate.fields);
+  const topicalBm25 = normalizedBm25(queryTerms, recallTopicalDocumentTerms(candidate), corpusStatistics);
+  const field = fieldScore(queryTerms, candidate.fields, {includeProject: true});
+  const topicalField = fieldScore(queryTerms, candidate.fields, {includeProject: false});
   const graph = graphScore(candidate.uri, graphDistances);
   const scope = scopeScore(context.project, candidate.fields?.project);
+  const kindIntent = kindIntentScore(queryTerms, candidate.kind);
+  const exact = exactTermScore(queryTerms, qualifyingExactTerms(candidate), candidate.fields, corpusStatistics, {
+    kindIntent,
+  });
   const freshness = freshnessScore(candidate.timestamp, candidate.kind, context.now);
   const authority = authorityScore(candidate.authority, candidate.trust);
   const lifecycle = lifecycleScore(candidate.status);
@@ -245,16 +283,18 @@ function scoreCandidate(
   const signals: RecallSignals = {
     authority,
     bm25,
+    exact,
     feedback,
     field,
     freshness,
     graph,
+    kindIntent,
     lifecycle,
     scope,
     semantic,
     temporal,
   };
-  const passedRelevanceGate = Math.max(semantic, bm25, field) >= RELEVANCE_GATE_MINIMUM;
+  const passedRelevanceGate = Math.max(semantic, topicalBm25, exact, topicalField) >= RELEVANCE_GATE_MINIMUM;
   const temporalMultiplier = temporal === 0 ? TEMPORALLY_INVALID_SCORE_MULTIPLIER : 1;
   const lifecycleMultiplier = LIFECYCLE_SCORE_MULTIPLIERS[candidate.status ?? 'active'];
   const relevanceScore = passedRelevanceGate ? clamp(weightedScore(signals) * temporalMultiplier) : 0;
@@ -263,7 +303,7 @@ function scoreCandidate(
   const lexicalOnly =
     semantic <= SIGNAL_ABSENCE_MAXIMUM &&
     graph <= SIGNAL_ABSENCE_MAXIMUM &&
-    Math.max(bm25, field) >= RELEVANCE_GATE_MINIMUM;
+    Math.max(bm25, exact, field) >= RELEVANCE_GATE_MINIMUM;
   const warnings = [
     ...(candidate.status && candidate.status !== 'active' ? [`memory is ${candidate.status}`] : []),
     ...(temporal === 0 ? ['outside temporal validity window'] : []),
@@ -277,8 +317,10 @@ function weightedScore(signals: RecallSignals): number {
   return (
     signals.semantic * SIGNAL_WEIGHTS.semantic +
     signals.bm25 * SIGNAL_WEIGHTS.bm25 +
+    signals.exact * SIGNAL_WEIGHTS.exact +
     signals.field * SIGNAL_WEIGHTS.field +
     signals.graph * SIGNAL_WEIGHTS.graph +
+    signals.kindIntent * SIGNAL_WEIGHTS.kindIntent +
     signals.scope * SIGNAL_WEIGHTS.scope +
     signals.freshness * SIGNAL_WEIGHTS.freshness +
     signals.authority * SIGNAL_WEIGHTS.authority +
@@ -286,6 +328,69 @@ function weightedScore(signals: RecallSignals): number {
     signals.temporal * SIGNAL_WEIGHTS.temporal +
     signals.feedback * SIGNAL_WEIGHTS.feedback
   );
+}
+
+function exactTermScore(
+  queryTerms: readonly string[],
+  exactTerms: readonly string[] | undefined,
+  fields: RecallFields | undefined,
+  corpusStatistics: RecallCorpusStatistics,
+  context: {readonly kindIntent: number},
+): number {
+  if (queryTerms.length === 0 || !exactTerms || exactTerms.length === 0) {
+    return 0;
+  }
+  const uniqueQuery = new Set(queryTerms);
+  const uniqueExactTerms = [...new Set(exactTerms.map(term => term.toLowerCase()))];
+  const matchedTerms = uniqueExactTerms.filter(term => tokenize(term).some(token => uniqueQuery.has(token)));
+  const matches = matchedTerms.length;
+  if (matches === 0) {
+    return 0;
+  }
+  const queryCoverage = matches / uniqueQuery.size;
+  const exactPrecision = matches / uniqueExactTerms.length;
+  if (matches >= EXACT_MULTI_TERM_MINIMUM && exactPrecision === 1) {
+    const matchedQueryTerms = new Set(matchedTerms.flatMap(tokenize).filter(term => uniqueQuery.has(term)));
+    const totalQueryWeight = [...uniqueQuery].reduce(
+      (total, term) => total + inverseDocumentFrequency(term, corpusStatistics),
+      0,
+    );
+    const matchedQueryWeight = [...matchedQueryTerms].reduce(
+      (total, term) => total + inverseDocumentFrequency(term, corpusStatistics),
+      0,
+    );
+    const idfWeightedCoverage = totalQueryWeight === 0 ? queryCoverage : matchedQueryWeight / totalQueryWeight;
+    return clamp(
+      Math.max(
+        EXACT_TERM_RESCUE_MINIMUM,
+        EXACT_MULTI_TERM_BASE_SCORE + idfWeightedCoverage * EXACT_MULTI_TERM_IDF_COVERAGE_WEIGHT,
+      ),
+    );
+  }
+  if (matches === 1 && exactPrecision === 1 && /[0-9_.-]/.test(matchedTerms[0] ?? '')) {
+    return EXACT_IDENTIFIER_SCORE;
+  }
+  if (
+    matches === 1 &&
+    exactPrecision === 1 &&
+    context.kindIntent === 1 &&
+    focusedFieldContainsTerm(fields, matchedTerms[0] ?? '')
+  ) {
+    return EXACT_CONTEXTUAL_TERM_SCORE;
+  }
+  return queryCoverage * exactPrecision;
+}
+
+function focusedFieldContainsTerm(fields: RecallFields | undefined, term: string): boolean {
+  if (!fields || term.length === 0) {
+    return false;
+  }
+  const focusedTerms = new Set(
+    [fields.title, fields.topic, ...(fields.identifiers ?? [])]
+      .filter((value): value is string => typeof value === 'string')
+      .flatMap(tokenize),
+  );
+  return tokenize(term).some(token => focusedTerms.has(token));
 }
 
 function normalizedBm25(
@@ -300,15 +405,11 @@ function normalizedBm25(
   for (const term of documentTerms) {
     termFrequency.set(term, (termFrequency.get(term) ?? 0) + 1);
   }
-  const documentCount = Math.max(1, corpusStatistics.documentCount);
   let score = 0;
   let maximum = 0;
   for (const term of new Set(queryTerms)) {
     const frequency = termFrequency.get(term) ?? 0;
-    const documentsWithTerm = corpusStatistics.documentFrequency[term] ?? 0;
-    const idf = Math.log(
-      1 + (documentCount - documentsWithTerm + BM25_IDF_SMOOTHING) / (documentsWithTerm + BM25_IDF_SMOOTHING),
-    );
+    const idf = inverseDocumentFrequency(term, corpusStatistics);
     maximum += idf * (BM25_SATURATION + 1);
     if (frequency === 0) {
       continue;
@@ -324,21 +425,56 @@ function normalizedBm25(
   return maximum === 0 ? 0 : clamp(score / maximum);
 }
 
-function fieldScore(queryTerms: readonly string[], fields: RecallFields | undefined): number {
+function inverseDocumentFrequency(term: string, corpusStatistics: RecallCorpusStatistics): number {
+  const documentCount = Math.max(1, corpusStatistics.documentCount);
+  const documentsWithTerm = corpusStatistics.documentFrequency[term] ?? 0;
+  return Math.log(
+    1 + (documentCount - documentsWithTerm + BM25_IDF_SMOOTHING) / (documentsWithTerm + BM25_IDF_SMOOTHING),
+  );
+}
+
+function fieldScore(
+  queryTerms: readonly string[],
+  fields: RecallFields | undefined,
+  options: {readonly includeProject: boolean},
+): number {
   if (queryTerms.length === 0 || !fields) {
     return 0;
   }
   const uniqueQuery = new Set(queryTerms);
-  const coverage = (value: string | readonly string[] | undefined): number => {
+  const coverage = (
+    value: string | readonly string[] | undefined,
+    options: {readonly rewardExactSubset: boolean},
+  ): number => {
     const terms = new Set(Array.isArray(value) ? value.flatMap(tokenize) : tokenize(value ?? ''));
-    return [...uniqueQuery].filter(term => terms.has(term)).length / uniqueQuery.size;
+    if (terms.size === 0) {
+      return 0;
+    }
+    const matches = [...uniqueQuery].filter(term => terms.has(term)).length;
+    const queryCoverage = matches / uniqueQuery.size;
+    const valuePrecision = matches / terms.size;
+    const exactSubsetBonus =
+      options.rewardExactSubset && matches === terms.size && matches > 0 ? FIELD_EXACT_SUBSET_BONUS : 0;
+    return clamp(
+      queryCoverage * FIELD_QUERY_COVERAGE_WEIGHT + valuePrecision * FIELD_VALUE_PRECISION_WEIGHT + exactSubsetBonus,
+    );
   };
   return clamp(
-    coverage(fields.title) * FIELD_WEIGHTS.title +
-      coverage(fields.topic) * FIELD_WEIGHTS.topic +
-      coverage(fields.project) * FIELD_WEIGHTS.project +
-      coverage(fields.identifiers) * FIELD_WEIGHTS.identifiers,
+    coverage(fields.title, {rewardExactSubset: true}) * FIELD_WEIGHTS.title +
+      coverage(fields.topic, {rewardExactSubset: true}) * FIELD_WEIGHTS.topic +
+      (options.includeProject ? coverage(fields.project, {rewardExactSubset: false}) * FIELD_WEIGHTS.project : 0) +
+      coverage(fields.identifiers, {rewardExactSubset: true}) * FIELD_WEIGHTS.identifiers,
   );
+}
+
+function kindIntentScore(queryTerms: readonly string[], kind: MemoryKind | undefined): number {
+  const requestedKinds = (Object.entries(MEMORY_KIND_INTENT_TERMS) as Array<[MemoryKind, ReadonlySet<string>]>)
+    .filter(([_candidateKind, terms]) => queryTerms.some(term => terms.has(term)))
+    .map(([candidateKind]) => candidateKind);
+  if (requestedKinds.length === 0) {
+    return 0;
+  }
+  return kind !== undefined && requestedKinds.includes(kind) ? 1 : 0;
 }
 
 function typedGraphDistances(
@@ -470,6 +606,11 @@ function explainSignals(
     ),
     reason('bm25_lexical', signals.bm25 * SIGNAL_WEIGHTS.bm25, `BM25/IDF lexical score ${signals.bm25.toFixed(2)}`),
     reason(
+      'exact_term_match',
+      signals.exact * SIGNAL_WEIGHTS.exact,
+      `exact-term corroboration ${signals.exact.toFixed(2)}`,
+    ),
+    reason(
       'field_match',
       signals.field * SIGNAL_WEIGHTS.field,
       `title/topic/project/identifier score ${signals.field.toFixed(2)}`,
@@ -478,6 +619,11 @@ function explainSignals(
       'graph_proximity',
       signals.graph * SIGNAL_WEIGHTS.graph,
       `typed graph proximity ${signals.graph.toFixed(2)}`,
+    ),
+    reason(
+      'memory_kind_intent',
+      signals.kindIntent * SIGNAL_WEIGHTS.kindIntent,
+      `memory-kind intent ${signals.kindIntent.toFixed(2)}`,
     ),
     reason('freshness', signals.freshness * SIGNAL_WEIGHTS.freshness, `recency score ${signals.freshness.toFixed(2)}`),
     reason(
@@ -521,15 +667,19 @@ function assessConfidence(results: readonly RankedRecallCandidate[]): RecallConf
   const margin = Math.max(0, first - second);
   const topSignals = results[0]?.signals;
   const corroboratingSignals = results[0]
-    ? [results[0].signals.semantic, results[0].signals.bm25, results[0].signals.field, results[0].signals.graph].filter(
-        signal => signal >= CORROBORATING_SIGNAL_MINIMUM,
-      ).length
+    ? [
+        results[0].signals.semantic,
+        results[0].signals.bm25,
+        results[0].signals.exact,
+        results[0].signals.field,
+        results[0].signals.graph,
+      ].filter(signal => signal >= CORROBORATING_SIGNAL_MINIMUM).length
     : 0;
   const weakLexicalOnly =
     topSignals !== undefined &&
     topSignals.semantic <= SIGNAL_ABSENCE_MAXIMUM &&
     topSignals.graph <= SIGNAL_ABSENCE_MAXIMUM &&
-    Math.max(topSignals.bm25, topSignals.field) < LEXICAL_ONLY_ANSWER_MINIMUM;
+    Math.max(topSignals.bm25, topSignals.exact, topSignals.field) < LEXICAL_ONLY_ANSWER_MINIMUM;
   if (results.length === 0 || first < NO_ANSWER_SCORE_MINIMUM || weakLexicalOnly) {
     return {
       level: 'no_answer',
@@ -564,6 +714,24 @@ export function recallDocumentTerms(candidate: RecallCandidate): readonly string
   );
 }
 
+function recallTopicalDocumentTerms(candidate: RecallCandidate): readonly string[] {
+  return tokenize(
+    [candidate.text, candidate.fields?.title, candidate.fields?.topic, ...(candidate.fields?.identifiers ?? [])]
+      .filter((value): value is string => typeof value === 'string')
+      .join(' '),
+  );
+}
+
+function qualifyingExactTerms(candidate: RecallCandidate): readonly string[] {
+  const topicalTerms = new Set(recallTopicalDocumentTerms(candidate));
+  const projectTerms = new Set(tokenize(candidate.fields?.project ?? ''));
+  const kindIntentTerms = candidate.kind ? MEMORY_KIND_INTENT_TERMS[candidate.kind] : undefined;
+  return (candidate.exactTerms ?? []).filter(term => {
+    const normalized = term.toLowerCase();
+    return topicalTerms.has(normalized) && !projectTerms.has(normalized) && kindIntentTerms?.has(normalized) !== true;
+  });
+}
+
 export function buildRecallCorpusStatistics(candidates: readonly RecallCandidate[]): RecallCorpusStatistics {
   const corpus = candidates.map(candidate => recallDocumentTerms(candidate));
   const frequencies: Record<string, number> = {};
@@ -583,7 +751,16 @@ export function buildRecallCorpusStatistics(candidates: readonly RecallCandidate
 
 function tokenize(value: string | readonly string[]): readonly string[] {
   const text = typeof value === 'string' ? value : value.join(' ');
-  return [...text.toLowerCase().matchAll(/[a-z0-9][a-z0-9_.-]{1,}/g)].map(match => match[0]);
+  return [...text.matchAll(/[a-z0-9][a-z0-9_.-]{1,}/gi)].flatMap(match => {
+    const raw = match[0];
+    const normalized = raw.toLowerCase();
+    const components = raw
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .split(/[._/-]+/)
+      .map(term => term.toLowerCase())
+      .filter(term => term.length >= 2 && term !== normalized);
+    return [normalized, ...components];
+  });
 }
 
 function clamp(value: number): number {

--- a/src/recall/runtime.ts
+++ b/src/recall/runtime.ts
@@ -12,6 +12,7 @@ interface RecallRuntimeConfig {
 }
 
 interface PrepareRecallSectionsInput {
+  readonly allowExactRescue: boolean;
   readonly allowedUriScopes?: readonly string[];
   readonly exactMatches: readonly ExactMatch[];
   readonly feedbackQuery: string;
@@ -63,6 +64,7 @@ export const prepareRecallSections = Effect.fn('recall.prepareSections')(functio
     {concurrency: 2},
   );
   return buildRecallSections(input.passes, input.exactMatches, input.limit, {
+    allowExactRescue: input.allowExactRescue,
     allowedUriScopes: input.allowedUriScopes,
     corpusStatistics: recallIndex?.corpusStatistics,
     feedbackByUri,

--- a/src/share.ts
+++ b/src/share.ts
@@ -82,7 +82,7 @@ const PACK_FILES_DIR = 'files';
 // back to the real install directory at install time so hardcoded paths resolve
 // on a teammate's machine.
 const PACK_ROOT_TOKEN = '${THREADNOTE_PACK_ROOT}';
-const AUTO_SHARE_FETCH_INTERVAL_MS = 5 * 60 * 1000;
+export const SHARED_BACKGROUND_FETCH_INTERVAL_MILLISECONDS = 5 * 60 * 1000;
 export const DEFAULT_GIT_REMOTE_NAME = 'origin';
 
 export {applyScrubber, scrubberBlocker} from './scrubber.js';
@@ -185,7 +185,6 @@ interface AutoShareState {
   lastCheckedAt: number;
   operationPromise?: Promise<unknown>;
   pendingReindexes: Map<string, readonly ChangedFile[]>;
-  timer?: ReturnType<typeof setInterval>;
 }
 
 const autoShareStates = new Map<string, AutoShareState>();
@@ -238,11 +237,6 @@ interface PendingReindexFile {
 }
 
 export function clearAutoShareStateForTest(): void {
-  for (const state of autoShareStates.values()) {
-    if (state.timer) {
-      clearInterval(state.timer);
-    }
-  }
   autoShareStates.clear();
 }
 
@@ -380,29 +374,8 @@ export async function runShareStatus(config: ShareRuntime, options: ShareStatusO
   }
 }
 
-export function startShareBackgroundFetch(config: ShareRuntime): void {
-  const state = autoShareState(config);
-  if (state.timer) {
-    return;
-  }
-  void refreshShareUpdateState(config, {force: true}).catch(err => {
-    consoleOutput.error(`share auto-fetch failed: ${err instanceof Error ? err.message : String(err)}`);
-  });
-  state.timer = setInterval(() => {
-    void refreshShareUpdateState(config, {force: false}).catch(err => {
-      consoleOutput.error(`share auto-fetch failed: ${err instanceof Error ? err.message : String(err)}`);
-    });
-  }, AUTO_SHARE_FETCH_INTERVAL_MS);
-  state.timer.unref?.();
-}
-
-export function stopShareBackgroundFetch(config: ShareRuntime): void {
-  const key = `${config.agentContextHome}:${config.account}:${config.user}`;
-  const state = autoShareStates.get(key);
-  if (state?.timer) {
-    clearInterval(state.timer);
-  }
-  autoShareStates.delete(key);
+export async function refreshSharedReposInBackground(config: ShareRuntime, force: boolean): Promise<void> {
+  return refreshShareUpdateState(config, {force});
 }
 
 export async function syncSharedReposBeforeAgentRead(config: ShareRuntime): Promise<AutoShareSyncResult> {
@@ -526,7 +499,11 @@ async function refreshShareUpdateStateLocked(
   options: {readonly force: boolean},
 ): Promise<string[]> {
   const now = Date.now();
-  if (!options.force && state.lastCheckedAt > 0 && now - state.lastCheckedAt < AUTO_SHARE_FETCH_INTERVAL_MS) {
+  if (
+    !options.force &&
+    state.lastCheckedAt > 0 &&
+    now - state.lastCheckedAt < SHARED_BACKGROUND_FETCH_INTERVAL_MILLISECONDS
+  ) {
     return [];
   }
   try {
@@ -4428,11 +4405,7 @@ async function applyChangesToOpenViking(
   const ov = await openVikingCliForMode(false);
   const failed: ChangedFile[] = [];
   for (const change of changes) {
-    if (!change.relativePath.endsWith('.md')) {
-      continue;
-    }
-    const firstSegment = change.relativePath.split('/')[0];
-    if (!SHAREABLE_TOP_LEVEL_DIRS.includes(firstSegment)) {
+    if (!isShareableMemoryChange(change)) {
       continue;
     }
     const uri = workfileToVikingUri(config, team, change.path);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1491,12 +1491,14 @@ function renderRecallHits(
     lines.push(`(+${overflow} more — refine the query or read a URI above)`);
   }
   const noSemanticMatch = shown.every(hit => hit.score === 0);
+  const showLowConfidenceNote =
+    noSemanticMatch && (confidence === undefined || confidence.level === 'low' || confidence.level === 'no_answer');
   const confidenceLine = confidence
     ? `Recall confidence: ${confidence.level.replace('_', ' ')} (${confidence.score.toFixed(2)}) — ${confidence.reason}`
     : undefined;
   return [
     ...(confidenceLine ? [confidenceLine] : []),
-    ...(noSemanticMatch ? [RECALL_LOW_CONFIDENCE_NOTE] : []),
+    ...(showLowConfidenceNote ? [RECALL_LOW_CONFIDENCE_NOTE] : []),
     ...lines,
   ].join('\n');
 }
@@ -1525,6 +1527,7 @@ const RECALL_INDEX_PRESELECTION_MULTIPLIER = 10;
 const RECALL_INDEX_PRESELECTION_MINIMUM = 100;
 
 interface HybridRecallOptions {
+  readonly allowExactRescue?: boolean;
   readonly allowedUriScopes?: readonly string[];
   readonly corpusStatistics?: RecallCorpusStatistics;
   readonly feedbackByUri?: ReadonlyMap<string, number>;
@@ -1635,9 +1638,10 @@ function hybridRankRecallHits(
     return {
       ...indexed,
       authority: indexed?.authority ?? (record ? boundedMemoryAuthority(uri, record.metadata) : recallAuthority(hit)),
+      exactTerms: hit.exactTerms,
       feedback: context.feedbackByUri?.get(uri),
       fields: {
-        identifiers: hit.exactTerms ?? indexed?.fields?.identifiers,
+        identifiers: indexed?.fields?.identifiers,
         project:
           record?.metadata.project ??
           indexed?.fields?.project ??

--- a/test/e2e/local-bins.e2e.ts
+++ b/test/e2e/local-bins.e2e.ts
@@ -626,7 +626,7 @@ describe('published local bins', () => {
 
       expect(firstText).toContain('Recall confidence:');
       expect(firstText).toContain('why:');
-      expect(firstStructured.rankerVersion).toBe('hybrid-v1');
+      expect(firstStructured.rankerVersion).toBe('hybrid-v2');
       expect(firstStructured.confidence.level).not.toBe('no_answer');
       expect(firstTarget).toBeDefined();
       expect(firstTarget?.finalScore).toBeGreaterThan(0);

--- a/test/integration/mcp.openviking-parity.test.ts
+++ b/test/integration/mcp.openviking-parity.test.ts
@@ -278,7 +278,7 @@ describe('Threadnote MCP toolsets', () => {
           confidence: {
             level: expect.stringMatching(/^(?:high|medium|low|no_answer)$/),
           },
-          rankerVersion: 'hybrid-v1',
+          rankerVersion: 'hybrid-v2',
           results: expect.any(Array),
         });
       },

--- a/test/integration/share.sync.test.ts
+++ b/test/integration/share.sync.test.ts
@@ -1,7 +1,8 @@
 import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
-import {Effect} from 'effect';
+import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
+import {Effect, Layer} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {listShareConflicts, showShareConflict} from '../../src/share.js';
 import {
@@ -12,10 +13,13 @@ import {
 import type {ShareRuntime, ShareTeamsFile} from '../../src/types.js';
 import {runCommand} from '../../src/utils.js';
 
-const runShareInit = (...args: Parameters<typeof runShareInitEffect>) => Effect.runPromise(runShareInitEffect(...args));
-const runShareSync = (...args: Parameters<typeof runShareSyncEffect>) => Effect.runPromise(runShareSyncEffect(...args));
+const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
+const runShareInit = (...args: Parameters<typeof runShareInitEffect>) =>
+  Effect.runPromise(runShareInitEffect(...args).pipe(Effect.provide(TestLayer)));
+const runShareSync = (...args: Parameters<typeof runShareSyncEffect>) =>
+  Effect.runPromise(runShareSyncEffect(...args).pipe(Effect.provide(TestLayer)));
 const resolveShareConflict = (...args: Parameters<typeof resolveShareConflictEffect>) =>
-  Effect.runPromise(resolveShareConflictEffect(...args));
+  Effect.runPromise(resolveShareConflictEffect(...args).pipe(Effect.provide(TestLayer)));
 
 interface TestShareRepo {
   readonly config: ShareRuntime;
@@ -497,6 +501,28 @@ describe('share sync git handling', () => {
       'MEMORY\nkind: durable\nstatus: active\n\nshared body\n',
     );
     await expect(readFile(pendingPath, 'utf8')).rejects.toMatchObject({code: 'ENOENT'});
+  });
+
+  it('does not ingest shared agent artifacts as memory conflicts', async () => {
+    const {config, home, root, seed} = await makeShareRepo();
+    const {ov, store} = await installFakeOv(root);
+    process.env.THREADNOTE_OV = ov;
+    process.env.THREADNOTE_FAKE_OV_STORE = store;
+    const relativePath = 'agent-artifacts/skills/codex/reviewer/SKILL.md';
+    const uri = 'viking://user/denys/memories/shared/default/agent-artifacts/skills/codex/reviewer/SKILL.md';
+    await mkdir(dirname(join(seed, relativePath)), {recursive: true});
+    await writeFile(join(seed, relativePath), '# Reviewer\n\nReview pull requests.\n', 'utf8');
+    await git(['add', relativePath], seed);
+    await git(['commit', '-m', 'add shared skill'], seed);
+    await git(['push', 'origin', 'main'], seed);
+
+    await runShareSync(config, {push: false});
+
+    await expect(readFile(join(home, 'share', 'auto-sync-pending-reindexes.json'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(readFile(fakeOvFile(store, uri), 'utf8')).rejects.toMatchObject({code: 'ENOENT'});
+    await expect(listShareConflicts(config, {team: 'default'})).resolves.toEqual([]);
   });
 
   it('keeps a pending added reindex blocked when OpenViking has a real local edit', async () => {

--- a/test/unit/effect-share.test.ts
+++ b/test/unit/effect-share.test.ts
@@ -1,22 +1,30 @@
 import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Effect, Layer} from 'effect';
+import {Effect, Fiber, Layer} from 'effect';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 
 const shareMocks = vi.hoisted(() => ({
   resolveTeam: vi.fn(),
+  runShareConflicts: vi.fn(),
   runSharePublish: vi.fn(),
+  runShareSync: vi.fn(),
+  shareAgentArtifact: vi.fn(),
+  shareBundlePack: vi.fn(),
+  refreshSharedReposInBackground: vi.fn(),
+  syncSharedReposBeforeAgentRead: vi.fn(),
   sharedUriFor: vi.fn(),
   unused: vi.fn(),
 }));
 
 vi.mock('../../src/share.js', () => ({
   installSharedAgentArtifacts: shareMocks.unused,
+  listShareConflicts: shareMocks.unused,
   listSharedAgentArtifacts: shareMocks.unused,
   removeMemoryUri: shareMocks.unused,
+  refreshSharedReposInBackground: shareMocks.refreshSharedReposInBackground,
   resolveShareConflict: shareMocks.unused,
   resolveTeam: shareMocks.resolveTeam,
   runShareConflictResolve: shareMocks.unused,
-  runShareConflicts: shareMocks.unused,
+  runShareConflicts: shareMocks.runShareConflicts,
   runShareConflictShow: shareMocks.unused,
   runShareInit: shareMocks.unused,
   runShareInstallArtifacts: shareMocks.unused,
@@ -28,12 +36,22 @@ vi.mock('../../src/share.js', () => ({
   runShareRename: shareMocks.unused,
   runShareSetUrl: shareMocks.unused,
   runShareStatus: shareMocks.unused,
-  runShareSync: shareMocks.unused,
+  runShareSync: shareMocks.runShareSync,
   runShareUnpublish: shareMocks.unused,
+  shareAgentArtifact: shareMocks.shareAgentArtifact,
+  shareBundlePack: shareMocks.shareBundlePack,
+  SHARED_BACKGROUND_FETCH_INTERVAL_MILLISECONDS: 300_000,
   sharedUriFor: shareMocks.sharedUriFor,
+  showShareConflict: shareMocks.unused,
+  syncSharedReposBeforeAgentRead: shareMocks.syncSharedReposBeforeAgentRead,
 }));
 
-import {runSharePublish} from '../../src/effect/share.js';
+import {
+  runShareConflicts,
+  runSharePublish,
+  runShareSync,
+  syncSharedReposBeforeAgentRead,
+} from '../../src/effect/share.js';
 import {mkdtemp, rm} from '../helpers/effect-filesystem.js';
 
 const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
@@ -90,5 +108,98 @@ describe('Effect share transaction', () => {
       expect.any(String),
       expect.objectContaining({team: 'alpha'}),
     );
+  });
+
+  it('keeps explicit sync blocked when an interrupted auto-sync Promise is still running', async () => {
+    const agentContextHome = await mkdtemp('threadnote-effect-share-sync-');
+    homes.push(agentContextHome);
+    const events: string[] = [];
+    let markFirstStarted: (() => void) | undefined;
+    let releaseFirst: (() => void) | undefined;
+    const firstStarted = new Promise<void>(resolve => {
+      markFirstStarted = resolve;
+    });
+    const firstBlocked = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    const config = {
+      account: 'local',
+      agentContextHome,
+      agentId: 'threadnote',
+      user: 'test-user',
+    };
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        shareMocks.syncSharedReposBeforeAgentRead.mockImplementationOnce(async () => {
+          events.push('first:start');
+          markFirstStarted?.();
+          await firstBlocked;
+          events.push('first:end');
+          return {syncedTeams: [], warnings: []};
+        });
+        shareMocks.runShareSync.mockImplementationOnce(async () => {
+          events.push('second:start');
+        });
+
+        const first = yield* Effect.forkChild(syncSharedReposBeforeAgentRead(config));
+        yield* Effect.promise(() => firstStarted);
+        const interruption = yield* Effect.forkChild(Fiber.interrupt(first));
+        yield* Effect.yieldNow;
+        const second = yield* Effect.forkChild(runShareSync(config, {}));
+        yield* Effect.yieldNow;
+        expect(events).toEqual(['first:start']);
+        yield* Effect.sync(() => releaseFirst?.());
+        yield* Fiber.join(interruption);
+        yield* Fiber.join(second);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
+    expect(events).toEqual(['first:start', 'first:end', 'second:start']);
+  });
+
+  it('keeps sync blocked while conflict inspection refreshes pending state', async () => {
+    const agentContextHome = await mkdtemp('threadnote-effect-share-conflicts-');
+    homes.push(agentContextHome);
+    const events: string[] = [];
+    let markInspectionStarted: (() => void) | undefined;
+    let releaseInspection: (() => void) | undefined;
+    const inspectionStarted = new Promise<void>(resolve => {
+      markInspectionStarted = resolve;
+    });
+    const inspectionBlocked = new Promise<void>(resolve => {
+      releaseInspection = resolve;
+    });
+    const config = {
+      account: 'local',
+      agentContextHome,
+      agentId: 'threadnote',
+      user: 'test-user',
+    };
+    shareMocks.runShareConflicts.mockImplementationOnce(async () => {
+      events.push('inspection:start');
+      markInspectionStarted?.();
+      await inspectionBlocked;
+      events.push('inspection:end');
+      return [];
+    });
+    shareMocks.runShareSync.mockImplementationOnce(async () => {
+      events.push('sync:start');
+    });
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const inspection = yield* Effect.forkChild(runShareConflicts(config, {}));
+        yield* Effect.promise(() => inspectionStarted);
+        const sync = yield* Effect.forkChild(runShareSync(config, {}));
+        yield* Effect.yieldNow;
+        expect(events).toEqual(['inspection:start']);
+        yield* Effect.sync(() => releaseInspection?.());
+        yield* Fiber.join(inspection);
+        yield* Fiber.join(sync);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
+    expect(events).toEqual(['inspection:start', 'inspection:end', 'sync:start']);
   });
 });

--- a/test/unit/recall.rank.test.ts
+++ b/test/unit/recall.rank.test.ts
@@ -34,6 +34,230 @@ describe('hybrid recall ranker', () => {
     );
   });
 
+  it('prefers an exact compound topic over a general body match', () => {
+    const ranked = rankRecallCandidates(
+      'threadnote user preference posting style for release notes',
+      [
+        {
+          fields: {
+            project: 'agent-posting',
+            title: 'Denys writing style',
+            topic: 'denys-writing-style',
+          },
+          kind: 'preference',
+          semantic: 0.69,
+          text: 'General posting style guidance that mentions release notes among many other formats.',
+          uri: 'viking://user/me/memories/preferences/denys-writing-style.md',
+        },
+        {
+          fields: {
+            project: 'github',
+            title: 'Release notes',
+            topic: 'release-notes',
+          },
+          kind: 'preference',
+          semantic: 0.68,
+          text: 'Release descriptions should emphasize end-user value.',
+          uri: 'viking://user/me/memories/preferences/release-notes.md',
+        },
+      ],
+      {project: 'threadnote', now: new Date('2026-07-23T00:00:00.000Z')},
+    );
+
+    expect(ranked.results[0]?.candidate.uri).toContain('release-notes.md');
+    expect(ranked.results[0]?.reasons.map(reason => reason.code)).toContain('memory_kind_intent');
+    expect(ranked.results[0]?.signals.field).toBeGreaterThan(ranked.results[1]?.signals.field ?? 0);
+  });
+
+  it('uses memory-kind intent to prefer durable contracts over related handoffs', () => {
+    const ranked = rankRecallCandidates(
+      'threadnote native Windows support contract and unsupported installation requirements',
+      [
+        {
+          fields: {project: 'threadnote', title: 'Recall and memory formation', topic: 'recall-and-memory-formation'},
+          kind: 'handoff',
+          semantic: 0.73,
+          text: 'Windows installation remains unsupported and is documented in shared durable memory.',
+          uri: 'viking://user/me/memories/handoffs/active/threadnote/recall-and-memory-formation.md',
+        },
+        {
+          authority: 'reviewed_shared',
+          fields: {
+            project: 'threadnote',
+            title: 'Windows installation support',
+            topic: 'windows-installation-support',
+          },
+          kind: 'durable',
+          semantic: 0.68,
+          text: 'Native Windows installation is unsupported until the package, OpenViking, and lifecycle gates pass.',
+          trust: 'approved',
+          uri: 'viking://user/me/memories/shared/default/durable/projects/threadnote/windows-installation-support.md',
+        },
+      ],
+      {project: 'threadnote', now: new Date('2026-07-23T00:00:00.000Z')},
+    );
+
+    expect(ranked.results[0]?.candidate.uri).toContain('windows-installation-support.md');
+    expect(ranked.results[0]?.signals.kindIntent).toBe(1);
+    expect(ranked.results[1]?.signals.kindIntent).toBe(0);
+  });
+
+  it('rescues a focused exact field without boosting a project-name-only match', () => {
+    const ranked = rankRecallCandidates(
+      'threadnote can users install reliably on native Windows what remains unsupported',
+      [
+        {
+          exactTerms: ['threadnote'],
+          fields: {project: 'threadnote', title: 'Threadnote macOS native app', topic: 'macos-native-app'},
+          kind: 'durable',
+          semantic: 0.69,
+          text: 'Threadnote macOS application guidance.',
+          uri: 'viking://user/me/memories/durable/projects/threadnote/macos-native-app.md',
+        },
+        {
+          authority: 'reviewed_shared',
+          exactTerms: ['windows'],
+          fields: {
+            project: 'threadnote',
+            title: 'Windows installation support',
+            topic: 'windows-installation-support',
+          },
+          kind: 'durable',
+          text: 'Native Windows installation remains unsupported.',
+          trust: 'approved',
+          uri: 'viking://user/me/memories/shared/default/durable/projects/threadnote/windows-installation-support.md',
+        },
+      ],
+      {
+        allowExactRescue: true,
+        minimumScore: 0.45,
+        project: 'threadnote',
+        now: new Date('2026-07-23T00:00:00.000Z'),
+      },
+    );
+
+    expect(ranked.results[0]?.candidate.uri).toContain('windows-installation-support.md');
+    expect(ranked.results[0]?.signals.exact).toBe(1);
+    expect(ranked.results.find(result => result.candidate.uri.includes('macos-native-app'))).toBeUndefined();
+  });
+
+  it('weights discriminative exact terms above common project-name matches', () => {
+    const ranked = rankRecallCandidates(
+      'Threadnote Windows installation issue durable decision',
+      [
+        {
+          exactTerms: ['Threadnote', 'installation', 'decision'],
+          fields: {project: 'threadnote', title: 'macos-native-app.md', topic: 'macos-native-app'},
+          kind: 'durable',
+          semantic: 0.62,
+          text: 'Threadnote native app installation decision.',
+          uri: 'viking://user/me/memories/durable/projects/threadnote/macos-native-app.md',
+        },
+        {
+          authority: 'reviewed_shared',
+          exactTerms: ['Windows', 'installation', 'decision'],
+          fields: {project: 'threadnote', title: 'Current status', topic: 'windows-installation-support'},
+          kind: 'durable',
+          text: 'Windows installation remains unsupported by a durable product decision.',
+          trust: 'approved',
+          uri: 'viking://user/me/memories/shared/default/durable/projects/threadnote/windows-installation-support.md',
+        },
+      ],
+      {
+        corpusStatistics: {
+          averageDocumentLength: 100,
+          documentCount: 59,
+          documentFrequency: {
+            decision: 7,
+            durable: 18,
+            installation: 7,
+            issue: 7,
+            threadnote: 55,
+            windows: 4,
+          },
+          totalDocumentLength: 5_900,
+        },
+        allowExactRescue: true,
+        minimumScore: 0.5,
+        now: new Date('2026-07-23T00:00:00.000Z'),
+        project: 'threadnote',
+      },
+    );
+
+    expect(ranked.results[0]?.candidate.uri).toContain('windows-installation-support.md');
+    expect(ranked.results[0]?.signals.exact).toBeGreaterThan(ranked.results[1]?.signals.exact ?? 0);
+  });
+
+  it('does not let default exact rescue bypass an explicit strict minimum', () => {
+    const ranked = rankRecallCandidates(
+      'Windows installation decision',
+      [
+        {
+          exactTerms: ['Windows', 'installation', 'decision'],
+          fields: {project: 'threadnote', title: 'Windows installation', topic: 'windows-installation'},
+          kind: 'durable',
+          text: 'Windows installation decision.',
+          uri: 'viking://user/me/memories/windows-installation.md',
+        },
+      ],
+      {allowExactRescue: false, minimumScore: 0.95, project: 'threadnote'},
+    );
+
+    expect(ranked.results).toEqual([]);
+    expect(ranked.confidence.level).toBe('no_answer');
+  });
+
+  it('does not treat a matching project field as topical evidence by itself', () => {
+    const ranked = rankRecallCandidates('threadnote quantum networking policy', [
+      {
+        fields: {project: 'threadnote'},
+        text: 'Unrelated deployment instructions.',
+        uri: 'viking://user/me/memories/unrelated.md',
+      },
+    ]);
+
+    expect(ranked.results).toEqual([]);
+    expect(ranked.confidence.level).toBe('no_answer');
+  });
+
+  it('does not treat a project-only exact identifier as topical evidence', () => {
+    const ranked = rankRecallCandidates(
+      'my-project quantum networking',
+      [
+        {
+          exactTerms: ['my-project'],
+          fields: {project: 'my-project'},
+          kind: 'durable',
+          text: 'Unrelated deployment instructions.',
+          uri: 'viking://user/me/memories/unrelated.md',
+        },
+      ],
+      {allowExactRescue: true, minimumScore: 0.45, project: 'my-project'},
+    );
+
+    expect(ranked.results).toEqual([]);
+    expect(ranked.confidence.level).toBe('no_answer');
+  });
+
+  it('does not reuse a generic kind-intent term as exact rescue evidence', () => {
+    const ranked = rankRecallCandidates(
+      'quantum networking policy',
+      [
+        {
+          exactTerms: ['policy'],
+          fields: {title: 'Policy'},
+          kind: 'durable',
+          text: 'Policy for unrelated deployments.',
+          uri: 'viking://user/me/memories/unrelated-policy.md',
+        },
+      ],
+      {allowExactRescue: true, minimumScore: 0.45},
+    );
+
+    expect(ranked.results).toEqual([]);
+    expect(ranked.confidence.level).toBe('no_answer');
+  });
+
   it('uses typed graph proximity without allowing authority to bypass topical relevance', () => {
     const seedUri = 'viking://resources/repos/threadnote/design.md';
     const ranked = rankRecallCandidates(
@@ -149,6 +373,7 @@ describe('hybrid recall ranker', () => {
       'release channel',
       [
         {
+          exactTerms: ['release', 'channel'],
           fields: {project: 'threadnote', title: 'Release channel'},
           semantic: 1,
           status: 'archived',

--- a/test/unit/share.admin.test.ts
+++ b/test/unit/share.admin.test.ts
@@ -1,7 +1,8 @@
 import {access, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {Effect} from 'effect';
+import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
+import {Effect, Layer} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {publishShareGitChange} from '../../src/share.js';
 import {
@@ -12,12 +13,13 @@ import {
 import type {CommandResult, ShareRuntime, ShareTeamsFile} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
 
+const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
 const runShareRemove = (...args: Parameters<typeof runShareRemoveEffect>) =>
-  Effect.runPromise(runShareRemoveEffect(...args));
+  Effect.runPromise(runShareRemoveEffect(...args).pipe(Effect.provide(TestLayer)));
 const runShareRename = (...args: Parameters<typeof runShareRenameEffect>) =>
-  Effect.runPromise(runShareRenameEffect(...args));
+  Effect.runPromise(runShareRenameEffect(...args).pipe(Effect.provide(TestLayer)));
 const runShareSetUrl = (...args: Parameters<typeof runShareSetUrlEffect>) =>
-  Effect.runPromise(runShareSetUrlEffect(...args));
+  Effect.runPromise(runShareSetUrlEffect(...args).pipe(Effect.provide(TestLayer)));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();

--- a/test/unit/share.artifacts.test.ts
+++ b/test/unit/share.artifacts.test.ts
@@ -1,7 +1,8 @@
 import {mkdtemp, mkdir, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {Effect} from 'effect';
+import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
+import {Effect, Layer} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {shareAgentArtifact, shareBundlePack} from '../../src/share.js';
 import {
@@ -12,12 +13,13 @@ import {
 import type {CommandResult, ShareRuntime} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
 
+const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
 const runShareInstallArtifacts = (...args: Parameters<typeof runShareInstallArtifactsEffect>) =>
-  Effect.runPromise(runShareInstallArtifactsEffect(...args));
+  Effect.runPromise(runShareInstallArtifactsEffect(...args).pipe(Effect.provide(TestLayer)));
 const listSharedAgentArtifacts = (...args: Parameters<typeof listSharedAgentArtifactsEffect>) =>
-  Effect.runPromise(listSharedAgentArtifactsEffect(...args));
+  Effect.runPromise(listSharedAgentArtifactsEffect(...args).pipe(Effect.provide(TestLayer)));
 const installSharedAgentArtifacts = (...args: Parameters<typeof installSharedAgentArtifactsEffect>) =>
-  Effect.runPromise(installSharedAgentArtifactsEffect(...args));
+  Effect.runPromise(installSharedAgentArtifactsEffect(...args).pipe(Effect.provide(TestLayer)));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -807,6 +807,55 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
     );
   });
 
+  it('rescues an authoritative exact shared memory before hybrid reranking', () => {
+    const uri = 'viking://user/me/memories/shared/default/durable/projects/threadnote/windows-installation-support.md';
+    const sections = buildRecallSections(
+      [
+        [
+          {
+            category: 'memories',
+            contextType: 'memory',
+            score: 0.71,
+            snippet: 'Windows installation remains unsupported and is documented in shared durable memory.',
+            uri: 'viking://user/me/memories/handoffs/active/threadnote/recall-and-memory-formation.md',
+          },
+        ],
+      ],
+      [{terms: ['windows'], uri}],
+      5,
+      {
+        allowExactRescue: true,
+        minimumScore: 0.45,
+        project: 'threadnote',
+        query: 'threadnote can users install reliably on native Windows what remains unsupported',
+        records: [
+          {
+            body: 'Native Windows installation remains unsupported until package, OpenViking, and lifecycle gates pass.',
+            content:
+              'MEMORY\nkind: durable\nstatus: active\nproject: threadnote\ntopic: windows-installation-support\n\nNative Windows installation remains unsupported until package, OpenViking, and lifecycle gates pass.',
+            headerTitle: 'MEMORY',
+            metadata: {
+              kind: 'durable',
+              project: 'threadnote',
+              sourceAgentClient: 'codex',
+              status: 'active',
+              timestamp: '2026-07-23T00:00:00.000Z',
+              topic: 'windows-installation-support',
+            },
+            uri,
+          },
+        ],
+      },
+    );
+
+    expect(sections.ranked[0]?.uri).toBe(uri);
+    expect(sections.ranked[0]?.score).toBe(0);
+    expect(sections.ranked[0]?.rankReasons?.map(reason => reason.code)).toEqual(
+      expect.arrayContaining(['bm25_lexical', 'exact_term_match', 'field_match', 'memory_kind_intent']),
+    );
+    expect(sections.semanticSection).not.toContain(RECALL_LOW_CONFIDENCE_NOTE);
+  });
+
   it('caps hydrated record authority and trust at the personal-memory boundary', () => {
     const uri = 'viking://user/me/memories/durable/projects/threadnote/unreviewed.md';
     const sections = buildRecallSections(


### PR DESCRIPTION
## What changed

- sharpen hybrid recall with topical exact-match attribution, IDF-aware lexical evidence, memory-kind intent, and
  strict explicit thresholds
- add transparent confidence and ranking explanations to packaged recall results
- serialize shared-memory refresh, sync, publication, conflicts, artifacts, and team administration through one
  Effect-composed cross-process lock
- publish package version `3.0.0-beta.2`

## Why

Beta testing found that repository names and generic memory-kind words could rescue otherwise unrelated results.
Shared-memory operations also needed one transaction boundary so automatic refresh could not overlap manual
publication or administration.

Users should see fewer weak recall results, clearer explanations for useful matches, and safer shared-memory behavior
when multiple agents or processes operate concurrently. Existing memories require no migration.

## Checks

- lint and TypeScript source/test typechecks
- 559 unit and integration tests
- build and bundle-size gates
- recall evaluation
- 11 packaged local-bin E2E tests against live OpenViking
- diff audit confirming no new nested Effect runtime in application code
