### PR TITLE
Keep graph storage bounded and improve Manager workflows

### DIFF
--- a/.github/release-notes/v4.0.6.md
+++ b/.github/release-notes/v4.0.6.md
@@ -1,0 +1,15 @@
+## What's new
+
+Threadnote 4.0.6 keeps native code graph storage bounded and makes Manager administration safer and easier.
+
+- **Remove orphaned or incompatible graphs without guessing a worktree path.** Manager can purge a graph by its
+  validated checkout identity even when the original worktree no longer exists, while refusing symbolic-link and
+  same-path replacement races.
+- **Stop superseded snapshots from becoming storage junk.** Reader leases now preserve exactly the views and clean
+  bases they still need, then retire displaced overlays and detached bases when the final reader finishes. Cleanup
+  proceeds in bounded background pages so ordinary queries stay responsive.
+- **Use consistent, accessible Manager dialogs.** Graph actions and other Manager workflows now use styled in-app
+  confirmation and input dialogs with safe destructive-action focus, required-field validation, keyboard behavior,
+  and queued requests instead of native browser prompts.
+- **Select or create projects and teams quickly.** Project and team fields are searchable autocomplete selectors that
+  deduplicate existing choices and offer new values explicitly.

--- a/README.md
+++ b/README.md
@@ -231,9 +231,11 @@ with `--dry-run`.
 
 The local Manager exposes the same graph administration lifecycle from its Graph panel: home-wide quick or deep
 diagnostics, immediate repair, per-view status, index/reindex, compaction previews, obsolete-store pruning, and
-per-graph or all-graph purge. Destructive actions require an explicit browser confirmation. When an older indexed
-view has no live worktree association, Manager asks for a local path and verifies its checkout/worktree identity before
-acting.
+per-graph or all-graph purge. Destructive actions require an explicit browser confirmation. Per-graph purge targets the
+inventoried checkout directly, including incompatible or orphaned stores with no live worktree. Source-reading actions
+such as index and reindex, plus worktree-bound compaction, still ask for a local path when necessary and verify its checkout/worktree identity
+before acting. The CLI equivalent for an orphaned store is
+`threadnote graph purge --checkout-id <64-character-checkout-id>`; preview it first with `--dry-run`.
 
 `threadnote manage` fails fast when graph repair or another native graph maintenance operation is already active;
 an already-running Manager returns an explicit busy response for graph requests until maintenance finishes.

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "@vscode/tree-sitter-wasm": "0.3.1",
         "effect": "4.0.0-beta.102",
         "fast-check": "4.9.0",
+        "happy-dom": "^20.11.1",
         "husky": "^9.1.7",
         "js-yaml": "^5.2.2",
         "mitata": "1.0.34",
@@ -391,6 +392,8 @@
 
     "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
@@ -493,6 +496,8 @@
 
     "browserslist": ["browserslist@4.28.7", "", { "dependencies": { "baseline-browser-mapping": "^2.10.44", "caniuse-lite": "^1.0.30001806", "electron-to-chromium": "^1.5.393", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
@@ -587,6 +592,8 @@
 
     "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "env-var": ["env-var@7.5.0", "", {}, "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA=="],
@@ -678,6 +685,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1222,6 +1231,8 @@
     "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/ui", "happy-dom", "jsdom"], "bin": "vitest.mjs" }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
 
     "web-tree-sitter": ["web-tree-sitter@0.26.11", "", {}, "sha512-Q5Dm3YTIXSXuH6FxX6RuzX2Qwpc4DPGiYMU87Wg5Z8OIStiQFiUex4zMDc0vBTw78EphaYJacncJghCHzbZptg=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 

--- a/manager/app.css
+++ b/manager/app.css
@@ -906,6 +906,63 @@ dd {
   color: var(--accent);
 }
 
+.manager-autocomplete {
+  min-width: 0;
+  position: relative;
+  width: 100%;
+}
+
+.manager-autocomplete-menu {
+  background: #111821;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  box-shadow: var(--shadow);
+  display: grid;
+  left: 0;
+  max-height: min(280px, 36dvh);
+  overflow: auto;
+  padding: 5px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+  z-index: 30;
+}
+
+.manager-autocomplete-menu button {
+  background: transparent;
+  border-color: transparent;
+  border-radius: 6px;
+  justify-content: flex-start;
+  min-height: 32px;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.manager-autocomplete-menu button:hover,
+.manager-autocomplete-menu button.is-active {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+}
+
+.manager-autocomplete-menu button.is-create {
+  color: var(--accent);
+  font-weight: 650;
+}
+
+.manager-autocomplete-menu button.is-create span {
+  align-items: center;
+  border: 1px solid var(--accent-line);
+  border-radius: 5px;
+  display: inline-flex;
+  height: 18px;
+  justify-content: center;
+  margin-right: 8px;
+  width: 18px;
+}
+
 .inspector textarea {
   height: 220px;
   margin: 8px 0;
@@ -2425,6 +2482,160 @@ dd {
   width: 100%;
 }
 
+.manager-dialog {
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  max-height: min(760px, calc(100dvh - 32px));
+  max-width: none;
+  overflow: visible;
+  padding: 0;
+  width: min(540px, calc(100vw - 32px));
+}
+
+.manager-dialog::backdrop {
+  backdrop-filter: blur(7px);
+  background: rgba(3, 6, 10, 0.72);
+}
+
+.manager-dialog-card {
+  background: radial-gradient(circle at 90% 0, rgba(103, 232, 199, 0.08), transparent 220px), var(--panel);
+  border: 1px solid var(--accent-line);
+  border-radius: 16px;
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.56);
+  display: grid;
+  max-height: min(760px, calc(100dvh - 32px));
+  overflow: hidden;
+}
+
+.manager-dialog-card.is-danger {
+  background: radial-gradient(circle at 90% 0, rgba(255, 122, 122, 0.1), transparent 220px), var(--panel);
+  border-color: rgba(255, 122, 122, 0.42);
+}
+
+.manager-dialog-header {
+  align-items: flex-start;
+  border-bottom: 1px solid var(--line-soft);
+  display: flex;
+  gap: 13px;
+  padding: 20px 22px 17px;
+}
+
+.manager-dialog-mark {
+  align-items: center;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 9px;
+  color: var(--accent);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 18px;
+  font-weight: 750;
+  height: 34px;
+  justify-content: center;
+  width: 34px;
+}
+
+.manager-dialog-card.is-danger .manager-dialog-mark {
+  background: var(--danger-soft);
+  border-color: rgba(255, 122, 122, 0.38);
+  color: var(--danger);
+}
+
+.manager-dialog-header p {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 3px;
+  text-transform: uppercase;
+}
+
+.manager-dialog-header h2 {
+  font-size: 21px;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.manager-dialog-body {
+  overflow-y: auto;
+  padding: 18px 22px 20px;
+}
+
+.manager-dialog-body > p {
+  color: #c8d0db;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.manager-dialog-detail {
+  background: var(--code-bg);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  display: block;
+  font-size: 12px;
+  line-height: 1.45;
+  margin-top: 13px;
+  max-height: 96px;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  padding: 9px 10px;
+  white-space: pre-wrap;
+}
+
+.manager-dialog-fields {
+  display: grid;
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.manager-dialog-field {
+  display: grid;
+  gap: 6px;
+}
+
+.manager-dialog-field > label {
+  align-items: center;
+  display: flex;
+  font-size: 13px;
+  font-weight: 650;
+  justify-content: space-between;
+}
+
+.manager-dialog-field > label em {
+  color: var(--muted);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.manager-dialog-fields small {
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.manager-dialog-fields strong {
+  color: var(--danger);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.manager-dialog-actions {
+  background: rgba(8, 11, 16, 0.48);
+  border-top: 1px solid var(--line-soft);
+  display: flex;
+  gap: 9px;
+  justify-content: flex-end;
+  padding: 14px 22px 16px;
+}
+
+.manager-dialog-actions button {
+  min-width: 108px;
+}
+
 .toast {
   background: #050508;
   border: 1px solid var(--line);
@@ -2581,6 +2792,23 @@ dd {
 }
 
 @media (max-width: 640px) {
+  .manager-dialog {
+    width: min(100% - 20px, 540px);
+  }
+
+  .manager-dialog-header,
+  .manager-dialog-body {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .manager-dialog-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
   .workspace-header {
     align-items: stretch;
     flex-direction: column;

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@vscode/tree-sitter-wasm": "0.3.1",
     "effect": "4.0.0-beta.102",
     "fast-check": "4.9.0",
+    "happy-dom": "^20.11.1",
     "husky": "^9.1.7",
     "js-yaml": "^5.2.2",
     "mitata": "1.0.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -10,6 +10,7 @@ import {
   repairCodeGraphIndexes,
   inspectObsoleteCodeGraphStores,
   purgeAllCodeGraphIndexes,
+  purgeCodeGraphIndex,
   purgeObsoleteCodeGraphStores,
   type CodeGraphMaintenanceProgress,
   type CodeGraphRepairCompletion,
@@ -746,16 +747,28 @@ export const runCodeGraphImpact = Effect.fn('codeGraph.command.impact')(function
 
 export const runCodeGraphPurge = Effect.fn('codeGraph.command.purge')(function* (
   config: RuntimeConfig,
-  options: CwdOption & {readonly all?: boolean; readonly dryRun?: boolean; readonly obsolete?: boolean},
+  options: CwdOption & {
+    readonly all?: boolean;
+    readonly checkoutId?: string;
+    readonly dryRun?: boolean;
+    readonly obsolete?: boolean;
+    readonly waitTimeoutMilliseconds?: number;
+  },
 ) {
   const path = yield* Path.Path;
-  if (options.all && options.obsolete) {
-    return yield* Effect.fail(new Error('Use either --all or --obsolete, not both.'));
+  if (options.all && (options.checkoutId !== undefined || options.obsolete)) {
+    return yield* Effect.fail(new Error('Use --all by itself, without --checkout-id or --obsolete.'));
+  }
+  if (options.checkoutId !== undefined && options.cwd !== undefined) {
+    return yield* Effect.fail(new Error('Use either --checkout-id or --cwd, not both.'));
   }
   if (options.obsolete) {
-    const cwd = yield* commandCwd(options.cwd);
-    const identity = yield* resolveRepositoryIdentity(cwd);
-    const summary = yield* purgeObsoleteCodeGraphStores(config.agentContextHome, identity.checkoutId, {
+    let checkoutId = options.checkoutId;
+    if (checkoutId === undefined) {
+      const cwd = yield* commandCwd(options.cwd);
+      checkoutId = (yield* resolveRepositoryIdentity(cwd)).checkoutId;
+    }
+    const summary = yield* purgeObsoleteCodeGraphStores(config.agentContextHome, checkoutId, {
       dryRun: options.dryRun === true,
     });
     const action = options.dryRun ? 'Would remove' : 'Removed';
@@ -775,6 +788,20 @@ export const runCodeGraphPurge = Effect.fn('codeGraph.command.purge')(function* 
     }
     const removed = yield* purgeAllCodeGraphIndexes(config.agentContextHome);
     yield* Console.log(`Removed derived code graph indexes: ${removed}`);
+    return;
+  }
+  if (options.checkoutId !== undefined) {
+    const summary = yield* purgeCodeGraphIndex(config.agentContextHome, options.checkoutId, {
+      dryRun: options.dryRun === true,
+      waitTimeoutMilliseconds: options.waitTimeoutMilliseconds,
+    });
+    if (!summary.existed) {
+      yield* Console.log(`No derived code graph index exists for checkout ${summary.checkoutId.slice(0, 12)}.`);
+      return;
+    }
+    yield* Console.log(
+      `${options.dryRun ? 'Would remove' : 'Removed'} derived code graph index for checkout ${summary.checkoutId.slice(0, 12)}.`,
+    );
     return;
   }
   const service = yield* CodeGraphQueryService;

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -1,5 +1,5 @@
 import * as SqliteClient from '@effect/sql-sqlite-bun/SqliteClient';
-import {Effect, FileSystem, Path} from 'effect';
+import {Crypto, Effect, FileSystem, Option, Path} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import type {DoctorCheck} from '../types.js';
 import {isFileLockTimeout, withExclusiveFileLock} from '../effect/file_lock.js';
@@ -80,7 +80,14 @@ export interface CodeGraphIndexPurgeSummary {
 }
 
 export interface CodeGraphIndexPurgeInterlock {
+  readonly beforeRemoval?: () => Effect.Effect<void>;
   readonly beforeVerification?: () => Effect.Effect<void>;
+}
+
+interface CodeGraphIndexPurgeTarget {
+  readonly dev: number;
+  readonly ino: number;
+  readonly path: string;
 }
 
 export interface CodeGraphRepairCompletion {
@@ -608,6 +615,7 @@ export const purgeCodeGraphIndex = Effect.fn('codeGraph.purgeIndex')(function* (
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const crypto = yield* Crypto.Crypto;
   if (!/^[0-9a-f]{64}$/.test(checkoutId)) {
     return yield* Effect.fail(new Error('Code graph checkout identity is invalid.'));
   }
@@ -632,11 +640,22 @@ export const purgeCodeGraphIndex = Effect.fn('codeGraph.purgeIndex')(function* (
               const initial = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
               yield* options.interlock?.beforeVerification?.() ?? Effect.void;
               const verified = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
-              if (initial !== verified) {
+              if (!sameCodeGraphIndexPurgeTarget(initial, verified)) {
                 return yield* Effect.fail(new Error('Code graph checkout target changed before purge.'));
               }
               if (verified !== undefined && !options.dryRun) {
-                yield* fs.remove(verified, {force: true, recursive: true});
+                yield* options.interlock?.beforeRemoval?.() ?? Effect.void;
+                const quarantine = path.join(
+                  path.dirname(verified.path),
+                  `.${checkoutId}.${yield* crypto.randomUUIDv4}.purging`,
+                );
+                yield* fs.rename(verified.path, quarantine);
+                const quarantined = yield* inspectQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine);
+                if (!sameCodeGraphIndexPurgeTarget(verified, quarantined)) {
+                  yield* restoreQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine, verified.path);
+                  return yield* Effect.fail(new Error('Code graph checkout target changed before purge.'));
+                }
+                yield* fs.remove(quarantine, {force: true, recursive: true});
               }
               return {
                 checkoutId,
@@ -782,7 +801,7 @@ function inspectCodeGraphIndexPurgeTarget(
   path: Path.Path,
   threadnoteHome: string,
   checkoutId: string,
-): Effect.Effect<string | undefined, Error | unknown> {
+): Effect.Effect<CodeGraphIndexPurgeTarget | undefined, Error | unknown> {
   return Effect.gen(function* () {
     const repositories = codeGraphRepositoriesRoot(path, threadnoteHome);
     if (!(yield* fs.exists(repositories))) return undefined;
@@ -813,8 +832,44 @@ function inspectCodeGraphIndexPurgeTarget(
     ) {
       return yield* Effect.fail(new Error('Refusing code graph purge outside the repositories root.'));
     }
-    return canonicalRepository;
+    const ino = Option.getOrUndefined(repositoryInfo.value.ino);
+    if (ino === undefined) {
+      return yield* Effect.fail(new Error('Refusing code graph purge without stable checkout identity metadata.'));
+    }
+    return {dev: repositoryInfo.value.dev, ino, path: canonicalRepository};
   });
+}
+
+function inspectQuarantinedCodeGraphIndexPurgeTarget(
+  fs: FileSystem.FileSystem,
+  quarantine: string,
+): Effect.Effect<CodeGraphIndexPurgeTarget | undefined, never> {
+  return Effect.gen(function* () {
+    if (yield* isSymbolicLink(fs, quarantine)) return undefined;
+    const info = yield* fs.stat(quarantine).pipe(Effect.option);
+    if (Option.isNone(info) || info.value.type !== 'Directory') return undefined;
+    const ino = Option.getOrUndefined(info.value.ino);
+    return ino === undefined ? undefined : {dev: info.value.dev, ino, path: quarantine};
+  }).pipe(Effect.catch(() => Effect.succeed(undefined)));
+}
+
+function sameCodeGraphIndexPurgeTarget(
+  left: CodeGraphIndexPurgeTarget | undefined,
+  right: CodeGraphIndexPurgeTarget | undefined,
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function restoreQuarantinedCodeGraphIndexPurgeTarget(
+  fs: FileSystem.FileSystem,
+  quarantine: string,
+  target: string,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    if (yield* fs.exists(target)) return;
+    yield* fs.rename(quarantine, target);
+  }).pipe(Effect.catch(() => Effect.void));
 }
 
 function isSymbolicLink(fs: FileSystem.FileSystem, candidate: string): Effect.Effect<boolean, never> {

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -637,30 +637,43 @@ export const purgeCodeGraphIndex = Effect.fn('codeGraph.purgeIndex')(function* (
             threadnoteHome,
             checkoutId,
             Effect.gen(function* () {
-              const initial = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
-              yield* options.interlock?.beforeVerification?.() ?? Effect.void;
-              const verified = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
-              if (!sameCodeGraphIndexPurgeTarget(initial, verified)) {
-                return yield* Effect.fail(new Error('Code graph checkout target changed before purge.'));
-              }
-              if (verified !== undefined && !options.dryRun) {
-                yield* options.interlock?.beforeRemoval?.() ?? Effect.void;
-                const quarantine = path.join(
-                  path.dirname(verified.path),
-                  `.${checkoutId}.${yield* crypto.randomUUIDv4}.purging`,
-                );
-                yield* fs.rename(verified.path, quarantine);
-                const quarantined = yield* inspectQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine);
-                if (!sameCodeGraphIndexPurgeTarget(verified, quarantined)) {
-                  yield* restoreQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine, verified.path);
-                  return yield* Effect.fail(new Error('Code graph checkout target changed before purge.'));
-                }
-                yield* fs.remove(quarantine, {force: true, recursive: true});
+              const purgeTarget = yield* Effect.scoped(
+                Effect.gen(function* () {
+                  // Keep the original directory open until it has been moved into quarantine.
+                  // POSIX may recycle a deleted directory's inode immediately; the live handle
+                  // prevents that replacement from comparing equal to the planned target.
+                  const initial = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+                  yield* options.interlock?.beforeVerification?.() ?? Effect.void;
+                  const verified = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+                  if (!sameCodeGraphIndexPurgeTarget(initial, verified)) {
+                    return yield* Effect.fail(new Error('Code graph checkout target changed before purge.'));
+                  }
+                  if (verified === undefined || options.dryRun) {
+                    return {existed: verified !== undefined, quarantine: undefined};
+                  }
+
+                  yield* options.interlock?.beforeRemoval?.() ?? Effect.void;
+                  const quarantine = path.join(
+                    path.dirname(verified.path),
+                    `.${checkoutId}.${yield* crypto.randomUUIDv4}.purging`,
+                  );
+                  yield* fs.rename(verified.path, quarantine);
+                  const moved = yield* inspectQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine);
+                  if (!sameCodeGraphIndexPurgeTarget(verified, moved)) {
+                    yield* restoreQuarantinedCodeGraphIndexPurgeTarget(fs, quarantine, verified.path);
+                    return yield* Effect.fail(new Error('Code graph checkout target changed before purge.'));
+                  }
+                  return {existed: true, quarantine};
+                }),
+              );
+              if (purgeTarget.quarantine !== undefined) {
+                // Close the directory handle before recursive deletion for Windows parity.
+                yield* fs.remove(purgeTarget.quarantine, {force: true, recursive: true});
               }
               return {
                 checkoutId,
                 dryRun: options.dryRun,
-                existed: verified !== undefined,
+                existed: purgeTarget.existed,
               } satisfies CodeGraphIndexPurgeSummary;
             }),
             waitTimeoutMilliseconds,
@@ -794,6 +807,31 @@ function obsoleteGraphFileName(
 
 function emptyObsoleteInventory(): ObsoleteCodeGraphStoreInventory {
   return {bytes: 0, checkouts: [], fileCount: 0, unsafeEntryCount: 0};
+}
+
+function openCodeGraphIndexPurgeTarget(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  threadnoteHome: string,
+  checkoutId: string,
+) {
+  return Effect.gen(function* () {
+    const planned = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+    if (planned === undefined) return undefined;
+
+    const opened = yield* fs.open(planned.path, {flag: 'r'});
+    const openedInfo = yield* opened.stat;
+    const openedIno = Option.getOrUndefined(openedInfo.ino);
+    if (openedInfo.type !== 'Directory' || openedIno === undefined) {
+      return yield* Effect.fail(new Error('Refusing code graph purge without stable checkout identity metadata.'));
+    }
+    const target = {dev: openedInfo.dev, ino: openedIno, path: planned.path} satisfies CodeGraphIndexPurgeTarget;
+    const current = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+    if (!sameCodeGraphIndexPurgeTarget(target, current)) {
+      return yield* Effect.fail(new Error('Code graph checkout target changed before purge.'));
+    }
+    return target;
+  });
 }
 
 function inspectCodeGraphIndexPurgeTarget(

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -73,6 +73,16 @@ export interface ObsoleteCodeGraphStorePurgeInterlock {
   readonly beforeVerification?: (inventory: ObsoleteCodeGraphStoreInventory) => Effect.Effect<void>;
 }
 
+export interface CodeGraphIndexPurgeSummary {
+  readonly checkoutId: string;
+  readonly dryRun: boolean;
+  readonly existed: boolean;
+}
+
+export interface CodeGraphIndexPurgeInterlock {
+  readonly beforeVerification?: () => Effect.Effect<void>;
+}
+
 export interface CodeGraphRepairCompletion {
   readonly doctorCheck: DoctorCheck;
   readonly summary: CodeGraphRepairSummary;
@@ -581,6 +591,67 @@ export const purgeObsoleteCodeGraphStores = Effect.fn('codeGraph.purgeObsoleteSt
   );
 });
 
+/**
+ * Removes one checkout-local disposable graph store without resolving a source worktree.
+ * The checkout root is derived from a validated identity, checked twice under all graph
+ * maintenance locks, and must remain an immediate non-symbolic-link child of the graph
+ * repositories directory.
+ */
+export const purgeCodeGraphIndex = Effect.fn('codeGraph.purgeIndex')(function* (
+  threadnoteHome: string,
+  checkoutId: string,
+  options: {
+    readonly dryRun: boolean;
+    readonly interlock?: CodeGraphIndexPurgeInterlock;
+    readonly waitTimeoutMilliseconds?: number;
+  },
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  if (!/^[0-9a-f]{64}$/.test(checkoutId)) {
+    return yield* Effect.fail(new Error('Code graph checkout identity is invalid.'));
+  }
+  const waitTimeoutMilliseconds = options.waitTimeoutMilliseconds ?? 0;
+  const lockOptions = {...CODE_GRAPH_PURGE_LOCK_OPTIONS, waitTimeoutMilliseconds};
+  return yield* withExclusiveFileLock(
+    fs,
+    codeGraphMaintenanceLockPath(path, threadnoteHome),
+    lockOptions,
+    withCodeGraphMaintenanceIntent(
+      threadnoteHome,
+      withExclusiveFileLock(
+        fs,
+        codeGraphRepositoryLockPath(path, threadnoteHome, checkoutId),
+        lockOptions,
+        Effect.gen(function* () {
+          yield* awaitCodeGraphWorktreeBuilds(threadnoteHome, checkoutId, waitTimeoutMilliseconds);
+          return yield* withCodeGraphDatabaseWriteLock(
+            threadnoteHome,
+            checkoutId,
+            Effect.gen(function* () {
+              const initial = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+              yield* options.interlock?.beforeVerification?.() ?? Effect.void;
+              const verified = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+              if (initial !== verified) {
+                return yield* Effect.fail(new Error('Code graph checkout target changed before purge.'));
+              }
+              if (verified !== undefined && !options.dryRun) {
+                yield* fs.remove(verified, {force: true, recursive: true});
+              }
+              return {
+                checkoutId,
+                dryRun: options.dryRun,
+                existed: verified !== undefined,
+              } satisfies CodeGraphIndexPurgeSummary;
+            }),
+            waitTimeoutMilliseconds,
+          );
+        }),
+      ),
+    ),
+  );
+});
+
 export const purgeAllCodeGraphIndexes = Effect.fn('codeGraph.purgeAllIndexes')(function* (threadnoteHome: string) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -704,6 +775,46 @@ function obsoleteGraphFileName(
 
 function emptyObsoleteInventory(): ObsoleteCodeGraphStoreInventory {
   return {bytes: 0, checkouts: [], fileCount: 0, unsafeEntryCount: 0};
+}
+
+function inspectCodeGraphIndexPurgeTarget(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  threadnoteHome: string,
+  checkoutId: string,
+): Effect.Effect<string | undefined, Error | unknown> {
+  return Effect.gen(function* () {
+    const repositories = codeGraphRepositoriesRoot(path, threadnoteHome);
+    if (!(yield* fs.exists(repositories))) return undefined;
+    if (yield* isSymbolicLink(fs, repositories)) {
+      return yield* Effect.fail(new Error('Refusing code graph purge through a symbolic-link repositories root.'));
+    }
+    const repositoriesInfo = yield* fs.stat(repositories).pipe(Effect.option);
+    if (repositoriesInfo._tag === 'None' || repositoriesInfo.value.type !== 'Directory') {
+      return yield* Effect.fail(
+        new Error('Refusing code graph purge because the repositories root is not a directory.'),
+      );
+    }
+    const canonicalRepositories = yield* fs.realPath(repositories);
+    const repositoryRoot = codeGraphRepositoryRoot(path, threadnoteHome, checkoutId);
+    if (!(yield* fs.exists(repositoryRoot))) return undefined;
+    if (yield* isSymbolicLink(fs, repositoryRoot)) {
+      return yield* Effect.fail(new Error('Refusing code graph purge through a symbolic-link checkout root.'));
+    }
+    const repositoryInfo = yield* fs.stat(repositoryRoot).pipe(Effect.option);
+    if (repositoryInfo._tag === 'None' || repositoryInfo.value.type !== 'Directory') {
+      return yield* Effect.fail(new Error('Refusing code graph purge because the checkout root is not a directory.'));
+    }
+    const canonicalRepository = yield* fs.realPath(repositoryRoot);
+    if (
+      path.dirname(canonicalRepository) !== canonicalRepositories ||
+      path.basename(canonicalRepository) !== checkoutId ||
+      !isContained(path, canonicalRepositories, canonicalRepository)
+    ) {
+      return yield* Effect.fail(new Error('Refusing code graph purge outside the repositories root.'));
+    }
+    return canonicalRepository;
+  });
 }
 
 function isSymbolicLink(fs: FileSystem.FileSystem, candidate: string): Effect.Effect<boolean, never> {

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -876,6 +876,7 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
           }
           if (matching) matching.schemaInitialized = true;
         });
+      const retiredSnapshotCleanupScheduled = new Set<string>();
       const scheduleCompletedBuildCleanup = (databasePath: string, snapshotId?: string) =>
         Effect.gen(function* () {
           const session = yield* Effect.serviceOption(CodeGraphDatabaseSession);
@@ -923,6 +924,56 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
               yield* Effect.sleep(CODE_GRAPH_CLEANUP_YIELD_MILLISECONDS);
             }
           });
+          yield* cleanup.pipe(Effect.ignore, Effect.forkIn(scope));
+        }).pipe(Effect.asVoid);
+      const scheduleRetiredSnapshotCleanup = (databasePath: string) =>
+        Effect.gen(function* () {
+          if (retiredSnapshotCleanupScheduled.has(databasePath)) return;
+          retiredSnapshotCleanupScheduled.add(databasePath);
+          const session = yield* Effect.serviceOption(CodeGraphDatabaseSession);
+          const options =
+            Option.isSome(session) && session.value.databasePath === databasePath ? session.value : undefined;
+          const writerLockPath = options?.writerLockPath ?? inferredCodeGraphWriterLockPath(path, databasePath);
+          const cleanupSweep = Effect.gen(function* () {
+            // Open SQLite only while holding the checkout writer gate. Purge
+            // owns the same gate, so a detached collector cannot retain a
+            // Windows handle or recreate a database after targeted deletion.
+            if (!(yield* fs.exists(databasePath))) return {deleted: 0, remaining: false};
+            return yield* useDatabaseDirect(
+              databasePath,
+              Effect.gen(function* () {
+                const sql = yield* SqlClient.SqlClient;
+                yield* configureConnection(sql);
+                return yield* pruneRetiredSnapshotRowsPage(sql);
+              }),
+            );
+          });
+          const runSweep =
+            writerLockPath === undefined
+              ? cleanupSweep.pipe(Effect.map(Option.some))
+              : withExclusiveFileLock(fs, writerLockPath, CODE_GRAPH_DETACHED_CLEANUP_LOCK_OPTIONS, cleanupSweep).pipe(
+                  Effect.map(Option.some),
+                  Effect.catch(error =>
+                    isFileLockTimeout(error) ? Effect.succeed(Option.none()) : Effect.fail(error),
+                  ),
+                  Effect.provideService(Crypto.Crypto, crypto),
+                  Effect.provideService(Path.Path, path),
+                  Effect.provideService(SystemInfo, system),
+                );
+          const cleanup = Effect.gen(function* () {
+            // Pointer publication and lease release stay latency-bounded. Give
+            // the foreground operation one polling window to finish before the
+            // opportunistic collector attempts its first page.
+            yield* Effect.sleep(CODE_GRAPH_CLEANUP_YIELD_MILLISECONDS);
+            for (;;) {
+              const result = yield* runSweep;
+              // This collector is opportunistic and bounded to one table page
+              // per writer-gate acquisition. Foreground work always wins; the
+              // next lease/index/maintenance pass resumes any remaining rows.
+              if (Option.isNone(result) || !result.value.remaining) return;
+              yield* Effect.sleep(CODE_GRAPH_CLEANUP_YIELD_MILLISECONDS);
+            }
+          }).pipe(Effect.ensuring(Effect.sync(() => retiredSnapshotCleanupScheduled.delete(databasePath))));
           yield* cleanup.pipe(Effect.ignore, Effect.forkIn(scope));
         }).pipe(Effect.asVoid);
       return CodeGraphStore.of({
@@ -982,15 +1033,24 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
         acquireSnapshotLease: (databasePath, snapshotId, durationMilliseconds) =>
           Effect.gen(function* () {
             const token = `${system.processId}:${yield* crypto.randomUUIDv4}`;
-            return yield* prepare(databasePath).pipe(
+            const acquired = yield* prepare(databasePath).pipe(
               Effect.andThen(
                 withWriterGate(
                   databasePath,
-                  useDatabase(databasePath, acquireSnapshotLease(snapshotId, durationMilliseconds, token)),
+                  useDatabase(
+                    databasePath,
+                    Effect.gen(function* () {
+                      const acquiredToken = yield* acquireSnapshotLease(snapshotId, durationMilliseconds, token);
+                      const cleanup = yield* pruneRetiredSnapshotRowsPage();
+                      return {cleanup, token: acquiredToken};
+                    }),
+                  ),
                 ),
               ),
               Effect.mapError(cause => storeError('acquire code graph snapshot lease', cause)),
             );
+            if (acquired.cleanup.remaining) yield* scheduleRetiredSnapshotCleanup(databasePath);
+            return acquired.token;
           }).pipe(Effect.mapError(cause => storeError('acquire code graph snapshot lease', cause))),
         activate: (databasePath, identity, snapshot, files, symbols, edges) =>
           prepare(databasePath).pipe(
@@ -1140,6 +1200,8 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
                 useDatabase(databasePath, promoteSnapshot(identity, snapshotId, activeWorktreeIds)),
               ),
             ),
+            Effect.tap(retired => (retired > 0 ? scheduleRetiredSnapshotCleanup(databasePath) : Effect.void)),
+            Effect.asVoid,
             Effect.mapError(cause => storeError('promote code graph snapshot', cause)),
           ),
         initialize: databasePath =>
@@ -1613,9 +1675,12 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
                       Effect.gen(function* () {
                         const sql = yield* SqlClient.SqlClient;
                         yield* configureConnection(sql);
-                        yield* sql.withTransaction(reconcileActiveWorktrees(sql, activeWorktreeIds));
+                        return yield* sql.withTransaction(reconcileActiveWorktrees(sql, activeWorktreeIds));
                       }),
                     ),
+                  ).pipe(
+                    Effect.tap(retired => (retired > 0 ? scheduleRetiredSnapshotCleanup(databasePath) : Effect.void)),
+                    Effect.asVoid,
                   )
                 : Effect.void,
             ),
@@ -1660,7 +1725,21 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
           fs.exists(databasePath).pipe(
             Effect.flatMap(exists =>
               exists
-                ? withWriterGate(databasePath, useDatabase(databasePath, releaseSnapshotLease(token)))
+                ? withWriterGate(
+                    databasePath,
+                    useDatabase(
+                      databasePath,
+                      Effect.gen(function* () {
+                        yield* releaseSnapshotLease(token);
+                        return yield* pruneRetiredSnapshotRowsPage();
+                      }),
+                    ),
+                  ).pipe(
+                    Effect.tap(cleanup =>
+                      cleanup.remaining ? scheduleRetiredSnapshotCleanup(databasePath) : Effect.void,
+                    ),
+                    Effect.asVoid,
+                  )
                 : Effect.void,
             ),
             Effect.mapError(cause => storeError('release code graph snapshot lease', cause)),
@@ -1671,7 +1750,18 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
               exists
                 ? withWriterGate(
                     databasePath,
-                    useDatabase(databasePath, renewSnapshotLease(token, durationMilliseconds)),
+                    useDatabase(
+                      databasePath,
+                      Effect.gen(function* () {
+                        yield* renewSnapshotLease(token, durationMilliseconds);
+                        return yield* pruneRetiredSnapshotRowsPage();
+                      }),
+                    ),
+                  ).pipe(
+                    Effect.tap(cleanup =>
+                      cleanup.remaining ? scheduleRetiredSnapshotCleanup(databasePath) : Effect.void,
+                    ),
+                    Effect.asVoid,
                   )
                 : Effect.fail(new CodeGraphStoreError('The code graph database disappeared while renewing a lease.')),
             ),
@@ -2924,9 +3014,39 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
     CREATE TABLE IF NOT EXISTS snapshot_leases (
       token TEXT PRIMARY KEY NOT NULL,
       snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
-      expires_at INTEGER NOT NULL
+      expires_at INTEGER NOT NULL,
+      retire_when_inactive INTEGER NOT NULL DEFAULT 0 CHECK (retire_when_inactive IN (0, 1))
     )
   `);
+  const addedLeaseRetirement = yield* ensureColumn(
+    sql,
+    'snapshot_leases',
+    'retire_when_inactive',
+    'INTEGER NOT NULL DEFAULT 0 CHECK (retire_when_inactive IN (0, 1))',
+  );
+  if (addedLeaseRetirement) {
+    const now = yield* Clock.currentTimeMillis;
+    // Existing runtimes did not record whether a lease pinned an active view.
+    // Preserve live non-active consumers, but migrate current pointers and
+    // already-expired displaced pointers so the upgrade can reclaim their
+    // abandoned history on the next lease sweep.
+    yield* sql`
+      UPDATE snapshot_leases AS lease
+      SET retire_when_inactive = 1
+      WHERE EXISTS (
+        SELECT 1 FROM active_snapshots AS active
+        WHERE active.snapshot_id = lease.snapshot_id
+      ) OR (
+        lease.expires_at <= ${now}
+        AND EXISTS (
+          SELECT 1
+          FROM snapshots AS candidate
+          JOIN active_snapshots AS active ON active.worktree_id = candidate.worktree_id
+          WHERE candidate.id = lease.snapshot_id
+        )
+      )
+    `;
+  }
   yield* sql.unsafe(`
     CREATE TABLE IF NOT EXISTS snapshot_files (
       snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
@@ -3295,8 +3415,9 @@ const ensureColumn = Effect.fn('codeGraph.ensureColumn')(function* (
   declaration: string,
 ) {
   const columns = yield* sql.unsafe<{readonly name: string}>(`PRAGMA table_info(${table})`);
-  if (columns.some(candidate => candidate.name === column)) return;
+  if (columns.some(candidate => candidate.name === column)) return false;
   yield* sql.unsafe(`ALTER TABLE ${table} ADD COLUMN ${column} ${declaration}`);
+  return true;
 });
 
 const diagnoseDatabase = Effect.fn('codeGraph.diagnoseDatabase')(function* () {
@@ -3396,6 +3517,54 @@ const repairDatabase = Effect.fn('codeGraph.repairDatabase')(function* (dryRun: 
   return {removedSnapshots} satisfies CodeGraphDatabaseRepair;
 });
 
+const reapExpiredSnapshotLeases = Effect.fn('codeGraph.reapExpiredSnapshotLeases')(function* (
+  sql: SqlClient.SqlClient,
+  now: number,
+) {
+  const expired = yield* sql<{readonly snapshot_id: string}>`
+    SELECT DISTINCT snapshot_id
+    FROM snapshot_leases
+    WHERE expires_at <= ${now} AND retire_when_inactive = 1
+    ORDER BY snapshot_id
+  `;
+  const candidates = expired.map(row => row.snapshot_id);
+  if (candidates.length > 0) {
+    // Carry the active-view provenance to any overlapping reader. The final
+    // lease release can then retire the displaced snapshot regardless of which
+    // token happened to outlive the original active-view lease.
+    yield* sql`UPDATE snapshot_leases SET retire_when_inactive = 1 WHERE ${sql.in('snapshot_id', candidates)}`;
+  }
+  yield* sql`DELETE FROM snapshot_leases WHERE expires_at <= ${now}`;
+  return candidates;
+});
+
+const retireLeaseCandidates = Effect.fn('codeGraph.retireLeaseCandidates')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotIds: readonly string[],
+  now: number,
+) {
+  const candidates = [...new Set(snapshotIds)];
+  if (candidates.length === 0) return 0;
+  yield* sql`
+    UPDATE snapshots
+    SET state = 'retired'
+    WHERE ${sql.in('id', candidates)}
+      AND state = 'ready'
+      AND id NOT IN (SELECT snapshot_id FROM active_snapshots)
+      AND id NOT IN (SELECT snapshot_id FROM snapshot_leases WHERE expires_at > ${now})
+      AND id NOT IN (
+        SELECT base_snapshot_id FROM snapshots
+        WHERE base_snapshot_id IS NOT NULL
+          AND id IN (
+            SELECT snapshot_id FROM active_snapshots
+            UNION
+            SELECT snapshot_id FROM snapshot_leases WHERE expires_at > ${now}
+          )
+      )
+  `;
+  return yield* lastStatementChangeCount(sql);
+});
+
 const acquireSnapshotLease = Effect.fn('codeGraph.acquireSnapshotLease')(function* (
   snapshotId: string,
   durationMilliseconds: number,
@@ -3407,7 +3576,6 @@ const acquireSnapshotLease = Effect.fn('codeGraph.acquireSnapshotLease')(functio
   const duration = Math.max(1_000, Math.min(60 * 60_000, Math.floor(durationMilliseconds)));
   yield* sql.withTransaction(
     Effect.gen(function* () {
-      yield* sql`DELETE FROM snapshot_leases WHERE expires_at <= ${now}`;
       const ready = yield* sql<{readonly id: string}>`
         SELECT id FROM snapshots WHERE id = ${snapshotId} AND state = 'ready' LIMIT 1
       `;
@@ -3415,9 +3583,19 @@ const acquireSnapshotLease = Effect.fn('codeGraph.acquireSnapshotLease')(functio
         return yield* Effect.fail(new CodeGraphStoreError(`Ready snapshot ${snapshotId} is no longer available.`));
       }
       yield* sql`
-        INSERT INTO snapshot_leases (token, snapshot_id, expires_at)
-        VALUES (${token}, ${snapshotId}, ${now + duration})
+        INSERT INTO snapshot_leases (token, snapshot_id, expires_at, retire_when_inactive)
+        VALUES (
+          ${token}, ${snapshotId}, ${now + duration},
+          CASE WHEN EXISTS (
+            SELECT 1 FROM active_snapshots WHERE snapshot_id = ${snapshotId}
+          ) THEN 1 ELSE 0 END
+        )
       `;
+      // The new lease protects its target before expired readers are reaped.
+      // This makes the next ordinary graph read self-heal snapshots left by a
+      // crashed process without racing a caller that is reacquiring that view.
+      const expired = yield* reapExpiredSnapshotLeases(sql, now);
+      yield* retireLeaseCandidates(sql, expired, now);
     }),
   );
   return token;
@@ -3426,7 +3604,28 @@ const acquireSnapshotLease = Effect.fn('codeGraph.acquireSnapshotLease')(functio
 const releaseSnapshotLease = Effect.fn('codeGraph.releaseSnapshotLease')(function* (token: string) {
   const sql = yield* SqlClient.SqlClient;
   yield* configureConnection(sql);
-  yield* sql`DELETE FROM snapshot_leases WHERE token = ${token}`;
+  yield* sql.withTransaction(
+    Effect.gen(function* () {
+      const released = yield* sql<{readonly snapshot_id: string}>`
+        SELECT snapshot_id
+        FROM snapshot_leases
+        WHERE token = ${token} AND retire_when_inactive = 1
+        LIMIT 1
+      `;
+      const releasedCandidates = released.map(row => row.snapshot_id);
+      if (releasedCandidates.length > 0) {
+        yield* sql`
+          UPDATE snapshot_leases
+          SET retire_when_inactive = 1
+          WHERE ${sql.in('snapshot_id', releasedCandidates)}
+        `;
+      }
+      yield* sql`DELETE FROM snapshot_leases WHERE token = ${token}`;
+      const now = yield* Clock.currentTimeMillis;
+      const expired = yield* reapExpiredSnapshotLeases(sql, now);
+      yield* retireLeaseCandidates(sql, [...releasedCandidates, ...expired], now);
+    }),
+  );
 });
 
 const renewSnapshotLease = Effect.fn('codeGraph.renewSnapshotLease')(function* (
@@ -3448,6 +3647,8 @@ const renewSnapshotLease = Effect.fn('codeGraph.renewSnapshotLease')(function* (
       yield* sql`
         UPDATE snapshot_leases SET expires_at = ${now + duration} WHERE token = ${token}
       `;
+      const expired = yield* reapExpiredSnapshotLeases(sql, now);
+      yield* retireLeaseCandidates(sql, expired, now);
     }),
   );
 });
@@ -9621,7 +9822,7 @@ const promoteSnapshot = Effect.fn('codeGraph.promoteSnapshot')(function* (
   yield* configureConnection(sql);
   yield* initializeSchema(sql);
   const retainedWorktreeIds = [...new Set([...activeWorktreeIds, identity.worktreeId])];
-  yield* sql.withTransaction(
+  return yield* sql.withTransaction(
     Effect.gen(function* () {
       const candidate = yield* sql<{
         readonly generation: number | null;
@@ -9658,7 +9859,7 @@ const promoteSnapshot = Effect.fn('codeGraph.promoteSnapshot')(function* (
           snapshot_id = excluded.snapshot_id,
           activated_at = excluded.activated_at
       `;
-      yield* markUnusedSnapshotsRetired(sql);
+      return yield* markUnusedSnapshotsRetired(sql);
     }),
   );
 });
@@ -9675,7 +9876,7 @@ const reconcileActiveWorktrees = Effect.fn('codeGraph.reconcileActiveWorktrees')
       WHERE NOT (${sql.in('worktree_id', retained)})
     `;
   }
-  yield* markUnusedSnapshotsRetired(sql);
+  return yield* markUnusedSnapshotsRetired(sql);
 });
 
 const markUnusedSnapshotsRetired = Effect.fn('codeGraph.markUnusedSnapshotsRetired')(function* (
@@ -9695,6 +9896,7 @@ const markUnusedSnapshotsRetired = Effect.fn('codeGraph.markUnusedSnapshotsRetir
           AND id IN (SELECT snapshot_id FROM active_snapshots UNION SELECT snapshot_id FROM snapshot_leases)
       )
   `;
+  return yield* lastStatementChangeCount(sql);
 });
 
 interface CompactLexicalCleanupSpec {
@@ -10110,6 +10312,127 @@ const clearSnapshotOwnedRows = Effect.fn('codeGraph.clearSnapshotOwnedRows')(fun
       yield* Effect.yieldNow;
     }
   }
+});
+
+interface RetiredSnapshotCleanupPage {
+  readonly deleted: number;
+  readonly remaining: boolean;
+}
+
+/**
+ * Reclaim at most one bounded table page. Lease acquire/release use this
+ * foreground step, while pointer promotion schedules the same state machine as
+ * a best-effort detached collector. Query completion therefore never cascades
+ * a repository-sized snapshot delete, while repeated ordinary use still makes
+ * durable progress if a short-lived CLI interrupts the detached fiber.
+ */
+const pruneRetiredSnapshotRowsPage = Effect.fn('codeGraph.pruneRetiredSnapshotRowsPage')(function* (
+  providedSql?: SqlClient.SqlClient,
+) {
+  const sql = providedSql ?? (yield* SqlClient.SqlClient);
+  yield* initializeSchema(sql);
+  const pending = yield* sql<{readonly present: number}>`
+    SELECT EXISTS(SELECT 1 FROM snapshots WHERE state = 'retired' LIMIT 1) AS present
+  `;
+  if (Number(pending[0]?.present ?? 0) === 0) {
+    return {deleted: 0, remaining: false} satisfies RetiredSnapshotCleanupPage;
+  }
+
+  const compactTargets = yield* sql<CompactLexicalSnapshotKeyRow & {readonly snapshot_id: string}>`
+    SELECT compact.snapshot_key, compact.snapshot_id
+    FROM lexical_compact_snapshots AS compact
+    JOIN snapshots AS snapshot ON snapshot.id = compact.snapshot_id
+    WHERE snapshot.state = 'retired'
+    ORDER BY compact.snapshot_id
+    LIMIT 1
+  `;
+  const compactTarget = compactTargets[0];
+  if (compactTarget !== undefined) {
+    const compactSnapshotKey = yield* validatedCompactLexicalCount(compactTarget.snapshot_key, 'cleanup snapshot key');
+    for (const spec of COMPACT_LEXICAL_CLEANUP_SPECS) {
+      const deleted = yield* sql.withTransaction(
+        Effect.gen(function* () {
+          const statement = compactLexicalCleanupPageStatement(
+            spec,
+            compactSnapshotKey,
+            spec.batchRows,
+            Option.some(compactTarget.snapshot_id),
+          );
+          yield* sql.unsafe(statement.text, statement.parameters);
+          return yield* lastStatementChangeCount(sql);
+        }),
+      );
+      if (!Number.isSafeInteger(deleted) || deleted < 0) {
+        return yield* Effect.fail(new CodeGraphStoreError('Retired snapshot cleanup returned an invalid row count.'));
+      }
+      if (deleted > 0) return {deleted, remaining: true} satisfies RetiredSnapshotCleanupPage;
+    }
+    const metadataDeleted = yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql.unsafe(
+          `DELETE FROM lexical_storage_formats
+           WHERE snapshot_id = ?
+             AND EXISTS (SELECT 1 FROM snapshots WHERE id = ? AND state = 'retired')`,
+          [compactTarget.snapshot_id, compactTarget.snapshot_id],
+        );
+        const formatRows = yield* lastStatementChangeCount(sql);
+        yield* sql.unsafe(
+          `DELETE FROM lexical_compact_snapshots
+           WHERE snapshot_key = ? AND snapshot_id = ?
+             AND EXISTS (SELECT 1 FROM snapshots WHERE id = ? AND state = 'retired')`,
+          [compactSnapshotKey, compactTarget.snapshot_id, compactTarget.snapshot_id],
+        );
+        return formatRows + (yield* lastStatementChangeCount(sql));
+      }),
+    );
+    if (metadataDeleted > 0) {
+      return {deleted: metadataDeleted, remaining: true} satisfies RetiredSnapshotCleanupPage;
+    }
+  }
+
+  for (const spec of RETIRED_SNAPSHOT_CLEANUP_SPECS) {
+    if (spec.table === LEGACY_BUILDING_REFERENCES_V3_TABLE && !(yield* tableExists(sql, spec.table))) continue;
+    const deleted = yield* sql.withTransaction(
+      Effect.gen(function* () {
+        const key = `(${spec.keyColumns.join(', ')})`;
+        yield* sql.unsafe(
+          `DELETE FROM ${spec.table}
+           WHERE ${key} IN (
+             SELECT ${spec.keyColumns.map(column => `candidate.${column}`).join(', ')}
+             FROM ${spec.table} AS candidate
+             WHERE candidate.snapshot_id IN (SELECT id FROM snapshots WHERE state = 'retired')
+             ORDER BY ${spec.keyColumns.map(column => `candidate.${column}`).join(', ')}
+             LIMIT ?
+           )`,
+          [spec.batchRows],
+        );
+        return yield* lastStatementChangeCount(sql);
+      }),
+    );
+    if (!Number.isSafeInteger(deleted) || deleted < 0) {
+      return yield* Effect.fail(new CodeGraphStoreError('Retired snapshot cleanup returned an invalid row count.'));
+    }
+    if (deleted > 0) return {deleted, remaining: true} satisfies RetiredSnapshotCleanupPage;
+  }
+
+  const removed = yield* sql.withTransaction(
+    Effect.gen(function* () {
+      yield* sql`DELETE FROM snapshots WHERE id IN (
+        SELECT id FROM snapshots WHERE state = 'retired' ORDER BY id LIMIT 100
+      )`;
+      return yield* lastStatementChangeCount(sql);
+    }),
+  );
+  if (!Number.isSafeInteger(removed) || removed < 0) {
+    return yield* Effect.fail(new CodeGraphStoreError('Retired snapshot cleanup returned an invalid count.'));
+  }
+  const remaining = yield* sql<{readonly present: number}>`
+    SELECT EXISTS(SELECT 1 FROM snapshots WHERE state = 'retired' LIMIT 1) AS present
+  `;
+  return {
+    deleted: removed,
+    remaining: Number(remaining[0]?.present ?? 0) !== 0,
+  } satisfies RetiredSnapshotCleanupPage;
 });
 
 /**

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -481,6 +481,7 @@ export interface CodeGraphStoreShape {
     databasePath: string,
     snapshotId: string,
     durationMilliseconds: number,
+    options?: {readonly retireWhenInactive?: boolean},
   ) => Effect.Effect<string, CodeGraphStoreError>;
   readonly promote: (
     databasePath: string,
@@ -1030,7 +1031,7 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
               Effect.fail(storeError('use code graph database session', cause as SqlError.SqlError)),
             ),
           ),
-        acquireSnapshotLease: (databasePath, snapshotId, durationMilliseconds) =>
+        acquireSnapshotLease: (databasePath, snapshotId, durationMilliseconds, options) =>
           Effect.gen(function* () {
             const token = `${system.processId}:${yield* crypto.randomUUIDv4}`;
             const acquired = yield* prepare(databasePath).pipe(
@@ -1040,7 +1041,12 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
                   useDatabase(
                     databasePath,
                     Effect.gen(function* () {
-                      const acquiredToken = yield* acquireSnapshotLease(snapshotId, durationMilliseconds, token);
+                      const acquiredToken = yield* acquireSnapshotLease(
+                        snapshotId,
+                        durationMilliseconds,
+                        token,
+                        options?.retireWhenInactive === true,
+                      );
                       const cleanup = yield* pruneRetiredSnapshotRowsPage();
                       return {cleanup, token: acquiredToken};
                     }),
@@ -3584,6 +3590,7 @@ const acquireSnapshotLease = Effect.fn('codeGraph.acquireSnapshotLease')(functio
   snapshotId: string,
   durationMilliseconds: number,
   token: string,
+  retireWhenInactive: boolean,
 ) {
   const sql = yield* SqlClient.SqlClient;
   yield* configureConnection(sql);
@@ -3601,7 +3608,7 @@ const acquireSnapshotLease = Effect.fn('codeGraph.acquireSnapshotLease')(functio
         INSERT INTO snapshot_leases (token, snapshot_id, expires_at, retire_when_inactive)
         VALUES (
           ${token}, ${snapshotId}, ${now + duration},
-          CASE WHEN EXISTS (
+          CASE WHEN ${retireWhenInactive ? 1 : 0} = 1 OR EXISTS (
             SELECT 1 FROM active_snapshots WHERE snapshot_id = ${snapshotId}
           ) THEN 1 ELSE 0 END
         )

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -3543,7 +3543,22 @@ const retireLeaseCandidates = Effect.fn('codeGraph.retireLeaseCandidates')(funct
   snapshotIds: readonly string[],
   now: number,
 ) {
-  const candidates = [...new Set(snapshotIds)];
+  const candidateSet = new Set(snapshotIds);
+  let frontier = [...candidateSet];
+  while (frontier.length > 0) {
+    const bases = yield* sql<{readonly base_snapshot_id: string}>`
+      SELECT DISTINCT base_snapshot_id
+      FROM snapshots
+      WHERE ${sql.in('id', frontier)} AND base_snapshot_id IS NOT NULL
+    `;
+    frontier = [];
+    for (const row of bases) {
+      if (candidateSet.has(row.base_snapshot_id)) continue;
+      candidateSet.add(row.base_snapshot_id);
+      frontier.push(row.base_snapshot_id);
+    }
+  }
+  const candidates = [...candidateSet];
   if (candidates.length === 0) return 0;
   yield* sql`
     UPDATE snapshots
@@ -9859,6 +9874,14 @@ const promoteSnapshot = Effect.fn('codeGraph.promoteSnapshot')(function* (
           snapshot_id = excluded.snapshot_id,
           activated_at = excluded.activated_at
       `;
+      // A lease acquired by ID may precede promotion. Once its snapshot owns
+      // an active pointer, its final release must reclaim that view after it is
+      // displaced just like a lease acquired while the pointer was active.
+      yield* sql`
+        UPDATE snapshot_leases
+        SET retire_when_inactive = 1
+        WHERE snapshot_id = ${snapshotId}
+      `;
       return yield* markUnusedSnapshotsRetired(sql);
     }),
   );
@@ -9883,7 +9906,7 @@ const markUnusedSnapshotsRetired = Effect.fn('codeGraph.markUnusedSnapshotsRetir
   sql: SqlClient.SqlClient,
 ) {
   const now = yield* Clock.currentTimeMillis;
-  yield* sql`DELETE FROM snapshot_leases WHERE expires_at <= ${now}`;
+  yield* reapExpiredSnapshotLeases(sql, now);
   yield* sql`
     UPDATE snapshots
     SET state = 'retired'
@@ -10330,7 +10353,6 @@ const pruneRetiredSnapshotRowsPage = Effect.fn('codeGraph.pruneRetiredSnapshotRo
   providedSql?: SqlClient.SqlClient,
 ) {
   const sql = providedSql ?? (yield* SqlClient.SqlClient);
-  yield* initializeSchema(sql);
   const pending = yield* sql<{readonly present: number}>`
     SELECT EXISTS(SELECT 1 FROM snapshots WHERE state = 'retired' LIMIT 1) AS present
   `;

--- a/src/code_graph/visualization.ts
+++ b/src/code_graph/visualization.ts
@@ -59,7 +59,10 @@ const MANAGER_QUERY_MAX_NODE_LIMIT = 200;
 const MANAGER_QUERY_MAX_LENGTH = 512;
 const MANAGER_QUERY_SEMANTIC_TIME_BUDGET_MILLISECONDS = 750;
 const MANAGER_QUERY_TRAVERSAL_TIME_BUDGET_MILLISECONDS = 1_000;
-const managerSnapshotLeases = new Map<string, {readonly renewAfter: number; readonly token: string}>();
+const managerSnapshotLeases = new Map<
+  string,
+  {readonly database: string; readonly renewAfter: number; readonly token: string}
+>();
 const INDEXED_VIEW_ID = /^[0-9a-f]{64}(?:\.[0-9a-f]{64})?$/;
 const NODE_ID_MAX_LENGTH = 512;
 const NODE_DETAIL_PROVENANCES: readonly CodeGraphProvenance[] = [
@@ -359,14 +362,33 @@ const retainManagerSnapshot = Effect.fn('codeGraph.retainManagerSnapshot')(funct
       .pipe(Effect.match({onFailure: () => false, onSuccess: () => true}));
     if (renewed) {
       managerSnapshotLeases.set(key, {
+        database,
         renewAfter: now + MANAGER_CATALOG_SNAPSHOT_RENEW_MILLISECONDS,
         token: existing.token,
       });
       return;
     }
   }
-  const token = yield* store.acquireSnapshotLease(database, snapshotId, MANAGER_CATALOG_SNAPSHOT_LEASE_MILLISECONDS);
-  managerSnapshotLeases.set(key, {renewAfter: now + MANAGER_CATALOG_SNAPSHOT_RENEW_MILLISECONDS, token});
+  const token = yield* store.acquireSnapshotLease(database, snapshotId, MANAGER_CATALOG_SNAPSHOT_LEASE_MILLISECONDS, {
+    retireWhenInactive: true,
+  });
+  managerSnapshotLeases.set(key, {
+    database,
+    renewAfter: now + MANAGER_CATALOG_SNAPSHOT_RENEW_MILLISECONDS,
+    token,
+  });
+});
+
+/** Releases every catalog lease owned by the current Manager process. */
+export const releaseManagerGraphSnapshotLeases = Effect.fn('codeGraph.releaseManagerSnapshotLeases')(function* () {
+  const store = yield* CodeGraphStore;
+  const leases = [...managerSnapshotLeases.values()];
+  managerSnapshotLeases.clear();
+  yield* Effect.forEach(
+    leases,
+    lease => store.releaseSnapshotLease(lease.database, lease.token).pipe(Effect.catch(() => Effect.void)),
+    {concurrency: 1, discard: true},
+  );
 });
 
 export function groupManagerGraphRepositories(

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -791,6 +791,7 @@ const graphPurge = Command.make(
   'purge',
   {
     all: boolean('all', 'Remove every disposable native code graph index'),
+    checkoutId: optionalString('checkout-id', 'Target one inventoried checkout by its full 64-character identity'),
     cwd: graphBounds.cwd,
     dryRun: boolean('dry-run', 'Show the derived index path without removing it'),
     obsolete: boolean('obsolete', 'Remove only verified older graph-vN SQLite files for this checkout'),

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1496,12 +1496,21 @@ const runManagerGraphAction = Effect.fn('manager.runGraphAction')(function* (
   if (action === 'purge-all') {
     return yield* runCaptured(() => runCodeGraphPurge(config, {all: true, dryRun}), runEffect);
   }
-  const [checkoutId, worktreeId] = yield* Effect.try({
-    try: () =>
-      [
-        requireGraphIdentity(body.checkoutId, 'checkoutId'),
-        requireGraphIdentity(body.worktreeId, 'worktreeId'),
-      ] as const,
+  const checkoutId = yield* Effect.try({
+    try: () => requireGraphIdentity(body.checkoutId, 'checkoutId'),
+    catch: error => error,
+  });
+  if (action === 'purge') {
+    return yield* runCaptured(
+      () => runCodeGraphPurge(config, {checkoutId, dryRun, waitTimeoutMilliseconds: 0}),
+      runEffect,
+    );
+  }
+  if (action === 'purge-obsolete') {
+    return yield* runCaptured(() => runCodeGraphPurge(config, {checkoutId, dryRun, obsolete: true}), runEffect);
+  }
+  const worktreeId = yield* Effect.try({
+    try: () => requireGraphIdentity(body.worktreeId, 'worktreeId'),
     catch: error => error,
   });
   const cwd = yield* resolveManagerGraphActionCwd(
@@ -1518,10 +1527,6 @@ const runManagerGraphAction = Effect.fn('manager.runGraphAction')(function* (
       );
     case 'index':
       return yield* runCaptured(() => runCodeGraphIndex(config, {cwd, full: body.full === true}), runEffect);
-    case 'purge':
-      return yield* runCaptured(() => runCodeGraphPurge(config, {cwd, dryRun}), runEffect);
-    case 'purge-obsolete':
-      return yield* runCaptured(() => runCodeGraphPurge(config, {cwd, dryRun, obsolete: true}), runEffect);
     default:
       return yield* Effect.fail(new Error(`Unsupported graph Manager action: ${action}`));
   }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -68,6 +68,7 @@ import {
   managerGraphCatalogPage,
   managerGraphNodeDetail,
   managerGraphQuery,
+  releaseManagerGraphSnapshotLeases,
   managerGraphVisualization,
   managerGraphViewsPage,
 } from './code_graph/visualization.js';
@@ -254,6 +255,7 @@ export function runManage(config: RuntimeConfig, options: ManageOptions) {
       const crypto = yield* Crypto.Crypto;
       const token = Encoding.encodeBase64Url(yield* crypto.randomBytes(24));
       const server = yield* HttpServer.HttpServer;
+      yield* Effect.addFinalizer(() => releaseManagerGraphSnapshotLeases());
       yield* server.serve(createManagerServer({config, jobs: new Map(), token}));
       const actualPort = server.address._tag === 'TcpAddress' ? server.address.port : (options.uiPort ?? 0);
       const url = `http://127.0.0.1:${actualPort}/?token=${encodeURIComponent(token)}`;

--- a/src/manager_dialog.tsx
+++ b/src/manager_dialog.tsx
@@ -28,7 +28,7 @@ export type ManagerDialogValues = Readonly<Record<string, string>>;
 export type ManagerDialogValidation =
   {readonly fieldId: string; readonly ok: false} | {readonly ok: true; readonly values: ManagerDialogValues};
 
-interface ManagerDialogs {
+export interface ManagerDialogs {
   readonly confirm: (options: ManagerDialogOptions) => Promise<boolean>;
   readonly prompt: (options: ManagerDialogOptions) => Promise<ManagerDialogValues | undefined>;
 }
@@ -41,6 +41,11 @@ interface PendingDialog {
 export interface ManagerAutocompleteEntry {
   readonly kind: 'create' | 'existing';
   readonly label: string;
+  readonly value: string;
+}
+
+interface PreparedManagerAutocompleteOption {
+  readonly normalized: string;
   readonly value: string;
 }
 
@@ -69,8 +74,10 @@ export function managerAutocompleteEntries(
   query: string,
   allowCreate: boolean,
 ): readonly ManagerAutocompleteEntry[] {
-  const trimmedQuery = query.trim();
-  const normalizedQuery = trimmedQuery.toLocaleLowerCase();
+  return managerAutocompleteEntriesFromPrepared(prepareManagerAutocompleteOptions(options), query, allowCreate);
+}
+
+function prepareManagerAutocompleteOptions(options: readonly string[]): readonly PreparedManagerAutocompleteOption[] {
   const unique = new Map<string, string>();
   for (const option of options) {
     const trimmed = option.trim();
@@ -78,11 +85,22 @@ export function managerAutocompleteEntries(
     const normalized = trimmed.toLocaleLowerCase();
     if (!unique.has(normalized)) unique.set(normalized, trimmed);
   }
-  const existing = [...unique.entries()]
-    .filter(([normalized]) => normalized.includes(normalizedQuery))
-    .map(([, value]): ManagerAutocompleteEntry => ({kind: 'existing', label: value, value}))
+  return [...unique.entries()]
+    .map(([normalized, value]) => ({normalized, value}))
     .sort((left, right) => left.value.localeCompare(right.value));
-  if (!allowCreate || !trimmedQuery || unique.has(normalizedQuery)) return existing;
+}
+
+function managerAutocompleteEntriesFromPrepared(
+  options: readonly PreparedManagerAutocompleteOption[],
+  query: string,
+  allowCreate: boolean,
+): readonly ManagerAutocompleteEntry[] {
+  const trimmedQuery = query.trim();
+  const normalizedQuery = trimmedQuery.toLocaleLowerCase();
+  const existing = options
+    .filter(option => option.normalized.includes(normalizedQuery))
+    .map(({value}): ManagerAutocompleteEntry => ({kind: 'existing', label: value, value}));
+  if (!allowCreate || !trimmedQuery || options.some(option => option.normalized === normalizedQuery)) return existing;
   return [{kind: 'create', label: `Create “${trimmedQuery}”`, value: trimmedQuery}, ...existing];
 }
 
@@ -90,9 +108,10 @@ export function ManagerAutocompleteInput(props: ManagerAutocompleteInputProps): 
   const listboxId = `${useId()}-options`;
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const preparedOptions = useMemo(() => prepareManagerAutocompleteOptions(props.options), [props.options]);
   const entries = useMemo(
-    () => managerAutocompleteEntries(props.options, props.value, props.allowCreate === true),
-    [props.allowCreate, props.options, props.value],
+    () => managerAutocompleteEntriesFromPrepared(preparedOptions, props.value, props.allowCreate === true),
+    [preparedOptions, props.allowCreate, props.value],
   );
   const activeEntry = entries[activeIndex];
 

--- a/src/manager_dialog.tsx
+++ b/src/manager_dialog.tsx
@@ -1,0 +1,416 @@
+import React, {createContext, useCallback, useContext, useEffect, useId, useMemo, useRef, useState} from 'react';
+
+export type ManagerDialogTone = 'default' | 'danger';
+
+export interface ManagerDialogField {
+  readonly allowCreate?: boolean;
+  readonly description?: string;
+  readonly id: string;
+  readonly initialValue?: string;
+  readonly label: string;
+  readonly options?: readonly string[];
+  readonly placeholder?: string;
+  readonly required?: boolean;
+}
+
+export interface ManagerDialogOptions {
+  readonly cancelLabel?: string;
+  readonly confirmLabel?: string;
+  readonly detail?: string;
+  readonly fields?: readonly ManagerDialogField[];
+  readonly message?: string;
+  readonly title: string;
+  readonly tone?: ManagerDialogTone;
+}
+
+export type ManagerDialogValues = Readonly<Record<string, string>>;
+
+export type ManagerDialogValidation =
+  {readonly fieldId: string; readonly ok: false} | {readonly ok: true; readonly values: ManagerDialogValues};
+
+interface ManagerDialogs {
+  readonly confirm: (options: ManagerDialogOptions) => Promise<boolean>;
+  readonly prompt: (options: ManagerDialogOptions) => Promise<ManagerDialogValues | undefined>;
+}
+
+interface PendingDialog {
+  readonly options: ManagerDialogOptions;
+  readonly resolve: (result: ManagerDialogValues | undefined) => void;
+}
+
+export interface ManagerAutocompleteEntry {
+  readonly kind: 'create' | 'existing';
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface ManagerAutocompleteInputProps {
+  readonly allowCreate?: boolean;
+  readonly disabled?: boolean;
+  readonly id?: string;
+  readonly initialFocus?: boolean;
+  readonly invalid?: boolean;
+  readonly name?: string;
+  readonly onChange: (value: string) => void;
+  readonly options: readonly string[];
+  readonly placeholder?: string;
+  readonly required?: boolean;
+  readonly value: string;
+}
+
+const ManagerDialogContext = createContext<ManagerDialogs | undefined>(undefined);
+const INERT_MANAGER_DIALOGS: ManagerDialogs = {
+  confirm: () => Promise.resolve(false),
+  prompt: () => Promise.resolve(undefined),
+};
+
+export function managerAutocompleteEntries(
+  options: readonly string[],
+  query: string,
+  allowCreate: boolean,
+): readonly ManagerAutocompleteEntry[] {
+  const trimmedQuery = query.trim();
+  const normalizedQuery = trimmedQuery.toLocaleLowerCase();
+  const unique = new Map<string, string>();
+  for (const option of options) {
+    const trimmed = option.trim();
+    if (!trimmed) continue;
+    const normalized = trimmed.toLocaleLowerCase();
+    if (!unique.has(normalized)) unique.set(normalized, trimmed);
+  }
+  const existing = [...unique.entries()]
+    .filter(([normalized]) => normalized.includes(normalizedQuery))
+    .map(([, value]): ManagerAutocompleteEntry => ({kind: 'existing', label: value, value}))
+    .sort((left, right) => left.value.localeCompare(right.value));
+  if (!allowCreate || !trimmedQuery || unique.has(normalizedQuery)) return existing;
+  return [{kind: 'create', label: `Create “${trimmedQuery}”`, value: trimmedQuery}, ...existing];
+}
+
+export function ManagerAutocompleteInput(props: ManagerAutocompleteInputProps): React.ReactElement {
+  const listboxId = `${useId()}-options`;
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const entries = useMemo(
+    () => managerAutocompleteEntries(props.options, props.value, props.allowCreate === true),
+    [props.allowCreate, props.options, props.value],
+  );
+  const activeEntry = entries[activeIndex];
+
+  useEffect(() => {
+    setActiveIndex(current => Math.min(current, Math.max(0, entries.length - 1)));
+  }, [entries.length]);
+
+  const choose = (entry: ManagerAutocompleteEntry): void => {
+    props.onChange(entry.value);
+    setOpen(false);
+  };
+
+  return (
+    <div
+      className="manager-autocomplete"
+      onBlur={event => {
+        const relatedTarget = event.relatedTarget;
+        if (!(relatedTarget instanceof Node) || !event.currentTarget.contains(relatedTarget)) setOpen(false);
+      }}
+    >
+      <input
+        aria-activedescendant={open && activeEntry ? `${listboxId}-${activeIndex}` : undefined}
+        aria-autocomplete="list"
+        aria-controls={listboxId}
+        aria-expanded={open && entries.length > 0}
+        aria-haspopup="listbox"
+        aria-invalid={props.invalid}
+        aria-required={props.required}
+        autoComplete="off"
+        data-manager-dialog-initial-focus={props.initialFocus}
+        disabled={props.disabled}
+        id={props.id}
+        name={props.name}
+        onChange={event => {
+          props.onChange(event.target.value);
+          setActiveIndex(0);
+          setOpen(true);
+        }}
+        onClick={() => {
+          setActiveIndex(0);
+          setOpen(true);
+        }}
+        onKeyDown={event => {
+          if (event.key === 'Escape' && open) {
+            event.preventDefault();
+            event.stopPropagation();
+            setOpen(false);
+            return;
+          }
+          if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && entries.length > 0) {
+            event.preventDefault();
+            setOpen(true);
+            setActiveIndex(current =>
+              event.key === 'ArrowDown'
+                ? (current + 1) % entries.length
+                : (current - 1 + entries.length) % entries.length,
+            );
+            return;
+          }
+          if (event.key === 'Enter' && open && activeEntry) {
+            event.preventDefault();
+            choose(activeEntry);
+          }
+        }}
+        placeholder={props.placeholder}
+        required={props.required}
+        role="combobox"
+        value={props.value}
+      />
+      {open && entries.length > 0 ? (
+        <div className="manager-autocomplete-menu" id={listboxId} role="listbox">
+          {entries.map((entry, index) => (
+            <button
+              aria-selected={index === activeIndex}
+              className={`${entry.kind === 'create' ? 'is-create' : ''} ${index === activeIndex ? 'is-active' : ''}`}
+              id={`${listboxId}-${index}`}
+              key={`${entry.kind}:${entry.value}`}
+              onClick={() => choose(entry)}
+              onMouseDown={event => event.preventDefault()}
+              onMouseEnter={() => setActiveIndex(index)}
+              role="option"
+              type="button"
+            >
+              {entry.kind === 'create' ? <span aria-hidden="true">+</span> : null}
+              {entry.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function validateManagerDialogValues(
+  fields: readonly ManagerDialogField[],
+  input: Readonly<Record<string, string>>,
+): ManagerDialogValidation {
+  const values: Record<string, string> = {};
+  for (const field of fields) {
+    const value = (input[field.id] ?? '').trim();
+    if (field.required && value.length === 0) {
+      return {fieldId: field.id, ok: false};
+    }
+    values[field.id] = value;
+  }
+  return {ok: true, values};
+}
+
+export function ManagerDialogProvider(props: {readonly children: React.ReactNode}): React.ReactElement {
+  const [pending, setPending] = useState<PendingDialog | undefined>();
+  const pendingRef = useRef<PendingDialog | undefined>(undefined);
+  const queueRef = useRef<PendingDialog[]>([]);
+
+  const present = useCallback((next: PendingDialog): void => {
+    if (pendingRef.current) {
+      queueRef.current.push(next);
+      return;
+    }
+    pendingRef.current = next;
+    setPending(next);
+  }, []);
+
+  const finish = useCallback((result: ManagerDialogValues | undefined): void => {
+    const current = pendingRef.current;
+    if (!current) return;
+    current.resolve(result);
+    const next = queueRef.current.shift();
+    pendingRef.current = next;
+    setPending(next);
+  }, []);
+
+  const prompt = useCallback(
+    (options: ManagerDialogOptions): Promise<ManagerDialogValues | undefined> =>
+      new Promise(resolve => present({options, resolve})),
+    [present],
+  );
+
+  const confirm = useCallback(
+    async (options: ManagerDialogOptions): Promise<boolean> =>
+      (await prompt({...options, fields: options.fields ?? []})) !== undefined,
+    [prompt],
+  );
+
+  useEffect(
+    () => () => {
+      pendingRef.current?.resolve(undefined);
+      for (const queued of queueRef.current.splice(0)) queued.resolve(undefined);
+    },
+    [],
+  );
+
+  const dialogs = useMemo(() => ({confirm, prompt}), [confirm, prompt]);
+  return (
+    <ManagerDialogContext.Provider value={dialogs}>
+      {props.children}
+      {pending ? <ManagerDialog onFinish={finish} request={pending} /> : null}
+    </ManagerDialogContext.Provider>
+  );
+}
+
+export function useManagerDialogs(): ManagerDialogs {
+  const dialogs = useContext(ManagerDialogContext);
+  if (!dialogs) throw new Error('Manager dialogs must be used inside ManagerDialogProvider.');
+  return dialogs;
+}
+
+export function useOptionalManagerDialogs(): ManagerDialogs {
+  return useContext(ManagerDialogContext) ?? INERT_MANAGER_DIALOGS;
+}
+
+function ManagerDialog(props: {
+  readonly onFinish: (result: ManagerDialogValues | undefined) => void;
+  readonly request: PendingDialog;
+}): React.ReactElement {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [validationField, setValidationField] = useState<string | undefined>();
+  const {options} = props.request;
+  const fields = options.fields ?? [];
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>(() => initialDialogValues(fields));
+  const tone = options.tone ?? 'default';
+  const dialogId = useId();
+  const titleId = `${dialogId}-title`;
+  const descriptionId = options.message ? `${dialogId}-description` : undefined;
+
+  useEffect(() => {
+    setValidationField(undefined);
+    setFieldValues(initialDialogValues(fields));
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (!dialog.open) dialog.showModal();
+    dialog.querySelector<HTMLElement>('[data-manager-dialog-initial-focus="true"]')?.focus();
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, [props.request]);
+
+  const submit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const result = validateManagerDialogValues(fields, fieldValues);
+    if (!result.ok) {
+      setValidationField(result.fieldId);
+      const invalidField = form.elements.namedItem(result.fieldId);
+      if (invalidField instanceof HTMLElement) invalidField.focus();
+      return;
+    }
+    props.onFinish(result.values);
+  };
+
+  return (
+    <dialog
+      aria-describedby={descriptionId}
+      aria-labelledby={titleId}
+      aria-modal="true"
+      className="manager-dialog"
+      onCancel={event => {
+        event.preventDefault();
+        props.onFinish(undefined);
+      }}
+      onKeyDown={event => {
+        if (event.key !== 'Escape') return;
+        event.preventDefault();
+        event.stopPropagation();
+        props.onFinish(undefined);
+      }}
+      ref={dialogRef}
+    >
+      <form className={`manager-dialog-card is-${tone}`} noValidate onSubmit={submit}>
+        <header className="manager-dialog-header">
+          <span aria-hidden="true" className="manager-dialog-mark">
+            {tone === 'danger' ? '!' : '◇'}
+          </span>
+          <div>
+            <p>
+              {tone === 'danger'
+                ? 'Confirm destructive action'
+                : fields.length > 0
+                  ? 'Review details'
+                  : 'Confirm action'}
+            </p>
+            <h2 id={titleId}>{options.title}</h2>
+          </div>
+        </header>
+        <div className="manager-dialog-body">
+          {options.message ? <p id={descriptionId}>{options.message}</p> : null}
+          {options.detail ? <code className="manager-dialog-detail">{options.detail}</code> : null}
+          {fields.length > 0 ? (
+            <div className="manager-dialog-fields">
+              {fields.map((field, index) => {
+                const inputId = `${dialogId}-${field.id}`;
+                return (
+                  <div className="manager-dialog-field" key={field.id}>
+                    <label htmlFor={inputId}>
+                      {field.label}
+                      {field.required ? <em>Required</em> : null}
+                    </label>
+                    {field.options ? (
+                      <ManagerAutocompleteInput
+                        allowCreate={field.allowCreate}
+                        id={inputId}
+                        initialFocus={index === 0}
+                        invalid={validationField === field.id}
+                        name={field.id}
+                        onChange={value => {
+                          setFieldValues(current => ({...current, [field.id]: value}));
+                          if (validationField === field.id) setValidationField(undefined);
+                        }}
+                        options={field.options}
+                        placeholder={field.placeholder}
+                        required={field.required}
+                        value={fieldValues[field.id] ?? ''}
+                      />
+                    ) : (
+                      <input
+                        aria-invalid={validationField === field.id}
+                        aria-required={field.required}
+                        data-manager-dialog-initial-focus={index === 0}
+                        id={inputId}
+                        name={field.id}
+                        onChange={event => {
+                          setFieldValues(current => ({...current, [field.id]: event.target.value}));
+                          if (validationField === field.id) setValidationField(undefined);
+                        }}
+                        placeholder={field.placeholder}
+                        required={field.required}
+                        value={fieldValues[field.id] ?? ''}
+                      />
+                    )}
+                    {field.description ? <small>{field.description}</small> : null}
+                    {validationField === field.id ? <strong>Enter a value to continue.</strong> : null}
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+        <footer className="manager-dialog-actions">
+          <button
+            className="quiet-button"
+            data-manager-dialog-initial-focus={fields.length === 0 && tone === 'danger'}
+            onClick={() => props.onFinish(undefined)}
+            type="button"
+          >
+            {options.cancelLabel ?? 'Cancel'}
+          </button>
+          <button
+            className={tone === 'danger' ? 'danger' : ''}
+            data-manager-dialog-initial-focus={fields.length === 0 && tone === 'default'}
+            type="submit"
+          >
+            {options.confirmLabel ?? 'Continue'}
+          </button>
+        </footer>
+      </form>
+    </dialog>
+  );
+}
+
+function initialDialogValues(fields: readonly ManagerDialogField[]): Record<string, string> {
+  return Object.fromEntries(fields.map(field => [field.id, field.initialValue ?? '']));
+}

--- a/src/manager_graph.tsx
+++ b/src/manager_graph.tsx
@@ -9,6 +9,7 @@ import {
   MANAGER_GRAPH_MAX_NODE_LIMIT,
   type ManagerGraphVisualizationLimits,
 } from './manager_graph_limits.js';
+import {type ManagerDialogOptions, useOptionalManagerDialogs} from './manager_dialog.js';
 
 interface GraphProject {
   readonly buildSystem?: string;
@@ -3090,22 +3091,45 @@ function GraphAdministration(props: {
   readonly output?: string;
   readonly report?: CodeGraphDiagnosticsReport;
 }): React.ReactElement {
+  const dialogs = useOptionalManagerDialogs();
   const [analyze, setAnalyze] = useState(false);
   const [deep, setDeep] = useState(false);
   const [forceCompact, setForceCompact] = useState(false);
   const blocked = props.busy !== undefined;
-  const confirmAction = (message: string, action: GraphAdministrationAction): void => {
-    if (window.confirm(message)) props.onAction(action);
+  const confirmAction = async (options: ManagerDialogOptions, action: GraphAdministrationAction): Promise<void> => {
+    if (await dialogs.confirm(options)) props.onAction(action);
   };
-  const targetAction = (
+  const targetAction = async (
     managementAvailable: boolean,
     action: Extract<GraphAdministrationAction, {readonly worktreeId: string}>,
-  ): GraphAdministrationAction | undefined => {
+  ): Promise<GraphAdministrationAction | undefined> => {
     if (managementAvailable) return action;
-    const cwd = window.prompt(
-      'Threadnote has no current local path for this indexed view. Enter an absolute path to its worktree. The server will verify its graph identity before acting.',
-    );
-    return cwd?.trim() ? {...action, cwd: cwd.trim()} : undefined;
+    const values = await dialogs.prompt({
+      confirmLabel: 'Use worktree',
+      detail: `Checkout ${action.checkoutId.slice(-12)} · view ${action.worktreeId.slice(-8)}`,
+      fields: [
+        {
+          description: 'Threadnote verifies this path against the indexed checkout and worktree before acting.',
+          id: 'cwd',
+          label: 'Absolute worktree path',
+          placeholder: '/absolute/path/to/worktree',
+          required: true,
+        },
+      ],
+      message: 'Threadnote has no current local path for this indexed view.',
+      title: 'Locate the indexed worktree',
+    });
+    return values ? {...action, cwd: values.cwd} : undefined;
+  };
+  const dispatchTargetAction = async (
+    managementAvailable: boolean,
+    action: Extract<GraphAdministrationAction, {readonly worktreeId: string}>,
+    confirmation?: ManagerDialogOptions,
+  ): Promise<void> => {
+    const targeted = await targetAction(managementAvailable, action);
+    if (!targeted) return;
+    if (confirmation && !(await dialogs.confirm(confirmation))) return;
+    props.onAction(targeted);
   };
   return (
     <details className="graph-administration">
@@ -3153,10 +3177,15 @@ function GraphAdministration(props: {
           <button
             disabled={blocked}
             onClick={() =>
-              confirmAction(
-                deep
-                  ? 'Deep repair may discard corrupt disposable graph databases. Continue?'
-                  : 'Run immediate quick repair and pending graph schema migrations?',
+              void confirmAction(
+                {
+                  confirmLabel: deep ? 'Run deep repair' : 'Run repair',
+                  message: deep
+                    ? 'Deep repair may discard corrupt disposable graph databases after integrity checks.'
+                    : 'Run immediate quick repair and pending graph schema migrations.',
+                  title: deep ? 'Repair every graph deeply?' : 'Repair every graph?',
+                  tone: deep ? 'danger' : 'default',
+                },
                 {action: 'repair', deep},
               )
             }
@@ -3171,7 +3200,15 @@ function GraphAdministration(props: {
             className="danger"
             disabled={blocked}
             onClick={() =>
-              confirmAction('Purge every local disposable native code graph index?', {action: 'purge-all'})
+              void confirmAction(
+                {
+                  confirmLabel: 'Purge every graph',
+                  message: 'Every local native code graph index will be removed and rebuilt on demand.',
+                  title: 'Purge all disposable graphs?',
+                  tone: 'danger',
+                },
+                {action: 'purge-all'},
+              )
             }
             type="button"
           >
@@ -3275,8 +3312,7 @@ function GraphAdministration(props: {
                       disabled={blocked || !target}
                       onClick={() => {
                         if (!target) return;
-                        const action = targetAction(managementAvailable, {action: 'index', ...target});
-                        if (action) props.onAction(action);
+                        void dispatchTargetAction(managementAvailable, {action: 'index', ...target});
                       }}
                       type="button"
                     >
@@ -3286,8 +3322,7 @@ function GraphAdministration(props: {
                       disabled={blocked || !target}
                       onClick={() => {
                         if (!target) return;
-                        const action = targetAction(managementAvailable, {action: 'index', full: true, ...target});
-                        if (action) props.onAction(action);
+                        void dispatchTargetAction(managementAvailable, {action: 'index', full: true, ...target});
                       }}
                       type="button"
                     >
@@ -3297,13 +3332,12 @@ function GraphAdministration(props: {
                       disabled={blocked || !target}
                       onClick={() => {
                         if (!target) return;
-                        const action = targetAction(managementAvailable, {
+                        void dispatchTargetAction(managementAvailable, {
                           action: 'compact',
                           dryRun: true,
                           force: forceCompact,
                           ...target,
                         });
-                        if (action) props.onAction(action);
                       }}
                       type="button"
                     >
@@ -3313,12 +3347,16 @@ function GraphAdministration(props: {
                       disabled={blocked || !target}
                       onClick={() => {
                         if (!target) return;
-                        const action = targetAction(managementAvailable, {
-                          action: 'compact',
-                          force: forceCompact,
-                          ...target,
-                        });
-                        if (action) confirmAction('Compact this verified graph database now?', action);
+                        void dispatchTargetAction(
+                          managementAvailable,
+                          {action: 'compact', force: forceCompact, ...target},
+                          {
+                            confirmLabel: 'Compact graph',
+                            detail: repository,
+                            message: 'Rewrite this verified graph database to reclaim reviewed free space.',
+                            title: 'Compact this graph?',
+                          },
+                        );
                       }}
                       type="button"
                     >
@@ -3342,10 +3380,16 @@ function GraphAdministration(props: {
                         <button
                           disabled={blocked}
                           onClick={() =>
-                            confirmAction(`Purge ${obsolete.fileCount} verified obsolete graph file(s)?`, {
-                              action: 'purge-obsolete',
-                              checkoutId: database.checkoutId,
-                            })
+                            void confirmAction(
+                              {
+                                confirmLabel: 'Purge obsolete files',
+                                detail: repository,
+                                message: `Remove ${obsolete.fileCount} verified obsolete graph file${obsolete.fileCount === 1 ? '' : 's'}.`,
+                                title: 'Purge obsolete graph files?',
+                                tone: 'danger',
+                              },
+                              {action: 'purge-obsolete', checkoutId: database.checkoutId},
+                            )
                           }
                           type="button"
                         >
@@ -3364,10 +3408,16 @@ function GraphAdministration(props: {
                       className="danger"
                       disabled={blocked}
                       onClick={() =>
-                        confirmAction('Purge this disposable native graph index?', {
-                          action: 'purge',
-                          checkoutId: database.checkoutId,
-                        })
+                        void confirmAction(
+                          {
+                            confirmLabel: 'Purge graph',
+                            detail: repository,
+                            message: 'Remove this disposable native graph index. It will rebuild on demand.',
+                            title: 'Purge this graph?',
+                            tone: 'danger',
+                          },
+                          {action: 'purge', checkoutId: database.checkoutId},
+                        )
                       }
                       type="button"
                     >

--- a/src/manager_graph.tsx
+++ b/src/manager_graph.tsx
@@ -89,13 +89,18 @@ export interface GraphCatalog {
 
 export type GraphAdministrationAction =
   | {
-      readonly action: 'compact' | 'index' | 'purge' | 'purge-obsolete';
+      readonly action: 'compact' | 'index';
       readonly checkoutId: string;
       readonly cwd?: string;
       readonly dryRun?: boolean;
       readonly force?: boolean;
       readonly full?: boolean;
       readonly worktreeId: string;
+    }
+  | {
+      readonly action: 'purge' | 'purge-obsolete';
+      readonly checkoutId: string;
+      readonly dryRun?: boolean;
     }
   | {readonly action: 'purge-all'; readonly dryRun?: boolean}
   | {readonly action: 'repair'; readonly deep?: boolean; readonly dryRun?: boolean};
@@ -3094,7 +3099,7 @@ function GraphAdministration(props: {
   };
   const targetAction = (
     managementAvailable: boolean,
-    action: Extract<GraphAdministrationAction, {readonly checkoutId: string}>,
+    action: Extract<GraphAdministrationAction, {readonly worktreeId: string}>,
   ): GraphAdministrationAction | undefined => {
     if (managementAvailable) return action;
     const cwd = window.prompt(
@@ -3322,32 +3327,26 @@ function GraphAdministration(props: {
                     {obsolete ? (
                       <>
                         <button
-                          disabled={blocked || !target}
-                          onClick={() => {
-                            if (!target) return;
-                            const action = targetAction(managementAvailable, {
+                          disabled={blocked}
+                          onClick={() =>
+                            props.onAction({
                               action: 'purge-obsolete',
+                              checkoutId: database.checkoutId,
                               dryRun: true,
-                              ...target,
-                            });
-                            if (action) props.onAction(action);
-                          }}
+                            })
+                          }
                           type="button"
                         >
                           Preview obsolete
                         </button>
                         <button
-                          disabled={blocked || !target}
-                          onClick={() => {
-                            if (!target) return;
-                            const action = targetAction(managementAvailable, {
+                          disabled={blocked}
+                          onClick={() =>
+                            confirmAction(`Purge ${obsolete.fileCount} verified obsolete graph file(s)?`, {
                               action: 'purge-obsolete',
-                              ...target,
-                            });
-                            if (action) {
-                              confirmAction(`Purge ${obsolete.fileCount} verified obsolete graph file(s)?`, action);
-                            }
-                          }}
+                              checkoutId: database.checkoutId,
+                            })
+                          }
                           type="button"
                         >
                           Purge obsolete
@@ -3355,24 +3354,21 @@ function GraphAdministration(props: {
                       </>
                     ) : null}
                     <button
-                      disabled={blocked || !target}
-                      onClick={() => {
-                        if (!target) return;
-                        const action = targetAction(managementAvailable, {action: 'purge', dryRun: true, ...target});
-                        if (action) props.onAction(action);
-                      }}
+                      disabled={blocked}
+                      onClick={() => props.onAction({action: 'purge', checkoutId: database.checkoutId, dryRun: true})}
                       type="button"
                     >
                       Preview purge
                     </button>
                     <button
                       className="danger"
-                      disabled={blocked || !target}
-                      onClick={() => {
-                        if (!target) return;
-                        const action = targetAction(managementAvailable, {action: 'purge', ...target});
-                        if (action) confirmAction('Purge this disposable native graph index?', action);
-                      }}
+                      disabled={blocked}
+                      onClick={() =>
+                        confirmAction('Purge this disposable native graph index?', {
+                          action: 'purge',
+                          checkoutId: database.checkoutId,
+                        })
+                      }
                       type="button"
                     >
                       Purge graph
@@ -3380,7 +3376,8 @@ function GraphAdministration(props: {
                   </div>
                   {!managementAvailable ? (
                     <small className="graph-management-unavailable">
-                      Enter the local worktree path when prompted; Threadnote verifies it against this graph identity.
+                      Index, reindex, and compact require a verified local worktree path. Purge actions target this
+                      inventoried checkout directly.
                     </small>
                   ) : null}
                 </article>

--- a/src/manager_ui.tsx
+++ b/src/manager_ui.tsx
@@ -3,6 +3,7 @@ import {createRoot} from 'react-dom/client';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type {CodeGraphDiagnosticsReport} from './code_graph/diagnostics.js';
+import {ManagerAutocompleteInput, ManagerDialogProvider, useManagerDialogs} from './manager_dialog.js';
 import {
   GraphWorkspace,
   graphBuildIsActive,
@@ -162,6 +163,7 @@ function loadSidebarWidth(): number {
 }
 
 function App(): React.ReactElement {
+  const dialogs = useManagerDialogs();
   const [panel, setPanel] = useState<PanelName>('graph');
   const [state, setState] = useState<StateResponse | undefined>();
   const [graphCatalog, setGraphCatalog] = useState<GraphCatalog | undefined>();
@@ -317,6 +319,11 @@ function App(): React.ReactElement {
   );
   const selectedList = useMemo(() => [...visibleSelectedUris], [visibleSelectedUris]);
   const outputUris = useMemo(() => resourceUrisFromText(output), [output]);
+  const projectOptions = useMemo(() => managerProjectOptions(tree), [tree]);
+  const teamOptions = useMemo(
+    () => uniqueSelectorValues(['default', ...shares.map(share => share.name), target.team]),
+    [shares, target.team],
+  );
 
   async function refreshAll(): Promise<void> {
     const [nextState, nextTree, nextShares, nextGraphs] = await Promise.all([
@@ -527,16 +534,27 @@ function App(): React.ReactElement {
   }
 
   async function archiveCurrent(): Promise<void> {
-    if (!selectedUri || !window.confirm(`Archive ${selectedUri}?`)) {
-      return;
-    }
+    if (!selectedUri) return;
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Archive memory',
+      detail: selectedUri,
+      message: 'The memory stays available in the archive and can be restored later.',
+      title: 'Archive this memory?',
+    });
+    if (!confirmed) return;
     await runAction('Archived memory', () => api('/api/memory/archive', {confirm: true, uri: selectedUri}));
   }
 
   async function forgetCurrent(): Promise<void> {
-    if (!selectedUri || !window.confirm(`Forget ${selectedUri}? This removes it from local context.`)) {
-      return;
-    }
+    if (!selectedUri) return;
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Forget memory',
+      detail: selectedUri,
+      message: 'This permanently removes the memory from local context.',
+      title: 'Forget this memory?',
+      tone: 'danger',
+    });
+    if (!confirmed) return;
     await runAction('Forgot memory', () => api('/api/memory/forget', {confirm: true, uri: selectedUri}));
     setSelectedUri(undefined);
   }
@@ -554,13 +572,14 @@ function App(): React.ReactElement {
       return;
     }
     const fileCount = countFiles(selectedNode);
-    if (
-      !window.confirm(
-        `Remove folder ${selectedNode.uri} and ${fileCount} file${fileCount === 1 ? '' : 's'}? This cannot be undone.`,
-      )
-    ) {
-      return;
-    }
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Remove folder',
+      detail: selectedNode.uri,
+      message: `This permanently removes ${fileCount} memory file${fileCount === 1 ? '' : 's'} from local context.`,
+      title: 'Remove this folder?',
+      tone: 'danger',
+    });
+    if (!confirmed) return;
     try {
       const result = await api<{readonly output?: string}>('/api/folder/remove', {
         confirm: true,
@@ -581,60 +600,101 @@ function App(): React.ReactElement {
   }
 
   async function publishCurrent(): Promise<void> {
-    if (!selectedUri) {
-      return;
-    }
-    const team = window.prompt('Team name', target.team || 'default') ?? '';
-    if (!team) {
-      return;
-    }
-    await runAction('Published memory', () => api('/api/memory/publish', {confirm: true, team, uri: selectedUri}));
+    if (!selectedUri) return;
+    const values = await dialogs.prompt({
+      confirmLabel: 'Publish memory',
+      detail: selectedUri,
+      fields: [
+        {
+          id: 'team',
+          initialValue: target.team || 'default',
+          label: 'Team',
+          options: teamOptions,
+          required: true,
+        },
+      ],
+      message: 'Publish this personal durable memory to a configured shared repository.',
+      title: 'Publish memory',
+    });
+    if (!values) return;
+    await runAction('Published memory', () =>
+      api('/api/memory/publish', {confirm: true, team: values.team, uri: selectedUri}),
+    );
   }
 
   async function unpublishCurrent(): Promise<void> {
-    if (!selectedUri || !window.confirm(`Unpublish ${selectedUri}?`)) {
-      return;
-    }
+    if (!selectedUri) return;
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Unpublish memory',
+      detail: selectedUri,
+      message: 'Remove this memory from its shared repository projection.',
+      title: 'Unpublish this memory?',
+      tone: 'danger',
+    });
+    if (!confirmed) return;
     await runAction('Unpublished memory', () =>
       api('/api/memory/unpublish', {confirm: true, team: target.team, uri: selectedUri}),
     );
   }
 
   async function moveCurrent(): Promise<void> {
-    if (!selectedUri) {
-      return;
-    }
-    const project = window.prompt('Project', target.project) ?? '';
-    const topic = window.prompt('Topic', target.topic) ?? '';
-    const team = window.prompt('Team for shared target, or blank for personal', target.team) ?? '';
-    if (!project || !topic || !window.confirm(`Move ${selectedUri}?`)) {
-      return;
-    }
+    if (!selectedUri) return;
+    const values = await dialogs.prompt({
+      confirmLabel: 'Move memory',
+      detail: selectedUri,
+      fields: [
+        {
+          allowCreate: true,
+          id: 'project',
+          initialValue: target.project,
+          label: 'Project',
+          options: projectOptions,
+          required: true,
+        },
+        {id: 'topic', initialValue: target.topic, label: 'Topic', required: true},
+        {
+          description: 'Leave blank to move it to personal memory.',
+          id: 'team',
+          initialValue: target.team,
+          label: 'Shared team',
+          options: teamOptions,
+        },
+      ],
+      message: 'Review the destination before moving this memory.',
+      title: 'Move memory',
+    });
+    if (!values) return;
     await runAction('Moved memory', () =>
       api('/api/memory/move', {
         confirm: true,
         kind: target.kind,
-        project,
+        project: values.project,
         status: target.status,
-        team,
-        topic,
+        team: values.team,
+        topic: values.topic,
         uri: selectedUri,
       }),
     );
   }
 
   async function bulk(action: 'archive' | 'forget' | 'publish'): Promise<void> {
-    if (
-      bulkAction ||
-      selectedList.length === 0 ||
-      !window.confirm(`${action} ${selectedList.length} selected memories?`)
-    ) {
-      return;
-    }
-    const team = action === 'publish' ? (window.prompt('Team name', 'default')?.trim() ?? '') : undefined;
-    if (action === 'publish' && !team) {
-      return;
-    }
+    if (bulkAction || selectedList.length === 0) return;
+    const title = `${bulkActionLabel(action)} ${selectedList.length} selected ${selectedList.length === 1 ? 'memory' : 'memories'}?`;
+    const values = await dialogs.prompt({
+      confirmLabel: bulkActionLabel(action),
+      fields:
+        action === 'publish'
+          ? [{id: 'team', initialValue: 'default', label: 'Team', options: teamOptions, required: true}]
+          : undefined,
+      message:
+        action === 'forget'
+          ? 'This permanently removes every selected memory from local context.'
+          : 'Only the currently selected memories will be changed.',
+      title,
+      tone: action === 'forget' ? 'danger' : 'default',
+    });
+    if (!values) return;
+    const team = action === 'publish' ? values.team : undefined;
     const currentSelectedUri = selectedUri;
     setBulkAction(action);
     try {
@@ -740,15 +800,13 @@ function App(): React.ReactElement {
   }
 
   async function applyConsolidation(): Promise<void> {
-    if (
-      draftingConsolidation ||
-      applyingConsolidation ||
-      !jobId ||
-      !draft ||
-      !window.confirm('Apply this consolidation and archive personal sources?')
-    ) {
-      return;
-    }
+    if (draftingConsolidation || applyingConsolidation || !jobId || !draft) return;
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Apply consolidation',
+      message: `Store the consolidated memory and archive ${consolidationSourceUris.length} personal source${consolidationSourceUris.length === 1 ? '' : 's'}.`,
+      title: 'Apply this consolidation?',
+    });
+    if (!confirmed) return;
     const sourceUris = consolidationSourceUris;
     const currentSelectedUri = selectedUri;
     setApplyingConsolidation(true);
@@ -784,6 +842,81 @@ function App(): React.ReactElement {
     } finally {
       setApplyingConsolidation(false);
     }
+  }
+
+  async function removeSelectedShare(): Promise<void> {
+    if (!selectedShare) return;
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Remove share',
+      detail: selectedShare,
+      message: keepShareFiles
+        ? 'Disconnect this shared repository and keep its local files.'
+        : 'Disconnect this shared repository and remove its managed local files.',
+      title: 'Remove this share?',
+      tone: 'danger',
+    });
+    if (!confirmed) return;
+    await runAction('Removed share', () =>
+      api('/api/shares/remove', {
+        confirm: true,
+        keepFiles: keepShareFiles,
+        preserveLocal: preserveShare,
+        team: selectedShare,
+      }),
+    );
+    await loadShares();
+  }
+
+  async function repairThreadnote(): Promise<void> {
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Run repair',
+      message: 'Run Threadnote repair now and write the approved maintenance changes.',
+      title: 'Repair Threadnote?',
+    });
+    if (!confirmed) return;
+    await runDoctorAction('Repair complete', 'Running repair', () => api('/api/doctor/repair', {confirm: true}));
+  }
+
+  async function applyCompactPlan(): Promise<void> {
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Apply compact plan',
+      message: 'Apply the current memory compaction plan and write its changes.',
+      title: 'Compact memories?',
+    });
+    if (!confirmed) return;
+    await runAction('Compact applied', () =>
+      api('/api/compact', {
+        apply: true,
+        confirm: true,
+        project: compactProject,
+        topic: compactTopic,
+      }).then(result => result as {output: string}),
+    );
+  }
+
+  async function importPack(): Promise<void> {
+    const confirmed = await dialogs.confirm({
+      confirmLabel: 'Import pack',
+      detail: packPath || 'No path entered',
+      message: 'Import memories and resources from this pack into local Threadnote storage.',
+      title: 'Import this pack?',
+    });
+    if (!confirmed) return;
+    await runAction('Import complete', () => api('/api/import-pack', {confirm: true, path: packPath}));
+  }
+
+  async function seedThreadnote(skills: boolean): Promise<void> {
+    const confirmed = await dialogs.confirm({
+      confirmLabel: skills ? 'Seed skills' : 'Seed resources',
+      message: skills
+        ? 'Write the configured Threadnote skills into their managed destinations.'
+        : 'Write the configured Threadnote resources into local storage.',
+      title: skills ? 'Run seed-skills?' : 'Run seed?',
+    });
+    if (!confirmed) return;
+    await runAction(skills ? 'Seed skills complete' : 'Seed complete', () =>
+      api('/api/seed', {confirm: true, ...(skills ? {skills: true} : {})}),
+    );
   }
 
   function selectTreeUri(uri: string): void {
@@ -1162,6 +1295,7 @@ function App(): React.ReactElement {
                   disabled={metadataFieldsDisabled}
                   onChange={setTarget}
                   openSelect={openSelect}
+                  projectOptions={projectOptions}
                   setOpenSelect={setOpenSelect}
                   target={target}
                 />
@@ -1218,18 +1352,7 @@ function App(): React.ReactElement {
             keepShareFiles={keepShareFiles}
             loadShares={loadShares}
             preserveShare={preserveShare}
-            removeShare={() =>
-              window.confirm(`Remove share ${selectedShare}?`)
-                ? runAction('Removed share', () =>
-                    api('/api/shares/remove', {
-                      confirm: true,
-                      keepFiles: keepShareFiles,
-                      preserveLocal: preserveShare,
-                      team: selectedShare,
-                    }),
-                  ).then(loadShares)
-                : undefined
-            }
+            removeShare={() => void removeSelectedShare()}
             renameShare={() =>
               runAction('Renamed share', () =>
                 api('/api/shares/rename', {confirm: true, team: selectedShare, to: renameShareTo}),
@@ -1285,16 +1408,7 @@ function App(): React.ReactElement {
                 >
                   Repair Dry Run
                 </button>
-                <button
-                  disabled={doctorBusy}
-                  onClick={() =>
-                    window.confirm('Run Threadnote repair and write changes?')
-                      ? void runDoctorAction('Repair complete', 'Running repair', () =>
-                          api('/api/doctor/repair', {confirm: true}),
-                        )
-                      : undefined
-                  }
-                >
+                <button disabled={doctorBusy} onClick={() => void repairThreadnote()}>
                   Repair
                 </button>
               </div>
@@ -1329,9 +1443,11 @@ function App(): React.ReactElement {
                     onChange={event => setRecallQuery(event.target.value)}
                     placeholder="Search memories and seeded resources"
                   />
-                  <input
+                  <ManagerAutocompleteInput
+                    allowCreate={false}
+                    onChange={setRecallProject}
+                    options={projectOptions}
                     value={recallProject}
-                    onChange={event => setRecallProject(event.target.value)}
                     placeholder="project scope (blank = all)"
                   />
                   <button
@@ -1373,9 +1489,11 @@ function App(): React.ReactElement {
               <aside className="form-pane">
                 <section className="form-section">
                   <h3>Hygiene</h3>
-                  <input
+                  <ManagerAutocompleteInput
+                    allowCreate={false}
+                    onChange={setCompactProject}
+                    options={projectOptions}
                     value={compactProject}
-                    onChange={event => setCompactProject(event.target.value)}
                     placeholder="project"
                   />
                   <input
@@ -1395,22 +1513,7 @@ function App(): React.ReactElement {
                     >
                       Dry Run
                     </button>
-                    <button
-                      onClick={() =>
-                        window.confirm('Apply compact plan?')
-                          ? void runAction('Compact applied', () =>
-                              api('/api/compact', {
-                                apply: true,
-                                confirm: true,
-                                project: compactProject,
-                                topic: compactTopic,
-                              }).then(result => result as {output: string}),
-                            )
-                          : undefined
-                      }
-                    >
-                      Apply
-                    </button>
+                    <button onClick={() => void applyCompactPlan()}>Apply</button>
                   </div>
                 </section>
                 <section className="form-section">
@@ -1426,42 +1529,14 @@ function App(): React.ReactElement {
                     >
                       Export
                     </button>
-                    <button
-                      onClick={() =>
-                        window.confirm(`Import ${packPath}?`)
-                          ? void runAction('Import complete', () =>
-                              api('/api/import-pack', {confirm: true, path: packPath}),
-                            )
-                          : undefined
-                      }
-                    >
-                      Import
-                    </button>
+                    <button onClick={() => void importPack()}>Import</button>
                   </div>
                 </section>
                 <section className="form-section">
                   <h3>Seed</h3>
                   <div className="button-row">
-                    <button
-                      onClick={() =>
-                        window.confirm('Run Threadnote seed and write resources?')
-                          ? void runAction('Seed complete', () => api('/api/seed', {confirm: true}))
-                          : undefined
-                      }
-                    >
-                      Seed
-                    </button>
-                    <button
-                      onClick={() =>
-                        window.confirm('Run Threadnote seed-skills and write resources?')
-                          ? void runAction('Seed skills complete', () =>
-                              api('/api/seed', {confirm: true, skills: true}),
-                            )
-                          : undefined
-                      }
-                    >
-                      Seed Skills
-                    </button>
+                    <button onClick={() => void seedThreadnote(false)}>Seed</button>
+                    <button onClick={() => void seedThreadnote(true)}>Seed Skills</button>
                   </div>
                 </section>
               </aside>
@@ -1605,6 +1680,7 @@ function TargetFields(props: {
   readonly disabled: boolean;
   readonly onChange: (value: TargetForm) => void;
   readonly openSelect?: SelectId;
+  readonly projectOptions: readonly string[];
   readonly setOpenSelect: (value: SelectId | undefined) => void;
   readonly target: TargetForm;
 }): React.ReactElement {
@@ -1637,11 +1713,13 @@ function TargetFields(props: {
         setOpenSelect={props.setOpenSelect}
         value={props.target.status}
       />
-      <input
+      <ManagerAutocompleteInput
+        allowCreate
         disabled={props.disabled}
-        value={props.target.project}
-        onChange={event => set({project: event.target.value})}
+        onChange={project => set({project})}
+        options={props.projectOptions}
         placeholder="project"
+        value={props.target.project}
       />
       <input
         disabled={props.disabled}
@@ -1733,6 +1811,10 @@ function SharesPanel(props: {
   readonly shareTeam: string;
   readonly syncShare: () => void;
 }): React.ReactElement {
+  const teamOptions = useMemo(
+    () => uniqueSelectorValues(['default', ...props.shares.map(share => share.name)]),
+    [props.shares],
+  );
   return (
     <section className="panel is-active">
       <div className="split">
@@ -1764,10 +1846,12 @@ function SharesPanel(props: {
         </section>
         <aside className="form-pane">
           <h3>Create Share</h3>
-          <input
-            value={props.shareTeam}
-            onChange={event => props.setShareTeam(event.target.value)}
+          <ManagerAutocompleteInput
+            allowCreate
+            onChange={props.setShareTeam}
+            options={teamOptions}
             placeholder="team name"
+            value={props.shareTeam}
           />
           <input
             value={props.shareRemote}
@@ -1776,15 +1860,18 @@ function SharesPanel(props: {
           />
           <button onClick={props.createShare}>Create</button>
           <h3>Selected Share</h3>
-          <input
-            value={props.selectedShare}
-            onChange={event => props.setSelectedShare(event.target.value)}
+          <ManagerAutocompleteInput
+            onChange={props.setSelectedShare}
+            options={teamOptions}
             placeholder="team"
+            value={props.selectedShare}
           />
-          <input
-            value={props.renameShareTo}
-            onChange={event => props.setRenameShareTo(event.target.value)}
+          <ManagerAutocompleteInput
+            allowCreate
+            onChange={props.setRenameShareTo}
+            options={teamOptions}
             placeholder="new team name"
+            value={props.renameShareTo}
           />
           <button onClick={props.renameShare}>Rename</button>
           <input
@@ -1961,6 +2048,27 @@ function findNodeInTrees(trees: readonly (TreeNode | undefined)[], uri: string):
   return undefined;
 }
 
+export function managerProjectOptions(tree: TreeNode | undefined): readonly string[] {
+  const projects: string[] = [];
+  const visit = (node: TreeNode): void => {
+    if (node.metadata?.project) projects.push(node.metadata.project);
+    for (const child of node.children ?? []) visit(child);
+  };
+  if (tree) visit(tree);
+  return uniqueSelectorValues(projects);
+}
+
+function uniqueSelectorValues(values: readonly string[]): readonly string[] {
+  const unique = new Map<string, string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const normalized = trimmed.toLocaleLowerCase();
+    if (!unique.has(normalized)) unique.set(normalized, trimmed);
+  }
+  return [...unique.values()].sort((left, right) => left.localeCompare(right));
+}
+
 function treeItemClass(active: boolean, readOnly: boolean, base?: string): string | undefined {
   const classes = [base, active ? 'is-active' : undefined, readOnly ? 'is-readonly' : undefined].filter(
     (value): value is string => typeof value === 'string',
@@ -2055,6 +2163,17 @@ function formatBulkResults(action: string, results: readonly BulkItemResult[]): 
   ].join('\n');
 }
 
+function bulkActionLabel(action: 'archive' | 'forget' | 'publish'): string {
+  switch (action) {
+    case 'archive':
+      return 'Archive';
+    case 'forget':
+      return 'Forget';
+    case 'publish':
+      return 'Publish';
+  }
+}
+
 function actionProgressLabel(action: 'archive' | 'forget' | 'publish'): string {
   switch (action) {
     case 'archive':
@@ -2135,5 +2254,9 @@ if (typeof document !== 'undefined') {
   if (!root) {
     throw new Error('Missing #root');
   }
-  createRoot(root).render(<App />);
+  createRoot(root).render(
+    <ManagerDialogProvider>
+      <App />
+    </ManagerDialogProvider>,
+  );
 }

--- a/test/unit/code-graph.benchmark-harness.test.ts
+++ b/test/unit/code-graph.benchmark-harness.test.ts
@@ -553,10 +553,15 @@ describe('code graph external benchmark harness', () => {
             leaseRows: 0,
           };
           let leaseRenewals = 0;
+          let comparisonLease: string | undefined;
           const pinned = yield* sqliteStructuralGraphEvidence(databasePath, firstSnapshotId, {
             onReadTransactionStarted: Effect.gen(function* () {
               yield* store.promote(databasePath, identity, replacementSnapshotId, new Set([identity.worktreeId]));
               yield* store.pruneRetiredSnapshots(databasePath);
+              // Lease release now retires a superseded view automatically. Hold
+              // a second reader lease so this test can intentionally compare
+              // the post-write digest after the pinned read transaction ends.
+              comparisonLease = yield* store.acquireSnapshotLease(databasePath, firstSnapshotId, 60_000);
               const writer = new Database(databasePath, {strict: true});
               try {
                 writer.run('PRAGMA busy_timeout = 5000');
@@ -573,6 +578,8 @@ describe('code graph external benchmark harness', () => {
             snapshotLeaseRenewalMilliseconds: 100,
           });
           const after = yield* sqliteStructuralGraphEvidence(databasePath, firstSnapshotId);
+          if (comparisonLease === undefined) return yield* Effect.die(new Error('Comparison lease was not acquired.'));
+          yield* store.releaseSnapshotLease(databasePath, comparisonLease);
           const mismatch = codeGraphStructuralParityEvidence(before, after);
           const failureMessage = codeGraphStructuralParityFailureMessage(mismatch);
           yield* store.reconcileWorktrees(databasePath, new Set([identity.worktreeId]));
@@ -618,7 +625,7 @@ describe('code graph external benchmark harness', () => {
       baseFileRows: 1,
       baseState: 'ready',
       firstState: 'ready',
-      leaseRows: 1,
+      leaseRows: 2,
     });
     expect(result.mismatch.mismatchedStreams.map(stream => stream.name)).toEqual(['snapshot']);
     expect(result.leaseRenewals).toBeGreaterThanOrEqual(1);

--- a/test/unit/code-graph.manager-catalog.test.ts
+++ b/test/unit/code-graph.manager-catalog.test.ts
@@ -5,7 +5,11 @@ import * as BunServices from '@effect/platform-bun/BunServices';
 import {Database} from 'bun:sqlite';
 import {Effect, Layer, Option} from 'effect';
 import {afterEach, describe, expect, it} from 'vitest';
-import {groupManagerGraphRepositories, managerGraphCatalog} from '../../src/code_graph/visualization.js';
+import {
+  groupManagerGraphRepositories,
+  managerGraphCatalog,
+  releaseManagerGraphSnapshotLeases,
+} from '../../src/code_graph/visualization.js';
 import {
   CodeGraphStore,
   codeGraphVisualizationCatalogComponentStatement,
@@ -848,6 +852,30 @@ describe('Manager logical repository and workspace catalogs', () => {
     expect(catalog.repositories).toEqual([]);
     expect(catalog.diagnostics).toEqual([expect.objectContaining({checkoutId, code: 'unreadable-database'})]);
     expect(catalog.diagnostics[0]?.message).not.toContain(home);
+  });
+
+  it('releases catalog snapshot leases when the Manager lifecycle ends', async () => {
+    const home = temporaryRoot('threadnote-manager-lease-lifecycle-');
+    const identity = repositoryIdentity(home, '9'.repeat(64));
+    const databasePath = join(home, 'indexes', 'code-graph', 'repositories', identity.checkoutId, 'graph-v3.sqlite');
+    const snapshot = readySnapshot(identity, 0, 0, 0, '2026-08-05T12:00:00.000Z');
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.activate(databasePath, identity, snapshot, [], [], []);
+        yield* managerGraphCatalog(home);
+      }).pipe(Effect.provide(storeLayer)),
+    );
+    const leased = new Database(databasePath, {readonly: true});
+    expect(leased.query('SELECT COUNT(*) AS count FROM snapshot_leases').get()).toEqual({count: 1});
+    leased.close();
+
+    await Effect.runPromise(releaseManagerGraphSnapshotLeases().pipe(Effect.provide(storeLayer)));
+
+    const released = new Database(databasePath, {readonly: true});
+    expect(released.query('SELECT COUNT(*) AS count FROM snapshot_leases').get()).toEqual({count: 0});
+    released.close();
   });
 });
 

--- a/test/unit/code-graph.purge.test.ts
+++ b/test/unit/code-graph.purge.test.ts
@@ -1,0 +1,167 @@
+import {readFile, readlink, rm as nodeRm, symlink} from 'node:fs/promises';
+import {Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
+import fc from 'fast-check';
+import {afterEach, describe, expect, it} from 'vitest';
+import {codeGraphRepositoryLockPath} from '../../src/code_graph/layout.js';
+import {purgeCodeGraphIndex} from '../../src/code_graph/maintenance.js';
+import {withExclusiveFileLock} from '../../src/effect/file_lock.js';
+import {join, mkdir, mkdtemp, rm, writeFile} from '../helpers/effect-filesystem.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+describe('targeted code graph purge', () => {
+  const homes: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+  });
+
+  it('previews and removes only the selected checkout without a worktree path', async () => {
+    const home = await mkdtemp('threadnote-targeted-graph-purge-');
+    homes.push(home);
+    const checkoutId = 'a'.repeat(64);
+    const siblingCheckoutId = 'b'.repeat(64);
+    const repositoryRoot = join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+    const siblingRoot = join(home, 'indexes', 'code-graph', 'repositories', siblingCheckoutId);
+    await mkdir(join(repositoryRoot, 'vectors'), {recursive: true});
+    await mkdir(siblingRoot, {recursive: true});
+    await writeFile(join(repositoryRoot, 'graph-v3.sqlite'), 'disposable graph\n');
+    await writeFile(join(repositoryRoot, 'vectors', 'model.sqlite'), 'disposable vectors\n');
+    await writeFile(join(siblingRoot, 'graph-v3.sqlite'), 'sibling must survive\n');
+
+    await expect(runEffect(purgeCodeGraphIndex(home, checkoutId, {dryRun: true}))).resolves.toEqual({
+      checkoutId,
+      dryRun: true,
+      existed: true,
+    });
+    await expect(Bun.file(join(repositoryRoot, 'graph-v3.sqlite')).exists()).resolves.toBe(true);
+
+    await expect(runEffect(purgeCodeGraphIndex(home, checkoutId, {dryRun: false}))).resolves.toEqual({
+      checkoutId,
+      dryRun: false,
+      existed: true,
+    });
+    await expect(Bun.file(join(repositoryRoot, 'graph-v3.sqlite')).exists()).resolves.toBe(false);
+    await expect(readFile(join(siblingRoot, 'graph-v3.sqlite'), 'utf8')).resolves.toContain('must survive');
+
+    await expect(runEffect(purgeCodeGraphIndex(home, checkoutId, {dryRun: false}))).resolves.toEqual({
+      checkoutId,
+      dryRun: false,
+      existed: false,
+    });
+  });
+
+  it('rejects invalid checkout identities before inspecting storage', async () => {
+    const home = await mkdtemp('threadnote-targeted-graph-purge-invalid-');
+    homes.push(home);
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string().filter(value => !/^[0-9a-f]{64}$/.test(value)),
+        async checkoutId => {
+          await expect(runEffect(purgeCodeGraphIndex(home, checkoutId, {dryRun: false}))).rejects.toThrow(
+            'Code graph checkout identity is invalid',
+          );
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'refuses a symbolic-link checkout root and preserves its target',
+    async () => {
+      const home = await mkdtemp('threadnote-targeted-graph-purge-link-');
+      homes.push(home);
+      const checkoutId = 'c'.repeat(64);
+      const repositories = join(home, 'indexes', 'code-graph', 'repositories');
+      const repositoryRoot = join(repositories, checkoutId);
+      const external = join(home, 'external-graph');
+      await mkdir(repositories, {recursive: true});
+      await mkdir(external, {recursive: true});
+      await writeFile(join(external, 'keep.txt'), 'external target must survive\n');
+      await symlink(external, repositoryRoot);
+
+      await expect(runEffect(purgeCodeGraphIndex(home, checkoutId, {dryRun: false}))).rejects.toThrow(
+        'symbolic-link checkout root',
+      );
+      await expect(readFile(join(external, 'keep.txt'), 'utf8')).resolves.toContain('must survive');
+      await expect(readlink(repositoryRoot)).resolves.toBe(external);
+    },
+  );
+
+  it('fails immediately while an active build owns the checkout lock', async () => {
+    const home = await mkdtemp('threadnote-targeted-graph-purge-lock-');
+    homes.push(home);
+    const checkoutId = 'd'.repeat(64);
+    const repositoryRoot = join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+    await mkdir(repositoryRoot, {recursive: true});
+    await writeFile(join(repositoryRoot, 'graph-v3.sqlite'), 'locked graph\n');
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const acquired = yield* Deferred.make<void>();
+        const release = yield* Deferred.make<void>();
+        const owner = yield* Effect.forkChild(
+          withExclusiveFileLock(
+            fs,
+            codeGraphRepositoryLockPath(path, home, checkoutId),
+            {
+              heartbeatIntervalMilliseconds: 20,
+              onAcquired: () => Deferred.succeed(acquired, undefined).pipe(Effect.asVoid),
+              retryIntervalMilliseconds: 5,
+              staleAfterMilliseconds: 100,
+              waitTimeoutMilliseconds: 5_000,
+            },
+            Deferred.await(release),
+          ),
+        );
+        yield* Deferred.await(acquired);
+        const purged = yield* purgeCodeGraphIndex(home, checkoutId, {dryRun: false}).pipe(
+          Effect.match({
+            onFailure: error => ({error, success: false as const}),
+            onSuccess: summary => ({success: true as const, summary}),
+          }),
+        );
+        yield* Deferred.succeed(release, undefined);
+        yield* Fiber.join(owner);
+        return purged;
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatchObject({name: 'FileLockTimeout'});
+    await expect(readFile(join(repositoryRoot, 'graph-v3.sqlite'), 'utf8')).resolves.toContain('locked');
+  });
+
+  it.skipIf(process.platform === 'win32')('revalidates the checkout root after planning', async () => {
+    const home = await mkdtemp('threadnote-targeted-graph-purge-race-');
+    homes.push(home);
+    const checkoutId = 'e'.repeat(64);
+    const repositories = join(home, 'indexes', 'code-graph', 'repositories');
+    const repositoryRoot = join(repositories, checkoutId);
+    const external = join(home, 'external-race-graph');
+    await mkdir(repositoryRoot, {recursive: true});
+    await mkdir(external, {recursive: true});
+    await writeFile(join(repositoryRoot, 'graph-v3.sqlite'), 'initial graph\n');
+    await writeFile(join(external, 'keep.txt'), 'external race target must survive\n');
+
+    await expect(
+      runEffect(
+        purgeCodeGraphIndex(home, checkoutId, {
+          dryRun: false,
+          interlock: {
+            beforeVerification: () =>
+              Effect.promise(async () => {
+                await nodeRm(repositoryRoot, {recursive: true});
+                await symlink(external, repositoryRoot);
+              }),
+          },
+        }),
+      ),
+    ).rejects.toThrow('symbolic-link checkout root');
+    await expect(readFile(join(external, 'keep.txt'), 'utf8')).resolves.toContain('must survive');
+    await expect(readlink(repositoryRoot)).resolves.toBe(external);
+  });
+});

--- a/test/unit/code-graph.purge.test.ts
+++ b/test/unit/code-graph.purge.test.ts
@@ -1,4 +1,4 @@
-import {readFile, readlink, rm as nodeRm, symlink} from 'node:fs/promises';
+import {readFile, readlink, rename, rm as nodeRm, symlink} from 'node:fs/promises';
 import {Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
 import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
@@ -163,5 +163,61 @@ describe('targeted code graph purge', () => {
     ).rejects.toThrow('symbolic-link checkout root');
     await expect(readFile(join(external, 'keep.txt'), 'utf8')).resolves.toContain('must survive');
     await expect(readlink(repositoryRoot)).resolves.toBe(external);
+  });
+
+  it('refuses a same-path directory replacement and preserves its contents', async () => {
+    const home = await mkdtemp('threadnote-targeted-graph-purge-directory-race-');
+    homes.push(home);
+    const checkoutId = 'f'.repeat(64);
+    const repositoryRoot = join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+    const sentinel = join(repositoryRoot, 'replacement-must-survive.txt');
+    await mkdir(repositoryRoot, {recursive: true});
+    await writeFile(join(repositoryRoot, 'graph-v3.sqlite'), 'initial graph\n');
+
+    await expect(
+      runEffect(
+        purgeCodeGraphIndex(home, checkoutId, {
+          dryRun: false,
+          interlock: {
+            beforeVerification: () =>
+              Effect.promise(async () => {
+                await nodeRm(repositoryRoot, {recursive: true});
+                await mkdir(repositoryRoot, {recursive: true});
+                await writeFile(sentinel, 'replacement must survive\n');
+              }),
+          },
+        }),
+      ),
+    ).rejects.toThrow('checkout target changed before purge');
+    await expect(readFile(sentinel, 'utf8')).resolves.toContain('must survive');
+  });
+
+  it('quarantines atomically and restores a directory swapped after verification', async () => {
+    const home = await mkdtemp('threadnote-targeted-graph-purge-removal-race-');
+    homes.push(home);
+    const checkoutId = '1'.repeat(64);
+    const repositoryRoot = join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+    const displacedRoot = join(home, 'displaced-original-graph');
+    const sentinel = join(repositoryRoot, 'replacement-must-survive.txt');
+    await mkdir(repositoryRoot, {recursive: true});
+    await writeFile(join(repositoryRoot, 'graph-v3.sqlite'), 'initial graph\n');
+
+    await expect(
+      runEffect(
+        purgeCodeGraphIndex(home, checkoutId, {
+          dryRun: false,
+          interlock: {
+            beforeRemoval: () =>
+              Effect.promise(async () => {
+                await rename(repositoryRoot, displacedRoot);
+                await mkdir(repositoryRoot, {recursive: true});
+                await writeFile(sentinel, 'replacement must survive\n');
+              }),
+          },
+        }),
+      ),
+    ).rejects.toThrow('checkout target changed before purge');
+    await expect(readFile(sentinel, 'utf8')).resolves.toContain('must survive');
+    await expect(readFile(join(displacedRoot, 'graph-v3.sqlite'), 'utf8')).resolves.toContain('initial graph');
   });
 });

--- a/test/unit/code-graph.snapshot-retention.test.ts
+++ b/test/unit/code-graph.snapshot-retention.test.ts
@@ -40,6 +40,29 @@ describe('code graph ready snapshot retention', () => {
     }
   });
 
+  it('reclaims a non-active snapshot after an explicitly transient lease is released', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-transient-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const transient = snapshot(identity, 'transient-by-id');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [transient]);
+        const lease = yield* store.acquireSnapshotLease(databasePath, transient.id, 60_000, {
+          retireWhenInactive: true,
+        });
+        yield* store.releaseSnapshotLease(databasePath, lease);
+        yield* waitForSnapshotRemoval(databasePath, transient.id);
+      }),
+    );
+
+    expect(readSnapshotState(databasePath, transient.id)).toBeUndefined();
+  });
+
   it('reclaims a superseded snapshot when its last lease is released and preserves the active view and base', async () => {
     const root = await mkdtemp('threadnote-ready-retention-release-');
     temporaryRoots.push(root);

--- a/test/unit/code-graph.snapshot-retention.test.ts
+++ b/test/unit/code-graph.snapshot-retention.test.ts
@@ -1,0 +1,283 @@
+import {Database} from 'bun:sqlite';
+import {Effect} from 'effect';
+import {afterEach, describe, expect, it} from 'vitest';
+import {CodeGraphStore, type CodeGraphStoreShape} from '../../src/code_graph/store.js';
+import type {CodeGraphSnapshot, RepositoryIdentity} from '../../src/code_graph/types.js';
+import {join, mkdtemp, rm} from '../helpers/effect-filesystem.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(root => rm(root, {force: true, recursive: true})));
+});
+
+describe('code graph ready snapshot retention', () => {
+  it('preserves a ready snapshot that was leased by ID without becoming an active worktree view', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-non-active-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const exported = snapshot(identity, 'exported-by-id');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [exported]);
+        const lease = yield* store.acquireSnapshotLease(databasePath, exported.id, 60_000);
+        yield* store.releaseSnapshotLease(databasePath, lease);
+      }),
+    );
+
+    const database = new Database(databasePath, {readonly: true, strict: true});
+    try {
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(exported.id)).toEqual({state: 'ready'});
+      expect(database.query('SELECT COUNT(*) AS count FROM active_snapshots').get()).toEqual({count: 0});
+      expect(database.query('SELECT COUNT(*) AS count FROM snapshot_leases').get()).toEqual({count: 0});
+    } finally {
+      database.close(false);
+    }
+  });
+
+  it('reclaims a superseded snapshot when its last lease is released and preserves the active view and base', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-release-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const base = snapshot(identity, 'base', {dirty: false});
+    const superseded = snapshot(identity, 'superseded', {baseSnapshotId: base.id});
+    const current = snapshot(identity, 'current', {baseSnapshotId: base.id});
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [base, superseded]);
+        yield* store.promote(databasePath, identity, superseded.id, new Set([identity.worktreeId]));
+        const lease = yield* store.acquireSnapshotLease(databasePath, superseded.id, 60_000);
+        yield* registerReadySnapshots(store, databasePath, identity, [current]);
+        yield* store.promote(databasePath, identity, current.id, new Set([identity.worktreeId]));
+        yield* Effect.sync(() => seedSymbol(databasePath, superseded.id));
+
+        expect(readSnapshotState(databasePath, superseded.id)).toBe('ready');
+        yield* store.releaseSnapshotLease(databasePath, lease);
+        expect(readSnapshotState(databasePath, superseded.id)).not.toBe('ready');
+        yield* waitForSnapshotRemoval(databasePath, superseded.id);
+      }),
+    );
+
+    const database = new Database(databasePath, {readonly: true, strict: true});
+    try {
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(superseded.id)).toBeNull();
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(base.id)).toEqual({state: 'ready'});
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(current.id)).toEqual({state: 'ready'});
+      expect(
+        database.query('SELECT snapshot_id FROM active_snapshots WHERE worktree_id = ?').get(identity.worktreeId),
+      ).toEqual({snapshot_id: current.id});
+      expect(database.query('SELECT COUNT(*) AS count FROM snapshot_leases').get()).toEqual({count: 0});
+      expect(database.query('PRAGMA foreign_key_check').all()).toEqual([]);
+    } finally {
+      database.close(false);
+    }
+  });
+
+  it('reaps an expired reader lease on the next ordinary acquire', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-expired-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const superseded = snapshot(identity, 'expired-reader');
+    const current = snapshot(identity, 'current');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [superseded]);
+        yield* store.promote(databasePath, identity, superseded.id, new Set([identity.worktreeId]));
+        const expiredLease = yield* store.acquireSnapshotLease(databasePath, superseded.id, 60_000);
+        yield* registerReadySnapshots(store, databasePath, identity, [current]);
+        yield* store.promote(databasePath, identity, current.id, new Set([identity.worktreeId]));
+        yield* Effect.sync(() => expireLease(databasePath, expiredLease));
+
+        const currentLease = yield* store.acquireSnapshotLease(databasePath, current.id, 60_000);
+        yield* waitForSnapshotRemoval(databasePath, superseded.id);
+        yield* store.releaseSnapshotLease(databasePath, currentLease);
+      }),
+    );
+
+    const database = new Database(databasePath, {readonly: true, strict: true});
+    try {
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(superseded.id)).toBeNull();
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(current.id)).toEqual({state: 'ready'});
+      expect(database.query('SELECT COUNT(*) AS count FROM snapshot_leases').get()).toEqual({count: 0});
+    } finally {
+      database.close(false);
+    }
+  });
+
+  it('migrates an expired displaced active-view lease from the pre-retention schema', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-migration-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const superseded = snapshot(identity, 'legacy-expired-reader');
+    const current = snapshot(identity, 'current');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [superseded]);
+        yield* store.promote(databasePath, identity, superseded.id, new Set([identity.worktreeId]));
+        const expiredLease = yield* store.acquireSnapshotLease(databasePath, superseded.id, 60_000);
+        yield* registerReadySnapshots(store, databasePath, identity, [current]);
+        yield* store.promote(databasePath, identity, current.id, new Set([identity.worktreeId]));
+        yield* Effect.sync(() => {
+          expireLease(databasePath, expiredLease);
+          dropLeaseRetirementColumn(databasePath);
+        });
+
+        yield* store.initialize(databasePath);
+        const currentLease = yield* store.acquireSnapshotLease(databasePath, current.id, 60_000);
+        yield* waitForSnapshotRemoval(databasePath, superseded.id);
+        yield* store.releaseSnapshotLease(databasePath, currentLease);
+      }),
+    );
+
+    const database = new Database(databasePath, {readonly: true, strict: true});
+    try {
+      const columns = database.query("PRAGMA table_info('snapshot_leases')").all() as readonly {
+        readonly name: string;
+      }[];
+      expect(columns.map(column => column.name)).toContain('retire_when_inactive');
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(superseded.id)).toBeNull();
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(current.id)).toEqual({state: 'ready'});
+    } finally {
+      database.close(false);
+    }
+  });
+});
+
+function registerReadySnapshots(
+  store: CodeGraphStoreShape,
+  databasePath: string,
+  identity: RepositoryIdentity,
+  snapshots: readonly CodeGraphSnapshot[],
+) {
+  return Effect.gen(function* () {
+    for (const candidate of snapshots) yield* store.markBuilding(databasePath, identity, candidate);
+    yield* Effect.sync(() => {
+      const database = new Database(databasePath, {strict: true});
+      try {
+        const ready = database.prepare("UPDATE snapshots SET state = 'ready', completed_at = ? WHERE id = ?");
+        const generation = database.prepare(
+          "INSERT INTO snapshot_extractor_generations (snapshot_id, generation) SELECT ?, CAST(value AS INTEGER) FROM schema_metadata WHERE key = 'minimum_extractor_generation'",
+        );
+        database.transaction(() => {
+          for (const candidate of snapshots) {
+            ready.run(new Date().toISOString(), candidate.id);
+            generation.run(candidate.id);
+          }
+        })();
+      } finally {
+        database.close(false);
+      }
+    });
+  });
+}
+
+function repositoryIdentity(root: string): RepositoryIdentity {
+  return {
+    caseMode: 'sensitive',
+    checkoutId: 'c'.repeat(64),
+    displayName: 'snapshot-retention-fixture',
+    gitCommonDirectory: root,
+    headCommit: '1'.repeat(40),
+    objectFormat: 'sha1',
+    repoRoot: root,
+    repositoryId: 'r'.repeat(64),
+    worktreeId: 'w'.repeat(64),
+  };
+}
+
+function snapshot(
+  identity: RepositoryIdentity,
+  suffix: string,
+  options: {readonly baseSnapshotId?: string; readonly dirty?: boolean} = {},
+): CodeGraphSnapshot {
+  const dirty = options.dirty ?? true;
+  return {
+    ...(options.baseSnapshotId ? {baseSnapshotId: options.baseSnapshotId} : {}),
+    commit: identity.headCommit,
+    dirty,
+    edgeCount: 0,
+    extractorSet: 'extractor-set',
+    fileCount: 0,
+    id: `cgsn_${suffix}`,
+    ...(dirty ? {overlayFingerprint: `overlay-${suffix}`} : {}),
+    repositoryId: identity.repositoryId,
+    state: 'building',
+    symbolCount: 0,
+    worktreeId: identity.worktreeId,
+  };
+}
+
+function seedSymbol(databasePath: string, snapshotId: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database
+      .query(
+        `INSERT INTO symbols (
+           snapshot_id, id, content_hash, kind, name, qualified_name, path, language,
+           arity, lookup_keys_json, resolution_domain, resolution_scope_id, package_name,
+           exported, signature, documentation, span_json
+         ) VALUES (?, 'superseded-symbol', 'content', 'function', 'stale', 'stale',
+           'src/stale.ts', 'typescript', NULL, '[]', 'typescript', NULL, NULL, 0,
+           NULL, NULL, '{"startLine":1,"endLine":1}')`,
+      )
+      .run(snapshotId);
+  } finally {
+    database.close(false);
+  }
+}
+
+function expireLease(databasePath: string, token: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.query('UPDATE snapshot_leases SET expires_at = ? WHERE token = ?').run(Date.now() - 1, token);
+  } finally {
+    database.close(false);
+  }
+}
+
+function dropLeaseRetirementColumn(databasePath: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.run('ALTER TABLE snapshot_leases DROP COLUMN retire_when_inactive');
+  } finally {
+    database.close(false);
+  }
+}
+
+function readSnapshotState(databasePath: string, snapshotId: string): string | undefined {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return (
+      database.query('SELECT state FROM snapshots WHERE id = ?').get(snapshotId) as {readonly state: string} | undefined
+    )?.state;
+  } finally {
+    database.close(false);
+  }
+}
+
+function waitForSnapshotRemoval(databasePath: string, snapshotId: string) {
+  return Effect.gen(function* () {
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      if (readSnapshotState(databasePath, snapshotId) === undefined) return;
+      yield* Effect.sleep(10);
+    }
+    return yield* Effect.fail(new Error(`Timed out waiting for retired snapshot ${snapshotId} to be reclaimed.`));
+  });
+}

--- a/test/unit/code-graph.snapshot-retention.test.ts
+++ b/test/unit/code-graph.snapshot-retention.test.ts
@@ -82,6 +82,123 @@ describe('code graph ready snapshot retention', () => {
     }
   });
 
+  it('reclaims the detached base of a superseded leased overlay', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-base-closure-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const base = snapshot(identity, 'detached-base', {dirty: false});
+    const superseded = snapshot(identity, 'leased-overlay', {baseSnapshotId: base.id});
+    const current = snapshot(identity, 'unrelated-current');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [base, superseded]);
+        yield* store.promote(databasePath, identity, superseded.id, new Set([identity.worktreeId]));
+        const lease = yield* store.acquireSnapshotLease(databasePath, superseded.id, 60_000);
+        yield* registerReadySnapshots(store, databasePath, identity, [current]);
+        yield* store.promote(databasePath, identity, current.id, new Set([identity.worktreeId]));
+
+        yield* store.releaseSnapshotLease(databasePath, lease);
+        yield* waitForSnapshotRemoval(databasePath, superseded.id);
+        yield* waitForSnapshotRemoval(databasePath, base.id);
+      }),
+    );
+
+    expect(readSnapshotState(databasePath, superseded.id)).toBeUndefined();
+    expect(readSnapshotState(databasePath, base.id)).toBeUndefined();
+    expect(readSnapshotState(databasePath, current.id)).toBe('ready');
+  });
+
+  it('keeps a displaced view until every overlapping lease is released', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-overlapping-leases-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const displaced = snapshot(identity, 'overlap-displaced');
+    const current = snapshot(identity, 'overlap-current');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [displaced]);
+        yield* store.promote(databasePath, identity, displaced.id, new Set([identity.worktreeId]));
+        const first = yield* store.acquireSnapshotLease(databasePath, displaced.id, 60_000);
+        const second = yield* store.acquireSnapshotLease(databasePath, displaced.id, 60_000);
+        yield* registerReadySnapshots(store, databasePath, identity, [current]);
+        yield* store.promote(databasePath, identity, current.id, new Set([identity.worktreeId]));
+
+        yield* store.releaseSnapshotLease(databasePath, first);
+        expect(readSnapshotState(databasePath, displaced.id)).toBe('ready');
+        yield* store.releaseSnapshotLease(databasePath, second);
+        yield* waitForSnapshotRemoval(databasePath, displaced.id);
+      }),
+    );
+
+    expect(readSnapshotState(databasePath, displaced.id)).toBeUndefined();
+    expect(readSnapshotState(databasePath, current.id)).toBe('ready');
+  });
+
+  it('carries retirement provenance from an expired lease to a renewed overlapping lease', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-renewed-overlap-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const displaced = snapshot(identity, 'renew-displaced');
+    const current = snapshot(identity, 'renew-current');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [displaced]);
+        yield* store.promote(databasePath, identity, displaced.id, new Set([identity.worktreeId]));
+        const expired = yield* store.acquireSnapshotLease(databasePath, displaced.id, 60_000);
+        const renewed = yield* store.acquireSnapshotLease(databasePath, displaced.id, 60_000);
+        yield* registerReadySnapshots(store, databasePath, identity, [current]);
+        yield* store.promote(databasePath, identity, current.id, new Set([identity.worktreeId]));
+        yield* Effect.sync(() => expireLease(databasePath, expired));
+
+        yield* store.renewSnapshotLease(databasePath, renewed, 60_000);
+        expect(readSnapshotState(databasePath, displaced.id)).toBe('ready');
+        yield* store.releaseSnapshotLease(databasePath, renewed);
+        yield* waitForSnapshotRemoval(databasePath, displaced.id);
+      }),
+    );
+
+    expect(readSnapshotState(databasePath, displaced.id)).toBeUndefined();
+  });
+
+  it('retires a lease acquired by ID when that snapshot is later promoted and displaced', async () => {
+    const root = await mkdtemp('threadnote-ready-retention-acquire-promote-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const identity = repositoryIdentity(root);
+    const acquired = snapshot(identity, 'acquired-before-promotion');
+    const current = snapshot(identity, 'after-acquired-promotion');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* registerReadySnapshots(store, databasePath, identity, [acquired]);
+        const lease = yield* store.acquireSnapshotLease(databasePath, acquired.id, 60_000);
+        yield* store.promote(databasePath, identity, acquired.id, new Set([identity.worktreeId]));
+        yield* registerReadySnapshots(store, databasePath, identity, [current]);
+        yield* store.promote(databasePath, identity, current.id, new Set([identity.worktreeId]));
+
+        yield* store.releaseSnapshotLease(databasePath, lease);
+        yield* waitForSnapshotRemoval(databasePath, acquired.id);
+      }),
+    );
+
+    expect(readSnapshotState(databasePath, acquired.id)).toBeUndefined();
+    expect(readSnapshotState(databasePath, current.id)).toBe('ready');
+  });
+
   it('reaps an expired reader lease on the next ordinary acquire', async () => {
     const root = await mkdtemp('threadnote-ready-retention-expired-');
     temporaryRoots.push(root);

--- a/test/unit/manager-dialog.test.ts
+++ b/test/unit/manager-dialog.test.ts
@@ -1,14 +1,48 @@
+// @vitest-environment happy-dom
+
 import {readFile} from 'node:fs/promises';
 import {join} from 'node:path';
 import fc from 'fast-check';
-import {describe, expect, it} from 'vitest';
+import React, {useState} from 'react';
+import {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {
+  ManagerAutocompleteInput,
+  ManagerDialogProvider,
   managerAutocompleteEntries,
+  type ManagerDialogs,
   type ManagerDialogField,
+  useManagerDialogs,
   validateManagerDialogValues,
 } from '../../src/manager_dialog.js';
 
 const root = process.cwd();
+let reactRoot: Root | undefined;
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT: boolean}).IS_REACT_ACT_ENVIRONMENT = true;
+  Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+    configurable: true,
+    value(this: HTMLDialogElement) {
+      this.open = true;
+    },
+  });
+  Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+    configurable: true,
+    value(this: HTMLDialogElement) {
+      this.open = false;
+    },
+  });
+});
+
+afterEach(async () => {
+  if (reactRoot) {
+    await act(async () => reactRoot?.unmount());
+    reactRoot = undefined;
+  }
+  document.body.replaceChildren();
+});
 
 describe('manager dialogs', () => {
   it('trims every submitted field without dropping optional empty values', () => {
@@ -72,6 +106,97 @@ describe('manager dialogs', () => {
     ]);
   });
 
+  it('queues dialogs, resolves cancel and confirm, and focuses the safe danger action', async () => {
+    let dialogs: ManagerDialogs | undefined;
+    await render(
+      React.createElement(
+        ManagerDialogProvider,
+        undefined,
+        React.createElement(DialogCapture, {onReady: value => (dialogs = value)}),
+      ),
+    );
+
+    let first!: Promise<Readonly<Record<string, string>> | undefined>;
+    let second!: Promise<boolean>;
+    await act(async () => {
+      first = dialogs!.prompt({title: 'First prompt'});
+      second = dialogs!.confirm({title: 'Dangerous follow-up', tone: 'danger'});
+    });
+    expect(document.querySelector('h2')?.textContent).toBe('First prompt');
+
+    await clickButton('Cancel');
+    await expect(first).resolves.toBeUndefined();
+    expect(document.querySelector('h2')?.textContent).toBe('Dangerous follow-up');
+    expect(document.activeElement?.textContent).toBe('Cancel');
+
+    await clickButton('Continue');
+    await expect(second).resolves.toBe(true);
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  it('keeps a required prompt open, reports the error, and focuses the invalid field', async () => {
+    let dialogs: ManagerDialogs | undefined;
+    await render(
+      React.createElement(
+        ManagerDialogProvider,
+        undefined,
+        React.createElement(DialogCapture, {onReady: value => (dialogs = value)}),
+      ),
+    );
+
+    let result!: Promise<Readonly<Record<string, string>> | undefined>;
+    await act(async () => {
+      result = dialogs!.prompt({
+        fields: [{id: 'project', label: 'Project', required: true}],
+        title: 'Required project',
+      });
+    });
+    await clickButton('Continue');
+
+    const input = document.querySelector<HTMLInputElement>('input[name="project"]');
+    expect(document.querySelector('.manager-dialog-field strong')?.textContent).toBe('Enter a value to continue.');
+    expect(input?.getAttribute('aria-invalid')).toBe('true');
+    expect(document.activeElement).toBe(input);
+
+    await clickButton('Cancel');
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('dismisses the active prompt with Escape', async () => {
+    let dialogs: ManagerDialogs | undefined;
+    await render(
+      React.createElement(
+        ManagerDialogProvider,
+        undefined,
+        React.createElement(DialogCapture, {onReady: value => (dialogs = value)}),
+      ),
+    );
+
+    let result!: Promise<Readonly<Record<string, string>> | undefined>;
+    await act(async () => {
+      result = dialogs!.prompt({title: 'Escape prompt'});
+    });
+    await act(async () => {
+      document.querySelector('dialog')?.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, key: 'Escape'}));
+    });
+
+    await expect(result).resolves.toBeUndefined();
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  it('supports keyboard selection in the autocomplete listbox', async () => {
+    await render(React.createElement(AutocompleteHarness));
+    const input = document.querySelector<HTMLInputElement>('input[role="combobox"]')!;
+
+    await act(async () => input.click());
+    expect(document.querySelectorAll('[role="option"]')).toHaveLength(2);
+    await act(async () => input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, key: 'ArrowDown'})));
+    await act(async () => input.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, key: 'Enter'})));
+
+    expect(input.value).toBe('Beta');
+    expect(input.getAttribute('aria-expanded')).toBe('false');
+  });
+
   it('keeps native browser prompts out of every Manager surface', async () => {
     const sources = await Promise.all(
       ['src/manager_ui.tsx', 'src/manager_graph.tsx'].map(file => readFile(join(root, file), 'utf8')),
@@ -82,3 +207,30 @@ describe('manager dialogs', () => {
     }
   });
 });
+
+function DialogCapture(props: {readonly onReady: (dialogs: ManagerDialogs) => void}): null {
+  props.onReady(useManagerDialogs());
+  return null;
+}
+
+function AutocompleteHarness(): React.ReactElement {
+  const [value, setValue] = useState('');
+  return React.createElement(ManagerAutocompleteInput, {
+    onChange: setValue,
+    options: ['Alpha', 'Beta'],
+    value,
+  });
+}
+
+async function render(element: React.ReactElement): Promise<void> {
+  const container = document.createElement('div');
+  document.body.append(container);
+  reactRoot = createRoot(container);
+  await act(async () => reactRoot?.render(element));
+}
+
+async function clickButton(label: string): Promise<void> {
+  const button = [...document.querySelectorAll('button')].find(candidate => candidate.textContent === label);
+  expect(button).toBeDefined();
+  await act(async () => button?.click());
+}

--- a/test/unit/manager-dialog.test.ts
+++ b/test/unit/manager-dialog.test.ts
@@ -1,0 +1,84 @@
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  managerAutocompleteEntries,
+  type ManagerDialogField,
+  validateManagerDialogValues,
+} from '../../src/manager_dialog.js';
+
+const root = process.cwd();
+
+describe('manager dialogs', () => {
+  it('trims every submitted field without dropping optional empty values', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (project, team) => {
+        const fields: readonly ManagerDialogField[] = [
+          {id: 'project', label: 'Project'},
+          {id: 'team', label: 'Team'},
+        ];
+        const result = validateManagerDialogValues(fields, {
+          project: `  ${project}  `,
+          team: `\t${team}\n`,
+        });
+
+        expect(result).toEqual({
+          ok: true,
+          values: {project: project.trim(), team: team.trim()},
+        });
+      }),
+    );
+  });
+
+  it('reports the first blank required field', () => {
+    const fields: readonly ManagerDialogField[] = [
+      {id: 'project', label: 'Project', required: true},
+      {id: 'topic', label: 'Topic', required: true},
+    ];
+
+    expect(validateManagerDialogValues(fields, {project: ' \n ', topic: 'kept'})).toEqual({
+      fieldId: 'project',
+      ok: false,
+    });
+  });
+
+  it('deduplicates and filters autocomplete options while offering novel values explicitly', () => {
+    fc.assert(
+      fc.property(fc.array(fc.string(), {maxLength: 40}), fc.string(), (options, query) => {
+        const entries = managerAutocompleteEntries(options, query, true);
+        const normalizedQuery = query.trim().toLocaleLowerCase();
+        const normalizedOptions = new Set(
+          options
+            .map(option => option.trim())
+            .filter(Boolean)
+            .map(option => option.toLocaleLowerCase()),
+        );
+        const existing = entries.filter(entry => entry.kind === 'existing');
+        const normalizedExisting = existing.map(entry => entry.value.toLocaleLowerCase());
+        const shouldCreate = normalizedQuery.length > 0 && !normalizedOptions.has(normalizedQuery);
+
+        expect(new Set(normalizedExisting).size).toBe(normalizedExisting.length);
+        expect(normalizedExisting.every(option => option.includes(normalizedQuery))).toBe(true);
+        expect(entries[0]?.kind === 'create').toBe(shouldCreate);
+        if (shouldCreate) expect(entries[0]?.value).toBe(query.trim());
+      }),
+    );
+  });
+
+  it('does not offer creation when the typed value already exists with different casing', () => {
+    expect(managerAutocompleteEntries(['Threadnote', ' threadnote '], 'THREADNOTE', true)).toEqual([
+      {kind: 'existing', label: 'Threadnote', value: 'Threadnote'},
+    ]);
+  });
+
+  it('keeps native browser prompts out of every Manager surface', async () => {
+    const sources = await Promise.all(
+      ['src/manager_ui.tsx', 'src/manager_graph.tsx'].map(file => readFile(join(root, file), 'utf8')),
+    );
+
+    for (const source of sources) {
+      expect(source).not.toMatch(/\bwindow\.(?:alert|confirm|prompt)\s*\(/);
+    }
+  });
+});

--- a/test/unit/manager-graph.performance.test.ts
+++ b/test/unit/manager-graph.performance.test.ts
@@ -11,6 +11,10 @@ import {
   managerGraphVisualizationLimits,
 } from '../../src/manager_graph_limits.js';
 
+// Istanbul instruments every branch in the layout loop. Keep the production
+// budget unchanged while allowing the measured coverage build its known tax.
+const focusedLayoutBudgetMilliseconds = '__coverage__' in globalThis ? 350 : 250;
+
 describe('Manager graph production-shaped budgets', () => {
   it('clamps server working sets before querying or serializing them', () => {
     expect(managerGraphVisualizationLimits()).toEqual({edgeLimit: 640, nodeLimit: 240});
@@ -66,7 +70,7 @@ describe('Manager graph production-shaped budgets', () => {
     const elapsedMilliseconds = performance.now() - startedAt;
 
     expect(result.size).toBe(MANAGER_GRAPH_MAX_NODE_LIMIT);
-    expect(elapsedMilliseconds).toBeLessThan(250);
+    expect(elapsedMilliseconds).toBeLessThan(focusedLayoutBudgetMilliseconds);
   });
 });
 

--- a/test/unit/manager.test.ts
+++ b/test/unit/manager.test.ts
@@ -833,6 +833,8 @@ describe('manager http API', () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     await seedManagerGraph(config);
+    const orphanedCheckoutId = 'd'.repeat(64);
+    const orphanedRoot = join(config.agentContextHome, 'indexes', 'code-graph', 'repositories', orphanedCheckoutId);
     const server = await startServer(config, 'secret');
     try {
       const headers = {authorization: 'Bearer secret', 'content-type': 'application/json'};
@@ -886,6 +888,38 @@ describe('manager http API', () => {
       });
       expect(relativeTarget.status).toBe(500);
       expect(await relativeTarget.json()).toMatchObject({error: 'Supply cwd as an absolute local worktree path.'});
+
+      await mkdir(orphanedRoot, {recursive: true});
+      await writeFile(join(orphanedRoot, 'graph-v3.sqlite'), 'incompatible disposable graph\n');
+      const targetedPreview = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({action: 'purge', checkoutId: orphanedCheckoutId, dryRun: true}),
+        headers,
+        method: 'POST',
+      });
+      expect(targetedPreview.status).toBe(200);
+      expect(await targetedPreview.json()).toMatchObject({
+        output: `Would remove derived code graph index for checkout ${orphanedCheckoutId.slice(0, 12)}.`,
+      });
+      expect(existsSync(orphanedRoot)).toBe(true);
+
+      const refusedTargetedPurge = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({action: 'purge', checkoutId: orphanedCheckoutId}),
+        headers,
+        method: 'POST',
+      });
+      expect(refusedTargetedPurge.status).toBe(500);
+      expect(await refusedTargetedPurge.json()).toMatchObject({error: 'Set confirm=true for this action.'});
+
+      const targetedPurge = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({action: 'purge', checkoutId: orphanedCheckoutId, confirm: true}),
+        headers,
+        method: 'POST',
+      });
+      expect(targetedPurge.status).toBe(200);
+      expect(await targetedPurge.json()).toMatchObject({
+        output: `Removed derived code graph index for checkout ${orphanedCheckoutId.slice(0, 12)}.`,
+      });
+      expect(existsSync(orphanedRoot)).toBe(false);
     } finally {
       await server.close();
     }

--- a/test/unit/manager.test.ts
+++ b/test/unit/manager.test.ts
@@ -15,7 +15,12 @@ import {
   resourcesTree,
   runManage,
 } from '../../src/manager.js';
-import {pruneSelectedMemoryUris, selectableMemoryUris, type TreeNode} from '../../src/manager_ui.js';
+import {
+  managerProjectOptions,
+  pruneSelectedMemoryUris,
+  selectableMemoryUris,
+  type TreeNode,
+} from '../../src/manager_ui.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import * as lifecycle from '../../src/lifecycle.js';
 import * as memory from '../../src/memory.js';
@@ -496,6 +501,38 @@ describe('manager UI selection helpers', () => {
 
     const visibleOnly = new Set(['threadnote://user/denys/memories/durable/projects/threadnote/first.md']);
     expect(pruneSelectedMemoryUris(visibleOnly, tree, {filter: 'first', showSystem: false})).toBe(visibleOnly);
+  });
+
+  it('collects distinct project selector options from nested memory metadata', () => {
+    const first = fileNode('threadnote://user/denys/memories/durable/projects/threadnote/first.md', 'first.md');
+    const second = fileNode('threadnote://user/denys/memories/handoffs/other/second.md', 'second.md');
+    const tree: TreeNode = {
+      ...selectionTree(),
+      children: [
+        {
+          ...first,
+          metadata: {
+            kind: 'durable',
+            project: 'Threadnote',
+            sourceAgentClient: 'codex',
+            status: 'active',
+            timestamp: '2026-08-05T00:00:00.000Z',
+          },
+        },
+        {
+          ...second,
+          metadata: {
+            kind: 'handoff',
+            project: 'threadnote',
+            sourceAgentClient: 'codex',
+            status: 'active',
+            timestamp: '2026-08-05T00:00:00.000Z',
+          },
+        },
+      ],
+    };
+
+    expect(managerProjectOptions(tree)).toEqual(['Threadnote']);
   });
 });
 


### PR DESCRIPTION
## What changed

- reclaim superseded native code graph snapshots and detached clean bases after their final reader lease ends
- release transient Manager catalog leases on shutdown so removed worktrees do not remain pinned until TTL expiry
- purge orphaned or incompatible checkout graphs without requiring a surviving worktree path, with stable filesystem identity and atomic quarantine checks
- replace native browser prompts across Manager with accessible in-app dialogs
- make project and team inputs searchable selectors that can explicitly create new values
- prepare the 4.0.6 patch release

## Why

Removed worktrees could leave ready snapshots and incompatible graph databases behind indefinitely. Manager also required users to know paths that no longer existed and relied on browser-native prompts. Lease provenance and base retention did not cover every promotion, overlap, expiry, and Manager shutdown order, so cleanup could retain junk or miss a still-needed base.

## Impact

Graph storage now converges after stale worktrees and readers disappear, normal Manager shutdown releases its graph pins immediately, destructive purge is safer against path replacement races, and Manager administration is consistent and keyboard-accessible.

## Validation

- dev-cycle: 1 review pass; 9 findings addressed
- bun run lint
- bun run typecheck
- bun run prettier:check
- full Vitest suite: 191 files, 1,821 tests on final HEAD
- exact-HEAD global install: 4.0.6-local.g87c3219d87fe
- installed graph index smoke completed for this checkout
- installed Manager lifecycle smoke: 8 transient leases acquired, 0 remained after Ctrl-C