### PR TITLE
Fix release evidence bounds and mobile landing layout

### DIFF
--- a/.github/workflows/production-large-evidence.yml
+++ b/.github/workflows/production-large-evidence.yml
@@ -3,11 +3,11 @@ name: Production-large code graph evidence
 on:
   workflow_call:
     inputs:
-      gate_release:
-        description: Whether this observation is a required release gate rather than non-blocking retained evidence
+      strict:
+        description: Whether an incomplete bounded observation should fail the evidence workflow
         required: false
         type: boolean
-        default: false
+        default: true
       release_ref:
         description: Optional exact Threadnote 4 release tag ref
         required: false
@@ -29,7 +29,7 @@ jobs:
   code-graph-production-large:
     name: Code graph production-large · n=1 · pinned Linux class
     runs-on: ubuntu-24.04
-    timeout-minutes: 360
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -54,8 +54,10 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: Capture one production-large observation with phase and storage telemetry
-        timeout-minutes: 320
+      - id: capture_production_large
+        name: Capture one production-large observation with phase and storage telemetry
+        continue-on-error: true
+        timeout-minutes: 20
         env:
           THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-ubuntu-24.04-${{ runner.arch }}
           THREADNOTE_BENCHMARK_RUNNER_ID: ${{ runner.name }}
@@ -71,7 +73,7 @@ jobs:
       - id: upload-production-large
         uses: actions/upload-artifact@v7
         if: always()
-        timeout-minutes: 10
+        timeout-minutes: 5
         with:
           name: code-graph-production-large-n1-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
           path: artifacts/code-graph-production-large-n1-*.json
@@ -86,20 +88,31 @@ jobs:
           ARTIFACT_URL: ${{ steps.upload-production-large.outputs.artifact-url }}
           SOURCE_REF: ${{ inputs.release_ref || github.ref }}
           SOURCE_SHA: ${{ inputs.release_sha || github.sha }}
-          RELEASE_GATE: ${{ inputs.gate_release }}
+          MEASUREMENT_OUTCOME: ${{ steps.capture_production_large.outcome }}
+          STRICT_EVIDENCE: ${{ inputs.strict }}
         run: |
-          if [[ "$RELEASE_GATE" == "true" ]]; then
-            release_policy='required before publishing this RC or stable release'
+          if [[ "$STRICT_EVIDENCE" == "true" ]]; then
+            evidence_policy='must complete for this evidence workflow to pass'
           else
-            release_policy='retained and reported without blocking beta publication'
+            evidence_policy='bounded observation retained without blocking release publication'
           fi
           {
             echo '## Production-large release evidence'
             echo
             echo "- Source ref: \`${SOURCE_REF}\`"
             echo "- Source commit: \`${SOURCE_SHA}\`"
-            echo "- Release policy: ${release_policy}"
+            echo "- Measurement outcome: \`${MEASUREMENT_OUTCOME}\`"
+            echo "- Evidence policy: ${evidence_policy}"
             echo "- Retained artifact digest: \`${ARTIFACT_DIGEST:-not-produced}\`"
             echo "- Retained artifact: ${ARTIFACT_URL:-not-produced}"
             echo '- Scope: aggregate production-shaped scan, materialization, resolution, activation-stage, SQLite scratch, and one-file reindex telemetry.'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce strict evidence completion
+        if: inputs.strict && steps.capture_production_large.outcome != 'success'
+        env:
+          MEASUREMENT_OUTCOME: ${{ steps.capture_production_large.outcome }}
+        shell: bash
+        run: |
+          echo "::error::Production-large evidence ended with outcome ${MEASUREMENT_OUTCOME}."
+          exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,21 +16,6 @@ env:
   BUN_VERSION: 1.3.14
 
 jobs:
-  # Verification, platform builds, and exact-commit evidence start together. Publication joins the required outcomes.
-  # Betas report production-large evidence asynchronously; RC and stable publication depend on it.
-  production-large-evidence:
-    name: Validate production-large release evidence
-    if: >-
-      github.event_name == 'push' &&
-      (startsWith(github.ref, 'refs/tags/v4.0.0-beta.') ||
-       startsWith(github.ref, 'refs/tags/v4.0.0-rc.') ||
-       github.ref == 'refs/tags/v4.0.0')
-    uses: ./.github/workflows/production-large-evidence.yml
-    with:
-      gate_release: ${{ startsWith(github.ref, 'refs/tags/v4.0.0-rc.') || github.ref == 'refs/tags/v4.0.0' }}
-      release_ref: ${{ github.ref }}
-      release_sha: ${{ github.sha }}
-
   verify:
     name: Verify release source
     runs-on: ubuntu-latest
@@ -392,39 +377,16 @@ jobs:
           path: artifacts/
           if-no-files-found: error
 
-  # Keep beta feedback fast: verified, signed platform artifacts are sufficient to publish the prerelease.
-  publish-beta:
-    name: Publish beta without waiting for production-large evidence
+  publish-release:
+    # Production-large evidence has a separate bounded tag workflow so release status reflects distribution only.
+    name: Publish complete immutable release
     if: >-
       always() &&
       github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags/v4.0.0-beta.') &&
       needs.verify.result == 'success' &&
       needs.linux.result == 'success' &&
       needs.macos.result == 'success'
     needs: [verify, linux, macos]
-    permissions:
-      contents: write
-    uses: ./.github/workflows/publish-release-assets.yml
-    with:
-      release_tag: ${{ github.ref_name }}
-
-  publish-evidence-gated:
-    name: Publish release after required production-large evidence
-    if: >-
-      always() &&
-      github.event_name == 'push' &&
-      !startsWith(github.ref, 'refs/tags/v4.0.0-beta.') &&
-      needs.verify.result == 'success' &&
-      needs.linux.result == 'success' &&
-      needs.macos.result == 'success' &&
-      (((startsWith(github.ref, 'refs/tags/v4.0.0-rc.') ||
-         github.ref == 'refs/tags/v4.0.0') &&
-        needs.production-large-evidence.result == 'success') ||
-       (!(startsWith(github.ref, 'refs/tags/v4.0.0-rc.') ||
-          github.ref == 'refs/tags/v4.0.0') &&
-        needs.production-large-evidence.result == 'skipped'))
-    needs: [verify, linux, macos, production-large-evidence]
     permissions:
       contents: write
     uses: ./.github/workflows/publish-release-assets.yml

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -1,0 +1,20 @@
+name: Retain bounded production-large release evidence
+
+on:
+  push:
+    tags:
+      - 'v4.0.0-beta.*'
+      - 'v4.0.0-rc.*'
+      - 'v4.0.0'
+
+permissions:
+  contents: read
+
+jobs:
+  production-large-evidence:
+    name: Retain bounded exact-tag production-large evidence
+    uses: ./.github/workflows/production-large-evidence.yml
+    with:
+      strict: false
+      release_ref: ${{ github.ref }}
+      release_sha: ${{ github.sha }}

--- a/docs/4.0-performance-reliability-audit.md
+++ b/docs/4.0-performance-reliability-audit.md
@@ -131,9 +131,9 @@ claim.
 - A dedicated opt-in/nightly profile now reproduces the field-investigation shape near 48k files, 800k symbols,
   2.7m edges, 12m lexical term rows, and mixed integrated/nested workspaces. It emits phase, CPU/RSS, SQLite/WAL,
   vector, sidecar, disk, status-latency, aggregate materialized-row, and one-file materialization telemetry. Every
-  `v4.0.0-beta.*`, `v4.0.0-rc.*`, and final `v4.0.0` tag runs it once on the pinned Linux class; immutable publication
-  waits for its exact-commit artifact and upload digest, retained for 90 days. It remains excluded from ordinary
-  pull-request latency gates.
+  `v4.0.0-beta.*`, `v4.0.0-rc.*`, and final `v4.0.0` tag starts one separate, 30-minute-bounded observation on the
+  pinned Linux class. Publication never waits for it; the latest exact-commit checkpoint and upload digest are retained
+  for 90 days for performance review. It remains excluded from ordinary pull-request latency gates.
 - A second scheduled/opt-in heavy-tail job checks pathological TypeScript, 25 MiB low-signal JSON, thousands of SVGs,
   interruption/resume cache reuse, and deterministic single-worker versus parallel parser output on a pinned Linux
   class. That suite covers parser/extraction/cache behavior; it does not establish production-scale materialization or

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -54,29 +54,28 @@ checksums but are not OS code-signed.
    user-visible value rather than implementation history, include concrete commands when useful, and do not add a
    validation/checks section.
 2. Merge the release source and ensure ordinary CI is green.
-3. For final 4.0 signoff, review the exact-tag `code-graph-production-large-n1` artifact produced by the publishing
-   workflow. Do not dispatch a duplicate production-large run for the same tag.
+3. Review the latest retained `code-graph-production-large-n1` evidence when assessing graph performance. Do not
+   dispatch a duplicate production-large run for the same tag.
 4. Confirm immutable releases are enabled and the Apple signing secrets below are configured.
 5. Create and push the version tag matching both `package.json` and the release-notes filename, for example
    `v4.0.0-beta.9`.
-6. Wait for `Publish standalone release`. Do not create a GitHub Release manually. Betas publish after all four enabled
-   archives are ready while their production-large evidence continues asynchronously; RC and stable releases publish
-   only after the exact-tag production-large evidence job succeeds.
+6. Wait for `Publish standalone release`. Do not create a GitHub Release manually. Every channel publishes after all
+   four enabled archives are verified while its bounded production-large observation continues independently.
 
-Every `v4.0.0-beta.*`, `v4.0.0-rc.*`, and final `v4.0.0` tag starts one production-large run on `ubuntu-24.04` inside
-the publishing workflow. Archive builds may proceed in parallel. Beta publication does not wait for this asynchronous
-evidence, while RC and stable publication fail closed until it validates the exact source, production-shape attainment,
-parity, telemetry, and canonical artifact. A failed run or missing upload blocks RC and stable publication; the
-benchmark workflow no longer starts duplicate work for the same tag. Aggregate, privacy-safe phase/materialization
-evidence, failure checkpoints, exact source commit, and upload digest are retained for 90 days. Treat a successful
-result as `n=1` same-runner release evidence, not as a portable p95. The heavy-tail job remains separate parser/cache
-coverage and must not be used as a substitute for production-scale materialization evidence.
+Every `v4.0.0-beta.*`, `v4.0.0-rc.*`, and final `v4.0.0` tag starts a separate production-large evidence workflow on
+`ubuntu-24.04`; the publishing workflow never waits for it and its conclusion reports distribution status only. The
+evidence job has a hard 30-minute ceiling: its measured phase gets 20 minutes, leaving bounded time to upload the
+latest privacy-safe checkpoint and summary. Incomplete release observations are reported but never delay publication;
+scheduled or explicitly requested strict runs still fail when the profile does not complete inside the same bound.
+Aggregate phase/materialization evidence, failure checkpoints, exact source commit, and upload digest are retained for
+90 days. Treat a successful result as `n=1` same-runner evidence, not as a portable p95. The heavy-tail job remains
+separate parser/cache coverage and must not be used as a substitute for production-scale materialization evidence.
 
-The release-evidence validator fails closed: the artifact must name the Threadnote 4 tag and exact matching commit,
+Completed release evidence remains provenance-strict: the artifact must name the Threadnote 4 tag and exact matching commit,
 the local checkout must resolve that tag through `ref^{commit}` to the same SHA, and the measured checkout must be
 clean. The benchmark workflow explicitly checks out the event ref and verifies that resolution before measurement. A
 production-shaped run without that provenance remains useful development evidence, but it cannot be presented as
-release evidence.
+exact-release evidence.
 
 The tag workflow fails before building or signing when its versioned release-notes file is absent, empty, or does not
 start with the required heading. It prepends this checked-in copy to GitHub's automatically generated changelog, so

--- a/test/evaluation/README.md
+++ b/test/evaluation/README.md
@@ -56,11 +56,12 @@ shared-runner latency is machine-independent.
 
 The reviewed `production-large` profile is shaped after the beta.27 field investigation: approximately 48,000
 eligible files, 800,000 symbols, 2.7 million edges, 12 million lexical term rows, and 24 integrated and nested
-workspaces. One reusable workflow runs weekly, through the explicit `include_production_large` input, and as the
-publication gate for every `v4.0.0-beta.*`, `v4.0.0-rc.*`, and final `v4.0.0` tag on the pinned `ubuntu-24.04` runner
-class. Publication waits for the exact-commit artifact and upload digest, retained for 90 days; ordinary pull requests retain the bounded development,
-10k-symbol, and 100k-symbol suites. `--profile-files` and `--profile-symbols` may shrink the same generator for harness
-development, but only the default shape is the reviewed profile. Release evidence must attain at least 90% of each
+workspaces. One reusable workflow runs weekly, through the explicit `include_production_large` input, and from a
+separate bounded workflow for every `v4.0.0-beta.*`, `v4.0.0-rc.*`, and final `v4.0.0` tag on the pinned
+`ubuntu-24.04` runner class. Publication never waits for this observation; the latest exact-commit checkpoint and upload
+digest are retained for 90 days. Ordinary pull requests retain the bounded development, 10k-symbol, and 100k-symbol
+suites. `--profile-files` and `--profile-symbols` may shrink the same generator for harness development, but only the
+default shape is the reviewed profile. Completed release evidence must attain at least 90% of each
 reviewed file, symbol, edge, and lexical-term target; merely carrying those measurement names cannot qualify an
 undersized run. There is intentionally no portable latency budget or fabricated checked result for this profile:
 retain the JSON artifact from each measured run and review it only when `sameRunnerComparisonKey` matches. The cold and
@@ -230,8 +231,9 @@ Each sampler atomically checkpoints its evidence into the workflow's artifact di
 exit. A separate run-lifecycle checkpoint records the current benchmark phase and ends as `complete` or `failed` when
 the process can finalize normally. If the process is killed, the last `running` phase and the sampler's
 `parent-exited` checkpoint remain. Sampler shutdown is bounded and escalates to process termination if the stop signal
-cannot be written or honored. The production step reserves at least 30 minutes before the job deadline, and artifact
-upload runs with `if: always()`, so failure and timeout evidence is retained whenever the runner itself remains alive.
+cannot be written or honored. The production job has a hard 30-minute ceiling: capture is limited to 20 minutes and
+artifact upload to 5 minutes, leaving the rest for checkout, setup, and summary. Upload runs with `if: always()`, so the
+latest failure or timeout checkpoint is retained whenever the runner itself remains alive.
 
 Graph code search is intentionally separate from memory recall. `recall_context` evaluates durable memories and
 resources; `inspect_code_graph` evaluates current source evidence. Agents may call both, but one subsystem failing or

--- a/test/evaluation/baselines/code-graph-v1/production-large-profile.json
+++ b/test/evaluation/baselines/code-graph-v1/production-large-profile.json
@@ -5,10 +5,10 @@
     "workspaceCount": 24
   },
   "notes": [
-    "Scheduled and manually dispatched runs plus the Threadnote 4 exact-tag publication gate use this profile; ordinary pull requests do not materialize it.",
+    "Scheduled and manually dispatched strict runs plus Threadnote 4's separate bounded exact-tag observation use this profile; ordinary pull requests do not materialize it.",
     "Targets come from the beta.27 large-monorepo investigation and are shape checks, not portable latency budgets.",
     "A checked performance artifact must come from a measured run; no synthetic latency baseline is accepted.",
-    "Threadnote 4 beta, RC, and final publication waits for one exact-commit observation retained for 90 days; ordinary pull requests do not run this profile.",
+    "Every covered v4.0.0 beta, RC, and final tag starts one non-blocking exact-commit observation retained for 90 days; ordinary pull requests do not run this profile.",
     "This profile retains materialization duration, CPU, RSS, and aggregate row counts; the separate heavy-tail fixture is parser/cache coverage, not materialization evidence."
   ],
   "profile": "production-large",

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -9,8 +9,11 @@ interface WorkflowJob {
   readonly permissions?: Readonly<Record<string, string>>;
   readonly 'runs-on'?: string;
   readonly steps?: readonly {
+    readonly 'continue-on-error'?: boolean;
+    readonly id?: string;
     readonly if?: string;
     readonly env?: Readonly<Record<string, string>>;
+    readonly name?: string;
     readonly run?: string;
     readonly 'timeout-minutes'?: number;
     readonly uses?: string;
@@ -29,10 +32,16 @@ interface WorkflowJob {
 interface BenchmarkWorkflow {
   readonly jobs: Readonly<Record<string, WorkflowJob>>;
   readonly on: {
+    readonly push?: {
+      readonly tags?: readonly string[];
+    };
     readonly pull_request?: {
       readonly paths?: readonly string[];
     };
     readonly workflow_dispatch?: {
+      readonly inputs?: Readonly<Record<string, unknown>>;
+    };
+    readonly workflow_call?: {
       readonly inputs?: Readonly<Record<string, unknown>>;
     };
   };
@@ -96,7 +105,7 @@ describe('platform benchmark workflow', () => {
     }
   });
 
-  it('reuses one fail-closed production-large n=1 workflow for schedule, opt-in, and release evidence', () => {
+  it('bounds the shared production-large n=1 workflow for schedule, opt-in, and release evidence', () => {
     const workflow = load(readFileSync('.github/workflows/benchmarks.yml', 'utf8'), {
       schema: JSON_SCHEMA,
     }) as BenchmarkWorkflow;
@@ -108,13 +117,16 @@ describe('platform benchmark workflow', () => {
     const command = job.steps?.flatMap(step => (step.run ? [step.run] : [])).join('\n') ?? '';
     const capture = job.steps?.find(step => step.run?.includes('--profile production-large'));
     const upload = job.steps?.find(step => step.uses?.startsWith('actions/upload-artifact@'));
+    const summary = job.steps?.find(step => step.run?.includes('Production-large release evidence'));
+    const enforcement = job.steps?.find(step => step.name === 'Enforce strict evidence completion');
 
     expect(workflow.on.workflow_dispatch?.inputs).toHaveProperty('include_production_large');
     expect(caller.if).toContain("github.event_name == 'schedule'");
     expect(caller.if).toContain('inputs.include_production_large');
     expect(caller.uses).toBe('./.github/workflows/production-large-evidence.yml');
+    expect(evidence.on.workflow_call?.inputs?.strict).toMatchObject({default: true, type: 'boolean'});
     expect(job['runs-on']).toBe('ubuntu-24.04');
-    expect(job['timeout-minutes']).toBe(360);
+    expect(job['timeout-minutes']).toBe(30);
     expect(command).toContain('--profile production-large');
     expect(command).toContain('--samples 1');
     expect(command).toContain('--warmups 0');
@@ -127,57 +139,60 @@ describe('platform benchmark workflow', () => {
       THREADNOTE_BENCHMARK_RELEASE_SHA: '${{ inputs.release_sha }}',
     });
     const captureTimeout = capture?.['timeout-minutes'];
-    expect(captureTimeout).toBeDefined();
-    expect(job['timeout-minutes']! - (captureTimeout ?? 0)).toBeGreaterThanOrEqual(30);
+    expect(captureTimeout).toBe(20);
+    expect(capture?.['continue-on-error']).toBe(true);
+    expect(job['timeout-minutes']! - (captureTimeout ?? 0)).toBeGreaterThanOrEqual(10);
     expect(upload?.uses).toBe('actions/upload-artifact@v7');
     expect(upload?.if).toBe('always()');
-    expect(upload?.['timeout-minutes']).toBeLessThanOrEqual(10);
+    expect(upload?.['timeout-minutes']).toBeLessThanOrEqual(5);
     expect(upload?.with?.path).toBe('artifacts/code-graph-production-large-n1-*.json');
     expect(upload?.with?.['if-no-files-found']).toBe('error');
     expect(upload?.with?.['retention-days']).toBe(90);
+    expect(enforcement?.if).toContain('inputs.strict');
+    expect(enforcement?.if).toContain("steps.capture_production_large.outcome != 'success'");
+    expect(enforcement?.run).toContain('exit 1');
+    expect(job.steps?.indexOf(enforcement!)).toBeGreaterThan(job.steps?.indexOf(upload!) ?? -1);
+    expect(job.steps?.indexOf(enforcement!)).toBeGreaterThan(job.steps?.indexOf(summary!) ?? -1);
   });
 
-  it('publishes betas after platform artifacts while retaining independent exact-commit evidence', () => {
+  it('publishes every channel after platform artifacts while retaining independent exact-commit evidence', () => {
     const workflow = load(readFileSync('.github/workflows/publish.yml', 'utf8'), {
+      schema: JSON_SCHEMA,
+    }) as BenchmarkWorkflow;
+    const releaseEvidence = load(readFileSync('.github/workflows/release-evidence.yml', 'utf8'), {
       schema: JSON_SCHEMA,
     }) as BenchmarkWorkflow;
     const publisher = load(readFileSync('.github/workflows/publish-release-assets.yml', 'utf8'), {
       schema: JSON_SCHEMA,
     }) as BenchmarkWorkflow;
-    const evidence = workflow.jobs['production-large-evidence']!;
+    const evidence = releaseEvidence.jobs['production-large-evidence']!;
     const linux = workflow.jobs.linux!;
     const macos = workflow.jobs.macos!;
-    const beta = workflow.jobs['publish-beta']!;
-    const gated = workflow.jobs['publish-evidence-gated']!;
+    const publish = workflow.jobs['publish-release']!;
     const release = publisher.jobs.publish!;
     const releaseCommand = release.steps?.flatMap(step => (step.run ? [step.run] : [])).join('\n') ?? '';
 
     expect(evidence.needs).toBeUndefined();
-    expect(evidence.if).toContain("startsWith(github.ref, 'refs/tags/v4.0.0-beta.')");
-    expect(evidence.if).toContain("startsWith(github.ref, 'refs/tags/v4.0.0-rc.')");
-    expect(evidence.if).toContain("github.ref == 'refs/tags/v4.0.0'");
+    expect(releaseEvidence.on.push?.tags).toEqual(['v4.0.0-beta.*', 'v4.0.0-rc.*', 'v4.0.0']);
     expect(evidence.uses).toBe('./.github/workflows/production-large-evidence.yml');
     expect(evidence.with).toMatchObject({
-      gate_release: "${{ startsWith(github.ref, 'refs/tags/v4.0.0-rc.') || github.ref == 'refs/tags/v4.0.0' }}",
+      strict: false,
       release_ref: '${{ github.ref }}',
       release_sha: '${{ github.sha }}',
     });
     expect(linux.needs).toBeUndefined();
     expect(macos.needs).toBeUndefined();
 
-    expect(beta.needs).toEqual(['verify', 'linux', 'macos']);
-    expect(beta.if).toContain("startsWith(github.ref, 'refs/tags/v4.0.0-beta.')");
-    expect(beta.if).toContain("needs.verify.result == 'success'");
-    expect(beta.if).not.toContain('needs.production-large-evidence');
-    expect(beta.uses).toBe('./.github/workflows/publish-release-assets.yml');
-    expect(beta.permissions).toEqual({contents: 'write'});
-
-    expect(gated.needs).toEqual(['verify', 'linux', 'macos', 'production-large-evidence']);
-    expect(gated.if).toContain("startsWith(github.ref, 'refs/tags/v4.0.0-rc.')");
-    expect(gated.if).toContain("github.ref == 'refs/tags/v4.0.0'");
-    expect(gated.if).toContain("needs.production-large-evidence.result == 'success'");
-    expect(gated.uses).toBe('./.github/workflows/publish-release-assets.yml');
-    expect(gated.permissions).toEqual({contents: 'write'});
+    expect(publish.needs).toEqual(['verify', 'linux', 'macos']);
+    expect(publish.if).toContain("needs.verify.result == 'success'");
+    expect(publish.if).toContain("needs.linux.result == 'success'");
+    expect(publish.if).toContain("needs.macos.result == 'success'");
+    expect(publish.if).not.toContain('needs.production-large-evidence');
+    expect(publish.uses).toBe('./.github/workflows/publish-release-assets.yml');
+    expect(publish.permissions).toEqual({contents: 'write'});
+    expect(workflow.jobs['publish-beta']).toBeUndefined();
+    expect(workflow.jobs['publish-evidence-gated']).toBeUndefined();
+    expect(workflow.jobs['production-large-evidence']).toBeUndefined();
 
     expect(release['runs-on']).toBe('ubuntu-latest');
     expect(release.permissions).toEqual({contents: 'write'});
@@ -185,16 +200,19 @@ describe('platform benchmark workflow', () => {
     expect(releaseCommand).toContain('--json isImmutable');
   });
 
-  it('reports whether retained production-large evidence is blocking the release', () => {
+  it('reports bounded evidence outcome and strictness without coupling it to publication', () => {
     const evidence = load(readFileSync('.github/workflows/production-large-evidence.yml', 'utf8'), {
       schema: JSON_SCHEMA,
     }) as BenchmarkWorkflow;
     const job = evidence.jobs['code-graph-production-large']!;
     const summary = job.steps?.find(step => step.run?.includes('Production-large release evidence'));
 
-    expect(summary?.env).toMatchObject({RELEASE_GATE: '${{ inputs.gate_release }}'});
-    expect(summary?.run).toContain('required before publishing this RC or stable release');
-    expect(summary?.run).toContain('retained and reported without blocking beta publication');
+    expect(summary?.env).toMatchObject({
+      MEASUREMENT_OUTCOME: '${{ steps.capture_production_large.outcome }}',
+      STRICT_EVIDENCE: '${{ inputs.strict }}',
+    });
+    expect(summary?.run).toContain('must complete for this evidence workflow to pass');
+    expect(summary?.run).toContain('bounded observation retained without blocking release publication');
   });
 
   it('runs the large-monorepo heavy-tail regression only by schedule or explicit opt-in', () => {

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1052,10 +1052,11 @@ describe('code graph release evidence', () => {
     }
   });
 
-  it('runs exact-tag production-large evidence once and gates RC/stable publication on it', () => {
+  it('runs bounded exact-tag production-large evidence once without gating publication on it', () => {
     const workflow = load(readFileSync('.github/workflows/benchmarks.yml', 'utf8')) as BenchmarkWorkflow;
     const evidence = load(readFileSync('.github/workflows/production-large-evidence.yml', 'utf8')) as BenchmarkWorkflow;
     const publish = load(readFileSync('.github/workflows/publish.yml', 'utf8')) as BenchmarkWorkflow;
+    const releaseEvidence = load(readFileSync('.github/workflows/release-evidence.yml', 'utf8')) as BenchmarkWorkflow;
     expect(workflow.on.push).toBeUndefined();
 
     const scheduled = workflow.jobs['code-graph-production-large']!;
@@ -1063,19 +1064,20 @@ describe('code graph release evidence', () => {
     expect(scheduled.if).toContain('inputs.include_production_large');
     expect(scheduled.uses).toBe('./.github/workflows/production-large-evidence.yml');
 
-    const releaseGate = publish.jobs['production-large-evidence']!;
-    expect(releaseGate.if).toContain("startsWith(github.ref, 'refs/tags/v4.0.0-beta.')");
-    expect(releaseGate.if).toContain("startsWith(github.ref, 'refs/tags/v4.0.0-rc.')");
-    expect(releaseGate.if).toContain("github.ref == 'refs/tags/v4.0.0'");
+    const releaseGate = releaseEvidence.jobs['production-large-evidence']!;
     expect(releaseGate.needs).toBeUndefined();
     expect(releaseGate.uses).toBe('./.github/workflows/production-large-evidence.yml');
     expect(releaseGate.with).toMatchObject({
-      gate_release: "${{ startsWith(github.ref, 'refs/tags/v4.0.0-rc.') || github.ref == 'refs/tags/v4.0.0' }}",
+      strict: false,
       release_ref: '${{ github.ref }}',
       release_sha: '${{ github.sha }}',
     });
-    expect(publish.jobs['publish-beta']?.if).not.toContain('needs.production-large-evidence');
-    expect(publish.jobs['publish-evidence-gated']?.if).toContain("needs.production-large-evidence.result == 'success'");
+    const publisher = publish.jobs['publish-release']!;
+    expect(publisher.needs).toEqual(['verify', 'linux', 'macos']);
+    expect(publisher.if).not.toContain('needs.production-large-evidence');
+    expect(publish.jobs['publish-beta']).toBeUndefined();
+    expect(publish.jobs['publish-evidence-gated']).toBeUndefined();
+    expect(publish.jobs['production-large-evidence']).toBeUndefined();
 
     const production = evidence.jobs['code-graph-production-large']!;
     const checkout = production.steps?.find(step => step.uses === 'actions/checkout@v7');

--- a/test/unit/publish-workflow.test.ts
+++ b/test/unit/publish-workflow.test.ts
@@ -40,24 +40,30 @@ describe('standalone release workflows', () => {
       expect(workflow).toContain('windows-11-arm');
       expect(workflow.match(/if: \$\{\{ false \}\}/g)).toHaveLength(2);
       expect(workflow).toContain('needs: [verify, linux, macos]');
-      expect(workflow).toContain('needs: [verify, linux, macos, production-large-evidence]');
+      expect(workflow).not.toContain('needs: [verify, linux, macos, production-large-evidence]');
       expect(workflow).not.toContain('needs: [linux, macos, windows-sign]');
       expect(workflow).not.toMatch(/\bnpm(?:\s|$)/);
     }),
   );
 
-  it.effect('blocks Threadnote 4 publication on the exact-tag production-large evidence workflow', () =>
+  it.effect('retains bounded exact-tag production-large evidence without blocking publication', () =>
     Effect.gen(function* () {
       const publish = yield* readProjectFile('.github/workflows/publish.yml');
+      const releaseEvidence = yield* readProjectFile('.github/workflows/release-evidence.yml');
       const benchmarks = yield* readProjectFile('.github/workflows/benchmarks.yml');
       const evidence = yield* readProjectFile('.github/workflows/production-large-evidence.yml');
 
-      expect(publish).toContain('production-large-evidence:');
-      expect(publish).toContain('uses: ./.github/workflows/production-large-evidence.yml');
-      expect(publish).toContain('release_ref: ${{ github.ref }}');
-      expect(publish).toContain('release_sha: ${{ github.sha }}');
-      expect(publish).toContain("needs.production-large-evidence.result == 'success'");
+      expect(publish).not.toContain('production-large-evidence:');
+      expect(publish).not.toContain('needs.production-large-evidence.result');
+      expect(releaseEvidence).toContain('production-large-evidence:');
+      expect(releaseEvidence).toContain('uses: ./.github/workflows/production-large-evidence.yml');
+      expect(releaseEvidence).toContain('release_ref: ${{ github.ref }}');
+      expect(releaseEvidence).toContain('release_sha: ${{ github.sha }}');
+      expect(releaseEvidence).toContain('strict: false');
       expect(evidence).toContain('workflow_call:');
+      expect(evidence).toContain('timeout-minutes: 30');
+      expect(evidence).toContain('timeout-minutes: 20');
+      expect(evidence).toContain('continue-on-error: true');
       expect(evidence).toContain('if-no-files-found: error');
       expect(evidence).toContain('retention-days: 90');
       expect(benchmarks).not.toContain("startsWith(github.ref, 'refs/tags/v4.0.0-");

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -1266,6 +1266,31 @@ describe('Threadnote 4 website content', () => {
     expect(styles).not.toContain('.manager-demo-graph-stage > div:first-child');
   });
 
+  it('contains the landing hero and install command at narrow mobile widths', async () => {
+    const styles = await readFile(join(root, 'website', 'src', 'styles.css'), 'utf8');
+    const tabletStart = styles.indexOf('@media (max-width: 980px)');
+    const mobileStart = styles.indexOf('@media (max-width: 680px)', tabletStart);
+    const tabletStyles = styles.slice(tabletStart, mobileStart);
+    const mobileStyles = styles.slice(mobileStart);
+
+    expect(styles).toMatch(/\.hero__copy\s*{[^}]*min-width: 0;/s);
+    expect(styles).toMatch(/\.hero__visual\s*{[^}]*min-width: 0;/s);
+    expect(tabletStyles).toMatch(/\.hero\s*{[^}]*grid-template-columns: minmax\(0, 1fr\);/s);
+    expect(mobileStyles).toMatch(/\.hero__actions \.button\s*{[^}]*width: 100%;[^}]*min-width: 0;/s);
+    expect(mobileStyles).toMatch(
+      /\.hero__install code\s*{[^}]*width: 100%;[^}]*overflow-wrap: anywhere;[^}]*white-space: normal;/s,
+    );
+  });
+
+  it('reveals the skip link only when it receives keyboard focus', async () => {
+    const styles = await readFile(join(root, 'website', 'src', 'styles.css'), 'utf8');
+
+    expect(styles).toMatch(/\.skip-link\s*{[^}]*opacity: 0;[^}]*pointer-events: none;/s);
+    expect(styles).toMatch(
+      /\.skip-link:focus,\s*\.skip-link:focus-visible\s*{[^}]*opacity: 1;[^}]*pointer-events: auto;[^}]*transform: translateY\(0\);/s,
+    );
+  });
+
   it('collapses the footer before its six links can overflow narrow tablet widths', async () => {
     const styles = await readFile(join(root, 'website', 'src', 'styles.css'), 'utf8');
     const tabletStart = styles.indexOf('@media (max-width: 760px)');

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -144,10 +144,15 @@ p {
   color: var(--ink);
   background: var(--teal);
   border-radius: 6px;
-  transform: translateY(-150%);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(calc(-100% - 24px));
 }
 
-.skip-link:focus {
+.skip-link:focus,
+.skip-link:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
   transform: translateY(0);
 }
 
@@ -436,6 +441,7 @@ p {
 .hero__copy {
   position: relative;
   z-index: 2;
+  min-width: 0;
 }
 
 .hero__version {
@@ -486,12 +492,15 @@ p {
   display: flex;
   align-items: center;
   gap: 14px;
+  min-width: 0;
   margin-top: 24px;
   color: var(--muted);
   font-size: 11px;
 }
 
 .hero__install code {
+  display: block;
+  min-width: 0;
   max-width: 100%;
   overflow-x: auto;
   padding: 7px 9px;
@@ -504,6 +513,7 @@ p {
 
 .hero__visual {
   position: relative;
+  min-width: 0;
   min-height: 570px;
   isolation: isolate;
 }
@@ -4926,7 +4936,7 @@ p {
   }
 
   .hero {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     padding-top: 95px;
   }
 
@@ -5257,7 +5267,8 @@ p {
   }
 
   .hero h1 {
-    font-size: clamp(45px, 14vw, 64px);
+    font-size: clamp(40px, 12.5vw, 56px);
+    line-height: 0.98;
   }
 
   .hero__lede {
@@ -5268,9 +5279,23 @@ p {
     display: grid;
   }
 
+  .hero__actions .button {
+    width: 100%;
+    min-width: 0;
+  }
+
   .hero__install {
     align-items: flex-start;
     flex-direction: column;
+    width: 100%;
+  }
+
+  .hero__install code {
+    width: 100%;
+    line-height: 1.6;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    word-break: break-word;
   }
 
   .hero__visual {


### PR DESCRIPTION
## What changed

- decoupled production-large measurements from release publication while retaining a separate exact-tag evidence workflow
- bounded production-large jobs to 30 minutes, with a 20-minute capture window and retained partial artifacts
- fixed narrow-screen landing-page overflow in the hero, actions, and install command
- kept the accessibility skip link hidden during normal browsing and visible only while keyboard-focused
- added workflow and responsive-layout regression coverage

## Why

The full production-large profile exceeded the requested release window and delayed distribution. Separately, long hero and installer content widened the mobile grid, clipping the landing page, while the skip link could remain visibly overlaid in normal mobile browsing.

## Impact

Releases now publish after verified platform artifacts without waiting for performance evidence. Mobile visitors get a contained landing layout; keyboard users retain an accessible focus-only skip link.

## Validation

- full suite: 182 files, 1,720 tests
- `bun run site:check`
- `bun run site:build`
- `bun run lint`
- `bun run typecheck`
- `bun run prettier:check`
- browser QA at 390 px and 1,440 px with zero horizontal overflow
