### PR TITLE
Administer native graphs and prepare Threadnote 4.0.5

### DIFF
--- a/.github/release-notes/v4.0.5.md
+++ b/.github/release-notes/v4.0.5.md
@@ -1,0 +1,20 @@
+## What's new
+
+Threadnote 4.0.5 makes native code graph maintenance observable and directly controllable while tightening local
+runtime and editor integration safety.
+
+- **Administer every local graph from one place.** Run `threadnote graph diagnostics`,
+  `threadnote graph repair --all`, or `threadnote graph purge --obsolete` without depending on the current directory.
+  The Manager now exposes matching status, diagnostics, repair, index, reindex, compact, and purge actions for each
+  graph and for safe all-graph operations.
+- **Start repairs immediately and avoid maintenance deadlocks.** Foreground repair no longer waits for a later query,
+  and `threadnote manage` fails fast with a clear message while graph repair or another maintenance operation owns the
+  graph lock.
+- **Trust graph health output.** Diagnostics now report persisted nodes, edges, and topology statistics from the
+  measured snapshot, identify disposable rebuilds and obsolete stores precisely, and keep doctor and repair guidance
+  consistent.
+- **Keep Cursor marketplace ownership intact.** Threadnote install, update, repair, and uninstall no longer write or
+  remove Cursor plugin files; doctor reports whether the independently distributed plugin is present.
+- **Prevent silent development-runtime takeovers.** Exact-HEAD global installs record an opaque checkout identity and
+  require `--take-over-global-runtime` before another worktree can replace the active development build. Process
+  diagnostics also keep the `OPERATION` column aligned across variable-width rows.

--- a/.threadnoteignore
+++ b/.threadnoteignore
@@ -1,5 +1,6 @@
 .git/
 node_modules/
+graphify-out/
 .claude/worktrees/
 .worktrees/
 bazel-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ scripts, installer/updater behavior, MCP behavior, storage, indexing, plugin lif
 4. Exercise the affected flow through the globally installed `threadnote` command and record the smoke result in the
    task handoff.
 
+The development installer records an opaque checkout identity and refuses to replace a global development runtime
+owned by another worktree. Do not bypass that guard while its task is active. After confirming the other task has
+finished, an intentional handoff can use `bun run dev:install-global -- --take-over-global-runtime`.
+
 Documentation-only and test-only changes do not require a global binary reinstall unless they alter a packaged runtime
 contract or expose a suspected runtime problem.
 

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -133,6 +133,11 @@ beta a launcher or editor process happened to start earlier. The exported fail-c
 `verifyManagedDevelopmentRuntimeForSource` verifier is the preflight for long benchmark harnesses; it returns the
 sanitized version, source commit, executable digest, target, and runtime evidence without recording local paths.
 
+The installer also records an opaque SHA-256 identity for the source checkout that owns the active global development
+runtime. A different worktree must not silently replace it. After confirming its task has finished, transfer ownership
+explicitly with `bun run dev:install-global -- --take-over-global-runtime`; the stored record never contains the local
+checkout path.
+
 ## Changing MCP tools
 
 Keep tool names and the default core toolset compact and backward-compatible. When adding or changing an input:

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ represented as assets rather than guessed. A corpus artifact over 64 MiB remains
 instead of being rejected or semantically decompressed. Selected OpenXML, OpenDocument, and EPUB text entries have
 bounded expansion. These are per-artifact extraction safety budgets, not repository or graph-size caps.
 
-Hidden directories and conventional generated roots such as `node_modules`, `dist`, `build`, `out`, `.nx`, and
-`bazel-*` are pruned before content is read, including when a broad package root contains them. Large unknown JSON,
+Hidden directories and conventional generated roots such as `node_modules`, `dist`, `build`, `out`, `.nx`,
+`graphify-out`, and `bazel-*` are pruned before content is read, including when a broad package root contains them. Large unknown JSON,
 JSONC, and YAML files keep only bounded structure, while recognized snapshots, golden files, fixtures, datasets, and
 animation payloads are fingerprinted with a streaming read and represented by their file/module metadata only. Package
 manifests, schemas, and configuration files keep their dedicated extraction paths.
@@ -228,6 +228,15 @@ or `--json` for the versioned diagnostic document. `graph repair --all` immediat
 migrations instead of waiting for a later graph query. Its default quick pass avoids scanning every page of a large
 database; use `--deep` only when a full integrity check and destructive recovery are intended, and preview either mode
 with `--dry-run`.
+
+The local Manager exposes the same graph administration lifecycle from its Graph panel: home-wide quick or deep
+diagnostics, immediate repair, per-view status, index/reindex, compaction previews, obsolete-store pruning, and
+per-graph or all-graph purge. Destructive actions require an explicit browser confirmation. When an older indexed
+view has no live worktree association, Manager asks for a local path and verifies its checkout/worktree identity before
+acting.
+
+`threadnote manage` fails fast when graph repair or another native graph maintenance operation is already active;
+an already-running Manager returns an explicit busy response for graph requests until maintenance finishes.
 
 Maven, Gradle, Kotlin Multiplatform/Android conventions, SwiftPM, conservative Xcode metadata, and nested or integrated
 Bazel workspaces form a static workspace model; repository build scripts are never executed. Bazel `WORKSPACE`,

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ threadnote graph surprises
 threadnote graph report --output architecture-report.md
 threadnote graph export --format graphml --output code-graph.graphml
 threadnote graph index --full
+threadnote graph diagnostics --analyze
+threadnote graph repair --all --dry-run
 threadnote graph compact --dry-run
 ```
 
@@ -218,6 +220,14 @@ When both 512 MiB and 20% of the database are reclaimable it recommends explicit
 zero-wait maintenance and checkout locks, verifies the active snapshot before and after SQLite's transactional
 `VACUUM`, and defers safely during a build. Preview it with `--dry-run`; `--force` is available below the reviewed
 threshold.
+
+`graph diagnostics` is home-wide and does not resolve a repository from the current directory. It reports every local
+graph database, ready snapshot, indexed view, active build, waiter, storage total, health issue, and obsolete store;
+add `--analyze` for bounded structural statistics per ready indexed view, `--deep` for full SQLite integrity checks,
+or `--json` for the versioned diagnostic document. `graph repair --all` immediately runs pending persistent-schema
+migrations instead of waiting for a later graph query. Its default quick pass avoids scanning every page of a large
+database; use `--deep` only when a full integrity check and destructive recovery are intended, and preview either mode
+with `--dry-run`.
 
 Maven, Gradle, Kotlin Multiplatform/Android conventions, SwiftPM, conservative Xcode metadata, and nested or integrated
 Bazel workspaces form a static workspace model; repository build scripts are never executed. Bazel `WORKSPACE`,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -179,10 +179,21 @@ rebuilt from canonical Markdown after corruption. Vector values are content-addr
 value already written. A changed active mapping is committed in one SQLite transaction only after every required
 vector is present; an interrupted embedding run leaves the previous mapping available.
 
-Repair and doctor also run a full SQLite integrity check over each derived native code graph. Large monorepo graphs can
-take time to scan; both commands print the current graph database and cleanup phase while they work. If a graph is
-reported as corrupt, run `threadnote repair`; repair discards unreadable derived graph databases, and the next graph
-query rebuilds them.
+`threadnote repair --deep` runs a full SQLite integrity check over each derived native code graph. Large monorepo
+graphs can take time to scan, and a pause at one database means SQLite is still reading that database's pages. Use the
+home-wide graph commands when the issue is isolated to native code graphs:
+
+```sh
+threadnote graph diagnostics --analyze --json
+threadnote graph repair --all --dry-run
+threadnote graph repair --all
+```
+
+`graph diagnostics` does not depend on the current directory. Its default health pass is quick; add `--deep` only when
+you need full SQLite integrity and foreign-key checks. `graph repair --all` immediately applies pending persistent
+schema migrations instead of waiting for a later graph query, while also keeping its default pass quick. Add `--deep`
+to discard an unreadable or corrupt derived graph database after the full check; its source repository and Threadnote
+memories are untouched, and the next graph query rebuilds the disposable graph.
 
 ```sh
 threadnote index verify

--- a/manager/app.css
+++ b/manager/app.css
@@ -934,6 +934,184 @@ dd {
   display: none;
 }
 
+.graph-administration {
+  background: rgba(16, 21, 29, 0.92);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+}
+
+.graph-administration > summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 14px;
+  justify-content: space-between;
+  list-style-position: inside;
+  padding: 9px 12px;
+}
+
+.graph-administration > summary > span {
+  display: inline-grid;
+  gap: 2px;
+}
+
+.graph-administration > summary small,
+.graph-administration > summary em,
+.graph-management-unavailable {
+  color: var(--muted);
+  font-size: 10px;
+  font-style: normal;
+}
+
+.graph-administration-body {
+  border-top: 1px solid var(--line);
+  display: grid;
+  gap: 10px;
+  max-height: min(460px, 56vh);
+  overflow: auto;
+  padding: 10px 12px 12px;
+}
+
+.graph-administration-toolbar,
+.graph-database-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.graph-administration-toolbar button,
+.graph-database-actions button {
+  font-size: 10px;
+  min-height: 30px;
+  padding: 5px 9px;
+}
+
+.graph-force-compact {
+  justify-self: start;
+}
+
+.graph-database-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.graph-database-card {
+  background: rgba(8, 11, 16, 0.58);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px;
+}
+
+.graph-database-card > header {
+  align-items: start;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.graph-database-card > header > span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.graph-database-card > header strong,
+.graph-database-card > header small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-database-card > header em {
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-size: 9px;
+  font-style: normal;
+  padding: 3px 7px;
+  text-transform: uppercase;
+}
+
+.graph-database-card > header em.is-corrupt,
+.graph-database-card > header em.is-incompatible,
+.graph-database-card > header em.is-unreadable {
+  border-color: rgba(255, 98, 120, 0.35);
+  color: var(--danger);
+}
+
+.graph-database-card dl {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+}
+
+.graph-database-card dl > div {
+  display: grid;
+  gap: 2px;
+}
+
+.graph-database-card dt {
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.graph-database-card dd {
+  font-size: 11px;
+  margin: 0;
+}
+
+.graph-database-issue {
+  color: #f7d56b;
+  font-size: 10px;
+  margin: 0;
+}
+
+.graph-database-views {
+  display: grid;
+  gap: 5px;
+}
+
+.graph-database-views > div {
+  border-left: 2px solid var(--accent-line);
+  display: grid;
+  gap: 2px;
+  padding-left: 7px;
+}
+
+.graph-database-views strong,
+.graph-database-views span,
+.graph-database-views small,
+.graph-database-job {
+  font-size: 10px;
+}
+
+.graph-database-views small,
+.graph-database-job {
+  color: var(--muted);
+}
+
+.graph-database-job {
+  margin: 0;
+}
+
+.graph-administration-output {
+  background: rgba(4, 7, 11, 0.75);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-size: 10px;
+  margin: 0;
+  max-height: 180px;
+  overflow: auto;
+  padding: 9px;
+  white-space: pre-wrap;
+}
+
 .graph-build-status {
   display: grid;
   gap: 8px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.0.3",
+  "version": "4.0.5",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/scripts/install-local-standalone.ts
+++ b/scripts/install-local-standalone.ts
@@ -4,10 +4,11 @@ import {Cause, Console, Crypto, Effect, Exit, FileSystem, Layer, Option, Path} f
 import {commandLauncherPath, installCommandShim, renderCommandShim} from '../src/command-shim.js';
 import {CommandExecutor, runCommandEffect} from '../src/effect/command.js';
 import {captureConsole} from '../src/effect/console.js';
-import {sha256FileHex} from '../src/effect/digest.js';
+import {sha256FileHex, sha256Hex} from '../src/effect/digest.js';
 import {SystemInfo, type SystemInfoShape} from '../src/effect/system.js';
 import {
   activateStandaloneRelease,
+  activeInstalledVersion,
   installationRoot,
   promoteStandaloneReleaseDirectory,
   pruneStandaloneReleases,
@@ -23,6 +24,7 @@ import {
   collectDevelopmentPayloadManifest,
   developmentBuildVersion,
   developmentPayloadManifestSha256,
+  isDevelopmentBuildVersion,
   prepareCanonicalDevelopmentInstallRoots,
   readDevelopmentReleaseEvidence,
   readManagedDevelopmentRuntimeEvidence,
@@ -34,6 +36,10 @@ import {
 const ROOT_URL = new URL('..', import.meta.url);
 const GIT_COMMIT_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const COMMAND_TIMEOUT_MILLISECONDS = 30 * 60_000;
+const DEVELOPMENT_RUNTIME_OWNER_FILE = 'development-runtime-owner.json';
+const DEVELOPMENT_RUNTIME_OWNER_SCHEMA_VERSION = 1 as const;
+const DEVELOPMENT_RUNTIME_OWNER_MAX_BYTES = 16 * 1024;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const CLEAN_GIT_STATUS_ARGUMENTS = [
   '-c',
   'core.fsmonitor=false',
@@ -52,6 +58,7 @@ const CLEAN_GIT_STATUS_ARGUMENTS = [
 
 export interface LocalStandaloneInstallOptions {
   readonly json: boolean;
+  readonly takeOverGlobalRuntime: boolean;
   readonly terminateSuperseded: boolean;
 }
 
@@ -76,21 +83,47 @@ export interface LocalStandaloneActivationInput {
   readonly executableName: string;
   readonly releaseRoot: string;
   readonly reused: boolean;
+  readonly sourceCheckoutId: string;
   readonly stagedRoot: Option.Option<string>;
+  readonly takeOverGlobalRuntime: boolean;
   readonly terminateSuperseded: boolean;
   readonly version: string;
 }
 
+export interface DevelopmentRuntimeOwnerV1 {
+  readonly schemaVersion: typeof DEVELOPMENT_RUNTIME_OWNER_SCHEMA_VERSION;
+  readonly sourceCheckoutId: string;
+  readonly version: string;
+}
+
+export type DevelopmentRuntimeOwnershipState = DevelopmentRuntimeOwnerV1 | 'absent' | 'invalid';
+
+export type DevelopmentRuntimeOwnershipConflict =
+  'different-source-checkout' | 'invalid-ownership-record' | 'untracked-development-activation';
+
 export function parseLocalStandaloneInstallArguments(arguments_: readonly string[]): LocalStandaloneInstallOptions {
   let json = false;
+  let takeOverGlobalRuntime = false;
   let terminateSuperseded = false;
   for (const argument of arguments_) {
     if (argument === '--') continue;
     if (argument === '--json') json = true;
+    else if (argument === '--take-over-global-runtime') takeOverGlobalRuntime = true;
     else if (argument === '--terminate-superseded') terminateSuperseded = true;
     else throw new Error(`Unknown local standalone install option: ${argument}`);
   }
-  return {json, terminateSuperseded};
+  return {json, takeOverGlobalRuntime, terminateSuperseded};
+}
+
+export function developmentRuntimeOwnershipConflict(
+  activeVersion: string | undefined,
+  owner: DevelopmentRuntimeOwnershipState,
+  requestedSourceCheckoutId: string,
+): DevelopmentRuntimeOwnershipConflict | undefined {
+  if (activeVersion === undefined || !isDevelopmentBuildVersion(activeVersion) || owner === 'absent') return undefined;
+  if (owner === 'invalid') return 'invalid-ownership-record';
+  if (owner.version !== activeVersion) return 'untracked-development-activation';
+  return owner.sourceCheckoutId === requestedSourceCheckoutId ? undefined : 'different-source-checkout';
 }
 
 export const installLocalStandalone = Effect.fn('developmentInstall.run')(function* (
@@ -120,6 +153,8 @@ export const installLocalStandalone = Effect.fn('developmentInstall.run')(functi
   const manifest = yield* readPackageManifest(fs, path.join(sourceRoot, 'package.json'));
   const version = developmentBuildVersion(manifest.version, commit);
   const roots = yield* prepareCanonicalDevelopmentInstallRoots(installationRoot(path, system));
+  const sourceCheckoutId = yield* developmentSourceCheckoutId(sourceRoot);
+  yield* requireDevelopmentRuntimeOwnership(roots.installRoot, sourceCheckoutId, options.takeOverGlobalRuntime);
   const releaseRoot = path.join(roots.versionsRoot, version);
   const executableName = system.platform === 'win32' ? 'threadnote.exe' : 'threadnote';
   const releaseExists = yield* fs.exists(releaseRoot);
@@ -145,7 +180,9 @@ export const installLocalStandalone = Effect.fn('developmentInstall.run')(functi
     executableName,
     releaseRoot,
     reused: releaseExists,
+    sourceCheckoutId,
     stagedRoot,
+    takeOverGlobalRuntime: options.takeOverGlobalRuntime,
     terminateSuperseded: options.terminateSuperseded,
     version,
   });
@@ -194,6 +231,98 @@ const verifyCleanSourceState = Effect.fn('developmentInstall.verifyCleanSourceSt
   }
 });
 
+const developmentSourceCheckoutId = Effect.fn('developmentInstall.sourceCheckoutId')(function* (sourceRoot: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
+  const canonicalSourceRoot = yield* fs.realPath(sourceRoot);
+  const normalizedSourceRoot =
+    system.platform === 'win32' ? canonicalSourceRoot.toLocaleLowerCase('en-US') : canonicalSourceRoot;
+  return yield* sha256Hex(`threadnote-development-source-checkout-v1\0${normalizedSourceRoot}`);
+});
+
+const requireDevelopmentRuntimeOwnership = Effect.fn('developmentInstall.requireRuntimeOwnership')(function* (
+  installRoot: string,
+  requestedSourceCheckoutId: string,
+  takeOverGlobalRuntime: boolean,
+) {
+  if (!SHA256_PATTERN.test(requestedSourceCheckoutId)) {
+    return yield* Effect.fail(new Error('The development source checkout identity is invalid.'));
+  }
+  const [activeVersion, owner] = yield* Effect.all([
+    activeInstalledVersion(),
+    readDevelopmentRuntimeOwner(installRoot),
+  ]);
+  const conflict = developmentRuntimeOwnershipConflict(activeVersion, owner, requestedSourceCheckoutId);
+  if (conflict === undefined || takeOverGlobalRuntime) return;
+  const reason =
+    conflict === 'different-source-checkout'
+      ? 'another source checkout owns the active global development runtime'
+      : conflict === 'untracked-development-activation'
+        ? 'the active global development runtime changed outside its owning installer'
+        : 'the active global development runtime ownership record is invalid';
+  return yield* Effect.fail(
+    new Error(
+      `Refusing to replace the global Threadnote runtime because ${reason}. ` +
+        'Rerun with --take-over-global-runtime only after confirming the other development task has finished.',
+    ),
+  );
+});
+
+const readDevelopmentRuntimeOwner = Effect.fn('developmentInstall.readRuntimeOwner')(function* (installRoot: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const file = path.join(installRoot, DEVELOPMENT_RUNTIME_OWNER_FILE);
+  if (!(yield* fs.exists(file))) return 'absent';
+  const [link, info] = yield* Effect.all([fs.readLink(file).pipe(Effect.option), fs.stat(file).pipe(Effect.option)]);
+  if (
+    Option.isSome(link) ||
+    Option.isNone(info) ||
+    info.value.type !== 'File' ||
+    Number(info.value.size) > DEVELOPMENT_RUNTIME_OWNER_MAX_BYTES ||
+    (system.platform !== 'win32' && (info.value.mode & 0o7777) !== 0o600)
+  ) {
+    return 'invalid';
+  }
+  const source = yield* fs.readFileString(file).pipe(Effect.option);
+  if (Option.isNone(source)) return 'invalid';
+  const value = yield* Effect.sync(() => {
+    try {
+      return JSON.parse(source.value) as unknown;
+    } catch {
+      return undefined;
+    }
+  });
+  return value === undefined ? 'invalid' : parseDevelopmentRuntimeOwner(value);
+});
+
+function parseDevelopmentRuntimeOwner(value: unknown): DevelopmentRuntimeOwnershipState {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return 'invalid';
+  const candidate = value as Partial<DevelopmentRuntimeOwnerV1>;
+  return candidate.schemaVersion === DEVELOPMENT_RUNTIME_OWNER_SCHEMA_VERSION &&
+    typeof candidate.sourceCheckoutId === 'string' &&
+    SHA256_PATTERN.test(candidate.sourceCheckoutId) &&
+    typeof candidate.version === 'string' &&
+    isDevelopmentBuildVersion(candidate.version)
+    ? (candidate as DevelopmentRuntimeOwnerV1)
+    : 'invalid';
+}
+
+const writeDevelopmentRuntimeOwner = Effect.fn('developmentInstall.writeRuntimeOwner')(function* (
+  installRoot: string,
+  owner: DevelopmentRuntimeOwnerV1,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const crypto = yield* Crypto.Crypto;
+  const file = path.join(installRoot, DEVELOPMENT_RUNTIME_OWNER_FILE);
+  const temporary = path.join(installRoot, `.${DEVELOPMENT_RUNTIME_OWNER_FILE}.${yield* crypto.randomUUIDv4}.tmp`);
+  yield* Effect.gen(function* () {
+    yield* fs.writeFileString(temporary, `${JSON.stringify(owner, undefined, 2)}\n`, {flag: 'wx', mode: 0o600});
+    yield* fs.rename(temporary, file);
+  }).pipe(Effect.ensuring(fs.remove(temporary, {force: true}).pipe(Effect.catch(() => Effect.void))));
+});
+
 /**
  * The complete managed-release mutation is one installation-lock critical
  * section. This prevents a concurrent updater from pruning a reused release
@@ -216,6 +345,7 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
       input.stagedRoot,
     );
     const installRoot = roots.installRoot;
+    yield* requireDevelopmentRuntimeOwnership(installRoot, input.sourceCheckoutId, input.takeOverGlobalRuntime);
     let reused = input.reused;
     let promotedByThisInstall = false;
     if (Option.isSome(input.stagedRoot)) {
@@ -263,6 +393,12 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
         captureFileSnapshot(fs, yield* commandLauncherPath('cli'), 'CLI launcher', 0o755),
         captureFileSnapshot(fs, yield* commandLauncherPath('mcp'), 'MCP launcher', 0o755),
         captureFileSnapshot(fs, path.join(installRoot, 'active-release.json'), 'active release pointer', 0o600),
+        captureFileSnapshot(
+          fs,
+          path.join(installRoot, DEVELOPMENT_RUNTIME_OWNER_FILE),
+          'development runtime owner',
+          0o600,
+        ),
       ]);
     }).pipe(
       Effect.catchCause(validationCause =>
@@ -286,6 +422,11 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
       const evidence = yield* readManagedDevelopmentRuntimeEvidence(input.commit);
       yield* installCommandShim(false, input.releaseRoot);
       yield* verifyLaunchers(fs, input.releaseRoot, input.version);
+      yield* writeDevelopmentRuntimeOwner(installRoot, {
+        schemaVersion: DEVELOPMENT_RUNTIME_OWNER_SCHEMA_VERSION,
+        sourceCheckoutId: input.sourceCheckoutId,
+        version: input.version,
+      });
       return evidence;
     }).pipe(
       Effect.catchCause(activationCause =>

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -7,9 +7,12 @@ import {CodeGraphIndexer, materializationStorageShortfalls} from './indexer.js';
 import {makeCodeGraphJsonProgressReporter} from './json_progress.js';
 import {codeGraphLayout} from './layout.js';
 import {
+  repairCodeGraphIndexes,
   inspectObsoleteCodeGraphStores,
   purgeAllCodeGraphIndexes,
   purgeObsoleteCodeGraphStores,
+  type CodeGraphMaintenanceProgress,
+  type CodeGraphRepairCompletion,
   type ObsoleteCodeGraphStoreInventory,
 } from './maintenance.js';
 import {
@@ -36,6 +39,7 @@ import {
   type ObservedCodeGraphBuildStatus,
 } from './build_status.js';
 import {compactCodeGraphStorage, inspectCodeGraphStorage, type CodeGraphStorage} from './storage.js';
+import {inspectAllCodeGraphs, renderCodeGraphDiagnostics} from './diagnostics.js';
 
 interface CwdOption {
   readonly cwd?: string;
@@ -45,6 +49,90 @@ export interface CodeGraphExportInterlock {
   readonly afterOutputCheck?: () => Effect.Effect<void>;
   readonly beforeLink?: (temporaryPath: string) => Effect.Effect<void>;
   readonly beforePublish?: (temporaryPath: string) => Effect.Effect<void>;
+}
+
+export const runCodeGraphRepair = Effect.fn('codeGraph.command.repair')(function* (
+  config: RuntimeConfig,
+  options: {readonly all?: boolean; readonly deep?: boolean; readonly dryRun?: boolean; readonly json?: boolean},
+) {
+  if (!options.all) {
+    return yield* Effect.fail(new Error('All-database graph repair requires --all.'));
+  }
+  let completion: CodeGraphRepairCompletion | undefined;
+  const summary = yield* repairCodeGraphIndexes(
+    config.agentContextHome,
+    options.dryRun === true,
+    options.json
+      ? undefined
+      : progress => Console.log(codeGraphRepairProgressMessage(progress, options.dryRun === true)),
+    result => Effect.sync(() => void (completion = result)),
+    {migrateSchema: true, mode: options.deep ? 'deep' : 'quick'},
+  );
+  if (options.json) {
+    yield* writeFinalCliOutput(
+      JSON.stringify({
+        doctor: completion?.doctorCheck ?? null,
+        dryRun: options.dryRun === true,
+        mode: options.deep ? 'deep' : 'quick',
+        summary,
+        type: 'code-graph-repair',
+        version: 1,
+      }),
+    );
+    return;
+  }
+  yield* Console.log(
+    `${options.dryRun ? 'Would repair' : 'Repaired'} ${summary.databases} native code graph database(s): ` +
+      `${summary.migratedDatabases} schema migration(s), ${summary.deferredDatabases} deferred, ` +
+      `${summary.discarded} disposable rebuild(s), ${summary.removedIncompleteSnapshots} incomplete snapshot(s), ` +
+      `${summary.removedTemporaryFiles} temporary vector file(s).`,
+  );
+  if (completion) {
+    yield* Console.log(
+      `${completion.doctorCheck.status.toUpperCase()} native code graph: ${completion.doctorCheck.detail}`,
+    );
+  }
+});
+
+export const runCodeGraphDiagnostics = Effect.fn('codeGraph.command.diagnostics')(function* (
+  config: RuntimeConfig,
+  options: {readonly analyze?: boolean; readonly deep?: boolean; readonly json?: boolean},
+) {
+  const report = yield* inspectAllCodeGraphs(config.agentContextHome, {
+    analyze: options.analyze,
+    deep: options.deep,
+    onProgress: options.json
+      ? undefined
+      : progress =>
+          Console.log(
+            `${progress.phase === 'analyzing' ? 'Analyzing' : options.deep ? 'Deep-checking' : 'Checking'} native code graph database ${progress.current}/${progress.total}.`,
+          ),
+  });
+  yield* writeFinalCliOutput(options.json ? JSON.stringify(report) : renderCodeGraphDiagnostics(report).trimEnd());
+});
+
+function codeGraphRepairProgressMessage(progress: CodeGraphMaintenanceProgress, dryRun: boolean): string {
+  const database = `native code graph database ${progress.current}/${progress.total}`;
+  switch (progress.phase) {
+    case 'checking':
+      return `Checking ${database}.`;
+    case 'migrating-schema':
+      return `${dryRun ? 'Would migrate' : 'Migrating'} the persistent schema for ${database}.`;
+    case 'cleaning-snapshots':
+      return `${dryRun ? 'Would clean' : 'Cleaning'} ${progress.snapshots ?? 0} incomplete snapshot(s) from ${database}.`;
+    case 'cleaning-vectors':
+      return `Checking temporary vector state for ${database}.`;
+    case 'discarding':
+      return `${dryRun ? 'Would discard' : 'Discarding'} unreadable derived ${database}.`;
+    case 'deferred':
+      if (progress.reason === 'active-build') {
+        return `Deferred ${database}: an active graph build owns the checkout.`;
+      }
+      if (progress.reason === 'schema-upgrade-on-use') {
+        return `Deferred ${database}: its persistent schema could not be migrated in this pass.`;
+      }
+      return `Deferred ${database}: rerun with --deep when a full derived-store check is convenient.`;
+  }
 }
 
 interface CodeGraphExportTemporaryIdentity {

--- a/src/code_graph/diagnostics.ts
+++ b/src/code_graph/diagnostics.ts
@@ -64,6 +64,7 @@ export interface CodeGraphDiagnosticsAnalysis {
 export interface CodeGraphDiagnosticsView {
   readonly activatedAt?: string;
   readonly analysis?: CodeGraphDiagnosticsAnalysis;
+  readonly managementAvailable: boolean;
   readonly metrics: CodeGraphVisualizationCatalog['metrics'];
   readonly model: CodeGraphVisualizationCatalog['model'];
   readonly projectCount: number;
@@ -221,6 +222,12 @@ export const inspectAllCodeGraphs = Effect.fn('codeGraph.inspectAllDiagnostics')
           views.push({
             ...(catalog.activatedAt ? {activatedAt: catalog.activatedAt} : {}),
             ...(analysis ? {analysis} : {}),
+            managementAvailable: [...buildSelection.builds, ...buildSelection.waiters].some(
+              status =>
+                status.identity.checkoutId === checkoutId &&
+                status.identity.worktreeId === catalog.viewWorktreeId &&
+                status.managerContext !== undefined,
+            ),
             metrics: catalog.metrics,
             model: catalog.model,
             projectCount: catalog.projectCount,

--- a/src/code_graph/diagnostics.ts
+++ b/src/code_graph/diagnostics.ts
@@ -1,0 +1,363 @@
+import {Effect, Path} from 'effect';
+import {analyzeCodeGraph, type CodeGraphAnalysisCoverage, type CodeGraphAnalysisStatistics} from './analysis.js';
+import {codeGraphAnalysisLimitsForView} from './analysis_render.js';
+import {
+  readAllCodeGraphBuildStatuses,
+  selectCodeGraphBuildStatuses,
+  type ObservedCodeGraphBuildStatus,
+} from './build_status.js';
+import {
+  diagnoseCodeGraphDatabaseReadOnly,
+  inspectObsoleteCodeGraphStores,
+  codeGraphDatabasePaths,
+} from './maintenance.js';
+import {codeGraphRepositoryLockActive, codeGraphWorktreeBuildActive} from './maintenance_gate.js';
+import {
+  CodeGraphStore,
+  sanitizeCodeGraphStoreDiagnostic,
+  type CodeGraphDatabaseHealth,
+  type CodeGraphStoreShape,
+  type CodeGraphVisualizationCatalog,
+} from './store.js';
+import {inspectCodeGraphStorage, type CodeGraphStorage} from './storage.js';
+
+const DIAGNOSTIC_CATALOG_PAGE_SIZE = 64;
+
+type PrivacySafeStorage<Storage = CodeGraphStorage> = Storage extends {readonly databasePath: string}
+  ? Omit<Storage, 'databasePath'>
+  : never;
+
+export interface CodeGraphDiagnosticsOptions {
+  readonly analyze?: boolean;
+  readonly deep?: boolean;
+  readonly onProgress?: (progress: CodeGraphDiagnosticsProgress) => Effect.Effect<void, never>;
+}
+
+export interface CodeGraphDiagnosticsProgress {
+  readonly current: number;
+  readonly phase: 'analyzing' | 'checking';
+  readonly total: number;
+}
+
+export interface CodeGraphDiagnosticsIssue {
+  readonly code: 'active-build' | 'analysis-failed' | 'catalog-unavailable' | 'health-check-failed';
+  readonly message: string;
+}
+
+export interface CodeGraphDiagnosticsAnalysis {
+  readonly coverage: CodeGraphAnalysisCoverage;
+  readonly statistics: CodeGraphAnalysisStatistics;
+  readonly usage: {
+    readonly aggregateEdgePageReads: number;
+    readonly aggregateEdgeRows: number;
+    readonly aggregateSummaryReads: number;
+    readonly aggregateSymbolPageReads: number;
+    readonly aggregateSymbolRows: number;
+    readonly durationMilliseconds: number;
+    readonly edgePageReads: number;
+    readonly edgeVisits: number;
+    readonly nodePageReads: number;
+  };
+  readonly warnings: readonly string[];
+}
+
+export interface CodeGraphDiagnosticsView {
+  readonly activatedAt?: string;
+  readonly analysis?: CodeGraphDiagnosticsAnalysis;
+  readonly metrics: CodeGraphVisualizationCatalog['metrics'];
+  readonly model: CodeGraphVisualizationCatalog['model'];
+  readonly projectCount: number;
+  readonly projectsTruncated: boolean;
+  readonly repository: CodeGraphVisualizationCatalog['repository'];
+  readonly snapshot: CodeGraphVisualizationCatalog['snapshot'];
+  readonly viewWorktreeId: string;
+  readonly workspaceCount: number;
+  readonly workspacesTruncated: boolean;
+}
+
+export interface CodeGraphDatabaseDiagnostics {
+  readonly builds: readonly Omit<ObservedCodeGraphBuildStatus, 'managerContext'>[];
+  readonly checkoutId: string;
+  readonly health?: CodeGraphDatabaseHealth;
+  readonly healthState: 'checked' | 'deferred' | 'unreadable';
+  readonly issues: readonly CodeGraphDiagnosticsIssue[];
+  readonly storage: PrivacySafeStorage;
+  readonly views: readonly CodeGraphDiagnosticsView[];
+  readonly waiters: readonly Omit<ObservedCodeGraphBuildStatus, 'managerContext'>[];
+}
+
+export interface CodeGraphDiagnosticsReport {
+  readonly databases: readonly CodeGraphDatabaseDiagnostics[];
+  readonly generatedAt: string;
+  readonly mode: {readonly analyze: boolean; readonly deep: boolean};
+  readonly obsoleteStores: {
+    readonly bytes: number;
+    readonly checkouts: readonly {
+      readonly bytes: number;
+      readonly checkoutId: string;
+      readonly fileCount: number;
+      readonly versions: readonly number[];
+    }[];
+    readonly fileCount: number;
+    readonly unsafeEntryCount: number;
+  };
+  readonly summary: {
+    readonly activeBuildCount: number;
+    readonly analysisCompleteCount: number;
+    readonly analysisPartialCount: number;
+    readonly databaseCount: number;
+    readonly deferredDatabaseCount: number;
+    readonly healthyDatabaseCount: number;
+    readonly readySnapshotCount: number;
+    readonly totalStorageBytes: number;
+    readonly unhealthyDatabaseCount: number;
+    readonly unreadableDatabaseCount: number;
+    readonly viewCount: number;
+    readonly waiterCount: number;
+  };
+  readonly type: 'code-graph-diagnostics';
+  readonly version: 1;
+}
+
+export const inspectAllCodeGraphs = Effect.fn('codeGraph.inspectAllDiagnostics')(function* (
+  threadnoteHome: string,
+  options: CodeGraphDiagnosticsOptions = {},
+) {
+  const path = yield* Path.Path;
+  const store = yield* CodeGraphStore;
+  const databases = yield* codeGraphDatabasePaths(threadnoteHome);
+  const buildSelection = selectCodeGraphBuildStatuses(yield* readAllCodeGraphBuildStatuses(threadnoteHome));
+  const obsolete = yield* inspectObsoleteCodeGraphStores(threadnoteHome);
+  const entries = yield* Effect.forEach(
+    databases,
+    (database, index) =>
+      Effect.gen(function* () {
+        yield* options.onProgress?.({current: index + 1, phase: 'checking', total: databases.length}) ?? Effect.void;
+        const checkoutId = path.basename(path.dirname(database));
+        const builds = buildSelection.builds
+          .filter(status => status.identity.checkoutId === checkoutId)
+          .map(privacySafeBuildStatus);
+        const waiters = buildSelection.waiters
+          .filter(status => status.identity.checkoutId === checkoutId)
+          .map(privacySafeBuildStatus);
+        const active =
+          (yield* codeGraphRepositoryLockActive(threadnoteHome, checkoutId)) ||
+          (yield* codeGraphWorktreeBuildActive(threadnoteHome, checkoutId));
+        const issues: CodeGraphDiagnosticsIssue[] = [];
+        let health: CodeGraphDatabaseHealth | undefined;
+        let healthState: CodeGraphDatabaseDiagnostics['healthState'];
+        if (active) {
+          healthState = 'deferred';
+          issues.push({
+            code: 'active-build',
+            message: 'An active graph build owns this checkout; database health inspection was deferred.',
+          });
+        } else {
+          const diagnosed = yield* diagnoseCodeGraphDatabaseReadOnly(database, options.deep === true).pipe(
+            Effect.match({onFailure: cause => ({cause}) as const, onSuccess: value => ({value}) as const}),
+          );
+          if ('value' in diagnosed) {
+            health = diagnosed.value;
+            healthState = 'checked';
+          } else {
+            healthState = 'unreadable';
+            issues.push({
+              code: 'health-check-failed',
+              message: privacySafeDiagnostic(diagnosed.cause),
+            });
+          }
+        }
+        const storage = privacySafeStorage(yield* inspectCodeGraphStorage(threadnoteHome, checkoutId));
+        const catalogResult = yield* loadAllCatalogs(store, database).pipe(
+          Effect.match({onFailure: cause => ({cause}) as const, onSuccess: value => ({value}) as const}),
+        );
+        const catalogs = 'value' in catalogResult ? catalogResult.value : [];
+        if ('cause' in catalogResult) {
+          issues.push({code: 'catalog-unavailable', message: privacySafeDiagnostic(catalogResult.cause)});
+        }
+        const analysisBySnapshot = new Map<string, CodeGraphDiagnosticsAnalysis | CodeGraphDiagnosticsIssue>();
+        const views: CodeGraphDiagnosticsView[] = [];
+        for (const catalog of catalogs) {
+          let analysis: CodeGraphDiagnosticsAnalysis | undefined;
+          if (options.analyze) {
+            const existing = analysisBySnapshot.get(catalog.snapshot.id);
+            if (existing) {
+              if ('statistics' in existing) analysis = existing;
+            } else {
+              yield* options.onProgress?.({
+                current: index + 1,
+                phase: 'analyzing',
+                total: databases.length,
+              }) ?? Effect.void;
+              const analyzed = yield* store
+                .withSession(
+                  database,
+                  analyzeCodeGraph(store, {
+                    databasePath: database,
+                    limits: codeGraphAnalysisLimitsForView('stats'),
+                    snapshot: catalog.snapshot,
+                  }),
+                  {readOnly: true},
+                )
+                .pipe(Effect.match({onFailure: cause => ({cause}) as const, onSuccess: value => ({value}) as const}));
+              if ('value' in analyzed) {
+                analysis = {
+                  coverage: analyzed.value.coverage,
+                  statistics: analyzed.value.statistics,
+                  usage: analyzed.value.usage,
+                  warnings: analyzed.value.warnings,
+                };
+                analysisBySnapshot.set(catalog.snapshot.id, analysis);
+              } else {
+                const issue = {
+                  code: 'analysis-failed',
+                  message: privacySafeDiagnostic(analyzed.cause),
+                } satisfies CodeGraphDiagnosticsIssue;
+                issues.push(issue);
+                analysisBySnapshot.set(catalog.snapshot.id, issue);
+              }
+            }
+          }
+          views.push({
+            ...(catalog.activatedAt ? {activatedAt: catalog.activatedAt} : {}),
+            ...(analysis ? {analysis} : {}),
+            metrics: catalog.metrics,
+            model: catalog.model,
+            projectCount: catalog.projectCount,
+            projectsTruncated: catalog.projectsTruncated,
+            repository: catalog.repository,
+            snapshot: catalog.snapshot,
+            viewWorktreeId: catalog.viewWorktreeId,
+            workspaceCount: catalog.workspaceCount,
+            workspacesTruncated: catalog.workspacesTruncated,
+          });
+        }
+        return {builds, checkoutId, health, healthState, issues, storage, views, waiters};
+      }),
+    {concurrency: options.analyze || options.deep ? 1 : 2},
+  );
+  const analyses = entries.flatMap(entry => entry.views.flatMap(view => (view.analysis ? [view.analysis] : [])));
+  return {
+    databases: entries,
+    generatedAt: new Date().toISOString(),
+    mode: {analyze: options.analyze === true, deep: options.deep === true},
+    obsoleteStores: {
+      bytes: obsolete.bytes,
+      checkouts: obsolete.checkouts.map(checkout => ({
+        bytes: checkout.bytes,
+        checkoutId: checkout.checkoutId,
+        fileCount: checkout.files.length,
+        versions: checkout.versions,
+      })),
+      fileCount: obsolete.fileCount,
+      unsafeEntryCount: obsolete.unsafeEntryCount,
+    },
+    summary: {
+      activeBuildCount: buildSelection.builds.filter(status => status.observation.liveness === 'active').length,
+      analysisCompleteCount: analyses.filter(analysis => analysis.coverage.complete).length,
+      analysisPartialCount: analyses.filter(analysis => !analysis.coverage.complete).length,
+      databaseCount: entries.length,
+      deferredDatabaseCount: entries.filter(entry => entry.healthState === 'deferred').length,
+      healthyDatabaseCount: entries.filter(entry => entry.health?.integrity === 'ok').length,
+      readySnapshotCount: entries.reduce((total, entry) => total + (entry.health?.readySnapshots ?? 0), 0),
+      totalStorageBytes: entries.reduce(
+        (total, entry) => total + (entry.storage.state === 'available' ? entry.storage.totalBytes : 0),
+        0,
+      ),
+      unhealthyDatabaseCount: entries.filter(entry => entry.health !== undefined && entry.health.integrity !== 'ok')
+        .length,
+      unreadableDatabaseCount: entries.filter(entry => entry.healthState === 'unreadable').length,
+      viewCount: entries.reduce((total, entry) => total + entry.views.length, 0),
+      waiterCount: buildSelection.waiters.length,
+    },
+    type: 'code-graph-diagnostics',
+    version: 1,
+  } satisfies CodeGraphDiagnosticsReport;
+});
+
+export function renderCodeGraphDiagnostics(report: CodeGraphDiagnosticsReport): string {
+  const lines = [
+    'Native code graph diagnostics',
+    `Databases: ${report.summary.databaseCount} · healthy ${report.summary.healthyDatabaseCount} · unhealthy ${report.summary.unhealthyDatabaseCount} · deferred ${report.summary.deferredDatabaseCount} · unreadable ${report.summary.unreadableDatabaseCount}`,
+    `Ready snapshots: ${report.summary.readySnapshotCount} · indexed views ${report.summary.viewCount} · storage ${formatBytes(report.summary.totalStorageBytes)}`,
+  ];
+  for (const database of report.databases) {
+    const repository = database.views[0]?.repository.displayName ?? 'unknown repository';
+    const health = database.health
+      ? `${database.health.integrity}; schema v${database.health.schemaVersion ?? 'unknown'}; extension ${database.health.persistentExtensionSchemaRevision ?? 'missing'}`
+      : database.healthState;
+    lines.push(
+      '',
+      `${repository} · checkout ${database.checkoutId.slice(-8)}`,
+      `Health: ${health}`,
+      `Snapshots: ${database.health?.readySnapshots ?? 0} ready · ${(database.health?.buildingSnapshots ?? 0) + (database.health?.failedSnapshots ?? 0)} incomplete`,
+      `Storage: ${database.storage.state === 'available' ? formatBytes(database.storage.totalBytes) : 'missing'}`,
+    );
+    for (const view of database.views) {
+      lines.push(
+        `View ${view.viewWorktreeId.slice(-8)}: ${view.snapshot.fileCount} files · ${view.snapshot.symbolCount} symbols · ${view.snapshot.edgeCount} edges`,
+      );
+      if (view.analysis) {
+        lines.push(
+          `Analysis: ${view.analysis.coverage.complete ? 'complete' : 'partial'} · ${view.analysis.statistics.connectedComponentCount} component(s) · ${view.analysis.statistics.communityCount} communit${view.analysis.statistics.communityCount === 1 ? 'y' : 'ies'}`,
+        );
+      }
+    }
+    for (const issue of database.issues) lines.push(`Warning: ${issue.code}: ${issue.message}`);
+  }
+  if (report.obsoleteStores.fileCount > 0 || report.obsoleteStores.unsafeEntryCount > 0) {
+    lines.push(
+      '',
+      `Obsolete stores: ${report.obsoleteStores.fileCount} file(s), ${formatBytes(report.obsoleteStores.bytes)}; unsafe entries ${report.obsoleteStores.unsafeEntryCount}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+const loadAllCatalogs = Effect.fn('codeGraph.loadAllDiagnosticCatalogs')(function* (
+  store: CodeGraphStoreShape,
+  database: string,
+) {
+  const catalogs: CodeGraphVisualizationCatalog[] = [];
+  for (let offset = 0; ; offset += DIAGNOSTIC_CATALOG_PAGE_SIZE) {
+    const page = yield* store.loadVisualizationCatalogs(database, 'deferred', {
+      includeDependencies: false,
+      projectLimit: 1,
+      viewLimit: DIAGNOSTIC_CATALOG_PAGE_SIZE,
+      viewOffset: offset,
+      workspaceLimit: 1,
+    });
+    catalogs.push(...page);
+    if (page.length < DIAGNOSTIC_CATALOG_PAGE_SIZE) return catalogs;
+  }
+});
+
+function privacySafeBuildStatus(
+  status: ObservedCodeGraphBuildStatus,
+): Omit<ObservedCodeGraphBuildStatus, 'managerContext'> {
+  const {managerContext: _managerContext, ...safe} = status;
+  return safe;
+}
+
+function privacySafeStorage(storage: CodeGraphStorage): PrivacySafeStorage {
+  const {databasePath: _databasePath, ...safe} = storage;
+  return safe;
+}
+
+function privacySafeDiagnostic(cause: unknown): string {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  return sanitizeCodeGraphStoreDiagnostic(message) || 'unknown database error';
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1024;
+  let unit = units[0]!;
+  for (const candidate of units.slice(1)) {
+    if (value < 1024) break;
+    value /= 1024;
+    unit = candidate;
+  }
+  return `${value >= 10 ? value.toFixed(1) : value.toFixed(2)} ${unit}`;
+}

--- a/src/code_graph/diagnostics.ts
+++ b/src/code_graph/diagnostics.ts
@@ -195,7 +195,7 @@ export const inspectAllCodeGraphs = Effect.fn('codeGraph.inspectAllDiagnostics')
                   database,
                   analyzeCodeGraph(store, {
                     databasePath: database,
-                    limits: codeGraphAnalysisLimitsForView('stats'),
+                    limits: codeGraphAnalysisLimitsForView('communities'),
                     snapshot: catalog.snapshot,
                   }),
                   {readOnly: true},

--- a/src/code_graph/inventory.ts
+++ b/src/code_graph/inventory.ts
@@ -56,6 +56,7 @@ const PRUNED_DIRECTORIES = new Set([
   'coverage',
   'deriveddata',
   'dist',
+  'graphify-out',
   'node_modules',
   'out',
   'pods',
@@ -68,6 +69,7 @@ const GENERATED_DIRECTORIES = new Set([
   'coverage',
   'deriveddata',
   'dist',
+  'graphify-out',
   'node_modules',
   'out',
 ]);

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -29,6 +29,7 @@ export interface CodeGraphRepairSummary {
   readonly databases: number;
   readonly deferredDatabases: number;
   readonly discarded: number;
+  readonly migratedDatabases: number;
   readonly obsoleteStoreBytes: number;
   readonly obsoleteStoreCheckouts: number;
   readonly obsoleteStoreFiles: number;
@@ -79,7 +80,8 @@ export interface CodeGraphRepairCompletion {
 
 export interface CodeGraphMaintenanceProgress {
   readonly current: number;
-  readonly phase: 'checking' | 'cleaning-snapshots' | 'cleaning-vectors' | 'deferred' | 'discarding';
+  readonly phase:
+    'checking' | 'cleaning-snapshots' | 'cleaning-vectors' | 'deferred' | 'discarding' | 'migrating-schema';
   readonly reason?: 'active-build' | 'deep-check-required' | 'schema-upgrade-on-use';
   readonly snapshots?: number;
   readonly total: number;
@@ -237,7 +239,7 @@ export const codeGraphDoctorCheck = Effect.fn('codeGraph.doctorCheck')(function*
   return codeGraphDoctorResult(databases.length, ready, incomplete, unhealthy, deferred, obsolete);
 });
 
-const diagnoseCodeGraphDatabaseReadOnly = Effect.fn('codeGraph.diagnoseDatabaseReadOnly')(function* (
+export const diagnoseCodeGraphDatabaseReadOnly = Effect.fn('codeGraph.diagnoseDatabaseReadOnly')(function* (
   databasePath: string,
   deep: boolean,
 ) {
@@ -308,7 +310,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
   dryRun: boolean,
   onProgress?: CodeGraphProgressHandler,
   onComplete?: CodeGraphRepairCompletionHandler<R>,
-  options: {readonly mode?: 'deep' | 'quick'} = {},
+  options: {readonly migrateSchema?: boolean; readonly mode?: 'deep' | 'quick'} = {},
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -325,6 +327,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
         const deep = options.mode !== 'quick';
         let deferredDatabases = 0;
         let discarded = 0;
+        let migratedDatabases = 0;
         let removedIncompleteSnapshots = 0;
         let remainingIncompleteSnapshots = 0;
         let removedTemporaryFiles = 0;
@@ -343,7 +346,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
               const decision = yield* store.withSession(
                 database,
                 Effect.gen(function* () {
-                  const diagnosed = deep
+                  let diagnosed = deep
                     ? yield* store.diagnose(database).pipe(Effect.option)
                     : yield* diagnoseCodeGraphDatabaseReadOnly(database, false).pipe(Effect.option);
                   if (
@@ -351,13 +354,23 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                     diagnosed.value?.schemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
                     diagnosed.value.integrity === 'incompatible'
                   ) {
-                    // Same-version beta databases with a missing revision or an
-                    // incompatible extension-table contract are recoverable on the
-                    // next ordinary writer open.
-                    // Never discard their ready snapshots as if the canonical graph
-                    // rows were corrupt merely because this maintenance pass is
-                    // deliberately read-only while holding the checkout gate.
-                    return 'schema-upgrade-on-use' as const;
+                    if (options.migrateSchema) {
+                      migratedDatabases += 1;
+                      yield* progress({phase: 'migrating-schema'});
+                      if (dryRun) return 'maintained' as const;
+                      yield* store.initialize(database);
+                      diagnosed = deep
+                        ? yield* store.diagnose(database).pipe(Effect.option)
+                        : yield* diagnoseCodeGraphDatabaseReadOnly(database, false).pipe(Effect.option);
+                    } else {
+                      // Same-version beta databases with a missing revision or an
+                      // incompatible extension-table contract are recoverable on the
+                      // next ordinary writer open.
+                      // Never discard their ready snapshots as if the canonical graph
+                      // rows were corrupt merely because this maintenance pass is
+                      // deliberately read-only while holding the checkout gate.
+                      return 'schema-upgrade-on-use' as const;
+                    }
                   }
                   if (diagnosed._tag === 'None' || diagnosed.value?.integrity !== 'ok') {
                     return deep ? ('discard' as const) : ('deep-check-required' as const);
@@ -423,6 +436,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
           databases: databases.length,
           deferredDatabases,
           discarded,
+          migratedDatabases,
           obsoleteStoreBytes: obsolete.bytes,
           obsoleteStoreCheckouts: obsolete.checkouts.length,
           obsoleteStoreFiles: obsolete.fileCount,
@@ -435,7 +449,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
             currentDatabases.length,
             readySnapshots,
             dryRun ? removedIncompleteSnapshots + remainingIncompleteSnapshots : remainingIncompleteSnapshots,
-            dryRun ? discarded : 0,
+            dryRun ? discarded + migratedDatabases : 0,
             deferredDatabases,
             obsolete,
           ),

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -92,11 +92,13 @@ import {runReportIssue} from '../report_issue.js';
 import {
   runCodeGraphAnalysis,
   runCodeGraphCompact,
+  runCodeGraphDiagnostics,
   runCodeGraphExport,
   runCodeGraphImpact,
   runCodeGraphIndex,
   runCodeGraphInspect,
   runCodeGraphPurge,
+  runCodeGraphRepair,
   runCodeGraphReport,
   runCodeGraphStatus,
   runCodeGraphWatch,
@@ -592,6 +594,27 @@ const graphStatus = Command.make(
   options => withRuntimeEffect(config => runCodeGraphStatus(config, options)),
 ).pipe(Command.withDescription('Show native code graph snapshot and freshness state'));
 
+const graphDiagnostics = Command.make(
+  'diagnostics',
+  {
+    analyze: boolean('analyze', 'Include bounded structural statistics for every ready indexed view'),
+    deep: boolean('deep', 'Run full SQLite integrity and foreign-key checks for every idle database'),
+    json: graphBounds.json,
+  },
+  options => withRuntimeEffect(config => runCodeGraphDiagnostics(config, options)),
+).pipe(Command.withDescription('Inspect health, storage, snapshots, builds, and statistics for every local graph'));
+
+const graphRepair = Command.make(
+  'repair',
+  {
+    all: boolean('all', 'Repair every local native code graph database'),
+    deep: boolean('deep', 'Run full SQLite integrity and foreign-key checks before destructive recovery'),
+    dryRun: boolean('dry-run', 'Print repair actions without modifying graph databases'),
+    json: graphBounds.json,
+  },
+  options => withRuntimeEffect(config => runCodeGraphRepair(config, options)),
+).pipe(Command.withDescription('Immediately migrate and repair native code graph databases'));
+
 const graphIndex = Command.make(
   'index',
   {
@@ -790,6 +813,8 @@ const graphCommand = Command.make('graph').pipe(
   Command.withDescription('Index and inspect the self-contained native code graph'),
   Command.withSubcommands([
     graphStatus,
+    graphDiagnostics,
+    graphRepair,
     graphIndex,
     graphQuery,
     graphNode,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -421,6 +421,8 @@ function codeGraphMaintenanceProgressMessage(progress: CodeGraphMaintenanceProgr
         : `Deferred ${database}: run \`threadnote repair --deep\` when a full derived-store check is convenient.`;
     case 'discarding':
       return `${dryRun ? 'Would discard' : 'Discarding'} unreadable derived ${database}.`;
+    case 'migrating-schema':
+      return `${dryRun ? 'Would migrate' : 'Migrating'} the persistent schema for ${database}.`;
   }
 }
 
@@ -429,6 +431,7 @@ function codeGraphRepairSummaryMessage(
     readonly databases: number;
     readonly deferredDatabases: number;
     readonly discarded: number;
+    readonly migratedDatabases: number;
     readonly obsoleteStoreBytes: number;
     readonly obsoleteStoreCheckouts: number;
     readonly obsoleteStoreFiles: number;
@@ -441,6 +444,7 @@ function codeGraphRepairSummaryMessage(
   return (
     `${dryRun ? 'Would repair' : 'Repaired'} ${summary.databases} native code graph database(s): ` +
     (summary.deferredDatabases > 0 ? `${summary.deferredDatabases} deferred, ` : '') +
+    (summary.migratedDatabases > 0 ? `${summary.migratedDatabases} schema migration(s), ` : '') +
     `${summary.discarded} disposable rebuild(s), ` +
     `${summary.removedIncompleteSnapshots} incomplete snapshot(s), ` +
     `${summary.removedTemporaryFiles} temporary vector file(s).` +

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -56,6 +56,11 @@ import {collectDoctorChecks, runRepair, runStart} from './lifecycle.js';
 import {runSeed, runSeedSkills} from './seeding.js';
 import {currentPackageVersion, fetchLatestVersion, releaseSource} from './update.js';
 import {selectUpdateChannel} from './update_channel.js';
+import {runCodeGraphCompact, runCodeGraphIndex, runCodeGraphPurge, runCodeGraphRepair} from './code_graph/commands.js';
+import {inspectAllCodeGraphs} from './code_graph/diagnostics.js';
+import {readAllCodeGraphBuildStatuses} from './code_graph/build_status.js';
+import {resolveRepositoryIdentity} from './code_graph/repository.js';
+import {codeGraphMaintenanceIntentActive} from './code_graph/maintenance_gate.js';
 import {
   managerGraphAnalysis,
   managerGraphBuildCatalog,
@@ -194,6 +199,8 @@ interface ManagerResponseSink {
 type ManagerOperation<A> = Effect.Effect<A, unknown, ApplicationServices>;
 type ManagerEffectPromise = undefined;
 const NATIVE_RESOURCE_BACKEND = 'threadnote-native';
+const GRAPH_MAINTENANCE_BUSY_MESSAGE =
+  'Native code graph repair or maintenance is in progress. Wait for it to finish before starting or using Threadnote Manager.';
 
 type ConsolidationStatus = 'completed' | 'failed' | 'running';
 
@@ -241,6 +248,9 @@ const STATIC_FILES: Readonly<
 export function runManage(config: RuntimeConfig, options: ManageOptions) {
   return Effect.scoped(
     Effect.gen(function* () {
+      if (yield* codeGraphMaintenanceIntentActive(config.agentContextHome)) {
+        return yield* Effect.fail(new Error(GRAPH_MAINTENANCE_BUSY_MESSAGE));
+      }
       const crypto = yield* Crypto.Crypto;
       const token = Encoding.encodeBase64Url(yield* crypto.randomBytes(24));
       const server = yield* HttpServer.HttpServer;
@@ -457,6 +467,10 @@ const handleRequestLegacy = Effect.fn('manager.handleRequestLegacy')(function* (
     writeJson(response, 401, {error: 'Unauthorized'});
     return;
   }
+  if (isGraphApiPath(url.pathname) && (yield* codeGraphMaintenanceIntentActive(context.config.agentContextHome))) {
+    writeJson(response, 409, {error: GRAPH_MAINTENANCE_BUSY_MESSAGE});
+    return;
+  }
 
   if (request.method === 'GET' && url.pathname === '/api/tree') {
     const [tree, resourceTree] = yield* Effect.all([memoryTree(context.config), resourcesTree(context.config)]);
@@ -469,6 +483,17 @@ const handleRequestLegacy = Effect.fn('manager.handleRequestLegacy')(function* (
   }
   if (request.method === 'GET' && url.pathname === '/api/graphs/status') {
     writeJson(response, 200, yield* managerGraphBuildCatalog(context.config.agentContextHome));
+    return;
+  }
+  if (request.method === 'GET' && url.pathname === '/api/graphs/diagnostics') {
+    writeJson(
+      response,
+      200,
+      yield* inspectAllCodeGraphs(context.config.agentContextHome, {
+        analyze: url.searchParams.get('analyze') === 'true',
+        deep: url.searchParams.get('deep') === 'true',
+      }),
+    );
     return;
   }
   if (request.method === 'GET' && url.pathname === '/api/graphs/page') {
@@ -602,6 +627,9 @@ const handleRequestLegacy = Effect.fn('manager.handleRequestLegacy')(function* (
 
   const body = yield* readJsonBody(request);
   switch (url.pathname) {
+    case '/api/graphs/action':
+      writeJson(response, 200, yield* runManagerGraphAction(context.config, body, context.runEffect));
+      return;
     case '/api/memory/archive':
       requireConfirm(body);
       writeJson(
@@ -1438,6 +1466,113 @@ const runCaptured = Effect.fn('manager.runCaptured')(function* (
   return {output: captured.output};
 });
 
+const runManagerGraphAction = Effect.fn('manager.runGraphAction')(function* (
+  config: RuntimeConfig,
+  body: Record<string, unknown>,
+  runEffect?: ManagerEffectPromise,
+) {
+  const action = yield* Effect.try({
+    try: () => requireString(body.action, 'action'),
+    catch: error => error,
+  });
+  const dryRun = body.dryRun === true;
+  if (!dryRun && ['compact', 'purge', 'purge-all', 'purge-obsolete', 'repair'].includes(action)) {
+    yield* Effect.try({
+      try: () => requireConfirm(body),
+      catch: error => error,
+    });
+  }
+  if (action === 'repair') {
+    return yield* runCaptured(
+      () =>
+        runCodeGraphRepair(config, {
+          all: true,
+          deep: body.deep === true,
+          dryRun,
+        }),
+      runEffect,
+    );
+  }
+  if (action === 'purge-all') {
+    return yield* runCaptured(() => runCodeGraphPurge(config, {all: true, dryRun}), runEffect);
+  }
+  const [checkoutId, worktreeId] = yield* Effect.try({
+    try: () =>
+      [
+        requireGraphIdentity(body.checkoutId, 'checkoutId'),
+        requireGraphIdentity(body.worktreeId, 'worktreeId'),
+      ] as const,
+    catch: error => error,
+  });
+  const cwd = yield* resolveManagerGraphActionCwd(
+    config.agentContextHome,
+    checkoutId,
+    worktreeId,
+    optionalString(body.cwd),
+  );
+  switch (action) {
+    case 'compact':
+      return yield* runCaptured(
+        () => runCodeGraphCompact(config, {cwd, dryRun, force: body.force === true}),
+        runEffect,
+      );
+    case 'index':
+      return yield* runCaptured(() => runCodeGraphIndex(config, {cwd, full: body.full === true}), runEffect);
+    case 'purge':
+      return yield* runCaptured(() => runCodeGraphPurge(config, {cwd, dryRun}), runEffect);
+    case 'purge-obsolete':
+      return yield* runCaptured(() => runCodeGraphPurge(config, {cwd, dryRun, obsolete: true}), runEffect);
+    default:
+      return yield* Effect.fail(new Error(`Unsupported graph Manager action: ${action}`));
+  }
+});
+
+const resolveManagerGraphActionCwd = Effect.fn('manager.resolveGraphActionCwd')(function* (
+  threadnoteHome: string,
+  checkoutId: string,
+  worktreeId: string,
+  suppliedCwd?: string,
+) {
+  if (suppliedCwd) {
+    const path = yield* Path.Path;
+    if (!path.isAbsolute(suppliedCwd)) {
+      return yield* Effect.fail(new Error('Supply cwd as an absolute local worktree path.'));
+    }
+    const identity = yield* resolveRepositoryIdentity(suppliedCwd);
+    if (identity.checkoutId !== checkoutId || identity.worktreeId !== worktreeId) {
+      return yield* Effect.fail(new Error('The supplied worktree path does not match the selected graph identity.'));
+    }
+    return identity.repoRoot;
+  }
+  const statuses = yield* readAllCodeGraphBuildStatuses(threadnoteHome);
+  for (const status of statuses) {
+    if (
+      status.identity.checkoutId !== checkoutId ||
+      status.identity.worktreeId !== worktreeId ||
+      status.managerContext === undefined
+    ) {
+      continue;
+    }
+    const identity = yield* resolveRepositoryIdentity(status.managerContext.worktreePath).pipe(Effect.option);
+    if (
+      Option.isSome(identity) &&
+      identity.value.checkoutId === checkoutId &&
+      identity.value.worktreeId === worktreeId
+    ) {
+      return status.managerContext.worktreePath;
+    }
+  }
+  return yield* Effect.fail(
+    new Error('The selected graph has no current local worktree target. Supply cwd and refresh graph diagnostics.'),
+  );
+});
+
+function requireGraphIdentity(value: unknown, name: string): string {
+  const identity = requireString(value, name);
+  if (!/^[0-9a-f]{64}$/.test(identity)) throw new Error(`Provide ${name} as a 64-character graph identity.`);
+  return identity;
+}
+
 const memoryUriFor = Effect.fn('manager.memoryUriFor')(function* (
   config: RuntimeConfig,
   metadata: {
@@ -1566,6 +1701,10 @@ function publicConfig(config: RuntimeConfig): Record<string, unknown> {
 function isAuthorized(context: ApiContext, request: ManagerRequest): boolean {
   const auth = request.headers.authorization;
   return auth === `Bearer ${context.token}` || request.headers['x-threadnote-token'] === context.token;
+}
+
+function isGraphApiPath(pathname: string): boolean {
+  return pathname === '/api/graph' || pathname.startsWith('/api/graph/') || pathname.startsWith('/api/graphs');
 }
 
 function isSystemMemoryName(name: string): boolean {

--- a/src/manager_graph.tsx
+++ b/src/manager_graph.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import * as THREE from 'three';
+import type {CodeGraphDiagnosticsReport} from './code_graph/diagnostics.js';
 import {compareCodeUnits} from './code_graph/ordering.js';
 import {
   MANAGER_GRAPH_DEFAULT_EDGE_LIMIT,
@@ -85,6 +86,19 @@ export interface GraphCatalog {
   readonly waiterCount: number;
   readonly waiters: readonly GraphBuildStatus[];
 }
+
+export type GraphAdministrationAction =
+  | {
+      readonly action: 'compact' | 'index' | 'purge' | 'purge-obsolete';
+      readonly checkoutId: string;
+      readonly cwd?: string;
+      readonly dryRun?: boolean;
+      readonly force?: boolean;
+      readonly full?: boolean;
+      readonly worktreeId: string;
+    }
+  | {readonly action: 'purge-all'; readonly dryRun?: boolean}
+  | {readonly action: 'repair'; readonly deep?: boolean; readonly dryRun?: boolean};
 
 export interface GraphCatalogPage {
   readonly projectOffset: number;
@@ -1102,6 +1116,9 @@ export function graphOverviewSizeLabel(graph: GraphVisualization): string {
 }
 
 export function GraphWorkspace(props: {
+  readonly administration?: CodeGraphDiagnosticsReport;
+  readonly administrationBusy?: string;
+  readonly administrationOutput?: string;
   readonly catalog?: GraphCatalog;
   readonly loadAnalysis: (repositoryId: string, snapshotId: string, signal: AbortSignal) => Promise<GraphAnalysis>;
   readonly loadGraph: (
@@ -1138,6 +1155,8 @@ export function GraphWorkspace(props: {
     query: string,
     signal: AbortSignal,
   ) => Promise<GraphViewPage>;
+  readonly onAdministrationAction?: (action: GraphAdministrationAction) => void;
+  readonly onDiagnostics?: (options: {readonly analyze: boolean; readonly deep: boolean}) => void;
   readonly onRefresh: () => void;
 }): React.ReactElement {
   const [repositoryId, setRepositoryId] = useState('');
@@ -1689,6 +1708,13 @@ export function GraphWorkspace(props: {
       </header>
 
       <div className="graph-notices">
+        <GraphAdministration
+          busy={props.administrationBusy}
+          onAction={props.onAdministrationAction ?? (() => undefined)}
+          onDiagnostics={props.onDiagnostics ?? (() => undefined)}
+          output={props.administrationOutput}
+          report={props.administration}
+        />
         {activeBuilds.length > 0 ? (
           <div className="graph-build-status" aria-live="polite">
             {activeBuilds.map(build => (
@@ -3052,6 +3078,317 @@ function NodeInspector(props: {
   );
 }
 
+function GraphAdministration(props: {
+  readonly busy?: string;
+  readonly onAction: (action: GraphAdministrationAction) => void;
+  readonly onDiagnostics: (options: {readonly analyze: boolean; readonly deep: boolean}) => void;
+  readonly output?: string;
+  readonly report?: CodeGraphDiagnosticsReport;
+}): React.ReactElement {
+  const [analyze, setAnalyze] = useState(false);
+  const [deep, setDeep] = useState(false);
+  const [forceCompact, setForceCompact] = useState(false);
+  const blocked = props.busy !== undefined;
+  const confirmAction = (message: string, action: GraphAdministrationAction): void => {
+    if (window.confirm(message)) props.onAction(action);
+  };
+  const targetAction = (
+    managementAvailable: boolean,
+    action: Extract<GraphAdministrationAction, {readonly checkoutId: string}>,
+  ): GraphAdministrationAction | undefined => {
+    if (managementAvailable) return action;
+    const cwd = window.prompt(
+      'Threadnote has no current local path for this indexed view. Enter an absolute path to its worktree. The server will verify its graph identity before acting.',
+    );
+    return cwd?.trim() ? {...action, cwd: cwd.trim()} : undefined;
+  };
+  return (
+    <details className="graph-administration">
+      <summary>
+        <span>
+          <strong>Graph administration</strong>
+          <small>
+            {props.report
+              ? `${props.report.summary.databaseCount} databases · ${props.report.summary.readySnapshotCount} ready snapshots`
+              : 'Load home-wide status, diagnostics, and maintenance controls'}
+          </small>
+        </span>
+        {props.busy ? <em>{props.busy}…</em> : null}
+      </summary>
+      <div className="graph-administration-body">
+        <div className="graph-administration-toolbar">
+          <label className="check-row">
+            <input
+              checked={analyze}
+              disabled={blocked}
+              onChange={event => setAnalyze(event.target.checked)}
+              type="checkbox"
+            />
+            <span>Structural stats</span>
+          </label>
+          <label className="check-row">
+            <input
+              checked={deep}
+              disabled={blocked}
+              onChange={event => setDeep(event.target.checked)}
+              type="checkbox"
+            />
+            <span>Deep SQLite checks</span>
+          </label>
+          <button disabled={blocked} onClick={() => props.onDiagnostics({analyze, deep})} type="button">
+            Diagnose all
+          </button>
+          <button
+            disabled={blocked}
+            onClick={() => props.onAction({action: 'repair', deep, dryRun: true})}
+            type="button"
+          >
+            Preview repair
+          </button>
+          <button
+            disabled={blocked}
+            onClick={() =>
+              confirmAction(
+                deep
+                  ? 'Deep repair may discard corrupt disposable graph databases. Continue?'
+                  : 'Run immediate quick repair and pending graph schema migrations?',
+                {action: 'repair', deep},
+              )
+            }
+            type="button"
+          >
+            {deep ? 'Deep repair all' : 'Repair all'}
+          </button>
+          <button disabled={blocked} onClick={() => props.onAction({action: 'purge-all', dryRun: true})} type="button">
+            Preview purge all
+          </button>
+          <button
+            className="danger"
+            disabled={blocked}
+            onClick={() =>
+              confirmAction('Purge every local disposable native code graph index?', {action: 'purge-all'})
+            }
+            type="button"
+          >
+            Purge all
+          </button>
+        </div>
+        <label className="check-row graph-force-compact">
+          <input
+            checked={forceCompact}
+            disabled={blocked}
+            onChange={event => setForceCompact(event.target.checked)}
+            type="checkbox"
+          />
+          <span>Force compaction below the reviewed reclaimable-space threshold</span>
+        </label>
+        {props.report ? (
+          <div className="graph-database-grid">
+            {props.report.databases.map(database => {
+              const view = database.views.find(candidate => candidate.managementAvailable) ?? database.views[0];
+              const managementAvailable = view?.managementAvailable === true;
+              const repository = view?.repository.displayName ?? `Checkout ${database.checkoutId.slice(-8)}`;
+              const obsolete = props.report?.obsoleteStores.checkouts.find(
+                checkout => checkout.checkoutId === database.checkoutId,
+              );
+              const target = view ? {checkoutId: database.checkoutId, worktreeId: view.viewWorktreeId} : undefined;
+              return (
+                <article className="graph-database-card" key={database.checkoutId}>
+                  <header>
+                    <span>
+                      <strong>{repository}</strong>
+                      <small>{database.checkoutId.slice(-12)}</small>
+                    </span>
+                    <em className={`is-${database.health?.integrity ?? database.healthState}`}>
+                      {database.health?.integrity ?? database.healthState}
+                    </em>
+                  </header>
+                  <dl>
+                    <div>
+                      <dt>Snapshots</dt>
+                      <dd>{database.health?.readySnapshots ?? 0} ready</dd>
+                    </div>
+                    <div>
+                      <dt>Views</dt>
+                      <dd>{database.views.length}</dd>
+                    </div>
+                    <div>
+                      <dt>Storage</dt>
+                      <dd>
+                        {database.storage.state === 'available'
+                          ? formatGraphBytes(database.storage.totalBytes)
+                          : 'missing'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Jobs</dt>
+                      <dd>{database.builds.length + database.waiters.length}</dd>
+                    </div>
+                  </dl>
+                  <div className="graph-database-views">
+                    {database.views.map(candidate => (
+                      <div key={`${database.checkoutId}:${candidate.viewWorktreeId}`}>
+                        <strong>View {candidate.viewWorktreeId.slice(-8)}</strong>
+                        <span>
+                          {candidate.snapshot.fileCount.toLocaleString()} files ·{' '}
+                          {candidate.snapshot.symbolCount.toLocaleString()} symbols ·{' '}
+                          {candidate.snapshot.edgeCount.toLocaleString()} edges
+                        </span>
+                        {candidate.analysis ? (
+                          <small>
+                            {candidate.analysis.coverage.complete ? 'Complete' : 'Partial'} analysis ·{' '}
+                            {candidate.analysis.statistics.connectedComponentCount.toLocaleString()} components ·{' '}
+                            {candidate.analysis.statistics.communityCount.toLocaleString()} communities · average degree{' '}
+                            {candidate.analysis.statistics.averageDegree.toFixed(2)} · maximum{' '}
+                            {candidate.analysis.statistics.maximumDegree.toLocaleString()} ·{' '}
+                            {candidate.analysis.statistics.isolatedNodeCount.toLocaleString()} isolated
+                          </small>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                  {[...database.builds, ...database.waiters].map(job => (
+                    <p className="graph-database-job" key={`${job.buildId}:${job.coordination?.role ?? 'build'}`}>
+                      {job.identity.worktreeId.slice(-8)} · {job.state} · {job.phase}
+                      {job.subphase ? `/${job.subphase}` : ''} · {job.observation.liveness}
+                    </p>
+                  ))}
+                  {database.issues.map(issue => (
+                    <p className="graph-database-issue" key={`${database.checkoutId}:${issue.code}`}>
+                      {issue.code}: {issue.message}
+                    </p>
+                  ))}
+                  <div className="graph-database-actions">
+                    <button
+                      disabled={blocked || !target}
+                      onClick={() => {
+                        if (!target) return;
+                        const action = targetAction(managementAvailable, {action: 'index', ...target});
+                        if (action) props.onAction(action);
+                      }}
+                      type="button"
+                    >
+                      Index
+                    </button>
+                    <button
+                      disabled={blocked || !target}
+                      onClick={() => {
+                        if (!target) return;
+                        const action = targetAction(managementAvailable, {action: 'index', full: true, ...target});
+                        if (action) props.onAction(action);
+                      }}
+                      type="button"
+                    >
+                      Reindex
+                    </button>
+                    <button
+                      disabled={blocked || !target}
+                      onClick={() => {
+                        if (!target) return;
+                        const action = targetAction(managementAvailable, {
+                          action: 'compact',
+                          dryRun: true,
+                          force: forceCompact,
+                          ...target,
+                        });
+                        if (action) props.onAction(action);
+                      }}
+                      type="button"
+                    >
+                      Preview compact
+                    </button>
+                    <button
+                      disabled={blocked || !target}
+                      onClick={() => {
+                        if (!target) return;
+                        const action = targetAction(managementAvailable, {
+                          action: 'compact',
+                          force: forceCompact,
+                          ...target,
+                        });
+                        if (action) confirmAction('Compact this verified graph database now?', action);
+                      }}
+                      type="button"
+                    >
+                      Compact
+                    </button>
+                    {obsolete ? (
+                      <>
+                        <button
+                          disabled={blocked || !target}
+                          onClick={() => {
+                            if (!target) return;
+                            const action = targetAction(managementAvailable, {
+                              action: 'purge-obsolete',
+                              dryRun: true,
+                              ...target,
+                            });
+                            if (action) props.onAction(action);
+                          }}
+                          type="button"
+                        >
+                          Preview obsolete
+                        </button>
+                        <button
+                          disabled={blocked || !target}
+                          onClick={() => {
+                            if (!target) return;
+                            const action = targetAction(managementAvailable, {
+                              action: 'purge-obsolete',
+                              ...target,
+                            });
+                            if (action) {
+                              confirmAction(`Purge ${obsolete.fileCount} verified obsolete graph file(s)?`, action);
+                            }
+                          }}
+                          type="button"
+                        >
+                          Purge obsolete
+                        </button>
+                      </>
+                    ) : null}
+                    <button
+                      disabled={blocked || !target}
+                      onClick={() => {
+                        if (!target) return;
+                        const action = targetAction(managementAvailable, {action: 'purge', dryRun: true, ...target});
+                        if (action) props.onAction(action);
+                      }}
+                      type="button"
+                    >
+                      Preview purge
+                    </button>
+                    <button
+                      className="danger"
+                      disabled={blocked || !target}
+                      onClick={() => {
+                        if (!target) return;
+                        const action = targetAction(managementAvailable, {action: 'purge', ...target});
+                        if (action) confirmAction('Purge this disposable native graph index?', action);
+                      }}
+                      type="button"
+                    >
+                      Purge graph
+                    </button>
+                  </div>
+                  {!managementAvailable ? (
+                    <small className="graph-management-unavailable">
+                      Enter the local worktree path when prompted; Threadnote verifies it against this graph identity.
+                    </small>
+                  ) : null}
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <p>Load diagnostics to enumerate every local graph database.</p>
+        )}
+        {props.output ? <pre className="graph-administration-output">{props.output}</pre> : null}
+      </div>
+    </details>
+  );
+}
+
 function GraphBuildProgress(props: {
   readonly build: GraphBuildStatus;
   readonly repositories: readonly GraphRepositoryGroup[];
@@ -3420,8 +3757,15 @@ function formatGraphMilliseconds(milliseconds: number): string {
 function formatGraphBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes < 0) return 'unknown';
   if (bytes < 1_024) return `${Math.round(bytes)} B`;
-  if (bytes < 1_048_576) return `${(bytes / 1_024).toFixed(1)} KiB`;
-  return `${(bytes / 1_048_576).toFixed(bytes >= 10 * 1_048_576 ? 1 : 2)} MiB`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1_024;
+  let unit = units[0]!;
+  for (const candidate of units.slice(1)) {
+    if (value < 1_024) break;
+    value /= 1_024;
+    unit = candidate;
+  }
+  return `${value >= 10 ? value.toFixed(1) : value.toFixed(2)} ${unit}`;
 }
 
 function buildGraphLayout(

--- a/src/manager_graph.tsx
+++ b/src/manager_graph.tsx
@@ -3237,11 +3237,18 @@ function GraphAdministration(props: {
                         {candidate.analysis ? (
                           <small>
                             {candidate.analysis.coverage.complete ? 'Complete' : 'Partial'} analysis ·{' '}
-                            {candidate.analysis.statistics.connectedComponentCount.toLocaleString()} components ·{' '}
-                            {candidate.analysis.statistics.communityCount.toLocaleString()} communities · average degree{' '}
-                            {candidate.analysis.statistics.averageDegree.toFixed(2)} · maximum{' '}
-                            {candidate.analysis.statistics.maximumDegree.toLocaleString()} ·{' '}
-                            {candidate.analysis.statistics.isolatedNodeCount.toLocaleString()} isolated
+                            {candidate.analysis.coverage.topology.state === 'complete' ||
+                            candidate.analysis.coverage.topology.state === 'partial' ? (
+                              <>
+                                {candidate.analysis.statistics.connectedComponentCount.toLocaleString()} components ·{' '}
+                                {candidate.analysis.statistics.communityCount.toLocaleString()} communities · average
+                                degree {candidate.analysis.statistics.averageDegree.toFixed(2)} · maximum{' '}
+                                {candidate.analysis.statistics.maximumDegree.toLocaleString()} ·{' '}
+                                {candidate.analysis.statistics.isolatedNodeCount.toLocaleString()} isolated
+                              </>
+                            ) : (
+                              <>topology {candidate.analysis.coverage.topology.state}</>
+                            )}
                           </small>
                         ) : null}
                       </div>

--- a/src/manager_ui.tsx
+++ b/src/manager_ui.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import type {CodeGraphDiagnosticsReport} from './code_graph/diagnostics.js';
 import {
   GraphWorkspace,
   graphBuildIsActive,
@@ -9,6 +10,7 @@ import {
   graphStatusPollDelay,
   graphStatusRequiresCatalogRefresh,
   type GraphAnalysis,
+  type GraphAdministrationAction,
   type GraphCatalog,
   type GraphCatalogPage,
   type GraphNodeDetail,
@@ -164,6 +166,9 @@ function App(): React.ReactElement {
   const [state, setState] = useState<StateResponse | undefined>();
   const [graphCatalog, setGraphCatalog] = useState<GraphCatalog | undefined>();
   const graphCatalogRef = useRef<GraphCatalog | undefined>(undefined);
+  const [graphDiagnostics, setGraphDiagnostics] = useState<CodeGraphDiagnosticsReport | undefined>();
+  const [graphAdministrationBusy, setGraphAdministrationBusy] = useState<string | undefined>();
+  const [graphAdministrationOutput, setGraphAdministrationOutput] = useState('');
   const [tree, setTree] = useState<TreeNode | undefined>();
   const [resourceTree, setResourceTree] = useState<TreeNode | undefined>();
   const [shares, setShares] = useState<readonly ShareSummary[]>([]);
@@ -217,6 +222,9 @@ function App(): React.ReactElement {
   useEffect(() => {
     if (panel === 'doctor') {
       void loadDoctor(false);
+    }
+    if (panel === 'graph' && !graphDiagnostics) {
+      void refreshGraphDiagnostics({analyze: false, deep: false}, false);
     }
   }, [panel]);
 
@@ -334,6 +342,49 @@ function App(): React.ReactElement {
       if (notify) toastMessage('Graph indexes refreshed');
     } catch (cause) {
       toastMessage(errorMessage(cause));
+    }
+  }
+
+  async function refreshGraphDiagnostics(
+    options: {readonly analyze: boolean; readonly deep: boolean},
+    notify = true,
+  ): Promise<void> {
+    setGraphAdministrationBusy(
+      options.deep ? 'Deep-checking graphs' : options.analyze ? 'Analyzing graphs' : 'Diagnosing graphs',
+    );
+    try {
+      const report = await api<CodeGraphDiagnosticsReport>(
+        `/api/graphs/diagnostics?analyze=${options.analyze}&deep=${options.deep}`,
+      );
+      setGraphDiagnostics(report);
+      setGraphAdministrationOutput('');
+      if (notify) toastMessage('Graph diagnostics refreshed');
+    } catch (cause) {
+      const message = errorMessage(cause);
+      setGraphAdministrationOutput(message);
+      toastMessage(message);
+    } finally {
+      setGraphAdministrationBusy(undefined);
+    }
+  }
+
+  async function runGraphAdministration(action: GraphAdministrationAction): Promise<void> {
+    const label = graphAdministrationActionLabel(action);
+    setGraphAdministrationBusy(label);
+    try {
+      const result = await api<{readonly output: string}>('/api/graphs/action', {
+        ...action,
+        confirm: action.dryRun !== true,
+      });
+      await Promise.all([refreshGraphCatalog(false), refreshGraphDiagnostics({analyze: false, deep: false}, false)]);
+      setGraphAdministrationOutput(result.output);
+      toastMessage(`${label} complete`);
+    } catch (cause) {
+      const message = errorMessage(cause);
+      setGraphAdministrationOutput(message);
+      toastMessage(message);
+    } finally {
+      setGraphAdministrationBusy(undefined);
     }
   }
 
@@ -1003,6 +1054,9 @@ function App(): React.ReactElement {
         {panel === 'graph' ? (
           <section className="panel graph-panel is-active">
             <GraphWorkspace
+              administration={graphDiagnostics}
+              administrationBusy={graphAdministrationBusy}
+              administrationOutput={graphAdministrationOutput}
               catalog={graphCatalog}
               loadAnalysis={loadManagerGraphAnalysis}
               loadCatalogPage={loadManagerGraphCatalogPage}
@@ -1010,6 +1064,8 @@ function App(): React.ReactElement {
               loadNodeDetail={loadManagerGraphNodeDetail}
               loadQuery={loadManagerGraphQuery}
               loadViewsPage={loadManagerGraphViewsPage}
+              onAdministrationAction={action => void runGraphAdministration(action)}
+              onDiagnostics={options => void refreshGraphDiagnostics(options)}
               onRefresh={() => void refreshGraphCatalog(true)}
             />
           </section>
@@ -1782,6 +1838,23 @@ async function api<T>(
     throw new Error(data.error ?? `HTTP ${response.status}`);
   }
   return data as T;
+}
+
+export function graphAdministrationActionLabel(action: GraphAdministrationAction): string {
+  switch (action.action) {
+    case 'compact':
+      return action.dryRun ? 'Compaction preview' : 'Graph compaction';
+    case 'index':
+      return action.full ? 'Graph reindex' : 'Graph index';
+    case 'purge':
+      return action.dryRun ? 'Graph purge preview' : 'Graph purge';
+    case 'purge-all':
+      return action.dryRun ? 'All-graph purge preview' : 'All-graph purge';
+    case 'purge-obsolete':
+      return action.dryRun ? 'Obsolete-store preview' : 'Obsolete-store purge';
+    case 'repair':
+      return action.dryRun ? 'Graph repair preview' : action.deep ? 'Deep graph repair' : 'Graph repair';
+  }
 }
 
 function loadManagerGraph(

--- a/src/process_diagnostics.ts
+++ b/src/process_diagnostics.ts
@@ -278,20 +278,7 @@ export const runProcessDiagnostics = Effect.fn('processDiagnostics.run')(functio
     yield* Console.log('No live Threadnote processes found.');
     return;
   }
-  yield* Console.log('PID\tPPID\tROLE\tVERSION\tAGE\tRSS\tOPERATION');
-  for (const process of diagnostics.processes) {
-    yield* Console.log(
-      [
-        process.processId,
-        process.parentProcessId === 0 ? '-' : process.parentProcessId,
-        process.role,
-        process.releaseVersion ?? '-',
-        formatDuration(process.ageMilliseconds),
-        process.rssBytes === undefined ? 'unknown' : formatBytes(process.rssBytes),
-        process.currentOperation ?? '-',
-      ].join('\t'),
-    );
-  }
+  yield* Console.log(renderProcessDiagnosticsTable(diagnostics.processes));
   if (diagnostics.processes.some(process => process.role === 'legacy')) {
     yield* Console.log(
       'Legacy entries predate runtime registration; restart their owning agent sessions to retire old releases safely.',
@@ -299,6 +286,27 @@ export const runProcessDiagnostics = Effect.fn('processDiagnostics.run')(functio
   }
   if (diagnostics.truncated) yield* Console.log(`Showing the first ${PROCESS_DIAGNOSTICS_LIMIT} live processes.`);
 });
+
+export function renderProcessDiagnosticsTable(processes: readonly ThreadnoteProcessDiagnostic[]): string {
+  const rows = [
+    ['PID', 'PPID', 'ROLE', 'VERSION', 'AGE', 'RSS', 'OPERATION'],
+    ...processes.map(process => [
+      String(process.processId),
+      process.parentProcessId === 0 ? '-' : String(process.parentProcessId),
+      process.role,
+      process.releaseVersion ?? '-',
+      formatDuration(process.ageMilliseconds),
+      process.rssBytes === undefined ? 'unknown' : formatBytes(process.rssBytes),
+      process.currentOperation ?? '-',
+    ]),
+  ];
+  const widths = rows[0]!.map((_, column) => Math.max(...rows.map(row => row[column]!.length)));
+  return rows
+    .map(row =>
+      row.map((value, column) => (column === row.length - 1 ? value : value.padEnd(widths[column]! + 2))).join(''),
+    )
+    .join('\n');
+}
 
 export const legacyProcessDoctorCheck = Effect.fn('processDiagnostics.doctorCheck')(function* (
   config: Pick<RuntimeConfig, 'agentContextHome'>,

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -42,8 +42,10 @@ describe('Effect CLI', () => {
     const node = await runCli(['graph', 'node', '--help']);
     const neighbors = await runCli(['graph', 'neighbors', '--help']);
     const analyze = await runCli(['graph', 'analyze', '--help']);
+    const diagnostics = await runCli(['graph', 'diagnostics', '--help']);
     const exportHelp = await runCli(['graph', 'export', '--help']);
     const purge = await runCli(['graph', 'purge', '--help']);
+    const repair = await runCli(['graph', 'repair', '--help']);
 
     expect(graph.stdout).toContain('status');
     expect(graph.stdout).toContain('index');
@@ -54,8 +56,10 @@ describe('Effect CLI', () => {
     expect(graph.stdout).toContain('impact');
     expect(graph.stdout).toContain('communities');
     expect(graph.stdout).toContain('community');
+    expect(graph.stdout).toContain('diagnostics');
     expect(graph.stdout).toContain('groups');
     expect(graph.stdout).toContain('report');
+    expect(graph.stdout).toContain('repair');
     expect(query.stdout).toContain('--query string');
     expect(query.stdout).toContain('--cwd string');
     expect(node.stdout).toContain('--node-id string');
@@ -68,6 +72,9 @@ describe('Effect CLI', () => {
       'choices: stats, communities, community, groups, hubs, surprises, confidence, full',
     );
     expect(analyze.stdout).toContain('--community-id string');
+    expect(diagnostics.stdout).toContain('--analyze');
+    expect(diagnostics.stdout).toContain('--deep');
+    expect(diagnostics.stdout).not.toContain('--cwd');
     const community = await runCli(['graph', 'community', '--help']);
     expect(community.stdout).toContain('--community-id string');
     expect(community.stdout).toContain('--member-limit integer');
@@ -76,6 +83,9 @@ describe('Effect CLI', () => {
     expect(exportHelp.stdout).toContain('--node-limit string');
     expect(exportHelp.stdout).toContain('--edge-limit string');
     expect(purge.stdout).toContain('--obsolete');
+    expect(repair.stdout).toContain('--all');
+    expect(repair.stdout).toContain('--deep');
+    expect(repair.stdout).toContain('--dry-run');
   });
 
   it('keeps graph index JSON parseable while streaming structured progress to stderr', async () => {

--- a/test/unit/code-graph.diagnostics.test.ts
+++ b/test/unit/code-graph.diagnostics.test.ts
@@ -1,0 +1,126 @@
+import {afterEach, describe, expect, it} from 'vitest';
+import {Effect} from 'effect';
+import {
+  inspectAllCodeGraphs,
+  renderCodeGraphDiagnostics,
+  type CodeGraphDiagnosticsReport,
+} from '../../src/code_graph/diagnostics.js';
+import {runCodeGraphDiagnostics} from '../../src/code_graph/commands.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {
+  CODE_GRAPH_SCHEMA_VERSION,
+  type CodeGraphSnapshot,
+  type RepositoryIdentity,
+} from '../../src/code_graph/types.js';
+import {captureConsole} from '../../src/effect/console.js';
+import type {RuntimeConfig} from '../../src/types.js';
+import {join, mkdir, mkdtemp, rm, writeFile} from '../helpers/effect-filesystem.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+describe('all-code-graph diagnostics', () => {
+  const homes: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+  });
+
+  it('reports every database without a repository cwd and keeps JSON privacy-safe', async () => {
+    const home = await mkdtemp('threadnote-graph-diagnostics-');
+    homes.push(home);
+    const healthyCheckoutId = '1'.repeat(64);
+    const unreadableCheckoutId = '2'.repeat(64);
+    const healthyRoot = join(home, 'indexes', 'code-graph', 'repositories', healthyCheckoutId);
+    const healthyDatabase = join(healthyRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+    const unreadableRoot = join(home, 'indexes', 'code-graph', 'repositories', unreadableCheckoutId);
+    const unreadableDatabase = join(unreadableRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+    const identity = repositoryIdentity(home, healthyCheckoutId);
+    const snapshot = readySnapshot(identity);
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.activate(healthyDatabase, identity, snapshot, [], [], []);
+      }),
+    );
+    await writeFile(join(healthyRoot, 'graph-v2.sqlite'), 'obsolete graph\n');
+    await mkdir(unreadableRoot, {recursive: true});
+    await writeFile(unreadableDatabase, 'not a sqlite database');
+
+    const report = await runEffect(inspectAllCodeGraphs(home, {analyze: true}));
+    expect(report.summary).toMatchObject({
+      databaseCount: 2,
+      healthyDatabaseCount: 1,
+      readySnapshotCount: 1,
+      unreadableDatabaseCount: 1,
+      viewCount: 1,
+    });
+    expect(report.obsoleteStores).toMatchObject({fileCount: 1, unsafeEntryCount: 0});
+    expect(report.databases.find(database => database.checkoutId === healthyCheckoutId)).toMatchObject({
+      health: {integrity: 'ok', readySnapshots: 1},
+      healthState: 'checked',
+      views: [
+        {
+          analysis: {
+            coverage: {complete: true},
+            statistics: {snapshotEdgeCount: 0, snapshotNodeCount: 0},
+          },
+          repository: {displayName: 'acme/diagnostics'},
+          snapshot: {id: snapshot.id},
+        },
+      ],
+    });
+    const unreadable = report.databases.find(database => database.checkoutId === unreadableCheckoutId);
+    expect(unreadable?.healthState).toBe('unreadable');
+    expect(unreadable?.issues.map(issue => issue.code)).toContain('health-check-failed');
+    expect(JSON.stringify(report)).not.toContain(home);
+    expect(renderCodeGraphDiagnostics(report)).toContain('Native code graph diagnostics');
+
+    const config: RuntimeConfig = {
+      account: 'local',
+      agentContextHome: home,
+      agentId: 'threadnote',
+      manifestPath: join(home, 'manifest.yaml'),
+      user: 'tester',
+    };
+    const output = await runEffect(captureConsole(runCodeGraphDiagnostics(config, {analyze: true, json: true})));
+    const commandReport = JSON.parse(output.output) as CodeGraphDiagnosticsReport;
+    expect(commandReport).toMatchObject({
+      mode: {analyze: true, deep: false},
+      summary: {analysisCompleteCount: 1, databaseCount: 2},
+      type: 'code-graph-diagnostics',
+      version: 1,
+    });
+    expect(commandReport.databases.find(database => database.checkoutId === healthyCheckoutId)).toMatchObject({
+      views: [{analysis: {coverage: {complete: true}}}],
+    });
+  });
+});
+
+function repositoryIdentity(root: string, checkoutId: string): RepositoryIdentity {
+  return {
+    caseMode: 'sensitive',
+    checkoutId,
+    displayName: 'acme/diagnostics',
+    gitCommonDirectory: join(root, '.git'),
+    headCommit: 'abcdef0123456789abcdef0123456789abcdef01',
+    objectFormat: 'sha1',
+    repoRoot: root,
+    repositoryId: '3'.repeat(64),
+    worktreeId: '4'.repeat(64),
+  };
+}
+
+function readySnapshot(identity: RepositoryIdentity): CodeGraphSnapshot {
+  return {
+    commit: identity.headCommit,
+    completedAt: '2026-08-05T08:00:00.000Z',
+    dirty: false,
+    edgeCount: 0,
+    extractorSet: 'diagnostics-test',
+    fileCount: 0,
+    id: 'cgsn_diagnostics',
+    repositoryId: identity.repositoryId,
+    state: 'ready',
+    symbolCount: 0,
+    worktreeId: identity.worktreeId,
+  };
+}

--- a/test/unit/code-graph.diagnostics.test.ts
+++ b/test/unit/code-graph.diagnostics.test.ts
@@ -60,7 +60,7 @@ describe('all-code-graph diagnostics', () => {
       views: [
         {
           analysis: {
-            coverage: {complete: true},
+            coverage: {complete: true, topology: {state: 'complete'}},
             statistics: {snapshotEdgeCount: 0, snapshotNodeCount: 0},
           },
           repository: {displayName: 'acme/diagnostics'},
@@ -90,7 +90,7 @@ describe('all-code-graph diagnostics', () => {
       version: 1,
     });
     expect(commandReport.databases.find(database => database.checkoutId === healthyCheckoutId)).toMatchObject({
-      views: [{analysis: {coverage: {complete: true}}}],
+      views: [{analysis: {coverage: {complete: true, topology: {state: 'complete'}}}}],
     });
   });
 });

--- a/test/unit/code-graph.inventory.test.ts
+++ b/test/unit/code-graph.inventory.test.ts
@@ -16,6 +16,7 @@ describe('native code graph inventory policy', () => {
     expect(acceptsRepositoryPath('packages/.cache/result.ts', ignore)).toBe(false);
     expect(acceptsRepositoryPath('packages/app/node_modules/library/index.ts', ignore)).toBe(false);
     expect(acceptsRepositoryPath('dist/generated.ts', ignore)).toBe(false);
+    expect(acceptsRepositoryPath('graphify-out/graph.json', ignore)).toBe(false);
     expect(acceptsRepositoryPath('fixtures/drop.ts', ignore)).toBe(false);
     expect(acceptsRepositoryPath('fixtures/keep.ts', ignore)).toBe(true);
     expect(acceptsRepositoryPath('../outside.ts', ignore)).toBe(false);
@@ -39,7 +40,16 @@ describe('native code graph inventory policy', () => {
   });
 
   it('does not let broad package source roots re-include nested build output', () => {
-    for (const directory of ['bazel-bin', 'bazel-out', 'bazel-testlogs', 'bazel-workspace', 'build', 'dist', 'out']) {
+    for (const directory of [
+      'bazel-bin',
+      'bazel-out',
+      'bazel-testlogs',
+      'bazel-workspace',
+      'build',
+      'dist',
+      'graphify-out',
+      'out',
+    ]) {
       expect(
         acceptsRepositoryPath(`packages/app/${directory}/generated.js`, '', ['packages/app'], ['packages/app']),
         directory,

--- a/test/unit/code-graph.maintenance-bounded.test.ts
+++ b/test/unit/code-graph.maintenance-bounded.test.ts
@@ -1,11 +1,14 @@
 import {Database} from 'bun:sqlite';
 import {Clock, Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
 import {afterEach, describe, expect, it} from 'vitest';
+import {runCodeGraphRepair} from '../../src/code_graph/commands.js';
 import {codeGraphDoctorCheck, repairCodeGraphIndexes} from '../../src/code_graph/maintenance.js';
 import {codeGraphRepositoryLockPath, codeGraphWorktreeLockPath} from '../../src/code_graph/layout.js';
 import {CODE_GRAPH_SCHEMA_VERSION} from '../../src/code_graph/types.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {captureConsole} from '../../src/effect/console.js';
 import {withExclusiveFileLock} from '../../src/effect/file_lock.js';
+import type {RuntimeConfig} from '../../src/types.js';
 import {join, mkdir, mkdtemp, rm, writeFile} from '../helpers/effect-filesystem.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
@@ -203,6 +206,99 @@ describe('bounded code graph maintenance', () => {
         yield* store.initialize(databasePath);
       }),
     );
+    await expect(runEffect(codeGraphDoctorCheck(home))).resolves.toMatchObject({status: 'ok'});
+  });
+
+  it('explicitly migrates recoverable schemas without waiting for a graph query', async () => {
+    const home = await mkdtemp('threadnote-graph-maintenance-explicit-migration-');
+    homes.push(home);
+    const checkoutId = 'f'.repeat(64);
+    const repositoryRoot = join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+    const databasePath = join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+      }),
+    );
+    const interrupted = new Database(databasePath, {strict: true});
+    try {
+      interrupted.exec(`
+        DELETE FROM schema_metadata WHERE key = 'persistent_extension_schema_revision';
+        DROP TABLE building_materialization_batches;
+      `);
+    } finally {
+      interrupted.close(false);
+    }
+
+    const previewProgress: string[] = [];
+    const preview = await runEffect(
+      repairCodeGraphIndexes(home, true, state => Effect.sync(() => previewProgress.push(state.phase)), undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+      }),
+    );
+    expect(preview).toMatchObject({deferredDatabases: 0, migratedDatabases: 1});
+    expect(previewProgress).toEqual(['checking', 'migrating-schema']);
+    await expect(runEffect(codeGraphDoctorCheck(home))).resolves.toMatchObject({status: 'fail'});
+
+    const repairProgress: string[] = [];
+    const repair = await runEffect(
+      repairCodeGraphIndexes(home, false, state => Effect.sync(() => repairProgress.push(state.phase)), undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+      }),
+    );
+    expect(repair).toMatchObject({deferredDatabases: 0, migratedDatabases: 1});
+    expect(repairProgress).toEqual(['checking', 'migrating-schema']);
+    await expect(runEffect(codeGraphDoctorCheck(home))).resolves.toMatchObject({status: 'ok'});
+  });
+
+  it('exposes foreground schema migration through graph repair --all', async () => {
+    const home = await mkdtemp('threadnote-graph-repair-command-');
+    homes.push(home);
+    const checkoutId = '1'.repeat(64);
+    const databasePath = join(
+      home,
+      'indexes',
+      'code-graph',
+      'repositories',
+      checkoutId,
+      `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+    );
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+      }),
+    );
+    const interrupted = new Database(databasePath, {strict: true});
+    try {
+      interrupted.exec(`
+        DELETE FROM schema_metadata WHERE key = 'persistent_extension_schema_revision';
+        DROP TABLE building_materialization_batches;
+      `);
+    } finally {
+      interrupted.close(false);
+    }
+    const config: RuntimeConfig = {
+      account: 'local',
+      agentContextHome: home,
+      agentId: 'threadnote',
+      manifestPath: join(home, 'manifest.yaml'),
+      user: 'tester',
+    };
+
+    const output = await runEffect(captureConsole(runCodeGraphRepair(config, {all: true, json: true})));
+
+    expect(JSON.parse(output.output)).toMatchObject({
+      doctor: {status: 'ok'},
+      dryRun: false,
+      mode: 'quick',
+      summary: {deferredDatabases: 0, migratedDatabases: 1},
+      type: 'code-graph-repair',
+      version: 1,
+    });
     await expect(runEffect(codeGraphDoctorCheck(home))).resolves.toMatchObject({status: 'ok'});
   });
 });

--- a/test/unit/code-graph.storage.test.ts
+++ b/test/unit/code-graph.storage.test.ts
@@ -174,11 +174,10 @@ describe('active code graph storage', () => {
         yield* Deferred.succeed(release, undefined);
         yield* Effect.forEach(owners, Fiber.join, {concurrency: 2});
         const system = yield* SystemInfo;
-        const compacted = yield* compactCodeGraphStorage(
-          fixture.home,
-          fixture.checkoutId,
-          {dryRun: false, force: true},
-        ).pipe(
+        const compacted = yield* compactCodeGraphStorage(fixture.home, fixture.checkoutId, {
+          dryRun: false,
+          force: true,
+        }).pipe(
           Effect.provideService(
             SystemInfo,
             SystemInfo.of({...system, availableDiskBytes: () => Effect.succeed(Number.MAX_SAFE_INTEGER)}),

--- a/test/unit/code-graph.storage.test.ts
+++ b/test/unit/code-graph.storage.test.ts
@@ -173,10 +173,17 @@ describe('active code graph storage', () => {
         });
         yield* Deferred.succeed(release, undefined);
         yield* Effect.forEach(owners, Fiber.join, {concurrency: 2});
-        const compacted = yield* compactCodeGraphStorage(fixture.home, fixture.checkoutId, {
-          dryRun: false,
-          force: true,
-        });
+        const system = yield* SystemInfo;
+        const compacted = yield* compactCodeGraphStorage(
+          fixture.home,
+          fixture.checkoutId,
+          {dryRun: false, force: true},
+        ).pipe(
+          Effect.provideService(
+            SystemInfo,
+            SystemInfo.of({...system, availableDiskBytes: () => Effect.succeed(Number.MAX_SAFE_INTEGER)}),
+          ),
+        );
         return {compacted, deferred};
       }),
     );

--- a/test/unit/development-runtime.test.ts
+++ b/test/unit/development-runtime.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../scripts/development-runtime.js';
 import {
   activateLocalStandaloneRelease,
+  developmentRuntimeOwnershipConflict,
   parseLocalStandaloneInstallArguments,
 } from '../../scripts/install-local-standalone.js';
 import {commandLauncherPath, renderCommandShim} from '../../src/command-shim.js';
@@ -39,9 +40,123 @@ describe('exact-head development runtime', () => {
   it('parses only the explicit developer installer switches', () => {
     expect(parseLocalStandaloneInstallArguments(['--', '--terminate-superseded', '--json'])).toEqual({
       json: true,
+      takeOverGlobalRuntime: false,
       terminateSuperseded: true,
     });
+    expect(parseLocalStandaloneInstallArguments(['--take-over-global-runtime'])).toEqual({
+      json: false,
+      takeOverGlobalRuntime: true,
+      terminateSuperseded: false,
+    });
     expect(() => parseLocalStandaloneInstallArguments(['--force'])).toThrow('Unknown local standalone install option');
+  });
+
+  it('keeps global development runtime ownership stable across arbitrary checkout identities', () => {
+    fc.assert(
+      fc.property(sourceCommitArbitrary, sourceCommit => {
+        const activeVersion = developmentBuildVersion('4.0.3', sourceCommit);
+        const sourceCheckoutId = sourceCommit.padEnd(64, '0');
+        const otherSourceCheckoutId = `${sourceCheckoutId[0] === '0' ? '1' : '0'}${sourceCheckoutId.slice(1)}`;
+        const owner = {schemaVersion: 1 as const, sourceCheckoutId, version: activeVersion};
+
+        expect(developmentRuntimeOwnershipConflict(activeVersion, owner, sourceCheckoutId)).toBeUndefined();
+        expect(developmentRuntimeOwnershipConflict(activeVersion, owner, otherSourceCheckoutId)).toBe(
+          'different-source-checkout',
+        );
+        expect(
+          developmentRuntimeOwnershipConflict(
+            developmentBuildVersion('4.0.3', otherSourceCheckoutId.slice(0, 40)),
+            owner,
+            sourceCheckoutId,
+          ),
+        ).toBe('untracked-development-activation');
+        expect(developmentRuntimeOwnershipConflict(activeVersion, 'invalid', sourceCheckoutId)).toBe(
+          'invalid-ownership-record',
+        );
+        expect(developmentRuntimeOwnershipConflict('4.0.3', owner, otherSourceCheckoutId)).toBeUndefined();
+      }),
+      {numRuns: 200},
+    );
+  });
+
+  it('requires an explicit takeover before another checkout can replace an active development runtime', async () => {
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseSystem = yield* SystemInfo;
+          const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-development-owner-'});
+          const installRoot = path.join(root, 'install');
+          const binRoot = path.join(root, 'bin');
+          const sourceCommit = '9'.repeat(40);
+          const version = developmentBuildVersion('4.0.3', sourceCommit);
+          const releaseRoot = path.join(installRoot, 'versions', version);
+          const executableName = baseSystem.platform === 'win32' ? 'threadnote.exe' : 'threadnote';
+          const firstCheckoutId = '1'.repeat(64);
+          const secondCheckoutId = '2'.repeat(64);
+          yield* writeDevelopmentReleaseFixture(
+            fs,
+            path,
+            releaseRoot,
+            version,
+            sourceCommit,
+            executableName,
+            'owned-development-release',
+          );
+          yield* fs.writeFileString(
+            path.join(installRoot, 'active-release.json'),
+            `${JSON.stringify({releaseRoot, version})}\n`,
+            {mode: 0o600},
+          );
+          const ownerFile = path.join(installRoot, 'development-runtime-owner.json');
+          yield* fs.writeFileString(
+            ownerFile,
+            `${JSON.stringify({schemaVersion: 1, sourceCheckoutId: firstCheckoutId, version})}\n`,
+            {mode: 0o600},
+          );
+          const testSystem = SystemInfo.of({
+            ...baseSystem,
+            environment: () => ({
+              ...baseSystem.environment(),
+              THREADNOTE_BIN_DIR: binRoot,
+              THREADNOTE_INSTALL_ROOT: installRoot,
+            }),
+          });
+          const canonicalInstallRoot = yield* fs.realPath(installRoot);
+          const canonicalVersionsRoot = yield* fs.realPath(path.join(installRoot, 'versions'));
+          const activation = (takeOverGlobalRuntime: boolean) =>
+            activateLocalStandaloneRelease({
+              canonicalInstallRoot,
+              canonicalVersionsRoot,
+              commit: sourceCommit,
+              executableName,
+              releaseRoot,
+              reused: true,
+              sourceCheckoutId: secondCheckoutId,
+              stagedRoot: Option.none(),
+              takeOverGlobalRuntime,
+              terminateSuperseded: false,
+              version,
+            }).pipe(
+              Effect.provideService(CommandExecutor, versionCommandExecutor(version)),
+              Effect.provideService(SystemInfo, testSystem),
+            );
+
+          const refusal = String(yield* activation(false).pipe(Effect.flip));
+          const ownerAfterRefusal = yield* fs.readFileString(ownerFile);
+          const installed = yield* activation(true);
+          const ownerAfterTakeover = yield* fs.readFileString(ownerFile);
+          return {installed, ownerAfterRefusal, ownerAfterTakeover, refusal, root};
+        }),
+      ).pipe(Effect.provide(ApplicationLayer)),
+    );
+
+    expect(result.refusal).toContain('another source checkout owns');
+    expect(JSON.parse(result.ownerAfterRefusal)).toMatchObject({sourceCheckoutId: '1'.repeat(64)});
+    expect(JSON.parse(result.ownerAfterTakeover)).toMatchObject({sourceCheckoutId: '2'.repeat(64)});
+    expect(result.ownerAfterTakeover).not.toContain(result.root);
+    expect(result.installed.active).toBe(true);
   });
 
   it('derives an unambiguous SHA-bound development version for valid release versions', () => {
@@ -527,7 +642,9 @@ describe('exact-head development runtime', () => {
             executableName,
             releaseRoot,
             reused: true,
+            sourceCheckoutId: 'a'.repeat(64),
             stagedRoot: Option.none(),
+            takeOverGlobalRuntime: false,
             terminateSuperseded: false,
             version,
           }).pipe(
@@ -596,7 +713,9 @@ describe('exact-head development runtime', () => {
             executableName,
             releaseRoot,
             reused: false,
+            sourceCheckoutId: 'a'.repeat(64),
             stagedRoot: Option.some(stagedRoot),
+            takeOverGlobalRuntime: false,
             terminateSuperseded: false,
             version,
           }).pipe(
@@ -682,7 +801,9 @@ describe('exact-head development runtime', () => {
               executableName: 'threadnote',
               releaseRoot,
               reused: true,
+              sourceCheckoutId: 'a'.repeat(64),
               stagedRoot: Option.none(),
+              takeOverGlobalRuntime: false,
               terminateSuperseded: false,
               version,
             }).pipe(Effect.provideService(CommandExecutor, executor), Effect.provideService(SystemInfo, testSystem));
@@ -759,7 +880,9 @@ describe('exact-head development runtime', () => {
             executableName: 'threadnote',
             releaseRoot,
             reused: true,
+            sourceCheckoutId: 'a'.repeat(64),
             stagedRoot: Option.none(),
+            takeOverGlobalRuntime: false,
             terminateSuperseded: false,
             version,
           }).pipe(Effect.provideService(SystemInfo, testSystem));
@@ -830,7 +953,9 @@ describe('exact-head development runtime', () => {
             executableName,
             releaseRoot,
             reused: true,
+            sourceCheckoutId: 'a'.repeat(64),
             stagedRoot: Option.none(),
+            takeOverGlobalRuntime: false,
             terminateSuperseded: false,
             version,
           }).pipe(
@@ -921,7 +1046,9 @@ describe('exact-head development runtime', () => {
             executableName,
             releaseRoot,
             reused: true,
+            sourceCheckoutId: 'a'.repeat(64),
             stagedRoot: Option.none(),
+            takeOverGlobalRuntime: false,
             terminateSuperseded: false,
             version,
           }).pipe(
@@ -1004,7 +1131,9 @@ describe('exact-head development runtime', () => {
             executableName,
             releaseRoot,
             reused: false,
+            sourceCheckoutId: 'a'.repeat(64),
             stagedRoot: Option.some(stagedRoot),
+            takeOverGlobalRuntime: false,
             terminateSuperseded: false,
             version,
           }).pipe(

--- a/test/unit/manager.test.ts
+++ b/test/unit/manager.test.ts
@@ -13,6 +13,7 @@ import {
   parseDoctorChecksFromOutput,
   readManagedMemory,
   resourcesTree,
+  runManage,
 } from '../../src/manager.js';
 import {pruneSelectedMemoryUris, selectableMemoryUris, type TreeNode} from '../../src/manager_ui.js';
 import type {RuntimeConfig} from '../../src/types.js';
@@ -23,6 +24,7 @@ import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {makeCodeGraphBuildReporter} from '../../src/code_graph/build_status.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {withCodeGraphMaintenanceIntent} from '../../src/code_graph/maintenance_gate.js';
 import type {CodeGraphWorkspace} from '../../src/code_graph/languages/types.js';
 import {
   CODE_GRAPH_EXTRACTOR_SET_VERSION,
@@ -377,6 +379,14 @@ describe('manager catalog', () => {
     vi.mocked(memory.runRecall)
       .mockReset()
       .mockImplementation((_config, options) => Console.log(`recall result: ${options.query}`));
+  });
+
+  it('refuses to start while native graph repair or maintenance is active', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    await expect(
+      runEffect(withCodeGraphMaintenanceIntent(config.agentContextHome, runManage(config, {open: false, uiPort: 0}))),
+    ).rejects.toThrow('Native code graph repair or maintenance is in progress');
   });
 
   it('maps local memory files into Threadnote URIs with parsed metadata', async () => {
@@ -814,6 +824,90 @@ describe('manager http API', () => {
       expect(analysisResponse.status).toBe(200);
       expect(analysis.statistics).toMatchObject({analyzedEdgeCount: 1_602, analyzedNodeCount: 523});
       expect(analysis.trust.classification).toBe('untrusted-repository-data');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('serves home-wide graph diagnostics and safety-gated lifecycle actions', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    await seedManagerGraph(config);
+    const server = await startServer(config, 'secret');
+    try {
+      const headers = {authorization: 'Bearer secret', 'content-type': 'application/json'};
+      const diagnosticsResponse = await fetch(`${server.url}/api/graphs/diagnostics?analyze=true`, {headers});
+      const diagnostics = (await diagnosticsResponse.json()) as {
+        readonly databases: readonly {
+          readonly health: {readonly integrity: string};
+          readonly views: readonly unknown[];
+        }[];
+        readonly mode: {readonly analyze: boolean; readonly deep: boolean};
+        readonly summary: {readonly databaseCount: number; readonly readySnapshotCount: number};
+        readonly type: string;
+      };
+      expect(diagnosticsResponse.status).toBe(200);
+      expect(diagnostics).toMatchObject({
+        mode: {analyze: true, deep: false},
+        summary: {databaseCount: 1, readySnapshotCount: 1},
+        type: 'code-graph-diagnostics',
+      });
+      expect(diagnostics.databases[0]).toMatchObject({health: {integrity: 'ok'}});
+
+      const repairPreview = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({action: 'repair', dryRun: true}),
+        headers,
+        method: 'POST',
+      });
+      const repairOutput = (await repairPreview.json()) as {readonly output: string};
+      expect(repairPreview.status).toBe(200);
+      expect(repairOutput.output).toContain('Would repair 1 native code graph database(s)');
+
+      const purgePreview = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({action: 'purge-all', dryRun: true}),
+        headers,
+        method: 'POST',
+      });
+      expect(purgePreview.status).toBe(200);
+      expect(await purgePreview.json()).toMatchObject({output: expect.stringContaining('Would remove derived')});
+
+      const refusedPurge = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({action: 'purge-all'}),
+        headers,
+        method: 'POST',
+      });
+      expect(refusedPurge.status).toBe(500);
+      expect(await refusedPurge.json()).toMatchObject({error: 'Set confirm=true for this action.'});
+
+      const relativeTarget = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({action: 'index', checkoutId: 'a'.repeat(64), cwd: '.', worktreeId: 'c'.repeat(64)}),
+        headers,
+        method: 'POST',
+      });
+      expect(relativeTarget.status).toBe(500);
+      expect(await relativeTarget.json()).toMatchObject({error: 'Supply cwd as an absolute local worktree path.'});
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns a busy response for graph APIs when maintenance starts after Manager', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const server = await startServer(config, 'secret');
+    try {
+      const response = await runEffect(
+        withCodeGraphMaintenanceIntent(
+          config.agentContextHome,
+          Effect.promise(() =>
+            fetch(`${server.url}/api/graphs/diagnostics`, {headers: {authorization: 'Bearer secret'}}),
+          ),
+        ),
+      );
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        error: expect.stringContaining('Native code graph repair or maintenance is in progress'),
+      });
     } finally {
       await server.close();
     }

--- a/test/unit/process-diagnostics.test.ts
+++ b/test/unit/process-diagnostics.test.ts
@@ -10,6 +10,7 @@ import {SystemInfo} from '../../src/effect/system.js';
 import {
   readThreadnoteProcessDiagnostics,
   legacyProcessDoctorCheck,
+  renderProcessDiagnosticsTable,
   threadnoteHomeForProcess,
   withThreadnoteProcessActivity,
   withThreadnoteProcessRegistration,
@@ -36,6 +37,39 @@ afterEach(async () => {
 });
 
 describe('process diagnostics', () => {
+  it('aligns operation values with their header when preceding cells have different widths', () => {
+    expect(
+      renderProcessDiagnosticsTable([
+        {
+          ageMilliseconds: (12 * 60 * 60 + 55 * 60) * 1_000,
+          currentOperation: 'mcp-server',
+          parentProcessId: 42_478,
+          processId: 79_155,
+          releaseVersion: '4.0.3',
+          role: 'mcp',
+          rssBytes: 138.2 * 1024 * 1024,
+          startedAt: '2026-08-04T00:00:00.000Z',
+        },
+        {
+          ageMilliseconds: (44 * 60 + 23) * 1_000,
+          currentOperation: 'repair',
+          parentProcessId: 1_100,
+          processId: 71_873,
+          releaseVersion: '4.0.3',
+          role: 'cli',
+          rssBytes: 78 * 1024 * 1024,
+          startedAt: '2026-08-05T00:00:00.000Z',
+        },
+      ]),
+    ).toBe(
+      [
+        'PID    PPID   ROLE  VERSION  AGE     RSS        OPERATION',
+        '79155  42478  mcp   4.0.3    12h55m  138.2 MiB  mcp-server',
+        '71873  1100   cli   4.0.3    44m23s  78.0 MiB   repair',
+      ].join('\n'),
+    );
+  });
+
   it.effect('reports a validated pre-registry release lease without exposing its private fields', () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/test/unit/process-diagnostics.test.ts
+++ b/test/unit/process-diagnostics.test.ts
@@ -70,6 +70,51 @@ describe('process diagnostics', () => {
     );
   });
 
+  it.prop(
+    'keeps every operation value under its header for arbitrary preceding column widths',
+    {
+      processes: FC.array(
+        FC.record({
+          ageMilliseconds: FC.integer({max: 14 * 24 * 60 * 60 * 1_000, min: 0}),
+          currentOperation: FC.option(
+            FC.constantFrom('diagnostics', 'index-repository', 'mcp-server', 'repair', 'repository-lock'),
+            {nil: undefined},
+          ),
+          parentProcessId: FC.integer({max: 9_999_999, min: 0}),
+          processId: FC.integer({max: 9_999_999, min: 1}),
+          releaseVersion: FC.option(
+            FC.constantFrom('4.0.3', '4.0.3-local.g0123456789abcdef0123456789abcdef01234567', 'unknown-build'),
+            {nil: undefined},
+          ),
+          role: FC.constantFrom(
+            'cli' as const,
+            'graph-builder' as const,
+            'graph-parser-worker' as const,
+            'graph-waiter' as const,
+            'legacy' as const,
+            'local-model-worker' as const,
+            'manager' as const,
+            'mcp' as const,
+          ),
+          rssBytes: FC.option(FC.integer({max: 8 * 1024 * 1024 * 1024, min: 0}), {nil: undefined}),
+          startedAt: FC.constant('2026-08-05T00:00:00.000Z'),
+        }),
+        {maxLength: 30, minLength: 1},
+      ),
+    },
+    ({processes}) => {
+      const lines = renderProcessDiagnosticsTable(processes).split('\n');
+      const operationColumn = lines[0]!.indexOf('OPERATION');
+
+      expect(operationColumn).toBeGreaterThan(0);
+      expect(lines).toHaveLength(processes.length + 1);
+      for (const [index, process] of processes.entries()) {
+        expect(lines[index + 1]!.slice(operationColumn)).toBe(process.currentOperation ?? '-');
+      }
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+
   it.effect('reports a validated pre-registry release lease without exposing its private fields', () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -1300,6 +1300,8 @@ threadnote share conflict resolve <id> --take shared`,
             type: 'code',
             language: 'sh',
             code: `threadnote graph status
+threadnote graph diagnostics --analyze
+threadnote graph repair --all --dry-run
 threadnote graph index
 threadnote graph index --full
 threadnote graph watch
@@ -1324,6 +1326,10 @@ threadnote graph compact --dry-run`,
           {
             type: 'paragraph',
             text: 'graph status reports exact active database, WAL, and SHM bytes and, when no build owns the checkout, page count, freelist pages, and reclaimable bytes. Threadnote recommends graph compact once at least 512 MiB and 20% are reclaimable. The explicit command uses zero-wait maintenance/build locks, pre/post verification, and SQLite transactional VACUUM; use --dry-run to preview or --force below the threshold.',
+          },
+          {
+            type: 'paragraph',
+            text: 'graph diagnostics is home-wide and does not depend on the current directory. It reports every local graph database, ready snapshot, indexed view, build, waiter, storage total, health issue, and obsolete store. Add --analyze for bounded structural statistics per indexed view, --deep for full SQLite integrity checks, or --json for the versioned diagnostic document. graph repair --all immediately performs pending persistent-schema migrations; its default pass is quick, while --deep opts into a full scan and destructive recovery of disposable corrupt stores. Both repair modes support --dry-run.',
           },
           {
             type: 'paragraph',


### PR DESCRIPTION
## Summary

- add home-wide native graph diagnostics and immediate repair, index, reindex, compact, and purge controls to the CLI and Manager
- keep Manager startup fail-fast during graph maintenance, report persisted topology correctly, and align process diagnostics
- remove Graphify artifacts from Threadnote indexing and use the native graph surface for repository inspection
- prevent silent exact-HEAD global runtime takeover by another worktree with an opaque checkout-ownership record and explicit override
- harden the load-sensitive compaction test, add property coverage for runtime ownership and process-table alignment, and prepare the 4.0.5 release source

## Verification

- `bun run lint`
- `bun run prettier:check`
- `bun run typecheck`
- `bun run test` — 188 files, 1,794 tests
- `bun run build`
- exact-HEAD global install and doctor verification at `f3a8855ca02841dce5ad64b25a1c56edac30db69`
- global CLI smoke: version, all-graph diagnostics JSON, process table, and path-free mode-0600 ownership receipt
