### PR TITLE
Accept all Threadnote 4 release evidence tags

### DIFF
--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -78,6 +78,8 @@ const NANOSECONDS_PER_MILLISECOND = 1_000_000;
 const EXTERNAL_SAMPLER_READY_TIMEOUT_MS = 5_000;
 const EXTERNAL_SAMPLER_STOP_TIMEOUT_MS = 5_000;
 const EXTERNAL_SAMPLER_TERMINATE_TIMEOUT_MS = 1_000;
+const THREADNOTE_4_RELEASE_REF_PATTERN =
+  /^refs\/tags\/v4\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:beta|rc)\.(?:0|[1-9]\d*))?$/;
 const STRUCTURAL_DIGEST_SNAPSHOT_LEASE_MILLISECONDS = 60 * 60_000;
 const STRUCTURAL_DIGEST_SNAPSHOT_LEASE_RENEWAL_MILLISECONDS = 5 * 60_000;
 const STRUCTURAL_DIGEST_ROW_CHUNK_SIZE = 10_000;
@@ -4226,7 +4228,7 @@ export function resolvedReleaseEvidenceSource(
   dirty: boolean,
 ): {readonly ref: string; readonly resolvedSha: string; readonly sha: string} {
   if (
-    !/^refs\/tags\/v4\.0\.0(?:-(?:beta|rc)\.\d+)?$/.test(ref) ||
+    !THREADNOTE_4_RELEASE_REF_PATTERN.test(ref) ||
     !EXACT_GIT_COMMIT_PATTERN.test(sha) ||
     resolvedSha !== sha ||
     checkoutCommit !== sha ||
@@ -4248,7 +4250,7 @@ const validateReleaseEvidenceSource = Effect.fn('benchmarkCodeGraph.validateRele
   if (
     ref === undefined ||
     sha === undefined ||
-    !/^refs\/tags\/v4\.0\.0(?:-(?:beta|rc)\.\d+)?$/.test(ref) ||
+    !THREADNOTE_4_RELEASE_REF_PATTERN.test(ref) ||
     !EXACT_GIT_COMMIT_PATTERN.test(sha)
   ) {
     return yield* Effect.fail(

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1,5 +1,6 @@
 import {readFileSync} from 'node:fs';
 import {load} from 'js-yaml';
+import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {
   EXTERNAL_REPOSITORY_EVIDENCE_MEASUREMENTS,
@@ -188,6 +189,39 @@ describe('code graph release evidence', () => {
     expect(() => resolvedReleaseEvidenceSource('refs/tags/v4.0.0-beta.30', commit, commit, commit, true)).toThrow(
       /clean checkout/,
     );
+  });
+
+  it('accepts every stable, beta, and RC Threadnote 4 tag', () => {
+    const commit = '0123456789abcdef0123456789abcdef01234567';
+    const versionNumber = fc.integer({max: 10_000, min: 0});
+    const prerelease = fc.option(fc.tuple(fc.constantFrom('beta', 'rc'), versionNumber), {nil: undefined});
+
+    fc.assert(
+      fc.property(versionNumber, versionNumber, prerelease, (minor, patch, channel) => {
+        const suffix = channel === undefined ? '' : `-${channel[0]}.${channel[1]}`;
+        const ref = `refs/tags/v4.${minor}.${patch}${suffix}`;
+
+        expect(resolvedReleaseEvidenceSource(ref, commit, commit, commit, false)).toEqual({
+          ref,
+          resolvedSha: commit,
+          sha: commit,
+        });
+      }),
+      {numRuns: 250},
+    );
+  });
+
+  it.each([
+    'refs/tags/v3.9.9',
+    'refs/tags/v5.0.0',
+    'refs/tags/v4.0',
+    'refs/tags/v4.0.1-alpha.1',
+    'refs/tags/v4.0.1-beta',
+    'refs/tags/v4.00.1',
+    'refs/heads/v4.0.1',
+  ])('rejects non-Threadnote-4 release ref %s', ref => {
+    const commit = '0123456789abcdef0123456789abcdef01234567';
+    expect(() => resolvedReleaseEvidenceSource(ref, commit, commit, commit, false)).toThrow(/locally resolvable tag/);
   });
 
   it('requires aggregate materialization evidence in every production-large artifact', () => {


### PR DESCRIPTION
## Summary

- generalize exact release-evidence provenance from `v4.0.0` to proper Threadnote 4 stable, beta, and RC tags
- keep malformed, non-4, and non-tag refs fail-closed
- add a 250-run property test plus explicit rejection cases

## Why

The independent `v4.0.1` release-evidence run failed before measurement because the tag trigger accepted `v4.*` while the benchmark validator still only accepted `v4.0.0`. Runtime publication is independent and unaffected.

## Validation

- full suite: 184 files, 1,761 tests
- lint, formatting, and typecheck
- exact-HEAD standalone build installed globally and dogfooded