### PR TITLE
Prepare Threadnote 4.1.0 beta.2 release

### DIFF
--- a/.github/release-notes/v4.1.0-beta.2.md
+++ b/.github/release-notes/v4.1.0-beta.2.md
@@ -1,0 +1,25 @@
+## What's new
+
+Threadnote 4.1 beta makes large, multi-worktree code graphs safer to operate, quicker to reuse, and more useful for
+day-to-day investigation.
+
+- **Keep graph storage healthy automatically.** Typed lifecycle reconciliation removes only authority-proven stale
+  views, abandoned builds, retired generations, and unreferenced cache data. Live writers, leases, reusable bases,
+  and the prior ready graph remain protected, including under low disk space.
+- **Reuse nearby work instead of rebuilding the repository.** Clean commits can reuse the nearest compatible graph,
+  dirty changes are bounded by a conservative project closure, interrupted builds resume from durable checkpoints,
+  and structural results become queryable before optional enrichment.
+- **Use smaller, explainable graph storage.** Compressed fact envelopes, deterministic snapshot retention, exact
+  table/index/snapshot accounting, and bounded resolution/materialization passes reduce write amplification without
+  weakening query parity or active-source coverage.
+- **Understand monorepo architecture directly.** Nx, pnpm, and TypeScript project components retain stable identities,
+  declared dependencies, source roots, diagnostics, and precomputed cross-component source aggregates.
+- **Investigate mobile and multi-repository systems.** Android XML and Apple plist/storyboard/XIB/asset-catalog
+  identifiers are searchable, package-scoped queries report honest local absence hints, and `graph query --workset`
+  returns bounded results with repository and snapshot provenance.
+- **Operate graphs from a calmer Manager.** Administration shows bounded active/recovery state, uses one inline remove
+  action, updates view counts immediately after removal, and gives the query workspace full width on desktop and
+  mobile.
+- **Run safely on Intel Macs.** The standalone Intel runtime uses a bounded disk-capacity probe verified on the exact
+  release runner, so capacity protection no longer blocks graph creation when native filesystem statistics are
+  unavailable.

--- a/docs/4.1.0-beta.2-release-evidence.md
+++ b/docs/4.1.0-beta.2-release-evidence.md
@@ -21,6 +21,19 @@ observation, and source verification exposed two test-harness timing assumptions
   `a6c389235624bdaab73d68503d98b75ff89b1cd28430fcb44eb8ded86ba2bd3f`. It indexed the clean head as snapshot
   `cgsn_9e568dcd36e3899b3e94666b6e86116473817ac4`: 733 files, 42,424 symbols, 128,065 relationships, and 728 files
   reused.
+- After PR #132 merged, release-preparation head `c87728b3cd14f6c58c64c9e4cc60aa1c4cd3ded0` was installed globally as
+  `4.1.0-beta.2.local.gc87728b3cd14f6c58c64c9e4cc60aa1c4cd3ded0`, executable SHA-256
+  `aafd7d4acaf16bcd6b18b210169fc4db5e156d777ea26ddc42681d8bf6739566`. `threadnote doctor --dry-run` reported
+  zero failures after repairing the stale derived recall index.
+- That installed runtime indexed the clean release-preparation head as snapshot
+  `cgsn_5e47ae79250f090af8ab5bf261d1a6744b5c29f5`: 733 files, 42,424 symbols, 128,068 relationships, and 730 files
+  reused. A global `probeRuntimeAvailableDiskBytes` graph query selected that exact current snapshot. Manager
+  diagnostics reported one verified active view, zero active builds, zero waiters, one healthy database, and zero
+  obsolete-store bytes.
+- PR #132 CI run `31359873046` and platform benchmark run `31359873105` passed, including the exact
+  `macos-15-intel` installed-release E2E. The post-merge main run `31360394512` passed on its failed-job rerun; its
+  initial attempt contained one corrupted dependency extraction and two non-reproducing load-sensitive test stalls,
+  while all three jobs passed unchanged on attempt 2.
 
 ## Release boundary
 

--- a/docs/4.1.0-beta.2-release-evidence.md
+++ b/docs/4.1.0-beta.2-release-evidence.md
@@ -1,0 +1,26 @@
+# Threadnote 4.1.0 beta.2 release evidence
+
+This record supplements [`4.1.0-beta.1-release-evidence.md`](./4.1.0-beta.1-release-evidence.md). The beta.1 tag was
+not published as a GitHub Release: its exact Intel macOS release job reproduced an unusable native disk-capacity
+observation, and source verification exposed two test-harness timing assumptions under full-suite load.
+
+## Corrective candidate
+
+- PR #132 routes Intel macOS capacity checks through the existing bounded, cancellable fallback and adds the exact
+  `macos-15-intel` release architecture to ordinary self-contained distribution CI.
+- The same PR isolates the vector-retirement crash-recovery clock and gives the bounded twelve-case corruption matrix
+  an explicit full-suite timeout without changing production behavior.
+- Exact candidate `bbee22febcce473ef2ed080decbc57c81c3daa53` was installed globally as
+  `4.1.0-beta.1.local.gbbee22febcce473ef2ed080decbc57c81c3daa53`, executable SHA-256
+  `3364616e5da7701fa249e6e0b5e10c66781d4d290802cfa845f3a037a81da55b`.
+- The installed candidate completed a real incremental graph index as snapshot
+  `cgsn_aab9aaef2dda3ed5a6cf34a70582804c275dcead`: 732 files, 42,419 symbols, 128,050 relationships, and 728 files
+  reused. Diagnostics reported one active view and zero active builds.
+
+## Release boundary
+
+The beta.2 tag may be created only from the clean merged source after PR CI passes, including the exact Intel macOS
+installed-release E2E. The tag-triggered publisher independently verifies package version, release notes, full source
+tests, native payloads, signing, notarization, checksums, and GitHub release immutability. A separate exact-tag
+production-large observation remains non-blocking and must be reported as a single retained run rather than a portable
+latency claim.

--- a/docs/4.1.0-beta.2-release-evidence.md
+++ b/docs/4.1.0-beta.2-release-evidence.md
@@ -16,6 +16,11 @@ observation, and source verification exposed two test-harness timing assumptions
 - The installed candidate completed a real incremental graph index as snapshot
   `cgsn_aab9aaef2dda3ed5a6cf34a70582804c275dcead`: 732 files, 42,419 symbols, 128,050 relationships, and 728 files
   reused. Diagnostics reported one active view and zero active builds.
+- The complete local beta.2 release-preparation head `aa0c827c251bad14a9e9e2de4ac25d29864dc89f` was installed as
+  `4.1.0-beta.2.local.gaa0c827c251bad14a9e9e2de4ac25d29864dc89f`, executable SHA-256
+  `a6c389235624bdaab73d68503d98b75ff89b1cd28430fcb44eb8ded86ba2bd3f`. It indexed the clean head as snapshot
+  `cgsn_9e568dcd36e3899b3e94666b6e86116473817ac4`: 733 files, 42,424 symbols, 128,065 relationships, and 728 files
+  reused.
 
 ## Release boundary
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,10 +34,10 @@ archiving. The same payload must contain the pinned Tree-sitter runtime, Java/Ko
 version/checksum manifest, and all four parser licenses. Source checks, archive smoke tests, and updater validation each
 reject missing or altered code-graph assets.
 
-Pull-request distribution CI retains the broad `ubuntu-latest`, `macos-latest`, and `windows-latest` lanes and adds an
-explicit `macos-15` Apple Silicon lane. `macos-15` is the exact runner label used to build the published macOS arm64
-archive, so its real-model installed-release E2E—including the supervised local-model worker—is a pre-tag gate rather
-than being exercised for the first time after a tag is pushed.
+Pull-request distribution CI retains `ubuntu-latest` and `windows-latest` and gates the exact `macos-15` Apple Silicon
+and `macos-15-intel` runner labels used by the release workflow. Their real-model installed-release E2E—including the
+supervised local-model worker and disk-capacity admission—is therefore a pre-tag gate rather than being exercised for
+the first time after a tag is pushed.
 
 ## Signing order
 
@@ -76,7 +76,7 @@ The release evidence record must distinguish a clean candidate run from exact-ta
 close implementation gates before merge, but only the tag-triggered artifact may claim exact release provenance. Keep
 public surrogate results, private path-free aggregate evidence, and checked-in same-machine comparisons separate; do
 not combine them into a synthetic percentile. The current beta closeout contract is documented in
-[`4.1.0-beta.1-release-evidence.md`](./4.1.0-beta.1-release-evidence.md).
+[`4.1.0-beta.2-release-evidence.md`](./4.1.0-beta.2-release-evidence.md).
 
 Every Threadnote 4 version tag starts a separate production-large evidence workflow on `ubuntu-24.04`; publication
 never waits for it. The evidence job has a hard 30-minute ceiling: its measured phase gets 20 minutes, leaving bounded

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.1.0-beta.1",
+  "version": "4.1.0-beta.2",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- set the package version to `4.1.0-beta.2`
- add beta.2 release notes and retained release evidence
- document the failed beta.1 tag and the immutable beta.2 replacement flow

## Why

`v4.1.0-beta.1` was tagged, but its exact Intel macOS publishing job exposed an unusable native disk-capacity observation, so no GitHub Release was published. PR #132 corrected that platform boundary and added Intel macOS installed-release coverage. This PR prepares a fresh beta.2 tag without moving the historical beta.1 tag.

## User impact

After this PR passes and merges, `v4.1.0-beta.2` can be tagged from merged `main`; the tag-triggered publisher will build, sign, notarize, checksum, and publish the immutable prerelease assets.

## Validation

- PR #132 CI run `31359873046`: passed, including all long shards and installed self-contained E2E on Ubuntu, Windows, Apple Silicon macOS, and Intel macOS
- platform benchmark run `31359873105`: passed
- post-merge main CI run `31360394512`, attempt 2: passed all failed-job reruns and the required aggregate
- exact release-branch HEAD `a3341e2d031ea338fffa5972f22615fb7ef76b89` installed globally as `4.1.0-beta.2.local.ga3341e2d031ea338fffa5972f22615fb7ef76b89`
- exact-head doctor: zero failures
- exact-head graph smoke: snapshot `cgsn_3e591ab27993c7a44977abde33d330a92f87d328`, 733 files, 42,424 symbols, 128,072 relationships, 732 reused; one verified view and zero active builds/waiters/obsolete stores
- precommit lint, formatting, and typechecks passed

No production logic changes are introduced by this release-preparation PR.
