### PR TITLE
Fix MCP canonical read client compatibility

### DIFF
--- a/src/effect/ai/mcp.ts
+++ b/src/effect/ai/mcp.ts
@@ -26,6 +26,7 @@ interface ToolDefinition<Fields extends ToolFields> {
 }
 
 interface ToolResult {
+  readonly _meta?: Readonly<Record<string, unknown>>;
   readonly content: readonly unknown[];
   readonly isError?: boolean;
   readonly structuredContent?: unknown;

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -4429,7 +4429,10 @@ function runNativeReadTool(
   // to derived graph/search evidence, never to user-authored memory content.
   // Keep the canonical bytes in MCP content only: repeating them in
   // structuredContent can make an otherwise valid read exceed a client's
-  // transport-frame policy.
+  // transport-frame policy, while metadata-only structuredContent can cause
+  // clients that prefer structured results to hide the canonical bytes. The
+  // URI-to-content association is implementation metadata, so keep it in the
+  // protocol-reserved _meta field instead of a model-facing result field.
   return Effect.gen(function* () {
     const store = yield* ResourceStore;
     const content: Array<{readonly text: string; readonly type: 'text'}> = [];
@@ -4440,8 +4443,10 @@ function runNativeReadTool(
       content.push({text, type: 'text'});
     }
     return {
+      _meta: {
+        'threadnote.io/canonical-read': {resources, type: 'threadnote-canonical-read', version: 1},
+      },
       content,
-      structuredContent: {resources, type: 'threadnote-canonical-read', version: 1},
     } satisfies CallToolResult;
   }).pipe(
     Effect.catch(error =>

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -12,11 +12,13 @@ interface TextContent {
   readonly type: 'text';
 }
 
-interface CanonicalReadStructuredContent {
+interface CanonicalReadMetadata {
   readonly resources: readonly {readonly contentIndex: number; readonly uri: string}[];
   readonly type: 'threadnote-canonical-read';
   readonly version: 1;
 }
+
+const CANONICAL_READ_METADATA_KEY = 'threadnote.io/canonical-read';
 
 const CORE_TOOL_NAMES = [
   'recall_context',
@@ -252,12 +254,13 @@ describe('Threadnote MCP toolsets', () => {
         });
 
         const result = await client.callTool({arguments: {uri}, name: 'read_context'}, undefined, {timeout: 30_000});
-        const structured = result.structuredContent as CanonicalReadStructuredContent | undefined;
+        const metadata = result._meta?.[CANONICAL_READ_METADATA_KEY] as CanonicalReadMetadata | undefined;
         const content = Array.isArray(result.content) ? result.content : [];
         const text = (content[0] as TextContent | undefined)?.text;
 
         expect(result.isError, JSON.stringify(result)).not.toBe(true);
-        expect(structured).toEqual({
+        expect(result.structuredContent).toBeUndefined();
+        expect(metadata).toEqual({
           resources: [{contentIndex: 0, uri}],
           type: 'threadnote-canonical-read',
           version: 1,
@@ -280,7 +283,8 @@ describe('Threadnote MCP toolsets', () => {
 
         expect(result.isError, JSON.stringify(result)).not.toBe(true);
         expect(result.content).toEqual([{text: content, type: 'text'}]);
-        expect(result.structuredContent).toEqual({
+        expect(result.structuredContent).toBeUndefined();
+        expect(result._meta?.[CANONICAL_READ_METADATA_KEY]).toEqual({
           resources: [{contentIndex: 0, uri}],
           type: 'threadnote-canonical-read',
           version: 1,
@@ -306,7 +310,8 @@ describe('Threadnote MCP toolsets', () => {
         expect(result.isError, JSON.stringify(result)).not.toBe(true);
         expect(Buffer.byteLength(text ?? '')).toBeGreaterThan(10 * 1_024 * 1_024);
         expect(text).toBe(content);
-        expect(result.structuredContent).toEqual({
+        expect(result.structuredContent).toBeUndefined();
+        expect(result._meta?.[CANONICAL_READ_METADATA_KEY]).toEqual({
           resources: [{contentIndex: 0, uri}],
           type: 'threadnote-canonical-read',
           version: 1,
@@ -342,7 +347,8 @@ describe('Threadnote MCP toolsets', () => {
           {text: firstContent, type: 'text'},
           {text: secondContent, type: 'text'},
         ]);
-        expect(result.structuredContent).toEqual({
+        expect(result.structuredContent).toBeUndefined();
+        expect(result._meta?.[CANONICAL_READ_METADATA_KEY]).toEqual({
           resources: [
             {contentIndex: 0, uri: firstUri},
             {contentIndex: 1, uri: secondUri},
@@ -401,7 +407,8 @@ describe('Threadnote MCP toolsets', () => {
           expect(output).toHaveLength(1);
           expect(primary).toEqual({text: content, type: 'text'});
           expect(Buffer.byteLength(primary?.text ?? '')).toBeGreaterThan(1_024 * 1_024);
-          expect(result.structuredContent).toEqual({
+          expect(result.structuredContent).toBeUndefined();
+          expect(result._meta?.[CANONICAL_READ_METADATA_KEY]).toEqual({
             resources: [{contentIndex: 0, uri}],
             type: 'threadnote-canonical-read',
             version: 1,


### PR DESCRIPTION
## Summary

- keep canonical memory bodies exclusively in MCP text `content`
- move the URI-to-content-index association from model-facing `structuredContent` to namespaced `_meta`
- add regression coverage for large reads, multi-resource ordering, and auto-sync contention

## Root cause

Threadnote returned the complete memory text and a metadata-only `structuredContent` object. Clients that prefer structured results could expose only the URI/index metadata to the model, making a successful canonical read appear empty. The new result shape keeps the full bytes as the sole model-facing output without duplicating large memories.

## User impact

Claude and other MCP clients that prioritize structured tool output now receive the canonical memory text instead of an index-only object. Protocol-aware consumers can still read the association from `_meta["threadnote.io/canonical-read"]`.

## Validation

- full repository suite: 184 files, 1,764 tests passed
- focused MCP integration after rebase: 20/20 passed
- source, test, and website typechecks passed
- oxlint and Prettier passed
- standalone binary build passed
- raw MCP calls against source and built binary returned full text, no `structuredContent`, and preserved namespaced metadata
