### PR TITLE
Improve worktree graph readiness and prepare 4.0.1

### DIFF
--- a/.github/release-notes/v4.0.1.md
+++ b/.github/release-notes/v4.0.1.md
@@ -1,0 +1,23 @@
+## What's new
+
+Threadnote 4.0.1 makes newly created and freshly updated worktrees useful much sooner by reusing graph work that has
+already been completed elsewhere in the same checkout.
+
+- **Query sooner.** Agents can use a consistent ready lexical graph while optional vector enrichment and whole-graph
+  analysis finish in the background.
+- **Reuse graph-equivalent commits.** Commits that do not change eligible graph content now activate an existing clean
+  graph immediately instead of rebuilding it under a new commit identity.
+- **Incremental clean worktrees.** Threadnote reuses a compatible full anchor and materializes committed additions,
+  modifications, renames, and deletions as a bounded one-level delta. Changes that affect cross-file resolution use a
+  conservative full resolution closure, with an automatic full-build fallback when compatibility cannot be proven.
+- **Handle immediate edits.** A worktree that becomes dirty during setup can build its effective graph directly from a
+  prior clean anchor without first waiting for an intermediate graph of the untouched commit.
+- **Warm likely targets.** Recently active checkouts prewarm a small bounded set of local main or upstream refs, and
+  materialized file shards are reused when their complete derivation context matches.
+
+Check graph freshness or query the current worktree directly:
+
+```bash
+threadnote graph status --cwd /path/to/worktree
+threadnote graph query --cwd /path/to/worktree --query YourSymbol
+```

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -3,9 +3,7 @@ name: Retain bounded production-large release evidence
 on:
   push:
     tags:
-      - 'v4.0.0-beta.*'
-      - 'v4.0.0-rc.*'
-      - 'v4.0.0'
+      - 'v4.*'
 
 permissions:
   contents: read

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -58,14 +58,13 @@ checksums but are not OS code-signed.
    dispatch a duplicate production-large run for the same tag.
 4. Confirm immutable releases are enabled and the Apple signing secrets below are configured.
 5. Create and push the version tag matching both `package.json` and the release-notes filename, for example
-   `v4.0.0-beta.9`.
+   `v4.0.1`.
 6. Wait for `Publish standalone release`. Do not create a GitHub Release manually. Every channel publishes after all
    four enabled archives are verified while its bounded production-large observation continues independently.
 
-Every `v4.0.0-beta.*`, `v4.0.0-rc.*`, and final `v4.0.0` tag starts a separate production-large evidence workflow on
-`ubuntu-24.04`; the publishing workflow never waits for it and its conclusion reports distribution status only. The
-evidence job has a hard 30-minute ceiling: its measured phase gets 20 minutes, leaving bounded time to upload the
-latest privacy-safe checkpoint and summary. Incomplete release observations are reported but never delay publication;
+Every Threadnote 4 version tag starts a separate production-large evidence workflow on `ubuntu-24.04`; publication
+never waits for it. The evidence job has a hard 30-minute ceiling: its measured phase gets 20 minutes, leaving bounded
+time to upload the latest privacy-safe checkpoint and summary. Incomplete release observations are reported but never delay publication;
 scheduled or explicitly requested strict runs still fail when the profile does not complete inside the same bound.
 Aggregate phase/materialization evidence, failure checkpoints, exact source commit, and upload digest are retained for
 90 days. Treat a successful result as `n=1` same-runner evidence, not as a portable p95. The heavy-tail job remains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/code_graph/analysis.ts
+++ b/src/code_graph/analysis.ts
@@ -505,6 +505,9 @@ export const analyzeCodeGraphWithLease = Effect.fn('codeGraph.analyzeWithSnapsho
     Math.max(2 * 60_000, budget.maxDurationMilliseconds + SNAPSHOT_LEASE_BUFFER_MILLISECONDS),
   );
   const lease = yield* store.acquireSnapshotLease(options.databasePath, options.snapshot.id, leaseDuration);
+  if (typeof store.ensureAnalysisSummary === 'function') {
+    yield* store.ensureAnalysisSummary(options.databasePath, options.snapshot.id).pipe(Effect.catch(() => Effect.void));
+  }
   return yield* store
     .withSession(options.databasePath, analyzeCodeGraph(store, options), {readOnly: true})
     .pipe(

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -34,6 +34,7 @@ import {
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   CodeGraphStore,
   type CodeGraphRetiredSnapshotCleanupProgress,
+  type CodeGraphReusableCleanBase,
   type CodeGraphReusableReexport,
   type CodeGraphReusableReexportSeed,
   type CodeGraphStagingProgress,
@@ -107,6 +108,8 @@ type IncrementalOverlayAssessment =
       readonly facts: readonly CodeGraphFileFacts[];
       readonly files: readonly CodeGraphInventoryFile[];
       readonly mode: 'eligible';
+      readonly deletedPaths?: readonly string[];
+      readonly resolutionClosure?: 'changed' | 'full';
       readonly reuse: 'persisted-base' | 'staged-base';
     }
   | {
@@ -120,6 +123,8 @@ type IncrementalOverlayPreassessment =
       readonly facts: readonly CodeGraphFileFacts[];
       readonly files: readonly CodeGraphInventoryFile[];
       readonly mode: 'compatible';
+      readonly deletedPaths?: readonly string[];
+      readonly resolutionClosure?: 'changed' | 'full';
     }
   | {
       readonly mode: 'fallback';
@@ -246,17 +251,9 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                             retiredSnapshotCleanupReporter(options.onProgress),
                             activeWorktreeIds,
                           );
-                          const analysisSummaryBackfilled = yield* prepareReadyAnalysisSummary({
-                            databasePath: layout.databasePath,
-                            onProgress: options.onProgress,
-                            snapshotId: completedByOwner.id,
-                            store,
-                          });
                           yield* store.promote(layout.databasePath, identity, completedByOwner.id, activeWorktreeIds);
                           return yield* reuseReadySnapshot({
                             activeWorktreeIds,
-                            analysisSummaryBackfilled,
-                            analysisSummaryPrepared: true,
                             embedding,
                             identity,
                             layout,
@@ -289,6 +286,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         }),
                       }).pipe(Effect.ensuring(parserPool.trimIdle()));
                       const extractorSet = extractorSetIdentity(inventory.files, languagePacks);
+                      const graphContentId = graphContentIdentity(extractorSet, inventory.files);
                       const logicalSnapshotId = snapshotIdentity(
                         identity,
                         inventory.dirty,
@@ -338,22 +336,11 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         activeWorktreeIds,
                       );
                       if (reusableReady) {
-                        let analysisSummaryBackfilled = false;
-                        let analysisSummaryPrepared = false;
                         if (existing?.id !== reusableReady.id) {
-                          analysisSummaryBackfilled = yield* prepareReadyAnalysisSummary({
-                            databasePath: layout.databasePath,
-                            onProgress: options.onProgress,
-                            snapshotId: reusableReady.id,
-                            store,
-                          });
-                          analysisSummaryPrepared = true;
                           yield* store.promote(layout.databasePath, identity, reusableReady.id, activeWorktreeIds);
                         }
                         return yield* reuseReadySnapshot({
                           activeWorktreeIds,
-                          analysisSummaryBackfilled,
-                          analysisSummaryPrepared,
                           embedding,
                           identity,
                           layout,
@@ -426,6 +413,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                           edgeCount: 0,
                           extractorSet,
                           fileCount: 0,
+                          graphContentId,
                           id: logicalSnapshotId,
                           repositoryId: identity.repositoryId,
                           state: 'building',
@@ -444,6 +432,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                           edgeCount: 0,
                           extractorSet,
                           fileCount: 0,
+                          graphContentId,
                           id: options.force ? forcedSnapshotId : directSnapshotId,
                           overlayFingerprint: inventory.overlayFingerprint,
                           repositoryId: identity.repositoryId,
@@ -461,38 +450,51 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                           building,
                         );
                       } else {
-                        const preassessment = yield* assessIncrementalOverlayCompatibility(
-                          {extractorSet, inventory, languagePacks, layout, store},
+                        const reusableDirtyBase = yield* attemptReusableDirtyBase(
+                          {extractorSet, identity, inventory, languagePacks, layout, store},
                           workspace,
                         );
+                        let preassessment: IncrementalOverlayPreassessment;
                         let incrementalBuilding: CodeGraphSnapshot | undefined;
+                        if (Option.isSome(reusableDirtyBase)) {
+                          committedBase = reusableDirtyBase.value.committedBase;
+                          preassessment = reusableDirtyBase.value.preassessment;
+                        } else {
+                          preassessment = yield* assessIncrementalOverlayCompatibility(
+                            {extractorSet, inventory, languagePacks, layout, store},
+                            workspace,
+                          );
+                          if (preassessment.mode === 'compatible') {
+                            committedBase = yield* ensureCommittedBase({
+                              activeWorktreeIds,
+                              embedding,
+                              force: false,
+                              forceGeneration,
+                              fs,
+                              identity,
+                              inventory,
+                              languagePacks,
+                              layout,
+                              onProgress: options.onProgress,
+                              persistentMaterializationTransactionBatchLimit:
+                                options.persistentMaterializationTransactionBatchLimit,
+                              startedAt,
+                              store,
+                              threadnoteHome: options.threadnoteHome,
+                            });
+                          }
+                        }
                         if (preassessment.mode === 'fallback') {
                           incrementalAssessment = preassessment;
                         } else {
-                          committedBase = yield* ensureCommittedBase({
-                            activeWorktreeIds,
-                            embedding,
-                            force: false,
-                            forceGeneration,
-                            fs,
-                            identity,
-                            inventory,
-                            languagePacks,
-                            layout,
-                            onProgress: options.onProgress,
-                            persistentMaterializationTransactionBatchLimit:
-                              options.persistentMaterializationTransactionBatchLimit,
-                            startedAt,
-                            store,
-                            threadnoteHome: options.threadnoteHome,
-                          });
                           incrementalBuilding = {
-                            baseSnapshotId: committedBase.snapshot.id,
+                            baseSnapshotId: committedBase!.snapshot.id,
                             commit: identity.headCommit,
                             dirty: inventory.dirty,
                             edgeCount: 0,
                             extractorSet,
                             fileCount: 0,
+                            graphContentId,
                             id: logicalSnapshotId,
                             overlayFingerprint: inventory.overlayFingerprint,
                             repositoryId: identity.repositoryId,
@@ -503,7 +505,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                           incrementalAssessment = yield* assessIncrementalOverlay(
                             {
                               building: incrementalBuilding,
-                              committedBase,
+                              committedBase: committedBase!,
                               force: false,
                               incrementalOverlayEnabled: true,
                               inventory,
@@ -536,6 +538,10 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                                   committedBase.snapshot.id,
                                   incrementalAssessment.files,
                                   incrementalAssessment.facts,
+                                  {
+                                    deletedPaths: incrementalAssessment.deletedPaths,
+                                    resolutionClosure: incrementalAssessment.resolutionClosure,
+                                  },
                                 )
                               : yield* store.replaceStagedModifiedFiles(
                                   layout.databasePath,
@@ -869,18 +875,21 @@ const prepareReadyAnalysisSummary = Effect.fn('codeGraph.prepareReadyAnalysisSum
     snapshotId: input.snapshotId,
     subphase: 'summarizing-analysis',
   }) ?? Effect.void;
-  const backfilled =
+  return yield* (
     typeof input.store.ensureAnalysisSummary === 'function'
-      ? yield* input.store.ensureAnalysisSummary(input.databasePath, input.snapshotId)
-      : false;
-  yield* input.onProgress?.({phase: 'activating', snapshotId: input.snapshotId, subphase: 'complete'}) ?? Effect.void;
-  return backfilled;
+      ? input.store.ensureAnalysisSummary(input.databasePath, input.snapshotId)
+      : Effect.succeed(false)
+  ).pipe(
+    Effect.ensuring(
+      (
+        input.onProgress?.({phase: 'activating', snapshotId: input.snapshotId, subphase: 'complete'}) ?? Effect.void
+      ).pipe(Effect.catch(() => Effect.void)),
+    ),
+  );
 });
 
 const reuseReadySnapshot = Effect.fn('codeGraph.reuseReadySnapshot')(function* (input: {
   readonly activeWorktreeIds: ReadonlySet<string>;
-  readonly analysisSummaryBackfilled?: boolean;
-  readonly analysisSummaryPrepared?: boolean;
   readonly embedding: CodeGraphEmbeddingIndexShape;
   readonly identity: RepositoryIdentity;
   readonly layout: CodeGraphLayout;
@@ -893,18 +902,26 @@ const reuseReadySnapshot = Effect.fn('codeGraph.reuseReadySnapshot')(function* (
   readonly threadnoteHome: string;
   readonly totalFiles: number;
 }) {
-  const analysisSummaryBackfilled = input.analysisSummaryPrepared
-    ? input.analysisSummaryBackfilled === true
-    : yield* prepareReadyAnalysisSummary({
-        databasePath: input.layout.databasePath,
-        onProgress: input.onProgress,
-        snapshotId: input.snapshot.id,
-        store: input.store,
-      });
+  let analysisSummaryFailure: string | undefined;
+  const analysisSummaryBackfilled = yield* prepareReadyAnalysisSummary({
+    databasePath: input.layout.databasePath,
+    onProgress: input.onProgress,
+    snapshotId: input.snapshot.id,
+    store: input.store,
+  }).pipe(
+    Effect.catch(cause =>
+      Effect.sync(() => {
+        analysisSummaryFailure = messageOf(cause);
+        return false;
+      }),
+    ),
+  );
   yield* input.store.reconcileWorktrees(input.layout.databasePath, input.activeWorktreeIds);
   const diagnostics: string[] = analysisSummaryBackfilled
     ? ['Built the persisted whole-graph analysis summary for this reused snapshot.']
-    : [];
+    : analysisSummaryFailure
+      ? [`Whole-graph analysis summary will be retried lazily: ${analysisSummaryFailure}`]
+      : [];
   const vectorCheck = yield* input.embedding
     .check(input.threadnoteHome, input.layout, input.snapshot.id)
     .pipe(Effect.catch(cause => Effect.succeed({reason: messageOf(cause), state: 'unavailable'} as const)));
@@ -1018,22 +1035,11 @@ const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(f
           input.logicalSnapshotId,
         );
         if (ready) {
-          let analysisSummaryBackfilled = false;
-          let analysisSummaryPrepared = false;
           if (input.existing?.id !== ready.id) {
-            analysisSummaryBackfilled = yield* prepareReadyAnalysisSummary({
-              databasePath: input.layout.databasePath,
-              onProgress: input.onProgress,
-              snapshotId: ready.id,
-              store: input.store,
-            });
-            analysisSummaryPrepared = true;
             yield* input.store.promote(input.layout.databasePath, input.identity, ready.id, input.activeWorktreeIds);
           }
           return yield* reuseReadySnapshot({
             activeWorktreeIds: input.activeWorktreeIds,
-            analysisSummaryBackfilled,
-            analysisSummaryPrepared,
             embedding: input.embedding,
             identity: input.identity,
             layout: input.layout,
@@ -1047,6 +1053,9 @@ const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(f
             totalFiles: input.inventory.files.length,
           });
         }
+        const workspace = yield* input.languagePacks.discoverWorkspace(input.inventory.files);
+        const reused = yield* attemptReusableCleanSnapshot(input, workspace);
+        if (Option.isSome(reused)) return reused.value;
       }
       const resumed = input.force
         ? yield* input.store.resumableForcedBuild(input.layout.databasePath, input.logicalSnapshotId)
@@ -1057,6 +1066,10 @@ const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(f
         edgeCount: 0,
         extractorSet: extractorSetIdentity(input.inventory.files, input.languagePacks),
         fileCount: 0,
+        graphContentId: graphContentIdentity(
+          extractorSetIdentity(input.inventory.files, input.languagePacks),
+          input.inventory.files,
+        ),
         id: input.fallbackSnapshotId,
         repositoryId: input.identity.repositoryId,
         state: 'building',
@@ -1092,6 +1105,287 @@ const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(f
       );
     }),
   );
+});
+
+const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSnapshot')(function* (
+  input: {
+    readonly activeWorktreeIds: ReadonlySet<string>;
+    readonly embedding: CodeGraphEmbeddingIndexShape;
+    readonly existing: CodeGraphSnapshot | undefined;
+    readonly fs: FileSystem.FileSystem;
+    readonly identity: RepositoryIdentity;
+    readonly inventory: CodeGraphInventory;
+    readonly languagePacks: CodeGraphLanguagePackRegistryShape;
+    readonly layout: CodeGraphLayout;
+    readonly logicalSnapshotId: string;
+    readonly onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void, unknown>;
+    readonly persistentMaterializationTransactionBatchLimit?: 1 | 4;
+    readonly startedAt: number;
+    readonly store: CodeGraphStoreShape;
+    readonly threadnoteHome: string;
+  },
+  workspace: CodeGraphWorkspace,
+) {
+  if (!input.store.reusableCleanBase || !input.store.activateCleanSnapshotAlias) {
+    return Option.none<CodeGraphIndexSummary>();
+  }
+  const extractorSet = extractorSetIdentity(input.inventory.files, input.languagePacks);
+  const candidate = yield* input.store.reusableCleanBase(
+    input.layout.databasePath,
+    input.identity.repositoryId,
+    extractorSet,
+    workspace.fingerprint,
+    reusableBaseFileSetFingerprint(input.inventory.files),
+    graphContentIdentity(extractorSet, input.inventory.files),
+  );
+  if (!candidate || candidate.snapshot.id === input.logicalSnapshotId) return Option.none<CodeGraphIndexSummary>();
+  const baseByPath = new Map(candidate.files.map(file => [file.path, file]));
+  if (input.inventory.files.some(file => file.source !== 'commit')) {
+    return Option.none<CodeGraphIndexSummary>();
+  }
+  const lease = yield* input.store
+    .acquireSnapshotLease(input.layout.databasePath, candidate.snapshot.id, CODE_GRAPH_ACTIVATION_LEASE_MILLISECONDS)
+    .pipe(Effect.option);
+  if (Option.isNone(lease)) return Option.none<CodeGraphIndexSummary>();
+  return yield* Effect.acquireUseRelease(
+    Effect.succeed(lease.value),
+    () =>
+      Effect.gen(function* () {
+        const modifiedFiles = input.inventory.files.filter(file => {
+          const base = baseByPath.get(file.path);
+          return (
+            !base ||
+            base.contentHash !== file.contentHash ||
+            base.language !== file.language ||
+            base.mode !== file.mode ||
+            base.size !== file.size
+          );
+        });
+        const currentPaths = new Set(input.inventory.files.map(file => file.path));
+        const deletedPaths = candidate.files.filter(file => !currentPaths.has(file.path)).map(file => file.path);
+        if (modifiedFiles.length === 0 && deletedPaths.length === 0) {
+          const alias: CodeGraphSnapshot = {
+            baseSnapshotId: candidate.snapshot.id,
+            commit: input.identity.headCommit,
+            dirty: false,
+            edgeCount: candidate.snapshot.edgeCount,
+            extractorSet,
+            fileCount: candidate.snapshot.fileCount,
+            graphContentId: graphContentIdentity(extractorSet, input.inventory.files),
+            id: input.logicalSnapshotId,
+            repositoryId: input.identity.repositoryId,
+            state: 'ready',
+            symbolCount: candidate.snapshot.symbolCount,
+            worktreeId: input.identity.worktreeId,
+          };
+          yield* verifyIndexInput(input.identity, input.inventory, true);
+          yield* input.store.activateCleanSnapshotAlias!(
+            input.layout.databasePath,
+            input.identity,
+            alias,
+            candidate.snapshot.id,
+          );
+          yield* verifyIndexInput(input.identity, input.inventory, true);
+          yield* input.store.promote(input.layout.databasePath, input.identity, alias.id, input.activeWorktreeIds);
+          yield* verifyIndexInput(input.identity, input.inventory, true);
+          return Option.some<CodeGraphIndexSummary>(
+            yield* reuseReadySnapshot({
+              activeWorktreeIds: input.activeWorktreeIds,
+              embedding: input.embedding,
+              identity: input.identity,
+              layout: input.layout,
+              onProgress: input.onProgress,
+              reusedFiles: input.inventory.files.length,
+              skippedFiles: input.inventory.skipped,
+              snapshot: alias,
+              startedAt: input.startedAt,
+              store: input.store,
+              threadnoteHome: input.threadnoteHome,
+              totalFiles: input.inventory.files.length,
+            }),
+          );
+        }
+        const assessmentInput = {
+          candidate,
+          inventory: input.inventory,
+          languagePacks: input.languagePacks,
+          layout: input.layout,
+          store: input.store,
+        };
+        const sameFileSet = deletedPaths.length === 0 && modifiedFiles.every(file => baseByPath.has(file.path));
+        const boundedAssessment = sameFileSet
+          ? yield* assessReusableCleanBaseCompatibility(assessmentInput, workspace, modifiedFiles)
+          : ({mode: 'fallback', reason: 'file-set-changed'} as const);
+        const preassessment =
+          boundedAssessment.mode === 'compatible'
+            ? boundedAssessment
+            : yield* assessReusableCleanBaseFullClosure(assessmentInput, workspace, deletedPaths);
+        if (preassessment.mode === 'fallback') return Option.none<CodeGraphIndexSummary>();
+        const committedBase: CommittedBaseResult = {
+          diagnostics: [],
+          leaseToken: Option.none(),
+          snapshot: candidate.snapshot,
+          stagingReusable: false,
+        };
+        const building: CodeGraphSnapshot = {
+          baseSnapshotId: candidate.snapshot.id,
+          commit: input.identity.headCommit,
+          dirty: false,
+          edgeCount: 0,
+          extractorSet,
+          fileCount: 0,
+          graphContentId: graphContentIdentity(extractorSet, input.inventory.files),
+          id: input.logicalSnapshotId,
+          repositoryId: input.identity.repositoryId,
+          state: 'building',
+          symbolCount: 0,
+          worktreeId: input.identity.worktreeId,
+        };
+        const incrementalAssessment = yield* assessIncrementalOverlay(
+          {
+            building,
+            committedBase,
+            force: false,
+            incrementalOverlayEnabled: true,
+            inventory: input.inventory,
+            languagePacks: input.languagePacks,
+            layout: input.layout,
+            store: input.store,
+          },
+          workspace,
+          preassessment,
+        );
+        if (incrementalAssessment.mode === 'fallback') return Option.none<CodeGraphIndexSummary>();
+        yield* input.onProgress?.({
+          completed: 0,
+          phase: 'materializing',
+          reused: input.inventory.files.length - incrementalAssessment.files.length,
+          total: incrementalAssessment.files.length,
+          unit: 'files',
+        }) ?? Effect.void;
+        const prepared = yield* input.store.preparePersistedIncrementalActivation(
+          input.layout.databasePath,
+          candidate.snapshot.id,
+          incrementalAssessment.files,
+          incrementalAssessment.facts,
+          {
+            deletedPaths: incrementalAssessment.deletedPaths,
+            resolutionClosure: incrementalAssessment.resolutionClosure,
+          },
+        );
+        if (!prepared) return Option.none<CodeGraphIndexSummary>();
+        yield* input.store.markBuilding(input.layout.databasePath, input.identity, building);
+        const summary = yield* buildAndActivate({
+          activeWorktreeIds: input.activeWorktreeIds,
+          activatePointer: true,
+          building,
+          committedBase,
+          embedding: input.embedding,
+          ensureVectors: true,
+          existing: input.existing,
+          force: false,
+          fs: input.fs,
+          identity: input.identity,
+          incrementalAssessment,
+          incrementalOverlayEnabled: true,
+          incrementalPrepared: true,
+          inventory: input.inventory,
+          languagePacks: input.languagePacks,
+          layout: input.layout,
+          onProgress: input.onProgress,
+          persistentMaterializationTransactionBatchLimit: input.persistentMaterializationTransactionBatchLimit,
+          startedAt: input.startedAt,
+          store: input.store,
+          threadnoteHome: input.threadnoteHome,
+          workspace,
+        }).pipe(
+          Effect.catch(cause =>
+            input.store
+              .markFailed(input.layout.databasePath, building.id, messageOf(cause))
+              .pipe(Effect.andThen(Effect.fail(cause))),
+          ),
+        );
+        return Option.some<CodeGraphIndexSummary>(summary);
+      }),
+    token => input.store.releaseSnapshotLease(input.layout.databasePath, token).pipe(Effect.catch(() => Effect.void)),
+  );
+});
+
+const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')(function* (
+  input: {
+    readonly extractorSet: string;
+    readonly identity: RepositoryIdentity;
+    readonly inventory: CodeGraphInventory;
+    readonly languagePacks: CodeGraphLanguagePackRegistryShape;
+    readonly layout: CodeGraphLayout;
+    readonly store: CodeGraphStoreShape;
+  },
+  workspace: CodeGraphWorkspace,
+) {
+  if (!input.store.reusableCleanBase) {
+    return Option.none<{
+      readonly committedBase: CommittedBaseResult;
+      readonly preassessment: Extract<IncrementalOverlayPreassessment, {readonly mode: 'compatible'}>;
+    }>();
+  }
+  const candidate = yield* input.store.reusableCleanBase(
+    input.layout.databasePath,
+    input.identity.repositoryId,
+    input.extractorSet,
+    workspace.fingerprint,
+    reusableBaseFileSetFingerprint(input.inventory.files),
+    graphContentIdentity(input.extractorSet, input.inventory.files),
+  );
+  if (!candidate) return Option.none();
+  const lease = yield* input.store
+    .acquireSnapshotLease(input.layout.databasePath, candidate.snapshot.id, CODE_GRAPH_ACTIVATION_LEASE_MILLISECONDS)
+    .pipe(Effect.option);
+  if (Option.isNone(lease)) return Option.none();
+  const leaseToken = yield* Effect.acquireRelease(Effect.succeed(lease.value), token =>
+    input.store.releaseSnapshotLease(input.layout.databasePath, token).pipe(Effect.catch(() => Effect.void)),
+  );
+  const baseByPath = new Map(candidate.files.map(file => [file.path, file]));
+  const currentPaths = new Set(input.inventory.files.map(file => file.path));
+  const modifiedFiles = input.inventory.files.filter(file => {
+    const base = baseByPath.get(file.path);
+    return (
+      !base ||
+      base.contentHash !== file.contentHash ||
+      base.language !== file.language ||
+      base.mode !== file.mode ||
+      base.size !== file.size ||
+      base.source !== file.source
+    );
+  });
+  const deletedPaths = candidate.files.filter(file => !currentPaths.has(file.path)).map(file => file.path);
+  if (modifiedFiles.length === 0 && deletedPaths.length === 0) return Option.none();
+  const assessmentInput = {
+    candidate,
+    inventory: input.inventory,
+    languagePacks: input.languagePacks,
+    layout: input.layout,
+    store: input.store,
+  };
+  const sameFileSet = deletedPaths.length === 0 && modifiedFiles.every(file => baseByPath.has(file.path));
+  const boundedAssessment = sameFileSet
+    ? yield* assessReusableCleanBaseCompatibility(assessmentInput, workspace, modifiedFiles)
+    : ({mode: 'fallback', reason: 'file-set-changed'} as const);
+  const preassessment =
+    boundedAssessment.mode === 'compatible'
+      ? boundedAssessment
+      : yield* assessReusableCleanBaseFullClosure(assessmentInput, workspace, deletedPaths);
+  if (preassessment.mode === 'fallback') return Option.none();
+  return Option.some({
+    committedBase: {
+      diagnostics: [
+        `Dirty snapshot reused compatible persisted base ${candidate.snapshot.id} without first building commit ${input.identity.headCommit}.`,
+      ],
+      leaseToken: Option.some(leaseToken),
+      snapshot: candidate.snapshot,
+      stagingReusable: false,
+    },
+    preassessment,
+  });
 });
 
 const ensureCommittedBase = Effect.fn('codeGraph.ensureCommittedBase')(function* (input: {
@@ -1177,6 +1471,7 @@ const ensureCommittedBase = Effect.fn('codeGraph.ensureCommittedBase')(function*
         edgeCount: 0,
         extractorSet,
         fileCount: 0,
+        graphContentId: graphContentIdentity(extractorSet, cleanInventory.files),
         id: snapshotId,
         repositoryId: input.identity.repositoryId,
         state: 'building',
@@ -1268,6 +1563,10 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
               input.committedBase!.snapshot.id,
               incrementalAssessment.files,
               incrementalAssessment.facts,
+              {
+                deletedPaths: incrementalAssessment.deletedPaths,
+                resolutionClosure: incrementalAssessment.resolutionClosure,
+              },
             )
           : yield* input.store.replaceStagedModifiedFiles(
               input.layout.databasePath,
@@ -1809,6 +2108,22 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
     yield* input.onProgress?.({phase: 'activating', snapshotId: activated.id, subphase: 'complete'}) ?? Effect.void;
     return activated;
   });
+  let analysisSummaryFailure: string | undefined;
+  const analysisSummaryBackfilled = input.activatePointer
+    ? yield* prepareReadyAnalysisSummary({
+        databasePath: input.layout.databasePath,
+        onProgress: input.onProgress,
+        snapshotId: activatedReady.id,
+        store: input.store,
+      }).pipe(
+        Effect.catch(cause =>
+          Effect.sync(() => {
+            analysisSummaryFailure = messageOf(cause);
+            return false;
+          }),
+        ),
+      )
+    : false;
   const embedding = input.ensureVectors
     ? yield* input.embedding
         .ensure(
@@ -1847,6 +2162,12 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
                 : `Dirty overlay reused clean staging for ${materializedFiles.toLocaleString()} modified file(s).`
               : `Dirty overlay used full materialization: ${overlayFallbackDescription(fallbackReason ?? 'staging-unavailable')}.`,
           ]
+        : incrementalApplied
+          ? [`Clean snapshot reused persisted base for ${materializedFiles.toLocaleString()} modified file(s).`]
+          : []),
+      ...(analysisSummaryBackfilled ? ['Built the persisted whole-graph analysis summary after promotion.'] : []),
+      ...(analysisSummaryFailure
+        ? [`Whole-graph analysis summary will be retried lazily: ${analysisSummaryFailure}`]
         : []),
       ...(embedding.ready ? [] : [`Vector graph retrieval unavailable: ${embedding.reason ?? 'unknown reason'}`]),
     ].slice(0, 100),
@@ -1854,7 +2175,7 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
     identity: input.identity,
     materialization: {
       ...(fallbackReason ? {fallbackReason} : {}),
-      mode: incrementalApplied ? 'incremental-overlay' : 'full',
+      mode: incrementalApplied ? (input.inventory.dirty ? 'incremental-overlay' : 'incremental-clean') : 'full',
       stagedFiles: materializedFiles,
       totalFiles: input.inventory.files.length,
     },
@@ -1882,7 +2203,7 @@ const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOverlay')
     return {mode: 'fallback', reason: 'disabled'} satisfies IncrementalOverlayAssessment;
   }
   if (input.force) return {mode: 'fallback', reason: 'forced-full-rebuild'} satisfies IncrementalOverlayAssessment;
-  const preassessment =
+  const preassessment: IncrementalOverlayPreassessment =
     suppliedPreassessment ??
     (yield* assessIncrementalOverlayCompatibility(
       {
@@ -1908,14 +2229,15 @@ const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOverlay')
       receipt.formatVersion !== CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION ||
       receipt.resolutionSurfaceVersion !== 1 ||
       receipt.workspaceFingerprint !== preassessment.committedWorkspace.fingerprint ||
-      receipt.fileSetFingerprint !== reusableBaseFileSetFingerprint(input.inventory.committedFiles)
+      (preassessment.resolutionClosure !== 'full' &&
+        receipt.fileSetFingerprint !== reusableBaseFileSetFingerprint(input.inventory.committedFiles))
     ) {
       return {mode: 'fallback', reason: 'staging-unavailable'} satisfies IncrementalOverlayAssessment;
     }
     reuse = 'persisted-base';
   }
   let reusableFacts = preassessment.facts;
-  if (reuse === 'persisted-base') {
+  if (reuse === 'persisted-base' && preassessment.resolutionClosure !== 'full') {
     const seeds = reusableReexportSeeds(preassessment.facts);
     if (seeds.length > 0) {
       const reexports = yield* input.store.reusableReexports(
@@ -1930,13 +2252,15 @@ const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOverlay')
     }
   }
   const finalBatches = finalCodeGraphFactBatches(reusableFacts);
-  if (finalBatches.length !== 1) {
+  if (finalBatches.length !== 1 && preassessment.resolutionClosure !== 'full') {
     return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayAssessment;
   }
   return {
-    facts: finalBatches[0]!.map(value => value.facts),
+    deletedPaths: preassessment.deletedPaths,
+    facts: finalBatches.flatMap(batch => batch.map(value => value.facts)),
     files: preassessment.files,
     mode: 'eligible',
+    resolutionClosure: preassessment.resolutionClosure,
     reuse,
   } satisfies IncrementalOverlayAssessment;
 });
@@ -2023,6 +2347,121 @@ const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assessIncreme
     facts: effectiveFacts,
     files: modifiedFiles,
     mode: 'compatible',
+  } satisfies IncrementalOverlayPreassessment;
+});
+
+const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusableCleanBaseCompatibility')(function* (
+  input: {
+    readonly candidate: CodeGraphReusableCleanBase;
+    readonly inventory: CodeGraphInventory;
+    readonly languagePacks: CodeGraphLanguagePackRegistryShape;
+    readonly layout: CodeGraphLayout;
+    readonly store: CodeGraphStoreShape;
+  },
+  workspace: CodeGraphWorkspace,
+  modifiedFiles: readonly CodeGraphInventoryFile[],
+) {
+  if (input.candidate.snapshot.extractorSet !== extractorSetIdentity(input.inventory.files, input.languagePacks)) {
+    return {mode: 'fallback', reason: 'extractor-context-changed'} satisfies IncrementalOverlayPreassessment;
+  }
+  if (input.candidate.receipt.workspaceFingerprint !== workspace.fingerprint) {
+    return {mode: 'fallback', reason: 'workspace-changed'} satisfies IncrementalOverlayPreassessment;
+  }
+  if (modifiedFiles.length === 0) {
+    return {mode: 'fallback', reason: 'no-materialized-changes'} satisfies IncrementalOverlayPreassessment;
+  }
+  const baseByPath = new Map(input.candidate.files.map(file => [file.path, file]));
+  const baseFiles = modifiedFiles.map(file => baseByPath.get(file.path)!);
+  const [baseCache, currentCache] = yield* Effect.all(
+    [
+      loadCachedFacts(input.store, input.layout.databasePath, baseFiles, input.languagePacks),
+      loadCachedFacts(input.store, input.layout.databasePath, modifiedFiles, input.languagePacks),
+    ],
+    {concurrency: 1},
+  );
+  if (
+    baseFiles.some(file => !baseCache.facts.has(file.path)) ||
+    modifiedFiles.some(file => !currentCache.facts.has(file.path))
+  ) {
+    return {mode: 'fallback', reason: 'cache-incomplete'} satisfies IncrementalOverlayPreassessment;
+  }
+  const baseFacts = attributeInventoryFacts(
+    input.candidate.files,
+    workspace,
+    baseFiles.map(file => input.languagePacks.postprocessFile(file, baseCache.facts.get(file.path)!)),
+  );
+  const currentFacts = attributeInventoryFacts(
+    input.inventory.files,
+    workspace,
+    modifiedFiles.map(file => input.languagePacks.postprocessFile(file, currentCache.facts.get(file.path)!)),
+  );
+  if (hasDynamicAliases(baseFacts) || hasDynamicAliases(currentFacts)) {
+    return {mode: 'fallback', reason: 'dynamic-aliases'} satisfies IncrementalOverlayPreassessment;
+  }
+  const baseFactsByPath = new Map(baseFacts.map(file => [file.path, file]));
+  if (
+    currentFacts.some(file => {
+      const base = baseFactsByPath.get(file.path);
+      return !base || !hasSameCodeGraphResolutionSurface(base.symbols, file.symbols);
+    })
+  ) {
+    return {mode: 'fallback', reason: 'resolution-surface-changed'} satisfies IncrementalOverlayPreassessment;
+  }
+  if (finalCodeGraphFactBatches(currentFacts).length !== 1) {
+    return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
+  }
+  return {
+    committedWorkspace: workspace,
+    facts: currentFacts,
+    files: modifiedFiles,
+    mode: 'compatible',
+  } satisfies IncrementalOverlayPreassessment;
+});
+
+/**
+ * File additions, deletions, renames, and exported-surface changes can affect
+ * references anywhere in the graph. Reuse the persisted full anchor, but stage
+ * and re-resolve the complete current inventory as a conservative bounded
+ * closure instead of first materializing another full anchor.
+ */
+const assessReusableCleanBaseFullClosure = Effect.fn('codeGraph.assessReusableCleanBaseFullClosure')(function* (
+  input: {
+    readonly candidate: CodeGraphReusableCleanBase;
+    readonly inventory: CodeGraphInventory;
+    readonly languagePacks: CodeGraphLanguagePackRegistryShape;
+    readonly layout: CodeGraphLayout;
+    readonly store: CodeGraphStoreShape;
+  },
+  workspace: CodeGraphWorkspace,
+  deletedPaths: readonly string[],
+) {
+  if (input.candidate.snapshot.extractorSet !== extractorSetIdentity(input.inventory.files, input.languagePacks)) {
+    return {mode: 'fallback', reason: 'extractor-context-changed'} satisfies IncrementalOverlayPreassessment;
+  }
+  if (input.candidate.receipt.workspaceFingerprint !== workspace.fingerprint) {
+    return {mode: 'fallback', reason: 'workspace-changed'} satisfies IncrementalOverlayPreassessment;
+  }
+  const cache = yield* loadCachedFacts(
+    input.store,
+    input.layout.databasePath,
+    input.inventory.files,
+    input.languagePacks,
+  );
+  if (input.inventory.files.some(file => !cache.facts.has(file.path))) {
+    return {mode: 'fallback', reason: 'cache-incomplete'} satisfies IncrementalOverlayPreassessment;
+  }
+  const facts = attributeInventoryFacts(
+    input.inventory.files,
+    workspace,
+    input.inventory.files.map(file => input.languagePacks.postprocessFile(file, cache.facts.get(file.path)!)),
+  );
+  return {
+    committedWorkspace: workspace,
+    deletedPaths,
+    facts,
+    files: input.inventory.files,
+    mode: 'compatible',
+    resolutionClosure: 'full',
   } satisfies IncrementalOverlayPreassessment;
 });
 
@@ -2531,6 +2970,29 @@ export function snapshotIdentity(
     .join('\n');
   return `cgsn_${sha256HexSync(
     `snapshot-v2\nlexical-storage:${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}\n${identity.repositoryId}\n${dirty ? identity.worktreeId : 'shared-commit'}\n${identity.headCommit}\n${dirty ? 'dirty' : 'clean'}\n${extractorSet}\n${inventory}`,
+  ).slice(0, 40)}`;
+}
+
+/**
+ * Identifies the graph-producing inputs without coupling them to a Git commit or
+ * worktree. Commit observations remain snapshot rows and may safely alias this
+ * identity when the eligible inventory and derivation identity are unchanged.
+ */
+export function graphContentIdentity(
+  extractorSet: string,
+  files: readonly {
+    readonly contentHash: string;
+    readonly language?: string;
+    readonly mode?: string;
+    readonly path: string;
+  }[],
+): string {
+  const inventory = files
+    .map(file => `${file.path}\0${file.contentHash}\0${file.language ?? ''}\0${file.mode ?? ''}`)
+    .sort()
+    .join('\n');
+  return `cgc_${sha256HexSync(
+    `graph-content-v1\nlexical-storage:${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}\n${extractorSet}\n${inventory}`,
   ).slice(0, 40)}`;
 }
 

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -33,6 +33,7 @@ import {
   CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION,
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   CodeGraphStore,
+  materializedShardDerivationIdentity,
   type CodeGraphRetiredSnapshotCleanupProgress,
   type CodeGraphReusableCleanBase,
   type CodeGraphReusableReexport,
@@ -1534,8 +1535,14 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
 }) {
   const workspace = input.workspace ?? (yield* input.languagePacks.discoverWorkspace(input.inventory.files));
   const attributeFacts = createCachedCodeGraphFactsAttributor(input.inventory.files, workspace);
+  const shardDerivationIdentity = materializedShardDerivationIdentity(
+    input.building.extractorSet,
+    workspace.fingerprint,
+    reusableBaseFileSetFingerprint(input.inventory.files),
+  );
   const extractionDiagnostics: string[] = [...workspace.diagnostics];
   let materializedFiles = 0;
+  let materializedShardFilesReused = 0;
   const reusedFiles = input.inventory.files.length - input.inventory.parsedFiles;
   const incrementalAssessment =
     input.incrementalAssessment ??
@@ -1602,6 +1609,13 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
       input.inventory.files,
       input.languagePacks,
     );
+    const materializedShards = yield* input.store.loadMaterializedFileShards(
+      input.layout.databasePath,
+      input.inventory.files,
+      input.building.extractorSet,
+      shardDerivationIdentity,
+    );
+    const materializedShardSetComplete = materializedShards.facts.size === input.inventory.files.length;
     if (cachedMetadata.files !== input.inventory.files.length) {
       return yield* Effect.fail(
         new Error('Cached code graph facts are incomplete during materialization planning; retry with a full rebuild.'),
@@ -1887,11 +1901,17 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
         unit: 'files',
       }) ?? Effect.void;
       const loadingStartedAt = yield* Clock.currentTimeMillis;
-      const cached = yield* loadCachedFacts(input.store, input.layout.databasePath, files, input.languagePacks);
+      const missingShardFiles = materializedShardSetComplete ? [] : files;
+      const cached = yield* loadCachedFacts(
+        input.store,
+        input.layout.databasePath,
+        missingShardFiles,
+        input.languagePacks,
+      );
       const batchLoadingMilliseconds = (yield* Clock.currentTimeMillis) - loadingStartedAt;
       loadingMilliseconds += batchLoadingMilliseconds;
       stageMilliseconds['loading-cache'] = loadingMilliseconds;
-      if (files.some(file => !cached.facts.has(file.path))) {
+      if (missingShardFiles.some(file => !cached.facts.has(file.path))) {
         return yield* Effect.fail(
           new Error('A cached code graph fact disappeared during indexing; retry with a full rebuild.'),
         );
@@ -1913,9 +1933,25 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
         unit: 'files',
       }) ?? Effect.void;
       const attributionStartedAt = yield* Clock.currentTimeMillis;
-      const facts = attributeFacts(
-        files.map(file => input.languagePacks.postprocessFile(file, cached.facts.get(file.path)!)),
+      const attributedMissingFacts = attributeFacts(
+        missingShardFiles.map(file => input.languagePacks.postprocessFile(file, cached.facts.get(file.path)!)),
       );
+      if (missingShardFiles.length > 0) {
+        yield* input.store.cacheMaterializedFileShards(
+          input.layout.databasePath,
+          missingShardFiles,
+          attributedMissingFacts.map(fact => serializeBoundedCodeGraphFact(fact)),
+          input.building.extractorSet,
+          shardDerivationIdentity,
+        );
+      }
+      const attributedMissingByPath = new Map(attributedMissingFacts.map(fact => [fact.path, fact]));
+      const facts = files.map(file =>
+        materializedShardSetComplete
+          ? materializedShards.facts.get(file.path)!
+          : attributedMissingByPath.get(file.path)!,
+      );
+      materializedShardFilesReused += files.length - missingShardFiles.length;
       const batchAttributionMilliseconds = (yield* Clock.currentTimeMillis) - attributionStartedAt;
       attributionMilliseconds += batchAttributionMilliseconds;
       stageMilliseconds.attributing = attributionMilliseconds;
@@ -1936,7 +1972,7 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
         const batchFiles = finalFacts.map(fact => filesByPath.get(fact.path)!);
         const batchSourceBytes = batchFiles.reduce((total, file) => total + file.size, 0);
         const batchCachedFactBytes = batchFiles.reduce(
-          (total, file) => total + (cached.bytesByPath.get(file.path) ?? 0),
+          (total, file) => total + (cachedMetadata.bytesByPath.get(file.path) ?? 0),
           0,
         );
         const symbols = uniqueById(finalFacts.flatMap(file => file.symbols));
@@ -2165,6 +2201,9 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
         : incrementalApplied
           ? [`Clean snapshot reused persisted base for ${materializedFiles.toLocaleString()} modified file(s).`]
           : []),
+      ...(materializedShardFilesReused > 0
+        ? [`Reused content-addressed materialized shards for ${materializedShardFilesReused.toLocaleString()} file(s).`]
+        : []),
       ...(analysisSummaryBackfilled ? ['Built the persisted whole-graph analysis summary after promotion.'] : []),
       ...(analysisSummaryFailure
         ? [`Whole-graph analysis summary will be retried lazily: ${analysisSummaryFailure}`]
@@ -2410,6 +2449,17 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
   if (finalCodeGraphFactBatches(currentFacts).length !== 1) {
     return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
   }
+  yield* input.store.cacheMaterializedFileShards(
+    input.layout.databasePath,
+    modifiedFiles,
+    currentFacts.map(fact => serializeBoundedCodeGraphFact(fact)),
+    input.candidate.snapshot.extractorSet,
+    materializedShardDerivationIdentity(
+      input.candidate.snapshot.extractorSet,
+      workspace.fingerprint,
+      reusableBaseFileSetFingerprint(input.inventory.files),
+    ),
+  );
   return {
     committedWorkspace: workspace,
     facts: currentFacts,
@@ -2454,6 +2504,17 @@ const assessReusableCleanBaseFullClosure = Effect.fn('codeGraph.assessReusableCl
     input.inventory.files,
     workspace,
     input.inventory.files.map(file => input.languagePacks.postprocessFile(file, cache.facts.get(file.path)!)),
+  );
+  yield* input.store.cacheMaterializedFileShards(
+    input.layout.databasePath,
+    input.inventory.files,
+    facts.map(fact => serializeBoundedCodeGraphFact(fact)),
+    input.candidate.snapshot.extractorSet,
+    materializedShardDerivationIdentity(
+      input.candidate.snapshot.extractorSet,
+      workspace.fingerprint,
+      reusableBaseFileSetFingerprint(input.inventory.files),
+    ),
   );
   return {
     committedWorkspace: workspace,

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -42,6 +42,7 @@ interface SnapshotRow {
   readonly edge_count: number;
   readonly extractor_set: string;
   readonly file_count: number;
+  readonly graph_content_id: unknown;
   readonly id: string;
   readonly overlay_fingerprint: unknown;
   readonly repository_id: string;
@@ -101,6 +102,12 @@ export interface CodeGraphReusableBaseReceipt extends CodeGraphReusableBaseRecei
   readonly resolutionSurfaceVersion: number;
   readonly reexportCount: number;
   readonly snapshotId: string;
+}
+
+export interface CodeGraphReusableCleanBase {
+  readonly files: readonly CodeGraphInventoryFile[];
+  readonly receipt: CodeGraphReusableBaseReceipt;
+  readonly snapshot: CodeGraphSnapshot;
 }
 
 export interface CodeGraphReusableReexport {
@@ -451,6 +458,12 @@ export interface CodeGraphStoreShape {
     promotionLeaseDurationMilliseconds?: number,
     onProgress?: CodeGraphActivationProgressCallback,
   ) => Effect.Effect<Option.Option<string>, CodeGraphStoreError>;
+  readonly activateCleanSnapshotAlias?: (
+    databasePath: string,
+    identity: RepositoryIdentity,
+    snapshot: CodeGraphSnapshot,
+    baseSnapshotId: string,
+  ) => Effect.Effect<void, CodeGraphStoreError>;
   readonly cacheFacts: (
     databasePath: string,
     files: readonly CodeGraphInventoryFile[],
@@ -485,6 +498,10 @@ export interface CodeGraphStoreShape {
     baseSnapshotId: string,
     files: readonly CodeGraphInventoryFile[],
     facts: readonly CodeGraphFileFacts[],
+    options?: {
+      readonly deletedPaths?: readonly string[];
+      readonly resolutionClosure?: 'changed' | 'full';
+    },
   ) => Effect.Effect<boolean, CodeGraphStoreError>;
   readonly replaceStagedModifiedFiles: (
     databasePath: string,
@@ -659,6 +676,14 @@ export interface CodeGraphStoreShape {
     databasePath: string,
     snapshotId: string,
   ) => Effect.Effect<CodeGraphReusableBaseReceipt | undefined, CodeGraphStoreError>;
+  readonly reusableCleanBase?: (
+    databasePath: string,
+    repositoryId: string,
+    extractorSet: string,
+    workspaceFingerprint: string,
+    fileSetFingerprint: string,
+    graphContentId?: string,
+  ) => Effect.Effect<CodeGraphReusableCleanBase | undefined, CodeGraphStoreError>;
   readonly reusableReexports: (
     databasePath: string,
     snapshotId: string,
@@ -1042,6 +1067,23 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
             }
             return Option.map(promotionLease, lease => lease.token);
           }).pipe(Effect.mapError(cause => storeError('activate staged code graph snapshot', cause))),
+        activateCleanSnapshotAlias: (databasePath, identity, snapshot, baseSnapshotId) =>
+          prepare(databasePath).pipe(
+            Effect.andThen(
+              useDatabase(
+                databasePath,
+                Effect.gen(function* () {
+                  const sql = yield* SqlClient.SqlClient;
+                  yield* ensureSchemaInitialized(databasePath, sql);
+                  yield* withWriterGate(
+                    databasePath,
+                    activateCleanSnapshotAlias(sql, identity, snapshot, baseSnapshotId),
+                  );
+                }),
+              ),
+            ),
+            Effect.mapError(cause => storeError('activate clean code graph snapshot alias', cause)),
+          ),
         cacheFacts: (databasePath, files, facts, extractorSet) =>
           Effect.gen(function* () {
             const bounded = yield* Effect.sync(() => facts.map(ensureBoundedCodeGraphFact));
@@ -1129,7 +1171,7 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
             ),
             Effect.mapError(cause => storeError('finalize persistent code graph materialization plan', cause)),
           ),
-        preparePersistedIncrementalActivation: (databasePath, baseSnapshotId, files, facts) =>
+        preparePersistedIncrementalActivation: (databasePath, baseSnapshotId, files, facts, options) =>
           prepare(databasePath).pipe(
             Effect.andThen(
               useDatabase(
@@ -1137,7 +1179,7 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
                 Effect.gen(function* () {
                   const sql = yield* SqlClient.SqlClient;
                   yield* ensureSchemaInitialized(databasePath, sql);
-                  return yield* preparePersistedIncrementalActivation(baseSnapshotId, files, facts);
+                  return yield* preparePersistedIncrementalActivation(baseSnapshotId, files, facts, options);
                 }),
               ),
             ),
@@ -1314,14 +1356,16 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
                     yield* upsertRepository(sql, identity);
                     const registered = yield* sql<{readonly id: string}>`
                       INSERT INTO snapshots (
-                        id, repository_id, worktree_id, commit_id, base_snapshot_id, extractor_set,
+                        id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id, extractor_set,
                         dirty, overlay_fingerprint, state, file_count, symbol_count, edge_count, started_at
                       ) VALUES (
                         ${snapshot.id}, ${snapshot.repositoryId}, ${snapshot.worktreeId}, ${snapshot.commit},
-                        ${snapshot.baseSnapshotId ?? null}, ${snapshot.extractorSet}, ${snapshot.dirty ? 1 : 0},
+                        ${snapshot.graphContentId ?? snapshot.id}, ${snapshot.baseSnapshotId ?? null},
+                        ${snapshot.extractorSet}, ${snapshot.dirty ? 1 : 0},
                         ${snapshot.overlayFingerprint ?? null}, 'building', 0, 0, 0, ${new Date().toISOString()}
                       )
                       ON CONFLICT(id) DO UPDATE SET
+                        graph_content_id = excluded.graph_content_id,
                         state = 'building',
                         file_count = 0,
                         symbol_count = 0,
@@ -1332,6 +1376,7 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
                       WHERE snapshots.repository_id = excluded.repository_id
                         AND snapshots.worktree_id = excluded.worktree_id
                         AND snapshots.commit_id = excluded.commit_id
+                        AND snapshots.graph_content_id = excluded.graph_content_id
                         AND snapshots.base_snapshot_id IS excluded.base_snapshot_id
                         AND snapshots.extractor_set = excluded.extractor_set
                         AND snapshots.dirty = excluded.dirty
@@ -1473,6 +1518,31 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
                 : Effect.succeed(undefined),
             ),
             Effect.mapError(cause => storeError('load reusable code graph base receipt', cause)),
+          ),
+        reusableCleanBase: (
+          databasePath,
+          repositoryId,
+          extractorSet,
+          workspaceFingerprint,
+          fileSetFingerprint,
+          graphContentId,
+        ) =>
+          fs.exists(databasePath).pipe(
+            Effect.flatMap(exists =>
+              exists
+                ? useReadOnlyDatabase(
+                    databasePath,
+                    selectReusableCleanBase(
+                      repositoryId,
+                      extractorSet,
+                      workspaceFingerprint,
+                      fileSetFingerprint,
+                      graphContentId,
+                    ),
+                  )
+                : Effect.succeed(undefined),
+            ),
+            Effect.mapError(cause => storeError('load reusable clean code graph base', cause)),
           ),
         reusableReexports: (databasePath, snapshotId, seeds) =>
           fs.exists(databasePath).pipe(
@@ -2709,6 +2779,7 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
       repository_id TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
       worktree_id TEXT NOT NULL,
       commit_id TEXT NOT NULL,
+      graph_content_id TEXT,
       base_snapshot_id TEXT,
       extractor_set TEXT NOT NULL,
       dirty INTEGER NOT NULL CHECK (dirty IN (0, 1)),
@@ -2722,6 +2793,11 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
       failure_summary TEXT
     )
   `);
+  yield* ensureColumn(sql, 'snapshots', 'graph_content_id', 'TEXT');
+  // Older graph-v3 databases predate explicit content identity. Their snapshot
+  // ID is a collision-safe migration sentinel; freshly observed snapshots use
+  // the commit-independent cgc_ identity generated by the indexer.
+  yield* sql.unsafe('UPDATE snapshots SET graph_content_id = id WHERE graph_content_id IS NULL');
   yield* migratePersistentExtensionTables(sql);
   yield* sql.unsafe(`
     CREATE TABLE IF NOT EXISTS snapshot_extractor_generations (
@@ -3043,6 +3119,9 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
   `);
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS snapshots_worktree_state ON snapshots(worktree_id, state)');
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS snapshots_commit ON snapshots(repository_id, commit_id)');
+  yield* sql.unsafe(
+    'CREATE INDEX IF NOT EXISTS snapshots_graph_content ON snapshots(repository_id, graph_content_id, state)',
+  );
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS snapshot_leases_expiry ON snapshot_leases(expires_at)');
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS snapshot_files_blob ON snapshot_files(path, content_hash)');
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS symbols_name ON symbols(snapshot_id, name)');
@@ -3904,11 +3983,12 @@ const activateCleanStagedSnapshot = Effect.fn('codeGraph.activateCleanStagedSnap
       yield* sql`DELETE FROM snapshots WHERE id = ${snapshot.id}`;
       yield* sql`
         INSERT INTO snapshots (
-          id, repository_id, worktree_id, commit_id, base_snapshot_id, extractor_set,
+          id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id, extractor_set,
           dirty, overlay_fingerprint, state, file_count, symbol_count, edge_count, started_at, completed_at
         ) VALUES (
           ${snapshot.id}, ${snapshot.repositoryId}, ${snapshot.worktreeId}, ${snapshot.commit},
-          NULL, ${snapshot.extractorSet}, ${snapshot.dirty ? 1 : 0}, ${snapshot.overlayFingerprint ?? null},
+          ${snapshot.graphContentId ?? snapshot.id}, NULL, ${snapshot.extractorSet}, ${snapshot.dirty ? 1 : 0},
+          ${snapshot.overlayFingerprint ?? null},
           'building', ${snapshot.fileCount}, ${snapshot.symbolCount}, ${snapshot.edgeCount}, ${startedAt}, NULL
         )
       `;
@@ -4011,8 +4091,6 @@ const activateCleanStagedSnapshot = Effect.fn('codeGraph.activateCleanStagedSnap
 
   yield* sql.withTransaction(
     Effect.gen(function* () {
-      yield* materializeCleanSnapshotAnalysisSummary(sql, snapshot);
-      yield* recordSnapshotAnalysisReceipt(sql, snapshot);
       yield* recordCompactLexicalFormat(sql, snapshot.id, copiedTerms, copiedTerms.postingCount, snapshot.symbolCount);
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
       if (!snapshot.dirty && reusableBaseReceipt) {
@@ -4159,11 +4237,12 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
         yield* sql`DELETE FROM snapshots WHERE id = ${snapshot.id}`;
         yield* sql`
           INSERT INTO snapshots (
-            id, repository_id, worktree_id, commit_id, base_snapshot_id, extractor_set,
+            id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id, extractor_set,
             dirty, overlay_fingerprint, state, file_count, symbol_count, edge_count, started_at, completed_at
           ) VALUES (
             ${snapshot.id}, ${snapshot.repositoryId}, ${snapshot.worktreeId}, ${snapshot.commit},
-            ${snapshot.baseSnapshotId ?? null}, ${snapshot.extractorSet}, ${snapshot.dirty ? 1 : 0},
+            ${snapshot.graphContentId ?? snapshot.id}, ${snapshot.baseSnapshotId ?? null}, ${snapshot.extractorSet},
+            ${snapshot.dirty ? 1 : 0},
             ${snapshot.overlayFingerprint ?? null}, 'building', ${snapshot.fileCount}, ${snapshot.symbolCount},
             ${snapshot.edgeCount},
             ${startedAt}, NULL
@@ -4344,13 +4423,6 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
           expectedCompactSymbols,
         );
       }
-      if (baseSnapshotId) {
-        yield* ensureReadySnapshotAnalysisSummary(sql, baseSnapshotId);
-        yield* materializeOverlaySnapshotAnalysisSummary(sql, snapshot, baseSnapshotId);
-      } else {
-        yield* materializeCleanSnapshotAnalysisSummary(sql, snapshot);
-      }
-      yield* recordSnapshotAnalysisReceipt(sql, snapshot);
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
       if (activated && !baseSnapshotId && !snapshot.dirty && reusableBaseReceipt) {
         yield* observe('copying-lookup-keys', 'started');
@@ -4875,8 +4947,6 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
       Effect.gen(function* () {
         yield* assertPersistentBuildOwner(sql, snapshot.id, ownerToken);
         yield* assertPersistentMaterializationComplete(sql, snapshot.id, ownerToken);
-        yield* materializeSnapshotAnalysisEdgeCounts(sql, snapshot.id);
-        yield* recordSnapshotAnalysisReceipt(sql, snapshot);
         yield* publishCompactLexicalFormat(sql, snapshot.id, compactLexicalReceipt);
         yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
         if (reusableBaseReceipt) {
@@ -4962,12 +5032,19 @@ const persistedIncrementalFactCounts = Effect.fn('codeGraph.persistedIncremental
     readonly symbols: number;
   }>`
     SELECT
-      base.file_count AS files,
+      base.file_count
+        - (
+            SELECT COUNT(*)
+            FROM snapshot_files AS file
+            JOIN activation_incremental_paths AS changed ON changed.path = file.path
+            WHERE file.snapshot_id = base.id
+          )
+        + (SELECT COUNT(*) FROM activation_files) AS files,
       base.symbol_count
         - (
             SELECT COUNT(*)
             FROM symbols AS symbol
-            JOIN activation_files AS changed ON changed.path = symbol.path
+            JOIN activation_incremental_paths AS changed ON changed.path = symbol.path
             WHERE symbol.snapshot_id = base.id
           )
         + (SELECT COUNT(*) FROM activation_symbols) AS symbols,
@@ -4975,7 +5052,7 @@ const persistedIncrementalFactCounts = Effect.fn('codeGraph.persistedIncremental
         - (
             SELECT COUNT(*)
             FROM edges AS edge
-            JOIN activation_files AS changed ON changed.path = edge.evidence_path
+            JOIN activation_incremental_paths AS changed ON changed.path = edge.evidence_path
             WHERE edge.snapshot_id = base.id
           )
         + (SELECT COUNT(*) FROM activation_edges) AS edges
@@ -4997,6 +5074,102 @@ const persistedIncrementalFactCounts = Effect.fn('codeGraph.persistedIncremental
   return counts;
 });
 
+const activateCleanSnapshotAlias = Effect.fn('codeGraph.activateCleanSnapshotAlias')(function* (
+  sql: SqlClient.SqlClient,
+  identity: RepositoryIdentity,
+  snapshot: CodeGraphSnapshot,
+  baseSnapshotId: string,
+) {
+  yield* configureConnection(sql);
+  if (snapshot.dirty || snapshot.baseSnapshotId !== baseSnapshotId) {
+    return yield* Effect.fail(new CodeGraphStoreError('Clean snapshot alias has the wrong base snapshot.'));
+  }
+  const baseRows = yield* sql<SnapshotRow>`
+    SELECT * FROM snapshots
+    WHERE id = ${baseSnapshotId} AND repository_id = ${snapshot.repositoryId}
+      AND extractor_set = ${snapshot.extractorSet} AND state = 'ready'
+      AND dirty = 0 AND base_snapshot_id IS NULL
+    LIMIT 1
+  `;
+  const base = baseRows[0];
+  if (
+    !base ||
+    Number(base.file_count) !== snapshot.fileCount ||
+    Number(base.symbol_count) !== snapshot.symbolCount ||
+    Number(base.edge_count) !== snapshot.edgeCount ||
+    !(yield* selectReusableBaseReceipt(baseSnapshotId))
+  ) {
+    return yield* Effect.fail(new CodeGraphStoreError(`Reusable clean base ${baseSnapshotId} is unavailable.`));
+  }
+  const baseGraphContentId = Option.getOrUndefined(sqlTextOption(base.graph_content_id)) ?? base.id;
+  if (snapshot.graphContentId !== undefined && snapshot.graphContentId !== baseGraphContentId) {
+    return yield* Effect.fail(new CodeGraphStoreError('Clean snapshot alias has different graph content.'));
+  }
+  const prior = yield* sql<SnapshotRow>`SELECT * FROM snapshots WHERE id = ${snapshot.id} LIMIT 1`;
+  if (prior[0]?.state === 'ready') {
+    const existing = snapshotFromRow(prior[0]);
+    if (
+      existing.baseSnapshotId === baseSnapshotId &&
+      existing.commit === snapshot.commit &&
+      existing.repositoryId === snapshot.repositoryId &&
+      existing.extractorSet === snapshot.extractorSet &&
+      (existing.graphContentId ?? existing.id) === (snapshot.graphContentId ?? baseGraphContentId) &&
+      !existing.dirty
+    ) {
+      return;
+    }
+    return yield* Effect.fail(
+      new CodeGraphStoreError(`Snapshot alias ${snapshot.id} already has incompatible content.`),
+    );
+  }
+  const completedAt = new Date().toISOString();
+  yield* sql.withTransaction(
+    Effect.gen(function* () {
+      yield* upsertRepository(sql, identity);
+      yield* purgeSnapshotTerms(sql, snapshot.id);
+      yield* sql`DELETE FROM snapshots WHERE id = ${snapshot.id}`;
+      yield* sql`
+        INSERT INTO snapshots (
+          id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id, extractor_set,
+          dirty, overlay_fingerprint, state, file_count, symbol_count, edge_count,
+          started_at, completed_at
+        ) VALUES (
+          ${snapshot.id}, ${snapshot.repositoryId}, ${snapshot.worktreeId}, ${snapshot.commit},
+          ${snapshot.graphContentId ?? baseGraphContentId}, ${baseSnapshotId}, ${snapshot.extractorSet},
+          0, NULL, 'ready', ${snapshot.fileCount},
+          ${snapshot.symbolCount}, ${snapshot.edgeCount}, ${completedAt}, ${completedAt}
+        )
+      `;
+      yield* sql`
+        INSERT INTO workspace_scopes (
+          snapshot_id, id, build_system, name, root, provenance, diagnostics_json
+        )
+        SELECT ${snapshot.id}, id, build_system, name, root, provenance, diagnostics_json
+        FROM workspace_scopes WHERE snapshot_id = ${baseSnapshotId}
+      `;
+      yield* sql`
+        INSERT INTO workspace_components (
+          snapshot_id, id, workspace_id, build_system, kind, name, root, resolution_domain,
+          languages_json, source_roots_json, workspace_roots_json, provenance, diagnostics_json
+        )
+        SELECT ${snapshot.id}, id, workspace_id, build_system, kind, name, root, resolution_domain,
+          languages_json, source_roots_json, workspace_roots_json, provenance, diagnostics_json
+        FROM workspace_components WHERE snapshot_id = ${baseSnapshotId}
+      `;
+      yield* sql`
+        INSERT INTO workspace_component_dependencies (
+          snapshot_id, source_component_id, target_component_id, provenance, evidence
+        )
+        SELECT ${snapshot.id}, source_component_id, target_component_id, provenance, evidence
+        FROM workspace_component_dependencies WHERE snapshot_id = ${baseSnapshotId}
+      `;
+      yield* sql`INSERT INTO lexical_compact_snapshots (snapshot_id) VALUES (${snapshot.id})`;
+      yield* publishCompactLexicalFormat(sql, snapshot.id, {postingCount: 0, symbolCount: 0, termCount: 0});
+      yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
+    }),
+  );
+});
+
 const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersistedIncrementalSnapshot')(function* (
   sql: SqlClient.SqlClient,
   identity: RepositoryIdentity,
@@ -5009,7 +5182,7 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
   let compactLexicalReceipt = Option.none<CompactLexicalFormatReceipt>();
   yield* configureConnection(sql);
   yield* observe('validating-input', 'started');
-  if (!snapshot.dirty || snapshot.baseSnapshotId !== baseSnapshotId) {
+  if (snapshot.baseSnapshotId !== baseSnapshotId) {
     return yield* Effect.fail(new CodeGraphStoreError('Persisted incremental activation has the wrong base snapshot.'));
   }
   const completedAt = new Date().toISOString();
@@ -5026,7 +5199,11 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
           new CodeGraphStoreError(`Reusable base receipt ${baseSnapshotId} is unavailable or incomplete.`),
         );
       }
-      if (!(yield* persistedIncrementalSurfaceMatches(sql, baseSnapshotId))) {
+      const closureRows = yield* sql<{readonly value: string}>`
+        SELECT value FROM activation_state WHERE key = 'resolution_closure' LIMIT 1
+      `;
+      const fullResolutionClosure = closureRows[0]?.value === 'full';
+      if (!fullResolutionClosure && !(yield* persistedIncrementalSurfaceMatches(sql, baseSnapshotId))) {
         return yield* Effect.fail(new CodeGraphStoreError('Persisted incremental resolution surface changed.'));
       }
       const changedPathsOnly = yield* sql<{readonly id: string}>`
@@ -5050,12 +5227,18 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
                AND NOT EXISTS (
                  SELECT 1 FROM symbols AS base
                  WHERE base.snapshot_id = ${baseSnapshotId} AND base.id = edge.source_id
+                   AND NOT EXISTS (
+                     SELECT 1 FROM activation_incremental_paths AS changed WHERE changed.path = base.path
+                   )
                ))
            OR (edge.target_id IS NOT NULL
                AND NOT EXISTS (SELECT 1 FROM activation_symbols AS current WHERE current.id = edge.target_id)
                AND NOT EXISTS (
                  SELECT 1 FROM symbols AS base
                  WHERE base.snapshot_id = ${baseSnapshotId} AND base.id = edge.target_id
+                   AND NOT EXISTS (
+                     SELECT 1 FROM activation_incremental_paths AS changed WHERE changed.path = base.path
+                   )
                ))
         LIMIT 1
       `;
@@ -5099,12 +5282,14 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
         yield* sql`DELETE FROM snapshots WHERE id = ${snapshot.id}`;
         yield* sql`
           INSERT INTO snapshots (
-            id, repository_id, worktree_id, commit_id, base_snapshot_id, extractor_set,
+            id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id, extractor_set,
             dirty, overlay_fingerprint, state, file_count, symbol_count, edge_count,
             started_at, completed_at
           ) VALUES (
             ${snapshot.id}, ${snapshot.repositoryId}, ${snapshot.worktreeId}, ${snapshot.commit},
-            ${baseSnapshotId}, ${snapshot.extractorSet}, 1, ${snapshot.overlayFingerprint ?? null},
+            ${snapshot.graphContentId ?? snapshot.id}, ${baseSnapshotId}, ${snapshot.extractorSet},
+            ${snapshot.dirty ? 1 : 0},
+            ${snapshot.dirty ? (snapshot.overlayFingerprint ?? null) : null},
             'building', ${snapshot.fileCount}, ${snapshot.symbolCount}, ${snapshot.edgeCount},
             ${startedAt}, NULL
           )
@@ -5140,6 +5325,14 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
           SELECT ${snapshot.id}, path, content_hash, language, mode, size, source
           FROM activation_files
         `;
+        yield* sql`
+          INSERT INTO snapshot_file_deletions (snapshot_id, path)
+          SELECT ${snapshot.id}, base.path
+          FROM snapshot_files AS base
+          JOIN activation_incremental_paths AS changed ON changed.path = base.path
+          WHERE base.snapshot_id = ${baseSnapshotId}
+            AND NOT EXISTS (SELECT 1 FROM activation_files AS current WHERE current.path = base.path)
+        `;
         yield* observe('copying-files', 'completed', Number(staged.files));
         yield* observe('copying-symbols', 'started');
         yield* sql`
@@ -5165,7 +5358,7 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
           INSERT INTO snapshot_symbol_deletions (snapshot_id, symbol_id)
           SELECT ${snapshot.id}, base.id
           FROM symbols AS base
-          JOIN activation_files AS changed ON changed.path = base.path
+          JOIN activation_incremental_paths AS changed ON changed.path = base.path
           WHERE base.snapshot_id = ${baseSnapshotId}
             AND NOT EXISTS (SELECT 1 FROM activation_symbols AS current WHERE current.id = base.id)
         `;
@@ -5183,15 +5376,12 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
           INSERT INTO snapshot_edge_deletions (snapshot_id, edge_id)
           SELECT ${snapshot.id}, base.id
           FROM edges AS base
-          JOIN activation_files AS changed ON changed.path = base.evidence_path
+          JOIN activation_incremental_paths AS changed ON changed.path = base.evidence_path
           WHERE base.snapshot_id = ${baseSnapshotId}
             AND NOT EXISTS (SELECT 1 FROM activation_edges AS current WHERE current.id = base.id)
         `;
         yield* observe('copying-edges', 'completed', Number(staged.edges));
       }
-      yield* ensureReadySnapshotAnalysisSummary(sql, baseSnapshotId);
-      yield* materializeOverlaySnapshotAnalysisSummary(sql, snapshot, baseSnapshotId);
-      yield* recordSnapshotAnalysisReceipt(sql, snapshot);
       if (existing[0]?.state !== 'ready') {
         if (Option.isNone(compactLexicalReceipt)) {
           return yield* Effect.fail(new CodeGraphStoreError('Persisted incremental lexical receipt is unavailable.'));
@@ -5261,6 +5451,7 @@ function persistentSnapshotBuildIdentityMatches(current: CodeGraphSnapshot, requ
   return (
     current.repositoryId === requested.repositoryId &&
     current.commit === requested.commit &&
+    (current.graphContentId ?? current.id) === (requested.graphContentId ?? requested.id) &&
     current.dirty === requested.dirty &&
     current.extractorSet === requested.extractorSet &&
     current.baseSnapshotId === requested.baseSnapshotId &&
@@ -5345,11 +5536,12 @@ const claimPersistentSnapshotBuild = Effect.fn('codeGraph.claimPersistentSnapsho
         } else {
           yield* sql`
           INSERT INTO snapshots (
-            id, repository_id, worktree_id, commit_id, base_snapshot_id, extractor_set,
+            id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id, extractor_set,
             dirty, overlay_fingerprint, state, file_count, symbol_count, edge_count, started_at
           ) VALUES (
             ${snapshot.id}, ${snapshot.repositoryId}, ${snapshot.worktreeId}, ${snapshot.commit},
-            ${snapshot.baseSnapshotId ?? null}, ${snapshot.extractorSet}, ${snapshot.dirty ? 1 : 0},
+            ${snapshot.graphContentId ?? snapshot.id}, ${snapshot.baseSnapshotId ?? null},
+            ${snapshot.extractorSet}, ${snapshot.dirty ? 1 : 0},
             ${snapshot.overlayFingerprint ?? null}, 'building', 0, 0, 0, ${new Date().toISOString()}
           )
         `;
@@ -7805,14 +7997,34 @@ const preparePersistedIncrementalActivation = Effect.fn('codeGraph.preparePersis
   baseSnapshotId: string,
   files: readonly CodeGraphInventoryFile[],
   facts: readonly CodeGraphFileFacts[],
+  options: {
+    readonly deletedPaths?: readonly string[];
+    readonly resolutionClosure?: 'changed' | 'full';
+  } = {},
 ) {
   const sql = yield* SqlClient.SqlClient;
-  if (files.length === 0 || facts.length !== files.length) return false;
+  const resolutionClosure = options.resolutionClosure ?? 'changed';
+  const deletedPaths = [...new Set(options.deletedPaths ?? [])];
+  if (
+    (files.length === 0 && (resolutionClosure !== 'full' || deletedPaths.length === 0)) ||
+    facts.length !== files.length
+  ) {
+    return false;
+  }
   const paths = new Set(files.map(file => file.path));
   if (paths.size !== files.length || facts.some(file => !paths.has(file.path))) return false;
+  if (deletedPaths.some(path => paths.has(path))) return false;
   if (!(yield* selectReusableBaseReceipt(baseSnapshotId))) return false;
 
   yield* prepareActivationTables(sql);
+  const incrementalPaths = [...paths, ...deletedPaths].sort();
+  for (const batch of chunk(incrementalPaths, ACTIVATION_FILE_BATCH_ROWS)) {
+    yield* sql.unsafe(
+      `INSERT INTO activation_incremental_paths (path)
+       VALUES ${batch.map(() => '(?)').join(', ')}`,
+      batch,
+    );
+  }
   yield* stageActivationFiles(sql, files);
   const symbols = facts.flatMap(file => file.symbols);
   yield* stageActivationSymbols(sql, symbols);
@@ -7825,14 +8037,17 @@ const preparePersistedIncrementalActivation = Effect.fn('codeGraph.preparePersis
     sql,
     facts.flatMap(file => file.references ?? []),
   );
-  const safe = yield* persistedIncrementalSurfaceMatches(sql, baseSnapshotId);
+  const safe = resolutionClosure === 'full' || (yield* persistedIncrementalSurfaceMatches(sql, baseSnapshotId));
   if (!safe) {
     yield* prepareActivationTables(sql);
     return false;
   }
   yield* sql`
     INSERT INTO activation_state (key, value)
-    VALUES ('mode', 'persisted-delta'), ('base_snapshot_id', ${baseSnapshotId})
+    VALUES
+      ('mode', 'persisted-delta'),
+      ('base_snapshot_id', ${baseSnapshotId}),
+      ('resolution_closure', ${resolutionClosure})
   `;
   return true;
 });
@@ -8190,7 +8405,7 @@ export function codeGraphPersistedDeltaResolutionPageStatement(
          AND (candidate.relation <> 'overrides' OR lookup.symbol_id IS NOT candidate.source_id)
         WHERE NOT EXISTS (
           SELECT 1
-          FROM activation_files AS changed
+          FROM activation_incremental_paths AS changed
           WHERE changed.path = lookup.evidence_path
         )
           AND NOT EXISTS (
@@ -9192,7 +9407,6 @@ const promoteSnapshot = Effect.fn('codeGraph.promoteSnapshot')(function* (
   const sql = yield* SqlClient.SqlClient;
   yield* configureConnection(sql);
   yield* initializeSchema(sql);
-  yield* sql.withTransaction(ensureReadySnapshotAnalysisSummary(sql, snapshotId));
   const retainedWorktreeIds = [...new Set([...activeWorktreeIds, identity.worktreeId])];
   yield* sql.withTransaction(
     Effect.gen(function* () {
@@ -9882,6 +10096,67 @@ const selectReadySnapshotForCommit = Effect.fn('codeGraph.selectReadySnapshotFor
     LIMIT 1
   `;
   return rows[0] ? snapshotFromRow(rows[0]) : undefined;
+});
+
+const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(function* (
+  repositoryId: string,
+  extractorSet: string,
+  workspaceFingerprint: string,
+  fileSetFingerprint: string,
+  graphContentId?: string,
+) {
+  const sql = yield* SqlClient.SqlClient;
+  yield* configureConnection(sql);
+  const candidates = yield* sql<SnapshotRow>`
+    SELECT snapshot.*
+    FROM snapshots AS snapshot
+    JOIN snapshot_reuse_receipts AS receipt ON receipt.snapshot_id = snapshot.id
+    WHERE snapshot.repository_id = ${repositoryId}
+      AND snapshot.extractor_set = ${extractorSet}
+      AND snapshot.state = 'ready'
+      AND snapshot.dirty = 0
+      AND snapshot.base_snapshot_id IS NULL
+      AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
+      AND receipt.resolution_surface_version = 1
+      AND receipt.workspace_fingerprint = ${workspaceFingerprint}
+    ORDER BY
+      CASE WHEN snapshot.graph_content_id = ${graphContentId ?? null} THEN 0 ELSE 1 END,
+      CASE WHEN receipt.file_set_fingerprint = ${fileSetFingerprint} THEN 0 ELSE 1 END,
+      snapshot.completed_at DESC,
+      snapshot.id
+    LIMIT 1
+  `;
+  const row = candidates[0];
+  if (!row) return undefined;
+  const receipt = yield* selectReusableBaseReceipt(row.id);
+  if (!receipt) return undefined;
+  const files = yield* sql<{
+    readonly content_hash: string;
+    readonly language: string;
+    readonly mode: string;
+    readonly path: string;
+    readonly size: number;
+    readonly source: string;
+  }>`
+    SELECT content_hash, language, mode, path, size, source
+    FROM snapshot_files
+    WHERE snapshot_id = ${row.id}
+    ORDER BY path
+  `;
+  if (files.length !== Number(row.file_count) || files.some(file => file.source !== 'commit')) return undefined;
+  return {
+    files: files.map(file => ({
+      blobId: `snapshot:${file.content_hash}`,
+      contentHash: file.content_hash,
+      language: file.language,
+      mode: file.mode,
+      path: file.path,
+      size: Number(file.size),
+      source: 'commit' as const,
+    })),
+    receipt,
+    snapshot: snapshotFromRow(row),
+  } satisfies CodeGraphReusableCleanBase;
 });
 
 const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt')(function* (snapshotId: string) {
@@ -12576,6 +12851,7 @@ function snapshotFromRow(row: SnapshotRow): CodeGraphSnapshot {
     edgeCount: row.edge_count,
     extractorSet: row.extractor_set,
     fileCount: row.file_count,
+    graphContentId: Option.getOrUndefined(sqlTextOption(row.graph_content_id)),
     id: row.id,
     overlayFingerprint: Option.getOrUndefined(sqlTextOption(row.overlay_fingerprint)),
     repositoryId: row.repository_id,

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -470,6 +470,13 @@ export interface CodeGraphStoreShape {
     facts: readonly CodeGraphCacheFactInput[],
     extractorSet: string,
   ) => Effect.Effect<void, CodeGraphStoreError>;
+  readonly cacheMaterializedFileShards: (
+    databasePath: string,
+    files: readonly CodeGraphInventoryFile[],
+    facts: readonly CodeGraphCacheFactInput[],
+    extractorSet: string,
+    derivationIdentity: string,
+  ) => Effect.Effect<void, CodeGraphStoreError>;
   readonly acquireSnapshotLease: (
     databasePath: string,
     snapshotId: string,
@@ -519,6 +526,12 @@ export interface CodeGraphStoreShape {
     files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[],
     extractorSet: string,
     options?: {readonly decode?: boolean},
+  ) => Effect.Effect<LoadedCodeGraphFacts, CodeGraphStoreError>;
+  readonly loadMaterializedFileShards: (
+    databasePath: string,
+    files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[],
+    extractorSet: string,
+    derivationIdentity: string,
   ) => Effect.Effect<LoadedCodeGraphFacts, CodeGraphStoreError>;
   readonly loadGraph: (databasePath: string, snapshotId: string) => Effect.Effect<StoredCodeGraph, CodeGraphStoreError>;
   readonly loadSymbols: (
@@ -1031,6 +1044,7 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
                       identity,
                       snapshot,
                       mode.baseSnapshotId,
+                      reusableBaseReceipt,
                       promotionLease,
                       onProgress,
                     ),
@@ -1100,6 +1114,24 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
               }),
             );
           }).pipe(Effect.mapError(cause => storeError('cache code graph file facts', cause))),
+        cacheMaterializedFileShards: (databasePath, files, facts, extractorSet, derivationIdentity) =>
+          Effect.gen(function* () {
+            const bounded = yield* Effect.sync(() => facts.map(ensureBoundedCodeGraphFact));
+            yield* prepare(databasePath);
+            yield* useDatabase(
+              databasePath,
+              Effect.gen(function* () {
+                const sql = yield* SqlClient.SqlClient;
+                yield* ensureSchemaInitialized(databasePath, sql);
+                yield* withWriterGate(
+                  databasePath,
+                  sql.withTransaction(
+                    storeMaterializedFileShards(sql, files, bounded, extractorSet, derivationIdentity),
+                  ),
+                );
+              }),
+            );
+          }).pipe(Effect.mapError(cause => storeError('cache materialized code graph file shards', cause))),
         promote: (databasePath, identity, snapshotId, activeWorktreeIds) =>
           prepare(databasePath).pipe(
             Effect.andThen(
@@ -1227,6 +1259,13 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
               useReadOnlyDatabase(databasePath, selectCachedFacts(files, extractorSet, options?.decode !== false)),
             ),
             Effect.mapError(cause => storeError('load cached code graph facts', cause)),
+          ),
+        loadMaterializedFileShards: (databasePath, files, extractorSet, derivationIdentity) =>
+          prepare(databasePath).pipe(
+            Effect.andThen(
+              useReadOnlyDatabase(databasePath, selectMaterializedFileShards(files, extractorSet, derivationIdentity)),
+            ),
+            Effect.mapError(cause => storeError('load materialized code graph file shards', cause)),
           ),
         loadGraph: (databasePath, snapshotId) =>
           prepare(databasePath).pipe(
@@ -2005,7 +2044,7 @@ function inferredCodeGraphWriterLockPath(path: Path.Path, databasePath: string):
   );
 }
 
-type PersistentExtensionGroup = 'analysis' | 'build' | 'lexical';
+type PersistentExtensionGroup = 'analysis' | 'build' | 'lexical' | 'shards';
 
 export type CodeGraphPersistentSchemaMigrationPhase =
   | 'added-materialization-plan'
@@ -2417,6 +2456,52 @@ const PERSISTENT_EXTENSION_TABLES = [
       /CHECK\s*\(\s*term_count\s*>=\s*0\s*\)/i,
     ],
   },
+  {
+    columns: [
+      requiredColumn('id', 'TEXT', 1),
+      requiredColumn('content_hash', 'TEXT'),
+      requiredColumn('extractor_set', 'TEXT'),
+      requiredColumn('derivation_identity', 'TEXT'),
+      requiredColumn('path_hint', 'TEXT'),
+      requiredColumn('facts_json', 'TEXT'),
+      requiredColumn('created_at', 'TEXT'),
+      requiredColumn('last_used_at', 'TEXT'),
+    ],
+    createSql: `CREATE TABLE IF NOT EXISTS materialized_file_shards (
+      id TEXT PRIMARY KEY NOT NULL,
+      content_hash TEXT NOT NULL,
+      extractor_set TEXT NOT NULL,
+      derivation_identity TEXT NOT NULL,
+      path_hint TEXT NOT NULL,
+      facts_json TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      last_used_at TEXT NOT NULL,
+      UNIQUE (content_hash, extractor_set, derivation_identity, path_hint)
+    ) WITHOUT ROWID`,
+    foreignKeys: [],
+    group: 'shards',
+    name: 'materialized_file_shards',
+    uniqueKeys: [['content_hash', 'extractor_set', 'derivation_identity', 'path_hint']],
+  },
+  {
+    columns: [
+      requiredColumn('snapshot_id', 'TEXT', 1),
+      requiredColumn('path', 'TEXT', 2),
+      requiredColumn('shard_id', 'TEXT'),
+    ],
+    createSql: `CREATE TABLE IF NOT EXISTS snapshot_file_shards (
+      snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+      path TEXT NOT NULL,
+      shard_id TEXT NOT NULL REFERENCES materialized_file_shards(id) ON DELETE CASCADE,
+      PRIMARY KEY (snapshot_id, path)
+    ) WITHOUT ROWID`,
+    foreignKeys: [
+      {from: 'snapshot_id', onDelete: 'CASCADE', table: 'snapshots', to: 'id'},
+      {from: 'shard_id', onDelete: 'CASCADE', table: 'materialized_file_shards', to: 'id'},
+    ],
+    group: 'shards',
+    name: 'snapshot_file_shards',
+  },
 ] as const satisfies readonly PersistentExtensionTableContract[];
 
 const LEGACY_SNAPSHOT_BUILD_OWNERS_CONTRACT = {
@@ -2457,7 +2542,7 @@ const LEGACY_BUILDING_REFERENCES_V3_CONTRACT = {
 
 const REMOVED_BETA30_INDEXES = ['snapshot_symbol_lookup_key', 'terms_lookup', 'terms_symbol'] as const;
 export const CODE_GRAPH_PERSISTENT_EXTENSION_TABLE_NAMES = PERSISTENT_EXTENSION_TABLES.map(table => table.name);
-export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 5;
+export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 6;
 
 function persistentExtensionTableInspection(
   sql: SqlClient.SqlClient,
@@ -4092,6 +4177,7 @@ const activateCleanStagedSnapshot = Effect.fn('codeGraph.activateCleanStagedSnap
   yield* sql.withTransaction(
     Effect.gen(function* () {
       yield* recordCompactLexicalFormat(sql, snapshot.id, copiedTerms, copiedTerms.postingCount, snapshot.symbolCount);
+      yield* associateSnapshotFileShards(sql, snapshot.id, snapshot.extractorSet, reusableBaseReceipt);
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
       if (!snapshot.dirty && reusableBaseReceipt) {
         yield* sql`
@@ -4422,6 +4508,8 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
           compactLexicalReceipt.postingCount,
           expectedCompactSymbols,
         );
+        if (baseSnapshotId) yield* inheritSnapshotFileShards(sql, snapshot.id, baseSnapshotId);
+        yield* associateSnapshotFileShards(sql, snapshot.id, snapshot.extractorSet, reusableBaseReceipt);
       }
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
       if (activated && !baseSnapshotId && !snapshot.dirty && reusableBaseReceipt) {
@@ -4948,6 +5036,7 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
         yield* assertPersistentBuildOwner(sql, snapshot.id, ownerToken);
         yield* assertPersistentMaterializationComplete(sql, snapshot.id, ownerToken);
         yield* publishCompactLexicalFormat(sql, snapshot.id, compactLexicalReceipt);
+        yield* associateSnapshotFileShards(sql, snapshot.id, snapshot.extractorSet, reusableBaseReceipt);
         yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
         if (reusableBaseReceipt) {
           yield* sql`
@@ -5163,6 +5252,11 @@ const activateCleanSnapshotAlias = Effect.fn('codeGraph.activateCleanSnapshotAli
         SELECT ${snapshot.id}, source_component_id, target_component_id, provenance, evidence
         FROM workspace_component_dependencies WHERE snapshot_id = ${baseSnapshotId}
       `;
+      yield* sql`
+        INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id)
+        SELECT ${snapshot.id}, path, shard_id
+        FROM snapshot_file_shards WHERE snapshot_id = ${baseSnapshotId}
+      `;
       yield* sql`INSERT INTO lexical_compact_snapshots (snapshot_id) VALUES (${snapshot.id})`;
       yield* publishCompactLexicalFormat(sql, snapshot.id, {postingCount: 0, symbolCount: 0, termCount: 0});
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
@@ -5175,6 +5269,7 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
   identity: RepositoryIdentity,
   snapshot: CodeGraphSnapshot,
   baseSnapshotId: string,
+  reusableBaseReceipt: CodeGraphReusableBaseReceiptInput | undefined,
   promotionLease: Option.Option<CodeGraphActivationLease> = Option.none(),
   onProgress?: CodeGraphActivationProgressCallback,
 ) {
@@ -5393,6 +5488,8 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
           Number(staged.terms),
           Number(staged.symbols),
         );
+        yield* inheritSnapshotFileShards(sql, snapshot.id, baseSnapshotId);
+        yield* associateSnapshotFileShards(sql, snapshot.id, snapshot.extractorSet, reusableBaseReceipt);
       }
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
       yield* insertActivationLease(sql, snapshot.id, promotionLease);
@@ -5443,6 +5540,122 @@ function storeFreshFacts(
           facts_json = excluded.facts_json,
           created_at = excluded.created_at
       `;
+    }
+  });
+}
+
+export function materializedShardDerivationIdentity(
+  extractorSet: string,
+  workspaceFingerprint: string,
+  fileSetFingerprint: string,
+): string {
+  return `cgfd_${sha256HexSync(
+    `materialized-file-derivation-v1\n${extractorSet}\n${workspaceFingerprint}\n${fileSetFingerprint}`,
+  ).slice(0, 40)}`;
+}
+
+export function materializedFileShardIdentity(
+  contentHash: string,
+  extractorSet: string,
+  derivationIdentity: string,
+  path: string,
+): string {
+  return `cgfs_${sha256HexSync(
+    `materialized-file-shard-v1\n${contentHash}\n${extractorSet}\n${derivationIdentity}\n${path}`,
+  ).slice(0, 40)}`;
+}
+
+const associateSnapshotFileShards = Effect.fn('codeGraph.associateSnapshotFileShards')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  extractorSet: string,
+  receipt: CodeGraphReusableBaseReceiptInput | undefined,
+) {
+  if (!receipt) return;
+  const derivationIdentity = materializedShardDerivationIdentity(
+    extractorSet,
+    receipt.workspaceFingerprint,
+    receipt.fileSetFingerprint,
+  );
+  yield* sql`
+    INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id)
+    SELECT ${snapshotId}, file.path, shard.id
+    FROM snapshot_files AS file
+    JOIN materialized_file_shards AS shard
+      ON shard.content_hash = file.content_hash
+     AND shard.path_hint = file.path
+     AND shard.extractor_set = ${extractorSet}
+     AND shard.derivation_identity = ${derivationIdentity}
+    WHERE file.snapshot_id = ${snapshotId}
+    ON CONFLICT(snapshot_id, path) DO UPDATE SET shard_id = excluded.shard_id
+  `;
+});
+
+const inheritSnapshotFileShards = Effect.fn('codeGraph.inheritSnapshotFileShards')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  baseSnapshotId: string,
+) {
+  yield* sql`
+    INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id)
+    SELECT ${snapshotId}, base.path, base.shard_id
+    FROM snapshot_file_shards AS base
+    WHERE base.snapshot_id = ${baseSnapshotId}
+      AND NOT EXISTS (
+        SELECT 1 FROM snapshot_files AS current
+        WHERE current.snapshot_id = ${snapshotId} AND current.path = base.path
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM snapshot_file_deletions AS deleted
+        WHERE deleted.snapshot_id = ${snapshotId} AND deleted.path = base.path
+      )
+    ON CONFLICT(snapshot_id, path) DO NOTHING
+  `;
+});
+
+function storeMaterializedFileShards(
+  sql: SqlClient.SqlClient,
+  files: readonly CodeGraphInventoryFile[],
+  facts: readonly BoundedCodeGraphFact[],
+  extractorSet: string,
+  derivationIdentity: string,
+) {
+  return Effect.gen(function* () {
+    const filesByPath = new Map(files.map(file => [file.path, file]));
+    if (filesByPath.size !== files.length || facts.length !== files.length) {
+      return yield* Effect.fail(new CodeGraphStoreError('Materialized file shard inputs are inconsistent.'));
+    }
+    const now = new Date().toISOString();
+    for (const bounded of facts) {
+      const file = filesByPath.get(bounded.facts.path);
+      if (!file) {
+        return yield* Effect.fail(
+          new CodeGraphStoreError(
+            `Materialized file shard does not match the indexed inventory: ${bounded.facts.path}.`,
+          ),
+        );
+      }
+      const shardId = materializedFileShardIdentity(file.contentHash, extractorSet, derivationIdentity, file.path);
+      const stored = yield* sql<{readonly id: string}>`
+        INSERT INTO materialized_file_shards (
+          id, content_hash, extractor_set, derivation_identity, path_hint,
+          facts_json, created_at, last_used_at
+        ) VALUES (
+          ${shardId}, ${file.contentHash}, ${extractorSet}, ${derivationIdentity}, ${file.path},
+          ${bounded.json}, ${now}, ${now}
+        )
+        ON CONFLICT(id) DO UPDATE SET
+          facts_json = excluded.facts_json,
+          last_used_at = excluded.last_used_at
+        WHERE materialized_file_shards.content_hash = excluded.content_hash
+          AND materialized_file_shards.extractor_set = excluded.extractor_set
+          AND materialized_file_shards.derivation_identity = excluded.derivation_identity
+          AND materialized_file_shards.path_hint = excluded.path_hint
+        RETURNING id
+      `;
+      if (stored[0]?.id !== shardId) {
+        return yield* Effect.fail(new CodeGraphStoreError(`Materialized file shard identity collision: ${shardId}.`));
+      }
     }
   });
 }
@@ -9745,6 +9958,12 @@ const RETIRED_SNAPSHOT_CLEANUP_SPECS = [
     batchRows: 5_000,
     keyColumns: ['snapshot_id', 'path'],
     maximumBatchRows: 20_000,
+    table: 'snapshot_file_shards',
+  },
+  {
+    batchRows: 5_000,
+    keyColumns: ['snapshot_id', 'path'],
+    maximumBatchRows: 20_000,
     table: 'snapshot_files',
   },
   {
@@ -10007,6 +10226,7 @@ const pruneCachedFileBlobs = Effect.fn('codeGraph.pruneCachedFileBlobs')(functio
 ) {
   if (acceptedExtractorSets === undefined) {
     yield* pruneUnreferencedFileBlobs(sql);
+    yield* pruneUnreferencedMaterializedFileShards(sql);
     return;
   }
   if (acceptedExtractorSets.length === 0) {
@@ -10023,7 +10243,19 @@ const pruneCachedFileBlobs = Effect.fn('codeGraph.pruneCachedFileBlobs')(functio
         )`,
     acceptedExtractorSets,
   );
+  yield* pruneUnreferencedMaterializedFileShards(sql);
 });
+
+const pruneUnreferencedMaterializedFileShards = Effect.fn('codeGraph.pruneUnreferencedMaterializedFileShards')(
+  function* (sql: SqlClient.SqlClient) {
+    yield* sql.unsafe(`
+      DELETE FROM materialized_file_shards
+      WHERE NOT EXISTS (
+        SELECT 1 FROM snapshot_file_shards WHERE snapshot_file_shards.shard_id = materialized_file_shards.id
+      )
+    `);
+  },
+);
 
 const selectReadySnapshot = Effect.fn('codeGraph.selectReadySnapshot')(function* (worktreeId: string) {
   const sql = yield* SqlClient.SqlClient;
@@ -10328,6 +10560,46 @@ const selectCachedFacts = Effect.fn('codeGraph.selectCachedFacts')(function* (
         bytesByPath.set(row.path_hint, factBytes);
       } catch {
         // A malformed cache row is disposable and will be replaced after extraction.
+      }
+    }
+  }
+  return {bytes, bytesByPath, facts: output, keys} satisfies LoadedCodeGraphFacts;
+});
+
+const selectMaterializedFileShards = Effect.fn('codeGraph.selectMaterializedFileShards')(function* (
+  files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[],
+  extractorSet: string,
+  derivationIdentity: string,
+) {
+  const sql = yield* SqlClient.SqlClient;
+  yield* configureConnection(sql);
+  const output = new Map<string, CodeGraphFileFacts>();
+  const bytesByPath = new Map<string, number>();
+  const keys = new Set<string>();
+  let bytes = 0;
+  for (const batch of chunk(files, 200)) {
+    if (batch.length === 0) continue;
+    const rows = yield* sql.unsafe<{
+      readonly facts_bytes: number;
+      readonly facts_json: string;
+      readonly path_hint: string;
+    }>(
+      `SELECT path_hint, facts_json, length(CAST(facts_json AS BLOB)) AS facts_bytes
+       FROM materialized_file_shards
+       WHERE extractor_set = ? AND derivation_identity = ?
+         AND (${batch.map(() => '(content_hash = ? AND path_hint = ?)').join(' OR ')})`,
+      [extractorSet, derivationIdentity, ...batch.flatMap(file => [file.contentHash, file.path])],
+    );
+    for (const row of rows) {
+      try {
+        const bounded = ensureBoundedCodeGraphFact(JSON.parse(row.facts_json) as CodeGraphFileFacts);
+        output.set(row.path_hint, bounded.facts);
+        keys.add(row.path_hint);
+        const factBytes = Number(row.facts_bytes);
+        bytes += factBytes;
+        bytesByPath.set(row.path_hint, factBytes);
+      } catch {
+        // Materialized shards are disposable; malformed rows are ignored and rebuilt.
       }
     }
   }

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -134,6 +134,8 @@ export interface CodeGraphSnapshot {
   readonly edgeCount: number;
   readonly extractorSet: string;
   readonly fileCount: number;
+  /** Content-addressed graph input identity, independent of commit and worktree pointers. */
+  readonly graphContentId?: string;
   readonly id: string;
   readonly overlayFingerprint?: string;
   readonly repositoryId: string;
@@ -380,7 +382,7 @@ export interface CodeGraphIndexSummary {
   readonly identity: RepositoryIdentity;
   readonly materialization?: {
     readonly fallbackReason?: CodeGraphOverlayFallbackReason;
-    readonly mode: 'full' | 'incremental-overlay' | 'reused-snapshot';
+    readonly mode: 'full' | 'incremental-clean' | 'incremental-overlay' | 'reused-snapshot';
     readonly stagedFiles: number;
     readonly totalFiles: number;
   };

--- a/src/code_graph/watcher.ts
+++ b/src/code_graph/watcher.ts
@@ -15,8 +15,10 @@ import {
   SynchronizedRef,
 } from 'effect';
 import {CodeGraphIndexer, type CodeGraphIndexerShape} from './indexer.js';
-import {CommandExecutor} from '../effect/command.js';
+import {CodeGraphStore, type CodeGraphStoreShape} from './store.js';
+import {CommandExecutor, type CommandOptions} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
+import type {CommandResult} from '../types.js';
 import type {CodeGraphProgress} from './types.js';
 import {currentCodeGraphBuildStatus, type ObservedCodeGraphBuildStatus} from './build_status.js';
 import {codeGraphLayout} from './layout.js';
@@ -137,12 +139,39 @@ export class CodeGraphWatcher extends Context.Service<CodeGraphWatcher, CodeGrap
       const commandExecutor = yield* CommandExecutor;
       const systemInfo = yield* SystemInfo;
       const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const scope = yield* Effect.scope;
+      const prewarmSemaphore = yield* Semaphore.make(1);
+      const prewarmedCommits = yield* SynchronizedRef.make(new Set<string>());
       const run = (
         options: CodeGraphWatchOptions,
         initialRefresh: boolean,
         requestRefresh: () => Effect.Effect<void>,
       ) => watchRepository(fs, path, options, initialRefresh, requestRefresh);
-      const refresh = (options: CodeGraphWatchOptions) => indexRepository(indexer, options).pipe(Effect.asVoid);
+      const schedulePrewarm = (options: CodeGraphWatchOptions) =>
+        systemInfo.environment().THREADNOTE_CODE_GRAPH_PREWARM === '0'
+          ? Effect.void
+          : prewarmLikelyCleanSnapshots({
+              commandExecutor,
+              indexer,
+              options,
+              path,
+              prewarmedCommits,
+              prewarmSemaphore,
+              store,
+            }).pipe(
+              Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(FileSystem.FileSystem, fs),
+              Effect.provideService(Path.Path, path),
+              Effect.provideService(SystemInfo, systemInfo),
+              Effect.forkIn(scope),
+              Effect.asVoid,
+            );
+      const refresh = (options: CodeGraphWatchOptions) =>
+        indexRepository(indexer, options).pipe(
+          Effect.tap(() => schedulePrewarm(options)),
+          Effect.asVoid,
+        );
       const watcher = yield* makeCodeGraphWatcher(run, refresh);
       return CodeGraphWatcher.of({
         ...watcher,
@@ -542,6 +571,92 @@ function persistedRefreshStatus(status: ObservedCodeGraphBuildStatus): CodeGraph
     },
   };
 }
+
+const PREWARM_REFS = [
+  'refs/remotes/origin/main',
+  'refs/remotes/origin/master',
+  'refs/heads/main',
+  'refs/heads/master',
+] as const;
+
+/** @internal Deterministic and property-tested admission for bounded prewarming. */
+export function prewarmCandidatesFromRefOutput(output: string, currentCommit: string, maximum = 2): readonly string[] {
+  const limit = Number.isSafeInteger(maximum) && maximum > 0 ? Math.min(maximum, 2) : 2;
+  return [
+    ...new Set(
+      output
+        .split(/\r?\n/u)
+        .map(value => value.trim().toLowerCase())
+        .filter(value => /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u.test(value) && value !== currentCommit.toLowerCase()),
+    ),
+  ].slice(0, limit);
+}
+
+const prewarmLikelyCleanSnapshots = Effect.fn('codeGraph.prewarmLikelyCleanSnapshots')(function* (input: {
+  readonly commandExecutor: {
+    readonly execute: (
+      executable: string,
+      args: readonly string[],
+      options?: CommandOptions,
+    ) => Effect.Effect<CommandResult, unknown>;
+  };
+  readonly indexer: CodeGraphIndexerShape;
+  readonly options: CodeGraphWatchOptions;
+  readonly path: Path.Path;
+  readonly prewarmedCommits: SynchronizedRef.SynchronizedRef<Set<string>>;
+  readonly prewarmSemaphore: Semaphore.Semaphore;
+  readonly store: CodeGraphStoreShape;
+}) {
+  const identity = yield* resolveRepositoryIdentity(input.options.cwd);
+  const refs = yield* input.commandExecutor.execute(
+    'git',
+    ['-C', identity.repoRoot, 'for-each-ref', '--format=%(objectname)', ...PREWARM_REFS],
+    {allowFailure: true, maxOutputBytes: 16 * 1024, timeoutMs: 10_000},
+  );
+  const commits = prewarmCandidatesFromRefOutput(refs.stdout, identity.headCommit);
+  if (commits.length === 0) return;
+  const layout = codeGraphLayout(input.path, input.options.threadnoteHome, identity.checkoutId, identity.worktreeId);
+  yield* input.prewarmSemaphore.withPermit(
+    Effect.forEach(
+      commits,
+      commit =>
+        Effect.gen(function* () {
+          const key = `${identity.checkoutId}:${commit}`;
+          const reserved = yield* SynchronizedRef.modify(input.prewarmedCommits, current => {
+            if (current.has(key)) return [false, current] as const;
+            const next = new Set(current);
+            if (next.size >= 64) next.delete(next.values().next().value!);
+            next.add(key);
+            return [true, next] as const;
+          });
+          if (!reserved) return;
+          yield* input.indexer
+            .ensureCommit({
+              commit,
+              cwd: input.options.cwd,
+              threadnoteHome: input.options.threadnoteHome,
+            })
+            .pipe(
+              Effect.flatMap(lease => input.store.releaseSnapshotLease(layout.databasePath, lease.leaseToken)),
+              Effect.catch(cause =>
+                SynchronizedRef.update(input.prewarmedCommits, current => {
+                  const next = new Set(current);
+                  next.delete(key);
+                  return next;
+                }).pipe(
+                  Effect.andThen(
+                    Effect.logDebug(
+                      `Code graph prewarm skipped ${commit}: ${cause instanceof Error ? cause.message : String(cause)}`,
+                    ),
+                  ),
+                ),
+              ),
+            );
+        }),
+      {concurrency: 1, discard: true},
+    ),
+  );
+});
 
 const indexRepository = (indexer: CodeGraphIndexerShape, options: CodeGraphWatchOptions) =>
   indexer

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -883,7 +883,7 @@ function registerCodeGraphTool(server: EffectMcpServerAdapter, config: RuntimeCo
           }
         }
         const refreshStatus = Option.getOrUndefined(yield* watcher.status(identity.worktreeId, refreshTarget));
-        if (refreshStatus?.state === 'failed' || refreshStatus?.state === 'indexing') {
+        if (codeGraphRefreshBlocksReadyInspection(status, refreshStatus)) {
           return codeGraphRefreshResult(operation, refreshStatus);
         }
         const result = yield* service.inspect({
@@ -1805,6 +1805,14 @@ const waitForCodeGraphRefresh = Effect.fn('mcpServer.waitForCodeGraphRefresh')(f
     yield* Effect.sleep(MCP_CODE_GRAPH_POLL_MILLISECONDS);
   }
 });
+
+export function codeGraphRefreshBlocksReadyInspection(
+  status: {readonly readySnapshot?: unknown; readonly stale: boolean},
+  refreshStatus: CodeGraphRefreshStatus | undefined,
+): boolean {
+  if (refreshStatus?.state === 'failed') return true;
+  return refreshStatus?.state === 'indexing' && (!status.readySnapshot || status.stale);
+}
 
 function codeGraphRefreshResult(
   operation: 'explain' | 'impact' | 'neighbors' | 'node' | 'path' | 'query',

--- a/test/integration/code-graph.incremental.property.test.ts
+++ b/test/integration/code-graph.incremental.property.test.ts
@@ -30,6 +30,12 @@ interface BarrelScenario {
   readonly revision: number;
 }
 
+interface CleanSurfaceChangeScenario {
+  readonly fileCount: number;
+  readonly mutation: 'arity' | 'export' | 'rename';
+  readonly sourceSeed: number;
+}
+
 const scenarioArbitrary = FC.record({
   baseTargets: FC.array(FC.integer({max: 31, min: 0}), {maxLength: 7, minLength: 7}),
   dirtyMask: FC.array(FC.boolean(), {maxLength: 7, minLength: 7}),
@@ -70,6 +76,12 @@ const barrelScenarioArbitrary = FC.record({
   dirtyArities: [dirtyZero ? 0 : -1, dirtyTwo ? 2 : -1].filter(arity => arity >= 0),
   revision,
 }));
+
+const cleanSurfaceChangeScenarioArbitrary = FC.record({
+  fileCount: FC.integer({max: 7, min: 3}),
+  mutation: FC.constantFrom('arity' as const, 'export' as const, 'rename' as const),
+  sourceSeed: FC.integer({max: 31, min: 0}),
+});
 
 describe('code graph incremental-overlay differential properties', () => {
   it.effect.prop(
@@ -203,6 +215,137 @@ describe('code graph incremental-overlay differential properties', () => {
     {
       fastCheck: {interruptAfterTimeLimit: 90_000, markInterruptAsFailure: true, numRuns: 10},
       timeout: 100_000,
+    },
+  );
+
+  it.effect.prop(
+    'matches a full rebuild after randomized compatible changes are committed cleanly',
+    {scenario: scenarioArbitrary},
+    ({scenario}) =>
+      Effect.promise(async () => {
+        const root = createRepository(scenario);
+        const incrementalHome = join(root, '.threadnote-clean-incremental-home');
+        const fullHome = join(root, '.threadnote-clean-full-home');
+        try {
+          const base = await runEffect(
+            Effect.gen(function* () {
+              const indexer = yield* CodeGraphIndexer;
+              return yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+            }),
+          );
+          applyDirtyScenario(root, scenario);
+          commitScenarioFiles(root, scenario, 'compatible clean property change');
+          const result = await runEffect(
+            Effect.gen(function* () {
+              const indexer = yield* CodeGraphIndexer;
+              const path = yield* Path.Path;
+              const query = yield* CodeGraphQueryService;
+              const store = yield* CodeGraphStore;
+              const incremental = yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+              const full = yield* indexer.index({cwd: root, threadnoteHome: fullHome});
+              const incrementalLayout = codeGraphLayout(
+                path,
+                incrementalHome,
+                incremental.identity.checkoutId,
+                incremental.identity.worktreeId,
+              );
+              const fullLayout = codeGraphLayout(path, fullHome, full.identity.checkoutId, full.identity.worktreeId);
+              const [incrementalQuery, fullQuery] = yield* Effect.all(
+                [
+                  query.inspect({
+                    cwd: root,
+                    operation: 'query',
+                    query: 'symbol0',
+                    refresh: false,
+                    threadnoteHome: incrementalHome,
+                  }),
+                  query.inspect({
+                    cwd: root,
+                    operation: 'query',
+                    query: 'symbol0',
+                    refresh: false,
+                    threadnoteHome: fullHome,
+                  }),
+                ],
+                {concurrency: 1},
+              );
+              return {
+                full,
+                fullCatalog: yield* store.loadVisualizationCatalog(fullLayout.databasePath),
+                fullGraph: yield* store.loadGraph(fullLayout.databasePath, full.snapshot.id),
+                fullQuery,
+                incremental,
+                incrementalCatalog: yield* store.loadVisualizationCatalog(incrementalLayout.databasePath),
+                incrementalGraph: yield* store.loadGraph(incrementalLayout.databasePath, incremental.snapshot.id),
+                incrementalHealth: yield* store.diagnose(incrementalLayout.databasePath),
+                incrementalQuery,
+              };
+            }),
+          );
+
+          expect(result.incremental.materialization).toEqual({
+            mode: 'incremental-clean',
+            stagedFiles: scenario.dirty.size,
+            totalFiles: scenario.fileCount,
+          });
+          expect(result.incremental.snapshot).toMatchObject({baseSnapshotId: base.snapshot.id, dirty: false});
+          expect(result.full.materialization).toEqual({
+            mode: 'full',
+            stagedFiles: scenario.fileCount,
+            totalFiles: scenario.fileCount,
+          });
+          expect(normalizeGraph(result.incrementalGraph)).toEqual(normalizeGraph(result.fullGraph));
+          expect(normalizeCatalog(result.incrementalCatalog)).toEqual(normalizeCatalog(result.fullCatalog));
+          expect(normalizeQuery(result.incrementalQuery)).toEqual(normalizeQuery(result.fullQuery));
+          expect(result.incrementalHealth).toMatchObject({foreignKeyViolations: 0, integrity: 'ok'});
+        } finally {
+          rmSync(root, {force: true, recursive: true});
+        }
+      }),
+    {
+      fastCheck: {interruptAfterTimeLimit: 90_000, markInterruptAsFailure: true, numRuns: 8},
+      timeout: 100_000,
+    },
+  );
+
+  it.effect.prop(
+    'fails closed to full materialization for randomized clean resolution-surface changes',
+    {scenario: cleanSurfaceChangeScenarioArbitrary},
+    ({scenario}) =>
+      Effect.promise(async () => {
+        const source = scenario.sourceSeed % scenario.fileCount;
+        const baseScenario = simpleScenario(scenario.fileCount);
+        const root = createRepository(baseScenario);
+        const home = join(root, '.threadnote-clean-surface-home');
+        try {
+          const base = await runEffect(
+            Effect.gen(function* () {
+              const indexer = yield* CodeGraphIndexer;
+              return yield* indexer.index({cwd: root, threadnoteHome: home});
+            }),
+          );
+          writeSurfaceChangedSource(root, baseScenario, source, scenario.mutation);
+          commitPaths(root, [`src/file-${source}.ts`], `clean ${scenario.mutation} surface change`);
+          const result = await runEffect(
+            Effect.gen(function* () {
+              const indexer = yield* CodeGraphIndexer;
+              return yield* indexer.index({cwd: root, threadnoteHome: home});
+            }),
+          );
+
+          expect(result.materialization).toEqual({
+            mode: 'incremental-clean',
+            stagedFiles: scenario.fileCount,
+            totalFiles: scenario.fileCount,
+          });
+          expect(result.snapshot).toMatchObject({baseSnapshotId: base.snapshot.id, dirty: false, state: 'ready'});
+        } finally {
+          rmSync(root, {force: true, recursive: true});
+        }
+      }),
+    {
+      fastCheck: {interruptAfterTimeLimit: 60_000, markInterruptAsFailure: true, numRuns: 6},
+      timeout: 70_000,
     },
   );
 
@@ -773,6 +916,52 @@ function applyDirtyScenario(root: string, scenario: DifferentialScenario): void 
   for (const source of scenario.dirty) {
     writeSource(root, source, scenario.dirtyTargets[source]!, scenario.fileCount, scenario.salt + source + 1);
   }
+}
+
+function commitScenarioFiles(root: string, scenario: DifferentialScenario, message: string): void {
+  commitPaths(
+    root,
+    [...scenario.dirty].map(source => `src/file-${source}.ts`),
+    message,
+  );
+}
+
+function commitPaths(root: string, paths: readonly string[], message: string): void {
+  git(root, ['add', ...paths]);
+  git(root, ['-c', 'user.name=Threadnote Test', '-c', 'user.email=test@threadnote.local', 'commit', '-qm', message]);
+}
+
+function simpleScenario(fileCount: number): DifferentialScenario {
+  const targets = Array.from({length: fileCount}, (_, source) => (source + 1) % fileCount);
+  return {
+    baseTargets: targets,
+    dirty: new Set(),
+    dirtyTargets: targets,
+    fileCount,
+    salt: 0,
+  };
+}
+
+function writeSurfaceChangedSource(
+  root: string,
+  scenario: DifferentialScenario,
+  source: number,
+  mutation: CleanSurfaceChangeScenario['mutation'],
+): void {
+  const target = differentFile(scenario.baseTargets[source]!, source, scenario.fileCount);
+  const exported = mutation === 'export' ? '' : 'export ';
+  const name = mutation === 'rename' ? `renamed${source}` : `symbol${source}`;
+  const parameters = mutation === 'arity' ? 'value: number' : '';
+  writeFileSync(
+    join(root, 'src', `file-${source}.ts`),
+    [
+      `import {symbol${target}} from './file-${target}.js';`,
+      `${exported}function ${name}(${parameters}): number {`,
+      `  return symbol${target}();`,
+      '}',
+      '',
+    ].join('\n'),
+  );
 }
 
 function restoreCleanScenario(root: string, scenario: DifferentialScenario): void {

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -607,6 +607,264 @@ describe('native code graph lifecycle', () => {
     }
   });
 
+  it('aliases a graph-equivalent clean commit without reparsing or rematerializing files', async () => {
+    const root = createManySourceRepository(12);
+    const home = join(root, '.threadnote-test-home');
+    const first = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        return yield* indexer.index({cwd: root, threadnoteHome: home});
+      }),
+    );
+    git(root, [
+      '-c',
+      'user.name=Threadnote Test',
+      '-c',
+      'user.email=test@threadnote.local',
+      'commit',
+      '--allow-empty',
+      '-qm',
+      'metadata-only commit',
+    ]);
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        const query = yield* CodeGraphQueryService;
+        const store = yield* CodeGraphStore;
+        const second = yield* indexer.index({cwd: root, threadnoteHome: home});
+        const firstGraph = yield* store.loadGraph(codeGraphDatabasePath(home, first), first.snapshot.id);
+        const secondGraph = yield* store.loadGraph(codeGraphDatabasePath(home, second), second.snapshot.id);
+        const found = yield* query.inspect({
+          cwd: root,
+          operation: 'query',
+          query: 'original0',
+          refresh: false,
+          threadnoteHome: home,
+        });
+        return {firstGraph, found, second, secondGraph};
+      }),
+    );
+
+    expect(result.second.snapshot.id).not.toBe(first.snapshot.id);
+    expect(result.second.snapshot).toMatchObject({baseSnapshotId: first.snapshot.id, dirty: false});
+    expect(result.second.snapshot.graphContentId).toBe(first.snapshot.graphContentId);
+    expect(result.second.snapshot.graphContentId).toMatch(/^cgc_[0-9a-f]{40}$/);
+    expect(result.second.materialization).toEqual({
+      mode: 'reused-snapshot',
+      stagedFiles: 0,
+      totalFiles: 12,
+    });
+    expect(result.second.reusedFiles).toBe(12);
+    expect(normalizeStoredGraph(result.secondGraph)).toEqual(normalizeStoredGraph(result.firstGraph));
+    expect(result.found.nodes.some(node => node.name === 'original0')).toBe(true);
+
+    const database = new Database(codeGraphDatabasePath(home, result.second), {readonly: true});
+    try {
+      const owned = database
+        .query<{readonly files: number; readonly symbols: number}, [string, string]>(
+          `SELECT
+             (SELECT COUNT(*) FROM snapshot_files WHERE snapshot_id = ?) AS files,
+             (SELECT COUNT(*) FROM symbols WHERE snapshot_id = ?) AS symbols`,
+        )
+        .get(result.second.snapshot.id, result.second.snapshot.id);
+      expect(owned).toEqual({files: 0, symbols: 0});
+    } finally {
+      database.close();
+    }
+  });
+
+  it('materializes only body-changed files for a compatible clean commit', async () => {
+    const root = createManySourceRepository(24);
+    const home = join(root, '.threadnote-test-home');
+    const first = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        return yield* indexer.index({cwd: root, threadnoteHome: home});
+      }),
+    );
+    const changedPath = join(root, 'src/file-000.ts');
+    writeFileSync(changedPath, readFileSync(changedPath, 'utf8').replace('return 0;', 'return 1000;'));
+    git(root, ['add', 'src/file-000.ts']);
+    git(root, [
+      '-c',
+      'user.name=Threadnote Test',
+      '-c',
+      'user.email=test@threadnote.local',
+      'commit',
+      '-qm',
+      'body-only change',
+    ]);
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const incremental = yield* indexer.index({cwd: root, threadnoteHome: home});
+        const incrementalGraph = yield* store.loadGraph(
+          codeGraphDatabasePath(home, incremental),
+          incremental.snapshot.id,
+        );
+        const full = yield* indexer.index({cwd: root, force: true, threadnoteHome: home});
+        const fullGraph = yield* store.loadGraph(codeGraphDatabasePath(home, full), full.snapshot.id);
+        return {fullGraph, incremental, incrementalGraph};
+      }),
+    );
+
+    expect(result.incremental.snapshot).toMatchObject({baseSnapshotId: first.snapshot.id, dirty: false});
+    expect(result.incremental.materialization).toEqual({
+      mode: 'incremental-clean',
+      stagedFiles: 1,
+      totalFiles: 24,
+    });
+    expect(result.incremental.diagnostics).toContain('Clean snapshot reused persisted base for 1 modified file(s).');
+    expect(normalizeStoredGraph(result.incrementalGraph)).toEqual(normalizeStoredGraph(result.fullGraph));
+  });
+
+  it('reuses a full anchor with a conservative graph-wide closure when a clean commit changes resolution', async () => {
+    const root = createManySourceRepository(4);
+    const home = join(root, '.threadnote-test-home');
+    const first = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        return yield* indexer.index({cwd: root, threadnoteHome: home});
+      }),
+    );
+    const changedPath = join(root, 'src/file-000.ts');
+    writeFileSync(changedPath, readFileSync(changedPath, 'utf8').replace('original0', 'renamed0'));
+    git(root, ['add', 'src/file-000.ts']);
+    git(root, [
+      '-c',
+      'user.name=Threadnote Test',
+      '-c',
+      'user.email=test@threadnote.local',
+      'commit',
+      '-qm',
+      'rename declaration',
+    ]);
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        const query = yield* CodeGraphQueryService;
+        const indexed = yield* indexer.index({cwd: root, threadnoteHome: home});
+        const found = yield* query.inspect({
+          cwd: root,
+          operation: 'query',
+          query: 'renamed0',
+          refresh: false,
+          threadnoteHome: home,
+        });
+        return {found, indexed};
+      }),
+    );
+
+    expect(result.indexed.materialization).toEqual({mode: 'incremental-clean', stagedFiles: 4, totalFiles: 4});
+    expect(result.indexed.snapshot).toMatchObject({baseSnapshotId: first.snapshot.id, dirty: false});
+    expect(result.found.nodes.some(node => node.name === 'renamed0')).toBe(true);
+  });
+
+  it.each([
+    [
+      'adds',
+      (root: string) => writeFileSync(join(root, 'src/added.ts'), 'export function added(): number { return 5; }\n'),
+      5,
+    ],
+    ['deletes', (root: string) => rmSync(join(root, 'src/file-000.ts')), 3],
+  ] as const)('reuses a full anchor when a clean commit %s an eligible file', async (_label, mutate, fileCount) => {
+    const root = createManySourceRepository(4);
+    const home = join(root, '.threadnote-test-home');
+    const first = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        return yield* indexer.index({cwd: root, threadnoteHome: home});
+      }),
+    );
+    mutate(root);
+    git(root, _label === 'adds' ? ['add', 'src/added.ts'] : ['add', '-u', 'src/file-000.ts']);
+    git(root, [
+      '-c',
+      'user.name=Threadnote Test',
+      '-c',
+      'user.email=test@threadnote.local',
+      'commit',
+      '-qm',
+      `${_label} eligible file`,
+    ]);
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const incremental = yield* indexer.index({cwd: root, threadnoteHome: home});
+        const incrementalGraph = yield* store.loadGraph(
+          codeGraphDatabasePath(home, incremental),
+          incremental.snapshot.id,
+        );
+        const full = yield* indexer.index({cwd: root, force: true, threadnoteHome: home});
+        const fullGraph = yield* store.loadGraph(codeGraphDatabasePath(home, full), full.snapshot.id);
+        return {fullGraph, incremental, incrementalGraph};
+      }),
+    );
+
+    expect(result.incremental.materialization).toEqual({
+      mode: 'incremental-clean',
+      stagedFiles: fileCount,
+      totalFiles: fileCount,
+    });
+    expect(result.incremental.snapshot).toMatchObject({baseSnapshotId: first.snapshot.id, dirty: false});
+    expect(normalizeStoredGraph(result.incrementalGraph)).toEqual(normalizeStoredGraph(result.fullGraph));
+  });
+
+  it('builds an immediately dirty worktree directly from the prior compatible anchor', async () => {
+    const root = createManySourceRepository(6);
+    const home = join(root, '.threadnote-test-home');
+    const first = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        return yield* indexer.index({cwd: root, threadnoteHome: home});
+      }),
+    );
+    const committedPath = join(root, 'src/file-000.ts');
+    writeFileSync(committedPath, readFileSync(committedPath, 'utf8').replace('return 0;', 'return 1000;'));
+    git(root, ['add', 'src/file-000.ts']);
+    git(root, [
+      '-c',
+      'user.name=Threadnote Test',
+      '-c',
+      'user.email=test@threadnote.local',
+      'commit',
+      '-qm',
+      'new clean commit',
+    ]);
+    const dirtyPath = join(root, 'src/file-001.ts');
+    writeFileSync(dirtyPath, readFileSync(dirtyPath, 'utf8').replace('return 1;', 'return 1001;'));
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const identity = yield* resolveRepositoryIdentity(root);
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const indexed = yield* indexer.index({cwd: root, threadnoteHome: home});
+        const cleanCommit = yield* store.readySnapshotForCommit(
+          codeGraphDatabasePath(home, indexed),
+          identity.repositoryId,
+          identity.headCommit,
+        );
+        return {cleanCommit, indexed};
+      }),
+    );
+
+    expect(result.indexed.materialization).toEqual({
+      mode: 'incremental-overlay',
+      stagedFiles: 2,
+      totalFiles: 6,
+    });
+    expect(result.indexed.snapshot).toMatchObject({baseSnapshotId: first.snapshot.id, dirty: true});
+    expect(result.cleanCommit).toBeUndefined();
+    expect(result.indexed.diagnostics.some(message => message.includes('without first building commit'))).toBe(true);
+  });
+
   it('reuses parsed file facts when repository resolution context changes', async () => {
     const root = createFixtureRepository();
     const home = join(root, '.threadnote-test-home');

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -575,18 +575,16 @@ describe('native code graph lifecycle', () => {
     );
     const materialization = afterDirty.indexed.materialization;
     expect(materialization).toMatchObject({
-      fallbackReason: 'resolution-surface-changed',
-      mode: 'full',
+      mode: 'incremental-overlay',
     });
     expect(materialization?.stagedFiles).toBe(materialization?.totalFiles);
-    expect(afterDirty.indexed.snapshot).toMatchObject({baseSnapshotId: undefined, dirty: true});
-    expect(afterDirty.indexed.snapshot.id).toMatch(/-direct$/);
+    expect(afterDirty.indexed.snapshot).toMatchObject({baseSnapshotId: result.forced.snapshot.id, dirty: true});
     expect(afterDirty.dirty.nodes.some(node => node.name === 'ensureDirtyVectorIndex')).toBe(true);
     expect(afterDirty.clean.nodes.some(node => node.name === 'ensureVectorIndex')).toBe(true);
     expect(afterDirty.health).toMatchObject({
       activeSnapshots: 2,
       integrity: 'ok',
-      readySnapshots: 2,
+      readySnapshots: 3,
     });
     const database = new Database(databasePath, {readonly: true});
     try {
@@ -719,6 +717,94 @@ describe('native code graph lifecycle', () => {
     });
     expect(result.incremental.diagnostics).toContain('Clean snapshot reused persisted base for 1 modified file(s).');
     expect(normalizeStoredGraph(result.incrementalGraph)).toEqual(normalizeStoredGraph(result.fullGraph));
+  });
+
+  it('reuses content-addressed materialized file shards during a forced clean rebuild', async () => {
+    const root = createManySourceRepository(12);
+    const home = join(root, '.threadnote-test-home');
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const first = yield* indexer.index({cwd: root, threadnoteHome: home});
+        const firstGraph = yield* store.loadGraph(codeGraphDatabasePath(home, first), first.snapshot.id);
+        yield* repairCodeGraphIndexes(home, false);
+        const rebuilt = yield* indexer.index({cwd: root, force: true, threadnoteHome: home});
+        const databasePath = codeGraphDatabasePath(home, rebuilt);
+        return {
+          databasePath,
+          first,
+          firstGraph,
+          rebuilt,
+          rebuiltGraph: yield* store.loadGraph(databasePath, rebuilt.snapshot.id),
+        };
+      }),
+    );
+
+    expect(result.rebuilt.materialization).toEqual({mode: 'full', stagedFiles: 12, totalFiles: 12});
+    expect(result.rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 12 file(s).');
+    const database = new Database(result.databasePath, {readonly: true});
+    try {
+      const shards = database
+        .query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM materialized_file_shards')
+        .get();
+      const references = database
+        .query<{readonly count: number}, [string]>(
+          `SELECT COUNT(*) AS count
+           FROM snapshot_file_shards
+           WHERE snapshot_id = ?`,
+        )
+        .get(result.rebuilt.snapshot.id);
+      expect(shards?.count).toBe(12);
+      expect(references?.count).toBe(12);
+    } finally {
+      database.close();
+    }
+    expect(normalizeStoredGraph(result.rebuiltGraph)).toEqual(normalizeStoredGraph(result.firstGraph));
+  });
+
+  it('falls back to complete attribution when a materialized shard set is partial', async () => {
+    const root = createManySourceRepository(12);
+    const home = join(root, '.threadnote-test-home');
+    const first = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        return yield* indexer.index({cwd: root, threadnoteHome: home});
+      }),
+    );
+    const databasePath = codeGraphDatabasePath(home, first);
+    const firstGraph = await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        return yield* store.loadGraph(databasePath, first.snapshot.id);
+      }),
+    );
+    const database = new Database(databasePath);
+    try {
+      database.exec(`DELETE FROM materialized_file_shards
+                     WHERE id = (SELECT id FROM materialized_file_shards ORDER BY id LIMIT 1)`);
+    } finally {
+      database.close();
+    }
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const rebuilt = yield* indexer.index({cwd: root, force: true, threadnoteHome: home});
+        return {
+          rebuilt,
+          rebuiltGraph: yield* store.loadGraph(databasePath, rebuilt.snapshot.id),
+        };
+      }),
+    );
+
+    expect(
+      result.rebuilt.diagnostics.some(diagnostic =>
+        diagnostic.startsWith('Reused content-addressed materialized shards for'),
+      ),
+    ).toBe(false);
+    expect(normalizeStoredGraph(result.rebuiltGraph)).toEqual(normalizeStoredGraph(firstGraph));
   });
 
   it('reuses a full anchor with a conservative graph-wide closure when a clean commit changes resolution', async () => {
@@ -990,7 +1076,11 @@ describe('native code graph lifecycle', () => {
     expect(result.indexed.reusedFiles).toBe(first.snapshot.fileCount - 1);
     expect(result.indexed.snapshot.commit).not.toBe(first.snapshot.commit);
     expect(result.indexed.snapshot.dirty).toBe(false);
-    expect(result.indexed.materialization?.mode).toBe('full');
+    expect(result.indexed.materialization).toEqual({
+      mode: 'incremental-clean',
+      stagedFiles: 1,
+      totalFiles: first.snapshot.fileCount,
+    });
     expect(result.graph.symbols.find(symbol => symbol.name === 'runApplication')?.packageName).toBe('@fixture/app');
     expect(
       result.graph.edges.some(
@@ -1078,8 +1168,7 @@ describe('native code graph lifecycle', () => {
       }),
     );
 
-    expect(cachedHashes).toEqual([latestHash]);
-    expect(cachedHashes).not.toContain(committedHash);
+    expect(cachedHashes).toEqual([committedHash, latestHash].sort());
     expect(cachedHashes).not.toContain(intermediateHash);
     expect(unchanged.reusedFiles).toBe(unchanged.snapshot.fileCount);
   });

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -173,7 +173,7 @@ describe('platform benchmark workflow', () => {
     const releaseCommand = release.steps?.flatMap(step => (step.run ? [step.run] : [])).join('\n') ?? '';
 
     expect(evidence.needs).toBeUndefined();
-    expect(releaseEvidence.on.push?.tags).toEqual(['v4.0.0-beta.*', 'v4.0.0-rc.*', 'v4.0.0']);
+    expect(releaseEvidence.on.push?.tags).toEqual(['v4.*']);
     expect(evidence.uses).toBe('./.github/workflows/production-large-evidence.yml');
     expect(evidence.with).toMatchObject({
       strict: false,

--- a/test/unit/code-graph.analysis-summary.property.test.ts
+++ b/test/unit/code-graph.analysis-summary.property.test.ts
@@ -104,6 +104,8 @@ describe('persisted code graph analysis summaries', () => {
             [...effectiveEdgeMap.values()],
           );
 
+          yield* store.ensureAnalysisSummary?.(databasePath, overlaySnapshot.id);
+          yield* store.ensureAnalysisSummary?.(databasePath, rebuiltSnapshot.id);
           const overlay = Option.getOrThrow(yield* store.loadAnalysisSummary(databasePath, overlaySnapshot.id));
           const rebuilt = Option.getOrThrow(yield* store.loadAnalysisSummary(databasePath, rebuiltSnapshot.id));
           expect(overlay).toEqual(rebuilt);
@@ -201,6 +203,8 @@ describe('persisted code graph analysis summaries', () => {
           effectiveEdges,
         );
 
+        yield* store.ensureAnalysisSummary?.(databasePath, overlay.id);
+        yield* store.ensureAnalysisSummary?.(databasePath, rebuilt.id);
         const actual = Option.getOrThrow(yield* store.loadAnalysisSummary(databasePath, overlay.id));
         const expected = Option.getOrThrow(yield* store.loadAnalysisSummary(databasePath, rebuilt.id));
         expect(actual).toEqual(expected);
@@ -248,6 +252,7 @@ describe('persisted code graph analysis summaries', () => {
           }),
         );
 
+        yield* store.ensureAnalysisSummary?.(databasePath, ready.id);
         const summary = Option.getOrThrow(yield* store.loadAnalysisSummary(databasePath, ready.id));
         expect(summary).toMatchObject({edgeCount: 1, symbolCount: 2});
         expect(summary.edges).toEqual([expect.objectContaining({count: 1, provenance: 'resolved', relation: 'calls'})]);
@@ -317,6 +322,7 @@ describe('persisted code graph analysis summaries', () => {
           }),
         );
 
+        yield* store.ensureAnalysisSummary?.(databasePath, ready.id);
         const summary = Option.getOrThrow(yield* store.loadAnalysisSummary(databasePath, ready.id));
         expect(summary.edges).toEqual([
           expect.objectContaining({

--- a/test/unit/code-graph.indexer.property.test.ts
+++ b/test/unit/code-graph.indexer.property.test.ts
@@ -7,6 +7,7 @@ import {
   deduplicateMaterializationRelationships,
   estimatedMaterializationStorageBytes,
   factMaterializationBatches,
+  graphContentIdentity,
   materializationRowsWithStoreProgress,
   materializationStoragePlan,
   materializationStorageShortfalls,
@@ -42,6 +43,33 @@ describe('code graph indexer properties', () => {
     ).slice(0, 40);
 
     expect(snapshotIdentity(identity, false, extractorSet, files)).toBe(`cgsn_${expected}`);
+  });
+
+  it('keeps graph content identity independent of commit order while detecting every eligible content change', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(
+          fc.record({
+            contentHash: fc.string({maxLength: 64, minLength: 1}),
+            language: fc.constantFrom('typescript', 'python', 'markdown'),
+            mode: fc.constantFrom('100644', '100755'),
+            path: fc.stringMatching(/^[a-z][a-z0-9]{0,8}\.ts$/),
+          }),
+          {minLength: 1, selector: file => file.path},
+        ),
+        files => {
+          const original = graphContentIdentity('extractor-set', files);
+          expect(graphContentIdentity('extractor-set', [...files].reverse())).toBe(original);
+
+          const changed = files.map((file, index) =>
+            index === 0 ? {...file, contentHash: `${file.contentHash}0`} : file,
+          );
+          expect(graphContentIdentity('extractor-set', changed)).not.toBe(original);
+          expect(graphContentIdentity('other-extractor-set', files)).not.toBe(original);
+        },
+      ),
+      {numRuns: 250},
+    );
   });
 
   it('splits high-density low-source-byte facts before one SQLite writer transaction becomes pathological', () => {

--- a/test/unit/code-graph.indexer.property.test.ts
+++ b/test/unit/code-graph.indexer.property.test.ts
@@ -15,7 +15,11 @@ import {
   snapshotIdentity,
 } from '../../src/code_graph/indexer.js';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
-import {CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION} from '../../src/code_graph/store.js';
+import {
+  CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION,
+  materializedFileShardIdentity,
+  materializedShardDerivationIdentity,
+} from '../../src/code_graph/store.js';
 import type {CodeGraphEdge, CodeGraphMaterializationRows, CodeGraphReference} from '../../src/code_graph/types.js';
 
 const byteCount = FC.integer({max: Number.MAX_SAFE_INTEGER, min: 0});
@@ -68,6 +72,20 @@ describe('code graph indexer properties', () => {
           expect(graphContentIdentity('other-extractor-set', files)).not.toBe(original);
         },
       ),
+      {numRuns: 250},
+    );
+  });
+
+  it('makes materialized shard identity content-addressed and derivation-context sensitive', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), fc.string(), fc.string(), (extractor, workspace, fileSet, path) => {
+        const derivation = materializedShardDerivationIdentity(extractor, workspace, fileSet);
+        const shard = materializedFileShardIdentity('content-hash', extractor, derivation, path);
+        expect(materializedFileShardIdentity('content-hash', extractor, derivation, path)).toBe(shard);
+        expect(materializedFileShardIdentity('changed-content', extractor, derivation, path)).not.toBe(shard);
+        expect(materializedFileShardIdentity('content-hash', extractor, derivation, `${path}/changed`)).not.toBe(shard);
+        expect(materializedShardDerivationIdentity(extractor, workspace, `${fileSet}/changed`)).not.toBe(derivation);
+      }),
       {numRuns: 250},
     );
   });

--- a/test/unit/code-graph.materialization-store.test.ts
+++ b/test/unit/code-graph.materialization-store.test.ts
@@ -3365,7 +3365,6 @@ interface CompletedBuildRows {
 }
 
 interface PersistentGraphEvidence {
-  readonly digest: string;
   readonly distinctFiles: number;
   readonly edges: number;
   readonly files: number;
@@ -3376,13 +3375,13 @@ function persistentGraphEvidence(databasePath: string, snapshotId: string): Pers
   const database = new Database(databasePath, {readonly: true, strict: true});
   const evidence = database
     .query(
-      `SELECT receipt.digest,
-         (SELECT COUNT(*) FROM snapshot_files WHERE snapshot_id = receipt.snapshot_id) AS files,
-         (SELECT COUNT(DISTINCT path) FROM snapshot_files WHERE snapshot_id = receipt.snapshot_id) AS distinctFiles,
-         (SELECT COUNT(*) FROM symbols WHERE snapshot_id = receipt.snapshot_id) AS symbols,
-         (SELECT COUNT(*) FROM edges WHERE snapshot_id = receipt.snapshot_id) AS edges
-       FROM snapshot_analysis_summary_receipts AS receipt
-       WHERE receipt.snapshot_id = ?`,
+      `SELECT
+         (SELECT COUNT(*) FROM snapshot_files WHERE snapshot_id = snapshot.id) AS files,
+         (SELECT COUNT(DISTINCT path) FROM snapshot_files WHERE snapshot_id = snapshot.id) AS distinctFiles,
+         (SELECT COUNT(*) FROM symbols WHERE snapshot_id = snapshot.id) AS symbols,
+         (SELECT COUNT(*) FROM edges WHERE snapshot_id = snapshot.id) AS edges
+       FROM snapshots AS snapshot
+       WHERE snapshot.id = ?`,
     )
     .get(snapshotId) as PersistentGraphEvidence;
   database.close(false);

--- a/test/unit/code-graph.persisted-delta-resolution.test.ts
+++ b/test/unit/code-graph.persisted-delta-resolution.test.ts
@@ -123,6 +123,7 @@ describe('persisted delta reference resolution', () => {
       createResolutionPlanSchema(database);
       database.exec(`
         INSERT INTO activation_files (path) VALUES ('src/caller.ts');
+        INSERT INTO activation_incremental_paths (path) VALUES ('src/caller.ts');
         INSERT INTO activation_edges (
           id, source_id, source_name, relation, target_id, target_name,
           provenance, confidence, evidence_path, evidence_span_json
@@ -291,6 +292,9 @@ function symbol(id: string, name: string, path: string, contentHash: string): Co
 function createResolutionPlanSchema(database: Database): void {
   database.exec(`
     CREATE TEMP TABLE activation_files (
+      path TEXT PRIMARY KEY
+    ) WITHOUT ROWID;
+    CREATE TEMP TABLE activation_incremental_paths (
       path TEXT PRIMARY KEY
     ) WITHOUT ROWID;
     CREATE TEMP TABLE activation_reference_candidates (

--- a/test/unit/code-graph.watcher.test.ts
+++ b/test/unit/code-graph.watcher.test.ts
@@ -1,8 +1,13 @@
 import {it as effectIt} from '@effect/vitest';
 import {Deferred, Effect, Ref} from 'effect';
 import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
-import {makeCodeGraphWatcher, type CodeGraphWatchOptions} from '../../src/code_graph/watcher.js';
+import {
+  makeCodeGraphWatcher,
+  prewarmCandidatesFromRefOutput,
+  type CodeGraphWatchOptions,
+} from '../../src/code_graph/watcher.js';
 
 const options: CodeGraphWatchOptions = {
   cwd: '/fixture/repository',
@@ -11,6 +16,31 @@ const options: CodeGraphWatchOptions = {
 };
 
 describe('CodeGraphWatcher', () => {
+  it('admits at most two unique non-current ref tips for prewarming', () => {
+    const objectId = fc
+      .array(fc.integer({max: 15, min: 0}), {maxLength: 40, minLength: 40})
+      .map(values => values.map(value => value.toString(16)).join(''));
+    fc.assert(
+      fc.property(
+        fc.array(objectId, {maxLength: 20}),
+        objectId,
+        fc.integer({max: 20, min: -5}),
+        (ids, current, limit) => {
+          const candidates = prewarmCandidatesFromRefOutput(
+            [...ids, current, 'not-an-object-id', ...ids].join('\n'),
+            current,
+            limit,
+          );
+          expect(candidates.length).toBeLessThanOrEqual(2);
+          expect(new Set(candidates).size).toBe(candidates.length);
+          expect(candidates).not.toContain(current);
+          expect(candidates.every(value => /^[0-9a-f]{40}$/u.test(value))).toBe(true);
+        },
+      ),
+      {numRuns: 250},
+    );
+  });
+
   it('deduplicates concurrent session registrations and finalizes the watcher with the session scope', async () => {
     const counts = await Effect.runPromise(
       Effect.gen(function* () {

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -6,6 +6,7 @@ import {
   codeGraphMcpAnalysisBudget,
   codeGraphMcpAnalysisLimits,
   codeGraphMcpResponse,
+  codeGraphRefreshBlocksReadyInspection,
   codeGraphQueryTimeoutResult,
   codeGraphRetryAfterMilliseconds,
   compactCodeGraphMcpProgress,
@@ -18,6 +19,20 @@ import type {CodeGraphRefreshStatus} from '../../src/code_graph/watcher.js';
 import {analysisEdge, analysisSnapshot, analysisSymbol, pagedAnalysisStore} from '../helpers/code-graph-analysis.js';
 
 describe('MCP code graph indexing progress', () => {
+  it('allows a current ready graph to serve while optional enrichment continues', () => {
+    const indexing = indexingStatus(60_000);
+
+    expect(codeGraphRefreshBlocksReadyInspection({readySnapshot: {id: 'ready'}, stale: false}, indexing)).toBe(false);
+    expect(codeGraphRefreshBlocksReadyInspection({readySnapshot: {id: 'stale'}, stale: true}, indexing)).toBe(true);
+    expect(codeGraphRefreshBlocksReadyInspection({stale: true}, indexing)).toBe(true);
+    expect(
+      codeGraphRefreshBlocksReadyInspection(
+        {readySnapshot: {id: 'ready'}, stale: false},
+        {message: 'fixture failed', state: 'failed'},
+      ),
+    ).toBe(true);
+  });
+
   it('derives a bounded adaptive poll interval from the phase estimate', () => {
     expect(codeGraphRetryAfterMilliseconds(undefined)).toBe(5_000);
     expect(codeGraphRetryAfterMilliseconds(indexingStatus(4_000))).toBe(3_000);


### PR DESCRIPTION
## Summary

- make ready lexical snapshots queryable before optional vector and whole-graph enrichment completes
- separate graph-content identity from commit identity and alias graph-equivalent clean commits
- build bounded one-level clean deltas for changed, added, renamed, and deleted files with conservative resolution closure
- build immediately dirty worktrees directly from compatible clean anchors
- prewarm a bounded set of likely local refs and reuse complete content-addressed materialized-file shard sets
- add schema, lifecycle, interruption, parity, maintenance, and property-based coverage
- prepare the 4.0.1 package version, curated release notes, and Threadnote 4 tag evidence trigger

## Validation

- `bun run typecheck`
- `bun run lint`
- full pre-commit suite: 184 files, 1,753 tests passed
- `bun run site:build`
- standalone build and `bun run check:self-contained`
- self-contained no-Node/Bun packaged smoke
- installed-release E2E: 23 passed, 1 platform-appropriate skip
- code-graph quality gate
- recall quality and recall-v2 non-inferiority gates
- exact-head global dogfood: graph query and `doctor --dry-run --strict` (0 failures)

After merge, the release source will be tagged `v4.0.1`; the checked-in publish workflow will build, sign, notarize, publish, and verify the immutable release.