### PR TITLE
fix: typecheck fixture for watcher refresh options

### DIFF
--- a/test/unit/code-graph.attach-shared-ready.test.ts
+++ b/test/unit/code-graph.attach-shared-ready.test.ts
@@ -202,6 +202,7 @@ describe('codeGraphWatcherRefreshIndexRequest', () => {
     expect(
       codeGraphWatcherRefreshIndexRequest({
         cwd: '/repo',
+        key: 'worktree',
         threadnoteHome: '/home',
       }),
     ).toEqual({


### PR DESCRIPTION
## Summary
- Add required \`key\` to the \`codeGraphWatcherRefreshIndexRequest\` unit fixture so \`bun run typecheck\` passes (blocked Verify release source on v4.0.8)

## Test plan
- Reviewer: none beyond typecheck gate