### PR TITLE
Add optional local AI recall expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Alice + Codex ──publish curated memory──▶ team Git repo
   machine.
 - **Targeted local recall.** OpenViking runs a local GGUF embedding model through `llama.cpp` to rank semantic matches;
   agents load selected `viking://` records instead of replaying the entire memory history.
+- **Optional local query expansion.** `threadnote local-ai install` can add a pinned, verified Gemma model that helps
+  weak and medium-confidence paraphrase recalls while deterministic retrieval remains in control.
 - **Recall explains itself.** Semantic and BM25 relevance, fields, graph links, currentness, authority, and bounded
   feedback produce a confidence level and inspectable ranking reasons.
 - **Routine continuity is automatic.** At meaningful task closeout, the agent writes normal durable feature knowledge

--- a/config/post-update-migrations.json
+++ b/config/post-update-migrations.json
@@ -39,6 +39,24 @@
         "If Threadnote reported any original files were still being processed, rerun the printed threadnote forget <uri> command later."
       ],
       "requiresProjectNameConsolidation": true
+    },
+    {
+      "id": "local-ai-recall-gemma-4-e4b-v1",
+      "introducedIn": "3.0.0",
+      "appliesToPrereleases": true,
+      "title": "Optional local AI recall with Gemma 4 E4B",
+      "description": [
+        "Threadnote can improve weak and medium-confidence recalls with a local instruction model while keeping deterministic retrieval and ranking in control.",
+        "This optional action downloads the official Gemma 4 E4B Q4_0 GGUF model (4.59 GB), verifies its pinned SHA-256, and stores its configuration under THREADNOTE_HOME.",
+        "The authenticated model service binds to 127.0.0.1 only and uses the llama.cpp runtime already installed with OpenViking.",
+        "High-confidence recalls never invoke the model; model failures fall back to the original deterministic result.",
+        "Gemma model use is subject to Google's Gemma Terms: https://ai.google.dev/gemma/terms"
+      ],
+      "commandArgs": ["local-ai", "install"],
+      "instructions": [
+        "Local AI recall is enabled. Run `threadnote local-ai status` to inspect it or `threadnote local-ai uninstall` to disable it while preserving the model."
+      ],
+      "markHandledWhenSkipped": true
     }
   ]
 }

--- a/docs/effect.md
+++ b/docs/effect.md
@@ -62,21 +62,73 @@ The stdio integration tests connect with the official MCP client and protect:
 - runtime rejection of invalid inputs;
 - OpenViking forwarding and share behavior.
 
-## Optional Effect AI consolidation
+## Optional Effect AI
 
-The manager can use `@effect/ai-openai-compat` for structured consolidation drafts. It is intentionally opt-in and keeps
-the same preview-before-apply safety model as Codex and Claude consolidation.
+Threadnote can use `@effect/ai-openai-compat` for structured consolidation drafts and bounded recall query expansion.
+It is intentionally opt-in. After an applicable package update, Threadnote offers to install the recommended local
+model; declining dismisses that offer without enabling or downloading anything. The same setup is available directly:
+
+```bash
+threadnote local-ai install
+threadnote local-ai status
+```
+
+`local-ai install` downloads the pinned official Gemma 4 E4B Q4_0 GGUF file (4.59 GB), verifies its size and SHA-256,
+stores the model under `THREADNOTE_HOME/threadnote/models`, and writes a versioned
+`THREADNOTE_HOME/threadnote/local-ai.json`. Pass `--model-path <path>` to verify and reuse an existing copy instead.
+The service binds only to `127.0.0.1:1934`. Installation also creates a mode-0600 access token. Health checks use a
+challenge-response proof before Threadnote sends any prompt, and the OpenAI-compatible endpoints require that token.
+
+Effect owns the service lifecycle: configuration, download orchestration, the lifecycle lock, detached process and PID
+record, health checks, logging, lazy startup, and safe stop/uninstall behavior. The bundled Python file is only a thin
+OpenAI-compatible HTTP adapter around the `llama_cpp` package already installed with OpenViking; it does not decide
+when or how the process runs. Configured local AI follows `threadnote start`, `stop`, `repair`, and `uninstall`, and a
+weak recall can lazily start a stopped service. A bounded readiness wait fails open, so model startup cannot prevent the
+deterministic recall result from returning.
+
+Stop verifies the authenticated launch ID, PID, model, and model path immediately before signaling the process. If a
+stale record or unhealthy endpoint cannot prove ownership, Threadnote refuses to signal that PID and leaves manual
+inspection to the user.
+
+Use the dedicated commands for explicit control:
+
+```bash
+threadnote local-ai start
+threadnote local-ai stop
+threadnote local-ai status
+threadnote local-ai uninstall               # preserves the managed model
+threadnote local-ai uninstall --erase-model # also removes the managed model
+```
+
+For recall, deterministic retrieval and ranking always run first. High-confidence results never call the model.
+Medium-confidence results can evaluate one rewrite; low-confidence and no-answer results can evaluate at most two,
+one search scope at a time. Rewrites are schema-validated, deduplicated, cached by query/project/provider fingerprint,
+and limited to 512 characters. The model stage times out after five seconds and fails open to the deterministic result.
+Expanded candidates are merged with the original candidates and exact matches, then reranked by the same deterministic
+ranker. Remote endpoints receive only the original query and inferred project. Explicit loopback endpoints additionally
+receive a bounded, scrubbed shortlist of local topic/identifier names with six-term index excerpts; rewrites that do
+not contain an exact shortlist term are discarded. This grounding data never goes to a non-loopback endpoint.
+
+The local model does not extract additional memory candidates or mutate canonical memories and their metadata.
+Candidate extraction keeps its existing policy. Explicit manager consolidation may use the same provider to generate
+an Effect Schema-validated `{ "draft": string }` object, but generating a draft never deletes source memories; cleanup
+remains a separate user-approved operation.
+
+Environment variables remain an advanced override for Ollama, LM Studio, hosted APIs, or another
+OpenAI-compatible chat-completions endpoint:
 
 ```bash
 export THREADNOTE_EFFECT_AI=1
 export THREADNOTE_EFFECT_AI_MODEL=<openai-compatible-model>
 export THREADNOTE_EFFECT_AI_API_KEY=<key>       # optional when the endpoint does not require one
 export THREADNOTE_EFFECT_AI_API_URL=<base-url>  # optional for the default OpenAI endpoint
-threadnote manage
 ```
 
-The model returns an Effect Schema-validated `{ "draft": string }` object. Generating a draft never deletes source
-memories; cleanup remains a separate user-approved operation.
+An explicit environment provider takes precedence over persisted local AI. Set `THREADNOTE_EFFECT_AI=0` to disable the
+persisted provider for one process.
+
+Use an instruction-tuned model with at least a 2K context window. Small models can satisfy the JSON schema while still
+choosing superficial topic matches; the expander fails open, but recall quality depends on the local model.
 
 ## Upgrading Effect
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -167,6 +167,21 @@ threadnote stop
 threadnote start
 ```
 
+## Local AI Recall Is Stopped or Unhealthy
+
+Inspect the persisted model path and loopback service:
+
+```bash
+threadnote local-ai status
+threadnote local-ai start
+```
+
+Startup logs are written to `THREADNOTE_HOME/logs/local-ai.log`. If the model file is missing or fails verification,
+or the private access token is missing or has unsafe permissions, rerun `threadnote local-ai install --force`. A
+local-model failure does not block recall: Threadnote returns its deterministic result without query expansion. Stop
+also refuses to signal a recorded PID when the authenticated endpoint cannot prove the same launch identity; inspect
+that process manually instead of deleting the safety check.
+
 ## Claude MCP Fails While Health Is OK
 
 Threadnote uses its bundled stdio MCP adapter by default, even when the installed OpenViking server exposes native

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threadnote",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threadnote",
-      "version": "3.0.0-beta.4",
+      "version": "3.0.0-beta.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "type": "module",
   "main": "dist/threadnote.js",
   "description": "Shared local context and handoffs for development agents",

--- a/scripts/evaluate-recall.ts
+++ b/scripts/evaluate-recall.ts
@@ -1,5 +1,6 @@
-import {NodeCrypto, NodeFileSystem, NodePath, NodeRuntime} from '@effect/platform-node';
-import {Clock, Console, Effect, FileSystem, Layer, Option, Path} from 'effect';
+import {NodeRuntime} from '@effect/platform-node';
+import {Clock, Console, Effect, FileSystem, Option, Path} from 'effect';
+import {ApplicationLayer} from '../src/effect/runtime.js';
 import {evaluateRecallFixture, parseRecallEvaluationFixture} from '../src/recall/evaluate.js';
 import {clearRecallIndexMemoryCache, expireRecallIndexValidation, loadRecallIndex} from '../src/recall/index.js';
 import {prepareRecallSections} from '../src/recall/runtime.js';
@@ -241,9 +242,6 @@ function percentile(sorted: readonly number[], quantile: number): number {
   return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * quantile))] ?? 0;
 }
 
-NodeRuntime.runMain(
-  program.pipe(Effect.provide(Layer.mergeAll(NodeCrypto.layer, NodeFileSystem.layer, NodePath.layer))),
-  {
-    disableErrorReporting: false,
-  },
-);
+NodeRuntime.runMain(program.pipe(Effect.provide(ApplicationLayer)), {
+  disableErrorReporting: false,
+});

--- a/scripts/local-ai-server.py
+++ b/scripts/local-ai-server.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Lock
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+
+MAX_REQUEST_BYTES = 1_048_576
+MAX_OUTPUT_TOKENS = 512
+SERVICE_ID = "threadnote-local-ai"
+inference_lock = Lock()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Threadnote loopback llama.cpp adapter")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--launch-id", required=True)
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--model-id", required=True)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--token-file", required=True)
+    return parser.parse_args()
+
+
+args = parse_args()
+if args.host not in {"127.0.0.1", "::1", "localhost"}:
+    raise SystemExit("Threadnote local AI only binds to an explicit loopback host.")
+
+log_file = open(args.log, "a", encoding="utf-8", buffering=1)
+sys.stdout = log_file
+sys.stderr = log_file
+
+with open(args.token_file, encoding="utf-8") as token_file:
+    access_token = token_file.read().strip()
+if not re.fullmatch(r"[A-Za-z0-9_-]{43}", access_token):
+    raise SystemExit("Threadnote local AI access token has an unsupported shape.")
+
+from llama_cpp import Llama
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        parsed_url = urlsplit(self.path)
+        if parsed_url.path == "/health":
+            challenge = parse_qs(parsed_url.query).get("challenge", [""])[0]
+            if not re.fullmatch(r"[A-Za-z0-9_-]{16,128}", challenge):
+                self.respond(
+                    {"error": {"message": "A valid health challenge is required.", "type": "invalid_request"}},
+                    status=400,
+                )
+                return
+            pid = os.getpid()
+            self.respond(
+                {
+                    "model": args.model_id,
+                    "launchId": args.launch_id,
+                    "pid": pid,
+                    "proof": health_proof(challenge, pid),
+                    "service": SERVICE_ID,
+                    "status": "ok",
+                }
+            )
+            return
+        if parsed_url.path == "/v1/models":
+            if not self.authorized():
+                return
+            self.respond(
+                {
+                    "data": [{"id": args.model_id, "object": "model", "owned_by": "threadnote-local"}],
+                    "object": "list",
+                }
+            )
+            return
+        self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path != "/v1/chat/completions":
+            self.send_error(404)
+            return
+        if not self.authorized():
+            return
+        try:
+            request = self.read_request()
+            response_format = request.get("response_format")
+            if isinstance(response_format, dict) and response_format.get("type") == "json_schema":
+                json_schema = response_format.get("json_schema")
+                if isinstance(json_schema, dict) and isinstance(json_schema.get("schema"), dict):
+                    response_format = {"schema": json_schema["schema"], "type": "json_object"}
+            messages = request.get("messages")
+            if not isinstance(messages, list):
+                raise ValueError("messages must be an array")
+            requested_tokens = request.get(
+                "max_tokens",
+                request.get("max_completion_tokens", request.get("max_output_tokens", 256)),
+            )
+            with inference_lock:
+                completion = model.create_chat_completion(
+                    messages=messages,
+                    max_tokens=min(max(1, int(requested_tokens)), MAX_OUTPUT_TOKENS),
+                    response_format=response_format,
+                    temperature=0,
+                )
+            self.respond(completion)
+        except Exception as error:
+            self.respond(
+                {
+                    "error": {
+                        "message": str(error),
+                        "type": "threadnote_local_ai_error",
+                    }
+                },
+                status=500,
+            )
+
+    def read_request(self) -> dict[str, Any]:
+        content_length = int(self.headers.get("content-length", "0"))
+        if content_length <= 0 or content_length > MAX_REQUEST_BYTES:
+            raise ValueError(f"request body must be between 1 and {MAX_REQUEST_BYTES} bytes")
+        parsed = json.loads(self.rfile.read(content_length))
+        if not isinstance(parsed, dict):
+            raise ValueError("request body must be a JSON object")
+        return parsed
+
+    def log_message(self, format: str, *values: object) -> None:
+        return
+
+    def authorized(self) -> bool:
+        supplied = self.headers.get("authorization", "")
+        expected = f"Bearer {access_token}"
+        if hmac.compare_digest(supplied, expected):
+            return True
+        self.respond(
+            {"error": {"message": "Authentication is required.", "type": "authentication_error"}},
+            status=401,
+        )
+        return False
+
+    def respond(self, body: object, status: int = 200) -> None:
+        payload = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def health_proof(challenge: str, pid: int) -> str:
+    payload = "\0".join(
+        [challenge, SERVICE_ID, args.model_id, str(pid), args.launch_id, access_token]
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+# Bind before loading the model. This reserves the port when multiple agent
+# processes notice a stopped service at the same time; the winner loads Gemma,
+# while the others observe the listener and wait for /health.
+server = ThreadingHTTPServer((args.host, args.port), Handler)
+model = Llama(model_path=args.model, n_ctx=4096, n_gpu_layers=-1, verbose=False)
+print(f"Threadnote local AI ready at http://{args.host}:{args.port}/v1", flush=True)
+server.serve_forever()

--- a/src/effect/ai-consolidator.ts
+++ b/src/effect/ai-consolidator.ts
@@ -2,6 +2,14 @@ import * as NodeHttpClient from '@effect/platform-node/NodeHttpClient';
 import {OpenAiClient, OpenAiLanguageModel} from '@effect/ai-openai-compat';
 import {Context, Effect, Layer, pipe, Redacted, Schema} from 'effect';
 import {LanguageModel} from 'effect/unstable/ai';
+import type {RuntimeConfig} from '../types.js';
+import {
+  ensureLocalAiStarted,
+  localAiApiUrl,
+  readLocalAiAccessToken,
+  readLocalAiSettings,
+  type LocalAiSettings,
+} from './local-ai.js';
 
 export const EFFECT_AI_ENABLED_ENV = 'THREADNOTE_EFFECT_AI';
 export const EFFECT_AI_API_KEY_ENV = 'THREADNOTE_EFFECT_AI_API_KEY';
@@ -12,6 +20,11 @@ export interface EffectAiConfiguration {
   readonly apiKey?: string;
   readonly apiUrl?: string;
   readonly model: string;
+}
+
+export interface ResolvedEffectAiConfiguration {
+  readonly configuration: EffectAiConfiguration;
+  readonly localAi?: LocalAiSettings;
 }
 
 export class AiConsolidationFailed extends Schema.TaggedErrorClass<AiConsolidationFailed>()('AiConsolidationFailed', {
@@ -52,15 +65,40 @@ export function effectAiConfiguration(
   };
 }
 
+export const resolveEffectAiConfiguration = Effect.fn('EffectAi.resolveConfiguration')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+  env: Readonly<Record<string, string | undefined>>,
+) {
+  const explicit = effectAiConfiguration(env);
+  if (explicit) return {configuration: explicit} satisfies ResolvedEffectAiConfiguration;
+  if (env[EFFECT_AI_ENABLED_ENV] !== undefined) return undefined;
+  const localAi = yield* readLocalAiSettings(config);
+  if (!localAi) return undefined;
+  const apiKey = yield* readLocalAiAccessToken(config);
+  if (!apiKey) {
+    return yield* Effect.fail(new Error('Local AI access token is missing. Run: threadnote local-ai install --force'));
+  }
+  return {
+    configuration: {
+      apiKey,
+      apiUrl: localAiApiUrl(localAi),
+      model: localAi.model,
+    },
+    localAi,
+  } satisfies ResolvedEffectAiConfiguration;
+});
+
+export const ensureEffectAiReady = Effect.fn('EffectAi.ensureReady')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+  resolved: ResolvedEffectAiConfiguration,
+) {
+  if (resolved.localAi) {
+    yield* ensureLocalAiStarted(config);
+  }
+});
+
 export function aiConsolidatorLayer(config: EffectAiConfiguration): Layer.Layer<AiConsolidator> {
-  const clientLayer = OpenAiClient.layer({
-    apiKey: config.apiKey ? Redacted.make(config.apiKey) : undefined,
-    apiUrl: config.apiUrl,
-  }).pipe(Layer.provide(NodeHttpClient.layerFetch));
-  const languageModelLayer = OpenAiLanguageModel.layer({
-    config: {max_output_tokens: 4000, strictJsonSchema: true},
-    model: config.model,
-  }).pipe(Layer.provide(clientLayer));
+  const languageModelLayer = effectAiLanguageModelLayer(config, 4000);
 
   return Layer.effect(
     AiConsolidator,
@@ -93,6 +131,17 @@ export function aiConsolidatorLayer(config: EffectAiConfiguration): Layer.Layer<
       });
     }),
   ).pipe(Layer.provide(languageModelLayer));
+}
+
+export function effectAiLanguageModelLayer(config: EffectAiConfiguration, maxOutputTokens: number) {
+  const clientLayer = OpenAiClient.layer({
+    apiKey: config.apiKey ? Redacted.make(config.apiKey) : undefined,
+    apiUrl: config.apiUrl,
+  }).pipe(Layer.provide(NodeHttpClient.layerFetch));
+  return OpenAiLanguageModel.layer({
+    config: {max_output_tokens: maxOutputTokens, strictJsonSchema: true},
+    model: config.model,
+  }).pipe(Layer.provide(clientLayer));
 }
 
 export function runEffectAiConsolidation(prompt: string, config: EffectAiConfiguration) {

--- a/src/effect/ai-recall.ts
+++ b/src/effect/ai-recall.ts
@@ -1,0 +1,260 @@
+import {Context, Effect, Layer, Schema} from 'effect';
+import {LanguageModel} from 'effect/unstable/ai';
+import {shouldExpandRecall, type RecallConfidenceLevel} from '../recall/rank.js';
+import type {RuntimeConfig} from '../types.js';
+import {
+  effectAiLanguageModelLayer,
+  ensureEffectAiReady,
+  type EffectAiConfiguration,
+  type ResolvedEffectAiConfiguration,
+} from './ai-consolidator.js';
+import {sha256Hex} from './digest.js';
+
+const MAX_RECALL_REWRITES = 2;
+const MAX_RECALL_REWRITE_LENGTH = 512;
+const MAX_RECALL_EXPANSION_SCOPES = 1;
+const MAX_RECALL_EXPANSION_CACHE_ENTRIES = 128;
+const RECALL_EXPANSION_TIMEOUT_MILLISECONDS = 5_000;
+const RECALL_VOCABULARY_DESCRIPTION_SEPARATOR = ' :: ';
+
+export interface RecallExpansionInput {
+  readonly project?: string;
+  readonly query: string;
+  readonly vocabulary?: readonly string[];
+}
+
+export class AiRecallExpansionFailed extends Schema.TaggedErrorClass<AiRecallExpansionFailed>()(
+  'AiRecallExpansionFailed',
+  {
+    cause: Schema.Defect(),
+    message: Schema.String,
+  },
+) {}
+
+const RecallExpansionDraft = Schema.Struct({
+  queries: Schema.Array(
+    Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(MAX_RECALL_REWRITE_LENGTH)),
+  ).check(Schema.isMinLength(1), Schema.isMaxLength(MAX_RECALL_REWRITES)),
+});
+
+export class RecallQueryExpander extends Context.Service<
+  RecallQueryExpander,
+  {
+    readonly expand: (input: RecallExpansionInput) => Effect.Effect<readonly string[], AiRecallExpansionFailed>;
+  }
+>()('threadnote/effect/RecallQueryExpander') {}
+
+export const expandRecallQueryEffect = Effect.fn('RecallQueryExpander.expand')(function* (input: RecallExpansionInput) {
+  const expander = yield* RecallQueryExpander;
+  return yield* expander.expand(input);
+});
+
+export function recallQueryExpanderLayer(config: EffectAiConfiguration): Layer.Layer<RecallQueryExpander> {
+  return Layer.effect(
+    RecallQueryExpander,
+    Effect.gen(function* () {
+      const model = yield* LanguageModel.LanguageModel;
+      return RecallQueryExpander.of({
+        expand: input =>
+          model
+            .generateObject({
+              objectName: 'threadnote_recall_query_expansion',
+              prompt: recallExpansionPrompt(input),
+              schema: RecallExpansionDraft,
+            })
+            .pipe(
+              Effect.map(response => normalizeRecallRewrites(input.query, response.value.queries, input.vocabulary)),
+              Effect.mapError(cause =>
+                cause instanceof AiRecallExpansionFailed
+                  ? cause
+                  : new AiRecallExpansionFailed({
+                      cause,
+                      message: 'Effect AI recall query expansion failed.',
+                    }),
+              ),
+            ),
+      });
+    }),
+  ).pipe(Layer.provide(effectAiLanguageModelLayer(config, 128)));
+}
+
+const expansionCache = new Map<string, readonly string[]>();
+
+export const runEffectAiRecallExpansion = Effect.fn('RecallQueryExpander.run')(function* (
+  input: RecallExpansionInput,
+  config: EffectAiConfiguration,
+) {
+  const fingerprint = yield* sha256Hex(
+    [
+      config.apiUrl ?? '',
+      config.model,
+      input.project ?? '',
+      normalizeQuery(input.query),
+      ...(input.vocabulary ?? []),
+    ].join('\u0000'),
+  );
+  const cached = expansionCache.get(fingerprint);
+  if (cached) {
+    expansionCache.delete(fingerprint);
+    expansionCache.set(fingerprint, cached);
+    return cached;
+  }
+  const rewrites = yield* expandRecallQueryEffect(input).pipe(
+    Effect.provide(recallQueryExpanderLayer(config)),
+    Effect.timeoutOrElse({
+      duration: RECALL_EXPANSION_TIMEOUT_MILLISECONDS,
+      orElse: () => Effect.succeed([]),
+    }),
+    Effect.catch(() => Effect.succeed([])),
+  );
+  expansionCache.set(fingerprint, rewrites);
+  while (expansionCache.size > MAX_RECALL_EXPANSION_CACHE_ENTRIES) {
+    const oldest = expansionCache.keys().next().value;
+    if (oldest === undefined) break;
+    expansionCache.delete(oldest);
+  }
+  return rewrites;
+});
+
+export const expandWeakRecallQueryEffect = Effect.fn('RecallQueryExpander.expandWeakRecall')(function* (
+  input: RecallExpansionInput & {readonly confidence: {readonly level: RecallConfidenceLevel} | undefined},
+  runtimeConfig: Pick<RuntimeConfig, 'agentContextHome'>,
+  resolved: ResolvedEffectAiConfiguration | undefined,
+) {
+  if (!shouldExpandRecall(input.confidence)) return [];
+  if (!resolved) return [];
+  const ready = yield* ensureEffectAiReady(runtimeConfig, resolved).pipe(
+    Effect.as(true),
+    Effect.timeoutOrElse({
+      duration: RECALL_EXPANSION_TIMEOUT_MILLISECONDS,
+      orElse: () => Effect.succeed(false),
+    }),
+    Effect.catch(() => Effect.succeed(false)),
+  );
+  if (!ready) return [];
+  const config = resolved.configuration;
+  const expansionInput = isLoopbackAiEndpoint(config.apiUrl) ? input : {project: input.project, query: input.query};
+  const rewrites = yield* runEffectAiRecallExpansion(expansionInput, config);
+  return limitRecallRewritesForConfidence(input.confidence, rewrites);
+});
+
+export {shouldExpandRecall};
+
+export function limitRecallRewritesForConfidence(
+  confidence: {readonly level: RecallConfidenceLevel} | undefined,
+  rewrites: readonly string[],
+): readonly string[] {
+  return confidence?.level === 'medium' ? rewrites.slice(0, 1) : rewrites;
+}
+
+export function recallMinimumScoreAfterExpansion(threshold: number, explicitThreshold: boolean): number | undefined {
+  return explicitThreshold ? threshold : undefined;
+}
+
+export function normalizeRecallRewrites(
+  originalQuery: string,
+  rewrites: readonly string[],
+  vocabulary?: readonly string[],
+): readonly string[] {
+  const original = normalizeQuery(originalQuery).toLowerCase();
+  const vocabularyTerms = vocabulary
+    ?.map(term => normalizeQuery(term.split(RECALL_VOCABULARY_DESCRIPTION_SEPARATOR, 1)[0] ?? ''))
+    .filter(term => term.length > 0);
+  const seen = new Set<string>([original]);
+  const normalized: string[] = [];
+  for (const rewrite of rewrites) {
+    const rawCandidate = normalizeQuery(rewrite);
+    const groundedTerm = vocabularyTerms
+      ?.filter(term => containsExactTerm(rawCandidate, term))
+      .sort((left, right) => right.length - left.length)[0];
+    const candidate = vocabularyTerms && vocabularyTerms.length > 0 ? groundedTerm : rawCandidate;
+    const key = candidate?.toLowerCase();
+    if (!candidate || !key || candidate.length > MAX_RECALL_REWRITE_LENGTH || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    normalized.push(candidate);
+    if (normalized.length === MAX_RECALL_REWRITES) break;
+  }
+  return normalized;
+}
+
+export function boundedRecallExpansionScopes(scopes: readonly (string | undefined)[]): readonly (string | undefined)[] {
+  const seen = new Set<string>();
+  const bounded: Array<string | undefined> = [];
+  for (const scope of scopes) {
+    const key = scope ?? '';
+    if (seen.has(key)) continue;
+    seen.add(key);
+    bounded.push(scope);
+    if (bounded.length === MAX_RECALL_EXPANSION_SCOPES) break;
+  }
+  return bounded;
+}
+
+function recallExpansionPrompt(input: RecallExpansionInput): string {
+  const localVocabulary = input.vocabulary?.filter(term => term.trim().length > 0);
+  if (localVocabulary && localVocabulary.length > 0) {
+    return [
+      'Select at most two memory-search topics from the local project vocabulary.',
+      'Match the meaning of the original query to the most relevant existing topic or identifier.',
+      'Judge the whole query; do not select a topic because it matches only one incidental word.',
+      'Treat generic project, platform, device, and app words as context rather than the primary match.',
+      'Resolve paraphrases into their conventional technical mechanism, then prefer the candidate whose topic or excerpt names that mechanism.',
+      'Return one query by default. Return two only when two vocabulary items are near-equal semantic matches.',
+      'Every query must contain at least one vocabulary item copied exactly, including punctuation.',
+      'Prefer an exact vocabulary item over an invented synonym or hyphenated paraphrase.',
+      'Add original query terms only when they help disambiguate the selected vocabulary item.',
+      'Candidate entries use "topic :: local index excerpt". Copy only the topic before "::", not the excerpt.',
+      'Do not answer the question, write prose, or introduce another topic.',
+      `Project: ${input.project ?? 'unknown'}`,
+      `Original query: ${input.query}`,
+      `Local candidates:\n${localVocabulary.map(candidate => `- ${candidate}`).join('\n')}`,
+    ].join('\n');
+  }
+  return [
+    'Rewrite a weak memory-search query into at most two concise keyword-style retrieval queries.',
+    'Translate conversational wording into likely source-code, configuration, and feature terminology.',
+    'Each array item must be one complete search phrase, not one token.',
+    'Keep the original topic and nouns; do not answer the question, write prose, or introduce another topic.',
+    'Preserve identifiers, quoted strings, version numbers, platform names, and proper nouns exactly.',
+    'Do not add facts that are not implied by the query or project.',
+    `Project: ${input.project ?? 'unknown'}`,
+    `Original query: ${input.query}`,
+  ].join('\n');
+}
+
+export function isLoopbackAiEndpoint(apiUrl: string | undefined): boolean {
+  if (!apiUrl) return false;
+  try {
+    const hostname = new URL(apiUrl).hostname.toLowerCase();
+    return (
+      hostname === '127.0.0.1' || hostname === '::1' || hostname === 'localhost' || hostname.endsWith('.localhost')
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function localRecallAiEnabled(config: EffectAiConfiguration | undefined): boolean {
+  return config !== undefined && isLoopbackAiEndpoint(config.apiUrl);
+}
+
+function normalizeQuery(query: string): string {
+  return query.replace(/\s+/g, ' ').trim();
+}
+
+function containsExactTerm(candidate: string, term: string): boolean {
+  const normalizedCandidate = candidate.toLowerCase();
+  const normalizedTerm = term.toLowerCase();
+  let offset = normalizedCandidate.indexOf(normalizedTerm);
+  while (offset >= 0) {
+    const before = normalizedCandidate[offset - 1];
+    const after = normalizedCandidate[offset + normalizedTerm.length];
+    if ((!before || !/[a-z0-9]/.test(before)) && (!after || !/[a-z0-9]/.test(after))) {
+      return true;
+    }
+    offset = normalizedCandidate.indexOf(normalizedTerm, offset + 1);
+  }
+  return false;
+}

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -4,6 +4,15 @@ import {OPENVIKING_MCP_NAME} from '../constants.js';
 import {runHooksInstall, runPreCompactHook, runSessionStartHook} from '../hooks.js';
 import {runDoctor, runInstall, runRepair, runStart, runStop, runUninstall} from '../lifecycle.js';
 import {
+  ensureLocalAiStarted,
+  readLocalAiSettings,
+  runLocalAiInstall,
+  runLocalAiStart,
+  runLocalAiStatus,
+  runLocalAiStop,
+  runLocalAiUninstall,
+} from './local-ai.js';
+import {
   runArchive,
   runCompact,
   runExportPack,
@@ -39,7 +48,8 @@ import {
   runShareUnpublish,
 } from './share.js';
 import type {RuntimeConfig} from '../types.js';
-import {maybeNotifyUpdate, runPostUpdate, runUpdate} from '../update.js';
+import {maybeNotifyUpdate, maybeRunPostUpdateAfterRepair, runPostUpdate, runUpdate} from '../update.js';
+import {errorMessage} from '../utils.js';
 import {runVersion} from '../version_command.js';
 import {runManage} from '../manager.js';
 import {applicationError} from './errors.js';
@@ -178,6 +188,7 @@ const install = Command.make(
     withRuntimeEffect(config =>
       Effect.gen(function* () {
         yield* runInstall(config, options);
+        yield* maybeRunPostUpdateAfterRepair(config, {dryRun: options.dryRun});
         if (options.withHooks) {
           for (const agent of ['claude', 'codex', 'cursor', 'copilot'] as const) {
             yield* Console.log(`\n--- ${agent} hooks ---`);
@@ -218,7 +229,7 @@ const update = Command.make(
     registry: optionalString('registry', 'npm registry URL'),
     repair: negatedBoolean('repair', 'Skip threadnote repair after updating the package'),
     runtime: defaultChoice('runtime', ['auto', 'npm', 'bun', 'deno'], 'auto, npm, bun, or deno', 'auto'),
-    yes: boolean('yes', 'Accept applicable post-update migrations without prompting'),
+    yes: boolean('yes', 'Accept applicable post-update actions without prompting'),
   },
   options => withRuntimeEffect(config => runUpdate(config, options)),
 ).pipe(Command.withDescription('Update the published Threadnote package, then repair local shims and MCP config'));
@@ -229,10 +240,10 @@ const postUpdate = Command.make(
     dryRun: boolean('dry-run', 'Print post-update actions without running them'),
     fromVersion: requiredString('from-version', 'Version before update'),
     toVersion: requiredString('to-version', 'Version after update'),
-    yes: boolean('yes', 'Accept applicable post-update migrations without prompting'),
+    yes: boolean('yes', 'Accept applicable post-update actions without prompting'),
   },
   options => withRuntimeEffect(config => runPostUpdate(config, options)),
-).pipe(Command.withDescription('Run packaged post-update migration prompts'), Command.withHidden);
+).pipe(Command.withDescription('Run packaged post-update action prompts'), Command.withHidden);
 
 const repair = Command.make(
   'repair',
@@ -251,6 +262,15 @@ const repair = Command.make(
     withRuntimeEffect(config =>
       Effect.gen(function* () {
         yield* runRepair(config, options);
+        if (options.start !== false && (yield* readLocalAiSettings(config))) {
+          if (options.dryRun) {
+            yield* runLocalAiStart(config, {dryRun: true});
+          } else {
+            yield* ensureLocalAiStarted(config).pipe(
+              Effect.catch(error => Console.warn(`WARN could not repair local AI health: ${errorMessage(error)}`)),
+            );
+          }
+        }
         yield* maybeNotifyUpdate(config, {dryRun: options.dryRun});
       }),
     ),
@@ -268,7 +288,14 @@ const start = Command.make(
   options =>
     withRuntimeEffect(config =>
       Effect.gen(function* () {
+        const localAiConfigured = (yield* readLocalAiSettings(config)) !== undefined;
+        if (options.foreground && localAiConfigured) {
+          yield* runLocalAiStart(config, options);
+        }
         yield* runStart(config, options);
+        if (!options.foreground && localAiConfigured) {
+          yield* runLocalAiStart(config, options);
+        }
         yield* maybeNotifyUpdate(config, {dryRun: options.dryRun});
       }),
     ),
@@ -277,7 +304,15 @@ const start = Command.make(
 const stop = Command.make(
   'stop',
   {dryRun: boolean('dry-run', 'Print the stop actions without running them')},
-  options => withRuntimeEffect(config => runStop(config, options)),
+  options =>
+    withRuntimeEffect(config =>
+      Effect.gen(function* () {
+        if (yield* readLocalAiSettings(config)) {
+          yield* runLocalAiStop(config, options);
+        }
+        yield* runStop(config, options);
+      }),
+    ),
 ).pipe(Command.withDescription('Stop the local OpenViking server or LaunchAgent'));
 
 const uninstall = Command.make(
@@ -292,8 +327,57 @@ const uninstall = Command.make(
     ),
     preserveMemories: boolean('preserve-memories', 'Preserve THREADNOTE_HOME and OpenViking memories (default)'),
   },
-  options => withRuntimeEffect(config => runUninstall(config, options)),
+  options =>
+    withRuntimeEffect(config =>
+      Effect.gen(function* () {
+        if (yield* readLocalAiSettings(config)) {
+          yield* runLocalAiStop(config, options);
+        }
+        yield* runUninstall(config, options);
+      }),
+    ),
 ).pipe(Command.withDescription('Remove Threadnote setup and optionally erase local memories'));
+
+const localAiInstall = Command.make(
+  'install',
+  {
+    dryRun: boolean('dry-run', 'Print local AI installation actions without making changes'),
+    force: boolean('force', 'Re-download and re-verify the managed model'),
+    modelPath: optionalString('model-path', 'Use an existing verified Gemma 4 E4B Q4_0 GGUF file'),
+    start: negatedBoolean('start', 'Install and configure without starting the local model service'),
+  },
+  options => withRuntimeEffect(config => runLocalAiInstall(config, options)),
+).pipe(Command.withDescription('Install and enable the recommended local recall model'));
+
+const localAiStart = Command.make(
+  'start',
+  {dryRun: boolean('dry-run', 'Print the local AI start action without running it')},
+  options => withRuntimeEffect(config => runLocalAiStart(config, options)),
+).pipe(Command.withDescription('Start the configured loopback model service'));
+
+const localAiStop = Command.make(
+  'stop',
+  {dryRun: boolean('dry-run', 'Print the local AI stop action without running it')},
+  options => withRuntimeEffect(config => runLocalAiStop(config, options)),
+).pipe(Command.withDescription('Stop the configured loopback model service'));
+
+const localAiStatus = Command.make('status', {}, () => withRuntimeEffect(config => runLocalAiStatus(config))).pipe(
+  Command.withDescription('Show local model installation and health'),
+);
+
+const localAiUninstall = Command.make(
+  'uninstall',
+  {
+    dryRun: boolean('dry-run', 'Print local AI removal actions without making changes'),
+    eraseModel: boolean('erase-model', 'Also delete a model inside the Threadnote-managed model directory'),
+  },
+  options => withRuntimeEffect(config => runLocalAiUninstall(config, options)),
+).pipe(Command.withDescription('Disable local AI and optionally remove its managed model'));
+
+const localAi = Command.make('local-ai').pipe(
+  Command.withDescription('Manage opt-in local AI recall'),
+  Command.withSubcommands([localAiInstall, localAiStart, localAiStop, localAiStatus, localAiUninstall]),
+);
 
 const seed = Command.make(
   'seed',
@@ -739,6 +823,7 @@ export const threadnoteCommand = root.pipe(
     start,
     stop,
     uninstall,
+    localAi,
     seed,
     initManifest,
     seedSkills,

--- a/src/effect/local-ai.ts
+++ b/src/effect/local-ai.ts
@@ -1,0 +1,821 @@
+import * as ChildProcess from 'effect/unstable/process/ChildProcess';
+import {Clock, Console, Crypto, Effect, Encoding, FileSystem, Path, Result} from 'effect';
+import {runCommandEffect, runStreamingCommandEffect} from './command.js';
+import {sha256Hex} from './digest.js';
+import {withExclusiveFileLock} from './file_lock.js';
+import {getJsonEffect} from './http.js';
+import {SystemInfo} from './system.js';
+import type {RuntimeConfig} from '../types.js';
+import {
+  ensureDirectory,
+  errorMessage,
+  expandPath,
+  findExecutable,
+  findOpenVikingCli,
+  isJsonObject,
+  isTcpPortOpen,
+  readFileIfExists,
+  toolRoot,
+} from '../utils.js';
+
+export const LOCAL_AI_MODEL_ID = 'gemma-4-E4B-it-Q4_0';
+export const LOCAL_AI_MODEL_FILE = 'gemma-4-E4B-it-Q4_0.gguf';
+export const LOCAL_AI_MODEL_REPOSITORY = 'ggml-org/gemma-4-E4B-it-GGUF';
+export const LOCAL_AI_MODEL_REVISION = '06f24bb269339b2a19a5167199b81e89ef813c10';
+export const LOCAL_AI_MODEL_SHA256 = 'a555b900214b477d8880e7832e0b8925e139b0159640036b09fe472b6f2097f2';
+export const LOCAL_AI_MODEL_SIZE = 4_590_807_392;
+export const LOCAL_AI_DEFAULT_PORT = 1934;
+
+const LOCAL_AI_CONFIG_VERSION = 1;
+const LOCAL_AI_CONFIG_FILE = 'local-ai.json';
+const LOCAL_AI_TOKEN_FILE = 'local-ai-token';
+const LOCAL_AI_LOCK_FILE = 'local-ai-server.lock';
+const LOCAL_AI_PID_FILE = 'local-ai-server.json';
+const LOCAL_AI_SERVICE_ID = 'threadnote-local-ai';
+const LOCAL_AI_SERVER_SCRIPT = 'local-ai-server.py';
+const LOCAL_AI_START_TIMEOUT_MILLISECONDS = 60_000;
+const LOCAL_AI_STOP_TIMEOUT_MILLISECONDS = 10_000;
+const LOCAL_AI_POLL_MILLISECONDS = 250;
+const LOCAL_AI_LOCK_STALE_MILLISECONDS = 90_000;
+const LOCAL_AI_LOCK_WAIT_MILLISECONDS = 75_000;
+type LocalAiRuntimeConfig = Pick<RuntimeConfig, 'agentContextHome'>;
+
+export interface LocalAiSettings {
+  readonly enabled: true;
+  readonly host: '127.0.0.1';
+  readonly model: string;
+  readonly modelPath: string;
+  readonly port: number;
+  readonly version: 1;
+}
+
+interface LocalAiProcessRecord {
+  readonly launchId: string;
+  readonly modelPath: string;
+  readonly pid: number;
+  readonly startedAt: string;
+  readonly version: 1;
+}
+
+interface LocalAiHealth {
+  readonly launchId: string;
+  readonly model: string;
+  readonly pid: number;
+  readonly service: typeof LOCAL_AI_SERVICE_ID;
+  readonly status: 'ok';
+}
+
+export interface LocalAiInstallOptions {
+  readonly dryRun?: boolean;
+  readonly force?: boolean;
+  readonly modelPath?: string;
+  readonly start?: boolean;
+}
+
+export interface LocalAiLifecycleOptions {
+  readonly dryRun?: boolean;
+}
+
+export interface LocalAiUninstallOptions extends LocalAiLifecycleOptions {
+  readonly eraseModel?: boolean;
+}
+
+export const runLocalAiInstall = Effect.fn('localAi.install')(function* (
+  config: RuntimeConfig,
+  options: LocalAiInstallOptions,
+) {
+  const dryRun = options.dryRun === true;
+  const pathService = yield* Path.Path;
+  const managedModelPath = yield* localAiManagedModelPath(config);
+  const modelPath = options.modelPath ? yield* expandPath(options.modelPath) : managedModelPath;
+  const settings: LocalAiSettings = {
+    enabled: true,
+    host: '127.0.0.1',
+    model: LOCAL_AI_MODEL_ID,
+    modelPath,
+    port: LOCAL_AI_DEFAULT_PORT,
+    version: LOCAL_AI_CONFIG_VERSION,
+  };
+  const configPath = yield* localAiConfigPath(config);
+  const tokenPath = yield* localAiTokenPath(config);
+
+  if (dryRun) {
+    if (!options.modelPath) {
+      yield* Console.log(
+        `Would download ${LOCAL_AI_MODEL_REPOSITORY}/${LOCAL_AI_MODEL_FILE} (${formatModelSize(LOCAL_AI_MODEL_SIZE)}) to ${modelPath}.`,
+      );
+    } else {
+      yield* Console.log(`Would verify existing model: ${modelPath}`);
+    }
+    yield* Console.log(`Would verify SHA-256 ${LOCAL_AI_MODEL_SHA256}.`);
+    yield* Console.log(`Would write local AI configuration: ${configPath}`);
+    yield* Console.log(`Would create a private local AI access token: ${tokenPath}`);
+    if (options.start !== false) {
+      yield* Console.log(`Would start the loopback model service at ${localAiApiUrl(settings)}.`);
+    }
+    return;
+  }
+
+  let verified = false;
+  if (!options.modelPath) {
+    if (options.force !== true) {
+      verified = yield* verifyLocalAiModel(modelPath).pipe(
+        Effect.as(true),
+        Effect.catch(() => Effect.succeed(false)),
+      );
+    }
+    if (!verified) {
+      const fs = yield* FileSystem.FileSystem;
+      yield* fs.remove(modelPath, {force: true});
+      yield* ensureDirectory(pathService.dirname(modelPath), false);
+      const {args, executable} = yield* localAiDownloadCommand(modelPath);
+      yield* Console.log(
+        `Downloading ${LOCAL_AI_MODEL_ID} (${formatModelSize(LOCAL_AI_MODEL_SIZE)}). This is a one-time local download.`,
+      );
+      const download = yield* runStreamingCommandEffect(executable, args);
+      if (download.exitCode !== 0) {
+        return yield* Effect.fail(new Error(`Local AI model download exited with ${download.exitCode}.`));
+      }
+    }
+  }
+
+  if (!verified) {
+    yield* verifyLocalAiModel(modelPath);
+  }
+  yield* ensureLocalAiAccessToken(config);
+  yield* writeLocalAiSettings(config, settings);
+  yield* Console.log(`Enabled local AI recall with ${LOCAL_AI_MODEL_ID}.`);
+  yield* Console.log(`Configuration: ${configPath}`);
+  if (options.start !== false) {
+    yield* startLocalAiServer(config, settings, {announce: true});
+  }
+});
+
+export const runLocalAiStart = Effect.fn('localAi.start')(function* (
+  config: RuntimeConfig,
+  options: LocalAiLifecycleOptions,
+) {
+  const settings = yield* requireLocalAiSettings(config);
+  if (options.dryRun === true) {
+    yield* Console.log(`Would start ${settings.model} at ${localAiApiUrl(settings)}.`);
+    return;
+  }
+  yield* startLocalAiServer(config, settings, {announce: true});
+});
+
+export const ensureLocalAiStarted = Effect.fn('localAi.ensureStarted')(function* (config: LocalAiRuntimeConfig) {
+  const settings = yield* readLocalAiSettings(config);
+  if (!settings) return false;
+  yield* startLocalAiServer(config, settings, {announce: false});
+  return true;
+});
+
+export const runLocalAiStop = Effect.fn('localAi.stop')(function* (
+  config: RuntimeConfig,
+  options: LocalAiLifecycleOptions,
+) {
+  yield* withLocalAiLifecycleLock(
+    config,
+    Effect.gen(function* () {
+      const record = yield* readLocalAiProcessRecord(config);
+      if (!record) {
+        if (options.dryRun !== true) {
+          yield* Console.log('No Threadnote local AI process is recorded.');
+        }
+        return;
+      }
+      if (options.dryRun === true) {
+        yield* Console.log(`Would stop Threadnote local AI process ${record.pid}.`);
+        return;
+      }
+      yield* stopLocalAiProcess(config, record);
+    }),
+  );
+});
+
+export const runLocalAiStatus = Effect.fn('localAi.status')(function* (config: RuntimeConfig) {
+  const settings = yield* readLocalAiSettings(config);
+  if (!settings) {
+    yield* Console.log('Local AI recall is not installed.');
+    yield* Console.log('Install it with: threadnote local-ai install');
+    return;
+  }
+  const fs = yield* FileSystem.FileSystem;
+  const modelInfo = yield* fs.stat(settings.modelPath).pipe(Effect.catch(() => Effect.succeed(undefined)));
+  const token = yield* requireLocalAiAccessToken(config);
+  const health = yield* readLocalAiHealth(settings, token);
+  yield* Console.log(`Local AI recall: enabled`);
+  yield* Console.log(`Model: ${settings.model}`);
+  yield* Console.log(`Model file: ${settings.modelPath}`);
+  yield* Console.log(
+    `Model present: ${modelInfo?.type === 'File' && Number(modelInfo.size) === LOCAL_AI_MODEL_SIZE ? 'yes' : 'no'}`,
+  );
+  yield* Console.log(`Endpoint: ${localAiApiUrl(settings)}`);
+  yield* Console.log(health ? `Service: healthy (pid ${health.pid})` : 'Service: stopped or unhealthy');
+});
+
+export const runLocalAiUninstall = Effect.fn('localAi.uninstall')(function* (
+  config: RuntimeConfig,
+  options: LocalAiUninstallOptions,
+) {
+  const settings = yield* readLocalAiSettings(config);
+  const configPath = yield* localAiConfigPath(config);
+  if (options.dryRun === true) {
+    yield* runLocalAiStop(config, options);
+    yield* Console.log(`Would remove local AI configuration: ${configPath}`);
+    if (options.eraseModel === true && settings) {
+      yield* Console.log(`Would remove managed local AI model when safe: ${settings.modelPath}`);
+    }
+    return;
+  }
+  yield* runLocalAiStop(config, options);
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.remove(configPath, {force: true});
+  yield* fs.remove(yield* localAiTokenPath(config), {force: true});
+  if (options.eraseModel === true && settings) {
+    const managedDirectory = yield* localAiModelsDirectory(config);
+    const pathService = yield* Path.Path;
+    const relative = pathService.relative(managedDirectory, settings.modelPath);
+    if (relative && !relative.startsWith('..') && !pathService.isAbsolute(relative)) {
+      yield* fs.remove(settings.modelPath, {force: true});
+      yield* Console.log(`Removed local AI model: ${settings.modelPath}`);
+    } else {
+      yield* Console.log(`Preserved external model path: ${settings.modelPath}`);
+    }
+  }
+  yield* Console.log('Disabled Threadnote local AI recall.');
+});
+
+export const readLocalAiSettings = Effect.fn('localAi.readSettings')(function* (config: LocalAiRuntimeConfig) {
+  const raw = yield* readFileIfExists(yield* localAiConfigPath(config));
+  if (!raw) return undefined;
+  return yield* Effect.try({
+    try: () => parseLocalAiSettings(JSON.parse(raw)),
+    catch: cause => new Error(`Invalid Threadnote local AI configuration: ${errorMessage(cause)}`, {cause}),
+  });
+});
+
+export function parseLocalAiSettings(value: unknown): LocalAiSettings {
+  if (
+    !isJsonObject(value) ||
+    value.version !== LOCAL_AI_CONFIG_VERSION ||
+    value.enabled !== true ||
+    value.host !== '127.0.0.1' ||
+    typeof value.model !== 'string' ||
+    value.model.trim().length === 0 ||
+    typeof value.modelPath !== 'string' ||
+    value.modelPath.trim().length === 0 ||
+    !Number.isInteger(value.port) ||
+    (value.port as number) < 1 ||
+    (value.port as number) > 65_535
+  ) {
+    throw new Error(`${LOCAL_AI_CONFIG_FILE} has an unsupported shape.`);
+  }
+  return {
+    enabled: true,
+    host: '127.0.0.1',
+    model: value.model,
+    modelPath: value.modelPath,
+    port: value.port as number,
+    version: LOCAL_AI_CONFIG_VERSION,
+  };
+}
+
+export function localAiApiUrl(settings: Pick<LocalAiSettings, 'host' | 'port'>): string {
+  return `http://${settings.host}:${settings.port}/v1`;
+}
+
+const startLocalAiServer = Effect.fn('localAi.startServer')(function* (
+  config: LocalAiRuntimeConfig,
+  settings: LocalAiSettings,
+  options: {readonly announce: boolean},
+) {
+  const token = yield* requireLocalAiAccessToken(config);
+  yield* withLocalAiLifecycleLock(config, startLocalAiServerUnlocked(config, settings, token, options));
+});
+
+const startLocalAiServerUnlocked = Effect.fn('localAi.startServerUnlocked')(function* (
+  config: LocalAiRuntimeConfig,
+  settings: LocalAiSettings,
+  token: string,
+  options: {readonly announce: boolean},
+) {
+  const healthy = yield* readLocalAiHealth(settings, token);
+  if (healthy) {
+    if (healthy.model !== settings.model) {
+      return yield* Effect.fail(
+        new Error(`Local AI endpoint is serving ${healthy.model}, but Threadnote is configured for ${settings.model}.`),
+      );
+    }
+    if (options.announce) {
+      yield* Console.log(`Local AI is already healthy at ${localAiApiUrl(settings)} (pid ${healthy.pid}).`);
+    }
+    return;
+  }
+
+  yield* assertLocalAiModelPresent(settings);
+  const system = yield* SystemInfo;
+  const existingRecord = yield* readLocalAiProcessRecord(config);
+  if (existingRecord && system.isProcessRunning(existingRecord.pid)) {
+    const recovered = yield* waitForLocalAiHealth(settings, token, LOCAL_AI_START_TIMEOUT_MILLISECONDS);
+    if (
+      recovered?.pid === existingRecord.pid &&
+      recovered.launchId === existingRecord.launchId &&
+      recovered.model === settings.model
+    ) {
+      return;
+    }
+    return yield* Effect.fail(
+      new Error(
+        `Recorded local AI process ${existingRecord.pid} is running but ownership could not be verified. ` +
+          'Inspect it before removing the process record or stopping it manually.',
+      ),
+    );
+  }
+  if (existingRecord) {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(yield* localAiPidPath(config), {force: true});
+  }
+  if (yield* isTcpPortOpen(settings.host, settings.port, 300)) {
+    return yield* Effect.fail(
+      new Error(
+        `Port ${settings.host}:${settings.port} is in use by a service that is not Threadnote local AI. ` +
+          'Stop it before running threadnote local-ai start.',
+      ),
+    );
+  }
+
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const python = yield* resolveOpenVikingPython();
+  const script = pathService.join(yield* toolRoot(), 'scripts', LOCAL_AI_SERVER_SCRIPT);
+  const tokenPath = yield* localAiTokenPath(config);
+  const logPath = pathService.join(config.agentContextHome, 'logs', 'local-ai.log');
+  const crypto = yield* Crypto.Crypto;
+  const launchId = yield* crypto.randomUUIDv4;
+  yield* ensureDirectory(pathService.dirname(logPath), false);
+  yield* fs.writeFileString(logPath, '', {flag: 'a', mode: 0o600});
+  const args = [
+    script,
+    '--host',
+    settings.host,
+    '--port',
+    String(settings.port),
+    '--model',
+    settings.modelPath,
+    '--model-id',
+    settings.model,
+    '--token-file',
+    tokenPath,
+    '--launch-id',
+    launchId,
+    '--log',
+    logPath,
+  ];
+  const pid = yield* Effect.scoped(spawnDetachedLocalAi(python, args));
+  const record: LocalAiProcessRecord = {
+    launchId,
+    modelPath: settings.modelPath,
+    pid,
+    startedAt: new Date(yield* Clock.currentTimeMillis).toISOString(),
+    version: 1,
+  };
+  yield* fs.writeFileString(yield* localAiPidPath(config), `${JSON.stringify(record, null, 2)}\n`, {mode: 0o600});
+  const started = yield* waitForLocalAiHealth(settings, token, LOCAL_AI_START_TIMEOUT_MILLISECONDS);
+  if (!started) {
+    yield* terminateLocalAiProcess(pid).pipe(Effect.ignore);
+    yield* fs.remove(yield* localAiPidPath(config), {force: true});
+    return yield* Effect.fail(
+      new Error(
+        `Local AI process ${pid} did not become healthy within ${LOCAL_AI_START_TIMEOUT_MILLISECONDS / 1000}s. ` +
+          `Logs: ${logPath}`,
+      ),
+    );
+  }
+  if (started.pid !== pid || started.launchId !== launchId) {
+    yield* terminateLocalAiProcess(pid).pipe(Effect.ignore);
+    yield* fs.remove(yield* localAiPidPath(config), {force: true});
+    return yield* Effect.fail(
+      new Error(
+        `Local AI endpoint changed ownership while process ${pid} was starting; refusing to record or stop pid ${started.pid}.`,
+      ),
+    );
+  }
+  if (options.announce) {
+    yield* Console.log(`Started local AI with pid ${pid}. Endpoint: ${localAiApiUrl(settings)}. Logs: ${logPath}`);
+  }
+});
+
+const spawnDetachedLocalAi = Effect.fn('localAi.spawnDetached')(function* (
+  executable: string,
+  args: readonly string[],
+) {
+  const child = yield* ChildProcess.make(executable, [...args], {
+    detached: true,
+    stderr: 'ignore',
+    stdin: 'ignore',
+    stdout: 'ignore',
+  });
+  yield* child.unref;
+  return Number(child.pid);
+});
+
+const stopLocalAiProcess = Effect.fn('localAi.stopProcess')(function* (
+  config: LocalAiRuntimeConfig,
+  record: LocalAiProcessRecord,
+) {
+  const system = yield* SystemInfo;
+  const fs = yield* FileSystem.FileSystem;
+  const pidPath = yield* localAiPidPath(config);
+  if (!system.isProcessRunning(record.pid)) {
+    yield* fs.remove(pidPath, {force: true});
+    yield* Console.log(`Removed stale local AI process record for ${record.pid}.`);
+    return;
+  }
+  const settings = yield* readLocalAiSettings(config);
+  const token = settings ? yield* requireLocalAiAccessToken(config) : undefined;
+  const health = settings && token ? yield* readLocalAiHealth(settings, token) : undefined;
+  if (!settings || !health || !localAiProcessOwnershipMatches(record, health, settings)) {
+    return yield* Effect.fail(
+      new Error(
+        `Refusing to stop pid ${record.pid}: Threadnote could not verify the recorded local AI process. ` +
+          'Inspect the process before stopping it manually or removing the stale process record.',
+      ),
+    );
+  }
+  yield* terminateLocalAiProcess(record.pid);
+  const stopped = yield* waitForProcessExit(record.pid, LOCAL_AI_STOP_TIMEOUT_MILLISECONDS);
+  if (!stopped) {
+    return yield* Effect.fail(
+      new Error(`Local AI process ${record.pid} did not stop within ${LOCAL_AI_STOP_TIMEOUT_MILLISECONDS / 1000}s.`),
+    );
+  }
+  yield* fs.remove(pidPath, {force: true});
+  yield* Console.log(`Stopped Threadnote local AI process ${record.pid}.`);
+});
+
+const terminateLocalAiProcess = Effect.fn('localAi.terminateProcess')(function* (pid: number) {
+  const system = yield* SystemInfo;
+  return yield* Effect.try({
+    try: () => system.signalProcess(pid, 'SIGTERM'),
+    catch: cause => new Error(`Could not stop local AI process ${pid}: ${errorMessage(cause)}`, {cause}),
+  });
+});
+
+const waitForProcessExit = Effect.fn('localAi.waitForProcessExit')(function* (pid: number, timeoutMs: number) {
+  const system = yield* SystemInfo;
+  const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+  while ((yield* Clock.currentTimeMillis) < deadline) {
+    if (!system.isProcessRunning(pid)) return true;
+    yield* Effect.sleep(LOCAL_AI_POLL_MILLISECONDS);
+  }
+  return !system.isProcessRunning(pid);
+});
+
+const readLocalAiHealth = Effect.fn('localAi.readHealth')(function* (settings: LocalAiSettings, token: string) {
+  const crypto = yield* Crypto.Crypto;
+  const challenge = Encoding.encodeBase64Url(yield* crypto.randomBytes(24));
+  const response = yield* getJsonEffect(
+    `http://${settings.host}:${settings.port}/health?challenge=${encodeURIComponent(challenge)}`,
+    {timeoutMs: 800},
+  ).pipe(Effect.result);
+  if (Result.isFailure(response)) return undefined;
+  const body = response.success.body;
+  if (
+    !isJsonObject(body) ||
+    body.status !== 'ok' ||
+    body.service !== LOCAL_AI_SERVICE_ID ||
+    typeof body.model !== 'string' ||
+    typeof body.launchId !== 'string' ||
+    typeof body.proof !== 'string' ||
+    !Number.isInteger(body.pid) ||
+    (body.pid as number) <= 0
+  ) {
+    return undefined;
+  }
+  const proof = yield* localAiHealthProof({
+    challenge,
+    launchId: body.launchId,
+    model: body.model,
+    pid: body.pid as number,
+    token,
+  });
+  if (!constantTimeTextEqual(body.proof, proof)) {
+    return undefined;
+  }
+  return {
+    launchId: body.launchId,
+    model: body.model,
+    pid: body.pid as number,
+    service: LOCAL_AI_SERVICE_ID,
+    status: 'ok',
+  } satisfies LocalAiHealth;
+});
+
+const waitForLocalAiHealth = Effect.fn('localAi.waitForHealth')(function* (
+  settings: LocalAiSettings,
+  token: string,
+  timeoutMs: number,
+) {
+  const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+  while ((yield* Clock.currentTimeMillis) < deadline) {
+    const health = yield* readLocalAiHealth(settings, token);
+    if (health?.model === settings.model) return health;
+    yield* Effect.sleep(LOCAL_AI_POLL_MILLISECONDS);
+  }
+  return undefined;
+});
+
+export function localAiProcessOwnershipMatches(
+  record: Pick<LocalAiProcessRecord, 'launchId' | 'modelPath' | 'pid'>,
+  health: Pick<LocalAiHealth, 'launchId' | 'model' | 'pid'> | undefined,
+  settings: Pick<LocalAiSettings, 'model' | 'modelPath'>,
+): boolean {
+  return (
+    health !== undefined &&
+    record.pid === health.pid &&
+    record.launchId === health.launchId &&
+    record.modelPath === settings.modelPath &&
+    health.model === settings.model
+  );
+}
+
+export const localAiHealthProof = Effect.fn('localAi.healthProof')(function* (input: {
+  readonly challenge: string;
+  readonly launchId: string;
+  readonly model: string;
+  readonly pid: number;
+  readonly token: string;
+}) {
+  return yield* sha256Hex(
+    [input.challenge, LOCAL_AI_SERVICE_ID, input.model, String(input.pid), input.launchId, input.token].join('\u0000'),
+  );
+});
+
+function constantTimeTextEqual(left: string, right: string): boolean {
+  const maximumLength = Math.max(left.length, right.length);
+  let difference = left.length ^ right.length;
+  for (let index = 0; index < maximumLength; index += 1) {
+    difference |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+  }
+  return difference === 0;
+}
+
+const assertLocalAiModelPresent = Effect.fn('localAi.assertModelPresent')(function* (settings: LocalAiSettings) {
+  const fs = yield* FileSystem.FileSystem;
+  const info = yield* fs.stat(settings.modelPath).pipe(Effect.catch(() => Effect.succeed(undefined)));
+  if (info?.type !== 'File' || Number(info.size) !== LOCAL_AI_MODEL_SIZE) {
+    return yield* Effect.fail(
+      new Error(
+        `Configured local AI model is missing or has the wrong size: ${settings.modelPath}. ` +
+          'Run threadnote local-ai install --force.',
+      ),
+    );
+  }
+});
+
+const verifyLocalAiModel = Effect.fn('localAi.verifyModel')(function* (modelPath: string) {
+  yield* assertLocalAiModelPresent({
+    enabled: true,
+    host: '127.0.0.1',
+    model: LOCAL_AI_MODEL_ID,
+    modelPath,
+    port: LOCAL_AI_DEFAULT_PORT,
+    version: 1,
+  });
+  yield* Console.log(`Verifying ${LOCAL_AI_MODEL_ID} SHA-256.`);
+  const digest = yield* sha256File(modelPath);
+  if (digest !== LOCAL_AI_MODEL_SHA256) {
+    return yield* Effect.fail(
+      new Error(`Local AI model checksum mismatch for ${modelPath}. Expected ${LOCAL_AI_MODEL_SHA256}, got ${digest}.`),
+    );
+  }
+});
+
+const sha256File = Effect.fn('localAi.sha256File')(function* (filePath: string) {
+  const system = yield* SystemInfo;
+  const command =
+    system.platform === 'win32'
+      ? yield* findHashCommand(['certutil'], executable => ({args: ['-hashfile', filePath, 'SHA256'], executable}))
+      : yield* findHashCommand(['shasum'], executable => ({args: ['-a', '256', filePath], executable})).pipe(
+          Effect.catch(() => findHashCommand(['sha256sum'], executable => ({args: [filePath], executable}))),
+        );
+  const result = yield* runCommandEffect(command.executable, command.args);
+  for (const line of result.stdout.split(/\r?\n/)) {
+    const firstToken = line.trim().split(/\s+/, 1)[0] ?? '';
+    if (/^[a-f0-9]{64}$/i.test(firstToken)) return firstToken.toLowerCase();
+    const compact = line.replace(/\s+/g, '');
+    if (/^[a-f0-9]{64}$/i.test(compact)) return compact.toLowerCase();
+  }
+  return yield* Effect.fail(new Error(`Could not parse the SHA-256 output for ${filePath}.`));
+});
+
+const findHashCommand = Effect.fn('localAi.findHashCommand')(function* (
+  candidates: readonly string[],
+  build: (executable: string) => {readonly args: readonly string[]; readonly executable: string},
+) {
+  const executable = yield* findExecutable(candidates);
+  if (!executable) {
+    return yield* Effect.fail(new Error(`Could not find ${candidates.join(' or ')} to verify the local AI model.`));
+  }
+  return build(executable);
+});
+
+const localAiDownloadCommand = Effect.fn('localAi.downloadCommand')(function* (modelPath: string) {
+  const pathService = yield* Path.Path;
+  const python = yield* resolveOpenVikingPython();
+  const binDirectory = pathService.dirname(python);
+  const system = yield* SystemInfo;
+  const hfName = system.platform === 'win32' ? 'hf.exe' : 'hf';
+  const siblingHf = pathService.join(binDirectory, hfName);
+  const fs = yield* FileSystem.FileSystem;
+  const hf = (yield* fs.exists(siblingHf)) ? siblingHf : yield* findExecutable(['hf']);
+  const commonArgs = [
+    'download',
+    LOCAL_AI_MODEL_REPOSITORY,
+    LOCAL_AI_MODEL_FILE,
+    '--revision',
+    LOCAL_AI_MODEL_REVISION,
+    '--local-dir',
+    pathService.dirname(modelPath),
+  ];
+  return hf
+    ? {args: commonArgs, executable: hf}
+    : {
+        args: ['-m', 'huggingface_hub.commands.huggingface_cli', ...commonArgs],
+        executable: python,
+      };
+});
+
+const resolveOpenVikingPython = Effect.fn('localAi.resolveOpenVikingPython')(function* () {
+  const ov = yield* findOpenVikingCli();
+  if (!ov) {
+    return yield* Effect.fail(
+      new Error('OpenViking is required before installing local AI. Run threadnote install or threadnote repair.'),
+    );
+  }
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const sibling = pathService.join(pathService.dirname(ov), system.platform === 'win32' ? 'python.exe' : 'python');
+  if (yield* fs.exists(sibling)) return sibling;
+  const raw = yield* fs.readFileString(ov).pipe(Effect.catch(() => Effect.succeed('')));
+  const firstLine = raw.split(/\r?\n/, 1)[0] ?? '';
+  const shebang = firstLine.startsWith('#!') ? firstLine.slice(2).trim() : undefined;
+  if (shebang) {
+    const parts = shebang.split(/\s+/);
+    if (parts[0]?.endsWith('/env') && parts[1]) {
+      const resolved = yield* findExecutable([parts[1]]);
+      if (resolved) return resolved;
+    } else if (parts[0]) {
+      return parts[0];
+    }
+  }
+  return yield* Effect.fail(new Error(`Could not resolve the Python runtime used by OpenViking from ${ov}.`));
+});
+
+const writeLocalAiSettings = Effect.fn('localAi.writeSettings')(function* (
+  config: LocalAiRuntimeConfig,
+  settings: LocalAiSettings,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const destination = yield* localAiConfigPath(config);
+  yield* ensureDirectory(pathService.dirname(destination), false);
+  const temporary = `${destination}.${system.processId}.tmp`;
+  yield* fs.writeFileString(temporary, `${JSON.stringify(settings, null, 2)}\n`, {mode: 0o600});
+  yield* fs.rename(temporary, destination);
+});
+
+export const readLocalAiAccessToken = Effect.fn('localAi.readAccessToken')(function* (config: LocalAiRuntimeConfig) {
+  const tokenPath = yield* localAiTokenPath(config);
+  const raw = yield* readFileIfExists(tokenPath);
+  if (!raw) return undefined;
+  const token = raw.trim();
+  if (!/^[A-Za-z0-9_-]{43}$/.test(token)) {
+    return yield* Effect.fail(new Error(`${LOCAL_AI_TOKEN_FILE} has an unsupported shape.`));
+  }
+  const system = yield* SystemInfo;
+  if (system.platform !== 'win32') {
+    const info = yield* (yield* FileSystem.FileSystem).stat(tokenPath);
+    if ((info.mode & 0o077) !== 0) {
+      return yield* Effect.fail(new Error(`${LOCAL_AI_TOKEN_FILE} must only be readable by its owner (mode 0600).`));
+    }
+  }
+  return token;
+});
+
+const ensureLocalAiAccessToken = Effect.fn('localAi.ensureAccessToken')(function* (config: LocalAiRuntimeConfig) {
+  const existing = yield* readLocalAiAccessToken(config);
+  if (existing) return existing;
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const tokenPath = yield* localAiTokenPath(config);
+  yield* ensureDirectory(pathService.dirname(tokenPath), false);
+  const crypto = yield* Crypto.Crypto;
+  const token = Encoding.encodeBase64Url(yield* crypto.randomBytes(32));
+  const stored = yield* fs.writeFileString(tokenPath, `${token}\n`, {flag: 'wx', mode: 0o600}).pipe(
+    Effect.as(token),
+    Effect.catch(() => requireLocalAiAccessToken(config)),
+  );
+  if ((yield* SystemInfo).platform !== 'win32') {
+    yield* fs.chmod(tokenPath, 0o600);
+  }
+  return stored;
+});
+
+const requireLocalAiAccessToken = Effect.fn('localAi.requireAccessToken')(function* (config: LocalAiRuntimeConfig) {
+  const token = yield* readLocalAiAccessToken(config);
+  if (!token) {
+    return yield* Effect.fail(new Error(`Local AI access token is missing. Run: threadnote local-ai install --force`));
+  }
+  return token;
+});
+
+const readLocalAiProcessRecord = Effect.fn('localAi.readProcessRecord')(function* (config: LocalAiRuntimeConfig) {
+  const raw = yield* readFileIfExists(yield* localAiPidPath(config));
+  if (!raw) return undefined;
+  const parsed = yield* Effect.try({
+    try: (): unknown => JSON.parse(raw),
+    catch: cause => new Error(`Invalid ${LOCAL_AI_PID_FILE}: ${errorMessage(cause)}`, {cause}),
+  });
+  if (
+    !isJsonObject(parsed) ||
+    parsed.version !== 1 ||
+    !Number.isInteger(parsed.pid) ||
+    (parsed.pid as number) <= 0 ||
+    typeof parsed.launchId !== 'string' ||
+    parsed.launchId.length === 0 ||
+    typeof parsed.modelPath !== 'string' ||
+    typeof parsed.startedAt !== 'string'
+  ) {
+    return yield* Effect.fail(new Error(`${LOCAL_AI_PID_FILE} has an unsupported shape.`));
+  }
+  return {
+    launchId: parsed.launchId,
+    modelPath: parsed.modelPath,
+    pid: parsed.pid as number,
+    startedAt: parsed.startedAt,
+    version: 1,
+  } satisfies LocalAiProcessRecord;
+});
+
+const requireLocalAiSettings = Effect.fn('localAi.requireSettings')(function* (config: LocalAiRuntimeConfig) {
+  const settings = yield* readLocalAiSettings(config);
+  if (!settings) {
+    return yield* Effect.fail(new Error('Local AI is not installed. Run: threadnote local-ai install'));
+  }
+  return settings;
+});
+
+const localAiConfigPath = Effect.fn('localAi.configPath')(function* (config: LocalAiRuntimeConfig) {
+  const pathService = yield* Path.Path;
+  return pathService.join(config.agentContextHome, 'threadnote', LOCAL_AI_CONFIG_FILE);
+});
+
+const localAiTokenPath = Effect.fn('localAi.tokenPath')(function* (config: LocalAiRuntimeConfig) {
+  const pathService = yield* Path.Path;
+  return pathService.join(config.agentContextHome, 'threadnote', LOCAL_AI_TOKEN_FILE);
+});
+
+const localAiPidPath = Effect.fn('localAi.pidPath')(function* (config: LocalAiRuntimeConfig) {
+  const pathService = yield* Path.Path;
+  return pathService.join(config.agentContextHome, LOCAL_AI_PID_FILE);
+});
+
+const localAiLockPath = Effect.fn('localAi.lockPath')(function* (config: LocalAiRuntimeConfig) {
+  const pathService = yield* Path.Path;
+  return pathService.join(config.agentContextHome, LOCAL_AI_LOCK_FILE);
+});
+
+const localAiModelsDirectory = Effect.fn('localAi.modelsDirectory')(function* (config: LocalAiRuntimeConfig) {
+  const pathService = yield* Path.Path;
+  return pathService.join(config.agentContextHome, 'threadnote', 'models');
+});
+
+const localAiManagedModelPath = Effect.fn('localAi.managedModelPath')(function* (config: LocalAiRuntimeConfig) {
+  const pathService = yield* Path.Path;
+  return pathService.join(yield* localAiModelsDirectory(config), LOCAL_AI_MODEL_FILE);
+});
+
+function formatModelSize(bytes: number): string {
+  return `${(bytes / 1_000_000_000).toFixed(2)} GB`;
+}
+
+function withLocalAiLifecycleLock<A, E, R>(config: LocalAiRuntimeConfig, effect: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    return yield* withExclusiveFileLock(
+      fs,
+      yield* localAiLockPath(config),
+      {
+        heartbeatIntervalMilliseconds: 10_000,
+        retryIntervalMilliseconds: LOCAL_AI_POLL_MILLISECONDS,
+        staleAfterMilliseconds: LOCAL_AI_LOCK_STALE_MILLISECONDS,
+        waitTimeoutMilliseconds: LOCAL_AI_LOCK_WAIT_MILLISECONDS,
+      },
+      effect,
+    );
+  });
+}

--- a/src/effect/system.ts
+++ b/src/effect/system.ts
@@ -10,6 +10,7 @@ export interface SystemInfoShape {
   readonly platform: NodeJS.Platform;
   readonly processId: number;
   readonly processArguments: readonly string[];
+  readonly signalProcess: (processId: number, signal: NodeJS.Signals) => void;
   readonly setExitCode: (code: number) => void;
   readonly setEnvironmentVariable: (name: string, value: string) => void;
   readonly stdinIsTTY: boolean;
@@ -44,6 +45,9 @@ export class SystemInfo extends Context.Service<SystemInfo, SystemInfoShape>()('
       platform: process.platform,
       processId: process.pid,
       processArguments: process.argv,
+      signalProcess: (processId, signal) => {
+        process.kill(processId, signal);
+      },
       setExitCode: code => {
         process.exitCode = code;
       },

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -3,7 +3,7 @@ import {Console, Crypto, Effect, Encoding, FileSystem, Path, Result} from 'effec
 import * as HttpServer from 'effect/unstable/http/HttpServer';
 import * as HttpServerRequest from 'effect/unstable/http/HttpServerRequest';
 import * as HttpServerResponse from 'effect/unstable/http/HttpServerResponse';
-import {effectAiConfiguration, runEffectAiConsolidation} from './effect/ai-consolidator.js';
+import {ensureEffectAiReady, resolveEffectAiConfiguration, runEffectAiConsolidation} from './effect/ai-consolidator.js';
 import {runCommandEffect} from './effect/command.js';
 import {captureConsole} from './effect/console.js';
 import type {ApplicationServices} from './effect/runtime.js';
@@ -348,8 +348,10 @@ export const readContextUri = Effect.fn('manager.readContextUri')(function* (
   return {content: result.output, output: result.output};
 });
 
-export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationAgents')(function* () {
-  const effectAi = effectAiConfiguration((yield* SystemInfo).environment());
+export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationAgents')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+) {
+  const effectAi = yield* resolveEffectAiConfiguration(config, (yield* SystemInfo).environment());
   const [codex, claude, cursor, copilot] = yield* Effect.all([
     findExecutable(['codex']),
     findExecutable(['claude']),
@@ -363,7 +365,7 @@ export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationA
     {available: copilot !== undefined, command: copilot, id: 'copilot', label: 'Copilot'},
     {
       available: effectAi !== undefined,
-      command: effectAi?.model,
+      command: effectAi?.configuration.model,
       id: 'effect-ai',
       label: 'Effect AI (OpenAI-compatible)',
     },
@@ -384,7 +386,7 @@ function handleRequestEffect(
         return;
       }
       const system = yield* SystemInfo;
-      const [agents, version] = yield* Effect.all([detectConsolidationAgents(), currentPackageVersion()]);
+      const [agents, version] = yield* Effect.all([detectConsolidationAgents(context.config), currentPackageVersion()]);
       const latest = yield* Effect.succeed(updateRegistry(system.environment())).pipe(
         Effect.flatMap(registry => fetchLatestVersion(registry, selectUpdateChannel(version))),
         Effect.match({onFailure: Result.fail, onSuccess: Result.succeed}),
@@ -1088,7 +1090,7 @@ function createConsolidation(context: ApiContext, body: Record<string, unknown>)
     context.jobs.set(job.id, job);
     yield* Effect.gen(function* () {
       const sources = yield* Effect.all(input.sourceUris.map(uri => readManagedMemory(context.config, uri)));
-      job.draft = yield* runConsolidationAgent(input.agent, sources);
+      job.draft = yield* runConsolidationAgent(context.config, input.agent, sources);
       job.status = 'completed';
     }).pipe(
       Effect.catch(error =>
@@ -1146,21 +1148,23 @@ const applyConsolidation = Effect.fn('manager.applyConsolidation')(function* (
 });
 
 function runConsolidationAgent(
+  runtimeConfig: RuntimeConfig,
   agent: ConsolidationAgent,
   sources: readonly {readonly content: string; readonly node: ManagerTreeNode}[],
 ) {
   const prompt = consolidationPrompt(sources);
   if (agent === 'effect-ai') {
     return Effect.gen(function* () {
-      const config = effectAiConfiguration((yield* SystemInfo).environment());
-      if (!config) {
+      const resolved = yield* resolveEffectAiConfiguration(runtimeConfig, (yield* SystemInfo).environment());
+      if (!resolved) {
         return yield* Effect.fail(
           new Error(
-            'Effect AI is not configured. Set THREADNOTE_EFFECT_AI=1 and THREADNOTE_EFFECT_AI_MODEL; add API URL/key variables when required.',
+            'Effect AI is not configured. Run `threadnote local-ai install`, or set the THREADNOTE_EFFECT_AI provider variables.',
           ),
         );
       }
-      return yield* runEffectAiConsolidation(prompt, config);
+      yield* ensureEffectAiReady(runtimeConfig, resolved);
+      return yield* runEffectAiConsolidation(prompt, resolved.configuration);
     });
   }
   if (agent !== 'codex' && agent !== 'claude') {

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -4,7 +4,7 @@ import * as NodeRuntime from '@effect/platform-node/NodeRuntime';
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import {Clock, Console, Effect, FileSystem, Path, pipe} from 'effect';
+import {Clock, Console, Effect, FileSystem, Path, Result, pipe} from 'effect';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, DEFAULT_HOST, DEFAULT_PORT} from './constants.js';
 import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset, parseMcpToolset} from './mcp_toolset.js';
 import {formatRecallIndexRepairMessages, repairStaleRecallIndex} from './index_repair.js';
@@ -61,6 +61,14 @@ import {
 } from './utils.js';
 import {withIdentity} from './runtime.js';
 import {EffectMcpServerAdapter, McpInput} from './effect/mcp.js';
+import {
+  boundedRecallExpansionScopes,
+  expandWeakRecallQueryEffect,
+  localRecallAiEnabled,
+  recallMinimumScoreAfterExpansion,
+  shouldExpandRecall,
+} from './effect/ai-recall.js';
+import {resolveEffectAiConfiguration} from './effect/ai-consolidator.js';
 import {sha256Hex} from './effect/digest.js';
 import {removeOpenVikingResourceEffect} from './effect/openviking.js';
 import {withMemoryUriLocks} from './effect/memory_lock.js';
@@ -102,7 +110,7 @@ import {
 } from './candidate_memory.js';
 import {recordRecallFeedback} from './recall/feedback.js';
 import {RECALL_RANKER_VERSION} from './recall/rank.js';
-import {prepareRecallSections} from './recall/runtime.js';
+import {loadRecallExpansionVocabulary, prepareRecallSections} from './recall/runtime.js';
 
 interface RuntimeConfig {
   readonly account: string;
@@ -1670,11 +1678,13 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
       threshold,
       params.includeArchived,
     );
+    const searchedScopes: Array<string | undefined> = [params.pinnedUri];
     const passes: Array<readonly RecallHit[]> = [base.hits];
     const scopedRecallUris = new Set([params.pinnedUri].filter((uri): uri is string => uri !== undefined));
     for (const scope of projectMemoryScopeUris(config, projectMemoryName, params.includeArchived)) {
       if (!scopedRecallUris.has(scope)) {
         scopedRecallUris.add(scope);
+        searchedScopes.push(scope);
         const projectMemoryPass = yield* recallSearchHits(
           config,
           ['search', query, '--uri', scope, ...limitArgs],
@@ -1686,6 +1696,7 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
     }
     const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
     if (seededUri?.startsWith('viking://') && seededUri !== params.pinnedUri) {
+      searchedScopes.push(seededUri);
       const seeded = yield* recallSearchHits(
         config,
         ['search', params.query, '--uri', seededUri, ...limitArgs],
@@ -1710,6 +1721,7 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
         .filter(uri => !alreadyScoped.has(uri))
         .slice(0, MAX_WORKSET_PASSES);
       for (const scope of worksetScopes) {
+        searchedScopes.push(scope);
         const worksetPass = yield* recallSearchHits(
           config,
           ['search', query, '--uri', scope, ...limitArgs],
@@ -1721,20 +1733,69 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
     }
 
     const exactMatches = yield* collectExactMemoryMatches(config, query, params.includeArchived, project);
-    const recallSections = yield* prepareRecallSections(config, {
-      allowExactRescue: params.threshold === undefined,
-      allowedUriScopes: params.pinnedUri ? [params.pinnedUri] : undefined,
-      exactMatches,
-      feedbackQuery: params.query,
-      includeInactive: params.includeArchived,
-      limit: params.nodeLimit ?? 12,
-      minimumScore: Number(threshold),
-      passes,
-      project: projectMemoryName ?? project?.name,
-      query,
-      readRecords: uris => readMemoryRecordsByUri(config, uris),
-      seedUris: [params.pinnedUri, seededUri].filter((uri): uri is string => uri !== undefined),
-    });
+    const environment = (yield* SystemInfo).environment();
+    const effectAiResult = yield* resolveEffectAiConfiguration(config, environment).pipe(Effect.result);
+    const effectAi = Result.isSuccess(effectAiResult) ? effectAiResult.success : undefined;
+    if (Result.isFailure(effectAiResult)) {
+      sections.push(
+        `Local AI recall unavailable: ${errorMessage(effectAiResult.failure)}. Deterministic recall continued.`,
+      );
+    }
+    let hybridMinimumScore: number | undefined = Number(threshold);
+    const expansionQueries: string[] = [];
+    const prepareSections = () =>
+      prepareRecallSections(config, {
+        allowExactRescue: params.threshold === undefined,
+        allowedUriScopes: params.pinnedUri ? [params.pinnedUri] : undefined,
+        exactMatches,
+        feedbackQuery: params.query,
+        includeInactive: params.includeArchived,
+        limit: params.nodeLimit ?? 12,
+        minimumScore: hybridMinimumScore,
+        passes,
+        project: projectMemoryName ?? project?.name,
+        query,
+        queryVariants: expansionQueries,
+        readRecords: uris => readMemoryRecordsByUri(config, uris),
+        seedUris: [params.pinnedUri, seededUri].filter((uri): uri is string => uri !== undefined),
+      });
+    let recallSections = yield* prepareSections();
+    const expansionVocabulary =
+      localRecallAiEnabled(effectAi?.configuration) && shouldExpandRecall(recallSections.confidence)
+        ? yield* loadRecallExpansionVocabulary(config, {
+            allowedUriScopes: params.pinnedUri ? [params.pinnedUri] : undefined,
+            includeInactive: params.includeArchived,
+            project: projectMemoryName ?? project?.name,
+            rankedCandidates: recallSections.expansionCandidates,
+          }).pipe(Effect.catch(() => Effect.succeed([])))
+        : [];
+    const proposedExpansionQueries = yield* expandWeakRecallQueryEffect(
+      {
+        confidence: recallSections.confidence,
+        project: projectMemoryName ?? project?.name,
+        query: params.query,
+        vocabulary: expansionVocabulary,
+      },
+      config,
+      effectAi,
+    );
+    for (const expansionQuery of proposedExpansionQueries) {
+      expansionQueries.push(expansionQuery);
+      for (const scope of boundedRecallExpansionScopes(searchedScopes)) {
+        const expansionPass = yield* recallSearchHits(
+          config,
+          ['search', expansionQuery, ...(scope ? ['--uri', scope] : []), ...limitArgs],
+          threshold,
+          params.includeArchived,
+        );
+        passes.push(expansionPass.hits);
+      }
+      hybridMinimumScore = recallMinimumScoreAfterExpansion(Number(threshold), params.threshold !== undefined);
+      recallSections = yield* prepareSections();
+    }
+    if (expansionQueries.length > 0) {
+      sections.push(`Recall query expansion: evaluated ${expansionQueries.length} model rewrite(s).`);
+    }
     const {semanticSection, exactTail} = recallSections;
     if (semanticSection) {
       sections.push(semanticSection);
@@ -1770,6 +1831,7 @@ function runRecallTool(config: RuntimeConfig, params: RecallToolParams) {
       isError: onlyErrorNote || undefined,
       structuredContent: {
         confidence: recallSections.confidence,
+        queryExpansions: expansionQueries,
         rankerVersion: RECALL_RANKER_VERSION,
         results: recallSections.ranked.slice(0, params.nodeLimit ?? 12).map(hit => ({
           category: hit.category,

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,10 +1,19 @@
 import yaml from 'js-yaml';
 import {Console, Crypto, Effect, FileSystem, Path, Result, pipe} from 'effect';
+import {
+  boundedRecallExpansionScopes,
+  expandWeakRecallQueryEffect,
+  localRecallAiEnabled,
+  recallMinimumScoreAfterExpansion,
+  shouldExpandRecall,
+} from './effect/ai-recall.js';
+import {resolveEffectAiConfiguration} from './effect/ai-consolidator.js';
 import {maybeRunEffect} from './effect/command.js';
 import {withMemoryUriLocks} from './effect/memory_lock.js';
 import {removeOpenVikingResourceEffect} from './effect/openviking.js';
 import {syncSharedReposBeforeAgentRead} from './effect/share.js';
 import {withSharedRepositoryLock} from './effect/share_lock.js';
+import {SystemInfo} from './effect/system.js';
 import {
   inferProjectFromQuery,
   inferWorksetFromQuery,
@@ -27,7 +36,7 @@ import {
   type MemoryRecord,
 } from './memory_hygiene.js';
 import {formatMemoryDocument, inferMemoryMetadata, memoryHeaderValue, type MemoryMetadata} from './memory_document.js';
-import {prepareRecallSections} from './recall/runtime.js';
+import {loadRecallExpansionVocabulary, prepareRecallSections} from './recall/runtime.js';
 import {withIdentity} from './runtime.js';
 import type {
   ArchiveOptions,
@@ -953,9 +962,9 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
     : undefined;
   const explicitWorkset = options.workset ? yield* requireWorkset(config.manifestPath, options.workset!) : undefined;
   const recallThreshold = options.threshold ?? (yield* recallScoreThreshold());
-  const searchArgs = (scopeUri: string | undefined): readonly string[] => [
+  const searchArgs = (searchQuery: string, scopeUri: string | undefined): readonly string[] => [
     'search',
-    query,
+    searchQuery,
     '--threshold',
     recallThreshold,
     '--level',
@@ -972,26 +981,30 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
     yield* Console.log(`Recall scope: ${inferredUri}`);
   }
   const includeArchived = options.includeArchived === true;
+  const searchedScopes: Array<string | undefined> = [inferredUri];
   const passes: Array<readonly RecallHit[]> = [
-    yield* recallSearchHits(config, ov, searchArgs(inferredUri), {dryRun, includeArchived}),
+    yield* recallSearchHits(config, ov, searchArgs(query, inferredUri), {dryRun, includeArchived}),
   ];
   const scopedRecallUris = new Set([inferredUri].filter((uri): uri is string => uri !== undefined));
   if (options.project && project) {
     const projectMemoryUri = `viking://user/${uriSegment(config.user)}/memories/durable/projects/${uriSegment(project.name)}`;
     if (!scopedRecallUris.has(projectMemoryUri)) {
       scopedRecallUris.add(projectMemoryUri);
-      passes.push(yield* recallSearchHits(config, ov, searchArgs(projectMemoryUri), {dryRun, includeArchived}));
+      searchedScopes.push(projectMemoryUri);
+      passes.push(yield* recallSearchHits(config, ov, searchArgs(query, projectMemoryUri), {dryRun, includeArchived}));
     }
   }
   for (const scope of projectMemoryScopeUris(config, projectMemoryName, includeArchived)) {
     if (!scopedRecallUris.has(scope)) {
       scopedRecallUris.add(scope);
-      passes.push(yield* recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived}));
+      searchedScopes.push(scope);
+      passes.push(yield* recallSearchHits(config, ov, searchArgs(query, scope), {dryRun, includeArchived}));
     }
   }
   const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
   if (seededUri?.startsWith('viking://') && seededUri !== inferredUri && !options.uri && options.inferScope !== false) {
-    passes.push(yield* recallSearchHits(config, ov, searchArgs(seededUri), {dryRun, includeArchived}));
+    searchedScopes.push(seededUri);
+    passes.push(yield* recallSearchHits(config, ov, searchArgs(query, seededUri), {dryRun, includeArchived}));
   }
 
   // Workset expansion: a named set of manifest projects recalled as one working
@@ -1012,7 +1025,8 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
       .filter(uri => !alreadyScoped.has(uri))
       .slice(0, MAX_WORKSET_PASSES);
     for (const scope of worksetScopes) {
-      passes.push(yield* recallSearchHits(config, ov, searchArgs(scope), {dryRun, includeArchived}));
+      searchedScopes.push(scope);
+      passes.push(yield* recallSearchHits(config, ov, searchArgs(query, scope), {dryRun, includeArchived}));
     }
   }
 
@@ -1021,20 +1035,75 @@ export const runRecall = Effect.fn('runRecall')(function* (config: RuntimeConfig
     includeArchived,
     project,
   });
-  const {semanticSection, exactTail} = yield* prepareRecallSections(config, {
-    allowExactRescue: options.threshold === undefined,
-    allowedUriScopes: options.uri ? [options.uri] : undefined,
-    exactMatches,
-    feedbackQuery: options.query,
-    includeInactive: includeArchived,
-    limit: nodeLimit ?? 12,
-    minimumScore: Number(recallThreshold),
-    passes,
-    project: projectMemoryName ?? project?.name,
-    query,
-    readRecords: uris => readMemoryRecordsByUri(config, uris),
-    seedUris: [inferredUri, seededUri].filter((uri): uri is string => uri !== undefined),
-  });
+  const environment = (yield* SystemInfo).environment();
+  let effectAiWarning: string | undefined;
+  const effectAi = dryRun
+    ? undefined
+    : yield* resolveEffectAiConfiguration(config, environment).pipe(
+        Effect.catch(cause => {
+          effectAiWarning = cause instanceof Error ? cause.message : String(cause);
+          return Effect.succeed(undefined);
+        }),
+      );
+  if (effectAiWarning) {
+    yield* Console.log(`Local AI recall unavailable: ${effectAiWarning}. Deterministic recall continued.`);
+  }
+  let hybridMinimumScore: number | undefined = Number(recallThreshold);
+  const expansionQueries: string[] = [];
+  const prepareSections = () =>
+    prepareRecallSections(config, {
+      allowExactRescue: options.threshold === undefined,
+      allowedUriScopes: options.uri ? [options.uri] : undefined,
+      exactMatches,
+      feedbackQuery: options.query,
+      includeInactive: includeArchived,
+      limit: nodeLimit ?? 12,
+      minimumScore: hybridMinimumScore,
+      passes,
+      project: projectMemoryName ?? project?.name,
+      query,
+      queryVariants: expansionQueries,
+      readRecords: uris => readMemoryRecordsByUri(config, uris),
+      seedUris: [inferredUri, seededUri].filter((uri): uri is string => uri !== undefined),
+    });
+  let recallSections = yield* prepareSections();
+  const expansionVocabulary =
+    localRecallAiEnabled(effectAi?.configuration) && shouldExpandRecall(recallSections.confidence)
+      ? yield* loadRecallExpansionVocabulary(config, {
+          allowedUriScopes: options.uri ? [options.uri] : undefined,
+          includeInactive: includeArchived,
+          project: projectMemoryName ?? project?.name,
+          rankedCandidates: recallSections.expansionCandidates,
+        }).pipe(Effect.catch(() => Effect.succeed([])))
+      : [];
+  const proposedExpansionQueries = dryRun
+    ? []
+    : yield* expandWeakRecallQueryEffect(
+        {
+          confidence: recallSections.confidence,
+          project: projectMemoryName ?? project?.name,
+          query: options.query,
+          vocabulary: expansionVocabulary,
+        },
+        config,
+        effectAi,
+      );
+  for (const expansionQuery of proposedExpansionQueries) {
+    expansionQueries.push(expansionQuery);
+    for (const scope of boundedRecallExpansionScopes(searchedScopes)) {
+      const expandedHits = yield* recallSearchHits(config, ov, searchArgs(expansionQuery, scope), {
+        dryRun,
+        includeArchived,
+      });
+      passes.push(expandedHits);
+    }
+    hybridMinimumScore = recallMinimumScoreAfterExpansion(Number(recallThreshold), options.threshold !== undefined);
+    recallSections = yield* prepareSections();
+  }
+  if (expansionQueries.length > 0) {
+    yield* Console.log(`Recall query expansion: evaluated ${expansionQueries.length} model rewrite(s).`);
+  }
+  const {semanticSection, exactTail} = recallSections;
   if (semanticSection) {
     yield* Console.log(`\n${semanticSection}`);
   }

--- a/src/recall/evaluate.ts
+++ b/src/recall/evaluate.ts
@@ -1,7 +1,9 @@
-import {rankRecallCandidates, type RecallCandidate, type RecallConfidenceLevel} from './rank.js';
+import {rankRecallCandidates, shouldExpandRecall, type RecallCandidate, type RecallConfidenceLevel} from './rank.js';
 
 export interface RecallEvaluationQuery {
+  readonly expandedSemanticScores?: Readonly<Record<string, number>>;
   readonly expectedAnswerability: 'answerable' | 'no_answer';
+  readonly expectedExpansion?: boolean;
   readonly forbiddenUris?: readonly string[];
   readonly id: string;
   readonly now?: string;
@@ -35,7 +37,9 @@ export interface RecallEvaluationResult {
   readonly metrics: RecallEvaluationMetrics;
   readonly queryResults: readonly {
     readonly confidence: RecallConfidenceLevel;
+    readonly expanded: boolean;
     readonly id: string;
+    readonly initialConfidence: RecallConfidenceLevel;
     readonly rankedUris: readonly string[];
   }[];
   readonly version: 1;
@@ -59,26 +63,53 @@ export function evaluateRecallFixture(fixture: RecallEvaluationFixture): RecallE
   let requiredReasonsPresent = true;
   const queryResults: Array<{
     readonly confidence: RecallConfidenceLevel;
+    readonly expanded: boolean;
     readonly id: string;
+    readonly initialConfidence: RecallConfidenceLevel;
     readonly rankedUris: readonly string[];
   }> = [];
 
   for (const query of fixture.queries) {
-    const ranked = rankRecallCandidates(
-      query.query,
-      fixture.documents.map(document => ({
-        ...document,
-        semantic: query.semanticScores?.[document.uri] ?? 0,
-      })),
-      {
-        now: query.now ? new Date(query.now) : undefined,
-        project: query.project,
-        seedUris: query.seedUris,
-      },
-    );
+    const rankWithSemanticScores = (semanticScores: Readonly<Record<string, number>>) =>
+      rankRecallCandidates(
+        query.query,
+        fixture.documents.map(document => ({
+          ...document,
+          semantic: semanticScores[document.uri] ?? 0,
+        })),
+        {
+          now: query.now ? new Date(query.now) : undefined,
+          project: query.project,
+          seedUris: query.seedUris,
+        },
+      );
+    const initial = rankWithSemanticScores(query.semanticScores ?? {});
+    const expanded =
+      shouldExpandRecall(initial.confidence) &&
+      query.expandedSemanticScores !== undefined &&
+      Object.keys(query.expandedSemanticScores).length > 0;
+    const ranked = expanded
+      ? rankWithSemanticScores(
+          Object.fromEntries(
+            fixture.documents.map(document => [
+              document.uri,
+              Math.max(query.semanticScores?.[document.uri] ?? 0, query.expandedSemanticScores?.[document.uri] ?? 0),
+            ]),
+          ),
+        )
+      : initial;
     const top = ranked.results.slice(0, EVALUATION_CUTOFF);
     const rankedUris = top.map(result => result.candidate.uri);
-    queryResults.push({confidence: ranked.confidence.level, id: query.id, rankedUris});
+    queryResults.push({
+      confidence: ranked.confidence.level,
+      expanded,
+      id: query.id,
+      initialConfidence: initial.confidence.level,
+      rankedUris,
+    });
+    if (query.expectedExpansion !== undefined && expanded !== query.expectedExpansion) {
+      failures.push(`${query.id}: expected expansion ${query.expectedExpansion}, got ${expanded}`);
+    }
     const relevantUris = Object.entries(query.relevance)
       .filter(([, grade]) => grade > 0)
       .map(([uri]) => uri);

--- a/src/recall/index.ts
+++ b/src/recall/index.ts
@@ -89,6 +89,8 @@ const SEED_FILE_MTIME_TOLERANCE_MILLISECONDS = 1;
 const TEXT_EXTENSIONS = new Set(['.json', '.md', '.mdx', '.txt', '.yaml', '.yml']);
 const IDENTIFIER_PATTERN = /[a-z0-9][a-z0-9_.-]{2,}/gi;
 const decodedCacheByPath = new Map<string, RecallIndexCache>();
+const decodedCacheGenerationByPath = new Map<string, string | null>();
+let staleGenerationCounter = 0;
 
 interface LoadRecallIndexOptions {
   readonly allowedUriScopes?: readonly string[];
@@ -187,8 +189,11 @@ export const loadRecallIndexData = Effect.fn('recall.loadIndexData')(function* (
     version: RECALL_INDEX_CACHE_VERSION,
   };
   if (cached) {
-    yield* fs.writeFileString(`${cachePath}.stale`, `${now}\n`, {mode: 0o600});
-    yield* Effect.sync(() => decodedCacheByPath.set(cachePath, cache));
+    const generation = yield* writeStaleGeneration(fs, cachePath);
+    yield* Effect.sync(() => {
+      decodedCacheByPath.set(cachePath, cache);
+      decodedCacheGenerationByPath.set(cachePath, generation);
+    });
   } else {
     yield* writeCacheAtomically(fs, cachePath, cache);
   }
@@ -203,23 +208,30 @@ export const loadRecallIndex = Effect.fn('recall.loadIndex')(function* (
 });
 
 export const clearRecallIndexMemoryCache = Effect.fn('recall.clearMemoryCache')(function* () {
-  yield* Effect.sync(() => decodedCacheByPath.clear());
+  yield* Effect.sync(() => {
+    decodedCacheByPath.clear();
+    decodedCacheGenerationByPath.clear();
+  });
 });
 
 export const expireRecallIndexValidation = Effect.fn('recall.expireValidation')(function* (
   agentContextHome: string,
   includeInactive: boolean,
 ) {
+  const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
   const cachePath = pathService.join(
     agentContextHome,
     'cache',
     includeInactive ? INACTIVE_CACHE_FILENAME : ACTIVE_CACHE_FILENAME,
   );
+  yield* fs.makeDirectory(pathService.dirname(cachePath), {recursive: true});
+  const generation = yield* writeStaleGeneration(fs, cachePath);
   yield* Effect.sync(() => {
     const cached = decodedCacheByPath.get(cachePath);
     if (cached) {
       decodedCacheByPath.set(cachePath, {...cached, validatedAt: 0});
+      decodedCacheGenerationByPath.set(cachePath, generation);
     }
   });
 });
@@ -659,13 +671,14 @@ function readCache(
   bypassMemory: boolean,
 ): Effect.Effect<RecallIndexCache | undefined, unknown> {
   return Effect.gen(function* () {
+    const staleGeneration = yield* readStaleGeneration(fs, path);
     if (!bypassMemory) {
       const decoded = decodedCacheByPath.get(path);
-      if (decoded) {
+      if (decoded && decodedCacheGenerationByPath.get(path) === staleGeneration) {
         return decoded;
       }
     }
-    if (yield* fs.exists(`${path}.stale`)) {
+    if (staleGeneration !== null) {
       return undefined;
     }
     if (!(yield* fs.exists(path))) {
@@ -676,10 +689,38 @@ function readCache(
     const parsed = parseCache(value);
     if (parsed) {
       decodedCacheByPath.set(path, parsed);
+      decodedCacheGenerationByPath.set(path, null);
     }
     return parsed;
   });
 }
+
+function readStaleGeneration(fs: FileSystem.FileSystem, path: string): Effect.Effect<string | null, never> {
+  return Effect.gen(function* () {
+    const stalePath = `${path}.stale`;
+    if (!(yield* fs.exists(stalePath).pipe(Effect.catch(() => Effect.succeed(false))))) {
+      return null;
+    }
+    return yield* fs.readFileString(stalePath).pipe(
+      Effect.map(value => value.trim() || 'present'),
+      Effect.catch(() => Effect.succeed('present')),
+    );
+  });
+}
+
+const writeStaleGeneration = Effect.fn('recall.writeStaleGeneration')(function* (
+  fs: FileSystem.FileSystem,
+  path: string,
+) {
+  const system = yield* SystemInfo;
+  const counter = yield* Effect.sync(() => {
+    staleGenerationCounter += 1;
+    return staleGenerationCounter;
+  });
+  const generation = `${yield* Clock.currentTimeMillis}:${system.processId}:${counter}`;
+  yield* fs.writeFileString(`${path}.stale`, `${generation}\n`, {mode: 0o600});
+  return generation;
+});
 
 function loadCanonicalResourcePolicy(
   config: RecallIndexConfig,
@@ -922,6 +963,9 @@ function writeCacheAtomically(
       .rename(temporaryPath, path)
       .pipe(Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.catch(() => Effect.void))));
     yield* fs.remove(`${path}.stale`, {force: true});
-    yield* Effect.sync(() => decodedCacheByPath.set(path, cache));
+    yield* Effect.sync(() => {
+      decodedCacheByPath.set(path, cache);
+      decodedCacheGenerationByPath.set(path, null);
+    });
   });
 }

--- a/src/recall/rank.ts
+++ b/src/recall/rank.ts
@@ -35,6 +35,7 @@ export interface RecallRankContext {
   readonly minimumScore?: number;
   readonly now?: Date;
   readonly project?: string;
+  readonly queryVariants?: readonly string[];
   readonly seedUris?: readonly string[];
 }
 
@@ -89,6 +90,10 @@ export interface RankedRecallSet {
   readonly confidence: RecallConfidence;
   readonly rankerVersion: typeof RECALL_RANKER_VERSION;
   readonly results: readonly RankedRecallCandidate[];
+}
+
+export function shouldExpandRecall(confidence: {readonly level: RecallConfidenceLevel} | undefined): boolean {
+  return confidence !== undefined && confidence.level !== 'high';
 }
 
 const SIGNAL_WEIGHTS = {
@@ -214,7 +219,10 @@ export function rankRecallCandidates(
   candidates: readonly RecallCandidate[],
   context: RecallRankContext = {},
 ): RankedRecallSet {
-  const queryTerms = tokenize(query);
+  const queryTermVariants = [
+    tokenize(query),
+    ...[...new Set(context.queryVariants?.map(variant => variant.trim()).filter(Boolean) ?? [])].map(tokenize),
+  ];
   const corpus = candidates.map(candidate => recallDocumentTerms(candidate));
   const corpusStatistics = context.corpusStatistics ?? buildRecallCorpusStatistics(candidates);
   const semanticAnchors = candidates
@@ -228,7 +236,10 @@ export function rankRecallCandidates(
   const now = context.now ?? DETERMINISTIC_DEFAULT_NOW;
   const ranked = candidates
     .map((candidate, index) =>
-      scoreCandidate(candidate, queryTerms, corpus[index] ?? [], corpusStatistics, graphDistances, {...context, now}),
+      scoreCandidate(candidate, queryTermVariants, corpus[index] ?? [], corpusStatistics, graphDistances, {
+        ...context,
+        now,
+      }),
     )
     .filter(
       result =>
@@ -258,23 +269,33 @@ export function rankRecallCandidates(
 
 function scoreCandidate(
   candidate: RecallCandidate,
-  queryTerms: readonly string[],
+  queryTermVariants: readonly (readonly string[])[],
   documentTerms: readonly string[],
   corpusStatistics: RecallCorpusStatistics,
   graphDistances: ReadonlyMap<string, {readonly distance: number; readonly weight: number}>,
   context: RecallRankContext & {readonly now: Date},
 ): RankedRecallCandidate {
+  const originalQueryTerms = queryTermVariants[0] ?? [];
+  const strongestVariant = (score: (queryTerms: readonly string[]) => number): number =>
+    Math.max(0, ...queryTermVariants.map(score));
   const semantic = clamp(candidate.semantic ?? 0);
-  const bm25 = normalizedBm25(queryTerms, documentTerms, corpusStatistics);
-  const topicalBm25 = normalizedBm25(queryTerms, recallTopicalDocumentTerms(candidate), corpusStatistics);
-  const field = fieldScore(queryTerms, candidate.fields, {includeProject: true});
-  const topicalField = fieldScore(queryTerms, candidate.fields, {includeProject: false});
+  const bm25 = strongestVariant(queryTerms => normalizedBm25(queryTerms, documentTerms, corpusStatistics));
+  const topicalDocumentTerms = recallTopicalDocumentTerms(candidate);
+  const topicalBm25 = strongestVariant(queryTerms =>
+    normalizedBm25(queryTerms, topicalDocumentTerms, corpusStatistics),
+  );
+  const field = strongestVariant(queryTerms => fieldScore(queryTerms, candidate.fields, {includeProject: true}));
+  const topicalField = strongestVariant(queryTerms =>
+    fieldScore(queryTerms, candidate.fields, {includeProject: false}),
+  );
   const graph = graphScore(candidate.uri, graphDistances);
   const scope = scopeScore(context.project, candidate.fields?.project);
-  const kindIntent = kindIntentScore(queryTerms, candidate.kind);
-  const exact = exactTermScore(queryTerms, qualifyingExactTerms(candidate), candidate.fields, corpusStatistics, {
-    kindIntent,
-  });
+  const kindIntent = kindIntentScore(originalQueryTerms, candidate.kind);
+  const exact = strongestVariant(queryTerms =>
+    exactTermScore(queryTerms, qualifyingExactTerms(candidate), candidate.fields, corpusStatistics, {
+      kindIntent,
+    }),
+  );
   const freshness = freshnessScore(candidate.timestamp, candidate.kind, context.now);
   const authority = authorityScore(candidate.authority, candidate.trust);
   const lifecycle = lifecycleScore(candidate.status);

--- a/src/recall/runtime.ts
+++ b/src/recall/runtime.ts
@@ -3,6 +3,7 @@ import type {MemoryRecord} from '../memory_document.js';
 import {buildRecallSections, type ExactMatch, type RecallHit} from '../utils.js';
 import {loadRecallFeedback} from './feedback.js';
 import {loadRecallIndexData} from './index.js';
+import type {RecallCandidate} from './rank.js';
 
 interface RecallRuntimeConfig {
   readonly account: string;
@@ -18,16 +19,22 @@ interface PrepareRecallSectionsInput<R> {
   readonly feedbackQuery: string;
   readonly includeInactive: boolean;
   readonly limit: number;
-  readonly minimumScore: number;
+  readonly minimumScore?: number;
   readonly passes: ReadonlyArray<readonly RecallHit[]>;
   readonly project?: string;
   readonly query: string;
+  readonly queryVariants?: readonly string[];
   readonly readRecords: (uris: readonly string[]) => Effect.Effect<readonly MemoryRecord[], unknown, R>;
   readonly seedUris?: readonly string[];
 }
 
 const INDEX_CANDIDATE_MULTIPLIER = 10;
 const INDEX_CANDIDATE_MINIMUM = 100;
+const EXPANSION_VOCABULARY_LIMIT = 50;
+const EXPANSION_VOCABULARY_RANKED_RESERVE = 25;
+const EXPANSION_DESCRIPTION_TERM_LIMIT = 6;
+const EXPANSION_DESCRIPTION_LENGTH_LIMIT = 80;
+const EXPANSION_DESCRIPTION_SEPARATOR = ' :: ';
 
 /**
  * Shared Effect orchestration for CLI and MCP recall. The entry points remain
@@ -46,35 +53,153 @@ export const prepareRecallSections = Effect.fn('recall.prepareSections')(functio
   ];
   const records = yield* input.readRecords(rankingUris);
   const now = new Date(yield* Clock.currentTimeMillis);
-  const [feedbackByUri, recallIndex] = yield* Effect.all(
+  const indexQueries = [input.query, ...(input.queryVariants ?? [])];
+  const [feedbackByUri, recallIndexes] = yield* Effect.all(
     [
       loadRecallFeedback(config.agentContextHome, {
         now,
         project: input.project,
         query: input.feedbackQuery,
       }),
-      loadRecallIndexData(config, {
-        allowedUriScopes: input.allowedUriScopes,
-        includeInactive: input.includeInactive,
-        limit: Math.max(INDEX_CANDIDATE_MINIMUM, input.limit * INDEX_CANDIDATE_MULTIPLIER),
-        query: input.query,
-        requiredUris: rankingUris,
-      }).pipe(Effect.catch(() => Effect.succeed(undefined))),
+      Effect.forEach(
+        indexQueries,
+        indexQuery =>
+          loadRecallIndexData(config, {
+            allowedUriScopes: input.allowedUriScopes,
+            includeInactive: input.includeInactive,
+            limit: Math.max(INDEX_CANDIDATE_MINIMUM, input.limit * INDEX_CANDIDATE_MULTIPLIER),
+            query: indexQuery,
+            requiredUris: rankingUris,
+          }).pipe(Effect.catch(() => Effect.succeed(undefined))),
+        {concurrency: 2},
+      ),
     ],
     {concurrency: 2},
   );
-  return buildRecallSections(input.passes, input.exactMatches, input.limit, {
+  const recallIndex = recallIndexes.find(index => index !== undefined);
+  const indexedCandidates = mergeRecallIndexCandidates(recallIndexes.map(index => index?.candidates ?? []));
+  const sections = buildRecallSections(input.passes, input.exactMatches, input.limit, {
     allowExactRescue: input.allowExactRescue,
     allowedUriScopes: input.allowedUriScopes,
     corpusStatistics: recallIndex?.corpusStatistics,
     feedbackByUri,
     includeInactive: input.includeInactive,
-    indexedCandidates: recallIndex?.candidates,
+    indexedCandidates,
     minimumScore: input.minimumScore,
     now,
     project: input.project,
     query: input.query,
+    queryVariants: input.queryVariants,
     records,
     seedUris: input.seedUris,
   });
+  return {...sections, expansionCandidates: indexedCandidates};
 });
+
+export const loadRecallExpansionVocabulary = Effect.fn('recall.loadExpansionVocabulary')(function* (
+  config: RecallRuntimeConfig,
+  input: {
+    readonly allowedUriScopes?: readonly string[];
+    readonly includeInactive: boolean;
+    readonly project?: string;
+    readonly rankedCandidates?: readonly RecallCandidate[];
+  },
+) {
+  if (!input.project) return [];
+  const index = yield* loadRecallIndexData(config, {includeInactive: input.includeInactive});
+  const mergedCandidates = mergeRecallIndexCandidates([input.rankedCandidates ?? [], index.candidates]);
+  const candidates = input.allowedUriScopes?.length
+    ? mergedCandidates.filter(candidate =>
+        input.allowedUriScopes?.some(scope => candidate.uri === scope || candidate.uri.startsWith(`${scope}/`)),
+      )
+    : mergedCandidates;
+  return recallExpansionVocabulary(candidates, input.project);
+});
+
+export function mergeRecallIndexCandidates(
+  candidateSets: readonly (readonly RecallCandidate[])[],
+): readonly RecallCandidate[] {
+  const seen = new Set<string>();
+  const merged: RecallCandidate[] = [];
+  const maximumLength = Math.max(0, ...candidateSets.map(candidates => candidates.length));
+  for (let index = 0; index < maximumLength; index += 1) {
+    for (const candidates of candidateSets) {
+      const candidate = candidates[index];
+      if (!candidate || seen.has(candidate.uri)) continue;
+      seen.add(candidate.uri);
+      merged.push(candidate);
+    }
+  }
+  return merged;
+}
+
+export function recallExpansionVocabulary(
+  candidates: readonly RecallCandidate[],
+  project: string | undefined,
+): readonly string[] {
+  if (!project) return [];
+  const normalizedProject = project.trim().toLowerCase();
+  const seen = new Set<string>();
+  const vocabulary: string[] = [];
+  const projectCandidates = prioritizeRecallExpansionCandidates(
+    candidates.filter(candidate => candidate.fields?.project?.trim().toLowerCase() === normalizedProject),
+  );
+  const append = (term: string | undefined, dedupeTerm = term): boolean => {
+    const value = term?.trim();
+    const dedupeValue = dedupeTerm?.trim();
+    const key = dedupeValue?.toLowerCase();
+    if (!value || !dedupeValue || dedupeValue.length > 120 || !key || seen.has(key)) return false;
+    seen.add(key);
+    vocabulary.push(value);
+    return vocabulary.length === EXPANSION_VOCABULARY_LIMIT;
+  };
+  for (const candidate of projectCandidates) {
+    const topic = candidate.fields?.topic?.trim();
+    const description = recallExpansionDescription(candidate.text);
+    if (append(topic && description ? `${topic}${EXPANSION_DESCRIPTION_SEPARATOR}${description}` : topic, topic)) {
+      return vocabulary;
+    }
+  }
+  for (const candidate of projectCandidates) {
+    for (const identifier of candidate.fields?.identifiers ?? []) {
+      if (append(identifier)) return vocabulary;
+    }
+  }
+  return vocabulary;
+}
+
+function prioritizeRecallExpansionCandidates(candidates: readonly RecallCandidate[]): readonly RecallCandidate[] {
+  const prioritized: RecallCandidate[] = [];
+  const seen = new Set<string>();
+  const append = (candidate: RecallCandidate): void => {
+    if (seen.has(candidate.uri)) return;
+    seen.add(candidate.uri);
+    prioritized.push(candidate);
+  };
+  for (const candidate of candidates.slice(0, EXPANSION_VOCABULARY_RANKED_RESERVE)) append(candidate);
+  for (const candidate of [...candidates].sort((left, right) => timestampValue(right) - timestampValue(left))) {
+    append(candidate);
+  }
+  for (const candidate of candidates) append(candidate);
+  return prioritized;
+}
+
+function timestampValue(candidate: RecallCandidate): number {
+  if (!candidate.timestamp) return Number.NEGATIVE_INFINITY;
+  const value = Date.parse(candidate.timestamp);
+  return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
+}
+
+function recallExpansionDescription(text: string): string {
+  const terms: string[] = [];
+  let previous = '';
+  for (const rawTerm of text.split(/\s+/)) {
+    const term = rawTerm.trim();
+    const key = term.toLowerCase();
+    if (!term || key === previous) continue;
+    terms.push(term);
+    previous = key;
+    if (terms.length === EXPANSION_DESCRIPTION_TERM_LIMIT) break;
+  }
+  return terms.join(' ').slice(0, EXPANSION_DESCRIPTION_LENGTH_LIMIT).trim();
+}

--- a/src/share.ts
+++ b/src/share.ts
@@ -3,6 +3,7 @@ import {CommandExecutor} from './effect/command.js';
 import {SystemInfo} from './effect/system.js';
 import {uriSegment} from './manifest.js';
 import {canonicalMemoryDocumentContent} from './memory_document.js';
+import {expireRecallIndexValidation} from './recall/index.js';
 import {withIdentity} from './runtime.js';
 import {applyScrubber, credentialScrubberBlocker, SCRUBBER_PATTERNS} from './scrubber.js';
 import type {
@@ -4455,6 +4456,10 @@ export const writeMemoryFile = Effect.fn('share.writeMemoryFile')(function* (
   yield* Effect.gen(function* () {
     yield* writeFile(tempPath, content, {encoding: 'utf8', mode: 0o600});
     yield* writeOvFileWithRetry(config, ov, uri, tempPath, initialMode, options);
+    yield* Effect.all([
+      expireRecallIndexValidation(config.agentContextHome, false),
+      expireRecallIndexValidation(config.agentContextHome, true),
+    ]);
     yield* refreshMemoryIndex(config, ov, uri, options);
   }).pipe(Effect.ensuring(rm(stagingDir, {force: true, recursive: true}).pipe(Effect.ignore)));
 });

--- a/src/update.ts
+++ b/src/update.ts
@@ -47,11 +47,13 @@ interface UpdateCache {
 }
 
 interface PostUpdateMigration {
+  readonly appliesToPrereleases?: boolean;
   readonly commandArgs: readonly string[];
   readonly description: readonly string[];
   readonly id: string;
   readonly instructions: readonly string[];
   readonly introducedIn: string;
+  readonly markHandledWhenSkipped?: boolean;
   readonly requiresLegacyHandoffs?: boolean;
   readonly requiresProjectNameConsolidation?: boolean;
   readonly title: string;
@@ -239,7 +241,7 @@ export function maybeRunPostUpdateAfterRepair(config: RuntimeConfig, options: {r
       return;
     }
     yield* Console.log('');
-    yield* Console.log('Repair found package post-update migrations.');
+    yield* Console.log('Repair found package post-update actions.');
     yield* Console.log(
       'This also covers updates launched by older Threadnote versions that only knew how to run repair.',
     );
@@ -570,12 +572,12 @@ const runApplicablePostUpdateMigrations = Effect.fn('update.runApplicableMigrati
     toVersion: options.toVersion,
   });
   if (migrations.length === 0) {
-    yield* Console.log('No post-update memory migrations apply.');
+    yield* Console.log('No post-update actions apply.');
     return;
   }
 
   yield* Console.log('');
-  yield* Console.log('Post-update memory migrations are available.');
+  yield* Console.log('Post-update actions are available.');
   const threadnoteCommand =
     currentThreadnoteCommand(system) ?? (yield* findExecutable([NPM_PACKAGE_NAME])) ?? NPM_PACKAGE_NAME;
   const handledMigrationIds = new Set(state.handledMigrationIds);
@@ -588,6 +590,9 @@ const runApplicablePostUpdateMigrations = Effect.fn('update.runApplicableMigrati
     if (!accepted) {
       yield* Console.log('Skipped. Run manually later:');
       yield* Console.log(`  ${formatMigrationCommand(threadnoteCommand, migration.commandArgs)}`);
+      if (options.interactive && migration.markHandledWhenSkipped === true) {
+        handledMigrationIds.add(migration.id);
+      }
       continue;
     }
     yield* runStreamingSubcommand(options.dryRun, threadnoteCommand, migration.commandArgs);
@@ -627,7 +632,7 @@ const applicablePostUpdateMigrations = Effect.fn('update.applicableMigrations')(
     if (compareVersions(options.fromVersion, migration.introducedIn) >= 0) {
       continue;
     }
-    if (compareVersions(migration.introducedIn, options.toVersion) > 0) {
+    if (!postUpdateMigrationReached(migration, options.fromVersion, options.toVersion)) {
       continue;
     }
     if (migration.requiresLegacyHandoffs === true && !(yield* hasLegacyLifecycleHandoffCandidates(config))) {
@@ -670,15 +675,33 @@ function parsePostUpdateMigration(value: unknown): PostUpdateMigration {
     throw new Error(`Invalid entry in ${POST_UPDATE_MIGRATIONS_FILE}.`);
   }
   return {
+    appliesToPrereleases: value.appliesToPrereleases === true,
     commandArgs: stringArray(value, 'commandArgs'),
     description: stringArray(value, 'description'),
     id: value.id,
     instructions: stringArray(value, 'instructions'),
     introducedIn: value.introducedIn,
+    markHandledWhenSkipped: value.markHandledWhenSkipped === true,
     requiresLegacyHandoffs: value.requiresLegacyHandoffs === true,
     requiresProjectNameConsolidation: value.requiresProjectNameConsolidation === true,
     title: value.title,
   };
+}
+
+function postUpdateMigrationReached(migration: PostUpdateMigration, fromVersion: string, toVersion: string): boolean {
+  if (compareVersions(migration.introducedIn, toVersion) <= 0) {
+    return true;
+  }
+  return (
+    migration.appliesToPrereleases === true &&
+    compareVersions(fromVersion, toVersion) < 0 &&
+    stableVersionCore(migration.introducedIn) === stableVersionCore(toVersion) &&
+    toVersion.includes('-')
+  );
+}
+
+function stableVersionCore(version: string): string {
+  return version.trim().replace(/^v/, '').split(/[+-]/, 1)[0] ?? '';
 }
 
 function stringArray(value: JsonObject, key: string): readonly string[] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1456,7 +1456,7 @@ export interface RecallSections {
   readonly ranked: readonly RecallHit[];
   /** Rendered ranked list, capped at `limit`. Undefined when there are no hits. */
   readonly semanticSection: string | undefined;
-  /** Exact-match pointer list for matches not already shown in the ranked window. */
+  /** Legacy exact-match pointer list. Hybrid recall incorporates exact evidence into ranking and leaves this empty. */
   readonly exactTail: string | undefined;
 }
 
@@ -1480,6 +1480,7 @@ interface HybridRecallOptions {
   readonly now?: Date;
   readonly project?: string;
   readonly query: string;
+  readonly queryVariants?: readonly string[];
   readonly records?: readonly MemoryRecord[];
   readonly seedUris?: readonly string[];
 }
@@ -1547,10 +1548,9 @@ export function buildRecallSections(
   const shownUris = new Set(shown.map(hit => stripAnchor(hit.uri)));
   return {
     confidence: hybrid?.confidence,
-    exactTail:
-      hybrid?.confidence.level === 'no_answer'
-        ? undefined
-        : formatExactMatchPointers(scopedExactMatches.filter(match => !shownUris.has(stripAnchor(match.uri)))),
+    exactTail: hybrid
+      ? undefined
+      : formatExactMatchPointers(scopedExactMatches.filter(match => !shownUris.has(stripAnchor(match.uri)))),
     ranked,
     semanticSection: renderRecallHits(shown, ranked.length - shown.length, hybrid?.confidence),
   };

--- a/test/e2e/local-bins.e2e.ts
+++ b/test/e2e/local-bins.e2e.ts
@@ -66,6 +66,7 @@ interface RecallContent {
     readonly level: string;
     readonly score: number;
   };
+  readonly queryExpansions?: readonly string[];
   readonly rankerVersion: string;
   readonly results: readonly {
     readonly finalScore: number;
@@ -114,6 +115,12 @@ describe('published local bins', () => {
       ['start'],
       ['stop'],
       ['uninstall'],
+      ['local-ai'],
+      ['local-ai', 'install'],
+      ['local-ai', 'start'],
+      ['local-ai', 'stop'],
+      ['local-ai', 'status'],
+      ['local-ai', 'uninstall'],
       ['seed'],
       ['init-manifest'],
       ['seed-skills'],
@@ -370,6 +377,8 @@ describe('published local bins', () => {
       ['start', '--dry-run'],
       ['stop', '--dry-run'],
       ['uninstall', '--dry-run', '--mcp', 'none', '--preserve-memories'],
+      ['local-ai', 'install', '--dry-run', '--no-start'],
+      ['local-ai', 'status'],
       ['seed-skills', '--dry-run'],
       ['migrate-memories', '--dry-run'],
       ['migrate-lifecycle', '--dry-run'],
@@ -688,6 +697,111 @@ describe('published local bins', () => {
     } finally {
       manager.process.kill('SIGINT');
       await waitForExit(manager.process);
+      await ai.close();
+    }
+  });
+
+  it('expands medium and weak recall through the packaged MCP bin and an OpenAI-compatible endpoint', async () => {
+    const fixture = await makeFixture('effect-ai-recall');
+    const project = 'threadnote';
+    const uri = `viking://user/e2e/memories/durable/projects/${project}/release-channel-contract.md`;
+    const alternateUri = `viking://user/e2e/memories/durable/projects/${project}/preview-install-contract.md`;
+    const rewrites = [
+      'release-channel-contract npm beta dist-tag stable latest',
+      'preview-install-contract prerelease versus stable installations',
+    ];
+    const groundedRewrites = ['release-channel-contract', 'preview-install-contract'];
+    const ai = await makeOpenAiCompatibleServer({queries: rewrites});
+    fixture.env.THREADNOTE_EFFECT_AI = '1';
+    fixture.env.THREADNOTE_EFFECT_AI_API_KEY = 'e2e-key';
+    fixture.env.THREADNOTE_EFFECT_AI_API_URL = `${ai.baseUrl}/v1`;
+    fixture.env.THREADNOTE_EFFECT_AI_MODEL = 'e2e-model';
+    try {
+      await withMcpClient(fixture, LIVE_OV.mcpUrl, 'full', async client => {
+        expect(
+          await callToolText(
+            client,
+            'remember_context',
+            {
+              project,
+              text: 'Beta installs use the npm beta dist-tag; stable installs use the latest dist-tag.',
+              topic: 'release-channel-contract',
+            },
+            60_000,
+          ),
+        ).toContain(uri);
+        expect(
+          await callToolText(
+            client,
+            'remember_context',
+            {
+              project,
+              text: 'Preview packages and ordinary installations follow different update channels.',
+              topic: 'preview-install-contract',
+            },
+            60_000,
+          ),
+        ).toContain(alternateUri);
+        await waitForOpenVikingSearch(fixture, groundedRewrites[0]!, uri);
+        await waitForOpenVikingSearch(fixture, groundedRewrites[1]!, alternateUri);
+
+        const recall = await callToolResult(
+          client,
+          'recall_context',
+          {
+            callerCwd: REPO_ROOT,
+            nodeLimit: 5,
+            query: 'How does the canary lane diverge from the GA lane?',
+          },
+          60_000,
+        );
+        const recallText = textFromToolResult(recall);
+        const structured = structuredContentFromToolResult<RecallContent>(recall);
+
+        expect(ai.requests).toHaveLength(1);
+        expect(structured.queryExpansions, JSON.stringify(ai.requests[0]?.body)).toEqual(groundedRewrites);
+        expect(recallText).toContain('Recall query expansion: evaluated 2 model rewrite(s).');
+        expect(recallText).toContain(uri);
+        expect(structured.results.some(result => result.uri === uri)).toBe(true);
+
+        const strictRecall = structuredContentFromToolResult<RecallContent>(
+          await callToolResult(
+            client,
+            'recall_context',
+            {
+              callerCwd: REPO_ROOT,
+              nodeLimit: 5,
+              query: 'How does the canary lane diverge from the GA lane?',
+              threshold: 0.99,
+            },
+            60_000,
+          ),
+        );
+        expect(strictRecall.queryExpansions).toEqual(groundedRewrites);
+        expect(strictRecall.results.every(result => result.finalScore >= 0.99)).toBe(true);
+        expect(strictRecall.results.some(result => result.uri === uri)).toBe(false);
+
+        const mediumRecall = await callToolResult(
+          client,
+          'recall_context',
+          {
+            callerCwd: REPO_ROOT,
+            nodeLimit: 5,
+            query: 'dist-tag comparison',
+          },
+          60_000,
+        );
+        const mediumText = textFromToolResult(mediumRecall);
+        const mediumStructured = structuredContentFromToolResult<RecallContent>(mediumRecall);
+
+        expect(mediumText).toContain('Recall query expansion: evaluated 1 model rewrite(s).');
+        expect(mediumStructured.queryExpansions).toEqual([groundedRewrites[0]]);
+        expect(mediumStructured.results.some(result => result.uri === uri)).toBe(true);
+      });
+      expect(ai.requests).toHaveLength(2);
+      expect(ai.requests[0]?.url).toBe('/v1/chat/completions');
+      expect(ai.requests[0]?.authorization).toBe('Bearer e2e-key');
+    } finally {
       await ai.close();
     }
   });
@@ -1507,6 +1621,22 @@ async function runCli(fixture: TestFixture, args: readonly string[], input?: str
   });
 }
 
+async function waitForOpenVikingSearch(fixture: TestFixture, query: string, expectedUri: string): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  let last = '';
+  while (Date.now() < deadline) {
+    const result = await runProcess(
+      LIVE_OV.ov,
+      ['search', query, '--threshold', '0.5', '--level', '2', '--output', 'json'],
+      {env: fixture.env},
+    );
+    last = `${result.stdout}\n${result.stderr}`;
+    if (result.code === 0 && result.stdout.includes(expectedUri)) return;
+    await new Promise(resolveWait => setTimeout(resolveWait, 100));
+  }
+  throw new Error(`OpenViking did not index ${expectedUri} for ${JSON.stringify(query)}.\n${last}`);
+}
+
 async function expectCliFailure(fixture: TestFixture, args: readonly string[], message: string): Promise<void> {
   const result = await runCli(fixture, args);
   expect(result.code, result.stdout + result.stderr).toBe(1);
@@ -1638,12 +1768,21 @@ async function withMcpClient<T>(
   }
 }
 
-async function callToolText(client: Client, name: string, args: Record<string, unknown>): Promise<string> {
-  return textFromToolResult(await callToolResult(client, name, args));
+async function callToolText(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+  timeoutMs = 10_000,
+): Promise<string> {
+  return textFromToolResult(await callToolResult(client, name, args, timeoutMs));
 }
 
-async function callToolResult(client: Client, name: string, args: Record<string, unknown>) {
-  const result = await client.callTool({arguments: args, name}, undefined, {timeout: 10_000});
+async function callToolResult(client: Client, name: string, args: Record<string, unknown>, timeoutMs = 10_000) {
+  const result = await client
+    .callTool({arguments: args, name}, undefined, {timeout: timeoutMs})
+    .catch((cause: unknown) => {
+      throw new Error(`${name} failed within the ${timeoutMs}ms E2E client budget.`, {cause});
+    });
   expect(result.isError, `${name} failed: ${textFromToolResult(result)}`).not.toBe(true);
   return result;
 }
@@ -1670,7 +1809,9 @@ function textFromToolResult(result: unknown): string {
     : '';
 }
 
-async function makeOpenAiCompatibleServer(): Promise<{
+async function makeOpenAiCompatibleServer(
+  responseObject: Readonly<Record<string, unknown>> = {draft: 'Consolidated by Effect AI E2E'},
+): Promise<{
   readonly baseUrl: string;
   readonly close: () => Promise<void>;
   readonly requests: Array<{readonly authorization?: string; readonly body: unknown; readonly url?: string}>;
@@ -1695,7 +1836,7 @@ async function makeOpenAiCompatibleServer(): Promise<{
           {
             finish_reason: 'stop',
             index: 0,
-            message: {content: JSON.stringify({draft: 'Consolidated by Effect AI E2E'}), role: 'assistant'},
+            message: {content: JSON.stringify(responseObject), role: 'assistant'},
           },
         ],
         created: Math.floor(Date.now() / 1000),

--- a/test/evaluation/fixtures/recall-v1/fixture.json
+++ b/test/evaluation/fixtures/recall-v1/fixture.json
@@ -80,6 +80,59 @@
         "topic": "candidate-memory",
         "project": "threadnote"
       }
+    },
+    {
+      "uri": "viking://user/me/memories/beta-update-policy.md",
+      "text": "Prerelease packages use the npm beta dist-tag; stable packages use latest.",
+      "authority": "user_approved",
+      "trust": "approved",
+      "kind": "durable",
+      "status": "active",
+      "timestamp": "2026-07-22T00:00:00.000Z",
+      "fields": {
+        "title": "Beta update policy",
+        "topic": "beta-update-policy",
+        "project": "threadnote"
+      }
+    },
+    {
+      "uri": "viking://user/me/memories/recall-ranker-signals.md",
+      "text": "Hybrid-v2 combines semantic similarity, BM25 lexical evidence, field matches, graph proximity, lifecycle, and feedback.",
+      "authority": "user_approved",
+      "trust": "approved",
+      "kind": "durable",
+      "status": "active",
+      "timestamp": "2026-07-22T00:00:00.000Z",
+      "fields": {
+        "title": "Recall ranker signals",
+        "topic": "recall-ranker-signals",
+        "project": "threadnote"
+      }
+    },
+    {
+      "uri": "viking://resources/repos/mobile-native/android-app-links.md",
+      "text": "Android App Links are declared in the AndroidManifest intent-filter and verified by assetlinks.json.",
+      "authority": "canonical_repo",
+      "trust": "approved",
+      "fields": {
+        "title": "Android App Links",
+        "topic": "android-app-links",
+        "project": "mobile-native"
+      }
+    },
+    {
+      "uri": "viking://user/me/memories/docs-reconnect-watchdog.md",
+      "text": "The Docs websocket reconnect watchdog restarts the live connection after transport loss.",
+      "authority": "user_approved",
+      "trust": "approved",
+      "kind": "durable",
+      "status": "active",
+      "timestamp": "2026-07-22T00:00:00.000Z",
+      "fields": {
+        "title": "Docs reconnect watchdog",
+        "topic": "docs-reconnect-watchdog",
+        "project": "docs"
+      }
     }
   ],
   "queries": [
@@ -136,6 +189,66 @@
       "expectedAnswerability": "no_answer",
       "relevance": {},
       "semanticScores": {}
+    },
+    {
+      "id": "paraphrase-beta-updates",
+      "query": "How do preview builds get upgraded compared with ordinary installs?",
+      "project": "threadnote",
+      "expectedAnswerability": "answerable",
+      "expectedExpansion": true,
+      "relevance": {
+        "viking://user/me/memories/beta-update-policy.md": 3
+      },
+      "requiredReasonCodes": ["semantic_similarity"],
+      "semanticScores": {},
+      "expandedSemanticScores": {
+        "viking://user/me/memories/beta-update-policy.md": 0.84
+      }
+    },
+    {
+      "id": "paraphrase-ranking-signals",
+      "query": "What evidence decides which saved note comes first?",
+      "project": "threadnote",
+      "expectedAnswerability": "answerable",
+      "expectedExpansion": true,
+      "relevance": {
+        "viking://user/me/memories/recall-ranker-signals.md": 3
+      },
+      "requiredReasonCodes": ["semantic_similarity"],
+      "semanticScores": {},
+      "expandedSemanticScores": {
+        "viking://user/me/memories/recall-ranker-signals.md": 0.86
+      }
+    },
+    {
+      "id": "paraphrase-android-app-links",
+      "query": "Where does the phone app claim website URLs on Android?",
+      "project": "mobile-native",
+      "expectedAnswerability": "answerable",
+      "expectedExpansion": true,
+      "relevance": {
+        "viking://resources/repos/mobile-native/android-app-links.md": 3
+      },
+      "requiredReasonCodes": ["semantic_similarity"],
+      "semanticScores": {},
+      "expandedSemanticScores": {
+        "viking://resources/repos/mobile-native/android-app-links.md": 0.88
+      }
+    },
+    {
+      "id": "paraphrase-docs-reconnect",
+      "query": "What brings Docs back after its live connection drops?",
+      "project": "docs",
+      "expectedAnswerability": "answerable",
+      "expectedExpansion": true,
+      "relevance": {
+        "viking://user/me/memories/docs-reconnect-watchdog.md": 3
+      },
+      "requiredReasonCodes": ["semantic_similarity"],
+      "semanticScores": {},
+      "expandedSemanticScores": {
+        "viking://user/me/memories/docs-reconnect-watchdog.md": 0.87
+      }
     }
   ]
 }

--- a/test/unit/effect-ai-recall.test.ts
+++ b/test/unit/effect-ai-recall.test.ts
@@ -1,0 +1,96 @@
+import {expect, it} from '@effect/vitest';
+import {Effect, Layer} from 'effect';
+import {describe} from 'vitest';
+import {
+  boundedRecallExpansionScopes,
+  expandRecallQueryEffect,
+  isLoopbackAiEndpoint,
+  limitRecallRewritesForConfidence,
+  normalizeRecallRewrites,
+  recallMinimumScoreAfterExpansion,
+  RecallQueryExpander,
+  shouldExpandRecall,
+} from '../../src/effect/ai-recall.js';
+
+describe('Effect AI recall expansion', () => {
+  it('only expands weak deterministic recalls', () => {
+    expect(shouldExpandRecall({level: 'no_answer'})).toBe(true);
+    expect(shouldExpandRecall({level: 'low'})).toBe(true);
+    expect(shouldExpandRecall({level: 'medium'})).toBe(true);
+    expect(shouldExpandRecall({level: 'high'})).toBe(false);
+    expect(shouldExpandRecall(undefined)).toBe(false);
+  });
+
+  it('keeps at most two unique, bounded rewrites and drops the original query', () => {
+    expect(
+      normalizeRecallRewrites('where is the Android link handled', [
+        ' Android app link intent filter ',
+        'where is the Android link handled',
+        'android app link intent filter',
+        'asset links manifest configuration',
+        'ignored third rewrite',
+        'x'.repeat(700),
+      ]),
+    ).toEqual(['Android app link intent filter', 'asset links manifest configuration']);
+  });
+
+  it('drops locally grounded rewrites that ignore the supplied project vocabulary', () => {
+    expect(
+      normalizeRecallRewrites(
+        'How do preview builds get upgraded?',
+        [
+          'upgrade-preview-builds-threadnote',
+          'beta-update-channel prerelease upgrades',
+          'release-process :: stable release workflow',
+        ],
+        ['beta-update-channel :: beta update and prerelease contract', 'release-process :: stable release workflow'],
+      ),
+    ).toEqual(['beta-update-channel', 'release-process']);
+  });
+
+  it('does not accept a vocabulary term embedded in a different word', () => {
+    expect(normalizeRecallRewrites('share behavior', ['shared repository'], ['share'])).toEqual([]);
+  });
+
+  it('uses only the first search scope for expansion', () => {
+    expect(
+      boundedRecallExpansionScopes([
+        undefined,
+        'viking://user/me/memories/durable/projects/threadnote',
+        undefined,
+        'viking://resources/repos/threadnote',
+        'viking://resources/repos/mobile',
+      ]),
+    ).toEqual([undefined]);
+  });
+
+  it('uses one rewrite for medium confidence and two for weaker recall', () => {
+    const rewrites = ['first', 'second'];
+    expect(limitRecallRewritesForConfidence({level: 'medium'}, rewrites)).toEqual(['first']);
+    expect(limitRecallRewritesForConfidence({level: 'low'}, rewrites)).toEqual(rewrites);
+    expect(limitRecallRewritesForConfidence({level: 'no_answer'}, rewrites)).toEqual(rewrites);
+  });
+
+  it('relaxes only the default threshold after expansion', () => {
+    expect(recallMinimumScoreAfterExpansion(0.4, false)).toBeUndefined();
+    expect(recallMinimumScoreAfterExpansion(0.9, true)).toBe(0.9);
+  });
+
+  it('only treats explicit loopback Effect AI endpoints as local', () => {
+    expect(isLoopbackAiEndpoint('http://127.0.0.1:8081/v1')).toBe(true);
+    expect(isLoopbackAiEndpoint('http://localhost:11434/v1')).toBe(true);
+    expect(isLoopbackAiEndpoint('https://models.example.com/v1')).toBe(false);
+    expect(isLoopbackAiEndpoint(undefined)).toBe(false);
+  });
+
+  it.effect('keeps application code provider-independent', () =>
+    expandRecallQueryEffect({project: 'threadnote', query: 'how do beta updates differ'}).pipe(
+      Effect.provide(
+        Layer.succeed(RecallQueryExpander, {
+          expand: ({query}) => Effect.succeed([`rewrite:${query}`]),
+        }),
+      ),
+      Effect.tap(rewrites => Effect.sync(() => expect(rewrites).toEqual(['rewrite:how do beta updates differ']))),
+    ),
+  );
+});

--- a/test/unit/local-ai.test.ts
+++ b/test/unit/local-ai.test.ts
@@ -1,0 +1,161 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {Effect} from 'effect';
+import {afterEach, describe, expect, it} from 'vitest';
+import {
+  EFFECT_AI_API_URL_ENV,
+  EFFECT_AI_ENABLED_ENV,
+  EFFECT_AI_MODEL_ENV,
+  resolveEffectAiConfiguration,
+} from '../../src/effect/ai-consolidator.js';
+import {
+  LOCAL_AI_DEFAULT_PORT,
+  LOCAL_AI_MODEL_ID,
+  localAiHealthProof,
+  localAiApiUrl,
+  localAiProcessOwnershipMatches,
+  parseLocalAiSettings,
+  runLocalAiInstall,
+} from '../../src/effect/local-ai.js';
+import {captureConsole} from '../../src/effect/console.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import type {RuntimeConfig} from '../../src/types.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const homes: string[] = [];
+const ACCESS_TOKEN = 'a'.repeat(43);
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+});
+
+describe('local AI configuration', () => {
+  it('accepts only a loopback, versioned configuration', () => {
+    const settings = parseLocalAiSettings({
+      enabled: true,
+      host: '127.0.0.1',
+      model: LOCAL_AI_MODEL_ID,
+      modelPath: '/models/gemma.gguf',
+      port: LOCAL_AI_DEFAULT_PORT,
+      version: 1,
+    });
+
+    expect(localAiApiUrl(settings)).toBe('http://127.0.0.1:1934/v1');
+    expect(() => parseLocalAiSettings({...settings, host: '0.0.0.0'})).toThrow(/unsupported shape/);
+    expect(() => parseLocalAiSettings({...settings, version: 2})).toThrow(/unsupported shape/);
+  });
+
+  it('uses persisted local configuration without environment variables', async () => {
+    const home = await makeHome();
+    await writeSettings(home);
+
+    const resolved = await runEffect(
+      resolveEffectAiConfiguration({agentContextHome: home}, {}).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    expect(resolved).toEqual({
+      configuration: {apiKey: ACCESS_TOKEN, apiUrl: 'http://127.0.0.1:1934/v1', model: LOCAL_AI_MODEL_ID},
+      localAi: expect.objectContaining({model: LOCAL_AI_MODEL_ID}),
+    });
+  });
+
+  it('proves health responses without sending the access token to an untrusted listener', async () => {
+    const proof = await runEffect(
+      localAiHealthProof({
+        challenge: 'challenge',
+        launchId: 'launch-id',
+        model: LOCAL_AI_MODEL_ID,
+        pid: 42,
+        token: ACCESS_TOKEN,
+      }).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    expect(proof).toHaveLength(64);
+    expect(proof).not.toContain(ACCESS_TOKEN);
+  });
+
+  it('only stops a process whose authenticated launch identity matches the record', () => {
+    const settings = {model: LOCAL_AI_MODEL_ID, modelPath: '/models/gemma.gguf'};
+    const record = {launchId: 'launch-id', modelPath: settings.modelPath, pid: 42};
+    const health = {launchId: 'launch-id', model: settings.model, pid: 42};
+
+    expect(localAiProcessOwnershipMatches(record, health, settings)).toBe(true);
+    expect(localAiProcessOwnershipMatches(record, undefined, settings)).toBe(false);
+    expect(localAiProcessOwnershipMatches(record, {...health, launchId: 'reused-pid'}, settings)).toBe(false);
+    expect(localAiProcessOwnershipMatches(record, {...health, pid: 43}, settings)).toBe(false);
+  });
+
+  it('lets an explicit environment provider override or disable persisted local AI', async () => {
+    const home = await makeHome();
+    await writeSettings(home);
+
+    const remote = await runEffect(
+      resolveEffectAiConfiguration(
+        {agentContextHome: home},
+        {
+          [EFFECT_AI_API_URL_ENV]: 'https://models.example.com/v1',
+          [EFFECT_AI_ENABLED_ENV]: '1',
+          [EFFECT_AI_MODEL_ENV]: 'remote-model',
+        },
+      ).pipe(Effect.provide(ApplicationLayer)),
+    );
+    const disabled = await runEffect(
+      resolveEffectAiConfiguration({agentContextHome: home}, {[EFFECT_AI_ENABLED_ENV]: '0'}).pipe(
+        Effect.provide(ApplicationLayer),
+      ),
+    );
+
+    expect(remote).toEqual({
+      configuration: {apiKey: undefined, apiUrl: 'https://models.example.com/v1', model: 'remote-model'},
+    });
+    expect(disabled).toBeUndefined();
+  });
+
+  it('prints a complete install plan without requiring OpenViking or a model download', async () => {
+    const home = await makeHome();
+    const result = await runEffect(
+      captureConsole(runLocalAiInstall(runtime(home), {dryRun: true})).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    expect(result.output).toContain('Would download ggml-org/gemma-4-E4B-it-GGUF');
+    expect(result.output).toContain('Would verify SHA-256');
+    expect(result.output).toContain('Would start the loopback model service at http://127.0.0.1:1934/v1');
+  });
+});
+
+async function makeHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'threadnote-local-ai-'));
+  homes.push(home);
+  return home;
+}
+
+async function writeSettings(home: string): Promise<void> {
+  const directory = join(home, 'threadnote');
+  await mkdir(directory, {recursive: true});
+  await writeFile(
+    join(directory, 'local-ai.json'),
+    `${JSON.stringify({
+      enabled: true,
+      host: '127.0.0.1',
+      model: LOCAL_AI_MODEL_ID,
+      modelPath: '/models/gemma.gguf',
+      port: LOCAL_AI_DEFAULT_PORT,
+      version: 1,
+    })}\n`,
+  );
+  await writeFile(join(directory, 'local-ai-token'), `${ACCESS_TOKEN}\n`, {mode: 0o600});
+}
+
+function runtime(agentContextHome: string): RuntimeConfig {
+  return {
+    account: 'local',
+    agentContextHome,
+    agentId: 'threadnote',
+    host: '127.0.0.1',
+    manifestPath: join(agentContextHome, 'seed-manifest.yaml'),
+    openVikingVersion: '0.4.7',
+    port: 1933,
+    user: 'test',
+  };
+}

--- a/test/unit/memory.recall.test.ts
+++ b/test/unit/memory.recall.test.ts
@@ -83,6 +83,32 @@ describe('runRecall index repair fallback', () => {
     expect(output).toContain('availability check');
   });
 
+  it('keeps deterministic recall available when the optional local AI config is malformed', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'threadnote-recall-malformed-local-ai-'));
+    await mkdir(join(dir, 'threadnote'), {recursive: true});
+    await writeFile(join(dir, 'threadnote', 'local-ai.json'), '{invalid', 'utf8');
+    const runCommand = vi
+      .spyOn(utils, 'runCommand')
+      .mockReturnValue(Effect.succeed({exitCode: 0, stderr: '', stdout: '[]'}));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    try {
+      await run(
+        runRecall(
+          {...runtime, agentContextHome: dir, manifestPath: join(dir, 'missing-seed-manifest.yaml')},
+          {inferScope: false, query: 'deterministic fallback'},
+        ),
+      );
+    } finally {
+      runCommand.mockRestore();
+      await rm(dir, {force: true, recursive: true});
+    }
+
+    const output = log.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(output).toContain('Local AI recall unavailable: Invalid Threadnote local AI configuration');
+    expect(output).toContain('Deterministic recall continued.');
+  });
+
   it('adds remote-derived project memory scopes for current repo recall', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'threadnote-recall-remote-project-'));
     const repoRoot = join(dir, 'easy-to-type');

--- a/test/unit/recall.evaluate.test.ts
+++ b/test/unit/recall.evaluate.test.ts
@@ -15,5 +15,10 @@ describe('recall evaluation contract v1', () => {
     expect(result.metrics.noAnswerRecall).toBe(1);
     expect(result.metrics.requiredReasonsPresent).toBe(true);
     expect(result.metrics.staleHitRate).toBe(0);
+
+    const paraphrases = result.queryResults.filter(query => query.id.startsWith('paraphrase-'));
+    expect(paraphrases).toHaveLength(4);
+    expect(paraphrases.every(query => query.expanded && query.initialConfidence !== 'high')).toBe(true);
+    expect(paraphrases.every(query => query.rankedUris.length > 0)).toBe(true);
   });
 });

--- a/test/unit/recall.index.test.ts
+++ b/test/unit/recall.index.test.ts
@@ -322,6 +322,19 @@ describe('local recall index', () => {
     expect(stable[0]?.uri).toBe('viking://resources/repos/threadnote/target.md');
   });
 
+  it('observes another process invalidating an already-warmed cache', async () => {
+    const resourceRoot = join(directory, 'data', 'viking', 'local', 'resources', 'repos', 'threadnote');
+    await mkdir(resourceRoot, {recursive: true});
+    await writeFile(join(resourceRoot, 'first.md'), '# First\n\nfirst-anchor', 'utf8');
+    await run(loadRecallIndex(config(), {includeInactive: false, query: 'first-anchor'}));
+
+    await writeFile(join(resourceRoot, 'second.md'), '# Second\n\nsecond-anchor', 'utf8');
+    await writeFile(join(directory, 'cache', 'recall-index-v5.json.stale'), 'external-generation\n', 'utf8');
+
+    const refreshed = await run(loadRecallIndex(config(), {includeInactive: false, query: 'second-anchor'}));
+    expect(refreshed[0]?.uri).toBe('viking://resources/repos/threadnote/second.md');
+  });
+
   it('caps self-asserted authority and trust at the URI source boundary', async () => {
     const personalPath = join(
       directory,

--- a/test/unit/recall.rank.test.ts
+++ b/test/unit/recall.rank.test.ts
@@ -34,6 +34,34 @@ describe('hybrid recall ranker', () => {
     );
   });
 
+  it('uses expanded query vocabulary without weakening original-query evidence', () => {
+    const candidates = [
+      {
+        fields: {project: 'threadnote', title: 'Beta update channel', topic: 'beta-update-channel'},
+        kind: 'durable' as const,
+        text: 'Prerelease packages use npm beta dist-tag; stable packages use latest.',
+        uri: 'viking://user/me/memories/beta-update-channel.md',
+      },
+      {
+        fields: {project: 'threadnote', title: 'Ordinary installation troubleshooting'},
+        semantic: 0.5,
+        text: 'Ordinary installation troubleshooting.',
+        uri: 'viking://user/me/memories/install-troubleshooting.md',
+      },
+    ];
+    const query = 'How do preview builds get upgraded compared with ordinary installs?';
+    const original = rankRecallCandidates(query, candidates, {project: 'threadnote'});
+    const expanded = rankRecallCandidates(query, candidates, {
+      project: 'threadnote',
+      queryVariants: ['beta prerelease channel npm dist-tag stable latest'],
+    });
+
+    expect(original.results[0]?.candidate.uri).toContain('install-troubleshooting.md');
+    expect(expanded.results[0]?.candidate.uri).toContain('beta-update-channel.md');
+    expect(expanded.results.some(result => result.candidate.uri.includes('install-troubleshooting.md'))).toBe(true);
+    expect(expanded.results[0]?.signals.bm25).toBeGreaterThan(original.results[0]?.signals.bm25 ?? 0);
+  });
+
   it('prefers an exact compound topic over a general body match', () => {
     const ranked = rankRecallCandidates(
       'threadnote user preference posting style for release notes',

--- a/test/unit/recall.runtime.test.ts
+++ b/test/unit/recall.runtime.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it} from 'vitest';
+import {mergeRecallIndexCandidates, recallExpansionVocabulary} from '../../src/recall/runtime.js';
+
+describe('recall expansion vocabulary', () => {
+  it('offers project topics before verbose candidate identifiers', () => {
+    expect(
+      recallExpansionVocabulary(
+        [
+          {
+            fields: {
+              identifiers: ['first.ts', 'second.ts'],
+              project: 'threadnote',
+              topic: 'lifecycle-memory-split',
+            },
+            text: 'lifecycle lifecycle memory split split keeps keeps handoffs handoffs separate separate',
+            uri: 'viking://first',
+          },
+          {
+            fields: {
+              identifiers: ['third.ts'],
+              project: 'threadnote',
+              topic: 'recall-and-memory-formation',
+            },
+            text: 'recall recall uses uses ranking ranking evidence evidence signals signals',
+            uri: 'viking://second',
+          },
+          {
+            fields: {
+              identifiers: ['fourth.ts'],
+              project: 'threadnote',
+              topic: 'recall-and-memory-formation',
+            },
+            text: 'duplicate handoff excerpt',
+            uri: 'viking://duplicate-topic',
+          },
+        ],
+        'threadnote',
+      ),
+    ).toEqual([
+      'lifecycle-memory-split :: lifecycle memory split keeps handoffs separate',
+      'recall-and-memory-formation :: recall uses ranking evidence signals',
+      'first.ts',
+      'second.ts',
+      'third.ts',
+      'fourth.ts',
+    ]);
+  });
+
+  it('interleaves original and expansion candidates before the bounded rank window', () => {
+    const candidate = (uri: string) => ({text: '', uri});
+
+    expect(
+      mergeRecallIndexCandidates([
+        [candidate('original-1'), candidate('original-2'), candidate('shared')],
+        [candidate('expanded-1'), candidate('shared'), candidate('expanded-2')],
+      ]).map(item => item.uri),
+    ).toEqual(['original-1', 'expanded-1', 'original-2', 'shared', 'expanded-2']);
+  });
+
+  it('reserves grounded vocabulary space for recent project topics after a large ranked prefix', () => {
+    const older = Array.from({length: 60}, (_unused, index) => ({
+      fields: {project: 'threadnote', topic: `older-topic-${index}`},
+      text: `older topic ${index}`,
+      timestamp: '2025-01-01T00:00:00.000Z',
+      uri: `viking://older-${index}`,
+    }));
+    const vocabulary = recallExpansionVocabulary(
+      [
+        ...older,
+        {
+          fields: {project: 'threadnote', topic: 'recent-release-contract'},
+          text: 'recent release channel contract',
+          timestamp: '2026-07-24T00:00:00.000Z',
+          uri: 'viking://recent',
+        },
+      ],
+      'threadnote',
+    );
+
+    expect(vocabulary).toHaveLength(50);
+    expect(vocabulary).toContain('recent-release-contract :: recent release channel contract');
+  });
+});

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -463,4 +463,28 @@ describe('runPostUpdate', () => {
       expect.arrayContaining(['repair-semantic-queue']),
     );
   });
+
+  it('offers the pinned local recall model as an opt-in post-update action', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    vi.mocked(utils.runCommand).mockImplementation((executable, args) => {
+      if (executable === '/ov' && args[0] === '--version') {
+        return Effect.succeed(ok('openviking 0.4.7\n'));
+      }
+      return Effect.succeed(ok());
+    });
+    const executeStreaming = vi.fn(() => Effect.succeed(ok()));
+    const executor = CommandExecutor.of({
+      execute: () => Effect.succeed(ok()),
+      executeStreaming,
+    });
+
+    await runEffect(
+      runPostUpdate(config, {fromVersion: '3.0.0-beta.4', toVersion: '3.0.0-beta.5', yes: true}).pipe(
+        Effect.provideService(CommandExecutor, executor),
+      ),
+    );
+
+    expect(executeStreaming).toHaveBeenCalledWith('/threadnote', ['local-ai', 'install'], {});
+  });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -777,7 +777,28 @@ describe('parseRecallHits / mergeRecallHits / formatRecallHits', () => {
     expect(sections.confidence?.level).not.toBe('no_answer');
     expect(sections.semanticSection).toContain('Recall confidence:');
     expect(sections.semanticSection).toContain('why:');
+    expect(sections.exactTail).toBeUndefined();
     expect(sections.ranked[0]?.rankReasons?.map(reason => reason.code)).toContain('field_match');
+  });
+
+  it('does not emit rejected exact pointers after hybrid ranking', () => {
+    const sections = buildRecallSections(
+      [],
+      [
+        {terms: ['alpha-42'], uri: 'viking://resources/repos/threadnote/alpha-42.md'},
+        {terms: ['beta-43'], uri: 'viking://resources/repos/threadnote/beta-43.md'},
+      ],
+      1,
+      {
+        allowExactRescue: true,
+        project: 'threadnote',
+        query: 'alpha-42 beta-43',
+      },
+    );
+
+    expect(sections.ranked.length).toBeGreaterThan(1);
+    expect(sections.exactTail).toBeUndefined();
+    expect(sections.semanticSection).not.toContain('Exact term matches');
   });
 
   it('suppresses weak keyword-only filler when hybrid confidence is no answer', () => {


### PR DESCRIPTION
## Summary

Adds an optional local Gemma 4 query-expansion path for weak and medium-confidence recalls while keeping deterministic retrieval, ranking, thresholds, and fail-open behavior in control.

## Detail

- Repairs `npm run eval:recall` by providing the complete Effect application layer and expands the fixture with beta-channel, ranking-signal, Android app-link, and Docs reconnect paraphrases.
- Runs the model only after deterministic confidence is known: high confidence skips it, medium evaluates one grounded rewrite, and low/no-answer evaluates at most two.
- Adds `threadnote local-ai install|start|stop|status|uninstall`, pinned model verification, lazy start, lifecycle locking, and a thin `llama_cpp` OpenAI-compatible adapter.
- Authenticates model endpoints with a private token and challenge-response health proof. PID stop requires the authenticated launch identity to match.
- Offers the 4.59 GB model as an optional post-update action for 3.0.0 and its prereleases. Explicit environment providers still override persisted local AI.
- Keeps memory-candidate extraction and metadata unchanged. The model is used only for query rewrites and explicit consolidation drafts.
- Makes recall-index invalidation generation-aware so long-lived MCP processes observe memory written by another process immediately.

The tradeoff is an opt-in 4.59 GB local download and model startup latency on the first weak recall; high-confidence recalls avoid the model and full-vocabulary work.

## Test plan

Coverage includes grounded rewrite limits, explicit-threshold preservation, malformed-provider fail-open behavior, authenticated lifecycle ownership, warmed cross-process cache invalidation, the four paraphrase fixtures, the 10k-document benchmark, and packaged MCP recall expansion.
