### PR TITLE
feat: prepare Threadnote 4.2 beta.2

### DIFF
--- a/.github/release-notes/v4.2.0-beta.2.md
+++ b/.github/release-notes/v4.2.0-beta.2.md
@@ -1,0 +1,8 @@
+## What's new
+
+Threadnote 4.2 beta.2 makes standalone updates fail safe when a release listing is temporarily stale.
+
+- `threadnote update --force` now refuses to install an older release from the installation's current channel. A
+  temporarily incomplete GitHub release listing can no longer turn a forced reinstall into an accidental downgrade.
+- Forced reinstall of the current version, newer same-channel updates, and explicit channel switches such as
+  `threadnote update --stable` remain supported. Archive checksum verification and atomic promotion are unchanged.

--- a/.github/release-notes/v4.2.0-beta.2.md
+++ b/.github/release-notes/v4.2.0-beta.2.md
@@ -1,8 +1,20 @@
 ## What's new
 
-Threadnote 4.2 beta.2 makes standalone updates fail safe when a release listing is temporarily stale.
+Threadnote 4.2 beta.2 improves preview updates and makes local runtime and graph-storage activity easier to understand
+and control.
 
+- The beta channel now follows the newest immutable Threadnote release across both stable and prerelease releases. A
+  beta installation can therefore graduate to a newer stable release during an update without `--stable`, while
+  `threadnote update --beta` explicitly re-enters this inclusive preview channel from a stable installation. After
+  graduation, ordinary updates infer the stable channel again; no separate channel preference is persisted.
 - `threadnote update --force` now refuses to install an older release from the installation's current channel. A
   temporarily incomplete GitHub release listing can no longer turn a forced reinstall into an accidental downgrade.
-- Forced reinstall of the current version, newer same-channel updates, and explicit channel switches such as
-  `threadnote update --stable` remain supported. Archive checksum verification and atomic promotion are unchanged.
+- Forced reinstall of the current version and newer updates remain supported. An explicit `threadnote update --stable`
+  can still move a prerelease installation to an older stable release. Archive checksum verification and atomic
+  promotion are unchanged.
+- Manager adds a Processes tab with a bounded, privacy-safe inventory of registered Threadnote runtimes. Isolated graph
+  compaction and deep-diagnostics workers now appear while they are alive, and an identity-bound icon action can stop
+  a selected process without exposing arguments, environment variables, paths, or private registration data. The
+  Manager process hosting the page is protected from self-termination.
+- Manager now labels graph databases with neither a verified local folder nor a ready snapshot as unassociated graph
+  storage and explains whether to index from the repository folder or preview and purge obsolete derived data.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ add it to the team's marketplace. The MCP command above remains required because
 platform-specific server configuration. See the [Cursor plugin guide](./docs/cursor-plugin.md) for installation,
 diagnostics, and publishing.
 
-To opt into prerelease builds, install the Threadnote 4 beta channel on macOS or Linux:
+To select the Threadnote 4 beta channel on macOS or Linux, pass `--beta`. This inclusive preview channel installs the
+newest immutable release across stable and prerelease builds, so a newer stable release wins when one is available:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.sh | sh -s -- --beta
@@ -242,7 +243,8 @@ causing future writes to grow it. When freelist bytes are both at least 512 MiB 
 Manager automatically compacts one eligible database at a time after active builders release their locks and sufficient
 disk headroom is verified. SQLite can require more than twice the database size as temporary free space during `VACUUM`, so Manager
 withholds compaction when that conservative headroom cannot be proved. Automatic compaction runs in an isolated child
-process, keeping Manager responsive; Manager shows the latest check, deferral, failure, or reclaimed bytes. Structural
+process, keeping Manager responsive; Manager shows the latest check, deferral, failure, or reclaimed bytes. While it
+runs, the worker also appears in Manager's privacy-safe Processes tab and in `threadnote processes`. Structural
 fragmentation analysis can scan live SQLite pages, so it is never scheduled automatically. Compaction rechecks the
 active snapshot before and after the transactional rewrite, and interruption leaves the original database intact.
 `graph compact --dry-run` remains available to inspect additional fragmentation explicitly, choose the timing, or
@@ -268,6 +270,12 @@ before acting. The CLI equivalent for an orphaned store is
 an already-running Manager returns an explicit busy response for graph requests until maintenance finishes.
 Manager labels graph views with repository name, the branch observed at a stated boundary, and trusted local folder whenever available; opaque
 checkout and worktree identities are reserved for last-resort diagnostics and exact CLI targeting.
+
+Manager's Processes tab shows the same bounded registered-runtime inventory as `threadnote processes`, including
+parentage, safe operation labels, age, memory, and release version. It never exposes command lines, environment
+variables, working directories, prompts, or registration secrets. A confirmed icon action targets one opaque,
+start-identity-bound process instance; stale or unverifiable identities fail closed, and the Manager process serving the
+page cannot terminate itself.
 
 Maven, Gradle, Kotlin Multiplatform/Android conventions, SwiftPM, conservative Xcode metadata, and nested or integrated
 Bazel workspaces form a static workspace model; repository build scripts are never executed. Bazel `WORKSPACE`,
@@ -299,13 +307,16 @@ is accepted for every format; those output controls are not graph admission limi
 
 ```sh
 threadnote update          # latest stable release
-threadnote update --beta   # opt into the latest beta release
-threadnote update --stable # return to the stable channel
+threadnote update --beta   # newest stable or prerelease release
+threadnote update --stable # explicitly select stable-only updates
 ```
 
-Stable installs report and install stable releases only. After opting into beta, ordinary `threadnote version` and
-`threadnote update` calls stay on the beta channel. Run `threadnote update --stable` to switch back, even when the
-stable release has a lower version than the installed beta.
+Stable installs report and install stable releases only. Prerelease installs infer the inclusive beta channel for
+ordinary `threadnote version` and `threadnote update` calls, so an invoked update can graduate to a newer stable release
+without `--stable`.
+Once stable is installed, unflagged calls infer the stable channel again; pass `--beta` to explicitly re-enter preview
+selection. Run `threadnote update --stable` to switch from a prerelease to stable even when the stable release has a
+lower version.
 
 Threadnote 3 cannot cross the new standalone-runtime boundary with `threadnote update`. Install v4 fresh using the
 installer above; after that, `threadnote update` manages all later 4.x releases.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,8 @@ that a package manager could not remove one, run the exact printed uninstall com
 does not remove unverified third-party files. Threadnote 3 cannot install v4 through `threadnote update`; a fresh
 standalone install is the supported upgrade path.
 
-Preserve the release channel when reinstalling. The bootstrap defaults to stable; beta users select the beta channel:
+The bootstrap defaults to stable-only selection. Pass the beta flag to select the newest immutable release across both
+stable and prerelease builds; this can install stable when it is newer than every prerelease:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.sh | sh -s -- --beta
@@ -23,6 +24,10 @@ curl -fsSL https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/
 ```powershell
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.ps1))) -Beta
 ```
+
+A prerelease installation follows this inclusive beta channel for ordinary updates. After it graduates to stable,
+unflagged updates infer stable-only selection again; use `threadnote update --beta` to explicitly re-enter preview
+selection.
 
 The PowerShell installer path is available for testing but no official Windows 4 asset is published until Authenticode
 signing is re-enabled.
@@ -179,7 +184,14 @@ below that parent. Run `threadnote processes` to see a bounded privacy-safe inve
 current operation, and RSS. The output excludes command lines, working directories, repository names, prompts, and
 model input.
 
-`ROLE` is how the process was started and never changes: `mcp`, `cli`, `manager`, `graph-parser-worker`, or
+The Processes tab in `threadnote manage` presents the same bounded registered-runtime inventory and refreshes while
+workers start and stop. Its stop icon requires confirmation and is bound to the exact private registration and operating
+system start identity shown in that row; it refuses stale, replaced, legacy, or unverifiable processes. The Manager
+process hosting the page is intentionally protected. Isolated automatic-compaction and deep-diagnostics workers appear
+there only while their operation is alive, so seeing only Manager after compaction completes is expected.
+
+`ROLE` is how the process was started and never changes: ordinary roles include `mcp`, `cli`, and `manager`; dedicated
+workers include `graph-parser-worker`, `graph-compaction-worker`, `graph-diagnostics-worker`, and
 `local-model-worker`. While a process builds or waits for a code graph, the role it is temporarily acting as is
 appended, as in `cli (graph-builder)` for a dedicated `threadnote graph index` run or `mcp (graph-waiter)` for an MCP
 server queued behind another build. A process is therefore identifiable by its own identity and by the graph work it
@@ -309,6 +321,11 @@ deterministic architecture report and likewise refuses to overwrite.
 If doctor reports a missing or mismatched grammar asset, reinstall or update the standalone archive for the current
 platform. Threadnote never downloads parser grammars at runtime. Repair may discard and rebuild graph SQLite files, but
 it does not modify the repository or canonical memories.
+
+A Manager card labeled **Unassociated graph storage** has neither a verified local repository folder nor a ready
+queryable snapshot. If the repository still exists, run `threadnote graph index --cwd <path>` from that folder and
+refresh Manager. If the database is obsolete, preview and purge it instead; graph databases are derived data and
+purging does not remove repository files or canonical memories.
 
 ## MCP does not appear in the agent
 

--- a/manager/app.css
+++ b/manager/app.css
@@ -3396,6 +3396,127 @@ dd {
   }
 }
 
+.process-workspace {
+  display: grid;
+  gap: 14px;
+  height: 100%;
+  overflow: auto;
+  padding: 20px;
+}
+
+.process-header > div > p:last-child {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 9px 0 0;
+  max-width: 720px;
+}
+
+.process-notice,
+.process-empty {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-size: 12px;
+  margin: 0;
+  padding: 12px 14px;
+}
+
+.process-notice.is-error {
+  background: var(--danger-soft);
+  border-color: rgba(255, 98, 120, 0.35);
+  color: var(--danger);
+}
+
+.process-list {
+  display: grid;
+  gap: 10px;
+}
+
+.process-card {
+  align-items: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 14px;
+}
+
+.process-card-main {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.process-card-title {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.process-card-title strong {
+  font-size: 14px;
+}
+
+.process-card-title em {
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-size: 9px;
+  font-style: normal;
+  padding: 2px 6px;
+}
+
+.process-card-title span,
+.process-card-main > p,
+.process-card dt {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.process-card-main > p {
+  margin: 0;
+}
+
+.process-card dl {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 2px 0 0;
+}
+
+.process-card dl > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.process-card dd {
+  font-size: 11px;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.process-terminate {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.process-terminate svg {
+  fill: none;
+  height: 16px;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  width: 16px;
+}
+
 @media (max-width: 640px) {
   .manager-dialog {
     width: min(100% - 20px, 540px);
@@ -3443,6 +3564,10 @@ dd {
 
   .worksets-operation-tabs button {
     min-width: max-content;
+  }
+
+  .process-card dl {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .worksets-editor-backdrop {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.2.0-beta.1",
+  "version": "4.2.0-beta.2",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -434,7 +434,7 @@ function Resolve-ThreadnoteVersion {
     switch ($channel) {
       'latest' { $false }
       'stable' { $false }
-      'beta' { $true }
+      'beta' { $null }
       default { throw 'THREADNOTE_CHANNEL must be latest, stable, or beta.' }
     }
   }
@@ -451,7 +451,9 @@ function Resolve-ThreadnoteVersion {
   }
   foreach ($candidate in $releaseResponse) {
     if ($candidate.draft -or $candidate.immutable -ne $true) { continue }
-    if (-not $requestedVersion -and [bool]$candidate.prerelease -ne $prerelease) { continue }
+    if (-not $requestedVersion -and $null -ne $prerelease -and [bool]$candidate.prerelease -ne $prerelease) {
+      continue
+    }
     $candidateVersion = ([string]$candidate.tag_name).TrimStart('v')
     if (-not (ConvertTo-ThreadnoteSemver $candidateVersion)) { continue }
     if ($requestedVersion -and $candidateVersion -cne $requestedVersion) { continue }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -352,7 +352,7 @@ resolve_version() {
   if [ -z "$requested_version" ]; then
     case "$CHANNEL" in
       latest | stable) prerelease=false ;;
-      beta) prerelease=true ;;
+      beta) prerelease=any ;;
       *) die "THREADNOTE_CHANNEL must be latest, stable, or beta." ;;
     esac
   else
@@ -411,7 +411,7 @@ resolve_version() {
               if (tag !~ /^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$/) continue
               if (requested != "") {
                 if (tag == requested) best = tag
-              } else if (candidate_prerelease == desired && greater(tag, best)) {
+              } else if ((desired == "any" || candidate_prerelease == desired) && greater(tag, best)) {
                 best = tag
               }
             }

--- a/src/code_graph/deep_diagnostics.ts
+++ b/src/code_graph/deep_diagnostics.ts
@@ -28,10 +28,11 @@ type CodeGraphDeepDiagnosticsResponse =
  * worker before the parent releases its maintenance and writer locks.
  */
 export const diagnoseCodeGraphDatabaseDeepIsolated: (
+  threadnoteHome: string,
   databasePath: string,
 ) => Effect.Effect<CodeGraphDatabaseHealth, Error | CommandExecutionError, CommandExecutor | SystemInfo> = Effect.fn(
   'codeGraph.diagnoseDatabaseDeepIsolated',
-)(function* (databasePath: string) {
+)(function* (threadnoteHome: string, databasePath: string) {
   const command = yield* CommandExecutor;
   const system = yield* SystemInfo;
   const invocation = deepDiagnosticsWorkerInvocation(system);
@@ -40,7 +41,7 @@ export const diagnoseCodeGraphDatabaseDeepIsolated: (
     protocol: CODE_GRAPH_DEEP_DIAGNOSTICS_PROTOCOL,
   } satisfies CodeGraphDeepDiagnosticsRequest;
   const result = yield* command.execute(invocation.executable, invocation.arguments, {
-    env: {THREADNOTE_CODE_GRAPH_DEEP_DIAGNOSTICS_WORKER: '1'},
+    env: deepDiagnosticsWorkerEnvironment(system.environment(), threadnoteHome),
     input: new TextEncoder().encode(`${JSON.stringify(request)}\n`),
     maxOutputBytes: CODE_GRAPH_DEEP_DIAGNOSTICS_OUTPUT_BYTES_MAXIMUM,
     timeoutMs: 0,
@@ -53,13 +54,42 @@ export const diagnoseCodeGraphDatabaseDeepIsolated: (
 });
 
 export function diagnoseCodeGraphDatabase(
+  threadnoteHome: string,
   databasePath: string,
   deep: boolean,
 ): Effect.Effect<CodeGraphDatabaseHealth, unknown, CommandExecutor | SystemInfo> {
-  if (deep) return diagnoseCodeGraphDatabaseDeepIsolated(databasePath);
+  if (deep) return diagnoseCodeGraphDatabaseDeepIsolated(threadnoteHome, databasePath);
   return diagnoseCodeGraphDatabaseReadOnly(databasePath, false).pipe(
     Effect.map(health => health as CodeGraphDatabaseHealth),
   );
+}
+
+/** @internal Preserve only host variables required to bootstrap the same-privilege worker. */
+export function deepDiagnosticsWorkerEnvironment(source: NodeJS.ProcessEnv, threadnoteHome: string): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    THREADNOTE_CODE_GRAPH_DEEP_DIAGNOSTICS_WORKER: '1',
+    THREADNOTE_HOME: threadnoteHome,
+  };
+  for (const key of [
+    'HOME',
+    'USERPROFILE',
+    'HOMEDRIVE',
+    'HOMEPATH',
+    'TMPDIR',
+    'TMP',
+    'TEMP',
+    'PATH',
+    'PATHEXT',
+    'ComSpec',
+    'COMSPEC',
+    'SystemRoot',
+    'SYSTEMROOT',
+    'WINDIR',
+  ] as const) {
+    const value = source[key];
+    if (value !== undefined) environment[key] = value;
+  }
+  return environment;
 }
 
 /** Internal standalone mode. It deliberately runs without BunRuntime signal handlers. */

--- a/src/code_graph/diagnostics.ts
+++ b/src/code_graph/diagnostics.ts
@@ -178,7 +178,7 @@ export const inspectAllCodeGraphs = Effect.fn('codeGraph.inspectAllDiagnostics')
             message: 'An active graph build owns this checkout; database health inspection was deferred.',
           });
         } else {
-          const diagnosed = yield* diagnoseCodeGraphDatabase(database, options.deep === true).pipe(
+          const diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, options.deep === true).pipe(
             Effect.match({onFailure: cause => ({cause}) as const, onSuccess: value => ({value}) as const}),
           );
           if ('value' in diagnosed) {

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -319,7 +319,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
           const decision = yield* store.withSession(
             database,
             Effect.gen(function* () {
-              let diagnosed = yield* diagnoseCodeGraphDatabase(database, deep).pipe(Effect.option);
+              let diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(Effect.option);
               if (
                 diagnosed._tag === 'Some' &&
                 diagnosed.value?.schemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
@@ -343,7 +343,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                     if (preparation.state === 'deferred') return 'schema-upgrade-on-use' as const;
                   }
                   yield* store.initialize(database);
-                  diagnosed = yield* diagnoseCodeGraphDatabase(database, deep).pipe(Effect.option);
+                  diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(Effect.option);
                   if (diagnosed._tag === 'Some' && diagnosed.value?.integrity === 'ok') {
                     migratedDatabases += 1;
                   } else {

--- a/src/code_graph/visualization.ts
+++ b/src/code_graph/visualization.ts
@@ -326,7 +326,8 @@ export const managerGraphCatalog = Effect.fn('codeGraph.managerCatalog')(functio
             diagnostic: {
               checkoutId,
               code: 'no-ready-snapshot',
-              message: 'An indexed repository database has no ready graph snapshot.',
+              message:
+                'Stored graph data has no queryable snapshot. Index from its repository folder, or purge it if it is obsolete.',
             } satisfies ManagerGraphCatalogDiagnostic,
           } as const;
         }
@@ -351,7 +352,8 @@ export const managerGraphCatalog = Effect.fn('codeGraph.managerCatalog')(functio
             diagnostic: {
               checkoutId,
               code: 'no-ready-snapshot',
-              message: 'An indexed repository database has no ready graph snapshot.',
+              message:
+                'Stored graph data has no queryable snapshot. Index from its repository folder, or purge it if it is obsolete.',
             } satisfies ManagerGraphCatalogDiagnostic,
           } as const;
         }

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -305,7 +305,7 @@ const update = Command.make(
   'update',
   {
     allowUntrustedSource: boolean('allow-untrusted-source', 'Allow a non-default release API source'),
-    beta: boolean('beta', 'Update to the latest beta release'),
+    beta: boolean('beta', 'Follow the beta channel: install the newest stable or prerelease release'),
     check: boolean('check', 'Only check whether a newer version is available'),
     dryRun: boolean('dry-run', 'Print update and repair commands without running them'),
     force: boolean('force', 'Reinstall the selected standalone release even if already current'),

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -9,7 +9,6 @@ import {
   runEffectAiConsolidation,
   runNativeAiConsolidation,
 } from './effect/ai/consolidator.js';
-import {resolveSelectedLocalModel} from './models/inference.js';
 import {runCommandEffect} from './effect/command.js';
 import {captureConsole} from './effect/console.js';
 import {ResourceStore} from './effect/resource-store.js';
@@ -54,8 +53,8 @@ import {
 } from './share.js';
 import {collectDoctorChecks, runRepair, runStart} from './lifecycle.js';
 import {runSeed, runSeedSkills} from './seeding.js';
-import {currentPackageVersion, fetchLatestVersion, releaseSource} from './update.js';
-import {selectUpdateChannel} from './update_channel.js';
+import {readManagerRuntimeState} from './manager_state.js';
+import {handleManagerProcessRequest} from './manager_processes.js';
 import {
   handleManagerWorksetRequest,
   isManagerWorksetApiPath,
@@ -453,30 +452,7 @@ export const readContextUri = Effect.fn('manager.readContextUri')(function* (
   return {content: result.output, output: result.output};
 });
 
-export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationAgents')(function* (
-  config: Pick<RuntimeConfig, 'agentContextHome'>,
-) {
-  const effectAi = yield* resolveEffectAiConfiguration(config, (yield* SystemInfo).environment());
-  const nativeGeneration = yield* resolveSelectedLocalModel(config.agentContextHome, 'generation');
-  const [codex, claude, cursor, copilot] = yield* Effect.all([
-    findExecutable(['codex']),
-    findExecutable(['claude']),
-    findExecutable(['cursor-agent']),
-    findExecutable(['copilot']),
-  ]);
-  return [
-    {available: codex !== undefined, command: codex, id: 'codex', label: 'Codex'},
-    {available: claude !== undefined, command: claude, id: 'claude', label: 'Claude'},
-    {available: cursor !== undefined, command: cursor, id: 'cursor', label: 'Cursor'},
-    {available: copilot !== undefined, command: copilot, id: 'copilot', label: 'Copilot'},
-    {
-      available: nativeGeneration !== undefined || effectAi !== undefined,
-      command: nativeGeneration?.manifest.id ?? effectAi?.configuration.model,
-      id: 'effect-ai',
-      label: nativeGeneration ? 'Threadnote local AI' : 'Effect AI (explicit remote provider)',
-    },
-  ];
-});
+export {detectConsolidationAgents} from './manager_state.js';
 
 function handleRequestEffect(
   context: ApiContext,
@@ -491,17 +467,10 @@ function handleRequestEffect(
         writeJson(response, 401, {error: 'Unauthorized'});
         return;
       }
-      const system = yield* SystemInfo;
-      const [agents, version] = yield* Effect.all([detectConsolidationAgents(context.config), currentPackageVersion()]);
-      const latest = yield* Effect.succeed(releaseSource(system.environment())).pipe(
-        Effect.flatMap(source => fetchLatestVersion(source, selectUpdateChannel(version))),
-        Effect.match({onFailure: Result.fail, onSuccess: Result.succeed}),
-      );
+      const state = yield* readManagerRuntimeState(context.config);
       writeJson(response, 200, {
-        agents,
+        ...state,
         config: publicConfig(context.config),
-        latestVersion: Result.isSuccess(latest) ? latest.success : undefined,
-        version,
       });
     });
   } else if (request.method === 'POST' && url.pathname === '/api/consolidations') {
@@ -559,6 +528,16 @@ const handleRequestLegacy = Effect.fn('manager.handleRequestLegacy')(function* (
   }
   if (!isAuthorized(context, request)) {
     writeJson(response, 401, {error: 'Unauthorized'});
+    return;
+  }
+  const processResponse = yield* handleManagerProcessRequest({
+    body: request.body,
+    config: context.config,
+    method: request.method,
+    url,
+  });
+  if (processResponse) {
+    writeJson(response, processResponse.status, processResponse.body);
     return;
   }
   if (

--- a/src/manager_graph_panels.tsx
+++ b/src/manager_graph_panels.tsx
@@ -601,7 +601,10 @@ export function GraphAdministration(props: {
             {props.report.databases.map(database => {
               const view = database.views.find(candidate => candidate.managementAvailable) ?? database.views[0];
               const managementAvailable = view?.managementAvailable === true;
-              const repository = view?.repository.displayName ?? 'Indexed repository';
+              const unassociatedWithoutSnapshot = view === undefined && database.health?.readySnapshots === 0;
+              const repository = unassociatedWithoutSnapshot
+                ? 'Unassociated graph storage'
+                : (view?.repository.displayName ?? 'Indexed repository');
               const jobs = graphAdministrationJobSelection(database.builds, database.waiters);
               const obsolete = props.report?.obsoleteStores.checkouts.find(
                 checkout => checkout.checkoutId === database.checkoutId,
@@ -620,8 +623,10 @@ export function GraphAdministration(props: {
                       <strong>{repository}</strong>
                       <small>
                         {view?.localAssociation.branch ? `observed branch ${view.localAssociation.branch} · ` : ''}
-                        {view?.localAssociation.displayPath ??
-                          'Local folder unavailable; opaque ID shown in diagnostics'}
+                        {unassociatedWithoutSnapshot
+                          ? 'No verified local folder or ready snapshot'
+                          : (view?.localAssociation.displayPath ??
+                            'Local folder unavailable; opaque ID shown in diagnostics')}
                       </small>
                     </span>
                     <em className={`is-${health}`}>{health === 'migration-pending' ? 'migrating' : health}</em>
@@ -886,7 +891,12 @@ export function GraphAdministration(props: {
                       Purge graph
                     </button>
                   </div>
-                  {!managementAvailable ? (
+                  {unassociatedWithoutSnapshot ? (
+                    <small className="graph-management-unavailable">
+                      This disposable graph has no queryable snapshot. Index from the repository folder with{' '}
+                      <code>threadnote graph index --cwd &lt;path&gt;</code>, or preview and purge it if it is obsolete.
+                    </small>
+                  ) : !managementAvailable ? (
                     <small className="graph-management-unavailable">
                       Index, reindex, and compact require a verified local worktree path. Purge actions target this
                       inventoried checkout directly.

--- a/src/manager_processes.ts
+++ b/src/manager_processes.ts
@@ -1,0 +1,106 @@
+import {Cause, Effect} from 'effect';
+import {
+  readManageableThreadnoteProcessDiagnostics,
+  terminateThreadnoteProcess,
+  ThreadnoteProcessTerminationError,
+} from './process_diagnostics.js';
+import type {RuntimeConfig} from './types.js';
+
+export interface ManagerProcessApiResponse {
+  readonly body: unknown;
+  readonly status: number;
+}
+
+export interface ManagerProcessApiRequest {
+  readonly body: Effect.Effect<Record<string, unknown>, unknown>;
+  readonly config: RuntimeConfig;
+  readonly method: string;
+  readonly url: URL;
+}
+
+class ManagerProcessApiError extends Error {
+  override readonly name = 'ManagerProcessApiError';
+
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+export function isManagerProcessApiPath(pathname: string): boolean {
+  return pathname === '/api/processes' || pathname.startsWith('/api/processes/');
+}
+
+export const handleManagerProcessRequest = Effect.fn('managerProcesses.handleRequest')(function* (
+  request: ManagerProcessApiRequest,
+) {
+  if (!isManagerProcessApiPath(request.url.pathname)) return undefined;
+  return yield* routeManagerProcessRequest(request).pipe(
+    Effect.catchCause(cause => Effect.succeed(managerProcessErrorResponse(Cause.squash(cause)))),
+  );
+});
+
+function routeManagerProcessRequest(request: ManagerProcessApiRequest) {
+  return Effect.gen(function* () {
+    if (request.method === 'GET' && request.url.pathname === '/api/processes') {
+      return response(200, yield* readManageableThreadnoteProcessDiagnostics(request.config));
+    }
+    if (request.method !== 'POST' || request.url.pathname !== '/api/processes/terminate') {
+      return response(404, {error: 'Not found'});
+    }
+    const body = yield* request.body.pipe(
+      Effect.mapError(() => new ManagerProcessApiError('invalid-json', 'Provide a JSON object request body.', 400)),
+    );
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      throw new ManagerProcessApiError('invalid-json', 'Provide a JSON object request body.', 400);
+    }
+    if (body.confirm !== true) {
+      throw new ManagerProcessApiError(
+        'confirmation-required',
+        'Confirm termination of the selected Threadnote process.',
+        400,
+      );
+    }
+    if (!Number.isSafeInteger(body.processId) || Number(body.processId) <= 0 || typeof body.processRef !== 'string') {
+      throw new ManagerProcessApiError('invalid-process-target', 'The process target is invalid.', 400);
+    }
+    return response(
+      200,
+      yield* terminateThreadnoteProcess(request.config, {
+        processId: Number(body.processId),
+        processRef: body.processRef,
+      }),
+    );
+  });
+}
+
+function managerProcessErrorResponse(error: unknown): ManagerProcessApiResponse {
+  if (error instanceof ManagerProcessApiError) {
+    return response(error.status, {code: error.code, error: error.message, retryAfterMilliseconds: 0});
+  }
+  if (error instanceof ThreadnoteProcessTerminationError) {
+    const status =
+      error.code === 'invalid-process-target'
+        ? 400
+        : error.code === 'process-permission-denied'
+          ? 403
+          : error.code === 'process-not-found'
+            ? 404
+            : error.code === 'process-signal-failed'
+              ? 500
+              : 409;
+    return response(status, {code: error.code, error: error.message, retryAfterMilliseconds: 0});
+  }
+  return response(500, {
+    code: 'process-operation-failed',
+    error: 'The Threadnote process operation failed.',
+    retryAfterMilliseconds: 0,
+  });
+}
+
+function response(status: number, body: unknown): ManagerProcessApiResponse {
+  return {body, status};
+}

--- a/src/manager_processes_view.tsx
+++ b/src/manager_processes_view.tsx
@@ -1,0 +1,218 @@
+import React, {useEffect, useState} from 'react';
+import {useManagerDialogs} from './manager_dialog.js';
+import {api, errorMessage} from './manager_ui_support.js';
+import type {
+  ManageableThreadnoteProcessDiagnostic,
+  ManageableThreadnoteProcessDiagnostics,
+} from './process_diagnostics.js';
+
+const PROCESS_POLL_MILLISECONDS = 2_000;
+
+export function ProcessesPanel(): React.ReactElement {
+  const dialogs = useManagerDialogs();
+  const [diagnostics, setDiagnostics] = useState<ManageableThreadnoteProcessDiagnostics>();
+  const [loadError, setLoadError] = useState('');
+  const [operationError, setOperationError] = useState('');
+  const [terminating, setTerminating] = useState<string>();
+
+  const load = async (signal?: AbortSignal): Promise<void> => {
+    try {
+      const next = await api<ManageableThreadnoteProcessDiagnostics>('/api/processes', undefined, {signal});
+      setDiagnostics(next);
+      setLoadError('');
+    } catch (cause) {
+      if (!signal?.aborted) setLoadError(errorMessage(cause));
+    }
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let timer: number | undefined;
+    const poll = async (): Promise<void> => {
+      await load(controller.signal);
+      if (!controller.signal.aborted) timer = window.setTimeout(() => void poll(), PROCESS_POLL_MILLISECONDS);
+    };
+    void poll();
+    return () => {
+      controller.abort();
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
+
+  const terminate = async (process: ManageableThreadnoteProcessDiagnostic): Promise<void> => {
+    if (!process.terminable || process.processRef === undefined) return;
+    const approved = await dialogs.confirm({
+      confirmLabel: 'Terminate process',
+      detail: `${processRoleLabel(process.role)} · PID ${process.processId}${process.currentOperation ? ` · ${process.currentOperation}` : ''}`,
+      message: 'Threadnote will request a graceful stop and may force-stop this exact process instance if needed.',
+      title: 'Terminate Threadnote process?',
+      tone: 'danger',
+    });
+    if (!approved) return;
+    setTerminating(process.processRef);
+    setOperationError('');
+    try {
+      await api('/api/processes/terminate', {
+        confirm: true,
+        processId: process.processId,
+        processRef: process.processRef,
+      });
+      await load();
+    } catch (cause) {
+      setOperationError(errorMessage(cause));
+      await load();
+    } finally {
+      setTerminating(undefined);
+    }
+  };
+
+  return (
+    <div className="process-workspace">
+      <header className="workspace-header process-header">
+        <div>
+          <p className="eyebrow">Runtime inventory</p>
+          <h2>Threadnote processes</h2>
+          <p>
+            Registered processes and identity-verified legacy runtimes. Arguments, environment variables, and private
+            registration data are never exposed.
+          </p>
+        </div>
+        <button
+          aria-label="Refresh process list"
+          onClick={() => void load()}
+          title="Refresh process list"
+          type="button"
+        >
+          Refresh
+        </button>
+      </header>
+
+      {loadError ? <p className="process-notice is-error">{loadError}</p> : null}
+      {operationError ? (
+        <p aria-live="polite" className="process-notice is-error">
+          {operationError}
+        </p>
+      ) : null}
+      {diagnostics?.truncated ? (
+        <p className="process-notice">The bounded inventory is truncated. Refresh after other processes exit.</p>
+      ) : null}
+
+      <div className="process-list">
+        {diagnostics === undefined ? (
+          <p className="process-empty">Loading registered processes…</p>
+        ) : diagnostics.processes.length === 0 ? (
+          <p className="process-empty">No registered Threadnote processes are visible.</p>
+        ) : (
+          diagnostics.processes.map(process => (
+            <article className="process-card" key={`${process.processId}:${process.startedAt}`}>
+              <div className="process-card-main">
+                <div className="process-card-title">
+                  <strong>{processRoleLabel(process.role)}</strong>
+                  {process.activityRole ? <em>{processRoleLabel(process.activityRole)} activity</em> : null}
+                  <span>PID {process.processId}</span>
+                </div>
+                <p>{process.currentOperation ? operationLabel(process.currentOperation) : 'Idle'}</p>
+                <dl>
+                  <div>
+                    <dt>Parent</dt>
+                    <dd>{parentLabel(process)}</dd>
+                  </div>
+                  <div>
+                    <dt>Running</dt>
+                    <dd>{formatDuration(process.ageMilliseconds)}</dd>
+                  </div>
+                  <div>
+                    <dt>Memory</dt>
+                    <dd>{process.rssBytes === undefined ? 'Unavailable' : formatBytes(process.rssBytes)}</dd>
+                  </div>
+                  <div>
+                    <dt>Version</dt>
+                    <dd>{process.releaseVersion ? `v${process.releaseVersion}` : 'Current runtime'}</dd>
+                  </div>
+                </dl>
+              </div>
+              <button
+                aria-label={`Terminate ${processRoleLabel(process.role)} process ${process.processId}`}
+                className="icon-button danger process-terminate"
+                disabled={!process.terminable || terminating !== undefined}
+                onClick={() => void terminate(process)}
+                title={terminationTitle(process)}
+                type="button"
+              >
+                <svg aria-hidden="true" viewBox="0 0 20 20">
+                  <rect height="9" rx="1" width="9" x="5.5" y="5.5" />
+                </svg>
+              </button>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function processRoleLabel(role: ManageableThreadnoteProcessDiagnostic['role']): string {
+  switch (role) {
+    case 'cli':
+      return 'CLI';
+    case 'graph-builder':
+      return 'Graph builder';
+    case 'graph-compaction-worker':
+      return 'Graph compaction worker';
+    case 'graph-diagnostics-worker':
+      return 'Graph diagnostics worker';
+    case 'graph-parser-worker':
+      return 'Graph parser worker';
+    case 'graph-waiter':
+      return 'Graph waiter';
+    case 'legacy':
+      return 'Legacy runtime';
+    case 'local-model-worker':
+      return 'Local model worker';
+    case 'manager':
+      return 'Manager';
+    case 'mcp':
+      return 'MCP server';
+  }
+}
+
+function operationLabel(operation: string): string {
+  return operation
+    .split('-')
+    .filter(Boolean)
+    .map((part, index) => (index === 0 ? `${part.slice(0, 1).toUpperCase()}${part.slice(1)}` : part))
+    .join(' ');
+}
+
+function parentLabel(process: ManageableThreadnoteProcessDiagnostic): string {
+  if (process.parentProcessId === 0) return 'Unavailable';
+  return process.parentRole
+    ? `${processRoleLabel(process.parentRole)} · PID ${process.parentProcessId}`
+    : `PID ${process.parentProcessId}`;
+}
+
+function terminationTitle(process: ManageableThreadnoteProcessDiagnostic): string {
+  if (process.terminable) return `Terminate ${processRoleLabel(process.role)}`;
+  switch (process.terminationBlockedReason) {
+    case 'current-manager':
+      return 'The current Manager process is protected';
+    case 'identity-unverified':
+      return 'Process identity could not be verified';
+    case 'legacy-process':
+      return 'Restart the owning client to stop this legacy process safely';
+    default:
+      return 'This process cannot be terminated from Manager';
+  }
+}
+
+function formatDuration(milliseconds: number): string {
+  const totalSeconds = Math.max(0, Math.floor(milliseconds / 1_000));
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  return hours > 0 ? `${hours}h ${minutes}m` : minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
+function formatBytes(bytes: number): string {
+  return `${(bytes / (1_024 * 1_024)).toFixed(1)} MiB`;
+}

--- a/src/manager_state.ts
+++ b/src/manager_state.ts
@@ -1,0 +1,55 @@
+import {Effect} from 'effect';
+import {resolveEffectAiConfiguration} from './effect/ai/consolidator.js';
+import {SystemInfo} from './effect/system.js';
+import {resolveSelectedLocalModel} from './models/inference.js';
+import type {RuntimeConfig} from './types.js';
+import {currentPackageVersion, fetchLatestVersion, releaseSource} from './update.js';
+import {selectUpdateChannel} from './update_channel.js';
+import {findExecutable} from './utils.js';
+import {compareVersions} from './version_compare.js';
+
+export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationAgents')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+) {
+  const effectAi = yield* resolveEffectAiConfiguration(config, (yield* SystemInfo).environment());
+  const nativeGeneration = yield* resolveSelectedLocalModel(config.agentContextHome, 'generation');
+  const [codex, claude, cursor, copilot] = yield* Effect.all([
+    findExecutable(['codex']),
+    findExecutable(['claude']),
+    findExecutable(['cursor-agent']),
+    findExecutable(['copilot']),
+  ]);
+  return [
+    {available: codex !== undefined, command: codex, id: 'codex', label: 'Codex'},
+    {available: claude !== undefined, command: claude, id: 'claude', label: 'Claude'},
+    {available: cursor !== undefined, command: cursor, id: 'cursor', label: 'Cursor'},
+    {available: copilot !== undefined, command: copilot, id: 'copilot', label: 'Copilot'},
+    {
+      available: nativeGeneration !== undefined || effectAi !== undefined,
+      command: nativeGeneration?.manifest.id ?? effectAi?.configuration.model,
+      id: 'effect-ai',
+      label: nativeGeneration ? 'Threadnote local AI' : 'Effect AI (explicit remote provider)',
+    },
+  ];
+});
+
+export function managerUpdateAvailable(currentVersion: string, latestVersion?: string): boolean {
+  return latestVersion !== undefined && compareVersions(latestVersion, currentVersion) > 0;
+}
+
+export const readManagerRuntimeState = Effect.fn('manager.readRuntimeState')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+) {
+  const system = yield* SystemInfo;
+  const [agents, version] = yield* Effect.all([detectConsolidationAgents(config), currentPackageVersion()]);
+  const latestVersion = yield* fetchLatestVersion(
+    releaseSource(system.environment()),
+    selectUpdateChannel(version),
+  ).pipe(Effect.catch(() => Effect.succeed(undefined)));
+  return {
+    agents,
+    latestVersion,
+    updateAvailable: managerUpdateAvailable(version, latestVersion),
+    version,
+  };
+});

--- a/src/manager_ui.tsx
+++ b/src/manager_ui.tsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm';
 import type {CodeGraphLocalDiagnosticsReport} from './code_graph/diagnostics.js';
 import {ManagerAutocompleteInput, ManagerDialogProvider, useManagerDialogs} from './manager_dialog.js';
 import {WorksetsPanel} from './manager_worksets_view.js';
+import {ProcessesPanel} from './manager_processes_view.js';
 import {
   graphViewRemovalApprovalDialog,
   graphViewRemovalTargetIsAbsent,
@@ -65,7 +66,7 @@ export {
   selectableMemoryUris,
 } from './manager_ui_support.js';
 
-export type PanelName = 'doctor' | 'graph' | 'memory' | 'shares' | 'tools' | 'worksets';
+export type PanelName = 'doctor' | 'graph' | 'memory' | 'processes' | 'shares' | 'tools' | 'worksets';
 type NavTreeTab = 'memories' | 'resources';
 type CheckStatus = 'fail' | 'ok' | 'warn';
 type MemoryKind = 'durable' | 'handoff' | 'incident' | 'preference' | 'smoke';
@@ -141,6 +142,7 @@ interface StateResponse {
     readonly user: string;
   };
   readonly latestVersion?: string;
+  readonly updateAvailable: boolean;
   readonly version: string;
 }
 
@@ -1147,7 +1149,7 @@ function App(): React.ReactElement {
         </div>
         <p className="sidebar-label">Workspace</p>
         <nav className="primary-nav" aria-label="Manager sections">
-          {(['graph', 'worksets', 'memory', 'shares', 'doctor', 'tools'] as const).map(name => (
+          {(['graph', 'worksets', 'memory', 'shares', 'processes', 'doctor', 'tools'] as const).map(name => (
             <button
               aria-current={panel === name ? 'page' : undefined}
               className={panel === name ? 'is-active' : undefined}
@@ -1267,7 +1269,7 @@ function App(): React.ReactElement {
             </div>
           </div>
         )}
-        {state?.latestVersion && state.latestVersion !== state.version ? (
+        {state?.updateAvailable && state.latestVersion ? (
           <div className="sidebar-update">
             <span>Update available</span>
             <strong>v{state.latestVersion}</strong>
@@ -1352,6 +1354,12 @@ function App(): React.ReactElement {
         {panel === 'worksets' ? (
           <section className="panel is-active">
             <WorksetsPanel />
+          </section>
+        ) : null}
+
+        {panel === 'processes' ? (
+          <section className="panel is-active">
+            <ProcessesPanel />
           </section>
         ) : null}
 

--- a/src/manager_ui_support.tsx
+++ b/src/manager_ui_support.tsx
@@ -471,6 +471,8 @@ function tabTitle(name: PanelName): string {
       return 'Graph';
     case 'memory':
       return 'Library';
+    case 'processes':
+      return 'Processes';
     case 'shares':
       return 'Sharing';
     case 'tools':
@@ -488,6 +490,8 @@ function panelIcon(name: PanelName): string {
       return '◉';
     case 'memory':
       return '◇';
+    case 'processes':
+      return '▣';
     case 'shares':
       return '⇄';
     case 'tools':
@@ -505,6 +509,8 @@ function panelNavDescription(name: PanelName): string {
       return 'Explore architecture';
     case 'memory':
       return 'Memories and resources';
+    case 'processes':
+      return 'Verified runtimes';
     case 'shares':
       return 'Team repositories';
     case 'tools':
@@ -522,6 +528,8 @@ function panelDescription(name: PanelName): string {
       return 'Repository architecture explorer';
     case 'memory':
       return 'Browse, edit, and consolidate context';
+    case 'processes':
+      return 'Inspect and safely terminate registered Threadnote runtimes';
     case 'shares':
       return 'Manage synchronized team context';
     case 'tools':

--- a/src/process_diagnostics.ts
+++ b/src/process_diagnostics.ts
@@ -3,6 +3,7 @@ import {writeFinalCliOutput} from './effect/cli_output.js';
 import type {RuntimeConfig} from './types.js';
 import {SystemInfo} from './effect/system.js';
 import {readLiveStandaloneProcessLeases} from './standalone_process_lease.js';
+import {sha256HexSync} from './crypto/sha256.js';
 
 const PROCESS_DIAGNOSTICS_SCHEMA_VERSION = 1;
 const PROCESS_DIAGNOSTICS_LIMIT = 100;
@@ -14,6 +15,8 @@ const SAFE_OPERATION = /^[a-z][a-z0-9-]{0,47}$/;
 export type ThreadnoteProcessRole =
   | 'cli'
   | 'graph-builder'
+  | 'graph-compaction-worker'
+  | 'graph-diagnostics-worker'
   | 'graph-parser-worker'
   | 'graph-waiter'
   | 'legacy'
@@ -52,6 +55,52 @@ export interface ThreadnoteProcessDiagnostics {
   readonly processes: readonly ThreadnoteProcessDiagnostic[];
   readonly schemaVersion: typeof PROCESS_DIAGNOSTICS_SCHEMA_VERSION;
   readonly truncated: boolean;
+}
+
+export interface ManageableThreadnoteProcessDiagnostic extends ThreadnoteProcessDiagnostic {
+  readonly processRef?: string;
+  readonly terminationBlockedReason?: 'current-manager' | 'identity-unverified' | 'legacy-process';
+  readonly terminable: boolean;
+}
+
+export interface ManageableThreadnoteProcessDiagnostics {
+  readonly processes: readonly ManageableThreadnoteProcessDiagnostic[];
+  readonly schemaVersion: typeof PROCESS_DIAGNOSTICS_SCHEMA_VERSION;
+  readonly truncated: boolean;
+}
+
+export type ThreadnoteProcessTerminationErrorCode =
+  | 'current-manager'
+  | 'invalid-process-target'
+  | 'process-not-found'
+  | 'process-permission-denied'
+  | 'process-signal-failed'
+  | 'process-stale';
+
+export class ThreadnoteProcessTerminationError extends Error {
+  readonly _tag = 'ThreadnoteProcessTerminationError' as const;
+
+  constructor(
+    readonly code: ThreadnoteProcessTerminationErrorCode,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface ThreadnoteProcessTerminationResult {
+  readonly processId: number;
+  readonly state: 'signaled' | 'terminated';
+}
+
+export interface ThreadnoteProcessTerminationTarget {
+  readonly processId: number;
+  readonly processRef: string;
+}
+
+export interface ThreadnoteProcessTerminationOptions {
+  readonly gracefulWaitMilliseconds?: number;
+  readonly forceWaitMilliseconds?: number;
 }
 
 interface ActiveProcessRegistration {
@@ -119,6 +168,19 @@ export function withThreadnoteProcessRegistration<A, E, R>(
   );
 }
 
+/**
+ * Register a worker whose top-level runner deliberately retains the host's
+ * default signal behavior. Registration itself installs no signal handlers.
+ */
+export function withSignalTransparentThreadnoteWorkerRegistration<A, E, R>(
+  home: string,
+  role: Extract<RegisteredThreadnoteProcessRole, 'graph-compaction-worker' | 'graph-diagnostics-worker'>,
+  operation: string,
+  effect: Effect.Effect<A, E, R>,
+) {
+  return withThreadnoteProcessRegistration(home, role, effect, operation);
+}
+
 export function withThreadnoteProcessActivity<A, E, R>(
   role: RegisteredThreadnoteProcessRole,
   operation: string,
@@ -148,7 +210,7 @@ export function withThreadnoteProcessActivity<A, E, R>(
   );
 }
 
-export const readThreadnoteProcessDiagnostics = Effect.fn('processDiagnostics.read')(function* (
+const readThreadnoteProcessSnapshot = Effect.fn('processDiagnostics.readSnapshot')(function* (
   config: Pick<RuntimeConfig, 'agentContextHome'>,
 ) {
   const fs = yield* FileSystem.FileSystem;
@@ -253,7 +315,7 @@ export const readThreadnoteProcessDiagnostics = Effect.fn('processDiagnostics.re
     ...value,
     ...(memoryByProcess.get(value.processId) === undefined ? {} : {rssBytes: memoryByProcess.get(value.processId)}),
   }));
-  return {
+  const diagnostics = {
     processes: sorted,
     schemaVersion: PROCESS_DIAGNOSTICS_SCHEMA_VERSION,
     truncated:
@@ -261,6 +323,99 @@ export const readThreadnoteProcessDiagnostics = Effect.fn('processDiagnostics.re
       live.length + legacy.length > PROCESS_DIAGNOSTICS_LIMIT ||
       candidateNames.length < eligibleNames.length,
   } satisfies ThreadnoteProcessDiagnostics;
+  return {diagnostics, registrations: new Map(live.map(value => [value.processId, value] as const))};
+});
+
+export const readThreadnoteProcessDiagnostics = Effect.fn('processDiagnostics.read')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+) {
+  return (yield* readThreadnoteProcessSnapshot(config)).diagnostics;
+});
+
+/**
+ * Adds an opaque, instance-bound control reference only when the private
+ * registration and the host's process-start identity agree. The registration
+ * token and start identity never leave this module.
+ */
+export const readManageableThreadnoteProcessDiagnostics = Effect.fn('processDiagnostics.readManageable')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+) {
+  const system = yield* SystemInfo;
+  const snapshot = yield* readThreadnoteProcessSnapshot(config);
+  const diagnostics = snapshot.diagnostics;
+  const processes: ManageableThreadnoteProcessDiagnostic[] = yield* Effect.forEach(
+    diagnostics.processes,
+    process =>
+      Effect.gen(function* () {
+        if (process.role === 'legacy') {
+          return {
+            ...process,
+            terminable: false,
+            terminationBlockedReason: 'legacy-process' as const,
+          };
+        }
+        const value = snapshot.registrations.get(process.processId);
+        const verified = value === undefined ? false : yield* registrationMatchesRunningProcess(system, value);
+        if (!verified || value === undefined) {
+          return {
+            ...process,
+            terminable: false,
+            terminationBlockedReason: 'identity-unverified' as const,
+          };
+        }
+        if (process.processId === system.processId) {
+          return {
+            ...process,
+            terminable: false,
+            terminationBlockedReason: 'current-manager' as const,
+          };
+        }
+        return {
+          ...process,
+          processRef: processReference(value),
+          terminable: true,
+        };
+      }),
+    {concurrency: 8},
+  );
+  return {...diagnostics, processes} satisfies ManageableThreadnoteProcessDiagnostics;
+});
+
+/** Terminate only the exact registered process instance selected by the caller. */
+export const terminateThreadnoteProcess = Effect.fn('processDiagnostics.terminate')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+  target: ThreadnoteProcessTerminationTarget,
+  options: ThreadnoteProcessTerminationOptions = {},
+) {
+  const system = yield* SystemInfo;
+  if (!Number.isSafeInteger(target.processId) || target.processId <= 0 || !isProcessReference(target.processRef)) {
+    return yield* Effect.fail(
+      new ThreadnoteProcessTerminationError('invalid-process-target', 'The process target is invalid.'),
+    );
+  }
+  if (target.processId === system.processId) {
+    return yield* Effect.fail(
+      new ThreadnoteProcessTerminationError('current-manager', 'The current Manager process cannot terminate itself.'),
+    );
+  }
+
+  const first = yield* resolveTerminationTarget(config, target);
+  yield* signalVerifiedProcess(system, first, 'SIGTERM');
+  const gracefulWaitMilliseconds = boundedTerminationWait(options.gracefulWaitMilliseconds, 2_000);
+  if (yield* waitForProcessExit(system, first, gracefulWaitMilliseconds)) {
+    return {processId: target.processId, state: 'terminated'} satisfies ThreadnoteProcessTerminationResult;
+  }
+
+  // Re-read the private registration and the OS start identity immediately
+  // before escalation. A replacement that reused the PID must never receive
+  // the second signal.
+  const second = yield* resolveTerminationTarget(config, target);
+  yield* signalVerifiedProcess(system, second, 'SIGKILL');
+  const forceWaitMilliseconds = boundedTerminationWait(options.forceWaitMilliseconds, 1_000);
+  return {
+    processId: target.processId,
+    state: (yield* waitForProcessExit(system, second, forceWaitMilliseconds)) ? 'terminated' : 'signaled',
+  } satisfies ThreadnoteProcessTerminationResult;
 });
 
 export const runProcessDiagnostics = Effect.fn('processDiagnostics.run')(function* (
@@ -519,12 +674,146 @@ function isRegisteredThreadnoteProcessRole(value: unknown): value is RegisteredT
   return (
     value === 'cli' ||
     value === 'graph-builder' ||
+    value === 'graph-compaction-worker' ||
+    value === 'graph-diagnostics-worker' ||
     value === 'graph-parser-worker' ||
     value === 'graph-waiter' ||
     value === 'local-model-worker' ||
     value === 'manager' ||
     value === 'mcp'
   );
+}
+
+function processReference(value: ProcessRegistrationFile): string {
+  return `tnp_${sha256HexSync(
+    `${PROCESS_DIAGNOSTICS_SCHEMA_VERSION}\0${value.processId}\0${value.processStartIdentity ?? ''}\0${value.token}`,
+  )}`;
+}
+
+function isProcessReference(value: string): boolean {
+  return /^tnp_[0-9a-f]{64}$/.test(value);
+}
+
+function registrationMatchesRunningProcess(system: SystemInfo['Service'], value: ProcessRegistrationFile) {
+  return Effect.gen(function* () {
+    if (!system.isProcessRunning(value.processId) || value.processStartIdentity === undefined) return false;
+    return (yield* system.processStartIdentity(value.processId)) === value.processStartIdentity;
+  });
+}
+
+function resolveTerminationTarget(
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+  target: ThreadnoteProcessTerminationTarget,
+) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
+    const candidate = yield* readRegistrationFile(
+      fs,
+      path.join(processDiagnosticsDirectory(path, config.agentContextHome), `${target.processId}.json`),
+    );
+    const value = Option.getOrUndefined(candidate);
+    if (!system.isProcessRunning(target.processId)) {
+      return yield* Effect.fail(
+        new ThreadnoteProcessTerminationError('process-not-found', 'The selected Threadnote process has exited.'),
+      );
+    }
+    if (
+      value === undefined ||
+      value.processId !== target.processId ||
+      value.processStartIdentity === undefined ||
+      processReference(value) !== target.processRef ||
+      !(yield* registrationMatchesRunningProcess(system, value))
+    ) {
+      return yield* Effect.fail(
+        new ThreadnoteProcessTerminationError(
+          'process-stale',
+          'The selected process instance changed. Refresh the process list and try again.',
+        ),
+      );
+    }
+    return value;
+  });
+}
+
+function signalVerifiedProcess(
+  system: SystemInfo['Service'],
+  registration: ProcessRegistrationFile,
+  signal: NodeJS.Signals,
+) {
+  return Effect.gen(function* () {
+    if (!system.isProcessRunning(registration.processId) || registration.processStartIdentity === undefined) {
+      return yield* Effect.fail(
+        new ThreadnoteProcessTerminationError(
+          'process-stale',
+          'The selected process instance changed. Refresh the process list and try again.',
+        ),
+      );
+    }
+    const identity = yield* system.processStartIdentity(registration.processId);
+    if (identity !== registration.processStartIdentity) {
+      return yield* Effect.fail(
+        new ThreadnoteProcessTerminationError(
+          'process-stale',
+          'The selected process instance changed. Refresh the process list and try again.',
+        ),
+      );
+    }
+    yield* Effect.try({
+      try: () => system.signalProcess(registration.processId, signal),
+      catch: cause => {
+        const code =
+          typeof cause === 'object' && cause !== null && 'code' in cause && typeof cause.code === 'string'
+            ? cause.code
+            : undefined;
+        if (code === 'ESRCH') {
+          return new ThreadnoteProcessTerminationError(
+            'process-not-found',
+            'The selected Threadnote process has exited.',
+          );
+        }
+        if (code === 'EPERM' || code === 'EACCES') {
+          return new ThreadnoteProcessTerminationError(
+            'process-permission-denied',
+            'Permission was denied while terminating the selected Threadnote process.',
+          );
+        }
+        return new ThreadnoteProcessTerminationError(
+          'process-signal-failed',
+          'The selected Threadnote process could not be terminated.',
+        );
+      },
+    });
+  });
+}
+
+function waitForProcessExit(
+  system: SystemInfo['Service'],
+  registration: ProcessRegistrationFile,
+  waitMilliseconds: number,
+) {
+  return Effect.gen(function* () {
+    const iterations = Math.ceil(waitMilliseconds / 50);
+    for (let iteration = 0; iteration < iterations; iteration += 1) {
+      if (!(yield* processInstanceIsRunning(system, registration))) return true;
+      yield* Effect.sleep(50);
+    }
+    return !(yield* processInstanceIsRunning(system, registration));
+  });
+}
+
+function processInstanceIsRunning(system: SystemInfo['Service'], registration: ProcessRegistrationFile) {
+  if (!system.isProcessRunning(registration.processId) || registration.processStartIdentity === undefined) {
+    return Effect.succeed(false);
+  }
+  return system
+    .processStartIdentity(registration.processId)
+    .pipe(Effect.map(identity => identity === registration.processStartIdentity));
+}
+
+function boundedTerminationWait(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? Math.min(value, 10_000) : fallback;
 }
 
 function removeRegistrationFile(fs: FileSystem.FileSystem, file: string) {

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -51,16 +51,47 @@ if (isCodeGraphDeepDiagnosticsWorker || isCodeGraphCompactionWorker) {
 }
 
 async function codeGraphDeepDiagnosticsWorkerProgram() {
-  const worker = await import('./code_graph/deep_diagnostics.js');
-  return worker.codeGraphDeepDiagnosticsWorkerProgram.pipe(Effect.provide(BunServices.layer));
+  const [worker, system, processDiagnostics, processLease] = await Promise.all([
+    import('./code_graph/deep_diagnostics.js'),
+    import('./effect/system.js'),
+    import('./process_diagnostics.js'),
+    import('./standalone_process_lease.js'),
+  ]);
+  const processHome = normalizedProcessHome(arguments_, processDiagnostics.threadnoteHomeForProcess);
+  return processHome.pipe(
+    Effect.flatMap(home =>
+      processLease.withStandaloneProcessLease(
+        processDiagnostics.withSignalTransparentThreadnoteWorkerRegistration(
+          home,
+          'graph-diagnostics-worker',
+          'deep-graph-diagnostics',
+          worker.codeGraphDeepDiagnosticsWorkerProgram,
+        ),
+      ),
+    ),
+    Effect.provide(Layer.merge(system.SystemInfo.layer, BunServices.layer)),
+  );
 }
 
 async function codeGraphAutomaticCompactionWorkerProgram() {
-  const [worker, system] = await Promise.all([
+  const [worker, system, processDiagnostics, processLease] = await Promise.all([
     import('./code_graph/automatic_compaction.js'),
     import('./effect/system.js'),
+    import('./process_diagnostics.js'),
+    import('./standalone_process_lease.js'),
   ]);
-  return worker.codeGraphAutomaticCompactionWorkerProgram.pipe(
+  const processHome = normalizedProcessHome(arguments_, processDiagnostics.threadnoteHomeForProcess);
+  return processHome.pipe(
+    Effect.flatMap(home =>
+      processLease.withStandaloneProcessLease(
+        processDiagnostics.withSignalTransparentThreadnoteWorkerRegistration(
+          home,
+          'graph-compaction-worker',
+          'compact-graph-storage',
+          worker.codeGraphAutomaticCompactionWorkerProgram,
+        ),
+      ),
+    ),
     Effect.provide(Layer.merge(system.SystemInfo.layer, BunServices.layer)),
   );
 }

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -13,7 +13,7 @@ interface UpdateCacheFile {
   readonly channel: UpdateChannel;
   readonly checkedAt: string;
   readonly latestVersion: string;
-  readonly version: 2;
+  readonly version: 3;
 }
 
 export interface UpdateCheckResult {
@@ -55,7 +55,7 @@ export function checkForThreadnoteUpdate(args: {readonly cachePath: string; read
         channel,
         checkedAt: new Date().toISOString(),
         latestVersion: fresh,
-        version: 2 as const,
+        version: 3 as const,
       });
       return toUpdateCheckResult(args.currentVersion, fresh);
     }
@@ -117,7 +117,7 @@ const readUpdateCache = Effect.fn('updateCheck.readCache')((cachePath: string) =
     }
     const parsed = parsedResult.success;
     if (
-      parsed.version !== 2 ||
+      parsed.version !== 3 ||
       (parsed.channel !== 'beta' && parsed.channel !== 'latest') ||
       typeof parsed.latestVersion !== 'string' ||
       typeof parsed.checkedAt !== 'string'
@@ -128,7 +128,7 @@ const readUpdateCache = Effect.fn('updateCheck.readCache')((cachePath: string) =
       channel: parsed.channel,
       checkedAt: parsed.checkedAt,
       latestVersion: parsed.latestVersion,
-      version: 2 as const,
+      version: 3 as const,
     };
   }).pipe(Effect.catch(() => Effect.succeed(undefined))),
 );

--- a/src/update.ts
+++ b/src/update.ts
@@ -230,6 +230,14 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     return;
   }
 
+  if (!isUpdateTargetAllowed(info.currentVersion, latestVersion, requestedChannel)) {
+    return yield* Effect.fail(
+      new UpdateOperationError(
+        `Refusing to downgrade Threadnote ${info.currentVersion} to ${latestVersion}. --force does not permit version downgrades; only an explicit beta-to-stable channel switch with --stable may install an older version.`,
+      ),
+    );
+  }
+
   const shouldRepair = options.repair !== false;
   const dryRun = options.dryRun === true;
   const releaseRoot = yield* withStandaloneInstallationLock(
@@ -713,6 +721,19 @@ export function requestedUpdateChannel(options: Pick<UpdateOptions, 'beta' | 'st
     return 'latest';
   }
   return undefined;
+}
+
+export function isUpdateTargetAllowed(
+  currentVersion: string,
+  targetVersion: string,
+  requestedChannel: UpdateChannel | undefined,
+): boolean {
+  if (compareVersions(currentVersion, targetVersion) <= 0) return true;
+  return (
+    requestedChannel === 'latest' &&
+    selectUpdateChannel(currentVersion) === 'beta' &&
+    selectUpdateChannel(targetVersion) === 'latest'
+  );
 }
 
 export function requiresFreshStandaloneInstall(version: string): boolean {

--- a/src/update.ts
+++ b/src/update.ts
@@ -78,6 +78,7 @@ interface UpdateCache {
   readonly checkedAt: string;
   readonly latestVersion: string;
   readonly source: string;
+  readonly version: 2;
 }
 
 interface ReleaseAsset {
@@ -178,7 +179,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   yield* Console.log(keyValue('Current version', infoText(info.currentVersion)));
   yield* Console.log(
     keyValue(
-      info.channel === 'beta' ? 'Latest beta version' : 'Latest version',
+      latestUpdateVersionLabel(info.channel),
       info.latestVersion ? infoText(info.latestVersion) : warning('not published'),
     ),
   );
@@ -192,7 +193,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   }
 
   if (info.latestVersion === undefined) {
-    yield* Console.log('No beta release is currently published.');
+    yield* Console.log('No release is currently published for the selected channel.');
     return;
   }
   const latestVersion = info.latestVersion;
@@ -219,10 +220,13 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
 
   if (!info.isUpdateAvailable && options.force !== true) {
     if (info.installedVersion !== undefined) {
-      const path = yield* Path.Path;
-      const activeReleaseRoot = path.join(installationRoot(path, system), 'versions', info.installedVersion);
       yield* withStandaloneInstallationLock(
-        installCommandShim(options.dryRun === true, activeReleaseRoot),
+        Effect.gen(function* () {
+          const path = yield* Path.Path;
+          const mutationInstalledVersion = (yield* activeInstalledVersion()) ?? info.installedVersion!;
+          const activeReleaseRoot = path.join(installationRoot(path, system), 'versions', mutationInstalledVersion);
+          yield* installCommandShim(options.dryRun === true, activeReleaseRoot);
+        }),
         options.dryRun === true,
       );
     }
@@ -231,17 +235,18 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   }
 
   if (!isUpdateTargetAllowed(info.currentVersion, latestVersion, requestedChannel)) {
-    return yield* Effect.fail(
-      new UpdateOperationError(
-        `Refusing to downgrade Threadnote ${info.currentVersion} to ${latestVersion}. --force does not permit version downgrades; only an explicit beta-to-stable channel switch with --stable may install an older version.`,
-      ),
-    );
+    return yield* Effect.fail(updateDowngradeError(info.currentVersion, latestVersion));
   }
 
   const shouldRepair = options.repair !== false;
   const dryRun = options.dryRun === true;
-  const releaseRoot = yield* withStandaloneInstallationLock(
+  const mutation = yield* withStandaloneInstallationLock(
     Effect.gen(function* () {
+      const lockedInstalledVersion = yield* activeInstalledVersion();
+      const currentVersion = lockedInstalledVersion ?? info.currentVersion;
+      if (!isUpdateTargetAllowed(currentVersion, latestVersion, requestedChannel)) {
+        return yield* Effect.fail(updateDowngradeError(currentVersion, latestVersion));
+      }
       const installed = yield* installStandaloneRelease({
         dryRun,
         force: options.force === true,
@@ -250,16 +255,17 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
       });
       yield* installCommandShim(dryRun, installed);
       yield* activateStandaloneRelease(installed, dryRun);
-      return installed;
+      return {currentVersion, releaseRoot: installed};
     }),
     dryRun,
   );
+  const {currentVersion: effectiveCurrentVersion, releaseRoot} = mutation;
   const path = yield* Path.Path;
   const threadnoteCommand = path.join(releaseRoot, system.platform === 'win32' ? 'threadnote.exe' : 'threadnote');
   const postUpdateArgs = [
     'post-update',
     '--from-version',
-    info.currentVersion,
+    effectiveCurrentVersion,
     '--to-version',
     latestVersion,
     ...(options.yes === true ? ['--yes'] : []),
@@ -285,6 +291,12 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
   yield* withStandaloneInstallationLock(pruneStandaloneReleases(releaseRoot, dryRun), dryRun);
   yield* printWhatsNewIfAvailable(info);
 });
+
+function updateDowngradeError(currentVersion: string, targetVersion: string): UpdateOperationError {
+  return new UpdateOperationError(
+    `Refusing to downgrade Threadnote ${currentVersion} to ${targetVersion}. --force does not permit version downgrades; only an explicit beta-to-stable channel switch with --stable may install an older version.`,
+  );
+}
 
 const installStandaloneRelease = Effect.fn('update.installStandaloneRelease')(function* (options: {
   readonly dryRun: boolean;
@@ -692,9 +704,14 @@ function getUpdateInfo(
         checkedAt: new Date().toISOString(),
         latestVersion,
         source: options.source,
+        version: 2,
       });
     }
-    const isChannelSwitch = options.requestedChannel !== undefined && channel !== inferredChannel;
+    const isChannelSwitch =
+      latestVersion !== undefined &&
+      options.requestedChannel === 'latest' &&
+      inferredChannel === 'beta' &&
+      selectUpdateChannel(latestVersion) === 'latest';
     const isVersionUpgrade = latestVersion !== undefined && compareVersions(currentVersion, latestVersion) < 0;
     return {
       channel,
@@ -736,6 +753,10 @@ export function isUpdateTargetAllowed(
   );
 }
 
+export function latestUpdateVersionLabel(channel: UpdateChannel): string {
+  return channel === 'beta' ? 'Latest beta-channel version' : 'Latest version';
+}
+
 export function requiresFreshStandaloneInstall(version: string): boolean {
   const major = Number.parseInt(stableVersionCore(version).split('.', 1)[0] ?? '', 10);
   return Number.isSafeInteger(major) && major < 4;
@@ -748,7 +769,7 @@ export const fetchLatestVersion = Effect.fn('fetchLatestVersion')(function* (
   channel: UpdateChannel = 'latest',
 ) {
   const releases = yield* fetchAvailableReleases(source);
-  const candidates = releases.filter(release => release.prerelease === (channel === 'beta'));
+  const candidates = channel === 'beta' ? releases : releases.filter(release => !release.prerelease);
   return candidates.sort((left, right) => compareVersions(right.version, left.version))[0]?.version;
 });
 
@@ -811,6 +832,7 @@ const readFreshCache = Effect.fn('update.readFreshCache')(function* (
   const parsed = parsedResult.success;
   if (
     !isJsonObject(parsed) ||
+    parsed.version !== 2 ||
     parsed.channel !== channel ||
     typeof parsed.checkedAt !== 'string' ||
     typeof parsed.latestVersion !== 'string' ||
@@ -822,7 +844,13 @@ const readFreshCache = Effect.fn('update.readFreshCache')(function* (
   if (!Number.isFinite(checkedAt) || Date.now() - checkedAt > UPDATE_CHECK_TTL_MS) {
     return undefined;
   }
-  return {channel, checkedAt: parsed.checkedAt, latestVersion: parsed.latestVersion, source};
+  return {
+    channel,
+    checkedAt: parsed.checkedAt,
+    latestVersion: parsed.latestVersion,
+    source,
+    version: 2,
+  } satisfies UpdateCache;
 });
 
 const writeUpdateCache = Effect.fn('update.writeCache')(function* (config: RuntimeConfig, cache: UpdateCache) {

--- a/src/update_channel.ts
+++ b/src/update_channel.ts
@@ -1,8 +1,16 @@
 export type UpdateChannel = 'beta' | 'latest';
 
-export function isBetaVersion(version: string): boolean {
+const DEVELOPMENT_VERSION_SUFFIX = /(?:^|[.-])local\.g[0-9a-f]{40}(?:[0-9a-f]{24})?$/iu;
+
+export function isPrereleaseVersion(version: string): boolean {
   const normalized = version.trim().replace(/^v/i, '').split('+', 1)[0] ?? '';
-  return /-beta(?:[.-]?\d+)?(?:[.-]|$)/i.test(normalized);
+  const releaseVersion = normalized.replace(DEVELOPMENT_VERSION_SUFFIX, '');
+  return /^\d+\.\d+\.\d+-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/u.test(releaseVersion);
+}
+
+/** Compatibility name retained for callers that predate the inclusive preview-channel contract. */
+export function isBetaVersion(version: string): boolean {
+  return isPrereleaseVersion(version);
 }
 
 export function selectUpdateChannel(currentVersion: string, requestedChannel?: UpdateChannel): UpdateChannel {

--- a/src/version_command.ts
+++ b/src/version_command.ts
@@ -1,7 +1,7 @@
 import {Console, Effect, Result} from 'effect';
 import {heading, info, keyValue, success, warning, withSpinnerEffect} from './cli_ui.js';
 import type {RuntimeConfig, VersionOptions} from './types.js';
-import {currentPackageVersion, fetchLatestVersion, resolveReleaseSource} from './update.js';
+import {currentPackageVersion, fetchLatestVersion, latestUpdateVersionLabel, resolveReleaseSource} from './update.js';
 import {selectUpdateChannel} from './update_channel.js';
 import {compareVersions, errorMessage} from './utils.js';
 import {whatsNewLinesForVersion, whatsNewLinesForVersionRange} from './release_notes.js';
@@ -28,10 +28,7 @@ export const runVersion = Effect.fn('runVersion')(function* (config: RuntimeConf
 
   yield* Console.log(keyValue('Current version', info(currentVersion)));
   yield* Console.log(
-    keyValue(
-      channel === 'beta' ? 'Latest beta version' : 'Latest version',
-      latestVersion ? info(latestVersion) : warning('unavailable'),
-    ),
+    keyValue(latestUpdateVersionLabel(channel), latestVersion ? info(latestVersion) : warning('unavailable')),
   );
   if (latestWarning) {
     yield* Console.log(warning(`Warning: ${latestWarning}`));

--- a/test/e2e/posix-installer.e2e.ts
+++ b/test/e2e/posix-installer.e2e.ts
@@ -202,6 +202,22 @@ esac
       port: 0,
       fetch(request) {
         const name = new URL(request.url).pathname.slice(1);
+        if (name === 'stable-winner-releases') {
+          return Response.json([
+            {
+              draft: false,
+              immutable: true,
+              prerelease: true,
+              tag_name: `v${packageManifest.version}`,
+            },
+            {
+              draft: false,
+              immutable: true,
+              prerelease: false,
+              tag_name: 'v9.0.0',
+            },
+          ]);
+        }
         if (name === 'releases') {
           const origin = new URL(request.url).origin;
           return new Response(
@@ -241,6 +257,12 @@ esac
                   prerelease: true,
                   tag_name: `v${packageManifest.version}`,
                 },
+                {
+                  draft: false,
+                  immutable: true,
+                  prerelease: false,
+                  tag_name: 'v4.1.1',
+                },
               ],
               null,
               2,
@@ -249,6 +271,8 @@ esac
           );
         }
         assetRequests.push(name);
+        if (name === `selection/${artifactName}`) return new Response(Bun.file(artifact));
+        if (name === `selection/${artifactName}.sha256`) return new Response(Bun.file(checksum));
         if (name === `unsafe-parent/${artifactName}`) return new Response(Bun.file(unsafeParentArtifact));
         if (name === `unsafe-parent/${artifactName}.sha256`) return new Response(unsafeParentChecksum);
         if (name === `unsafe-link/${artifactName}`) return new Response(Bun.file(unsafeLinkArtifact));
@@ -273,6 +297,39 @@ esac
         USER: 'standalone-installer-e2e',
         USERPROFILE: userHome,
       };
+      const stableWinnerFailure = await execute(
+        'sh',
+        [join(process.cwd(), 'scripts', 'install.sh'), '--beta', '--no-start'],
+        {
+          env: {
+            ...installEnvironment,
+            THREADNOTE_INSTALL_ROOT: join(root, 'stable-winner-install'),
+            THREADNOTE_RELEASE_DOWNLOAD_ROOT: `http://127.0.0.1:${server.port}/selection`,
+            THREADNOTE_RELEASE_SOURCE: `http://127.0.0.1:${server.port}/stable-winner-releases`,
+          },
+          timeout: 60_000,
+        },
+      ).catch((cause: unknown) => cause);
+      expect(String((stableWinnerFailure as {readonly stdout?: unknown}).stdout)).toContain(
+        'Downloading Threadnote 9.0.0',
+      );
+      expect(String((stableWinnerFailure as {readonly stderr?: unknown}).stderr)).toContain(
+        'Release metadata does not match 9.0.0',
+      );
+      const stableOnlyFailure = await execute('sh', [join(process.cwd(), 'scripts', 'install.sh'), '--no-start'], {
+        env: {
+          ...installEnvironment,
+          THREADNOTE_INSTALL_ROOT: join(root, 'stable-only-install'),
+          THREADNOTE_RELEASE_DOWNLOAD_ROOT: `http://127.0.0.1:${server.port}/selection`,
+        },
+        timeout: 60_000,
+      }).catch((cause: unknown) => cause);
+      expect(String((stableOnlyFailure as {readonly stdout?: unknown}).stdout)).toContain(
+        'Downloading Threadnote 4.1.1',
+      );
+      expect(String((stableOnlyFailure as {readonly stderr?: unknown}).stderr)).toContain(
+        'Release metadata does not match 4.1.1',
+      );
       for (const rejectedVersion of ['4.0.0-beta.6', '4.0.0-beta.5', '4.0.0-beta.4']) {
         const requestsBefore = assetRequests.length;
         const failure = await execute('sh', [join(process.cwd(), 'scripts', 'install.sh'), '--no-start'], {

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -36,6 +36,22 @@ windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release
       port: 0,
       fetch(request) {
         const name = new URL(request.url).pathname.slice(1);
+        if (name === 'stable-winner-releases') {
+          return Response.json([
+            {
+              draft: false,
+              immutable: true,
+              prerelease: true,
+              tag_name: `v${packageManifest.version}`,
+            },
+            {
+              draft: false,
+              immutable: true,
+              prerelease: false,
+              tag_name: 'v9.0.0',
+            },
+          ]);
+        }
         if (name === 'releases') {
           return Response.json([
             {
@@ -62,9 +78,17 @@ windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release
               prerelease: true,
               tag_name: `v${packageManifest.version}`,
             },
+            {
+              draft: false,
+              immutable: true,
+              prerelease: false,
+              tag_name: 'v4.1.1',
+            },
           ]);
         }
         assetRequests.push(name);
+        if (name === `selection/${artifactName}`) return new Response(Bun.file(artifact));
+        if (name === `selection/${artifactName}.sha256`) return new Response(Bun.file(checksum));
         if (name === artifactName && transientArchiveFailures > 0) {
           transientArchiveFailures -= 1;
           return new Response('retry this request', {status: 503});
@@ -96,6 +120,40 @@ windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release
         THREADNOTE_RELEASE_SOURCE: `http://127.0.0.1:${server.port}/releases`,
         USERPROFILE: userHome,
       };
+      const stableWinnerFailure = await execute(join(powerShellDirectory, 'powershell.exe'), installerArguments, {
+        env: {
+          ...installEnvironment,
+          THREADNOTE_INSTALL_ROOT: join(root, 'stable-winner-install'),
+          THREADNOTE_RELEASE_DOWNLOAD_ROOT: `http://127.0.0.1:${server.port}/selection`,
+          THREADNOTE_RELEASE_SOURCE: `http://127.0.0.1:${server.port}/stable-winner-releases`,
+        },
+        timeout: 60_000,
+      }).catch((cause: unknown) => cause);
+      expect(String((stableWinnerFailure as {readonly stdout?: unknown}).stdout)).toContain(
+        'Downloading Threadnote 9.0.0',
+      );
+      expect(String((stableWinnerFailure as {readonly stderr?: unknown}).stderr)).toContain(
+        'Release metadata does not match Threadnote 9.0.0',
+      );
+      const stableOnlyFailure = await execute(
+        join(powerShellDirectory, 'powershell.exe'),
+        installerArguments.filter(argument => argument !== '-Beta'),
+        {
+          env: {
+            ...installEnvironment,
+            THREADNOTE_CHANNEL: 'stable',
+            THREADNOTE_INSTALL_ROOT: join(root, 'stable-only-install'),
+            THREADNOTE_RELEASE_DOWNLOAD_ROOT: `http://127.0.0.1:${server.port}/selection`,
+          },
+          timeout: 60_000,
+        },
+      ).catch((cause: unknown) => cause);
+      expect(String((stableOnlyFailure as {readonly stdout?: unknown}).stdout)).toContain(
+        'Downloading Threadnote 4.1.1',
+      );
+      expect(String((stableOnlyFailure as {readonly stderr?: unknown}).stderr)).toContain(
+        'Release metadata does not match Threadnote 4.1.1',
+      );
       for (const rejectedVersion of ['4.0.0-beta.6', '4.0.0-beta.5', '4.0.0-beta.4']) {
         const requestsBefore = assetRequests.length;
         const failure = await execute(join(powerShellDirectory, 'powershell.exe'), installerArguments, {

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -23,6 +23,7 @@ describe('Effect CLI', () => {
   it('exposes explicit beta and stable update channels', async () => {
     const result = await runCli(['update', '--help']);
     expect(result.stdout).toContain('--beta');
+    expect(result.stdout).toContain('newest stable or prerelease release');
     expect(result.stdout).toContain('--stable');
   });
 

--- a/test/unit/code-graph.diagnostics.test.ts
+++ b/test/unit/code-graph.diagnostics.test.ts
@@ -2,7 +2,7 @@ import {TestError} from '../helpers/test-error.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {it as effectIt} from '@effect/vitest';
 import {Effect, FileSystem, PlatformError} from 'effect';
-import {afterEach, describe, expect} from 'vitest';
+import {afterEach, describe, expect, it} from 'vitest';
 import {
   inspectAllCodeGraphs,
   inspectAllCodeGraphsLocal,
@@ -10,6 +10,7 @@ import {
   type CodeGraphLocalDiagnosticsReport,
 } from '../../src/code_graph/diagnostics.js';
 import {runCodeGraphDiagnostics} from '../../src/code_graph/commands.js';
+import {deepDiagnosticsWorkerEnvironment} from '../../src/code_graph/deep_diagnostics.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
 import {recordVerifiedCodeGraphLocalAssociation} from '../../src/code_graph/local_provenance.js';
 import {observeManagerGraphCatalogRevision} from '../../src/code_graph/manager_catalog_revision.js';
@@ -35,6 +36,25 @@ describe('all-code-graph diagnostics', () => {
 
   afterEach(async () => {
     await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
+  });
+
+  it('passes only bounded bootstrap variables and the exact Threadnote home to the deep worker', () => {
+    expect(
+      deepDiagnosticsWorkerEnvironment(
+        {
+          ARBITRARY_PARENT_VALUE: 'private',
+          HOME: '/bootstrap-home',
+          PATH: '/bootstrap-bin',
+          THREADNOTE_TEST_SECRET: 'private-secret',
+        },
+        '/threadnote-home',
+      ),
+    ).toEqual({
+      HOME: '/bootstrap-home',
+      PATH: '/bootstrap-bin',
+      THREADNOTE_CODE_GRAPH_DEEP_DIAGNOSTICS_WORKER: '1',
+      THREADNOTE_HOME: '/threadnote-home',
+    });
   });
 
   effectIt.effect('reports every database without a repository cwd and keeps JSON privacy-safe', () =>

--- a/test/unit/code-graph.manager-catalog.test.ts
+++ b/test/unit/code-graph.manager-catalog.test.ts
@@ -1600,7 +1600,12 @@ describe('Manager logical repository and workspace catalogs', () => {
             const refreshed = yield* managerGraphCatalog(home);
             expect(refreshed.repositories).toEqual([]);
             expect(refreshed.diagnostics).toEqual([
-              expect.objectContaining({checkoutId: identity.checkoutId, code: 'no-ready-snapshot'}),
+              expect.objectContaining({
+                checkoutId: identity.checkoutId,
+                code: 'no-ready-snapshot',
+                message:
+                  'Stored graph data has no queryable snapshot. Index from its repository folder, or purge it if it is obsolete.',
+              }),
             ]);
           }),
         ),

--- a/test/unit/code-graph.materialization-store.test.ts
+++ b/test/unit/code-graph.materialization-store.test.ts
@@ -51,7 +51,6 @@ import {
   type RepositoryIdentity,
 } from '../../src/code_graph/types.js';
 import {discoverManifestWorkspace} from '../../src/code_graph/workspace.js';
-import {withExclusiveFileLock} from '../../src/effect/file_lock.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {claimPersistentBuildForTest} from '../helpers/code-graph-build.js';
 import {join, mkdtemp, rm} from '../helpers/effect-filesystem.js';
@@ -1911,71 +1910,47 @@ describe('code graph full-build materialization store', () => {
     ),
   );
 
-  it('opens detached completed-build cleanup only while holding the checkout writer gate', async () => {
-    const fixture = await materializationFixture();
-    const writerLockPath = join(fixture.root, 'checkout-writer.lock');
-    const snapshot = readySnapshot(fixture.identity, 1, 0);
-    const stored = symbol('gated-cleanup', 'gatedCleanup', ['typescript:name:gatedCleanup']);
-    let cleanupConnectionOpened = false;
-    let cleanupConnectionOpenedWhileGateHeld = false;
-
-    const remainingAfterContention = await runEffect(
+  effectIt.effect('opens detached completed-build cleanup only while holding the checkout writer gate', () =>
+    TestClock.withLive(
       Effect.gen(function* () {
+        const fixture = yield* Effect.promise(materializationFixture);
+        const writerLockPath = join(fixture.root, 'checkout-writer.lock');
+        const snapshot = readySnapshot(fixture.identity, 1, 0);
+        const stored = symbol('gated-cleanup', 'gatedCleanup', ['typescript:name:gatedCleanup']);
         const fs = yield* FileSystem.FileSystem;
         const store = yield* CodeGraphStore;
-        yield* withExclusiveFileLock(
-          fs,
-          writerLockPath,
+        const cleanupConnectionOpened = yield* Deferred.make<boolean>();
+        yield* store.withSession(
+          fixture.databasePath,
+          Effect.gen(function* () {
+            const ownerToken = yield* claimPersistentBuildForTest(store, fixture.databasePath, fixture.identity, {
+              ...snapshot,
+              state: 'building',
+            });
+            yield* store.prepareActivation(fixture.databasePath, [fixture.file], snapshot.id, 1, ownerToken);
+            yield* store.stageActivationFacts(fixture.databasePath, [stored], [], [], undefined, 0);
+            yield* store.resolveStagedReferences(fixture.databasePath);
+            yield* store.activateStaged(fixture.databasePath, fixture.identity, snapshot);
+          }),
           {
-            retryIntervalMilliseconds: 10,
-            staleAfterMilliseconds: 120_000,
-            waitTimeoutMilliseconds: 5_000,
+            onCompletedBuildCleanupConnection: () =>
+              fs.exists(writerLockPath).pipe(
+                Effect.catch(() => Effect.succeed(false)),
+                Effect.flatMap(writerGateHeld => Deferred.succeed(cleanupConnectionOpened, writerGateHeld)),
+                Effect.asVoid,
+              ),
+            writerLockPath,
           },
-          store.withSession(
-            fixture.databasePath,
-            Effect.gen(function* () {
-              const ownerToken = yield* claimPersistentBuildForTest(store, fixture.databasePath, fixture.identity, {
-                ...snapshot,
-                state: 'building',
-              });
-              yield* store.prepareActivation(fixture.databasePath, [fixture.file], snapshot.id, 1, ownerToken);
-              yield* store.stageActivationFacts(fixture.databasePath, [stored], [], [], undefined, 0);
-              yield* store.resolveStagedReferences(fixture.databasePath);
-              yield* store.activateStaged(fixture.databasePath, fixture.identity, snapshot);
-              yield* Effect.promise(() => Bun.sleep(100));
-              cleanupConnectionOpenedWhileGateHeld = cleanupConnectionOpened;
-            }),
-            {
-              onCompletedBuildCleanupConnection: () =>
-                Effect.sync(() => {
-                  cleanupConnectionOpened = true;
-                }),
-              writerGateHeld: true,
-              writerLockPath,
-            },
-          ),
         );
-        const remaining = readCompletedBuildRows(fixture.databasePath, snapshot.id);
-        yield* store.withSession(fixture.databasePath, Effect.void, {
-          cleanupCompletedBuildRows: true,
-          onCompletedBuildCleanupConnection: () =>
-            Effect.sync(() => {
-              cleanupConnectionOpened = true;
-            }),
-          writerLockPath,
+        expect(yield* Deferred.await(cleanupConnectionOpened).pipe(Effect.timeout('5 seconds'))).toBe(true);
+        expect(yield* Effect.promise(() => awaitCompletedBuildCleanup(fixture.databasePath, snapshot.id))).toEqual({
+          batches: 0,
+          candidates: 0,
+          refs: 0,
         });
-        for (let attempt = 0; attempt < 100 && !cleanupConnectionOpened; attempt += 1) {
-          yield* Effect.promise(() => Bun.sleep(10));
-        }
-        return remaining;
-      }),
-    );
-
-    expect(cleanupConnectionOpenedWhileGateHeld).toBe(false);
-    expect(remainingAfterContention.batches).toBe(1);
-    expect(cleanupConnectionOpened).toBe(true);
-    expect(readCompletedBuildRows(fixture.databasePath, snapshot.id)).toEqual({batches: 0, candidates: 0, refs: 0});
-  });
+      }).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
 
   effectIt.effect('gives a waiting foreground writer priority between detached cleanup sweeps', () =>
     TestClock.withLive(

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -134,6 +134,48 @@ describe('manager graph focus', () => {
     expect(markup).toContain('Index, reindex, and compact require a verified local worktree path.');
   });
 
+  it('labels graph storage without a folder or ready snapshot as disposable and unassociated', () => {
+    const neverResolves = () => new Promise<never>(() => undefined);
+    const markup = renderToStaticMarkup(
+      createElement(GraphWorkspace, {
+        administration: {
+          databases: [
+            {
+              builds: [],
+              checkoutId: 'a'.repeat(64),
+              health: {integrity: 'ok', readySnapshots: 0},
+              healthState: 'checked',
+              issues: [],
+              storage: {state: 'available', totalBytes: 12_000},
+              views: [],
+              waiters: [],
+            },
+          ],
+          generatedAt: '2026-08-12T12:00:00.000Z',
+          mode: {analyze: false, deep: false},
+          obsoleteStores: {bytes: 0, checkouts: [], fileCount: 0, unsafeEntryCount: 0},
+          summary: {databaseCount: 1, readySnapshotCount: 0, viewCount: 0},
+          type: 'code-graph-diagnostics',
+          version: 2,
+        } as never,
+        loadAnalysis: neverResolves,
+        loadCatalogPage: neverResolves,
+        loadGraph: neverResolves,
+        loadNodeDetail: neverResolves,
+        loadQuery: neverResolves,
+        loadViewsPage: neverResolves,
+        onAdministrationAction: () => undefined,
+        onRefresh: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('<strong>Unassociated graph storage</strong>');
+    expect(markup).toContain('No verified local folder or ready snapshot');
+    expect(markup).toContain('This disposable graph has no queryable snapshot.');
+    expect(markup).toContain('threadnote graph index --cwd &lt;path&gt;');
+    expect(markup).not.toContain('<strong>Indexed repository</strong>');
+  });
+
   it('renders the graph workspace before its first catalog response', () => {
     const neverResolves = () => new Promise<never>(() => undefined);
 

--- a/test/unit/manager-processes-ui.test.ts
+++ b/test/unit/manager-processes-ui.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+
+import React, {act} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {ManagerDialogProvider} from '../../src/manager_dialog.js';
+import {ProcessesPanel} from '../../src/manager_processes_view.js';
+
+let reactRoot: Root | undefined;
+let fetchOriginal: typeof fetch;
+let requests: Array<{readonly body?: Record<string, unknown>; readonly path: string}>;
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT: boolean}).IS_REACT_ACT_ENVIRONMENT = true;
+  fetchOriginal = globalThis.fetch;
+  requests = [];
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const path =
+      typeof input === 'string' ? input : input instanceof URL ? input.pathname : new URL(input.url).pathname;
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined;
+    requests.push({body, path});
+    if (path === '/api/processes/terminate') {
+      return Promise.resolve(jsonResponse({processId: 80297, state: 'terminated'}));
+    }
+    return Promise.resolve(
+      jsonResponse({
+        processes: [
+          {
+            ageMilliseconds: 540_000,
+            currentOperation: 'compact-graph-storage',
+            parentProcessId: 80276,
+            parentRole: 'manager',
+            processId: 80297,
+            processRef: `tnp_${'a'.repeat(64)}`,
+            role: 'graph-compaction-worker',
+            rssBytes: 100 * 1_024 * 1_024,
+            startedAt: '2026-08-12T00:00:00.000Z',
+            terminable: true,
+          },
+          {
+            activityRole: 'graph-builder',
+            ageMilliseconds: 10_000,
+            currentOperation: 'index-repository',
+            parentProcessId: 1,
+            processId: 80300,
+            processRef: `tnp_${'b'.repeat(64)}`,
+            role: 'mcp',
+            startedAt: '2026-08-12T00:00:00.000Z',
+            terminable: true,
+          },
+          {
+            ageMilliseconds: 5_000,
+            currentOperation: 'manager-ui',
+            parentProcessId: 1,
+            processId: 80276,
+            role: 'manager',
+            startedAt: '2026-08-12T00:00:00.000Z',
+            terminable: false,
+            terminationBlockedReason: 'current-manager',
+          },
+        ],
+        schemaVersion: 1,
+        truncated: false,
+      }),
+    );
+  }) as typeof fetch;
+});
+
+afterEach(async () => {
+  if (reactRoot) await act(async () => reactRoot?.unmount());
+  document.body.replaceChildren();
+  globalThis.fetch = fetchOriginal;
+  reactRoot = undefined;
+});
+
+describe('Manager Processes panel', () => {
+  it('shows compaction and activity roles without exposing opaque control data as text', async () => {
+    await renderProcesses();
+    expect(document.body.textContent).toContain('Graph compaction worker');
+    expect(document.body.textContent).toContain('Compact graph storage');
+    expect(document.body.textContent).toContain('Manager · PID 80276');
+    expect(document.body.textContent).toContain('MCP server');
+    expect(document.body.textContent).toContain('Graph builder activity');
+    expect(document.body.textContent).not.toContain(`tnp_${'a'.repeat(64)}`);
+
+    const stop = document.querySelector<HTMLButtonElement>(
+      '[aria-label="Terminate Graph compaction worker process 80297"]',
+    );
+    const managerStop = document.querySelector<HTMLButtonElement>('[aria-label="Terminate Manager process 80276"]');
+    expect(stop?.title).toBe('Terminate Graph compaction worker');
+    expect(stop?.disabled).toBe(false);
+    expect(managerStop?.title).toBe('The current Manager process is protected');
+    expect(managerStop?.disabled).toBe(true);
+  });
+
+  it('confirms termination and posts the exact opaque process reference with the PID', async () => {
+    await renderProcesses();
+    const stop = document.querySelector<HTMLButtonElement>(
+      '[aria-label="Terminate Graph compaction worker process 80297"]',
+    )!;
+    await act(async () => stop.click());
+    const confirm = await waitForElement<HTMLButtonElement>('dialog.manager-dialog button.danger');
+    expect(document.querySelector('dialog.manager-dialog')?.textContent).toContain('PID 80297');
+    await act(async () => confirm.click());
+    await flush();
+    expect(requests.find(request => request.path === '/api/processes/terminate')?.body).toEqual({
+      confirm: true,
+      processId: 80297,
+      processRef: `tnp_${'a'.repeat(64)}`,
+    });
+  });
+});
+
+async function renderProcesses(): Promise<void> {
+  const container = document.createElement('div');
+  document.body.append(container);
+  reactRoot = createRoot(container);
+  await act(async () => {
+    reactRoot?.render(React.createElement(ManagerDialogProvider, undefined, React.createElement(ProcessesPanel)));
+  });
+  await waitForElement('[aria-label="Terminate Graph compaction worker process 80297"]');
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise(resolve => window.setTimeout(resolve, 0));
+  });
+}
+
+async function waitForElement<T extends Element>(selector: string): Promise<T> {
+  for (let index = 0; index < 20; index += 1) {
+    const element = document.querySelector<T>(selector);
+    if (element) return element;
+    await flush();
+  }
+  throw new Error(`Element did not render: ${selector}`);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {headers: {'content-type': 'application/json'}, status});
+}

--- a/test/unit/manager-processes.test.ts
+++ b/test/unit/manager-processes.test.ts
@@ -1,0 +1,134 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {join} from '../helpers/node-path.js';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {expect, it} from '@effect/vitest';
+import {Effect, FileSystem} from 'effect';
+import {describe} from 'vitest';
+import {SystemInfo} from '../../src/effect/system.js';
+import {handleManagerProcessRequest} from '../../src/manager_processes.js';
+import type {RuntimeConfig} from '../../src/types.js';
+
+describe('Manager process API', () => {
+  it.effect('requires explicit confirmation before process termination', () =>
+    Effect.gen(function* () {
+      const response = yield* handleManagerProcessRequest({
+        body: Effect.succeed({processId: 123, processRef: `tnp_${'a'.repeat(64)}`}),
+        config: testConfig('/unused'),
+        method: 'POST',
+        url: new URL('http://localhost/api/processes/terminate'),
+      });
+      expect(response).toEqual({
+        body: {
+          code: 'confirmation-required',
+          error: 'Confirm termination of the selected Threadnote process.',
+          retryAfterMilliseconds: 0,
+        },
+        status: 400,
+      });
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer)),
+  );
+
+  it.effect('maps a stale opaque process target to a typed conflict without signaling', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-manager-process-stale-'});
+      const processId = 1_234_601;
+      yield* writeRegistration(fileSystem, home, processId, 'private-registration-token');
+      let signals = 0;
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: id => id === processId,
+        processStartIdentity: () => Effect.succeed('identity-a'),
+        signalProcess: () => {
+          signals += 1;
+        },
+      });
+      const response = yield* handleManagerProcessRequest({
+        body: Effect.succeed({confirm: true, processId, processRef: `tnp_${'a'.repeat(64)}`}),
+        config: testConfig(home),
+        method: 'POST',
+        url: new URL('http://localhost/api/processes/terminate'),
+      }).pipe(Effect.provideService(SystemInfo, testSystem));
+      expect(response).toMatchObject({body: {code: 'process-stale'}, status: 409});
+      expect(signals).toBe(0);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
+  it.effect('returns a privacy-safe inventory and a successful exact-instance termination response', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-manager-process-success-'});
+      const processId = 1_234_602;
+      const token = 'private-success-registration-token';
+      yield* writeRegistration(fileSystem, home, processId, token);
+      let running = true;
+      const signals: NodeJS.Signals[] = [];
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: id => id === processId && running,
+        processStartIdentity: () => Effect.succeed('identity-a'),
+        signalProcess: (_id, signal) => {
+          signals.push(signal);
+          running = false;
+        },
+      });
+      const config = testConfig(home);
+      const listed = yield* handleManagerProcessRequest({
+        body: Effect.succeed({}),
+        config,
+        method: 'GET',
+        url: new URL('http://localhost/api/processes'),
+      }).pipe(Effect.provideService(SystemInfo, testSystem));
+      expect(listed).toBeDefined();
+      expect(listed!.status).toBe(200);
+      const serialized = JSON.stringify(listed!.body);
+      expect(serialized).not.toContain(token);
+      expect(serialized).not.toContain(home);
+      const process = (listed!.body as {processes: readonly {processId: number; processRef?: string}[]}).processes[0]!;
+      expect(process).toMatchObject({processId, processRef: expect.stringMatching(/^tnp_[0-9a-f]{64}$/u)});
+
+      const terminated = yield* handleManagerProcessRequest({
+        body: Effect.succeed({confirm: true, processId, processRef: process.processRef}),
+        config,
+        method: 'POST',
+        url: new URL('http://localhost/api/processes/terminate'),
+      }).pipe(Effect.provideService(SystemInfo, testSystem));
+      expect(terminated).toEqual({body: {processId, state: 'terminated'}, status: 200});
+      expect(signals).toEqual(['SIGTERM']);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+});
+
+function writeRegistration(fileSystem: FileSystem.FileSystem, home: string, processId: number, token: string) {
+  return Effect.gen(function* () {
+    const directory = join(home, 'runtime', 'processes');
+    yield* fileSystem.makeDirectory(directory, {recursive: true});
+    yield* fileSystem.writeFileString(
+      join(directory, `${processId}.json`),
+      `${JSON.stringify({
+        baseRole: 'mcp',
+        currentOperation: 'mcp-server',
+        parentProcessId: 42,
+        processId,
+        processStartIdentity: 'identity-a',
+        role: 'mcp',
+        schemaVersion: 1,
+        startedAt: '2026-08-12T00:00:00.000Z',
+        token,
+        updatedAt: '2026-08-12T00:00:00.000Z',
+      })}\n`,
+    );
+  });
+}
+
+function testConfig(agentContextHome: string): RuntimeConfig {
+  return {
+    account: 'local',
+    agentContextHome,
+    agentId: 'threadnote',
+    manifestPath: join(agentContextHome, 'manifest.yaml'),
+    user: 'test',
+  };
+}

--- a/test/unit/manager-state.test.ts
+++ b/test/unit/manager-state.test.ts
@@ -1,0 +1,34 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {managerUpdateAvailable} from '../../src/manager_state.js';
+
+describe('Manager runtime state', () => {
+  it.each([
+    {current: '4.2.0-beta.2', expected: true, latest: '4.2.0'},
+    {current: '4.2.0-beta.2', expected: false, latest: '4.2.0-beta.2'},
+    {current: '4.2.0', expected: false, latest: '4.2.0-beta.9'},
+    {current: '4.2.0-beta.2', expected: false, latest: '4.1.9'},
+    {current: '4.2.0', expected: false, latest: undefined},
+  ])('reports $latest over $current as updateAvailable=$expected', ({current, expected, latest}) => {
+    expect(managerUpdateAvailable(current, latest)).toBe(expected);
+  });
+
+  it('matches numeric SemVer precedence for stable release triples', () => {
+    const version = fc.tuple(
+      fc.integer({max: 99, min: 0}),
+      fc.integer({max: 99, min: 0}),
+      fc.integer({max: 99, min: 0}),
+    );
+    fc.assert(
+      fc.property(version, version, (current, latest) => {
+        const currentVersion = current.join('.');
+        const latestVersion = latest.join('.');
+        const expected =
+          latest[0] > current[0] ||
+          (latest[0] === current[0] && latest[1] > current[1]) ||
+          (latest[0] === current[0] && latest[1] === current[1] && latest[2] > current[2]);
+        expect(managerUpdateAvailable(currentVersion, latestVersion)).toBe(expected);
+      }),
+    );
+  });
+});

--- a/test/unit/manager.test.ts
+++ b/test/unit/manager.test.ts
@@ -589,6 +589,49 @@ describe('manager http API', () => {
     }
   });
 
+  it('requires the session token for process inventory and termination without signaling', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const server = await startServer(config, 'secret');
+    const kill = vi.spyOn(process, 'kill');
+    try {
+      const inventory = await fetch(`${server.url}/api/processes`);
+      const termination = await fetch(`${server.url}/api/processes/terminate`, {
+        body: JSON.stringify({
+          confirm: true,
+          processId: 123_456,
+          processRef: `tnp_${'a'.repeat(64)}`,
+        }),
+        headers: {'content-type': 'application/json'},
+        method: 'POST',
+      });
+      expect(inventory.status).toBe(401);
+      expect(termination.status).toBe(401);
+      expect(kill).not.toHaveBeenCalled();
+    } finally {
+      kill.mockRestore();
+      await server.close();
+    }
+  });
+
+  it('keeps authenticated process inventory available during graph maintenance', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const server = await startServer(config, 'secret');
+    try {
+      const response = await runEffect(
+        withCodeGraphMaintenanceIntent(
+          config.agentContextHome,
+          Effect.promise(() => fetch(`${server.url}/api/processes`, {headers: {authorization: 'Bearer secret'}})),
+        ),
+      );
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({processes: expect.any(Array), schemaVersion: 1});
+    } finally {
+      await server.close();
+    }
+  });
+
   it('serves active graph jobs without requiring a graph database read', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);

--- a/test/unit/process-diagnostics.test.ts
+++ b/test/unit/process-diagnostics.test.ts
@@ -8,10 +8,14 @@ import {Effect, FileSystem} from 'effect';
 import * as FC from 'effect/testing/FastCheck';
 import {afterEach, beforeEach, describe} from 'vitest';
 import {SystemInfo} from '../../src/effect/system.js';
+import {CODE_GRAPH_COMPACTION_WORKER_ARGUMENT} from '../../src/worker_protocol.js';
 import {
+  readManageableThreadnoteProcessDiagnostics,
   readThreadnoteProcessDiagnostics,
   legacyProcessDoctorCheck,
   renderProcessDiagnosticsTable,
+  terminateThreadnoteProcess,
+  ThreadnoteProcessTerminationError,
   threadnoteHomeForProcess,
   withThreadnoteProcessActivity,
   withThreadnoteProcessRegistration,
@@ -37,7 +41,277 @@ afterEach(async () => {
   previousInstallationRoot = undefined;
 });
 
+function testRegistration(
+  processId: number,
+  role: 'graph-parser-worker' | 'mcp',
+  processStartIdentity: string,
+  token: string,
+) {
+  return {
+    baseRole: role,
+    currentOperation: role === 'mcp' ? 'mcp-server' : 'parser-stdio',
+    parentProcessId: 42,
+    processId,
+    processStartIdentity,
+    role,
+    schemaVersion: 1,
+    startedAt: '2026-08-12T00:00:00.000Z',
+    token,
+    updatedAt: '2026-08-12T00:00:00.000Z',
+  } as const;
+}
+
 describe('process diagnostics', () => {
+  it.effect('binds a process reference to the same registration snapshot as the displayed row', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-process-snapshot-'});
+      const processId = 1_234_501;
+      const registrationPath = join(home, 'runtime', 'processes', `${processId}.json`);
+      const first = testRegistration(processId, 'mcp', 'identity-a', 'first-registration-token');
+      const replacement = testRegistration(processId, 'graph-parser-worker', 'identity-a', 'replacement-token-value');
+      yield* fileSystem.makeDirectory(join(home, 'runtime', 'processes'), {recursive: true});
+      yield* fileSystem.writeFileString(registrationPath, `${JSON.stringify(first)}\n`);
+      let replaced = false;
+      let signals = 0;
+      const replacingFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        readFileString: (file, encoding) =>
+          fileSystem.readFileString(file, encoding).pipe(
+            Effect.tap(() => {
+              if (file !== registrationPath || replaced) return Effect.void;
+              replaced = true;
+              return fileSystem.writeFileString(registrationPath, `${JSON.stringify(replacement)}\n`);
+            }),
+          ),
+      });
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: id => id === processId,
+        processStartIdentity: () => Effect.succeed('identity-a'),
+        signalProcess: () => {
+          signals += 1;
+        },
+      });
+
+      const listed = yield* readManageableThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+        Effect.provideService(FileSystem.FileSystem, replacingFileSystem),
+        Effect.provideService(SystemInfo, testSystem),
+      );
+      expect(listed.processes[0]).toMatchObject({processId, role: 'mcp', terminable: true});
+      expect(listed.processes[0]?.processRef).toMatch(/^tnp_[0-9a-f]{64}$/u);
+      const outcome = yield* terminateThreadnoteProcess(
+        {agentContextHome: home},
+        {processId, processRef: listed.processes[0]!.processRef!},
+        {forceWaitMilliseconds: 0, gracefulWaitMilliseconds: 0},
+      ).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+        Effect.match({onFailure: error => ({error}), onSuccess: value => ({value})}),
+      );
+      expect('error' in outcome ? outcome.error : undefined).toMatchObject({code: 'process-stale'});
+      expect(signals).toBe(0);
+      expect(JSON.stringify(listed)).not.toContain(first.token);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
+  it.effect('does not signal when process identity changes between target resolution and signal', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-process-signal-race-'});
+      const processId = 1_234_502;
+      const registration = testRegistration(processId, 'mcp', 'identity-a', 'signal-race-token-value');
+      yield* fileSystem.makeDirectory(join(home, 'runtime', 'processes'), {recursive: true});
+      yield* fileSystem.writeFileString(
+        join(home, 'runtime', 'processes', `${processId}.json`),
+        `${JSON.stringify(registration)}\n`,
+      );
+      let terminating = false;
+      let identityReads = 0;
+      let signals = 0;
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: id => id === processId,
+        processStartIdentity: () => {
+          identityReads += 1;
+          return Effect.succeed(terminating && identityReads >= 2 ? 'replacement-identity' : 'identity-a');
+        },
+        signalProcess: () => {
+          signals += 1;
+        },
+      });
+      const listed = yield* readManageableThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+      );
+      identityReads = 0;
+      terminating = true;
+      const outcome = yield* terminateThreadnoteProcess(
+        {agentContextHome: home},
+        {processId, processRef: listed.processes[0]!.processRef!},
+        {forceWaitMilliseconds: 0, gracefulWaitMilliseconds: 0},
+      ).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+        Effect.match({onFailure: error => ({error}), onSuccess: value => ({value})}),
+      );
+      expect('error' in outcome ? outcome.error : undefined).toBeInstanceOf(ThreadnoteProcessTerminationError);
+      expect('error' in outcome ? outcome.error : undefined).toMatchObject({code: 'process-stale'});
+      expect(signals).toBe(0);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
+  it.effect('does not force-signal a replacement that appears after the graceful signal', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-process-force-race-'});
+      const processId = 1_234_503;
+      const registration = testRegistration(processId, 'mcp', 'identity-a', 'force-race-token-value');
+      yield* fileSystem.makeDirectory(join(home, 'runtime', 'processes'), {recursive: true});
+      yield* fileSystem.writeFileString(
+        join(home, 'runtime', 'processes', `${processId}.json`),
+        `${JSON.stringify(registration)}\n`,
+      );
+      let terminating = false;
+      let identityReads = 0;
+      const signals: NodeJS.Signals[] = [];
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: id => id === processId,
+        processStartIdentity: () => {
+          identityReads += 1;
+          return Effect.succeed(terminating && identityReads >= 5 ? 'replacement-identity' : 'identity-a');
+        },
+        signalProcess: (_id, signal) => {
+          signals.push(signal);
+        },
+      });
+      const listed = yield* readManageableThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+      );
+      identityReads = 0;
+      terminating = true;
+      const outcome = yield* terminateThreadnoteProcess(
+        {agentContextHome: home},
+        {processId, processRef: listed.processes[0]!.processRef!},
+        {forceWaitMilliseconds: 0, gracefulWaitMilliseconds: 0},
+      ).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+        Effect.match({onFailure: error => ({error}), onSuccess: value => ({value})}),
+      );
+      expect('error' in outcome ? outcome.error : undefined).toMatchObject({code: 'process-stale'});
+      expect(signals).toEqual(['SIGTERM']);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
+  it.effect('protects the current Manager process before reading or signaling a target', () =>
+    Effect.gen(function* () {
+      const nativeSystem = yield* SystemInfo;
+      let signals = 0;
+      const processId = 1_234_504;
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        processId,
+        signalProcess: () => {
+          signals += 1;
+        },
+      });
+      const outcome = yield* terminateThreadnoteProcess(
+        {agentContextHome: '/unused'},
+        {processId, processRef: `tnp_${'a'.repeat(64)}`},
+      ).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+        Effect.match({onFailure: error => ({error}), onSuccess: value => ({value})}),
+      );
+      expect('error' in outcome ? outcome.error : undefined).toMatchObject({code: 'current-manager'});
+      expect(signals).toBe(0);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer)),
+  );
+
+  it.effect('reports termination after the exact registered process exits on SIGTERM', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-process-terminate-'});
+      const processId = 1_234_505;
+      const registration = testRegistration(processId, 'mcp', 'identity-a', 'terminate-token-value');
+      yield* fileSystem.makeDirectory(join(home, 'runtime', 'processes'), {recursive: true});
+      yield* fileSystem.writeFileString(
+        join(home, 'runtime', 'processes', `${processId}.json`),
+        `${JSON.stringify(registration)}\n`,
+      );
+      let running = true;
+      const signals: NodeJS.Signals[] = [];
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: id => id === processId && running,
+        processStartIdentity: () => Effect.succeed('identity-a'),
+        signalProcess: (_id, signal) => {
+          signals.push(signal);
+          running = false;
+        },
+      });
+      const listed = yield* readManageableThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+      );
+      const result = yield* terminateThreadnoteProcess(
+        {agentContextHome: home},
+        {processId, processRef: listed.processes[0]!.processRef!},
+        {gracefulWaitMilliseconds: 0},
+      ).pipe(Effect.provideService(SystemInfo, testSystem));
+      expect(result).toEqual({processId, state: 'terminated'});
+      expect(signals).toEqual(['SIGTERM']);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
+  it.live('registers the signal-transparent compaction worker under its Manager parent', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-compaction-process-'});
+      yield* withThreadnoteProcessRegistration(
+        home,
+        'manager',
+        Effect.acquireUseRelease(
+          Effect.sync(() =>
+            Bun.spawn({
+              cmd: [process.execPath, 'src/standalone.ts', CODE_GRAPH_COMPACTION_WORKER_ARGUMENT],
+              cwd: process.cwd(),
+              env: {...process.env, THREADNOTE_HOME: home},
+              stderr: 'pipe',
+              stdin: 'pipe',
+              stdout: 'pipe',
+            }),
+          ),
+          child =>
+            Effect.gen(function* () {
+              const registrationPath = join(home, 'runtime', 'processes', `${child.pid}.json`);
+              for (let attempt = 0; attempt < 100 && !(yield* fileSystem.exists(registrationPath)); attempt += 1) {
+                yield* Effect.sleep(25);
+              }
+              expect(yield* fileSystem.exists(registrationPath)).toBe(true);
+              const diagnostics = yield* readThreadnoteProcessDiagnostics({agentContextHome: home});
+              expect(diagnostics.processes).toContainEqual(
+                expect.objectContaining({
+                  currentOperation: 'compact-graph-storage',
+                  parentProcessId: process.pid,
+                  parentRole: 'manager',
+                  processId: child.pid,
+                  role: 'graph-compaction-worker',
+                }),
+              );
+              child.kill('SIGTERM');
+              yield* Effect.promise(() => child.exited);
+            }),
+          child =>
+            Effect.sync(() => {
+              if (child.exitCode === null) child.kill('SIGKILL');
+            }),
+        ),
+        'manager-ui',
+      );
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
   it('aligns operation values with their header when preceding cells have different widths', () => {
     expect(
       renderProcessDiagnosticsTable([

--- a/test/unit/update-channel.test.ts
+++ b/test/unit/update-channel.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest';
+import {isBetaVersion, isPrereleaseVersion, selectUpdateChannel} from '../../src/update_channel.js';
+
+describe('update channel inference', () => {
+  it('infers the inclusive preview channel for any valid release prerelease', () => {
+    for (const version of ['4.2.0-alpha.1', '4.2.0-beta.2', '4.2.0-rc.1']) {
+      expect(isPrereleaseVersion(version)).toBe(true);
+      expect(isBetaVersion(version)).toBe(true);
+      expect(selectUpdateChannel(version)).toBe('beta');
+    }
+  });
+
+  it('infers local development builds from their underlying release version', () => {
+    const stableLocal = `4.2.0-local.g${'a'.repeat(40)}`;
+    expect(isPrereleaseVersion(stableLocal)).toBe(false);
+    expect(isBetaVersion(stableLocal)).toBe(false);
+    expect(selectUpdateChannel(stableLocal)).toBe('latest');
+
+    for (const version of [`4.2.0-beta.2.local.g${'a'.repeat(40)}`, `4.2.0-rc.1.local.g${'a'.repeat(64)}`]) {
+      expect(isPrereleaseVersion(version)).toBe(true);
+      expect(isBetaVersion(version)).toBe(true);
+      expect(selectUpdateChannel(version)).toBe('beta');
+    }
+  });
+
+  it('keeps stable inference and explicit channel overrides unchanged', () => {
+    expect(selectUpdateChannel('4.2.0')).toBe('latest');
+    expect(selectUpdateChannel('4.2.0', 'beta')).toBe('beta');
+    expect(selectUpdateChannel('4.2.0-rc.1', 'latest')).toBe('latest');
+  });
+});

--- a/test/unit/update-check.test.ts
+++ b/test/unit/update-check.test.ts
@@ -33,7 +33,7 @@ describe('Effect update check', () => {
       yield* Effect.promise(() =>
         writeFile(
           cachePath,
-          JSON.stringify({channel: 'latest', checkedAt: new Date().toISOString(), latestVersion: '2.0.0', version: 2}),
+          JSON.stringify({channel: 'latest', checkedAt: new Date().toISOString(), latestVersion: '2.0.0', version: 3}),
           'utf8',
         ),
       );
@@ -77,14 +77,19 @@ describe('Effect update check', () => {
     }),
   );
 
-  effectIt.effect('uses and caches the beta channel for an installed beta', () =>
+  effectIt.effect('invalidates a v2 beta cache and discovers a newer stable release', () =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(temporaryDirectory);
       const cachePath = join(directory, 'update.json');
       yield* Effect.promise(() =>
         writeFile(
           cachePath,
-          JSON.stringify({channel: 'latest', checkedAt: new Date().toISOString(), latestVersion: '2.0.4', version: 2}),
+          JSON.stringify({
+            channel: 'beta',
+            checkedAt: new Date().toISOString(),
+            latestVersion: '3.0.0-beta.2',
+            version: 2,
+          }),
           'utf8',
         ),
       );
@@ -97,17 +102,26 @@ describe('Effect update check', () => {
             prerelease: true,
             tag_name: 'v3.0.0-beta.2',
           },
+          {
+            assets: [],
+            draft: false,
+            immutable: true,
+            prerelease: false,
+            tag_name: 'v3.0.0',
+          },
         ]),
       );
       vi.stubGlobal('fetch', fetch);
 
       expect(yield* runCheck(cachePath, '3.0.0-beta.1')).toEqual({
         currentVersion: '3.0.0-beta.1',
-        latestVersion: '3.0.0-beta.2',
+        latestVersion: '3.0.0',
         outdated: true,
       });
       expect(fetch.mock.calls.some(([url]) => String(url).includes('/releases?per_page=100'))).toBe(true);
       expect(yield* Effect.promise(() => readFile(cachePath, 'utf8'))).toContain('"channel":"beta"');
+      expect(yield* Effect.promise(() => readFile(cachePath, 'utf8'))).toContain('"latestVersion":"3.0.0"');
+      expect(yield* Effect.promise(() => readFile(cachePath, 'utf8'))).toContain('"version":3');
     }),
   );
 });

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -4,6 +4,7 @@ import {provideTestLayer} from '../helpers/effect-layer.js';
 import {mkdtemp, rm} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
+import fc from 'fast-check';
 import {Crypto, Effect, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
@@ -28,6 +29,7 @@ vi.mock('../../src/utils.js', async importOriginal => {
 
 import {
   fetchLatestVersion,
+  isUpdateTargetAllowed,
   maybeNotifyUpdate,
   maybeRunPostUpdateAfterRepair,
   parseReleaseChecksum,
@@ -77,6 +79,30 @@ describe('standalone release selection', () => {
   it('requires a fresh install before the standalone 4.x updater boundary', () => {
     expect(requiresFreshStandaloneInstall('3.0.5')).toBe(true);
     expect(requiresFreshStandaloneInstall('4.0.0-beta.1')).toBe(false);
+  });
+
+  it('permits generated version transitions only under the downgrade policy', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({max: 100, min: 1}),
+        fc.constantFrom<'downgrade' | 'equal' | 'upgrade'>('downgrade', 'equal', 'upgrade'),
+        fc.boolean(),
+        fc.boolean(),
+        fc.constantFrom<undefined | 'beta' | 'latest'>(undefined, 'beta', 'latest'),
+        (baseMajor, direction, currentIsBeta, targetIsBeta, requestedChannel) => {
+          const currentMajor = direction === 'downgrade' ? baseMajor + 1 : baseMajor;
+          const targetMajor = direction === 'upgrade' ? baseMajor + 1 : baseMajor;
+          const effectiveTargetIsBeta = direction === 'equal' ? currentIsBeta : targetIsBeta;
+          const currentVersion = `${currentMajor}.0.0${currentIsBeta ? '-beta.2' : ''}`;
+          const targetVersion = `${targetMajor}.0.0${effectiveTargetIsBeta ? '-beta.2' : ''}`;
+          const expected =
+            direction !== 'downgrade' || (currentIsBeta && !effectiveTargetIsBeta && requestedChannel === 'latest');
+
+          expect(isUpdateTargetAllowed(currentVersion, targetVersion, requestedChannel)).toBe(expected);
+        },
+      ),
+      {numRuns: 200},
+    );
   });
 
   effectIt.effect('selects stable and beta GitHub releases while ignoring drafts and mutable releases', () =>
@@ -283,6 +309,140 @@ describe('update notifications', () => {
 });
 
 describe('standalone updater', () => {
+  effectIt.effect('treats a stale same-channel release listing as up to date without force', () =>
+    Effect.gen(function* () {
+      const currentVersion = '4.2.0-beta.2';
+      const olderVersion = '4.2.0-beta.1';
+      vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(currentVersion));
+      let downloadAttempted = false;
+      const http = HttpService.of({
+        downloadToFile: () => {
+          downloadAttempted = true;
+          return Effect.die('up-to-date path must not download');
+        },
+        getJson: () => Effect.succeed({body: [releaseResponse(olderVersion, true)], status: 200}),
+        getStatus: () => Effect.die('not used'),
+        getText: () => Effect.die('up-to-date path must not fetch checksums'),
+      });
+
+      const captured = yield* captureConsole(
+        runUpdate(runtimeConfig('/tmp/threadnote-update-stale-listing'), {beta: true}).pipe(
+          Effect.provideService(HttpService, http),
+        ),
+      );
+
+      expect(captured.output).toContain('Threadnote is up to date.');
+      expect(downloadAttempted).toBe(false);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('refuses a forced same-channel downgrade before downloading or activating it', () =>
+    Effect.gen(function* () {
+      const currentVersion = '4.2.0-beta.2';
+      const olderVersion = '4.2.0-beta.1';
+      vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(currentVersion));
+      let downloadAttempted = false;
+      const http = HttpService.of({
+        downloadToFile: () => {
+          downloadAttempted = true;
+          return Effect.die('downgrade must not download');
+        },
+        getJson: () => Effect.succeed({body: [releaseResponse(olderVersion, true)], status: 200}),
+        getStatus: () => Effect.die('not used'),
+        getText: () => Effect.die('downgrade must not fetch checksums'),
+      });
+
+      const failure = yield* runUpdate(runtimeConfig('/tmp/threadnote-update-same-channel-downgrade'), {
+        beta: true,
+        force: true,
+      }).pipe(Effect.provideService(HttpService, http), provideTestLayer(ApplicationLayer), Effect.flip);
+
+      expect(String(failure)).toContain(`Refusing to downgrade Threadnote ${currentVersion} to ${olderVersion}`);
+      expect(downloadAttempted).toBe(false);
+    }),
+  );
+
+  effectIt.effect('refuses a stable-to-older-beta channel switch before downloading or activating it', () =>
+    Effect.gen(function* () {
+      const currentVersion = '4.2.0';
+      const olderVersion = '4.1.0-beta.1';
+      vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(currentVersion));
+      let downloadAttempted = false;
+      const http = HttpService.of({
+        downloadToFile: () => {
+          downloadAttempted = true;
+          return Effect.die('downgrade must not download');
+        },
+        getJson: () => Effect.succeed({body: [releaseResponse(olderVersion, true)], status: 200}),
+        getStatus: () => Effect.die('not used'),
+        getText: () => Effect.die('downgrade must not fetch checksums'),
+      });
+
+      const failure = yield* runUpdate(runtimeConfig('/tmp/threadnote-update-stable-to-beta-downgrade'), {
+        beta: true,
+      }).pipe(Effect.provideService(HttpService, http), provideTestLayer(ApplicationLayer), Effect.flip);
+
+      expect(String(failure)).toContain(`Refusing to downgrade Threadnote ${currentVersion} to ${olderVersion}`);
+      expect(downloadAttempted).toBe(false);
+    }),
+  );
+
+  effectIt.effect('allows an explicit beta-to-stable channel switch to an older stable version', () =>
+    Effect.gen(function* () {
+      const currentVersion = '4.2.0-beta.1';
+      const stableVersion = '4.1.1';
+      vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(currentVersion));
+      const system = yield* SystemInfo;
+      const artifactName = releaseArtifactName(system);
+      const http = HttpService.of({
+        downloadToFile: () => Effect.die('dry run must not download'),
+        getJson: () => Effect.succeed({body: [releaseResponse(stableVersion, false, artifactName)], status: 200}),
+        getStatus: () => Effect.die('not used'),
+        getText: () => Effect.die('dry run must not fetch checksums'),
+      });
+
+      const captured = yield* captureConsole(
+        runUpdate(runtimeConfig('/tmp/threadnote-update-beta-to-stable'), {
+          dryRun: true,
+          postUpdate: false,
+          repair: false,
+          stable: true,
+        }).pipe(Effect.provideService(HttpService, http)),
+      );
+
+      expect(captured.output).toContain(`Would install standalone Threadnote to:`);
+      expect(captured.output).toContain(stableVersion);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('allows force to reinstall the equal selected version', () =>
+    Effect.gen(function* () {
+      const currentVersion = '4.2.0-beta.1';
+      vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(currentVersion));
+      const system = yield* SystemInfo;
+      const artifactName = releaseArtifactName(system);
+      const http = HttpService.of({
+        downloadToFile: () => Effect.die('dry run must not download'),
+        getJson: () => Effect.succeed({body: [releaseResponse(currentVersion, true, artifactName)], status: 200}),
+        getStatus: () => Effect.die('not used'),
+        getText: () => Effect.die('dry run must not fetch checksums'),
+      });
+
+      const captured = yield* captureConsole(
+        runUpdate(runtimeConfig('/tmp/threadnote-update-force-reinstall'), {
+          beta: true,
+          dryRun: true,
+          force: true,
+          postUpdate: false,
+          repair: false,
+        }).pipe(Effect.provideService(HttpService, http)),
+      );
+
+      expect(captured.output).toContain(`Would install standalone Threadnote to:`);
+      expect(captured.output).toContain(currentVersion);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('updates the active installation when a newer local development binary invokes the updater', () =>
     Effect.gen(function* () {
       const activeVersion = '4.0.0-beta.19';

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -5,7 +5,7 @@ import {mkdtemp, rm} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import fc from 'fast-check';
-import {Crypto, Effect, FileSystem, Path} from 'effect';
+import {Crypto, Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {captureConsole} from '../../src/effect/console.js';
@@ -14,9 +14,9 @@ import {sha256FileHex} from '../../src/effect/digest.js';
 import {HttpService} from '../../src/effect/http.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
-import {activateStandaloneRelease} from '../../src/installations.js';
+import {activateStandaloneRelease, withStandaloneInstallationLock} from '../../src/installations.js';
 import {migrateThreadnoteStorageLayout} from '../../src/migration/layout.js';
-import type {RuntimeConfig} from '../../src/types.js';
+import type {RuntimeConfig, UpdateOptions} from '../../src/types.js';
 
 vi.mock('../../src/utils.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils.js')>();
@@ -30,6 +30,7 @@ vi.mock('../../src/utils.js', async importOriginal => {
 import {
   fetchLatestVersion,
   isUpdateTargetAllowed,
+  latestUpdateVersionLabel,
   maybeNotifyUpdate,
   maybeRunPostUpdateAfterRepair,
   parseReleaseChecksum,
@@ -81,6 +82,11 @@ describe('standalone release selection', () => {
     expect(requiresFreshStandaloneInstall('4.0.0-beta.1')).toBe(false);
   });
 
+  it('labels the inclusive beta channel without describing a stable winner as a beta release', () => {
+    expect(latestUpdateVersionLabel('beta')).toBe('Latest beta-channel version');
+    expect(latestUpdateVersionLabel('latest')).toBe('Latest version');
+  });
+
   it('permits generated version transitions only under the downgrade policy', () => {
     fc.assert(
       fc.property(
@@ -105,7 +111,7 @@ describe('standalone release selection', () => {
     );
   });
 
-  effectIt.effect('selects stable and beta GitHub releases while ignoring drafts and mutable releases', () =>
+  effectIt.effect('selects a newer prerelease for beta while stable excludes it, drafts, and mutable releases', () =>
     Effect.gen(function* () {
       const releases = [
         releaseResponse('4.1.0-beta.2', true),
@@ -129,6 +135,58 @@ describe('standalone release selection', () => {
       expect(stable).toBe('4.0.1');
       expect(beta).toBe('4.1.0-beta.2');
     }),
+  );
+
+  effectIt.effect('selects a newer stable release for the inclusive beta channel', () =>
+    Effect.gen(function* () {
+      const releases = [releaseResponse('4.1.0-beta.2', true), releaseResponse('4.2.0', false)];
+      const http = HttpService.of({
+        downloadToFile: () => Effect.die('not used'),
+        getJson: () => Effect.succeed({body: releases, status: 200}),
+        getStatus: () => Effect.succeed(200),
+        getText: () => Effect.die('not used'),
+      });
+
+      const [stable, beta] = yield* Effect.all([
+        fetchLatestVersion(OFFICIAL_RELEASE_SOURCE, 'latest'),
+        fetchLatestVersion(OFFICIAL_RELEASE_SOURCE, 'beta'),
+      ]).pipe(Effect.provideService(HttpService, http));
+
+      expect(stable).toBe('4.2.0');
+      expect(beta).toBe('4.2.0');
+    }),
+  );
+
+  effectIt.effect.prop(
+    'selects the newest stable-or-prerelease version for every bounded beta-channel pair',
+    {
+      betaMinor: fc.integer({max: 50, min: 0}),
+      stableMinor: fc.integer({max: 50, min: 0}),
+    },
+    ({betaMinor, stableMinor}) =>
+      Effect.gen(function* () {
+        const betaVersion = `4.${betaMinor}.0-beta.1`;
+        const stableVersion = `4.${stableMinor}.0`;
+        const http = HttpService.of({
+          downloadToFile: () => Effect.die('not used'),
+          getJson: () =>
+            Effect.succeed({
+              body: [releaseResponse(betaVersion, true), releaseResponse(stableVersion, false)],
+              status: 200,
+            }),
+          getStatus: () => Effect.succeed(200),
+          getText: () => Effect.die('not used'),
+        });
+
+        const [stable, beta] = yield* Effect.all([
+          fetchLatestVersion(OFFICIAL_RELEASE_SOURCE, 'latest'),
+          fetchLatestVersion(OFFICIAL_RELEASE_SOURCE, 'beta'),
+        ]).pipe(Effect.provideService(HttpService, http));
+
+        expect(stable).toBe(stableVersion);
+        expect(beta).toBe(betaMinor > stableMinor ? betaVersion : stableVersion);
+      }),
+    {fastCheck: {numRuns: 100}},
   );
 
   it('requires HTTPS and explicit trust for custom release sources', () => {
@@ -211,6 +269,61 @@ describe('standalone release selection', () => {
 });
 
 describe('update notifications', () => {
+  effectIt.effect('invalidates a prerelease-only beta cache before announcing a newer stable release', () =>
+    Effect.gen(function* () {
+      vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed('4.1.0-beta.2'));
+      const result = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseSystem = yield* SystemInfo;
+          const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-update-cache-version-'});
+          const config = runtimeConfig(path.join(temporaryRoot, 'home'));
+          yield* fs.makeDirectory(config.agentContextHome, {recursive: true});
+          yield* fs.writeFileString(
+            path.join(config.agentContextHome, 'update-check.json'),
+            `${JSON.stringify({
+              channel: 'beta',
+              checkedAt: new Date().toISOString(),
+              latestVersion: '4.1.0-beta.3',
+              source: OFFICIAL_RELEASE_SOURCE,
+            })}\n`,
+          );
+          let requests = 0;
+          const http = HttpService.of({
+            downloadToFile: () => Effect.die('not used'),
+            getJson: () =>
+              Effect.sync(() => {
+                requests += 1;
+                return {body: [releaseResponse('4.2.0', false)], status: 200};
+              }),
+            getStatus: () => Effect.die('not used'),
+            getText: () => Effect.die('not used'),
+          });
+          const system = SystemInfo.of({...baseSystem, environment: () => ({})});
+          const captured = yield* captureConsole(
+            maybeNotifyUpdate(config).pipe(
+              Effect.provideService(HttpService, http),
+              Effect.provideService(SystemInfo, system),
+            ),
+          );
+          return {
+            cache: JSON.parse(yield* fs.readFileString(path.join(config.agentContextHome, 'update-check.json'))) as {
+              readonly latestVersion: string;
+              readonly version?: number;
+            },
+            output: captured.output,
+            requests,
+          };
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer));
+
+      expect(result.requests).toBe(1);
+      expect(result.output).toContain('Update available: threadnote 4.1.0-beta.2 -> 4.2.0');
+      expect(result.cache).toMatchObject({latestVersion: '4.2.0', version: 2});
+    }),
+  );
+
   effectIt.effect('revalidates a cached update before announcing a withdrawn release', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(
@@ -309,6 +422,87 @@ describe('update notifications', () => {
 });
 
 describe('standalone updater', () => {
+  effectIt.effect('updates an installed beta to a newer stable release without an explicit channel flag', () =>
+    Effect.gen(function* () {
+      const captured = yield* captureDryRunUpdateSelection(
+        '4.1.0-beta.2',
+        [
+          ['4.1.0-beta.3', true],
+          ['4.2.0', false],
+        ],
+        {},
+      );
+
+      expect(captured.output).toContain('Latest beta-channel version: 4.2.0');
+      expect(captured.output).toContain('versions/4.2.0');
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('updates an installed release candidate through the inclusive preview channel', () =>
+    Effect.gen(function* () {
+      const captured = yield* captureDryRunUpdateSelection(
+        '4.2.0-rc.1',
+        [
+          ['4.2.0-rc.2', true],
+          ['4.1.1', false],
+        ],
+        {},
+      );
+
+      expect(captured.output).toContain('Latest beta-channel version: 4.2.0-rc.2');
+      expect(captured.output).toContain('versions/4.2.0-rc.2');
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('selects a newer stable release when --beta explicitly enters the inclusive channel', () =>
+    Effect.gen(function* () {
+      const captured = yield* captureDryRunUpdateSelection(
+        '4.1.0-beta.2',
+        [
+          ['4.1.0-beta.3', true],
+          ['4.2.0', false],
+        ],
+        {beta: true},
+      );
+
+      expect(captured.output).toContain('Latest beta-channel version: 4.2.0');
+      expect(captured.output).toContain('versions/4.2.0');
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('does not reinstall an equal stable winner merely because --beta was explicit', () =>
+    Effect.gen(function* () {
+      const captured = yield* captureDryRunUpdateSelection(
+        '4.2.0',
+        [
+          ['4.1.0-beta.9', true],
+          ['4.2.0', false],
+        ],
+        {beta: true},
+      );
+
+      expect(captured.output).toContain('Latest beta-channel version: 4.2.0');
+      expect(captured.output).toContain('Threadnote is up to date.');
+      expect(captured.output).not.toContain('Would install standalone Threadnote');
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('selects a newer beta over the newest stable release', () =>
+    Effect.gen(function* () {
+      const captured = yield* captureDryRunUpdateSelection(
+        '4.1.0',
+        [
+          ['4.2.0-beta.1', true],
+          ['4.1.1', false],
+        ],
+        {beta: true},
+      );
+
+      expect(captured.output).toContain('Latest beta-channel version: 4.2.0-beta.1');
+      expect(captured.output).toContain('versions/4.2.0-beta.1');
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('treats a stale same-channel release listing as up to date without force', () =>
     Effect.gen(function* () {
       const currentVersion = '4.2.0-beta.2';
@@ -362,7 +556,87 @@ describe('standalone updater', () => {
     }),
   );
 
-  effectIt.effect('refuses a stable-to-older-beta channel switch before downloading or activating it', () =>
+  effectIt.effect('revalidates the active version under the installation lock before a forced reinstall', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const selectedVersion = '4.2.0-beta.2';
+        const concurrentlyActivatedVersion = '4.2.0-beta.3';
+        vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(selectedVersion));
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-update-lock-race-'});
+        const installRoot = path.join(temporaryRoot, 'install');
+        const binRoot = path.join(temporaryRoot, 'bin');
+        const selectedRoot = path.join(installRoot, 'versions', selectedVersion);
+        const concurrentRoot = path.join(installRoot, 'versions', concurrentlyActivatedVersion);
+        for (const [releaseRoot, version] of [
+          [selectedRoot, selectedVersion],
+          [concurrentRoot, concurrentlyActivatedVersion],
+        ] as const) {
+          yield* fs.makeDirectory(releaseRoot, {recursive: true});
+          yield* fs.writeFileString(path.join(releaseRoot, 'release.json'), `${JSON.stringify({version})}\n`);
+        }
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({
+            ...baseSystem.environment(),
+            THREADNOTE_BIN_DIR: binRoot,
+            THREADNOTE_INSTALL_ROOT: installRoot,
+          }),
+        });
+        yield* activateStandaloneRelease(selectedRoot, false).pipe(Effect.provideService(SystemInfo, testSystem));
+
+        const selectionStarted = yield* Deferred.make<void>();
+        const allowSelection = yield* Deferred.make<void>();
+        let releaseFetches = 0;
+        let downloadAttempted = false;
+        const http = HttpService.of({
+          downloadToFile: () => {
+            downloadAttempted = true;
+            return Effect.die('the stale target must not download');
+          },
+          getJson: () =>
+            Effect.gen(function* () {
+              releaseFetches += 1;
+              if (releaseFetches === 1) {
+                yield* Deferred.succeed(selectionStarted, undefined);
+                yield* Deferred.await(allowSelection);
+              }
+              return {body: [releaseResponse(selectedVersion, true)], status: 200};
+            }),
+          getStatus: () => Effect.die('not used'),
+          getText: () => Effect.die('the stale target must not fetch checksums'),
+        });
+        const updater = yield* Effect.forkScoped(
+          runUpdate(runtimeConfig(path.join(temporaryRoot, 'home')), {
+            beta: true,
+            force: true,
+            postUpdate: false,
+            repair: false,
+          }).pipe(Effect.provideService(HttpService, http), Effect.provideService(SystemInfo, testSystem), Effect.flip),
+        );
+        yield* Deferred.await(selectionStarted);
+        yield* withStandaloneInstallationLock(activateStandaloneRelease(concurrentRoot, false)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        yield* Deferred.succeed(allowSelection, undefined);
+
+        const failure = yield* Fiber.join(updater);
+        const active = JSON.parse(yield* fs.readFileString(path.join(installRoot, 'active-release.json'))) as {
+          version: string;
+        };
+        expect(String(failure)).toContain(
+          `Refusing to downgrade Threadnote ${concurrentlyActivatedVersion} to ${selectedVersion}`,
+        );
+        expect(releaseFetches).toBe(1);
+        expect(downloadAttempted).toBe(false);
+        expect(active.version).toBe(concurrentlyActivatedVersion);
+      }),
+    ).pipe(TestClock.withLive, provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('refuses a forced stable-to-older-beta selection before downloading or activating it', () =>
     Effect.gen(function* () {
       const currentVersion = '4.2.0';
       const olderVersion = '4.1.0-beta.1';
@@ -380,6 +654,7 @@ describe('standalone updater', () => {
 
       const failure = yield* runUpdate(runtimeConfig('/tmp/threadnote-update-stable-to-beta-downgrade'), {
         beta: true,
+        force: true,
       }).pipe(Effect.provideService(HttpService, http), provideTestLayer(ApplicationLayer), Effect.flip);
 
       expect(String(failure)).toContain(`Refusing to downgrade Threadnote ${currentVersion} to ${olderVersion}`);
@@ -1443,6 +1718,36 @@ function runtimeConfig(home: string): RuntimeConfig {
   };
 }
 
+function captureDryRunUpdateSelection(
+  currentVersion: string,
+  releases: readonly (readonly [version: string, prerelease: boolean])[],
+  options: UpdateOptions,
+) {
+  vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(currentVersion));
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    const artifactName = releaseArtifactName(system);
+    const http = HttpService.of({
+      downloadToFile: () => Effect.die('dry run must not download'),
+      getJson: () =>
+        Effect.succeed({
+          body: releases.map(([version, prerelease]) => releaseResponse(version, prerelease, artifactName)),
+          status: 200,
+        }),
+      getStatus: () => Effect.die('not used'),
+      getText: () => Effect.die('dry run must not fetch checksums'),
+    });
+    return yield* captureConsole(
+      runUpdate(runtimeConfig(`/tmp/threadnote-update-selection-${currentVersion}`), {
+        ...options,
+        dryRun: true,
+        postUpdate: false,
+        repair: false,
+      }).pipe(Effect.provideService(HttpService, http)),
+    );
+  });
+}
+
 function writeUpdateCacheFixture(
   fs: FileSystem.FileSystem,
   path: Path.Path,
@@ -1458,6 +1763,7 @@ function writeUpdateCacheFixture(
           checkedAt: new Date().toISOString(),
           latestVersion,
           source: OFFICIAL_RELEASE_SOURCE,
+          version: 2,
         })}\n`,
       ),
     ),

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -434,7 +434,7 @@ describe('standalone updater', () => {
       );
 
       expect(captured.output).toContain('Latest beta-channel version: 4.2.0');
-      expect(captured.output).toContain('versions/4.2.0');
+      expect(captured.output).toMatch(/versions[\\/]4\.2\.0/);
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 
@@ -450,7 +450,7 @@ describe('standalone updater', () => {
       );
 
       expect(captured.output).toContain('Latest beta-channel version: 4.2.0-rc.2');
-      expect(captured.output).toContain('versions/4.2.0-rc.2');
+      expect(captured.output).toMatch(/versions[\\/]4\.2\.0-rc\.2/);
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 
@@ -466,7 +466,7 @@ describe('standalone updater', () => {
       );
 
       expect(captured.output).toContain('Latest beta-channel version: 4.2.0');
-      expect(captured.output).toContain('versions/4.2.0');
+      expect(captured.output).toMatch(/versions[\\/]4\.2\.0/);
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 
@@ -499,7 +499,7 @@ describe('standalone updater', () => {
       );
 
       expect(captured.output).toContain('Latest beta-channel version: 4.2.0-beta.1');
-      expect(captured.output).toContain('versions/4.2.0-beta.1');
+      expect(captured.output).toMatch(/versions[\\/]4\.2\.0-beta\.1/);
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 

--- a/test/unit/windows-support.test.ts
+++ b/test/unit/windows-support.test.ts
@@ -84,10 +84,12 @@ describe('Windows platform contracts', () => {
     expect(installer).toContain("$type -notin @('-', 'd')");
   });
 
-  it('selects the beta release channel from an explicit bootstrap flag', async () => {
+  it('selects the inclusive beta release channel from an explicit bootstrap flag', async () => {
     const installer = await Bun.file(new URL('../../scripts/install.ps1', import.meta.url)).text();
 
     expect(installer).toContain('[switch]$Beta');
     expect(installer).toContain("$channel = if ($Beta) { 'beta' }");
+    expect(installer).toContain("'beta' { $null }");
+    expect(installer).toContain('$null -ne $prerelease');
   });
 });

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -1414,7 +1414,7 @@ threadnote graph export --format svg --output code-graph.svg`,
       {
         id: 'manager',
         title: 'Manager',
-        summary: 'A foreground, loopback-only web UI for Doctor, memories, shares, tools, and graph visualizations.',
+        summary: 'A foreground, loopback-only web UI for graphs, Worksets, memories, processes, and health.',
         body: [
           {
             type: 'code',
@@ -1436,7 +1436,9 @@ threadnote manage --no-open`,
             items: [
               'Doctor: installation, integration, model, index, and storage health.',
               'Memory: browse lifecycle-aware canonical records and pending candidates.',
-              'Knowledge graph: explore current symbols and relationships, request topology signals, and preview or remove one exact indexed view without requiring its local folder. Removal refreshes the target, asks for explicit confirmation, and reports busy or stale state without force-bypassing shared readers and bases.',
+              'Knowledge graph: explore current symbols and relationships, request topology signals, and preview or remove one exact indexed view without requiring its local folder. Storage with neither a verified folder nor a ready snapshot is labeled unassociated and offers explicit index-or-purge guidance.',
+              'Worksets: create and maintain manifest projects and named cross-repository definitions, publish a ready generation explicitly, then search or traverse its bounded evidence.',
+              'Processes: inspect safe role, parent, operation, age, memory, and version metadata without exposing arguments, environment, paths, prompts, or private registration data. Confirmed termination revalidates the exact opaque registration and OS start identity before every signal; stale targets fail closed and the current Manager is protected.',
               'Shares: inspect configured teams, synchronization, and conflicts.',
               'Tools: discover operational surfaces without memorizing every command.',
             ],
@@ -1771,7 +1773,7 @@ threadnote update --check`,
           },
           {
             type: 'paragraph',
-            text: "After opting into beta, ordinary version and update checks remain on the beta channel. Use --stable to return to stable even when that version is numerically lower. Updates verify immutable release assets, promote atomically, preserve ~/.threadnote data and verified model files, then repair Threadnote-owned integrations. Cursor Marketplace plugin updates remain owned by Cursor and the organization's policy.",
+            text: "The beta channel is an inclusive preview channel: it selects the newest immutable Threadnote release across stable and prerelease builds, so an invoked update can graduate an older beta to a fresher stable without --stable. After that graduation, ordinary updates follow stable; use --beta to re-enter preview selection. Use --stable to request stable explicitly, even when it is numerically lower than an installed prerelease. Updates verify immutable release assets, promote atomically, preserve ~/.threadnote data and verified model files, then repair Threadnote-owned integrations. Cursor Marketplace plugin updates remain owned by Cursor and the organization's policy.",
           },
           {
             type: 'paragraph',


### PR DESCRIPTION
## Summary

- make the beta channel inclusive of the newest immutable stable or prerelease release, with cache and POSIX/PowerShell installer parity
- prevent forced semantic downgrades, including a concurrent-update recheck under the installation lock
- add Manager's privacy-safe Processes tab with identity-bound termination and protected Manager/legacy/unverified rows
- register isolated graph compaction and deep-diagnostics workers so live work is visible
- clarify unassociated graph storage and index-or-purge recovery in Manager
- update beta.2 release notes and user documentation

## Verification

- full local suite: 302 files, 2,975 passed, 1 skipped
- lint, full source/test/site typecheck, Prettier, and diff checks
- standalone build, self-contained check/smoke, and release smoke
- site check/build (46 crawler-visible pages)
- focused updater/installer, Manager/process, graph, API/UI, auth, race, and property tests
- exact-HEAD global install and doctor: 0 failures
- live Manager QA at desktop and 390px: no overflow or console warnings/errors
- live deep-diagnostics worker appeared under its parent; confirmed identity-bound stop removed only that worker; current Manager remained protected
- live stale-list forced downgrade was refused before download

The three untracked design documents in the local checkout are user-owned and intentionally excluded.
