### PR TITLE
Distribute the Cursor integration through Marketplace

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "threadnote",
+  "owner": {
+    "name": "Threadnote"
+  },
+  "metadata": {
+    "description": "Official Cursor plugin for Threadnote shared local context and engineering memory."
+  },
+  "plugins": [
+    {
+      "name": "threadnote",
+      "source": "cursor-plugin",
+      "description": "Always-on Cursor instructions for using Threadnote as shared local context and engineering memory.",
+      "minClientVersions": {
+        "cursor": "2.5.0"
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Threadnote development instructions
+
+Threadnote must dogfood itself. Every agent doing non-trivial work in this repository must use the current Threadnote
+installation as part of the task instead of treating Threadnote only as code being edited. Repository files and the
+nearest checked-in guidance remain authoritative.
+
+## Dogfood Threadnote on every task
+
+- At the start, call `recall_context` with `project: threadnote` and the absolute `callerCwd`, then read the relevant
+  `threadnote://` records it returns.
+- Use Threadnote's own `inspect_code_graph` for focused current-source relationships and `analyze_code_graph` for
+  repository-wide structure when those tools are relevant. Use exact text or path search for literals and verification.
+- Store reusable decisions and contracts as durable memory. Store current status, checks, blockers, and next steps as a
+  handoff before pausing or ending meaningful work.
+- Use stable project/topic identities and update an existing memory with `replaceUri`; do not create timestamped
+  duplicates. Never store secrets, credentials, customer data, or raw production logs.
+- Prefer the Threadnote MCP tools. If they are unavailable, use the `threadnote` CLI as the fallback and treat the
+  unavailability as a dogfooding issue under the policy below.
+
+## Install logic changes globally
+
+After changing runtime or product logic, do not stop after tests. This includes behavior under `src/`, runtime-facing
+scripts, installer/updater behavior, MCP behavior, storage, indexing, plugin lifecycle, and release payload logic.
+
+1. Run the checks appropriate to the change.
+2. Commit the intended change and make the worktree clean; the development installer deliberately refuses dirty or
+   non-HEAD source.
+3. Run `bun run dev:install-global` from this checkout. It builds, installs, activates, and doctor-verifies the exact
+   HEAD as the global development Threadnote binary.
+4. Exercise the affected flow through the globally installed `threadnote` command and record the smoke result in the
+   task handoff.
+
+Documentation-only and test-only changes do not require a global binary reinstall unless they alter a packaged runtime
+contract or expose a suspected runtime problem.
+
+## Never ignore dogfooding issues
+
+Any unexpected behavior encountered while using Threadnote itself is product evidence, not disposable tooling noise.
+Do not silently bypass it or omit it from closeout.
+
+- Reproduce it with the smallest safe case, investigate the responsible code or state, and fix it when it is in scope.
+  If it cannot be fixed in the current task, record the blocker and the safest bounded workaround.
+- Maintain one active issues memory with `kind: durable`, `project: threadnote`, and `topic: dogfood-issues`. Recall and
+  read it first, then update it with `replaceUri` rather than creating another issue ledger.
+- For every issue, record the affected commit/version, symptom, minimal reproduction, expected versus actual behavior,
+  diagnosis, status, workaround if any, fix commit or PR when available, and verification performed. Keep evidence
+  privacy-safe and bounded.
+- If Threadnote returns an error, also prepare a privacy-safe `threadnote report-issue` preview after investigation.
+  Create a public issue only with explicit user approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,19 @@ nearest checked-in guidance remain authoritative.
 - Prefer the Threadnote MCP tools. If they are unavailable, use the `threadnote` CLI as the fallback and treat the
   unavailability as a dogfooding issue under the policy below.
 
+## Seek property-based testing opportunities
+
+During development, always assess whether changed behavior has general properties that example tests alone would
+underspecify. Look especially for round trips, idempotence, determinism, ordering, monotonicity, parser and serializer
+boundaries, state-machine transitions, incremental-versus-clean equivalence, and non-mutation guarantees.
+
+- When a meaningful property exists, add a bounded Fast-check property to the normal Vitest suite. Prefer generators
+  that shrink well and assertions against an independent model or invariant rather than reimplementing production code.
+- Keep focused example-based regression tests for important concrete failures, even when a property test also covers the
+  broader contract.
+- Do not force property tests onto static copy, one-off wiring, or behavior with no useful input space or invariant.
+  Close out the task by stating which property-testing opportunity was added, or why none was appropriate.
+
 ## Install logic changes globally
 
 After changing runtime or product logic, do not stop after tests. This includes behavior under `src/`, runtime-facing

--- a/CURSOR_PLUGIN_LICENSE.md
+++ b/CURSOR_PLUGIN_LICENSE.md
@@ -1,0 +1,5 @@
+The files under `.cursor-plugin/` and `cursor-plugin/` are licensed under the MIT License reproduced in
+`cursor-plugin/LICENSE`.
+
+All other files in this repository remain licensed under the GNU Affero General Public License v3.0 or later unless a
+different license is stated in their directory.

--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ threadnote mcp-install codex --apply # or claude / cursor / copilot
 threadnote doctor
 ```
 
-When Cursor is installed, Threadnote install, update, and repair copy the bundled **Threadnote** plugin to
-`~/.cursor/plugins/local/threadnote` so Cursor loads the always-on rule at user scope. Reload Cursor after the first
-install. The MCP command above remains required because it writes the user- and platform-specific server configuration.
-See the [Cursor plugin guide](./docs/cursor-plugin.md) for diagnostics and optional Marketplace publication.
+Cursor instructions are distributed separately as the **Threadnote** Cursor Marketplace plugin. Threadnote never writes
+to Cursor's local-plugin directory; install the plugin from Cursor after it is listed, or ask a team administrator to
+add it to the team's marketplace. The MCP command above remains required because it writes the user- and
+platform-specific server configuration. See the [Cursor plugin guide](./docs/cursor-plugin.md) for installation,
+diagnostics, and publishing.
 
 To opt into prerelease builds, install the Threadnote 4 beta channel on macOS or Linux:
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ threadnote mcp-install codex --apply # or claude / cursor / copilot
 threadnote doctor
 ```
 
+When Cursor is installed, Threadnote install, update, and repair copy the bundled **Threadnote** plugin to
+`~/.cursor/plugins/local/threadnote` so Cursor loads the always-on rule at user scope. Reload Cursor after the first
+install. The MCP command above remains required because it writes the user- and platform-specific server configuration.
+See the [Cursor plugin guide](./docs/cursor-plugin.md) for diagnostics and optional Marketplace publication.
+
 To opt into prerelease builds, install the Threadnote 4 beta channel on macOS or Linux:
 
 ```sh

--- a/cursor-plugin/.cursor-plugin/plugin.json
+++ b/cursor-plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "threadnote",
+  "displayName": "Threadnote",
+  "version": "1.0.0",
+  "description": "Always-on Cursor instructions for using Threadnote as shared local context and engineering memory.",
+  "minClientVersions": {
+    "cursor": "2.5.0"
+  },
+  "author": {
+    "name": "Denys Kashkovskyi"
+  },
+  "publisher": "Threadnote",
+  "homepage": "https://threadnote.io/",
+  "repository": "https://github.com/Kashkovsky/threadnote",
+  "license": "MIT",
+  "logo": "https://threadnote.io/threadnote-logo.svg",
+  "keywords": ["agent-memory", "context", "handoff", "knowledge-graph", "threadnote"],
+  "category": "developer-tools",
+  "tags": ["context", "memory", "rules"],
+  "rules": "./rules/"
+}

--- a/cursor-plugin/.threadnote-managed.json
+++ b/cursor-plugin/.threadnote-managed.json
@@ -1,0 +1,4 @@
+{
+  "managedBy": "threadnote",
+  "schemaVersion": 1
+}

--- a/cursor-plugin/.threadnote-managed.json
+++ b/cursor-plugin/.threadnote-managed.json
@@ -1,4 +1,0 @@
-{
-  "managedBy": "threadnote",
-  "schemaVersion": 1
-}

--- a/cursor-plugin/CHANGELOG.md
+++ b/cursor-plugin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0
+
+- Add an always-applied Cursor rule with the complete Threadnote agent instructions.
+- Document the separate, user-specific Cursor MCP setup and doctor verification flow.
+- Install and refresh the plugin as a Threadnote-managed local plugin during install, update, and repair.

--- a/cursor-plugin/CHANGELOG.md
+++ b/cursor-plugin/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 - Add an always-applied Cursor rule with the complete Threadnote agent instructions.
 - Document the separate, user-specific Cursor MCP setup and doctor verification flow.
-- Install and refresh the plugin as a Threadnote-managed local plugin during install, update, and repair.
+- Distribute the plugin through Cursor's public or team Marketplace without local-plugin injection by the Threadnote CLI.

--- a/cursor-plugin/LICENSE
+++ b/cursor-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Denys Kashkovskyi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cursor-plugin/README.md
+++ b/cursor-plugin/README.md
@@ -1,0 +1,37 @@
+# Threadnote for Cursor
+
+This plugin gives Cursor an always-applied `.mdc` rule for using Threadnote as shared local context, engineering memory,
+code-graph search, and agent handoffs. Plugin rules are a documented user-level integration, unlike writing a rule into
+the project-only `~/.cursor/rules` path.
+
+## Prerequisites
+
+- Cursor 2.5 or newer
+- A working Threadnote installation
+- The Threadnote MCP server configured for Cursor with `threadnote mcp-install cursor --apply`
+
+The plugin intentionally does not bundle `mcp.json`. Threadnote's MCP configuration contains user-specific storage
+settings and an absolute, platform-specific launcher path. The Threadnote CLI owns that configuration so installing the
+plugin cannot create a second, conflicting `threadnote` MCP server.
+
+## Install
+
+When Threadnote detects Cursor, `threadnote install`, `threadnote update`, and `threadnote repair` install or refresh
+this directory at `~/.cursor/plugins/local/threadnote`. Reload the Cursor window after the first installation or an
+update.
+
+For source development before building a standalone release, this directory can also be copied to that location
+manually. The plugin should appear under Cursor Settings > Plugins > Installed.
+
+After optional Marketplace publication, users can instead find **Threadnote** in Cursor Settings > Plugins or run
+`/add-plugin threadnote` in a Cursor agent chat. A Threadnote-managed local copy takes precedence and should be removed
+with `threadnote uninstall` before testing the Marketplace copy.
+
+Run `threadnote doctor` to verify both the global Cursor MCP entry and the installed plugin rule. Threadnote only runs
+the plugin check when it detects a Cursor installation. Threadnote refuses to overwrite or remove an unmarked local
+plugin directory at the same path.
+
+## License
+
+The files distributed from this plugin directory are licensed under the MIT License. The Threadnote runtime and the
+rest of its repository remain licensed under AGPL-3.0-or-later.

--- a/cursor-plugin/README.md
+++ b/cursor-plugin/README.md
@@ -1,8 +1,8 @@
 # Threadnote for Cursor
 
 This plugin gives Cursor an always-applied `.mdc` rule for using Threadnote as shared local context, engineering memory,
-code-graph search, and agent handoffs. Plugin rules are a documented user-level integration, unlike writing a rule into
-the project-only `~/.cursor/rules` path.
+code-graph search, and agent handoffs. Plugin rules provide user- or team-level distribution without pretending that
+Cursor's documented project rule directory is a user-level rule location.
 
 ## Prerequisites
 
@@ -16,20 +16,17 @@ plugin cannot create a second, conflicting `threadnote` MCP server.
 
 ## Install
 
-When Threadnote detects Cursor, `threadnote install`, `threadnote update`, and `threadnote repair` install or refresh
-this directory at `~/.cursor/plugins/local/threadnote`. Reload the Cursor window after the first installation or an
-update.
+Once the plugin is publicly listed, find **Threadnote** in Cursor's Marketplace or run `/add-plugin threadnote` in a
+Cursor agent chat. On a managed Teams or Enterprise account, ask an administrator to allow the public plugin or add
+this repository to a team marketplace and choose the appropriate install policy.
 
-For source development before building a standalone release, this directory can also be copied to that location
-manually. The plugin should appear under Cursor Settings > Plugins > Installed.
+The Threadnote CLI does not copy, refresh, or remove this plugin under `~/.cursor/plugins/local`. Installation and
+updates remain owned by Cursor and the organization's Marketplace policy. Reload Cursor after installation, then run
+`threadnote doctor` to verify both the global Cursor MCP entry and the installed rule. The plugin check is omitted when
+Threadnote does not detect Cursor.
 
-After optional Marketplace publication, users can instead find **Threadnote** in Cursor Settings > Plugins or run
-`/add-plugin threadnote` in a Cursor agent chat. A Threadnote-managed local copy takes precedence and should be removed
-with `threadnote uninstall` before testing the Marketplace copy.
-
-Run `threadnote doctor` to verify both the global Cursor MCP entry and the installed plugin rule. Threadnote only runs
-the plugin check when it detects a Cursor installation. Threadnote refuses to overwrite or remove an unmarked local
-plugin directory at the same path.
+Contributors can validate the source with `bun run cursor-plugin:check`. Exercise an unpublished build through an
+administrator-controlled team marketplace; do not inject it into Cursor's local-plugin directory.
 
 ## License
 

--- a/cursor-plugin/rules/threadnote.mdc
+++ b/cursor-plugin/rules/threadnote.mdc
@@ -1,0 +1,48 @@
+---
+description: Use Threadnote for shared local context, memory, code-graph investigation, and agent handoffs
+alwaysApply: true
+---
+
+<!-- BEGIN THREADNOTE USER INSTRUCTIONS -->
+# Agent instructions
+
+Use Threadnote as shared local context and memory. Repo files remain authoritative; follow the nearest checked-in
+`AGENTS.md`, `CLAUDE.md`, or equivalent guidance first.
+
+At the start of a non-trivial task, call `recall_context` with the project and absolute `callerCwd`, then treat relevant
+`threadnote://` URIs as pointers and read them. Store reusable decisions and contracts with `kind: durable`; store status,
+checks, blockers, and next steps with `kind: handoff`. Use stable `project` and `topic` identities, and update an
+existing memory with `replaceUri` instead of creating timestamped duplicates.
+
+For non-trivial investigation of existing source, use `inspect_code_graph` before broad `rg` or grep searches.
+`query` finds definitions and concepts; use the returned stable `cgs_` ID with `node` for exact lookup, `neighbors` for
+bounded directional adjacency, or as a `path` endpoint. `explain` accepts a human-readable symbol selector, and `impact`
+traces reverse dependencies from a query or Git `base`. Use the separate `analyze_code_graph` tool for whole-repository
+statistics, stable community drill-down, structural groups, hubs or god nodes, confidence audits, and surprising
+cross-community links. Use text search afterward for exact literals, unsupported files, or verification. If either
+graph tool returns `state: "indexing"`, continue useful independent work such as targeted text or path search, then
+retry after `retryAfterMilliseconds` before making relationship-aware graph claims. The optional estimate is scoped
+only to the current measured phase; it is not a full-build promise. Indexing is expected cold-start progress, not graph
+failure. If graph search is unavailable or fails, report the issue and use text search as the fallback; do not silently
+skip graph search. Memory recall answers what was learned or decided; code-graph search answers what the current Git
+snapshot and worktree contain. Call both when a task needs historical context and present code evidence, but do not
+treat one as a fallback answer from the other.
+
+At closeout, store normal durable feature knowledge and handoffs directly without asking. Use
+`review_session_context` only for additional session-extracted candidates, and apply those only after explicit user
+approval. Never store secrets, credentials, customer data, or raw production logs.
+
+Use MCP tools when available and the `threadnote` CLI as fallback. If native storage or indexing fails, run
+`threadnote doctor --dry-run`, report the diagnostic, and continue independent work when possible. The 4.0 runtime has
+no daemon to start.
+
+If Threadnote itself returns an error, use `threadnote report-issue --title <title> --body <description>` to prepare the
+public GitHub issue preview without sensitive information. Create it only after explicit user approval by rerunning
+with `--apply --approval <preview-digest>`; add `--include-logs` only when the user approves posting the bounded
+privacy-safe production logs. If GitHub CLI is missing or signed out, ask before helping the user install it or run
+`gh auth login`.
+
+Before publishing safe durable memory, confirm with the user. Never publish handoffs or preferences. Resolve dirty git
+or share conflicts before syncing, and never overwrite local modifications with force without explicit approval.
+Before pausing, switching agents, or ending meaningful work with local changes, store a concise handoff.
+<!-- END THREADNOTE USER INSTRUCTIONS -->

--- a/docs/cursor-plugin.md
+++ b/docs/cursor-plugin.md
@@ -1,0 +1,71 @@
+# Cursor plugin
+
+Threadnote's Cursor integration is a bundled local plugin containing an always-applied `.mdc` rule. Cursor documents
+`.cursor/rules` as project scope; Threadnote no longer writes user instructions there. When Cursor is detected,
+Threadnote installs the plugin at `~/.cursor/plugins/local/threadnote` during install, update, and repair. The MCP server
+remains a separate global Cursor configuration because it contains the user's Threadnote home, identity, toolset, and
+platform-specific absolute launcher path.
+
+The implementation follows Cursor's [plugin reference](https://cursor.com/docs/reference/plugins) and
+[rule anatomy](https://cursor.com/docs/rules).
+
+## Local verification
+
+1. Install Threadnote and configure its Cursor MCP server:
+
+   ```sh
+   threadnote mcp-install cursor --apply
+   ```
+
+2. Run `threadnote install` or `threadnote repair`. Threadnote atomically installs the bundled plugin at
+   `~/.cursor/plugins/local/threadnote/`; the destination contains `.cursor-plugin/plugin.json` directly beneath the
+   `threadnote` directory.
+3. In Cursor, run **Developer: Reload Window**, then confirm that Threadnote appears in
+   **Cursor Settings > Plugins > Installed**.
+4. Run the repository checks and Threadnote diagnostics:
+
+   ```sh
+   bun run cursor-plugin:check
+   threadnote doctor
+   ```
+
+The doctor reports a Cursor plugin check only when Cursor is installed. It recognizes the managed local directory and
+Cursor's Marketplace cache, verifies the plugin manifest and version, and confirms that `rules/threadnote.mdc` has a
+description, `alwaysApply: true`, and the complete managed Threadnote instruction block. Install, update, repair, and
+uninstall only replace or remove a local plugin carrying Threadnote's ownership marker; an unmarked directory or a
+symlink is preserved with a warning.
+
+## Optional: publish to the Cursor Marketplace
+
+Cursor requires Marketplace plugins to be open source and permissively licensed. Its current
+[publisher terms](https://cursor.com/marketplace-publisher-terms) expressly exclude AGPL, GPL, and LGPL components from
+submitted plugins. The distributable `cursor-plugin/` subtree and root Marketplace metadata are therefore licensed
+separately under MIT; the Threadnote executable and the rest of this repository remain AGPL-3.0-or-later. Do not move
+runtime code or the repository's AGPL license into the plugin subtree without resolving that Marketplace license
+conflict first.
+
+For the first submission:
+
+1. Make the repository public and merge the plugin source into the default branch. The root
+   `.cursor-plugin/marketplace.json` must point to `cursor-plugin`, whose own manifest is
+   `cursor-plugin/.cursor-plugin/plugin.json`.
+2. Keep the plugin manifest, Marketplace entry, rule, README, changelog, and MIT license in the public commit being
+   submitted. Confirm that the rule body still matches `config/agent-instructions.md` with
+   `bun run cursor-plugin:check`.
+3. Test that exact default-branch commit locally using the steps above. Verify the MCP server and plugin independently
+   in `threadnote doctor`, start a fresh Cursor agent chat, and confirm that the rule is listed as active.
+4. Sign in to Cursor and open <https://cursor.com/marketplace/publish>. Submit
+   `https://github.com/Kashkovsky/threadnote` as the public repository and complete the publisher application. Cursor
+   reviews publisher identity, source, security, quality, and data handling before listing the plugin.
+5. After approval, verify discovery in <https://cursor.com/marketplace> and installation from Cursor with
+   `/add-plugin threadnote`. Remove or rename any local test copy first so the Marketplace installation is the one being
+   exercised.
+
+For an update, increment `version` in `cursor-plugin/.cursor-plugin/plugin.json`, add a matching changelog entry, run
+the checks again, and merge the update to the submitted repository. Then request a re-index from Cursor through the
+publisher workflow; the publisher terms say a new publisher application is not required for each modification, but
+updates remain subject to review.
+
+The Marketplace name, publisher identity, listing copy, and MIT licensing must be reviewed by the repository owner
+before submission. Publishing accepts Cursor's Marketplace Publisher Terms and is an external action; it is not part of
+the Threadnote release workflow.

--- a/docs/cursor-plugin.md
+++ b/docs/cursor-plugin.md
@@ -1,15 +1,21 @@
 # Cursor plugin
 
-Threadnote's Cursor integration is a bundled local plugin containing an always-applied `.mdc` rule. Cursor documents
-`.cursor/rules` as project scope; Threadnote no longer writes user instructions there. When Cursor is detected,
-Threadnote installs the plugin at `~/.cursor/plugins/local/threadnote` during install, update, and repair. The MCP server
-remains a separate global Cursor configuration because it contains the user's Threadnote home, identity, toolset, and
-platform-specific absolute launcher path.
+Threadnote's Cursor instructions are an always-applied `.mdc` rule distributed through Cursor's public or team
+Marketplace. Cursor documents `.cursor/rules` as project scope, so Threadnote no longer writes a supposed user rule
+under `~/.cursor/rules`. It also never writes to `~/.cursor/plugins/local`: Cursor and, where applicable, the
+organization administrator own plugin installation, updates, and removal.
 
 The implementation follows Cursor's [plugin reference](https://cursor.com/docs/reference/plugins) and
-[rule anatomy](https://cursor.com/docs/rules).
+[rule anatomy](https://cursor.com/docs/rules). The root `.cursor-plugin/marketplace.json` points to `cursor-plugin/`,
+whose `.cursor-plugin/plugin.json` exposes `rules/threadnote.mdc`. The standalone Threadnote payload includes a copy of
+that source only so `threadnote doctor` can validate the installed Marketplace version; lifecycle commands never copy
+it into Cursor.
 
-## Local verification
+The MCP server remains a separate global Cursor configuration because it contains the user's Threadnote home,
+identity, toolset, and platform-specific absolute launcher path. The plugin intentionally has no `mcp.json` and cannot
+create a duplicate server entry.
+
+## Install and verify
 
 1. Install Threadnote and configure its Cursor MCP server:
 
@@ -17,55 +23,77 @@ The implementation follows Cursor's [plugin reference](https://cursor.com/docs/r
    threadnote mcp-install cursor --apply
    ```
 
-2. Run `threadnote install` or `threadnote repair`. Threadnote atomically installs the bundled plugin at
-   `~/.cursor/plugins/local/threadnote/`; the destination contains `.cursor-plugin/plugin.json` directly beneath the
-   `threadnote` directory.
-3. In Cursor, run **Developer: Reload Window**, then confirm that Threadnote appears in
-   **Cursor Settings > Plugins > Installed**.
-4. Run the repository checks and Threadnote diagnostics:
+2. Install **Threadnote** from Cursor's Marketplace after the public listing is approved, or run
+   `/add-plugin threadnote` in a Cursor agent chat.
+3. On a managed Teams or Enterprise account, ask an administrator to allow the public plugin or add the Threadnote
+   repository to a team marketplace. The administrator can make it opt-in, default-on, or required according to the
+   organization's policy.
+4. Reload Cursor or open a new window, then run `threadnote doctor`.
 
-   ```sh
-   bun run cursor-plugin:check
-   threadnote doctor
-   ```
+Before the public listing is approved, an administrator-controlled team marketplace is the supported way to exercise
+the exact default-branch plugin source. Do not test by copying it to `~/.cursor/plugins/local`.
 
-The doctor reports a Cursor plugin check only when Cursor is installed. It recognizes the managed local directory and
-Cursor's Marketplace cache, verifies the plugin manifest and version, and confirms that `rules/threadnote.mdc` has a
-description, `alwaysApply: true`, and the complete managed Threadnote instruction block. Install, update, repair, and
-uninstall only replace or remove a local plugin carrying Threadnote's ownership marker; an unmarked directory or a
-symlink is preserved with a warning.
+## Doctor contract
 
-## Optional: publish to the Cursor Marketplace
+`threadnote doctor` adds a Cursor plugin check only when Cursor is detected. The check is read-only:
+
+- An exact local installation at `~/.cursor/plugins/local/threadnote` fails as unsupported and must be removed outside
+  Threadnote before installing the Marketplace version.
+- An installed Marketplace copy is discovered in Cursor's plugin cache. Doctor validates the plugin name and semantic
+  version, then confirms that `rules/threadnote.mdc` has a description, `alwaysApply: true`, and the complete Threadnote
+  instruction block.
+- A version older than the source bundled with Threadnote warns that it should be updated through Cursor. A same-version
+  rule mismatch fails. A valid newer Marketplace version is accepted.
+- A missing plugin warns with public- and team-Marketplace installation guidance.
+
+Install, update, repair, and uninstall do not mutate either local or Marketplace plugin state. They still remove the
+legacy Threadnote-managed instruction block from the ignored `~/.cursor/rules/threadnote.md` or `.mdc` paths.
+
+## Why local injection is unsupported
+
+The withdrawn local-plugin implementation copied this bundle to `~/.cursor/plugins/local/threadnote` during Threadnote
+install, update, and repair. On a managed enterprise Cursor installation, that copy coincided with Cursor losing access
+to every model. Recovery in the observed incident required reinstalling Cursor after clearing its local application
+state. An administrator restriction is plausible, but has not been proven as the root cause.
+
+Because the impact was severe, local injection is a hard unsupported boundary. If doctor finds the old copy, fully quit
+Cursor and move only that exact plugin directory aside before restarting. If model access is already affected, preserve
+any settings you need and coordinate with the Cursor administrator or Cursor support before clearing broader Cursor
+state. Threadnote will report the condition but will not delete anything.
+
+## Publish to the public Marketplace
 
 Cursor requires Marketplace plugins to be open source and permissively licensed. Its current
 [publisher terms](https://cursor.com/marketplace-publisher-terms) expressly exclude AGPL, GPL, and LGPL components from
-submitted plugins. The distributable `cursor-plugin/` subtree and root Marketplace metadata are therefore licensed
+submitted plugins. The distributable `.cursor-plugin/` metadata and `cursor-plugin/` subtree are therefore licensed
 separately under MIT; the Threadnote executable and the rest of this repository remain AGPL-3.0-or-later. Do not move
 runtime code or the repository's AGPL license into the plugin subtree without resolving that Marketplace license
 conflict first.
 
 For the first submission:
 
-1. Make the repository public and merge the plugin source into the default branch. The root
-   `.cursor-plugin/marketplace.json` must point to `cursor-plugin`, whose own manifest is
-   `cursor-plugin/.cursor-plugin/plugin.json`.
-2. Keep the plugin manifest, Marketplace entry, rule, README, changelog, and MIT license in the public commit being
-   submitted. Confirm that the rule body still matches `config/agent-instructions.md` with
-   `bun run cursor-plugin:check`.
-3. Test that exact default-branch commit locally using the steps above. Verify the MCP server and plugin independently
-   in `threadnote doctor`, start a fresh Cursor agent chat, and confirm that the rule is listed as active.
-4. Sign in to Cursor and open <https://cursor.com/marketplace/publish>. Submit
-   `https://github.com/Kashkovsky/threadnote` as the public repository and complete the publisher application. Cursor
-   reviews publisher identity, source, security, quality, and data handling before listing the plugin.
-5. After approval, verify discovery in <https://cursor.com/marketplace> and installation from Cursor with
-   `/add-plugin threadnote`. Remove or rename any local test copy first so the Marketplace installation is the one being
-   exercised.
+1. Merge the plugin source into the public repository's default branch. Keep `.cursor-plugin/marketplace.json`,
+   `cursor-plugin/.cursor-plugin/plugin.json`, the rule, README, changelog, logo reference, and MIT license in the exact
+   commit being submitted.
+2. Validate the package and standalone copy:
 
-For an update, increment `version` in `cursor-plugin/.cursor-plugin/plugin.json`, add a matching changelog entry, run
-the checks again, and merge the update to the submitted repository. Then request a re-index from Cursor through the
-publisher workflow; the publisher terms say a new publisher application is not required for each modification, but
-updates remain subject to review.
+   ```sh
+   bun run cursor-plugin:check
+   bun run build
+   bun run check:self-contained
+   ```
 
-The Marketplace name, publisher identity, listing copy, and MIT licensing must be reviewed by the repository owner
-before submission. Publishing accepts Cursor's Marketplace Publisher Terms and is an external action; it is not part of
-the Threadnote release workflow.
+3. Import that default-branch source into an administrator-controlled team marketplace and verify that Cursor lists the
+   plugin, the rule is active in a fresh agent chat, the MCP server works independently, and `threadnote doctor` passes.
+4. An authorized publisher must sign in and submit `https://github.com/Kashkovsky/threadnote` at
+   <https://cursor.com/marketplace/publish>. Submission accepts Cursor's Marketplace Publisher Terms and supplies the
+   publisher identity, so it is deliberately not automated by the Threadnote release process.
+5. After approval, verify discovery at <https://cursor.com/marketplace>, install the public copy with
+   `/add-plugin threadnote`, and repeat the fresh-chat and doctor checks on both unmanaged and admin-managed Cursor.
+
+For an update, increment `version` in `cursor-plugin/.cursor-plugin/plugin.json`, add a matching changelog entry, merge
+the source update, and request a re-index through Cursor's publisher workflow. Cursor's publisher terms say that a new
+publisher application is not required for every modification, though updates remain reviewable.
+
+The Marketplace name, publisher identity, listing copy, and MIT license boundary must be reviewed by the repository
+owner before submission. A Threadnote version tag does not submit or re-index the Cursor plugin.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,8 +13,9 @@ Linux uses the immutable GitHub release as its publisher trust root; an offline 
 of the Threadnote 4 release model.
 
 Cursor Marketplace publication is a separate reviewed workflow with its own permissive-license boundary and plugin
-version. Follow [the Cursor plugin publishing guide](./cursor-plugin.md); a Threadnote version tag does not submit or
-re-index the plugin automatically.
+version. A standalone release bundles the plugin source only as a read-only doctor reference; install, update, repair,
+and uninstall never place it into Cursor. Follow [the Cursor plugin publishing guide](./cursor-plugin.md); a Threadnote
+version tag does not submit or re-index the plugin automatically.
 
 ## Build matrix
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,6 +12,10 @@ local download path. Official installers and the built-in updater also require A
 Linux uses the immutable GitHub release as its publisher trust root; an offline project signing authority is not part
 of the Threadnote 4 release model.
 
+Cursor Marketplace publication is a separate reviewed workflow with its own permissive-license boundary and plugin
+version. Follow [the Cursor plugin publishing guide](./cursor-plugin.md); a Threadnote version tag does not submit or
+re-index the plugin automatically.
+
 ## Build matrix
 
 CI bytecode-compiles the exact standalone entrypoint for all eight Bun base targets:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,13 +54,18 @@ no-op. Use `threadnote doctor` for storage, index, and model diagnostics.
 
 ## Cursor does not load the Threadnote instructions
 
-Do not put a rule under `~/.cursor/rules`; Cursor documents `.cursor/rules/*.mdc` as project scope. Run
-`threadnote repair` to install or refresh the managed plugin at `~/.cursor/plugins/local/threadnote/`, then run
-**Developer: Reload Window**. Configure the MCP server separately with `threadnote mcp-install cursor --apply`.
+Do not put a rule under `~/.cursor/rules`; Cursor documents `.cursor/rules/*.mdc` as project scope. Install **Threadnote**
+from Cursor's public Marketplace, or ask a Teams or Enterprise administrator to allow it or add it to a team
+marketplace. Configure the MCP server separately with `threadnote mcp-install cursor --apply`, then reload Cursor.
 
 Run `threadnote doctor` afterward. When Cursor is installed, doctor verifies the global MCP entry and the plugin's
 manifest, version, `.mdc` anatomy, and complete always-applied instruction block. When Cursor is not installed, the
-Cursor plugin check is omitted.
+Cursor plugin check is omitted. Threadnote lifecycle commands never install or repair the plugin.
+
+If doctor reports `~/.cursor/plugins/local/threadnote`, fully quit Cursor and move only that unsupported local copy aside
+before installing through the Marketplace. Threadnote does not remove it automatically. If model access is affected on
+a managed device, preserve needed settings and coordinate with the Cursor administrator or Cursor support before
+clearing broader application state.
 
 ## Collect production logs for support
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,6 +52,16 @@ automatically; add that directory to `PATH` yourself or use its absolute launche
 Threadnote 4 owns no daemon. `threadnote start` verifies the on-demand runtime and `threadnote stop` is a compatibility
 no-op. Use `threadnote doctor` for storage, index, and model diagnostics.
 
+## Cursor does not load the Threadnote instructions
+
+Do not put a rule under `~/.cursor/rules`; Cursor documents `.cursor/rules/*.mdc` as project scope. Run
+`threadnote repair` to install or refresh the managed plugin at `~/.cursor/plugins/local/threadnote/`, then run
+**Developer: Reload Window**. Configure the MCP server separately with `threadnote mcp-install cursor --apply`.
+
+Run `threadnote doctor` afterward. When Cursor is installed, doctor verifies the global MCP entry and the plugin's
+manifest, version, `.mdc` anatomy, and complete always-applied instruction block. When Cursor is not installed, the
+Cursor plugin check is omitted.
+
 ## Collect production logs for support
 
 Run `threadnote logs` to list the available files. Threadnote writes JSON Lines operational diagnostics under

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:self-contained": "bun scripts/check-self-contained.ts",
     "clean": "bun scripts/clean.ts",
     "compile:targets": "bun scripts/compile-targets.ts",
+    "cursor-plugin:check": "bun --bun vitest run test/unit/cursor-plugin.test.ts",
     "dev": "bun src/standalone.ts",
     "dev:install-global": "bun scripts/install-local-standalone.ts",
     "dev:mcp-server": "bun src/standalone.ts mcp-server",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -10,7 +10,7 @@ interface PackageManifest {
 }
 
 const ROOT_URL = new URL('..', import.meta.url);
-const RELEASE_DIRECTORIES = ['assets', 'config', 'manager'] as const;
+const RELEASE_DIRECTORIES = ['assets', 'config', 'cursor-plugin', 'manager'] as const;
 const FORBIDDEN_RELEASE_DIRECTORIES = ['docs', 'training', 'website', 'site-dist'] as const;
 const RELEASE_FILES = ['.threadnoteignore', 'LICENSE', 'THIRD_PARTY.md'] as const;
 const NATIVE_RUNTIME_PACKAGE = 'node-llama-cpp';

--- a/scripts/check-self-contained.ts
+++ b/scripts/check-self-contained.ts
@@ -251,7 +251,9 @@ const validateCursorPlugin = Effect.fn('checkSelfContained.validateCursorPlugin'
   root: string,
   failures: string[],
 ) {
-  const instructions = (yield* fs.readFileString(path.join(root, 'config', 'agent-instructions.md'))).trim();
+  const instructions = normalizeNewlines(
+    yield* fs.readFileString(path.join(root, 'config', 'agent-instructions.md')),
+  ).trim();
   const rule = yield* fs.readFileString(path.join(root, 'cursor-plugin', 'rules', 'threadnote.mdc'));
   const marker = yield* parseJsonFile(fs, path.join(root, 'cursor-plugin', '.threadnote-managed.json'));
   if (!isRecord(marker) || marker.managedBy !== 'threadnote' || marker.schemaVersion !== 1) {
@@ -265,13 +267,17 @@ const validateCursorPlugin = Effect.fn('checkSelfContained.validateCursorPlugin'
     instructions,
     '<!-- END THREADNOTE USER INSTRUCTIONS -->',
   ].join('\n');
-  if (!rule.replaceAll('\r\n', '\n').includes(expectedBlock)) {
+  if (!normalizeNewlines(rule).includes(expectedBlock)) {
     failures.push('Cursor plugin rule is out of sync with config/agent-instructions.md');
   }
 });
 
 function normalizePath(value: string): string {
   return value.replaceAll('\\', '/');
+}
+
+function normalizeNewlines(value: string): string {
+  return value.replaceAll('\r\n', '\n');
 }
 
 const validateCodeGraphAssets = Effect.fn('checkSelfContained.validateCodeGraphAssets')(function* (

--- a/scripts/check-self-contained.ts
+++ b/scripts/check-self-contained.ts
@@ -179,7 +179,6 @@ const checkSelfContained = Effect.gen(function* () {
       path.join(root, 'dist', 'runtime', 'node-llama-cpp.js'),
       path.join(root, 'dist', 'runtime', 'native'),
       path.join(root, 'dist', 'config', 'agent-instructions.md'),
-      path.join(root, 'dist', 'cursor-plugin', '.threadnote-managed.json'),
       path.join(root, 'dist', 'cursor-plugin', '.cursor-plugin', 'plugin.json'),
       path.join(root, 'dist', 'cursor-plugin', 'rules', 'threadnote.mdc'),
       path.join(root, 'dist', 'cursor-plugin', 'LICENSE'),
@@ -255,10 +254,6 @@ const validateCursorPlugin = Effect.fn('checkSelfContained.validateCursorPlugin'
     yield* fs.readFileString(path.join(root, 'config', 'agent-instructions.md')),
   ).trim();
   const rule = yield* fs.readFileString(path.join(root, 'cursor-plugin', 'rules', 'threadnote.mdc'));
-  const marker = yield* parseJsonFile(fs, path.join(root, 'cursor-plugin', '.threadnote-managed.json'));
-  if (!isRecord(marker) || marker.managedBy !== 'threadnote' || marker.schemaVersion !== 1) {
-    failures.push('Cursor plugin ownership marker is missing or invalid');
-  }
   if (!/^---\r?\n[\s\S]*?^description:\s*\S.+$[\s\S]*?^alwaysApply:\s*true\s*$[\s\S]*?^---$/m.test(rule)) {
     failures.push('Cursor plugin rule must have a description and alwaysApply: true MDC frontmatter');
   }

--- a/scripts/check-self-contained.ts
+++ b/scripts/check-self-contained.ts
@@ -67,6 +67,7 @@ const checkSelfContained = Effect.gen(function* () {
   const root = yield* path.fromFileUrl(ROOT_URL);
   const failures: string[] = [];
   yield* validateCodeGraphAssets(fs, path, path.join(root, 'assets', 'code-graph'), failures, root);
+  yield* validateCursorPlugin(fs, path, root, failures);
 
   for (const file of FORBIDDEN_LEGACY_FILES) {
     if (yield* fs.exists(path.join(root, file))) {
@@ -178,6 +179,10 @@ const checkSelfContained = Effect.gen(function* () {
       path.join(root, 'dist', 'runtime', 'node-llama-cpp.js'),
       path.join(root, 'dist', 'runtime', 'native'),
       path.join(root, 'dist', 'config', 'agent-instructions.md'),
+      path.join(root, 'dist', 'cursor-plugin', '.threadnote-managed.json'),
+      path.join(root, 'dist', 'cursor-plugin', '.cursor-plugin', 'plugin.json'),
+      path.join(root, 'dist', 'cursor-plugin', 'rules', 'threadnote.mdc'),
+      path.join(root, 'dist', 'cursor-plugin', 'LICENSE'),
       packagedLogo,
       path.join(root, 'dist', 'assets', 'code-graph', 'manifest.json'),
       path.join(root, 'dist', 'assets', 'code-graph', 'runtime', 'web-tree-sitter.wasm'),
@@ -238,6 +243,31 @@ const sourceFiles = Effect.fn('checkSelfContained.sourceFiles')(function* (
     }
   }
   return output;
+});
+
+const validateCursorPlugin = Effect.fn('checkSelfContained.validateCursorPlugin')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  root: string,
+  failures: string[],
+) {
+  const instructions = (yield* fs.readFileString(path.join(root, 'config', 'agent-instructions.md'))).trim();
+  const rule = yield* fs.readFileString(path.join(root, 'cursor-plugin', 'rules', 'threadnote.mdc'));
+  const marker = yield* parseJsonFile(fs, path.join(root, 'cursor-plugin', '.threadnote-managed.json'));
+  if (!isRecord(marker) || marker.managedBy !== 'threadnote' || marker.schemaVersion !== 1) {
+    failures.push('Cursor plugin ownership marker is missing or invalid');
+  }
+  if (!/^---\r?\n[\s\S]*?^description:\s*\S.+$[\s\S]*?^alwaysApply:\s*true\s*$[\s\S]*?^---$/m.test(rule)) {
+    failures.push('Cursor plugin rule must have a description and alwaysApply: true MDC frontmatter');
+  }
+  const expectedBlock = [
+    '<!-- BEGIN THREADNOTE USER INSTRUCTIONS -->',
+    instructions,
+    '<!-- END THREADNOTE USER INSTRUCTIONS -->',
+  ].join('\n');
+  if (!rule.replaceAll('\r\n', '\n').includes(expectedBlock)) {
+    failures.push('Cursor plugin rule is out of sync with config/agent-instructions.md');
+  }
 });
 
 function normalizePath(value: string): string {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,12 +11,15 @@ export const SEED_STATE_FILE = 'seed-state.json';
 export const USER_AGENT_INSTRUCTION_TARGETS = [
   {kind: 'block', label: 'codex user instructions', path: '~/.codex/AGENTS.md'},
   {kind: 'block', label: 'claude user instructions', path: '~/.claude/CLAUDE.md'},
-  {kind: 'block', label: 'cursor user rule', path: '~/.cursor/rules/threadnote.md'},
   {
     kind: 'file',
     label: 'copilot user instructions',
     path: '~/.copilot/instructions/threadnote.instructions.md',
   },
+] as const;
+export const LEGACY_CURSOR_INSTRUCTION_PATHS = [
+  '~/.cursor/rules/threadnote.md',
+  '~/.cursor/rules/threadnote.mdc',
 ] as const;
 
 export const CLAUDE_SETTINGS_PATH = '~/.claude/settings.json';

--- a/src/cursor-plugin.ts
+++ b/src/cursor-plugin.ts
@@ -1,15 +1,12 @@
-import {Console, Effect, FileSystem, Option, Path} from 'effect';
+import {Effect, FileSystem, Path} from 'effect';
 import {USER_INSTRUCTIONS_END_MARKER, USER_INSTRUCTIONS_START_MARKER} from './constants.js';
-import {sha256FileHex} from './effect/digest.js';
 import {SystemInfo} from './effect/system.js';
 import type {DoctorCheck} from './types.js';
 import {errorMessage, expandPath, findExecutable, readFileIfExists, toolRoot} from './utils.js';
 
 const CURSOR_PLUGIN_NAME = 'threadnote';
 const CURSOR_PLUGIN_MANIFEST = '.cursor-plugin/plugin.json';
-const CURSOR_PLUGIN_MARKER = '.threadnote-managed.json';
 const CURSOR_PLUGIN_RULE = 'rules/threadnote.mdc';
-const CURSOR_PLUGIN_MARKER_SCHEMA_VERSION = 1;
 
 interface CursorPluginManifest {
   readonly name: string;
@@ -26,106 +23,6 @@ export const cursorPluginDoctorChecks = Effect.fn('cursorPlugin.doctorChecks')(f
   const cursorInstalled = options.cursorInstalled ?? (yield* isCursorInstalled());
   if (!cursorInstalled) return [];
   return [yield* cursorPluginDoctorCheck()];
-});
-
-export const installCursorPlugin = Effect.fn('cursorPlugin.install')(function* (
-  dryRun: boolean,
-  releaseRoot?: string,
-  options: CursorAvailabilityOptions = {},
-) {
-  const cursorInstalled = options.cursorInstalled ?? (yield* isCursorInstalled());
-  if (!cursorInstalled) return;
-
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const system = yield* SystemInfo;
-  const sourceRoot = path.join(releaseRoot ?? (yield* toolRoot()), 'cursor-plugin');
-  const targetRoot = yield* localCursorPluginRoot();
-  const targetExists = yield* fs.exists(targetRoot);
-  if (targetExists && (yield* isSymbolicLink(targetRoot))) {
-    yield* Console.warn(`WARN ${targetRoot} is a symlink; not replacing it with the managed Cursor plugin.`);
-    return;
-  }
-  if (targetExists && !(yield* hasManagedCursorPluginMarker(targetRoot))) {
-    yield* Console.warn(`WARN ${targetRoot} is not managed by Threadnote; not modifying it.`);
-    return;
-  }
-  if (dryRun) {
-    yield* Console.log(
-      targetExists
-        ? `Would refresh managed Cursor plugin: ${targetRoot}`
-        : `Would install Cursor plugin: ${targetRoot}`,
-    );
-    return;
-  }
-
-  yield* validateCursorPluginSource(sourceRoot);
-  if (targetExists && (yield* directoryTreesMatch(sourceRoot, targetRoot))) {
-    yield* Console.log(`Cursor plugin already current: ${targetRoot}`);
-    return;
-  }
-
-  const parent = path.dirname(targetRoot);
-  yield* fs.makeDirectory(parent, {recursive: true, mode: 0o700});
-  const operationId = `${system.processId}-${crypto.randomUUID()}`;
-  const temporaryRoot = path.join(parent, `.${CURSOR_PLUGIN_NAME}.${operationId}.installing`);
-  const backupRoot = path.join(parent, `.${CURSOR_PLUGIN_NAME}.${operationId}.backup`);
-  const cleanupTemporary = fs
-    .remove(temporaryRoot, {force: true, recursive: true})
-    .pipe(Effect.catch(() => Effect.void));
-  yield* Effect.gen(function* () {
-    yield* fs.copy(sourceRoot, temporaryRoot, {overwrite: false});
-    let movedExisting = false;
-    if (targetExists) {
-      yield* fs.rename(targetRoot, backupRoot);
-      movedExisting = true;
-    }
-    yield* fs.rename(temporaryRoot, targetRoot).pipe(
-      Effect.catch(cause =>
-        Effect.gen(function* () {
-          if (movedExisting && !(yield* fs.exists(targetRoot)) && (yield* fs.exists(backupRoot))) {
-            yield* fs.rename(backupRoot, targetRoot);
-          }
-          return yield* Effect.fail(cause);
-        }),
-      ),
-    );
-    if (movedExisting) {
-      yield* fs
-        .remove(backupRoot, {recursive: true})
-        .pipe(
-          Effect.catch(cause =>
-            Console.warn(
-              `WARN could not remove the previous Cursor plugin backup at ${backupRoot}: ${errorMessage(cause)}`,
-            ),
-          ),
-        );
-    }
-  }).pipe(Effect.ensuring(cleanupTemporary));
-  yield* Console.log(
-    targetExists ? `Refreshed managed Cursor plugin: ${targetRoot}` : `Installed Cursor plugin: ${targetRoot}`,
-  );
-  yield* Console.log('Reload Cursor or open a new Cursor window so the Threadnote plugin refreshes.');
-});
-
-export const removeCursorPlugin = Effect.fn('cursorPlugin.remove')(function* (dryRun: boolean) {
-  const fs = yield* FileSystem.FileSystem;
-  const targetRoot = yield* localCursorPluginRoot();
-  if (!(yield* fs.exists(targetRoot))) return;
-  if (yield* isSymbolicLink(targetRoot)) {
-    yield* Console.warn(`WARN ${targetRoot} is a symlink; not removing it.`);
-    return;
-  }
-  if (!(yield* hasManagedCursorPluginMarker(targetRoot))) {
-    yield* Console.warn(`WARN ${targetRoot} is not managed by Threadnote; not removing it.`);
-    return;
-  }
-  if (dryRun) {
-    yield* Console.log(`Would remove managed Cursor plugin: ${targetRoot}`);
-    return;
-  }
-  yield* fs.remove(targetRoot, {recursive: true});
-  yield* Console.log(`Removed managed Cursor plugin: ${targetRoot}. It can be restored with threadnote install.`);
 });
 
 export const isCursorInstalled = Effect.fn('cursorPlugin.isCursorInstalled')(function* () {
@@ -183,17 +80,13 @@ export const isCursorInstalled = Effect.fn('cursorPlugin.isCursorInstalled')(fun
 const cursorPluginDoctorCheck = Effect.fn('cursorPlugin.doctorCheck')(function* () {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const localRoot = yield* localCursorPluginRoot();
+  const localRoot = yield* expandPath(`~/.cursor/plugins/local/${CURSOR_PLUGIN_NAME}`);
   if (yield* fs.exists(localRoot)) {
-    const check = yield* inspectCursorPluginRoot(localRoot);
-    if (check.status === 'ok' && !(yield* hasManagedCursorPluginMarker(localRoot))) {
-      return {
-        detail: `${localRoot}; valid but not managed by Threadnote; repair will not overwrite it`,
-        name: 'Cursor plugin',
-        status: 'warn',
-      } satisfies DoctorCheck;
-    }
-    return check;
+    return {
+      detail: `unsupported local installation at ${localRoot}; remove it while Cursor is closed, then install Threadnote through the Cursor Marketplace or your team marketplace`,
+      name: 'Cursor plugin',
+      status: 'fail',
+    } satisfies DoctorCheck;
   }
 
   const cacheRoot = yield* expandPath('~/.cursor/plugins/cache');
@@ -215,7 +108,8 @@ const cursorPluginDoctorCheck = Effect.fn('cursorPlugin.doctorCheck')(function* 
   }
 
   return {
-    detail: 'not installed; run `threadnote repair` to install the managed local plugin',
+    detail:
+      'not installed through Cursor; install Threadnote from the Cursor Marketplace or ask your team administrator to add or allow it',
     name: 'Cursor plugin',
     status: 'warn',
   } satisfies DoctorCheck;
@@ -239,7 +133,7 @@ const inspectCursorPluginRoot = Effect.fn('cursorPlugin.inspectRoot')(function* 
   const rule = yield* readFileIfExists(rulePath);
   if (rule === undefined) {
     return {
-      detail: `${rulePath} missing; run \`threadnote repair\``,
+      detail: `${rulePath} missing; reinstall the plugin through the Cursor Marketplace`,
       name: 'Cursor plugin',
       status: 'fail',
     } satisfies DoctorCheck;
@@ -247,7 +141,7 @@ const inspectCursorPluginRoot = Effect.fn('cursorPlugin.inspectRoot')(function* 
   const ruleProblem = cursorRuleProblem(rule);
   if (ruleProblem) {
     return {
-      detail: `${rulePath} ${ruleProblem}; run \`threadnote repair\``,
+      detail: `${rulePath} ${ruleProblem}; reinstall the plugin through the Cursor Marketplace`,
       name: 'Cursor plugin',
       status: 'fail',
     } satisfies DoctorCheck;
@@ -262,14 +156,14 @@ const inspectCursorPluginRoot = Effect.fn('cursorPlugin.inspectRoot')(function* 
   const comparison = compareSemver(manifest.version, bundledManifest.version);
   if (comparison < 0) {
     return {
-      detail: `${pluginRoot}; v${manifest.version} is older than bundled v${bundledManifest.version}; run \`threadnote repair\``,
+      detail: `${pluginRoot}; v${manifest.version} is older than bundled v${bundledManifest.version}; update it through the Cursor Marketplace`,
       name: 'Cursor plugin',
       status: 'warn',
     } satisfies DoctorCheck;
   }
   if (comparison === 0 && normalizeNewlines(rule) !== normalizeNewlines(bundledRule)) {
     return {
-      detail: `${rulePath} differs from bundled v${bundledManifest.version}; run \`threadnote repair\``,
+      detail: `${rulePath} differs from bundled v${bundledManifest.version}; reinstall it through the Cursor Marketplace`,
       name: 'Cursor plugin',
       status: 'fail',
     } satisfies DoctorCheck;
@@ -279,21 +173,6 @@ const inspectCursorPluginRoot = Effect.fn('cursorPlugin.inspectRoot')(function* 
     name: 'Cursor plugin',
     status: 'ok',
   } satisfies DoctorCheck;
-});
-
-const validateCursorPluginSource = Effect.fn('cursorPlugin.validateSource')(function* (pluginRoot: string) {
-  const path = yield* Path.Path;
-  const manifest = yield* readCursorPluginManifest(path.join(pluginRoot, CURSOR_PLUGIN_MANIFEST));
-  if (manifest.name !== CURSOR_PLUGIN_NAME) {
-    return yield* Effect.fail(new Error(`Bundled Cursor plugin must be named ${CURSOR_PLUGIN_NAME}.`));
-  }
-  if (!(yield* hasManagedCursorPluginMarker(pluginRoot))) {
-    return yield* Effect.fail(new Error('Bundled Cursor plugin is missing its Threadnote ownership marker.'));
-  }
-  const rule = yield* readFileIfExists(path.join(pluginRoot, CURSOR_PLUGIN_RULE));
-  const problem = rule === undefined ? 'is missing' : cursorRuleProblem(rule);
-  if (problem) return yield* Effect.fail(new Error(`Bundled Cursor plugin rule ${problem}.`));
-  return manifest;
 });
 
 const readCursorPluginManifest = Effect.fn('cursorPlugin.readManifest')(function* (manifestPath: string) {
@@ -315,64 +194,6 @@ const readCursorPluginManifest = Effect.fn('cursorPlugin.readManifest')(function
   }
   return parsed as CursorPluginManifest;
 });
-
-const hasManagedCursorPluginMarker = Effect.fn('cursorPlugin.hasManagedMarker')(function* (pluginRoot: string) {
-  const path = yield* Path.Path;
-  const raw = yield* readFileIfExists(path.join(pluginRoot, CURSOR_PLUGIN_MARKER));
-  return isManagedCursorPluginMarker(raw);
-});
-
-const localCursorPluginRoot = Effect.fn('cursorPlugin.localRoot')(() =>
-  expandPath(`~/.cursor/plugins/local/${CURSOR_PLUGIN_NAME}`),
-);
-
-const isSymbolicLink = Effect.fn('cursorPlugin.isSymbolicLink')(function* (target: string) {
-  const fs = yield* FileSystem.FileSystem;
-  return Option.isSome(yield* fs.readLink(target).pipe(Effect.option));
-});
-
-const directoryTreesMatch = Effect.fn('cursorPlugin.directoryTreesMatch')(function* (
-  sourceRoot: string,
-  targetRoot: string,
-) {
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const [sourceEntries, targetEntries] = yield* Effect.all([
-    fs.readDirectory(sourceRoot, {recursive: true}),
-    fs.readDirectory(targetRoot, {recursive: true}),
-  ]);
-  const sourceByNormalizedPath = new Map(sourceEntries.map(entry => [normalizePath(entry), entry]));
-  const targetByNormalizedPath = new Map(targetEntries.map(entry => [normalizePath(entry), entry]));
-  const sourcePaths = [...sourceByNormalizedPath.keys()].sort();
-  const targetPaths = [...targetByNormalizedPath.keys()].sort();
-  if (JSON.stringify(sourcePaths) !== JSON.stringify(targetPaths)) return false;
-  for (const relative of sourcePaths) {
-    const sourceEntry = path.join(sourceRoot, sourceByNormalizedPath.get(relative)!);
-    const targetEntry = path.join(targetRoot, targetByNormalizedPath.get(relative)!);
-    const [sourceInfo, targetInfo] = yield* Effect.all([fs.stat(sourceEntry), fs.stat(targetEntry)]);
-    if (sourceInfo.type !== targetInfo.type) return false;
-    if (sourceInfo.type === 'File' && (yield* sha256FileHex(sourceEntry)) !== (yield* sha256FileHex(targetEntry))) {
-      return false;
-    }
-  }
-  return true;
-});
-
-function isManagedCursorPluginMarker(content: string | undefined): boolean {
-  if (content === undefined) return false;
-  try {
-    const parsed = JSON.parse(content) as unknown;
-    return (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      !Array.isArray(parsed) &&
-      (parsed as Record<string, unknown>).managedBy === 'threadnote' &&
-      (parsed as Record<string, unknown>).schemaVersion === CURSOR_PLUGIN_MARKER_SCHEMA_VERSION
-    );
-  } catch {
-    return false;
-  }
-}
 
 function cursorRuleProblem(content: string): string | undefined {
   const normalized = normalizeNewlines(content);

--- a/src/cursor-plugin.ts
+++ b/src/cursor-plugin.ts
@@ -1,0 +1,414 @@
+import {Console, Effect, FileSystem, Option, Path} from 'effect';
+import {USER_INSTRUCTIONS_END_MARKER, USER_INSTRUCTIONS_START_MARKER} from './constants.js';
+import {sha256FileHex} from './effect/digest.js';
+import {SystemInfo} from './effect/system.js';
+import type {DoctorCheck} from './types.js';
+import {errorMessage, expandPath, findExecutable, readFileIfExists, toolRoot} from './utils.js';
+
+const CURSOR_PLUGIN_NAME = 'threadnote';
+const CURSOR_PLUGIN_MANIFEST = '.cursor-plugin/plugin.json';
+const CURSOR_PLUGIN_MARKER = '.threadnote-managed.json';
+const CURSOR_PLUGIN_RULE = 'rules/threadnote.mdc';
+const CURSOR_PLUGIN_MARKER_SCHEMA_VERSION = 1;
+
+interface CursorPluginManifest {
+  readonly name: string;
+  readonly version: string;
+}
+
+interface CursorAvailabilityOptions {
+  readonly cursorInstalled?: boolean;
+}
+
+export const cursorPluginDoctorChecks = Effect.fn('cursorPlugin.doctorChecks')(function* (
+  options: CursorAvailabilityOptions = {},
+) {
+  const cursorInstalled = options.cursorInstalled ?? (yield* isCursorInstalled());
+  if (!cursorInstalled) return [];
+  return [yield* cursorPluginDoctorCheck()];
+});
+
+export const installCursorPlugin = Effect.fn('cursorPlugin.install')(function* (
+  dryRun: boolean,
+  releaseRoot?: string,
+  options: CursorAvailabilityOptions = {},
+) {
+  const cursorInstalled = options.cursorInstalled ?? (yield* isCursorInstalled());
+  if (!cursorInstalled) return;
+
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const sourceRoot = path.join(releaseRoot ?? (yield* toolRoot()), 'cursor-plugin');
+  const targetRoot = yield* localCursorPluginRoot();
+  const targetExists = yield* fs.exists(targetRoot);
+  if (targetExists && (yield* isSymbolicLink(targetRoot))) {
+    yield* Console.warn(`WARN ${targetRoot} is a symlink; not replacing it with the managed Cursor plugin.`);
+    return;
+  }
+  if (targetExists && !(yield* hasManagedCursorPluginMarker(targetRoot))) {
+    yield* Console.warn(`WARN ${targetRoot} is not managed by Threadnote; not modifying it.`);
+    return;
+  }
+  if (dryRun) {
+    yield* Console.log(
+      targetExists
+        ? `Would refresh managed Cursor plugin: ${targetRoot}`
+        : `Would install Cursor plugin: ${targetRoot}`,
+    );
+    return;
+  }
+
+  yield* validateCursorPluginSource(sourceRoot);
+  if (targetExists && (yield* directoryTreesMatch(sourceRoot, targetRoot))) {
+    yield* Console.log(`Cursor plugin already current: ${targetRoot}`);
+    return;
+  }
+
+  const parent = path.dirname(targetRoot);
+  yield* fs.makeDirectory(parent, {recursive: true, mode: 0o700});
+  const operationId = `${system.processId}-${crypto.randomUUID()}`;
+  const temporaryRoot = path.join(parent, `.${CURSOR_PLUGIN_NAME}.${operationId}.installing`);
+  const backupRoot = path.join(parent, `.${CURSOR_PLUGIN_NAME}.${operationId}.backup`);
+  const cleanupTemporary = fs
+    .remove(temporaryRoot, {force: true, recursive: true})
+    .pipe(Effect.catch(() => Effect.void));
+  yield* Effect.gen(function* () {
+    yield* fs.copy(sourceRoot, temporaryRoot, {overwrite: false});
+    let movedExisting = false;
+    if (targetExists) {
+      yield* fs.rename(targetRoot, backupRoot);
+      movedExisting = true;
+    }
+    yield* fs.rename(temporaryRoot, targetRoot).pipe(
+      Effect.catch(cause =>
+        Effect.gen(function* () {
+          if (movedExisting && !(yield* fs.exists(targetRoot)) && (yield* fs.exists(backupRoot))) {
+            yield* fs.rename(backupRoot, targetRoot);
+          }
+          return yield* Effect.fail(cause);
+        }),
+      ),
+    );
+    if (movedExisting) {
+      yield* fs
+        .remove(backupRoot, {recursive: true})
+        .pipe(
+          Effect.catch(cause =>
+            Console.warn(
+              `WARN could not remove the previous Cursor plugin backup at ${backupRoot}: ${errorMessage(cause)}`,
+            ),
+          ),
+        );
+    }
+  }).pipe(Effect.ensuring(cleanupTemporary));
+  yield* Console.log(
+    targetExists ? `Refreshed managed Cursor plugin: ${targetRoot}` : `Installed Cursor plugin: ${targetRoot}`,
+  );
+  yield* Console.log('Reload Cursor or open a new Cursor window so the Threadnote plugin refreshes.');
+});
+
+export const removeCursorPlugin = Effect.fn('cursorPlugin.remove')(function* (dryRun: boolean) {
+  const fs = yield* FileSystem.FileSystem;
+  const targetRoot = yield* localCursorPluginRoot();
+  if (!(yield* fs.exists(targetRoot))) return;
+  if (yield* isSymbolicLink(targetRoot)) {
+    yield* Console.warn(`WARN ${targetRoot} is a symlink; not removing it.`);
+    return;
+  }
+  if (!(yield* hasManagedCursorPluginMarker(targetRoot))) {
+    yield* Console.warn(`WARN ${targetRoot} is not managed by Threadnote; not removing it.`);
+    return;
+  }
+  if (dryRun) {
+    yield* Console.log(`Would remove managed Cursor plugin: ${targetRoot}`);
+    return;
+  }
+  yield* fs.remove(targetRoot, {recursive: true});
+  yield* Console.log(`Removed managed Cursor plugin: ${targetRoot}. It can be restored with threadnote install.`);
+});
+
+export const isCursorInstalled = Effect.fn('cursorPlugin.isCursorInstalled')(function* () {
+  if (yield* findExecutable(['cursor', 'cursor-agent'])) return true;
+
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const environment = system.environment();
+  const homeRelativeToTemporary = path.relative(system.tempDirectory, system.homeDirectory);
+  const homeIsTemporary =
+    homeRelativeToTemporary === '' ||
+    (homeRelativeToTemporary !== '..' &&
+      !homeRelativeToTemporary.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(homeRelativeToTemporary));
+  const includeSystemMarkers = !homeIsTemporary;
+  const markers: string[] = [];
+  if (system.platform === 'darwin') {
+    markers.push(
+      path.join(system.homeDirectory, 'Applications', 'Cursor.app'),
+      path.join(system.homeDirectory, 'Library', 'Application Support', 'Cursor'),
+    );
+    if (includeSystemMarkers) markers.push('/Applications/Cursor.app');
+  } else if (system.platform === 'win32') {
+    markers.push(
+      path.join(system.homeDirectory, 'AppData', 'Local', 'Programs', 'cursor', 'Cursor.exe'),
+      path.join(system.homeDirectory, 'AppData', 'Roaming', 'Cursor'),
+    );
+    if (includeSystemMarkers) {
+      for (const root of [environment.LOCALAPPDATA, environment.ProgramFiles, environment['ProgramFiles(x86)']]) {
+        if (!root) continue;
+        markers.push(path.join(root, 'Programs', 'cursor', 'Cursor.exe'), path.join(root, 'Cursor', 'Cursor.exe'));
+      }
+      if (environment.APPDATA) markers.push(path.join(environment.APPDATA, 'Cursor'));
+    }
+  } else if (system.platform === 'linux') {
+    const configHome =
+      includeSystemMarkers && environment.XDG_CONFIG_HOME
+        ? environment.XDG_CONFIG_HOME
+        : path.join(system.homeDirectory, '.config');
+    markers.push(
+      path.join(configHome, 'Cursor'),
+      path.join(system.homeDirectory, '.local', 'share', 'applications', 'cursor.desktop'),
+    );
+    if (includeSystemMarkers) {
+      markers.push('/usr/share/applications/cursor.desktop', '/opt/Cursor/cursor', '/opt/cursor/cursor');
+    }
+  }
+  for (const marker of markers) {
+    if (yield* fs.exists(marker)) return true;
+  }
+  return false;
+});
+
+const cursorPluginDoctorCheck = Effect.fn('cursorPlugin.doctorCheck')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const localRoot = yield* localCursorPluginRoot();
+  if (yield* fs.exists(localRoot)) {
+    const check = yield* inspectCursorPluginRoot(localRoot);
+    if (check.status === 'ok' && !(yield* hasManagedCursorPluginMarker(localRoot))) {
+      return {
+        detail: `${localRoot}; valid but not managed by Threadnote; repair will not overwrite it`,
+        name: 'Cursor plugin',
+        status: 'warn',
+      } satisfies DoctorCheck;
+    }
+    return check;
+  }
+
+  const cacheRoot = yield* expandPath('~/.cursor/plugins/cache');
+  if (yield* fs.exists(cacheRoot)) {
+    const candidates: Array<{readonly manifest: CursorPluginManifest; readonly root: string}> = [];
+    const entries = (yield* fs.readDirectory(cacheRoot, {recursive: true})).sort();
+    for (const entry of entries) {
+      if (!normalizePath(entry).endsWith(CURSOR_PLUGIN_MANIFEST)) continue;
+      const manifestPath = path.join(cacheRoot, entry);
+      const manifest = yield* readCursorPluginManifest(manifestPath).pipe(
+        Effect.catch(() => Effect.succeed(undefined)),
+      );
+      if (manifest?.name !== CURSOR_PLUGIN_NAME) continue;
+      candidates.push({manifest, root: path.dirname(path.dirname(manifestPath))});
+    }
+    candidates.sort((left, right) => compareSemver(right.manifest.version, left.manifest.version));
+    const current = candidates[0];
+    if (current) return yield* inspectCursorPluginRoot(current.root);
+  }
+
+  return {
+    detail: 'not installed; run `threadnote repair` to install the managed local plugin',
+    name: 'Cursor plugin',
+    status: 'warn',
+  } satisfies DoctorCheck;
+});
+
+const inspectCursorPluginRoot = Effect.fn('cursorPlugin.inspectRoot')(function* (pluginRoot: string) {
+  const path = yield* Path.Path;
+  const manifestPath = path.join(pluginRoot, CURSOR_PLUGIN_MANIFEST);
+  const manifest = yield* readCursorPluginManifest(manifestPath).pipe(
+    Effect.mapError(cause => new Error(`${manifestPath}: ${errorMessage(cause)}`)),
+  );
+  if (manifest.name !== CURSOR_PLUGIN_NAME) {
+    return {
+      detail: `${manifestPath} declares plugin ${JSON.stringify(manifest.name)} instead of ${CURSOR_PLUGIN_NAME}`,
+      name: 'Cursor plugin',
+      status: 'fail',
+    } satisfies DoctorCheck;
+  }
+
+  const rulePath = path.join(pluginRoot, CURSOR_PLUGIN_RULE);
+  const rule = yield* readFileIfExists(rulePath);
+  if (rule === undefined) {
+    return {
+      detail: `${rulePath} missing; run \`threadnote repair\``,
+      name: 'Cursor plugin',
+      status: 'fail',
+    } satisfies DoctorCheck;
+  }
+  const ruleProblem = cursorRuleProblem(rule);
+  if (ruleProblem) {
+    return {
+      detail: `${rulePath} ${ruleProblem}; run \`threadnote repair\``,
+      name: 'Cursor plugin',
+      status: 'fail',
+    } satisfies DoctorCheck;
+  }
+
+  const bundledRoot = path.join(yield* toolRoot(), 'cursor-plugin');
+  const bundledManifest = yield* readCursorPluginManifest(path.join(bundledRoot, CURSOR_PLUGIN_MANIFEST));
+  const bundledRule = yield* readFileIfExists(path.join(bundledRoot, CURSOR_PLUGIN_RULE));
+  if (bundledRule === undefined) {
+    return yield* Effect.fail(new Error('The standalone release is missing its bundled Cursor plugin rule.'));
+  }
+  const comparison = compareSemver(manifest.version, bundledManifest.version);
+  if (comparison < 0) {
+    return {
+      detail: `${pluginRoot}; v${manifest.version} is older than bundled v${bundledManifest.version}; run \`threadnote repair\``,
+      name: 'Cursor plugin',
+      status: 'warn',
+    } satisfies DoctorCheck;
+  }
+  if (comparison === 0 && normalizeNewlines(rule) !== normalizeNewlines(bundledRule)) {
+    return {
+      detail: `${rulePath} differs from bundled v${bundledManifest.version}; run \`threadnote repair\``,
+      name: 'Cursor plugin',
+      status: 'fail',
+    } satisfies DoctorCheck;
+  }
+  return {
+    detail: `${pluginRoot}; v${manifest.version}; always-applied rule verified`,
+    name: 'Cursor plugin',
+    status: 'ok',
+  } satisfies DoctorCheck;
+});
+
+const validateCursorPluginSource = Effect.fn('cursorPlugin.validateSource')(function* (pluginRoot: string) {
+  const path = yield* Path.Path;
+  const manifest = yield* readCursorPluginManifest(path.join(pluginRoot, CURSOR_PLUGIN_MANIFEST));
+  if (manifest.name !== CURSOR_PLUGIN_NAME) {
+    return yield* Effect.fail(new Error(`Bundled Cursor plugin must be named ${CURSOR_PLUGIN_NAME}.`));
+  }
+  if (!(yield* hasManagedCursorPluginMarker(pluginRoot))) {
+    return yield* Effect.fail(new Error('Bundled Cursor plugin is missing its Threadnote ownership marker.'));
+  }
+  const rule = yield* readFileIfExists(path.join(pluginRoot, CURSOR_PLUGIN_RULE));
+  const problem = rule === undefined ? 'is missing' : cursorRuleProblem(rule);
+  if (problem) return yield* Effect.fail(new Error(`Bundled Cursor plugin rule ${problem}.`));
+  return manifest;
+});
+
+const readCursorPluginManifest = Effect.fn('cursorPlugin.readManifest')(function* (manifestPath: string) {
+  const raw = yield* readFileIfExists(manifestPath);
+  if (raw === undefined) return yield* Effect.fail(new Error('manifest is missing'));
+  const parsed = yield* Effect.try({
+    try: () => JSON.parse(raw) as unknown,
+    catch: cause => new Error('manifest is not valid JSON', {cause}),
+  });
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    Array.isArray(parsed) ||
+    typeof (parsed as Record<string, unknown>).name !== 'string' ||
+    typeof (parsed as Record<string, unknown>).version !== 'string' ||
+    !isSemver((parsed as Record<string, unknown>).version as string)
+  ) {
+    return yield* Effect.fail(new Error('manifest must declare string name and semantic version fields'));
+  }
+  return parsed as CursorPluginManifest;
+});
+
+const hasManagedCursorPluginMarker = Effect.fn('cursorPlugin.hasManagedMarker')(function* (pluginRoot: string) {
+  const path = yield* Path.Path;
+  const raw = yield* readFileIfExists(path.join(pluginRoot, CURSOR_PLUGIN_MARKER));
+  return isManagedCursorPluginMarker(raw);
+});
+
+const localCursorPluginRoot = Effect.fn('cursorPlugin.localRoot')(() =>
+  expandPath(`~/.cursor/plugins/local/${CURSOR_PLUGIN_NAME}`),
+);
+
+const isSymbolicLink = Effect.fn('cursorPlugin.isSymbolicLink')(function* (target: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return Option.isSome(yield* fs.readLink(target).pipe(Effect.option));
+});
+
+const directoryTreesMatch = Effect.fn('cursorPlugin.directoryTreesMatch')(function* (
+  sourceRoot: string,
+  targetRoot: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const [sourceEntries, targetEntries] = yield* Effect.all([
+    fs.readDirectory(sourceRoot, {recursive: true}),
+    fs.readDirectory(targetRoot, {recursive: true}),
+  ]);
+  const sourceByNormalizedPath = new Map(sourceEntries.map(entry => [normalizePath(entry), entry]));
+  const targetByNormalizedPath = new Map(targetEntries.map(entry => [normalizePath(entry), entry]));
+  const sourcePaths = [...sourceByNormalizedPath.keys()].sort();
+  const targetPaths = [...targetByNormalizedPath.keys()].sort();
+  if (JSON.stringify(sourcePaths) !== JSON.stringify(targetPaths)) return false;
+  for (const relative of sourcePaths) {
+    const sourceEntry = path.join(sourceRoot, sourceByNormalizedPath.get(relative)!);
+    const targetEntry = path.join(targetRoot, targetByNormalizedPath.get(relative)!);
+    const [sourceInfo, targetInfo] = yield* Effect.all([fs.stat(sourceEntry), fs.stat(targetEntry)]);
+    if (sourceInfo.type !== targetInfo.type) return false;
+    if (sourceInfo.type === 'File' && (yield* sha256FileHex(sourceEntry)) !== (yield* sha256FileHex(targetEntry))) {
+      return false;
+    }
+  }
+  return true;
+});
+
+function isManagedCursorPluginMarker(content: string | undefined): boolean {
+  if (content === undefined) return false;
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    return (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      (parsed as Record<string, unknown>).managedBy === 'threadnote' &&
+      (parsed as Record<string, unknown>).schemaVersion === CURSOR_PLUGIN_MARKER_SCHEMA_VERSION
+    );
+  } catch {
+    return false;
+  }
+}
+
+function cursorRuleProblem(content: string): string | undefined {
+  const normalized = normalizeNewlines(content);
+  const frontmatter = /^---\n([\s\S]*?)\n---(?:\n|$)/.exec(normalized)?.[1];
+  if (!frontmatter) return 'has no valid MDC frontmatter';
+  if (!/^description:\s*\S.+$/m.test(frontmatter)) return 'has no non-empty description';
+  if (!/^alwaysApply:\s*true\s*$/m.test(frontmatter)) return 'is not marked alwaysApply: true';
+  const start = normalized.indexOf(USER_INSTRUCTIONS_START_MARKER);
+  const end = normalized.indexOf(USER_INSTRUCTIONS_END_MARKER);
+  if (start === -1 || end < start) return 'does not contain the complete Threadnote instruction block';
+  return undefined;
+}
+
+function compareSemver(left: string, right: string): number {
+  const [leftCore, leftPrerelease] = left.split('-', 2);
+  const [rightCore, rightPrerelease] = right.split('-', 2);
+  const leftParts = leftCore!.split('.').map(Number);
+  const rightParts = rightCore!.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = leftParts[index]! - rightParts[index]!;
+    if (difference !== 0) return difference;
+  }
+  if (leftPrerelease === rightPrerelease) return 0;
+  if (leftPrerelease === undefined) return 1;
+  if (rightPrerelease === undefined) return -1;
+  return leftPrerelease.localeCompare(rightPrerelease);
+}
+
+function isSemver(value: string): boolean {
+  return /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/.test(value);
+}
+
+function normalizeNewlines(value: string): string {
+  return value.replaceAll('\r\n', '\n');
+}
+
+function normalizePath(value: string): string {
+  return value.replaceAll('\\', '/');
+}

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,9 +1,11 @@
 import {Console, Effect, FileSystem, Path, Result} from 'effect';
 import {
+  LEGACY_CURSOR_INSTRUCTION_PATHS,
   USER_AGENT_INSTRUCTION_TARGETS,
   USER_INSTRUCTIONS_END_MARKER,
   USER_INSTRUCTIONS_START_MARKER,
 } from './constants.js';
+import {cursorPluginDoctorChecks, installCursorPlugin, removeCursorPlugin} from './cursor-plugin.js';
 import {startProgress} from './cli_ui.js';
 import {commandShimCheck, installCommandShim, removeCommandShim} from './command-shim.js';
 import {sha256FileHex} from './effect/digest.js';
@@ -166,6 +168,7 @@ export const collectDoctorChecks = Effect.fn('lifecycle.collectDoctorChecks')(fu
     yield* safeDoctorCheck('memory project consistency', memoryProjectConsistencyCheck(config)),
   );
   checks.push(...(yield* safeDoctorChecks('agent instructions', userAgentInstructionsChecks())));
+  checks.push(...(yield* safeDoctorChecks('Cursor plugin', cursorPluginDoctorChecks())));
   if (config.agentContextHome.endsWith('.openviking')) {
     checks.push({
       detail: 'THREADNOTE_HOME still targets a legacy .openviking directory; run `threadnote migrate`',
@@ -289,6 +292,7 @@ export const runInstall = Effect.fn('lifecycle.install')(function* (config: Runt
     );
   }
   yield* installUserAgentInstructions(dryRun);
+  yield* withStandaloneInstallationLock(installCursorPlugin(dryRun, releaseRoot), dryRun);
   if (options.start !== false) {
     yield* Console.log(
       'Threadnote 4 uses local storage and a supervised on-demand inference worker; no background server is required.',
@@ -480,6 +484,7 @@ export const runUninstall = Effect.fn('lifecycle.uninstall')(function* (
   if (yield* hasManagedClaudeHooks()) {
     yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun, remove: true});
   }
+  yield* withStandaloneInstallationLock(removeCursorPlugin(dryRun), dryRun);
   yield* removeCommandShim(dryRun);
   yield* removeUserAgentInstructions(dryRun);
   if (options.eraseMemories === true) {
@@ -777,6 +782,7 @@ const installUserAgentInstructions = Effect.fn('lifecycle.installUserAgentInstru
         : `Updated agent instructions: ${targetPath}`,
     );
   }
+  yield* removeLegacyCursorUserRules(dryRun);
 });
 
 const removeUserAgentInstructions = Effect.fn('lifecycle.removeUserAgentInstructions')(function* (dryRun: boolean) {
@@ -807,7 +813,43 @@ const removeUserAgentInstructions = Effect.fn('lifecycle.removeUserAgentInstruct
       yield* Console.log(`Updated ${targetPath}`);
     }
   }
+  yield* removeLegacyCursorUserRules(dryRun);
 });
+
+const removeLegacyCursorUserRules = Effect.fn('lifecycle.removeLegacyCursorUserRules')(function* (dryRun: boolean) {
+  const fs = yield* FileSystem.FileSystem;
+  for (const legacyPath of LEGACY_CURSOR_INSTRUCTION_PATHS) {
+    const targetPath = yield* expandPath(legacyPath);
+    const currentContent = yield* readFileIfExists(targetPath);
+    if (currentContent === undefined) continue;
+    const contentWithoutBlock = removeManagedBlock(currentContent);
+    if (contentWithoutBlock === undefined) {
+      yield* Console.log(`WARN ${targetPath} has partial Threadnote markers; not modifying it`);
+      continue;
+    }
+    const nextContent = isCursorRuleFrontmatterOnly(contentWithoutBlock) ? '' : contentWithoutBlock;
+    if (nextContent === currentContent) continue;
+    if (dryRun) {
+      yield* Console.log(
+        nextContent.trim().length === 0
+          ? `Would remove legacy Cursor user rule: ${targetPath}`
+          : `Would update ${targetPath} to remove legacy Threadnote instructions`,
+      );
+    } else if (nextContent.trim().length === 0) {
+      yield* fs.remove(targetPath);
+      yield* Console.log(`Removed legacy Cursor user rule: ${targetPath}`);
+    } else {
+      yield* fs.writeFileString(targetPath, nextContent, {mode: 0o644});
+      yield* Console.log(`Updated ${targetPath} to remove legacy Threadnote instructions`);
+    }
+  }
+});
+
+function isCursorRuleFrontmatterOnly(content: string): boolean {
+  const match = /^---\s*\r?\n([\s\S]*?)\r?\n---\s*$/.exec(content);
+  if (!match) return false;
+  return /^alwaysApply:\s*true\s*$/m.test(match[1] ?? '');
+}
 
 const renderUserAgentInstructions = Effect.fn('lifecycle.renderUserAgentInstructions')(function* (
   target: UserAgentInstructionTarget,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -5,7 +5,7 @@ import {
   USER_INSTRUCTIONS_END_MARKER,
   USER_INSTRUCTIONS_START_MARKER,
 } from './constants.js';
-import {cursorPluginDoctorChecks, installCursorPlugin, removeCursorPlugin} from './cursor-plugin.js';
+import {cursorPluginDoctorChecks} from './cursor-plugin.js';
 import {startProgress} from './cli_ui.js';
 import {commandShimCheck, installCommandShim, removeCommandShim} from './command-shim.js';
 import {sha256FileHex} from './effect/digest.js';
@@ -292,7 +292,6 @@ export const runInstall = Effect.fn('lifecycle.install')(function* (config: Runt
     );
   }
   yield* installUserAgentInstructions(dryRun);
-  yield* withStandaloneInstallationLock(installCursorPlugin(dryRun, releaseRoot), dryRun);
   if (options.start !== false) {
     yield* Console.log(
       'Threadnote 4 uses local storage and a supervised on-demand inference worker; no background server is required.',
@@ -484,7 +483,6 @@ export const runUninstall = Effect.fn('lifecycle.uninstall')(function* (
   if (yield* hasManagedClaudeHooks()) {
     yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun, remove: true});
   }
-  yield* withStandaloneInstallationLock(removeCursorPlugin(dryRun), dryRun);
   yield* removeCommandShim(dryRun);
   yield* removeUserAgentInstructions(dryRun);
   if (options.eraseMemories === true) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -31,6 +31,7 @@ import {isLegacyHomeMigrationPending, isThreadnoteHomeMigrationPending} from './
 import {whatsNewLinesForVersionRange} from './release_notes.js';
 import type {JsonObject, PostUpdateOptions, RuntimeConfig, UpdateOptions} from './types.js';
 import {selectUpdateChannel, type UpdateChannel} from './update_channel.js';
+import {isDevelopmentBuildVersion} from './version_compare.js';
 import {
   compareVersions,
   ensureDirectory,
@@ -65,6 +66,7 @@ interface UpdateInfo {
   readonly isVersionUpgrade: boolean;
   readonly latestVersion: string | undefined;
   readonly source: string;
+  readonly usedCache: boolean;
 }
 
 interface UpdateCache {
@@ -121,16 +123,29 @@ export function maybeNotifyUpdate(config: RuntimeConfig, options: {readonly dryR
     if (isUpdateNotificationDisabled(system.environment())) {
       return;
     }
+    const packageVersion = yield* currentPackageVersion();
+    if (isDevelopmentBuildVersion(packageVersion)) {
+      return;
+    }
     const source = yield* fromSync('resolve release source', () =>
       resolveReleaseSource(undefined, false, system.environment()),
     );
-    const info = yield* getUpdateInfo(config, {
+    let info = yield* getUpdateInfo(config, {
       allowCacheWrite: options.dryRun !== true,
       preferFresh: false,
       preferInstalledVersion: false,
       source,
       requestedChannel: undefined,
     });
+    if (info.isUpdateAvailable && info.usedCache) {
+      info = yield* getUpdateInfo(config, {
+        allowCacheWrite: options.dryRun !== true,
+        preferFresh: true,
+        preferInstalledVersion: false,
+        source,
+        requestedChannel: undefined,
+      });
+    }
     if (info.isUpdateAvailable) {
       yield* Console.log('');
       yield* Console.log(warning(`Update available: threadnote ${info.currentVersion} -> ${info.latestVersion}`));
@@ -662,6 +677,7 @@ function getUpdateInfo(
       isVersionUpgrade,
       latestVersion,
       source: options.source,
+      usedCache: cached !== undefined,
     };
   });
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -9,7 +9,6 @@ import {
   withSpinnerEffect,
 } from './cli_ui.js';
 import {installCommandShim} from './command-shim.js';
-import {installCursorPlugin} from './cursor-plugin.js';
 import {extractGzipTar} from './effect/archive.js';
 import {maybeRunEffect, runCommandEffect, runStreamingCommandEffect} from './effect/command.js';
 import {applicationError, fromSync} from './effect/errors.js';
@@ -200,22 +199,11 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   }
 
   if (!info.isUpdateAvailable && options.force !== true) {
-    const path = yield* Path.Path;
-    const activeReleaseRoot =
-      info.installedVersion === undefined
-        ? yield* toolRoot()
-        : path.join(installationRoot(path, system), 'versions', info.installedVersion);
     if (info.installedVersion !== undefined) {
+      const path = yield* Path.Path;
+      const activeReleaseRoot = path.join(installationRoot(path, system), 'versions', info.installedVersion);
       yield* withStandaloneInstallationLock(
-        Effect.gen(function* () {
-          yield* installCommandShim(options.dryRun === true, activeReleaseRoot);
-          yield* installCursorPlugin(options.dryRun === true, activeReleaseRoot);
-        }),
-        options.dryRun === true,
-      );
-    } else {
-      yield* withStandaloneInstallationLock(
-        installCursorPlugin(options.dryRun === true, activeReleaseRoot),
+        installCommandShim(options.dryRun === true, activeReleaseRoot),
         options.dryRun === true,
       );
     }
@@ -239,7 +227,6 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     }),
     dryRun,
   );
-  yield* withStandaloneInstallationLock(installCursorPlugin(dryRun, releaseRoot), dryRun);
   const path = yield* Path.Path;
   const threadnoteCommand = path.join(releaseRoot, system.platform === 'win32' ? 'threadnote.exe' : 'threadnote');
   const postUpdateArgs = [

--- a/src/update.ts
+++ b/src/update.ts
@@ -9,6 +9,7 @@ import {
   withSpinnerEffect,
 } from './cli_ui.js';
 import {installCommandShim} from './command-shim.js';
+import {installCursorPlugin} from './cursor-plugin.js';
 import {extractGzipTar} from './effect/archive.js';
 import {maybeRunEffect, runCommandEffect, runStreamingCommandEffect} from './effect/command.js';
 import {applicationError, fromSync} from './effect/errors.js';
@@ -199,11 +200,22 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   }
 
   if (!info.isUpdateAvailable && options.force !== true) {
+    const path = yield* Path.Path;
+    const activeReleaseRoot =
+      info.installedVersion === undefined
+        ? yield* toolRoot()
+        : path.join(installationRoot(path, system), 'versions', info.installedVersion);
     if (info.installedVersion !== undefined) {
-      const path = yield* Path.Path;
-      const activeReleaseRoot = path.join(installationRoot(path, system), 'versions', info.installedVersion);
       yield* withStandaloneInstallationLock(
-        installCommandShim(options.dryRun === true, activeReleaseRoot),
+        Effect.gen(function* () {
+          yield* installCommandShim(options.dryRun === true, activeReleaseRoot);
+          yield* installCursorPlugin(options.dryRun === true, activeReleaseRoot);
+        }),
+        options.dryRun === true,
+      );
+    } else {
+      yield* withStandaloneInstallationLock(
+        installCursorPlugin(options.dryRun === true, activeReleaseRoot),
         options.dryRun === true,
       );
     }
@@ -227,6 +239,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     }),
     dryRun,
   );
+  yield* withStandaloneInstallationLock(installCursorPlugin(dryRun, releaseRoot), dryRun);
   const path = yield* Path.Path;
   const threadnoteCommand = path.join(releaseRoot, system.platform === 'win32' ? 'threadnote.exe' : 'threadnote');
   const postUpdateArgs = [

--- a/src/version_compare.ts
+++ b/src/version_compare.ts
@@ -17,6 +17,13 @@ export function compareVersions(leftVersion: string, rightVersion: string): numb
   return (left.suffix ?? '').localeCompare(right.suffix ?? '', 'en', {numeric: true});
 }
 
+const DEVELOPMENT_BUILD_VERSION_PATTERN =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-(?:[0-9A-Za-z-]+\.)*local\.g[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
+
+export function isDevelopmentBuildVersion(version: string): boolean {
+  return DEVELOPMENT_BUILD_VERSION_PATTERN.test(version);
+}
+
 function suffixRank(suffix: string | undefined): number {
   if (suffix === undefined) return 0;
   return /^post/i.test(suffix) ? 1 : -1;

--- a/test/unit/cursor-plugin.test.ts
+++ b/test/unit/cursor-plugin.test.ts
@@ -1,0 +1,198 @@
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import {expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {describe} from 'vitest';
+import {USER_INSTRUCTIONS_END_MARKER, USER_INSTRUCTIONS_START_MARKER} from '../../src/constants.js';
+import {cursorPluginDoctorChecks, installCursorPlugin, removeCursorPlugin} from '../../src/cursor-plugin.js';
+import {captureConsole} from '../../src/effect/console.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+
+const root = process.cwd();
+const pluginRoot = join(root, 'cursor-plugin');
+
+describe('Cursor plugin package', () => {
+  it('matches Cursor manifest anatomy and the canonical Threadnote instructions', async () => {
+    const [marketplaceRaw, manifestRaw, markerRaw, rule, instructions, pluginLicense, licenseScope, packageRaw] =
+      await Promise.all([
+        readFile(join(root, '.cursor-plugin', 'marketplace.json'), 'utf8'),
+        readFile(join(pluginRoot, '.cursor-plugin', 'plugin.json'), 'utf8'),
+        readFile(join(pluginRoot, '.threadnote-managed.json'), 'utf8'),
+        readFile(join(pluginRoot, 'rules', 'threadnote.mdc'), 'utf8'),
+        readFile(join(root, 'config', 'agent-instructions.md'), 'utf8'),
+        readFile(join(pluginRoot, 'LICENSE'), 'utf8'),
+        readFile(join(root, 'CURSOR_PLUGIN_LICENSE.md'), 'utf8'),
+        readFile(join(root, 'package.json'), 'utf8'),
+      ]);
+    const marketplace = JSON.parse(marketplaceRaw) as Record<string, unknown>;
+    const manifest = JSON.parse(manifestRaw) as Record<string, unknown>;
+
+    expect(Object.keys(marketplace).sort()).toEqual(['metadata', 'name', 'owner', 'plugins']);
+    expect(marketplace).toMatchObject({
+      name: 'threadnote',
+      plugins: [
+        {
+          minClientVersions: {cursor: '2.5.0'},
+          name: 'threadnote',
+          source: 'cursor-plugin',
+        },
+      ],
+    });
+    expect(Object.keys(manifest).sort()).toEqual(
+      [
+        'author',
+        'category',
+        'description',
+        'displayName',
+        'homepage',
+        'keywords',
+        'license',
+        'logo',
+        'minClientVersions',
+        'name',
+        'publisher',
+        'repository',
+        'rules',
+        'tags',
+        'version',
+      ].sort(),
+    );
+    expect(manifest).toMatchObject({
+      license: 'MIT',
+      minClientVersions: {cursor: '2.5.0'},
+      name: 'threadnote',
+      rules: './rules/',
+      version: '1.0.0',
+    });
+    expect(JSON.parse(markerRaw)).toEqual({managedBy: 'threadnote', schemaVersion: 1});
+    expect(rule).toMatch(/^---\ndescription: .+\nalwaysApply: true\n---\n/);
+    expect(rule).toContain(
+      `${USER_INSTRUCTIONS_START_MARKER}\n${instructions.trim()}\n${USER_INSTRUCTIONS_END_MARKER}`,
+    );
+    expect(pluginLicense.startsWith('MIT License')).toBe(true);
+    expect(licenseScope).toContain('`.cursor-plugin/` and `cursor-plugin/`');
+    expect(JSON.parse(packageRaw)).toMatchObject({license: 'AGPL-3.0-or-later'});
+  });
+
+  it.effect('skips absent Cursor and verifies local and Marketplace plugin installs', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-cursor-plugin-'});
+        const userHome = path.join(temporaryRoot, 'user');
+        const testSystem = SystemInfo.of({
+          ...system,
+          environment: () => ({...system.environment(), PATH: ''}),
+          homeDirectory: userHome,
+        });
+
+        const skipped = yield* cursorPluginDoctorChecks({cursorInstalled: false}).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(skipped).toEqual([]);
+
+        const missing = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(missing).toMatchObject([{name: 'Cursor plugin', status: 'warn'}]);
+
+        const localRoot = path.join(userHome, '.cursor', 'plugins', 'local', 'threadnote');
+        yield* fs.copy(pluginRoot, localRoot, {overwrite: true});
+        const local = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(local).toMatchObject([{name: 'Cursor plugin', status: 'ok'}]);
+        expect(local[0]?.detail).toContain('always-applied rule verified');
+
+        const localManifest = path.join(localRoot, '.cursor-plugin', 'plugin.json');
+        yield* fs.writeFileString(
+          localManifest,
+          (yield* fs.readFileString(localManifest)).replace('"version": "1.0.0"', '"version": "0.9.0"'),
+        );
+        const outdated = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(outdated).toMatchObject([{name: 'Cursor plugin', status: 'warn'}]);
+        expect(outdated[0]?.detail).toContain('is older than bundled v1.0.0');
+        yield* fs.copy(pluginRoot, localRoot, {overwrite: true});
+
+        const localRule = path.join(localRoot, 'rules', 'threadnote.mdc');
+        yield* fs.writeFileString(localRule, (yield* fs.readFileString(localRule)).replace('alwaysApply: true', ''));
+        const invalid = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(invalid).toMatchObject([{name: 'Cursor plugin', status: 'fail'}]);
+
+        yield* fs.remove(localRoot, {recursive: true});
+        const cachedRoot = path.join(userHome, '.cursor', 'plugins', 'cache', 'threadnote', '1.0.0');
+        yield* fs.copy(pluginRoot, cachedRoot, {overwrite: true});
+        const cached = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(cached).toMatchObject([{name: 'Cursor plugin', status: 'ok'}]);
+        expect(cached[0]?.detail).toContain(cachedRoot);
+      }),
+    ).pipe(Effect.provide(ApplicationLayer)),
+  );
+
+  it.effect('installs, refreshes, and removes only Threadnote-managed local plugins', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-cursor-plugin-install-'});
+        const userHome = path.join(temporaryRoot, 'user');
+        const targetRoot = path.join(userHome, '.cursor', 'plugins', 'local', 'threadnote');
+        const testSystem = SystemInfo.of({...system, homeDirectory: userHome});
+
+        const dryRun = yield* captureConsole(installCursorPlugin(true, root, {cursorInstalled: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(dryRun.output).toContain(`Would install Cursor plugin: ${targetRoot}`);
+        expect(yield* fs.exists(targetRoot)).toBe(false);
+
+        const installed = yield* captureConsole(installCursorPlugin(false, root, {cursorInstalled: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(installed.output).toContain(`Installed Cursor plugin: ${targetRoot}`);
+        expect(JSON.parse(yield* fs.readFileString(path.join(targetRoot, '.threadnote-managed.json')))).toEqual({
+          managedBy: 'threadnote',
+          schemaVersion: 1,
+        });
+
+        const targetRule = path.join(targetRoot, 'rules', 'threadnote.mdc');
+        yield* fs.writeFileString(targetRule, 'tampered\n');
+        const refreshed = yield* captureConsole(installCursorPlugin(false, root, {cursorInstalled: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(refreshed.output).toContain(`Refreshed managed Cursor plugin: ${targetRoot}`);
+        expect(yield* fs.readFileString(targetRule)).toBe(
+          yield* fs.readFileString(join(pluginRoot, 'rules', 'threadnote.mdc')),
+        );
+
+        const removed = yield* captureConsole(removeCursorPlugin(false)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(removed.output).toContain(`Removed managed Cursor plugin: ${targetRoot}`);
+        expect(yield* fs.exists(targetRoot)).toBe(false);
+
+        yield* fs.makeDirectory(targetRoot, {recursive: true});
+        const sentinel = path.join(targetRoot, 'user-owned.txt');
+        yield* fs.writeFileString(sentinel, 'preserve\n');
+        const refusedInstall = yield* captureConsole(installCursorPlugin(false, root, {cursorInstalled: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(refusedInstall.output).toContain(`${targetRoot} is not managed by Threadnote; not modifying it`);
+        const refusedRemoval = yield* captureConsole(removeCursorPlugin(false)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(refusedRemoval.output).toContain(`${targetRoot} is not managed by Threadnote; not removing it`);
+        expect(yield* fs.readFileString(sentinel)).toBe('preserve\n');
+      }),
+    ).pipe(Effect.provide(ApplicationLayer)),
+  );
+});

--- a/test/unit/cursor-plugin.test.ts
+++ b/test/unit/cursor-plugin.test.ts
@@ -1,11 +1,10 @@
-import {readFile} from 'node:fs/promises';
+import {access, readFile} from 'node:fs/promises';
 import {join} from 'node:path';
 import {expect, it} from '@effect/vitest';
 import {Effect, FileSystem, Path} from 'effect';
 import {describe} from 'vitest';
 import {USER_INSTRUCTIONS_END_MARKER, USER_INSTRUCTIONS_START_MARKER} from '../../src/constants.js';
-import {cursorPluginDoctorChecks, installCursorPlugin, removeCursorPlugin} from '../../src/cursor-plugin.js';
-import {captureConsole} from '../../src/effect/console.js';
+import {cursorPluginDoctorChecks} from '../../src/cursor-plugin.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
 
@@ -14,17 +13,27 @@ const pluginRoot = join(root, 'cursor-plugin');
 
 describe('Cursor plugin package', () => {
   it('matches Cursor manifest anatomy and the canonical Threadnote instructions', async () => {
-    const [marketplaceRaw, manifestRaw, markerRaw, rule, instructions, pluginLicense, licenseScope, packageRaw] =
-      await Promise.all([
-        readFile(join(root, '.cursor-plugin', 'marketplace.json'), 'utf8'),
-        readFile(join(pluginRoot, '.cursor-plugin', 'plugin.json'), 'utf8'),
-        readFile(join(pluginRoot, '.threadnote-managed.json'), 'utf8'),
-        readFile(join(pluginRoot, 'rules', 'threadnote.mdc'), 'utf8'),
-        readFile(join(root, 'config', 'agent-instructions.md'), 'utf8'),
-        readFile(join(pluginRoot, 'LICENSE'), 'utf8'),
-        readFile(join(root, 'CURSOR_PLUGIN_LICENSE.md'), 'utf8'),
-        readFile(join(root, 'package.json'), 'utf8'),
-      ]);
+    const [
+      marketplaceRaw,
+      manifestRaw,
+      rule,
+      instructions,
+      pluginLicense,
+      licenseScope,
+      packageRaw,
+      lifecycle,
+      update,
+    ] = await Promise.all([
+      readFile(join(root, '.cursor-plugin', 'marketplace.json'), 'utf8'),
+      readFile(join(pluginRoot, '.cursor-plugin', 'plugin.json'), 'utf8'),
+      readFile(join(pluginRoot, 'rules', 'threadnote.mdc'), 'utf8'),
+      readFile(join(root, 'config', 'agent-instructions.md'), 'utf8'),
+      readFile(join(pluginRoot, 'LICENSE'), 'utf8'),
+      readFile(join(root, 'CURSOR_PLUGIN_LICENSE.md'), 'utf8'),
+      readFile(join(root, 'package.json'), 'utf8'),
+      readFile(join(root, 'src', 'lifecycle.ts'), 'utf8'),
+      readFile(join(root, 'src', 'update.ts'), 'utf8'),
+    ]);
     const marketplace = JSON.parse(marketplaceRaw) as Record<string, unknown>;
     const manifest = JSON.parse(manifestRaw) as Record<string, unknown>;
 
@@ -65,7 +74,6 @@ describe('Cursor plugin package', () => {
       rules: './rules/',
       version: '1.0.0',
     });
-    expect(JSON.parse(markerRaw)).toEqual({managedBy: 'threadnote', schemaVersion: 1});
     expect(rule).toMatch(/^---\ndescription: .+\nalwaysApply: true\n---\n/);
     expect(rule).toContain(
       `${USER_INSTRUCTIONS_START_MARKER}\n${instructions.trim()}\n${USER_INSTRUCTIONS_END_MARKER}`,
@@ -73,9 +81,13 @@ describe('Cursor plugin package', () => {
     expect(pluginLicense.startsWith('MIT License')).toBe(true);
     expect(licenseScope).toContain('`.cursor-plugin/` and `cursor-plugin/`');
     expect(JSON.parse(packageRaw)).toMatchObject({license: 'AGPL-3.0-or-later'});
+    expect(await pathExists(join(pluginRoot, '.threadnote-managed.json'))).toBe(false);
+    expect(lifecycle).not.toContain('installCursorPlugin');
+    expect(lifecycle).not.toContain('removeCursorPlugin');
+    expect(update).not.toContain('installCursorPlugin');
   });
 
-  it.effect('skips absent Cursor and verifies local and Marketplace plugin installs', () =>
+  it.effect('skips absent Cursor and verifies only Marketplace-managed plugin installs', () =>
     Effect.scoped(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -88,111 +100,64 @@ describe('Cursor plugin package', () => {
           environment: () => ({...system.environment(), PATH: ''}),
           homeDirectory: userHome,
         });
+        const doctor = () =>
+          cursorPluginDoctorChecks({cursorInstalled: true}).pipe(Effect.provideService(SystemInfo, testSystem));
 
         const skipped = yield* cursorPluginDoctorChecks({cursorInstalled: false}).pipe(
           Effect.provideService(SystemInfo, testSystem),
         );
         expect(skipped).toEqual([]);
 
-        const missing = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
+        const missing = yield* doctor();
         expect(missing).toMatchObject([{name: 'Cursor plugin', status: 'warn'}]);
+        expect(missing[0]?.detail).toContain('Cursor Marketplace');
 
         const localRoot = path.join(userHome, '.cursor', 'plugins', 'local', 'threadnote');
-        yield* fs.copy(pluginRoot, localRoot, {overwrite: true});
-        const local = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
-        expect(local).toMatchObject([{name: 'Cursor plugin', status: 'ok'}]);
-        expect(local[0]?.detail).toContain('always-applied rule verified');
-
-        const localManifest = path.join(localRoot, '.cursor-plugin', 'plugin.json');
-        yield* fs.writeFileString(
-          localManifest,
-          (yield* fs.readFileString(localManifest)).replace('"version": "1.0.0"', '"version": "0.9.0"'),
-        );
-        const outdated = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
-        expect(outdated).toMatchObject([{name: 'Cursor plugin', status: 'warn'}]);
-        expect(outdated[0]?.detail).toContain('is older than bundled v1.0.0');
-        yield* fs.copy(pluginRoot, localRoot, {overwrite: true});
-
-        const localRule = path.join(localRoot, 'rules', 'threadnote.mdc');
-        yield* fs.writeFileString(localRule, (yield* fs.readFileString(localRule)).replace('alwaysApply: true', ''));
-        const invalid = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
-        expect(invalid).toMatchObject([{name: 'Cursor plugin', status: 'fail'}]);
-
+        yield* fs.makeDirectory(localRoot, {recursive: true});
+        const local = yield* doctor();
+        expect(local).toMatchObject([{name: 'Cursor plugin', status: 'fail'}]);
+        expect(local[0]?.detail).toContain('unsupported local installation');
+        expect(local[0]?.detail).toContain('team marketplace');
         yield* fs.remove(localRoot, {recursive: true});
+
         const cachedRoot = path.join(userHome, '.cursor', 'plugins', 'cache', 'threadnote', '1.0.0');
         yield* fs.copy(pluginRoot, cachedRoot, {overwrite: true});
-        const cached = yield* cursorPluginDoctorChecks({cursorInstalled: true}).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
+        const cached = yield* doctor();
         expect(cached).toMatchObject([{name: 'Cursor plugin', status: 'ok'}]);
         expect(cached[0]?.detail).toContain(cachedRoot);
-      }),
-    ).pipe(Effect.provide(ApplicationLayer)),
-  );
 
-  it.effect('installs, refreshes, and removes only Threadnote-managed local plugins', () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const system = yield* SystemInfo;
-        const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-cursor-plugin-install-'});
-        const userHome = path.join(temporaryRoot, 'user');
-        const targetRoot = path.join(userHome, '.cursor', 'plugins', 'local', 'threadnote');
-        const testSystem = SystemInfo.of({...system, homeDirectory: userHome});
+        yield* fs.makeDirectory(localRoot, {recursive: true});
+        const localWithMarketplaceCopy = yield* doctor();
+        expect(localWithMarketplaceCopy).toMatchObject([{name: 'Cursor plugin', status: 'fail'}]);
+        expect(localWithMarketplaceCopy[0]?.detail).toContain('unsupported local installation');
+        yield* fs.remove(localRoot, {recursive: true});
 
-        const dryRun = yield* captureConsole(installCursorPlugin(true, root, {cursorInstalled: true})).pipe(
-          Effect.provideService(SystemInfo, testSystem),
+        const cachedManifest = path.join(cachedRoot, '.cursor-plugin', 'plugin.json');
+        yield* fs.writeFileString(
+          cachedManifest,
+          (yield* fs.readFileString(cachedManifest)).replace('"version": "1.0.0"', '"version": "0.9.0"'),
         );
-        expect(dryRun.output).toContain(`Would install Cursor plugin: ${targetRoot}`);
-        expect(yield* fs.exists(targetRoot)).toBe(false);
+        const outdated = yield* doctor();
+        expect(outdated).toMatchObject([{name: 'Cursor plugin', status: 'warn'}]);
+        expect(outdated[0]?.detail).toContain('is older than bundled v1.0.0');
+        expect(outdated[0]?.detail).toContain('Cursor Marketplace');
 
-        const installed = yield* captureConsole(installCursorPlugin(false, root, {cursorInstalled: true})).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
-        expect(installed.output).toContain(`Installed Cursor plugin: ${targetRoot}`);
-        expect(JSON.parse(yield* fs.readFileString(path.join(targetRoot, '.threadnote-managed.json')))).toEqual({
-          managedBy: 'threadnote',
-          schemaVersion: 1,
-        });
-
-        const targetRule = path.join(targetRoot, 'rules', 'threadnote.mdc');
-        yield* fs.writeFileString(targetRule, 'tampered\n');
-        const refreshed = yield* captureConsole(installCursorPlugin(false, root, {cursorInstalled: true})).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
-        expect(refreshed.output).toContain(`Refreshed managed Cursor plugin: ${targetRoot}`);
-        expect(yield* fs.readFileString(targetRule)).toBe(
-          yield* fs.readFileString(join(pluginRoot, 'rules', 'threadnote.mdc')),
-        );
-
-        const removed = yield* captureConsole(removeCursorPlugin(false)).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
-        expect(removed.output).toContain(`Removed managed Cursor plugin: ${targetRoot}`);
-        expect(yield* fs.exists(targetRoot)).toBe(false);
-
-        yield* fs.makeDirectory(targetRoot, {recursive: true});
-        const sentinel = path.join(targetRoot, 'user-owned.txt');
-        yield* fs.writeFileString(sentinel, 'preserve\n');
-        const refusedInstall = yield* captureConsole(installCursorPlugin(false, root, {cursorInstalled: true})).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
-        expect(refusedInstall.output).toContain(`${targetRoot} is not managed by Threadnote; not modifying it`);
-        const refusedRemoval = yield* captureConsole(removeCursorPlugin(false)).pipe(
-          Effect.provideService(SystemInfo, testSystem),
-        );
-        expect(refusedRemoval.output).toContain(`${targetRoot} is not managed by Threadnote; not removing it`);
-        expect(yield* fs.readFileString(sentinel)).toBe('preserve\n');
+        yield* fs.copy(pluginRoot, cachedRoot, {overwrite: true});
+        const cachedRule = path.join(cachedRoot, 'rules', 'threadnote.mdc');
+        yield* fs.writeFileString(cachedRule, (yield* fs.readFileString(cachedRule)).replace('alwaysApply: true', ''));
+        const invalid = yield* doctor();
+        expect(invalid).toMatchObject([{name: 'Cursor plugin', status: 'fail'}]);
+        expect(invalid[0]?.detail).toContain('Cursor Marketplace');
       }),
     ).pipe(Effect.provide(ApplicationLayer)),
   );
 });
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/test/unit/lifecycle.instructions.test.ts
+++ b/test/unit/lifecycle.instructions.test.ts
@@ -62,6 +62,30 @@ describe('agent instruction lifecycle', () => {
             rerank: () => Effect.die(new Error('Unexpected reranking')),
           });
           const commandShim = path.join(userHome, '.local', 'bin', 'threadnote');
+          const legacyCursorRule = path.join(userHome, '.cursor', 'rules', 'threadnote.md');
+          const legacyCursorMdcRule = path.join(userHome, '.cursor', 'rules', 'threadnote.mdc');
+          yield* fs.makeDirectory(path.dirname(legacyCursorRule), {recursive: true});
+          yield* fs.writeFileString(
+            legacyCursorRule,
+            [
+              'Preserve this user-authored note.',
+              '',
+              '<!-- BEGIN THREADNOTE USER INSTRUCTIONS -->',
+              'Stale Threadnote instructions.',
+              '<!-- END THREADNOTE USER INSTRUCTIONS -->',
+            ].join('\n'),
+          );
+          yield* fs.writeFileString(
+            legacyCursorMdcRule,
+            [
+              '---',
+              'alwaysApply: true',
+              '---',
+              '<!-- BEGIN THREADNOTE USER INSTRUCTIONS -->',
+              'Stale Threadnote instructions.',
+              '<!-- END THREADNOTE USER INSTRUCTIONS -->',
+            ].join('\n'),
+          );
           if (system.platform !== 'win32') {
             yield* fs.makeDirectory(path.dirname(commandShim), {recursive: true});
             yield* fs.writeFileString(
@@ -109,12 +133,12 @@ describe('agent instruction lifecycle', () => {
           const generatedInstructions = yield* Effect.all([
             fs.readFileString(path.join(userHome, '.codex', 'AGENTS.md')),
             fs.readFileString(path.join(userHome, '.claude', 'CLAUDE.md')),
-            fs.readFileString(path.join(userHome, '.cursor', 'rules', 'threadnote.md')),
             fs.readFileString(path.join(userHome, '.copilot', 'instructions', 'threadnote.instructions.md')),
           ]);
           expect(generatedInstructions[1]).toContain('<!-- BEGIN THREADNOTE USER INSTRUCTIONS -->');
-          expect(generatedInstructions[2]).toContain('threadnote://');
-          expect(generatedInstructions[3]).toContain('applyTo: "**"');
+          expect(generatedInstructions[2]).toContain('applyTo: "**"');
+          expect(yield* fs.readFileString(legacyCursorRule)).toBe('Preserve this user-authored note.\n');
+          expect(yield* fs.exists(legacyCursorMdcRule)).toBe(false);
           expect(generatedInstructions.every(content => content.includes('`query` finds definitions'))).toBe(true);
           expect(generatedInstructions.every(content => content.includes('Git `base`'))).toBe(true);
           expect(
@@ -124,7 +148,7 @@ describe('agent instruction lifecycle', () => {
           ).toBe(true);
 
           const checks = yield* userAgentInstructionsChecks().pipe(Effect.provideService(SystemInfo, testSystem));
-          expect(checks).toHaveLength(4);
+          expect(checks).toHaveLength(3);
           expect(checks.every(check => check.status === 'ok')).toBe(true);
 
           if (system.platform !== 'win32') {

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -193,8 +193,6 @@ describe('standalone updater', () => {
           const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-local-update-test-'});
           const installRoot = path.join(temporaryRoot, 'install');
           const binRoot = path.join(temporaryRoot, 'bin');
-          const userHome = path.join(temporaryRoot, 'user-home');
-          yield* fs.makeDirectory(cursorApplicationDataPath(path, userHome, baseSystem.platform), {recursive: true});
           const oldReleaseRoot = path.join(installRoot, 'versions', activeVersion);
           yield* fs.makeDirectory(oldReleaseRoot, {recursive: true});
           yield* fs.writeFileString(
@@ -213,13 +211,9 @@ describe('standalone updater', () => {
             ...baseSystem,
             environment: () => ({
               ...baseSystem.environment(),
-              HOME: userHome,
               THREADNOTE_BIN_DIR: binRoot,
               THREADNOTE_INSTALL_ROOT: installRoot,
-              USERPROFILE: userHome,
-              XDG_CONFIG_HOME: path.join(userHome, '.config'),
             }),
-            homeDirectory: userHome,
           });
           yield* activateStandaloneRelease(oldReleaseRoot, false).pipe(Effect.provideService(SystemInfo, testSystem));
 
@@ -238,9 +232,6 @@ describe('standalone updater', () => {
               version: string;
             },
             captured,
-            cursorRule: yield* fs.readFileString(
-              path.join(userHome, '.cursor', 'plugins', 'local', 'threadnote', 'rules', 'threadnote.mdc'),
-            ),
             launcher: yield* fs.readFileString(launcher),
           };
         }),
@@ -249,10 +240,7 @@ describe('standalone updater', () => {
 
     expect(result.captured.output).toContain(`Current version: ${activeVersion}`);
     expect(result.captured.output).toContain(`Installed standalone Threadnote ${latestVersion}`);
-    expect(result.captured.output).toContain('Installed Cursor plugin:');
     expect(result.active.version).toBe(latestVersion);
-    expect(result.cursorRule).toContain('alwaysApply: true');
-    expect(result.cursorRule).toContain('<!-- BEGIN THREADNOTE USER INSTRUCTIONS -->');
     expect(result.launcher).toContain(latestVersion);
   });
 
@@ -268,7 +256,6 @@ describe('standalone updater', () => {
           const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-launcher-repair-test-'});
           const installRoot = path.join(temporaryRoot, 'install');
           const binRoot = path.join(temporaryRoot, 'bin');
-          const userHome = path.join(temporaryRoot, 'user-home');
           const releaseRoot = path.join(installRoot, 'versions', latestVersion);
           yield* fs.makeDirectory(releaseRoot, {recursive: true});
           yield* fs.writeFileString(
@@ -279,12 +266,9 @@ describe('standalone updater', () => {
             ...baseSystem,
             environment: () => ({
               ...baseSystem.environment(),
-              HOME: userHome,
               THREADNOTE_BIN_DIR: binRoot,
               THREADNOTE_INSTALL_ROOT: installRoot,
-              USERPROFILE: userHome,
             }),
-            homeDirectory: userHome,
           });
           yield* activateStandaloneRelease(releaseRoot, false).pipe(Effect.provideService(SystemInfo, testSystem));
           const launcher = path.join(binRoot, baseSystem.platform === 'win32' ? 'threadnote.cmd' : 'threadnote');
@@ -1283,7 +1267,6 @@ function writeReleaseArchive(
         ),
       );
       const cursorPluginPaths = [
-        '.threadnote-managed.json',
         '.cursor-plugin/plugin.json',
         'rules/threadnote.mdc',
         'README.md',
@@ -1350,10 +1333,4 @@ async function codeGraphFixtureAsset(
 
 function pathSeparator(): string {
   return process.platform === 'win32' ? '\\' : '/';
-}
-
-function cursorApplicationDataPath(path: Path.Path, home: string, platform: NodeJS.Platform): string {
-  if (platform === 'darwin') return path.join(home, 'Library', 'Application Support', 'Cursor');
-  if (platform === 'win32') return path.join(home, 'AppData', 'Roaming', 'Cursor');
-  return path.join(home, '.config', 'Cursor');
 }

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -193,6 +193,8 @@ describe('standalone updater', () => {
           const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-local-update-test-'});
           const installRoot = path.join(temporaryRoot, 'install');
           const binRoot = path.join(temporaryRoot, 'bin');
+          const userHome = path.join(temporaryRoot, 'user-home');
+          yield* fs.makeDirectory(cursorApplicationDataPath(path, userHome, baseSystem.platform), {recursive: true});
           const oldReleaseRoot = path.join(installRoot, 'versions', activeVersion);
           yield* fs.makeDirectory(oldReleaseRoot, {recursive: true});
           yield* fs.writeFileString(
@@ -211,9 +213,13 @@ describe('standalone updater', () => {
             ...baseSystem,
             environment: () => ({
               ...baseSystem.environment(),
+              HOME: userHome,
               THREADNOTE_BIN_DIR: binRoot,
               THREADNOTE_INSTALL_ROOT: installRoot,
+              USERPROFILE: userHome,
+              XDG_CONFIG_HOME: path.join(userHome, '.config'),
             }),
+            homeDirectory: userHome,
           });
           yield* activateStandaloneRelease(oldReleaseRoot, false).pipe(Effect.provideService(SystemInfo, testSystem));
 
@@ -232,6 +238,9 @@ describe('standalone updater', () => {
               version: string;
             },
             captured,
+            cursorRule: yield* fs.readFileString(
+              path.join(userHome, '.cursor', 'plugins', 'local', 'threadnote', 'rules', 'threadnote.mdc'),
+            ),
             launcher: yield* fs.readFileString(launcher),
           };
         }),
@@ -240,7 +249,10 @@ describe('standalone updater', () => {
 
     expect(result.captured.output).toContain(`Current version: ${activeVersion}`);
     expect(result.captured.output).toContain(`Installed standalone Threadnote ${latestVersion}`);
+    expect(result.captured.output).toContain('Installed Cursor plugin:');
     expect(result.active.version).toBe(latestVersion);
+    expect(result.cursorRule).toContain('alwaysApply: true');
+    expect(result.cursorRule).toContain('<!-- BEGIN THREADNOTE USER INSTRUCTIONS -->');
     expect(result.launcher).toContain(latestVersion);
   });
 
@@ -256,6 +268,7 @@ describe('standalone updater', () => {
           const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-launcher-repair-test-'});
           const installRoot = path.join(temporaryRoot, 'install');
           const binRoot = path.join(temporaryRoot, 'bin');
+          const userHome = path.join(temporaryRoot, 'user-home');
           const releaseRoot = path.join(installRoot, 'versions', latestVersion);
           yield* fs.makeDirectory(releaseRoot, {recursive: true});
           yield* fs.writeFileString(
@@ -266,9 +279,12 @@ describe('standalone updater', () => {
             ...baseSystem,
             environment: () => ({
               ...baseSystem.environment(),
+              HOME: userHome,
               THREADNOTE_BIN_DIR: binRoot,
               THREADNOTE_INSTALL_ROOT: installRoot,
+              USERPROFILE: userHome,
             }),
+            homeDirectory: userHome,
           });
           yield* activateStandaloneRelease(releaseRoot, false).pipe(Effect.provideService(SystemInfo, testSystem));
           const launcher = path.join(binRoot, baseSystem.platform === 'win32' ? 'threadnote.cmd' : 'threadnote');
@@ -1266,6 +1282,22 @@ function writeReleaseArchive(
           ]),
         ),
       );
+      const cursorPluginPaths = [
+        '.threadnote-managed.json',
+        '.cursor-plugin/plugin.json',
+        'rules/threadnote.mdc',
+        'README.md',
+        'CHANGELOG.md',
+        'LICENSE',
+      ];
+      const cursorPluginAssets = Object.fromEntries(
+        await Promise.all(
+          cursorPluginPaths.map(async asset => [
+            `cursor-plugin/${asset}`,
+            await Bun.file(`cursor-plugin/${asset}`).bytes(),
+          ]),
+        ),
+      );
       if (options.tamperCodeGraphAsset) {
         assets['assets/code-graph/grammars/java.wasm'] = new TextEncoder().encode('tampered grammar');
       }
@@ -1273,6 +1305,7 @@ function writeReleaseArchive(
         archivePath,
         {
           ...assets,
+          ...cursorPluginAssets,
           [executableName]: '#!/usr/bin/env sh\nexit 0\n',
           'release.json': `${JSON.stringify({
             codeGraphAssets: {
@@ -1317,4 +1350,10 @@ async function codeGraphFixtureAsset(
 
 function pathSeparator(): string {
   return process.platform === 'win32' ? '\\' : '/';
+}
+
+function cursorApplicationDataPath(path: Path.Path, home: string, platform: NodeJS.Platform): string {
+  if (platform === 'darwin') return path.join(home, 'Library', 'Application Support', 'Cursor');
+  if (platform === 'win32') return path.join(home, 'AppData', 'Roaming', 'Cursor');
+  return path.join(home, '.config', 'Cursor');
 }

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../src/utils.js', async importOriginal => {
 
 import {
   fetchLatestVersion,
+  maybeNotifyUpdate,
   maybeRunPostUpdateAfterRepair,
   parseReleaseChecksum,
   promoteReleaseDirectory,
@@ -176,6 +177,105 @@ describe('standalone release selection', () => {
     expect(codesignCommands.join('\n')).toContain('threadnote');
     expect(codesignCommands.join('\n')).not.toContain('metadata.txt');
     expect(commands.join('\n')).not.toContain('spctl');
+  });
+});
+
+describe('update notifications', () => {
+  it('revalidates a cached update before announcing a withdrawn release', async () => {
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseSystem = yield* SystemInfo;
+          const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-update-notification-'});
+          const config = runtimeConfig(path.join(temporaryRoot, 'home'));
+          yield* writeUpdateCacheFixture(fs, path, config, '4.0.1');
+          let requests = 0;
+          const http = HttpService.of({
+            downloadToFile: () => Effect.die('not used'),
+            getJson: () =>
+              Effect.sync(() => {
+                requests += 1;
+                return {body: [releaseResponse(RELEASE_VERSION, false)], status: 200};
+              }),
+            getStatus: () => Effect.die('not used'),
+            getText: () => Effect.die('not used'),
+          });
+          const system = SystemInfo.of({...baseSystem, environment: () => ({})});
+          const captured = yield* captureConsole(
+            maybeNotifyUpdate(config, {dryRun: true}).pipe(
+              Effect.provideService(HttpService, http),
+              Effect.provideService(SystemInfo, system),
+            ),
+          );
+          return {output: captured.output, requests};
+        }),
+      ).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    expect(result).toEqual({output: '', requests: 1});
+  });
+
+  it('announces a cached update only after confirming that it is still published', async () => {
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseSystem = yield* SystemInfo;
+          const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-update-notification-'});
+          const config = runtimeConfig(path.join(temporaryRoot, 'home'));
+          yield* writeUpdateCacheFixture(fs, path, config, '4.0.1');
+          let requests = 0;
+          const http = HttpService.of({
+            downloadToFile: () => Effect.die('not used'),
+            getJson: () =>
+              Effect.sync(() => {
+                requests += 1;
+                return {body: [releaseResponse('4.0.1', false)], status: 200};
+              }),
+            getStatus: () => Effect.die('not used'),
+            getText: () => Effect.die('not used'),
+          });
+          const system = SystemInfo.of({...baseSystem, environment: () => ({})});
+          const captured = yield* captureConsole(
+            maybeNotifyUpdate(config, {dryRun: true}).pipe(
+              Effect.provideService(HttpService, http),
+              Effect.provideService(SystemInfo, system),
+            ),
+          );
+          return {output: captured.output, requests};
+        }),
+      ).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    expect(result.requests).toBe(1);
+    expect(result.output).toContain('Update available: threadnote 4.0.0 -> 4.0.1');
+  });
+
+  it('does not check or announce updates for an exact local development build', async () => {
+    vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(`4.0.0-local.g${'a'.repeat(40)}`));
+    let requests = 0;
+    const http = HttpService.of({
+      downloadToFile: () => Effect.die('not used'),
+      getJson: () =>
+        Effect.sync(() => {
+          requests += 1;
+          return {body: [releaseResponse('4.0.1', false)], status: 200};
+        }),
+      getStatus: () => Effect.die('not used'),
+      getText: () => Effect.die('not used'),
+    });
+    const captured = await Effect.runPromise(
+      captureConsole(maybeNotifyUpdate(runtimeConfig('/tmp/threadnote-local-update-notification'))).pipe(
+        Effect.provideService(HttpService, http),
+        Effect.provide(ApplicationLayer),
+      ),
+    );
+
+    expect(captured.output).toBe('');
+    expect(requests).toBe(0);
   });
 });
 
@@ -1171,6 +1271,27 @@ function runtimeConfig(home: string): RuntimeConfig {
     manifestPath: `${home}/seed-manifest.yaml`,
     user: 'update-test',
   };
+}
+
+function writeUpdateCacheFixture(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  config: RuntimeConfig,
+  latestVersion: string,
+) {
+  return fs.makeDirectory(config.agentContextHome, {recursive: true}).pipe(
+    Effect.andThen(
+      fs.writeFileString(
+        path.join(config.agentContextHome, 'update-check.json'),
+        `${JSON.stringify({
+          channel: 'latest',
+          checkedAt: new Date().toISOString(),
+          latestVersion,
+          source: OFFICIAL_RELEASE_SOURCE,
+        })}\n`,
+      ),
+    ),
+  );
 }
 
 function fixtureMigration(

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -1253,14 +1253,24 @@ describe('Threadnote 4 website content', () => {
     );
   });
 
-  it('documents the explicit publishing and supported hook boundaries', () => {
+  it('documents explicit publishing, Cursor Marketplace, and supported hook boundaries', () => {
     const content = JSON.stringify(docsSections);
+    const cursorPluginArticle = docsSections
+      .flatMap(section => section.articles)
+      .find(article => article.id === 'cursor-marketplace-plugin');
 
     expect(content).toContain('threadnote install-hooks claude --dry-run');
     expect(content).not.toContain('threadnote install-hooks codex --dry-run');
     expect(content).toContain('threadnote share publish');
     expect(content).toContain('--preview');
     expect(content).toContain('selected vector generation');
+    expect(cursorPluginArticle).toBeDefined();
+    expect(JSON.stringify(cursorPluginArticle)).toContain('threadnote mcp-install cursor --apply');
+    expect(JSON.stringify(cursorPluginArticle)).toContain('/add-plugin threadnote');
+    expect(JSON.stringify(cursorPluginArticle)).toContain('https://cursor.com/marketplace/publish');
+    expect(JSON.stringify(cursorPluginArticle)).toContain('never deletes it automatically');
+    expect(content).toContain('Threadnote never injects a Cursor plugin under ~/.cursor/plugins/local');
+    expect(content).not.toContain('Cursor, and Copilot rely on the user-level instructions Threadnote installs');
   });
 
   it('uses the real Manager labels and share status fields in the mock data', () => {

--- a/test/unit/website-release-boundary.test.ts
+++ b/test/unit/website-release-boundary.test.ts
@@ -12,7 +12,9 @@ describe('website and standalone release boundary', () => {
   it('keeps documentation and website trees out of the standalone build', async () => {
     const buildSource = await readFile(join(root, 'scripts', 'build.ts'), 'utf8');
 
-    expect(buildSource).toContain("const RELEASE_DIRECTORIES = ['assets', 'config', 'manager'] as const;");
+    expect(buildSource).toContain(
+      "const RELEASE_DIRECTORIES = ['assets', 'config', 'cursor-plugin', 'manager'] as const;",
+    );
     expect(buildSource).toContain(
       "const FORBIDDEN_RELEASE_DIRECTORIES = ['docs', 'training', 'website', 'site-dist'] as const;",
     );

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -220,7 +220,8 @@ export const cliCommands: CliCommandReference[] = [
   },
   {
     command: 'update',
-    summary: 'Install a verified standalone release and repair local integrations while preserving owned data.',
+    summary:
+      'Install a verified standalone release and repair Threadnote-owned integrations while preserving owned data; Cursor Marketplace state remains Cursor-owned.',
     examples: ['threadnote update', 'threadnote update --beta', 'threadnote update --stable'],
   },
   {
@@ -463,7 +464,7 @@ threadnote doctor`,
           },
           {
             type: 'paragraph',
-            text: 'The bootstrap installer downloads an immutable GitHub release, verifies SHA-256, atomically promotes it, and invokes threadnote install. That lifecycle initializes ~/.threadnote, downloads and selects the core BGE Small embedding model, builds recall indexes, and writes user-level instructions. Existing verified models and canonical data are preserved during updates.',
+            text: "The bootstrap installer downloads an immutable GitHub release, verifies SHA-256, atomically promotes it, and invokes threadnote install. That lifecycle initializes ~/.threadnote, downloads and selects the core BGE Small embedding model, builds recall indexes, and writes supported user-level instructions for Codex, Claude Code, and Copilot. Cursor instructions are installed separately through Cursor's Marketplace. Existing verified models and canonical data are preserved during updates.",
           },
           {
             type: 'note',
@@ -526,7 +527,7 @@ threadnote doctor`,
         body: [
           {
             type: 'paragraph',
-            text: 'Install writes a bounded Threadnote instruction block into the supported user-level agent instruction file. Checked-in AGENTS.md, CLAUDE.md, and equivalent repository guidance remain authoritative and take precedence.',
+            text: 'Install writes a bounded Threadnote instruction block into supported user-level agent instruction files for Codex, Claude Code, and Copilot. Cursor receives the same instruction block through its separate Marketplace plugin; Threadnote does not write a supposed user rule under ~/.cursor/rules. Checked-in AGENTS.md, CLAUDE.md, and equivalent repository guidance remain authoritative and take precedence.',
           },
           {
             type: 'list',
@@ -549,7 +550,81 @@ threadnote install --with-hooks`,
           },
           {
             type: 'paragraph',
-            text: 'Managed SessionStart and PreCompact lifecycle hooks are currently available for Claude Code only. Codex, Cursor, and Copilot rely on the user-level instructions Threadnote installs because those clients do not expose equivalent managed hooks. Hooks do not replace agent judgment or start a Threadnote daemon.',
+            text: 'Managed SessionStart and PreCompact lifecycle hooks are currently available for Claude Code only. Codex and Copilot rely on their supported user-level instruction files; Cursor relies on the separately installed Marketplace plugin. Threadnote never injects a Cursor plugin under ~/.cursor/plugins/local. Hooks do not replace agent judgment or start a Threadnote daemon.',
+          },
+        ],
+      },
+      {
+        id: 'cursor-marketplace-plugin',
+        title: 'Cursor Marketplace plugin',
+        summary: "Install and verify Threadnote's always-applied Cursor rule without local-plugin injection.",
+        keywords: [
+          'Cursor plugin',
+          'Cursor Marketplace',
+          'team marketplace',
+          'enterprise Cursor',
+          'always-applied MDC rule',
+          'publish Cursor plugin',
+        ],
+        body: [
+          {
+            type: 'paragraph',
+            text: 'Cursor needs two independent pieces: the user-specific local MCP server configuration and the Threadnote Marketplace plugin containing the always-applied `.mdc` rule. The plugin intentionally has no `mcp.json`, so it cannot duplicate or replace the configuration owned by the Threadnote CLI.',
+          },
+          {
+            type: 'heading',
+            text: 'Install and verify',
+          },
+          {
+            type: 'code',
+            language: 'sh',
+            code: 'threadnote mcp-install cursor --apply',
+          },
+          {
+            type: 'list',
+            items: [
+              "After the public listing is approved, find **Threadnote** in Cursor's Marketplace or run `/add-plugin threadnote` in a Cursor agent chat.",
+              'On Teams or Enterprise, ask an administrator to allow the public plugin or add the Threadnote repository to a team marketplace. The administrator can make installation opt-in, default-on, or required.',
+              'Reload Cursor or open a new window, start a fresh agent chat, and confirm the Threadnote rule is active.',
+            ],
+          },
+          {
+            type: 'code',
+            language: 'sh',
+            code: 'threadnote doctor',
+          },
+          {
+            type: 'note',
+            text: 'The plugin check appears only when Threadnote detects Cursor and is read-only. Install, update, repair, and uninstall never create, refresh, or remove either `~/.cursor/plugins/local` or Cursor-managed Marketplace state.',
+          },
+          {
+            type: 'warning',
+            text: 'If doctor reports `~/.cursor/plugins/local/threadnote`, fully quit Cursor and move only that legacy local copy aside before installing through the Marketplace. The withdrawn local injection coincided with a managed Cursor installation losing access to every model; an administrator restriction is plausible but is not a proven root cause. Threadnote reports the condition and never deletes it automatically.',
+          },
+          {
+            type: 'heading',
+            text: 'Publisher checklist',
+          },
+          {
+            type: 'list',
+            items: [
+              'Keep `.cursor-plugin/marketplace.json`, `cursor-plugin/.cursor-plugin/plugin.json`, the `.mdc` rule, README, changelog, logo reference, and MIT license together on the public default branch.',
+              "Test that exact default-branch source through an administrator-controlled team marketplace. Do not copy it into Cursor's local-plugin directory.",
+              "Have an authorized publisher submit the public repository at [Cursor's publishing form](https://cursor.com/marketplace/publish) and review the [Marketplace Publisher Terms](https://cursor.com/marketplace-publisher-terms).",
+              'After approval, verify public discovery, `/add-plugin threadnote`, a fresh agent chat, and `threadnote doctor` on both unmanaged and administrator-managed Cursor accounts.',
+              'For updates, increment the plugin manifest version, add a matching changelog entry, merge the source, and request a re-index through Cursor. A Threadnote release does not publish the plugin.',
+            ],
+          },
+          {
+            type: 'code',
+            language: 'sh',
+            code: `bun run cursor-plugin:check
+bun run build
+bun run check:self-contained`,
+          },
+          {
+            type: 'note',
+            text: 'Cursor requires Marketplace plugins to use a permissive open-source license. The distributable plugin paths are MIT-licensed; the Threadnote runtime and the rest of the repository remain AGPL-3.0-or-later.',
           },
         ],
       },
@@ -1527,11 +1602,11 @@ threadnote repair`,
           },
           {
             type: 'paragraph',
-            text: 'Doctor checks the self-contained home, canonical layout, core model, recall indexes, code-graph integrity, configured MCP clients, and agent instructions. Strict mode exits non-zero when a check fails.',
+            text: 'Doctor checks the self-contained home, canonical layout, core model, recall indexes, code-graph integrity, configured MCP clients, and agent instructions. When Cursor is installed, it also performs a read-only check of the Marketplace plugin and rejects the legacy local injection path. Strict mode exits non-zero when a check fails.',
           },
           {
             type: 'paragraph',
-            text: 'Repair can reassert storage layout, provision the core embedding model, rebuild derived lexical/vector state, clean corrupt or abandoned code-graph databases, and repair hooks or MCP configuration. It does not modify repositories or delete canonical memories.',
+            text: 'Repair can reassert storage layout, provision the core embedding model, rebuild derived lexical/vector state, clean corrupt or abandoned code-graph databases, and repair hooks or MCP configuration. It does not install, update, remove, or repair Cursor plugins; Marketplace state remains Cursor-owned. It also does not modify repositories or delete canonical memories.',
           },
           {
             type: 'note',
@@ -1586,7 +1661,7 @@ threadnote update --check`,
           },
           {
             type: 'paragraph',
-            text: 'After opting into beta, ordinary version and update checks remain on the beta channel. Use --stable to return to stable even when that version is numerically lower. Updates verify immutable release assets, promote atomically, preserve ~/.threadnote data and verified model files, then repair integrations.',
+            text: "After opting into beta, ordinary version and update checks remain on the beta channel. Use --stable to return to stable even when that version is numerically lower. Updates verify immutable release assets, promote atomically, preserve ~/.threadnote data and verified model files, then repair Threadnote-owned integrations. Cursor Marketplace plugin updates remain owned by Cursor and the organization's policy.",
           },
           {
             type: 'paragraph',


### PR DESCRIPTION
## What

- Package Threadnote's Cursor rule as a Marketplace plugin with valid `.mdc` rule anatomy, manifests, changelog, license boundary, and release validation.
- Remove lifecycle ownership of `~/.cursor/plugins/local/threadnote`; doctor checks the legacy path only when Cursor is installed and gives read-only remediation.
- Document public and team Marketplace installation, enterprise policy choices, validation, publication, and re-indexing in repository and website docs.
- Add root `AGENTS.md` guidance that makes Threadnote dogfood itself, requires exact-HEAD global installs after product-logic changes, and keeps one durable dogfood issue ledger.
- Revalidate cached positive update notices so withdrawn releases are not advertised, while suppressing automatic update notices for exact local development builds.

## Why

The locally injected Cursor plugin could interfere with model access in a managed enterprise Cursor environment. An admin-policy interaction is plausible, but it is not confirmed as the root cause. Marketplace distribution gives Cursor and workspace administrators ownership of installation and policy enforcement, while Threadnote retains ownership only of its MCP configuration.

Cursor requires Marketplace rule files to use `.mdc` and the documented rule frontmatter/anatomy; a user-level `~/.cursor/rules/*.md` injection is not a supported equivalent.

## Impact and boundaries

- Threadnote install, update, and repair no longer write or delete Cursor plugin state.
- Existing legacy local plugin directories are reported but deliberately left untouched.
- The Marketplace wrapper is MIT-licensed; it invokes the separately installed AGPL Threadnote runtime over MCP.
- No package or release version is bumped by this PR. Marketplace publication remains a separate maintainer action after merge.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`: 187 files, 1,784 tests
- `bun run cursor-plugin:check`
- `bun run site:check`: 48 tests
- `THREADNOTE_SITE_BASE=/threadnote/ bun run site:build`
- Cursor JSON schemas validated against the official schema endpoints
- exact clean HEAD installed globally as `4.0.3-local.g65c6226923ce14051fc64476a82aa474b97aa964`
- `threadnote version`, `threadnote doctor --dry-run`, and `threadnote repair --no-post-update` exercised against the real local installation; the withdrawn 4.0.4 notice is no longer emitted
