### PR TITLE
Add Cursor Cloud shared memory profile

### DIFF
--- a/src/cursor_cloud.ts
+++ b/src/cursor_cloud.ts
@@ -1,0 +1,343 @@
+import {Console, Effect, FileSystem, Path} from 'effect';
+import type {RuntimeConfig, ShareTeamConfig, ShareTeamsFile} from './types.js';
+import {runShareInit, runShareSync} from './share.js';
+import {normalizeTeamName, readTeamsFile, shareTeamAccess} from './share.js';
+import {withSharedRepositoryLock} from './effect/share_lock.js';
+import {SystemInfo} from './effect/system.js';
+import {canonicalResourceUri} from './storage/resource-id.js';
+import {uriSegment} from './mcp_server_common.js';
+
+export const CURSOR_CLOUD_MCP_TOOLSET = 'cursor-cloud' as const;
+export const CURSOR_CLOUD_TEAM_ENV = 'THREADNOTE_CURSOR_CLOUD_TEAM';
+export const DEFAULT_CURSOR_CLOUD_IDENTITY = 'cursor-cloud';
+
+export class CursorCloudOperationError extends Error {
+  readonly _tag = 'CursorCloudOperationError' as const;
+}
+
+export interface CursorCloudProfileV1 {
+  readonly account: string;
+  readonly agentId: string;
+  readonly graphMode: 'local-checkout';
+  readonly homeDurability: 'ephemeral';
+  readonly memoryRoot: string;
+  readonly profile: 'shared-read-write';
+  readonly provider: 'cursor-cloud';
+  readonly team: string;
+  readonly user: string;
+  readonly version: 1;
+}
+
+export interface CursorCloudMcpConfig {
+  readonly args: readonly ['-lc', 'exec "$HOME/.local/bin/threadnote" mcp-server'];
+  readonly command: '/bin/sh';
+  readonly env: Readonly<{
+    THREADNOTE_ACCOUNT: string;
+    THREADNOTE_AGENT_ID: string;
+    THREADNOTE_CURSOR_CLOUD_TEAM: string;
+    THREADNOTE_MCP_TOOLSET: typeof CURSOR_CLOUD_MCP_TOOLSET;
+    THREADNOTE_USER: string;
+  }>;
+  readonly type: 'stdio';
+}
+
+export interface CursorCloudMemoryScope {
+  readonly mode: 'shared-read-write';
+  readonly root: string;
+  readonly team: string;
+}
+
+export interface CursorCloudBootstrapOptions {
+  readonly dryRun?: boolean;
+  readonly remote: string;
+  readonly sync?: boolean;
+  readonly team?: string;
+}
+
+export type CursorCloudBootstrapPlan =
+  | {readonly action: 'initialize'; readonly remote: string; readonly team: string}
+  | {readonly action: 'reuse'; readonly remote: string; readonly team: string};
+
+export interface CursorCloudVerifyCheck {
+  readonly detail: string;
+  readonly name: string;
+  readonly status: 'fail' | 'ok' | 'warn';
+}
+
+export interface CursorCloudVerifyReceiptV1 {
+  readonly checks: readonly CursorCloudVerifyCheck[];
+  readonly memoryRoot: string;
+  readonly profile: 'shared-read-write';
+  readonly provider: 'cursor-cloud';
+  readonly status: 'fail' | 'ok';
+  readonly team: string;
+  readonly version: 1;
+}
+
+export function cursorCloudMemoryRoot(user: string, team: string): string {
+  return canonicalResourceUri('user', [uriSegment(user), 'memories', 'shared', normalizeTeamName(team)]);
+}
+
+export function buildCursorCloudProfile(
+  config: Pick<RuntimeConfig, 'account'>,
+  options: {readonly agentId?: string; readonly team?: string; readonly user?: string} = {},
+): CursorCloudProfileV1 {
+  const team = normalizeTeamName(options.team ?? DEFAULT_CURSOR_CLOUD_IDENTITY);
+  const user = requiredIdentity(options.user ?? DEFAULT_CURSOR_CLOUD_IDENTITY, 'user');
+  const agentId = requiredIdentity(options.agentId ?? DEFAULT_CURSOR_CLOUD_IDENTITY, 'agent id');
+  return {
+    account: config.account,
+    agentId,
+    graphMode: 'local-checkout',
+    homeDurability: 'ephemeral',
+    memoryRoot: cursorCloudMemoryRoot(user, team),
+    profile: 'shared-read-write',
+    provider: 'cursor-cloud',
+    team,
+    user,
+    version: 1,
+  };
+}
+
+export function buildCursorCloudMcpConfig(profile: CursorCloudProfileV1): CursorCloudMcpConfig {
+  return {
+    args: ['-lc', 'exec "$HOME/.local/bin/threadnote" mcp-server'],
+    command: '/bin/sh',
+    env: {
+      THREADNOTE_ACCOUNT: profile.account,
+      THREADNOTE_AGENT_ID: profile.agentId,
+      THREADNOTE_CURSOR_CLOUD_TEAM: profile.team,
+      THREADNOTE_MCP_TOOLSET: CURSOR_CLOUD_MCP_TOOLSET,
+      THREADNOTE_USER: profile.user,
+    },
+    type: 'stdio',
+  };
+}
+
+export function cursorCloudRuntimeConfig(
+  config: RuntimeConfig,
+  options: {readonly agentId?: string; readonly user?: string},
+): RuntimeConfig {
+  const profile = buildCursorCloudProfile(config, options);
+  return {...config, agentId: profile.agentId, user: profile.user};
+}
+
+export function credentialFreeGitRemote(remote: string): string {
+  const normalized = remote.trim();
+  const hasForbiddenCharacter = [...normalized].some(character => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return /\s/u.test(character) || codePoint <= 0x1f || codePoint === 0x7f;
+  });
+  if (!normalized || hasForbiddenCharacter) {
+    throw new CursorCloudOperationError('The Cursor Cloud memory remote must be a non-empty URL without whitespace.');
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(normalized)) {
+    let parsed: URL;
+    try {
+      parsed = new URL(normalized);
+    } catch {
+      throw new CursorCloudOperationError('The Cursor Cloud memory remote must be a valid Git URL.');
+    }
+    if (parsed.username || parsed.password) {
+      throw new CursorCloudOperationError(
+        'The Cursor Cloud memory remote must not contain embedded credentials; configure authentication in Cursor or the Git provider.',
+      );
+    }
+  }
+  return normalized;
+}
+
+export function planCursorCloudBootstrap(
+  teamsFile: ShareTeamsFile,
+  requestedRemote: string,
+  requestedTeam = DEFAULT_CURSOR_CLOUD_IDENTITY,
+): CursorCloudBootstrapPlan {
+  const team = normalizeTeamName(requestedTeam);
+  const remote = credentialFreeGitRemote(requestedRemote);
+  const existing = teamsFile.teams[team];
+  if (!existing) return {action: 'initialize', remote, team};
+  assertEquivalentWritableTeam(existing, remote, team);
+  return {action: 'reuse', remote, team};
+}
+
+export const resolveCursorCloudMemoryScope = Effect.fn('cursorCloud.resolveMemoryScope')(function* (
+  config: RuntimeConfig,
+  environment: Readonly<Record<string, string | undefined>>,
+) {
+  const rawTeam = environment[CURSOR_CLOUD_TEAM_ENV]?.trim();
+  if (!rawTeam) {
+    throw new CursorCloudOperationError(
+      `${CURSOR_CLOUD_TEAM_ENV} is required when ${CURSOR_CLOUD_MCP_TOOLSET} is selected.`,
+    );
+  }
+  const team = normalizeTeamName(rawTeam);
+  const teamsFile = yield* readTeamsFile(config);
+  const configured = teamsFile.teams[team];
+  if (!configured) {
+    throw new CursorCloudOperationError(
+      `Cursor Cloud memory team "${team}" is not configured. Run threadnote cloud cursor bootstrap first.`,
+    );
+  }
+  if (shareTeamAccess(configured) !== 'read-write') {
+    throw new CursorCloudOperationError(
+      `Cursor Cloud memory team "${team}" must be read-write before the MCP profile can start.`,
+    );
+  }
+  return {
+    mode: 'shared-read-write',
+    root: cursorCloudMemoryRoot(config.user, team),
+    team,
+  } satisfies CursorCloudMemoryScope;
+});
+
+export const runCursorCloudConfig = Effect.fn('cursorCloud.config')(function* (
+  config: RuntimeConfig,
+  options: {readonly agentId?: string; readonly team?: string; readonly user?: string},
+) {
+  const profile = buildCursorCloudProfile(config, options);
+  yield* Console.log(JSON.stringify(buildCursorCloudMcpConfig(profile), undefined, 2));
+});
+
+export const runCursorCloudBootstrap = Effect.fn('cursorCloud.bootstrap')(function* (
+  config: RuntimeConfig,
+  options: CursorCloudBootstrapOptions,
+) {
+  yield* withSharedRepositoryLock(
+    config,
+    Effect.gen(function* () {
+      const plan = planCursorCloudBootstrap(yield* readTeamsFile(config), options.remote, options.team);
+      if (plan.action === 'initialize') {
+        yield* runShareInit(config, plan.remote, {
+          dryRun: options.dryRun,
+          push: true,
+          readOnly: false,
+          setDefault: true,
+          team: plan.team,
+        });
+      } else {
+        yield* Console.log(`Cursor Cloud memory team "${plan.team}" is already configured read-write; reusing it.`);
+      }
+      if (options.dryRun === true) {
+        yield* Console.log('Dry run complete; the memory share was not changed or synchronized.');
+      } else if (options.sync !== false) {
+        yield* runShareSync(config, {push: true, team: plan.team});
+      }
+      yield* Console.log(`Cursor Cloud memory root: ${cursorCloudMemoryRoot(config.user, plan.team)}/`);
+    }),
+  );
+});
+
+export const runCursorCloudVerify = Effect.fn('cursorCloud.verify')(function* (
+  config: RuntimeConfig,
+  options: {readonly cwd: string; readonly json?: boolean; readonly team?: string},
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const team = normalizeTeamName(options.team ?? DEFAULT_CURSOR_CLOUD_IDENTITY);
+  const memoryRoot = cursorCloudMemoryRoot(config.user, team);
+  const teamsFile = yield* readTeamsFile(config);
+  const configured = teamsFile.teams[team];
+  const checks: CursorCloudVerifyCheck[] = [
+    {
+      detail:
+        system.platform === 'linux' ? 'Linux cloud runtime' : `${system.platform}; production Cursor Cloud uses Linux`,
+      name: 'platform',
+      status: system.platform === 'linux' ? 'ok' : 'warn',
+    },
+    {
+      detail: (yield* fs.exists(config.agentContextHome)) ? 'initialized' : 'missing',
+      name: 'Threadnote home',
+      status: (yield* fs.exists(config.agentContextHome)) ? 'ok' : 'fail',
+    },
+    {
+      detail: configured ? 'configured' : 'missing',
+      name: 'memory team',
+      status: configured ? 'ok' : 'fail',
+    },
+  ];
+  if (configured) checks.push(...(yield* configuredTeamChecks(fs, configured)));
+  const cwdIsAbsolute = path.isAbsolute(options.cwd);
+  const cwdExists = cwdIsAbsolute && (yield* fs.exists(options.cwd));
+  checks.push({
+    detail: cwdExists ? 'absolute checkout path exists' : 'expected an existing absolute checkout path',
+    name: 'local graph checkout',
+    status: cwdExists ? 'ok' : 'fail',
+  });
+  checks.push({detail: memoryRoot, name: 'exclusive memory root', status: 'ok'});
+  const receipt: CursorCloudVerifyReceiptV1 = {
+    checks,
+    memoryRoot,
+    profile: 'shared-read-write',
+    provider: 'cursor-cloud',
+    status: checks.some(check => check.status === 'fail') ? 'fail' : 'ok',
+    team,
+    version: 1,
+  };
+  if (options.json === true) {
+    yield* Console.log(JSON.stringify(receipt));
+  } else {
+    yield* Console.log('Cursor Cloud verification');
+    for (const check of checks) yield* Console.log(`${check.status.toUpperCase()} ${check.name}: ${check.detail}`);
+    yield* Console.log(`Status: ${receipt.status}`);
+  }
+  if (receipt.status === 'fail') {
+    throw new CursorCloudOperationError('Cursor Cloud verification failed; resolve the failed checks above.');
+  }
+});
+
+function requiredIdentity(value: string, label: string): string {
+  const normalized = uriSegment(value.trim());
+  if (!value.trim() || normalized === 'unknown') {
+    throw new CursorCloudOperationError(`Cursor Cloud ${label} must contain a portable identifier.`);
+  }
+  return normalized;
+}
+
+function assertEquivalentWritableTeam(existing: ShareTeamConfig, remote: string, team: string): void {
+  if (existing.remote.trim() !== remote) {
+    throw new CursorCloudOperationError(
+      `Cursor Cloud memory team "${team}" already uses a different remote. Review it with threadnote share status before changing configuration.`,
+    );
+  }
+  if (shareTeamAccess(existing) !== 'read-write') {
+    throw new CursorCloudOperationError(
+      `Cursor Cloud memory team "${team}" is not read-write. Change it explicitly with threadnote share set-access before retrying.`,
+    );
+  }
+}
+
+const configuredTeamChecks = Effect.fn('cursorCloud.configuredTeamChecks')(function* (
+  fs: FileSystem.FileSystem,
+  configured: ShareTeamConfig,
+) {
+  const remoteStatus = yield* Effect.try({
+    try: () => credentialFreeGitRemote(configured.remote),
+    catch: cause => new CursorCloudOperationError('Cursor Cloud Git remote validation failed.', {cause}),
+  }).pipe(
+    Effect.as('ok' as const),
+    Effect.catch(() => Effect.succeed('fail' as const)),
+  );
+  return [
+    {
+      detail: shareTeamAccess(configured),
+      name: 'share access',
+      status: shareTeamAccess(configured) === 'read-write' ? ('ok' as const) : ('fail' as const),
+    },
+    {
+      detail: remoteStatus === 'ok' ? 'credential-free remote' : 'remote contains credentials or is invalid',
+      name: 'Git remote',
+      status: remoteStatus,
+    },
+    {
+      detail: (yield* fs.exists(configured.worktree)) ? 'present' : 'missing',
+      name: 'share worktree',
+      status: (yield* fs.exists(configured.worktree)) ? ('ok' as const) : ('fail' as const),
+    },
+    {
+      detail: (yield* fs.exists(configured.gitdir)) ? 'present' : 'missing',
+      name: 'share gitdir',
+      status: (yield* fs.exists(configured.gitdir)) ? ('ok' as const) : ('fail' as const),
+    },
+  ] satisfies readonly CursorCloudVerifyCheck[];
+});

--- a/src/effect/ai/mcp_resource.ts
+++ b/src/effect/ai/mcp_resource.ts
@@ -1,6 +1,6 @@
 import {Effect} from 'effect';
 import {McpSchema} from 'effect/unstable/ai';
-import {parseResourceId} from '../../storage/resource-id.js';
+import {parseResourceId, resourceIdIsWithin} from '../../storage/resource-id.js';
 import {ResourceStore, type ResourceStoreError} from '../resource-store.js';
 import {MCP_RESOURCE_ERROR_DATA, MCP_RESOURCE_NOT_FOUND_ERROR_DATA} from './mcp.js';
 
@@ -19,6 +19,7 @@ interface McpResourceConfig {
 export function readThreadnoteMcpResource(
   config: McpResourceConfig,
   uri: string,
+  scopeRoot?: string,
 ): Effect.Effect<
   typeof McpSchema.ReadResourceResult.Type,
   McpSchema.InternalError | McpSchema.InvalidParams,
@@ -26,6 +27,12 @@ export function readThreadnoteMcpResource(
 > {
   return Effect.gen(function* () {
     const canonicalUri = yield* canonicalThreadnoteUri(uri);
+    if (scopeRoot && !resourceIdIsWithin(canonicalUri, scopeRoot)) {
+      return yield* new McpSchema.InvalidParams({
+        data: MCP_RESOURCE_ERROR_DATA,
+        message: 'The requested resource is outside the active Cursor Cloud memory scope.',
+      });
+    }
     const store = yield* ResourceStore;
     const location = {account: config.account, home: config.agentContextHome, user: config.user};
     const read = yield* store.readBounded(location, canonicalUri, MCP_RESOURCE_READ_MAX_BYTES);

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -111,6 +111,12 @@ import {
 } from '../code_graph/commands.js';
 import {runProcessDiagnostics} from '../process_diagnostics.js';
 import {runContextBrief} from '../context_brief/commands.js';
+import {
+  cursorCloudRuntimeConfig,
+  runCursorCloudBootstrap,
+  runCursorCloudConfig,
+  runCursorCloudVerify,
+} from '../cursor_cloud.js';
 
 const describeFlag = <A>(flag: Flag.Flag<A>, description: string): Flag.Flag<A> =>
   flag.pipe(Flag.withDescription(description));
@@ -1422,6 +1428,71 @@ const forget = Command.make(
   ({uri, ...options}) => withRuntimeEffect(config => runForget(config, uri, options)),
 ).pipe(Command.withDescription('Remove a threadnote:// URI from local Threadnote context'));
 
+const cursorCloudIdentityFlags = {
+  agentId: defaultString('agent-id', 'Stable agent identity used by Cursor Cloud', 'cursor-cloud'),
+  team: defaultString('team', 'Shared-memory team reserved for Cursor Cloud', 'cursor-cloud'),
+  user: defaultString('user', 'Stable Threadnote user identity used by Cursor Cloud', 'cursor-cloud'),
+} as const;
+
+const cursorCloudConfig = Command.make(
+  'config',
+  {
+    ...cursorCloudIdentityFlags,
+    memoryMode: defaultChoice(
+      'memory-mode',
+      ['shared-read-write'],
+      'Cursor Cloud memory capability profile',
+      'shared-read-write',
+    ),
+  },
+  ({agentId, team, user}) =>
+    withRuntimeEffect(config =>
+      runCursorCloudConfig(cursorCloudRuntimeConfig(config, {agentId, user}), {agentId, team, user}),
+    ),
+).pipe(Command.withDescription('Print a deterministic Cursor Dashboard MCP configuration'));
+
+const cursorCloudBootstrap = Command.make(
+  'bootstrap',
+  {
+    ...cursorCloudIdentityFlags,
+    dryRun: boolean('dry-run', 'Preview configuration without changing or synchronizing the share'),
+    remote: requiredString('remote', 'Credential-free Git URL for the shared memory repository'),
+    sync: negatedBoolean('sync', 'Configure the share without synchronizing it immediately'),
+  },
+  ({agentId, dryRun, remote, sync, team, user}) =>
+    withRuntimeEffect(config =>
+      runCursorCloudBootstrap(cursorCloudRuntimeConfig(config, {agentId, user}), {
+        dryRun,
+        remote,
+        sync,
+        team,
+      }),
+    ),
+).pipe(Command.withDescription('Idempotently prepare an exclusive writable Cursor Cloud memory share'));
+
+const cursorCloudVerify = Command.make(
+  'verify',
+  {
+    ...cursorCloudIdentityFlags,
+    cwd: requiredString('cwd', 'Absolute Cursor Cloud checkout path used for local code-graph inspection'),
+    json: boolean('json', 'Print a machine-readable verification receipt'),
+  },
+  ({agentId, cwd, json, team, user}) =>
+    withRuntimeEffect(config =>
+      runCursorCloudVerify(cursorCloudRuntimeConfig(config, {agentId, user}), {cwd, json, team}),
+    ),
+).pipe(Command.withDescription('Verify the Cursor Cloud runtime, share, and local graph checkout'));
+
+const cursorCloud = Command.make('cursor').pipe(
+  Command.withDescription('Configure Threadnote for Cursor Cloud Agents'),
+  Command.withSubcommands([cursorCloudConfig, cursorCloudBootstrap, cursorCloudVerify]),
+);
+
+const cloud = Command.make('cloud').pipe(
+  Command.withDescription('Cloud-agent integrations'),
+  Command.withSubcommands([cursorCloud]),
+);
+
 const shareInit = Command.make(
   'init',
   {
@@ -1725,6 +1796,7 @@ const topLevelCommandRegistrations = [
   registerTopLevelCommand('handoff', handoff),
   registerTopLevelCommand('archive', archive),
   registerTopLevelCommand('forget', forget),
+  registerTopLevelCommand('cloud', cloud),
   registerTopLevelCommand('share', share, {
     productionLog: {
       subcommands: {

--- a/src/effect/share.ts
+++ b/src/effect/share.ts
@@ -78,13 +78,16 @@ export const monitorSharedRepositories = Effect.fn('share.monitorRepositories')(
     yield* refresh(false);
   }
 });
-export const syncSharedReposBeforeAgentRead = Effect.fn('share.syncBeforeAgentRead')(function* (config: ShareRuntime) {
+export const syncSharedReposBeforeAgentRead = Effect.fn('share.syncBeforeAgentRead')(function* (
+  config: ShareRuntime,
+  team?: string,
+) {
   const observed = yield* observeSharedRepositoryHomeLock(config.agentContextHome);
   if (observed === 'active') {
     markSharedAutoSyncDeferred(config);
     return {syncedTeams: [] as readonly string[], warnings: [] as readonly string[]};
   }
-  const sync = withSharedRepositoryLock(config, syncSharedReposBeforeAgentReadEffect(config), {
+  const sync = withSharedRepositoryLock(config, syncSharedReposBeforeAgentReadEffect(config, team), {
     waitTimeoutMilliseconds: SHARED_REPOSITORY_READ_LOCK_WAIT_TIMEOUT_MILLISECONDS,
   });
   return yield* sync.pipe(

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -1,6 +1,12 @@
 import {Console, Effect} from 'effect';
 import {MCP_PROCESS_LIFECYCLE_PROBE_ENV} from './constants.js';
-import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset, parseMcpToolset} from './mcp_toolset.js';
+import {
+  DEFAULT_MCP_TOOLSET,
+  MCP_TOOLSET_ENV,
+  type McpToolset,
+  mcpToolCapabilities,
+  parseMcpToolset,
+} from './mcp_toolset.js';
 import {currentPackageVersion} from './utils.js';
 import {getRuntimeConfig as getApplicationRuntimeConfig} from './runtime.js';
 import {EffectMcpServerAdapter, McpInput, mcpProgressHeartbeatMilliseconds} from './effect/ai/mcp.js';
@@ -15,6 +21,7 @@ import {captureConsole} from './effect/console.js';
 import {monitorSharedRepositories} from './effect/share.js';
 import {runObsidianProjectionPublish} from './obsidian_projection.js';
 import {withProductionLogging} from './effect/production_log.js';
+import {resolveCursorCloudMemoryScope, type CursorCloudMemoryScope} from './cursor_cloud.js';
 import {
   McpServerOperationError,
   type RecallProgressTiming,
@@ -86,9 +93,12 @@ export const mcpServerEffect = Effect.gen(function* () {
         heartbeatMilliseconds: mcpProgressHeartbeatMilliseconds(system.environment()),
         sharedSyncDelayMilliseconds: mcpProgressTestSharedSyncDelayMilliseconds(system.environment()),
       };
+      const memoryScope =
+        toolset === 'cursor-cloud' ? yield* resolveCursorCloudMemoryScope(config, system.environment()) : undefined;
       setMcpStartupVersion(yield* currentPackageVersion().pipe(Effect.catch(() => Effect.succeed(undefined))));
-      const instructions =
-        'Call `recall_context` with project and absolute `callerCwd`; read `threadnote://` URIs. Use `inspect_code_graph` before broad `rg`/grep; round-trip `cgs_` IDs via `node`, `neighbors`, or `path`. Use `analyze_code_graph` for whole-repo stats, communities, hubs, and surprises. Retry `state=indexing` after `retryAfterMilliseconds`; exact text search remains useful meanwhile. Write durable knowledge and handoffs directly under stable project/topic; replace duplicates. Use `review_session_context` for additional user-approved candidates. Do not store secrets/customer data/raw logs. Confirm publishes; never publish handoffs/preferences.';
+      const instructions = memoryScope
+        ? `Cursor Cloud uses the exclusive shared memory scope ${memoryScope.root}. Call recall_context with an absolute callerCwd, then read returned threadnote:// URIs. Store durable memories with remember_context; writes are committed and pushed to the configured share. Memory tools reject any URI outside that scope. Use inspect_code_graph and analyze_code_graph only for the local checkout; worksets are disabled. Full cloud integration is still in development.`
+        : 'Call `recall_context` with project and absolute `callerCwd`; read `threadnote://` URIs. Use `inspect_code_graph` before broad `rg`/grep; round-trip `cgs_` IDs via `node`, `neighbors`, or `path`. Use `analyze_code_graph` for whole-repo stats, communities, hubs, and surprises. Retry `state=indexing` after `retryAfterMilliseconds`; exact text search remains useful meanwhile. Write durable knowledge and handoffs directly under stable project/topic; replace duplicates. Use `review_session_context` for additional user-approved candidates. Do not store secrets/customer data/raw logs. Confirm publishes; never publish handoffs/preferences.';
       const server = new EffectMcpServerAdapter(
         'threadnote-local-adapter',
         '0.2.0',
@@ -96,22 +106,26 @@ export const mcpServerEffect = Effect.gen(function* () {
         config.agentContextHome,
       );
 
-      registerResources(server, config);
-      registerTools(server, config, toolset, recallProgressTiming);
+      registerResources(server, config, memoryScope);
+      registerTools(server, config, toolset, recallProgressTiming, memoryScope);
       // Packaged lifecycle coverage uses runtime diagnostics to create the real
       // crash-isolated child without requiring an installed or selected model.
       if (system.environment()[MCP_PROCESS_LIFECYCLE_PROBE_ENV] === '1') {
         const runtime = yield* LocalModelRuntime;
         yield* runtime.diagnostics.pipe(Effect.catch(() => Effect.void));
       }
-      yield* Effect.forkScoped(monitorSharedRepositories(config));
+      if (!memoryScope) yield* Effect.forkScoped(monitorSharedRepositories(config));
       yield* Console.error('Threadnote local MCP adapter running');
       return yield* server.run();
     }),
   );
 });
 
-function registerResources(server: EffectMcpServerAdapter, config: RuntimeConfig): void {
+function registerResources(
+  server: EffectMcpServerAdapter,
+  config: RuntimeConfig,
+  memoryScope?: CursorCloudMemoryScope,
+): void {
   server.registerResourceTemplate(
     {
       description:
@@ -125,7 +139,7 @@ function registerResources(server: EffectMcpServerAdapter, config: RuntimeConfig
       routerPath: '*',
       uriTemplate: 'threadnote://{+resourcePath}',
     },
-    uri => readThreadnoteMcpResource(config, uri),
+    uri => readThreadnoteMcpResource(config, uri, memoryScope?.root),
   );
 }
 
@@ -138,13 +152,16 @@ function registerTools(
   config: RuntimeConfig,
   toolset: McpToolset,
   recallProgressTiming: RecallProgressTiming,
+  memoryScope?: CursorCloudMemoryScope,
 ): void {
+  const capabilities = mcpToolCapabilities(toolset);
   registerSearchTool(
     server,
     config,
     'recall_context',
     'Search memories and seeded project guidance. Pass a stable project and absolute callerCwd for current repo/branch. Returns threadnote:// pointers to read or list. Lower threshold if results are sparse.',
     recallProgressTiming,
+    memoryScope,
   );
   if (toolset === 'full') {
     registerSearchTool(
@@ -156,88 +173,99 @@ function registerTools(
     );
   }
 
-  registerCodeGraphTool(server, config);
-  registerContextBriefTool(server, config);
+  registerCodeGraphTool(server, config, {allowWorkset: capabilities.graphWorkset});
+  if (capabilities.contextBrief) registerContextBriefTool(server, config);
 
   registerReadTool(
     server,
     config,
     'read_context',
     'Read a threadnote:// file URI returned by recall_context or list_context.',
+    memoryScope,
   );
   if (toolset === 'full') {
     registerReadTool(server, config, 'read', 'Compatibility alias for read_context.');
   }
 
-  registerListTool(server, config, 'list_context', 'List a threadnote:// directory returned by recall_context.');
+  registerListTool(
+    server,
+    config,
+    'list_context',
+    'List a threadnote:// directory returned by recall_context.',
+    memoryScope,
+  );
   if (toolset === 'full') {
     registerListTool(server, config, 'list', 'Compatibility alias for list_context.');
   }
 
-  registerStoreTool(
-    server,
-    config,
-    'remember_context',
-    'Store a durable Threadnote memory. Required: pass JSON arguments with text.',
-  );
+  if (capabilities.memoryWrite) {
+    registerStoreTool(
+      server,
+      config,
+      'remember_context',
+      'Store a durable Threadnote memory. Required: pass JSON arguments with text.',
+      memoryScope,
+    );
+  }
   if (toolset === 'full') {
     registerStoreTool(server, config, 'store', 'Compatibility alias for remember_context.');
   }
 
-  registerCandidateMemoryTools(server, config);
+  if (capabilities.memoryReview) registerCandidateMemoryTools(server, config);
 
-  server.registerTool(
-    'obsidian_publish',
-    {
-      annotations: {readOnlyHint: false, destructiveHint: true, idempotentHint: true},
-      description:
-        'Preview or publish explicitly selected Threadnote memory URIs to a configured Obsidian projection. Preview is the default; set apply=true only after the user selects the memories and destination projection.',
-      inputSchema: {
-        apply: McpInput.boolean('Write the selected memories and persist their projection selection'),
-        force: McpInput.boolean('Regenerate edited files already managed by this projection'),
-        projection: McpInput.string('Required configured Obsidian projection identifier'),
-        uri: McpInput.stringOrStrings('Required canonical Threadnote memory URI or list of URIs'),
-        uris: McpInput.stringOrStrings('Compatibility alias for uri'),
+  if (capabilities.memoryPublish)
+    server.registerTool(
+      'obsidian_publish',
+      {
+        annotations: {readOnlyHint: false, destructiveHint: true, idempotentHint: true},
+        description:
+          'Preview or publish explicitly selected Threadnote memory URIs to a configured Obsidian projection. Preview is the default; set apply=true only after the user selects the memories and destination projection.',
+        inputSchema: {
+          apply: McpInput.boolean('Write the selected memories and persist their projection selection'),
+          force: McpInput.boolean('Regenerate edited files already managed by this projection'),
+          projection: McpInput.string('Required configured Obsidian projection identifier'),
+          uri: McpInput.stringOrStrings('Required canonical Threadnote memory URI or list of URIs'),
+          uris: McpInput.stringOrStrings('Compatibility alias for uri'),
+        },
       },
-    },
-    ({apply, force, projection, uri, uris}) => {
-      const checkedProjection = requiredText(projection, 'obsidian_publish', 'projection', {
-        projection: 'engineering-memory',
-        uri: 'threadnote://user/example/memories/durable/projects/threadnote/obsidian.md',
-      });
-      if (!checkedProjection.ok) {
-        return checkedProjection.error;
-      }
-      const checkedUris = requiredResourceUriList(
-        uris ?? uri,
-        'obsidian_publish',
-        'threadnote://user/example/memories/durable/projects/threadnote/obsidian.md',
-      );
-      if (!checkedUris.ok) {
-        return checkedUris.error;
-      }
-      return captureConsole(
-        runObsidianProjectionPublish(config, {
-          apply,
-          force,
-          id: checkedProjection.value,
-          uris: checkedUris.value,
-        }),
-      ).pipe(
-        Effect.map(({output, value}) => ({
-          content: [{type: 'text' as const, text: output}],
-          structuredContent: {
-            applied: apply === true,
-            entries: value,
-            projection: checkedProjection.value,
+      ({apply, force, projection, uri, uris}) => {
+        const checkedProjection = requiredText(projection, 'obsidian_publish', 'projection', {
+          projection: 'engineering-memory',
+          uri: 'threadnote://user/example/memories/durable/projects/threadnote/obsidian.md',
+        });
+        if (!checkedProjection.ok) {
+          return checkedProjection.error;
+        }
+        const checkedUris = requiredResourceUriList(
+          uris ?? uri,
+          'obsidian_publish',
+          'threadnote://user/example/memories/durable/projects/threadnote/obsidian.md',
+        );
+        if (!checkedUris.ok) {
+          return checkedUris.error;
+        }
+        return captureConsole(
+          runObsidianProjectionPublish(config, {
+            apply,
+            force,
+            id: checkedProjection.value,
             uris: checkedUris.value,
-          },
-        })),
-      );
-    },
-  );
+          }),
+        ).pipe(
+          Effect.map(({output, value}) => ({
+            content: [{type: 'text' as const, text: output}],
+            structuredContent: {
+              applied: apply === true,
+              entries: value,
+              projection: checkedProjection.value,
+              uris: checkedUris.value,
+            },
+          })),
+        );
+      },
+    );
 
-  if (toolset === 'full') {
+  if (capabilities.maintenance) {
     registerArchiveTool(
       server,
       config,
@@ -262,39 +290,40 @@ function registerTools(
     }),
   );
 
-  server.registerTool(
-    'share_publish',
-    {
-      annotations: {readOnlyHint: false, destructiveHint: true},
-      description:
-        'Publish a personal durable memory to the team shared repo. Scans for sensitive data, optionally redacts soft leaks, writes and pushes the shared copy first, then removes the original. Confirm with the user; never publish handoffs or preferences. Use preview to inspect without writing.',
-      inputSchema: {
-        message: McpInput.string('Commit message override; defaults to "share: publish <path>"'),
-        preview: McpInput.boolean(
-          'Return the bytes that would land in the shared git repo (after frontmatter strip and redaction) without writing or committing. Use this to inspect the body before publishing.',
-        ),
-        push: McpInput.boolean('Push to remote after committing; defaults to true'),
-        redact: McpInput.boolean(
-          'Replace soft-leak matches (local paths) with placeholders and continue; credentials still block.',
-        ),
-        team: McpInput.string('Team name; defaults to the configured default team'),
-        uri: McpInput.string('Required threadnote:// memory URI to publish'),
+  if (capabilities.memoryPublish)
+    server.registerTool(
+      'share_publish',
+      {
+        annotations: {readOnlyHint: false, destructiveHint: true},
+        description:
+          'Publish a personal durable memory to the team shared repo. Scans for sensitive data, optionally redacts soft leaks, writes and pushes the shared copy first, then removes the original. Confirm with the user; never publish handoffs or preferences. Use preview to inspect without writing.',
+        inputSchema: {
+          message: McpInput.string('Commit message override; defaults to "share: publish <path>"'),
+          preview: McpInput.boolean(
+            'Return the bytes that would land in the shared git repo (after frontmatter strip and redaction) without writing or committing. Use this to inspect the body before publishing.',
+          ),
+          push: McpInput.boolean('Push to remote after committing; defaults to true'),
+          redact: McpInput.boolean(
+            'Replace soft-leak matches (local paths) with placeholders and continue; credentials still block.',
+          ),
+          team: McpInput.string('Team name; defaults to the configured default team'),
+          uri: McpInput.string('Required threadnote:// memory URI to publish'),
+        },
       },
-    },
-    ({message, preview, push, redact, team, uri}) => {
-      const checkedUri = requiredResourceUri(
-        uri,
-        'share_publish',
-        'threadnote://user/example/memories/durable/projects/foo/bar.md',
-      );
-      if (!checkedUri.ok) {
-        return checkedUri.error;
-      }
-      return runSharePublishTool(config, checkedUri.value, {message, preview, push, redact, team});
-    },
-  );
+      ({message, preview, push, redact, team, uri}) => {
+        const checkedUri = requiredResourceUri(
+          uri,
+          'share_publish',
+          'threadnote://user/example/memories/durable/projects/foo/bar.md',
+        );
+        if (!checkedUri.ok) {
+          return checkedUri.error;
+        }
+        return runSharePublishTool(config, checkedUri.value, {message, preview, push, redact, team});
+      },
+    );
 
-  if (toolset === 'core') {
+  if (!capabilities.maintenance) {
     return;
   }
 

--- a/src/mcp_server_code_graph.ts
+++ b/src/mcp_server_code_graph.ts
@@ -121,7 +121,11 @@ export function registerContextBriefTool(server: EffectMcpServerAdapter, config:
   );
 }
 
-export function registerCodeGraphTool(server: EffectMcpServerAdapter, config: RuntimeConfig): void {
+export function registerCodeGraphTool(
+  server: EffectMcpServerAdapter,
+  config: RuntimeConfig,
+  options: {readonly allowWorkset?: boolean} = {},
+): void {
   server.registerTool(
     'inspect_code_graph',
     {
@@ -207,6 +211,14 @@ export function registerCodeGraphTool(server: EffectMcpServerAdapter, config: Ru
         }
         if (packageName?.trim() && operation !== 'query') {
           return argumentError('inspect_code_graph package is valid only for operation=query.');
+        }
+        if (
+          options.allowWorkset === false &&
+          (workset?.trim() || cursor?.trim() || budgetTokens !== undefined || operation === 'topology')
+        ) {
+          return argumentError(
+            'inspect_code_graph workset operations are unavailable in the Cursor Cloud profile; inspect the local checkout with callerCwd.',
+          );
         }
         if (workset?.trim() && !['query', 'path', 'impact', 'topology'].includes(operation)) {
           return argumentError('inspect_code_graph workset is valid for query, path, impact, and topology.');

--- a/src/mcp_server_memory.ts
+++ b/src/mcp_server_memory.ts
@@ -10,6 +10,7 @@ import {
 } from './memory_hygiene.js';
 import {
   ensureSharedDirectoryChain,
+  assertShareTeamWritable,
   assertSharedWorktreeFileReady,
   isInSharedNamespace,
   publishShareGitChange,
@@ -19,6 +20,8 @@ import {
   sharedTeamNameForUri,
   stripPersonalProvenance,
   resourceUriToWorktreeRelative,
+  setMemoryVisibility,
+  sharedUriFor,
   writeMemoryFile,
   writeSharedWorktreeFile,
 } from './share.js';
@@ -29,7 +32,13 @@ import {withMemoryUriLocks} from './effect/memory_lock.js';
 import {withSharedRepositoryLock} from './effect/share_lock.js';
 import {ResourceStore, type ResourceStoreMutation} from './effect/resource-store.js';
 import {canonicalMemoryDocumentContent, formatMemoryDocument, type MemoryMetadata} from './memory_document.js';
-import {canonicalResourceUri, parseResourceId, resourceIdWithoutAnchor} from './storage/resource-id.js';
+import {
+  canonicalResourceUri,
+  parseResourceId,
+  resourceIdIsWithin,
+  resourceIdWithoutAnchor,
+} from './storage/resource-id.js';
+import type {CursorCloudMemoryScope} from './cursor_cloud.js';
 import {
   McpServerOperationError,
   type RuntimeConfig,
@@ -384,6 +393,102 @@ export function writeDurableMemory(config: RuntimeConfig, params: WriteDurableMe
       ? withSharedRepositoryLock(config, write)
       : write;
   return serializedWrite.pipe(
+    Effect.catch(error =>
+      Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
+    ),
+    Effect.map(result => result as CallToolResult),
+  );
+}
+
+export function writeCursorCloudSharedMemory(
+  config: RuntimeConfig,
+  scope: CursorCloudMemoryScope,
+  params: WriteDurableMemoryParams,
+) {
+  const write = withSharedRepositoryLock(
+    config,
+    Effect.gen(function* () {
+      if (params.metadata.kind !== 'durable') {
+        return argumentError('Cursor Cloud shared memory writes support durable memories only.');
+      }
+      const prepared = yield* preparePersonalMemoryWrite(config, params);
+      const targetUri = params.replaceUri ?? sharedUriFor(config, prepared.memoryUri, scope.team);
+      if (!resourceIdIsWithin(targetUri, scope.root)) {
+        return argumentError(`Cursor Cloud durable memory writes must stay within ${scope.root}.`);
+      }
+      const resolved = yield* resolveTeam(config, scope.team);
+      assertShareTeamWritable(resolved, 'write Cursor Cloud memories');
+      const fs = yield* FileSystem.FileSystem;
+      return yield* withMemoryUriLocks(
+        fs,
+        config.agentContextHome,
+        [targetUri],
+        Effect.gen(function* () {
+          const [existingTarget] = yield* readMemoryRecordsByUri(config, [targetUri]);
+          if (params.replaceUri && !existingTarget) {
+            return argumentError(`Shared memory ${targetUri} no longer exists.`);
+          }
+          const metadata: MemoryMetadata = {
+            ...prepared.finalMetadata,
+            createdAt:
+              existingTarget?.metadata.createdAt ??
+              existingTarget?.metadata.timestamp ??
+              prepared.finalMetadata.createdAt,
+            memoryId: existingTarget?.metadata.memoryId ?? prepared.finalMetadata.memoryId,
+            supersedes: undefined,
+            visibility: 'shared',
+          };
+          const rawMemory = setMemoryVisibility(formatMemoryDocument('MEMORY', metadata, params.bodyText), 'shared');
+          const scrub = applyScrubber(rawMemory, {redact: false});
+          if (scrub.blocker) {
+            return argumentError(
+              `Refusing to write shared memory ${targetUri}: possible ${scrub.blocker}. Strip the sensitive value first.`,
+            );
+          }
+          const relativePath = resourceUriToWorktreeRelative(config, targetUri, resolved.name);
+          yield* assertSharedWorktreeFileReady(resolved.config.worktree, relativePath, existingTarget?.content);
+          yield* ensureSharedDirectoryChain(config, 'threadnote-native', targetUri, false, {quiet: true});
+          yield* writeMemoryFile(
+            config,
+            'threadnote-native',
+            targetUri,
+            scrub.cleaned,
+            existingTarget ? 'replace' : 'create',
+            false,
+            {quiet: true},
+          );
+          const [storedTarget] = yield* readMemoryRecordsByUri(config, [targetUri]);
+          if (
+            !storedTarget ||
+            canonicalMemoryDocumentContent(storedTarget.content) !== canonicalMemoryDocumentContent(scrub.cleaned)
+          ) {
+            return argumentError(`Shared memory verification failed after writing ${targetUri}.`);
+          }
+          yield* writeSharedWorktreeFile(resolved.config.worktree, relativePath, scrub.cleaned);
+          const gitMessages = yield* publishShareGitChange(
+            resolved.config.worktree,
+            relativePath,
+            `cloud: ${existingTarget ? 'update' : 'store'} ${relativePath}`,
+          );
+          const messages = [`${existingTarget ? 'Updated' : 'Stored'} shared memory: ${targetUri}`, ...gitMessages];
+          return {
+            _meta: {
+              'threadnote.io/memory-scope': {
+                mode: scope.mode,
+                root: scope.root,
+                team: scope.team,
+                type: 'threadnote-memory-scope',
+                version: 1,
+              },
+            },
+            content: [{type: 'text' as const, text: messages.join('\n')}],
+            structuredContent: {memoryUri: targetUri, persistence: 'shared-git-pushed'},
+          } satisfies CallToolResult;
+        }),
+      );
+    }),
+  );
+  return write.pipe(
     Effect.catch(error =>
       Effect.succeed({content: [{type: 'text' as const, text: errorMessage(error)}], isError: true}),
     ),

--- a/src/mcp_server_recall.ts
+++ b/src/mcp_server_recall.ts
@@ -60,6 +60,8 @@ import {
   withCandidateReviewLock,
 } from './candidate_memory.js';
 import {recordRecallFeedback} from './recall/feedback.js';
+import type {CursorCloudMemoryScope} from './cursor_cloud.js';
+import {resourceIdIsWithin} from './storage/resource-id.js';
 import {loadRecallExactMatches} from './recall/index.js';
 import {RECALL_RANKER_VERSION} from './recall/rank.js';
 import {syncObsidianSourcesBeforeRecall} from './obsidian_source.js';
@@ -104,6 +106,7 @@ import {
   runNativeReadTool,
   textFromCallToolResult,
   writeDurableMemory,
+  writeCursorCloudSharedMemory,
 } from './mcp_server_memory.js';
 export function registerCandidateMemoryTools(server: EffectMcpServerAdapter, config: RuntimeConfig): void {
   server.registerTool(
@@ -631,6 +634,7 @@ export function registerSearchTool(
   name: string,
   description: string,
   progressTiming: RecallProgressTiming,
+  memoryScope?: CursorCloudMemoryScope,
 ): void {
   server.registerTool(
     name,
@@ -664,13 +668,20 @@ export function registerSearchTool(
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
+      if (workset?.trim() && memoryScope) {
+        return argumentError(`${name} does not allow worksets in the Cursor Cloud profile.`);
+      }
+      const scopedUri = checkedUri.value ?? memoryScope?.root;
+      if (scopedUri && memoryScope && !resourceIdIsWithin(scopedUri, memoryScope.root)) {
+        return argumentError(`${name} uri must stay within ${memoryScope.root}.`);
+      }
       return runRecallTool(
         config,
         {
           callerCwd,
           project: project?.trim() || undefined,
           query: checkedQuery.value,
-          pinnedUri: checkedUri.value,
+          pinnedUri: scopedUri,
           nodeLimit,
           includeArchived: includeArchived === true,
           threshold: threshold === undefined ? undefined : String(threshold),
@@ -678,6 +689,7 @@ export function registerSearchTool(
         },
         progress,
         progressTiming,
+        memoryScope,
       ).pipe(
         Effect.flatMap(withStaleVersionNotice),
         Effect.catch(error =>
@@ -712,6 +724,7 @@ function runRecallTool(
   params: RecallToolParams,
   progress: McpToolProgress,
   progressTiming: RecallProgressTiming,
+  memoryScope?: CursorCloudMemoryScope,
 ) {
   return Effect.gen(function* () {
     const syncWarnings: string[] = [];
@@ -721,9 +734,9 @@ function runRecallTool(
       withProductionPhaseTiming(
         'recall.shared-sync',
         progressTiming.sharedSyncDelayMilliseconds === 0
-          ? syncSharedReposBeforeAgentRead(config)
+          ? syncSharedReposBeforeAgentRead(config, memoryScope?.team)
           : Effect.sleep(progressTiming.sharedSyncDelayMilliseconds).pipe(
-              Effect.andThen(syncSharedReposBeforeAgentRead(config)),
+              Effect.andThen(syncSharedReposBeforeAgentRead(config, memoryScope?.team)),
             ),
       ),
       progressTiming.heartbeatMilliseconds,
@@ -738,21 +751,23 @@ function runRecallTool(
       }),
     );
     const obsidianSyncWarnings: string[] = [];
-    const syncedObsidianSources = yield* withMcpProgressHeartbeat(
-      progress,
-      RECALL_MCP_PROGRESS.obsidianSync,
-      withProductionPhaseTiming('recall.obsidian-sync', syncObsidianSourcesBeforeRecall(config)),
-      progressTiming.heartbeatMilliseconds,
-    ).pipe(
-      Effect.map(syncResult => {
-        obsidianSyncWarnings.push(...syncResult.warnings);
-        return syncResult.syncedSources;
-      }),
-      Effect.catch(error => {
-        obsidianSyncWarnings.push(`Obsidian source refresh failed: ${errorMessage(error)}`);
-        return Effect.succeed([] as readonly string[]);
-      }),
-    );
+    const syncedObsidianSources = memoryScope
+      ? []
+      : yield* withMcpProgressHeartbeat(
+          progress,
+          RECALL_MCP_PROGRESS.obsidianSync,
+          withProductionPhaseTiming('recall.obsidian-sync', syncObsidianSourcesBeforeRecall(config)),
+          progressTiming.heartbeatMilliseconds,
+        ).pipe(
+          Effect.map(syncResult => {
+            obsidianSyncWarnings.push(...syncResult.warnings);
+            return syncResult.syncedSources;
+          }),
+          Effect.catch(error => {
+            obsidianSyncWarnings.push(`Obsidian source refresh failed: ${errorMessage(error)}`);
+            return Effect.succeed([] as readonly string[]);
+          }),
+        );
     yield* progress.report(RECALL_MCP_PROGRESS.workspaceContext);
     const query = yield* enrichRecallQueryWithWorkspaceContext(params.query, {
       cwd: params.callerCwd,
@@ -998,12 +1013,18 @@ function runRecallTool(
       sections.push(`Auto-sync warning: ${warning}`);
     }
     if (sections.length === 0) {
-      return {content: [{type: 'text' as const, text: 'No recall results found.'}]};
+      return {
+        content: [{type: 'text' as const, text: 'No recall results found.'}],
+        ...(memoryScope
+          ? {structuredContent: {memoryScope: cursorCloudMemoryScopeReceipt(memoryScope), results: []}}
+          : {}),
+      };
     }
     return {
       content: [{type: 'text' as const, text: sections.join('\n\n')}],
       structuredContent: {
         confidence: recallSections.confidence,
+        ...(memoryScope ? {memoryScope: cursorCloudMemoryScopeReceipt(memoryScope)} : {}),
         queryExpansions: expansionQueries,
         rankerVersion: RECALL_RANKER_VERSION,
         results: recallSections.ranked.slice(0, params.nodeLimit ?? 12).map(hit => ({
@@ -1082,6 +1103,7 @@ export function registerReadTool(
   config: RuntimeConfig,
   name: string,
   description: string,
+  memoryScope?: CursorCloudMemoryScope,
 ): void {
   server.registerTool(
     name,
@@ -1100,9 +1122,15 @@ export function registerReadTool(
       if (!checkedUris.ok) {
         return checkedUris.error;
       }
+      const outsideScope = memoryScope
+        ? checkedUris.value.find(uri => !resourceIdIsWithin(uri, memoryScope.root))
+        : undefined;
+      if (outsideScope) {
+        return argumentError(`${name} uri must stay within ${memoryScope!.root}.`);
+      }
       return Effect.gen(function* () {
         const syncWarnings: string[] = [];
-        const syncedTeams = yield* syncSharedReposBeforeAgentRead(config).pipe(
+        const syncedTeams = yield* syncSharedReposBeforeAgentRead(config, memoryScope?.team).pipe(
           Effect.map(result => {
             syncWarnings.push(...result.warnings);
             return result.syncedTeams;
@@ -1113,16 +1141,25 @@ export function registerReadTool(
           }),
         );
         const result = yield* runNativeReadTool(config, checkedUris.value);
+        const scopedResult = memoryScope
+          ? {
+              ...result,
+              _meta: {
+                ...result._meta,
+                'threadnote.io/memory-scope': cursorCloudMemoryScopeReceipt(memoryScope),
+              },
+            }
+          : result;
         if (result.isError === true || (syncedTeams.length === 0 && syncWarnings.length === 0)) {
-          return result;
+          return scopedResult;
         }
         const syncMessages = [
           syncedTeams.length > 0 ? `Auto-synced shared memories: ${syncedTeams.join(', ')}` : undefined,
           ...syncWarnings.map(warning => `Auto-sync warning: ${warning}`),
         ].filter((part): part is string => part !== undefined);
         return {
-          ...result,
-          content: [...result.content, {type: 'text', text: syncMessages.join('\n')}],
+          ...scopedResult,
+          content: [...scopedResult.content, {type: 'text', text: syncMessages.join('\n')}],
         };
       });
     },
@@ -1134,6 +1171,7 @@ export function registerListTool(
   config: RuntimeConfig,
   name: string,
   description: string,
+  memoryScope?: CursorCloudMemoryScope,
 ): void {
   server.registerTool(
     name,
@@ -1154,15 +1192,33 @@ export function registerListTool(
       if (!checkedUri.ok) {
         return checkedUri.error;
       }
-      return yield* runNativeListTool(config, {
+      const scopedUri = checkedUri.value ?? memoryScope?.root ?? 'threadnote://';
+      if (memoryScope && !resourceIdIsWithin(scopedUri, memoryScope.root)) {
+        return argumentError(`${name} uri must stay within ${memoryScope.root}.`);
+      }
+      yield* syncSharedReposBeforeAgentRead(config, memoryScope?.team).pipe(Effect.catch(() => Effect.void));
+      const result = yield* runNativeListTool(config, {
         all,
         nodeLimit: nodeLimit ?? node_limit,
         recursive,
         simple,
-        uri: checkedUri.value ?? 'threadnote://',
+        uri: scopedUri,
       });
+      return memoryScope && result.structuredContent
+        ? {
+            ...result,
+            structuredContent: {
+              ...result.structuredContent,
+              memoryScope: cursorCloudMemoryScopeReceipt(memoryScope),
+            },
+          }
+        : result;
     }),
   );
+}
+
+function cursorCloudMemoryScopeReceipt(scope: CursorCloudMemoryScope) {
+  return {mode: scope.mode, root: scope.root, team: scope.team, type: 'threadnote-memory-scope', version: 1} as const;
 }
 
 export function registerStoreTool(
@@ -1170,6 +1226,7 @@ export function registerStoreTool(
   config: RuntimeConfig,
   name: string,
   description: string,
+  memoryScope?: CursorCloudMemoryScope,
 ): void {
   server.registerTool(
     name,
@@ -1207,8 +1264,37 @@ export function registerStoreTool(
       if (!checkedReferences.ok) {
         return checkedReferences.error;
       }
+      const memoryKind = kind ?? 'durable';
+      if (memoryScope && memoryKind !== 'durable' && memoryKind !== 'handoff') {
+        return argumentError(
+          `${name} supports durable shared memories and transient local handoffs in the Cursor Cloud profile.`,
+        );
+      }
+      if (memoryScope) {
+        const outsideReference = checkedReferences.value?.find(
+          reference => !resourceIdIsWithin(reference, memoryScope.root),
+        );
+        if (outsideReference) {
+          return argumentError(`${name} references must stay within ${memoryScope.root}.`);
+        }
+        if (
+          memoryKind === 'durable' &&
+          checkedReplaceUri.value &&
+          !resourceIdIsWithin(checkedReplaceUri.value, memoryScope.root)
+        ) {
+          return argumentError(`${name} replaceUri must stay within ${memoryScope.root}.`);
+        }
+        const handoffRoot = `threadnote://user/${uriSegment(config.user)}/memories/handoffs`;
+        if (
+          memoryKind === 'handoff' &&
+          checkedReplaceUri.value &&
+          !resourceIdIsWithin(checkedReplaceUri.value, handoffRoot)
+        ) {
+          return argumentError(`${name} local handoff replaceUri must stay within ${handoffRoot}.`);
+        }
+      }
       const metadata: MemoryMetadata = {
-        kind: kind ?? 'durable',
+        kind: memoryKind,
         project: normalizeOptionalMetadata(project),
         references: checkedReferences.value,
         sourceAgentClient: sourceAgentClient ?? 'mcp',
@@ -1217,8 +1303,15 @@ export function registerStoreTool(
         topic: normalizeOptionalMetadata(topic),
       };
       return Effect.gen(function* () {
+        if (memoryScope && memoryKind === 'durable') {
+          return yield* writeCursorCloudSharedMemory(config, memoryScope, {
+            bodyText: checkedText.value,
+            metadata,
+            replaceUri: checkedReplaceUri.value,
+          });
+        }
         const enrichedMetadata =
-          checkedReplaceUri.value && isInSharedNamespace(config, checkedReplaceUri.value)
+          memoryScope || (checkedReplaceUri.value && isInSharedNamespace(config, checkedReplaceUri.value))
             ? metadata
             : yield* enrichMemoryMetadataWithConfiguredLocalAi(config, metadata, checkedText.value).pipe(
                 Effect.catch(error =>
@@ -1227,11 +1320,25 @@ export function registerStoreTool(
                   ).pipe(Effect.as(metadata)),
                 ),
               );
-        return yield* writeDurableMemory(config, {
+        const result = yield* writeDurableMemory(config, {
           bodyText: checkedText.value,
           metadata: enrichedMetadata,
           replaceUri: checkedReplaceUri.value,
         });
+        return memoryScope && memoryKind === 'handoff'
+          ? {
+              ...result,
+              _meta: {
+                ...result._meta,
+                'threadnote.io/persistence': {
+                  durability: 'cloud-workspace-local',
+                  note: 'This handoff may not survive a new Cursor Cloud session.',
+                  type: 'threadnote-cloud-persistence',
+                  version: 1,
+                },
+              },
+            }
+          : result;
       }).pipe(Effect.flatMap(withStaleVersionNotice));
     },
   );

--- a/src/mcp_toolset.ts
+++ b/src/mcp_toolset.ts
@@ -1,11 +1,59 @@
 export const DEFAULT_MCP_TOOLSET = 'core';
 export const MCP_TOOLSET_ENV = 'THREADNOTE_MCP_TOOLSET';
 
-export type McpToolset = 'core' | 'full';
+export type McpToolset = 'core' | 'cursor-cloud' | 'full';
+
+export interface McpToolCapabilities {
+  readonly contextBrief: boolean;
+  readonly graphLocal: boolean;
+  readonly graphWorkset: boolean;
+  readonly maintenance: boolean;
+  readonly memoryPublish: boolean;
+  readonly memoryRead: boolean;
+  readonly memoryReview: boolean;
+  readonly memoryWrite: boolean;
+}
+
+const TOOLSET_CAPABILITIES = {
+  core: {
+    contextBrief: true,
+    graphLocal: true,
+    graphWorkset: true,
+    maintenance: false,
+    memoryPublish: true,
+    memoryRead: true,
+    memoryReview: true,
+    memoryWrite: true,
+  },
+  'cursor-cloud': {
+    contextBrief: false,
+    graphLocal: true,
+    graphWorkset: false,
+    maintenance: false,
+    memoryPublish: false,
+    memoryRead: true,
+    memoryReview: false,
+    memoryWrite: true,
+  },
+  full: {
+    contextBrief: true,
+    graphLocal: true,
+    graphWorkset: true,
+    maintenance: true,
+    memoryPublish: true,
+    memoryRead: true,
+    memoryReview: true,
+    memoryWrite: true,
+  },
+} as const satisfies Record<McpToolset, McpToolCapabilities>;
 
 export function parseMcpToolset(value: string): McpToolset {
-  if (value === 'core' || value === 'full') {
+  if (value === 'core' || value === 'cursor-cloud' || value === 'full') {
     return value;
   }
-  throw new Error(`Invalid MCP toolset: ${value}. Expected core or full.`);
+  throw new Error(`Invalid MCP toolset: ${value}. Expected core, cursor-cloud, or full.`);
+}
+
+export function mcpToolCapabilities(toolset: McpToolset): McpToolCapabilities {
+  return TOOLSET_CAPABILITIES[toolset];
 }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -41,6 +41,23 @@ const safeSeededProjects = Effect.fn('onboarding.safeSeededProjects')((config: O
 // unit-testable without MCP plumbing. The text is instructions FOR
 // the agent (present conversationally, offer to run), not a message to paste.
 export function buildOnboardingGuide(state: OnboardingState): string {
+  if (state.toolset === 'cursor-cloud') {
+    return [
+      '# Threadnote for Cursor Cloud Agents',
+      '',
+      'This session has one exclusive shared-memory scope. Start with recall_context,',
+      'then read only the threadnote:// URIs it returns. list_context can browse within that same scope.',
+      '',
+      'The code graph is local to the current cloud checkout. Use inspect_code_graph before broad text',
+      'search and analyze_code_graph for repository-wide structure. Named worksets are unavailable.',
+      '',
+      'Store durable knowledge with remember_context. Each write is committed and pushed to the configured',
+      'share so it survives the ephemeral cloud session. A kind=handoff write stays local and may not survive',
+      'a new cloud session; all other personal/local memory kinds stay inaccessible.',
+      'Review/apply actions, separate publishing, Obsidian operations, and maintenance tools are unavailable.',
+      'Full Cursor Cloud integration is still in development.',
+    ].join('\n');
+  }
   const runtimeLine =
     state.runtimeReady === false
       ? 'The Threadnote home is not ready — run `threadnote install`, then `threadnote doctor`. Offer to walk the user through that first.'

--- a/src/share.ts
+++ b/src/share.ts
@@ -16,10 +16,12 @@ export type {
 } from './share_core.js';
 export {
   clearAutoShareStateForTest,
+  assertShareTeamWritable,
   DEFAULT_GIT_REMOTE_NAME,
   ensureSharedDirectoryChain,
   isInSharedNamespace,
   markSharedAutoSyncDeferred,
+  normalizeTeamName,
   parentUri,
   personalUriFor,
   readTeamsFile,

--- a/src/share_sync.ts
+++ b/src/share_sync.ts
@@ -76,14 +76,17 @@ export const refreshSharedReposInBackground = Effect.fn('share.refreshSharedRepo
 
 export const syncSharedReposBeforeAgentRead = Effect.fn('share.syncSharedReposBeforeAgentRead')(function* (
   config: ShareRuntime,
+  selectedTeam?: string,
 ) {
   const state = autoShareState(config);
   return yield* enqueueShareOperation(
     state,
     Effect.fn('share.callback')(function* () {
       yield* loadPendingReindexes(config, state);
-      const warnings = yield* refreshShareUpdateStateLocked(config, state, {force: false});
-      const syncTeams = new Set([...state.behindTeams, ...state.pendingReindexes.keys()]);
+      const warnings = yield* refreshShareUpdateStateLocked(config, state, {force: false, team: selectedTeam});
+      const syncTeams = new Set(
+        [...state.behindTeams, ...state.pendingReindexes.keys()].filter(team => !selectedTeam || team === selectedTeam),
+      );
       if (syncTeams.size === 0) {
         return {syncedTeams: [], warnings};
       }
@@ -132,7 +135,7 @@ const refreshShareUpdateState = Effect.fn('share.refreshShareUpdateState')(funct
 const refreshShareUpdateStateLocked = Effect.fn('share.refreshShareUpdateStateLocked')(function* (
   config: ShareRuntime,
   state: AutoShareState,
-  options: {readonly force: boolean},
+  options: {readonly force: boolean; readonly team?: string},
 ) {
   const now = Date.now();
   if (
@@ -145,7 +148,7 @@ const refreshShareUpdateStateLocked = Effect.fn('share.refreshShareUpdateStateLo
   }
   state.forceNextCheck = false;
   return yield* Effect.gen(function* () {
-    const statuses = yield* fetchShareUpdateStatuses(config);
+    const statuses = yield* fetchShareUpdateStatuses(config, options.team);
     const nextBehindTeams = new Set(state.behindTeams);
     for (const status of statuses) {
       if (!status.warning) {
@@ -168,9 +171,12 @@ function enqueueShareOperation<A, E, R>(
   return action();
 }
 
-const fetchShareUpdateStatuses = Effect.fn('share.fetchShareUpdateStatuses')(function* (config: ShareRuntime) {
+const fetchShareUpdateStatuses = Effect.fn('share.fetchShareUpdateStatuses')(function* (
+  config: ShareRuntime,
+  selectedTeam?: string,
+) {
   const teamsFile = yield* readTeamsFile(config);
-  const teams = Object.entries(teamsFile.teams);
+  const teams = Object.entries(teamsFile.teams).filter(([name]) => !selectedTeam || name === selectedTeam);
   if (teams.length === 0) {
     return [];
   }

--- a/src/storage/resource-id.ts
+++ b/src/storage/resource-id.ts
@@ -62,6 +62,15 @@ export function resourceIdWithoutAnchor(resourceId: ResourceId): ResourceId {
   };
 }
 
+export function resourceIdIsWithin(candidateUri: string, rootUri: string): boolean {
+  const candidate = resourceIdWithoutAnchor(parseResourceId(candidateUri));
+  const root = resourceIdWithoutAnchor(parseResourceId(rootUri));
+  return (
+    candidate.namespace === root.namespace &&
+    root.segments.every((segment, index) => candidate.segments[index] === segment)
+  );
+}
+
 export function validatePortableSegment(value: string, input = value): string {
   if (!value) return invalid(input, 'empty path segments are not allowed');
   if (value !== value.normalize('NFC')) return invalid(input, 'path segments must use NFC Unicode normalization');

--- a/test/integration/cursor-cloud.test.ts
+++ b/test/integration/cursor-cloud.test.ts
@@ -1,0 +1,277 @@
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import {execFile} from '../helpers/node-child-process.js';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from '../helpers/node-fs-promises.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import {promisify} from '../helpers/node-util.js';
+import {describe, expect, it} from 'vitest';
+
+const execFilePromise = promisify(execFile);
+const CLOUD_TOOL_NAMES = [
+  'recall_context',
+  'inspect_code_graph',
+  'analyze_code_graph',
+  'read_context',
+  'list_context',
+  'remember_context',
+  'threadnote_guide',
+] as const;
+const gitIdentityEnvironment = {
+  GIT_AUTHOR_EMAIL: 'cursor-cloud@threadnote.local',
+  GIT_AUTHOR_NAME: 'Cursor Cloud Test',
+  GIT_COMMITTER_EMAIL: 'cursor-cloud@threadnote.local',
+  GIT_COMMITTER_NAME: 'Cursor Cloud Test',
+};
+
+describe('Cursor Cloud integration', () => {
+  it('prints deterministic Dashboard configuration and idempotently bootstraps a writable share', async () => {
+    const fixture = await cloudFixture();
+    try {
+      const firstConfig = await runCli([
+        'cloud',
+        'cursor',
+        'config',
+        '--home',
+        fixture.home,
+        '--team',
+        'engineering',
+        '--user',
+        'cloud-user',
+        '--agent-id',
+        'cloud-agent',
+      ]);
+      const secondConfig = await runCli([
+        'cloud',
+        'cursor',
+        'config',
+        '--home',
+        fixture.home,
+        '--team',
+        'engineering',
+        '--user',
+        'cloud-user',
+        '--agent-id',
+        'cloud-agent',
+      ]);
+      expect(secondConfig.stdout).toBe(firstConfig.stdout);
+      expect(JSON.parse(firstConfig.stdout)).toMatchObject({
+        env: {
+          THREADNOTE_CURSOR_CLOUD_TEAM: 'engineering',
+          THREADNOTE_MCP_TOOLSET: 'cursor-cloud',
+          THREADNOTE_USER: 'cloud-user',
+        },
+        type: 'stdio',
+      });
+
+      const first = await bootstrap(fixture);
+      const before = await readFile(join(fixture.home, 'share', 'teams.json'), 'utf8');
+      const second = await bootstrap(fixture);
+      const after = await readFile(join(fixture.home, 'share', 'teams.json'), 'utf8');
+      expect(first.stdout).toContain(
+        'Cursor Cloud memory root: threadnote://user/cloud-user/memories/shared/engineering/',
+      );
+      expect(second.stdout).toContain('already configured read-write; reusing it');
+      expect(after).toBe(before);
+      expect(JSON.parse(after)).toMatchObject({
+        defaultTeam: 'engineering',
+        teams: {engineering: {name: 'engineering', remote: fixture.remote}},
+      });
+
+      const verified = await runCli([
+        'cloud',
+        'cursor',
+        'verify',
+        '--home',
+        fixture.home,
+        '--team',
+        'engineering',
+        '--user',
+        'cloud-user',
+        '--agent-id',
+        'cloud-agent',
+        '--cwd',
+        process.cwd(),
+        '--json',
+      ]);
+      expect(JSON.parse(verified.stdout)).toMatchObject({
+        memoryRoot: 'threadnote://user/cloud-user/memories/shared/engineering',
+        profile: 'shared-read-write',
+        status: 'ok',
+      });
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('confines reads, persists durable writes to Git, and keeps handoffs local', async () => {
+    const fixture = await cloudFixture();
+    await bootstrap(fixture);
+    try {
+      await withCloudMcp(fixture, async client => {
+        const tools = await client.listTools();
+        expect(tools.tools.map(tool => tool.name)).toEqual(CLOUD_TOOL_NAMES);
+
+        await expect(
+          callError(client, 'read_context', {
+            uri: 'threadnote://user/cloud-user/memories/durable/projects/threadnote/private.md',
+          }),
+        ).resolves.toContain('must stay within');
+        await expect(
+          callError(client, 'inspect_code_graph', {
+            callerCwd: process.cwd(),
+            operation: 'query',
+            query: 'memory scope',
+            workset: 'all-repositories',
+          }),
+        ).resolves.toContain('workset operations are unavailable');
+        await expect(
+          callError(client, 'remember_context', {
+            kind: 'preference',
+            text: 'Do not persist this cloud preference.',
+          }),
+        ).resolves.toContain('durable shared memories and transient local handoffs');
+
+        const handoff = await callText(client, 'remember_context', {
+          kind: 'handoff',
+          project: 'threadnote',
+          text: 'Transient cloud checkout handoff.',
+          topic: 'cursor-cloud-transient',
+        });
+        expect(handoff).toContain(
+          'Stored memory: threadnote://user/cloud-user/memories/handoffs/active/threadnote/cursor-cloud-transient.md',
+        );
+
+        const durable = await client.callTool({
+          arguments: {
+            kind: 'durable',
+            project: 'threadnote',
+            text: 'Cursor Cloud durable memory persisted through the designated share.',
+            topic: 'cursor-cloud-persisted',
+          },
+          name: 'remember_context',
+        });
+        expect(durable.isError).not.toBe(true);
+        expect(durable.structuredContent).toMatchObject({
+          memoryUri:
+            'threadnote://user/cloud-user/memories/shared/engineering/durable/projects/threadnote/cursor-cloud-persisted.md',
+          persistence: 'shared-git-pushed',
+        });
+        const read = await callText(client, 'read_context', {
+          uri: 'threadnote://user/cloud-user/memories/shared/engineering/durable/projects/threadnote/cursor-cloud-persisted.md',
+        });
+        expect(read).toContain('Cursor Cloud durable memory persisted through the designated share.');
+      });
+
+      const remoteTree = await execFilePromise(
+        'git',
+        ['--git-dir', fixture.remote, 'ls-tree', '-r', '--name-only', 'main'],
+        {env: {...process.env, ...gitIdentityEnvironment}},
+      );
+      expect(remoteTree.stdout).toContain('durable/projects/threadnote/cursor-cloud-persisted.md');
+      expect(remoteTree.stdout).not.toContain('handoffs/');
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+});
+
+interface CloudFixture {
+  readonly home: string;
+  readonly remote: string;
+  readonly root: string;
+}
+
+async function cloudFixture(): Promise<CloudFixture> {
+  const root = await mkdtemp(join(tmpdir(), 'threadnote-cursor-cloud-'));
+  const remote = join(root, 'memory-share.git');
+  const source = join(root, 'seed');
+  const home = join(root, 'home');
+  await mkdir(source, {recursive: true});
+  await execFilePromise('git', ['init', '--bare', '--initial-branch=main', remote], {
+    env: {...process.env, ...gitIdentityEnvironment},
+  });
+  await execFilePromise('git', ['-C', source, 'init', '--initial-branch=main'], {
+    env: {...process.env, ...gitIdentityEnvironment},
+  });
+  await writeFile(join(source, 'README.md'), '# Cursor Cloud memory share\n');
+  await execFilePromise('git', ['-C', source, 'add', 'README.md'], {
+    env: {...process.env, ...gitIdentityEnvironment},
+  });
+  await execFilePromise('git', ['-C', source, 'commit', '-m', 'seed memory share'], {
+    env: {...process.env, ...gitIdentityEnvironment},
+  });
+  await execFilePromise('git', ['-C', source, 'remote', 'add', 'origin', remote], {
+    env: {...process.env, ...gitIdentityEnvironment},
+  });
+  await execFilePromise('git', ['-C', source, 'push', '-u', 'origin', 'main'], {
+    env: {...process.env, ...gitIdentityEnvironment},
+  });
+  return {home, remote, root};
+}
+
+function bootstrap(fixture: CloudFixture) {
+  return runCli([
+    'cloud',
+    'cursor',
+    'bootstrap',
+    '--home',
+    fixture.home,
+    '--remote',
+    fixture.remote,
+    '--team',
+    'engineering',
+    '--user',
+    'cloud-user',
+    '--agent-id',
+    'cloud-agent',
+  ]);
+}
+
+function runCli(args: readonly string[]) {
+  return execFilePromise(process.execPath, ['src/standalone.ts', ...args], {
+    cwd: process.cwd(),
+    env: {...process.env, ...gitIdentityEnvironment, NO_COLOR: '1'},
+  });
+}
+
+async function withCloudMcp<T>(fixture: CloudFixture, use: (client: Client) => Promise<T>): Promise<T> {
+  const transport = new StdioClientTransport({
+    args: [join(process.cwd(), 'src', 'standalone.ts'), 'mcp-server'],
+    command: process.execPath,
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ...gitIdentityEnvironment,
+      THREADNOTE_ACCOUNT: 'local',
+      THREADNOTE_AGENT_ID: 'cloud-agent',
+      THREADNOTE_CURSOR_CLOUD_TEAM: 'engineering',
+      THREADNOTE_HOME: fixture.home,
+      THREADNOTE_MANIFEST: join(fixture.home, 'seed-manifest.yaml'),
+      THREADNOTE_MCP_TOOLSET: 'cursor-cloud',
+      THREADNOTE_USER: 'cloud-user',
+    } as Record<string, string>,
+    stderr: 'pipe',
+  });
+  const client = new Client({name: 'threadnote-cursor-cloud-test', version: '0.0.0'});
+  try {
+    await client.connect(transport);
+    return await use(client);
+  } finally {
+    await client.close();
+  }
+}
+
+async function callText(client: Client, name: string, args: Record<string, unknown>): Promise<string> {
+  const result = await client.callTool({arguments: args, name});
+  return (result.content as Array<{text?: string; type: string}>)
+    .filter(content => content.type === 'text')
+    .map(content => content.text ?? '')
+    .join('\n');
+}
+
+async function callError(client: Client, name: string, args: Record<string, unknown>): Promise<string> {
+  const result = await client.callTool({arguments: args, name});
+  expect(result.isError).toBe(true);
+  return (result.content as Array<{text?: string; type: string}>).map(content => content.text ?? '').join('\n');
+}

--- a/test/unit/cursor-cloud.test.ts
+++ b/test/unit/cursor-cloud.test.ts
@@ -1,0 +1,110 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  buildCursorCloudMcpConfig,
+  buildCursorCloudProfile,
+  credentialFreeGitRemote,
+  cursorCloudMemoryRoot,
+  planCursorCloudBootstrap,
+} from '../../src/cursor_cloud.js';
+import type {RuntimeConfig, ShareTeamConfig, ShareTeamsFile} from '../../src/types.js';
+
+const runtime: RuntimeConfig = {
+  account: 'local',
+  agentContextHome: '/tmp/threadnote-cloud-test',
+  agentId: 'threadnote',
+  manifestPath: '/tmp/threadnote-cloud-test/seed-manifest.yaml',
+  user: 'local-user',
+};
+
+describe('Cursor Cloud profile', () => {
+  it('renders a deterministic writable shared-memory MCP configuration', () => {
+    const profile = buildCursorCloudProfile(runtime, {
+      agentId: 'cursor-agent',
+      team: 'engineering',
+      user: 'cloud-user',
+    });
+
+    expect(profile).toMatchObject({
+      agentId: 'cursor-agent',
+      memoryRoot: 'threadnote://user/cloud-user/memories/shared/engineering',
+      profile: 'shared-read-write',
+      team: 'engineering',
+      user: 'cloud-user',
+    });
+    expect(buildCursorCloudMcpConfig(profile)).toEqual(buildCursorCloudMcpConfig(profile));
+    expect(buildCursorCloudMcpConfig(profile).env).toEqual({
+      THREADNOTE_ACCOUNT: 'local',
+      THREADNOTE_AGENT_ID: 'cursor-agent',
+      THREADNOTE_CURSOR_CLOUD_TEAM: 'engineering',
+      THREADNOTE_MCP_TOOLSET: 'cursor-cloud',
+      THREADNOTE_USER: 'cloud-user',
+    });
+  });
+
+  it('plans initialization once and reuses only the equivalent writable share', () => {
+    const remote = 'git@example.com:team/memories.git';
+    expect(planCursorCloudBootstrap(emptyTeams(), remote, 'engineering')).toEqual({
+      action: 'initialize',
+      remote,
+      team: 'engineering',
+    });
+    expect(planCursorCloudBootstrap(teamsWith(teamConfig(remote)), remote, 'engineering')).toEqual({
+      action: 'reuse',
+      remote,
+      team: 'engineering',
+    });
+    expect(() => planCursorCloudBootstrap(teamsWith(teamConfig(remote, 'read-only')), remote, 'engineering')).toThrow(
+      'not read-write',
+    );
+    expect(() =>
+      planCursorCloudBootstrap(teamsWith(teamConfig('git@example.com:other/memories.git')), remote, 'engineering'),
+    ).toThrow('different remote');
+  });
+
+  it('constructs the canonical exclusive memory root', () => {
+    expect(cursorCloudMemoryRoot('Cloud User', 'product-team')).toBe(
+      'threadnote://user/cloud-user/memories/shared/product-team',
+    );
+  });
+
+  it('never reflects embedded HTTP credentials in rejection messages', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[A-Za-z0-9]{1,16}$/),
+        fc.stringMatching(/^[A-Za-z0-9]{1,16}$/),
+        (username, password) => {
+          const remote = `https://${username}:${password}@example.com/team/memories.git`;
+          let message = '';
+          try {
+            credentialFreeGitRemote(remote);
+          } catch (cause) {
+            message = cause instanceof Error ? cause.message : String(cause);
+          }
+          expect(message).toContain('must not contain embedded credentials');
+          expect(message).not.toContain(remote);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+});
+
+function emptyTeams(): ShareTeamsFile {
+  return {teams: {}, version: 1};
+}
+
+function teamsWith(team: ShareTeamConfig): ShareTeamsFile {
+  return {defaultTeam: 'engineering', teams: {engineering: team}, version: 1};
+}
+
+function teamConfig(remote: string, access?: 'read-only'): ShareTeamConfig {
+  return {
+    ...(access ? {access} : {}),
+    addedAt: '2026-08-12T00:00:00.000Z',
+    gitdir: '/tmp/threadnote-cloud-test/share/teams/engineering.gitdir',
+    name: 'engineering',
+    remote,
+    worktree: '/tmp/threadnote-cloud-test/share/worktrees/engineering',
+  };
+}

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -10,7 +10,7 @@ import {captureConsole} from '../../src/effect/console.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import {mcpAdapterCommand, resolveMcpClients, runMcpInstall} from '../../src/mcp.js';
-import {parseMcpToolset} from '../../src/mcp_toolset.js';
+import {mcpToolCapabilities, parseMcpToolset} from '../../src/mcp_toolset.js';
 import type {RuntimeConfig} from '../../src/types.js';
 
 function runtime(): RuntimeConfig {
@@ -87,7 +87,22 @@ describe('MCP toolsets', () => {
   );
 
   it('rejects unsupported toolsets', () => {
-    expect(() => parseMcpToolset('minimal')).toThrow('Invalid MCP toolset: minimal. Expected core or full.');
+    expect(() => parseMcpToolset('minimal')).toThrow(
+      'Invalid MCP toolset: minimal. Expected core, cursor-cloud, or full.',
+    );
+  });
+
+  it('gives Cursor Cloud shared writes without review, publishing, maintenance, or worksets', () => {
+    expect(mcpToolCapabilities(parseMcpToolset('cursor-cloud'))).toEqual({
+      contextBrief: false,
+      graphLocal: true,
+      graphWorkset: false,
+      maintenance: false,
+      memoryPublish: false,
+      memoryRead: true,
+      memoryReview: false,
+      memoryWrite: true,
+    });
   });
 
   effectIt.effect('launches the Windows MCP cmd adapter through ComSpec', () =>

--- a/test/unit/onboarding.test.ts
+++ b/test/unit/onboarding.test.ts
@@ -35,6 +35,16 @@ describe('buildOnboardingGuide', () => {
     expect(guide).toContain('share_skill(');
   });
 
+  it('describes shared durable writes and transient local handoffs for Cursor Cloud', () => {
+    const guide = buildOnboardingGuide({seededProjects: [], teams: ['engineering'], toolset: 'cursor-cloud'});
+    expect(guide).toContain('exclusive shared-memory scope');
+    expect(guide).toContain('remember_context');
+    expect(guide).toContain('committed and pushed');
+    expect(guide).toContain('kind=handoff write stays local');
+    expect(guide).toContain('all other personal/local memory kinds stay inaccessible');
+    expect(guide).not.toContain('share_publish(');
+  });
+
   it('nudges first-time team setup when no team is configured', () => {
     const guide = buildOnboardingGuide({seededProjects: [], teams: []});
     expect(guide).toContain('No share team configured yet');

--- a/test/unit/resource-id.property.test.ts
+++ b/test/unit/resource-id.property.test.ts
@@ -4,6 +4,7 @@ import {
   canonicalResourceUri,
   InvalidResourceId,
   parseResourceId,
+  resourceIdIsWithin,
   resourceIdWithoutAnchor,
 } from '../../src/storage/resource-id.js';
 
@@ -126,6 +127,27 @@ describe('ResourceId properties', () => {
       expect(resourceIdWithoutAnchor(withoutAnchor)).toBe(withoutAnchor);
     },
     {fastCheck: {numRuns: 250}},
+  );
+
+  it.prop(
+    'accepts exactly a canonical root and its descendants while rejecting sibling roots',
+    {
+      childSegments: FC.array(portableSegmentArbitrary, {maxLength: 5}),
+      namespace: portableSegmentArbitrary,
+      rootSegments: FC.array(portableSegmentArbitrary, {maxLength: 5, minLength: 1}),
+      sibling: portableSegmentArbitrary,
+    },
+    ({childSegments, namespace, rootSegments, sibling}) => {
+      const root = canonicalResourceUri(namespace, rootSegments);
+      const child = canonicalResourceUri(namespace, [...rootSegments, ...childSegments]);
+      const siblingRoot = canonicalResourceUri(namespace, [...rootSegments.slice(0, -1), sibling]);
+
+      expect(resourceIdIsWithin(root, root)).toBe(true);
+      expect(resourceIdIsWithin(child, root)).toBe(true);
+      if (siblingRoot !== root) expect(resourceIdIsWithin(siblingRoot, root)).toBe(false);
+      expect(resourceIdIsWithin(canonicalResourceUri(`${namespace}-other`, rootSegments), root)).toBe(false);
+    },
+    {fastCheck: {numRuns: 200}},
   );
 
   it.prop(


### PR DESCRIPTION
## What changed

- add `threadnote cloud cursor config`, `bootstrap`, and `verify` for deterministic Cursor Cloud setup
- add a capability-enforced `cursor-cloud` MCP toolset scoped to one designated read-write memory share
- publish `kind=durable` memories directly to the shared Git repository with commit and push
- keep `kind=handoff` memories local and transient, while rejecting unsupported cloud memory kinds
- confine recall, reads, listings, and resources to the selected shared namespace
- retain local code-graph inspection while disabling named Worksets in the cloud profile
- add unit, integration, and property coverage for setup, confinement, idempotency, and persistence

## Why

Cursor Cloud Agent VMs are ephemeral, so VM-local durable memories cannot be treated as cross-session context. This profile makes one Git-backed share the durable memory plane while preserving local handoffs for coordination during the current workspace lifetime.

The public setup guide is already on `main` and continues to describe this as a beta while full first-class integration is in development.

## Validation

- `bun run typecheck`
- `bun run lint`
- focused Cursor Cloud suite: 6 files, 80 tests passed
- `git diff --check origin/main...HEAD`
- standalone local-binary integration previously passed against a real stdio MCP client and local bare Git remote
- full local suite intentionally stopped at user request; CI is the full-suite gate
