### PR TITLE
Fix Manager graph build identity and stale status

### DIFF
--- a/manager/app.css
+++ b/manager/app.css
@@ -967,12 +967,38 @@ dd {
   font-size: 11px;
 }
 
+.graph-build-target {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.graph-build-target > span {
+  max-width: min(920px, 78vw);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .graph-build-card > header span,
 .graph-build-card > footer span,
 .graph-build-card > p {
   color: var(--muted);
   font-size: 10px;
   margin: 0;
+}
+
+.graph-build-phase {
+  color: var(--text) !important;
+  font-weight: 650;
+}
+
+.graph-build-attention {
+  background: rgba(247, 213, 107, 0.08);
+  border: 1px solid rgba(247, 213, 107, 0.28);
+  border-radius: 8px;
+  color: #f7d56b !important;
+  padding: 7px 9px;
 }
 
 .graph-build-meter {

--- a/src/code_graph/build_status.ts
+++ b/src/code_graph/build_status.ts
@@ -94,6 +94,7 @@ export interface CodeGraphBuildStatus {
   readonly identity: {
     readonly checkoutId: string;
     readonly commit: string;
+    readonly displayName?: string;
     readonly repositoryId: string;
     readonly worktreeId: string;
   };
@@ -137,6 +138,10 @@ export interface ObservedCodeGraphBuildStatus extends CodeGraphBuildStatus {
     readonly progressSilent?: boolean;
     readonly role: 'history' | 'owner' | 'waiter';
   };
+  /** Local-only Manager context. Never written into the privacy-safe build status document. */
+  readonly managerContext?: {
+    readonly worktreePath: string;
+  };
   readonly observation: {
     readonly heartbeatAgeMilliseconds: number;
     readonly liveness: CodeGraphBuildLiveness;
@@ -174,6 +179,8 @@ interface ProcessObservation {
 const STATUS_DIRECTORY = 'build-status';
 const STATUS_FILE_BYTES_LIMIT = 64 * 1_024;
 const STATUS_HISTORY_PER_WORKTREE = 8;
+const MANAGER_CONTEXT_FILE_BYTES_LIMIT = 8 * 1_024;
+const MANAGER_CONTEXT_SCHEMA_VERSION = 1 as const;
 const HASH_ID = /^[0-9a-f]{64}$/;
 const BUILD_ID = /^[0-9a-f-]{16,64}$/;
 const COMMIT_ID = /^[0-9a-f]{7,64}$/;
@@ -213,6 +220,7 @@ export const makeCodeGraphBuildReporter = Effect.fn('codeGraph.buildStatus.makeR
       identity: {
         checkoutId: identity.checkoutId,
         commit: identity.headCommit.slice(0, 12),
+        displayName: boundedText(identity.displayName, 256),
         repositoryId: identity.repositoryId,
         worktreeId: identity.worktreeId,
       },
@@ -264,6 +272,7 @@ export const makeCodeGraphBuildReporter = Effect.fn('codeGraph.buildStatus.makeR
       .pipe(Effect.catch(() => Effect.void));
 
   yield* persist(current => current, true);
+  yield* writeCodeGraphManagerContext(fs, path, file, buildId, identity.repoRoot).pipe(Effect.catch(() => Effect.void));
 
   const complete = (snapshot: CodeGraphSnapshot, reusedFiles: number, skippedFiles: number) =>
     persist((current, now) => {
@@ -306,7 +315,10 @@ export const makeCodeGraphBuildReporter = Effect.fn('codeGraph.buildStatus.makeR
           },
         },
       };
-    }, true).pipe(Effect.andThen(pruneCodeGraphBuildHistory(fs, path, layout, identity.worktreeId, buildId)));
+    }, true).pipe(
+      Effect.ensuring(removeCodeGraphManagerContext(fs, path, file, buildId)),
+      Effect.andThen(pruneCodeGraphBuildHistory(fs, path, layout, identity.worktreeId, buildId)),
+    );
 
   return {
     complete: summary => complete(summary.snapshot, summary.reusedFiles, summary.skippedFiles),
@@ -338,7 +350,10 @@ export const makeCodeGraphBuildReporter = Effect.fn('codeGraph.buildStatus.makeR
             },
           },
         };
-      }, true).pipe(Effect.andThen(pruneCodeGraphBuildHistory(fs, path, layout, identity.worktreeId, buildId))),
+      }, true).pipe(
+        Effect.ensuring(removeCodeGraphManagerContext(fs, path, file, buildId)),
+        Effect.andThen(pruneCodeGraphBuildHistory(fs, path, layout, identity.worktreeId, buildId)),
+      ),
     heartbeat: Effect.gen(function* () {
       while (true) {
         yield* Effect.sleep(CODE_GRAPH_BUILD_HEARTBEAT_INTERVAL_MILLISECONDS);
@@ -406,6 +421,7 @@ export const readAllCodeGraphBuildStatuses = Effect.fn('codeGraph.buildStatus.re
     checkoutId =>
       readBuildStatusesBelow(fs, path, path.join(root, checkoutId, STATUS_DIRECTORY)).pipe(
         Effect.flatMap(statuses => annotateBuildCoordinationByWorktree(fs, path, threadnoteHome, checkoutId, statuses)),
+        Effect.flatMap(statuses => attachCodeGraphManagerContexts(fs, path, root, checkoutId, statuses)),
       ),
     {concurrency: 8},
   );
@@ -680,6 +696,92 @@ function writeCodeGraphBuildStatus(
   });
 }
 
+function codeGraphManagerContextPath(path: Path.Path, statusFile: string, buildId: string): string {
+  return path.join(path.dirname(statusFile), `${buildId}.manager-context`);
+}
+
+function writeCodeGraphManagerContext(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  statusFile: string,
+  buildId: string,
+  worktreePath: string,
+) {
+  return Effect.gen(function* () {
+    if (!isText(worktreePath, 4_096)) return;
+    const file = codeGraphManagerContextPath(path, statusFile, buildId);
+    if ((yield* fs.readLink(file).pipe(Effect.option))._tag === 'Some') return;
+    const temporary = path.join(path.dirname(file), `.${buildId}.manager-context.tmp`);
+    const content = `${JSON.stringify({buildId, schemaVersion: MANAGER_CONTEXT_SCHEMA_VERSION, worktreePath})}\n`;
+    if (new TextEncoder().encode(content).byteLength > MANAGER_CONTEXT_FILE_BYTES_LIMIT) return;
+    yield* fs.writeFileString(temporary, content, {flag: 'wx', mode: 0o600});
+    yield* fs
+      .rename(temporary, file)
+      .pipe(Effect.onError(() => fs.remove(temporary, {force: true}).pipe(Effect.catch(() => Effect.void))));
+  });
+}
+
+function removeCodeGraphManagerContext(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  statusFile: string,
+  buildId: string,
+) {
+  return fs
+    .remove(codeGraphManagerContextPath(path, statusFile, buildId), {force: true})
+    .pipe(Effect.catch(() => Effect.void));
+}
+
+function attachCodeGraphManagerContexts(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  repositoriesRoot: string,
+  checkoutId: string,
+  statuses: readonly ObservedCodeGraphBuildStatus[],
+) {
+  return Effect.forEach(
+    statuses,
+    status => {
+      const statusFile = path.join(
+        repositoriesRoot,
+        checkoutId,
+        STATUS_DIRECTORY,
+        status.identity.worktreeId,
+        `${status.buildId}.json`,
+      );
+      const contextFile = codeGraphManagerContextPath(path, statusFile, status.buildId);
+      if (status.state === 'completed' || status.state === 'failed' || status.observation.liveness === 'abandoned') {
+        return fs.remove(contextFile, {force: true}).pipe(
+          Effect.catch(() => Effect.void),
+          Effect.as(status),
+        );
+      }
+      return readCodeGraphManagerContext(fs, contextFile, status.buildId).pipe(
+        Effect.map(context => (context ? {...status, managerContext: context} : status)),
+      );
+    },
+    {concurrency: 8},
+  );
+}
+
+function readCodeGraphManagerContext(fs: FileSystem.FileSystem, file: string, buildId: string) {
+  return Effect.gen(function* () {
+    if ((yield* fs.readLink(file).pipe(Effect.option))._tag === 'Some') return undefined;
+    const info = yield* fs.stat(file);
+    if (info.type !== 'File' || Number(info.size) > MANAGER_CONTEXT_FILE_BYTES_LIMIT) return undefined;
+    const value: unknown = JSON.parse(yield* fs.readFileString(file));
+    if (
+      !isRecord(value) ||
+      value.schemaVersion !== MANAGER_CONTEXT_SCHEMA_VERSION ||
+      value.buildId !== buildId ||
+      !isText(value.worktreePath, 4_096)
+    ) {
+      return undefined;
+    }
+    return {worktreePath: value.worktreePath};
+  }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+}
+
 function ensurePrivateRegularDirectory(fs: FileSystem.FileSystem, path: Path.Path, directory: string) {
   return Effect.gen(function* () {
     const parent = path.dirname(directory);
@@ -796,6 +898,8 @@ export function parseCodeGraphBuildStatus(value: unknown): CodeGraphBuildStatus 
   if (value.request !== undefined && !request) return undefined;
   const resolution = parseResolution(value.resolution);
   if (value.resolution !== undefined && !resolution) return undefined;
+  const displayName = value.identity.displayName;
+  if (displayName !== undefined && !isText(displayName, 256)) return undefined;
   return {
     ...(activation ? {activation} : {}),
     ...(activity ? {activity} : {}),
@@ -806,6 +910,7 @@ export function parseCodeGraphBuildStatus(value: unknown): CodeGraphBuildStatus 
     identity: {
       checkoutId: value.identity.checkoutId,
       commit: value.identity.commit,
+      ...(displayName ? {displayName} : {}),
       repositoryId: value.identity.repositoryId,
       worktreeId: value.identity.worktreeId,
     },
@@ -1413,7 +1518,9 @@ function pruneCodeGraphBuildHistory(
     const directory = path.dirname(codeGraphBuildStatusPath(path, layout, worktreeId, currentBuildId));
     if (!(yield* regularDirectory(fs, directory))) return;
     const candidates = yield* Effect.forEach(
-      (yield* fs.readDirectory(directory)).filter(name => name.endsWith('.json')),
+      (yield* fs.readDirectory(directory)).filter(
+        name => name.endsWith('.json') && BUILD_ID.test(name.slice(0, -'.json'.length)),
+      ),
       name =>
         Effect.gen(function* () {
           const file = path.join(directory, name);
@@ -1426,10 +1533,17 @@ function pruneCodeGraphBuildHistory(
       .flatMap(candidate => (candidate._tag === 'Some' ? [candidate.value] : []))
       .sort((left, right) => right.modifiedAt - left.modifiedAt)
       .slice(STATUS_HISTORY_PER_WORKTREE);
-    yield* Effect.forEach(removable, candidate => fs.remove(candidate.file, {force: true}), {
-      concurrency: 1,
-      discard: true,
-    });
+    yield* Effect.forEach(
+      removable,
+      candidate => {
+        const buildId = path.basename(candidate.file).slice(0, -'.json'.length);
+        return Effect.all(
+          [fs.remove(candidate.file, {force: true}), removeCodeGraphManagerContext(fs, path, candidate.file, buildId)],
+          {concurrency: 2, discard: true},
+        );
+      },
+      {concurrency: 1, discard: true},
+    );
   }).pipe(Effect.catch(() => Effect.void));
 }
 

--- a/src/manager_graph.tsx
+++ b/src/manager_graph.tsx
@@ -151,8 +151,12 @@ export interface GraphBuildStatus {
   readonly identity: {
     readonly checkoutId: string;
     readonly commit: string;
+    readonly displayName?: string;
     readonly repositoryId: string;
     readonly worktreeId: string;
+  };
+  readonly managerContext?: {
+    readonly worktreePath: string;
   };
   readonly observation: {
     readonly heartbeatAgeMilliseconds: number;
@@ -297,8 +301,51 @@ interface GraphMaterializationStorage {
   readonly temporaryDatabaseHighWaterBytes: number;
 }
 
+export function graphBuildIsActive(build: GraphBuildStatus): boolean {
+  return (
+    (build.state === 'queued' || build.state === 'running') &&
+    build.observation.liveness === 'active' &&
+    build.coordination?.role !== 'history'
+  );
+}
+
+export function graphBuildShouldDisplay(build: GraphBuildStatus): boolean {
+  return build.state === 'failed' || graphBuildIsActive(build);
+}
+
+export interface GraphBuildTarget {
+  readonly repositoryLabel: string;
+  readonly worktreeLabel: string;
+}
+
+export function graphBuildTarget(
+  build: GraphBuildStatus,
+  repositories: readonly GraphRepositoryGroup[],
+): GraphBuildTarget {
+  const repository = repositories.find(candidate => candidate.repositoryId === build.identity.repositoryId);
+  const view = repository?.views.find(
+    candidate =>
+      candidate.checkoutId === build.identity.checkoutId && candidate.worktreeId === build.identity.worktreeId,
+  );
+  const fallbackName = build.identity.displayName?.trim();
+  const repositoryLabel = repository
+    ? graphRepositoryOptionLabel(repository, repositories)
+    : fallbackName
+      ? `${fallbackName} · repository ${shortGraphIdentity(build.identity.repositoryId)}`
+      : `Repository ${shortGraphIdentity(build.identity.repositoryId)}`;
+  return {
+    repositoryLabel,
+    worktreeLabel:
+      build.managerContext?.worktreePath ??
+      view?.label ??
+      `Checkout ${shortGraphIdentity(build.identity.checkoutId)} · worktree ${shortGraphIdentity(
+        build.identity.worktreeId,
+      )}`,
+  };
+}
+
 export function graphStatusPollDelay(builds: readonly GraphBuildStatus[]): number {
-  return builds.some(build => build.state === 'queued' || build.state === 'running') ? 1_000 : 15_000;
+  return builds.some(graphBuildIsActive) ? 1_000 : 15_000;
 }
 
 export function graphCompletedBuildResultIdentity(build: GraphBuildStatus): string | undefined {
@@ -365,6 +412,10 @@ export function graphRepositoryOptionLabel(
     candidate => candidate.id !== repository.id && candidate.displayName === repository.displayName,
   );
   return collides ? `${repository.displayName} · ${repository.id.slice(0, 8)}` : repository.displayName;
+}
+
+function shortGraphIdentity(value: string): string {
+  return value.slice(-8) || 'unknown';
 }
 
 export function mergeGraphRepositoryGroups(
@@ -1171,9 +1222,7 @@ export function GraphWorkspace(props: {
     () => [...new Set(graph?.edges.map(edge => edge.relation) ?? [])].sort(compareCodeUnits),
     [graph],
   );
-  const activeBuilds = (props.catalog?.builds ?? []).filter(
-    build => build.state === 'queued' || build.state === 'running' || build.state === 'failed',
-  );
+  const activeBuilds = (props.catalog?.builds ?? []).filter(graphBuildShouldDisplay);
   const selectedRepositoryIsIndexing = activeBuilds.some(
     build =>
       repository !== undefined &&
@@ -1646,6 +1695,7 @@ export function GraphWorkspace(props: {
               <GraphBuildProgress
                 build={build}
                 key={`${build.identity.checkoutId}:${build.identity.worktreeId}:${build.buildId}`}
+                repositories={repositories}
                 waiterCount={graphWaiterCountForBuild(build, props.catalog?.waiters ?? [])}
               />
             ))}
@@ -3004,6 +3054,7 @@ function NodeInspector(props: {
 
 function GraphBuildProgress(props: {
   readonly build: GraphBuildStatus;
+  readonly repositories: readonly GraphRepositoryGroup[];
   readonly waiterCount: number;
 }): React.ReactElement {
   const {build} = props;
@@ -3015,17 +3066,29 @@ function GraphBuildProgress(props: {
       : undefined;
   const elapsed = Math.max(0, Date.now() - Date.parse(build.timestamps.startedAt));
   const lastProgress = Math.max(0, Date.now() - Date.parse(build.timestamps.lastProgressAt));
-  const progressSilent = build.coordination?.progressSilent === true || lastProgress > 15_000;
-  const eta = lastProgress <= 15_000 ? build.eta : undefined;
-  const role = build.coordination?.role === 'owner' ? 'Builder' : build.state === 'queued' ? 'Queued' : 'Build';
+  const progressSilent = build.coordination?.progressSilent === true;
+  const eta = progressSilent ? undefined : build.eta;
+  const target = graphBuildTarget(build, props.repositories);
+  const statusLabel =
+    build.state === 'failed'
+      ? 'Indexing failed'
+      : build.state === 'queued'
+        ? 'Waiting to index'
+        : progressSilent
+          ? 'Indexing status is stale'
+          : 'Indexing';
   return (
     <article className={`graph-build-card is-${build.state} is-${build.observation.liveness}`}>
       <header>
-        <strong>
-          {role} · {build.phase}/{build.subphase ?? 'working'}
-        </strong>
-        <span>{formatBuildDuration(elapsed)} elapsed</span>
+        <div className="graph-build-target">
+          <strong>{target.repositoryLabel}</strong>
+          <span title={target.worktreeLabel}>{target.worktreeLabel}</span>
+        </div>
+        <span>Elapsed {formatBuildDuration(elapsed)}</span>
       </header>
+      <p className="graph-build-phase">
+        {statusLabel} · {build.phase}/{build.subphase ?? 'working'} · commit {build.identity.commit}
+      </p>
       {percentage === undefined ? null : (
         <div className="graph-build-meter" aria-label={`${Math.round(percentage)}% complete`}>
           <i style={{width: `${percentage}%`}} />
@@ -3039,15 +3102,19 @@ function GraphBuildProgress(props: {
           : completed === undefined || total === undefined
             ? 'Preparing phase counters'
             : `${completed.toLocaleString()} / ${total.toLocaleString()} ${build.counters.unit ?? 'items'}`}
-        {' · '}last progress {formatBuildDuration(lastProgress)} ago
-        {progressSilent && build.coordination?.role === 'owner'
-          ? ' · progress is silent; lock owner is still alive'
-          : ''}
+        {' · '}last progress change {formatBuildDuration(lastProgress)} ago
       </p>
+      {progressSilent ? (
+        <p className="graph-build-attention">
+          No progress update for {formatBuildDuration(lastProgress)}. Process {build.owner.processId} still owns the
+          build lock, but Manager cannot determine whether its current operation is advancing.
+        </p>
+      ) : null}
       {build.activity ? (
         <p>
-          Current: {build.activity.stage} {build.activity.language} · {formatGraphBytes(build.activity.bytes)} · batch{' '}
-          {build.activity.batchCompleted.toLocaleString()}/{build.activity.batchTotal.toLocaleString()}
+          Current reported step: {build.activity.stage} {build.activity.language} ·{' '}
+          {formatGraphBytes(build.activity.bytes)} · batch {build.activity.batchCompleted.toLocaleString()}/
+          {build.activity.batchTotal.toLocaleString()}
           {build.activity.parseMilliseconds === undefined
             ? ''
             : ` · parse ${formatGraphMilliseconds(build.activity.parseMilliseconds)}`}
@@ -3059,7 +3126,7 @@ function GraphBuildProgress(props: {
       ) : null}
       {build.materialization?.activity ? (
         <p>
-          Current: {graphMaterializationStageLabel(build.materialization.activity.stage)} · batch{' '}
+          Current reported step: {graphMaterializationStageLabel(build.materialization.activity.stage)} · batch{' '}
           {graphActiveBatchNumber(
             build.materialization.activity.batchCompleted,
             build.materialization.activity.batchTotal,
@@ -3073,7 +3140,7 @@ function GraphBuildProgress(props: {
             ? ''
             : ` · ${formatGraphBytes(build.materialization.activity.factsBytes)} final facts`}
           {graphMaterializationRows(build.materialization.activity.rows)}
-          {' · '}active{' '}
+          {' · '}this step{' '}
           {formatBuildDuration(Math.max(0, Date.now() - Date.parse(build.materialization.activity.startedAt)))}
           {build.materialization.activity.transactionMilliseconds === undefined
             ? ''
@@ -3082,7 +3149,7 @@ function GraphBuildProgress(props: {
       ) : null}
       {build.activation?.activity ? (
         <p>
-          Current: activating · {build.activation.activity.stage.replaceAll('-', ' ')} ·{' '}
+          Current reported step: activating · {build.activation.activity.stage.replaceAll('-', ' ')} ·{' '}
           {build.activation.activity.state}
           {build.activation.activity.rows === undefined
             ? ''
@@ -3209,14 +3276,13 @@ function GraphBuildProgress(props: {
         </p>
       ) : null}
       <footer>
-        <span>PID {build.owner.processId}</span>
+        <span>Process {build.owner.processId}</span>
         {eta && eta.confidence !== 'low' ? (
           <span>
-            Phase ETA {formatBuildDuration(eta.remainingMilliseconds)} · {eta.confidence}
+            Estimated time remaining in this phase: {formatBuildDuration(eta.remainingMilliseconds)} · {eta.confidence}{' '}
+            confidence
             {eta.basis ? ` · ${graphEtaBasisLabel(eta.basis)}` : ''}
           </span>
-        ) : build.eta ? (
-          <span>{progressSilent ? 'Phase ETA paused while progress is silent' : 'Phase ETA stabilizing'}</span>
         ) : null}
         {props.waiterCount > 0 ? <span>{props.waiterCount} waiting process(es)</span> : null}
         {build.error ? <span className="graph-build-error">{build.error.summary}</span> : null}

--- a/src/manager_ui.tsx
+++ b/src/manager_ui.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
   GraphWorkspace,
+  graphBuildIsActive,
   graphCompletedBuildResultIdentity,
   graphStatusPollDelay,
   graphStatusRequiresCatalogRefresh,
@@ -229,7 +230,7 @@ function App(): React.ReactElement {
       try {
         const status = await api<Pick<GraphCatalog, 'builds' | 'waiterCount' | 'waiters'>>('/api/graphs/status');
         if (cancelled) return;
-        const active = status.builds.some(build => build.state === 'queued' || build.state === 'running');
+        const active = status.builds.some(graphBuildIsActive);
         const refreshCatalog =
           (observedActiveBuild && !active) ||
           graphStatusRequiresCatalogRefresh(graphCatalogRef.current, status.builds, acknowledgedCompletedResults);

--- a/test/unit/code-graph.build-status.property.test.ts
+++ b/test/unit/code-graph.build-status.property.test.ts
@@ -81,6 +81,15 @@ describe('code graph build-status properties', () => {
     {fastCheck: {numRuns: 250}},
   );
 
+  it('round-trips a bounded repository display name without accepting local-path control characters', () => {
+    const status = buildStatus('running', true);
+    const named = {...status, identity: {...status.identity, displayName: 'example/repository'}};
+    expect(parseCodeGraphBuildStatus(named)?.identity.displayName).toBe('example/repository');
+    expect(
+      parseCodeGraphBuildStatus({...named, identity: {...named.identity, displayName: 'example\nrepository'}}),
+    ).toBeUndefined();
+  });
+
   it.prop(
     'never throws while validating arbitrary JSON values and only returns bounded schema-v1 records',
     {value: FC.jsonValue()},

--- a/test/unit/code-graph.build-status.test.ts
+++ b/test/unit/code-graph.build-status.test.ts
@@ -4,9 +4,11 @@ import {afterEach, describe, expect, it} from 'vitest';
 import {
   CODE_GRAPH_BUILD_PROGRESS_WRITE_INTERVAL_MILLISECONDS,
   CODE_GRAPH_BUILD_STALE_AFTER_MILLISECONDS,
+  type CodeGraphBuildStatus,
   calibratedCodeGraphEtaConfidence,
   makeCodeGraphBuildReporter,
   observeCodeGraphBuildStatus,
+  readAllCodeGraphBuildStatuses,
   readCodeGraphBuildStatuses,
   selectCodeGraphBuildStatuses,
 } from '../../src/code_graph/build_status.js';
@@ -93,7 +95,7 @@ describe('code graph cross-process build status', () => {
   it('keeps active owner and queued observer jobs separate and atomically readable', async () => {
     const home = await mkdtemp('threadnote-graph-build-status-');
     homes.push(home);
-    const statuses = await runEffect(
+    const result = await runEffect(
       Effect.gen(function* () {
         const path = yield* Path.Path;
         const identity = fixtureIdentity(home);
@@ -102,9 +104,13 @@ describe('code graph cross-process build status', () => {
         yield* owner.progress({completed: 8, phase: 'materializing', reused: 5, total: 20, unit: 'files'});
         const observer = yield* makeCodeGraphBuildReporter(identity, layout);
         yield* observer.progress({phase: 'waiting', reason: 'database-writer'});
-        return yield* readCodeGraphBuildStatuses(layout);
+        return {
+          global: yield* readAllCodeGraphBuildStatuses(home),
+          scoped: yield* readCodeGraphBuildStatuses(layout),
+        };
       }),
     );
+    const statuses = result.scoped;
 
     expect(statuses).toHaveLength(2);
     expect(new Set(statuses.map(status => status.buildId)).size).toBe(2);
@@ -118,6 +124,41 @@ describe('code graph cross-process build status', () => {
       unit: 'files',
     });
     expect(JSON.stringify(statuses)).not.toContain(home);
+    expect(result.global).toHaveLength(2);
+    expect(result.global.every(status => status.managerContext?.worktreePath === `${home}/repository`)).toBe(true);
+  });
+
+  it('removes transient Manager path context after its build owner exits', async () => {
+    const home = await mkdtemp('threadnote-graph-build-abandoned-context-');
+    homes.push(home);
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const identity = fixtureIdentity(home);
+        const layout = codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId);
+        const reporter = yield* makeCodeGraphBuildReporter(identity, layout);
+        yield* reporter.progress({completed: 8, phase: 'materializing', reused: 5, total: 20, unit: 'files'});
+        const directory = path.join(layout.repositoryRoot, 'build-status', identity.worktreeId);
+        const statusFile = (yield* fs.readDirectory(directory)).find(name => name.endsWith('.json'))!;
+        const statusPath = path.join(directory, statusFile);
+        const status = JSON.parse(yield* fs.readFileString(statusPath)) as CodeGraphBuildStatus;
+        yield* fs.writeFileString(
+          statusPath,
+          `${JSON.stringify({...status, owner: {...status.owner, processId: 2_147_483_647}})}\n`,
+        );
+        const before = yield* fs.readDirectory(directory);
+        const statuses = yield* readAllCodeGraphBuildStatuses(home);
+        const after = yield* fs.readDirectory(directory);
+        return {after, before, statuses};
+      }),
+    );
+
+    expect(result.before.some(name => name.endsWith('.manager-context'))).toBe(true);
+    expect(result.statuses).toHaveLength(1);
+    expect(result.statuses[0]?.observation).toMatchObject({liveness: 'abandoned', reason: 'owner-exited'});
+    expect(result.statuses[0]?.managerContext).toBeUndefined();
+    expect(result.after.some(name => name.endsWith('.manager-context'))).toBe(false);
   });
 
   it('persists privacy-safe superseded-snapshot reclamation progress', async () => {
@@ -649,7 +690,8 @@ describe('code graph cross-process build status', () => {
         const reporter = yield* makeCodeGraphBuildReporter(identity, layout);
         yield* reporter.progress({completed: 1, phase: 'materializing', reused: 0, total: 10, unit: 'files'});
         const directory = path.join(layout.repositoryRoot, 'build-status', identity.worktreeId);
-        const statusPath = path.join(directory, (yield* fs.readDirectory(directory))[0]!);
+        const statusFile = (yield* fs.readDirectory(directory)).find(name => name.endsWith('.json'))!;
+        const statusPath = path.join(directory, statusFile);
         const status = JSON.parse(yield* fs.readFileString(statusPath)) as {
           timestamps: Record<string, string>;
         };

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -7,6 +7,9 @@ import {
   graphAnalysisRequestIsCurrent,
   graphAnalysisCoverageLabel,
   graphAnalysisTopologyAvailable,
+  graphBuildIsActive,
+  graphBuildShouldDisplay,
+  graphBuildTarget,
   graphCatalogSearchOptions,
   graphCatalogPageOffsets,
   graphCatalogContinuationHasMore,
@@ -57,6 +60,35 @@ describe('manager graph focus', () => {
     ).not.toThrow();
   });
 
+  it('renders stale live owners with concrete repository, path, and status facts', () => {
+    const neverResolves = () => new Promise<never>(() => undefined);
+    const repository = {...repositoryGroup('repository', ['view-a'], 'view-a'), displayName: 'example/repository'};
+    const build = {
+      ...graphBuildStatus('running'),
+      coordination: {lockVerified: true, progressSilent: true, role: 'owner' as const},
+      managerContext: {worktreePath: '/tmp/jobs/repository-task-17'},
+    };
+    const markup = renderToStaticMarkup(
+      createElement(GraphWorkspace, {
+        catalog: {builds: [build], diagnostics: [], repositories: [repository], waiterCount: 0, waiters: []},
+        loadAnalysis: neverResolves,
+        loadCatalogPage: neverResolves,
+        loadGraph: neverResolves,
+        loadNodeDetail: neverResolves,
+        loadQuery: neverResolves,
+        loadViewsPage: neverResolves,
+        onRefresh: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('example/repository');
+    expect(markup).toContain('/tmp/jobs/repository-task-17');
+    expect(markup).toContain('Indexing status is stale');
+    expect(markup).toContain('Manager cannot determine whether its current operation is advancing.');
+    expect(markup).not.toContain('Phase ETA paused');
+    expect(markup).not.toContain('progress is silent');
+  });
+
   it('uses catalog fallbacks before either a view or continuation exists', () => {
     expect(graphCatalogContinuationHasMore(undefined, undefined, 'projectHasMore', false)).toBe(false);
     expect(graphCatalogContinuationHasMore(undefined, undefined, 'workspaceHasMore', true)).toBe(true);
@@ -83,6 +115,19 @@ describe('manager graph focus', () => {
     expect(graphStatusPollDelay([graphBuildStatus('running')])).toBe(1_000);
     expect(graphStatusPollDelay([graphBuildStatus('queued')])).toBe(1_000);
     expect(graphStatusPollDelay([graphBuildStatus('completed')])).toBe(15_000);
+    const abandoned = {
+      ...graphBuildStatus('running'),
+      observation: {heartbeatAgeMilliseconds: 60_000, liveness: 'abandoned' as const},
+    };
+    expect(graphBuildIsActive(abandoned)).toBe(false);
+    expect(graphBuildShouldDisplay(abandoned)).toBe(false);
+    expect(graphStatusPollDelay([abandoned])).toBe(15_000);
+    const staleOwner = {
+      ...graphBuildStatus('running'),
+      coordination: {lockVerified: true, progressSilent: true, role: 'owner' as const},
+    };
+    expect(graphBuildIsActive(staleOwner)).toBe(true);
+    expect(graphBuildShouldDisplay(staleOwner)).toBe(true);
   });
 
   it('refreshes a terminal snapshot missing from the catalog and scopes waiters to their build', () => {
@@ -181,6 +226,36 @@ describe('manager graph focus', () => {
     const second = {...repositoryGroup('22222222-logical', ['view-b'], 'view-b'), displayName: 'mobile-native'};
     expect(graphRepositoryOptionLabel(first, [first, second])).toBe('mobile-native · 11111111');
     expect(graphRepositoryOptionLabel(second, [first, second])).toBe('mobile-native · 22222222');
+  });
+
+  it('labels build banners with their global repository and live worktree path', () => {
+    const repository = repositoryGroup('repo-a', ['view-a'], 'view-a');
+    const build = {
+      ...graphBuildStatus('running'),
+      identity: {
+        ...graphBuildStatus('running').identity,
+        checkoutId: 'view-a',
+        displayName: 'example/repo-a',
+        repositoryId: 'repo-a',
+        worktreeId: 'view-a',
+      },
+      managerContext: {worktreePath: '/tmp/jobs/repo-a-task-17'},
+    };
+    expect(graphBuildTarget(build, [repository])).toEqual({
+      repositoryLabel: 'repo-a',
+      worktreeLabel: '/tmp/jobs/repo-a-task-17',
+    });
+    expect(graphBuildTarget({...build, managerContext: undefined}, [repository])).toEqual({
+      repositoryLabel: 'repo-a',
+      worktreeLabel: 'view-a',
+    });
+    const {managerContext: _managerContext, ...buildWithoutContext} = build;
+    expect(
+      graphBuildTarget({...buildWithoutContext, identity: {...build.identity, repositoryId: 'missing'}}, []),
+    ).toEqual({
+      repositoryLabel: 'example/repo-a · repository missing',
+      worktreeLabel: 'Checkout view-a · worktree view-a',
+    });
   });
 
   it('rejects an analysis response after its repository, snapshot, or request generation changes', () => {


### PR DESCRIPTION
## Summary

- Label every live graph-build banner with its repository and exact originating worktree path, independent of the directory where Manager was launched.
- Distinguish lock-verified progress silence from an exited build owner. Abandoned records no longer render as active or force one-second polling.
- Replace ambiguous ETA copy with concrete state, phase, commit, elapsed time, last progress change, and an explicit statement of what Manager can and cannot verify.
- Keep absolute paths in a private, bounded, transient Manager-only sidecar. Remove it on completion, failure, or abandoned-owner observation so volatile worktrees do not leave path metadata behind; repository-scoped CLI and MCP status stays path-free.

## Root cause

Manager selected persisted queued or running state without considering observed process liveness. A build whose owner had exited could therefore remain visible indefinitely, and the privacy-safe status document did not contain enough local identity for the global Manager to say which repository or worktree originated it.

## Validation

- bun run lint
- bun run prettier:check
- bun run typecheck
- bun run test — 184 files, 1,739 tests
- Focused graph-status and Manager suite — 52 tests
- bun run build
- bun run check:self-contained
- Built executable version check
- Self-contained smoke with Node and Bun absent from PATH
- Live Manager preview during a real full graph index: 560 files, 29,897 symbols, 87,865 relationships; repository and worktree path rendering confirmed