### PR TITLE
release: prepare Threadnote 4.2 stable

### DIFF
--- a/.github/release-notes/v4.2.0.md
+++ b/.github/release-notes/v4.2.0.md
@@ -1,0 +1,76 @@
+## What's new
+
+Threadnote 4.2 brings multi-repository Projects and Worksets into Manager, extends native graph investigation across
+prepared repository sets, and makes graph storage and local runtime activity easier to understand and control. It also
+introduces an initial Cursor Cloud Agents shared-memory profile and safer stable and preview updates.
+
+### Manage Projects and Worksets end to end
+
+- Manager can create, inspect, edit, rename, and delete manifest Projects and Worksets, including an **Add your first
+  project** flow for an empty manifest. Project cards lead with the repository folder and observed branch instead of
+  opaque checkout IDs.
+- Project writes preserve supported YAML comments and use revision-fenced atomic updates. Git roots are canonicalized,
+  duplicate checkout ownership is rejected, and seeding blocks escaping patterns, symbolic-link traversal, and
+  path-swap races.
+- Renaming a Project updates referencing Worksets in the same transaction. Deleting one leaves dependent member names
+  visibly unresolved and never deletes repositories, seeded resources, memories, or graph databases.
+- Worksets can prepare a published graph generation, then run bounded queries and continuation, exact paths, reverse
+  impact, topology, and Context Briefs with per-repository provenance. Queries never fan out cold builds; run
+  `threadnote workset prepare <name>` when a member needs its first or a fresher ready snapshot.
+- Client-injected agent guidance is shorter, graph-first for unfamiliar source, and documents the same published-ready
+  Workset contract.
+
+### Keep graph storage and runtimes bounded
+
+- Retired repository snapshots and Workset generations are reclaimed with bounded storage admission and physically
+  paged cleanup, preventing repeated builds from accumulating retired payloads without bound.
+- Manager distinguishes allocated SQLite pages, useful live data, and reusable freelist space. While Manager is
+  running, it automatically compacts at most one eligible freelist-heavy database at a time after conservative
+  disk-headroom, cooldown, build, and maintenance checks.
+- The Processes tab shows a compact, privacy-safe inventory of registered Threadnote runtimes. Graph compaction and
+  deep-diagnostics workers appear only while alive, and a confirmed identity-bound icon action can stop a selected
+  process without exposing arguments, environment variables, paths, or private registration data. The current Manager
+  is protected.
+- Graph databases with neither a verified folder nor a ready snapshot are labeled **unassociated graph storage**, with
+  explicit guidance to index from the repository folder or preview and purge obsolete derived data.
+- The core embedding model is available from an immutable Threadnote release asset, with resumable transfer, SHA-256
+  verification, and atomic promotion when Hugging Face is unavailable.
+
+### Update safely across stable and previews
+
+- Stable installations continue to select stable releases only. The beta channel is inclusive: it selects the newest
+  immutable stable or prerelease, so an invoked update from beta.2 can discover Threadnote 4.2 without `--stable`.
+  After graduation, ordinary updates infer stable-only selection again; use `threadnote update --beta` to re-enter
+  preview selection.
+- `threadnote update --force` refuses semantic downgrades, preventing stale or incomplete release listings from turning
+  a forced reinstall into an older installation. Reinstalling the current version and upgrading remain supported; an
+  explicit `threadnote update --stable` can still move a prerelease to an older stable release.
+- Release archive checksum verification, installation locking, and atomic promotion remain in force.
+
+### Try the Cursor Cloud Agents profile (beta)
+
+- The initial Cursor Cloud profile adds `threadnote cloud cursor config`, `bootstrap`, and `verify` commands for
+  deterministic stdio MCP setup, idempotent writable-share preparation, and runtime verification in an ephemeral
+  checkout.
+- The profile confines memory reads and durable writes to one designated Git-backed share. Durable writes are scrubbed,
+  committed, and pushed; local code-graph inspection remains available for the current checkout while Worksets,
+  maintenance, review, and separate publishing tools are disabled.
+- Full first-class Cursor Cloud lifecycle automation is still in development. Keep Git credentials outside repository
+  files, remote URLs, MCP JSON, and agent instructions, and treat VM-local handoffs as transient.
+
+### Upgrade to Threadnote 4.2
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```
+
+An installation already following the beta channel also discovers stable 4.2 automatically because it is newer than
+the 4.2 prereleases. For a fresh macOS or Linux installation:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.sh | sh
+```
+
+Updates preserve Threadnote data and verified model files.

--- a/manager/app.css
+++ b/manager/app.css
@@ -3397,9 +3397,12 @@ dd {
 }
 
 .process-workspace {
+  align-content: start;
   display: grid;
   gap: 14px;
+  grid-auto-rows: max-content;
   height: 100%;
+  min-height: 0;
   overflow: auto;
   padding: 20px;
 }
@@ -3430,8 +3433,11 @@ dd {
 }
 
 .process-list {
+  align-content: start;
   display: grid;
   gap: 10px;
+  grid-auto-rows: max-content;
+  min-height: 0;
 }
 
 .process-card {
@@ -3442,7 +3448,8 @@ dd {
   display: grid;
   gap: 14px;
   grid-template-columns: minmax(0, 1fr) auto;
-  padding: 14px;
+  min-height: 0;
+  padding: 12px 14px;
 }
 
 .process-card-main {
@@ -3485,7 +3492,7 @@ dd {
 .process-card dl {
   display: grid;
   gap: 8px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(140px, 100%), 1fr));
   margin: 2px 0 0;
 }
 
@@ -3498,9 +3505,7 @@ dd {
 .process-card dd {
   font-size: 11px;
   margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .process-terminate {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.2.0-beta.2",
+  "version": "4.2.0",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/manager_processes_view.tsx
+++ b/src/manager_processes_view.tsx
@@ -97,14 +97,14 @@ export function ProcessesPanel(): React.ReactElement {
         <p className="process-notice">The bounded inventory is truncated. Refresh after other processes exit.</p>
       ) : null}
 
-      <div className="process-list">
+      <div aria-label="Threadnote process inventory" className="process-list" role="list">
         {diagnostics === undefined ? (
           <p className="process-empty">Loading registered processes…</p>
         ) : diagnostics.processes.length === 0 ? (
           <p className="process-empty">No registered Threadnote processes are visible.</p>
         ) : (
           diagnostics.processes.map(process => (
-            <article className="process-card" key={`${process.processId}:${process.startedAt}`}>
+            <article className="process-card" key={`${process.processId}:${process.startedAt}`} role="listitem">
               <div className="process-card-main">
                 <div className="process-card-title">
                   <strong>{processRoleLabel(process.role)}</strong>

--- a/test/unit/manager-processes-ui.test.ts
+++ b/test/unit/manager-processes-ui.test.ts
@@ -5,6 +5,8 @@ import {createRoot, type Root} from 'react-dom/client';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {ManagerDialogProvider} from '../../src/manager_dialog.js';
 import {ProcessesPanel} from '../../src/manager_processes_view.js';
+import {readFile} from '../helpers/node-fs-promises.js';
+import {join} from '../helpers/node-path.js';
 
 let reactRoot: Root | undefined;
 let fetchOriginal: typeof fetch;
@@ -76,6 +78,9 @@ afterEach(async () => {
 describe('Manager Processes panel', () => {
   it('shows compaction and activity roles without exposing opaque control data as text', async () => {
     await renderProcesses();
+    const processList = document.querySelector('[aria-label="Threadnote process inventory"]');
+    expect(processList?.getAttribute('role')).toBe('list');
+    expect(processList?.querySelectorAll('[role="listitem"]')).toHaveLength(3);
     expect(document.body.textContent).toContain('Graph compaction worker');
     expect(document.body.textContent).toContain('Compact graph storage');
     expect(document.body.textContent).toContain('Manager · PID 80276');
@@ -108,6 +113,18 @@ describe('Manager Processes panel', () => {
       processId: 80297,
       processRef: `tnp_${'a'.repeat(64)}`,
     });
+  });
+
+  it('keeps process rows content-sized and lets metadata wrap responsively', async () => {
+    const css = await readFile(join(process.cwd(), 'manager', 'app.css'), 'utf8');
+    expect(css).toMatch(
+      /\.process-workspace\s*\{[\s\S]*?align-content: start;[\s\S]*?grid-auto-rows: max-content;[\s\S]*?min-height: 0;/u,
+    );
+    expect(css).toMatch(
+      /\.process-list\s*\{[\s\S]*?align-content: start;[\s\S]*?grid-auto-rows: max-content;[\s\S]*?min-height: 0;/u,
+    );
+    expect(css).toMatch(/\.process-card dl\s*\{[\s\S]*?repeat\(auto-fit, minmax\(min\(140px, 100%\), 1fr\)\)/u);
+    expect(css).toMatch(/\.process-card dd\s*\{[\s\S]*?overflow-wrap: anywhere;/u);
   });
 });
 

--- a/website/src/content/docsCursorCloud.ts
+++ b/website/src/content/docsCursorCloud.ts
@@ -22,7 +22,7 @@ export const cursorCloudDocsSection: DocsSection = {
       body: [
         {
           type: 'warning',
-          text: 'Full first-class Cursor Cloud Agents integration is still in development. The current beta uses a local stdio MCP server, an idempotent bootstrap command, and a capability-enforced cloud profile. Durable memories are committed and pushed to one designated share; local handoffs remain transient. Managed remote transport and broader cloud lifecycle automation are not yet included.',
+          text: 'Full first-class Cursor Cloud Agents integration is still in development. The current integration uses a local stdio MCP server, an idempotent bootstrap command, and a capability-enforced cloud profile. Durable memories are committed and pushed to one designated share; local handoffs remain transient. Managed remote transport and broader cloud lifecycle automation are not yet included.',
         },
         {
           type: 'paragraph',


### PR DESCRIPTION
## Summary

- promote Threadnote from `4.2.0-beta.2` to `4.2.0` with consolidated stable release notes
- refine the Manager Processes tab so process cards are compact, content-sized, and responsive instead of stretching to fill the viewport
- update Cursor Cloud wording for the stable release while retaining its beta maturity warning

## Verification

- full test suite: 304 files, 2,985 passed, 1 intentional skip
- lint, source/test typecheck, Prettier, and diff checks
- site checks and production build: 58 checks, 46 pages
- standalone build, self-contained validation, and release smoke: 11/11
- Manager Processes visual QA at desktop and mobile widths with no horizontal overflow
- exact-HEAD global development install and doctor verification
- Cursor Cloud `config` → `bootstrap` → `verify` smoke against an isolated Git remote

## Release boundary

Do not tag this PR head. After the complete PR matrix and review are green, merge it, verify `origin/main`, then create the annotated `v4.2.0` tag at that exact merged commit. The tag push will run the immutable release workflow.
