### PR TITLE
Publish prepared release notes from main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,11 +3,12 @@ name: Website
 on:
   push:
     branches: [main]
-    tags: ['v*.*.*']
     paths:
       - '.github/workflows/pages.yml'
+      - 'package.json'
       - 'scripts/site-doc-pages.ts'
       - 'scripts/site-performance-evidence.ts'
+      - 'scripts/site-release-notes.ts'
       - 'src/evaluation/benchmark.ts'
       - '.github/release-notes/**'
       - 'test/evaluation/candidates/threadnote-4.0.0/benchmarks/darwin-arm64-m1-max/code-graph-intellij-*.json'

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -72,6 +72,11 @@ creates a GitHub prerelease; do not use an unnumbered `-beta` suffix.
 6. Wait for `Publish standalone release`. Do not create a GitHub Release manually. Every channel publishes after all
    four enabled archives are verified while its bounded production-large observation continues independently.
 
+The main-branch website build includes the prepared stable `package.json` version when its matching release note is
+checked in but its tag does not exist yet. Merge only a ready-to-tag stable version and push its tag immediately; until
+a later main deployment observes the tag, What's New uses the release-preparation commit date and its release link is
+intentionally future-facing.
+
 The release evidence record must distinguish a clean candidate run from exact-tag evidence. Candidate evidence can
 close implementation gates before merge, but only the tag-triggered artifact may claim exact release provenance. Keep
 public surrogate results, private path-free aggregate evidence, and checked-in same-machine comparisons separate; do

--- a/scripts/site-release-notes.ts
+++ b/scripts/site-release-notes.ts
@@ -15,6 +15,10 @@ export interface WebsiteRelease extends PublishedReleaseRef {
   readonly releaseUrl: string;
 }
 
+interface WebsiteReleaseSource extends PublishedReleaseRef {
+  readonly noteRef: string;
+}
+
 const STABLE_RELEASE = /^v(\d+)\.(\d+)\.(\d+)$/;
 
 export function parseStableReleaseVersion(version: string): StableReleaseVersion | undefined {
@@ -39,6 +43,14 @@ export function selectLatestMajorReleases(releases: readonly PublishedReleaseRef
     if (release.major === latestMajor) byVersion.set(release.version, release);
   }
   return [...byVersion.values()].sort(compareReleasesDescending);
+}
+
+function includePreparedWebsiteRelease<T extends PublishedReleaseRef>(
+  published: readonly T[],
+  prepared: T | undefined,
+): readonly T[] {
+  if (prepared === undefined || published.some(release => release.version === prepared.version)) return published;
+  return [...published, prepared];
 }
 
 function plainText(markdown: string): string {
@@ -97,8 +109,42 @@ function runGit(repositoryRoot: string, arguments_: readonly string[]): string {
   return result.stdout.toString();
 }
 
+function gitObjectExists(repositoryRoot: string, object: string): boolean {
+  return (
+    Bun.spawnSync({
+      cmd: ['git', 'cat-file', '-e', object],
+      cwd: repositoryRoot,
+      stderr: 'ignore',
+      stdout: 'ignore',
+    }).exitCode === 0
+  );
+}
+
+function loadPreparedWebsiteRelease(
+  repositoryRoot: string,
+  published: readonly WebsiteReleaseSource[],
+): WebsiteReleaseSource | undefined {
+  const manifest = JSON.parse(runGit(repositoryRoot, ['show', 'HEAD:package.json'])) as {readonly version?: unknown};
+  if (typeof manifest.version !== 'string') return undefined;
+  const parsed = parseStableReleaseVersion(`v${manifest.version}`);
+  if (parsed === undefined) return undefined;
+  if (published.some(release => compareReleasesDescending(parsed, release) >= 0)) return undefined;
+
+  const releaseNotePath = `.github/release-notes/${parsed.version}.md`;
+  if (!gitObjectExists(repositoryRoot, `HEAD:${releaseNotePath}`)) return undefined;
+  const publishedAt = runGit(repositoryRoot, [
+    'log',
+    '-1',
+    '--format=%cI',
+    '--',
+    'package.json',
+    releaseNotePath,
+  ]).trim();
+  return {...parsed, noteRef: 'HEAD', publishedAt};
+}
+
 export function loadLatestMajorWebsiteReleases(repositoryRoot: string): readonly WebsiteRelease[] {
-  const refs = runGit(repositoryRoot, [
+  const published = runGit(repositoryRoot, [
     'for-each-ref',
     '--format=%(refname:short)|%(creatordate:iso-strict)',
     'refs/tags/v*',
@@ -112,15 +158,19 @@ export function loadLatestMajorWebsiteReleases(repositoryRoot: string): readonly
       const version = line.slice(0, separator);
       const parsed = parseStableReleaseVersion(version);
       if (!parsed) return [];
-      return [{...parsed, publishedAt: line.slice(separator + 1)}];
+      return [{...parsed, noteRef: version, publishedAt: line.slice(separator + 1)} satisfies WebsiteReleaseSource];
     });
+  const refs = includePreparedWebsiteRelease(published, loadPreparedWebsiteRelease(repositoryRoot, published));
 
   const selected = selectLatestMajorReleases(refs);
-  if (selected.length === 0) throw new Error('The website needs at least one published stable release tag.');
+  if (selected.length === 0) throw new Error('The website needs at least one published or prepared stable release.');
+  const sourcesByVersion = new Map(refs.map(release => [release.version, release]));
 
   return selected.map(release => {
     const releaseNotePath = `.github/release-notes/${release.version}.md`;
-    const markdown = runGit(repositoryRoot, ['show', `${release.version}:${releaseNotePath}`]);
+    const source = sourcesByVersion.get(release.version);
+    if (source === undefined) throw new Error(`Could not resolve website release source for ${release.version}.`);
+    const markdown = runGit(repositoryRoot, ['show', `${source.noteRef}:${releaseNotePath}`]);
     const {summary, highlights} = summarizeReleaseNote(markdown);
     if (!summary) throw new Error(`${releaseNotePath} needs an introductory release summary.`);
     return {

--- a/test/unit/ci-workflow.test.ts
+++ b/test/unit/ci-workflow.test.ts
@@ -184,7 +184,9 @@ describe('dependency-aware CI workflow', () => {
     expect(pagePaths).toEqual(
       expect.arrayContaining([
         '.github/workflows/pages.yml',
+        'package.json',
         'scripts/site-performance-evidence.ts',
+        'scripts/site-release-notes.ts',
         'src/evaluation/benchmark.ts',
         'website/**',
       ]),

--- a/test/unit/website-release-boundary.test.ts
+++ b/test/unit/website-release-boundary.test.ts
@@ -241,10 +241,10 @@ describe('website and standalone release boundary', () => {
       const prepared = loadLatestMajorWebsiteReleases(repository);
       expect(prepared.map(release => release.version)).toEqual(['v4.1.1', 'v4.0.0']);
       expect(prepared[0]).toMatchObject({
-        publishedAt: '2026-08-11T11:00:00+00:00',
         releaseUrl: 'https://github.com/Kashkovsky/threadnote/releases/tag/v4.1.1',
         summary: 'Threadnote 4.1.1 is ready.',
       });
+      expect(new Date(prepared[0]!.publishedAt).toISOString()).toBe('2026-08-11T11:00:00.000Z');
 
       gitAt(
         '2026-08-12T12:00:00Z',
@@ -260,7 +260,7 @@ describe('website and standalone release boundary', () => {
       );
       const tagged = loadLatestMajorWebsiteReleases(repository);
       expect(tagged.map(release => release.version)).toEqual(['v4.1.1', 'v4.0.0']);
-      expect(tagged[0]?.publishedAt).toBe('2026-08-12T12:00:00+00:00');
+      expect(new Date(tagged[0]!.publishedAt).toISOString()).toBe('2026-08-12T12:00:00.000Z');
     } finally {
       await rm(repository, {force: true, recursive: true});
     }

--- a/test/unit/website-release-boundary.test.ts
+++ b/test/unit/website-release-boundary.test.ts
@@ -5,6 +5,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, expect, it} from 'vitest';
 import {assertPerformanceSourceClean} from '../../scripts/site-performance-evidence.js';
+import {loadLatestMajorWebsiteReleases} from '../../scripts/site-release-notes.js';
 
 const root = process.cwd();
 
@@ -162,14 +163,107 @@ describe('website and standalone release boundary', () => {
     expect(workflow).toContain('fetch-depth: 0');
     const pushTrigger = workflow.slice(workflow.indexOf('  push:'), workflow.indexOf('  workflow_dispatch:'));
     expect(pushTrigger).toContain('paths:');
+    expect(pushTrigger).toContain('branches: [main]');
+    expect(pushTrigger).not.toContain('tags:');
+    expect(pushTrigger).toContain("'package.json'");
     expect(pushTrigger).toContain("'website/**'");
     expect(pushTrigger).toContain("'scripts/site-doc-pages.ts'");
     expect(pushTrigger).toContain("'scripts/site-performance-evidence.ts'");
+    expect(pushTrigger).toContain("'scripts/site-release-notes.ts'");
     expect(pushTrigger).toContain("'src/evaluation/benchmark.ts'");
     expect(pushTrigger).not.toContain("'src/**'");
     expect(workflow).toContain('path: site-dist');
     expect(workflow).toContain('actions/deploy-pages@');
     expect(workflow).toMatch(/^ {2}THREADNOTE_SITE_BASE: \/$/m);
+  });
+
+  it('loads a prepared stable release before tagging and deduplicates it after tagging', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'threadnote-prepared-site-release-'));
+    const git = (...arguments_: string[]) =>
+      execFileSync('git', arguments_, {cwd: repository, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']});
+    const gitAt = (date: string, ...arguments_: string[]) =>
+      execFileSync('git', arguments_, {
+        cwd: repository,
+        encoding: 'utf8',
+        env: {...process.env, GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date},
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+    try {
+      await mkdir(join(repository, '.github', 'release-notes'), {recursive: true});
+      await writeFile(join(repository, 'package.json'), '{"version":"4.0.0"}\n');
+      await writeFile(
+        join(repository, '.github', 'release-notes', 'v4.0.0.md'),
+        "## What's new\n\nThreadnote 4.0 is ready.\n\n### Standalone runtime\n",
+      );
+      git('init');
+      git('add', '.');
+      gitAt(
+        '2026-08-10T10:00:00Z',
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=threadnote@example.invalid',
+        'commit',
+        '-m',
+        '4.0 release',
+      );
+      gitAt(
+        '2026-08-10T10:05:00Z',
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=threadnote@example.invalid',
+        'tag',
+        '-a',
+        'v4.0.0',
+        '-m',
+        'v4.0.0',
+      );
+
+      await writeFile(join(repository, 'package.json'), '{"version":"4.1.1"}\n');
+      await writeFile(
+        join(repository, '.github', 'release-notes', 'v4.1.1.md'),
+        "## What's new\n\nThreadnote 4.1.1 is ready.\n\n### Faster refreshes\n",
+      );
+      git('add', '.');
+      gitAt(
+        '2026-08-11T11:00:00Z',
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=threadnote@example.invalid',
+        'commit',
+        '-m',
+        'prepare 4.1.1',
+      );
+
+      const prepared = loadLatestMajorWebsiteReleases(repository);
+      expect(prepared.map(release => release.version)).toEqual(['v4.1.1', 'v4.0.0']);
+      expect(prepared[0]).toMatchObject({
+        publishedAt: '2026-08-11T11:00:00+00:00',
+        releaseUrl: 'https://github.com/Kashkovsky/threadnote/releases/tag/v4.1.1',
+        summary: 'Threadnote 4.1.1 is ready.',
+      });
+
+      gitAt(
+        '2026-08-12T12:00:00Z',
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=threadnote@example.invalid',
+        'tag',
+        '-a',
+        'v4.1.1',
+        '-m',
+        'v4.1.1',
+      );
+      const tagged = loadLatestMajorWebsiteReleases(repository);
+      expect(tagged.map(release => release.version)).toEqual(['v4.1.1', 'v4.0.0']);
+      expect(tagged[0]?.publishedAt).toBe('2026-08-12T12:00:00+00:00');
+    } finally {
+      await rm(repository, {force: true, recursive: true});
+    }
   });
 
   it('uses threadnote.io as the single public website origin', async () => {


### PR DESCRIPTION
## What changed

- Include the checked-in stable package version in website release data before its tag exists, provided its exact release note is present and it is newer than every published stable tag.
- Prefer and deduplicate the real tag after publication, including its creator date.
- Make Pages deploy from main only and trigger it for package/release-loader changes.
- Document the ready-to-tag publishing contract.

## Why

GitHub Pages keys deployments by `GITHUB_SHA`. The v4.1.1 main push and tag push resolved to the same commit, so the successful tag deployment retained the pre-tag artifact and the live What's New page stayed on v4.1.0. The first main deployment must already contain the prepared release note.

## Verification

- `bun --bun vitest run test/unit/website-content.test.ts test/unit/website-release-boundary.test.ts test/unit/ci-workflow.test.ts --maxWorkers=1 --reporter=verbose` (60 passed)
- `bun --bun tsc -p test/tsconfig.json --noEmit`
- `bun run site:typecheck`
- `bun run site:build` (generated bundle contains v4.1.1 and v4.1.0)
- pre-commit lint, formatting, application/test/site typechecks
