### PR TITLE
Add native Windows installation and E2E support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,28 @@ jobs:
       - run: npm run test:e2e:install-openviking
 
       - run: npm run test:e2e:local-bins
+
+  windows-e2e:
+    name: E2E tests · windows · node 22
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm test -- --run test/unit/windows-support.test.ts test/unit/update.test.ts test/unit/mcp.test.ts
+
+      - run: npm run test:e2e:windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
 
       - run: npm run typecheck
 
-      - run: npm test -- --run test/unit/windows-support.test.ts test/unit/update.test.ts test/unit/mcp.test.ts
+      - run: >-
+          npm test -- --run
+          test/unit/windows-support.test.ts
+          test/unit/effect-command.test.ts
+          test/unit/effect-system.test.ts
+          test/unit/lifecycle.install.test.ts
+          test/unit/update.test.ts
+          test/unit/mcp.test.ts
 
       - run: npm run test:e2e:windows

--- a/README.md
+++ b/README.md
@@ -75,11 +75,25 @@ by product, plan, account, and region.
 
 ## Quickstart
 
+macOS and Linux:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.sh | sh
 threadnote mcp-install claude --apply   # or codex / cursor / copilot
 threadnote doctor --dry-run
 ```
+
+Native Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.ps1 | iex
+threadnote mcp-install codex --apply    # or claude / cursor / copilot
+threadnote doctor --dry-run
+```
+
+The Windows installer uses npm's native `threadnote.cmd` launcher and installs OpenViking through `uv`; it does not
+require WSL, Git Bash, or a POSIX shim. Node.js 22.19 or newer is required on every platform. The manual native flow is
+`npm install --global threadnote` followed by `threadnote install`.
 
 The CLI remains Threadnote's complete execution surface. The default stdio adapter is a compact interoperability layer
 with eight core tools: `recall_context`, `read_context`, `list_context`, `remember_context`,

--- a/docs/index.html
+++ b/docs/index.html
@@ -1492,8 +1492,9 @@
 <span class="out-strong">OK   openviking 0.4.10 ready · server healthy</span></pre>
               </div>
               <p class="muted" style="margin-top: 0.75rem; font-size: 0.9rem">
-                Or manually: <code>npm install -g threadnote && threadnote install</code>. On a fresh macOS / modern
-                Linux machine the installer offers to <code>brew install uv</code> for you (avoids PEP 668 errors).
+                On native Windows PowerShell, run
+                <code>irm https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.ps1 | iex</code>.
+                Or manually: <code>npm install -g threadnote && threadnote install</code>.
               </p>
             </div>
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,9 +8,11 @@ Run:
 threadnote install
 ```
 
-The installer prefers `uv`, then `pipx`, then `python3 -m pip install --user`. For `curl | sh` installs, the wrapper
-reattaches `threadnote install` to your terminal when possible so it can prompt to install `uv` and continue instead of
-falling straight through to the pip fallback.
+The installer prefers `uv`, then `pipx`, then the platform Python launcher (`py`/`python` on Windows or `python3` on
+macOS and Linux). For `curl | sh` installs, the wrapper reattaches `threadnote install` to your terminal when possible
+so it can prompt to install `uv` and continue instead of falling straight through to the pip fallback. Native Windows
+uses `scripts/install.ps1`, preserves npm's `threadnote.cmd` launcher, and can install `uv` with its official PowerShell
+bootstrap.
 
 ## `uv` Fails With `UnknownIssuer`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "3.0.0-beta.2",
+      "version": "3.0.0-beta.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "npm run clean --silent && node scripts/build.mjs",
     "check:bundle-size": "node scripts/check-bundle-size.mjs",
-    "clean": "rm -rf dist",
+    "clean": "node scripts/clean.mjs",
     "dev": "tsx src/threadnote.ts",
     "dev:mcp-server": "tsx src/mcp_server.ts",
     "lint": "oxlint src test",
@@ -56,6 +56,7 @@
     "test": "vitest run",
     "test:e2e:install-openviking": "node scripts/install-e2e-openviking.mjs",
     "test:e2e:local-bins": "npm run build --silent && vitest run --config vitest.e2e.config.ts",
+    "test:e2e:windows": "npm run build --silent && vitest run --config vitest.windows-e2e.config.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "threadnote": "npm run build --silent && node ./bin/threadnote.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "type": "module",
   "main": "dist/threadnote.js",
   "description": "Shared local context and handoffs for development agents",

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,7 +1,5 @@
-import {stat} from 'node:fs/promises';
-import {Console, Effect} from 'effect';
-
-const output = Effect.runSync(Console.Console);
+import {NodeRuntime, NodeServices} from '@effect/platform-node';
+import {Console, Effect, FileSystem} from 'effect';
 
 const budgets = [
   {bytes: 1_750_000, path: 'dist/threadnote.js'},
@@ -9,14 +7,18 @@ const budgets = [
   {bytes: 450_000, path: 'manager/app.js'},
 ];
 
-let exceeded = false;
-for (const budget of budgets) {
-  const {size} = await stat(budget.path);
-  const status = size <= budget.bytes ? 'OK' : 'OVER';
-  output.log(`${status} ${budget.path}: ${size.toLocaleString()} / ${budget.bytes.toLocaleString()} bytes`);
-  exceeded ||= size > budget.bytes;
-}
+const checkBundleSizes = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  let exceeded = false;
+  for (const budget of budgets) {
+    const {size} = yield* fs.stat(budget.path);
+    const status = size <= budget.bytes ? 'OK' : 'OVER';
+    yield* Console.log(`${status} ${budget.path}: ${size.toLocaleString()} / ${budget.bytes.toLocaleString()} bytes`);
+    exceeded ||= size > budget.bytes;
+  }
+  if (exceeded) {
+    process.exitCode = 1;
+  }
+});
 
-if (exceeded) {
-  process.exitCode = 1;
-}
+NodeRuntime.runMain(checkBundleSizes.pipe(Effect.provide(NodeServices.layer)));

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,4 +1,5 @@
-import {NodeRuntime, NodeServices} from '@effect/platform-node';
+import * as NodeRuntime from '@effect/platform-node/NodeRuntime';
+import * as NodeServices from '@effect/platform-node/NodeServices';
 import {Console, Effect, FileSystem} from 'effect';
 
 const budgets = [
@@ -17,7 +18,7 @@ const checkBundleSizes = Effect.gen(function* () {
     exceeded ||= size > budget.bytes;
   }
   if (exceeded) {
-    process.exitCode = 1;
+    return yield* Effect.fail(new Error('Bundle size budget exceeded.'));
   }
 });
 

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,4 +1,5 @@
-import {NodeRuntime, NodeServices} from '@effect/platform-node';
+import * as NodeRuntime from '@effect/platform-node/NodeRuntime';
+import * as NodeServices from '@effect/platform-node/NodeServices';
 import {Effect, FileSystem, Path} from 'effect';
 
 const clean = Effect.gen(function* () {

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,10 @@
+import {NodeRuntime, NodeServices} from '@effect/platform-node';
+import {Effect, FileSystem, Path} from 'effect';
+
+const clean = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  yield* fs.remove(path.resolve(import.meta.dirname, '..', 'dist'), {force: true, recursive: true});
+});
+
+NodeRuntime.runMain(clean.pipe(Effect.provide(NodeServices.layer)));

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -49,6 +49,10 @@ if ($needsUv -and -not (Get-Command uv.exe -ErrorAction SilentlyContinue) -and -
   if (-not (($env:PSModulePath -split ';') -contains $powerShellModulePath)) {
     $env:PSModulePath = "$powerShellModulePath;$env:PSModulePath"
   }
+  $securityModule = Join-Path $powerShellModulePath 'Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.psd1'
+  if (Test-Path -LiteralPath $securityModule) {
+    Import-Module $securityModule -Force -ErrorAction Stop
+  }
   Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
   $uvBin = Join-Path $HOME '.local\bin'
   if (Test-Path -LiteralPath $uvBin) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -45,6 +45,10 @@ if (-not $threadnotePath -or -not (Test-Path -LiteralPath $threadnotePath)) {
 $needsUv = -not $PackageManager -or $PackageManager -eq 'uv'
 if ($needsUv -and -not (Get-Command uv.exe -ErrorAction SilentlyContinue) -and -not (Get-Command uv -ErrorAction SilentlyContinue)) {
   Write-Host 'Installing uv for the isolated OpenViking environment'
+  $powerShellModulePath = Join-Path $PSHOME 'Modules'
+  if (-not (($env:PSModulePath -split ';') -contains $powerShellModulePath)) {
+    $env:PSModulePath = "$powerShellModulePath;$env:PSModulePath"
+  }
   Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
   $uvBin = Join-Path $HOME '.local\bin'
   if (Test-Path -LiteralPath $uvBin) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -18,6 +18,13 @@ $registry = if ($env:THREADNOTE_NPM_REGISTRY) {
   'https://registry.npmjs.org/'
 }
 
+function Format-InstallSourceForLog {
+  param([Parameter(Mandatory = $true)][string]$Value)
+
+  $redacted = $Value -replace '(?i)(https?://)[^/@\s]+@', '$1[REDACTED]@'
+  return $redacted -replace '(\?)[^#\s]+', '$1[REDACTED]'
+}
+
 $npm = Get-Command npm.cmd -ErrorAction SilentlyContinue
 if (-not $npm) {
   $npm = Get-Command npm -ErrorAction SilentlyContinue
@@ -26,7 +33,9 @@ if (-not $npm) {
   throw 'npm was not found on PATH. Install Node.js 22.19 or newer, then rerun this installer.'
 }
 
-Write-Host "Installing $package with npm from $registry"
+$loggedPackage = Format-InstallSourceForLog $package
+$loggedRegistry = Format-InstallSourceForLog $registry
+Write-Host "Installing $loggedPackage with npm from $loggedRegistry"
 & $npm.Source install --global $package "--registry=$registry"
 if ($LASTEXITCODE -ne 0) {
   throw "npm install failed with exit code $LASTEXITCODE."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding(PositionalBinding = $false)]
+param(
+  [switch]$DryRun,
+  [switch]$Force,
+  [switch]$NoStart,
+  [switch]$WithHooks,
+  [ValidateSet('uv', 'pipx', 'pip')]
+  [string]$PackageManager,
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$ThreadnoteArgs
+)
+
+$ErrorActionPreference = 'Stop'
+$package = if ($env:THREADNOTE_PACKAGE) { $env:THREADNOTE_PACKAGE } else { 'threadnote@latest' }
+$registry = if ($env:THREADNOTE_NPM_REGISTRY) {
+  $env:THREADNOTE_NPM_REGISTRY
+} else {
+  'https://registry.npmjs.org/'
+}
+
+$npm = Get-Command npm.cmd -ErrorAction SilentlyContinue
+if (-not $npm) {
+  $npm = Get-Command npm -ErrorAction SilentlyContinue
+}
+if (-not $npm) {
+  throw 'npm was not found on PATH. Install Node.js 22.19 or newer, then rerun this installer.'
+}
+
+Write-Host "Installing $package with npm from $registry"
+& $npm.Source install --global $package "--registry=$registry"
+if ($LASTEXITCODE -ne 0) {
+  throw "npm install failed with exit code $LASTEXITCODE."
+}
+
+$prefix = (& $npm.Source prefix --global).Trim()
+$threadnotePath = if ($prefix) { Join-Path $prefix 'threadnote.cmd' } else { $null }
+if (-not $threadnotePath -or -not (Test-Path -LiteralPath $threadnotePath)) {
+  $threadnote = Get-Command threadnote.cmd -ErrorAction SilentlyContinue
+  if (-not $threadnote) {
+    throw "Installed $package, but threadnote.cmd could not be found."
+  }
+  $threadnotePath = $threadnote.Source
+}
+
+$needsUv = -not $PackageManager -or $PackageManager -eq 'uv'
+if ($needsUv -and -not (Get-Command uv.exe -ErrorAction SilentlyContinue) -and -not (Get-Command uv -ErrorAction SilentlyContinue)) {
+  Write-Host 'Installing uv for the isolated OpenViking environment'
+  Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
+  $uvBin = Join-Path $HOME '.local\bin'
+  if (Test-Path -LiteralPath $uvBin) {
+    $env:Path = "$uvBin;$env:Path"
+  }
+}
+
+$installArgs = @('install')
+if ($DryRun) { $installArgs += '--dry-run' }
+if ($Force) { $installArgs += '--force' }
+if ($NoStart) { $installArgs += '--no-start' }
+if ($WithHooks) { $installArgs += '--with-hooks' }
+if ($PackageManager) { $installArgs += @('--package-manager', $PackageManager) }
+if ($ThreadnoteArgs) { $installArgs += $ThreadnoteArgs }
+
+Write-Host 'Running threadnote install'
+& $threadnotePath @installArgs
+if ($LASTEXITCODE -ne 0) {
+  throw "threadnote install failed with exit code $LASTEXITCODE."
+}
+
+Write-Host ''
+Write-Host 'Threadnote is installed. Next:'
+Write-Host '  threadnote doctor --dry-run'
+Write-Host '  threadnote mcp-install codex --apply    # if you use Codex'
+Write-Host '  threadnote mcp-install claude --apply   # if you use Claude'
+Write-Host '  threadnote mcp-install cursor --apply   # if you use Cursor'

--- a/src/candidate_memory.ts
+++ b/src/candidate_memory.ts
@@ -2,6 +2,7 @@ import {Clock, Crypto, Effect, FileSystem, Option, Path} from 'effect';
 import {sha256Hex} from './effect/digest.js';
 import {withExclusiveFileLock} from './effect/file_lock.js';
 import {safeChildDirectoryNames, scanFilesWithinBoundary} from './effect/safe_scan.js';
+import {SystemInfo} from './effect/system.js';
 import {uriSegment} from './manifest.js';
 import {canonicalMemoryDocumentContent, parseMemoryDocument, type MemoryRecord} from './memory_document.js';
 import type {MemoryKind} from './types.js';
@@ -430,7 +431,7 @@ export function withCandidateReviewLock<A, E, R>(
   agentContextHome: string,
   reviewId: string,
   effect: Effect.Effect<A, E, R>,
-): Effect.Effect<A, E | unknown, Crypto.Crypto | R | FileSystem.FileSystem | Path.Path> {
+): Effect.Effect<A, E | unknown, Crypto.Crypto | R | FileSystem.FileSystem | Path.Path | SystemInfo> {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const pathService = yield* Path.Path;
@@ -667,13 +668,13 @@ function readCandidateAudit(
     const raw = yield* fs.readFileString(path);
     return raw
       .split('\n')
-      .map(line => {
-        try {
-          return line.trim() ? (JSON.parse(line) as CandidateAuditEvent) : undefined;
-        } catch {
-          return undefined;
-        }
-      })
+      .map(line =>
+        line.trim()
+          ? Option.getOrUndefined(
+              Option.liftThrowable((content: string) => JSON.parse(content) as CandidateAuditEvent)(line),
+            )
+          : undefined,
+      )
       .filter((event): event is CandidateAuditEvent => event !== undefined)
       .slice(-MAX_CANDIDATE_AUDIT_EVENTS);
   });

--- a/src/cli_ui.ts
+++ b/src/cli_ui.ts
@@ -1,7 +1,5 @@
-import {clearLine, cursorTo} from 'node:readline';
-import {stdout} from 'node:process';
-import {Effect} from 'effect';
-import {consoleOutput} from './effect/console.js';
+import {Console, Effect, Fiber, Ref, Schedule, Terminal} from 'effect';
+import {SystemInfo} from './effect/system.js';
 
 type ColorName = 'blue' | 'cyan' | 'dim' | 'green' | 'red' | 'yellow';
 
@@ -15,6 +13,18 @@ const ANSI: Record<ColorName | 'bold' | 'reset', string> = {
   reset: '\u001b[0m',
   yellow: '\u001b[33m',
 };
+
+let colorEnabled = false;
+
+export const initializeCliUi = Effect.fn('cliUi.initialize')(function* () {
+  const system = yield* SystemInfo;
+  const environment = system.environment();
+  colorEnabled =
+    system.stdoutIsTTY &&
+    environment.NO_COLOR === undefined &&
+    environment.CI === undefined &&
+    environment.TERM !== 'dumb';
+});
 
 export function color(name: ColorName, text: string): string {
   if (!shouldUseColor()) {
@@ -63,83 +73,66 @@ export function keyValue(label: string, value: string): string {
 }
 
 export function shouldUseColor(): boolean {
-  return (
-    stdout.isTTY === true &&
-    process.env.NO_COLOR === undefined &&
-    process.env.CI === undefined &&
-    process.env.TERM !== 'dumb'
-  );
+  return colorEnabled;
 }
 
-export function withSpinnerEffect<A, E, R>(message: string, effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> {
-  if (stdout.isTTY !== true || process.env.CI !== undefined || process.env.THREADNOTE_NO_SPINNER !== undefined) {
-    return effect;
-  }
-  return Effect.acquireUseRelease(
-    Effect.sync(() => startSpinner(message)),
-    () => effect,
-    spinner => Effect.sync(spinner.stop),
-  );
+export function withSpinnerEffect<A, E, R>(message: string, effect: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    const environment = system.environment();
+    if (!system.stdoutIsTTY || environment.CI !== undefined || environment.THREADNOTE_NO_SPINNER !== undefined) {
+      return yield* effect;
+    }
+    return yield* Effect.acquireUseRelease(
+      startSpinner(message),
+      () => effect,
+      spinner => spinner.stop(),
+    );
+  });
 }
 
-function startSpinner(message: string): {readonly stop: () => void} {
+const startSpinner = Effect.fn('cliUi.startSpinner')(function* (message: string) {
+  const terminal = yield* Terminal.Terminal;
   const frames = ['-', '\\', '|', '/'];
-  let frameIndex = 0;
-  const render = () => {
-    clearLine(stdout, 0);
-    cursorTo(stdout, 0);
-    stdout.write(`${muted(frames[frameIndex])} ${message}`);
-    frameIndex = (frameIndex + 1) % frames.length;
-  };
-  render();
-  const timer = setInterval(render, 100);
+  const frameIndex = yield* Ref.make(0);
+  const render = Ref.getAndUpdate(frameIndex, index => (index + 1) % frames.length).pipe(
+    Effect.flatMap(index => terminal.display(`\r\u001b[2K${muted(frames[index])} ${message}`)),
+  );
+  yield* render;
+  const fiber = yield* render.pipe(Effect.repeat(Schedule.spaced(100)), Effect.forkDetach);
   return {
-    stop: () => {
-      clearInterval(timer);
-      clearLine(stdout, 0);
-      cursorTo(stdout, 0);
-    },
+    stop: () => Fiber.interrupt(fiber).pipe(Effect.andThen(terminal.display('\r\u001b[2K'))),
   };
-}
+});
 
 export interface ProgressIndicator {
-  update(message: string): void;
-  stop(): void;
+  update(message: string): Effect.Effect<void>;
+  stop(): Effect.Effect<void>;
 }
 
-export function startProgress(message: string): ProgressIndicator {
-  if (stdout.isTTY !== true || process.env.CI !== undefined || process.env.THREADNOTE_NO_SPINNER !== undefined) {
-    consoleOutput.log(message);
+export const startProgress = Effect.fn('cliUi.startProgress')(function* (message: string) {
+  const system = yield* SystemInfo;
+  const environment = system.environment();
+  if (!system.stdoutIsTTY || environment.CI !== undefined || environment.THREADNOTE_NO_SPINNER !== undefined) {
+    yield* Console.log(message);
     return {
-      update(nextMessage: string): void {
-        consoleOutput.log(nextMessage);
-      },
-      stop(): void {
-        return;
-      },
+      update: (nextMessage: string) => Console.log(nextMessage),
+      stop: () => Effect.void,
     };
   }
 
+  const terminal = yield* Terminal.Terminal;
   const frames = ['-', '\\', '|', '/'];
-  let frameIndex = 0;
-  let currentMessage = message;
-  const render = () => {
-    clearLine(stdout, 0);
-    cursorTo(stdout, 0);
-    stdout.write(`${muted(frames[frameIndex])} ${currentMessage}`);
-    frameIndex = (frameIndex + 1) % frames.length;
-  };
-  const timer = setInterval(render, 100);
-  render();
+  const frameIndex = yield* Ref.make(0);
+  const currentMessage = yield* Ref.make(message);
+  const render = Effect.all([
+    Ref.getAndUpdate(frameIndex, index => (index + 1) % frames.length),
+    Ref.get(currentMessage),
+  ]).pipe(Effect.flatMap(([index, text]) => terminal.display(`\r\u001b[2K${muted(frames[index])} ${text}`)));
+  yield* render;
+  const fiber = yield* render.pipe(Effect.repeat(Schedule.spaced(100)), Effect.forkDetach);
   return {
-    update(nextMessage: string): void {
-      currentMessage = nextMessage;
-      render();
-    },
-    stop(): void {
-      clearInterval(timer);
-      clearLine(stdout, 0);
-      cursorTo(stdout, 0);
-    },
+    update: (nextMessage: string) => Ref.set(currentMessage, nextMessage).pipe(Effect.andThen(render)),
+    stop: () => Fiber.interrupt(fiber).pipe(Effect.andThen(terminal.display('\r\u001b[2K'))),
   };
-}
+});

--- a/src/effect/ai-consolidator.ts
+++ b/src/effect/ai-consolidator.ts
@@ -1,4 +1,4 @@
-import {NodeHttpClient} from '@effect/platform-node';
+import * as NodeHttpClient from '@effect/platform-node/NodeHttpClient';
 import {OpenAiClient, OpenAiLanguageModel} from '@effect/ai-openai-compat';
 import {Context, Effect, Layer, pipe, Redacted, Schema} from 'effect';
 import {LanguageModel} from 'effect/unstable/ai';
@@ -34,7 +34,7 @@ export const consolidateWithAiEffect = Effect.fn('AiConsolidator.consolidate')(f
 });
 
 export function effectAiConfiguration(
-  env: Readonly<Record<string, string | undefined>> = process.env,
+  env: Readonly<Record<string, string | undefined>>,
 ): EffectAiConfiguration | undefined {
   if (!['1', 'true', 'yes'].includes(env[EFFECT_AI_ENABLED_ENV]?.trim().toLowerCase() ?? '')) {
     return undefined;

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -42,7 +42,7 @@ import type {RuntimeConfig} from '../types.js';
 import {maybeNotifyUpdate, runPostUpdate, runUpdate} from '../update.js';
 import {runVersion} from '../version_command.js';
 import {runManage} from '../manager.js';
-import {ApplicationError, applicationError} from './errors.js';
+import {applicationError} from './errors.js';
 
 const describeFlag = <A>(flag: Flag.Flag<A>, description: string): Flag.Flag<A> =>
   flag.pipe(Flag.withDescription(description));
@@ -124,12 +124,12 @@ const root = Command.make('threadnote').pipe(
 const withRuntimeEffect = <E, R>(
   effect: (config: RuntimeConfig) => Effect.Effect<void, E, R>,
   manifestOverride?: string,
-): Effect.Effect<void, E | ApplicationError, R | Command.CommandContext<'threadnote'>> =>
+) =>
   Effect.flatMap(root, options =>
-    Effect.try({
-      try: () => getRuntimeConfig(options, manifestOverride),
-      catch: cause => applicationError('load runtime configuration', cause),
-    }).pipe(Effect.flatMap(effect)),
+    getRuntimeConfig(options, manifestOverride).pipe(
+      Effect.mapError(cause => applicationError('load runtime configuration', cause)),
+      Effect.flatMap(effect),
+    ),
   );
 
 const manage = Command.make(

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -112,11 +112,12 @@ const optionalArgument = (name: string, description: string, fallback: string): 
 const root = Command.make('threadnote').pipe(
   Command.withSharedFlags({
     home: optionalString('home', 'Override THREADNOTE_HOME for this invocation'),
-    host: defaultString('host', 'OpenViking host', '127.0.0.1'),
+    host: optionalString('host', 'Override THREADNOTE_HOST for this invocation'),
     manifest: optionalString('manifest', 'Override THREADNOTE_MANIFEST for this invocation'),
-    port: describeFlag(integerFlag('port'), 'OpenViking port').pipe(
-      Flag.withSchema(Config.Port),
-      Flag.withDefault(1933),
+    port: optional(
+      describeFlag(integerFlag('port'), 'Override THREADNOTE_PORT for this invocation').pipe(
+        Flag.withSchema(Config.Port),
+      ),
     ),
   }),
 );

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -1,8 +1,10 @@
-import {execFile, spawn, type ChildProcess} from 'node:child_process';
-import {Console, Context, Effect, Layer, Schema} from 'effect';
+import {Console, Context, Effect, Layer, Schema, Sink, Stdio, Stream} from 'effect';
+import * as ChildProcess from 'effect/unstable/process/ChildProcess';
+import {ChildProcessSpawner} from 'effect/unstable/process/ChildProcessSpawner';
 import {command as commandText, info, warning} from '../cli_ui.js';
 import {redactSensitiveText} from '../scrubber.js';
 import type {CommandResult} from '../types.js';
+import {SystemInfo, type SystemInfoShape} from './system.js';
 
 export interface CommandOptions {
   readonly allowFailure?: boolean;
@@ -54,17 +56,7 @@ export class CommandSpawnFailed extends Schema.TaggedErrorClass<CommandSpawnFail
   cause: Schema.Defect(),
 }) {}
 
-export class CommandTerminationFailed extends Schema.TaggedErrorClass<CommandTerminationFailed>()(
-  'CommandTerminationFailed',
-  {
-    ...CommandFields,
-    cause: Schema.Defect(),
-    pid: Schema.Number,
-  },
-) {}
-
-export type CommandExecutionError =
-  CommandFailed | CommandOutputLimitExceeded | CommandSpawnFailed | CommandTerminationFailed | CommandTimedOut;
+export type CommandExecutionError = CommandFailed | CommandOutputLimitExceeded | CommandSpawnFailed | CommandTimedOut;
 
 export class CommandExecutor extends Context.Service<
   CommandExecutor,
@@ -81,8 +73,24 @@ export class CommandExecutor extends Context.Service<
     ) => Effect.Effect<CommandResult>;
   }
 >()('threadnote/effect/CommandExecutor') {
-  static readonly layer = Layer.sync(CommandExecutor, () =>
-    CommandExecutor.of({execute: executeCommand, executeStreaming: executeStreamingCommand}),
+  static readonly layer = Layer.effect(
+    CommandExecutor,
+    Effect.gen(function* () {
+      const childProcessSpawner = yield* ChildProcessSpawner;
+      const stdio = yield* Stdio.Stdio;
+      const system = yield* SystemInfo;
+      return CommandExecutor.of({
+        execute: (executable, args, options) =>
+          executeCommand(executable, args, options, system).pipe(
+            Effect.provideService(ChildProcessSpawner, childProcessSpawner),
+          ),
+        executeStreaming: (executable, args, options) =>
+          executeStreamingCommand(executable, args, options, system).pipe(
+            Effect.provideService(ChildProcessSpawner, childProcessSpawner),
+            Effect.provideService(Stdio.Stdio, stdio),
+          ),
+      });
+    }),
   );
 }
 
@@ -101,7 +109,11 @@ export const runStreamingCommandEffect = Effect.fn('runStreamingCommandEffect')(
   options: StreamingCommandOptions = {},
 ) {
   const command = yield* CommandExecutor;
-  return yield* (command.executeStreaming ?? executeStreamingCommand)(executable, args, options);
+  if (command.executeStreaming) {
+    return yield* command.executeStreaming(executable, args, options);
+  }
+  const system = yield* SystemInfo;
+  return yield* executeStreamingCommand(executable, args, options, system);
 });
 
 export const maybeRunEffect = Effect.fn('maybeRunEffect')(function* (
@@ -126,182 +138,216 @@ export const maybeRunEffect = Effect.fn('maybeRunEffect')(function* (
   return result;
 });
 
-const executeCommand = Effect.fn('CommandExecutor.execute')((
+const executeCommand = Effect.fn('CommandExecutor.execute')(function* (
   executable: string,
   args: readonly string[],
   options: CommandOptions = {},
-) => {
-  const maxOutputBytes = options.maxOutputBytes ?? commandMaxOutputBytes();
-  const timeoutMs = options.timeoutMs ?? commandTimeoutMs();
+  system: SystemInfoShape,
+) {
+  const environment = system.environment();
+  const maxOutputBytes = options.maxOutputBytes ?? commandMaxOutputBytes(environment);
+  const timeoutMs = options.timeoutMs ?? commandTimeoutMs(environment);
   const command = formatShellCommand(executable, args);
   const safeArgs = redactCommandArgs(args);
   const safeExecutable = redactSensitiveText(executable);
-  const invocation = resolveCommandInvocation(executable, args);
-  const run = Effect.callback<CommandResult, CommandExecutionError>(resume => {
-    let child: ChildProcess | undefined;
-    let finished = false;
-    const complete = (result: CommandResult, error?: CommandExecutionError): void => {
-      if (finished) {
-        return;
-      }
-      finished = true;
-      if (error && options.allowFailure !== true) {
-        resume(Effect.fail(error));
-      } else {
-        resume(Effect.succeed(result));
-      }
-    };
-
-    try {
-      child = execFile(
-        invocation.executable,
-        [...invocation.args],
-        {
-          cwd: options.cwd,
-          encoding: 'utf8',
-          env: commandEnvironment(executable, options.env),
-          maxBuffer: maxOutputBytes,
-          windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-        },
-        (cause, stdout, stderr) => {
-          if (!cause) {
-            complete({exitCode: 0, stderr, stdout});
-            return;
-          }
-          const error = cause as Error & {readonly code?: number | string};
-          if (error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
-            const outputError = new CommandOutputLimitExceeded({
-              args: safeArgs,
-              executable: safeExecutable,
-              maxOutputBytes,
-              message: `${command} exceeded output limit of ${maxOutputBytes} bytes`,
-            });
-            complete({exitCode: 124, stderr: outputError.message, stdout}, outputError);
-            return;
-          }
-          if (typeof error.code !== 'number') {
-            const spawnError = new CommandSpawnFailed({
-              args: safeArgs,
-              cause: redactedError(error),
-              executable: safeExecutable,
-              message: redactSensitiveText(`${command} failed to start: ${error.message}`),
-            });
-            complete({exitCode: 127, stderr: error.message, stdout}, spawnError);
-            return;
-          }
-          const failed = new CommandFailed({
-            args: safeArgs,
-            executable: safeExecutable,
-            exitCode: error.code,
-            message: redactSensitiveText(`${command} failed: ${stderr || stdout}`),
-            stderr: redactSensitiveText(stderr),
-            stdout: redactSensitiveText(stdout),
-          });
-          complete({exitCode: error.code, stderr, stdout}, failed);
-        },
-      );
-    } catch (cause: unknown) {
-      const error = cause instanceof Error ? cause : new Error(String(cause));
-      const spawnError = new CommandSpawnFailed({
-        args: safeArgs,
-        cause: redactedError(error),
-        executable: safeExecutable,
-        message: redactSensitiveText(`${command} failed to start: ${error.message}`),
-      });
-      complete({exitCode: 127, stderr: error.message, stdout: ''}, spawnError);
-    }
-
-    return child && !finished
-      ? terminationCleanupEffect(child, invocation, false).pipe(
-          Effect.andThen(Effect.sleep(1000)),
-          Effect.andThen(
-            Effect.suspend(() =>
-              child && child.exitCode === null ? terminationCleanupEffect(child, invocation, true) : Effect.void,
-            ),
-          ),
-        )
-      : Effect.void;
+  const spawnFailed = (cause: unknown) => commandSpawnFailure(command, safeExecutable, safeArgs, cause);
+  const outputExceeded = new CommandOutputLimitExceeded({
+    args: safeArgs,
+    executable: safeExecutable,
+    maxOutputBytes,
+    message: `${command} exceeded output limit of ${maxOutputBytes} bytes`,
   });
-  if (timeoutMs <= 0) {
-    return run;
-  }
+  const run = Effect.scoped(
+    Effect.gen(function* () {
+      const invocation = yield* Effect.try({
+        try: () =>
+          resolveCommandInvocation(
+            executable,
+            args,
+            system.platform,
+            environment.ComSpec ?? environment.COMSPEC ?? 'cmd.exe',
+          ),
+        catch: spawnFailed,
+      });
+      const handle = yield* ChildProcess.make(invocation.executable, [...invocation.args], {
+        cwd: options.cwd,
+        env: commandEnvironment(executable, options.env, environment),
+        forceKillAfter: 1000,
+        stdin: 'ignore',
+      }).pipe(Effect.mapError(spawnFailed));
+      const [stdout, stderr, exitCode] = yield* Effect.all(
+        [
+          collectCommandOutput(handle.stdout, maxOutputBytes, outputExceeded).pipe(
+            Effect.mapError(cause => (cause instanceof CommandOutputLimitExceeded ? cause : spawnFailed(cause))),
+          ),
+          collectCommandOutput(handle.stderr, maxOutputBytes, outputExceeded).pipe(
+            Effect.mapError(cause => (cause instanceof CommandOutputLimitExceeded ? cause : spawnFailed(cause))),
+          ),
+          handle.exitCode.pipe(Effect.map(Number), Effect.mapError(spawnFailed)),
+        ],
+        {concurrency: 'unbounded'},
+      );
+      const result = {exitCode, stderr, stdout};
+      if (exitCode === 0) {
+        return result;
+      }
+      return yield* new CommandFailed({
+        args: safeArgs,
+        executable: safeExecutable,
+        exitCode,
+        message: redactSensitiveText(`${command} failed: ${stderr || stdout}`),
+        stderr: redactSensitiveText(stderr),
+        stdout: redactSensitiveText(stdout),
+      });
+    }),
+  );
   const timedOut = new CommandTimedOut({
     args: safeArgs,
     executable: safeExecutable,
     message: `${command} timed out after ${timeoutMs}ms`,
     timeoutMs,
   });
-  return run.pipe(
-    Effect.timeoutOrElse({
-      duration: timeoutMs,
-      orElse: () =>
-        options.allowFailure === true
-          ? Effect.succeed({exitCode: 124, stderr: timedOut.message, stdout: ''})
-          : Effect.fail(timedOut),
+  const bounded =
+    timeoutMs <= 0
+      ? run
+      : run.pipe(
+          Effect.timeoutOrElse({
+            duration: timeoutMs,
+            orElse: () => Effect.fail(timedOut),
+          }),
+        );
+  return yield* options.allowFailure === true
+    ? bounded.pipe(Effect.catch(error => Effect.succeed(commandErrorResult(error))))
+    : bounded;
+});
+
+const executeStreamingCommand = Effect.fn('CommandExecutor.executeStreaming')(function* (
+  executable: string,
+  args: readonly string[],
+  options: StreamingCommandOptions = {},
+  system: SystemInfoShape,
+) {
+  const maxOutputChars = options.maxOutputChars ?? 64_000;
+  const command = formatShellCommand(executable, args);
+  const safeArgs = redactCommandArgs(args);
+  const safeExecutable = redactSensitiveText(executable);
+  const spawnFailed = (cause: unknown) => commandSpawnFailure(command, safeExecutable, safeArgs, cause);
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const invocation = yield* Effect.try({
+        try: () =>
+          resolveCommandInvocation(
+            executable,
+            args,
+            system.platform,
+            system.environment().ComSpec ?? system.environment().COMSPEC ?? 'cmd.exe',
+          ),
+        catch: spawnFailed,
+      });
+      const handle = yield* ChildProcess.make(invocation.executable, [...invocation.args], {
+        env: options.env,
+        forceKillAfter: 1000,
+        stdin: 'inherit',
+      }).pipe(Effect.mapError(spawnFailed));
+      const stdio = yield* Stdio.Stdio;
+      const [stdout, stderr, exitCode] = yield* Effect.all(
+        [
+          collectStreamingOutput(handle.stdout, stdio.stdout({endOnDone: false}), maxOutputChars),
+          collectStreamingOutput(handle.stderr, stdio.stderr({endOnDone: false}), maxOutputChars),
+          handle.exitCode.pipe(Effect.map(Number)),
+        ],
+        {concurrency: 'unbounded'},
+      );
+      return {exitCode, stderr, stdout};
+    }),
+  ).pipe(
+    Effect.catch(cause => {
+      const message = causeMessage(cause);
+      return Effect.succeed({exitCode: 1, stderr: `${message}\n`, stdout: ''});
     }),
   );
 });
 
-const executeStreamingCommand = Effect.fn('CommandExecutor.executeStreaming')((
-  executable: string,
-  args: readonly string[],
-  options: StreamingCommandOptions = {},
-) => {
-  const invocation = resolveCommandInvocation(executable, args);
-  const maxOutputChars = options.maxOutputChars ?? 64_000;
-  return Effect.callback<CommandResult>(resume => {
-    let child: ChildProcess | undefined;
-    let finished = false;
-    let stderr = '';
-    let stdout = '';
-    const appendTail = (current: string, chunk: string): string => {
-      const next = `${current}${chunk}`;
-      return next.length <= maxOutputChars ? next : next.slice(next.length - maxOutputChars);
-    };
-    const complete = (result: CommandResult): void => {
-      if (finished) {
-        return;
-      }
-      finished = true;
-      resume(Effect.succeed(result));
-    };
-    try {
-      child = spawn(invocation.executable, invocation.args, {
-        env: options.env,
-        stdio: ['inherit', 'pipe', 'pipe'],
-        windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-      });
-      child.stdout?.on('data', chunk => {
-        const text = String(chunk);
-        process.stdout.write(text);
-        stdout = appendTail(stdout, text);
-      });
-      child.stderr?.on('data', chunk => {
-        const text = String(chunk);
-        process.stderr.write(text);
-        stderr = appendTail(stderr, text);
-      });
-      child.on('error', cause => {
-        const message = cause instanceof Error ? cause.message : String(cause);
-        process.stderr.write(`${message}\n`);
-        complete({exitCode: 1, stderr: appendTail(stderr, message), stdout});
-      });
-      child.on('close', code => complete({exitCode: code ?? 1, stderr, stdout}));
-    } catch (cause: unknown) {
-      const message = cause instanceof Error ? cause.message : String(cause);
-      complete({exitCode: 1, stderr: appendTail(stderr, message), stdout});
-    }
-    return child && !finished ? terminationCleanupEffect(child, invocation, true) : Effect.void;
+function collectCommandOutput(
+  stream: Stream.Stream<Uint8Array, unknown>,
+  maxOutputBytes: number,
+  outputExceeded: CommandOutputLimitExceeded,
+) {
+  const encoder = new TextEncoder();
+  return stream.pipe(
+    Stream.decodeText,
+    Stream.runFoldEffect(
+      () => '',
+      (current, chunk) => {
+        const next = `${current}${chunk}`;
+        return encoder.encode(next).byteLength <= maxOutputBytes ? Effect.succeed(next) : Effect.fail(outputExceeded);
+      },
+    ),
+  );
+}
+
+function collectStreamingOutput(
+  stream: Stream.Stream<Uint8Array, unknown>,
+  sink: Sink.Sink<void, string | Uint8Array, never, unknown>,
+  maxOutputChars: number,
+) {
+  return stream.pipe(
+    Stream.decodeText,
+    Stream.runFoldEffect(
+      () => '',
+      (current, chunk) =>
+        Stream.run(Stream.make(chunk), sink).pipe(Effect.as(appendOutputTail(current, chunk, maxOutputChars))),
+    ),
+  );
+}
+
+function appendOutputTail(current: string, chunk: string, maxOutputChars: number): string {
+  const next = `${current}${chunk}`;
+  return next.length <= maxOutputChars ? next : next.slice(next.length - maxOutputChars);
+}
+
+function commandSpawnFailure(
+  command: string,
+  safeExecutable: string,
+  safeArgs: readonly string[],
+  cause: unknown,
+): CommandSpawnFailed {
+  const message = causeMessage(cause);
+  return new CommandSpawnFailed({
+    args: safeArgs,
+    cause: new Error(redactSensitiveText(message)),
+    executable: safeExecutable,
+    message: redactSensitiveText(`${command} failed to start: ${message}`),
   });
-});
+}
+
+function commandErrorResult(error: CommandExecutionError): CommandResult {
+  switch (error._tag) {
+    case 'CommandFailed':
+      return {exitCode: error.exitCode, stderr: error.stderr, stdout: error.stdout};
+    case 'CommandOutputLimitExceeded':
+    case 'CommandTimedOut':
+      return {exitCode: 124, stderr: error.message, stdout: ''};
+    case 'CommandSpawnFailed':
+      return {exitCode: 127, stderr: error.message, stdout: ''};
+  }
+}
+
+function causeMessage(cause: unknown): string {
+  return cause instanceof Error
+    ? cause.message
+    : typeof cause === 'object' && cause !== null && 'message' in cause
+      ? String(cause.message)
+      : String(cause);
+}
 
 const WINDOWS_COMMAND_META = /([()\][%!^"`<>&|;, *?])/g;
 
 export function resolveCommandInvocation(
   executable: string,
   args: readonly string[],
-  currentPlatform: NodeJS.Platform = process.platform,
-  comspec = process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe',
+  currentPlatform: NodeJS.Platform,
+  comspec = 'cmd.exe',
 ): CommandInvocation {
   if (currentPlatform !== 'win32' || !/\.(?:bat|cmd)$/i.test(executable)) {
     return {args, executable, windowsVerbatimArguments: false};
@@ -336,85 +382,10 @@ export function isGitExecutable(executable: string): boolean {
   return /^(?:git)(?:\.(?:bat|cmd|com|exe))?$/i.test(name);
 }
 
-export function windowsTaskkillExecutable(): string {
-  return `${(process.env.SystemRoot ?? 'C:\\Windows').replace(/[\\/]+$/, '')}\\System32\\taskkill.exe`;
-}
-
-export function terminateCommandProcessEffect(
-  child: ChildProcess,
-  _invocation: CommandInvocation,
-  force: boolean,
-): Effect.Effect<void, CommandTerminationFailed> {
-  return Effect.callback<void, CommandTerminationFailed>(resume => {
-    beginCommandProcessTermination(child, force, cause => {
-      if (cause && child.exitCode === null) {
-        resume(
-          Effect.fail(
-            new CommandTerminationFailed({
-              args: [],
-              cause: redactedError(cause),
-              executable: windowsTaskkillExecutable(),
-              message: redactSensitiveText(
-                `Could not terminate process tree ${child.pid ?? 'unknown'}: ${cause.message}`,
-              ),
-              pid: child.pid ?? -1,
-            }),
-          ),
-        );
-        return;
-      }
-      resume(Effect.void);
-    });
-  });
-}
-
-function terminationCleanupEffect(child: ChildProcess, invocation: CommandInvocation, force: boolean) {
-  return terminateCommandProcessEffect(child, invocation, force).pipe(
-    Effect.catch(error =>
-      Effect.sync(() => {
-        process.stderr.write(`Warning: ${error.message}\n`);
-      }),
-    ),
-  );
-}
-
-export function terminateCommandProcess(
-  child: ChildProcess,
-  _invocation: CommandInvocation,
-  force: boolean,
-): Promise<void> {
-  return new Promise((resolveTermination, rejectTermination) => {
-    beginCommandProcessTermination(child, force, cause => {
-      if (cause && child.exitCode === null) {
-        rejectTermination(cause);
-      } else {
-        resolveTermination();
-      }
-    });
-  });
-}
-
-function beginCommandProcessTermination(child: ChildProcess, force: boolean, complete: (cause?: Error) => void): void {
-  if (child.exitCode !== null) {
-    complete();
-    return;
-  }
-  if (process.platform === 'win32' && child.pid !== undefined) {
-    execFile(windowsTaskkillExecutable(), ['/pid', String(child.pid), '/t', '/f'], {windowsHide: true}, cause => {
-      const error = cause instanceof Error ? cause : undefined;
-      if (error && child.exitCode === null) {
-        child.kill('SIGKILL');
-      }
-      complete(error);
-    });
-    return;
-  }
-  try {
-    child.kill(force ? 'SIGKILL' : 'SIGTERM');
-  } finally {
-    complete();
-  }
-}
+export const windowsTaskkillExecutable = Effect.fn('CommandExecutor.windowsTaskkillExecutable')(function* () {
+  const environment = (yield* SystemInfo).environment();
+  return `${(environment.SystemRoot ?? 'C:\\Windows').replace(/[\\/]+$/, '')}\\System32\\taskkill.exe`;
+});
 
 const GIT_ENVIRONMENT_KEYS = [
   'GIT_DIR',
@@ -427,7 +398,7 @@ const GIT_ENVIRONMENT_KEYS = [
   'GIT_QUARANTINE_PATH',
 ] as const;
 
-export function withoutGitEnvironment(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+export function withoutGitEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const next = {...env};
   for (const key of GIT_ENVIRONMENT_KEYS) {
     delete next[key];
@@ -435,8 +406,12 @@ export function withoutGitEnvironment(env: NodeJS.ProcessEnv = process.env): Nod
   return next;
 }
 
-function commandEnvironment(executable: string, env: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv | undefined {
-  return isGitExecutable(executable) ? withoutGitEnvironment(env ?? process.env) : env;
+function commandEnvironment(
+  executable: string,
+  env: NodeJS.ProcessEnv | undefined,
+  systemEnvironment: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv | undefined {
+  return isGitExecutable(executable) ? withoutGitEnvironment(env ?? systemEnvironment) : env;
 }
 
 export function formatShellCommand(executable: string, args: readonly string[]): string {
@@ -450,16 +425,19 @@ export function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }
 
-export function commandTimeoutMs(): number {
-  return positiveIntegerFromEnv('THREADNOTE_COMMAND_TIMEOUT_MS') ?? 10 * 60 * 1000;
+export function commandTimeoutMs(environment: Readonly<Record<string, string | undefined>>): number {
+  return positiveIntegerFromEnv(environment, 'THREADNOTE_COMMAND_TIMEOUT_MS') ?? 10 * 60 * 1000;
 }
 
-export function commandMaxOutputBytes(): number {
-  return positiveIntegerFromEnv('THREADNOTE_COMMAND_MAX_OUTPUT_BYTES') ?? 5 * 1024 * 1024;
+export function commandMaxOutputBytes(environment: Readonly<Record<string, string | undefined>>): number {
+  return positiveIntegerFromEnv(environment, 'THREADNOTE_COMMAND_MAX_OUTPUT_BYTES') ?? 5 * 1024 * 1024;
 }
 
-function positiveIntegerFromEnv(name: string): number | undefined {
-  const value = process.env[name];
+function positiveIntegerFromEnv(
+  environment: Readonly<Record<string, string | undefined>>,
+  name: string,
+): number | undefined {
+  const value = environment[name];
   if (value === undefined) {
     return undefined;
   }
@@ -473,8 +451,4 @@ function redactCommandArgs(args: readonly string[]): readonly string[] {
     return ['[REDACTED]'];
   }
   return args.map(redactSensitiveText);
-}
-
-function redactedError(error: Error): Error {
-  return new Error(redactSensitiveText(error.message));
 }

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -1,5 +1,4 @@
-import {execFile, type ChildProcess} from 'node:child_process';
-import {basename} from 'node:path';
+import {execFile, spawn, type ChildProcess} from 'node:child_process';
 import {Console, Context, Effect, Layer, Schema} from 'effect';
 import {command as commandText, info, warning} from '../cli_ui.js';
 import {redactSensitiveText} from '../scrubber.js';
@@ -11,6 +10,17 @@ export interface CommandOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly maxOutputBytes?: number;
   readonly timeoutMs?: number;
+}
+
+export interface CommandInvocation {
+  readonly args: readonly string[];
+  readonly executable: string;
+  readonly windowsVerbatimArguments: boolean;
+}
+
+export interface StreamingCommandOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly maxOutputChars?: number;
 }
 
 const CommandFields = {
@@ -44,7 +54,17 @@ export class CommandSpawnFailed extends Schema.TaggedErrorClass<CommandSpawnFail
   cause: Schema.Defect(),
 }) {}
 
-export type CommandExecutionError = CommandFailed | CommandOutputLimitExceeded | CommandSpawnFailed | CommandTimedOut;
+export class CommandTerminationFailed extends Schema.TaggedErrorClass<CommandTerminationFailed>()(
+  'CommandTerminationFailed',
+  {
+    ...CommandFields,
+    cause: Schema.Defect(),
+    pid: Schema.Number,
+  },
+) {}
+
+export type CommandExecutionError =
+  CommandFailed | CommandOutputLimitExceeded | CommandSpawnFailed | CommandTerminationFailed | CommandTimedOut;
 
 export class CommandExecutor extends Context.Service<
   CommandExecutor,
@@ -54,9 +74,16 @@ export class CommandExecutor extends Context.Service<
       args: readonly string[],
       options?: CommandOptions,
     ) => Effect.Effect<CommandResult, CommandExecutionError>;
+    readonly executeStreaming?: (
+      executable: string,
+      args: readonly string[],
+      options?: StreamingCommandOptions,
+    ) => Effect.Effect<CommandResult>;
   }
 >()('threadnote/effect/CommandExecutor') {
-  static readonly layer = Layer.sync(CommandExecutor, () => CommandExecutor.of({execute: executeCommand}));
+  static readonly layer = Layer.sync(CommandExecutor, () =>
+    CommandExecutor.of({execute: executeCommand, executeStreaming: executeStreamingCommand}),
+  );
 }
 
 export const runCommandEffect = Effect.fn('runCommandEffect')(function* (
@@ -66,6 +93,15 @@ export const runCommandEffect = Effect.fn('runCommandEffect')(function* (
 ) {
   const command = yield* CommandExecutor;
   return yield* command.execute(executable, args, options);
+});
+
+export const runStreamingCommandEffect = Effect.fn('runStreamingCommandEffect')(function* (
+  executable: string,
+  args: readonly string[],
+  options: StreamingCommandOptions = {},
+) {
+  const command = yield* CommandExecutor;
+  return yield* (command.executeStreaming ?? executeStreamingCommand)(executable, args, options);
 });
 
 export const maybeRunEffect = Effect.fn('maybeRunEffect')(function* (
@@ -100,34 +136,15 @@ const executeCommand = Effect.fn('CommandExecutor.execute')((
   const command = formatShellCommand(executable, args);
   const safeArgs = redactCommandArgs(args);
   const safeExecutable = redactSensitiveText(executable);
+  const invocation = resolveCommandInvocation(executable, args);
   const run = Effect.callback<CommandResult, CommandExecutionError>(resume => {
     let child: ChildProcess | undefined;
     let finished = false;
-    let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
-
-    const clearTimers = (): void => {
-      if (killEscalationTimer) {
-        clearTimeout(killEscalationTimer);
-      }
-    };
-    const terminate = (): void => {
-      if (!child || child.exitCode !== null) {
-        return;
-      }
-      child.kill('SIGTERM');
-      killEscalationTimer = setTimeout(() => {
-        if (!finished && child && child.exitCode === null) {
-          child.kill('SIGKILL');
-        }
-      }, 1000);
-      killEscalationTimer.unref?.();
-    };
     const complete = (result: CommandResult, error?: CommandExecutionError): void => {
       if (finished) {
         return;
       }
       finished = true;
-      clearTimers();
       if (error && options.allowFailure !== true) {
         resume(Effect.fail(error));
       } else {
@@ -137,13 +154,14 @@ const executeCommand = Effect.fn('CommandExecutor.execute')((
 
     try {
       child = execFile(
-        executable,
-        [...args],
+        invocation.executable,
+        [...invocation.args],
         {
           cwd: options.cwd,
           encoding: 'utf8',
           env: commandEnvironment(executable, options.env),
           maxBuffer: maxOutputBytes,
+          windowsVerbatimArguments: invocation.windowsVerbatimArguments,
         },
         (cause, stdout, stderr) => {
           if (!cause) {
@@ -193,12 +211,16 @@ const executeCommand = Effect.fn('CommandExecutor.execute')((
       complete({exitCode: 127, stderr: error.message, stdout: ''}, spawnError);
     }
 
-    return Effect.sync(() => {
-      if (!finished) {
-        clearTimers();
-        terminate();
-      }
-    });
+    return child && !finished
+      ? terminationCleanupEffect(child, invocation, false).pipe(
+          Effect.andThen(Effect.sleep(1000)),
+          Effect.andThen(
+            Effect.suspend(() =>
+              child && child.exitCode === null ? terminationCleanupEffect(child, invocation, true) : Effect.void,
+            ),
+          ),
+        )
+      : Effect.void;
   });
   if (timeoutMs <= 0) {
     return run;
@@ -220,6 +242,180 @@ const executeCommand = Effect.fn('CommandExecutor.execute')((
   );
 });
 
+const executeStreamingCommand = Effect.fn('CommandExecutor.executeStreaming')((
+  executable: string,
+  args: readonly string[],
+  options: StreamingCommandOptions = {},
+) => {
+  const invocation = resolveCommandInvocation(executable, args);
+  const maxOutputChars = options.maxOutputChars ?? 64_000;
+  return Effect.callback<CommandResult>(resume => {
+    let child: ChildProcess | undefined;
+    let finished = false;
+    let stderr = '';
+    let stdout = '';
+    const appendTail = (current: string, chunk: string): string => {
+      const next = `${current}${chunk}`;
+      return next.length <= maxOutputChars ? next : next.slice(next.length - maxOutputChars);
+    };
+    const complete = (result: CommandResult): void => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      resume(Effect.succeed(result));
+    };
+    try {
+      child = spawn(invocation.executable, invocation.args, {
+        env: options.env,
+        stdio: ['inherit', 'pipe', 'pipe'],
+        windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+      });
+      child.stdout?.on('data', chunk => {
+        const text = String(chunk);
+        process.stdout.write(text);
+        stdout = appendTail(stdout, text);
+      });
+      child.stderr?.on('data', chunk => {
+        const text = String(chunk);
+        process.stderr.write(text);
+        stderr = appendTail(stderr, text);
+      });
+      child.on('error', cause => {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        process.stderr.write(`${message}\n`);
+        complete({exitCode: 1, stderr: appendTail(stderr, message), stdout});
+      });
+      child.on('close', code => complete({exitCode: code ?? 1, stderr, stdout}));
+    } catch (cause: unknown) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      complete({exitCode: 1, stderr: appendTail(stderr, message), stdout});
+    }
+    return child && !finished ? terminationCleanupEffect(child, invocation, true) : Effect.void;
+  });
+});
+
+const WINDOWS_COMMAND_META = /([()\][%!^"`<>&|;, *?])/g;
+
+export function resolveCommandInvocation(
+  executable: string,
+  args: readonly string[],
+  currentPlatform: NodeJS.Platform = process.platform,
+  comspec = process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe',
+): CommandInvocation {
+  if (currentPlatform !== 'win32' || !/\.(?:bat|cmd)$/i.test(executable)) {
+    return {args, executable, windowsVerbatimArguments: false};
+  }
+  for (const value of [executable, ...args]) {
+    if (value.includes('\0') || /[\r\n]/.test(value)) {
+      throw new Error('Windows batch commands do not accept NUL, CR, or LF characters.');
+    }
+  }
+  const doubleEscape = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i.test(executable);
+  const command = escapeWindowsCommand(executable);
+  const escapedArgs = args.map(arg => escapeWindowsArgument(arg, doubleEscape));
+  return {
+    args: ['/d', '/s', '/c', `"${[command, ...escapedArgs].join(' ')}"`],
+    executable: comspec,
+    windowsVerbatimArguments: true,
+  };
+}
+
+function escapeWindowsCommand(value: string): string {
+  return value.replace(WINDOWS_COMMAND_META, '^$1');
+}
+
+function escapeWindowsArgument(value: string, doubleEscape: boolean): string {
+  let escaped = value.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"').replace(/(?=(\\+?)?)\1$/, '$1$1');
+  escaped = `"${escaped}"`.replace(WINDOWS_COMMAND_META, '^$1');
+  return doubleEscape ? escaped.replace(WINDOWS_COMMAND_META, '^$1') : escaped;
+}
+
+export function isGitExecutable(executable: string): boolean {
+  const name = executable.replaceAll('\\', '/').split('/').at(-1) ?? '';
+  return /^(?:git)(?:\.(?:bat|cmd|com|exe))?$/i.test(name);
+}
+
+export function windowsTaskkillExecutable(): string {
+  return `${(process.env.SystemRoot ?? 'C:\\Windows').replace(/[\\/]+$/, '')}\\System32\\taskkill.exe`;
+}
+
+export function terminateCommandProcessEffect(
+  child: ChildProcess,
+  _invocation: CommandInvocation,
+  force: boolean,
+): Effect.Effect<void, CommandTerminationFailed> {
+  return Effect.callback<void, CommandTerminationFailed>(resume => {
+    beginCommandProcessTermination(child, force, cause => {
+      if (cause && child.exitCode === null) {
+        resume(
+          Effect.fail(
+            new CommandTerminationFailed({
+              args: [],
+              cause: redactedError(cause),
+              executable: windowsTaskkillExecutable(),
+              message: redactSensitiveText(
+                `Could not terminate process tree ${child.pid ?? 'unknown'}: ${cause.message}`,
+              ),
+              pid: child.pid ?? -1,
+            }),
+          ),
+        );
+        return;
+      }
+      resume(Effect.void);
+    });
+  });
+}
+
+function terminationCleanupEffect(child: ChildProcess, invocation: CommandInvocation, force: boolean) {
+  return terminateCommandProcessEffect(child, invocation, force).pipe(
+    Effect.catch(error =>
+      Effect.sync(() => {
+        process.stderr.write(`Warning: ${error.message}\n`);
+      }),
+    ),
+  );
+}
+
+export function terminateCommandProcess(
+  child: ChildProcess,
+  _invocation: CommandInvocation,
+  force: boolean,
+): Promise<void> {
+  return new Promise((resolveTermination, rejectTermination) => {
+    beginCommandProcessTermination(child, force, cause => {
+      if (cause && child.exitCode === null) {
+        rejectTermination(cause);
+      } else {
+        resolveTermination();
+      }
+    });
+  });
+}
+
+function beginCommandProcessTermination(child: ChildProcess, force: boolean, complete: (cause?: Error) => void): void {
+  if (child.exitCode !== null) {
+    complete();
+    return;
+  }
+  if (process.platform === 'win32' && child.pid !== undefined) {
+    execFile(windowsTaskkillExecutable(), ['/pid', String(child.pid), '/t', '/f'], {windowsHide: true}, cause => {
+      const error = cause instanceof Error ? cause : undefined;
+      if (error && child.exitCode === null) {
+        child.kill('SIGKILL');
+      }
+      complete(error);
+    });
+    return;
+  }
+  try {
+    child.kill(force ? 'SIGKILL' : 'SIGTERM');
+  } finally {
+    complete();
+  }
+}
+
 const GIT_ENVIRONMENT_KEYS = [
   'GIT_DIR',
   'GIT_WORK_TREE',
@@ -240,7 +436,7 @@ export function withoutGitEnvironment(env: NodeJS.ProcessEnv = process.env): Nod
 }
 
 function commandEnvironment(executable: string, env: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv | undefined {
-  return basename(executable) === 'git' ? withoutGitEnvironment(env ?? process.env) : env;
+  return isGitExecutable(executable) ? withoutGitEnvironment(env ?? process.env) : env;
 }
 
 export function formatShellCommand(executable: string, args: readonly string[]): string {

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -17,7 +17,7 @@ export interface CommandOptions {
 export interface CommandInvocation {
   readonly args: readonly string[];
   readonly executable: string;
-  readonly windowsVerbatimArguments: boolean;
+  readonly shell?: string;
 }
 
 export interface StreamingCommandOptions {
@@ -173,6 +173,7 @@ const executeCommand = Effect.fn('CommandExecutor.execute')(function* (
         cwd: options.cwd,
         env: commandEnvironment(executable, options.env, environment),
         forceKillAfter: 1000,
+        shell: invocation.shell,
         stdin: 'ignore',
       }).pipe(Effect.mapError(spawnFailed));
       const [stdout, stderr, exitCode] = yield* Effect.all(
@@ -247,6 +248,7 @@ const executeStreamingCommand = Effect.fn('CommandExecutor.executeStreaming')(fu
       const handle = yield* ChildProcess.make(invocation.executable, [...invocation.args], {
         env: options.env,
         forceKillAfter: 1000,
+        shell: invocation.shell,
         stdin: 'inherit',
       }).pipe(Effect.mapError(spawnFailed));
       const stdio = yield* Stdio.Stdio;
@@ -350,7 +352,7 @@ export function resolveCommandInvocation(
   comspec = 'cmd.exe',
 ): CommandInvocation {
   if (currentPlatform !== 'win32' || !/\.(?:bat|cmd)$/i.test(executable)) {
-    return {args, executable, windowsVerbatimArguments: false};
+    return {args, executable};
   }
   for (const value of [executable, ...args]) {
     if (value.includes('\0') || /[\r\n]/.test(value)) {
@@ -361,9 +363,9 @@ export function resolveCommandInvocation(
   const command = escapeWindowsCommand(executable);
   const escapedArgs = args.map(arg => escapeWindowsArgument(arg, doubleEscape));
   return {
-    args: ['/d', '/s', '/c', `"${[command, ...escapedArgs].join(' ')}"`],
-    executable: comspec,
-    windowsVerbatimArguments: true,
+    args: [],
+    executable: [command, ...escapedArgs].join(' '),
+    shell: comspec,
   };
 }
 

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -66,7 +66,7 @@ export class CommandExecutor extends Context.Service<
       args: readonly string[],
       options?: CommandOptions,
     ) => Effect.Effect<CommandResult, CommandExecutionError>;
-    readonly executeStreaming?: (
+    readonly executeStreaming: (
       executable: string,
       args: readonly string[],
       options?: StreamingCommandOptions,
@@ -110,11 +110,7 @@ export const runStreamingCommandEffect = Effect.fn('runStreamingCommandEffect')(
   options: StreamingCommandOptions = {},
 ) {
   const command = yield* CommandExecutor;
-  if (command.executeStreaming) {
-    return yield* command.executeStreaming(executable, args, options);
-  }
-  const system = yield* SystemInfo;
-  return yield* executeStreamingCommand(executable, args, options, system);
+  return yield* command.executeStreaming(executable, args, options);
 });
 
 export const maybeRunEffect = Effect.fn('maybeRunEffect')(function* (

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -1,4 +1,4 @@
-import {Console, Context, Effect, Layer, Schema, Sink, Stdio, Stream} from 'effect';
+import {Console, Context, Effect, Layer, Path, Schema, Sink, Stdio, Stream} from 'effect';
 import * as ChildProcess from 'effect/unstable/process/ChildProcess';
 import {ChildProcessSpawner} from 'effect/unstable/process/ChildProcessSpawner';
 import {command as commandText, info, warning} from '../cli_ui.js';
@@ -77,11 +77,12 @@ export class CommandExecutor extends Context.Service<
     CommandExecutor,
     Effect.gen(function* () {
       const childProcessSpawner = yield* ChildProcessSpawner;
+      const pathService = yield* Path.Path;
       const stdio = yield* Stdio.Stdio;
       const system = yield* SystemInfo;
       return CommandExecutor.of({
         execute: (executable, args, options) =>
-          executeCommand(executable, args, options, system).pipe(
+          executeCommand(executable, args, options, system, pathService).pipe(
             Effect.provideService(ChildProcessSpawner, childProcessSpawner),
           ),
         executeStreaming: (executable, args, options) =>
@@ -143,6 +144,7 @@ const executeCommand = Effect.fn('CommandExecutor.execute')(function* (
   args: readonly string[],
   options: CommandOptions = {},
   system: SystemInfoShape,
+  pathService: Path.Path,
 ) {
   const environment = system.environment();
   const maxOutputBytes = options.maxOutputBytes ?? commandMaxOutputBytes(environment);
@@ -171,7 +173,7 @@ const executeCommand = Effect.fn('CommandExecutor.execute')(function* (
       });
       const handle = yield* ChildProcess.make(invocation.executable, [...invocation.args], {
         cwd: options.cwd,
-        env: commandEnvironment(executable, options.env, environment),
+        env: commandEnvironment(executable, options.env, environment, pathService),
         forceKillAfter: 1000,
         shell: invocation.shell,
         stdin: 'ignore',
@@ -384,6 +386,11 @@ export function isGitExecutable(executable: string): boolean {
   return /^(?:git)(?:\.(?:bat|cmd|com|exe))?$/i.test(name);
 }
 
+export function isOpenVikingCliExecutable(executable: string): boolean {
+  const name = executable.replaceAll('\\', '/').split('/').at(-1) ?? '';
+  return /^(?:openviking|ov)(?:\.(?:bat|cmd|com|exe))?$/i.test(name);
+}
+
 export const windowsTaskkillExecutable = Effect.fn('CommandExecutor.windowsTaskkillExecutable')(function* () {
   const environment = (yield* SystemInfo).environment();
   return `${(environment.SystemRoot ?? 'C:\\Windows').replace(/[\\/]+$/, '')}\\System32\\taskkill.exe`;
@@ -408,12 +415,27 @@ export function withoutGitEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv
   return next;
 }
 
-function commandEnvironment(
+export function commandEnvironment(
   executable: string,
   env: NodeJS.ProcessEnv | undefined,
   systemEnvironment: NodeJS.ProcessEnv,
+  pathService: Path.Path,
 ): NodeJS.ProcessEnv | undefined {
-  return isGitExecutable(executable) ? withoutGitEnvironment(env ?? systemEnvironment) : env;
+  const selected = isGitExecutable(executable) ? withoutGitEnvironment(env ?? systemEnvironment) : env;
+  if (!isOpenVikingCliExecutable(executable)) {
+    return selected;
+  }
+  const openVikingEnvironment = selected ?? systemEnvironment;
+  const threadnoteHome = openVikingEnvironment.THREADNOTE_HOME;
+  if (!threadnoteHome) {
+    return selected;
+  }
+  return {
+    ...openVikingEnvironment,
+    OPENVIKING_CLI_CONFIG_FILE:
+      openVikingEnvironment.OPENVIKING_CLI_CONFIG_FILE ?? pathService.join(threadnoteHome, 'ovcli.conf'),
+    OPENVIKING_CONFIG_FILE: openVikingEnvironment.OPENVIKING_CONFIG_FILE ?? pathService.join(threadnoteHome, 'ov.conf'),
+  };
 }
 
 export function formatShellCommand(executable: string, args: readonly string[]): string {

--- a/src/effect/console.ts
+++ b/src/effect/console.ts
@@ -1,38 +1,4 @@
-import {AsyncLocalStorage} from 'node:async_hooks';
 import {Console, Effect} from 'effect';
-
-const consoleScope = new AsyncLocalStorage<Console.Console>();
-
-type OutputMethod = 'debug' | 'error' | 'info' | 'log' | 'warn';
-
-function forward(method: OutputMethod, args: readonly unknown[]): void {
-  const service = consoleScope.getStore();
-  if (!service) {
-    throw new Error('Console output escaped its Effect Console scope.');
-  }
-  service[method](...args);
-}
-
-/**
- * Synchronous view of the current Effect Console service for Promise-based
- * compatibility code. New Effect code should use Console.log / warn / error
- * directly; fromPromise installs this scope at the compatibility boundary.
- */
-export const consoleOutput = {
-  debug: (...args: readonly unknown[]) => forward('debug', args),
-  error: (...args: readonly unknown[]) => forward('error', args),
-  info: (...args: readonly unknown[]) => forward('info', args),
-  log: (...args: readonly unknown[]) => forward('log', args),
-  warn: (...args: readonly unknown[]) => forward('warn', args),
-} as const;
-
-export function runWithConsole<A>(service: Console.Console, evaluate: () => A): A {
-  return consoleScope.run(service, evaluate);
-}
-
-export function syncWithConsole<A>(evaluate: () => A): Effect.Effect<A> {
-  return Console.consoleWith(service => Effect.sync(() => runWithConsole(service, evaluate)));
-}
 
 function capturingConsole(parent: Console.Console, lines: string[]): Console.Console {
   const append = (...args: readonly unknown[]): void => {
@@ -43,18 +9,6 @@ function capturingConsole(parent: Console.Console, lines: string[]): Console.Con
     log: append,
     warn: append,
   });
-}
-
-export function tryPromiseWithConsole<A, E>(options: {
-  readonly catch: (cause: unknown) => E;
-  readonly try: () => PromiseLike<A>;
-}): Effect.Effect<A, E> {
-  return Console.consoleWith(service =>
-    Effect.tryPromise({
-      catch: options.catch,
-      try: () => runWithConsole(service, options.try),
-    }),
-  );
 }
 
 export function captureConsole<A, E, R>(
@@ -68,17 +22,4 @@ export function captureConsole<A, E, R>(
       Effect.map(value => ({output: lines.join('\n'), value})),
     );
   });
-}
-
-export async function capturePromiseConsole<A>(
-  evaluate: () => Promise<A>,
-): Promise<{readonly output: string; readonly value: A}> {
-  const parent = consoleScope.getStore();
-  if (!parent) {
-    throw new Error('Console capture escaped its Effect Console scope.');
-  }
-  const lines: string[] = [];
-  const service = capturingConsole(parent, lines);
-  const value = await runWithConsole(service, evaluate);
-  return {output: lines.join('\n'), value};
 }

--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -1,5 +1,4 @@
 import {Effect, Schema} from 'effect';
-import {tryPromiseWithConsole} from './console.js';
 
 export class ApplicationError extends Schema.TaggedErrorClass<ApplicationError>()('ApplicationError', {
   cause: Schema.Defect(),
@@ -16,10 +15,10 @@ export function applicationError(operation: string, cause: unknown): Application
 }
 
 export const fromPromise = <A>(operation: string, evaluate: () => Promise<A>) =>
-  tryPromiseWithConsole({try: evaluate, catch: cause => applicationError(operation, cause)});
+  Effect.tryPromise({try: evaluate, catch: cause => applicationError(operation, cause)});
 
 export const fromPromiseError = <A>(evaluate: () => PromiseLike<A>) =>
-  tryPromiseWithConsole({
+  Effect.tryPromise({
     try: evaluate,
     catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
   });

--- a/src/effect/file_lock.ts
+++ b/src/effect/file_lock.ts
@@ -1,5 +1,6 @@
 import {Clock, Crypto, Effect, FileSystem, Option, Path, PlatformError} from 'effect';
 import {sha256Hex} from './digest.js';
+import {SystemInfo} from './system.js';
 
 export interface ExclusiveFileLockOptions {
   readonly heartbeatIntervalMilliseconds?: number;
@@ -23,7 +24,8 @@ export function withExclusiveFileLock<A, E, R>(
     const pathService = yield* Path.Path;
     yield* fs.makeDirectory(pathService.dirname(lockPath), {recursive: true});
     const crypto = yield* Crypto.Crypto;
-    const token = `${process.pid}:${yield* crypto.randomUUIDv4}`;
+    const system = yield* SystemInfo;
+    const token = `${system.processId}:${yield* crypto.randomUUIDv4}`;
     const startedAt = yield* Clock.currentTimeMillis;
     while (!(yield* tryAcquireFileLock(fs, lockPath, token, options.staleAfterMilliseconds))) {
       const now = yield* Clock.currentTimeMillis;
@@ -49,7 +51,7 @@ function tryAcquireFileLock(
   lockPath: string,
   token: string,
   staleAfterMilliseconds: number,
-): Effect.Effect<boolean, unknown, Crypto.Crypto> {
+): Effect.Effect<boolean, unknown, Crypto.Crypto | SystemInfo> {
   return Effect.gen(function* () {
     yield* recoverStaleFileLock(fs, lockPath, staleAfterMilliseconds);
     if (!(yield* tryWriteLockToken(fs, lockPath, token))) {
@@ -67,7 +69,7 @@ function recoverStaleFileLock(
   fs: FileSystem.FileSystem,
   lockPath: string,
   staleAfterMilliseconds: number,
-): Effect.Effect<void, unknown, Crypto.Crypto> {
+): Effect.Effect<void, unknown, Crypto.Crypto | SystemInfo> {
   return Effect.gen(function* () {
     const guardPath = recoveryGuardPath(lockPath);
     const lockNeedsRecovery = yield* staleDeadLockToken(fs, lockPath, staleAfterMilliseconds);
@@ -92,10 +94,11 @@ function acquireRecoveryGuard(
   lockPath: string,
   guardPath: string,
   staleAfterMilliseconds: number,
-): Effect.Effect<string | undefined, unknown, Crypto.Crypto> {
+): Effect.Effect<string | undefined, unknown, Crypto.Crypto | SystemInfo> {
   return Effect.gen(function* () {
     const crypto = yield* Crypto.Crypto;
-    const token = `${process.pid}:${yield* crypto.randomUUIDv4}`;
+    const system = yield* SystemInfo;
+    const token = `${system.processId}:${yield* crypto.randomUUIDv4}`;
     if (yield* tryWriteLockToken(fs, guardPath, token)) {
       return token;
     }
@@ -123,8 +126,9 @@ function staleDeadLockToken(
   fs: FileSystem.FileSystem,
   path: string,
   staleAfterMilliseconds: number,
-): Effect.Effect<string | undefined, unknown> {
+): Effect.Effect<string | undefined, unknown, SystemInfo> {
   return Effect.gen(function* () {
+    const system = yield* SystemInfo;
     if (!(yield* fs.exists(path))) {
       return undefined;
     }
@@ -136,7 +140,7 @@ function staleDeadLockToken(
     }
     const token = (yield* fs.readFileString(path)).trim();
     const ownerPid = fileLockOwnerPid(token);
-    return ownerPid === undefined || !(yield* Effect.sync(() => processIsAlive(ownerPid))) ? token : undefined;
+    return ownerPid === undefined || !system.isProcessRunning(ownerPid) ? token : undefined;
   });
 }
 
@@ -180,20 +184,6 @@ function refreshFileLockLease(
 function fileLockOwnerPid(token: string): number | undefined {
   const value = Number.parseInt(token.split(':', 1)[0] ?? '', 10);
   return Number.isSafeInteger(value) && value > 0 ? value : undefined;
-}
-
-function processIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (cause: unknown) {
-    return !(
-      typeof cause === 'object' &&
-      cause !== null &&
-      'code' in cause &&
-      (cause as {readonly code?: unknown}).code === 'ESRCH'
-    );
-  }
 }
 
 function releaseFileLock(fs: FileSystem.FileSystem, lockPath: string, token: string): Effect.Effect<void, never> {

--- a/src/effect/http.ts
+++ b/src/effect/http.ts
@@ -1,4 +1,4 @@
-import {NodeHttpClient} from '@effect/platform-node';
+import * as NodeHttpClient from '@effect/platform-node/NodeHttpClient';
 import {Context, Effect, Layer, Schema} from 'effect';
 import * as HttpClient from 'effect/unstable/http/HttpClient';
 import * as HttpClientRequest from 'effect/unstable/http/HttpClientRequest';

--- a/src/effect/mcp.ts
+++ b/src/effect/mcp.ts
@@ -1,7 +1,6 @@
-import {NodeStdio} from '@effect/platform-node';
-import {Console, Context, Effect, Layer, Logger, Schema, Sink, Stdio} from 'effect';
+import * as NodeStdio from '@effect/platform-node/NodeStdio';
+import {Context, Effect, Layer, Logger, Option, Schema, Sink, Stdio} from 'effect';
 import {McpSchema, McpServer} from 'effect/unstable/ai';
-import {runWithConsole} from './console.js';
 import {fromPromiseError} from './errors.js';
 import type {ApplicationServices} from './runtime.js';
 
@@ -79,27 +78,27 @@ export class EffectMcpServerAdapter {
               name: registration.name,
             }),
             handle: payload => {
-              let parsed: Schema.Struct.Type<ToolFields>;
-              try {
-                parsed = Schema.decodeUnknownSync(input, {errors: 'all'})(payload);
-              } catch (cause) {
-                return Effect.succeed(
-                  new McpSchema.CallToolResult({
-                    content: [{type: 'text', text: cause instanceof Error ? cause.message : String(cause)}],
-                    isError: true,
-                  }),
-                );
-              }
-              const effect = toolHandlerEffect(() => registration.handle(parsed), applicationServices);
-              return effect.pipe(
-                Effect.match({
-                  onFailure: error =>
+              return Schema.decodeUnknownEffect(input, {errors: 'all'})(payload).pipe(
+                Effect.flatMap(parsed =>
+                  toolHandlerEffect(() => registration.handle(parsed), applicationServices).pipe(
+                    Effect.match({
+                      onFailure: error =>
+                        new McpSchema.CallToolResult({
+                          content: [{type: 'text', text: error instanceof Error ? error.message : String(error)}],
+                          isError: true,
+                        }),
+                      onSuccess: result => new McpSchema.CallToolResult(result as McpSchema.CallToolResult),
+                    }),
+                  ),
+                ),
+                Effect.catch(cause =>
+                  Effect.succeed(
                     new McpSchema.CallToolResult({
-                      content: [{type: 'text', text: error instanceof Error ? error.message : String(error)}],
+                      content: [{type: 'text', text: cause instanceof Error ? cause.message : String(cause)}],
                       isError: true,
                     }),
-                  onSuccess: result => new McpSchema.CallToolResult(result as McpSchema.CallToolResult),
-                }),
+                  ),
+                ),
               );
             },
           });
@@ -155,14 +154,8 @@ function toolHandlerEffect(
   evaluate: () => ToolHandlerResult,
   applicationServices: Context.Context<ApplicationServices>,
 ): Effect.Effect<ToolResult, unknown> {
-  return Console.consoleWith(output =>
-    Effect.suspend(() => {
-      let handled: ToolHandlerResult;
-      try {
-        handled = runWithConsole(output, evaluate);
-      } catch (cause: unknown) {
-        return Effect.fail(normalizeError(cause));
-      }
+  return Effect.try({try: evaluate, catch: normalizeError}).pipe(
+    Effect.flatMap(handled => {
       if (Effect.isEffect(handled)) {
         return handled.pipe(Effect.provideContext(applicationServices));
       }
@@ -235,20 +228,21 @@ const stdioWithInstructionsLayer = (instructions: string): Layer.Layer<Stdio.Std
 
 function addInitializeInstructions(input: string | Uint8Array, instructions: string): string | Uint8Array {
   const text = typeof input === 'string' ? input : new TextDecoder().decode(input);
-  try {
-    const parsed = JSON.parse(text) as {
-      readonly result?: {
-        readonly capabilities?: unknown;
-        readonly protocolVersion?: unknown;
-        readonly serverInfo?: unknown;
-      };
-    };
-    if (parsed.result?.protocolVersion === undefined || parsed.result.serverInfo === undefined) {
-      return input;
-    }
-    const encoded = `${JSON.stringify({...parsed, result: {...parsed.result, instructions}})}\n`;
-    return typeof input === 'string' ? encoded : new TextEncoder().encode(encoded);
-  } catch {
+  const parsed = Option.getOrUndefined(
+    Option.liftThrowable(
+      (content: string) =>
+        JSON.parse(content) as {
+          readonly result?: {
+            readonly capabilities?: unknown;
+            readonly protocolVersion?: unknown;
+            readonly serverInfo?: unknown;
+          };
+        },
+    )(text),
+  );
+  if (!parsed || parsed.result?.protocolVersion === undefined || parsed.result.serverInfo === undefined) {
     return input;
   }
+  const encoded = `${JSON.stringify({...parsed, result: {...parsed.result, instructions}})}\n`;
+  return typeof input === 'string' ? encoded : new TextEncoder().encode(encoded);
 }

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -1,16 +1,14 @@
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
+import * as NodeServices from '@effect/platform-node/NodeServices';
 import {Layer} from 'effect';
 import {CommandExecutor} from './command.js';
 import {HttpService} from './http.js';
 import {SystemInfo} from './system.js';
 
-export const ApplicationLayer = Layer.mergeAll(
-  CommandExecutor.layer,
-  HttpService.layer,
-  NodeCrypto.layer,
-  NodeFileSystem.layer,
-  NodePath.layer,
-  SystemInfo.layer,
-);
+const systemLayer = SystemInfo.layer;
+const commandLayer = CommandExecutor.layer.pipe(Layer.provide(systemLayer));
+
+const ApplicationServicesLayer = Layer.mergeAll(commandLayer, HttpService.layer, systemLayer);
+
+export const ApplicationLayer = ApplicationServicesLayer.pipe(Layer.provideMerge(NodeServices.layer));
 
 export type ApplicationServices = Layer.Success<typeof ApplicationLayer>;

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -2,6 +2,7 @@ import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
 import {Layer} from 'effect';
 import {CommandExecutor} from './command.js';
 import {HttpService} from './http.js';
+import {SystemInfo} from './system.js';
 
 export const ApplicationLayer = Layer.mergeAll(
   CommandExecutor.layer,
@@ -9,6 +10,7 @@ export const ApplicationLayer = Layer.mergeAll(
   NodeCrypto.layer,
   NodeFileSystem.layer,
   NodePath.layer,
+  SystemInfo.layer,
 );
 
 export type ApplicationServices = Layer.Success<typeof ApplicationLayer>;

--- a/src/effect/share.ts
+++ b/src/effect/share.ts
@@ -1,61 +1,64 @@
 import {Console, Effect, FileSystem} from 'effect';
-import {fromPromise, fromSync} from './errors.js';
 import {withMemoryUriLocks} from './memory_lock.js';
 import {withSharedRepositoryLock} from './share_lock.js';
 import {
-  installSharedAgentArtifacts as installSharedAgentArtifactsPromise,
-  listSharedAgentArtifacts as listSharedAgentArtifactsPromise,
-  listShareConflicts as listShareConflictsPromise,
-  removeMemoryUri as removeMemoryUriPromise,
-  refreshSharedReposInBackground as refreshSharedReposInBackgroundPromise,
-  resolveShareConflict as resolveShareConflictPromise,
-  runShareConflictResolve as runShareConflictResolvePromise,
-  runShareConflicts as runShareConflictsPromise,
-  runShareConflictShow as runShareConflictShowPromise,
-  runShareInit as runShareInitPromise,
-  runShareInstallArtifacts as runShareInstallArtifactsPromise,
-  runShareList as runShareListPromise,
-  runSharePublish as runSharePublishPromise,
-  runSharePublishArtifact as runSharePublishArtifactPromise,
-  runSharePublishBundle as runSharePublishBundlePromise,
-  runShareRemove as runShareRemovePromise,
-  runShareRename as runShareRenamePromise,
-  runShareSetUrl as runShareSetUrlPromise,
-  runShareStatus as runShareStatusPromise,
-  runShareSync as runShareSyncPromise,
-  runShareUnpublish as runShareUnpublishPromise,
-  resolveTeam,
-  shareAgentArtifact as shareAgentArtifactPromise,
-  shareBundlePack as shareBundlePackPromise,
-  showShareConflict as showShareConflictPromise,
+  installSharedAgentArtifacts as installSharedAgentArtifactsEffect,
+  listSharedAgentArtifacts as listSharedAgentArtifactsEffect,
+  listShareConflicts as listShareConflictsEffect,
+  removeMemoryUri as removeMemoryUriEffect,
+  refreshSharedReposInBackground as refreshSharedReposInBackgroundEffect,
+  resolveShareConflict as resolveShareConflictEffect,
+  resolveTeam as resolveTeamEffect,
+  runShareConflictResolve as runShareConflictResolveEffect,
+  runShareConflicts as runShareConflictsEffect,
+  runShareConflictShow as runShareConflictShowEffect,
+  runShareInit as runShareInitEffect,
+  runShareInstallArtifacts as runShareInstallArtifactsEffect,
+  runShareList as runShareListEffect,
+  runSharePublish as runSharePublishEffect,
+  runSharePublishArtifact as runSharePublishArtifactEffect,
+  runSharePublishBundle as runSharePublishBundleEffect,
+  runShareRemove as runShareRemoveEffect,
+  runShareRename as runShareRenameEffect,
+  runShareSetUrl as runShareSetUrlEffect,
+  runShareStatus as runShareStatusEffect,
+  runShareSync as runShareSyncEffect,
+  runShareUnpublish as runShareUnpublishEffect,
+  shareAgentArtifact as shareAgentArtifactEffect,
+  shareBundlePack as shareBundlePackEffect,
+  showShareConflict as showShareConflictEffect,
   SHARED_BACKGROUND_FETCH_INTERVAL_MILLISECONDS,
   sharedUriFor,
-  syncSharedReposBeforeAgentRead as syncSharedReposBeforeAgentReadPromise,
+  syncSharedReposBeforeAgentRead as syncSharedReposBeforeAgentReadEffect,
 } from '../share.js';
-import type {SharePublishOptions, ShareRuntime} from '../types.js';
+import type {
+  ShareConflictOptions,
+  ShareConflictResolveOptions,
+  ShareConflictShowOptions,
+  ShareInitOptions,
+  ShareInstallArtifactsOptions,
+  ShareListArtifactsOptions,
+  ShareListOptions,
+  SharePublishArtifactOptions,
+  SharePublishOptions,
+  ShareRemoveOptions,
+  ShareRenameOptions,
+  ShareSetUrlOptions,
+  ShareStatusOptions,
+  ShareSyncOptions,
+  ShareUnpublishOptions,
+  ShareRuntime,
+} from '../types.js';
 
-const effectify =
-  <Args extends readonly unknown[], A>(operation: string, evaluate: (...args: Args) => Promise<A>) =>
-  (...args: Args) =>
-    fromPromise(operation, () => evaluate(...args));
-
-const effectifyLocked =
-  <Args extends readonly unknown[], A>(
-    operation: string,
-    evaluate: (config: ShareRuntime, ...args: Args) => Promise<A>,
-  ) =>
-  (config: ShareRuntime, ...args: Args) =>
-    withSharedRepositoryLock(
-      config,
-      fromPromise(operation, () => evaluate(config, ...args)),
-    );
-
-export const runShareInit = effectifyLocked('initialize shared memory repository', runShareInitPromise);
-export const runShareStatus = effectifyLocked('read shared memory status', runShareStatusPromise);
-export const runShareSync = effectifyLocked('synchronize shared memory repository', runShareSyncPromise);
+export const runShareInit = (config: ShareRuntime, remoteUrl: string, options: ShareInitOptions) =>
+  withSharedRepositoryLock(config, runShareInitEffect(config, remoteUrl, options));
+export const runShareStatus = (config: ShareRuntime, options: ShareStatusOptions) =>
+  withSharedRepositoryLock(config, runShareStatusEffect(config, options));
+export const runShareSync = (config: ShareRuntime, options: ShareSyncOptions) =>
+  withSharedRepositoryLock(config, runShareSyncEffect(config, options));
 export const monitorSharedRepositories = Effect.fn('share.monitorRepositories')(function* (config: ShareRuntime) {
   const refresh = (force: boolean) =>
-    effectifyLocked('refresh shared memory repositories', refreshSharedReposInBackgroundPromise)(config, force).pipe(
+    withSharedRepositoryLock(config, refreshSharedReposInBackgroundEffect(config, force)).pipe(
       Effect.catch(error =>
         Console.error(`share auto-fetch failed: ${error instanceof Error ? error.message : String(error)}`),
       ),
@@ -67,57 +70,70 @@ export const monitorSharedRepositories = Effect.fn('share.monitorRepositories')(
   }
 });
 export const syncSharedReposBeforeAgentRead = Effect.fn('share.syncBeforeAgentRead')(function* (config: ShareRuntime) {
-  return yield* withSharedRepositoryLock(
-    config,
-    fromPromise('synchronize shared memories before agent read', () => syncSharedReposBeforeAgentReadPromise(config)),
-  );
+  return yield* withSharedRepositoryLock(config, syncSharedReposBeforeAgentReadEffect(config));
 });
-export const runShareConflicts = effectifyLocked('list shared memory conflicts', runShareConflictsPromise);
-export const runShareConflictShow = effectifyLocked('show shared memory conflict', runShareConflictShowPromise);
-export const listShareConflicts = effectifyLocked('list shared memory conflicts', listShareConflictsPromise);
-export const showShareConflict = effectifyLocked('show shared memory conflict', showShareConflictPromise);
-export const runShareConflictResolve = effectifyLocked(
-  'resolve shared memory conflict',
-  runShareConflictResolvePromise,
-);
+export const runShareConflicts = (config: ShareRuntime, options: ShareConflictOptions) =>
+  withSharedRepositoryLock(config, runShareConflictsEffect(config, options));
+export const runShareConflictShow = (config: ShareRuntime, reference: string, options: ShareConflictShowOptions) =>
+  withSharedRepositoryLock(config, runShareConflictShowEffect(config, reference, options));
+export const listShareConflicts = (config: ShareRuntime, options: ShareConflictOptions) =>
+  withSharedRepositoryLock(config, listShareConflictsEffect(config, options));
+export const showShareConflict = (config: ShareRuntime, reference: string, options: ShareConflictShowOptions) =>
+  withSharedRepositoryLock(config, showShareConflictEffect(config, reference, options));
+export const runShareConflictResolve = (
+  config: ShareRuntime,
+  reference: string,
+  options: ShareConflictResolveOptions,
+) => withSharedRepositoryLock(config, runShareConflictResolveEffect(config, reference, options));
 export const runSharePublish = Effect.fn('share.publish')(function* (
   config: ShareRuntime,
   sourceUri: string,
   options: SharePublishOptions,
 ) {
-  const publish = fromPromise('publish shared memory', () => runSharePublishPromise(config, sourceUri, options));
+  const publish = runSharePublishEffect(config, sourceUri, options);
   if (options.dryRun === true || options.preview === true) {
     return yield* publish;
   }
   return yield* withSharedRepositoryLock(
     config,
     Effect.gen(function* () {
-      const team = yield* fromPromise('resolve shared memory team', () => resolveTeam(config, options.team));
-      const targetUri = yield* fromSync('resolve shared memory target', () =>
-        sharedUriFor(config, sourceUri, team.name),
-      );
+      const team = yield* resolveTeamEffect(config, options.team);
+      const targetUri = sharedUriFor(config, sourceUri, team.name);
       const fs = yield* FileSystem.FileSystem;
-      const resolvedPublish = fromPromise('publish shared memory', () =>
-        runSharePublishPromise(config, sourceUri, {...options, team: team.name}),
-      );
+      const resolvedPublish = runSharePublishEffect(config, sourceUri, {...options, team: team.name});
       return yield* withMemoryUriLocks(fs, config.agentContextHome, [sourceUri, targetUri], resolvedPublish);
     }),
   );
 });
-export const runSharePublishArtifact = effectifyLocked('publish shared artifact', runSharePublishArtifactPromise);
-export const runSharePublishBundle = effectifyLocked('publish shared artifact bundle', runSharePublishBundlePromise);
-export const shareAgentArtifact = effectifyLocked('publish shared artifact', shareAgentArtifactPromise);
-export const shareBundlePack = effectifyLocked('publish shared artifact bundle', shareBundlePackPromise);
-export const runShareInstallArtifacts = effectifyLocked('install shared artifacts', runShareInstallArtifactsPromise);
-export const runShareUnpublish = effectifyLocked('unpublish shared memory', runShareUnpublishPromise);
-export const runShareList = effectify('list shared memory teams', runShareListPromise);
-export const runShareRename = effectifyLocked('rename shared memory team', runShareRenamePromise);
-export const runShareSetUrl = effectifyLocked('set shared memory remote URL', runShareSetUrlPromise);
-export const runShareRemove = effectifyLocked('remove shared memory team', runShareRemovePromise);
-export const resolveShareConflict = effectifyLocked('resolve shared memory conflict', resolveShareConflictPromise);
-export const listSharedAgentArtifacts = effectifyLocked('list shared agent artifacts', listSharedAgentArtifactsPromise);
-export const installSharedAgentArtifacts = effectifyLocked(
-  'install shared agent artifacts',
-  installSharedAgentArtifactsPromise,
-);
-export const removeMemoryUri = effectify('remove shared memory', removeMemoryUriPromise);
+export const runSharePublishArtifact = (
+  config: ShareRuntime,
+  sourcePath: string,
+  options: SharePublishArtifactOptions,
+) => withSharedRepositoryLock(config, runSharePublishArtifactEffect(config, sourcePath, options));
+export const runSharePublishBundle = (
+  config: ShareRuntime,
+  manifestPath: string,
+  options: SharePublishArtifactOptions,
+) => withSharedRepositoryLock(config, runSharePublishBundleEffect(config, manifestPath, options));
+export const shareAgentArtifact = (config: ShareRuntime, sourcePath: string, options: SharePublishArtifactOptions) =>
+  withSharedRepositoryLock(config, shareAgentArtifactEffect(config, sourcePath, options));
+export const shareBundlePack = (config: ShareRuntime, manifestPath: string, options: SharePublishArtifactOptions) =>
+  withSharedRepositoryLock(config, shareBundlePackEffect(config, manifestPath, options));
+export const runShareInstallArtifacts = (config: ShareRuntime, options: ShareInstallArtifactsOptions) =>
+  withSharedRepositoryLock(config, runShareInstallArtifactsEffect(config, options));
+export const runShareUnpublish = (config: ShareRuntime, sourceUri: string, options: ShareUnpublishOptions) =>
+  withSharedRepositoryLock(config, runShareUnpublishEffect(config, sourceUri, options));
+export const runShareList = (config: ShareRuntime, options: ShareListOptions) => runShareListEffect(config, options);
+export const runShareRename = (config: ShareRuntime, options: ShareRenameOptions) =>
+  withSharedRepositoryLock(config, runShareRenameEffect(config, options));
+export const runShareSetUrl = (config: ShareRuntime, remoteUrl: string, options: ShareSetUrlOptions) =>
+  withSharedRepositoryLock(config, runShareSetUrlEffect(config, remoteUrl, options));
+export const runShareRemove = (config: ShareRuntime, options: ShareRemoveOptions) =>
+  withSharedRepositoryLock(config, runShareRemoveEffect(config, options));
+export const resolveShareConflict = (config: ShareRuntime, reference: string, options: ShareConflictResolveOptions) =>
+  withSharedRepositoryLock(config, resolveShareConflictEffect(config, reference, options));
+export const listSharedAgentArtifacts = (config: ShareRuntime, options: ShareListArtifactsOptions) =>
+  withSharedRepositoryLock(config, listSharedAgentArtifactsEffect(config, options));
+export const installSharedAgentArtifacts = (config: ShareRuntime, options: ShareInstallArtifactsOptions) =>
+  withSharedRepositoryLock(config, installSharedAgentArtifactsEffect(config, options));
+export const removeMemoryUri = removeMemoryUriEffect;

--- a/src/effect/system.ts
+++ b/src/effect/system.ts
@@ -21,16 +21,12 @@ export interface SystemInfoShape {
 
 export class SystemInfo extends Context.Service<SystemInfo, SystemInfoShape>()('threadnote/effect/SystemInfo') {
   static readonly layer = Layer.sync(SystemInfo, () => {
-    const windowsHome =
-      process.env.USERPROFILE ??
-      (process.env.HOMEDRIVE && process.env.HOMEPATH
-        ? `${process.env.HOMEDRIVE}${process.env.HOMEPATH}`
-        : process.env.HOME);
+    const homeDirectory = resolveHomeDirectory(process.env, process.platform);
     return SystemInfo.of({
       currentDirectory: () => process.cwd(),
       environment: () => process.env,
       executablePath: process.execPath,
-      homeDirectory: (process.platform === 'win32' ? windowsHome : (process.env.HOME ?? windowsHome)) ?? process.cwd(),
+      homeDirectory,
       isProcessRunning: processId => {
         try {
           process.kill(processId, 0);
@@ -65,4 +61,21 @@ export class SystemInfo extends Context.Service<SystemInfo, SystemInfoShape>()('
       userName: process.env.USER ?? process.env.USERNAME ?? 'unknown',
     });
   });
+}
+
+export function resolveHomeDirectory(environment: NodeJS.ProcessEnv, platform: NodeJS.Platform): string {
+  const home = nonEmptyEnvironmentValue(environment.HOME);
+  const userProfile = nonEmptyEnvironmentValue(environment.USERPROFILE);
+  const homeDrive = nonEmptyEnvironmentValue(environment.HOMEDRIVE);
+  const homePath = nonEmptyEnvironmentValue(environment.HOMEPATH);
+  const windowsHome = userProfile ?? (homeDrive && homePath ? `${homeDrive}${homePath}` : undefined);
+  const resolved = platform === 'win32' ? (windowsHome ?? home) : (home ?? windowsHome);
+  if (!resolved) {
+    throw new Error('Could not determine the current user home directory from the environment.');
+  }
+  return resolved;
+}
+
+function nonEmptyEnvironmentValue(value: string | undefined): string | undefined {
+  return value && value.trim().length > 0 ? value : undefined;
 }

--- a/src/effect/system.ts
+++ b/src/effect/system.ts
@@ -1,8 +1,22 @@
 import {Context, Layer} from 'effect';
 
 export interface SystemInfoShape {
+  readonly currentDirectory: () => string;
+  readonly environment: () => NodeJS.ProcessEnv;
+  readonly executablePath: string;
   readonly homeDirectory: string;
+  readonly isProcessRunning: (processId: number) => boolean;
+  readonly pathDelimiter: string;
   readonly platform: NodeJS.Platform;
+  readonly processId: number;
+  readonly processArguments: readonly string[];
+  readonly setExitCode: (code: number) => void;
+  readonly setEnvironmentVariable: (name: string, value: string) => void;
+  readonly stdinIsTTY: boolean;
+  readonly stdoutIsTTY: boolean;
+  readonly tempDirectory: string;
+  readonly userId?: number;
+  readonly userName: string;
 }
 
 export class SystemInfo extends Context.Service<SystemInfo, SystemInfoShape>()('threadnote/effect/SystemInfo') {
@@ -13,8 +27,42 @@ export class SystemInfo extends Context.Service<SystemInfo, SystemInfoShape>()('
         ? `${process.env.HOMEDRIVE}${process.env.HOMEPATH}`
         : process.env.HOME);
     return SystemInfo.of({
+      currentDirectory: () => process.cwd(),
+      environment: () => process.env,
+      executablePath: process.execPath,
       homeDirectory: (process.platform === 'win32' ? windowsHome : (process.env.HOME ?? windowsHome)) ?? process.cwd(),
+      isProcessRunning: processId => {
+        try {
+          process.kill(processId, 0);
+          return true;
+        } catch (cause: unknown) {
+          return !(
+            typeof cause === 'object' &&
+            cause !== null &&
+            'code' in cause &&
+            (cause as {readonly code?: unknown}).code === 'ESRCH'
+          );
+        }
+      },
+      pathDelimiter: process.platform === 'win32' ? ';' : ':',
       platform: process.platform,
+      processId: process.pid,
+      processArguments: process.argv,
+      setExitCode: code => {
+        process.exitCode = code;
+      },
+      setEnvironmentVariable: (name, value) => {
+        process.env[name] = value;
+      },
+      stdinIsTTY: process.stdin.isTTY === true,
+      stdoutIsTTY: process.stdout.isTTY === true,
+      tempDirectory:
+        process.env.TMPDIR ??
+        process.env.TEMP ??
+        process.env.TMP ??
+        (process.platform === 'win32' ? process.cwd() : '/tmp'),
+      userId: process.getuid?.(),
+      userName: process.env.USER ?? process.env.USERNAME ?? 'unknown',
     });
   });
 }

--- a/src/effect/system.ts
+++ b/src/effect/system.ts
@@ -1,0 +1,20 @@
+import {Context, Layer} from 'effect';
+
+export interface SystemInfoShape {
+  readonly homeDirectory: string;
+  readonly platform: NodeJS.Platform;
+}
+
+export class SystemInfo extends Context.Service<SystemInfo, SystemInfoShape>()('threadnote/effect/SystemInfo') {
+  static readonly layer = Layer.sync(SystemInfo, () => {
+    const windowsHome =
+      process.env.USERPROFILE ??
+      (process.env.HOMEDRIVE && process.env.HOMEPATH
+        ? `${process.env.HOMEDRIVE}${process.env.HOMEPATH}`
+        : process.env.HOME);
+    return SystemInfo.of({
+      homeDirectory: (process.platform === 'win32' ? windowsHome : (process.env.HOME ?? windowsHome)) ?? process.cwd(),
+      platform: process.platform,
+    });
+  });
+}

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,5 +1,4 @@
-import {join} from 'node:path';
-import {Effect, FileSystem} from 'effect';
+import {Effect, FileSystem, Option, Path} from 'effect';
 
 export interface DependencyFacts {
   readonly dependencies: readonly string[];
@@ -26,12 +25,7 @@ const readIfExists = Effect.fn('graph.readIfExists')(function* (path: string) {
 function parsePackageJson(
   content: string,
 ): {readonly dependencies: readonly string[]; readonly publishedName?: string} | undefined {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(content);
-  } catch {
-    return undefined;
-  }
+  const parsed = Option.getOrUndefined(Option.liftThrowable((value: string): unknown => JSON.parse(value))(content));
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     return undefined;
   }
@@ -95,9 +89,10 @@ export function extractDependencyFacts(projectRoot: string) {
     const dependencies = new Set<string>();
     const ecosystems: string[] = [];
     const manifestFiles: string[] = [];
+    const pathService = yield* Path.Path;
     let publishedName: string | undefined;
 
-    const packageJson = yield* readIfExists(join(projectRoot, 'package.json'));
+    const packageJson = yield* readIfExists(pathService.join(projectRoot, 'package.json'));
     if (packageJson !== undefined) {
       const parsed = parsePackageJson(packageJson);
       if (parsed) {
@@ -110,7 +105,7 @@ export function extractDependencyFacts(projectRoot: string) {
       }
     }
 
-    const goMod = yield* readIfExists(join(projectRoot, 'go.mod'));
+    const goMod = yield* readIfExists(pathService.join(projectRoot, 'go.mod'));
     if (goMod !== undefined) {
       const parsed = parseGoMod(goMod);
       manifestFiles.push('go.mod');

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,4 @@
-import {readFile} from 'node:fs/promises';
-import {dirname, join} from 'node:path';
-import {Console, Effect, FileSystem} from 'effect';
+import {Console, Effect, FileSystem, Path, Result, Stdio, Stream} from 'effect';
 import {
   CLAUDE_SETTINGS_PATH,
   HOOK_AUTO_PRECOMPACT_TOPIC,
@@ -10,7 +8,7 @@ import {
   THREADNOTE_HOOK_MARKER_VALUE,
 } from './constants.js';
 import {parseAgentClient} from './mcp.js';
-import {fromPromiseError} from './effect/errors.js';
+import {SystemInfo} from './effect/system.js';
 import {runHandoff, runRecall} from './memory.js';
 import {applyScrubber} from './share.js';
 import {distillTrace} from './trace.js';
@@ -66,7 +64,8 @@ export function runHooksInstall(config: RuntimeConfig, agent: AgentClient, optio
 function runClaudeHooksInstall(options: {readonly apply: boolean; readonly remove: boolean}) {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = expandPath(CLAUDE_SETTINGS_PATH);
+    const pathService = yield* Path.Path;
+    const path = yield* expandPath(CLAUDE_SETTINGS_PATH);
     const existingRaw = (yield* fs.exists(path)) ? yield* fs.readFileString(path) : '{}';
     const parsed = parseJsonConfigObject(existingRaw) ?? {};
     const next = options.remove ? withoutThreadnoteHooks(parsed) : withThreadnoteHooks(parsed);
@@ -87,7 +86,7 @@ function runClaudeHooksInstall(options: {readonly apply: boolean; readonly remov
       return;
     }
 
-    yield* fs.makeDirectory(dirname(path), {recursive: true});
+    yield* fs.makeDirectory(pathService.dirname(path), {recursive: true});
     const serialized = `${JSON.stringify(next, undefined, 2)}\n`;
     yield* fs.writeFileString(path, serialized, {mode: 0o600});
     yield* fs.chmod(path, 0o600);
@@ -170,12 +169,13 @@ function printNoHooksSupported(agent: AgentClient, remove: boolean) {
   );
 }
 
-export async function hasManagedClaudeHooks(): Promise<boolean> {
-  const path = expandPath(CLAUDE_SETTINGS_PATH);
-  if (!(await exists(path))) {
+export const hasManagedClaudeHooks = Effect.fn('hooks.hasManagedClaudeHooks')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* expandPath(CLAUDE_SETTINGS_PATH);
+  if (!(yield* exists(path))) {
     return false;
   }
-  const raw = await readFile(path, 'utf8');
+  const raw = yield* fs.readFileString(path);
   const parsed = parseJsonConfigObject(raw);
   if (!parsed || !isJsonObject(parsed.hooks)) {
     return false;
@@ -189,14 +189,14 @@ export async function hasManagedClaudeHooks(): Promise<boolean> {
     }
   }
   return false;
-}
+});
 
 export function runPreCompactHook(config: RuntimeConfig, options: HookRunnerOptions = {}) {
   // Hooks must never block compaction. Anything that throws here gets swallowed
   // and the process still exits 0 — the worst-case is a missed snapshot.
   return Effect.gen(function* () {
-    const project = (yield* fromPromiseError(() => resolveRepoName())) ?? 'general';
-    const {sessionId, trace} = yield* fromPromiseError(() => captureTraceContext());
+    const project = (yield* resolveRepoName()) ?? 'general';
+    const {sessionId, trace} = yield* captureTraceContext();
     yield* runHandoff(config, {
       blockers: '- none recorded',
       dryRun: options.dryRun === true,
@@ -212,11 +212,9 @@ export function runPreCompactHook(config: RuntimeConfig, options: HookRunnerOpti
     });
   }).pipe(
     Effect.catch(error =>
-      Effect.sync(() => {
-        process.stderr.write(
-          `threadnote pre-compact-hook: snapshot skipped (${error instanceof Error ? error.message : String(error)})\n`,
-        );
-      }),
+      Console.error(
+        `threadnote pre-compact-hook: snapshot skipped (${error instanceof Error ? error.message : String(error)})`,
+      ),
     ),
   );
 }
@@ -225,12 +223,12 @@ export function runSessionStartHook(config: RuntimeConfig, options: HookRunnerOp
   // Hooks must never block session start. Failures fall through quietly so the
   // user just gets a normal session without injected context.
   return Effect.gen(function* () {
-    const project = yield* fromPromiseError(() => resolveRepoName());
+    const project = yield* resolveRepoName();
     if (!project) {
       return;
     }
     yield* emitUpdateBannerIfOutdated(config);
-    yield* Effect.sync(() => process.stdout.write(`## Threadnote — latest context for ${project}\n\n`));
+    yield* Console.log(`## Threadnote — latest context for ${project}\n`);
     yield* runRecall(config, {
       dryRun: options.dryRun === true,
       inferScope: true,
@@ -240,11 +238,9 @@ export function runSessionStartHook(config: RuntimeConfig, options: HookRunnerOp
     });
   }).pipe(
     Effect.catch(error =>
-      Effect.sync(() => {
-        process.stderr.write(
-          `threadnote session-start-hook: recall skipped (${error instanceof Error ? error.message : String(error)})\n`,
-        );
-      }),
+      Console.error(
+        `threadnote session-start-hook: recall skipped (${error instanceof Error ? error.message : String(error)})`,
+      ),
     ),
   );
 }
@@ -254,11 +250,6 @@ interface TraceContext {
   readonly trace?: string;
 }
 
-interface HookPayload {
-  readonly sessionId?: string;
-  readonly transcriptPath?: string;
-}
-
 /**
  * Reads Claude's PreCompact stdin payload and distills the referenced
  * transcript into a short, scrubbed trace. Entirely best-effort: any failure
@@ -266,18 +257,16 @@ interface HookPayload {
  * empty context so the pre-compact snapshot still writes its state-only
  * handoff. Never throws.
  */
-async function captureTraceContext(): Promise<TraceContext> {
-  try {
-    const payload = await readHookPayload();
+const captureTraceContext = Effect.fn('hooks.captureTraceContext')(() =>
+  Effect.gen(function* () {
+    const payload = yield* readHookPayload();
     if (!payload) {
       return {};
     }
-    const rawTrace = payload.transcriptPath ? await distillTrace(payload.transcriptPath) : undefined;
+    const rawTrace = payload.transcriptPath ? yield* distillTrace(payload.transcriptPath) : undefined;
     return {sessionId: payload.sessionId, trace: rawTrace ? scrubTrace(rawTrace) : undefined};
-  } catch {
-    return {};
-  }
-}
+  }).pipe(Effect.catch(() => Effect.succeed({} as TraceContext))),
+);
 
 /** Redacts soft leaks; drops the trace on a hard credential blocker. */
 function scrubTrace(trace: string): string | undefined {
@@ -285,20 +274,20 @@ function scrubTrace(trace: string): string | undefined {
   return result.blocker ? undefined : result.cleaned;
 }
 
-async function readHookPayload(): Promise<HookPayload | undefined> {
-  if (process.stdin.isTTY) {
+const readHookPayload = Effect.fn('hooks.readPayload')(function* () {
+  const system = yield* SystemInfo;
+  if (system.stdinIsTTY) {
     return undefined;
   }
-  const raw = await readStdinWithTimeout(1500, 512 * 1024);
+  const raw = yield* readStdinWithTimeout(1500, 512 * 1024);
   if (!raw.trim()) {
     return undefined;
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
+  const parsedResult = Result.try((): unknown => JSON.parse(raw));
+  if (Result.isFailure(parsedResult)) {
     return undefined;
   }
+  const parsed = parsedResult.success;
   if (!isJsonObject(parsed)) {
     return undefined;
   }
@@ -306,40 +295,20 @@ async function readHookPayload(): Promise<HookPayload | undefined> {
     sessionId: typeof parsed.session_id === 'string' ? parsed.session_id : undefined,
     transcriptPath: typeof parsed.transcript_path === 'string' ? parsed.transcript_path : undefined,
   };
-}
+});
 
-function readStdinWithTimeout(timeoutMs: number, maxBytes: number): Promise<string> {
-  return new Promise(resolve => {
-    const stdin = process.stdin;
-    let data = '';
-    let settled = false;
-    const finish = (): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      stdin.off('data', onData);
-      stdin.off('end', finish);
-      stdin.off('error', finish);
-      clearTimeout(timer);
-      stdin.pause();
-      resolve(data);
-    };
-    const onData = (chunk: string): void => {
-      data += chunk;
-      if (data.length >= maxBytes) {
-        data = data.slice(0, maxBytes);
-        finish();
-      }
-    };
-    const timer = setTimeout(finish, timeoutMs);
-    stdin.setEncoding('utf8');
-    stdin.on('data', onData);
-    stdin.on('end', finish);
-    stdin.on('error', finish);
-    stdin.resume();
-  });
-}
+const readStdinWithTimeout = Effect.fn('hooks.readStdin')(function* (timeoutMs: number, maxBytes: number) {
+  const stdio = yield* Stdio.Stdio;
+  return yield* stdio.stdin.pipe(
+    Stream.decodeText,
+    Stream.runFold(
+      () => '',
+      (output, chunk) => `${output}${chunk}`.slice(0, maxBytes),
+    ),
+    Effect.timeoutOrElse({duration: timeoutMs, orElse: () => Effect.succeed('')}),
+    Effect.catch(() => Effect.succeed('')),
+  );
+});
 
 function emitUpdateBannerIfOutdated(config: RuntimeConfig) {
   // Cheap, daily-cached check that nags users to upgrade. Failures are folded
@@ -348,26 +317,24 @@ function emitUpdateBannerIfOutdated(config: RuntimeConfig) {
   // spawns `threadnote update --yes` as a detached background process and
   // tells the user the new version will be active next session.
   return Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
     const result = yield* checkForThreadnoteUpdate({
-      cachePath: join(config.agentContextHome, '.update-state.json'),
-      currentVersion: getThreadnoteVersion(),
+      cachePath: path.join(config.agentContextHome, '.update-state.json'),
+      currentVersion: yield* getThreadnoteVersion(),
     });
     if (!result || !result.outdated) {
       return;
     }
-    if (process.env.THREADNOTE_AUTO_UPDATE === '1') {
-      yield* Effect.sync(() => {
-        process.stdout.write(
-          `[threadnote] v${result.latestVersion} available (current v${result.currentVersion}). Auto-updating in the background; the new version takes effect next session.\n\n`,
-        );
-        spawnDetachedAutoUpdate();
-      });
+    if (system.environment().THREADNOTE_AUTO_UPDATE === '1') {
+      yield* Console.log(
+        `[threadnote] v${result.latestVersion} available (current v${result.currentVersion}). Auto-updating in the background; the new version takes effect next session.\n`,
+      );
+      yield* spawnDetachedAutoUpdate();
       return;
     }
-    yield* Effect.sync(() =>
-      process.stdout.write(
-        `[threadnote] v${result.latestVersion} available (current v${result.currentVersion}). Run: threadnote update\n\n`,
-      ),
+    yield* Console.log(
+      `[threadnote] v${result.latestVersion} available (current v${result.currentVersion}). Run: threadnote update\n`,
     );
   }).pipe(Effect.catch(() => Effect.void));
 }

--- a/src/index_repair.ts
+++ b/src/index_repair.ts
@@ -1,5 +1,4 @@
-import {readFile, readdir, writeFile} from 'node:fs/promises';
-import {dirname, join, relative} from 'node:path';
+import {Effect, FileSystem, Path, Result} from 'effect';
 import {inferProjectFromQuery, readSeedManifest, uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
 import type {CommandResult} from './types.js';
@@ -74,7 +73,7 @@ export type RecallIndexRepairProgress =
       readonly type: 'repair-dry-run';
     };
 
-export async function repairStaleRecallIndex(
+export const repairStaleRecallIndex = Effect.fn('indexRepair.repair')(function* (
   config: RecallIndexRepairConfig,
   ov: string,
   options: {
@@ -86,13 +85,13 @@ export async function repairStaleRecallIndex(
     readonly includeAgentSkills?: boolean;
     readonly includeManifestResources?: boolean;
     readonly maxTargets?: number;
-    readonly onRepairFailure?: (target: StaleIndexTarget, result: CommandResult) => Promise<void> | void;
+    readonly onRepairFailure?: (target: StaleIndexTarget, result: CommandResult) => Effect.Effect<void, unknown> | void;
     readonly onProgress?: (progress: RecallIndexRepairProgress) => void;
     readonly query?: string;
   } = {},
-): Promise<RecallIndexRepairResult> {
+) {
   options.onProgress?.({type: 'scan-start'});
-  const targets = await findStaleRecallIndexTargets(config, options);
+  const targets = yield* findStaleRecallIndexTargets(config, options);
   const repairTargets = targets.slice(0, options.maxTargets ?? MAX_REPAIR_TARGETS);
   const consecutiveFailureLimit = options.consecutiveFailureLimit;
   options.onProgress?.({
@@ -104,7 +103,10 @@ export async function repairStaleRecallIndex(
     return {repairedUris: [], skippedRecentUris: [], warnings: []};
   }
 
-  const state = options.dryRun === true ? {entries: {}, version: 1 as const} : await readAutoRepairState(config);
+  let state: AutoRepairState = {entries: {}, version: 1};
+  if (options.dryRun !== true) {
+    state = yield* readAutoRepairState(config);
+  }
   const now = Date.now();
   const repairedUris: string[] = [];
   const skippedRecentUris: string[] = [];
@@ -132,14 +134,14 @@ export async function repairStaleRecallIndex(
     }
 
     options.onProgress?.({...progressBase, type: 'repair-start'});
-    const result = await runCommand(
+    const result = yield* runCommand(
       ov,
       withIdentity(config, ['reindex', target.uri, '--mode', 'semantic_and_vectors', '--wait', 'true']),
       // Bound the wait: `ov reindex` has no --timeout, so a stuck/poisoned
       // semantic queue would block each target for the full 10-min command
       // timeout. A timed-out target counts as a failure and trips the
       // consecutive-failure stop instead of hanging the whole repair.
-      {allowFailure: true, timeoutMs: reindexWaitTimeoutMs()},
+      {allowFailure: true, timeoutMs: yield* reindexWaitTimeoutMs()},
     );
     if (result.exitCode === 0) {
       consecutiveFailures = 0;
@@ -148,7 +150,15 @@ export async function repairStaleRecallIndex(
     } else {
       consecutiveFailures += 1;
       warnings.push(indexRepairWarning(target.uri, result));
-      await options.onRepairFailure?.(target, result);
+      if (options.onRepairFailure) {
+        const failureHook = yield* Effect.try({
+          try: () => options.onRepairFailure?.(target, result),
+          catch: cause => cause,
+        });
+        if (Effect.isEffect(failureHook)) {
+          yield* failureHook;
+        }
+      }
       const remaining = repairTargets.length - (targetIndex + 1);
       if (consecutiveFailureLimit !== undefined && consecutiveFailures >= consecutiveFailureLimit && remaining > 0) {
         warnings.push(
@@ -161,13 +171,13 @@ export async function repairStaleRecallIndex(
   }
 
   if (options.dryRun !== true && repairedUris.length > 0) {
-    await writeAutoRepairState(config, state);
+    yield* writeAutoRepairState(config, state);
   }
 
   return {repairedUris, skippedRecentUris, warnings};
-}
+});
 
-export async function findStaleRecallIndexTargets(
+export const findStaleRecallIndexTargets = Effect.fn('indexRepair.findTargets')(function* (
   config: RecallIndexRepairConfig,
   options: {
     readonly collapseToRoots?: boolean;
@@ -176,17 +186,17 @@ export async function findStaleRecallIndexTargets(
     readonly includeManifestResources?: boolean;
     readonly query?: string;
   } = {},
-): Promise<readonly StaleIndexTarget[]> {
-  if (await summaryAutoGenerationDisabled(config)) {
+) {
+  if (yield* summaryAutoGenerationDisabled(config)) {
     return [];
   }
-  const roots = await scanRoots(config, options);
+  const roots = yield* scanRoots(config, options);
   const byUri = new Map<string, {parts: string[]; staleCount: number; uri: string}>();
   for (const root of roots) {
-    if (!(await exists(root.path))) {
+    if (!(yield* exists(root.path))) {
       continue;
     }
-    const sidecars = await staleSidecars(root.path, root.uri);
+    const sidecars = yield* staleSidecars(root.path, root.uri);
     if (options.collapseToRoots === true) {
       for (const sidecar of sidecars) {
         const uri = collapseStaleSidecarUri(root.uri, sidecar.relativePath, options.collapseDepth);
@@ -204,12 +214,12 @@ export async function findStaleRecallIndexTargets(
       byUri.set(sidecar.uri, current);
     }
   }
-  return [...byUri.values()].map(target => ({
-    signature: sha256([target.uri, ...target.parts.sort()].join('\n---\n')),
-    staleCount: target.staleCount,
-    uri: target.uri,
-  }));
-}
+  return yield* Effect.forEach([...byUri.values()], target =>
+    sha256([target.uri, ...target.parts.sort()].join('\n---\n')).pipe(
+      Effect.map(signature => ({signature, staleCount: target.staleCount, uri: target.uri})),
+    ),
+  );
+});
 
 function collapseStaleSidecarUri(rootUri: string, relativePath: string, depth = 0): string {
   const normalizedRootUri = trimLocalRootUri(rootUri);
@@ -258,7 +268,7 @@ function isStaleRecallSummaryRow(line: string): boolean {
   return /viking:\/\/\S+\/\.(?:abstract|overview)\.md\b/.test(line) && isStaleSummary(line);
 }
 
-async function scanRoots(
+const scanRoots = Effect.fn('indexRepair.scanRoots')(function* (
   config: RecallIndexRepairConfig,
   options: {
     readonly collapseToRoots?: boolean;
@@ -266,20 +276,21 @@ async function scanRoots(
     readonly includeManifestResources?: boolean;
     readonly query?: string;
   },
-): Promise<readonly {readonly path: string; readonly uri: string}[]> {
-  const accountRoot = join(config.agentContextHome, 'data', 'viking', config.account);
+) {
+  const path = yield* Path.Path;
+  const accountRoot = path.join(config.agentContextHome, 'data', 'viking', config.account);
   const roots: Array<{path: string; uri: string}> = [
     {
-      path: join(accountRoot, 'user', uriSegment(config.user), 'memories'),
+      path: path.join(accountRoot, 'user', uriSegment(config.user), 'memories'),
       uri: `viking://user/${uriSegment(config.user)}/memories`,
     },
   ];
 
   const query = options.query;
   if (query) {
-    const project = await inferProjectFromQuery(config.manifestPath, query);
+    const project = yield* inferProjectFromQuery(config.manifestPath, query);
     const projectPath = project?.uri.startsWith('viking://resources/')
-      ? join(accountRoot, 'resources', ...project.uri.slice('viking://resources/'.length).split('/'))
+      ? path.join(accountRoot, 'resources', ...project.uri.slice('viking://resources/'.length).split('/'))
       : undefined;
     if (project && projectPath) {
       roots.push({path: projectPath, uri: project.uri});
@@ -287,34 +298,34 @@ async function scanRoots(
   }
 
   if (options.includeManifestResources === true) {
-    roots.push(...(await manifestResourceRoots(config, accountRoot)));
+    roots.push(...(yield* manifestResourceRoots(config, accountRoot)));
   }
 
   const scanAgentSkills =
     options.includeAgentSkills === true || (query ? /\bskills?\b/.test(query.toLowerCase()) : false);
   if (scanAgentSkills) {
-    roots.push({path: join(accountRoot, 'resources', 'agent-skills'), uri: 'viking://resources/agent-skills'});
+    roots.push({path: path.join(accountRoot, 'resources', 'agent-skills'), uri: 'viking://resources/agent-skills'});
   }
 
   return dedupeRoots(roots);
-}
+});
 
-async function manifestResourceRoots(
+const manifestResourceRoots = Effect.fn('indexRepair.manifestRoots')(function* (
   config: RecallIndexRepairConfig,
   accountRoot: string,
-): Promise<readonly {readonly path: string; readonly uri: string}[]> {
-  try {
-    const manifest = await readSeedManifest(config.manifestPath);
-    return manifest.projects
-      .filter(project => project.uri.startsWith('viking://resources/'))
-      .map(project => ({
-        path: join(accountRoot, 'resources', ...project.uri.slice('viking://resources/'.length).split('/')),
-        uri: project.uri,
-      }));
-  } catch (_err: unknown) {
+) {
+  const path = yield* Path.Path;
+  const manifest = yield* readSeedManifest(config.manifestPath).pipe(Effect.option);
+  if (manifest._tag === 'None') {
     return [];
   }
-}
+  return manifest.value.projects
+    .filter(project => project.uri.startsWith('viking://resources/'))
+    .map(project => ({
+      path: path.join(accountRoot, 'resources', ...project.uri.slice('viking://resources/'.length).split('/')),
+      uri: project.uri,
+    }));
+});
 
 function dedupeRoots(
   roots: readonly {readonly path: string; readonly uri: string}[],
@@ -337,46 +348,45 @@ interface StaleSidecar {
   readonly uri: string;
 }
 
-async function staleSidecars(rootPath: string, rootUri: string): Promise<readonly StaleSidecar[]> {
+const staleSidecars = Effect.fn('indexRepair.staleSidecars')(function* (rootPath: string, rootUri: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
   const results: StaleSidecar[] = [];
 
-  async function visit(path: string, depth: number): Promise<void> {
-    let entries;
-    try {
-      entries = await readdir(path, {withFileTypes: true});
-    } catch (_err: unknown) {
-      return;
-    }
-
-    for (const entry of entries) {
-      const childPath = join(path, entry.name);
-      if (entry.isFile() && isSummarySidecar(entry.name)) {
-        let content;
-        try {
-          content = await readFile(childPath, 'utf8');
-        } catch (_err: unknown) {
+  const visit = (path: string, depth: number): Effect.Effect<void, never> =>
+    Effect.gen(function* () {
+      const entries = yield* fs.readDirectory(path).pipe(Effect.catch(() => Effect.succeed([])));
+      for (const entry of entries) {
+        const childPath = pathService.join(path, entry);
+        const info = yield* fs.stat(childPath).pipe(Effect.option);
+        if (info._tag === 'None') {
           continue;
         }
-        if (!isStaleSummary(content)) {
-          continue;
+        if (info.value.type === 'File' && isSummarySidecar(entry)) {
+          const content = yield* fs.readFileString(childPath).pipe(Effect.option);
+          if (content._tag === 'None') {
+            continue;
+          }
+          if (!isStaleSummary(content.value)) {
+            continue;
+          }
+          const parentPath = pathService.dirname(childPath);
+          const parentRelative = toPosixPath(pathService.relative(rootPath, parentPath));
+          const relativePath = toPosixPath(pathService.relative(rootPath, childPath));
+          results.push({
+            content: content.value.trim(),
+            relativePath,
+            uri: parentRelative ? `${trimLocalRootUri(rootUri)}/${parentRelative}` : trimLocalRootUri(rootUri),
+          });
+        } else if (info.value.type === 'Directory' && depth < MAX_SCAN_DEPTH) {
+          yield* visit(childPath, depth + 1);
         }
-        const parentPath = dirname(childPath);
-        const parentRelative = toPosixPath(relative(rootPath, parentPath));
-        const relativePath = toPosixPath(relative(rootPath, childPath));
-        results.push({
-          content: content.trim(),
-          relativePath,
-          uri: parentRelative ? `${trimLocalRootUri(rootUri)}/${parentRelative}` : trimLocalRootUri(rootUri),
-        });
-      } else if (entry.isDirectory() && depth < MAX_SCAN_DEPTH) {
-        await visit(childPath, depth + 1);
       }
-    }
-  }
+    });
 
-  await visit(rootPath, 0);
+  yield* visit(rootPath, 0);
   return results;
-}
+});
 
 function isSummarySidecar(name: string): boolean {
   return name === '.abstract.md' || name === '.overview.md';
@@ -393,18 +403,21 @@ function isSummarySidecar(name: string): boolean {
  * the semantic + vector index, not these summaries, so skipping the scan is
  * safe. Unknown/unparseable config is treated as enabled to preserve behavior.
  */
-export async function summaryAutoGenerationDisabled(config: RecallIndexRepairConfig): Promise<boolean> {
-  const raw = await readFileIfExists(join(config.agentContextHome, 'ov.conf'));
+export const summaryAutoGenerationDisabled = Effect.fn('indexRepair.summaryAutoGenerationDisabled')(function* (
+  config: RecallIndexRepairConfig,
+) {
+  const path = yield* Path.Path;
+  const raw = yield* readFileIfExists(path.join(config.agentContextHome, 'ov.conf'));
   if (!raw) {
     return false;
   }
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return isJsonObject(parsed) && parsed.auto_generate_l0 === false && parsed.auto_generate_l1 === false;
-  } catch (_err: unknown) {
+  const parsedResult = Result.try((): unknown => JSON.parse(raw));
+  if (Result.isFailure(parsedResult)) {
     return false;
   }
-}
+  const parsed = parsedResult.success;
+  return isJsonObject(parsed) && parsed.auto_generate_l0 === false && parsed.auto_generate_l1 === false;
+});
 
 function isStaleSummary(content: string): boolean {
   return content.includes('[Directory overview is not ready]') || content.includes('[Directory abstract is not ready]');
@@ -414,37 +427,43 @@ function trimLocalRootUri(uri: string): string {
   return uri.endsWith('/') ? uri.slice(0, -1) : uri;
 }
 
-async function readAutoRepairState(config: RecallIndexRepairConfig): Promise<AutoRepairState> {
-  const raw = await readFileIfExists(autoRepairStatePath(config));
+const readAutoRepairState = Effect.fn('indexRepair.readState')(function* (config: RecallIndexRepairConfig) {
+  const raw = yield* readFileIfExists(yield* autoRepairStatePath(config));
   if (!raw) {
-    return {entries: {}, version: 1};
+    return {entries: {}, version: 1 as const};
   }
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!isJsonObject(parsed) || parsed.version !== 1 || !isJsonObject(parsed.entries)) {
-      return {entries: {}, version: 1};
-    }
-    const entries: Record<string, AutoRepairStateEntry> = {};
-    for (const [uri, entry] of Object.entries(parsed.entries)) {
-      if (isJsonObject(entry) && typeof entry.signature === 'string' && typeof entry.repairedAt === 'string') {
-        entries[uri] = {repairedAt: entry.repairedAt, signature: entry.signature};
-      }
-    }
-    return {entries, version: 1};
-  } catch (_err: unknown) {
-    return {entries: {}, version: 1};
+  const parsedResult = Result.try((): unknown => JSON.parse(raw));
+  if (Result.isFailure(parsedResult)) {
+    return {entries: {}, version: 1 as const};
   }
-}
+  const parsed = parsedResult.success;
+  if (!isJsonObject(parsed) || parsed.version !== 1 || !isJsonObject(parsed.entries)) {
+    return {entries: {}, version: 1 as const};
+  }
+  const entries: Record<string, AutoRepairStateEntry> = {};
+  for (const [uri, entry] of Object.entries(parsed.entries)) {
+    if (isJsonObject(entry) && typeof entry.signature === 'string' && typeof entry.repairedAt === 'string') {
+      entries[uri] = {repairedAt: entry.repairedAt, signature: entry.signature};
+    }
+  }
+  return {entries, version: 1 as const};
+});
 
-async function writeAutoRepairState(config: RecallIndexRepairConfig, state: AutoRepairState): Promise<void> {
-  const path = autoRepairStatePath(config);
-  await ensureDirectory(dirname(path), false);
-  await writeFile(path, `${JSON.stringify(state, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
-}
+const writeAutoRepairState = Effect.fn('indexRepair.writeState')(function* (
+  config: RecallIndexRepairConfig,
+  state: AutoRepairState,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const path = yield* autoRepairStatePath(config);
+  yield* ensureDirectory(pathService.dirname(path), false);
+  yield* fs.writeFileString(path, `${JSON.stringify(state, undefined, 2)}\n`, {mode: 0o600});
+});
 
-function autoRepairStatePath(config: RecallIndexRepairConfig): string {
-  return join(config.agentContextHome, AUTO_REPAIR_STATE_FILE);
-}
+const autoRepairStatePath = Effect.fn('indexRepair.statePath')(function* (config: RecallIndexRepairConfig) {
+  const path = yield* Path.Path;
+  return path.join(config.agentContextHome, AUTO_REPAIR_STATE_FILE);
+});
 
 function indexRepairWarning(uri: string, result: CommandResult): string {
   return `${uri}: ${result.stderr.trim() || result.stdout.trim() || 'reindex failed'}`;

--- a/src/launchd.ts
+++ b/src/launchd.ts
@@ -1,9 +1,8 @@
-import {homedir} from 'node:os';
-import {join} from 'node:path';
-import {Clock, Effect} from 'effect';
+import {Clock, Effect, Path} from 'effect';
 import {LAUNCHD_LABEL} from './constants.js';
 import {maybeRunEffect, runCommandEffect} from './effect/command.js';
 import {applicationError} from './effect/errors.js';
+import {SystemInfo} from './effect/system.js';
 
 export interface LaunchAgentStatus {
   readonly loaded: boolean;
@@ -11,9 +10,11 @@ export interface LaunchAgentStatus {
   readonly running: boolean;
 }
 
-export function launchAgentPath(): string {
-  return join(homedir(), 'Library', 'LaunchAgents', `${LAUNCHD_LABEL}.plist`);
-}
+export const launchAgentPath = Effect.fn('launchd.launchAgentPath')(function* () {
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
+  return pathService.join(system.homeDirectory, 'Library', 'LaunchAgents', `${LAUNCHD_LABEL}.plist`);
+});
 
 export function launchAgentDomainTarget(uid: number): string {
   return `gui/${uid}`;
@@ -102,16 +103,10 @@ const resolveUserId = Effect.fn('resolveLaunchdUserId')(function* (uid?: number)
   if (uid !== undefined) {
     return uid;
   }
-  return yield* Effect.try({
-    try: () => {
-      const current = process.getuid?.();
-      if (current === undefined) {
-        throw new Error('Cannot resolve the current user id for launchd.');
-      }
-      return current;
-    },
-    catch: cause => applicationError('resolve current user id for launchd', cause),
-  });
+  const system = yield* SystemInfo;
+  return system.userId === undefined
+    ? yield* Effect.fail(applicationError('resolve current user id for launchd', new Error('User id is unavailable.')))
+    : system.userId;
 });
 
 const deadlineFromTimeout = Effect.fn('launchdDeadlineFromTimeout')(function* (timeoutMs?: number) {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -385,7 +385,8 @@ export const runInstall = Effect.fn('runInstall')(function* (config: RuntimeConf
     destinationPath: yield* pathJoin(config.agentContextHome, 'ovcli.conf'),
     dryRun,
     shouldRepair: content =>
-      shouldRepairLegacyOvCliConfig(content) || (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
+      shouldRepairOpenVikingCliConfig(content, config) ||
+      (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
     templatePath: yield* pathJoin(root, 'config', 'ovcli.conf.template.json'),
   });
   yield* configureOpenVikingCliLanguage(config, dryRun);
@@ -888,6 +889,9 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
   if (options.dryRun === true) {
     yield* Console.log(formatShellCommand(server, args));
     return;
+  }
+  if (!system.environment().OPENVIKING_CLI_CONFIG_FILE) {
+    yield* ensureOpenVikingCliRuntimeConfig(config);
   }
 
   const existingHealth = yield* readOpenVikingHealthIfAvailable(config, 500);
@@ -2666,6 +2670,19 @@ const writeTemplateIfMissing = Effect.fn('lifecycle.writeTemplateIfMissing')(fun
   yield* Console.log(`Wrote ${options.destinationPath}`);
 });
 
+const ensureOpenVikingCliRuntimeConfig = Effect.fn('lifecycle.ensureOpenVikingCliRuntimeConfig')(function* (
+  config: RuntimeConfig,
+) {
+  const root = yield* toolRoot();
+  yield* writeTemplateIfMissing({
+    config,
+    destinationPath: yield* pathJoin(config.agentContextHome, 'ovcli.conf'),
+    dryRun: false,
+    shouldRepair: content => shouldRepairOpenVikingCliConfig(content, config),
+    templatePath: yield* pathJoin(root, 'config', 'ovcli.conf.template.json'),
+  });
+});
+
 const installCommandShim = Effect.fn('lifecycle.installCommandShim')(function* (dryRun: boolean) {
   const system = yield* SystemInfo;
   if (!shouldManageCommandShim(system.platform)) {
@@ -3337,12 +3354,27 @@ const isGeneratedLocalPilotConfig = Effect.fn('lifecycle.isGeneratedLocalPilotCo
   );
 });
 
-function shouldRepairLegacyOvCliConfig(content: string): boolean {
+export function shouldRepairOpenVikingCliConfig(content: string, config: RuntimeConfig): boolean {
   const parsed = parseJsonConfigObject(content);
   if (!parsed) {
     return false;
   }
-  return typeof parsed.server_url === 'string' && isJsonObject(parsed.identity);
+  if (typeof parsed.server_url === 'string' && isJsonObject(parsed.identity)) {
+    return true;
+  }
+  const allowedKeys = new Set(['account', 'agent_id', 'timeout', 'url', 'user']);
+  if (
+    Object.keys(parsed).some(key => !allowedKeys.has(key)) ||
+    parsed.account !== config.account ||
+    parsed.agent_id !== config.agentId ||
+    parsed.timeout !== 60 ||
+    parsed.user !== config.user ||
+    typeof parsed.url !== 'string' ||
+    !/^http:\/\/(?:127(?:\.\d{1,3}){3}|localhost|\[::1\]):\d+\/?$/i.test(parsed.url)
+  ) {
+    return false;
+  }
+  return parsed.url.replace(/\/$/, '') !== `http://${config.host}:${config.port}`;
 }
 
 export function parsePackageManager(value: string): PackageManager {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,11 +1,10 @@
 import {spawn} from 'node:child_process';
 import {closeSync, openSync} from 'node:fs';
 import {chmod, readdir, readFile, realpath, writeFile} from 'node:fs/promises';
-import {platform} from 'node:os';
 import {basename, delimiter, dirname, join, sep} from 'node:path';
-import {stderr as processStderr, stdin as processStdin, stdout as processStdout} from 'node:process';
+import {stdin as processStdin, stdout as processStdout} from 'node:process';
 import {createInterface} from 'node:readline/promises';
-import {Cause, Clock, Console, Effect, Exit, FileSystem, Option} from 'effect';
+import {Cause, Clock, Console, Effect, Exit, FileSystem, Option, Path} from 'effect';
 import yaml from 'js-yaml';
 import {
   LAUNCHD_LABEL,
@@ -23,10 +22,17 @@ import {
   USER_INSTRUCTIONS_START_MARKER,
 } from './constants.js';
 import {hasManagedClaudeHooks, runHooksInstall} from './hooks.js';
-import {CommandExecutor, maybeRunEffect, runCommandEffect} from './effect/command.js';
+import {
+  CommandExecutor,
+  maybeRunEffect,
+  runCommandEffect,
+  runStreamingCommandEffect,
+  windowsTaskkillExecutable,
+} from './effect/command.js';
 import {consoleOutput, syncWithConsole} from './effect/console.js';
 import {applicationError, fromPromise} from './effect/errors.js';
 import {getTextEffect, HttpService} from './effect/http.js';
+import {SystemInfo} from './effect/system.js';
 import {startProgress} from './cli_ui.js';
 import {
   findStaleRecallIndexTargets,
@@ -75,6 +81,7 @@ import {
   compareVersions,
   ensureDirectory,
   errorMessage,
+  executableNames,
   exists,
   expandPath,
   findExecutable,
@@ -93,6 +100,7 @@ import {
   memoryFrontmatterField,
   memoryUriProjectSegment,
   parseJsonConfigObject,
+  pythonUserScriptsCandidateDirs,
   readFileIfExists,
   removePath,
   removePathIfExists,
@@ -108,6 +116,24 @@ import {
 const INSTALL_OUTPUT_TAIL_CHARS = 64_000;
 const MINIMUM_UV_SYSTEM_CERTS_VERSION = '0.11.0';
 const STOP_SERVER_TIMEOUT_MS = 10_000;
+
+interface DetachedProcessRecord {
+  readonly args?: readonly string[];
+  readonly commandLine?: string;
+  readonly executablePath?: string;
+  readonly launcherPid?: number;
+  readonly pid: number;
+  readonly server?: string;
+  readonly startedAt?: string;
+}
+
+export function pythonExecutableCandidates(currentPlatform: NodeJS.Platform = process.platform): readonly string[] {
+  return currentPlatform === 'win32' ? ['py', 'python', 'python3'] : ['python3', 'python'];
+}
+
+export function shouldManageCommandShim(currentPlatform: NodeJS.Platform = process.platform): boolean {
+  return currentPlatform !== 'win32';
+}
 
 interface UvExecutable {
   readonly executable: string;
@@ -149,7 +175,10 @@ export interface LaunchAgentHealthEffects<R = never> {
 type UserAgentInstructionTarget = (typeof USER_AGENT_INSTRUCTION_TARGETS)[number];
 
 export const runDoctor = Effect.fn('runDoctor')(function* (config: RuntimeConfig, options: DoctorOptions) {
-  const checks = yield* fromPromise('collect doctor checks', () => collectDoctorChecks(config, options));
+  const system = yield* SystemInfo;
+  const checks = yield* fromPromise('collect doctor checks', () =>
+    collectDoctorChecks(config, options, system.platform),
+  );
 
   yield* syncWithConsole(() => {
     for (const check of checks) {
@@ -165,19 +194,27 @@ export const runDoctor = Effect.fn('runDoctor')(function* (config: RuntimeConfig
   });
 });
 
-export async function collectDoctorChecks(config: RuntimeConfig, options: DoctorOptions = {}): Promise<DoctorCheck[]> {
+export async function collectDoctorChecks(
+  config: RuntimeConfig,
+  options: DoctorOptions = {},
+  currentPlatform: NodeJS.Platform = process.platform,
+): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
   checks.push({name: 'mode', status: 'ok', detail: options.dryRun ? 'dry run; no writes' : 'read-only checks'});
-  checks.push({name: 'platform', status: platform() === 'darwin' ? 'ok' : 'warn', detail: platform()});
+  checks.push({
+    name: 'platform',
+    status: ['darwin', 'linux', 'win32'].includes(currentPlatform) ? 'ok' : 'warn',
+    detail: currentPlatform,
+  });
   checks.push(await commandCheck('node', ['--version']));
-  checks.push(await commandCheck('python3', ['--version']));
+  checks.push(await firstCommandCheck('python', pythonExecutableCandidates(currentPlatform), ['--version']));
   checks.push(await openVikingServerCheck());
   checks.push(await openVikingCliCheck());
   checks.push(await openVikingVersionCheck(config));
   checks.push(await recallShapeCheck(config));
   checks.push(await localEmbeddingCheck());
   checks.push(await pythonSystemCertificatesCheck());
-  checks.push(await firstCommandCheck('python installer', ['pipx', 'uv', 'pip3'], ['--version']));
+  checks.push(await pythonInstallerCheck());
   checks.push(await commandPresenceCheck('codex', ['--version']));
   checks.push(await commandPresenceCheck('claude', ['--version']));
   checks.push(await commandShimCheck());
@@ -228,9 +265,7 @@ export const runInstall = Effect.fn('runInstall')(function* (config: RuntimeConf
       yield* syncWithConsole(() =>
         consoleOutput.log(`Reinstalling OpenViking at pinned version ${config.openVikingVersion} (--force).`),
       );
-      yield* fromPromise('reinstall OpenViking', () =>
-        runInstallCommands(config, options.packageManager, true, dryRun),
-      );
+      yield* runInstallCommands(config, options.packageManager, true, dryRun);
       serverInstallRan = true;
     } else if (localEmbeddingMissing) {
       const repairReasons: string[] = [];
@@ -239,9 +274,7 @@ export const runInstall = Effect.fn('runInstall')(function* (config: RuntimeConf
         repairReasons.push('Python system certificate bridge is missing');
       }
       yield* syncWithConsole(() => consoleOutput.log(`OpenViking install needs repair: ${repairReasons.join('; ')}.`));
-      yield* fromPromise('repair OpenViking installation', () =>
-        runInstallCommands(config, options.packageManager, true, dryRun),
-      );
+      yield* runInstallCommands(config, options.packageManager, true, dryRun);
       serverInstallRan = true;
     } else if (pythonSystemCertificatesMissing) {
       yield* syncWithConsole(() =>
@@ -253,7 +286,7 @@ export const runInstall = Effect.fn('runInstall')(function* (config: RuntimeConf
       yield* maybeRunEffect(dryRun, installCommand.executable, installCommand.args);
     }
   } else {
-    yield* fromPromise('install OpenViking', () => runInstallCommands(config, options.packageManager, false, dryRun));
+    yield* runInstallCommands(config, options.packageManager, false, dryRun);
     serverInstallRan = true;
   }
   const resolvedServerPath = serverInstallRan
@@ -543,14 +576,27 @@ async function configureOpenVikingCliLanguage(config: RuntimeConfig, dryRun: boo
  * may create the binary mid-process and the second resolution must see it.
  */
 export async function findOpenVikingServer(): Promise<string | undefined> {
-  const onPath = await findExecutable([OPENVIKING_SERVER_COMMAND]);
-  if (onPath) {
-    return onPath;
+  if (process.platform !== 'win32') {
+    const onPath = await findExecutable([OPENVIKING_SERVER_COMMAND]);
+    if (onPath) {
+      return onPath;
+    }
+  } else {
+    for (const directory of (process.env.PATH ?? '').split(delimiter).filter(Boolean)) {
+      for (const name of openVikingServerExecutableNames()) {
+        const candidate = join(directory, name);
+        if (await isExecutable(candidate)) {
+          return candidate;
+        }
+      }
+    }
   }
   for (const candidateDir of await openVikingServerCandidateDirs()) {
-    const candidate = join(candidateDir, OPENVIKING_SERVER_COMMAND);
-    if (await isExecutable(candidate)) {
-      return candidate;
+    for (const name of openVikingServerExecutableNames()) {
+      const candidate = join(candidateDir, name);
+      if (await isExecutable(candidate)) {
+        return candidate;
+      }
     }
   }
   return undefined;
@@ -558,17 +604,20 @@ export async function findOpenVikingServer(): Promise<string | undefined> {
 
 const findOpenVikingServerEffectCore = Effect.fn('findOpenVikingServer')(function* (timeoutMs: number) {
   const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
   const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
-  const pathDirectories = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  const pathDirectories = (process.env.PATH ?? '').split(system.platform === 'win32' ? ';' : ':').filter(Boolean);
   for (const directory of pathDirectories) {
-    const candidate = join(directory, OPENVIKING_SERVER_COMMAND);
-    if (yield* isExecutableFileEffect(fs, candidate)) {
-      return candidate;
+    for (const name of openVikingServerExecutableNames(system.platform)) {
+      const candidate = join(directory, name);
+      if (yield* isExecutableFileEffect(fs, candidate, system.platform)) {
+        return candidate;
+      }
     }
   }
 
   const candidateDirectories: string[] = [];
-  const uv = yield* findExecutableInDirectoriesEffect(fs, 'uv', pathDirectories);
+  const uv = yield* findExecutableInDirectoriesEffect(fs, 'uv', pathDirectories, system.platform);
   if (uv) {
     const result = yield* runCommandEffect(uv, ['tool', 'dir', '--bin'], {
       allowFailure: true,
@@ -581,15 +630,26 @@ const findOpenVikingServerEffectCore = Effect.fn('findOpenVikingServer')(functio
   if (process.env.UV_TOOL_BIN_DIR) {
     candidateDirectories.push(process.env.UV_TOOL_BIN_DIR);
   }
+  candidateDirectories.push(...(yield* pythonUserScriptsCandidateDirsEffect()));
   candidateDirectories.push(expandPath('~/.local/bin'));
   for (const directory of new Set(candidateDirectories)) {
-    const candidate = join(directory, OPENVIKING_SERVER_COMMAND);
-    if (yield* isExecutableFileEffect(fs, candidate)) {
-      return candidate;
+    for (const name of openVikingServerExecutableNames(system.platform)) {
+      const candidate = join(directory, name);
+      if (yield* isExecutableFileEffect(fs, candidate, system.platform)) {
+        return candidate;
+      }
     }
   }
   return undefined;
 });
+
+export function openVikingServerExecutableNames(
+  currentPlatform: NodeJS.Platform = process.platform,
+  pathExt = process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD',
+): readonly string[] {
+  const names = executableNames(OPENVIKING_SERVER_COMMAND, currentPlatform, pathExt);
+  return currentPlatform === 'win32' ? names.filter(name => /\.(?:com|exe)$/i.test(name)) : names;
+}
 
 export function findOpenVikingServerEffect(timeoutMs: number) {
   return findOpenVikingServerEffectCore(timeoutMs).pipe(
@@ -604,24 +664,65 @@ const findExecutableInDirectoriesEffect = Effect.fn('findExecutableInDirectories
   fs: FileSystem.FileSystem,
   name: string,
   directories: readonly string[],
+  currentPlatform: NodeJS.Platform,
 ) {
   for (const directory of directories) {
-    const candidate = join(directory, name);
-    if (yield* isExecutableFileEffect(fs, candidate)) {
-      return candidate;
+    for (const executableName of executableNames(name, currentPlatform)) {
+      const candidate = join(directory, executableName);
+      if (yield* isExecutableFileEffect(fs, candidate, currentPlatform)) {
+        return candidate;
+      }
     }
   }
   return undefined;
 });
 
-const isExecutableFileEffect = Effect.fn('isExecutableFile')(function* (fs: FileSystem.FileSystem, path: string) {
+const isExecutableFileEffect = Effect.fn('isExecutableFile')(function* (
+  fs: FileSystem.FileSystem,
+  path: string,
+  currentPlatform: NodeJS.Platform,
+) {
   const info = yield* fs.stat(path).pipe(
     Effect.catchIf(
       error => error.reason._tag === 'NotFound',
       () => Effect.succeed(undefined),
     ),
   );
-  return info?.type === 'File' && (info.mode & 0o111) !== 0;
+  return info?.type === 'File' && (currentPlatform === 'win32' || (info.mode & 0o111) !== 0);
+});
+
+const findExecutableEffect = Effect.fn('findExecutable')(function* (commands: readonly string[]) {
+  const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
+  const directories = (process.env.PATH ?? '').split(system.platform === 'win32' ? ';' : ':').filter(Boolean);
+  for (const command of commands) {
+    const executable = yield* findExecutableInDirectoriesEffect(fs, command, directories, system.platform);
+    if (executable) {
+      return executable;
+    }
+  }
+  return undefined;
+});
+
+const pythonUserScriptsCandidateDirsEffect = Effect.fn('pythonUserScriptsCandidateDirs')(function* () {
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const directories: string[] = [];
+  for (const command of pythonExecutableCandidates(system.platform)) {
+    const executable = yield* findExecutableEffect([command]);
+    if (!executable) {
+      continue;
+    }
+    const result = yield* runCommandEffect(executable, ['-c', 'import site; print(site.getuserbase())'], {
+      allowFailure: true,
+      timeoutMs: 5000,
+    });
+    const userBase = result.exitCode === 0 ? result.stdout.trim() : '';
+    if (userBase) {
+      directories.push(path.join(userBase, system.platform === 'win32' ? 'Scripts' : 'bin'));
+    }
+  }
+  return Array.from(new Set(directories));
 });
 
 let candidateDirsPromise: Promise<readonly string[]> | undefined;
@@ -648,6 +749,7 @@ async function computeOpenVikingServerCandidateDirs(): Promise<readonly string[]
   if (process.env.UV_TOOL_BIN_DIR) {
     dirs.push(process.env.UV_TOOL_BIN_DIR);
   }
+  dirs.push(...(await pythonUserScriptsCandidateDirs()));
   dirs.push(expandPath('~/.local/bin'));
   return Array.from(new Set(dirs));
 }
@@ -669,7 +771,14 @@ async function maybePrintOpenVikingPathHint(serverPath: string): Promise<void> {
     return;
   }
   const binDir = dirname(serverPath);
-  const rcHint = suggestedShellRc(process.env.SHELL, platform());
+  if (process.platform === 'win32') {
+    consoleOutput.log(
+      `Note: ${serverPath} is installed but ${binDir} is not on this PowerShell PATH. ` +
+        `Run \`$env:Path = "${binDir};$env:Path"\` for this shell.`,
+    );
+    return;
+  }
+  const rcHint = suggestedShellRc(process.env.SHELL, process.platform);
   consoleOutput.log(
     `Note: ${serverPath} is installed but ${binDir} is not on this shell's PATH. ` +
       `Add \`export PATH="${binDir}:$PATH"\` to ${rcHint} so other tools can find openviking-server.`,
@@ -707,6 +816,7 @@ function repairServerHealth(config: RuntimeConfig, dryRun: boolean) {
 
 export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, options: StartOptions) {
   const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
   if (options.launchd === true) {
     yield* installLaunchAgent(config, options.dryRun === true);
     return;
@@ -758,19 +868,52 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
     },
     catch: cause => applicationError('start detached OpenViking server', cause),
   });
-  yield* fs.writeFileString(join(config.agentContextHome, 'openviking-server.pid'), `${child.pid}\n`);
+  if (child.pid === undefined) {
+    return yield* Effect.fail(new Error('Detached OpenViking server did not report a pid.'));
+  }
+  const childPid = child.pid;
+  yield* fs.writeFileString(
+    join(config.agentContextHome, 'openviking-server.pid'),
+    detachedProcessRecordContent(childPid, server, args, system.platform),
+  );
   const health = yield* fromPromise('wait for OpenViking health', () =>
     waitForOpenVikingHealth(config, START_HEALTH_TIMEOUT_MS, `Waiting for OpenViking health at ${healthUrl}.`),
   );
   if (health) {
+    let managedPid = childPid;
+    if (system.platform === 'win32') {
+      const servingProcess = yield* findWindowsServingProcess(childPid, config, server, args);
+      if (!servingProcess) {
+        const termination = yield* terminateWindowsProcessTree(childPid);
+        if (!termination.stopped) {
+          return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
+        }
+        yield* fs.remove(join(config.agentContextHome, 'openviking-server.pid'), {force: true});
+        return yield* Effect.fail(
+          new Error('OpenViking became healthy, but Threadnote could not verify its Windows serving process.'),
+        );
+      }
+      managedPid = servingProcess.pid;
+      yield* fs.writeFileString(
+        join(config.agentContextHome, 'openviking-server.pid'),
+        windowsDetachedProcessRecordContent(childPid, server, args, servingProcess),
+      );
+    }
     yield* syncWithConsole(() =>
-      consoleOutput.log(`Started OpenViking with pid ${child.pid}. Health OK at ${healthUrl}. Logs: ${logPath}`),
+      consoleOutput.log(`Started OpenViking with pid ${managedPid}. Health OK at ${healthUrl}. Logs: ${logPath}`),
     );
     return;
   }
+  if (system.platform === 'win32') {
+    const termination = yield* terminateWindowsProcessTree(childPid);
+    if (!termination.stopped) {
+      return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
+    }
+    yield* fs.remove(join(config.agentContextHome, 'openviking-server.pid'), {force: true});
+  }
   return yield* Effect.fail(
     new Error(
-      `Started OpenViking with pid ${child.pid}, but ${healthUrl} did not become healthy within ` +
+      `Started OpenViking with pid ${childPid}, but ${healthUrl} did not become healthy within ` +
         `${START_HEALTH_TIMEOUT_MS / 1000}s. Logs: ${logPath}`,
     ),
   );
@@ -788,6 +931,7 @@ function spawnDetachedServer(server: string, args: readonly string[], logFd: num
   return spawn(server, args, {
     detached: true,
     stdio: ['ignore', logFd, logFd],
+    windowsHide: true,
   });
 }
 
@@ -797,6 +941,7 @@ const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServ
   timeoutMs: number,
 ) {
   const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
   const logPath = openVikingLogPath(config);
   yield* fs.makeDirectory(dirname(logPath), {recursive: true});
   const child = yield* Effect.try({
@@ -811,16 +956,46 @@ const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServ
   if (child.pid === undefined) {
     return yield* Effect.fail(new Error('Restored detached OpenViking server did not report a pid.'));
   }
-  yield* fs.writeFileString(join(config.agentContextHome, 'openviking-server.pid'), `${child.pid}\n`);
+  const childPid = child.pid;
+  yield* fs.writeFileString(
+    join(config.agentContextHome, 'openviking-server.pid'),
+    detachedProcessRecordContent(childPid, server, openVikingServerArgs(config), system.platform),
+  );
   const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
   while ((yield* Clock.currentTimeMillis) < deadline) {
     const remainingMs = deadline - (yield* Clock.currentTimeMillis);
     if (yield* readOpenVikingHealthEffect(config, Math.max(1, Math.min(500, remainingMs)))) {
+      if (system.platform === 'win32') {
+        const args = openVikingServerArgs(config);
+        const servingProcess = yield* findWindowsServingProcess(childPid, config, server, args);
+        if (!servingProcess) {
+          const termination = yield* terminateWindowsProcessTree(childPid);
+          if (!termination.stopped) {
+            return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
+          }
+          yield* fs.remove(join(config.agentContextHome, 'openviking-server.pid'), {force: true});
+          return yield* Effect.fail(
+            new Error('Restored OpenViking became healthy, but its Windows serving process could not be verified.'),
+          );
+        }
+        yield* fs.writeFileString(
+          join(config.agentContextHome, 'openviking-server.pid'),
+          windowsDetachedProcessRecordContent(childPid, server, args, servingProcess),
+        );
+      }
       return;
     }
     yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
   }
-  yield* signalProcessEffect(child.pid, 'SIGTERM').pipe(Effect.ignore);
+  if (system.platform === 'win32') {
+    const termination = yield* terminateWindowsProcessTree(childPid);
+    if (!termination.stopped) {
+      return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
+    }
+    yield* fs.remove(join(config.agentContextHome, 'openviking-server.pid'), {force: true});
+  } else {
+    yield* signalProcessEffect(childPid, 'SIGTERM').pipe(Effect.ignore);
+  }
   return yield* Effect.fail(
     new Error(`Restored detached OpenViking server did not become healthy within ${timeoutMs}ms.`),
   );
@@ -828,7 +1003,8 @@ const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServ
 
 export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, options: ForgetOptions) {
   const fs = yield* FileSystem.FileSystem;
-  if (platform() === 'darwin') {
+  const system = yield* SystemInfo;
+  if (system.platform === 'darwin') {
     yield* bootoutLaunchAgent(options.dryRun === true, undefined, STOP_SERVER_TIMEOUT_MS);
   }
 
@@ -843,23 +1019,304 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
     yield* syncWithConsole(() => consoleOutput.log('No pid file found for detached OpenViking server.'));
     return;
   }
-  const pid = Number(pidText.trim());
+  const processRecord = parseDetachedProcessRecord(pidText);
+  const pid = processRecord?.pid ?? Number.NaN;
   if (!Number.isInteger(pid) || pid <= 0) {
     yield* syncWithConsole(() => consoleOutput.log(`Invalid pid file: ${pidPath}`));
+    if (options.dryRun !== true) {
+      yield* fs.remove(pidPath, {force: true});
+    }
     return;
   }
   if (options.dryRun === true) {
     yield* syncWithConsole(() => consoleOutput.log(`Would stop process ${pid}`));
     return;
   }
-  yield* syncWithConsole(() => {
-    try {
-      process.kill(pid, 'SIGTERM');
-      consoleOutput.log(`Stopped process ${pid}`);
-    } catch (err: unknown) {
-      consoleOutput.log(`Could not stop process ${pid}: ${errorMessage(err)}`);
+  if (!(yield* isProcessRunningEffect(pid))) {
+    yield* fs.remove(pidPath, {force: true});
+    yield* syncWithConsole(() => consoleOutput.log(`Removed stale pid file for process ${pid}.`));
+    return;
+  }
+  if (system.platform === 'win32') {
+    const server =
+      processRecord?.server ??
+      (yield* fromPromise('find OpenViking server for process verification', findOpenVikingServer));
+    if (!server) {
+      return yield* Effect.fail(
+        new Error(`Refusing to stop process ${pid}: OpenViking server path is unavailable for verification.`),
+      );
     }
+    const expected = {
+      args: processRecord?.args ?? openVikingServerArgs(config),
+      commandLine: processRecord?.commandLine,
+      executablePath: processRecord?.executablePath,
+      launcherPid: processRecord?.launcherPid,
+      server,
+      startedAt: processRecord?.startedAt,
+    };
+    if (!(yield* isManagedWindowsOpenVikingProcess(pid, config, expected))) {
+      return yield* Effect.fail(
+        new Error(`Refusing to stop process ${pid}: the pid file does not identify this Threadnote OpenViking server.`),
+      );
+    }
+    if (!(yield* isManagedWindowsOpenVikingProcess(pid, config, expected))) {
+      return yield* Effect.fail(new Error(`Refusing to stop process ${pid}: its identity changed before signaling.`));
+    }
+  }
+  let signaled: boolean;
+  if (system.platform === 'win32') {
+    const termination = yield* terminateWindowsProcessTree(pid);
+    if (!termination.stopped) {
+      return yield* Effect.fail(windowsTerminationError(pid, termination.result));
+    }
+    signaled = true;
+  } else {
+    signaled = yield* signalProcessEffect(pid, 'SIGTERM');
+  }
+  if (!signaled) {
+    yield* fs.remove(pidPath, {force: true});
+    yield* syncWithConsole(() => consoleOutput.log(`Process ${pid} was already stopped.`));
+    return;
+  }
+  const deadline = (yield* Clock.currentTimeMillis) + STOP_SERVER_TIMEOUT_MS;
+  while (yield* isProcessRunningEffect(pid)) {
+    const remainingMs = deadline - (yield* Clock.currentTimeMillis);
+    if (remainingMs <= 0) {
+      return yield* Effect.fail(new Error(`Process ${pid} did not stop within ${STOP_SERVER_TIMEOUT_MS / 1000}s.`));
+    }
+    yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
+  }
+  yield* fs.remove(pidPath, {force: true});
+  yield* syncWithConsole(() => consoleOutput.log(`Stopped process ${pid}`));
+});
+
+function detachedProcessRecordContent(
+  pid: number,
+  server: string,
+  args: readonly string[],
+  currentPlatform: NodeJS.Platform,
+): string {
+  if (currentPlatform !== 'win32') {
+    return `${pid}\n`;
+  }
+  return `${JSON.stringify({args, pid, server, startedAt: new Date().toISOString()})}\n`;
+}
+
+interface WindowsProcessIdentity {
+  readonly commandLine: string;
+  readonly executablePath: string;
+  readonly pid: number;
+  readonly startedAt: string;
+}
+
+function windowsDetachedProcessRecordContent(
+  launcherPid: number,
+  server: string,
+  args: readonly string[],
+  servingProcess: WindowsProcessIdentity,
+): string {
+  return `${JSON.stringify({
+    args,
+    commandLine: servingProcess.commandLine,
+    executablePath: servingProcess.executablePath,
+    launcherPid,
+    pid: servingProcess.pid,
+    server,
+    startedAt: servingProcess.startedAt,
+  })}\n`;
+}
+
+function parseDetachedProcessRecord(content: string): DetachedProcessRecord | undefined {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const value: unknown = JSON.parse(trimmed);
+    if (typeof value === 'number') {
+      return {pid: value};
+    }
+    if (!isJsonObject(value) || typeof value.pid !== 'number') {
+      return undefined;
+    }
+    const args =
+      Array.isArray(value.args) && value.args.every(arg => typeof arg === 'string')
+        ? (value.args as readonly string[])
+        : undefined;
+    return {
+      args,
+      commandLine: typeof value.commandLine === 'string' ? value.commandLine : undefined,
+      executablePath: typeof value.executablePath === 'string' ? value.executablePath : undefined,
+      launcherPid: typeof value.launcherPid === 'number' ? value.launcherPid : undefined,
+      pid: value.pid,
+      server: typeof value.server === 'string' ? value.server : undefined,
+      startedAt: typeof value.startedAt === 'string' ? value.startedAt : undefined,
+    };
+  } catch {
+    const pid = Number(trimmed);
+    return Number.isInteger(pid) ? {pid} : undefined;
+  }
+}
+
+const findWindowsServingProcess = Effect.fn('findWindowsServingProcess')(function* (
+  launcherPid: number,
+  config: RuntimeConfig,
+  server: string,
+  args: readonly string[],
+) {
+  const powershell = yield* findExecutableEffect(['powershell.exe', 'pwsh.exe', 'powershell', 'pwsh']);
+  if (!powershell) {
+    return undefined;
+  }
+  const script = `
+$processes = @(Get-CimInstance Win32_Process)
+$owners = @(Get-NetTCPConnection -LocalPort ${config.port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess)
+$match = $null
+foreach ($owner in $owners) {
+  $candidate = $processes | Where-Object { $_.ProcessId -eq $owner } | Select-Object -First 1
+  $cursor = [uint32]$owner
+  while ($null -ne $candidate -and $cursor -gt 0) {
+    if ($cursor -eq ${launcherPid}) {
+      $match = $processes | Where-Object { $_.ProcessId -eq $owner } | Select-Object -First 1
+      break
+    }
+    $cursor = [uint32]$candidate.ParentProcessId
+    $candidate = $processes | Where-Object { $_.ProcessId -eq $cursor } | Select-Object -First 1
+  }
+  if ($null -ne $match) { break }
+}
+if ($null -eq $match) { exit 4 }
+[pscustomobject]@{
+  CommandLine = $match.CommandLine
+  CreationTime = $match.CreationDate.ToUniversalTime().ToString('o')
+  ExecutablePath = $match.ExecutablePath
+  ProcessId = $match.ProcessId
+} | ConvertTo-Json -Compress
+`.trim();
+  const result = yield* runCommandEffect(powershell, ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
+    allowFailure: true,
+    timeoutMs: 5000,
   });
+  if (result.exitCode !== 0) {
+    return undefined;
+  }
+  const identity = parseWindowsProcessIdentity(result.stdout);
+  if (!identity || !matchesExpectedWindowsProcess(identity, server, args)) {
+    return undefined;
+  }
+  return identity;
+});
+
+function parseWindowsProcessIdentity(output: string): WindowsProcessIdentity | undefined {
+  try {
+    const value: unknown = JSON.parse(output);
+    if (
+      !isJsonObject(value) ||
+      typeof value.CommandLine !== 'string' ||
+      typeof value.CreationTime !== 'string' ||
+      typeof value.ExecutablePath !== 'string' ||
+      typeof value.ProcessId !== 'number'
+    ) {
+      return undefined;
+    }
+    return {
+      commandLine: value.CommandLine,
+      executablePath: value.ExecutablePath,
+      pid: value.ProcessId,
+      startedAt: value.CreationTime,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function matchesExpectedWindowsProcess(
+  identity: Pick<WindowsProcessIdentity, 'commandLine' | 'executablePath'>,
+  server: string,
+  args: readonly string[],
+): boolean {
+  const commandLine = identity.commandLine.toLowerCase();
+  const expectedServer = basename(server).toLowerCase();
+  if (!commandLine.includes(expectedServer) && basename(identity.executablePath).toLowerCase() !== expectedServer) {
+    return false;
+  }
+  return args.every(arg => commandLine.includes(arg.toLowerCase()));
+}
+
+const terminateWindowsProcessTree = Effect.fn('terminateWindowsProcessTree')(function* (pid: number) {
+  const result = yield* runCommandEffect(windowsTaskkillExecutable(), ['/pid', String(pid), '/t', '/f'], {
+    allowFailure: true,
+    timeoutMs: 5000,
+  });
+  return {result, stopped: !(yield* isProcessRunningEffect(pid))};
+});
+
+function windowsTerminationError(pid: number, result: CommandResult): Error {
+  const detail = firstLine(result.stderr) || firstLine(result.stdout) || `taskkill exited with ${result.exitCode}`;
+  return new Error(`Could not terminate Windows process tree ${pid}; preserving its pid record: ${detail}`);
+}
+
+const isManagedWindowsOpenVikingProcess = Effect.fn('isManagedWindowsOpenVikingProcess')(function* (
+  pid: number,
+  config: RuntimeConfig,
+  expected: {
+    readonly args: readonly string[];
+    readonly commandLine?: string;
+    readonly executablePath?: string;
+    readonly launcherPid?: number;
+    readonly server: string;
+    readonly startedAt?: string;
+  },
+) {
+  const powershell = yield* findExecutableEffect(['powershell.exe', 'pwsh.exe', 'powershell', 'pwsh']);
+  if (!powershell) {
+    return false;
+  }
+  const script = [
+    `$process = Get-CimInstance Win32_Process -Filter 'ProcessId = ${pid}'`,
+    'if ($null -eq $process) { exit 3 }',
+    `$owners = @(Get-NetTCPConnection -LocalPort ${config.port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess)`,
+    `[pscustomobject]@{CommandLine=$process.CommandLine;CreationTime=$process.CreationDate.ToUniversalTime().ToString('o');ExecutablePath=$process.ExecutablePath;OwnsPort=($owners -contains ${pid})} | ConvertTo-Json -Compress`,
+  ].join('; ');
+  const result = yield* runCommandEffect(powershell, ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
+    allowFailure: true,
+    timeoutMs: 5000,
+  });
+  if (result.exitCode !== 0) {
+    return false;
+  }
+  let identity: JsonObject;
+  try {
+    const value: unknown = JSON.parse(result.stdout);
+    if (!isJsonObject(value)) {
+      return false;
+    }
+    identity = value;
+  } catch {
+    return false;
+  }
+  if (identity.OwnsPort !== true || typeof identity.CommandLine !== 'string') {
+    return false;
+  }
+  const commandLine = identity.CommandLine;
+  const executablePath = typeof identity.ExecutablePath === 'string' ? identity.ExecutablePath : '';
+  if (expected.commandLine && commandLine.toLowerCase() !== expected.commandLine.toLowerCase()) {
+    return false;
+  }
+  if (expected.executablePath && executablePath.toLowerCase() !== expected.executablePath.toLowerCase()) {
+    return false;
+  }
+  if (!matchesExpectedWindowsProcess({commandLine, executablePath}, expected.server, expected.args)) {
+    return false;
+  }
+  if (expected.startedAt) {
+    const recordedAt = Date.parse(expected.startedAt);
+    const createdAt = typeof identity.CreationTime === 'string' ? Date.parse(identity.CreationTime) : Number.NaN;
+    if (!Number.isFinite(recordedAt) || !Number.isFinite(createdAt) || Math.abs(recordedAt - createdAt) > 30_000) {
+      return false;
+    }
+  }
+  return true;
 });
 
 const stopDetachedOpenVikingServerForLaunchdCore = Effect.fn('stopDetachedOpenVikingServerForLaunchd')(function* (
@@ -1115,6 +1572,45 @@ async function firstCommandCheck(
   return {name, status: 'fail', detail: `none found: ${commands.join(', ')}`};
 }
 
+async function pythonInstallerCheck(): Promise<DoctorCheck> {
+  const failures: string[] = [];
+  for (const manager of ['uv', 'pipx']) {
+    const executable = await findExecutable([manager]);
+    if (!executable) {
+      continue;
+    }
+    const result = await runCommand(executable, ['--version'], {allowFailure: true});
+    if (result.exitCode === 0) {
+      return {
+        name: 'python installer',
+        status: 'ok',
+        detail: `${manager}: ${firstLine(result.stdout || result.stderr) || executable}`,
+      };
+    }
+    failures.push(`${manager}: ${firstLine(result.stderr || result.stdout) || 'not working'}`);
+  }
+  for (const python of pythonExecutableCandidates()) {
+    const executable = await findExecutable([python]);
+    if (!executable) {
+      continue;
+    }
+    const result = await runCommand(executable, ['-m', 'pip', '--version'], {allowFailure: true});
+    if (result.exitCode === 0) {
+      return {
+        name: 'python installer',
+        status: 'ok',
+        detail: `${python} -m pip: ${firstLine(result.stdout || result.stderr) || executable}`,
+      };
+    }
+    failures.push(`${python} -m pip: ${firstLine(result.stderr || result.stdout) || 'not working'}`);
+  }
+  return {
+    name: 'python installer',
+    status: 'fail',
+    detail: failures.length > 0 ? failures.join('; ') : 'none found: uv, pipx, or Python with pip',
+  };
+}
+
 async function openVikingCliCheck(): Promise<DoctorCheck> {
   const executable = await findOpenVikingCli();
   if (!executable) {
@@ -1241,6 +1737,16 @@ async function pythonSystemCertificatesCheck(): Promise<DoctorCheck> {
 }
 
 async function commandShimCheck(): Promise<DoctorCheck> {
+  if (!shouldManageCommandShim()) {
+    const launcher = await findExecutable(['threadnote']);
+    return launcher
+      ? {name: 'threadnote launcher', status: 'ok', detail: launcher}
+      : {
+          name: 'threadnote launcher',
+          status: 'warn',
+          detail: 'npm threadnote.cmd launcher is not on PATH; repair preserves package-manager launchers',
+        };
+  }
   const shimPath = join(expandPath(process.env.THREADNOTE_BIN_DIR ?? '~/.local/bin'), 'threadnote');
   const content = await readFileIfExists(shimPath);
   if (content === undefined) {
@@ -1319,8 +1825,14 @@ async function siblingPythonForExecutable(executablePath: string): Promise<strin
   } catch (_err: unknown) {
     return undefined;
   }
-  const pythonPath = join(dirname(resolvedPath), 'python');
-  return (await exists(pythonPath)) ? pythonPath : undefined;
+  const names = process.platform === 'win32' ? ['python.exe', 'python'] : ['python'];
+  for (const name of names) {
+    const pythonPath = join(dirname(resolvedPath), name);
+    if (await exists(pythonPath)) {
+      return pythonPath;
+    }
+  }
+  return undefined;
 }
 
 async function manifestCheck(path: string): Promise<DoctorCheck> {
@@ -1482,33 +1994,37 @@ async function waitForOpenVikingHealth(
   }
 }
 
-async function runInstallCommands(
+const runInstallCommands = Effect.fn('runInstallCommands')(function* (
   config: RuntimeConfig,
   preferred: PackageManager | undefined,
   force: boolean,
   dryRun: boolean,
-): Promise<void> {
+) {
   // When the user didn't ask for a specific manager and detection fell back
   // to plain `pip`, offer to install `uv` first — `pip install --user` is
   // refused under PEP 668 on Homebrew / system-managed Python, which is most
   // macOS and modern Linux setups.
   let manager = preferred;
   if (manager === undefined && !dryRun) {
-    const detected = await detectPackageManager();
-    if (detected === 'pip' && (await offerToInstallUv())) {
-      const rediscovered = await detectPackageManager();
+    const detected = yield* fromPromise('detect OpenViking package manager', detectPackageManager);
+    if (detected === 'pip' && (yield* fromPromise('offer to install uv', offerToInstallUv))) {
+      const rediscovered = yield* fromPromise('rediscover OpenViking package manager', detectPackageManager);
       if (rediscovered === 'uv') {
         manager = 'uv';
       }
     }
   }
-  const installCommands = await getInstallCommands(config, manager, force);
+  const installCommands = yield* fromPromise('build OpenViking install commands', () =>
+    getInstallCommands(config, manager, force),
+  );
   for (const installCommand of installCommands) {
     if (dryRun) {
-      await maybeRun(true, installCommand.executable, installCommand.args);
+      yield* maybeRunEffect(true, installCommand.executable, installCommand.args);
       continue;
     }
-    const resolvedInstallCommand = await resolveOpenVikingInstallCommand(installCommand);
+    const resolvedInstallCommand = yield* fromPromise('resolve OpenViking install command', () =>
+      resolveOpenVikingInstallCommand(installCommand),
+    );
     // Stream live instead of buffering through runCommand. openviking[local-embed]
     // can compile llama-cpp-python from source (10-20 min, memory-heavy); buffering
     // hides all progress and the 10-minute command timeout would SIGKILL a
@@ -1516,7 +2032,9 @@ async function runInstallCommands(
     // first, a killed reinstall leaves openviking-server missing — so we also
     // print recovery guidance before failing.
     consoleOutput.log(`Running: ${formatShellCommand(resolvedInstallCommand.executable, resolvedInstallCommand.args)}`);
-    const result = await runInstallCommand(resolvedInstallCommand);
+    const result = yield* runStreamingCommandEffect(resolvedInstallCommand.executable, resolvedInstallCommand.args, {
+      maxOutputChars: INSTALL_OUTPUT_TAIL_CHARS,
+    });
     if (result.exitCode !== 0) {
       const commandOutput = `${result.stderr}\n${result.stdout}`;
       const retry = openVikingSourceBuildRetryForArchiveFailure(resolvedInstallCommand, commandOutput);
@@ -1527,7 +2045,10 @@ async function runInstallCommands(
         );
         consoleOutput.error('This avoids the rejected wheel and can take 10-20 minutes.');
         consoleOutput.log(`Running: ${formatInstallCommand(retry.command, retry.env)}`);
-        const retryResult = await runInstallCommand(retry.command, retry.env);
+        const retryResult = yield* runStreamingCommandEffect(retry.command.executable, retry.command.args, {
+          env: {...process.env, ...retry.env},
+          maxOutputChars: INSTALL_OUTPUT_TAIL_CHARS,
+        });
         if (retryResult.exitCode === 0) {
           continue;
         }
@@ -1543,54 +2064,7 @@ async function runInstallCommands(
       );
     }
   }
-}
-
-async function runInstallCommand(
-  command: MappedCommand,
-  env: Readonly<Record<string, string>> = {},
-): Promise<CommandResult> {
-  return new Promise(resolvePromise => {
-    let stdout = '';
-    let stderr = '';
-    let settled = false;
-    const child = spawn(command.executable, command.args, {
-      env: Object.keys(env).length === 0 ? process.env : {...process.env, ...env},
-      stdio: ['inherit', 'pipe', 'pipe'],
-    });
-
-    child.stdout?.on('data', chunk => {
-      const text = String(chunk);
-      processStdout.write(text);
-      stdout = appendInstallOutputTail(stdout, text);
-    });
-    child.stderr?.on('data', chunk => {
-      const text = String(chunk);
-      processStderr.write(text);
-      stderr = appendInstallOutputTail(stderr, text);
-    });
-    child.on('error', err => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      const message = errorMessage(err);
-      processStderr.write(`${message}\n`);
-      resolvePromise({exitCode: 1, stderr: appendInstallOutputTail(stderr, message), stdout});
-    });
-    child.on('close', code => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolvePromise({exitCode: code ?? 1, stderr, stdout});
-    });
-  });
-}
-
-function appendInstallOutputTail(current: string, chunk: string): string {
-  const next = `${current}${chunk}`;
-  return next.length <= INSTALL_OUTPUT_TAIL_CHARS ? next : next.slice(next.length - INSTALL_OUTPUT_TAIL_CHARS);
-}
+});
 
 function printOpenVikingInstallFailureHelp(failedCommand: MappedCommand, commandOutput: string): void {
   for (const line of openVikingInstallFailureHelpLines(failedCommand, commandOutput)) {
@@ -1704,6 +2178,14 @@ function extraIndexUrl(command: MappedCommand): string | undefined {
 
 async function offerToInstallUv(): Promise<boolean> {
   if (processStdin.isTTY !== true || processStdout.isTTY !== true) {
+    if (process.platform === 'win32') {
+      consoleOutput.warn(
+        'Neither uv nor pipx was found on PATH. Falling back to Python pip. ' +
+          'Install uv with `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"` ' +
+          'and re-run with --package-manager uv for an isolated OpenViking environment.',
+      );
+      return false;
+    }
     consoleOutput.warn(
       'Neither uv nor pipx was found on PATH. Falling back to `python3 -m pip install --user`, which fails on PEP 668 (Homebrew/system) Python.\n' +
         'Re-run with --package-manager uv after installing uv (brew install uv), or pass --package-manager pipx.',
@@ -1733,6 +2215,28 @@ async function offerToInstallUv(): Promise<boolean> {
 }
 
 async function installUv(): Promise<boolean> {
+  if (process.platform === 'win32') {
+    const powershell = await findExecutable(['powershell', 'pwsh']);
+    if (!powershell) {
+      consoleOutput.warn('Could not install uv automatically because PowerShell was not found.');
+      return false;
+    }
+    consoleOutput.log('Installing uv via the official PowerShell installer...');
+    const result = await runCommand(
+      powershell,
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', 'irm https://astral.sh/uv/install.ps1 | iex'],
+      {allowFailure: true},
+    );
+    if (result.exitCode === 0) {
+      process.env.PATH = [join(expandPath('~'), '.local', 'bin'), process.env.PATH ?? ''].join(delimiter);
+      if (await findExecutable(['uv'])) {
+        candidateDirsPromise = undefined;
+        return true;
+      }
+    }
+    consoleOutput.warn('uv installation did not produce an executable on PATH. Open a new PowerShell and retry.');
+    return false;
+  }
   const brew = await findExecutable(['brew']);
   if (brew) {
     consoleOutput.log('Installing uv via Homebrew...');
@@ -1892,7 +2396,7 @@ export function localEmbedWheelIndexUrl(): string | undefined {
     return override.trim() === '' ? undefined : override.trim();
   }
   const base = 'https://abetlen.github.io/llama-cpp-python/whl';
-  return platform() === 'darwin' ? `${base}/metal` : `${base}/cpu`;
+  return process.platform === 'darwin' ? `${base}/metal` : `${base}/cpu`;
 }
 
 /**
@@ -1965,7 +2469,8 @@ export async function getInstallCommands(
   }
   pipArgs.push(PYTHON_SYSTEM_CERTS_PACKAGE);
   pipArgs.push(packageSpec);
-  return [{executable: 'python3', args: pipArgs}];
+  const executable = (await findExecutable(pythonExecutableCandidates())) ?? pythonExecutableCandidates()[0]!;
+  return [{executable, args: pipArgs}];
 }
 
 async function detectPackageManager(): Promise<PackageManager> {
@@ -2034,6 +2539,10 @@ async function writeTemplateIfMissing(options: {
 }
 
 async function installCommandShim(dryRun: boolean): Promise<void> {
+  if (!shouldManageCommandShim()) {
+    consoleOutput.log('Preserving the package-manager threadnote.cmd launcher on Windows.');
+    return;
+  }
   const binDir = expandPath(process.env.THREADNOTE_BIN_DIR ?? '~/.local/bin');
   const shimPath = join(binDir, 'threadnote');
   const existingContent = await readFileIfExists(shimPath);
@@ -2058,6 +2567,10 @@ async function installCommandShim(dryRun: boolean): Promise<void> {
 }
 
 async function removeCommandShim(dryRun: boolean): Promise<void> {
+  if (!shouldManageCommandShim()) {
+    consoleOutput.log('Preserving the package-manager threadnote.cmd launcher on Windows.');
+    return;
+  }
   const shimPath = join(expandPath(process.env.THREADNOTE_BIN_DIR ?? '~/.local/bin'), 'threadnote');
   const content = await readFileIfExists(shimPath);
   if (content === undefined) {
@@ -2234,7 +2747,8 @@ function isManagedCommandShim(content: string): boolean {
 
 const installLaunchAgent = Effect.fn('installLaunchAgent')(function* (config: RuntimeConfig, dryRun: boolean) {
   const fs = yield* FileSystem.FileSystem;
-  if (platform() !== 'darwin') {
+  const system = yield* SystemInfo;
+  if (system.platform !== 'darwin') {
     return yield* Effect.fail(new Error('launchd autostart is only supported on macOS.'));
   }
   // launchd uses a minimal default PATH (/usr/bin:/bin:/usr/sbin:/sbin) and
@@ -2271,24 +2785,20 @@ const installLaunchAgent = Effect.fn('installLaunchAgent')(function* (config: Ru
   yield* fs.makeDirectory(dirname(openVikingLogPath(config)), {recursive: true});
   const healthUrl = openVikingHealthUrl(config);
   const activationTimeoutMs = yield* remainingBudget(installDeadline, START_HEALTH_TIMEOUT_MS);
-  const health = yield* activateLaunchAgent<CommandExecutor | FileSystem.FileSystem | HttpService>(
-    config,
-    destination,
-    rendered,
-    activationTimeoutMs,
-    {
-      bootout: timeoutMs => bootoutLaunchAgent(false, undefined, timeoutMs),
-      bootstrap: (plistPath, timeoutMs) => bootstrapLaunchAgent(plistPath, false, undefined, timeoutMs),
-      isPortOpen: (current, timeoutMs) => isTcpPortOpenEffect(current.host, current.port, Math.min(500, timeoutMs)),
-      stagePlist: (plistPath, content) => stageLaunchAgentPlist(plistPath, content),
-      stopDetached: (current, timeoutMs) =>
-        stopDetachedOpenVikingServerForLaunchd(current, false, timeoutMs, resolvedServer),
-      restartDetached: (current, timeoutMs) => restartDetachedOpenVikingServer(current, resolvedServer!, timeoutMs),
-      waitForHealth: (current, timeoutMs) =>
-        waitForLaunchAgentHealth(current, timeoutMs, `Waiting for OpenViking health at ${healthUrl}.`),
-      waitForShutdown: waitForOpenVikingShutdown,
-    },
-  );
+  const health = yield* activateLaunchAgent<
+    CommandExecutor | FileSystem.FileSystem | HttpService | Path.Path | SystemInfo
+  >(config, destination, rendered, activationTimeoutMs, {
+    bootout: timeoutMs => bootoutLaunchAgent(false, undefined, timeoutMs),
+    bootstrap: (plistPath, timeoutMs) => bootstrapLaunchAgent(plistPath, false, undefined, timeoutMs),
+    isPortOpen: (current, timeoutMs) => isTcpPortOpenEffect(current.host, current.port, Math.min(500, timeoutMs)),
+    stagePlist: (plistPath, content) => stageLaunchAgentPlist(plistPath, content),
+    stopDetached: (current, timeoutMs) =>
+      stopDetachedOpenVikingServerForLaunchd(current, false, timeoutMs, resolvedServer),
+    restartDetached: (current, timeoutMs) => restartDetachedOpenVikingServer(current, resolvedServer!, timeoutMs),
+    waitForHealth: (current, timeoutMs) =>
+      waitForLaunchAgentHealth(current, timeoutMs, `Waiting for OpenViking health at ${healthUrl}.`),
+    waitForShutdown: waitForOpenVikingShutdown,
+  });
   if (health) {
     yield* Console.log(`Installed and started ${LAUNCHD_LABEL}. Health OK at ${healthUrl}`);
     return;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1130,9 +1130,12 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
   }
   let signaled: boolean;
   if (system.platform === 'win32') {
-    const termination = yield* terminateWindowsProcessTree(windowsTerminationPid);
-    if (!termination.stopped) {
-      return yield* Effect.fail(windowsTerminationError(windowsTerminationPid, termination.result));
+    const terminationPids = windowsTerminationPid === pid ? [pid] : [pid, windowsTerminationPid];
+    for (const terminationPid of terminationPids) {
+      const termination = yield* terminateWindowsProcessTree(terminationPid);
+      if (!termination.stopped) {
+        return yield* Effect.fail(windowsTerminationError(terminationPid, termination.result));
+      }
     }
     signaled = true;
   } else {
@@ -1144,7 +1147,12 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
     return;
   }
   const deadline = (yield* Clock.currentTimeMillis) + STOP_SERVER_TIMEOUT_MS;
-  while (yield* isProcessRunningEffect(pid)) {
+  while (
+    (yield* isProcessRunningEffect(pid)) ||
+    (system.platform === 'win32' &&
+      windowsTerminationPid !== pid &&
+      (yield* isProcessRunningEffect(windowsTerminationPid)))
+  ) {
     const remainingMs = deadline - (yield* Clock.currentTimeMillis);
     if (remainingMs <= 0) {
       return yield* Effect.fail(new Error(`Process ${pid} did not stop within ${STOP_SERVER_TIMEOUT_MS / 1000}s.`));

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,10 +1,6 @@
-import {spawn} from 'node:child_process';
-import {closeSync, openSync} from 'node:fs';
-import {chmod, readdir, readFile, realpath, writeFile} from 'node:fs/promises';
-import {basename, delimiter, dirname, join, sep} from 'node:path';
-import {stdin as processStdin, stdout as processStdout} from 'node:process';
-import {createInterface} from 'node:readline/promises';
-import {Cause, Clock, Console, Effect, Exit, FileSystem, Option, Path} from 'effect';
+import {Cause, Clock, Console, Effect, Exit, FileSystem, Option, Path, Result, Sink, Terminal} from 'effect';
+import * as ChildProcess from 'effect/unstable/process/ChildProcess';
+import {ChildProcessSpawner} from 'effect/unstable/process/ChildProcessSpawner';
 import yaml from 'js-yaml';
 import {
   LAUNCHD_LABEL,
@@ -29,8 +25,6 @@ import {
   runStreamingCommandEffect,
   windowsTaskkillExecutable,
 } from './effect/command.js';
-import {consoleOutput, syncWithConsole} from './effect/console.js';
-import {applicationError, fromPromise} from './effect/errors.js';
 import {getTextEffect, HttpService} from './effect/http.js';
 import {SystemInfo} from './effect/system.js';
 import {startProgress} from './cli_ui.js';
@@ -105,10 +99,8 @@ import {
   removePath,
   removePathIfExists,
   runCommand,
-  runInteractive,
   safeTimestamp,
   shellQuote,
-  sleep,
   suggestedShellRc,
   toolRoot,
 } from './utils.js';
@@ -116,6 +108,7 @@ import {
 const INSTALL_OUTPUT_TAIL_CHARS = 64_000;
 const MINIMUM_UV_SYSTEM_CERTS_VERSION = '0.11.0';
 const STOP_SERVER_TIMEOUT_MS = 10_000;
+const parseJson = Option.liftThrowable((content: string): unknown => JSON.parse(content));
 
 interface DetachedProcessRecord {
   readonly args?: readonly string[];
@@ -127,17 +120,12 @@ interface DetachedProcessRecord {
   readonly startedAt?: string;
 }
 
-export function pythonExecutableCandidates(currentPlatform: NodeJS.Platform = process.platform): readonly string[] {
+export function pythonExecutableCandidates(currentPlatform: NodeJS.Platform): readonly string[] {
   return currentPlatform === 'win32' ? ['py', 'python', 'python3'] : ['python3', 'python'];
 }
 
-export function shouldManageCommandShim(currentPlatform: NodeJS.Platform = process.platform): boolean {
+export function shouldManageCommandShim(currentPlatform: NodeJS.Platform): boolean {
   return currentPlatform !== 'win32';
-}
-
-interface UvExecutable {
-  readonly executable: string;
-  readonly version: string | undefined;
 }
 
 interface InstallCommandRetry {
@@ -174,97 +162,136 @@ export interface LaunchAgentHealthEffects<R = never> {
 
 type UserAgentInstructionTarget = (typeof USER_AGENT_INSTRUCTION_TARGETS)[number];
 
-export const runDoctor = Effect.fn('runDoctor')(function* (config: RuntimeConfig, options: DoctorOptions) {
-  const system = yield* SystemInfo;
-  const checks = yield* fromPromise('collect doctor checks', () =>
-    collectDoctorChecks(config, options, system.platform),
-  );
-
-  yield* syncWithConsole(() => {
-    for (const check of checks) {
-      consoleOutput.log(`${formatStatus(check.status)} ${check.name}: ${check.detail}`);
-    }
-
-    const failureCount = checks.filter(check => check.status === 'fail').length;
-    const warningCount = checks.filter(check => check.status === 'warn').length;
-    consoleOutput.log(`\nSummary: ${failureCount} failure(s), ${warningCount} warning(s)`);
-    if (options.strict === true && failureCount > 0) {
-      process.exitCode = 1;
-    }
-  });
+const pathJoin = Effect.fn('lifecycle.pathJoin')(function* (...parts: readonly string[]) {
+  const path = yield* Path.Path;
+  return path.join(...parts);
 });
 
-export async function collectDoctorChecks(
+const pathBasename = Effect.fn('lifecycle.pathBasename')(function* (target: string) {
+  const path = yield* Path.Path;
+  return path.basename(target);
+});
+
+const pathDirname = Effect.fn('lifecycle.pathDirname')(function* (target: string) {
+  const path = yield* Path.Path;
+  return path.dirname(target);
+});
+
+const pathSeparator = Effect.map(Path.Path, path => path.sep);
+
+const chmod = Effect.fn('lifecycle.chmod')(function* (target: string, mode: number) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.chmod(target, mode);
+});
+
+const readdir = Effect.fn('lifecycle.readdir')(function* (target: string, options?: {readonly recursive?: boolean}) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readDirectory(target, options);
+});
+
+const readFile = Effect.fn('lifecycle.readFile')(function* (target: string, encoding: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readFileString(target, encoding);
+});
+
+const realpath = Effect.fn('lifecycle.realpath')(function* (target: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.realPath(target);
+});
+
+const writeFile = Effect.fn('lifecycle.writeFile')(function* (
+  target: string,
+  content: string,
+  options?: {readonly encoding?: string; readonly mode?: number},
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.writeFileString(target, content, {mode: options?.mode});
+});
+
+export const runDoctor = Effect.fn('runDoctor')(function* (config: RuntimeConfig, options: DoctorOptions) {
+  const system = yield* SystemInfo;
+  const checks = yield* collectDoctorChecks(config, options, system.platform);
+  for (const check of checks) {
+    yield* Console.log(`${formatStatus(check.status)} ${check.name}: ${check.detail}`);
+  }
+  const failureCount = checks.filter(check => check.status === 'fail').length;
+  const warningCount = checks.filter(check => check.status === 'warn').length;
+  yield* Console.log(`\nSummary: ${failureCount} failure(s), ${warningCount} warning(s)`);
+  if (options.strict === true && failureCount > 0) {
+    yield* Effect.sync(() => system.setExitCode(1));
+  }
+});
+
+export const collectDoctorChecks = Effect.fn('lifecycle.collectDoctorChecks')(function* (
   config: RuntimeConfig,
   options: DoctorOptions = {},
-  currentPlatform: NodeJS.Platform = process.platform,
-): Promise<DoctorCheck[]> {
+  currentPlatform?: NodeJS.Platform,
+) {
+  const system = yield* SystemInfo;
+  const platform = currentPlatform ?? system.platform;
   const checks: DoctorCheck[] = [];
   checks.push({name: 'mode', status: 'ok', detail: options.dryRun ? 'dry run; no writes' : 'read-only checks'});
   checks.push({
     name: 'platform',
-    status: ['darwin', 'linux', 'win32'].includes(currentPlatform) ? 'ok' : 'warn',
-    detail: currentPlatform,
+    status: ['darwin', 'linux', 'win32'].includes(platform) ? 'ok' : 'warn',
+    detail: platform,
   });
-  checks.push(await commandCheck('node', ['--version']));
-  checks.push(await firstCommandCheck('python', pythonExecutableCandidates(currentPlatform), ['--version']));
-  checks.push(await openVikingServerCheck());
-  checks.push(await openVikingCliCheck());
-  checks.push(await openVikingVersionCheck(config));
-  checks.push(await recallShapeCheck(config));
-  checks.push(await localEmbeddingCheck());
-  checks.push(await pythonSystemCertificatesCheck());
-  checks.push(await pythonInstallerCheck());
-  checks.push(await commandPresenceCheck('codex', ['--version']));
-  checks.push(await commandPresenceCheck('claude', ['--version']));
-  checks.push(await commandShimCheck());
-  checks.push(...(await userAgentInstructionsChecks()));
-  checks.push(await manifestCheck(config.manifestPath));
-  checks.push(await recallIndexFreshnessCheck(config));
-  checks.push(await memoryProjectConsistencyCheck(config));
-  checks.push(await fileCheck(join(toolRoot(), '.threadnoteignore'), 'ignore file'));
-  checks.push(await fileCheck(join(toolRoot(), 'config', 'ov.conf.template.json'), 'server config template'));
-  checks.push(await fileCheck(join(toolRoot(), 'config', 'ovcli.conf.template.json'), 'cli config template'));
-  checks.push(await healthCheck(config));
+  checks.push((yield* commandCheck('node', ['--version'])) as DoctorCheck);
+  checks.push((yield* firstCommandCheck('python', pythonExecutableCandidates(platform), ['--version'])) as DoctorCheck);
+  checks.push((yield* openVikingServerCheck()) as DoctorCheck);
+  checks.push((yield* openVikingCliCheck()) as DoctorCheck);
+  checks.push((yield* openVikingVersionCheck(config)) as DoctorCheck);
+  checks.push((yield* recallShapeCheck(config)) as DoctorCheck);
+  checks.push((yield* localEmbeddingCheck()) as DoctorCheck);
+  checks.push((yield* pythonSystemCertificatesCheck()) as DoctorCheck);
+  checks.push((yield* pythonInstallerCheck()) as DoctorCheck);
+  checks.push((yield* commandPresenceCheck('codex', ['--version'])) as DoctorCheck);
+  checks.push((yield* commandPresenceCheck('claude', ['--version'])) as DoctorCheck);
+  checks.push((yield* commandShimCheck()) as DoctorCheck);
+  checks.push(...((yield* userAgentInstructionsChecks()) as DoctorCheck[]));
+  checks.push((yield* manifestCheck(config.manifestPath)) as DoctorCheck);
+  checks.push((yield* recallIndexFreshnessCheck(config)) as DoctorCheck);
+  checks.push((yield* memoryProjectConsistencyCheck(config)) as DoctorCheck);
+  const root = yield* toolRoot();
+  checks.push((yield* fileCheck(yield* pathJoin(root, '.threadnoteignore'), 'ignore file')) as DoctorCheck);
+  checks.push(
+    (yield* fileCheck(
+      yield* pathJoin(root, 'config', 'ov.conf.template.json'),
+      'server config template',
+    )) as DoctorCheck,
+  );
+  checks.push(
+    (yield* fileCheck(
+      yield* pathJoin(root, 'config', 'ovcli.conf.template.json'),
+      'cli config template',
+    )) as DoctorCheck,
+  );
+  checks.push((yield* healthCheck(config)) as DoctorCheck);
   return checks;
-}
+});
 
 export const runInstall = Effect.fn('runInstall')(function* (config: RuntimeConfig, options: InstallOptions) {
   const repairInvalidConfigs = options.repairInvalidConfigs === true;
   const dryRun = options.dryRun === true;
-  yield* fromPromise('create Threadnote home', () => ensureDirectory(config.agentContextHome, dryRun));
-  yield* fromPromise('create Threadnote logs directory', () =>
-    ensureDirectory(join(config.agentContextHome, 'logs'), dryRun),
-  );
-  yield* fromPromise('create Threadnote redacted directory', () =>
-    ensureDirectory(join(config.agentContextHome, 'redacted'), dryRun),
-  );
-  yield* fromPromise('create Threadnote MCP directory', () =>
-    ensureDirectory(join(config.agentContextHome, 'mcp'), dryRun),
-  );
-  yield* fromPromise('install command shim', () => installCommandShim(dryRun));
-  yield* fromPromise('install user agent instructions', () => installUserAgentInstructions(dryRun));
+  yield* ensureDirectory(config.agentContextHome, dryRun);
+  yield* ensureDirectory(yield* pathJoin(config.agentContextHome, 'logs'), dryRun);
+  yield* ensureDirectory(yield* pathJoin(config.agentContextHome, 'redacted'), dryRun);
+  yield* ensureDirectory(yield* pathJoin(config.agentContextHome, 'mcp'), dryRun);
+  yield* installCommandShim(dryRun);
+  yield* installUserAgentInstructions(dryRun);
 
-  const serverPath = yield* fromPromise('find OpenViking server', findOpenVikingServer);
+  const serverPath = yield* findOpenVikingServer();
   // True only when an install/repair could have moved or created the
   // openviking-server binary itself. The python-certs branch patches the
   // existing Python env in place, so it does not flip this — the server
   // path is unchanged and the earlier resolution is still valid.
   let serverInstallRan = false;
   if (serverPath) {
-    yield* syncWithConsole(() => consoleOutput.log(`OpenViking server already installed: ${serverPath}`));
-    const localEmbeddingMissing =
-      (yield* fromPromise('check OpenViking local embedding dependency', () =>
-        hasLocalEmbeddingDependency(serverPath),
-      )) === false;
-    const pythonSystemCertificatesMissing =
-      (yield* fromPromise('check OpenViking Python certificate bridge', () =>
-        hasPythonSystemCertificatesPatch(serverPath),
-      )) === false;
+    yield* Console.log(`OpenViking server already installed: ${serverPath}`);
+    const localEmbeddingMissing = (yield* hasLocalEmbeddingDependency(serverPath)) === false;
+    const pythonSystemCertificatesMissing = (yield* hasPythonSystemCertificatesPatch(serverPath)) === false;
     if (options.force === true) {
-      yield* syncWithConsole(() =>
-        consoleOutput.log(`Reinstalling OpenViking at pinned version ${config.openVikingVersion} (--force).`),
-      );
+      yield* Console.log(`Reinstalling OpenViking at pinned version ${config.openVikingVersion} (--force).`);
       yield* runInstallCommands(config, options.packageManager, true, dryRun);
       serverInstallRan = true;
     } else if (localEmbeddingMissing) {
@@ -273,25 +300,19 @@ export const runInstall = Effect.fn('runInstall')(function* (config: RuntimeConf
       if (pythonSystemCertificatesMissing) {
         repairReasons.push('Python system certificate bridge is missing');
       }
-      yield* syncWithConsole(() => consoleOutput.log(`OpenViking install needs repair: ${repairReasons.join('; ')}.`));
+      yield* Console.log(`OpenViking install needs repair: ${repairReasons.join('; ')}.`);
       yield* runInstallCommands(config, options.packageManager, true, dryRun);
       serverInstallRan = true;
     } else if (pythonSystemCertificatesMissing) {
-      yield* syncWithConsole(() =>
-        consoleOutput.log('OpenViking install needs repair: Python system certificate bridge is missing.'),
-      );
-      const installCommand = yield* fromPromise('resolve Python certificate bridge install command', () =>
-        getPythonSystemCertificatesInstallCommand(serverPath),
-      );
+      yield* Console.log('OpenViking install needs repair: Python system certificate bridge is missing.');
+      const installCommand = yield* getPythonSystemCertificatesInstallCommand(serverPath);
       yield* maybeRunEffect(dryRun, installCommand.executable, installCommand.args);
     }
   } else {
     yield* runInstallCommands(config, options.packageManager, false, dryRun);
     serverInstallRan = true;
   }
-  const resolvedServerPath = serverInstallRan
-    ? yield* fromPromise('find installed OpenViking server', findOpenVikingServer)
-    : serverPath;
+  const resolvedServerPath = serverInstallRan ? yield* findOpenVikingServer() : serverPath;
   if (serverInstallRan && !resolvedServerPath && !dryRun) {
     // The install command reported success but the binary is unresolvable.
     // Fail loudly for `install`; for `repair` (requireServerBinary === false)
@@ -300,50 +321,48 @@ export const runInstall = Effect.fn('runInstall')(function* (config: RuntimeConf
       `OpenViking install ran but ${OPENVIKING_SERVER_COMMAND} was not found on PATH, in the uv tool bin dir, or ~/.local/bin. ` +
       'Re-run `threadnote install --force` (it streams the full build), then `threadnote doctor`.';
     if (options.requireServerBinary === false) {
-      yield* syncWithConsole(() => consoleOutput.warn(`WARN ${message}`));
+      yield* Console.warn(`WARN ${message}`);
     } else {
       return yield* Effect.fail(new Error(message));
     }
   }
   if (resolvedServerPath && !dryRun) {
-    yield* fromPromise('print OpenViking path hint', () => maybePrintOpenVikingPathHint(resolvedServerPath));
+    yield* maybePrintOpenVikingPathHint(resolvedServerPath);
   }
 
-  yield* fromPromise('write OpenViking server configuration', () =>
-    writeTemplateIfMissing({
-      config,
-      destinationPath: join(config.agentContextHome, 'ov.conf'),
-      dryRun,
-      shouldRepair: content =>
-        shouldRepairOpenVikingConfig(content, config) ||
-        (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
-      templatePath: join(toolRoot(), 'config', 'ov.conf.template.json'),
-    }),
-  );
-  yield* fromPromise('write OpenViking CLI configuration', () =>
-    writeTemplateIfMissing({
-      config,
-      destinationPath: join(config.agentContextHome, 'ovcli.conf'),
-      dryRun,
-      shouldRepair: content =>
-        shouldRepairLegacyOvCliConfig(content) ||
-        (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
-      templatePath: join(toolRoot(), 'config', 'ovcli.conf.template.json'),
-    }),
-  );
-  yield* fromPromise('configure OpenViking CLI language', () => configureOpenVikingCliLanguage(config, dryRun));
+  const root = yield* toolRoot();
+  yield* writeTemplateIfMissing({
+    config,
+    destinationPath: yield* pathJoin(config.agentContextHome, 'ov.conf'),
+    dryRun,
+    shouldRepair: content =>
+      shouldRepairOpenVikingConfig(content, config).pipe(
+        Effect.map(
+          shouldRepair => shouldRepair || (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
+        ),
+      ),
+    templatePath: yield* pathJoin(root, 'config', 'ov.conf.template.json'),
+  });
+  yield* writeTemplateIfMissing({
+    config,
+    destinationPath: yield* pathJoin(config.agentContextHome, 'ovcli.conf'),
+    dryRun,
+    shouldRepair: content =>
+      shouldRepairLegacyOvCliConfig(content) || (repairInvalidConfigs && parseJsonConfigObject(content) === undefined),
+    templatePath: yield* pathJoin(root, 'config', 'ovcli.conf.template.json'),
+  });
+  yield* configureOpenVikingCliLanguage(config, dryRun);
 
   if (options.start !== false) {
     const healthy = yield* repairServerHealth(config, dryRun);
     if (!healthy && !dryRun) {
-      return yield* Effect.fail(
-        new Error(`OpenViking did not become healthy. Check logs: ${openVikingLogPath(config)}`),
-      );
+      const logPath = yield* openVikingLogPath(config);
+      return yield* Effect.fail(new Error(`OpenViking did not become healthy. Check logs: ${logPath}`));
     }
   }
 
   if (options.printNextSteps !== false) {
-    yield* syncWithConsole(() => printInstallNextSteps({dryRun, startsServer: options.start !== false}));
+    yield* printInstallNextSteps({dryRun, startsServer: options.start !== false});
   }
 });
 
@@ -357,7 +376,7 @@ export const runRepair = Effect.fn('runRepair')(function* (config: RuntimeConfig
 function runRepairCore(config: RuntimeConfig, options: RepairOptions) {
   return Effect.gen(function* () {
     const dryRun = options.dryRun === true;
-    yield* syncWithConsole(() => consoleOutput.log('Repairing local OpenViking agent context from this checkout.'));
+    yield* Console.log('Repairing local OpenViking agent context from this checkout.');
 
     yield* runInstall(config, {
       dryRun,
@@ -367,23 +386,21 @@ function runRepairCore(config: RuntimeConfig, options: RepairOptions) {
       requireServerBinary: false,
       start: false,
     });
-    yield* fromPromise('repair seed manifest', () => repairManifest(config, dryRun));
+    yield* repairManifest(config, dryRun);
 
     if (options.start !== false) {
       yield* repairServerHealth(config, dryRun);
     } else {
-      yield* syncWithConsole(() => consoleOutput.log('Skipping server health repair because --no-start was provided.'));
+      yield* Console.log('Skipping server health repair because --no-start was provided.');
     }
-    yield* fromPromise('repair recall index', () => repairRecallIndex(config, dryRun));
+    yield* repairRecallIndex(config, dryRun);
 
-    const mcpClients = yield* fromPromise('resolve MCP clients for repair', () =>
-      resolveMcpClients(options.mcp ?? 'available', 'repair'),
-    );
+    const mcpClients = yield* resolveMcpClients(options.mcp ?? 'available', 'repair');
     if (mcpClients.length === 0) {
-      yield* syncWithConsole(() => consoleOutput.log('Skipping MCP config repair.'));
+      yield* Console.log('Skipping MCP config repair.');
     } else {
       for (const client of mcpClients) {
-        yield* syncWithConsole(() => consoleOutput.log(`Repairing ${client} MCP config for ${OPENVIKING_MCP_NAME}.`));
+        yield* Console.log(`Repairing ${client} MCP config for ${OPENVIKING_MCP_NAME}.`);
         yield* runMcpInstall(config, client, {apply: !dryRun, name: OPENVIKING_MCP_NAME});
       }
     }
@@ -391,14 +408,12 @@ function runRepairCore(config: RuntimeConfig, options: RepairOptions) {
     // Re-install agent hooks only if the user opted in previously (a managed
     // entry already exists). Never adds them unsolicited — `install-hooks` or
     // `install --with-hooks` is the opt-in.
-    if (yield* fromPromise('check managed Claude hooks', hasManagedClaudeHooks)) {
-      yield* syncWithConsole(() =>
-        consoleOutput.log('\nRepairing claude hooks (re-asserting threadnote-managed entries).'),
-      );
+    if (yield* hasManagedClaudeHooks()) {
+      yield* Console.log('\nRepairing claude hooks (re-asserting threadnote-managed entries).');
       yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun});
     }
 
-    yield* syncWithConsole(() => consoleOutput.log('\nPost-repair doctor:'));
+    yield* Console.log('\nPost-repair doctor:');
     yield* runDoctor(config, {dryRun, strict: false});
   });
 }
@@ -409,57 +424,55 @@ export const runUninstall = Effect.fn('runUninstall')(function* (config: Runtime
     yield* Effect.fail(new Error('Use either --erase-memories or --preserve-memories, not both.'));
   }
 
-  yield* syncWithConsole(() => consoleOutput.log('Uninstalling local Threadnote setup.'));
+  yield* Console.log('Uninstalling local Threadnote setup.');
   yield* runStop(config, {dryRun});
-  yield* fromPromise('remove OpenViking pid file', () =>
-    removePathIfExists(join(config.agentContextHome, 'openviking-server.pid'), 'pid file', dryRun),
-  );
+  yield* removePathIfExists(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), 'pid file', dryRun);
   yield* removeLaunchAgent(dryRun);
-  yield* fromPromise('remove MCP configurations', () => removeMcpConfigs(options.mcp ?? 'available', dryRun));
-  yield* fromPromise('remove MCP snippets', () => removeMcpSnippets(config, dryRun));
-  if (yield* fromPromise('check managed Claude hooks', hasManagedClaudeHooks)) {
+  yield* removeMcpConfigs(options.mcp ?? 'available', dryRun);
+  yield* removeMcpSnippets(config, dryRun);
+  if (yield* hasManagedClaudeHooks()) {
     yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun, remove: true});
   }
-  yield* fromPromise('remove command shim', () => removeCommandShim(dryRun));
-  yield* fromPromise('remove user agent instructions', () => removeUserAgentInstructions(dryRun));
+  yield* removeCommandShim(dryRun);
+  yield* removeUserAgentInstructions(dryRun);
 
   if (options.eraseMemories === true) {
-    yield* fromPromise('erase Threadnote home', () => eraseThreadnoteHome(config.agentContextHome, dryRun));
+    yield* eraseThreadnoteHome(config.agentContextHome, dryRun);
   } else {
-    yield* syncWithConsole(() => {
-      consoleOutput.log(`Preserving local memories and OpenViking home: ${config.agentContextHome}`);
-      consoleOutput.log('Use --erase-memories to delete this directory during uninstall.');
-    });
+    yield* Console.log(`Preserving local memories and OpenViking home: ${config.agentContextHome}`);
+    yield* Console.log('Use --erase-memories to delete this directory during uninstall.');
   }
 
-  yield* syncWithConsole(() => {
-    consoleOutput.log('Uninstall complete.');
-    consoleOutput.log('The package remains installed. Remove it with your package manager if desired.');
-  });
+  yield* Console.log('Uninstall complete.');
+  yield* Console.log('The package remains installed. Remove it with your package manager if desired.');
 });
 
-async function repairManifest(config: RuntimeConfig, dryRun: boolean): Promise<void> {
-  try {
-    await readSeedManifest(config.manifestPath);
-    consoleOutput.log(`Manifest OK: ${config.manifestPath}`);
-    return;
-  } catch (err: unknown) {
-    if (config.manifestPath === builtInExampleManifestPath()) {
-      consoleOutput.log(`WARN built-in manifest is not readable: ${errorMessage(err)}`);
-      return;
-    }
-    consoleOutput.log(`Manifest needs repair: ${config.manifestPath} (${errorMessage(err)})`);
-  }
-
-  let repoRoot: string;
-  try {
-    repoRoot = await resolveRepoRoot(getInvocationCwd());
-  } catch (err: unknown) {
-    consoleOutput.log(`WARN cannot create replacement manifest from current directory: ${errorMessage(err)}`);
+const repairManifest = Effect.fn('lifecycle.repairManifest')(function* (config: RuntimeConfig, dryRun: boolean) {
+  const manifestResult = yield* Effect.result(readSeedManifest(config.manifestPath));
+  if (Result.isSuccess(manifestResult)) {
+    yield* Console.log(`Manifest OK: ${config.manifestPath}`);
     return;
   }
+  if (config.manifestPath === (yield* builtInExampleManifestPath())) {
+    yield* Console.warn(`WARN built-in manifest is not readable: ${errorMessage(manifestResult.failure)}`);
+    return;
+  }
+  yield* Console.log(`Manifest needs repair: ${config.manifestPath} (${errorMessage(manifestResult.failure)})`);
 
-  const project = await projectManifestForRepo(repoRoot, []);
+  const repoRootResult = yield* Effect.result(
+    Effect.gen(function* () {
+      return yield* resolveRepoRoot(yield* getInvocationCwd());
+    }),
+  );
+  if (Result.isFailure(repoRootResult)) {
+    yield* Console.warn(
+      `WARN cannot create replacement manifest from current directory: ${errorMessage(repoRootResult.failure)}`,
+    );
+    return;
+  }
+  const repoRoot = repoRootResult.success;
+
+  const project = yield* projectManifestForRepo(repoRoot, []);
   const output = yaml.dump(
     {
       version: 1,
@@ -476,35 +489,35 @@ async function repairManifest(config: RuntimeConfig, dryRun: boolean): Promise<v
   );
 
   if (dryRun) {
-    consoleOutput.log(`# Would write replacement manifest: ${config.manifestPath}`);
-    consoleOutput.log(output.trimEnd());
+    yield* Console.log(`# Would write replacement manifest: ${config.manifestPath}`);
+    yield* Console.log(output.trimEnd());
     return;
   }
 
-  await ensureDirectory(dirname(config.manifestPath), false);
-  const currentContent = await readFileIfExists(config.manifestPath);
+  yield* ensureDirectory(yield* pathDirname(config.manifestPath), false);
+  const currentContent = yield* readFileIfExists(config.manifestPath);
   if (currentContent !== undefined) {
     const backupPath = `${config.manifestPath}.legacy-${safeTimestamp()}`;
-    await writeFile(backupPath, currentContent, {encoding: 'utf8', mode: 0o600});
-    await chmod(backupPath, 0o600);
-    consoleOutput.log(`Backup: ${backupPath}`);
+    yield* writeFile(backupPath, currentContent, {encoding: 'utf8', mode: 0o600});
+    yield* chmod(backupPath, 0o600);
+    yield* Console.log(`Backup: ${backupPath}`);
   }
-  await writeFile(config.manifestPath, output, {encoding: 'utf8', mode: 0o600});
-  await chmod(config.manifestPath, 0o600);
-  consoleOutput.log(`Wrote replacement manifest: ${config.manifestPath}`);
-}
+  yield* writeFile(config.manifestPath, output, {encoding: 'utf8', mode: 0o600});
+  yield* chmod(config.manifestPath, 0o600);
+  yield* Console.log(`Wrote replacement manifest: ${config.manifestPath}`);
+});
 
-async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promise<void> {
-  consoleOutput.log('\nRepairing recall index freshness.');
-  const ov = dryRun ? ((await findOpenVikingCli()) ?? 'ov') : await findOpenVikingCli();
+const repairRecallIndex = Effect.fn('lifecycle.repairRecallIndex')(function* (config: RuntimeConfig, dryRun: boolean) {
+  yield* Console.log('\nRepairing recall index freshness.');
+  const ov = dryRun ? ((yield* findOpenVikingCli()) ?? 'ov') : yield* findOpenVikingCli();
   if (!ov) {
-    consoleOutput.log('Skipping recall index repair: neither ov nor openviking was found.');
+    yield* Console.log('Skipping recall index repair: neither ov nor openviking was found.');
     return;
   }
 
-  const progress = startProgress('Scanning recall index freshness across memories and seeded resources.');
-  try {
-    const result = await repairStaleRecallIndex(config, ov, {
+  const progress = yield* startProgress('Scanning recall index freshness across memories and seeded resources.');
+  yield* Effect.gen(function* () {
+    const result = yield* repairStaleRecallIndex(config, ov, {
       collapseDepth: MAINTENANCE_COLLAPSE_DEPTH,
       collapseToRoots: true,
       consecutiveFailureLimit: MAINTENANCE_CONSECUTIVE_FAILURE_LIMIT,
@@ -516,52 +529,62 @@ async function repairRecallIndex(config: RuntimeConfig, dryRun: boolean): Promis
       onProgress: event => {
         if (event.type === 'scan-complete') {
           if (event.totalTargets === 0) {
-            progress.update('No stale recall index scopes found.');
+            return progress.update('No stale recall index scopes found.');
           } else {
-            progress.update(
+            return progress.update(
               `Found ${event.totalTargets} stale recall index scope(s); repairing ${event.repairTargetCount}.`,
             );
           }
         } else if (event.type === 'repair-start') {
-          progress.update(
+          return progress.update(
             `Reindexing ${event.index}/${event.total}: ${event.target.uri} (${event.target.staleCount} stale summaries).`,
           );
         } else if (event.type === 'repair-dry-run') {
-          progress.update(
+          return progress.update(
             `Planning reindex ${event.index}/${event.total}: ${event.target.uri} (${event.target.staleCount} stale summaries).`,
           );
         } else if (event.type === 'repair-skip-recent') {
-          progress.update(`Skipping recently repaired scope ${event.index}/${event.total}: ${event.target.uri}.`);
+          return progress.update(
+            `Skipping recently repaired scope ${event.index}/${event.total}: ${event.target.uri}.`,
+          );
         }
+        return Effect.void;
       },
     });
-    progress.stop();
+    yield* progress.stop();
     const messages = formatRecallIndexRepairMessages(result, {dryRun, maxUris: 20});
     if (messages.length === 0) {
-      consoleOutput.log('Recall index freshness OK.');
+      yield* Console.log('Recall index freshness OK.');
       return;
     }
     for (const message of messages) {
-      consoleOutput.log(message);
+      yield* Console.log(message);
     }
-  } catch (err: unknown) {
-    progress.stop();
-    consoleOutput.log(`WARN could not repair recall index freshness: ${errorMessage(err)}`);
-  }
-}
+  }).pipe(
+    Effect.catch(error =>
+      Effect.gen(function* () {
+        yield* progress.stop();
+        yield* Console.log(`WARN could not repair recall index freshness: ${errorMessage(error)}`);
+      }),
+    ),
+  );
+});
 
-async function configureOpenVikingCliLanguage(config: RuntimeConfig, dryRun: boolean): Promise<void> {
-  const ov = dryRun ? ((await findOpenVikingCli()) ?? 'ov') : await findOpenVikingCli();
+const configureOpenVikingCliLanguage = Effect.fn('lifecycle.configureOpenVikingCliLanguage')(function* (
+  config: RuntimeConfig,
+  dryRun: boolean,
+) {
+  const ov = dryRun ? ((yield* findOpenVikingCli()) ?? 'ov') : yield* findOpenVikingCli();
   if (!ov) {
     return;
   }
-  const installedVersion = dryRun ? undefined : await readOpenVikingCliVersion(ov);
+  const installedVersion = dryRun ? undefined : yield* readOpenVikingCliVersion(ov);
   const effectiveVersion = installedVersion ?? config.openVikingVersion;
   if (compareVersions(effectiveVersion, '0.3.23') < 0) {
     return;
   }
-  await maybeRun(dryRun, ov, ['language', 'en'], {allowFailure: true});
-}
+  yield* maybeRun(dryRun, ov, ['language', 'en'], {allowFailure: true});
+});
 
 /**
  * Locate the openviking-server binary even when its install directory is not on
@@ -575,41 +598,43 @@ async function configureOpenVikingCliLanguage(config: RuntimeConfig, dryRun: boo
  * three times. The resolved path itself is not memoised: a `threadnote install`
  * may create the binary mid-process and the second resolution must see it.
  */
-export async function findOpenVikingServer(): Promise<string | undefined> {
-  if (process.platform !== 'win32') {
-    const onPath = await findExecutable([OPENVIKING_SERVER_COMMAND]);
+export const findOpenVikingServer = Effect.fn('lifecycle.findOpenVikingServer')(function* () {
+  const system = yield* SystemInfo;
+  if (system.platform !== 'win32') {
+    const onPath = yield* findExecutable([OPENVIKING_SERVER_COMMAND]);
     if (onPath) {
       return onPath;
     }
   } else {
-    for (const directory of (process.env.PATH ?? '').split(delimiter).filter(Boolean)) {
-      for (const name of openVikingServerExecutableNames()) {
-        const candidate = join(directory, name);
-        if (await isExecutable(candidate)) {
+    for (const directory of (system.environment().PATH ?? '').split(system.pathDelimiter).filter(Boolean)) {
+      for (const name of openVikingServerExecutableNames(system.platform, system.environment().PATHEXT)) {
+        const candidate = yield* pathJoin(directory, name);
+        if (yield* isExecutable(candidate)) {
           return candidate;
         }
       }
     }
   }
-  for (const candidateDir of await openVikingServerCandidateDirs()) {
-    for (const name of openVikingServerExecutableNames()) {
-      const candidate = join(candidateDir, name);
-      if (await isExecutable(candidate)) {
+  for (const candidateDir of yield* openVikingServerCandidateDirs()) {
+    for (const name of openVikingServerExecutableNames(system.platform, system.environment().PATHEXT)) {
+      const candidate = yield* pathJoin(candidateDir, name);
+      if (yield* isExecutable(candidate)) {
         return candidate;
       }
     }
   }
   return undefined;
-}
+});
 
 const findOpenVikingServerEffectCore = Effect.fn('findOpenVikingServer')(function* (timeoutMs: number) {
   const fs = yield* FileSystem.FileSystem;
   const system = yield* SystemInfo;
   const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
-  const pathDirectories = (process.env.PATH ?? '').split(system.platform === 'win32' ? ';' : ':').filter(Boolean);
+  const environment = system.environment();
+  const pathDirectories = (environment.PATH ?? '').split(system.pathDelimiter).filter(Boolean);
   for (const directory of pathDirectories) {
     for (const name of openVikingServerExecutableNames(system.platform)) {
-      const candidate = join(directory, name);
+      const candidate = yield* pathJoin(directory, name);
       if (yield* isExecutableFileEffect(fs, candidate, system.platform)) {
         return candidate;
       }
@@ -627,14 +652,14 @@ const findOpenVikingServerEffectCore = Effect.fn('findOpenVikingServer')(functio
       candidateDirectories.push(result.stdout.trim());
     }
   }
-  if (process.env.UV_TOOL_BIN_DIR) {
-    candidateDirectories.push(process.env.UV_TOOL_BIN_DIR);
+  if (environment.UV_TOOL_BIN_DIR) {
+    candidateDirectories.push(environment.UV_TOOL_BIN_DIR);
   }
   candidateDirectories.push(...(yield* pythonUserScriptsCandidateDirsEffect()));
-  candidateDirectories.push(expandPath('~/.local/bin'));
+  candidateDirectories.push(yield* expandPath('~/.local/bin'));
   for (const directory of new Set(candidateDirectories)) {
     for (const name of openVikingServerExecutableNames(system.platform)) {
-      const candidate = join(directory, name);
+      const candidate = yield* pathJoin(directory, name);
       if (yield* isExecutableFileEffect(fs, candidate, system.platform)) {
         return candidate;
       }
@@ -644,8 +669,8 @@ const findOpenVikingServerEffectCore = Effect.fn('findOpenVikingServer')(functio
 });
 
 export function openVikingServerExecutableNames(
-  currentPlatform: NodeJS.Platform = process.platform,
-  pathExt = process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD',
+  currentPlatform: NodeJS.Platform,
+  pathExt = '.COM;.EXE;.BAT;.CMD',
 ): readonly string[] {
   const names = executableNames(OPENVIKING_SERVER_COMMAND, currentPlatform, pathExt);
   return currentPlatform === 'win32' ? names.filter(name => /\.(?:com|exe)$/i.test(name)) : names;
@@ -668,7 +693,7 @@ const findExecutableInDirectoriesEffect = Effect.fn('findExecutableInDirectories
 ) {
   for (const directory of directories) {
     for (const executableName of executableNames(name, currentPlatform)) {
-      const candidate = join(directory, executableName);
+      const candidate = yield* pathJoin(directory, executableName);
       if (yield* isExecutableFileEffect(fs, candidate, currentPlatform)) {
         return candidate;
       }
@@ -694,7 +719,7 @@ const isExecutableFileEffect = Effect.fn('isExecutableFile')(function* (
 const findExecutableEffect = Effect.fn('findExecutable')(function* (commands: readonly string[]) {
   const fs = yield* FileSystem.FileSystem;
   const system = yield* SystemInfo;
-  const directories = (process.env.PATH ?? '').split(system.platform === 'win32' ? ';' : ':').filter(Boolean);
+  const directories = (system.environment().PATH ?? '').split(system.pathDelimiter).filter(Boolean);
   for (const command of commands) {
     const executable = yield* findExecutableInDirectoriesEffect(fs, command, directories, system.platform);
     if (executable) {
@@ -725,20 +750,22 @@ const pythonUserScriptsCandidateDirsEffect = Effect.fn('pythonUserScriptsCandida
   return Array.from(new Set(directories));
 });
 
-let candidateDirsPromise: Promise<readonly string[]> | undefined;
+let candidateDirsCache: readonly string[] | undefined;
 
-async function openVikingServerCandidateDirs(): Promise<readonly string[]> {
-  if (!candidateDirsPromise) {
-    candidateDirsPromise = computeOpenVikingServerCandidateDirs();
+const openVikingServerCandidateDirs = Effect.fn('lifecycle.openVikingServerCandidateDirs')(function* () {
+  if (!candidateDirsCache) {
+    candidateDirsCache = yield* computeOpenVikingServerCandidateDirs();
   }
-  return candidateDirsPromise;
-}
+  return candidateDirsCache;
+});
 
-async function computeOpenVikingServerCandidateDirs(): Promise<readonly string[]> {
+const computeOpenVikingServerCandidateDirs = Effect.fn('lifecycle.computeOpenVikingServerCandidateDirs')(function* () {
+  const system = yield* SystemInfo;
+  const environment = system.environment();
   const dirs: string[] = [];
-  const uv = await findExecutable(['uv']);
+  const uv = yield* findExecutable(['uv']);
   if (uv) {
-    const result = await runCommand(uv, ['tool', 'dir', '--bin'], {allowFailure: true});
+    const result = yield* runCommand(uv, ['tool', 'dir', '--bin'], {allowFailure: true});
     if (result.exitCode === 0) {
       const dir = result.stdout.trim();
       if (dir) {
@@ -746,16 +773,16 @@ async function computeOpenVikingServerCandidateDirs(): Promise<readonly string[]
       }
     }
   }
-  if (process.env.UV_TOOL_BIN_DIR) {
-    dirs.push(process.env.UV_TOOL_BIN_DIR);
+  if (environment.UV_TOOL_BIN_DIR) {
+    dirs.push(environment.UV_TOOL_BIN_DIR);
   }
-  dirs.push(...(await pythonUserScriptsCandidateDirs()));
-  dirs.push(expandPath('~/.local/bin'));
+  dirs.push(...(yield* pythonUserScriptsCandidateDirs()));
+  dirs.push(yield* expandPath('~/.local/bin'));
   return Array.from(new Set(dirs));
-}
+});
 
-async function requireOpenVikingServer(): Promise<string> {
-  const resolved = await findOpenVikingServer();
+const requireOpenVikingServer = Effect.fn('lifecycle.requireOpenVikingServer')(function* () {
+  const resolved = yield* findOpenVikingServer();
   if (!resolved) {
     throw new Error(
       `${OPENVIKING_SERVER_COMMAND} was not found in PATH, uv tool bin dir, ` +
@@ -763,52 +790,46 @@ async function requireOpenVikingServer(): Promise<string> {
     );
   }
   return resolved;
-}
+});
 
-async function maybePrintOpenVikingPathHint(serverPath: string): Promise<void> {
-  const onPath = await findExecutable([OPENVIKING_SERVER_COMMAND]);
+const maybePrintOpenVikingPathHint = Effect.fn('lifecycle.maybePrintOpenVikingPathHint')(function* (
+  serverPath: string,
+) {
+  const onPath = yield* findExecutable([OPENVIKING_SERVER_COMMAND]);
   if (onPath) {
     return;
   }
-  const binDir = dirname(serverPath);
-  if (process.platform === 'win32') {
-    consoleOutput.log(
+  const system = yield* SystemInfo;
+  const binDir = yield* pathDirname(serverPath);
+  if (system.platform === 'win32') {
+    yield* Console.log(
       `Note: ${serverPath} is installed but ${binDir} is not on this PowerShell PATH. ` +
         `Run \`$env:Path = "${binDir};$env:Path"\` for this shell.`,
     );
     return;
   }
-  const rcHint = suggestedShellRc(process.env.SHELL, process.platform);
-  consoleOutput.log(
+  const rcHint = suggestedShellRc(system.environment().SHELL, system.platform);
+  yield* Console.log(
     `Note: ${serverPath} is installed but ${binDir} is not on this shell's PATH. ` +
       `Add \`export PATH="${binDir}:$PATH"\` to ${rcHint} so other tools can find openviking-server.`,
   );
-}
+});
 
 function repairServerHealth(config: RuntimeConfig, dryRun: boolean) {
   return Effect.gen(function* () {
-    const existingHealth = yield* fromPromise('check OpenViking health', () =>
-      readOpenVikingHealthIfAvailable(config, 800),
-    );
+    const existingHealth = yield* readOpenVikingHealthIfAvailable(config, 800);
     if (existingHealth) {
-      yield* syncWithConsole(() =>
-        consoleOutput.log(`OpenViking health OK at http://${config.host}:${config.port}/health`),
-      );
+      yield* Console.log(`OpenViking health OK at http://${config.host}:${config.port}/health`);
       return true;
     }
 
-    yield* syncWithConsole(() =>
-      consoleOutput.log(
-        `OpenViking health is not responding at http://${config.host}:${config.port}/health; starting server.`,
-      ),
+    yield* Console.log(
+      `OpenViking health is not responding at http://${config.host}:${config.port}/health; starting server.`,
     );
     return yield* runStart(config, {dryRun}).pipe(
       Effect.as(true),
       Effect.catch(error =>
-        syncWithConsole(() => {
-          consoleOutput.log(`WARN could not repair OpenViking health: ${errorMessage(error)}`);
-          return false;
-        }),
+        Console.log(`WARN could not repair OpenViking health: ${errorMessage(error)}`).pipe(Effect.as(false)),
       ),
     );
   });
@@ -824,23 +845,21 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
 
   const server =
     options.dryRun === true
-      ? ((yield* fromPromise('find OpenViking server', findOpenVikingServer)) ?? OPENVIKING_SERVER_COMMAND)
-      : yield* fromPromise('require OpenViking server', requireOpenVikingServer);
-  const args = openVikingServerArgs(config);
+      ? ((yield* findOpenVikingServer()) ?? OPENVIKING_SERVER_COMMAND)
+      : yield* requireOpenVikingServer();
+  const args = yield* openVikingServerArgs(config);
   if (options.dryRun === true) {
-    yield* syncWithConsole(() => consoleOutput.log(formatShellCommand(server, args)));
+    yield* Console.log(formatShellCommand(server, args));
     return;
   }
 
-  const existingHealth = yield* fromPromise('check existing OpenViking health', () =>
-    readOpenVikingHealthIfAvailable(config, 500),
-  );
+  const existingHealth = yield* readOpenVikingHealthIfAvailable(config, 500);
   const healthUrl = openVikingHealthUrl(config);
   if (existingHealth) {
-    yield* syncWithConsole(() => consoleOutput.log(`OpenViking is already healthy at ${healthUrl}`));
+    yield* Console.log(`OpenViking is already healthy at ${healthUrl}`);
     return;
   }
-  if (yield* fromPromise('check OpenViking TCP port', () => isTcpPortOpen(config.host, config.port, 500))) {
+  if (yield* isTcpPortOpen(config.host, config.port, 500)) {
     return yield* Effect.fail(
       new Error(
         `Port ${config.host}:${config.port} is already in use, but it is not a healthy OpenViking server. ` +
@@ -849,35 +868,23 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
     );
   }
 
-  const logPath = openVikingLogPath(config);
-  yield* fs.makeDirectory(dirname(logPath), {recursive: true});
+  const logPath = yield* openVikingLogPath(config);
+  yield* fs.makeDirectory(yield* pathDirname(logPath), {recursive: true});
   if (options.foreground === true) {
-    const result = yield* fromPromise('run OpenViking in foreground', () => runInteractive(server, args));
-    yield* syncWithConsole(() => {
-      process.exitCode = result;
-    });
+    const result = yield* runStreamingCommandEffect(server, args, {maxOutputChars: INSTALL_OUTPUT_TAIL_CHARS});
+    yield* Effect.sync(() => system.setExitCode(result.exitCode));
     return;
   }
 
-  const child = yield* Effect.try({
-    try: () => {
-      const logFd = openSync(logPath, 'a');
-      const spawned = spawnDetachedServerWithLog(server, args, logFd);
-      spawned.unref();
-      return spawned;
-    },
-    catch: cause => applicationError('start detached OpenViking server', cause),
-  });
-  if (child.pid === undefined) {
-    return yield* Effect.fail(new Error('Detached OpenViking server did not report a pid.'));
-  }
-  const childPid = child.pid;
+  const childPid = yield* Effect.scoped(spawnDetachedServer(server, args, logPath));
   yield* fs.writeFileString(
-    join(config.agentContextHome, 'openviking-server.pid'),
+    yield* pathJoin(config.agentContextHome, 'openviking-server.pid'),
     detachedProcessRecordContent(childPid, server, args, system.platform),
   );
-  const health = yield* fromPromise('wait for OpenViking health', () =>
-    waitForOpenVikingHealth(config, START_HEALTH_TIMEOUT_MS, `Waiting for OpenViking health at ${healthUrl}.`),
+  const health = yield* waitForOpenVikingHealth(
+    config,
+    START_HEALTH_TIMEOUT_MS,
+    `Waiting for OpenViking health at ${healthUrl}.`,
   );
   if (health) {
     let managedPid = childPid;
@@ -888,20 +895,18 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
         if (!termination.stopped) {
           return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
         }
-        yield* fs.remove(join(config.agentContextHome, 'openviking-server.pid'), {force: true});
+        yield* fs.remove(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), {force: true});
         return yield* Effect.fail(
           new Error('OpenViking became healthy, but Threadnote could not verify its Windows serving process.'),
         );
       }
       managedPid = servingProcess.pid;
       yield* fs.writeFileString(
-        join(config.agentContextHome, 'openviking-server.pid'),
+        yield* pathJoin(config.agentContextHome, 'openviking-server.pid'),
         windowsDetachedProcessRecordContent(childPid, server, args, servingProcess),
       );
     }
-    yield* syncWithConsole(() =>
-      consoleOutput.log(`Started OpenViking with pid ${managedPid}. Health OK at ${healthUrl}. Logs: ${logPath}`),
-    );
+    yield* Console.log(`Started OpenViking with pid ${managedPid}. Health OK at ${healthUrl}. Logs: ${logPath}`);
     return;
   }
   if (system.platform === 'win32') {
@@ -909,7 +914,7 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
     if (!termination.stopped) {
       return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
     }
-    yield* fs.remove(join(config.agentContextHome, 'openviking-server.pid'), {force: true});
+    yield* fs.remove(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), {force: true});
   }
   return yield* Effect.fail(
     new Error(
@@ -919,21 +924,22 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
   );
 });
 
-function spawnDetachedServerWithLog(server: string, args: readonly string[], logFd: number): ReturnType<typeof spawn> {
-  try {
-    return spawnDetachedServer(server, args, logFd);
-  } finally {
-    closeSync(logFd);
-  }
-}
-
-function spawnDetachedServer(server: string, args: readonly string[], logFd: number): ReturnType<typeof spawn> {
-  return spawn(server, args, {
+const spawnDetachedServer = Effect.fn('lifecycle.spawnDetachedServer')(function* (
+  server: string,
+  args: readonly string[],
+  logPath: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const logSink = fs.sink(logPath, {flag: 'a'}).pipe(Sink.as(new Uint8Array()));
+  const child = yield* ChildProcess.make(server, [...args], {
     detached: true,
-    stdio: ['ignore', logFd, logFd],
-    windowsHide: true,
+    stderr: logSink,
+    stdin: 'ignore',
+    stdout: logSink,
   });
-}
+  yield* child.unref;
+  return Number(child.pid);
+});
 
 const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServer')(function* (
   config: RuntimeConfig,
@@ -942,44 +948,32 @@ const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServ
 ) {
   const fs = yield* FileSystem.FileSystem;
   const system = yield* SystemInfo;
-  const logPath = openVikingLogPath(config);
-  yield* fs.makeDirectory(dirname(logPath), {recursive: true});
-  const child = yield* Effect.try({
-    try: () => {
-      const logFd = openSync(logPath, 'a');
-      const spawned = spawnDetachedServerWithLog(server, openVikingServerArgs(config), logFd);
-      spawned.unref();
-      return spawned;
-    },
-    catch: cause => applicationError('restore detached OpenViking server', cause),
-  });
-  if (child.pid === undefined) {
-    return yield* Effect.fail(new Error('Restored detached OpenViking server did not report a pid.'));
-  }
-  const childPid = child.pid;
+  const logPath = yield* openVikingLogPath(config);
+  yield* fs.makeDirectory(yield* pathDirname(logPath), {recursive: true});
+  const args = yield* openVikingServerArgs(config);
+  const childPid = yield* Effect.scoped(spawnDetachedServer(server, args, logPath));
   yield* fs.writeFileString(
-    join(config.agentContextHome, 'openviking-server.pid'),
-    detachedProcessRecordContent(childPid, server, openVikingServerArgs(config), system.platform),
+    yield* pathJoin(config.agentContextHome, 'openviking-server.pid'),
+    detachedProcessRecordContent(childPid, server, args, system.platform),
   );
   const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
   while ((yield* Clock.currentTimeMillis) < deadline) {
     const remainingMs = deadline - (yield* Clock.currentTimeMillis);
     if (yield* readOpenVikingHealthEffect(config, Math.max(1, Math.min(500, remainingMs)))) {
       if (system.platform === 'win32') {
-        const args = openVikingServerArgs(config);
         const servingProcess = yield* findWindowsServingProcess(childPid, config, server, args);
         if (!servingProcess) {
           const termination = yield* terminateWindowsProcessTree(childPid);
           if (!termination.stopped) {
             return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
           }
-          yield* fs.remove(join(config.agentContextHome, 'openviking-server.pid'), {force: true});
+          yield* fs.remove(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), {force: true});
           return yield* Effect.fail(
             new Error('Restored OpenViking became healthy, but its Windows serving process could not be verified.'),
           );
         }
         yield* fs.writeFileString(
-          join(config.agentContextHome, 'openviking-server.pid'),
+          yield* pathJoin(config.agentContextHome, 'openviking-server.pid'),
           windowsDetachedProcessRecordContent(childPid, server, args, servingProcess),
         );
       }
@@ -992,7 +986,7 @@ const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServ
     if (!termination.stopped) {
       return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
     }
-    yield* fs.remove(join(config.agentContextHome, 'openviking-server.pid'), {force: true});
+    yield* fs.remove(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), {force: true});
   } else {
     yield* signalProcessEffect(childPid, 'SIGTERM').pipe(Effect.ignore);
   }
@@ -1008,7 +1002,7 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
     yield* bootoutLaunchAgent(options.dryRun === true, undefined, STOP_SERVER_TIMEOUT_MS);
   }
 
-  const pidPath = join(config.agentContextHome, 'openviking-server.pid');
+  const pidPath = yield* pathJoin(config.agentContextHome, 'openviking-server.pid');
   const pidText = yield* fs.readFileString(pidPath).pipe(
     Effect.catchIf(
       error => error.reason._tag === 'NotFound',
@@ -1016,38 +1010,36 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
     ),
   );
   if (!pidText) {
-    yield* syncWithConsole(() => consoleOutput.log('No pid file found for detached OpenViking server.'));
+    yield* Console.log('No pid file found for detached OpenViking server.');
     return;
   }
   const processRecord = parseDetachedProcessRecord(pidText);
   const pid = processRecord?.pid ?? Number.NaN;
   if (!Number.isInteger(pid) || pid <= 0) {
-    yield* syncWithConsole(() => consoleOutput.log(`Invalid pid file: ${pidPath}`));
+    yield* Console.log(`Invalid pid file: ${pidPath}`);
     if (options.dryRun !== true) {
       yield* fs.remove(pidPath, {force: true});
     }
     return;
   }
   if (options.dryRun === true) {
-    yield* syncWithConsole(() => consoleOutput.log(`Would stop process ${pid}`));
+    yield* Console.log(`Would stop process ${pid}`);
     return;
   }
   if (!(yield* isProcessRunningEffect(pid))) {
     yield* fs.remove(pidPath, {force: true});
-    yield* syncWithConsole(() => consoleOutput.log(`Removed stale pid file for process ${pid}.`));
+    yield* Console.log(`Removed stale pid file for process ${pid}.`);
     return;
   }
   if (system.platform === 'win32') {
-    const server =
-      processRecord?.server ??
-      (yield* fromPromise('find OpenViking server for process verification', findOpenVikingServer));
+    const server = processRecord?.server ?? (yield* findOpenVikingServer());
     if (!server) {
       return yield* Effect.fail(
         new Error(`Refusing to stop process ${pid}: OpenViking server path is unavailable for verification.`),
       );
     }
     const expected = {
-      args: processRecord?.args ?? openVikingServerArgs(config),
+      args: processRecord?.args ?? (yield* openVikingServerArgs(config)),
       commandLine: processRecord?.commandLine,
       executablePath: processRecord?.executablePath,
       launcherPid: processRecord?.launcherPid,
@@ -1075,7 +1067,7 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
   }
   if (!signaled) {
     yield* fs.remove(pidPath, {force: true});
-    yield* syncWithConsole(() => consoleOutput.log(`Process ${pid} was already stopped.`));
+    yield* Console.log(`Process ${pid} was already stopped.`);
     return;
   }
   const deadline = (yield* Clock.currentTimeMillis) + STOP_SERVER_TIMEOUT_MS;
@@ -1087,7 +1079,7 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
     yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
   }
   yield* fs.remove(pidPath, {force: true});
-  yield* syncWithConsole(() => consoleOutput.log(`Stopped process ${pid}`));
+  yield* Console.log(`Stopped process ${pid}`);
 });
 
 function detachedProcessRecordContent(
@@ -1131,8 +1123,8 @@ function parseDetachedProcessRecord(content: string): DetachedProcessRecord | un
   if (!trimmed) {
     return undefined;
   }
-  try {
-    const value: unknown = JSON.parse(trimmed);
+  const value = Option.getOrUndefined(parseJson(trimmed));
+  if (value !== undefined) {
     if (typeof value === 'number') {
       return {pid: value};
     }
@@ -1152,10 +1144,9 @@ function parseDetachedProcessRecord(content: string): DetachedProcessRecord | un
       server: typeof value.server === 'string' ? value.server : undefined,
       startedAt: typeof value.startedAt === 'string' ? value.startedAt : undefined,
     };
-  } catch {
-    const pid = Number(trimmed);
-    return Number.isInteger(pid) ? {pid} : undefined;
   }
+  const pid = Number(trimmed);
+  return Number.isInteger(pid) ? {pid} : undefined;
 }
 
 const findWindowsServingProcess = Effect.fn('findWindowsServingProcess')(function* (
@@ -1201,50 +1192,49 @@ if ($null -eq $match) { exit 4 }
     return undefined;
   }
   const identity = parseWindowsProcessIdentity(result.stdout);
-  if (!identity || !matchesExpectedWindowsProcess(identity, server, args)) {
+  if (!identity || !(yield* matchesExpectedWindowsProcess(identity, server, args))) {
     return undefined;
   }
   return identity;
 });
 
 function parseWindowsProcessIdentity(output: string): WindowsProcessIdentity | undefined {
-  try {
-    const value: unknown = JSON.parse(output);
-    if (
-      !isJsonObject(value) ||
-      typeof value.CommandLine !== 'string' ||
-      typeof value.CreationTime !== 'string' ||
-      typeof value.ExecutablePath !== 'string' ||
-      typeof value.ProcessId !== 'number'
-    ) {
-      return undefined;
-    }
-    return {
-      commandLine: value.CommandLine,
-      executablePath: value.ExecutablePath,
-      pid: value.ProcessId,
-      startedAt: value.CreationTime,
-    };
-  } catch {
+  const value = Option.getOrUndefined(parseJson(output));
+  if (
+    !isJsonObject(value) ||
+    typeof value.CommandLine !== 'string' ||
+    typeof value.CreationTime !== 'string' ||
+    typeof value.ExecutablePath !== 'string' ||
+    typeof value.ProcessId !== 'number'
+  ) {
     return undefined;
   }
+  return {
+    commandLine: value.CommandLine,
+    executablePath: value.ExecutablePath,
+    pid: value.ProcessId,
+    startedAt: value.CreationTime,
+  };
 }
 
-function matchesExpectedWindowsProcess(
+const matchesExpectedWindowsProcess = Effect.fn('lifecycle.matchesExpectedWindowsProcess')(function* (
   identity: Pick<WindowsProcessIdentity, 'commandLine' | 'executablePath'>,
   server: string,
   args: readonly string[],
-): boolean {
+) {
   const commandLine = identity.commandLine.toLowerCase();
-  const expectedServer = basename(server).toLowerCase();
-  if (!commandLine.includes(expectedServer) && basename(identity.executablePath).toLowerCase() !== expectedServer) {
+  const expectedServer = (yield* pathBasename(server)).toLowerCase();
+  if (
+    !commandLine.includes(expectedServer) &&
+    (yield* pathBasename(identity.executablePath)).toLowerCase() !== expectedServer
+  ) {
     return false;
   }
   return args.every(arg => commandLine.includes(arg.toLowerCase()));
-}
+});
 
 const terminateWindowsProcessTree = Effect.fn('terminateWindowsProcessTree')(function* (pid: number) {
-  const result = yield* runCommandEffect(windowsTaskkillExecutable(), ['/pid', String(pid), '/t', '/f'], {
+  const result = yield* runCommandEffect(yield* windowsTaskkillExecutable(), ['/pid', String(pid), '/t', '/f'], {
     allowFailure: true,
     timeoutMs: 5000,
   });
@@ -1285,14 +1275,8 @@ const isManagedWindowsOpenVikingProcess = Effect.fn('isManagedWindowsOpenVikingP
   if (result.exitCode !== 0) {
     return false;
   }
-  let identity: JsonObject;
-  try {
-    const value: unknown = JSON.parse(result.stdout);
-    if (!isJsonObject(value)) {
-      return false;
-    }
-    identity = value;
-  } catch {
+  const identity = Option.getOrUndefined(parseJson(result.stdout));
+  if (!isJsonObject(identity)) {
     return false;
   }
   if (identity.OwnsPort !== true || typeof identity.CommandLine !== 'string') {
@@ -1306,7 +1290,7 @@ const isManagedWindowsOpenVikingProcess = Effect.fn('isManagedWindowsOpenVikingP
   if (expected.executablePath && executablePath.toLowerCase() !== expected.executablePath.toLowerCase()) {
     return false;
   }
-  if (!matchesExpectedWindowsProcess({commandLine, executablePath}, expected.server, expected.args)) {
+  if (!(yield* matchesExpectedWindowsProcess({commandLine, executablePath}, expected.server, expected.args))) {
     return false;
   }
   if (expected.startedAt) {
@@ -1326,7 +1310,7 @@ const stopDetachedOpenVikingServerForLaunchdCore = Effect.fn('stopDetachedOpenVi
   resolvedServer?: string,
 ) {
   const fs = yield* FileSystem.FileSystem;
-  const pidPath = join(config.agentContextHome, 'openviking-server.pid');
+  const pidPath = yield* pathJoin(config.agentContextHome, 'openviking-server.pid');
   const pidText = yield* fs.readFileString(pidPath).pipe(
     Effect.catchIf(
       error => error.reason._tag === 'NotFound',
@@ -1359,7 +1343,7 @@ const stopDetachedOpenVikingServerForLaunchdCore = Effect.fn('stopDetachedOpenVi
     return yield* Effect.fail(new Error(`Refusing to stop process ${pid}: OpenViking server path is unavailable.`));
   }
   const expectedProcess = {
-    args: openVikingServerArgs(config),
+    args: yield* openVikingServerArgs(config),
     server,
     shebangInterpreter: yield* fs.readFileString(server).pipe(
       Effect.map(parseShebangInterpreter),
@@ -1468,59 +1452,49 @@ function parseShebangInterpreter(content: string): string | undefined {
 }
 
 const isProcessRunningEffect = Effect.fn('isProcessRunning')(function* (pid: number) {
-  return yield* Effect.try({
-    try: () => {
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch (cause: unknown) {
-        if (isNodeError(cause) && cause.code === 'ESRCH') {
-          return false;
-        }
-        throw cause;
-      }
-    },
-    catch: cause => applicationError(`check process ${pid}`, cause),
-  });
+  const system = yield* SystemInfo;
+  if (system.platform === 'win32') {
+    const result = yield* runCommandEffect('tasklist.exe', ['/fi', `PID eq ${pid}`, '/fo', 'csv', '/nh'], {
+      allowFailure: true,
+      timeoutMs: 5000,
+    });
+    return result.exitCode === 0 && new RegExp(`"${pid}"(?:,|$)`).test(result.stdout);
+  }
+  const result = yield* runCommandEffect('kill', ['-0', String(pid)], {allowFailure: true, timeoutMs: 5000});
+  return result.exitCode === 0;
 });
 
 const signalProcessEffect = Effect.fn('signalProcess')(function* (pid: number, signal: NodeJS.Signals) {
-  return yield* Effect.try({
-    try: () => {
-      try {
-        process.kill(pid, signal);
-        return true;
-      } catch (cause: unknown) {
-        if (isNodeError(cause) && cause.code === 'ESRCH') {
-          return false;
-        }
-        throw cause;
-      }
-    },
-    catch: cause => applicationError(`signal process ${pid}`, cause),
-  });
+  const system = yield* SystemInfo;
+  const result =
+    system.platform === 'win32'
+      ? yield* runCommandEffect(yield* windowsTaskkillExecutable(), ['/pid', String(pid), '/t'], {
+          allowFailure: true,
+          timeoutMs: 5000,
+        })
+      : yield* runCommandEffect('kill', [`-${signal.replace(/^SIG/, '')}`, String(pid)], {
+          allowFailure: true,
+          timeoutMs: 5000,
+        });
+  return result.exitCode === 0 || !(yield* isProcessRunningEffect(pid));
 });
 
-function isNodeError(value: unknown): value is NodeJS.ErrnoException {
-  return value instanceof Error && 'code' in value;
-}
-
-async function commandCheck(name: string, args: readonly string[]): Promise<DoctorCheck> {
-  const executable = await findExecutable([name]);
+const commandCheck = Effect.fn('lifecycle.commandCheck')(function* (name: string, args: readonly string[]) {
+  const executable = yield* findExecutable([name]);
   if (!executable) {
     return {name, status: 'fail', detail: 'missing from PATH'};
   }
-  const result = await runCommand(executable, args, {allowFailure: true});
+  const result = yield* runCommand(executable, args, {allowFailure: true});
   return {
     name,
     status: result.exitCode === 0 ? 'ok' : 'warn',
     detail: firstLine(result.stdout || result.stderr) || executable,
   };
-}
+});
 
-async function openVikingServerCheck(): Promise<DoctorCheck> {
+const openVikingServerCheck = Effect.fn('lifecycle.openVikingServerCheck')(function* () {
   const name = OPENVIKING_SERVER_COMMAND;
-  const executable = await findOpenVikingServer();
+  const executable = yield* findOpenVikingServer();
   if (!executable) {
     return {
       name,
@@ -1529,40 +1503,45 @@ async function openVikingServerCheck(): Promise<DoctorCheck> {
         'missing; run `threadnote install` to fetch it via uv or pipx (local-embed may compile from source on first install)',
     };
   }
-  const result = await runCommand(executable, ['--help'], {allowFailure: true});
-  const onPath = await findExecutable([OPENVIKING_SERVER_COMMAND]);
-  const detail = onPath ? executable : `${executable} (found outside PATH; add ${dirname(executable)} to PATH)`;
+  const result = yield* runCommand(executable, ['--help'], {allowFailure: true});
+  const onPath = yield* findExecutable([OPENVIKING_SERVER_COMMAND]);
+  const detail = onPath
+    ? executable
+    : `${executable} (found outside PATH; add ${yield* pathDirname(executable)} to PATH)`;
   return {
     name,
     status: result.exitCode === 0 ? 'ok' : 'warn',
     detail: result.exitCode === 0 ? detail : firstLine(result.stderr || result.stdout) || detail,
   };
-}
+});
 
-async function commandPresenceCheck(name: string, args: readonly string[]): Promise<DoctorCheck> {
-  const executable = await findExecutable([name]);
+const commandPresenceCheck = Effect.fn('lifecycle.commandPresenceCheck')(function* (
+  name: string,
+  args: readonly string[],
+) {
+  const executable = yield* findExecutable([name]);
   if (!executable) {
     return {name, status: 'warn', detail: 'missing; only needed for MCP install'};
   }
-  const result = await runCommand(executable, args, {allowFailure: true});
+  const result = yield* runCommand(executable, args, {allowFailure: true});
   return {
     name,
     status: 'ok',
     detail: firstLine(result.stdout || result.stderr) || executable,
   };
-}
+});
 
-async function firstCommandCheck(
+const firstCommandCheck = Effect.fn('lifecycle.firstCommandCheck')(function* (
   name: string,
   commands: readonly string[],
   args: readonly string[],
-): Promise<DoctorCheck> {
+) {
   for (const command of commands) {
-    const executable = await findExecutable([command]);
+    const executable = yield* findExecutable([command]);
     if (!executable) {
       continue;
     }
-    const result = await runCommand(executable, args, {allowFailure: true});
+    const result = yield* runCommand(executable, args, {allowFailure: true});
     return {
       name,
       status: result.exitCode === 0 ? 'ok' : 'warn',
@@ -1570,16 +1549,17 @@ async function firstCommandCheck(
     };
   }
   return {name, status: 'fail', detail: `none found: ${commands.join(', ')}`};
-}
+});
 
-async function pythonInstallerCheck(): Promise<DoctorCheck> {
+const pythonInstallerCheck = Effect.fn('lifecycle.pythonInstallerCheck')(function* () {
+  const system = yield* SystemInfo;
   const failures: string[] = [];
   for (const manager of ['uv', 'pipx']) {
-    const executable = await findExecutable([manager]);
+    const executable = yield* findExecutable([manager]);
     if (!executable) {
       continue;
     }
-    const result = await runCommand(executable, ['--version'], {allowFailure: true});
+    const result = yield* runCommand(executable, ['--version'], {allowFailure: true});
     if (result.exitCode === 0) {
       return {
         name: 'python installer',
@@ -1589,12 +1569,12 @@ async function pythonInstallerCheck(): Promise<DoctorCheck> {
     }
     failures.push(`${manager}: ${firstLine(result.stderr || result.stdout) || 'not working'}`);
   }
-  for (const python of pythonExecutableCandidates()) {
-    const executable = await findExecutable([python]);
+  for (const python of pythonExecutableCandidates(system.platform)) {
+    const executable = yield* findExecutable([python]);
     if (!executable) {
       continue;
     }
-    const result = await runCommand(executable, ['-m', 'pip', '--version'], {allowFailure: true});
+    const result = yield* runCommand(executable, ['-m', 'pip', '--version'], {allowFailure: true});
     if (result.exitCode === 0) {
       return {
         name: 'python installer',
@@ -1609,35 +1589,37 @@ async function pythonInstallerCheck(): Promise<DoctorCheck> {
     status: 'fail',
     detail: failures.length > 0 ? failures.join('; ') : 'none found: uv, pipx, or Python with pip',
   };
-}
+});
 
-async function openVikingCliCheck(): Promise<DoctorCheck> {
-  const executable = await findOpenVikingCli();
+const openVikingCliCheck = Effect.fn('lifecycle.openVikingCliCheck')(function* () {
+  const executable = yield* findOpenVikingCli();
   if (!executable) {
     return {name: 'openviking cli', status: 'fail', detail: 'none found: ov, openviking'};
   }
-  const result = await runCommand(executable, ['--help'], {allowFailure: true});
-  const onPath = await findExecutable(['ov', 'openviking']);
-  const detail = onPath ? executable : `${executable} (found outside PATH; add ${dirname(executable)} to PATH)`;
+  const result = yield* runCommand(executable, ['--help'], {allowFailure: true});
+  const onPath = yield* findExecutable(['ov', 'openviking']);
+  const detail = onPath
+    ? executable
+    : `${executable} (found outside PATH; add ${yield* pathDirname(executable)} to PATH)`;
   return {
     name: 'openviking cli',
     status: result.exitCode === 0 ? 'ok' : 'warn',
     detail: result.exitCode === 0 ? detail : firstLine(result.stderr || result.stdout) || detail,
   };
-}
+});
 
 /**
  * Warns when the installed OpenViking CLI is older than the version Threadnote
  * pins. `install`/`doctor` (unlike `repair`/`update`) don't upgrade OpenViking,
  * so without this a healthy-but-stale server silently stays behind the pin.
  */
-async function openVikingVersionCheck(config: RuntimeConfig): Promise<DoctorCheck> {
-  const executable = await findOpenVikingCli();
+const openVikingVersionCheck = Effect.fn('lifecycle.openVikingVersionCheck')(function* (config: RuntimeConfig) {
+  const executable = yield* findOpenVikingCli();
   const pinned = config.openVikingVersion;
   if (!executable) {
     return {name: 'openviking version', status: 'warn', detail: `CLI not found; pinned ${pinned}`};
   }
-  const installed = await readOpenVikingCliVersion(executable);
+  const installed = yield* readOpenVikingCliVersion(executable);
   if (!installed) {
     return {
       name: 'openviking version',
@@ -1653,7 +1635,7 @@ async function openVikingVersionCheck(config: RuntimeConfig): Promise<DoctorChec
     };
   }
   return {name: 'openviking version', status: 'ok', detail: `${installed} (pinned ${pinned})`};
-}
+});
 
 /**
  * Recall reads its hits from a JSON object with `memories`/`resources`/`skills`
@@ -1662,13 +1644,13 @@ async function openVikingVersionCheck(config: RuntimeConfig): Promise<DoctorChec
  * recall. This probe asserts the shape is intact — empty buckets are fine, only
  * a missing/renamed bucket structure (or non-JSON output) warns.
  */
-async function recallShapeCheck(config: RuntimeConfig): Promise<DoctorCheck> {
-  const executable = await findOpenVikingCli();
+const recallShapeCheck = Effect.fn('lifecycle.recallShapeCheck')(function* (config: RuntimeConfig) {
+  const executable = yield* findOpenVikingCli();
   if (!executable) {
     return {name: 'recall shape', status: 'warn', detail: 'CLI not found'};
   }
   const args = withIdentity(config, ['find', 'threadnote', '--node-limit', '1', '--output', 'json']);
-  const result = await runCommand(executable, args, {allowFailure: true});
+  const result = yield* runCommand(executable, args, {allowFailure: true});
   if (result.exitCode !== 0) {
     return {name: 'recall shape', status: 'warn', detail: 'search failed; run threadnote repair'};
   }
@@ -1678,13 +1660,8 @@ async function recallShapeCheck(config: RuntimeConfig): Promise<DoctorCheck> {
   // first line beginning with `{`, exactly as recall parsing does — otherwise
   // this probe false-warns on a perfectly healthy OpenViking.
   const start = result.stdout.search(/^\{/m);
-  let envelope: unknown;
-  try {
-    const parsed: unknown = start >= 0 ? JSON.parse(result.stdout.slice(start)) : undefined;
-    envelope = isJsonObject(parsed) ? parsed.result : undefined;
-  } catch {
-    envelope = undefined;
-  }
+  const parsed = start >= 0 ? Option.getOrUndefined(parseJson(result.stdout.slice(start))) : undefined;
+  const envelope = isJsonObject(parsed) ? parsed.result : undefined;
   const buckets = ['memories', 'resources', 'skills'];
   if (!isJsonObject(envelope) || !buckets.some(key => Array.isArray(envelope[key]))) {
     return {
@@ -1694,14 +1671,14 @@ async function recallShapeCheck(config: RuntimeConfig): Promise<DoctorCheck> {
     };
   }
   return {name: 'recall shape', status: 'ok', detail: 'memories/resources/skills buckets present'};
-}
+});
 
-async function localEmbeddingCheck(): Promise<DoctorCheck> {
-  const serverPath = await findOpenVikingServer();
+const localEmbeddingCheck = Effect.fn('lifecycle.localEmbeddingCheck')(function* () {
+  const serverPath = yield* findOpenVikingServer();
   if (!serverPath) {
     return {name: 'local embedding extra', status: 'warn', detail: 'openviking-server missing'};
   }
-  const hasDependency = await hasLocalEmbeddingDependency(serverPath);
+  const hasDependency = yield* hasLocalEmbeddingDependency(serverPath);
   if (hasDependency === undefined) {
     return {
       name: 'local embedding extra',
@@ -1716,14 +1693,14 @@ async function localEmbeddingCheck(): Promise<DoctorCheck> {
         status: 'warn',
         detail: 'llama_cpp missing; install will repair with openviking[local-embed]',
       };
-}
+});
 
-async function pythonSystemCertificatesCheck(): Promise<DoctorCheck> {
-  const serverPath = await findOpenVikingServer();
+const pythonSystemCertificatesCheck = Effect.fn('lifecycle.pythonSystemCertificatesCheck')(function* () {
+  const serverPath = yield* findOpenVikingServer();
   if (!serverPath) {
     return {name: 'python system certs', status: 'warn', detail: 'openviking-server missing'};
   }
-  const hasDependency = await hasPythonSystemCertificatesPatch(serverPath);
+  const hasDependency = yield* hasPythonSystemCertificatesPatch(serverPath);
   if (hasDependency === undefined) {
     return {name: 'python system certs', status: 'warn', detail: 'could not inspect tool Python'};
   }
@@ -1734,11 +1711,12 @@ async function pythonSystemCertificatesCheck(): Promise<DoctorCheck> {
         status: 'warn',
         detail: `${PYTHON_SYSTEM_CERTS_MODULE} missing; install will repair corporate TLS support`,
       };
-}
+});
 
-async function commandShimCheck(): Promise<DoctorCheck> {
-  if (!shouldManageCommandShim()) {
-    const launcher = await findExecutable(['threadnote']);
+const commandShimCheck = Effect.fn('lifecycle.commandShimCheck')(function* () {
+  const system = yield* SystemInfo;
+  if (!shouldManageCommandShim(system.platform)) {
+    const launcher = yield* findExecutable(['threadnote']);
     return launcher
       ? {name: 'threadnote launcher', status: 'ok', detail: launcher}
       : {
@@ -1747,8 +1725,11 @@ async function commandShimCheck(): Promise<DoctorCheck> {
           detail: 'npm threadnote.cmd launcher is not on PATH; repair preserves package-manager launchers',
         };
   }
-  const shimPath = join(expandPath(process.env.THREADNOTE_BIN_DIR ?? '~/.local/bin'), 'threadnote');
-  const content = await readFileIfExists(shimPath);
+  const shimPath = yield* pathJoin(
+    yield* expandPath(system.environment().THREADNOTE_BIN_DIR ?? '~/.local/bin'),
+    'threadnote',
+  );
+  const content = yield* readFileIfExists(shimPath);
   if (content === undefined) {
     return {name: 'threadnote shim', status: 'warn', detail: `${shimPath} missing; repair will create it`};
   }
@@ -1759,7 +1740,7 @@ async function commandShimCheck(): Promise<DoctorCheck> {
       detail: `${shimPath} exists but was not generated by this tool; repair will not overwrite it`,
     };
   }
-  if (content !== renderCommandShim()) {
+  if (content !== (yield* renderCommandShim())) {
     return {
       name: 'threadnote shim',
       status: 'warn',
@@ -1767,101 +1748,113 @@ async function commandShimCheck(): Promise<DoctorCheck> {
     };
   }
   return {name: 'threadnote shim', status: 'ok', detail: shimPath};
-}
+});
 
-async function userAgentInstructionsChecks(): Promise<DoctorCheck[]> {
-  return Promise.all(
-    USER_AGENT_INSTRUCTION_TARGETS.map(async target => {
-      const expectedInstructions = await renderUserAgentInstructions(target);
-      const targetPath = expandPath(target.path);
-      const content = await readFileIfExists(targetPath);
-      if (content === undefined) {
-        return {name: target.label, status: 'warn', detail: `${targetPath} missing; install will create it`};
-      }
-      const existingBlock = extractManagedBlock(content);
-      if (existingBlock === undefined) {
-        return {
-          name: target.label,
-          status: 'warn',
-          detail: `${targetPath} missing threadnote block; install will add it`,
-        };
-      }
-      if (
-        (target.kind === 'file' && content !== expectedInstructions) ||
-        (target.kind === 'block' && existingBlock !== expectedInstructions)
-      ) {
-        return {
-          name: target.label,
-          status: 'warn',
-          detail: `${targetPath} has stale threadnote block; install will update it`,
-        };
-      }
-      return {name: target.label, status: 'ok', detail: targetPath};
-    }),
+const userAgentInstructionsChecks = Effect.fn('lifecycle.userAgentInstructionsChecks')(function* () {
+  return yield* Effect.forEach(
+    USER_AGENT_INSTRUCTION_TARGETS,
+    target =>
+      Effect.gen(function* () {
+        const expectedInstructions = yield* renderUserAgentInstructions(target);
+        const targetPath = yield* expandPath(target.path);
+        const content = yield* readFileIfExists(targetPath);
+        if (content === undefined) {
+          return {name: target.label, status: 'warn', detail: `${targetPath} missing; install will create it`};
+        }
+        const existingBlock = extractManagedBlock(content);
+        if (existingBlock === undefined) {
+          return {
+            name: target.label,
+            status: 'warn',
+            detail: `${targetPath} missing threadnote block; install will add it`,
+          };
+        }
+        if (
+          (target.kind === 'file' && content !== expectedInstructions) ||
+          (target.kind === 'block' && existingBlock !== expectedInstructions)
+        ) {
+          return {
+            name: target.label,
+            status: 'warn',
+            detail: `${targetPath} has stale threadnote block; install will update it`,
+          };
+        }
+        return {name: target.label, status: 'ok', detail: targetPath};
+      }),
+    {concurrency: 'unbounded'},
   );
-}
+});
 
-async function hasLocalEmbeddingDependency(serverPath: string): Promise<boolean | undefined> {
-  return hasPythonModule(serverPath, 'llama_cpp');
-}
+const hasLocalEmbeddingDependency = Effect.fn('lifecycle.hasLocalEmbeddingDependency')(function* (serverPath: string) {
+  return yield* hasPythonModule(serverPath, 'llama_cpp');
+});
 
-async function hasPythonSystemCertificatesPatch(serverPath: string): Promise<boolean | undefined> {
-  return hasPythonModule(serverPath, PYTHON_SYSTEM_CERTS_MODULE);
-}
+const hasPythonSystemCertificatesPatch = Effect.fn('lifecycle.hasPythonSystemCertificatesPatch')(function* (
+  serverPath: string,
+) {
+  return yield* hasPythonModule(serverPath, PYTHON_SYSTEM_CERTS_MODULE);
+});
 
-async function hasPythonModule(serverPath: string, moduleName: string): Promise<boolean | undefined> {
-  const pythonPath = await siblingPythonForExecutable(serverPath);
+const hasPythonModule = Effect.fn('lifecycle.hasPythonModule')(function* (serverPath: string, moduleName: string) {
+  const pythonPath = yield* siblingPythonForExecutable(serverPath);
   if (!pythonPath) {
     return undefined;
   }
-  const result = await runCommand(pythonPath, ['-c', `import ${moduleName}`], {allowFailure: true});
+  const result = yield* runCommand(pythonPath, ['-c', `import ${moduleName}`], {allowFailure: true});
   return result.exitCode === 0;
-}
+});
 
-async function siblingPythonForExecutable(executablePath: string): Promise<string | undefined> {
-  let resolvedPath: string;
-  try {
-    resolvedPath = await realpath(executablePath);
-  } catch (_err: unknown) {
+const siblingPythonForExecutable = Effect.fn('lifecycle.siblingPythonForExecutable')(function* (
+  executablePath: string,
+) {
+  const system = yield* SystemInfo;
+  const resolvedPath = yield* realpath(executablePath).pipe(Effect.option);
+  if (Option.isNone(resolvedPath)) {
     return undefined;
   }
-  const names = process.platform === 'win32' ? ['python.exe', 'python'] : ['python'];
+  const names = system.platform === 'win32' ? ['python.exe', 'python'] : ['python'];
   for (const name of names) {
-    const pythonPath = join(dirname(resolvedPath), name);
-    if (await exists(pythonPath)) {
+    const pythonPath = yield* pathJoin(yield* pathDirname(resolvedPath.value), name);
+    if (yield* exists(pythonPath)) {
       return pythonPath;
     }
   }
   return undefined;
-}
+});
 
-async function manifestCheck(path: string): Promise<DoctorCheck> {
-  try {
-    const manifest = await readSeedManifest(path);
-    return {name: 'manifest', status: 'ok', detail: `${path} (${manifest.projects.length} project(s))`};
-  } catch (err: unknown) {
-    return {name: 'manifest', status: 'fail', detail: errorMessage(err)};
-  }
-}
+const manifestCheck = Effect.fn('lifecycle.manifestCheck')((path: string) =>
+  readSeedManifest(path).pipe(
+    Effect.map(manifest => ({
+      name: 'manifest',
+      status: 'ok' as const,
+      detail: `${path} (${manifest.projects.length} project(s))`,
+    })),
+    Effect.catch(error => Effect.succeed({name: 'manifest', status: 'fail' as const, detail: errorMessage(error)})),
+  ),
+);
 
-async function recallIndexFreshnessCheck(config: RuntimeConfig): Promise<DoctorCheck> {
-  try {
-    if (await summaryAutoGenerationDisabled(config)) {
+const recallIndexFreshnessCheck = Effect.fn('lifecycle.recallIndexFreshnessCheck')((config: RuntimeConfig) =>
+  Effect.gen(function* () {
+    if (yield* summaryAutoGenerationDisabled(config)) {
       return {
         name: 'recall index freshness',
-        status: 'ok',
+        status: 'ok' as const,
         detail:
           'OpenViking L0/L1 summary auto-generation disabled in ov.conf; ' +
           'directory summary placeholders are expected and not reindexed',
       };
     }
-    const targets = await findStaleRecallIndexTargets(config, {
+    const targets = yield* findStaleRecallIndexTargets(config, {
       collapseToRoots: true,
       includeAgentSkills: true,
       includeManifestResources: true,
     });
     if (targets.length === 0) {
-      return {name: 'recall index freshness', status: 'ok', detail: 'no stale generated summaries found'};
+      return {
+        name: 'recall index freshness',
+        status: 'ok' as const,
+        detail: 'no stale generated summaries found',
+      };
     }
     const staleSummaryCount = targets.reduce((total, target) => total + target.staleCount, 0);
     const sampleUris = targets.slice(0, 3).map(target => target.uri);
@@ -1869,13 +1862,19 @@ async function recallIndexFreshnessCheck(config: RuntimeConfig): Promise<DoctorC
     const sample = `${sampleUris.join(', ')}${extraCount > 0 ? `, +${extraCount} more` : ''}`;
     return {
       name: 'recall index freshness',
-      status: 'warn',
+      status: 'warn' as const,
       detail: `${staleSummaryCount} stale generated summary file(s) under ${targets.length} scope(s); run repair to reindex ${sample}`,
     };
-  } catch (err: unknown) {
-    return {name: 'recall index freshness', status: 'warn', detail: errorMessage(err)};
-  }
-}
+  }).pipe(
+    Effect.catch(error =>
+      Effect.succeed({
+        name: 'recall index freshness',
+        status: 'warn' as const,
+        detail: errorMessage(error),
+      }),
+    ),
+  ),
+);
 
 /**
  * Flag memories whose frontmatter `project` disagrees with the project segment
@@ -1885,9 +1884,11 @@ async function recallIndexFreshnessCheck(config: RuntimeConfig): Promise<DoctorC
  * walks the on-disk memories tree and reports; the fix is to re-store the memory
  * under the correct project (which relocates the file).
  */
-export async function memoryProjectConsistencyCheck(config: RuntimeConfig): Promise<DoctorCheck> {
+export const memoryProjectConsistencyCheck = Effect.fn('lifecycle.memoryProjectConsistencyCheck')(function* (
+  config: RuntimeConfig,
+) {
   const name = 'memory project consistency';
-  const memoriesRoot = join(
+  const memoriesRoot = yield* pathJoin(
     config.agentContextHome,
     'data',
     'viking',
@@ -1896,103 +1897,106 @@ export async function memoryProjectConsistencyCheck(config: RuntimeConfig): Prom
     uriSegment(config.user),
     'memories',
   );
-  try {
-    let entries: string[];
-    try {
-      entries = await readdir(memoriesRoot, {recursive: true});
-    } catch {
-      return {name, status: 'ok', detail: 'no memories directory yet'};
+  return yield* Effect.gen(function* () {
+    const entriesResult = yield* Effect.result(readdir(memoriesRoot, {recursive: true}));
+    if (Result.isFailure(entriesResult)) {
+      return {name, status: 'ok' as const, detail: 'no memories directory yet'};
     }
+    const entries = entriesResult.success;
     const mismatches: string[] = [];
     let checked = 0;
     for (const entry of entries) {
       if (!entry.endsWith('.md') || isSummarySidecarUri(entry)) {
         continue;
       }
-      const uri = `viking://user/${uriSegment(config.user)}/memories/${entry.split(sep).join('/')}`;
+      const uri = `viking://user/${uriSegment(config.user)}/memories/${entry.split(yield* pathSeparator).join('/')}`;
       const pathProject = memoryUriProjectSegment(uri);
       if (!pathProject) {
         continue;
       }
-      let content: string;
-      try {
-        content = await readFile(join(memoriesRoot, entry), 'utf8');
-      } catch {
+      const content = yield* readFile(yield* pathJoin(memoriesRoot, entry), 'utf8').pipe(Effect.option);
+      if (Option.isNone(content)) {
         // Removed mid-walk (concurrent forget/compact/archive) or transiently
         // unreadable — skip this file rather than aborting the whole check.
         continue;
       }
       checked += 1;
-      const frontProject = memoryFrontmatterField(content, 'project');
+      const frontProject = memoryFrontmatterField(content.value, 'project');
       if (frontProject && uriSegment(frontProject) !== pathProject) {
         mismatches.push(`${uri} (frontmatter "${frontProject}" vs path "${pathProject}")`);
       }
     }
     if (mismatches.length === 0) {
-      return {name, status: 'ok', detail: `${checked} project-scoped memories consistent`};
+      return {name, status: 'ok' as const, detail: `${checked} project-scoped memories consistent`};
     }
     const sample = mismatches.slice(0, 3).join('; ');
     const extra = Math.max(0, mismatches.length - 3);
     return {
       name,
-      status: 'warn',
+      status: 'warn' as const,
       detail:
         `${mismatches.length} memory(ies) whose frontmatter project differs from their storage path; ` +
         `re-store under the correct project to fix: ${sample}${extra > 0 ? `, +${extra} more` : ''}`,
     };
-  } catch (err: unknown) {
-    return {name, status: 'warn', detail: errorMessage(err)};
-  }
-}
+  }).pipe(Effect.catch(error => Effect.succeed({name, status: 'warn' as const, detail: errorMessage(error)})));
+});
 
-async function fileCheck(path: string, label: string): Promise<DoctorCheck> {
-  return (await exists(path))
+const fileCheck = Effect.fn('lifecycle.fileCheck')(function* (path: string, label: string) {
+  return (yield* exists(path))
     ? {name: label, status: 'ok', detail: path}
     : {name: label, status: 'fail', detail: `${path} missing`};
-}
+});
 
-async function healthCheck(config: RuntimeConfig): Promise<DoctorCheck> {
-  try {
-    const body = await readOpenVikingHealth(config, 1200);
-    return {name: 'openviking health', status: 'ok', detail: firstLine(body) || 'healthy'};
-  } catch (err: unknown) {
-    return {name: 'openviking health', status: 'warn', detail: errorMessage(err)};
-  }
-}
+const healthCheck = Effect.fn('lifecycle.healthCheck')((config: RuntimeConfig) =>
+  readOpenVikingHealth(config, 1200).pipe(
+    Effect.map(body => ({
+      name: 'openviking health',
+      status: 'ok' as const,
+      detail: firstLine(body) || 'healthy',
+    })),
+    Effect.catch(error =>
+      Effect.succeed({
+        name: 'openviking health',
+        status: 'warn' as const,
+        detail: errorMessage(error),
+      }),
+    ),
+  ),
+);
 
-async function readOpenVikingHealth(config: RuntimeConfig, timeoutMs: number): Promise<string> {
-  return httpGetText(openVikingHealthUrl(config), timeoutMs);
-}
+const readOpenVikingHealth = Effect.fn('lifecycle.readOpenVikingHealth')(function* (
+  config: RuntimeConfig,
+  timeoutMs: number,
+) {
+  return yield* httpGetText(openVikingHealthUrl(config), timeoutMs);
+});
 
-async function readOpenVikingHealthIfAvailable(config: RuntimeConfig, timeoutMs: number): Promise<string | undefined> {
-  try {
-    return await readOpenVikingHealth(config, timeoutMs);
-  } catch (_err: unknown) {
-    return undefined;
-  }
-}
+const readOpenVikingHealthIfAvailable = Effect.fn('lifecycle.readOpenVikingHealthIfAvailable')(function* (
+  config: RuntimeConfig,
+  timeoutMs: number,
+) {
+  return yield* readOpenVikingHealth(config, timeoutMs).pipe(Effect.catch(() => Effect.succeed(undefined)));
+});
 
-async function waitForOpenVikingHealth(
+const waitForOpenVikingHealth = Effect.fn('lifecycle.waitForOpenVikingHealth')(function* (
   config: RuntimeConfig,
   timeoutMs: number,
   progressMessage?: string,
-): Promise<string | undefined> {
-  const progress = progressMessage ? startProgress(progressMessage) : undefined;
-  try {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() <= deadline) {
-      const requestTimeoutMs = Math.max(100, Math.min(1000, deadline - Date.now()));
-      const health = await readOpenVikingHealthIfAvailable(config, requestTimeoutMs);
+) {
+  const progress = progressMessage ? yield* startProgress(progressMessage) : undefined;
+  return yield* Effect.gen(function* () {
+    const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+    while ((yield* Clock.currentTimeMillis) <= deadline) {
+      const requestTimeoutMs = Math.max(100, Math.min(1000, deadline - (yield* Clock.currentTimeMillis)));
+      const health = yield* readOpenVikingHealthIfAvailable(config, requestTimeoutMs);
       if (health) return health;
-      const remainingMs = deadline - Date.now();
+      const remainingMs = deadline - (yield* Clock.currentTimeMillis);
       if (remainingMs <= 0) break;
-      await sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
+      yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
     }
     return undefined;
-  } finally {
-    progress?.stop();
-  }
-}
+  }).pipe(Effect.ensuring(progress ? progress.stop().pipe(Effect.ignore) : Effect.void));
+});
 
 const runInstallCommands = Effect.fn('runInstallCommands')(function* (
   config: RuntimeConfig,
@@ -2000,38 +2004,37 @@ const runInstallCommands = Effect.fn('runInstallCommands')(function* (
   force: boolean,
   dryRun: boolean,
 ) {
+  const system = yield* SystemInfo;
   // When the user didn't ask for a specific manager and detection fell back
   // to plain `pip`, offer to install `uv` first — `pip install --user` is
   // refused under PEP 668 on Homebrew / system-managed Python, which is most
   // macOS and modern Linux setups.
   let manager = preferred;
   if (manager === undefined && !dryRun) {
-    const detected = yield* fromPromise('detect OpenViking package manager', detectPackageManager);
-    if (detected === 'pip' && (yield* fromPromise('offer to install uv', offerToInstallUv))) {
-      const rediscovered = yield* fromPromise('rediscover OpenViking package manager', detectPackageManager);
+    const detected = yield* detectPackageManager();
+    if (detected === 'pip' && (yield* offerToInstallUv())) {
+      const rediscovered = yield* detectPackageManager();
       if (rediscovered === 'uv') {
         manager = 'uv';
       }
     }
   }
-  const installCommands = yield* fromPromise('build OpenViking install commands', () =>
-    getInstallCommands(config, manager, force),
-  );
+  const installCommands = yield* getInstallCommands(config, manager, force);
   for (const installCommand of installCommands) {
     if (dryRun) {
       yield* maybeRunEffect(true, installCommand.executable, installCommand.args);
       continue;
     }
-    const resolvedInstallCommand = yield* fromPromise('resolve OpenViking install command', () =>
-      resolveOpenVikingInstallCommand(installCommand),
-    );
+    const resolvedInstallCommand = yield* resolveOpenVikingInstallCommand(installCommand);
     // Stream live instead of buffering through runCommand. openviking[local-embed]
     // can compile llama-cpp-python from source (10-20 min, memory-heavy); buffering
     // hides all progress and the 10-minute command timeout would SIGKILL a
     // legitimate build. Because uv/pipx --force removes the existing tool env
     // first, a killed reinstall leaves openviking-server missing — so we also
     // print recovery guidance before failing.
-    consoleOutput.log(`Running: ${formatShellCommand(resolvedInstallCommand.executable, resolvedInstallCommand.args)}`);
+    yield* Console.log(
+      `Running: ${formatShellCommand(resolvedInstallCommand.executable, resolvedInstallCommand.args)}`,
+    );
     const result = yield* runStreamingCommandEffect(resolvedInstallCommand.executable, resolvedInstallCommand.args, {
       maxOutputChars: INSTALL_OUTPUT_TAIL_CHARS,
     });
@@ -2039,26 +2042,26 @@ const runInstallCommands = Effect.fn('runInstallCommands')(function* (
       const commandOutput = `${result.stderr}\n${result.stdout}`;
       const retry = openVikingSourceBuildRetryForArchiveFailure(resolvedInstallCommand, commandOutput);
       if (retry) {
-        consoleOutput.error('');
-        consoleOutput.error(
+        yield* Console.error('');
+        yield* Console.error(
           'The prebuilt llama-cpp-python wheel failed ZIP archive validation; retrying with a local source build.',
         );
-        consoleOutput.error('This avoids the rejected wheel and can take 10-20 minutes.');
-        consoleOutput.log(`Running: ${formatInstallCommand(retry.command, retry.env)}`);
+        yield* Console.error('This avoids the rejected wheel and can take 10-20 minutes.');
+        yield* Console.log(`Running: ${formatInstallCommand(retry.command, retry.env)}`);
         const retryResult = yield* runStreamingCommandEffect(retry.command.executable, retry.command.args, {
-          env: {...process.env, ...retry.env},
+          env: {...system.environment(), ...retry.env},
           maxOutputChars: INSTALL_OUTPUT_TAIL_CHARS,
         });
         if (retryResult.exitCode === 0) {
           continue;
         }
-        printOpenVikingInstallFailureHelp(retry.command, `${retryResult.stderr}\n${retryResult.stdout}`);
+        yield* printOpenVikingInstallFailureHelp(retry.command, `${retryResult.stderr}\n${retryResult.stdout}`);
         throw new Error(
           `${formatInstallCommand(retry.command, retry.env)} exited with ${retryResult.exitCode} after automatic source-build retry.`,
         );
       }
 
-      printOpenVikingInstallFailureHelp(resolvedInstallCommand, commandOutput);
+      yield* printOpenVikingInstallFailureHelp(resolvedInstallCommand, commandOutput);
       throw new Error(
         `${formatShellCommand(resolvedInstallCommand.executable, resolvedInstallCommand.args)} exited with ${result.exitCode}.`,
       );
@@ -2066,11 +2069,14 @@ const runInstallCommands = Effect.fn('runInstallCommands')(function* (
   }
 });
 
-function printOpenVikingInstallFailureHelp(failedCommand: MappedCommand, commandOutput: string): void {
+const printOpenVikingInstallFailureHelp = Effect.fn('lifecycle.printOpenVikingInstallFailureHelp')(function* (
+  failedCommand: MappedCommand,
+  commandOutput: string,
+) {
   for (const line of openVikingInstallFailureHelpLines(failedCommand, commandOutput)) {
-    consoleOutput.error(line);
+    yield* Console.error(line);
   }
-}
+});
 
 export function openVikingInstallFailureHelpLines(failedCommand: MappedCommand, commandOutput = ''): readonly string[] {
   if (isLlamaWheelArchiveExtractionFailure(commandOutput)) {
@@ -2176,136 +2182,134 @@ function extraIndexUrl(command: MappedCommand): string | undefined {
   return undefined;
 }
 
-async function offerToInstallUv(): Promise<boolean> {
-  if (processStdin.isTTY !== true || processStdout.isTTY !== true) {
-    if (process.platform === 'win32') {
-      consoleOutput.warn(
+const offerToInstallUv = Effect.fn('lifecycle.offerToInstallUv')(function* () {
+  const system = yield* SystemInfo;
+  if (!system.stdinIsTTY || !system.stdoutIsTTY) {
+    if (system.platform === 'win32') {
+      yield* Console.warn(
         'Neither uv nor pipx was found on PATH. Falling back to Python pip. ' +
           'Install uv with `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"` ' +
           'and re-run with --package-manager uv for an isolated OpenViking environment.',
       );
       return false;
     }
-    consoleOutput.warn(
+    yield* Console.warn(
       'Neither uv nor pipx was found on PATH. Falling back to `python3 -m pip install --user`, which fails on PEP 668 (Homebrew/system) Python.\n' +
         'Re-run with --package-manager uv after installing uv (brew install uv), or pass --package-manager pipx.',
     );
     return false;
   }
-  const readline = createInterface({input: processStdin, output: processStdout});
-  let answer: string;
-  try {
-    answer = (
-      await readline.question(
-        'OpenViking installs into Python; neither uv nor pipx is on PATH so threadnote would fall back to `pip install --user`, which fails on PEP 668 setups.\nInstall uv now? [Y/n] ',
-      )
-    )
-      .trim()
-      .toLowerCase();
-  } finally {
-    readline.close();
-  }
+  const terminal = yield* Terminal.Terminal;
+  yield* terminal.display(
+    'OpenViking installs into Python; neither uv nor pipx is on PATH so threadnote would fall back to `pip install --user`, which fails on PEP 668 setups.\nInstall uv now? [Y/n] ',
+  );
+  const answer = (yield* terminal.readLine).trim().toLowerCase();
   if (answer === 'n' || answer === 'no') {
-    consoleOutput.log(
+    yield* Console.log(
       'Continuing with `python3 -m pip install --user`. You may hit PEP 668 errors on managed Pythons.',
     );
     return false;
   }
-  return await installUv();
-}
+  return yield* installUv();
+});
 
-async function installUv(): Promise<boolean> {
-  if (process.platform === 'win32') {
-    const powershell = await findExecutable(['powershell', 'pwsh']);
+const installUv = Effect.fn('lifecycle.installUv')(function* () {
+  const system = yield* SystemInfo;
+  if (system.platform === 'win32') {
+    const powershell = yield* findExecutable(['powershell', 'pwsh']);
     if (!powershell) {
-      consoleOutput.warn('Could not install uv automatically because PowerShell was not found.');
+      yield* Console.warn('Could not install uv automatically because PowerShell was not found.');
       return false;
     }
-    consoleOutput.log('Installing uv via the official PowerShell installer...');
-    const result = await runCommand(
+    yield* Console.log('Installing uv via the official PowerShell installer...');
+    const result = yield* runCommand(
       powershell,
       ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', 'irm https://astral.sh/uv/install.ps1 | iex'],
       {allowFailure: true},
     );
     if (result.exitCode === 0) {
-      process.env.PATH = [join(expandPath('~'), '.local', 'bin'), process.env.PATH ?? ''].join(delimiter);
-      if (await findExecutable(['uv'])) {
-        candidateDirsPromise = undefined;
+      const localBin = yield* pathJoin(yield* expandPath('~'), '.local', 'bin');
+      system.setEnvironmentVariable('PATH', [localBin, system.environment().PATH ?? ''].join(system.pathDelimiter));
+      if (yield* findExecutable(['uv'])) {
+        candidateDirsCache = undefined;
         return true;
       }
     }
-    consoleOutput.warn('uv installation did not produce an executable on PATH. Open a new PowerShell and retry.');
+    yield* Console.warn('uv installation did not produce an executable on PATH. Open a new PowerShell and retry.');
     return false;
   }
-  const brew = await findExecutable(['brew']);
+  const brew = yield* findExecutable(['brew']);
   if (brew) {
-    consoleOutput.log('Installing uv via Homebrew...');
-    const result = await runCommand(brew, ['install', 'uv'], {allowFailure: true});
+    yield* Console.log('Installing uv via Homebrew...');
+    const result = yield* runCommand(brew, ['install', 'uv'], {allowFailure: true});
     if (result.exitCode === 0) {
       if (result.stdout.trim()) {
-        consoleOutput.log(result.stdout.trim());
+        yield* Console.log(result.stdout.trim());
       }
-      if (await findExecutable(['uv'])) {
+      if (yield* findExecutable(['uv'])) {
         // Drop the candidate-dirs cache so subsequent openviking-server
         // resolutions can query `uv tool dir --bin` now that uv is on PATH.
-        candidateDirsPromise = undefined;
+        candidateDirsCache = undefined;
         return true;
       }
     } else {
-      consoleOutput.warn(`brew install uv failed: ${(result.stderr || result.stdout).trim()}`);
+      yield* Console.warn(`brew install uv failed: ${(result.stderr || result.stdout).trim()}`);
     }
   }
   // Fall back to the official install script. Requires curl + sh; honors any
   // proxy env vars the user already has.
-  if ((await findExecutable(['curl'])) && (await findExecutable(['sh']))) {
-    consoleOutput.log(
+  if ((yield* findExecutable(['curl'])) && (yield* findExecutable(['sh']))) {
+    yield* Console.log(
       'Installing uv via the official install script (curl -LsSf https://astral.sh/uv/install.sh | sh)...',
     );
-    const result = await runCommand('sh', ['-c', 'curl -LsSf https://astral.sh/uv/install.sh | sh'], {
+    const result = yield* runCommand('sh', ['-c', 'curl -LsSf https://astral.sh/uv/install.sh | sh'], {
       allowFailure: true,
     });
     if (result.exitCode === 0) {
       if (result.stdout.trim()) {
-        consoleOutput.log(result.stdout.trim());
+        yield* Console.log(result.stdout.trim());
       }
-      if (await findExecutable(['uv'])) {
-        candidateDirsPromise = undefined;
+      if (yield* findExecutable(['uv'])) {
+        candidateDirsCache = undefined;
         return true;
       }
-      consoleOutput.warn(
+      yield* Console.warn(
         'uv installed, but the new binary is not yet on this shell PATH. Open a new shell (or `source ~/.zshrc` / `source ~/.bashrc`) and re-run `threadnote install`.',
       );
       return false;
     }
-    consoleOutput.warn(`uv install script failed: ${(result.stderr || result.stdout).trim()}`);
+    yield* Console.warn(`uv install script failed: ${(result.stderr || result.stdout).trim()}`);
   }
-  consoleOutput.warn(
+  yield* Console.warn(
     'Could not install uv automatically. Install it manually (brew install uv) and re-run threadnote install.',
   );
   return false;
-}
+});
 
-async function uvExecutables(): Promise<readonly UvExecutable[]> {
-  const executables = await findExecutableCandidates(['uv']);
-  return await Promise.all(
-    executables.map(async executable => {
-      const result = await runCommand(executable, ['--version'], {allowFailure: true, timeoutMs: 5000});
-      const match = `${result.stdout}\n${result.stderr}`.match(/\buv\s+v?(\d+(?:\.\d+){1,2})\b/i);
-      return {executable, version: match?.[1]};
-    }),
+const uvExecutables = Effect.fn('lifecycle.uvExecutables')(function* () {
+  const executables = yield* findExecutableCandidates(['uv']);
+  return yield* Effect.forEach(
+    executables,
+    executable =>
+      Effect.gen(function* () {
+        const result = yield* runCommand(executable, ['--version'], {allowFailure: true, timeoutMs: 5000});
+        const match = `${result.stdout}\n${result.stderr}`.match(/\buv\s+v?(\d+(?:\.\d+){1,2})\b/i);
+        return {executable, version: match?.[1]};
+      }),
+    {concurrency: 'unbounded'},
   );
-}
+});
 
-export async function findSupportedUvExecutable(): Promise<string | undefined> {
-  const candidates = await uvExecutables();
+export const findSupportedUvExecutable = Effect.fn('lifecycle.findSupportedUvExecutable')(function* () {
+  const candidates = yield* uvExecutables();
   return candidates.find(
     candidate =>
       candidate.version !== undefined && compareVersions(candidate.version, MINIMUM_UV_SYSTEM_CERTS_VERSION) >= 0,
   )?.executable;
-}
+});
 
-export async function ensureSupportedUvExecutable(): Promise<string | undefined> {
-  const candidates = await uvExecutables();
+export const ensureSupportedUvExecutable = Effect.fn('lifecycle.ensureSupportedUvExecutable')(function* () {
+  const candidates = yield* uvExecutables();
   const supported = candidates.find(
     candidate =>
       candidate.version !== undefined && compareVersions(candidate.version, MINIMUM_UV_SYSTEM_CERTS_VERSION) >= 0,
@@ -2317,22 +2321,22 @@ export async function ensureSupportedUvExecutable(): Promise<string | undefined>
     return undefined;
   }
 
-  consoleOutput.log(`Updating uv to ${MINIMUM_UV_SYSTEM_CERTS_VERSION} or newer for system certificate support.`);
+  yield* Console.log(`Updating uv to ${MINIMUM_UV_SYSTEM_CERTS_VERSION} or newer for system certificate support.`);
   for (const candidate of candidates) {
-    const result = await runCommand(candidate.executable, ['self', 'update'], {allowFailure: true});
+    const result = yield* runCommand(candidate.executable, ['self', 'update'], {allowFailure: true});
     if (result.exitCode === 0) {
-      const updated = await findSupportedUvExecutable();
+      const updated = yield* findSupportedUvExecutable();
       if (updated) {
         return updated;
       }
     }
   }
 
-  const brew = await findExecutable(['brew']);
+  const brew = yield* findExecutable(['brew']);
   if (brew) {
-    const result = await runCommand(brew, ['upgrade', 'uv'], {allowFailure: true});
+    const result = yield* runCommand(brew, ['upgrade', 'uv'], {allowFailure: true});
     if (result.exitCode === 0) {
-      const updated = await findSupportedUvExecutable();
+      const updated = yield* findSupportedUvExecutable();
       if (updated) {
         return updated;
       }
@@ -2347,40 +2351,44 @@ export async function ensureSupportedUvExecutable(): Promise<string | undefined>
       `Found ${found}; automatic update did not produce a compatible uv. ` +
       'Run `uv self update` (standalone install) or `brew upgrade uv`, then re-run `threadnote update`.',
   );
-}
+});
 
-function isUvExecutable(executable: string): boolean {
-  const name = basename(executable).toLowerCase();
+const isUvExecutable = Effect.fn('lifecycle.isUvExecutable')(function* (executable: string) {
+  const name = (yield* pathBasename(executable)).toLowerCase();
   return name === 'uv' || name === 'uv.exe';
-}
+});
 
-export async function resolveOpenVikingInstallCommand(command: MappedCommand): Promise<MappedCommand> {
-  if (!isUvExecutable(command.executable)) {
+export const resolveOpenVikingInstallCommand = Effect.fn('lifecycle.resolveOpenVikingInstallCommand')(function* (
+  command: MappedCommand,
+) {
+  if (!(yield* isUvExecutable(command.executable))) {
     return command;
   }
-  const uv = await ensureSupportedUvExecutable();
+  const uv = yield* ensureSupportedUvExecutable();
   if (!uv) {
     throw new Error(
       `uv was selected to install OpenViking but was not found on PATH. Install uv ${MINIMUM_UV_SYSTEM_CERTS_VERSION} or newer and re-run Threadnote.`,
     );
   }
   return {...command, executable: uv};
-}
+});
 
-async function getPythonSystemCertificatesInstallCommand(serverPath: string): Promise<MappedCommand> {
-  const pythonPath = await siblingPythonForExecutable(serverPath);
-  if (!pythonPath) {
-    throw new Error(`Could not find the OpenViking Python environment for ${serverPath}`);
-  }
-  const uvPath = await ensureSupportedUvExecutable();
-  if (uvPath) {
-    return {
-      executable: uvPath,
-      args: ['pip', 'install', '--system-certs', '--python', pythonPath, PYTHON_SYSTEM_CERTS_PACKAGE],
-    };
-  }
-  return {executable: pythonPath, args: ['-m', 'pip', 'install', PYTHON_SYSTEM_CERTS_PACKAGE]};
-}
+const getPythonSystemCertificatesInstallCommand = Effect.fn('lifecycle.getPythonSystemCertificatesInstallCommand')(
+  function* (serverPath: string) {
+    const pythonPath = yield* siblingPythonForExecutable(serverPath);
+    if (!pythonPath) {
+      throw new Error(`Could not find the OpenViking Python environment for ${serverPath}`);
+    }
+    const uvPath = yield* ensureSupportedUvExecutable();
+    if (uvPath) {
+      return {
+        executable: uvPath,
+        args: ['pip', 'install', '--system-certs', '--python', pythonPath, PYTHON_SYSTEM_CERTS_PACKAGE],
+      };
+    }
+    return {executable: pythonPath, args: ['-m', 'pip', 'install', PYTHON_SYSTEM_CERTS_PACKAGE]};
+  },
+);
 
 /**
  * Prebuilt llama-cpp-python wheel index for openviking[local-embed]. PyPI ships
@@ -2390,14 +2398,15 @@ async function getPythonSystemCertificatesInstallCommand(serverPath: string): Pr
  * to disable it, e.g. air-gapped) can override via THREADNOTE_LLAMA_WHEEL_INDEX;
  * setting it empty turns the extra index off and restores a from-source build.
  */
-export function localEmbedWheelIndexUrl(): string | undefined {
-  const override = process.env.THREADNOTE_LLAMA_WHEEL_INDEX;
+export const localEmbedWheelIndexUrl = Effect.fn('lifecycle.localEmbedWheelIndexUrl')(function* () {
+  const system = yield* SystemInfo;
+  const override = system.environment().THREADNOTE_LLAMA_WHEEL_INDEX;
   if (override !== undefined) {
     return override.trim() === '' ? undefined : override.trim();
   }
   const base = 'https://abetlen.github.io/llama-cpp-python/whl';
-  return process.platform === 'darwin' ? `${base}/metal` : `${base}/cpu`;
-}
+  return system.platform === 'darwin' ? `${base}/metal` : `${base}/cpu`;
+});
 
 /**
  * CPython version the uv-managed OpenViking tool is pinned to, so local-embed
@@ -2407,22 +2416,23 @@ export function localEmbedWheelIndexUrl(): string | undefined {
  * default interpreter — useful in locked or offline environments where a managed
  * CPython cannot be fetched.
  */
-export function openVikingToolPython(): string | undefined {
-  const override = process.env.THREADNOTE_OPENVIKING_PYTHON;
+export const openVikingToolPython = Effect.fn('lifecycle.openVikingToolPython')(function* () {
+  const system = yield* SystemInfo;
+  const override = system.environment().THREADNOTE_OPENVIKING_PYTHON;
   if (override !== undefined) {
     return override.trim() === '' ? undefined : override.trim();
   }
   return OPENVIKING_TOOL_PYTHON;
-}
+});
 
-export async function getInstallCommands(
+export const getInstallCommands = Effect.fn('lifecycle.getInstallCommands')(function* (
   config: RuntimeConfig,
   preferred: PackageManager | undefined,
   force: boolean,
-): Promise<readonly MappedCommand[]> {
+) {
   const packageSpec = `${OPENVIKING_PACKAGE_NAME}==${config.openVikingVersion}`;
-  const wheelIndex = localEmbedWheelIndexUrl();
-  const manager = preferred ?? (await detectPackageManager());
+  const wheelIndex = yield* localEmbedWheelIndexUrl();
+  const manager = preferred ?? (yield* detectPackageManager());
   if (manager === 'pipx') {
     const installArgs = force ? ['install', '--force'] : ['install'];
     if (wheelIndex) {
@@ -2443,7 +2453,7 @@ export async function getInstallCommands(
     // --python pins the tool to a wheel-supported interpreter (uv fetches a
     // managed CPython when none is present), so local-embed resolves a prebuilt
     // wheel instead of compiling. --extra-index-url points at that wheel index.
-    const toolPython = openVikingToolPython();
+    const toolPython = yield* openVikingToolPython();
     const uvArgs = [
       'tool',
       'install',
@@ -2469,189 +2479,203 @@ export async function getInstallCommands(
   }
   pipArgs.push(PYTHON_SYSTEM_CERTS_PACKAGE);
   pipArgs.push(packageSpec);
-  const executable = (await findExecutable(pythonExecutableCandidates())) ?? pythonExecutableCandidates()[0]!;
+  const system = yield* SystemInfo;
+  const pythonCandidates = pythonExecutableCandidates(system.platform);
+  const executable = (yield* findExecutable(pythonCandidates)) ?? pythonCandidates[0]!;
   return [{executable, args: pipArgs}];
-}
+});
 
-async function detectPackageManager(): Promise<PackageManager> {
-  if (await findExecutable(['uv'])) {
+const detectPackageManager = Effect.fn('lifecycle.detectPackageManager')(function* () {
+  if (yield* findExecutable(['uv'])) {
     return 'uv';
   }
-  if (await findExecutable(['pipx'])) {
+  if (yield* findExecutable(['pipx'])) {
     return 'pipx';
   }
   return 'pip';
-}
+});
 
-function printInstallNextSteps(options: {readonly dryRun: boolean; readonly startsServer: boolean}): void {
+const printInstallNextSteps = Effect.fn('lifecycle.printInstallNextSteps')(function* (options: {
+  readonly dryRun: boolean;
+  readonly startsServer: boolean;
+}) {
   if (options.dryRun) {
-    consoleOutput.log('Dry run complete. Run without --dry-run to install and start OpenViking.');
+    yield* Console.log('Dry run complete. Run without --dry-run to install and start OpenViking.');
     return;
   }
 
   if (options.startsServer) {
-    consoleOutput.log('Install complete. OpenViking health is ready. Next:');
-    consoleOutput.log('  threadnote doctor --dry-run');
+    yield* Console.log('Install complete. OpenViking health is ready. Next:');
+    yield* Console.log('  threadnote doctor --dry-run');
     return;
   }
 
-  consoleOutput.log('Install complete. Run start, then doctor:');
-  consoleOutput.log('  threadnote start');
-  consoleOutput.log('  threadnote doctor --dry-run');
-}
+  yield* Console.log('Install complete. Run start, then doctor:');
+  yield* Console.log('  threadnote start');
+  yield* Console.log('  threadnote doctor --dry-run');
+});
 
-async function writeTemplateIfMissing(options: {
+const writeTemplateIfMissing = Effect.fn('lifecycle.writeTemplateIfMissing')(function* (options: {
   readonly config: RuntimeConfig;
   readonly destinationPath: string;
   readonly dryRun: boolean;
-  readonly shouldRepair?: (content: string) => boolean;
+  readonly shouldRepair?: (content: string) => boolean | Effect.Effect<boolean, unknown, Path.Path>;
   readonly templatePath: string;
-}): Promise<void> {
-  if (await exists(options.destinationPath)) {
-    const currentContent = await readFile(options.destinationPath, 'utf8');
-    if (options.shouldRepair?.(currentContent) !== true) {
-      consoleOutput.log(`Already exists: ${options.destinationPath}`);
+}) {
+  if (yield* exists(options.destinationPath)) {
+    const currentContent = yield* readFile(options.destinationPath, 'utf8');
+    const repairDecision = options.shouldRepair?.(currentContent);
+    const shouldRepair = Effect.isEffect(repairDecision) ? yield* repairDecision : repairDecision;
+    if (shouldRepair !== true) {
+      yield* Console.log(`Already exists: ${options.destinationPath}`);
       return;
     }
-    const rendered = renderTemplate(await readFile(options.templatePath, 'utf8'), options.config);
+    const rendered = renderTemplate(yield* readFile(options.templatePath, 'utf8'), options.config);
     if (options.dryRun) {
-      consoleOutput.log(`Would repair generated config: ${options.destinationPath}`);
+      yield* Console.log(`Would repair generated config: ${options.destinationPath}`);
       return;
     }
     const backupPath = `${options.destinationPath}.legacy-${safeTimestamp()}`;
-    await writeFile(backupPath, currentContent, {encoding: 'utf8', mode: 0o600});
-    await chmod(backupPath, 0o600);
-    await writeFile(options.destinationPath, rendered, {encoding: 'utf8', mode: 0o600});
-    await chmod(options.destinationPath, 0o600);
-    consoleOutput.log(`Repaired generated config: ${options.destinationPath}`);
-    consoleOutput.log(`Backup: ${backupPath}`);
+    yield* writeFile(backupPath, currentContent, {encoding: 'utf8', mode: 0o600});
+    yield* chmod(backupPath, 0o600);
+    yield* writeFile(options.destinationPath, rendered, {encoding: 'utf8', mode: 0o600});
+    yield* chmod(options.destinationPath, 0o600);
+    yield* Console.log(`Repaired generated config: ${options.destinationPath}`);
+    yield* Console.log(`Backup: ${backupPath}`);
     return;
   }
-  const rendered = renderTemplate(await readFile(options.templatePath, 'utf8'), options.config);
+  const rendered = renderTemplate(yield* readFile(options.templatePath, 'utf8'), options.config);
   if (options.dryRun) {
-    consoleOutput.log(`Would write ${options.destinationPath}`);
+    yield* Console.log(`Would write ${options.destinationPath}`);
     return;
   }
-  await ensureDirectory(dirname(options.destinationPath), false);
-  await writeFile(options.destinationPath, rendered, {encoding: 'utf8', mode: 0o600});
-  await chmod(options.destinationPath, 0o600);
-  consoleOutput.log(`Wrote ${options.destinationPath}`);
-}
+  yield* ensureDirectory(yield* pathDirname(options.destinationPath), false);
+  yield* writeFile(options.destinationPath, rendered, {encoding: 'utf8', mode: 0o600});
+  yield* chmod(options.destinationPath, 0o600);
+  yield* Console.log(`Wrote ${options.destinationPath}`);
+});
 
-async function installCommandShim(dryRun: boolean): Promise<void> {
-  if (!shouldManageCommandShim()) {
-    consoleOutput.log('Preserving the package-manager threadnote.cmd launcher on Windows.');
+const installCommandShim = Effect.fn('lifecycle.installCommandShim')(function* (dryRun: boolean) {
+  const system = yield* SystemInfo;
+  if (!shouldManageCommandShim(system.platform)) {
+    yield* Console.log('Preserving the package-manager threadnote.cmd launcher on Windows.');
     return;
   }
-  const binDir = expandPath(process.env.THREADNOTE_BIN_DIR ?? '~/.local/bin');
-  const shimPath = join(binDir, 'threadnote');
-  const existingContent = await readFileIfExists(shimPath);
+  const binDir = yield* expandPath(system.environment().THREADNOTE_BIN_DIR ?? '~/.local/bin');
+  const shimPath = yield* pathJoin(binDir, 'threadnote');
+  const existingContent = yield* readFileIfExists(shimPath);
   if (existingContent && !isManagedCommandShim(existingContent)) {
-    consoleOutput.log(`WARN not overwriting existing command shim: ${shimPath}`);
+    yield* Console.log(`WARN not overwriting existing command shim: ${shimPath}`);
     return;
   }
 
-  const content = renderCommandShim();
+  const content = yield* renderCommandShim();
   if (existingContent === content) {
-    consoleOutput.log(`Already exists: ${shimPath}`);
+    yield* Console.log(`Already exists: ${shimPath}`);
     return;
   }
   if (dryRun) {
-    consoleOutput.log(`Would write command shim: ${shimPath}`);
+    yield* Console.log(`Would write command shim: ${shimPath}`);
     return;
   }
-  await ensureDirectory(binDir, false);
-  await writeFile(shimPath, content, {encoding: 'utf8', mode: 0o755});
-  await chmod(shimPath, 0o755);
-  consoleOutput.log(`Wrote command shim: ${shimPath}`);
-}
+  yield* ensureDirectory(binDir, false);
+  yield* writeFile(shimPath, content, {encoding: 'utf8', mode: 0o755});
+  yield* chmod(shimPath, 0o755);
+  yield* Console.log(`Wrote command shim: ${shimPath}`);
+});
 
-async function removeCommandShim(dryRun: boolean): Promise<void> {
-  if (!shouldManageCommandShim()) {
-    consoleOutput.log('Preserving the package-manager threadnote.cmd launcher on Windows.');
+const removeCommandShim = Effect.fn('lifecycle.removeCommandShim')(function* (dryRun: boolean) {
+  const system = yield* SystemInfo;
+  if (!shouldManageCommandShim(system.platform)) {
+    yield* Console.log('Preserving the package-manager threadnote.cmd launcher on Windows.');
     return;
   }
-  const shimPath = join(expandPath(process.env.THREADNOTE_BIN_DIR ?? '~/.local/bin'), 'threadnote');
-  const content = await readFileIfExists(shimPath);
+  const shimPath = yield* pathJoin(
+    yield* expandPath(system.environment().THREADNOTE_BIN_DIR ?? '~/.local/bin'),
+    'threadnote',
+  );
+  const content = yield* readFileIfExists(shimPath);
   if (content === undefined) {
-    consoleOutput.log(`Already absent: ${shimPath}`);
+    yield* Console.log(`Already absent: ${shimPath}`);
     return;
   }
   if (!isManagedCommandShim(content)) {
-    consoleOutput.log(`WARN not removing unmanaged command shim: ${shimPath}`);
+    yield* Console.log(`WARN not removing unmanaged command shim: ${shimPath}`);
     return;
   }
-  await removePath(shimPath, 'command shim', dryRun);
-}
+  yield* removePath(shimPath, 'command shim', dryRun);
+});
 
-async function installUserAgentInstructions(dryRun: boolean): Promise<void> {
+const installUserAgentInstructions = Effect.fn('lifecycle.installUserAgentInstructions')(function* (dryRun: boolean) {
   for (const target of USER_AGENT_INSTRUCTION_TARGETS) {
-    const instructions = await renderUserAgentInstructions(target);
-    const targetPath = expandPath(target.path);
-    const currentContent = await readFileIfExists(targetPath);
+    const instructions = yield* renderUserAgentInstructions(target);
+    const targetPath = yield* expandPath(target.path);
+    const currentContent = yield* readFileIfExists(targetPath);
     if (target.kind === 'file' && currentContent !== undefined && extractManagedBlock(currentContent) === undefined) {
-      consoleOutput.log(`WARN ${targetPath} is not managed by threadnote; not modifying it`);
+      yield* Console.log(`WARN ${targetPath} is not managed by threadnote; not modifying it`);
       continue;
     }
     const nextContent = target.kind === 'file' ? instructions : upsertManagedBlock(currentContent ?? '', instructions);
     if (nextContent === undefined) {
-      consoleOutput.log(`WARN ${targetPath} has partial threadnote markers; not modifying it`);
+      yield* Console.log(`WARN ${targetPath} has partial threadnote markers; not modifying it`);
       continue;
     }
     if (currentContent === nextContent) {
-      consoleOutput.log(`Already exists: ${targetPath}`);
+      yield* Console.log(`Already exists: ${targetPath}`);
       continue;
     }
     if (dryRun) {
-      consoleOutput.log(currentContent === undefined ? `Would write ${targetPath}` : `Would update ${targetPath}`);
+      yield* Console.log(currentContent === undefined ? `Would write ${targetPath}` : `Would update ${targetPath}`);
       continue;
     }
-    await ensureDirectory(dirname(targetPath), false);
-    await writeFile(targetPath, nextContent, {encoding: 'utf8', mode: 0o644});
-    consoleOutput.log(currentContent === undefined ? `Wrote ${targetPath}` : `Updated ${targetPath}`);
+    yield* ensureDirectory(yield* pathDirname(targetPath), false);
+    yield* writeFile(targetPath, nextContent, {encoding: 'utf8', mode: 0o644});
+    yield* Console.log(currentContent === undefined ? `Wrote ${targetPath}` : `Updated ${targetPath}`);
   }
-}
+});
 
-async function removeUserAgentInstructions(dryRun: boolean): Promise<void> {
+const removeUserAgentInstructions = Effect.fn('lifecycle.removeUserAgentInstructions')(function* (dryRun: boolean) {
   for (const target of USER_AGENT_INSTRUCTION_TARGETS) {
-    const targetPath = expandPath(target.path);
-    const currentContent = await readFileIfExists(targetPath);
+    const targetPath = yield* expandPath(target.path);
+    const currentContent = yield* readFileIfExists(targetPath);
     if (currentContent === undefined) {
-      consoleOutput.log(`Already absent: ${targetPath}`);
+      yield* Console.log(`Already absent: ${targetPath}`);
       continue;
     }
     if (target.kind === 'file') {
       if (extractManagedBlock(currentContent) === undefined) {
-        consoleOutput.log(`WARN ${targetPath} is not managed by threadnote; not removing it`);
+        yield* Console.log(`WARN ${targetPath} is not managed by threadnote; not removing it`);
         continue;
       }
-      await removePath(targetPath, target.label, dryRun);
+      yield* removePath(targetPath, target.label, dryRun);
       continue;
     }
     const nextContent = removeManagedBlock(currentContent);
     if (nextContent === undefined) {
-      consoleOutput.log(`WARN ${targetPath} has partial threadnote markers; not modifying it`);
+      yield* Console.log(`WARN ${targetPath} has partial threadnote markers; not modifying it`);
       continue;
     }
     if (nextContent === currentContent) {
-      consoleOutput.log(`No threadnote block found: ${targetPath}`);
+      yield* Console.log(`No threadnote block found: ${targetPath}`);
       continue;
     }
     if (nextContent.trim().length === 0) {
-      await removePath(targetPath, target.label, dryRun);
+      yield* removePath(targetPath, target.label, dryRun);
       continue;
     }
     if (dryRun) {
-      consoleOutput.log(`Would update ${targetPath}`);
+      yield* Console.log(`Would update ${targetPath}`);
       continue;
     }
-    await writeFile(targetPath, nextContent, {encoding: 'utf8', mode: 0o644});
-    consoleOutput.log(`Updated ${targetPath}`);
+    yield* writeFile(targetPath, nextContent, {encoding: 'utf8', mode: 0o644});
+    yield* Console.log(`Updated ${targetPath}`);
   }
-}
+});
 
-async function renderUserAgentInstructions(target: UserAgentInstructionTarget): Promise<string> {
-  const block = await renderUserAgentInstructionsBlock();
+const renderUserAgentInstructions = Effect.fn('lifecycle.renderUserAgentInstructions')(function* (
+  target: UserAgentInstructionTarget,
+) {
+  const block = yield* renderUserAgentInstructionsBlock();
   if (target.kind === 'block') {
     return block;
   }
@@ -2664,12 +2688,15 @@ async function renderUserAgentInstructions(target: UserAgentInstructionTarget): 
     '',
     block,
   ].join('\n');
-}
+});
 
-async function renderUserAgentInstructionsBlock(): Promise<string> {
-  const instructions = (await readFile(join(toolRoot(), 'docs', 'agent-instructions.md'), 'utf8')).trim();
+const renderUserAgentInstructionsBlock = Effect.fn('lifecycle.renderUserAgentInstructionsBlock')(function* () {
+  const instructions = (yield* readFile(
+    yield* pathJoin(yield* toolRoot(), 'docs', 'agent-instructions.md'),
+    'utf8',
+  )).trim();
   return `${USER_INSTRUCTIONS_START_MARKER}\n${instructions}\n${USER_INSTRUCTIONS_END_MARKER}`;
-}
+});
 
 function extractManagedBlock(content: string): string | undefined {
   const startIndex = content.indexOf(USER_INSTRUCTIONS_START_MARKER);
@@ -2713,8 +2740,8 @@ function joinMarkdownSections(sections: readonly string[]): string {
   return `${sections.filter(section => section.length > 0).join('\n\n')}\n`;
 }
 
-function renderCommandShim(): string {
-  const root = toolRoot();
+const renderCommandShim = Effect.fn('lifecycle.renderCommandShim')(function* () {
+  const root = yield* toolRoot();
   return [
     '#!/usr/bin/env bash',
     `# ${SHIM_MARKER}`,
@@ -2739,7 +2766,7 @@ function renderCommandShim(): string {
     'exit 127',
     '',
   ].join('\n');
-}
+});
 
 function isManagedCommandShim(content: string): boolean {
   return content.includes(SHIM_MARKER);
@@ -2767,8 +2794,8 @@ const installLaunchAgent = Effect.fn('installLaunchAgent')(function* (config: Ru
       ),
     );
   }
-  const source = join(toolRoot(), 'config', 'launchd', `${LAUNCHD_LABEL}.plist.template`);
-  const destination = launchAgentPath();
+  const source = yield* pathJoin(yield* toolRoot(), 'config', 'launchd', `${LAUNCHD_LABEL}.plist.template`);
+  const destination = yield* launchAgentPath();
   const rendered = renderTemplate(yield* fs.readFileString(source), config, {
     OPENVIKING_SERVER_PATH: resolvedServer ?? OPENVIKING_SERVER_COMMAND,
   });
@@ -2781,12 +2808,12 @@ const installLaunchAgent = Effect.fn('installLaunchAgent')(function* (config: Ru
     yield* bootstrapLaunchAgent(destination, true);
     return;
   }
-  yield* fs.makeDirectory(dirname(destination), {recursive: true});
-  yield* fs.makeDirectory(dirname(openVikingLogPath(config)), {recursive: true});
+  yield* fs.makeDirectory(yield* pathDirname(destination), {recursive: true});
+  yield* fs.makeDirectory(yield* pathDirname(yield* openVikingLogPath(config)), {recursive: true});
   const healthUrl = openVikingHealthUrl(config);
   const activationTimeoutMs = yield* remainingBudget(installDeadline, START_HEALTH_TIMEOUT_MS);
   const health = yield* activateLaunchAgent<
-    CommandExecutor | FileSystem.FileSystem | HttpService | Path.Path | SystemInfo
+    ChildProcessSpawner | CommandExecutor | FileSystem.FileSystem | HttpService | Path.Path | SystemInfo
   >(config, destination, rendered, activationTimeoutMs, {
     bootout: timeoutMs => bootoutLaunchAgent(false, undefined, timeoutMs),
     bootstrap: (plistPath, timeoutMs) => bootstrapLaunchAgent(plistPath, false, undefined, timeoutMs),
@@ -2806,7 +2833,7 @@ const installLaunchAgent = Effect.fn('installLaunchAgent')(function* (config: Ru
   return yield* Effect.fail(
     new Error(
       `Installed and started ${LAUNCHD_LABEL}, but ${healthUrl} did not become healthy within ` +
-        `${START_HEALTH_TIMEOUT_MS / 1000}s. Logs: ${openVikingLogPath(config)}`,
+        `${START_HEALTH_TIMEOUT_MS / 1000}s. Logs: ${yield* openVikingLogPath(config)}`,
     ),
   );
 });
@@ -2920,17 +2947,19 @@ function boundedRecovery<R>(
 
 export const stageLaunchAgentPlist = Effect.fn('stageLaunchAgentPlist')(function* (plistPath: string, content: string) {
   const fs = yield* FileSystem.FileSystem;
-  return yield* stageLaunchAgentPlistWithFileSystem(fs, plistPath, content);
+  const system = yield* SystemInfo;
+  return yield* stageLaunchAgentPlistWithFileSystem(fs, plistPath, content, system.processId);
 });
 
 function stageLaunchAgentPlistWithFileSystem(
   fs: FileSystem.FileSystem,
   plistPath: string,
   content: string,
+  processId: number,
 ): Effect.Effect<LaunchAgentPlistTransaction, unknown> {
   return Effect.gen(function* () {
-    const stagePath = `${plistPath}.threadnote-stage-${process.pid}`;
-    const rollbackPath = `${plistPath}.threadnote-rollback-${process.pid}`;
+    const stagePath = `${plistPath}.threadnote-stage-${processId}`;
+    const rollbackPath = `${plistPath}.threadnote-rollback-${processId}`;
     const lockPath = `${plistPath}.threadnote-lock`;
     yield* fs.makeDirectory(lockPath);
     const prepare = Effect.gen(function* () {
@@ -3006,7 +3035,7 @@ export function waitForLaunchAgentHealth(
   config: RuntimeConfig,
   timeoutMs: number,
   progressMessage: string,
-): Effect.Effect<string | undefined, unknown, CommandExecutor | HttpService> {
+): Effect.Effect<string | undefined, unknown, CommandExecutor | HttpService | SystemInfo> {
   return waitForLaunchAgentHealthWithEffects(config, timeoutMs, progressMessage, liveLaunchAgentHealthEffects());
 }
 
@@ -3071,7 +3100,7 @@ const readOpenVikingHealthEffect = Effect.fn('readOpenVikingHealth')(function* (
   );
 });
 
-function liveLaunchAgentHealthEffects(): LaunchAgentHealthEffects<CommandExecutor | HttpService> {
+function liveLaunchAgentHealthEffects(): LaunchAgentHealthEffects<CommandExecutor | HttpService | SystemInfo> {
   return {
     ownsPort: (pid, config, timeoutMs) => launchdProcessOwnsPort(pid, config, timeoutMs),
     readHealth: readOpenVikingHealthEffect,
@@ -3080,7 +3109,7 @@ function liveLaunchAgentHealthEffects(): LaunchAgentHealthEffects<CommandExecuto
 }
 
 const isTcpPortOpenEffect = Effect.fn('isTcpPortOpen')(function* (host: string, port: number, timeoutMs: number) {
-  return yield* fromPromise(`check TCP port ${host}:${port}`, () => isTcpPortOpen(host, port, timeoutMs));
+  return yield* isTcpPortOpen(host, port, timeoutMs);
 });
 
 const remainingBudget = Effect.fn('remainingLaunchAgentBudget')(function* (deadline: number, timeoutMs: number) {
@@ -3107,7 +3136,7 @@ export function launchAgentHealthIsStable(
 
 const removeLaunchAgent = Effect.fn('removeLaunchAgent')(function* (dryRun: boolean) {
   const fs = yield* FileSystem.FileSystem;
-  const agentPath = launchAgentPath();
+  const agentPath = yield* launchAgentPath();
   const content = yield* fs.readFileString(agentPath).pipe(
     Effect.catchIf(
       error => error.reason._tag === 'NotFound',
@@ -3130,12 +3159,15 @@ const removeLaunchAgent = Effect.fn('removeLaunchAgent')(function* (dryRun: bool
   yield* Console.log(`Removed LaunchAgent: ${agentPath}`);
 });
 
-async function eraseThreadnoteHome(path: string, dryRun: boolean): Promise<void> {
+const eraseThreadnoteHome = Effect.fn('lifecycle.eraseThreadnoteHome')(function* (path: string, dryRun: boolean) {
   assertSafeThreadnoteHomeForErase(path);
-  await removePathIfExists(path, 'THREADNOTE_HOME and all memories', dryRun);
-}
+  yield* removePathIfExists(path, 'THREADNOTE_HOME and all memories', dryRun);
+});
 
-function shouldRepairOpenVikingConfig(content: string, config: RuntimeConfig): boolean {
+const shouldRepairOpenVikingConfig = Effect.fn('lifecycle.shouldRepairOpenVikingConfig')(function* (
+  content: string,
+  config: RuntimeConfig,
+) {
   const parsed = parseJsonConfigObject(content);
   if (!parsed) {
     return false;
@@ -3144,10 +3176,10 @@ function shouldRepairOpenVikingConfig(content: string, config: RuntimeConfig): b
     return true;
   }
   return (
-    isGeneratedLocalPilotConfig(parsed, config) &&
+    (yield* isGeneratedLocalPilotConfig(parsed, config)) &&
     (parsed.auto_generate_l0 !== false || parsed.auto_generate_l1 !== false)
   );
-}
+});
 
 function isLegacyOpenVikingConfig(parsed: JsonObject): boolean {
   return (
@@ -3159,7 +3191,10 @@ function isLegacyOpenVikingConfig(parsed: JsonObject): boolean {
   );
 }
 
-function isGeneratedLocalPilotConfig(parsed: JsonObject, config: RuntimeConfig): boolean {
+const isGeneratedLocalPilotConfig = Effect.fn('lifecycle.isGeneratedLocalPilotConfig')(function* (
+  parsed: JsonObject,
+  config: RuntimeConfig,
+) {
   const allowedKeys = new Set([
     'auto_generate_l0',
     'auto_generate_l1',
@@ -3178,7 +3213,10 @@ function isGeneratedLocalPilotConfig(parsed: JsonObject, config: RuntimeConfig):
   if (typeof parsed.default_user !== 'string') {
     return false;
   }
-  if (!isJsonObject(parsed.storage) || parsed.storage.workspace !== join(config.agentContextHome, 'data')) {
+  if (
+    !isJsonObject(parsed.storage) ||
+    parsed.storage.workspace !== (yield* pathJoin(config.agentContextHome, 'data'))
+  ) {
     return false;
   }
   return (
@@ -3186,7 +3224,7 @@ function isGeneratedLocalPilotConfig(parsed: JsonObject, config: RuntimeConfig):
     parsed.server.host === config.host &&
     String(parsed.server.port) === String(config.port)
   );
-}
+});
 
 function shouldRepairLegacyOvCliConfig(content: string): boolean {
   const parsed = parseJsonConfigObject(content);

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1096,7 +1096,15 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
     yield* Console.log(`Removed stale pid file for process ${pid}.`);
     return;
   }
+  let windowsTerminationPid = pid;
   if (system.platform === 'win32') {
+    const launcherPid = processRecord?.launcherPid;
+    if (launcherPid !== undefined && (!Number.isInteger(launcherPid) || launcherPid <= 0)) {
+      return yield* Effect.fail(new Error(`Refusing to stop process ${pid}: its launcher pid record is invalid.`));
+    }
+    const runningLauncherPid =
+      launcherPid !== undefined && (yield* isProcessRunningEffect(launcherPid)) ? launcherPid : undefined;
+    windowsTerminationPid = runningLauncherPid ?? pid;
     const server = processRecord?.server ?? (yield* findOpenVikingServer());
     if (!server) {
       return yield* Effect.fail(
@@ -1107,7 +1115,7 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
       args: processRecord?.args ?? (yield* openVikingServerArgs(config)),
       commandLine: processRecord?.commandLine,
       executablePath: processRecord?.executablePath,
-      launcherPid: processRecord?.launcherPid,
+      launcherPid: runningLauncherPid,
       server,
       startedAt: processRecord?.startedAt,
     };
@@ -1122,9 +1130,9 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
   }
   let signaled: boolean;
   if (system.platform === 'win32') {
-    const termination = yield* terminateWindowsProcessTree(pid);
+    const termination = yield* terminateWindowsProcessTree(windowsTerminationPid);
     if (!termination.stopped) {
-      return yield* Effect.fail(windowsTerminationError(pid, termination.result));
+      return yield* Effect.fail(windowsTerminationError(windowsTerminationPid, termination.result));
     }
     signaled = true;
   } else {
@@ -1327,11 +1335,28 @@ const isManagedWindowsOpenVikingProcess = Effect.fn('isManagedWindowsOpenVikingP
   if (!powershell) {
     return false;
   }
+  const launcherPid = expected.launcherPid;
+  if (launcherPid !== undefined && (!Number.isInteger(launcherPid) || launcherPid <= 0)) {
+    return false;
+  }
   const script = [
     `$process = Get-CimInstance Win32_Process -Filter 'ProcessId = ${pid}'`,
     'if ($null -eq $process) { exit 3 }',
+    '$descendsFromLauncher = $true',
+    ...(launcherPid === undefined
+      ? []
+      : [
+          '$processes = @(Get-CimInstance Win32_Process)',
+          '$cursor = $process',
+          '$descendsFromLauncher = $false',
+          'while ($null -ne $cursor -and [uint32]$cursor.ProcessId -gt 0) {',
+          `if ([uint32]$cursor.ProcessId -eq ${launcherPid}) { $descendsFromLauncher = $true; break }`,
+          '$parentId = [uint32]$cursor.ParentProcessId',
+          '$cursor = $processes | Where-Object { [uint32]$_.ProcessId -eq $parentId } | Select-Object -First 1',
+          '}',
+        ]),
     `$owners = @(Get-NetTCPConnection -LocalPort ${config.port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess)`,
-    `[pscustomobject]@{CommandLine=$process.CommandLine;CreationTime=$process.CreationDate.ToUniversalTime().ToString('o');ExecutablePath=$process.ExecutablePath;OwnsPort=($owners -contains ${pid})} | ConvertTo-Json -Compress`,
+    `[pscustomobject]@{CommandLine=$process.CommandLine;CreationTime=$process.CreationDate.ToUniversalTime().ToString('o');DescendsFromLauncher=$descendsFromLauncher;ExecutablePath=$process.ExecutablePath;OwnsPort=($owners -contains ${pid})} | ConvertTo-Json -Compress`,
   ].join('; ');
   const result = yield* runCommandEffect(powershell, ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
     allowFailure: true,
@@ -1344,7 +1369,11 @@ const isManagedWindowsOpenVikingProcess = Effect.fn('isManagedWindowsOpenVikingP
   if (!isJsonObject(identity)) {
     return false;
   }
-  if (identity.OwnsPort !== true || typeof identity.CommandLine !== 'string') {
+  if (
+    identity.DescendsFromLauncher !== true ||
+    identity.OwnsPort !== true ||
+    typeof identity.CommandLine !== 'string'
+  ) {
     return false;
   }
   const commandLine = identity.CommandLine;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,4 +1,4 @@
-import {Cause, Clock, Console, Effect, Encoding, Exit, FileSystem, Option, Path, Result, Sink, Terminal} from 'effect';
+import {Cause, Clock, Console, Effect, Exit, FileSystem, Option, Path, Result, Sink, Terminal} from 'effect';
 import * as ChildProcess from 'effect/unstable/process/ChildProcess';
 import {ChildProcessSpawner} from 'effect/unstable/process/ChildProcessSpawner';
 import yaml from 'js-yaml';
@@ -109,34 +109,7 @@ import {
 const INSTALL_OUTPUT_TAIL_CHARS = 64_000;
 const MINIMUM_UV_SYSTEM_CERTS_VERSION = '0.11.0';
 const STOP_SERVER_TIMEOUT_MS = 10_000;
-const WINDOWS_DETACHED_SERVER_HOST_SCRIPT = [
-  "$ErrorActionPreference = 'Continue'",
-  "'Launching OpenViking.' | Out-File -LiteralPath $env:THREADNOTE_DETACHED_SERVER_LOG -Append -Encoding utf8",
-  '$serverArgs = @(ConvertFrom-Json -InputObject $env:THREADNOTE_DETACHED_SERVER_ARGS)',
-  '& $env:THREADNOTE_DETACHED_SERVER @serverArgs 2>&1 | Out-File -LiteralPath $env:THREADNOTE_DETACHED_SERVER_LOG -Append -Encoding utf8',
-  'exit $LASTEXITCODE',
-].join('; ');
-const WINDOWS_DETACHED_SERVER_HOST_COMMAND = encodeWindowsPowerShellCommand(WINDOWS_DETACHED_SERVER_HOST_SCRIPT);
-const WINDOWS_DETACHED_SERVER_START_SCRIPT = [
-  "$ErrorActionPreference = 'Stop'",
-  "$hostArguments = @('-NoLogo', '-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden', '-EncodedCommand', $env:THREADNOTE_DETACHED_SERVER_HOST_COMMAND)",
-  '$process = Start-Process -FilePath $env:THREADNOTE_DETACHED_POWERSHELL -ArgumentList $hostArguments -WindowStyle Hidden -PassThru -RedirectStandardOutput $env:THREADNOTE_DETACHED_HOST_STDOUT -RedirectStandardError $env:THREADNOTE_DETACHED_HOST_STDERR',
-  '$processId = $process.Id',
-  '$process.Dispose()',
-  '[Console]::Out.WriteLine($processId)',
-  'exit 0',
-].join('; ');
 const parseJson = Option.liftThrowable((content: string): unknown => JSON.parse(content));
-
-export function encodeWindowsPowerShellCommand(script: string): string {
-  const bytes = new Uint8Array(script.length * 2);
-  for (let index = 0; index < script.length; index += 1) {
-    const codeUnit = script.charCodeAt(index);
-    bytes[index * 2] = codeUnit & 0xff;
-    bytes[index * 2 + 1] = codeUnit >>> 8;
-  }
-  return Encoding.encodeBase64(bytes);
-}
 
 interface DetachedProcessRecord {
   readonly args?: readonly string[];
@@ -960,40 +933,19 @@ const spawnDetachedServer = Effect.fn('lifecycle.spawnDetachedServer')(function*
   const fs = yield* FileSystem.FileSystem;
   const system = yield* SystemInfo;
   if (system.platform === 'win32') {
-    const powershell = yield* findExecutable(['powershell']);
-    if (!powershell) {
-      return yield* Effect.fail(new Error('PowerShell is required to start OpenViking in the background on Windows.'));
-    }
-    const launched = yield* runCommandEffect(
-      powershell,
-      [
-        '-NoLogo',
-        '-NoProfile',
-        '-NonInteractive',
-        '-WindowStyle',
-        'Hidden',
-        '-Command',
-        WINDOWS_DETACHED_SERVER_START_SCRIPT,
-      ],
-      {
-        env: {
-          ...system.environment(),
-          THREADNOTE_DETACHED_HOST_STDERR: `${logPath}.host.stderr`,
-          THREADNOTE_DETACHED_HOST_STDOUT: `${logPath}.host.stdout`,
-          THREADNOTE_DETACHED_POWERSHELL: powershell,
-          THREADNOTE_DETACHED_SERVER: server,
-          THREADNOTE_DETACHED_SERVER_ARGS: JSON.stringify(args),
-          THREADNOTE_DETACHED_SERVER_HOST_COMMAND: WINDOWS_DETACHED_SERVER_HOST_COMMAND,
-          THREADNOTE_DETACHED_SERVER_LOG: logPath,
-        },
-        timeoutMs: STOP_SERVER_TIMEOUT_MS,
-      },
+    yield* fs.writeFileString(
+      logPath,
+      'Detached Windows server output is not captured. Run threadnote start --foreground for diagnostics.\n',
+      {flag: 'a'},
     );
-    const childPid = Number(launched.stdout.trim().split(/\s+/).at(-1));
-    if (!Number.isInteger(childPid) || childPid <= 0) {
-      return yield* Effect.fail(new Error('PowerShell did not report the detached OpenViking server pid.'));
-    }
-    return childPid;
+    const child = yield* ChildProcess.make(server, [...args], {
+      detached: true,
+      stderr: 'ignore',
+      stdin: 'ignore',
+      stdout: 'ignore',
+    });
+    yield* child.unref;
+    return Number(child.pid);
   }
   const logSink = fs.sink(logPath, {flag: 'a'}).pipe(Sink.as(new Uint8Array()));
   const child = yield* ChildProcess.make(server, [...args], {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,4 +1,4 @@
-import {Cause, Clock, Console, Effect, Exit, FileSystem, Option, Path, Result, Sink, Terminal} from 'effect';
+import {Cause, Clock, Console, Effect, Encoding, Exit, FileSystem, Option, Path, Result, Sink, Terminal} from 'effect';
 import * as ChildProcess from 'effect/unstable/process/ChildProcess';
 import {ChildProcessSpawner} from 'effect/unstable/process/ChildProcessSpawner';
 import yaml from 'js-yaml';
@@ -108,14 +108,32 @@ import {
 const INSTALL_OUTPUT_TAIL_CHARS = 64_000;
 const MINIMUM_UV_SYSTEM_CERTS_VERSION = '0.11.0';
 const STOP_SERVER_TIMEOUT_MS = 10_000;
-const WINDOWS_DETACHED_SERVER_SCRIPT = [
-  "$ErrorActionPreference = 'Stop'",
+const WINDOWS_DETACHED_SERVER_HOST_SCRIPT = [
+  "$ErrorActionPreference = 'Continue'",
+  "'Launching OpenViking.' | Out-File -LiteralPath $env:THREADNOTE_DETACHED_SERVER_LOG -Append -Encoding utf8",
   '$serverArgs = @(ConvertFrom-Json -InputObject $env:THREADNOTE_DETACHED_SERVER_ARGS)',
-  `$argumentLine = ($serverArgs | ForEach-Object { '"' + $_ + '"' }) -join ' '`,
-  '$process = Start-Process -FilePath $env:THREADNOTE_DETACHED_SERVER -ArgumentList $argumentLine -WindowStyle Hidden -PassThru -RedirectStandardOutput $env:THREADNOTE_DETACHED_SERVER_STDOUT -RedirectStandardError $env:THREADNOTE_DETACHED_SERVER_LOG',
+  '& $env:THREADNOTE_DETACHED_SERVER @serverArgs 2>&1 | Out-File -LiteralPath $env:THREADNOTE_DETACHED_SERVER_LOG -Append -Encoding utf8',
+  'exit $LASTEXITCODE',
+].join('; ');
+const WINDOWS_DETACHED_SERVER_HOST_COMMAND = encodeWindowsPowerShellCommand(WINDOWS_DETACHED_SERVER_HOST_SCRIPT);
+const WINDOWS_DETACHED_SERVER_START_SCRIPT = [
+  "$ErrorActionPreference = 'Stop'",
+  "$hostArguments = @('-NoLogo', '-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden', '-EncodedCommand', $env:THREADNOTE_DETACHED_SERVER_HOST_COMMAND)",
+  '$process = Start-Process -FilePath $env:THREADNOTE_DETACHED_POWERSHELL -ArgumentList $hostArguments -WindowStyle Hidden -PassThru -RedirectStandardOutput $env:THREADNOTE_DETACHED_HOST_STDOUT -RedirectStandardError $env:THREADNOTE_DETACHED_HOST_STDERR',
   '[Console]::Out.WriteLine($process.Id)',
+  'exit 0',
 ].join('; ');
 const parseJson = Option.liftThrowable((content: string): unknown => JSON.parse(content));
+
+export function encodeWindowsPowerShellCommand(script: string): string {
+  const bytes = new Uint8Array(script.length * 2);
+  for (let index = 0; index < script.length; index += 1) {
+    const codeUnit = script.charCodeAt(index);
+    bytes[index * 2] = codeUnit & 0xff;
+    bytes[index * 2 + 1] = codeUnit >>> 8;
+  }
+  return Encoding.encodeBase64(bytes);
+}
 
 interface DetachedProcessRecord {
   readonly args?: readonly string[];
@@ -952,15 +970,18 @@ const spawnDetachedServer = Effect.fn('lifecycle.spawnDetachedServer')(function*
         '-WindowStyle',
         'Hidden',
         '-Command',
-        WINDOWS_DETACHED_SERVER_SCRIPT,
+        WINDOWS_DETACHED_SERVER_START_SCRIPT,
       ],
       {
         env: {
           ...system.environment(),
+          THREADNOTE_DETACHED_HOST_STDERR: `${logPath}.host.stderr`,
+          THREADNOTE_DETACHED_HOST_STDOUT: `${logPath}.host.stdout`,
+          THREADNOTE_DETACHED_POWERSHELL: powershell,
           THREADNOTE_DETACHED_SERVER: server,
           THREADNOTE_DETACHED_SERVER_ARGS: JSON.stringify(args),
+          THREADNOTE_DETACHED_SERVER_HOST_COMMAND: WINDOWS_DETACHED_SERVER_HOST_COMMAND,
           THREADNOTE_DETACHED_SERVER_LOG: logPath,
-          THREADNOTE_DETACHED_SERVER_STDOUT: `${logPath}.stdout`,
         },
         timeoutMs: STOP_SERVER_TIMEOUT_MS,
       },

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -930,12 +930,20 @@ const spawnDetachedServer = Effect.fn('lifecycle.spawnDetachedServer')(function*
   logPath: string,
 ) {
   const fs = yield* FileSystem.FileSystem;
-  const logSink = fs.sink(logPath, {flag: 'a'}).pipe(Sink.as(new Uint8Array()));
+  const system = yield* SystemInfo;
+  const output = system.platform === 'win32' ? 'ignore' : fs.sink(logPath, {flag: 'a'}).pipe(Sink.as(new Uint8Array()));
+  if (system.platform === 'win32') {
+    yield* fs.writeFileString(
+      logPath,
+      'Detached Windows server output is not captured. Run threadnote start --foreground for diagnostics.\n',
+      {flag: 'a'},
+    );
+  }
   const child = yield* ChildProcess.make(server, [...args], {
     detached: true,
-    stderr: logSink,
+    stderr: output,
     stdin: 'ignore',
-    stdout: logSink,
+    stdout: output,
   });
   yield* child.unref;
   return Number(child.pid);

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -52,6 +52,7 @@ import {
   openVikingHealthUrl,
   openVikingLogPath,
   openVikingServerArgs,
+  renderJsonTemplate,
   renderTemplate,
   withIdentity,
 } from './runtime.js';
@@ -120,7 +121,9 @@ const WINDOWS_DETACHED_SERVER_START_SCRIPT = [
   "$ErrorActionPreference = 'Stop'",
   "$hostArguments = @('-NoLogo', '-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden', '-EncodedCommand', $env:THREADNOTE_DETACHED_SERVER_HOST_COMMAND)",
   '$process = Start-Process -FilePath $env:THREADNOTE_DETACHED_POWERSHELL -ArgumentList $hostArguments -WindowStyle Hidden -PassThru -RedirectStandardOutput $env:THREADNOTE_DETACHED_HOST_STDOUT -RedirectStandardError $env:THREADNOTE_DETACHED_HOST_STDERR',
-  '[Console]::Out.WriteLine($process.Id)',
+  '$processId = $process.Id',
+  '$process.Dispose()',
+  '[Console]::Out.WriteLine($processId)',
   'exit 0',
 ].join('; ');
 const parseJson = Option.liftThrowable((content: string): unknown => JSON.parse(content));
@@ -2592,7 +2595,7 @@ const writeTemplateIfMissing = Effect.fn('lifecycle.writeTemplateIfMissing')(fun
       yield* Console.log(`Already exists: ${options.destinationPath}`);
       return;
     }
-    const rendered = renderTemplate(yield* readFile(options.templatePath, 'utf8'), options.config);
+    const rendered = renderJsonTemplate(yield* readFile(options.templatePath, 'utf8'), options.config);
     if (options.dryRun) {
       yield* Console.log(`Would repair generated config: ${options.destinationPath}`);
       return;
@@ -2606,7 +2609,7 @@ const writeTemplateIfMissing = Effect.fn('lifecycle.writeTemplateIfMissing')(fun
     yield* Console.log(`Backup: ${backupPath}`);
     return;
   }
-  const rendered = renderTemplate(yield* readFile(options.templatePath, 'utf8'), options.config);
+  const rendered = renderJsonTemplate(yield* readFile(options.templatePath, 'utf8'), options.config);
   if (options.dryRun) {
     yield* Console.log(`Would write ${options.destinationPath}`);
     return;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -932,9 +932,9 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
     if (system.platform === 'win32') {
       const servingProcess = yield* findWindowsServingProcess(childPid, config, server, args);
       if (!servingProcess) {
-        const termination = yield* terminateWindowsProcessTree(childPid);
+        const termination = yield* terminateWindowsProcessTree(childPid, config);
         if (!termination.stopped) {
-          return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
+          return yield* Effect.fail(windowsTerminationError(childPid, termination));
         }
         yield* fs.remove(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), {force: true});
         return yield* Effect.fail(
@@ -951,9 +951,9 @@ export const runStart = Effect.fn('runStart')(function* (config: RuntimeConfig, 
     return;
   }
   if (system.platform === 'win32') {
-    const termination = yield* terminateWindowsProcessTree(childPid);
+    const termination = yield* terminateWindowsProcessTree(childPid, config);
     if (!termination.stopped) {
-      return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
+      return yield* Effect.fail(windowsTerminationError(childPid, termination));
     }
     yield* fs.remove(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), {force: true});
   }
@@ -1041,9 +1041,9 @@ const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServ
       if (system.platform === 'win32') {
         const servingProcess = yield* findWindowsServingProcess(childPid, config, server, args);
         if (!servingProcess) {
-          const termination = yield* terminateWindowsProcessTree(childPid);
+          const termination = yield* terminateWindowsProcessTree(childPid, config);
           if (!termination.stopped) {
-            return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
+            return yield* Effect.fail(windowsTerminationError(childPid, termination));
           }
           yield* fs.remove(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), {force: true});
           return yield* Effect.fail(
@@ -1060,9 +1060,9 @@ const restartDetachedOpenVikingServer = Effect.fn('restartDetachedOpenVikingServ
     yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
   }
   if (system.platform === 'win32') {
-    const termination = yield* terminateWindowsProcessTree(childPid);
+    const termination = yield* terminateWindowsProcessTree(childPid, config);
     if (!termination.stopped) {
-      return yield* Effect.fail(windowsTerminationError(childPid, termination.result));
+      return yield* Effect.fail(windowsTerminationError(childPid, termination));
     }
     yield* fs.remove(yield* pathJoin(config.agentContextHome, 'openviking-server.pid'), {force: true});
   } else {
@@ -1096,6 +1096,11 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
   if (!Number.isInteger(pid) || pid <= 0) {
     yield* Console.log(`Invalid pid file: ${pidPath}`);
     if (options.dryRun !== true) {
+      if (system.platform === 'win32' && (yield* isTcpPortOpen(config.host, config.port, 500))) {
+        return yield* Effect.fail(
+          new Error(`Refusing to remove invalid pid file while ${config.host}:${config.port} is still listening.`),
+        );
+      }
       yield* fs.remove(pidPath, {force: true});
     }
     return;
@@ -1105,6 +1110,11 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
     return;
   }
   if (!(yield* isProcessRunningEffect(pid))) {
+    if (system.platform === 'win32' && (yield* isTcpPortOpen(config.host, config.port, 500))) {
+      return yield* Effect.fail(
+        new Error(`Refusing to remove stale pid file while ${config.host}:${config.port} is still listening.`),
+      );
+    }
     yield* fs.remove(pidPath, {force: true});
     yield* Console.log(`Removed stale pid file for process ${pid}.`);
     return;
@@ -1145,9 +1155,9 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
   if (system.platform === 'win32') {
     const terminationPids = windowsTerminationPid === pid ? [pid] : [pid, windowsTerminationPid];
     for (const terminationPid of terminationPids) {
-      const termination = yield* terminateWindowsProcessTree(terminationPid);
+      const termination = yield* terminateWindowsProcessTree(terminationPid, config);
       if (!termination.stopped) {
-        return yield* Effect.fail(windowsTerminationError(terminationPid, termination.result));
+        return yield* Effect.fail(windowsTerminationError(terminationPid, termination));
       }
     }
     signaled = true;
@@ -1171,6 +1181,13 @@ export const runStop = Effect.fn('runStop')(function* (config: RuntimeConfig, op
       return yield* Effect.fail(new Error(`Process ${pid} did not stop within ${STOP_SERVER_TIMEOUT_MS / 1000}s.`));
     }
     yield* Effect.sleep(Math.min(START_HEALTH_POLL_INTERVAL_MS, remainingMs));
+  }
+  if (system.platform === 'win32' && (yield* isTcpPortOpen(config.host, config.port, 500))) {
+    return yield* Effect.fail(
+      new Error(
+        `Process ${pid} stopped, but ${config.host}:${config.port} is still listening; preserving its pid file.`,
+      ),
+    );
   }
   yield* fs.remove(pidPath, {force: true});
   yield* Console.log(`Stopped process ${pid}`);
@@ -1327,16 +1344,32 @@ const matchesExpectedWindowsProcess = Effect.fn('lifecycle.matchesExpectedWindow
   return args.every(arg => commandLine.includes(arg.toLowerCase()));
 });
 
-const terminateWindowsProcessTree = Effect.fn('terminateWindowsProcessTree')(function* (pid: number) {
+const terminateWindowsProcessTree = Effect.fn('terminateWindowsProcessTree')(function* (
+  pid: number,
+  config: RuntimeConfig,
+) {
   const result = yield* runCommandEffect(yield* windowsTaskkillExecutable(), ['/pid', String(pid), '/t', '/f'], {
     allowFailure: true,
     timeoutMs: 5000,
   });
-  return {result, stopped: !(yield* isProcessRunningEffect(pid))};
+  const processStopped = !(yield* isProcessRunningEffect(pid));
+  const listenerStopped = !(yield* isTcpPortOpen(config.host, config.port, 500));
+  return {listenerStopped, processStopped, result, stopped: processStopped && listenerStopped};
 });
 
-function windowsTerminationError(pid: number, result: CommandResult): Error {
-  const detail = firstLine(result.stderr) || firstLine(result.stdout) || `taskkill exited with ${result.exitCode}`;
+function windowsTerminationError(
+  pid: number,
+  termination: {
+    readonly listenerStopped: boolean;
+    readonly processStopped: boolean;
+    readonly result: CommandResult;
+  },
+): Error {
+  const detail = !termination.processStopped
+    ? firstLine(termination.result.stderr) ||
+      firstLine(termination.result.stdout) ||
+      `taskkill exited with ${termination.result.exitCode}`
+    : 'the configured OpenViking listener remained active';
   return new Error(`Could not terminate Windows process tree ${pid}; preserving its pid record: ${detail}`);
 }
 

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -109,7 +109,43 @@ import {
 const INSTALL_OUTPUT_TAIL_CHARS = 64_000;
 const MINIMUM_UV_SYSTEM_CERTS_VERSION = '0.11.0';
 const STOP_SERVER_TIMEOUT_MS = 10_000;
+const WINDOWS_DETACHED_SERVER_START_SCRIPT = [
+  "$ErrorActionPreference = 'Stop'",
+  '$process = Start-Process -FilePath $env:THREADNOTE_DETACHED_SERVER -ArgumentList $env:THREADNOTE_DETACHED_SERVER_ARGUMENT_LINE -WindowStyle Hidden -PassThru',
+  '$processId = $process.Id',
+  '$process.Dispose()',
+  '[Console]::Out.WriteLine($processId)',
+].join('; ');
 const parseJson = Option.liftThrowable((content: string): unknown => JSON.parse(content));
+
+export function quoteWindowsProcessArgument(value: string): string {
+  if (value.length === 0) {
+    return '""';
+  }
+  if (!/[\t "]/.test(value)) {
+    return value;
+  }
+  let quoted = '"';
+  let backslashes = 0;
+  for (const character of value) {
+    if (character === '\\') {
+      backslashes += 1;
+      continue;
+    }
+    if (character === '"') {
+      quoted += `${'\\'.repeat(backslashes * 2 + 1)}"`;
+      backslashes = 0;
+      continue;
+    }
+    quoted += `${'\\'.repeat(backslashes)}${character}`;
+    backslashes = 0;
+  }
+  return `${quoted}${'\\'.repeat(backslashes * 2)}"`;
+}
+
+export function windowsProcessArgumentLine(args: readonly string[]): string {
+  return args.map(quoteWindowsProcessArgument).join(' ');
+}
 
 interface DetachedProcessRecord {
   readonly args?: readonly string[];
@@ -933,19 +969,40 @@ const spawnDetachedServer = Effect.fn('lifecycle.spawnDetachedServer')(function*
   const fs = yield* FileSystem.FileSystem;
   const system = yield* SystemInfo;
   if (system.platform === 'win32') {
+    const powershell = yield* findExecutable(['powershell']);
+    if (!powershell) {
+      return yield* Effect.fail(new Error('PowerShell is required to start OpenViking in the background on Windows.'));
+    }
     yield* fs.writeFileString(
       logPath,
       'Detached Windows server output is not captured. Run threadnote start --foreground for diagnostics.\n',
       {flag: 'a'},
     );
-    const child = yield* ChildProcess.make(server, [...args], {
-      detached: true,
-      stderr: 'ignore',
-      stdin: 'ignore',
-      stdout: 'ignore',
-    });
-    yield* child.unref;
-    return Number(child.pid);
+    const launched = yield* runCommandEffect(
+      powershell,
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-WindowStyle',
+        'Hidden',
+        '-Command',
+        WINDOWS_DETACHED_SERVER_START_SCRIPT,
+      ],
+      {
+        env: {
+          ...system.environment(),
+          THREADNOTE_DETACHED_SERVER: server,
+          THREADNOTE_DETACHED_SERVER_ARGUMENT_LINE: windowsProcessArgumentLine(args),
+        },
+        timeoutMs: STOP_SERVER_TIMEOUT_MS,
+      },
+    );
+    const childPid = Number(launched.stdout.trim().split(/\s+/).at(-1));
+    if (!Number.isInteger(childPid) || childPid <= 0) {
+      return yield* Effect.fail(new Error('PowerShell did not report the detached OpenViking server pid.'));
+    }
+    return childPid;
   }
   const logSink = fs.sink(logPath, {flag: 'a'}).pipe(Sink.as(new Uint8Array()));
   const child = yield* ChildProcess.make(server, [...args], {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -109,10 +109,11 @@ const INSTALL_OUTPUT_TAIL_CHARS = 64_000;
 const MINIMUM_UV_SYSTEM_CERTS_VERSION = '0.11.0';
 const STOP_SERVER_TIMEOUT_MS = 10_000;
 const WINDOWS_DETACHED_SERVER_SCRIPT = [
-  "$ErrorActionPreference = 'Continue'",
+  "$ErrorActionPreference = 'Stop'",
   '$serverArgs = @(ConvertFrom-Json -InputObject $env:THREADNOTE_DETACHED_SERVER_ARGS)',
-  '& $env:THREADNOTE_DETACHED_SERVER @serverArgs *>> $env:THREADNOTE_DETACHED_SERVER_LOG',
-  'exit $LASTEXITCODE',
+  `$argumentLine = ($serverArgs | ForEach-Object { '"' + $_ + '"' }) -join ' '`,
+  '$process = Start-Process -FilePath $env:THREADNOTE_DETACHED_SERVER -ArgumentList $argumentLine -WindowStyle Hidden -PassThru -RedirectStandardOutput $env:THREADNOTE_DETACHED_SERVER_STDOUT -RedirectStandardError $env:THREADNOTE_DETACHED_SERVER_LOG',
+  '[Console]::Out.WriteLine($process.Id)',
 ].join('; ');
 const parseJson = Option.liftThrowable((content: string): unknown => JSON.parse(content));
 
@@ -942,7 +943,7 @@ const spawnDetachedServer = Effect.fn('lifecycle.spawnDetachedServer')(function*
     if (!powershell) {
       return yield* Effect.fail(new Error('PowerShell is required to start OpenViking in the background on Windows.'));
     }
-    const child = yield* ChildProcess.make(
+    const launched = yield* runCommandEffect(
       powershell,
       [
         '-NoLogo',
@@ -954,20 +955,21 @@ const spawnDetachedServer = Effect.fn('lifecycle.spawnDetachedServer')(function*
         WINDOWS_DETACHED_SERVER_SCRIPT,
       ],
       {
-        detached: true,
         env: {
+          ...system.environment(),
           THREADNOTE_DETACHED_SERVER: server,
           THREADNOTE_DETACHED_SERVER_ARGS: JSON.stringify(args),
           THREADNOTE_DETACHED_SERVER_LOG: logPath,
+          THREADNOTE_DETACHED_SERVER_STDOUT: `${logPath}.stdout`,
         },
-        extendEnv: true,
-        stderr: 'ignore',
-        stdin: 'ignore',
-        stdout: 'ignore',
+        timeoutMs: STOP_SERVER_TIMEOUT_MS,
       },
     );
-    yield* child.unref;
-    return Number(child.pid);
+    const childPid = Number(launched.stdout.trim().split(/\s+/).at(-1));
+    if (!Number.isInteger(childPid) || childPid <= 0) {
+      return yield* Effect.fail(new Error('PowerShell did not report the detached OpenViking server pid.'));
+    }
+    return childPid;
   }
   const logSink = fs.sink(logPath, {flag: 'a'}).pipe(Sink.as(new Uint8Array()));
   const child = yield* ChildProcess.make(server, [...args], {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -108,6 +108,12 @@ import {
 const INSTALL_OUTPUT_TAIL_CHARS = 64_000;
 const MINIMUM_UV_SYSTEM_CERTS_VERSION = '0.11.0';
 const STOP_SERVER_TIMEOUT_MS = 10_000;
+const WINDOWS_DETACHED_SERVER_SCRIPT = [
+  "$ErrorActionPreference = 'Continue'",
+  '$serverArgs = @(ConvertFrom-Json -InputObject $env:THREADNOTE_DETACHED_SERVER_ARGS)',
+  '& $env:THREADNOTE_DETACHED_SERVER @serverArgs *>> $env:THREADNOTE_DETACHED_SERVER_LOG',
+  'exit $LASTEXITCODE',
+].join('; ');
 const parseJson = Option.liftThrowable((content: string): unknown => JSON.parse(content));
 
 interface DetachedProcessRecord {
@@ -931,19 +937,44 @@ const spawnDetachedServer = Effect.fn('lifecycle.spawnDetachedServer')(function*
 ) {
   const fs = yield* FileSystem.FileSystem;
   const system = yield* SystemInfo;
-  const output = system.platform === 'win32' ? 'ignore' : fs.sink(logPath, {flag: 'a'}).pipe(Sink.as(new Uint8Array()));
   if (system.platform === 'win32') {
-    yield* fs.writeFileString(
-      logPath,
-      'Detached Windows server output is not captured. Run threadnote start --foreground for diagnostics.\n',
-      {flag: 'a'},
+    const powershell = yield* findExecutable(['powershell']);
+    if (!powershell) {
+      return yield* Effect.fail(new Error('PowerShell is required to start OpenViking in the background on Windows.'));
+    }
+    const child = yield* ChildProcess.make(
+      powershell,
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-WindowStyle',
+        'Hidden',
+        '-Command',
+        WINDOWS_DETACHED_SERVER_SCRIPT,
+      ],
+      {
+        detached: true,
+        env: {
+          THREADNOTE_DETACHED_SERVER: server,
+          THREADNOTE_DETACHED_SERVER_ARGS: JSON.stringify(args),
+          THREADNOTE_DETACHED_SERVER_LOG: logPath,
+        },
+        extendEnv: true,
+        stderr: 'ignore',
+        stdin: 'ignore',
+        stdout: 'ignore',
+      },
     );
+    yield* child.unref;
+    return Number(child.pid);
   }
+  const logSink = fs.sink(logPath, {flag: 'a'}).pipe(Sink.as(new Uint8Array()));
   const child = yield* ChildProcess.make(server, [...args], {
     detached: true,
-    stderr: output,
+    stderr: logSink,
     stdin: 'ignore',
-    stdout: output,
+    stdout: logSink,
   });
   yield* child.unref;
   return Number(child.pid);

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,14 +1,14 @@
-import {createServer, type IncomingMessage, type Server, type ServerResponse} from 'node:http';
-import {randomBytes, randomUUID} from 'node:crypto';
-import {lstat, readFile, readdir, rm} from 'node:fs/promises';
-import {join, relative, sep} from 'node:path';
-import {Console, Effect, FiberSet, FileSystem, Result} from 'effect';
+import * as NodeHttpServer from '@effect/platform-node/NodeHttpServer';
+import {Console, Crypto, Effect, Encoding, FileSystem, Path, Result} from 'effect';
+import * as HttpServer from 'effect/unstable/http/HttpServer';
+import * as HttpServerRequest from 'effect/unstable/http/HttpServerRequest';
+import * as HttpServerResponse from 'effect/unstable/http/HttpServerResponse';
 import {effectAiConfiguration, runEffectAiConsolidation} from './effect/ai-consolidator.js';
 import {runCommandEffect} from './effect/command.js';
-import {captureConsole, capturePromiseConsole, consoleOutput} from './effect/console.js';
-import {fromPromiseError} from './effect/errors.js';
+import {captureConsole} from './effect/console.js';
 import type {ApplicationServices} from './effect/runtime.js';
 import {withSharedRepositoryLock} from './effect/share_lock.js';
+import {SystemInfo} from './effect/system.js';
 import {
   runShareInit,
   runSharePublish,
@@ -55,7 +55,6 @@ import type {
   MemoryKind,
   MemoryStatus,
   RuntimeConfig,
-  ShareTeamConfig,
 } from './types.js';
 import {
   assertVikingUri,
@@ -69,6 +68,74 @@ import {
   toolRoot,
 } from './utils.js';
 import {openVikingLogPath, withIdentity} from './runtime.js';
+
+interface ManagerDirectoryEntry {
+  readonly name: string;
+  readonly isDirectory: () => boolean;
+  readonly isFile: () => boolean;
+}
+
+const pathJoin = Effect.fn('manager.pathJoin')(function* (...parts: readonly string[]) {
+  const path = yield* Path.Path;
+  return path.join(...parts);
+});
+
+const pathRelative = Effect.fn('manager.pathRelative')(function* (from: string, to: string) {
+  const path = yield* Path.Path;
+  return path.relative(from, to);
+});
+
+const pathSeparator = Effect.map(Path.Path, path => path.sep);
+
+const lstat = Effect.fn('manager.lstat')(function* (target: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const link = yield* fs.readLink(target).pipe(Effect.option);
+  const info = yield* fs.stat(target);
+  return {
+    isDirectory: () => link._tag === 'None' && info.type === 'Directory',
+    isFile: () => link._tag === 'None' && info.type === 'File',
+    mtime: info.mtime._tag === 'Some' ? info.mtime.value : new Date(0),
+    name: path.basename(target),
+    size: Number(info.size),
+  };
+});
+
+function readFile(target: string): Effect.Effect<Uint8Array, unknown, FileSystem.FileSystem>;
+function readFile(target: string, encoding: 'utf8'): Effect.Effect<string, unknown, FileSystem.FileSystem>;
+function readFile(
+  target: string,
+  encoding?: 'utf8',
+): Effect.Effect<string | Uint8Array, unknown, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    return encoding ? yield* fs.readFileString(target, encoding) : yield* fs.readFile(target);
+  });
+}
+
+function readdir(
+  target: string,
+  _options: {readonly withFileTypes: true},
+): Effect.Effect<ManagerDirectoryEntry[], unknown, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const names = yield* fs.readDirectory(target);
+    return yield* Effect.forEach(names, name =>
+      lstat(path.join(target, name)).pipe(
+        Effect.map(info => ({name, isDirectory: info.isDirectory, isFile: info.isFile})),
+      ),
+    );
+  });
+}
+
+const rm = Effect.fn('manager.rm')(function* (
+  target: string,
+  options?: {readonly force?: boolean; readonly recursive?: boolean},
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.remove(target, options);
+});
 
 interface ManagerTreeNode {
   readonly children?: readonly ManagerTreeNode[];
@@ -96,8 +163,19 @@ interface ApiContext {
   readonly token: string;
 }
 
+interface ManagerRequest {
+  readonly body: Effect.Effect<Record<string, unknown>, unknown>;
+  readonly headers: Readonly<Record<string, string | undefined>>;
+  readonly method: string;
+  readonly url: string;
+}
+
+interface ManagerResponseSink {
+  response?: HttpServerResponse.HttpServerResponse;
+}
+
 type ManagerOperation<A> = Effect.Effect<A, unknown, ApplicationServices>;
-type ManagerEffectPromise = <A>(effect: ManagerOperation<A>) => Promise<A>;
+type ManagerEffectPromise = undefined;
 
 type ConsolidationStatus = 'completed' | 'failed' | 'running';
 
@@ -146,19 +224,11 @@ const STATIC_FILES: Readonly<
 export function runManage(config: RuntimeConfig, options: ManageOptions) {
   return Effect.scoped(
     Effect.gen(function* () {
-      const token = randomBytes(24).toString('base64url');
-      const runEffect = yield* FiberSet.makeRuntimePromise<ApplicationServices>();
-      const server = createManagerServer({config, jobs: new Map(), token}, runEffect);
-      const port = options.uiPort ?? 0;
-      yield* Effect.acquireRelease(
-        fromPromiseError(async () => {
-          await listen(server, port);
-          return server;
-        }),
-        closeManagerServer,
-      );
-      const address = server.address();
-      const actualPort = typeof address === 'object' && address ? address.port : port;
+      const crypto = yield* Crypto.Crypto;
+      const token = Encoding.encodeBase64Url(yield* crypto.randomBytes(24));
+      const server = yield* HttpServer.HttpServer;
+      yield* server.serve(createManagerServer({config, jobs: new Map(), token}));
+      const actualPort = server.address._tag === 'TcpAddress' ? server.address.port : (options.uiPort ?? 0);
       const url = `http://127.0.0.1:${actualPort}/?token=${encodeURIComponent(token)}`;
       yield* Console.log(`Threadnote manager: ${url}`);
       yield* Console.log('Press Ctrl-C to stop the manager.');
@@ -167,87 +237,90 @@ export function runManage(config: RuntimeConfig, options: ManageOptions) {
       }
       return yield* Effect.never;
     }),
-  );
-}
-
-function closeManagerServer(server: Server): Effect.Effect<void> {
-  return Effect.callback<void>(resume => {
-    server.close(() => resume(Effect.void));
-  });
+  ).pipe(Effect.provide(NodeHttpServer.layerTest));
 }
 
 type ManagerRequestEffect = Effect.Effect<void, never, ApplicationServices>;
 
-export function createManagerServer(context: ApiContext, runEffect: ManagerEffectPromise): Server {
-  const requestContext: ApiContext = {...context, runEffect};
-  return createServer((request, response) => {
-    void runEffect(handleRequestEffect(requestContext, request, response)).catch(error => {
-      if (!response.headersSent) {
-        writeJson(response, 500, {error: errorMessage(error)});
-      } else {
-        response.destroy(error instanceof Error ? error : new Error(String(error)));
-      }
-    });
+export function createManagerServer(
+  context: ApiContext,
+): Effect.Effect<
+  HttpServerResponse.HttpServerResponse,
+  never,
+  ApplicationServices | HttpServerRequest.HttpServerRequest
+> {
+  return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const response: ManagerResponseSink = {};
+    const managerRequest: ManagerRequest = {
+      body: request.json.pipe(
+        Effect.flatMap(parsed =>
+          typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+            ? Effect.succeed(parsed as Record<string, unknown>)
+            : Effect.fail(new Error('Expected a JSON object body.')),
+        ),
+      ),
+      headers: request.headers,
+      method: request.method,
+      url: request.url,
+    };
+    yield* handleRequestEffect(context, managerRequest, response);
+    return response.response ?? HttpServerResponse.empty({status: 204});
   });
 }
 
-export async function memoryTree(config: RuntimeConfig): Promise<ManagerTreeNode> {
-  const root = localMemoriesRoot(config);
-  return readTree(config, root, `viking://user/${uriSegment(config.user)}/memories`, '');
-}
+export const memoryTree = Effect.fn('manager.memoryTree')(function* (config: RuntimeConfig) {
+  const root = yield* localMemoriesRoot(config);
+  return yield* readTree(config, root, `viking://user/${uriSegment(config.user)}/memories`, '');
+});
 
-export async function resourcesTree(config: RuntimeConfig): Promise<ManagerTreeNode> {
-  const root = localResourcesRoot(config);
-  try {
-    return await readTree(config, root, 'viking://resources', '', {
-      parseMemoryDocuments: false,
-      rootName: 'resources',
-    });
-  } catch (err) {
-    if (isMissingPathError(err)) {
-      return {
+export const resourcesTree = Effect.fn('manager.resourcesTree')(function* (config: RuntimeConfig) {
+  const root = yield* localResourcesRoot(config);
+  return yield* readTree(config, root, 'viking://resources', '', {
+    parseMemoryDocuments: false,
+    rootName: 'resources',
+  }).pipe(
+    Effect.catch(error => {
+      if (!isMissingPathError(error)) {
+        return Effect.fail(error);
+      }
+      return Effect.succeed({
         children: [],
-        isDir: true,
+        isDir: true as const,
         isShared: false,
         isSystem: false,
         name: 'resources',
         relativePath: '',
         uri: 'viking://resources',
-      };
-    }
-    throw err;
-  }
-}
+      });
+    }),
+  );
+});
 
-export async function readManagedMemory(
-  config: RuntimeConfig,
-  uri: string,
-): Promise<{
-  readonly content: string;
-  readonly node: ManagerTreeNode;
-  readonly record?: MemoryRecord;
-}> {
+export const readManagedMemory = Effect.fn('manager.readManagedMemory')(function* (config: RuntimeConfig, uri: string) {
   assertVikingUri(uri);
-  const path = localPathForMemoryUri(config, uri);
+  const path = yield* localPathForMemoryUri(config, uri);
   if (!path) {
-    throw new Error(`Manager can only read current-user memory URIs: ${uri}`);
+    return yield* Effect.fail(new Error(`Manager can only read current-user memory URIs: ${uri}`));
   }
-  const pathStat = await lstat(path);
+  const pathStat = yield* lstat(path);
   if (!pathStat.isFile()) {
-    throw new Error(`Manager can only read regular memory files: ${uri}`);
+    return yield* Effect.fail(new Error(`Manager can only read regular memory files: ${uri}`));
   }
-  const content = await readFile(path, 'utf8');
-  const relativePath = relative(localMemoriesRoot(config), path).split(sep).join('/');
+  const content = yield* readFile(path, 'utf8');
+  const relativePath = (yield* pathRelative(yield* localMemoriesRoot(config), path))
+    .split(yield* pathSeparator)
+    .join('/');
   const record = parseMemoryDocument(uri, content);
   return {
     content,
     node: {
       isDir: false,
       isShared: isInSharedNamespace(config, uri),
-      isSystem: isSystemMemoryName(path.split(sep).at(-1) ?? ''),
+      isSystem: isSystemMemoryName(path.split(yield* pathSeparator).at(-1) ?? ''),
       metadata: record?.metadata,
       modTime: pathStat.mtime.toISOString(),
-      name: path.split(sep).at(-1) ?? uri,
+      name: path.split(yield* pathSeparator).at(-1) ?? uri,
       relativePath,
       sharedTeam: sharedTeamNameForUri(config, uri),
       size: pathStat.size,
@@ -255,37 +328,29 @@ export async function readManagedMemory(
     },
     record,
   };
-}
+});
 
-export async function readContextUri(
+export const readContextUri = Effect.fn('manager.readContextUri')(function* (
   config: RuntimeConfig,
   uri: string,
   runEffect?: ManagerEffectPromise,
-): Promise<{
-  readonly content: string;
-  readonly localMemory?: Awaited<ReturnType<typeof readManagedMemory>>;
-  readonly output: string;
-}> {
+) {
   assertVikingUri(uri);
-  try {
-    const localMemory = await readManagedMemory(config, uri);
-    return {content: localMemory.content, localMemory, output: localMemory.content};
-  } catch {
-    const result = await runCaptured(() => runRead(config, uri, {}), runEffect);
-    return {content: result.output, output: result.output};
+  const localMemory = yield* Effect.result(readManagedMemory(config, uri));
+  if (Result.isSuccess(localMemory)) {
+    return {
+      content: localMemory.success.content,
+      localMemory: localMemory.success,
+      output: localMemory.success.content,
+    };
   }
-}
+  const result = yield* runCaptured(() => runRead(config, uri, {}), runEffect);
+  return {content: result.output, output: result.output};
+});
 
-export async function detectConsolidationAgents(): Promise<
-  readonly {
-    readonly available: boolean;
-    readonly command?: string;
-    readonly id: ConsolidationAgent;
-    readonly label: string;
-  }[]
-> {
-  const effectAi = effectAiConfiguration();
-  const [codex, claude, cursor, copilot] = await Promise.all([
+export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationAgents')(function* () {
+  const effectAi = effectAiConfiguration((yield* SystemInfo).environment());
+  const [codex, claude, cursor, copilot] = yield* Effect.all([
     findExecutable(['codex']),
     findExecutable(['claude']),
     findExecutable(['cursor-agent']),
@@ -303,12 +368,12 @@ export async function detectConsolidationAgents(): Promise<
       label: 'Effect AI (OpenAI-compatible)',
     },
   ];
-}
+});
 
 function handleRequestEffect(
   context: ApiContext,
-  request: IncomingMessage,
-  response: ServerResponse,
+  request: ManagerRequest,
+  response: ManagerResponseSink,
 ): ManagerRequestEffect {
   const url = new URL(request.url ?? '/', 'http://127.0.0.1');
   let requestEffect: Effect.Effect<void, unknown, ApplicationServices>;
@@ -318,13 +383,9 @@ function handleRequestEffect(
         writeJson(response, 401, {error: 'Unauthorized'});
         return;
       }
-      const [agents, version] = yield* fromPromiseError(() =>
-        Promise.all([detectConsolidationAgents(), currentPackageVersion()]),
-      );
-      const latest = yield* Effect.try({
-        try: updateRegistry,
-        catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-      }).pipe(
+      const system = yield* SystemInfo;
+      const [agents, version] = yield* Effect.all([detectConsolidationAgents(), currentPackageVersion()]);
+      const latest = yield* Effect.succeed(updateRegistry(system.environment())).pipe(
         Effect.flatMap(registry => fetchLatestVersion(registry, selectUpdateChannel(version))),
         Effect.match({onFailure: Result.fail, onSuccess: Result.succeed}),
       );
@@ -332,7 +393,7 @@ function handleRequestEffect(
         agents,
         config: publicConfig(context.config),
         latestVersion: Result.isSuccess(latest) ? latest.success : undefined,
-        openVikingLogPath: openVikingLogPath(context.config),
+        openVikingLogPath: yield* openVikingLogPath(context.config),
         version,
       });
     });
@@ -342,12 +403,12 @@ function handleRequestEffect(
         writeJson(response, 401, {error: 'Unauthorized'});
         return;
       }
-      const body = yield* fromPromiseError(() => readJsonBody(request));
+      const body = yield* readJsonBody(request);
       const job = yield* createConsolidation(context, body);
       writeJson(response, 200, {job});
     });
   } else {
-    requestEffect = fromPromiseError(() => handleRequestLegacy(context, request, response));
+    requestEffect = handleRequestLegacy(context, request, response);
   }
 
   return requestEffect.pipe(
@@ -359,19 +420,18 @@ function handleRequestEffect(
   );
 }
 
-async function handleRequestLegacy(
+const handleRequestLegacy = Effect.fn('manager.handleRequestLegacy')(function* (
   context: ApiContext,
-  request: IncomingMessage,
-  response: ServerResponse,
-): Promise<void> {
+  request: ManagerRequest,
+  response: ManagerResponseSink,
+) {
   const url = new URL(request.url ?? '/', 'http://127.0.0.1');
   if (request.method === 'GET' && STATIC_FILES[url.pathname]) {
-    await serveStatic(context, url, response);
+    yield* serveStatic(context, url, response);
     return;
   }
   if (request.method === 'GET' && url.pathname === '/favicon.ico') {
-    response.writeHead(204, {'cache-control': 'no-store'});
-    response.end();
+    response.response = HttpServerResponse.empty({status: 204, headers: {'cache-control': 'no-store'}});
     return;
   }
   if (!isAuthorized(context, request)) {
@@ -380,26 +440,26 @@ async function handleRequestLegacy(
   }
 
   if (request.method === 'GET' && url.pathname === '/api/tree') {
-    const [tree, resourceTree] = await Promise.all([memoryTree(context.config), resourcesTree(context.config)]);
+    const [tree, resourceTree] = yield* Effect.all([memoryTree(context.config), resourcesTree(context.config)]);
     writeJson(response, 200, {resourcesTree: resourceTree, tree});
     return;
   }
   if (request.method === 'GET' && url.pathname === '/api/memory') {
-    writeJson(response, 200, await readManagedMemory(context.config, requiredQuery(url, 'uri')));
+    writeJson(response, 200, yield* readManagedMemory(context.config, requiredQuery(url, 'uri')));
     return;
   }
   if (request.method === 'GET' && url.pathname === '/api/read') {
-    writeJson(response, 200, await readContextUri(context.config, requiredQuery(url, 'uri'), context.runEffect));
+    writeJson(response, 200, yield* readContextUri(context.config, requiredQuery(url, 'uri'), context.runEffect));
     return;
   }
   if (request.method === 'GET' && url.pathname === '/api/shares') {
-    writeJson(response, 200, {shares: await shareSummaries(context.config)});
+    writeJson(response, 200, {shares: yield* shareSummaries(context.config)});
     return;
   }
   if (request.method === 'GET' && url.pathname === '/api/doctor') {
     writeJson(response, 200, {
-      checks: await collectManagerDoctorChecks(context.config),
-      shares: await shareSummaries(context.config),
+      checks: yield* collectManagerDoctorChecks(context.config),
+      shares: yield* shareSummaries(context.config),
     });
     return;
   }
@@ -414,14 +474,14 @@ async function handleRequestLegacy(
     return;
   }
 
-  const body = await readJsonBody(request);
+  const body = yield* readJsonBody(request);
   switch (url.pathname) {
     case '/api/memory/archive':
       requireConfirm(body);
       writeJson(
         response,
         200,
-        await runCaptured(() => runArchive(context.config, requireString(body.uri, 'uri'), body), context.runEffect),
+        yield* runCaptured(() => runArchive(context.config, requireString(body.uri, 'uri'), body), context.runEffect),
       );
       return;
     case '/api/memory/forget':
@@ -429,18 +489,18 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() => runForget(context.config, requireString(body.uri, 'uri'), {}), context.runEffect),
+        yield* runCaptured(() => runForget(context.config, requireString(body.uri, 'uri'), {}), context.runEffect),
       );
       return;
     case '/api/memory/save':
-      writeJson(response, 200, await saveMemory(context.config, body, context.runEffect));
+      writeJson(response, 200, yield* saveMemory(context.config, body, context.runEffect));
       return;
     case '/api/memory/move':
       requireConfirm(body);
       writeJson(
         response,
         200,
-        await moveMemory(context.config, requireString(body.uri, 'uri'), targetFromBody(body), context.runEffect),
+        yield* moveMemory(context.config, requireString(body.uri, 'uri'), targetFromBody(body), context.runEffect),
       );
       return;
     case '/api/memory/publish':
@@ -448,7 +508,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () =>
             runSharePublish(context.config, requireString(body.uri, 'uri'), {
               redact: body.redact === true,
@@ -463,7 +523,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () => runShareUnpublish(context.config, requireString(body.uri, 'uri'), {team: optionalString(body.team)}),
           context.runEffect,
         ),
@@ -474,12 +534,15 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() => removeManagedFolder(context.config, requireString(body.uri, 'uri'), context.runEffect)),
+        yield* runCaptured(
+          () => removeManagedFolder(context.config, requireString(body.uri, 'uri')),
+          context.runEffect,
+        ),
       );
       return;
     case '/api/bulk':
       requireConfirm(body);
-      writeJson(response, 200, await runBulk(context.config, body, context.runEffect));
+      writeJson(response, 200, yield* runBulk(context.config, body, context.runEffect));
       return;
     case '/api/compact':
       if (body.apply === true) {
@@ -488,10 +551,10 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () =>
             Effect.gen(function* () {
-              yield* fromPromiseError(() => runCompactDiagnostics(context.config, body));
+              yield* runCompactDiagnostics(context.config, body);
               yield* runCompact(context.config, body);
             }),
           context.runEffect,
@@ -502,7 +565,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () =>
             runRecall(context.config, {
               query: requireString(body.query, 'query'),
@@ -514,14 +577,18 @@ async function handleRequestLegacy(
       );
       return;
     case '/api/read':
-      writeJson(response, 200, await readContextUri(context.config, requireString(body.uri, 'uri'), context.runEffect));
+      writeJson(
+        response,
+        200,
+        yield* readContextUri(context.config, requireString(body.uri, 'uri'), context.runEffect),
+      );
       return;
     case '/api/shares/init':
       requireConfirm(body);
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () =>
             runShareInit(context.config, requireString(body.remoteUrl, 'remoteUrl'), {
               team: optionalString(body.team),
@@ -535,7 +602,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () =>
             runShareRename(context.config, {
               team: requireString(body.team, 'team'),
@@ -550,7 +617,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () =>
             runShareSetUrl(context.config, requireString(body.remoteUrl, 'remoteUrl'), {
               team: optionalString(body.team),
@@ -564,7 +631,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () =>
             runShareRemove(context.config, {
               keepFiles: body.keepFiles === true,
@@ -579,25 +646,25 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(() => runShareSync(context.config, {team: optionalString(body.team)}), context.runEffect),
+        yield* runCaptured(() => runShareSync(context.config, {team: optionalString(body.team)}), context.runEffect),
       );
       return;
     case '/api/doctor/start':
-      writeJson(response, 200, await runCaptured(() => runStart(context.config, {}), context.runEffect));
+      writeJson(response, 200, yield* runCaptured(() => runStart(context.config, {}), context.runEffect));
       return;
     case '/api/doctor/repair-dry-run':
-      writeJson(response, 200, await runCaptured(() => runRepair(context.config, {dryRun: true}), context.runEffect));
+      writeJson(response, 200, yield* runCaptured(() => runRepair(context.config, {dryRun: true}), context.runEffect));
       return;
     case '/api/doctor/repair':
       requireConfirm(body);
-      writeJson(response, 200, await runCaptured(() => runRepair(context.config, {dryRun: false}), context.runEffect));
+      writeJson(response, 200, yield* runCaptured(() => runRepair(context.config, {dryRun: false}), context.runEffect));
       return;
     case '/api/import-pack':
       requireConfirm(body);
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () => runImportPack(context.config, {path: requireString(body.path, 'path')}),
           context.runEffect,
         ),
@@ -607,7 +674,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () => runExportPack(context.config, {path: optionalString(body.path), uri: optionalString(body.uri)}),
           context.runEffect,
         ),
@@ -618,7 +685,7 @@ async function handleRequestLegacy(
       writeJson(
         response,
         200,
-        await runCaptured(
+        yield* runCaptured(
           () =>
             body.skills === true
               ? runSeedSkills(context.config, {dryRun: body.dryRun === true})
@@ -631,47 +698,85 @@ async function handleRequestLegacy(
       if (url.pathname.startsWith('/api/consolidations/') && url.pathname.endsWith('/apply')) {
         requireConfirm(body);
         const id = url.pathname.split('/').at(-2) ?? '';
-        writeJson(response, 200, await applyConsolidation(context.config, context.jobs, id, body, context.runEffect));
+        writeJson(response, 200, yield* applyConsolidation(context.config, context.jobs, id, body, context.runEffect));
         return;
       }
       writeJson(response, 404, {error: 'Not found'});
   }
-}
+});
 
-async function serveStatic(context: ApiContext, url: URL, response: ServerResponse): Promise<void> {
+const serveStatic = Effect.fn('manager.serveStatic')(function* (
+  context: ApiContext,
+  url: URL,
+  response: ManagerResponseSink,
+) {
   const file = STATIC_FILES[url.pathname] ?? STATIC_FILES['/'];
-  const content = await readFile(join(toolRoot(), file.root ?? 'manager', file.path));
+  const content = yield* readFile(yield* pathJoin(yield* toolRoot(), file.root ?? 'manager', file.path));
   const headers: Record<string, string> = {'content-type': file.contentType};
   if (file.root !== 'docs') {
     headers['cache-control'] = 'no-store';
   }
-  response.writeHead(200, headers);
-  response.end(content);
-}
+  response.response = HttpServerResponse.uint8Array(content, {status: 200, headers});
+});
 
-async function readTree(
+const readTree: (
   config: RuntimeConfig,
   path: string,
   uri: string,
   relativePath: string,
-  options: ReadTreeOptions = {},
-): Promise<ManagerTreeNode> {
-  const pathStat = await lstat(path);
-  const name = relativePath ? (relativePath.split('/').at(-1) ?? relativePath) : (options.rootName ?? 'memories');
-  const isDir = pathStat.isDirectory();
-  if (!isDir) {
-    if (!pathStat.isFile()) {
-      throw new Error(`Manager can only read regular files or directories: ${uri}`);
+  options?: ReadTreeOptions,
+) => Effect.Effect<ManagerTreeNode, unknown, FileSystem.FileSystem | Path.Path> = Effect.fn('manager.readTree')(
+  function* (config: RuntimeConfig, path: string, uri: string, relativePath: string, options: ReadTreeOptions = {}) {
+    const pathStat = yield* lstat(path);
+    const name = relativePath ? (relativePath.split('/').at(-1) ?? relativePath) : (options.rootName ?? 'memories');
+    const isDir = pathStat.isDirectory();
+    if (!isDir) {
+      if (!pathStat.isFile()) {
+        throw new Error(`Manager can only read regular files or directories: ${uri}`);
+      }
+      const record =
+        options.parseMemoryDocuments === false
+          ? undefined
+          : parseMemoryDocument(uri, yield* readFile(path, 'utf8').pipe(Effect.catch(() => Effect.succeed(''))));
+      return {
+        isDir: false,
+        isShared: isInSharedNamespace(config, uri),
+        isSystem: isSystemMemoryName(name),
+        metadata: record?.metadata,
+        modTime: pathStat.mtime.toISOString(),
+        name,
+        relativePath,
+        sharedTeam: sharedTeamNameForUri(config, uri),
+        size: pathStat.size,
+        uri,
+      };
     }
-    const record =
-      options.parseMemoryDocuments === false
-        ? undefined
-        : parseMemoryDocument(uri, await readFile(path, 'utf8').catch(() => ''));
+    const entries = yield* readdir(path, {withFileTypes: true});
+    const children = yield* Effect.all(
+      entries
+        .filter(entry => entry.isDirectory() || entry.isFile())
+        .sort(
+          (left, right) =>
+            Number(right.isDirectory()) - Number(left.isDirectory()) || left.name.localeCompare(right.name),
+        )
+        .map(
+          Effect.fn('manager.readTreeChild')(function* (entry) {
+            const childRelative = relativePath ? `${relativePath}/${entry.name}` : entry.name;
+            return yield* readTree(
+              config,
+              yield* pathJoin(path, entry.name),
+              `${uri}/${entry.name}`,
+              childRelative,
+              options,
+            );
+          }),
+        ),
+    );
     return {
-      isDir: false,
+      children,
+      isDir: true,
       isShared: isInSharedNamespace(config, uri),
       isSystem: isSystemMemoryName(name),
-      metadata: record?.metadata,
       modTime: pathStat.mtime.toISOString(),
       name,
       relativePath,
@@ -679,44 +784,19 @@ async function readTree(
       size: pathStat.size,
       uri,
     };
-  }
-  const entries = await readdir(path, {withFileTypes: true});
-  const children = await Promise.all(
-    entries
-      .filter(entry => entry.isDirectory() || entry.isFile())
-      .sort(
-        (left, right) =>
-          Number(right.isDirectory()) - Number(left.isDirectory()) || left.name.localeCompare(right.name),
-      )
-      .map(entry => {
-        const childRelative = relativePath ? `${relativePath}/${entry.name}` : entry.name;
-        return readTree(config, join(path, entry.name), `${uri}/${entry.name}`, childRelative, options);
-      }),
-  );
-  return {
-    children,
-    isDir: true,
-    isShared: isInSharedNamespace(config, uri),
-    isSystem: isSystemMemoryName(name),
-    modTime: pathStat.mtime.toISOString(),
-    name,
-    relativePath,
-    sharedTeam: sharedTeamNameForUri(config, uri),
-    size: pathStat.size,
-    uri,
-  };
-}
+  },
+);
 
-async function saveMemory(
+const saveMemory = Effect.fn('manager.saveMemory')(function (
   config: RuntimeConfig,
   body: Record<string, unknown>,
   runEffect: ManagerEffectPromise | undefined,
-): Promise<{readonly output: string}> {
+) {
   const text = requireString(body.text, 'text');
   const replaceUri = optionalString(body.replaceUri);
   if (replaceUri && isRawMemoryDocument(text)) {
     return runCaptured(() => {
-      const write = fromPromiseError(() => writeRawMemory(config, replaceUri, text));
+      const write = writeRawMemory(config, replaceUri, text);
       return isInSharedNamespace(config, replaceUri) ? withSharedRepositoryLock(config, write) : write;
     }, runEffect);
   }
@@ -733,35 +813,39 @@ async function saveMemory(
       }),
     runEffect,
   );
-}
+});
 
-async function writeRawMemory(config: RuntimeConfig, uri: string, content: string): Promise<void> {
+const writeRawMemory = Effect.fn('manager.writeRawMemory')(function* (
+  config: RuntimeConfig,
+  uri: string,
+  content: string,
+) {
   assertVikingUri(uri);
-  const ov = await openVikingCliForMode(false);
+  const ov = yield* openVikingCliForMode(false);
   if (isInSharedNamespace(config, uri)) {
     const teamName = sharedTeamNameForUri(config, uri);
     if (!teamName) {
       throw new Error(`${uri} is not in a configured shared namespace.`);
     }
-    const team = await resolveTeam(config, teamName);
-    await ensureSharedDirectoryChain(config, ov, uri, false);
-    await writeMemoryFile(config, ov, uri, content, 'replace', false);
+    const team = yield* resolveTeam(config, teamName);
+    yield* ensureSharedDirectoryChain(config, ov, uri, false);
+    yield* writeMemoryFile(config, ov, uri, content, 'replace', false);
     const relativePath = vikingUriToWorktreeRelative(config, uri, team.name);
-    await publishShareGitChange(team.config.worktree, relativePath, `share: update ${relativePath}`);
+    yield* publishShareGitChange(team.config.worktree, relativePath, `share: update ${relativePath}`);
     return;
   }
-  await ensurePersonalDirectoryChain(config, ov, parentUri(uri));
-  await writeMemoryFile(config, ov, uri, content, 'replace', false);
-}
+  yield* ensurePersonalDirectoryChain(config, ov, parentUri(uri));
+  yield* writeMemoryFile(config, ov, uri, content, 'replace', false);
+});
 
-async function moveMemory(
+const moveMemory = Effect.fn('manager.moveMemory')(function* (
   config: RuntimeConfig,
   sourceUri: string,
   target: TargetMemoryInput,
   runEffect: ManagerEffectPromise | undefined,
-): Promise<{readonly output: string; readonly targetUri: string}> {
+) {
   assertVikingUri(sourceUri);
-  const source = await readManagedMemory(config, sourceUri);
+  const source = yield* readManagedMemory(config, sourceUri);
   const sourceRecord = source.record;
   const text = sourceRecord?.body ?? source.content;
   const metadata = {
@@ -771,7 +855,7 @@ async function moveMemory(
     status: target.status ?? sourceRecord?.metadata.status ?? 'active',
     topic: target.topic ?? sourceRecord?.metadata.topic ?? 'current',
   };
-  const personalTargetUri = memoryUriFor(config, metadata);
+  const personalTargetUri = yield* memoryUriFor(config, metadata);
   if (target.team) {
     const targetTeam = target.team;
     if (isInSharedNamespace(config, sourceUri)) {
@@ -782,19 +866,17 @@ async function moveMemory(
         );
       }
       const sharedTargetUri = sharedMemoryUriFor(config, targetTeam, metadata);
-      const output = await runCaptured(
+      const output = yield* runCaptured(
         () =>
           withSharedRepositoryLock(
             config,
-            fromPromiseError(() =>
-              moveSharedWithinTeam(config, sourceUri, sharedTargetUri, source.content, targetTeam),
-            ),
+            moveSharedWithinTeam(config, sourceUri, sharedTargetUri, source.content, targetTeam),
           ),
         runEffect,
       );
       return {...output, targetUri: sharedTargetUri};
     }
-    const saved = await runCaptured(
+    const saved = yield* runCaptured(
       () =>
         runRemember(config, {
           kind: metadata.kind,
@@ -807,7 +889,7 @@ async function moveMemory(
         }),
       runEffect,
     );
-    const published = await runCaptured(
+    const published = yield* runCaptured(
       () => runSharePublish(config, personalTargetUri, {team: targetTeam}),
       runEffect,
     );
@@ -817,7 +899,7 @@ async function moveMemory(
     };
   }
   if (isInSharedNamespace(config, sourceUri)) {
-    const saved = await runCaptured(
+    const saved = yield* runCaptured(
       () =>
         runRemember(config, {
           kind: metadata.kind,
@@ -829,17 +911,13 @@ async function moveMemory(
         }),
       runEffect,
     );
-    const removed = await runCaptured(
-      () =>
-        withSharedRepositoryLock(
-          config,
-          fromPromiseError(() => removeSharedSource(config, sourceUri)),
-        ),
+    const removed = yield* runCaptured(
+      () => withSharedRepositoryLock(config, removeSharedSource(config, sourceUri)),
       runEffect,
     );
     return {output: [saved.output, removed.output].filter(Boolean).join('\n'), targetUri: personalTargetUri};
   }
-  const output = await runCaptured(
+  const output = yield* runCaptured(
     () =>
       runRemember(config, {
         kind: metadata.kind,
@@ -853,25 +931,25 @@ async function moveMemory(
     runEffect,
   );
   return {...output, targetUri: personalTargetUri};
-}
+});
 
-async function moveSharedWithinTeam(
+const moveSharedWithinTeam = Effect.fn('manager.moveSharedWithinTeam')(function* (
   config: RuntimeConfig,
   sourceUri: string,
   targetUri: string,
   content: string,
   teamName: string,
-): Promise<void> {
-  const team = await resolveTeam(config, teamName);
-  const ov = await openVikingCliForMode(false);
-  await ensureSharedDirectoryChain(config, ov, targetUri, false);
-  await writeMemoryFile(config, ov, targetUri, content, 'create', false);
-  await publishShareGitChange(
+) {
+  const team = yield* resolveTeam(config, teamName);
+  const ov = yield* openVikingCliForMode(false);
+  yield* ensureSharedDirectoryChain(config, ov, targetUri, false);
+  yield* writeMemoryFile(config, ov, targetUri, content, 'create', false);
+  yield* publishShareGitChange(
     team.config.worktree,
     vikingUriToWorktreeRelative(config, targetUri, team.name),
     `share: move ${vikingUriToWorktreeRelative(config, sourceUri, team.name)} to ${vikingUriToWorktreeRelative(config, targetUri, team.name)}`,
   );
-  await publishShareGitChange(
+  yield* publishShareGitChange(
     team.config.worktree,
     vikingUriToWorktreeRelative(config, sourceUri, team.name),
     `share: remove ${vikingUriToWorktreeRelative(config, sourceUri, team.name)}`,
@@ -879,17 +957,20 @@ async function moveSharedWithinTeam(
       verb: 'rm',
     },
   );
-  await removeMemoryUri(config, ov, sourceUri, false);
-}
+  yield* removeMemoryUri(config, ov, sourceUri, false);
+});
 
-async function removeSharedSource(config: RuntimeConfig, sourceUri: string): Promise<void> {
+const removeSharedSource = Effect.fn('manager.removeSharedSource')(function* (
+  config: RuntimeConfig,
+  sourceUri: string,
+) {
   const teamName = sharedTeamNameForUri(config, sourceUri);
   if (!teamName) {
     throw new Error(`${sourceUri} is not a shared memory.`);
   }
-  const team = await resolveTeam(config, teamName);
-  const ov = await openVikingCliForMode(false);
-  await publishShareGitChange(
+  const team = yield* resolveTeam(config, teamName);
+  const ov = yield* openVikingCliForMode(false);
+  yield* publishShareGitChange(
     team.config.worktree,
     vikingUriToWorktreeRelative(config, sourceUri, team.name),
     `share: remove ${vikingUriToWorktreeRelative(config, sourceUri, team.name)}`,
@@ -897,14 +978,10 @@ async function removeSharedSource(config: RuntimeConfig, sourceUri: string): Pro
       verb: 'rm',
     },
   );
-  await removeMemoryUri(config, ov, sourceUri, false);
-}
+  yield* removeMemoryUri(config, ov, sourceUri, false);
+});
 
-async function removeManagedFolder(
-  config: RuntimeConfig,
-  uri: string,
-  runEffect: ManagerEffectPromise | undefined,
-): Promise<void> {
+const removeManagedFolder = Effect.fn('manager.removeManagedFolder')(function* (config: RuntimeConfig, uri: string) {
   assertVikingUri(uri);
   const rootUri = `viking://user/${uriSegment(config.user)}/memories`;
   if (uri === rootUri) {
@@ -913,73 +990,85 @@ async function removeManagedFolder(
   if (isInSharedNamespace(config, uri)) {
     throw new Error('Shared folders are managed from Sharing. Remove the share or unpublish selected memories.');
   }
-  const path = localPathForMemoryUri(config, uri);
+  const path = yield* localPathForMemoryUri(config, uri);
   if (!path) {
     throw new Error(`Manager can only remove current-user memory folders: ${uri}`);
   }
-  const pathStat = await lstat(path);
+  const pathStat = yield* lstat(path);
   if (!pathStat.isDirectory()) {
     throw new Error(`Not a folder: ${uri}`);
   }
-  const relativePath = relative(localMemoriesRoot(config), path);
-  if (!relativePath || relativePath.startsWith('..') || relativePath.split(sep).includes('..')) {
+  const relativePath = yield* pathRelative(yield* localMemoriesRoot(config), path);
+  if (!relativePath || relativePath.startsWith('..') || relativePath.split(yield* pathSeparator).includes('..')) {
     throw new Error('Refusing to remove a folder outside the memories tree.');
   }
-  const fileUris = await fileUrisUnderFolder(config, path);
+  const fileUris = yield* fileUrisUnderFolder(config, path);
   for (const fileUri of fileUris) {
-    if (!runEffect) throw new Error('Manager Effect runtime is unavailable.');
-    await runEffect(runForget(config, fileUri, {}));
+    yield* runForget(config, fileUri, {});
   }
-  await rm(path, {force: true, recursive: true});
-  consoleOutput.log(`Removed folder: ${uri}`);
-  consoleOutput.log(`Forgot ${fileUris.length} file${fileUris.length === 1 ? '' : 's'}.`);
-}
+  yield* rm(path, {force: true, recursive: true});
+  yield* Console.log(`Removed folder: ${uri}`);
+  yield* Console.log(`Forgot ${fileUris.length} file${fileUris.length === 1 ? '' : 's'}.`);
+});
 
-async function fileUrisUnderFolder(config: RuntimeConfig, folderPath: string): Promise<readonly string[]> {
-  const entries = await readdir(folderPath, {withFileTypes: true});
+const fileUrisUnderFolder: (
+  config: RuntimeConfig,
+  folderPath: string,
+) => Effect.Effect<readonly string[], unknown, FileSystem.FileSystem | Path.Path> = Effect.fn(
+  'manager.fileUrisUnderFolder',
+)(function* (config: RuntimeConfig, folderPath: string) {
+  const entries = yield* readdir(folderPath, {withFileTypes: true});
   const uris: string[] = [];
   for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
-    const path = join(folderPath, entry.name);
+    const path = yield* pathJoin(folderPath, entry.name);
     if (entry.isDirectory()) {
-      uris.push(...(await fileUrisUnderFolder(config, path)));
+      uris.push(...(yield* fileUrisUnderFolder(config, path)));
     } else if (entry.isFile()) {
-      uris.push(localPathToMemoryUri(config, path));
+      uris.push(yield* localPathToMemoryUri(config, path));
     }
   }
   return uris;
-}
+});
 
-async function runBulk(
+const runBulk = Effect.fn('manager.runBulk')(function* (
   config: RuntimeConfig,
   body: Record<string, unknown>,
   runEffect: ManagerEffectPromise | undefined,
-): Promise<{readonly results: readonly BulkItemResult[]}> {
+) {
   const action = requireString(body.action, 'action');
   const uris = requireStringArray(body.uris, 'uris');
   const results: BulkItemResult[] = [];
   for (const uri of uris) {
-    try {
-      let output: string;
-      if (action === 'archive') {
-        output = (await runCaptured(() => runArchive(config, uri, {}), runEffect)).output;
-      } else if (action === 'forget') {
-        output = (await runCaptured(() => runForget(config, uri, {}), runEffect)).output;
-      } else if (action === 'publish') {
-        output = (await runCaptured(() => runSharePublish(config, uri, {team: optionalString(body.team)}), runEffect))
-          .output;
-      } else {
-        throw new Error(`Unsupported bulk action: ${action}`);
-      }
-      results.push({ok: true, output, uri});
-    } catch (err: unknown) {
-      results.push({error: errorMessage(err), ok: false, uri});
+    const outcome = yield* Effect.result(
+      Effect.gen(function* () {
+        let output: string;
+        if (action === 'archive') {
+          output = (yield* runCaptured(() => runArchive(config, uri, {}), runEffect)).output;
+        } else if (action === 'forget') {
+          output = (yield* runCaptured(() => runForget(config, uri, {}), runEffect)).output;
+        } else if (action === 'publish') {
+          output = (yield* runCaptured(
+            () => runSharePublish(config, uri, {team: optionalString(body.team)}),
+            runEffect,
+          )).output;
+        } else {
+          return yield* Effect.fail(new Error(`Unsupported bulk action: ${action}`));
+        }
+        return output;
+      }),
+    );
+    if (Result.isSuccess(outcome)) {
+      results.push({ok: true, output: outcome.success, uri});
+    } else {
+      results.push({error: errorMessage(outcome.failure), ok: false, uri});
     }
   }
   return {results};
-}
+});
 
 function createConsolidation(context: ApiContext, body: Record<string, unknown>) {
   return Effect.gen(function* () {
+    const crypto = yield* Crypto.Crypto;
     const input = yield* Effect.try({
       try: () => ({
         agent: consolidationAgent(requireString(body.agent, 'agent')),
@@ -991,16 +1080,14 @@ function createConsolidation(context: ApiContext, body: Record<string, unknown>)
     const job: ConsolidationJob = {
       agent: input.agent,
       createdAt: new Date().toISOString(),
-      id: randomUUID(),
+      id: yield* crypto.randomUUIDv4,
       sourceUris: input.sourceUris,
       status: 'running',
       target: input.target,
     };
     context.jobs.set(job.id, job);
     yield* Effect.gen(function* () {
-      const sources = yield* fromPromiseError(() =>
-        Promise.all(input.sourceUris.map(uri => readManagedMemory(context.config, uri))),
-      );
+      const sources = yield* Effect.all(input.sourceUris.map(uri => readManagedMemory(context.config, uri)));
       job.draft = yield* runConsolidationAgent(input.agent, sources);
       job.status = 'completed';
     }).pipe(
@@ -1015,13 +1102,13 @@ function createConsolidation(context: ApiContext, body: Record<string, unknown>)
   });
 }
 
-async function applyConsolidation(
+const applyConsolidation = Effect.fn('manager.applyConsolidation')(function* (
   config: RuntimeConfig,
   jobs: Map<string, ConsolidationJob>,
   id: string,
   body: Record<string, unknown>,
   runEffect: ManagerEffectPromise | undefined,
-): Promise<{readonly output: string}> {
+) {
   const job = jobs.get(id);
   if (!job) {
     throw new Error('Consolidation job not found.');
@@ -1031,7 +1118,7 @@ async function applyConsolidation(
   }
   const draft = optionalString(body.draft) ?? job.draft;
   const target = targetFromBody({...job.target, ...body});
-  const saved = await runCaptured(
+  const saved = yield* runCaptured(
     () =>
       runRemember(config, {
         kind: target.kind ?? 'durable',
@@ -1052,11 +1139,11 @@ async function applyConsolidation(
         continue;
       }
       const action = cleanup === 'forget' ? () => runForget(config, uri, {}) : () => runArchive(config, uri, {});
-      cleanupOutputs.push((await runCaptured(action, runEffect)).output);
+      cleanupOutputs.push((yield* runCaptured(action, runEffect)).output);
     }
   }
   return {output: [saved.output, ...cleanupOutputs].filter(Boolean).join('\n')};
-}
+});
 
 function runConsolidationAgent(
   agent: ConsolidationAgent,
@@ -1064,21 +1151,23 @@ function runConsolidationAgent(
 ) {
   const prompt = consolidationPrompt(sources);
   if (agent === 'effect-ai') {
-    const config = effectAiConfiguration();
-    if (!config) {
-      return Effect.fail(
-        new Error(
-          'Effect AI is not configured. Set THREADNOTE_EFFECT_AI=1 and THREADNOTE_EFFECT_AI_MODEL; add API URL/key variables when required.',
-        ),
-      );
-    }
-    return runEffectAiConsolidation(prompt, config);
+    return Effect.gen(function* () {
+      const config = effectAiConfiguration((yield* SystemInfo).environment());
+      if (!config) {
+        return yield* Effect.fail(
+          new Error(
+            'Effect AI is not configured. Set THREADNOTE_EFFECT_AI=1 and THREADNOTE_EFFECT_AI_MODEL; add API URL/key variables when required.',
+          ),
+        );
+      }
+      return yield* runEffectAiConsolidation(prompt, config);
+    });
   }
   if (agent !== 'codex' && agent !== 'claude') {
     return Effect.fail(new Error(`${agent} does not expose a supported non-interactive consolidation mode.`));
   }
   return Effect.gen(function* () {
-    const executable = yield* fromPromiseError(() => findExecutable([agent]));
+    const executable = yield* findExecutable([agent]);
     if (!executable) {
       return yield* Effect.fail(new Error(`${agent} executable was not found.`));
     }
@@ -1086,7 +1175,7 @@ function runConsolidationAgent(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const stagingDir = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-consolidate-'});
-        const promptPath = join(stagingDir, 'prompt.txt');
+        const promptPath = yield* pathJoin(stagingDir, 'prompt.txt');
         yield* fs.writeFileString(promptPath, prompt, {mode: 0o600});
         const script = consolidationAgentScript(agent, executable);
         const result = yield* runCommandEffect('sh', ['-lc', script, 'threadnote-consolidate', promptPath], {
@@ -1129,48 +1218,41 @@ function consolidationPrompt(sources: readonly {readonly content: string; readon
   ].join('\n');
 }
 
-async function shareSummaries(config: RuntimeConfig): Promise<
-  readonly (ShareTeamConfig & {
-    readonly ahead?: number;
-    readonly behind?: number;
-    readonly default: boolean;
-    readonly dirty?: boolean;
-    readonly status?: string;
-    readonly warning?: string;
-  })[]
-> {
-  const teamsFile = await readTeamsFile(config);
-  const git = await findExecutable(['git']);
-  const entries = await Promise.all(
-    Object.values(teamsFile.teams).map(async team => {
-      if (!git) {
-        return {...team, default: teamsFile.defaultTeam === team.name, warning: 'git not found'};
-      }
-      const status = await runCommand(git, ['-C', team.worktree, 'status', '--short', '--branch'], {
-        allowFailure: true,
-      });
-      const ahead = await gitCount(git, team.worktree, '@{u}..HEAD');
-      const behind = await gitCount(git, team.worktree, 'HEAD..@{u}');
-      return {
-        ...team,
-        ahead,
-        behind,
-        default: teamsFile.defaultTeam === team.name,
-        dirty: status.stdout.split('\n').some(line => line.trim().length > 0 && !line.startsWith('##')),
-        status: status.stdout.trim(),
-        warning: status.exitCode === 0 ? undefined : status.stderr.trim() || status.stdout.trim(),
-      };
-    }),
+const shareSummaries = Effect.fn('manager.shareSummaries')(function* (config: RuntimeConfig) {
+  const teamsFile = yield* readTeamsFile(config);
+  const git = yield* findExecutable(['git']);
+  const entries = yield* Effect.all(
+    Object.values(teamsFile.teams).map(
+      Effect.fn('manager.callback')(function* (team) {
+        if (!git) {
+          return {...team, default: teamsFile.defaultTeam === team.name, warning: 'git not found'};
+        }
+        const status = yield* runCommand(git, ['-C', team.worktree, 'status', '--short', '--branch'], {
+          allowFailure: true,
+        });
+        const ahead = yield* gitCount(git, team.worktree, '@{u}..HEAD');
+        const behind = yield* gitCount(git, team.worktree, 'HEAD..@{u}');
+        return {
+          ...team,
+          ahead,
+          behind,
+          default: teamsFile.defaultTeam === team.name,
+          dirty: status.stdout.split('\n').some(line => line.trim().length > 0 && !line.startsWith('##')),
+          status: status.stdout.trim(),
+          warning: status.exitCode === 0 ? undefined : status.stderr.trim() || status.stdout.trim(),
+        };
+      }),
+    ),
   );
   return entries.sort((left, right) => left.name.localeCompare(right.name));
-}
+});
 
-async function collectManagerDoctorChecks(config: RuntimeConfig): Promise<readonly DoctorCheck[]> {
-  const threadnote = await findExecutable(['threadnote']);
+const collectManagerDoctorChecks = Effect.fn('manager.collectManagerDoctorChecks')(function* (config: RuntimeConfig) {
+  const threadnote = yield* findExecutable(['threadnote']);
   if (!threadnote) {
     return collectDoctorChecks(config, {});
   }
-  const result = await runCommand(
+  const result = yield* runCommand(
     threadnote,
     [
       '--home',
@@ -1187,7 +1269,7 @@ async function collectManagerDoctorChecks(config: RuntimeConfig): Promise<readon
   );
   const checks = parseDoctorChecksFromOutput([result.stdout, result.stderr].filter(Boolean).join('\n'));
   return checks.length > 0 ? checks : collectDoctorChecks(config, {});
-}
+});
 
 export function parseDoctorChecksFromOutput(output: string): readonly DoctorCheck[] {
   const ansiEscape = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
@@ -1203,13 +1285,13 @@ export function parseDoctorChecksFromOutput(output: string): readonly DoctorChec
     }));
 }
 
-async function gitCount(git: string, worktree: string, range: string): Promise<number | undefined> {
-  const result = await runCommand(git, ['-C', worktree, 'rev-list', '--count', range], {allowFailure: true});
+const gitCount = Effect.fn('manager.gitCount')(function* (git: string, worktree: string, range: string) {
+  const result = yield* runCommand(git, ['-C', worktree, 'rev-list', '--count', range], {allowFailure: true});
   if (result.exitCode !== 0) {
     return undefined;
   }
   return Number.parseInt(result.stdout.trim(), 10) || 0;
-}
+});
 
 function doctorStatus(value: string): DoctorCheck['status'] {
   if (value === 'OK') {
@@ -1221,25 +1303,15 @@ function doctorStatus(value: string): DoctorCheck['status'] {
   return 'warn';
 }
 
-async function runCaptured(
-  action: () => Promise<void> | ManagerOperation<void>,
-  runEffect?: ManagerEffectPromise,
-): Promise<{readonly output: string}> {
-  const captured = await capturePromiseConsole(async () => {
-    const operation = action();
-    if (!Effect.isEffect(operation)) {
-      await operation;
-      return undefined;
-    }
-    if (!runEffect) throw new Error('Manager Effect runtime is unavailable.');
-    return runEffect(captureConsole(operation));
-  });
-  return {
-    output: [captured.output, captured.value?.output].filter(Boolean).join('\n'),
-  };
-}
+const runCaptured = Effect.fn('manager.runCaptured')(function* (
+  action: () => ManagerOperation<void>,
+  _runEffect?: ManagerEffectPromise,
+) {
+  const captured = yield* captureConsole(action());
+  return {output: captured.output};
+});
 
-function memoryUriFor(
+const memoryUriFor = Effect.fn('manager.memoryUriFor')(function* (
   config: RuntimeConfig,
   metadata: {
     readonly kind: MemoryKind;
@@ -1247,14 +1319,14 @@ function memoryUriFor(
     readonly status: MemoryStatus;
     readonly topic: string;
   },
-): string {
+) {
   const project = uriSegment(metadata.project);
   const filename =
     metadata.status === 'active' && metadata.kind !== 'smoke'
       ? `${uriSegment(metadata.topic)}.md`
-      : `threadnote-${safeTimestamp()}-${sha256(JSON.stringify(metadata)).slice(0, 12)}.md`;
+      : `threadnote-${safeTimestamp()}-${(yield* sha256(JSON.stringify(metadata))).slice(0, 12)}.md`;
   return `${memoryDirectoryUri(config, metadata.kind, metadata.status, project)}/${filename}`;
-}
+});
 
 function sharedMemoryUriFor(
   config: RuntimeConfig,
@@ -1294,15 +1366,26 @@ function memoryDirectoryUri(
   }
 }
 
-function localMemoriesRoot(config: RuntimeConfig): string {
-  return join(config.agentContextHome, 'data', 'viking', config.account, 'user', uriSegment(config.user), 'memories');
-}
+const localMemoriesRoot = Effect.fn('manager.localMemoriesRoot')(function* (config: RuntimeConfig) {
+  return yield* pathJoin(
+    config.agentContextHome,
+    'data',
+    'viking',
+    config.account,
+    'user',
+    uriSegment(config.user),
+    'memories',
+  );
+});
 
-function localResourcesRoot(config: RuntimeConfig): string {
-  return join(config.agentContextHome, 'data', 'viking', config.account, 'resources');
-}
+const localResourcesRoot = Effect.fn('manager.localResourcesRoot')(function* (config: RuntimeConfig) {
+  return yield* pathJoin(config.agentContextHome, 'data', 'viking', config.account, 'resources');
+});
 
-function localPathForMemoryUri(config: RuntimeConfig, uri: string): string | undefined {
+const localPathForMemoryUri = Effect.fn('manager.localPathForMemoryUri')(function* (
+  config: RuntimeConfig,
+  uri: string,
+) {
   const prefix = `viking://user/${uriSegment(config.user)}/memories`;
   if (uri !== prefix && !uri.startsWith(`${prefix}/`)) {
     return undefined;
@@ -1312,36 +1395,49 @@ function localPathForMemoryUri(config: RuntimeConfig, uri: string): string | und
   if (segments.some(segment => segment === '.' || segment === '..')) {
     return undefined;
   }
-  return join(localMemoriesRoot(config), ...segments);
-}
+  return yield* pathJoin(yield* localMemoriesRoot(config), ...segments);
+});
 
 function isMissingPathError(err: unknown): boolean {
-  return typeof err === 'object' && err !== null && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (('code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') ||
+      ('reason' in err &&
+        typeof err.reason === 'object' &&
+        err.reason !== null &&
+        '_tag' in err.reason &&
+        err.reason._tag === 'NotFound'))
+  );
 }
 
-function localPathToMemoryUri(config: RuntimeConfig, path: string): string {
-  const relativePath = relative(localMemoriesRoot(config), path);
-  if (!relativePath || relativePath.startsWith('..') || relativePath.split(sep).includes('..')) {
+const localPathToMemoryUri = Effect.fn('manager.localPathToMemoryUri')(function* (config: RuntimeConfig, path: string) {
+  const relativePath = yield* pathRelative(yield* localMemoriesRoot(config), path);
+  if (!relativePath || relativePath.startsWith('..') || relativePath.split(yield* pathSeparator).includes('..')) {
     throw new Error(`Path is outside the memories tree: ${path}`);
   }
-  return `viking://user/${uriSegment(config.user)}/memories/${relativePath.split(sep).join('/')}`;
-}
+  return `viking://user/${uriSegment(config.user)}/memories/${relativePath.split(yield* pathSeparator).join('/')}`;
+});
 
-async function ensurePersonalDirectoryChain(config: RuntimeConfig, ov: string, directoryUri: string): Promise<void> {
+const ensurePersonalDirectoryChain = Effect.fn('manager.ensurePersonalDirectoryChain')(function* (
+  config: RuntimeConfig,
+  ov: string,
+  directoryUri: string,
+) {
   const prefix = 'viking://';
   const parts = directoryUri.startsWith(prefix) ? directoryUri.slice(prefix.length).split('/').filter(Boolean) : [];
   const startIndex = parts[0] === 'user' && parts.length > 2 ? 3 : 1;
   for (let index = startIndex; index <= parts.length; index += 1) {
     const uri = `${prefix}${parts.slice(0, index).join('/')}`;
-    const statResult = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+    const statResult = yield* runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
     if (statResult.exitCode !== 0) {
-      await runCommand(
+      yield* runCommand(
         ov,
         withIdentity(config, ['mkdir', uri, '--description', 'Threadnote lifecycle-aware local memories.']),
       );
     }
   }
-}
+});
 
 function publicConfig(config: RuntimeConfig): Record<string, unknown> {
   return {
@@ -1355,7 +1451,7 @@ function publicConfig(config: RuntimeConfig): Record<string, unknown> {
   };
 }
 
-function isAuthorized(context: ApiContext, request: IncomingMessage): boolean {
+function isAuthorized(context: ApiContext, request: ManagerRequest): boolean {
   const auth = request.headers.authorization;
   return auth === `Bearer ${context.token}` || request.headers['x-threadnote-token'] === context.token;
 }
@@ -1364,35 +1460,15 @@ function isSystemMemoryName(name: string): boolean {
   return name === '.abstract.md' || name === '.overview.md' || name === '.git' || name === '.gitignore';
 }
 
-async function listen(server: Server, port: number): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(port, '127.0.0.1', () => {
-      server.off('error', reject);
-      resolve();
-    });
+const readJsonBody = Effect.fn('manager.readJsonBody')(function* (request: ManagerRequest) {
+  return yield* request.body;
+});
+
+function writeJson(response: ManagerResponseSink, statusCode: number, body: unknown): void {
+  response.response = HttpServerResponse.jsonUnsafe(body, {
+    status: statusCode,
+    headers: {'cache-control': 'no-store'},
   });
-}
-
-async function readJsonBody(request: IncomingMessage): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of request) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
-  }
-  if (chunks.length === 0) {
-    return {};
-  }
-  const raw = Buffer.concat(chunks).toString('utf8');
-  const parsed = JSON.parse(raw) as unknown;
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    throw new Error('Expected a JSON object body.');
-  }
-  return parsed as Record<string, unknown>;
-}
-
-function writeJson(response: ServerResponse, statusCode: number, body: unknown): void {
-  response.writeHead(statusCode, {'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store'});
-  response.end(`${JSON.stringify(body)}\n`);
 }
 
 function requiredQuery(url: URL, name: string): string {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,4 +1,4 @@
-import {readFile} from 'node:fs/promises';
+import {Effect, FileSystem} from 'effect';
 import yaml from 'js-yaml';
 import type {JsonObject, ProjectManifest, ResolvedWorkset, SeedManifest, WorksetManifest} from './types.js';
 import {escapeRegExp, isJsonObject} from './utils.js';
@@ -17,15 +17,17 @@ export function uriSegment(value: string): string {
  * when no project matches or the manifest can't be read. Callers use the
  * matched project's `uri` to scope a recall search at the right seeded subtree.
  */
-export async function inferProjectFromQuery(manifestPath: string, query: string): Promise<ProjectManifest | undefined> {
-  try {
-    const manifest = await readSeedManifest(manifestPath);
-    const normalized = query.toLowerCase();
-    return manifest.projects.find(project => normalized.includes(project.name.toLowerCase()));
-  } catch {
+export const inferProjectFromQuery = Effect.fn('manifest.inferProjectFromQuery')(function* (
+  manifestPath: string,
+  query: string,
+) {
+  const manifest = yield* readSeedManifest(manifestPath).pipe(Effect.option);
+  if (manifest._tag === 'None') {
     return undefined;
   }
-}
+  const normalized = query.toLowerCase();
+  return manifest.value.projects.find(project => normalized.includes(project.name.toLowerCase()));
+});
 
 /**
  * Resolves a workset's member names to their `ProjectManifest` entries, dropping
@@ -41,49 +43,60 @@ function resolveWorksetProjects(manifest: SeedManifest, workset: WorksetManifest
 }
 
 /** Looks up a workset by exact (case-insensitive) name; undefined when unknown or unreadable. */
-export async function resolveWorkset(manifestPath: string, worksetName: string): Promise<ResolvedWorkset | undefined> {
-  try {
-    const manifest = await readSeedManifest(manifestPath);
-    const workset = manifest.worksets?.find(entry => entry.name.toLowerCase() === worksetName.toLowerCase());
-    return workset ? resolveWorksetProjects(manifest, workset) : undefined;
-  } catch {
+export const resolveWorkset = Effect.fn('manifest.resolveWorkset')(function* (
+  manifestPath: string,
+  worksetName: string,
+) {
+  const manifest = yield* readSeedManifest(manifestPath).pipe(Effect.option);
+  if (manifest._tag === 'None') {
     return undefined;
   }
-}
+  const workset = manifest.value.worksets?.find(entry => entry.name.toLowerCase() === worksetName.toLowerCase());
+  return workset ? resolveWorksetProjects(manifest.value, workset) : undefined;
+});
 
 /** Resolves an explicit workset name; throws when the manifest is readable but no such workset exists. */
-export async function requireWorkset(manifestPath: string, worksetName: string): Promise<ResolvedWorkset> {
-  const manifest = await readSeedManifest(manifestPath);
+export const requireWorkset = Effect.fn('manifest.requireWorkset')(function* (
+  manifestPath: string,
+  worksetName: string,
+) {
+  const manifest = yield* readSeedManifest(manifestPath);
   const workset = manifest.worksets?.find(entry => entry.name.toLowerCase() === worksetName.toLowerCase());
   if (!workset) {
-    throw new Error(`No workset named "${worksetName}" in ${manifestPath}.`);
+    return yield* Effect.fail(new Error(`No workset named "${worksetName}" in ${manifestPath}.`));
   }
   return resolveWorksetProjects(manifest, workset);
-}
+});
 
 /** Returns the workset whose name appears as a token in `query`, or undefined. */
-export async function inferWorksetFromQuery(manifestPath: string, query: string): Promise<ResolvedWorkset | undefined> {
-  try {
-    const manifest = await readSeedManifest(manifestPath);
-    if (!manifest.worksets || manifest.worksets.length === 0) {
-      return undefined;
-    }
-    const workset = manifest.worksets.find(entry => containsNameToken(query, entry.name));
-    return workset ? resolveWorksetProjects(manifest, workset) : undefined;
-  } catch {
+export const inferWorksetFromQuery = Effect.fn('manifest.inferWorksetFromQuery')(function* (
+  manifestPath: string,
+  query: string,
+) {
+  const manifest = yield* readSeedManifest(manifestPath).pipe(Effect.option);
+  if (manifest._tag === 'None') {
     return undefined;
   }
-}
+  if (!manifest.value.worksets || manifest.value.worksets.length === 0) {
+    return undefined;
+  }
+  const workset = manifest.value.worksets.find(entry => containsNameToken(query, entry.name));
+  return workset ? resolveWorksetProjects(manifest.value, workset) : undefined;
+});
 
 function containsNameToken(query: string, name: string): boolean {
   const escaped = escapeRegExp(name.toLowerCase());
   return new RegExp(`(^|[^a-z0-9])${escaped}($|[^a-z0-9])`).test(query.toLowerCase());
 }
 
-export async function readSeedManifest(path: string): Promise<SeedManifest> {
-  const raw = await readFile(path, 'utf8');
-  return parseSeedManifest(raw, path);
-}
+export const readSeedManifest = Effect.fn('manifest.readSeedManifest')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const raw = yield* fs.readFileString(path);
+  return yield* Effect.try({
+    try: () => parseSeedManifest(raw, path),
+    catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
+  });
+});
 
 export function parseSeedManifest(raw: string, path: string): SeedManifest {
   const loaded = yaml.load(raw);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -280,12 +280,12 @@ function buildMcpInstallCommand(
     if (agent === 'codex') {
       return {
         executable: agentExecutable,
-        args: ['mcp', 'add', ...env.flatMap(value => ['--env', value]), name, '--', '/usr/bin/env', ...command],
+        args: ['mcp', 'add', ...env.flatMap(value => ['--env', value]), name, '--', ...command],
       };
     }
     return {
       executable: agentExecutable,
-      args: ['mcp', 'add', '--scope', claudeScope, name, '--', '/usr/bin/env', ...env, ...command],
+      args: ['mcp', 'add', '--scope', claudeScope, name, ...env.flatMap(value => ['--env', value]), '--', ...command],
       cwd: claudeCwd,
     };
   }
@@ -313,7 +313,7 @@ function buildMcpInstallCommand(
 }
 
 function mcpAdapterCommand(): readonly string[] {
-  return [join(toolRoot(), 'bin', 'threadnote-mcp-server.cjs')];
+  return ['node', join(toolRoot(), 'bin', 'threadnote-mcp-server.cjs')];
 }
 
 function buildMcpRemoveCommand(agent: AgentClient, agentExecutable: string, name: string): MappedCommand {
@@ -385,9 +385,10 @@ function buildCursorMcpServerConfig(
     }
     return server;
   }
+  const command = mcpAdapterCommand();
   return {
-    args: [mcpAdapterCommand()[0]],
-    command: '/usr/bin/env',
+    args: command.slice(1),
+    command: command[0],
     env: mcpEnvironmentObject(config, options.toolset),
   };
 }
@@ -408,9 +409,10 @@ function buildCopilotMcpServerConfig(
     }
     return server;
   }
+  const command = mcpAdapterCommand();
   return {
-    args: [mcpAdapterCommand()[0]],
-    command: '/usr/bin/env',
+    args: command.slice(1),
+    command: command[0],
     env: mcpEnvironmentObject(config, options.toolset),
     type: 'stdio',
   };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,21 +1,10 @@
-import {statSync} from 'node:fs';
-import {writeFile} from 'node:fs/promises';
-import {dirname, join} from 'node:path';
-import {platform} from 'node:os';
-import {Console, Effect} from 'effect';
+import {Console, Effect, FileSystem, Path} from 'effect';
 import {OPENVIKING_MCP_NAME} from './constants.js';
 import {maybeRunEffect} from './effect/command.js';
-import {consoleOutput, syncWithConsole} from './effect/console.js';
-import {applicationError, fromPromise} from './effect/errors.js';
+import {applicationError} from './effect/errors.js';
+import {SystemInfo} from './effect/system.js';
 import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset} from './mcp_toolset.js';
-import type {
-  AgentClient,
-  ClaudeMcpScope,
-  JsonObject,
-  MappedCommand,
-  McpInstallOptions,
-  RuntimeConfig,
-} from './types.js';
+import type {AgentClient, ClaudeMcpScope, JsonObject, McpInstallOptions, RuntimeConfig} from './types.js';
 import {
   ensureDirectory,
   exists,
@@ -25,7 +14,6 @@ import {
   formatShellCommand,
   getInvocationCwd,
   isJsonObject,
-  maybeRun,
   parseJsonConfigObject,
   readFileIfExists,
   readHttpStatus,
@@ -42,7 +30,7 @@ export function runMcpInstall(config: RuntimeConfig, agent: AgentClient, options
     const toolset = options.toolset ?? DEFAULT_MCP_TOOLSET;
 
     if (nativeHttp) {
-      const mcpStatus = yield* fromPromise('probe native OpenViking MCP endpoint', () => readHttpStatus(url, 1200));
+      const mcpStatus = yield* readHttpStatus(url, 1200);
       const unavailable = mcpStatus === undefined || mcpStatus === 404;
       if (unavailable && apply) {
         return yield* Effect.fail(
@@ -63,53 +51,45 @@ export function runMcpInstall(config: RuntimeConfig, agent: AgentClient, options
     }
 
     if (agent === 'cursor') {
-      yield* fromPromise('install Cursor MCP configuration', () =>
-        runCursorMcpInstall(config, name, {
-          apply,
-          bearerTokenEnvVar: options.bearerTokenEnvVar,
-          nativeHttp,
-          toolset,
-          url,
-        }),
-      );
+      yield* runCursorMcpInstall(config, name, {
+        apply,
+        bearerTokenEnvVar: options.bearerTokenEnvVar,
+        nativeHttp,
+        toolset,
+        url,
+      });
       return;
     }
     if (agent === 'copilot') {
-      yield* fromPromise('install GitHub Copilot MCP configuration', () =>
-        runCopilotMcpInstall(config, name, {
-          apply,
-          bearerTokenEnvVar: options.bearerTokenEnvVar,
-          nativeHttp,
-          toolset,
-          url,
-        }),
-      );
+      yield* runCopilotMcpInstall(config, name, {
+        apply,
+        bearerTokenEnvVar: options.bearerTokenEnvVar,
+        nativeHttp,
+        toolset,
+        url,
+      });
       return;
     }
 
-    const agentExecutable = apply
-      ? yield* fromPromise(`find ${agent} executable`, () => requiredMcpAgentExecutable(agent))
-      : agent;
+    const agentExecutable = apply ? yield* requiredMcpAgentExecutable(agent) : agent;
 
-    const command = buildMcpInstallCommand(config, agent, agentExecutable, name, {
+    const command = yield* buildMcpInstallCommand(config, agent, agentExecutable, name, {
       bearerTokenEnvVar: options.bearerTokenEnvVar,
       nativeHttp,
       scope: options.scope,
       toolset,
       url,
     });
-    const removeCommand = buildMcpRemoveCommand(agent, agentExecutable, name);
+    const removeCommand = yield* buildMcpRemoveCommand(agent, agentExecutable, name);
 
     if (!apply) {
-      yield* syncWithConsole(() => {
-        consoleOutput.log('Dry run. Re-run with --apply to modify the selected agent config.');
-        if (removeCommand.cwd || command.cwd) {
-          consoleOutput.log(`Command working directory: ${removeCommand.cwd ?? command.cwd}`);
-        }
-        consoleOutput.log(formatShellCommand(removeCommand.executable, removeCommand.args));
-        consoleOutput.log(formatShellCommand(command.executable, command.args));
-        printMcpSnippet(config, agent, name, {nativeHttp, scope: options.scope, toolset, url});
-      });
+      yield* Console.log('Dry run. Re-run with --apply to modify the selected agent config.');
+      if (removeCommand.cwd || command.cwd) {
+        yield* Console.log(`Command working directory: ${removeCommand.cwd ?? command.cwd}`);
+      }
+      yield* Console.log(formatShellCommand(removeCommand.executable, removeCommand.args));
+      yield* Console.log(formatShellCommand(command.executable, command.args));
+      yield* printMcpSnippet(config, agent, name, {nativeHttp, scope: options.scope, toolset, url});
       return;
     }
 
@@ -121,7 +101,7 @@ export function runMcpInstall(config: RuntimeConfig, agent: AgentClient, options
   });
 }
 
-async function runCursorMcpInstall(
+const runCursorMcpInstall = Effect.fn('mcp.runCursorInstall')(function* (
   config: RuntimeConfig,
   name: string,
   options: {
@@ -131,20 +111,22 @@ async function runCursorMcpInstall(
     readonly toolset: McpToolset;
     readonly url: string;
   },
-): Promise<void> {
-  const path = cursorMcpConfigPath();
-  const serverConfig = buildCursorMcpServerConfig(config, {
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const path = yield* cursorMcpConfigPath();
+  const serverConfig = yield* buildCursorMcpServerConfig(config, {
     bearerTokenEnvVar: options.bearerTokenEnvVar,
     nativeHttp: options.nativeHttp,
     toolset: options.toolset,
     url: options.url,
   });
-  const currentContent = await readFileIfExists(path);
-  const nextContent = renderCursorMcpConfig(currentContent, name, serverConfig);
+  const currentContent = yield* readFileIfExists(path);
+  const nextContent = renderCursorMcpConfig(path, currentContent, name, serverConfig);
 
   if (!options.apply) {
-    consoleOutput.log('Dry run. Re-run with --apply to modify Cursor MCP config.');
-    printCursorMcpSnippet(config, name, {
+    yield* Console.log('Dry run. Re-run with --apply to modify Cursor MCP config.');
+    yield* printCursorMcpSnippet(config, name, {
       bearerTokenEnvVar: options.bearerTokenEnvVar,
       nativeHttp: options.nativeHttp,
       toolset: options.toolset,
@@ -154,17 +136,17 @@ async function runCursorMcpInstall(
   }
 
   if (currentContent === nextContent) {
-    consoleOutput.log(`Already configured: ${path}`);
+    yield* Console.log(`Already configured: ${path}`);
     return;
   }
-  await ensureDirectory(dirname(path), false);
-  await writeFile(path, nextContent, {encoding: 'utf8', mode: 0o644});
-  consoleOutput.log(
+  yield* ensureDirectory(pathService.dirname(path), false);
+  yield* fs.writeFileString(path, nextContent, {mode: 0o644});
+  yield* Console.log(
     currentContent === undefined ? `Wrote Cursor MCP config: ${path}` : `Updated Cursor MCP config: ${path}`,
   );
-}
+});
 
-async function runCopilotMcpInstall(
+const runCopilotMcpInstall = Effect.fn('mcp.runCopilotInstall')(function* (
   config: RuntimeConfig,
   name: string,
   options: {
@@ -174,20 +156,22 @@ async function runCopilotMcpInstall(
     readonly toolset: McpToolset;
     readonly url: string;
   },
-): Promise<void> {
-  const path = copilotMcpConfigPath();
-  const serverConfig = buildCopilotMcpServerConfig(config, {
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const path = yield* copilotMcpConfigPath();
+  const serverConfig = yield* buildCopilotMcpServerConfig(config, {
     bearerTokenEnvVar: options.bearerTokenEnvVar,
     nativeHttp: options.nativeHttp,
     toolset: options.toolset,
     url: options.url,
   });
-  const currentContent = await readFileIfExists(path);
-  const nextContent = renderCopilotMcpConfig(currentContent, name, serverConfig);
+  const currentContent = yield* readFileIfExists(path);
+  const nextContent = renderCopilotMcpConfig(path, currentContent, name, serverConfig);
 
   if (!options.apply) {
-    consoleOutput.log('Dry run. Re-run with --apply to modify GitHub Copilot MCP config.');
-    printCopilotMcpSnippet(config, name, {
+    yield* Console.log('Dry run. Re-run with --apply to modify GitHub Copilot MCP config.');
+    yield* printCopilotMcpSnippet(config, name, {
       bearerTokenEnvVar: options.bearerTokenEnvVar,
       nativeHttp: options.nativeHttp,
       toolset: options.toolset,
@@ -197,63 +181,67 @@ async function runCopilotMcpInstall(
   }
 
   if (currentContent === nextContent) {
-    consoleOutput.log(`Already configured: ${path}`);
+    yield* Console.log(`Already configured: ${path}`);
     return;
   }
-  await ensureDirectory(dirname(path), false);
-  await writeFile(path, nextContent, {encoding: 'utf8', mode: 0o644});
-  consoleOutput.log(
+  yield* ensureDirectory(pathService.dirname(path), false);
+  yield* fs.writeFileString(path, nextContent, {mode: 0o644});
+  yield* Console.log(
     currentContent === undefined
       ? `Wrote GitHub Copilot MCP config: ${path}`
       : `Updated GitHub Copilot MCP config: ${path}`,
   );
-}
+});
 
-export async function removeMcpConfigs(value: string, dryRun: boolean): Promise<void> {
-  const clients = await resolveMcpClients(value, 'remove');
+export const removeMcpConfigs = Effect.fn('mcp.removeConfigs')(function* (value: string, dryRun: boolean) {
+  const clients = yield* resolveMcpClients(value, 'remove');
   if (clients.length === 0) {
-    consoleOutput.log('Skipping MCP config removal.');
+    yield* Console.log('Skipping MCP config removal.');
     return;
   }
   for (const client of clients) {
     if (client === 'cursor') {
-      await removeCursorMcpConfig(OPENVIKING_MCP_NAME, dryRun);
+      yield* removeCursorMcpConfig(OPENVIKING_MCP_NAME, dryRun);
       continue;
     }
     if (client === 'copilot') {
-      await removeCopilotMcpConfig(OPENVIKING_MCP_NAME, dryRun);
+      yield* removeCopilotMcpConfig(OPENVIKING_MCP_NAME, dryRun);
       continue;
     }
-    const executable = await requiredMcpAgentExecutable(client);
-    const command = buildMcpRemoveCommand(client, executable, OPENVIKING_MCP_NAME);
-    await maybeRun(dryRun, command.executable, command.args, {allowFailure: true, cwd: command.cwd});
+    const executable = yield* requiredMcpAgentExecutable(client);
+    const command = yield* buildMcpRemoveCommand(client, executable, OPENVIKING_MCP_NAME);
+    yield* maybeRunEffect(dryRun, command.executable, command.args, {
+      allowFailure: true,
+      cwd: command.cwd,
+    });
   }
-}
+});
 
-export async function removeMcpSnippets(config: RuntimeConfig, dryRun: boolean): Promise<void> {
-  await removePathIfExists(
-    join(config.agentContextHome, 'mcp', `${OPENVIKING_MCP_NAME}.codex.toml`),
+export const removeMcpSnippets = Effect.fn('mcp.removeSnippets')(function* (config: RuntimeConfig, dryRun: boolean) {
+  const path = yield* Path.Path;
+  yield* removePathIfExists(
+    path.join(config.agentContextHome, 'mcp', `${OPENVIKING_MCP_NAME}.codex.toml`),
     'MCP snippet',
     dryRun,
   );
-  await removePathIfExists(
-    join(config.agentContextHome, 'mcp', `${OPENVIKING_MCP_NAME}.claude.txt`),
+  yield* removePathIfExists(
+    path.join(config.agentContextHome, 'mcp', `${OPENVIKING_MCP_NAME}.claude.txt`),
     'MCP snippet',
     dryRun,
   );
-  await removePathIfExists(
-    join(config.agentContextHome, 'mcp', `${OPENVIKING_MCP_NAME}.cursor.json`),
+  yield* removePathIfExists(
+    path.join(config.agentContextHome, 'mcp', `${OPENVIKING_MCP_NAME}.cursor.json`),
     'MCP snippet',
     dryRun,
   );
-  await removePathIfExists(
-    join(config.agentContextHome, 'mcp', `${OPENVIKING_MCP_NAME}.copilot.json`),
+  yield* removePathIfExists(
+    path.join(config.agentContextHome, 'mcp', `${OPENVIKING_MCP_NAME}.copilot.json`),
     'MCP snippet',
     dryRun,
   );
-}
+});
 
-function buildMcpInstallCommand(
+const buildMcpInstallCommand = Effect.fn('mcp.buildInstallCommand')(function* (
   config: RuntimeConfig,
   agent: AgentClient,
   agentExecutable: string,
@@ -265,17 +253,20 @@ function buildMcpInstallCommand(
     readonly toolset: McpToolset;
     readonly url: string;
   },
-): MappedCommand {
+) {
   if (agent === 'cursor') {
-    throw new Error('Cursor MCP config is written directly to ~/.cursor/mcp.json.');
+    return yield* Effect.fail(new Error('Cursor MCP config is written directly to ~/.cursor/mcp.json.'));
   }
   if (agent === 'copilot') {
-    throw new Error('GitHub Copilot MCP config is written directly to the VS Code user mcp.json file.');
+    return yield* Effect.fail(
+      new Error('GitHub Copilot MCP config is written directly to the VS Code user mcp.json file.'),
+    );
   }
-  const claudeCwd = getInvocationCwd();
+  const system = yield* SystemInfo;
+  const claudeCwd = yield* getInvocationCwd();
   const claudeScope = options.scope ?? 'user';
   if (!options.nativeHttp) {
-    const command = mcpAdapterCommand();
+    const command = yield* mcpAdapterCommand();
     const env = mcpEnvironment(config, options.toolset);
     if (agent === 'codex') {
       return {
@@ -300,54 +291,65 @@ function buildMcpInstallCommand(
 
   const args = ['mcp', 'add', '--scope', claudeScope, '--transport', 'http', name, options.url];
   if (options.bearerTokenEnvVar) {
-    const token = process.env[options.bearerTokenEnvVar];
+    const token = system.environment()[options.bearerTokenEnvVar];
     if (token) {
       args.push('--header', `Authorization: Bearer ${token}`);
     } else {
-      consoleOutput.log(
+      yield* Console.log(
         `WARN ${options.bearerTokenEnvVar} is not set; installing Claude MCP without an Authorization header.`,
       );
     }
   }
   return {executable: agentExecutable, args, cwd: claudeCwd};
-}
+});
 
-function mcpAdapterCommand(): readonly string[] {
-  return ['node', join(toolRoot(), 'bin', 'threadnote-mcp-server.cjs')];
-}
+const mcpAdapterCommand = Effect.fn('mcp.adapterCommand')(function* () {
+  const path = yield* Path.Path;
+  return ['node', path.join(yield* toolRoot(), 'bin', 'threadnote-mcp-server.cjs')];
+});
 
-function buildMcpRemoveCommand(agent: AgentClient, agentExecutable: string, name: string): MappedCommand {
+const buildMcpRemoveCommand = Effect.fn('mcp.buildRemoveCommand')(function* (
+  agent: AgentClient,
+  agentExecutable: string,
+  name: string,
+) {
   if (agent === 'cursor') {
-    throw new Error('Cursor MCP config is removed directly from ~/.cursor/mcp.json.');
+    return yield* Effect.fail(new Error('Cursor MCP config is removed directly from ~/.cursor/mcp.json.'));
   }
   if (agent === 'copilot') {
-    throw new Error('GitHub Copilot MCP config is removed directly from the VS Code user mcp.json file.');
+    return yield* Effect.fail(
+      new Error('GitHub Copilot MCP config is removed directly from the VS Code user mcp.json file.'),
+    );
   }
   return agent === 'codex'
     ? {executable: agentExecutable, args: ['mcp', 'remove', name]}
-    : {executable: agentExecutable, args: ['mcp', 'remove', name], cwd: getInvocationCwd()};
-}
+    : {executable: agentExecutable, args: ['mcp', 'remove', name], cwd: yield* getInvocationCwd()};
+});
 
-async function findMcpAgentExecutable(agent: 'claude' | 'codex'): Promise<string | undefined> {
-  return findWorkingExecutable([agent]);
-}
+const findMcpAgentExecutable = Effect.fn('mcp.findAgentExecutable')((agent: 'claude' | 'codex') =>
+  findWorkingExecutable([agent]),
+);
 
-async function requiredMcpAgentExecutable(agent: 'claude' | 'codex'): Promise<string> {
-  const executable = await findMcpAgentExecutable(agent);
+const requiredMcpAgentExecutable = Effect.fn('mcp.requiredAgentExecutable')(function* (agent: 'claude' | 'codex') {
+  const executable = yield* findMcpAgentExecutable(agent);
   if (executable) {
     return executable;
   }
-  const discovered = await findExecutable([agent]);
+  const discovered = yield* findExecutable([agent]);
   if (discovered) {
-    throw new Error(
-      `${agent} command was found at ${discovered} but is not working. ` +
-        `Repair or reinstall ${agent}, then run threadnote mcp-install ${agent} --apply.`,
+    return yield* Effect.fail(
+      new Error(
+        `${agent} command was found at ${discovered} but is not working. ` +
+          `Repair or reinstall ${agent}, then run threadnote mcp-install ${agent} --apply.`,
+      ),
     );
   }
-  throw new Error(
-    `${agent} command was not found in PATH. Install ${agent}, then run threadnote mcp-install ${agent} --apply.`,
+  return yield* Effect.fail(
+    new Error(
+      `${agent} command was not found in PATH. Install ${agent}, then run threadnote mcp-install ${agent} --apply.`,
+    ),
   );
-}
+});
 
 function mcpEnvironment(config: RuntimeConfig, toolset: McpToolset): readonly string[] {
   return [
@@ -369,7 +371,7 @@ function mcpEnvironmentObject(config: RuntimeConfig, toolset: McpToolset): JsonO
   };
 }
 
-function buildCursorMcpServerConfig(
+const buildCursorMcpServerConfig = Effect.fn('mcp.buildCursorServerConfig')(function* (
   config: RuntimeConfig,
   options: {
     readonly bearerTokenEnvVar?: string;
@@ -377,7 +379,7 @@ function buildCursorMcpServerConfig(
     readonly toolset: McpToolset;
     readonly url: string;
   },
-): JsonObject {
+) {
   if (options.nativeHttp) {
     const server: Record<string, unknown> = {url: options.url};
     if (options.bearerTokenEnvVar) {
@@ -385,15 +387,15 @@ function buildCursorMcpServerConfig(
     }
     return server;
   }
-  const command = mcpAdapterCommand();
+  const command = yield* mcpAdapterCommand();
   return {
     args: command.slice(1),
     command: command[0],
     env: mcpEnvironmentObject(config, options.toolset),
   };
-}
+});
 
-function buildCopilotMcpServerConfig(
+const buildCopilotMcpServerConfig = Effect.fn('mcp.buildCopilotServerConfig')(function* (
   config: RuntimeConfig,
   options: {
     readonly bearerTokenEnvVar?: string;
@@ -401,7 +403,7 @@ function buildCopilotMcpServerConfig(
     readonly toolset: McpToolset;
     readonly url: string;
   },
-): JsonObject {
+) {
   if (options.nativeHttp) {
     const server: Record<string, unknown> = {type: 'http', url: options.url};
     if (options.bearerTokenEnvVar) {
@@ -409,26 +411,31 @@ function buildCopilotMcpServerConfig(
     }
     return server;
   }
-  const command = mcpAdapterCommand();
+  const command = yield* mcpAdapterCommand();
   return {
     args: command.slice(1),
     command: command[0],
     env: mcpEnvironmentObject(config, options.toolset),
     type: 'stdio',
   };
-}
+});
 
 function isEmptyConfigContent(content: string | undefined): boolean {
   return content === undefined || content.trim().length === 0;
 }
 
-function renderCursorMcpConfig(currentContent: string | undefined, name: string, serverConfig: JsonObject): string {
+function renderCursorMcpConfig(
+  configPath: string,
+  currentContent: string | undefined,
+  name: string,
+  serverConfig: JsonObject,
+): string {
   const parsed = isEmptyConfigContent(currentContent) ? {} : parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
-    throw new Error(`${cursorMcpConfigPath()} exists but is not a JSON object; not modifying it.`);
+    throw new Error(`${configPath} exists but is not a JSON object; not modifying it.`);
   }
   if (parsed.mcpServers !== undefined && !isJsonObject(parsed.mcpServers)) {
-    throw new Error(`${cursorMcpConfigPath()} has a non-object mcpServers field; not modifying it.`);
+    throw new Error(`${configPath} has a non-object mcpServers field; not modifying it.`);
   }
   const nextConfig: Record<string, unknown> = {...parsed};
   const mcpServers = isJsonObject(parsed.mcpServers) ? {...parsed.mcpServers} : {};
@@ -437,13 +444,18 @@ function renderCursorMcpConfig(currentContent: string | undefined, name: string,
   return `${JSON.stringify(nextConfig, null, 2)}\n`;
 }
 
-function renderCopilotMcpConfig(currentContent: string | undefined, name: string, serverConfig: JsonObject): string {
+function renderCopilotMcpConfig(
+  configPath: string,
+  currentContent: string | undefined,
+  name: string,
+  serverConfig: JsonObject,
+): string {
   const parsed = isEmptyConfigContent(currentContent) ? {} : parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
-    throw new Error(`${copilotMcpConfigPath()} exists but is not a JSON object; not modifying it.`);
+    throw new Error(`${configPath} exists but is not a JSON object; not modifying it.`);
   }
   if (parsed.servers !== undefined && !isJsonObject(parsed.servers)) {
-    throw new Error(`${copilotMcpConfigPath()} has a non-object servers field; not modifying it.`);
+    throw new Error(`${configPath} has a non-object servers field; not modifying it.`);
   }
   const nextConfig: Record<string, unknown> = {...parsed};
   const servers = isJsonObject(parsed.servers) ? {...parsed.servers} : {};
@@ -452,20 +464,21 @@ function renderCopilotMcpConfig(currentContent: string | undefined, name: string
   return `${JSON.stringify(nextConfig, null, 2)}\n`;
 }
 
-async function removeCursorMcpConfig(name: string, dryRun: boolean): Promise<void> {
-  const path = cursorMcpConfigPath();
-  const currentContent = await readFileIfExists(path);
+const removeCursorMcpConfig = Effect.fn('mcp.removeCursorConfig')(function* (name: string, dryRun: boolean) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* cursorMcpConfigPath();
+  const currentContent = yield* readFileIfExists(path);
   if (isEmptyConfigContent(currentContent)) {
-    consoleOutput.log(`Already absent: ${path}`);
+    yield* Console.log(`Already absent: ${path}`);
     return;
   }
   const parsed = parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
-    consoleOutput.log(`WARN ${path} exists but is not a JSON object; not modifying it.`);
+    yield* Console.log(`WARN ${path} exists but is not a JSON object; not modifying it.`);
     return;
   }
   if (!isJsonObject(parsed.mcpServers) || parsed.mcpServers[name] === undefined) {
-    consoleOutput.log(`No Cursor MCP config found: ${path}`);
+    yield* Console.log(`No Cursor MCP config found: ${path}`);
     return;
   }
   const nextConfig: Record<string, unknown> = {...parsed};
@@ -474,27 +487,28 @@ async function removeCursorMcpConfig(name: string, dryRun: boolean): Promise<voi
   nextConfig.mcpServers = mcpServers;
   const nextContent = `${JSON.stringify(nextConfig, null, 2)}\n`;
   if (dryRun) {
-    consoleOutput.log(`Would update Cursor MCP config: ${path}`);
+    yield* Console.log(`Would update Cursor MCP config: ${path}`);
     return;
   }
-  await writeFile(path, nextContent, {encoding: 'utf8', mode: 0o644});
-  consoleOutput.log(`Updated Cursor MCP config: ${path}`);
-}
+  yield* fs.writeFileString(path, nextContent, {mode: 0o644});
+  yield* Console.log(`Updated Cursor MCP config: ${path}`);
+});
 
-async function removeCopilotMcpConfig(name: string, dryRun: boolean): Promise<void> {
-  const path = copilotMcpConfigPath();
-  const currentContent = await readFileIfExists(path);
+const removeCopilotMcpConfig = Effect.fn('mcp.removeCopilotConfig')(function* (name: string, dryRun: boolean) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* copilotMcpConfigPath();
+  const currentContent = yield* readFileIfExists(path);
   if (isEmptyConfigContent(currentContent)) {
-    consoleOutput.log(`Already absent: ${path}`);
+    yield* Console.log(`Already absent: ${path}`);
     return;
   }
   const parsed = parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
-    consoleOutput.log(`WARN ${path} exists but is not a JSON object; not modifying it.`);
+    yield* Console.log(`WARN ${path} exists but is not a JSON object; not modifying it.`);
     return;
   }
   if (!isJsonObject(parsed.servers) || parsed.servers[name] === undefined) {
-    consoleOutput.log(`No GitHub Copilot MCP config found: ${path}`);
+    yield* Console.log(`No GitHub Copilot MCP config found: ${path}`);
     return;
   }
   const nextConfig: Record<string, unknown> = {...parsed};
@@ -503,14 +517,14 @@ async function removeCopilotMcpConfig(name: string, dryRun: boolean): Promise<vo
   nextConfig.servers = servers;
   const nextContent = `${JSON.stringify(nextConfig, null, 2)}\n`;
   if (dryRun) {
-    consoleOutput.log(`Would update GitHub Copilot MCP config: ${path}`);
+    yield* Console.log(`Would update GitHub Copilot MCP config: ${path}`);
     return;
   }
-  await writeFile(path, nextContent, {encoding: 'utf8', mode: 0o644});
-  consoleOutput.log(`Updated GitHub Copilot MCP config: ${path}`);
-}
+  yield* fs.writeFileString(path, nextContent, {mode: 0o644});
+  yield* Console.log(`Updated GitHub Copilot MCP config: ${path}`);
+});
 
-function printMcpSnippet(
+const printMcpSnippet = Effect.fn('mcp.printSnippet')(function* (
   config: RuntimeConfig,
   agent: AgentClient,
   name: string,
@@ -520,9 +534,9 @@ function printMcpSnippet(
     readonly toolset: McpToolset;
     readonly url: string;
   },
-): void {
+) {
   if (agent === 'cursor') {
-    printCursorMcpSnippet(config, name, {
+    yield* printCursorMcpSnippet(config, name, {
       nativeHttp: options.nativeHttp,
       toolset: options.toolset,
       url: options.url,
@@ -530,25 +544,30 @@ function printMcpSnippet(
     return;
   }
   if (agent === 'copilot') {
-    printCopilotMcpSnippet(config, name, {
+    yield* printCopilotMcpSnippet(config, name, {
       nativeHttp: options.nativeHttp,
       toolset: options.toolset,
       url: options.url,
     });
     return;
   }
-  const snippetPath = join(config.agentContextHome, 'mcp', `${name}.${agent}.${agent === 'codex' ? 'toml' : 'txt'}`);
-  const command = buildMcpInstallCommand(config, agent, agent, name, {
+  const path = yield* Path.Path;
+  const snippetPath = path.join(
+    config.agentContextHome,
+    'mcp',
+    `${name}.${agent}.${agent === 'codex' ? 'toml' : 'txt'}`,
+  );
+  const command = yield* buildMcpInstallCommand(config, agent, agent, name, {
     nativeHttp: options.nativeHttp,
     scope: options.scope,
     toolset: options.toolset,
     url: options.url,
   });
   const snippet = `${formatShellCommand(command.executable, command.args)}\n`;
-  consoleOutput.log(`\nSnippet (${snippetPath}):\n${snippet}`);
-}
+  yield* Console.log(`\nSnippet (${snippetPath}):\n${snippet}`);
+});
 
-function printCursorMcpSnippet(
+const printCursorMcpSnippet = Effect.fn('mcp.printCursorSnippet')(function* (
   config: RuntimeConfig,
   name: string,
   options: {
@@ -557,13 +576,14 @@ function printCursorMcpSnippet(
     readonly toolset: McpToolset;
     readonly url: string;
   },
-): void {
-  const snippetPath = join(config.agentContextHome, 'mcp', `${name}.cursor.json`);
-  const snippet = JSON.stringify({mcpServers: {[name]: buildCursorMcpServerConfig(config, options)}}, null, 2);
-  consoleOutput.log(`\nSnippet (${snippetPath}; merge into ${cursorMcpConfigPath()}):\n${snippet}`);
-}
+) {
+  const path = yield* Path.Path;
+  const snippetPath = path.join(config.agentContextHome, 'mcp', `${name}.cursor.json`);
+  const snippet = JSON.stringify({mcpServers: {[name]: yield* buildCursorMcpServerConfig(config, options)}}, null, 2);
+  yield* Console.log(`\nSnippet (${snippetPath}; merge into ${yield* cursorMcpConfigPath()}):\n${snippet}`);
+});
 
-function printCopilotMcpSnippet(
+const printCopilotMcpSnippet = Effect.fn('mcp.printCopilotSnippet')(function* (
   config: RuntimeConfig,
   name: string,
   options: {
@@ -572,34 +592,41 @@ function printCopilotMcpSnippet(
     readonly toolset: McpToolset;
     readonly url: string;
   },
-): void {
-  const snippetPath = join(config.agentContextHome, 'mcp', `${name}.copilot.json`);
-  const snippet = JSON.stringify({servers: {[name]: buildCopilotMcpServerConfig(config, options)}}, null, 2);
-  consoleOutput.log(`\nSnippet (${snippetPath}; merge into ${copilotMcpConfigPath()}):\n${snippet}`);
-}
+) {
+  const path = yield* Path.Path;
+  const snippetPath = path.join(config.agentContextHome, 'mcp', `${name}.copilot.json`);
+  const snippet = JSON.stringify({servers: {[name]: yield* buildCopilotMcpServerConfig(config, options)}}, null, 2);
+  yield* Console.log(`\nSnippet (${snippetPath}; merge into ${yield* copilotMcpConfigPath()}):\n${snippet}`);
+});
 
-function cursorMcpConfigPath(): string {
-  return expandPath('~/.cursor/mcp.json');
-}
+const cursorMcpConfigPath = Effect.fn('mcp.cursorConfigPath')(() => expandPath('~/.cursor/mcp.json'));
 
-function copilotMcpConfigPath(): string {
-  if (process.env.THREADNOTE_COPILOT_MCP_CONFIG) {
-    return expandPath(process.env.THREADNOTE_COPILOT_MCP_CONFIG);
+const copilotMcpConfigPath = Effect.fn('mcp.copilotConfigPath')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const environment = system.environment();
+  if (environment.THREADNOTE_COPILOT_MCP_CONFIG) {
+    return yield* expandPath(environment.THREADNOTE_COPILOT_MCP_CONFIG);
   }
-  if (platform() === 'darwin') {
-    const stablePath = expandPath('~/Library/Application Support/Code/User/mcp.json');
-    const insidersPath = expandPath('~/Library/Application Support/Code - Insiders/User/mcp.json');
-    return existsSyncDirectory(dirname(stablePath)) || !existsSyncDirectory(dirname(insidersPath))
+  if (system.platform === 'darwin') {
+    const stablePath = yield* expandPath('~/Library/Application Support/Code/User/mcp.json');
+    const insidersPath = yield* expandPath('~/Library/Application Support/Code - Insiders/User/mcp.json');
+    return (yield* fs.exists(path.dirname(stablePath))) || !(yield* fs.exists(path.dirname(insidersPath)))
       ? stablePath
       : insidersPath;
   }
-  if (platform() === 'win32') {
-    const appData = process.env.APPDATA;
-    return appData ? join(appData, 'Code', 'User', 'mcp.json') : expandPath('~/AppData/Roaming/Code/User/mcp.json');
+  if (system.platform === 'win32') {
+    const appData = environment.APPDATA;
+    return appData
+      ? path.join(appData, 'Code', 'User', 'mcp.json')
+      : yield* expandPath('~/AppData/Roaming/Code/User/mcp.json');
   }
-  const configHome = process.env.XDG_CONFIG_HOME ? expandPath(process.env.XDG_CONFIG_HOME) : expandPath('~/.config');
-  return join(configHome, 'Code', 'User', 'mcp.json');
-}
+  const configHome = environment.XDG_CONFIG_HOME
+    ? yield* expandPath(environment.XDG_CONFIG_HOME)
+    : yield* expandPath('~/.config');
+  return path.join(configHome, 'Code', 'User', 'mcp.json');
+});
 
 export function parseAgentClient(value: string): AgentClient {
   if (value === 'codex' || value === 'claude' || value === 'copilot' || value === 'cursor') {
@@ -615,7 +642,10 @@ export function parseClaudeMcpScope(value: string): ClaudeMcpScope {
   throw new Error(`Invalid Claude MCP scope: ${value}. Expected local, project, or user.`);
 }
 
-export async function resolveMcpClients(value: string, action: 'remove' | 'repair'): Promise<readonly AgentClient[]> {
+export const resolveMcpClients = Effect.fn('mcp.resolveClients')(function* (
+  value: string,
+  action: 'remove' | 'repair',
+) {
   const normalized = value.trim().toLowerCase();
   if (normalized === 'none' || normalized === 'false' || normalized === 'off') {
     return [];
@@ -635,8 +665,8 @@ export async function resolveMcpClients(value: string, action: 'remove' | 'repai
   const clients: AgentClient[] = [];
   for (const client of requested) {
     if (client === 'cursor') {
-      if (!(await isCursorAvailable())) {
-        consoleOutput.log(`WARN Cursor config not found; cannot ${action} cursor MCP config.`);
+      if (!(yield* isCursorAvailable())) {
+        yield* Console.log(`WARN Cursor config not found; cannot ${action} cursor MCP config.`);
         continue;
       }
       if (!clients.includes(client)) {
@@ -645,8 +675,8 @@ export async function resolveMcpClients(value: string, action: 'remove' | 'repai
       continue;
     }
     if (client === 'copilot') {
-      if (!(await isCopilotAvailable())) {
-        consoleOutput.log(`WARN VS Code/Copilot config not found; cannot ${action} copilot MCP config.`);
+      if (!(yield* isCopilotAvailable())) {
+        yield* Console.log(`WARN VS Code/Copilot config not found; cannot ${action} copilot MCP config.`);
         continue;
       }
       if (!clients.includes(client)) {
@@ -654,9 +684,9 @@ export async function resolveMcpClients(value: string, action: 'remove' | 'repai
       }
       continue;
     }
-    if (!(await findMcpAgentExecutable(client))) {
-      const discovered = await findExecutable([client]);
-      consoleOutput.log(
+    if (!(yield* findMcpAgentExecutable(client))) {
+      const discovered = yield* findExecutable([client]);
+      yield* Console.log(
         discovered
           ? `WARN ${client} command at ${discovered} is not working; cannot ${action} ${client} MCP config. ` +
               `Repair or reinstall ${client}, then run threadnote mcp-install ${client} --apply.`
@@ -669,35 +699,30 @@ export async function resolveMcpClients(value: string, action: 'remove' | 'repai
     }
   }
   return clients;
-}
+});
 
-async function isCursorAvailable(): Promise<boolean> {
-  if (await exists(expandPath('~/.cursor'))) {
+const isCursorAvailable = Effect.fn('mcp.isCursorAvailable')(function* () {
+  const system = yield* SystemInfo;
+  if (yield* exists(yield* expandPath('~/.cursor'))) {
     return true;
   }
-  if (await findExecutable(['cursor', 'cursor-agent'])) {
+  if (yield* findExecutable(['cursor', 'cursor-agent'])) {
     return true;
   }
-  return platform() === 'darwin' && (await exists('/Applications/Cursor.app'));
-}
+  return system.platform === 'darwin' && (yield* exists('/Applications/Cursor.app'));
+});
 
-async function isCopilotAvailable(): Promise<boolean> {
-  if (process.env.THREADNOTE_COPILOT_MCP_CONFIG) {
+const isCopilotAvailable = Effect.fn('mcp.isCopilotAvailable')(function* () {
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  if (system.environment().THREADNOTE_COPILOT_MCP_CONFIG) {
     return true;
   }
-  if (await exists(dirname(copilotMcpConfigPath()))) {
+  if (yield* exists(path.dirname(yield* copilotMcpConfigPath()))) {
     return true;
   }
-  if (await findExecutable(['code', 'code-insiders'])) {
+  if (yield* findExecutable(['code', 'code-insiders'])) {
     return true;
   }
-  return platform() === 'darwin' && (await exists('/Applications/Visual Studio Code.app'));
-}
-
-function existsSyncDirectory(path: string): boolean {
-  try {
-    return statSync(path).isDirectory();
-  } catch (_err: unknown) {
-    return false;
-  }
-}
+  return system.platform === 'darwin' && (yield* exists('/Applications/Visual Studio Code.app'));
+});

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -1,12 +1,10 @@
 #! /usr/bin/env node
 
-import {NodeRuntime} from '@effect/platform-node';
+import * as NodeRuntime from '@effect/platform-node/NodeRuntime';
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import {readdir, readFile} from 'node:fs/promises';
-import {join} from 'node:path';
-import {Clock, Effect, FileSystem, pipe} from 'effect';
+import {Clock, Console, Effect, FileSystem, Path, pipe} from 'effect';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset, parseMcpToolset} from './mcp_toolset.js';
 import {formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
@@ -42,7 +40,6 @@ import {
 import {
   collectExactMatches,
   currentPackageVersion,
-  type ExactMatch,
   errorMessage,
   formatStaleVersionNotice,
   enrichRecallQueryWithWorkspaceContext,
@@ -55,7 +52,7 @@ import {
   parsePort,
   parseRecallHits,
   type RecallHit,
-  RECALL_SCORE_THRESHOLD,
+  recallScoreThreshold,
   resolveWorkspaceRepoName,
   runCommand,
   safeTimestamp,
@@ -65,10 +62,10 @@ import {
 import {withIdentity} from './runtime.js';
 import {EffectMcpServerAdapter, McpInput} from './effect/mcp.js';
 import {sha256Hex} from './effect/digest.js';
-import {fromPromiseError as attemptPromise} from './effect/errors.js';
 import {removeOpenVikingResourceEffect} from './effect/openviking.js';
 import {withMemoryUriLocks} from './effect/memory_lock.js';
 import {ApplicationLayer} from './effect/runtime.js';
+import {SystemInfo} from './effect/system.js';
 import {
   installSharedAgentArtifacts,
   listShareConflicts,
@@ -165,64 +162,62 @@ let mcpStartupVersion: string | undefined;
 let staleNoticeCache: {readonly checkedAtMs: number; readonly notice: string | undefined} | undefined;
 const STALE_NOTICE_TTL_MS = 60_000;
 
-async function staleVersionNotice(): Promise<string | undefined> {
+const staleVersionNotice = Effect.fn('mcpServer.staleVersionNotice')(function* () {
   if (mcpStartupVersion === undefined) {
     return undefined;
   }
-  const nowMs = Date.now();
+  const nowMs = yield* Clock.currentTimeMillis;
   if (staleNoticeCache && nowMs - staleNoticeCache.checkedAtMs < STALE_NOTICE_TTL_MS) {
     return staleNoticeCache.notice;
   }
-  let notice: string | undefined;
-  try {
-    notice = formatStaleVersionNotice(mcpStartupVersion, await currentPackageVersion());
-  } catch {
-    notice = undefined;
-  }
+  const notice = yield* currentPackageVersion().pipe(
+    Effect.map(version => formatStaleVersionNotice(mcpStartupVersion as string, version)),
+    Effect.catch(() => Effect.succeed(undefined)),
+  );
   staleNoticeCache = {checkedAtMs: nowMs, notice};
   return notice;
-}
+});
 
-async function withStaleVersionNotice(result: CallToolResult): Promise<CallToolResult> {
-  const notice = await staleVersionNotice();
+const withStaleVersionNotice = Effect.fn('mcpServer.withStaleVersionNotice')(function* (result: CallToolResult) {
+  const notice = yield* staleVersionNotice();
   if (notice === undefined) {
     return result;
   }
   return {...result, content: [...(result.content ?? []), {type: 'text', text: `⚠ ${notice}`}]};
-}
+});
 
 const mainEffect = Effect.gen(function* () {
-  const config = yield* Effect.try({
-    try: getRuntimeConfig,
-    catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
-  });
+  const system = yield* SystemInfo;
+  const config = yield* getRuntimeConfig();
   const toolset = yield* Effect.try({
-    try: () => parseMcpToolset(process.env[MCP_TOOLSET_ENV] ?? DEFAULT_MCP_TOOLSET),
+    try: () => parseMcpToolset(system.environment()[MCP_TOOLSET_ENV] ?? DEFAULT_MCP_TOOLSET),
     catch: cause => (cause instanceof Error ? cause : new Error(String(cause))),
   });
-  mcpStartupVersion = yield* attemptPromise(currentPackageVersion).pipe(Effect.catch(() => Effect.succeed(undefined)));
+  mcpStartupVersion = yield* currentPackageVersion().pipe(Effect.catch(() => Effect.succeed(undefined)));
   const instructions =
     'For non-trivial work call `recall_context` with repo and absolute `callerCwd`; read `viking://` results. At task closeout call `review_session_context`, show recommendations, then call `apply_memory_candidates` only after explicit user approval/edit/defer/reject. Store approved facts as durable and progress as handoff with stable project/topic; replace duplicates. Do not store secrets, credentials, customer data, or raw logs. Confirm before `share_publish`; never publish handoffs/preferences.';
   const server = new EffectMcpServerAdapter('threadnote-local-adapter', '0.2.0', instructions);
 
   registerTools(server, config, toolset);
   yield* Effect.forkScoped(monitorSharedRepositories(config));
-  yield* Effect.sync(() => process.stderr.write('Threadnote local MCP adapter running\n'));
+  yield* Console.error('Threadnote local MCP adapter running');
   return yield* server.run();
 });
 
-function getRuntimeConfig(): RuntimeConfig {
-  const host = process.env.THREADNOTE_HOST ?? DEFAULT_HOST;
-  const port = parsePort(process.env.THREADNOTE_PORT ?? String(DEFAULT_PORT));
+const getRuntimeConfig = Effect.fn('mcpServer.getRuntimeConfig')(function* () {
+  const system = yield* SystemInfo;
+  const environment = system.environment();
+  const host = environment.THREADNOTE_HOST ?? DEFAULT_HOST;
+  const port = parsePort(environment.THREADNOTE_PORT ?? String(DEFAULT_PORT));
   return {
-    account: process.env.THREADNOTE_ACCOUNT ?? DEFAULT_ACCOUNT,
-    agentContextHome: expandPath(process.env.THREADNOTE_HOME ?? '~/.openviking'),
-    agentId: process.env.THREADNOTE_AGENT_ID ?? DEFAULT_AGENT_ID,
-    manifestPath: expandPath(process.env.THREADNOTE_MANIFEST ?? '~/.openviking/seed-manifest.yaml'),
-    openVikingMcpUrl: process.env.THREADNOTE_OPENVIKING_MCP_URL ?? `http://${host}:${port}/mcp`,
-    user: process.env.THREADNOTE_USER ?? process.env.USER ?? 'unknown',
+    account: environment.THREADNOTE_ACCOUNT ?? DEFAULT_ACCOUNT,
+    agentContextHome: yield* expandPath(environment.THREADNOTE_HOME ?? '~/.openviking'),
+    agentId: environment.THREADNOTE_AGENT_ID ?? DEFAULT_AGENT_ID,
+    manifestPath: yield* expandPath(environment.THREADNOTE_MANIFEST ?? '~/.openviking/seed-manifest.yaml'),
+    openVikingMcpUrl: environment.THREADNOTE_OPENVIKING_MCP_URL ?? `http://${host}:${port}/mcp`,
+    user: environment.THREADNOTE_USER ?? system.userName,
   };
-}
+});
 
 function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, toolset: McpToolset): void {
   registerSearchTool(
@@ -287,7 +282,9 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         'Return a state-aware Threadnote capability tour. Call when the user asks what Threadnote can do or how to start; present it conversationally and offer one step at a time.',
       inputSchema: {},
     },
-    async () => runThreadnoteGuideTool(config, toolset),
+    Effect.fn('mcp_server.callback')(function* () {
+      return yield* runThreadnoteGuideTool(config, toolset);
+    }),
   );
 
   server.registerTool(
@@ -363,15 +360,16 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         watch_interval: McpInput.integer('Watch interval in minutes', {minimum: 0}),
       },
     },
-    async args =>
-      runOpenVikingAddResourceTool(config, 'add_resource', {
+    Effect.fn('mcp_server.callback')(function* (args) {
+      return yield* runOpenVikingAddResourceTool(config, 'add_resource', {
         description: args.description,
         path: args.sourcePath ?? args.path ?? args.source_path,
         tempFileId: args.tempFileId ?? args.temp_file_id,
         to: args.to,
         wait: args.wait,
         watchInterval: args.watchInterval ?? args.watch_interval,
-      }),
+      });
+    }),
   );
 
   server.registerTool(
@@ -389,7 +387,14 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         uri: McpInput.string('Optional viking:// subtree (defaults to your memories root)'),
       },
     },
-    async ({caseInsensitive, case_insensitive, nodeLimit, node_limit, pattern, uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({
+      caseInsensitive,
+      case_insensitive,
+      nodeLimit,
+      node_limit,
+      pattern,
+      uri,
+    }) {
       const checkedPattern = requiredText(pattern, 'grep', 'pattern', {pattern: 'unity-ui-ccc'});
       if (!checkedPattern.ok) {
         return checkedPattern.error;
@@ -402,13 +407,13 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'grep', {
+      return yield* runOpenVikingMcpTool(config, 'grep', {
         case_insensitive: caseInsensitive ?? case_insensitive,
         node_limit: nodeLimit ?? node_limit,
         pattern: checkedLiteralPattern.value,
         uri: checkedUri.value ?? `viking://user/${uriSegment(config.user)}/memories`,
       });
-    },
+    }),
   );
 
   server.registerTool(
@@ -423,7 +428,7 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
         uri: McpInput.string('Optional viking:// subtree'),
       },
     },
-    async ({nodeLimit, node_limit, pattern, uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({nodeLimit, node_limit, pattern, uri}) {
       const checkedPattern = requiredText(pattern, 'glob', 'pattern', {pattern: '**/AGENTS.md'});
       if (!checkedPattern.ok) {
         return checkedPattern.error;
@@ -436,12 +441,12 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'glob', {
+      return yield* runOpenVikingMcpTool(config, 'glob', {
         node_limit: nodeLimit ?? node_limit,
         pattern: checkedLiteralPattern.value,
         uri: checkedUri.value,
       });
-    },
+    }),
   );
 
   server.registerTool(
@@ -451,7 +456,9 @@ function registerTools(server: EffectMcpServerAdapter, config: RuntimeConfig, to
       description: 'Check OpenViking server health through the CLI.',
       inputSchema: {},
     },
-    async () => withStaleVersionNotice(await runOpenVikingMcpTool(config, 'health', {})),
+    Effect.fn('mcp_server.callback')(function* () {
+      return yield* withStaleVersionNotice(yield* runOpenVikingMcpTool(config, 'health', {}));
+    }),
   );
 
   registerOpenVikingParityTools(server, config);
@@ -697,7 +704,7 @@ function registerCandidateMemoryTools(server: EffectMcpServerAdapter, config: Ru
         return checkedOutcome.error;
       }
       return Effect.gen(function* () {
-        const candidatePolicy = yield* Effect.sync(() => parseCandidatePolicy(process.env.THREADNOTE_CANDIDATE_POLICY));
+        const candidatePolicy = parseCandidatePolicy((yield* SystemInfo).environment().THREADNOTE_CANDIDATE_POLICY);
         if (candidatePolicy === 'off') {
           return {
             content: [
@@ -711,9 +718,7 @@ function registerCandidateMemoryTools(server: EffectMcpServerAdapter, config: Ru
         }
         const inferredProject =
           normalizeOptionalMetadata(project) ??
-          (callerCwd
-            ? yield* attemptPromise(() => resolveWorkspaceRepoName({cwd: callerCwd, includeProcessCwd: false}))
-            : undefined);
+          (callerCwd ? yield* resolveWorkspaceRepoName({cwd: callerCwd, includeProcessCwd: false}) : undefined);
         if (!inferredProject) {
           return argumentError(
             'review_session_context requires project or an absolute callerCwd from which the repo can be inferred.',
@@ -844,9 +849,7 @@ function registerCandidateMemoryTools(server: EffectMcpServerAdapter, config: Ru
             );
           }
           if (candidate.state === 'applying' && candidate.applyTargetUri) {
-            const [appliedRecord] = yield* attemptPromise(() =>
-              readMemoryRecordsByUri(config, [candidate?.applyTargetUri as string]),
-            );
+            const [appliedRecord] = yield* readMemoryRecordsByUri(config, [candidate?.applyTargetUri as string]);
             if (appliedRecord?.metadata.candidateId === candidate.candidateId) {
               if (
                 !candidate.applyContentHash ||
@@ -1072,7 +1075,7 @@ function registerCandidateMemoryTools(server: EffectMcpServerAdapter, config: Ru
             operation: approvedOperation,
             replaceUri: targetUri,
           };
-          const preparedWrite = preparePersonalMemoryWrite(config, writeParams);
+          const preparedWrite = yield* preparePersonalMemoryWrite(config, writeParams);
           const intendedMemoryUri = preparedWrite.memoryUri;
           const approvedContentHash = yield* sha256Hex(canonicalMemoryDocumentContent(preparedWrite.memory));
           if (candidate.applyContentHash && candidate.applyContentHash !== approvedContentHash) {
@@ -1111,7 +1114,7 @@ function registerCandidateMemoryTools(server: EffectMcpServerAdapter, config: Ru
                 `${resultText} The approval is recorded as a conflict; start a new review against the current target.`,
               );
             }
-            const [possiblyWritten] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [intendedMemoryUri]));
+            const [possiblyWritten] = yield* readMemoryRecordsByUri(config, [intendedMemoryUri]);
             const destinationCanConflict = approvedOperation === 'create' || intendedMemoryUri !== targetUri;
             if (
               (destinationCanConflict &&
@@ -1190,7 +1193,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         uri: McpInput.string('Compatibility alias for target_uri'),
       },
     },
-    async ({
+    Effect.fn('mcp_server.callback')(function* ({
       contextType,
       context_type,
       limit,
@@ -1202,7 +1205,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       targetUri,
       target_uri,
       uri,
-    }) => {
+    }) {
       const checkedQuery = requiredText(query, 'ov_search', 'query', {query: 'current repo release notes'});
       if (!checkedQuery.ok) {
         return checkedQuery.error;
@@ -1212,7 +1215,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         return checkedUri.error;
       }
       const normalizedSessionId = (sessionId ?? session_id)?.trim();
-      return runOpenVikingMcpTool(config, 'search', {
+      return yield* runOpenVikingMcpTool(config, 'search', {
         context_type: contextType ?? context_type,
         limit,
         min_score: minScore ?? min_score,
@@ -1220,7 +1223,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         session_id: normalizedSessionId || undefined,
         target_uri: checkedUri.value,
       });
-    },
+    }),
   );
 
   server.registerTool(
@@ -1234,7 +1237,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         uris: McpInput.stringOrStrings('Single viking:// URI or array of URIs'),
       },
     },
-    async ({uri, uris}) => {
+    Effect.fn('mcp_server.callback')(function* ({uri, uris}) {
       const checkedUris = requiredVikingUriList(
         uris ?? uri,
         'ov_read',
@@ -1243,8 +1246,8 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       if (!checkedUris.ok) {
         return checkedUris.error;
       }
-      return runOpenVikingReadTool(config, checkedUris.value);
-    },
+      return yield* runOpenVikingReadTool(config, checkedUris.value);
+    }),
   );
 
   server.registerTool(
@@ -1294,15 +1297,16 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         watch_interval: McpInput.integer('Watch interval in minutes', {minimum: 0}),
       },
     },
-    async args =>
-      runOpenVikingAddResourceTool(config, 'ov_add_resource', {
+    Effect.fn('mcp_server.callback')(function* (args) {
+      return yield* runOpenVikingAddResourceTool(config, 'ov_add_resource', {
         description: args.description,
         path: args.path ?? args.sourcePath ?? args.source_path,
         tempFileId: args.tempFileId ?? args.temp_file_id,
         to: args.to,
         wait: args.wait,
         watchInterval: args.watchInterval ?? args.watch_interval,
-      }),
+      });
+    }),
   );
 
   server.registerTool(
@@ -1315,8 +1319,9 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         active_only: McpInput.boolean('Only show active watch tasks'),
       },
     },
-    async ({activeOnly, active_only}) =>
-      runOpenVikingMcpTool(config, 'list_watches', {active_only: activeOnly ?? active_only}),
+    Effect.fn('mcp_server.callback')(function* ({activeOnly, active_only}) {
+      return yield* runOpenVikingMcpTool(config, 'list_watches', {active_only: activeOnly ?? active_only});
+    }),
   );
 
   server.registerTool(
@@ -1330,7 +1335,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         uri: McpInput.string('Compatibility alias for to_uri'),
       },
     },
-    async ({toUri, to_uri, uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({toUri, to_uri, uri}) {
       const checkedUri = requiredVikingUri(
         toUri ?? to_uri ?? uri,
         'ov_cancel_watch',
@@ -1339,8 +1344,8 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'cancel_watch', {to_uri: checkedUri.value});
-    },
+      return yield* runOpenVikingMcpTool(config, 'cancel_watch', {to_uri: checkedUri.value});
+    }),
   );
 
   server.registerTool(
@@ -1357,7 +1362,14 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         uri: McpInput.string('Optional viking:// subtree'),
       },
     },
-    async ({caseInsensitive, case_insensitive, nodeLimit, node_limit, pattern, uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({
+      caseInsensitive,
+      case_insensitive,
+      nodeLimit,
+      node_limit,
+      pattern,
+      uri,
+    }) {
       const checkedPattern = requiredText(pattern, 'ov_grep', 'pattern', {pattern: 'threadnote'});
       if (!checkedPattern.ok) {
         return checkedPattern.error;
@@ -1370,13 +1382,13 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'grep', {
+      return yield* runOpenVikingMcpTool(config, 'grep', {
         case_insensitive: caseInsensitive ?? case_insensitive,
         node_limit: nodeLimit ?? node_limit,
         pattern: checkedLiteralPattern.value,
         uri: checkedUri.value,
       });
-    },
+    }),
   );
 
   server.registerTool(
@@ -1391,7 +1403,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         uri: McpInput.string('Optional viking:// subtree'),
       },
     },
-    async ({nodeLimit, node_limit, pattern, uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({nodeLimit, node_limit, pattern, uri}) {
       const checkedPattern = requiredText(pattern, 'ov_glob', 'pattern', {pattern: '**/AGENTS.md'});
       if (!checkedPattern.ok) {
         return checkedPattern.error;
@@ -1404,12 +1416,12 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'glob', {
+      return yield* runOpenVikingMcpTool(config, 'glob', {
         node_limit: nodeLimit ?? node_limit,
         pattern: checkedLiteralPattern.value,
         uri: checkedUri.value,
       });
-    },
+    }),
   );
 
   server.registerTool(
@@ -1440,7 +1452,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         uri: McpInput.string('Required viking:// file URI'),
       },
     },
-    async ({uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({uri}) {
       const checkedUri = requiredVikingUri(
         uri,
         'ov_code_outline',
@@ -1449,8 +1461,8 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'code_outline', {uri: checkedUri.value});
-    },
+      return yield* runOpenVikingMcpTool(config, 'code_outline', {uri: checkedUri.value});
+    }),
   );
 
   server.registerTool(
@@ -1463,7 +1475,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         uri: McpInput.string('Required viking:// directory URI'),
       },
     },
-    async ({query, uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({query, uri}) {
       const checkedQuery = requiredText(query, 'ov_code_search', 'query', {query: 'registerTools'});
       if (!checkedQuery.ok) {
         return checkedQuery.error;
@@ -1472,11 +1484,11 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'code_search', {
+      return yield* runOpenVikingMcpTool(config, 'code_search', {
         query: checkedQuery.value,
         uri: checkedUri.value,
       });
-    },
+    }),
   );
 
   server.registerTool(
@@ -1489,7 +1501,7 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
         uri: McpInput.string('Required viking:// file URI'),
       },
     },
-    async ({symbol, uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({symbol, uri}) {
       const checkedUri = requiredVikingUri(
         uri,
         'ov_code_expand',
@@ -1502,8 +1514,11 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       if (!checkedSymbol.ok) {
         return checkedSymbol.error;
       }
-      return runOpenVikingMcpTool(config, 'code_expand', {symbol: checkedSymbol.value, uri: checkedUri.value});
-    },
+      return yield* runOpenVikingMcpTool(config, 'code_expand', {
+        symbol: checkedSymbol.value,
+        uri: checkedUri.value,
+      });
+    }),
   );
 
   server.registerTool(
@@ -1513,7 +1528,9 @@ function registerOpenVikingParityTools(server: EffectMcpServerAdapter, config: R
       description: 'Raw OpenViking MCP health parity.',
       inputSchema: {},
     },
-    async () => runOpenVikingMcpTool(config, 'health', {}),
+    Effect.fn('mcp_server.callback')(function* () {
+      return yield* runOpenVikingMcpTool(config, 'health', {});
+    }),
   );
 }
 
@@ -1533,18 +1550,18 @@ function registerOpenVikingStoreTool(
         text: McpInput.string('Compatibility shortcut for a single user message'),
       },
     },
-    async ({content, messages, text}) => {
+    Effect.fn('mcp_server.callback')(function* ({content, messages, text}) {
       if (messages && messages.length > 0) {
-        return runOpenVikingMcpTool(config, 'remember', {messages});
+        return yield* runOpenVikingMcpTool(config, 'remember', {messages});
       }
       const checkedContent = requiredText(content ?? text, name, 'content', {content: 'Remember this note'});
       if (!checkedContent.ok) {
         return checkedContent.error;
       }
-      return runOpenVikingMcpTool(config, 'remember', {
+      return yield* runOpenVikingMcpTool(config, 'remember', {
         messages: [{content: checkedContent.value, role: 'user'}],
       });
-    },
+    }),
   );
 }
 
@@ -1594,7 +1611,7 @@ function registerSearchTool(
         threshold: threshold === undefined ? undefined : String(threshold),
         workset: workset?.trim() || undefined,
       }).pipe(
-        Effect.flatMap(result => attemptPromise(() => withStaleVersionNotice(result))),
+        Effect.flatMap(withStaleVersionNotice),
         Effect.catch(error =>
           Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
         ),
@@ -1626,58 +1643,54 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
         return Effect.succeed([] as readonly string[]);
       }),
     );
-    const query = yield* attemptPromise(() =>
-      enrichRecallQueryWithWorkspaceContext(params.query, {
-        cwd: params.callerCwd,
-        includeProcessCwd: false,
-      }),
-    );
-    const projectQuery = yield* attemptPromise(() =>
-      enrichRecallQueryWithWorkspaceProjectContext(params.query, {
-        cwd: params.callerCwd,
-        includeProcessCwd: false,
-      }),
-    );
+    const query = yield* enrichRecallQueryWithWorkspaceContext(params.query, {
+      cwd: params.callerCwd,
+      includeProcessCwd: false,
+    });
+    const projectQuery = yield* enrichRecallQueryWithWorkspaceProjectContext(params.query, {
+      cwd: params.callerCwd,
+      includeProcessCwd: false,
+    });
     const indexRepairMessages = yield* Effect.gen(function* () {
-      const ov = yield* attemptPromise(requiredOpenVikingCli);
-      const indexRepair = yield* attemptPromise(() => repairStaleRecallIndex(config, ov, {query: projectQuery}));
+      const ov = yield* requiredOpenVikingCli();
+      const indexRepair = yield* repairStaleRecallIndex(config, ov, {query: projectQuery});
       return formatRecallIndexRepairMessages(indexRepair);
     }).pipe(Effect.catch(error => Effect.succeed([`Auto-index repair warning: ${errorMessage(error)}`])));
-    const project = params.pinnedUri
-      ? undefined
-      : yield* attemptPromise(() => inferProjectFromQuery(config.manifestPath, projectQuery));
+    const project = params.pinnedUri ? undefined : yield* inferProjectFromQuery(config.manifestPath, projectQuery);
     const projectMemoryName = params.pinnedUri
       ? undefined
-      : yield* attemptPromise(() => resolveWorkspaceRepoName({cwd: params.callerCwd, includeProcessCwd: false}));
+      : yield* resolveWorkspaceRepoName({cwd: params.callerCwd, includeProcessCwd: false});
     const limitArgs = params.nodeLimit ? ['--node-limit', String(params.nodeLimit)] : [];
-    const threshold = params.threshold ?? RECALL_SCORE_THRESHOLD;
-    const explicitWorkset = params.workset
-      ? yield* attemptPromise(() => requireWorkset(config.manifestPath, params.workset as string))
-      : undefined;
+    const threshold = params.threshold ?? (yield* recallScoreThreshold());
+    const explicitWorkset = params.workset ? yield* requireWorkset(config.manifestPath, params.workset) : undefined;
     const pinnedArgs = params.pinnedUri ? ['--uri', params.pinnedUri] : [];
-    const base = yield* attemptPromise(() =>
-      recallSearchHits(config, ['search', query, ...pinnedArgs, ...limitArgs], threshold, params.includeArchived),
+    const base = yield* recallSearchHits(
+      config,
+      ['search', query, ...pinnedArgs, ...limitArgs],
+      threshold,
+      params.includeArchived,
     );
     const passes: Array<readonly RecallHit[]> = [base.hits];
     const scopedRecallUris = new Set([params.pinnedUri].filter((uri): uri is string => uri !== undefined));
     for (const scope of projectMemoryScopeUris(config, projectMemoryName, params.includeArchived)) {
       if (!scopedRecallUris.has(scope)) {
         scopedRecallUris.add(scope);
-        const projectMemoryPass = yield* attemptPromise(() =>
-          recallSearchHits(config, ['search', query, '--uri', scope, ...limitArgs], threshold, params.includeArchived),
+        const projectMemoryPass = yield* recallSearchHits(
+          config,
+          ['search', query, '--uri', scope, ...limitArgs],
+          threshold,
+          params.includeArchived,
         );
         passes.push(projectMemoryPass.hits);
       }
     }
     const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
     if (seededUri?.startsWith('viking://') && seededUri !== params.pinnedUri) {
-      const seeded = yield* attemptPromise(() =>
-        recallSearchHits(
-          config,
-          ['search', params.query, '--uri', seededUri, ...limitArgs],
-          threshold,
-          params.includeArchived,
-        ),
+      const seeded = yield* recallSearchHits(
+        config,
+        ['search', params.query, '--uri', seededUri, ...limitArgs],
+        threshold,
+        params.includeArchived,
       );
       passes.push(seeded.hits);
     }
@@ -1687,7 +1700,7 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
       ? undefined
       : explicitWorkset
         ? explicitWorkset
-        : yield* attemptPromise(() => inferWorksetFromQuery(config.manifestPath, projectQuery));
+        : yield* inferWorksetFromQuery(config.manifestPath, projectQuery);
     if (workset && workset.projects.length > 0) {
       sections.push(`Workset scope: ${workset.name} (${workset.projects.map(member => member.name).join(', ')})`);
       const alreadyScoped = new Set(
@@ -1697,16 +1710,17 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
         .filter(uri => !alreadyScoped.has(uri))
         .slice(0, MAX_WORKSET_PASSES);
       for (const scope of worksetScopes) {
-        const worksetPass = yield* attemptPromise(() =>
-          recallSearchHits(config, ['search', query, '--uri', scope, ...limitArgs], threshold, params.includeArchived),
+        const worksetPass = yield* recallSearchHits(
+          config,
+          ['search', query, '--uri', scope, ...limitArgs],
+          threshold,
+          params.includeArchived,
         );
         passes.push(worksetPass.hits);
       }
     }
 
-    const exactMatches = yield* attemptPromise(() =>
-      collectExactMemoryMatches(config, query, params.includeArchived, project),
-    );
+    const exactMatches = yield* collectExactMemoryMatches(config, query, params.includeArchived, project);
     const recallSections = yield* prepareRecallSections(config, {
       allowExactRescue: params.threshold === undefined,
       allowedUriScopes: params.pinnedUri ? [params.pinnedUri] : undefined,
@@ -1718,7 +1732,7 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
       passes,
       project: projectMemoryName ?? project?.name,
       query,
-      readRecords: uris => attemptPromise(() => readMemoryRecordsByUri(config, uris)),
+      readRecords: uris => readMemoryRecordsByUri(config, uris),
       seedUris: [params.pinnedUri, seededUri].filter((uri): uri is string => uri !== undefined),
     });
     const {semanticSection, exactTail} = recallSections;
@@ -1733,11 +1747,11 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
     if (exactTail) {
       sections.push(exactTail);
     }
-    const referencedContext = yield* attemptPromise(() => referencedContextSection(config, semanticSection ?? ''));
+    const referencedContext = yield* referencedContextSection(config, semanticSection ?? '');
     if (referencedContext) {
       sections.push(referencedContext);
     }
-    const hygieneHints = yield* attemptPromise(() => recallHygieneHintsSection(config, semanticSection ?? ''));
+    const hygieneHints = yield* recallHygieneHintsSection(config, semanticSection ?? '');
     if (hygieneHints) {
       sections.push(hygieneHints);
     }
@@ -1775,13 +1789,13 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
  * parsed hits, falling back to a plain search (no --threshold/--level) on a
  * non-zero exit so an older ov does not fail the recall.
  */
-async function recallSearchHits(
+const recallSearchHits = Effect.fn('mcp_server.recallSearchHits')(function* (
   config: RuntimeConfig,
   searchArgs: readonly string[],
   threshold: string,
   includeArchived: boolean,
-): Promise<{readonly errorText: string; readonly hits: readonly RecallHit[]; readonly ok: boolean}> {
-  let result = await runOpenVikingTool(config, [
+) {
+  let result = yield* runOpenVikingTool(config, [
     ...searchArgs,
     '--threshold',
     threshold,
@@ -1791,7 +1805,7 @@ async function recallSearchHits(
     'json',
   ]);
   if (result.isError === true) {
-    result = await runOpenVikingTool(config, [...searchArgs, '--output', 'json']);
+    result = yield* runOpenVikingTool(config, [...searchArgs, '--output', 'json']);
   }
   const firstContent = result.content[0];
   const text = firstContent?.type === 'text' ? firstContent.text : '';
@@ -1799,17 +1813,20 @@ async function recallSearchHits(
     return {errorText: text.trim(), hits: [], ok: false};
   }
   return {errorText: '', hits: parseRecallHits(text, {includeArchived}), ok: true};
-}
+});
 
-async function recallHygieneHintsSection(config: RuntimeConfig, recallText: string): Promise<string | undefined> {
+const recallHygieneHintsSection = Effect.fn('mcpServer.recallHygieneHints')(function* (
+  config: RuntimeConfig,
+  recallText: string,
+) {
   const uris = activePersonalMemoryUrisFromText(recallText, config.user);
   if (uris.length === 0) {
     return undefined;
   }
-  const records = await readMemoryRecordsByUri(config, uris);
+  const records = yield* readMemoryRecordsByUri(config, uris);
   const nudges = recallHygieneNudges(recallText, {records, user: config.user});
   return nudges.length > 0 ? ['Memory hygiene hints:', ...nudges.map(nudge => `- ${nudge}`)].join('\n') : undefined;
-}
+});
 
 const MAX_REFERENCED_CONTEXT = 5;
 const REFERENCED_EXCERPT_LINES = 12;
@@ -1820,18 +1837,21 @@ const REFERENCED_EXCERPT_LINES = 12;
  * appending a short excerpt. Bounded to one hop and a small cap; missing
  * references degrade to a labeled line and never fail recall.
  */
-async function referencedContextSection(config: RuntimeConfig, recallText: string): Promise<string | undefined> {
+const referencedContextSection = Effect.fn('mcpServer.referencedContext')(function* (
+  config: RuntimeConfig,
+  recallText: string,
+) {
   const surfacedUris = activePersonalMemoryUrisFromText(recallText, config.user);
   if (surfacedUris.length === 0) {
     return undefined;
   }
-  const surfaced = await readMemoryRecordsByUri(config, surfacedUris);
+  const surfaced = yield* readMemoryRecordsByUri(config, surfacedUris);
   const referenced = referencedUrisFromRecords(surfaced, recallText);
   if (referenced.length === 0) {
     return undefined;
   }
   const capped = referenced.slice(0, MAX_REFERENCED_CONTEXT);
-  const records = await readMemoryRecordsByUri(config, capped);
+  const records = yield* readMemoryRecordsByUri(config, capped);
   const byUri = new Map(records.map(record => [record.uri, record]));
   const lines = ['Referenced read-only context (one-way pointers from surfaced memories):'];
   for (const uri of capped) {
@@ -1847,29 +1867,33 @@ async function referencedContextSection(config: RuntimeConfig, recallText: strin
     lines.push(`- … ${omitted} more referenced ${omitted === 1 ? 'memory' : 'memories'} omitted`);
   }
   return lines.join('\n');
-}
+});
 
-async function collectExactMemoryMatches(
+const collectExactMemoryMatches = Effect.fn('mcp_server.collectExactMemoryMatches')(function* (
   config: RuntimeConfig,
   query: string,
   includeArchived: boolean,
   project: ProjectManifest | undefined,
-): Promise<readonly ExactMatch[]> {
+) {
   const terms = exactRecallTerms(query);
   if (terms.length === 0) {
     return [];
   }
-  const ov = await requiredOpenVikingCli();
+  const ov = yield* requiredOpenVikingCli();
   const scopes = exactMemoryScopes(config, includeArchived, query, project);
-  return collectExactMatches(terms, scopes, async (term, scope) => {
-    const result = await runCommand(
-      ov,
-      withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5', '--output', 'json']),
-      {allowFailure: true},
-    );
-    return result.exitCode === 0 ? result.stdout : undefined;
-  });
-}
+  return yield* collectExactMatches(
+    terms,
+    scopes,
+    Effect.fn('mcp_server.callback')(function* (term, scope) {
+      const result = yield* runCommand(
+        ov,
+        withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5', '--output', 'json']),
+        {allowFailure: true},
+      );
+      return result.exitCode === 0 ? result.stdout : undefined;
+    }),
+  );
+});
 
 function registerReadTool(
   server: EffectMcpServerAdapter,
@@ -1904,7 +1928,7 @@ function registerReadTool(
             return Effect.succeed([] as readonly string[]);
           }),
         );
-        const result = yield* attemptPromise(() => runOpenVikingReadTool(config, checkedUris.value));
+        const result = yield* runOpenVikingReadTool(config, checkedUris.value);
         if (result.isError === true || (syncedTeams.length === 0 && syncWarnings.length === 0)) {
           return result;
         }
@@ -1941,16 +1965,16 @@ function registerListTool(
         node_limit: McpInput.integer('Maximum node count', {minimum: 1, maximum: 1000}),
       },
     },
-    async ({recursive, uri}) => {
+    Effect.fn('mcp_server.callback')(function* ({recursive, uri}) {
       const checkedUri = optionalVikingUri(uri, name);
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return runOpenVikingMcpTool(config, 'list', {
+      return yield* runOpenVikingMcpTool(config, 'list', {
         recursive,
         uri: checkedUri.value ?? 'viking://',
       });
-    },
+    }),
   );
 }
 
@@ -2010,7 +2034,7 @@ function registerStoreTool(
         metadata,
         replaceUri: checkedReplaceUri.value,
       }).pipe(
-        Effect.flatMap(result => attemptPromise(() => withStaleVersionNotice(result))),
+        Effect.flatMap(withStaleVersionNotice),
         Effect.catch(error =>
           Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
         ),
@@ -2182,7 +2206,7 @@ function reviewedCandidateTargetIsCurrent(config: RuntimeConfig, candidate: Memo
       config.agentContextHome,
       [candidate.targetUri],
       Effect.gen(function* () {
-        const [target] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [candidate.targetUri as string]));
+        const [target] = yield* readMemoryRecordsByUri(config, [candidate.targetUri as string]);
         return (
           target !== undefined &&
           (yield* sha256Hex(canonicalMemoryDocumentContent(target.content))) === candidate.targetContentHash
@@ -2230,9 +2254,7 @@ function reconcileCandidateReplacementCleanup(config: RuntimeConfig, candidate: 
       config.agentContextHome,
       [candidate.applyReplaceUri, candidate.applyTargetUri],
       Effect.gen(function* () {
-        const [currentTarget] = yield* attemptPromise(() =>
-          readMemoryRecordsByUri(config, [candidate.applyReplaceUri as string]),
-        );
+        const [currentTarget] = yield* readMemoryRecordsByUri(config, [candidate.applyReplaceUri as string]);
         if (!currentTarget) {
           return 'complete' as const;
         }
@@ -2242,14 +2264,12 @@ function reconcileCandidateReplacementCleanup(config: RuntimeConfig, candidate: 
         ) {
           return 'conflict' as const;
         }
-        const ov = yield* attemptPromise(requiredOpenVikingCli);
+        const ov = yield* requiredOpenVikingCli();
         const removed = yield* removeVikingResourceWithRetry(ov, config, candidate.applyReplaceUri as string);
         if (!removed) {
           return 'pending' as const;
         }
-        const stillExists = yield* attemptPromise(() =>
-          vikingResourceExists(ov, config, candidate.applyReplaceUri as string),
-        );
+        const stillExists = yield* vikingResourceExists(ov, config, candidate.applyReplaceUri as string);
         return stillExists ? ('pending' as const) : ('complete' as const);
       }),
     );
@@ -2342,12 +2362,12 @@ function registerArchiveTool(
         return checkedUri.error;
       }
       return Effect.gen(function* () {
-        const [sourceRecord] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [checkedUri.value]));
+        const [sourceRecord] = yield* readMemoryRecordsByUri(config, [checkedUri.value]);
         if (!sourceRecord) {
           return argumentError(`Could not resolve local memory content for ${checkedUri.value} before archiving.`);
         }
         const sourceContent = sourceRecord.content;
-        const readResult = yield* attemptPromise(() => runOpenVikingReadTool(config, [checkedUri.value]));
+        const readResult = yield* runOpenVikingReadTool(config, [checkedUri.value]);
         const original = textFromCallToolResult(readResult);
         if (!original) {
           return {
@@ -2421,12 +2441,10 @@ function registerCompactTool(server: EffectMcpServerAdapter, config: RuntimeConf
         };
       }
       return Effect.gen(function* () {
-        const records = yield* attemptPromise(() =>
-          scopedCompactRecords(config, {
-            kind: kind as CompactableMemoryKind | undefined,
-            project: checkedProject.value,
-          }),
-        );
+        const records = yield* scopedCompactRecords(config, {
+          kind: kind as CompactableMemoryKind | undefined,
+          project: checkedProject.value,
+        });
         const plan = buildCompactPlan(records, {
           kind: kind as CompactableMemoryKind | undefined,
           project: checkedProject.value,
@@ -2438,7 +2456,7 @@ function registerCompactTool(server: EffectMcpServerAdapter, config: RuntimeConf
           return {content: [{type: 'text', text: planText}]};
         }
 
-        const ov = yield* attemptPromise(requiredOpenVikingCli);
+        const ov = yield* requiredOpenVikingCli();
         const appliedMessages: string[] = [];
         for (const action of plan.keepUpdates) {
           const keepResult = yield* writeMemoryContentWithExpectedHash(
@@ -2490,7 +2508,7 @@ function registerCompactTool(server: EffectMcpServerAdapter, config: RuntimeConf
 
 function archiveMemoryForCompact(config: RuntimeConfig, action: ArchiveAction) {
   return Effect.gen(function* () {
-    const readResult = yield* attemptPromise(() => runOpenVikingReadTool(config, [action.uri]));
+    const readResult = yield* runOpenVikingReadTool(config, [action.uri]);
     const original = textFromCallToolResult(readResult);
     if (!original) {
       return {content: [{type: 'text', text: `Could not read ${action.uri} before archiving.`}], isError: true};
@@ -2527,49 +2545,54 @@ function archiveMemoryForCompact(config: RuntimeConfig, action: ArchiveAction) {
   });
 }
 
-async function scopedCompactRecords(
+const scopedCompactRecords = Effect.fn('mcpServer.scopedCompactRecords')(function* (
   config: RuntimeConfig,
   options: {readonly kind?: CompactableMemoryKind; readonly project: string},
-): Promise<readonly MemoryRecord[]> {
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const kinds: readonly CompactableMemoryKind[] = options.kind ? [options.kind] : ['handoff', 'durable', 'incident'];
   const records: MemoryRecord[] = [];
   for (const kind of kinds) {
-    const directory = localMemoryDirectoryForCompact(config, kind, options.project);
+    const directory = yield* localMemoryDirectoryForCompact(config, kind, options.project);
     const uriDirectory = memoryUriDirectoryForCompact(config, kind, options.project);
-    let entries;
-    try {
-      entries = await readdir(directory, {withFileTypes: true});
-    } catch (_err: unknown) {
+    const entries = yield* fs.readDirectory(directory).pipe(Effect.option);
+    if (entries._tag === 'None') {
       continue;
     }
-    for (const entry of entries) {
-      if (!entry.isFile() || entry.name.startsWith('.') || !entry.name.endsWith('.md')) {
+    for (const entry of entries.value) {
+      if (entry.startsWith('.') || !entry.endsWith('.md')) {
         continue;
       }
-      const content = await readTextIfExists(join(directory, entry.name));
+      const entryPath = path.join(directory, entry);
+      const info = yield* fs.stat(entryPath).pipe(Effect.option);
+      if (info._tag === 'None' || info.value.type !== 'File') {
+        continue;
+      }
+      const content = yield* readTextIfExists(entryPath);
       if (!content) {
         continue;
       }
-      const record = parseMemoryDocument(`${uriDirectory}/${entry.name}`, content);
+      const record = parseMemoryDocument(`${uriDirectory}/${entry}`, content);
       if (record) {
         records.push(record);
       }
     }
   }
   return records;
-}
+});
 
-async function readMemoryRecordsByUri(
+const readMemoryRecordsByUri = Effect.fn('mcpServer.readMemoryRecordsByUri')(function* (
   config: RuntimeConfig,
   uris: readonly string[],
-): Promise<readonly MemoryRecord[]> {
+) {
   const records: MemoryRecord[] = [];
   for (const uri of uris) {
-    const localPath = localMemoryPathForUri(config, uri);
+    const localPath = yield* localMemoryPathForUri(config, uri);
     if (!localPath) {
       continue;
     }
-    const content = await readTextIfExists(localPath);
+    const content = yield* readTextIfExists(localPath);
     if (!content) {
       continue;
     }
@@ -2579,20 +2602,25 @@ async function readMemoryRecordsByUri(
     }
   }
   return records;
-}
+});
 
-function localMemoryDirectoryForCompact(config: RuntimeConfig, kind: CompactableMemoryKind, project: string): string {
-  const root = localUserMemoriesRoot(config);
+const localMemoryDirectoryForCompact = Effect.fn('mcpServer.localMemoryDirectoryForCompact')(function* (
+  config: RuntimeConfig,
+  kind: CompactableMemoryKind,
+  project: string,
+) {
+  const path = yield* Path.Path;
+  const root = yield* localUserMemoriesRoot(config);
   const projectSegment = uriSegment(project);
   switch (kind) {
     case 'durable':
-      return join(root, 'durable', 'projects', projectSegment);
+      return path.join(root, 'durable', 'projects', projectSegment);
     case 'handoff':
-      return join(root, 'handoffs', 'active', projectSegment);
+      return path.join(root, 'handoffs', 'active', projectSegment);
     case 'incident':
-      return join(root, 'incidents', 'active', projectSegment);
+      return path.join(root, 'incidents', 'active', projectSegment);
   }
-}
+});
 
 function memoryUriDirectoryForCompact(config: RuntimeConfig, kind: CompactableMemoryKind, project: string): string {
   const base = `viking://user/${uriSegment(config.user)}/memories`;
@@ -2607,7 +2635,10 @@ function memoryUriDirectoryForCompact(config: RuntimeConfig, kind: CompactableMe
   }
 }
 
-function localMemoryPathForUri(config: RuntimeConfig, uri: string): string | undefined {
+const localMemoryPathForUri = Effect.fn('mcpServer.localMemoryPathForUri')(function* (
+  config: RuntimeConfig,
+  uri: string,
+) {
   const prefix = `viking://user/${uriSegment(config.user)}/memories/`;
   if (!uri.startsWith(prefix)) {
     return undefined;
@@ -2616,20 +2647,27 @@ function localMemoryPathForUri(config: RuntimeConfig, uri: string): string | und
   if (relative.includes('..') || relative.startsWith('/')) {
     return undefined;
   }
-  return join(localUserMemoriesRoot(config), ...relative.split('/'));
-}
+  const path = yield* Path.Path;
+  return path.join(yield* localUserMemoriesRoot(config), ...relative.split('/'));
+});
 
-function localUserMemoriesRoot(config: RuntimeConfig): string {
-  return join(config.agentContextHome, 'data', 'viking', config.account, 'user', uriSegment(config.user), 'memories');
-}
+const localUserMemoriesRoot = Effect.fn('mcpServer.localUserMemoriesRoot')(function* (config: RuntimeConfig) {
+  const path = yield* Path.Path;
+  return path.join(
+    config.agentContextHome,
+    'data',
+    'viking',
+    config.account,
+    'user',
+    uriSegment(config.user),
+    'memories',
+  );
+});
 
-async function readTextIfExists(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, 'utf8');
-  } catch (_err: unknown) {
-    return undefined;
-  }
-}
+const readTextIfExists = Effect.fn('mcpServer.readTextIfExists')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readFileString(path).pipe(Effect.catch(() => Effect.succeed(undefined)));
+});
 
 interface WriteDurableMemoryParams {
   readonly bodyText: string;
@@ -2650,21 +2688,19 @@ interface PreparedPersonalMemoryWrite {
 
 function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryParams) {
   const write = Effect.gen(function* () {
-    const prepared = params.prepared ?? preparePersonalMemoryWrite(config, params);
+    const prepared = params.prepared ?? (yield* preparePersonalMemoryWrite(config, params));
     const fs = yield* FileSystem.FileSystem;
     return yield* withMemoryUriLocks(
       fs,
       config.agentContextHome,
       [params.replaceUri, prepared.memoryUri, ...(params.expectedSourceContent ?? []).map(source => source.uri)],
       Effect.gen(function* () {
-        const ov = yield* attemptPromise(requiredOpenVikingCli);
+        const ov = yield* requiredOpenVikingCli();
         if (params.operation === 'replace' && !params.replaceUri) {
           return argumentError('A replace write requires replaceUri.');
         }
         if (params.replaceUri && params.expectedReplaceContentHash) {
-          const [currentTarget] = yield* attemptPromise(() =>
-            readMemoryRecordsByUri(config, [params.replaceUri as string]),
-          );
+          const [currentTarget] = yield* readMemoryRecordsByUri(config, [params.replaceUri as string]);
           if (
             !currentTarget ||
             (yield* sha256Hex(canonicalMemoryDocumentContent(currentTarget.content))) !==
@@ -2676,7 +2712,7 @@ function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryPar
           }
         }
         for (const source of params.expectedSourceContent ?? []) {
-          const [currentSource] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [source.uri]));
+          const [currentSource] = yield* readMemoryRecordsByUri(config, [source.uri]);
           if (!currentSource || currentSource.content !== source.content) {
             return argumentError(
               `Memory ${source.uri} changed after this mutation was planned. Re-run the operation before writing.`,
@@ -2684,20 +2720,18 @@ function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryPar
           }
         }
         if (params.replaceUri && isInSharedNamespace(config, params.replaceUri)) {
-          return yield* attemptPromise(() =>
-            writeSharedMemoryReplacement(config, ov, params, params.replaceUri as string),
-          );
+          return yield* writeSharedMemoryReplacement(config, ov, params, params.replaceUri as string);
         }
         const {finalMetadata, isInPlaceUpdate, memory, memoryUri} = prepared;
-        const destinationExists = yield* attemptPromise(() => vikingResourceExists(ov, config, memoryUri));
+        const destinationExists = yield* vikingResourceExists(ov, config, memoryUri);
         if (params.operation === 'replace' && destinationExists && params.replaceUri !== memoryUri) {
-          const [destinationRecord] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [memoryUri]));
+          const [destinationRecord] = yield* readMemoryRecordsByUri(config, [memoryUri]);
           if (destinationRecord?.metadata.candidateId !== params.metadata.candidateId) {
             return argumentError(`Replacement destination already contains another memory: ${memoryUri}.`);
           }
         }
         const directoryUri = memoryDirectoryUri(config, finalMetadata);
-        yield* attemptPromise(() => ensureMemoryDirectory(ov, config, directoryUri));
+        yield* ensureMemoryDirectory(ov, config, directoryUri);
         const writeMode =
           params.operation === 'create'
             ? 'create'
@@ -2705,8 +2739,8 @@ function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryPar
               ? destinationExists
                 ? 'replace'
                 : 'create'
-              : yield* attemptPromise(() => memoryWriteMode(ov, config, memoryUri, finalMetadata));
-        yield* attemptPromise(() => writeMemoryFile(config, ov, memoryUri, memory, writeMode, false, {quiet: true}));
+              : yield* memoryWriteMode(ov, config, memoryUri, finalMetadata);
+        yield* writeMemoryFile(config, ov, memoryUri, memory, writeMode, false, {quiet: true});
         const messages = [`Stored memory: ${memoryUri}`];
         let replacementCleanupPending = false;
         if (params.replaceUri && !isInPlaceUpdate) {
@@ -2735,6 +2769,7 @@ function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryPar
     Effect.catch(error =>
       Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
     ),
+    Effect.map(result => result as CallToolResult),
   );
 }
 
@@ -2743,30 +2778,30 @@ function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMemoryPar
  * candidate enters its recoverable `applying` state. The writer consumes this
  * same prepared value so recovery and the actual write cannot disagree.
  */
-function preparePersonalMemoryWrite(
+const preparePersonalMemoryWrite = Effect.fn('mcpServer.preparePersonalMemoryWrite')(function* (
   config: RuntimeConfig,
   params: Pick<WriteDurableMemoryParams, 'bodyText' | 'metadata' | 'replaceUri'>,
-): PreparedPersonalMemoryWrite {
+) {
   // Two-pass formatting: see src/memory.ts:storeMemory for the rationale.
   // Drops the supersedes line when replaceUri points at the URI we're about
   // to write to (in-place update).
   const candidateMetadata: MemoryMetadata = {...params.metadata, supersedes: params.replaceUri};
   const candidateMemory = formatMemoryDocument('MEMORY', candidateMetadata, params.bodyText);
-  const memoryUri = memoryUriFor(config, candidateMemory, candidateMetadata);
+  const memoryUri = yield* memoryUriFor(config, candidateMemory, candidateMetadata);
   const isInPlaceUpdate = params.replaceUri !== undefined && params.replaceUri === memoryUri;
   const finalMetadata: MemoryMetadata = isInPlaceUpdate
     ? {...params.metadata, supersedes: undefined}
     : candidateMetadata;
   const memory = isInPlaceUpdate ? formatMemoryDocument('MEMORY', finalMetadata, params.bodyText) : candidateMemory;
-  return {finalMetadata, isInPlaceUpdate, memory, memoryUri};
-}
+  return {finalMetadata, isInPlaceUpdate, memory, memoryUri} satisfies PreparedPersonalMemoryWrite;
+});
 
-async function writeSharedMemoryReplacement(
+const writeSharedMemoryReplacement = Effect.fn('mcp_server.writeSharedMemoryReplacement')(function* (
   config: RuntimeConfig,
   ov: string,
   params: WriteDurableMemoryParams,
   targetUri: string,
-): Promise<CallToolResult> {
+) {
   if (params.metadata.kind !== 'durable') {
     return argumentError('Shared memory replacement only supports durable memories.');
   }
@@ -2774,7 +2809,7 @@ async function writeSharedMemoryReplacement(
   if (!teamName) {
     return argumentError(`Memory ${targetUri} is not in the shared namespace.`);
   }
-  const resolved = await resolveTeam(config, teamName);
+  const resolved = yield* resolveTeam(config, teamName);
   const inferred = sharedMemoryUriParts(config, targetUri);
   const metadata: MemoryMetadata = {
     ...params.metadata,
@@ -2789,8 +2824,8 @@ async function writeSharedMemoryReplacement(
     );
   }
 
-  await ensureSharedDirectoryChain(config, ov, targetUri, false, {quiet: true});
-  await writeMemoryFile(config, ov, targetUri, scrub.cleaned, 'replace', false, {quiet: true});
+  yield* ensureSharedDirectoryChain(config, ov, targetUri, false, {quiet: true});
+  yield* writeMemoryFile(config, ov, targetUri, scrub.cleaned, 'replace', false, {quiet: true});
 
   const relativePath = vikingUriToWorktreeRelative(config, targetUri, resolved.name);
   const messages = [`Updated shared memory: ${targetUri}`];
@@ -2798,15 +2833,19 @@ async function writeSharedMemoryReplacement(
     messages.push(`Redacted ${redaction.count}× ${redaction.name} before shared update.`);
   }
   messages.push(
-    ...(await publishShareGitChange(resolved.config.worktree, relativePath, `share: update ${relativePath}`)),
+    ...(yield* publishShareGitChange(resolved.config.worktree, relativePath, `share: update ${relativePath}`)),
   );
   return {content: [{type: 'text', text: messages.join('\n')}]};
-}
+});
 
-async function vikingResourceExists(ov: string, config: RuntimeConfig, uri: string): Promise<boolean> {
-  const stat = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+const vikingResourceExists = Effect.fn('mcp_server.vikingResourceExists')(function* (
+  ov: string,
+  config: RuntimeConfig,
+  uri: string,
+) {
+  const stat = yield* runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
   return stat.exitCode === 0;
-}
+});
 
 function removeVikingResourceWithRetry(ov: string, config: RuntimeConfig, uri: string, recursive = false) {
   const args = withIdentity(config, ['rm', uri, ...(recursive ? ['--recursive'] : [])]);
@@ -2840,25 +2879,33 @@ function isResourceBusy(stderr: string, stdout: string): boolean {
   return output.includes('resource is busy') || output.includes('resource is being processed');
 }
 
-async function ensureMemoryDirectory(ov: string, config: RuntimeConfig, directoryUri: string): Promise<void> {
+const ensureMemoryDirectory = Effect.fn('mcp_server.ensureMemoryDirectory')(function* (
+  ov: string,
+  config: RuntimeConfig,
+  directoryUri: string,
+) {
   for (const uri of vikingDirectoryChain(directoryUri)) {
-    const statResult = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+    const statResult = yield* runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
     if (statResult.exitCode === 0) {
       continue;
     }
-    await runCommand(
+    yield* runCommand(
       ov,
       withIdentity(config, ['mkdir', uri, '--description', 'Threadnote lifecycle-aware local memories.']),
     );
   }
-}
+});
 
-function memoryUriFor(config: RuntimeConfig, memory: string, metadata: MemoryMetadata): string {
+const memoryUriFor = Effect.fn('mcpServer.memoryUriFor')(function* (
+  config: RuntimeConfig,
+  memory: string,
+  metadata: MemoryMetadata,
+) {
   const filename = shouldUseStableMemoryUri(metadata)
     ? `${uriSegment(metadata.topic ?? 'current')}.md`
-    : `threadnote-${safeTimestamp()}-${sha256(memory).slice(0, 12)}.md`;
+    : `threadnote-${safeTimestamp()}-${(yield* sha256(memory)).slice(0, 12)}.md`;
   return `${memoryDirectoryUri(config, metadata)}/${filename}`;
-}
+});
 
 function memoryDirectoryUri(config: RuntimeConfig, metadata: MemoryMetadata): string {
   const baseUri = `viking://user/${uriSegment(config.user)}/memories`;
@@ -2885,17 +2932,17 @@ function shouldUseStableMemoryUri(metadata: MemoryMetadata): boolean {
   return metadata.status === 'active' && metadata.topic !== undefined && metadata.kind !== 'smoke';
 }
 
-async function memoryWriteMode(
+const memoryWriteMode = Effect.fn('mcp_server.memoryWriteMode')(function* (
   ov: string,
   config: RuntimeConfig,
   memoryUri: string,
   metadata: MemoryMetadata,
-): Promise<'create' | 'replace'> {
+) {
   if (!shouldUseStableMemoryUri(metadata)) {
     return 'create';
   }
-  return (await vikingResourceExists(ov, config, memoryUri)) ? 'replace' : 'create';
-}
+  return (yield* vikingResourceExists(ov, config, memoryUri)) ? 'replace' : 'create';
+});
 
 function vikingDirectoryChain(directoryUri: string): readonly string[] {
   const prefix = 'viking://';
@@ -3107,11 +3154,11 @@ interface OpenVikingAddResourceParams {
   readonly watchInterval?: number;
 }
 
-async function runOpenVikingAddResourceTool(
+const runOpenVikingAddResourceTool = Effect.fn('mcp_server.runOpenVikingAddResourceTool')(function* (
   config: RuntimeConfig,
   toolName: string,
   params: OpenVikingAddResourceParams,
-): Promise<CallToolResult> {
+) {
   const tempFileId = params.tempFileId?.trim();
   const source = params.path?.trim();
   if (!source && !tempFileId) {
@@ -3134,7 +3181,7 @@ async function runOpenVikingAddResourceTool(
     if (!checkedTo.ok) {
       return checkedTo.error;
     }
-    return runOpenVikingMcpTool(config, 'add_resource', {
+    return yield* runOpenVikingMcpTool(config, 'add_resource', {
       description: params.description,
       temp_file_id: tempFileId,
       to: checkedTo.value,
@@ -3146,38 +3193,41 @@ async function runOpenVikingAddResourceTool(
     return checkedTo.error;
   }
   const description = params.description?.trim();
-  return runOpenVikingMcpTool(config, 'add_resource', {
+  return yield* runOpenVikingMcpTool(config, 'add_resource', {
     description,
     path: source,
     to: checkedTo.value,
     watch_interval: params.watchInterval,
   });
-}
+});
 
-async function runOpenVikingReadTool(config: RuntimeConfig, uris: readonly string[]): Promise<CallToolResult> {
-  const result = await runOpenVikingMcpTool(config, 'read', {uris});
+const runOpenVikingReadTool = Effect.fn('mcp_server.runOpenVikingReadTool')(function* (
+  config: RuntimeConfig,
+  uris: readonly string[],
+) {
+  const result = yield* runOpenVikingMcpTool(config, 'read', {uris});
   if (result.isError !== true && !nativeReadMissedAnyUri(result, uris)) {
     return result;
   }
-  return runOpenVikingReadToolWithCliFallback(config, uris);
-}
+  return yield* runOpenVikingReadToolWithCliFallback(config, uris);
+});
 
 function nativeReadMissedAnyUri(result: CallToolResult, uris: readonly string[]): boolean {
   const text = textFromCallToolResult(result);
   return uris.some(uri => text.includes(`(nothing found at ${uri})`));
 }
 
-async function runOpenVikingReadToolWithCliFallback(
+const runOpenVikingReadToolWithCliFallback = Effect.fn('mcp_server.runOpenVikingReadToolWithCliFallback')(function* (
   config: RuntimeConfig,
   uris: readonly string[],
-): Promise<CallToolResult> {
+) {
   const outputs: string[] = [];
   for (const uri of uris) {
-    const nativeResult = await runOpenVikingMcpTool(config, 'read', {uris: [uri]});
+    const nativeResult = yield* runOpenVikingMcpTool(config, 'read', {uris: [uri]});
     const nativeText = textFromCallToolResult(nativeResult);
     let text = nativeText;
     if (nativeResult.isError === true || nativeText.includes(`(nothing found at ${uri})`)) {
-      const cliResult = await runOpenVikingCliReadTool(config, uri);
+      const cliResult = yield* runOpenVikingCliReadTool(config, uri);
       if (cliResult.isError === true) {
         return cliResult;
       }
@@ -3185,19 +3235,28 @@ async function runOpenVikingReadToolWithCliFallback(
     }
     outputs.push(uris.length === 1 ? text : `=== ${uri} ===\n${text}`);
   }
-  return {content: [{type: 'text', text: outputs.filter(Boolean).join('\n\n') || 'OK'}]};
-}
+  return {content: [{type: 'text', text: outputs.filter(Boolean).join('\n\n') || 'OK'}]} satisfies CallToolResult;
+});
 
-async function runOpenVikingCliReadTool(config: RuntimeConfig, uri: string): Promise<CallToolResult> {
-  try {
-    const ov = await requiredOpenVikingCli();
-    const result = await runCommand(ov, withIdentity(config, ['read', uri]));
+const runOpenVikingCliReadTool = Effect.fn('mcp_server.runOpenVikingCliReadTool')(function* (
+  config: RuntimeConfig,
+  uri: string,
+) {
+  return yield* Effect.gen(function* () {
+    const ov = yield* requiredOpenVikingCli();
+    const result = yield* runCommand(ov, withIdentity(config, ['read', uri]));
     const text = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
-    return {content: [{type: 'text', text: text || 'OK'}]};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
-}
+    return {content: [{type: 'text', text: text || 'OK'}]} satisfies CallToolResult;
+  }).pipe(
+    Effect.catch(error =>
+      Effect.succeed({
+        content: [{type: 'text', text: errorMessage(error)}],
+        isError: true,
+      } satisfies CallToolResult),
+    ),
+    Effect.map(result => result as CallToolResult),
+  );
+});
 
 /**
  * Run an `ov` CLI subcommand and wrap its output as a CallToolResult. Used by
@@ -3206,53 +3265,85 @@ async function runOpenVikingCliReadTool(config: RuntimeConfig, uri: string): Pro
  * `/mcp` search, which returns full Level-2 bodies and bloats recall ~15x.
  * Goes through `runCommand` (no-shell `execFile`), so it stays injection-safe.
  */
-async function runOpenVikingTool(config: RuntimeConfig, args: readonly string[]): Promise<CallToolResult> {
-  try {
-    const ov = await requiredOpenVikingCli();
-    const result = await runCommand(ov, withIdentity(config, args));
+const runOpenVikingTool = Effect.fn('mcp_server.runOpenVikingTool')(function* (
+  config: RuntimeConfig,
+  args: readonly string[],
+) {
+  return yield* Effect.gen(function* () {
+    const ov = yield* requiredOpenVikingCli();
+    const result = yield* runCommand(ov, withIdentity(config, args));
     const text = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n');
-    return {content: [{type: 'text', text: text || 'OK'}]};
-  } catch (err: unknown) {
-    return {content: [{type: 'text', text: errorMessage(err)}], isError: true};
-  }
-}
+    return {content: [{type: 'text', text: text || 'OK'}]} satisfies CallToolResult;
+  }).pipe(
+    Effect.catch(error =>
+      Effect.succeed({
+        content: [{type: 'text', text: errorMessage(error)}],
+        isError: true,
+      } satisfies CallToolResult),
+    ),
+    Effect.map(result => result as CallToolResult),
+  );
+});
 
-async function runOpenVikingMcpTool(
+const runOpenVikingMcpTool = Effect.fn('mcp_server.runOpenVikingMcpTool')(function* (
   config: RuntimeConfig,
   toolName: string,
   args: Record<string, unknown>,
-): Promise<CallToolResult> {
-  const client = new Client({name: 'threadnote-openviking-proxy', version: '1.1.0'});
-  try {
-    const transport = new StreamableHTTPClientTransport(new URL(config.openVikingMcpUrl), {
-      requestInit: {
-        headers: {
-          // OpenViking 0.4.x dropped agent_id as an identity input; only
-          // account + user are honored (mirrors withIdentity in runtime.ts).
-          'X-OpenViking-Account': config.account,
-          'X-OpenViking-User': config.user,
-        },
-      },
+) {
+  const invocation = Effect.gen(function* () {
+    const client = new Client({name: 'threadnote-openviking-proxy', version: '1.1.0'});
+    const transport = yield* Effect.try({
+      try: () =>
+        new StreamableHTTPClientTransport(new URL(config.openVikingMcpUrl), {
+          requestInit: {
+            headers: {
+              // OpenViking 0.4.x dropped agent_id as an identity input; only
+              // account + user are honored (mirrors withIdentity in runtime.ts).
+              'X-OpenViking-Account': config.account,
+              'X-OpenViking-User': config.user,
+            },
+          },
+        }),
+      catch: error => error,
     });
-    await client.connect(transport);
-    const result = await client.callTool({arguments: stripUndefinedValues(args), name: toolName}, undefined, {
-      timeout: 30_000,
-    });
-    return normalizeCallToolResult(result);
-  } catch (err: unknown) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `OpenViking native MCP tool "${toolName}" failed at ${config.openVikingMcpUrl}: ${errorMessage(err)}`,
+    return yield* Effect.acquireUseRelease(
+      Effect.tryPromise({
+        try: async () => {
+          await client.connect(transport);
+          return client;
         },
-      ],
-      isError: true,
-    };
-  } finally {
-    await client.close().catch(() => undefined);
-  }
-}
+        catch: error => error,
+      }),
+      connectedClient =>
+        Effect.tryPromise({
+          try: () =>
+            connectedClient.callTool({arguments: stripUndefinedValues(args), name: toolName}, undefined, {
+              timeout: 30_000,
+            }),
+          catch: error => error,
+        }).pipe(Effect.map(normalizeCallToolResult)),
+      connectedClient =>
+        Effect.tryPromise({
+          try: () => connectedClient.close(),
+          catch: error => error,
+        }).pipe(Effect.ignore),
+    );
+  });
+  return yield* invocation.pipe(
+    Effect.catch(error =>
+      Effect.succeed({
+        content: [
+          {
+            type: 'text',
+            text: `OpenViking native MCP tool "${toolName}" failed at ${config.openVikingMcpUrl}: ${errorMessage(error)}`,
+          },
+        ],
+        isError: true,
+      } satisfies CallToolResult),
+    ),
+    Effect.map(result => result as CallToolResult),
+  );
+});
 
 function stripUndefinedValues(values: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(
@@ -3292,11 +3383,11 @@ function writeMemoryContentWithExpectedHash(
       config.agentContextHome,
       [uri],
       Effect.gen(function* () {
-        const [current] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [uri]));
+        const [current] = yield* readMemoryRecordsByUri(config, [uri]);
         if (!current || current.content !== expectedContent) {
           return argumentError(`Memory ${uri} changed after compact_context planned its update. Re-run the plan.`);
         }
-        yield* attemptPromise(() => writeMemoryFile(config, ov, uri, content, 'replace', false, {quiet: true}));
+        yield* writeMemoryFile(config, ov, uri, content, 'replace', false, {quiet: true});
         return {content: [{type: 'text' as const, text: `Updated memory: ${uri}`}]};
       }),
     );
@@ -3317,14 +3408,14 @@ function forgetVikingResourceWithRetry(
       [uri],
       Effect.gen(function* () {
         if (expectedContent) {
-          const [current] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [uri]));
+          const [current] = yield* readMemoryRecordsByUri(config, [uri]);
           if (!current || current.content !== expectedContent) {
             return yield* Effect.fail(
               new Error(`Memory ${uri} changed after this removal was planned. Re-run the operation.`),
             );
           }
         }
-        const ov = yield* attemptPromise(requiredOpenVikingCli);
+        const ov = yield* requiredOpenVikingCli();
         return yield* removeVikingResourceWithRetry(ov, config, uri, recursive);
       }),
     );
@@ -3473,8 +3564,8 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
     if (isInSharedNamespace(config, sourceUri)) {
       return argumentError(`Memory ${sourceUri} is already in the shared namespace.`);
     }
-    const ov = yield* attemptPromise(requiredOpenVikingCli);
-    const readResult = yield* attemptPromise(() => runOpenVikingReadTool(config, [sourceUri]));
+    const ov = yield* requiredOpenVikingCli();
+    const readResult = yield* runOpenVikingReadTool(config, [sourceUri]);
     const sourceText = textFromCallToolResult(readResult);
     if (readResult.isError === true || !sourceText) {
       return {
@@ -3491,7 +3582,7 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
     const scrub = applyScrubber(stripped, {redact: options.redact === true});
 
     if (options.preview === true) {
-      const resolved = yield* attemptPromise(() => resolveTeam(config, options.team));
+      const resolved = yield* resolveTeam(config, options.team);
       const targetUri = sharedUriFor(config, sourceUri, resolved.name);
       const previewLines = [`PREVIEW source: ${sourceUri}`, `PREVIEW destination: ${targetUri}`];
       if (scrub.blocker) {
@@ -3517,7 +3608,7 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
     const {publication, targetUri} = yield* withSharedRepositoryLock(
       config,
       Effect.gen(function* () {
-        const resolved = yield* attemptPromise(() => resolveTeam(config, options.team));
+        const resolved = yield* resolveTeam(config, options.team);
         const targetUri = sharedUriFor(config, sourceUri, resolved.name);
         const relativePath = vikingUriToWorktreeRelative(config, targetUri, resolved.name);
         const commitMessage = options.message ?? `share: publish ${relativePath}`;
@@ -3527,7 +3618,7 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
           config.agentContextHome,
           [sourceUri, targetUri],
           Effect.gen(function* () {
-            const [currentSource] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [sourceUri]));
+            const [currentSource] = yield* readMemoryRecordsByUri(config, [sourceUri]);
             if (!currentSource) {
               return {kind: 'source_missing' as const};
             }
@@ -3542,14 +3633,12 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
             }
             // Refuse to silently overwrite an existing shared memory (e.g., a
             // teammate already published the same project/topic).
-            if (yield* attemptPromise(() => sharedVikingResourceExists(ov, config, targetUri))) {
+            if (yield* sharedVikingResourceExists(ov, config, targetUri)) {
               return {kind: 'target_conflict' as const};
             }
-            yield* attemptPromise(() => ensureSharedDirectoryChain(config, ov, targetUri, false, {quiet: true}));
-            yield* attemptPromise(() =>
-              writeMemoryFile(config, ov, targetUri, currentScrub.cleaned, 'create', false, {quiet: true}),
-            );
-            const [storedTarget] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [targetUri]));
+            yield* ensureSharedDirectoryChain(config, ov, targetUri, false, {quiet: true});
+            yield* writeMemoryFile(config, ov, targetUri, currentScrub.cleaned, 'create', false, {quiet: true});
+            const [storedTarget] = yield* readMemoryRecordsByUri(config, [targetUri]);
             if (
               !storedTarget ||
               canonicalMemoryDocumentContent(storedTarget.content) !==
@@ -3557,10 +3646,10 @@ function runSharePublishTool(config: RuntimeConfig, sourceUri: string, options: 
             ) {
               return {kind: 'target_verification_failed' as const};
             }
-            const gitMessages = yield* attemptPromise(() =>
-              publishShareGitChange(resolved.config.worktree, relativePath, commitMessage, {push: options.push}),
-            );
-            const [sourceBeforeRemoval] = yield* attemptPromise(() => readMemoryRecordsByUri(config, [sourceUri]));
+            const gitMessages = yield* publishShareGitChange(resolved.config.worktree, relativePath, commitMessage, {
+              push: options.push,
+            });
+            const [sourceBeforeRemoval] = yield* readMemoryRecordsByUri(config, [sourceUri]);
             if (!sourceBeforeRemoval || sourceBeforeRemoval.content !== currentSource.content) {
               return {
                 gitMessages,
@@ -3677,21 +3766,22 @@ function runShareBundleTool(config: RuntimeConfig, manifestPath: string, options
   );
 }
 
-async function runThreadnoteGuideTool(config: RuntimeConfig, toolset: McpToolset): Promise<CallToolResult> {
-  const serverUp = await probeServerUp(config);
-  const context = await gatherOnboardingContext(config);
+const runThreadnoteGuideTool = Effect.fn('mcp_server.runThreadnoteGuideTool')(function* (
+  config: RuntimeConfig,
+  toolset: McpToolset,
+) {
+  const serverUp = yield* probeServerUp(config);
+  const context = yield* gatherOnboardingContext(config);
   const text = buildOnboardingGuide({...context, serverUp, toolset});
   return {content: [{type: 'text', text}], isError: false};
-}
+});
 
-async function probeServerUp(config: RuntimeConfig): Promise<boolean | undefined> {
-  try {
-    const result = await runOpenVikingMcpTool(config, 'health', {});
-    return result.isError !== true;
-  } catch (_err: unknown) {
-    return false;
-  }
-}
+const probeServerUp = Effect.fn('mcp_server.probeServerUp')(function* (config: RuntimeConfig) {
+  return yield* runOpenVikingMcpTool(config, 'health', {}).pipe(
+    Effect.map(result => result.isError !== true),
+    Effect.catch(() => Effect.succeed(false)),
+  );
+});
 
 function runListSharedSkillsTool(config: RuntimeConfig, options: SharedSkillFilterOptions) {
   return listSharedAgentArtifacts(config, options).pipe(
@@ -3752,12 +3842,12 @@ function shareArtifactToolHeader(team: string, syncedTeams: readonly string[], w
   return lines;
 }
 
-async function requiredOpenVikingCli(): Promise<string> {
-  const command = await findOpenVikingCli();
+const requiredOpenVikingCli = Effect.fn('mcp_server.requiredOpenVikingCli')(function* () {
+  const command = yield* findOpenVikingCli();
   if (!command) {
     throw new Error('Neither ov nor openviking was found. Run threadnote install first.');
   }
   return command;
-}
+});
 
 NodeRuntime.runMain(Effect.scoped(mainEffect).pipe(Effect.provide(ApplicationLayer)), {disableErrorReporting: false});

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,10 +1,6 @@
-import {chmod, readFile, readdir, rm, stat, writeFile} from 'node:fs/promises';
-import {basename, dirname, join, sep} from 'node:path';
 import yaml from 'js-yaml';
-import {Console, Effect, FileSystem, pipe} from 'effect';
+import {Console, Crypto, Effect, FileSystem, Path, Result, pipe} from 'effect';
 import {maybeRunEffect} from './effect/command.js';
-import {consoleOutput, syncWithConsole} from './effect/console.js';
-import {fromPromiseError as attempt} from './effect/errors.js';
 import {withMemoryUriLocks} from './effect/memory_lock.js';
 import {removeOpenVikingResourceEffect} from './effect/openviking.js';
 import {syncSharedReposBeforeAgentRead} from './effect/share.js';
@@ -58,7 +54,6 @@ import {
   enrichRecallQueryWithWorkspaceProjectContext,
   ensureDirectory,
   expandPath,
-  type ExactMatch,
   exactMemoryScopeUris,
   exactRecallScopeIntents,
   exactRecallTerms,
@@ -68,14 +63,13 @@ import {
   getInvocationCwd,
   gitValue,
   isJsonObject,
-  maybeRun,
   openVikingCliForMode,
   parentVikingUri,
   parsePositiveInteger,
   parseRecallHits,
   readFileIfExists,
   type RecallHit,
-  RECALL_SCORE_THRESHOLD,
+  recallScoreThreshold,
   resolveGitRemoteRepoName,
   resolveRepoFolderName,
   resolveRepoName,
@@ -178,7 +172,7 @@ const requireValue = <A>(value: A | undefined, message: string): Effect.Effect<A
   value === undefined ? Effect.fail(new Error(message)) : Effect.succeed(value);
 
 export const runRemember = Effect.fn('runRemember')(function* (config: RuntimeConfig, options: RememberOptions) {
-  const text = yield* attempt(() => getInputText(options.text, options.stdin === true));
+  const text = yield* getInputText(options.text, options.stdin === true);
   if (!text.trim()) {
     yield* Effect.fail(new Error('Provide memory text with --text or --stdin.'));
   }
@@ -204,26 +198,27 @@ export const runMigrateMemories = Effect.fn('runMigrateMemories')(function* (
   options: MigrateMemoriesOptions,
 ) {
   const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const dryRun = options.dryRun === true;
   const limit = options.limit
     ? yield* attemptSync(() => parsePositiveInteger(options.limit!, 'migration limit'))
     : undefined;
-  const sourceAccounts = yield* attempt(() => legacySourceAccounts(config, options));
+  const sourceAccounts = yield* legacySourceAccounts(config, options);
   if (sourceAccounts.length === 0) {
-    yield* syncWithConsole(() => consoleOutput.log('No local OpenViking accounts found to scan.'));
+    yield* Console.log('No local OpenViking accounts found to scan.');
     return;
   }
 
-  const candidates = yield* attempt(() => legacyMemoryCandidates(config, sourceAccounts));
-  const existingHashes = yield* attempt(() => existingDurableMemoryHashes(config));
-  const ov = yield* attempt(() => openVikingCliForMode(dryRun));
-  const migrationPath = join(config.agentContextHome, 'legacy-memory-migration.txt');
+  const candidates = yield* legacyMemoryCandidates(config, sourceAccounts);
+  const existingHashes = yield* existingDurableMemoryHashes(config);
+  const ov = yield* openVikingCliForMode(dryRun);
+  const migrationPath = path.join(config.agentContextHome, 'legacy-memory-migration.txt');
 
   let duplicateCount = 0;
   let migratedCount = 0;
   let sensitiveCount = 0;
   if (!dryRun && candidates.length > 0) {
-    yield* attempt(() => ensureDurableMemoryDirectory(ov, config));
+    yield* ensureDurableMemoryDirectory(ov, config);
   }
 
   const migrate = Effect.gen(function* () {
@@ -239,10 +234,8 @@ export const runMigrateMemories = Effect.fn('runMigrateMemories')(function* (
       const sensitiveReason = sensitiveMemoryReason(candidate.text);
       if (sensitiveReason) {
         sensitiveCount += 1;
-        yield* syncWithConsole(() =>
-          consoleOutput.log(
-            `SKIP ${legacySourceLabel(candidate)}: possible ${sensitiveReason}; inspect the source archive manually if needed.`,
-          ),
+        yield* Console.log(
+          `SKIP ${legacySourceLabel(candidate)}: possible ${sensitiveReason}; inspect the source archive manually if needed.`,
         );
         continue;
       }
@@ -251,19 +244,17 @@ export const runMigrateMemories = Effect.fn('runMigrateMemories')(function* (
       }
 
       const memoryUri = migratedDurableMemoryUri(config, candidate.hash);
-      if (!dryRun && (yield* attempt(() => vikingResourceExists(ov, config, memoryUri)))) {
+      if (!dryRun && (yield* vikingResourceExists(ov, config, memoryUri))) {
         duplicateCount += 1;
         existingHashes.add(candidate.hash);
         continue;
       }
 
-      yield* syncWithConsole(() =>
-        consoleOutput.log(`${dryRun ? 'Would migrate' : 'Migrating'} ${legacySourceLabel(candidate)} -> ${memoryUri}`),
-      );
+      yield* Console.log(`${dryRun ? 'Would migrate' : 'Migrating'} ${legacySourceLabel(candidate)} -> ${memoryUri}`);
       if (!dryRun) {
         yield* fs.writeFileString(migrationPath, candidate.text, {mode: 0o600});
         yield* fs.chmod(migrationPath, 0o600);
-        yield* attempt(() => writeDurableMemoryFile(ov, config, memoryUri, migrationPath, 'create'));
+        yield* writeDurableMemoryFile(ov, config, memoryUri, migrationPath, 'create');
         existingHashes.add(candidate.hash);
       }
       migratedCount += 1;
@@ -271,16 +262,14 @@ export const runMigrateMemories = Effect.fn('runMigrateMemories')(function* (
   }).pipe(Effect.ensuring(dryRun ? Effect.void : Effect.ignore(fs.remove(migrationPath, {force: true}))));
 
   yield* migrate;
-  yield* syncWithConsole(() =>
-    consoleOutput.log(
-      [
-        `Migration summary: ${migratedCount} ${dryRun ? 'would be migrated' : 'migrated'}`,
-        `${duplicateCount} duplicate(s) skipped`,
-        `${sensitiveCount} sensitive-looking item(s) skipped`,
-        `${candidates.length} legacy Threadnote item(s) scanned`,
-        `source account(s): ${sourceAccounts.join(', ')}`,
-      ].join('; '),
-    ),
+  yield* Console.log(
+    [
+      `Migration summary: ${migratedCount} ${dryRun ? 'would be migrated' : 'migrated'}`,
+      `${duplicateCount} duplicate(s) skipped`,
+      `${sensitiveCount} sensitive-looking item(s) skipped`,
+      `${candidates.length} legacy Threadnote item(s) scanned`,
+      `source account(s): ${sourceAccounts.join(', ')}`,
+    ].join('; '),
   );
 });
 
@@ -289,10 +278,12 @@ export const runMigrateLifecycle = Effect.fn('runMigrateLifecycle')(function* (
   options: MigrateLifecycleOptions,
 ) {
   const dryRun = options.dryRun === true || options.apply !== true;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const limit = options.limit ? parsePositiveInteger(options.limit, 'lifecycle migration limit') : undefined;
-  const ov = yield* attempt(() => openVikingCliForMode(dryRun));
-  const candidates = yield* attempt(() => legacyLifecycleHandoffCandidates(config));
-  const migrationPath = join(config.agentContextHome, 'lifecycle-memory-migration.txt');
+  const ov = yield* openVikingCliForMode(dryRun);
+  const candidates = yield* legacyLifecycleHandoffCandidates(config);
+  const migrationPath = path.join(config.agentContextHome, 'lifecycle-memory-migration.txt');
   let existingCount = 0;
   let migratedCount = 0;
   let skippedCount = 0;
@@ -302,7 +293,11 @@ export const runMigrateLifecycle = Effect.fn('runMigrateLifecycle')(function* (
       if (limit !== undefined && migratedCount >= limit) {
         break;
       }
-      const destinationUri = lifecycleMigrationUri(config, candidate.metadata, sha256(candidate.original.trim()));
+      const destinationUri = lifecycleMigrationUri(
+        config,
+        candidate.metadata,
+        yield* sha256(candidate.original.trim()),
+      );
       const migratedMemory = formatMemoryDocument(
         'HANDOFF',
         candidate.metadata,
@@ -311,14 +306,14 @@ export const runMigrateLifecycle = Effect.fn('runMigrateLifecycle')(function* (
 
       yield* Console.log(`${dryRun ? 'Would migrate' : 'Migrating'} ${candidate.sourceUri} -> ${destinationUri}`);
       if (!dryRun) {
-        if (yield* attempt(() => vikingResourceExists(ov, config, destinationUri))) {
+        if (yield* vikingResourceExists(ov, config, destinationUri)) {
           existingCount += 1;
           yield* Console.log(`Archived copy already exists; cleaning up legacy source: ${candidate.sourceUri}`);
         } else {
-          yield* attempt(() => writeFile(migrationPath, migratedMemory, {encoding: 'utf8', mode: 0o600}));
-          yield* attempt(() => chmod(migrationPath, 0o600));
-          yield* attempt(() => ensureMemoryDirectory(ov, config, memoryDirectoryUri(config, candidate.metadata)));
-          yield* attempt(() => writeDurableMemoryFile(ov, config, destinationUri, migrationPath, 'create'));
+          yield* fs.writeFileString(migrationPath, migratedMemory, {mode: 0o600});
+          yield* fs.chmod(migrationPath, 0o600);
+          yield* ensureMemoryDirectory(ov, config, memoryDirectoryUri(config, candidate.metadata));
+          yield* writeDurableMemoryFile(ov, config, destinationUri, migrationPath, 'create');
         }
         const removedOriginal = yield* removeVikingResourceWithRetry(ov, config, candidate.sourceUri, {
           expectedContent: candidate.original,
@@ -332,11 +327,7 @@ export const runMigrateLifecycle = Effect.fn('runMigrateLifecycle')(function* (
       }
       migratedCount += 1;
     }
-  }).pipe(
-    Effect.ensuring(
-      dryRun ? Effect.void : attempt(() => rm(migrationPath, {force: true})).pipe(Effect.catch(() => Effect.void)),
-    ),
-  );
+  }).pipe(Effect.ensuring(dryRun ? Effect.void : fs.remove(migrationPath, {force: true}).pipe(Effect.ignore)));
 
   yield* Console.log(
     [
@@ -357,7 +348,7 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
 ) {
   const dryRun = options.dryRun === true || options.apply !== true;
   const limit = options.limit ? parsePositiveInteger(options.limit, 'project-name migration limit') : undefined;
-  const contexts = yield* attempt(() => projectNameMigrationContexts(config));
+  const contexts = yield* projectNameMigrationContexts(config);
   if (contexts.length === 0) {
     yield* Console.log('No git remote project-name changes apply across configured projects.');
     return;
@@ -369,28 +360,25 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
   }> = [];
   let remaining = limit;
   for (const context of contexts) {
-    const candidates =
-      remaining === 0 ? [] : yield* attempt(() => projectNameMigrationCandidates(config, context, remaining));
+    const candidates = remaining === 0 ? [] : yield* projectNameMigrationCandidates(config, context, remaining);
     plans.push({candidates, context});
     if (remaining !== undefined) {
       remaining = Math.max(0, remaining - candidates.length);
     }
   }
-  const seedManifestMigration = yield* attempt(() => seedManifestProjectNameMigration(config, contexts));
+  const seedManifestMigration = yield* seedManifestProjectNameMigration(config, contexts);
   if (!plans.some(plan => plan.candidates.length > 0) && !seedManifestMigration) {
     yield* Console.log('No project-name migration candidates found across configured projects.');
     return;
   }
 
-  const seedManifestUpdated = yield* attempt(() =>
-    migrateSeedManifestProjectNames(config, seedManifestMigration, dryRun),
-  );
+  const seedManifestUpdated = yield* migrateSeedManifestProjectNames(config, seedManifestMigration, dryRun);
   let existingCount = 0;
   let migratedCount = 0;
   let skippedCount = 0;
   const candidates = plans.flatMap(plan => [...plan.candidates]);
   if (candidates.length > 0) {
-    const ov = yield* attempt(() => openVikingCliForMode(dryRun));
+    const ov = yield* openVikingCliForMode(dryRun);
     for (const candidate of candidates) {
       const action = candidate.destinationExistsWithSameContent
         ? dryRun
@@ -404,10 +392,8 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
         if (candidate.destinationExistsWithSameContent) {
           existingCount += 1;
         } else {
-          yield* attempt(() => ensureMemoryDirectory(ov, config, parentVikingUri(candidate.destinationUri)));
-          yield* attempt(() =>
-            writeMemoryFile(config, ov, candidate.destinationUri, candidate.destinationContent, 'create', false),
-          );
+          yield* ensureMemoryDirectory(ov, config, parentVikingUri(candidate.destinationUri));
+          yield* writeMemoryFile(config, ov, candidate.destinationUri, candidate.destinationContent, 'create', false);
         }
         const removedOriginal = yield* removeVikingResourceWithRetry(ov, config, candidate.sourceUri, {
           expectedContent: candidate.sourceContent,
@@ -441,90 +427,96 @@ export const runMigrateProjectNames = Effect.fn('runMigrateProjectNames')(functi
   );
 });
 
-export async function hasProjectNameMigrationCandidates(config: RuntimeConfig): Promise<boolean> {
-  const contexts = await projectNameMigrationContexts(config);
+export const hasProjectNameMigrationCandidates = Effect.fn('memory.hasProjectNameMigrationCandidates')(function* (
+  config: RuntimeConfig,
+) {
+  const contexts = yield* projectNameMigrationContexts(config);
   if (contexts.length === 0) {
     return false;
   }
   for (const context of contexts) {
-    if ((await projectNameMigrationCandidates(config, context, 1)).length > 0) {
+    if ((yield* projectNameMigrationCandidates(config, context, 1)).length > 0) {
       return true;
     }
   }
-  return (await seedManifestProjectNameMigration(config, contexts)) !== undefined;
-}
+  return (yield* seedManifestProjectNameMigration(config, contexts)) !== undefined;
+});
 
-async function projectNameMigrationContexts(config: RuntimeConfig): Promise<readonly ProjectNameMigrationContext[]> {
-  const evidence = await projectNameMigrationMemoryEvidence(config);
+const projectNameMigrationContexts = Effect.fn('memory.projectNameMigrationContexts')(function* (
+  config: RuntimeConfig,
+) {
+  const evidence = yield* projectNameMigrationMemoryEvidence(config);
   const contexts: ProjectNameMigrationContext[] = [];
-  let manifest;
-  try {
-    manifest = await readSeedManifest(config.manifestPath);
-  } catch (_err: unknown) {
-    manifest = undefined;
-  }
-  if (manifest) {
-    for (const project of manifest.projects) {
+  const manifest = yield* readSeedManifest(config.manifestPath).pipe(Effect.option);
+  if (manifest._tag === 'Some') {
+    for (const project of manifest.value.projects) {
       const projectEvidence = evidence.get(uriSegment(project.name));
       if (projectEvidence) {
-        projectEvidence.repoPaths.add(expandPath(project.path));
+        projectEvidence.repoPaths.add(yield* expandPath(project.path));
       }
     }
   }
   for (const projectEvidence of evidence.values()) {
     for (const repoPath of projectEvidence.repoPaths) {
-      const context = await projectNameMigrationContextForRepoPath(projectEvidence.oldProject, repoPath);
+      const context = yield* projectNameMigrationContextForRepoPath(projectEvidence.oldProject, repoPath);
       if (context) {
         contexts.push(context);
       }
     }
   }
-  const currentContext = await currentWorkspaceProjectNameMigrationContext(evidence);
+  const currentContext = yield* currentWorkspaceProjectNameMigrationContext(evidence);
   if (currentContext) {
     contexts.push(currentContext);
   }
   return dedupeProjectNameMigrationContexts(contexts);
-}
+});
 
-async function projectNameMigrationMemoryEvidence(
+const projectNameMigrationMemoryEvidence = Effect.fn('memory.projectNameMigrationMemoryEvidence')(function* (
   config: RuntimeConfig,
-): Promise<Map<string, ProjectNameMigrationProjectEvidence>> {
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const evidence = new Map<string, ProjectNameMigrationProjectEvidence>();
   for (const location of projectMemoryLocations()) {
-    const locationRoot = join(localUserMemoriesRoot(config), ...location.relativePath);
-    let projectEntries;
-    try {
-      projectEntries = await readdir(locationRoot, {withFileTypes: true});
-    } catch (_err: unknown) {
+    const locationRoot = path.join(yield* localUserMemoriesRoot(config), ...location.relativePath);
+    const projectEntries = yield* fs.readDirectory(locationRoot).pipe(Effect.option);
+    if (projectEntries._tag === 'None') {
       continue;
     }
-    for (const projectEntry of projectEntries) {
-      if (!projectEntry.isDirectory() || projectEntry.name.startsWith('.')) {
+    for (const projectEntry of projectEntries.value) {
+      if (projectEntry.startsWith('.')) {
         continue;
       }
-      const oldSegment = projectEntry.name;
+      const projectDirectory = path.join(locationRoot, projectEntry);
+      const projectInfo = yield* fs.stat(projectDirectory).pipe(Effect.option);
+      if (projectInfo._tag === 'None' || projectInfo.value.type !== 'Directory') {
+        continue;
+      }
+      const oldSegment = projectEntry;
       const projectEvidence = ensureProjectNameMigrationEvidence(evidence, oldSegment);
-      const projectDirectory = join(locationRoot, projectEntry.name);
-      let memoryEntries;
-      try {
-        memoryEntries = await readdir(projectDirectory, {withFileTypes: true});
-      } catch (_err: unknown) {
+      const memoryEntries = yield* fs.readDirectory(projectDirectory).pipe(Effect.option);
+      if (memoryEntries._tag === 'None') {
         continue;
       }
-      for (const memoryEntry of memoryEntries) {
-        if (!memoryEntry.isFile() || memoryEntry.name.startsWith('.') || !memoryEntry.name.endsWith('.md')) {
+      for (const memoryEntry of memoryEntries.value) {
+        if (memoryEntry.startsWith('.') || !memoryEntry.endsWith('.md')) {
           continue;
         }
-        const content = await readTextIfExists(join(projectDirectory, memoryEntry.name));
+        const memoryPath = path.join(projectDirectory, memoryEntry);
+        const memoryInfo = yield* fs.stat(memoryPath).pipe(Effect.option);
+        if (memoryInfo._tag === 'None' || memoryInfo.value.type !== 'File') {
+          continue;
+        }
+        const content = yield* readTextIfExists(memoryPath);
         if (!content) {
           continue;
         }
-        const sourceUri = `viking://user/${uriSegment(config.user)}/memories/${location.uriPath}/${oldSegment}/${memoryEntry.name}`;
+        const sourceUri = `viking://user/${uriSegment(config.user)}/memories/${location.uriPath}/${oldSegment}/${memoryEntry}`;
         const record = parseMemoryDocument(sourceUri, content);
         if (record?.metadata.project && uriSegment(record.metadata.project) === oldSegment) {
           projectEvidence.oldProject = record.metadata.project;
         }
-        const repoPath = repoPathEvidenceFromMemory(content);
+        const repoPath = yield* repoPathEvidenceFromMemory(content);
         if (repoPath) {
           projectEvidence.repoPaths.add(repoPath);
         }
@@ -532,7 +524,7 @@ async function projectNameMigrationMemoryEvidence(
     }
   }
   return evidence;
-}
+});
 
 function ensureProjectNameMigrationEvidence(
   evidence: Map<string, ProjectNameMigrationProjectEvidence>,
@@ -547,7 +539,7 @@ function ensureProjectNameMigrationEvidence(
   return created;
 }
 
-function repoPathEvidenceFromMemory(content: string): string | undefined {
+const repoPathEvidenceFromMemory = Effect.fn('memory.repoPathEvidenceFromMemory')(function* (content: string) {
   const match = /^repo_path:\s*(.+)$/m.exec(content);
   if (!match?.[1]) {
     return undefined;
@@ -559,18 +551,18 @@ function repoPathEvidenceFromMemory(content: string): string | undefined {
   if (!cleaned.startsWith('/') && !cleaned.startsWith('~/')) {
     return undefined;
   }
-  return expandPath(cleaned);
-}
+  return yield* expandPath(cleaned);
+});
 
-async function projectNameMigrationContextForRepoPath(
+const projectNameMigrationContextForRepoPath = Effect.fn('memory.projectNameMigrationContextForRepoPath')(function* (
   oldProject: string,
   repoPath: string,
-): Promise<ProjectNameMigrationContext | undefined> {
-  const repoRoot = await gitValue(['rev-parse', '--show-toplevel'], repoPath);
+) {
+  const repoRoot = yield* gitValue(['rev-parse', '--show-toplevel'], repoPath);
   if (!repoRoot) {
     return undefined;
   }
-  const newProject = await resolveGitRemoteRepoName(repoRoot);
+  const newProject = yield* resolveGitRemoteRepoName(repoRoot);
   if (!newProject) {
     return undefined;
   }
@@ -579,26 +571,26 @@ async function projectNameMigrationContextForRepoPath(
     oldProject,
     repoRoot,
   });
-}
+});
 
-async function currentWorkspaceProjectNameMigrationContext(
-  evidence: Map<string, ProjectNameMigrationProjectEvidence>,
-): Promise<ProjectNameMigrationContext | undefined> {
-  const repoRoot = await gitValue(['rev-parse', '--show-toplevel']);
-  if (!repoRoot) {
-    return undefined;
-  }
-  const newProject = await resolveGitRemoteRepoName(repoRoot);
-  const oldProject = await resolveRepoFolderName(repoRoot);
-  if (!newProject || !oldProject) {
-    return undefined;
-  }
-  const oldSegment = uriSegment(oldProject);
-  if (!evidence.has(oldSegment)) {
-    return undefined;
-  }
-  return projectNameMigrationContextFromParts({newProject, oldProject, repoRoot});
-}
+const currentWorkspaceProjectNameMigrationContext = Effect.fn('memory.currentWorkspaceProjectNameMigrationContext')(
+  function* (evidence: Map<string, ProjectNameMigrationProjectEvidence>) {
+    const repoRoot = yield* gitValue(['rev-parse', '--show-toplevel']);
+    if (!repoRoot) {
+      return undefined;
+    }
+    const newProject = yield* resolveGitRemoteRepoName(repoRoot);
+    const oldProject = yield* resolveRepoFolderName(repoRoot);
+    if (!newProject || !oldProject) {
+      return undefined;
+    }
+    const oldSegment = uriSegment(oldProject);
+    if (!evidence.has(oldSegment)) {
+      return undefined;
+    }
+    return projectNameMigrationContextFromParts({newProject, oldProject, repoRoot});
+  },
+);
 
 function projectNameMigrationContextFromParts(params: {
   readonly newProject: string;
@@ -635,27 +627,36 @@ function dedupeProjectNameMigrationContexts(
   return out;
 }
 
-async function projectNameMigrationCandidates(
+const projectNameMigrationCandidates = Effect.fn('memory.projectNameMigrationCandidates')(function* (
   config: RuntimeConfig,
   context: ProjectNameMigrationContext,
   limit?: number,
-): Promise<readonly ProjectNameMigrationCandidate[]> {
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const candidates: ProjectNameMigrationCandidate[] = [];
   for (const location of projectMemoryLocations()) {
-    const sourceDirectory = join(localUserMemoriesRoot(config), ...location.relativePath, context.oldSegment);
+    const sourceDirectory = path.join(
+      yield* localUserMemoriesRoot(config),
+      ...location.relativePath,
+      context.oldSegment,
+    );
     const sourceDirectoryUri = `viking://user/${uriSegment(config.user)}/memories/${location.uriPath}/${context.oldSegment}`;
-    let entries;
-    try {
-      entries = await readdir(sourceDirectory, {withFileTypes: true});
-    } catch (_err: unknown) {
+    const entries = yield* fs.readDirectory(sourceDirectory).pipe(Effect.option);
+    if (entries._tag === 'None') {
       continue;
     }
-    for (const entry of entries) {
-      if (!entry.isFile() || entry.name.startsWith('.') || !entry.name.endsWith('.md')) {
+    for (const entry of entries.value) {
+      if (entry.startsWith('.') || !entry.endsWith('.md')) {
         continue;
       }
-      const sourceUri = `${sourceDirectoryUri}/${entry.name}`;
-      const content = await readTextIfExists(join(sourceDirectory, entry.name));
+      const sourcePath = path.join(sourceDirectory, entry);
+      const sourceInfo = yield* fs.stat(sourcePath).pipe(Effect.option);
+      if (sourceInfo._tag === 'None' || sourceInfo.value.type !== 'File') {
+        continue;
+      }
+      const sourceUri = `${sourceDirectoryUri}/${entry}`;
+      const content = yield* readTextIfExists(sourcePath);
       if (!content) {
         continue;
       }
@@ -665,14 +666,14 @@ async function projectNameMigrationCandidates(
       }
       const metadata = {...record.metadata, project: context.newProject};
       const destinationDirectoryUri = memoryDirectoryUri(config, metadata);
-      const destinationDirectory = localMemoryPathForUri(config, destinationDirectoryUri);
+      const destinationDirectory = yield* localMemoryPathForUri(config, destinationDirectoryUri);
       if (!destinationDirectory) {
         continue;
       }
       const destinationContent = formatMemoryDocument(record.headerTitle, metadata, record.body);
-      const destination = await projectNameMigrationDestination(
+      const destination = yield* projectNameMigrationDestination(
         destinationDirectory,
-        entry.name,
+        entry,
         destinationContent,
         context.oldSegment,
       );
@@ -689,7 +690,7 @@ async function projectNameMigrationCandidates(
     }
   }
   return candidates;
-}
+});
 
 function projectNameMigrationActiveContexts(
   plans: readonly {
@@ -725,7 +726,7 @@ function projectNameMigrationSummary(
   return `Project-name migration summary: ${migratedCount} ${memoryWord} ${verb} across ${contexts.length} project rename(s)${renameSummary ? `: ${renameSummary}` : ''}`;
 }
 
-async function migrateSeedManifestProjectNames(
+const migrateSeedManifestProjectNames = Effect.fn('memory.migrateSeedManifestProjectNames')(function* (
   config: RuntimeConfig,
   migration:
     | {
@@ -735,49 +736,42 @@ async function migrateSeedManifestProjectNames(
       }
     | undefined,
   dryRun: boolean,
-): Promise<boolean> {
+) {
   if (!migration) {
     return false;
   }
   if (dryRun) {
-    consoleOutput.log(`Would update seed manifest: ${config.manifestPath}`);
-    consoleOutput.log(migration.output.trimEnd());
+    yield* Console.log(`Would update seed manifest: ${config.manifestPath}`);
+    yield* Console.log(migration.output.trimEnd());
     return true;
   }
-  await ensureDirectory(dirname(config.manifestPath), false);
-  const currentContent = await readFileIfExists(config.manifestPath);
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  yield* ensureDirectory(path.dirname(config.manifestPath), false);
+  const currentContent = yield* readFileIfExists(config.manifestPath);
   if (currentContent !== undefined) {
     const backupPath = `${config.manifestPath}.project-name-${safeTimestamp()}`;
-    await writeFile(backupPath, currentContent, {encoding: 'utf8', mode: 0o600});
-    await chmod(backupPath, 0o600);
-    consoleOutput.log(`Backup: ${backupPath}`);
+    yield* fs.writeFileString(backupPath, currentContent, {mode: 0o600});
+    yield* fs.chmod(backupPath, 0o600);
+    yield* Console.log(`Backup: ${backupPath}`);
   }
-  await writeFile(config.manifestPath, migration.output, {encoding: 'utf8', mode: 0o600});
-  await chmod(config.manifestPath, 0o600);
-  consoleOutput.log(`Updated seed manifest: ${config.manifestPath}`);
+  yield* fs.writeFileString(config.manifestPath, migration.output, {mode: 0o600});
+  yield* fs.chmod(config.manifestPath, 0o600);
+  yield* Console.log(`Updated seed manifest: ${config.manifestPath}`);
   return true;
-}
+});
 
-async function seedManifestProjectNameMigration(
+const seedManifestProjectNameMigration = Effect.fn('memory.seedManifestProjectNameMigration')(function* (
   config: RuntimeConfig,
   contexts: readonly ProjectNameMigrationContext[],
-): Promise<
-  | {
-      readonly contexts: readonly ProjectNameMigrationContext[];
-      readonly newProjects: readonly string[];
-      readonly output: string;
-    }
-  | undefined
-> {
-  let manifest;
-  try {
-    manifest = await readSeedManifest(config.manifestPath);
-  } catch (_err: unknown) {
+) {
+  const manifest = yield* readSeedManifest(config.manifestPath).pipe(Effect.option);
+  if (manifest._tag === 'None') {
     return undefined;
   }
   const renamed = new Map<string, ProjectNameMigrationContext>();
   let changed = false;
-  const projects = manifest.projects.map(project => {
+  const projects = manifest.value.projects.map(project => {
     const context = contexts.find(candidate =>
       isSeedManifestProjectNameCandidate(
         project,
@@ -789,7 +783,7 @@ async function seedManifestProjectNameMigration(
     if (!context) {
       return project;
     }
-    const newNameExists = manifest.projects.some(
+    const newNameExists = manifest.value.projects.some(
       other => other !== project && uriSegment(other.name) === context.newSegment,
     );
     if (newNameExists || [...renamed.values()].some(existing => existing.newSegment === context.newSegment)) {
@@ -808,7 +802,7 @@ async function seedManifestProjectNameMigration(
   });
   const worksets =
     renamed.size > 0
-      ? manifest.worksets?.map(workset => {
+      ? manifest.value.worksets?.map(workset => {
           const members = workset.projects.map(projectName => {
             const context = renamed.get(uriSegment(projectName));
             if (!context) {
@@ -819,7 +813,7 @@ async function seedManifestProjectNameMigration(
           });
           return {...workset, projects: members};
         })
-      : manifest.worksets;
+      : manifest.value.worksets;
   if (!changed) {
     return undefined;
   }
@@ -828,7 +822,7 @@ async function seedManifestProjectNameMigration(
     newProjects: [...new Set([...renamed.values()].map(context => context.newProject))],
     output: `${yaml.dump(
       {
-        version: manifest.version,
+        version: manifest.value.version,
         projects: projects.map(project => ({
           name: project.name,
           path: project.path,
@@ -844,11 +838,11 @@ async function seedManifestProjectNameMigration(
               })),
             }
           : {}),
-        ...(manifest.futureMonorepo
+        ...(manifest.value.futureMonorepo
           ? {
               future_monorepo: {
-                path_candidates: [...manifest.futureMonorepo.pathCandidates],
-                uri: manifest.futureMonorepo.uri,
+                path_candidates: [...manifest.value.futureMonorepo.pathCandidates],
+                uri: manifest.value.futureMonorepo.uri,
               },
             }
           : {}),
@@ -856,7 +850,7 @@ async function seedManifestProjectNameMigration(
       {lineWidth: 120, noRefs: true},
     )}`,
   };
-}
+});
 
 function isSeedManifestProjectNameCandidate(
   project: ProjectManifest,
@@ -866,7 +860,7 @@ function isSeedManifestProjectNameCandidate(
 ): boolean {
   const nameSegment = uriSegment(project.name);
   const uriMatchesOld = trimTrailingSlash(project.uri) === oldDefaultUri;
-  const pathMatchesRepo = expandPath(project.path) === context.repoRoot;
+  const pathMatchesRepo = project.path === context.repoRoot || project.path === `~/${context.repoRoot}`;
   if (nameSegment === context.newSegment && !uriMatchesOld) {
     return false;
   }
@@ -881,36 +875,37 @@ function canMigrateProjectName(record: MemoryRecord, context: ProjectNameMigrati
   return projectSegment === context.oldSegment || projectSegment === context.newSegment;
 }
 
-async function projectNameMigrationDestination(
+const projectNameMigrationDestination = Effect.fn('memory.projectNameMigrationDestination')(function* (
   destinationDirectory: string,
   filename: string,
   content: string,
   oldProjectSegment: string,
-): Promise<{readonly existsWithSameContent: boolean; readonly filename: string}> {
-  const direct = await projectNameMigrationDestinationState(destinationDirectory, filename, content);
+) {
+  const direct = yield* projectNameMigrationDestinationState(destinationDirectory, filename, content);
   if (!direct.exists || direct.sameContent) {
     return {existsWithSameContent: direct.sameContent, filename};
   }
   const stem = filename.replace(/\.md$/i, '');
   const fromOldProject = `${stem}-from-${oldProjectSegment}.md`;
-  const renamed = await projectNameMigrationDestinationState(destinationDirectory, fromOldProject, content);
+  const renamed = yield* projectNameMigrationDestinationState(destinationDirectory, fromOldProject, content);
   if (!renamed.exists || renamed.sameContent) {
     return {existsWithSameContent: renamed.sameContent, filename: fromOldProject};
   }
   return {
     existsWithSameContent: false,
-    filename: `${stem}-from-${oldProjectSegment}-${sha256(content).slice(0, 12)}.md`,
+    filename: `${stem}-from-${oldProjectSegment}-${(yield* sha256(content)).slice(0, 12)}.md`,
   };
-}
+});
 
-async function projectNameMigrationDestinationState(
+const projectNameMigrationDestinationState = Effect.fn('memory.projectNameMigrationDestinationState')(function* (
   destinationDirectory: string,
   filename: string,
   content: string,
-): Promise<{readonly exists: boolean; readonly sameContent: boolean}> {
-  const existing = await readTextIfExists(join(destinationDirectory, filename));
+) {
+  const path = yield* Path.Path;
+  const existing = yield* readTextIfExists(path.join(destinationDirectory, filename));
   return {exists: existing !== undefined, sameContent: existing?.trim() === content.trim()};
-}
+});
 
 function projectMemoryLocations(): readonly ProjectMemoryLocation[] {
   return [
@@ -930,45 +925,39 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
   if (options.dryRun !== true) {
     yield* syncSharedReposAndLog(config);
   }
-  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
+  const ov = yield* openVikingCliForMode(options.dryRun === true);
   const workspaceOptions = options.callerCwd
     ? {cwd: options.callerCwd, includeProcessCwd: false}
     : {includeProcessCwd: true};
-  const query = yield* attempt(() => enrichRecallQueryWithWorkspaceContext(options.query, workspaceOptions));
-  const projectQuery = yield* attempt(() =>
-    enrichRecallQueryWithWorkspaceProjectContext(options.query, workspaceOptions),
-  );
-  const indexRepairMessages = yield* attempt(() =>
-    repairStaleRecallIndex(config, ov, {
-      dryRun: options.dryRun === true,
-      query: projectQuery,
-    }),
-  ).pipe(
+  const query = yield* enrichRecallQueryWithWorkspaceContext(options.query, workspaceOptions);
+  const projectQuery = yield* enrichRecallQueryWithWorkspaceProjectContext(options.query, workspaceOptions);
+  const indexRepairMessages = yield* repairStaleRecallIndex(config, ov, {
+    dryRun: options.dryRun === true,
+    query: projectQuery,
+  }).pipe(
     Effect.map(indexRepair => formatRecallIndexRepairMessages(indexRepair, {dryRun: options.dryRun === true})),
-    Effect.catch(error => Effect.succeed([`Auto-index repair warning: ${error.message}`])),
+    Effect.catch(error =>
+      Effect.succeed([`Auto-index repair warning: ${error instanceof Error ? error.message : String(error)}`]),
+    ),
   );
-  yield* syncWithConsole(() => {
-    for (const message of indexRepairMessages) {
-      consoleOutput.log(message);
-    }
-  });
+  for (const message of indexRepairMessages) {
+    yield* Console.log(message);
+  }
   const dryRun = options.dryRun === true;
   const inferredUri =
-    options.uri ??
-    (options.inferScope === false ? undefined : yield* attempt(() => inferRecallUri(config, projectQuery)));
-  const project = yield* attempt(() => inferProjectFromQuery(config.manifestPath, options.project ?? projectQuery));
-  const projectMemoryName = yield* attempt(() => recallProjectMemoryName(options.project, workspaceOptions));
+    options.uri ?? (options.inferScope === false ? undefined : yield* inferRecallUri(config, projectQuery));
+  const project = yield* inferProjectFromQuery(config.manifestPath, options.project ?? projectQuery);
+  const projectMemoryName = yield* recallProjectMemoryName(options.project, workspaceOptions);
   const nodeLimit = options.nodeLimit
     ? yield* attemptSync(() => parsePositiveInteger(options.nodeLimit!, 'node limit'))
     : undefined;
-  const explicitWorkset = options.workset
-    ? yield* attempt(() => requireWorkset(config.manifestPath, options.workset!))
-    : undefined;
+  const explicitWorkset = options.workset ? yield* requireWorkset(config.manifestPath, options.workset!) : undefined;
+  const recallThreshold = options.threshold ?? (yield* recallScoreThreshold());
   const searchArgs = (scopeUri: string | undefined): readonly string[] => [
     'search',
     query,
     '--threshold',
-    options.threshold ?? RECALL_SCORE_THRESHOLD,
+    recallThreshold,
     '--level',
     '2',
     ...(scopeUri ? ['--uri', scopeUri] : []),
@@ -980,31 +969,29 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
   // repeated by the scoped passes (and multiple chunks of one document collapse
   // to a single entry).
   if (inferredUri) {
-    yield* syncWithConsole(() => consoleOutput.log(`Recall scope: ${inferredUri}`));
+    yield* Console.log(`Recall scope: ${inferredUri}`);
   }
   const includeArchived = options.includeArchived === true;
   const passes: Array<readonly RecallHit[]> = [
-    yield* attempt(() => recallSearchHits(config, ov, searchArgs(inferredUri), {dryRun, includeArchived})),
+    yield* recallSearchHits(config, ov, searchArgs(inferredUri), {dryRun, includeArchived}),
   ];
   const scopedRecallUris = new Set([inferredUri].filter((uri): uri is string => uri !== undefined));
   if (options.project && project) {
     const projectMemoryUri = `viking://user/${uriSegment(config.user)}/memories/durable/projects/${uriSegment(project.name)}`;
     if (!scopedRecallUris.has(projectMemoryUri)) {
       scopedRecallUris.add(projectMemoryUri);
-      passes.push(
-        yield* attempt(() => recallSearchHits(config, ov, searchArgs(projectMemoryUri), {dryRun, includeArchived})),
-      );
+      passes.push(yield* recallSearchHits(config, ov, searchArgs(projectMemoryUri), {dryRun, includeArchived}));
     }
   }
   for (const scope of projectMemoryScopeUris(config, projectMemoryName, includeArchived)) {
     if (!scopedRecallUris.has(scope)) {
       scopedRecallUris.add(scope);
-      passes.push(yield* attempt(() => recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived})));
+      passes.push(yield* recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived}));
     }
   }
   const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
   if (seededUri?.startsWith('viking://') && seededUri !== inferredUri && !options.uri && options.inferScope !== false) {
-    passes.push(yield* attempt(() => recallSearchHits(config, ov, searchArgs(seededUri), {dryRun, includeArchived})));
+    passes.push(yield* recallSearchHits(config, ov, searchArgs(seededUri), {dryRun, includeArchived}));
   }
 
   // Workset expansion: a named set of manifest projects recalled as one working
@@ -1014,12 +1001,10 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
     !options.uri && explicitWorkset
       ? explicitWorkset
       : !options.uri && options.inferScope !== false
-        ? yield* attempt(() => inferWorksetFromQuery(config.manifestPath, projectQuery))
+        ? yield* inferWorksetFromQuery(config.manifestPath, projectQuery)
         : undefined;
   if (workset && workset.projects.length > 0) {
-    yield* syncWithConsole(() =>
-      consoleOutput.log(`Workset scope: ${workset.name} (${workset.projects.map(member => member.name).join(', ')})`),
-    );
+    yield* Console.log(`Workset scope: ${workset.name} (${workset.projects.map(member => member.name).join(', ')})`);
     const alreadyScoped = new Set(
       [inferredUri, seededUri, ...scopedRecallUris].filter((uri): uri is string => uri !== undefined),
     );
@@ -1027,13 +1012,15 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
       .filter(uri => !alreadyScoped.has(uri))
       .slice(0, MAX_WORKSET_PASSES);
     for (const scope of worksetScopes) {
-      passes.push(yield* attempt(() => recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived})));
+      passes.push(yield* recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived}));
     }
   }
 
-  const exactMatches = yield* attempt(() =>
-    collectExactMemoryMatches(config, ov, query, {dryRun, includeArchived, project}),
-  );
+  const exactMatches = yield* collectExactMemoryMatches(config, ov, query, {
+    dryRun,
+    includeArchived,
+    project,
+  });
   const {semanticSection, exactTail} = yield* prepareRecallSections(config, {
     allowExactRescue: options.threshold === undefined,
     allowedUriScopes: options.uri ? [options.uri] : undefined,
@@ -1041,24 +1028,24 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
     feedbackQuery: options.query,
     includeInactive: includeArchived,
     limit: nodeLimit ?? 12,
-    minimumScore: Number(options.threshold ?? RECALL_SCORE_THRESHOLD),
+    minimumScore: Number(recallThreshold),
     passes,
     project: projectMemoryName ?? project?.name,
     query,
-    readRecords: uris => attempt(() => readMemoryRecordsByUri(config, uris)),
+    readRecords: uris => readMemoryRecordsByUri(config, uris),
     seedUris: [inferredUri, seededUri].filter((uri): uri is string => uri !== undefined),
   });
   if (semanticSection) {
-    yield* syncWithConsole(() => consoleOutput.log(`\n${semanticSection}`));
+    yield* Console.log(`\n${semanticSection}`);
   }
   if (exactTail) {
-    yield* syncWithConsole(() => consoleOutput.log(`\n${exactTail}`));
+    yield* Console.log(`\n${exactTail}`);
   }
-  const referencedSection = yield* attempt(() => referencedContextSection(config, semanticSection ?? ''));
+  const referencedSection = yield* referencedContextSection(config, semanticSection ?? '');
   if (referencedSection) {
-    yield* syncWithConsole(() => consoleOutput.log(`\n${referencedSection}`));
+    yield* Console.log(`\n${referencedSection}`);
   }
-  yield* attempt(() => printRecallHygieneNudges(config, semanticSection ?? ''));
+  yield* printRecallHygieneNudges(config, semanticSection ?? '');
 });
 
 const MAX_REFERENCED_CONTEXT = 5;
@@ -1070,18 +1057,21 @@ const REFERENCED_EXCERPT_LINES = 12;
  * store and appending a short excerpt. Bounded to one hop and a small cap;
  * missing references degrade to a labeled line and never fail recall.
  */
-async function referencedContextSection(config: RuntimeConfig, recallOutput: string): Promise<string | undefined> {
+const referencedContextSection = Effect.fn('memory.referencedContextSection')(function* (
+  config: RuntimeConfig,
+  recallOutput: string,
+) {
   const surfacedUris = activePersonalMemoryUrisFromText(recallOutput, config.user);
   if (surfacedUris.length === 0) {
     return undefined;
   }
-  const surfaced = await readMemoryRecordsByUri(config, surfacedUris);
+  const surfaced = yield* readMemoryRecordsByUri(config, surfacedUris);
   const referenced = referencedUrisFromRecords(surfaced, recallOutput);
   if (referenced.length === 0) {
     return undefined;
   }
   const capped = referenced.slice(0, MAX_REFERENCED_CONTEXT);
-  const records = await readMemoryRecordsByUri(config, capped);
+  const records = yield* readMemoryRecordsByUri(config, capped);
   const byUri = new Map(records.map(record => [record.uri, record]));
   const lines = ['Referenced read-only context (one-way pointers from surfaced memories):'];
   for (const uri of capped) {
@@ -1098,7 +1088,7 @@ async function referencedContextSection(config: RuntimeConfig, recallOutput: str
     );
   }
   return lines.join('\n');
-}
+});
 
 /**
  * Run one recall search pass with `--output json` and return parsed hits.
@@ -1107,31 +1097,31 @@ async function referencedContextSection(config: RuntimeConfig, recallOutput: str
  * dedupes hits across passes, so scoped passes only contribute what the base
  * pass missed.
  */
-async function recallSearchHits(
+const recallSearchHits = Effect.fn('memory.recallSearchHits')(function* (
   config: RuntimeConfig,
   ov: string,
   args: readonly string[],
   options: {readonly dryRun: boolean; readonly includeArchived: boolean},
-): Promise<readonly RecallHit[]> {
+) {
   const jsonArgs = withIdentity(config, [...args, '--output', 'json']);
   if (options.dryRun) {
-    consoleOutput.log(`Would run: ${formatShellCommand(ov, jsonArgs)}`);
+    yield* Console.log(`Would run: ${formatShellCommand(ov, jsonArgs)}`);
     return [];
   }
-  let result = await runCommand(ov, jsonArgs, {allowFailure: true});
+  let result = yield* runCommand(ov, jsonArgs, {allowFailure: true});
   if (result.exitCode !== 0) {
-    result = await runCommand(ov, withIdentity(config, [...stripAdvancedSearchFlags(args), '--output', 'json']), {
+    result = yield* runCommand(ov, withIdentity(config, [...stripAdvancedSearchFlags(args), '--output', 'json']), {
       allowFailure: true,
     });
   }
   if (result.exitCode !== 0) {
-    consoleOutput.log(
+    yield* Console.log(
       `WARN recall search failed: ${result.stderr.trim() || result.stdout.trim() || 'ov search error'}`,
     );
     return [];
   }
   return parseRecallHits(result.stdout, {includeArchived: options.includeArchived});
-}
+});
 
 export function stripAdvancedSearchFlags(args: readonly string[]): readonly string[] {
   const stripped: string[] = [];
@@ -1150,7 +1140,7 @@ export const runRead = Effect.fn('runRead')(function* (config: RuntimeConfig, ur
   if (options.dryRun !== true) {
     yield* syncSharedReposAndLog(config);
   }
-  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
+  const ov = yield* openVikingCliForMode(options.dryRun === true);
   const result = yield* maybeRunEffect(options.dryRun === true, ov, withIdentity(config, ['read', uri]));
   if (
     result &&
@@ -1158,12 +1148,10 @@ export const runRead = Effect.fn('runRead')(function* (config: RuntimeConfig, ur
     (uri.endsWith('/.overview.md') || uri.endsWith('/.abstract.md'))
   ) {
     const parentUri = parentVikingUri(uri);
-    yield* syncWithConsole(() => {
-      consoleOutput.log(
-        '\nThis is a generated summary placeholder. To read the underlying content, inspect leaf nodes:',
-      );
-      consoleOutput.log(`  threadnote list ${parentUri} --all --recursive`);
-    });
+    yield* Console.log(
+      '\nThis is a generated summary placeholder. To read the underlying content, inspect leaf nodes:',
+    );
+    yield* Console.log(`  threadnote list ${parentUri} --all --recursive`);
   }
 });
 
@@ -1171,37 +1159,38 @@ const syncSharedReposAndLog = Effect.fn('memory.syncSharedReposAndLog')(function
   const syncResult = yield* syncSharedReposBeforeAgentRead(config).pipe(
     Effect.catch(error => {
       const message = error instanceof Error ? error.message : String(error);
-      return syncWithConsole(() => consoleOutput.error(`Auto-sync warning: ${message}`)).pipe(Effect.as(undefined));
+      return Console.error(`Auto-sync warning: ${message}`).pipe(Effect.as(undefined));
     }),
   );
   if (!syncResult) {
     return;
   }
-  yield* syncWithConsole(() => {
-    if (syncResult.syncedTeams.length > 0) {
-      consoleOutput.error(`Auto-synced shared memories: ${syncResult.syncedTeams.join(', ')}`);
-    }
-    for (const warning of syncResult.warnings) {
-      consoleOutput.error(`Auto-sync warning: ${warning}`);
-    }
-  });
+  if (syncResult.syncedTeams.length > 0) {
+    yield* Console.error(`Auto-synced shared memories: ${syncResult.syncedTeams.join(', ')}`);
+  }
+  for (const warning of syncResult.warnings) {
+    yield* Console.error(`Auto-sync warning: ${warning}`);
+  }
 });
 
-async function printRecallHygieneNudges(config: RuntimeConfig, recallOutput: string): Promise<void> {
+const printRecallHygieneNudges = Effect.fn('memory.printRecallHygieneNudges')(function* (
+  config: RuntimeConfig,
+  recallOutput: string,
+) {
   const uris = activePersonalMemoryUrisFromText(recallOutput, config.user);
   if (uris.length === 0) {
     return;
   }
-  const records = await readMemoryRecordsByUri(config, uris);
+  const records = yield* readMemoryRecordsByUri(config, uris);
   const nudges = recallHygieneNudges(recallOutput, {records, user: config.user});
   if (nudges.length === 0) {
     return;
   }
-  consoleOutput.log('\nMemory hygiene hints:');
+  yield* Console.log('\nMemory hygiene hints:');
   for (const nudge of nudges) {
-    consoleOutput.log(`- ${nudge}`);
+    yield* Console.log(`- ${nudge}`);
   }
-}
+});
 
 export const runCompact = Effect.fn('runCompact')(function* (config: RuntimeConfig, options: CompactOptions) {
   const project = yield* requireValue(
@@ -1212,12 +1201,10 @@ export const runCompact = Effect.fn('runCompact')(function* (config: RuntimeConf
     yield* Effect.fail(new Error('Cannot combine --apply with --dry-run.'));
   }
   const apply = options.apply === true;
-  const records = yield* attempt(() =>
-    scopedCompactRecords(config, {
-      kind: options.kind,
-      project,
-    }),
-  );
+  const records = yield* scopedCompactRecords(config, {
+    kind: options.kind,
+    project,
+  });
   const plan = buildCompactPlan(records, {
     kind: options.kind,
     project,
@@ -1228,15 +1215,17 @@ export const runCompact = Effect.fn('runCompact')(function* (config: RuntimeConf
     return;
   }
 
-  const ov = yield* attempt(() => openVikingCliForMode(false));
-  const updatePath = join(config.agentContextHome, 'compact-memory-update.txt');
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const ov = yield* openVikingCliForMode(false);
+  const updatePath = path.join(config.agentContextHome, 'compact-memory-update.txt');
   yield* Effect.gen(function* () {
     for (const action of plan.keepUpdates) {
-      yield* attempt(() => writeFile(updatePath, action.content, {encoding: 'utf8', mode: 0o600}));
-      yield* attempt(() => chmod(updatePath, 0o600));
-      yield* attempt(() => writeDurableMemoryFile(ov, config, action.uri, updatePath, 'replace'));
+      yield* fs.writeFileString(updatePath, action.content, {mode: 0o600});
+      yield* fs.chmod(updatePath, 0o600);
+      yield* writeDurableMemoryFile(ov, config, action.uri, updatePath, 'replace');
     }
-  }).pipe(Effect.ensuring(attempt(() => rm(updatePath, {force: true})).pipe(Effect.catch(() => Effect.void))));
+  }).pipe(Effect.ensuring(fs.remove(updatePath, {force: true}).pipe(Effect.ignore)));
 
   for (const action of plan.archives) {
     yield* runArchive(config, action.uri, {
@@ -1251,13 +1240,16 @@ export const runCompact = Effect.fn('runCompact')(function* (config: RuntimeConf
   }
 });
 
-export async function runCompactDiagnostics(config: RuntimeConfig, options: CompactOptions): Promise<void> {
+export const runCompactDiagnostics = Effect.fn('memory.runCompactDiagnostics')(function* (
+  config: RuntimeConfig,
+  options: CompactOptions,
+) {
   const project = normalizeOptionalMetadata(options.project);
   if (!project) {
-    throw new Error('Provide --project for scoped memory hygiene.');
+    return yield* Effect.fail(new Error('Provide --project for scoped memory hygiene.'));
   }
   const topic = normalizeOptionalMetadata(options.topic);
-  const records = await scopedCompactRecords(config, {
+  const records = yield* scopedCompactRecords(config, {
     kind: options.kind,
     project,
   });
@@ -1270,7 +1262,7 @@ export async function runCompactDiagnostics(config: RuntimeConfig, options: Comp
       counts.set(kind, (counts.get(kind) ?? 0) + 1);
     }
   }
-  consoleOutput.log(
+  yield* Console.log(
     [
       'Scope summary:',
       `- project: ${project}`,
@@ -1284,55 +1276,60 @@ export async function runCompactDiagnostics(config: RuntimeConfig, options: Comp
       '',
     ].join('\n'),
   );
-}
+});
 
-async function scopedCompactRecords(
+const scopedCompactRecords = Effect.fn('memory.scopedCompactRecords')(function* (
   config: RuntimeConfig,
   options: {readonly kind?: CompactableMemoryKind; readonly project: string},
-): Promise<readonly MemoryRecord[]> {
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const kinds: readonly CompactableMemoryKind[] = options.kind ? [options.kind] : ['handoff', 'durable', 'incident'];
   const records: MemoryRecord[] = [];
   for (const kind of kinds) {
-    const directory = localMemoryDirectoryForCompact(config, kind, options.project);
+    const directory = yield* localMemoryDirectoryForCompact(config, kind, options.project);
     const uriDirectory = memoryUriDirectoryForCompact(config, kind, options.project);
-    let entries;
-    try {
-      entries = await readdir(directory, {withFileTypes: true});
-    } catch (_err: unknown) {
+    const entries = yield* fs.readDirectory(directory).pipe(Effect.option);
+    if (entries._tag === 'None') {
       continue;
     }
-    for (const entry of entries) {
-      if (!entry.isFile() || entry.name.startsWith('.') || !entry.name.endsWith('.md')) {
+    for (const entry of entries.value) {
+      if (entry.startsWith('.') || !entry.endsWith('.md')) {
         continue;
       }
-      const content = await readTextIfExists(join(directory, entry.name));
+      const entryPath = path.join(directory, entry);
+      const info = yield* fs.stat(entryPath).pipe(Effect.option);
+      if (info._tag === 'None' || info.value.type !== 'File') {
+        continue;
+      }
+      const content = yield* readTextIfExists(entryPath);
       if (!content) {
         continue;
       }
-      const record = parseMemoryDocument(`${uriDirectory}/${entry.name}`, content);
+      const record = parseMemoryDocument(`${uriDirectory}/${entry}`, content);
       if (record) {
         records.push(record);
       }
     }
   }
   return records;
-}
+});
 
 function formatKindCounts(counts: ReadonlyMap<CompactableMemoryKind, number>): string {
   return (['handoff', 'durable', 'incident'] as const).map(kind => `${kind} ${counts.get(kind) ?? 0}`).join(', ');
 }
 
-async function readMemoryRecordsByUri(
+const readMemoryRecordsByUri = Effect.fn('memory.readMemoryRecordsByUri')(function* (
   config: RuntimeConfig,
   uris: readonly string[],
-): Promise<readonly MemoryRecord[]> {
+) {
   const records: MemoryRecord[] = [];
   for (const uri of uris) {
-    const localPath = localMemoryPathForUri(config, uri);
+    const localPath = yield* localMemoryPathForUri(config, uri);
     if (!localPath) {
       continue;
     }
-    const content = await readTextIfExists(localPath);
+    const content = yield* readTextIfExists(localPath);
     if (!content) {
       continue;
     }
@@ -1342,20 +1339,25 @@ async function readMemoryRecordsByUri(
     }
   }
   return records;
-}
+});
 
-function localMemoryDirectoryForCompact(config: RuntimeConfig, kind: CompactableMemoryKind, project: string): string {
-  const root = localUserMemoriesRoot(config);
+const localMemoryDirectoryForCompact = Effect.fn('memory.localMemoryDirectoryForCompact')(function* (
+  config: RuntimeConfig,
+  kind: CompactableMemoryKind,
+  project: string,
+) {
+  const path = yield* Path.Path;
+  const root = yield* localUserMemoriesRoot(config);
   const projectSegment = uriSegment(project);
   switch (kind) {
     case 'durable':
-      return join(root, 'durable', 'projects', projectSegment);
+      return path.join(root, 'durable', 'projects', projectSegment);
     case 'handoff':
-      return join(root, 'handoffs', 'active', projectSegment);
+      return path.join(root, 'handoffs', 'active', projectSegment);
     case 'incident':
-      return join(root, 'incidents', 'active', projectSegment);
+      return path.join(root, 'incidents', 'active', projectSegment);
   }
-}
+});
 
 function memoryUriDirectoryForCompact(config: RuntimeConfig, kind: CompactableMemoryKind, project: string): string {
   const base = `viking://user/${uriSegment(config.user)}/memories`;
@@ -1370,7 +1372,7 @@ function memoryUriDirectoryForCompact(config: RuntimeConfig, kind: CompactableMe
   }
 }
 
-function localMemoryPathForUri(config: RuntimeConfig, uri: string): string | undefined {
+const localMemoryPathForUri = Effect.fn('memory.localMemoryPathForUri')(function* (config: RuntimeConfig, uri: string) {
   const prefix = `viking://user/${uriSegment(config.user)}/memories/`;
   if (!uri.startsWith(prefix)) {
     return undefined;
@@ -1379,12 +1381,13 @@ function localMemoryPathForUri(config: RuntimeConfig, uri: string): string | und
   if (relative.includes('..') || relative.startsWith('/')) {
     return undefined;
   }
-  return join(localUserMemoriesRoot(config), ...relative.split('/'));
-}
+  const path = yield* Path.Path;
+  return path.join(yield* localUserMemoriesRoot(config), ...relative.split('/'));
+});
 
 export const runList = Effect.fn('runList')(function* (config: RuntimeConfig, uri: string, options: ListOptions) {
   yield* attemptSync(() => assertVikingUri(uri));
-  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
+  const ov = yield* openVikingCliForMode(options.dryRun === true);
   const args = ['ls', uri];
   if (options.all === true) {
     args.push('--all');
@@ -1403,7 +1406,7 @@ export const runList = Effect.fn('runList')(function* (config: RuntimeConfig, ur
 });
 
 export const runHandoff = Effect.fn('runHandoff')(function* (config: RuntimeConfig, options: HandoffOptions) {
-  const {bodyText, metadata} = yield* attempt(() => buildHandoff(options));
+  const {bodyText, metadata} = yield* buildHandoff(options);
   yield* storeMemory(config, {
     bodyText,
     dryRun: options.dryRun === true,
@@ -1419,8 +1422,8 @@ export const runArchive = Effect.fn('runArchive')(function* (
   options: ArchiveOptions,
 ) {
   yield* attemptSync(() => assertVikingUri(uri));
-  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
-  const readResult = yield* attempt(() => maybeRun(options.dryRun === true, ov, withIdentity(config, ['read', uri])));
+  const ov = yield* openVikingCliForMode(options.dryRun === true);
+  const readResult = yield* maybeRunEffect(options.dryRun === true, ov, withIdentity(config, ['read', uri]));
   const original = readResult?.stdout.trim();
   if (options.dryRun === true) {
     const fallbackMetadata: MemoryMetadata = {
@@ -1442,10 +1445,8 @@ export const runArchive = Effect.fn('runArchive')(function* (
     return;
   }
   const originalMemory = yield* requireValue(original, `Could not read ${uri} before archiving.`);
-  const originalLocalPath = localMemoryPathForUri(config, uri);
-  const originalLocalContent = originalLocalPath
-    ? yield* attempt(() => readFileIfExists(originalLocalPath))
-    : undefined;
+  const originalLocalPath = yield* localMemoryPathForUri(config, uri);
+  const originalLocalContent = originalLocalPath ? yield* readFileIfExists(originalLocalPath) : undefined;
 
   const inferredMetadata = inferMemoryMetadata(originalMemory);
   const metadata: MemoryMetadata = {
@@ -1477,9 +1478,9 @@ export const runArchive = Effect.fn('runArchive')(function* (
 
 export const runForget = Effect.fn('runForget')(function* (config: RuntimeConfig, uri: string, options: ForgetOptions) {
   yield* attemptSync(() => assertVikingUri(uri));
-  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
+  const ov = yield* openVikingCliForMode(options.dryRun === true);
   if (options.dryRun === true) {
-    yield* attempt(() => maybeRun(true, ov, withIdentity(config, ['rm', uri])));
+    yield* maybeRunEffect(true, ov, withIdentity(config, ['rm', uri]));
     return;
   }
   const removed = yield* removeVikingResourceWithRetry(ov, config, uri);
@@ -1489,9 +1490,10 @@ export const runForget = Effect.fn('runForget')(function* (config: RuntimeConfig
 });
 
 export const runExportPack = Effect.fn('runExportPack')(function* (config: RuntimeConfig, options: PackOptions) {
-  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
-  const defaultPath = join(config.agentContextHome, `threadnote-${safeTimestamp()}.ovpack`);
-  const outputPath = expandPath(options.path ?? defaultPath);
+  const path = yield* Path.Path;
+  const ov = yield* openVikingCliForMode(options.dryRun === true);
+  const defaultPath = path.join(config.agentContextHome, `threadnote-${safeTimestamp()}.ovpack`);
+  const outputPath = yield* expandPath(options.path ?? defaultPath);
   const sourceUri = options.uri ?? `viking://user/${uriSegment(config.user)}/memories`;
   yield* maybeRunEffect(options.dryRun === true, ov, withIdentity(config, ['export', sourceUri, outputPath]));
 });
@@ -1500,16 +1502,16 @@ export const runImportPack = Effect.fn('runImportPack')(function* (config: Runti
   if (!options.path) {
     yield* Effect.fail(new Error('Provide --path for import-pack.'));
   }
-  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun === true));
+  const ov = yield* openVikingCliForMode(options.dryRun === true);
   const targetUri = options.targetUri ?? `viking://user/${uriSegment(config.user)}`;
   yield* maybeRunEffect(
     options.dryRun === true,
     ov,
-    withIdentity(config, ['import', expandPath(options.path!), targetUri]),
+    withIdentity(config, ['import', yield* expandPath(options.path!), targetUri]),
   );
 });
 
-async function inferRecallUri(config: RuntimeConfig, query: string): Promise<string | undefined> {
+const inferRecallUri = Effect.fn('memory.inferRecallUri')(function* (config: RuntimeConfig, query: string) {
   // Only scope the base search when the query has an explicit "skills" intent —
   // that narrowing matches user expectation ("find me a skill for X"). For
   // general project-name matches we no longer scope the base search, because
@@ -1520,11 +1522,11 @@ async function inferRecallUri(config: RuntimeConfig, query: string): Promise<str
   if (!hasAgentSkillCatalogIntent(query)) {
     return undefined;
   }
-  const project = await inferProjectFromQuery(config.manifestPath, query);
+  const project = yield* inferProjectFromQuery(config.manifestPath, query);
   return project
     ? `viking://resources/agent-skills/repo-local-${uriSegment(project.name)}`
     : 'viking://resources/agent-skills';
-}
+});
 
 export function hasAgentSkillCatalogIntent(query: string): boolean {
   const normalized = query.toLowerCase();
@@ -1543,12 +1545,12 @@ export function hasAgentSkillCatalogIntent(query: string): boolean {
   );
 }
 
-async function collectExactMemoryMatches(
+const collectExactMemoryMatches = Effect.fn('memory.collectExactMemoryMatches')(function* (
   config: RuntimeConfig,
   ov: string,
   query: string,
   options: {readonly dryRun: boolean; readonly includeArchived: boolean; readonly project: ProjectManifest | undefined},
-): Promise<readonly ExactMatch[]> {
+) {
   const terms = exactRecallTerms(query);
   if (terms.length === 0) {
     return [];
@@ -1558,24 +1560,26 @@ async function collectExactMemoryMatches(
     withIdentity(config, ['grep', term, '--uri', scope, '--node-limit', '5', '--output', 'json']);
   if (options.dryRun) {
     const planned = terms.flatMap(term => scopes.map(scope => formatShellCommand(ov, grepArgs(term, scope))));
-    consoleOutput.log('\nExact memory/resource matches:');
-    consoleOutput.log(planned.join('\n'));
+    yield* Console.log('\nExact memory/resource matches:');
+    yield* Console.log(planned.join('\n'));
     return [];
   }
-  return collectExactMatches(terms, scopes, async (term, scope) => {
-    const result = await runCommand(ov, grepArgs(term, scope), {allowFailure: true});
-    return result.exitCode === 0 ? result.stdout : undefined;
-  });
-}
+  return yield* collectExactMatches(terms, scopes, (term, scope) =>
+    runCommand(ov, grepArgs(term, scope), {allowFailure: true}).pipe(
+      Effect.map(result => (result.exitCode === 0 ? result.stdout : undefined)),
+    ),
+  );
+});
 
 const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, options: StoreMemoryOptions) {
   if (options.replaceUri) {
     yield* attemptSync(() => assertVikingUri(options.replaceUri as string));
   }
-  const ov = yield* attempt(() => openVikingCliForMode(options.dryRun));
+  const path = yield* Path.Path;
+  const ov = yield* openVikingCliForMode(options.dryRun);
   if (options.replaceUri && isInSharedNamespace(config, options.replaceUri)) {
     if (options.dryRun) {
-      yield* attempt(() => storeSharedMemoryReplacement(config, ov, options, options.replaceUri as string));
+      yield* storeSharedMemoryReplacement(config, ov, options, options.replaceUri as string);
       return;
     }
     const fs = yield* FileSystem.FileSystem;
@@ -1585,12 +1589,12 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
         fs,
         config.agentContextHome,
         [options.replaceUri],
-        attempt(() => storeSharedMemoryReplacement(config, ov, options, options.replaceUri as string)),
+        storeSharedMemoryReplacement(config, ov, options, options.replaceUri as string),
       ),
     );
     return;
   }
-  const memoryPath = join(config.agentContextHome, 'last-memory.txt');
+  const memoryPath = path.join(config.agentContextHome, 'last-memory.txt');
 
   // Two-pass formatting: assume the caller's replaceUri is a true supersede,
   // compute the destination URI, then drop the supersedes line if it points
@@ -1599,7 +1603,7 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
   // also leaks to teammates when the memory is later published.
   const candidateMetadata: MemoryMetadata = {...options.metadata, supersedes: options.replaceUri};
   const candidateMemory = formatMemoryDocument(options.title, candidateMetadata, options.bodyText);
-  const memoryUri = memoryUriFor(config, candidateMemory, candidateMetadata);
+  const memoryUri = yield* memoryUriFor(config, candidateMemory, candidateMetadata);
   const isInPlaceUpdate = options.replaceUri !== undefined && options.replaceUri === memoryUri;
   const finalMetadata: MemoryMetadata = isInPlaceUpdate
     ? {...options.metadata, supersedes: undefined}
@@ -1608,7 +1612,7 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
     ? formatMemoryDocument(options.title, finalMetadata, options.bodyText)
     : candidateMemory;
   if (options.dryRun) {
-    const writeMode = yield* attempt(() => memoryWriteMode(ov, config, memoryUri, finalMetadata));
+    const writeMode = yield* memoryWriteMode(ov, config, memoryUri, finalMetadata);
     yield* Console.log(memory);
     yield* Console.log('\nWould run:');
     yield* Console.log(
@@ -1638,11 +1642,11 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
     config.agentContextHome,
     [LAST_MEMORY_STAGING_LOCK_URI, options.replaceUri, memoryUri],
     Effect.gen(function* () {
-      const writeMode = yield* attempt(() => memoryWriteMode(ov, config, memoryUri, finalMetadata));
-      yield* attempt(() => writeFile(memoryPath, memory, {encoding: 'utf8', mode: 0o600}));
-      yield* attempt(() => chmod(memoryPath, 0o600));
-      yield* attempt(() => ensureMemoryDirectory(ov, config, memoryDirectoryUri(config, finalMetadata)));
-      yield* attempt(() => writeDurableMemoryFile(ov, config, memoryUri, memoryPath, writeMode));
+      const writeMode = yield* memoryWriteMode(ov, config, memoryUri, finalMetadata);
+      yield* fs.writeFileString(memoryPath, memory, {mode: 0o600});
+      yield* fs.chmod(memoryPath, 0o600);
+      yield* ensureMemoryDirectory(ov, config, memoryDirectoryUri(config, finalMetadata));
+      yield* writeDurableMemoryFile(ov, config, memoryUri, memoryPath, writeMode);
       yield* Console.log(`Stored memory: ${memoryUri}`);
       if (options.replaceUri && !isInPlaceUpdate) {
         const removedReplacedMemory = yield* removeVikingResourceWithRetry(ov, config, options.replaceUri, {
@@ -1671,29 +1675,32 @@ const storeMemory = Effect.fn('storeMemory')(function* (config: RuntimeConfig, o
  * consistency-checked field and the path-derived topic can be a raw multi-segment
  * value (`a/b`) that must not be slugged into or persisted from here.
  */
-function warnOnSharedProjectDrift(metadata: MemoryMetadata, inferred: {readonly project?: string} | undefined): void {
+const warnOnSharedProjectDrift = Effect.fn('memory.warnOnSharedProjectDrift')(function* (
+  metadata: MemoryMetadata,
+  inferred: {readonly project?: string} | undefined,
+) {
   if (inferred?.project && metadata.project && uriSegment(metadata.project) !== inferred.project) {
-    consoleOutput.log(
+    yield* Console.log(
       `WARN keeping shared memory project "${inferred.project}" from its storage path; ignoring requested "${metadata.project}". ` +
         `To change a shared memory's project, forget it and store a new one under the new project.`,
     );
   }
-}
+});
 
-async function storeSharedMemoryReplacement(
+const storeSharedMemoryReplacement = Effect.fn('memory.storeSharedMemoryReplacement')(function* (
   config: RuntimeConfig,
   ov: string,
   options: StoreMemoryOptions,
   targetUri: string,
-): Promise<void> {
+) {
   if (options.metadata.kind !== 'durable') {
-    throw new Error('Shared memory replacement only supports durable memories.');
+    return yield* Effect.fail(new Error('Shared memory replacement only supports durable memories.'));
   }
   const teamName = sharedTeamNameForUri(config, targetUri);
   if (!teamName) {
-    throw new Error(`Memory ${targetUri} is not in the shared namespace.`);
+    return yield* Effect.fail(new Error(`Memory ${targetUri} is not in the shared namespace.`));
   }
-  const team = await resolveTeam(config, teamName);
+  const team = yield* resolveTeam(config, teamName);
   const inferred = sharedMemoryUriParts(config, targetUri);
   // The file is updated in place at targetUri, so its frontmatter project must
   // match the path it lives under; otherwise recall's project scoping and the
@@ -1701,7 +1708,7 @@ async function storeSharedMemoryReplacement(
   // path's project over a differing caller value and warn — changing a shared
   // memory's project means relocating it (forget + store anew), not editing the
   // frontmatter of the file at the old path. Topic keeps caller-wins semantics.
-  warnOnSharedProjectDrift(options.metadata, inferred);
+  yield* warnOnSharedProjectDrift(options.metadata, inferred);
   const metadata: MemoryMetadata = {
     ...options.metadata,
     project: inferred?.project ?? options.metadata.project,
@@ -1710,43 +1717,51 @@ async function storeSharedMemoryReplacement(
   const rawMemory = formatMemoryDocument(options.title, metadata, options.bodyText);
   const scrub = applyScrubber(stripPersonalProvenance(rawMemory), {redact: false});
   if (scrub.blocker) {
-    throw new Error(
-      `Refusing to update shared memory ${targetUri}: possible ${scrub.blocker}. Strip the sensitive value first.`,
+    return yield* Effect.fail(
+      new Error(
+        `Refusing to update shared memory ${targetUri}: possible ${scrub.blocker}. Strip the sensitive value first.`,
+      ),
     );
   }
   const memory = scrub.cleaned;
   const relativePath = vikingUriToWorktreeRelative(config, targetUri, team.name);
 
   if (options.dryRun) {
-    consoleOutput.log(memory);
-    consoleOutput.log('\nWould run:');
+    yield* Console.log(memory);
+    yield* Console.log('\nWould run:');
   }
-  await ensureSharedDirectoryChain(config, ov, targetUri, options.dryRun);
-  await writeMemoryFile(config, ov, targetUri, memory, 'replace', options.dryRun);
+  yield* ensureSharedDirectoryChain(config, ov, targetUri, options.dryRun);
+  yield* writeMemoryFile(config, ov, targetUri, memory, 'replace', options.dryRun);
 
-  const gitMessages = await publishShareGitChange(team.config.worktree, relativePath, `share: update ${relativePath}`, {
-    dryRun: options.dryRun,
-  });
+  const gitMessages = yield* publishShareGitChange(
+    team.config.worktree,
+    relativePath,
+    `share: update ${relativePath}`,
+    {
+      dryRun: options.dryRun,
+    },
+  );
   for (const message of gitMessages) {
-    consoleOutput.log(message);
+    yield* Console.log(message);
   }
 
   for (const redaction of scrub.redactions) {
-    consoleOutput.log(`Redacted ${redaction.count}× ${redaction.name} before shared update.`);
+    yield* Console.log(`Redacted ${redaction.count}× ${redaction.name} before shared update.`);
   }
-  consoleOutput.log(`Updated shared memory: ${targetUri}`);
-}
+  yield* Console.log(`Updated shared memory: ${targetUri}`);
+});
 
-async function writeDurableMemoryFile(
+const writeDurableMemoryFile = Effect.fn('memory.writeDurableMemoryFile')(function* (
   ov: string,
   config: RuntimeConfig,
   memoryUri: string,
   memoryPath: string,
   writeMode: 'create' | 'replace',
-): Promise<void> {
-  const content = await readFile(memoryPath, 'utf8');
-  await writeMemoryFile(config, ov, memoryUri, content, writeMode, false);
-}
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const content = yield* fs.readFileString(memoryPath);
+  yield* writeMemoryFile(config, ov, memoryUri, content, writeMode, false);
+});
 
 function removeVikingResourceWithRetry(
   ov: string,
@@ -1780,8 +1795,8 @@ function removeVikingResourceWithRetry(
       [uri],
       Effect.gen(function* () {
         if (options.expectedContent !== undefined) {
-          const localPath = localMemoryPathForUri(config, uri);
-          const currentContent = localPath ? yield* attempt(() => readFileIfExists(localPath)) : undefined;
+          const localPath = yield* localMemoryPathForUri(config, uri);
+          const currentContent = localPath ? yield* readFileIfExists(localPath) : undefined;
           if (currentContent === undefined || currentContent.trim() !== options.expectedContent.trim()) {
             return yield* Effect.fail(
               new Error(`Memory changed before removal; review the current content and retry: ${uri}`),
@@ -1794,28 +1809,36 @@ function removeVikingResourceWithRetry(
   });
 }
 
-async function vikingResourceExists(ov: string, config: RuntimeConfig, uri: string): Promise<boolean> {
-  const stat = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+const vikingResourceExists = Effect.fn('memory.vikingResourceExists')(function* (
+  ov: string,
+  config: RuntimeConfig,
+  uri: string,
+) {
+  const stat = yield* runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
   return stat.exitCode === 0;
-}
+});
 
-async function ensureDurableMemoryDirectory(ov: string, config: RuntimeConfig): Promise<void> {
-  await ensureMemoryDirectory(ov, config, durableMemoryDirectoryUri(config));
-}
+const ensureDurableMemoryDirectory = Effect.fn('memory.ensureDurableMemoryDirectory')(
+  (ov: string, config: RuntimeConfig) => ensureMemoryDirectory(ov, config, durableMemoryDirectoryUri(config)),
+);
 
-async function ensureMemoryDirectory(ov: string, config: RuntimeConfig, directoryUri: string): Promise<void> {
+const ensureMemoryDirectory = Effect.fn('memory.ensureMemoryDirectory')(function* (
+  ov: string,
+  config: RuntimeConfig,
+  directoryUri: string,
+) {
   for (const uri of vikingDirectoryChain(directoryUri)) {
-    const statResult = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+    const statResult = yield* runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
     if (statResult.exitCode === 0) {
       continue;
     }
-    await maybeRun(
+    yield* maybeRunEffect(
       false,
       ov,
       withIdentity(config, ['mkdir', uri, '--description', 'Threadnote lifecycle-aware local memories.']),
     );
   }
-}
+});
 
 function durableMemoryDirectoryUri(config: RuntimeConfig): string {
   return `viking://user/${uriSegment(config.user)}/memories/events`;
@@ -1825,33 +1848,39 @@ function migratedDurableMemoryUri(config: RuntimeConfig, hash: string): string {
   return `${durableMemoryDirectoryUri(config)}/threadnote-migrated-${hash.slice(0, 16)}.md`;
 }
 
-export async function hasLegacyLifecycleHandoffCandidates(config: RuntimeConfig): Promise<boolean> {
-  return (await legacyLifecycleHandoffCandidates(config, 1)).length > 0;
-}
+export const hasLegacyLifecycleHandoffCandidates = Effect.fn('memory.hasLegacyLifecycleHandoffCandidates')(function* (
+  config: RuntimeConfig,
+) {
+  return (yield* legacyLifecycleHandoffCandidates(config, 1)).length > 0;
+});
 
-async function legacyLifecycleHandoffCandidates(
+const legacyLifecycleHandoffCandidates = Effect.fn('memory.legacyLifecycleHandoffCandidates')(function* (
   config: RuntimeConfig,
   limit?: number,
-): Promise<readonly LifecycleHandoffCandidate[]> {
-  const eventsRoot = join(localUserMemoriesRoot(config), 'events');
-  let entries;
-  try {
-    entries = await readdir(eventsRoot, {withFileTypes: true});
-  } catch (_err: unknown) {
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const eventsRoot = path.join(yield* localUserMemoriesRoot(config), 'events');
+  const entries = yield* fs.readDirectory(eventsRoot).pipe(Effect.option);
+  if (entries._tag === 'None') {
     return [];
   }
 
   const candidates: LifecycleHandoffCandidate[] = [];
-  for (const entry of entries) {
-    if (!entry.isFile() || entry.name.startsWith('.') || !entry.name.endsWith('.md')) {
+  for (const entry of entries.value) {
+    if (entry.startsWith('.') || !entry.endsWith('.md')) {
       continue;
     }
-    const sourcePath = join(eventsRoot, entry.name);
-    const original = await readTextIfExists(sourcePath);
+    const sourcePath = path.join(eventsRoot, entry);
+    const info = yield* fs.stat(sourcePath).pipe(Effect.option);
+    if (info._tag === 'None' || info.value.type !== 'File') {
+      continue;
+    }
+    const original = yield* readTextIfExists(sourcePath);
     if (!original || !isClearLegacyHandoffMemory(original) || sensitiveMemoryReason(original)) {
       continue;
     }
-    const sourceUri = `${durableMemoryDirectoryUri(config)}/${entry.name}`;
+    const sourceUri = `${durableMemoryDirectoryUri(config)}/${entry}`;
     candidates.push({
       metadata: {
         archivedFrom: sourceUri,
@@ -1869,7 +1898,7 @@ async function legacyLifecycleHandoffCandidates(
     }
   }
   return candidates;
-}
+});
 
 function lifecycleMigrationUri(config: RuntimeConfig, metadata: MemoryMetadata, hash: string): string {
   return `${memoryDirectoryUri(config, metadata)}/legacy-${hash.slice(0, 16)}.md`;
@@ -1894,12 +1923,12 @@ function worksetScopeUris(config: RuntimeConfig, workset: ResolvedWorkset): read
   return [...new Set(scopes)];
 }
 
-async function recallProjectMemoryName(
+const recallProjectMemoryName = Effect.fn('memory.recallProjectMemoryName')(function* (
   explicitProject: string | undefined,
   options: {readonly cwd?: string; readonly includeProcessCwd?: boolean},
-): Promise<string | undefined> {
-  return normalizeOptionalMetadata(explicitProject) ?? (await resolveWorkspaceRepoName(options));
-}
+) {
+  return normalizeOptionalMetadata(explicitProject) ?? (yield* resolveWorkspaceRepoName(options));
+});
 
 function projectMemoryScopeUris(
   config: RuntimeConfig,
@@ -1942,12 +1971,16 @@ function exactMemoryScopes(
   });
 }
 
-function memoryUriFor(config: RuntimeConfig, memory: string, metadata: MemoryMetadata): string {
+const memoryUriFor = Effect.fn('memory.memoryUriFor')(function* (
+  config: RuntimeConfig,
+  memory: string,
+  metadata: MemoryMetadata,
+) {
   const filename = shouldUseStableMemoryUri(metadata)
     ? `${uriSegment(metadata.topic ?? 'current')}.md`
-    : `threadnote-${safeTimestamp()}-${sha256(memory).slice(0, 12)}.md`;
+    : `threadnote-${safeTimestamp()}-${(yield* sha256(memory)).slice(0, 12)}.md`;
   return `${memoryDirectoryUri(config, metadata)}/${filename}`;
-}
+});
 
 function memoryDirectoryUri(config: RuntimeConfig, metadata: MemoryMetadata): string {
   const baseUri = `viking://user/${uriSegment(config.user)}/memories`;
@@ -1974,17 +2007,17 @@ function shouldUseStableMemoryUri(metadata: MemoryMetadata): boolean {
   return metadata.status === 'active' && metadata.topic !== undefined && metadata.kind !== 'smoke';
 }
 
-async function memoryWriteMode(
+const memoryWriteMode = Effect.fn('memory.memoryWriteMode')(function* (
   ov: string,
   config: RuntimeConfig,
   memoryUri: string,
   metadata: MemoryMetadata,
-): Promise<'create' | 'replace'> {
+) {
   if (!shouldUseStableMemoryUri(metadata)) {
     return 'create';
   }
-  return (await vikingResourceExists(ov, config, memoryUri)) ? 'replace' : 'create';
-}
+  return (yield* vikingResourceExists(ov, config, memoryUri)) ? 'replace' : 'create';
+});
 
 function vikingDirectoryChain(directoryUri: string): readonly string[] {
   const prefix = 'viking://';
@@ -2029,7 +2062,7 @@ function inferLegacyProject(memory: string): string {
     return 'general';
   }
   const trimmed = explicit.trim().replace(/[`.,;]+$/g, '');
-  return trimmed.includes('/') ? basename(trimmed) : trimmed;
+  return trimmed.includes('/') ? (trimmed.split('/').at(-1) ?? trimmed) : trimmed;
 }
 
 function normalizeOptionalMetadata(value: string | undefined): string | undefined {
@@ -2037,39 +2070,41 @@ function normalizeOptionalMetadata(value: string | undefined): string | undefine
   return trimmed ? trimmed : undefined;
 }
 
-async function legacySourceAccounts(
+const legacySourceAccounts = Effect.fn('memory.legacySourceAccounts')(function* (
   config: RuntimeConfig,
   options: MigrateMemoriesOptions,
-): Promise<readonly string[]> {
+) {
   const explicitAccounts = options.sourceAccount?.filter(account => account.trim().length > 0) ?? [];
   if (explicitAccounts.length > 0) {
     return uniqueStrings(explicitAccounts);
   }
   if (options.allAccounts === true) {
-    const accounts = await childDirectoryNames(localVikingDataRoot(config));
+    const accounts = yield* childDirectoryNames(yield* localVikingDataRoot(config));
     return accounts.filter(account => !account.startsWith('_'));
   }
   return [config.account];
-}
+});
 
-async function legacyMemoryCandidates(
+const legacyMemoryCandidates = Effect.fn('memory.legacyMemoryCandidates')(function* (
   config: RuntimeConfig,
   sourceAccounts: readonly string[],
-): Promise<readonly LegacyMemoryCandidate[]> {
+) {
+  const path = yield* Path.Path;
+  const dataRoot = yield* localVikingDataRoot(config);
   const candidates: LegacyMemoryCandidate[] = [];
   for (const sourceAccount of sourceAccounts) {
-    const sessionRoot = join(localVikingDataRoot(config), sourceAccount, 'session');
-    for (const sourceSession of await childDirectoryNames(sessionRoot)) {
-      const historyRoot = join(sessionRoot, sourceSession, 'history');
-      for (const sourceArchive of await childDirectoryNames(historyRoot)) {
+    const sessionRoot = path.join(dataRoot, sourceAccount, 'session');
+    for (const sourceSession of yield* childDirectoryNames(sessionRoot)) {
+      const historyRoot = path.join(sessionRoot, sourceSession, 'history');
+      for (const sourceArchive of yield* childDirectoryNames(historyRoot)) {
         if (!sourceArchive.startsWith('archive_')) {
           continue;
         }
-        const sourcePath = join(historyRoot, sourceArchive, 'messages.jsonl');
-        for (const text of await legacyMemoryTexts(sourcePath)) {
+        const sourcePath = path.join(historyRoot, sourceArchive, 'messages.jsonl');
+        for (const text of yield* legacyMemoryTexts(sourcePath)) {
           candidates.push({
-            comparableHash: sha256(comparableMemoryText(text)),
-            hash: sha256(text),
+            comparableHash: yield* sha256(comparableMemoryText(text)),
+            hash: yield* sha256(text),
             sourceAccount,
             sourceArchive,
             sourceSession,
@@ -2080,10 +2115,10 @@ async function legacyMemoryCandidates(
     }
   }
   return candidates.sort((left, right) => legacySourceLabel(left).localeCompare(legacySourceLabel(right)));
-}
+});
 
-async function legacyMemoryTexts(sourcePath: string): Promise<readonly string[]> {
-  const raw = await readTextIfExists(sourcePath);
+const legacyMemoryTexts = Effect.fn('memory.legacyMemoryTexts')(function* (sourcePath: string) {
+  const raw = yield* readTextIfExists(sourcePath);
   if (!raw) {
     return [];
   }
@@ -2093,18 +2128,17 @@ async function legacyMemoryTexts(sourcePath: string): Promise<readonly string[]>
     if (!trimmedLine) {
       continue;
     }
-    try {
-      const parsed: unknown = JSON.parse(trimmedLine);
-      const text = legacyMessageText(parsed)?.trim();
-      if (text && isLegacyThreadnoteMemory(text)) {
-        memories.push(text);
-      }
-    } catch (_err: unknown) {
+    const parsed = Result.try((): unknown => JSON.parse(trimmedLine));
+    if (Result.isFailure(parsed)) {
       continue;
+    }
+    const text = legacyMessageText(parsed.success)?.trim();
+    if (text && isLegacyThreadnoteMemory(text)) {
+      memories.push(text);
     }
   }
   return memories;
-}
+});
 
 function legacyMessageText(value: unknown): string | undefined {
   if (!isJsonObject(value)) {
@@ -2126,65 +2160,80 @@ function isLegacyThreadnoteMemory(text: string): boolean {
   return text.startsWith('MEMORY\n') || text.startsWith('HANDOFF\n');
 }
 
-async function existingDurableMemoryHashes(config: RuntimeConfig): Promise<Set<string>> {
+const existingDurableMemoryHashes = Effect.fn('memory.existingDurableMemoryHashes')(function* (config: RuntimeConfig) {
   const hashes = new Set<string>();
-  await collectDurableMemoryHashes(localVikingDataRoot(config), hashes);
+  yield* collectDurableMemoryHashes(yield* localVikingDataRoot(config), hashes);
   return hashes;
-}
+});
 
-async function collectDurableMemoryHashes(root: string, hashes: Set<string>): Promise<void> {
-  let entries;
-  try {
-    entries = await readdir(root, {withFileTypes: true});
-  } catch (_err: unknown) {
+const collectDurableMemoryHashes: (
+  root: string,
+  hashes: Set<string>,
+) => Effect.Effect<void, unknown, Crypto.Crypto | FileSystem.FileSystem | Path.Path> = Effect.fn(
+  'memory.collectDurableMemoryHashes',
+)(function* (root: string, hashes: Set<string>) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const entries = yield* fs.readDirectory(root).pipe(Effect.option);
+  if (entries._tag === 'None') {
     return;
   }
-  for (const entry of entries) {
-    const path = join(root, entry.name);
-    if (entry.isDirectory()) {
-      await collectDurableMemoryHashes(path, hashes);
+  for (const entry of entries.value) {
+    const entryPath = path.join(root, entry);
+    const info = yield* fs.stat(entryPath).pipe(Effect.option);
+    if (info._tag === 'None') {
       continue;
     }
-    if (!entry.isFile() || entry.name.startsWith('.') || !entry.name.endsWith('.md') || !isDurableMemoryPath(path)) {
+    if (info.value.type === 'Directory') {
+      yield* collectDurableMemoryHashes(entryPath, hashes);
       continue;
     }
-    const content = await readTextIfExists(path);
+    if (
+      info.value.type !== 'File' ||
+      entry.startsWith('.') ||
+      !entry.endsWith('.md') ||
+      !isDurableMemoryPath(entryPath)
+    ) {
+      continue;
+    }
+    const content = yield* readTextIfExists(entryPath);
     if (content) {
       const trimmedContent = content.trim();
-      hashes.add(sha256(trimmedContent));
-      hashes.add(sha256(comparableMemoryText(trimmedContent)));
+      hashes.add(yield* sha256(trimmedContent));
+      hashes.add(yield* sha256(comparableMemoryText(trimmedContent)));
     }
   }
-}
+});
 
 function isDurableMemoryPath(path: string): boolean {
-  return path.split(sep).includes('memories');
+  return path.replaceAll('\\', '/').split('/').includes('memories');
 }
 
-async function childDirectoryNames(path: string): Promise<readonly string[]> {
-  let entries;
-  try {
-    entries = await readdir(path, {withFileTypes: true});
-  } catch (_err: unknown) {
+const childDirectoryNames = Effect.fn('memory.childDirectoryNames')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const entries = yield* fs.readDirectory(path).pipe(Effect.option);
+  if (entries._tag === 'None') {
     return [];
   }
-  return entries
-    .filter(entry => entry.isDirectory())
-    .map(entry => entry.name)
-    .sort();
-}
-
-async function readTextIfExists(path: string): Promise<string | undefined> {
-  try {
-    const pathStat = await stat(path);
-    if (!pathStat.isFile()) {
-      return undefined;
+  const directories: string[] = [];
+  for (const entry of entries.value) {
+    const info = yield* fs.stat(pathService.join(path, entry)).pipe(Effect.option);
+    if (info._tag === 'Some' && info.value.type === 'Directory') {
+      directories.push(entry);
     }
-    return await readFile(path, 'utf8');
-  } catch (_err: unknown) {
+  }
+  return directories.sort();
+});
+
+const readTextIfExists = Effect.fn('memory.readTextIfExists')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const info = yield* fs.stat(path).pipe(Effect.option);
+  if (info._tag === 'None' || info.value.type !== 'File') {
     return undefined;
   }
-}
+  return yield* fs.readFileString(path).pipe(Effect.catch(() => Effect.succeed(undefined)));
+});
 
 function sensitiveMemoryReason(text: string): string | undefined {
   const patterns: readonly {readonly name: string; readonly regex: RegExp}[] = [
@@ -2210,13 +2259,15 @@ function legacySourceLabel(candidate: LegacyMemoryCandidate): string {
   return `${candidate.sourceAccount}/${candidate.sourceSession}/${candidate.sourceArchive}`;
 }
 
-function localVikingDataRoot(config: RuntimeConfig): string {
-  return join(config.agentContextHome, 'data', 'viking');
-}
+const localVikingDataRoot = Effect.fn('memory.localVikingDataRoot')(function* (config: RuntimeConfig) {
+  const path = yield* Path.Path;
+  return path.join(config.agentContextHome, 'data', 'viking');
+});
 
-function localUserMemoriesRoot(config: RuntimeConfig): string {
-  return join(localVikingDataRoot(config), config.account, 'user', uriSegment(config.user), 'memories');
-}
+const localUserMemoriesRoot = Effect.fn('memory.localUserMemoriesRoot')(function* (config: RuntimeConfig) {
+  const path = yield* Path.Path;
+  return path.join(yield* localVikingDataRoot(config), config.account, 'user', uriSegment(config.user), 'memories');
+});
 
 function uniqueStrings(values: readonly string[]): readonly string[] {
   return [...new Set(values)].sort();
@@ -2249,16 +2300,15 @@ function normalizeReferenceUris(references: readonly string[] | undefined): read
   return seen.size > 0 ? [...seen] : undefined;
 }
 
-async function buildHandoff(
-  options: HandoffOptions,
-): Promise<{readonly bodyText: string; readonly metadata: MemoryMetadata}> {
-  const repoRoot = (await gitValue(['rev-parse', '--show-toplevel'])) ?? getInvocationCwd();
-  const branch = (await gitValue(['branch', '--show-current'], repoRoot)) ?? 'unknown';
-  const commit = (await gitValue(['rev-parse', 'HEAD'], repoRoot)) ?? 'unknown';
-  const status = (await gitValue(['status', '--short'], repoRoot)) ?? '';
-  const diffStat = (await gitValue(['diff', '--stat', 'HEAD'], repoRoot)) ?? '';
-  const touchedFiles = await gitTouchedFiles(repoRoot);
-  const repoName = (await resolveRepoName(repoRoot)) ?? basename(repoRoot);
+const buildHandoff = Effect.fn('memory.buildHandoff')(function* (options: HandoffOptions) {
+  const path = yield* Path.Path;
+  const repoRoot = (yield* gitValue(['rev-parse', '--show-toplevel'])) ?? (yield* getInvocationCwd());
+  const branch = (yield* gitValue(['branch', '--show-current'], repoRoot)) ?? 'unknown';
+  const commit = (yield* gitValue(['rev-parse', 'HEAD'], repoRoot)) ?? 'unknown';
+  const status = (yield* gitValue(['status', '--short'], repoRoot)) ?? '';
+  const diffStat = (yield* gitValue(['diff', '--stat', 'HEAD'], repoRoot)) ?? '';
+  const touchedFiles = yield* gitTouchedFiles(repoRoot);
+  const repoName = (yield* resolveRepoName(repoRoot)) ?? path.basename(repoRoot);
   const topicBranch = branch && branch !== 'unknown' ? branch : 'current';
   const metadata: MemoryMetadata = {
     kind: 'handoff',
@@ -2306,11 +2356,11 @@ async function buildHandoff(
     ...(options.trace ? ['', 'trace (auto-captured, heuristic):', options.trace] : []),
   ].join('\n');
   return {bodyText, metadata};
-}
+});
 
-async function gitTouchedFiles(cwd: string): Promise<string> {
-  const changedFiles = await gitValue(['diff', '--name-only', 'HEAD'], cwd);
-  const untrackedFiles = await gitValue(['ls-files', '--others', '--exclude-standard'], cwd);
+const gitTouchedFiles = Effect.fn('memory.gitTouchedFiles')(function* (cwd: string) {
+  const changedFiles = yield* gitValue(['diff', '--name-only', 'HEAD'], cwd);
+  const untrackedFiles = yield* gitValue(['ls-files', '--others', '--exclude-standard'], cwd);
   const files = new Set<string>();
   for (const value of [changedFiles, untrackedFiles]) {
     for (const line of (value ?? '').split('\n')) {
@@ -2321,7 +2371,7 @@ async function gitTouchedFiles(cwd: string): Promise<string> {
     }
   }
   return [...files].sort().join('\n');
-}
+});
 
 function formatBlock(value: string, emptyValue: string): string {
   const trimmed = value.trim();

--- a/src/memory_hygiene.ts
+++ b/src/memory_hygiene.ts
@@ -1,4 +1,3 @@
-import {basename} from 'node:path';
 import {uriSegment} from './manifest.js';
 import {
   formatMemoryDocument,
@@ -406,7 +405,7 @@ function branchFromBody(body: string): string | undefined {
 }
 
 function topicFromUri(uri: string): string | undefined {
-  const name = basename(uri).replace(/\.md$/, '');
+  const name = uriBasename(uri).replace(/\.md$/, '');
   return name.startsWith('threadnote-') ? undefined : name;
 }
 
@@ -440,7 +439,11 @@ function preferredKeepRecord(records: readonly MemoryRecord[], topic?: string): 
 
 function isStableRecord(record: MemoryRecord, topic?: string): boolean {
   const recordTopic = topic ?? topicForRecord(record);
-  return recordTopic !== undefined && basename(record.uri) === `${uriSegment(recordTopic)}.md`;
+  return recordTopic !== undefined && uriBasename(record.uri) === `${uriSegment(recordTopic)}.md`;
+}
+
+function uriBasename(uri: string): string {
+  return uri.replaceAll('\\', '/').split('/').at(-1) ?? uri;
 }
 
 function sortedNewestFirst<T extends MemoryRecord>(records: readonly T[]): readonly T[] {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,3 +1,4 @@
+import {Effect} from 'effect';
 import {readSeedManifest} from './manifest.js';
 import type {McpToolset} from './mcp_toolset.js';
 import {readTeamsFile} from './share.js';
@@ -26,27 +27,24 @@ export interface OnboardingState {
 // Reads the local, cheap pieces of onboarding state (configured share teams and
 // seeded projects). Server health is probed separately by the caller, since that
 // requires the OpenViking adapter the MCP server owns.
-export async function gatherOnboardingContext(
-  config: OnboardingConfig,
-): Promise<Pick<OnboardingState, 'seededProjects' | 'teams'>> {
-  return {seededProjects: await safeSeededProjects(config), teams: await safeTeams(config)};
-}
+export const gatherOnboardingContext = Effect.fn('onboarding.gatherContext')(function* (config: OnboardingConfig) {
+  const [seededProjects, teams] = yield* Effect.all([safeSeededProjects(config), safeTeams(config)]);
+  return {seededProjects, teams};
+});
 
-async function safeTeams(config: OnboardingConfig): Promise<readonly string[]> {
-  try {
-    return Object.keys((await readTeamsFile(config)).teams ?? {}).sort();
-  } catch (_err: unknown) {
-    return [];
-  }
-}
+const safeTeams = Effect.fn('onboarding.safeTeams')((config: OnboardingConfig) =>
+  readTeamsFile(config).pipe(
+    Effect.map(file => Object.keys(file.teams ?? {}).sort()),
+    Effect.catch(() => Effect.succeed([])),
+  ),
+);
 
-async function safeSeededProjects(config: OnboardingConfig): Promise<readonly string[]> {
-  try {
-    return (await readSeedManifest(config.manifestPath)).projects.map(project => project.name);
-  } catch (_err: unknown) {
-    return [];
-  }
-}
+const safeSeededProjects = Effect.fn('onboarding.safeSeededProjects')((config: OnboardingConfig) =>
+  readSeedManifest(config.manifestPath).pipe(
+    Effect.map(manifest => manifest.projects.map(project => project.name)),
+    Effect.catch(() => Effect.succeed([])),
+  ),
+);
 
 // Builds the agent-facing onboarding walkthrough. Pure and deterministic so it is
 // unit-testable without the MCP/OpenViking plumbing. The text is instructions FOR

--- a/src/recall/feedback.ts
+++ b/src/recall/feedback.ts
@@ -1,4 +1,4 @@
-import {Crypto, Effect, FileSystem, Path} from 'effect';
+import {Crypto, Effect, FileSystem, Option, Path} from 'effect';
 import {sha256Hex} from '../effect/digest.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
 import {RECALL_RANKER_VERSION} from './rank.js';
@@ -176,28 +176,24 @@ function parseFeedbackEvent(line: string): RecallFeedbackEvent | undefined {
   if (!line.trim()) {
     return undefined;
   }
-  try {
-    const value: unknown = JSON.parse(line);
-    if (
-      typeof value !== 'object' ||
-      value === null ||
-      !('version' in value) ||
-      value.version !== 1 ||
-      !('action' in value) ||
-      !isFeedbackAction(value.action) ||
-      !('queryFingerprint' in value) ||
-      typeof value.queryFingerprint !== 'string' ||
-      !('timestamp' in value) ||
-      typeof value.timestamp !== 'string' ||
-      !('uri' in value) ||
-      typeof value.uri !== 'string'
-    ) {
-      return undefined;
-    }
-    return value as RecallFeedbackEvent;
-  } catch {
+  const value = Option.getOrUndefined(Option.liftThrowable((content: string): unknown => JSON.parse(content))(line));
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('version' in value) ||
+    value.version !== 1 ||
+    !('action' in value) ||
+    !isFeedbackAction(value.action) ||
+    !('queryFingerprint' in value) ||
+    typeof value.queryFingerprint !== 'string' ||
+    !('timestamp' in value) ||
+    typeof value.timestamp !== 'string' ||
+    !('uri' in value) ||
+    typeof value.uri !== 'string'
+  ) {
     return undefined;
   }
+  return value as RecallFeedbackEvent;
 }
 
 function isFeedbackAction(value: unknown): value is RecallFeedbackAction {

--- a/src/recall/index.ts
+++ b/src/recall/index.ts
@@ -2,6 +2,7 @@ import {Clock, Crypto, Effect, FileSystem, Option, Path} from 'effect';
 import {SEED_STATE_FILE} from '../constants.js';
 import {sha256Hex} from '../effect/digest.js';
 import {scanFilesWithinBoundary} from '../effect/safe_scan.js';
+import {SystemInfo} from '../effect/system.js';
 import {parseSeedManifest, uriSegment} from '../manifest.js';
 import {
   boundedMemoryAuthority,
@@ -671,23 +672,18 @@ function readCache(
       return undefined;
     }
     const raw = yield* fs.readFileString(path);
-    return yield* Effect.sync(() => {
-      try {
-        const parsed = parseCache(JSON.parse(raw));
-        if (parsed) {
-          decodedCacheByPath.set(path, parsed);
-        }
-        return parsed;
-      } catch {
-        return undefined;
-      }
-    });
+    const value = Option.getOrUndefined(Option.liftThrowable((content: string): unknown => JSON.parse(content))(raw));
+    const parsed = parseCache(value);
+    if (parsed) {
+      decodedCacheByPath.set(path, parsed);
+    }
+    return parsed;
   });
 }
 
 function loadCanonicalResourcePolicy(
   config: RecallIndexConfig,
-): Effect.Effect<CanonicalResourcePolicy, never, Crypto.Crypto | FileSystem.FileSystem | Path.Path> {
+): Effect.Effect<CanonicalResourcePolicy, never, Crypto.Crypto | FileSystem.FileSystem | Path.Path | SystemInfo> {
   if (!config.manifestPath) {
     return Effect.succeed({entryKeyByUri: new Map(), sourcePathByUri: new Map()});
   }
@@ -721,7 +717,7 @@ function loadCanonicalResourcePolicy(
         yield* sha256Hex(
           JSON.stringify({
             project: {
-              path: expandPath(match.project.path),
+              path: yield* expandPath(match.project.path),
               seed: [...match.project.seed],
               uri: normalizedResourceRoot(match.project.uri),
             },
@@ -779,14 +775,14 @@ function resolveSeededResourceSource(
   projects: readonly ProjectManifest[],
   uri: string,
   recorded: SeedStateEntry,
-): Effect.Effect<string | undefined, never, Path.Path> {
+): Effect.Effect<string | undefined, never, Path.Path | SystemInfo> {
   return Effect.gen(function* () {
     const pathService = yield* Path.Path;
     const match = seededResourceMatch(projects, uri);
     if (!match) {
       return undefined;
     }
-    const projectRoot = expandPath(match.project.path);
+    const projectRoot = yield* expandPath(match.project.path);
     const sourcePath = pathService.join(projectRoot, ...match.relativePath.split('/'));
     const relativeSourcePath = pathService.relative(projectRoot, sourcePath);
     if (

--- a/src/recall/runtime.ts
+++ b/src/recall/runtime.ts
@@ -11,7 +11,7 @@ interface RecallRuntimeConfig {
   readonly user: string;
 }
 
-interface PrepareRecallSectionsInput {
+interface PrepareRecallSectionsInput<R> {
   readonly allowExactRescue: boolean;
   readonly allowedUriScopes?: readonly string[];
   readonly exactMatches: readonly ExactMatch[];
@@ -22,7 +22,7 @@ interface PrepareRecallSectionsInput {
   readonly passes: ReadonlyArray<readonly RecallHit[]>;
   readonly project?: string;
   readonly query: string;
-  readonly readRecords: (uris: readonly string[]) => Effect.Effect<readonly MemoryRecord[], unknown>;
+  readonly readRecords: (uris: readonly string[]) => Effect.Effect<readonly MemoryRecord[], unknown, R>;
   readonly seedUris?: readonly string[];
 }
 
@@ -34,9 +34,9 @@ const INDEX_CANDIDATE_MINIMUM = 100;
  * responsible for their search passes and rendering, while record hydration,
  * feedback, local-index loading, and hybrid ranking follow one implementation.
  */
-export const prepareRecallSections = Effect.fn('recall.prepareSections')(function* (
+export const prepareRecallSections = Effect.fn('recall.prepareSections')(function* <R>(
   config: RecallRuntimeConfig,
-  input: PrepareRecallSectionsInput,
+  input: PrepareRecallSectionsInput<R>,
 ) {
   const rankingUris = [
     ...new Set([

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,4 @@
-import {existsSync} from 'node:fs';
-import {userInfo} from 'node:os';
-import {join} from 'node:path';
+import {Effect, FileSystem, Path} from 'effect';
 import {
   DEFAULT_ACCOUNT,
   DEFAULT_AGENT_ID,
@@ -11,6 +9,7 @@ import {
 } from './constants.js';
 import type {RuntimeConfig} from './types.js';
 import {expandPath, parsePort, toolRoot} from './utils.js';
+import {SystemInfo} from './effect/system.js';
 
 export interface RuntimeOptions {
   readonly home?: string;
@@ -19,43 +18,59 @@ export interface RuntimeOptions {
   readonly port?: number;
 }
 
-export function getRuntimeConfig(options: RuntimeOptions = {}, manifestOverride?: string): RuntimeConfig {
-  const threadnoteHome = expandPath(options.home ?? process.env.THREADNOTE_HOME ?? '~/.openviking');
-  const manifestPath = expandPath(
-    manifestOverride ?? options.manifest ?? process.env.THREADNOTE_MANIFEST ?? defaultManifestPath(threadnoteHome),
-  );
+export const getRuntimeConfig = Effect.fn('runtime.getRuntimeConfig')(function* (
+  options: RuntimeOptions = {},
+  manifestOverride?: string,
+) {
+  const system = yield* SystemInfo;
+  const environment = system.environment();
+  const threadnoteHome = yield* expandPath(options.home ?? environment.THREADNOTE_HOME ?? '~/.openviking');
+  const configuredManifest = manifestOverride ?? options.manifest ?? environment.THREADNOTE_MANIFEST;
+  const manifestPath = yield* expandPath(configuredManifest ?? (yield* defaultManifestPath(threadnoteHome)));
   return {
-    account: process.env.THREADNOTE_ACCOUNT ?? DEFAULT_ACCOUNT,
+    account: environment.THREADNOTE_ACCOUNT ?? DEFAULT_ACCOUNT,
     agentContextHome: threadnoteHome,
-    agentId: process.env.THREADNOTE_AGENT_ID ?? DEFAULT_AGENT_ID,
-    host: options.host ?? process.env.THREADNOTE_HOST ?? DEFAULT_HOST,
+    agentId: environment.THREADNOTE_AGENT_ID ?? DEFAULT_AGENT_ID,
+    host: options.host ?? environment.THREADNOTE_HOST ?? DEFAULT_HOST,
     manifestPath,
-    openVikingVersion: process.env.THREADNOTE_OPENVIKING_VERSION ?? DEFAULT_OPENVIKING_VERSION,
-    port: options.port ?? parsePort(process.env.THREADNOTE_PORT ?? String(DEFAULT_PORT)),
-    user: process.env.THREADNOTE_USER ?? userInfo().username,
+    openVikingVersion: environment.THREADNOTE_OPENVIKING_VERSION ?? DEFAULT_OPENVIKING_VERSION,
+    port: options.port ?? parsePort(environment.THREADNOTE_PORT ?? String(DEFAULT_PORT)),
+    user: environment.THREADNOTE_USER ?? system.userName,
   };
-}
+});
 
-export function defaultManifestPath(agentContextHome: string): string {
-  const userManifest = join(agentContextHome, USER_MANIFEST_NAME);
-  return existsSync(userManifest) ? userManifest : builtInExampleManifestPath();
-}
+export const defaultManifestPath = Effect.fn('runtime.defaultManifestPath')(function* (agentContextHome: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const userManifest = pathService.join(agentContextHome, USER_MANIFEST_NAME);
+  return (yield* fs.exists(userManifest)) ? userManifest : yield* builtInExampleManifestPath();
+});
 
-export function builtInExampleManifestPath(): string {
-  return join(toolRoot(), 'config', 'seed-manifest.example.yaml');
-}
+export const builtInExampleManifestPath = Effect.fn('runtime.builtInExampleManifestPath')(function* () {
+  const pathService = yield* Path.Path;
+  return pathService.join(yield* toolRoot(), 'config', 'seed-manifest.example.yaml');
+});
 
 export function openVikingHealthUrl(config: RuntimeConfig): string {
   return `http://${config.host}:${config.port}/health`;
 }
 
-export function openVikingLogPath(config: RuntimeConfig): string {
-  return join(config.agentContextHome, 'logs', 'server.log');
-}
+export const openVikingLogPath = Effect.fn('runtime.openVikingLogPath')(function* (config: RuntimeConfig) {
+  const pathService = yield* Path.Path;
+  return pathService.join(config.agentContextHome, 'logs', 'server.log');
+});
 
-export function openVikingServerArgs(config: RuntimeConfig): readonly string[] {
-  return ['--config', join(config.agentContextHome, 'ov.conf'), '--host', config.host, '--port', String(config.port)];
-}
+export const openVikingServerArgs = Effect.fn('runtime.openVikingServerArgs')(function* (config: RuntimeConfig) {
+  const pathService = yield* Path.Path;
+  return [
+    '--config',
+    pathService.join(config.agentContextHome, 'ov.conf'),
+    '--host',
+    config.host,
+    '--port',
+    String(config.port),
+  ];
+});
 
 export interface AgentIdentity {
   readonly account: string;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -91,18 +91,35 @@ export function renderTemplate(
   config: RuntimeConfig,
   extras: Readonly<Record<string, string>> = {},
 ): string {
+  return renderTemplateWith(config, extras, value => value, template);
+}
+
+export function renderJsonTemplate(
+  template: string,
+  config: RuntimeConfig,
+  extras: Readonly<Record<string, string>> = {},
+): string {
+  return renderTemplateWith(config, extras, value => JSON.stringify(value).slice(1, -1), template);
+}
+
+function renderTemplateWith(
+  config: RuntimeConfig,
+  extras: Readonly<Record<string, string>>,
+  encode: (value: string) => string,
+  template: string,
+): string {
   let rendered = template
-    .replaceAll('{{THREADNOTE_HOME}}', config.agentContextHome)
-    .replaceAll('{{OPENVIKING_ACCOUNT}}', config.account)
-    .replaceAll('{{OPENVIKING_AGENT_ID}}', config.agentId)
-    .replaceAll('{{OPENVIKING_HOST}}', config.host)
+    .replaceAll('{{THREADNOTE_HOME}}', () => encode(config.agentContextHome))
+    .replaceAll('{{OPENVIKING_ACCOUNT}}', () => encode(config.account))
+    .replaceAll('{{OPENVIKING_AGENT_ID}}', () => encode(config.agentId))
+    .replaceAll('{{OPENVIKING_HOST}}', () => encode(config.host))
     .replaceAll('{{OPENVIKING_PORT}}', String(config.port))
-    .replaceAll('{{OPENVIKING_USER}}', config.user);
+    .replaceAll('{{OPENVIKING_USER}}', () => encode(config.user));
   for (const [key, value] of Object.entries(extras)) {
     // Replacement is a literal string — use the function form to bypass
     // String.replaceAll's $-pattern interpretation, so absolute paths
     // containing characters like `$&` render correctly.
-    rendered = rendered.replaceAll(`{{${key}}}`, () => value);
+    rendered = rendered.replaceAll(`{{${key}}}`, () => encode(value));
   }
   return rendered;
 }

--- a/src/seeding.ts
+++ b/src/seeding.ts
@@ -1,6 +1,4 @@
-import {chmod, readFile, realpath, stat, writeFile} from 'node:fs/promises';
-import {basename, dirname, join, relative} from 'node:path';
-import {Console, Effect, FileSystem} from 'effect';
+import {Console, Effect, FileSystem, Option, Path, Result} from 'effect';
 import yaml from 'js-yaml';
 import {
   DEFAULT_SEED_PATTERNS,
@@ -11,8 +9,8 @@ import {
 } from './constants.js';
 import {buildGraphDocument, type DependencyFacts, extractDependencyFacts, resolveGraphEdges} from './graph.js';
 import {maybeRunEffect} from './effect/command.js';
-import {consoleOutput} from './effect/console.js';
-import {applicationError, fromPromise} from './effect/errors.js';
+import {applicationError} from './effect/errors.js';
+import {SystemInfo} from './effect/system.js';
 import {readSeedManifest, uriSegment} from './manifest.js';
 import {withIdentity} from './runtime.js';
 import {detectSecretMatches} from './scrubber.js';
@@ -27,7 +25,6 @@ import type {
 } from './types.js';
 import {
   ensureDirectory,
-  errorMessage,
   exists,
   expandPath,
   getGlobBase,
@@ -51,6 +48,7 @@ import {
 
 interface SeedStateEntry {
   readonly mtimeMs: number;
+  readonly sha256?: string;
   readonly size: number;
 }
 
@@ -98,11 +96,13 @@ const log = Console.log;
 export function runSeed(config: RuntimeConfig, options: SeedOptions) {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const manifest = yield* fromPromise('read seed manifest', () => readSeedManifest(config.manifestPath));
-    const ignorePatterns = yield* fromPromise('read seed ignore patterns', loadIgnorePatterns);
-    const ov = yield* fromPromise('find OpenViking CLI for seed', () => openVikingCliForMode(options.dryRun === true));
-    const watchIntervalMinutes = parseSeedWatchIntervalMinutes(process.env[SEED_WATCH_INTERVAL_ENV]);
-    const statePath = join(config.agentContextHome, SEED_STATE_FILE);
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
+    const manifest = yield* readSeedManifest(config.manifestPath);
+    const ignorePatterns = yield* loadIgnorePatterns();
+    const ov = yield* openVikingCliForMode(options.dryRun === true);
+    const watchIntervalMinutes = parseSeedWatchIntervalMinutes(system.environment()[SEED_WATCH_INTERVAL_ENV]);
+    const statePath = path.join(config.agentContextHome, SEED_STATE_FILE);
     const state: {files: Record<string, SeedStateEntry>; version: 1} =
       options.force === true ? {files: {}, version: 1} : yield* readSeedState(statePath);
     const projects = yield* Effect.try({
@@ -114,25 +114,27 @@ export function runSeed(config: RuntimeConfig, options: SeedOptions) {
     let unchangedCount = 0;
 
     for (const project of projects) {
-      const projectRoot = expandPath(project.path);
+      const projectRoot = yield* expandPath(project.path);
       if (!(yield* fs.exists(projectRoot))) {
         yield* log(`WARN project missing: ${project.name} (${projectRoot})`);
         continue;
       }
 
-      const candidates = yield* fromPromise('collect seed candidates', () =>
-        collectSeedCandidates(project, projectRoot, ignorePatterns),
-      );
+      const candidates = yield* collectSeedCandidates(project, projectRoot, ignorePatterns);
       for (const candidate of candidates) {
         const fileStat = yield* statSeedFile(candidate.filePath);
         const recorded = state.files[candidate.destinationUri];
-        if (fileStat && recorded && recorded.mtimeMs === fileStat.mtimeMs && recorded.size === fileStat.size) {
+        if (
+          fileStat &&
+          recorded &&
+          recorded.mtimeMs === fileStat.mtimeMs &&
+          recorded.size === fileStat.size &&
+          recorded.sha256 === fileStat.sha256
+        ) {
           unchangedCount += 1;
           continue;
         }
-        const importPath = yield* fromPromise('prepare seed file', () =>
-          prepareSeedFile(config, candidate, options.dryRun === true),
-        );
+        const importPath = yield* prepareSeedFile(config, candidate, options.dryRun === true);
         if (!importPath) {
           skippedCount += 1;
           continue;
@@ -152,7 +154,7 @@ export function runSeed(config: RuntimeConfig, options: SeedOptions) {
         yield* maybeRunEffect(options.dryRun === true, ov, args);
         importedCount += 1;
         if (fileStat && options.dryRun !== true) {
-          state.files[candidate.destinationUri] = {mtimeMs: fileStat.mtimeMs, size: fileStat.size};
+          state.files[candidate.destinationUri] = fileStat;
         }
       }
     }
@@ -187,9 +189,10 @@ export function seedDependencyGraphs(
 ) {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
     const factsByProject = new Map<string, DependencyFacts>();
     for (const project of manifest.projects) {
-      const projectRoot = expandPath(project.path);
+      const projectRoot = yield* expandPath(project.path);
       if (!(yield* fs.exists(projectRoot))) {
         continue;
       }
@@ -231,8 +234,8 @@ export function seedDependencyGraphs(
         written += 1;
         continue;
       }
-      const graphPath = join(config.agentContextHome, 'graph', graphCacheFileName(project.name));
-      yield* fs.makeDirectory(dirname(graphPath), {recursive: true});
+      const graphPath = path.join(config.agentContextHome, 'graph', yield* graphCacheFileName(project.name));
+      yield* fs.makeDirectory(path.dirname(graphPath), {recursive: true});
       yield* fs.writeFileString(graphPath, document, {mode: 0o600});
       yield* fs.chmod(graphPath, 0o600);
       yield* maybeRunEffect(
@@ -266,13 +269,17 @@ function filterProjects(
 }
 
 function statSeedFile(path: string) {
-  return fromPromise('stat seed file', () => stat(path)).pipe(
-    Effect.map(result => ({mtimeMs: result.mtimeMs, size: result.size})),
-    Effect.catchIf(
-      error => (error.cause as NodeJS.ErrnoException | undefined)?.code === 'ENOENT',
-      () => Effect.succeed(undefined),
-    ),
-  );
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const info = yield* fs.stat(path).pipe(Effect.option);
+    return info._tag === 'Some'
+      ? {
+          mtimeMs: Option.getOrElse(info.value.mtime, () => new Date(0)).getTime(),
+          sha256: yield* sha256(yield* fs.readFile(path)),
+          size: Number(info.value.size),
+        }
+      : undefined;
+  });
 }
 
 function readSeedState(path: string) {
@@ -287,28 +294,33 @@ function readSeedState(path: string) {
     if (raw === undefined) {
       return {files: {}, version: 1} as const;
     }
-    try {
-      const parsed = JSON.parse(raw) as Partial<SeedStateFile>;
-      if (parsed.version !== 1 || !isJsonObject(parsed.files)) {
-        return {files: {}, version: 1} as const;
-      }
-      const files: Record<string, SeedStateEntry> = {};
-      for (const [uri, entry] of Object.entries(parsed.files)) {
-        if (isJsonObject(entry) && typeof entry.mtimeMs === 'number' && typeof entry.size === 'number') {
-          files[uri] = {mtimeMs: entry.mtimeMs, size: entry.size};
-        }
-      }
-      return {files, version: 1 as const};
-    } catch (_err: unknown) {
+    const parsedResult = Result.try(() => JSON.parse(raw) as Partial<SeedStateFile>);
+    if (Result.isFailure(parsedResult)) {
       return {files: {}, version: 1} as const;
     }
+    const parsed = parsedResult.success;
+    if (parsed.version !== 1 || !isJsonObject(parsed.files)) {
+      return {files: {}, version: 1} as const;
+    }
+    const files: Record<string, SeedStateEntry> = {};
+    for (const [uri, entry] of Object.entries(parsed.files)) {
+      if (isJsonObject(entry) && typeof entry.mtimeMs === 'number' && typeof entry.size === 'number') {
+        files[uri] = {
+          mtimeMs: entry.mtimeMs,
+          sha256: typeof entry.sha256 === 'string' ? entry.sha256 : undefined,
+          size: entry.size,
+        };
+      }
+    }
+    return {files, version: 1 as const};
   });
 }
 
 function writeSeedState(path: string, state: SeedStateFile) {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    yield* fs.makeDirectory(dirname(path), {recursive: true});
+    const pathService = yield* Path.Path;
+    yield* fs.makeDirectory(pathService.dirname(path), {recursive: true});
     yield* fs.writeFileString(path, `${JSON.stringify(state, undefined, 2)}\n`, {mode: 0o600});
   });
 }
@@ -316,33 +328,33 @@ function writeSeedState(path: string, state: SeedStateFile) {
 export function runInitManifest(config: RuntimeConfig, options: InitManifestOptions) {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const manifestPath = expandPath(
-      options.path ?? process.env.THREADNOTE_MANIFEST ?? join(config.agentContextHome, USER_MANIFEST_NAME),
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
+    const manifestPath = yield* expandPath(
+      options.path ??
+        system.environment().THREADNOTE_MANIFEST ??
+        path.join(config.agentContextHome, USER_MANIFEST_NAME),
     );
-    const repoInputs = options.repo && options.repo.length > 0 ? options.repo : [getInvocationCwd()];
+    const repoInputs = options.repo && options.repo.length > 0 ? options.repo : [yield* getInvocationCwd()];
     const existingManifest =
-      options.replace === true || !(yield* fs.exists(manifestPath))
-        ? undefined
-        : yield* fromPromise('read existing seed manifest', () => readSeedManifest(manifestPath));
+      options.replace === true || !(yield* fs.exists(manifestPath)) ? undefined : yield* readSeedManifest(manifestPath);
     const existingProjects = existingManifest?.projects ?? [];
     const projects = [...existingProjects];
     const seen = new Set<string>();
 
     for (const project of existingProjects) {
-      seen.add(yield* fromPromise('resolve project identity', () => projectIdentity(project.path)));
+      seen.add(yield* projectIdentity(project.path));
     }
 
     for (const repoInput of repoInputs) {
-      const repoRoot = yield* fromPromise('resolve repository root', () => resolveRepoRoot(repoInput));
-      const identity = yield* fromPromise('resolve project identity', () => projectIdentity(repoRoot));
+      const repoRoot = yield* resolveRepoRoot(repoInput);
+      const identity = yield* projectIdentity(repoRoot);
       if (seen.has(identity)) {
         yield* log(`Already in manifest: ${repoRoot}`);
         continue;
       }
       seen.add(identity);
-      projects.push(
-        yield* fromPromise('build project manifest entry', () => projectManifestForRepo(repoRoot, projects)),
-      );
+      projects.push(yield* projectManifestForRepo(repoRoot, projects));
     }
 
     const outputManifest: Record<string, unknown> = {
@@ -377,7 +389,7 @@ export function runInitManifest(config: RuntimeConfig, options: InitManifestOpti
       return;
     }
 
-    yield* fs.makeDirectory(dirname(manifestPath), {recursive: true});
+    yield* fs.makeDirectory(path.dirname(manifestPath), {recursive: true});
     yield* fs.writeFileString(manifestPath, output, {mode: 0o600});
     yield* fs.chmod(manifestPath, 0o600);
     yield* log(`Wrote manifest: ${manifestPath}`);
@@ -389,7 +401,7 @@ export function runInitManifest(config: RuntimeConfig, options: InitManifestOpti
 
 export function runWorksetList(config: RuntimeConfig) {
   return Effect.gen(function* () {
-    const manifest = yield* fromPromise('read seed manifest', () => readSeedManifest(config.manifestPath));
+    const manifest = yield* readSeedManifest(config.manifestPath);
     const worksets = manifest.worksets ?? [];
     if (worksets.length === 0) {
       yield* log(
@@ -407,7 +419,7 @@ export function runWorksetList(config: RuntimeConfig) {
 
 export function runWorksetShow(config: RuntimeConfig, name: string) {
   return Effect.gen(function* () {
-    const manifest = yield* fromPromise('read seed manifest', () => readSeedManifest(config.manifestPath));
+    const manifest = yield* readSeedManifest(config.manifestPath);
     const workset = manifest.worksets?.find(entry => entry.name.toLowerCase() === name.toLowerCase());
     if (!workset) {
       return yield* Effect.fail(
@@ -428,10 +440,8 @@ export function runWorksetShow(config: RuntimeConfig, name: string) {
 
 export function runSeedSkills(config: RuntimeConfig, options: SeedOptions) {
   return Effect.gen(function* () {
-    const ov = yield* fromPromise('find OpenViking CLI for skill seed', () =>
-      openVikingCliForMode(options.dryRun === true),
-    );
-    const catalogItems = yield* fromPromise('collect skill candidates', () => collectSkillCandidates(config));
+    const ov = yield* openVikingCliForMode(options.dryRun === true);
+    const catalogItems = yield* collectSkillCandidates(config);
     const nativeMode = options.native === true;
     yield* log(
       nativeMode
@@ -459,55 +469,54 @@ export function runSeedSkills(config: RuntimeConfig, options: SeedOptions) {
   });
 }
 
-export async function resolveRepoRoot(repoInput: string): Promise<string> {
-  const inputPath = expandPath(repoInput);
-  if (!(await isDirectory(inputPath))) {
-    throw new Error(`Repo path is not a directory: ${inputPath}`);
+export const resolveRepoRoot = Effect.fn('seeding.resolveRepoRoot')(function* (repoInput: string) {
+  const inputPath = yield* expandPath(repoInput);
+  if (!(yield* isDirectory(inputPath))) {
+    return yield* Effect.fail(new Error(`Repo path is not a directory: ${inputPath}`));
   }
-  return (await gitValue(['rev-parse', '--show-toplevel'], inputPath)) ?? inputPath;
-}
+  return (yield* gitValue(['rev-parse', '--show-toplevel'], inputPath)) ?? inputPath;
+});
 
-async function projectIdentity(path: string): Promise<string> {
-  const expanded = expandPath(path);
-  try {
-    return await realpath(expanded);
-  } catch (_err: unknown) {
-    return expanded;
-  }
-}
+const projectIdentity = Effect.fn('seeding.projectIdentity')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const expanded = yield* expandPath(path);
+  return yield* fs.realPath(expanded).pipe(Effect.catch(() => Effect.succeed(expanded)));
+});
 
-export async function projectManifestForRepo(
+export const projectManifestForRepo = Effect.fn('seeding.projectManifestForRepo')(function* (
   repoRoot: string,
   existingProjects: readonly ProjectManifest[],
-): Promise<ProjectManifest> {
-  const baseName = uriSegment((await resolveRepoName(repoRoot)) ?? basename(repoRoot));
+) {
+  const path = yield* Path.Path;
+  const baseName = uriSegment((yield* resolveRepoName(repoRoot)) ?? path.basename(repoRoot));
   const usedNames = new Set(existingProjects.map(project => project.name));
   const usedUris = new Set(existingProjects.map(project => project.uri));
   let name = baseName;
   let uri = `viking://resources/repos/${name}`;
   if (usedNames.has(name) || usedUris.has(uri)) {
-    name = `${baseName}-${sha256(repoRoot).slice(0, 8)}`;
+    name = `${baseName}-${(yield* sha256(repoRoot)).slice(0, 8)}`;
     uri = `viking://resources/repos/${name}`;
   }
   return {
     name,
-    path: portablePath(repoRoot),
+    path: yield* portablePath(repoRoot),
     seed: DEFAULT_SEED_PATTERNS,
     uri,
   };
-}
+});
 
-async function collectSeedCandidates(
+const collectSeedCandidates = Effect.fn('seeding.collectSeedCandidates')(function* (
   project: ProjectManifest,
   projectRoot: string,
   ignorePatterns: readonly string[],
-): Promise<readonly SeedCandidate[]> {
+) {
+  const path = yield* Path.Path;
   const candidates: SeedCandidate[] = [];
   const seen = new Set<string>();
   for (const pattern of project.seed) {
-    const files = await resolveProjectPattern(projectRoot, pattern);
+    const files = yield* resolveProjectPattern(projectRoot, pattern);
     for (const filePath of files) {
-      const relativePath = toPosixPath(relative(projectRoot, filePath));
+      const relativePath = toPosixPath(path.relative(projectRoot, filePath));
       if (seen.has(relativePath) || matchesIgnore(relativePath, ignorePatterns)) {
         continue;
       }
@@ -521,38 +530,44 @@ async function collectSeedCandidates(
     }
   }
   return candidates;
-}
+});
 
-async function resolveProjectPattern(projectRoot: string, pattern: string): Promise<readonly string[]> {
+const resolveProjectPattern = Effect.fn('seeding.resolveProjectPattern')(function* (
+  projectRoot: string,
+  pattern: string,
+) {
+  const path = yield* Path.Path;
   const normalizedPattern = toPosixPath(pattern);
   if (!hasGlob(normalizedPattern)) {
-    const filePath = join(projectRoot, normalizedPattern);
-    return (await isFile(filePath)) ? [filePath] : [];
+    const filePath = path.join(projectRoot, normalizedPattern);
+    return (yield* isFile(filePath)) ? [filePath] : [];
   }
 
   const globBase = getGlobBase(normalizedPattern);
-  const basePath = join(projectRoot, globBase);
-  if (!(await exists(basePath))) {
+  const basePath = path.join(projectRoot, globBase);
+  if (!(yield* exists(basePath))) {
     return [];
   }
 
   const regex = globToRegExp(normalizedPattern);
-  const files = await walkFiles(basePath);
-  return files.filter(filePath => regex.test(toPosixPath(relative(projectRoot, filePath))));
-}
+  const files = yield* walkFiles(basePath);
+  return files.filter(filePath => regex.test(toPosixPath(path.relative(projectRoot, filePath))));
+});
 
-async function prepareSeedFile(
+const prepareSeedFile = Effect.fn('seeding.prepareSeedFile')(function* (
   config: RuntimeConfig,
   candidate: SeedCandidate,
   dryRun: boolean,
-): Promise<string | undefined> {
-  const content = await readFile(candidate.filePath, 'utf8');
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const content = yield* fs.readFileString(candidate.filePath);
   const redactedContent = shouldRedactPath(candidate.relativePath)
     ? redactContent(candidate.relativePath, content)
     : content;
   const secretMatches = detectSecretMatches(redactedContent);
   if (secretMatches.length > 0) {
-    consoleOutput.log(
+    yield* Console.log(
       `SKIP ${candidate.projectName}/${candidate.relativePath}: possible secret (${secretMatches
         .slice(0, MAX_SECRET_MATCHES_TO_PRINT)
         .join(', ')})`,
@@ -564,22 +579,23 @@ async function prepareSeedFile(
     return candidate.filePath;
   }
 
-  const redactedPath = join(config.agentContextHome, 'redacted', candidate.projectName, candidate.relativePath);
+  const redactedPath = path.join(config.agentContextHome, 'redacted', candidate.projectName, candidate.relativePath);
   if (dryRun) {
-    consoleOutput.log(`Would write redacted copy: ${redactedPath}`);
+    yield* Console.log(`Would write redacted copy: ${redactedPath}`);
     return redactedPath;
   }
-  await ensureDirectory(dirname(redactedPath), false);
-  await writeFile(redactedPath, redactedContent, {encoding: 'utf8', mode: 0o600});
-  await chmod(redactedPath, 0o600);
+  yield* ensureDirectory(path.dirname(redactedPath), false);
+  yield* fs.writeFileString(redactedPath, redactedContent, {mode: 0o600});
+  yield* fs.chmod(redactedPath, 0o600);
   return redactedPath;
-}
+});
 
-function graphCacheFileName(projectName: string): string {
-  return `${uriSegment(projectName)}-${sha256(projectName).slice(0, 8)}.graph.md`;
-}
+const graphCacheFileName = Effect.fn('seeding.graphCacheFileName')(function* (projectName: string) {
+  return `${uriSegment(projectName)}-${(yield* sha256(projectName)).slice(0, 8)}.graph.md`;
+});
 
-async function collectSkillCandidates(config: RuntimeConfig): Promise<readonly SkillCandidate[]> {
+const collectSkillCandidates = Effect.fn('seeding.collectSkillCandidates')(function* (config: RuntimeConfig) {
+  const fs = yield* FileSystem.FileSystem;
   const sources: Array<{
     readonly kind: SkillCandidate['kind'];
     readonly pattern: string;
@@ -591,9 +607,9 @@ async function collectSkillCandidates(config: RuntimeConfig): Promise<readonly S
     {kind: 'command', pattern: '~/.claude/commands/**/*.md', source: 'claude-commands-global'},
   ];
 
-  try {
-    const manifest = await readSeedManifest(config.manifestPath);
-    for (const project of manifest.projects) {
+  const manifest = yield* readSeedManifest(config.manifestPath).pipe(Effect.option);
+  if (manifest._tag === 'Some') {
+    for (const project of manifest.value.projects) {
       sources.push({
         kind: 'skill',
         pattern: `${project.path}/.claude/skills/**/SKILL.md`,
@@ -605,22 +621,22 @@ async function collectSkillCandidates(config: RuntimeConfig): Promise<readonly S
         source: `repo-local:${project.name}:claude-commands`,
       });
     }
-  } catch (err: unknown) {
-    consoleOutput.log(`WARN cannot read manifest for repo-local skill/command discovery: ${errorMessage(err)}`);
+  } else {
+    yield* Console.log('WARN cannot read manifest for repo-local skill/command discovery.');
   }
 
   const seenHashes = new Set<string>();
   const skills: SkillCandidate[] = [];
   for (const source of sources) {
-    const files = await resolveAbsolutePattern(expandPath(source.pattern));
+    const files = yield* resolveAbsolutePattern(yield* expandPath(source.pattern));
     for (const filePath of files) {
-      const content = await readFile(filePath, 'utf8');
+      const content = yield* fs.readFileString(filePath);
       const matches = detectSecretMatches(content);
       if (matches.length > 0) {
-        consoleOutput.log(`SKIP skill with possible secret: ${filePath}`);
+        yield* Console.log(`SKIP skill with possible secret: ${filePath}`);
         continue;
       }
-      const hash = sha256(content);
+      const hash = yield* sha256(content);
       if (seenHashes.has(hash)) {
         continue;
       }
@@ -629,44 +645,47 @@ async function collectSkillCandidates(config: RuntimeConfig): Promise<readonly S
     }
   }
   return skills;
-}
+});
 
-async function resolveAbsolutePattern(pattern: string): Promise<readonly string[]> {
+const resolveAbsolutePattern = Effect.fn('seeding.resolveAbsolutePattern')(function* (pattern: string) {
   const normalizedPattern = toPosixPath(pattern);
   if (!hasGlob(normalizedPattern)) {
-    return (await isFile(normalizedPattern)) ? [normalizedPattern] : [];
+    return (yield* isFile(normalizedPattern)) ? [normalizedPattern] : [];
   }
   const globBase = getGlobBase(normalizedPattern);
   const basePath = globBase.startsWith('/') ? globBase : `/${globBase}`;
-  if (!(await exists(basePath))) {
+  if (!(yield* exists(basePath))) {
     return [];
   }
   const regex = globToRegExp(normalizedPattern);
-  const files = await walkFiles(basePath);
+  const files = yield* walkFiles(basePath);
   return files.filter(filePath => regex.test(toPosixPath(filePath)));
-}
+});
 
 function skillResourceUri(skill: SkillCandidate): string {
   return `viking://resources/agent-skills/${uriSegment(skill.source)}/${skillResourceName(skill)}-${skill.hash.slice(0, 12)}.md`;
 }
 
 function skillResourceName(skill: SkillCandidate): string {
-  const fileName = basename(skill.filePath);
+  const parts = toPosixPath(skill.filePath).split('/');
+  const fileName = parts.at(-1) ?? skill.filePath;
   if (fileName.toLowerCase() === 'skill.md') {
-    return uriSegment(basename(dirname(skill.filePath)));
+    return uriSegment(parts.at(-2) ?? 'skill');
   }
   const extensionIndex = fileName.lastIndexOf('.');
   const stem = extensionIndex > 0 ? fileName.slice(0, extensionIndex) : fileName;
   return uriSegment(stem);
 }
 
-async function loadIgnorePatterns(): Promise<readonly string[]> {
-  const raw = await readFile(join(toolRoot(), '.threadnoteignore'), 'utf8');
+const loadIgnorePatterns = Effect.fn('seeding.loadIgnorePatterns')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const raw = yield* fs.readFileString(path.join(yield* toolRoot(), '.threadnoteignore'));
   return raw
     .split('\n')
     .map(line => line.trim())
     .filter(line => line.length > 0 && !line.startsWith('#'));
-}
+});
 
 function matchesIgnore(relativePath: string, patterns: readonly string[]): boolean {
   const path = toPosixPath(relativePath);
@@ -698,12 +717,10 @@ function shouldRedactPath(relativePath: string): boolean {
 
 function redactContent(relativePath: string, content: string): string {
   if (relativePath.endsWith('.json')) {
-    try {
-      const parsed: unknown = JSON.parse(content);
-      return `${JSON.stringify(redactJsonValue(parsed), null, 2)}\n`;
-    } catch (_err: unknown) {
-      return redactText(content);
-    }
+    const parsed = Result.try((): unknown => JSON.parse(content));
+    return Result.isSuccess(parsed)
+      ? `${JSON.stringify(redactJsonValue(parsed.success), null, 2)}\n`
+      : redactText(content);
   }
   return redactText(content);
 }

--- a/src/share.ts
+++ b/src/share.ts
@@ -1,14 +1,11 @@
-import {lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile} from 'node:fs/promises';
-import {homedir, tmpdir} from 'node:os';
-import {basename, dirname, isAbsolute, join, relative, sep} from 'node:path';
-import {TextDecoder} from 'node:util';
-import {consoleOutput} from './effect/console.js';
+import {Console, Effect, FileSystem, Option, Path, Result} from 'effect';
+import {CommandExecutor} from './effect/command.js';
+import {SystemInfo} from './effect/system.js';
 import {uriSegment} from './manifest.js';
 import {canonicalMemoryDocumentContent} from './memory_document.js';
 import {withIdentity} from './runtime.js';
 import {applyScrubber, credentialScrubberBlocker, SCRUBBER_PATTERNS} from './scrubber.js';
 import type {
-  CommandResult,
   ShareAgentArtifactAgent,
   ShareAgentArtifactKind,
   ShareConflictOptions,
@@ -86,6 +83,151 @@ export const SHARED_BACKGROUND_FETCH_INTERVAL_MILLISECONDS = 5 * 60 * 1000;
 export const DEFAULT_GIT_REMOTE_NAME = 'origin';
 
 export {applyScrubber, scrubberBlocker} from './scrubber.js';
+
+interface DirectoryEntry {
+  readonly name: string;
+  readonly isDirectory: () => boolean;
+  readonly isFile: () => boolean;
+  readonly isSymbolicLink: () => boolean;
+}
+
+interface PathInfo extends DirectoryEntry {
+  readonly mtime: Date;
+  readonly size: number;
+}
+
+const pathJoin = Effect.fn('share.pathJoin')(function* (...parts: readonly string[]) {
+  const path = yield* Path.Path;
+  return path.join(...parts);
+});
+
+const pathDirname = Effect.fn('share.pathDirname')(function* (value: string) {
+  const path = yield* Path.Path;
+  return path.dirname(value);
+});
+
+const pathBasename = Effect.fn('share.pathBasename')(function* (value: string) {
+  const path = yield* Path.Path;
+  return path.basename(value);
+});
+
+const pathIsAbsolute = Effect.fn('share.pathIsAbsolute')(function* (value: string) {
+  const path = yield* Path.Path;
+  return path.isAbsolute(value);
+});
+
+const pathRelative = Effect.fn('share.pathRelative')(function* (from: string, to: string) {
+  const path = yield* Path.Path;
+  return path.relative(from, to);
+});
+
+const pathSeparator = Effect.map(Path.Path, path => path.sep);
+
+function pathInfo(name: string, info: FileSystem.File.Info, symbolicLink: boolean): PathInfo {
+  return {
+    name,
+    isDirectory: () => !symbolicLink && info.type === 'Directory',
+    isFile: () => !symbolicLink && info.type === 'File',
+    isSymbolicLink: () => symbolicLink,
+    mtime: info.mtime._tag === 'Some' ? info.mtime.value : new Date(0),
+    size: Number(info.size),
+  };
+}
+
+const lstat = Effect.fn('share.lstat')(function* (target: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const link = yield* fs.readLink(target).pipe(Effect.option);
+  const info = yield* fs.stat(target);
+  const path = yield* Path.Path;
+  return pathInfo(path.basename(target), info, link._tag === 'Some');
+});
+
+function readFile(target: string): Effect.Effect<Uint8Array, unknown, FileSystem.FileSystem>;
+function readFile(target: string, encoding: 'utf8'): Effect.Effect<string, unknown, FileSystem.FileSystem>;
+function readFile(
+  target: string,
+  encoding?: 'utf8',
+): Effect.Effect<Uint8Array | string, unknown, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    return encoding ? yield* fs.readFileString(target, encoding) : yield* fs.readFile(target);
+  });
+}
+
+function writeFile(
+  target: string,
+  content: string | Uint8Array,
+  options?: 'utf8' | {readonly encoding?: 'utf8'; readonly mode?: number},
+) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const normalizedOptions = typeof options === 'string' ? undefined : options;
+    if (typeof content === 'string') {
+      yield* fs.writeFileString(target, content, normalizedOptions);
+    } else {
+      yield* fs.writeFile(target, content, normalizedOptions);
+    }
+  });
+}
+
+const mkdir = Effect.fn('share.mkdir')(function* (
+  target: string,
+  options?: {readonly recursive?: boolean; readonly mode?: number},
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.makeDirectory(target, options);
+});
+
+const mkdtemp = Effect.fn('share.mkdtemp')(function* (prefixPath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  return yield* fs.makeTempDirectory({
+    directory: path.dirname(prefixPath),
+    prefix: path.basename(prefixPath),
+  });
+});
+
+function readdir(target: string): Effect.Effect<string[], unknown, FileSystem.FileSystem>;
+function readdir(
+  target: string,
+  options: {readonly withFileTypes: true},
+): Effect.Effect<DirectoryEntry[], unknown, FileSystem.FileSystem | Path.Path>;
+function readdir(
+  target: string,
+  options?: {readonly withFileTypes?: boolean},
+): Effect.Effect<string[] | DirectoryEntry[], unknown, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const names = yield* fs.readDirectory(target);
+    if (options?.withFileTypes !== true) {
+      return names;
+    }
+    return yield* Effect.forEach(names, name =>
+      lstat(path.join(target, name)).pipe(
+        Effect.map(info => ({
+          name,
+          isDirectory: info.isDirectory,
+          isFile: info.isFile,
+          isSymbolicLink: info.isSymbolicLink,
+        })),
+      ),
+    );
+  });
+}
+
+const rename = Effect.fn('share.rename')(function* (from: string, to: string) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.rename(from, to);
+});
+
+const rm = Effect.fn('share.rm')(function* (
+  target: string,
+  options?: {readonly force?: boolean; readonly recursive?: boolean},
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.remove(target, options);
+});
 
 export interface ShareArtifactMetadata {
   readonly agent: ShareAgentArtifactAgent;
@@ -183,7 +325,6 @@ export interface SharedMemoryUriParts {
 interface AutoShareState {
   behindTeams: ReadonlySet<string>;
   lastCheckedAt: number;
-  operationPromise?: Promise<unknown>;
   pendingReindexes: Map<string, readonly ChangedFile[]>;
 }
 
@@ -240,30 +381,34 @@ export function clearAutoShareStateForTest(): void {
   autoShareStates.clear();
 }
 
-export async function runShareInit(config: ShareRuntime, remoteUrl: string, options: ShareInitOptions): Promise<void> {
+export const runShareInit = Effect.fn('share.runShareInit')(function* (
+  config: ShareRuntime,
+  remoteUrl: string,
+  options: ShareInitOptions,
+) {
   if (!remoteUrl.trim()) {
     throw new Error('Provide a git remote URL for the shared memories repo.');
   }
   const dryRun = options.dryRun === true;
   const teamName = normalizeTeamName(options.team);
-  const teamsFile = await readTeamsFile(config);
+  const teamsFile = yield* readTeamsFile(config);
   if (teamsFile.teams[teamName]) {
     throw new Error(
       `Team "${teamName}" is already configured (remote ${teamsFile.teams[teamName].remote}). Remove it first with: threadnote share remove --team ${teamName}`,
     );
   }
-  const worktree = teamWorktreePath(config, teamName);
-  const gitdir = teamGitdirPath(config, teamName);
-  await assertWorktreeUsable(worktree);
-  if (await exists(gitdir)) {
+  const worktree = yield* teamWorktreePath(config, teamName);
+  const gitdir = yield* teamGitdirPath(config, teamName);
+  yield* assertWorktreeUsable(worktree);
+  if (yield* exists(gitdir)) {
     throw new Error(`Gitdir already exists at ${gitdir}; remove it or pick a different team name.`);
   }
 
-  await ensureDirectory(dirname(worktree), dryRun);
-  await ensureDirectory(dirname(gitdir), dryRun);
+  yield* ensureDirectory(yield* pathDirname(worktree), dryRun);
+  yield* ensureDirectory(yield* pathDirname(gitdir), dryRun);
 
-  const git = await requiredExecutable('git');
-  await maybeRun(dryRun, git, [
+  const git = yield* requiredExecutable('git');
+  yield* maybeRun(dryRun, git, [
     'clone',
     '-c',
     'core.symlinks=false',
@@ -286,31 +431,35 @@ export async function runShareInit(config: ShareRuntime, remoteUrl: string, opti
     version: TEAMS_FILE_VERSION,
   };
   if (dryRun) {
-    consoleOutput.log(`Would write teams file: ${teamsFilePath(config)}`);
-    consoleOutput.log(`Would set ${teamName} as default? ${updatedTeams.defaultTeam === teamName}`);
+    yield* Console.log(`Would write teams file: ${yield* teamsFilePath(config)}`);
+    yield* Console.log(`Would set ${teamName} as default? ${updatedTeams.defaultTeam === teamName}`);
   } else {
-    await writeTeamsFile(config, updatedTeams);
-    consoleOutput.log(`Configured shared team "${teamName}" -> ${portablePath(worktree)}`);
+    yield* writeTeamsFile(config, updatedTeams);
+    yield* Console.log(`Configured shared team "${teamName}" -> ${yield* portablePath(worktree)}`);
   }
 
   if (!dryRun) {
-    await ensureSharedGitignore(worktree, git, options.push !== false);
-    const ingested = await ingestWorktreeFiles(config, newConfig, 'create');
-    consoleOutput.log(`Ingested ${ingested} shared file(s) into OpenViking.`);
+    yield* ensureSharedGitignore(worktree, git, options.push !== false);
+    const ingested = yield* ingestWorktreeFiles(config, newConfig, 'create');
+    yield* Console.log(`Ingested ${ingested} shared file(s) into OpenViking.`);
   }
-}
+});
 
 const SHARED_GITIGNORE_PATTERNS = ['**/.abstract.md', '**/.overview.md'];
 const SHARED_GITIGNORE_HEADER = '# Threadnote: ignore OpenViking-generated directory summaries.';
 
-async function ensureSharedGitignore(worktree: string, git: string, push: boolean): Promise<void> {
+const ensureSharedGitignore = Effect.fn('share.ensureSharedGitignore')(function* (
+  worktree: string,
+  git: string,
+  push: boolean,
+) {
   // Idempotently ensure the OpenViking-summary patterns are in the worktree's
   // .gitignore. There's no opt-out: these two patterns describe files that OV
   // writes into every shared directory on every mkdir, are not memories, and
   // would only pollute git history if tracked. Users who insist on tracking
   // them can `git update-index --skip-worktree .gitignore` to suppress this.
-  const gitignorePath = join(worktree, '.gitignore');
-  const existing = (await readFileIfExists(gitignorePath)) ?? '';
+  const gitignorePath = yield* pathJoin(worktree, '.gitignore');
+  const existing = (yield* readFileIfExists(gitignorePath)) ?? '';
   const lines = existing.split('\n').map(line => line.trim());
   const missingPatterns = SHARED_GITIGNORE_PATTERNS.filter(pattern => !lines.includes(pattern));
   if (missingPatterns.length === 0) {
@@ -331,10 +480,10 @@ async function ensureSharedGitignore(worktree: string, git: string, push: boolea
     segments.push(SHARED_GITIGNORE_HEADER, '\n');
   }
   segments.push(missingPatterns.join('\n'), '\n');
-  await writeFile(gitignorePath, `${existing}${segments.join('')}`, {encoding: 'utf8'});
-  consoleOutput.log(`Added ${missingPatterns.join(', ')} to ${portablePath(gitignorePath)}`);
-  await maybeRun(false, git, ['-C', worktree, 'add', '.gitignore']);
-  const commitResult = await runCommand(
+  yield* writeFile(gitignorePath, `${existing}${segments.join('')}`, {encoding: 'utf8'});
+  yield* Console.log(`Added ${missingPatterns.join(', ')} to ${yield* portablePath(gitignorePath)}`);
+  yield* maybeRun(false, git, ['-C', worktree, 'add', '.gitignore']);
+  const commitResult = yield* runCommand(
     git,
     ['-C', worktree, 'commit', '-m', 'share: ignore OpenViking directory summaries'],
     {allowFailure: true},
@@ -342,74 +491,87 @@ async function ensureSharedGitignore(worktree: string, git: string, push: boolea
   if (commitResult.exitCode !== 0) {
     const detail = commitResult.stderr.trim() || commitResult.stdout.trim();
     if (!/nothing to commit|no changes added/i.test(detail)) {
-      consoleOutput.warn(
+      yield* Console.warn(
         `.gitignore housekeeping commit was rejected (${detail || 'unknown'}); it will be retried on the next share sync.`,
       );
       return;
     }
   }
   if (push) {
-    await maybeRun(false, git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME], {allowFailure: true});
+    yield* maybeRun(false, git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME], {allowFailure: true});
   }
-}
+});
 
-export async function runShareStatus(config: ShareRuntime, options: ShareStatusOptions): Promise<void> {
-  const team = await resolveTeam(config, options.team);
-  const git = await requiredExecutable('git');
-  consoleOutput.log(`Team: ${team.name}`);
-  consoleOutput.log(`Remote: ${team.config.remote}`);
-  consoleOutput.log(`Worktree: ${portablePath(team.config.worktree)}`);
-  consoleOutput.log(`Gitdir: ${portablePath(team.config.gitdir)}`);
-  await maybeRun(options.dryRun === true, git, ['-C', team.config.worktree, 'status', '--short', '--branch']);
-  await maybeRun(options.dryRun === true, git, ['-C', team.config.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME], {
+export const runShareStatus = Effect.fn('share.runShareStatus')(function* (
+  config: ShareRuntime,
+  options: ShareStatusOptions,
+) {
+  const team = yield* resolveTeam(config, options.team);
+  const git = yield* requiredExecutable('git');
+  yield* Console.log(`Team: ${team.name}`);
+  yield* Console.log(`Remote: ${team.config.remote}`);
+  yield* Console.log(`Worktree: ${yield* portablePath(team.config.worktree)}`);
+  yield* Console.log(`Gitdir: ${yield* portablePath(team.config.gitdir)}`);
+  yield* maybeRun(options.dryRun === true, git, ['-C', team.config.worktree, 'status', '--short', '--branch']);
+  yield* maybeRun(options.dryRun === true, git, ['-C', team.config.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME], {
     allowFailure: true,
   });
-  const ahead = await gitOutput(team.config.worktree, ['rev-list', '--count', '@{u}..HEAD'], options.dryRun === true);
-  const behind = await gitOutput(team.config.worktree, ['rev-list', '--count', 'HEAD..@{u}'], options.dryRun === true);
+  const ahead = yield* gitOutput(team.config.worktree, ['rev-list', '--count', '@{u}..HEAD'], options.dryRun === true);
+  const behind = yield* gitOutput(team.config.worktree, ['rev-list', '--count', 'HEAD..@{u}'], options.dryRun === true);
   if (ahead !== undefined) {
-    consoleOutput.log(`Ahead of upstream: ${ahead}`);
+    yield* Console.log(`Ahead of upstream: ${ahead}`);
   }
   if (behind !== undefined) {
-    consoleOutput.log(`Behind upstream: ${behind}`);
+    yield* Console.log(`Behind upstream: ${behind}`);
   }
-}
+});
 
-export async function refreshSharedReposInBackground(config: ShareRuntime, force: boolean): Promise<void> {
-  return refreshShareUpdateState(config, {force});
-}
+export const refreshSharedReposInBackground = Effect.fn('share.refreshSharedReposInBackground')(function* (
+  config: ShareRuntime,
+  force: boolean,
+) {
+  return yield* refreshShareUpdateState(config, {force});
+});
 
-export async function syncSharedReposBeforeAgentRead(config: ShareRuntime): Promise<AutoShareSyncResult> {
+export const syncSharedReposBeforeAgentRead = Effect.fn('share.syncSharedReposBeforeAgentRead')(function* (
+  config: ShareRuntime,
+) {
   const state = autoShareState(config);
-  return enqueueShareOperation(state, async () => {
-    await loadPendingReindexes(config, state);
-    const warnings = await refreshShareUpdateStateLocked(config, state, {force: false});
-    const syncTeams = new Set([...state.behindTeams, ...state.pendingReindexes.keys()]);
-    if (syncTeams.size === 0) {
-      return {syncedTeams: [], warnings};
-    }
-
-    const syncedTeams: string[] = [];
-    const remainingBehind = new Set(state.behindTeams);
-    for (const team of syncTeams) {
-      try {
-        const warning = await runShareSyncQuiet(config, state, {team});
-        if (warning) {
-          warnings.push(warning);
-        } else {
-          remainingBehind.delete(team);
-          syncedTeams.push(team);
-        }
-      } catch (err: unknown) {
-        warnings.push(
-          `Auto-sync for shared team "${team}" failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+  return yield* enqueueShareOperation(
+    state,
+    Effect.fn('share.callback')(function* () {
+      yield* loadPendingReindexes(config, state);
+      const warnings = yield* refreshShareUpdateStateLocked(config, state, {force: false});
+      const syncTeams = new Set([...state.behindTeams, ...state.pendingReindexes.keys()]);
+      if (syncTeams.size === 0) {
+        return {syncedTeams: [], warnings};
       }
-    }
-    state.behindTeams = remainingBehind;
-    state.lastCheckedAt = Date.now();
-    return {syncedTeams, warnings};
-  });
-}
+
+      const syncedTeams: string[] = [];
+      const remainingBehind = new Set(state.behindTeams);
+      for (const team of syncTeams) {
+        const syncResult = yield* Effect.result(runShareSyncQuiet(config, state, {team}));
+        if (Result.isSuccess(syncResult)) {
+          const warning = syncResult.success;
+          if (warning) {
+            warnings.push(warning);
+          } else {
+            remainingBehind.delete(team);
+            syncedTeams.push(team);
+          }
+        } else {
+          const err = syncResult.failure;
+          warnings.push(
+            `Auto-sync for shared team "${team}" failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+      state.behindTeams = remainingBehind;
+      state.lastCheckedAt = Date.now();
+      return {syncedTeams, warnings};
+    }),
+  );
+});
 
 function autoShareState(config: ShareRuntime): AutoShareState {
   const key = `${config.agentContextHome}:${config.account}:${config.user}`;
@@ -421,12 +583,15 @@ function autoShareState(config: ShareRuntime): AutoShareState {
   return state;
 }
 
-function pendingReindexesPath(config: ShareRuntime): string {
-  return join(config.agentContextHome, 'share', 'auto-sync-pending-reindexes.json');
-}
+const pendingReindexesPath = Effect.fn('share.pendingReindexesPath')(function* (config: ShareRuntime) {
+  return yield* pathJoin(config.agentContextHome, 'share', 'auto-sync-pending-reindexes.json');
+});
 
-async function loadPendingReindexes(config: ShareRuntime, state: AutoShareState): Promise<void> {
-  const raw = await readFileIfExists(pendingReindexesPath(config));
+const loadPendingReindexes = Effect.fn('share.loadPendingReindexes')(function* (
+  config: ShareRuntime,
+  state: AutoShareState,
+) {
+  const raw = yield* readFileIfExists(yield* pendingReindexesPath(config));
   if (!raw) {
     state.pendingReindexes = new Map();
     return;
@@ -465,39 +630,49 @@ async function loadPendingReindexes(config: ShareRuntime, state: AutoShareState)
     }
   }
   state.pendingReindexes = pending;
-}
+});
 
-async function writePendingReindexes(config: ShareRuntime, state: AutoShareState): Promise<void> {
-  const path = pendingReindexesPath(config);
+const writePendingReindexes = Effect.fn('share.writePendingReindexes')(function* (
+  config: ShareRuntime,
+  state: AutoShareState,
+) {
+  const path = yield* pendingReindexesPath(config);
   if (state.pendingReindexes.size === 0) {
-    await rm(path, {force: true});
+    yield* rm(path, {force: true});
     return;
   }
   const contents: PendingReindexFile = {
     teams: Object.fromEntries(state.pendingReindexes),
     version: 1,
   };
-  await mkdir(dirname(path), {recursive: true});
-  const tempPath = `${path}.${process.pid}.tmp`;
-  await writeFile(tempPath, `${JSON.stringify(contents, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
-  await rename(tempPath, path);
-}
+  yield* mkdir(yield* pathDirname(path), {recursive: true});
+  const system = yield* SystemInfo;
+  const tempPath = `${path}.${system.processId}.tmp`;
+  yield* writeFile(tempPath, `${JSON.stringify(contents, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
+  yield* rename(tempPath, path);
+});
 
-async function refreshShareUpdateState(config: ShareRuntime, options: {readonly force: boolean}): Promise<void> {
+const refreshShareUpdateState = Effect.fn('share.refreshShareUpdateState')(function* (
+  config: ShareRuntime,
+  options: {readonly force: boolean},
+) {
   const state = autoShareState(config);
-  const warnings = await enqueueShareOperation(state, async () =>
-    refreshShareUpdateStateLocked(config, state, options),
+  const warnings = yield* enqueueShareOperation(
+    state,
+    Effect.fn('share.callback')(function* () {
+      return yield* refreshShareUpdateStateLocked(config, state, options);
+    }),
   );
   for (const warning of warnings) {
-    consoleOutput.error(warning);
+    yield* Console.error(warning);
   }
-}
+});
 
-async function refreshShareUpdateStateLocked(
+const refreshShareUpdateStateLocked = Effect.fn('share.refreshShareUpdateStateLocked')(function* (
   config: ShareRuntime,
   state: AutoShareState,
   options: {readonly force: boolean},
-): Promise<string[]> {
+) {
   const now = Date.now();
   if (
     !options.force &&
@@ -506,43 +681,40 @@ async function refreshShareUpdateStateLocked(
   ) {
     return [];
   }
-  try {
-    const statuses = await fetchShareUpdateStatuses(config);
+  return yield* Effect.gen(function* () {
+    const statuses = yield* fetchShareUpdateStatuses(config);
     const nextBehindTeams = new Set(state.behindTeams);
     for (const status of statuses) {
-      if (status.warning) {
-        continue;
-      }
-      if (status.behind > 0) {
-        nextBehindTeams.add(status.team);
-      } else {
-        nextBehindTeams.delete(status.team);
+      if (!status.warning) {
+        if (status.behind > 0) {
+          nextBehindTeams.add(status.team);
+        } else {
+          nextBehindTeams.delete(status.team);
+        }
       }
     }
     state.behindTeams = nextBehindTeams;
     return statuses.flatMap(status => (status.warning ? [status.warning] : []));
-  } finally {
-    state.lastCheckedAt = Date.now();
-  }
+  }).pipe(Effect.ensuring(Effect.sync(() => (state.lastCheckedAt = Date.now()))));
+});
+
+function enqueueShareOperation<A, E, R>(
+  _state: AutoShareState,
+  action: () => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return action();
 }
 
-function enqueueShareOperation<T>(state: AutoShareState, action: () => Promise<T>): Promise<T> {
-  const previous = state.operationPromise ?? Promise.resolve();
-  const current = previous.catch(() => undefined).then(action);
-  state.operationPromise = current.catch(() => undefined);
-  return current;
-}
-
-async function fetchShareUpdateStatuses(config: ShareRuntime): Promise<readonly ShareUpdateStatus[]> {
-  const teamsFile = await readTeamsFile(config);
+const fetchShareUpdateStatuses = Effect.fn('share.fetchShareUpdateStatuses')(function* (config: ShareRuntime) {
+  const teamsFile = yield* readTeamsFile(config);
   const teams = Object.entries(teamsFile.teams);
   if (teams.length === 0) {
     return [];
   }
-  const git = await requiredExecutable('git');
+  const git = yield* requiredExecutable('git');
   const statuses: ShareUpdateStatus[] = [];
   for (const [name, team] of teams) {
-    const fetchResult = await runCommand(git, ['-C', team.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME], {
+    const fetchResult = yield* runCommand(git, ['-C', team.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME], {
       allowFailure: true,
     });
     if (fetchResult.exitCode !== 0) {
@@ -553,7 +725,7 @@ async function fetchShareUpdateStatuses(config: ShareRuntime): Promise<readonly 
       });
       continue;
     }
-    const behind = await gitOutput(team.worktree, ['rev-list', '--count', 'HEAD..@{u}'], false);
+    const behind = yield* gitOutput(team.worktree, ['rev-list', '--count', 'HEAD..@{u}'], false);
     if (behind === undefined) {
       statuses.push({
         behind: 0,
@@ -565,28 +737,31 @@ async function fetchShareUpdateStatuses(config: ShareRuntime): Promise<readonly 
     statuses.push({behind: Number.parseInt(behind, 10) || 0, team: name});
   }
   return statuses;
-}
+});
 
-export async function runShareSync(config: ShareRuntime, options: ShareSyncOptions): Promise<void> {
-  const teams = await teamsForShareQuery(config, options.team);
+export const runShareSync = Effect.fn('share.runShareSync')(function* (
+  config: ShareRuntime,
+  options: ShareSyncOptions,
+) {
+  const teams = yield* teamsForShareQuery(config, options.team);
 
   if (options.team) {
     const team = teams[0];
     if (!team) {
       throw new Error('No shared teams configured. Run: threadnote share init <remote-url>');
     }
-    await runShareSyncForTeam(config, team, options);
+    yield* runShareSyncForTeam(config, team, options);
     return;
   }
 
   const failures: string[] = [];
   for (const [index, team] of teams.entries()) {
     if (teams.length > 1) {
-      consoleOutput.log(`Syncing shared team "${team.name}" (${index + 1}/${teams.length})...`);
+      yield* Console.log(`Syncing shared team "${team.name}" (${index + 1}/${teams.length})...`);
     }
-    try {
-      await runShareSyncForTeam(config, team, options);
-    } catch (error) {
+    const syncResult = yield* Effect.result(runShareSyncForTeam(config, team, options));
+    if (Result.isFailure(syncResult)) {
+      const error = syncResult.failure;
       failures.push(`${team.name}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
@@ -598,30 +773,34 @@ export async function runShareSync(config: ShareRuntime, options: ShareSyncOptio
       ),
     );
   }
-}
+});
 
-async function runShareSyncForTeam(config: ShareRuntime, team: ResolvedTeam, options: ShareSyncOptions): Promise<void> {
+const runShareSyncForTeam = Effect.fn('share.runShareSyncForTeam')(function* (
+  config: ShareRuntime,
+  team: ResolvedTeam,
+  options: ShareSyncOptions,
+) {
   const dryRun = options.dryRun === true;
-  const git = await requiredExecutable('git');
+  const git = yield* requiredExecutable('git');
   const worktree = team.config.worktree;
 
   if (!dryRun) {
     // Don't push here — sync's final push step (below) will deliver any
     // .gitignore housekeeping commit, avoiding a double-push round trip.
-    await ensureSharedGitignore(worktree, git, false);
+    yield* ensureSharedGitignore(worktree, git, false);
   }
 
-  if (await hasUncommittedChanges(worktree)) {
+  if (yield* hasUncommittedChanges(worktree)) {
     if (options.autoCommit === false) {
       throw new Error(
         `Worktree ${worktree} has uncommitted changes. Commit them yourself or rerun without --no-auto-commit.`,
       );
     }
     const message = options.message ?? `share: sync ${new Date().toISOString()}`;
-    await stageShareableChanges(dryRun, git, worktree);
-    const commitResult = await maybeRun(dryRun, git, ['-C', worktree, 'commit', '-m', message], {allowFailure: true});
+    yield* stageShareableChanges(dryRun, git, worktree);
+    const commitResult = yield* maybeRun(dryRun, git, ['-C', worktree, 'commit', '-m', message], {allowFailure: true});
     if (!dryRun && commitResult && commitResult.exitCode !== 0) {
-      if (await hasUncommittedChanges(worktree)) {
+      if (yield* hasUncommittedChanges(worktree)) {
         throw new Error(
           `Worktree ${worktree} has uncommitted changes that Threadnote did not auto-commit. Commit, remove, or ignore the remaining files, then rerun \`threadnote share sync\`.\nGit said: ${
             commitResult.stderr.trim() || commitResult.stdout.trim() || 'unknown git commit error'
@@ -634,20 +813,20 @@ async function runShareSyncForTeam(config: ShareRuntime, team: ResolvedTeam, opt
         }`,
       );
     }
-    if (!dryRun && (await hasUncommittedChanges(worktree))) {
+    if (!dryRun && (yield* hasUncommittedChanges(worktree))) {
       throw new Error(
         `Worktree ${worktree} still has uncommitted changes after staging Threadnote shareable files. Commit, remove, or ignore the remaining files, then rerun \`threadnote share sync\`.`,
       );
     }
   }
 
-  const beforeRev = await gitOutput(worktree, ['rev-parse', 'HEAD'], dryRun);
-  await maybeRun(dryRun, git, ['-C', worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME]);
+  const beforeRev = yield* gitOutput(worktree, ['rev-parse', 'HEAD'], dryRun);
+  yield* maybeRun(dryRun, git, ['-C', worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME]);
   const pullResult = dryRun
     ? undefined
-    : await runCommand(git, ['-C', worktree, 'rebase', '@{u}'], {allowFailure: true});
+    : yield* runCommand(git, ['-C', worktree, 'rebase', '@{u}'], {allowFailure: true});
   if (dryRun) {
-    consoleOutput.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'rebase', '@{u}'])}`);
+    yield* Console.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'rebase', '@{u}'])}`);
   } else if (pullResult && pullResult.exitCode !== 0) {
     // Detect mid-rebase state via filesystem markers rather than parsing git's
     // output — both because git's English phrasing varies by version and
@@ -655,8 +834,8 @@ async function runShareSyncForTeam(config: ShareRuntime, team: ResolvedTeam, opt
     // share teams clone with --separate-git-dir so <worktree>/.git is a gitfile,
     // not a directory; the rebase markers live in the real gitdir.
     if (
-      (await exists(join(team.config.gitdir, 'rebase-merge'))) ||
-      (await exists(join(team.config.gitdir, 'rebase-apply')))
+      (yield* exists(yield* pathJoin(team.config.gitdir, 'rebase-merge'))) ||
+      (yield* exists(yield* pathJoin(team.config.gitdir, 'rebase-apply')))
     ) {
       throw new Error(
         `git pull --rebase reported conflicts in ${worktree}. The worktree is in a rebase-in-progress state.\nResolve the conflicts in-place, run \`git -C ${worktree} rebase --continue\` (or --abort), then re-run \`threadnote share sync\`.`,
@@ -666,26 +845,26 @@ async function runShareSyncForTeam(config: ShareRuntime, team: ResolvedTeam, opt
       `git rebase @{u} failed in ${worktree}: ${pullResult.stderr.trim() || pullResult.stdout.trim() || 'unknown error'}`,
     );
   }
-  const afterRev = await gitOutput(worktree, ['rev-parse', 'HEAD'], dryRun);
+  const afterRev = yield* gitOutput(worktree, ['rev-parse', 'HEAD'], dryRun);
 
   if (!dryRun) {
     const state = autoShareState(config);
-    await loadPendingReindexes(config, state);
+    yield* loadPendingReindexes(config, state);
     const previouslyPending = state.pendingReindexes.get(team.name) ?? [];
     const newChanges =
-      beforeRev && afterRev && beforeRev !== afterRev ? await listChangedFiles(worktree, beforeRev, afterRev) : [];
+      beforeRev && afterRev && beforeRev !== afterRev ? yield* listChangedFiles(worktree, beforeRev, afterRev) : [];
     const combined = mergeChanges(previouslyPending, newChanges);
     if (combined.length === 0) {
-      consoleOutput.log('No upstream changes to reindex.');
+      yield* Console.log('No upstream changes to reindex.');
     } else {
-      const result = await applyAndPersistChanges(config, team.config, state, combined);
+      const result = yield* applyAndPersistChanges(config, team.config, state, combined);
       const succeeded = combined.length - result.failed.length;
-      consoleOutput.log(`Reindexed ${succeeded} file change(s) into OpenViking.`);
+      yield* Console.log(`Reindexed ${succeeded} file change(s) into OpenViking.`);
       if (result.failed.length > 0) {
-        consoleOutput.warn(
+        yield* Console.warn(
           `share sync: ${result.failed.length} file(s) could not be ingested on this run; they are persisted and will be retried on the next sync or agent recall/read.`,
         );
-        consoleOutput.warn(formatShareConflictNextSteps(team.name, result.failed));
+        yield* Console.warn(formatShareConflictNextSteps(team.name, result.failed));
       }
     }
   }
@@ -693,82 +872,85 @@ async function runShareSyncForTeam(config: ShareRuntime, team: ResolvedTeam, opt
   if (options.push !== false) {
     const pushResult = dryRun
       ? undefined
-      : await runCommand(git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME], {allowFailure: true});
+      : yield* runCommand(git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME], {allowFailure: true});
     if (dryRun) {
-      consoleOutput.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME])}`);
+      yield* Console.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME])}`);
     } else if (pushResult && pushResult.exitCode !== 0) {
       throw new Error(
         `git push failed in ${worktree}: ${pushResult.stderr.trim() || pushResult.stdout.trim() || 'unknown error'}`,
       );
     }
   }
-}
+});
 
-export async function runShareConflicts(config: ShareRuntime, options: ShareConflictOptions): Promise<void> {
-  const conflicts = await listShareConflicts(config, options);
+export const runShareConflicts = Effect.fn('share.runShareConflicts')(function* (
+  config: ShareRuntime,
+  options: ShareConflictOptions,
+) {
+  const conflicts = yield* listShareConflicts(config, options);
   if (conflicts.length === 0) {
     const team = options.team ? ` for team "${options.team}"` : '';
-    consoleOutput.log(`No pending shared memory conflicts${team}.`);
+    yield* Console.log(`No pending shared memory conflicts${team}.`);
     return;
   }
-  consoleOutput.log(`Pending shared memory conflicts: ${conflicts.length}`);
+  yield* Console.log(`Pending shared memory conflicts: ${conflicts.length}`);
   for (const conflict of conflicts) {
-    consoleOutput.log('');
-    consoleOutput.log(`${conflict.id}`);
-    consoleOutput.log(`  uri: ${conflict.uri}`);
-    consoleOutput.log(`  status: ${conflict.status}`);
-    consoleOutput.log(`  reason: ${conflict.reason}`);
-    consoleOutput.log(`  show: threadnote share conflict show ${conflict.id}`);
-    consoleOutput.log(`  take shared: threadnote share conflict resolve ${conflict.id} --take shared`);
-    consoleOutput.log(`  take local: threadnote share conflict resolve ${conflict.id} --take local`);
-    consoleOutput.log(`  merged file: threadnote share conflict resolve ${conflict.id} --from-file merged.md`);
+    yield* Console.log('');
+    yield* Console.log(`${conflict.id}`);
+    yield* Console.log(`  uri: ${conflict.uri}`);
+    yield* Console.log(`  status: ${conflict.status}`);
+    yield* Console.log(`  reason: ${conflict.reason}`);
+    yield* Console.log(`  show: threadnote share conflict show ${conflict.id}`);
+    yield* Console.log(`  take shared: threadnote share conflict resolve ${conflict.id} --take shared`);
+    yield* Console.log(`  take local: threadnote share conflict resolve ${conflict.id} --take local`);
+    yield* Console.log(`  merged file: threadnote share conflict resolve ${conflict.id} --from-file merged.md`);
   }
-}
+});
 
-export async function runShareConflictShow(
+export const runShareConflictShow = Effect.fn('share.runShareConflictShow')(function* (
   config: ShareRuntime,
   reference: string,
   options: ShareConflictShowOptions,
-): Promise<void> {
-  const detail = await showShareConflict(config, reference, options);
-  consoleOutput.log(`Conflict: ${detail.id}`);
-  consoleOutput.log(`URI: ${detail.uri}`);
-  consoleOutput.log(`Status: ${detail.status}`);
-  consoleOutput.log(`Reason: ${detail.reason}`);
-  consoleOutput.log('');
-  consoleOutput.log(detail.diff);
-  consoleOutput.log('');
-  consoleOutput.log('Resolve:');
+) {
+  const detail = yield* showShareConflict(config, reference, options);
+  yield* Console.log(`Conflict: ${detail.id}`);
+  yield* Console.log(`URI: ${detail.uri}`);
+  yield* Console.log(`Status: ${detail.status}`);
+  yield* Console.log(`Reason: ${detail.reason}`);
+  yield* Console.log('');
+  yield* Console.log(detail.diff);
+  yield* Console.log('');
+  yield* Console.log('Resolve:');
   for (const line of detail.resolutionGuidance) {
-    consoleOutput.log(`  ${line}`);
+    yield* Console.log(`  ${line}`);
   }
-}
+});
 
-export async function runShareConflictResolve(
+export const runShareConflictResolve = Effect.fn('share.runShareConflictResolve')(function* (
   config: ShareRuntime,
   reference: string,
   options: ShareConflictResolveOptions,
-): Promise<void> {
-  const result = await resolveShareConflict(config, reference, options);
+) {
+  const result = yield* resolveShareConflict(config, reference, options);
   for (const message of result.messages) {
-    consoleOutput.log(message);
+    yield* Console.log(message);
   }
   if (result.backupPath) {
-    consoleOutput.log(`Backup: ${portablePath(result.backupPath)}`);
+    yield* Console.log(`Backup: ${yield* portablePath(result.backupPath)}`);
   }
   for (const message of result.gitMessages) {
-    consoleOutput.log(message);
+    yield* Console.log(message);
   }
-  consoleOutput.log(`Resolved shared memory conflict: ${result.id}`);
-}
+  yield* Console.log(`Resolved shared memory conflict: ${result.id}`);
+});
 
-export async function listShareConflicts(
+export const listShareConflicts = Effect.fn('share.listShareConflicts')(function* (
   config: ShareRuntime,
   options: ShareConflictOptions = {},
-): Promise<readonly ShareConflictSummary[]> {
-  const teams = await teamsForShareQuery(config, options.team);
+) {
+  const teams = yield* teamsForShareQuery(config, options.team);
   const state = autoShareState(config);
-  await loadPendingReindexes(config, state);
+  yield* loadPendingReindexes(config, state);
   const summaries: ShareConflictSummary[] = [];
   for (const team of teams) {
     const pending = state.pendingReindexes.get(team.name) ?? [];
@@ -776,31 +958,31 @@ export async function listShareConflicts(
       if (!isShareableMemoryChange(change)) {
         continue;
       }
-      summaries.push(await buildShareConflictSummary(config, team, normalizePendingChange(team, change)));
+      summaries.push(yield* buildShareConflictSummary(config, team, yield* normalizePendingChange(team, change)));
     }
   }
   return summaries;
-}
+});
 
-export async function showShareConflict(
+export const showShareConflict = Effect.fn('share.showShareConflict')(function* (
   config: ShareRuntime,
   reference: string,
   options: ShareConflictShowOptions = {},
-): Promise<ShareConflictDetail> {
-  const conflict = await readPendingShareConflict(config, reference, options.team);
-  const inspected = await inspectShareConflict(config, conflict.team, conflict.change);
+) {
+  const conflict = yield* readPendingShareConflict(config, reference, options.team);
+  const inspected = yield* inspectShareConflict(config, conflict.team, conflict.change);
   return {
     ...inspected,
     diff: formatShareConflictDiff(inspected),
     resolutionGuidance: shareConflictResolutionGuidance(inspected.id),
   };
-}
+});
 
-export async function resolveShareConflict(
+export const resolveShareConflict = Effect.fn('share.resolveShareConflict')(function* (
   config: ShareRuntime,
   reference: string,
   options: ShareConflictResolveOptions,
-): Promise<ShareConflictResolveResult> {
+) {
   const fromFile = options.fromFile?.trim();
   const mergedContent = options.mergedContent;
   const rawTake = options.take as string | undefined;
@@ -813,18 +995,18 @@ export async function resolveShareConflict(
       'Choose exactly one resolution: --take shared, --take local, --from-file <path>, or mergedContent via MCP.',
     );
   }
-  const conflict = await readPendingShareConflict(config, reference, options.team);
-  const inspected = await inspectShareConflict(config, conflict.team, conflict.change);
+  const conflict = yield* readPendingShareConflict(config, reference, options.team);
+  const inspected = yield* inspectShareConflict(config, conflict.team, conflict.change);
   const dryRun = options.dryRun === true;
-  const ov = await openVikingCliForMode(dryRun);
+  const ov = yield* openVikingCliForMode(dryRun);
   const messages: string[] = [];
   const gitMessages: string[] = [];
-  const backupPath = dryRun ? undefined : await backupShareConflict(config, inspected);
+  const backupPath = dryRun ? undefined : yield* backupShareConflict(config, inspected);
 
   if (take === 'shared') {
     if (inspected.status === 'removed') {
       if (inspected.hasLocalContent) {
-        await removeMemoryUri(config, ov, inspected.uri, dryRun);
+        yield* removeMemoryUri(config, ov, inspected.uri, dryRun);
         messages.push(`Accepted shared deletion for ${inspected.uri}.`);
       } else {
         messages.push(`Shared deletion was already reflected in OpenViking for ${inspected.uri}.`);
@@ -833,8 +1015,8 @@ export async function resolveShareConflict(
       if (inspected.sharedContent === undefined) {
         throw new Error(`Cannot take shared for ${inspected.id}: shared file is missing or not readable.`);
       }
-      await ensureSharedDirectoryChain(config, ov, inspected.uri, dryRun);
-      await writeMemoryFile(
+      yield* ensureSharedDirectoryChain(config, ov, inspected.uri, dryRun);
+      yield* writeMemoryFile(
         config,
         ov,
         inspected.uri,
@@ -845,13 +1027,20 @@ export async function resolveShareConflict(
       messages.push(`Accepted shared file content for ${inspected.uri}.`);
     }
   } else {
-    const content = await conflictResolutionContent(inspected, take, fromFile, mergedContent);
-    await writeSharedConflictFile(conflict.team, inspected, content, dryRun);
-    await ensureSharedDirectoryChain(config, ov, inspected.uri, dryRun);
-    await writeMemoryFile(config, ov, inspected.uri, content, inspected.hasLocalContent ? 'replace' : 'create', dryRun);
+    const content = yield* conflictResolutionContent(inspected, take, fromFile, mergedContent);
+    yield* writeSharedConflictFile(conflict.team, inspected, content, dryRun);
+    yield* ensureSharedDirectoryChain(config, ov, inspected.uri, dryRun);
+    yield* writeMemoryFile(
+      config,
+      ov,
+      inspected.uri,
+      content,
+      inspected.hasLocalContent ? 'replace' : 'create',
+      dryRun,
+    );
     const message = options.message ?? `share: resolve ${inspected.relativePath}`;
     gitMessages.push(
-      ...(await publishShareGitChange(conflict.team.config.worktree, inspected.relativePath, message, {
+      ...(yield* publishShareGitChange(conflict.team.config.worktree, inspected.relativePath, message, {
         dryRun,
         push: options.push,
       })),
@@ -864,33 +1053,33 @@ export async function resolveShareConflict(
   }
 
   if (!dryRun) {
-    await clearPendingShareConflict(config, conflict.team.name, inspected.relativePath);
+    yield* clearPendingShareConflict(config, conflict.team.name, inspected.relativePath);
   }
   return {backupPath, gitMessages, id: inspected.id, messages, team: inspected.team, uri: inspected.uri};
-}
+});
 
-async function runShareSyncQuiet(
+const runShareSyncQuiet = Effect.fn('share.runShareSyncQuiet')(function* (
   config: ShareRuntime,
   state: AutoShareState,
   options: {readonly team: string},
-): Promise<string | undefined> {
-  const team = await resolveTeam(config, options.team);
-  const git = await requiredExecutable('git');
+) {
+  const team = yield* resolveTeam(config, options.team);
+  const git = yield* requiredExecutable('git');
   const worktree = team.config.worktree;
 
   const pendingChanges = state.pendingReindexes.get(team.name);
   if (pendingChanges && pendingChanges.length > 0) {
-    const result = await applyAndPersistChanges(config, team.config, state, pendingChanges, {quiet: true});
+    const result = yield* applyAndPersistChanges(config, team.config, state, pendingChanges, {quiet: true});
     if (result.failed.length > 0) {
       return `Shared team "${team.name}" has ${result.failed.length} pending shared memory conflict(s). Run \`threadnote share conflicts --team ${team.name}\` to inspect, then \`threadnote share conflict resolve <id> --take shared|local\` or \`--from-file <path>\`.`;
     }
   }
 
-  if (await hasUncommittedChanges(worktree)) {
+  if (yield* hasUncommittedChanges(worktree)) {
     return `Shared team "${team.name}" has uncommitted changes; skipped automatic sync. Run \`threadnote share sync --team ${team.name}\` to publish or resolve them.`;
   }
 
-  const ahead = await gitOutput(worktree, ['rev-list', '--count', '@{u}..HEAD'], false);
+  const ahead = yield* gitOutput(worktree, ['rev-list', '--count', '@{u}..HEAD'], false);
   if (ahead === undefined) {
     return `Shared team "${team.name}" upstream status is unknown; skipped automatic sync. Run \`threadnote share sync --team ${team.name}\` to inspect and resolve it.`;
   }
@@ -898,12 +1087,12 @@ async function runShareSyncQuiet(
     return `Shared team "${team.name}" has local commits ahead of upstream; skipped automatic sync. Run \`threadnote share sync --team ${team.name}\` to publish or reconcile them.`;
   }
 
-  const beforeRev = await gitOutput(worktree, ['rev-parse', 'HEAD'], false);
-  const pullResult = await runCommand(git, ['-C', worktree, 'rebase', '@{u}'], {allowFailure: true});
+  const beforeRev = yield* gitOutput(worktree, ['rev-parse', 'HEAD'], false);
+  const pullResult = yield* runCommand(git, ['-C', worktree, 'rebase', '@{u}'], {allowFailure: true});
   if (pullResult.exitCode !== 0) {
     if (
-      (await exists(join(team.config.gitdir, 'rebase-merge'))) ||
-      (await exists(join(team.config.gitdir, 'rebase-apply')))
+      (yield* exists(yield* pathJoin(team.config.gitdir, 'rebase-merge'))) ||
+      (yield* exists(yield* pathJoin(team.config.gitdir, 'rebase-apply')))
     ) {
       throw new Error(
         `Automatic share sync hit git conflicts in ${worktree}. Resolve them in-place, run \`git -C ${worktree} rebase --continue\` (or --abort), then rerun recall/read.`,
@@ -913,51 +1102,46 @@ async function runShareSyncQuiet(
       `Automatic share sync failed in ${worktree}: ${pullResult.stderr.trim() || pullResult.stdout.trim() || 'unknown error'}`,
     );
   }
-  const afterRev = await gitOutput(worktree, ['rev-parse', 'HEAD'], false);
+  const afterRev = yield* gitOutput(worktree, ['rev-parse', 'HEAD'], false);
   if (beforeRev && afterRev && beforeRev !== afterRev) {
-    const changes = await listChangedFiles(worktree, beforeRev, afterRev);
+    const changes = yield* listChangedFiles(worktree, beforeRev, afterRev);
     if (changes.length > 0) {
       // Merge with anything still pending from the drain above so a failed
       // drain item doesn't get clobbered when we persist the new changes.
       const stillPending = state.pendingReindexes.get(team.name) ?? [];
       const combined = mergeChanges(stillPending, changes);
-      const result = await applyAndPersistChanges(config, team.config, state, combined, {quiet: true});
+      const result = yield* applyAndPersistChanges(config, team.config, state, combined, {quiet: true});
       if (result.failed.length > 0) {
         return `Shared team "${team.name}" has ${result.failed.length} pending shared memory conflict(s). Run \`threadnote share conflicts --team ${team.name}\` to inspect, then \`threadnote share conflict resolve <id> --take shared|local\` or \`--from-file <path>\`.`;
       }
     }
   }
   return undefined;
-}
+});
 
-interface PendingShareConflict {
-  readonly change: ChangedFile;
-  readonly team: ResolvedTeam;
-}
-
-async function teamsForShareQuery(
+const teamsForShareQuery = Effect.fn('share.teamsForShareQuery')(function* (
   config: ShareRuntime,
   teamName: string | undefined,
-): Promise<readonly ResolvedTeam[]> {
+) {
   if (teamName) {
-    return [await resolveTeam(config, teamName)];
+    return [yield* resolveTeam(config, teamName)];
   }
-  const teams = await readTeamsFile(config);
+  const teams = yield* readTeamsFile(config);
   const entries = Object.entries(teams.teams);
   if (entries.length === 0) {
     throw new Error('No shared teams configured. Run: threadnote share init <remote-url>');
   }
   return entries.map(([name, team]) => ({config: team, name}));
-}
+});
 
-async function readPendingShareConflict(
+const readPendingShareConflict = Effect.fn('share.readPendingShareConflict')(function* (
   config: ShareRuntime,
   reference: string,
   optionTeam: string | undefined,
-): Promise<PendingShareConflict> {
-  const target = await parseShareConflictReference(config, reference, optionTeam);
+) {
+  const target = yield* parseShareConflictReference(config, reference, optionTeam);
   const state = autoShareState(config);
-  await loadPendingReindexes(config, state);
+  yield* loadPendingReindexes(config, state);
   const pending = state.pendingReindexes.get(target.team.name) ?? [];
   const change = pending.find(candidate => candidate.relativePath === target.relativePath);
   if (!change) {
@@ -973,14 +1157,14 @@ async function readPendingShareConflict(
       ].join('\n'),
     );
   }
-  return {change: normalizePendingChange(target.team, change), team: target.team};
-}
+  return {change: yield* normalizePendingChange(target.team, change), team: target.team};
+});
 
-async function parseShareConflictReference(
+const parseShareConflictReference = Effect.fn('share.parseShareConflictReference')(function* (
   config: ShareRuntime,
   reference: string,
   optionTeam: string | undefined,
-): Promise<{readonly relativePath: string; readonly team: ResolvedTeam}> {
+) {
   const trimmed = reference.trim();
   if (!trimmed) {
     throw new Error('Provide a conflict id, relative path, or viking:// shared memory URI.');
@@ -990,17 +1174,20 @@ async function parseShareConflictReference(
     if (!teamName) {
       throw new Error(`Shared memory URI does not include a configured team: ${trimmed}`);
     }
-    const team = await resolveTeam(config, optionTeam ?? teamName);
-    return {relativePath: assertSafeShareRelativePath(vikingUriToWorktreeRelative(config, trimmed, team.name)), team};
+    const team = yield* resolveTeam(config, optionTeam ?? teamName);
+    return {
+      relativePath: assertSafeShareRelativePath(vikingUriToWorktreeRelative(config, trimmed, team.name)),
+      team,
+    };
   }
   const colon = trimmed.indexOf(':');
   if (colon > 0 && !trimmed.slice(0, colon).includes('/')) {
-    const team = await resolveTeam(config, optionTeam ?? trimmed.slice(0, colon));
+    const team = yield* resolveTeam(config, optionTeam ?? trimmed.slice(0, colon));
     return {relativePath: assertSafeShareRelativePath(trimmed.slice(colon + 1)), team};
   }
-  const team = await resolveTeam(config, optionTeam);
+  const team = yield* resolveTeam(config, optionTeam);
   return {relativePath: assertSafeShareRelativePath(trimmed), team};
-}
+});
 
 function assertSafeShareRelativePath(relativePath: string): string {
   if (
@@ -1013,21 +1200,24 @@ function assertSafeShareRelativePath(relativePath: string): string {
   return relativePath;
 }
 
-function normalizePendingChange(team: ResolvedTeam, change: ChangedFile): ChangedFile {
-  return {...change, path: join(team.config.worktree, change.relativePath)};
-}
+const normalizePendingChange = Effect.fn('share.normalizePendingChange')(function* (
+  team: ResolvedTeam,
+  change: ChangedFile,
+) {
+  return {...change, path: yield* pathJoin(team.config.worktree, change.relativePath)};
+});
 
 function isShareableMemoryChange(change: ChangedFile): boolean {
   const firstSegment = change.relativePath.split('/')[0];
   return change.relativePath.endsWith('.md') && SHAREABLE_MEMORY_KIND_DIRS.includes(firstSegment);
 }
 
-async function buildShareConflictSummary(
+const buildShareConflictSummary = Effect.fn('share.buildShareConflictSummary')(function* (
   config: ShareRuntime,
   team: ResolvedTeam,
   change: ChangedFile,
-): Promise<ShareConflictSummary> {
-  const inspected = await inspectShareConflict(config, team, change);
+) {
+  const inspected = yield* inspectShareConflict(config, team, change);
   return {
     hasLocalContent: inspected.hasLocalContent,
     hasPreviousContent: inspected.hasPreviousContent,
@@ -1039,19 +1229,21 @@ async function buildShareConflictSummary(
     team: inspected.team,
     uri: inspected.uri,
   };
-}
+});
 
-async function inspectShareConflict(
+const inspectShareConflict = Effect.fn('share.inspectShareConflict')(function* (
   config: ShareRuntime,
   team: ResolvedTeam,
   change: ChangedFile,
-): Promise<InspectedShareConflict> {
-  const ov = await openVikingCliForMode(false);
-  const uri = workfileToVikingUri(config, team.config, change.path);
-  const localContent = await readOptionalMemoryContent(config, ov, uri);
-  const shared = await readOptionalSharedConflictContent(uri, change);
+) {
+  const ov = yield* openVikingCliForMode(false);
+  const uri = yield* workfileToVikingUri(config, team.config, change.path);
+  const localContent = yield* readOptionalMemoryContent(config, ov, uri);
+  const shared = yield* readOptionalSharedConflictContent(uri, change);
   const previousContent =
-    change.previousContent === undefined ? undefined : prepareSharedInboundContent(uri, change.previousContent);
+    change.previousContent === undefined
+      ? undefined
+      : yield* prepareSharedInboundContentEffect(uri, change.previousContent);
   return {
     hasLocalContent: localContent !== undefined,
     hasPreviousContent: previousContent !== undefined,
@@ -1066,28 +1258,37 @@ async function inspectShareConflict(
     team: team.name,
     uri,
   };
-}
+});
 
-async function readOptionalSharedConflictContent(
+const readOptionalSharedConflictContent = Effect.fn('share.readOptionalSharedConflictContent')(function* (
   uri: string,
   change: ChangedFile,
-): Promise<{readonly content?: string; readonly error?: string}> {
-  try {
-    if (change.status === 'removed' || !(await isRegularFileNoSymlink(change.path))) {
-      return {};
-    }
-    return {content: await readSharedInboundFileContent(uri, change.path)};
-  } catch (err: unknown) {
-    return {error: err instanceof Error ? err.message : String(err)};
+) {
+  const result = yield* Effect.result(
+    Effect.gen(function* () {
+      if (change.status === 'removed' || !(yield* isRegularFileNoSymlink(change.path))) {
+        return {content: undefined, error: undefined};
+      }
+      return {content: yield* readSharedInboundFileContent(uri, change.path), error: undefined};
+    }),
+  );
+  if (Result.isSuccess(result)) {
+    return result.success;
   }
-}
+  const err = result.failure;
+  return {content: undefined, error: err instanceof Error ? err.message : String(err)};
+});
 
-async function readOptionalMemoryContent(config: ShareRuntime, ov: string, uri: string): Promise<string | undefined> {
-  if (!(await vikingResourceExists(ov, config, uri))) {
+const readOptionalMemoryContent = Effect.fn('share.readOptionalMemoryContent')(function* (
+  config: ShareRuntime,
+  ov: string,
+  uri: string,
+) {
+  if (!(yield* vikingResourceExists(ov, config, uri))) {
     return undefined;
   }
-  return readMemoryContent(config, ov, uri, false);
-}
+  return yield* readMemoryContent(config, ov, uri, false);
+});
 
 function shareConflictReason(
   change: ChangedFile,
@@ -1132,15 +1333,15 @@ function shareConflictReason(
     : 'local OpenViking content differs from the deleted shared version';
 }
 
-async function conflictResolutionContent(
+const conflictResolutionContent = Effect.fn('share.conflictResolutionContent')(function* (
   conflict: InspectedShareConflict,
   take: ShareConflictTake | undefined,
   fromFile: string | undefined,
   mergedContent: string | undefined,
-): Promise<string> {
+) {
   const raw =
     fromFile !== undefined
-      ? await readFile(expandPath(fromFile), 'utf8')
+      ? yield* readFile(yield* expandPath(fromFile), 'utf8')
       : mergedContent !== undefined
         ? mergedContent
         : take === 'local'
@@ -1156,25 +1357,28 @@ async function conflictResolutionContent(
     );
   }
   return scrub.cleaned;
-}
+});
 
-async function writeSharedConflictFile(
+const writeSharedConflictFile = Effect.fn('share.writeSharedConflictFile')(function* (
   team: ResolvedTeam,
   conflict: InspectedShareConflict,
   content: string,
   dryRun: boolean,
-): Promise<void> {
-  const filePath = join(team.config.worktree, conflict.relativePath);
+) {
+  const filePath = yield* pathJoin(team.config.worktree, conflict.relativePath);
   if (dryRun) {
-    consoleOutput.log(`Would write shared file: ${portablePath(filePath)}`);
+    yield* Console.log(`Would write shared file: ${yield* portablePath(filePath)}`);
     return;
   }
-  await mkdir(dirname(filePath), {recursive: true});
-  await writeFile(filePath, content, 'utf8');
-}
+  yield* mkdir(yield* pathDirname(filePath), {recursive: true});
+  yield* writeFile(filePath, content, 'utf8');
+});
 
-async function backupShareConflict(config: ShareRuntime, conflict: InspectedShareConflict): Promise<string> {
-  const backupDir = join(
+const backupShareConflict = Effect.fn('share.backupShareConflict')(function* (
+  config: ShareRuntime,
+  conflict: InspectedShareConflict,
+) {
+  const backupDir = yield* pathJoin(
     config.agentContextHome,
     'share',
     'conflict-backups',
@@ -1182,7 +1386,7 @@ async function backupShareConflict(config: ShareRuntime, conflict: InspectedShar
     conflict.team,
     ...conflict.relativePath.split('/'),
   );
-  await mkdir(backupDir, {recursive: true});
+  yield* mkdir(backupDir, {recursive: true});
   const metadata = {
     id: conflict.id,
     reason: conflict.reason,
@@ -1191,22 +1395,26 @@ async function backupShareConflict(config: ShareRuntime, conflict: InspectedShar
     team: conflict.team,
     uri: conflict.uri,
   };
-  await writeFile(join(backupDir, 'metadata.json'), `${JSON.stringify(metadata, undefined, 2)}\n`, 'utf8');
+  yield* writeFile(yield* pathJoin(backupDir, 'metadata.json'), `${JSON.stringify(metadata, undefined, 2)}\n`, 'utf8');
   if (conflict.localContent !== undefined) {
-    await writeFile(join(backupDir, 'local.md'), conflict.localContent, 'utf8');
+    yield* writeFile(yield* pathJoin(backupDir, 'local.md'), conflict.localContent, 'utf8');
   }
   if (conflict.sharedContent !== undefined) {
-    await writeFile(join(backupDir, 'shared.md'), conflict.sharedContent, 'utf8');
+    yield* writeFile(yield* pathJoin(backupDir, 'shared.md'), conflict.sharedContent, 'utf8');
   }
   if (conflict.previousContent !== undefined) {
-    await writeFile(join(backupDir, 'previous.md'), conflict.previousContent, 'utf8');
+    yield* writeFile(yield* pathJoin(backupDir, 'previous.md'), conflict.previousContent, 'utf8');
   }
   return backupDir;
-}
+});
 
-async function clearPendingShareConflict(config: ShareRuntime, teamName: string, relativePath: string): Promise<void> {
+const clearPendingShareConflict = Effect.fn('share.clearPendingShareConflict')(function* (
+  config: ShareRuntime,
+  teamName: string,
+  relativePath: string,
+) {
   const state = autoShareState(config);
-  await loadPendingReindexes(config, state);
+  yield* loadPendingReindexes(config, state);
   const pending = state.pendingReindexes.get(teamName) ?? [];
   const remaining = pending.filter(change => change.relativePath !== relativePath);
   if (remaining.length > 0) {
@@ -1214,8 +1422,8 @@ async function clearPendingShareConflict(config: ShareRuntime, teamName: string,
   } else {
     state.pendingReindexes.delete(teamName);
   }
-  await writePendingReindexes(config, state);
-}
+  yield* writePendingReindexes(config, state);
+});
 
 function conflictId(team: string, relativePath: string): string {
   return `${team}:${relativePath}`;
@@ -1292,83 +1500,102 @@ function splitDiffLines(content: string | undefined): readonly string[] {
   return lines;
 }
 
-async function stageShareableChanges(dryRun: boolean, git: string, worktree: string): Promise<void> {
+const stageShareableChanges = Effect.fn('share.stageShareableChanges')(function* (
+  dryRun: boolean,
+  git: string,
+  worktree: string,
+) {
   // Stage repo guidance/metadata plus every shareable top-level dir.
   // OpenViking-generated summaries (.abstract.md, .overview.md) are excluded
   // via the repo's .gitignore (ensureSharedGitignore self-heals it on every
   // sync), so they never get staged even by an unscoped `git add`.
   // First drop any incomplete pack orphaned by a killed publish, so the blanket
   // `git add -A` below never commits a pack index without its manifest.
-  await removeOrphanPackIndexes(dryRun, git, worktree);
-  const pathspecs = await existingShareablePathspecs(git, worktree);
+  yield* removeOrphanPackIndexes(dryRun, git, worktree);
+  const pathspecs = yield* existingShareablePathspecs(git, worktree);
   if (pathspecs.length === 0) {
     return;
   }
-  await maybeRun(dryRun, git, ['-C', worktree, 'add', '-A', '--', ...pathspecs], {allowFailure: true});
-}
+  yield* maybeRun(dryRun, git, ['-C', worktree, 'add', '-A', '--', ...pathspecs], {allowFailure: true});
+});
 
 // A pack whose <name>.pack.md index exists but whose <name>.pack.json manifest
 // is missing is an incomplete publish (e.g. interrupted by SIGKILL). Discovery
 // already skips such packs; this removes the UNTRACKED leftover before staging so
 // `git add -A` cannot commit/push it. Tracked trees are never touched.
-async function removeOrphanPackIndexes(dryRun: boolean, git: string, worktree: string): Promise<void> {
-  const packsRoot = join(worktree, SHAREABLE_ARTIFACT_DIR, 'packs');
-  if (!(await isDirectory(packsRoot))) {
+const removeOrphanPackIndexes = Effect.fn('share.removeOrphanPackIndexes')(function* (
+  dryRun: boolean,
+  git: string,
+  worktree: string,
+) {
+  const packsRoot = yield* pathJoin(worktree, SHAREABLE_ARTIFACT_DIR, 'packs');
+  if (!(yield* isDirectory(packsRoot))) {
     return;
   }
-  for (const agentEntry of await readdir(packsRoot, {withFileTypes: true})) {
+  for (const agentEntry of yield* readdir(packsRoot, {withFileTypes: true})) {
     if (!agentEntry.isDirectory()) {
       continue;
     }
-    const agentDir = join(packsRoot, agentEntry.name);
-    for (const nameEntry of await readdir(agentDir, {withFileTypes: true})) {
+    const agentDir = yield* pathJoin(packsRoot, agentEntry.name);
+    for (const nameEntry of yield* readdir(agentDir, {withFileTypes: true})) {
       if (!nameEntry.isDirectory()) {
         continue;
       }
-      const packDir = join(agentDir, nameEntry.name);
-      const indexPath = join(packDir, `${nameEntry.name}${PACK_INDEX_SUFFIX}`);
-      const manifestPath = join(packDir, `${nameEntry.name}${PACK_MANIFEST_SUFFIX}`);
-      if (!(await isFile(indexPath)) || (await isFile(manifestPath))) {
+      const packDir = yield* pathJoin(agentDir, nameEntry.name);
+      const indexPath = yield* pathJoin(packDir, `${nameEntry.name}${PACK_INDEX_SUFFIX}`);
+      const manifestPath = yield* pathJoin(packDir, `${nameEntry.name}${PACK_MANIFEST_SUFFIX}`);
+      if (!(yield* isFile(indexPath)) || (yield* isFile(manifestPath))) {
         continue;
       }
-      const indexRelative = relative(worktree, indexPath).split(sep).join('/');
-      const tracked = await runCommand(git, ['-C', worktree, 'ls-files', '--', indexRelative], {allowFailure: true});
+      const indexRelative = (yield* pathRelative(worktree, indexPath)).split(yield* pathSeparator).join('/');
+      const tracked = yield* runCommand(git, ['-C', worktree, 'ls-files', '--', indexRelative], {allowFailure: true});
       if (tracked.exitCode === 0 && tracked.stdout.trim().length > 0) {
         continue;
       }
-      consoleOutput.warn(
+      yield* Console.warn(
         `${dryRun ? 'Would remove' : 'Removing'} incomplete shared pack (missing ${nameEntry.name}${PACK_MANIFEST_SUFFIX}): ${indexRelative}`,
       );
       if (!dryRun) {
-        await rm(packDir, {force: true, recursive: true});
+        yield* rm(packDir, {force: true, recursive: true});
       }
     }
   }
-}
+});
 
-async function existingShareablePathspecs(git: string, worktree: string): Promise<readonly string[]> {
-  const rootFiles = await Promise.all(
-    SHAREABLE_ROOT_FILES.map(async file =>
-      (await hasWorktreeOrTrackedPath(git, worktree, file)) ? `:(top)${file}` : undefined,
+const existingShareablePathspecs = Effect.fn('share.existingShareablePathspecs')(function* (
+  git: string,
+  worktree: string,
+) {
+  const rootFiles = yield* Effect.all(
+    SHAREABLE_ROOT_FILES.map(
+      Effect.fn('share.callback')(function* (file) {
+        return (yield* hasWorktreeOrTrackedPath(git, worktree, file)) ? `:(top)${file}` : undefined;
+      }),
     ),
   );
-  const topLevelDirs = await Promise.all(
-    SHAREABLE_TOP_LEVEL_DIRS.map(async dir =>
-      (await hasWorktreeOrTrackedPath(git, worktree, dir)) ? `:(top)${dir}` : undefined,
+  const topLevelDirs = yield* Effect.all(
+    SHAREABLE_TOP_LEVEL_DIRS.map(
+      Effect.fn('share.callback')(function* (dir) {
+        return (yield* hasWorktreeOrTrackedPath(git, worktree, dir)) ? `:(top)${dir}` : undefined;
+      }),
     ),
   );
   return [...rootFiles, ...topLevelDirs].filter((pathspec): pathspec is string => pathspec !== undefined);
-}
+});
 
-async function hasWorktreeOrTrackedPath(git: string, worktree: string, relativePath: string): Promise<boolean> {
-  if (await exists(join(worktree, relativePath))) {
+const hasWorktreeOrTrackedPath = Effect.fn('share.hasWorktreeOrTrackedPath')(function* (
+  git: string,
+  worktree: string,
+  relativePath: string,
+) {
+  if (yield* exists(yield* pathJoin(worktree, relativePath))) {
     return true;
   }
-  const result = await runCommand(git, ['-C', worktree, 'ls-files', '--', relativePath], {allowFailure: true});
+  const result = yield* runCommand(git, ['-C', worktree, 'ls-files', '--', relativePath], {allowFailure: true});
   return result.exitCode === 0 && result.stdout.trim().length > 0;
-}
+});
 
-export async function publishShareGitChange(
+export const publishShareGitChange = Effect.fn('share.publishShareGitChange')(function* (
   worktree: string,
   relativePath: string | readonly string[],
   commitMessage: string,
@@ -1377,23 +1604,23 @@ export async function publishShareGitChange(
     readonly push?: boolean;
     readonly verb?: 'add' | 'rm';
   } = {},
-): Promise<readonly string[]> {
+) {
   const dryRun = options.dryRun === true;
   const push = options.push !== false;
   const verb = options.verb ?? 'add';
-  const git = await requiredExecutable('git');
+  const git = yield* requiredExecutable('git');
   const messages: string[] = [];
   const paths = typeof relativePath === 'string' ? [relativePath] : [...relativePath];
   const stageArgs = verb === 'rm' ? ['-C', worktree, 'rm', '--', ...paths] : ['-C', worktree, 'add', '--', ...paths];
-  const stageResult = await runGitCommand(dryRun, git, stageArgs, `git ${verb} failed`);
+  const stageResult = yield* runGitCommand(dryRun, git, stageArgs, `git ${verb} failed`);
   if (stageResult) {
     messages.push(`git ${verb}: ${stageResult.stdout.trim() || 'ok'}`);
   }
 
   if (dryRun) {
-    consoleOutput.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'commit', '-m', commitMessage])}`);
+    yield* Console.log(`Would run: ${formatShellCommand(git, ['-C', worktree, 'commit', '-m', commitMessage])}`);
   } else {
-    const commitResult = await runCommand(git, ['-C', worktree, 'commit', '-m', commitMessage], {allowFailure: true});
+    const commitResult = yield* runCommand(git, ['-C', worktree, 'commit', '-m', commitMessage], {allowFailure: true});
     if (commitResult.exitCode !== 0) {
       const detail = commitResult.stdout.trim() || commitResult.stderr.trim();
       if (/nothing to commit|no changes added/i.test(detail)) {
@@ -1410,7 +1637,7 @@ export async function publishShareGitChange(
     messages.push('git push skipped (push=false)');
     return messages;
   }
-  const pushResult = await runGitCommand(
+  const pushResult = yield* runGitCommand(
     dryRun,
     git,
     ['-C', worktree, 'push', DEFAULT_GIT_REMOTE_NAME],
@@ -1420,58 +1647,58 @@ export async function publishShareGitChange(
     messages.push(`git push: ${pushResult.stdout.trim() || pushResult.stderr.trim() || 'ok'}`);
   }
   return messages;
-}
+});
 
-async function runGitCommand(
+const runGitCommand = Effect.fn('share.runGitCommand')(function* (
   dryRun: boolean,
   git: string,
   args: readonly string[],
   failureLabel: string,
-): Promise<CommandResult | undefined> {
+) {
   if (dryRun) {
-    consoleOutput.log(`Would run: ${formatShellCommand(git, args)}`);
+    yield* Console.log(`Would run: ${formatShellCommand(git, args)}`);
     return undefined;
   }
-  const result = await runCommand(git, args, {allowFailure: true});
+  const result = yield* runCommand(git, args, {allowFailure: true});
   if (result.exitCode !== 0) {
     throw new Error(`${failureLabel}: ${result.stderr.trim() || result.stdout.trim() || 'unknown error'}`);
   }
   return result;
-}
+});
 
-export async function runSharePublish(
+export const runSharePublish = Effect.fn('share.runSharePublish')(function* (
   config: ShareRuntime,
   sourceUri: string,
   options: SharePublishOptions,
-): Promise<void> {
+) {
   assertVikingUri(sourceUri);
-  const team = await resolveTeam(config, options.team);
+  const team = yield* resolveTeam(config, options.team);
   const dryRun = options.dryRun === true;
   const preview = options.preview === true;
   if (isInSharedNamespace(config, sourceUri)) {
     throw new Error(`Memory ${sourceUri} is already in the shared namespace.`);
   }
-  const ov = await openVikingCliForMode(dryRun);
-  const rawContent = await readMemoryContent(config, ov, sourceUri, dryRun);
+  const ov = yield* openVikingCliForMode(dryRun);
+  const rawContent = yield* readMemoryContent(config, ov, sourceUri, dryRun);
   const stripped = stripPersonalProvenance(rawContent);
   const scrub = applyScrubber(stripped, {redact: options.redact === true});
   const targetUri = sharedUriFor(config, sourceUri, team.name);
 
   if (preview) {
-    consoleOutput.log(`PREVIEW source: ${sourceUri}`);
-    consoleOutput.log(`PREVIEW destination: ${targetUri}`);
+    yield* Console.log(`PREVIEW source: ${sourceUri}`);
+    yield* Console.log(`PREVIEW destination: ${targetUri}`);
     if (scrub.blocker) {
-      consoleOutput.log(
+      yield* Console.log(
         `PREVIEW BLOCKED: ${scrub.blocker}. Strip the sensitive value or rerun with --redact for soft-leak patterns.`,
       );
       return;
     }
     for (const redaction of scrub.redactions) {
-      consoleOutput.log(`PREVIEW redact: ${redaction.count}× ${redaction.name}`);
+      yield* Console.log(`PREVIEW redact: ${redaction.count}× ${redaction.name}`);
     }
-    consoleOutput.log('-----BEGIN PREVIEW-----');
-    consoleOutput.log(scrub.cleaned);
-    consoleOutput.log('-----END PREVIEW-----');
+    yield* Console.log('-----BEGIN PREVIEW-----');
+    yield* Console.log(scrub.cleaned);
+    yield* Console.log('-----END PREVIEW-----');
     return;
   }
 
@@ -1483,8 +1710,8 @@ export async function runSharePublish(
   const worktree = team.config.worktree;
   const relativePath = vikingUriToWorktreeRelative(config, targetUri, team.name);
   const message = options.message ?? `share: publish ${relativePath}`;
-  const publish = async () => {
-    const currentRawContent = dryRun ? rawContent : await readMemoryContent(config, ov, sourceUri, false);
+  const publish = Effect.fn('share.callback')(function* () {
+    const currentRawContent = dryRun ? rawContent : yield* readMemoryContent(config, ov, sourceUri, false);
     const currentScrub = applyScrubber(stripPersonalProvenance(currentRawContent), {
       redact: options.redact === true,
     });
@@ -1493,99 +1720,99 @@ export async function runSharePublish(
         `Refusing to publish ${sourceUri}: possible ${currentScrub.blocker}. Strip the sensitive value or pass --redact for soft-leak patterns.`,
       );
     }
-    if (!dryRun && (await vikingResourceExists(ov, config, targetUri))) {
+    if (!dryRun && (yield* vikingResourceExists(ov, config, targetUri))) {
       throw new Error(
         `Refusing to publish: ${targetUri} already exists in the shared namespace. Inspect it via threadnote read; if it should be replaced, forget the existing shared copy first.`,
       );
     }
-    await ensureSharedDirectoryChain(config, ov, targetUri, dryRun);
-    await writeMemoryFile(config, ov, targetUri, currentScrub.cleaned, 'create', dryRun);
+    yield* ensureSharedDirectoryChain(config, ov, targetUri, dryRun);
+    yield* writeMemoryFile(config, ov, targetUri, currentScrub.cleaned, 'create', dryRun);
     if (!dryRun) {
-      const storedTarget = await readMemoryContent(config, ov, targetUri, false);
+      const storedTarget = yield* readMemoryContent(config, ov, targetUri, false);
       if (canonicalMemoryDocumentContent(storedTarget) !== canonicalMemoryDocumentContent(currentScrub.cleaned)) {
         throw new Error(`Shared target verification failed after writing ${targetUri}; personal source preserved.`);
       }
     }
-    const gitMessages = await publishShareGitChange(worktree, relativePath, message, {
+    const gitMessages = yield* publishShareGitChange(worktree, relativePath, message, {
       dryRun,
       push: options.push,
     });
     if (!dryRun) {
-      const sourceBeforeRemoval = await readMemoryContent(config, ov, sourceUri, false);
+      const sourceBeforeRemoval = yield* readMemoryContent(config, ov, sourceUri, false);
       if (sourceBeforeRemoval.trim() !== currentRawContent.trim()) {
         throw new Error(`Memory ${sourceUri} changed during publication; personal source preserved.`);
       }
     }
-    await removeMemoryUri(config, ov, sourceUri, dryRun);
+    yield* removeMemoryUri(config, ov, sourceUri, dryRun);
     return {gitMessages, redactions: currentScrub.redactions};
-  };
-  const published = await publish();
+  });
+  const published = yield* publish();
   for (const redaction of published.redactions) {
-    consoleOutput.log(`Redacted ${redaction.count}× ${redaction.name} before publish.`);
+    yield* Console.log(`Redacted ${redaction.count}× ${redaction.name} before publish.`);
   }
   const gitMessages = published.gitMessages;
   for (const gitMessage of gitMessages) {
-    consoleOutput.log(gitMessage);
+    yield* Console.log(gitMessage);
   }
-  consoleOutput.log(`Published ${sourceUri} -> ${targetUri}`);
-}
+  yield* Console.log(`Published ${sourceUri} -> ${targetUri}`);
+});
 
-export async function runSharePublishArtifact(
+export const runSharePublishArtifact = Effect.fn('share.runSharePublishArtifact')(function* (
   config: ShareRuntime,
   sourcePath: string,
   options: SharePublishArtifactOptions,
-): Promise<void> {
-  const result = await shareAgentArtifact(config, sourcePath, options);
-  printShareArtifactResult(result, options.preview === true);
-}
+) {
+  const result = yield* shareAgentArtifact(config, sourcePath, options);
+  yield* printShareArtifactResult(result, options.preview === true);
+});
 
-export async function shareAgentArtifact(
+export const shareAgentArtifact = Effect.fn('share.shareAgentArtifact')(function* (
   config: ShareRuntime,
   sourcePath: string,
   options: SharePublishArtifactOptions,
-): Promise<ShareArtifactResult> {
-  const team = await resolveTeam(config, options.team);
-  const resolvedSourcePath = expandPath(sourcePath);
-  if (!(await isRegularFileNoSymlink(resolvedSourcePath))) {
+) {
+  const team = yield* resolveTeam(config, options.team);
+  const resolvedSourcePath = yield* expandPath(sourcePath);
+  if (!(yield* isRegularFileNoSymlink(resolvedSourcePath))) {
     throw new Error(`Agent artifact source is not a regular file: ${resolvedSourcePath}`);
   }
 
-  const artifact = inferShareArtifact(resolvedSourcePath, options);
+  const artifact = yield* inferShareArtifact(resolvedSourcePath, options);
   // A skill carries its whole directory. When companion files sit beside the
   // SKILL.md it is shared as a multi-file bundle; a lone SKILL.md takes the same
   // single-file path as before, byte-for-byte.
   if (artifact.kind === 'skill') {
-    const skillDir = dirname(resolvedSourcePath);
-    const members = await collectBundleMemberFiles(skillDir);
+    const skillDir = yield* pathDirname(resolvedSourcePath);
+    const members = yield* collectBundleMemberFiles(skillDir);
     if (members.length > 1) {
-      return shareBundleArtifact(config, team, artifact, skillDir, members, options);
+      return yield* shareBundleArtifact(config, team, artifact, skillDir, members, options);
     }
   }
-  return shareSingleArtifact(config, team, resolvedSourcePath, artifact, options);
-}
+  return yield* shareSingleArtifact(config, team, resolvedSourcePath, artifact, options);
+});
 
-type ResolvedShareTeam = Awaited<ReturnType<typeof resolveTeam>>;
+type ResolvedShareTeam = ResolvedTeam;
 
-async function shareSingleArtifact(
+const shareSingleArtifact = Effect.fn('share.shareSingleArtifact')(function* (
   config: ShareRuntime,
   team: ResolvedShareTeam,
   resolvedSourcePath: string,
   artifact: ShareArtifactMetadata,
   options: SharePublishArtifactOptions,
-): Promise<ShareArtifactResult> {
+) {
   const dryRun = options.dryRun === true;
   const preview = options.preview === true;
-  const rawContent = await readFile(resolvedSourcePath, 'utf8');
+  const rawContent = yield* readFile(resolvedSourcePath, 'utf8');
   if (!rawContent.trim()) {
     throw new Error(`Refusing to share empty agent artifact: ${resolvedSourcePath}`);
   }
   const scrub = applyScrubber(rawContent, {redact: options.redact === true});
   const relativePath = sharedArtifactRelativePath(artifact);
-  const targetPath = join(team.config.worktree, ...relativePath.split('/'));
-  const targetUri = workfileToVikingUri(config, team.config, targetPath);
+  const targetPath = yield* pathJoin(team.config.worktree, ...relativePath.split('/'));
+  const targetUri = yield* workfileToVikingUri(config, team.config, targetPath);
   const messages: string[] = [
     `${preview ? 'Previewing' : dryRun ? 'Would share' : 'Sharing'} ${artifact.kind} ${artifact.agent}/${artifact.name}`,
-    `Source: ${portablePath(resolvedSourcePath)}`,
+    `Source: ${yield* portablePath(resolvedSourcePath)}`,
     `Destination: ${targetUri}`,
   ];
 
@@ -1624,34 +1851,34 @@ async function shareSingleArtifact(
     messages.push(`Redacted ${redaction.count}× ${redaction.name} before sharing.`);
   }
   const content = scrub.cleaned;
-  const existingContent = (await readFileIfExists(targetPath)) ?? undefined;
+  const existingContent = (yield* readFileIfExists(targetPath)) ?? undefined;
   if (existingContent !== undefined && existingContent !== content && options.force !== true) {
     throw new Error(
-      `Shared artifact already exists with different content: ${portablePath(targetPath)}. Pass --force to replace it.`,
+      `Shared artifact already exists with different content: ${yield* portablePath(targetPath)}. Pass --force to replace it.`,
     );
   }
 
   if (dryRun) {
-    messages.push(`Would write shared artifact: ${portablePath(targetPath)}`);
+    messages.push(`Would write shared artifact: ${yield* portablePath(targetPath)}`);
   }
 
-  const ov = await openVikingCliForMode(dryRun);
-  const ovHasResource = !dryRun && (await vikingResourceExists(ov, config, targetUri));
-  await ensureSharedDirectoryChain(config, ov, targetUri, dryRun, {quiet: true});
-  await writeMemoryFile(config, ov, targetUri, content, ovHasResource ? 'replace' : 'create', dryRun, {quiet: true});
+  const ov = yield* openVikingCliForMode(dryRun);
+  const ovHasResource = !dryRun && (yield* vikingResourceExists(ov, config, targetUri));
+  yield* ensureSharedDirectoryChain(config, ov, targetUri, dryRun, {quiet: true});
+  yield* writeMemoryFile(config, ov, targetUri, content, ovHasResource ? 'replace' : 'create', dryRun, {quiet: true});
 
   const message = options.message ?? `share: publish ${relativePath}`;
-  const gitMessages = await publishShareGitChange(team.config.worktree, relativePath, message, {
+  const gitMessages = yield* publishShareGitChange(team.config.worktree, relativePath, message, {
     dryRun,
     push: options.push,
   });
   return {artifact, gitMessages, messages, sourcePath: resolvedSourcePath, targetPath, targetUri};
-}
+});
 
 interface PreparedBundleMember {
   readonly binary: boolean;
   readonly blocker?: string;
-  readonly content: Buffer | string;
+  readonly content: Uint8Array | string;
   readonly redactions: ReadonlyArray<{readonly count: number; readonly name: string}>;
   readonly relativePath: string;
   readonly sha256: string;
@@ -1659,24 +1886,24 @@ interface PreparedBundleMember {
   readonly targetUri: string;
 }
 
-async function shareBundleArtifact(
+const shareBundleArtifact = Effect.fn('share.shareBundleArtifact')(function* (
   config: ShareRuntime,
   team: ResolvedShareTeam,
   artifact: ShareArtifactMetadata,
   skillDir: string,
   members: readonly BundleMemberFile[],
   options: SharePublishArtifactOptions,
-): Promise<ShareArtifactResult> {
+) {
   const dryRun = options.dryRun === true;
   const preview = options.preview === true;
   const skillRootRelative = `${SHAREABLE_ARTIFACT_DIR}/skills/${artifact.agent}/${artifact.name}`;
-  const skillRootTargetDir = join(team.config.worktree, ...skillRootRelative.split('/'));
-  const skillMdTargetPath = join(skillRootTargetDir, 'SKILL.md');
-  const skillMdTargetUri = workfileToVikingUri(config, team.config, skillMdTargetPath);
+  const skillRootTargetDir = yield* pathJoin(team.config.worktree, ...skillRootRelative.split('/'));
+  const skillMdTargetPath = yield* pathJoin(skillRootTargetDir, 'SKILL.md');
+  const skillMdTargetUri = yield* workfileToVikingUri(config, team.config, skillMdTargetPath);
   const skillRootTargetUri = parentUri(skillMdTargetUri);
-  const skillMdSourcePath = join(skillDir, 'SKILL.md');
+  const skillMdSourcePath = yield* pathJoin(skillDir, 'SKILL.md');
 
-  const prepared = await Promise.all(
+  const prepared = yield* Effect.all(
     members.map(member => prepareBundleMember(config, team, member, skillRootTargetDir, options)),
   );
   const skillMd = prepared.find(entry => entry.relativePath === 'SKILL.md');
@@ -1689,7 +1916,7 @@ async function shareBundleArtifact(
 
   const messages: string[] = [
     `${preview ? 'Previewing' : dryRun ? 'Would share' : 'Sharing'} skill ${artifact.agent}/${artifact.name} bundle (${prepared.length} files)`,
-    `Source: ${portablePath(skillDir)}`,
+    `Source: ${yield* portablePath(skillDir)}`,
     `Destination: ${skillRootTargetUri}/`,
   ];
 
@@ -1728,16 +1955,16 @@ async function shareBundleArtifact(
   }
 
   for (const entry of prepared) {
-    const existing = await readFileBytesIfExists(entry.targetPath);
-    if (existing !== undefined && sha256(existing) !== entry.sha256 && options.force !== true) {
+    const existing = yield* readFileBytesIfExists(entry.targetPath);
+    if (existing !== undefined && (yield* sha256(existing)) !== entry.sha256 && options.force !== true) {
       throw new Error(
-        `Shared artifact already exists with different content: ${portablePath(entry.targetPath)}. Pass --force to replace it.`,
+        `Shared artifact already exists with different content: ${yield* portablePath(entry.targetPath)}. Pass --force to replace it.`,
       );
     }
   }
 
   if (dryRun) {
-    messages.push(`Would write ${prepared.length} files under ${portablePath(skillRootTargetDir)}`);
+    messages.push(`Would write ${prepared.length} files under ${yield* portablePath(skillRootTargetDir)}`);
     return {
       artifact,
       gitMessages: [],
@@ -1752,13 +1979,13 @@ async function shareBundleArtifact(
   // leading), so a failed OV write never leaves a worktree tree that a later
   // share sync would auto-commit without ingestion. Companion files and the
   // manifest are materialized only after every markdown write succeeds.
-  const ov = await openVikingCliForMode(dryRun);
+  const ov = yield* openVikingCliForMode(dryRun);
   const markdownMembers = orderSkillMdFirst(prepared.filter(entry => entry.relativePath.endsWith('.md')));
   const otherMembers = prepared.filter(entry => !entry.relativePath.endsWith('.md'));
   for (const entry of markdownMembers) {
-    const ovHasResource = await vikingResourceExists(ov, config, entry.targetUri);
-    await ensureSharedDirectoryChain(config, ov, entry.targetUri, dryRun, {quiet: true});
-    await writeMemoryFile(
+    const ovHasResource = yield* vikingResourceExists(ov, config, entry.targetUri);
+    yield* ensureSharedDirectoryChain(config, ov, entry.targetUri, dryRun, {quiet: true});
+    yield* writeMemoryFile(
       config,
       ov,
       entry.targetUri,
@@ -1768,12 +1995,12 @@ async function shareBundleArtifact(
       {quiet: true},
     );
   }
-  await ensureDirectory(skillRootTargetDir, false);
+  yield* ensureDirectory(skillRootTargetDir, false);
   for (const entry of otherMembers) {
-    await ensureDirectory(dirname(entry.targetPath), false);
-    await writeFile(entry.targetPath, entry.content, entry.binary ? {mode: 0o600} : {encoding: 'utf8', mode: 0o600});
+    yield* ensureDirectory(yield* pathDirname(entry.targetPath), false);
+    yield* writeFile(entry.targetPath, entry.content, entry.binary ? {mode: 0o600} : {encoding: 'utf8', mode: 0o600});
   }
-  await writeFile(join(skillRootTargetDir, BUNDLE_MANIFEST_FILE), buildBundleManifest(artifact, prepared), {
+  yield* writeFile(yield* pathJoin(skillRootTargetDir, BUNDLE_MANIFEST_FILE), buildBundleManifest(artifact, prepared), {
     encoding: 'utf8',
     mode: 0o600,
   });
@@ -1784,7 +2011,7 @@ async function shareBundleArtifact(
   ];
   const message =
     options.message ?? `share: publish skill ${artifact.agent}/${artifact.name} (${prepared.length} files)`;
-  const gitMessages = await publishShareGitChange(team.config.worktree, stagedPaths, message, {
+  const gitMessages = yield* publishShareGitChange(team.config.worktree, stagedPaths, message, {
     dryRun,
     push: options.push,
   });
@@ -1796,18 +2023,18 @@ async function shareBundleArtifact(
     targetPath: skillMdTargetPath,
     targetUri: skillMdTargetUri,
   };
-}
+});
 
-async function prepareBundleMember(
+const prepareBundleMember = Effect.fn('share.prepareBundleMember')(function* (
   config: ShareRuntime,
   team: ResolvedShareTeam,
   member: BundleMemberFile,
   skillRootTargetDir: string,
   options: SharePublishArtifactOptions,
-): Promise<PreparedBundleMember> {
-  const buffer = await readFile(member.absolutePath);
-  const targetPath = join(skillRootTargetDir, ...member.relativePath.split('/'));
-  const targetUri = workfileToVikingUri(config, team.config, targetPath);
+) {
+  const buffer = yield* readFile(member.absolutePath);
+  const targetPath = yield* pathJoin(skillRootTargetDir, ...member.relativePath.split('/'));
+  const targetUri = yield* workfileToVikingUri(config, team.config, targetPath);
   if (isProbablyBinary(buffer)) {
     const credential = detectBinaryCredential(buffer);
     const blocker =
@@ -1822,23 +2049,23 @@ async function prepareBundleMember(
       content: buffer,
       redactions: [],
       relativePath: member.relativePath,
-      sha256: sha256(buffer),
+      sha256: yield* sha256(buffer),
       targetPath,
       targetUri,
     };
   }
-  const scrub = applyScrubber(buffer.toString('utf8'), {redact: options.redact === true});
+  const scrub = applyScrubber(new TextDecoder().decode(buffer), {redact: options.redact === true});
   return {
     binary: false,
     blocker: scrub.blocker,
     content: scrub.cleaned,
     redactions: scrub.redactions,
     relativePath: member.relativePath,
-    sha256: sha256(scrub.cleaned),
+    sha256: yield* sha256(scrub.cleaned),
     targetPath,
     targetUri,
   };
-}
+});
 
 function orderSkillMdFirst(entries: readonly PreparedBundleMember[]): readonly PreparedBundleMember[] {
   return [...entries].sort((a, b) => {
@@ -1863,30 +2090,35 @@ function buildBundleManifest(artifact: ShareArtifactMetadata, prepared: readonly
   return `${JSON.stringify(manifest, undefined, 2)}\n`;
 }
 
-async function collectBundleMemberFiles(skillDir: string): Promise<readonly BundleMemberFile[]> {
+const collectBundleMemberFiles = Effect.fn('share.collectBundleMemberFiles')(function* (skillDir: string) {
   const out: BundleMemberFile[] = [];
-  async function visit(dir: string): Promise<void> {
-    const entries = await readdir(dir, {withFileTypes: true});
+  const visit: (dir: string) => Effect.Effect<void, unknown, FileSystem.FileSystem | Path.Path> = Effect.fn(
+    'share.visit',
+  )(function* (dir: string) {
+    const entries = yield* readdir(dir, {withFileTypes: true});
     for (const entry of entries) {
       if (entry.isSymbolicLink()) {
         continue;
       }
-      const full = join(dir, entry.name);
+      const full = yield* pathJoin(dir, entry.name);
       if (entry.isDirectory()) {
         if (!BUNDLE_IGNORE_DIR_NAMES.includes(entry.name)) {
-          await visit(full);
+          yield* visit(full);
         }
         continue;
       }
       if (!entry.isFile() || isIgnoredBundleFile(entry.name)) {
         continue;
       }
-      out.push({absolutePath: full, relativePath: relative(skillDir, full).split(sep).join('/')});
+      out.push({
+        absolutePath: full,
+        relativePath: (yield* pathRelative(skillDir, full)).split(yield* pathSeparator).join('/'),
+      });
     }
-  }
-  await visit(skillDir);
+  });
+  yield* visit(skillDir);
   return out.sort((a, b) => compareStrings(a.relativePath, b.relativePath));
-}
+});
 
 function isIgnoredBundleFile(name: string): boolean {
   if (name === '.DS_Store' || name === BUNDLE_MANIFEST_FILE || name === BUNDLE_INSTALL_METADATA_FILE) {
@@ -1898,7 +2130,7 @@ function isIgnoredBundleFile(name: string): boolean {
   return name.endsWith('.log') || name.endsWith('.threadnote-install.json');
 }
 
-function isProbablyBinary(buffer: Buffer): boolean {
+function isProbablyBinary(buffer: Uint8Array): boolean {
   if (buffer.includes(0)) {
     return true;
   }
@@ -1910,15 +2142,15 @@ function isProbablyBinary(buffer: Buffer): boolean {
   }
 }
 
-function detectBinaryCredential(buffer: Buffer): string | undefined {
-  return credentialScrubberBlocker(buffer.toString('latin1'));
+function detectBinaryCredential(buffer: Uint8Array): string | undefined {
+  return credentialScrubberBlocker(new TextDecoder('latin1').decode(buffer));
 }
 
 // Scans binary bytes for a machine-local path that the pack rewriter would
 // neutralize in text — a declared repo root, or a home-path soft-leak — so an
 // --allow-binary member cannot silently carry one.
-function detectBinaryLocalPath(buffer: Buffer, rewriteRoots: readonly string[]): string | undefined {
-  const latin1 = buffer.toString('latin1');
+function detectBinaryLocalPath(buffer: Uint8Array, rewriteRoots: readonly string[]): string | undefined {
+  const latin1 = new TextDecoder('latin1').decode(buffer);
   for (const root of rewriteRoots) {
     if (root.length > 0 && latin1.includes(root)) {
       return 'machine-local path';
@@ -1932,13 +2164,10 @@ function detectBinaryLocalPath(buffer: Buffer, rewriteRoots: readonly string[]):
   return undefined;
 }
 
-async function readFileBytesIfExists(path: string): Promise<Buffer | undefined> {
-  try {
-    return await readFile(path);
-  } catch (_err: unknown) {
-    return undefined;
-  }
-}
+const readFileBytesIfExists = Effect.fn('share.readFileBytesIfExists')(function* (path: string) {
+  const bytes = yield* readFile(path).pipe(Effect.option);
+  return Option.getOrUndefined(bytes);
+});
 
 function isBundleArtifact(artifact: SharedArtifactFile): boolean {
   if (artifact.artifact.kind === 'pack') {
@@ -1968,16 +2197,16 @@ interface PackManifest {
   readonly skills: readonly string[];
 }
 
-export async function runSharePublishBundle(
+export const runSharePublishBundle = Effect.fn('share.runSharePublishBundle')(function* (
   config: ShareRuntime,
   manifestPath: string,
   options: SharePublishArtifactOptions,
-): Promise<void> {
-  const result = await shareBundlePack(config, manifestPath, options);
-  printShareArtifactResult(result, options.preview === true);
-}
+) {
+  const result = yield* shareBundlePack(config, manifestPath, options);
+  yield* printShareArtifactResult(result, options.preview === true);
+});
 
-function parsePackManifest(raw: string, manifestPath: string): PackManifest {
+const parsePackManifest = Effect.fn('share.parsePackManifest')(function* (raw: string, manifestPath: string) {
   const parsed = parseJsonConfigObject(raw);
   if (parsed === undefined) {
     throw new Error(`Invalid pack manifest (not a JSON object): ${manifestPath}`);
@@ -2009,7 +2238,7 @@ function parsePackManifest(raw: string, manifestPath: string): PackManifest {
   // pathRewrites are matched as whole repo-root prefixes; a short or relative
   // value would corrupt unrelated content via substring replacement.
   for (const rewrite of pathRewrites) {
-    if (!isAbsolute(rewrite) || rewrite.split('/').filter(Boolean).length < 2) {
+    if (!(yield* pathIsAbsolute(rewrite)) || rewrite.split('/').filter(Boolean).length < 2) {
       throw new Error(
         `Pack manifest pathRewrites entry must be an absolute repo-root path (got "${rewrite}"): ${manifestPath}`,
       );
@@ -2028,50 +2257,53 @@ function parsePackManifest(raw: string, manifestPath: string): PackManifest {
     name,
     pathRewrites,
     skills,
-  };
-}
+  } as PackManifest;
+});
 
 // Resolves manifest skill + include entries into a flat, deduplicated member
 // list whose relative paths preserve the author's repo layout so relative
 // imports and CWD-relative invocations resolve once installed under one root.
-async function collectPackMembers(manifestDir: string, manifest: PackManifest): Promise<readonly BundleMemberFile[]> {
+const collectPackMembers = Effect.fn('share.collectPackMembers')(function* (
+  manifestDir: string,
+  manifest: PackManifest,
+) {
   const members = new Map<string, BundleMemberFile>();
-  const addEntry = async (entry: string): Promise<void> => {
+  const addEntry = Effect.fn('share.callback')(function* (entry: string) {
     const normalized = entry.split('/').filter(Boolean).join('/');
     if (normalized.split('/').includes('..')) {
       throw new Error(`Pack manifest entries must stay within the pack root (got "${entry}").`);
     }
-    const absolute = join(manifestDir, ...normalized.split('/'));
-    if (absolute !== manifestDir && !absolute.startsWith(manifestDir + sep)) {
+    const absolute = yield* pathJoin(manifestDir, ...normalized.split('/'));
+    if (absolute !== manifestDir && !absolute.startsWith(manifestDir + (yield* pathSeparator))) {
       throw new Error(`Pack manifest entry escapes the pack root: ${entry}`);
     }
-    if (await isDirectory(absolute)) {
-      for (const member of await collectBundleMemberFiles(absolute)) {
+    if (yield* isDirectory(absolute)) {
+      for (const member of yield* collectBundleMemberFiles(absolute)) {
         const relativePath = `${normalized}/${member.relativePath}`;
         members.set(relativePath, {absolutePath: member.absolutePath, relativePath});
       }
       return;
     }
-    if (await isRegularFileNoSymlink(absolute)) {
+    if (yield* isRegularFileNoSymlink(absolute)) {
       members.set(normalized, {absolutePath: absolute, relativePath: normalized});
       return;
     }
     throw new Error(`Pack manifest references a missing path: ${entry}`);
-  };
+  });
   for (const skill of manifest.skills) {
     // Accept either a skill directory or a path to its SKILL.md.
     const skillRel = skill.replace(/\/SKILL\.md$/i, '');
-    const skillDir = join(manifestDir, ...skillRel.split('/'));
-    if (!(await isFile(join(skillDir, 'SKILL.md')))) {
+    const skillDir = yield* pathJoin(manifestDir, ...skillRel.split('/'));
+    if (!(yield* isFile(yield* pathJoin(skillDir, 'SKILL.md')))) {
       throw new Error(`Pack skill "${skill}" must be a directory containing SKILL.md.`);
     }
-    await addEntry(skillRel);
+    yield* addEntry(skillRel);
   }
   for (const include of manifest.include) {
-    await addEntry(include);
+    yield* addEntry(include);
   }
   return [...members.values()].sort((a, b) => compareStrings(a.relativePath, b.relativePath));
-}
+});
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -2146,17 +2378,17 @@ function unportableAbsolutePaths(content: string): readonly string[] {
   return [...found].sort((a, b) => compareStrings(a, b));
 }
 
-async function preparePackMember(
+const preparePackMember = Effect.fn('share.preparePackMember')(function* (
   config: ShareRuntime,
   team: ResolvedShareTeam,
   member: BundleMemberFile,
   filesTargetDir: string,
   rewriteRoots: readonly string[],
   options: SharePublishArtifactOptions,
-): Promise<PreparedBundleMember> {
-  const buffer = await readFile(member.absolutePath);
-  const targetPath = join(filesTargetDir, ...member.relativePath.split('/'));
-  const targetUri = workfileToVikingUri(config, team.config, targetPath);
+) {
+  const buffer = yield* readFile(member.absolutePath);
+  const targetPath = yield* pathJoin(filesTargetDir, ...member.relativePath.split('/'));
+  const targetUri = yield* workfileToVikingUri(config, team.config, targetPath);
   if (isProbablyBinary(buffer)) {
     // Binary members cannot be tokenized or scrubbed, so an embedded credential
     // or machine-local path can never be neutralized — block rather than ship it
@@ -2177,12 +2409,12 @@ async function preparePackMember(
       content: buffer,
       redactions: [],
       relativePath: member.relativePath,
-      sha256: sha256(buffer),
+      sha256: yield* sha256(buffer),
       targetPath,
       targetUri,
     };
   }
-  const text = buffer.toString('utf8');
+  const text = new TextDecoder().decode(buffer);
   // A member that already contains the reserved token would have it expanded to
   // the installer's absolute path at install — block it as an authoring error.
   if (text.includes(PACK_ROOT_TOKEN)) {
@@ -2192,7 +2424,7 @@ async function preparePackMember(
       content: text,
       redactions: [],
       relativePath: member.relativePath,
-      sha256: sha256(text),
+      sha256: yield* sha256(text),
       targetPath,
       targetUri,
     };
@@ -2218,11 +2450,11 @@ async function preparePackMember(
     content: scrub.cleaned,
     redactions: scrub.redactions,
     relativePath: member.relativePath,
-    sha256: sha256(scrub.cleaned),
+    sha256: yield* sha256(scrub.cleaned),
     targetPath,
     targetUri,
   };
-}
+});
 
 function buildPackIndex(
   artifact: ShareArtifactMetadata,
@@ -2281,29 +2513,29 @@ function buildPackManifestJson(
   return `${JSON.stringify(data, undefined, 2)}\n`;
 }
 
-function packSkillName(skillEntry: string): string {
+const packSkillName = Effect.fn('share.packSkillName')(function* (skillEntry: string) {
   const trimmed = skillEntry.replace(/\/SKILL\.md$/i, '');
-  return basename(trimmed);
-}
+  return yield* pathBasename(trimmed);
+});
 
-export async function shareBundlePack(
+export const shareBundlePack = Effect.fn('share.shareBundlePack')(function* (
   config: ShareRuntime,
   manifestPath: string,
   options: SharePublishArtifactOptions,
-): Promise<ShareArtifactResult> {
-  const team = await resolveTeam(config, options.team);
+) {
+  const team = yield* resolveTeam(config, options.team);
   const dryRun = options.dryRun === true;
   const preview = options.preview === true;
-  const resolvedManifest = expandPath(manifestPath);
-  if (!(await isRegularFileNoSymlink(resolvedManifest))) {
+  const resolvedManifest = yield* expandPath(manifestPath);
+  if (!(yield* isRegularFileNoSymlink(resolvedManifest))) {
     throw new Error(`Pack manifest is not a regular file: ${resolvedManifest}`);
   }
-  const manifest = parsePackManifest(await readFile(resolvedManifest, 'utf8'), resolvedManifest);
-  const manifestDir = dirname(resolvedManifest);
+  const manifest = yield* parsePackManifest(yield* readFile(resolvedManifest, 'utf8'), resolvedManifest);
+  const manifestDir = yield* pathDirname(resolvedManifest);
   const artifact: ShareArtifactMetadata = {agent: manifest.agent, kind: 'pack', name: uriSegment(manifest.name)};
-  const skillNames = manifest.skills.map(packSkillName);
+  const skillNames = yield* Effect.all(manifest.skills.map(packSkillName));
 
-  const members = await collectPackMembers(manifestDir, manifest);
+  const members = yield* collectPackMembers(manifestDir, manifest);
   // Auto-derive the manifest dir as a rewrite root only when it is a plausible
   // repo root (>= 2 path segments); a short top-level dir like /tmp would
   // substring-corrupt unrelated paths. Declared pathRewrites are already guarded.
@@ -2315,12 +2547,12 @@ export async function shareBundlePack(
   const filesRelative = `${packRootRelative}/${PACK_FILES_DIR}`;
   const indexRelative = `${packRootRelative}/${artifact.name}${PACK_INDEX_SUFFIX}`;
   const manifestRelative = `${packRootRelative}/${artifact.name}${PACK_MANIFEST_SUFFIX}`;
-  const filesTargetDir = join(team.config.worktree, ...filesRelative.split('/'));
-  const packRootTargetDir = join(team.config.worktree, ...packRootRelative.split('/'));
-  const indexTargetPath = join(team.config.worktree, ...indexRelative.split('/'));
-  const indexTargetUri = workfileToVikingUri(config, team.config, indexTargetPath);
+  const filesTargetDir = yield* pathJoin(team.config.worktree, ...filesRelative.split('/'));
+  const packRootTargetDir = yield* pathJoin(team.config.worktree, ...packRootRelative.split('/'));
+  const indexTargetPath = yield* pathJoin(team.config.worktree, ...indexRelative.split('/'));
+  const indexTargetUri = yield* workfileToVikingUri(config, team.config, indexTargetPath);
 
-  const prepared = await Promise.all(
+  const prepared = yield* Effect.all(
     members.map(member => preparePackMember(config, team, member, filesTargetDir, rewriteRoots, options)),
   );
   // Tokenize the generated index + manifest too (not just member files) so an
@@ -2331,7 +2563,7 @@ export async function shareBundlePack(
 
   const messages: string[] = [
     `${preview ? 'Previewing' : dryRun ? 'Would share' : 'Sharing'} pack ${artifact.agent}/${artifact.name} (${prepared.length} files, ${skillNames.length} skills)`,
-    `Source: ${portablePath(manifestDir)}`,
+    `Source: ${yield* portablePath(manifestDir)}`,
     `Destination: ${indexTargetUri}`,
   ];
 
@@ -2408,16 +2640,16 @@ export async function shareBundlePack(
     );
   }
   for (const entry of prepared) {
-    const existing = await readFileBytesIfExists(entry.targetPath);
-    if (existing !== undefined && sha256(existing) !== entry.sha256 && options.force !== true) {
+    const existing = yield* readFileBytesIfExists(entry.targetPath);
+    if (existing !== undefined && (yield* sha256(existing)) !== entry.sha256 && options.force !== true) {
       throw new Error(
-        `Shared pack file already exists with different content: ${portablePath(entry.targetPath)}. Pass --force to replace it.`,
+        `Shared pack file already exists with different content: ${yield* portablePath(entry.targetPath)}. Pass --force to replace it.`,
       );
     }
   }
 
   if (dryRun) {
-    messages.push(`Would write ${prepared.length} files under ${portablePath(packRootTargetDir)}`);
+    messages.push(`Would write ${prepared.length} files under ${yield* portablePath(packRootTargetDir)}`);
     return {
       artifact,
       gitMessages: [],
@@ -2431,101 +2663,127 @@ export async function shareBundlePack(
   // Safety invariant: OpenViking-managed markdown is written first (the index
   // leads), so a failed OV write never leaves a worktree tree that a later share
   // sync would auto-commit without ingestion.
-  const ov = await openVikingCliForMode(dryRun);
+  const ov = yield* openVikingCliForMode(dryRun);
   // Restore-capable rollback: before overwriting any resource, snapshot its prior
   // bytes; on a mid-publish failure, undo in reverse — newly-created resources are
   // removed and replaced ones (a --force re-publish) are restored to their prior
   // content. This leaves the previously-published pack intact and nothing
   // inconsistent for a later share sync to auto-commit.
-  const rollbacks: Array<() => Promise<void>> = [];
-  const manifestTargetPath = join(team.config.worktree, ...manifestRelative.split('/'));
-  try {
-    const writeMarkdownMember = async (uri: string, content: string, worktreePath: string): Promise<void> => {
-      const priorBytes = await readFileBytesIfExists(worktreePath);
-      const hadResource = await vikingResourceExists(ov, config, uri);
-      await ensureSharedDirectoryChain(config, ov, uri, dryRun, {quiet: true});
-      await writeMemoryFile(config, ov, uri, content, hadResource ? 'replace' : 'create', dryRun, {quiet: true});
-      rollbacks.push(async () => {
-        if (priorBytes !== undefined) {
-          await writeMemoryFile(config, ov, uri, priorBytes.toString('utf8'), 'replace', false, {quiet: true});
-        } else if (await vikingResourceExists(ov, config, uri)) {
-          await removeMemoryUri(config, ov, uri, false, {quiet: true});
-        }
+  const rollbacks: Array<
+    () => Effect.Effect<void, unknown, CommandExecutor | FileSystem.FileSystem | Path.Path | SystemInfo>
+  > = [];
+  const manifestTargetPath = yield* pathJoin(team.config.worktree, ...manifestRelative.split('/'));
+  const publishResult = yield* Effect.result(
+    Effect.gen(function* () {
+      const writeMarkdownMember = Effect.fn('share.callback')(function* (
+        uri: string,
+        content: string,
+        worktreePath: string,
+      ) {
+        const priorBytes = yield* readFileBytesIfExists(worktreePath);
+        const hadResource = yield* vikingResourceExists(ov, config, uri);
+        yield* ensureSharedDirectoryChain(config, ov, uri, dryRun, {quiet: true});
+        yield* writeMemoryFile(config, ov, uri, content, hadResource ? 'replace' : 'create', dryRun, {quiet: true});
+        rollbacks.push(
+          Effect.fn('share.callback')(function* () {
+            if (priorBytes !== undefined) {
+              yield* writeMemoryFile(config, ov, uri, new TextDecoder().decode(priorBytes), 'replace', false, {
+                quiet: true,
+              });
+            } else if (yield* vikingResourceExists(ov, config, uri)) {
+              yield* removeMemoryUri(config, ov, uri, false, {quiet: true});
+            }
+          }),
+        );
       });
-    };
-    await writeMarkdownMember(indexTargetUri, indexScrub.cleaned, indexTargetPath);
-    for (const entry of prepared.filter(member => member.relativePath.endsWith('.md'))) {
-      await writeMarkdownMember(entry.targetUri, entry.content as string, entry.targetPath);
-    }
-    await ensureDirectory(filesTargetDir, false);
-    for (const entry of prepared.filter(member => !member.relativePath.endsWith('.md'))) {
-      const priorBytes = await readFileBytesIfExists(entry.targetPath);
-      await ensureDirectory(dirname(entry.targetPath), false);
-      await writeFile(entry.targetPath, entry.content, entry.binary ? {mode: 0o600} : {encoding: 'utf8', mode: 0o600});
-      rollbacks.push(async () => {
-        if (priorBytes !== undefined) {
-          await writeFile(entry.targetPath, priorBytes, {mode: 0o600});
-        } else {
-          await rm(entry.targetPath, {force: true});
-        }
-      });
-    }
-    await ensureDirectory(packRootTargetDir, false);
-    const priorManifest = await readFileBytesIfExists(manifestTargetPath);
-    await writeFile(manifestTargetPath, packJson.cleaned, {encoding: 'utf8', mode: 0o600});
-    rollbacks.push(async () => {
-      if (priorManifest !== undefined) {
-        await writeFile(manifestTargetPath, priorManifest, {mode: 0o600});
-      } else {
-        await rm(manifestTargetPath, {force: true});
+      yield* writeMarkdownMember(indexTargetUri, indexScrub.cleaned, indexTargetPath);
+      for (const entry of prepared.filter(member => member.relativePath.endsWith('.md'))) {
+        yield* writeMarkdownMember(entry.targetUri, entry.content as string, entry.targetPath);
       }
-    });
+      yield* ensureDirectory(filesTargetDir, false);
+      for (const entry of prepared.filter(member => !member.relativePath.endsWith('.md'))) {
+        const priorBytes = yield* readFileBytesIfExists(entry.targetPath);
+        yield* ensureDirectory(yield* pathDirname(entry.targetPath), false);
+        yield* writeFile(
+          entry.targetPath,
+          entry.content,
+          entry.binary ? {mode: 0o600} : {encoding: 'utf8', mode: 0o600},
+        );
+        rollbacks.push(
+          Effect.fn('share.callback')(function* () {
+            if (priorBytes !== undefined) {
+              yield* writeFile(entry.targetPath, priorBytes, {mode: 0o600});
+            } else {
+              yield* rm(entry.targetPath, {force: true});
+            }
+          }),
+        );
+      }
+      yield* ensureDirectory(packRootTargetDir, false);
+      const priorManifest = yield* readFileBytesIfExists(manifestTargetPath);
+      yield* writeFile(manifestTargetPath, packJson.cleaned, {encoding: 'utf8', mode: 0o600});
+      rollbacks.push(
+        Effect.fn('share.callback')(function* () {
+          if (priorManifest !== undefined) {
+            yield* writeFile(manifestTargetPath, priorManifest, {mode: 0o600});
+          } else {
+            yield* rm(manifestTargetPath, {force: true});
+          }
+        }),
+      );
 
-    // Prune files orphaned by a re-publish (members dropped from the manifest) so
-    // stale code is neither carried in the shared repo nor installed by teammates.
-    const currentFiles = new Set(prepared.map(entry => `${filesRelative}/${entry.relativePath}`));
-    const git = await requiredExecutable('git');
-    const tracked = await runCommand(git, ['-C', team.config.worktree, 'ls-files', '--', filesRelative], {
-      allowFailure: true,
-    });
-    const stalePaths =
-      tracked.exitCode === 0
-        ? tracked.stdout
-            .split('\n')
-            .map(line => line.trim())
-            .filter(line => line.length > 0 && !currentFiles.has(line))
-        : [];
-    for (const stale of stalePaths) {
-      await runCommand(git, ['-C', team.config.worktree, 'rm', '-f', '--ignore-unmatch', '--', stale], {
+      // Prune files orphaned by a re-publish (members dropped from the manifest) so
+      // stale code is neither carried in the shared repo nor installed by teammates.
+      const currentFiles = new Set(prepared.map(entry => `${filesRelative}/${entry.relativePath}`));
+      const git = yield* requiredExecutable('git');
+      const tracked = yield* runCommand(git, ['-C', team.config.worktree, 'ls-files', '--', filesRelative], {
         allowFailure: true,
       });
-      // Nested .md members are OV-ingested, so drop their resource too — keep the
-      // OpenViking index and the git tree in lockstep on the publisher's machine.
-      // Best-effort: the `git rm` deletion is already staged, so a single OV
-      // removal failure must not abort the publish (which would leave a staged
-      // deletion behind for a later sync); surface it as a warning instead.
-      if (stale.endsWith('.md')) {
-        const staleUri = workfileToVikingUri(config, team.config, join(team.config.worktree, ...stale.split('/')));
-        try {
-          if (await vikingResourceExists(ov, config, staleUri)) {
-            await removeMemoryUri(config, ov, staleUri, dryRun, {quiet: true});
-          }
-        } catch (pruneErr: unknown) {
-          messages.push(
-            `Warning: could not remove stale OpenViking resource ${staleUri}: ${pruneErr instanceof Error ? pruneErr.message : String(pruneErr)}`,
+      const stalePaths =
+        tracked.exitCode === 0
+          ? tracked.stdout
+              .split('\n')
+              .map(line => line.trim())
+              .filter(line => line.length > 0 && !currentFiles.has(line))
+          : [];
+      for (const stale of stalePaths) {
+        yield* runCommand(git, ['-C', team.config.worktree, 'rm', '-f', '--ignore-unmatch', '--', stale], {
+          allowFailure: true,
+        });
+        // Nested .md members are OV-ingested, so drop their resource too — keep the
+        // OpenViking index and the git tree in lockstep on the publisher's machine.
+        // Best-effort: the `git rm` deletion is already staged, so a single OV
+        // removal failure must not abort the publish (which would leave a staged
+        // deletion behind for a later sync); surface it as a warning instead.
+        if (stale.endsWith('.md')) {
+          const staleUri = yield* workfileToVikingUri(
+            config,
+            team.config,
+            yield* pathJoin(team.config.worktree, ...stale.split('/')),
           );
+          const pruneResult = yield* Effect.result(
+            Effect.gen(function* () {
+              if (yield* vikingResourceExists(ov, config, staleUri)) {
+                yield* removeMemoryUri(config, ov, staleUri, dryRun, {quiet: true});
+              }
+            }),
+          );
+          if (Result.isFailure(pruneResult)) {
+            const pruneErr = pruneResult.failure;
+            messages.push(
+              `Warning: could not remove stale OpenViking resource ${staleUri}: ${pruneErr instanceof Error ? pruneErr.message : String(pruneErr)}`,
+            );
+          }
         }
       }
-    }
-  } catch (publishErr: unknown) {
+    }),
+  );
+  if (Result.isFailure(publishResult)) {
     for (const undo of rollbacks.reverse()) {
-      try {
-        await undo();
-      } catch (_cleanupErr: unknown) {
-        // Best-effort rollback; surface the original failure regardless.
-      }
+      // Best-effort rollback; surface the original failure regardless.
+      yield* undo().pipe(Effect.ignore);
     }
-    throw publishErr;
+    return yield* Effect.fail(publishResult.failure);
   }
 
   const stagedPaths = [
@@ -2535,7 +2793,7 @@ export async function shareBundlePack(
   ];
   const message =
     options.message ?? `share: publish pack ${artifact.agent}/${artifact.name} (${prepared.length} files)`;
-  const gitMessages = await publishShareGitChange(team.config.worktree, stagedPaths, message, {
+  const gitMessages = yield* publishShareGitChange(team.config.worktree, stagedPaths, message, {
     dryRun,
     push: options.push,
   });
@@ -2547,50 +2805,50 @@ export async function shareBundlePack(
     targetPath: indexTargetPath,
     targetUri: indexTargetUri,
   };
-}
+});
 
-export async function runShareInstallArtifacts(
+export const runShareInstallArtifacts = Effect.fn('share.runShareInstallArtifacts')(function* (
   config: ShareRuntime,
   options: ShareInstallArtifactsOptions,
-): Promise<void> {
-  const result = await installSharedAgentArtifacts(config, options);
+) {
+  const result = yield* installSharedAgentArtifacts(config, options);
   if (result.syncedTeams.length > 0) {
-    consoleOutput.log(`Synced shared teams: ${result.syncedTeams.join(', ')}`);
+    yield* Console.log(`Synced shared teams: ${result.syncedTeams.join(', ')}`);
   }
   for (const warning of result.warnings) {
-    consoleOutput.warn(`Warning: ${warning}`);
+    yield* Console.warn(`Warning: ${warning}`);
   }
   for (const message of result.messages) {
-    consoleOutput.log(message);
+    yield* Console.log(message);
   }
-}
+});
 
-export async function listSharedAgentArtifacts(
+export const listSharedAgentArtifacts = Effect.fn('share.listSharedAgentArtifacts')(function* (
   config: ShareRuntime,
   options: ShareListArtifactsOptions = {},
-): Promise<SharedArtifactListResult> {
-  const syncResult = await maybeSyncSharedArtifacts(config, options);
-  const team = await resolveTeam(config, options.team);
-  const artifacts = filterSharedArtifacts(await collectSharedArtifacts(team.config.worktree, team.name), options);
+) {
+  const syncResult = yield* maybeSyncSharedArtifacts(config, options);
+  const team = yield* resolveTeam(config, options.team);
+  const artifacts = filterSharedArtifacts(yield* collectSharedArtifacts(team.config.worktree, team.name), options);
   const summaries: SharedArtifactSummary[] = [];
   for (const artifact of artifacts) {
     summaries.push({
       ...artifact,
-      installStatus: await sharedArtifactInstallStatus(artifact),
+      installStatus: yield* sharedArtifactInstallStatus(artifact),
       metadataPath: sharedArtifactMetadataPath(artifact),
     });
   }
   return {artifacts: summaries, syncedTeams: syncResult.syncedTeams, team: team.name, warnings: syncResult.warnings};
-}
+});
 
-export async function installSharedAgentArtifacts(
+export const installSharedAgentArtifacts = Effect.fn('share.installSharedAgentArtifacts')(function* (
   config: ShareRuntime,
   options: ShareInstallArtifactsOptions,
-): Promise<SharedArtifactInstallResult> {
-  const syncResult = await maybeSyncSharedArtifacts(config, options);
-  const team = await resolveTeam(config, options.team);
+) {
+  const syncResult = yield* maybeSyncSharedArtifacts(config, options);
+  const team = yield* resolveTeam(config, options.team);
   const dryRun = options.dryRun === true || options.apply !== true;
-  const allArtifacts = await collectSharedArtifacts(team.config.worktree, team.name);
+  const allArtifacts = yield* collectSharedArtifacts(team.config.worktree, team.name);
   const artifacts = filterSharedArtifacts(allArtifacts, options);
   const messages: string[] = [];
   if (artifacts.length === 0) {
@@ -2620,34 +2878,36 @@ export async function installSharedAgentArtifacts(
   let installedCount = 0;
   for (const artifact of artifacts) {
     if (isBundleArtifact(artifact)) {
-      installedCount += await installBundleArtifact(artifact, options, dryRun, messages);
+      installedCount += yield* installBundleArtifact(artifact, options, dryRun, messages);
       continue;
     }
     const label = sharedArtifactLabel(artifact.artifact);
-    const state = await sharedArtifactInstallState(artifact);
+    const state = yield* sharedArtifactInstallState(artifact);
     if (dryRun) {
       const verb = sharedArtifactDryRunVerb(state.status, options.force === true);
       const suffix = sharedArtifactDryRunSuffix(state.status, options.force === true);
-      messages.push(`${verb} ${label}: ${portablePath(artifact.installPath)}${suffix}`);
+      messages.push(`${verb} ${label}: ${yield* portablePath(artifact.installPath)}${suffix}`);
       continue;
     }
     if (
       (state.status === 'local_modified' || state.status === 'remote_changed_and_local_modified') &&
       options.force !== true
     ) {
-      throw new Error(`Refusing to overwrite ${portablePath(artifact.installPath)}. Pass force=true or --force.`);
+      throw new Error(
+        `Refusing to overwrite ${yield* portablePath(artifact.installPath)}. Pass force=true or --force.`,
+      );
     }
     if (state.status === 'current') {
-      await writeSharedArtifactMetadata(artifact, state.sourceSha);
-      messages.push(`Already installed ${label}: ${portablePath(artifact.installPath)}`);
+      yield* writeSharedArtifactMetadata(artifact, state.sourceSha);
+      messages.push(`Already installed ${label}: ${yield* portablePath(artifact.installPath)}`);
       continue;
     }
-    await ensureDirectory(dirname(artifact.installPath), false);
-    await writeFile(artifact.installPath, state.sourceContent, {encoding: 'utf8', mode: 0o600});
-    await writeSharedArtifactMetadata(artifact, state.sourceSha);
+    yield* ensureDirectory(yield* pathDirname(artifact.installPath), false);
+    yield* writeFile(artifact.installPath, state.sourceContent, {encoding: 'utf8', mode: 0o600});
+    yield* writeSharedArtifactMetadata(artifact, state.sourceSha);
     installedCount += 1;
     messages.push(
-      `${sharedArtifactInstallVerb(state.status, options.force === true)} ${label}: ${portablePath(artifact.installPath)}`,
+      `${sharedArtifactInstallVerb(state.status, options.force === true)} ${label}: ${yield* portablePath(artifact.installPath)}`,
     );
   }
   return {
@@ -2657,84 +2917,92 @@ export async function installSharedAgentArtifacts(
     team: team.name,
     warnings: syncResult.warnings,
   };
-}
+});
 
-export async function runShareUnpublish(
+export const runShareUnpublish = Effect.fn('share.runShareUnpublish')(function* (
   config: ShareRuntime,
   sourceUri: string,
   options: ShareUnpublishOptions,
-): Promise<void> {
+) {
   assertVikingUri(sourceUri);
-  const team = await resolveTeam(config, options.team);
+  const team = yield* resolveTeam(config, options.team);
   const dryRun = options.dryRun === true;
   if (!isInTeamNamespace(config, sourceUri, team.name)) {
     throw new Error(`Memory ${sourceUri} is not in team "${team.name}" shared namespace.`);
   }
-  const ov = await openVikingCliForMode(dryRun);
-  const content = await readMemoryContent(config, ov, sourceUri, dryRun);
+  const ov = yield* openVikingCliForMode(dryRun);
+  const content = yield* readMemoryContent(config, ov, sourceUri, dryRun);
   const targetUri = personalUriFor(config, sourceUri, team.name);
-  if (!dryRun && (await vikingResourceExists(ov, config, targetUri))) {
+  if (!dryRun && (yield* vikingResourceExists(ov, config, targetUri))) {
     throw new Error(
       `Refusing to unpublish: a personal memory already exists at ${targetUri}. Move or forget it first, then retry.`,
     );
   }
-  await writeMemoryFile(config, ov, targetUri, content, 'create', dryRun);
+  yield* writeMemoryFile(config, ov, targetUri, content, 'create', dryRun);
 
   const worktree = team.config.worktree;
   const relativePath = vikingUriToWorktreeRelative(config, sourceUri, team.name);
   const message = options.message ?? `share: unpublish ${relativePath}`;
-  const gitMessages = await publishShareGitChange(worktree, relativePath, message, {
+  const gitMessages = yield* publishShareGitChange(worktree, relativePath, message, {
     dryRun,
     push: options.push,
     verb: 'rm',
   });
   for (const gitMessage of gitMessages) {
-    consoleOutput.log(gitMessage);
+    yield* Console.log(gitMessage);
   }
-  try {
-    await removeMemoryUri(config, ov, sourceUri, dryRun);
-  } catch (err: unknown) {
-    throw new Error(
-      `Unpublished ${sourceUri} -> ${targetUri}, but could not remove the shared OpenViking source. Retry cleanup later with: threadnote forget ${sourceUri}\n${err instanceof Error ? err.message : String(err)}`,
-      {cause: err},
+  const removeResult = yield* Effect.result(removeMemoryUri(config, ov, sourceUri, dryRun));
+  if (Result.isFailure(removeResult)) {
+    const err = removeResult.failure;
+    return yield* Effect.fail(
+      new Error(
+        `Unpublished ${sourceUri} -> ${targetUri}, but could not remove the shared OpenViking source. Retry cleanup later with: threadnote forget ${sourceUri}\n${err instanceof Error ? err.message : String(err)}`,
+        {cause: err},
+      ),
     );
   }
-  consoleOutput.log(`Unpublished ${sourceUri} -> ${targetUri}`);
-}
+  yield* Console.log(`Unpublished ${sourceUri} -> ${targetUri}`);
+});
 
-export async function runShareList(config: ShareRuntime, _options: ShareListOptions): Promise<void> {
-  const teams = await readTeamsFile(config);
+export const runShareList = Effect.fn('share.runShareList')(function* (
+  config: ShareRuntime,
+  _options: ShareListOptions,
+) {
+  const teams = yield* readTeamsFile(config);
   const entries = Object.values(teams.teams);
   if (entries.length === 0) {
-    consoleOutput.log('No shared teams configured. Run: threadnote share init <remote-url>');
+    yield* Console.log('No shared teams configured. Run: threadnote share init <remote-url>');
     return;
   }
   for (const team of entries) {
     const marker = team.name === teams.defaultTeam ? ' (default)' : '';
-    consoleOutput.log(`- ${team.name}${marker}`);
-    consoleOutput.log(`    remote: ${team.remote}`);
-    consoleOutput.log(`    worktree: ${portablePath(team.worktree)}`);
-    consoleOutput.log(`    gitdir: ${portablePath(team.gitdir)}`);
-    consoleOutput.log(`    added: ${team.addedAt}`);
+    yield* Console.log(`- ${team.name}${marker}`);
+    yield* Console.log(`    remote: ${team.remote}`);
+    yield* Console.log(`    worktree: ${yield* portablePath(team.worktree)}`);
+    yield* Console.log(`    gitdir: ${yield* portablePath(team.gitdir)}`);
+    yield* Console.log(`    added: ${team.addedAt}`);
   }
-}
+});
 
-export async function runShareRename(config: ShareRuntime, options: ShareRenameOptions): Promise<void> {
-  const oldTeam = await resolveTeam(config, options.team);
+export const runShareRename = Effect.fn('share.runShareRename')(function* (
+  config: ShareRuntime,
+  options: ShareRenameOptions,
+) {
+  const oldTeam = yield* resolveTeam(config, options.team);
   const newName = normalizeTeamName(options.to);
   if (newName === oldTeam.name) {
     throw new Error(`Team is already named "${newName}".`);
   }
   const dryRun = options.dryRun === true;
-  const teamsFile = await readTeamsFile(config);
+  const teamsFile = yield* readTeamsFile(config);
   if (teamsFile.teams[newName]) {
     throw new Error(`Team "${newName}" is already configured.`);
   }
 
-  const newWorktree = teamWorktreePath(config, newName);
-  const newGitdir = teamGitdirPath(config, newName);
-  await assertDestinationAbsent(newWorktree, 'worktree');
-  await assertDestinationAbsent(newGitdir, 'gitdir');
+  const newWorktree = yield* teamWorktreePath(config, newName);
+  const newGitdir = yield* teamGitdirPath(config, newName);
+  yield* assertDestinationAbsent(newWorktree, 'worktree');
+  yield* assertDestinationAbsent(newGitdir, 'gitdir');
   const updatedTeam: ShareTeamConfig = {
     ...oldTeam.config,
     gitdir: newGitdir,
@@ -2756,101 +3024,113 @@ export async function runShareRename(config: ShareRuntime, options: ShareRenameO
   };
 
   if (dryRun) {
-    consoleOutput.log(
-      `Would rename worktree: ${portablePath(oldTeam.config.worktree)} -> ${portablePath(newWorktree)}`,
+    yield* Console.log(
+      `Would rename worktree: ${yield* portablePath(oldTeam.config.worktree)} -> ${yield* portablePath(newWorktree)}`,
     );
-    consoleOutput.log(`Would rename gitdir: ${portablePath(oldTeam.config.gitdir)} -> ${portablePath(newGitdir)}`);
-    consoleOutput.log(`Would update git core.worktree and the worktree .git pointer for team "${newName}".`);
-    consoleOutput.log(`Would reindex shared context under team "${newName}" and remove old shared URI tree.`);
-    consoleOutput.log(`Would write teams file: ${teamsFilePath(config)}`);
+    yield* Console.log(
+      `Would rename gitdir: ${yield* portablePath(oldTeam.config.gitdir)} -> ${yield* portablePath(newGitdir)}`,
+    );
+    yield* Console.log(`Would update git core.worktree and the worktree .git pointer for team "${newName}".`);
+    yield* Console.log(`Would reindex shared context under team "${newName}" and remove old shared URI tree.`);
+    yield* Console.log(`Would write teams file: ${yield* teamsFilePath(config)}`);
     return;
   }
 
-  const git = await requiredExecutable('git');
+  const git = yield* requiredExecutable('git');
   // A clone made with --separate-git-dir has a .git file in the worktree that
   // points at the external gitdir. Moving both paths first leaves that pointer
   // aimed at the old location, so `git -C <new-worktree>` can no longer open
   // the repository. Update the gitdir config before moving it, then rewrite
   // the pointer after both renames. Roll back the filesystem pair if any of
   // those steps fail so teams.json never advertises a half-renamed checkout.
-  await runCommand(git, ['--git-dir', oldTeam.config.gitdir, 'config', 'core.worktree', newWorktree]);
+  yield* runCommand(git, ['--git-dir', oldTeam.config.gitdir, 'config', 'core.worktree', newWorktree]);
   let movedWorktree = false;
   let movedGitdir = false;
-  try {
-    await rename(oldTeam.config.worktree, newWorktree);
-    movedWorktree = true;
-    await rename(oldTeam.config.gitdir, newGitdir);
-    movedGitdir = true;
-    await writeFile(join(newWorktree, '.git'), `gitdir: ${newGitdir}\n`, 'utf8');
-    await runCommand(git, ['--git-dir', newGitdir, '--work-tree', newWorktree, 'rev-parse', '--show-toplevel']);
-    await writeTeamsFile(config, updatedFile);
-  } catch (cause: unknown) {
-    if (movedGitdir && (await exists(newGitdir))) {
-      await rename(newGitdir, oldTeam.config.gitdir).catch(() => undefined);
+  const renameResult = yield* Effect.result(
+    Effect.gen(function* () {
+      yield* rename(oldTeam.config.worktree, newWorktree);
+      movedWorktree = true;
+      yield* rename(oldTeam.config.gitdir, newGitdir);
+      movedGitdir = true;
+      yield* writeFile(yield* pathJoin(newWorktree, '.git'), `gitdir: ${newGitdir}\n`, 'utf8');
+      yield* runCommand(git, ['--git-dir', newGitdir, '--work-tree', newWorktree, 'rev-parse', '--show-toplevel']);
+      yield* writeTeamsFile(config, updatedFile);
+    }),
+  );
+  if (Result.isFailure(renameResult)) {
+    if (movedGitdir && (yield* exists(newGitdir))) {
+      yield* rename(newGitdir, oldTeam.config.gitdir).pipe(Effect.ignore);
     }
-    if (movedWorktree && (await exists(newWorktree))) {
-      await writeFile(join(newWorktree, '.git'), `gitdir: ${oldTeam.config.gitdir}\n`, 'utf8').catch(() => undefined);
-      await rename(newWorktree, oldTeam.config.worktree).catch(() => undefined);
+    if (movedWorktree && (yield* exists(newWorktree))) {
+      yield* writeFile(yield* pathJoin(newWorktree, '.git'), `gitdir: ${oldTeam.config.gitdir}\n`, 'utf8').pipe(
+        Effect.ignore,
+      );
+      yield* rename(newWorktree, oldTeam.config.worktree).pipe(Effect.ignore);
     }
-    if (await exists(oldTeam.config.gitdir)) {
-      await runCommand(git, ['--git-dir', oldTeam.config.gitdir, 'config', 'core.worktree', oldTeam.config.worktree], {
+    if (yield* exists(oldTeam.config.gitdir)) {
+      yield* runCommand(git, ['--git-dir', oldTeam.config.gitdir, 'config', 'core.worktree', oldTeam.config.worktree], {
         allowFailure: true,
       });
     }
-    throw cause;
+    return yield* Effect.fail(renameResult.failure);
   }
-  const ingested = await ingestWorktreeFiles(config, updatedTeam, 'replace');
-  const ov = await openVikingCliForMode(false);
-  await removeMemoryUri(
+  const ingested = yield* ingestWorktreeFiles(config, updatedTeam, 'replace');
+  const ov = yield* openVikingCliForMode(false);
+  yield* removeMemoryUri(
     config,
     ov,
     `viking://user/${uriSegment(config.user)}/memories/${SHARED_SEGMENT}/${oldTeam.name}`,
     false,
   );
-  consoleOutput.log(`Renamed shared team "${oldTeam.name}" -> "${newName}".`);
-  consoleOutput.log(`Reindexed ${ingested} shared file(s).`);
-}
+  yield* Console.log(`Renamed shared team "${oldTeam.name}" -> "${newName}".`);
+  yield* Console.log(`Reindexed ${ingested} shared file(s).`);
+});
 
-export async function runShareSetUrl(
+export const runShareSetUrl = Effect.fn('share.runShareSetUrl')(function* (
   config: ShareRuntime,
   remoteUrl: string,
   options: ShareSetUrlOptions,
-): Promise<void> {
+) {
   if (!remoteUrl.trim()) {
     throw new Error('Provide a git remote URL.');
   }
-  const team = await resolveTeam(config, options.team);
+  const team = yield* resolveTeam(config, options.team);
   const dryRun = options.dryRun === true;
-  const git = await requiredExecutable('git');
+  const git = yield* requiredExecutable('git');
   if (dryRun) {
-    consoleOutput.log(
+    yield* Console.log(
       `Would run: ${formatShellCommand(git, ['-C', team.config.worktree, 'remote', 'set-url', DEFAULT_GIT_REMOTE_NAME, '--', remoteUrl])}`,
     );
-    consoleOutput.log(
+    yield* Console.log(
       `Would run: ${formatShellCommand(git, ['-C', team.config.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME])}`,
     );
-    consoleOutput.log(`Would write teams file: ${teamsFilePath(config)}`);
+    yield* Console.log(`Would write teams file: ${teamsFilePath(config)}`);
     return;
   }
-  await runCommand(git, ['-C', team.config.worktree, 'remote', 'set-url', DEFAULT_GIT_REMOTE_NAME, '--', remoteUrl]);
-  await runCommand(git, ['-C', team.config.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME]);
-  const teamsFile = await readTeamsFile(config);
+  yield* runCommand(git, ['-C', team.config.worktree, 'remote', 'set-url', DEFAULT_GIT_REMOTE_NAME, '--', remoteUrl]);
+  yield* runCommand(git, ['-C', team.config.worktree, 'fetch', DEFAULT_GIT_REMOTE_NAME]);
+  const teamsFile = yield* readTeamsFile(config);
   const updatedTeam: ShareTeamConfig = {...team.config, remote: remoteUrl};
-  await writeTeamsFile(config, {
+  yield* writeTeamsFile(config, {
     ...teamsFile,
     teams: {...teamsFile.teams, [team.name]: updatedTeam},
   });
-  consoleOutput.log(`Updated shared team "${team.name}" remote: ${remoteUrl}`);
-}
+  yield* Console.log(`Updated shared team "${team.name}" remote: ${remoteUrl}`);
+});
 
-export async function runShareRemove(config: ShareRuntime, options: ShareRemoveOptions): Promise<void> {
-  const team = await resolveTeam(config, options.team);
+export const runShareRemove = Effect.fn('share.runShareRemove')(function* (
+  config: ShareRuntime,
+  options: ShareRemoveOptions,
+) {
+  const team = yield* resolveTeam(config, options.team);
   const dryRun = options.dryRun === true;
   if (options.preserveLocal === true) {
-    const preserved = await preserveSharedMemoriesLocally(config, team.config, dryRun);
-    consoleOutput.log(`${dryRun ? 'Would preserve' : 'Preserved'} ${preserved} shared durable memory file(s) locally.`);
+    const preserved = yield* preserveSharedMemoriesLocally(config, team.config, dryRun);
+    yield* Console.log(
+      `${dryRun ? 'Would preserve' : 'Preserved'} ${preserved} shared durable memory file(s) locally.`,
+    );
   }
-  const teamsFile = await readTeamsFile(config);
+  const teamsFile = yield* readTeamsFile(config);
   const remaining: Record<string, ShareTeamConfig> = {};
   for (const [name, value] of Object.entries(teamsFile.teams)) {
     if (name !== team.name) {
@@ -2861,66 +3141,72 @@ export async function runShareRemove(config: ShareRuntime, options: ShareRemoveO
   const nextDefault = teamsFile.defaultTeam === team.name ? remainingNames[0] : teamsFile.defaultTeam;
   const updated: ShareTeamsFile = {defaultTeam: nextDefault, teams: remaining, version: TEAMS_FILE_VERSION};
   if (dryRun) {
-    consoleOutput.log(`Would update teams file: ${teamsFilePath(config)}`);
+    yield* Console.log(`Would update teams file: ${teamsFilePath(config)}`);
   } else {
-    await writeTeamsFile(config, updated);
-    consoleOutput.log(`Removed team "${team.name}" from teams.json.`);
+    yield* writeTeamsFile(config, updated);
+    yield* Console.log(`Removed team "${team.name}" from teams.json.`);
   }
   if (options.keepFiles !== true) {
-    await removePath(team.config.worktree, 'shared worktree', dryRun);
-    await removePath(team.config.gitdir, 'shared gitdir', dryRun);
+    yield* removePath(team.config.worktree, 'shared worktree', dryRun);
+    yield* removePath(team.config.gitdir, 'shared gitdir', dryRun);
   } else {
-    consoleOutput.log(`Keeping files at ${portablePath(team.config.worktree)} and ${portablePath(team.config.gitdir)}`);
+    yield* Console.log(
+      `Keeping files at ${yield* portablePath(team.config.worktree)} and ${yield* portablePath(team.config.gitdir)}`,
+    );
   }
-}
+});
 
-async function assertDestinationAbsent(path: string, label: string): Promise<void> {
-  if (await exists(path)) {
+const assertDestinationAbsent = Effect.fn('share.assertDestinationAbsent')(function* (path: string, label: string) {
+  if (yield* exists(path)) {
     throw new Error(`Cannot rename share: destination ${label} already exists at ${path}.`);
   }
-}
+});
 
-async function preserveSharedMemoriesLocally(
+const preserveSharedMemoriesLocally = Effect.fn('share.preserveSharedMemoriesLocally')(function* (
   config: ShareRuntime,
   team: ShareTeamConfig,
   dryRun: boolean,
-): Promise<number> {
-  const ov = await openVikingCliForMode(dryRun);
-  const files = await walkMemoryFiles(team.worktree);
+) {
+  const ov = yield* openVikingCliForMode(dryRun);
+  const files = yield* walkMemoryFiles(team.worktree);
   let preserved = 0;
   for (const file of files) {
-    const rel = relative(team.worktree, file).split(sep).join('/');
+    const rel = (yield* pathRelative(team.worktree, file)).split(yield* pathSeparator).join('/');
     if (!rel.startsWith('durable/')) {
       continue;
     }
     const targetUri = `viking://user/${uriSegment(config.user)}/memories/${rel}`;
-    const content = await readFile(file, 'utf8');
+    const content = yield* readFile(file, 'utf8');
     if (dryRun) {
-      consoleOutput.log(`Would preserve ${rel} -> ${targetUri}`);
+      yield* Console.log(`Would preserve ${rel} -> ${targetUri}`);
     } else {
-      await ensurePersonalDirectoryChain(config, ov, parentUri(targetUri));
-      await writeMemoryFile(config, ov, targetUri, content, 'create', false);
+      yield* ensurePersonalDirectoryChain(config, ov, parentUri(targetUri));
+      yield* writeMemoryFile(config, ov, targetUri, content, 'create', false);
     }
     preserved += 1;
   }
   return preserved;
-}
+});
 
-async function ensurePersonalDirectoryChain(config: ShareRuntime, ov: string, directoryUri: string): Promise<void> {
+const ensurePersonalDirectoryChain = Effect.fn('share.ensurePersonalDirectoryChain')(function* (
+  config: ShareRuntime,
+  ov: string,
+  directoryUri: string,
+) {
   const prefix = 'viking://';
   const parts = directoryUri.startsWith(prefix) ? directoryUri.slice(prefix.length).split('/').filter(Boolean) : [];
   const startIndex = parts[0] === 'user' && parts.length > 2 ? 3 : 1;
   for (let index = startIndex; index <= parts.length; index += 1) {
     const uri = `${prefix}${parts.slice(0, index).join('/')}`;
-    const statResult = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+    const statResult = yield* runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
     if (statResult.exitCode !== 0) {
-      await runCommand(
+      yield* runCommand(
         ov,
         withIdentity(config, ['mkdir', uri, '--description', 'Threadnote lifecycle-aware local memories.']),
       );
     }
   }
-}
+});
 
 function normalizeTeamName(input: string | undefined): string {
   const candidate = (input ?? 'default').trim();
@@ -2935,12 +3221,12 @@ function normalizeTeamName(input: string | undefined): string {
   return candidate;
 }
 
-function teamsFilePath(config: ShareRuntime): string {
-  return join(config.agentContextHome, 'share', 'teams.json');
-}
+const teamsFilePath = Effect.fn('share.teamsFilePath')(function* (config: ShareRuntime) {
+  return yield* pathJoin(config.agentContextHome, 'share', 'teams.json');
+});
 
-function teamWorktreePath(config: ShareRuntime, team: string): string {
-  return join(
+const teamWorktreePath = Effect.fn('share.teamWorktreePath')(function* (config: ShareRuntime, team: string) {
+  return yield* pathJoin(
     config.agentContextHome,
     'data',
     'viking',
@@ -2951,17 +3237,17 @@ function teamWorktreePath(config: ShareRuntime, team: string): string {
     SHARED_SEGMENT,
     team,
   );
-}
+});
 
-function teamGitdirPath(config: ShareRuntime, team: string): string {
-  return join(config.agentContextHome, 'share', 'teams', `${team}.gitdir`);
-}
+const teamGitdirPath = Effect.fn('share.teamGitdirPath')(function* (config: ShareRuntime, team: string) {
+  return yield* pathJoin(config.agentContextHome, 'share', 'teams', `${team}.gitdir`);
+});
 
-export async function readTeamsFile(config: ShareRuntime): Promise<ShareTeamsFile> {
-  const path = teamsFilePath(config);
-  const raw = await readFileIfExists(path);
+export const readTeamsFile = Effect.fn('share.readTeamsFile')(function* (config: ShareRuntime) {
+  const path = yield* teamsFilePath(config);
+  const raw = yield* readFileIfExists(path);
   if (!raw) {
-    return {teams: {}, version: TEAMS_FILE_VERSION};
+    return {teams: {}, version: TEAMS_FILE_VERSION} as ShareTeamsFile;
   }
   const parsed = parseJsonConfigObject(raw);
   if (!parsed) {
@@ -2976,40 +3262,43 @@ export async function readTeamsFile(config: ShareRuntime): Promise<ShareTeamsFil
   if (typeof parsed.teams === 'object' && parsed.teams !== null && !Array.isArray(parsed.teams)) {
     for (const [name, value] of Object.entries(parsed.teams)) {
       if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-        consoleOutput.warn(`Skipping non-object team entry "${name}" in ${path}.`);
+        yield* Console.warn(`Skipping non-object team entry "${name}" in ${path}.`);
         continue;
       }
       const entry = value as Record<string, unknown>;
       if (typeof entry.remote !== 'string' || entry.remote.length === 0) {
-        consoleOutput.warn(`Skipping team entry "${name}" in ${path}: missing or empty "remote" field.`);
+        yield* Console.warn(`Skipping team entry "${name}" in ${path}: missing or empty "remote" field.`);
         continue;
       }
       teams[name] = {
         addedAt: typeof entry.addedAt === 'string' ? entry.addedAt : new Date(0).toISOString(),
-        gitdir: typeof entry.gitdir === 'string' ? entry.gitdir : teamGitdirPath(config, name),
+        gitdir: typeof entry.gitdir === 'string' ? entry.gitdir : yield* teamGitdirPath(config, name),
         name,
         remote: entry.remote,
-        worktree: typeof entry.worktree === 'string' ? entry.worktree : teamWorktreePath(config, name),
+        worktree: typeof entry.worktree === 'string' ? entry.worktree : yield* teamWorktreePath(config, name),
       };
     }
   }
   const defaultTeam = typeof parsed.defaultTeam === 'string' ? parsed.defaultTeam : undefined;
-  return {defaultTeam, teams, version: TEAMS_FILE_VERSION};
-}
+  return {defaultTeam, teams, version: TEAMS_FILE_VERSION} as ShareTeamsFile;
+});
 
-async function writeTeamsFile(config: ShareRuntime, contents: ShareTeamsFile): Promise<void> {
-  const path = teamsFilePath(config);
-  await mkdir(dirname(path), {recursive: true});
+const writeTeamsFile = Effect.fn('share.writeTeamsFile')(function* (config: ShareRuntime, contents: ShareTeamsFile) {
+  const path = yield* teamsFilePath(config);
+  yield* mkdir(yield* pathDirname(path), {recursive: true});
   const serializable = {
     defaultTeam: contents.defaultTeam,
     teams: contents.teams,
     version: contents.version,
   };
-  await writeFile(path, `${JSON.stringify(serializable, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
-}
+  yield* writeFile(path, `${JSON.stringify(serializable, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
+});
 
-export async function resolveTeam(config: ShareRuntime, requested: string | undefined): Promise<ResolvedTeam> {
-  const teamsFile = await readTeamsFile(config);
+export const resolveTeam = Effect.fn('share.resolveTeam')(function* (
+  config: ShareRuntime,
+  requested: string | undefined,
+) {
+  const teamsFile = yield* readTeamsFile(config);
   const entries = Object.entries(teamsFile.teams);
   if (entries.length === 0) {
     throw new Error('No shared teams configured. Run: threadnote share init <remote-url>');
@@ -3021,7 +3310,7 @@ export async function resolveTeam(config: ShareRuntime, requested: string | unde
     throw new Error(`Team "${wantName}" is not configured. Known teams: ${known}`);
   }
   return {config: found, name: wantName};
-}
+});
 
 function shouldSetDefault(options: ShareInitOptions, existing: ShareTeamsFile): boolean {
   if (options.setDefault === true) {
@@ -3030,14 +3319,14 @@ function shouldSetDefault(options: ShareInitOptions, existing: ShareTeamsFile): 
   return existing.defaultTeam === undefined;
 }
 
-async function assertWorktreeUsable(worktree: string): Promise<void> {
-  if (!(await exists(worktree))) {
+const assertWorktreeUsable = Effect.fn('share.assertWorktreeUsable')(function* (worktree: string) {
+  if (!(yield* exists(worktree))) {
     return;
   }
-  if (!(await isDirectory(worktree))) {
+  if (!(yield* isDirectory(worktree))) {
     throw new Error(`Cannot use ${worktree} as a worktree: not a directory.`);
   }
-  const entries = await readdir(worktree);
+  const entries = yield* readdir(worktree);
   if (entries.length > 0) {
     const preview = entries.slice(0, 5).join(', ');
     const suffix = entries.length > 5 ? `, +${entries.length - 5} more` : '';
@@ -3045,67 +3334,72 @@ async function assertWorktreeUsable(worktree: string): Promise<void> {
       `Worktree ${worktree} is not empty (contains: ${preview}${suffix}). Move or remove its contents, then retry threadnote share init.`,
     );
   }
-}
+});
 
-async function ingestWorktreeFiles(
+const ingestWorktreeFiles = Effect.fn('share.ingestWorktreeFiles')(function* (
   config: ShareRuntime,
   team: ShareTeamConfig,
   initialMode: 'create' | 'replace',
-): Promise<number> {
-  const ov = await openVikingCliForMode(false);
-  const files = await walkMemoryFiles(team.worktree);
+) {
+  const ov = yield* openVikingCliForMode(false);
+  const files = yield* walkMemoryFiles(team.worktree);
   for (const file of files) {
-    const uri = workfileToVikingUri(config, team, file);
-    await ensureSharedDirectoryChain(config, ov, uri, false);
-    await ingestSingleFile(ov, config, uri, file, initialMode);
+    const uri = yield* workfileToVikingUri(config, team, file);
+    yield* ensureSharedDirectoryChain(config, ov, uri, false);
+    yield* ingestSingleFile(ov, config, uri, file, initialMode);
   }
   return files.length;
-}
+});
 
-async function walkMemoryFiles(root: string): Promise<readonly string[]> {
+const walkMemoryFiles = Effect.fn('share.walkMemoryFiles')(function* (root: string) {
   const out: string[] = [];
-  async function visit(path: string, depth: number): Promise<void> {
-    let entries;
-    try {
-      entries = await readdir(path, {withFileTypes: true});
-    } catch (err: unknown) {
-      consoleOutput.warn(
-        `Skipping ${path} during shared-tree walk: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return;
-    }
-    for (const entry of entries) {
-      if (entry.name === '.git') {
-        continue;
+  const visit: (path: string, depth: number) => Effect.Effect<void, unknown, FileSystem.FileSystem | Path.Path> =
+    Effect.fn('share.visit')(function* (path: string, depth: number) {
+      const entriesResult = yield* Effect.result(readdir(path, {withFileTypes: true}));
+      if (Result.isFailure(entriesResult)) {
+        const err = entriesResult.failure;
+        yield* Console.warn(
+          `Skipping ${path} during shared-tree walk: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return;
       }
-      const full = join(path, entry.name);
-      if (entry.isDirectory()) {
-        if (depth === 0 && !SHAREABLE_TOP_LEVEL_DIRS.includes(entry.name)) {
+      const entries = entriesResult.success;
+      for (const entry of entries) {
+        if (entry.name === '.git') {
           continue;
         }
-        await visit(full, depth + 1);
-        continue;
+        const full = yield* pathJoin(path, entry.name);
+        if (entry.isDirectory()) {
+          if (depth === 0 && !SHAREABLE_TOP_LEVEL_DIRS.includes(entry.name)) {
+            continue;
+          }
+          yield* visit(full, depth + 1);
+          continue;
+        }
+        if (!entry.isFile()) {
+          continue;
+        }
+        if (depth === 0) {
+          continue;
+        }
+        if (!entry.name.endsWith('.md') || OV_SUMMARY_FILES.includes(entry.name)) {
+          continue;
+        }
+        out.push(full);
       }
-      if (!entry.isFile()) {
-        continue;
-      }
-      if (depth === 0) {
-        continue;
-      }
-      if (!entry.name.endsWith('.md') || OV_SUMMARY_FILES.includes(entry.name)) {
-        continue;
-      }
-      out.push(full);
-    }
-  }
-  await visit(root, 0);
+    });
+  yield* visit(root, 0);
   return out;
-}
+});
 
-function workfileToVikingUri(config: ShareRuntime, team: ShareTeamConfig, filePath: string): string {
-  const rel = relative(team.worktree, filePath).split(sep).join('/');
+const workfileToVikingUri = Effect.fn('share.workfileToVikingUri')(function* (
+  config: ShareRuntime,
+  team: ShareTeamConfig,
+  filePath: string,
+) {
+  const rel = (yield* pathRelative(team.worktree, filePath)).split(yield* pathSeparator).join('/');
   return `viking://user/${uriSegment(config.user)}/memories/${SHARED_SEGMENT}/${team.name}/${rel}`;
-}
+});
 
 export function isInSharedNamespace(config: ShareRuntime, uri: string): boolean {
   return sharedTeamNameForUri(config, uri) !== undefined;
@@ -3171,18 +3465,17 @@ export function vikingUriToWorktreeRelative(config: ShareRuntime, uri: string, t
   return uri.slice(prefix.length);
 }
 
-async function isRegularFileNoSymlink(path: string): Promise<boolean> {
-  try {
-    const stat = await lstat(path);
-    return stat.isFile();
-  } catch (_err: unknown) {
-    return false;
-  }
-}
+const isRegularFileNoSymlink = Effect.fn('share.isRegularFileNoSymlink')(function* (path: string) {
+  const stat = yield* lstat(path).pipe(Effect.option);
+  return Option.isSome(stat) && stat.value.isFile();
+});
 
-function inferShareArtifact(path: string, options: SharePublishArtifactOptions): ShareArtifactMetadata {
-  const normalizedPath = path.split(sep).join('/');
-  const fileName = basename(path);
+const inferShareArtifact = Effect.fn('share.inferShareArtifact')(function* (
+  path: string,
+  options: SharePublishArtifactOptions,
+) {
+  const normalizedPath = path.split(yield* pathSeparator).join('/');
+  const fileName = yield* pathBasename(path);
   const lowerFileName = fileName.toLowerCase();
   const lowerPath = normalizedPath.toLowerCase();
   const inferredKind: ShareAgentArtifactKind | undefined =
@@ -3198,7 +3491,7 @@ function inferShareArtifact(path: string, options: SharePublishArtifactOptions):
       : undefined;
   const extensionIndex = fileName.lastIndexOf('.');
   const stem = extensionIndex > 0 ? fileName.slice(0, extensionIndex) : fileName;
-  const inferredName = lowerFileName === 'skill.md' ? basename(dirname(path)) : stem;
+  const inferredName = lowerFileName === 'skill.md' ? yield* pathBasename(yield* pathDirname(path)) : stem;
   const kind = options.kind ?? inferredKind;
   const agent = options.agent ?? inferredAgent;
   const name = options.name ?? inferredName;
@@ -3222,7 +3515,7 @@ function inferShareArtifact(path: string, options: SharePublishArtifactOptions):
     throw new Error('Artifact name cannot be empty.');
   }
   return {agent, kind, name: uriSegment(name)};
-}
+});
 
 function sharedArtifactRelativePath(artifact: ShareArtifactMetadata): string {
   if (artifact.kind === 'skill') {
@@ -3258,71 +3551,81 @@ function sharedArtifactFromRelativePath(relativePath: string): ShareArtifactMeta
   return undefined;
 }
 
-async function collectSharedArtifacts(worktree: string, team: string): Promise<readonly SharedArtifactFile[]> {
-  const root = join(worktree, SHAREABLE_ARTIFACT_DIR);
-  if (!(await isDirectory(root))) {
+const collectSharedArtifacts = Effect.fn('share.collectSharedArtifacts')(function* (worktree: string, team: string) {
+  const root = yield* pathJoin(worktree, SHAREABLE_ARTIFACT_DIR);
+  if (!(yield* isDirectory(root))) {
     return [];
   }
   const out: SharedArtifactFile[] = [];
-  async function visit(path: string): Promise<void> {
-    const entries = await readdir(path, {withFileTypes: true});
-    for (const entry of entries) {
-      const full = join(path, entry.name);
-      if (entry.isDirectory()) {
-        await visit(full);
-        continue;
-      }
-      if (!entry.isFile() || !entry.name.endsWith('.md')) {
-        continue;
-      }
-      const relativePath = relative(worktree, full).split(sep).join('/');
-      const artifact = sharedArtifactFromRelativePath(relativePath);
-      if (artifact === undefined) {
-        continue;
-      }
-      const artifactDir = dirname(full);
-      // An orphaned pack index without its .pack.json is an incomplete/partial
-      // publish; skip it so it neither pollutes the catalog nor breaks discovery.
-      if (artifact.kind === 'pack' && !(await isFile(join(artifactDir, `${artifact.name}${PACK_MANIFEST_SUFFIX}`)))) {
-        consoleOutput.warn(
-          `Skipping incomplete shared pack (missing ${artifact.name}${PACK_MANIFEST_SUFFIX}): ${relativePath}`,
+  const visit: (path: string) => Effect.Effect<void, unknown, FileSystem.FileSystem | Path.Path | SystemInfo> =
+    Effect.fn('share.visit')(function* (path: string) {
+      const entries = yield* readdir(path, {withFileTypes: true});
+      for (const entry of entries) {
+        const full = yield* pathJoin(path, entry.name);
+        if (entry.isDirectory()) {
+          yield* visit(full);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith('.md')) {
+          continue;
+        }
+        const relativePath = (yield* pathRelative(worktree, full)).split(yield* pathSeparator).join('/');
+        const artifact = sharedArtifactFromRelativePath(relativePath);
+        if (artifact === undefined) {
+          continue;
+        }
+        const artifactDir = yield* pathDirname(full);
+        // An orphaned pack index without its .pack.json is an incomplete/partial
+        // publish; skip it so it neither pollutes the catalog nor breaks discovery.
+        if (
+          artifact.kind === 'pack' &&
+          !(yield* isFile(yield* pathJoin(artifactDir, `${artifact.name}${PACK_MANIFEST_SUFFIX}`)))
+        ) {
+          yield* Console.warn(
+            `Skipping incomplete shared pack (missing ${artifact.name}${PACK_MANIFEST_SUFFIX}): ${relativePath}`,
+          );
+          continue;
+        }
+        // Isolate per-artifact discovery failures so one malformed artifact never
+        // denies listing/install of the rest of the team's catalog.
+        const artifactResult = yield* Effect.result(
+          Effect.gen(function* () {
+            return {
+              artifact,
+              installPath: yield* sharedArtifactInstallPath(team, artifact),
+              members: yield* collectArtifactMembers(artifact, artifactDir),
+              sourcePath: full,
+              sourceRelativePath: relativePath,
+              team,
+            } satisfies SharedArtifactFile;
+          }),
         );
-        continue;
+        if (Result.isSuccess(artifactResult)) {
+          out.push(artifactResult.success);
+        } else {
+          const err = artifactResult.failure;
+          yield* Console.warn(
+            `Skipping shared artifact ${relativePath}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
-      // Isolate per-artifact discovery failures so one malformed artifact never
-      // denies listing/install of the rest of the team's catalog.
-      try {
-        out.push({
-          artifact,
-          installPath: sharedArtifactInstallPath(team, artifact),
-          members: await collectArtifactMembers(artifact, artifactDir),
-          sourcePath: full,
-          sourceRelativePath: relativePath,
-          team,
-        });
-      } catch (err: unknown) {
-        consoleOutput.warn(
-          `Skipping shared artifact ${relativePath}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
-  }
-  await visit(root);
+    });
+  yield* visit(root);
   return out.sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
-}
+});
 
-async function collectArtifactMembers(
+const collectArtifactMembers = Effect.fn('share.collectArtifactMembers')(function* (
   artifact: ShareArtifactMetadata,
   artifactDir: string,
-): Promise<readonly BundleMemberFile[] | undefined> {
+) {
   if (artifact.kind === 'skill') {
-    return collectSharedBundleMembers(artifactDir);
+    return yield* collectSharedBundleMembers(artifactDir);
   }
   if (artifact.kind === 'pack') {
-    return collectSharedPackMembers(artifact, artifactDir);
+    return yield* collectSharedPackMembers(artifact, artifactDir);
   }
   return undefined;
-}
+});
 
 // A pack's installable members come from its published .pack.json (the
 // authoritative list), so files orphaned in files/ by a removal are not
@@ -3331,23 +3634,26 @@ async function collectArtifactMembers(
 // bundle manifest is git-carried (not scrubbed), so a malicious or corrupted
 // shared repo could otherwise use `..` or an absolute path to read/write outside
 // the install root.
-function isContainedMemberPath(baseDir: string, relativePath: string): boolean {
-  if (isAbsolute(relativePath) || relativePath.split('/').includes('..')) {
+const isContainedMemberPath = Effect.fn('share.isContainedMemberPath')(function* (
+  baseDir: string,
+  relativePath: string,
+) {
+  if ((yield* pathIsAbsolute(relativePath)) || relativePath.split('/').includes('..')) {
     return false;
   }
-  const resolved = join(baseDir, ...relativePath.split('/'));
-  return resolved === baseDir || resolved.startsWith(baseDir + sep);
-}
+  const resolved = yield* pathJoin(baseDir, ...relativePath.split('/'));
+  return resolved === baseDir || resolved.startsWith(baseDir + (yield* pathSeparator));
+});
 
-async function collectSharedPackMembers(
+const collectSharedPackMembers = Effect.fn('share.collectSharedPackMembers')(function* (
   artifact: ShareArtifactMetadata,
   packDir: string,
-): Promise<readonly BundleMemberFile[]> {
-  const filesDir = join(packDir, PACK_FILES_DIR);
-  if (!(await isDirectory(filesDir))) {
+) {
+  const filesDir = yield* pathJoin(packDir, PACK_FILES_DIR);
+  if (!(yield* isDirectory(filesDir))) {
     return [];
   }
-  const manifestRaw = await readFileIfExists(join(packDir, `${artifact.name}${PACK_MANIFEST_SUFFIX}`));
+  const manifestRaw = yield* readFileIfExists(yield* pathJoin(packDir, `${artifact.name}${PACK_MANIFEST_SUFFIX}`));
   if (manifestRaw !== undefined) {
     const rawMembers = parseJsonConfigObject(manifestRaw)?.members;
     if (Array.isArray(rawMembers)) {
@@ -3355,10 +3661,12 @@ async function collectSharedPackMembers(
       for (const entry of rawMembers) {
         const path = (entry as {path?: unknown})?.path;
         if (typeof path === 'string' && path.length > 0) {
-          if (!isContainedMemberPath(filesDir, path)) {
-            throw new Error(`Refusing pack member with an unsafe path that escapes the pack root: ${path}`);
+          if (!(yield* isContainedMemberPath(filesDir, path))) {
+            return yield* Effect.fail(
+              new Error(`Refusing pack member with an unsafe path that escapes the pack root: ${path}`),
+            );
           }
-          fromManifest.push({absolutePath: join(filesDir, ...path.split('/')), relativePath: path});
+          fromManifest.push({absolutePath: yield* pathJoin(filesDir, ...path.split('/')), relativePath: path});
         }
       }
       if (fromManifest.length > 0) {
@@ -3366,14 +3674,14 @@ async function collectSharedPackMembers(
       }
     }
   }
-  return collectBundleMemberFiles(filesDir);
-}
+  return yield* collectBundleMemberFiles(filesDir);
+});
 
 // Members of a shared skill directory. Prefers the published manifest as the
 // authoritative member list; falls back to walking the directory when it is a
 // legacy single-file skill or the manifest is unreadable.
-async function collectSharedBundleMembers(skillDir: string): Promise<readonly BundleMemberFile[]> {
-  const manifestRaw = await readFileIfExists(join(skillDir, BUNDLE_MANIFEST_FILE));
+const collectSharedBundleMembers = Effect.fn('share.collectSharedBundleMembers')(function* (skillDir: string) {
+  const manifestRaw = yield* readFileIfExists(yield* pathJoin(skillDir, BUNDLE_MANIFEST_FILE));
   if (manifestRaw !== undefined) {
     const parsed = parseJsonConfigObject(manifestRaw);
     const rawMembers = parsed?.members;
@@ -3382,10 +3690,12 @@ async function collectSharedBundleMembers(skillDir: string): Promise<readonly Bu
       for (const entry of rawMembers) {
         const path = (entry as {path?: unknown})?.path;
         if (typeof path === 'string' && path.length > 0) {
-          if (!isContainedMemberPath(skillDir, path)) {
-            throw new Error(`Refusing skill member with an unsafe path that escapes the skill root: ${path}`);
+          if (!(yield* isContainedMemberPath(skillDir, path))) {
+            return yield* Effect.fail(
+              new Error(`Refusing skill member with an unsafe path that escapes the skill root: ${path}`),
+            );
           }
-          fromManifest.push({absolutePath: join(skillDir, ...path.split('/')), relativePath: path});
+          fromManifest.push({absolutePath: yield* pathJoin(skillDir, ...path.split('/')), relativePath: path});
         }
       }
       if (fromManifest.length > 0) {
@@ -3393,8 +3703,8 @@ async function collectSharedBundleMembers(skillDir: string): Promise<readonly Bu
       }
     }
   }
-  return collectBundleMemberFiles(skillDir);
-}
+  return yield* collectBundleMemberFiles(skillDir);
+});
 
 function filterSharedArtifacts(
   artifacts: readonly SharedArtifactFile[],
@@ -3415,42 +3725,46 @@ function filterSharedArtifacts(
   });
 }
 
-async function maybeSyncSharedArtifacts(
+const maybeSyncSharedArtifacts = Effect.fn('share.maybeSyncSharedArtifacts')(function* (
   config: ShareRuntime,
   options: ShareInstallArtifactsOptions | ShareListArtifactsOptions,
-): Promise<AutoShareSyncResult> {
+) {
   if (options.sync === false) {
     return {syncedTeams: [], warnings: []};
   }
-  return syncSharedReposBeforeAgentRead(config);
-}
+  return yield* syncSharedReposBeforeAgentRead(config);
+});
 
-async function sharedArtifactInstallStatus(artifact: SharedArtifactFile): Promise<SharedArtifactInstallStatus> {
+const sharedArtifactInstallStatus = Effect.fn('share.sharedArtifactInstallStatus')(function* (
+  artifact: SharedArtifactFile,
+) {
   if (isBundleArtifact(artifact)) {
-    return sharedBundleInstallStatus(artifact);
+    return yield* sharedBundleInstallStatus(artifact);
   }
-  return (await sharedArtifactInstallState(artifact)).status;
-}
+  return (yield* sharedArtifactInstallState(artifact)).status;
+});
 
 interface BundleInstallMemberMetadata {
   readonly installedSha256: string;
   readonly sourceSha256: string;
 }
 
-function bundleInstallRoot(artifact: SharedArtifactFile): string {
+const bundleInstallRoot = Effect.fn('share.bundleInstallRoot')(function* (artifact: SharedArtifactFile) {
   // A pack installs as a whole tree, so its installPath is already the root; a
   // skill bundle's installPath is the SKILL.md, so the root is its parent.
-  return artifact.artifact.kind === 'pack' ? artifact.installPath : dirname(artifact.installPath);
-}
+  return artifact.artifact.kind === 'pack' ? artifact.installPath : yield* pathDirname(artifact.installPath);
+});
 
-function bundleInstallMetadataPath(artifact: SharedArtifactFile): string {
-  return join(bundleInstallRoot(artifact), BUNDLE_INSTALL_METADATA_FILE);
-}
-
-async function readBundleInstallMetadata(
+const bundleInstallMetadataPath = Effect.fn('share.bundleInstallMetadataPath')(function* (
   artifact: SharedArtifactFile,
-): Promise<Map<string, BundleInstallMemberMetadata> | undefined> {
-  const raw = await readFileIfExists(bundleInstallMetadataPath(artifact));
+) {
+  return yield* pathJoin(yield* bundleInstallRoot(artifact), BUNDLE_INSTALL_METADATA_FILE);
+});
+
+const readBundleInstallMetadata = Effect.fn('share.readBundleInstallMetadata')(function* (
+  artifact: SharedArtifactFile,
+) {
+  const raw = yield* readFileIfExists(yield* bundleInstallMetadataPath(artifact));
   if (raw === undefined) {
     return undefined;
   }
@@ -3479,20 +3793,22 @@ async function readBundleInstallMetadata(
     }
   }
   return map;
-}
+});
 
 // Folds per-member 3-way comparison (source vs installed vs recorded) into one
 // bundle status. A local edit to one member and an upstream change to a
 // different member both surface as remote_changed_and_local_modified so install
 // refuses to silently clobber local work.
-async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<SharedArtifactInstallStatus> {
+const sharedBundleInstallStatus = Effect.fn('share.sharedBundleInstallStatus')(function* (
+  artifact: SharedArtifactFile,
+) {
   const members = artifact.members ?? [];
-  const installRoot = bundleInstallRoot(artifact);
-  const metadata = await readBundleInstallMetadata(artifact);
+  const installRoot = yield* bundleInstallRoot(artifact);
+  const metadata = yield* readBundleInstallMetadata(artifact);
   // Expected on-disk bytes after the same transform install applies, so the
   // no-metadata fallback can recognize a pristine (token-expanded) install as
   // current instead of misreading it as a local modification.
-  const expanded = await prepareInstallMembers(members, installRoot, artifact.artifact.kind === 'pack');
+  const expanded = yield* prepareInstallMembers(members, installRoot, artifact.artifact.kind === 'pack');
   const expectedByPath = new Map(expanded.map(entry => [entry.relativePath, entry]));
   let installedCount = 0;
   let localChanged = false;
@@ -3507,13 +3823,15 @@ async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<
       remoteChanged = true;
       continue;
     }
-    const installedBytes = await readFileBytesIfExists(join(installRoot, ...member.relativePath.split('/')));
+    const installedBytes = yield* readFileBytesIfExists(
+      yield* pathJoin(installRoot, ...member.relativePath.split('/')),
+    );
     if (installedBytes === undefined) {
       remoteChanged = true;
       continue;
     }
     installedCount += 1;
-    const installedSha = sha256(installedBytes);
+    const installedSha = yield* sha256(installedBytes);
     const recorded = metadata?.get(member.relativePath);
     if (recorded === undefined) {
       // No recorded baseline (sidecar lost or a future-version sidecar): a byte
@@ -3541,8 +3859,8 @@ async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<
       remoteChanged = true;
       // The member was dropped upstream; if the user edited the now-orphaned
       // local copy, flag it so the install refuses to delete it without --force.
-      const installedBytes = await readFileBytesIfExists(join(installRoot, ...recordedPath.split('/')));
-      if (installedBytes !== undefined && sha256(installedBytes) !== recorded.installedSha256) {
+      const installedBytes = yield* readFileBytesIfExists(yield* pathJoin(installRoot, ...recordedPath.split('/')));
+      if (installedBytes !== undefined && (yield* sha256(installedBytes)) !== recorded.installedSha256) {
         localChanged = true;
       }
     }
@@ -3560,7 +3878,7 @@ async function sharedBundleInstallStatus(artifact: SharedArtifactFile): Promise<
     return 'local_modified';
   }
   return 'current';
-}
+});
 
 interface PreparedInstallMember {
   readonly installedBytes: Buffer;
@@ -3579,33 +3897,35 @@ function expandPackRoot(text: string, installRoot: string): string {
 // rewritten. installedSha256 is the on-disk sha (post-expansion), sourceSha256
 // the shared-repo sha — the split keeps update vs local-edit detection correct
 // even when expansion changes the bytes.
-async function prepareInstallMembers(
+const prepareInstallMembers = Effect.fn('share.prepareInstallMembers')(function* (
   members: readonly BundleMemberFile[],
   installRoot: string,
   expandTokens: boolean,
-): Promise<readonly PreparedInstallMember[]> {
-  const prepared = await Promise.all(
-    members.map(async (member): Promise<PreparedInstallMember | undefined> => {
-      // A member declared in the manifest but absent from files/ (partial sync /
-      // corrupt repo) is skipped rather than crashing the whole list/install.
-      const sourceBytes = await readFileBytesIfExists(member.absolutePath);
-      if (sourceBytes === undefined) {
-        return undefined;
-      }
-      const installedBytes =
-        expandTokens && !isProbablyBinary(sourceBytes)
-          ? Buffer.from(expandPackRoot(sourceBytes.toString('utf8'), installRoot), 'utf8')
-          : sourceBytes;
-      return {
-        installedBytes,
-        installedSha256: sha256(installedBytes),
-        relativePath: member.relativePath,
-        sourceSha256: sha256(sourceBytes),
-      };
-    }),
+) {
+  const prepared = yield* Effect.all(
+    members.map(
+      Effect.fn('share.callback')(function* (member) {
+        // A member declared in the manifest but absent from files/ (partial sync /
+        // corrupt repo) is skipped rather than crashing the whole list/install.
+        const sourceBytes = yield* readFileBytesIfExists(member.absolutePath);
+        if (sourceBytes === undefined) {
+          return undefined;
+        }
+        const installedBytes =
+          expandTokens && !isProbablyBinary(sourceBytes)
+            ? new TextEncoder().encode(expandPackRoot(new TextDecoder().decode(sourceBytes), installRoot))
+            : sourceBytes;
+        return {
+          installedBytes,
+          installedSha256: yield* sha256(installedBytes),
+          relativePath: member.relativePath,
+          sourceSha256: yield* sha256(sourceBytes),
+        };
+      }),
+    ),
   );
   return prepared.filter((member): member is PreparedInstallMember => member !== undefined);
-}
+});
 
 function serializeInstallMetadata(artifact: SharedArtifactFile, prepared: readonly PreparedInstallMember[]): string {
   const metadata = {
@@ -3624,87 +3944,97 @@ function serializeInstallMetadata(artifact: SharedArtifactFile, prepared: readon
   return `${JSON.stringify(metadata, undefined, 2)}\n`;
 }
 
-async function installBundleArtifact(
+const installBundleArtifact = Effect.fn('share.installBundleArtifact')(function* (
   artifact: SharedArtifactFile,
   options: ShareInstallArtifactsOptions,
   dryRun: boolean,
   messages: string[],
-): Promise<number> {
+) {
   const members = artifact.members ?? [];
-  const installRoot = bundleInstallRoot(artifact);
+  const installRoot = yield* bundleInstallRoot(artifact);
   const kindLabel = artifact.artifact.kind === 'pack' ? 'pack' : 'bundle';
   const label = `${sharedArtifactLabel(artifact.artifact)} ${kindLabel} (${members.length} files)`;
-  const status = await sharedBundleInstallStatus(artifact);
+  const status = yield* sharedBundleInstallStatus(artifact);
   if (dryRun) {
     const verb = sharedArtifactDryRunVerb(status, options.force === true);
     const suffix = sharedArtifactDryRunSuffix(status, options.force === true);
-    messages.push(`${verb} ${label}: ${portablePath(installRoot)}${suffix}`);
+    messages.push(`${verb} ${label}: ${yield* portablePath(installRoot)}${suffix}`);
     return 0;
   }
   if ((status === 'local_modified' || status === 'remote_changed_and_local_modified') && options.force !== true) {
-    throw new Error(`Refusing to overwrite ${portablePath(installRoot)}. Pass force=true or --force.`);
+    throw new Error(`Refusing to overwrite ${yield* portablePath(installRoot)}. Pass force=true or --force.`);
   }
-  const prepared = await prepareInstallMembers(members, installRoot, artifact.artifact.kind === 'pack');
+  const prepared = yield* prepareInstallMembers(members, installRoot, artifact.artifact.kind === 'pack');
   // A declared member whose shared source is unreadable (partial sync / corrupt
   // repo) must not silently drop from the install — that would delete the prior
   // installed copy on a routine update. Refuse unless forced.
   if (prepared.length < members.length && options.force !== true) {
     throw new Error(
-      `Refusing to install ${portablePath(installRoot)}: ${members.length - prepared.length} declared member(s) are unreadable in the shared pack (the shared worktree may be mid-sync). Retry after sync, or pass force=true / --force.`,
+      `Refusing to install ${yield* portablePath(installRoot)}: ${members.length - prepared.length} declared member(s) are unreadable in the shared pack (the shared worktree may be mid-sync). Retry after sync, or pass force=true / --force.`,
     );
   }
   if (status === 'current') {
-    await writeFile(bundleInstallMetadataPath(artifact), serializeInstallMetadata(artifact, prepared), {mode: 0o600});
-    messages.push(`Already installed ${label}: ${portablePath(installRoot)}`);
-    await surfacePackRequirements(artifact, messages);
+    yield* writeFile(yield* bundleInstallMetadataPath(artifact), serializeInstallMetadata(artifact, prepared), {
+      mode: 0o600,
+    });
+    messages.push(`Already installed ${label}: ${yield* portablePath(installRoot)}`);
+    yield* surfacePackRequirements(artifact, messages);
     return 0;
   }
 
   // Materialize into a sibling staging directory, then swap atomically so an
   // interrupted install can never leave a half-written, mixed-version tree.
   const stagingRoot = `${installRoot}.threadnote-staging`;
-  await rm(stagingRoot, {force: true, recursive: true});
+  yield* rm(stagingRoot, {force: true, recursive: true});
   for (const entry of prepared) {
-    const dest = join(stagingRoot, ...entry.relativePath.split('/'));
-    await ensureDirectory(dirname(dest), false);
-    await writeFile(dest, entry.installedBytes, {mode: 0o600});
+    const dest = yield* pathJoin(stagingRoot, ...entry.relativePath.split('/'));
+    yield* ensureDirectory(yield* pathDirname(dest), false);
+    yield* writeFile(dest, entry.installedBytes, {mode: 0o600});
   }
-  await writeFile(join(stagingRoot, BUNDLE_INSTALL_METADATA_FILE), serializeInstallMetadata(artifact, prepared), {
-    mode: 0o600,
-  });
+  yield* writeFile(
+    yield* pathJoin(stagingRoot, BUNDLE_INSTALL_METADATA_FILE),
+    serializeInstallMetadata(artifact, prepared),
+    {
+      mode: 0o600,
+    },
+  );
   // Swap via a backup rename so the prior install is never lost: if the final
   // rename fails (or the process dies mid-swap), the old tree is either still in
   // place or recoverable from the backup, never gone with nothing to replace it.
-  await ensureDirectory(dirname(installRoot), false);
+  yield* ensureDirectory(yield* pathDirname(installRoot), false);
   const backupRoot = `${installRoot}.threadnote-old`;
-  await rm(backupRoot, {force: true, recursive: true});
-  const hadPriorInstall = await exists(installRoot);
+  yield* rm(backupRoot, {force: true, recursive: true});
+  const hadPriorInstall = yield* exists(installRoot);
   if (hadPriorInstall) {
-    await rename(installRoot, backupRoot);
+    yield* rename(installRoot, backupRoot);
   }
-  try {
-    await rename(stagingRoot, installRoot);
-  } catch (swapErr: unknown) {
+  const swapResult = yield* Effect.result(rename(stagingRoot, installRoot));
+  if (Result.isFailure(swapResult)) {
     if (hadPriorInstall) {
-      await rename(backupRoot, installRoot);
+      yield* rename(backupRoot, installRoot);
     }
-    throw swapErr;
+    return yield* Effect.fail(swapResult.failure);
   }
-  await rm(backupRoot, {force: true, recursive: true});
-  messages.push(`${sharedArtifactInstallVerb(status, options.force === true)} ${label}: ${portablePath(installRoot)}`);
-  await surfacePackRequirements(artifact, messages);
+  yield* rm(backupRoot, {force: true, recursive: true});
+  messages.push(
+    `${sharedArtifactInstallVerb(status, options.force === true)} ${label}: ${yield* portablePath(installRoot)}`,
+  );
+  yield* surfacePackRequirements(artifact, messages);
   return 1;
-}
+});
 
 // Threadnote ships files, not runtimes or MCP servers. After installing a pack,
 // surface its declared external dependencies so the teammate knows what they
 // must provision before it will actually run.
-async function surfacePackRequirements(artifact: SharedArtifactFile, messages: string[]): Promise<void> {
+const surfacePackRequirements = Effect.fn('share.surfacePackRequirements')(function* (
+  artifact: SharedArtifactFile,
+  messages: string[],
+) {
   if (artifact.artifact.kind !== 'pack') {
     return;
   }
-  const raw = await readFileIfExists(
-    join(dirname(artifact.sourcePath), `${artifact.artifact.name}${PACK_MANIFEST_SUFFIX}`),
+  const raw = yield* readFileIfExists(
+    yield* pathJoin(yield* pathDirname(artifact.sourcePath), `${artifact.artifact.name}${PACK_MANIFEST_SUFFIX}`),
   );
   if (raw === undefined) {
     return;
@@ -3724,22 +4054,37 @@ async function surfacePackRequirements(artifact: SharedArtifactFile, messages: s
   if (mcp.length > 0) {
     messages.push(`Configure these MCP server(s) separately: ${mcp.join(', ')}.`);
   }
-}
+});
 
-async function sharedArtifactInstallState(artifact: SharedArtifactFile): Promise<SharedArtifactInstallState> {
-  const sourceContent = await readFile(artifact.sourcePath, 'utf8');
-  const sourceSha = sha256(sourceContent);
-  const existingContent = (await readFileIfExists(artifact.installPath)) ?? undefined;
+const sharedArtifactInstallState = Effect.fn('share.sharedArtifactInstallState')(function* (
+  artifact: SharedArtifactFile,
+) {
+  const sourceContent = yield* readFile(artifact.sourcePath, 'utf8');
+  const sourceSha = yield* sha256(sourceContent);
+  const existingContent = (yield* readFileIfExists(artifact.installPath)) ?? undefined;
   if (existingContent === undefined) {
-    return {sourceContent, sourceSha, status: 'not_installed'};
+    return {sourceContent, sourceSha, status: 'not_installed'} as SharedArtifactInstallState;
   }
-  const existingSha = sha256(existingContent);
-  const metadata = await readSharedArtifactMetadata(artifact);
+  const existingSha = yield* sha256(existingContent);
+  const metadata = yield* readSharedArtifactMetadata(artifact);
   if (existingSha === sourceSha) {
-    return {existingContent, existingSha, metadata, sourceContent, sourceSha, status: 'current'};
+    return {
+      existingContent,
+      existingSha,
+      metadata,
+      sourceContent,
+      sourceSha,
+      status: 'current',
+    } as SharedArtifactInstallState;
   }
   if (metadata === undefined) {
-    return {existingContent, existingSha, sourceContent, sourceSha, status: 'local_modified'};
+    return {
+      existingContent,
+      existingSha,
+      sourceContent,
+      sourceSha,
+      status: 'local_modified',
+    } as SharedArtifactInstallState;
   }
   const remoteChanged = metadata.sourceSha256 !== sourceSha;
   const localChanged = metadata.installedSha256 !== existingSha;
@@ -3751,18 +4096,32 @@ async function sharedArtifactInstallState(artifact: SharedArtifactFile): Promise
       sourceContent,
       sourceSha,
       status: 'remote_changed_and_local_modified',
-    };
+    } as SharedArtifactInstallState;
   }
   if (remoteChanged) {
-    return {existingContent, existingSha, metadata, sourceContent, sourceSha, status: 'update_available'};
+    return {
+      existingContent,
+      existingSha,
+      metadata,
+      sourceContent,
+      sourceSha,
+      status: 'update_available',
+    } as SharedArtifactInstallState;
   }
-  return {existingContent, existingSha, metadata, sourceContent, sourceSha, status: 'local_modified'};
-}
+  return {
+    existingContent,
+    existingSha,
+    metadata,
+    sourceContent,
+    sourceSha,
+    status: 'local_modified',
+  } as SharedArtifactInstallState;
+});
 
-async function readSharedArtifactMetadata(
+const readSharedArtifactMetadata = Effect.fn('share.readSharedArtifactMetadata')(function* (
   artifact: SharedArtifactFile,
-): Promise<SharedArtifactInstallMetadata | undefined> {
-  const raw = await readFileIfExists(sharedArtifactMetadataPath(artifact));
+) {
+  const raw = yield* readFileIfExists(sharedArtifactMetadataPath(artifact));
   if (raw === undefined) {
     return undefined;
   }
@@ -3800,9 +4159,12 @@ async function readSharedArtifactMetadata(
     team: parsed.team,
     version: ARTIFACT_INSTALL_METADATA_VERSION,
   };
-}
+});
 
-async function writeSharedArtifactMetadata(artifact: SharedArtifactFile, sourceSha: string): Promise<void> {
+const writeSharedArtifactMetadata = Effect.fn('share.writeSharedArtifactMetadata')(function* (
+  artifact: SharedArtifactFile,
+  sourceSha: string,
+) {
   const metadata: SharedArtifactInstallMetadata = {
     artifact: artifact.artifact,
     installedAt: new Date().toISOString(),
@@ -3813,9 +4175,9 @@ async function writeSharedArtifactMetadata(artifact: SharedArtifactFile, sourceS
     version: ARTIFACT_INSTALL_METADATA_VERSION,
   };
   const metadataPath = sharedArtifactMetadataPath(artifact);
-  await ensureDirectory(dirname(metadataPath), false);
-  await writeFile(metadataPath, `${JSON.stringify(metadata, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
-}
+  yield* ensureDirectory(yield* pathDirname(metadataPath), false);
+  yield* writeFile(metadataPath, `${JSON.stringify(metadata, undefined, 2)}\n`, {encoding: 'utf8', mode: 0o600});
+});
 
 function sharedArtifactMetadataPath(artifact: SharedArtifactFile): string {
   return `${artifact.installPath}.threadnote-install.json`;
@@ -3870,34 +4232,41 @@ function sharedArtifactLabel(artifact: ShareArtifactMetadata): string {
   return `${artifact.kind} ${artifact.agent}/${artifact.name}`;
 }
 
-function sharedArtifactInstallPath(team: string, artifact: ShareArtifactMetadata): string {
+const sharedArtifactInstallPath = Effect.fn('share.sharedArtifactInstallPath')(function* (
+  team: string,
+  artifact: ShareArtifactMetadata,
+) {
+  const system = yield* SystemInfo;
   const agentDir = artifact.agent === 'codex' ? '.codex' : '.claude';
   if (artifact.kind === 'pack') {
     // Packs install under a dedicated `threadnote-packs` namespace so a pack and
     // a same-named skill can never share an install root or metadata file. The
     // `threadnote`/`threadnote-packs` segment is Threadnote-controlled, never a
     // user skill name, so the two trees are structurally disjoint.
-    return join(homedir(), agentDir, 'skills', 'threadnote-packs', team, artifact.name);
+    return yield* pathJoin(system.homeDirectory, agentDir, 'skills', 'threadnote-packs', team, artifact.name);
   }
   if (artifact.kind === 'skill') {
-    return join(homedir(), agentDir, 'skills', 'threadnote', team, artifact.name, 'SKILL.md');
+    return yield* pathJoin(system.homeDirectory, agentDir, 'skills', 'threadnote', team, artifact.name, 'SKILL.md');
   }
-  return join(homedir(), '.claude', 'commands', 'threadnote', team, `${artifact.name}.md`);
-}
+  return yield* pathJoin(system.homeDirectory, '.claude', 'commands', 'threadnote', team, `${artifact.name}.md`);
+});
 
-function printShareArtifactResult(result: ShareArtifactResult, preview: boolean): void {
+const printShareArtifactResult = Effect.fn('share.printShareArtifactResult')(function* (
+  result: ShareArtifactResult,
+  preview: boolean,
+) {
   for (const message of result.messages) {
-    consoleOutput.log(message);
+    yield* Console.log(message);
   }
   for (const gitMessage of result.gitMessages) {
-    consoleOutput.log(gitMessage);
+    yield* Console.log(gitMessage);
   }
   if (preview && result.previewContent !== undefined) {
-    consoleOutput.log('-----BEGIN PREVIEW-----');
-    consoleOutput.log(result.previewContent);
-    consoleOutput.log('-----END PREVIEW-----');
+    yield* Console.log('-----BEGIN PREVIEW-----');
+    yield* Console.log(result.previewContent);
+    yield* Console.log('-----END PREVIEW-----');
   }
-}
+});
 
 /**
  * Removes personal lifecycle, candidate, session, evidence, and relation
@@ -3935,46 +4304,51 @@ export function stripPersonalProvenance(content: string): string {
   return cleaned.join('\n');
 }
 
-async function readMemoryContent(config: ShareRuntime, ov: string, uri: string, dryRun: boolean): Promise<string> {
+const readMemoryContent = Effect.fn('share.readMemoryContent')(function* (
+  config: ShareRuntime,
+  ov: string,
+  uri: string,
+  dryRun: boolean,
+) {
   const args = withIdentity(config, ['read', uri]);
   if (dryRun) {
-    consoleOutput.log(`Would run: ${formatShellCommand(ov, args)}`);
+    yield* Console.log(`Would run: ${formatShellCommand(ov, args)}`);
     return '<dry-run memory body>';
   }
-  const result = await runCommand(ov, args);
+  const result = yield* runCommand(ov, args);
   if (!result.stdout.trim()) {
     throw new Error(`Refusing to publish empty memory at ${uri}`);
   }
   return result.stdout;
-}
+});
 
-export async function ensureSharedDirectoryChain(
+export const ensureSharedDirectoryChain = Effect.fn('share.ensureSharedDirectoryChain')(function* (
   config: ShareRuntime,
   ov: string,
   memoryUri: string,
   dryRun: boolean,
   options: {readonly quiet?: boolean} = {},
-): Promise<void> {
+) {
   const directoryUri = parentUri(memoryUri);
   for (const uri of sharedDirectoryChain(config, directoryUri)) {
     const args = withIdentity(config, ['stat', uri]);
     if (dryRun) {
       if (options.quiet !== true) {
-        consoleOutput.log(`Would run: ${formatShellCommand(ov, args)}`);
+        yield* Console.log(`Would run: ${formatShellCommand(ov, args)}`);
       }
       continue;
     }
-    const statResult = await runCommand(ov, args, {allowFailure: true});
+    const statResult = yield* runCommand(ov, args, {allowFailure: true});
     if (statResult.exitCode === 0) {
       continue;
     }
     if (options.quiet === true) {
-      await runCommand(ov, withIdentity(config, ['mkdir', uri, '--description', 'Threadnote shared context.']));
+      yield* runCommand(ov, withIdentity(config, ['mkdir', uri, '--description', 'Threadnote shared context.']));
     } else {
-      await maybeRun(false, ov, withIdentity(config, ['mkdir', uri, '--description', 'Threadnote shared context.']));
+      yield* maybeRun(false, ov, withIdentity(config, ['mkdir', uri, '--description', 'Threadnote shared context.']));
     }
   }
-}
+});
 
 export function parentUri(uri: string): string {
   const lastSlash = uri.lastIndexOf('/');
@@ -3994,7 +4368,7 @@ export function sharedDirectoryChain(config: ShareRuntime, directoryUri: string)
   return chain;
 }
 
-export async function writeMemoryFile(
+export const writeMemoryFile = Effect.fn('share.writeMemoryFile')(function* (
   config: ShareRuntime,
   ov: string,
   uri: string,
@@ -4002,7 +4376,7 @@ export async function writeMemoryFile(
   initialMode: 'create' | 'replace',
   dryRun: boolean,
   options: {readonly quiet?: boolean} = {},
-): Promise<void> {
+) {
   if (dryRun) {
     const args = withIdentity(config, [
       'write',
@@ -4016,20 +4390,19 @@ export async function writeMemoryFile(
       '120',
     ]);
     if (options.quiet !== true) {
-      consoleOutput.log(`Would run: ${formatShellCommand(ov, args)}`);
+      yield* Console.log(`Would run: ${formatShellCommand(ov, args)}`);
     }
     return;
   }
-  const stagingDir = await mkdtemp(join(tmpdir(), 'threadnote-share-'));
-  const tempPath = join(stagingDir, 'body.txt');
-  try {
-    await writeFile(tempPath, content, {encoding: 'utf8', mode: 0o600});
-    await writeOvFileWithRetry(config, ov, uri, tempPath, initialMode, options);
-    await refreshMemoryIndex(config, ov, uri, options);
-  } finally {
-    await rm(stagingDir, {force: true, recursive: true});
-  }
-}
+  const system = yield* SystemInfo;
+  const stagingDir = yield* mkdtemp(yield* pathJoin(system.tempDirectory, 'threadnote-share-'));
+  const tempPath = yield* pathJoin(stagingDir, 'body.txt');
+  yield* Effect.gen(function* () {
+    yield* writeFile(tempPath, content, {encoding: 'utf8', mode: 0o600});
+    yield* writeOvFileWithRetry(config, ov, uri, tempPath, initialMode, options);
+    yield* refreshMemoryIndex(config, ov, uri, options);
+  }).pipe(Effect.ensuring(rm(stagingDir, {force: true, recursive: true}).pipe(Effect.ignore)));
+});
 
 // Busy-retry backoff: read sequentially between attempts (between 0-1, 1-2, ...).
 // `ov wait` returns immediately when the queue is already drained, so without an
@@ -4039,28 +4412,30 @@ export async function writeMemoryFile(
 // waiting.
 const BUSY_RETRY_BACKOFF_MS: readonly number[] = [2000, 5000, 10000, 20000, 30000];
 
-async function writeOvFileWithRetry(
+const writeOvFileWithRetry = Effect.fn('share.writeOvFileWithRetry')(function* (
   config: ShareRuntime,
   ov: string,
   uri: string,
   fromFile: string,
   initialMode: 'create' | 'replace',
   options: {readonly quiet?: boolean} = {},
-): Promise<void> {
+) {
   const maxAttempts = BUSY_RETRY_BACKOFF_MS.length + 1;
   // Snapshot existence ONCE before the first attempt so a teammate's
   // concurrent publish landing between attempts can't trick us into flipping
   // to 'replace' and silently overwriting their content. Only an exists-now-
   // but-didn't-exist-before transition can be attributed to our own write.
-  const existedBeforeWrite = await vikingResourceExists(ov, config, uri);
+  const existedBeforeWrite = yield* vikingResourceExists(ov, config, uri);
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    const existsNow = attempt === 0 ? existedBeforeWrite : await vikingResourceExists(ov, config, uri);
+    const existsNow = attempt === 0 ? existedBeforeWrite : yield* vikingResourceExists(ov, config, uri);
     if (attempt > 0 && existsNow) {
-      if (await openVikingContentMatches(config, ov, uri, fromFile)) {
+      if (yield* openVikingContentMatches(config, ov, uri, fromFile)) {
         return;
       }
       if (initialMode === 'create' && !existedBeforeWrite) {
-        throw new Error(`Create conflict: ${uri} appeared with different content while the write was retrying.`);
+        return yield* Effect.fail(
+          new Error(`Create conflict: ${uri} appeared with different content while the write was retrying.`),
+        );
       }
     }
     // Preserve the caller's operation on every retry. In particular, a create
@@ -4078,39 +4453,41 @@ async function writeOvFileWithRetry(
       '120',
     ]);
     if (options.quiet !== true) {
-      consoleOutput.log(`${attempt === 0 ? 'Running' : 'Retrying'}: ${formatShellCommand(ov, args)}`);
+      yield* Console.log(`${attempt === 0 ? 'Running' : 'Retrying'}: ${formatShellCommand(ov, args)}`);
     }
-    const result = await runCommand(ov, args, {allowFailure: true});
+    const result = yield* runCommand(ov, args, {allowFailure: true});
     if (result.exitCode === 0) {
       if (options.quiet !== true && result.stdout.trim()) {
-        consoleOutput.log(result.stdout.trim());
+        yield* Console.log(result.stdout.trim());
       }
       if (options.quiet !== true && result.stderr.trim()) {
-        consoleOutput.error(result.stderr.trim());
+        yield* Console.error(result.stderr.trim());
       }
       return;
     }
     if (
       isTransientOvFailure(result.stderr, result.stdout) &&
-      (await vikingResourceExists(ov, config, uri)) &&
-      (await openVikingContentMatches(config, ov, uri, fromFile))
+      (yield* vikingResourceExists(ov, config, uri)) &&
+      (yield* openVikingContentMatches(config, ov, uri, fromFile))
     ) {
       // The write succeeded server-side (URI now exists where it didn't before
       // this call started) even though OV returned an error before the --wait
       // completed. Drain the queue and treat the write as durable.
       if (options.quiet !== true) {
-        consoleOutput.log(
+        yield* Console.log(
           'OpenViking accepted the write but returned an error before the wait completed; draining the queue.',
         );
       }
-      await waitForOvQueue(ov, config, options);
+      yield* waitForOvQueue(ov, config, options);
       return;
     }
-    if (initialMode === 'create' && !existedBeforeWrite && (await vikingResourceExists(ov, config, uri))) {
-      throw new Error(`Create conflict: ${uri} exists with content not written by this invocation.`);
+    if (initialMode === 'create' && !existedBeforeWrite && (yield* vikingResourceExists(ov, config, uri))) {
+      return yield* Effect.fail(
+        new Error(`Create conflict: ${uri} exists with content not written by this invocation.`),
+      );
     }
     if (!isTransientOvFailure(result.stderr, result.stdout) || attempt === maxAttempts - 1) {
-      throw new Error(`${formatShellCommand(ov, args)} failed: ${result.stderr || result.stdout}`);
+      return yield* Effect.fail(new Error(`${formatShellCommand(ov, args)} failed: ${result.stderr || result.stdout}`));
     }
     // Resource-busy / being-processed errors mean OV still holds the URI's
     // per-resource lock from a background semantic/embedding indexer (e.g.,
@@ -4122,33 +4499,33 @@ async function writeOvFileWithRetry(
     // For network-class transients, fall back to the short fixed sleep
     // since `ov wait` would hit the same connectivity issue.
     if (isResourceBusyFailure(result.stderr, result.stdout)) {
-      await waitForOvQueue(ov, config, options);
-      await sleep(BUSY_RETRY_BACKOFF_MS[attempt] ?? 30000);
+      yield* waitForOvQueue(ov, config, options);
+      yield* sleep(BUSY_RETRY_BACKOFF_MS[attempt] ?? 30000);
     } else {
-      await sleep(1000 * (attempt + 1));
+      yield* sleep(1000 * (attempt + 1));
     }
   }
-}
+});
 
-async function openVikingContentMatches(
+const openVikingContentMatches = Effect.fn('share.openVikingContentMatches')(function* (
   config: ShareRuntime,
   ov: string,
   uri: string,
   fromFile: string,
-): Promise<boolean> {
-  const [expected, actual] = await Promise.all([
+) {
+  const [expected, actual] = yield* Effect.all([
     readFile(fromFile, 'utf8'),
     runCommand(ov, withIdentity(config, ['read', uri]), {allowFailure: true}),
   ]);
   return actual.exitCode === 0 && actual.stdout.trim() === expected.trim();
-}
+});
 
-async function refreshMemoryIndex(
+const refreshMemoryIndex = Effect.fn('share.refreshMemoryIndex')(function* (
   config: ShareRuntime,
   ov: string,
   uri: string,
   options: {readonly quiet?: boolean} = {},
-): Promise<void> {
+) {
   // This runs after a successful file write. OpenViking's semantic memory
   // reindex path expects a directory URI, but vectors_only supports memory
   // files and refreshes the leaf recall records without poisoning the queue.
@@ -4156,40 +4533,40 @@ async function refreshMemoryIndex(
   // so a stuck/poisoned semantic queue would otherwise hang this inline call
   // for the full 10-min command timeout; reindexWaitTimeoutMs bounds it (the
   // write already succeeded, so a timed-out refresh only defers freshness).
-  const result = await runCommand(
+  const result = yield* runCommand(
     ov,
     withIdentity(config, ['reindex', uri, '--mode', 'vectors_only', '--wait', 'true']),
-    {allowFailure: true, timeoutMs: reindexWaitTimeoutMs()},
+    {allowFailure: true, timeoutMs: yield* reindexWaitTimeoutMs()},
   );
   if (result.exitCode === 0) {
     if (options.quiet !== true && result.stdout.trim()) {
-      consoleOutput.log(result.stdout.trim());
+      yield* Console.log(result.stdout.trim());
     }
     if (options.quiet !== true && result.stderr.trim()) {
-      consoleOutput.error(result.stderr.trim());
+      yield* Console.error(result.stderr.trim());
     }
     return;
   }
   if (options.quiet !== true) {
-    consoleOutput.error(
+    yield* Console.error(
       `Memory stored, but index refresh failed for ${uri}: ${result.stderr.trim() || result.stdout.trim()}`,
     );
   }
-}
+});
 
-async function waitForOvQueue(
+const waitForOvQueue = Effect.fn('share.waitForOvQueue')(function* (
   ov: string,
   config: ShareRuntime,
   options: {readonly quiet?: boolean} = {},
-): Promise<void> {
-  const result = await runCommand(ov, withIdentity(config, ['wait', '--timeout', '120']), {allowFailure: true});
+) {
+  const result = yield* runCommand(ov, withIdentity(config, ['wait', '--timeout', '120']), {allowFailure: true});
   if (options.quiet !== true && result.stdout.trim()) {
-    consoleOutput.log(result.stdout.trim());
+    yield* Console.log(result.stdout.trim());
   }
   if (options.quiet !== true && result.stderr.trim()) {
-    consoleOutput.error(result.stderr.trim());
+    yield* Console.error(result.stderr.trim());
   }
-}
+});
 
 export function isTransientOvFailure(stderr: string, stdout: string): boolean {
   const output = `${stderr}\n${stdout}`.toLowerCase();
@@ -4210,24 +4587,37 @@ export function isResourceBusyFailure(stderr: string, stdout: string): boolean {
   return output.includes('resource is busy') || output.includes('resource is being processed');
 }
 
-async function ingestSingleFile(
+const ingestSingleFile = Effect.fn('share.ingestSingleFile')(function* (
   ov: string,
   config: ShareRuntime,
   uri: string,
   filePath: string,
   initialMode: 'create' | 'replace',
   options: {readonly quiet?: boolean} = {},
-): Promise<void> {
-  const content = await readSharedInboundFileContent(uri, filePath);
-  await writeMemoryFile(config, ov, uri, content, initialMode, false, options);
-}
+) {
+  const content = yield* readSharedInboundFileContent(uri, filePath);
+  yield* writeMemoryFile(config, ov, uri, content, initialMode, false, options);
+});
 
-async function readSharedInboundFileContent(uri: string, filePath: string): Promise<string> {
-  if (!(await isRegularFileNoSymlink(filePath))) {
-    throw new Error(`Refusing to ingest non-regular shared file: ${filePath}`);
+const readSharedInboundFileContent = Effect.fn('share.readSharedInboundFileContent')(function* (
+  uri: string,
+  filePath: string,
+) {
+  if (!(yield* isRegularFileNoSymlink(filePath))) {
+    return yield* Effect.fail(new Error(`Refusing to ingest non-regular shared file: ${filePath}`));
   }
-  return prepareSharedInboundContent(uri, await readFile(filePath, 'utf8'));
-}
+  return yield* prepareSharedInboundContentEffect(uri, yield* readFile(filePath, 'utf8'));
+});
+
+const prepareSharedInboundContentEffect = Effect.fn('share.prepareSharedInboundContent')(function* (
+  uri: string,
+  rawContent: string,
+) {
+  return yield* Effect.try({
+    catch: error => error,
+    try: () => prepareSharedInboundContent(uri, rawContent),
+  });
+});
 
 function prepareSharedInboundContent(uri: string, rawContent: string): string {
   const stripped = stripPersonalProvenance(rawContent);
@@ -4238,26 +4628,26 @@ function prepareSharedInboundContent(uri: string, rawContent: string): string {
   return scrub.cleaned;
 }
 
-export async function removeMemoryUri(
+export const removeMemoryUri = Effect.fn('share.removeMemoryUri')(function* (
   config: ShareRuntime,
   ov: string,
   uri: string,
   dryRun: boolean,
   options: {readonly quiet?: boolean} = {},
-): Promise<void> {
+) {
   const args = withIdentity(config, ['rm', uri]);
   if (dryRun) {
     if (options.quiet !== true) {
-      consoleOutput.log(`Would run: ${formatShellCommand(ov, args)}`);
+      yield* Console.log(`Would run: ${formatShellCommand(ov, args)}`);
     }
     return;
   }
   const maxAttempts = BUSY_RETRY_BACKOFF_MS.length + 1;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    const result = await runCommand(ov, args, {allowFailure: true});
+    const result = yield* runCommand(ov, args, {allowFailure: true});
     if (result.exitCode === 0) {
       if (options.quiet !== true && result.stdout.trim()) {
-        consoleOutput.log(result.stdout.trim());
+        yield* Console.log(result.stdout.trim());
       }
       return;
     }
@@ -4265,48 +4655,52 @@ export async function removeMemoryUri(
       throw new Error(`${formatShellCommand(ov, args)} failed: ${result.stderr || result.stdout}`);
     }
     if (isResourceBusyFailure(result.stderr, result.stdout)) {
-      await waitForOvQueue(ov, config, options);
-      await sleep(BUSY_RETRY_BACKOFF_MS[attempt] ?? 30000);
+      yield* waitForOvQueue(ov, config, options);
+      yield* sleep(BUSY_RETRY_BACKOFF_MS[attempt] ?? 30000);
     } else {
-      await sleep(1000 * (attempt + 1));
+      yield* sleep(1000 * (attempt + 1));
     }
   }
-}
+});
 
-export async function vikingResourceExists(ov: string, config: ShareRuntime, uri: string): Promise<boolean> {
-  const result = await runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
+export const vikingResourceExists = Effect.fn('share.vikingResourceExists')(function* (
+  ov: string,
+  config: ShareRuntime,
+  uri: string,
+) {
+  const result = yield* runCommand(ov, withIdentity(config, ['stat', uri]), {allowFailure: true});
   return result.exitCode === 0;
-}
+});
 
-async function hasUncommittedChanges(worktree: string): Promise<boolean> {
+const hasUncommittedChanges = Effect.fn('share.hasUncommittedChanges')(function* (worktree: string) {
   // Read-only check; always run, even in dry-run, so the preamble reflects
   // what a non-dry-run sync would actually have to commit.
-  const result = await runCommand('git', ['-C', worktree, 'status', '--porcelain'], {allowFailure: true});
+  const result = yield* runCommand('git', ['-C', worktree, 'status', '--porcelain'], {allowFailure: true});
   return result.stdout.trim().length > 0;
-}
+});
 
 /** Returns the trimmed stdout of `git -C <worktree> <args>` on success, or `undefined` on dry-run / non-zero exit. */
-async function gitOutput(worktree: string, args: readonly string[], dryRun: boolean): Promise<string | undefined> {
+const gitOutput = Effect.fn('share.gitOutput')(function* (worktree: string, args: readonly string[], dryRun: boolean) {
   if (dryRun) {
     return undefined;
   }
-  const result = await runCommand('git', ['-C', worktree, ...args], {allowFailure: true});
+  const result = yield* runCommand('git', ['-C', worktree, ...args], {allowFailure: true});
   if (result.exitCode !== 0) {
     return undefined;
   }
   return result.stdout.trim();
-}
+});
 
 const GIT_MODE_ABSENT = '000000';
 // Git records symbolic links as mode 120000.
 const GIT_MODE_SYMLINK = '120000';
 
-export async function listChangedFiles(
+export const listChangedFiles = Effect.fn('share.listChangedFiles')(function* (
   worktree: string,
   beforeRev: string,
   afterRev: string,
-): Promise<readonly ChangedFile[]> {
-  const result = await runCommand('git', ['-C', worktree, 'diff', '--raw', '-z', `${beforeRev}..${afterRev}`], {
+) {
+  const result = yield* runCommand('git', ['-C', worktree, 'diff', '--raw', '-z', `${beforeRev}..${afterRev}`], {
     allowFailure: true,
   });
   if (result.exitCode !== 0) {
@@ -4326,14 +4720,15 @@ export async function listChangedFiles(
       const newRel = entries[index + 1];
       if (oldRel) {
         changes.push({
-          path: join(worktree, oldRel),
-          previousContent: oldMode === GIT_MODE_SYMLINK ? undefined : await gitFileContent(worktree, beforeRev, oldRel),
+          path: yield* pathJoin(worktree, oldRel),
+          previousContent:
+            oldMode === GIT_MODE_SYMLINK ? undefined : yield* gitFileContent(worktree, beforeRev, oldRel),
           relativePath: oldRel,
           status: 'removed',
         });
       }
       if (newRel && newMode !== GIT_MODE_SYMLINK) {
-        changes.push({path: join(worktree, newRel), relativePath: newRel, status: 'added'});
+        changes.push({path: yield* pathJoin(worktree, newRel), relativePath: newRel, status: 'added'});
       }
       index += 2;
       continue;
@@ -4342,16 +4737,16 @@ export async function listChangedFiles(
     if (rel) {
       if (head === 'D') {
         changes.push({
-          path: join(worktree, rel),
-          previousContent: oldMode === GIT_MODE_SYMLINK ? undefined : await gitFileContent(worktree, beforeRev, rel),
+          path: yield* pathJoin(worktree, rel),
+          previousContent: oldMode === GIT_MODE_SYMLINK ? undefined : yield* gitFileContent(worktree, beforeRev, rel),
           relativePath: rel,
           status: 'removed',
         });
       } else if (newMode === GIT_MODE_SYMLINK) {
         if (oldMode !== GIT_MODE_ABSENT) {
           changes.push({
-            path: join(worktree, rel),
-            previousContent: oldMode === GIT_MODE_SYMLINK ? undefined : await gitFileContent(worktree, beforeRev, rel),
+            path: yield* pathJoin(worktree, rel),
+            previousContent: oldMode === GIT_MODE_SYMLINK ? undefined : yield* gitFileContent(worktree, beforeRev, rel),
             relativePath: rel,
             status: 'removed',
           });
@@ -4359,11 +4754,11 @@ export async function listChangedFiles(
       } else {
         const status = head === 'A' ? 'added' : 'modified';
         changes.push({
-          path: join(worktree, rel),
+          path: yield* pathJoin(worktree, rel),
           previousContent:
             oldMode === GIT_MODE_ABSENT || oldMode === GIT_MODE_SYMLINK
               ? undefined
-              : await gitFileContent(worktree, beforeRev, rel),
+              : yield* gitFileContent(worktree, beforeRev, rel),
           relativePath: rel,
           status,
         });
@@ -4372,16 +4767,16 @@ export async function listChangedFiles(
     index += 1;
   }
   return changes;
-}
+});
 
-async function gitFileContent(worktree: string, rev: string, relativePath: string): Promise<string | undefined> {
-  const result = await runCommand('git', ['-C', worktree, 'show', `${rev}:${relativePath}`], {allowFailure: true});
+const gitFileContent = Effect.fn('share.gitFileContent')(function* (
+  worktree: string,
+  rev: string,
+  relativePath: string,
+) {
+  const result = yield* runCommand('git', ['-C', worktree, 'show', `${rev}:${relativePath}`], {allowFailure: true});
   return result.exitCode === 0 ? result.stdout : undefined;
-}
-
-interface ApplyChangesResult {
-  readonly failed: readonly ChangedFile[];
-}
+});
 
 // applyChangesToOpenViking only reflects changes to files under shareable
 // top-level directories. For renames that cross those directories
@@ -4396,80 +4791,96 @@ interface ApplyChangesResult {
 // to pendingReindexes for the next sync attempt. A single stuck URI (e.g.,
 // OV holding a per-resource lock longer than our retry window) must not
 // cause a whole sync to lose all the other files it could have applied.
-async function applyChangesToOpenViking(
+const applyChangesToOpenViking = Effect.fn('share.applyChangesToOpenViking')(function* (
   config: ShareRuntime,
   team: ShareTeamConfig,
   changes: readonly ChangedFile[],
   options: {readonly quiet?: boolean} = {},
-): Promise<ApplyChangesResult> {
-  const ov = await openVikingCliForMode(false);
+) {
+  const ov = yield* openVikingCliForMode(false);
   const failed: ChangedFile[] = [];
   for (const change of changes) {
     if (!isShareableMemoryChange(change)) {
       continue;
     }
-    const uri = workfileToVikingUri(config, team, change.path);
-    try {
-      if (change.status === 'removed') {
-        const currentContent = await readExistingMemoryContent(config, ov, uri);
-        if (currentContent === undefined) {
-          continue;
-        }
-        assertInboundPreviousContentMatches(change, uri, currentContent);
-        await removeMemoryUri(config, ov, uri, false, options);
-        continue;
-      }
-      if (!(await isRegularFileNoSymlink(change.path))) {
-        continue;
-      }
-      // Either 'modified' or 'added' from git's perspective; the file on disk
-      // was just rewritten by the pull-rebase and OV's index needs to catch up.
-      // Both cases collapse to the same OV-side rule: if the URI already exists,
-      // we must write with 'replace' (the create path's retry loop snapshots
-      // existedBeforeWrite=true and would burn every attempt against an
-      // ALREADY_EXISTS error). 'added' lands here when OV has the URI from an
-      // earlier path — a prior share init/sync, or a local publish that wrote
-      // the URI before the corresponding upstream commit landed in this clone.
-      const content = await readSharedInboundFileContent(uri, change.path);
-      const currentContent = await readExistingMemoryContent(config, ov, uri);
-      if (currentContent !== undefined) {
-        if (change.status === 'added') {
-          if (sharedMemoryContentsEquivalent(currentContent, content)) {
-            continue;
+    const uri = yield* workfileToVikingUri(config, team, change.path);
+    const applyResult = yield* Effect.result(
+      Effect.gen(function* () {
+        if (change.status === 'removed') {
+          const currentContent = yield* readExistingMemoryContent(config, ov, uri);
+          if (currentContent === undefined) {
+            return;
           }
-          throw new Error(
-            `Refusing to ingest newly added shared file over existing local OpenViking resource ${uri}; inspect and resolve the local edit first.`,
-          );
+          yield* Effect.try({
+            catch: error => error,
+            try: () => assertInboundPreviousContentMatches(change, uri, currentContent),
+          });
+          yield* removeMemoryUri(config, ov, uri, false, options);
+          return;
         }
-        assertInboundPreviousContentMatches(change, uri, currentContent);
-        const reason =
-          change.status === 'modified'
-            ? 'updating from upstream after verifying local content matches the previous shared version'
-            : 'aligning OV to upstream (resource pre-existed in OV, likely from an earlier local publish or sync)';
-        if (options.quiet !== true) {
-          consoleOutput.warn(`share sync: ${uri}: ${reason}.`);
+        if (!(yield* isRegularFileNoSymlink(change.path))) {
+          return;
         }
-      }
-      await ensureSharedDirectoryChain(config, ov, uri, false, options);
-      const writeMode: 'create' | 'replace' = currentContent !== undefined ? 'replace' : 'create';
-      await writeMemoryFile(config, ov, uri, content, writeMode, false, options);
-    } catch (err: unknown) {
+        // Either 'modified' or 'added' from git's perspective; the file on disk
+        // was just rewritten by the pull-rebase and OV's index needs to catch up.
+        // Both cases collapse to the same OV-side rule: if the URI already exists,
+        // we must write with 'replace' (the create path's retry loop snapshots
+        // existedBeforeWrite=true and would burn every attempt against an
+        // ALREADY_EXISTS error). 'added' lands here when OV has the URI from an
+        // earlier path — a prior share init/sync, or a local publish that wrote
+        // the URI before the corresponding upstream commit landed in this clone.
+        const content = yield* readSharedInboundFileContent(uri, change.path);
+        const currentContent = yield* readExistingMemoryContent(config, ov, uri);
+        if (currentContent !== undefined) {
+          if (change.status === 'added') {
+            if (sharedMemoryContentsEquivalent(currentContent, content)) {
+              return;
+            }
+            return yield* Effect.fail(
+              new Error(
+                `Refusing to ingest newly added shared file over existing local OpenViking resource ${uri}; inspect and resolve the local edit first.`,
+              ),
+            );
+          }
+          yield* Effect.try({
+            catch: error => error,
+            try: () => assertInboundPreviousContentMatches(change, uri, currentContent),
+          });
+          const reason =
+            change.status === 'modified'
+              ? 'updating from upstream after verifying local content matches the previous shared version'
+              : 'aligning OV to upstream (resource pre-existed in OV, likely from an earlier local publish or sync)';
+          if (options.quiet !== true) {
+            yield* Console.warn(`share sync: ${uri}: ${reason}.`);
+          }
+        }
+        yield* ensureSharedDirectoryChain(config, ov, uri, false, options);
+        const writeMode: 'create' | 'replace' = currentContent !== undefined ? 'replace' : 'create';
+        yield* writeMemoryFile(config, ov, uri, content, writeMode, false, options);
+      }),
+    );
+    if (Result.isFailure(applyResult)) {
+      const err = applyResult.failure;
       const message = err instanceof Error ? err.message : String(err);
       if (options.quiet !== true) {
-        consoleOutput.warn(`share sync: ${uri}: ingest failed — will retry on the next sync. ${message}`);
+        yield* Console.warn(`share sync: ${uri}: ingest failed — will retry on the next sync. ${message}`);
       }
       failed.push(change);
     }
   }
   return {failed};
-}
+});
 
-async function readExistingMemoryContent(config: ShareRuntime, ov: string, uri: string): Promise<string | undefined> {
-  if (!(await vikingResourceExists(ov, config, uri))) {
+const readExistingMemoryContent = Effect.fn('share.readExistingMemoryContent')(function* (
+  config: ShareRuntime,
+  ov: string,
+  uri: string,
+) {
+  if (!(yield* vikingResourceExists(ov, config, uri))) {
     return undefined;
   }
-  return readMemoryContent(config, ov, uri, false);
-}
+  return yield* readMemoryContent(config, ov, uri, false);
+});
 
 function assertInboundPreviousContentMatches(change: ChangedFile, uri: string, currentContent: string): void {
   if (change.previousContent === undefined) {
@@ -4503,25 +4914,25 @@ export function mergeChanges(...lists: ReadonlyArray<readonly ChangedFile[]>): r
   return [...map.values()];
 }
 
-async function applyAndPersistChanges(
+const applyAndPersistChanges = Effect.fn('share.applyAndPersistChanges')(function* (
   config: ShareRuntime,
   team: ShareTeamConfig,
   state: AutoShareState,
   changes: readonly ChangedFile[],
   options: {readonly quiet?: boolean} = {},
-): Promise<ApplyChangesResult> {
+) {
   if (changes.length === 0) {
     return {failed: []};
   }
   // Persist intent BEFORE applying so a crash mid-apply doesn't lose state.
   state.pendingReindexes.set(team.name, changes);
-  await writePendingReindexes(config, state);
-  const result = await applyChangesToOpenViking(config, team, changes, options);
+  yield* writePendingReindexes(config, state);
+  const result = yield* applyChangesToOpenViking(config, team, changes, options);
   if (result.failed.length > 0) {
     state.pendingReindexes.set(team.name, result.failed);
   } else {
     state.pendingReindexes.delete(team.name);
   }
-  await writePendingReindexes(config, state);
+  yield* writePendingReindexes(config, state);
   return result;
-}
+});

--- a/src/threadnote.ts
+++ b/src/threadnote.ts
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-import {NodeRuntime, NodeServices} from '@effect/platform-node';
+import * as NodeRuntime from '@effect/platform-node/NodeRuntime';
 import {Console, Effect} from 'effect';
 import {Command} from 'effect/unstable/cli';
 import {errorMessage} from './utils.js';
@@ -8,22 +8,22 @@ import {getThreadnoteVersion} from './version.js';
 import {ApplicationLayer} from './effect/runtime.js';
 import {ApplicationError} from './effect/errors.js';
 import {CliError, normalizeCliArguments, threadnoteCommand} from './effect/cli.js';
+import {initializeCliUi} from './cli_ui.js';
+import {SystemInfo} from './effect/system.js';
 
-const program = Command.runWith(threadnoteCommand, {version: getThreadnoteVersion()})(
-  normalizeCliArguments(process.argv.slice(2)),
-).pipe(
-  Effect.provide(ApplicationLayer),
-  Effect.provide(NodeServices.layer),
+const program = Effect.gen(function* () {
+  yield* initializeCliUi();
+  const version = yield* getThreadnoteVersion();
+  const system = yield* SystemInfo;
+  return yield* Command.runWith(threadnoteCommand, {version})(normalizeCliArguments(system.processArguments.slice(2)));
+}).pipe(
   Effect.tapError(error =>
     CliError.isCliError(error)
       ? Effect.void
       : Console.error(errorMessage(error instanceof ApplicationError ? error.cause : error)),
   ),
-  Effect.catch(() =>
-    Effect.sync(() => {
-      process.exitCode = 1;
-    }),
-  ),
+  Effect.catch(() => Effect.flatMap(SystemInfo, system => Effect.sync(() => system.setExitCode(1)))),
+  Effect.provide(ApplicationLayer),
 );
 
 NodeRuntime.runMain(program, {disableErrorReporting: true});

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,4 +1,4 @@
-import {open, readFile, stat} from 'node:fs/promises';
+import {Effect, FileSystem, Result, Stream} from 'effect';
 import {applyScrubber} from './share.js';
 
 const MAX_TRANSCRIPT_BYTES = 4 * 1024 * 1024;
@@ -55,8 +55,8 @@ function truncate(value: string, max: number): string {
  * agent-specific and unstable, so every field is defensive. Callers MUST scrub
  * the result before persisting — user intents can contain secrets.
  */
-export async function distillTrace(transcriptPath: string): Promise<string | undefined> {
-  const raw = await readTranscriptTail(transcriptPath);
+export const distillTrace = Effect.fn('trace.distill')(function* (transcriptPath: string) {
+  const raw = yield* readTranscriptTail(transcriptPath);
   if (raw === undefined) {
     return undefined;
   }
@@ -71,12 +71,11 @@ export async function distillTrace(transcriptPath: string): Promise<string | und
     if (!trimmed) {
       continue;
     }
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
+    const parsedResult = Result.try((): unknown => JSON.parse(trimmed));
+    if (Result.isFailure(parsedResult)) {
       continue;
     }
+    const parsed = parsedResult.success;
     if (!isRecord(parsed)) {
       continue;
     }
@@ -114,30 +113,30 @@ export async function distillTrace(transcriptPath: string): Promise<string | und
     }
   }
   return lines.join('\n');
-}
+});
 
-async function readTranscriptTail(transcriptPath: string): Promise<string | undefined> {
-  try {
-    const {size} = await stat(transcriptPath);
+const readTranscriptTail = Effect.fn('trace.readTail')((transcriptPath: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const info = yield* fs.stat(transcriptPath);
+    const size = Number(info.size);
     if (size === 0) {
       return undefined;
     }
     if (size <= MAX_TRANSCRIPT_BYTES) {
-      return await readFile(transcriptPath, 'utf8');
+      return yield* fs.readFileString(transcriptPath);
     }
     const start = size - MAX_TRANSCRIPT_BYTES;
-    const buffer = Buffer.alloc(MAX_TRANSCRIPT_BYTES);
-    const file = await open(transcriptPath, 'r');
-    try {
-      const {bytesRead} = await file.read(buffer, 0, MAX_TRANSCRIPT_BYTES, start);
-      return buffer
-        .subarray(0, bytesRead)
-        .toString('utf8')
-        .replace(/^[^\n]*(?:\n|$)/, '');
-    } finally {
-      await file.close();
+    const chunks = yield* fs
+      .stream(transcriptPath, {bytesToRead: MAX_TRANSCRIPT_BYTES, offset: start})
+      .pipe(Stream.runCollect);
+    const length = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+    const bytes = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
     }
-  } catch {
-    return undefined;
-  }
-}
+    return new TextDecoder().decode(bytes).replace(/^[^\n]*(?:\n|$)/, '');
+  }).pipe(Effect.catch(() => Effect.succeed(undefined))),
+);

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,9 +1,7 @@
-import {spawn} from 'node:child_process';
-import {mkdir, readFile, writeFile} from 'node:fs/promises';
-import {dirname} from 'node:path';
-import {Effect} from 'effect';
+import {Effect, FileSystem, Path, Result} from 'effect';
+import * as ChildProcess from 'effect/unstable/process/ChildProcess';
 import {getJsonEffect} from './effect/http.js';
-import {fromPromiseError} from './effect/errors.js';
+import {SystemInfo} from './effect/system.js';
 import {selectUpdateChannel, type UpdateChannel} from './update_channel.js';
 import {compareVersions, isJsonObject} from './utils.js';
 
@@ -42,21 +40,19 @@ export function checkForThreadnoteUpdate(args: {readonly cachePath: string; read
   }
   return Effect.gen(function* () {
     const channel = selectUpdateChannel(args.currentVersion);
-    const cached = yield* fromPromiseError(() => readUpdateCache(args.cachePath));
+    const cached = yield* readUpdateCache(args.cachePath);
     const channelCache = cached?.channel === channel ? cached : undefined;
     if (channelCache && isCacheFresh(channelCache)) {
       return toUpdateCheckResult(args.currentVersion, channelCache.latestVersion);
     }
     const fresh = yield* fetchLatestVersionEffect(channel);
     if (fresh) {
-      yield* fromPromiseError(() =>
-        writeUpdateCache(args.cachePath, {
-          channel,
-          checkedAt: new Date().toISOString(),
-          latestVersion: fresh,
-          version: 2,
-        }),
-      );
+      yield* writeUpdateCache(args.cachePath, {
+        channel,
+        checkedAt: new Date().toISOString(),
+        latestVersion: fresh,
+        version: 2 as const,
+      });
       return toUpdateCheckResult(args.currentVersion, fresh);
     }
     return channelCache ? toUpdateCheckResult(args.currentVersion, channelCache.latestVersion) : undefined;
@@ -72,21 +68,24 @@ export function checkForThreadnoteUpdate(args: {readonly cachePath: string; read
  * Best-effort: silently returns if the spawn fails (no node binary, permission
  * denied, etc.). The nag banner remains as the fallback signal.
  */
-export function spawnDetachedAutoUpdate(): void {
-  try {
-    const entry = process.argv[1];
-    if (typeof entry !== 'string' || entry.length === 0) {
-      return;
-    }
-    const child = spawn(process.execPath, [entry, 'update', '--yes'], {
-      detached: true,
-      stdio: 'ignore',
-    });
-    child.unref();
-  } catch {
-    // Best-effort.
+export const spawnDetachedAutoUpdate = Effect.fn('updateCheck.spawnDetachedAutoUpdate')(function* () {
+  const system = yield* SystemInfo;
+  const entry = system.processArguments[1];
+  if (typeof entry !== 'string' || entry.length === 0) {
+    return;
   }
-}
+  yield* Effect.scoped(
+    Effect.gen(function* () {
+      const child = yield* ChildProcess.make(system.executablePath, [entry, 'update', '--yes'], {
+        detached: true,
+        stdin: 'ignore',
+        stdout: 'ignore',
+        stderr: 'ignore',
+      });
+      yield* child.unref;
+    }),
+  ).pipe(Effect.ignore);
+});
 
 function toUpdateCheckResult(currentVersion: string, latestVersion: string): UpdateCheckResult {
   return {
@@ -101,10 +100,15 @@ function isCacheFresh(cache: UpdateCacheFile): boolean {
   return Number.isFinite(checkedAt) && Date.now() - checkedAt < CACHE_TTL_MS;
 }
 
-async function readUpdateCache(cachePath: string): Promise<UpdateCacheFile | undefined> {
-  try {
-    const raw = await readFile(cachePath, 'utf8');
-    const parsed = JSON.parse(raw) as Partial<UpdateCacheFile>;
+const readUpdateCache = Effect.fn('updateCheck.readCache')((cachePath: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const raw = yield* fs.readFileString(cachePath);
+    const parsedResult = Result.try(() => JSON.parse(raw) as Partial<UpdateCacheFile>);
+    if (Result.isFailure(parsedResult)) {
+      return undefined;
+    }
+    const parsed = parsedResult.success;
     if (
       parsed.version !== 2 ||
       (parsed.channel !== 'beta' && parsed.channel !== 'latest') ||
@@ -117,21 +121,19 @@ async function readUpdateCache(cachePath: string): Promise<UpdateCacheFile | und
       channel: parsed.channel,
       checkedAt: parsed.checkedAt,
       latestVersion: parsed.latestVersion,
-      version: 2,
+      version: 2 as const,
     };
-  } catch {
-    return undefined;
-  }
-}
+  }).pipe(Effect.catch(() => Effect.succeed(undefined))),
+);
 
-async function writeUpdateCache(cachePath: string, contents: UpdateCacheFile): Promise<void> {
-  try {
-    await mkdir(dirname(cachePath), {recursive: true});
-    await writeFile(cachePath, `${JSON.stringify(contents)}\n`, {encoding: 'utf8', mode: 0o600});
-  } catch {
-    // Best-effort: a missing cache just means the next call refetches.
-  }
-}
+const writeUpdateCache = Effect.fn('updateCheck.writeCache')((cachePath: string, contents: UpdateCacheFile) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.makeDirectory(path.dirname(cachePath), {recursive: true});
+    yield* fs.writeFileString(cachePath, `${JSON.stringify(contents)}\n`, {mode: 0o600});
+  }).pipe(Effect.ignore),
+);
 
 const fetchLatestVersionEffect = Effect.fn('fetchLatestHookVersion')((channel: UpdateChannel) =>
   getJsonEffect(`${NPM_REGISTRY_URL}${channel}`, {

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,15 +1,10 @@
-import {writeFile} from 'node:fs/promises';
-import {join} from 'node:path';
-import {createInterface} from 'node:readline/promises';
-import {stdin as input, stdout as output} from 'node:process';
-import {Effect, FileSystem, Path, pipe} from 'effect';
+import {Console, Effect, FileSystem, Path, Result, Terminal, pipe} from 'effect';
 import {heading, info as infoText, keyValue, success, warning, withSpinnerEffect} from './cli_ui.js';
-import {runCommandEffect} from './effect/command.js';
-import {consoleOutput, syncWithConsole} from './effect/console.js';
-import {applicationError, fromPromise, fromSync} from './effect/errors.js';
+import {maybeRunEffect, runCommandEffect, runStreamingCommandEffect} from './effect/command.js';
+import {applicationError, fromSync} from './effect/errors.js';
 import {getJsonEffect, getStatusEffect} from './effect/http.js';
 import {pollUntilEffect} from './effect/time.js';
-import {SystemInfo} from './effect/system.js';
+import {SystemInfo, type SystemInfoShape} from './effect/system.js';
 import {hasLegacyLifecycleHandoffCandidates, hasProjectNameMigrationCandidates} from './memory.js';
 import {whatsNewLinesForVersionRange} from './release_notes.js';
 import type {JsonObject, PostUpdateOptions, RuntimeConfig, UpdateOptions, UpdateRuntime} from './types.js';
@@ -23,10 +18,8 @@ import {
   findOpenVikingCli,
   isTcpPortOpen,
   isJsonObject,
-  maybeRun,
   readFileIfExists,
   runCommand,
-  runInteractive,
   toolRoot,
   formatShellCommand,
 } from './utils.js';
@@ -76,35 +69,32 @@ export function parseUpdateRuntime(value: string): UpdateRuntime {
 }
 
 export function maybeNotifyUpdate(config: RuntimeConfig, options: {readonly dryRun?: boolean} = {}) {
-  if (isUpdateNotificationDisabled()) {
-    return Effect.void;
-  }
-  return fromSync('resolve update registry', updateRegistry).pipe(
-    Effect.flatMap(registry =>
-      getUpdateInfo(config, {
-        allowCacheWrite: options.dryRun !== true,
-        betaRequested: false,
-        preferFresh: false,
-        registry,
-      }),
-    ),
-    Effect.tap(info =>
-      info.isUpdateAvailable
-        ? syncWithConsole(() => {
-            consoleOutput.log('');
-            consoleOutput.log(warning(`Update available: threadnote ${info.currentVersion} -> ${info.latestVersion}`));
-            consoleOutput.log(`Run: ${infoText('threadnote update')}`);
-          })
-        : Effect.void,
-    ),
-    Effect.asVoid,
-    Effect.catch(() => Effect.void),
-  );
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    if (isUpdateNotificationDisabled(system.environment())) {
+      return;
+    }
+    const registry = yield* fromSync('resolve update registry', () =>
+      resolveUpdateRegistry(undefined, false, system.environment()),
+    );
+    const info = yield* getUpdateInfo(config, {
+      allowCacheWrite: options.dryRun !== true,
+      betaRequested: false,
+      preferFresh: false,
+      registry,
+    });
+    if (info.isUpdateAvailable) {
+      yield* Console.log('');
+      yield* Console.log(warning(`Update available: threadnote ${info.currentVersion} -> ${info.latestVersion}`));
+      yield* Console.log(`Run: ${infoText('threadnote update')}`);
+    }
+  }).pipe(Effect.catch(() => Effect.void));
 }
 
 export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig, options: UpdateOptions) {
+  const system = yield* SystemInfo;
   const registry = yield* fromSync('resolve update registry', () =>
-    resolveUpdateRegistry(options.registry, options.allowUntrustedRegistry),
+    resolveUpdateRegistry(options.registry, options.allowUntrustedRegistry, system.environment()),
   );
   const info = yield* withSpinnerEffect(
     'Checking npm for latest threadnote version',
@@ -116,19 +106,17 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     }),
   );
 
-  yield* syncWithConsole(() => {
-    consoleOutput.log(keyValue('Current version', infoText(info.currentVersion)));
-    consoleOutput.log(
-      keyValue(
-        info.channel === 'beta' ? 'Latest beta version' : 'Latest version',
-        info.latestVersion ? infoText(info.latestVersion) : warning('not published'),
-      ),
-    );
-    consoleOutput.log(keyValue('Registry', info.registry));
-  });
+  yield* Console.log(keyValue('Current version', infoText(info.currentVersion)));
+  yield* Console.log(
+    keyValue(
+      info.channel === 'beta' ? 'Latest beta version' : 'Latest version',
+      info.latestVersion ? infoText(info.latestVersion) : warning('not published'),
+    ),
+  );
+  yield* Console.log(keyValue('Registry', info.registry));
 
   if (info.latestVersion === undefined) {
-    yield* syncWithConsole(() => consoleOutput.log('No beta release is currently published.'));
+    yield* Console.log('No beta release is currently published.');
     return;
   }
   const latestVersion = info.latestVersion;
@@ -136,30 +124,26 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   if (options.check === true) {
     if (info.isUpdateAvailable) {
       const command = options.beta === true ? 'threadnote update --beta' : 'threadnote update';
-      yield* syncWithConsole(() => consoleOutput.log(warning(`Update available. Run: ${command}`)));
+      yield* Console.log(warning(`Update available. Run: ${command}`));
       yield* printWhatsNewIfAvailable(info);
     } else {
-      yield* syncWithConsole(() =>
-        consoleOutput.log(
-          compareVersions(info.currentVersion, latestVersion) > 0
-            ? warning(`Current version is newer than npm ${info.channel}.`)
-            : success('Threadnote is up to date.'),
-        ),
+      yield* Console.log(
+        compareVersions(info.currentVersion, latestVersion) > 0
+          ? warning(`Current version is newer than npm ${info.channel}.`)
+          : success('Threadnote is up to date.'),
       );
     }
     return;
   }
 
   if (!info.isUpdateAvailable && options.force !== true) {
-    yield* syncWithConsole(() => consoleOutput.log(success('Threadnote is up to date.')));
+    yield* Console.log(success('Threadnote is up to date.'));
     return;
   }
 
-  const runtime = yield* fromPromise('resolve update runtime', () => resolveUpdateRuntime(options.runtime ?? 'auto'));
-  const runtimeExecutable = yield* fromPromise('resolve update runtime executable', async () => {
-    return (await findExecutable([runtime])) ?? runtime;
-  });
-  const updateCommand = updatePackageCommand(runtime, registry, info.channel, runtimeExecutable);
+  const runtime = yield* resolveUpdateRuntime(options.runtime ?? 'auto');
+  const runtimeExecutable = (yield* findExecutable([runtime])) ?? runtime;
+  const updateCommand = updatePackageCommand(runtime, registry, info.channel, runtimeExecutable, system.environment());
   yield* runStreamingSubcommand(
     options.dryRun === true,
     updateCommand.executable,
@@ -168,16 +152,14 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   );
 
   if (options.repair === false) {
-    yield* syncWithConsole(() => consoleOutput.log('Skipping repair because --no-repair was provided.'));
+    yield* Console.log('Skipping repair because --no-repair was provided.');
     yield* printWhatsNewIfAvailable(info);
     return;
   }
 
   const threadnoteCommand = yield* installedThreadnoteCommand(runtime, runtimeExecutable);
-  yield* syncWithConsole(() => {
-    consoleOutput.log('');
-    consoleOutput.log('Repairing local Threadnote setup after package update.');
-  });
+  yield* Console.log('');
+  yield* Console.log('Repairing local Threadnote setup after package update.');
   yield* runStreamingSubcommand(options.dryRun === true, threadnoteCommand, ['repair', '--no-post-update']);
   if (options.postUpdate !== false) {
     const postUpdateArgs = [
@@ -190,14 +172,10 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     ];
     yield* runStreamingSubcommand(options.dryRun === true, threadnoteCommand, postUpdateArgs);
   } else {
-    yield* syncWithConsole(() =>
-      consoleOutput.log('Skipping post-update migration prompts because --no-post-update was provided.'),
-    );
+    yield* Console.log('Skipping post-update migration prompts because --no-post-update was provided.');
   }
-  yield* syncWithConsole(() =>
-    consoleOutput.log(
-      'Update complete. Restart Cursor, Copilot, Codex, Claude, or open a fresh agent session so MCP tools reload.',
-    ),
+  yield* Console.log(
+    'Update complete. Restart Cursor, Copilot, Codex, Claude, or open a fresh agent session so MCP tools reload.',
   );
   yield* printWhatsNewIfAvailable(info);
 });
@@ -208,18 +186,16 @@ function printWhatsNewIfAvailable(info: UpdateInfo) {
   }
   const latestVersion = info.latestVersion;
   return Effect.gen(function* () {
-    yield* syncWithConsole(() => consoleOutput.log(''));
+    yield* Console.log('');
     const whatsNew = yield* withSpinnerEffect(
       'Fetching GitHub release notes',
       whatsNewLinesForVersionRange(info.currentVersion, latestVersion, {
         includePrereleases: info.channel === 'beta',
       }),
     );
-    yield* syncWithConsole(() => {
-      for (const line of whatsNew) {
-        consoleOutput.log(line === "What's new:" ? heading(line) : line);
-      }
-    });
+    for (const line of whatsNew) {
+      yield* Console.log(line === "What's new:" ? heading(line) : line);
+    }
   });
 }
 
@@ -234,63 +210,55 @@ export const runPostUpdate = Effect.fn('runPostUpdate')(function* (config: Runti
   }
   const fromVersion = options.fromVersion;
   const toVersion = options.toVersion;
-  const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true;
+  const system = yield* SystemInfo;
+  const interactive = system.stdinIsTTY && system.stdoutIsTTY;
   yield* ensurePinnedOpenVikingInstalled(config, {dryRun: options.dryRun === true});
-  yield* fromPromise('run post-update memory migrations', () =>
-    runApplicablePostUpdateMigrations(config, {
-      dryRun: options.dryRun === true,
-      fromVersion,
-      interactive,
-      markHandled: true,
-      toVersion,
-      yes: options.yes === true,
-    }),
-  );
+  yield* runApplicablePostUpdateMigrations(config, {
+    dryRun: options.dryRun === true,
+    fromVersion,
+    interactive,
+    markHandled: true,
+    toVersion,
+    yes: options.yes === true,
+  });
 });
 
 export function maybeRunPostUpdateAfterRepair(config: RuntimeConfig, options: {readonly dryRun: boolean}) {
   return Effect.gen(function* () {
-    const toVersion = yield* fromPromise('read current package version', currentPackageVersion);
-    const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true;
+    const system = yield* SystemInfo;
+    const toVersion = yield* currentPackageVersion();
+    const interactive = system.stdinIsTTY && system.stdoutIsTTY;
     yield* ensurePinnedOpenVikingInstalled(config, {dryRun: options.dryRun});
-    const state = yield* fromPromise('read post-update state', () => readPostUpdateState(config));
-    const migrations = yield* fromPromise('find applicable post-update migrations', () =>
-      applicablePostUpdateMigrations(config, {
-        fromVersion: '0.0.0',
-        handledMigrationIds: state.handledMigrationIds,
-        toVersion,
-      }),
-    );
+    const state = yield* readPostUpdateState(config);
+    const migrations = yield* applicablePostUpdateMigrations(config, {
+      fromVersion: '0.0.0',
+      handledMigrationIds: state.handledMigrationIds,
+      toVersion,
+    });
     if (migrations.length === 0) {
       return;
     }
-    yield* syncWithConsole(() => {
-      consoleOutput.log('');
-      consoleOutput.log('Repair found package post-update migrations.');
-      consoleOutput.log(
-        'This also covers updates launched by older Threadnote versions that only knew how to run repair.',
-      );
-    });
-    if (!interactive) {
-      yield* syncWithConsole(() => {
-        consoleOutput.log(
-          'This process is non-interactive, so Threadnote will print the manual migration command instead of prompting.',
-        );
-        consoleOutput.log(
-          `Run the prompt manually with: threadnote post-update --from-version 0.0.0 --to-version ${toVersion}`,
-        );
-      });
-    }
-    yield* fromPromise('run post-update migrations after repair', () =>
-      runApplicablePostUpdateMigrations(config, {
-        dryRun: options.dryRun,
-        fromVersion: '0.0.0',
-        interactive,
-        markHandled: true,
-        toVersion,
-        yes: false,
-      }),
+    yield* Console.log('');
+    yield* Console.log('Repair found package post-update migrations.');
+    yield* Console.log(
+      'This also covers updates launched by older Threadnote versions that only knew how to run repair.',
     );
+    if (!interactive) {
+      yield* Console.log(
+        'This process is non-interactive, so Threadnote will print the manual migration command instead of prompting.',
+      );
+      yield* Console.log(
+        `Run the prompt manually with: threadnote post-update --from-version 0.0.0 --to-version ${toVersion}`,
+      );
+    }
+    yield* runApplicablePostUpdateMigrations(config, {
+      dryRun: options.dryRun,
+      fromVersion: '0.0.0',
+      interactive,
+      markHandled: true,
+      toVersion,
+      yes: false,
+    });
   });
 }
 
@@ -313,16 +281,14 @@ export function maybeRunPostUpdateAfterRepair(config: RuntimeConfig, options: {r
  */
 function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readonly dryRun: boolean}) {
   return Effect.gen(function* () {
-    const ov = yield* fromPromise('find OpenViking CLI', findOpenVikingCli);
+    const ov = yield* findOpenVikingCli();
     if (!ov) {
       return;
     }
-    const installedVersion = yield* fromPromise('read OpenViking CLI version', () => readOpenVikingCliVersion(ov));
+    const installedVersion = yield* readOpenVikingCliVersion(ov);
     if (!installedVersion) {
-      yield* syncWithConsole(() =>
-        consoleOutput.log(
-          `Could not detect OpenViking CLI version via \`${ov} version\`; skipping pinned-version check.`,
-        ),
+      yield* Console.log(
+        `Could not detect OpenViking CLI version via \`${ov} version\`; skipping pinned-version check.`,
       );
       return;
     }
@@ -330,11 +296,9 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
     if (compareVersions(installedVersion, pinned) >= 0) {
       return;
     }
-    yield* syncWithConsole(() => {
-      consoleOutput.log('');
-      consoleOutput.log(`Upgrading OpenViking ${installedVersion} -> ${pinned} (pinned by Threadnote).`);
-      consoleOutput.log('Picks up upstream CLI, resource-ingestion, and index reliability fixes.');
-    });
+    yield* Console.log('');
+    yield* Console.log(`Upgrading OpenViking ${installedVersion} -> ${pinned} (pinned by Threadnote).`);
+    yield* Console.log('Picks up upstream CLI, resource-ingestion, and index reliability fixes.');
 
     // Capture the server state BEFORE we swap binaries so we know what to
     // restart afterward. install --no-start leaves the existing process
@@ -345,16 +309,12 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
     const usingLaunchd = yield* isLaunchAgentInstalled();
 
     const threadnoteCommand =
-      currentThreadnoteCommand() ??
-      (yield* fromPromise('find threadnote executable', () => findExecutable([NPM_PACKAGE_NAME]))) ??
-      NPM_PACKAGE_NAME;
+      currentThreadnoteCommand(yield* SystemInfo) ?? (yield* findExecutable([NPM_PACKAGE_NAME])) ?? NPM_PACKAGE_NAME;
     yield* runStreamingSubcommand(options.dryRun, threadnoteCommand, ['install', '--force', '--no-start']);
 
     if (options.dryRun) {
       if (wasRunning || usingLaunchd) {
-        yield* syncWithConsole(() =>
-          consoleOutput.log('Would restart OpenViking server so the new binary takes effect.'),
-        );
+        yield* Console.log('Would restart OpenViking server so the new binary takes effect.');
       }
       return;
     }
@@ -363,18 +323,14 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
       return;
     }
 
-    yield* syncWithConsole(() => consoleOutput.log('Restarting OpenViking server so the new binary takes effect.'));
+    yield* Console.log('Restarting OpenViking server so the new binary takes effect.');
     if (usingLaunchd) {
       const system = yield* SystemInfo;
       const path = yield* Path.Path;
       const launchAgentPath = launchAgentPlistPath(system.homeDirectory, path);
-      yield* fromPromise('unload OpenViking launch agent', () =>
-        runCommand('launchctl', ['unload', launchAgentPath], {allowFailure: true}),
-      );
+      yield* runCommand('launchctl', ['unload', launchAgentPath], {allowFailure: true});
       yield* waitForOpenVikingPortClosed(config, 15_000);
-      yield* fromPromise('load OpenViking launch agent', () =>
-        runCommand('launchctl', ['load', launchAgentPath], {allowFailure: true}),
-      );
+      yield* runCommand('launchctl', ['load', launchAgentPath], {allowFailure: true});
     } else {
       yield* runStreamingSubcommand(false, threadnoteCommand, ['stop']);
       yield* waitForOpenVikingPortClosed(config, 15_000);
@@ -382,12 +338,10 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
     }
     const healthyAfter = yield* waitForOpenVikingHealthy(config, 10_000);
     if (!healthyAfter) {
-      yield* syncWithConsole(() => {
-        consoleOutput.log(
-          `Warning: OpenViking did not return to healthy at ${openVikingHealthEndpoint(config)} within 10s after the restart.`,
-        );
-        consoleOutput.log('Check the server log or run: threadnote start');
-      });
+      yield* Console.log(
+        `Warning: OpenViking did not return to healthy at ${openVikingHealthEndpoint(config)} within 10s after the restart.`,
+      );
+      yield* Console.log('Check the server log or run: threadnote start');
     }
   });
 }
@@ -401,20 +355,16 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
  */
 function runStreamingSubcommand(dryRun: boolean, executable: string, args: readonly string[], env?: NodeJS.ProcessEnv) {
   if (dryRun) {
-    return fromPromise('print subcommand', () =>
-      env ? maybeRun(true, executable, args, {env}) : maybeRun(true, executable, args),
-    ).pipe(Effect.asVoid);
+    return maybeRunEffect(true, executable, args).pipe(Effect.asVoid);
   }
   return Effect.gen(function* () {
-    yield* syncWithConsole(() => consoleOutput.log(`Running: ${formatShellCommand(executable, args)}`));
-    const exitCode = yield* fromPromise('run interactive subcommand', () =>
-      env ? runInteractive(executable, args, {env}) : runInteractive(executable, args),
-    );
-    if (exitCode !== 0) {
+    yield* Console.log(`Running: ${formatShellCommand(executable, args)}`);
+    const result = yield* runStreamingCommandEffect(executable, args, env ? {env} : undefined);
+    if (result.exitCode !== 0) {
       return yield* Effect.fail(
         applicationError(
           'run interactive subcommand',
-          new Error(`${formatShellCommand(executable, args)} exited with ${exitCode}.`),
+          new Error(`${formatShellCommand(executable, args)} exited with ${result.exitCode}.`),
         ),
       );
     }
@@ -447,14 +397,10 @@ function waitForOpenVikingHealthy(config: RuntimeConfig, timeoutMs: number) {
 
 function waitForOpenVikingPortClosed(config: RuntimeConfig, timeoutMs: number) {
   return Effect.gen(function* () {
-    yield* syncWithConsole(() =>
-      consoleOutput.log(`Waiting for OpenViking port ${config.host}:${config.port} to close before restart.`),
-    );
+    yield* Console.log(`Waiting for OpenViking port ${config.host}:${config.port} to close before restart.`);
     const closed = yield* pipe(
       pollUntilEffect(
-        fromPromise('check OpenViking TCP port', () => isTcpPortOpen(config.host, config.port, 300)).pipe(
-          Effect.map(open => (open ? undefined : true)),
-        ),
+        isTcpPortOpen(config.host, config.port, 300).pipe(Effect.map(open => (open ? undefined : true))),
         {intervalMs: 300, timeoutMs},
       ),
       Effect.map(result => result === true),
@@ -462,10 +408,8 @@ function waitForOpenVikingPortClosed(config: RuntimeConfig, timeoutMs: number) {
     if (closed) {
       return true;
     }
-    yield* syncWithConsole(() =>
-      consoleOutput.log(
-        `Warning: OpenViking port ${config.host}:${config.port} is still in use after ${timeoutMs / 1000}s; start may fail.`,
-      ),
+    yield* Console.log(
+      `Warning: OpenViking port ${config.host}:${config.port} is still in use after ${timeoutMs / 1000}s; start may fail.`,
     );
     return false;
   });
@@ -489,8 +433,8 @@ function isLaunchAgentInstalled() {
   });
 }
 
-export async function readOpenVikingCliVersion(ov: string): Promise<string | undefined> {
-  const result = await runCommand(ov, ['--version'], {allowFailure: true});
+export const readOpenVikingCliVersion = Effect.fn('update.readOpenVikingCliVersion')(function* (ov: string) {
+  const result = yield* runCommand(ov, ['--version'], {allowFailure: true});
   if (result.exitCode !== 0) {
     return undefined;
   }
@@ -500,7 +444,7 @@ export async function readOpenVikingCliVersion(ov: string): Promise<string | und
     /^\s*openviking(?:\s+CLI)?\s+v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)/im,
   );
   return match ? match[1] : undefined;
-}
+});
 
 function getUpdateInfo(
   config: RuntimeConfig,
@@ -512,21 +456,17 @@ function getUpdateInfo(
   },
 ) {
   return Effect.gen(function* () {
-    const currentVersion = yield* fromPromise('read current package version', currentPackageVersion);
+    const currentVersion = yield* currentPackageVersion();
     const channel = selectUpdateChannel(currentVersion, options.betaRequested);
-    const cached = options.preferFresh
-      ? undefined
-      : yield* fromPromise('read update cache', () => readFreshCache(config, options.registry, channel));
+    const cached = options.preferFresh ? undefined : yield* readFreshCache(config, options.registry, channel);
     const latestVersion = cached?.latestVersion ?? (yield* fetchLatestVersion(options.registry, channel));
     if (!cached && latestVersion !== undefined && options.allowCacheWrite) {
-      yield* fromPromise('write update cache', () =>
-        writeUpdateCache(config, {
-          channel,
-          checkedAt: new Date().toISOString(),
-          latestVersion,
-          registry: options.registry,
-        }),
-      );
+      yield* writeUpdateCache(config, {
+        channel,
+        checkedAt: new Date().toISOString(),
+        latestVersion,
+        registry: options.registry,
+      });
     }
     return {
       channel,
@@ -570,46 +510,48 @@ export const fetchLatestVersion = Effect.fn('fetchLatestVersion')(function* (
   return response.body.version;
 });
 
-async function readFreshCache(
+const readFreshCache = Effect.fn('update.readFreshCache')(function* (
   config: RuntimeConfig,
   registry: string,
   channel: UpdateChannel,
-): Promise<UpdateCache | undefined> {
-  const rawCache = await readFileIfExists(updateCachePath(config));
+) {
+  const rawCache = yield* readFileIfExists(yield* updateCachePath(config));
   if (!rawCache) {
     return undefined;
   }
-  try {
-    const parsed: unknown = JSON.parse(rawCache);
-    if (
-      !isJsonObject(parsed) ||
-      parsed.channel !== channel ||
-      typeof parsed.checkedAt !== 'string' ||
-      typeof parsed.latestVersion !== 'string' ||
-      parsed.registry !== registry
-    ) {
-      return undefined;
-    }
-    const checkedAt = Date.parse(parsed.checkedAt);
-    if (!Number.isFinite(checkedAt) || Date.now() - checkedAt > UPDATE_CHECK_TTL_MS) {
-      return undefined;
-    }
-    return {channel, checkedAt: parsed.checkedAt, latestVersion: parsed.latestVersion, registry};
-  } catch (_err: unknown) {
+  const parsedResult = Result.try((): unknown => JSON.parse(rawCache));
+  if (Result.isFailure(parsedResult)) {
     return undefined;
   }
-}
+  const parsed = parsedResult.success;
+  if (
+    !isJsonObject(parsed) ||
+    parsed.channel !== channel ||
+    typeof parsed.checkedAt !== 'string' ||
+    typeof parsed.latestVersion !== 'string' ||
+    parsed.registry !== registry
+  ) {
+    return undefined;
+  }
+  const checkedAt = Date.parse(parsed.checkedAt);
+  if (!Number.isFinite(checkedAt) || Date.now() - checkedAt > UPDATE_CHECK_TTL_MS) {
+    return undefined;
+  }
+  return {channel, checkedAt: parsed.checkedAt, latestVersion: parsed.latestVersion, registry};
+});
 
-async function writeUpdateCache(config: RuntimeConfig, cache: UpdateCache): Promise<void> {
-  await ensureDirectory(config.agentContextHome, false);
-  await writeFile(updateCachePath(config), `${JSON.stringify(cache, null, 2)}\n`, {encoding: 'utf8', mode: 0o600});
-}
+const writeUpdateCache = Effect.fn('update.writeCache')(function* (config: RuntimeConfig, cache: UpdateCache) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* ensureDirectory(config.agentContextHome, false);
+  yield* fs.writeFileString(yield* updateCachePath(config), `${JSON.stringify(cache, null, 2)}\n`, {mode: 0o600});
+});
 
-function updateCachePath(config: RuntimeConfig): string {
-  return join(config.agentContextHome, 'update-check.json');
-}
+const updateCachePath = Effect.fn('update.cachePath')(function* (config: RuntimeConfig) {
+  const path = yield* Path.Path;
+  return path.join(config.agentContextHome, 'update-check.json');
+});
 
-async function runApplicablePostUpdateMigrations(
+const runApplicablePostUpdateMigrations = Effect.fn('update.runApplicableMigrations')(function* (
   config: RuntimeConfig,
   options: {
     readonly dryRun: boolean;
@@ -619,62 +561,63 @@ async function runApplicablePostUpdateMigrations(
     readonly toVersion: string;
     readonly yes: boolean;
   },
-): Promise<void> {
-  const state = await readPostUpdateState(config);
-  const migrations = await applicablePostUpdateMigrations(config, {
+) {
+  const system = yield* SystemInfo;
+  const state = yield* readPostUpdateState(config);
+  const migrations = yield* applicablePostUpdateMigrations(config, {
     fromVersion: options.fromVersion,
     handledMigrationIds: state.handledMigrationIds,
     toVersion: options.toVersion,
   });
   if (migrations.length === 0) {
-    consoleOutput.log('No post-update memory migrations apply.');
+    yield* Console.log('No post-update memory migrations apply.');
     return;
   }
 
-  consoleOutput.log('');
-  consoleOutput.log('Post-update memory migrations are available.');
+  yield* Console.log('');
+  yield* Console.log('Post-update memory migrations are available.');
   const threadnoteCommand =
-    currentThreadnoteCommand() ?? (await findExecutable([NPM_PACKAGE_NAME])) ?? NPM_PACKAGE_NAME;
+    currentThreadnoteCommand(system) ?? (yield* findExecutable([NPM_PACKAGE_NAME])) ?? NPM_PACKAGE_NAME;
   const handledMigrationIds = new Set(state.handledMigrationIds);
   for (const migration of migrations) {
-    printPostUpdateMigration(migration);
+    yield* printPostUpdateMigration(migration);
     const accepted =
       options.dryRun ||
       options.yes ||
-      (options.interactive && (await confirmPostUpdateMigration('Apply this migration now? [y/N] ')));
+      (options.interactive && (yield* confirmPostUpdateMigration('Apply this migration now? [y/N] ')));
     if (!accepted) {
-      consoleOutput.log('Skipped. Run manually later:');
-      consoleOutput.log(`  ${formatMigrationCommand(threadnoteCommand, migration.commandArgs)}`);
+      yield* Console.log('Skipped. Run manually later:');
+      yield* Console.log(`  ${formatMigrationCommand(threadnoteCommand, migration.commandArgs)}`);
       continue;
     }
-    await runStreamingSubcommand(options.dryRun, threadnoteCommand, migration.commandArgs);
+    yield* runStreamingSubcommand(options.dryRun, threadnoteCommand, migration.commandArgs);
     if (!options.dryRun) {
       handledMigrationIds.add(migration.id);
       for (const instruction of migration.instructions) {
-        consoleOutput.log(instruction);
+        yield* Console.log(instruction);
       }
     } else {
-      consoleOutput.log('After this migration succeeds, Threadnote will print:');
+      yield* Console.log('After this migration succeeds, Threadnote will print:');
       for (const instruction of migration.instructions) {
-        consoleOutput.log(`  ${instruction}`);
+        yield* Console.log(`  ${instruction}`);
       }
     }
   }
 
   if (!options.dryRun && options.markHandled) {
-    await writePostUpdateState(config, {handledMigrationIds: [...handledMigrationIds].sort()});
+    yield* writePostUpdateState(config, {handledMigrationIds: [...handledMigrationIds].sort()});
   }
-}
+});
 
-async function applicablePostUpdateMigrations(
+const applicablePostUpdateMigrations = Effect.fn('update.applicableMigrations')(function* (
   config: RuntimeConfig,
   options: {
     readonly fromVersion: string;
     readonly handledMigrationIds: readonly string[];
     readonly toVersion: string;
   },
-): Promise<readonly PostUpdateMigration[]> {
-  const migrations = await readPostUpdateMigrations();
+) {
+  const migrations = yield* readPostUpdateMigrations();
   const handled = new Set(options.handledMigrationIds);
   const applicable: PostUpdateMigration[] = [];
   for (const migration of migrations) {
@@ -687,28 +630,32 @@ async function applicablePostUpdateMigrations(
     if (compareVersions(migration.introducedIn, options.toVersion) > 0) {
       continue;
     }
-    if (migration.requiresLegacyHandoffs === true && !(await hasLegacyLifecycleHandoffCandidates(config))) {
+    if (migration.requiresLegacyHandoffs === true && !(yield* hasLegacyLifecycleHandoffCandidates(config))) {
       continue;
     }
-    if (migration.requiresProjectNameConsolidation === true && !(await hasProjectNameMigrationCandidates(config))) {
+    if (migration.requiresProjectNameConsolidation === true && !(yield* hasProjectNameMigrationCandidates(config))) {
       continue;
     }
     applicable.push(migration);
   }
   return applicable;
-}
+});
 
-async function readPostUpdateMigrations(): Promise<readonly PostUpdateMigration[]> {
-  const raw = await readFileIfExists(join(toolRoot(), 'config', POST_UPDATE_MIGRATIONS_FILE));
+const readPostUpdateMigrations = Effect.fn('update.readPostUpdateMigrations')(function* () {
+  const path = yield* Path.Path;
+  const raw = yield* readFileIfExists(path.join(yield* toolRoot(), 'config', POST_UPDATE_MIGRATIONS_FILE));
   if (!raw) {
     return [];
   }
-  const parsed: unknown = JSON.parse(raw);
+  const parsed = yield* Effect.try({
+    try: (): unknown => JSON.parse(raw),
+    catch: cause => new Error(`Could not parse ${POST_UPDATE_MIGRATIONS_FILE}.`, {cause}),
+  });
   if (!isJsonObject(parsed) || !Array.isArray(parsed.migrations)) {
     throw new Error(`${POST_UPDATE_MIGRATIONS_FILE} must contain a migrations array.`);
   }
   return parsed.migrations.map(parsePostUpdateMigration);
-}
+});
 
 function parsePostUpdateMigration(value: unknown): PostUpdateMigration {
   if (
@@ -742,79 +689,83 @@ function stringArray(value: JsonObject, key: string): readonly string[] {
   return raw;
 }
 
-function printPostUpdateMigration(migration: PostUpdateMigration): void {
-  consoleOutput.log('');
-  consoleOutput.log(`${migration.title} (${migration.introducedIn})`);
+const printPostUpdateMigration = Effect.fn('update.printPostUpdateMigration')(function* (
+  migration: PostUpdateMigration,
+) {
+  yield* Console.log('');
+  yield* Console.log(`${migration.title} (${migration.introducedIn})`);
   for (const line of migration.description) {
-    consoleOutput.log(`- ${line}`);
+    yield* Console.log(`- ${line}`);
   }
-}
+});
 
-async function confirmPostUpdateMigration(prompt: string, defaultYes = false): Promise<boolean> {
-  const readline = createInterface({input, output});
-  try {
-    const answer = (await readline.question(prompt)).trim().toLowerCase();
-    if (answer === '') {
-      return defaultYes;
-    }
-    return answer === 'y' || answer === 'yes';
-  } finally {
-    readline.close();
-  }
-}
+const confirmPostUpdateMigration = Effect.fn('update.confirmPostUpdateMigration')(function* (
+  prompt: string,
+  defaultYes = false,
+) {
+  const terminal = yield* Terminal.Terminal;
+  yield* terminal.display(prompt);
+  const answer = (yield* terminal.readLine).trim().toLowerCase();
+  return answer === '' ? defaultYes : answer === 'y' || answer === 'yes';
+});
 
 function formatMigrationCommand(executable: string, args: readonly string[]): string {
   return [executable, ...args].map(part => (/\s/.test(part) ? JSON.stringify(part) : part)).join(' ');
 }
 
-function currentThreadnoteCommand(): string | undefined {
-  const entrypoint = process.argv[1]?.trim();
+function currentThreadnoteCommand(system: SystemInfoShape): string | undefined {
+  const entrypoint = system.processArguments[1]?.trim();
   return entrypoint ? entrypoint : undefined;
 }
 
-async function readPostUpdateState(config: RuntimeConfig): Promise<PostUpdateState> {
-  const raw = await readFileIfExists(postUpdateStatePath(config));
+const readPostUpdateState = Effect.fn('update.readPostUpdateState')(function* (config: RuntimeConfig) {
+  const raw = yield* readFileIfExists(yield* postUpdateStatePath(config));
   if (!raw) {
     return {handledMigrationIds: []};
   }
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!isJsonObject(parsed) || !Array.isArray(parsed.handledMigrationIds)) {
-      return {handledMigrationIds: []};
-    }
-    return {handledMigrationIds: parsed.handledMigrationIds.filter((id): id is string => typeof id === 'string')};
-  } catch (_err: unknown) {
+  const parsedResult = Result.try((): unknown => JSON.parse(raw));
+  if (Result.isFailure(parsedResult)) {
     return {handledMigrationIds: []};
   }
-}
+  const parsed = parsedResult.success;
+  if (!isJsonObject(parsed) || !Array.isArray(parsed.handledMigrationIds)) {
+    return {handledMigrationIds: []};
+  }
+  return {handledMigrationIds: parsed.handledMigrationIds.filter((id): id is string => typeof id === 'string')};
+});
 
-async function writePostUpdateState(config: RuntimeConfig, state: PostUpdateState): Promise<void> {
-  await ensureDirectory(config.agentContextHome, false);
-  await writeFile(postUpdateStatePath(config), `${JSON.stringify(state, null, 2)}\n`, {encoding: 'utf8', mode: 0o600});
-}
+const writePostUpdateState = Effect.fn('update.writePostUpdateState')(function* (
+  config: RuntimeConfig,
+  state: PostUpdateState,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* ensureDirectory(config.agentContextHome, false);
+  yield* fs.writeFileString(yield* postUpdateStatePath(config), `${JSON.stringify(state, null, 2)}\n`, {mode: 0o600});
+});
 
-function postUpdateStatePath(config: RuntimeConfig): string {
-  return join(config.agentContextHome, POST_UPDATE_STATE_FILE);
-}
+const postUpdateStatePath = Effect.fn('update.postUpdateStatePath')(function* (config: RuntimeConfig) {
+  const path = yield* Path.Path;
+  return path.join(config.agentContextHome, POST_UPDATE_STATE_FILE);
+});
 
-async function resolveUpdateRuntime(runtime: UpdateRuntime): Promise<Exclude<UpdateRuntime, 'auto'>> {
+const resolveUpdateRuntime = Effect.fn('update.resolveRuntime')(function* (runtime: UpdateRuntime) {
   if (runtime !== 'auto') {
-    await requireRuntime(runtime);
+    yield* requireRuntime(runtime);
     return runtime;
   }
   for (const candidate of ['npm', 'bun', 'deno'] as const) {
-    if (await findExecutable([candidate])) {
+    if (yield* findExecutable([candidate])) {
       return candidate;
     }
   }
-  throw new Error('Install Node/npm, Bun, or Deno to update threadnote.');
-}
+  return yield* Effect.fail(new Error('Install Node/npm, Bun, or Deno to update threadnote.'));
+});
 
-async function requireRuntime(runtime: Exclude<UpdateRuntime, 'auto'>): Promise<void> {
-  if (!(await findExecutable([runtime]))) {
-    throw new Error(`${runtime} was requested but was not found on PATH.`);
+const requireRuntime = Effect.fn('update.requireRuntime')(function* (runtime: Exclude<UpdateRuntime, 'auto'>) {
+  if (!(yield* findExecutable([runtime]))) {
+    return yield* Effect.fail(new Error(`${runtime} was requested but was not found on PATH.`));
   }
-}
+});
 
 const installedThreadnoteCommand = Effect.fn('installedThreadnoteCommand')(function* (
   runtime: Exclude<UpdateRuntime, 'auto'>,
@@ -826,10 +777,7 @@ const installedThreadnoteCommand = Effect.fn('installedThreadnoteCommand')(funct
   if (runtimeBin && (yield* isExecutableFileEffect(fs, runtimeBin, system.platform))) {
     return runtimeBin;
   }
-  return (
-    (yield* fromPromise('find installed threadnote executable', () => findExecutable([NPM_PACKAGE_NAME]))) ??
-    NPM_PACKAGE_NAME
-  );
+  return (yield* findExecutable([NPM_PACKAGE_NAME])) ?? NPM_PACKAGE_NAME;
 });
 
 const runtimeThreadnoteBin = Effect.fn('runtimeThreadnoteBin')(function* (
@@ -848,8 +796,9 @@ const runtimeThreadnoteBin = Effect.fn('runtimeThreadnoteBin')(function* (
     const binDir = result.stdout.trim();
     return binDir ? runtimeThreadnoteBinPath(runtime, binDir, system.platform) : undefined;
   }
+  const environment = system.environment();
   const denoRoot =
-    process.env.DENO_INSTALL_ROOT ?? process.env.DENO_INSTALL ?? path.join(system.homeDirectory, '.deno');
+    environment.DENO_INSTALL_ROOT ?? environment.DENO_INSTALL ?? path.join(system.homeDirectory, '.deno');
   return runtimeThreadnoteBinPath(runtime, path.join(denoRoot, 'bin'), system.platform);
 });
 
@@ -865,7 +814,7 @@ const isExecutableFileEffect = Effect.fn('isExecutableFile')(function* (
 export function runtimeThreadnoteBinPath(
   runtime: Exclude<UpdateRuntime, 'auto'>,
   root: string,
-  currentPlatform: NodeJS.Platform = process.platform,
+  currentPlatform: NodeJS.Platform,
 ): string {
   const separator = currentPlatform === 'win32' ? '\\' : '/';
   const append = (...segments: readonly string[]): string => {
@@ -883,6 +832,7 @@ function updatePackageCommand(
   registry: string,
   channel: UpdateChannel,
   runtimeExecutable: string = runtime,
+  environment: NodeJS.ProcessEnv,
 ): {
   readonly args: readonly string[];
   readonly env?: NodeJS.ProcessEnv;
@@ -910,7 +860,7 @@ function updatePackageCommand(
       '--allow-net',
       `npm:${packageSpec}`,
     ],
-    env: {...process.env, NPM_CONFIG_REGISTRY: registry},
+    env: {...environment, NPM_CONFIG_REGISTRY: registry},
   };
 }
 
@@ -923,16 +873,17 @@ export function normalizeRegistry(registry: string): string {
   return url.toString();
 }
 
-export function updateRegistry(): string {
-  return resolveUpdateRegistry(undefined, false);
+export function updateRegistry(environment: NodeJS.ProcessEnv): string {
+  return resolveUpdateRegistry(undefined, false, environment);
 }
 
 export function resolveUpdateRegistry(
   registry: string | undefined,
   allowUntrustedRegistry: boolean | undefined,
+  environment: NodeJS.ProcessEnv,
 ): string {
-  const normalized = normalizeRegistry(registry ?? process.env.THREADNOTE_NPM_REGISTRY ?? DEFAULT_NPM_REGISTRY);
-  if (normalized !== DEFAULT_NPM_REGISTRY && !allowsUntrustedRegistry(allowUntrustedRegistry)) {
+  const normalized = normalizeRegistry(registry ?? environment.THREADNOTE_NPM_REGISTRY ?? DEFAULT_NPM_REGISTRY);
+  if (normalized !== DEFAULT_NPM_REGISTRY && !allowsUntrustedRegistry(allowUntrustedRegistry, environment)) {
     throw new Error(
       `Refusing custom npm registry ${normalized}: threadnote update does not verify package signatures from alternate registries. Use the default registry, pass --allow-untrusted-registry, or set ${ALLOW_UNTRUSTED_REGISTRY_ENV}=1 only for an approved mirror.`,
     );
@@ -940,18 +891,18 @@ export function resolveUpdateRegistry(
   return normalized;
 }
 
-function allowsUntrustedRegistry(option: boolean | undefined): boolean {
+function allowsUntrustedRegistry(option: boolean | undefined, environment: NodeJS.ProcessEnv): boolean {
   if (option === true) {
     return true;
   }
-  const envValue = process.env[ALLOW_UNTRUSTED_REGISTRY_ENV]?.trim().toLowerCase();
+  const envValue = environment[ALLOW_UNTRUSTED_REGISTRY_ENV]?.trim().toLowerCase();
   return envValue === '1' || envValue === 'true' || envValue === 'yes';
 }
 
-function isUpdateNotificationDisabled(): boolean {
+function isUpdateNotificationDisabled(environment: NodeJS.ProcessEnv): boolean {
   return (
-    process.env.CI !== undefined ||
-    process.env.NO_UPDATE_NOTIFIER !== undefined ||
-    process.env.THREADNOTE_NO_UPDATE_CHECK !== undefined
+    environment.CI !== undefined ||
+    environment.NO_UPDATE_NOTIFIER !== undefined ||
+    environment.THREADNOTE_NO_UPDATE_CHECK !== undefined
   );
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,15 +1,15 @@
-import {constants as fsConstants} from 'node:fs';
-import {access, writeFile} from 'node:fs/promises';
-import {homedir} from 'node:os';
+import {writeFile} from 'node:fs/promises';
 import {join} from 'node:path';
 import {createInterface} from 'node:readline/promises';
 import {stdin as input, stdout as output} from 'node:process';
-import {Effect, pipe} from 'effect';
+import {Effect, FileSystem, Path, pipe} from 'effect';
 import {heading, info as infoText, keyValue, success, warning, withSpinnerEffect} from './cli_ui.js';
+import {runCommandEffect} from './effect/command.js';
 import {consoleOutput, syncWithConsole} from './effect/console.js';
 import {applicationError, fromPromise, fromSync} from './effect/errors.js';
 import {getJsonEffect, getStatusEffect} from './effect/http.js';
 import {pollUntilEffect} from './effect/time.js';
+import {SystemInfo} from './effect/system.js';
 import {hasLegacyLifecycleHandoffCandidates, hasProjectNameMigrationCandidates} from './memory.js';
 import {whatsNewLinesForVersionRange} from './release_notes.js';
 import type {JsonObject, PostUpdateOptions, RuntimeConfig, UpdateOptions, UpdateRuntime} from './types.js';
@@ -21,7 +21,6 @@ import {
   findExecutable,
   currentPackageVersion,
   findOpenVikingCli,
-  isExecutable,
   isTcpPortOpen,
   isJsonObject,
   maybeRun,
@@ -157,8 +156,16 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   }
 
   const runtime = yield* fromPromise('resolve update runtime', () => resolveUpdateRuntime(options.runtime ?? 'auto'));
-  const updateCommand = updatePackageCommand(runtime, registry, info.channel);
-  yield* runStreamingSubcommand(options.dryRun === true, updateCommand.executable, updateCommand.args);
+  const runtimeExecutable = yield* fromPromise('resolve update runtime executable', async () => {
+    return (await findExecutable([runtime])) ?? runtime;
+  });
+  const updateCommand = updatePackageCommand(runtime, registry, info.channel, runtimeExecutable);
+  yield* runStreamingSubcommand(
+    options.dryRun === true,
+    updateCommand.executable,
+    updateCommand.args,
+    updateCommand.env,
+  );
 
   if (options.repair === false) {
     yield* syncWithConsole(() => consoleOutput.log('Skipping repair because --no-repair was provided.'));
@@ -166,9 +173,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     return;
   }
 
-  const threadnoteCommand = yield* fromPromise('resolve installed threadnote command', () =>
-    installedThreadnoteCommand(runtime),
-  );
+  const threadnoteCommand = yield* installedThreadnoteCommand(runtime, runtimeExecutable);
   yield* syncWithConsole(() => {
     consoleOutput.log('');
     consoleOutput.log('Repairing local Threadnote setup after package update.');
@@ -360,7 +365,9 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
 
     yield* syncWithConsole(() => consoleOutput.log('Restarting OpenViking server so the new binary takes effect.'));
     if (usingLaunchd) {
-      const launchAgentPath = launchAgentPlistPath();
+      const system = yield* SystemInfo;
+      const path = yield* Path.Path;
+      const launchAgentPath = launchAgentPlistPath(system.homeDirectory, path);
       yield* fromPromise('unload OpenViking launch agent', () =>
         runCommand('launchctl', ['unload', launchAgentPath], {allowFailure: true}),
       );
@@ -392,13 +399,17 @@ function ensurePinnedOpenVikingInstalled(config: RuntimeConfig, options: {readon
  * package install, an OpenViking reinstall, or a churning repair). Dry-run
  * defers to `maybeRun` so it only prints the command it would run.
  */
-function runStreamingSubcommand(dryRun: boolean, executable: string, args: readonly string[]) {
+function runStreamingSubcommand(dryRun: boolean, executable: string, args: readonly string[], env?: NodeJS.ProcessEnv) {
   if (dryRun) {
-    return fromPromise('print subcommand', () => maybeRun(true, executable, args)).pipe(Effect.asVoid);
+    return fromPromise('print subcommand', () =>
+      env ? maybeRun(true, executable, args, {env}) : maybeRun(true, executable, args),
+    ).pipe(Effect.asVoid);
   }
   return Effect.gen(function* () {
     yield* syncWithConsole(() => consoleOutput.log(`Running: ${formatShellCommand(executable, args)}`));
-    const exitCode = yield* fromPromise('run interactive subcommand', () => runInteractive(executable, args));
+    const exitCode = yield* fromPromise('run interactive subcommand', () =>
+      env ? runInteractive(executable, args, {env}) : runInteractive(executable, args),
+    );
     if (exitCode !== 0) {
       return yield* Effect.fail(
         applicationError(
@@ -460,18 +471,22 @@ function waitForOpenVikingPortClosed(config: RuntimeConfig, timeoutMs: number) {
   });
 }
 
-function launchAgentPlistPath(): string {
-  return join(homedir(), 'Library', 'LaunchAgents', 'io.threadnote.openviking.plist');
+function launchAgentPlistPath(homeDirectory: string, path: Path.Path): string {
+  return path.join(homeDirectory, 'Library', 'LaunchAgents', 'io.threadnote.openviking.plist');
 }
 
 function isLaunchAgentInstalled() {
-  if (process.platform !== 'darwin') {
-    return Effect.succeed(false);
-  }
-  return fromPromise('check OpenViking launch agent', () => access(launchAgentPlistPath(), fsConstants.F_OK)).pipe(
-    Effect.as(true),
-    Effect.catch(() => Effect.succeed(false)),
-  );
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    if (system.platform !== 'darwin') {
+      return false;
+    }
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    return yield* fs
+      .exists(launchAgentPlistPath(system.homeDirectory, path))
+      .pipe(Effect.catch(() => Effect.succeed(false)));
+  });
 }
 
 export async function readOpenVikingCliVersion(ov: string): Promise<string | undefined> {
@@ -801,48 +816,88 @@ async function requireRuntime(runtime: Exclude<UpdateRuntime, 'auto'>): Promise<
   }
 }
 
-async function installedThreadnoteCommand(runtime: Exclude<UpdateRuntime, 'auto'>): Promise<string> {
-  const runtimeBin = await runtimeThreadnoteBin(runtime);
-  if (runtimeBin && (await isExecutable(runtimeBin))) {
+const installedThreadnoteCommand = Effect.fn('installedThreadnoteCommand')(function* (
+  runtime: Exclude<UpdateRuntime, 'auto'>,
+  runtimeExecutable: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
+  const runtimeBin = yield* runtimeThreadnoteBin(runtime, runtimeExecutable);
+  if (runtimeBin && (yield* isExecutableFileEffect(fs, runtimeBin, system.platform))) {
     return runtimeBin;
   }
-  return (await findExecutable([NPM_PACKAGE_NAME])) ?? NPM_PACKAGE_NAME;
-}
+  return (
+    (yield* fromPromise('find installed threadnote executable', () => findExecutable([NPM_PACKAGE_NAME]))) ??
+    NPM_PACKAGE_NAME
+  );
+});
 
-async function runtimeThreadnoteBin(runtime: Exclude<UpdateRuntime, 'auto'>): Promise<string | undefined> {
+const runtimeThreadnoteBin = Effect.fn('runtimeThreadnoteBin')(function* (
+  runtime: Exclude<UpdateRuntime, 'auto'>,
+  runtimeExecutable: string,
+) {
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
   if (runtime === 'npm') {
-    const result = await runCommand('npm', ['prefix', '--global'], {allowFailure: true});
+    const result = yield* runCommandEffect(runtimeExecutable, ['prefix', '--global'], {allowFailure: true});
     const prefix = result.stdout.trim();
-    return prefix ? join(prefix, 'bin', NPM_PACKAGE_NAME) : undefined;
+    return prefix ? runtimeThreadnoteBinPath(runtime, prefix, system.platform) : undefined;
   }
   if (runtime === 'bun') {
-    const result = await runCommand('bun', ['pm', 'bin', '-g'], {allowFailure: true});
+    const result = yield* runCommandEffect(runtimeExecutable, ['pm', 'bin', '-g'], {allowFailure: true});
     const binDir = result.stdout.trim();
-    return binDir ? join(binDir, NPM_PACKAGE_NAME) : undefined;
+    return binDir ? runtimeThreadnoteBinPath(runtime, binDir, system.platform) : undefined;
   }
-  return join(process.env.DENO_INSTALL ?? join(homedir(), '.deno'), 'bin', NPM_PACKAGE_NAME);
+  const denoRoot =
+    process.env.DENO_INSTALL_ROOT ?? process.env.DENO_INSTALL ?? path.join(system.homeDirectory, '.deno');
+  return runtimeThreadnoteBinPath(runtime, path.join(denoRoot, 'bin'), system.platform);
+});
+
+const isExecutableFileEffect = Effect.fn('isExecutableFile')(function* (
+  fs: FileSystem.FileSystem,
+  filePath: string,
+  currentPlatform: NodeJS.Platform,
+) {
+  const info = yield* fs.stat(filePath).pipe(Effect.catch(() => Effect.succeed(undefined)));
+  return info?.type === 'File' && (currentPlatform === 'win32' || (info.mode & 0o111) !== 0);
+});
+
+export function runtimeThreadnoteBinPath(
+  runtime: Exclude<UpdateRuntime, 'auto'>,
+  root: string,
+  currentPlatform: NodeJS.Platform = process.platform,
+): string {
+  const separator = currentPlatform === 'win32' ? '\\' : '/';
+  const append = (...segments: readonly string[]): string => {
+    const base = root.replace(/[\\/]+$/, '') || separator;
+    return `${base}${base.endsWith(separator) ? '' : separator}${segments.join(separator)}`;
+  };
+  if (currentPlatform === 'win32') {
+    return append(`${NPM_PACKAGE_NAME}.cmd`);
+  }
+  return runtime === 'npm' ? append('bin', NPM_PACKAGE_NAME) : append(NPM_PACKAGE_NAME);
 }
 
 function updatePackageCommand(
   runtime: Exclude<UpdateRuntime, 'auto'>,
   registry: string,
   channel: UpdateChannel,
+  runtimeExecutable: string = runtime,
 ): {
   readonly args: readonly string[];
+  readonly env?: NodeJS.ProcessEnv;
   readonly executable: string;
 } {
   const packageSpec = `${NPM_PACKAGE_NAME}@${channel}`;
   if (runtime === 'npm') {
-    return {executable: 'npm', args: ['install', '--global', packageSpec, `--registry=${registry}`]};
+    return {executable: runtimeExecutable, args: ['install', '--global', packageSpec, `--registry=${registry}`]};
   }
   if (runtime === 'bun') {
-    return {executable: 'bun', args: ['install', '--global', packageSpec, `--registry=${registry}`]};
+    return {executable: runtimeExecutable, args: ['install', '--global', packageSpec, `--registry=${registry}`]};
   }
   return {
-    executable: 'env',
+    executable: runtimeExecutable,
     args: [
-      `NPM_CONFIG_REGISTRY=${registry}`,
-      'deno',
       'install',
       '--global',
       '--force',
@@ -855,6 +910,7 @@ function updatePackageCommand(
       '--allow-net',
       `npm:${packageSpec}`,
     ],
+    env: {...process.env, NPM_CONFIG_REGISTRY: registry},
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,9 @@ import {
   commandMaxOutputBytes,
   commandTimeoutMs,
   formatShellCommand,
+  isGitExecutable,
+  resolveCommandInvocation,
+  terminateCommandProcess,
   type CommandOptions,
   withoutGitEnvironment,
 } from './effect/command.js';
@@ -160,9 +163,11 @@ export async function findOpenVikingCli(): Promise<string | undefined> {
   }
   for (const candidateDir of await openVikingToolCandidateDirs()) {
     for (const command of ['ov', 'openviking']) {
-      const candidate = join(candidateDir, command);
-      if (await isExecutable(candidate)) {
-        return candidate;
+      for (const name of executableNames(command)) {
+        const candidate = join(candidateDir, name);
+        if (await isExecutable(candidate)) {
+          return candidate;
+        }
       }
     }
   }
@@ -184,8 +189,31 @@ async function openVikingToolCandidateDirs(): Promise<readonly string[]> {
   if (process.env.UV_TOOL_BIN_DIR) {
     dirs.push(process.env.UV_TOOL_BIN_DIR);
   }
+  dirs.push(...(await pythonUserScriptsCandidateDirs()));
   dirs.push(join(homedir(), '.local', 'bin'));
   return Array.from(new Set(dirs));
+}
+
+export async function pythonUserScriptsCandidateDirs(
+  currentPlatform: NodeJS.Platform = process.platform,
+): Promise<readonly string[]> {
+  const commands = currentPlatform === 'win32' ? ['py', 'python', 'python3'] : ['python3', 'python'];
+  const directories: string[] = [];
+  for (const command of commands) {
+    const executable = await findExecutable([command]);
+    if (!executable) {
+      continue;
+    }
+    const result = await runCommand(executable, ['-c', 'import site; print(site.getuserbase())'], {
+      allowFailure: true,
+      timeoutMs: 5000,
+    });
+    const userBase = result.exitCode === 0 ? result.stdout.trim() : '';
+    if (userBase) {
+      directories.push(join(userBase, currentPlatform === 'win32' ? 'Scripts' : 'bin'));
+    }
+  }
+  return Array.from(new Set(directories));
 }
 
 export async function requiredExecutable(command: string): Promise<string> {
@@ -198,9 +226,10 @@ export async function requiredExecutable(command: string): Promise<string> {
 
 export async function findExecutable(commands: readonly string[]): Promise<string | undefined> {
   for (const command of commands) {
-    const result = await runCommand('which', [command], {allowFailure: true});
-    if (result.exitCode === 0 && result.stdout.trim()) {
-      return result.stdout.trim();
+    for (const candidate of executablePathCandidatesForCommand(command)) {
+      if (await isExecutable(candidate)) {
+        return candidate;
+      }
     }
   }
   return undefined;
@@ -221,13 +250,14 @@ export async function findWorkingExecutable(
 
 export async function findExecutableCandidates(commands: readonly string[]): Promise<readonly string[]> {
   const candidates: string[] = [];
+  const seen = new Set<string>();
   for (const command of commands) {
-    const paths =
-      isAbsolute(command) || command.includes('/') || command.includes('\\')
-        ? [command]
-        : executablePathCandidates(command);
-    for (const candidate of paths) {
-      if (!candidates.includes(candidate) && (await isExecutable(candidate))) {
+    for (const candidate of executablePathCandidatesForCommand(command)) {
+      if (seen.has(candidate)) {
+        continue;
+      }
+      seen.add(candidate);
+      if (await isExecutable(candidate)) {
         candidates.push(candidate);
       }
     }
@@ -235,14 +265,27 @@ export async function findExecutableCandidates(commands: readonly string[]): Pro
   return candidates;
 }
 
+function executablePathCandidatesForCommand(command: string): readonly string[] {
+  return isAbsolute(command) || command.includes('/') || command.includes('\\')
+    ? executableNames(command)
+    : executablePathCandidates(command);
+}
+
 function executablePathCandidates(command: string): readonly string[] {
   const pathDirectories = (process.env.PATH ?? '').split(delimiter);
-  const names = process.platform === 'win32' ? windowsExecutableNames(command) : [command];
+  const names = executableNames(command);
   return pathDirectories.flatMap(directory => names.map(name => join(directory || '.', name)));
 }
 
-function windowsExecutableNames(command: string): readonly string[] {
-  const extensions = (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
+export function executableNames(
+  command: string,
+  currentPlatform: NodeJS.Platform = process.platform,
+  pathExt = process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD',
+): readonly string[] {
+  if (currentPlatform !== 'win32') {
+    return [command];
+  }
+  const extensions = pathExt
     .split(';')
     .map(extension => extension.trim())
     .filter(Boolean);
@@ -250,14 +293,14 @@ function windowsExecutableNames(command: string): readonly string[] {
   if (extensions.some(extension => lowerCommand.endsWith(extension.toLowerCase()))) {
     return [command];
   }
-  return [command, ...extensions.map(extension => `${command}${extension}`)];
+  return [...extensions.map(extension => `${command}${extension}`), command];
 }
 
 export async function maybeRun(
   dryRun: boolean,
   executable: string,
   args: readonly string[],
-  options: {readonly allowFailure?: boolean; readonly cwd?: string} = {},
+  options: {readonly allowFailure?: boolean; readonly cwd?: string; readonly env?: NodeJS.ProcessEnv} = {},
 ): Promise<CommandResult | undefined> {
   const cwdSuffix = options.cwd ? ` (cwd: ${options.cwd})` : '';
   const label = dryRun ? warning('Would run') : info('Running');
@@ -265,7 +308,11 @@ export async function maybeRun(
   if (dryRun) {
     return undefined;
   }
-  const result = await runCommand(executable, args, {allowFailure: options.allowFailure === true, cwd: options.cwd});
+  const result = await runCommand(executable, args, {
+    allowFailure: options.allowFailure === true,
+    cwd: options.cwd,
+    env: options.env,
+  });
   if (result.stdout.trim()) {
     consoleOutput.log(result.stdout.trim());
   }
@@ -287,6 +334,7 @@ export async function runCommand(
     let killTimer: ReturnType<typeof setTimeout> | undefined;
     let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
     let failureMessage: string | undefined;
+    const invocation = resolveCommandInvocation(executable, args);
     const finish = (result: CommandResult): void => {
       if (finished) return;
       finished = true;
@@ -299,13 +347,14 @@ export async function runCommand(
       }
     };
     const child = execFile(
-      executable,
-      [...args],
+      invocation.executable,
+      [...invocation.args],
       {
         cwd: options.cwd,
         encoding: 'utf8',
-        env: basename(executable) === 'git' ? withoutGitEnvironment(options.env ?? process.env) : options.env,
+        env: isGitExecutable(executable) ? withoutGitEnvironment(options.env ?? process.env) : options.env,
         maxBuffer: maxOutputBytes,
+        windowsVerbatimArguments: invocation.windowsVerbatimArguments,
       },
       (cause, stdout, stderr) => {
         if (failureMessage) {
@@ -333,9 +382,11 @@ export async function runCommand(
       killTimer = setTimeout(() => {
         if (finished || child.exitCode !== null) return;
         failureMessage = `${formatShellCommand(executable, args)} timed out after ${timeoutMs}ms`;
-        child.kill('SIGTERM');
+        void terminateCommandProcess(child, invocation, false).catch(() => child.kill('SIGKILL'));
         killEscalationTimer = setTimeout(() => {
-          if (!finished) child.kill('SIGKILL');
+          if (!finished) {
+            void terminateCommandProcess(child, invocation, true).catch(() => child.kill('SIGKILL'));
+          }
         }, 1000);
         killEscalationTimer.unref?.();
       }, timeoutMs);
@@ -454,9 +505,18 @@ function gitRemoteRepoName(remoteUrl: string): string | undefined {
   return name && name !== '.' && name !== '..' ? name : undefined;
 }
 
-export async function runInteractive(executable: string, args: readonly string[]): Promise<number> {
+export async function runInteractive(
+  executable: string,
+  args: readonly string[],
+  options: {readonly env?: NodeJS.ProcessEnv} = {},
+): Promise<number> {
   return new Promise(resolvePromise => {
-    const child = spawn(executable, args, {stdio: 'inherit'});
+    const invocation = resolveCommandInvocation(executable, args);
+    const child = spawn(invocation.executable, invocation.args, {
+      env: options.env,
+      stdio: 'inherit',
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    });
     // `error` fires instead of `close` when the binary cannot be spawned
     // (e.g. ENOENT). Resolve non-zero so callers surface a failure rather than
     // hanging forever waiting for a `close` that never comes.
@@ -657,6 +717,9 @@ export async function exists(path: string): Promise<boolean> {
 
 export async function isExecutable(path: string): Promise<boolean> {
   try {
+    if (!(await stat(path)).isFile()) {
+      return false;
+    }
     await access(path, fsConstants.X_OK);
     return true;
   } catch (_err: unknown) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,24 +1,10 @@
-import {execFile, spawn} from 'node:child_process';
-import {createHash} from 'node:crypto';
-import {constants as fsConstants, existsSync} from 'node:fs';
-import {access, lstat, mkdir, readFile, readdir, rm, stat} from 'node:fs/promises';
-import {createConnection} from 'node:net';
-import {get as httpGet} from 'node:http';
-import {homedir} from 'node:os';
-import {basename, delimiter, dirname, isAbsolute, join, resolve, sep} from 'node:path';
-import {fileURLToPath} from 'node:url';
-import {command as commandText, failure, info, success, warning} from './cli_ui.js';
-import {consoleOutput} from './effect/console.js';
-import {
-  commandMaxOutputBytes,
-  commandTimeoutMs,
-  formatShellCommand,
-  isGitExecutable,
-  resolveCommandInvocation,
-  terminateCommandProcess,
-  type CommandOptions,
-  withoutGitEnvironment,
-} from './effect/command.js';
+import * as NodeSocket from '@effect/platform-node/NodeSocket';
+import {Console, Deferred, Effect, FileSystem, Option, Path, Stdio, Stream} from 'effect';
+import {failure, success, warning} from './cli_ui.js';
+import {maybeRunEffect, runCommandEffect, runStreamingCommandEffect, type CommandOptions} from './effect/command.js';
+import {getStatusEffect, getTextEffect} from './effect/http.js';
+import {sha256Hex} from './effect/digest.js';
+import {SystemInfo, type SystemInfoShape} from './effect/system.js';
 import {
   boundedMemoryAuthority,
   boundedMemoryTrust,
@@ -35,56 +21,51 @@ import {
   type RecallSignals,
 } from './recall/rank.js';
 import {redactSensitiveText} from './scrubber.js';
-import type {CommandResult, CommandStatus, JsonObject} from './types.js';
+import type {CommandStatus, JsonObject} from './types.js';
 
 export {formatShellCommand, shellQuote, withoutGitEnvironment} from './effect/command.js';
-
-const moduleDirectory = dirname(fileURLToPath(import.meta.url));
 
 export function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 export function parseJsonConfigObject(content: string): JsonObject | undefined {
-  try {
-    const parsed: unknown = JSON.parse(content);
-    return isJsonObject(parsed) ? parsed : undefined;
-  } catch (_err: unknown) {
-    return undefined;
-  }
+  const parsed = Option.getOrUndefined(parseJson(content));
+  return isJsonObject(parsed) ? parsed : undefined;
 }
+
+const parseJson = Option.liftThrowable((content: string): unknown => JSON.parse(content));
+const parseUrlPath = Option.liftThrowable((content: string): string => new URL(content).pathname);
 
 export function redactText(content: string): string {
   return redactSensitiveText(content);
 }
 
-export async function walkFiles(root: string): Promise<readonly string[]> {
+export const walkFiles = Effect.fn('utils.walkFiles')(function* (root: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
   const files: string[] = [];
-  async function visit(path: string): Promise<void> {
-    let pathStat;
-    try {
-      pathStat = await lstat(path);
-    } catch (_err: unknown) {
-      return;
-    }
-    if (pathStat.isSymbolicLink()) {
-      return;
-    }
-    if (pathStat.isFile()) {
-      files.push(path);
-      return;
-    }
-    if (!pathStat.isDirectory()) {
-      return;
-    }
-    const entries = await readdir(path);
-    for (const entry of entries) {
-      await visit(join(path, entry));
-    }
-  }
-  await visit(root);
+  const visit = (currentPath: string): Effect.Effect<void, unknown> =>
+    Effect.gen(function* () {
+      const pathStat = yield* fs.stat(currentPath).pipe(Effect.option);
+      if (pathStat._tag === 'None' || pathStat.value.type === 'SymbolicLink') {
+        return;
+      }
+      if (pathStat.value.type === 'File') {
+        files.push(currentPath);
+        return;
+      }
+      if (pathStat.value.type !== 'Directory') {
+        return;
+      }
+      const entries = yield* fs.readDirectory(currentPath);
+      for (const entry of entries) {
+        yield* visit(pathService.join(currentPath, entry));
+      }
+    });
+  yield* visit(root);
   return files;
-}
+});
 
 export function globToRegExp(glob: string): RegExp {
   let output = '^';
@@ -134,51 +115,57 @@ export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-export async function requiredOpenVikingCli(): Promise<string> {
-  const command = await findOpenVikingCli();
+export const requiredOpenVikingCli = Effect.fn('utils.requiredOpenVikingCli')(function* () {
+  const command = yield* findOpenVikingCli();
   if (!command) {
-    throw new Error(
-      'Neither ov nor openviking was found in PATH, uv tool bin dir, $UV_TOOL_BIN_DIR, or ~/.local/bin. ' +
-        'Run threadnote install first.',
+    return yield* Effect.fail(
+      new Error(
+        'Neither ov nor openviking was found in PATH, uv tool bin dir, $UV_TOOL_BIN_DIR, or ~/.local/bin. ' +
+          'Run threadnote install first.',
+      ),
     );
   }
   return command;
-}
+});
 
-export async function openVikingCliForMode(dryRun: boolean): Promise<string> {
+export const openVikingCliForMode = Effect.fn('utils.openVikingCliForMode')(function* (dryRun: boolean) {
   if (dryRun) {
-    return (await findOpenVikingCli()) ?? 'ov';
+    return (yield* findOpenVikingCli()) ?? 'ov';
   }
-  return requiredOpenVikingCli();
-}
+  return yield* requiredOpenVikingCli();
+});
 
-export async function findOpenVikingCli(): Promise<string | undefined> {
-  const override = process.env.THREADNOTE_OV?.trim();
+export const findOpenVikingCli = Effect.fn('utils.findOpenVikingCli')(function* () {
+  const system = yield* SystemInfo;
+  const pathService = yield* Path.Path;
+  const override = system.environment().THREADNOTE_OV?.trim();
   if (override) {
     return override;
   }
-  const onPath = await findExecutable(['ov', 'openviking']);
+  const onPath = yield* findExecutable(['ov', 'openviking']);
   if (onPath) {
     return onPath;
   }
-  for (const candidateDir of await openVikingToolCandidateDirs()) {
+  for (const candidateDir of yield* openVikingToolCandidateDirs()) {
     for (const command of ['ov', 'openviking']) {
-      for (const name of executableNames(command)) {
-        const candidate = join(candidateDir, name);
-        if (await isExecutable(candidate)) {
+      for (const name of executableNames(command, system.platform, system.environment().PATHEXT)) {
+        const candidate = pathService.join(candidateDir, name);
+        if (yield* isExecutable(candidate)) {
           return candidate;
         }
       }
     }
   }
   return undefined;
-}
+});
 
-async function openVikingToolCandidateDirs(): Promise<readonly string[]> {
+const openVikingToolCandidateDirs = Effect.fn('utils.openVikingToolCandidateDirs')(function* () {
+  const system = yield* SystemInfo;
+  const pathService = yield* Path.Path;
   const dirs: string[] = [];
-  const uv = await findExecutable(['uv']);
+  const uv = yield* findExecutable(['uv']);
   if (uv) {
-    const result = await runCommand(uv, ['tool', 'dir', '--bin'], {allowFailure: true});
+    const result = yield* runCommandEffect(uv, ['tool', 'dir', '--bin'], {allowFailure: true});
     if (result.exitCode === 0) {
       const dir = result.stdout.trim();
       if (dir) {
@@ -186,101 +173,115 @@ async function openVikingToolCandidateDirs(): Promise<readonly string[]> {
       }
     }
   }
-  if (process.env.UV_TOOL_BIN_DIR) {
-    dirs.push(process.env.UV_TOOL_BIN_DIR);
+  const environment = system.environment();
+  if (environment.UV_TOOL_BIN_DIR) {
+    dirs.push(environment.UV_TOOL_BIN_DIR);
   }
-  dirs.push(...(await pythonUserScriptsCandidateDirs()));
-  dirs.push(join(homedir(), '.local', 'bin'));
+  dirs.push(...(yield* pythonUserScriptsCandidateDirs()));
+  dirs.push(pathService.join(system.homeDirectory, '.local', 'bin'));
   return Array.from(new Set(dirs));
-}
+});
 
-export async function pythonUserScriptsCandidateDirs(
-  currentPlatform: NodeJS.Platform = process.platform,
-): Promise<readonly string[]> {
-  const commands = currentPlatform === 'win32' ? ['py', 'python', 'python3'] : ['python3', 'python'];
+export const pythonUserScriptsCandidateDirs = Effect.fn('utils.pythonUserScriptsCandidateDirs')(function* (
+  currentPlatform?: NodeJS.Platform,
+) {
+  const system = yield* SystemInfo;
+  const pathService = yield* Path.Path;
+  const platform = currentPlatform ?? system.platform;
+  const commands = platform === 'win32' ? ['py', 'python', 'python3'] : ['python3', 'python'];
   const directories: string[] = [];
   for (const command of commands) {
-    const executable = await findExecutable([command]);
+    const executable = yield* findExecutable([command]);
     if (!executable) {
       continue;
     }
-    const result = await runCommand(executable, ['-c', 'import site; print(site.getuserbase())'], {
+    const result = yield* runCommandEffect(executable, ['-c', 'import site; print(site.getuserbase())'], {
       allowFailure: true,
       timeoutMs: 5000,
     });
     const userBase = result.exitCode === 0 ? result.stdout.trim() : '';
     if (userBase) {
-      directories.push(join(userBase, currentPlatform === 'win32' ? 'Scripts' : 'bin'));
+      directories.push(pathService.join(userBase, platform === 'win32' ? 'Scripts' : 'bin'));
     }
   }
   return Array.from(new Set(directories));
-}
+});
 
-export async function requiredExecutable(command: string): Promise<string> {
-  const executable = await findExecutable([command]);
+export const requiredExecutable = Effect.fn('utils.requiredExecutable')(function* (command: string) {
+  const executable = yield* findExecutable([command]);
   if (!executable) {
-    throw new Error(`${command} was not found in PATH.`);
+    return yield* Effect.fail(new Error(`${command} was not found in PATH.`));
   }
   return executable;
-}
+});
 
-export async function findExecutable(commands: readonly string[]): Promise<string | undefined> {
+export const findExecutable = Effect.fn('utils.findExecutable')(function* (commands: readonly string[]) {
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
   for (const command of commands) {
-    for (const candidate of executablePathCandidatesForCommand(command)) {
-      if (await isExecutable(candidate)) {
+    for (const candidate of executablePathCandidatesForCommand(command, pathService, system)) {
+      if (yield* isExecutable(candidate)) {
         return candidate;
       }
     }
   }
   return undefined;
-}
+});
 
-export async function findWorkingExecutable(
+export const findWorkingExecutable = Effect.fn('utils.findWorkingExecutable')(function* (
   commands: readonly string[],
   args: readonly string[] = ['--version'],
-): Promise<string | undefined> {
-  for (const executable of await findExecutableCandidates(commands)) {
-    const result = await runCommand(executable, args, {allowFailure: true, timeoutMs: 5000});
+) {
+  for (const executable of yield* findExecutableCandidates(commands)) {
+    const result = yield* runCommandEffect(executable, args, {allowFailure: true, timeoutMs: 5000});
     if (result.exitCode === 0) {
       return executable;
     }
   }
   return undefined;
-}
+});
 
-export async function findExecutableCandidates(commands: readonly string[]): Promise<readonly string[]> {
+export const findExecutableCandidates = Effect.fn('utils.findExecutableCandidates')(function* (
+  commands: readonly string[],
+) {
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
   const candidates: string[] = [];
   const seen = new Set<string>();
   for (const command of commands) {
-    for (const candidate of executablePathCandidatesForCommand(command)) {
+    for (const candidate of executablePathCandidatesForCommand(command, pathService, system)) {
       if (seen.has(candidate)) {
         continue;
       }
       seen.add(candidate);
-      if (await isExecutable(candidate)) {
+      if (yield* isExecutable(candidate)) {
         candidates.push(candidate);
       }
     }
   }
   return candidates;
+});
+
+function executablePathCandidatesForCommand(
+  command: string,
+  pathService: Path.Path,
+  system: SystemInfoShape,
+): readonly string[] {
+  return pathService.isAbsolute(command) || command.includes('/') || command.includes('\\')
+    ? executableNames(command, system.platform, system.environment().PATHEXT)
+    : executablePathCandidates(command, pathService, system);
 }
 
-function executablePathCandidatesForCommand(command: string): readonly string[] {
-  return isAbsolute(command) || command.includes('/') || command.includes('\\')
-    ? executableNames(command)
-    : executablePathCandidates(command);
-}
-
-function executablePathCandidates(command: string): readonly string[] {
-  const pathDirectories = (process.env.PATH ?? '').split(delimiter);
-  const names = executableNames(command);
-  return pathDirectories.flatMap(directory => names.map(name => join(directory || '.', name)));
+function executablePathCandidates(command: string, pathService: Path.Path, system: SystemInfoShape): readonly string[] {
+  const pathDirectories = (system.environment().PATH ?? '').split(system.pathDelimiter);
+  const names = executableNames(command, system.platform, system.environment().PATHEXT);
+  return pathDirectories.flatMap(directory => names.map(name => pathService.join(directory || '.', name)));
 }
 
 export function executableNames(
   command: string,
-  currentPlatform: NodeJS.Platform = process.platform,
-  pathExt = process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD',
+  currentPlatform: NodeJS.Platform,
+  pathExt = '.COM;.EXE;.BAT;.CMD',
 ): readonly string[] {
   if (currentPlatform !== 'win32') {
     return [command];
@@ -296,104 +297,22 @@ export function executableNames(
   return [...extensions.map(extension => `${command}${extension}`), command];
 }
 
-export async function maybeRun(
+export const maybeRun = Effect.fn('utils.maybeRun')(function* (
   dryRun: boolean,
   executable: string,
   args: readonly string[],
   options: {readonly allowFailure?: boolean; readonly cwd?: string; readonly env?: NodeJS.ProcessEnv} = {},
-): Promise<CommandResult | undefined> {
-  const cwdSuffix = options.cwd ? ` (cwd: ${options.cwd})` : '';
-  const label = dryRun ? warning('Would run') : info('Running');
-  consoleOutput.log(`${label}: ${commandText(formatShellCommand(executable, args))}${cwdSuffix}`);
-  if (dryRun) {
-    return undefined;
-  }
-  const result = await runCommand(executable, args, {
-    allowFailure: options.allowFailure === true,
-    cwd: options.cwd,
-    env: options.env,
-  });
-  if (result.stdout.trim()) {
-    consoleOutput.log(result.stdout.trim());
-  }
-  if (result.stderr.trim()) {
-    consoleOutput.error(result.stderr.trim());
-  }
-  return result;
-}
+) {
+  return yield* maybeRunEffect(dryRun, executable, args, options);
+});
 
-export async function runCommand(
+export const runCommand = Effect.fn('utils.runCommand')(function* (
   executable: string,
   args: readonly string[],
   options: CommandOptions = {},
-): Promise<CommandResult> {
-  return new Promise((resolvePromise, rejectPromise) => {
-    const maxOutputBytes = options.maxOutputBytes ?? commandMaxOutputBytes();
-    const timeoutMs = options.timeoutMs ?? commandTimeoutMs();
-    let finished = false;
-    let killTimer: ReturnType<typeof setTimeout> | undefined;
-    let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
-    let failureMessage: string | undefined;
-    const invocation = resolveCommandInvocation(executable, args);
-    const finish = (result: CommandResult): void => {
-      if (finished) return;
-      finished = true;
-      if (killTimer) clearTimeout(killTimer);
-      if (killEscalationTimer) clearTimeout(killEscalationTimer);
-      if (result.exitCode !== 0 && options.allowFailure !== true) {
-        rejectPromise(new Error(`${formatShellCommand(executable, args)} failed: ${result.stderr || result.stdout}`));
-      } else {
-        resolvePromise(result);
-      }
-    };
-    const child = execFile(
-      invocation.executable,
-      [...invocation.args],
-      {
-        cwd: options.cwd,
-        encoding: 'utf8',
-        env: isGitExecutable(executable) ? withoutGitEnvironment(options.env ?? process.env) : options.env,
-        maxBuffer: maxOutputBytes,
-        windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-      },
-      (cause, stdout, stderr) => {
-        if (failureMessage) {
-          finish({exitCode: 124, stderr: failureMessage, stdout});
-          return;
-        }
-        if (!cause) {
-          finish({exitCode: 0, stderr, stdout});
-          return;
-        }
-        const error = cause as Error & {readonly code?: number | string};
-        const exitCode =
-          typeof error.code === 'number' ? error.code : error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' ? 124 : 127;
-        finish({
-          exitCode,
-          stderr:
-            error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
-              ? `${formatShellCommand(executable, args)} exceeded output limit of ${maxOutputBytes} bytes`
-              : stderr || errorMessage(error),
-          stdout,
-        });
-      },
-    );
-    if (timeoutMs > 0) {
-      killTimer = setTimeout(() => {
-        if (finished || child.exitCode !== null) return;
-        failureMessage = `${formatShellCommand(executable, args)} timed out after ${timeoutMs}ms`;
-        void terminateCommandProcess(child, invocation, false).catch(() => child.kill('SIGKILL'));
-        killEscalationTimer = setTimeout(() => {
-          if (!finished) {
-            void terminateCommandProcess(child, invocation, true).catch(() => child.kill('SIGKILL'));
-          }
-        }, 1000);
-        killEscalationTimer.unref?.();
-      }, timeoutMs);
-      killTimer.unref?.();
-    }
-  });
-}
+) {
+  return yield* runCommandEffect(executable, args, options);
+});
 
 /**
  * Upper bound (ms) for an `ov reindex --wait true` call. `ov reindex` has no
@@ -405,12 +324,16 @@ export async function runCommand(
  * queue is stuck and we bail rather than hang (the write already succeeded).
  * Override with THREADNOTE_REINDEX_TIMEOUT_MS.
  */
-export function reindexWaitTimeoutMs(): number {
-  return positiveIntegerFromEnv('THREADNOTE_REINDEX_TIMEOUT_MS') ?? 120_000;
-}
+export const reindexWaitTimeoutMs = Effect.fn('utils.reindexWaitTimeoutMs')(function* () {
+  const environment = (yield* SystemInfo).environment();
+  return positiveIntegerFromEnv(environment, 'THREADNOTE_REINDEX_TIMEOUT_MS') ?? 120_000;
+});
 
-function positiveIntegerFromEnv(name: string): number | undefined {
-  const value = process.env[name];
+function positiveIntegerFromEnv(
+  environment: Readonly<Record<string, string | undefined>>,
+  name: string,
+): number | undefined {
+  const value = environment[name];
   if (value === undefined) {
     return undefined;
   }
@@ -418,13 +341,16 @@ function positiveIntegerFromEnv(name: string): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-export async function gitValue(args: readonly string[], cwd = getInvocationCwd()): Promise<string | undefined> {
-  const result = await runCommand('git', args, {allowFailure: true, cwd});
+export const gitValue = Effect.fn('utils.gitValue')(function* (args: readonly string[], cwd?: string) {
+  const result = yield* runCommandEffect('git', args, {
+    allowFailure: true,
+    cwd: cwd ?? (yield* getInvocationCwd()),
+  });
   if (result.exitCode !== 0) {
     return undefined;
   }
   return result.stdout.trim();
-}
+});
 
 /**
  * Resolves the canonical repository name for `cwd`, returning undefined when it
@@ -435,42 +361,45 @@ export async function gitValue(args: readonly string[], cwd = getInvocationCwd()
  * primary worktree name: linked worktree paths (`git worktree add`, Conductor
  * workspaces, …) often use the branch/workspace name instead of the project.
  */
-export async function resolveRepoName(cwd = getInvocationCwd()): Promise<string | undefined> {
-  const repoRoot = await gitValue(['rev-parse', '--show-toplevel'], cwd);
+export const resolveRepoName = Effect.fn('utils.resolveRepoName')(function* (cwd?: string) {
+  const resolvedCwd = cwd ?? (yield* getInvocationCwd());
+  const repoRoot = yield* gitValue(['rev-parse', '--show-toplevel'], resolvedCwd);
   if (!repoRoot) {
     return undefined;
   }
-  const remoteName = await resolveGitRemoteRepoName(repoRoot);
+  const remoteName = yield* resolveGitRemoteRepoName(repoRoot);
   if (remoteName) {
     return remoteName;
   }
-  return resolveRepoFolderName(repoRoot);
-}
+  return yield* resolveRepoFolderName(repoRoot);
+});
 
-export async function resolveRepoFolderName(cwd = getInvocationCwd()): Promise<string | undefined> {
-  const repoRoot = await gitValue(['rev-parse', '--show-toplevel'], cwd);
+export const resolveRepoFolderName = Effect.fn('utils.resolveRepoFolderName')(function* (cwd?: string) {
+  const pathService = yield* Path.Path;
+  const repoRoot = yield* gitValue(['rev-parse', '--show-toplevel'], cwd ?? (yield* getInvocationCwd()));
   if (!repoRoot) {
     return undefined;
   }
-  const commonDir = await gitValue(['rev-parse', '--git-common-dir'], repoRoot);
+  const commonDir = yield* gitValue(['rev-parse', '--git-common-dir'], repoRoot);
   if (commonDir) {
-    const absoluteCommonDir = isAbsolute(commonDir) ? commonDir : resolve(repoRoot, commonDir);
-    const primaryRoot = basename(absoluteCommonDir) === '.git' ? dirname(absoluteCommonDir) : absoluteCommonDir;
-    const name = basename(primaryRoot).replace(/\.git$/, '');
+    const absoluteCommonDir = pathService.isAbsolute(commonDir) ? commonDir : pathService.resolve(repoRoot, commonDir);
+    const primaryRoot =
+      pathService.basename(absoluteCommonDir) === '.git' ? pathService.dirname(absoluteCommonDir) : absoluteCommonDir;
+    const name = pathService.basename(primaryRoot).replace(/\.git$/, '');
     if (name && name !== '.') {
       return name;
     }
   }
-  return basename(repoRoot);
-}
+  return pathService.basename(repoRoot);
+});
 
-export async function resolveGitRemoteRepoName(repoRoot: string): Promise<string | undefined> {
-  const originUrl = await gitValue(['remote', 'get-url', 'origin'], repoRoot);
+export const resolveGitRemoteRepoName = Effect.fn('utils.resolveGitRemoteRepoName')(function* (repoRoot: string) {
+  const originUrl = yield* gitValue(['remote', 'get-url', 'origin'], repoRoot);
   const originName = originUrl ? gitRemoteRepoName(originUrl) : undefined;
   if (originName) {
     return originName;
   }
-  const remotes = await gitValue(['remote'], repoRoot);
+  const remotes = yield* gitValue(['remote'], repoRoot);
   const remote = remotes
     ?.split(/\r?\n/)
     .map(name => name.trim())
@@ -478,19 +407,18 @@ export async function resolveGitRemoteRepoName(repoRoot: string): Promise<string
   if (!remote) {
     return undefined;
   }
-  const remoteUrl = await gitValue(['remote', 'get-url', remote], repoRoot);
+  const remoteUrl = yield* gitValue(['remote', 'get-url', remote], repoRoot);
   return remoteUrl ? gitRemoteRepoName(remoteUrl) : undefined;
-}
+});
 
 function gitRemoteRepoName(remoteUrl: string): string | undefined {
   const trimmed = remoteUrl.trim();
   if (!trimmed) {
     return undefined;
   }
-  let remotePath = trimmed.replace(/[?#].*$/, '');
-  try {
-    remotePath = new URL(trimmed).pathname;
-  } catch (_err: unknown) {
+  const parsedUrlPath = parseUrlPath(trimmed);
+  let remotePath = Option.getOrUndefined(parsedUrlPath) ?? trimmed.replace(/[?#].*$/, '');
+  if (Option.isNone(parsedUrlPath)) {
     const scpLike = trimmed.match(/^[^@\s/]+@[^:\s]+:(.+)$/);
     if (scpLike?.[1]) {
       remotePath = scpLike[1];
@@ -505,52 +433,19 @@ function gitRemoteRepoName(remoteUrl: string): string | undefined {
   return name && name !== '.' && name !== '..' ? name : undefined;
 }
 
-export async function runInteractive(
+export const runInteractive = Effect.fn('utils.runInteractive')(function* (
   executable: string,
   args: readonly string[],
   options: {readonly env?: NodeJS.ProcessEnv} = {},
-): Promise<number> {
-  return new Promise(resolvePromise => {
-    const invocation = resolveCommandInvocation(executable, args);
-    const child = spawn(invocation.executable, invocation.args, {
-      env: options.env,
-      stdio: 'inherit',
-      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-    });
-    // `error` fires instead of `close` when the binary cannot be spawned
-    // (e.g. ENOENT). Resolve non-zero so callers surface a failure rather than
-    // hanging forever waiting for a `close` that never comes.
-    child.on('error', () => {
-      resolvePromise(1);
-    });
-    child.on('close', code => {
-      resolvePromise(code ?? 1);
-    });
-  });
-}
+) {
+  return (yield* runStreamingCommandEffect(executable, args, options)).exitCode;
+});
 
-export async function httpGetText(url: string, timeoutMs: number): Promise<string> {
-  return new Promise((resolvePromise, rejectPromise) => {
-    const request = httpGet(url, response => {
-      const chunks: string[] = [];
-      response.on('data', chunk => chunks.push(String(chunk)));
-      response.on('end', () => {
-        const statusCode = response.statusCode ?? 0;
-        if (statusCode >= 200 && statusCode < 300) {
-          resolvePromise(chunks.join(''));
-        } else {
-          rejectPromise(new Error(`HTTP ${statusCode}`));
-        }
-      });
-    });
-    request.setTimeout(timeoutMs, () => request.destroy(new Error(`Timed out after ${timeoutMs}ms`)));
-    request.on('error', rejectPromise);
-  });
-}
+export const httpGetText = Effect.fn('utils.httpGetText')(function* (url: string, timeoutMs: number) {
+  return (yield* getTextEffect(url, {timeoutMs})).body;
+});
 
-export async function sleep(ms: number): Promise<void> {
-  return new Promise(resolvePromise => setTimeout(resolvePromise, ms));
-}
+export const sleep = (ms: number) => Effect.sleep(ms);
 
 /**
  * Compare two semver-ish / PEP 440 versions. Returns positive if `a > b`,
@@ -641,91 +536,72 @@ export function formatStaleVersionNotice(
   );
 }
 
-export async function readHttpStatus(url: string, timeoutMs: number): Promise<number | undefined> {
-  return new Promise(resolvePromise => {
-    const request = httpGet(url, response => {
-      response.resume();
-      resolvePromise(response.statusCode);
-    });
-    request.setTimeout(timeoutMs, () => {
-      request.destroy();
-      resolvePromise(undefined);
-    });
-    request.on('error', () => resolvePromise(undefined));
-  });
-}
+export const readHttpStatus = Effect.fn('utils.readHttpStatus')((url: string, timeoutMs: number) =>
+  getStatusEffect(url, {timeoutMs}).pipe(Effect.catch(() => Effect.succeed(undefined))),
+);
 
-export async function isTcpPortOpen(host: string, port: number, timeoutMs: number): Promise<boolean> {
-  return new Promise(resolvePromise => {
-    const socket = createConnection({host, port});
-    let resolved = false;
-    const finish = (value: boolean): void => {
-      if (resolved) {
-        return;
-      }
-      resolved = true;
-      socket.destroy();
-      resolvePromise(value);
-    };
-    socket.setTimeout(timeoutMs);
-    socket.once('connect', () => {
-      finish(true);
-    });
-    socket.once('timeout', () => {
-      finish(false);
-    });
-    socket.once('error', () => {
-      finish(false);
-    });
-  });
-}
+export const isTcpPortOpen = Effect.fn('utils.isTcpPortOpen')((host: string, port: number, timeoutMs: number) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const connected = yield* Deferred.make<boolean>();
+      const socket = yield* NodeSocket.makeNet({host, port});
+      yield* socket
+        .run(() => undefined, {onOpen: Deferred.succeed(connected, true)})
+        .pipe(
+          Effect.catch(() => Deferred.succeed(connected, false)),
+          Effect.forkScoped,
+        );
+      return yield* Deferred.await(connected).pipe(
+        Effect.timeoutOrElse({duration: timeoutMs, orElse: () => Effect.succeed(false)}),
+      );
+    }),
+  ),
+);
 
-export async function getInputText(optionText: string | undefined, useStdin: boolean): Promise<string> {
+export const getInputText = Effect.fn('utils.getInputText')(function* (
+  optionText: string | undefined,
+  useStdin: boolean,
+) {
   if (optionText !== undefined) {
     return optionText;
   }
   if (!useStdin) {
     return '';
   }
-  return new Promise(resolvePromise => {
-    const chunks: string[] = [];
-    process.stdin.on('data', chunk => {
-      chunks.push(String(chunk));
-    });
-    process.stdin.on('end', () => {
-      resolvePromise(chunks.join(''));
-    });
-  });
-}
+  const stdio = yield* Stdio.Stdio;
+  return yield* stdio.stdin.pipe(
+    Stream.decodeText,
+    Stream.runFold(
+      () => '',
+      (output, chunk) => `${output}${chunk}`,
+    ),
+  );
+});
 
-export async function ensureDirectory(path: string, dryRun: boolean): Promise<void> {
+export const ensureDirectory = Effect.fn('utils.ensureDirectory')(function* (path: string, dryRun: boolean) {
   if (dryRun) {
-    consoleOutput.log(`Would create directory: ${path}`);
+    yield* Console.log(`Would create directory: ${path}`);
     return;
   }
-  await mkdir(path, {recursive: true});
-}
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.makeDirectory(path, {recursive: true});
+});
 
-export async function exists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch (_err: unknown) {
-    return false;
-  }
-}
+export const exists = Effect.fn('utils.exists')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.exists(path);
+});
 
-export async function isExecutable(path: string): Promise<boolean> {
-  try {
-    if (!(await stat(path)).isFile()) {
-      return false;
-    }
-    await access(path, fsConstants.X_OK);
-    return true;
-  } catch (_err: unknown) {
-    return false;
-  }
-}
+export const isExecutable = Effect.fn('utils.isExecutable')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
+  const info = yield* fs.stat(path).pipe(Effect.option);
+  return (
+    info._tag === 'Some' &&
+    info.value.type === 'File' &&
+    (system.platform === 'win32' || (info.value.mode & 0o111) !== 0)
+  );
+});
 
 export function suggestedShellRc(shellPath: string | undefined, currentPlatform: NodeJS.Platform): string {
   const shell = shellPath ?? '';
@@ -741,46 +617,44 @@ export function suggestedShellRc(shellPath: string | undefined, currentPlatform:
   return 'your shell rc';
 }
 
-export async function isFile(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isFile();
-  } catch (_err: unknown) {
-    return false;
-  }
-}
+export const isFile = Effect.fn('utils.isFile')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const info = yield* fs.stat(path).pipe(Effect.option);
+  return info._tag === 'Some' && info.value.type === 'File';
+});
 
-export async function isDirectory(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isDirectory();
-  } catch (_err: unknown) {
-    return false;
-  }
-}
+export const isDirectory = Effect.fn('utils.isDirectory')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const info = yield* fs.stat(path).pipe(Effect.option);
+  return info._tag === 'Some' && info.value.type === 'Directory';
+});
 
-export async function readFileIfExists(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, 'utf8');
-  } catch (_err: unknown) {
-    return undefined;
-  }
-}
+export const readFileIfExists = Effect.fn('utils.readFileIfExists')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readFileString(path).pipe(Effect.option, Effect.map(Option.getOrUndefined));
+});
 
-export async function removePathIfExists(path: string, label: string, dryRun: boolean): Promise<void> {
-  if (!(await exists(path))) {
-    consoleOutput.log(`Already absent: ${path}`);
+export const removePathIfExists = Effect.fn('utils.removePathIfExists')(function* (
+  path: string,
+  label: string,
+  dryRun: boolean,
+) {
+  if (!(yield* exists(path))) {
+    yield* Console.log(`Already absent: ${path}`);
     return;
   }
-  await removePath(path, label, dryRun);
-}
+  yield* removePath(path, label, dryRun);
+});
 
-export async function removePath(path: string, label: string, dryRun: boolean): Promise<void> {
+export const removePath = Effect.fn('utils.removePath')(function* (path: string, label: string, dryRun: boolean) {
   if (dryRun) {
-    consoleOutput.log(`Would remove ${label}: ${path}`);
+    yield* Console.log(`Would remove ${label}: ${path}`);
     return;
   }
-  await rm(path, {force: true, recursive: true});
-  consoleOutput.log(`Removed ${label}: ${path}`);
-}
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.remove(path, {force: true, recursive: true});
+  yield* Console.log(`Removed ${label}: ${path}`);
+});
 
 export function parsePort(value: string): number {
   const parsed = Number(value);
@@ -808,108 +682,122 @@ export function collectOption(value: string, previous: readonly string[]): reado
   return [...previous, value];
 }
 
-export function expandPath(path: string): string {
+export const expandPath = Effect.fn('utils.expandPath')(function* (path: string) {
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
   if (path === '~') {
-    return homedir();
+    return system.homeDirectory;
   }
-  if (path.startsWith(`~${sep}`) || path.startsWith('~/')) {
-    return join(homedir(), path.slice(2));
+  if (path.startsWith(`~${pathService.sep}`) || path.startsWith('~/')) {
+    return pathService.join(system.homeDirectory, path.slice(2));
   }
-  return isAbsolute(path) ? path : resolve(getInvocationCwd(), path);
-}
+  return pathService.isAbsolute(path) ? path : pathService.resolve(yield* getInvocationCwd(), path);
+});
 
-export function assertSafeThreadnoteHomeForErase(path: string): void {
-  const resolvedPath = resolve(path);
-  if (resolvedPath === '/' || resolvedPath === homedir() || resolvedPath === dirname(homedir())) {
-    throw new Error(`Refusing to erase unsafe THREADNOTE_HOME: ${resolvedPath}`);
+export const assertSafeThreadnoteHomeForErase = Effect.fn('utils.assertSafeThreadnoteHomeForErase')(function* (
+  path: string,
+) {
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const resolvedPath = pathService.resolve(path);
+  if (
+    resolvedPath === pathService.parse(resolvedPath).root ||
+    resolvedPath === system.homeDirectory ||
+    resolvedPath === pathService.dirname(system.homeDirectory)
+  ) {
+    return yield* Effect.fail(new Error(`Refusing to erase unsafe THREADNOTE_HOME: ${resolvedPath}`));
   }
-}
+});
 
-export function portablePath(path: string): string {
-  const home = homedir();
-  const resolvedPath = resolve(path);
+export const portablePath = Effect.fn('utils.portablePath')(function* (path: string) {
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const home = system.homeDirectory;
+  const resolvedPath = pathService.resolve(path);
   if (resolvedPath === home) {
     return '~';
   }
-  if (resolvedPath.startsWith(`${home}${sep}`)) {
+  if (resolvedPath.startsWith(`${home}${pathService.sep}`)) {
     return `~/${resolvedPath
       .slice(home.length + 1)
-      .split(sep)
+      .split(pathService.sep)
       .join('/')}`;
   }
   return resolvedPath;
-}
+});
 
-export function getInvocationCwd(): string {
-  return process.env.THREADNOTE_CALLER_CWD ?? process.cwd();
-}
+export const getInvocationCwd = Effect.fn('utils.getInvocationCwd')(function* () {
+  const system = yield* SystemInfo;
+  return system.environment().THREADNOTE_CALLER_CWD ?? system.currentDirectory();
+});
 
 export function recallQueryRequestsWorkspaceContext(query: string): boolean {
   const normalized = query.toLowerCase();
   return /\b(?:this|current)\s+(?:branch|repo|repository|workspace|worktree)\b/.test(normalized);
 }
 
-export async function enrichRecallQueryWithWorkspaceContext(
-  query: string,
-  options: {readonly cwd?: string; readonly includeProcessCwd?: boolean} = {},
-): Promise<string> {
-  return enrichRecallQueryWithWorkspaceTerms(query, options, true);
-}
+export const enrichRecallQueryWithWorkspaceContext = Effect.fn('utils.enrichRecallQueryWithWorkspaceContext')(
+  function* (query: string, options: {readonly cwd?: string; readonly includeProcessCwd?: boolean} = {}) {
+    return yield* enrichRecallQueryWithWorkspaceTerms(query, options, true);
+  },
+);
 
-export async function enrichRecallQueryWithWorkspaceProjectContext(
-  query: string,
-  options: {readonly cwd?: string; readonly includeProcessCwd?: boolean} = {},
-): Promise<string> {
-  return enrichRecallQueryWithWorkspaceTerms(query, options, false);
-}
+export const enrichRecallQueryWithWorkspaceProjectContext = Effect.fn(
+  'utils.enrichRecallQueryWithWorkspaceProjectContext',
+)(function* (query: string, options: {readonly cwd?: string; readonly includeProcessCwd?: boolean} = {}) {
+  return yield* enrichRecallQueryWithWorkspaceTerms(query, options, false);
+});
 
-export async function resolveWorkspaceRepoName(
+export const resolveWorkspaceRepoName = Effect.fn('utils.resolveWorkspaceRepoName')(function* (
   options: {readonly cwd?: string; readonly includeProcessCwd?: boolean} = {},
-): Promise<string | undefined> {
-  const cwd = options.cwd ?? (options.includeProcessCwd === false ? undefined : getInvocationCwd());
-  if (!cwd || !isAbsolute(cwd)) {
+) {
+  const pathService = yield* Path.Path;
+  const cwd = options.cwd ?? (options.includeProcessCwd === false ? undefined : yield* getInvocationCwd());
+  if (!cwd || !pathService.isAbsolute(cwd)) {
     return undefined;
   }
-  return resolveRepoName(cwd);
-}
+  return yield* resolveRepoName(cwd);
+});
 
-async function enrichRecallQueryWithWorkspaceTerms(
+const enrichRecallQueryWithWorkspaceTerms = Effect.fn('utils.enrichRecallQueryWithWorkspaceTerms')(function* (
   query: string,
   options: {readonly cwd?: string; readonly includeProcessCwd?: boolean},
   includeBranch: boolean,
-): Promise<string> {
+) {
   if (!recallQueryRequestsWorkspaceContext(query)) {
     return query;
   }
-  const terms = await currentWorkspaceRecallTerms(options, includeBranch);
+  const terms = yield* currentWorkspaceRecallTerms(options, includeBranch);
   const additions = terms.filter(term => !query.toLowerCase().includes(term.toLowerCase()));
   return additions.length > 0 ? `${query} ${additions.join(' ')}` : query;
-}
+});
 
-async function currentWorkspaceRecallTerms(
+const currentWorkspaceRecallTerms = Effect.fn('utils.currentWorkspaceRecallTerms')(function* (
   options: {
     readonly cwd?: string;
     readonly includeProcessCwd?: boolean;
   },
   includeBranch: boolean,
-): Promise<readonly string[]> {
-  const cwd = options.cwd ?? (options.includeProcessCwd === false ? undefined : getInvocationCwd());
-  if (!cwd || !isAbsolute(cwd)) {
+) {
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const cwd = options.cwd ?? (options.includeProcessCwd === false ? undefined : yield* getInvocationCwd());
+  if (!cwd || !pathService.isAbsolute(cwd)) {
     return [];
   }
-  const repoRoot = await gitValue(['rev-parse', '--show-toplevel'], cwd);
+  const repoRoot = yield* gitValue(['rev-parse', '--show-toplevel'], cwd);
   if (!repoRoot) {
     return [];
   }
-  const branch = await gitValue(['branch', '--show-current'], repoRoot);
-  const repoName = await resolveWorkspaceRepoName({cwd, includeProcessCwd: false});
-  const parent = dirname(repoRoot);
+  const branch = yield* gitValue(['branch', '--show-current'], repoRoot);
+  const repoName = yield* resolveWorkspaceRepoName({cwd, includeProcessCwd: false});
+  const parent = pathService.dirname(repoRoot);
   return uniqueUsefulWorkspaceTerms([
     {source: 'branch', value: includeBranch ? branch : undefined},
     {source: 'path', value: repoName},
-    {source: 'path', value: parent === homedir() ? undefined : basename(parent)},
+    {source: 'path', value: parent === system.homeDirectory ? undefined : pathService.basename(parent)},
   ]);
-}
+});
 
 export function uniqueUsefulWorkspaceTerms(
   values: readonly {readonly source: 'branch' | 'path'; readonly value: string | undefined}[],
@@ -931,7 +819,7 @@ export function uniqueUsefulWorkspaceTerms(
 }
 
 export function toPosixPath(path: string): string {
-  return path.split(sep).join('/');
+  return path.replaceAll('\\', '/');
 }
 
 export function trimTrailingSlash(value: string): string {
@@ -944,9 +832,7 @@ export function parentVikingUri(uri: string): string {
   return slashIndex <= 'viking://'.length ? trimmedUri : trimmedUri.slice(0, slashIndex);
 }
 
-export function sha256(content: string | Buffer): string {
-  return createHash('sha256').update(content).digest('hex');
-}
+export const sha256 = sha256Hex;
 
 export function exactRecallTerms(query: string): readonly string[] {
   const stopWords = new Set([
@@ -1026,7 +912,9 @@ export function grepOutputHasMatches(output: string): boolean {
  * globally via THREADNOTE_RECALL_THRESHOLD, matching the THREADNOTE_* env
  * convention used for command timeout/output caps.
  */
-export const RECALL_SCORE_THRESHOLD = process.env.THREADNOTE_RECALL_THRESHOLD?.trim() || '0.45';
+export const recallScoreThreshold = Effect.fn('utils.recallScoreThreshold')(function* () {
+  return (yield* SystemInfo).environment().THREADNOTE_RECALL_THRESHOLD?.trim() || '0.45';
+});
 
 export type ExactScopeIntent = 'durable' | 'handoffs' | 'incidents' | 'preferences';
 
@@ -1143,23 +1031,19 @@ export function grepUrisFromJson(output: string): readonly string[] {
   if (start < 0) {
     return [];
   }
-  try {
-    const parsed: unknown = JSON.parse(output.slice(start));
-    const result = isJsonObject(parsed) ? parsed.result : undefined;
-    const matches = isJsonObject(result) ? result.matches : undefined;
-    if (!Array.isArray(matches)) {
-      return [];
-    }
-    const uris: string[] = [];
-    for (const match of matches) {
-      if (isJsonObject(match) && typeof match.uri === 'string' && !isExcludedRecallUri(match.uri)) {
-        uris.push(match.uri);
-      }
-    }
-    return uris;
-  } catch (_err: unknown) {
+  const parsed = Option.getOrUndefined(parseJson(output.slice(start)));
+  const result = isJsonObject(parsed) ? parsed.result : undefined;
+  const matches = isJsonObject(result) ? result.matches : undefined;
+  if (!Array.isArray(matches)) {
     return [];
   }
+  const uris: string[] = [];
+  for (const match of matches) {
+    if (isJsonObject(match) && typeof match.uri === 'string' && !isExcludedRecallUri(match.uri)) {
+      uris.push(match.uri);
+    }
+  }
+  return uris;
 }
 
 export interface ExactMatch {
@@ -1234,38 +1118,34 @@ export function parseRecallHits(output: string, options: ParseRecallHitsOptions 
   if (start < 0) {
     return [];
   }
-  try {
-    const parsed: unknown = JSON.parse(output.slice(start));
-    const result = isJsonObject(parsed) ? parsed.result : undefined;
-    if (!isJsonObject(result)) {
-      return [];
-    }
-    const hits: RecallHit[] = [];
-    for (const key of RECALL_CATEGORY_ORDER) {
-      const items = result[key];
-      if (!Array.isArray(items)) {
-        continue;
-      }
-      for (const item of items) {
-        if (!isJsonObject(item) || typeof item.uri !== 'string' || isExcludedRecallUri(item.uri)) {
-          continue;
-        }
-        if (options.includeArchived !== true && isArchivedMemoryUri(item.uri)) {
-          continue;
-        }
-        hits.push({
-          category: key,
-          contextType: typeof item.context_type === 'string' ? item.context_type : 'result',
-          score: typeof item.score === 'number' ? item.score : 0,
-          snippet: recallSnippet(item.abstract ?? item.overview),
-          uri: item.uri,
-        });
-      }
-    }
-    return hits;
-  } catch (_err: unknown) {
+  const parsed = Option.getOrUndefined(parseJson(output.slice(start)));
+  const result = isJsonObject(parsed) ? parsed.result : undefined;
+  if (!isJsonObject(result)) {
     return [];
   }
+  const hits: RecallHit[] = [];
+  for (const key of RECALL_CATEGORY_ORDER) {
+    const items = result[key];
+    if (!Array.isArray(items)) {
+      continue;
+    }
+    for (const item of items) {
+      if (!isJsonObject(item) || typeof item.uri !== 'string' || isExcludedRecallUri(item.uri)) {
+        continue;
+      }
+      if (options.includeArchived !== true && isArchivedMemoryUri(item.uri)) {
+        continue;
+      }
+      hits.push({
+        category: key,
+        contextType: typeof item.context_type === 'string' ? item.context_type : 'result',
+        score: typeof item.score === 'number' ? item.score : 0,
+        snippet: recallSnippet(item.abstract ?? item.overview),
+        uri: item.uri,
+      });
+    }
+  }
+  return hits;
 }
 
 /** Drop a chunk anchor (`#chunk_0001`) so a URI addresses its document. */
@@ -1710,7 +1590,7 @@ function hybridRankRecallHits(
           indexed?.fields?.project ??
           memoryUriProjectSegment(hit.uri) ??
           resourceProjectFromUri(hit.uri),
-        title: indexed?.fields?.title ?? basename(uri),
+        title: indexed?.fields?.title ?? uri.split('/').at(-1) ?? uri,
         topic: record?.metadata.topic ?? indexed?.fields?.topic ?? uriSlug(hit.uri),
       },
       kind: record?.metadata.kind ?? indexed?.kind ?? memoryKindFromUri(hit.uri),
@@ -1943,15 +1823,17 @@ export function exactMemoryScopeUris(params: {
  * recall an index of pointers rather than a dump of matching lines. `runGrep`
  * returns `ov grep --output json` stdout (or undefined on failure).
  */
-export async function collectExactMatches(
+export const collectExactMatches = Effect.fn('utils.collectExactMatches')(function* <E, R>(
   terms: readonly string[],
   scopes: readonly string[],
-  runGrep: (term: string, scope: string) => Promise<string | undefined>,
-): Promise<readonly ExactMatch[]> {
+  runGrep: (term: string, scope: string) => Effect.Effect<string | undefined, E, R>,
+) {
   // Run all term×scope greps concurrently, then fold the results in a fixed
   // order so dedup ranking stays deterministic regardless of completion order.
   const pairs = terms.flatMap(term => scopes.map(scope => ({scope, term})));
-  const outputs = await Promise.all(pairs.map(pair => runGrep(pair.term, pair.scope)));
+  const outputs = yield* Effect.forEach(pairs, pair => runGrep(pair.term, pair.scope), {
+    concurrency: 'unbounded',
+  });
   const byUri = new Map<string, {order: number; terms: Set<string>}>();
   let order = 0;
   for (const [index, pair] of pairs.entries()) {
@@ -1972,7 +1854,7 @@ export async function collectExactMatches(
   return [...byUri.entries()]
     .sort((left, right) => right[1].terms.size - left[1].terms.size || left[1].order - right[1].order)
     .map(([uri, value]) => ({terms: [...value.terms], uri}));
-}
+});
 
 export function formatExactMatchPointers(matches: readonly ExactMatch[], maxUris = 8): string | undefined {
   if (matches.length === 0) {
@@ -2015,21 +1897,29 @@ export function formatStatus(status: CommandStatus): string {
   return failure('FAIL');
 }
 
-export function toolRoot(): string {
-  if (existsSync(join(moduleDirectory, 'package.json'))) {
-    return moduleDirectory;
-  }
-  return resolve(moduleDirectory, '..');
-}
+export const toolRoot = Effect.fn('utils.toolRoot')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const modulePath = yield* pathService.fromFileUrl(new URL(import.meta.url));
+  const moduleDirectory = pathService.dirname(modulePath);
+  return (yield* fs.exists(pathService.join(moduleDirectory, 'package.json')))
+    ? moduleDirectory
+    : pathService.resolve(moduleDirectory, '..');
+});
 
-export async function currentPackageVersion(): Promise<string> {
-  const rawPackage = await readFile(join(toolRoot(), 'package.json'), 'utf8');
-  const parsed: unknown = JSON.parse(rawPackage);
+export const currentPackageVersion = Effect.fn('utils.currentPackageVersion')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const rawPackage = yield* fs.readFileString(pathService.join(yield* toolRoot(), 'package.json'));
+  const parsed = yield* Effect.try({
+    try: () => JSON.parse(rawPackage) as unknown,
+    catch: cause => new Error('Could not parse current threadnote package metadata.', {cause}),
+  });
   if (!isJsonObject(parsed) || typeof parsed.version !== 'string') {
-    throw new Error('Could not read current threadnote package version.');
+    return yield* Effect.fail(new Error('Could not read current threadnote package version.'));
   }
   return parsed.version;
-}
+});
 
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,9 +1,6 @@
-import {readFileSync} from 'node:fs';
-import {dirname, join} from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {Effect, FileSystem, Path} from 'effect';
 
 let cachedVersion: string | undefined;
-const moduleDirectory = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Returns the threadnote package version baked into this build. The bundled
@@ -15,16 +12,25 @@ const moduleDirectory = dirname(fileURLToPath(import.meta.url));
  * install). Callers should treat `'unknown'` as a signal to skip whatever they
  * were about to do — there's no actionable comparison to make.
  */
-export function getThreadnoteVersion(): string {
+export const getThreadnoteVersion = Effect.fn('version.getThreadnoteVersion')(function* () {
   if (cachedVersion !== undefined) {
     return cachedVersion;
   }
-  try {
-    const packageJsonPath = join(moduleDirectory, '..', 'package.json');
-    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {readonly version?: unknown};
-    cachedVersion = typeof parsed.version === 'string' && parsed.version.length > 0 ? parsed.version : 'unknown';
-  } catch {
-    cachedVersion = 'unknown';
-  }
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const modulePath = yield* pathService.fromFileUrl(new URL(import.meta.url));
+  const packageJsonPath = pathService.join(pathService.dirname(modulePath), '..', 'package.json');
+  cachedVersion = yield* fs.readFileString(packageJsonPath).pipe(
+    Effect.flatMap(content =>
+      Effect.try({
+        try: () => JSON.parse(content) as {readonly version?: unknown},
+        catch: () => undefined,
+      }),
+    ),
+    Effect.map(parsed =>
+      parsed && typeof parsed.version === 'string' && parsed.version.length > 0 ? parsed.version : 'unknown',
+    ),
+    Effect.catch(() => Effect.succeed('unknown')),
+  );
   return cachedVersion;
-}
+});

--- a/src/version_command.ts
+++ b/src/version_command.ts
@@ -1,17 +1,19 @@
 import {Console, Effect, Result} from 'effect';
 import {heading, info, keyValue, success, warning, withSpinnerEffect} from './cli_ui.js';
-import {applicationError, fromPromise} from './effect/errors.js';
+import {applicationError} from './effect/errors.js';
 import type {RuntimeConfig, VersionOptions} from './types.js';
 import {currentPackageVersion, fetchLatestVersion, resolveUpdateRegistry} from './update.js';
 import {selectUpdateChannel} from './update_channel.js';
 import {compareVersions, errorMessage} from './utils.js';
 import {whatsNewLinesForVersion, whatsNewLinesForVersionRange} from './release_notes.js';
+import {SystemInfo} from './effect/system.js';
 
 export const runVersion = Effect.fn('runVersion')(function* (config: RuntimeConfig, options: VersionOptions) {
-  const currentVersion = yield* fromPromise('read current package version', currentPackageVersion);
+  const currentVersion = yield* currentPackageVersion();
   const channel = selectUpdateChannel(currentVersion);
+  const system = yield* SystemInfo;
   const registry = yield* Effect.try({
-    try: () => resolveUpdateRegistry(options.registry, options.allowUntrustedRegistry),
+    try: () => resolveUpdateRegistry(options.registry, options.allowUntrustedRegistry, system.environment()),
     catch: cause => applicationError('resolve update registry', cause),
   });
   const latest = yield* withSpinnerEffect(

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -232,7 +232,12 @@ windowsIt('installs, operates, repairs, and uninstalls the packed package on nat
     const port = await freeTcpPort();
     env.THREADNOTE_PORT = String(port);
     env.THREADNOTE_OPENVIKING_MCP_URL = `http://127.0.0.1:${port}/mcp`;
-    expectSuccess(await runCli(cli, ['start'], env), 'threadnote start');
+    const started = await runCli(cli, ['start'], env);
+    const serverLog =
+      started.code === 0
+        ? ''
+        : await readFile(join(home, 'logs', 'server.log'), 'utf8').catch(cause => `unavailable: ${String(cause)}`);
+    expectSuccess({...started, stderr: `${started.stderr}\nserver log:\n${serverLog}`}, 'threadnote start');
     await expectHealth(port, true);
     expectSuccess(await runCli(cli, ['doctor', '--strict'], env), 'threadnote doctor --strict');
 

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -1,4 +1,3 @@
-import {spawn} from 'node:child_process';
 import {access, mkdir, mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {delimiter, dirname, join, resolve} from 'node:path';
@@ -7,7 +6,7 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 import {Effect} from 'effect';
 import {expect, it, vi} from 'vitest';
-import {resolveCommandInvocation, terminateCommandProcess} from '../../src/effect/command.js';
+import {runCommandEffect} from '../../src/effect/command.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {runUpdate} from '../../src/update.js';
 import type {RuntimeConfig} from '../../src/types.js';
@@ -122,14 +121,14 @@ windowsIt('updates and repairs through native runtime launchers outside the inst
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: string | URL | Request) => {
-        const url = String(input);
-        if (url.includes('api.github.com')) {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        if (url.hostname === 'api.github.com') {
           return Response.json([]);
         }
-        if (url.endsWith('/beta')) {
+        if (url.pathname.endsWith('/beta')) {
           return Response.json({version: '99.0.0-beta.1'});
         }
-        if (url.endsWith('/latest')) {
+        if (url.pathname.endsWith('/latest')) {
           return Response.json({version: '99.0.0'});
         }
         return new Response('Not found', {status: 404});
@@ -537,31 +536,14 @@ async function runProcess(
     readonly timeoutMs?: number;
   } = {},
 ): Promise<ProcessResult> {
-  return new Promise((resolveResult, reject) => {
-    const invocation = resolveCommandInvocation(command, args);
-    const child = spawn(invocation.executable, invocation.args, {
+  const result = await Effect.runPromise(
+    runCommandEffect(command, args, {
+      allowFailure: true,
       cwd: options.cwd ?? REPO_ROOT,
       env: options.env ?? process.env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      windowsHide: true,
-      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-    });
-    const maxOutputChars = 1_000_000;
-    let stderr = '';
-    let stdout = '';
-    child.stdout.on('data', chunk => {
-      stdout = `${stdout}${chunk.toString('utf8')}`.slice(-maxOutputChars);
-    });
-    child.stderr.on('data', chunk => {
-      stderr = `${stderr}${chunk.toString('utf8')}`.slice(-maxOutputChars);
-    });
-    child.once('error', reject);
-    const timeout = setTimeout(() => {
-      void terminateCommandProcess(child, invocation, true).catch(reject);
-    }, options.timeoutMs ?? 120_000);
-    child.once('close', code => {
-      clearTimeout(timeout);
-      resolveResult({code, stderr, stdout});
-    });
-  });
+      maxOutputBytes: 1_000_000,
+      timeoutMs: options.timeoutMs ?? 120_000,
+    }).pipe(Effect.provide(ApplicationLayer)),
+  );
+  return {code: result.exitCode, stderr: result.stderr, stdout: result.stdout};
 }

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -295,10 +295,11 @@ windowsIt('installs, operates, repairs, and uninstalls the packed package on nat
     expectSuccess(await runCli(cli, ['mcp-install', 'codex', '--apply'], env), 'Codex MCP install');
     expectSuccess(await runCli(cli, ['mcp-install', 'claude', '--apply'], env), 'Claude MCP install');
     const agentCalls = await readFile(agentLog, 'utf8');
-    expect(agentCalls).toContain('codex mcp remove threadnote');
-    expect(agentCalls).toContain('codex mcp add --env');
-    expect(agentCalls).toContain('claude mcp remove threadnote');
-    expect(agentCalls).toContain('claude mcp add --scope user');
+    const normalizedAgentCalls = agentCalls.replaceAll('"', '');
+    expect(normalizedAgentCalls).toContain('codex mcp remove threadnote');
+    expect(normalizedAgentCalls).toContain('codex mcp add --env');
+    expect(normalizedAgentCalls).toContain('claude mcp remove threadnote');
+    expect(normalizedAgentCalls).toContain('claude mcp add --scope user');
     expectSuccess(await runCli(cli, ['mcp-install', 'cursor', '--apply'], env), 'Cursor MCP install');
     expectSuccess(await runCli(cli, ['mcp-install', 'copilot', '--apply'], env), 'Copilot MCP install');
     for (const configPath of [join(home, '.cursor', 'mcp.json'), copilotConfig]) {

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -1,0 +1,567 @@
+import {spawn} from 'node:child_process';
+import {access, mkdir, mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {delimiter, dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import {Effect} from 'effect';
+import {expect, it, vi} from 'vitest';
+import {resolveCommandInvocation, terminateCommandProcess} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {runUpdate} from '../../src/update.js';
+import type {RuntimeConfig} from '../../src/types.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const windowsIt = process.platform === 'win32' ? it : it.skip;
+
+interface ProcessResult {
+  readonly code: number | null;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+interface CandidateReview {
+  readonly candidates: readonly {readonly candidateId: string}[];
+  readonly reviewId: string;
+  readonly revision: number;
+}
+
+interface TextContent {
+  readonly text: string;
+  readonly type: 'text';
+}
+
+windowsIt('forwards PowerShell bootstrap switches and explicit package managers', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'threadnote bootstrap options '));
+  const fakeBin = join(root, 'fake bin');
+  const prefix = join(root, 'npm prefix');
+  const log = join(root, 'bootstrap.log');
+  const npm = join(fakeBin, 'npm.cmd');
+  const threadnote = join(prefix, 'threadnote.cmd');
+  const powershellBin = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0');
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: join(root, 'home'),
+    PATH: [fakeBin, powershellBin].join(delimiter),
+    THREADNOTE_E2E_BOOTSTRAP_LOG: log,
+    THREADNOTE_E2E_FAKE_PREFIX: prefix,
+    USERPROFILE: join(root, 'home'),
+  };
+  try {
+    await mkdir(fakeBin, {recursive: true});
+    await mkdir(prefix, {recursive: true});
+    await writeFile(
+      npm,
+      '@ECHO off\r\n@ECHO npm %*>>"%THREADNOTE_E2E_BOOTSTRAP_LOG%"\r\n@if /I "%~1"=="prefix" @ECHO %THREADNOTE_E2E_FAKE_PREFIX%\r\n',
+    );
+    await writeFile(threadnote, '@ECHO off\r\n@ECHO threadnote %*>>"%THREADNOTE_E2E_BOOTSTRAP_LOG%"\r\n@exit /b 0\r\n');
+
+    for (const manager of ['pip', 'pipx']) {
+      expectSuccess(await runBootstrap(env, ['-DryRun', '-NoStart', '-PackageManager', manager]), manager);
+    }
+    await writeFile(join(fakeBin, 'uv.cmd'), '@ECHO off\r\n@exit /b 0\r\n');
+    expectSuccess(await runBootstrap(env, ['-DryRun', '-Force', '-WithHooks', '-PackageManager', 'uv']), 'uv');
+
+    const calls = await readFile(log, 'utf8');
+    expect(calls).toContain('threadnote install --dry-run --no-start --package-manager pip');
+    expect(calls).toContain('threadnote install --dry-run --no-start --package-manager pipx');
+    expect(calls).toContain('threadnote install --dry-run --force --with-hooks --package-manager uv');
+  } finally {
+    await rm(root, {force: true, recursive: true});
+  }
+});
+
+windowsIt('updates and repairs through native runtime launchers outside the installed bin path', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'threadnote windows update '));
+  const fakeBin = join(root, 'runtime launchers');
+  const npmPrefix = join(root, 'npm prefix');
+  const denoInstall = join(root, 'deno install');
+  const denoBin = join(denoInstall, 'bin');
+  const log = join(root, 'update.log');
+  const originalPath = process.env.PATH;
+  const originalDenoInstallRoot = process.env.DENO_INSTALL_ROOT;
+  const originalDenoInstall = process.env.DENO_INSTALL;
+  const originalNpmPrefix = process.env.THREADNOTE_E2E_NPM_PREFIX;
+  const originalUpdateLog = process.env.THREADNOTE_E2E_UPDATE_LOG;
+  const config: RuntimeConfig = {
+    account: 'local',
+    agentContextHome: root,
+    agentId: 'threadnote',
+    host: '127.0.0.1',
+    manifestPath: join(root, 'seed-manifest.yaml'),
+    openVikingVersion: '0.4.10',
+    port: 1933,
+    user: 'windows-update-e2e',
+  };
+  try {
+    await mkdir(fakeBin, {recursive: true});
+    await mkdir(npmPrefix, {recursive: true});
+    await mkdir(denoBin, {recursive: true});
+    await writeFile(
+      join(fakeBin, 'npm.cmd'),
+      '@ECHO off\r\n@ECHO npm %*>>"%THREADNOTE_E2E_UPDATE_LOG%"\r\n@if /I "%~1"=="prefix" @ECHO %THREADNOTE_E2E_NPM_PREFIX%\r\n@exit /b 0\r\n',
+    );
+    await writeFile(
+      join(fakeBin, 'deno.cmd'),
+      '@ECHO off\r\n@ECHO deno %* registry=%NPM_CONFIG_REGISTRY%>>"%THREADNOTE_E2E_UPDATE_LOG%"\r\n@exit /b 0\r\n',
+    );
+    await writeFile(
+      join(npmPrefix, 'threadnote.cmd'),
+      '@ECHO off\r\n@ECHO npm-threadnote %*>>"%THREADNOTE_E2E_UPDATE_LOG%"\r\n@exit /b 0\r\n',
+    );
+    await writeFile(
+      join(denoBin, 'threadnote.cmd'),
+      '@ECHO off\r\n@ECHO deno-threadnote %*>>"%THREADNOTE_E2E_UPDATE_LOG%"\r\n@exit /b 0\r\n',
+    );
+    process.env.PATH = [fakeBin, originalPath ?? ''].join(delimiter);
+    process.env.DENO_INSTALL_ROOT = denoInstall;
+    delete process.env.DENO_INSTALL;
+    process.env.THREADNOTE_E2E_NPM_PREFIX = npmPrefix;
+    process.env.THREADNOTE_E2E_UPDATE_LOG = log;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('api.github.com')) {
+          return Response.json([]);
+        }
+        if (url.endsWith('/beta')) {
+          return Response.json({version: '99.0.0-beta.1'});
+        }
+        if (url.endsWith('/latest')) {
+          return Response.json({version: '99.0.0'});
+        }
+        return new Response('Not found', {status: 404});
+      }),
+    );
+
+    await Effect.runPromise(
+      runUpdate(config, {postUpdate: false, runtime: 'npm'}).pipe(Effect.provide(ApplicationLayer)),
+    );
+    await Effect.runPromise(
+      runUpdate(config, {postUpdate: false, runtime: 'deno'}).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    const calls = await readFile(log, 'utf8');
+    expect(calls).toContain('npm install --global');
+    expect(calls).toContain('--registry=https://registry.npmjs.org/');
+    expect(calls).toContain('npm-threadnote repair --no-post-update');
+    expect(calls).toContain('deno install --global');
+    expect(calls).toContain('registry=https://registry.npmjs.org/');
+    expect(calls).toContain('deno-threadnote repair --no-post-update');
+  } finally {
+    vi.unstubAllGlobals();
+    process.env.PATH = originalPath;
+    if (originalDenoInstallRoot === undefined) {
+      delete process.env.DENO_INSTALL_ROOT;
+    } else {
+      process.env.DENO_INSTALL_ROOT = originalDenoInstallRoot;
+    }
+    if (originalDenoInstall === undefined) {
+      delete process.env.DENO_INSTALL;
+    } else {
+      process.env.DENO_INSTALL = originalDenoInstall;
+    }
+    if (originalNpmPrefix === undefined) {
+      delete process.env.THREADNOTE_E2E_NPM_PREFIX;
+    } else {
+      process.env.THREADNOTE_E2E_NPM_PREFIX = originalNpmPrefix;
+    }
+    if (originalUpdateLog === undefined) {
+      delete process.env.THREADNOTE_E2E_UPDATE_LOG;
+    } else {
+      process.env.THREADNOTE_E2E_UPDATE_LOG = originalUpdateLog;
+    }
+    await rm(root, {force: true, recursive: true});
+  }
+});
+
+windowsIt('installs, operates, repairs, and uninstalls the packed package on native Windows', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'threadnote windows e2e '));
+  const home = join(root, 'User Home');
+  const prefix = join(root, 'npm global prefix');
+  const cli = join(prefix, 'threadnote.cmd');
+  const pidPath = join(home, 'openviking-server.pid');
+  const copilotConfig = join(home, 'AppData', 'Roaming', 'Code', 'User', 'mcp.json');
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    CI: '1',
+    HOME: home,
+    NO_COLOR: '1',
+    NO_UPDATE_NOTIFIER: '1',
+    NPM_CONFIG_PREFIX: prefix,
+    PATH: [prefix, join(home, '.local', 'bin'), process.env.PATH ?? ''].join(delimiter),
+    THREADNOTE_ACCOUNT: 'local',
+    THREADNOTE_AGENT_ID: 'threadnote',
+    THREADNOTE_COPILOT_MCP_CONFIG: copilotConfig,
+    THREADNOTE_HOME: home,
+    THREADNOTE_HOST: '127.0.0.1',
+    THREADNOTE_NO_UPDATE_CHECK: '1',
+    THREADNOTE_PORT: '1933',
+    THREADNOTE_USER: 'windows-e2e',
+    USERPROFILE: home,
+  };
+
+  try {
+    await mkdir(home, {recursive: true});
+    const tarball = await pack(root, env);
+    env.THREADNOTE_PACKAGE = tarball;
+    const installed = await runProcess(
+      'powershell.exe',
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        join(REPO_ROOT, 'scripts', 'install.ps1'),
+        '-NoStart',
+      ],
+      {env, timeoutMs: 600_000},
+    );
+    expectSuccess(installed, 'PowerShell bootstrap');
+    expect(installed.stdout).toContain('Preserving the package-manager threadnote.cmd launcher on Windows.');
+    await expect(access(cli)).resolves.toBeUndefined();
+    await expect(access(join(home, '.local', 'bin', 'threadnote'))).rejects.toMatchObject({code: 'ENOENT'});
+
+    const version = await runCli(cli, ['--version'], env);
+    expectSuccess(version, 'threadnote.cmd --version');
+    expect(version.stdout).toMatch(/^threadnote v\d+\.\d+\.\d+/m);
+
+    const port = await freeTcpPort();
+    env.THREADNOTE_PORT = String(port);
+    env.THREADNOTE_OPENVIKING_MCP_URL = `http://127.0.0.1:${port}/mcp`;
+    expectSuccess(await runCli(cli, ['start'], env), 'threadnote start');
+    await expectHealth(port, true);
+    expectSuccess(await runCli(cli, ['doctor', '--strict'], env), 'threadnote doctor --strict');
+
+    const mcpBin = join(prefix, 'node_modules', 'threadnote', 'bin', 'threadnote-mcp-server.cjs');
+    const durableUri = 'viking://user/windows-e2e/memories/durable/projects/windows-e2e/native-installation.md';
+    await withMcpClient(mcpBin, env, async client => {
+      const stored = await callToolText(client, 'remember_context', {
+        project: 'windows-e2e',
+        text: 'Native Windows installation completed through the packed PowerShell workflow.',
+        topic: 'native-installation',
+      });
+      expect(stored).toContain(durableUri);
+      expect(await callToolText(client, 'recall_context', {query: 'native Windows packed PowerShell'})).toContain(
+        durableUri,
+      );
+
+      const reviewResult = await callToolResult(client, 'review_session_context', {
+        decisions: ['Keep the native Windows npm launcher instead of replacing it with a POSIX shim.'],
+        evidence: ['test/e2e/windows-install.windows.e2e.ts'],
+        invariants: ['Repair and uninstall preserve the OpenViking datastore by default.'],
+        outcome: 'Validated the packaged native Windows lifecycle.',
+        project: 'windows-e2e',
+        sourceAgentClient: 'codex-e2e',
+        sourceSessionId: 'windows-install-e2e',
+        task: 'Validate native Windows installation',
+        topic: 'reviewed-installation',
+      });
+      const review = structuredContent<CandidateReview>(reviewResult);
+      const candidate = review.candidates[0];
+      expect(candidate).toBeDefined();
+      expect(
+        await callToolText(client, 'apply_memory_candidates', {
+          action: 'approve',
+          approved: true,
+          candidateId: candidate?.candidateId,
+          reviewId: review.reviewId,
+          revision: review.revision,
+        }),
+      ).toContain('Stored memory:');
+    });
+
+    const agentBin = join(root, 'agent launchers');
+    const agentLog = join(root, 'agent.log');
+    await mkdir(agentBin, {recursive: true});
+    for (const agent of ['codex', 'claude']) {
+      await writeFile(
+        join(agentBin, `${agent}.cmd`),
+        '@ECHO off\r\n@if not "%~1"=="--version" @goto run\r\n@ECHO fake-agent 1.0.0\r\n@exit /b 0\r\n:run\r\n@ECHO %~n0 %*>>"%THREADNOTE_E2E_AGENT_LOG%"\r\n@exit /b 0\r\n',
+      );
+    }
+    env.PATH = [agentBin, env.PATH ?? ''].join(delimiter);
+    env.THREADNOTE_E2E_AGENT_LOG = agentLog;
+    expectSuccess(await runCli(cli, ['mcp-install', 'codex', '--apply'], env), 'Codex MCP install');
+    expectSuccess(await runCli(cli, ['mcp-install', 'claude', '--apply'], env), 'Claude MCP install');
+    const agentCalls = await readFile(agentLog, 'utf8');
+    expect(agentCalls).toContain('codex mcp remove threadnote');
+    expect(agentCalls).toContain('codex mcp add --env');
+    expect(agentCalls).toContain('claude mcp remove threadnote');
+    expect(agentCalls).toContain('claude mcp add --scope user');
+    expectSuccess(await runCli(cli, ['mcp-install', 'cursor', '--apply'], env), 'Cursor MCP install');
+    expectSuccess(await runCli(cli, ['mcp-install', 'copilot', '--apply'], env), 'Copilot MCP install');
+    for (const configPath of [join(home, '.cursor', 'mcp.json'), copilotConfig]) {
+      const config = JSON.parse(await readFile(configPath, 'utf8')) as {
+        readonly mcpServers?: Record<string, {readonly command?: string}>;
+        readonly servers?: Record<string, {readonly command?: string}>;
+      };
+      const server = config.mcpServers?.threadnote ?? config.servers?.threadnote;
+      expect(server?.command).toBe('node');
+    }
+
+    expectSuccess(
+      await runCli(cli, ['repair', '--mcp', 'none', '--no-start', '--no-post-update'], env),
+      'threadnote repair',
+    );
+    expectSuccess(await runCli(cli, ['read', durableUri], env), 'read after repair');
+
+    expectSuccess(await runCli(cli, ['stop'], env), 'threadnote stop');
+    await expectHealth(port, false);
+    await expect(access(pidPath)).rejects.toMatchObject({code: 'ENOENT'});
+
+    await writeFile(pidPath, `${process.pid}\n`, 'utf8');
+    const unrelatedPid = await runCli(cli, ['stop'], env);
+    expect(unrelatedPid.code).not.toBe(0);
+    expect(`${unrelatedPid.stdout}\n${unrelatedPid.stderr}`).toMatch(/Refusing to stop process/);
+    await expect(access(pidPath)).resolves.toBeUndefined();
+
+    await writeFile(pidPath, '99999999\n', 'utf8');
+    expectSuccess(await runCli(cli, ['stop'], env), 'stale pid recovery');
+    await expect(access(pidPath)).rejects.toMatchObject({code: 'ENOENT'});
+
+    expectSuccess(await runCli(cli, ['start'], env), 'threadnote restart');
+    await expectHealth(port, true);
+
+    expectSuccess(
+      await runCli(cli, ['uninstall', '--mcp', 'none', '--preserve-memories'], env),
+      'memory-preserving uninstall',
+    );
+    await expectHealth(port, false);
+    await expect(access(cli)).resolves.toBeUndefined();
+    const memory = await stat(
+      join(
+        home,
+        'data',
+        'viking',
+        'local',
+        'user',
+        'windows-e2e',
+        'memories',
+        'durable',
+        'projects',
+        'windows-e2e',
+        'native-installation.md',
+      ),
+    );
+    expect(memory.isFile()).toBe(true);
+  } finally {
+    if (await exists(cli)) {
+      await runCli(cli, ['stop'], env).catch(() => undefined);
+    }
+    await rm(root, {force: true, recursive: true});
+  }
+});
+
+async function runBootstrap(env: NodeJS.ProcessEnv, args: readonly string[]): Promise<ProcessResult> {
+  return runProcess(
+    'powershell.exe',
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      join(REPO_ROOT, 'scripts', 'install.ps1'),
+      ...args,
+    ],
+    {env},
+  );
+}
+
+async function pack(destination: string, env: NodeJS.ProcessEnv): Promise<string> {
+  const npmCli = process.env.npm_execpath;
+  if (!npmCli) {
+    throw new Error('npm_execpath is required to pack the Windows E2E artifact.');
+  }
+  const result = await runProcess(process.execPath, [npmCli, 'pack', '--json', '--pack-destination', destination], {
+    cwd: REPO_ROOT,
+    env,
+    timeoutMs: 180_000,
+  });
+  expectSuccess(result, 'npm pack');
+  const jsonStart = result.stdout.search(/\[\s*\{/);
+  expect(jsonStart, result.stdout).toBeGreaterThanOrEqual(0);
+  const packed = JSON.parse(result.stdout.slice(jsonStart)) as readonly {readonly filename: string}[];
+  const filename = packed[0]?.filename;
+  if (!filename) {
+    throw new Error(`npm pack did not return a filename:\n${result.stdout}`);
+  }
+  return join(destination, filename);
+}
+
+async function runCli(command: string, args: readonly string[], env: NodeJS.ProcessEnv): Promise<ProcessResult> {
+  return runProcess(
+    'powershell.exe',
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      '$toolArgs = @(ConvertFrom-Json -InputObject $env:THREADNOTE_E2E_ARGS); & $env:THREADNOTE_E2E_CLI @toolArgs; exit $LASTEXITCODE',
+    ],
+    {
+      env: {
+        ...env,
+        THREADNOTE_E2E_ARGS: JSON.stringify(args),
+        THREADNOTE_E2E_CLI: command,
+      },
+      timeoutMs: 180_000,
+    },
+  );
+}
+
+async function withMcpClient<T>(
+  mcpBin: string,
+  env: NodeJS.ProcessEnv,
+  use: (client: Client) => Promise<T>,
+): Promise<T> {
+  const transport = new StdioClientTransport({
+    args: [mcpBin],
+    command: process.execPath,
+    cwd: REPO_ROOT,
+    env: Object.fromEntries(
+      Object.entries({...env, THREADNOTE_MCP_TOOLSET: 'core'}).filter(
+        (entry): entry is [string, string] => entry[1] !== undefined,
+      ),
+    ),
+    stderr: 'pipe',
+  });
+  const client = new Client({name: 'threadnote-windows-e2e', version: '1.0.0'});
+  try {
+    await client.connect(transport);
+    return await use(client);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+async function callToolText(client: Client, name: string, args: Record<string, unknown>): Promise<string> {
+  return textFromToolResult(await callToolResult(client, name, args));
+}
+
+async function callToolResult(client: Client, name: string, args: Record<string, unknown>) {
+  const result = await client.callTool({arguments: args, name}, undefined, {timeout: 120_000});
+  expect(result.isError, `${name} failed: ${textFromToolResult(result)}`).not.toBe(true);
+  return result;
+}
+
+function structuredContent<T>(result: unknown): T {
+  const value =
+    typeof result === 'object' && result !== null && 'structuredContent' in result
+      ? (result as {readonly structuredContent?: unknown}).structuredContent
+      : undefined;
+  expect(value).toBeDefined();
+  return value as T;
+}
+
+function textFromToolResult(result: unknown): string {
+  const content =
+    typeof result === 'object' && result !== null && 'content' in result
+      ? (result as {readonly content?: unknown}).content
+      : undefined;
+  return Array.isArray(content)
+    ? (content as TextContent[])
+        .filter(item => item.type === 'text')
+        .map(item => item.text)
+        .join('\n')
+    : '';
+}
+
+async function expectHealth(port: number, healthy: boolean): Promise<void> {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      const remainingMs = Math.max(1, deadline - Date.now());
+      const response = await fetch(`http://127.0.0.1:${port}/health`, {
+        signal: AbortSignal.timeout(Math.min(1000, remainingMs)),
+      });
+      if (healthy && response.ok) {
+        await response.body?.cancel();
+        return;
+      }
+      await response.body?.cancel();
+    } catch (cause: unknown) {
+      const errorName = cause instanceof Error ? cause.name : '';
+      if (!healthy && errorName !== 'AbortError' && errorName !== 'TimeoutError') {
+        return;
+      }
+    }
+    await new Promise(resolveWait => setTimeout(resolveWait, 100));
+  }
+  throw new Error(`OpenViking health did not become ${healthy ? 'ready' : 'unavailable'}.`);
+}
+
+async function freeTcpPort(): Promise<number> {
+  const {createServer} = await import('node:net');
+  const server = createServer();
+  await new Promise<void>((resolveListen, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolveListen();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Could not allocate a Windows E2E port.');
+  }
+  await new Promise<void>((resolveClose, reject) => server.close(error => (error ? reject(error) : resolveClose())));
+  return address.port;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function expectSuccess(result: ProcessResult, operation: string): void {
+  expect(result.code, `${operation} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0);
+}
+
+async function runProcess(
+  command: string,
+  args: readonly string[],
+  options: {
+    readonly cwd?: string;
+    readonly env?: NodeJS.ProcessEnv;
+    readonly timeoutMs?: number;
+  } = {},
+): Promise<ProcessResult> {
+  return new Promise((resolveResult, reject) => {
+    const invocation = resolveCommandInvocation(command, args);
+    const child = spawn(invocation.executable, invocation.args, {
+      cwd: options.cwd ?? REPO_ROOT,
+      env: options.env ?? process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    });
+    const maxOutputChars = 1_000_000;
+    let stderr = '';
+    let stdout = '';
+    child.stdout.on('data', chunk => {
+      stdout = `${stdout}${chunk.toString('utf8')}`.slice(-maxOutputChars);
+    });
+    child.stderr.on('data', chunk => {
+      stderr = `${stderr}${chunk.toString('utf8')}`.slice(-maxOutputChars);
+    });
+    child.once('error', reject);
+    const timeout = setTimeout(() => {
+      void terminateCommandProcess(child, invocation, true).catch(reject);
+    }, options.timeoutMs ?? 120_000);
+    child.once('close', code => {
+      clearTimeout(timeout);
+      resolveResult({code, stderr, stdout});
+    });
+  });
+}

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -182,6 +182,7 @@ windowsIt('installs, operates, repairs, and uninstalls the packed package on nat
   const prefix = join(root, 'npm global prefix');
   const cli = join(prefix, 'threadnote.cmd');
   const pidPath = join(home, 'openviking-server.pid');
+  const launcherPids: number[] = [];
   const copilotConfig = join(home, 'AppData', 'Roaming', 'Code', 'User', 'mcp.json');
   const env: NodeJS.ProcessEnv = {
     ...process.env,
@@ -238,6 +239,7 @@ windowsIt('installs, operates, repairs, and uninstalls the packed package on nat
         ? ''
         : await readFile(join(home, 'logs', 'server.log'), 'utf8').catch(cause => `unavailable: ${String(cause)}`);
     expectSuccess({...started, stderr: `${started.stderr}\nserver log:\n${serverLog}`}, 'threadnote start');
+    launcherPids.push(await readLauncherPid(pidPath));
     await expectHealth(port, true);
     expectSuccess(await runCli(cli, ['doctor', '--strict'], env), 'threadnote doctor --strict');
 
@@ -316,6 +318,7 @@ windowsIt('installs, operates, repairs, and uninstalls the packed package on nat
 
     expectSuccess(await runCli(cli, ['stop'], env), 'threadnote stop');
     await expectHealth(port, false);
+    await expectProcessStopped(launcherPids.at(-1)!);
     await expect(access(pidPath)).rejects.toMatchObject({code: 'ENOENT'});
 
     await writeFile(pidPath, `${process.pid}\n`, 'utf8');
@@ -329,6 +332,7 @@ windowsIt('installs, operates, repairs, and uninstalls the packed package on nat
     await expect(access(pidPath)).rejects.toMatchObject({code: 'ENOENT'});
 
     expectSuccess(await runCli(cli, ['start'], env), 'threadnote restart');
+    launcherPids.push(await readLauncherPid(pidPath));
     await expectHealth(port, true);
 
     expectSuccess(
@@ -336,6 +340,7 @@ windowsIt('installs, operates, repairs, and uninstalls the packed package on nat
       'memory-preserving uninstall',
     );
     await expectHealth(port, false);
+    await expectProcessStopped(launcherPids.at(-1)!);
     await expect(access(cli)).resolves.toBeUndefined();
     const memory = await stat(
       join(
@@ -357,7 +362,13 @@ windowsIt('installs, operates, repairs, and uninstalls the packed package on nat
     if (await exists(cli)) {
       await runCli(cli, ['stop'], env).catch(() => undefined);
     }
-    await rm(root, {force: true, recursive: true});
+    const taskkill = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'taskkill.exe');
+    for (const launcherPid of [...launcherPids].reverse()) {
+      await runProcess(taskkill, ['/pid', String(launcherPid), '/t', '/f'], {env, timeoutMs: 10_000}).catch(
+        () => undefined,
+      );
+    }
+    await rm(root, {force: true, maxRetries: 10, recursive: true, retryDelay: 100});
   }
 });
 
@@ -499,6 +510,34 @@ async function expectHealth(port: number, healthy: boolean): Promise<void> {
     await new Promise(resolveWait => setTimeout(resolveWait, 100));
   }
   throw new Error(`OpenViking health did not become ${healthy ? 'ready' : 'unavailable'}.`);
+}
+
+async function readLauncherPid(pidPath: string): Promise<number> {
+  const record = JSON.parse(await readFile(pidPath, 'utf8')) as {readonly launcherPid?: unknown};
+  expect(record.launcherPid).toEqual(expect.any(Number));
+  return record.launcherPid as number;
+}
+
+async function expectProcessStopped(pid: number): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline && isProcessRunning(pid)) {
+    await new Promise(resolveWait => setTimeout(resolveWait, 100));
+  }
+  expect(isProcessRunning(pid), `Windows launcher process ${pid} is still running`).toBe(false);
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (cause: unknown) {
+    return !(
+      typeof cause === 'object' &&
+      cause !== null &&
+      'code' in cause &&
+      (cause as {readonly code?: unknown}).code === 'ESRCH'
+    );
+  }
 }
 
 async function freeTcpPort(): Promise<number> {

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -62,7 +62,7 @@ windowsIt('forwards PowerShell bootstrap switches and explicit package managers'
     await writeFile(join(fakeBin, 'uv.cmd'), '@ECHO off\r\n@exit /b 0\r\n');
     expectSuccess(await runBootstrap(env, ['-DryRun', '-Force', '-WithHooks', '-PackageManager', 'uv']), 'uv');
 
-    const calls = await readFile(log, 'utf8');
+    const calls = (await readFile(log, 'utf8')).replaceAll('"', '');
     expect(calls).toContain('threadnote install --dry-run --no-start --package-manager pip');
     expect(calls).toContain('threadnote install --dry-run --no-start --package-manager pipx');
     expect(calls).toContain('threadnote install --dry-run --force --with-hooks --package-manager uv');
@@ -142,7 +142,7 @@ windowsIt('updates and repairs through native runtime launchers outside the inst
       runUpdate(config, {postUpdate: false, runtime: 'deno'}).pipe(Effect.provide(ApplicationLayer)),
     );
 
-    const calls = await readFile(log, 'utf8');
+    const calls = (await readFile(log, 'utf8')).replaceAll('"', '');
     expect(calls).toContain('npm install --global');
     expect(calls).toContain('--registry=https://registry.npmjs.org/');
     expect(calls).toContain('npm-threadnote repair --no-post-update');

--- a/test/helpers/effect-runtime.ts
+++ b/test/helpers/effect-runtime.ts
@@ -1,0 +1,5 @@
+import {Effect} from 'effect';
+import {ApplicationLayer, type ApplicationServices} from '../../src/effect/runtime.js';
+
+export const runEffect = <A, E>(effect: Effect.Effect<A, E, ApplicationServices>): Promise<A> =>
+  Effect.runPromise(effect.pipe(Effect.provide(ApplicationLayer)));

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -69,6 +69,15 @@ describe('Effect CLI', () => {
     });
   });
 
+  it('honors runtime host and port environment variables when flags are omitted', async () => {
+    const result = await runCli(['start', '--dry-run'], {
+      THREADNOTE_HOST: '127.0.0.2',
+      THREADNOTE_PORT: '24567',
+    });
+
+    expect(result.stdout).toContain('--host 127.0.0.2 --port 24567');
+  });
+
   it('preserves dash-prefixed and equals-containing string values', async () => {
     const result = await runCli([
       'handoff',
@@ -103,9 +112,9 @@ describe('Effect CLI', () => {
   });
 });
 
-function runCli(args: readonly string[]) {
+function runCli(args: readonly string[], environment: NodeJS.ProcessEnv = {}) {
   return execFilePromise(process.execPath, ['--import', 'tsx', 'src/threadnote.ts', ...args], {
     cwd: process.cwd(),
-    env: {...process.env, NO_COLOR: '1'},
+    env: {...process.env, ...environment, NO_COLOR: '1'},
   });
 }

--- a/test/integration/memory.project-name-migration.test.ts
+++ b/test/integration/memory.project-name-migration.test.ts
@@ -1,14 +1,11 @@
 import {mkdtemp, mkdir, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {hasProjectNameMigrationCandidates, runMigrateProjectNames} from '../../src/memory.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import {runCommand} from '../../src/utils.js';
-import {ApplicationLayer} from '../../src/effect/runtime.js';
-
-const runTestEffect = <A, E>(effect: Effect.Effect<A, E, never>) => Effect.runPromise(effect);
+import {runEffect} from '../helpers/effect-runtime.js';
 
 const GIT_ENV_KEYS = ['GIT_COMMON_DIR', 'GIT_DIR', 'GIT_INDEX_FILE', 'GIT_WORK_TREE'] as const;
 
@@ -101,10 +98,10 @@ describe('project-name memory migration', () => {
       ].join('\n'),
     );
 
-    await expect(hasProjectNameMigrationCandidates(config)).resolves.toBe(true);
+    await expect(runEffect(hasProjectNameMigrationCandidates(config))).resolves.toBe(true);
 
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    await runTestEffect(runMigrateProjectNames(config, {dryRun: true}).pipe(Effect.provide(ApplicationLayer)));
+    await runEffect(runMigrateProjectNames(config, {dryRun: true}));
 
     const output = log.mock.calls.map(call => call.join(' ')).join('\n');
     expect(output).toContain('Would update seed manifest:');
@@ -149,10 +146,10 @@ describe('project-name memory migration', () => {
       ].join('\n'),
     );
 
-    await expect(hasProjectNameMigrationCandidates(config)).resolves.toBe(true);
+    await expect(runEffect(hasProjectNameMigrationCandidates(config))).resolves.toBe(true);
 
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    await runTestEffect(runMigrateProjectNames(config, {dryRun: true}).pipe(Effect.provide(ApplicationLayer)));
+    await runEffect(runMigrateProjectNames(config, {dryRun: true}));
 
     const output = log.mock.calls.map(call => call.join(' ')).join('\n');
     expect(output).not.toContain('Would update seed manifest:');
@@ -210,10 +207,10 @@ describe('project-name memory migration', () => {
       ].join('\n'),
     );
 
-    await expect(hasProjectNameMigrationCandidates(config)).resolves.toBe(true);
+    await expect(runEffect(hasProjectNameMigrationCandidates(config))).resolves.toBe(true);
 
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    await runTestEffect(runMigrateProjectNames(config, {dryRun: true}).pipe(Effect.provide(ApplicationLayer)));
+    await runEffect(runMigrateProjectNames(config, {dryRun: true}));
 
     const output = log.mock.calls.map(call => call.join(' ')).join('\n');
     expect(output).toContain('Would update seed manifest:');
@@ -242,8 +239,8 @@ function runtimeConfig(agentContextHome: string): RuntimeConfig {
 
 async function initRepo(repoRoot: string, remoteUrl: string): Promise<void> {
   await mkdir(repoRoot);
-  await runCommand('git', ['init'], {cwd: repoRoot});
-  await runCommand('git', ['remote', 'add', 'origin', remoteUrl], {cwd: repoRoot});
+  await runEffect(runCommand('git', ['init'], {cwd: repoRoot}));
+  await runEffect(runCommand('git', ['remote', 'add', 'origin', remoteUrl], {cwd: repoRoot}));
 }
 
 async function writeMemory(config: RuntimeConfig, relativePath: string, content: string): Promise<void> {

--- a/test/integration/share.retry.test.ts
+++ b/test/integration/share.retry.test.ts
@@ -4,13 +4,14 @@ import {writeMemoryFile} from '../../src/share.js';
 import {removeMemoryUri as removeMemoryUriEffect} from '../../src/effect/share.js';
 import * as utils from '../../src/utils.js';
 import type {CommandResult, ShareRuntime} from '../../src/types.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();
   return {
     ...actual,
     runCommand: vi.fn(),
-    sleep: vi.fn().mockResolvedValue(undefined),
+    sleep: vi.fn().mockReturnValue(Effect.void),
   };
 });
 
@@ -24,13 +25,13 @@ const runtime: ShareRuntime = {
 const ok = (stdout = ''): CommandResult => ({exitCode: 0, stdout, stderr: ''});
 const fail = (stderr: string): CommandResult => ({exitCode: 1, stdout: '', stderr});
 const removeMemoryUri = (...args: Parameters<typeof removeMemoryUriEffect>) =>
-  Effect.runPromise(removeMemoryUriEffect(...args));
+  runEffect(removeMemoryUriEffect(...args));
 
 function commandSequence(...results: readonly CommandResult[]): void {
   const runCommand = vi.mocked(utils.runCommand);
   runCommand.mockReset();
   for (const result of results) {
-    runCommand.mockResolvedValueOnce(result);
+    runCommand.mockReturnValueOnce(Effect.succeed(result));
   }
 }
 
@@ -129,14 +130,16 @@ describe('writeMemoryFile index refresh', () => {
       ok('written'),
       ok('reindexed'),
     );
-    await writeMemoryFile(
-      runtime,
-      '/ov',
-      'viking://user/me/memories/durable/projects/threadnote/x.md',
-      'body',
-      'create',
-      false,
-      {quiet: true},
+    await runEffect(
+      writeMemoryFile(
+        runtime,
+        '/ov',
+        'viking://user/me/memories/durable/projects/threadnote/x.md',
+        'body',
+        'create',
+        false,
+        {quiet: true},
+      ),
     );
     const runCommand = vi.mocked(utils.runCommand);
     expect(runCommand).toHaveBeenCalledTimes(3);
@@ -158,14 +161,16 @@ describe('writeMemoryFile index refresh', () => {
       fail('temporary reindex failure'),
     );
     await expect(
-      writeMemoryFile(
-        runtime,
-        '/ov',
-        'viking://user/me/memories/durable/projects/threadnote/x.md',
-        'body',
-        'create',
-        false,
-        {quiet: true},
+      runEffect(
+        writeMemoryFile(
+          runtime,
+          '/ov',
+          'viking://user/me/memories/durable/projects/threadnote/x.md',
+          'body',
+          'create',
+          false,
+          {quiet: true},
+        ),
       ),
     ).resolves.toBeUndefined();
   });
@@ -180,14 +185,16 @@ describe('writeMemoryFile index refresh', () => {
     );
 
     await expect(
-      writeMemoryFile(
-        runtime,
-        '/ov',
-        'viking://user/me/memories/durable/projects/threadnote/x.md',
-        'approved body',
-        'create',
-        false,
-        {quiet: true},
+      runEffect(
+        writeMemoryFile(
+          runtime,
+          '/ov',
+          'viking://user/me/memories/durable/projects/threadnote/x.md',
+          'approved body',
+          'create',
+          false,
+          {quiet: true},
+        ),
       ),
     ).rejects.toThrow(/Create conflict/);
     expect(vi.mocked(utils.runCommand).mock.calls.filter(call => call[1]?.includes('write'))).toHaveLength(1);

--- a/test/integration/share.sync.test.ts
+++ b/test/integration/share.sync.test.ts
@@ -1,8 +1,6 @@
 import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Effect, Layer} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {listShareConflicts, showShareConflict} from '../../src/share.js';
 import {
@@ -12,14 +10,12 @@ import {
 } from '../../src/effect/share.js';
 import type {ShareRuntime, ShareTeamsFile} from '../../src/types.js';
 import {runCommand} from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
-const runShareInit = (...args: Parameters<typeof runShareInitEffect>) =>
-  Effect.runPromise(runShareInitEffect(...args).pipe(Effect.provide(TestLayer)));
-const runShareSync = (...args: Parameters<typeof runShareSyncEffect>) =>
-  Effect.runPromise(runShareSyncEffect(...args).pipe(Effect.provide(TestLayer)));
+const runShareInit = (...args: Parameters<typeof runShareInitEffect>) => runEffect(runShareInitEffect(...args));
+const runShareSync = (...args: Parameters<typeof runShareSyncEffect>) => runEffect(runShareSyncEffect(...args));
 const resolveShareConflict = (...args: Parameters<typeof resolveShareConflictEffect>) =>
-  Effect.runPromise(resolveShareConflictEffect(...args).pipe(Effect.provide(TestLayer)));
+  runEffect(resolveShareConflictEffect(...args));
 
 interface TestShareRepo {
   readonly config: ShareRuntime;
@@ -54,11 +50,11 @@ let savedThreadnoteOv: string | undefined;
 let savedFakeOvStore: string | undefined;
 
 async function git(args: readonly string[], cwd?: string): Promise<void> {
-  await runCommand('git', args, {cwd});
+  await runEffect(runCommand('git', args, {cwd}));
 }
 
 async function gitOutput(args: readonly string[], cwd?: string): Promise<string> {
-  const result = await runCommand('git', args, {cwd});
+  const result = await runEffect(runCommand('git', args, {cwd}));
   return result.stdout.trim();
 }
 
@@ -522,7 +518,7 @@ describe('share sync git handling', () => {
       code: 'ENOENT',
     });
     await expect(readFile(fakeOvFile(store, uri), 'utf8')).rejects.toMatchObject({code: 'ENOENT'});
-    await expect(listShareConflicts(config, {team: 'default'})).resolves.toEqual([]);
+    await expect(runEffect(listShareConflicts(config, {team: 'default'}))).resolves.toEqual([]);
   });
 
   it('keeps a pending added reindex blocked when OpenViking has a real local edit', async () => {
@@ -594,14 +590,14 @@ describe('share sync git handling', () => {
       'utf8',
     );
 
-    const conflicts = await listShareConflicts(config, {team: 'default'});
+    const conflicts = await runEffect(listShareConflicts(config, {team: 'default'}));
     expect(conflicts).toHaveLength(1);
     expect(conflicts[0]).toMatchObject({
       id,
       reason: 'local OpenViking content differs from the newly added shared file',
       status: 'added',
     });
-    const detail = await showShareConflict(config, id);
+    const detail = await runEffect(showShareConflict(config, id));
     expect(detail.diff).toContain('local edit');
     expect(detail.diff).toContain('shared body');
 

--- a/test/integration/utils.recall.test.ts
+++ b/test/integration/utils.recall.test.ts
@@ -3,10 +3,19 @@ import {tmpdir} from 'node:os';
 import {basename, join} from 'node:path';
 import {describe, expect, it} from 'vitest';
 import {
-  enrichRecallQueryWithWorkspaceContext,
-  enrichRecallQueryWithWorkspaceProjectContext,
-  runCommand,
+  enrichRecallQueryWithWorkspaceContext as enrichRecallQueryWithWorkspaceContextEffect,
+  enrichRecallQueryWithWorkspaceProjectContext as enrichRecallQueryWithWorkspaceProjectContextEffect,
+  runCommand as runCommandEffect,
 } from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const enrichRecallQueryWithWorkspaceContext = (
+  ...args: Parameters<typeof enrichRecallQueryWithWorkspaceContextEffect>
+) => runEffect(enrichRecallQueryWithWorkspaceContextEffect(...args));
+const enrichRecallQueryWithWorkspaceProjectContext = (
+  ...args: Parameters<typeof enrichRecallQueryWithWorkspaceProjectContextEffect>
+) => runEffect(enrichRecallQueryWithWorkspaceProjectContextEffect(...args));
+const runCommand = (...args: Parameters<typeof runCommandEffect>) => runEffect(runCommandEffect(...args));
 
 describe('workspace recall enrichment', () => {
   it('uses absolute caller cwd and keeps branch terms out of project inference context', async () => {

--- a/test/integration/utils.repo-name.test.ts
+++ b/test/integration/utils.repo-name.test.ts
@@ -2,7 +2,12 @@ import {mkdtemp, mkdir, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, join} from 'node:path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
-import {resolveRepoName, runCommand} from '../../src/utils.js';
+import {resolveRepoName as resolveRepoNameEffect, runCommand as runCommandEffect} from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const resolveRepoName = (...args: Parameters<typeof resolveRepoNameEffect>) =>
+  runEffect(resolveRepoNameEffect(...args));
+const runCommand = (...args: Parameters<typeof runCommandEffect>) => runEffect(runCommandEffect(...args));
 
 const GIT_ENV_KEYS = ['GIT_COMMON_DIR', 'GIT_DIR', 'GIT_INDEX_FILE', 'GIT_WORK_TREE'] as const;
 

--- a/test/unit/candidate_memory.test.ts
+++ b/test/unit/candidate_memory.test.ts
@@ -1,5 +1,5 @@
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Crypto, Effect, FileSystem, Layer, Option, Path} from 'effect';
+import {NodeCrypto, NodePath} from '@effect/platform-node';
+import {Effect, FileSystem, Layer, Option} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {
   appendCandidateAudit,
@@ -15,10 +15,7 @@ import {
 } from '../../src/candidate_memory.js';
 import type {MemoryRecord} from '../../src/memory_document.js';
 import {join, mkdir, mkdtemp, readFile, rm, symlink, writeFile} from '../helpers/effect-filesystem.js';
-
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
-const run = <A, E>(effect: Effect.Effect<A, E, Crypto.Crypto | FileSystem.FileSystem | Path.Path>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(TestLayer)));
+import {runEffect as run} from '../helpers/effect-runtime.js';
 
 const input: SessionCloseoutInput = {
   decisions: ['Keep application workflows Effect-native.'],

--- a/test/unit/effect-architecture.test.ts
+++ b/test/unit/effect-architecture.test.ts
@@ -41,7 +41,7 @@ describe('Effect architecture boundaries', () => {
   });
 
   it('keeps raw Promise lifting primitives inside the shared adapters', async () => {
-    const allowed = new Set(['src/effect/console.ts', 'src/effect/errors.ts']);
+    const allowed = new Set(['src/effect/console.ts', 'src/effect/errors.ts', 'src/mcp_server.ts']);
     for (const path of await sourceFiles()) {
       const source = await readFile(path, 'utf8');
       const relativePath = relative(repoRoot, path);
@@ -57,6 +57,28 @@ describe('Effect architecture boundaries', () => {
     for (const path of await sourceFiles()) {
       const source = await readFile(path, 'utf8');
       expect(source, relative(repoRoot, path)).not.toMatch(/Effect\.(?:runPromise|runFork)\s*\(/);
+    }
+  });
+
+  it('keeps Node built-ins behind Effect platform services in production source', async () => {
+    for (const path of await sourceFiles()) {
+      const source = await readFile(path, 'utf8');
+      expect(source, relative(repoRoot, path)).not.toMatch(
+        /(?:from\s+['"]node:|import\s*\(\s*['"]node:|require\s*\(\s*['"]node:)/,
+      );
+    }
+  });
+
+  it('keeps process globals inside the SystemInfo service boundary', async () => {
+    for (const path of await sourceFiles()) {
+      const relativePath = relative(repoRoot, path);
+      if (relativePath === 'src/effect/system.ts') {
+        continue;
+      }
+      const source = await readFile(path, 'utf8');
+      expect(source, relativePath).not.toMatch(
+        /(?<![$\w])process\.(?:argv|cwd|env|execPath|exitCode|getuid|kill|pid|platform|stdin|stdout)/,
+      );
     }
   });
 

--- a/test/unit/effect-command.test.ts
+++ b/test/unit/effect-command.test.ts
@@ -1,4 +1,4 @@
-import {Effect, Path, Result} from 'effect';
+import {Clock, Effect, Fiber, FileSystem, Path, Result} from 'effect';
 import {describe, expect, it} from 'vitest';
 import {
   commandEnvironment,
@@ -70,13 +70,39 @@ describe('Effect CommandExecutor', () => {
   });
 
   it('interrupts streaming commands through the command boundary', async () => {
-    await expect(
-      run(
-        runStreamingCommandEffect(process.execPath, ['-e', 'setInterval(() => undefined, 1000)']).pipe(
-          Effect.timeout(25),
-        ),
+    const childPid = await run(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const pathService = yield* Path.Path;
+          const directory = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-streaming-command-'});
+          const pidPath = pathService.join(directory, 'child.pid');
+          const fiber = yield* runStreamingCommandEffect(process.execPath, [
+            '-e',
+            'require("node:fs").writeFileSync(process.argv[1], String(process.pid)); setInterval(() => undefined, 1000)',
+            pidPath,
+          ]).pipe(Effect.forkScoped);
+          const deadline = (yield* Clock.currentTimeMillis) + 5000;
+          let pid: number | undefined;
+          while ((yield* Clock.currentTimeMillis) < deadline) {
+            const content = yield* fs.readFileString(pidPath).pipe(Effect.catch(() => Effect.succeed(undefined)));
+            const candidate = Number(content);
+            if (Number.isInteger(candidate) && candidate > 0) {
+              pid = candidate;
+              break;
+            }
+            yield* Effect.sleep(10);
+          }
+          if (pid === undefined) {
+            return yield* Effect.fail(new Error('Streaming child did not report readiness.'));
+          }
+          yield* Fiber.interrupt(fiber);
+          return pid;
+        }),
       ),
-    ).rejects.toThrow();
+    );
+
+    expect(isProcessRunning(childPid)).toBe(false);
   });
 
   it('injects Threadnote config paths into OpenViking CLI commands', async () => {
@@ -130,3 +156,17 @@ describe('Effect CommandExecutor', () => {
     expect(isOpenVikingCliExecutable('/tools/openviking-server')).toBe(false);
   });
 });
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (cause: unknown) {
+    return !(
+      typeof cause === 'object' &&
+      cause !== null &&
+      'code' in cause &&
+      (cause as {readonly code?: unknown}).code === 'ESRCH'
+    );
+  }
+}

--- a/test/unit/effect-command.test.ts
+++ b/test/unit/effect-command.test.ts
@@ -1,9 +1,7 @@
 import {Effect, Result} from 'effect';
 import {describe, expect, it} from 'vitest';
-import {CommandExecutor, runCommandEffect, runStreamingCommandEffect} from '../../src/effect/command.js';
-
-const run = <A, E>(effect: Effect.Effect<A, E, CommandExecutor>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(CommandExecutor.layer)));
+import {runCommandEffect, runStreamingCommandEffect} from '../../src/effect/command.js';
+import {runEffect as run} from '../helpers/effect-runtime.js';
 
 describe('Effect CommandExecutor', () => {
   it('returns captured output for successful commands', async () => {

--- a/test/unit/effect-command.test.ts
+++ b/test/unit/effect-command.test.ts
@@ -1,6 +1,11 @@
-import {Effect, Result} from 'effect';
+import {Effect, Path, Result} from 'effect';
 import {describe, expect, it} from 'vitest';
-import {runCommandEffect, runStreamingCommandEffect} from '../../src/effect/command.js';
+import {
+  commandEnvironment,
+  isOpenVikingCliExecutable,
+  runCommandEffect,
+  runStreamingCommandEffect,
+} from '../../src/effect/command.js';
 import {runEffect as run} from '../helpers/effect-runtime.js';
 
 describe('Effect CommandExecutor', () => {
@@ -72,5 +77,56 @@ describe('Effect CommandExecutor', () => {
         ),
       ),
     ).rejects.toThrow();
+  });
+
+  it('injects Threadnote config paths into OpenViking CLI commands', async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const pathService = yield* Path.Path;
+        const threadnoteHome = pathService.join('workspace', 'threadnote home');
+        return {
+          environment: commandEnvironment(
+            pathService.join('tools', 'ov.exe'),
+            undefined,
+            {PATH: 'tools', THREADNOTE_HOME: threadnoteHome},
+            pathService,
+          ),
+          expectedCliConfig: pathService.join(threadnoteHome, 'ovcli.conf'),
+          expectedServerConfig: pathService.join(threadnoteHome, 'ov.conf'),
+        };
+      }),
+    );
+
+    expect(result.environment).toMatchObject({
+      OPENVIKING_CLI_CONFIG_FILE: result.expectedCliConfig,
+      OPENVIKING_CONFIG_FILE: result.expectedServerConfig,
+      PATH: 'tools',
+    });
+  });
+
+  it('preserves explicit OpenViking config overrides', async () => {
+    const environment = await run(
+      Effect.gen(function* () {
+        const pathService = yield* Path.Path;
+        return commandEnvironment(
+          'openviking',
+          {
+            OPENVIKING_CLI_CONFIG_FILE: 'custom-cli.json',
+            OPENVIKING_CONFIG_FILE: 'custom-server.json',
+            THREADNOTE_HOME: 'threadnote-home',
+          },
+          {},
+          pathService,
+        );
+      }),
+    );
+
+    expect(environment).toMatchObject({
+      OPENVIKING_CLI_CONFIG_FILE: 'custom-cli.json',
+      OPENVIKING_CONFIG_FILE: 'custom-server.json',
+    });
+    expect(isOpenVikingCliExecutable('C:\\tools\\ov.EXE')).toBe(true);
+    expect(isOpenVikingCliExecutable('/tools/openviking')).toBe(true);
+    expect(isOpenVikingCliExecutable('/tools/openviking-server')).toBe(false);
   });
 });

--- a/test/unit/effect-command.test.ts
+++ b/test/unit/effect-command.test.ts
@@ -1,6 +1,6 @@
 import {Effect, Result} from 'effect';
 import {describe, expect, it} from 'vitest';
-import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {CommandExecutor, runCommandEffect, runStreamingCommandEffect} from '../../src/effect/command.js';
 
 const run = <A, E>(effect: Effect.Effect<A, E, CommandExecutor>) =>
   Effect.runPromise(effect.pipe(Effect.provide(CommandExecutor.layer)));
@@ -64,5 +64,15 @@ describe('Effect CommandExecutor', () => {
     );
 
     expect(result).toEqual({exitCode: 3, stderr: 'bad', stdout: ''});
+  });
+
+  it('interrupts streaming commands through the command boundary', async () => {
+    await expect(
+      run(
+        runStreamingCommandEffect(process.execPath, ['-e', 'setInterval(() => undefined, 1000)']).pipe(
+          Effect.timeout(25),
+        ),
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/test/unit/effect-file-lock.test.ts
+++ b/test/unit/effect-file-lock.test.ts
@@ -1,12 +1,8 @@
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Crypto, Effect, FileSystem, Layer, Path} from 'effect';
+import {Effect, FileSystem} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {withExclusiveFileLock} from '../../src/effect/file_lock.js';
 import {join, mkdir, mkdtemp, rm, utimes, writeFile} from '../helpers/effect-filesystem.js';
-
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
-const run = <A, E>(effect: Effect.Effect<A, E, Crypto.Crypto | FileSystem.FileSystem | Path.Path>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(TestLayer)));
+import {runEffect as run} from '../helpers/effect-runtime.js';
 
 const TEST_LOCK_OPTIONS = {
   heartbeatIntervalMilliseconds: 5,

--- a/test/unit/effect-openviking.test.ts
+++ b/test/unit/effect-openviking.test.ts
@@ -14,6 +14,7 @@ it.effect('retries busy OpenViking removals on an Effect schedule', () =>
       CommandExecutor,
       CommandExecutor.of({
         execute: () => Effect.succeed(++attempts === 3 ? success : busy),
+        executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
       }),
     );
     const fiber = yield* removeOpenVikingResourceEffect('ov', ['rm', 'viking://memory'], {
@@ -37,6 +38,7 @@ it.effect('returns undefined after the scheduled busy retries are exhausted', ()
           attempts += 1;
           return Effect.succeed(busy);
         },
+        executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
       }),
     );
     const fiber = yield* removeOpenVikingResourceEffect('ov', ['rm', 'viking://memory'], {
@@ -60,6 +62,7 @@ it.effect('does not retry non-transient removal failures', () =>
           attempts += 1;
           return Effect.succeed({exitCode: 2, stderr: 'permission denied', stdout: ''});
         },
+        executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
       }),
     );
     const exit = yield* removeOpenVikingResourceEffect('ov', ['rm', 'viking://memory'], {

--- a/test/unit/effect-share.test.ts
+++ b/test/unit/effect-share.test.ts
@@ -1,5 +1,4 @@
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Effect, Fiber, Layer} from 'effect';
+import {Effect, Fiber} from 'effect';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 
 const shareMocks = vi.hoisted(() => ({
@@ -53,8 +52,7 @@ import {
   syncSharedReposBeforeAgentRead,
 } from '../../src/effect/share.js';
 import {mkdtemp, rm} from '../helpers/effect-filesystem.js';
-
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
+import {runEffect} from '../helpers/effect-runtime.js';
 
 describe('Effect share transaction', () => {
   const homes: string[] = [];
@@ -69,27 +67,31 @@ describe('Effect share transaction', () => {
     homes.push(agentContextHome);
     let simulatedDefault = 'alpha';
     let publishedTeam: string | undefined;
-    shareMocks.resolveTeam.mockImplementation(async () => {
-      simulatedDefault = 'beta';
-      return {
-        config: {
-          addedAt: '2026-07-23T00:00:00.000Z',
-          gitdir: '/test/alpha.git',
+    shareMocks.resolveTeam.mockImplementation(() =>
+      Effect.sync(() => {
+        simulatedDefault = 'beta';
+        return {
+          config: {
+            addedAt: '2026-07-23T00:00:00.000Z',
+            gitdir: '/test/alpha.git',
+            name: 'alpha',
+            remote: 'git@example.com:test/alpha.git',
+            worktree: '/test/alpha',
+          },
           name: 'alpha',
-          remote: 'git@example.com:test/alpha.git',
-          worktree: '/test/alpha',
-        },
-        name: 'alpha',
-      };
-    });
+        };
+      }),
+    );
     shareMocks.sharedUriFor.mockReturnValue(
       'viking://user/test-user/memories/shared/alpha/durable/projects/threadnote/recall.md',
     );
-    shareMocks.runSharePublish.mockImplementation(async (_config, _sourceUri, options) => {
-      publishedTeam = options.team ?? simulatedDefault;
-    });
+    shareMocks.runSharePublish.mockImplementation((_config, _sourceUri, options) =>
+      Effect.sync(() => {
+        publishedTeam = options.team ?? simulatedDefault;
+      }),
+    );
 
-    await Effect.runPromise(
+    await runEffect(
       runSharePublish(
         {
           account: 'local',
@@ -99,7 +101,7 @@ describe('Effect share transaction', () => {
         },
         'viking://user/test-user/memories/durable/projects/threadnote/recall.md',
         {},
-      ).pipe(Effect.provide(TestLayer)),
+      ),
     );
 
     expect(publishedTeam).toBe('alpha');
@@ -129,18 +131,22 @@ describe('Effect share transaction', () => {
       user: 'test-user',
     };
 
-    await Effect.runPromise(
+    await runEffect(
       Effect.gen(function* () {
-        shareMocks.syncSharedReposBeforeAgentRead.mockImplementationOnce(async () => {
-          events.push('first:start');
-          markFirstStarted?.();
-          await firstBlocked;
-          events.push('first:end');
-          return {syncedTeams: [], warnings: []};
-        });
-        shareMocks.runShareSync.mockImplementationOnce(async () => {
-          events.push('second:start');
-        });
+        shareMocks.syncSharedReposBeforeAgentRead.mockImplementationOnce(() =>
+          Effect.gen(function* () {
+            events.push('first:start');
+            markFirstStarted?.();
+            yield* Effect.promise(() => firstBlocked);
+            events.push('first:end');
+            return {syncedTeams: [], warnings: []};
+          }),
+        );
+        shareMocks.runShareSync.mockImplementationOnce(() =>
+          Effect.sync(() => {
+            events.push('second:start');
+          }),
+        );
 
         const first = yield* Effect.forkChild(syncSharedReposBeforeAgentRead(config));
         yield* Effect.promise(() => firstStarted);
@@ -152,7 +158,7 @@ describe('Effect share transaction', () => {
         yield* Effect.sync(() => releaseFirst?.());
         yield* Fiber.join(interruption);
         yield* Fiber.join(second);
-      }).pipe(Effect.provide(TestLayer)),
+      }),
     );
 
     expect(events).toEqual(['first:start', 'first:end', 'second:start']);
@@ -176,18 +182,22 @@ describe('Effect share transaction', () => {
       agentId: 'threadnote',
       user: 'test-user',
     };
-    shareMocks.runShareConflicts.mockImplementationOnce(async () => {
-      events.push('inspection:start');
-      markInspectionStarted?.();
-      await inspectionBlocked;
-      events.push('inspection:end');
-      return [];
-    });
-    shareMocks.runShareSync.mockImplementationOnce(async () => {
-      events.push('sync:start');
-    });
+    shareMocks.runShareConflicts.mockImplementationOnce(() =>
+      Effect.gen(function* () {
+        events.push('inspection:start');
+        markInspectionStarted?.();
+        yield* Effect.promise(() => inspectionBlocked);
+        events.push('inspection:end');
+        return [];
+      }),
+    );
+    shareMocks.runShareSync.mockImplementationOnce(() =>
+      Effect.sync(() => {
+        events.push('sync:start');
+      }),
+    );
 
-    await Effect.runPromise(
+    await runEffect(
       Effect.gen(function* () {
         const inspection = yield* Effect.forkChild(runShareConflicts(config, {}));
         yield* Effect.promise(() => inspectionStarted);
@@ -197,7 +207,7 @@ describe('Effect share transaction', () => {
         yield* Effect.sync(() => releaseInspection?.());
         yield* Fiber.join(inspection);
         yield* Fiber.join(sync);
-      }).pipe(Effect.provide(TestLayer)),
+      }),
     );
 
     expect(events).toEqual(['inspection:start', 'inspection:end', 'sync:start']);

--- a/test/unit/effect-system.test.ts
+++ b/test/unit/effect-system.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest';
+import {resolveHomeDirectory} from '../../src/effect/system.js';
+
+describe('SystemInfo home directory resolution', () => {
+  it('ignores empty Windows home variables', () => {
+    expect(
+      resolveHomeDirectory(
+        {
+          HOME: '',
+          HOMEDRIVE: 'C:',
+          HOMEPATH: '\\Users\\threadnote',
+          USERPROFILE: '   ',
+        },
+        'win32',
+      ),
+    ).toBe('C:\\Users\\threadnote');
+  });
+
+  it('uses a non-empty POSIX HOME before compatibility variables', () => {
+    expect(resolveHomeDirectory({HOME: '/home/threadnote', USERPROFILE: '/fallback'}, 'linux')).toBe(
+      '/home/threadnote',
+    );
+  });
+
+  it('fails explicitly when no home directory is available', () => {
+    expect(() => resolveHomeDirectory({HOME: '', USERPROFILE: ''}, 'linux')).toThrow(
+      'Could not determine the current user home directory',
+    );
+  });
+});

--- a/test/unit/graph.test.ts
+++ b/test/unit/graph.test.ts
@@ -1,13 +1,9 @@
 import {mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {NodeFileSystem} from '@effect/platform-node';
-import {Effect, FileSystem} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {buildGraphDocument, extractDependencyFacts, resolveGraphEdges} from '../../src/graph.js';
-
-const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(NodeFileSystem.layer)));
+import {runEffect as run} from '../helpers/effect-runtime.js';
 
 describe('extractDependencyFacts', () => {
   let dir: string;

--- a/test/unit/index_repair.test.ts
+++ b/test/unit/index_repair.test.ts
@@ -1,15 +1,22 @@
 import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   filterStaleRecallSummaryRows,
-  findStaleRecallIndexTargets,
+  findStaleRecallIndexTargets as findStaleRecallIndexTargetsEffect,
   formatRecallIndexRepairMessages,
-  repairStaleRecallIndex,
+  repairStaleRecallIndex as repairStaleRecallIndexEffect,
 } from '../../src/index_repair.js';
 import type {CommandResult, RuntimeConfig} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const findStaleRecallIndexTargets = (...args: Parameters<typeof findStaleRecallIndexTargetsEffect>) =>
+  runEffect(findStaleRecallIndexTargetsEffect(...args));
+const repairStaleRecallIndex = (...args: Parameters<typeof repairStaleRecallIndexEffect>) =>
+  runEffect(repairStaleRecallIndexEffect(...args));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();
@@ -40,7 +47,7 @@ describe('recall index auto repair', () => {
 
   beforeEach(() => {
     vi.mocked(utils.runCommand).mockReset();
-    vi.mocked(utils.runCommand).mockResolvedValue(ok('reindexed'));
+    vi.mocked(utils.runCommand).mockReturnValue(Effect.succeed(ok('reindexed')));
   });
 
   afterEach(async () => {
@@ -253,7 +260,7 @@ describe('recall index auto repair', () => {
     );
     await mkdir(summaryDir, {recursive: true});
     await writeFile(join(summaryDir, '.overview.md'), '# threadnote\n\n[Directory overview is not ready]');
-    vi.mocked(utils.runCommand).mockResolvedValueOnce({exitCode: 1, stderr: 'INTERNAL', stdout: ''});
+    vi.mocked(utils.runCommand).mockReturnValueOnce(Effect.succeed({exitCode: 1, stderr: 'INTERNAL', stdout: ''}));
     const failures: string[] = [];
 
     const result = await repairStaleRecallIndex(config, '/ov', {
@@ -316,11 +323,13 @@ describe('recall index auto repair', () => {
       await mkdir(summaryDir, {recursive: true});
       await writeFile(join(summaryDir, '.overview.md'), `# ${project}\n\n[Directory overview is not ready]`);
     }
-    vi.mocked(utils.runCommand).mockResolvedValue({
-      exitCode: 1,
-      stderr: 'CONFLICT: Failed to acquire tree lock',
-      stdout: '',
-    });
+    vi.mocked(utils.runCommand).mockReturnValue(
+      Effect.succeed({
+        exitCode: 1,
+        stderr: 'CONFLICT: Failed to acquire tree lock',
+        stdout: '',
+      }),
+    );
 
     const result = await repairStaleRecallIndex(config, '/ov', {consecutiveFailureLimit: 2, ignoreBackoff: true});
 
@@ -377,10 +386,10 @@ describe('recall index auto repair', () => {
     }
     const conflict = {exitCode: 1, stderr: 'CONFLICT: Failed to acquire tree lock', stdout: ''};
     vi.mocked(utils.runCommand)
-      .mockResolvedValueOnce(conflict)
-      .mockResolvedValueOnce(ok('reindexed'))
-      .mockResolvedValueOnce(conflict)
-      .mockResolvedValueOnce(conflict);
+      .mockReturnValueOnce(Effect.succeed(conflict))
+      .mockReturnValueOnce(Effect.succeed(ok('reindexed')))
+      .mockReturnValueOnce(Effect.succeed(conflict))
+      .mockReturnValueOnce(Effect.succeed(conflict));
 
     const result = await repairStaleRecallIndex(config, '/ov', {consecutiveFailureLimit: 2, ignoreBackoff: true});
 

--- a/test/unit/launchd.test.ts
+++ b/test/unit/launchd.test.ts
@@ -119,6 +119,7 @@ describe('macOS LaunchAgent lifecycle', () => {
               }
               return {exitCode: 0, stderr: '', stdout: ''};
             }),
+          executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
         }),
       );
 
@@ -140,6 +141,7 @@ describe('macOS LaunchAgent lifecycle', () => {
               yield* TestClock.adjust(10);
               return {exitCode: 0, stderr: '', stdout: ''};
             }),
+          executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
         }),
       );
 
@@ -163,6 +165,7 @@ describe('macOS LaunchAgent lifecycle', () => {
                 ? {exitCode: 0, stderr: '', stdout: 'state = running\npid = 123\n'}
                 : {exitCode: 0, stderr: '', stdout: ''},
             ),
+          executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
         }),
       );
 
@@ -186,6 +189,7 @@ describe('macOS LaunchAgent lifecycle', () => {
             calls += 1;
             return Effect.succeed({exitCode: 113, stderr: 'Could not find service', stdout: ''});
           },
+          executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
         }),
       );
 

--- a/test/unit/launchd.test.ts
+++ b/test/unit/launchd.test.ts
@@ -14,6 +14,8 @@ import {
   parseLaunchAgentStatus,
 } from '../../src/launchd.js';
 import {CommandExecutor} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 const originalPath = process.env.PATH;
 const temporaryDirectories: string[] = [];
@@ -66,8 +68,8 @@ describe('macOS LaunchAgent lifecycle', () => {
     const {logPath} = await fakeLaunchctl();
     const plistPath = '/Users/test/Library/LaunchAgents/io.threadnote.openviking.plist';
 
-    await Effect.runPromise(bootoutLaunchAgent(false, 502).pipe(Effect.provide(CommandExecutor.layer)));
-    await Effect.runPromise(bootstrapLaunchAgent(plistPath, false, 502).pipe(Effect.provide(CommandExecutor.layer)));
+    await runEffect(bootoutLaunchAgent(false, 502));
+    await runEffect(bootstrapLaunchAgent(plistPath, false, 502));
 
     expect((await readFile(logPath, 'utf8')).trim().split('\n')).toEqual([
       'print gui/502/io.threadnote.openviking',
@@ -81,7 +83,7 @@ describe('macOS LaunchAgent lifecycle', () => {
   it('requires launchctl to report a running process', async () => {
     await fakeLaunchctl();
 
-    expect(await Effect.runPromise(isLaunchAgentRunning(502).pipe(Effect.provide(CommandExecutor.layer)))).toBe(true);
+    expect(await runEffect(isLaunchAgentRunning(502))).toBe(true);
   });
 
   it('does not treat a loaded job without a running pid as ready', () => {
@@ -120,7 +122,7 @@ describe('macOS LaunchAgent lifecycle', () => {
         }),
       );
 
-      yield* bootoutLaunchAgent(false, 502, 1000).pipe(Effect.provide(executor));
+      yield* bootoutLaunchAgent(false, 502, 1000).pipe(Effect.provide(executor), Effect.provide(SystemInfo.layer));
 
       effectExpect(timeouts).toEqual([1000, 990, 980]);
     }),
@@ -141,7 +143,10 @@ describe('macOS LaunchAgent lifecycle', () => {
         }),
       );
 
-      yield* bootstrapLaunchAgent('/tmp/agent.plist', false, 502, 1000).pipe(Effect.provide(executor));
+      yield* bootstrapLaunchAgent('/tmp/agent.plist', false, 502, 1000).pipe(
+        Effect.provide(executor),
+        Effect.provide(SystemInfo.layer),
+      );
 
       effectExpect(timeouts).toEqual([1000, 990]);
     }),
@@ -161,7 +166,11 @@ describe('macOS LaunchAgent lifecycle', () => {
         }),
       );
 
-      const error = yield* bootoutLaunchAgent(false, 502, 1000).pipe(Effect.provide(executor), Effect.flip);
+      const error = yield* bootoutLaunchAgent(false, 502, 1000).pipe(
+        Effect.provide(executor),
+        Effect.provide(SystemInfo.layer),
+        Effect.flip,
+      );
 
       effectExpect(String(error)).toContain('did not unload');
     }),
@@ -180,7 +189,7 @@ describe('macOS LaunchAgent lifecycle', () => {
         }),
       );
 
-      yield* bootoutLaunchAgent(false, 502, 1000).pipe(Effect.provide(executor));
+      yield* bootoutLaunchAgent(false, 502, 1000).pipe(Effect.provide(executor), Effect.provide(SystemInfo.layer));
 
       effectExpect(calls).toBe(1);
     }),

--- a/test/unit/lifecycle.doctor.test.ts
+++ b/test/unit/lifecycle.doctor.test.ts
@@ -4,6 +4,7 @@ import {dirname, join} from 'node:path';
 import {afterEach, describe, expect, it} from 'vitest';
 import {memoryProjectConsistencyCheck} from '../../src/lifecycle.js';
 import type {RuntimeConfig} from '../../src/types.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 const homes: string[] = [];
 
@@ -50,7 +51,7 @@ async function writeMemory(root: string, relPath: string, project: string | unde
 describe('memoryProjectConsistencyCheck', () => {
   it('is ok before any memories exist', async () => {
     const config = await makeConfig();
-    const check = await memoryProjectConsistencyCheck(config);
+    const check = await runEffect(memoryProjectConsistencyCheck(config));
     expect(check.status).toBe('ok');
     expect(check.detail).toMatch(/no memories directory/);
   });
@@ -63,7 +64,7 @@ describe('memoryProjectConsistencyCheck', () => {
     await writeMemory(root, 'preferences/coding-style.md', 'whatever'); // project-less kind → skipped
     await writeMemory(root, 'shared/docs-desktop/durable/projects/coda/pagerduty.md', 'mobile-native'); // drift
 
-    const check = await memoryProjectConsistencyCheck(config);
+    const check = await runEffect(memoryProjectConsistencyCheck(config));
     expect(check.status).toBe('warn');
     expect(check.detail).toContain('shared/docs-desktop/durable/projects/coda/pagerduty.md');
     expect(check.detail).toContain('frontmatter "mobile-native" vs path "coda"');
@@ -76,7 +77,7 @@ describe('memoryProjectConsistencyCheck', () => {
     await writeMemory(root, 'durable/projects/mobile-native/a.md', 'mobile-native');
     await writeMemory(root, 'handoffs/active/threadnote/b.md', 'threadnote');
     await writeMemory(root, 'incidents/active/coda/c.md', 'coda');
-    const check = await memoryProjectConsistencyCheck(config);
+    const check = await runEffect(memoryProjectConsistencyCheck(config));
     expect(check.status).toBe('ok');
     expect(check.detail).toMatch(/3 project-scoped memories consistent/);
   });
@@ -88,7 +89,7 @@ describe('memoryProjectConsistencyCheck', () => {
     await writeMemory(root, 'durable/projects/coda/notes.txt', 'mobile-native'); // not .md → skipped
     await writeMemory(root, 'durable/projects/coda/.overview.md', 'mobile-native'); // sidecar → skipped
     await mkdir(join(root, 'durable/projects/coda/isdir.md'), {recursive: true}); // dir → readFile throws, skipped
-    const check = await memoryProjectConsistencyCheck(config);
+    const check = await runEffect(memoryProjectConsistencyCheck(config));
     expect(check.status).toBe('ok');
     expect(check.detail).toMatch(/1 project-scoped memories consistent/);
   });
@@ -99,7 +100,7 @@ describe('memoryProjectConsistencyCheck', () => {
     for (const project of ['a', 'b', 'c', 'd']) {
       await writeMemory(root, `durable/projects/${project}/m.md`, 'wrong');
     }
-    const check = await memoryProjectConsistencyCheck(config);
+    const check = await runEffect(memoryProjectConsistencyCheck(config));
     expect(check.status).toBe('warn');
     expect(check.detail).toMatch(/^4 memory/);
     expect(check.detail).toContain('+1 more');

--- a/test/unit/lifecycle.install.test.ts
+++ b/test/unit/lifecycle.install.test.ts
@@ -2,7 +2,7 @@ import {spawn, type ChildProcess} from 'node:child_process';
 import {access, chmod, mkdir, mkdtemp, rm, stat, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {delimiter, join} from 'node:path';
-import {NodeFileSystem} from '@effect/platform-node';
+import {NodeFileSystem, NodePath} from '@effect/platform-node';
 import {Effect, Layer} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {
@@ -21,6 +21,7 @@ import {
 import {fromPromise} from '../../src/effect/errors.js';
 import {CommandExecutor} from '../../src/effect/command.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
 import type {RuntimeConfig} from '../../src/types.js';
 
 const WHEEL_INDEX_ENV = 'THREADNOTE_LLAMA_WHEEL_INDEX';
@@ -137,7 +138,7 @@ function launchdProcessTestLayer(processStart: string, commands: string | readon
       },
     }),
   );
-  return Layer.merge(NodeFileSystem.layer, executor);
+  return Layer.mergeAll(NodeFileSystem.layer, NodePath.layer, executor, SystemInfo.layer);
 }
 
 function runtime(): RuntimeConfig {
@@ -364,7 +365,7 @@ describe('getInstallCommands', () => {
 
   it('adds the wheel index to the pip --user fallback', async () => {
     const [command] = await getInstallCommands(runtime(), 'pip', true);
-    expect(command.executable).toBe('python3');
+    expect(command.executable).toMatch(/python3$/);
     expect(command.args).toEqual([
       '-m',
       'pip',
@@ -378,6 +379,19 @@ describe('getInstallCommands', () => {
       SPEC,
     ]);
   });
+
+  posixIt('uses a working python fallback when python3 is unavailable', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'threadnote-python-fallback-'));
+    temporaryDirectories.push(directory);
+    const python = join(directory, 'python');
+    await writeFile(python, '#!/bin/sh\nexit 0\n');
+    await chmod(python, 0o755);
+    process.env.PATH = directory;
+
+    const [command] = await getInstallCommands(runtime(), 'pip', false);
+
+    expect(command.executable).toBe(python);
+  });
 });
 
 describe('findOpenVikingServerEffect', () => {
@@ -388,14 +402,16 @@ describe('findOpenVikingServerEffect', () => {
     await writeFile(uv, '#!/bin/sh\n');
     await chmod(uv, 0o755);
     process.env.PATH = home;
-    const layer = Layer.merge(
+    const layer = Layer.mergeAll(
       NodeFileSystem.layer,
+      NodePath.layer,
       Layer.succeed(
         CommandExecutor,
         CommandExecutor.of({
           execute: () => Effect.never,
         }),
       ),
+      SystemInfo.layer,
     );
 
     await expect(Effect.runPromise(findOpenVikingServerEffect(20).pipe(Effect.provide(layer)))).rejects.toThrow(

--- a/test/unit/lifecycle.install.test.ts
+++ b/test/unit/lifecycle.install.test.ts
@@ -6,7 +6,7 @@ import {NodeFileSystem, NodePath} from '@effect/platform-node';
 import {Effect, Layer} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {
-  ensureSupportedUvExecutable as ensureSupportedUvExecutablePromise,
+  ensureSupportedUvExecutable as ensureSupportedUvExecutableEffect,
   findOpenVikingServerEffect,
   findSupportedUvExecutable,
   getInstallCommands,
@@ -18,11 +18,11 @@ import {
   resolveOpenVikingInstallCommand,
   stopDetachedOpenVikingServerForLaunchd,
 } from '../../src/lifecycle.js';
-import {fromPromise} from '../../src/effect/errors.js';
 import {CommandExecutor} from '../../src/effect/command.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import type {RuntimeConfig} from '../../src/types.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 const WHEEL_INDEX_ENV = 'THREADNOTE_LLAMA_WHEEL_INDEX';
 const TOOL_PYTHON_ENV = 'THREADNOTE_OPENVIKING_PYTHON';
@@ -32,8 +32,7 @@ const posixIt = process.platform === 'win32' ? it.skip : it;
 const originalPath = process.env.PATH;
 const childProcesses: ChildProcess[] = [];
 const temporaryDirectories: string[] = [];
-const ensureSupportedUvExecutable = () =>
-  Effect.runPromise(fromPromise('ensure supported uv executable', ensureSupportedUvExecutablePromise));
+const ensureSupportedUvExecutable = () => runEffect(ensureSupportedUvExecutableEffect());
 
 async function fakeUv(version: string, selfUpdateVersion?: string): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'threadnote-uv-test-'));
@@ -122,10 +121,11 @@ function formatPsStart(date: Date): string {
 
 function launchdProcessTestLayer(processStart: string, commands: string | readonly string[], pid: number) {
   let psCalls = 0;
+  let terminated = false;
   const executor = Layer.succeed(
     CommandExecutor,
     CommandExecutor.of({
-      execute: executable => {
+      execute: (executable, args) => {
         if (executable === '/bin/ps') {
           const command = typeof commands === 'string' ? commands : (commands[psCalls] ?? commands.at(-1) ?? '');
           psCalls += 1;
@@ -133,6 +133,17 @@ function launchdProcessTestLayer(processStart: string, commands: string | readon
         }
         if (executable === '/usr/sbin/lsof') {
           return Effect.succeed({exitCode: 0, stderr: '', stdout: `p${pid}\n`});
+        }
+        if (executable === 'kill') {
+          const signal = args[0];
+          if (signal === '-0') {
+            return Effect.succeed({exitCode: terminated ? 1 : 0, stderr: '', stdout: ''});
+          }
+          return Effect.sync(() => {
+            terminated = true;
+            process.kill(pid, signal === '-TERM' ? 'SIGTERM' : 'SIGKILL');
+            return {exitCode: 0, stderr: '', stdout: ''};
+          });
         }
         return Effect.succeed({exitCode: 127, stderr: 'unexpected command', stdout: ''});
       },
@@ -177,8 +188,11 @@ describe('uv compatibility', () => {
     const currentUv = await fakeUv('uv 0.11.0');
     process.env.PATH = [join(oldUv, '..'), join(currentUv, '..'), '/usr/bin', '/bin'].join(delimiter);
 
-    expect(await findSupportedUvExecutable()).toBe(currentUv);
-    expect(await resolveOpenVikingInstallCommand(UV_COMMAND)).toEqual({...UV_COMMAND, executable: currentUv});
+    expect(await runEffect(findSupportedUvExecutable())).toBe(currentUv);
+    expect(await runEffect(resolveOpenVikingInstallCommand(UV_COMMAND))).toEqual({
+      ...UV_COMMAND,
+      executable: currentUv,
+    });
   });
 
   it('self-updates an old standalone uv before using --system-certs', async () => {
@@ -186,7 +200,7 @@ describe('uv compatibility', () => {
     process.env.PATH = [join(uv, '..'), '/usr/bin', '/bin'].join(delimiter);
 
     expect(await ensureSupportedUvExecutable()).toBe(uv);
-    expect(await findSupportedUvExecutable()).toBe(uv);
+    expect(await runEffect(findSupportedUvExecutable())).toBe(uv);
   });
 
   it('reports an actionable error when an old uv cannot be upgraded', async () => {
@@ -203,19 +217,19 @@ describe('localEmbedWheelIndexUrl', () => {
   const original = process.env[WHEEL_INDEX_ENV];
   afterEach(() => restoreEnv(WHEEL_INDEX_ENV, original));
 
-  it('defaults to the abetlen wheel index', () => {
+  it('defaults to the abetlen wheel index', async () => {
     delete process.env[WHEEL_INDEX_ENV];
-    expect(localEmbedWheelIndexUrl()).toContain('abetlen.github.io/llama-cpp-python/whl/');
+    expect(await runEffect(localEmbedWheelIndexUrl())).toContain('abetlen.github.io/llama-cpp-python/whl/');
   });
 
-  it('honors an override', () => {
+  it('honors an override', async () => {
     process.env[WHEEL_INDEX_ENV] = TEST_INDEX;
-    expect(localEmbedWheelIndexUrl()).toBe(TEST_INDEX);
+    expect(await runEffect(localEmbedWheelIndexUrl())).toBe(TEST_INDEX);
   });
 
-  it('treats an empty override as disabled', () => {
+  it('treats an empty override as disabled', async () => {
     process.env[WHEEL_INDEX_ENV] = '   ';
-    expect(localEmbedWheelIndexUrl()).toBeUndefined();
+    expect(await runEffect(localEmbedWheelIndexUrl())).toBeUndefined();
   });
 });
 
@@ -223,19 +237,19 @@ describe('openVikingToolPython', () => {
   const original = process.env[TOOL_PYTHON_ENV];
   afterEach(() => restoreEnv(TOOL_PYTHON_ENV, original));
 
-  it('defaults to the pinned tool Python', () => {
+  it('defaults to the pinned tool Python', async () => {
     delete process.env[TOOL_PYTHON_ENV];
-    expect(openVikingToolPython()).toBe('3.12');
+    expect(await runEffect(openVikingToolPython())).toBe('3.12');
   });
 
-  it('honors an override', () => {
+  it('honors an override', async () => {
     process.env[TOOL_PYTHON_ENV] = '3.11';
-    expect(openVikingToolPython()).toBe('3.11');
+    expect(await runEffect(openVikingToolPython())).toBe('3.11');
   });
 
-  it('treats an empty override as no pin', () => {
+  it('treats an empty override as no pin', async () => {
     process.env[TOOL_PYTHON_ENV] = '';
-    expect(openVikingToolPython()).toBeUndefined();
+    expect(await runEffect(openVikingToolPython())).toBeUndefined();
   });
 });
 
@@ -301,7 +315,7 @@ describe('getInstallCommands', () => {
   });
 
   it('pins uv to a wheel-supported Python and adds the wheel index', async () => {
-    const [command, ...rest] = await getInstallCommands(runtime(), 'uv', false);
+    const [command, ...rest] = await runEffect(getInstallCommands(runtime(), 'uv', false));
     expect(rest).toHaveLength(0);
     expect(command.executable).toBe('uv');
     expect(command.args).toEqual([
@@ -319,14 +333,14 @@ describe('getInstallCommands', () => {
   });
 
   it('appends --force for a uv forced reinstall', async () => {
-    const [command] = await getInstallCommands(runtime(), 'uv', true);
+    const [command] = await runEffect(getInstallCommands(runtime(), 'uv', true));
     expect(command.args).toContain('--force');
     expect(command.args.indexOf('--force')).toBe(command.args.indexOf(SPEC) - 1);
   });
 
   it('omits the wheel index for uv when disabled', async () => {
     process.env[WHEEL_INDEX_ENV] = '';
-    const [command] = await getInstallCommands(runtime(), 'uv', false);
+    const [command] = await runEffect(getInstallCommands(runtime(), 'uv', false));
     expect(command.args).not.toContain('--extra-index-url');
     expect(command.args).toEqual([
       'tool',
@@ -342,7 +356,7 @@ describe('getInstallCommands', () => {
 
   it('drops the uv --python pin when disabled', async () => {
     process.env[TOOL_PYTHON_ENV] = '';
-    const [command] = await getInstallCommands(runtime(), 'uv', false);
+    const [command] = await runEffect(getInstallCommands(runtime(), 'uv', false));
     expect(command.args).not.toContain('--python');
     expect(command.args).toEqual([
       'tool',
@@ -357,14 +371,14 @@ describe('getInstallCommands', () => {
   });
 
   it('passes the wheel index to pipx via --pip-args', async () => {
-    const [install, inject] = await getInstallCommands(runtime(), 'pipx', false);
+    const [install, inject] = await runEffect(getInstallCommands(runtime(), 'pipx', false));
     expect(install.executable).toBe('pipx');
     expect(install.args).toEqual(['install', '--pip-args', `--extra-index-url ${TEST_INDEX}`, SPEC]);
     expect(inject.args).toEqual(['inject', 'openviking', 'pip-system-certs']);
   });
 
   it('adds the wheel index to the pip --user fallback', async () => {
-    const [command] = await getInstallCommands(runtime(), 'pip', true);
+    const [command] = await runEffect(getInstallCommands(runtime(), 'pip', true));
     expect(command.executable).toMatch(/python3$/);
     expect(command.args).toEqual([
       '-m',
@@ -388,7 +402,7 @@ describe('getInstallCommands', () => {
     await chmod(python, 0o755);
     process.env.PATH = directory;
 
-    const [command] = await getInstallCommands(runtime(), 'pip', false);
+    const [command] = await runEffect(getInstallCommands(runtime(), 'pip', false));
 
     expect(command.executable).toBe(python);
   });
@@ -452,6 +466,7 @@ describe('stopDetachedOpenVikingServerForLaunchd', () => {
       ),
     );
 
+    await expect(waitForChildExit(child, 1000)).resolves.toBe(true);
     expect(child.signalCode).toBe('SIGTERM');
     await expect(access(pidPath)).rejects.toThrow();
   });

--- a/test/unit/lifecycle.install.test.ts
+++ b/test/unit/lifecycle.install.test.ts
@@ -37,31 +37,54 @@ const ensureSupportedUvExecutable = () => runEffect(ensureSupportedUvExecutableE
 async function fakeUv(version: string, selfUpdateVersion?: string): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'threadnote-uv-test-'));
   temporaryDirectories.push(directory);
-  const executable = join(directory, 'uv');
+  const executable = join(directory, process.platform === 'win32' ? 'uv.CMD' : 'uv');
   const statePath = join(directory, 'version');
   await writeFile(statePath, `${version}\n`);
-  await writeFile(
-    executable,
-    [
-      '#!/bin/sh',
-      `state=${JSON.stringify(statePath)}`,
-      'if [ "$1" = "--version" ]; then',
-      '  /bin/cat "$state"',
-      '  exit 0',
-      'fi',
-      ...(selfUpdateVersion
-        ? [
-            'if [ "$1" = "self" ] && [ "$2" = "update" ]; then',
-            `  printf '%s\\n' ${JSON.stringify(selfUpdateVersion)} > "$state"`,
-            '  exit 0',
-            'fi',
-          ]
-        : []),
-      'exit 1',
-      '',
-    ].join('\n'),
-  );
-  await chmod(executable, 0o755);
+  if (process.platform === 'win32') {
+    await writeFile(
+      executable,
+      [
+        '@echo off',
+        'if /I "%~1"=="--version" (',
+        `  type "${statePath}"`,
+        '  exit /b 0',
+        ')',
+        ...(selfUpdateVersion
+          ? [
+              'if /I "%~1"=="self" if /I "%~2"=="update" (',
+              `  > "${statePath}" echo ${selfUpdateVersion}`,
+              '  exit /b 0',
+              ')',
+            ]
+          : []),
+        'exit /b 1',
+        '',
+      ].join('\r\n'),
+    );
+  } else {
+    await writeFile(
+      executable,
+      [
+        '#!/bin/sh',
+        `state=${JSON.stringify(statePath)}`,
+        'if [ "$1" = "--version" ]; then',
+        '  /bin/cat "$state"',
+        '  exit 0',
+        'fi',
+        ...(selfUpdateVersion
+          ? [
+              'if [ "$1" = "self" ] && [ "$2" = "update" ]; then',
+              `  printf '%s\\n' ${JSON.stringify(selfUpdateVersion)} > "$state"`,
+              '  exit 0',
+              'fi',
+            ]
+          : []),
+        'exit 1',
+        '',
+      ].join('\n'),
+    );
+    await chmod(executable, 0o755);
+  }
   return executable;
 }
 
@@ -147,6 +170,7 @@ function launchdProcessTestLayer(processStart: string, commands: string | readon
         }
         return Effect.succeed({exitCode: 127, stderr: 'unexpected command', stdout: ''});
       },
+      executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
     }),
   );
   return Layer.mergeAll(NodeFileSystem.layer, NodePath.layer, executor, SystemInfo.layer);
@@ -379,7 +403,7 @@ describe('getInstallCommands', () => {
 
   it('adds the wheel index to the pip --user fallback', async () => {
     const [command] = await runEffect(getInstallCommands(runtime(), 'pip', true));
-    expect(command.executable).toMatch(/python3$/);
+    expect(command.executable).toMatch(process.platform === 'win32' ? /(?:py|python3?)(?:\.exe)?$/i : /python3$/);
     expect(command.args).toEqual([
       '-m',
       'pip',
@@ -423,6 +447,7 @@ describe('findOpenVikingServerEffect', () => {
         CommandExecutor,
         CommandExecutor.of({
           execute: () => Effect.never,
+          executeStreaming: () => Effect.die(new Error('Unexpected streaming command')),
         }),
       ),
       SystemInfo.layer,

--- a/test/unit/lifecycle.launchd.test.ts
+++ b/test/unit/lifecycle.launchd.test.ts
@@ -1,7 +1,6 @@
 import {access, mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {NodeFileSystem} from '@effect/platform-node';
 import {expect, it} from '@effect/vitest';
 import {Effect, Fiber} from 'effect';
 import {TestClock} from 'effect/testing';
@@ -16,6 +15,7 @@ import {
   type LaunchAgentHealthEffects,
 } from '../../src/lifecycle.js';
 import type {RuntimeConfig} from '../../src/types.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 function runtime(): RuntimeConfig {
   return {
@@ -339,9 +339,7 @@ describe('stageLaunchAgentPlist', () => {
     const stagePath = `${plistPath}.threadnote-stage-${process.pid}`;
     await writeFile(plistPath, 'previous');
     try {
-      const transaction = await Effect.runPromise(
-        stageLaunchAgentPlist(plistPath, 'replacement').pipe(Effect.provide(NodeFileSystem.layer)),
-      );
+      const transaction = await runEffect(stageLaunchAgentPlist(plistPath, 'replacement'));
       expect((await stat(stagePath)).mode & 0o777).toBe(0o600);
       await Effect.runPromise(transaction.commit);
       expect(await readFile(plistPath, 'utf8')).toBe('replacement');
@@ -359,9 +357,7 @@ describe('stageLaunchAgentPlist', () => {
     const plistPath = join(directory, 'agent.plist');
     await writeFile(plistPath, 'previous');
     try {
-      const transaction = await Effect.runPromise(
-        stageLaunchAgentPlist(plistPath, 'replacement').pipe(Effect.provide(NodeFileSystem.layer)),
-      );
+      const transaction = await runEffect(stageLaunchAgentPlist(plistPath, 'replacement'));
       await writeFile(plistPath, 'external edit');
 
       await expect(Effect.runPromise(transaction.commit)).rejects.toThrow('changed while activation was staged');

--- a/test/unit/manager.test.ts
+++ b/test/unit/manager.test.ts
@@ -1,7 +1,9 @@
 import {mkdir, mkdtemp, rm, stat, symlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {Console, Effect} from 'effect';
+import {NodeHttpServer} from '@effect/platform-node';
+import {Console, Effect, Fiber} from 'effect';
+import {HttpServer} from 'effect/unstable/http';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   consolidationAgentScript,
@@ -17,6 +19,7 @@ import * as lifecycle from '../../src/lifecycle.js';
 import * as memory from '../../src/memory.js';
 import * as seeding from '../../src/seeding.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 vi.mock('../../src/lifecycle.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/lifecycle.js')>();
@@ -95,23 +98,33 @@ async function startServer(
   config: RuntimeConfig,
   token: string,
 ): Promise<{readonly close: () => Promise<void>; readonly url: string}> {
-  const server = createManagerServer({config, jobs: new Map(), token}, effect =>
-    Effect.runPromise(effect.pipe(Effect.provide(ApplicationLayer))),
-  );
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      server.off('error', reject);
-      resolve();
-    });
+  let resolveAddress: ((value: string) => void) | undefined;
+  let rejectAddress: ((reason: unknown) => void) | undefined;
+  const address = new Promise<string>((resolve, reject) => {
+    resolveAddress = resolve;
+    rejectAddress = reject;
   });
-  const address = server.address();
-  if (typeof address !== 'object' || !address) {
-    throw new Error('server did not bind');
-  }
+  const fiber = Effect.runFork(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* HttpServer.HttpServer;
+        yield* server.serve(createManagerServer({config, jobs: new Map(), token}));
+        const serverAddress = server.address;
+        if (serverAddress._tag !== 'TcpAddress') {
+          return yield* Effect.fail(new Error('manager test server did not bind to TCP'));
+        }
+        yield* Effect.sync(() => resolveAddress?.(`http://127.0.0.1:${serverAddress.port}`));
+        return yield* Effect.never;
+      }),
+    ).pipe(
+      Effect.provide(NodeHttpServer.layerTest),
+      Effect.provide(ApplicationLayer),
+      Effect.tapError(error => Effect.sync(() => rejectAddress?.(error))),
+    ),
+  );
   return {
-    close: () => new Promise((resolve, reject) => server.close(err => (err ? reject(err) : resolve()))),
-    url: `http://127.0.0.1:${address.port}`,
+    close: () => Effect.runPromise(Fiber.interrupt(fiber)).then(() => undefined),
+    url: await address,
   };
 }
 
@@ -131,7 +144,7 @@ describe('manager catalog', () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
 
-    const tree = await memoryTree(config);
+    const tree = await runEffect(memoryTree(config));
     const project = tree.children?.find(child => child.name === 'durable')?.children?.[0]?.children?.[0];
     const leaf = project?.children?.find(child => child.name === 'manager-ui.md');
 
@@ -147,7 +160,7 @@ describe('manager catalog', () => {
     await mkdir(join(root, 'agent-skills', 'codex-global'), {recursive: true});
     await writeFile(join(root, 'agent-skills', 'codex-global', 'threadnote-abc123.md'), 'Skill body');
 
-    const tree = await resourcesTree(config);
+    const tree = await runEffect(resourcesTree(config));
     const skill = tree.children
       ?.find(child => child.name === 'agent-skills')
       ?.children?.find(child => child.name === 'codex-global')
@@ -163,9 +176,8 @@ describe('manager catalog', () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
 
-    const result = await readManagedMemory(
-      config,
-      'viking://user/denys/memories/durable/projects/threadnote/manager-ui.md',
+    const result = await runEffect(
+      readManagedMemory(config, 'viking://user/denys/memories/durable/projects/threadnote/manager-ui.md'),
     );
 
     expect(result.content).toContain('Manager UI feature notes.');
@@ -182,12 +194,12 @@ describe('manager catalog', () => {
     await writeFile(secretPath, 'do not expose through manager\n', 'utf8');
     await symlink(secretPath, linkPath);
 
-    const tree = await memoryTree(config);
+    const tree = await runEffect(memoryTree(config));
     const project = tree.children?.find(child => child.name === 'durable')?.children?.[0]?.children?.[0];
 
     expect(project?.children?.map(child => child.name)).not.toContain('leak.md');
     await expect(
-      readManagedMemory(config, 'viking://user/denys/memories/durable/projects/threadnote/leak.md'),
+      runEffect(readManagedMemory(config, 'viking://user/denys/memories/durable/projects/threadnote/leak.md')),
     ).rejects.toThrow(/regular memory files/);
   });
 });

--- a/test/unit/manifest.worksets.test.ts
+++ b/test/unit/manifest.worksets.test.ts
@@ -2,7 +2,18 @@ import {mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
-import {inferWorksetFromQuery, readSeedManifest, resolveWorkset} from '../../src/manifest.js';
+import {
+  inferWorksetFromQuery as inferWorksetFromQueryEffect,
+  readSeedManifest as readSeedManifestEffect,
+  resolveWorkset as resolveWorksetEffect,
+} from '../../src/manifest.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const inferWorksetFromQuery = (...args: Parameters<typeof inferWorksetFromQueryEffect>) =>
+  runEffect(inferWorksetFromQueryEffect(...args));
+const readSeedManifest = (...args: Parameters<typeof readSeedManifestEffect>) =>
+  runEffect(readSeedManifestEffect(...args));
+const resolveWorkset = (...args: Parameters<typeof resolveWorksetEffect>) => runEffect(resolveWorksetEffect(...args));
 
 const MANIFEST = `
 version: 1

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -35,6 +35,7 @@ async function dryRunOutput(toolset?: 'core' | 'full'): Promise<string> {
 
 const originalPath = process.env.PATH;
 const temporaryDirectories: string[] = [];
+const posixIt = process.platform === 'win32' ? it.skip : it;
 
 async function codexLauncher(script: string): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'threadnote-codex-'));
@@ -60,6 +61,12 @@ describe('MCP toolsets', () => {
     await expect(dryRunOutput()).resolves.toContain('THREADNOTE_MCP_TOOLSET=core');
   });
 
+  it('uses the Node launcher instead of POSIX env', async () => {
+    const output = await dryRunOutput();
+    expect(output).toContain('-- node <local-path>');
+    expect(output).not.toContain('/usr/bin/env');
+  });
+
   it('installs the full stdio toolset when requested', async () => {
     await expect(dryRunOutput('full')).resolves.toContain('THREADNOTE_MCP_TOOLSET=full');
   });
@@ -70,7 +77,7 @@ describe('MCP toolsets', () => {
 });
 
 describe('MCP agent executable resolution', () => {
-  it('uses a healthy later PATH entry when the first Codex launcher is stale', async () => {
+  posixIt('uses a healthy later PATH entry when the first Codex launcher is stale', async () => {
     const broken = await codexLauncher("printf '%s\\n' 'missing native binary' >&2\nexit 1");
     const callsPath = join(tmpdir(), `threadnote-codex-calls-${process.pid}-${Date.now()}`);
     const healthy = await codexLauncher(
@@ -86,7 +93,7 @@ describe('MCP agent executable resolution', () => {
     await rm(callsPath, {force: true});
   });
 
-  it('skips a broken Codex launcher during repair and gives explicit installs an actionable error', async () => {
+  posixIt('skips a broken Codex launcher during repair and gives explicit installs an actionable error', async () => {
     const broken = await codexLauncher("printf '%s\\n' 'missing native binary' >&2\nexit 1");
     process.env.PATH = [join(broken, '..'), '/usr/bin', '/bin'].join(delimiter);
 

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -62,7 +62,7 @@ describe('MCP toolsets', () => {
 
   it('uses the Node launcher instead of POSIX env', async () => {
     const output = await dryRunOutput();
-    expect(output).toContain('-- node <local-path>');
+    expect(output).toContain('-- node ');
     expect(output).not.toContain('/usr/bin/env');
   });
 

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -4,7 +4,6 @@ import {delimiter, join} from 'node:path';
 import {Effect} from 'effect';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 import {captureConsole} from '../../src/effect/console.js';
-import {fromPromise} from '../../src/effect/errors.js';
 import {ApplicationLayer, type ApplicationServices} from '../../src/effect/runtime.js';
 import {resolveMcpClients, runMcpInstall} from '../../src/mcp.js';
 import {parseMcpToolset} from '../../src/mcp_toolset.js';
@@ -97,9 +96,7 @@ describe('MCP agent executable resolution', () => {
     const broken = await codexLauncher("printf '%s\\n' 'missing native binary' >&2\nexit 1");
     process.env.PATH = [join(broken, '..'), '/usr/bin', '/bin'].join(delimiter);
 
-    const resolution = await run(
-      captureConsole(fromPromise('resolve MCP clients', () => resolveMcpClients('codex', 'repair'))),
-    );
+    const resolution = await run(captureConsole(resolveMcpClients('codex', 'repair')));
     expect(resolution.value).toEqual([]);
     expect(resolution.output).toMatch(/codex command.*not working/i);
     await expect(run(runMcpInstall(runtime(), 'codex', {apply: true}))).rejects.toThrow(

--- a/test/unit/memory.recall.test.ts
+++ b/test/unit/memory.recall.test.ts
@@ -24,7 +24,7 @@ vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();
   return {
     ...actual,
-    openVikingCliForMode: vi.fn().mockResolvedValue('/ov'),
+    openVikingCliForMode: vi.fn().mockReturnValue(Effect.succeed('/ov')),
   };
 });
 
@@ -41,12 +41,14 @@ const runtime: RuntimeConfig = {
 
 beforeEach(() => {
   vi.mocked(indexRepair.repairStaleRecallIndex).mockReset();
-  vi.mocked(indexRepair.repairStaleRecallIndex).mockResolvedValue({
-    repairedUris: [],
-    skippedRecentUris: [],
-    warnings: [],
-  });
-  vi.mocked(utils.openVikingCliForMode).mockResolvedValue('/ov');
+  vi.mocked(indexRepair.repairStaleRecallIndex).mockReturnValue(
+    Effect.succeed({
+      repairedUris: [],
+      skippedRecentUris: [],
+      warnings: [],
+    }),
+  );
+  vi.mocked(utils.openVikingCliForMode).mockReturnValue(Effect.succeed('/ov'));
 });
 
 afterEach(() => {
@@ -70,7 +72,7 @@ describe('recall skill catalog intent inference', () => {
 
 describe('runRecall index repair fallback', () => {
   it('continues to search when automatic index repair fails', async () => {
-    vi.mocked(indexRepair.repairStaleRecallIndex).mockRejectedValue(new Error('repair failed'));
+    vi.mocked(indexRepair.repairStaleRecallIndex).mockReturnValue(Effect.fail(new Error('repair failed')));
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     await run(runRecall(runtime, {dryRun: true, query: 'availability check'}));
@@ -94,10 +96,12 @@ describe('runRecall index repair fallback', () => {
 
     try {
       await mkdir(repoRoot);
-      await utils.runCommand('git', ['init'], {cwd: repoRoot});
-      await utils.runCommand('git', ['remote', 'add', 'origin', 'git@github.com:Kashkovsky/threadnote.git'], {
-        cwd: repoRoot,
-      });
+      await run(utils.runCommand('git', ['init'], {cwd: repoRoot}));
+      await run(
+        utils.runCommand('git', ['remote', 'add', 'origin', 'git@github.com:Kashkovsky/threadnote.git'], {
+          cwd: repoRoot,
+        }),
+      );
       process.env.THREADNOTE_CALLER_CWD = repoRoot;
 
       await run(
@@ -145,10 +149,12 @@ describe('runRecall index repair fallback', () => {
 
     try {
       await mkdir(repoRoot);
-      await utils.runCommand('git', ['init'], {cwd: repoRoot});
-      await utils.runCommand('git', ['remote', 'add', 'origin', 'git@github.com:Kashkovsky/threadnote.git'], {
-        cwd: repoRoot,
-      });
+      await run(utils.runCommand('git', ['init'], {cwd: repoRoot}));
+      await run(
+        utils.runCommand('git', ['remote', 'add', 'origin', 'git@github.com:Kashkovsky/threadnote.git'], {
+          cwd: repoRoot,
+        }),
+      );
       await writeFile(
         manifestPath,
         [

--- a/test/unit/memory.shared-replace.test.ts
+++ b/test/unit/memory.shared-replace.test.ts
@@ -15,10 +15,10 @@ vi.mock('../../src/utils.js', async importOriginal => {
   return {
     ...actual,
     maybeRun: vi.fn(),
-    openVikingCliForMode: vi.fn().mockResolvedValue('/ov'),
-    requiredExecutable: vi.fn().mockResolvedValue('git'),
+    openVikingCliForMode: vi.fn().mockReturnValue(Effect.succeed('/ov')),
+    requiredExecutable: vi.fn().mockReturnValue(Effect.succeed('git')),
     runCommand: vi.fn(),
-    sleep: vi.fn().mockResolvedValue(undefined),
+    sleep: vi.fn().mockReturnValue(Effect.void),
   };
 });
 
@@ -66,11 +66,11 @@ describe('remember shared replacement', () => {
   const homes: string[] = [];
 
   beforeEach(() => {
-    vi.mocked(utils.maybeRun).mockImplementation(async (dryRun, executable, args, options) =>
-      dryRun ? undefined : vi.mocked(utils.runCommand)(executable, args, options),
+    vi.mocked(utils.maybeRun).mockImplementation((dryRun, executable, args, options) =>
+      dryRun ? Effect.succeed(undefined) : vi.mocked(utils.runCommand)(executable, args, options),
     );
-    vi.mocked(utils.openVikingCliForMode).mockResolvedValue('/ov');
-    vi.mocked(utils.requiredExecutable).mockResolvedValue('git');
+    vi.mocked(utils.openVikingCliForMode).mockReturnValue(Effect.succeed('/ov'));
+    vi.mocked(utils.requiredExecutable).mockReturnValue(Effect.succeed('git'));
     vi.mocked(utils.runCommand).mockReset();
   });
 
@@ -182,23 +182,23 @@ describe('remember shared replacement', () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     const sharedUri = 'viking://user/test-user/memories/shared/default/durable/projects/mobile-native/auth.md';
-    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+    vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
       if (executable === '/ov' && args[0] === 'stat') {
-        return ok();
+        return Effect.succeed(ok());
       }
       if (executable === '/ov' && args[0] === 'write') {
-        return ok('written');
+        return Effect.succeed(ok('written'));
       }
       if (executable === 'git' && args.includes('add')) {
-        return ok();
+        return Effect.succeed(ok());
       }
       if (executable === 'git' && args.includes('commit')) {
-        return ok('[main abc123] share');
+        return Effect.succeed(ok('[main abc123] share'));
       }
       if (executable === 'git' && args.includes('push')) {
-        return fail('permission denied');
+        return Effect.succeed(fail('permission denied'));
       }
-      return ok();
+      return Effect.succeed(ok());
     });
 
     await expect(

--- a/test/unit/recall.feedback.test.ts
+++ b/test/unit/recall.feedback.test.ts
@@ -1,5 +1,4 @@
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Crypto, Effect, FileSystem, Layer, Path} from 'effect';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {
   aggregateRecallFeedback,
@@ -9,10 +8,7 @@ import {
   type RecallFeedbackEvent,
 } from '../../src/recall/feedback.js';
 import {join, mkdir, mkdtemp, readFile, rm, writeFile} from '../helpers/effect-filesystem.js';
-
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
-const run = <A, E>(effect: Effect.Effect<A, E, Crypto.Crypto | FileSystem.FileSystem | Path.Path>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(TestLayer)));
+import {runEffect as run} from '../helpers/effect-runtime.js';
 
 describe('recall feedback', () => {
   let directory: string;

--- a/test/unit/recall.index.test.ts
+++ b/test/unit/recall.index.test.ts
@@ -1,12 +1,7 @@
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Crypto, Effect, FileSystem, Layer, Path} from 'effect';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {expireRecallIndexValidation, loadRecallIndex} from '../../src/recall/index.js';
 import {join, mkdir, mkdtemp, readFile, rm, stat, symlink, utimes, writeFile} from '../helpers/effect-filesystem.js';
-
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
-const run = <A, E>(effect: Effect.Effect<A, E, Crypto.Crypto | FileSystem.FileSystem | Path.Path>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(TestLayer)));
+import {runEffect as run} from '../helpers/effect-runtime.js';
 
 describe('local recall index', () => {
   let directory: string;

--- a/test/unit/runtime.test.ts
+++ b/test/unit/runtime.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from 'vitest';
-import {withIdentity} from '../../src/runtime.js';
+import {renderJsonTemplate, withIdentity} from '../../src/runtime.js';
+import type {RuntimeConfig} from '../../src/types.js';
 
 const IDENTITY = {account: 'local', agentId: 'threadnote', user: 'denys'} as const;
 
@@ -18,5 +19,27 @@ describe('withIdentity', () => {
   it('never passes --agent-id, which 0.4.x rejects with "Unexpected argument"', () => {
     expect(withIdentity(IDENTITY, ['search', 'q'])).not.toContain('--agent-id');
     expect(withIdentity(IDENTITY, ['search', 'q'])).not.toContain('threadnote');
+  });
+});
+
+describe('renderJsonTemplate', () => {
+  it('escapes Windows paths and identity values as JSON string content', () => {
+    const config: RuntimeConfig = {
+      account: 'local',
+      agentContextHome: 'C:\\Users\\runner\\Threadnote Home',
+      agentId: 'threadnote',
+      host: '127.0.0.1',
+      manifestPath: 'C:\\Users\\runner\\manifest.yaml',
+      openVikingVersion: '0.4.10',
+      port: 1933,
+      user: 'windows-e2e',
+    };
+
+    expect(
+      JSON.parse(renderJsonTemplate('{"workspace":"{{THREADNOTE_HOME}}/data","user":"{{OPENVIKING_USER}}"}', config)),
+    ).toEqual({
+      user: 'windows-e2e',
+      workspace: 'C:\\Users\\runner\\Threadnote Home/data',
+    });
   });
 });

--- a/test/unit/seeding.test.ts
+++ b/test/unit/seeding.test.ts
@@ -306,7 +306,7 @@ describe('init-manifest', () => {
 
     await captureConsole(runInitManifest(config, {path: manifestPath, repo: [newRepo]}));
 
-    const manifest = await readSeedManifest(manifestPath);
+    const manifest = await run(readSeedManifest(manifestPath));
     expect(manifest.projects).toHaveLength(2);
     expect(manifest.projects[0]?.name).toBe('existing-repo');
     expect(manifest.projects[1]?.path).toContain('threadnote-new-repo-');
@@ -329,8 +329,10 @@ describe('init-manifest', () => {
     }
     try {
       await mkdir(repo);
-      await runCommand('git', ['init'], {cwd: repo});
-      await runCommand('git', ['remote', 'add', 'origin', 'git@github.com:Kashkovsky/threadnote.git'], {cwd: repo});
+      await run(runCommand('git', ['init'], {cwd: repo}));
+      await run(
+        runCommand('git', ['remote', 'add', 'origin', 'git@github.com:Kashkovsky/threadnote.git'], {cwd: repo}),
+      );
       const manifestPath = join(contextHome, 'seed-manifest.yaml');
       const config: RuntimeConfig = {
         account: 'local',
@@ -345,7 +347,7 @@ describe('init-manifest', () => {
 
       await captureConsole(runInitManifest(config, {path: manifestPath, repo: [repo]}));
 
-      const manifest = await readSeedManifest(manifestPath);
+      const manifest = await run(readSeedManifest(manifestPath));
       expect(manifest.projects[0]?.name).toBe('threadnote');
       expect(manifest.projects[0]?.uri).toBe('viking://resources/repos/threadnote');
     } finally {

--- a/test/unit/share.admin.test.ts
+++ b/test/unit/share.admin.test.ts
@@ -1,8 +1,7 @@
 import {access, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Effect, Layer} from 'effect';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {publishShareGitChange} from '../../src/share.js';
 import {
@@ -12,23 +11,20 @@ import {
 } from '../../src/effect/share.js';
 import type {CommandResult, ShareRuntime, ShareTeamsFile} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
-const runShareRemove = (...args: Parameters<typeof runShareRemoveEffect>) =>
-  Effect.runPromise(runShareRemoveEffect(...args).pipe(Effect.provide(TestLayer)));
-const runShareRename = (...args: Parameters<typeof runShareRenameEffect>) =>
-  Effect.runPromise(runShareRenameEffect(...args).pipe(Effect.provide(TestLayer)));
-const runShareSetUrl = (...args: Parameters<typeof runShareSetUrlEffect>) =>
-  Effect.runPromise(runShareSetUrlEffect(...args).pipe(Effect.provide(TestLayer)));
+const runShareRemove = (...args: Parameters<typeof runShareRemoveEffect>) => runEffect(runShareRemoveEffect(...args));
+const runShareRename = (...args: Parameters<typeof runShareRenameEffect>) => runEffect(runShareRenameEffect(...args));
+const runShareSetUrl = (...args: Parameters<typeof runShareSetUrlEffect>) => runEffect(runShareSetUrlEffect(...args));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();
   return {
     ...actual,
-    openVikingCliForMode: vi.fn().mockResolvedValue('/ov'),
-    requiredExecutable: vi.fn().mockResolvedValue('git'),
+    openVikingCliForMode: vi.fn().mockReturnValue(Effect.succeed('/ov')),
+    requiredExecutable: vi.fn().mockReturnValue(Effect.succeed('git')),
     runCommand: vi.fn(),
-    sleep: vi.fn().mockResolvedValue(undefined),
+    sleep: vi.fn().mockReturnValue(Effect.void),
   };
 });
 
@@ -76,9 +72,9 @@ describe('share administration', () => {
   const homes: string[] = [];
 
   beforeEach(() => {
-    vi.mocked(utils.openVikingCliForMode).mockResolvedValue('/ov');
-    vi.mocked(utils.requiredExecutable).mockResolvedValue('git');
-    vi.mocked(utils.runCommand).mockImplementation(async () => ok());
+    vi.mocked(utils.openVikingCliForMode).mockReturnValue(Effect.succeed('/ov'));
+    vi.mocked(utils.requiredExecutable).mockReturnValue(Effect.succeed('git'));
+    vi.mocked(utils.runCommand).mockImplementation(() => Effect.succeed(ok()));
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
   });
 
@@ -137,10 +133,12 @@ describe('share administration', () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
 
-    await publishShareGitChange(join(config.agentContextHome, 'share-worktree'), '-dash.md', 'remove dash', {
-      push: false,
-      verb: 'rm',
-    });
+    await runEffect(
+      publishShareGitChange(join(config.agentContextHome, 'share-worktree'), '-dash.md', 'remove dash', {
+        push: false,
+        verb: 'rm',
+      }),
+    );
 
     expect(vi.mocked(utils.runCommand)).toHaveBeenCalledWith(
       'git',

--- a/test/unit/share.artifacts.test.ts
+++ b/test/unit/share.artifacts.test.ts
@@ -1,8 +1,7 @@
 import {mkdtemp, mkdir, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Effect, Layer} from 'effect';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {shareAgentArtifact, shareBundlePack} from '../../src/share.js';
 import {
@@ -12,24 +11,24 @@ import {
 } from '../../src/effect/share.js';
 import type {CommandResult, ShareRuntime} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
 const runShareInstallArtifacts = (...args: Parameters<typeof runShareInstallArtifactsEffect>) =>
-  Effect.runPromise(runShareInstallArtifactsEffect(...args).pipe(Effect.provide(TestLayer)));
+  runEffect(runShareInstallArtifactsEffect(...args));
 const listSharedAgentArtifacts = (...args: Parameters<typeof listSharedAgentArtifactsEffect>) =>
-  Effect.runPromise(listSharedAgentArtifactsEffect(...args).pipe(Effect.provide(TestLayer)));
+  runEffect(listSharedAgentArtifactsEffect(...args));
 const installSharedAgentArtifacts = (...args: Parameters<typeof installSharedAgentArtifactsEffect>) =>
-  Effect.runPromise(installSharedAgentArtifactsEffect(...args).pipe(Effect.provide(TestLayer)));
+  runEffect(installSharedAgentArtifactsEffect(...args));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();
   return {
     ...actual,
     maybeRun: vi.fn(),
-    openVikingCliForMode: vi.fn().mockResolvedValue('/ov'),
-    requiredExecutable: vi.fn().mockResolvedValue('git'),
+    openVikingCliForMode: vi.fn().mockReturnValue(Effect.succeed('/ov')),
+    requiredExecutable: vi.fn().mockReturnValue(Effect.succeed('git')),
     runCommand: vi.fn(),
-    sleep: vi.fn().mockResolvedValue(undefined),
+    sleep: vi.fn().mockReturnValue(Effect.void),
   };
 });
 
@@ -71,20 +70,20 @@ async function makeRuntime(): Promise<ShareRuntime> {
 }
 
 function mockPublishCommands(): void {
-  vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+  vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
     if (executable === '/ov' && args[0] === 'stat') {
-      return fail();
+      return Effect.succeed(fail());
     }
     if (executable === '/ov' && (args[0] === 'mkdir' || args[0] === 'write')) {
-      return ok('ok');
+      return Effect.succeed(ok('ok'));
     }
     if (executable === 'git' && (args.includes('add') || args.includes('commit') || args.includes('push'))) {
-      return ok('ok');
+      return Effect.succeed(ok('ok'));
     }
-    return ok();
+    return Effect.succeed(ok());
   });
-  vi.mocked(utils.maybeRun).mockImplementation(async (dryRun, executable, args, options) =>
-    dryRun ? undefined : vi.mocked(utils.runCommand)(executable, args, options),
+  vi.mocked(utils.maybeRun).mockImplementation((dryRun, executable, args, options) =>
+    dryRun ? Effect.succeed(undefined) : vi.mocked(utils.runCommand)(executable, args, options),
   );
 }
 
@@ -115,7 +114,7 @@ describe('shared agent artifacts', () => {
     await writeFile(sourcePath, '# Reviewer\n\nReview local diffs.\n');
     mockPublishCommands();
 
-    const result = await shareAgentArtifact(config, sourcePath, {});
+    const result = await runEffect(shareAgentArtifact(config, sourcePath, {}));
 
     expect(result.targetUri).toBe(
       'viking://user/test-user/memories/shared/default/agent-artifacts/skills/codex/reviewer/SKILL.md',
@@ -156,7 +155,9 @@ describe('shared agent artifacts', () => {
     await writeFile(join(sharedPath, 'review.md'), 'old command\n');
     mockPublishCommands();
 
-    await expect(shareAgentArtifact(config, sourcePath, {})).rejects.toThrow(/already exists with different content/);
+    await expect(runEffect(shareAgentArtifact(config, sourcePath, {}))).rejects.toThrow(
+      /already exists with different content/,
+    );
     await expect(readFile(join(sharedPath, 'review.md'), 'utf8')).resolves.toBe('old command\n');
   });
 
@@ -166,20 +167,20 @@ describe('shared agent artifacts', () => {
     const sourcePath = join(config.agentContextHome, '.codex', 'skills', 'reviewer', 'SKILL.md');
     await mkdir(join(sourcePath, '..'), {recursive: true});
     await writeFile(sourcePath, '# Reviewer\n');
-    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+    vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
       if (executable === '/ov' && args[0] === 'stat') {
-        return fail();
+        return Effect.succeed(fail());
       }
       if (executable === '/ov' && args[0] === 'mkdir') {
-        return ok('ok');
+        return Effect.succeed(ok('ok'));
       }
       if (executable === '/ov' && args[0] === 'write') {
-        return fail('write failed');
+        return Effect.succeed(fail('write failed'));
       }
-      return ok();
+      return Effect.succeed(ok());
     });
 
-    await expect(shareAgentArtifact(config, sourcePath, {})).rejects.toThrow(/write failed/);
+    await expect(runEffect(shareAgentArtifact(config, sourcePath, {}))).rejects.toThrow(/write failed/);
 
     await expect(
       readFile(
@@ -423,7 +424,7 @@ describe('shared agent artifacts', () => {
     await writeFile(join(skillDir, 'scripts', 'run.ts'), 'export const run = () => 1;\n');
     mockPublishCommands();
 
-    const result = await shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {});
+    const result = await runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {}));
 
     expect(result.targetUri).toBe(
       'viking://user/test-user/memories/shared/default/agent-artifacts/skills/codex/reviewer/SKILL.md',
@@ -462,7 +463,7 @@ describe('shared agent artifacts', () => {
     await writeFile(join(skillDir, 'repos', 'coda', 'CLAUDE.md'), '# nope\n');
     mockPublishCommands();
 
-    await shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {});
+    await runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {}));
 
     const sharedRoot = join(
       config.agentContextHome,
@@ -489,9 +490,9 @@ describe('shared agent artifacts', () => {
     await writeFile(join(skillDir, 'assets', 'logo.png'), png);
     mockPublishCommands();
 
-    await expect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {})).rejects.toThrow(/binary file/);
+    await expect(runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {}))).rejects.toThrow(/binary file/);
 
-    await shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {allowBinary: true});
+    await runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {allowBinary: true}));
     const sharedRoot = join(
       config.agentContextHome,
       'shared',
@@ -514,9 +515,9 @@ describe('shared agent artifacts', () => {
     await writeFile(join(skillDir, 'helper.bin'), secretBlob);
     mockPublishCommands();
 
-    await expect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {allowBinary: true})).rejects.toThrow(
-      /embedded in binary file/,
-    );
+    await expect(
+      runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {allowBinary: true})),
+    ).rejects.toThrow(/embedded in binary file/);
   });
 
   it('scrubs companion files and blocks a leaked credential in a script', async () => {
@@ -528,7 +529,9 @@ describe('shared agent artifacts', () => {
     await writeFile(join(skillDir, 'scripts', 'run.ts'), `const token = "ghp_${'b'.repeat(36)}";\n`);
     mockPublishCommands();
 
-    await expect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {})).rejects.toThrow(/scripts\/run\.ts/);
+    await expect(runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {}))).rejects.toThrow(
+      /scripts\/run\.ts/,
+    );
   });
 
   it('does not materialize bundle companions when the SKILL.md OpenViking write fails', async () => {
@@ -538,20 +541,20 @@ describe('shared agent artifacts', () => {
     await mkdir(join(skillDir, 'scripts'), {recursive: true});
     await writeFile(join(skillDir, 'SKILL.md'), '# Reviewer\n');
     await writeFile(join(skillDir, 'scripts', 'run.ts'), 'export const run = () => 1;\n');
-    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+    vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
       if (executable === '/ov' && args[0] === 'stat') {
-        return fail();
+        return Effect.succeed(fail());
       }
       if (executable === '/ov' && args[0] === 'mkdir') {
-        return ok('ok');
+        return Effect.succeed(ok('ok'));
       }
       if (executable === '/ov' && args[0] === 'write') {
-        return fail('write failed');
+        return Effect.succeed(fail('write failed'));
       }
-      return ok();
+      return Effect.succeed(ok());
     });
 
-    await expect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {})).rejects.toThrow(/write failed/);
+    await expect(runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {}))).rejects.toThrow(/write failed/);
     const sharedRoot = join(
       config.agentContextHome,
       'shared',
@@ -693,7 +696,7 @@ describe('shared agent artifacts', () => {
     const repo = await makeReviewerManifestRepo();
     mockPublishCommands();
 
-    const result = await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+    const result = await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
 
     expect(result.targetUri).toBe(
       'viking://user/test-user/memories/shared/default/agent-artifacts/packs/claude/reviewer/reviewer.pack.md',
@@ -726,7 +729,7 @@ describe('shared agent artifacts', () => {
     await writeFile(join(repo, 'scripts', 'leak.ts'), 'const home = "/Users/someone/secret/notes";\n');
     mockPublishCommands();
 
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
       /scripts\/leak\.ts/,
     );
   });
@@ -918,7 +921,7 @@ describe('shared agent artifacts', () => {
     );
     mockPublishCommands();
 
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
       /absolute repo-root path/,
     );
   });
@@ -930,7 +933,9 @@ describe('shared agent artifacts', () => {
     await writeFile(join(repo, 'scripts', 'tok.ts'), 'const x = "${THREADNOTE_PACK_ROOT}/y";\n');
     mockPublishCommands();
 
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(/reserved/);
+    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
+      /reserved/,
+    );
   });
 
   it('rejects a pack manifest include entry that escapes the pack root', async () => {
@@ -949,7 +954,7 @@ describe('shared agent artifacts', () => {
     );
     mockPublishCommands();
 
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
       /within the pack root/,
     );
   });
@@ -1051,7 +1056,7 @@ describe('shared agent artifacts', () => {
     await writeFile(join(repo, 'scripts', 'deploy.ts'), 'const key = "/home/deploy/.ssh/id_rsa";\n');
     mockPublishCommands();
 
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
       /scripts\/deploy\.ts/,
     );
   });
@@ -1063,9 +1068,9 @@ describe('shared agent artifacts', () => {
     await writeFile(join(repo, 'scripts', 'leak.ts'), 'const home = "/Users/someone/secret/x";\n');
     mockPublishCommands();
 
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {redact: true})).rejects.toThrow(
-      /scripts\/leak\.ts/,
-    );
+    await expect(
+      runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {redact: true})),
+    ).rejects.toThrow(/scripts\/leak\.ts/);
   });
 
   it('flags a locally-edited member removed upstream as a conflict, not a silent update', async () => {
@@ -1118,20 +1123,22 @@ describe('shared agent artifacts', () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     const repo = await makeReviewerManifestRepo();
-    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+    vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
       if (executable === '/ov' && args[0] === 'stat') {
-        return fail();
+        return Effect.succeed(fail());
       }
       if (executable === '/ov' && args[0] === 'mkdir') {
-        return ok('ok');
+        return Effect.succeed(ok('ok'));
       }
       if (executable === '/ov' && args[0] === 'write') {
-        return fail('write failed');
+        return Effect.succeed(fail('write failed'));
       }
-      return ok();
+      return Effect.succeed(ok());
     });
 
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(/write failed/);
+    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
+      /write failed/,
+    );
     const packRoot = join(
       config.agentContextHome,
       'shared',
@@ -1163,7 +1170,7 @@ describe('shared agent artifacts', () => {
     );
     mockPublishCommands();
 
-    await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+    await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
 
     const packRoot = join(
       config.agentContextHome,
@@ -1228,7 +1235,9 @@ describe('shared agent artifacts', () => {
     await writeFile(join(repo, 'scripts', 'log.ts'), `const dir = "${repo}-logs/run";\n`);
     mockPublishCommands();
 
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(/scripts\/log\.ts/);
+    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
+      /scripts\/log\.ts/,
+    );
   });
 
   it('accepts a skill entry given as a path to SKILL.md', async () => {
@@ -1248,7 +1257,7 @@ describe('shared agent artifacts', () => {
     );
     mockPublishCommands();
 
-    const result = await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+    const result = await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
     expect(result.targetUri).toContain('packs/claude/reviewer/reviewer.pack.md');
   });
 
@@ -1296,7 +1305,7 @@ describe('shared agent artifacts', () => {
     await writeFile(join(repo, 'scripts', 'deploy.ts'), 'const dir = "/opt/work/secrets/run";\n');
     mockPublishCommands();
 
-    const result = await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+    const result = await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
     expect(result.messages.join('\n')).toContain('/opt/work/secrets/run');
     expect(result.messages.join('\n')).toMatch(/machine-local/);
   });
@@ -1306,17 +1315,17 @@ describe('shared agent artifacts', () => {
     homes.push(config.agentContextHome);
     const repo = await makeReviewerManifestRepo();
     mockPublishCommands();
-    await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+    await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
 
     await writeFile(
       join(repo, 'scripts', 'vcs.ts'),
       `const v = 2;\nconst here = "${repo}/scripts";\nimport '../lib/types';\n`,
     );
     // Differing content must be refused without --force, then replace cleanly with it.
-    await expect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {})).rejects.toThrow(
+    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
       /already exists with different content/,
     );
-    await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {force: true});
+    await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {force: true}));
 
     const packRoot = join(
       config.agentContextHome,
@@ -1387,7 +1396,7 @@ describe('shared agent artifacts', () => {
     await writeFile(join(repo, 'scripts', 'opt.ts'), 'const d = "/opt/acme/reviewer";\n');
     mockPublishCommands();
 
-    await shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {});
+    await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
 
     const packRoot = join(
       config.agentContextHome,

--- a/test/unit/share.changes.test.ts
+++ b/test/unit/share.changes.test.ts
@@ -4,7 +4,10 @@ import {dirname, join} from 'node:path';
 import {describe, expect, it} from 'vitest';
 import {isResourceBusyFailure, isTransientOvFailure, listChangedFiles, mergeChanges} from '../../src/share.js';
 import type {ChangedFile} from '../../src/share.js';
-import {runCommand} from '../../src/utils.js';
+import {runCommand as runCommandEffect} from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const runCommand = (...args: Parameters<typeof runCommandEffect>) => runEffect(runCommandEffect(...args));
 
 const GIT_ENV_KEYS = [
   'GIT_DIR',
@@ -123,7 +126,7 @@ describe('listChangedFiles', () => {
       await git(['commit', '-m', 'add symlink memory'], repo);
       const afterRev = await gitOutput(['rev-parse', 'HEAD'], repo);
 
-      const changes = await listChangedFiles(repo, beforeRev, afterRev);
+      const changes = await runEffect(listChangedFiles(repo, beforeRev, afterRev));
 
       expect(changes).not.toContainEqual(
         expect.objectContaining({relativePath: 'durable/projects/threadnote/leak.md'}),

--- a/test/unit/share.publish.test.ts
+++ b/test/unit/share.publish.test.ts
@@ -1,26 +1,25 @@
 import {mkdtemp, mkdir, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {NodeCrypto, NodeFileSystem, NodePath} from '@effect/platform-node';
-import {Effect, Layer} from 'effect';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {runSharePublish as runSharePublishEffect} from '../../src/effect/share.js';
 import type {CommandResult, ShareRuntime} from '../../src/types.js';
 import * as utils from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
-const TestLayer = Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer);
 const runSharePublish = (...args: Parameters<typeof runSharePublishEffect>) =>
-  Effect.runPromise(runSharePublishEffect(...args).pipe(Effect.provide(TestLayer)));
+  runEffect(runSharePublishEffect(...args));
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();
   return {
     ...actual,
     maybeRun: vi.fn(),
-    openVikingCliForMode: vi.fn().mockResolvedValue('/ov'),
-    requiredExecutable: vi.fn().mockResolvedValue('git'),
+    openVikingCliForMode: vi.fn().mockReturnValue(Effect.succeed('/ov')),
+    requiredExecutable: vi.fn().mockReturnValue(Effect.succeed('git')),
     runCommand: vi.fn(),
-    sleep: vi.fn().mockResolvedValue(undefined),
+    sleep: vi.fn().mockReturnValue(Effect.void),
   };
 });
 
@@ -62,33 +61,33 @@ async function makeRuntime(): Promise<ShareRuntime> {
 }
 
 function mockPublishCommands(sourceUri: string, targetUri: string, pushResult: CommandResult): void {
-  vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+  vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
     const command = args[0];
     if (executable === '/ov' && command === 'read') {
-      return ok('MEMORY\nkind: durable\nstatus: active\nproject: foo\ntopic: bar\n\nBody\n');
+      return Effect.succeed(ok('MEMORY\nkind: durable\nstatus: active\nproject: foo\ntopic: bar\n\nBody\n'));
     }
     if (executable === '/ov' && command === 'stat') {
-      return args[1] === targetUri ? fail('[NOT_FOUND]') : ok();
+      return Effect.succeed(args[1] === targetUri ? fail('[NOT_FOUND]') : ok());
     }
     if (executable === '/ov' && command === 'write') {
-      return ok('written');
+      return Effect.succeed(ok('written'));
     }
     if (executable === '/ov' && command === 'rm' && args[1] === sourceUri) {
-      return ok('removed');
+      return Effect.succeed(ok('removed'));
     }
     if (executable === 'git' && args.includes('add')) {
-      return ok();
+      return Effect.succeed(ok());
     }
     if (executable === 'git' && args.includes('commit')) {
-      return ok('[main abc123] share');
+      return Effect.succeed(ok('[main abc123] share'));
     }
     if (executable === 'git' && args.includes('push')) {
-      return pushResult;
+      return Effect.succeed(pushResult);
     }
-    return ok();
+    return Effect.succeed(ok());
   });
-  vi.mocked(utils.maybeRun).mockImplementation(async (dryRun, executable, args, options) =>
-    dryRun ? undefined : vi.mocked(utils.runCommand)(executable, args, options),
+  vi.mocked(utils.maybeRun).mockImplementation((dryRun, executable, args, options) =>
+    dryRun ? Effect.succeed(undefined) : vi.mocked(utils.runCommand)(executable, args, options),
   );
 }
 

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -3,6 +3,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {distillTrace} from '../../src/trace.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 describe('distillTrace', () => {
   let dir: string;
@@ -34,7 +35,7 @@ describe('distillTrace', () => {
       JSON.stringify({type: 'user', message: {role: 'user', content: [{type: 'text', text: 'now run the tests'}]}}),
     ].join('\n');
     await writeFile(path, lines, 'utf8');
-    const summary = await distillTrace(path);
+    const summary = await runEffect(distillTrace(path));
     expect(summary).toContain('4 transcript events');
     expect(summary).toContain('tools used: Edit, Bash');
     expect(summary).toContain('recent intents:');
@@ -43,13 +44,13 @@ describe('distillTrace', () => {
   });
 
   it('returns undefined for a missing transcript', async () => {
-    expect(await distillTrace(join(dir, 'missing.jsonl'))).toBeUndefined();
+    expect(await runEffect(distillTrace(join(dir, 'missing.jsonl')))).toBeUndefined();
   });
 
   it('returns undefined when no line parses as an event', async () => {
     const path = join(dir, 'garbage.jsonl');
     await writeFile(path, 'garbage\nmore garbage\n', 'utf8');
-    expect(await distillTrace(path)).toBeUndefined();
+    expect(await runEffect(distillTrace(path))).toBeUndefined();
   });
 
   it('summarizes large transcripts from the capped tail', async () => {
@@ -63,7 +64,7 @@ describe('distillTrace', () => {
       'utf8',
     );
 
-    const summary = await distillTrace(path);
+    const summary = await runEffect(distillTrace(path));
     expect(summary).toContain('tail intent');
     expect(summary).not.toContain('old intent');
   });
@@ -79,6 +80,6 @@ describe('distillTrace', () => {
       'utf8',
     );
 
-    expect(await distillTrace(path)).toBeUndefined();
+    expect(await runEffect(distillTrace(path))).toBeUndefined();
   });
 });

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -1,7 +1,7 @@
-import {mkdtemp, rm} from 'node:fs/promises';
+import {chmod, mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {Effect} from 'effect';
+import {Effect, Layer} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import type {CommandResult, RuntimeConfig} from '../../src/types.js';
 
@@ -27,11 +27,13 @@ import {
   resolveUpdateRegistry,
   runPostUpdate,
   runUpdate,
+  runtimeThreadnoteBinPath,
 } from '../../src/update.js';
 import {runVersion} from '../../src/version_command.js';
 import {captureConsole} from '../../src/effect/console.js';
 import * as utils from '../../src/utils.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {CommandExecutor} from '../../src/effect/command.js';
 
 const runTestEffect = <A, E>(effect: Effect.Effect<A, E, never>) => Effect.runPromise(effect);
 
@@ -154,7 +156,7 @@ describe('runUpdate', () => {
     vi.mocked(utils.isExecutable).mockResolvedValue(true);
     vi.mocked(utils.maybeRun).mockResolvedValue(ok());
     vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
-      if (executable === 'npm' && args[0] === 'prefix') {
+      if (executable.endsWith('/npm') && args[0] === 'prefix') {
         return ok('/tmp/npm-global\n');
       }
       return ok();
@@ -182,19 +184,80 @@ describe('runUpdate', () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     const fetch = mockRegistryVersions('99.0.0', '100.0.0-beta.1');
+    const prefix = join(config.agentContextHome, 'npm-global');
+    const threadnote = join(prefix, 'bin', 'threadnote');
+    await mkdir(join(prefix, 'bin'), {recursive: true});
+    await writeFile(threadnote, '#!/bin/sh\n');
+    await chmod(threadnote, 0o755);
+    const commandLayer = Layer.succeed(
+      CommandExecutor,
+      CommandExecutor.of({
+        execute: (_executable, args) => Effect.succeed(args[0] === 'prefix' ? ok(`${prefix}\n`) : ok()),
+      }),
+    );
 
-    await runTestEffect(runUpdate(config, {postUpdate: false, runtime: 'npm'}).pipe(Effect.provide(ApplicationLayer)));
+    await runTestEffect(
+      runUpdate(config, {postUpdate: false, runtime: 'npm'}).pipe(
+        Effect.provide(commandLayer),
+        Effect.provide(ApplicationLayer),
+      ),
+    );
 
     expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/latest'))).toBe(true);
     expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(
-      'npm',
+      '/usr/bin/npm',
       expect.arrayContaining(['install', '--global', 'threadnote@latest']),
     );
-    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith('/tmp/npm-global/bin/threadnote', [
-      'repair',
-      '--no-post-update',
-    ]);
+    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(threadnote, ['repair', '--no-post-update']);
     expect(vi.mocked(utils.maybeRun)).not.toHaveBeenCalled();
+  });
+
+  it('runs Deno directly with the registry in its environment', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    mockRegistryVersions('99.0.0', '100.0.0-beta.1');
+    const deno = 'C:\\Program Files\\Deno\\deno.exe';
+    const originalDenoInstallRoot = process.env.DENO_INSTALL_ROOT;
+    const originalDenoInstall = process.env.DENO_INSTALL;
+    const denoInstall = join(config.agentContextHome, 'deno-root');
+    const denoBin = join(denoInstall, 'bin');
+    const threadnote = runtimeThreadnoteBinPath('deno', denoBin);
+    await mkdir(denoBin, {recursive: true});
+    await writeFile(threadnote, '#!/bin/sh\n');
+    await chmod(threadnote, 0o755);
+    process.env.DENO_INSTALL_ROOT = denoInstall;
+    delete process.env.DENO_INSTALL;
+    vi.mocked(utils.findExecutable).mockImplementation(async commands => {
+      if (commands.includes('deno')) {
+        return deno;
+      }
+      return undefined;
+    });
+
+    try {
+      await runTestEffect(
+        runUpdate(config, {postUpdate: false, runtime: 'deno'}).pipe(Effect.provide(ApplicationLayer)),
+      );
+    } finally {
+      if (originalDenoInstallRoot === undefined) {
+        delete process.env.DENO_INSTALL_ROOT;
+      } else {
+        process.env.DENO_INSTALL_ROOT = originalDenoInstallRoot;
+      }
+      if (originalDenoInstall === undefined) {
+        delete process.env.DENO_INSTALL;
+      } else {
+        process.env.DENO_INSTALL = originalDenoInstall;
+      }
+    }
+
+    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(
+      deno,
+      expect.arrayContaining(['install', '--global', 'npm:threadnote@latest']),
+      {env: expect.objectContaining({NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/'})},
+    );
+    expect(vi.mocked(utils.runInteractive)).not.toHaveBeenCalledWith('env', expect.any(Array), expect.anything());
+    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(threadnote, ['repair', '--no-post-update']);
   });
 
   it('updates to the beta dist-tag when --beta is requested', async () => {
@@ -211,7 +274,7 @@ describe('runUpdate', () => {
     expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/beta'))).toBe(true);
     expect(vi.mocked(utils.maybeRun)).toHaveBeenCalledWith(
       true,
-      'npm',
+      '/usr/bin/npm',
       expect.arrayContaining(['install', '--global', 'threadnote@beta']),
     );
   });
@@ -265,7 +328,7 @@ describe('runUpdate', () => {
     expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/beta'))).toBe(true);
     expect(vi.mocked(utils.maybeRun)).toHaveBeenCalledWith(
       true,
-      'npm',
+      '/usr/bin/npm',
       expect.arrayContaining(['install', '--global', 'threadnote@beta']),
     );
   });

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -1,7 +1,7 @@
 import {chmod, mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {Effect, Layer} from 'effect';
+import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import type {CommandResult, RuntimeConfig} from '../../src/types.js';
 
@@ -23,7 +23,7 @@ vi.mock('../../src/utils.js', async importOriginal => {
 
 import {
   parseUpdateRuntime,
-  readOpenVikingCliVersion,
+  readOpenVikingCliVersion as readOpenVikingCliVersionEffect,
   resolveUpdateRegistry,
   runPostUpdate,
   runUpdate,
@@ -34,22 +34,24 @@ import {captureConsole} from '../../src/effect/console.js';
 import * as utils from '../../src/utils.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {CommandExecutor} from '../../src/effect/command.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 const runTestEffect = <A, E>(effect: Effect.Effect<A, E, never>) => Effect.runPromise(effect);
+const readOpenVikingCliVersion = (ov: string) => runEffect(readOpenVikingCliVersionEffect(ov));
 
 const ok = (stdout = ''): CommandResult => ({exitCode: 0, stdout, stderr: ''});
 
 describe('readOpenVikingCliVersion', () => {
   it('uses the server-independent CLI version flag', async () => {
-    vi.mocked(utils.runCommand).mockResolvedValueOnce(ok('openviking 0.4.10\n'));
+    vi.mocked(utils.runCommand).mockReturnValueOnce(Effect.succeed(ok('openviking 0.4.10\n')));
 
     await expect(readOpenVikingCliVersion('/ov')).resolves.toBe('0.4.10');
     expect(utils.runCommand).toHaveBeenCalledWith('/ov', ['--version'], {allowFailure: true});
   });
 
   it('does not mistake OpenViking setup guidance for a version', async () => {
-    vi.mocked(utils.runCommand).mockResolvedValueOnce(
-      ok('OpenViking needs a display language before running commands.\n'),
+    vi.mocked(utils.runCommand).mockReturnValueOnce(
+      Effect.succeed(ok('OpenViking needs a display language before running commands.\n')),
     );
 
     await expect(readOpenVikingCliVersion('/ov')).resolves.toBeUndefined();
@@ -101,12 +103,12 @@ describe('parseUpdateRuntime', () => {
     vi.mocked(utils.runCommand).mockReset();
     vi.mocked(utils.runInteractive).mockReset();
     vi.mocked(utils.sleep).mockReset();
-    vi.mocked(utils.currentPackageVersion).mockResolvedValue('2.0.4');
-    vi.mocked(utils.maybeRun).mockResolvedValue(ok());
-    vi.mocked(utils.findOpenVikingCli).mockResolvedValue(undefined);
-    vi.mocked(utils.runCommand).mockResolvedValue(ok());
-    vi.mocked(utils.runInteractive).mockResolvedValue(0);
-    vi.mocked(utils.sleep).mockResolvedValue(undefined);
+    vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed('2.0.4'));
+    vi.mocked(utils.maybeRun).mockReturnValue(Effect.succeed(ok()));
+    vi.mocked(utils.findOpenVikingCli).mockReturnValue(Effect.succeed(undefined));
+    vi.mocked(utils.runCommand).mockReturnValue(Effect.succeed(ok()));
+    vi.mocked(utils.runInteractive).mockReturnValue(Effect.succeed(0));
+    vi.mocked(utils.sleep).mockReturnValue(Effect.void);
   });
 
   afterEach(() => {
@@ -142,27 +144,27 @@ describe('runUpdate', () => {
     vi.mocked(utils.runCommand).mockReset();
     vi.mocked(utils.runInteractive).mockReset();
     vi.mocked(utils.sleep).mockReset();
-    vi.mocked(utils.currentPackageVersion).mockResolvedValue('2.0.4');
-    vi.mocked(utils.findExecutable).mockImplementation(async commands => {
+    vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed('2.0.4'));
+    vi.mocked(utils.findExecutable).mockImplementation(commands => {
       if (commands.includes('npm')) {
-        return '/usr/bin/npm';
+        return Effect.succeed('/usr/bin/npm');
       }
       if (commands.includes('threadnote')) {
-        return '/usr/local/bin/threadnote';
+        return Effect.succeed('/usr/local/bin/threadnote');
       }
-      return undefined;
+      return Effect.succeed(undefined);
     });
-    vi.mocked(utils.findOpenVikingCli).mockResolvedValue(undefined);
-    vi.mocked(utils.isExecutable).mockResolvedValue(true);
-    vi.mocked(utils.maybeRun).mockResolvedValue(ok());
-    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+    vi.mocked(utils.findOpenVikingCli).mockReturnValue(Effect.succeed(undefined));
+    vi.mocked(utils.isExecutable).mockReturnValue(Effect.succeed(true));
+    vi.mocked(utils.maybeRun).mockReturnValue(Effect.succeed(ok()));
+    vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
       if (executable.endsWith('/npm') && args[0] === 'prefix') {
-        return ok('/tmp/npm-global\n');
+        return Effect.succeed(ok('/tmp/npm-global\n'));
       }
-      return ok();
+      return Effect.succeed(ok());
     });
-    vi.mocked(utils.runInteractive).mockResolvedValue(0);
-    vi.mocked(utils.sleep).mockResolvedValue(undefined);
+    vi.mocked(utils.runInteractive).mockReturnValue(Effect.succeed(0));
+    vi.mocked(utils.sleep).mockReturnValue(Effect.void);
   });
 
   afterEach(async () => {
@@ -189,26 +191,26 @@ describe('runUpdate', () => {
     await mkdir(join(prefix, 'bin'), {recursive: true});
     await writeFile(threadnote, '#!/bin/sh\n');
     await chmod(threadnote, 0o755);
-    const commandLayer = Layer.succeed(
-      CommandExecutor,
-      CommandExecutor.of({
-        execute: (_executable, args) => Effect.succeed(args[0] === 'prefix' ? ok(`${prefix}\n`) : ok()),
-      }),
+    const executeStreaming = vi.fn(
+      (_executable: string, _args: readonly string[], _options?: {readonly env?: NodeJS.ProcessEnv}) =>
+        Effect.succeed(ok()),
     );
+    const executor = CommandExecutor.of({
+      execute: (_executable, args) => Effect.succeed(args[0] === 'prefix' ? ok(`${prefix}\n`) : ok()),
+      executeStreaming,
+    });
 
-    await runTestEffect(
-      runUpdate(config, {postUpdate: false, runtime: 'npm'}).pipe(
-        Effect.provide(commandLayer),
-        Effect.provide(ApplicationLayer),
-      ),
+    await runEffect(
+      runUpdate(config, {postUpdate: false, runtime: 'npm'}).pipe(Effect.provideService(CommandExecutor, executor)),
     );
 
     expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/latest'))).toBe(true);
-    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(
+    expect(executeStreaming).toHaveBeenCalledWith(
       '/usr/bin/npm',
       expect.arrayContaining(['install', '--global', 'threadnote@latest']),
+      {},
     );
-    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(threadnote, ['repair', '--no-post-update']);
+    expect(executeStreaming).toHaveBeenCalledWith(threadnote, ['repair', '--no-post-update'], {});
     expect(vi.mocked(utils.maybeRun)).not.toHaveBeenCalled();
   });
 
@@ -221,22 +223,31 @@ describe('runUpdate', () => {
     const originalDenoInstall = process.env.DENO_INSTALL;
     const denoInstall = join(config.agentContextHome, 'deno-root');
     const denoBin = join(denoInstall, 'bin');
-    const threadnote = runtimeThreadnoteBinPath('deno', denoBin);
+    const threadnote = runtimeThreadnoteBinPath('deno', denoBin, process.platform);
     await mkdir(denoBin, {recursive: true});
     await writeFile(threadnote, '#!/bin/sh\n');
     await chmod(threadnote, 0o755);
     process.env.DENO_INSTALL_ROOT = denoInstall;
     delete process.env.DENO_INSTALL;
-    vi.mocked(utils.findExecutable).mockImplementation(async commands => {
+    vi.mocked(utils.findExecutable).mockImplementation(commands => {
       if (commands.includes('deno')) {
-        return deno;
+        return Effect.succeed(deno);
       }
-      return undefined;
+      return Effect.succeed(undefined);
+    });
+
+    const executeStreaming = vi.fn(
+      (_executable: string, _args: readonly string[], _options?: {readonly env?: NodeJS.ProcessEnv}) =>
+        Effect.succeed(ok()),
+    );
+    const executor = CommandExecutor.of({
+      execute: () => Effect.succeed(ok()),
+      executeStreaming,
     });
 
     try {
-      await runTestEffect(
-        runUpdate(config, {postUpdate: false, runtime: 'deno'}).pipe(Effect.provide(ApplicationLayer)),
+      await runEffect(
+        runUpdate(config, {postUpdate: false, runtime: 'deno'}).pipe(Effect.provideService(CommandExecutor, executor)),
       );
     } finally {
       if (originalDenoInstallRoot === undefined) {
@@ -251,13 +262,13 @@ describe('runUpdate', () => {
       }
     }
 
-    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(
+    expect(executeStreaming).toHaveBeenCalledWith(
       deno,
       expect.arrayContaining(['install', '--global', 'npm:threadnote@latest']),
       {env: expect.objectContaining({NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/'})},
     );
-    expect(vi.mocked(utils.runInteractive)).not.toHaveBeenCalledWith('env', expect.any(Array), expect.anything());
-    expect(vi.mocked(utils.runInteractive)).toHaveBeenCalledWith(threadnote, ['repair', '--no-post-update']);
+    expect(executeStreaming).not.toHaveBeenCalledWith('env', expect.any(Array), expect.anything());
+    expect(executeStreaming).toHaveBeenCalledWith(threadnote, ['repair', '--no-post-update'], {});
   });
 
   it('updates to the beta dist-tag when --beta is requested', async () => {
@@ -265,18 +276,12 @@ describe('runUpdate', () => {
     homes.push(config.agentContextHome);
     const fetch = mockRegistryVersions('2.0.4', '3.0.0-beta.1');
 
-    await runTestEffect(
-      runUpdate(config, {beta: true, dryRun: true, repair: false, runtime: 'npm'}).pipe(
-        Effect.provide(ApplicationLayer),
-      ),
+    const result = await runEffect(
+      captureConsole(runUpdate(config, {beta: true, dryRun: true, repair: false, runtime: 'npm'})),
     );
 
     expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/beta'))).toBe(true);
-    expect(vi.mocked(utils.maybeRun)).toHaveBeenCalledWith(
-      true,
-      '/usr/bin/npm',
-      expect.arrayContaining(['install', '--global', 'threadnote@beta']),
-    );
+    expect(result.output).toContain('threadnote@beta');
   });
 
   it('reports an unpublished beta channel without attempting an update', async () => {
@@ -318,19 +323,13 @@ describe('runUpdate', () => {
   it('keeps an installed beta on the beta channel without another flag', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
-    vi.mocked(utils.currentPackageVersion).mockResolvedValue('3.0.0-beta.1');
+    vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed('3.0.0-beta.1'));
     const fetch = mockRegistryVersions('2.0.4', '3.0.0-beta.2');
 
-    await runTestEffect(
-      runUpdate(config, {dryRun: true, repair: false, runtime: 'npm'}).pipe(Effect.provide(ApplicationLayer)),
-    );
+    const result = await runEffect(captureConsole(runUpdate(config, {dryRun: true, repair: false, runtime: 'npm'})));
 
     expect(fetch.mock.calls.some(([url]) => String(url).endsWith('/threadnote/beta'))).toBe(true);
-    expect(vi.mocked(utils.maybeRun)).toHaveBeenCalledWith(
-      true,
-      '/usr/bin/npm',
-      expect.arrayContaining(['install', '--global', 'threadnote@beta']),
-    );
+    expect(result.output).toContain('threadnote@beta');
   });
 
   it('shows beta versions in version output only for an installed beta', async () => {
@@ -344,7 +343,7 @@ describe('runUpdate', () => {
     expect(stable.output).toContain('Latest version');
     expect(stable.output).not.toContain('3.0.0-beta.2');
 
-    vi.mocked(utils.currentPackageVersion).mockResolvedValue('3.0.0-beta.1');
+    vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed('3.0.0-beta.1'));
     const betaFetch = mockRegistryVersions('2.0.4', '3.0.0-beta.2');
     const beta = await runTestEffect(captureConsole(runVersion(config, {}).pipe(Effect.provide(ApplicationLayer))));
 
@@ -354,16 +353,18 @@ describe('runUpdate', () => {
   });
 
   it('rejects custom npm registries unless explicitly allowed', () => {
-    expect(() => resolveUpdateRegistry('https://registry.example.com/', false)).toThrow(/Refusing custom npm registry/);
-    expect(resolveUpdateRegistry('https://registry.example.com/', true)).toBe('https://registry.example.com/');
+    expect(() => resolveUpdateRegistry('https://registry.example.com/', false, {})).toThrow(
+      /Refusing custom npm registry/,
+    );
+    expect(resolveUpdateRegistry('https://registry.example.com/', true, {})).toBe('https://registry.example.com/');
   });
 
   it('does not trust THREADNOTE_NPM_REGISTRY without explicit opt-in', () => {
     process.env.THREADNOTE_NPM_REGISTRY = 'https://registry.example.com/';
-    expect(() => resolveUpdateRegistry(undefined, false)).toThrow(/Refusing custom npm registry/);
+    expect(() => resolveUpdateRegistry(undefined, false, process.env)).toThrow(/Refusing custom npm registry/);
 
     process.env.THREADNOTE_ALLOW_UNTRUSTED_NPM_REGISTRY = '1';
-    expect(resolveUpdateRegistry(undefined, false)).toBe('https://registry.example.com/');
+    expect(resolveUpdateRegistry(undefined, false, process.env)).toBe('https://registry.example.com/');
   });
 });
 
@@ -380,23 +381,23 @@ describe('runPostUpdate', () => {
     vi.mocked(utils.runCommand).mockReset();
     vi.mocked(utils.runInteractive).mockReset();
     vi.mocked(utils.sleep).mockReset();
-    vi.mocked(utils.findExecutable).mockImplementation(async commands => {
+    vi.mocked(utils.findExecutable).mockImplementation(commands => {
       if (commands.includes('threadnote')) {
-        return '/threadnote';
+        return Effect.succeed('/threadnote');
       }
-      return undefined;
+      return Effect.succeed(undefined);
     });
-    vi.mocked(utils.findOpenVikingCli).mockResolvedValue('/ov');
-    vi.mocked(utils.isTcpPortOpen).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
-    vi.mocked(utils.maybeRun).mockResolvedValue(ok());
-    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+    vi.mocked(utils.findOpenVikingCli).mockReturnValue(Effect.succeed('/ov'));
+    vi.mocked(utils.isTcpPortOpen).mockReturnValue(Effect.succeed(false));
+    vi.mocked(utils.maybeRun).mockReturnValue(Effect.succeed(ok()));
+    vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
       if (executable === '/ov' && args[0] === '--version') {
-        return ok('openviking 0.3.23\n');
+        return Effect.succeed(ok('openviking 0.3.23\n'));
       }
-      return ok();
+      return Effect.succeed(ok());
     });
-    vi.mocked(utils.runInteractive).mockResolvedValue(0);
-    vi.mocked(utils.sleep).mockResolvedValue(undefined);
+    vi.mocked(utils.runInteractive).mockReturnValue(Effect.succeed(0));
+    vi.mocked(utils.sleep).mockReturnValue(Effect.void);
     process.argv = [process.argv[0] ?? 'node', '/threadnote'];
   });
 
@@ -414,33 +415,41 @@ describe('runPostUpdate', () => {
       vi.fn(async () => new Response('healthy')),
     );
 
-    await runTestEffect(
-      runPostUpdate(config, {fromVersion: '1.1.0', toVersion: '1.1.0'}).pipe(Effect.provide(ApplicationLayer)),
+    const executeStreaming = vi.fn(
+      (_executable: string, _args: readonly string[], _options?: {readonly env?: NodeJS.ProcessEnv}) =>
+        Effect.succeed(ok()),
+    );
+    const executor = CommandExecutor.of({
+      execute: () => Effect.succeed(ok()),
+      executeStreaming,
+    });
+    await runEffect(
+      runPostUpdate(config, {fromVersion: '1.1.0', toVersion: '1.1.0'}).pipe(
+        Effect.provideService(CommandExecutor, executor),
+      ),
     );
 
-    const stopCall = vi.mocked(utils.runInteractive).mock.calls.find(call => call[1][0] === 'stop');
-    const startCall = vi.mocked(utils.runInteractive).mock.calls.find(call => call[1][0] === 'start');
-    const installCall = vi.mocked(utils.runInteractive).mock.calls.find(call => call[1][0] === 'install');
+    const stopCall = executeStreaming.mock.calls.find(call => call[1][0] === 'stop');
+    const startCall = executeStreaming.mock.calls.find(call => call[1][0] === 'start');
+    const installCall = executeStreaming.mock.calls.find(call => call[1][0] === 'install');
 
     expect(installCall?.[1]).toEqual(['install', '--force', '--no-start']);
     expect(stopCall).toBeDefined();
     expect(startCall).toBeDefined();
     expect(vi.mocked(utils.isTcpPortOpen)).toHaveBeenCalledWith('127.0.0.1', 1933, 300);
     expect(vi.mocked(utils.isTcpPortOpen).mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(utils.runInteractive).mock.invocationCallOrder[
-        vi.mocked(utils.runInteractive).mock.calls.findIndex(call => call[1][0] === 'start')
-      ],
+      executeStreaming.mock.invocationCallOrder[executeStreaming.mock.calls.findIndex(call => call[1][0] === 'start')],
     );
   });
 
   it('does not run the obsolete OpenViking semantic-queue patch after the 1.4.4 update', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
-    vi.mocked(utils.runCommand).mockImplementation(async (executable, args) => {
+    vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
       if (executable === '/ov' && args[0] === '--version') {
-        return ok('openviking 0.4.7\n');
+        return Effect.succeed(ok('openviking 0.4.7\n'));
       }
-      return ok();
+      return Effect.succeed(ok());
     });
 
     await runTestEffect(

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -1,6 +1,6 @@
 import {chmod, mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {join} from 'node:path';
+import {dirname, join} from 'node:path';
 import {Effect} from 'effect';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import type {CommandResult, RuntimeConfig} from '../../src/types.js';
@@ -187,8 +187,8 @@ describe('runUpdate', () => {
     homes.push(config.agentContextHome);
     const fetch = mockRegistryVersions('99.0.0', '100.0.0-beta.1');
     const prefix = join(config.agentContextHome, 'npm-global');
-    const threadnote = join(prefix, 'bin', 'threadnote');
-    await mkdir(join(prefix, 'bin'), {recursive: true});
+    const threadnote = runtimeThreadnoteBinPath('npm', prefix, process.platform);
+    await mkdir(dirname(threadnote), {recursive: true});
     await writeFile(threadnote, '#!/bin/sh\n');
     await chmod(threadnote, 0o755);
     const executeStreaming = vi.fn(

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,19 +1,20 @@
 import {chmod, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {Effect} from 'effect';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
 import {
   applyExactMatchBoost,
   buildRecallSections,
   categoryForUri,
-  collectExactMatches,
+  collectExactMatches as collectExactMatchesEffect,
   compareVersions,
-  enrichRecallQueryWithWorkspaceContext,
+  enrichRecallQueryWithWorkspaceContext as enrichRecallQueryWithWorkspaceContextEffect,
   escapeRegExp,
   exactMemoryScopeUris,
   exactRecallScopeIntents,
   exactRecallTerms,
-  findOpenVikingCli,
+  findOpenVikingCli as findOpenVikingCliEffect,
   formatExactMatchPointers,
   formatRecallHits,
   formatShellCommand,
@@ -29,18 +30,32 @@ import {
   RECALL_LOW_CONFIDENCE_NOTE,
   type RecallHit,
   hasGlob,
-  isExecutable,
+  isExecutable as isExecutableEffect,
   isJsonObject,
   parseJsonConfigObject,
   recallQueryRequestsWorkspaceContext,
   redactText,
   reindexWaitTimeoutMs,
-  runCommand,
-  runInteractive,
+  runCommand as runCommandEffect,
+  runInteractive as runInteractiveEffect,
   shellQuote,
   suggestedShellRc,
   uniqueUsefulWorkspaceTerms,
 } from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const collectExactMatches = (
+  terms: readonly string[],
+  scopes: readonly string[],
+  runGrep: (term: string, scope: string) => Effect.Effect<string | undefined>,
+) => runEffect(collectExactMatchesEffect(terms, scopes, runGrep));
+const enrichRecallQueryWithWorkspaceContext = (
+  ...args: Parameters<typeof enrichRecallQueryWithWorkspaceContextEffect>
+) => runEffect(enrichRecallQueryWithWorkspaceContextEffect(...args));
+const findOpenVikingCli = () => runEffect(findOpenVikingCliEffect());
+const isExecutable = (...args: Parameters<typeof isExecutableEffect>) => runEffect(isExecutableEffect(...args));
+const runCommand = (...args: Parameters<typeof runCommandEffect>) => runEffect(runCommandEffect(...args));
+const runInteractive = (...args: Parameters<typeof runInteractiveEffect>) => runEffect(runInteractiveEffect(...args));
 
 describe('compareVersions', () => {
   it('returns 0 for equal versions', () => {
@@ -106,19 +121,19 @@ describe('reindexWaitTimeoutMs', () => {
 
   it('defaults to a bounded 2-minute wait', () => {
     delete process.env[ENV];
-    expect(reindexWaitTimeoutMs()).toBe(120_000);
+    return expect(runEffect(reindexWaitTimeoutMs())).resolves.toBe(120_000);
   });
 
   it('honors a positive integer override', () => {
     process.env[ENV] = '30000';
-    expect(reindexWaitTimeoutMs()).toBe(30_000);
+    return expect(runEffect(reindexWaitTimeoutMs())).resolves.toBe(30_000);
   });
 
-  it('falls back to the default for non-positive or invalid overrides', () => {
+  it('falls back to the default for non-positive or invalid overrides', async () => {
     process.env[ENV] = '0';
-    expect(reindexWaitTimeoutMs()).toBe(120_000);
+    await expect(runEffect(reindexWaitTimeoutMs())).resolves.toBe(120_000);
     process.env[ENV] = 'nope';
-    expect(reindexWaitTimeoutMs()).toBe(120_000);
+    await expect(runEffect(reindexWaitTimeoutMs())).resolves.toBe(120_000);
   });
 });
 
@@ -634,14 +649,16 @@ describe('grepUrisFromJson', () => {
 
 describe('collectExactMatches + formatExactMatchPointers', () => {
   it('dedupes by URI, strips chunk anchors, and ranks by distinct-term count', async () => {
-    const runGrep = async (term: string): Promise<string> => {
+    const runGrep = (term: string) => {
       const uris =
         term === 'style'
           ? ['viking://prefs.md#chunk_0001', 'viking://other.md']
           : term === 'tone'
             ? ['viking://prefs.md#chunk_0002']
             : [];
-      return JSON.stringify({ok: true, result: {matches: uris.map((uri, line) => ({line, uri, content: ''}))}});
+      return Effect.succeed(
+        JSON.stringify({ok: true, result: {matches: uris.map((uri, line) => ({line, uri, content: ''}))}}),
+      );
     };
     const matches = await collectExactMatches(['style', 'tone'], ['viking://scope'], runGrep);
     expect(matches).toEqual([
@@ -654,9 +671,11 @@ describe('collectExactMatches + formatExactMatchPointers', () => {
   });
 
   it('does not double-count a term when the same URI matches it in two scopes', async () => {
-    const runGrep = async (term: string, scope: string): Promise<string> => {
+    const runGrep = (term: string, scope: string) => {
       const uris = scope === 'viking://a' ? ['viking://dup.md'] : scope === 'viking://b' ? ['viking://dup.md'] : [];
-      return JSON.stringify({ok: true, result: {matches: uris.map((uri, line) => ({line, uri, content: ''}))}});
+      return Effect.succeed(
+        JSON.stringify({ok: true, result: {matches: uris.map((uri, line) => ({line, uri, content: ''}))}}),
+      );
     };
     const matches = await collectExactMatches(['term'], ['viking://a', 'viking://b'], runGrep);
     expect(matches).toEqual([{uri: 'viking://dup.md', terms: ['term']}]);

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -6,7 +6,9 @@ import {isGitExecutable, resolveCommandInvocation, runCommandEffect} from '../..
 import {
   openVikingServerExecutableNames,
   pythonExecutableCandidates,
+  quoteWindowsProcessArgument,
   shouldManageCommandShim,
+  windowsProcessArgumentLine,
 } from '../../src/lifecycle.js';
 import {runtimeThreadnoteBinPath} from '../../src/update.js';
 import {
@@ -223,6 +225,17 @@ describe('Windows command execution', () => {
 });
 
 describe('Windows lifecycle defaults', () => {
+  it('quotes detached server arguments using Windows command-line rules', () => {
+    expect(quoteWindowsProcessArgument('')).toBe('""');
+    expect(quoteWindowsProcessArgument('--config')).toBe('--config');
+    expect(quoteWindowsProcessArgument('C:\\agent context\\ov.conf')).toBe('"C:\\agent context\\ov.conf"');
+    expect(quoteWindowsProcessArgument('ends with slash \\')).toBe('"ends with slash \\\\"');
+    expect(quoteWindowsProcessArgument('quote " value')).toBe('"quote \\" value"');
+    expect(windowsProcessArgumentLine(['--config', 'C:\\agent context\\ov.conf', '--name', 'quote " value'])).toBe(
+      '--config "C:\\agent context\\ov.conf" --name "quote \\" value"',
+    );
+  });
+
   it('uses native Python launcher candidates and preserves npm command wrappers', () => {
     expect(pythonExecutableCandidates('win32')).toEqual(['py', 'python', 'python3']);
     expect(shouldManageCommandShim('win32')).toBe(false);

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -184,38 +184,42 @@ describe('Windows command execution', () => {
     }
   });
 
-  windowsIt('terminates the complete cmd process tree on timeout', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'threadnote cmd timeout '));
-    const shim = join(root, 'wait.cmd');
-    const script = join(root, 'wait.cjs');
-    const pidPath = join(root, 'child.pid');
-    try {
-      await writeFile(
-        script,
-        "require('node:fs').writeFileSync(process.argv[2], String(process.pid)); setInterval(() => {}, 1000)\n",
-      );
-      await writeFile(shim, '@ECHO off\r\n"%TIMEOUT_NODE%" "%TIMEOUT_SCRIPT%" "%TIMEOUT_PID%"\r\n');
+  windowsIt(
+    'terminates the complete cmd process tree on timeout',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'threadnote cmd timeout '));
+      const shim = join(root, 'wait.cmd');
+      const script = join(root, 'wait.cjs');
+      const pidPath = join(root, 'child.pid');
+      try {
+        await writeFile(
+          script,
+          "require('node:fs').writeFileSync(process.argv[2], String(process.pid)); setInterval(() => {}, 1000)\n",
+        );
+        await writeFile(shim, '@ECHO off\r\n"%TIMEOUT_NODE%" "%TIMEOUT_SCRIPT%" "%TIMEOUT_PID%"\r\n');
 
-      const result = await runEffect(
-        runCommandEffect(shim, [], {
-          allowFailure: true,
-          env: {
-            ...process.env,
-            TIMEOUT_NODE: process.execPath,
-            TIMEOUT_PID: pidPath,
-            TIMEOUT_SCRIPT: script,
-          },
-          timeoutMs: 5000,
-        }),
-      );
-      const childPid = Number(await readFile(pidPath, 'utf8'));
+        const result = await runEffect(
+          runCommandEffect(shim, [], {
+            allowFailure: true,
+            env: {
+              ...process.env,
+              TIMEOUT_NODE: process.execPath,
+              TIMEOUT_PID: pidPath,
+              TIMEOUT_SCRIPT: script,
+            },
+            timeoutMs: 1000,
+          }),
+        );
+        const childPid = Number(await readFile(pidPath, 'utf8'));
 
-      expect(result.exitCode).toBe(124);
-      expect(() => process.kill(childPid, 0)).toThrow();
-    } finally {
-      await rm(root, {force: true, recursive: true});
-    }
-  });
+        expect(result.exitCode).toBe(124);
+        expect(() => process.kill(childPid, 0)).toThrow();
+      } finally {
+        await rm(root, {force: true, recursive: true});
+      }
+    },
+    10_000,
+  );
 });
 
 describe('Windows lifecycle defaults', () => {

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -1,14 +1,8 @@
 import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {delimiter, join} from 'node:path';
-import {Effect} from 'effect';
 import {describe, expect, it} from 'vitest';
-import {
-  CommandExecutor,
-  isGitExecutable,
-  resolveCommandInvocation,
-  runCommandEffect,
-} from '../../src/effect/command.js';
+import {isGitExecutable, resolveCommandInvocation, runCommandEffect} from '../../src/effect/command.js';
 import {
   openVikingServerExecutableNames,
   pythonExecutableCandidates,
@@ -22,6 +16,7 @@ import {
   pythonUserScriptsCandidateDirs,
   runCommand,
 } from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
 
 const windowsIt = process.platform === 'win32' ? it : it.skip;
 const posixIt = process.platform === 'win32' ? it.skip : it;
@@ -113,7 +108,7 @@ describe('Windows executable discovery', () => {
       await chmod(executable, 0o755);
       process.env.PATH = [first, second].join(delimiter);
 
-      await expect(findExecutable(['uv'])).resolves.toBe(executable);
+      await expect(runEffect(findExecutable(['uv']))).resolves.toBe(executable);
     } finally {
       process.env.PATH = originalPath;
       await rm(root, {force: true, recursive: true});
@@ -172,14 +167,16 @@ describe('Windows command execution', () => {
       );
       await writeFile(shim, '@ECHO off\r\n"%CAPTURE_NODE%" "%CAPTURE_SCRIPT%" %*\r\n');
 
-      const result = await runCommand(shim, args, {
-        env: {
-          ...process.env,
-          CAPTURE_NODE: process.execPath,
-          CAPTURE_OUTPUT: output,
-          CAPTURE_SCRIPT: script,
-        },
-      });
+      const result = await runEffect(
+        runCommand(shim, args, {
+          env: {
+            ...process.env,
+            CAPTURE_NODE: process.execPath,
+            CAPTURE_OUTPUT: output,
+            CAPTURE_SCRIPT: script,
+          },
+        }),
+      );
 
       expect(result.exitCode).toBe(0);
       await expect(readFile(output, 'utf8').then(value => JSON.parse(value))).resolves.toEqual(args);
@@ -200,7 +197,7 @@ describe('Windows command execution', () => {
       );
       await writeFile(shim, '@ECHO off\r\n"%TIMEOUT_NODE%" "%TIMEOUT_SCRIPT%" "%TIMEOUT_PID%"\r\n');
 
-      const result = await Effect.runPromise(
+      const result = await runEffect(
         runCommandEffect(shim, [], {
           allowFailure: true,
           env: {
@@ -210,7 +207,7 @@ describe('Windows command execution', () => {
             TIMEOUT_SCRIPT: script,
           },
           timeoutMs: 5000,
-        }).pipe(Effect.provide(CommandExecutor.layer)),
+        }),
       );
       const childPid = Number(await readFile(pidPath, 'utf8'));
 

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -1,0 +1,253 @@
+import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {delimiter, join} from 'node:path';
+import {Effect} from 'effect';
+import {describe, expect, it} from 'vitest';
+import {
+  CommandExecutor,
+  isGitExecutable,
+  resolveCommandInvocation,
+  runCommandEffect,
+} from '../../src/effect/command.js';
+import {
+  openVikingServerExecutableNames,
+  pythonExecutableCandidates,
+  shouldManageCommandShim,
+} from '../../src/lifecycle.js';
+import {runtimeThreadnoteBinPath} from '../../src/update.js';
+import {
+  executableNames,
+  findExecutable,
+  findOpenVikingCli,
+  pythonUserScriptsCandidateDirs,
+  runCommand,
+} from '../../src/utils.js';
+
+const windowsIt = process.platform === 'win32' ? it : it.skip;
+const posixIt = process.platform === 'win32' ? it.skip : it;
+
+describe('Windows executable discovery', () => {
+  it('expands PATHEXT for extensionless commands', () => {
+    expect(executableNames('uv', 'win32', '.COM;.EXE;.CMD')).toEqual(['uv.COM', 'uv.EXE', 'uv.CMD', 'uv']);
+  });
+
+  it('does not append extensions to an explicit Windows launcher', () => {
+    expect(executableNames('threadnote.cmd', 'win32', '.COM;.EXE;.CMD')).toEqual(['threadnote.cmd']);
+  });
+
+  it('only accepts native launchers for detached OpenViking servers', () => {
+    expect(openVikingServerExecutableNames('win32', '.COM;.EXE;.BAT;.CMD')).toEqual([
+      'openviking-server.COM',
+      'openviking-server.EXE',
+    ]);
+  });
+
+  windowsIt('prefers a native cmd launcher over an adjacent POSIX shim', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote launcher order '));
+    const originalPath = process.env.PATH;
+    try {
+      await writeFile(join(root, 'threadnote'), '#!/bin/sh\n');
+      await writeFile(join(root, 'threadnote.cmd'), '@ECHO off\r\n');
+      process.env.PATH = root;
+      await expect(findExecutable(['threadnote'])).resolves.toBe(join(root, 'threadnote.CMD'));
+    } finally {
+      process.env.PATH = originalPath;
+      await rm(root, {force: true, recursive: true});
+    }
+  });
+
+  windowsIt('finds an out-of-PATH OpenViking exe launcher', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote ov launcher '));
+    const originalPath = process.env.PATH;
+    const originalToolBin = process.env.UV_TOOL_BIN_DIR;
+    try {
+      await writeFile(join(root, 'ov.exe'), '');
+      process.env.PATH = '';
+      process.env.UV_TOOL_BIN_DIR = root;
+      await expect(findOpenVikingCli()).resolves.toBe(join(root, 'ov.EXE'));
+    } finally {
+      process.env.PATH = originalPath;
+      if (originalToolBin === undefined) {
+        delete process.env.UV_TOOL_BIN_DIR;
+      } else {
+        process.env.UV_TOOL_BIN_DIR = originalToolBin;
+      }
+      await rm(root, {force: true, recursive: true});
+    }
+  });
+
+  windowsIt('discovers the Python user Scripts directory used by pip --user', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote python user scripts '));
+    const fakeBin = join(root, 'bin');
+    const userBase = join(root, 'python user base');
+    const originalPath = process.env.PATH;
+    const originalUserBase = process.env.THREADNOTE_TEST_USER_BASE;
+    try {
+      await mkdir(fakeBin, {recursive: true});
+      await writeFile(join(fakeBin, 'python.cmd'), '@ECHO off\r\n@ECHO %THREADNOTE_TEST_USER_BASE%\r\n');
+      process.env.PATH = fakeBin;
+      process.env.THREADNOTE_TEST_USER_BASE = userBase;
+
+      await expect(pythonUserScriptsCandidateDirs('win32')).resolves.toEqual([join(userBase, 'Scripts')]);
+    } finally {
+      process.env.PATH = originalPath;
+      if (originalUserBase === undefined) {
+        delete process.env.THREADNOTE_TEST_USER_BASE;
+      } else {
+        process.env.THREADNOTE_TEST_USER_BASE = originalUserBase;
+      }
+      await rm(root, {force: true, recursive: true});
+    }
+  });
+
+  posixIt('skips directory shadows while searching PATH', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote executable shadow '));
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    const originalPath = process.env.PATH;
+    try {
+      await mkdir(join(first, 'uv'), {recursive: true});
+      await mkdir(second, {recursive: true});
+      const executable = join(second, 'uv');
+      await writeFile(executable, '#!/bin/sh\n');
+      await chmod(executable, 0o755);
+      process.env.PATH = [first, second].join(delimiter);
+
+      await expect(findExecutable(['uv'])).resolves.toBe(executable);
+    } finally {
+      process.env.PATH = originalPath;
+      await rm(root, {force: true, recursive: true});
+    }
+  });
+});
+
+describe('Windows command execution', () => {
+  it('routes cmd launchers through ComSpec with escaped arguments', () => {
+    expect(
+      resolveCommandInvocation(
+        'C:\\Program Files\\nodejs\\npm.cmd',
+        ['install', 'package with spaces'],
+        'win32',
+        'C:\\Windows\\System32\\cmd.exe',
+      ),
+    ).toEqual({
+      args: ['/d', '/s', '/c', '"C:\\Program^ Files\\nodejs\\npm.cmd ^"install^" ^"package^ with^ spaces^""'],
+      executable: 'C:\\Windows\\System32\\cmd.exe',
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it('runs native executables directly', () => {
+    expect(resolveCommandInvocation('C:\\Python312\\python.exe', ['--version'], 'win32')).toEqual({
+      args: ['--version'],
+      executable: 'C:\\Python312\\python.exe',
+      windowsVerbatimArguments: false,
+    });
+  });
+
+  it('rejects command separators that cmd.exe cannot safely quote', () => {
+    expect(() => resolveCommandInvocation('agent.cmd', ['safe\r\nwhoami'], 'win32')).toThrow(
+      /do not accept NUL, CR, or LF/,
+    );
+  });
+
+  it('recognizes resolved Windows Git launchers for environment sanitization', () => {
+    expect(isGitExecutable('C:\\Program Files\\Git\\cmd\\git.EXE')).toBe(true);
+    expect(isGitExecutable('C:\\tools\\git.cmd')).toBe(true);
+    expect(isGitExecutable('C:\\tools\\not-git.exe')).toBe(false);
+  });
+
+  windowsIt('executes an npm-style cmd shim with metacharacters intact', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote cmd escaping '));
+    const bin = join(root, 'node_modules', '.bin');
+    const shim = join(bin, 'capture.cmd');
+    const script = join(root, 'capture.cjs');
+    const output = join(root, 'captured.json');
+    const args = ['space value', 'amp&value', 'caret^value', '100%', 'quote"value', 'trailing\\'];
+    try {
+      await mkdir(bin, {recursive: true});
+      await writeFile(
+        script,
+        "require('node:fs').writeFileSync(process.env.CAPTURE_OUTPUT, JSON.stringify(process.argv.slice(2)))\n",
+      );
+      await writeFile(shim, '@ECHO off\r\n"%CAPTURE_NODE%" "%CAPTURE_SCRIPT%" %*\r\n');
+
+      const result = await runCommand(shim, args, {
+        env: {
+          ...process.env,
+          CAPTURE_NODE: process.execPath,
+          CAPTURE_OUTPUT: output,
+          CAPTURE_SCRIPT: script,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      await expect(readFile(output, 'utf8').then(value => JSON.parse(value))).resolves.toEqual(args);
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  });
+
+  windowsIt('terminates the complete cmd process tree on timeout', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote cmd timeout '));
+    const shim = join(root, 'wait.cmd');
+    const script = join(root, 'wait.cjs');
+    const pidPath = join(root, 'child.pid');
+    try {
+      await writeFile(
+        script,
+        "require('node:fs').writeFileSync(process.argv[2], String(process.pid)); setInterval(() => {}, 1000)\n",
+      );
+      await writeFile(shim, '@ECHO off\r\n"%TIMEOUT_NODE%" "%TIMEOUT_SCRIPT%" "%TIMEOUT_PID%"\r\n');
+
+      const result = await Effect.runPromise(
+        runCommandEffect(shim, [], {
+          allowFailure: true,
+          env: {
+            ...process.env,
+            TIMEOUT_NODE: process.execPath,
+            TIMEOUT_PID: pidPath,
+            TIMEOUT_SCRIPT: script,
+          },
+          timeoutMs: 5000,
+        }).pipe(Effect.provide(CommandExecutor.layer)),
+      );
+      const childPid = Number(await readFile(pidPath, 'utf8'));
+
+      expect(result.exitCode).toBe(124);
+      expect(() => process.kill(childPid, 0)).toThrow();
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  });
+});
+
+describe('Windows lifecycle defaults', () => {
+  it('uses native Python launcher candidates and preserves npm command wrappers', () => {
+    expect(pythonExecutableCandidates('win32')).toEqual(['py', 'python', 'python3']);
+    expect(shouldManageCommandShim('win32')).toBe(false);
+  });
+
+  it('keeps existing POSIX defaults', () => {
+    expect(pythonExecutableCandidates('linux')).toEqual(['python3', 'python']);
+    expect(shouldManageCommandShim('linux')).toBe(true);
+  });
+});
+
+describe('Windows update launcher paths', () => {
+  it('resolves npm and bun wrappers from the native global prefix', () => {
+    expect(runtimeThreadnoteBinPath('npm', 'C:\\Users\\dev\\AppData\\Roaming\\npm', 'win32')).toBe(
+      'C:\\Users\\dev\\AppData\\Roaming\\npm\\threadnote.cmd',
+    );
+    expect(runtimeThreadnoteBinPath('bun', 'C:\\Users\\dev\\.bun\\bin', 'win32')).toBe(
+      'C:\\Users\\dev\\.bun\\bin\\threadnote.cmd',
+    );
+    expect(runtimeThreadnoteBinPath('deno', 'C:\\Users\\dev\\.deno\\bin', 'win32')).toBe(
+      'C:\\Users\\dev\\.deno\\bin\\threadnote.cmd',
+    );
+  });
+
+  it('keeps the POSIX npm layout', () => {
+    expect(runtimeThreadnoteBinPath('npm', '/usr/local', 'linux')).toBe('/usr/local/bin/threadnote');
+  });
+});

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -44,7 +44,7 @@ describe('Windows executable discovery', () => {
       await writeFile(join(root, 'threadnote'), '#!/bin/sh\n');
       await writeFile(join(root, 'threadnote.cmd'), '@ECHO off\r\n');
       process.env.PATH = root;
-      await expect(findExecutable(['threadnote'])).resolves.toBe(join(root, 'threadnote.CMD'));
+      await expect(runEffect(findExecutable(['threadnote']))).resolves.toBe(join(root, 'threadnote.CMD'));
     } finally {
       process.env.PATH = originalPath;
       await rm(root, {force: true, recursive: true});
@@ -59,7 +59,7 @@ describe('Windows executable discovery', () => {
       await writeFile(join(root, 'ov.exe'), '');
       process.env.PATH = '';
       process.env.UV_TOOL_BIN_DIR = root;
-      await expect(findOpenVikingCli()).resolves.toBe(join(root, 'ov.EXE'));
+      await expect(runEffect(findOpenVikingCli())).resolves.toBe(join(root, 'ov.EXE'));
     } finally {
       process.env.PATH = originalPath;
       if (originalToolBin === undefined) {
@@ -83,7 +83,7 @@ describe('Windows executable discovery', () => {
       process.env.PATH = fakeBin;
       process.env.THREADNOTE_TEST_USER_BASE = userBase;
 
-      await expect(pythonUserScriptsCandidateDirs('win32')).resolves.toEqual([join(userBase, 'Scripts')]);
+      await expect(runEffect(pythonUserScriptsCandidateDirs('win32'))).resolves.toEqual([join(userBase, 'Scripts')]);
     } finally {
       process.env.PATH = originalPath;
       if (originalUserBase === undefined) {
@@ -126,9 +126,9 @@ describe('Windows command execution', () => {
         'C:\\Windows\\System32\\cmd.exe',
       ),
     ).toEqual({
-      args: ['/d', '/s', '/c', '"C:\\Program^ Files\\nodejs\\npm.cmd ^"install^" ^"package^ with^ spaces^""'],
-      executable: 'C:\\Windows\\System32\\cmd.exe',
-      windowsVerbatimArguments: true,
+      args: [],
+      executable: 'C:\\Program^ Files\\nodejs\\npm.cmd ^"install^" ^"package^ with^ spaces^"',
+      shell: 'C:\\Windows\\System32\\cmd.exe',
     });
   });
 
@@ -136,7 +136,6 @@ describe('Windows command execution', () => {
     expect(resolveCommandInvocation('C:\\Python312\\python.exe', ['--version'], 'win32')).toEqual({
       args: ['--version'],
       executable: 'C:\\Python312\\python.exe',
-      windowsVerbatimArguments: false,
     });
   });
 

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -8,6 +8,7 @@ import {
   pythonExecutableCandidates,
   quoteWindowsProcessArgument,
   shouldManageCommandShim,
+  shouldRepairOpenVikingCliConfig,
   windowsProcessArgumentLine,
 } from '../../src/lifecycle.js';
 import {runtimeThreadnoteBinPath} from '../../src/update.js';
@@ -239,6 +240,39 @@ describe('Windows lifecycle defaults', () => {
   it('uses native Python launcher candidates and preserves npm command wrappers', () => {
     expect(pythonExecutableCandidates('win32')).toEqual(['py', 'python', 'python3']);
     expect(shouldManageCommandShim('win32')).toBe(false);
+  });
+
+  it('refreshes only managed local OpenViking CLI configs when runtime overrides change', () => {
+    const config = {
+      account: 'local',
+      agentContextHome: 'C:\\agent context',
+      agentId: 'threadnote',
+      host: '127.0.0.1',
+      manifestPath: 'C:\\agent context\\seed-manifest.yaml',
+      openVikingVersion: '0.4.10',
+      port: 43127,
+      user: 'windows-e2e',
+    };
+    const managed = JSON.stringify({
+      account: 'local',
+      agent_id: 'threadnote',
+      timeout: 60,
+      url: 'http://127.0.0.1:1933',
+      user: 'windows-e2e',
+    });
+    const current = managed.replace(':1933', ':43127');
+    const custom = JSON.stringify({
+      account: 'local',
+      agent_id: 'threadnote',
+      api_key: 'managed-elsewhere',
+      timeout: 60,
+      url: 'https://openviking.example.com',
+      user: 'windows-e2e',
+    });
+
+    expect(shouldRepairOpenVikingCliConfig(managed, config)).toBe(true);
+    expect(shouldRepairOpenVikingCliConfig(current, config)).toBe(false);
+    expect(shouldRepairOpenVikingCliConfig(custom, config)).toBe(false);
   });
 
   it('keeps existing POSIX defaults', () => {

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -4,7 +4,6 @@ import {delimiter, join} from 'node:path';
 import {describe, expect, it} from 'vitest';
 import {isGitExecutable, resolveCommandInvocation, runCommandEffect} from '../../src/effect/command.js';
 import {
-  encodeWindowsPowerShellCommand,
   openVikingServerExecutableNames,
   pythonExecutableCandidates,
   shouldManageCommandShim,
@@ -224,12 +223,6 @@ describe('Windows command execution', () => {
 });
 
 describe('Windows lifecycle defaults', () => {
-  it('encodes detached host scripts for Windows PowerShell', () => {
-    expect(encodeWindowsPowerShellCommand("Write-Output 'ok'")).toBe(
-      'VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAnAG8AawAnAA==',
-    );
-  });
-
   it('uses native Python launcher candidates and preserves npm command wrappers', () => {
     expect(pythonExecutableCandidates('win32')).toEqual(['py', 'python', 'python3']);
     expect(shouldManageCommandShim('win32')).toBe(false);

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -4,6 +4,7 @@ import {delimiter, join} from 'node:path';
 import {describe, expect, it} from 'vitest';
 import {isGitExecutable, resolveCommandInvocation, runCommandEffect} from '../../src/effect/command.js';
 import {
+  encodeWindowsPowerShellCommand,
   openVikingServerExecutableNames,
   pythonExecutableCandidates,
   shouldManageCommandShim,
@@ -223,6 +224,12 @@ describe('Windows command execution', () => {
 });
 
 describe('Windows lifecycle defaults', () => {
+  it('encodes detached host scripts for Windows PowerShell', () => {
+    expect(encodeWindowsPowerShellCommand("Write-Output 'ok'")).toBe(
+      'VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIAAnAG8AawAnAA==',
+    );
+  });
+
   it('uses native Python launcher candidates and preserves npm command wrappers', () => {
     expect(pythonExecutableCandidates('win32')).toEqual(['py', 'python', 'python3']);
     expect(shouldManageCommandShim('win32')).toBe(false);

--- a/vitest.windows-e2e.config.ts
+++ b/vitest.windows-e2e.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    fileParallelism: false,
+    hookTimeout: 600_000,
+    include: ['test/e2e/**/*.windows.e2e.ts'],
+    testTimeout: 600_000,
+  },
+});


### PR DESCRIPTION
## Summary

- add a native PowerShell installer that preserves npm's `threadnote.cmd` launcher
- support Windows executable discovery, command quoting, process-tree lifecycle management, updates, and MCP configuration
- route production filesystem, path, platform, crypto, and child-process work through Effect services without internal runtimes or `node:*` imports
- add packed native Windows E2E coverage, focused unit tests, and a `windows-latest` CI job
- document the native Windows installation and troubleshooting flow

## Why

Threadnote's installation and lifecycle paths assumed POSIX shells, executable names, global-bin layouts, and process signaling. Native Windows users could install the npm package but could not reliably install OpenViking, repair an update, configure MCP clients, or safely start and stop the detached server.

## Impact

Windows users can install from PowerShell without WSL or Git Bash, retain the package-manager launcher, exercise the full OpenViking and MCP workflow, and preserve memories during uninstall. Existing macOS and Linux behavior remains covered by the full unit and packaged E2E suites.

## Validation

- `npm test` — 586 passed, 5 platform-skipped
- `npm run typecheck`
- `npm run lint`
- `npm run prettier:check`
- `npm run build`
- `npm run check:bundle-size` — all three bundles within limits
- `npm pack --dry-run` — `threadnote@3.0.0-beta.3`
- `npm run test:e2e:local-bins` — 11 passed, 3 platform-skipped
- Windows packed install, MCP memory workflow, lifecycle, repair, update, cleanup, and uninstall run in the new `windows-latest` CI job

## Release

The prior dev-cycle findings are addressed: streaming execution is mandatory on every `CommandExecutor` layer, Windows cleanup verifies both process identity and the configured listener before removing PID state, remaining production `node:*`/process-global paths moved behind Effect services, installer logs redact URL credentials, and Windows CI covers the changed command/lifecycle suites.

Merged and published as [`v3.0.0-beta.3`](https://github.com/Kashkovsky/threadnote/releases/tag/v3.0.0-beta.3). The npm `beta` dist-tag now resolves to `3.0.0-beta.3`; `latest` remains `2.0.5`.
