### PR TITLE
Release Threadnote 4.0.2

### DIFF
--- a/.github/release-notes/v4.0.2.md
+++ b/.github/release-notes/v4.0.2.md
@@ -1,0 +1,17 @@
+## What's new
+
+Threadnote 4.0.2 keeps graph queries responsive after pulling a new clean commit, improves compatibility for canonical
+MCP reads, and refreshes the runtime and release pipeline.
+
+- **Query immediately after clean pulls.** Ordinary graph queries, node lookups, and explanations can use the ready
+  graph snapshot while the new commit is indexed instead of blocking on a refresh. Dirty-worktree overlays still
+  refresh before answering, and exact path and impact queries retain their stricter freshness requirements.
+- **Avoid unnecessary semantic scans.** When lexical graph matches already fill the candidate budget, Threadnote skips
+  the vector search instead of spending up to its semantic timeout without changing the result set.
+- **Read canonical MCP content reliably.** Canonical content metadata now travels in protocol metadata rather than
+  model-facing structured output, including for clients that prefer structured results and for large payloads.
+- **Refresh dependencies and security overrides.** The release updates Effect, React, YAML and compression libraries,
+  and pins patched transitive versions for the affected networking and parsing packages.
+- **Harden release evidence.** Stable Threadnote 4 tags are accepted by the production benchmark provenance gate, CI
+  scopes checks by changed paths, and checked-in measurements document graph-equivalent and one-file worktree
+  readiness.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone release version from 4.0.1 to 4.0.2
- add versioned release notes covering every user-visible change since 4.0.1
- include the post-pull graph latency fix, MCP canonical-read compatibility, dependency/security refreshes, and release evidence improvements

## Release audit

- reviewed all commits after `v4.0.1` through the merged graph-query fix in #109
- reviewed the latest retained production-large evidence attempt for `v4.0.1`; it failed provenance validation before measurement, which the already-merged stable-tag fix corrects for this tag
- confirmed the release workflow owns immutable GitHub release creation after the version tag is pushed

## Checks

- `bun --bun vitest run test/unit/release_notes.test.ts test/unit/publish-workflow.test.ts test/unit/ci-workflow.test.ts test/unit/benchmark-workflow.test.ts test/unit/code-graph.release-evidence.test.ts test/unit/website-release-boundary.test.ts` (56 tests)
- `bun run precommit` (lint, formatting, 186 files / 1,777 tests)
- commit hook (lint, formatting, 186 files / 1,777 tests)
