### PR TITLE
fix(release): make stable verification reproducible

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/test/e2e/local-bins.e2e.ts
+++ b/test/e2e/local-bins.e2e.ts
@@ -951,19 +951,29 @@ describe('built self-contained distribution', () => {
         name: 'recall_context',
       });
       expect(invalidRecall.isError).toBe(true);
-      const productionLog = await readFile(join(home, 'logs', 'threadnote.log'), 'utf8');
-      const mcpLogEntries = parseProductionLog(productionLog).filter(entry => entry.component === 'mcp');
-      expect(mcpLogEntries).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({event: 'invocation.finished', operation: 'health', outcome: 'success'}),
-          expect.objectContaining({
-            errorType: 'McpToolError',
-            event: 'invocation.finished',
-            operation: 'recall_context',
-            outcome: 'failure',
-          }),
-        ]),
-      );
+      let productionLog = '';
+      await expect
+        .poll(
+          async () => {
+            productionLog = await readFile(join(home, 'logs', 'threadnote.log'), 'utf8');
+            const mcpLogEntries = parseProductionLog(productionLog).filter(entry => entry.component === 'mcp');
+            return {
+              health: mcpLogEntries.some(
+                entry =>
+                  entry.event === 'invocation.finished' && entry.operation === 'health' && entry.outcome === 'success',
+              ),
+              invalidRecall: mcpLogEntries.some(
+                entry =>
+                  entry.errorType === 'McpToolError' &&
+                  entry.event === 'invocation.finished' &&
+                  entry.operation === 'recall_context' &&
+                  entry.outcome === 'failure',
+              ),
+            };
+          },
+          {interval: 50, timeout: 10_000},
+        )
+        .toEqual({health: true, invalidRecall: true});
       expect(productionLog).not.toContain(privatePayloadMarker);
       const recall = await client.callTool({
         arguments: {query: 'MCP-OBSIDIAN-881'},

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -702,6 +702,9 @@ describe('Threadnote 4 website content', () => {
       expect(() =>
         execFileSync('git', ['cat-file', '-e', `${target[1]}:${target[2]}`], {cwd: root, stdio: 'pipe'}),
       ).not.toThrow();
+      expect(() =>
+        execFileSync('git', ['merge-base', '--is-ancestor', target[1], 'HEAD'], {cwd: root, stdio: 'pipe'}),
+      ).not.toThrow();
     }
     expect(performancePage).not.toMatch(/>Pending<|pending artifact|evidence pending/i);
     expect(performancePage).toContain('aria-label={`Open the pinned');

--- a/website/src/content/performanceHighlights.ts
+++ b/website/src/content/performanceHighlights.ts
@@ -3,8 +3,7 @@ import intellijQueryEvidence from '../../../test/evaluation/candidates/threadnot
 import lexicalProductionEvidence from '../../../test/evaluation/candidates/threadnote-4.0.0/benchmarks/darwin-arm64-m1-max/code-graph-lexical-production-100k-2026-08-02.json' with {type: 'json'};
 import type {PerformanceControlLanguage} from './performance.js';
 
-const intellijEvidenceCommit = 'b42baea0dfd00d5d9eb38569cce646f26ac16279';
-const lexicalEvidenceCommit = '00faf82c0c79141139d8c3181d50956ce7c55c11';
+const publicEvidenceCommit = '2172d719b5f2138d34fcc0370c1ccda501be82dc';
 const evidenceDirectory = 'test/evaluation/candidates/threadnote-4.0.0/benchmarks/darwin-arm64-m1-max';
 
 function requireLanguageControl(language: string) {
@@ -75,8 +74,8 @@ export const checkedInPerformanceEvidence = {
     ]),
   ) as Readonly<Record<PerformanceControlLanguage, Readonly<{milliseconds: number; query: string}>>>,
   artifacts: {
-    query: `https://github.com/Kashkovsky/threadnote/blob/${intellijEvidenceCommit}/${evidenceDirectory}/code-graph-intellij-query-2026-08-01.json`,
-    analysis: `https://github.com/Kashkovsky/threadnote/blob/${intellijEvidenceCommit}/${evidenceDirectory}/code-graph-intellij-analysis-summary-2026-08-01.json`,
-    lexicalStorage: `https://github.com/Kashkovsky/threadnote/blob/${lexicalEvidenceCommit}/${evidenceDirectory}/code-graph-lexical-production-100k-2026-08-02.json`,
+    query: `https://github.com/Kashkovsky/threadnote/blob/${publicEvidenceCommit}/${evidenceDirectory}/code-graph-intellij-query-2026-08-01.json`,
+    analysis: `https://github.com/Kashkovsky/threadnote/blob/${publicEvidenceCommit}/${evidenceDirectory}/code-graph-intellij-analysis-summary-2026-08-01.json`,
+    lexicalStorage: `https://github.com/Kashkovsky/threadnote/blob/${publicEvidenceCommit}/${evidenceDirectory}/code-graph-lexical-production-100k-2026-08-02.json`,
   },
 } as const;


### PR DESCRIPTION
## Summary

- pin public performance evidence links to artifacts present in merged `main` history
- fetch complete history during exact-tag release verification
- wait for bounded asynchronous MCP production-log completion on slower macOS runners

## Validation

- full pre-commit suite: 182 files, 1718 tests
- local-bin E2E: 18/18
- focused publish/website tests: 42/42
- lint, typecheck, formatting, and website checks pass

This is the corrective change for the unpublished `v4.0.0` release attempt; no runtime behavior changes.