### PR TITLE
Fix graph refresh after language-pack upgrades and prepare 4.2.1

### DIFF
--- a/.github/release-notes/v4.2.1.md
+++ b/.github/release-notes/v4.2.1.md
@@ -1,0 +1,25 @@
+## What's new
+
+Threadnote 4.2.1 makes native code-graph upgrades recognize source files newly supported by a language pack instead of
+continuing to serve an older clean snapshot.
+
+### Refresh graphs when language support changes
+
+- Existing graphs now become stale when their recorded language-pack contract differs from the installed Threadnote
+  runtime. The next current graph query refreshes the snapshot automatically.
+- Aspect AXL (`.axl`) sources are included after upgrading, even when the repository was already indexed before AXL
+  support was added. They appear as Starlark modules, declarations, imports, and relationships.
+- Clean snapshots, dirty overlays, incremental builds, and shared snapshot attachments all retain the language-pack
+  provenance needed for future upgrade checks.
+
+To refresh a repository immediately after updating, run:
+
+```sh
+threadnote graph query --cwd /path/to/repository --freshness current --query path/to/source.axl
+```
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -1643,6 +1643,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
             }) ?? Effect.void
           ).pipe(Effect.catch(() => Effect.void)),
         persistentCapacityGuard,
+        input.languagePacks.activePackProvenance(input.inventory.files.map(file => file.path)),
       ),
       lease =>
         Option.match(lease, {

--- a/src/code_graph/languages/registry.ts
+++ b/src/code_graph/languages/registry.ts
@@ -100,13 +100,7 @@ export function createCodeGraphLanguagePackRegistry(
       const activeIds = new Set(paths.flatMap(path => Option.toArray(Option.map(match(path), value => value.pack.id))));
       return packs
         .filter(pack => activeIds.has(pack.id))
-        .map(pack => ({
-          cacheIdentity: packCacheIdentity(pack),
-          derivationIdentity: packDerivationIdentity(pack),
-          id: pack.id,
-          resolutionDomain: pack.resolutionStrategy.domain,
-          resolutionVersion: pack.resolutionStrategy.version,
-        }))
+        .map(codeGraphLanguagePackProvenance)
         .sort((left, right) => left.id.localeCompare(right.id));
     },
     cacheIdentityForPath: path => Option.map(match(path), value => value.cacheIdentity),
@@ -155,6 +149,16 @@ export function createCodeGraphLanguagePackRegistry(
       .extract(attributed, context)
       .pipe(Effect.map(facts => captureRationaleInputs(attributed, facts)));
   }
+}
+
+export function codeGraphLanguagePackProvenance(pack: CodeGraphLanguagePack): CodeGraphLanguagePackProvenance {
+  return {
+    cacheIdentity: packCacheIdentity(pack),
+    derivationIdentity: packDerivationIdentity(pack),
+    id: pack.id,
+    resolutionDomain: pack.resolutionStrategy.domain,
+    resolutionVersion: pack.resolutionStrategy.version,
+  };
 }
 
 export function packCacheIdentity(pack: CodeGraphLanguagePack): string {

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -5,12 +5,17 @@ import {SystemInfo} from '../effect/system.js';
 import {
   codeGraphDirectPersistentCapacityProtector,
   CodeGraphIndexer,
+  extractorSetIdentityFromPackProvenance,
   type DirectPersistentCapacityProtection,
 } from './indexer.js';
 import type {CodeGraphDirectPersistentCapacityBoundary} from './disk_capacity.js';
 import {CodeGraphMaintenanceCoordinator} from './maintenance_coordinator.js';
 import {worktreeOverlayState} from './inventory.js';
-import {CodeGraphLanguagePackRegistry} from './languages/registry.js';
+import {
+  codeGraphLanguagePackProvenance,
+  CodeGraphLanguagePackRegistry,
+  type CodeGraphLanguagePackRegistryShape,
+} from './languages/registry.js';
 import {
   codeGraphLayout,
   codeGraphMaintenanceLockPath,
@@ -29,7 +34,12 @@ import {
 } from './local_provenance.js';
 import {compareCodeUnits} from './ordering.js';
 import {resolveRepositoryIdentity, resolveRepositoryIdentityForExpectation} from './repository.js';
-import {codeGraphSymbolSearchScoreMultiplier, CodeGraphStore, type CodeGraphStoreShape} from './store.js';
+import {
+  codeGraphSymbolSearchScoreMultiplier,
+  CodeGraphStore,
+  type CodeGraphLanguagePackProvenance,
+  type CodeGraphStoreShape,
+} from './store.js';
 import {CodeGraphEmbeddingIndex, type CodeGraphEmbeddingIndexShape} from './embedding.js';
 import {
   CODE_GRAPH_RESULT_VERSION,
@@ -136,6 +146,41 @@ export function shouldAttachSharedReadySnapshot(input: {
   );
 }
 
+/**
+ * A clean Git worktree can still have a stale graph after a runtime upgrade.
+ * Reconstruct the active extractor contract from the snapshot provenance and the
+ * current language-pack catalog before treating that snapshot as current.
+ */
+export function codeGraphSnapshotMatchesCurrentLanguagePacks(
+  snapshot: Pick<CodeGraphSnapshot, 'extractorSet'>,
+  provenance: readonly CodeGraphLanguagePackProvenance[] | undefined,
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+): boolean {
+  if (provenance === undefined) return false;
+  const previousIds = new Set(provenance.map(pack => pack.id));
+  if (previousIds.size !== provenance.length) return false;
+  const currentProvenance = languagePacks.packs
+    .filter(pack => previousIds.has(pack.id))
+    .map(codeGraphLanguagePackProvenance);
+  if (currentProvenance.length !== previousIds.size) return false;
+  return (
+    extractorSetIdentityFromPackProvenance(provenance) === snapshot.extractorSet &&
+    extractorSetIdentityFromPackProvenance(currentProvenance) === snapshot.extractorSet
+  );
+}
+
+function codeGraphSnapshotRuntimeCurrent(
+  store: CodeGraphStoreShape,
+  databasePath: string,
+  snapshot: CodeGraphSnapshot,
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+) {
+  return store.snapshotPackProvenance(databasePath, snapshot.id).pipe(
+    Effect.map(provenance => codeGraphSnapshotMatchesCurrentLanguagePacks(snapshot, provenance, languagePacks)),
+    Effect.catch(() => Effect.succeed(false)),
+  );
+}
+
 function attachCodeGraphStatusObservation(
   status: CodeGraphStatus,
   observation: CodeGraphStatusObservation | undefined,
@@ -227,9 +272,13 @@ export class CodeGraphQueryService extends Context.Service<
           if (!identityAlreadyObserved) yield* recordVerifiedCodeGraphLocalAssociation(threadnoteHome, identity);
           const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
           const readySnapshot = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+          const runtimeCurrent = readySnapshot
+            ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, readySnapshot, languagePacks)
+            : false;
           const overlay = options?.observeWorktree === false ? undefined : yield* worktreeOverlayState(identity);
           const stale =
             !readySnapshot ||
+            !runtimeCurrent ||
             readySnapshot.commit !== identity.headCommit ||
             (overlay !== undefined && !snapshotMatches(readySnapshot, identity.headCommit, overlay));
           const status = {
@@ -280,8 +329,12 @@ export class CodeGraphQueryService extends Context.Service<
             identity.repositoryId,
             identity.headCommit,
           );
+          const candidateRuntimeCurrent = candidate
+            ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, candidate, languagePacks)
+            : false;
           if (
             candidate === undefined ||
+            !candidateRuntimeCurrent ||
             !shouldAttachSharedReadySnapshot({
               candidate,
               headCommit: identity.headCommit,
@@ -312,8 +365,12 @@ export class CodeGraphQueryService extends Context.Service<
                 identity.repositoryId,
                 identity.headCommit,
               );
+              const lockedCandidateRuntimeCurrent = lockedCandidate
+                ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, lockedCandidate, languagePacks)
+                : false;
               if (
                 lockedCandidate === undefined ||
+                !lockedCandidateRuntimeCurrent ||
                 !shouldAttachSharedReadySnapshot({
                   candidate: lockedCandidate,
                   headCommit: identity.headCommit,
@@ -402,6 +459,9 @@ export class CodeGraphQueryService extends Context.Service<
                 (yield* resolveAndRecordCodeGraphLocalAssociation(options.threadnoteHome, options.cwd)).identity;
               const layout = codeGraphLayout(path, options.threadnoteHome, identity.checkoutId, identity.worktreeId);
               const existing = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+              const runtimeCurrent = existing
+                ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, existing, languagePacks)
+                : false;
               const strictFreshness =
                 options.strictFreshness ??
                 (options.refresh === true || options.operation === 'impact' || options.operation === 'path');
@@ -411,6 +471,7 @@ export class CodeGraphQueryService extends Context.Service<
                 (observeBeforeRead ? yield* observeWorktree(identity, options.interlock) : undefined);
               const stale =
                 !existing ||
+                !runtimeCurrent ||
                 existing.commit !== identity.headCommit ||
                 (overlay !== undefined && !snapshotMatches(existing, identity.headCommit, overlay));
               const freshnessRequired =
@@ -433,6 +494,7 @@ export class CodeGraphQueryService extends Context.Service<
                       embedding,
                       expectedRepositoryId: identity.repositoryId,
                       layout,
+                      languagePacks,
                       deferWorktreeObservation: overlay === undefined && !rebuilt,
                       observation: overlay === undefined || rebuilt ? undefined : {identity, overlay},
                       options,
@@ -1025,6 +1087,7 @@ const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (in
   readonly embedding: CodeGraphEmbeddingIndexShape;
   readonly expectedRepositoryId: string;
   readonly layout: CodeGraphLayout;
+  readonly languagePacks: CodeGraphLanguagePackRegistryShape;
   readonly observation?: {
     readonly identity: RepositoryIdentity;
     readonly overlay: {readonly dirty: boolean; readonly fingerprint?: string};
@@ -1051,6 +1114,12 @@ const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (in
     );
   }
   const snapshot = {...storedSnapshot, worktreeId: identity.worktreeId};
+  const runtimeCurrent = yield* codeGraphSnapshotRuntimeCurrent(
+    input.store,
+    input.layout.databasePath,
+    snapshot,
+    input.languagePacks,
+  );
   yield* input.options.interlock?.afterSnapshotSelected?.() ?? Effect.void;
   const lease = yield* input.store.acquireSnapshotLease(input.layout.databasePath, snapshot.id, 2 * 60_000);
   const read = Effect.gen(function* () {
@@ -1162,8 +1231,9 @@ const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (in
     const finalOverlay = input.strictFreshness
       ? yield* observeWorktree(finalIdentity, input.options.interlock)
       : overlay;
-    const freshness =
-      finalOverlay === undefined
+    const freshness = !runtimeCurrent
+      ? 'stale'
+      : finalOverlay === undefined
         ? snapshot.commit === finalIdentity.headCommit
           ? 'deferred'
           : 'stale'

--- a/src/code_graph/store_activation.ts
+++ b/src/code_graph/store_activation.ts
@@ -3,6 +3,7 @@ import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   type CodeGraphActivationProgressCallback,
+  type CodeGraphLanguagePackProvenance,
   type CodeGraphReusableBaseReceiptInput,
 } from './store_models.js';
 import {configureConnection} from './store_session.js';
@@ -62,6 +63,7 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
   reusableBaseReceipt?: CodeGraphReusableBaseReceiptInput,
   promotionLease: Option.Option<CodeGraphActivationLease> = Option.none(),
   onProgress?: CodeGraphActivationProgressCallback,
+  snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
 ) {
   const observe = activationProgressObserver(onProgress);
   yield* observe('validating-input', 'started');
@@ -96,6 +98,7 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
         reusableBaseReceipt,
         promotionLease,
         observe,
+        snapshotPackProvenance,
       );
       return;
     }
@@ -369,6 +372,9 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
         yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
       }
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
+      if (snapshotPackProvenance !== undefined) {
+        yield* recordSnapshotPackProvenance(sql, snapshot.id, snapshotPackProvenance);
+      }
       if (activated && !baseSnapshotId && !snapshot.dirty && reusableBaseReceipt) {
         yield* observe('copying-lookup-keys', 'started');
         yield* sql`
@@ -404,7 +410,6 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
             ${new Date().toISOString()}
           FROM activation_symbol_lookup
         `;
-        yield* recordSnapshotPackProvenance(sql, snapshot.id, reusableBaseReceipt.packProvenance);
       }
       yield* insertActivationLease(sql, snapshot.id, promotionLease);
       if (activated) {
@@ -456,6 +461,7 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
   reusableBaseReceipt: CodeGraphReusableBaseReceiptInput | undefined,
   promotionLease: Option.Option<CodeGraphActivationLease> = Option.none(),
   onProgress?: CodeGraphActivationProgressCallback,
+  snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
 ) {
   const observe = activationProgressObserver(onProgress);
   let compactLexicalReceipt = Option.none<CompactLexicalFormatReceipt>();
@@ -718,6 +724,9 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
         yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
       }
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
+      if (snapshotPackProvenance !== undefined) {
+        yield* recordSnapshotPackProvenance(sql, snapshot.id, snapshotPackProvenance);
+      }
       yield* insertActivationLease(sql, snapshot.id, promotionLease);
       if (existing[0]?.state !== 'ready') {
         yield* observe('recording-completion', 'started');

--- a/src/code_graph/store_activation_persistent.ts
+++ b/src/code_graph/store_activation_persistent.ts
@@ -5,6 +5,7 @@ import {
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   type CodeGraphActivationProgressCallback,
   type CodeGraphDirectPersistentCapacityProtector,
+  type CodeGraphLanguagePackProvenance,
   type CodeGraphReusableBaseReceiptInput,
 } from './store_models.js';
 import {LEGACY_BUILDING_REFERENCES_V3_TABLE} from './store_schema_contracts.js';
@@ -183,6 +184,7 @@ const activateCleanStagedSnapshot = Effect.fn('codeGraph.activateCleanStagedSnap
   reusableBaseReceipt: CodeGraphReusableBaseReceiptInput | undefined,
   promotionLease: Option.Option<CodeGraphActivationLease>,
   observe: ActivationProgressObserver,
+  snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
 ) {
   const existing = yield* sql<{readonly started_at: string}>`
     SELECT started_at FROM snapshots WHERE id = ${snapshot.id} LIMIT 1
@@ -330,6 +332,9 @@ const activateCleanStagedSnapshot = Effect.fn('codeGraph.activateCleanStagedSnap
       yield* recordCompactLexicalFormat(sql, snapshot.id, copiedTerms, copiedTerms.postingCount, snapshot.symbolCount);
       yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
+      if (snapshotPackProvenance !== undefined) {
+        yield* recordSnapshotPackProvenance(sql, snapshot.id, snapshotPackProvenance);
+      }
       if (!snapshot.dirty && reusableBaseReceipt) {
         yield* sql`
           INSERT INTO snapshot_reuse_receipts (
@@ -344,7 +349,6 @@ const activateCleanStagedSnapshot = Effect.fn('codeGraph.activateCleanStagedSnap
             ${new Date().toISOString()}
           )
         `;
-        yield* recordSnapshotPackProvenance(sql, snapshot.id, reusableBaseReceipt.packProvenance);
       }
       yield* insertActivationLease(sql, snapshot.id, promotionLease);
       yield* observe('recording-completion', 'started');
@@ -584,6 +588,7 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
   onProgress?: CodeGraphActivationProgressCallback,
   writerGate?: CodeGraphWriterGate,
   persistentCapacityProtector?: CodeGraphDirectPersistentCapacityProtector,
+  snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
 ) {
   const runWrite: CodeGraphWriterGate = writerGate ?? (effect => effect);
   const observe = activationProgressObserver(onProgress);
@@ -682,6 +687,9 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
           yield* publishCompactLexicalFormat(sql, snapshot.id, compactLexicalReceipt);
           yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
           yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
+          if (snapshotPackProvenance !== undefined) {
+            yield* recordSnapshotPackProvenance(sql, snapshot.id, snapshotPackProvenance);
+          }
           if (reusableBaseReceipt) {
             yield* sql`
           INSERT INTO snapshot_reuse_receipts (
@@ -695,7 +703,6 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
             ${new Date().toISOString()}
           )
         `;
-            yield* recordSnapshotPackProvenance(sql, snapshot.id, reusableBaseReceipt.packProvenance);
           }
           yield* insertActivationLease(sql, snapshot.id, promotionLease);
           const completed = yield* sql<{readonly id: string}>`
@@ -852,6 +859,17 @@ const activateCleanSnapshotAlias = Effect.fn('codeGraph.activateCleanSnapshotAli
       yield* sql`INSERT INTO lexical_compact_snapshots (snapshot_id) VALUES (${snapshot.id})`;
       yield* publishCompactLexicalFormat(sql, snapshot.id, {postingCount: 0, symbolCount: 0, termCount: 0});
       yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
+      yield* sql`
+        INSERT INTO snapshot_pack_provenance (
+          snapshot_id, pack_id, cache_identity, derivation_identity,
+          resolution_domain, resolution_version
+        )
+        SELECT
+          ${snapshot.id}, pack_id, cache_identity, derivation_identity,
+          resolution_domain, resolution_version
+        FROM snapshot_pack_provenance
+        WHERE snapshot_id = ${baseSnapshotId}
+      `;
     }),
   );
 });

--- a/src/code_graph/store_pack_provenance.ts
+++ b/src/code_graph/store_pack_provenance.ts
@@ -1,7 +1,48 @@
 import {Effect} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import type {CodeGraphLanguagePackProvenance} from './store_models.js';
-import {CodeGraphStoreError} from './types.js';
+import {configureConnection, tableExists} from './store_session.js';
+import {CODE_GRAPH_EXTRACTOR_GENERATION, CodeGraphStoreError} from './types.js';
+
+export const selectSnapshotPackProvenance = Effect.fn('codeGraph.selectSnapshotPackProvenance')(function* (
+  snapshotId: string,
+) {
+  const sql = yield* SqlClient.SqlClient;
+  yield* configureConnection(sql);
+  if (
+    !(yield* tableExists(sql, 'snapshot_pack_provenance')) ||
+    !(yield* tableExists(sql, 'snapshot_extractor_generations'))
+  ) {
+    return undefined;
+  }
+  const currentGeneration = yield* sql<{readonly snapshot_id: string}>`
+    SELECT snapshot_id
+    FROM snapshot_extractor_generations
+    WHERE snapshot_id = ${snapshotId}
+      AND generation >= ${CODE_GRAPH_EXTRACTOR_GENERATION}
+    LIMIT 1
+  `;
+  if (!currentGeneration[0]) return undefined;
+  const rows = yield* sql<{
+    readonly cache_identity: string;
+    readonly derivation_identity: string;
+    readonly pack_id: string;
+    readonly resolution_domain: string;
+    readonly resolution_version: string;
+  }>`
+    SELECT pack_id, cache_identity, derivation_identity, resolution_domain, resolution_version
+    FROM snapshot_pack_provenance
+    WHERE snapshot_id = ${snapshotId}
+    ORDER BY pack_id
+  `;
+  return rows.map((pack): CodeGraphLanguagePackProvenance => ({
+    cacheIdentity: pack.cache_identity,
+    derivationIdentity: pack.derivation_identity,
+    id: pack.pack_id,
+    resolutionDomain: pack.resolution_domain,
+    resolutionVersion: pack.resolution_version,
+  }));
+});
 
 export const recordSnapshotPackProvenance = Effect.fn('codeGraph.recordSnapshotPackProvenance')(function* (
   sql: SqlClient.SqlClient,
@@ -14,6 +55,9 @@ export const recordSnapshotPackProvenance = Effect.fn('codeGraph.recordSnapshotP
       return yield* Effect.fail(new CodeGraphStoreError('Code graph language-pack provenance is invalid.'));
     }
     ids.add(pack.id);
+  }
+  yield* sql`DELETE FROM snapshot_pack_provenance WHERE snapshot_id = ${snapshotId}`;
+  for (const pack of provenance) {
     yield* sql`
       INSERT INTO snapshot_pack_provenance (
         snapshot_id, pack_id, cache_identity, derivation_identity,

--- a/src/code_graph/store_queries.ts
+++ b/src/code_graph/store_queries.ts
@@ -45,6 +45,7 @@ import {
 } from './store_query_core.js';
 import {materializedFileShardIdentity} from './store_cache.js';
 import {type CodeGraphSqlQueryStatement} from './store_visualization_sql.js';
+import {selectSnapshotPackProvenance} from './store_pack_provenance.js';
 
 const selectReadySnapshot = Effect.fn('codeGraph.selectReadySnapshot')(function* (worktreeId: string) {
   const sql = yield* SqlClient.SqlClient;
@@ -333,18 +334,8 @@ const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt
   `;
   const row = rows[0];
   if (!row) return undefined;
-  const packProvenance = yield* sql<{
-    readonly cache_identity: string;
-    readonly derivation_identity: string;
-    readonly pack_id: string;
-    readonly resolution_domain: string;
-    readonly resolution_version: string;
-  }>`
-    SELECT pack_id, cache_identity, derivation_identity, resolution_domain, resolution_version
-    FROM snapshot_pack_provenance
-    WHERE snapshot_id = ${snapshotId}
-    ORDER BY pack_id
-  `;
+  const packProvenance = yield* selectSnapshotPackProvenance(snapshotId);
+  if (packProvenance === undefined) return undefined;
   const lookupCount = Number(row.lookup_count);
   const aliasCount = Number(row.alias_count);
   const reexportCount = Number(row.reexport_count);
@@ -367,13 +358,7 @@ const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt
     fileSetFingerprint: row.file_set_fingerprint,
     formatVersion: Number(row.format_version),
     lookupCount,
-    packProvenance: packProvenance.map(pack => ({
-      cacheIdentity: pack.cache_identity,
-      derivationIdentity: pack.derivation_identity,
-      id: pack.pack_id,
-      resolutionDomain: pack.resolution_domain,
-      resolutionVersion: pack.resolution_version,
-    })),
+    packProvenance,
     reexportCount,
     resolutionSurfaceVersion: Number(row.resolution_surface_version),
     snapshotId: row.snapshot_id,

--- a/src/code_graph/store_service_data.ts
+++ b/src/code_graph/store_service_data.ts
@@ -21,6 +21,7 @@ import {
   selectEdgePage,
   selectEdgesForNodes,
 } from './store_queries.js';
+import {selectSnapshotPackProvenance} from './store_pack_provenance.js';
 import {pruneCachedFileBlobs} from './store_cleanup_core.js';
 import {prepareActivationTables} from './store_staging_core.js';
 import {
@@ -109,6 +110,7 @@ type CodeGraphStoreDataMethods = Pick<
   | 'currentLexicalReadySnapshotById'
   | 'readySnapshotForCommit'
   | 'reusableBaseReceipt'
+  | 'snapshotPackProvenance'
   | 'reusableCleanBase'
   | 'reusableReexports'
   | 'relationshipSummaryForNode'
@@ -560,6 +562,15 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
           exists ? useReadOnlyDatabase(databasePath, selectReusableBaseReceipt(snapshotId)) : Effect.succeed(undefined),
         ),
         Effect.mapError(cause => storeError('load reusable code graph base receipt', cause)),
+      ),
+    snapshotPackProvenance: (databasePath, snapshotId) =>
+      fs.exists(databasePath).pipe(
+        Effect.flatMap(exists =>
+          exists
+            ? useReadOnlyDatabase(databasePath, selectSnapshotPackProvenance(snapshotId))
+            : Effect.succeed(undefined),
+        ),
+        Effect.mapError(cause => storeError('load code graph snapshot language-pack provenance', cause)),
       ),
     reusableCleanBase: (
       databasePath,

--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -302,7 +302,7 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
           true,
         );
       }).pipe(Effect.mapError(cause => storeError('validate code graph view snapshot lease', cause))),
-    activate: (databasePath, identity, snapshot, files, symbols, edges) =>
+    activate: (databasePath, identity, snapshot, files, symbols, edges, snapshotPackProvenance) =>
       prepare(databasePath).pipe(
         Effect.andThen(
           withWriterGate(
@@ -317,7 +317,15 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
                 yield* stageActivationSymbols(sql, symbols, 'insert');
                 yield* stageActivationSymbolTerms(sql, symbols, 'insert');
                 yield* stageActivationEdges(sql, edges, 'insert');
-                yield* activateStagedSnapshot(sql, identity, snapshot);
+                yield* activateStagedSnapshot(
+                  sql,
+                  identity,
+                  snapshot,
+                  undefined,
+                  undefined,
+                  undefined,
+                  snapshotPackProvenance,
+                );
               }),
             ),
           ),
@@ -332,8 +340,10 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
       promotionLeaseDurationMilliseconds,
       onProgress,
       persistentCapacityProtector,
+      snapshotPackProvenance,
     ) =>
       Effect.gen(function* () {
+        const activationPackProvenance = snapshotPackProvenance ?? reusableBaseReceipt?.packProvenance;
         const promotionLease =
           promotionLeaseDurationMilliseconds === undefined
             ? Option.none<CodeGraphActivationLease>()
@@ -358,6 +368,7 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
                   reusableBaseReceipt,
                   promotionLease,
                   onProgress,
+                  activationPackProvenance,
                 ),
               );
               const capacity = yield* temporaryPublicationCapacity(sql);
@@ -380,12 +391,21 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
                 onProgress,
                 effect => withWriterGate(databasePath, effect),
                 persistentCapacityProtector,
+                activationPackProvenance,
               );
               return snapshot.id;
             }
             const publication = withWriterGate(
               databasePath,
-              activateStagedSnapshot(sql, identity, snapshot, reusableBaseReceipt, promotionLease, onProgress),
+              activateStagedSnapshot(
+                sql,
+                identity,
+                snapshot,
+                reusableBaseReceipt,
+                promotionLease,
+                onProgress,
+                activationPackProvenance,
+              ),
             );
             const capacity = yield* temporaryPublicationCapacity(sql);
             yield* persistentCapacityProtector ? persistentCapacityProtector(capacity, publication) : publication;

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -15,6 +15,7 @@ import type {
   CodeGraphDirectPersistentCapacityProtector,
   CodeGraphEdgeCursor,
   CodeGraphPersistentBuildClaim,
+  CodeGraphLanguagePackProvenance,
   CodeGraphRemovedViewCleanupAuthorizationResult,
   CodeGraphRemovedViewCleanupEntry,
   CodeGraphRemovedViewCleanupStoreOptions,
@@ -90,6 +91,7 @@ export interface CodeGraphStoreShape {
     files: readonly CodeGraphInventoryFile[],
     symbols: readonly CodeGraphSymbol[],
     edges: readonly CodeGraphEdge[],
+    snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
   ) => Effect.Effect<void, CodeGraphStoreError>;
   readonly activateStaged: (
     databasePath: string,
@@ -99,6 +101,7 @@ export interface CodeGraphStoreShape {
     promotionLeaseDurationMilliseconds?: number,
     onProgress?: CodeGraphActivationProgressCallback,
     persistentCapacityProtector?: CodeGraphDirectPersistentCapacityProtector,
+    snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
   ) => Effect.Effect<Option.Option<string>, CodeGraphStoreError>;
   readonly activateCleanSnapshotAlias?: (
     databasePath: string,
@@ -409,6 +412,10 @@ export interface CodeGraphStoreShape {
     databasePath: string,
     snapshotId: string,
   ) => Effect.Effect<CodeGraphReusableBaseReceipt | undefined, CodeGraphStoreError>;
+  readonly snapshotPackProvenance: (
+    databasePath: string,
+    snapshotId: string,
+  ) => Effect.Effect<readonly CodeGraphLanguagePackProvenance[] | undefined, CodeGraphStoreError>;
   readonly reusableCleanBase?: (
     databasePath: string,
     repositoryId: string,

--- a/test/integration/code-graph.cross-session-incremental.test.ts
+++ b/test/integration/code-graph.cross-session-incremental.test.ts
@@ -9,6 +9,7 @@ import {Context, Effect, Layer, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {CodeGraphQueryService} from '../../src/code_graph/query.js';
 import {
   BUILTIN_LANGUAGE_PACK_REGISTRY,
   CodeGraphLanguagePackRegistry,
@@ -266,6 +267,58 @@ describe('cross-session code graph increments', () => {
         Effect.ensuring(removeTemporaryPaths(() => [root, home, referenceHome])),
         provideTestLayer(ApplicationLayer),
         TestClock.withLive,
+      );
+    },
+    60_000,
+  );
+
+  it.effect(
+    'refreshes a clean ready snapshot when the current language pack accepts a previously omitted AXL source',
+    () => {
+      let home: string | undefined;
+      let root: string | undefined;
+      return Effect.gen(function* () {
+        root = createRepository();
+        home = mkdtempSync(join(tmpdir(), 'threadnote-axl-pack-upgrade-home-'));
+        const axlPath = 'crates/aspect-cli/src/builtins/aspect/bazel.axl';
+        mkdirSync(join(root, 'crates/aspect-cli/src/builtins/aspect'), {recursive: true});
+        writeFileSync(join(root, 'BUILD.bazel'), 'exports_files(["package.json"])\n');
+        writeFileSync(join(root, axlPath), 'UPGRADE_MARKER = 1\n');
+        git(root, ['add', '.']);
+        git(root, ['commit', '--amend', '-qm', 'fixture with AXL source']);
+
+        const legacyRegistry = createCodeGraphLanguagePackRegistry(
+          BUILTIN_LANGUAGE_PACK_REGISTRY.packs.map(pack =>
+            pack.id === 'bazel'
+              ? {...pack, files: pack.files.filter(matcher => matcher.value !== '.axl'), version: '1.0.0'}
+              : pack,
+          ),
+        );
+        const legacy = yield* indexWithRegistry(root, home, legacyRegistry);
+        const query = yield* CodeGraphQueryService;
+        const before = yield* query.status(home, root, {requestMaintenance: false});
+
+        expect(legacy.snapshot.fileCount).toBe(3);
+        expect(before).toMatchObject({freshness: 'stale', stale: true});
+
+        const refreshed = yield* query.inspect({
+          cwd: root,
+          operation: 'query',
+          query: axlPath,
+          refresh: true,
+          requestMaintenance: false,
+          threadnoteHome: home,
+        });
+
+        expect(refreshed.freshness).toBe('current');
+        expect(refreshed.snapshot.id).not.toBe(legacy.snapshot.id);
+        expect(refreshed.nodes).toEqual(
+          expect.arrayContaining([expect.objectContaining({language: 'starlark', path: axlPath})]),
+        );
+      }).pipe(
+        provideTestLayer(ApplicationLayer),
+        TestClock.withLive,
+        Effect.ensuring(removeTemporaryPaths(() => [root, home])),
       );
     },
     60_000,

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -4187,7 +4187,7 @@ describe('native code graph lifecycle', () => {
         const query = yield* CodeGraphQueryService;
         const indexed = yield* indexer.index({cwd: root, threadnoteHome: home});
         replaceFunction(root, 'ensureVectorIndex', 'ensureDirtyVectorIndex');
-        const stale = yield* query.status(home, root);
+        const stale = yield* query.status(home, root, {requestMaintenance: false});
         yield* store.markBuilding(before.databasePath, indexed.identity, {
           ...indexed.snapshot,
           id: `${indexed.snapshot.id}-interrupted`,

--- a/test/integration/code-graph.view-attach-lock.test.ts
+++ b/test/integration/code-graph.view-attach-lock.test.ts
@@ -8,6 +8,8 @@ import {TestClock} from 'effect/testing';
 import {it as effectIt} from '@effect/vitest';
 import {afterEach, describe, expect, it} from 'vitest';
 import {CodeGraphDiskCapacityPressureError} from '../../src/code_graph/disk_capacity.js';
+import {extractorSetIdentityFromPackProvenance} from '../../src/code_graph/indexer.js';
+import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../../src/code_graph/languages/registry.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {CodeGraphQueryService} from '../../src/code_graph/query.js';
 import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
@@ -19,6 +21,7 @@ import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
 const temporaryRoots: string[] = [];
+const fixturePackProvenance = BUILTIN_LANGUAGE_PACK_REGISTRY.activePackProvenance(['main.ts']);
 
 afterEach(() => {
   for (const root of temporaryRoots.splice(0).reverse()) rmSync(root, {force: true, recursive: true});
@@ -36,7 +39,7 @@ describe('shared ready view attachment locking', () => {
       const identity = yield* resolveRepositoryIdentity(repositoryRoot);
       const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
       const snapshot = readySnapshot(identity);
-      yield* store.activate(layout.databasePath, identity, snapshot, [], [], []);
+      yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
       yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
       const before = yield* graph.statusForIdentity(threadnoteHome, identity);
       let promotionProbes = 0;
@@ -80,7 +83,7 @@ describe('shared ready view attachment locking', () => {
         const identity = yield* resolveRepositoryIdentity(repositoryRoot);
         const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
         const snapshot = readySnapshot(identity);
-        yield* store.activate(layout.databasePath, identity, snapshot, [], [], []);
+        yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
         yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
         const before = yield* graph.statusForIdentity(threadnoteHome, identity);
 
@@ -172,7 +175,7 @@ describe('shared ready view attachment locking', () => {
         const identity = yield* resolveRepositoryIdentity(repositoryRoot);
         const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
         const snapshot = readySnapshot(identity);
-        yield* store.activate(layout.databasePath, identity, snapshot, [], [], []);
+        yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
         yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
         const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
           afterOptimisticCandidate: () => Effect.sync(() => git(repositoryRoot, ['reset', '--hard', nextCommit])),
@@ -203,7 +206,7 @@ describe('shared ready view attachment locking', () => {
         const identity = yield* resolveRepositoryIdentity(repositoryRoot);
         const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
         const snapshot = readySnapshot(identity);
-        yield* store.activate(layout.databasePath, identity, snapshot, [], [], []);
+        yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
         yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
         const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
           afterPromotion: () =>
@@ -236,7 +239,7 @@ describe('shared ready view attachment locking', () => {
         const identity = yield* resolveRepositoryIdentity(repositoryRoot);
         const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
         const snapshot = readySnapshot(identity);
-        yield* store.activate(layout.databasePath, identity, snapshot, [], [], []);
+        yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
         yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
         const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
           afterPromotion: () =>
@@ -287,7 +290,7 @@ function readySnapshot(identity: RepositoryIdentity): CodeGraphSnapshot {
     completedAt: '2026-08-08T00:00:00.000Z',
     dirty: false,
     edgeCount: 0,
-    extractorSet: 'view-attach-lock-test',
+    extractorSet: extractorSetIdentityFromPackProvenance(fixturePackProvenance),
     fileCount: 0,
     id: 'snapshot-view-attach-lock',
     repositoryId: identity.repositoryId,

--- a/test/unit/code-graph.pack-provenance.property.test.ts
+++ b/test/unit/code-graph.pack-provenance.property.test.ts
@@ -2,7 +2,13 @@ import {describe, expect, it} from '@effect/vitest';
 import {Effect} from 'effect';
 import * as FC from 'effect/testing/FastCheck';
 import {extractorSetIdentityFromPackProvenance} from '../../src/code_graph/indexer.js';
+import {
+  BUILTIN_LANGUAGE_PACK_REGISTRY,
+  codeGraphLanguagePackProvenance,
+  createCodeGraphLanguagePackRegistry,
+} from '../../src/code_graph/languages/registry.js';
 import {assessCodeGraphLanguagePackDelta} from '../../src/code_graph/languages/provenance.js';
+import {codeGraphSnapshotMatchesCurrentLanguagePacks} from '../../src/code_graph/query.js';
 import type {CodeGraphLanguagePackProvenance} from '../../src/code_graph/store.js';
 
 const packIds = ['typescript', 'bazel', 'python', 'java'] as const;
@@ -52,6 +58,37 @@ describe('code graph language-pack provenance', () => {
         reason: 'missing-provenance',
       });
     }),
+  );
+
+  it.effect.prop(
+    'recognizes current snapshot contracts independent of active-pack ordering and rejects provenance drift',
+    {
+      activeIds: FC.uniqueArray(FC.constantFrom(...packIds), {minLength: 1}),
+      reverseCatalog: FC.boolean(),
+      reverseReceipt: FC.boolean(),
+    },
+    ({activeIds, reverseCatalog, reverseReceipt}) =>
+      Effect.sync(() => {
+        const activeIdSet = new Set<string>(activeIds);
+        const selected = BUILTIN_LANGUAGE_PACK_REGISTRY.packs.filter(value => activeIdSet.has(value.id));
+        const registry = createCodeGraphLanguagePackRegistry(reverseCatalog ? [...selected].reverse() : selected);
+        const provenance = selected.map(codeGraphLanguagePackProvenance);
+        const extractorSet = extractorSetIdentityFromPackProvenance(provenance);
+        const snapshot = {extractorSet};
+        const storedProvenance = reverseReceipt ? [...provenance].reverse() : provenance;
+
+        expect(codeGraphSnapshotMatchesCurrentLanguagePacks(snapshot, storedProvenance, registry)).toBe(true);
+        expect(
+          codeGraphSnapshotMatchesCurrentLanguagePacks(
+            snapshot,
+            storedProvenance.map((value, index) =>
+              index === 0 ? {...value, cacheIdentity: `${value.cacheIdentity}-stale`} : value,
+            ),
+            registry,
+          ),
+        ).toBe(false);
+      }),
+    {fastCheck: {numRuns: 100}},
   );
 });
 

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -13,7 +13,7 @@ import type {CodeGraphEmbeddingIndexShape} from '../../src/code_graph/embedding.
 import {CodeGraphEmbeddingIndex} from '../../src/code_graph/embedding.js';
 import {CommandExecutor} from '../../src/effect/command.js';
 import {SystemInfo} from '../../src/effect/system.js';
-import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {CodeGraphIndexer, extractorSetIdentityFromPackProvenance} from '../../src/code_graph/indexer.js';
 import {CodeGraphLanguagePackRegistry} from '../../src/code_graph/languages/registry.js';
 import type {CodeGraphLayout} from '../../src/code_graph/layout.js';
 import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
@@ -147,6 +147,7 @@ describe('code graph query budgets', () => {
             readySnapshot: () => Ref.get(snapshotRef),
             readySnapshotForCommit: () => Effect.succeed(undefined),
             releaseSnapshotLease: () => Effect.void,
+            snapshotPackProvenance: () => Effect.succeed([]),
             symbolsByIds: () => Effect.succeed([]),
             withSession: (_databasePath: string, effect: Effect.Effect<unknown, unknown, unknown>) => effect,
           } as unknown as CodeGraphStoreShape),
@@ -184,7 +185,7 @@ describe('code graph query budgets', () => {
             completedAt: '2026-08-08T00:00:00.000Z',
             dirty: false,
             edgeCount: 0,
-            extractorSet: 'query-maintenance-test',
+            extractorSet: extractorSetIdentityFromPackProvenance([]),
             fileCount: 1,
             id: `cgsn_${'1'.repeat(40)}`,
             repositoryId: identity.repositoryId,


### PR DESCRIPTION
## What changed

- persist active language-pack provenance on every graph snapshot shape
- treat snapshots as stale when their recorded parser contract differs from the installed runtime
- refresh older clean graphs so newly supported Aspect `.axl` sources are indexed as Starlark
- add upgrade regression and bounded property coverage
- prepare Threadnote 4.2.1 with curated release notes

## Root cause

Graph freshness compared only Git commit and worktree state. A clean snapshot built before the Bazel pack admitted
`.axl` could therefore remain “current” after Threadnote was upgraded, even though it omitted those files.

## User impact

A current graph query now rebuilds incompatible older snapshots automatically. Existing Aspect CLI graphs discover
`.axl` modules, declarations, imports, and relationships after upgrading.

## Validation

- full Vitest suite: 304 files; 2,987 passed; 1 skipped
- lint plus source, test, and website type checks
- release contract tests: 4 files; 25 tests
- real v4.0.8 → installed 4.2.1 development runtime smoke against `aspect-build/aspect-cli`: 271 → 420
  indexed files and 8 Starlark nodes for `crates/aspect-cli/src/builtins/aspect/bazel.axl`
