### PR TITLE
Improve site text readability

### DIFF
--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -1381,6 +1381,16 @@ describe('Threadnote 4 website content', () => {
     );
   });
 
+  it('keeps every explicit site text size at or above the shared 12px minimum', async () => {
+    const styles = await readFile(join(root, 'website', 'src', 'styles.css'), 'utf8');
+    const explicitPixelSizes = [...styles.matchAll(/(?:font-size:\s*|font:\s*)(\d+(?:\.\d+)?)px/g)].map(match =>
+      Number(match[1]),
+    );
+
+    expect(styles).toContain('--font-size-min: 12px;');
+    expect(explicitPixelSizes.filter(size => size < 12)).toEqual([]);
+  });
+
   it('stacks the worktree-readiness evidence without connector overflow on mobile', async () => {
     const styles = await readFile(join(root, 'website', 'src', 'styles.css'), 'utf8');
     const tabletStart = styles.indexOf('@media (max-width: 980px)');

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -18,6 +18,7 @@
   --magenta: #f17cdd;
   --red: #ff7e86;
   --green: #78e6a3;
+  --font-size-min: 12px;
   --content: 1240px;
   --content-wide: 1440px;
   --radius: 12px;
@@ -164,7 +165,7 @@ p {
   min-height: 100vh;
   color: var(--text-soft);
   font:
-    12px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -197,7 +198,7 @@ p {
   min-height: 44px;
   padding: 0 18px;
   color: var(--ink);
-  font-size: 12px;
+  font-size: var(--font-size-min);
   font-weight: 650;
   background: var(--teal);
   border: 1px solid var(--teal);
@@ -217,11 +218,21 @@ p {
   display: block;
   margin-bottom: 16px;
   color: var(--teal);
-  font-size: 11px;
+  font-size: var(--font-size-min);
   font-weight: 620;
   letter-spacing: 0.11em;
   line-height: 1.4;
   text-transform: uppercase;
+}
+
+.trust-strip span,
+.hero__install,
+.hero__install code,
+.docs-nav-section a,
+.docs-sidebar__github,
+.docs-outline,
+.manager-demo-hero-facts span {
+  font-size: var(--font-size-min);
 }
 
 .site-header {
@@ -276,7 +287,7 @@ p {
 .site-nav > a {
   position: relative;
   color: var(--text-soft);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 530;
 }
 
@@ -327,7 +338,7 @@ p {
   min-height: 48px;
   padding: 0 20px;
   color: #08110f;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 650;
   background: var(--teal);
   border: 1px solid var(--teal);
@@ -354,7 +365,7 @@ p {
   min-height: 36px;
   padding: 0 15px;
   color: var(--ink) !important;
-  font-size: 12px !important;
+  font-size: var(--font-size-min) !important;
 }
 
 .button--ghost {
@@ -392,7 +403,7 @@ p {
 .site-footer p {
   margin: 12px 0 0;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .site-footer__links {
@@ -400,7 +411,7 @@ p {
   align-items: flex-start;
   gap: 28px;
   color: var(--text-soft);
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .site-footer__links a:hover {
@@ -452,7 +463,7 @@ p {
   padding: 8px 11px;
   color: var(--text-soft);
   font:
-    10px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -495,7 +506,6 @@ p {
   min-width: 0;
   margin-top: 24px;
   color: var(--muted);
-  font-size: 11px;
 }
 
 .hero__install code {
@@ -505,7 +515,6 @@ p {
   overflow-x: auto;
   padding: 7px 9px;
   color: var(--text-soft);
-  font-size: 10px;
   background: var(--panel);
   border: 1px solid var(--line-soft);
   border-radius: 4px;
@@ -625,14 +634,14 @@ p {
   margin-bottom: 6px;
   color: var(--muted);
   font:
-    9px/1.2 'JetBrains Mono Variable',
+    var(--font-size-min)/1.2 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.09em;
   text-transform: uppercase;
 }
 
 .hero-node strong {
-  font-size: 12px;
+  font-size: var(--font-size-min);
   font-weight: 560;
 }
 
@@ -663,7 +672,7 @@ p {
   gap: 14px;
   color: var(--muted);
   font:
-    9px/1.2 'JetBrains Mono Variable',
+    var(--font-size-min)/1.2 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -706,7 +715,6 @@ p {
 
 .trust-strip span {
   color: var(--muted);
-  font-size: 11px;
   line-height: 1.4;
 }
 
@@ -775,7 +783,7 @@ p {
 
 .agent-trace__header .eyebrow {
   margin-bottom: 8px;
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .agent-trace__header h3 {
@@ -787,7 +795,7 @@ p {
 .agent-trace__header p {
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 15px;
 }
 
 .agent-trace__controls {
@@ -800,7 +808,7 @@ p {
   padding: 0 11px;
   color: var(--text-soft);
   font:
-    10px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   background: transparent;
   border: 1px solid var(--line);
@@ -842,7 +850,7 @@ p {
   margin-bottom: 18px;
   color: var(--muted);
   font:
-    9px/1.2 'JetBrains Mono Variable',
+    var(--font-size-min)/1.2 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.09em;
   text-transform: uppercase;
@@ -925,7 +933,7 @@ p {
   margin-bottom: 6px;
   color: var(--muted);
   font:
-    9px/1.2 'JetBrains Mono Variable',
+    var(--font-size-min)/1.2 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -933,7 +941,7 @@ p {
 .trace-message p {
   margin-bottom: 0;
   color: var(--text-soft);
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.55;
 }
 
@@ -941,7 +949,7 @@ p {
   display: block;
   margin-top: 8px;
   color: var(--teal);
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .tool-call {
@@ -962,7 +970,7 @@ p {
 .tool-call__icon {
   color: var(--violet);
   font:
-    12px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -970,7 +978,7 @@ p {
   overflow: hidden;
   color: var(--text);
   font:
-    10px/1.3 'JetBrains Mono Variable',
+    var(--font-size-min)/1.3 'JetBrains Mono Variable',
     monospace;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -980,7 +988,7 @@ p {
   display: block;
   overflow: hidden;
   color: #91a0b0;
-  font-size: 9px;
+  font-size: var(--font-size-min);
   line-height: 1.55;
   text-overflow: ellipsis;
 }
@@ -990,7 +998,7 @@ p {
   margin-top: 8px;
   color: var(--muted);
   font:
-    8px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -1016,20 +1024,20 @@ p {
 .evidence-list span {
   margin-top: 3px;
   color: var(--teal);
-  font-size: 7px;
+  font-size: var(--font-size-min);
 }
 
 .evidence-list code {
   min-width: 0;
   overflow-wrap: anywhere;
   color: var(--text-soft);
-  font-size: 8px;
+  font-size: var(--font-size-min);
   line-height: 1.5;
 }
 
 .empty-state {
   color: var(--muted);
-  font-size: 11px;
+  font-size: 13px;
   text-align: center;
 }
 
@@ -1044,7 +1052,7 @@ p {
   padding: 10px;
   color: var(--muted);
   font:
-    8px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
   background: rgba(8, 11, 16, 0.72);
   border: 1px solid var(--line-soft);
@@ -1113,7 +1121,7 @@ p {
   grid-row: 1 / 3;
   color: var(--teal);
   font:
-    10px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -1134,7 +1142,7 @@ p {
 .graph-showcase__tool-switcher small {
   color: var(--muted);
   font:
-    9px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -1172,7 +1180,7 @@ p {
 .graph-showcase__capabilities article > div span,
 .graph-showcase__capabilities article > div small {
   font:
-    9px/1.35 'JetBrains Mono Variable',
+    var(--font-size-min)/1.35 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -1197,7 +1205,7 @@ p {
 .graph-showcase__capabilities p {
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--font-size-min);
   line-height: 1.6;
 }
 
@@ -1251,7 +1259,7 @@ p {
 .graph-showcase__manager-preview > header span,
 .graph-showcase__manager-preview > header strong {
   font:
-    8px/1.35 'JetBrains Mono Variable',
+    var(--font-size-min)/1.35 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -1355,7 +1363,7 @@ p {
   margin-bottom: 5px;
   color: #657180;
   font:
-    7px/1.35 'JetBrains Mono Variable',
+    var(--font-size-min)/1.35 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -1363,7 +1371,7 @@ p {
 .graph-showcase__manager-body dd {
   overflow-wrap: anywhere;
   color: #b6c0ca;
-  font-size: 11px;
+  font-size: var(--font-size-min);
 }
 
 /* Feature and architecture sections */
@@ -1417,13 +1425,13 @@ p {
 .feature-card__index {
   color: var(--muted);
   font:
-    10px/1.2 'JetBrains Mono Variable',
+    var(--font-size-min)/1.2 'JetBrains Mono Variable',
     monospace;
 }
 
 .feature-card .eyebrow {
   margin-bottom: 12px;
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .feature-card h3 {
@@ -1445,7 +1453,7 @@ p {
   bottom: 28px;
   left: 28px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .feature-card--blue .feature-card__top svg,
@@ -1544,7 +1552,7 @@ p {
   padding: 0 9px;
   color: var(--teal);
   font:
-    9px/1.5 'JetBrains Mono Variable',
+    var(--font-size-min)/1.5 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
   background: var(--ink);
@@ -1570,14 +1578,14 @@ p {
   margin-bottom: 16px;
   color: var(--teal);
   font:
-    10px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
 }
 
 .architecture-map__core strong {
   padding: 8px 0;
   color: var(--text-soft);
-  font-size: 12px;
+  font-size: var(--font-size-min);
   font-weight: 500;
   border-top: 1px solid var(--line-soft);
 }
@@ -1593,7 +1601,7 @@ p {
   padding: 9px 5px;
   color: var(--muted);
   font:
-    8px/1.3 'JetBrains Mono Variable',
+    var(--font-size-min)/1.3 'JetBrains Mono Variable',
     monospace;
   text-align: center;
   background: var(--ink-soft);
@@ -1629,13 +1637,13 @@ p {
   margin-bottom: 7px;
   color: var(--muted);
   font:
-    8px/1.2 'JetBrains Mono Variable',
+    var(--font-size-min)/1.2 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
 
 .architecture-map__external strong {
-  font-size: 11px;
+  font-size: var(--font-size-min);
   font-weight: 550;
 }
 
@@ -1663,7 +1671,7 @@ p {
 .workflow-list li > span {
   color: var(--teal);
   font:
-    10px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -1684,7 +1692,7 @@ p {
   min-height: 4.65em;
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--font-size-min);
   line-height: 1.55;
 }
 
@@ -1739,7 +1747,7 @@ p {
 .manager-teaser__chrome code {
   margin-left: 10px;
   color: #687687;
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .manager-teaser__app {
@@ -1764,7 +1772,7 @@ p {
   margin: 0 auto 18px;
   color: var(--ink);
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   background: var(--teal);
   border-radius: 5px;
@@ -1774,7 +1782,7 @@ p {
 .manager-teaser__app > aside span {
   padding: 8px 6px;
   color: #7f8c9b;
-  font-size: 8px;
+  font-size: var(--font-size-min);
   text-align: center;
   border-radius: 4px;
 }
@@ -1823,7 +1831,7 @@ p {
   gap: 12px;
   color: #728090;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -1858,7 +1866,7 @@ p {
 .manager-teaser__detail > span {
   color: #657180;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -1871,7 +1879,7 @@ p {
   display: block;
   overflow-wrap: anywhere;
   color: var(--teal);
-  font-size: 7px;
+  font-size: var(--font-size-min);
 }
 
 .manager-teaser__detail dl {
@@ -1889,7 +1897,7 @@ p {
 .manager-teaser__detail dd {
   margin: 0;
   color: #7c8998;
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .content-section--cta {
@@ -1979,7 +1987,7 @@ p {
   padding: 0 13px;
   color: var(--muted);
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
   background: var(--panel-raised);
@@ -1990,7 +1998,7 @@ p {
   padding: 5px 8px;
   color: var(--text-soft);
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   background: transparent;
   border: 1px solid var(--line);
@@ -2005,7 +2013,7 @@ p {
 
 .code-block pre code {
   color: #c5d0db;
-  font-size: 11px;
+  font-size: var(--font-size-min);
   line-height: 1.7;
   white-space: pre;
 }
@@ -2063,12 +2071,12 @@ p {
 
 .subpage-hero__metric span {
   margin-bottom: 14px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .subpage-hero__metric small {
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--font-size-min);
   line-height: 1.5;
 }
 
@@ -2089,7 +2097,7 @@ p {
   min-height: 38px;
   padding: 0 14px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: 13px;
   white-space: nowrap;
   background: transparent;
   border: 1px solid transparent;
@@ -2133,7 +2141,7 @@ p {
 .tips-index button > span {
   color: var(--muted);
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -2146,13 +2154,13 @@ p {
   margin-bottom: 6px;
   color: var(--muted);
   font:
-    8px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
 
 .tips-index button strong {
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 540;
   line-height: 1.35;
 }
@@ -2192,7 +2200,7 @@ p {
 
 .tip-detail > header > p {
   color: var(--text-soft);
-  font-size: 16px;
+  font-size: 17px;
 }
 
 .tip-detail__why {
@@ -2209,7 +2217,7 @@ p {
 .tip-detail__why strong {
   color: var(--teal);
   font:
-    10px/1.6 'JetBrains Mono Variable',
+    var(--font-size-min)/1.6 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -2217,7 +2225,7 @@ p {
 .tip-detail__why p {
   margin: 0;
   color: var(--text-soft);
-  font-size: 13px;
+  font-size: 15px;
 }
 
 .tip-checklist {
@@ -2244,7 +2252,7 @@ p {
   gap: 12px;
   padding: 13px 15px;
   color: var(--text-soft);
-  font-size: 13px;
+  font-size: 15px;
   background: rgba(16, 21, 29, 0.65);
   border: 1px solid var(--line-soft);
   border-radius: 6px;
@@ -2294,7 +2302,7 @@ p {
 .comparison-product > span {
   color: var(--teal);
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -2328,7 +2336,7 @@ p {
   height: 42px;
   margin-bottom: 8px;
   font:
-    10px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   border: 1px solid var(--line);
   border-radius: 50%;
@@ -2336,7 +2344,7 @@ p {
 }
 
 .comparison-plus small {
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .comparison-table-wrap,
@@ -2356,7 +2364,7 @@ p {
 .comparison-table td {
   padding: 20px;
   color: var(--text-soft);
-  font-size: 12px;
+  font-size: var(--font-size-min);
   line-height: 1.55;
   text-align: left;
   vertical-align: top;
@@ -2377,7 +2385,7 @@ p {
 .comparison-table thead th {
   color: var(--muted);
   font:
-    9px/1.3 'JetBrains Mono Variable',
+    var(--font-size-min)/1.3 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
   background: var(--panel-raised);
@@ -2386,7 +2394,7 @@ p {
 .comparison-table tbody th {
   width: 150px;
   color: var(--text);
-  font-size: 11px;
+  font-size: var(--font-size-min);
   font-weight: 590;
   background: rgba(16, 21, 29, 0.65);
 }
@@ -2394,7 +2402,7 @@ p {
 .comparison-note {
   margin: 18px 0 0;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--font-size-min);
 }
 
 .comparison-note a {
@@ -2431,7 +2439,7 @@ p {
 .faq-list summary > span {
   color: var(--muted);
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -2505,7 +2513,7 @@ p {
 
 .docs-sidebar__top .eyebrow {
   margin-bottom: 7px;
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .docs-sidebar__top > strong {
@@ -2526,7 +2534,7 @@ p {
   padding: 0 10px;
   margin: 18px 0 28px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--font-size-min);
   text-align: left;
   background: var(--panel);
   border: 1px solid var(--line);
@@ -2536,7 +2544,7 @@ p {
 .docs-search-button kbd {
   padding: 4px 5px;
   color: var(--text-soft);
-  font-size: 8px;
+  font-size: var(--font-size-min);
   background: var(--ink);
   border: 1px solid var(--line);
   border-radius: 3px;
@@ -2550,7 +2558,7 @@ p {
   margin-bottom: 9px;
   color: var(--muted);
   font:
-    9px/1.3 'JetBrains Mono Variable',
+    var(--font-size-min)/1.3 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2561,7 +2569,6 @@ p {
   padding: 5px 9px;
   margin-left: -9px;
   color: #929eab;
-  font-size: 11px;
   line-height: 1.45;
   border-left: 1px solid transparent;
 }
@@ -2581,7 +2588,6 @@ p {
   display: block;
   padding: 15px 0;
   color: var(--muted);
-  font-size: 10px;
   border-top: 1px solid var(--line);
 }
 
@@ -2608,7 +2614,7 @@ p {
   margin-bottom: 52px;
   color: var(--muted);
   font:
-    9px/1.2 'JetBrains Mono Variable',
+    var(--font-size-min)/1.2 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -2624,7 +2630,7 @@ p {
 
 .docs-article__header .eyebrow {
   margin-bottom: 12px;
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .docs-article__header h1 {
@@ -2675,7 +2681,7 @@ p {
 .docs-table-wrap code {
   padding: 2px 4px;
   color: var(--teal-bright);
-  font-size: 0.82em;
+  font-size: max(var(--font-size-min), 0.82em);
   overflow-wrap: anywhere;
   background: rgba(103, 232, 199, 0.07);
   border: 1px solid rgba(103, 232, 199, 0.12);
@@ -2704,7 +2710,7 @@ p {
   margin-bottom: 8px;
   color: var(--teal);
   font:
-    9px/1.3 'JetBrains Mono Variable',
+    var(--font-size-min)/1.3 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -2755,7 +2761,7 @@ p {
 }
 
 .docs-article .code-block pre code {
-  font-size: 12px;
+  font-size: var(--font-size-min);
 }
 
 .docs-table-wrap {
@@ -2767,7 +2773,7 @@ p {
   min-width: 130px;
   padding: 14px 16px;
   color: var(--text-soft);
-  font-size: 11px;
+  font-size: var(--font-size-min);
   line-height: 1.55;
   text-align: left;
   vertical-align: top;
@@ -2787,7 +2793,7 @@ p {
 .docs-table-wrap thead th {
   color: var(--text);
   font:
-    9px/1.3 'JetBrains Mono Variable',
+    var(--font-size-min)/1.3 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
   background: var(--panel-raised);
@@ -2828,13 +2834,13 @@ p {
   margin-bottom: 8px;
   color: var(--muted);
   font:
-    8px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
 
 .docs-pagination strong {
-  font-size: 12px;
+  font-size: var(--font-size-min);
   font-weight: 550;
 }
 
@@ -2843,7 +2849,6 @@ p {
   top: 100px;
   padding-left: 17px;
   color: var(--muted);
-  font-size: 10px;
   border-left: 1px solid var(--line);
 }
 
@@ -2856,14 +2861,14 @@ p {
 .docs-outline > span:first-child {
   margin-bottom: 14px;
   font:
-    8px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
 
 .docs-outline > strong {
   color: var(--text-soft);
-  font-size: 11px;
+  font-size: var(--font-size-min);
   font-weight: 560;
 }
 
@@ -2953,7 +2958,7 @@ p {
   min-height: 34px;
   padding: 0 8px;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--font-size-min);
   background: transparent;
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -2977,7 +2982,7 @@ p {
   padding: 7px 14px 10px;
   color: var(--muted);
   font:
-    8px/1.2 'JetBrains Mono Variable',
+    var(--font-size-min)/1.2 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -3017,7 +3022,7 @@ p {
   margin-bottom: 4px;
   color: var(--teal);
   font:
-    8px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -3031,7 +3036,7 @@ p {
   margin: 0;
   overflow: hidden;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--font-size-min);
   line-height: 1.45;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -3076,7 +3081,7 @@ p {
   margin-bottom: 13px;
   color: var(--teal);
   font:
-    9px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -3105,9 +3110,8 @@ p {
 .manager-demo-hero-facts span {
   padding: 8px 10px;
   color: var(--muted);
-  font:
-    9px/1 'JetBrains Mono Variable',
-    monospace;
+  font-family: 'JetBrains Mono Variable', monospace;
+  line-height: 1;
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -3130,7 +3134,7 @@ p {
   padding: 7px 16px;
   color: #9dafc0;
   font:
-    9px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
   background: rgba(255, 184, 107, 0.09);
   border-bottom: 1px solid rgba(255, 184, 107, 0.22);
@@ -3181,14 +3185,14 @@ p {
 }
 
 .manager-demo-brand strong {
-  font-size: 12px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-brand div > span {
   margin-top: 3px;
   color: #687687;
   font:
-    8px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -3197,7 +3201,7 @@ p {
   margin: 0 0 8px;
   color: #5d6b79;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -3217,7 +3221,7 @@ p {
   min-height: 44px;
   padding: 0 9px;
   color: #8492a2;
-  font-size: 11px;
+  font-size: var(--font-size-min);
   text-align: left;
   background: transparent;
   border: 1px solid transparent;
@@ -3227,7 +3231,7 @@ p {
 .manager-demo-tabs button small {
   color: #53606e;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -3277,14 +3281,14 @@ p {
 }
 
 .manager-demo-runtime strong {
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-runtime div > span {
   margin-top: 3px;
   color: #637080;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -3301,7 +3305,7 @@ p {
   padding: 0 20px;
   color: #697786;
   font:
-    8px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   background: #121923;
   border-bottom: 1px solid #26303d;
@@ -3346,7 +3350,7 @@ p {
 
 .manager-demo-workspace-heading .manager-demo-eyebrow {
   margin-bottom: 6px;
-  font-size: 7px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-workspace-heading h3 {
@@ -3358,7 +3362,7 @@ p {
 .manager-demo-workspace-heading p:not(.manager-demo-eyebrow) {
   margin: 0;
   color: #758291;
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-workspace-heading > button,
@@ -3366,7 +3370,7 @@ p {
   min-height: 40px;
   padding: 0 13px;
   color: #07110e;
-  font-size: 10px;
+  font-size: var(--font-size-min);
   font-weight: 650;
   background: var(--teal);
   border: 0;
@@ -3390,7 +3394,7 @@ p {
   margin-bottom: 5px;
   color: #596776;
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -3401,7 +3405,7 @@ p {
   height: 40px;
   padding: 0 8px;
   color: #aeb8c3;
-  font-size: 10px;
+  font-size: var(--font-size-min);
   background: #0b1016;
   border: 1px solid #293441;
   border-radius: 4px;
@@ -3414,7 +3418,7 @@ p {
   min-height: 40px;
   color: #687686;
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   white-space: nowrap;
 }
@@ -3435,7 +3439,7 @@ p {
   padding: 0 12px;
   color: #5d6a78;
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   background: #0e141c;
   border: 1px solid #27313d;
@@ -3445,7 +3449,7 @@ p {
   min-height: 34px;
   padding: 0 9px;
   color: #758291;
-  font-size: 9px;
+  font-size: var(--font-size-min);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 3px;
@@ -3513,7 +3517,7 @@ p {
   z-index: 1;
   color: #687686;
   font:
-    8px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   place-items: center;
 }
@@ -3528,7 +3532,7 @@ p {
 
 .manager-demo-scene-fallback strong {
   color: #aeb8c3;
-  font-size: 11px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-node-strip {
@@ -3599,13 +3603,13 @@ p {
 
 .manager-demo-node-button strong {
   color: #aeb9c5;
-  font-size: 10px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-node-button small {
   margin-top: 3px;
   color: #596777;
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-node-empty {
@@ -3613,7 +3617,7 @@ p {
   margin: 0;
   padding: 0 10px;
   color: #778493;
-  font-size: 10px;
+  font-size: var(--font-size-min);
   white-space: nowrap;
 }
 
@@ -3635,7 +3639,7 @@ p {
   padding: 4px 5px;
   color: #687686;
   font:
-    6px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
   border: 1px solid #293542;
@@ -3681,7 +3685,7 @@ p {
   display: block;
   overflow-wrap: anywhere;
   color: var(--teal);
-  font-size: 7px;
+  font-size: var(--font-size-min);
   line-height: 1.5;
 }
 
@@ -3700,7 +3704,7 @@ p {
 .manager-demo-detail-list dt,
 .manager-demo-detail-list dd {
   margin: 0;
-  font-size: 7px;
+  font-size: var(--font-size-min);
   line-height: 1.4;
 }
 
@@ -3719,7 +3723,7 @@ p {
   margin-bottom: 7px;
   color: #5d6a78;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -3754,7 +3758,7 @@ p {
 .manager-demo-relationships li span,
 .manager-demo-relationships li strong {
   display: block;
-  font-size: 7px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-relationships li span {
@@ -3771,7 +3775,7 @@ p {
 
 .manager-demo-relationships li small {
   color: #596776;
-  font-size: 6px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-graph-footer {
@@ -3780,7 +3784,7 @@ p {
   padding: 9px 11px;
   color: #536170;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -3808,7 +3812,7 @@ p {
   margin-bottom: 12px;
   color: #667483;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -3822,7 +3826,7 @@ p {
 
 .manager-demo-metric-row small {
   color: #647281;
-  font-size: 7px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-table {
@@ -3844,7 +3848,7 @@ p {
   padding: 0 12px;
   color: #5d6a78;
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
   background: #151c25;
@@ -3858,23 +3862,23 @@ p {
 
 .manager-demo-table article strong {
   display: block;
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-table article p {
   margin: 4px 0;
   color: #74818f;
-  font-size: 7px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-table article code {
   color: #5f6c7b;
-  font-size: 6px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-table article > span {
   color: #8793a1;
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-status {
@@ -3884,7 +3888,7 @@ p {
   padding: 4px 6px;
   color: var(--teal) !important;
   font:
-    6px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace !important;
   background: rgba(103, 232, 199, 0.06);
   border: 1px solid rgba(103, 232, 199, 0.15);
@@ -3924,13 +3928,13 @@ p {
 }
 
 .manager-demo-share-grid header strong {
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-share-grid header small {
   margin-top: 3px;
   color: #5f6d7c;
-  font-size: 6px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-share-grid > article > strong {
@@ -3943,7 +3947,7 @@ p {
 
 .manager-demo-share-grid > article > span {
   color: #657281;
-  font-size: 7px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-share-grid footer {
@@ -3953,7 +3957,7 @@ p {
   padding-top: 13px;
   margin-top: 20px;
   color: #5e6b79;
-  font-size: 6px;
+  font-size: var(--font-size-min);
   border-top: 1px solid #27313d;
 }
 
@@ -3961,7 +3965,7 @@ p {
   min-height: 34px;
   padding: 0 4px;
   color: var(--blue);
-  font-size: 9px;
+  font-size: var(--font-size-min);
   background: transparent;
   border: 0;
 }
@@ -3978,7 +3982,7 @@ p {
 .manager-demo-callout span {
   color: var(--blue);
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -3986,7 +3990,7 @@ p {
 .manager-demo-callout p {
   margin: 7px 0 0;
   color: #7a8796;
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-doctor-summary {
@@ -4024,7 +4028,7 @@ p {
 .manager-demo-doctor-summary div > span {
   margin-top: 5px;
   color: #6f7c8a;
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-check-list {
@@ -4054,7 +4058,7 @@ p {
   width: 22px;
   height: 22px;
   color: var(--green);
-  font-size: 10px;
+  font-size: var(--font-size-min);
   background: rgba(120, 230, 163, 0.07);
   border: 1px solid rgba(120, 230, 163, 0.16);
   border-radius: 50%;
@@ -4067,13 +4071,13 @@ p {
 }
 
 .manager-demo-check-list strong {
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-check-list div > span {
   margin-top: 4px;
   color: #6a7785;
-  font-size: 7px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-tools-grid {
@@ -4094,21 +4098,21 @@ p {
   margin-bottom: 14px;
   color: var(--violet);
   font:
-    7px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
 
 .manager-demo-tools-grid code {
   color: var(--teal);
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-tools-grid p {
   min-height: 54px;
   margin: 10px 0;
   color: #74818f;
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-tools-grid a {
@@ -4117,7 +4121,7 @@ p {
   min-height: 34px;
   padding: 0 4px;
   color: #8895a3;
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-tools-grid a:hover {
@@ -4154,7 +4158,7 @@ p {
 
 .manager-demo-footnote code {
   color: var(--teal);
-  font-size: 12px;
+  font-size: var(--font-size-min);
 }
 
 .manager-demo-footnote p {
@@ -4188,7 +4192,7 @@ p {
 
 .graph-showcase__performance-cta .eyebrow {
   margin-bottom: 9px;
-  font-size: 8px;
+  font-size: var(--font-size-min);
 }
 
 .graph-showcase__performance-cta h3,
@@ -4205,7 +4209,7 @@ p {
 
 .graph-showcase__performance-cta p {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--font-size-min);
 }
 
 .graph-showcase__performance-cta > svg {
@@ -4283,7 +4287,7 @@ p {
 .performance-run-card > header strong,
 .performance-run-card > header small {
   font:
-    9px/1.35 'JetBrains Mono Variable',
+    var(--font-size-min)/1.35 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -4323,7 +4327,7 @@ p {
 .performance-run-card code {
   color: var(--muted);
   font:
-    8px/1.35 'JetBrains Mono Variable',
+    var(--font-size-min)/1.35 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -4359,7 +4363,7 @@ p {
 .performance-run-card dd {
   overflow-wrap: anywhere;
   color: var(--text-soft);
-  font-size: 11px;
+  font-size: var(--font-size-min);
   text-align: right;
 }
 
@@ -4367,7 +4371,7 @@ p {
   padding: 18px;
   margin: 0;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--font-size-min);
 }
 
 .performance-run-card > p a {
@@ -4408,7 +4412,7 @@ p {
 .performance-control-panel article small {
   color: var(--muted);
   font:
-    9px/1.4 'JetBrains Mono Variable',
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -4458,7 +4462,7 @@ p {
   margin-left: 8px;
   color: var(--muted);
   font:
-    8px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -4488,7 +4492,7 @@ p {
 .performance-proof-grid p {
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--font-size-min);
 }
 
 .performance-control-panel,
@@ -4520,7 +4524,7 @@ p {
 .performance-phase-panel > header p {
   margin: 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--font-size-min);
 }
 
 .performance-control-panel > div,
@@ -4591,7 +4595,7 @@ p {
 .performance-pipeline li > div span,
 .performance-pipeline li > div small {
   font:
-    9px/1.35 'JetBrains Mono Variable',
+    var(--font-size-min)/1.35 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -4615,7 +4619,7 @@ p {
 .performance-pipeline li > p {
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--font-size-min);
 }
 
 .performance-worktrees {
@@ -4641,7 +4645,7 @@ p {
 .performance-worktrees__copy .performance-worktrees__evidence {
   margin-top: 24px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--font-size-min);
 }
 
 .performance-worktrees__evidence a {
@@ -4661,7 +4665,7 @@ p {
   gap: 10px;
   align-items: center;
   color: var(--text-soft);
-  font-size: 12px;
+  font-size: var(--font-size-min);
 }
 
 .performance-worktrees__copy li svg {
@@ -4713,7 +4717,7 @@ p {
 .performance-worktrees__branches small {
   color: var(--muted);
   font:
-    8px/1.35 'JetBrains Mono Variable',
+    var(--font-size-min)/1.35 'JetBrains Mono Variable',
     monospace;
 }
 
@@ -4812,7 +4816,7 @@ p {
 .performance-surfaces article > span {
   color: var(--teal);
   font:
-    9px/1 'JetBrains Mono Variable',
+    var(--font-size-min)/1 'JetBrains Mono Variable',
     monospace;
   text-transform: uppercase;
 }
@@ -4831,7 +4835,7 @@ p {
 
 .performance-surfaces article > code {
   color: var(--teal);
-  font-size: 9px;
+  font-size: var(--font-size-min);
 }
 
 .performance-methodology {
@@ -5126,7 +5130,7 @@ p {
     padding: 0 10px;
     color: var(--text-soft);
     font:
-      9px/1 'JetBrains Mono Variable',
+      var(--font-size-min)/1 'JetBrains Mono Variable',
       monospace;
     background: var(--panel);
     border: 1px solid var(--line);


### PR DESCRIPTION
## What changed

- introduced one shared `--font-size-min: 12px` typography token
- raised every explicit site text size below 12px to that shared minimum
- consolidated the requested selectors into one grouped CSS rule
- kept headings and existing text sizes above the minimum unchanged
- added a regression test preventing explicit sub-12px text sizes

## Why

Small labels, body copy, code, and demo text were difficult to read. This establishes a site-wide 12px floor without duplicating the value across selectors.

## Validation

- `bun run site:check` (48 tests)
- `bun run site:build`
- computed-font audit across all six routes at desktop and 390px mobile widths: no visible text below 12px
- no horizontal overflow on the audited routes
