### PR TITLE
Release 4.0.8: fast-attach ready graph for new worktrees

### DIFF
--- a/.github/release-notes/v4.0.8.md
+++ b/.github/release-notes/v4.0.8.md
@@ -1,0 +1,13 @@
+## What's new
+
+Threadnote 4.0.8 makes code-graph search answer immediately on a fresh clean worktree when a ready snapshot already
+exists for the same commit, instead of briefly returning an indexing wait.
+
+- **Attach a shared ready graph on first touch.** When you open a new clean linked worktree and call
+  `inspect_code_graph` or `threadnote graph query` / `graph analyze`, Threadnote promotes the existing HEAD-matching
+  ready snapshot onto that worktree before starting a refresh. Ordinary reads stop paying a first-touch materialize wait
+  when the shared checkout graph is already built.
+- **Reuse content-equivalent clean commits when the exact snapshot id misses.** Clean inventory that would otherwise
+  rematerialize can promote a ready snapshot with the same graph content instead of rebuilding facts.
+- **Keep watcher refresh off the embedding path.** Background MCP watcher refresh refreshes structure without owning
+  vector embedding; explicit `threadnote graph index` still builds vectors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -692,7 +692,11 @@ export const runCodeGraphInspect = Effect.fn('codeGraph.command.inspect')(functi
 ) {
   const service = yield* CodeGraphQueryService;
   const cwd = yield* commandCwd(options.cwd);
-  const status = yield* service.status(config.agentContextHome, cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  let status = yield* service.statusForIdentity(config.agentContextHome, identity);
+  if (status.stale || !status.readySnapshot) {
+    status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity);
+  }
   const strictFreshness = options.operation === 'impact' || options.operation === 'path';
   const statusObservation = observationFromCodeGraphStatus(status);
   // Preserve live-edit behavior, but do not make an ordinary read wait for a clean post-pull rebuild.
@@ -1091,12 +1095,17 @@ const ensureAnalysisSnapshot = Effect.fn('codeGraph.command.ensureAnalysisSnapsh
 ) {
   const query = yield* CodeGraphQueryService;
   const indexer = yield* CodeGraphIndexer;
-  let status = yield* query.status(config.agentContextHome, cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  let status = yield* query.statusForIdentity(config.agentContextHome, identity);
+  if (status.stale || !status.readySnapshot) {
+    status = yield* query.attachSharedReadySnapshot(config.agentContextHome, identity);
+  }
   if (status.stale) {
     if (json) {
       const reportProgress = yield* makeCodeGraphJsonProgressReporter();
       yield* indexer.index({
         cwd,
+        ensureVectors: false,
         onProgress: reportProgress,
         threadnoteHome: config.agentContextHome,
       });
@@ -1106,6 +1115,7 @@ const ensureAnalysisSnapshot = Effect.fn('codeGraph.command.ensureAnalysisSnapsh
         progress =>
           indexer.index({
             cwd,
+            ensureVectors: false,
             onProgress: state => progress.update(progressMessage(state)).pipe(Effect.catch(() => Effect.void)),
             threadnoteHome: config.agentContextHome,
           }),

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -319,11 +319,26 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       const reusableExisting = existing
                         ? yield* store.currentLexicalReadySnapshotById(layout.databasePath, existing.id)
                         : undefined;
-                      const reusableReady = !options.force
+                      const reusableReadyById = !options.force
                         ? reusableExisting && readyCandidateIds.includes(reusableExisting.id)
                           ? reusableExisting
                           : yield* firstReadySnapshotById(store, layout.databasePath, readyCandidateIds)
                         : undefined;
+                      // Exact cgsn_* can miss when inventory source/provenance differs slightly
+                      // from the shared clean row while graph content is identical. Prefer promote
+                      // of a HEAD-matching clean ready snapshot over rematerializing.
+                      const reusableReady =
+                        reusableReadyById ??
+                        (!options.force && !inventory.dirty
+                          ? yield* reusableReadySnapshotForCleanCommit({
+                              databasePath: layout.databasePath,
+                              extractorSet,
+                              graphContentId,
+                              headCommit: identity.headCommit,
+                              repositoryId: identity.repositoryId,
+                              store,
+                            })
+                          : undefined);
                       // A ready candidate wins this request. Do not preserve an
                       // interrupted logical/direct sibling that cannot be used on
                       // the early-return path: a repository-sized persistent build
@@ -1084,6 +1099,41 @@ const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(f
             reusedFiles: input.inventory.files.length - input.inventory.parsedFiles,
             skippedFiles: input.inventory.skipped,
             snapshot: ready,
+            startedAt: input.startedAt,
+            store: input.store,
+            threadnoteHome: input.threadnoteHome,
+            totalFiles: input.inventory.files.length,
+          });
+        }
+        const extractorSet = extractorSetIdentity(input.inventory.files, input.languagePacks);
+        const graphContentId = graphContentIdentity(extractorSet, input.inventory.files);
+        const commitReady = yield* reusableReadySnapshotForCleanCommit({
+          databasePath: input.layout.databasePath,
+          extractorSet,
+          graphContentId,
+          headCommit: input.identity.headCommit,
+          repositoryId: input.identity.repositoryId,
+          store: input.store,
+        });
+        if (commitReady) {
+          if (input.existing?.id !== commitReady.id) {
+            yield* input.store.promote(
+              input.layout.databasePath,
+              input.identity,
+              commitReady.id,
+              input.activeWorktreeIds,
+            );
+          }
+          return yield* reuseReadySnapshot({
+            activeWorktreeIds: input.activeWorktreeIds,
+            embedding: input.embedding,
+            ensureVectors: input.ensureVectors,
+            identity: input.identity,
+            layout: input.layout,
+            onProgress: input.onProgress,
+            reusedFiles: input.inventory.files.length - input.inventory.parsedFiles,
+            skippedFiles: input.inventory.skipped,
+            snapshot: commitReady,
             startedAt: input.startedAt,
             store: input.store,
             threadnoteHome: input.threadnoteHome,
@@ -3117,6 +3167,57 @@ const firstReadySnapshotById = Effect.fn('codeGraph.firstReadySnapshotById')(fun
   }
   return undefined;
 });
+
+/**
+ * Decide whether a clean ready snapshot for HEAD is graph-equivalent to the
+ * current inventory and safe to promote without rematerializing.
+ *
+ * Requires an explicit graphContentId on the candidate so we never promote a
+ * same-commit row that merely shares extractor set but not inventory content.
+ */
+export function shouldReuseReadySnapshotForCleanCommit(input: {
+  readonly candidate?: {
+    readonly commit: string;
+    readonly dirty: boolean;
+    readonly graphContentId?: string;
+    readonly id: string;
+  };
+  readonly graphContentId: string;
+  readonly headCommit: string;
+}): boolean {
+  return (
+    input.candidate !== undefined &&
+    input.candidate.dirty === false &&
+    input.candidate.commit === input.headCommit &&
+    input.candidate.graphContentId !== undefined &&
+    input.candidate.graphContentId === input.graphContentId
+  );
+}
+
+const reusableReadySnapshotForCleanCommit = Effect.fn('codeGraph.reusableReadySnapshotForCleanCommit')(
+  function* (input: {
+    readonly databasePath: string;
+    readonly extractorSet: string;
+    readonly graphContentId: string;
+    readonly headCommit: string;
+    readonly repositoryId: string;
+    readonly store: CodeGraphStoreShape;
+  }) {
+    const candidate = yield* input.store.readySnapshotForCommit(
+      input.databasePath,
+      input.repositoryId,
+      input.headCommit,
+      input.extractorSet,
+    );
+    return shouldReuseReadySnapshotForCleanCommit({
+      candidate,
+      graphContentId: input.graphContentId,
+      headCommit: input.headCommit,
+    })
+      ? candidate
+      : undefined;
+  },
+);
 
 function embeddingSymbolSource(store: CodeGraphStoreShape, databasePath: string, snapshotId: string) {
   return {

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -17,7 +17,7 @@ import {
   withCodeGraphMaintenanceIntent,
 } from './maintenance_gate.js';
 import {compareCodeUnits} from './ordering.js';
-import {resolveRepositoryIdentity} from './repository.js';
+import {repositoryWorktreeIds, resolveRepositoryIdentity} from './repository.js';
 import {CodeGraphStore, type CodeGraphStoreShape} from './store.js';
 import {CodeGraphEmbeddingIndex, type CodeGraphEmbeddingIndexShape} from './embedding.js';
 import {
@@ -90,6 +90,25 @@ export function canUseReadySnapshotAfterCleanCommitChange(status: CodeGraphStatu
   );
 }
 
+/**
+ * Decide whether a shared clean ready snapshot can be promoted onto this worktree
+ * without inventory or rematerialization.
+ */
+export function shouldAttachSharedReadySnapshot(input: {
+  readonly candidate?: {readonly commit: string; readonly dirty: boolean; readonly id: string};
+  readonly overlayDirty: boolean;
+  readonly readySnapshot?: {readonly commit: string; readonly id: string};
+  readonly headCommit: string;
+}): boolean {
+  if (input.overlayDirty) return false;
+  return (
+    input.candidate !== undefined &&
+    input.candidate.dirty === false &&
+    input.candidate.commit === input.headCommit &&
+    input.candidate.id !== input.readySnapshot?.id
+  );
+}
+
 function attachCodeGraphStatusObservation(
   status: CodeGraphStatus,
   observation: CodeGraphStatusObservation | undefined,
@@ -107,6 +126,14 @@ function attachCodeGraphStatusObservation(
 export class CodeGraphQueryService extends Context.Service<
   CodeGraphQueryService,
   {
+    /**
+     * Promote a shared clean ready snapshot for HEAD onto this worktree when
+     * the worktree is clean and has no matching active pointer yet.
+     */
+    readonly attachSharedReadySnapshot: (
+      threadnoteHome: string,
+      identity: RepositoryIdentity,
+    ) => Effect.Effect<CodeGraphStatus, unknown>;
     readonly inspect: (options: CodeGraphInspectOptions) => Effect.Effect<CodeGraphQueryResult, unknown>;
     readonly purge: (threadnoteHome: string, cwd: string) => Effect.Effect<string, unknown>;
     readonly status: (
@@ -175,7 +202,38 @@ export class CodeGraphQueryService extends Context.Service<
           } satisfies CodeGraphStatus;
           return attachCodeGraphStatusObservation(status, overlay === undefined ? undefined : {identity, overlay});
         });
+      const attachSharedReadySnapshot = (threadnoteHome: string, identity: RepositoryIdentity) =>
+        Effect.gen(function* () {
+          // statusForIdentity already attaches a non-writable observation; never re-attach
+          // onto the same object (Object.defineProperty would throw).
+          const status = yield* statusForIdentity(threadnoteHome, identity);
+          if (!status.stale && status.readySnapshot?.commit === identity.headCommit) return status;
+          const overlay = observationFromCodeGraphStatus(status)?.overlay ?? (yield* worktreeOverlayState(identity));
+          if (overlay.dirty) return status;
+          const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
+          const candidate = yield* store.readySnapshotForCommit(
+            layout.databasePath,
+            identity.repositoryId,
+            identity.headCommit,
+          );
+          if (
+            candidate === undefined ||
+            !shouldAttachSharedReadySnapshot({
+              candidate,
+              headCommit: identity.headCommit,
+              overlayDirty: overlay.dirty,
+              readySnapshot: status.readySnapshot,
+            })
+          ) {
+            return status;
+          }
+          const activeWorktreeIds = yield* repositoryWorktreeIds(identity);
+          yield* store.promote(layout.databasePath, identity, candidate.id, activeWorktreeIds);
+          return yield* statusForIdentity(threadnoteHome, identity);
+        });
       return CodeGraphQueryService.of({
+        attachSharedReadySnapshot: (threadnoteHome, identity) =>
+          withRepositoryServices(attachSharedReadySnapshot(threadnoteHome, identity)),
         inspect: options =>
           withRepositoryServices(
             Effect.gen(function* () {

--- a/src/code_graph/watcher.ts
+++ b/src/code_graph/watcher.ts
@@ -660,16 +660,27 @@ const prewarmLikelyCleanSnapshots = Effect.fn('codeGraph.prewarmLikelyCleanSnaps
 
 const indexRepository = (indexer: CodeGraphIndexerShape, options: CodeGraphWatchOptions) =>
   indexer
-    .index({
-      cwd: options.cwd,
-      onProgress: options.onProgress,
-      threadnoteHome: options.threadnoteHome,
-    })
+    .index(codeGraphWatcherRefreshIndexRequest(options))
     .pipe(
       Effect.tap(
         summary => options.onRefreshed?.(summary.snapshot.symbolCount, summary.snapshot.edgeCount) ?? Effect.void,
       ),
     );
+
+/** Watcher-driven refresh never owns embedding; explicit `graph index` still does. */
+export function codeGraphWatcherRefreshIndexRequest(options: CodeGraphWatchOptions): {
+  readonly cwd: string;
+  readonly ensureVectors: false;
+  readonly onProgress: CodeGraphWatchOptions['onProgress'];
+  readonly threadnoteHome: string;
+} {
+  return {
+    cwd: options.cwd,
+    ensureVectors: false,
+    onProgress: options.onProgress,
+    threadnoteHome: options.threadnoteHome,
+  };
+}
 
 const watchRepository = Effect.fn('codeGraph.watchRepository')(function* (
   fs: FileSystem.FileSystem,

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -869,6 +869,9 @@ function registerCodeGraphTool(server: EffectMcpServerAdapter, config: RuntimeCo
         const service = yield* CodeGraphQueryService;
         const strictFreshness = operation === 'impact' || operation === 'path';
         let status = yield* service.statusForIdentity(config.agentContextHome, identity);
+        if (status.stale || !status.readySnapshot) {
+          status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity);
+        }
         let staleAfterCleanCommitChange = canUseReadySnapshotAfterCleanCommitChange(status);
         let refreshStarted = false;
         if (status.stale) {
@@ -883,6 +886,9 @@ function registerCodeGraphTool(server: EffectMcpServerAdapter, config: RuntimeCo
           }
           identity = yield* resolveRepositoryIdentity(checkedCwd.value);
           status = yield* service.statusForIdentity(config.agentContextHome, identity);
+          if (status.stale || !status.readySnapshot) {
+            status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity);
+          }
           staleAfterCleanCommitChange = canUseReadySnapshotAfterCleanCommitChange(status);
           if (!status.readySnapshot || (status.stale && strictFreshness)) {
             const refreshStatus = Option.getOrUndefined(yield* watcher.status(identity.worktreeId, refreshTarget));
@@ -980,6 +986,9 @@ function registerCodeGraphTool(server: EffectMcpServerAdapter, config: RuntimeCo
         });
         const query = yield* CodeGraphQueryService;
         let status = yield* query.status(config.agentContextHome, checkedCwd.value);
+        if (status.stale || !status.readySnapshot) {
+          status = yield* query.attachSharedReadySnapshot(config.agentContextHome, identity);
+        }
         const refreshStarted = status.stale
           ? yield* watcher.refresh({
               cwd: identity.repoRoot,
@@ -994,6 +1003,9 @@ function registerCodeGraphTool(server: EffectMcpServerAdapter, config: RuntimeCo
           });
         }
         if (status.stale) status = yield* query.status(config.agentContextHome, checkedCwd.value);
+        if (status.stale || !status.readySnapshot) {
+          status = yield* query.attachSharedReadySnapshot(config.agentContextHome, identity);
+        }
         if (!status.readySnapshot || status.stale) {
           return codeGraphAnalysisRefreshResult(
             operation,

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -605,6 +605,99 @@ describe('native code graph lifecycle', () => {
     }
   });
 
+  it('attaches a shared clean ready snapshot to a new worktree without rematerializing', async () => {
+    const root = createFixtureRepository();
+    git(root, ['branch', 'graph-attach-a']);
+    git(root, ['branch', 'graph-attach-b']);
+    const worktreeRoot = temporaryDirectory('threadnote-code-graph-attach-worktrees-');
+    const worktreeA = join(worktreeRoot, 'worktree-a');
+    const worktreeB = join(worktreeRoot, 'worktree-b');
+    git(root, ['worktree', 'add', worktreeA, 'graph-attach-a']);
+    git(root, ['worktree', 'add', worktreeB, 'graph-attach-b']);
+    const home = join(root, '.threadnote-test-home');
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const graph = yield* CodeGraphQueryService;
+        const indexer = yield* CodeGraphIndexer;
+        const first = yield* indexer.index({cwd: worktreeA, threadnoteHome: home});
+        const identityB = yield* resolveRepositoryIdentity(worktreeB);
+        const before = yield* graph.statusForIdentity(home, identityB);
+        const attached = yield* graph.attachSharedReadySnapshot(home, identityB);
+        const after = yield* graph.statusForIdentity(home, identityB);
+        const found = yield* graph.inspect({
+          cwd: worktreeB,
+          operation: 'query',
+          query: 'ensureVectorIndex',
+          refresh: false,
+          threadnoteHome: home,
+        });
+        return {after, attached, before, first, found, identityB};
+      }),
+    );
+
+    expect(result.before.readySnapshot).toBeUndefined();
+    expect(result.before.stale).toBe(true);
+    expect(result.attached.stale).toBe(false);
+    expect(result.attached.readySnapshot?.id).toBe(result.first.snapshot.id);
+    expect(result.attached.readySnapshot?.worktreeId).toBe(result.identityB.worktreeId);
+    expect(result.after.readySnapshot?.id).toBe(result.first.snapshot.id);
+    expect(result.after.stale).toBe(false);
+    expect(result.found.snapshot.id).toBe(result.first.snapshot.id);
+    expect(result.found.nodes.some(node => node.name === 'ensureVectorIndex')).toBe(true);
+  });
+
+  it('attaches a shared clean base while a sibling worktree keeps a dirty overlay', async () => {
+    const root = createFixtureRepository();
+    git(root, ['branch', 'graph-sibling-a']);
+    git(root, ['branch', 'graph-sibling-b']);
+    const worktreeRoot = temporaryDirectory('threadnote-code-graph-sibling-dirty-');
+    const worktreeA = join(worktreeRoot, 'worktree-a');
+    const worktreeB = join(worktreeRoot, 'worktree-b');
+    git(root, ['worktree', 'add', worktreeA, 'graph-sibling-a']);
+    git(root, ['worktree', 'add', worktreeB, 'graph-sibling-b']);
+    const home = join(root, '.threadnote-test-home');
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const graph = yield* CodeGraphQueryService;
+        const indexer = yield* CodeGraphIndexer;
+        const clean = yield* indexer.index({cwd: worktreeA, threadnoteHome: home});
+        replaceFunction(worktreeA, 'ensureVectorIndex', 'ensureSiblingDirtyVectorIndex');
+        const dirty = yield* indexer.index({cwd: worktreeA, threadnoteHome: home});
+        const identityB = yield* resolveRepositoryIdentity(worktreeB);
+        const attached = yield* graph.attachSharedReadySnapshot(home, identityB);
+        const found = yield* graph.inspect({
+          cwd: worktreeB,
+          operation: 'query',
+          query: 'ensureVectorIndex',
+          refresh: false,
+          threadnoteHome: home,
+        });
+        const dirtyOnly = yield* graph.inspect({
+          cwd: worktreeA,
+          operation: 'query',
+          query: 'ensureSiblingDirtyVectorIndex',
+          refresh: false,
+          threadnoteHome: home,
+        });
+        return {attached, clean, dirty, dirtyOnly, found, identityB};
+      }),
+    );
+
+    expect(result.dirty.snapshot.dirty).toBe(true);
+    expect(result.dirty.snapshot.id).not.toBe(result.clean.snapshot.id);
+    expect(result.attached.stale).toBe(false);
+    expect(result.attached.readySnapshot?.dirty).toBe(false);
+    expect(result.attached.readySnapshot?.id).toBe(result.clean.snapshot.id);
+    expect(result.attached.readySnapshot?.worktreeId).toBe(result.identityB.worktreeId);
+    expect(result.found.snapshot.id).toBe(result.clean.snapshot.id);
+    expect(result.found.nodes.some(node => node.name === 'ensureVectorIndex')).toBe(true);
+    expect(result.found.nodes.some(node => node.name === 'ensureSiblingDirtyVectorIndex')).toBe(false);
+    expect(result.dirtyOnly.snapshot.id).toBe(result.dirty.snapshot.id);
+    expect(result.dirtyOnly.nodes.some(node => node.name === 'ensureSiblingDirtyVectorIndex')).toBe(true);
+  });
+
   it('aliases a graph-equivalent clean commit without reparsing or rematerializing files', async () => {
     const root = createManySourceRepository(12);
     const home = join(root, '.threadnote-test-home');

--- a/test/unit/code-graph.attach-shared-ready.test.ts
+++ b/test/unit/code-graph.attach-shared-ready.test.ts
@@ -1,0 +1,214 @@
+import {describe, expect, it} from '@effect/vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {shouldReuseReadySnapshotForCleanCommit} from '../../src/code_graph/indexer.js';
+import {shouldAttachSharedReadySnapshot} from '../../src/code_graph/query.js';
+import {codeGraphWatcherRefreshIndexRequest} from '../../src/code_graph/watcher.js';
+
+const commit = 'a'.repeat(40);
+const otherCommit = 'b'.repeat(40);
+const graphContentId = `cgc_${'1'.repeat(40)}`;
+const otherGraphContentId = `cgc_${'2'.repeat(40)}`;
+
+describe('shouldAttachSharedReadySnapshot', () => {
+  it('promotes when the worktree is clean and a HEAD-matching candidate is unused', () => {
+    expect(
+      shouldAttachSharedReadySnapshot({
+        candidate: {commit, dirty: false, id: 'cgsn_shared'},
+        headCommit: commit,
+        overlayDirty: false,
+        readySnapshot: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it('no-ops when the worktree is dirty', () => {
+    expect(
+      shouldAttachSharedReadySnapshot({
+        candidate: {commit, dirty: false, id: 'cgsn_shared'},
+        headCommit: commit,
+        overlayDirty: true,
+        readySnapshot: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it('no-ops when there is no reusable candidate', () => {
+    expect(
+      shouldAttachSharedReadySnapshot({
+        headCommit: commit,
+        overlayDirty: false,
+        readySnapshot: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it('no-ops when the worktree pointer already matches the candidate', () => {
+    expect(
+      shouldAttachSharedReadySnapshot({
+        candidate: {commit, dirty: false, id: 'cgsn_shared'},
+        headCommit: commit,
+        overlayDirty: false,
+        readySnapshot: {commit, id: 'cgsn_shared'},
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects dirty or wrong-commit candidates', () => {
+    expect(
+      shouldAttachSharedReadySnapshot({
+        candidate: {commit, dirty: true, id: 'cgsn_dirty'},
+        headCommit: commit,
+        overlayDirty: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAttachSharedReadySnapshot({
+        candidate: {commit: otherCommit, dirty: false, id: 'cgsn_other'},
+        headCommit: commit,
+        overlayDirty: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('still attaches a clean shared candidate when only local overlay dirtiness matters', () => {
+    // Sibling dirty overlays must not be modeled as overlayDirty on this worktree.
+    expect(
+      shouldAttachSharedReadySnapshot({
+        candidate: {commit, dirty: false, id: 'cgsn_shared'},
+        headCommit: commit,
+        overlayDirty: false,
+        readySnapshot: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it.prop(
+    'attaches only for clean overlays with a distinct HEAD-matching clean candidate',
+    {
+      candidateCommit: FC.constantFrom(commit, otherCommit),
+      candidateDirty: FC.boolean(),
+      candidateId: FC.constantFrom('cgsn_a', 'cgsn_b'),
+      hasCandidate: FC.boolean(),
+      hasReady: FC.boolean(),
+      overlayDirty: FC.boolean(),
+      readyId: FC.constantFrom('cgsn_a', 'cgsn_b'),
+    },
+    ({candidateCommit, candidateDirty, candidateId, hasCandidate, hasReady, overlayDirty, readyId}) => {
+      const candidate = hasCandidate ? {commit: candidateCommit, dirty: candidateDirty, id: candidateId} : undefined;
+      const readySnapshot = hasReady ? {commit, id: readyId} : undefined;
+      const expected =
+        !overlayDirty &&
+        candidate !== undefined &&
+        candidate.dirty === false &&
+        candidate.commit === commit &&
+        candidate.id !== readySnapshot?.id;
+      expect(
+        shouldAttachSharedReadySnapshot({
+          candidate,
+          headCommit: commit,
+          overlayDirty,
+          readySnapshot,
+        }),
+      ).toBe(expected);
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+});
+
+describe('shouldReuseReadySnapshotForCleanCommit', () => {
+  it('reuses when commit and graph content match a clean candidate', () => {
+    expect(
+      shouldReuseReadySnapshotForCleanCommit({
+        candidate: {commit, dirty: false, graphContentId, id: 'cgsn_other_id'},
+        graphContentId,
+        headCommit: commit,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects dirty, wrong-commit, missing, or content-mismatched candidates', () => {
+    expect(
+      shouldReuseReadySnapshotForCleanCommit({
+        candidate: {commit, dirty: true, graphContentId, id: 'cgsn_dirty'},
+        graphContentId,
+        headCommit: commit,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReuseReadySnapshotForCleanCommit({
+        candidate: {commit: otherCommit, dirty: false, graphContentId, id: 'cgsn_other'},
+        graphContentId,
+        headCommit: commit,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReuseReadySnapshotForCleanCommit({
+        candidate: {commit, dirty: false, id: 'cgsn_legacy'},
+        graphContentId,
+        headCommit: commit,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReuseReadySnapshotForCleanCommit({
+        candidate: {commit, dirty: false, graphContentId: otherGraphContentId, id: 'cgsn_mismatch'},
+        graphContentId,
+        headCommit: commit,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReuseReadySnapshotForCleanCommit({
+        graphContentId,
+        headCommit: commit,
+      }),
+    ).toBe(false);
+  });
+
+  it.prop(
+    'reuses only clean HEAD snapshots with an explicit matching graphContentId',
+    {
+      candidateCommit: FC.constantFrom(commit, otherCommit),
+      candidateDirty: FC.boolean(),
+      candidateGraphContentId: FC.constantFrom(graphContentId, otherGraphContentId, undefined),
+      hasCandidate: FC.boolean(),
+    },
+    ({candidateCommit, candidateDirty, candidateGraphContentId, hasCandidate}) => {
+      const candidate = hasCandidate
+        ? {
+            commit: candidateCommit,
+            dirty: candidateDirty,
+            ...(candidateGraphContentId === undefined ? {} : {graphContentId: candidateGraphContentId}),
+            id: 'cgsn_candidate',
+          }
+        : undefined;
+      const expected =
+        candidate !== undefined &&
+        candidate.dirty === false &&
+        candidate.commit === commit &&
+        candidate.graphContentId === graphContentId;
+      expect(
+        shouldReuseReadySnapshotForCleanCommit({
+          candidate,
+          graphContentId,
+          headCommit: commit,
+        }),
+      ).toBe(expected);
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+});
+
+describe('codeGraphWatcherRefreshIndexRequest', () => {
+  it('disables vector materialization for watcher-driven refresh', () => {
+    expect(
+      codeGraphWatcherRefreshIndexRequest({
+        cwd: '/repo',
+        threadnoteHome: '/home',
+      }),
+    ).toEqual({
+      cwd: '/repo',
+      ensureVectors: false,
+      onProgress: undefined,
+      threadnoteHome: '/home',
+    });
+  });
+});

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -36,6 +36,13 @@ describe('MCP code graph indexing progress', () => {
     ).toBe(true);
   });
 
+  it('does not block inspection after a shared ready snapshot is attached to the worktree', () => {
+    const indexing = indexingStatus(60_000);
+    expect(codeGraphRefreshBlocksReadyInspection({readySnapshot: {id: 'cgsn_shared'}, stale: false}, indexing)).toBe(
+      false,
+    );
+  });
+
   it('derives a bounded adaptive poll interval from the phase estimate', () => {
     expect(codeGraphRetryAfterMilliseconds(undefined)).toBe(5_000);
     expect(codeGraphRetryAfterMilliseconds(indexingStatus(4_000))).toBe(3_000);


### PR DESCRIPTION
## Summary
- Promote a shared clean ready graph snapshot onto a new worktree before MCP/CLI graph inspect returns an indexing wait
- Reuse content-equivalent clean commits when the exact snapshot id misses
- Skip vector embedding on watcher-driven refresh; bump to 4.0.8 with curated release notes

## Test plan
- Fresh clean linked worktree: first `threadnote graph query` / `inspect_code_graph` should return current without a materialize wait when the shared checkout graph is already ready