### PR TITLE
Avoid blocking graph queries after clean pulls

### DIFF
--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -600,20 +600,27 @@ export const runCodeGraphInspect = Effect.fn('codeGraph.command.inspect')(functi
   const cwd = yield* commandCwd(options.cwd);
   const status = yield* service.status(config.agentContextHome, cwd);
   const strictFreshness = options.operation === 'impact' || options.operation === 'path';
+  const statusObservation = observationFromCodeGraphStatus(status);
+  // Preserve live-edit behavior, but do not make an ordinary read wait for a clean post-pull rebuild.
+  const staleAfterCleanCommitChange =
+    status.readySnapshot !== undefined &&
+    status.readySnapshot.commit !== status.identity.headCommit &&
+    statusObservation?.overlay.dirty === false;
+  const refresh = !status.readySnapshot || (status.stale && (strictFreshness || !staleAfterCleanCommitChange));
   const inspect = (onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void>) =>
     service.inspect({
       ...options,
       cwd,
       onProgress,
-      refresh: true,
-      statusObservation: observationFromCodeGraphStatus(status),
+      refresh,
+      statusObservation,
       strictFreshness,
       threadnoteHome: config.agentContextHome,
     });
   const reportProgress = options.json ? yield* makeCodeGraphJsonProgressReporter() : undefined;
   const result = options.json
     ? yield* inspect(reportProgress)
-    : status.stale
+    : refresh
       ? yield* Effect.acquireUseRelease(
           startProgress('Scanning repository source from Git.'),
           progress => inspect(state => progress.update(progressMessage(state)).pipe(Effect.catch(() => Effect.void))),

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -371,7 +371,7 @@ export const traversalQuery = Effect.fn('codeGraph.traversalQuery')(function* (
     : [...lexicalById.values()]
         .sort((left, right) => right.score - left.score || compareCodeUnits(left.id, right.id))
         .slice(0, seedLimit);
-  const semanticEligible = !timedOut && !(impact && seedQueries?.length);
+  const semanticEligible = !timedOut && !(impact && seedQueries?.length) && lexicalSeeds.length < seedLimit;
   const semanticResult = !semanticEligible
     ? {scores: new Map<string, number>(), timedOut: false}
     : yield* embedding.search(threadnoteHome, layout, snapshotId, query, Math.min(nodeLimit, 12)).pipe(

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -114,6 +114,74 @@ describe('Effect CLI', () => {
     }
   });
 
+  it('returns a ready stale graph immediately after the checked-out commit changes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-graph-stale-query-'));
+    const home = join(root, '.threadnote-test-home');
+    try {
+      await writeFile(join(root, 'package.json'), '{"name":"stale-query"}\n');
+      await writeFile(join(root, 'index.ts'), 'export function indexedBeforePull(): number { return 1; }\n');
+      await execFilePromise('git', ['-C', root, 'init', '-q']);
+      await execFilePromise('git', ['-C', root, 'add', '.']);
+      await execFilePromise('git', [
+        '-C',
+        root,
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=test@threadnote.local',
+        'commit',
+        '-qm',
+        'indexed commit',
+      ]);
+      const indexedCommit = (await execFilePromise('git', ['-C', root, 'rev-parse', 'HEAD'])).stdout.trim();
+      await runCli(['graph', 'index', '--home', home, '--cwd', root, '--json']);
+
+      await writeFile(join(root, 'after-pull.ts'), 'export function addedAfterPull(): number { return 2; }\n');
+      await execFilePromise('git', ['-C', root, 'add', 'after-pull.ts']);
+      await execFilePromise('git', [
+        '-C',
+        root,
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=test@threadnote.local',
+        'commit',
+        '-qm',
+        'simulated pull',
+      ]);
+
+      const result = await runCli([
+        'graph',
+        'query',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--query',
+        'indexedBeforePull',
+        '--node-limit',
+        '1',
+        '--depth',
+        '0',
+        '--edge-limit',
+        '1',
+        '--json',
+      ]);
+      const graph = JSON.parse(result.stdout) as {
+        readonly freshness?: string;
+        readonly nodes?: readonly {readonly name?: string}[];
+        readonly snapshot?: {readonly commit?: string};
+      };
+
+      expect(graph.freshness).toBe('stale');
+      expect(graph.snapshot?.commit).toBe(indexedCommit);
+      expect(graph.nodes?.some(node => node.name === 'indexedBeforePull')).toBe(true);
+      expect(result.stderr).toBe('');
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  }, 30_000);
+
   it('drains graph query JSON larger than the platform pipe buffer before exiting', async () => {
     const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-graph-large-output-'));
     const home = join(root, '.threadnote-test-home');

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -229,6 +229,53 @@ describe('code graph query budgets', () => {
     }),
   );
 
+  it.effect('skips semantic search when lexical search fills the seed budget', () =>
+    Effect.gen(function* () {
+      const lexicalMatches = Array.from({length: 12}, (_, index) => ({
+        ...seed,
+        contentHash: `lexical-${index}-hash`,
+        id: `lexical-${index}`,
+        name: `lexical${index}`,
+        qualifiedName: `lexical${index}`,
+      }));
+      let semanticCalls = 0;
+      const store = {
+        edgesForNodes: () => Effect.succeed([]),
+        searchSymbolsMany: () => Effect.succeed([lexicalMatches]),
+        symbolsByIds: () => Effect.succeed([]),
+      } as unknown as CodeGraphStoreShape;
+      const unnecessaryEmbedding = {
+        search: () =>
+          Effect.sync(() => {
+            semanticCalls += 1;
+            return new Map<string, number>();
+          }),
+      } as unknown as CodeGraphEmbeddingIndexShape;
+
+      const result = yield* traversalQuery(
+        store,
+        layout.databasePath,
+        'snapshot',
+        'director dependency injection',
+        'both',
+        12,
+        1,
+        0,
+        ['resolved'],
+        unnecessaryEmbedding,
+        '/fixture/home',
+        layout,
+        false,
+      );
+
+      expect(result.nodes).toHaveLength(12);
+      expect(semanticCalls).toBe(0);
+      expect(result.warnings).not.toContain(
+        'Semantic graph search reached its elapsed-time budget; lexical graph results were returned.',
+      );
+    }),
+  );
+
   it.effect('accepts semantic evidence that takes longer than the traversal budget', () =>
     Effect.gen(function* () {
       const calls: string[] = [];


### PR DESCRIPTION
## What changed

- Return the latest ready code-graph snapshot immediately for ordinary query, node, and explain reads after a clean commit switch.
- Preserve synchronous freshness for dirty worktree overlays and strict path/impact reads.
- Skip semantic vector search when lexical search already fills the query seed budget.
- Add CLI and unit regressions for both latency paths.

## Why

A graph query immediately after pulling a new commit synchronously rebuilt a large stale graph before returning any evidence. On a warm graph, strong lexical matches still waited for the exact semantic vector scan to hit its 10-second budget.

The CLI always requested refresh even for non-strict operations, unlike the existing MCP stale-snapshot policy. Traversal also invoked semantic search even when lexical search had already supplied every seed it could use.

## Impact

Large-monorepo queries after a clean pull can return the previous ready snapshot immediately, explicitly marked `freshness: "stale"`. Dirty local edits remain visible through the existing refresh behavior, and strict operations remain current. Lexically complete queries avoid unnecessary semantic latency.

## Validation

- Full suite: 186 test files, 1,777 tests passed before rebase.
- Rebased onto current `origin/main`.
- Post-rebase focused query and CLI integration regressions passed.
- Post-rebase typecheck, lint, and Prettier checks passed.
- Globally installed exact-HEAD build was dogfooded against a simulated pull; the query returned 12 lexical matches in 0.33 seconds without rebuilding.
