### PR TITLE
Scope CI checks by changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '.github/release-notes/**'
+      - '.gitignore'
+      - '.threadnoteignore'
+      - '*.md'
+      - 'LICENSE'
+      - 'docs/**'
+      - 'website/**'
   pull_request:
     branches: [main, codex/4.0.0]
 
@@ -15,8 +23,37 @@ env:
   E2E_EMBEDDING_MODEL_SHA256: f046db1dc724cf4f6f0a0c5917e922823b73eb1d27b8f9a9c2797f7866974804
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      actions: ${{ steps.scopes.outputs.actions }}
+      code: ${{ steps.scopes.outputs.code }}
+      quality: ${{ steps.scopes.outputs.quality }}
+      release: ${{ steps.scopes.outputs.release }}
+      site_check: ${{ steps.scopes.outputs.site_check }}
+      site_build: ${{ steps.scopes.outputs.site_build }}
+      windows: ${{ steps.scopes.outputs.windows }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - id: scopes
+        name: Select required checks conservatively
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: bun test/ci/ci-scopes.ts --base "$BASE_SHA" --head "$HEAD_SHA"
+
   test:
     name: Unit and integration tests
+    needs: changes
     runs-on: ubuntu-latest
 
     steps:
@@ -25,6 +62,7 @@ jobs:
           fetch-depth: 0
 
       - name: Validate GitHub Actions workflows
+        if: needs.changes.outputs.actions == 'true'
         uses: docker://rhysd/actionlint:1.7.8
         with:
           args: -color
@@ -34,17 +72,35 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - run: bun install --frozen-lockfile
-      - run: bun run lint
+
       - run: bun run prettier:check
+
+      - run: bun run lint
+        if: needs.changes.outputs.code == 'true'
+
       - run: bun run typecheck
+        if: needs.changes.outputs.code == 'true'
+
+      - name: Check website contracts
+        if: needs.changes.outputs.site_check == 'true' && needs.changes.outputs.code != 'true'
+        run: bun run site:check
+
       - run: bun run site:build
+        if: needs.changes.outputs.site_build == 'true'
         env:
           THREADNOTE_SITE_BASE: /
+
       - run: bun run build
+        if: needs.changes.outputs.release == 'true'
+
       - run: bun run check:self-contained
+        if: needs.changes.outputs.release == 'true'
+
       - run: bun run test:coverage
+        if: needs.changes.outputs.code == 'true'
 
       - name: Upload coverage
+        if: needs.changes.outputs.code == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: coverage
@@ -54,6 +110,8 @@ jobs:
 
   recall-quality:
     name: Recall quality and non-inferiority
+    needs: changes
+    if: needs.changes.outputs.quality == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -80,6 +138,8 @@ jobs:
 
   windows-smoke:
     name: Bun unit smoke · Windows
+    needs: changes
+    if: needs.changes.outputs.windows == 'true'
     runs-on: windows-latest
     timeout-minutes: 30
 
@@ -103,6 +163,8 @@ jobs:
 
   prepare-e2e-model:
     name: Prepare pinned E2E model
+    needs: changes
+    if: needs.changes.outputs.release == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -137,6 +199,8 @@ jobs:
 
   standalone-targets:
     name: Bytecode compile · ${{ matrix.target }}
+    needs: changes
+    if: needs.changes.outputs.release == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -165,7 +229,8 @@ jobs:
 
   self-contained-distribution:
     name: Self-contained Bun release · ${{ matrix.os }}
-    needs: prepare-e2e-model
+    needs: [changes, prepare-e2e-model]
+    if: needs.changes.outputs.release == 'true' && needs.prepare-e2e-model.result == 'success'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,14 @@ name: Website
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/pages.yml'
+      - 'scripts/site-performance-evidence.ts'
+      - 'src/evaluation/benchmark.ts'
+      - 'test/evaluation/candidates/threadnote-4.0.0/benchmarks/darwin-arm64-m1-max/code-graph-intellij-*.json'
+      - 'test/evaluation/candidates/threadnote-4.0.0/benchmarks/darwin-arm64-m1-max/code-graph-lexical-production-100k-*.json'
+      - 'test/evaluation/candidates/threadnote-4.0.1/benchmarks/darwin-arm64-m1-max/code-graph-worktree-readiness-*.json'
+      - 'website/**'
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -80,6 +80,24 @@ bun run test:smoke:self-contained
 
 `typecheck` intentionally uses TypeScript 7 for both source and test code.
 
+### CI changed-path routing
+
+Pull-request CI classifies the complete merge-base diff and enables checks by dependency scope. Scopes are monotonic:
+adding a changed path can only add checks, and an empty, invalid, or unrecognized path inventory enables every scope.
+
+| Change surface                                   | Required CI work                                                                              |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Documentation only                               | Formatting                                                                                    |
+| `website/**` only                                | Formatting, website contracts, and website build                                              |
+| Unit or integration tests only                   | Lint, typecheck, and coverage                                                                 |
+| Runtime and release inputs                       | General checks, standalone build, bytecode targets, platform release smoke, and Windows smoke |
+| Recall, vector, evaluation, or code-graph inputs | General checks plus recall/graph quality and the separately path-filtered benchmarks          |
+| Workflow files                                   | Actionlint plus the scopes owned by that workflow                                             |
+
+The classifier lives in `test/ci/ci-scopes.ts`, and its routing contract is covered by property and workflow tests.
+Website deployment has a separate path filter limited to site output inputs, so unrelated merges do not rebuild Pages.
+Documentation-only and website-only merges also avoid repeating pull-request CI on the resulting `main` push.
+
 ### Local distribution end-to-end tests
 
 Run the local-bin suite when a change affects any of the following:

--- a/test/ci/ci-scopes.ts
+++ b/test/ci/ci-scopes.ts
@@ -1,0 +1,286 @@
+export const ciScopeKeys = ['actions', 'code', 'quality', 'release', 'site_check', 'site_build', 'windows'] as const;
+
+export type CiScopeKey = (typeof ciScopeKeys)[number];
+export type CiScopes = Readonly<Record<CiScopeKey, boolean>>;
+
+export interface CiScopeClassification {
+  readonly changedCount: number;
+  readonly paths: readonly string[];
+  readonly scopes: CiScopes;
+}
+
+const noScopes = (): Record<CiScopeKey, boolean> => ({
+  actions: false,
+  code: false,
+  quality: false,
+  release: false,
+  site_build: false,
+  site_check: false,
+  windows: false,
+});
+
+const allScopes = (): Record<CiScopeKey, boolean> => ({
+  actions: true,
+  code: true,
+  quality: true,
+  release: true,
+  site_build: true,
+  site_check: true,
+  windows: true,
+});
+
+function selectedScopes(...keys: readonly CiScopeKey[]): Record<CiScopeKey, boolean> {
+  const scopes = noScopes();
+  for (const key of keys) scopes[key] = true;
+  return scopes;
+}
+
+function mergeScopes(target: Record<CiScopeKey, boolean>, source: CiScopes): void {
+  for (const key of ciScopeKeys) target[key] ||= source[key];
+}
+
+function normalizeGitPath(path: string): string | undefined {
+  const normalized = path.replaceAll('\\', '/').replace(/^\.\/+/, '');
+  if (
+    normalized.length === 0 ||
+    normalized.startsWith('/') ||
+    normalized.includes('\0') ||
+    normalized.split('/').some(segment => segment === '' || segment === '.' || segment === '..')
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function isDocumentationOnlyPath(path: string): boolean {
+  return (
+    path === 'LICENSE' ||
+    path === 'THIRD_PARTY.md' ||
+    path === 'CONTRIBUTION.md' ||
+    path === '.gitignore' ||
+    path === '.threadnoteignore' ||
+    path.startsWith('docs/') ||
+    path.startsWith('.github/release-notes/') ||
+    (/^[^/]+\.md$/u.test(path) && path !== 'README.md')
+  );
+}
+
+function isQualityPath(path: string): boolean {
+  return (
+    path.startsWith('src/code_graph/') ||
+    path.startsWith('src/crypto/') ||
+    path.startsWith('src/effect/ai/') ||
+    path.startsWith('src/evaluation/') ||
+    path.startsWith('src/models/') ||
+    path.startsWith('src/recall/') ||
+    path === 'src/effect/command.ts' ||
+    path === 'src/effect/digest.ts' ||
+    path === 'src/effect/file_lock.ts' ||
+    path === 'src/effect/runtime.ts' ||
+    path === 'src/effect/system.ts' ||
+    path === 'src/search/chunker.ts' ||
+    path === 'src/search/vector-index.ts' ||
+    path === 'src/search/vector-search.ts' ||
+    path === 'src/storage/layout.ts' ||
+    path.startsWith('test/evaluation/') ||
+    /^test\/(?:integration|unit)\/(?:code-graph|core-embedding|effect-ai|evaluation|manager-graph|model|recall|vector)/u.test(
+      path,
+    ) ||
+    path.startsWith('training/') ||
+    /^scripts\/(?:benchmark-(?:code-graph|recall|target|worktree-readiness)|capture-recall|code-graph|evaluate-(?:code-graph|recall)|recall-vector-storage-budget|training\/|.*reranker)/u.test(
+      path,
+    )
+  );
+}
+
+function isReleaseTestPath(path: string): boolean {
+  return (
+    path.startsWith('test/e2e/') ||
+    /^test\/(?:integration|unit)\/(?:build-code-sanitization|bun-package-contract|development-runtime|effect-system|installations|legacy-installation|lifecycle|process-diagnostics|release_notes|update|windows-support)/u.test(
+      path,
+    ) ||
+    path === 'vitest.e2e.config.ts' ||
+    path === 'vitest.windows-e2e.config.ts'
+  );
+}
+
+function scopesForWorkflow(path: string): CiScopes {
+  if (path === '.github/workflows/ci.yml') return allScopes();
+  if (path === '.github/workflows/pages.yml') {
+    return selectedScopes('actions', 'site_check', 'site_build');
+  }
+  if (path === '.github/workflows/benchmarks.yml' || path === '.github/workflows/production-large-evidence.yml') {
+    return selectedScopes('actions', 'quality');
+  }
+  if (
+    path === '.github/workflows/publish.yml' ||
+    path === '.github/workflows/publish-release-assets.yml' ||
+    path === '.github/workflows/release-evidence.yml'
+  ) {
+    return selectedScopes('actions', 'release');
+  }
+  return allScopes();
+}
+
+function scopesForScript(path: string): CiScopes {
+  if (path === 'scripts/site-performance-evidence.ts') {
+    return selectedScopes('code', 'site_check', 'site_build');
+  }
+  if (path.startsWith('scripts/effect/')) {
+    return selectedScopes('code', 'quality', 'release', 'windows');
+  }
+  if (path === 'scripts/generate-code-graph-language-catalog.ts') {
+    return selectedScopes('code', 'quality', 'release', 'windows');
+  }
+  if (isQualityPath(path)) return selectedScopes('code', 'quality');
+  if (
+    /^scripts\/(?:archive-release|build|check-self-contained|clean|compile-targets|development-runtime|install|install-local-standalone|release-targets|smoke-self-contained)\.(?:plist|ps1|sh|ts)$/u.test(
+      path,
+    ) ||
+    path === 'scripts/macos-entitlements.plist'
+  ) {
+    return selectedScopes('code', 'release', 'windows');
+  }
+  return allScopes();
+}
+
+function scopesForPath(path: string): CiScopes {
+  if (path.startsWith('website/')) return selectedScopes('site_check', 'site_build');
+  if (path === 'test/unit/website-content.test.ts' || path === 'test/unit/website-release-boundary.test.ts') {
+    return selectedScopes('code', 'site_check');
+  }
+  if (
+    /^test\/evaluation\/candidates\/threadnote-4\.0\.[01]\/benchmarks\/darwin-arm64-m1-max\/(?:code-graph-(?:intellij-(?:analysis-summary|query)|lexical-production-100k|worktree-readiness)-.*\.json)$/u.test(
+      path,
+    )
+  ) {
+    return selectedScopes('site_check', 'site_build');
+  }
+  if (path === 'README.md') return selectedScopes('site_check');
+  if (isDocumentationOnlyPath(path)) return noScopes();
+
+  if (path.startsWith('.github/workflows/')) return scopesForWorkflow(path);
+  if (path.startsWith('.github/')) return allScopes();
+  if (path.startsWith('scripts/')) return scopesForScript(path);
+  if (path === 'test/ci/ci-scopes.ts') return allScopes();
+
+  if (path === 'package.json' || path === 'bun.lock' || path === '.npmrc') return allScopes();
+  if (path === 'tsconfig.json') return selectedScopes('code', 'release', 'windows');
+  if (path === 'vitest.config.ts') return selectedScopes('code');
+  if (path === 'vitest.e2e.config.ts' || path === 'vitest.windows-e2e.config.ts') {
+    return selectedScopes('code', 'release', 'windows');
+  }
+  if (path === '.oxlintrc.json' || path === '.prettierrc.json' || path === '.prettierignore') {
+    return selectedScopes('code', 'site_check');
+  }
+  if (path.startsWith('.husky/')) return selectedScopes('code');
+
+  if (path.startsWith('src/')) {
+    const scopes = selectedScopes('code', 'release', 'windows');
+    if (isQualityPath(path)) scopes.quality = true;
+    if (path === 'src/evaluation/benchmark.ts') {
+      scopes.site_check = true;
+      scopes.site_build = true;
+    }
+    return scopes;
+  }
+  if (path.startsWith('assets/') || path.startsWith('config/') || path.startsWith('manager/')) {
+    return selectedScopes('code', 'release', 'windows');
+  }
+  if (path.startsWith('training/')) return selectedScopes('code', 'quality');
+  if (path.startsWith('test/')) {
+    const scopes = selectedScopes('code');
+    if (isQualityPath(path)) scopes.quality = true;
+    if (isReleaseTestPath(path)) {
+      scopes.release = true;
+      scopes.windows = true;
+    }
+    return scopes;
+  }
+
+  return allScopes();
+}
+
+export function classifyCiScopes(paths: Iterable<string>): CiScopeClassification {
+  const normalizedPaths = new Set<string>();
+  const scopes = noScopes();
+  let invalidPath = false;
+
+  for (const path of paths) {
+    const normalized = normalizeGitPath(path);
+    if (!normalized) {
+      invalidPath = true;
+      continue;
+    }
+    normalizedPaths.add(normalized);
+  }
+
+  const sortedPaths = [...normalizedPaths].sort((left, right) => left.localeCompare(right));
+  if (invalidPath || sortedPaths.length === 0)
+    return {changedCount: sortedPaths.length, paths: sortedPaths, scopes: allScopes()};
+
+  for (const path of sortedPaths) mergeScopes(scopes, scopesForPath(path));
+  return {changedCount: sortedPaths.length, paths: sortedPaths, scopes};
+}
+
+function commitArgument(name: '--base' | '--head'): string | undefined {
+  const index = Bun.argv.indexOf(name);
+  return index === -1 ? undefined : Bun.argv[index + 1];
+}
+
+function isCommitId(value: string | undefined): value is string {
+  return Boolean(value && /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/iu.test(value) && !/^0+$/u.test(value));
+}
+
+function classifyCurrentDiff(
+  base: string | undefined,
+  head: string | undefined,
+): {
+  readonly classification: CiScopeClassification;
+  readonly reason: string;
+} {
+  if (!isCommitId(base) || !isCommitId(head)) {
+    return {classification: classifyCiScopes([]), reason: 'missing-or-invalid-commit-range'};
+  }
+  const result = Bun.spawnSync({
+    cmd: ['git', 'diff', '--name-only', '-z', '--no-renames', `${base}...${head}`, '--'],
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    return {classification: classifyCiScopes([]), reason: `git-diff-failed-${result.exitCode}`};
+  }
+  const paths = new TextDecoder().decode(result.stdout).split('\0').filter(Boolean);
+  return {classification: classifyCiScopes(paths), reason: paths.length === 0 ? 'empty-diff-fail-safe' : 'classified'};
+}
+
+async function writeGitHubOutputs(classification: CiScopeClassification, reason: string): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    const lines = [
+      ...ciScopeKeys.map(key => `${key}=${String(classification.scopes[key])}`),
+      `changed_count=${classification.changedCount}`,
+      `reason=${reason}`,
+    ];
+    await Bun.write(outputPath, `${lines.join('\n')}\n`);
+  }
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    const enabled = ciScopeKeys.filter(key => classification.scopes[key]);
+    await Bun.write(
+      summaryPath,
+      `### CI scope\n\n- Changed paths: ${classification.changedCount}\n- Reason: \`${reason}\`\n- Enabled: ${
+        enabled.length > 0 ? enabled.map(key => `\`${key}\``).join(', ') : 'formatting only'
+      }\n`,
+    );
+  }
+}
+
+if (import.meta.main) {
+  const {classification, reason} = classifyCurrentDiff(commitArgument('--base'), commitArgument('--head'));
+  await writeGitHubOutputs(classification, reason);
+  process.stdout.write(
+    `${JSON.stringify({changedCount: classification.changedCount, reason, scopes: classification.scopes})}\n`,
+  );
+}

--- a/test/unit/ci-scopes.property.test.ts
+++ b/test/unit/ci-scopes.property.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from '@effect/vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {ciScopeKeys, classifyCiScopes, type CiScopeKey} from '../ci/ci-scopes.js';
+
+const pathSegment = FC.stringMatching(/^[a-z][a-z0-9_-]{0,20}$/u);
+const websitePath = FC.array(pathSegment, {maxLength: 5, minLength: 1}).map(parts => `website/${parts.join('/')}.tsx`);
+const documentationPath = FC.oneof(
+  FC.array(pathSegment, {maxLength: 5, minLength: 1}).map(parts => `docs/${parts.join('/')}.md`),
+  pathSegment.map(segment => `${segment}.md`),
+);
+const knownPath = FC.oneof(
+  websitePath,
+  documentationPath,
+  pathSegment.map(segment => `src/${segment}.ts`),
+  pathSegment.map(segment => `test/unit/${segment}.test.ts`),
+  pathSegment.map(segment => `scripts/${segment}.ts`),
+  FC.constantFrom('README.md', 'package.json', '.github/workflows/pages.yml', '.github/workflows/ci.yml'),
+);
+
+function enabledScopes(paths: readonly string[]): readonly CiScopeKey[] {
+  const classification = classifyCiScopes(paths);
+  return ciScopeKeys.filter(key => classification.scopes[key]);
+}
+
+describe('CI changed-path scope properties', () => {
+  it.prop(
+    'is invariant to path order and duplicates',
+    {paths: FC.array(knownPath, {maxLength: 40, minLength: 1})},
+    ({paths}) => {
+      const expected = classifyCiScopes(paths);
+      const reordered = classifyCiScopes([...paths].reverse());
+      const duplicated = classifyCiScopes([...paths, ...paths]);
+
+      expect(reordered).toEqual(expected);
+      expect(duplicated).toEqual(expected);
+    },
+    {fastCheck: {numRuns: 300}},
+  );
+
+  it.prop(
+    'never disables a scope when another changed path is added',
+    {paths: FC.array(knownPath, {maxLength: 30, minLength: 1}), extra: knownPath},
+    ({paths, extra}) => {
+      const before = classifyCiScopes(paths).scopes;
+      const after = classifyCiScopes([...paths, extra]).scopes;
+
+      for (const key of ciScopeKeys) {
+        if (before[key]) expect(after[key]).toBe(true);
+      }
+    },
+    {fastCheck: {numRuns: 300}},
+  );
+
+  it.prop(
+    'isolates pure website changes from runtime, release, Windows, and quality work',
+    {paths: FC.array(websitePath, {maxLength: 30, minLength: 1})},
+    ({paths}) => {
+      expect(enabledScopes(paths)).toEqual(['site_check', 'site_build']);
+    },
+    {fastCheck: {numRuns: 250}},
+  );
+
+  it.prop(
+    'keeps pure documentation changes on the formatting-only lane',
+    {paths: FC.array(documentationPath, {maxLength: 30, minLength: 1})},
+    ({paths}) => {
+      expect(enabledScopes(paths)).toEqual([]);
+    },
+    {fastCheck: {numRuns: 250}},
+  );
+
+  it.prop(
+    'fails safe for paths outside the classified repository surface',
+    {segment: pathSegment},
+    ({segment}) => {
+      expect(enabledScopes([`unclassified-${segment}/payload.bin`])).toEqual(ciScopeKeys);
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+
+  it('fails safe for empty, invalid, and parent-traversing path inventories', () => {
+    for (const paths of [[], [''], ['../website/index.html'], ['/website/index.html']]) {
+      expect(enabledScopes(paths)).toEqual(ciScopeKeys);
+    }
+  });
+
+  it('maps representative repository paths to the expected expensive scopes', () => {
+    expect(enabledScopes(['test/unit/utils.test.ts'])).toEqual(['code']);
+    expect(enabledScopes(['src/installations.ts'])).toEqual(['code', 'release', 'windows']);
+    expect(enabledScopes(['src/recall/index.ts'])).toEqual(['code', 'quality', 'release', 'windows']);
+    expect(enabledScopes(['.github/workflows/pages.yml'])).toEqual(['actions', 'site_check', 'site_build']);
+    expect(enabledScopes(['README.md'])).toEqual(['site_check']);
+    expect(enabledScopes(['test/ci/ci-scopes.ts'])).toEqual(ciScopeKeys);
+    expect(enabledScopes(['scripts/benchmark-worktree-readiness.ts'])).toEqual(['code', 'quality']);
+    expect(enabledScopes(['scripts/release-targets.ts'])).toEqual(['code', 'release', 'windows']);
+    expect(enabledScopes(['scripts/effect/script.ts'])).toEqual(['code', 'quality', 'release', 'windows']);
+  });
+});

--- a/test/unit/ci-workflow.test.ts
+++ b/test/unit/ci-workflow.test.ts
@@ -1,0 +1,127 @@
+import {readFileSync} from 'node:fs';
+import {JSON_SCHEMA, load} from 'js-yaml';
+import {describe, expect, it} from 'vitest';
+import {ciScopeKeys} from '../ci/ci-scopes.js';
+
+interface WorkflowStep {
+  readonly env?: Readonly<Record<string, string>>;
+  readonly id?: string;
+  readonly if?: string;
+  readonly name?: string;
+  readonly run?: string;
+  readonly uses?: string;
+  readonly with?: Readonly<Record<string, unknown>>;
+}
+
+interface WorkflowJob {
+  readonly if?: string;
+  readonly needs?: string | readonly string[];
+  readonly outputs?: Readonly<Record<string, string>>;
+  readonly steps?: readonly WorkflowStep[];
+}
+
+interface Workflow {
+  readonly jobs: Readonly<Record<string, WorkflowJob>>;
+  readonly on: {
+    readonly pull_request?: {
+      readonly paths?: readonly string[];
+      readonly 'paths-ignore'?: readonly string[];
+    };
+    readonly push?: {
+      readonly paths?: readonly string[];
+      readonly 'paths-ignore'?: readonly string[];
+    };
+  };
+}
+
+function workflow(path: string): Workflow {
+  return load(readFileSync(path, 'utf8'), {schema: JSON_SCHEMA}) as Workflow;
+}
+
+function stepForRun(job: WorkflowJob, run: string): WorkflowStep {
+  const step = job.steps?.find(candidate => candidate.run === run);
+  expect(step, `missing workflow step: ${run}`).toBeDefined();
+  return step!;
+}
+
+describe('dependency-aware CI workflow', () => {
+  it('exports every classifier scope and preserves a fail-safe full-diff checkout', () => {
+    const ci = workflow('.github/workflows/ci.yml');
+    const changes = ci.jobs.changes!;
+    const checkout = changes.steps?.find(step => step.uses?.startsWith('actions/checkout@'));
+    const classifier = changes.steps?.find(step => step.id === 'scopes');
+
+    expect(Object.keys(changes.outputs ?? {})).toEqual(ciScopeKeys);
+    expect(checkout?.with?.['fetch-depth']).toBe(0);
+    expect(classifier?.run).toBe('bun test/ci/ci-scopes.ts --base "$BASE_SHA" --head "$HEAD_SHA"');
+    expect(classifier?.env).toMatchObject({
+      BASE_SHA: '${{ github.event.pull_request.base.sha || github.event.before }}',
+      HEAD_SHA: '${{ github.event.pull_request.head.sha || github.sha }}',
+    });
+  });
+
+  it('keeps the stable primary check while gating its expensive steps by scope', () => {
+    const ci = workflow('.github/workflows/ci.yml');
+    const job = ci.jobs.test!;
+    const actionlint = job.steps?.find(step => step.uses === 'docker://rhysd/actionlint:1.7.8');
+
+    expect(job.needs).toBe('changes');
+    expect(actionlint?.if).toBe("needs.changes.outputs.actions == 'true'");
+    expect(stepForRun(job, 'bun run prettier:check').if).toBeUndefined();
+    expect(stepForRun(job, 'bun run lint').if).toBe("needs.changes.outputs.code == 'true'");
+    expect(stepForRun(job, 'bun run typecheck').if).toBe("needs.changes.outputs.code == 'true'");
+    expect(stepForRun(job, 'bun run site:check').if).toBe(
+      "needs.changes.outputs.site_check == 'true' && needs.changes.outputs.code != 'true'",
+    );
+    expect(stepForRun(job, 'bun run site:build').if).toBe("needs.changes.outputs.site_build == 'true'");
+    expect(stepForRun(job, 'bun run build').if).toBe("needs.changes.outputs.release == 'true'");
+    expect(stepForRun(job, 'bun run check:self-contained').if).toBe("needs.changes.outputs.release == 'true'");
+    expect(stepForRun(job, 'bun run test:coverage').if).toBe("needs.changes.outputs.code == 'true'");
+  });
+
+  it('gates quality, Windows, bytecode, model, and release matrices independently', () => {
+    const jobs = workflow('.github/workflows/ci.yml').jobs;
+
+    expect(jobs['recall-quality']).toMatchObject({
+      needs: 'changes',
+      if: "needs.changes.outputs.quality == 'true'",
+    });
+    expect(jobs['windows-smoke']).toMatchObject({
+      needs: 'changes',
+      if: "needs.changes.outputs.windows == 'true'",
+    });
+    for (const name of ['prepare-e2e-model', 'standalone-targets']) {
+      expect(jobs[name]).toMatchObject({
+        needs: 'changes',
+        if: "needs.changes.outputs.release == 'true'",
+      });
+    }
+    expect(jobs['self-contained-distribution']).toMatchObject({
+      needs: ['changes', 'prepare-e2e-model'],
+      if: "needs.changes.outputs.release == 'true' && needs.prepare-e2e-model.result == 'success'",
+    });
+  });
+
+  it('routes website-only changes to PR site checks and output-changing pushes to Pages', () => {
+    const ci = workflow('.github/workflows/ci.yml');
+    const pages = workflow('.github/workflows/pages.yml');
+    const benchmarks = workflow('.github/workflows/benchmarks.yml');
+    const pagePaths = pages.on.push?.paths ?? [];
+    const benchmarkPaths = benchmarks.on.pull_request?.paths ?? [];
+
+    expect(ci.on.push?.['paths-ignore']).toEqual(
+      expect.arrayContaining(['.github/release-notes/**', '*.md', 'LICENSE', 'docs/**', 'website/**']),
+    );
+    expect(ci.on.pull_request?.['paths-ignore']).toBeUndefined();
+    expect(pagePaths).toEqual(
+      expect.arrayContaining([
+        '.github/workflows/pages.yml',
+        'scripts/site-performance-evidence.ts',
+        'src/evaluation/benchmark.ts',
+        'website/**',
+      ]),
+    );
+    expect(pagePaths).not.toContain('src/**');
+    expect(benchmarkPaths.some(path => path === 'website/**' || path.startsWith('website/'))).toBe(false);
+  });
+});

--- a/test/unit/publish-workflow.test.ts
+++ b/test/unit/publish-workflow.test.ts
@@ -144,7 +144,7 @@ describe('standalone release workflows', () => {
 
       expect(ci).toContain('docker://rhysd/actionlint:1.7.8');
       expect(ci).toContain('args: -color');
-      expect(ci).not.toContain('-ignore');
+      expect(ci).not.toMatch(/^\s*args:[^\n]*-ignore/gm);
       expect(yield* projectFileExists('.github/actionlint.yaml')).toBe(false);
       expect(yield* projectFileExists('.github/actionlint.yml')).toBe(false);
       for (const runner of hostedReleaseRunners) {

--- a/test/unit/website-release-boundary.test.ts
+++ b/test/unit/website-release-boundary.test.ts
@@ -158,7 +158,11 @@ describe('website and standalone release boundary', () => {
     expect(workflow).toContain('bun run site:build');
     expect(workflow).toContain('fetch-depth: 0');
     const pushTrigger = workflow.slice(workflow.indexOf('  push:'), workflow.indexOf('  workflow_dispatch:'));
-    expect(pushTrigger).not.toContain('paths:');
+    expect(pushTrigger).toContain('paths:');
+    expect(pushTrigger).toContain("'website/**'");
+    expect(pushTrigger).toContain("'scripts/site-performance-evidence.ts'");
+    expect(pushTrigger).toContain("'src/evaluation/benchmark.ts'");
+    expect(pushTrigger).not.toContain("'src/**'");
     expect(workflow).toContain('path: site-dist');
     expect(workflow).toContain('actions/deploy-pages@');
     expect(workflow).toMatch(/^ {2}THREADNOTE_SITE_BASE: \/$/m);


### PR DESCRIPTION
## Summary\n\n- classify the complete pull-request or push diff into independent website, code, quality, release, Windows, and workflow scopes\n- keep unknown and invalid path inventories fail-safe while skipping unrelated recall, benchmark, bytecode, platform, and Pages work\n- add property-based scope invariants, workflow contract tests, and contributor documentation\n\nThis workflow-changing pull request intentionally selects every scope once so the new router is exercised by the complete pipeline before merge.\n\n## Validation\n\n- Actionlint 1.7.8\n- lint, Prettier, and TypeScript checks\n- full coverage: 186 files and 1,775 tests\n- standalone build, self-contained validation, and standalone smoke\n- website contracts and production website build\n- recall v1, recall v2 non-inferiority, and native code-graph quality gates\n- exact-head global install and code-graph dogfood