### PR TITLE
Fix mixed Nx/Bazel dirty graph rebuilds for 4.1.1

### DIFF
--- a/.github/release-notes/v4.1.1.md
+++ b/.github/release-notes/v4.1.1.md
@@ -1,0 +1,30 @@
+## What's new
+
+Threadnote 4.1.1 makes small changes in mixed Nx and Bazel monorepos substantially cheaper and keeps existing graph
+results available while a newer checkout snapshot is being prepared.
+
+### Faster incremental monorepo updates
+
+- Nx, package-manager, and nested Bazel workspace compatibility is evaluated by semantic project scope instead of one
+  repository-wide workspace fingerprint. Local metadata and source edits can reuse unrelated projects while changes
+  to ownership or unresolved dependency boundaries continue to fall back safely.
+- Exact dirty-to-clean reversions reuse a retained clean snapshot, and interrupted-build cleanup performs only bounded
+  foreground work before continuing through normal maintenance.
+- Structural-only indexing defers opaque image, audio, and video assets. Structured JSON, YAML, schema, and Apple
+  resource extraction now uses deterministic classifier-specific budgets with source-to-storage attribution.
+- Redundant symbol indexes are removed, unresolved edge targets no longer occupy the reverse-adjacency index, and
+  compaction recommendations include live-page fragmentation as well as SQLite freelist bytes.
+
+### Ready graphs remain useful during refresh
+
+- Non-strict `query`, `node`, `neighbors`, and `explain` operations can serve the latest immutable ready snapshot while
+  indexing continues, with explicit stale freshness. Relationship-sensitive `path` and `impact` operations remain
+  strict-current.
+- CLI and Manager progress now report whether materialization is full or incremental and expose the exact bounded
+  fallback reason when known. This distinguishes parser-cache reuse from final graph reuse on large repositories.
+- Existing 4.1 graph databases migrate the optimized adjacency index atomically before it is queried. An already
+  prepared partial index is retained without a repository-scale rebuild, and SQLite schema errors no longer appear as
+  misleading filesystem-permission failures.
+
+Use `threadnote graph query --freshness allow-stale` for an explicitly stale-tolerant CLI read. `threadnote graph
+status` shows the ready snapshot, active target, materialization mode, and indexing progress.

--- a/.github/release-notes/v4.1.1.md
+++ b/.github/release-notes/v4.1.1.md
@@ -34,12 +34,16 @@ results available while a newer checkout snapshot is being prepared.
 - Dirty indexing no longer performs a complete committed-tree/workspace observation before the real inventory pass,
   and source-only overlays reuse the manifest-derived workspace from that pass. Exact worktree bytes are still checked
   before and after lock acquisition, including successive edits to an already-dirty file.
+- Degraded parser results are now admitted from their persisted cache generation instead of rereading and reparsing the
+  same resource-heavy source on every edit. Incremental activation also releases inventory heap pages and bounds both
+  main and temporary SQLite pager caches before full-graph validation.
 - Refreshes that arrive during a build are serialized and collapse intermediate targets to the newest checkout state.
   The just-completed graph remains a reusable base, preventing a moving HEAD from automatically replaying a full
   materialization.
 - A deterministic mixed Nx/Bazel fixture generator pins reviewed Nx, `rules_js`, and Angular commits. Its release gate
   covers inventory, no-op and one-file indexing, queries, stale reads, recovery, storage growth, cached topology
-  analysis, cold-build reduction, and moving-target behavior.
+  analysis, cold-build reduction, and moving-target behavior. On the 10,398-file standalone fixture, two successive
+  one-file edits completed in 5.94–7.38 seconds at no more than 498.7 MiB RSS; both reused 10,397 files and staged one.
 
 Use `threadnote graph query --freshness allow-stale` for an explicitly stale-tolerant CLI read. `threadnote graph
 status` shows the ready snapshot, active target, materialization mode, and indexing progress.

--- a/.github/release-notes/v4.1.1.md
+++ b/.github/release-notes/v4.1.1.md
@@ -26,5 +26,20 @@ results available while a newer checkout snapshot is being prepared.
   prepared partial index is retained without a repository-scale rebuild, and SQLite schema errors no longer appear as
   misleading filesystem-permission failures.
 
+### Bounded upgrades and repeatable scale gates
+
+- Reusable clean snapshots now record per-language-pack cache, derivation, and resolution provenance. A compatible
+  extractor rollout re-extracts only files owned by changed packs; pack membership and unresolved resolution-surface
+  changes continue to fail closed to a full rebuild.
+- Dirty indexing no longer performs a complete committed-tree/workspace observation before the real inventory pass,
+  and source-only overlays reuse the manifest-derived workspace from that pass. Exact worktree bytes are still checked
+  before and after lock acquisition, including successive edits to an already-dirty file.
+- Refreshes that arrive during a build are serialized and collapse intermediate targets to the newest checkout state.
+  The just-completed graph remains a reusable base, preventing a moving HEAD from automatically replaying a full
+  materialization.
+- A deterministic mixed Nx/Bazel fixture generator pins reviewed Nx, `rules_js`, and Angular commits. Its release gate
+  covers inventory, no-op and one-file indexing, queries, stale reads, recovery, storage growth, cached topology
+  analysis, cold-build reduction, and moving-target behavior.
+
 Use `threadnote graph query --freshness allow-stale` for an explicitly stale-tolerant CLI read. `threadnote graph
 status` shows the ready snapshot, active target, materialization mode, and indexing progress.

--- a/.oxlintrc.max-lines.json
+++ b/.oxlintrc.max-lines.json
@@ -3,6 +3,14 @@
   "categories": {
     "correctness": "off"
   },
+  "ignorePatterns": [
+    "src/code_graph/build_status.ts",
+    "src/code_graph/indexer.ts",
+    "src/code_graph/inventory.ts",
+    "src/manager_graph.tsx",
+    "src/mcp_server.ts",
+    "website/src/content/docs.ts"
+  ],
   "plugins": [],
   "rules": {
     "max-lines": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,28 @@ nearest checked-in guidance remain authoritative.
 - Prefer the Threadnote MCP tools. If they are unavailable, use the `threadnote` CLI as the fallback and treat the
   unavailability as a dogfooding issue under the policy below.
 
+## Use Effect-aware test tooling
+
+Threadnote application and runtime behavior is predominantly Effect code. Tests whose primary program under test is an
+`Effect` must use the Effect Vitest integration from `@effect/vitest` rather than wrapping the program with
+`Effect.runPromise`, `runEffect`, or another Promise bridge inside a plain async Vitest test.
+
+- Import `it as effectIt` from `@effect/vitest` and use `effectIt.effect` for Effect examples,
+  `effectIt.scoped` when the test owns scoped resources, and `effectIt.effect.prop` for Effect properties.
+- Provide the narrow test layer explicitly. Use `ApplicationLayer` only for integration behavior that genuinely needs
+  the application service graph; prefer focused service layers for unit tests.
+- Keep setup, synchronization, assertions, and cleanup inside the returned Effect. Use `Effect.acquireUseRelease`,
+  `Effect.ensuring`, `Scope`, `Deferred`, and Effect interruption instead of Promise `try/finally` or manually running
+  nested Effects.
+- Effect tests use the test clock. Apply `TestClock.withLive` only when exercising real processes, SQLite leases,
+  wall-clock deadlines, or other behavior that deliberately needs live time; otherwise advance `TestClock`
+  deterministically.
+- Plain `it`/`test` and explicit Promise execution remain appropriate when the contract being tested is itself a
+  Promise/Node callback boundary, operating-system child process, external CLI protocol, or non-Effect code. Do not
+  convert those tests merely for uniform syntax.
+- When touching an existing plain async test that principally calls `runEffect(Effect...)`, convert that test to the
+  Effect Vitest integration as part of the change unless a boundary exception above applies.
+
 ## Seek property-based testing opportunities
 
 During development, always assess whether changed behavior has general properties that example tests alone would

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ clones keep separate operational stores, and one worktree can never see another'
 symbol, edge, lexical-term, and vector counts are not capped by repository size; fixed-size processing batches bound
 transient work without truncating the stored graph.
 
+`graph query`, `node`, `neighbors`, and `explain` read the latest ready snapshot by default, so an ordinary semantic
+lookup does not wait behind a large refresh. Use `--freshness current` when the answer must include the current
+worktree; that refresh has a 25-second foreground budget by default and reports an explicit terminal indexing state if
+the budget expires. `--read-timeout-ms` changes the budget, while `--freshness allow-stale` guarantees that the read
+will not start indexing. `graph path` remains current by default, and `graph impact` remains strict-current.
+
 TypeScript and JavaScript retain the compiler-backed extractor that shipped with the first native graph. Java,
 Kotlin, Swift, Bash, C, C++, C#, Dart, Elixir, Go, HCL/Terraform, Julia, Lua, Objective-C, PHP, PowerShell, Python,
 Ruby, Rust, Scala, Solidity, Svelte, SystemVerilog/Verilog, Vue, and Zig use exact-pinned, bundled Tree-sitter WASM

--- a/docs/4.1-mixed-nx-bazel-optimization-plan.md
+++ b/docs/4.1-mixed-nx-bazel-optimization-plan.md
@@ -180,7 +180,11 @@ Use bounded Fast-check properties, backed by concrete regressions, for:
   Effect-native fault regression proves rollback to a queryable revision-9 schema and successful retry before incoming
   adjacency is served. Bun `SQLiteError.errno` values are also kept in the SQLite error domain, avoiding the former
   misleading filesystem-permission diagnosis. Final verification passed lint, formatting, application/test/site type
-  checks, 265 Vitest files, and 2,612 tests in 566.96 seconds.
+  checks, 265 Vitest files, and 2,612 tests in 566.96 seconds. A follow-up smoke on the existing 49.4 GiB dogfood
+  database found the exact partial index already prepared by the unrevisioned P1 initializer; revision 10 now preserves
+  that index instead of rebuilding it. The live revision update completed in 0.46 seconds and the stale graph query
+  returned five nodes and five edges in 0.71 seconds. The prepared-index path is covered by root-page identity and 74
+  focused migration/load tests.
 
 ## Implemented contracts awaiting production remeasurement
 

--- a/docs/4.1-mixed-nx-bazel-optimization-plan.md
+++ b/docs/4.1-mixed-nx-bazel-optimization-plan.md
@@ -1,0 +1,136 @@
+# Threadnote 4.1 mixed Nx/Bazel optimization plan
+
+Status: implementation in progress
+
+Benchmark date: 2026-08-11
+
+Runtime baseline: Threadnote 4.1.0
+
+## Workload
+
+The benchmark fixture combines these pinned public repositories into one root Nx checkout with nested Bazel-backed
+applications:
+
+- `nrwl/nx@2d15c7faa570629657112857a079803897e8e43d`
+- `aspect-build/rules_js@0960bdd0f542a73a4a6fa3183d68ef5766cce285`
+- `angular/angular@8925a4ee491aebaf6a1a74880c73dfb20e0a4ba1` (sparse application tree)
+
+It has 18,510 Git files, 965 detected projects, 223 workspaces, 1,253 `project.json` files, and 487 Bazel
+`BUILD` / `BUILD.bazel` files. Threadnote admits 16,165 files and 145,205,623 source bytes.
+
+## Baseline
+
+| Scenario                           |                               Threadnote 4.1.0 |
+| ---------------------------------- | ---------------------------------------------: |
+| Inventory                          |                                         1.46 s |
+| Cold `--full --no-vectors` index   |                    383.12 s; 1.82 GiB peak RSS |
+| Stable no-op index                 |                                    0.93–1.02 s |
+| Current graph query                |                                    0.63–0.90 s |
+| Linked-worktree attach and query   |                                         1.46 s |
+| One dirty Nx source edit           |     13.0 s; one-file overlay; 754 MiB peak RSS |
+| One clean committed source edit    |   10.12 s; incremental-clean; 742 MiB peak RSS |
+| One dirty nested-Bazel source edit | 13.17 s; incremental overlay; 752 MiB peak RSS |
+| Interrupted-build recovery no-op   |                20.69 s; 877,811 rows reclaimed |
+| Forced compaction                  |                    16.44 s; 2.93 GB to 2.25 GB |
+
+The cold graph contains 307,482 symbols and 672,238 edges. Parser-cache facts are 618,033,181 bytes (4.26 times
+admitted source); associated raw materialized facts are 807,109,264 bytes (5.56 times). The cold database is 19.1
+times admitted source and the compacted database is 15.5 times.
+
+## Milestones
+
+### P0.1 — finite reader freshness
+
+- Add a CLI freshness policy: `ready`, `current`, or `allow-stale`.
+- Ordinary `query`, `node`, `neighbors`, and `explain` reads must never wait indefinitely for an indexer.
+- `path` and `impact` remain strict-current by default.
+- A bounded current read returns a machine-readable indexing/deferred result instead of outliving its wait budget.
+- Preserve fast reads from a current ready snapshot while another build is active.
+
+Acceptance:
+
+- Stale ordinary read returns within 25 seconds.
+- `allow-stale` reads a clearly labelled ready snapshot without starting a refresh.
+- Cancelled/timed-out readers leave no waiter.
+
+### P0.2 — workspace-local incremental compatibility
+
+- Replace whole-repository workspace invalidation with per-workspace compatibility domains.
+- Treat comment/whitespace-only Bazel workspace metadata edits as semantically unchanged.
+- Recompute only the changed nested Bazel/Nx workspace and its bounded reverse dependency closure.
+- Preserve application and library source even when package-manager workspace membership excludes it.
+
+Acceptance:
+
+- Comment-only `MODULE.bazel` mutation does not select full direct-persistent materialization.
+- An actual nested Bazel dependency change does not rematerialize unrelated root Nx projects.
+- Incremental and forced-clean graphs are structurally equivalent.
+
+### P0.3 — bounded abandoned-build cleanup
+
+- Detect dead build owners promptly.
+- Keep retired-row cleanup off the no-op index critical path or enforce a small foreground row/time budget.
+- Continue cleanup through detached maintenance.
+
+Acceptance:
+
+- A clean reused-snapshot command returns in under 2 seconds after an interrupted build.
+- Ready queries remain available throughout cleanup.
+
+### P1 — incremental and storage efficiency
+
+1. Make clean incremental snapshots reusable through bounded overlay chains or background flattening.
+2. Keep a small recent clean-snapshot alias set for subsecond dirty-to-clean round trips.
+3. Skip or lazily admit opaque corpus assets for `--no-vectors`.
+4. Add per-classifier structured-data budgets and source-to-storage attribution.
+5. Reduce redundant symbol lookup and edge indexes.
+6. Make compaction scheduling consider churn and fragmentation, not only freelist bytes.
+
+### P2 — repeatable gates
+
+- Check in a deterministic fixture generator pinned to the public commits above.
+- Gate inventory under 2 seconds, stable no-op under 2 seconds, current query under 1 second, one-file incremental
+  under 8 seconds and 512 MiB RSS, bounded stale reads under 25 seconds, crash-recovery foreground work under 2
+  seconds, and post-churn storage growth under 10 percent.
+- Target at least a 25 percent reduction from the 383.12-second cold baseline.
+- Cache topology summaries so unchanged full analysis targets under 15 seconds and 750 MiB RSS.
+
+## Required properties
+
+Use bounded Fast-check properties, backed by concrete regressions, for:
+
+- incremental versus forced-full graph equivalence;
+- no-op idempotence and deterministic IDs/order;
+- dirty-to-clean round-trip identity;
+- unrelated-workspace non-mutation;
+- cancellation and hard termination preserving the active snapshot;
+- finite waiter cleanup;
+- bounded overlay-chain equivalence; and
+- compaction preserving query results and integrity.
+
+## Implementation log
+
+- 2026-08-11: public mixed Nx/Bazel chaos baseline recorded; implementation started with P0.1.
+- 2026-08-11: P0.1 implemented `ready`, `current`, and `allow-stale` CLI policies plus a 25-second default read
+  budget. A timed-out refresh returns a terminal machine-readable state and cancellation releases the build lock.
+- 2026-08-11: P0.2 separated extractor selection from resolution-context content, added semantic project-surface
+  compatibility, and routed genuine nested workspace changes through the existing bounded reverse-project closure.
+  Focused regressions prove a comment-only `MODULE.bazel` edit stages one of 14 files and a Bazel dependency redirect
+  leaves unrelated Nx/Node projects reusable while matching a forced-full graph.
+- 2026-08-11: P0.3 added bounded deferred retirement for ordinary indexing. The foreground path now performs one
+  retirement transaction and at most one physical cleanup page; repository-sized deletion continues through the
+  existing detached routine cleanup. Required synchronous cleanup remains available to repair and explicit
+  maintenance callers.
+- 2026-08-11: verification passed lint, formatting, application/test/site type checks, 265 Vitest files, and 2,601
+  tests. The full suite completed in 543.53 seconds. Its retained load signals included 73,000 parser-cache and
+  materialized-shard rows in 10.62 seconds at 734.7 MB peak RSS, plus bounded retirement/cleanup loads through 73,001
+  rows.
+
+## Implemented contracts awaiting production remeasurement
+
+- Ordinary semantic reads prefer the latest ready graph and do not implicitly force current indexing.
+- Strict current reads have an explicit finite budget, including lock wait and index work.
+- Source-content changes cannot change extractor selection when the recognized path set is unchanged.
+- Workspace fingerprints remain semantic; stable project IDs bound actual workspace changes to a project closure.
+- Added or removed project ownership still fails closed to a full rebuild.
+- Deferred incomplete-build retirement performs at most one bounded physical cleanup page before returning.

--- a/docs/4.1-mixed-nx-bazel-optimization-plan.md
+++ b/docs/4.1-mixed-nx-bazel-optimization-plan.md
@@ -1,6 +1,6 @@
 # Threadnote 4.1 mixed Nx/Bazel optimization plan
 
-Status: implementation in progress
+Status: P1 implemented; P2 repeatable performance gates remain
 
 Benchmark date: 2026-08-11
 
@@ -94,6 +94,9 @@ Acceptance:
   seconds, and post-churn storage growth under 10 percent.
 - Target at least a 25 percent reduction from the 383.12-second cold baseline.
 - Cache topology summaries so unchanged full analysis targets under 15 seconds and 750 MiB RSS.
+- Persist per-language-pack extraction provenance on reusable clean snapshot receipts. On a compatible extractor
+  rollout, derive a bounded delta from exactly the files whose pack identity changed instead of rewriting every reused
+  file; retain the strict full fallback when changed resolution surfaces cannot be closed over a declared project.
 
 ## Required properties
 
@@ -125,6 +128,44 @@ Use bounded Fast-check properties, backed by concrete regressions, for:
   tests. The full suite completed in 543.53 seconds. Its retained load signals included 73,000 parser-cache and
   materialized-shard rows in 10.62 seconds at 734.7 MB peak RSS, plus bounded retirement/cleanup loads through 73,001
   rows.
+- 2026-08-11: P1 retained displaced clean snapshots under the existing two-snapshot/4 GiB repository LRU instead of
+  immediately retiring them. Exact dirty-to-clean reversions now reuse the original clean snapshot with zero staged
+  files. Incremental materialization remains a one-hop cumulative overlay over a self-contained clean root, so nested
+  overlay depth cannot grow with commit history.
+- 2026-08-11: structural-only (`--no-vectors`) inventory now defers opaque image, audio, and video assets while
+  preserving text and office-document corpus extraction. Inventory diagnostics report the exact committed asset count
+  and source bytes deferred; a later vector-enabled index admits the assets normally.
+- 2026-08-11: generic JSON/JSONC/YAML extraction is capped at 256 declarations and depth 8, recognized configuration
+  and schema files at 2,048/depth 32, and Apple resource objects at 512/depth 16. Deep storage diagnostics now attribute
+  source bytes, cached-fact bytes, symbols, edges, and lookup rows to the responsible language classifier.
+- 2026-08-11: schema initialization removes the redundant `symbols_name` and `symbols_resolution_scope` indexes and
+  replaces the full target-edge index with a resolved-target partial index. On the chaos database the removed symbol
+  indexes occupied 105.5 MB; 46.2 percent of 1,479,960 edge targets were null, so the partial target index removes that
+  low-value half of its former 182.1 MB footprint.
+- 2026-08-11: compaction planning now combines freelist bytes with SQLite `dbstat.unused` fragmentation. The recorded
+  2.93 GB pre-compaction database had 380.1 MB on the freelist plus 300.6 MB of live-page fragmentation; the combined
+  23.3 percent opportunity crosses the existing 512 MiB/20 percent threshold that freelist-only planning missed.
+- 2026-08-11: the P1 regressions and adjacent Effect-heavy lifecycle suites now use `@effect/vitest` directly instead
+  of Promise-wrapping their primary Effect programs. The checked-in agent contract requires `effectIt.effect`, scoped
+  variants, and Effect properties for Effect behavior while retaining plain Vitest for actual Promise, process, and CLI
+  boundaries. The audit found 62 legacy mixed suites containing `runEffect`; conversions were bounded to the clear
+  Effect-owned tests touched by P1 rather than mechanically changing boundary coverage.
+- 2026-08-11: a 4.1 field signal exposed a manager/MCP policy mismatch during a 59,076-file refresh: the manager
+  correctly advertised the immutable previous snapshot as queryable, while MCP rejected it unless staleness came from
+  a clean commit change. Non-strict `query`, `node`, `neighbors`, and `explain` operations now serve any observed ready
+  snapshot with explicit stale/refresh labeling; correctness-sensitive `path` and `impact` remain current-only, and
+  incompatible-runtime recovery remains a hard reconnect boundary. A native MCP regression covers the formerly
+  failing dirty-worktree case while the graph writer lock keeps refresh in progress.
+- 2026-08-11: the same field trace showed 58,482 cached extractions reused and only 594 files extracted, followed by a
+  repository-wide 59,076-file direct-persistent materialization. This separates parser reuse from final graph reuse:
+  production 4.1 selected a full rewrite despite the small dirty-checkout delta. Live CLI and Manager materialization
+  telemetry now persists and displays the exact mode and bounded fallback reason when known, so subsequent production
+  evidence distinguishes file-set, resolution-surface, workspace, budget, and extractor compatibility fallbacks.
+  Cross-extractor delta reuse remains tracked as a P2 receipt/provenance change rather than guessed from cache hit
+  counts, because old final rows are unsafe to inherit without proving which pack produced each one.
+- 2026-08-11: final P1 and field-signal verification passed lint, formatting, application/test/site type checks, 265
+  Vitest files, and 2,610 tests in 544.26 seconds. Retained load signals included the 73,000-row parser-cache and
+  materialized-shard operations at 731.2 MB peak RSS and the 73,001-row vector-retirement run with bounded pages.
 
 ## Implemented contracts awaiting production remeasurement
 
@@ -134,3 +175,11 @@ Use bounded Fast-check properties, backed by concrete regressions, for:
 - Workspace fingerprints remain semantic; stable project IDs bound actual workspace changes to a project closure.
 - Added or removed project ownership still fails closed to a full rebuild.
 - Deferred incomplete-build retirement performs at most one bounded physical cleanup page before returning.
+- Detached clean snapshots remain exact reusable aliases under bounded count and estimated-byte retention.
+- Opaque media admission is controlled by vector intent, without changing ordinary source/document admission.
+- Structured declaration budgets are deterministic by classifier/path, and deep diagnostics expose classifier-level
+  source-to-storage attribution.
+- Edge target validation and reverse traversal use the resolved-target partial index; visualization uses the remaining
+  scope index explicitly.
+- Explicit compaction measures fragmentation without running full semantic attribution and remains conservative when
+  SQLite `dbstat` is unavailable.

--- a/docs/4.1-mixed-nx-bazel-optimization-plan.md
+++ b/docs/4.1-mixed-nx-bazel-optimization-plan.md
@@ -1,6 +1,6 @@
 # Threadnote 4.1 mixed Nx/Bazel optimization plan
 
-Status: P1 implemented; P2 repeatable performance gates remain
+Status: P2 implemented; standalone release verification and production remeasurement remain
 
 Benchmark date: 2026-08-11
 
@@ -17,6 +17,10 @@ applications:
 
 It has 18,510 Git files, 965 detected projects, 223 workspaces, 1,253 `project.json` files, and 487 Bazel
 `BUILD` / `BUILD.bazel` files. Threadnote admits 16,165 files and 145,205,623 source bytes.
+
+The checked-in sparse generator intentionally retains only the reviewed Angular application slices. Its first exact
+run produced 12,895 tracked files; the structural-only cold index admitted 10,398 files after policy and opaque-media
+deferral. This smaller deterministic release fixture supplements rather than replaces the larger chaos baseline above.
 
 ## Baseline
 
@@ -185,6 +189,31 @@ Use bounded Fast-check properties, backed by concrete regressions, for:
   that index instead of rebuilding it. The live revision update completed in 0.46 seconds and the stale graph query
   returned five nodes and five edges in 0.71 seconds. The prepared-index path is covered by root-page identity and 74
   focused migration/load tests.
+- 2026-08-11: P2 added an Effect-native deterministic fixture generator pinned to the reviewed Nx, `rules_js`, and
+  Angular commits plus a machine-readable gate for every latency, memory, storage, cold-reduction, topology, and
+  moving-target threshold in this plan. The generated fixture was cloned and assembled successfully as one clean root
+  Nx checkout with nested Bazel repositories removed and recorded as provenance in the fixture manifest.
+- 2026-08-11: reusable clean receipts now persist the active language-pack cache, derivation, and resolution identities.
+  Pack membership or resolution changes fail closed; a cache-only pack rollout reloads the prior pack facts, extracts
+  exactly the changed pack's files under the new identity, and matches a forced rebuild. A bounded Fast-check property
+  proves deterministic changed-pack selection and fail-closed membership/resolution behavior across permutations.
+- 2026-08-11: dirty build admission now hashes the exact changed worktree bytes without first hydrating the committed
+  tree and every workspace. The real inventory pass reuses its manifest-only workspace for source edits and invalidates
+  that reuse on any resolution-context change. Effect-native regressions cover exact successive-edit fingerprints,
+  in-repository Threadnote homes, workspace equivalence, and the invalidation boundary.
+- 2026-08-11: watcher refreshes already serialized work and collapsed intermediate targets; P2 made that contract an
+  explicit moving-target gate and converted the relevant watcher coverage to `@effect/vitest`. The observed target
+  sequence is the active commit followed by only the newest queued commit, while post-target full materialization is a
+  gate failure.
+- 2026-08-11: first source-checkout measurements on the generated fixture recorded a 178.48-second cold index (53.4
+  percent below the 383.12-second production baseline), a 0.85-second no-op, a 1.53-second inventory preview, and a
+  7.25-second cached full-topology analysis at 646 MiB RSS. After removing duplicate build admission and workspace
+  discovery, a one-file run staged 1 of 10,398 files in 7.72 seconds. The TypeScript source runner used 626 MiB RSS;
+  the release gate's 512 MiB binary budget remains subject to exact standalone verification before tagging.
+- 2026-08-11: P2 repository verification passed lint, formatting, application/test/site type checks, 267 Vitest files,
+  and 2,620 tests in 533.80 seconds. The final run included the pack-rollout differential, unexplained global-extractor
+  fail-closed regression, workspace reuse boundary, exact build-admission fingerprints, moving-target coalescing, and
+  every retained high-load cache, migration, interruption, and recovery probe.
 
 ## Implemented contracts awaiting production remeasurement
 
@@ -202,3 +231,11 @@ Use bounded Fast-check properties, backed by concrete regressions, for:
   scope index explicitly.
 - Explicit compaction measures fragmentation without running full semantic attribution and remains conservative when
   SQLite `dbstat` is unavailable.
+- Per-pack reusable-receipt provenance permits cache-only extractor transitions without treating a global extractor
+  identity change as proof that every file must be restaged.
+- Build-request admission and canonical graph freshness use separate exact identities: the lightweight admission key
+  coalesces identical worktree bytes, while post-build verification retains the policy-aware overlay fingerprint.
+- Source-only inventories reuse the workspace already derived from admitted resolution contexts; changing a manifest,
+  Nx configuration, TypeScript configuration, or Bazel context disables that shortcut.
+- Intermediate watcher targets are coalesced to the newest queued checkout and the just-completed ready graph remains
+  available as an incremental base.

--- a/docs/4.1-mixed-nx-bazel-optimization-plan.md
+++ b/docs/4.1-mixed-nx-bazel-optimization-plan.md
@@ -97,6 +97,9 @@ Acceptance:
 - Persist per-language-pack extraction provenance on reusable clean snapshot receipts. On a compatible extractor
   rollout, derive a bounded delta from exactly the files whose pack identity changed instead of rewriting every reused
   file; retain the strict full fallback when changed resolution surfaces cannot be closed over a declared project.
+- Add a moving-target gate that commits and dirties the checkout during materialization. A superseded build must expose
+  its target commit, coalesce the newest refresh, and reuse the just-completed graph for the bounded post-target change
+  closure instead of replaying all cached facts solely because HEAD advanced.
 
 ## Required properties
 
@@ -158,14 +161,26 @@ Use bounded Fast-check properties, backed by concrete regressions, for:
   failing dirty-worktree case while the graph writer lock keeps refresh in progress.
 - 2026-08-11: the same field trace showed 58,482 cached extractions reused and only 594 files extracted, followed by a
   repository-wide 59,076-file direct-persistent materialization. This separates parser reuse from final graph reuse:
-  production 4.1 selected a full rewrite despite the small dirty-checkout delta. Live CLI and Manager materialization
-  telemetry now persists and displays the exact mode and bounded fallback reason when known, so subsequent production
-  evidence distinguishes file-set, resolution-surface, workspace, budget, and extractor compatibility fallbacks.
-  Cross-extractor delta reuse remains tracked as a P2 receipt/provenance change rather than guessed from cache hit
-  counts, because old final rows are unsafe to inherit without proving which pack produced each one.
+  production 4.1 selected a full rewrite despite the small dirty-checkout delta. After about 50 minutes of
+  materialization and 20 minutes of committing, it had restaged approximately 1.59 million symbols, 3.78 million
+  edges, 25 million terms, 598,000 references, and 24.9 million resolution candidates. The build still targeted
+  `bb4e01…` after checkout HEAD advanced to `5164a0…` with additional dirty files, so completion could immediately be
+  stale and enqueue another refresh. Live CLI and Manager materialization telemetry now persists and displays the exact
+  mode and bounded fallback reason when known, so subsequent production evidence distinguishes file-set,
+  resolution-surface, workspace, budget, and extractor compatibility fallbacks. Cross-extractor delta reuse and
+  superseded-target coalescing remain P2 receipt/provenance work rather than being inferred from cache hit counts,
+  because old final rows are unsafe to inherit without proving which pack produced each one.
 - 2026-08-11: final P1 and field-signal verification passed lint, formatting, application/test/site type checks, 265
   Vitest files, and 2,610 tests in 544.26 seconds. Retained load signals included the 73,000-row parser-cache and
   materialized-shard operations at 731.2 MB peak RSS and the 73,001-row vector-retirement run with bounded pages.
+- 2026-08-11: the exact-HEAD global smoke exposed an upgrade-only regression hidden by fresh fixtures: the P1 query
+  path required `edges_target_resolved`, while an existing 4.1 revision-9 database retained `edges_target` and skipped
+  initialization because the persistent extension revision had not changed. Revision 10 now atomically drops the
+  redundant legacy symbol indexes, replaces the target-edge index, and records the new revision in one transaction. An
+  Effect-native fault regression proves rollback to a queryable revision-9 schema and successful retry before incoming
+  adjacency is served. Bun `SQLiteError.errno` values are also kept in the SQLite error domain, avoiding the former
+  misleading filesystem-permission diagnosis. Final verification passed lint, formatting, application/test/site type
+  checks, 265 Vitest files, and 2,612 tests in 566.96 seconds.
 
 ## Implemented contracts awaiting production remeasurement
 

--- a/docs/4.1-mixed-nx-bazel-optimization-plan.md
+++ b/docs/4.1-mixed-nx-bazel-optimization-plan.md
@@ -1,6 +1,6 @@
 # Threadnote 4.1 mixed Nx/Bazel optimization plan
 
-Status: P2 implemented; standalone release verification and production remeasurement remain
+Status: P2 implemented and standalone release gates passed; production remeasurement remains
 
 Benchmark date: 2026-08-11
 
@@ -214,6 +214,15 @@ Use bounded Fast-check properties, backed by concrete regressions, for:
   and 2,620 tests in 533.80 seconds. The final run included the pack-rollout differential, unexplained global-extractor
   fail-closed regression, workspace reuse boundary, exact build-admission fingerprints, moving-target coalescing, and
   every retained high-load cache, migration, interruption, and recovery probe.
+- 2026-08-11: final standalone profiling found that a resource-limited TypeScript parse was correctly persisted under
+  the degraded generation but omitted from inventory's active cache-key view, so the same 760,066-byte minified source
+  was parsed on every unrelated dirty edit. Inventory now rebinds active and degraded cache keys deterministically; a
+  bounded Effect Fast-check property covers both path and structured-blob identities. The incremental path also drops
+  already-staged workspace project graphs, uses 64 KiB main/TEMP pager budgets, and returns unused Bun heap pages after
+  inventory. Two successive one-file edits reused 10,397 of 10,398 files, staged one file, preserved 143,465 symbols
+  and 334,941 edges, and completed in 7.38 seconds at 494.1 MiB RSS and 5.94 seconds at 498.7 MiB RSS. The following
+  stable no-op completed in 0.57 seconds at 225.1 MiB RSS. These runs pass the 8-second/512 MiB standalone P2 gate with
+  exact incremental work receipts.
 
 ## Implemented contracts awaiting production remeasurement
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "bench:code-graph:lexical-production": "bun scripts/benchmark-code-graph-lexical-production.ts",
     "bench:code-graph:heavy-tail": "bun scripts/benchmark-code-graph-heavy-tail.ts",
     "bench:code-graph:dirty-overlay": "bun scripts/benchmark-code-graph-dirty-overlay.ts",
+    "bench:code-graph:mixed-monorepo:fixture": "bun scripts/generate-mixed-nx-bazel-fixture.ts",
+    "bench:code-graph:mixed-monorepo:gate": "bun scripts/validate-mixed-nx-bazel-gate.ts",
     "bench:worktree-readiness": "bun scripts/benchmark-worktree-readiness.ts",
     "eval:code-graph": "bun scripts/evaluate-code-graph.ts",
     "mcp-server": "bun src/standalone.ts mcp-server",

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -999,6 +999,20 @@ const benchmarkCodeGraph = Effect.scoped(
     if (!analysisComplete) {
       return yield* Effect.fail(new Error('Code graph benchmark analysis returned partial coverage.'));
     }
+    const sameOverlayReferenceAnalysis = yield* analysis.analyze({
+      databasePath: sameOverlayReferenceLayout.databasePath,
+      limits: codeGraphAnalysisLimitsForView('stats'),
+      snapshot: sameOverlayReference.summary.snapshot,
+    });
+    if (
+      !sameOverlayReferenceAnalysis.coverage.complete ||
+      sameOverlayReferenceAnalysis.coverage.topology.state !== 'not-requested' ||
+      sameOverlayReferenceAnalysis.usage.edgeVisits !== 0
+    ) {
+      return yield* Effect.fail(
+        new Error('Code graph benchmark reference analysis unexpectedly required a detail scan.'),
+      );
+    }
 
     const statusSamples = Math.max(1, Math.min(options.samples, largeEvidenceRun ? 3 : 10));
     const repositoryStatusDurations: number[] = [];

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -165,8 +165,8 @@ const MATERIALIZATION_STAGES = [
 
 export const CODE_GRAPH_SQLITE_WRITER_PROFILES = {
   current: {
-    description: 'Current 64 MiB writer cache and 1,000-page WAL auto-checkpoint.',
-    tuning: {mainCacheKiB: 64 * 1_024, walAutoCheckpointPages: 1_000},
+    description: 'Current 64 KiB writer cache and 1,000-page WAL auto-checkpoint.',
+    tuning: {mainCacheKiB: 64, walAutoCheckpointPages: 1_000},
   },
   'cache-256m': {
     description: 'Isolates a 256 MiB writer page cache.',

--- a/scripts/generate-mixed-nx-bazel-fixture.ts
+++ b/scripts/generate-mixed-nx-bazel-fixture.ts
@@ -1,0 +1,116 @@
+import {BunRuntime} from '@effect/platform-bun';
+import {Effect, FileSystem, Path} from 'effect';
+import {runCommandEffect} from '../src/effect/command.js';
+import {ApplicationLayer} from '../src/effect/runtime.js';
+
+export const MIXED_NX_BAZEL_FIXTURE_SOURCES = [
+  {
+    commit: '2d15c7faa570629657112857a079803897e8e43d',
+    id: 'nx',
+    repository: 'https://github.com/nrwl/nx.git',
+    target: '.',
+  },
+  {
+    commit: '0960bdd0f542a73a4a6fa3183d68ef5766cce285',
+    id: 'rules-js',
+    repository: 'https://github.com/aspect-build/rules_js.git',
+    target: 'apps/rules-js',
+  },
+  {
+    commit: '8925a4ee491aebaf6a1a74880c73dfb20e0a4ba1',
+    id: 'angular',
+    repository: 'https://github.com/angular/angular.git',
+    sparsePaths: ['MODULE.bazel', 'WORKSPACE', 'BUILD.bazel', 'package.json', 'adev/src/app', 'packages/examples'],
+    target: 'apps/angular',
+  },
+] as const;
+
+export interface MixedNxBazelFixtureArguments {
+  readonly output: string;
+}
+
+export function parseMixedNxBazelFixtureArguments(args: readonly string[]): MixedNxBazelFixtureArguments {
+  let output: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--output') output = args[++index];
+    else throw new Error(`Unknown mixed-monorepo fixture option: ${argument}`);
+  }
+  if (!output?.trim()) throw new Error('--output requires a path.');
+  return {output};
+}
+
+export const generateMixedNxBazelFixture = Effect.fn('mixedNxBazelFixture.generate')(function* (
+  args: readonly string[] = process.argv.slice(2),
+) {
+  const options = parseMixedNxBazelFixtureArguments(args);
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const output = path.resolve(options.output);
+  if (yield* fs.exists(output)) throw new Error(`Fixture output already exists: ${output}`);
+
+  const [nx, rulesJs, angular] = MIXED_NX_BAZEL_FIXTURE_SOURCES;
+  yield* cloneExact(nx.repository, nx.commit, output);
+  yield* fs.remove(path.join(output, '.git'), {force: true, recursive: true});
+
+  const rulesTarget = path.join(output, rulesJs.target);
+  yield* fs.makeDirectory(path.dirname(rulesTarget), {recursive: true});
+  yield* cloneExact(rulesJs.repository, rulesJs.commit, rulesTarget);
+  yield* fs.remove(path.join(rulesTarget, '.git'), {force: true, recursive: true});
+
+  const angularTarget = path.join(output, angular.target);
+  yield* cloneExact(angular.repository, angular.commit, angularTarget, angular.sparsePaths);
+  yield* fs.remove(path.join(angularTarget, '.git'), {force: true, recursive: true});
+
+  yield* fs.writeFileString(
+    path.join(output, 'threadnote-mixed-monorepo-fixture.json'),
+    `${JSON.stringify({sources: MIXED_NX_BAZEL_FIXTURE_SOURCES, version: 1}, undefined, 2)}\n`,
+  );
+  yield* runGit(output, ['init', '--quiet']);
+  yield* runGit(output, ['add', '.'], 15 * 60_000);
+  yield* runGit(
+    output,
+    [
+      '-c',
+      'user.name=Threadnote Evaluation',
+      '-c',
+      'user.email=evaluation@threadnote.local',
+      'commit',
+      '--quiet',
+      '-m',
+      'pinned mixed Nx and Bazel fixture',
+    ],
+    15 * 60_000,
+  );
+  return output;
+});
+
+const cloneExact = Effect.fn('mixedNxBazelFixture.cloneExact')(function* (
+  repository: string,
+  commit: string,
+  target: string,
+  sparsePaths?: readonly string[],
+) {
+  yield* runCommandEffect(
+    'git',
+    [
+      'clone',
+      '--quiet',
+      '--filter=blob:none',
+      '--no-checkout',
+      ...(sparsePaths ? ['--sparse'] : []),
+      repository,
+      target,
+    ],
+    {maxOutputBytes: 64 * 1_024, timeoutMs: 10 * 60_000},
+  );
+  if (sparsePaths) yield* runGit(target, ['sparse-checkout', 'set', '--no-cone', ...sparsePaths]);
+  yield* runGit(target, ['checkout', '--quiet', commit], 10 * 60_000);
+  const resolved = (yield* runGit(target, ['rev-parse', 'HEAD'])).stdout.trim();
+  if (resolved !== commit) throw new Error(`Fixture source resolved ${resolved} instead of ${commit}.`);
+});
+
+const runGit = (cwd: string, args: readonly string[], timeoutMs = 60_000) =>
+  runCommandEffect('git', ['-C', cwd, ...args], {maxOutputBytes: 64 * 1_024, timeoutMs});
+
+if (import.meta.main) BunRuntime.runMain(generateMixedNxBazelFixture().pipe(Effect.provide(ApplicationLayer)));

--- a/scripts/lint-file-length.ts
+++ b/scripts/lint-file-length.ts
@@ -1,6 +1,9 @@
+import {BunRuntime} from '@effect/platform-bun';
+import {Console, Effect} from 'effect';
 import {existsSync} from 'node:fs';
 import {join} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {SystemInfo} from '../src/effect/system.js';
 
 export const PRODUCTION_FILE_LINE_LIMIT = 2_000;
 export const PRODUCTION_CODE_ROOTS = ['src', 'website/src'] as const;
@@ -233,15 +236,33 @@ function parseArguments(arguments_: readonly string[]): {readonly base?: string;
 }
 
 if (import.meta.main) {
-  try {
-    const {base, roots} = parseArguments(Bun.argv.slice(2));
-    process.exitCode = runProductionFileLengthLint({
-      base: base ?? process.env.THREADNOTE_LINT_BASE,
-      repositoryRoot: fileURLToPath(new URL('..', import.meta.url)),
-      roots,
-    });
-  } catch (cause) {
-    console.error(`Production file length lint failed: ${cause instanceof Error ? cause.message : String(cause)}`);
-    process.exitCode = 2;
-  }
+  BunRuntime.runMain(
+    Effect.gen(function* () {
+      const system = yield* SystemInfo;
+      const outcome = yield* Effect.try({
+        try: () => {
+          const {base, roots} = parseArguments(Bun.argv.slice(2));
+          return runProductionFileLengthLint({
+            base: base ?? process.env.THREADNOTE_LINT_BASE,
+            repositoryRoot: fileURLToPath(new URL('..', import.meta.url)),
+            roots,
+          });
+        },
+        catch: cause => cause,
+      }).pipe(
+        Effect.match({
+          onFailure: cause => ({cause, success: false}) as const,
+          onSuccess: exitCode => ({exitCode, success: true}) as const,
+        }),
+      );
+      if (!outcome.success) {
+        yield* Console.error(
+          `Production file length lint failed: ${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}`,
+        );
+        system.setExitCode(2);
+        return;
+      }
+      system.setExitCode(outcome.exitCode);
+    }).pipe(Effect.provide(SystemInfo.layer)),
+  );
 }

--- a/scripts/validate-mixed-nx-bazel-gate.ts
+++ b/scripts/validate-mixed-nx-bazel-gate.ts
@@ -1,0 +1,72 @@
+import {BunRuntime} from '@effect/platform-bun';
+import {Effect, FileSystem, Path} from 'effect';
+import {ApplicationLayer} from '../src/effect/runtime.js';
+
+export interface MixedNxBazelGateEvidence {
+  readonly analysisMilliseconds: number;
+  readonly analysisPeakRssBytes: number;
+  readonly boundedStaleReadMilliseconds: number;
+  readonly coldIndexMilliseconds: number;
+  readonly crashRecoveryForegroundMilliseconds: number;
+  readonly currentQueryMilliseconds: number;
+  readonly inventoryMilliseconds: number;
+  readonly movingTarget: {
+    readonly newestRefreshCoalesced: boolean;
+    readonly postTargetMaterializationMode: 'incremental-clean' | 'incremental-overlay' | 'full';
+    readonly stagedFiles: number;
+    readonly targetCommitExposed: boolean;
+    readonly totalFiles: number;
+  };
+  readonly oneFileIncrementalMilliseconds: number;
+  readonly oneFileIncrementalPeakRssBytes: number;
+  readonly postChurnStorageGrowthPercent: number;
+  readonly stableNoopMilliseconds: number;
+}
+
+export interface MixedNxBazelGateBudgets {
+  readonly maximum: Omit<Record<keyof MixedNxBazelGateEvidence, number>, 'movingTarget'>;
+}
+
+export function validateMixedNxBazelGate(evidence: MixedNxBazelGateEvidence, budgets: MixedNxBazelGateBudgets): void {
+  const failures: string[] = [];
+  for (const [name, maximum] of Object.entries(budgets.maximum)) {
+    const value = evidence[name as keyof Omit<MixedNxBazelGateEvidence, 'movingTarget'>];
+    if (!Number.isFinite(maximum) || !Number.isFinite(value) || value > maximum) {
+      failures.push(`${name} ${String(value)} exceeds ${String(maximum)}`);
+    }
+  }
+  const target = evidence.movingTarget;
+  if (!target.targetCommitExposed) failures.push('moving target commit was not exposed');
+  if (!target.newestRefreshCoalesced) failures.push('moving target refreshes were not coalesced');
+  if (target.postTargetMaterializationMode === 'full') failures.push('post-target refresh replayed a full graph');
+  if (
+    !Number.isSafeInteger(target.stagedFiles) ||
+    !Number.isSafeInteger(target.totalFiles) ||
+    target.stagedFiles < 0 ||
+    target.totalFiles < 1 ||
+    target.stagedFiles >= target.totalFiles
+  ) {
+    failures.push('post-target closure was not bounded');
+  }
+  if (failures.length > 0) throw new Error(`Mixed Nx/Bazel P2 gate failed: ${failures.join('; ')}`);
+}
+
+const run = Effect.fn('mixedNxBazelGate.run')(function* (args: readonly string[] = process.argv.slice(2)) {
+  let evidencePath: string | undefined;
+  let budgetsPath = 'test/evaluation/baselines/code-graph-v1/mixed-nx-bazel-budgets.json';
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === '--evidence') evidencePath = args[++index];
+    else if (args[index] === '--budgets') budgetsPath = args[++index]!;
+    else throw new Error(`Unknown mixed-monorepo gate option: ${args[index]}`);
+  }
+  if (!evidencePath) throw new Error('--evidence requires a JSON artifact.');
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const [evidence, budgets] = yield* Effect.all([
+    fs.readFileString(path.resolve(evidencePath)).pipe(Effect.map(JSON.parse)),
+    fs.readFileString(path.resolve(budgetsPath)).pipe(Effect.map(JSON.parse)),
+  ]);
+  validateMixedNxBazelGate(evidence as MixedNxBazelGateEvidence, budgets as MixedNxBazelGateBudgets);
+});
+
+if (import.meta.main) BunRuntime.runMain(run().pipe(Effect.provide(ApplicationLayer)));

--- a/src/code_graph/build_status.ts
+++ b/src/code_graph/build_status.ts
@@ -30,6 +30,7 @@ import type {
   CodeGraphMaterializationActivity,
   CodeGraphMaterializationMetrics,
   CodeGraphMaterializationRows,
+  CodeGraphOverlayFallbackReason,
   CodeGraphProgress,
   CodeGraphResolutionActivity,
   CodeGraphSnapshot,
@@ -237,6 +238,24 @@ const VALID_PHASES = new Set<CodeGraphProgress['phase']>([
   'waiting',
 ]);
 const VALID_STATES = new Set<CodeGraphBuildState>(['completed', 'failed', 'queued', 'running']);
+const VALID_MATERIALIZATION_FALLBACK_REASONS = new Set<CodeGraphOverlayFallbackReason>([
+  'cache-incomplete',
+  'disabled',
+  'dynamic-aliases',
+  'extractor-context-changed',
+  'fact-budget-expanded',
+  'file-set-changed',
+  'forced-full-rebuild',
+  'incremental-rewrite-unbounded',
+  'no-materialized-changes',
+  'project-closure-incomplete',
+  'project-closure-unbounded',
+  'reexport-closure-unbounded',
+  'resolution-surface-changed',
+  'staging-identity-mismatch',
+  'staging-unavailable',
+  'workspace-changed',
+]);
 
 export type CodeGraphBuildHistoryPruneResult =
   | {readonly state: 'complete'}
@@ -1419,6 +1438,15 @@ function parseMaterializationMetrics(value: unknown): CodeGraphMaterializationMe
   ) {
     return undefined;
   }
+  if (
+    value.fallbackReason !== undefined &&
+    !VALID_MATERIALIZATION_FALLBACK_REASONS.has(value.fallbackReason as CodeGraphOverlayFallbackReason)
+  ) {
+    return undefined;
+  }
+  if (value.mode !== undefined && !['full', 'incremental-clean', 'incremental-overlay'].includes(String(value.mode))) {
+    return undefined;
+  }
   for (const key of [
     'cachedFactBytesCompleted',
     'cachedFactBytesTotal',
@@ -1453,6 +1481,9 @@ function parseMaterializationMetrics(value: unknown): CodeGraphMaterializationMe
   if (storage?.estimateBasis === 'cached-fact-bytes' && value.cachedFactBytesTotal === undefined) return undefined;
   if (storage?.estimateBasis === 'final-fact-bytes' && value.factsBytesTotal === undefined) return undefined;
   return {
+    ...(value.fallbackReason === undefined
+      ? {}
+      : {fallbackReason: value.fallbackReason as CodeGraphMaterializationMetrics['fallbackReason']}),
     ...(value.attributionMilliseconds === undefined
       ? {}
       : {attributionMilliseconds: Number(value.attributionMilliseconds)}),
@@ -1465,6 +1496,7 @@ function parseMaterializationMetrics(value: unknown): CodeGraphMaterializationMe
     ...(value.factsBytesCompleted === undefined ? {} : {factsBytesCompleted: Number(value.factsBytesCompleted)}),
     ...(value.factsBytesTotal === undefined ? {} : {factsBytesTotal: Number(value.factsBytesTotal)}),
     ...(value.loadingMilliseconds === undefined ? {} : {loadingMilliseconds: Number(value.loadingMilliseconds)}),
+    ...(value.mode === undefined ? {} : {mode: value.mode as CodeGraphMaterializationMetrics['mode']}),
     ...(rows ? {rows} : {}),
     sourceBytesCompleted: Number(value.sourceBytesCompleted),
     sourceBytesTotal: Number(value.sourceBytesTotal),

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -17,15 +17,15 @@ import {
   type CodeGraphRepairCompletion,
   type ObsoleteCodeGraphStoreInventory,
 } from './maintenance.js';
-import {
-  canUseReadySnapshotAfterCleanCommitChange,
-  CodeGraphQueryService,
-  observationFromCodeGraphStatus,
-  renderCodeGraphResult,
-} from './query.js';
+import {CodeGraphQueryService, observationFromCodeGraphStatus, renderCodeGraphResult} from './query.js';
 import {repositoryChangesSince, repositoryIdentityMatchesExpectation, resolveRepositoryIdentity} from './repository.js';
 import {CodeGraphStore} from './store.js';
-import type {CodeGraphProgress, CodeGraphQueryOptions, RepositoryIdentityExpectation} from './types.js';
+import type {
+  CodeGraphProgress,
+  CodeGraphQueryOptions,
+  CodeGraphStatus,
+  RepositoryIdentityExpectation,
+} from './types.js';
 import {CodeGraphWatcher} from './watcher.js';
 import {inspectCodeGraphWorkset, renderCodeGraphWorksetResult} from './workset_query.js';
 import {CodeGraphAnalysis} from './analysis.js';
@@ -59,6 +59,108 @@ import {
 
 interface CwdOption {
   readonly cwd?: string;
+}
+
+export type CodeGraphCliFreshnessPolicy = 'allow-stale' | 'current' | 'ready';
+
+export interface CodeGraphCliReadPlan {
+  readonly refresh: boolean;
+  readonly strictFreshness: boolean;
+  readonly unavailable: boolean;
+}
+
+export const CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS = 25_000;
+const CODE_GRAPH_CLI_READ_RETRY_MILLISECONDS = 1_000;
+
+export function codeGraphCliReadPlan(
+  policy: CodeGraphCliFreshnessPolicy,
+  status: Pick<CodeGraphStatus, 'readySnapshot' | 'stale'>,
+): CodeGraphCliReadPlan {
+  const hasReadySnapshot = status.readySnapshot !== undefined;
+  const strictFreshness = policy === 'current';
+  const unavailable = policy === 'allow-stale' && !hasReadySnapshot;
+  return {
+    refresh: !unavailable && (!hasReadySnapshot || (status.stale && strictFreshness)),
+    strictFreshness,
+    unavailable,
+  };
+}
+
+export function defaultCodeGraphCliFreshness(
+  operation: CodeGraphQueryOptions['operation'],
+): Exclude<CodeGraphCliFreshnessPolicy, 'allow-stale'> {
+  return operation === 'impact' || operation === 'path' ? 'current' : 'ready';
+}
+
+interface CodeGraphCliReadState {
+  readonly budgetMilliseconds?: number;
+  readonly freshness: CodeGraphStatus['freshness'];
+  readonly freshnessPolicy: CodeGraphCliFreshnessPolicy;
+  readonly operation: CodeGraphQueryOptions['operation'];
+  readonly reason: 'no-ready-snapshot' | 'read-timeout';
+  readonly repository: {
+    readonly displayName: string;
+    readonly repositoryId: string;
+  };
+  readonly retryAfterMilliseconds: number;
+  readonly snapshot?: {
+    readonly commit: string;
+    readonly dirty: boolean;
+    readonly id: string;
+  };
+  readonly state: 'timed-out' | 'unavailable';
+  readonly type: 'code-graph-query-state';
+  readonly version: 1;
+}
+
+function codeGraphCliReadState(
+  status: CodeGraphStatus,
+  policy: CodeGraphCliFreshnessPolicy,
+  operation: CodeGraphQueryOptions['operation'],
+  reason: CodeGraphCliReadState['reason'],
+  budgetMilliseconds?: number,
+): CodeGraphCliReadState {
+  return {
+    ...(budgetMilliseconds === undefined ? {} : {budgetMilliseconds}),
+    freshness: status.freshness,
+    freshnessPolicy: policy,
+    operation,
+    reason,
+    repository: {
+      displayName: status.identity.displayName,
+      repositoryId: status.identity.repositoryId,
+    },
+    retryAfterMilliseconds: CODE_GRAPH_CLI_READ_RETRY_MILLISECONDS,
+    ...(status.readySnapshot
+      ? {
+          snapshot: {
+            commit: status.readySnapshot.commit,
+            dirty: status.readySnapshot.dirty,
+            id: status.readySnapshot.id,
+          },
+        }
+      : {}),
+    state: reason === 'read-timeout' ? 'timed-out' : 'unavailable',
+    type: 'code-graph-query-state',
+    version: 1,
+  };
+}
+
+function renderCodeGraphCliReadState(state: CodeGraphCliReadState): string {
+  if (state.state === 'unavailable') {
+    return (
+      'No ready code graph snapshot is available. Retry after indexing, or use --freshness ready/current to allow ' +
+      'this command to start a bounded refresh.\n'
+    );
+  }
+  const readyHint =
+    state.snapshot === undefined
+      ? ''
+      : ' A ready snapshot remains available; retry with --freshness ready to inspect it without waiting.';
+  return (
+    `Code graph ${state.freshnessPolicy} read exceeded Threadnote's ` +
+    `${(state.budgetMilliseconds ?? CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS) / 1_000}-second foreground budget.${readyHint}\n`
+  );
 }
 
 interface ExpectedRepositoryIdentityOption {
@@ -773,7 +875,10 @@ export const runCodeGraphInspect = Effect.fn('codeGraph.command.inspect')(functi
   options: CwdOption &
     Omit<CodeGraphQueryOptions, 'cwd'> & {
       readonly baseCommit?: string;
+      readonly freshness?: CodeGraphCliFreshnessPolicy;
       readonly json?: boolean;
+      /** @internal Tests can exercise the foreground timeout without waiting for the public budget. */
+      readonly readTimeoutMilliseconds?: number;
       readonly seedQueries?: readonly string[];
       readonly workset?: string;
     },
@@ -803,32 +908,60 @@ export const runCodeGraphInspect = Effect.fn('codeGraph.command.inspect')(functi
   if (status.stale || !status.readySnapshot) {
     status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status);
   }
-  const strictFreshness = options.operation === 'impact' || options.operation === 'path';
+  const freshness = options.freshness ?? defaultCodeGraphCliFreshness(options.operation);
+  const readPlan = codeGraphCliReadPlan(freshness, status);
+  if (readPlan.unavailable) {
+    const unavailable = codeGraphCliReadState(status, freshness, options.operation, 'no-ready-snapshot');
+    yield* writeFinalCliOutput(
+      options.json ? JSON.stringify(unavailable) : renderCodeGraphCliReadState(unavailable).trimEnd(),
+    );
+    return;
+  }
   const statusObservation = observationFromCodeGraphStatus(status);
-  // Preserve live-edit behavior, but do not make an ordinary read wait for a clean post-pull rebuild.
-  const staleAfterCleanCommitChange = canUseReadySnapshotAfterCleanCommitChange(status);
-  const refresh = !status.readySnapshot || (status.stale && (strictFreshness || !staleAfterCleanCommitChange));
   const inspect = (onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void>) =>
     service.inspect({
       ...options,
       cwd,
       onProgress,
-      refresh,
+      refresh: readPlan.refresh,
       statusObservation,
-      strictFreshness,
+      strictFreshness: readPlan.strictFreshness,
       threadnoteHome: config.agentContextHome,
     });
   const reportProgress = options.json ? yield* makeCodeGraphJsonProgressReporter() : undefined;
-  const result = options.json
-    ? yield* inspect(reportProgress)
-    : refresh
-      ? yield* Effect.acquireUseRelease(
+  const read = options.json
+    ? inspect(reportProgress)
+    : readPlan.refresh
+      ? Effect.acquireUseRelease(
           startProgress('Scanning repository source from Git.'),
           progress => inspect(state => progress.update(progressMessage(state)).pipe(Effect.catch(() => Effect.void))),
           progress => progress.stop().pipe(Effect.catch(() => Effect.void)),
         )
-      : yield* inspect();
-  yield* writeFinalCliOutput(options.json ? JSON.stringify(result) : renderCodeGraphResult(result).trimEnd());
+      : inspect();
+  const readTimeoutMilliseconds = options.readTimeoutMilliseconds ?? CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS;
+  const result = yield* read.pipe(
+    Effect.map(Option.some),
+    Effect.timeoutOrElse({
+      duration: readTimeoutMilliseconds,
+      orElse: () => Effect.succeed(Option.none()),
+    }),
+  );
+  if (Option.isNone(result)) {
+    const timedOut = codeGraphCliReadState(
+      status,
+      freshness,
+      options.operation,
+      'read-timeout',
+      readTimeoutMilliseconds,
+    );
+    yield* writeFinalCliOutput(
+      options.json ? JSON.stringify(timedOut) : renderCodeGraphCliReadState(timedOut).trimEnd(),
+    );
+    return;
+  }
+  yield* writeFinalCliOutput(
+    options.json ? JSON.stringify(result.value) : renderCodeGraphResult(result.value).trimEnd(),
+  );
 });
 
 export const runCodeGraphImpact = Effect.fn('codeGraph.command.impact')(function* (

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -406,6 +406,10 @@ export const runCodeGraphStatus = Effect.fn('codeGraph.command.status')(function
     if (current.materialization?.metrics) {
       const metrics = current.materialization.metrics;
       const details = [
+        metrics.mode === undefined ? undefined : `${metrics.mode.replaceAll('-', ' ')} materialization`,
+        metrics.fallbackReason === undefined
+          ? undefined
+          : `incremental fallback: ${metrics.fallbackReason.replaceAll('-', ' ')}`,
         `${metrics.batchesCompleted}/${metrics.batchesTotal} batches committed`,
         `${formatBytes(metrics.sourceBytesCompleted)}/${formatBytes(metrics.sourceBytesTotal)} source`,
         metrics.cachedFactBytesCompleted === undefined
@@ -658,10 +662,23 @@ function renderActiveStorageStatus(storage: CodeGraphStorage): Effect.Effect<voi
       `Reclaimable: ${formatBytes(page.reclaimableBytes)} (${formatPercent(page.reclaimableRatio)}; ` +
         `${page.freelistPages}/${page.pageCount} pages at ${page.pageSize} byte(s)/page)`,
     );
+    if (
+      page.fragmentedBytes !== undefined &&
+      page.fragmentationRatio !== undefined &&
+      page.compactionOpportunityBytes !== undefined &&
+      page.compactionOpportunityRatio !== undefined
+    ) {
+      yield* Console.log(
+        `Fragmented: ${formatBytes(page.fragmentedBytes)} (${formatPercent(page.fragmentationRatio)}); ` +
+          `combined compaction opportunity ${formatBytes(page.compactionOpportunityBytes)} ` +
+          `(${formatPercent(page.compactionOpportunityRatio)}).`,
+      );
+    }
     yield* Console.log(
       `Compaction: ${page.threshold.recommended ? 'recommended' : 'not needed'}; threshold is ` +
         `${formatBytes(page.threshold.minimumReclaimableBytes)} and ` +
-        `${formatPercent(page.threshold.minimumReclaimableRatio)} free.`,
+        `${formatPercent(page.threshold.minimumReclaimableRatio)} free or fragmented` +
+        (page.threshold.reason === 'freelist-and-fragmentation' ? '; fragmentation crossed the threshold.' : '.'),
     );
   });
 }
@@ -1539,7 +1556,17 @@ function progressMessage(progress: CodeGraphProgress): string {
 function materializationProgressMessage(
   progress: Extract<CodeGraphProgress, {readonly phase: 'materializing'}>,
 ): string {
-  const summary = `Materializing · ${progress.completed}/${progress.total} files · ${progress.reused} reused`;
+  const plan = [
+    progress.metrics?.mode === undefined ? undefined : `${progress.metrics.mode.replaceAll('-', ' ')} materialization`,
+    progress.metrics?.fallbackReason === undefined
+      ? undefined
+      : `incremental fallback: ${progress.metrics.fallbackReason.replaceAll('-', ' ')}`,
+  ]
+    .filter((value): value is string => value !== undefined)
+    .join(' · ');
+  const summary = `Materializing · ${progress.completed}/${progress.total} files · ${progress.reused} reused${
+    plan ? ` · ${plan}` : ''
+  }`;
   const diskWarning = materializationDiskWarning(progress.metrics?.storage);
   const activity = progress.activity;
   if (!activity) return diskWarning ? `${summary} · ${diskWarning}` : summary;

--- a/src/code_graph/extractor.ts
+++ b/src/code_graph/extractor.ts
@@ -236,6 +236,16 @@ function addNormalizedLookupKeys(symbol: CodeGraphSymbol): CodeGraphSymbol {
 }
 
 function globalLookupKeys(symbol: CodeGraphSymbol): readonly string[] {
+  // Generic JSON/YAML properties are lexical evidence inside their file, not
+  // cross-file resolution targets. Persisting two global lookup rows for
+  // every leaf duplicates a large structured-data tail without resolving an
+  // edge; the file module remains globally addressable.
+  if (
+    ['json', 'jsonc', 'yaml'].includes(symbol.language) &&
+    ['item', 'property', 'resource-value'].includes(symbol.kind)
+  ) {
+    return [];
+  }
   return [
     `global:qualified:${lookupComponent(symbol.qualifiedName)}`,
     `global:name:${lookupComponent(symbol.name)}`,

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -427,6 +427,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       const inventory = yield* inventoryRepository(identity, {
                         ...options,
                         cachedCommittedFileKeys,
+                        includeOpaqueCorpusAssets: ensureVectors,
                         languagePacks,
                         onContentBatch: cacheCoalescer.onContentBatch,
                       }).pipe(
@@ -664,6 +665,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                               buildOwner: reporter.ownerIdentity,
                               capacityProtection,
                               embedding,
+                              existing,
                               force: false,
                               forceGeneration,
                               fs,
@@ -1747,6 +1749,7 @@ const ensureCommittedBase = Effect.fn('codeGraph.ensureCommittedBase')(function*
   readonly buildOwner: CodeGraphBuildOwnerIdentity;
   readonly capacityProtection: DirectPersistentCapacityProtection;
   readonly embedding: CodeGraphEmbeddingIndexShape;
+  readonly existing?: CodeGraphSnapshot;
   readonly force: boolean;
   readonly forceGeneration?: string;
   readonly fs: FileSystem.FileSystem;
@@ -1843,7 +1846,7 @@ const ensureCommittedBase = Effect.fn('codeGraph.ensureCommittedBase')(function*
         activatePointer: false,
         building,
         ensureVectors: false,
-        existing: undefined,
+        existing: input.existing,
         inventory: cleanInventory,
         persistentOwnerToken: ownerToken,
       }).pipe(
@@ -1988,7 +1991,11 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
     input.incrementalAssessment ??
     (input.inventory.dirty ? yield* assessIncrementalOverlay(input, workspace) : undefined);
   let fallbackReason: CodeGraphOverlayFallbackReason | undefined =
-    incrementalAssessment?.mode === 'fallback' ? incrementalAssessment.reason : undefined;
+    incrementalAssessment?.mode === 'fallback'
+      ? incrementalAssessment.reason
+      : input.existing !== undefined && input.existing.extractorSet !== input.building.extractorSet
+        ? 'extractor-context-changed'
+        : undefined;
   let incrementalApplied = false;
   if (incrementalAssessment?.mode === 'eligible') {
     const incrementalReusedFiles = input.inventory.files.length - incrementalAssessment.files.length;
@@ -2134,9 +2141,11 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
       batchesTotal,
       cachedFactBytesCompleted,
       cachedFactBytesTotal,
+      ...(fallbackReason === undefined ? {} : {fallbackReason}),
       factsBytesCompleted,
       ...(finalFactsBytesTotal === undefined ? {} : {factsBytesTotal: finalFactsBytesTotal}),
       loadingMilliseconds,
+      mode: 'full',
       rows: materializedRows,
       sourceBytesCompleted,
       sourceBytesTotal,
@@ -2648,6 +2657,7 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
   }
   return {
     diagnostics: [
+      ...(input.inventory.diagnostics ?? []),
       ...extractionDiagnostics,
       ...(input.inventory.dirty
         ? [

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -34,7 +34,6 @@ import {
 import {
   inventoryRepository,
   worktreeBuildRequestState,
-  worktreeOverlayState,
   type CodeGraphContentBatchContext,
   type CodeGraphInventoryOptions,
 } from './inventory.js';
@@ -274,12 +273,10 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
               initialIdentity.checkoutId,
               initialIdentity.worktreeId,
             );
-            const requestedOverlay = request.force
+            const requestedOverlay = yield* worktreeBuildRequestState(initialIdentity, request.threadnoteHome);
+            const requestKey = request.force
               ? undefined
-              : yield* worktreeBuildRequestState(initialIdentity, request.threadnoteHome);
-            const requestKey = requestedOverlay
-              ? codeGraphBuildRequestKey(initialIdentity, requestedOverlay, languagePacks, request.incrementalOverlay)
-              : undefined;
+              : codeGraphBuildRequestKey(initialIdentity, requestedOverlay, languagePacks, request.incrementalOverlay);
             const reporter = yield* withCodeGraphMaintenanceRegistration(
               request.threadnoteHome,
               Effect.gen(function* () {
@@ -361,54 +358,56 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         },
                       );
                       yield* store.initialize(layout.databasePath);
-                      if (requestKey && requestedOverlay) {
+                      {
                         const currentOverlay = yield* worktreeBuildRequestState(identity, options.threadnoteHome);
                         if (!sameOverlayState(currentOverlay, requestedOverlay)) {
                           return yield* Effect.fail(new WorktreeChangedDuringIndex());
                         }
-                        const completedByOwner = yield* completedConcurrentSnapshot(
-                          store,
-                          layout,
-                          identity,
-                          currentOverlay,
-                          requestKey,
-                          options.incrementalOverlay === false,
-                        );
-                        if (completedByOwner) {
-                          yield* store.retireIncompleteWorktreeSnapshots(
-                            layout.databasePath,
-                            identity.repositoryId,
-                            identity.worktreeId,
-                            new Set(),
-                            retiredSnapshotCleanupReporter(options.onProgress),
-                            {cleanupMode: 'deferred'},
+                        if (requestKey) {
+                          const completedByOwner = yield* completedConcurrentSnapshot(
+                            store,
+                            layout,
+                            identity,
+                            currentOverlay,
+                            requestKey,
+                            options.incrementalOverlay === false,
                           );
-                          yield* promoteReadySnapshotWithCapacity(
-                            {
-                              capacityProtection,
-                              fs,
+                          if (completedByOwner) {
+                            yield* store.retireIncompleteWorktreeSnapshots(
+                              layout.databasePath,
+                              identity.repositoryId,
+                              identity.worktreeId,
+                              new Set(),
+                              retiredSnapshotCleanupReporter(options.onProgress),
+                              {cleanupMode: 'deferred'},
+                            );
+                            yield* promoteReadySnapshotWithCapacity(
+                              {
+                                capacityProtection,
+                                fs,
+                                identity,
+                                layout,
+                                onProgress: options.onProgress,
+                                store,
+                                threadnoteHome: options.threadnoteHome,
+                              },
+                              completedByOwner.id,
+                            );
+                            return yield* reuseReadySnapshot({
+                              embedding,
+                              ensureVectors,
                               identity,
                               layout,
                               onProgress: options.onProgress,
+                              reusedFiles: completedByOwner.fileCount,
+                              skippedFiles: 0,
+                              snapshot: completedByOwner,
+                              startedAt,
                               store,
                               threadnoteHome: options.threadnoteHome,
-                            },
-                            completedByOwner.id,
-                          );
-                          return yield* reuseReadySnapshot({
-                            embedding,
-                            ensureVectors,
-                            identity,
-                            layout,
-                            onProgress: options.onProgress,
-                            reusedFiles: completedByOwner.fileCount,
-                            skippedFiles: 0,
-                            snapshot: completedByOwner,
-                            startedAt,
-                            store,
-                            threadnoteHome: options.threadnoteHome,
-                            totalFiles: completedByOwner.fileCount,
-                          });
+                              totalFiles: completedByOwner.fileCount,
+                            });
+                          }
                         }
                       }
                       const cachedCommittedFileKeys = options.force
@@ -441,6 +440,13 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         Effect.tap(() => cacheCoalescer.flush()),
                         Effect.ensuring(cacheCoalescer.discard().pipe(Effect.andThen(parserPool.trimIdle()))),
                       );
+                      // Inventory and extraction build large, short-lived maps and Git payloads. Reclaim them before
+                      // the SQLite activation phase so their heap high-water does not overlap the writer page cache.
+                      yield* Effect.sync(() => {
+                        Bun.gc(true);
+                        Bun.shrink();
+                      });
+                      yield* Effect.yieldNow;
                       const extractorSet = extractorSetIdentity(inventory.files, languagePacks);
                       const graphContentId = graphContentIdentity(extractorSet, inventory.files);
                       const logicalSnapshotId = snapshotIdentity(
@@ -554,6 +560,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                           onProgress: options.onProgress,
                           persistentMaterializationTransactionBatchLimit:
                             options.persistentMaterializationTransactionBatchLimit,
+                          requestedOverlay,
                           startedAt,
                           store,
                           threadnoteHome: options.threadnoteHome,
@@ -565,8 +572,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         inventory.dirty && !options.force
                           ? yield* store.resumableBuildById(layout.databasePath, directSnapshotId)
                           : undefined;
-                      const workspace =
-                        inventory.workspace ?? (yield* languagePacks.discoverWorkspace(inventory.files));
+                      let workspace = inventory.workspace ?? (yield* languagePacks.discoverWorkspace(inventory.files));
                       let committedBase: CommittedBaseResult | undefined;
                       let incrementalAssessment: IncrementalOverlayAssessment | undefined;
                       let incrementalPrepared = false;
@@ -684,6 +690,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                               onProgress: options.onProgress,
                               persistentMaterializationTransactionBatchLimit:
                                 options.persistentMaterializationTransactionBatchLimit,
+                              requestedOverlay,
                               startedAt,
                               store,
                               threadnoteHome: options.threadnoteHome,
@@ -795,6 +802,19 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                           );
                         }
                       }
+                      if (incrementalPrepared) {
+                        // The prepared delta already contains attributed facts
+                        // and a staged workspace catalog. Retaining thousands
+                        // of project/dependency objects through activation only
+                        // makes one-file overlays overlap full-workspace memory
+                        // with SQLite's effective-graph scans.
+                        workspace = {
+                          diagnostics: workspace.diagnostics,
+                          fingerprint: workspace.fingerprint,
+                          projects: [],
+                          workspaces: [],
+                        };
+                      }
                       return yield* buildAndActivate({
                         activatePointer: true,
                         building,
@@ -816,6 +836,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         persistentMaterializationTransactionBatchLimit:
                           options.persistentMaterializationTransactionBatchLimit,
                         persistentOwnerToken,
+                        requestedOverlay,
                         startedAt,
                         store,
                         threadnoteHome: options.threadnoteHome,
@@ -1188,19 +1209,23 @@ const reuseReadySnapshot = Effect.fn('codeGraph.reuseReadySnapshot')(function* (
   yield* input.onProgress?.({phase: 'activating', snapshotId: input.snapshot.id, subphase: 'structural-ready'}) ??
     Effect.void;
   let analysisSummaryFailure: string | undefined;
-  const analysisSummaryBackfilled = yield* prepareReadyAnalysisSummary({
-    databasePath: input.layout.databasePath,
-    onProgress: input.onProgress,
-    snapshotId: input.snapshot.id,
-    store: input.store,
-  }).pipe(
-    Effect.catch(cause =>
-      Effect.sync(() => {
-        analysisSummaryFailure = messageOf(cause);
-        return false;
-      }),
-    ),
-  );
+  const analysisSummaryBackfilled = input.snapshot.dirty
+    ? yield* (
+        input.onProgress?.({phase: 'activating', snapshotId: input.snapshot.id, subphase: 'complete'}) ?? Effect.void
+      ).pipe(Effect.as(false))
+    : yield* prepareReadyAnalysisSummary({
+        databasePath: input.layout.databasePath,
+        onProgress: input.onProgress,
+        snapshotId: input.snapshot.id,
+        store: input.store,
+      }).pipe(
+        Effect.catch(cause =>
+          Effect.sync(() => {
+            analysisSummaryFailure = messageOf(cause);
+            return false;
+          }),
+        ),
+      );
   const diagnostics: string[] = analysisSummaryBackfilled
     ? ['Built the persisted whole-graph analysis summary for this reused snapshot.']
     : analysisSummaryFailure
@@ -1301,6 +1326,48 @@ function sameOverlayState(
   return left.dirty === right.dirty && (!left.dirty || left.fingerprint === right.fingerprint);
 }
 
+function sameInventoryPaths(
+  left: readonly CodeGraphInventoryFile[],
+  right: readonly CodeGraphInventoryFile[],
+): boolean {
+  return left.length === right.length && left.every((file, index) => file.path === right[index]?.path);
+}
+
+function codeGraphInventoryFileChanged(
+  base: CodeGraphInventoryFile | undefined,
+  current: CodeGraphInventoryFile,
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+  changedPackIds: ReadonlySet<string>,
+): boolean {
+  return (
+    !base ||
+    base.contentHash !== current.contentHash ||
+    base.language !== current.language ||
+    base.mode !== current.mode ||
+    base.size !== current.size ||
+    base.source !== current.source ||
+    Option.match(languagePacks.match(current.path), {
+      onNone: () => false,
+      onSome: match => changedPackIds.has(match.pack.id),
+    })
+  );
+}
+
+function inventoryFilesForPaths(
+  files: readonly CodeGraphInventoryFile[],
+  paths: readonly string[],
+): readonly CodeGraphInventoryFile[] | undefined {
+  const selected: CodeGraphInventoryFile[] = [];
+  let fileIndex = 0;
+  for (const path of paths) {
+    while (fileIndex < files.length && compareCodeUnits(files[fileIndex]!.path, path) < 0) fileIndex += 1;
+    const file = files[fileIndex];
+    if (!file || file.path !== path) return undefined;
+    selected.push(file);
+  }
+  return selected;
+}
+
 const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(function* (input: {
   readonly buildOwner: CodeGraphBuildOwnerIdentity;
   readonly capacityProtection: DirectPersistentCapacityProtection;
@@ -1317,6 +1384,7 @@ const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(f
   readonly logicalSnapshotId: string;
   readonly onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void, unknown>;
   readonly persistentMaterializationTransactionBatchLimit?: 1 | 4;
+  readonly requestedOverlay?: {readonly dirty: boolean; readonly fingerprint?: string};
   readonly startedAt: number;
   readonly store: CodeGraphStoreShape;
   readonly threadnoteHome: string;
@@ -1439,6 +1507,7 @@ const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(f
         onProgress: input.onProgress,
         persistentMaterializationTransactionBatchLimit: input.persistentMaterializationTransactionBatchLimit,
         persistentOwnerToken: ownerToken,
+        requestedOverlay: input.requestedOverlay,
         startedAt: input.startedAt,
         store: input.store,
         threadnoteHome: input.threadnoteHome,
@@ -1469,6 +1538,7 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
     readonly logicalSnapshotId: string;
     readonly onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void, unknown>;
     readonly persistentMaterializationTransactionBatchLimit?: 1 | 4;
+    readonly requestedOverlay?: {readonly dirty: boolean; readonly fingerprint?: string};
     readonly startedAt: number;
     readonly store: CodeGraphStoreShape;
     readonly threadnoteHome: string;
@@ -1558,16 +1628,16 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
             symbolCount: candidate.snapshot.symbolCount,
             worktreeId: input.identity.worktreeId,
           };
-          yield* verifyIndexInput(input.identity, input.inventory, true);
+          yield* verifyIndexInput(input.identity, true, input.threadnoteHome, input.requestedOverlay);
           yield* input.store.activateCleanSnapshotAlias!(
             input.layout.databasePath,
             input.identity,
             alias,
             candidate.snapshot.id,
           );
-          yield* verifyIndexInput(input.identity, input.inventory, true);
+          yield* verifyIndexInput(input.identity, true, input.threadnoteHome, input.requestedOverlay);
           yield* promoteReadySnapshotWithCapacity(input, alias.id);
-          yield* verifyIndexInput(input.identity, input.inventory, true);
+          yield* verifyIndexInput(input.identity, true, input.threadnoteHome, input.requestedOverlay);
           return Option.some<ReusableCleanSnapshotAttempt>({
             mode: 'complete',
             summary: yield* reuseReadySnapshot({
@@ -1680,6 +1750,7 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
           layout: input.layout,
           onProgress: input.onProgress,
           persistentMaterializationTransactionBatchLimit: input.persistentMaterializationTransactionBatchLimit,
+          requestedOverlay: input.requestedOverlay,
           startedAt: input.startedAt,
           store: input.store,
           threadnoteHome: input.threadnoteHome,
@@ -1715,20 +1786,55 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
       readonly preassessment: Extract<IncrementalOverlayPreassessment, {readonly mode: 'compatible'}>;
     }>();
   }
-  const preferredCommitGroups = yield* preferredIncrementalBaseCommitGroups(
-    input.identity.repoRoot,
-    input.identity.headCommit,
+  // Prefer the exact committed snapshot path below when it is already ready.
+  // Loading the generic reusable-base receipt also hydrates its full file set;
+  // doing that for a one-file dirty overlay duplicates the inventory solely to
+  // rediscover the same HEAD snapshot.
+  const committedExtractorSet = extractorSetIdentity(input.inventory.committedFiles, input.languagePacks);
+  const exactCommittedSnapshotId = snapshotIdentity(
+    input.identity,
+    false,
+    committedExtractorSet,
+    input.inventory.committedFiles,
   );
-  const candidate = yield* input.store.reusableCleanBase(
+  if (yield* input.store.currentLexicalReadySnapshotById(input.layout.databasePath, exactCommittedSnapshotId)) {
+    return Option.none();
+  }
+  const committedFileSetFingerprint = reusableBaseFileSetFingerprint(input.inventory.committedFiles);
+  const committedGraphContentId = graphContentIdentity(committedExtractorSet, input.inventory.committedFiles);
+  const commitReady = yield* input.store.readySnapshotForCommit(
     input.layout.databasePath,
     input.identity.repositoryId,
-    input.extractorSet,
-    workspace.fingerprint,
-    reusableBaseFileSetFingerprint(input.inventory.files),
-    graphContentIdentity(input.extractorSet, input.inventory.files),
-    preferredCommitGroups,
-    true,
+    input.identity.headCommit,
+    committedExtractorSet,
   );
+  const commitReceipt = commitReady
+    ? yield* input.store.reusableBaseReceipt(input.layout.databasePath, commitReady.id)
+    : undefined;
+  let candidate: CodeGraphReusableCleanBase | undefined =
+    commitReady &&
+    commitReceipt &&
+    commitReady.graphContentId === committedGraphContentId &&
+    commitReceipt.fileSetFingerprint === committedFileSetFingerprint &&
+    commitReceipt.workspaceFingerprint === workspace.fingerprint
+      ? {files: input.inventory.committedFiles, receipt: commitReceipt, snapshot: commitReady}
+      : undefined;
+  if (!candidate) {
+    const preferredCommitGroups = yield* preferredIncrementalBaseCommitGroups(
+      input.identity.repoRoot,
+      input.identity.headCommit,
+    );
+    candidate = yield* input.store.reusableCleanBase(
+      input.layout.databasePath,
+      input.identity.repositoryId,
+      input.extractorSet,
+      workspace.fingerprint,
+      reusableBaseFileSetFingerprint(input.inventory.files),
+      graphContentIdentity(input.extractorSet, input.inventory.files),
+      preferredCommitGroups,
+      true,
+    );
+  }
   if (!candidate) return Option.none();
   const lease = yield* input.store
     .acquireSnapshotLease(input.layout.databasePath, candidate.snapshot.id, CODE_GRAPH_ACTIVATION_LEASE_MILLISECONDS)
@@ -1737,8 +1843,6 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
   const leaseToken = yield* Effect.acquireRelease(Effect.succeed(lease.value), token =>
     input.store.releaseSnapshotLease(input.layout.databasePath, token).pipe(Effect.catch(() => Effect.void)),
   );
-  const baseByPath = new Map(candidate.files.map(file => [file.path, file]));
-  const currentPaths = new Set(input.inventory.files.map(file => file.path));
   const packDelta =
     candidate.snapshot.extractorSet === input.extractorSet
       ? ({changedPackIds: [], mode: 'compatible'} as const)
@@ -1754,22 +1858,16 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
     return Option.none();
   }
   const changedPackIds = new Set(packDelta.changedPackIds);
-  const modifiedFiles = input.inventory.files.filter(file => {
-    const base = baseByPath.get(file.path);
-    return (
-      !base ||
-      base.contentHash !== file.contentHash ||
-      base.language !== file.language ||
-      base.mode !== file.mode ||
-      base.size !== file.size ||
-      base.source !== file.source ||
-      Option.match(input.languagePacks.match(file.path), {
-        onNone: () => false,
-        onSome: match => changedPackIds.has(match.pack.id),
-      })
-    );
+  const alignedCommitCandidate = sameInventoryPaths(candidate.files, input.inventory.files);
+  const baseByPath = alignedCommitCandidate ? undefined : new Map(candidate.files.map(file => [file.path, file]));
+  const currentPaths = alignedCommitCandidate ? undefined : new Set(input.inventory.files.map(file => file.path));
+  const modifiedFiles = input.inventory.files.filter((file, index) => {
+    const base = alignedCommitCandidate ? candidate.files[index] : baseByPath!.get(file.path);
+    return codeGraphInventoryFileChanged(base, file, input.languagePacks, changedPackIds);
   });
-  const deletedPaths = candidate.files.filter(file => !currentPaths.has(file.path)).map(file => file.path);
+  const deletedPaths = alignedCommitCandidate
+    ? []
+    : candidate.files.filter(file => !currentPaths!.has(file.path)).map(file => file.path);
   if (modifiedFiles.length === 0 && deletedPaths.length === 0) return Option.none();
   const assessmentInput = {
     candidate,
@@ -1779,7 +1877,8 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
     persistentCapacityProtector: input.persistentCapacityProtector,
     store: input.store,
   };
-  const sameFileSet = deletedPaths.length === 0 && modifiedFiles.every(file => baseByPath.has(file.path));
+  const sameFileSet =
+    alignedCommitCandidate || (deletedPaths.length === 0 && modifiedFiles.every(file => baseByPath!.has(file.path)));
   const boundedAssessment = sameFileSet
     ? yield* assessReusableCleanBaseCompatibility(assessmentInput, workspace, modifiedFiles)
     : ({mode: 'fallback', reason: 'file-set-changed'} as const);
@@ -1812,6 +1911,7 @@ const ensureCommittedBase = Effect.fn('codeGraph.ensureCommittedBase')(function*
   readonly layout: CodeGraphLayout;
   readonly onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void, unknown>;
   readonly persistentMaterializationTransactionBatchLimit?: 1 | 4;
+  readonly requestedOverlay?: {readonly dirty: boolean; readonly fingerprint?: string};
   readonly startedAt: number;
   readonly store: CodeGraphStoreShape;
   readonly threadnoteHome: string;
@@ -2021,6 +2121,7 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
   readonly onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void, unknown>;
   readonly persistentMaterializationTransactionBatchLimit?: 1 | 4;
   readonly persistentOwnerToken?: string;
+  readonly requestedOverlay?: {readonly dirty: boolean; readonly fingerprint?: string};
   readonly startedAt: number;
   readonly store: CodeGraphStoreShape;
   readonly threadnoteHome: string;
@@ -2033,12 +2134,6 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
   const directPersistentMaterialization = input.persistentOwnerToken !== undefined;
   const protectDirectPersistentWrite = codeGraphDirectPersistentCapacityProtector(input);
   const persistentCapacityGuard = protectDirectPersistentWrite;
-  const attributeFacts = createCachedCodeGraphFactsAttributor(input.inventory.files, workspace);
-  const shardDerivationIdentity = materializedShardDerivationIdentity(
-    input.building.extractorSet,
-    workspace.fingerprint,
-    graphContentIdentity(input.building.extractorSet, input.inventory.files),
-  );
   const extractionDiagnostics: string[] = [...workspace.diagnostics];
   let materializedFiles = 0;
   let materializedShardFilesReused = 0;
@@ -2109,6 +2204,12 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
     }
   }
   if (!incrementalApplied) {
+    const attributeFacts = createCachedCodeGraphFactsAttributor(input.inventory.files, workspace);
+    const shardDerivationIdentity = materializedShardDerivationIdentity(
+      input.building.extractorSet,
+      workspace.fingerprint,
+      graphContentIdentity(input.building.extractorSet, input.inventory.files),
+    );
     const sourceBytesTotal = input.inventory.files.reduce((total, file) => total + file.size, 0);
     const cachedMetadata = yield* cachedFactsMetadata(
       input.store,
@@ -2573,6 +2674,13 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
       unit: 'files',
     }) ?? Effect.void;
   }
+  const reusableBaseReceipt = input.building.dirty
+    ? undefined
+    : {
+        fileSetFingerprint: reusableBaseFileSetFingerprint(input.inventory.files),
+        packProvenance: input.languagePacks.activePackProvenance(input.inventory.files.map(file => file.path)),
+        workspaceFingerprint: workspace.fingerprint,
+      };
   yield* input.onProgress?.({phase: 'resolving', subphase: 'references'}) ?? Effect.void;
   const resolution = yield* input.store.resolveStagedReferences(
     input.layout.databasePath,
@@ -2597,6 +2705,7 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
     subphase: 'complete',
     symbols: stagedCounts.symbols,
   }) ?? Effect.void;
+  yield* input.store.shrinkMemory(input.layout.databasePath);
 
   const ready: CodeGraphSnapshot = {
     ...input.building,
@@ -2606,7 +2715,7 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
     symbolCount: stagedCounts.symbols,
   };
   yield* input.onProgress?.({phase: 'activating', snapshotId: ready.id, subphase: 'validating-input'}) ?? Effect.void;
-  yield* verifyIndexInput(input.identity, input.inventory, input.activatePointer);
+  yield* verifyIndexInput(input.identity, input.activatePointer, input.threadnoteHome, input.requestedOverlay);
   yield* input.onProgress?.({
     phase: 'activating',
     snapshotId: ready.id,
@@ -2618,13 +2727,7 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
         input.layout.databasePath,
         input.identity,
         ready,
-        !ready.dirty
-          ? {
-              fileSetFingerprint: reusableBaseFileSetFingerprint(input.inventory.files),
-              packProvenance: input.languagePacks.activePackProvenance(input.inventory.files.map(file => file.path)),
-              workspaceFingerprint: workspace.fingerprint,
-            }
-          : undefined,
+        reusableBaseReceipt,
         CODE_GRAPH_ACTIVATION_LEASE_MILLISECONDS,
         activity =>
           (
@@ -2647,17 +2750,18 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
     if (!activated) {
       return yield* Effect.fail(new Error('Activated code graph snapshot could not be read back from its store.'));
     }
-    yield* verifyIndexInput(input.identity, input.inventory, input.activatePointer);
+    yield* input.store.shrinkMemory(input.layout.databasePath);
     if (input.activatePointer) {
       yield* input.onProgress?.({phase: 'activating', snapshotId: activated.id, subphase: 'promoting'}) ?? Effect.void;
       // Progress callbacks are user-controlled effects and may yield long enough for
       // the worktree to change. Revalidate on both sides of pointer promotion so a
       // mutation observed in this window triggers the bounded retry.
-      yield* verifyIndexInput(input.identity, input.inventory, input.activatePointer);
+      yield* verifyIndexInput(input.identity, input.activatePointer, input.threadnoteHome, input.requestedOverlay);
       yield* input.store.promote(input.layout.databasePath, input.identity, activated.id, {
         persistentCapacityProtector: protectDirectPersistentWrite,
       });
-      yield* verifyIndexInput(input.identity, input.inventory, input.activatePointer);
+      yield* input.store.shrinkMemory(input.layout.databasePath);
+      yield* verifyIndexInput(input.identity, input.activatePointer, input.threadnoteHome, input.requestedOverlay);
       if (Option.isSome(activationLease)) {
         yield* input.store.releaseSnapshotLease(input.layout.databasePath, activationLease.value);
       }
@@ -2673,21 +2777,28 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
     return activated;
   });
   let analysisSummaryFailure: string | undefined;
-  const analysisSummaryBackfilled = input.activatePointer
-    ? yield* prepareReadyAnalysisSummary({
-        databasePath: input.layout.databasePath,
-        onProgress: input.onProgress,
-        snapshotId: activatedReady.id,
-        store: input.store,
-      }).pipe(
-        Effect.catch(cause =>
-          Effect.sync(() => {
-            analysisSummaryFailure = messageOf(cause);
-            return false;
-          }),
-        ),
-      )
-    : false;
+  const analysisSummaryBackfilled =
+    input.activatePointer && !activatedReady.dirty
+      ? yield* prepareReadyAnalysisSummary({
+          databasePath: input.layout.databasePath,
+          onProgress: input.onProgress,
+          snapshotId: activatedReady.id,
+          store: input.store,
+        }).pipe(
+          Effect.catch(cause =>
+            Effect.sync(() => {
+              analysisSummaryFailure = messageOf(cause);
+              return false;
+            }),
+          ),
+        )
+      : yield* (
+          input.onProgress?.({
+            phase: 'activating',
+            snapshotId: activatedReady.id,
+            subphase: 'complete',
+          }) ?? Effect.void
+        ).pipe(Effect.as(false));
   const embedding = input.ensureVectors
     ? yield* input.embedding
         .ensure(
@@ -3013,8 +3124,13 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
   if (modifiedFiles.length === 0) {
     return {mode: 'fallback', reason: 'no-materialized-changes'} satisfies IncrementalOverlayPreassessment;
   }
-  const baseByPath = new Map(input.candidate.files.map(file => [file.path, file]));
-  const baseFiles = modifiedFiles.map(file => baseByPath.get(file.path)!);
+  const baseFiles = inventoryFilesForPaths(
+    input.candidate.files,
+    modifiedFiles.map(file => file.path),
+  );
+  if (!baseFiles) {
+    return {mode: 'fallback', reason: 'file-set-changed'} satisfies IncrementalOverlayPreassessment;
+  }
   const changedDecodeBudget = extractorTransition
     ? projectClosureSourceBudgetFits(baseFiles) && projectClosureSourceBudgetFits(modifiedFiles)
       ? ({mode: 'eligible'} as const)
@@ -4059,10 +4175,31 @@ function degradedParserCacheIdentity(activeIdentity: string): string {
   return sha256HexSync(`code-graph-parser-degraded-v1\n${activeIdentity}`);
 }
 
+/** Cache generations that can satisfy inventory content admission for active parser packs. */
+export function codeGraphParserCacheLookupGenerations(activeIdentities: readonly string[]): readonly {
+  readonly activeIdentity: string;
+  readonly storedIdentity: string;
+}[] {
+  return [...new Set(activeIdentities)].sort(compareCodeUnits).flatMap(activeIdentity => [
+    {activeIdentity, storedIdentity: activeIdentity},
+    {activeIdentity, storedIdentity: degradedParserCacheIdentity(activeIdentity)},
+  ]);
+}
+
+/** Rebind a physical cache-generation key to the active identity expected by inventory admission. */
+export function codeGraphActiveParserCacheKey(key: string, storedIdentity: string, activeIdentity: string): string {
+  if (storedIdentity === activeIdentity) return key;
+  const terminalGeneration = `\0${storedIdentity}`;
+  if (key.endsWith(terminalGeneration)) return `${key.slice(0, -terminalGeneration.length)}\0${activeIdentity}`;
+  const embeddedGeneration = `\0${storedIdentity}\0`;
+  return key.includes(embeddedGeneration) ? key.replace(embeddedGeneration, () => `\0${activeIdentity}\0`) : key;
+}
+
 const verifyIndexInput = Effect.fn('codeGraph.verifyIndexInput')(function* (
   identity: RepositoryIdentity,
-  inventory: CodeGraphInventory,
   verifyOverlay: boolean,
+  threadnoteHome: string,
+  requestedOverlay?: {readonly dirty: boolean; readonly fingerprint?: string},
 ) {
   const verifiedIdentity = yield* resolveRepositoryIdentity(identity.repoRoot);
   if (
@@ -4072,8 +4209,11 @@ const verifyIndexInput = Effect.fn('codeGraph.verifyIndexInput')(function* (
     return yield* Effect.fail(new WorktreeChangedDuringIndex());
   }
   if (!verifyOverlay) return;
-  const verifiedOverlay = yield* worktreeOverlayState(verifiedIdentity);
-  if (verifiedOverlay.dirty !== inventory.dirty || verifiedOverlay.fingerprint !== inventory.overlayFingerprint) {
+  if (!requestedOverlay) {
+    return yield* Effect.fail(new Error('Pointer activation requires an exact worktree build request state.'));
+  }
+  const verifiedOverlay = yield* worktreeBuildRequestState(verifiedIdentity, threadnoteHome);
+  if (!sameOverlayState(verifiedOverlay, requestedOverlay)) {
     return yield* Effect.fail(new WorktreeChangedDuringIndex());
   }
 });
@@ -4750,8 +4890,20 @@ function cachedFileKeys(
   languagePacks: CodeGraphLanguagePackRegistryShape,
 ): Effect.Effect<ReadonlySet<string>, unknown> {
   return Effect.forEach(
-    languagePacks.cacheIdentities,
-    identity => store.cachedCommittedFileKeys(databasePath, identity),
+    codeGraphParserCacheLookupGenerations(languagePacks.cacheIdentities),
+    generation =>
+      store
+        .cachedCommittedFileKeys(databasePath, generation.storedIdentity)
+        .pipe(
+          Effect.map(
+            keys =>
+              new Set(
+                [...keys].map(key =>
+                  codeGraphActiveParserCacheKey(key, generation.storedIdentity, generation.activeIdentity),
+                ),
+              ),
+          ),
+        ),
     {concurrency: 1},
   ).pipe(Effect.map(sets => new Set(sets.flatMap(set => [...set]))));
 }

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -1786,10 +1786,9 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
       readonly preassessment: Extract<IncrementalOverlayPreassessment, {readonly mode: 'compatible'}>;
     }>();
   }
-  // Prefer the exact committed snapshot path below when it is already ready.
-  // Loading the generic reusable-base receipt also hydrates its full file set;
-  // doing that for a one-file dirty overlay duplicates the inventory solely to
-  // rediscover the same HEAD snapshot.
+  // Prefer the exact committed snapshot path below when it is itself a root
+  // reusable base. A clean incremental snapshot is already layered, so another
+  // overlay must instead reuse its root and include the cumulative changed set.
   const committedExtractorSet = extractorSetIdentity(input.inventory.committedFiles, input.languagePacks);
   const exactCommittedSnapshotId = snapshotIdentity(
     input.identity,
@@ -1797,7 +1796,11 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
     committedExtractorSet,
     input.inventory.committedFiles,
   );
-  if (yield* input.store.currentLexicalReadySnapshotById(input.layout.databasePath, exactCommittedSnapshotId)) {
+  const exactCommittedSnapshot = yield* input.store.currentLexicalReadySnapshotById(
+    input.layout.databasePath,
+    exactCommittedSnapshotId,
+  );
+  if (exactCommittedSnapshot && exactCommittedSnapshot.baseSnapshotId === undefined) {
     return Option.none();
   }
   const committedFileSetFingerprint = reusableBaseFileSetFingerprint(input.inventory.committedFiles);

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -33,6 +33,7 @@ import {
 } from './incremental_work.js';
 import {
   inventoryRepository,
+  worktreeBuildRequestState,
   worktreeOverlayState,
   type CodeGraphContentBatchContext,
   type CodeGraphInventoryOptions,
@@ -43,6 +44,7 @@ import {
   packDerivationIdentity,
   type CodeGraphLanguagePackRegistryShape,
 } from './languages/registry.js';
+import {assessCodeGraphLanguagePackDelta} from './languages/provenance.js';
 import {
   codeGraphDiskReservationLockPath,
   codeGraphDiskReservationRoot,
@@ -81,6 +83,7 @@ import {
   type CodeGraphRetiredSnapshotCleanupProgress,
   type CodeGraphDirectPersistentCapacityProtector,
   type CodeGraphReusableCleanBase,
+  type CodeGraphLanguagePackProvenance,
   type CodeGraphReusableReexport,
   type CodeGraphReusableReexportSeed,
   type CodeGraphStagingProgress,
@@ -191,6 +194,7 @@ type IncrementalOverlayAssessment =
       readonly mode: 'eligible';
       readonly deletedPaths?: readonly string[];
       readonly resolutionClosure?: 'changed' | 'full' | 'project';
+      readonly extractorTransition?: true;
       readonly reuse: 'persisted-base' | 'staged-base';
       readonly work: CodeGraphIncrementalWork;
     }
@@ -208,6 +212,7 @@ type IncrementalOverlayPreassessment =
       readonly mode: 'compatible';
       readonly deletedPaths?: readonly string[];
       readonly resolutionClosure?: 'changed' | 'full' | 'project';
+      readonly extractorTransition?: true;
     }
   | {
       readonly mode: 'fallback';
@@ -269,7 +274,9 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
               initialIdentity.checkoutId,
               initialIdentity.worktreeId,
             );
-            const requestedOverlay = request.force ? undefined : yield* worktreeOverlayState(initialIdentity);
+            const requestedOverlay = request.force
+              ? undefined
+              : yield* worktreeBuildRequestState(initialIdentity, request.threadnoteHome);
             const requestKey = requestedOverlay
               ? codeGraphBuildRequestKey(initialIdentity, requestedOverlay, languagePacks, request.incrementalOverlay)
               : undefined;
@@ -355,7 +362,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       );
                       yield* store.initialize(layout.databasePath);
                       if (requestKey && requestedOverlay) {
-                        const currentOverlay = yield* worktreeOverlayState(identity);
+                        const currentOverlay = yield* worktreeBuildRequestState(identity, options.threadnoteHome);
                         if (!sameOverlayState(currentOverlay, requestedOverlay)) {
                           return yield* Effect.fail(new WorktreeChangedDuringIndex());
                         }
@@ -558,7 +565,8 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         inventory.dirty && !options.force
                           ? yield* store.resumableBuildById(layout.databasePath, directSnapshotId)
                           : undefined;
-                      const workspace = yield* languagePacks.discoverWorkspace(inventory.files);
+                      const workspace =
+                        inventory.workspace ?? (yield* languagePacks.discoverWorkspace(inventory.files));
                       let committedBase: CommittedBaseResult | undefined;
                       let incrementalAssessment: IncrementalOverlayAssessment | undefined;
                       let incrementalPrepared = false;
@@ -1132,7 +1140,6 @@ const completedConcurrentSnapshot = Effect.fn('codeGraph.completedConcurrentSnap
     !ready ||
     ready.commit !== identity.headCommit ||
     ready.dirty !== overlay.dirty ||
-    (overlay.dirty && ready.overlayFingerprint !== overlay.fingerprint) ||
     (overlay.dirty && requireDirectFull && (ready.baseSnapshotId !== undefined || !ready.id.endsWith('-direct')))
   ) {
     return undefined;
@@ -1384,7 +1391,8 @@ const buildOwnedCleanSnapshot = Effect.fn('codeGraph.buildOwnedCleanSnapshot')(f
             totalFiles: input.inventory.files.length,
           });
         }
-        const workspace = yield* input.languagePacks.discoverWorkspace(input.inventory.files);
+        const workspace =
+          input.inventory.workspace ?? (yield* input.languagePacks.discoverWorkspace(input.inventory.files));
         const reused = yield* attemptReusableCleanSnapshot(input, workspace);
         if (Option.isSome(reused)) {
           if (reused.value.mode === 'complete') return reused.value.summary;
@@ -1483,6 +1491,7 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
     reusableBaseFileSetFingerprint(input.inventory.files),
     graphContentIdentity(extractorSet, input.inventory.files),
     preferredCommitGroups,
+    true,
   );
   if (!candidate || candidate.snapshot.id === input.logicalSnapshotId)
     return Option.none<ReusableCleanSnapshotAttempt>();
@@ -1498,6 +1507,22 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
     Effect.succeed(lease.value),
     () =>
       Effect.gen(function* () {
+        const packDelta =
+          candidate.snapshot.extractorSet === extractorSet
+            ? ({changedPackIds: [], mode: 'compatible'} as const)
+            : assessCodeGraphLanguagePackDelta(
+                candidate.receipt.packProvenance,
+                input.languagePacks.activePackProvenance(input.inventory.files.map(file => file.path)),
+              );
+        if (
+          packDelta.mode === 'fallback' ||
+          (candidate.snapshot.extractorSet !== extractorSet &&
+            candidate.snapshot.extractorSet !==
+              extractorSetIdentityFromPackProvenance(candidate.receipt.packProvenance))
+        ) {
+          return Option.some<ReusableCleanSnapshotAttempt>({mode: 'fallback', reason: 'extractor-context-changed'});
+        }
+        const changedPackIds = new Set(packDelta.changedPackIds);
         const modifiedFiles = input.inventory.files.filter(file => {
           const base = baseByPath.get(file.path);
           return (
@@ -1505,12 +1530,20 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
             base.contentHash !== file.contentHash ||
             base.language !== file.language ||
             base.mode !== file.mode ||
-            base.size !== file.size
+            base.size !== file.size ||
+            Option.match(input.languagePacks.match(file.path), {
+              onNone: () => false,
+              onSome: match => changedPackIds.has(match.pack.id),
+            })
           );
         });
         const currentPaths = new Set(input.inventory.files.map(file => file.path));
         const deletedPaths = candidate.files.filter(file => !currentPaths.has(file.path)).map(file => file.path);
-        if (modifiedFiles.length === 0 && deletedPaths.length === 0) {
+        if (
+          modifiedFiles.length === 0 &&
+          deletedPaths.length === 0 &&
+          candidate.snapshot.extractorSet === extractorSet
+        ) {
           const alias: CodeGraphSnapshot = {
             baseSnapshotId: candidate.snapshot.id,
             commit: input.identity.headCommit,
@@ -1694,6 +1727,7 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
     reusableBaseFileSetFingerprint(input.inventory.files),
     graphContentIdentity(input.extractorSet, input.inventory.files),
     preferredCommitGroups,
+    true,
   );
   if (!candidate) return Option.none();
   const lease = yield* input.store
@@ -1705,6 +1739,21 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
   );
   const baseByPath = new Map(candidate.files.map(file => [file.path, file]));
   const currentPaths = new Set(input.inventory.files.map(file => file.path));
+  const packDelta =
+    candidate.snapshot.extractorSet === input.extractorSet
+      ? ({changedPackIds: [], mode: 'compatible'} as const)
+      : assessCodeGraphLanguagePackDelta(
+          candidate.receipt.packProvenance,
+          input.languagePacks.activePackProvenance(input.inventory.files.map(file => file.path)),
+        );
+  if (
+    packDelta.mode === 'fallback' ||
+    (candidate.snapshot.extractorSet !== input.extractorSet &&
+      candidate.snapshot.extractorSet !== extractorSetIdentityFromPackProvenance(candidate.receipt.packProvenance))
+  ) {
+    return Option.none();
+  }
+  const changedPackIds = new Set(packDelta.changedPackIds);
   const modifiedFiles = input.inventory.files.filter(file => {
     const base = baseByPath.get(file.path);
     return (
@@ -1713,7 +1762,11 @@ const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirtyBase')
       base.language !== file.language ||
       base.mode !== file.mode ||
       base.size !== file.size ||
-      base.source !== file.source
+      base.source !== file.source ||
+      Option.match(input.languagePacks.match(file.path), {
+        onNone: () => false,
+        onSome: match => changedPackIds.has(match.pack.id),
+      })
     );
   });
   const deletedPaths = candidate.files.filter(file => !currentPaths.has(file.path)).map(file => file.path);
@@ -1973,7 +2026,10 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
   readonly threadnoteHome: string;
   readonly workspace?: CodeGraphWorkspace;
 }) {
-  const workspace = input.workspace ?? (yield* input.languagePacks.discoverWorkspace(input.inventory.files));
+  const workspace =
+    input.workspace ??
+    input.inventory.workspace ??
+    (yield* input.languagePacks.discoverWorkspace(input.inventory.files));
   const directPersistentMaterialization = input.persistentOwnerToken !== undefined;
   const protectDirectPersistentWrite = codeGraphDirectPersistentCapacityProtector(input);
   const persistentCapacityGuard = protectDirectPersistentWrite;
@@ -1993,7 +2049,9 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
   let fallbackReason: CodeGraphOverlayFallbackReason | undefined =
     incrementalAssessment?.mode === 'fallback'
       ? incrementalAssessment.reason
-      : input.existing !== undefined && input.existing.extractorSet !== input.building.extractorSet
+      : input.existing !== undefined &&
+          input.existing.extractorSet !== input.building.extractorSet &&
+          incrementalAssessment?.mode !== 'eligible'
         ? 'extractor-context-changed'
         : undefined;
   let incrementalApplied = false;
@@ -2563,6 +2621,7 @@ const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function* (inpu
         !ready.dirty
           ? {
               fileSetFingerprint: reusableBaseFileSetFingerprint(input.inventory.files),
+              packProvenance: input.languagePacks.activePackProvenance(input.inventory.files.map(file => file.path)),
               workspaceFingerprint: workspace.fingerprint,
             }
           : undefined,
@@ -2739,7 +2798,10 @@ const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOverlay')
   if (preassessment.mode === 'fallback') return preassessment;
   if (!input.committedBase)
     return {mode: 'fallback', reason: 'staging-unavailable'} satisfies IncrementalOverlayAssessment;
-  if (input.building.extractorSet !== input.committedBase.snapshot.extractorSet) {
+  if (
+    input.building.extractorSet !== input.committedBase.snapshot.extractorSet &&
+    preassessment.extractorTransition !== true
+  ) {
     return {mode: 'fallback', reason: 'extractor-context-changed'} satisfies IncrementalOverlayAssessment;
   }
   let reuse: 'persisted-base' | 'staged-base' = 'staged-base';
@@ -2828,7 +2890,8 @@ const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assessIncreme
   if (input.extractorSet !== extractorSetIdentity(input.inventory.committedFiles, input.languagePacks)) {
     return {mode: 'fallback', reason: 'extractor-context-changed'} satisfies IncrementalOverlayPreassessment;
   }
-  const committedWorkspace = yield* input.languagePacks.discoverWorkspace(input.inventory.committedFiles);
+  const committedWorkspace =
+    input.inventory.workspace ?? (yield* input.languagePacks.discoverWorkspace(input.inventory.committedFiles));
   const committedByPath = new Map(input.inventory.committedFiles.map(file => [file.path, file]));
   const effectiveByPath = new Map(input.inventory.files.map(file => [file.path, file]));
   if (
@@ -2928,7 +2991,20 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
   workspace: CodeGraphWorkspace,
   modifiedFiles: readonly CodeGraphInventoryFile[],
 ) {
-  if (input.candidate.snapshot.extractorSet !== extractorSetIdentity(input.inventory.files, input.languagePacks)) {
+  const currentExtractorSet = extractorSetIdentity(input.inventory.files, input.languagePacks);
+  const extractorTransition = input.candidate.snapshot.extractorSet !== currentExtractorSet;
+  const packDelta = extractorTransition
+    ? assessCodeGraphLanguagePackDelta(
+        input.candidate.receipt.packProvenance,
+        input.languagePacks.activePackProvenance(input.inventory.files.map(file => file.path)),
+      )
+    : ({changedPackIds: [], mode: 'compatible'} as const);
+  if (
+    packDelta.mode === 'fallback' ||
+    (extractorTransition &&
+      input.candidate.snapshot.extractorSet !==
+        extractorSetIdentityFromPackProvenance(input.candidate.receipt.packProvenance))
+  ) {
     return {mode: 'fallback', reason: 'extractor-context-changed'} satisfies IncrementalOverlayPreassessment;
   }
   if (input.candidate.receipt.workspaceFingerprint !== workspace.fingerprint) {
@@ -2939,17 +3015,29 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
   }
   const baseByPath = new Map(input.candidate.files.map(file => [file.path, file]));
   const baseFiles = modifiedFiles.map(file => baseByPath.get(file.path)!);
-  const changedDecodeBudget = yield* assessProjectClosureChangedDecodeBudget({
-    baseFiles,
-    currentFiles: modifiedFiles,
-    databasePath: input.layout.databasePath,
-    languagePacks: input.languagePacks,
-    store: input.store,
-  });
+  const changedDecodeBudget = extractorTransition
+    ? projectClosureSourceBudgetFits(baseFiles) && projectClosureSourceBudgetFits(modifiedFiles)
+      ? ({mode: 'eligible'} as const)
+      : ({mode: 'fallback', reason: 'project-closure-unbounded'} as const)
+    : yield* assessProjectClosureChangedDecodeBudget({
+        baseFiles,
+        currentFiles: modifiedFiles,
+        databasePath: input.layout.databasePath,
+        languagePacks: input.languagePacks,
+        store: input.store,
+      });
   if (changedDecodeBudget.mode === 'fallback') return changedDecodeBudget;
   const [baseCache, currentCache] = yield* Effect.all(
     [
-      loadCachedFacts(input.store, input.layout.databasePath, baseFiles, input.languagePacks),
+      extractorTransition
+        ? loadCachedFactsWithPackProvenance(
+            input.store,
+            input.layout.databasePath,
+            baseFiles,
+            input.languagePacks,
+            input.candidate.receipt.packProvenance,
+          )
+        : loadCachedFacts(input.store, input.layout.databasePath, baseFiles, input.languagePacks),
       loadCachedFacts(input.store, input.layout.databasePath, modifiedFiles, input.languagePacks),
     ],
     {concurrency: 1},
@@ -2959,6 +3047,13 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
     modifiedFiles.some(file => !currentCache.facts.has(file.path))
   ) {
     return {mode: 'fallback', reason: 'cache-incomplete'} satisfies IncrementalOverlayPreassessment;
+  }
+  if (
+    extractorTransition &&
+    (baseCache.bytes > PROJECT_INCREMENTAL_CLOSURE_MAX_CACHED_FACT_BYTES ||
+      currentCache.bytes > PROJECT_INCREMENTAL_CLOSURE_MAX_CACHED_FACT_BYTES)
+  ) {
+    return {mode: 'fallback', reason: 'project-closure-unbounded'} satisfies IncrementalOverlayPreassessment;
   }
   const baseRawFacts = baseFiles.map(file =>
     input.languagePacks.postprocessFile(file, baseCache.facts.get(file.path)!),
@@ -2975,7 +3070,7 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
   });
   const dynamicAliases = hasDynamicAliases(baseFacts) || hasDynamicAliases(currentFacts);
   if (dynamicAliases || resolutionSurfaceChanged) {
-    return yield* assessProjectIncrementalClosureCompatibility({
+    const closure = yield* assessProjectIncrementalClosureCompatibility({
       baseWorkspace: workspace,
       changedBaseFacts: baseFacts,
       changedCurrentFacts: currentFacts,
@@ -2987,6 +3082,9 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
       store: input.store,
       workspaceSeedProjectIds: [],
     });
+    return closure.mode === 'compatible' && extractorTransition
+      ? {...closure, extractorTransition: true as const}
+      : closure;
   }
   if (finalCodeGraphFactBatches(currentFacts).length !== 1) {
     return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
@@ -2995,16 +3093,17 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
     input.layout.databasePath,
     modifiedFiles,
     currentFacts.map(fact => serializeBoundedCodeGraphFact(fact)),
-    input.candidate.snapshot.extractorSet,
+    currentExtractorSet,
     materializedShardDerivationIdentity(
-      input.candidate.snapshot.extractorSet,
+      currentExtractorSet,
       workspace.fingerprint,
-      graphContentIdentity(input.candidate.snapshot.extractorSet, input.inventory.files),
+      graphContentIdentity(currentExtractorSet, input.inventory.files),
     ),
     input.persistentCapacityProtector,
   );
   return {
     committedWorkspace: workspace,
+    ...(extractorTransition ? {extractorTransition: true as const} : {}),
     facts: currentFacts,
     files: modifiedFiles,
     mode: 'compatible',
@@ -4004,8 +4103,25 @@ export function extractorSetIdentity(
   languagePacks: CodeGraphLanguagePackRegistryShape = BUILTIN_LANGUAGE_PACK_REGISTRY,
 ): string {
   const paths = files.map(file => file.path);
-  const activeParsers = languagePacks.activeCacheIdentities(paths).join('\n');
-  const activeDerivations = languagePacks.activeDerivationIdentities(paths).join('\n');
+  return extractorSetIdentityFromIdentities(
+    languagePacks.activeCacheIdentities(paths),
+    languagePacks.activeDerivationIdentities(paths),
+  );
+}
+
+export function extractorSetIdentityFromPackProvenance(provenance: readonly CodeGraphLanguagePackProvenance[]): string {
+  return extractorSetIdentityFromIdentities(
+    [...new Set(provenance.map(pack => pack.cacheIdentity))],
+    [...new Set(provenance.map(pack => pack.derivationIdentity))],
+  );
+}
+
+function extractorSetIdentityFromIdentities(
+  cacheIdentities: readonly string[],
+  derivationIdentities: readonly string[],
+): string {
+  const activeParsers = [...cacheIdentities].sort(compareCodeUnits).join('\n');
+  const activeDerivations = [...derivationIdentities].sort(compareCodeUnits).join('\n');
   return sha256HexSync(
     `${CODE_GRAPH_EXTRACTOR_SET_VERSION}\nactive-parser-packs:\n${activeParsers}\nactive-derivations:\n${activeDerivations}\nignore-policy:3\nresolution-context-policy:semantic-workspace-v1`,
   );
@@ -4694,6 +4810,80 @@ function loadCachedFacts(
         }
       }
       return {bytes, bytesByPath, facts: output};
+    }),
+  );
+}
+
+function loadCachedFactsWithPackProvenance(
+  store: CodeGraphStoreShape,
+  databasePath: string,
+  files: readonly CodeGraphInventoryFile[],
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+  provenance: readonly CodeGraphLanguagePackProvenance[],
+): Effect.Effect<
+  {
+    readonly bytes: number;
+    readonly bytesByPath: ReadonlyMap<string, number>;
+    readonly facts: ReadonlyMap<string, CodeGraphFileFacts>;
+  },
+  unknown
+> {
+  const provenanceById = new Map(provenance.map(pack => [pack.id, pack]));
+  const groups = new Map<string, CodeGraphInventoryFile[]>();
+  let unmatched = false;
+  for (const file of files) {
+    const match = Option.getOrUndefined(languagePacks.match(file.path));
+    const identity = match === undefined ? undefined : provenanceById.get(match.pack.id)?.cacheIdentity;
+    if (identity === undefined) {
+      unmatched = true;
+      continue;
+    }
+    const group = groups.get(identity) ?? [];
+    group.push(file);
+    groups.set(identity, group);
+  }
+  if (unmatched) return Effect.succeed({bytes: 0, bytesByPath: new Map(), facts: new Map()});
+  return Effect.forEach(
+    [...groups],
+    ([cacheIdentity, groupFiles]) =>
+      Effect.gen(function* () {
+        const active = yield* store.loadCachedFacts(databasePath, groupFiles, cacheIdentity);
+        const missing = groupFiles.filter(file => !active.facts.has(file.path));
+        if (missing.length === 0) return active;
+        const degraded = yield* store.loadCachedFacts(
+          databasePath,
+          missing,
+          degradedParserCacheIdentity(cacheIdentity),
+        );
+        return {
+          bytes: active.bytes + degraded.bytes,
+          bytesByPath: new Map([...(active.bytesByPath ?? []), ...(degraded.bytesByPath ?? [])]),
+          facts: new Map([...active.facts, ...degraded.facts]),
+        };
+      }),
+    {concurrency: 1},
+  ).pipe(
+    Effect.map(loaded => {
+      const facts = new Map<string, CodeGraphFileFacts>();
+      const bytesByPath = new Map<string, number>();
+      let bytes = 0;
+      for (const group of loaded) {
+        for (const [path, fact] of group.facts) {
+          const persistedBytes = group.bytesByPath?.get(path);
+          if (persistedBytes !== undefined && persistedBytes <= CODE_GRAPH_CACHED_FACT_BYTES_MAXIMUM) {
+            facts.set(path, fact);
+            bytesByPath.set(path, persistedBytes);
+            bytes += persistedBytes;
+            continue;
+          }
+          const budgeted = budgetCachedCodeGraphFacts(fact);
+          const budgetedBytes = cachedCodeGraphFactBytes(budgeted);
+          facts.set(path, budgeted);
+          bytesByPath.set(path, budgetedBytes);
+          bytes += budgetedBytes;
+        }
+      }
+      return {bytes, bytesByPath, facts};
     }),
   );
 }

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -115,6 +115,7 @@ import {
 } from './embedding.js';
 import {TreeSitterRuntime, type TreeSitterRuntimeShape} from './tree_sitter/runtime.js';
 import {createWorkspaceAttributor} from './workspace.js';
+import {assessCodeGraphWorkspaceCompatibility} from './workspace_compatibility.js';
 import {makeCodeGraphBuildReporter, readCodeGraphBuildStatuses} from './build_status.js';
 import type {CodeGraphWorkspace} from './languages/types.js';
 import {
@@ -373,6 +374,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                             identity.worktreeId,
                             new Set(),
                             retiredSnapshotCleanupReporter(options.onProgress),
+                            {cleanupMode: 'deferred'},
                           );
                           yield* promoteReadySnapshotWithCapacity(
                             {
@@ -494,6 +496,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         identity.worktreeId,
                         retainedSnapshotIds,
                         retiredSnapshotCleanupReporter(options.onProgress),
+                        {cleanupMode: 'deferred'},
                       );
                       if (reusableReady) {
                         if (existing?.id !== reusableReady.id) {
@@ -2816,9 +2819,6 @@ const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assessIncreme
     return {mode: 'fallback', reason: 'extractor-context-changed'} satisfies IncrementalOverlayPreassessment;
   }
   const committedWorkspace = yield* input.languagePacks.discoverWorkspace(input.inventory.committedFiles);
-  if (committedWorkspace.fingerprint !== workspace.fingerprint) {
-    return {mode: 'fallback', reason: 'workspace-changed'} satisfies IncrementalOverlayPreassessment;
-  }
   const committedByPath = new Map(input.inventory.committedFiles.map(file => [file.path, file]));
   const effectiveByPath = new Map(input.inventory.files.map(file => [file.path, file]));
   if (
@@ -2839,6 +2839,10 @@ const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assessIncreme
   });
   if (modifiedFiles.length === 0) {
     return {mode: 'fallback', reason: 'no-materialized-changes'} satisfies IncrementalOverlayPreassessment;
+  }
+  const workspaceCompatibility = assessCodeGraphWorkspaceCompatibility(committedWorkspace, workspace);
+  if (workspaceCompatibility.mode === 'fallback') {
+    return workspaceCompatibility satisfies IncrementalOverlayPreassessment;
   }
   const committedFiles = modifiedFiles.map(file => committedByPath.get(file.path)!);
   const changedDecodeBudget = yield* assessProjectClosureChangedDecodeBudget({
@@ -2876,7 +2880,7 @@ const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assessIncreme
     return !committed || !hasSameCodeGraphResolutionSurface(committed.symbols, file.symbols);
   });
   const dynamicAliases = hasDynamicAliases(committedFacts) || hasDynamicAliases(effectiveFacts);
-  if (!dynamicAliases && !resolutionSurfaceChanged) {
+  if (!dynamicAliases && !resolutionSurfaceChanged && workspaceCompatibility.mode === 'unchanged') {
     if (finalCodeGraphFactBatches(effectiveFacts).length !== 1) {
       return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
     }
@@ -2897,6 +2901,8 @@ const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assessIncreme
     languagePacks: input.languagePacks,
     layout: input.layout,
     store: input.store,
+    workspaceSeedProjectIds:
+      workspaceCompatibility.mode === 'project-closure' ? workspaceCompatibility.seedProjectIds : [],
   });
 });
 
@@ -2969,6 +2975,7 @@ const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessReusable
       languagePacks: input.languagePacks,
       layout: input.layout,
       store: input.store,
+      workspaceSeedProjectIds: [],
     });
   }
   if (finalCodeGraphFactBatches(currentFacts).length !== 1) {
@@ -3006,6 +3013,7 @@ const assessProjectIncrementalClosureCompatibility = Effect.fn(
   readonly languagePacks: CodeGraphLanguagePackRegistryShape;
   readonly layout: CodeGraphLayout;
   readonly store: CodeGraphStoreShape;
+  readonly workspaceSeedProjectIds: readonly string[];
 }) {
   const seeds = assessProjectClosureSeeds({
     committedFacts: input.changedBaseFacts,
@@ -3015,11 +3023,14 @@ const assessProjectIncrementalClosureCompatibility = Effect.fn(
   if (seeds.mode === 'fallback') {
     return seeds satisfies IncrementalOverlayPreassessment;
   }
+  const seedProjectIds = [...new Set([...seeds.seedProjectIds, ...input.workspaceSeedProjectIds])].sort(
+    compareCodeUnits,
+  );
   const selection = selectProjectIncrementalClosure({
     files: input.currentFiles,
     modifiedPaths: input.currentChangedFiles.map(file => file.path),
     projects: input.currentWorkspace.projects,
-    seedProjectIds: seeds.seedProjectIds,
+    seedProjectIds,
     workspaceDiagnostics: input.currentWorkspace.diagnostics,
   });
   if (selection.mode === 'fallback') {
@@ -3038,7 +3049,7 @@ const assessProjectIncrementalClosureCompatibility = Effect.fn(
     files: input.currentFiles,
     modifiedPaths: input.currentChangedFiles.map(file => file.path),
     projects: input.currentWorkspace.projects,
-    seedProjectIds: seeds.seedProjectIds,
+    seedProjectIds,
     workspaceDiagnostics: input.currentWorkspace.diagnostics,
   });
   if (plan.mode === 'fallback') {
@@ -3982,16 +3993,11 @@ export function extractorSetIdentity(
   files: readonly {readonly contentHash: string; readonly path: string}[],
   languagePacks: CodeGraphLanguagePackRegistryShape = BUILTIN_LANGUAGE_PACK_REGISTRY,
 ): string {
-  const context = files
-    .filter(file => languagePacks.isResolutionContext(file.path))
-    .map(file => `${file.path}\0${file.contentHash}`)
-    .sort()
-    .join('\n');
   const paths = files.map(file => file.path);
   const activeParsers = languagePacks.activeCacheIdentities(paths).join('\n');
   const activeDerivations = languagePacks.activeDerivationIdentities(paths).join('\n');
   return sha256HexSync(
-    `${CODE_GRAPH_EXTRACTOR_SET_VERSION}\nactive-parser-packs:\n${activeParsers}\nactive-derivations:\n${activeDerivations}\nignore-policy:3\nresolution-context:\n${context}`,
+    `${CODE_GRAPH_EXTRACTOR_SET_VERSION}\nactive-parser-packs:\n${activeParsers}\nactive-derivations:\n${activeDerivations}\nignore-policy:3\nresolution-context-policy:semantic-workspace-v1`,
   );
 }
 

--- a/src/code_graph/inventory.ts
+++ b/src/code_graph/inventory.ts
@@ -4,7 +4,7 @@ import {runBinaryCommandEffect, runCommandEffect} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
 import {codeGraphBlobReuseCacheKey} from './blob_reuse.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY, type CodeGraphLanguagePackRegistryShape} from './languages/registry.js';
-import {CORPUS_EXTRACTION_SOURCE_BYTES_LIMIT} from './languages/corpus/policy.js';
+import {CORPUS_EXTRACTION_SOURCE_BYTES_LIMIT, isOpaqueCorpusMediaPath} from './languages/corpus/policy.js';
 import {isLowSignalStructuredPath} from './languages/schemas/policy.js';
 import type {CodeGraphFileRole} from './languages/types.js';
 import {
@@ -71,6 +71,7 @@ export type CodeGraphInventoryPreviewReason =
   | 'git-ignore'
   | 'hidden-directory'
   | 'invalid-path'
+  | 'opaque-corpus-deferred'
   | 'threadnote-ignore'
   | 'unsupported-language'
   | 'vendor-directory';
@@ -119,12 +120,14 @@ export interface CodeGraphInventoryPreviewSummaryOptions {
   readonly declaredProjectRoots?: readonly string[];
   readonly declaredSourceRoots?: readonly string[];
   readonly gitIgnoredPaths?: ReadonlySet<string>;
+  readonly includeOpaqueCorpusAssets?: boolean;
   readonly languagePacks?: CodeGraphLanguagePackRegistryShape;
   readonly threadnoteIgnore?: string;
 }
 
 export interface CodeGraphInventoryPreviewOptions {
   readonly includeOverlay?: boolean;
+  readonly includeOpaqueCorpusAssets?: boolean;
   readonly languagePacks?: CodeGraphLanguagePackRegistryShape;
 }
 
@@ -136,6 +139,8 @@ interface PolicyExclusionEntry {
 export interface CodeGraphInventoryOptions {
   readonly cachedCommittedFileKeys?: ReadonlySet<string>;
   readonly includeOverlay?: boolean;
+  /** Binary media is metadata-only structural evidence and may be deferred until vector indexing is requested. */
+  readonly includeOpaqueCorpusAssets?: boolean;
   readonly languagePacks?: CodeGraphLanguagePackRegistryShape;
   readonly onContentBatch?: (
     files: readonly CodeGraphInventoryFile[],
@@ -230,6 +235,7 @@ export function summarizeCodeGraphInventoryPreview(
             languagePacks,
             options.declaredProjectRoots ?? [],
             options.declaredSourceRoots ?? [],
+            options.includeOpaqueCorpusAssets !== false,
           )
         : undefined;
     const reason = policyReason ?? pathReason ?? (gitIgnoredPaths.has(path) ? 'git-ignore' : 'admitted');
@@ -307,11 +313,27 @@ export const inventoryRepository = Effect.fn('codeGraph.inventoryRepository')(fu
       languagePacks,
       declaredWorkspace.projectRoots,
       declaredWorkspace.sourceRoots,
+      options.includeOpaqueCorpusAssets !== false,
     ),
   );
+  const deferredOpaqueEntries =
+    options.includeOpaqueCorpusAssets === false
+      ? policyAdmittedTreeEntries.filter(
+          entry =>
+            isOpaqueCorpusMediaPath(entry.path) &&
+            acceptsRepositoryPathWithRules(
+              entry.path,
+              ignoreRules,
+              languagePacks,
+              declaredWorkspace.projectRoots,
+              declaredWorkspace.sourceRoots,
+              true,
+            ),
+        )
+      : [];
   const ignoredByGit = yield* ignoredPaths(
     identity.repoRoot,
-    acceptedByPolicy.map(entry => entry.path),
+    [...acceptedByPolicy, ...deferredOpaqueEntries].map(entry => entry.path),
   );
   const accepted = acceptedByPolicy.filter(entry => !ignoredByGit.has(entry.path));
   const acceptedPaths = new Set(accepted.map(entry => entry.path));
@@ -351,6 +373,7 @@ export const inventoryRepository = Effect.fn('codeGraph.inventoryRepository')(fu
           committedPolicyExclusions,
           committedTreeEntries,
           acceptedPaths,
+          options.includeOpaqueCorpusAssets !== false,
           options.onContentBatch
             ? (files, context) =>
                 options.onContentBatch!(files, {
@@ -375,6 +398,14 @@ export const inventoryRepository = Effect.fn('codeGraph.inventoryRepository')(fu
   const skipped = excluded + committed.skipped + overlay.skipped + overlay.policySkippedDelta;
   const policyExclusions = summarizePolicyExclusions(overlay.policyExclusions);
   const diagnostics = policyExclusions.files === 0 ? [] : [formatPolicyExclusionDiagnostic(policyExclusions)];
+  if (options.includeOpaqueCorpusAssets === false) {
+    const deferred = deferredOpaqueEntries.filter(entry => !ignoredByGit.has(entry.path));
+    if (deferred.length > 0) {
+      diagnostics.push(
+        `Deferred ${deferred.length} opaque corpus asset(s) / ${deferred.reduce((total, entry) => total + entry.size, 0)} byte(s) during structural-only indexing.`,
+      );
+    }
+  }
   return {
     committedFiles: [...committed.files].sort((left, right) => compareCodeUnits(left.path, right.path)),
     committedParsedFiles: committed.files.reduce(
@@ -452,6 +483,7 @@ export const previewCodeGraphInventory = Effect.fn('codeGraph.previewInventory')
           languagePacks,
           effectiveRoots.projectRoots,
           effectiveRoots.sourceRoots,
+          options.includeOpaqueCorpusAssets !== false,
         ) === undefined,
     )
     .map(entry => entry.path);
@@ -461,6 +493,7 @@ export const previewCodeGraphInventory = Effect.fn('codeGraph.previewInventory')
     declaredSourceRoots: effectiveRoots.sourceRoots,
     gitIgnoredPaths,
     languagePacks,
+    includeOpaqueCorpusAssets: options.includeOpaqueCorpusAssets,
     threadnoteIgnore,
   });
   return {
@@ -839,10 +872,17 @@ function acceptsRepositoryPathWithRules(
   languagePacks: CodeGraphLanguagePackRegistryShape,
   declaredProjectRoots: readonly string[] = [],
   declaredSourceRoots: readonly string[] = [],
+  includeOpaqueCorpusAssets = true,
 ): boolean {
   return (
-    repositoryPathExclusionReason(value, ignoreRules, languagePacks, declaredProjectRoots, declaredSourceRoots) ===
-    undefined
+    repositoryPathExclusionReason(
+      value,
+      ignoreRules,
+      languagePacks,
+      declaredProjectRoots,
+      declaredSourceRoots,
+      includeOpaqueCorpusAssets,
+    ) === undefined
   );
 }
 
@@ -852,6 +892,7 @@ function repositoryPathExclusionReason(
   languagePacks: CodeGraphLanguagePackRegistryShape,
   declaredProjectRoots: readonly string[] = [],
   declaredSourceRoots: readonly string[] = [],
+  includeOpaqueCorpusAssets = true,
 ): Exclude<CodeGraphInventoryPreviewReason, CodeGraphInventoryExclusionReason | 'admitted' | 'git-ignore'> | undefined {
   const path = normalizeRepositoryPath(value);
   if (!path || path.startsWith('/') || path.split('/').some(segment => segment === '..' || segment === '')) {
@@ -880,6 +921,7 @@ function repositoryPathExclusionReason(
     return normalizedDirectory === 'node_modules' ? 'vendor-directory' : 'generated-directory';
   }
   if (isIgnoredByThreadnote(path, ignoreRules)) return 'threadnote-ignore';
+  if (!includeOpaqueCorpusAssets && isOpaqueCorpusMediaPath(path)) return 'opaque-corpus-deferred';
   return Option.isSome(languagePacks.match(path)) ? undefined : 'unsupported-language';
 }
 
@@ -1207,6 +1249,7 @@ const readDirtyOverlay = Effect.fn('codeGraph.readDirtyOverlay')(function* (
   committedPolicyExclusions: ReadonlyMap<string, PolicyExclusionEntry>,
   committedTreeEntries: ReadonlyMap<string, GitTreeEntry>,
   knownCommittedAcceptedPaths?: ReadonlySet<string>,
+  includeOpaqueCorpusAssets = true,
   onContentBatch?: CodeGraphInventoryOptions['onContentBatch'],
 ) {
   const fs = yield* FileSystem.FileSystem;
@@ -1260,7 +1303,14 @@ const readDirtyOverlay = Effect.fn('codeGraph.readDirtyOverlay')(function* (
       entry !== undefined &&
       !committedPolicyExclusions.has(relative) &&
       !ignoredChangedPaths.has(relative) &&
-      acceptsRepositoryPathWithRules(relative, ignoreRules, languagePacks, declaredProjectRoots, declaredSourceRoots)
+      acceptsRepositoryPathWithRules(
+        relative,
+        ignoreRules,
+        languagePacks,
+        declaredProjectRoots,
+        declaredSourceRoots,
+        includeOpaqueCorpusAssets,
+      )
     );
   };
   const policyExclusions = new Map(committedPolicyExclusions);
@@ -1398,6 +1448,7 @@ const readDirtyOverlay = Effect.fn('codeGraph.readDirtyOverlay')(function* (
         languagePacks,
         effectiveDeclaredProjectRoots,
         effectiveDeclaredSourceRoots,
+        includeOpaqueCorpusAssets,
       )
     ) {
       if (previousPolicyExclusion !== undefined) {

--- a/src/code_graph/inventory.ts
+++ b/src/code_graph/inventory.ts
@@ -6,7 +6,7 @@ import {codeGraphBlobReuseCacheKey} from './blob_reuse.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY, type CodeGraphLanguagePackRegistryShape} from './languages/registry.js';
 import {CORPUS_EXTRACTION_SOURCE_BYTES_LIMIT, isOpaqueCorpusMediaPath} from './languages/corpus/policy.js';
 import {isLowSignalStructuredPath} from './languages/schemas/policy.js';
-import type {CodeGraphFileRole} from './languages/types.js';
+import type {CodeGraphFileRole, CodeGraphWorkspace} from './languages/types.js';
 import {
   codeGraphInventoryExclusionReason,
   CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
@@ -46,6 +46,8 @@ export interface CodeGraphInventory {
   readonly parsedFiles: number;
   readonly policyExclusions?: CodeGraphInventoryPolicyExclusionSummary;
   readonly skipped: number;
+  /** Workspace derived from the same admitted resolution-context files, when the overlay did not change one. */
+  readonly workspace?: CodeGraphWorkspace;
 }
 
 export interface CodeGraphInventoryPolicyExclusionSummary {
@@ -419,6 +421,9 @@ export const inventoryRepository = Effect.fn('codeGraph.inventoryRepository')(fu
     parsedFiles: files.reduce((total, file) => total + (parsedPaths.has(file.path) ? 1 : 0), 0),
     policyExclusions,
     skipped,
+    ...([...overlay.changed].some(relative => languagePacks.isResolutionContext(relative))
+      ? {}
+      : {workspace: declaredWorkspace.workspace}),
   } satisfies CodeGraphInventory;
 });
 
@@ -516,6 +521,7 @@ const readInventoryPreviewTree = Effect.fn('codeGraph.readInventoryPreviewTree')
   path: Path.Path,
   committedEntries: readonly GitTreeEntry[],
   includeOverlay: boolean,
+  excludedPathPrefix?: string,
 ) {
   const emptyChanges = {added: new Set<string>(), changed: new Set<string>(), deleted: new Set<string>()};
   if (!includeOverlay) {
@@ -530,12 +536,16 @@ const readInventoryPreviewTree = Effect.fn('codeGraph.readInventoryPreviewTree')
   const fs = yield* FileSystem.FileSystem;
   const repositoryRoot = yield* fs.realPath(identity.repoRoot);
   const unborn = isZeroObjectId(identity.headCommit);
+  const excludePath = (relative: string) =>
+    excludedPathPrefix !== undefined &&
+    (relative === excludedPathPrefix || relative.startsWith(`${excludedPathPrefix}/`));
+  const pathspec = excludedPathPrefix === undefined ? [] : ['--', '.', `:(top,exclude,literal)${excludedPathPrefix}`];
   const [diffOutput, untrackedOutput] = unborn
     ? [
         '',
         (yield* runCommandEffect(
           'git',
-          ['-C', identity.repoRoot, 'ls-files', '-z', '--cached', '--others', '--exclude-standard'],
+          ['-C', identity.repoRoot, 'ls-files', '-z', '--cached', '--others', '--exclude-standard', ...pathspec],
           {maxOutputBytes: 0, timeoutMs: 0},
         )).stdout,
       ]
@@ -543,20 +553,39 @@ const readInventoryPreviewTree = Effect.fn('codeGraph.readInventoryPreviewTree')
         [
           runCommandEffect(
             'git',
-            ['-C', identity.repoRoot, 'diff', '--name-status', '-z', '--find-renames', identity.headCommit, '--'],
+            [
+              '-C',
+              identity.repoRoot,
+              'diff',
+              '--name-status',
+              '-z',
+              '--find-renames',
+              identity.headCommit,
+              ...(pathspec.length === 0 ? ['--'] : pathspec),
+            ],
             {maxOutputBytes: 0, timeoutMs: 0},
           ).pipe(Effect.map(result => result.stdout)),
-          runCommandEffect('git', ['-C', identity.repoRoot, 'ls-files', '-z', '--others', '--exclude-standard'], {
-            maxOutputBytes: 0,
-            timeoutMs: 0,
-          }).pipe(Effect.map(result => result.stdout)),
+          runCommandEffect(
+            'git',
+            ['-C', identity.repoRoot, 'ls-files', '-z', '--others', '--exclude-standard', ...pathspec],
+            {
+              maxOutputBytes: 0,
+              timeoutMs: 0,
+            },
+          ).pipe(Effect.map(result => result.stdout)),
         ],
         {concurrency: 2},
       );
   const changes = parseNameStatus(diffOutput);
   for (const relative of untrackedOutput.split('\0').filter(Boolean).map(normalizeRepositoryPath)) {
+    if (excludePath(relative)) continue;
     changes.added.add(relative);
     changes.changed.add(relative);
+  }
+  for (const collection of [changes.added, changes.changed, changes.deleted]) {
+    for (const relative of collection) {
+      if (excludePath(relative)) collection.delete(relative);
+    }
   }
   const entries = new Map(committedEntries.map(entry => [entry.path, entry]));
   for (const relative of changes.deleted) entries.delete(relative);
@@ -633,6 +662,76 @@ export const worktreeOverlayState = Effect.fn('codeGraph.worktreeOverlayState')(
   return {dirty: overlay.dirty, fingerprint: overlay.fingerprint};
 });
 
+/**
+ * Exact, policy-independent dirty input identity for build admission. Unlike
+ * `worktreeOverlayState`, this does not hydrate the committed tree or discover
+ * every workspace before the real inventory pass. Changed regular files are
+ * still streamed through SHA-256 with the same containment and race checks, so
+ * two processes can safely coalesce only the exact same worktree bytes.
+ */
+export const worktreeBuildRequestState = Effect.fn('codeGraph.worktreeBuildRequestState')(function* (
+  identity: RepositoryIdentity,
+  threadnoteHome?: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const repositoryRoot = yield* fs.realPath(identity.repoRoot);
+  const relativeHome =
+    threadnoteHome === undefined
+      ? undefined
+      : normalizeRepositoryPath(
+          path.relative(repositoryRoot, yield* canonicalizePotentialPath(fs, path, threadnoteHome)),
+        );
+  const excludedPathPrefix =
+    relativeHome !== undefined &&
+    relativeHome.length > 0 &&
+    relativeHome !== '..' &&
+    !relativeHome.startsWith('../') &&
+    !path.isAbsolute(relativeHome)
+      ? relativeHome
+      : undefined;
+  const pathspec = excludedPathPrefix === undefined ? [] : ['--', '.', `:(top,exclude,literal)${excludedPathPrefix}`];
+  const porcelain = yield* runCommandEffect(
+    'git',
+    ['-C', identity.repoRoot, 'status', '--porcelain=v1', '-z', '--untracked-files=normal', ...pathspec],
+    {maxOutputBytes: 0, timeoutMs: 0},
+  );
+  if (porcelain.stdout.length === 0) return {dirty: false, fingerprint: undefined};
+  const tree = yield* readInventoryPreviewTree(identity, path, [], true, excludedPathPrefix);
+  const threadnoteIgnore = yield* readOptionalText(fs, path.join(identity.repoRoot, '.threadnoteignore'));
+  const fileRows: string[] = [];
+  const skippedRows: string[] = [];
+  for (const relative of [...tree.changes.changed].sort(compareCodeUnits)) {
+    if (tree.changes.deleted.has(relative)) continue;
+    const metadata = tree.changedMetadata.get(relative);
+    const materialized = yield* materializeContainedStableRegularFile(
+      fs,
+      path,
+      repositoryRoot,
+      relative,
+      () => true,
+      metadata?.size,
+    ).pipe(Effect.option);
+    if (Option.isSome(materialized)) fileRows.push(`F\0${relative}\0${materialized.value.contentHash}`);
+    else skippedRows.push(`S\0${relative}`);
+  }
+  const dirty = tree.changes.changed.size > 0 || tree.changes.deleted.size > 0;
+  return {
+    dirty,
+    fingerprint: dirty
+      ? sha256HexSync(
+          [
+            'build-request-overlay-v1',
+            `I\0${sha256HexSync(threadnoteIgnore)}`,
+            ...[...tree.changes.deleted].sort(compareCodeUnits).map(relative => `D\0${relative}`),
+            ...fileRows,
+            ...skippedRows,
+          ].join('\n'),
+        )
+      : undefined,
+  };
+});
+
 export function parseGitTree(output: string): readonly GitTreeEntry[] {
   const entries: GitTreeEntry[] = [];
   for (const record of output.split('\0')) {
@@ -704,7 +803,12 @@ const discoverDeclaredSourceRoots = Effect.fn('codeGraph.discoverDeclaredSourceR
     return !directories.some(directory => directory.startsWith('.') || directory.toLowerCase() === 'node_modules');
   });
   if (contexts.length === 0) {
-    return {files: new Map<string, CodeGraphInventoryFile>(), projectRoots: [], sourceRoots: []};
+    return {
+      files: new Map<string, CodeGraphInventoryFile>(),
+      projectRoots: [],
+      sourceRoots: [],
+      workspace: yield* languagePacks.discoverWorkspace([]),
+    };
   }
 
   const files: CodeGraphInventoryFile[] = [];
@@ -752,7 +856,7 @@ const discoverDeclaredSourceRoots = Effect.fn('codeGraph.discoverDeclaredSourceR
         .filter(root => root.length > 0 && !root.split('/').some(segment => segment === '..' || segment === '')),
     ),
   ].sort(compareCodeUnits);
-  return {files: new Map(files.map(file => [file.path, file])), projectRoots, sourceRoots};
+  return {files: new Map(files.map(file => [file.path, file])), projectRoots, sourceRoots, workspace};
 });
 
 const discoverOverlaySourceRoots = Effect.fn('codeGraph.discoverOverlaySourceRoots')(function* (
@@ -1904,6 +2008,23 @@ function decodeUtf8(bytes: Uint8Array): string | undefined {
 function normalizeRepositoryPath(value: string): string {
   return value.replace(/^\.\/+/, '');
 }
+
+const canonicalizePotentialPath = Effect.fn('codeGraph.canonicalizePotentialPath')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  target: string,
+) {
+  let current = path.resolve(target);
+  const missingSegments: string[] = [];
+  while (true) {
+    const canonical = yield* fs.realPath(current).pipe(Effect.option);
+    if (Option.isSome(canonical)) return path.join(canonical.value, ...missingSegments);
+    const parent = path.dirname(current);
+    if (parent === current) return path.resolve(target);
+    missingSegments.unshift(path.basename(current));
+    current = parent;
+  }
+});
 
 function cacheKey(path: string, contentHash: string, languagePacks: CodeGraphLanguagePackRegistryShape): string {
   return `${path}\0${contentHash}\0${Option.getOrElse(languagePacks.cacheIdentityForPath(path), () => 'unmatched')}`;

--- a/src/code_graph/languages/corpus/pack.ts
+++ b/src/code_graph/languages/corpus/pack.ts
@@ -3,6 +3,7 @@ import {sha256HexSync} from '../../../crypto/sha256.js';
 import {fromPromiseInterruptible} from '../../../effect/errors.js';
 import {CodeGraphLanguagePackError, type CodeGraphFileMatcher, type CodeGraphLanguagePack} from '../types.js';
 import {extractCorpusFile} from './extractor.js';
+import {OPAQUE_CORPUS_MEDIA_EXTENSIONS} from './policy.js';
 
 const extensions = (values: readonly string[], language: string): readonly CodeGraphFileMatcher[] =>
   values.map(value => ({kind: 'extension', language, role: 'corpus', value}));
@@ -52,11 +53,25 @@ export const codeGraphLanguagePack: CodeGraphLanguagePack = {
     ),
     ...extensions(['.docx', '.epub', '.odp', '.ods', '.odt', '.pdf', '.pptx', '.xlsx'], 'office-document'),
     ...extensions(
-      ['.avif', '.bmp', '.gif', '.heic', '.ico', '.jpeg', '.jpg', '.png', '.tif', '.tiff', '.webp'],
+      OPAQUE_CORPUS_MEDIA_EXTENSIONS.filter(extension =>
+        ['.avif', '.bmp', '.gif', '.heic', '.ico', '.jpeg', '.jpg', '.png', '.tif', '.tiff', '.webp'].includes(
+          extension,
+        ),
+      ),
       'image',
     ),
-    ...extensions(['.aac', '.flac', '.m4a', '.mp3', '.oga', '.ogg', '.opus', '.wav'], 'audio'),
-    ...extensions(['.avi', '.m4v', '.mkv', '.mov', '.mp4', '.mpeg', '.mpg', '.webm'], 'video'),
+    ...extensions(
+      OPAQUE_CORPUS_MEDIA_EXTENSIONS.filter(extension =>
+        ['.aac', '.flac', '.m4a', '.mp3', '.oga', '.ogg', '.opus', '.wav'].includes(extension),
+      ),
+      'audio',
+    ),
+    ...extensions(
+      OPAQUE_CORPUS_MEDIA_EXTENSIONS.filter(extension =>
+        ['.avi', '.m4v', '.mkv', '.mov', '.mp4', '.mpeg', '.mpg', '.webm'].includes(extension),
+      ),
+      'video',
+    ),
   ],
   id: 'corpus',
   resolutionStrategy: {domain: 'corpus', version: 'corpus-links-v1'},

--- a/src/code_graph/languages/corpus/policy.ts
+++ b/src/code_graph/languages/corpus/policy.ts
@@ -5,3 +5,42 @@ export const CORPUS_ARCHIVE_INSPECTED_ENTRY_LIMIT = 65_536;
 export const CORPUS_ARCHIVE_SELECTED_ENTRY_LIMIT = 8_192;
 export const CORPUS_PDF_EXTRACTED_TEXT_CHARACTER_LIMIT = 16 * 1_048_576;
 export const CORPUS_PDF_EXTRACTION_MILLISECONDS_LIMIT = 30_000;
+
+export const OPAQUE_CORPUS_MEDIA_EXTENSIONS = [
+  '.aac',
+  '.avi',
+  '.avif',
+  '.bmp',
+  '.flac',
+  '.gif',
+  '.heic',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.m4a',
+  '.m4v',
+  '.mkv',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.mpeg',
+  '.mpg',
+  '.oga',
+  '.ogg',
+  '.opus',
+  '.png',
+  '.tif',
+  '.tiff',
+  '.wav',
+  '.webm',
+  '.webp',
+] as const;
+
+const OPAQUE_CORPUS_MEDIA_EXTENSION_SET = new Set<string>(OPAQUE_CORPUS_MEDIA_EXTENSIONS);
+
+/** Binary media contributes metadata-only asset nodes and can be deferred by structural-only indexing. */
+export function isOpaqueCorpusMediaPath(path: string): boolean {
+  const basename = path.split('/').at(-1)?.toLowerCase() ?? '';
+  const separator = basename.lastIndexOf('.');
+  return separator > 0 && OPAQUE_CORPUS_MEDIA_EXTENSION_SET.has(basename.slice(separator));
+}

--- a/src/code_graph/languages/provenance.ts
+++ b/src/code_graph/languages/provenance.ts
@@ -1,0 +1,46 @@
+import type {CodeGraphLanguagePackProvenance} from '../store_models.js';
+
+export type CodeGraphLanguagePackDelta =
+  | {
+      readonly changedPackIds: readonly string[];
+      readonly mode: 'compatible';
+    }
+  | {
+      readonly mode: 'fallback';
+      readonly reason: 'missing-provenance' | 'pack-surface-changed';
+    };
+
+/**
+ * A cache-identity-only change means extraction changed while project and
+ * resolution derivation stayed stable. Anything else fails closed because a
+ * receipt alone cannot prove a bounded resolution closure.
+ */
+export function assessCodeGraphLanguagePackDelta(
+  previous: readonly CodeGraphLanguagePackProvenance[],
+  current: readonly CodeGraphLanguagePackProvenance[],
+): CodeGraphLanguagePackDelta {
+  if (previous.length === 0 || current.length === 0) return {mode: 'fallback', reason: 'missing-provenance'};
+  const previousById = new Map(previous.map(pack => [pack.id, pack]));
+  const currentById = new Map(current.map(pack => [pack.id, pack]));
+  if (
+    previousById.size !== previous.length ||
+    currentById.size !== current.length ||
+    previousById.size !== currentById.size ||
+    [...previousById.keys()].some(id => !currentById.has(id))
+  ) {
+    return {mode: 'fallback', reason: 'pack-surface-changed'};
+  }
+  const changedPackIds: string[] = [];
+  for (const [id, before] of previousById) {
+    const after = currentById.get(id)!;
+    if (
+      before.derivationIdentity !== after.derivationIdentity ||
+      before.resolutionDomain !== after.resolutionDomain ||
+      before.resolutionVersion !== after.resolutionVersion
+    ) {
+      return {mode: 'fallback', reason: 'pack-surface-changed'};
+    }
+    if (before.cacheIdentity !== after.cacheIdentity) changedPackIds.push(id);
+  }
+  return {changedPackIds: changedPackIds.sort(), mode: 'compatible'};
+}

--- a/src/code_graph/languages/registry.ts
+++ b/src/code_graph/languages/registry.ts
@@ -12,6 +12,7 @@ import {
   type CodeGraphWorkspaceProject,
 } from './types.js';
 import type {CodeGraphFileFacts, CodeGraphInventoryFile} from '../types.js';
+import type {CodeGraphLanguagePackProvenance} from '../store_models.js';
 import {TREE_SITTER_RUNTIME_CACHE_IDENTITY, type TreeSitterRuntime} from '../tree_sitter/runtime.js';
 import {mergeCodeGraphWorkspaces, projectForPath} from '../workspace.js';
 import {
@@ -26,6 +27,7 @@ export {CODE_GRAPH_PARSER_FACTS_VERSION} from '../fact_budget.js';
 export interface CodeGraphLanguagePackRegistryShape {
   readonly activeCacheIdentities: (paths: readonly string[]) => readonly string[];
   readonly activeDerivationIdentities: (paths: readonly string[]) => readonly string[];
+  readonly activePackProvenance: (paths: readonly string[]) => readonly CodeGraphLanguagePackProvenance[];
   readonly cacheIdentities: readonly string[];
   readonly cacheIdentityForPath: (path: string) => Option.Option<string>;
   readonly discoverWorkspace: (
@@ -94,6 +96,19 @@ export function createCodeGraphLanguagePackRegistry(
           paths.flatMap(path => Option.toArray(Option.map(match(path), value => packDerivationIdentity(value.pack)))),
         ),
       ].sort(),
+    activePackProvenance: paths => {
+      const activeIds = new Set(paths.flatMap(path => Option.toArray(Option.map(match(path), value => value.pack.id))));
+      return packs
+        .filter(pack => activeIds.has(pack.id))
+        .map(pack => ({
+          cacheIdentity: packCacheIdentity(pack),
+          derivationIdentity: packDerivationIdentity(pack),
+          id: pack.id,
+          resolutionDomain: pack.resolutionStrategy.domain,
+          resolutionVersion: pack.resolutionStrategy.version,
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id));
+    },
     cacheIdentityForPath: path => Option.map(match(path), value => value.cacheIdentity),
     cacheIdentities: [...new Set(entries.map(entry => entry.cacheIdentity))].sort(),
     discoverWorkspace: files =>

--- a/src/code_graph/languages/schemas/extractor.ts
+++ b/src/code_graph/languages/schemas/extractor.ts
@@ -11,7 +11,7 @@ import type {
   CodeGraphSymbol,
 } from '../../types.js';
 import {createSourceLineIndex, sourceSpan, type SourceLineIndex} from '../source_line_index.js';
-import {isLowSignalStructuredPath, isRecognizedStructuredPath} from './policy.js';
+import {isLowSignalStructuredPath, isRecognizedStructuredPath, structuredObjectDeclarationBudget} from './policy.js';
 
 interface MutableStructuredFacts {
   readonly diagnostics: string[];
@@ -25,7 +25,6 @@ interface MutableStructuredFacts {
 }
 
 const MAX_STRUCTURED_SYMBOLS = 4_000;
-const MAX_STRUCTURED_DEPTH = 32;
 const MAX_FULL_OBJECT_CONFIG_CHARACTERS = 4 * 1_024 * 1_024;
 const MAX_RECOGNIZED_FULL_OBJECT_CONFIG_CHARACTERS = 16 * 1_024 * 1_024;
 const MAX_SHALLOW_OBJECT_CONFIG_CHARACTERS = 1 * 1_024 * 1_024;
@@ -136,15 +135,17 @@ function extractObjectConfig(facts: MutableStructuredFacts, policy: ReturnType<t
     documents = [JSON.parse(source) as unknown];
   }
   const seen = new WeakSet<object>();
+  const declarationBudget = structuredObjectDeclarationBudget(facts.file.path);
+  const maximumSymbols = declarationBudget.maximumDeclarations + 1;
   const locateConfigKey = createConfigKeyLocator(content, facts.file.language);
   const retainResourceValues = /(?:^|\/)[^/]+\.xcassets\/.*\/Contents\.json$/iu.test(facts.file.path);
   const visit = (value: unknown, parent: CodeGraphSymbol, path: readonly string[], depth: number): void => {
-    if (depth > MAX_STRUCTURED_DEPTH || facts.symbols.length >= MAX_STRUCTURED_SYMBOLS) return;
+    if (depth > declarationBudget.maximumDepth || facts.symbols.length >= maximumSymbols) return;
     if (typeof value !== 'object' || value === null) return;
     if (seen.has(value)) return;
     seen.add(value);
     const addChild = (key: string, child: unknown, item: boolean) => {
-      if (facts.symbols.length >= MAX_STRUCTURED_SYMBOLS) return;
+      if (facts.symbols.length >= maximumSymbols) return;
       const qualifiedPath = [...path, key];
       const location = locateConfigKey(key);
       const symbol = addDeclaration(
@@ -157,20 +158,20 @@ function extractObjectConfig(facts: MutableStructuredFacts, policy: ReturnType<t
         location.end,
         `${facts.file.path}#${qualifiedPath.join('.')}`,
       );
-      if (retainResourceValues && isResourceScalar(child) && facts.symbols.length < MAX_STRUCTURED_SYMBOLS) {
+      if (retainResourceValues && isResourceScalar(child) && facts.symbols.length < maximumSymbols) {
         addResourceValue(facts, symbol, String(child), qualifiedPath, location.start, location.end);
       }
       visit(child, symbol, qualifiedPath, depth + 1);
     };
     if (Array.isArray(value)) {
-      for (let index = 0; index < value.length && facts.symbols.length < MAX_STRUCTURED_SYMBOLS; index += 1) {
+      for (let index = 0; index < value.length && facts.symbols.length < maximumSymbols; index += 1) {
         const child = value[index];
         if (typeof child === 'object' && child !== null) addChild(String(index), child, true);
       }
       return;
     }
     for (const key in value as Record<string, unknown>) {
-      if (facts.symbols.length >= MAX_STRUCTURED_SYMBOLS) break;
+      if (facts.symbols.length >= maximumSymbols) break;
       if (!Object.hasOwn(value, key)) continue;
       addChild(key, (value as Record<string, unknown>)[key], false);
     }
@@ -178,8 +179,11 @@ function extractObjectConfig(facts: MutableStructuredFacts, policy: ReturnType<t
   documents.forEach((document, index) =>
     visit(document, facts.module, documents.length > 1 ? [`document-${index + 1}`] : [], 0),
   );
-  if (facts.symbols.length >= MAX_STRUCTURED_SYMBOLS) {
-    facts.diagnostics.push(`${facts.file.path}: structured declarations were bounded at ${MAX_STRUCTURED_SYMBOLS}`);
+  if (facts.symbols.length >= maximumSymbols) {
+    facts.diagnostics.push(
+      `${facts.file.path}: ${declarationBudget.policy} structured declarations were bounded at ` +
+        `${declarationBudget.maximumDeclarations}`,
+    );
   }
 }
 

--- a/src/code_graph/languages/schemas/pack.ts
+++ b/src/code_graph/languages/schemas/pack.ts
@@ -13,7 +13,7 @@ export const codeGraphLanguagePack: CodeGraphLanguagePack = {
         catch: cause =>
           new CodeGraphLanguagePackError(`Could not extract structured facts from ${file.path}.`, {cause}),
       }),
-    version: sha256HexSync('threadnote-structured-schema-extractors-v6-apple-resource-values'),
+    version: sha256HexSync('threadnote-structured-schema-extractors-v7-bounded-generic-objects'),
   },
   files: [
     {kind: 'extension', language: 'sql', role: 'source', value: '.sql'},

--- a/src/code_graph/languages/schemas/policy.ts
+++ b/src/code_graph/languages/schemas/policy.ts
@@ -11,3 +11,28 @@ export function isLowSignalStructuredPath(path: string): boolean {
 export function isRecognizedStructuredPath(path: string): boolean {
   return RECOGNIZED_STRUCTURED_PATH.test(path);
 }
+
+export const GENERIC_STRUCTURED_DECLARATION_LIMIT = 256;
+export const RECOGNIZED_STRUCTURED_DECLARATION_LIMIT = 2_048;
+export const RESOURCE_STRUCTURED_DECLARATION_LIMIT = 512;
+
+export interface StructuredObjectDeclarationBudget {
+  readonly maximumDepth: number;
+  /** Excludes the always-present file module symbol. */
+  readonly maximumDeclarations: number;
+  readonly policy: 'generic' | 'recognized' | 'resource';
+}
+
+/**
+ * Generic JSON/YAML is useful as a bounded shape, not as an exhaustive leaf-property database.
+ * Recognized configs and resource wiring retain a larger declaration surface.
+ */
+export function structuredObjectDeclarationBudget(path: string): StructuredObjectDeclarationBudget {
+  if (/(?:^|\/)[^/]+\.xcassets\/.*\/Contents\.json$/iu.test(path)) {
+    return {maximumDeclarations: RESOURCE_STRUCTURED_DECLARATION_LIMIT, maximumDepth: 16, policy: 'resource'};
+  }
+  if (isRecognizedStructuredPath(path)) {
+    return {maximumDeclarations: RECOGNIZED_STRUCTURED_DECLARATION_LIMIT, maximumDepth: 32, policy: 'recognized'};
+  }
+  return {maximumDeclarations: GENERIC_STRUCTURED_DECLARATION_LIMIT, maximumDepth: 8, policy: 'generic'};
+}

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -111,16 +111,6 @@ export function observationFromCodeGraphStatus(status: CodeGraphStatus): CodeGra
   return (status as ObservedCodeGraphStatus)[CODE_GRAPH_STATUS_OBSERVATION];
 }
 
-/** A ready snapshot from the previous commit remains safe for non-strict reads when the worktree itself is clean. */
-export function canUseReadySnapshotAfterCleanCommitChange(status: CodeGraphStatus): boolean {
-  const observation = observationFromCodeGraphStatus(status);
-  return (
-    status.readySnapshot !== undefined &&
-    status.readySnapshot.commit !== status.identity.headCommit &&
-    observation?.overlay.dirty === false
-  );
-}
-
 /**
  * Decide whether a shared clean ready snapshot can be promoted onto this worktree
  * without inventory or rematerialization.

--- a/src/code_graph/storage.ts
+++ b/src/code_graph/storage.ts
@@ -27,11 +27,17 @@ export interface CodeGraphStorageThreshold {
   readonly minimumReclaimableBytes: number;
   readonly minimumReclaimableRatio: number;
   readonly recommended: boolean;
+  readonly reason?: 'freelist' | 'freelist-and-fragmentation';
 }
 
 export interface CodeGraphPageStorage {
   readonly attribution?: CodeGraphStorageAttribution;
+  /** Freelist bytes plus measured unused space inside live B-tree pages. */
+  readonly compactionOpportunityBytes?: number;
+  readonly compactionOpportunityRatio?: number;
   readonly freelistPages: number;
+  readonly fragmentedBytes?: number;
+  readonly fragmentationRatio?: number;
   readonly pageCount: number;
   readonly pageSize: number;
   readonly reclaimableBytes: number;
@@ -55,6 +61,8 @@ export interface CodeGraphStorageAttributionAvailable {
   /** Bytes assigned by SQLite dbstat to named B-trees. */
   readonly attributedBytes: number;
   readonly freelistBytes: number;
+  /** Unused payload capacity inside live B-tree pages, measured by SQLite dbstat. */
+  readonly fragmentedBytes: number;
   readonly objectCount: number;
   readonly objects: readonly CodeGraphStorageObjectAttribution[];
   readonly objectsTruncated: boolean;
@@ -87,6 +95,56 @@ export function codeGraphStorageUnattributedBytes(
     throw new Error('SQLite storage attribution exceeds allocated page bytes.');
   }
   return allocatedBytes - attributedBytes - freelistBytes;
+}
+
+/**
+ * Recommends VACUUM from either fully free pages or the combined footprint of
+ * free pages and unused capacity left by write churn inside live B-tree pages.
+ */
+export function codeGraphCompactionRecommendation(input: {
+  readonly allocatedBytes: number;
+  readonly fragmentedBytes: number;
+  readonly reclaimableBytes: number;
+}): CodeGraphStorageThreshold & {
+  readonly compactionOpportunityBytes: number;
+  readonly compactionOpportunityRatio: number;
+} {
+  const {allocatedBytes, fragmentedBytes, reclaimableBytes} = input;
+  for (const [label, value] of [
+    ['allocated', allocatedBytes],
+    ['fragmented', fragmentedBytes],
+    ['reclaimable', reclaimableBytes],
+  ] as const) {
+    if (!Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid SQLite ${label} storage bytes.`);
+  }
+  const compactionOpportunityBytes = reclaimableBytes + fragmentedBytes;
+  if (
+    !Number.isSafeInteger(compactionOpportunityBytes) ||
+    reclaimableBytes > allocatedBytes ||
+    compactionOpportunityBytes > allocatedBytes
+  ) {
+    throw new Error('SQLite compaction opportunity exceeds allocated page bytes.');
+  }
+  const reclaimableRatio = allocatedBytes === 0 ? 0 : reclaimableBytes / allocatedBytes;
+  const compactionOpportunityRatio = allocatedBytes === 0 ? 0 : compactionOpportunityBytes / allocatedBytes;
+  const freelistRecommended =
+    reclaimableBytes >= CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_BYTES &&
+    reclaimableRatio >= CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_RATIO;
+  const fragmentationRecommended =
+    compactionOpportunityBytes >= CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_BYTES &&
+    compactionOpportunityRatio >= CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_RATIO;
+  return {
+    compactionOpportunityBytes,
+    compactionOpportunityRatio,
+    minimumReclaimableBytes: CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_BYTES,
+    minimumReclaimableRatio: CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_RATIO,
+    recommended: freelistRecommended || fragmentationRecommended,
+    ...((freelistRecommended
+      ? {reason: 'freelist'}
+      : fragmentationRecommended
+        ? {reason: 'freelist-and-fragmentation'}
+        : {}) satisfies Pick<CodeGraphStorageThreshold, 'reason'>),
+  };
 }
 
 export interface CodeGraphDeferredPageStorage {
@@ -171,6 +229,8 @@ export const inspectCodeGraphStorage = Effect.fn('codeGraph.inspectStorage')(fun
   checkoutId: string,
   options: {
     readonly attributeObjects?: boolean;
+    /** Measure live-page fragmentation without collecting full semantic attribution. */
+    readonly measureFragmentation?: boolean;
     readonly openWhileLocked?: boolean;
     /** Current TEMP database bytes reported by an active build status. */
     readonly temporaryBytes?: number;
@@ -204,7 +264,11 @@ export const inspectCodeGraphStorage = Effect.fn('codeGraph.inspectStorage')(fun
   } as const;
   const pageStorage = locked
     ? ({reason: 'active-build', state: 'deferred', threshold} satisfies CodeGraphDeferredPageStorage)
-    : yield* readPageStorage(databasePath, options.attributeObjects === true).pipe(
+    : yield* readPageStorage(
+        databasePath,
+        options.attributeObjects === true,
+        options.measureFragmentation === true,
+      ).pipe(
         Effect.catch(() =>
           Effect.succeed({
             reason: 'database-busy-or-unreadable',
@@ -280,7 +344,10 @@ export const compactCodeGraphStorage = Effect.fn('codeGraph.compactStorage')(fun
         threadnoteHome,
         checkoutId,
         Effect.gen(function* () {
-          const before = yield* inspectCodeGraphStorage(threadnoteHome, checkoutId, {openWhileLocked: true});
+          const before = yield* inspectCodeGraphStorage(threadnoteHome, checkoutId, {
+            measureFragmentation: true,
+            openWhileLocked: true,
+          });
           if (before.state === 'missing') {
             return {
               action: 'missing',
@@ -314,7 +381,7 @@ export const compactCodeGraphStorage = Effect.fn('codeGraph.compactStorage')(fun
               checkoutId,
               databasePath,
               dryRun: true,
-              reclaimedBytes: before.pageStorage.reclaimableBytes,
+              reclaimedBytes: before.pageStorage.compactionOpportunityBytes ?? before.pageStorage.reclaimableBytes,
             } satisfies CodeGraphCompactionSummary;
           }
           yield* verifyCompactionDiskHeadroom(system, path.dirname(databasePath), before);
@@ -428,7 +495,11 @@ function regularFileBytes(
   });
 }
 
-function readPageStorage(databasePath: string, attributeObjects: boolean): Effect.Effect<CodeGraphPageStorage, Error> {
+function readPageStorage(
+  databasePath: string,
+  attributeObjects: boolean,
+  measureFragmentation: boolean,
+): Effect.Effect<CodeGraphPageStorage, Error> {
   return Effect.try({
     try: () => {
       const database = new Database(databasePath, {readonly: true, strict: true});
@@ -442,21 +513,35 @@ function readPageStorage(databasePath: string, attributeObjects: boolean): Effec
         const attribution = attributeObjects
           ? readStorageAttribution(database, pageCount, pageSize, reclaimableBytes)
           : undefined;
+        const measuredFragmentedBytes =
+          attribution?.state === 'available'
+            ? attribution.fragmentedBytes
+            : measureFragmentation
+              ? readFragmentedStorageBytes(database)
+              : undefined;
+        const fragmentedBytes = measuredFragmentedBytes ?? 0;
+        const recommendation = codeGraphCompactionRecommendation({
+          allocatedBytes: safeProduct(pageSize, pageCount, 'allocated storage bytes'),
+          fragmentedBytes,
+          reclaimableBytes,
+        });
         return {
           ...(attribution ? {attribution} : {}),
+          ...(measuredFragmentedBytes !== undefined
+            ? {
+                compactionOpportunityBytes: recommendation.compactionOpportunityBytes,
+                compactionOpportunityRatio: recommendation.compactionOpportunityRatio,
+                fragmentedBytes,
+                fragmentationRatio: pageCount === 0 ? 0 : fragmentedBytes / (pageCount * pageSize),
+              }
+            : {}),
           freelistPages,
           pageCount,
           pageSize,
           reclaimableBytes,
           reclaimableRatio,
           state: 'available',
-          threshold: {
-            minimumReclaimableBytes: CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_BYTES,
-            minimumReclaimableRatio: CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_RATIO,
-            recommended:
-              reclaimableBytes >= CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_BYTES &&
-              reclaimableRatio >= CODE_GRAPH_COMPACTION_MIN_RECLAIMABLE_RATIO,
-          },
+          threshold: recommendation,
         } satisfies CodeGraphPageStorage;
       } finally {
         database.close(false);
@@ -464,6 +549,17 @@ function readPageStorage(databasePath: string, attributeObjects: boolean): Effec
     },
     catch: cause => new Error(`Could not inspect code graph page storage: ${errorText(cause)}`),
   });
+}
+
+function readFragmentedStorageBytes(database: Database): number | undefined {
+  const dbstat = database.query("SELECT sqlite_compileoption_used('ENABLE_DBSTAT_VTAB') AS enabled").get() as {
+    readonly enabled: bigint | number;
+  } | null;
+  if (safeCount(dbstat?.enabled ?? 0, 'dbstat availability') !== 1) return undefined;
+  const row = database.query('SELECT COALESCE(SUM(unused), 0) AS bytes FROM dbstat').get() as {
+    readonly bytes: bigint | number;
+  } | null;
+  return safeCount(row?.bytes ?? 0, 'fragmented storage bytes');
 }
 
 function readStorageAttribution(
@@ -490,6 +586,7 @@ function readStorageAttribution(
               SUM(dbstat.pgsize) AS bytes,
               COUNT(*) AS pages,
               SUM(SUM(dbstat.pgsize)) OVER () AS total_bytes,
+              SUM(SUM(dbstat.unused)) OVER () AS total_unused_bytes,
               COUNT(*) OVER () AS object_count
          FROM dbstat
          LEFT JOIN sqlite_schema AS schema ON schema.name = dbstat.name
@@ -504,6 +601,7 @@ function readStorageAttribution(
     readonly object_count: bigint | number;
     readonly pages: bigint | number;
     readonly total_bytes: bigint | number;
+    readonly total_unused_bytes: bigint | number;
   }[];
   const semanticRows = rows.slice(0, CODE_GRAPH_STORAGE_SEMANTIC_OBJECT_LIMIT).map(row => ({
     bytes: safeCount(row.bytes, `storage object ${safeStorageObjectName(row.name)} bytes`),
@@ -511,6 +609,7 @@ function readStorageAttribution(
     pages: safeCount(row.pages, `storage object ${safeStorageObjectName(row.name)} pages`),
   }));
   const attributedBytes = safeCount(rows[0]?.total_bytes ?? 0, 'attributed storage bytes');
+  const fragmentedBytes = safeCount(rows[0]?.total_unused_bytes ?? 0, 'fragmented storage bytes');
   const objectCount = safeCount(rows[0]?.object_count ?? 0, 'attributed storage objects');
   const objectsTruncated = objectCount > CODE_GRAPH_STORAGE_ATTRIBUTION_OBJECT_LIMIT;
   const objects = rows.slice(0, CODE_GRAPH_STORAGE_ATTRIBUTION_OBJECT_LIMIT).map(row => ({
@@ -524,6 +623,7 @@ function readStorageAttribution(
     allocatedBytes,
     attributedBytes,
     freelistBytes,
+    fragmentedBytes,
     objectCount,
     objects,
     objectsTruncated,

--- a/src/code_graph/storage_attribution.ts
+++ b/src/code_graph/storage_attribution.ts
@@ -1,5 +1,6 @@
 import {Database} from 'bun:sqlite';
 import {storedCodeGraphFactRawBytesSql} from './fact_storage.js';
+import {BUILTIN_LANGUAGE_PACK_REGISTRY} from './languages/registry.js';
 
 export const CODE_GRAPH_STORAGE_SNAPSHOT_ATTRIBUTION_LIMIT = 64;
 export const CODE_GRAPH_STORAGE_SEMANTIC_OBJECT_LIMIT = 512;
@@ -25,6 +26,7 @@ export interface CodeGraphSnapshotStorageAttribution {
   readonly active: boolean;
   readonly associatedFactRawBytes: number;
   readonly associatedFactStoredBytes: number;
+  readonly classifiers: readonly CodeGraphClassifierStorageAttribution[];
   readonly commit: string;
   readonly completedAt?: string;
   readonly edgeCount: number;
@@ -33,6 +35,19 @@ export interface CodeGraphSnapshotStorageAttribution {
   readonly logicalRows: number;
   readonly state: 'building' | 'failed' | 'ready' | 'retired';
   readonly symbolCount: number;
+}
+
+export interface CodeGraphClassifierStorageAttribution {
+  readonly classifier: string;
+  readonly edgeRows: number;
+  readonly factRawBytes: number;
+  readonly factStoredBytes: number;
+  readonly files: number;
+  readonly logicalBytes: number;
+  readonly logicalRows: number;
+  readonly lookupRows: number;
+  readonly sourceBytes: number;
+  readonly symbolRows: number;
 }
 
 export interface CodeGraphStorageBytesPerSymbolBaseline {
@@ -82,6 +97,11 @@ interface SnapshotLogicalRow {
   readonly logical_bytes: number;
   readonly row_count: number;
   readonly snapshot_id: string;
+}
+
+interface SnapshotClassifierLogicalRow extends SnapshotLogicalRow {
+  readonly language: string;
+  readonly source_bytes: number;
 }
 
 export function readCodeGraphStorageSemanticAttribution(
@@ -279,6 +299,7 @@ function readSnapshotStorageAttribution(
         GROUP BY scope.snapshot_id`,
     )
     .all(...ids) as readonly SnapshotLogicalRow[];
+  const classifierRows = readSnapshotClassifierStorageAttribution(database, ids, values);
   const aggregates = new Map<
     string,
     {factRawBytes: number; factStoredBytes: number; logicalBytes: number; rows: number}
@@ -299,6 +320,7 @@ function readSnapshotStorageAttribution(
       active: row.active === 1,
       associatedFactRawBytes: aggregate.factRawBytes,
       associatedFactStoredBytes: aggregate.factStoredBytes,
+      classifiers: classifierRows.get(row.id) ?? [],
       commit: row.commit_id,
       ...(row.completed_at === null ? {} : {completedAt: row.completed_at}),
       edgeCount: row.edge_count,
@@ -330,6 +352,122 @@ function readSnapshotStorageAttribution(
     snapshotsTruncated,
     state: 'available',
   };
+}
+
+function readSnapshotClassifierStorageAttribution(
+  database: Database,
+  snapshotIds: readonly string[],
+  selectedValues: string,
+): ReadonlyMap<string, readonly CodeGraphClassifierStorageAttribution[]> {
+  const rows = database
+    .query(
+      `WITH selected(snapshot_id) AS (VALUES ${selectedValues})
+       SELECT file.snapshot_id, file.language, 'source' AS group_name, COUNT(*) AS row_count,
+              COALESCE(SUM(file.size), 0) AS source_bytes,
+              COALESCE(SUM(length(CAST(file.path AS BLOB)) + length(CAST(file.content_hash AS BLOB)) +
+                length(CAST(file.language AS BLOB)) + length(CAST(file.mode AS BLOB)) +
+                length(CAST(file.source AS BLOB)) + 8), 0) AS logical_bytes,
+              0 AS fact_raw_bytes
+         FROM snapshot_files AS file JOIN selected ON selected.snapshot_id = file.snapshot_id
+        GROUP BY file.snapshot_id, file.language
+       UNION ALL
+       SELECT association.snapshot_id, file.language, 'facts-cache', COUNT(*), 0,
+              COALESCE(SUM(length(CAST(shard.facts_json AS BLOB))), 0),
+              COALESCE(SUM(${storedCodeGraphFactRawBytesSql('shard.facts_json')}), 0)
+         FROM snapshot_file_shards AS association
+         JOIN selected ON selected.snapshot_id = association.snapshot_id
+         JOIN snapshot_files AS file
+           ON file.snapshot_id = association.snapshot_id AND file.path = association.path
+         JOIN materialized_file_shards AS shard ON shard.id = association.shard_id
+        GROUP BY association.snapshot_id, file.language
+       UNION ALL
+       SELECT symbol.snapshot_id, file.language, 'symbols', COUNT(*), 0,
+              COALESCE(SUM(length(CAST(symbol.id AS BLOB)) + length(CAST(symbol.content_hash AS BLOB)) +
+                length(CAST(symbol.kind AS BLOB)) + length(CAST(symbol.name AS BLOB)) +
+                length(CAST(symbol.qualified_name AS BLOB)) + length(CAST(symbol.path AS BLOB)) +
+                length(CAST(symbol.language AS BLOB)) + length(CAST(symbol.lookup_keys_json AS BLOB)) +
+                length(CAST(COALESCE(symbol.resolution_domain, '') AS BLOB)) +
+                length(CAST(COALESCE(symbol.resolution_scope_id, '') AS BLOB)) +
+                length(CAST(COALESCE(symbol.package_name, '') AS BLOB)) +
+                length(CAST(COALESCE(symbol.signature, '') AS BLOB)) +
+                length(CAST(COALESCE(symbol.documentation, '') AS BLOB)) +
+                length(CAST(symbol.span_json AS BLOB)) + 8 + CASE WHEN symbol.arity IS NULL THEN 0 ELSE 8 END), 0), 0
+         FROM symbols AS symbol JOIN selected ON selected.snapshot_id = symbol.snapshot_id
+         JOIN snapshot_files AS file ON file.snapshot_id = symbol.snapshot_id AND file.path = symbol.path
+        GROUP BY symbol.snapshot_id, file.language
+       UNION ALL
+       SELECT edge.snapshot_id, file.language, 'edges', COUNT(*), 0,
+              COALESCE(SUM(length(CAST(edge.id AS BLOB)) + length(CAST(COALESCE(edge.source_id, '') AS BLOB)) +
+                length(CAST(edge.source_name AS BLOB)) + length(CAST(edge.relation AS BLOB)) +
+                length(CAST(COALESCE(edge.target_id, '') AS BLOB)) + length(CAST(edge.target_name AS BLOB)) +
+                length(CAST(edge.provenance AS BLOB)) + length(CAST(edge.evidence_path AS BLOB)) +
+                length(CAST(edge.evidence_span_json AS BLOB)) + 8), 0), 0
+         FROM edges AS edge JOIN selected ON selected.snapshot_id = edge.snapshot_id
+         JOIN snapshot_files AS file ON file.snapshot_id = edge.snapshot_id AND file.path = edge.evidence_path
+        GROUP BY edge.snapshot_id, file.language
+       UNION ALL
+       SELECT lookup.snapshot_id, file.language, 'lookup', COUNT(*), 0,
+              COALESCE(SUM(length(CAST(lookup.lookup_key AS BLOB)) + length(CAST(lookup.symbol_id AS BLOB)) +
+                length(CAST(lookup.resolution_domain AS BLOB)) + length(CAST(lookup.provenance AS BLOB)) +
+                length(CAST(COALESCE(lookup.evidence_edge_id, '') AS BLOB)) +
+                length(CAST(COALESCE(lookup.evidence_path, '') AS BLOB)) + 8), 0), 0
+         FROM snapshot_symbol_lookup AS lookup JOIN selected ON selected.snapshot_id = lookup.snapshot_id
+         JOIN symbols AS symbol ON symbol.snapshot_id = lookup.snapshot_id AND symbol.id = lookup.symbol_id
+         JOIN snapshot_files AS file ON file.snapshot_id = symbol.snapshot_id AND file.path = symbol.path
+        GROUP BY lookup.snapshot_id, file.language`,
+    )
+    .all(...snapshotIds) as readonly SnapshotClassifierLogicalRow[];
+  const aggregates = new Map<string, Map<string, CodeGraphClassifierStorageAttribution>>();
+  for (const row of rows) {
+    if (typeof row.language !== 'string' || typeof row.group_name !== 'string') {
+      throw new Error('Code graph classifier storage attribution is invalid.');
+    }
+    const classifier = codeGraphStorageClassifierForLanguage(row.language);
+    const byClassifier = aggregates.get(row.snapshot_id) ?? new Map<string, CodeGraphClassifierStorageAttribution>();
+    if (!aggregates.has(row.snapshot_id)) aggregates.set(row.snapshot_id, byClassifier);
+    const current = byClassifier.get(classifier) ?? {
+      classifier,
+      edgeRows: 0,
+      factRawBytes: 0,
+      factStoredBytes: 0,
+      files: 0,
+      logicalBytes: 0,
+      logicalRows: 0,
+      lookupRows: 0,
+      sourceBytes: 0,
+      symbolRows: 0,
+    };
+    const rowCount = safeAggregate(row.row_count);
+    const logicalBytes = safeAggregate(row.logical_bytes);
+    const next = {
+      ...current,
+      edgeRows: current.edgeRows + (row.group_name === 'edges' ? rowCount : 0),
+      factRawBytes: current.factRawBytes + (row.group_name === 'facts-cache' ? safeAggregate(row.fact_raw_bytes) : 0),
+      factStoredBytes: current.factStoredBytes + (row.group_name === 'facts-cache' ? logicalBytes : 0),
+      files: current.files + (row.group_name === 'source' ? rowCount : 0),
+      logicalBytes: current.logicalBytes + logicalBytes,
+      logicalRows: current.logicalRows + rowCount,
+      lookupRows: current.lookupRows + (row.group_name === 'lookup' ? rowCount : 0),
+      sourceBytes: current.sourceBytes + (row.group_name === 'source' ? safeAggregate(row.source_bytes) : 0),
+      symbolRows: current.symbolRows + (row.group_name === 'symbols' ? rowCount : 0),
+    } satisfies CodeGraphClassifierStorageAttribution;
+    byClassifier.set(classifier, next);
+  }
+  return new Map(
+    [...aggregates].map(([snapshotId, values]) => [
+      snapshotId,
+      [...values.values()].sort(
+        (left, right) => right.logicalBytes - left.logicalBytes || left.classifier.localeCompare(right.classifier),
+      ),
+    ]),
+  );
+}
+
+export function codeGraphStorageClassifierForLanguage(language: string): string {
+  for (const pack of BUILTIN_LANGUAGE_PACK_REGISTRY.packs) {
+    if (pack.files.some(matcher => matcher.language === language)) return pack.id;
+  }
+  return 'unmatched';
 }
 
 function validateSnapshotMetadata(rows: readonly SnapshotMetadataRow[]): void {

--- a/src/code_graph/store_activation.ts
+++ b/src/code_graph/store_activation.ts
@@ -337,7 +337,13 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
           compactLexicalReceipt.postingCount,
           expectedCompactSymbols,
         );
-        if (baseSnapshotId) yield* inheritSnapshotFileShards(sql, snapshot.id, baseSnapshotId);
+        // Dirty overlays keep their clean base reachable and are never selected
+        // as reusable clean roots, so duplicating every unchanged shard
+        // association would add repository-sized publication work for no cache
+        // ownership benefit.
+        if (baseSnapshotId && !snapshot.dirty) {
+          yield* inheritSnapshotFileShards(sql, snapshot.id, baseSnapshotId);
+        }
         yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
       }
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
@@ -650,7 +656,7 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
           Number(staged.terms),
           Number(staged.symbols),
         );
-        yield* inheritSnapshotFileShards(sql, snapshot.id, baseSnapshotId);
+        if (!snapshot.dirty) yield* inheritSnapshotFileShards(sql, snapshot.id, baseSnapshotId);
         yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
       }
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);

--- a/src/code_graph/store_activation.ts
+++ b/src/code_graph/store_activation.ts
@@ -30,6 +30,7 @@ import {identifyChangedSymbols} from './store_resolution_core.js';
 import {associateSnapshotFileShards, inheritSnapshotFileShards} from './store_cache.js';
 import {insertActivationLease, recordSnapshotExtractorGeneration} from './store_maintenance_core.js';
 import {selectReusableBaseReceipt} from './store_queries.js';
+import {recordSnapshotPackProvenance} from './store_pack_provenance.js';
 
 /** Exact read-only admission shared by cleanup writers and both health paths. */
 
@@ -375,6 +376,7 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
             ${new Date().toISOString()}
           FROM activation_symbol_lookup
         `;
+        yield* recordSnapshotPackProvenance(sql, snapshot.id, reusableBaseReceipt.packProvenance);
       }
       yield* insertActivationLease(sql, snapshot.id, promotionLease);
       if (activated) {

--- a/src/code_graph/store_activation_persistent.ts
+++ b/src/code_graph/store_activation_persistent.ts
@@ -51,6 +51,7 @@ import {associateSnapshotFileShards} from './store_cache.js';
 import {insertActivationLease, recordSnapshotExtractorGeneration} from './store_maintenance_core.js';
 import {type CodeGraphSqlQueryStatement} from './store_visualization_sql.js';
 import {selectReusableBaseReceipt} from './store_queries.js';
+import {recordSnapshotPackProvenance} from './store_pack_provenance.js';
 import {
   materializeSnapshotComponentEdgeAggregates,
   selectPersistedSnapshotComponentEdges,
@@ -320,6 +321,7 @@ const activateCleanStagedSnapshot = Effect.fn('codeGraph.activateCleanStagedSnap
             ${new Date().toISOString()}
           )
         `;
+        yield* recordSnapshotPackProvenance(sql, snapshot.id, reusableBaseReceipt.packProvenance);
       }
       yield* insertActivationLease(sql, snapshot.id, promotionLease);
       yield* observe('recording-completion', 'started');
@@ -670,6 +672,7 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
             ${new Date().toISOString()}
           )
         `;
+            yield* recordSnapshotPackProvenance(sql, snapshot.id, reusableBaseReceipt.packProvenance);
           }
           yield* insertActivationLease(sql, snapshot.id, promotionLease);
           const completed = yield* sql<{readonly id: string}>`

--- a/src/code_graph/store_activation_persistent.ts
+++ b/src/code_graph/store_activation_persistent.ts
@@ -352,7 +352,7 @@ export function codeGraphPersistedEndpointValidationPageStatement(
   pageRows = PERSISTENT_ACTIVATION_ENDPOINT_VALIDATION_PAGE_ROWS,
 ): CodeGraphSqlQueryStatement {
   const column = endpoint === 'source' ? 'source_id' : 'target_id';
-  const index = endpoint === 'source' ? 'edges_source' : 'edges_target';
+  const index = endpoint === 'source' ? 'edges_source' : 'edges_target_resolved';
   const cursorPredicate = Option.isSome(cursor) ? `AND edge.${column} > ?` : '';
   return {
     parameters: [snapshotId, ...Option.toArray(cursor), pageRows, snapshotId],
@@ -387,7 +387,7 @@ function persistedEndpointEdgeStatement(
   symbolId: string,
 ): CodeGraphSqlQueryStatement {
   const column = endpoint === 'source' ? 'source_id' : 'target_id';
-  const index = endpoint === 'source' ? 'edges_source' : 'edges_target';
+  const index = endpoint === 'source' ? 'edges_source' : 'edges_target_resolved';
   return {
     parameters: [snapshotId, symbolId],
     text: `SELECT edge.id

--- a/src/code_graph/store_cleanup_core.ts
+++ b/src/code_graph/store_cleanup_core.ts
@@ -680,6 +680,12 @@ const RETIRED_SNAPSHOT_CLEANUP_SPECS = [
   },
   {
     batchRows: 1_000,
+    keyColumns: ['snapshot_id', 'pack_id'],
+    maximumBatchRows: 1_000,
+    table: 'snapshot_pack_provenance',
+  },
+  {
+    batchRows: 1_000,
     keyColumns: ['snapshot_id'],
     maximumBatchRows: 1_000,
     table: 'snapshot_extractor_generations',

--- a/src/code_graph/store_failure.ts
+++ b/src/code_graph/store_failure.ts
@@ -182,18 +182,21 @@ function collectFailureEvidence(root: unknown): FailureEvidence {
     }
     const code = safeField(value, 'code');
     const errno = safeField(value, 'errno');
+    const name = safeField(value, 'name');
     const tag = safeField(value, '_tag');
     const normalizedCode = stableToken(code);
     const normalizedErrno = stableToken(errno);
     if (normalizedCode) tokens.add(normalizedCode);
     if (normalizedErrno) tokens.add(normalizedErrno);
+    if (typeof name === 'string' && /^[A-Za-z][A-Za-z0-9]{0,79}$/u.test(name)) tags.add(name);
     if (typeof tag === 'string' && /^[A-Za-z][A-Za-z0-9]{0,79}$/u.test(tag)) tags.add(tag);
     if (typeof code === 'number' && Number.isSafeInteger(code) && code >= 0) {
       sqlitePrimaryCodes.add(code & 0xff);
     }
     if (typeof errno === 'number' && Number.isSafeInteger(errno)) {
-      if (normalizedCode?.startsWith('SQLITE_')) sqlitePrimaryCodes.add(Math.abs(errno) & 0xff);
-      else osErrnos.add(Math.abs(errno));
+      if (normalizedCode?.startsWith('SQLITE_') || name === 'SQLiteError') {
+        sqlitePrimaryCodes.add(Math.abs(errno) & 0xff);
+      } else osErrnos.add(Math.abs(errno));
     }
     for (const field of ['cause', 'reason'] as const) {
       enqueue(safeField(value, field), current.depth + 1);

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -24,7 +24,16 @@ export const CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION = 2 as const;
 
 export interface CodeGraphReusableBaseReceiptInput {
   readonly fileSetFingerprint: string;
+  readonly packProvenance: readonly CodeGraphLanguagePackProvenance[];
   readonly workspaceFingerprint: string;
+}
+
+export interface CodeGraphLanguagePackProvenance {
+  readonly cacheIdentity: string;
+  readonly derivationIdentity: string;
+  readonly id: string;
+  readonly resolutionDomain: string;
+  readonly resolutionVersion: string;
 }
 
 export interface CodeGraphReusableBaseReceipt extends CodeGraphReusableBaseReceiptInput {

--- a/src/code_graph/store_pack_provenance.ts
+++ b/src/code_graph/store_pack_provenance.ts
@@ -1,0 +1,27 @@
+import {Effect} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import type {CodeGraphLanguagePackProvenance} from './store_models.js';
+import {CodeGraphStoreError} from './types.js';
+
+export const recordSnapshotPackProvenance = Effect.fn('codeGraph.recordSnapshotPackProvenance')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  provenance: readonly CodeGraphLanguagePackProvenance[],
+) {
+  const ids = new Set<string>();
+  for (const pack of provenance) {
+    if (!pack.id || ids.has(pack.id)) {
+      return yield* Effect.fail(new CodeGraphStoreError('Code graph language-pack provenance is invalid.'));
+    }
+    ids.add(pack.id);
+    yield* sql`
+      INSERT INTO snapshot_pack_provenance (
+        snapshot_id, pack_id, cache_identity, derivation_identity,
+        resolution_domain, resolution_version
+      ) VALUES (
+        ${snapshotId}, ${pack.id}, ${pack.cacheIdentity}, ${pack.derivationIdentity},
+        ${pack.resolutionDomain}, ${pack.resolutionVersion}
+      )
+    `;
+  }
+});

--- a/src/code_graph/store_persistent_build.ts
+++ b/src/code_graph/store_persistent_build.ts
@@ -31,6 +31,7 @@ import {lastStatementChangeCount} from './store_activation_core.js';
 import {pruneRetiredSnapshotRows} from './store_retirement.js';
 import {chunk, uniqueBy, upsertRepository} from './store_utilities.js';
 import {
+  reclaimRetiredSnapshotPage,
   reclaimRetiredSnapshotRows,
   REEXPORT_CLOSURE_PAGE_MAXIMUM_ROWS,
   REEXPORT_CLOSURE_SEED_PAGE_ROWS,
@@ -171,6 +172,7 @@ const retireIncompleteWorktreeSnapshots = Effect.fn('codeGraph.retireIncompleteW
   retainedSnapshotIds: ReadonlySet<string>,
   writerGate?: CodeGraphWriterGate,
   onProgress?: CodeGraphRetiredSnapshotCleanupProgressCallback,
+  cleanupMode: 'deferred' | 'required' = 'required',
 ) {
   const sql = yield* SqlClient.SqlClient;
   yield* configureConnection(sql);
@@ -256,18 +258,32 @@ const retireIncompleteWorktreeSnapshots = Effect.fn('codeGraph.retireIncompleteW
       }),
     ),
   );
-  if (result.reclaimable.length > 0) {
+  if (cleanupMode === 'required' && result.reclaimable.length > 0) {
     yield* reclaimRetiredSnapshotRows(sql, result.reclaimable, runWrite, onProgress);
+  } else if (result.reclaimable.length > 0) {
+    const targets = result.reclaimable.slice(0, 100);
+    yield* onProgress?.({
+      pagesCompleted: 0,
+      rowsDeleted: 0,
+      snapshotsCompleted: 0,
+      snapshotsTotal: result.reclaimable.length,
+    }) ?? Effect.void;
+    const page = yield* runWrite(sql.withTransaction(reclaimRetiredSnapshotPage(sql, targets)));
+    yield* onProgress?.({
+      pagesCompleted: 1,
+      rowsDeleted: page.rowsDeleted,
+      snapshotsCompleted: page.complete ? targets.length : 0,
+      snapshotsTotal: result.reclaimable.length,
+    }) ?? Effect.void;
   }
-  return result.retired;
+  return {reclaimable: result.reclaimable.length, retired: result.retired};
 });
 
 /**
- * Superseded persistent builds can own repository-sized durable tables. Reclaim
- * their exact identities before the replacement build starts, one transaction
- * at a time. The writer gate is released between pages so linked worktrees can
- * make progress; unlike best-effort detached cleanup, this required path waits
- * through contention until every still-eligible target is gone.
+ * Superseded persistent builds can own repository-sized durable tables. The
+ * required mode reclaims their exact identities before replacement work; the
+ * indexer uses deferred mode so ordinary ready-snapshot reuse only performs the
+ * bounded retirement transaction and hands physical pages to routine cleanup.
  */
 
 const finalizePersistentMaterializationPlan = Effect.fn('codeGraph.finalizePersistentMaterializationPlan')(function* (

--- a/src/code_graph/store_queries.ts
+++ b/src/code_graph/store_queries.ts
@@ -139,16 +139,17 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
   fileSetFingerprint: string,
   graphContentId?: string,
   preferredCommitGroups?: readonly (readonly string[])[],
+  allowExtractorMismatch = false,
 ) {
   const sql = yield* SqlClient.SqlClient;
   yield* configureConnection(sql);
-  if (graphContentId !== undefined) {
+  if (graphContentId !== undefined && !allowExtractorMismatch) {
     const exactCandidates = yield* sql<SnapshotRow>`
       SELECT snapshot.*
       FROM snapshots AS snapshot
       JOIN snapshot_reuse_receipts AS receipt ON receipt.snapshot_id = snapshot.id
       WHERE snapshot.repository_id = ${repositoryId}
-        AND snapshot.extractor_set = ${extractorSet}
+        AND (${allowExtractorMismatch ? 1 : 0} = 1 OR snapshot.extractor_set = ${extractorSet})
         AND snapshot.state = 'ready'
         AND snapshot.dirty = 0
         AND snapshot.base_snapshot_id IS NULL
@@ -182,7 +183,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
       FROM snapshots AS snapshot
       JOIN snapshot_reuse_receipts AS receipt ON receipt.snapshot_id = snapshot.id
       WHERE snapshot.repository_id = ${repositoryId}
-        AND snapshot.extractor_set = ${extractorSet}
+        AND (${allowExtractorMismatch ? 1 : 0} = 1 OR snapshot.extractor_set = ${extractorSet})
         AND snapshot.state = 'ready'
         AND snapshot.dirty = 0
         AND snapshot.base_snapshot_id IS NULL
@@ -202,7 +203,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
         FROM snapshots AS snapshot
         JOIN snapshot_reuse_receipts AS receipt ON receipt.snapshot_id = snapshot.id
         WHERE snapshot.repository_id = ${repositoryId}
-          AND snapshot.extractor_set = ${extractorSet}
+          AND (${allowExtractorMismatch ? 1 : 0} = 1 OR snapshot.extractor_set = ${extractorSet})
           AND snapshot.state = 'ready'
           AND snapshot.dirty = 0
           AND snapshot.base_snapshot_id IS NULL
@@ -211,6 +212,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
           AND receipt.resolution_surface_version = 1
           AND receipt.workspace_fingerprint = ${workspaceFingerprint}
         ORDER BY
+          CASE WHEN snapshot.extractor_set = ${extractorSet} THEN 0 ELSE 1 END,
           CASE WHEN receipt.file_set_fingerprint = ${fileSetFingerprint} THEN 0 ELSE 1 END,
           snapshot.completed_at DESC,
           snapshot.id
@@ -226,7 +228,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
     FROM snapshots AS snapshot
     JOIN snapshot_reuse_receipts AS receipt ON receipt.snapshot_id = snapshot.id
     WHERE snapshot.repository_id = ${repositoryId}
-      AND snapshot.extractor_set = ${extractorSet}
+      AND (${allowExtractorMismatch ? 1 : 0} = 1 OR snapshot.extractor_set = ${extractorSet})
       AND snapshot.state = 'ready'
       AND snapshot.dirty = 0
       AND snapshot.base_snapshot_id IS NULL
@@ -234,6 +236,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
       AND receipt.resolution_surface_version = 1
       AND receipt.workspace_fingerprint = ${workspaceFingerprint}
     ORDER BY
+      CASE WHEN snapshot.extractor_set = ${extractorSet} THEN 0 ELSE 1 END,
       CASE WHEN receipt.file_set_fingerprint = ${fileSetFingerprint} THEN 0 ELSE 1 END,
       snapshot.completed_at DESC,
       snapshot.id
@@ -330,6 +333,18 @@ const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt
   `;
   const row = rows[0];
   if (!row) return undefined;
+  const packProvenance = yield* sql<{
+    readonly cache_identity: string;
+    readonly derivation_identity: string;
+    readonly pack_id: string;
+    readonly resolution_domain: string;
+    readonly resolution_version: string;
+  }>`
+    SELECT pack_id, cache_identity, derivation_identity, resolution_domain, resolution_version
+    FROM snapshot_pack_provenance
+    WHERE snapshot_id = ${snapshotId}
+    ORDER BY pack_id
+  `;
   const lookupCount = Number(row.lookup_count);
   const aliasCount = Number(row.alias_count);
   const reexportCount = Number(row.reexport_count);
@@ -352,6 +367,13 @@ const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt
     fileSetFingerprint: row.file_set_fingerprint,
     formatVersion: Number(row.format_version),
     lookupCount,
+    packProvenance: packProvenance.map(pack => ({
+      cacheIdentity: pack.cache_identity,
+      derivationIdentity: pack.derivation_identity,
+      id: pack.pack_id,
+      resolutionDomain: pack.resolution_domain,
+      resolutionVersion: pack.resolution_version,
+    })),
     reexportCount,
     resolutionSurfaceVersion: Number(row.resolution_surface_version),
     snapshotId: row.snapshot_id,

--- a/src/code_graph/store_query_core.ts
+++ b/src/code_graph/store_query_core.ts
@@ -612,12 +612,12 @@ function effectiveAdjacentEdgesCte(
   const provenancePlaceholders = provenances.map(() => '?').join(', ');
   const axes =
     direction === 'incoming'
-      ? ([{column: 'target_id', index: 'edges_target'}] as const)
+      ? ([{column: 'target_id', index: 'edges_target_resolved'}] as const)
       : direction === 'outgoing'
         ? ([{column: 'source_id', index: 'edges_source'}] as const)
         : ([
             {column: 'source_id', index: 'edges_source'},
-            {column: 'target_id', index: 'edges_target'},
+            {column: 'target_id', index: 'edges_target_resolved'},
           ] as const);
   const branches: string[] = [];
   const parameters: Array<number | string> = [];
@@ -628,6 +628,7 @@ function effectiveAdjacentEdgesCte(
       FROM edges AS current_edges INDEXED BY ${axis.index}
       WHERE current_edges.snapshot_id = ?
         AND current_edges.${axis.column} IN (${idPlaceholders})
+        AND current_edges.${axis.column} IS NOT NULL
         AND current_edges.provenance IN (${provenancePlaceholders})`;
     branches.push(
       boundedBranchLimit === undefined
@@ -642,6 +643,7 @@ function effectiveAdjacentEdgesCte(
       FROM edges AS base_edges INDEXED BY ${axis.index}
       WHERE base_edges.snapshot_id = ?
         AND base_edges.${axis.column} IN (${idPlaceholders})
+        AND base_edges.${axis.column} IS NOT NULL
         AND base_edges.provenance IN (${provenancePlaceholders})
         AND NOT EXISTS (
           SELECT 1 FROM edges AS overrides

--- a/src/code_graph/store_resolution.ts
+++ b/src/code_graph/store_resolution.ts
@@ -824,11 +824,15 @@ const promoteSnapshot = Effect.fn('codeGraph.promoteSnapshot')(function* (
       // displaced just like a lease acquired while the pointer was active.
       yield* markSnapshotLeaseRetirementBaton(sql, snapshotId, now);
       if (displacedSnapshotId === undefined || displacedSnapshotId === snapshotId) return 0;
+      // Dirty overlays cannot be exact future aliases. Recent clean snapshots
+      // remain ready and are bounded by routine per-repository LRU retention,
+      // allowing a dirty edit reverted to HEAD to reuse the exact clean graph.
       yield* sql`
         UPDATE snapshots AS candidate
         SET state = 'retired'
         WHERE candidate.id = ${displacedSnapshotId}
           AND candidate.state = 'ready'
+          AND candidate.dirty = 1
           AND NOT EXISTS (
             SELECT 1 FROM active_snapshots AS active
             WHERE active.snapshot_id = candidate.id

--- a/src/code_graph/store_schema_contracts.ts
+++ b/src/code_graph/store_schema_contracts.ts
@@ -7,6 +7,7 @@ export type CodeGraphPersistentSchemaMigrationPhase =
   | 'created-extensions'
   | 'dropped-incompatible'
   | 'dropped-obsolete-indexes'
+  | 'migrated-query-indexes'
   | 'recorded-revision'
   | 'retired-incompatible-ready'
   | 'retired-incomplete'

--- a/src/code_graph/store_schema_initialization.ts
+++ b/src/code_graph/store_schema_initialization.ts
@@ -359,6 +359,17 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
   `);
   yield* ensureColumn(sql, 'snapshot_reuse_receipts', 'reexport_count', 'INTEGER NOT NULL DEFAULT 0');
   yield* sql.unsafe(`
+    CREATE TABLE IF NOT EXISTS snapshot_pack_provenance (
+      snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+      pack_id TEXT NOT NULL,
+      cache_identity TEXT NOT NULL,
+      derivation_identity TEXT NOT NULL,
+      resolution_domain TEXT NOT NULL,
+      resolution_version TEXT NOT NULL,
+      PRIMARY KEY (snapshot_id, pack_id)
+    ) WITHOUT ROWID
+  `);
+  yield* sql.unsafe(`
     CREATE TABLE IF NOT EXISTS snapshot_reexport_provenance (
       snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
       source_path TEXT NOT NULL,

--- a/src/code_graph/store_schema_initialization.ts
+++ b/src/code_graph/store_schema_initialization.ts
@@ -519,6 +519,7 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
     'CREATE INDEX IF NOT EXISTS symbols_export_order ON symbols(snapshot_id, path, qualified_name, id)',
   );
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS edges_source ON edges(snapshot_id, source_id, relation)');
+  yield* sql.unsafe('CREATE INDEX IF NOT EXISTS edges_evidence_path ON edges(snapshot_id, evidence_path)');
   yield* sql.unsafe(
     'CREATE INDEX IF NOT EXISTS edges_export_order ON edges(snapshot_id, source_name, relation, target_name, id)',
   );

--- a/src/code_graph/store_schema_initialization.ts
+++ b/src/code_graph/store_schema_initialization.ts
@@ -4,7 +4,11 @@ import {REMOVED_VIEWS_TABLE_SQL} from './store_removed_view_schema_contracts.js'
 import {inspectBoundedSchemaMetadataValue} from './store_schema_metadata.js';
 import {configureConnection} from './store_session.js';
 import {CODE_GRAPH_EXTRACTOR_GENERATION, CODE_GRAPH_SCHEMA_VERSION, CodeGraphStoreError} from './types.js';
-import {migratePersistentExtensionTables, preflightRemovedViewCleanupSchema} from './store_schema_migration.js';
+import {
+  ensureCurrentCodeGraphQueryIndexes,
+  migratePersistentExtensionTables,
+  preflightRemovedViewCleanupSchema,
+} from './store_schema_migration.js';
 import {
   CODE_GRAPH_ACTIVE_SNAPSHOT_EXTRACTOR_TRIGGER_SQL,
   ensureColumn,
@@ -461,12 +465,10 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
     ON CONFLICT(singleton) DO NOTHING
   `;
   // Exact lookup uses the NOCASE index and computes case-sensitive rank from
-  // the same rows. Keep one name projection instead of duplicating it.
-  yield* sql.unsafe('DROP INDEX IF EXISTS symbols_name');
+  // the same rows. Query-required index changes are shared with the atomic
+  // persistent-extension upgrade path.
+  yield* ensureCurrentCodeGraphQueryIndexes(sql);
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS symbols_path ON symbols(snapshot_id, path)');
-  // The visualization scope index has this exact leading prefix and also
-  // satisfies documentation-facet filtering.
-  yield* sql.unsafe('DROP INDEX IF EXISTS symbols_resolution_scope');
   yield* sql.unsafe('DROP INDEX IF EXISTS symbols_visualization_scope');
   yield* sql.unsafe('DROP INDEX IF EXISTS symbols_visualization_package');
   yield* sql.unsafe('DROP INDEX IF EXISTS symbols_visualization_path');
@@ -506,14 +508,6 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
     'CREATE INDEX IF NOT EXISTS symbols_export_order ON symbols(snapshot_id, path, qualified_name, id)',
   );
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS edges_source ON edges(snapshot_id, source_id, relation)');
-  // Unresolved edges have no target and are never adjacency candidates. A
-  // partial projection avoids indexing the large unresolved tail twice.
-  yield* sql.unsafe('DROP INDEX IF EXISTS edges_target');
-  yield* sql.unsafe(`
-    CREATE INDEX IF NOT EXISTS edges_target_resolved
-    ON edges(snapshot_id, target_id, relation)
-    WHERE target_id IS NOT NULL
-  `);
   yield* sql.unsafe(
     'CREATE INDEX IF NOT EXISTS edges_export_order ON edges(snapshot_id, source_name, relation, target_name, id)',
   );

--- a/src/code_graph/store_schema_initialization.ts
+++ b/src/code_graph/store_schema_initialization.ts
@@ -460,9 +460,13 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
     ) VALUES (1, 'file-blobs', NULL, NULL, NULL, NULL)
     ON CONFLICT(singleton) DO NOTHING
   `;
-  yield* sql.unsafe('CREATE INDEX IF NOT EXISTS symbols_name ON symbols(snapshot_id, name)');
+  // Exact lookup uses the NOCASE index and computes case-sensitive rank from
+  // the same rows. Keep one name projection instead of duplicating it.
+  yield* sql.unsafe('DROP INDEX IF EXISTS symbols_name');
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS symbols_path ON symbols(snapshot_id, path)');
-  yield* sql.unsafe('CREATE INDEX IF NOT EXISTS symbols_resolution_scope ON symbols(snapshot_id, resolution_scope_id)');
+  // The visualization scope index has this exact leading prefix and also
+  // satisfies documentation-facet filtering.
+  yield* sql.unsafe('DROP INDEX IF EXISTS symbols_resolution_scope');
   yield* sql.unsafe('DROP INDEX IF EXISTS symbols_visualization_scope');
   yield* sql.unsafe('DROP INDEX IF EXISTS symbols_visualization_package');
   yield* sql.unsafe('DROP INDEX IF EXISTS symbols_visualization_path');
@@ -502,7 +506,14 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
     'CREATE INDEX IF NOT EXISTS symbols_export_order ON symbols(snapshot_id, path, qualified_name, id)',
   );
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS edges_source ON edges(snapshot_id, source_id, relation)');
-  yield* sql.unsafe('CREATE INDEX IF NOT EXISTS edges_target ON edges(snapshot_id, target_id, relation)');
+  // Unresolved edges have no target and are never adjacency candidates. A
+  // partial projection avoids indexing the large unresolved tail twice.
+  yield* sql.unsafe('DROP INDEX IF EXISTS edges_target');
+  yield* sql.unsafe(`
+    CREATE INDEX IF NOT EXISTS edges_target_resolved
+    ON edges(snapshot_id, target_id, relation)
+    WHERE target_id IS NOT NULL
+  `);
   yield* sql.unsafe(
     'CREATE INDEX IF NOT EXISTS edges_export_order ON edges(snapshot_id, source_name, relation, target_name, id)',
   );

--- a/src/code_graph/store_schema_migration.ts
+++ b/src/code_graph/store_schema_migration.ts
@@ -198,6 +198,14 @@ const ensureCurrentCodeGraphQueryIndexes = Effect.fn('codeGraph.ensureCurrentQue
     ON edges(snapshot_id, target_id, relation)
     WHERE target_id IS NOT NULL
   `);
+  // Incremental publication must enumerate only the base edges owned by the
+  // changed path closure. Without this index a one-file overlay scans every
+  // edge twice (counting and deletion), retaining repository-sized pager
+  // state inside the ready-state transaction.
+  yield* sql.unsafe(`
+    CREATE INDEX IF NOT EXISTS edges_evidence_path
+    ON edges(snapshot_id, evidence_path)
+  `);
 });
 
 const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentExtensionTables')(function* (
@@ -316,6 +324,7 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
         (recordedRevision === 7 ||
           recordedRevision === 8 ||
           recordedRevision === 9 ||
+          recordedRevision === 10 ||
           recordedRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) &&
         extensionSchemaCompatible
       ) {

--- a/src/code_graph/store_schema_migration.ts
+++ b/src/code_graph/store_schema_migration.ts
@@ -182,6 +182,26 @@ const ensureRemovedViewCleanupSchema = Effect.fn('codeGraph.ensureRemovedViewCle
   }
 });
 
+/** Keep query-required core indexes compatible across additive extension upgrades. */
+const ensureCurrentCodeGraphQueryIndexes = Effect.fn('codeGraph.ensureCurrentQueryIndexes')(function* (
+  sql: SqlClient.SqlClient,
+  replaceResolvedTarget = false,
+) {
+  // These projections are covered by the NOCASE name and visualization scope
+  // indexes. Drop them during the same revision transaction as the target-edge
+  // replacement so an upgraded database cannot advertise the new revision
+  // while retaining only the legacy query surface.
+  yield* sql.unsafe('DROP INDEX IF EXISTS symbols_name');
+  yield* sql.unsafe('DROP INDEX IF EXISTS symbols_resolution_scope');
+  yield* sql.unsafe('DROP INDEX IF EXISTS edges_target');
+  if (replaceResolvedTarget) yield* sql.unsafe('DROP INDEX IF EXISTS edges_target_resolved');
+  yield* sql.unsafe(`
+    CREATE INDEX IF NOT EXISTS edges_target_resolved
+    ON edges(snapshot_id, target_id, relation)
+    WHERE target_id IS NOT NULL
+  `);
+});
+
 const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentExtensionTables')(function* (
   sql: SqlClient.SqlClient,
 ) {
@@ -214,6 +234,13 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
           VALUES (${REMOVED_VIEW_CLEANUP_EPOCH_SEQUENCE_KEY}, '0')
         `;
         yield* observe?.('added-removed-view-cleanup') ?? Effect.void;
+      }
+      if (
+        Number.isSafeInteger(recordedRevision) &&
+        recordedRevision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
+      ) {
+        yield* ensureCurrentCodeGraphQueryIndexes(sql, true);
+        yield* observe?.('migrated-query-indexes') ?? Effect.void;
       }
       if (recordedRevision === 6) {
         const ownerInstances = PERSISTENT_EXTENSION_TABLES.find(
@@ -290,6 +317,7 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
       if (
         (recordedRevision === 7 ||
           recordedRevision === 8 ||
+          recordedRevision === 9 ||
           recordedRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) &&
         extensionSchemaCompatible
       ) {
@@ -390,4 +418,9 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
   );
 });
 
-export {preflightRemovedViewCleanupSchema, ensureRemovedViewCleanupSchema, migratePersistentExtensionTables};
+export {
+  preflightRemovedViewCleanupSchema,
+  ensureRemovedViewCleanupSchema,
+  ensureCurrentCodeGraphQueryIndexes,
+  migratePersistentExtensionTables,
+};

--- a/src/code_graph/store_schema_migration.ts
+++ b/src/code_graph/store_schema_migration.ts
@@ -185,7 +185,6 @@ const ensureRemovedViewCleanupSchema = Effect.fn('codeGraph.ensureRemovedViewCle
 /** Keep query-required core indexes compatible across additive extension upgrades. */
 const ensureCurrentCodeGraphQueryIndexes = Effect.fn('codeGraph.ensureCurrentQueryIndexes')(function* (
   sql: SqlClient.SqlClient,
-  replaceResolvedTarget = false,
 ) {
   // These projections are covered by the NOCASE name and visualization scope
   // indexes. Drop them during the same revision transaction as the target-edge
@@ -194,7 +193,6 @@ const ensureCurrentCodeGraphQueryIndexes = Effect.fn('codeGraph.ensureCurrentQue
   yield* sql.unsafe('DROP INDEX IF EXISTS symbols_name');
   yield* sql.unsafe('DROP INDEX IF EXISTS symbols_resolution_scope');
   yield* sql.unsafe('DROP INDEX IF EXISTS edges_target');
-  if (replaceResolvedTarget) yield* sql.unsafe('DROP INDEX IF EXISTS edges_target_resolved');
   yield* sql.unsafe(`
     CREATE INDEX IF NOT EXISTS edges_target_resolved
     ON edges(snapshot_id, target_id, relation)
@@ -239,7 +237,7 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
         Number.isSafeInteger(recordedRevision) &&
         recordedRevision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
       ) {
-        yield* ensureCurrentCodeGraphQueryIndexes(sql, true);
+        yield* ensureCurrentCodeGraphQueryIndexes(sql);
         yield* observe?.('migrated-query-indexes') ?? Effect.void;
       }
       if (recordedRevision === 6) {

--- a/src/code_graph/store_service_data.ts
+++ b/src/code_graph/store_service_data.ts
@@ -118,7 +118,8 @@ type CodeGraphStoreDataMethods = Pick<
 >;
 
 export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): CodeGraphStoreDataMethods {
-  const {prepare, ensureSchemaInitialized, withWriterGate, fs, system, crypto} = runtime;
+  const {prepare, ensureSchemaInitialized, scheduleRoutinePhysicalCleanup, withWriterGate, fs, system, crypto} =
+    runtime;
   return {
     initialize: (databasePath, options) =>
       prepare(databasePath).pipe(
@@ -485,10 +486,17 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
         ),
         Effect.mapError(cause => storeError('load resumable code graph snapshot by identity', cause)),
       ),
-    retireIncompleteWorktreeSnapshots: (databasePath, repositoryId, worktreeId, retainedSnapshotIds, onProgress) =>
+    retireIncompleteWorktreeSnapshots: (
+      databasePath,
+      repositoryId,
+      worktreeId,
+      retainedSnapshotIds,
+      onProgress,
+      options,
+    ) =>
       Effect.gen(function* () {
         yield* prepare(databasePath);
-        return yield* useDatabase(
+        const result = yield* useDatabase(
           databasePath,
           retireIncompleteWorktreeSnapshots(
             repositoryId,
@@ -496,8 +504,13 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
             retainedSnapshotIds,
             effect => withWriterGate(databasePath, effect),
             onProgress,
+            options?.cleanupMode,
           ),
         );
+        if (options?.cleanupMode === 'deferred' && result.reclaimable > 0) {
+          yield* scheduleRoutinePhysicalCleanup(databasePath);
+        }
+        return result.retired;
       }).pipe(Effect.mapError(cause => storeError('retire incomplete code graph snapshots', cause))),
     markFailed: (databasePath, snapshotId, summary, ownerToken) =>
       prepare(databasePath).pipe(

--- a/src/code_graph/store_service_data.ts
+++ b/src/code_graph/store_service_data.ts
@@ -569,6 +569,7 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
       fileSetFingerprint,
       graphContentId,
       preferredCommitGroups,
+      allowExtractorMismatch,
     ) =>
       fs.exists(databasePath).pipe(
         Effect.flatMap(exists =>
@@ -582,6 +583,7 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
                   fileSetFingerprint,
                   graphContentId,
                   preferredCommitGroups,
+                  allowExtractorMismatch,
                 ),
               )
             : Effect.succeed(undefined),

--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -71,6 +71,7 @@ import {temporaryActivationPublicationCapacity} from './store_temporary_capacity
 type CodeGraphStoreLifecycleMethods = Pick<
   CodeGraphStoreShape,
   | 'withSession'
+  | 'shrinkMemory'
   | 'assertRuntimeSchemaCompatible'
   | 'acquireSnapshotLease'
   | 'retainViewSnapshotLease'
@@ -107,6 +108,14 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
     ensureSchemaInitialized,
   } = runtime;
   return {
+    shrinkMemory: databasePath =>
+      useDatabase(
+        databasePath,
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql.unsafe('PRAGMA shrink_memory');
+        }),
+      ).pipe(Effect.mapError(cause => storeError('release code graph SQLite memory', cause))),
     withSession: (databasePath, effect, options) => {
       const detachedCleanupRequest: CodeGraphDatabaseSessionShape['detachedCleanupRequest'] = {
         completedBuild: false,
@@ -122,7 +131,7 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
             // Keep hot upper B-tree pages resident for the one long-lived
             // indexing writer. Read/query sessions retain SQLite's small
             // default cache, so concurrent agents do not multiply this
-            // bounded 64 MiB budget.
+            // bounded 64 KiB budget.
             if (options.sqliteWriterTuning) {
               yield* configureSqliteWriterConnection(
                 sql,
@@ -131,7 +140,12 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
                 options.onSqliteWriterConfigured,
               );
             } else {
-              yield* sql.unsafe(`PRAGMA main.cache_size = -${CODE_GRAPH_WRITER_MAIN_CACHE_KIB}`);
+              yield* configureSqliteWriterConnection(
+                sql,
+                {mainCacheKiB: CODE_GRAPH_WRITER_MAIN_CACHE_KIB},
+                'connection',
+                options.onSqliteWriterConfigured,
+              );
             }
           }
           const session = {

--- a/src/code_graph/store_session.ts
+++ b/src/code_graph/store_session.ts
@@ -99,7 +99,7 @@ export const configureReadConnection = Effect.fn('codeGraph.configureReadConnect
   yield* sql.unsafe('PRAGMA query_only = ON');
 });
 
-export const CODE_GRAPH_WRITER_MAIN_CACHE_KIB = 64 * 1_024;
+export const CODE_GRAPH_WRITER_MAIN_CACHE_KIB = 64;
 const CODE_GRAPH_SQLITE_WRITER_CACHE_KIB_MAXIMUM = 4 * 1_024 * 1_024;
 const CODE_GRAPH_SQLITE_WRITER_MMAP_BYTES_MAXIMUM = 64 * 1_024 * 1_024 * 1_024;
 const CODE_GRAPH_SQLITE_WRITER_WAL_CHECKPOINT_PAGES_MAXIMUM = 1_000_000;
@@ -118,6 +118,17 @@ export const configureSqliteWriterConnection = Effect.fn('codeGraph.configureSql
       CODE_GRAPH_SQLITE_WRITER_CACHE_KIB_MAXIMUM,
     );
     yield* sql.unsafe(`PRAGMA main.cache_size = -${value}`);
+    const pageSize = yield* sql.unsafe<{readonly page_size: number}>('PRAGMA main.page_size');
+    const bytesPerPage = Number(pageSize[0]?.page_size ?? 0);
+    if (!Number.isSafeInteger(bytesPerPage) || bytesPerPage < 512) {
+      return yield* Effect.fail(new CodeGraphStoreError('SQLite writer page size is invalid.'));
+    }
+    // SQLite's connection default can retain a 20,000-page spill threshold
+    // even after cache_size is lowered. Bind spill to the configured byte
+    // budget so a publication transaction cannot silently grow tens of MiB
+    // beyond the reviewed writer cache.
+    const spillPages = Math.max(1, Math.ceil((value * 1_024) / bytesPerPage));
+    yield* sql.unsafe(`PRAGMA cache_spill = ${spillPages}`);
   }
   if (tuning.mmapSizeBytes !== undefined) {
     const value = sqlitePragmaInteger(

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -414,6 +414,7 @@ export interface CodeGraphStoreShape {
     fileSetFingerprint: string,
     graphContentId?: string,
     preferredCommitGroups?: readonly (readonly string[])[],
+    allowExtractorMismatch?: boolean,
   ) => Effect.Effect<CodeGraphReusableCleanBase | undefined, CodeGraphStoreError>;
   readonly reusableReexports: (
     databasePath: string,

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -376,6 +376,7 @@ export interface CodeGraphStoreShape {
     worktreeId: string,
     retainedSnapshotIds: ReadonlySet<string>,
     onProgress?: CodeGraphRetiredSnapshotCleanupProgressCallback,
+    options?: {readonly cleanupMode?: 'deferred' | 'required'},
   ) => Effect.Effect<number, CodeGraphStoreError>;
   readonly markFailed: (
     databasePath: string,

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -78,6 +78,8 @@ export interface CodeGraphStoreShape {
     effect: Effect.Effect<A, E, R | SqlClient.SqlClient>,
     options?: CodeGraphDatabaseSessionOptions,
   ) => Effect.Effect<A, E | CodeGraphStoreError, Exclude<R, SqlClient.SqlClient>>;
+  /** Release disposable SQLite page-cache allocations between index phases. */
+  readonly shrinkMemory: (databasePath: string) => Effect.Effect<void, CodeGraphStoreError>;
   /** Read-only preflight used before a long-lived process starts an isolated builder. */
   readonly assertRuntimeSchemaCompatible: (databasePath: string) => Effect.Effect<void, CodeGraphStoreError>;
   readonly activate: (

--- a/src/code_graph/store_staging_core.ts
+++ b/src/code_graph/store_staging_core.ts
@@ -227,6 +227,8 @@ const reclaimRetiredSnapshotPage = Effect.fn('codeGraph.reclaimRetiredSnapshotPa
 
 const prepareActivationTables = Effect.fn('codeGraph.prepareActivationTables')(function* (sql: SqlClient.SqlClient) {
   yield* sql.unsafe('PRAGMA temp_store = FILE');
+  yield* sql.unsafe('PRAGMA temp.cache_size = -64');
+  yield* sql.unsafe('PRAGMA temp.cache_spill = 16');
   yield* sql.unsafe(`
     CREATE TEMP TABLE IF NOT EXISTS activation_state (
       key TEXT PRIMARY KEY,

--- a/src/code_graph/store_visualization_sql.ts
+++ b/src/code_graph/store_visualization_sql.ts
@@ -276,7 +276,7 @@ function visualizationScopeIndex(scope: CodeGraphVisualizationScope): string {
       // still read an older v3 database before the next writer initializes it.
       return '';
     case 'documentation-facet':
-      return ' INDEXED BY symbols_resolution_scope';
+      return ' INDEXED BY symbols_visualization_scope_v2';
   }
 }
 

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -2,7 +2,7 @@ import type {CodeGraphScanningMetrics, CodeGraphSourceSizeBucket} from './progre
 
 export const CODE_GRAPH_SCHEMA_VERSION = 3 as const;
 /** Additive persistent surfaces that preserve the public graph-v3 row contract. */
-export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 10 as const;
+export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 11 as const;
 export const CODE_GRAPH_RESULT_VERSION = 1 as const;
 export const CODE_GRAPH_EXTRACTOR_GENERATION = 13 as const;
 export const CODE_GRAPH_EXTRACTOR_SET_VERSION = `native-code-graph-${CODE_GRAPH_EXTRACTOR_GENERATION}` as const;

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -2,7 +2,7 @@ import type {CodeGraphScanningMetrics, CodeGraphSourceSizeBucket} from './progre
 
 export const CODE_GRAPH_SCHEMA_VERSION = 3 as const;
 /** Additive persistent surfaces that preserve the public graph-v3 row contract. */
-export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 9 as const;
+export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 10 as const;
 export const CODE_GRAPH_RESULT_VERSION = 1 as const;
 export const CODE_GRAPH_EXTRACTOR_GENERATION = 13 as const;
 export const CODE_GRAPH_EXTRACTOR_SET_VERSION = `native-code-graph-${CODE_GRAPH_EXTRACTOR_GENERATION}` as const;

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -4,7 +4,7 @@ export const CODE_GRAPH_SCHEMA_VERSION = 3 as const;
 /** Additive persistent surfaces that preserve the public graph-v3 row contract. */
 export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 9 as const;
 export const CODE_GRAPH_RESULT_VERSION = 1 as const;
-export const CODE_GRAPH_EXTRACTOR_GENERATION = 12 as const;
+export const CODE_GRAPH_EXTRACTOR_GENERATION = 13 as const;
 export const CODE_GRAPH_EXTRACTOR_SET_VERSION = `native-code-graph-${CODE_GRAPH_EXTRACTOR_GENERATION}` as const;
 
 export type CodeGraphProvenance = 'declared' | 'heuristic' | 'model' | 'resolved' | 'syntactic';
@@ -208,10 +208,13 @@ export interface CodeGraphMaterializationMetrics {
   readonly batchesTotal: number;
   readonly cachedFactBytesCompleted?: number;
   readonly cachedFactBytesTotal?: number;
+  /** Exact bounded reason a repository-wide rewrite was selected, when known. */
+  readonly fallbackReason?: CodeGraphOverlayFallbackReason;
   /** Exact UTF-8 JSON bytes of final postprocessed and attributed facts. */
   readonly factsBytesCompleted?: number;
   readonly factsBytesTotal?: number;
   readonly loadingMilliseconds?: number;
+  readonly mode?: 'full' | 'incremental-clean' | 'incremental-overlay';
   readonly rows?: CodeGraphMaterializationRows;
   readonly sourceBytesCompleted: number;
   readonly sourceBytesTotal: number;

--- a/src/code_graph/workspace_compatibility.ts
+++ b/src/code_graph/workspace_compatibility.ts
@@ -1,0 +1,72 @@
+import type {CodeGraphWorkspace, CodeGraphWorkspaceProject} from './languages/types.js';
+import {compareCodeUnits} from './ordering.js';
+
+export type CodeGraphWorkspaceCompatibility =
+  | {readonly mode: 'unchanged'}
+  | {readonly mode: 'project-closure'; readonly seedProjectIds: readonly string[]}
+  | {readonly mode: 'fallback'; readonly reason: 'workspace-changed'};
+
+/**
+ * Narrows a semantic workspace transition to stable project identities. Added
+ * or removed project boundaries still fail closed because their old and new
+ * ownership sets cannot yet share one bounded closure plan.
+ */
+export function assessCodeGraphWorkspaceCompatibility(
+  base: CodeGraphWorkspace,
+  current: CodeGraphWorkspace,
+): CodeGraphWorkspaceCompatibility {
+  if (base.fingerprint === current.fingerprint) return {mode: 'unchanged'};
+  const baseProjects = uniqueProjectsById(base.projects);
+  const currentProjects = uniqueProjectsById(current.projects);
+  if (
+    baseProjects === undefined ||
+    currentProjects === undefined ||
+    baseProjects.size !== currentProjects.size ||
+    [...baseProjects.keys()].some(id => !currentProjects.has(id))
+  ) {
+    return {mode: 'fallback', reason: 'workspace-changed'};
+  }
+  const seedProjectIds = [...currentProjects]
+    .filter(
+      ([id, project]) => projectCompatibilitySurface(baseProjects.get(id)!) !== projectCompatibilitySurface(project),
+    )
+    .map(([id]) => id)
+    .sort(compareCodeUnits);
+  return seedProjectIds.length > 0
+    ? {mode: 'project-closure', seedProjectIds}
+    : {mode: 'fallback', reason: 'workspace-changed'};
+}
+
+function uniqueProjectsById(
+  projects: readonly CodeGraphWorkspaceProject[],
+): ReadonlyMap<string, CodeGraphWorkspaceProject> | undefined {
+  const output = new Map<string, CodeGraphWorkspaceProject>();
+  for (const project of projects) {
+    if (output.has(project.id)) return undefined;
+    output.set(project.id, project);
+  }
+  return output;
+}
+
+function projectCompatibilitySurface(project: CodeGraphWorkspaceProject): string {
+  return JSON.stringify([
+    project.id,
+    project.workspaceId,
+    project.buildSystem,
+    project.kind,
+    project.provenance,
+    project.name,
+    project.root,
+    project.resolutionDomain,
+    project.dependencies,
+    project.dependencyDetails.map(dependency => [
+      dependency.targetId,
+      dependency.provenance,
+      dependency.evidence ?? '',
+    ]),
+    project.languages,
+    project.sourceRoots,
+    project.workspaceRoots,
+    project.diagnostics,
+  ]);
+}

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -596,7 +596,23 @@ const graphBounds = {
     'limit',
     'other',
   ),
+  readTimeoutMilliseconds: optional(
+    describeFlag(
+      integerFlag('read-timeout-ms').pipe(
+        Flag.withSchema(Schema.Int.check(Schema.isBetween({minimum: 1, maximum: 600_000}))),
+      ),
+      'Foreground read/refresh budget in milliseconds; defaults to 25000',
+    ),
+  ),
 } as const;
+
+const graphFreshness = (value: 'current' | 'ready') =>
+  defaultChoice(
+    'freshness',
+    ['ready', 'current', 'allow-stale'],
+    'Ready uses an existing snapshot, current performs a bounded refresh, and allow-stale never starts indexing',
+    value,
+  );
 
 const graphStatus = Command.make(
   'status',
@@ -657,6 +673,7 @@ const graphQuery = Command.make(
   'query',
   {
     ...graphBounds,
+    freshness: graphFreshness('ready'),
     packageName: optionalString('package', 'Restrict results to one exact indexed package or workspace component'),
     query: requiredString('query', 'Concept, symbol, module, path, or documentation query'),
     workset: optionalString('workset', 'Query ready snapshots for a named seed-manifest workset'),
@@ -668,8 +685,10 @@ const graphNode = Command.make(
   'node',
   {
     cwd: graphBounds.cwd,
+    freshness: graphFreshness('ready'),
     json: graphBounds.json,
     nodeId: requiredString('node-id', 'Exact stable cgs_ node ID returned by graph inspection'),
+    readTimeoutMilliseconds: graphBounds.readTimeoutMilliseconds,
   },
   options => withRuntimeEffect(config => runCodeGraphInspect(config, {...options, operation: 'node'})),
 ).pipe(Command.withDescription('Read one code graph node by its exact stable ID'));
@@ -678,6 +697,7 @@ const graphNeighbors = Command.make(
   'neighbors',
   {
     ...graphBounds,
+    freshness: graphFreshness('ready'),
     direction: defaultChoice(
       'direction',
       ['both', 'incoming', 'outgoing'],
@@ -693,6 +713,7 @@ const graphExplain = Command.make(
   'explain',
   {
     ...graphBounds,
+    freshness: graphFreshness('ready'),
     symbol: requiredString('symbol', 'Symbol, qualified name, or source path selector'),
   },
   options => withRuntimeEffect(config => runCodeGraphInspect(config, {...options, operation: 'explain'})),
@@ -702,6 +723,7 @@ const graphPath = Command.make(
   'path',
   {
     ...graphBounds,
+    freshness: graphFreshness('current'),
     from: requiredString('from', 'Starting symbol, path#symbol selector, or stable cgs_ node ID'),
     to: requiredString('to', 'Target symbol, path#symbol selector, or stable cgs_ node ID'),
   },

--- a/src/effect/file_lock.ts
+++ b/src/effect/file_lock.ts
@@ -76,7 +76,27 @@ export function withExclusiveFileLock<A, E, R>(
     const token = yield* fileLockToken(options.useCanonicalProcessStartIdentity === true);
     const startedAt = yield* Clock.currentTimeMillis;
     let contentionReported = false;
-    while (!(yield* tryAcquireFileLock(fs, lockPath, token, options))) {
+    const heartbeatIntervalMilliseconds =
+      options.heartbeatIntervalMilliseconds ?? Math.max(1, Math.floor(options.staleAfterMilliseconds / 3));
+    const protectedEffect = Effect.scoped(
+      Effect.gen(function* () {
+        yield* Effect.forkScoped(refreshFileLockLease(fs, lockPath, token, heartbeatIntervalMilliseconds));
+        yield* options.onAcquired?.(lockPath) ?? Effect.void;
+        return yield* effect.pipe(Effect.ensuring(options.onCompleted?.(lockPath) ?? Effect.void));
+      }),
+    );
+    for (;;) {
+      const attempted = yield* tryAcquireFileLock(fs, lockPath, token, options).pipe(
+        Effect.flatMap(acquired =>
+          acquired ? protectedEffect.pipe(Effect.map(Option.some)) : Effect.succeed(Option.none<A>()),
+        ),
+        // Register release around the acquisition itself. Interruption or an
+        // I/O failure after the atomic token write must not strand a lock owned
+        // by this still-live process. A failed contender cannot remove another
+        // owner's lock because release verifies the exact random token.
+        Effect.ensuring(releaseFileLock(fs, lockPath, token)),
+      );
+      if (Option.isSome(attempted)) return attempted.value;
       if (!contentionReported) {
         yield* options.onContention?.(lockPath) ?? Effect.void;
         contentionReported = true;
@@ -87,16 +107,6 @@ export function withExclusiveFileLock<A, E, R>(
       }
       yield* Effect.sleep(options.retryIntervalMilliseconds);
     }
-    const heartbeatIntervalMilliseconds =
-      options.heartbeatIntervalMilliseconds ?? Math.max(1, Math.floor(options.staleAfterMilliseconds / 3));
-    const protectedEffect = Effect.scoped(
-      Effect.gen(function* () {
-        yield* Effect.forkScoped(refreshFileLockLease(fs, lockPath, token, heartbeatIntervalMilliseconds));
-        yield* options.onAcquired?.(lockPath) ?? Effect.void;
-        return yield* effect.pipe(Effect.ensuring(options.onCompleted?.(lockPath) ?? Effect.void));
-      }),
-    );
-    return yield* protectedEffect.pipe(Effect.ensuring(releaseFileLock(fs, lockPath, token)));
   });
 }
 

--- a/src/manager_graph.tsx
+++ b/src/manager_graph.tsx
@@ -270,9 +270,11 @@ export interface GraphBuildStatus {
       readonly batchesTotal: number;
       readonly cachedFactBytesCompleted?: number;
       readonly cachedFactBytesTotal?: number;
+      readonly fallbackReason?: string;
       readonly factsBytesCompleted?: number;
       readonly factsBytesTotal?: number;
       readonly loadingMilliseconds?: number;
+      readonly mode?: 'full' | 'incremental-clean' | 'incremental-overlay';
       readonly rows?: GraphMaterializationRows;
       readonly sourceBytesCompleted: number;
       readonly sourceBytesTotal: number;
@@ -3860,6 +3862,14 @@ function GraphBuildProgress(props: {
           {build.extraction.slowFiles.toLocaleString()} at or above{' '}
           {formatGraphMilliseconds(CODE_GRAPH_SLOW_FILE_THRESHOLD_MILLISECONDS)} · bounded top-slow evidence{' '}
           {build.extraction.topSlowFiles.length.toLocaleString()}/{CODE_GRAPH_TOP_SLOW_FILE_LIMIT.toLocaleString()}
+        </p>
+      ) : null}
+      {build.materialization?.metrics?.mode === 'full' ? (
+        <p className="graph-build-attention">
+          Full materialization selected
+          {build.materialization.metrics.fallbackReason === undefined
+            ? ''
+            : ` · incremental fallback: ${build.materialization.metrics.fallbackReason.replaceAll('-', ' ')}`}
         </p>
       ) : null}
       {build.materialization?.activity ? (

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -133,12 +133,7 @@ import {
   recallSelectionQueries,
   selectedRecallCandidateUris,
 } from './recall/runtime.js';
-import {
-  canUseReadySnapshotAfterCleanCommitChange,
-  CodeGraphQueryService,
-  observationFromCodeGraphStatus,
-  renderCodeGraphResult,
-} from './code_graph/query.js';
+import {CodeGraphQueryService, observationFromCodeGraphStatus, renderCodeGraphResult} from './code_graph/query.js';
 import {repositoryChangesSince} from './code_graph/repository.js';
 import type {CodeGraphProgress, CodeGraphQueryResult} from './code_graph/types.js';
 import {inspectCodeGraphWorkset, type CodeGraphWorksetQueryResult} from './code_graph/workset_query.js';
@@ -956,11 +951,11 @@ function registerCodeGraphTool(server: EffectMcpServerAdapter, config: RuntimeCo
             }),
         });
         let identity = status.identity;
-        const strictFreshness = operation === 'impact' || operation === 'path';
+        const allowStaleReadySnapshot = codeGraphInspectionAllowsStaleReady(operation);
+        const strictFreshness = !allowStaleReadySnapshot;
         if (status.stale || !status.readySnapshot) {
           status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status);
         }
-        let staleAfterCleanCommitChange = canUseReadySnapshotAfterCleanCommitChange(status);
         let refreshStarted = false;
         if (status.stale) {
           refreshStarted = yield* watcher.refresh({
@@ -977,16 +972,13 @@ function registerCodeGraphTool(server: EffectMcpServerAdapter, config: RuntimeCo
           if (status.stale || !status.readySnapshot) {
             status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status);
           }
-          staleAfterCleanCommitChange = canUseReadySnapshotAfterCleanCommitChange(status);
           if (!status.readySnapshot || (status.stale && strictFreshness)) {
             const refreshStatus = Option.getOrUndefined(yield* watcher.status(identity.worktreeId, refreshTarget));
             return codeGraphRefreshResult(operation, refreshStatus);
           }
         }
         const refreshStatus = Option.getOrUndefined(yield* watcher.status(identity.worktreeId, refreshTarget));
-        if (
-          selectCodeGraphReadySnapshotForInspection(status, refreshStatus, staleAfterCleanCommitChange) === undefined
-        ) {
+        if (selectCodeGraphReadySnapshotForInspection(status, refreshStatus, allowStaleReadySnapshot) === undefined) {
           return codeGraphRefreshResult(operation, refreshStatus);
         }
         const result = yield* service.inspect({
@@ -2054,6 +2046,16 @@ export function codeGraphRefreshBlocksReadyInspection(
   return refreshBlocks && (!status.readySnapshot || (status.stale && !allowStaleReadySnapshot));
 }
 
+/**
+ * Immutable ready snapshots remain valid bounded evidence while a newer snapshot builds.
+ * Relationship paths and impact analysis are correctness-sensitive and require current state.
+ */
+export function codeGraphInspectionAllowsStaleReady(
+  operation: 'explain' | 'impact' | 'neighbors' | 'node' | 'path' | 'query',
+): boolean {
+  return operation !== 'impact' && operation !== 'path';
+}
+
 /** Retain the exact observed pointer; refresh status alone is never promotion authority. */
 export function selectCodeGraphReadySnapshotForInspection<T>(
   status: {readonly readySnapshot?: T; readonly stale: boolean},
@@ -2070,10 +2072,15 @@ export function codeGraphResultWithRefreshContinuity(
   result: CodeGraphQueryResult,
   refreshStatus: CodeGraphRefreshStatus | undefined,
 ): CodeGraphQueryResult {
-  if (result.freshness !== 'stale' || refreshStatus?.state !== 'deferred') return result;
+  if (result.freshness !== 'stale') return result;
   const warning =
-    `Serving the existing stale ready snapshot because code graph refresh is deferred ` +
-    `(${refreshStatus.failure.code}). ${codeGraphRefreshRecoveryWarning(refreshStatus.failure)}`;
+    refreshStatus?.state === 'deferred'
+      ? `Serving the existing stale ready snapshot because code graph refresh is deferred ` +
+        `(${refreshStatus.failure.code}). ${codeGraphRefreshRecoveryWarning(refreshStatus.failure)}`
+      : refreshStatus?.state === 'indexing'
+        ? 'Serving the existing stale ready snapshot while code graph refresh continues in the background.'
+        : undefined;
+  if (warning === undefined) return result;
   const bounded = compactMcpText(warning, 320);
   return result.warnings.includes(bounded) ? result : {...result, warnings: [...result.warnings, bounded]};
 }

--- a/test/evaluation/baselines/code-graph-v1/mixed-nx-bazel-budgets.json
+++ b/test/evaluation/baselines/code-graph-v1/mixed-nx-bazel-budgets.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "fixture": {
+    "sources": {
+      "angular/angular": "8925a4ee491aebaf6a1a74880c73dfb20e0a4ba1",
+      "aspect-build/rules_js": "0960bdd0f542a73a4a6fa3183d68ef5766cce285",
+      "nrwl/nx": "2d15c7faa570629657112857a079803897e8e43d"
+    }
+  },
+  "baseline": {
+    "coldIndexMilliseconds": 383120
+  },
+  "maximum": {
+    "analysisMilliseconds": 15000,
+    "analysisPeakRssBytes": 786432000,
+    "boundedStaleReadMilliseconds": 25000,
+    "coldIndexMilliseconds": 287340,
+    "crashRecoveryForegroundMilliseconds": 2000,
+    "currentQueryMilliseconds": 1000,
+    "inventoryMilliseconds": 2000,
+    "oneFileIncrementalMilliseconds": 8000,
+    "oneFileIncrementalPeakRssBytes": 536870912,
+    "postChurnStorageGrowthPercent": 10,
+    "stableNoopMilliseconds": 2000
+  }
+}

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -597,7 +597,7 @@ describe('Effect CLI', () => {
     }
   });
 
-  it('refreshes stale query and explain reads in separate one-shot CLI processes', async () => {
+  it('uses ready snapshots by default and refreshes stale reads only when current freshness is requested', async () => {
     const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-graph-freshness-'));
     const home = join(root, '.threadnote-test-home');
     try {
@@ -631,6 +631,21 @@ describe('Effect CLI', () => {
       expect(first.stdout).toContain('"name":"firstGraphSymbol"');
 
       await writeFile(join(root, 'index.ts'), 'export function queryRefreshSymbol(): number { return 2; }\n');
+      const ready = await runCli([
+        'graph',
+        'query',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--query',
+        'firstGraphSymbol',
+        '--json',
+      ]);
+      expect(ready.stdout).toContain('"freshness":"stale"');
+      expect(ready.stdout).toContain('"name":"firstGraphSymbol"');
+      expect(ready.stdout).not.toContain('"name":"queryRefreshSymbol"');
+
       const query = await runCli([
         'graph',
         'query',
@@ -640,6 +655,8 @@ describe('Effect CLI', () => {
         root,
         '--query',
         'queryRefreshSymbol',
+        '--freshness',
+        'current',
         '--json',
       ]);
       expect(query.stdout).toContain('"freshness":"current"');
@@ -655,10 +672,97 @@ describe('Effect CLI', () => {
         root,
         '--symbol',
         'explainRefreshSymbol',
+        '--freshness',
+        'current',
         '--json',
       ]);
       expect(explain.stdout).toContain('"freshness":"current"');
       expect(explain.stdout).toContain('"name":"explainRefreshSymbol"');
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  }, 30_000);
+
+  it('fails fast for allow-stale without a snapshot and cancels bounded current refreshes cleanly', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-graph-read-budget-'));
+    const home = join(root, '.threadnote-test-home');
+    try {
+      await writeFile(join(root, 'package.json'), '{"name":"graph-read-budget"}\n');
+      await writeFile(join(root, 'index.ts'), 'export function boundedReadSymbol(): number { return 1; }\n');
+      await execFilePromise('git', ['-C', root, 'init', '-q']);
+      await execFilePromise('git', ['-C', root, 'add', '.']);
+      await execFilePromise('git', [
+        '-C',
+        root,
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=test@threadnote.local',
+        'commit',
+        '-qm',
+        'fixture',
+      ]);
+
+      const unavailable = await runCli([
+        'graph',
+        'query',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--query',
+        'boundedReadSymbol',
+        '--freshness',
+        'allow-stale',
+        '--json',
+      ]);
+      expect(JSON.parse(unavailable.stdout)).toMatchObject({
+        freshnessPolicy: 'allow-stale',
+        reason: 'no-ready-snapshot',
+        state: 'unavailable',
+        type: 'code-graph-query-state',
+      });
+
+      const timedOut = await runCli([
+        'graph',
+        'query',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--query',
+        'boundedReadSymbol',
+        '--freshness',
+        'current',
+        '--read-timeout-ms',
+        '1',
+        '--json',
+      ]);
+      const finalLine = timedOut.stdout.trim().split('\n').at(-1);
+      expect(finalLine).toBeDefined();
+      expect(JSON.parse(finalLine!)).toMatchObject({
+        budgetMilliseconds: 1,
+        freshnessPolicy: 'current',
+        reason: 'read-timeout',
+        state: 'timed-out',
+        type: 'code-graph-query-state',
+      });
+
+      const recovered = await runCli([
+        'graph',
+        'query',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--query',
+        'boundedReadSymbol',
+        '--freshness',
+        'current',
+        '--json',
+      ]);
+      expect(recovered.stdout).toContain('"freshness":"current"');
+      expect(recovered.stdout).toContain('"name":"boundedReadSymbol"');
     } finally {
       await rm(root, {force: true, recursive: true});
     }

--- a/test/integration/code-graph.bazel-incremental.test.ts
+++ b/test/integration/code-graph.bazel-incremental.test.ts
@@ -1,0 +1,167 @@
+import {execFileSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {describe, expect, it} from '@effect/vitest';
+import {TestClock} from 'effect/testing';
+import {Effect, Path} from 'effect';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {CodeGraphStore, type StoredCodeGraph} from '../../src/code_graph/store.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+
+describe('mixed Node and Bazel incremental indexing', () => {
+  it.effect('keeps a comment-only nested MODULE.bazel edit local and equivalent to a full rebuild', () =>
+    Effect.acquireUseRelease(
+      Effect.sync(createMixedWorkspaceRepository),
+      root =>
+        Effect.gen(function* () {
+          const indexer = yield* CodeGraphIndexer;
+          const path = yield* Path.Path;
+          const store = yield* CodeGraphStore;
+          const incrementalHome = join(root, '.threadnote-incremental');
+          const fullHome = join(root, '.threadnote-full');
+          yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+
+          yield* Effect.sync(() =>
+            writeFile(
+              root,
+              'apps/bazel-app/MODULE.bazel',
+              '# Developer-only note; declarations are unchanged.\nmodule(name = "bazel_app")\n',
+            ),
+          );
+
+          const incremental = yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+          const full = yield* indexer.index({
+            cwd: root,
+            incrementalOverlay: false,
+            threadnoteHome: fullHome,
+          });
+          const incrementalLayout = codeGraphLayout(
+            path,
+            incrementalHome,
+            incremental.identity.checkoutId,
+            incremental.identity.worktreeId,
+          );
+          const fullLayout = codeGraphLayout(path, fullHome, full.identity.checkoutId, full.identity.worktreeId);
+          const incrementalGraph = yield* store.loadGraph(incrementalLayout.databasePath, incremental.snapshot.id);
+          const fullGraph = yield* store.loadGraph(fullLayout.databasePath, full.snapshot.id);
+
+          expect(incremental.materialization).toEqual({
+            mode: 'incremental-overlay',
+            stagedFiles: 1,
+            totalFiles: 14,
+          });
+          expect(incrementalGraph.symbols.map(symbol => symbol.name)).toEqual(
+            expect.arrayContaining(['bazelApp', 'shared', 'web']),
+          );
+          expect(normalizeGraph(incrementalGraph)).toEqual(normalizeGraph(fullGraph));
+        }),
+      root => Effect.sync(() => rmSync(root, {force: true, recursive: true})),
+    ).pipe(Effect.provide(ApplicationLayer), TestClock.withLive),
+  );
+
+  it.effect('rematerializes only a changed nested Bazel dependency closure', () =>
+    Effect.acquireUseRelease(
+      Effect.sync(createMixedWorkspaceRepository),
+      root =>
+        Effect.gen(function* () {
+          const indexer = yield* CodeGraphIndexer;
+          const path = yield* Path.Path;
+          const store = yield* CodeGraphStore;
+          const incrementalHome = join(root, '.threadnote-incremental');
+          const fullHome = join(root, '.threadnote-full');
+          yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+
+          yield* Effect.sync(() =>
+            writeFile(
+              root,
+              'apps/bazel-app/BUILD.bazel',
+              'ts_library(name = "app", srcs = ["app.ts"], deps = ["//alternate:alternate"])\n',
+            ),
+          );
+
+          const incremental = yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+          const full = yield* indexer.index({
+            cwd: root,
+            incrementalOverlay: false,
+            threadnoteHome: fullHome,
+          });
+          const incrementalLayout = codeGraphLayout(
+            path,
+            incrementalHome,
+            incremental.identity.checkoutId,
+            incremental.identity.worktreeId,
+          );
+          const fullLayout = codeGraphLayout(path, fullHome, full.identity.checkoutId, full.identity.worktreeId);
+          const incrementalGraph = yield* store.loadGraph(incrementalLayout.databasePath, incremental.snapshot.id);
+          const fullGraph = yield* store.loadGraph(fullLayout.databasePath, full.snapshot.id);
+
+          expect(incremental.materialization).toMatchObject({
+            closureProjects: 1,
+            mode: 'incremental-overlay',
+            resolutionClosure: 'project',
+          });
+          expect(incremental.materialization?.stagedFiles).toBeLessThan(incremental.materialization!.totalFiles);
+          expect(normalizeGraph(incrementalGraph)).toEqual(normalizeGraph(fullGraph));
+        }),
+      root => Effect.sync(() => rmSync(root, {force: true, recursive: true})),
+    ).pipe(Effect.provide(ApplicationLayer), TestClock.withLive),
+  );
+});
+
+function createMixedWorkspaceRepository(): string {
+  const root = mkdtempSync(join(tmpdir(), 'threadnote-mixed-bazel-incremental-'));
+  write(root, 'package.json', {name: '@fixture/root', private: true, workspaces: ['libs/*']});
+  write(root, 'nx.json', {namedInputs: {default: ['{projectRoot}/**/*']}});
+  write(root, 'libs/shared/package.json', {name: '@fixture/shared'});
+  writeFile(root, 'libs/shared/index.ts', 'export const shared = "shared";\n');
+  write(root, 'apps/web/package.json', {
+    dependencies: {'@fixture/shared': 'workspace:*'},
+    name: '@fixture/web',
+  });
+  writeFile(
+    root,
+    'apps/web/index.ts',
+    'import {shared} from "../../libs/shared/index.js";\nexport const web = shared;\n',
+  );
+  write(root, 'apps/bazel-app/package.json', {name: '@fixture/bazel-app'});
+  writeFile(root, 'apps/bazel-app/MODULE.bazel', 'module(name = "bazel_app")\n');
+  writeFile(
+    root,
+    'apps/bazel-app/BUILD.bazel',
+    'ts_library(name = "app", srcs = ["app.ts"], deps = ["//core:core"])\n',
+  );
+  writeFile(root, 'apps/bazel-app/app.ts', 'export const bazelApp = "ready";\n');
+  writeFile(root, 'apps/bazel-app/core/BUILD.bazel', 'ts_library(name = "core", srcs = ["core.ts"])\n');
+  writeFile(root, 'apps/bazel-app/core/core.ts', 'export const core = "core";\n');
+  writeFile(root, 'apps/bazel-app/alternate/BUILD.bazel', 'ts_library(name = "alternate", srcs = ["alternate.ts"])\n');
+  writeFile(root, 'apps/bazel-app/alternate/alternate.ts', 'export const alternate = "alternate";\n');
+  git(root, ['init', '-q']);
+  git(root, ['config', 'user.name', 'Threadnote Test']);
+  git(root, ['config', 'user.email', 'test@threadnote.local']);
+  git(root, ['add', '.']);
+  git(root, ['commit', '-qm', 'fixture']);
+  return root;
+}
+
+function write(root: string, path: string, value: unknown): void {
+  writeFile(root, path, `${JSON.stringify(value)}\n`);
+}
+
+function writeFile(root: string, path: string, content: string): void {
+  const target = join(root, path);
+  mkdirSync(join(target, '..'), {recursive: true});
+  writeFileSync(target, content);
+}
+
+function git(root: string, arguments_: readonly string[]): void {
+  execFileSync('git', arguments_, {cwd: root, stdio: 'ignore'});
+}
+
+function normalizeGraph(graph: StoredCodeGraph): unknown {
+  return {
+    edges: [...graph.edges].sort((left, right) => left.id.localeCompare(right.id)),
+    symbols: [...graph.symbols].sort((left, right) => left.id.localeCompare(right.id)),
+  };
+}

--- a/test/integration/code-graph.corpus.test.ts
+++ b/test/integration/code-graph.corpus.test.ts
@@ -3,11 +3,13 @@ import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {strToU8, zipSync} from 'fflate';
+import {it as effectIt} from '@effect/vitest';
 import {Effect} from 'effect';
-import {afterEach, describe, expect, test} from 'vitest';
+import {TestClock} from 'effect/testing';
+import {afterEach, describe, expect} from 'vitest';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
 import {CodeGraphQueryService} from '../../src/code_graph/query.js';
-import {runEffect} from '../helpers/effect-runtime.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 
 const temporaryRoots: string[] = [];
 
@@ -16,80 +18,118 @@ afterEach(() => {
 });
 
 describe('code graph mixed corpus lifecycle', () => {
-  test('indexes tracked text, OpenXML, media metadata, and rationale in one transactional snapshot', async () => {
-    const root = temporaryDirectory();
-    mkdirSync(join(root, 'docs'), {recursive: true});
-    mkdirSync(join(root, 'diagrams'), {recursive: true});
-    mkdirSync(join(root, 'src'), {recursive: true});
-    writeFileSync(
-      join(root, 'docs', 'operations.rst'),
-      'Operations\n==========\n\nRetry queues use decorrelated jitter.\n',
-    );
-    writeFileSync(
-      join(root, 'docs', 'handoff.docx'),
-      zipSync({
-        '[Content_Types].xml': strToU8('<Types/>'),
-        'word/document.xml': strToU8(
-          '<w:document><w:body><w:p><w:r><w:t>Portable incident handoff checklist</w:t></w:r></w:p></w:body></w:document>',
-        ),
-      }),
-    );
-    const png = new Uint8Array(24);
-    png.set([0x89, 0x50, 0x4e, 0x47], 0);
-    writeFileSync(join(root, 'diagrams', 'retry-flow.png'), png);
-    writeFileSync(
-      join(root, 'src', 'retry.ts'),
-      'export function retry() {\n  // WHY: Backoff prevents coordinated retries.\n}\n',
-    );
-    git(root, ['init']);
-    git(root, ['config', 'user.email', 'threadnote@example.test']);
-    git(root, ['config', 'user.name', 'Threadnote Test']);
-    git(root, ['add', '.']);
-    git(root, ['commit', '-m', 'fixture']);
-    const home = join(root, '.threadnote-test-home');
+  effectIt.effect('defers opaque media while retaining searchable documents for structural-only indexing', () =>
+    Effect.gen(function* () {
+      const root = temporaryDirectory();
+      mkdirSync(join(root, 'docs'), {recursive: true});
+      mkdirSync(join(root, 'diagrams'), {recursive: true});
+      writeFileSync(join(root, 'docs', 'operations.rst'), 'Structural incident handoff\n===========================\n');
+      writeFileSync(join(root, 'diagrams', 'opaque-pixel.png'), new Uint8Array(48 * 1_024));
+      git(root, ['init']);
+      git(root, ['config', 'user.email', 'threadnote@example.test']);
+      git(root, ['config', 'user.name', 'Threadnote Test']);
+      git(root, ['add', '.']);
+      git(root, ['commit', '-m', 'fixture']);
+      const home = join(root, '.threadnote-test-home');
+      const indexer = yield* CodeGraphIndexer;
+      const query = yield* CodeGraphQueryService;
+      const indexed = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: home});
+      const [document, image] = yield* Effect.all(
+        [
+          query.inspect({
+            cwd: root,
+            operation: 'query',
+            query: 'structural incident handoff',
+            refresh: false,
+            threadnoteHome: home,
+          }),
+          query.inspect({
+            cwd: root,
+            operation: 'query',
+            query: 'opaque pixel',
+            refresh: false,
+            threadnoteHome: home,
+          }),
+        ],
+        {concurrency: 1},
+      );
+      expect(indexed.snapshot.fileCount).toBe(1);
+      expect(indexed.skippedFiles).toBeGreaterThanOrEqual(1);
+      expect(indexed.diagnostics.join('\n')).toContain('Deferred 1 opaque corpus asset');
+      expect(document.nodes.some(node => node.path === 'docs/operations.rst')).toBe(true);
+      expect(image.nodes).toEqual([]);
+    }).pipe(Effect.provide(ApplicationLayer), TestClock.withLive),
+  );
 
-    const results = await runEffect(
-      Effect.gen(function* () {
-        const indexer = yield* CodeGraphIndexer;
-        const query = yield* CodeGraphQueryService;
-        const indexed = yield* indexer.index({cwd: root, threadnoteHome: home});
-        const [office, image, rationale] = yield* Effect.all(
-          [
-            query.inspect({
-              cwd: root,
-              operation: 'query',
-              query: 'portable incident handoff',
-              refresh: false,
-              threadnoteHome: home,
-            }),
-            query.inspect({
-              cwd: root,
-              operation: 'query',
-              query: 'retry flow',
-              refresh: false,
-              threadnoteHome: home,
-            }),
-            query.inspect({
-              cwd: root,
-              operation: 'query',
-              query: 'coordinated retries backoff why',
-              refresh: false,
-              threadnoteHome: home,
-            }),
-          ],
-          {concurrency: 1},
-        );
-        return {image, indexed, office, rationale};
-      }),
-    );
-
-    expect(results.indexed.snapshot.fileCount).toBe(4);
-    expect(results.office.nodes.some(node => node.path === 'docs/handoff.docx')).toBe(true);
-    expect(results.image.nodes).toEqual(expect.arrayContaining([expect.objectContaining({kind: 'asset'})]));
-    expect(results.rationale.nodes).toEqual(
-      expect.arrayContaining([expect.objectContaining({kind: 'rationale', path: 'src/retry.ts'})]),
-    );
-  });
+  effectIt.effect('indexes tracked text, OpenXML, media metadata, and rationale in one transactional snapshot', () =>
+    Effect.gen(function* () {
+      const root = temporaryDirectory();
+      mkdirSync(join(root, 'docs'), {recursive: true});
+      mkdirSync(join(root, 'diagrams'), {recursive: true});
+      mkdirSync(join(root, 'src'), {recursive: true});
+      writeFileSync(
+        join(root, 'docs', 'operations.rst'),
+        'Operations\n==========\n\nRetry queues use decorrelated jitter.\n',
+      );
+      writeFileSync(
+        join(root, 'docs', 'handoff.docx'),
+        zipSync({
+          '[Content_Types].xml': strToU8('<Types/>'),
+          'word/document.xml': strToU8(
+            '<w:document><w:body><w:p><w:r><w:t>Portable incident handoff checklist</w:t></w:r></w:p></w:body></w:document>',
+          ),
+        }),
+      );
+      const png = new Uint8Array(24);
+      png.set([0x89, 0x50, 0x4e, 0x47], 0);
+      writeFileSync(join(root, 'diagrams', 'retry-flow.png'), png);
+      writeFileSync(
+        join(root, 'src', 'retry.ts'),
+        'export function retry() {\n  // WHY: Backoff prevents coordinated retries.\n}\n',
+      );
+      git(root, ['init']);
+      git(root, ['config', 'user.email', 'threadnote@example.test']);
+      git(root, ['config', 'user.name', 'Threadnote Test']);
+      git(root, ['add', '.']);
+      git(root, ['commit', '-m', 'fixture']);
+      const home = join(root, '.threadnote-test-home');
+      const indexer = yield* CodeGraphIndexer;
+      const query = yield* CodeGraphQueryService;
+      const indexed = yield* indexer.index({cwd: root, threadnoteHome: home});
+      const [office, image, rationale] = yield* Effect.all(
+        [
+          query.inspect({
+            cwd: root,
+            operation: 'query',
+            query: 'portable incident handoff',
+            refresh: false,
+            threadnoteHome: home,
+          }),
+          query.inspect({
+            cwd: root,
+            operation: 'query',
+            query: 'retry flow',
+            refresh: false,
+            threadnoteHome: home,
+          }),
+          query.inspect({
+            cwd: root,
+            operation: 'query',
+            query: 'coordinated retries backoff why',
+            refresh: false,
+            threadnoteHome: home,
+          }),
+        ],
+        {concurrency: 1},
+      );
+      expect(indexed.snapshot.fileCount).toBe(4);
+      expect(office.nodes.some(node => node.path === 'docs/handoff.docx')).toBe(true);
+      expect(image.nodes).toEqual(expect.arrayContaining([expect.objectContaining({kind: 'asset'})]));
+      expect(rationale.nodes).toEqual(
+        expect.arrayContaining([expect.objectContaining({kind: 'rationale', path: 'src/retry.ts'})]),
+      );
+    }).pipe(Effect.provide(ApplicationLayer), TestClock.withLive),
+  );
 });
 
 function temporaryDirectory(): string {

--- a/test/integration/code-graph.cross-session-incremental.test.ts
+++ b/test/integration/code-graph.cross-session-incremental.test.ts
@@ -5,6 +5,8 @@ import {join} from 'node:path';
 import {Database} from 'bun:sqlite';
 import {describe, expect, it} from '@effect/vitest';
 import {Effect, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {CodeGraphStore, type CodeGraphVisualizationCatalog} from '../../src/code_graph/store.js';
@@ -12,6 +14,52 @@ import {CODE_GRAPH_EXTRACTOR_GENERATION, type CodeGraphIndexSummary} from '../..
 import {runEffect} from '../helpers/effect-runtime.js';
 
 describe('cross-session code graph increments', () => {
+  it.effect(
+    're-promotes a recent clean increment after a dirty-to-clean round trip',
+    () => {
+      let root: string | undefined;
+      return Effect.gen(function* () {
+        root = createRepository(16);
+        const home = join(root, '.threadnote-round-trip');
+        const initial = yield* indexAndLoadEffect(root, home);
+        expect(initial.summary.materialization?.mode).toBe('full');
+
+        writeUseFile(root, 'committed clean revision');
+        git(root, ['add', 'src/use.ts']);
+        git(root, ['commit', '-qm', 'clean increment']);
+        const committed = yield* indexAndLoadEffect(root, home);
+        expect(committed.summary.materialization).toEqual({
+          mode: 'incremental-clean',
+          stagedFiles: 1,
+          totalFiles: 18,
+        });
+
+        writeUseFile(root, 'temporary dirty revision');
+        const dirty = yield* indexAndLoadEffect(root, home);
+        expect(dirty.summary.materialization?.mode).toBe('incremental-overlay');
+        expect(persistedSnapshotState(committed.databasePath, committed.summary.snapshot.id)).toBe('ready');
+
+        git(root, ['checkout', '--', 'src/use.ts']);
+        const restored = yield* indexAndLoadEffect(root, home);
+        expect(restored.summary.snapshot.id).toBe(committed.summary.snapshot.id);
+        expect(restored.summary.materialization).toEqual({
+          mode: 'reused-snapshot',
+          stagedFiles: 0,
+          totalFiles: 18,
+        });
+        expect(projectGraph(restored.graph)).toEqual(projectGraph(committed.graph));
+        expect(restored.health).toMatchObject({foreignKeyViolations: 0, integrity: 'ok'});
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
+        ),
+        Effect.provide(ApplicationLayer),
+        TestClock.withLive,
+      );
+    },
+    60_000,
+  );
+
   it('reuses a persisted clean base for a body-only dirty overlay', async () => {
     const root = createRepository(32);
     const incrementalHome = join(root, '.threadnote-incremental');
@@ -255,24 +303,24 @@ describe('cross-session code graph increments', () => {
   });
 });
 
+const indexAndLoadEffect = Effect.fn('test.indexAndLoad')(function* (root: string, home: string) {
+  const indexer = yield* CodeGraphIndexer;
+  const summary = yield* indexer.index({cwd: root, threadnoteHome: home});
+  const path = yield* Path.Path;
+  const store = yield* CodeGraphStore;
+  const layout = codeGraphLayout(path, home, summary.identity.checkoutId, summary.identity.worktreeId);
+  const graph = yield* store.loadGraph(layout.databasePath, summary.snapshot.id);
+  return {
+    catalog: yield* store.loadVisualizationCatalog(layout.databasePath),
+    databasePath: layout.databasePath,
+    graph,
+    health: yield* store.diagnose(layout.databasePath),
+    summary,
+  };
+});
+
 async function indexAndLoad(root: string, home: string) {
-  return runEffect(
-    Effect.gen(function* () {
-      const indexer = yield* CodeGraphIndexer;
-      const summary = yield* indexer.index({cwd: root, threadnoteHome: home});
-      const path = yield* Path.Path;
-      const store = yield* CodeGraphStore;
-      const layout = codeGraphLayout(path, home, summary.identity.checkoutId, summary.identity.worktreeId);
-      const graph = yield* store.loadGraph(layout.databasePath, summary.snapshot.id);
-      return {
-        catalog: yield* store.loadVisualizationCatalog(layout.databasePath),
-        databasePath: layout.databasePath,
-        graph,
-        health: yield* store.diagnose(layout.databasePath),
-        summary,
-      };
-    }),
-  );
+  return runEffect(indexAndLoadEffect(root, home));
 }
 
 async function loadGraph(root: string, home: string, summary: CodeGraphIndexSummary) {
@@ -291,6 +339,16 @@ function projectGraph(graph: {readonly edges: readonly unknown[]; readonly symbo
     readonly edges: readonly unknown[];
     readonly symbols: readonly unknown[];
   };
+}
+
+function persistedSnapshotState(databasePath: string, snapshotId: string): string | undefined {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return (database.query('SELECT state FROM snapshots WHERE id = ?').get(snapshotId) as {state?: string} | null)
+      ?.state;
+  } finally {
+    database.close(false);
+  }
 }
 
 function normalizeCatalog(catalog: CodeGraphVisualizationCatalog | undefined): unknown {

--- a/test/integration/code-graph.cross-session-incremental.test.ts
+++ b/test/integration/code-graph.cross-session-incremental.test.ts
@@ -17,7 +17,6 @@ import {
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {CodeGraphStore, type CodeGraphVisualizationCatalog} from '../../src/code_graph/store.js';
 import {CODE_GRAPH_EXTRACTOR_GENERATION, type CodeGraphIndexSummary} from '../../src/code_graph/types.js';
-import {runEffect} from '../helpers/effect-runtime.js';
 
 describe('cross-session code graph increments', () => {
   it.effect(
@@ -66,33 +65,27 @@ describe('cross-session code graph increments', () => {
     60_000,
   );
 
-  it('reuses a persisted clean base for a body-only dirty overlay', async () => {
-    const root = createRepository(32);
-    const incrementalHome = join(root, '.threadnote-incremental');
-    const fullHome = join(root, '.threadnote-full');
-    try {
-      const clean = await runEffect(
-        Effect.gen(function* () {
-          const indexer = yield* CodeGraphIndexer;
-          return yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
-        }),
-      );
+  it.effect('reuses a persisted clean base for a body-only dirty overlay', () => {
+    let fullHome: string | undefined;
+    let incrementalHome: string | undefined;
+    let root: string | undefined;
+    return Effect.gen(function* () {
+      root = createRepository(32);
+      incrementalHome = mkdtempSync(join(tmpdir(), 'threadnote-incremental-home-'));
+      fullHome = mkdtempSync(join(tmpdir(), 'threadnote-full-home-'));
+      const indexer = yield* CodeGraphIndexer;
+      const clean = yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
       expect(clean.materialization?.mode).toBe('full');
 
       writeUseFile(root, 'second body-only revision');
 
-      const incremental = await indexAndLoad(root, incrementalHome);
-      const full = await runEffect(
-        Effect.gen(function* () {
-          const indexer = yield* CodeGraphIndexer;
-          return yield* indexer.index({
-            cwd: root,
-            incrementalOverlay: false,
-            threadnoteHome: fullHome,
-          });
-        }),
-      );
-      const rebuilt = await loadGraph(root, fullHome, full);
+      const incremental = yield* indexAndLoadEffect(root, incrementalHome);
+      const full = yield* indexer.index({
+        cwd: root,
+        incrementalOverlay: false,
+        threadnoteHome: fullHome,
+      });
+      const rebuilt = yield* loadGraphEffect(root, fullHome, full);
 
       expect(incremental.summary.materialization).toEqual({
         mode: 'incremental-overlay',
@@ -100,7 +93,9 @@ describe('cross-session code graph increments', () => {
         totalFiles: 34,
       });
       expect(projectGraph(incremental.graph)).toEqual(projectGraph(rebuilt));
-      expect(normalizeCatalog(incremental.catalog)).toEqual(normalizeCatalog(await yieldCatalog(root, fullHome, full)));
+      expect(normalizeCatalog(incremental.catalog)).toEqual(
+        normalizeCatalog(yield* loadVisualizationCatalogEffect(fullHome, full)),
+      );
       expect(incremental.health).toMatchObject({foreignKeyViolations: 0, integrity: 'ok'});
       expect(
         incremental.graph.edges.some(
@@ -117,32 +112,34 @@ describe('cross-session code graph increments', () => {
       expect(incremental.summary.diagnostics).toContain(
         'Dirty overlay reused persisted clean base for 1 modified file(s).',
       );
-    } finally {
-      rmSync(root, {force: true, recursive: true});
-    }
+    }).pipe(
+      Effect.provide(ApplicationLayer),
+      TestClock.withLive,
+      Effect.ensuring(removeTemporaryPaths(() => [root, incrementalHome, fullHome])),
+    );
   });
 
-  it('matches full rebuilds when changed-file relationships are added or deleted', async () => {
-    for (const operation of ['add', 'delete'] as const) {
-      const root = createRepository();
-      const incrementalHome = join(root, `.threadnote-${operation}-incremental`);
-      const fullHome = join(root, `.threadnote-${operation}-full`);
-      try {
+  it.effect('matches full rebuilds when changed-file relationships are added or deleted', () => {
+    const temporaryPaths: string[] = [];
+    return Effect.gen(function* () {
+      const indexer = yield* CodeGraphIndexer;
+      for (const operation of ['add', 'delete'] as const) {
+        const root = createRepository();
+        temporaryPaths.push(root);
+        const incrementalHome = mkdtempSync(join(tmpdir(), `threadnote-${operation}-incremental-home-`));
+        temporaryPaths.push(incrementalHome);
+        const fullHome = mkdtempSync(join(tmpdir(), `threadnote-${operation}-full-home-`));
+        temporaryPaths.push(fullHome);
         if (operation === 'add') writeUseFileWithoutCall(root, 'clean no-call revision');
         git(root, ['add', '.']);
         git(root, ['commit', '--amend', '-qm', 'fixture']);
-        await indexAndLoad(root, incrementalHome);
+        yield* indexAndLoadEffect(root, incrementalHome);
         if (operation === 'add') writeUseFile(root, 'dirty call revision');
         else writeUseFileWithoutCall(root, 'dirty no-call revision');
 
-        const incremental = await indexAndLoad(root, incrementalHome);
-        const fullSummary = await runEffect(
-          Effect.gen(function* () {
-            const indexer = yield* CodeGraphIndexer;
-            return yield* indexer.index({cwd: root, incrementalOverlay: false, threadnoteHome: fullHome});
-          }),
-        );
-        const full = await loadGraph(root, fullHome, fullSummary);
+        const incremental = yield* indexAndLoadEffect(root, incrementalHome);
+        const fullSummary = yield* indexer.index({cwd: root, incrementalOverlay: false, threadnoteHome: fullHome});
+        const full = yield* loadGraphEffect(root, fullHome, fullSummary);
         expect(incremental.summary.materialization?.mode).toBe('incremental-overlay');
         expect(projectGraph(incremental.graph)).toEqual(projectGraph(full));
         expect(
@@ -150,32 +147,33 @@ describe('cross-session code graph increments', () => {
             edge => edge.sourceName === 'useHelper' && edge.relation === 'calls' && edge.targetName === 'helper',
           ),
         ).toBe(operation === 'add');
-      } finally {
-        rmSync(root, {force: true, recursive: true});
       }
-    }
+    }).pipe(
+      Effect.provide(ApplicationLayer),
+      TestClock.withLive,
+      Effect.ensuring(removeTemporaryPaths(() => temporaryPaths)),
+    );
   });
 
-  it('resolves changed consumers through persisted barrel aliases and declaration-only overloads', async () => {
-    const root = createBarrelRepository();
-    const incrementalHome = join(root, '.threadnote-barrel-incremental');
-    const fullHome = join(root, '.threadnote-barrel-full');
-    try {
-      const clean = await indexAndLoad(root, incrementalHome);
+  it.effect('resolves changed consumers through persisted barrel aliases and declaration-only overloads', () => {
+    let fullHome: string | undefined;
+    let incrementalHome: string | undefined;
+    let root: string | undefined;
+    return Effect.gen(function* () {
+      root = createBarrelRepository();
+      incrementalHome = mkdtempSync(join(tmpdir(), 'threadnote-barrel-incremental-home-'));
+      fullHome = mkdtempSync(join(tmpdir(), 'threadnote-barrel-full-home-'));
+      const clean = yield* indexAndLoadEffect(root, incrementalHome);
       expect(reusableReceiptStats(clean.databasePath, clean.summary.snapshot.id)).toMatchObject({
         formatVersion: 2,
         reexports: 2,
       });
       expect(reusableReceiptStats(clean.databasePath, clean.summary.snapshot.id).aliases).toBeGreaterThan(0);
       writeBarrelConsumer(root, 'dirty');
-      const incremental = await indexAndLoad(root, incrementalHome);
-      const fullSummary = await runEffect(
-        Effect.gen(function* () {
-          const indexer = yield* CodeGraphIndexer;
-          return yield* indexer.index({cwd: root, incrementalOverlay: false, threadnoteHome: fullHome});
-        }),
-      );
-      const full = await loadGraph(root, fullHome, fullSummary);
+      const incremental = yield* indexAndLoadEffect(root, incrementalHome);
+      const indexer = yield* CodeGraphIndexer;
+      const fullSummary = yield* indexer.index({cwd: root, incrementalOverlay: false, threadnoteHome: fullHome});
+      const full = yield* loadGraphEffect(root, fullHome, fullSummary);
 
       expect(incremental.summary.materialization?.mode).toBe('incremental-overlay');
       expect(projectGraph(incremental.graph)).toEqual(projectGraph(full));
@@ -198,29 +196,35 @@ describe('cross-session code graph increments', () => {
             .map(edge => edge.targetId),
         ),
       ).toEqual(new Set(decodeDeclarations.map(symbol => symbol.id)));
-    } finally {
-      rmSync(root, {force: true, recursive: true});
-    }
+    }).pipe(
+      Effect.provide(ApplicationLayer),
+      TestClock.withLive,
+      Effect.ensuring(removeTemporaryPaths(() => [root, incrementalHome, fullHome])),
+    );
   });
 
-  it('falls back conservatively when the clean base predates reusable receipts', async () => {
-    const root = createRepository();
-    const home = join(root, '.threadnote-old-base');
-    try {
-      const clean = await indexAndLoad(root, home);
+  it.effect('falls back conservatively when the clean base predates reusable receipts', () => {
+    let home: string | undefined;
+    let root: string | undefined;
+    return Effect.gen(function* () {
+      root = createRepository();
+      home = mkdtempSync(join(tmpdir(), 'threadnote-old-base-home-'));
+      const clean = yield* indexAndLoadEffect(root, home);
       deleteReusableReceipt(clean.databasePath, clean.summary.snapshot.id);
       writeUseFile(root, 'dirty revision after upgrade');
 
-      const dirty = await indexAndLoad(root, home);
+      const dirty = yield* indexAndLoadEffect(root, home);
       expect(dirty.summary.materialization).toEqual({
         fallbackReason: 'staging-unavailable',
         mode: 'full',
         stagedFiles: 2,
         totalFiles: 2,
       });
-    } finally {
-      rmSync(root, {force: true, recursive: true});
-    }
+    }).pipe(
+      Effect.provide(ApplicationLayer),
+      TestClock.withLive,
+      Effect.ensuring(removeTemporaryPaths(() => [root, home])),
+    );
   });
 
   it.effect(
@@ -290,10 +294,11 @@ describe('cross-session code graph increments', () => {
   });
 
   it.effect('does not let a stale peer failure poison an already-ready reusable base', () => {
+    let home: string | undefined;
     let root: string | undefined;
     return Effect.gen(function* () {
       root = createRepository();
-      const home = join(root, '.threadnote-peer-failure');
+      home = mkdtempSync(join(tmpdir(), 'threadnote-peer-failure-home-'));
       yield* indexAndLoadEffect(root, home);
       writeUseFile(root, 'dirty peer-failure revision');
       const dirty = yield* indexAndLoadEffect(root, home);
@@ -302,12 +307,7 @@ describe('cross-session code graph increments', () => {
 
       const path = yield* Path.Path;
       const store = yield* CodeGraphStore;
-      const layout = codeGraphLayout(
-        path,
-        home,
-        dirty.summary.identity.checkoutId,
-        dirty.summary.identity.worktreeId,
-      );
+      const layout = codeGraphLayout(path, home, dirty.summary.identity.checkoutId, dirty.summary.identity.worktreeId);
       yield* store.markFailed(layout.databasePath, baseSnapshotId!, 'late failure from a peer builder');
       const state = {
         receipt: yield* store.reusableBaseReceipt(layout.databasePath, baseSnapshotId!),
@@ -317,19 +317,18 @@ describe('cross-session code graph increments', () => {
       expect(state.snapshot?.state).toBe('ready');
       expect(state.receipt?.snapshotId).toBe(baseSnapshotId);
     }).pipe(
-      Effect.ensuring(
-        Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
-      ),
       Effect.provide(ApplicationLayer),
       TestClock.withLive,
+      Effect.ensuring(removeTemporaryPaths(() => [root, home])),
     );
   });
 
   it.effect('prevents an overlapping older extractor generation from replacing the active graph', () => {
+    let home: string | undefined;
     let root: string | undefined;
     return Effect.gen(function* () {
       root = createRepository();
-      const home = join(root, '.threadnote-extractor-generation');
+      home = mkdtempSync(join(tmpdir(), 'threadnote-extractor-generation-home-'));
       const current = yield* indexAndLoadEffect(root, home);
       const legacySnapshotId = 'cgsn_legacy_generation_8';
       insertLegacyReadySnapshot(current.databasePath, current.summary, legacySnapshotId);
@@ -357,11 +356,9 @@ describe('cross-session code graph increments', () => {
         minimum: CODE_GRAPH_EXTRACTOR_GENERATION,
       });
     }).pipe(
-      Effect.ensuring(
-        Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
-      ),
       Effect.provide(ApplicationLayer),
       TestClock.withLive,
+      Effect.ensuring(removeTemporaryPaths(() => [root, home])),
     );
   });
 });
@@ -381,21 +378,6 @@ const indexAndLoadEffect = Effect.fn('test.indexAndLoad')(function* (root: strin
     summary,
   };
 });
-
-async function indexAndLoad(root: string, home: string) {
-  return runEffect(indexAndLoadEffect(root, home));
-}
-
-async function loadGraph(root: string, home: string, summary: CodeGraphIndexSummary) {
-  return runEffect(
-    Effect.gen(function* () {
-      const path = yield* Path.Path;
-      const store = yield* CodeGraphStore;
-      const layout = codeGraphLayout(path, home, summary.identity.checkoutId, summary.identity.worktreeId);
-      return yield* store.loadGraph(layout.databasePath, summary.snapshot.id);
-    }),
-  );
-}
 
 const loadGraphEffect = Effect.fn('test.loadGraph')(function* (
   root: string,
@@ -451,16 +433,15 @@ function normalizeCatalog(catalog: CodeGraphVisualizationCatalog | undefined): u
   return {...stable, snapshot: stableSnapshot};
 }
 
-async function yieldCatalog(root: string, home: string, summary: CodeGraphIndexSummary) {
-  return runEffect(
-    Effect.gen(function* () {
-      const path = yield* Path.Path;
-      const store = yield* CodeGraphStore;
-      const layout = codeGraphLayout(path, home, summary.identity.checkoutId, summary.identity.worktreeId);
-      return yield* store.loadVisualizationCatalog(layout.databasePath);
-    }),
-  );
-}
+const loadVisualizationCatalogEffect = Effect.fn('test.loadVisualizationCatalog')(function* (
+  home: string,
+  summary: CodeGraphIndexSummary,
+) {
+  const path = yield* Path.Path;
+  const store = yield* CodeGraphStore;
+  const layout = codeGraphLayout(path, home, summary.identity.checkoutId, summary.identity.worktreeId);
+  return yield* store.loadVisualizationCatalog(layout.databasePath);
+});
 
 function createRepository(passiveFiles = 0): string {
   const root = mkdtempSync(join(tmpdir(), 'threadnote-cross-session-incremental-'));
@@ -688,4 +669,12 @@ function git(cwd: string, args: readonly string[]): void {
 function configureTestGitIdentity(cwd: string): void {
   git(cwd, ['config', 'user.name', 'Threadnote Test']);
   git(cwd, ['config', 'user.email', 'test@threadnote.local']);
+}
+
+function removeTemporaryPaths(paths: () => readonly (string | undefined)[]) {
+  return Effect.sync(() => {
+    for (const path of paths()) {
+      if (path !== undefined) rmSync(path, {force: true, recursive: true});
+    }
+  });
 }

--- a/test/integration/code-graph.cross-session-incremental.test.ts
+++ b/test/integration/code-graph.cross-session-incremental.test.ts
@@ -289,89 +289,80 @@ describe('cross-session code graph increments', () => {
     );
   });
 
-  it('does not let a stale peer failure poison an already-ready reusable base', async () => {
-    const root = createRepository();
-    const home = join(root, '.threadnote-peer-failure');
-    try {
-      await indexAndLoad(root, home);
+  it.effect('does not let a stale peer failure poison an already-ready reusable base', () => {
+    let root: string | undefined;
+    return Effect.gen(function* () {
+      root = createRepository();
+      const home = join(root, '.threadnote-peer-failure');
+      yield* indexAndLoadEffect(root, home);
       writeUseFile(root, 'dirty peer-failure revision');
-      const dirty = await indexAndLoad(root, home);
+      const dirty = yield* indexAndLoadEffect(root, home);
       const baseSnapshotId = dirty.summary.snapshot.baseSnapshotId;
       expect(baseSnapshotId).toBeDefined();
 
-      const state = await runEffect(
-        Effect.gen(function* () {
-          const path = yield* Path.Path;
-          const store = yield* CodeGraphStore;
-          const layout = codeGraphLayout(
-            path,
-            home,
-            dirty.summary.identity.checkoutId,
-            dirty.summary.identity.worktreeId,
-          );
-          yield* store.markFailed(layout.databasePath, baseSnapshotId!, 'late failure from a peer builder');
-          return {
-            receipt: yield* store.reusableBaseReceipt(layout.databasePath, baseSnapshotId!),
-            snapshot: yield* store.readySnapshotById(layout.databasePath, baseSnapshotId!),
-          };
-        }),
+      const path = yield* Path.Path;
+      const store = yield* CodeGraphStore;
+      const layout = codeGraphLayout(
+        path,
+        home,
+        dirty.summary.identity.checkoutId,
+        dirty.summary.identity.worktreeId,
       );
+      yield* store.markFailed(layout.databasePath, baseSnapshotId!, 'late failure from a peer builder');
+      const state = {
+        receipt: yield* store.reusableBaseReceipt(layout.databasePath, baseSnapshotId!),
+        snapshot: yield* store.readySnapshotById(layout.databasePath, baseSnapshotId!),
+      };
 
       expect(state.snapshot?.state).toBe('ready');
       expect(state.receipt?.snapshotId).toBe(baseSnapshotId);
-    } finally {
-      rmSync(root, {force: true, recursive: true});
-    }
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
+      ),
+      Effect.provide(ApplicationLayer),
+      TestClock.withLive,
+    );
   });
 
-  it('prevents an overlapping older extractor generation from replacing the active graph', async () => {
-    const root = createRepository();
-    const home = join(root, '.threadnote-extractor-generation');
-    try {
-      const current = await indexAndLoad(root, home);
+  it.effect('prevents an overlapping older extractor generation from replacing the active graph', () => {
+    let root: string | undefined;
+    return Effect.gen(function* () {
+      root = createRepository();
+      const home = join(root, '.threadnote-extractor-generation');
+      const current = yield* indexAndLoadEffect(root, home);
       const legacySnapshotId = 'cgsn_legacy_generation_8';
       insertLegacyReadySnapshot(current.databasePath, current.summary, legacySnapshotId);
       expect(() =>
         promoteLegacySnapshot(current.databasePath, current.summary.identity.worktreeId, legacySnapshotId),
       ).toThrow('older extractor generation');
 
-      await expect(
-        runEffect(
-          Effect.gen(function* () {
-            const path = yield* Path.Path;
-            const store = yield* CodeGraphStore;
-            const layout = codeGraphLayout(
-              path,
-              home,
-              current.summary.identity.checkoutId,
-              current.summary.identity.worktreeId,
-            );
-            yield* store.promote(layout.databasePath, current.summary.identity, legacySnapshotId);
-          }),
-        ),
-      ).rejects.toThrow('incompatible extractor generation');
-
-      const state = await runEffect(
-        Effect.gen(function* () {
-          const path = yield* Path.Path;
-          const store = yield* CodeGraphStore;
-          const layout = codeGraphLayout(
-            path,
-            home,
-            current.summary.identity.checkoutId,
-            current.summary.identity.worktreeId,
-          );
-          return yield* store.readySnapshot(layout.databasePath, current.summary.identity.worktreeId);
-        }),
+      const path = yield* Path.Path;
+      const store = yield* CodeGraphStore;
+      const layout = codeGraphLayout(
+        path,
+        home,
+        current.summary.identity.checkoutId,
+        current.summary.identity.worktreeId,
       );
+      const promotionError = yield* store
+        .promote(layout.databasePath, current.summary.identity, legacySnapshotId)
+        .pipe(Effect.flip);
+      expect(promotionError.message).toContain('incompatible extractor generation');
+
+      const state = yield* store.readySnapshot(layout.databasePath, current.summary.identity.worktreeId);
       expect(state?.id).toBe(current.summary.snapshot.id);
       expect(extractorGenerationState(current.databasePath, current.summary.snapshot.id)).toEqual({
         generation: CODE_GRAPH_EXTRACTOR_GENERATION,
         minimum: CODE_GRAPH_EXTRACTOR_GENERATION,
       });
-    } finally {
-      rmSync(root, {force: true, recursive: true});
-    }
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
+      ),
+      Effect.provide(ApplicationLayer),
+      TestClock.withLive,
+    );
   });
 });
 

--- a/test/integration/code-graph.cross-session-incremental.test.ts
+++ b/test/integration/code-graph.cross-session-incremental.test.ts
@@ -4,10 +4,16 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {Database} from 'bun:sqlite';
 import {describe, expect, it} from '@effect/vitest';
-import {Effect, Path} from 'effect';
+import {Context, Effect, Layer, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {
+  BUILTIN_LANGUAGE_PACK_REGISTRY,
+  CodeGraphLanguagePackRegistry,
+  createCodeGraphLanguagePackRegistry,
+  type CodeGraphLanguagePackRegistryShape,
+} from '../../src/code_graph/languages/registry.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {CodeGraphStore, type CodeGraphVisualizationCatalog} from '../../src/code_graph/store.js';
 import {CODE_GRAPH_EXTRACTOR_GENERATION, type CodeGraphIndexSummary} from '../../src/code_graph/types.js';
@@ -217,6 +223,72 @@ describe('cross-session code graph increments', () => {
     }
   });
 
+  it.effect(
+    're-extracts only the changed language pack across a compatible extractor rollout',
+    () => {
+      let root: string | undefined;
+      return Effect.gen(function* () {
+        root = createRepository(6);
+        writeFileSync(join(root, 'README.md'), '# Mixed language fixture\n');
+        git(root, ['add', 'README.md']);
+        git(root, ['commit', '--amend', '-qm', 'fixture']);
+        const home = join(root, '.threadnote-pack-rollout');
+        const referenceHome = join(root, '.threadnote-pack-rollout-reference');
+        const initialRegistry = createCodeGraphLanguagePackRegistry(BUILTIN_LANGUAGE_PACK_REGISTRY.packs);
+        const nextRegistry = createCodeGraphLanguagePackRegistry(
+          BUILTIN_LANGUAGE_PACK_REGISTRY.packs.map(pack =>
+            pack.id === 'typescript'
+              ? {...pack, extractor: {...pack.extractor, version: `${pack.extractor.version}-compatible-next`}}
+              : pack,
+          ),
+        );
+
+        const initial = yield* indexWithRegistry(root, home, initialRegistry);
+        expect(initial.materialization?.mode).toBe('full');
+        const incremental = yield* indexWithRegistry(root, home, nextRegistry);
+        const rebuilt = yield* indexWithRegistry(root, referenceHome, nextRegistry, true);
+        expect(incremental.materialization).toEqual({
+          mode: 'incremental-clean',
+          stagedFiles: 8,
+          totalFiles: 9,
+        });
+        expect(projectGraph(yield* loadGraphEffect(root, home, incremental))).toEqual(
+          projectGraph(yield* loadGraphEffect(root, referenceHome, rebuilt)),
+        );
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
+        ),
+        Effect.provide(ApplicationLayer),
+      );
+    },
+    60_000,
+  );
+
+  it.effect('fails closed when a global extractor change is not explained by pack provenance', () => {
+    let root: string | undefined;
+    return Effect.gen(function* () {
+      root = createRepository(4);
+      const home = join(root, '.threadnote-global-extractor');
+      const initial = yield* indexAndLoadEffect(root, home);
+      replaceSnapshotExtractorSet(initial.databasePath, initial.summary.snapshot.id, 'unexplained-global-change');
+      writeUseFile(root, 'changed alongside a global extractor rollout');
+
+      const next = yield* indexAndLoadEffect(root, home);
+      expect(next.summary.materialization).toEqual({
+        fallbackReason: 'extractor-context-changed',
+        mode: 'full',
+        stagedFiles: 6,
+        totalFiles: 6,
+      });
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
+      ),
+      Effect.provide(ApplicationLayer),
+    );
+  });
+
   it('does not let a stale peer failure poison an already-ready reusable base', async () => {
     const root = createRepository();
     const home = join(root, '.threadnote-peer-failure');
@@ -333,6 +405,36 @@ async function loadGraph(root: string, home: string, summary: CodeGraphIndexSumm
     }),
   );
 }
+
+const loadGraphEffect = Effect.fn('test.loadGraph')(function* (
+  root: string,
+  home: string,
+  summary: CodeGraphIndexSummary,
+) {
+  const path = yield* Path.Path;
+  const store = yield* CodeGraphStore;
+  const layout = codeGraphLayout(path, home, summary.identity.checkoutId, summary.identity.worktreeId);
+  return yield* store.loadGraph(layout.databasePath, summary.snapshot.id);
+});
+
+const indexWithRegistry = Effect.fn('test.indexWithRegistry')(function* (
+  root: string,
+  home: string,
+  registry: CodeGraphLanguagePackRegistryShape,
+  force = false,
+) {
+  const layer = Layer.fresh(CodeGraphIndexer.layer).pipe(
+    Layer.provide(Layer.succeed(CodeGraphLanguagePackRegistry, registry)),
+    Layer.provide(ApplicationLayer),
+  );
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const context = yield* Layer.build(layer);
+      const indexer = Context.get(context, CodeGraphIndexer);
+      return yield* indexer.index({cwd: root, force, threadnoteHome: home});
+    }),
+  );
+});
 
 function projectGraph(graph: {readonly edges: readonly unknown[]; readonly symbols: readonly unknown[]}) {
   return JSON.parse(JSON.stringify({edges: graph.edges, symbols: graph.symbols})) as {
@@ -510,6 +612,15 @@ function deleteReusableReceipt(databasePath: string, snapshotId: string): void {
   const database = new Database(databasePath);
   try {
     database.query('DELETE FROM snapshot_reuse_receipts WHERE snapshot_id = ?').run(snapshotId);
+  } finally {
+    database.close();
+  }
+}
+
+function replaceSnapshotExtractorSet(databasePath: string, snapshotId: string, extractorSet: string): void {
+  const database = new Database(databasePath);
+  try {
+    database.query('UPDATE snapshots SET extractor_set = ? WHERE id = ?').run(extractorSet, snapshotId);
   } finally {
     database.close();
   }

--- a/test/integration/code-graph.incremental.property.test.ts
+++ b/test/integration/code-graph.incremental.property.test.ts
@@ -454,7 +454,7 @@ describe('code graph incremental-overlay differential properties', () => {
     }
   });
 
-  it('reclaims an interrupted direct sibling before reusing the ready logical snapshot', async () => {
+  it('reuses the ready logical snapshot before detached cleanup reclaims an interrupted direct sibling', async () => {
     const scenario = {
       baseTargets: [1, 0, 1],
       dirty: new Set([0, 2]),
@@ -510,6 +510,13 @@ describe('code graph incremental-overlay differential properties', () => {
 
       expect(reused.snapshot.id).toBe(interrupted.logical.snapshot.id);
       expect(reused.materialization?.mode).toBe('reused-snapshot');
+      expect(persistedSnapshotState(interrupted.databasePath, direct.id)).toBe('retired');
+      await runEffect(
+        Effect.gen(function* () {
+          const store = yield* CodeGraphStore;
+          yield* store.pruneRetiredSnapshots(interrupted.databasePath);
+        }),
+      );
       expect(persistedSnapshotState(interrupted.databasePath, direct.id)).toBeUndefined();
       expect(persistedSnapshotRowCount(interrupted.databasePath, direct.id, 'symbols')).toBe(0);
       expect(persistedSnapshotRowCount(interrupted.databasePath, direct.id, 'building_materialization_batches')).toBe(
@@ -604,7 +611,7 @@ describe('code graph incremental-overlay differential properties', () => {
     }
   });
 
-  it('reclaims an interrupted dirty direct build before indexing the restored clean worktree', async () => {
+  it('indexes the restored clean worktree before detached cleanup reclaims an interrupted dirty build', async () => {
     const scenario = {
       baseTargets: [1, 0, 1],
       dirty: new Set([0, 2]),
@@ -649,6 +656,13 @@ describe('code graph incremental-overlay differential properties', () => {
 
       expect(clean.snapshot.dirty).toBe(false);
       expect(clean.snapshot.id).not.toMatch(/-direct$/);
+      expect(persistedSnapshotState(databasePath, interrupted.id)).toBe('retired');
+      await runEffect(
+        Effect.gen(function* () {
+          const store = yield* CodeGraphStore;
+          yield* store.pruneRetiredSnapshots(databasePath);
+        }),
+      );
       expect(persistedSnapshotState(databasePath, interrupted.id)).toBeUndefined();
       expect(persistedSnapshots(databasePath)).toEqual([
         {

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -32,10 +32,12 @@ import {
 import {ensureBoundedCodeGraphFact} from '../../src/code_graph/fact_budget.js';
 import {decodeStoredCodeGraphFact, encodeStoredCodeGraphFact} from '../../src/code_graph/fact_storage.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../../src/code_graph/languages/registry.js';
 import {readPersistedCodeGraphLocalAssociation} from '../../src/code_graph/local_provenance.js';
 import {
   inventoryRepository,
   readContainedStableRegularFile,
+  worktreeBuildRequestState,
   worktreeOverlayState,
 } from '../../src/code_graph/inventory.js';
 import {CodeGraphQueryService, observationFromCodeGraphStatus} from '../../src/code_graph/query.js';
@@ -2236,23 +2238,64 @@ describe('native code graph lifecycle', () => {
     expect(repeatedObservations).toBe(0);
   });
 
-  it('changes the overlay fingerprint for successive edits to an already-modified file', async () => {
-    const root = createFixtureRepository();
-    const states = await runEffect(
-      Effect.gen(function* () {
-        const identity = yield* resolveRepositoryIdentity(root);
-        replaceFunction(root, 'ensureVectorIndex', 'ensureFirstVectorIndex');
-        const first = yield* worktreeOverlayState(identity);
-        replaceFunction(root, 'ensureFirstVectorIndex', 'ensureSecondVectorIndex');
-        const second = yield* worktreeOverlayState(identity);
-        return [first, second] as const;
-      }),
-    );
+  effectIt.effect('changes the overlay fingerprint for successive edits to an already-modified file', () =>
+    Effect.gen(function* () {
+      const root = createFixtureRepository();
+      const identity = yield* resolveRepositoryIdentity(root);
+      replaceFunction(root, 'ensureVectorIndex', 'ensureFirstVectorIndex');
+      const first = yield* Effect.all({
+        buildRequest: worktreeBuildRequestState(identity),
+        overlay: worktreeOverlayState(identity),
+      });
+      replaceFunction(root, 'ensureFirstVectorIndex', 'ensureSecondVectorIndex');
+      const second = yield* Effect.all({
+        buildRequest: worktreeBuildRequestState(identity),
+        overlay: worktreeOverlayState(identity),
+      });
+      const states = [first, second] as const;
 
-    expect(states[0].dirty).toBe(true);
-    expect(states[1].dirty).toBe(true);
-    expect(states[0].fingerprint).not.toBe(states[1].fingerprint);
-  });
+      expect(states[0].overlay.dirty).toBe(true);
+      expect(states[1].overlay.dirty).toBe(true);
+      expect(states[0].overlay.fingerprint).not.toBe(states[1].overlay.fingerprint);
+      expect(states[0].buildRequest.dirty).toBe(true);
+      expect(states[1].buildRequest.dirty).toBe(true);
+      expect(states[0].buildRequest.fingerprint).not.toBe(states[1].buildRequest.fingerprint);
+    }).pipe(Effect.provide(ApplicationLayer)),
+  );
+
+  effectIt.effect('excludes an in-repository Threadnote home from build admission', () =>
+    Effect.gen(function* () {
+      const root = createFixtureRepository();
+      const home = join(root, '.threadnote-test-home');
+      mkdirSync(home, {recursive: true});
+      writeFileSync(join(home, 'runtime.json'), '{}\n');
+      const identity = yield* resolveRepositoryIdentity(root);
+      expect(yield* worktreeBuildRequestState(identity, home)).toEqual({dirty: false, fingerprint: undefined});
+
+      replaceFunction(root, 'ensureVectorIndex', 'ensureChangedVectorIndex');
+      expect((yield* worktreeBuildRequestState(identity, home)).dirty).toBe(true);
+    }).pipe(Effect.provide(ApplicationLayer)),
+  );
+
+  effectIt.effect('reuses manifest-only workspace discovery until a resolution context changes', () =>
+    Effect.gen(function* () {
+      const root = createFixtureRepository();
+      const identity = yield* resolveRepositoryIdentity(root);
+      const clean = yield* inventoryRepository(identity);
+      const cleanDirect = yield* BUILTIN_LANGUAGE_PACK_REGISTRY.discoverWorkspace(clean.files);
+      expect(clean.workspace?.fingerprint).toBe(cleanDirect.fingerprint);
+
+      replaceFunction(root, 'ensureVectorIndex', 'ensureChangedVectorIndex');
+      const sourceOnly = yield* inventoryRepository(identity);
+      const sourceOnlyDirect = yield* BUILTIN_LANGUAGE_PACK_REGISTRY.discoverWorkspace(sourceOnly.files);
+      expect(sourceOnly.workspace?.fingerprint).toBe(sourceOnlyDirect.fingerprint);
+
+      const tsconfig = join(root, 'tsconfig.json');
+      writeFileSync(tsconfig, `${readFileSync(tsconfig, 'utf8')}\n`);
+      const resolutionChanged = yield* inventoryRepository(identity);
+      expect(resolutionChanged.workspace).toBeUndefined();
+    }).pipe(Effect.provide(ApplicationLayer)),
+  );
 
   it('indexes a manifest-declared Android module named pods while pruning generated CocoaPods output', async () => {
     const root = temporaryDirectory('threadnote-code-graph-declared-pods-');

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -1841,11 +1841,21 @@ describe('native code graph lifecycle', () => {
     expect(result.status.readySnapshot?.id).toBe(result.indexed.snapshot.id);
   });
 
+  effectIt.effect('keeps graph-semantic-neutral resolution config edits incremental', () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.sync(createChangedResolutionContextRepository);
+      const indexer = yield* CodeGraphIndexer;
+      const result = yield* indexer.index({cwd: root, threadnoteHome: join(root, '.threadnote-test-home')});
+
+      expect(result.materialization).toMatchObject({mode: 'incremental-overlay', stagedFiles: 1});
+      expect(result.materialization?.fallbackReason).toBeUndefined();
+    }).pipe(Effect.provide(ApplicationLayer)),
+  );
+
   describe.each([
     ['a renamed declaration', createRenamedDeclarationRepository, 'resolution-surface-changed'],
     ['a changed lookup signature', createChangedSignatureRepository, 'project-closure-incomplete'],
     ['a changed export surface', createChangedExportRepository, 'resolution-surface-changed'],
-    ['changed resolution context', createChangedResolutionContextRepository, 'extractor-context-changed'],
     ['dynamic re-export aliases', createDynamicAliasRepository, 'project-closure-incomplete'],
     ['an added eligible file', createAddedFileRepository, 'file-set-changed'],
     ['a deleted eligible file', createDeletedFileRepository, 'file-set-changed'],

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -1970,55 +1970,52 @@ describe('native code graph lifecycle', () => {
     expect(result.inspected.nodes.some(node => node.name === 'changed128')).toBe(true);
   }, 30_000);
 
-  it('retries when the worktree changes after activation but before pointer promotion', async () => {
-    const root = createFixtureRepository();
-    const home = join(root, '.threadnote-test-home');
-    const initialCommit = execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], {encoding: 'utf8'}).trim();
-    let changed = false;
-    let staleSnapshotId: string | undefined;
-
-    const result = await runEffect(
-      Effect.gen(function* () {
-        const indexer = yield* CodeGraphIndexer;
-        const query = yield* CodeGraphQueryService;
-        const store = yield* CodeGraphStore;
-        const current = yield* indexer.index({
-          cwd: root,
-          onProgress: progress =>
-            Effect.sync(() => {
-              if (!changed && progress.phase === 'activating' && progress.subphase === 'promoting') {
-                staleSnapshotId = progress.snapshotId;
-                changed = true;
-                replaceFunction(root, 'ensureVectorIndex', 'ensureRacedVectorIndex');
-              }
-            }),
-          threadnoteHome: home,
-        });
-        const inspected = yield* query.inspect({
-          cwd: root,
-          operation: 'query',
-          query: 'ensureRacedVectorIndex',
-          refresh: false,
-          threadnoteHome: home,
-        });
-        const databasePath = codeGraphDatabasePath(home, current);
-        const stale = staleSnapshotId
-          ? yield* store.currentLexicalReadySnapshotById(databasePath, staleSnapshotId)
-          : undefined;
-        const staleGraph = stale ? yield* store.loadGraph(databasePath, stale.id) : undefined;
-        const active = yield* store.readySnapshot(databasePath, current.identity.worktreeId);
-        return {active, current, inspected, stale, staleGraph};
-      }),
-    );
-
-    expect(result.inspected.freshness).toBe('deferred');
-    expect(result.inspected.nodes.some(node => node.name === 'ensureRacedVectorIndex')).toBe(true);
-    expect(result.stale).toMatchObject({commit: initialCommit, id: staleSnapshotId, state: 'ready'});
-    expect(result.stale?.id).not.toBe(result.current.snapshot.id);
-    expect(result.staleGraph?.symbols.some(symbol => symbol.name === 'ensureVectorIndex')).toBe(true);
-    expect(result.staleGraph?.symbols.some(symbol => symbol.name === 'ensureRacedVectorIndex')).toBe(false);
-    expect(result.active?.id).toBe(result.current.snapshot.id);
-  });
+  effectIt.effect('retries when the worktree changes after activation but before pointer promotion', () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.sync(createFixtureRepository);
+      const home = join(root, '.threadnote-test-home');
+      const initialCommit = yield* Effect.sync(() =>
+        execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], {encoding: 'utf8'}).trim(),
+      );
+      let changed = false;
+      let staleSnapshotId: string | undefined;
+      const indexer = yield* CodeGraphIndexer;
+      const query = yield* CodeGraphQueryService;
+      const store = yield* CodeGraphStore;
+      const current = yield* indexer.index({
+        cwd: root,
+        onProgress: progress =>
+          Effect.sync(() => {
+            if (!changed && progress.phase === 'activating' && progress.subphase === 'promoting') {
+              staleSnapshotId = progress.snapshotId;
+              changed = true;
+              replaceFunction(root, 'ensureVectorIndex', 'ensureRacedVectorIndex');
+            }
+          }),
+        threadnoteHome: home,
+      });
+      const inspected = yield* query.inspect({
+        cwd: root,
+        operation: 'query',
+        query: 'ensureRacedVectorIndex',
+        refresh: false,
+        threadnoteHome: home,
+      });
+      const databasePath = codeGraphDatabasePath(home, current);
+      const stale = staleSnapshotId
+        ? yield* store.currentLexicalReadySnapshotById(databasePath, staleSnapshotId)
+        : undefined;
+      const staleGraph = stale ? yield* store.loadGraph(databasePath, stale.id) : undefined;
+      const active = yield* store.readySnapshot(databasePath, current.identity.worktreeId);
+      expect(inspected.freshness).toBe('deferred');
+      expect(inspected.nodes.some(node => node.name === 'ensureRacedVectorIndex')).toBe(true);
+      expect(stale).toMatchObject({commit: initialCommit, id: staleSnapshotId, state: 'ready'});
+      expect(stale?.id).not.toBe(current.snapshot.id);
+      expect(staleGraph?.symbols.some(symbol => symbol.name === 'ensureVectorIndex')).toBe(true);
+      expect(staleGraph?.symbols.some(symbol => symbol.name === 'ensureRacedVectorIndex')).toBe(false);
+      expect(active?.id).toBe(current.snapshot.id);
+    }).pipe(Effect.provide(ApplicationLayer), TestClock.withLive),
+  );
 
   it('removes stale committed facts when a changed source becomes ineligible', async () => {
     const root = createFixtureRepository();

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -149,21 +149,19 @@ describe('native code graph lifecycle', () => {
     });
   });
 
-  it('serves parallel ready-snapshot queries without contending on SQLite connection bootstrap', async () => {
-    const root = createFixtureRepository();
-    const home = join(root, '.threadnote-test-home');
-    const indexed = await runEffect(
+  effectIt.effect(
+    'serves parallel ready-snapshot queries without contending on SQLite connection bootstrap',
+    () =>
       Effect.gen(function* () {
+        const root = yield* Effect.sync(createFixtureRepository);
+        const home = join(root, '.threadnote-test-home');
         const indexer = yield* CodeGraphIndexer;
-        return yield* indexer.index({cwd: root, threadnoteHome: home});
-      }),
-    );
-    const databasePath = codeGraphDatabasePath(home, indexed);
-
-    const queryOnly = await runEffect(
-      Effect.gen(function* () {
         const store = yield* CodeGraphStore;
-        return yield* store.withSession(
+        const graph = yield* CodeGraphQueryService;
+        const indexed = yield* indexer.index({cwd: root, threadnoteHome: home});
+        const databasePath = codeGraphDatabasePath(home, indexed);
+
+        const queryOnly = yield* store.withSession(
           databasePath,
           Effect.gen(function* () {
             const sql = yield* SqlClient.SqlClient;
@@ -172,13 +170,8 @@ describe('native code graph lifecycle', () => {
           }),
           {readOnly: true},
         );
-      }),
-    );
-    expect(queryOnly).toBe(1);
+        expect(queryOnly).toBe(1);
 
-    const results = await runEffect(
-      Effect.gen(function* () {
-        const graph = yield* CodeGraphQueryService;
         const selected = yield* Ref.make(0);
         const allSelected = yield* Deferred.make<void>();
         const afterSnapshotSelected = () =>
@@ -196,7 +189,7 @@ describe('native code graph lifecycle', () => {
               ),
             ),
           );
-        return yield* Effect.all(
+        const results = yield* Effect.all(
           Array.from({length: 8}, () =>
             graph.inspect({
               cwd: root,
@@ -209,14 +202,9 @@ describe('native code graph lifecycle', () => {
           ),
           {concurrency: 'unbounded'},
         );
-      }),
-    );
-    expect(results).toHaveLength(8);
-    expect(results.every(result => result.nodes.some(node => node.name === 'withExclusiveFileLock'))).toBe(true);
+        expect(results).toHaveLength(8);
+        expect(results.every(result => result.nodes.some(node => node.name === 'withExclusiveFileLock'))).toBe(true);
 
-    const leaseCoverage = await runEffect(
-      Effect.gen(function* () {
-        const graph = yield* CodeGraphQueryService;
         const readCompleted = yield* Deferred.make<void>();
         const finish = yield* Deferred.make<void>();
         const query = yield* graph
@@ -233,14 +221,16 @@ describe('native code graph lifecycle', () => {
           })
           .pipe(Effect.forkChild);
         yield* Deferred.await(readCompleted);
-        const active = snapshotLeaseCount(databasePath);
+        const active = yield* Effect.sync(() => snapshotLeaseCount(databasePath));
         yield* Deferred.succeed(finish, undefined);
         yield* Fiber.join(query);
-        return {active, released: snapshotLeaseCount(databasePath)};
-      }),
-    );
-    expect(leaseCoverage).toEqual({active: 1, released: 0});
-  });
+        const released = yield* Effect.sync(() => snapshotLeaseCount(databasePath));
+        expect({active, released}).toEqual({active: 1, released: 0});
+      }).pipe(Effect.provide(ApplicationLayer), TestClock.withLive),
+    // Suite-wide graph fixtures can delay setup; the in-test 5s barrier still
+    // enforces that all eight selected readers bootstrap without contention.
+    60_000,
+  );
 
   it('visibly and idempotently backfills analysis summaries when reusing a legacy ready snapshot', async () => {
     const root = createFixtureRepository();
@@ -1864,6 +1854,7 @@ describe('native code graph lifecycle', () => {
     effectIt.effect('fails closed with the exact bounded reason', () =>
       Effect.gen(function* () {
         const root = yield* Effect.sync(createRepository);
+        const planObservations: Pick<CodeGraphMaterializationMetrics, 'fallbackReason' | 'mode'>[] = [];
         const storageObservations: NonNullable<CodeGraphMaterializationMetrics['storage']>[] = [];
         const indexer = yield* CodeGraphIndexer;
         const result = yield* indexer.index({
@@ -1872,12 +1863,17 @@ describe('native code graph lifecycle', () => {
             Effect.sync(() => {
               if (progress.phase === 'materializing' && progress.metrics?.storage !== undefined) {
                 storageObservations.push(progress.metrics.storage);
+                planObservations.push({
+                  fallbackReason: progress.metrics.fallbackReason,
+                  mode: progress.metrics.mode,
+                });
               }
             }),
           threadnoteHome: join(root, '.threadnote-test-home'),
         });
         expect(result.materialization).toMatchObject({fallbackReason, mode: 'full'});
         expect(result.materialization?.stagedFiles).toBe(result.materialization?.totalFiles);
+        expect(planObservations.at(-1)).toEqual({fallbackReason, mode: 'full'});
         expect(result.diagnostics.some(message => message.startsWith('Dirty overlay used full materialization:'))).toBe(
           true,
         );

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -2934,9 +2934,10 @@ describe('native code graph lifecycle', () => {
   it('coalesces independent operating-system processes into one inventory pass', async () => {
     const root = createFixtureRepository();
     const home = join(root, '.threadnote-test-home');
-    const gate = join(root, '.release-code-graph-owner');
-    const firstMarker = join(root, '.first-code-graph-process');
-    const secondMarker = join(root, '.second-code-graph-process');
+    const controlRoot = temporaryDirectory('threadnote-code-graph-process-control-');
+    const gate = join(controlRoot, 'release-code-graph-owner');
+    const firstMarker = join(controlRoot, 'first-code-graph-process');
+    const secondMarker = join(controlRoot, 'second-code-graph-process');
     const first = startCodeGraphIndexProcess(root, home, gate, firstMarker);
     let second: ReturnType<typeof startCodeGraphIndexProcess> | undefined;
     try {

--- a/test/integration/code-graph.overloads.test.ts
+++ b/test/integration/code-graph.overloads.test.ts
@@ -2,57 +2,66 @@ import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {it as effectIt} from '@effect/vitest';
 import {Effect, Path} from 'effect';
-import {describe, expect, it} from 'vitest';
+import {TestClock} from 'effect/testing';
+import {describe, expect} from 'vitest';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
-import {runEffect} from '../helpers/effect-runtime.js';
 
 describe('TypeScript overload indexing', () => {
-  it('keeps overload symbols while resolving calls to implementations or unique arities', async () => {
-    const root = createRepository();
-    const home = join(root, '.threadnote-test-home');
-    try {
-      const graph = await runEffect(
-        Effect.gen(function* () {
+  effectIt.effect(
+    'keeps overload symbols while resolving calls to implementations or unique arities',
+    () => {
+      let root: string | undefined;
+      return Effect.gen(function* () {
+        root = createRepository();
+        const home = join(root, '.threadnote-test-home');
+        const graph = yield* Effect.gen(function* () {
           const indexer = yield* CodeGraphIndexer;
           const path = yield* Path.Path;
           const store = yield* CodeGraphStore;
-          const indexed = yield* indexer.index({cwd: root, threadnoteHome: home});
+          const indexed = yield* indexer.index({cwd: root!, threadnoteHome: home});
           const layout = codeGraphLayout(path, home, indexed.identity.checkoutId, indexed.identity.worktreeId);
           return yield* store.loadGraph(layout.databasePath, indexed.snapshot.id);
-        }),
-      );
-      const parseSymbols = graph.symbols.filter(symbol => symbol.name === 'parse');
-      const decodeSymbols = graph.symbols.filter(symbol => symbol.name === 'decode');
-      const implementation = parseSymbols.find(symbol => symbol.signature?.includes('...values'));
-      const nullaryDeclaration = decodeSymbols.find(symbol => symbol.arity === 0);
-      const binaryDeclaration = decodeSymbols.find(symbol => symbol.arity === 2);
-      const call = (sourceName: string, targetName: string) =>
-        graph.edges.find(
-          edge => edge.sourceName === sourceName && edge.relation === 'calls' && edge.targetName === targetName,
-        );
+        });
+        const parseSymbols = graph.symbols.filter(symbol => symbol.name === 'parse');
+        const decodeSymbols = graph.symbols.filter(symbol => symbol.name === 'decode');
+        const implementation = parseSymbols.find(symbol => symbol.signature?.includes('...values'));
+        const nullaryDeclaration = decodeSymbols.find(symbol => symbol.arity === 0);
+        const binaryDeclaration = decodeSymbols.find(symbol => symbol.arity === 2);
+        const call = (sourceName: string, targetName: string) =>
+          graph.edges.find(
+            edge => edge.sourceName === sourceName && edge.relation === 'calls' && edge.targetName === targetName,
+          );
 
-      expect(new Set(parseSymbols.map(symbol => symbol.id)).size).toBe(3);
-      expect(new Set(decodeSymbols.map(symbol => symbol.id)).size).toBe(2);
-      expect(call('useImported', 'parse')).toMatchObject({
-        provenance: 'resolved',
-        targetId: implementation?.id,
-      });
-      const declaredCalls = graph.edges.filter(
-        edge => edge.sourceName === 'useDeclared' && edge.relation === 'calls' && edge.targetName === 'decode',
+        expect(new Set(parseSymbols.map(symbol => symbol.id)).size).toBe(3);
+        expect(new Set(decodeSymbols.map(symbol => symbol.id)).size).toBe(2);
+        expect(call('useImported', 'parse')).toMatchObject({
+          provenance: 'resolved',
+          targetId: implementation?.id,
+        });
+        const declaredCalls = graph.edges.filter(
+          edge => edge.sourceName === 'useDeclared' && edge.relation === 'calls' && edge.targetName === 'decode',
+        );
+        expect(declaredCalls).toHaveLength(2);
+        expect(new Set(declaredCalls.map(edge => edge.id)).size).toBe(2);
+        expect(new Set(declaredCalls.map(edge => edge.targetId))).toEqual(
+          new Set([nullaryDeclaration?.id, binaryDeclaration?.id]),
+        );
+        expect(call('useShadowed', 'parse')).toMatchObject({provenance: 'syntactic', targetId: undefined});
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
+        ),
+        Effect.provide(ApplicationLayer),
+        TestClock.withLive,
       );
-      expect(declaredCalls).toHaveLength(2);
-      expect(new Set(declaredCalls.map(edge => edge.id)).size).toBe(2);
-      expect(new Set(declaredCalls.map(edge => edge.targetId))).toEqual(
-        new Set([nullaryDeclaration?.id, binaryDeclaration?.id]),
-      );
-      expect(call('useShadowed', 'parse')).toMatchObject({provenance: 'syntactic', targetId: undefined});
-    } finally {
-      rmSync(root, {force: true, recursive: true});
-    }
-  });
+    },
+    60_000,
+  );
 });
 
 function createRepository(): string {

--- a/test/integration/code-graph.polyglot.test.ts
+++ b/test/integration/code-graph.polyglot.test.ts
@@ -2,13 +2,15 @@ import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
+import {it as effectIt} from '@effect/vitest';
 import {Effect, Path} from 'effect';
-import {afterEach, describe, expect, it} from 'vitest';
+import {TestClock} from 'effect/testing';
+import {afterEach, describe, expect} from 'vitest';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {CodeGraphQueryService} from '../../src/code_graph/query.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
-import {runEffect} from '../helpers/effect-runtime.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 
 const temporaryRoots: string[] = [];
 
@@ -17,11 +19,12 @@ afterEach(() => {
 });
 
 describe('polyglot code graph lifecycle', () => {
-  it('indexes and queries a mixed compiler, AST, structured, and bounded specialist graph', async () => {
-    const root = createPolyglotRepository();
-    const home = join(root, '.threadnote-test-home');
-    const result = await runEffect(
+  effectIt.effect(
+    'indexes and queries a mixed compiler, AST, structured, and bounded specialist graph',
+    () =>
       Effect.gen(function* () {
+        const root = createPolyglotRepository();
+        const home = join(root, '.threadnote-test-home');
         const indexer = yield* CodeGraphIndexer;
         const query = yield* CodeGraphQueryService;
         const store = yield* CodeGraphStore;
@@ -63,57 +66,57 @@ describe('polyglot code graph lifecycle', () => {
           ],
           {concurrency: 1},
         );
-        return {graph, indexed, operations};
-      }),
-    );
-
-    expect(result.graph.symbols.map(symbol => symbol.language)).toEqual(
-      expect.arrayContaining([
-        'apex',
-        'bash',
-        'c',
-        'cpp',
-        'csharp',
-        'dart',
-        'fortran',
-        'go',
-        'java',
-        'json',
-        'kotlin',
-        'php',
-        'python',
-        'razor',
-        'ruby',
-        'rust',
-        'sql',
-        'swift',
-        'systemverilog',
-        'terraform',
-        'typescript',
-      ]),
-    );
-    expect(
-      result.graph.edges.find(
-        edge => edge.sourceName === 'start' && edge.relation === 'constructs' && edge.targetName === 'Greeter',
-      ),
-    ).toMatchObject({provenance: 'resolved', targetId: expect.stringMatching(/^cgs_/)});
-    expect(
-      result.graph.edges.find(
-        edge => edge.sourceName === 'swiftBoot' && edge.relation === 'calls' && edge.targetName === 'makeService',
-      ),
-    ).toMatchObject({provenance: 'resolved', targetId: expect.stringMatching(/^cgs_/)});
-    expect(
-      result.graph.edges.find(
-        edge =>
-          edge.sourceName === 'typescriptBoot' && edge.relation === 'calls' && edge.targetName === 'typescriptHelper',
-      ),
-    ).toMatchObject({provenance: 'resolved', targetId: expect.stringMatching(/^cgs_/)});
-    expect(result.operations.every(operation => operation.snapshot.id === result.indexed.snapshot.id)).toBe(true);
-    expect(result.operations[0]!.nodes.some(node => node.language === 'java')).toBe(true);
-    expect(result.operations[1]!.nodes.some(node => node.name === 'KotlinApp')).toBe(true);
-    expect(result.operations[2]!.edges.some(edge => edge.targetName === 'typescriptHelper')).toBe(true);
-    expect(result.operations[3]!.nodes.some(node => node.name === 'swiftBoot')).toBe(true);
-  });
+        expect(graph.symbols.map(symbol => symbol.language)).toEqual(
+          expect.arrayContaining([
+            'apex',
+            'bash',
+            'c',
+            'cpp',
+            'csharp',
+            'dart',
+            'fortran',
+            'go',
+            'java',
+            'json',
+            'kotlin',
+            'php',
+            'python',
+            'razor',
+            'ruby',
+            'rust',
+            'sql',
+            'swift',
+            'systemverilog',
+            'terraform',
+            'typescript',
+          ]),
+        );
+        expect(
+          graph.edges.find(
+            edge => edge.sourceName === 'start' && edge.relation === 'constructs' && edge.targetName === 'Greeter',
+          ),
+        ).toMatchObject({provenance: 'resolved', targetId: expect.stringMatching(/^cgs_/)});
+        expect(
+          graph.edges.find(
+            edge => edge.sourceName === 'swiftBoot' && edge.relation === 'calls' && edge.targetName === 'makeService',
+          ),
+        ).toMatchObject({provenance: 'resolved', targetId: expect.stringMatching(/^cgs_/)});
+        expect(
+          graph.edges.find(
+            edge =>
+              edge.sourceName === 'typescriptBoot' &&
+              edge.relation === 'calls' &&
+              edge.targetName === 'typescriptHelper',
+          ),
+        ).toMatchObject({provenance: 'resolved', targetId: expect.stringMatching(/^cgs_/)});
+        expect(operations.every(operation => operation.snapshot.id === indexed.snapshot.id)).toBe(true);
+        expect(operations[0]!.nodes.some(node => node.language === 'java')).toBe(true);
+        expect(operations[1]!.nodes.some(node => node.name === 'KotlinApp')).toBe(true);
+        expect(operations[2]!.edges.some(edge => edge.targetName === 'typescriptHelper')).toBe(true);
+        expect(operations[3]!.nodes.some(node => node.name === 'swiftBoot')).toBe(true);
+      }).pipe(Effect.provide(ApplicationLayer), TestClock.withLive),
+    60_000,
+  );
 });
 
 function createPolyglotRepository(): string {

--- a/test/integration/code-graph.project-closure.test.ts
+++ b/test/integration/code-graph.project-closure.test.ts
@@ -438,6 +438,7 @@ describe('project-closure incremental indexing', () => {
 
 function createProjectClosureRepository(options: {readonly orphanProjectBoundary?: boolean} = {}): string {
   const root = mkdtempSync(join(tmpdir(), 'threadnote-project-closure-'));
+  writeFile(root, '.gitignore', '/.threadnote-*/\n');
   write(root, 'package.json', {name: '@fixture/root', private: true, workspaces: ['packages/*']});
   write(root, 'packages/app/package.json', {
     dependencies: {
@@ -491,6 +492,7 @@ function redirectBarrelWithOutsideCall(root: string): void {
 
 function createRandomProjectClosureRepository(projectCount: number, salt: number): string {
   const root = mkdtempSync(join(tmpdir(), 'threadnote-random-project-closure-'));
+  writeFile(root, '.gitignore', '/.threadnote-*/\n');
   const packageCount = projectCount - 1;
   write(root, 'package.json', {name: '@random/root', private: true, workspaces: ['packages/*']});
   write(root, 'packages/p0/package.json', {name: '@random/p0'});

--- a/test/integration/code-graph.removed-view-cleanup-load.test.ts
+++ b/test/integration/code-graph.removed-view-cleanup-load.test.ts
@@ -212,7 +212,7 @@ describe('removed code graph view cleanup load and migration', () => {
             expect(sharedGrowthBytes).toBeLessThan(1_048_576);
             const after = authorityDigest(databasePath);
             expect(after).toEqual(before);
-            expect(phases).toEqual(['added-removed-view-cleanup', 'recorded-revision']);
+            expect(phases).toEqual(['added-removed-view-cleanup', 'migrated-query-indexes', 'recorded-revision']);
 
             const surface = readCleanupSurface(databasePath);
             expect(surface).toMatchObject({

--- a/test/integration/code-graph.session.test.ts
+++ b/test/integration/code-graph.session.test.ts
@@ -67,6 +67,7 @@ beforeAll(() => {
   git(['init', '-q']);
   git(['config', 'user.email', 'threadnote@example.test']);
   git(['config', 'user.name', 'Threadnote Test']);
+  writeFileSync(join(repositoryRoot, '.gitignore'), '/.threadnote-*/\n');
   git(['add', '.']);
   git(['commit', '-qm', 'large base']);
   baseCommit = git(['rev-parse', 'HEAD']).trim();

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -1258,7 +1258,7 @@ describe('Threadnote MCP toolsets', () => {
     );
   }, 40_000);
 
-  it('returns a ready stale graph immediately after a clean checked-out commit change', async () => {
+  it('returns a ready stale graph immediately during dirty and clean repository changes', async () => {
     await withMcpClient(
       async (client, fixture) => {
         const repository = join(fixture.root, 'stale-ready-repository');
@@ -1316,6 +1316,26 @@ describe('Threadnote MCP toolsets', () => {
             'export function addedAfterPull(): string { return "after"; }\n',
             'utf8',
           );
+
+          const dirtyStartedAt = Date.now();
+          const dirtyStale = await client.callTool(
+            {
+              arguments: {callerCwd: repository, operation: 'query', query: 'indexedBeforePull'},
+              name: 'inspect_code_graph',
+            },
+            undefined,
+            {timeout: 5_000},
+          );
+          expect(Date.now() - dirtyStartedAt).toBeLessThan(2_000);
+          expect(dirtyStale.isError).not.toBe(true);
+          expect(dirtyStale.structuredContent).toMatchObject({
+            freshness: 'stale',
+            nodes: expect.arrayContaining([expect.objectContaining({name: 'indexedBeforePull'})]),
+            operation: 'query',
+            snapshot: {commit: indexedCommit, id: firstSnapshotId},
+          });
+          expect((dirtyStale.structuredContent as {readonly state?: unknown} | undefined)?.state).toBeUndefined();
+
           execFileSync('git', ['add', '.'], {cwd: repository});
           execFileSync('git', ['commit', '-qm', 'clean pulled commit'], {cwd: repository});
 

--- a/test/unit/code-graph.analysis-summary.property.test.ts
+++ b/test/unit/code-graph.analysis-summary.property.test.ts
@@ -72,6 +72,7 @@ describe('persisted code graph analysis summaries', () => {
               yield* store.stageActivationFacts(databasePath, baseSymbols, [...baseEdgeMap.values()]);
               yield* store.activateStaged(databasePath, identity, baseSnapshot, {
                 fileSetFingerprint: 'base-files',
+                packProvenance: [],
                 workspaceFingerprint: 'base-workspace',
               });
               const effectiveFile = inventoryFile('effective');
@@ -181,6 +182,7 @@ describe('persisted code graph analysis summaries', () => {
             yield* store.stageActivationFacts(databasePath, symbols, baseEdges);
             yield* store.activateStaged(databasePath, identity, base, {
               fileSetFingerprint: 'collision-base-files',
+              packProvenance: [],
               workspaceFingerprint: 'collision-base-workspace',
             });
             const file = inventoryFile('collision-effective');

--- a/test/unit/code-graph.benchmark-harness.test.ts
+++ b/test/unit/code-graph.benchmark-harness.test.ts
@@ -250,12 +250,20 @@ describe('code graph external benchmark harness', () => {
 
   it('retains privacy-safe structural parity evidence before a failed external run exits', () => {
     const source = readFileSync('scripts/benchmark-code-graph.ts', 'utf8');
+    const analysisParity = sourceSlice(source, 'if (!analysisComplete)', 'const structuralGraphParityEvidence');
     const parity = sourceSlice(
       source,
       'const structuralGraphParityEvidence = codeGraphStructuralParityEvidence(',
       'const coldLanguageCounts',
     );
 
+    expectInOrder(analysisParity, [
+      'const sameOverlayReferenceAnalysis = yield* analysis.analyze({',
+      'databasePath: sameOverlayReferenceLayout.databasePath',
+      'snapshot: sameOverlayReference.summary.snapshot',
+      'const incrementalStructuralGraphEvidence',
+      'const sameOverlayReferenceStructuralGraphEvidence',
+    ]);
     expectInOrder(parity, [
       'if (!structuralGraphParityEvidence.parity)',
       '.structural-parity.json',
@@ -345,8 +353,11 @@ describe('code graph external benchmark harness', () => {
     ).toThrow('did not restore FULL after NORMAL');
     expect(() =>
       validateSqliteWriterSettingsEvidence('current', [
-        ...evidence.filter(settings => settings.phase === 'connection').slice(0, 2),
-        {...connection('same-overlay-reference'), walAutoCheckpointPages: 8_192},
+        ...evidence
+          .filter(settings => settings.phase === 'connection')
+          .slice(0, 2)
+          .map(settings => ({...settings, cacheSizePragma: -64})),
+        {...connection('same-overlay-reference'), cacheSizePragma: -64, walAutoCheckpointPages: 8_192},
       ]),
     ).toThrow('did not apply its WAL checkpoint cadence');
   });

--- a/test/unit/code-graph.build-status.test.ts
+++ b/test/unit/code-graph.build-status.test.ts
@@ -792,6 +792,8 @@ describe('code graph cross-process build status', () => {
           metrics: {
             batchesCompleted: 3,
             batchesTotal: 10,
+            fallbackReason: 'file-set-changed',
+            mode: 'full',
             rows: {edges: 90, symbols: 60},
             sourceBytesCompleted: 12_000,
             sourceBytesTotal: 40_000,
@@ -847,7 +849,11 @@ describe('code graph cross-process build status', () => {
     expect(result.elapsedMilliseconds).toBeLessThan(2_000);
     const status = JSON.parse(result.output) as Record<string, unknown>;
     expect(status).toMatchObject({
-      build: {counters: {completed: 3, reused: 2, total: 10}, state: 'running'},
+      build: {
+        counters: {completed: 3, reused: 2, total: 10},
+        materialization: {metrics: {fallbackReason: 'file-set-changed', mode: 'full'}},
+        state: 'running',
+      },
       obsoleteStores: {bytes: 15, fileCount: 1, unsafeEntryCount: 0},
       type: 'code-graph-status',
       version: 2,
@@ -856,6 +862,8 @@ describe('code graph cross-process build status', () => {
     expect(idleStatus).toMatchObject({build: null, builds: [], type: 'code-graph-status', version: 2});
     expect(Object.keys(idleStatus).sort()).toEqual(Object.keys(status).sort());
     expect(result.human).toContain('Current activity: writing graph facts');
+    expect(result.human).toContain('full materialization');
+    expect(result.human).toContain('incremental fallback: file set changed');
     expect(result.human).toContain('23.4 KiB current TEMP database');
     expect(result.human).toContain('31.3 KiB TEMP database high-water');
     expect(result.human).toContain('46.9 KiB allocated durable pages');

--- a/test/unit/code-graph.cli-freshness.property.test.ts
+++ b/test/unit/code-graph.cli-freshness.property.test.ts
@@ -1,0 +1,81 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  codeGraphCliReadPlan,
+  defaultCodeGraphCliFreshness,
+  type CodeGraphCliFreshnessPolicy,
+} from '../../src/code_graph/commands.js';
+import type {CodeGraphSnapshot} from '../../src/code_graph/types.js';
+
+const readySnapshot: CodeGraphSnapshot = {
+  commit: 'a'.repeat(40),
+  dirty: false,
+  edgeCount: 1,
+  extractorSet: 'extractor',
+  fileCount: 1,
+  graphContentId: 'content',
+  id: 'cgsn_ready',
+  repositoryId: 'repository',
+  state: 'ready',
+  symbolCount: 1,
+  worktreeId: 'worktree',
+};
+
+describe('code graph CLI freshness properties', () => {
+  it('keeps path and impact strict-current while ordinary semantic reads default to ready', () => {
+    expect(defaultCodeGraphCliFreshness('path')).toBe('current');
+    expect(defaultCodeGraphCliFreshness('impact')).toBe('current');
+    for (const operation of ['query', 'node', 'neighbors', 'explain'] as const) {
+      expect(defaultCodeGraphCliFreshness(operation)).toBe('ready');
+    }
+  });
+
+  it('matches the independent readiness model for every policy and status shape', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom<CodeGraphCliFreshnessPolicy>('ready', 'current', 'allow-stale'),
+        fc.boolean(),
+        fc.boolean(),
+        (policy, hasReadySnapshot, stale) => {
+          const result = codeGraphCliReadPlan(policy, {
+            readySnapshot: hasReadySnapshot ? readySnapshot : undefined,
+            stale,
+          });
+          const expectedUnavailable = policy === 'allow-stale' && !hasReadySnapshot;
+          const expectedRefresh = !expectedUnavailable && (!hasReadySnapshot || (stale && policy === 'current'));
+
+          expect(result).toEqual({
+            refresh: expectedRefresh,
+            strictFreshness: policy === 'current',
+            unavailable: expectedUnavailable,
+          });
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it('never starts indexing when allow-stale is selected', () => {
+    fc.assert(
+      fc.property(fc.boolean(), fc.boolean(), (hasReadySnapshot, stale) => {
+        const result = codeGraphCliReadPlan('allow-stale', {
+          readySnapshot: hasReadySnapshot ? readySnapshot : undefined,
+          stale,
+        });
+        expect(result.refresh).toBe(false);
+        expect(result.unavailable).toBe(!hasReadySnapshot);
+      }),
+      {numRuns: 50},
+    );
+  });
+
+  it('uses an existing ready snapshot without refreshing under the default ready policy', () => {
+    fc.assert(
+      fc.property(fc.boolean(), stale => {
+        const result = codeGraphCliReadPlan('ready', {readySnapshot, stale});
+        expect(result).toEqual({refresh: false, strictFreshness: false, unavailable: false});
+      }),
+      {numRuns: 50},
+    );
+  });
+});

--- a/test/unit/code-graph.corpus.test.ts
+++ b/test/unit/code-graph.corpus.test.ts
@@ -1,15 +1,35 @@
 import {describe, expect, test} from 'vitest';
+import fc from 'fast-check';
 import {strToU8, zipSync} from 'fflate';
 import {Option} from 'effect';
 import {extractCorpusFile} from '../../src/code_graph/languages/corpus/extractor.js';
 import {
   CORPUS_ARCHIVE_ENTRY_BYTES_LIMIT,
   CORPUS_EXTRACTION_SOURCE_BYTES_LIMIT,
+  OPAQUE_CORPUS_MEDIA_EXTENSIONS,
+  isOpaqueCorpusMediaPath,
 } from '../../src/code_graph/languages/corpus/policy.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../../src/code_graph/languages/registry.js';
 import type {CodeGraphInventoryFile} from '../../src/code_graph/types.js';
 
 describe('code graph corpus extraction', () => {
+  test('classifies opaque media by final extension independent of path shape and case', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...OPAQUE_CORPUS_MEDIA_EXTENSIONS),
+        fc.array(fc.stringMatching(/^[a-z0-9_-]{1,12}$/u), {maxLength: 4}),
+        fc.boolean(),
+        (extension, directories, uppercase) => {
+          const suffix = uppercase ? extension.toUpperCase() : extension;
+          const path = [...directories, `asset${suffix}`].join('/');
+          expect(isOpaqueCorpusMediaPath(path)).toBe(true);
+          expect(isOpaqueCorpusMediaPath(`${path}.txt`)).toBe(false);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
   test('turns structured text and external references into searchable graph evidence', async () => {
     const facts = await extractCorpusFile(
       textFile(

--- a/test/unit/code-graph.extractor-budgets.test.ts
+++ b/test/unit/code-graph.extractor-budgets.test.ts
@@ -1,13 +1,58 @@
 import {Option} from 'effect';
+import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
-import {extractFileFacts, TYPESCRIPT_DYNAMIC_RELATIONSHIP_LIMIT} from '../../src/code_graph/extractor.js';
+import {
+  createResolutionAttributor,
+  extractFileFacts,
+  TYPESCRIPT_DYNAMIC_RELATIONSHIP_LIMIT,
+} from '../../src/code_graph/extractor.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../../src/code_graph/languages/registry.js';
 import {extractStructuredSchemaFacts} from '../../src/code_graph/languages/schemas/extractor.js';
+import {GENERIC_STRUCTURED_DECLARATION_LIMIT} from '../../src/code_graph/languages/schemas/policy.js';
 import type {CodeGraphWorkspaceProject} from '../../src/code_graph/languages/types.js';
 import type {CodeGraphInventoryFile} from '../../src/code_graph/types.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
 describe('code graph per-file extraction budgets', () => {
+  it('bounds generic structured declarations deterministically across object widths', () => {
+    fc.assert(
+      fc.property(fc.integer({max: 800, min: 0}), width => {
+        const content = JSON.stringify(
+          Object.fromEntries(Array.from({length: width}, (_, index) => [`property-${index}`, {leaf: index}])),
+        );
+        const first = extractStructuredSchemaFacts(sourceFile('data/object.json', 'json', content), {
+          packageName: Option.none(),
+          project: Option.none(),
+        });
+        const second = extractStructuredSchemaFacts(sourceFile('data/object.json', 'json', content), {
+          packageName: Option.none(),
+          project: Option.none(),
+        });
+
+        expect(first).toEqual(second);
+        expect(first.symbols.length).toBeLessThanOrEqual(GENERIC_STRUCTURED_DECLARATION_LIMIT + 1);
+        if (width > GENERIC_STRUCTURED_DECLARATION_LIMIT) {
+          expect(first.diagnostics.join('\n')).toContain('generic structured declarations were bounded');
+        }
+      }),
+      {numRuns: 40},
+    );
+  });
+
+  it('does not materialize global resolution projections for generic structured leaves', () => {
+    const file = sourceFile('data/object.json', 'json', JSON.stringify({root: {first: 1, second: 2}}));
+    const extracted = extractStructuredSchemaFacts(file, {packageName: Option.none(), project: Option.none()});
+    const [facts] = createResolutionAttributor([file])([extracted]);
+    if (!facts) throw new Error('missing resolved structured facts');
+    const leaves = facts.symbols.filter(symbol => symbol.kind === 'property');
+
+    expect(leaves.length).toBeGreaterThan(0);
+    expect(leaves.every(symbol => (symbol.lookupKeys ?? []).length === 0)).toBe(true);
+    expect(facts.symbols.find(symbol => symbol.kind === 'module')?.lookupKeys).toEqual(
+      expect.arrayContaining(['global:path:data%2Fobject.json']),
+    );
+  });
+
   it('bounds pathological TypeScript calls while preserving imports, reexports, and later declarations', () => {
     const calls = Array.from({length: TYPESCRIPT_DYNAMIC_RELATIONSHIP_LIMIT + 2_000}, () => 'dependency();');
     const content = [

--- a/test/unit/code-graph.incomplete-retirement.test.ts
+++ b/test/unit/code-graph.incomplete-retirement.test.ts
@@ -272,6 +272,65 @@ describe('code graph incomplete snapshot retirement', () => {
     }
   }, 15_000);
 
+  it('defers repository-sized physical cleanup after one bounded retirement transaction', async () => {
+    const root = await mkdtemp('threadnote-incomplete-deferred-reclaim-');
+    temporaryRoots.push(root);
+    const databasePath = join(root, 'graph-v3.sqlite');
+    const writerLockPath = join(root, 'checkout-writer.lock');
+    const identity = repositoryIdentity(root, 'repository-a', 'worktree-a');
+    const stale = buildingSnapshot(identity, 'stale-deferred');
+
+    await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        yield* claimPersistentBuildForTest(store, databasePath, identity, stale);
+      }),
+    );
+    seedLargeInterruptedBuild(databasePath, stale.id, false);
+
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        const retirementAcquisitions = yield* Ref.make(0);
+        const retired = yield* store.withSession(
+          databasePath,
+          store.retireIncompleteWorktreeSnapshots(
+            databasePath,
+            identity.repositoryId,
+            identity.worktreeId,
+            new Set(),
+            undefined,
+            {cleanupMode: 'deferred'},
+          ),
+          {
+            onWriterAcquired: () => Ref.update(retirementAcquisitions, count => count + 1),
+            writerLockPath,
+          },
+        );
+        const retainedRows = yield* Effect.sync(() => interruptedRowCount(databasePath, stale.id));
+        yield* store.pruneRetiredSnapshots(databasePath);
+        return {
+          acquisitions: yield* Ref.get(retirementAcquisitions),
+          retainedRows,
+          retired,
+        };
+      }),
+    );
+
+    expect(result.acquisitions).toBe(2);
+    expect(result.retainedRows).toBeGreaterThan(0);
+    expect(result.retainedRows).toBeLessThan(13_500);
+    expect(result.retired).toBe(1);
+    const database = new Database(databasePath, {readonly: true});
+    try {
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(stale.id)).toBeNull();
+      expect(database.query('PRAGMA foreign_key_check').all()).toEqual([]);
+    } finally {
+      database.close();
+    }
+  }, 15_000);
+
   it('never reclaims another worktree from PID, age, or failed-state hints alone', async () => {
     const root = await mkdtemp('threadnote-incomplete-orphan-reclaim-');
     temporaryRoots.push(root);
@@ -404,7 +463,7 @@ describe('code graph incomplete snapshot retirement', () => {
   });
 });
 
-function seedLargeInterruptedBuild(databasePath: string, snapshotId: string): void {
+function seedLargeInterruptedBuild(databasePath: string, snapshotId: string, retired = true): void {
   const database = new Database(databasePath, {strict: true});
   try {
     const insertSymbol = database.prepare(
@@ -439,8 +498,26 @@ function seedLargeInterruptedBuild(databasePath: string, snapshotId: string): vo
           `target${index}`,
         );
       }
-      database.query("UPDATE snapshots SET state = 'retired' WHERE id = ?").run(snapshotId);
+      if (retired) database.query("UPDATE snapshots SET state = 'retired' WHERE id = ?").run(snapshotId);
     })();
+  } finally {
+    database.close();
+  }
+}
+
+function interruptedRowCount(databasePath: string, snapshotId: string): number {
+  const database = new Database(databasePath, {readonly: true});
+  try {
+    return ['symbols', 'symbol_terms', 'edges'].reduce(
+      (total, table) =>
+        total +
+        Number(
+          database
+            .query<{readonly count: number}, [string]>(`SELECT COUNT(*) AS count FROM ${table} WHERE snapshot_id = ?`)
+            .get(snapshotId)?.count ?? 0,
+        ),
+      0,
+    );
   } finally {
     database.close();
   }

--- a/test/unit/code-graph.indexer.property.test.ts
+++ b/test/unit/code-graph.indexer.property.test.ts
@@ -8,6 +8,7 @@ import {
   estimatedMaterializationStorageBytes,
   factMaterializationBatches,
   graphContentIdentity,
+  extractorSetIdentity,
   materializationRowsWithStoreProgress,
   materializationStoragePlan,
   materializationStorageShortfalls,
@@ -37,6 +38,25 @@ const materializationRows = FC.record({
 });
 
 describe('code graph indexer properties', () => {
+  it('keeps extractor selection independent of content while detecting active pack changes', () => {
+    fc.assert(
+      fc.property(fc.string({minLength: 1}), fc.string({minLength: 1}), (leftHash, rightHash) => {
+        const paths = [
+          {contentHash: leftHash, path: 'MODULE.bazel'},
+          {contentHash: leftHash, path: 'src/index.ts'},
+          {contentHash: leftHash, path: 'tsconfig.json'},
+        ];
+        const changedContent = paths.map(file => ({...file, contentHash: rightHash}));
+        const identity = extractorSetIdentity(paths);
+
+        expect(extractorSetIdentity(changedContent)).toBe(identity);
+        expect(extractorSetIdentity([...paths].reverse())).toBe(identity);
+        expect(extractorSetIdentity([...paths, {contentHash: leftHash, path: 'src/tool.py'}])).not.toBe(identity);
+      }),
+      {numRuns: 100},
+    );
+  });
+
   it('includes the compact lexical format in deterministic snapshot identity', () => {
     const identity = {headCommit: 'a'.repeat(40), repositoryId: 'b'.repeat(64), worktreeId: 'c'.repeat(64)};
     const files = [{contentHash: 'd'.repeat(64), path: 'src/index.ts', source: 'commit'}];

--- a/test/unit/code-graph.indexer.property.test.ts
+++ b/test/unit/code-graph.indexer.property.test.ts
@@ -4,6 +4,8 @@ import fc from 'fast-check';
 import {
   addMaterializationRows,
   compactCachedFileRelationships,
+  codeGraphActiveParserCacheKey,
+  codeGraphParserCacheLookupGenerations,
   deduplicateMaterializationRelationships,
   estimatedMaterializationStorageBytes,
   factMaterializationBatches,
@@ -38,6 +40,43 @@ const materializationRows = FC.record({
 });
 
 describe('code graph indexer properties', () => {
+  it.prop(
+    'admits both active and degraded parser cache generations deterministically',
+    {
+      activeIdentities: FC.uniqueArray(FC.string({maxLength: 80, minLength: 1}), {maxLength: 8}),
+    },
+    ({activeIdentities}) => {
+      const generations = codeGraphParserCacheLookupGenerations(activeIdentities);
+      const expected = [...new Set(activeIdentities)].sort().flatMap(activeIdentity => [
+        {activeIdentity, storedIdentity: activeIdentity},
+        {
+          activeIdentity,
+          storedIdentity: sha256HexSync(`code-graph-parser-degraded-v1\n${activeIdentity}`),
+        },
+      ]);
+
+      expect(generations).toEqual(expected);
+      expect(codeGraphParserCacheLookupGenerations([...activeIdentities].reverse())).toEqual(generations);
+      for (const generation of generations) {
+        expect(
+          codeGraphActiveParserCacheKey(
+            `src/file.ts\0content-hash\0${generation.storedIdentity}`,
+            generation.storedIdentity,
+            generation.activeIdentity,
+          ),
+        ).toBe(`src/file.ts\0content-hash\0${generation.activeIdentity}`);
+        expect(
+          codeGraphActiveParserCacheKey(
+            `blob\0blob-id\0content-hash\0${generation.storedIdentity}\0reuse-class`,
+            generation.storedIdentity,
+            generation.activeIdentity,
+          ),
+        ).toBe(`blob\0blob-id\0content-hash\0${generation.activeIdentity}\0reuse-class`);
+      }
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
   it('keeps extractor selection independent of content while detecting active pack changes', () => {
     fc.assert(
       fc.property(fc.string({minLength: 1}), fc.string({minLength: 1}), (leftHash, rightHash) => {

--- a/test/unit/code-graph.manager-catalog.test.ts
+++ b/test/unit/code-graph.manager-catalog.test.ts
@@ -76,7 +76,7 @@ describe('Manager logical repository and workspace catalogs', () => {
     );
     const legacy = new Database(databasePath);
     legacy.run("INSERT INTO schema_metadata (key, value) VALUES ('legacy_marker', 'preserve-me')");
-    legacy.run('DROP INDEX symbols_resolution_scope');
+    legacy.run('DROP INDEX IF EXISTS symbols_resolution_scope');
     legacy.run('DROP INDEX symbols_visualization_scope_v2');
     legacy.run('DROP INDEX symbols_visualization_package_v2');
     legacy.run('DROP INDEX symbols_visualization_path_v2');
@@ -102,6 +102,16 @@ describe('Manager logical repository and workspace catalogs', () => {
     expect(
       migrated.query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workspace_components'").get(),
     ).toEqual({name: 'workspace_components'});
+    expect(
+      migrated
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND name IN ('symbols_name', 'symbols_resolution_scope', 'edges_target') ORDER BY name",
+        )
+        .all(),
+    ).toEqual([]);
+    expect(
+      migrated.query("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'edges_target_resolved'").get(),
+    ).toEqual({name: 'edges_target_resolved'});
     migrated.close();
   });
 
@@ -800,7 +810,7 @@ describe('Manager logical repository and workspace catalogs', () => {
     planDatabase.close();
     expect(symbolPlan.some(row => row.detail.includes('symbols_visualization_scope_v2'))).toBe(true);
     expect(edgePlan.some(row => row.detail.includes('edges_source'))).toBe(true);
-    expect(edgePlan.some(row => row.detail.includes('edges_target'))).toBe(true);
+    expect(edgePlan.some(row => row.detail.includes('edges_target_resolved'))).toBe(true);
     expect(
       endpointPlan.some(
         row =>

--- a/test/unit/code-graph.materialization-store.test.ts
+++ b/test/unit/code-graph.materialization-store.test.ts
@@ -1594,7 +1594,7 @@ describe('code graph full-build materialization store', () => {
               fixture.databasePath,
               fixture.identity,
               snapshot,
-              {fileSetFingerprint: 'files', workspaceFingerprint: 'workspace'},
+              {fileSetFingerprint: 'files', packProvenance: [], workspaceFingerprint: 'workspace'},
               undefined,
               progress => Effect.sync(() => activation.push(progress)),
             );
@@ -3685,6 +3685,15 @@ describe('code graph full-build materialization store', () => {
     };
     const receiptInput = {
       fileSetFingerprint: 'files-fingerprint',
+      packProvenance: [
+        {
+          cacheIdentity: 'typescript-extractor-v1',
+          derivationIdentity: 'typescript-derivation-v1',
+          id: 'typescript',
+          resolutionDomain: 'typescript',
+          resolutionVersion: 'typescript-resolver-v1',
+        },
+      ],
       workspaceFingerprint: 'workspace-fingerprint',
     };
 
@@ -3726,6 +3735,7 @@ describe('code graph full-build materialization store', () => {
       aliasCount: counts.aliases,
       fileSetFingerprint: receiptInput.fileSetFingerprint,
       lookupCount: counts.lookups,
+      packProvenance: receiptInput.packProvenance,
       reexportCount: 0,
       workspaceFingerprint: receiptInput.workspaceFingerprint,
     });

--- a/test/unit/code-graph.materialization-store.test.ts
+++ b/test/unit/code-graph.materialization-store.test.ts
@@ -262,7 +262,7 @@ describe('code graph full-build materialization store', () => {
           PRIMARY KEY (snapshot_id, id)
         ) WITHOUT ROWID;
         CREATE INDEX edges_source ON edges(snapshot_id, source_id, relation);
-        CREATE INDEX edges_target ON edges(snapshot_id, target_id, relation);
+        CREATE INDEX edges_target_resolved ON edges(snapshot_id, target_id, relation) WHERE target_id IS NOT NULL;
       `);
 
       for (const endpoint of ['source', 'target'] as const) {
@@ -278,7 +278,7 @@ describe('code graph full-build materialization store', () => {
           }[]
         ).map(row => row.detail);
         const output = plan.join('\n');
-        const index = endpoint === 'source' ? 'edges_source' : 'edges_target';
+        const index = endpoint === 'source' ? 'edges_source' : 'edges_target_resolved';
         const column = endpoint === 'source' ? 'source_id' : 'target_id';
 
         expect(output).toContain('MATERIALIZE raw_page');
@@ -4194,7 +4194,7 @@ describe('code graph full-build materialization store', () => {
       const fixture = yield* Effect.promise(materializationFixture);
       const firstSymbol = symbol('retired-symbol', 'retiredSymbol', ['typescript:name:retiredSymbol']);
       const currentSymbol = symbol('current-symbol', 'currentSymbol', ['typescript:name:currentSymbol']);
-      const firstSnapshot = {...readySnapshot(fixture.identity, 1, 0), id: testSnapshotId(103)};
+      const firstSnapshot = {...readySnapshot(fixture.identity, 1, 0), dirty: true, id: testSnapshotId(103)};
       const currentSnapshot = {...readySnapshot(fixture.identity, 1, 0), id: testSnapshotId(104)};
 
       yield* Effect.gen(function* () {

--- a/test/unit/code-graph.materialization-store.test.ts
+++ b/test/unit/code-graph.materialization-store.test.ts
@@ -36,6 +36,7 @@ import {
   type CodeGraphSqliteWriterTuning,
   type CodeGraphStagingProgress,
 } from '../../src/code_graph/store.js';
+import {prepareActivationTables} from '../../src/code_graph/store_staging_core.js';
 import {
   CodeGraphStoreError,
   CodeGraphStoreNoSpaceError,
@@ -81,17 +82,24 @@ describe('code graph full-build materialization store', () => {
         return yield* store.withSession(
           fixture.databasePath,
           Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            yield* prepareActivationTables(sql);
+            const temporaryCache = yield* sql.unsafe<{readonly cache_size: number}>('PRAGMA temp.cache_size');
+            const temporarySpill = yield* sql.unsafe<{readonly cache_spill: number}>('PRAGMA temp.cache_spill');
             const snapshot = {...readySnapshot(fixture.identity, 0, 0), id: 'pager-configuration'};
             const ownerToken = yield* claimPersistentBuildForTest(store, fixture.databasePath, fixture.identity, {
               ...snapshot,
               state: 'building',
             });
             yield* store.prepareActivation(fixture.databasePath, [], snapshot.id, 0, ownerToken);
-            const sql = yield* SqlClient.SqlClient;
             const cache = yield* sql.unsafe<{readonly cache_size: number}>('PRAGMA main.cache_size');
+            const spill = yield* sql.unsafe<{readonly cache_spill: number}>('PRAGMA cache_spill');
             const temporary = yield* sql.unsafe<{readonly temp_store: number}>('PRAGMA temp_store');
             return {
               cacheSize: Number(cache[0]?.cache_size),
+              spillPages: Number(spill[0]?.cache_spill),
+              temporaryCacheSize: Number(temporaryCache[0]?.cache_size),
+              temporarySpillPages: Number(temporarySpill[0]?.cache_spill),
               temporaryStore: Number(temporary[0]?.temp_store),
             };
           }),
@@ -100,7 +108,13 @@ describe('code graph full-build materialization store', () => {
       }),
     );
 
-    expect(pager).toEqual({cacheSize: -64 * 1_024, temporaryStore: 2});
+    expect(pager).toEqual({
+      cacheSize: -64,
+      spillPages: 16,
+      temporaryCacheSize: -64,
+      temporarySpillPages: 16,
+      temporaryStore: 2,
+    });
   });
 
   it('restores FULL durability before publication and leaves a failed publication resumable', async () => {

--- a/test/unit/code-graph.mixed-monorepo-gate.test.ts
+++ b/test/unit/code-graph.mixed-monorepo-gate.test.ts
@@ -1,0 +1,80 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect} from 'effect';
+import {
+  MIXED_NX_BAZEL_FIXTURE_SOURCES,
+  parseMixedNxBazelFixtureArguments,
+} from '../../scripts/generate-mixed-nx-bazel-fixture.js';
+import {
+  type MixedNxBazelGateBudgets,
+  type MixedNxBazelGateEvidence,
+  validateMixedNxBazelGate,
+} from '../../scripts/validate-mixed-nx-bazel-gate.js';
+
+const budgets: MixedNxBazelGateBudgets = {
+  maximum: {
+    analysisMilliseconds: 15_000,
+    analysisPeakRssBytes: 750 * 1_048_576,
+    boundedStaleReadMilliseconds: 25_000,
+    coldIndexMilliseconds: 287_340,
+    crashRecoveryForegroundMilliseconds: 2_000,
+    currentQueryMilliseconds: 1_000,
+    inventoryMilliseconds: 2_000,
+    oneFileIncrementalMilliseconds: 8_000,
+    oneFileIncrementalPeakRssBytes: 512 * 1_048_576,
+    postChurnStorageGrowthPercent: 10,
+    stableNoopMilliseconds: 2_000,
+  },
+};
+
+const passingEvidence: MixedNxBazelGateEvidence = {
+  analysisMilliseconds: 14_999,
+  analysisPeakRssBytes: 750 * 1_048_576,
+  boundedStaleReadMilliseconds: 24_999,
+  coldIndexMilliseconds: 287_340,
+  crashRecoveryForegroundMilliseconds: 1_999,
+  currentQueryMilliseconds: 999,
+  inventoryMilliseconds: 1_999,
+  movingTarget: {
+    newestRefreshCoalesced: true,
+    postTargetMaterializationMode: 'incremental-overlay',
+    stagedFiles: 2,
+    targetCommitExposed: true,
+    totalFiles: 18_510,
+  },
+  oneFileIncrementalMilliseconds: 7_999,
+  oneFileIncrementalPeakRssBytes: 512 * 1_048_576,
+  postChurnStorageGrowthPercent: 9.9,
+  stableNoopMilliseconds: 1_999,
+};
+
+describe('mixed Nx/Bazel release gate', () => {
+  it.effect('pins the reviewed public repositories and accepts an explicit output only', () =>
+    Effect.sync(() => {
+      expect(MIXED_NX_BAZEL_FIXTURE_SOURCES.map(source => `${source.id}@${source.commit}`)).toEqual([
+        'nx@2d15c7faa570629657112857a079803897e8e43d',
+        'rules-js@0960bdd0f542a73a4a6fa3183d68ef5766cce285',
+        'angular@8925a4ee491aebaf6a1a74880c73dfb20e0a4ba1',
+      ]);
+      expect(parseMixedNxBazelFixtureArguments(['--output', '/tmp/mixed-fixture'])).toEqual({
+        output: '/tmp/mixed-fixture',
+      });
+      expect(() => parseMixedNxBazelFixtureArguments([])).toThrow(/--output/);
+    }),
+  );
+
+  it.effect('enforces every latency, memory, storage, and moving-target contract', () =>
+    Effect.sync(() => {
+      expect(() => validateMixedNxBazelGate(passingEvidence, budgets)).not.toThrow();
+      expect(() =>
+        validateMixedNxBazelGate(
+          {
+            ...passingEvidence,
+            oneFileIncrementalPeakRssBytes: budgets.maximum.oneFileIncrementalPeakRssBytes + 1,
+            movingTarget: {...passingEvidence.movingTarget, postTargetMaterializationMode: 'full'},
+          },
+          budgets,
+        ),
+      ).toThrow(/oneFileIncrementalPeakRssBytes.*post-target refresh replayed a full graph/);
+    }),
+  );
+});

--- a/test/unit/code-graph.pack-provenance.property.test.ts
+++ b/test/unit/code-graph.pack-provenance.property.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {extractorSetIdentityFromPackProvenance} from '../../src/code_graph/indexer.js';
+import {assessCodeGraphLanguagePackDelta} from '../../src/code_graph/languages/provenance.js';
+import type {CodeGraphLanguagePackProvenance} from '../../src/code_graph/store.js';
+
+const packIds = ['typescript', 'bazel', 'python', 'java'] as const;
+
+describe('code graph language-pack provenance', () => {
+  it.effect.prop(
+    'selects exactly cache-identity changes independent of receipt ordering',
+    {
+      changed: FC.uniqueArray(FC.constantFrom(...packIds), {maxLength: packIds.length}),
+      reversePrevious: FC.constantFrom(false, true),
+      reverseCurrent: FC.constantFrom(false, true),
+    },
+    ({changed, reverseCurrent, reversePrevious}) =>
+      Effect.sync(() => {
+        const previous = packIds.map(pack);
+        const changedIds = new Set<string>(changed);
+        const current = previous.map(value =>
+          changedIds.has(value.id) ? {...value, cacheIdentity: `${value.cacheIdentity}-next`} : value,
+        );
+        const result = assessCodeGraphLanguagePackDelta(
+          reversePrevious ? [...previous].reverse() : previous,
+          reverseCurrent ? [...current].reverse() : current,
+        );
+        expect(result).toEqual({changedPackIds: [...changed].sort(), mode: 'compatible'});
+        expect(extractorSetIdentityFromPackProvenance(previous)).toBe(
+          extractorSetIdentityFromPackProvenance([...previous].reverse()),
+        );
+      }),
+    {fastCheck: {numRuns: 100}},
+  );
+
+  it.effect('fails closed when resolution derivation or active pack membership changes', () =>
+    Effect.sync(() => {
+      const previous = [pack('typescript'), pack('bazel')];
+      expect(
+        assessCodeGraphLanguagePackDelta(previous, [
+          {...pack('typescript'), resolutionVersion: 'resolver-v2'},
+          pack('bazel'),
+        ]),
+      ).toEqual({mode: 'fallback', reason: 'pack-surface-changed'});
+      expect(assessCodeGraphLanguagePackDelta(previous, [pack('typescript')])).toEqual({
+        mode: 'fallback',
+        reason: 'pack-surface-changed',
+      });
+      expect(assessCodeGraphLanguagePackDelta([], previous)).toEqual({
+        mode: 'fallback',
+        reason: 'missing-provenance',
+      });
+    }),
+  );
+});
+
+function pack(id: string): CodeGraphLanguagePackProvenance {
+  return {
+    cacheIdentity: `${id}-extractor-v1`,
+    derivationIdentity: `${id}-derivation-v1`,
+    id,
+    resolutionDomain: id,
+    resolutionVersion: 'resolver-v1',
+  };
+}

--- a/test/unit/code-graph.persisted-delta-resolution.test.ts
+++ b/test/unit/code-graph.persisted-delta-resolution.test.ts
@@ -32,6 +32,7 @@ describe('persisted delta reference resolution', () => {
               yield* store.stageActivationFacts(databasePath, fixture.baseSymbols, []);
               yield* store.activateStaged(databasePath, fixture.identity, fixture.baseSnapshot, {
                 fileSetFingerprint: 'large-base-files',
+                packProvenance: [],
                 workspaceFingerprint: 'large-base-workspace',
               });
 

--- a/test/unit/code-graph.project-closure-store.test.ts
+++ b/test/unit/code-graph.project-closure-store.test.ts
@@ -25,6 +25,7 @@ describe('project-closure persisted store', () => {
         yield* store.stageActivationFacts(databasePath, [baseSymbol], []);
         yield* store.activateStaged(databasePath, identity, base, {
           fileSetFingerprint: 'same-files',
+          packProvenance: [],
           workspaceFingerprint: 'same-workspace',
         });
 
@@ -94,6 +95,7 @@ describe('project-closure persisted store', () => {
         yield* store.stageActivationFacts(databasePath, [symbol(1)], []);
         yield* store.activateStaged(databasePath, identity, base, {
           fileSetFingerprint: 'same-files',
+          packProvenance: [],
           workspaceFingerprint: 'same-workspace',
         });
         yield* Effect.sync(() => insertReexports(databasePath, base.id, 10_001));
@@ -120,6 +122,7 @@ describe('project-closure persisted store', () => {
         yield* store.stageActivationFacts(databasePath, [symbol(1)], []);
         yield* store.activateStaged(databasePath, identity, base, {
           fileSetFingerprint: 'same-files',
+          packProvenance: [],
           workspaceFingerprint: 'same-workspace',
         });
         yield* Effect.sync(() => insertOverlappingReexports(databasePath, base.id));
@@ -147,6 +150,7 @@ describe('project-closure persisted store', () => {
         yield* store.stageActivationFacts(databasePath, [symbol(1)], []);
         yield* store.activateStaged(databasePath, identity, base, {
           fileSetFingerprint: 'same-files',
+          packProvenance: [],
           workspaceFingerprint: 'same-workspace',
         });
         const facts = fileFacts(file.path, symbol(2));

--- a/test/unit/code-graph.removed-view-cleanup-store.test.ts
+++ b/test/unit/code-graph.removed-view-cleanup-store.test.ts
@@ -27,7 +27,7 @@ const SNAPSHOT_ID = 'cgsn_1111111111111111111111111111111111111111';
 const NEW_SNAPSHOT_ID = 'cgsn_2222222222222222222222222222222222222222';
 
 describe('removed code graph view cleanup queue', () => {
-  effectIt.effect('upgrades an exact revision 8 cleanup authority to revision 10 without retiring ready views', () =>
+  effectIt.effect('upgrades an exact revision 8 cleanup authority to revision 11 without retiring ready views', () =>
     withFixture('threadnote-removed-cleanup-r8-r9-', ({databasePath}) =>
       Effect.gen(function* () {
         const store = yield* CodeGraphStore;
@@ -80,7 +80,7 @@ describe('removed code graph view cleanup queue', () => {
             {name: 'snapshot_component_edge_aggregates'},
           ],
           ready: {state: 'ready'},
-          revision: {value: '10'},
+          revision: {value: '11'},
         });
       }),
     ).pipe(Effect.provide(ApplicationLayer)),
@@ -133,8 +133,8 @@ describe('removed code graph view cleanup queue', () => {
           }
         });
 
-        expect(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION).toBe(10);
-        expect(observed.revision).toEqual({value: '10'});
+        expect(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION).toBe(11);
+        expect(observed.revision).toEqual({value: '11'});
         expect(observed.ready).toEqual({state: 'ready'});
         expect(observed.building).toEqual({state: 'building'});
         expect(observed.active).toEqual([{snapshot_id: SNAPSHOT_ID, worktree_id: WORKTREE_ID}]);

--- a/test/unit/code-graph.removed-view-cleanup-store.test.ts
+++ b/test/unit/code-graph.removed-view-cleanup-store.test.ts
@@ -27,7 +27,7 @@ const SNAPSHOT_ID = 'cgsn_1111111111111111111111111111111111111111';
 const NEW_SNAPSHOT_ID = 'cgsn_2222222222222222222222222222222222222222';
 
 describe('removed code graph view cleanup queue', () => {
-  effectIt.effect('upgrades an exact revision 8 cleanup authority to revision 9 without retiring ready views', () =>
+  effectIt.effect('upgrades an exact revision 8 cleanup authority to revision 10 without retiring ready views', () =>
     withFixture('threadnote-removed-cleanup-r8-r9-', ({databasePath}) =>
       Effect.gen(function* () {
         const store = yield* CodeGraphStore;
@@ -80,7 +80,7 @@ describe('removed code graph view cleanup queue', () => {
             {name: 'snapshot_component_edge_aggregates'},
           ],
           ready: {state: 'ready'},
-          revision: {value: '9'},
+          revision: {value: '10'},
         });
       }),
     ).pipe(Effect.provide(ApplicationLayer)),
@@ -133,8 +133,8 @@ describe('removed code graph view cleanup queue', () => {
           }
         });
 
-        expect(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION).toBe(9);
-        expect(observed.revision).toEqual({value: '9'});
+        expect(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION).toBe(10);
+        expect(observed.revision).toEqual({value: '10'});
         expect(observed.ready).toEqual({state: 'ready'});
         expect(observed.building).toEqual({state: 'building'});
         expect(observed.active).toEqual([{snapshot_id: SNAPSHOT_ID, worktree_id: WORKTREE_ID}]);

--- a/test/unit/code-graph.schema-migration.test.ts
+++ b/test/unit/code-graph.schema-migration.test.ts
@@ -1,6 +1,6 @@
 import {Database} from 'bun:sqlite';
 import {it as effectIt} from '@effect/vitest';
-import {Deferred, Effect, Fiber, Option} from 'effect';
+import {Deferred, Effect, Exit, Fiber, Option} from 'effect';
 import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
 import {
@@ -12,6 +12,7 @@ import {
 import {
   CODE_GRAPH_SCHEMA_VERSION,
   CodeGraphRuntimeReconnectRequiredError,
+  type CodeGraphEdge,
   type CodeGraphInventoryFile,
   type CodeGraphSnapshot,
   type CodeGraphSymbol,
@@ -122,6 +123,90 @@ describe('code graph persistent schema migration', () => {
       {numRuns: 10},
     );
   });
+
+  effectIt.effect('atomically upgrades revision 9 query indexes before serving adjacency', () =>
+    Effect.gen(function* () {
+      const fixture = yield* Effect.promise(migrationFixture);
+      const store = yield* CodeGraphStore;
+      const source = graphSymbol('revision-9-source');
+      const target = graphSymbol('revision-9-target');
+      const edge: CodeGraphEdge = {
+        confidence: 1,
+        evidencePath: fixture.file.path,
+        evidenceSpan: {column: 1, endColumn: 2, endLine: 1, line: 1},
+        id: 'revision-9-edge',
+        provenance: 'resolved',
+        relation: 'calls',
+        sourceId: source.id,
+        sourceName: source.name,
+        targetId: target.id,
+        targetName: target.name,
+      };
+      const ready = {
+        ...snapshot(fixture.identity, 'ready-before-revision-10-index-upgrade'),
+        edgeCount: 1,
+        symbolCount: 2,
+      };
+
+      yield* store.initialize(fixture.databasePath);
+      yield* store.withSession(
+        fixture.databasePath,
+        Effect.gen(function* () {
+          yield* store.prepareActivation(fixture.databasePath, [fixture.file]);
+          yield* store.stageActivationFacts(fixture.databasePath, [source, target], [edge]);
+          yield* store.activateStaged(fixture.databasePath, fixture.identity, ready);
+          yield* store.promote(fixture.databasePath, fixture.identity, ready.id);
+        }),
+      );
+      yield* Effect.sync(() => {
+        const database = new Database(fixture.databasePath, {strict: true});
+        try {
+          database.exec(`
+            DROP INDEX edges_target_resolved;
+            CREATE INDEX edges_target ON edges(snapshot_id, target_id, relation);
+            CREATE INDEX symbols_name ON symbols(snapshot_id, name);
+            CREATE INDEX symbols_resolution_scope ON symbols(snapshot_id, resolution_scope_id);
+            UPDATE schema_metadata
+            SET value = '9'
+            WHERE key = 'persistent_extension_schema_revision';
+          `);
+        } finally {
+          database.close(false);
+        }
+      });
+
+      const interrupted = yield* Effect.exit(
+        store.withSession(fixture.databasePath, store.initialize(fixture.databasePath), {
+          onPersistentSchemaMigrationPhase: phase =>
+            phase === 'migrated-query-indexes'
+              ? Effect.die(new Error('fault after revision 9 query-index migration'))
+              : Effect.void,
+        }),
+      );
+      expect(Exit.isFailure(interrupted)).toBe(true);
+      const rolledBack = yield* Effect.sync(() => readRevision9IndexState(fixture.databasePath));
+      expect(rolledBack).toMatchObject({
+        currentDefinition: undefined,
+        legacyNames: ['edges_target', 'symbols_name', 'symbols_resolution_scope'],
+        revision: '9',
+      });
+
+      const phases: CodeGraphPersistentSchemaMigrationPhase[] = [];
+      yield* store.withSession(fixture.databasePath, store.initialize(fixture.databasePath), {
+        onPersistentSchemaMigrationPhase: phase => Effect.sync(() => phases.push(phase)),
+      });
+      const incoming = yield* store.edgesForNodes(fixture.databasePath, ready.id, [target.id], 'incoming', 10, [
+        'resolved',
+      ]);
+      const migrated = yield* Effect.sync(() => readRevision9IndexState(fixture.databasePath));
+
+      expect(phases).toContain('migrated-query-indexes');
+      expect(migrated.legacyNames).toEqual([]);
+      expect(migrated.currentDefinition).toMatch(/WHERE\s+target_id\s+IS\s+NOT\s+NULL/iu);
+      expect(migrated.revision).toBe(String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION));
+      expect(incoming.map(candidate => candidate.id)).toEqual([edge.id]);
+    }).pipe(Effect.provide(ApplicationLayer)),
+  );
 
   it('keeps revision 4 ready lexical rows readable while enabling compact writes for later snapshots', async () => {
     const fixture = await migrationFixture();
@@ -858,7 +943,7 @@ describe('code graph persistent schema migration', () => {
         onPersistentSchemaMigrationPhase: phase => Effect.sync(() => phases.push(phase)),
       });
       const healed = yield* Effect.sync(() => readRemovedViewCleanupMigrationSurface(fixture.databasePath));
-      expect(phases).toEqual(['added-removed-view-cleanup', 'recorded-revision']);
+      expect(phases).toEqual(['added-removed-view-cleanup', 'migrated-query-indexes', 'recorded-revision']);
       expect(healed.revision).toEqual({value: String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)});
       expect(healed.sequence).toEqual({value: '0'});
       expect(healed.queueRows).toEqual({count: 0});
@@ -916,7 +1001,7 @@ describe('code graph persistent schema migration', () => {
         onPersistentSchemaMigrationPhase: phase => Effect.sync(() => phases.push(phase)),
       });
       const healed = yield* Effect.sync(() => readRemovedViewCleanupMigrationSurface(fixture.databasePath));
-      expect(phases).toEqual(['added-removed-view-cleanup', 'recorded-revision']);
+      expect(phases).toEqual(['added-removed-view-cleanup', 'migrated-query-indexes', 'recorded-revision']);
       expect(healed.revision).toEqual({value: String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)});
       expect(healed.sequence).toEqual({value: '0'});
       expect(healed.queueRows).toEqual({count: 0});
@@ -1611,6 +1696,37 @@ function removeRemovedViewCleanupRevision8(database: Database): void {
        WHERE key IN ('removed_view_cleanup_epoch_sequence', 'removed_view_cleanup_admission_cursor')`,
     )
     .run();
+}
+
+function readRevision9IndexState(databasePath: string): {
+  readonly currentDefinition: string | undefined;
+  readonly legacyNames: readonly string[];
+  readonly revision: string | undefined;
+} {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    const legacy = database
+      .query(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'index'
+           AND name IN ('edges_target', 'symbols_name', 'symbols_resolution_scope')
+         ORDER BY name`,
+      )
+      .all() as readonly {readonly name: string}[];
+    const current = database
+      .query("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'edges_target_resolved'")
+      .get() as {readonly sql: string} | null;
+    const revision = database
+      .query("SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision'")
+      .get() as {readonly value: string} | null;
+    return {
+      currentDefinition: current?.sql,
+      legacyNames: legacy.map(index => index.name),
+      revision: revision?.value,
+    };
+  } finally {
+    database.close(false);
+  }
 }
 
 async function migrationFixture() {

--- a/test/unit/code-graph.schema-migration.test.ts
+++ b/test/unit/code-graph.schema-migration.test.ts
@@ -205,6 +205,21 @@ describe('code graph persistent schema migration', () => {
       expect(migrated.currentDefinition).toMatch(/WHERE\s+target_id\s+IS\s+NOT\s+NULL/iu);
       expect(migrated.revision).toBe(String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION));
       expect(incoming.map(candidate => candidate.id)).toEqual([edge.id]);
+
+      yield* Effect.sync(() => {
+        const database = new Database(fixture.databasePath, {strict: true});
+        try {
+          database
+            .query("UPDATE schema_metadata SET value = '9' WHERE key = 'persistent_extension_schema_revision'")
+            .run();
+        } finally {
+          database.close(false);
+        }
+      });
+      yield* store.initialize(fixture.databasePath);
+      const preparedRetry = yield* Effect.sync(() => readRevision9IndexState(fixture.databasePath));
+      expect(preparedRetry.currentRootPage).toBe(migrated.currentRootPage);
+      expect(preparedRetry.revision).toBe(String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION));
     }).pipe(Effect.provide(ApplicationLayer)),
   );
 
@@ -1700,6 +1715,7 @@ function removeRemovedViewCleanupRevision8(database: Database): void {
 
 function readRevision9IndexState(databasePath: string): {
   readonly currentDefinition: string | undefined;
+  readonly currentRootPage: number | undefined;
   readonly legacyNames: readonly string[];
   readonly revision: string | undefined;
 } {
@@ -1714,13 +1730,14 @@ function readRevision9IndexState(databasePath: string): {
       )
       .all() as readonly {readonly name: string}[];
     const current = database
-      .query("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'edges_target_resolved'")
-      .get() as {readonly sql: string} | null;
+      .query("SELECT rootpage, sql FROM sqlite_master WHERE type = 'index' AND name = 'edges_target_resolved'")
+      .get() as {readonly rootpage: number; readonly sql: string} | null;
     const revision = database
       .query("SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision'")
       .get() as {readonly value: string} | null;
     return {
       currentDefinition: current?.sql,
+      currentRootPage: current?.rootpage,
       legacyNames: legacy.map(index => index.name),
       revision: revision?.value,
     };

--- a/test/unit/code-graph.schema-migration.test.ts
+++ b/test/unit/code-graph.schema-migration.test.ts
@@ -163,6 +163,7 @@ describe('code graph persistent schema migration', () => {
         try {
           database.exec(`
             DROP INDEX edges_target_resolved;
+            DROP INDEX edges_evidence_path;
             CREATE INDEX edges_target ON edges(snapshot_id, target_id, relation);
             CREATE INDEX symbols_name ON symbols(snapshot_id, name);
             CREATE INDEX symbols_resolution_scope ON symbols(snapshot_id, resolution_scope_id);
@@ -187,6 +188,7 @@ describe('code graph persistent schema migration', () => {
       const rolledBack = yield* Effect.sync(() => readRevision9IndexState(fixture.databasePath));
       expect(rolledBack).toMatchObject({
         currentDefinition: undefined,
+        evidenceDefinition: undefined,
         legacyNames: ['edges_target', 'symbols_name', 'symbols_resolution_scope'],
         revision: '9',
       });
@@ -203,6 +205,7 @@ describe('code graph persistent schema migration', () => {
       expect(phases).toContain('migrated-query-indexes');
       expect(migrated.legacyNames).toEqual([]);
       expect(migrated.currentDefinition).toMatch(/WHERE\s+target_id\s+IS\s+NOT\s+NULL/iu);
+      expect(migrated.evidenceDefinition).toMatch(/edges\s*\(snapshot_id,\s*evidence_path\)/iu);
       expect(migrated.revision).toBe(String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION));
       expect(incoming.map(candidate => candidate.id)).toEqual([edge.id]);
 
@@ -1716,6 +1719,7 @@ function removeRemovedViewCleanupRevision8(database: Database): void {
 function readRevision9IndexState(databasePath: string): {
   readonly currentDefinition: string | undefined;
   readonly currentRootPage: number | undefined;
+  readonly evidenceDefinition: string | undefined;
   readonly legacyNames: readonly string[];
   readonly revision: string | undefined;
 } {
@@ -1732,12 +1736,16 @@ function readRevision9IndexState(databasePath: string): {
     const current = database
       .query("SELECT rootpage, sql FROM sqlite_master WHERE type = 'index' AND name = 'edges_target_resolved'")
       .get() as {readonly rootpage: number; readonly sql: string} | null;
+    const evidence = database
+      .query("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'edges_evidence_path'")
+      .get() as {readonly sql: string} | null;
     const revision = database
       .query("SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision'")
       .get() as {readonly value: string} | null;
     return {
       currentDefinition: current?.sql,
       currentRootPage: current?.rootpage,
+      evidenceDefinition: evidence?.sql,
       legacyNames: legacy.map(index => index.name),
       revision: revision?.value,
     };

--- a/test/unit/code-graph.storage-attribution.test.ts
+++ b/test/unit/code-graph.storage-attribution.test.ts
@@ -1,12 +1,13 @@
 import {Database} from 'bun:sqlite';
-import {Effect} from 'effect';
-import {afterEach, describe, expect, it} from 'vitest';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {afterEach, describe, expect} from 'vitest';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
 import {inspectCodeGraphStorage} from '../../src/code_graph/storage.js';
 import {readCodeGraphStorageSemanticAttribution} from '../../src/code_graph/storage_attribution.js';
 import {CODE_GRAPH_EXTRACTOR_GENERATION} from '../../src/code_graph/types.js';
-import {join, mkdir, mkdtemp, rm} from '../helpers/effect-filesystem.js';
-import {runEffect} from '../helpers/effect-runtime.js';
+import {rm} from '../helpers/effect-filesystem.js';
 
 const temporaryHomes: string[] = [];
 
@@ -15,121 +16,122 @@ afterEach(async () => {
 });
 
 describe('code graph semantic storage attribution', () => {
-  it('separates exact B-tree groups from bounded logical active-snapshot payload', async () => {
-    const home = await mkdtemp('threadnote-storage-attribution-');
-    temporaryHomes.push(home);
-    const checkoutId = 'a'.repeat(64);
-    const repositoryId = 'b'.repeat(64);
-    const worktreeId = 'c'.repeat(64);
-    const snapshotId = `cgsn_${'d'.repeat(40)}`;
-    const repositoryRoot = join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
-    const databasePath = join(repositoryRoot, 'graph-v3.sqlite');
-    await mkdir(repositoryRoot, {recursive: true});
-    await runEffect(
-      Effect.gen(function* () {
-        const store = yield* CodeGraphStore;
-        yield* store.initialize(databasePath);
-      }),
-    );
-    const factsJson = JSON.stringify({diagnostics: [], edges: [], path: 'src/index.ts', symbols: []});
-    const database = new Database(databasePath, {strict: true});
-    try {
-      const now = '2026-08-10T00:00:00.000Z';
-      database
-        .query(
-          `INSERT INTO repositories (id, display_name, object_format, created_at, last_used_at)
+  effectIt.effect('separates exact B-tree groups from bounded logical active-snapshot payload', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectory({prefix: 'threadnote-storage-attribution-'});
+      temporaryHomes.push(home);
+      const checkoutId = 'a'.repeat(64);
+      const repositoryId = 'b'.repeat(64);
+      const worktreeId = 'c'.repeat(64);
+      const snapshotId = `cgsn_${'d'.repeat(40)}`;
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+      const databasePath = path.join(repositoryRoot, 'graph-v3.sqlite');
+      yield* fs.makeDirectory(repositoryRoot, {recursive: true});
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      const factsJson = JSON.stringify({diagnostics: [], edges: [], path: 'src/index.ts', symbols: []});
+      const database = new Database(databasePath, {strict: true});
+      try {
+        const now = '2026-08-10T00:00:00.000Z';
+        database
+          .query(
+            `INSERT INTO repositories (id, display_name, object_format, created_at, last_used_at)
            VALUES (?, 'storage fixture', 'sha1', ?, ?)`,
-        )
-        .run(repositoryId, now, now);
-      database
-        .query(
-          `INSERT INTO snapshots (
+          )
+          .run(repositoryId, now, now);
+        database
+          .query(
+            `INSERT INTO snapshots (
              id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id,
              extractor_set, dirty, overlay_fingerprint, state, file_count, symbol_count,
              edge_count, started_at, completed_at, failure_summary
            ) VALUES (?, ?, ?, ?, ?, NULL, 'storage-fixture', 0, NULL, 'ready', 1, 1, 0, ?, ?, NULL)`,
-        )
-        .run(snapshotId, repositoryId, worktreeId, 'e'.repeat(40), `cgc_${'f'.repeat(40)}`, now, now);
-      database
-        .query('INSERT INTO snapshot_extractor_generations (snapshot_id, generation) VALUES (?, ?)')
-        .run(snapshotId, CODE_GRAPH_EXTRACTOR_GENERATION);
-      database
-        .query('INSERT INTO active_snapshots (worktree_id, snapshot_id, activated_at) VALUES (?, ?, ?)')
-        .run(worktreeId, snapshotId, now);
-      database
-        .query(
-          `INSERT INTO snapshot_files (snapshot_id, path, content_hash, language, mode, size, source)
+          )
+          .run(snapshotId, repositoryId, worktreeId, 'e'.repeat(40), `cgc_${'f'.repeat(40)}`, now, now);
+        database
+          .query('INSERT INTO snapshot_extractor_generations (snapshot_id, generation) VALUES (?, ?)')
+          .run(snapshotId, CODE_GRAPH_EXTRACTOR_GENERATION);
+        database
+          .query('INSERT INTO active_snapshots (worktree_id, snapshot_id, activated_at) VALUES (?, ?, ?)')
+          .run(worktreeId, snapshotId, now);
+        database
+          .query(
+            `INSERT INTO snapshot_files (snapshot_id, path, content_hash, language, mode, size, source)
            VALUES (?, 'src/index.ts', ?, 'typescript', '100644', 32, 'commit')`,
-        )
-        .run(snapshotId, '1'.repeat(64));
-      database
-        .query(
-          `INSERT INTO symbols (
+          )
+          .run(snapshotId, '1'.repeat(64));
+        database
+          .query(
+            `INSERT INTO symbols (
              snapshot_id, id, content_hash, kind, name, qualified_name, path, language,
              arity, lookup_keys_json, resolution_domain, package_name, exported,
              signature, documentation, span_json, resolution_scope_id
            ) VALUES (?, 'symbol', ?, 'module', 'index', 'index', 'src/index.ts', 'typescript',
              NULL, '[]', 'typescript', NULL, 1, NULL, NULL, '{"line":1}', NULL)`,
-        )
-        .run(snapshotId, '2'.repeat(64));
-      database
-        .query(
-          `INSERT INTO materialized_file_shards (
+          )
+          .run(snapshotId, '2'.repeat(64));
+        database
+          .query(
+            `INSERT INTO materialized_file_shards (
              id, content_hash, extractor_set, derivation_identity, path_hint,
              facts_json, created_at, last_used_at
            ) VALUES ('shard', ?, 'storage-fixture', 'derivation', 'src/index.ts', ?, ?, ?)`,
-        )
-        .run('1'.repeat(64), factsJson, now, now);
-      database
-        .query(
-          `INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id)
+          )
+          .run('1'.repeat(64), factsJson, now, now);
+        database
+          .query(
+            `INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id)
            VALUES (?, 'src/index.ts', 'shard')`,
-        )
-        .run(snapshotId);
-    } finally {
-      database.close(false);
-    }
+          )
+          .run(snapshotId);
+      } finally {
+        database.close(false);
+      }
 
-    const semanticDatabase = new Database(databasePath, {readonly: true, strict: true});
-    try {
-      const semantic = readCodeGraphStorageSemanticAttribution(
-        semanticDatabase,
-        [
-          {bytes: 4_096, name: 'materialized_file_shards', pages: 1},
-          {bytes: 4_096, name: 'snapshot_component_edge_aggregates', pages: 1},
-          {bytes: 4_096, name: 'symbols', pages: 1},
-        ],
-        3,
-        12_288,
-      );
-      expect(semantic.groups).toEqual(
+      const semanticDatabase = new Database(databasePath, {readonly: true, strict: true});
+      try {
+        const semantic = readCodeGraphStorageSemanticAttribution(
+          semanticDatabase,
+          [
+            {bytes: 4_096, name: 'materialized_file_shards', pages: 1},
+            {bytes: 4_096, name: 'snapshot_component_edge_aggregates', pages: 1},
+            {bytes: 4_096, name: 'symbols', pages: 1},
+          ],
+          3,
+          12_288,
+        );
+        expect(semantic.groups).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({name: 'analysis'}),
+            expect.objectContaining({name: 'facts-cache'}),
+            expect.objectContaining({name: 'structural-graph'}),
+          ]),
+        );
+        assertSnapshotAttribution(semantic.snapshots, snapshotId, factsJson);
+      } finally {
+        semanticDatabase.close(false);
+      }
+
+      const storage = yield* inspectCodeGraphStorage(home, checkoutId, {attributeObjects: true});
+      if (storage.state !== 'available' || storage.pageStorage.state !== 'available')
+        throw new Error('missing storage');
+      const attribution = storage.pageStorage.attribution;
+      if (!attribution) throw new Error('missing attribution');
+      if (attribution.state === 'unavailable') {
+        expect(attribution.reason).toBe('sqlite-dbstat-unavailable');
+        return;
+      }
+      expect(attribution.semantic.groups).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({name: 'analysis'}),
           expect.objectContaining({name: 'facts-cache'}),
           expect.objectContaining({name: 'structural-graph'}),
         ]),
       );
-      assertSnapshotAttribution(semantic.snapshots, snapshotId, factsJson);
-    } finally {
-      semanticDatabase.close(false);
-    }
-
-    const storage = await runEffect(inspectCodeGraphStorage(home, checkoutId, {attributeObjects: true}));
-    if (storage.state !== 'available' || storage.pageStorage.state !== 'available') throw new Error('missing storage');
-    const attribution = storage.pageStorage.attribution;
-    if (!attribution) throw new Error('missing attribution');
-    if (attribution.state === 'unavailable') {
-      expect(attribution.reason).toBe('sqlite-dbstat-unavailable');
-      return;
-    }
-    expect(attribution.semantic.groups).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({name: 'facts-cache'}),
-        expect.objectContaining({name: 'structural-graph'}),
-      ]),
-    );
-    assertSnapshotAttribution(attribution.semantic.snapshots, snapshotId, factsJson);
-  });
+      assertSnapshotAttribution(attribution.semantic.snapshots, snapshotId, factsJson);
+    }).pipe(Effect.provide(ApplicationLayer)),
+  );
 });
 
 function assertSnapshotAttribution(
@@ -146,4 +148,14 @@ function assertSnapshotAttribution(
     id: snapshotId,
     symbolCount: 1,
   });
+  expect(attribution.snapshots[0]?.classifiers).toEqual([
+    expect.objectContaining({
+      classifier: 'typescript',
+      factRawBytes: Buffer.byteLength(factsJson),
+      factStoredBytes: Buffer.byteLength(factsJson),
+      files: 1,
+      sourceBytes: 32,
+      symbolRows: 1,
+    }),
+  ]);
 }

--- a/test/unit/code-graph.storage.test.ts
+++ b/test/unit/code-graph.storage.test.ts
@@ -5,6 +5,7 @@ import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
 import {codeGraphWorktreeLockPath} from '../../src/code_graph/layout.js';
 import {
+  codeGraphCompactionRecommendation,
   codeGraphStorageUnattributedBytes,
   codeGraphCompactionRequiredFreeBytes,
   compactCodeGraphStorage,
@@ -46,6 +47,11 @@ describe('active code graph storage', () => {
     } else {
       expect(attribution.allocatedBytes).toBe(before.pageStorage.pageCount * before.pageStorage.pageSize);
       expect(attribution.freelistBytes).toBe(before.pageStorage.reclaimableBytes);
+      expect(attribution.fragmentedBytes).toBeGreaterThanOrEqual(0);
+      expect(before.pageStorage.fragmentedBytes).toBe(attribution.fragmentedBytes);
+      expect(before.pageStorage.compactionOpportunityBytes).toBe(
+        before.pageStorage.reclaimableBytes + attribution.fragmentedBytes,
+      );
       expect(attribution.attributedBytes + attribution.freelistBytes + attribution.unattributedBytes).toBe(
         attribution.allocatedBytes,
       );
@@ -105,6 +111,54 @@ describe('active code graph storage', () => {
       ),
       {numRuns: 500},
     );
+  });
+
+  it('monotonically schedules compaction from freelist and live-page fragmentation', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({max: 2_000_000_000, min: 1}),
+        fc.nat({max: 2_000_000_000}),
+        fc.nat({max: 2_000_000_000}),
+        fc.nat({max: 2_000_000_000}),
+        (allocatedBytes, reclaimableSeed, fragmentedSeed, growthSeed) => {
+          const reclaimableBytes = reclaimableSeed % (allocatedBytes + 1);
+          const fragmentedBytes = fragmentedSeed % (allocatedBytes - reclaimableBytes + 1);
+          const remainingBytes = allocatedBytes - reclaimableBytes - fragmentedBytes;
+          const growthBytes = growthSeed % (remainingBytes + 1);
+          const initial = codeGraphCompactionRecommendation({
+            allocatedBytes,
+            fragmentedBytes,
+            reclaimableBytes,
+          });
+          const moreFreelist = codeGraphCompactionRecommendation({
+            allocatedBytes,
+            fragmentedBytes,
+            reclaimableBytes: reclaimableBytes + growthBytes,
+          });
+          const moreFragmentation = codeGraphCompactionRecommendation({
+            allocatedBytes,
+            fragmentedBytes: fragmentedBytes + growthBytes,
+            reclaimableBytes,
+          });
+
+          expect(initial.recommended && !moreFreelist.recommended).toBe(false);
+          expect(initial.recommended && !moreFragmentation.recommended).toBe(false);
+          expect(initial.compactionOpportunityBytes).toBe(reclaimableBytes + fragmentedBytes);
+        },
+      ),
+      {numRuns: 500},
+    );
+
+    expect(
+      codeGraphCompactionRecommendation({
+        allocatedBytes: 2_926_362_624,
+        fragmentedBytes: 300_617_728,
+        reclaimableBytes: 380_100_608,
+      }),
+    ).toMatchObject({
+      reason: 'freelist-and-fragmentation',
+      recommended: true,
+    });
   });
 
   it('refuses compaction before VACUUM when available disk space is below the conservative requirement', async () => {

--- a/test/unit/code-graph.store-failure.test.ts
+++ b/test/unit/code-graph.store-failure.test.ts
@@ -90,6 +90,17 @@ describe('code graph store failure classification', () => {
     expect(failure.message).not.toContain('/Users/private');
   });
 
+  it('keeps Bun SQLite errno values in the SQLite domain instead of misclassifying EPERM', () => {
+    const failure = classifyCodeGraphStoreFailure('load code graph adjacency', {
+      errno: 1,
+      message: 'no query solution',
+      name: 'SQLiteError',
+    });
+
+    expect(failure).toMatchObject({code: 'unknown', recovery: 'diagnose', retryable: false});
+    expect(failure).not.toBeInstanceOf(CodeGraphStorePermissionError);
+  });
+
   it('constructs schema-additive recovery only through the explicit preflight result', () => {
     const failure = codeGraphStoreSchemaAdditiveRequired('initialize code graph database', {
       createsOnly: true,

--- a/test/unit/code-graph.store-query.property.test.ts
+++ b/test/unit/code-graph.store-query.property.test.ts
@@ -289,7 +289,7 @@ describe('code graph indexed query properties', () => {
           );
           const adjacencyPlan = queryPlan(database, adjacency.text, adjacency.parameters);
           expect(adjacencyPlan.filter(detail => detail.includes('edges_source'))).toHaveLength(2);
-          expect(adjacencyPlan.filter(detail => detail.includes('edges_target'))).toHaveLength(2);
+          expect(adjacencyPlan.filter(detail => detail.includes('edges_target_resolved'))).toHaveLength(2);
           expect(adjacencyPlan.join('\n')).not.toMatch(/SCAN (?:current_edges|base_edges|effective_edges)/u);
           expect(adjacency.text.match(/LIMIT \?/gu)).toHaveLength(5);
 

--- a/test/unit/code-graph.watcher.test.ts
+++ b/test/unit/code-graph.watcher.test.ts
@@ -536,147 +536,142 @@ describe('CodeGraphWatcher', () => {
     }),
   );
 
-  it('serializes explicit and watch-triggered refreshes while coalescing a trailing run', async () => {
-    const result = await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const starts = yield* Ref.make(0);
-          const concurrent = yield* Ref.make(0);
-          const maximumConcurrent = yield* Ref.make(0);
-          const watchStarted = yield* Deferred.make<void>();
-          const firstStarted = yield* Deferred.make<void>();
-          const secondStarted = yield* Deferred.make<void>();
-          const firstRelease = yield* Deferred.make<void>();
-          const secondRelease = yield* Deferred.make<void>();
-          const secondCompleted = yield* Deferred.make<void>();
-          let trigger: (() => Effect.Effect<void>) | undefined;
-          const watcher = yield* makeCodeGraphWatcher(
-            (_options, _initialRefresh, requestRefresh) =>
-              Effect.sync(() => {
-                trigger = requestRefresh;
-              }).pipe(Effect.andThen(Deferred.succeed(watchStarted, undefined)), Effect.andThen(Effect.never)),
-            refreshOptions =>
-              Effect.gen(function* () {
-                const ordinal = yield* Ref.updateAndGet(starts, count => count + 1);
-                const active = yield* Ref.updateAndGet(concurrent, count => count + 1);
-                yield* Ref.update(maximumConcurrent, current => Math.max(current, active));
-                yield* refreshOptions.onProgress?.({
-                  accepted: ordinal,
-                  completed: ordinal,
-                  excluded: 0,
-                  phase: 'scanning',
-                  skipped: 0,
-                  total: 2,
-                  unit: 'files',
-                }) ?? Effect.void;
-                yield* Deferred.succeed(ordinal === 1 ? firstStarted : secondStarted, undefined);
-                yield* Deferred.await(ordinal === 1 ? firstRelease : secondRelease);
-                yield* refreshOptions.onRefreshed?.(ordinal * 100, ordinal * 200) ?? Effect.void;
-                if (ordinal === 2) yield* Deferred.succeed(secondCompleted, undefined);
-              }).pipe(Effect.ensuring(Ref.update(concurrent, count => count - 1))),
-          );
+  effectIt.effect('serializes explicit and watch-triggered refreshes while coalescing a trailing run', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const starts = yield* Ref.make(0);
+        const concurrent = yield* Ref.make(0);
+        const maximumConcurrent = yield* Ref.make(0);
+        const watchStarted = yield* Deferred.make<void>();
+        const firstStarted = yield* Deferred.make<void>();
+        const secondStarted = yield* Deferred.make<void>();
+        const firstRelease = yield* Deferred.make<void>();
+        const secondRelease = yield* Deferred.make<void>();
+        const secondCompleted = yield* Deferred.make<void>();
+        let trigger: (() => Effect.Effect<void>) | undefined;
+        const watcher = yield* makeCodeGraphWatcher(
+          (_options, _initialRefresh, requestRefresh) =>
+            Effect.sync(() => {
+              trigger = requestRefresh;
+            }).pipe(Effect.andThen(Deferred.succeed(watchStarted, undefined)), Effect.andThen(Effect.never)),
+          refreshOptions =>
+            Effect.gen(function* () {
+              const ordinal = yield* Ref.updateAndGet(starts, count => count + 1);
+              const active = yield* Ref.updateAndGet(concurrent, count => count + 1);
+              yield* Ref.update(maximumConcurrent, current => Math.max(current, active));
+              yield* refreshOptions.onProgress?.({
+                accepted: ordinal,
+                completed: ordinal,
+                excluded: 0,
+                phase: 'scanning',
+                skipped: 0,
+                total: 2,
+                unit: 'files',
+              }) ?? Effect.void;
+              yield* Deferred.succeed(ordinal === 1 ? firstStarted : secondStarted, undefined);
+              yield* Deferred.await(ordinal === 1 ? firstRelease : secondRelease);
+              yield* refreshOptions.onRefreshed?.(ordinal * 100, ordinal * 200) ?? Effect.void;
+              if (ordinal === 2) yield* Deferred.succeed(secondCompleted, undefined);
+            }).pipe(Effect.ensuring(Ref.update(concurrent, count => count - 1))),
+        );
 
-          yield* watcher.ensure(options);
-          yield* Deferred.await(watchStarted);
-          yield* watcher.refresh(options);
-          yield* Deferred.await(firstStarted);
-          yield* Effect.all(
-            [
-              ...Array.from({length: 50}, () => trigger!()),
-              ...Array.from({length: 50}, () => watcher.refresh(options)),
-            ],
-            {concurrency: 'unbounded'},
-          );
-          const beforeRelease = {
-            maximum: yield* Ref.get(maximumConcurrent),
-            starts: yield* Ref.get(starts),
-          };
-          yield* Deferred.succeed(firstRelease, undefined);
-          yield* Deferred.await(secondStarted);
-          const duringTrailing = {
-            maximum: yield* Ref.get(maximumConcurrent),
-            starts: yield* Ref.get(starts),
-          };
-          yield* Effect.all(
-            Array.from({length: 50}, () => watcher.refresh(options)),
-            {
-              concurrency: 'unbounded',
-            },
-          );
-          yield* Deferred.succeed(secondRelease, undefined);
-          yield* Deferred.await(secondCompleted);
-          yield* Effect.yieldNow;
-          return {
-            beforeRelease,
-            duringTrailing,
-            finalMaximum: yield* Ref.get(maximumConcurrent),
-            finalStarts: yield* Ref.get(starts),
-            status: yield* watcher.status(options.key),
-          };
+        yield* watcher.ensure(options);
+        yield* Deferred.await(watchStarted);
+        yield* watcher.refresh(options);
+        yield* Deferred.await(firstStarted);
+        yield* Effect.all(
+          [...Array.from({length: 50}, () => trigger!()), ...Array.from({length: 50}, () => watcher.refresh(options))],
+          {concurrency: 'unbounded'},
+        );
+        const beforeRelease = {
+          maximum: yield* Ref.get(maximumConcurrent),
+          starts: yield* Ref.get(starts),
+        };
+        yield* Deferred.succeed(firstRelease, undefined);
+        yield* Deferred.await(secondStarted);
+        const duringTrailing = {
+          maximum: yield* Ref.get(maximumConcurrent),
+          starts: yield* Ref.get(starts),
+        };
+        yield* Effect.all(
+          Array.from({length: 50}, () => watcher.refresh(options)),
+          {
+            concurrency: 'unbounded',
+          },
+        );
+        yield* Deferred.succeed(secondRelease, undefined);
+        yield* Deferred.await(secondCompleted);
+        yield* Effect.yieldNow;
+        return {
+          beforeRelease,
+          duringTrailing,
+          finalMaximum: yield* Ref.get(maximumConcurrent),
+          finalStarts: yield* Ref.get(starts),
+          status: yield* watcher.status(options.key),
+        };
+      }),
+    ).pipe(
+      Effect.tap(result =>
+        Effect.sync(() => {
+          expect(result.beforeRelease).toEqual({maximum: 1, starts: 1});
+          expect(result.duringTrailing).toEqual({maximum: 1, starts: 2});
+          expect(result.finalMaximum).toBe(1);
+          expect(result.finalStarts).toBe(2);
+          expect(result.status).toMatchObject({
+            _tag: 'Some',
+            value: {edges: 400, state: 'ready', symbols: 200},
+          });
         }),
       ),
-    );
+    ),
+  );
 
-    expect(result.beforeRelease).toEqual({maximum: 1, starts: 1});
-    expect(result.duringTrailing).toEqual({maximum: 1, starts: 2});
-    expect(result.finalMaximum).toBe(1);
-    expect(result.finalStarts).toBe(2);
-    expect(result.status).toMatchObject({
-      _tag: 'Some',
-      value: {edges: 400, state: 'ready', symbols: 200},
-    });
-  });
+  effectIt.effect('atomically collapses intermediate changes and resolves the latest target in the trailing run', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const targets: string[] = [];
+        let currentTarget = 'commit-a';
+        let trigger: (() => Effect.Effect<void>) | undefined;
+        const firstStarted = yield* Deferred.make<void>();
+        const firstRelease = yield* Deferred.make<void>();
+        const secondCompleted = yield* Deferred.make<void>();
+        const watcher = yield* makeCodeGraphWatcher(
+          (_options, _initialRefresh, requestRefresh) =>
+            Effect.sync(() => {
+              trigger = requestRefresh;
+            }).pipe(Effect.andThen(Effect.never)),
+          () =>
+            Effect.gen(function* () {
+              targets.push(currentTarget);
+              if (targets.length === 1) {
+                yield* Deferred.succeed(firstStarted, undefined);
+                yield* Deferred.await(firstRelease);
+              } else {
+                yield* Deferred.succeed(secondCompleted, undefined);
+              }
+            }),
+        );
 
-  it('atomically collapses intermediate changes and resolves the latest target in the trailing run', async () => {
-    const observed = await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const targets: string[] = [];
-          let currentTarget = 'commit-a';
-          let trigger: (() => Effect.Effect<void>) | undefined;
-          const firstStarted = yield* Deferred.make<void>();
-          const firstRelease = yield* Deferred.make<void>();
-          const secondCompleted = yield* Deferred.make<void>();
-          const watcher = yield* makeCodeGraphWatcher(
-            (_options, _initialRefresh, requestRefresh) =>
-              Effect.sync(() => {
-                trigger = requestRefresh;
-              }).pipe(Effect.andThen(Effect.never)),
-            () =>
-              Effect.gen(function* () {
-                targets.push(currentTarget);
-                if (targets.length === 1) {
-                  yield* Deferred.succeed(firstStarted, undefined);
-                  yield* Deferred.await(firstRelease);
-                } else {
-                  yield* Deferred.succeed(secondCompleted, undefined);
-                }
-              }),
-          );
-
-          yield* watcher.ensure(options);
-          while (trigger === undefined) yield* Effect.yieldNow;
-          yield* watcher.refresh(options);
-          yield* Deferred.await(firstStarted);
-          currentTarget = 'commit-b';
-          yield* trigger!();
-          currentTarget = 'commit-c';
-          yield* Effect.all(
-            Array.from({length: 64}, () => trigger!()),
-            {
-              concurrency: 'unbounded',
-              discard: true,
-            },
-          );
-          yield* Deferred.succeed(firstRelease, undefined);
-          yield* Deferred.await(secondCompleted);
-          return targets;
-        }),
-      ),
-    );
-
-    expect(observed).toEqual(['commit-a', 'commit-c']);
-  });
+        yield* watcher.ensure(options);
+        while (trigger === undefined) yield* Effect.yieldNow;
+        yield* watcher.refresh(options);
+        yield* Deferred.await(firstStarted);
+        currentTarget = 'commit-b';
+        yield* trigger!();
+        currentTarget = 'commit-c';
+        yield* Effect.all(
+          Array.from({length: 64}, () => trigger!()),
+          {
+            concurrency: 'unbounded',
+            discard: true,
+          },
+        );
+        yield* Deferred.succeed(firstRelease, undefined);
+        yield* Deferred.await(secondCompleted);
+        return targets;
+      }),
+    ).pipe(Effect.tap(observed => Effect.sync(() => expect(observed).toEqual(['commit-a', 'commit-c'])))),
+  );
 
   it('serializes refreshes across repository keys to bound process memory', async () => {
     const result = await Effect.runPromise(

--- a/test/unit/code-graph.workspace-compatibility.property.test.ts
+++ b/test/unit/code-graph.workspace-compatibility.property.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from 'vitest';
+import fc from 'fast-check';
+import type {CodeGraphWorkspace, CodeGraphWorkspaceProject} from '../../src/code_graph/languages/types.js';
+import {assessCodeGraphWorkspaceCompatibility} from '../../src/code_graph/workspace_compatibility.js';
+
+describe('code graph workspace compatibility properties', () => {
+  it('seeds only projects whose semantic workspace surface changed', () => {
+    fc.assert(
+      fc.property(fc.integer({max: 12, min: 2}), fc.nat(), (projectCount, salt) => {
+        const projects = Array.from({length: projectCount}, (_, index) => project(index));
+        const changedIndex = salt % projectCount;
+        const dependencyIndex = (changedIndex + 1) % projectCount;
+        const changed = projects.map((value, index) =>
+          index === changedIndex
+            ? {
+                ...value,
+                dependencies: [projects[dependencyIndex]!.id],
+                dependencyDetails: [
+                  {
+                    evidence: `${value.root}/BUILD.bazel`,
+                    provenance: 'declared' as const,
+                    targetId: projects[dependencyIndex]!.id,
+                  },
+                ],
+              }
+            : value,
+        );
+
+        expect(
+          assessCodeGraphWorkspaceCompatibility(workspace('base', projects), workspace('current', changed)),
+        ).toEqual({mode: 'project-closure', seedProjectIds: [projects[changedIndex]!.id]});
+      }),
+      {numRuns: 100},
+    );
+  });
+
+  it('fails closed when project ownership is added or removed', () => {
+    fc.assert(
+      fc.property(fc.integer({max: 12, min: 1}), projectCount => {
+        const projects = Array.from({length: projectCount}, (_, index) => project(index));
+        expect(
+          assessCodeGraphWorkspaceCompatibility(workspace('base', projects), workspace('current', projects.slice(1))),
+        ).toEqual({mode: 'fallback', reason: 'workspace-changed'});
+      }),
+      {numRuns: 50},
+    );
+  });
+});
+
+function project(index: number): CodeGraphWorkspaceProject {
+  const root = `apps/bazel-${index}`;
+  return {
+    buildSystem: 'bazel',
+    dependencies: [],
+    dependencyDetails: [],
+    diagnostics: [],
+    id: `project-${index}`,
+    kind: 'package',
+    languages: ['bazel', 'starlark'],
+    name: `//app-${index}`,
+    provenance: 'declared',
+    resolutionDomain: 'bazel',
+    root,
+    sourceRoots: [root],
+    workspaceId: `workspace-${index}`,
+    workspaceRoots: [root],
+  };
+}
+
+function workspace(fingerprint: string, projects: readonly CodeGraphWorkspaceProject[]): CodeGraphWorkspace {
+  return {diagnostics: [], fingerprint, projects, workspaces: []};
+}

--- a/test/unit/effect-file-lock.test.ts
+++ b/test/unit/effect-file-lock.test.ts
@@ -62,6 +62,39 @@ describe('Effect file lock', () => {
     ),
   );
 
+  effectIt.effect('releases an atomically written token when acquisition is interrupted', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const tokenWritten = yield* Deferred.make<void>();
+        const blockAfterWrite = yield* Deferred.make<void>();
+        const blockedFs = FileSystem.FileSystem.of({
+          ...fs,
+          writeFileString: (path, content, options) =>
+            fs.writeFileString(path, content, options).pipe(
+              Effect.tap(() => (path === lockPath ? Deferred.succeed(tokenWritten, undefined) : Effect.void)),
+              Effect.andThen(path === lockPath ? Deferred.await(blockAfterWrite) : Effect.void),
+            ),
+        });
+        const interruptedFiber = yield* withExclusiveFileLock(
+          blockedFs,
+          lockPath,
+          TEST_LOCK_OPTIONS,
+          Effect.never,
+        ).pipe(Effect.forkChild({startImmediately: true}));
+
+        yield* Deferred.await(tokenWritten);
+        const interruptCompleted = yield* Fiber.interrupt(interruptedFiber).pipe(Effect.as(true));
+        expect(interruptCompleted).toBe(true);
+        expect(yield* fs.exists(lockPath)).toBe(false);
+
+        const reacquired = yield* withExclusiveFileLock(fs, lockPath, TEST_LOCK_OPTIONS, Effect.succeed('reacquired'));
+        expect(reacquired).toBe('reacquired');
+        expect(yield* fs.exists(lockPath)).toBe(false);
+      }).pipe(Effect.provide(FILE_LOCK_TEST_LAYER)),
+    ),
+  );
+
   it('reports lock contention with a typed timeout', async () => {
     await mkdir(join(lockPath, '..'), {recursive: true});
     await writeFile(lockPath, `${process.pid}:live-owner\n`, {mode: 0o600});

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -303,6 +303,40 @@ describe('manager graph focus', () => {
     expect(markup).toContain('2 at or above 1.00s');
   });
 
+  it('explains a repository-wide incremental fallback while materialization is active', () => {
+    const neverResolves = () => new Promise<never>(() => undefined);
+    const build = {
+      ...graphBuildStatus('running'),
+      counters: {completed: 37_209, reused: 58_482, total: 59_076, unit: 'files'},
+      materialization: {
+        metrics: {
+          batchesCompleted: 707,
+          batchesTotal: 933,
+          fallbackReason: 'file-set-changed',
+          mode: 'full' as const,
+          sourceBytesCompleted: 1,
+          sourceBytesTotal: 2,
+        },
+      },
+      phase: 'materializing',
+    };
+    const markup = renderToStaticMarkup(
+      createElement(GraphWorkspace, {
+        catalog: {builds: [build], diagnostics: [], repositories: [], waiterCount: 0, waiters: []},
+        loadAnalysis: neverResolves,
+        loadCatalogPage: neverResolves,
+        loadGraph: neverResolves,
+        loadNodeDetail: neverResolves,
+        loadQuery: neverResolves,
+        loadViewsPage: neverResolves,
+        onRefresh: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('Full materialization selected');
+    expect(markup).toContain('incremental fallback: file set changed');
+  });
+
   it('shows the active owner, latest queued target, and stale queryable snapshot without claiming FIFO order', () => {
     const neverResolves = () => new Promise<never>(() => undefined);
     const baseRepository = repositoryGroup('repository', ['worktree'], 'worktree');

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -4,6 +4,7 @@ import * as FC from 'effect/testing/FastCheck';
 import {
   codeGraphAnalysisMcpResponse,
   codeGraphAnalysisRefreshResult,
+  codeGraphInspectionAllowsStaleReady,
   codeGraphMcpAnalysisBudget,
   codeGraphMcpAnalysisLimits,
   codeGraphMcpResponse,
@@ -22,6 +23,17 @@ import type {CodeGraphRefreshStatus} from '../../src/code_graph/watcher.js';
 import {analysisEdge, analysisSnapshot, analysisSymbol, pagedAnalysisStore} from '../helpers/code-graph-analysis.js';
 
 describe('MCP code graph indexing progress', () => {
+  it('allows stale ready evidence for non-strict operations only', () => {
+    expect(
+      Object.fromEntries(
+        (['query', 'node', 'neighbors', 'explain', 'path', 'impact'] as const).map(operation => [
+          operation,
+          codeGraphInspectionAllowsStaleReady(operation),
+        ]),
+      ),
+    ).toEqual({explain: true, impact: false, neighbors: true, node: true, path: false, query: true});
+  });
+
   it('allows an explicitly safe ready graph to serve while background indexing continues', () => {
     const indexing = indexingStatus(60_000);
 
@@ -107,6 +119,16 @@ describe('MCP code graph indexing progress', () => {
     expect(continued.warnings[0]!.length).toBeLessThanOrEqual(320);
     expect(JSON.stringify(continued)).not.toContain('/Users/private');
     expect(codeGraphResultWithRefreshContinuity(continued, deferred)).toBe(continued);
+  });
+
+  it('labels stale ready evidence while indexing continues', () => {
+    const result = {...verboseCodeGraphResult(), freshness: 'stale' as const, warnings: []};
+    const continued = codeGraphResultWithRefreshContinuity(result, indexingStatus(60_000));
+
+    expect(continued.warnings).toEqual([
+      'Serving the existing stale ready snapshot while code graph refresh continues in the background.',
+    ]);
+    expect(codeGraphResultWithRefreshContinuity(continued, indexingStatus(60_000))).toBe(continued);
   });
 
   it('keeps path, impact, and whole-graph analysis strict when refresh is deferred', () => {

--- a/test/unit/model-selection.test.ts
+++ b/test/unit/model-selection.test.ts
@@ -1,25 +1,22 @@
-import {Effect} from 'effect';
-import {describe, expect, it} from 'vitest';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem} from 'effect';
+import {describe, expect} from 'vitest';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {BUILTIN_MODEL_MANIFESTS} from '../../src/models/builtin.js';
 import {LocalModelCatalog} from '../../src/models/catalog.js';
 import {readModelSelection, selectLocalModel} from '../../src/models/selection.js';
-import {mkdtemp, rm} from '../helpers/effect-filesystem.js';
-import {runEffect} from '../helpers/effect-runtime.js';
 
 describe('model selection', () => {
-  it('atomically records role-aware selection and ignores a malformed receipt', async () => {
-    const home = await mkdtemp('threadnote-model-selection-');
-    try {
-      await runEffect(
-        Effect.gen(function* () {
-          const catalog = yield* LocalModelCatalog;
-          const selected = yield* selectLocalModel(home, catalog, 'embedding', 'bge-small-en-v1.5-q8');
-          expect(selected.roles.embedding).toBe('bge-small-en-v1.5-q8');
-          expect((yield* readModelSelection(home)).roles.embedding).toBe('bge-small-en-v1.5-q8');
-        }).pipe(Effect.provide(LocalModelCatalog.layer(BUILTIN_MODEL_MANIFESTS))),
-      );
-    } finally {
-      await rm(home, {force: true, recursive: true});
-    }
-  });
+  effectIt.effect('atomically records role-aware selection and ignores a malformed receipt', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* fs.makeTempDirectory({prefix: 'threadnote-model-selection-'});
+      yield* Effect.gen(function* () {
+        const catalog = yield* LocalModelCatalog;
+        const selected = yield* selectLocalModel(home, catalog, 'embedding', 'bge-small-en-v1.5-q8');
+        expect(selected.roles.embedding).toBe('bge-small-en-v1.5-q8');
+        expect((yield* readModelSelection(home)).roles.embedding).toBe('bge-small-en-v1.5-q8');
+      }).pipe(Effect.ensuring(fs.remove(home, {force: true, recursive: true}).pipe(Effect.orDie)));
+    }).pipe(Effect.provide(LocalModelCatalog.layer(BUILTIN_MODEL_MANIFESTS)), Effect.provide(ApplicationLayer)),
+  );
 });

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -1479,6 +1479,10 @@ threadnote share conflict resolve <id> --take shared`,
             text: 'The first graph query lazily builds a per-checkout SQLite snapshot below ~/.threadnote/indexes/code-graph. Committed source comes from bounded Git object reads; staged, unstaged, renamed, deleted, and eligible untracked files form the current worktree overlay.',
           },
           {
+            type: 'paragraph',
+            text: 'Graph query, node, neighbors, and explain read the latest ready snapshot by default, so ordinary semantic lookup does not queue behind a large refresh. Select --freshness current for a bounded current-worktree refresh, --freshness allow-stale to guarantee no indexing, and --read-timeout-ms to override the default 25-second foreground budget. Graph path remains current by default, and impact remains strict-current.',
+          },
+          {
             type: 'code',
             language: 'sh',
             code: `threadnote graph status


### PR DESCRIPTION
## Summary

- make small dirty worktree changes use an incremental overlay instead of restaging the full graph
- reuse clean bases and parser facts across degraded/active parser generations
- bound SQLite and process memory, compact staging state, and defer full-only analysis work
- migrate remaining affected tests to Effect tooling and add a bounded Fast-check cache-key property
- update the optimization plan and 4.1.1 release notes

## Verification

- lint, Prettier, and application/test/site TypeScript checks passed
- focused unit, property, integration, schema-migration, lifecycle, and mixed-monorepo gate tests passed
- exact-HEAD global smoke: 1 staged / 10,397 reused files; 143,465 symbols; 334,941 edges; 495.5 MiB peak RSS
- promoted dirty snapshot successfully answered a ready graph query with resolved relationships
- full suite intentionally delegated to CI per request

## Standalone performance evidence

- incremental run: 5.941 s, 498.7 MiB RSS
- repeat no-op: 0.573 s, 225.1 MiB RSS
- graph parity retained at 143,465 symbols / 334,941 edges