### PR TITLE
release: Threadnote 4.2.2 graph readiness

### DIFF
--- a/.github/release-notes/v4.2.2.md
+++ b/.github/release-notes/v4.2.2.md
@@ -1,0 +1,32 @@
+## What's new
+
+Threadnote 4.2.2 keeps native code graphs available while work moves across linked worktrees and reduces unnecessary
+whole-repository graph rebuilds after ordinary source-file changes.
+
+### Ready graphs across active worktrees
+
+- A newly created linked worktree can attach an existing clean snapshot immediately instead of waiting for another cold
+  graph build.
+- After a source edit, graph queries continue to return usable current or stale evidence while the refreshed snapshot
+  converges, across TypeScript, Python, and Rust repositories.
+- Two worktrees from the same repository can build at the same time without sharing dirty state or blocking one another.
+
+### Smaller refreshes for project-scoped changes
+
+- Adding, deleting, or renaming a source file inside a complete declared project graph now refreshes only the affected
+  project and its reverse dependencies when that closure is safe and bounded.
+- The same bounded behavior applies to uncommitted edits and committed changes.
+- Ambiguous ownership, incomplete project metadata, global resolution changes, and other uncertain cases still fall back
+  to full materialization.
+
+To require evidence from the latest graph after an edit, run:
+
+```sh
+threadnote graph query --cwd /path/to/worktree --freshness current --query YourSymbol
+```
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/code_graph/incremental_closure.ts
+++ b/src/code_graph/incremental_closure.ts
@@ -61,6 +61,84 @@ export type ProjectClosureSeedAssessment =
       readonly reason: 'dynamic-aliases' | 'project-closure-incomplete' | 'resolution-surface-changed';
     };
 
+/**
+ * File additions and deletions have no before/after fact pair to compare. They
+ * may still use project-closure materialization when every changed path has a
+ * unique owner in a complete declared dependency model. Deletions are resolved
+ * against the base workspace; current additions and modifications use the
+ * current workspace.
+ */
+export function assessProjectFileSetClosureSeeds(input: {
+  readonly baseProjects: readonly CodeGraphWorkspaceProject[];
+  readonly currentChangedPaths: readonly string[];
+  readonly currentProjects: readonly CodeGraphWorkspaceProject[];
+  readonly deletedPaths: readonly string[];
+}): ProjectClosureSeedAssessment {
+  const baseProjectsById = uniqueProjectsById(input.baseProjects);
+  const currentProjectsById = uniqueProjectsById(input.currentProjects);
+  if (
+    baseProjectsById === undefined ||
+    currentProjectsById === undefined ||
+    !hasCompleteDeclaredDependencyModel(input.baseProjects, baseProjectsById) ||
+    !hasCompleteDeclaredDependencyModel(input.currentProjects, currentProjectsById)
+  ) {
+    return incompleteSeeds();
+  }
+  const seeds = new Set<string>();
+  let ownershipChecks = 0;
+  const collect = (
+    paths: readonly string[],
+    projects: readonly CodeGraphWorkspaceProject[],
+    projectsById: ReadonlyMap<string, CodeGraphWorkspaceProject>,
+  ): boolean => {
+    const indexesByDomain = projectPathIndexesByDomain(projects);
+    for (const path of uniqueSorted(paths)) {
+      let owned = false;
+      for (const [domain, indexes] of indexesByDomain) {
+        ownershipChecks += 1;
+        const owner = nearestProject(indexes, path);
+        if (owner.mode !== 'unique') return false;
+        if (owner.projectId === undefined) continue;
+        const project = projectsById.get(owner.projectId);
+        const currentProject = currentProjectsById.get(owner.projectId);
+        if (
+          !project ||
+          !currentProject ||
+          project.resolutionDomain !== domain ||
+          currentProject.resolutionDomain !== domain ||
+          project.provenance !== 'declared' ||
+          currentProject.provenance !== 'declared' ||
+          project.buildSystem === 'inferred' ||
+          currentProject.buildSystem === 'inferred' ||
+          project.diagnostics.length > 0 ||
+          currentProject.diagnostics.length > 0
+        ) {
+          return false;
+        }
+        seeds.add(owner.projectId);
+        owned = true;
+      }
+      if (!owned) return false;
+    }
+    return true;
+  };
+  if (
+    !collect(input.currentChangedPaths, input.currentProjects, currentProjectsById) ||
+    !collect(input.deletedPaths, input.baseProjects, baseProjectsById) ||
+    seeds.size === 0
+  ) {
+    return incompleteSeeds();
+  }
+  return {
+    mode: 'eligible',
+    planningOperations: {
+      ownershipChecks,
+      pathIndexProjects: input.baseProjects.length + input.currentProjects.length,
+    },
+    seedProjectIds: [...seeds].sort(compareCodeUnits),
+  };
+}
+
 export function planProjectIncrementalClosure(input: ProjectIncrementalClosureInput): ProjectIncrementalClosurePlan {
   const selection = selectProjectIncrementalClosure(input);
   if (selection.mode === 'fallback') return selection;
@@ -370,6 +448,17 @@ function hasCompleteDeclaredDependencyModel(
     }
   }
   return true;
+}
+
+function uniqueProjectsById(
+  projects: readonly CodeGraphWorkspaceProject[],
+): ReadonlyMap<string, CodeGraphWorkspaceProject> | undefined {
+  const projectsById = new Map<string, CodeGraphWorkspaceProject>();
+  for (const project of projects) {
+    if (projectsById.has(project.id)) return undefined;
+    projectsById.set(project.id, project);
+  }
+  return projectsById;
 }
 
 function hasSameGlobalSymbolSurface(left: CodeGraphSymbol, right: CodeGraphSymbol): boolean {

--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -634,10 +634,11 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
           persistentCapacityProtector: codeGraphDirectPersistentCapacityProtector(input),
           store: input.store,
         };
-        const sameFileSet = deletedPaths.length === 0 && modifiedFiles.every(file => baseByPath.has(file.path));
-        const boundedAssessment = sameFileSet
-          ? yield* assessReusableCleanBaseCompatibility(assessmentInput, workspace, modifiedFiles)
-          : ({mode: 'fallback', reason: 'file-set-changed'} as const);
+        const boundedAssessment = yield* assessReusableCleanBaseCompatibility(
+          assessmentInput,
+          workspace,
+          modifiedFiles,
+        );
         if (boundedAssessment.mode === 'fallback') {
           return Option.some<ReusableCleanSnapshotAttempt>(boundedAssessment);
         }
@@ -850,11 +851,7 @@ export const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirt
     persistentCapacityProtector: input.persistentCapacityProtector,
     store: input.store,
   };
-  const sameFileSet =
-    alignedCommitCandidate || (deletedPaths.length === 0 && modifiedFiles.every(file => baseByPath!.has(file.path)));
-  const boundedAssessment = sameFileSet
-    ? yield* assessReusableCleanBaseCompatibility(assessmentInput, workspace, modifiedFiles)
-    : ({mode: 'fallback', reason: 'file-set-changed'} as const);
+  const boundedAssessment = yield* assessReusableCleanBaseCompatibility(assessmentInput, workspace, modifiedFiles);
   if (boundedAssessment.mode === 'fallback') return Option.none();
   const preassessment = boundedAssessment;
   return Option.some({

--- a/src/code_graph/indexer_incremental.ts
+++ b/src/code_graph/indexer_incremental.ts
@@ -4,6 +4,7 @@ import {createRepositoryFactAttributor} from './extractor.js';
 import {finalCodeGraphFactBatches, serializeBoundedCodeGraphFact} from './fact_budget.js';
 import {
   assessProjectClosureSeeds,
+  assessProjectFileSetClosureSeeds,
   planProjectIncrementalClosure,
   PROJECT_INCREMENTAL_CLOSURE_MAX_CACHED_FACT_BYTES,
   PROJECT_INCREMENTAL_CLOSURE_MAX_FILES,
@@ -100,7 +101,7 @@ export const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOv
       receipt.resolutionSurfaceVersion !== 1 ||
       receipt.workspaceFingerprint !== preassessment.committedWorkspace.fingerprint ||
       (preassessment.resolutionClosure !== 'full' &&
-        receipt.fileSetFingerprint !== reusableBaseFileSetFingerprint(input.inventory.committedFiles))
+        receipt.fileSetFingerprint !== preassessment.baseFileSetFingerprint)
     ) {
       return {mode: 'fallback', reason: 'staging-unavailable'} satisfies IncrementalOverlayAssessment;
     }
@@ -139,7 +140,11 @@ export const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOv
     }
   }
   const finalBatches = finalCodeGraphFactBatches(reusableFacts);
-  if (finalBatches.length !== 1 && preassessment.resolutionClosure !== 'full') {
+  const deletionOnlyProjectClosure =
+    reusableFacts.length === 0 &&
+    (preassessment.deletedPaths?.length ?? 0) > 0 &&
+    preassessment.resolutionClosure === 'project';
+  if (finalBatches.length !== 1 && preassessment.resolutionClosure !== 'full' && !deletionOnlyProjectClosure) {
     return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayAssessment;
   }
   const facts = finalBatches.flatMap(batch => batch.map(value => value.facts));
@@ -182,15 +187,13 @@ export const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assess
       input.inventory.workspace ?? (yield* input.languagePacks.discoverWorkspace(input.inventory.committedFiles));
     const committedByPath = new Map(input.inventory.committedFiles.map(file => [file.path, file]));
     const effectiveByPath = new Map(input.inventory.files.map(file => [file.path, file]));
-    if (
-      committedByPath.size !== effectiveByPath.size ||
-      [...committedByPath].some(([path]) => !effectiveByPath.has(path))
-    ) {
-      return {mode: 'fallback', reason: 'file-set-changed'} satisfies IncrementalOverlayPreassessment;
-    }
+    const deletedPaths = input.inventory.committedFiles
+      .filter(file => !effectiveByPath.has(file.path))
+      .map(file => file.path);
     const modifiedFiles = input.inventory.files.filter(file => {
-      const committed = committedByPath.get(file.path)!;
+      const committed = committedByPath.get(file.path);
       return (
+        committed === undefined ||
         committed.contentHash !== file.contentHash ||
         committed.language !== file.language ||
         committed.mode !== file.mode ||
@@ -198,12 +201,27 @@ export const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assess
         committed.source !== file.source
       );
     });
-    if (modifiedFiles.length === 0) {
+    if (modifiedFiles.length === 0 && deletedPaths.length === 0) {
       return {mode: 'fallback', reason: 'no-materialized-changes'} satisfies IncrementalOverlayPreassessment;
     }
     const workspaceCompatibility = assessCodeGraphWorkspaceCompatibility(committedWorkspace, workspace);
     if (workspaceCompatibility.mode === 'fallback') {
       return workspaceCompatibility satisfies IncrementalOverlayPreassessment;
+    }
+    if (deletedPaths.length > 0 || modifiedFiles.some(file => !committedByPath.has(file.path))) {
+      return yield* assessProjectFileSetIncrementalClosureCompatibility({
+        baseFileSetFingerprint: reusableBaseFileSetFingerprint(input.inventory.committedFiles),
+        baseWorkspace: committedWorkspace,
+        currentChangedFiles: modifiedFiles,
+        currentFiles: input.inventory.files,
+        currentWorkspace: workspace,
+        deletedPaths,
+        languagePacks: input.languagePacks,
+        layout: input.layout,
+        store: input.store,
+        workspaceSeedProjectIds:
+          workspaceCompatibility.mode === 'project-closure' ? workspaceCompatibility.seedProjectIds : [],
+      });
     }
     const committedFiles = modifiedFiles.map(file => committedByPath.get(file.path)!);
     const changedDecodeBudget = yield* assessProjectClosureChangedDecodeBudget({
@@ -250,6 +268,7 @@ export const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assess
         return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
       }
       return {
+        baseFileSetFingerprint: reusableBaseFileSetFingerprint(input.inventory.committedFiles),
         committedWorkspace,
         facts: effectiveFacts,
         files: modifiedFiles,
@@ -257,6 +276,7 @@ export const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assess
       } satisfies IncrementalOverlayPreassessment;
     }
     return yield* assessProjectIncrementalClosureCompatibility({
+      baseFileSetFingerprint: reusableBaseFileSetFingerprint(input.inventory.committedFiles),
       baseWorkspace: committedWorkspace,
       changedBaseFacts: committedFacts,
       changedCurrentFacts: effectiveFacts,
@@ -304,8 +324,28 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
     if (input.candidate.receipt.workspaceFingerprint !== workspace.fingerprint) {
       return {mode: 'fallback', reason: 'workspace-changed'} satisfies IncrementalOverlayPreassessment;
     }
-    if (modifiedFiles.length === 0) {
+    const currentPaths = new Set(input.inventory.files.map(file => file.path));
+    const deletedPaths = input.candidate.files.filter(file => !currentPaths.has(file.path)).map(file => file.path);
+    if (modifiedFiles.length === 0 && deletedPaths.length === 0) {
       return {mode: 'fallback', reason: 'no-materialized-changes'} satisfies IncrementalOverlayPreassessment;
+    }
+    const baseByPath = new Map(input.candidate.files.map(file => [file.path, file]));
+    if (deletedPaths.length > 0 || modifiedFiles.some(file => !baseByPath.has(file.path))) {
+      if (extractorTransition) {
+        return {mode: 'fallback', reason: 'extractor-context-changed'} satisfies IncrementalOverlayPreassessment;
+      }
+      return yield* assessProjectFileSetIncrementalClosureCompatibility({
+        baseFileSetFingerprint: reusableBaseFileSetFingerprint(input.candidate.files),
+        baseWorkspace: workspace,
+        currentChangedFiles: modifiedFiles,
+        currentFiles: input.inventory.files,
+        currentWorkspace: workspace,
+        deletedPaths,
+        languagePacks: input.languagePacks,
+        layout: input.layout,
+        store: input.store,
+        workspaceSeedProjectIds: [],
+      });
     }
     const baseFiles = inventoryFilesForPaths(
       input.candidate.files,
@@ -370,6 +410,7 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
     const dynamicAliases = hasDynamicAliases(baseFacts) || hasDynamicAliases(currentFacts);
     if (dynamicAliases || resolutionSurfaceChanged) {
       const closure = yield* assessProjectIncrementalClosureCompatibility({
+        baseFileSetFingerprint: reusableBaseFileSetFingerprint(input.candidate.files),
         baseWorkspace: workspace,
         changedBaseFacts: baseFacts,
         changedCurrentFacts: currentFacts,
@@ -401,6 +442,7 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
       input.persistentCapacityProtector,
     );
     return {
+      baseFileSetFingerprint: reusableBaseFileSetFingerprint(input.candidate.files),
       committedWorkspace: workspace,
       ...(extractorTransition ? {extractorTransition: true as const} : {}),
       facts: currentFacts,
@@ -413,6 +455,7 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
 const assessProjectIncrementalClosureCompatibility = Effect.fn(
   'codeGraph.assessProjectIncrementalClosureCompatibility',
 )(function* (input: {
+  readonly baseFileSetFingerprint: string;
   readonly baseWorkspace: CodeGraphWorkspace;
   readonly changedBaseFacts: readonly CodeGraphFileFacts[];
   readonly changedCurrentFacts: readonly CodeGraphFileFacts[];
@@ -435,63 +478,133 @@ const assessProjectIncrementalClosureCompatibility = Effect.fn(
   const seedProjectIds = [...new Set([...seeds.seedProjectIds, ...input.workspaceSeedProjectIds])].sort(
     compareCodeUnits,
   );
-  const selection = selectProjectIncrementalClosure({
-    files: input.currentFiles,
-    modifiedPaths: input.currentChangedFiles.map(file => file.path),
-    projects: input.currentWorkspace.projects,
-    seedProjectIds,
-    workspaceDiagnostics: input.currentWorkspace.diagnostics,
-  });
-  if (selection.mode === 'fallback') {
-    return selection satisfies IncrementalOverlayPreassessment;
-  }
-  const currentByPath = new Map(input.currentFiles.map(file => [file.path, file]));
-  const affectedFiles = selection.affectedPaths.map(path => currentByPath.get(path)!);
-  const metadata = yield* cachedFactsMetadata(
-    input.store,
-    input.layout.databasePath,
-    affectedFiles,
-    input.languagePacks,
-  );
-  const plan = planProjectIncrementalClosure({
-    cachedFactBytesByPath: metadata.bytesByPath,
-    files: input.currentFiles,
-    modifiedPaths: input.currentChangedFiles.map(file => file.path),
-    projects: input.currentWorkspace.projects,
-    seedProjectIds,
-    workspaceDiagnostics: input.currentWorkspace.diagnostics,
-  });
-  if (plan.mode === 'fallback') {
-    return plan satisfies IncrementalOverlayPreassessment;
-  }
-  if (metadata.files !== affectedFiles.length || plan.affectedPaths.length !== affectedFiles.length) {
-    return {mode: 'fallback', reason: 'cache-incomplete'} satisfies IncrementalOverlayPreassessment;
-  }
-  const currentCache = yield* loadCachedFacts(
-    input.store,
-    input.layout.databasePath,
-    affectedFiles,
-    input.languagePacks,
-  );
-  if (affectedFiles.some(file => !currentCache.facts.has(file.path))) {
-    return {mode: 'fallback', reason: 'cache-incomplete'} satisfies IncrementalOverlayPreassessment;
-  }
-  const currentRawFacts = affectedFiles.map(file =>
-    input.languagePacks.postprocessFile(file, currentCache.facts.get(file.path)!),
-  );
-  const currentFacts = attributeInventoryFacts(input.currentFiles, input.currentWorkspace, currentRawFacts);
-  if (finalCodeGraphFactBatches(currentFacts).length !== 1) {
-    return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
-  }
-  return {
-    closureProjects: plan.projectIds.length,
+  return yield* assessPlannedProjectIncrementalClosure({
+    baseFileSetFingerprint: input.baseFileSetFingerprint,
     committedWorkspace: input.baseWorkspace,
-    facts: currentFacts,
-    files: affectedFiles,
-    mode: 'compatible',
-    resolutionClosure: 'project',
-  } satisfies IncrementalOverlayPreassessment;
+    currentChangedFiles: input.currentChangedFiles,
+    currentFiles: input.currentFiles,
+    currentWorkspace: input.currentWorkspace,
+    languagePacks: input.languagePacks,
+    layout: input.layout,
+    seedProjectIds,
+    store: input.store,
+  });
 });
+
+const assessProjectFileSetIncrementalClosureCompatibility = Effect.fn(
+  'codeGraph.assessProjectFileSetIncrementalClosureCompatibility',
+)(function* (input: {
+  readonly baseFileSetFingerprint: string;
+  readonly baseWorkspace: CodeGraphWorkspace;
+  readonly currentChangedFiles: readonly CodeGraphInventoryFile[];
+  readonly currentFiles: readonly CodeGraphInventoryFile[];
+  readonly currentWorkspace: CodeGraphWorkspace;
+  readonly deletedPaths: readonly string[];
+  readonly languagePacks: CodeGraphLanguagePackRegistryShape;
+  readonly layout: CodeGraphLayout;
+  readonly store: CodeGraphStoreShape;
+  readonly workspaceSeedProjectIds: readonly string[];
+}) {
+  if (input.baseWorkspace.projects.length === 0 || input.currentWorkspace.projects.length === 0) {
+    return {mode: 'fallback', reason: 'file-set-changed'} satisfies IncrementalOverlayPreassessment;
+  }
+  const seeds = assessProjectFileSetClosureSeeds({
+    baseProjects: input.baseWorkspace.projects,
+    currentChangedPaths: input.currentChangedFiles.map(file => file.path),
+    currentProjects: input.currentWorkspace.projects,
+    deletedPaths: input.deletedPaths,
+  });
+  if (seeds.mode === 'fallback') return seeds satisfies IncrementalOverlayPreassessment;
+  const seedProjectIds = [...new Set([...seeds.seedProjectIds, ...input.workspaceSeedProjectIds])].sort(
+    compareCodeUnits,
+  );
+  return yield* assessPlannedProjectIncrementalClosure({
+    baseFileSetFingerprint: input.baseFileSetFingerprint,
+    committedWorkspace: input.baseWorkspace,
+    currentChangedFiles: input.currentChangedFiles,
+    currentFiles: input.currentFiles,
+    currentWorkspace: input.currentWorkspace,
+    deletedPaths: input.deletedPaths,
+    languagePacks: input.languagePacks,
+    layout: input.layout,
+    seedProjectIds,
+    store: input.store,
+  });
+});
+
+const assessPlannedProjectIncrementalClosure = Effect.fn('codeGraph.assessPlannedProjectIncrementalClosure')(
+  function* (input: {
+    readonly baseFileSetFingerprint: string;
+    readonly committedWorkspace: CodeGraphWorkspace;
+    readonly currentChangedFiles: readonly CodeGraphInventoryFile[];
+    readonly currentFiles: readonly CodeGraphInventoryFile[];
+    readonly currentWorkspace: CodeGraphWorkspace;
+    readonly deletedPaths?: readonly string[];
+    readonly languagePacks: CodeGraphLanguagePackRegistryShape;
+    readonly layout: CodeGraphLayout;
+    readonly seedProjectIds: readonly string[];
+    readonly store: CodeGraphStoreShape;
+  }) {
+    const selection = selectProjectIncrementalClosure({
+      files: input.currentFiles,
+      modifiedPaths: input.currentChangedFiles.map(file => file.path),
+      projects: input.currentWorkspace.projects,
+      seedProjectIds: input.seedProjectIds,
+      workspaceDiagnostics: input.currentWorkspace.diagnostics,
+    });
+    if (selection.mode === 'fallback') {
+      return selection satisfies IncrementalOverlayPreassessment;
+    }
+    const currentByPath = new Map(input.currentFiles.map(file => [file.path, file]));
+    const affectedFiles = selection.affectedPaths.map(path => currentByPath.get(path)!);
+    const metadata = yield* cachedFactsMetadata(
+      input.store,
+      input.layout.databasePath,
+      affectedFiles,
+      input.languagePacks,
+    );
+    const plan = planProjectIncrementalClosure({
+      cachedFactBytesByPath: metadata.bytesByPath,
+      files: input.currentFiles,
+      modifiedPaths: input.currentChangedFiles.map(file => file.path),
+      projects: input.currentWorkspace.projects,
+      seedProjectIds: input.seedProjectIds,
+      workspaceDiagnostics: input.currentWorkspace.diagnostics,
+    });
+    if (plan.mode === 'fallback') {
+      return plan satisfies IncrementalOverlayPreassessment;
+    }
+    if (metadata.files !== affectedFiles.length || plan.affectedPaths.length !== affectedFiles.length) {
+      return {mode: 'fallback', reason: 'cache-incomplete'} satisfies IncrementalOverlayPreassessment;
+    }
+    const currentCache = yield* loadCachedFacts(
+      input.store,
+      input.layout.databasePath,
+      affectedFiles,
+      input.languagePacks,
+    );
+    if (affectedFiles.some(file => !currentCache.facts.has(file.path))) {
+      return {mode: 'fallback', reason: 'cache-incomplete'} satisfies IncrementalOverlayPreassessment;
+    }
+    const currentRawFacts = affectedFiles.map(file =>
+      input.languagePacks.postprocessFile(file, currentCache.facts.get(file.path)!),
+    );
+    const currentFacts = attributeInventoryFacts(input.currentFiles, input.currentWorkspace, currentRawFacts);
+    if (finalCodeGraphFactBatches(currentFacts).length !== 1) {
+      return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
+    }
+    return {
+      baseFileSetFingerprint: input.baseFileSetFingerprint,
+      closureProjects: plan.projectIds.length,
+      committedWorkspace: input.committedWorkspace,
+      deletedPaths: input.deletedPaths,
+      facts: currentFacts,
+      files: affectedFiles,
+      mode: 'compatible',
+      resolutionClosure: 'project',
+    } satisfies IncrementalOverlayPreassessment;
+  },
+);
 
 const assessProjectClosureChangedDecodeBudget = Effect.fn('codeGraph.assessProjectClosureChangedDecodeBudget')(
   function* (input: {

--- a/src/code_graph/indexer_types.ts
+++ b/src/code_graph/indexer_types.ts
@@ -81,6 +81,7 @@ export type IncrementalOverlayAssessment =
 
 export type IncrementalOverlayPreassessment =
   | {
+      readonly baseFileSetFingerprint: string;
       readonly committedWorkspace: CodeGraphWorkspace;
       readonly facts: readonly CodeGraphFileFacts[];
       readonly files: readonly CodeGraphInventoryFile[];

--- a/src/code_graph/store_build_core.ts
+++ b/src/code_graph/store_build_core.ts
@@ -769,15 +769,11 @@ const persistedIncrementalProjectFilesMatch = Effect.fn('codeGraph.persistedIncr
       SELECT changed.path
       FROM activation_incremental_paths AS changed
       LEFT JOIN activation_files AS current ON current.path = changed.path
-      WHERE current.path IS NULL
-      UNION ALL
-      SELECT current.path
-      FROM activation_files AS current
       LEFT JOIN snapshot_files AS base
-        ON base.snapshot_id = ${baseSnapshotId} AND base.path = current.path
-      WHERE base.path IS NULL
-         OR base.language IS NOT current.language
-         OR base.mode IS NOT current.mode
+        ON base.snapshot_id = ${baseSnapshotId} AND base.path = changed.path
+      WHERE (current.path IS NULL AND base.path IS NULL)
+         OR (current.path IS NOT NULL AND base.path IS NOT NULL
+             AND (base.language IS NOT current.language OR base.mode IS NOT current.mode))
       LIMIT 1
     `;
   return invalid.length === 0;

--- a/src/code_graph/store_build_preparation.ts
+++ b/src/code_graph/store_build_preparation.ts
@@ -549,7 +549,7 @@ const preparePersistedIncrementalActivation = Effect.fn('codeGraph.preparePersis
   if (!isPersistedIncrementalResolutionClosure(resolutionClosure)) return false;
   const deletedPaths = [...new Set(options.deletedPaths ?? [])];
   if (
-    (files.length === 0 && (resolutionClosure !== 'full' || deletedPaths.length === 0)) ||
+    (files.length === 0 && (resolutionClosure === 'changed' || deletedPaths.length === 0)) ||
     facts.length !== files.length
   ) {
     return false;

--- a/test/helpers/code-graph-index-process.ts
+++ b/test/helpers/code-graph-index-process.ts
@@ -19,7 +19,7 @@ const summary = await Effect.runPromise(
         Effect.gen(function* () {
           process.stdout.write(`${JSON.stringify({progress, type: 'progress'})}\n`);
           if (progress.phase === 'waiting') writeFileSync(`${marker}.waiting`, 'waiting\n');
-          if (progress.phase !== 'scanning' || progress.completed !== 0) return;
+          if (progress.phase !== 'scanning' || existsSync(`${marker}.scanning`)) return;
           writeFileSync(`${marker}.scanning`, 'scanning\n');
           while (!existsSync(releaseGate)) yield* Effect.sleep(25);
         }),

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -3618,7 +3618,14 @@ describe('native code graph lifecycle', () => {
   );
 
   it('indexes linked worktrees concurrently across processes without mixing dirty overlays or waiters', async () => {
-    const root = createFixtureRepository();
+    const root = createConcurrentProjectRepository();
+    const home = join(root, '.threadnote-test-home');
+    const baseline = await runEffect(
+      Effect.gen(function* () {
+        const indexer = yield* CodeGraphIndexer;
+        return yield* indexer.index({cwd: root, threadnoteHome: home});
+      }),
+    );
     git(root, ['branch', 'graph-process-a']);
     git(root, ['branch', 'graph-process-b']);
     const worktreeRoot = temporaryDirectory('threadnote-code-graph-process-worktrees-');
@@ -3626,9 +3633,14 @@ describe('native code graph lifecycle', () => {
     const worktreeB = join(worktreeRoot, 'worktree-b');
     git(root, ['worktree', 'add', worktreeA, 'graph-process-a']);
     git(root, ['worktree', 'add', worktreeB, 'graph-process-b']);
-    replaceFunction(worktreeA, 'ensureVectorIndex', 'ensureConcurrentBranchA');
-    replaceFunction(worktreeB, 'ensureVectorIndex', 'ensureConcurrentBranchB');
-    const home = join(root, '.threadnote-test-home');
+    writeFileSync(
+      join(worktreeA, 'packages/shared/branch-a.ts'),
+      'export function ensureConcurrentBranchA(): string { return "a"; }\n',
+    );
+    writeFileSync(
+      join(worktreeB, 'packages/shared/branch-b.ts'),
+      'export function ensureConcurrentBranchB(): string { return "b"; }\n',
+    );
     const gateA = join(root, '.release-worktree-a');
     const gateB = join(root, '.release-worktree-b');
     const markerA = join(root, '.worktree-process-a');
@@ -3641,10 +3653,11 @@ describe('native code graph lifecycle', () => {
       second = startCodeGraphIndexProcess(worktreeB, home, gateB, markerB);
       await waitForPath(`${markerB}.scanning`);
       const observed = await runEffect(Effect.map(readAllCodeGraphBuildStatuses(home), selectCodeGraphBuildStatuses));
+      const owners = observed.builds.filter(build => build.coordination?.role === 'owner');
       expect(observed.waiters).toEqual([]);
-      expect(observed.builds.filter(build => build.coordination?.role === 'owner')).toHaveLength(2);
-      expect(new Set(observed.builds.map(build => build.identity.worktreeId)).size).toBe(2);
-      const checkoutId = observed.builds[0]?.identity.checkoutId;
+      expect(owners).toHaveLength(2);
+      expect(new Set(owners.map(build => build.identity.worktreeId)).size).toBe(2);
+      const checkoutId = owners[0]?.identity.checkoutId;
       if (!checkoutId) throw new TestError('Linked-worktree builders did not publish a checkout identity.');
       expect(await runEffect(compactCodeGraphStorage(home, checkoutId, {dryRun: false, force: true}))).toMatchObject({
         action: 'deferred',
@@ -3665,6 +3678,10 @@ describe('native code graph lifecycle', () => {
       expect(summaryA.identity.checkoutId).toBe(summaryB.identity.checkoutId);
       expect(summaryA.identity.worktreeId).not.toBe(summaryB.identity.worktreeId);
       expect(summaryA.snapshot.id).not.toBe(summaryB.snapshot.id);
+      expect(summaryA.materialization).toMatchObject({mode: 'incremental-overlay'});
+      expect(summaryB.materialization).toMatchObject({mode: 'incremental-overlay'});
+      expect(summaryA.snapshot.baseSnapshotId).toBe(baseline.snapshot.id);
+      expect(summaryB.snapshot.baseSnapshotId).toBe(baseline.snapshot.id);
 
       const [queryA, queryB] = await runEffect(
         Effect.gen(function* () {
@@ -3704,7 +3721,7 @@ describe('native code graph lifecycle', () => {
           .all();
         expect(overlays).toHaveLength(2);
         expect(new Set(overlays.map(row => row.worktree_id)).size).toBe(2);
-        expect(overlays.every(row => row.base_snapshot_id === null)).toBe(true);
+        expect(overlays.every(row => row.base_snapshot_id === baseline.snapshot.id)).toBe(true);
       } finally {
         database.close();
       }
@@ -4477,6 +4494,28 @@ function createFixtureRepository(): string {
   return root;
 }
 
+function createConcurrentProjectRepository(): string {
+  const root = temporaryDirectory('threadnote-code-graph-concurrent-project-');
+  mkdirSync(join(root, 'packages/shared'), {recursive: true});
+  writeFileSync(join(root, '.gitignore'), '/.threadnote-*/\n');
+  writeFileSync(
+    join(root, 'package.json'),
+    `${JSON.stringify({name: '@concurrent/root', private: true, workspaces: ['packages/*']}, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(root, 'packages/shared/package.json'),
+    `${JSON.stringify({name: '@concurrent/shared'}, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(root, 'packages/shared/index.ts'),
+    'export function ensureConcurrentBase(): string { return "base"; }\n',
+  );
+  git(root, ['init', '-q']);
+  git(root, ['add', '.']);
+  git(root, ['-c', 'user.name=Threadnote Test', '-c', 'user.email=test@threadnote.local', 'commit', '-qm', 'fixture']);
+  return root;
+}
+
 function createManySourceRepository(count: number): string {
   const root = temporaryDirectory('threadnote-code-graph-many-');
   mkdirSync(join(root, 'src'), {recursive: true});
@@ -4810,7 +4849,7 @@ function codeGraphProcessProgress(output: string): readonly {readonly completed?
 function codeGraphProcessSummary(output: string): {
   readonly identity: {readonly checkoutId: string; readonly worktreeId: string};
   readonly materialization?: {readonly mode: string; readonly stagedFiles: number};
-  readonly snapshot: {readonly id: string};
+  readonly snapshot: {readonly baseSnapshotId?: string; readonly id: string};
 } {
   const summary = output
     .split(/\r?\n/)
@@ -4821,7 +4860,7 @@ function codeGraphProcessSummary(output: string): {
   return summary as {
     readonly identity: {readonly checkoutId: string; readonly worktreeId: string};
     readonly materialization?: {readonly mode: string; readonly stagedFiles: number};
-    readonly snapshot: {readonly id: string};
+    readonly snapshot: {readonly baseSnapshotId?: string; readonly id: string};
   };
 }
 

--- a/test/integration/code-graph.project-closure.test.ts
+++ b/test/integration/code-graph.project-closure.test.ts
@@ -1,7 +1,7 @@
 import {TestError} from '../helpers/test-error.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {execFileSync} from '../helpers/node-child-process.js';
-import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from '../helpers/node-fs.js';
+import {mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync} from '../helpers/node-fs.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import {Database} from 'bun:sqlite';
@@ -283,14 +283,160 @@ describe('project-closure incremental indexing', () => {
     ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
-  it.effect('fails closed for file-set, global-surface, and unreconciled-workspace changes', () =>
+  it.effect('incrementally materializes bounded project closures for add, delete, and rename file-set changes', () =>
     Effect.forEach(
       [
         {
-          create: () => createProjectClosureRepository(),
+          deltaPaths: [
+            'packages/app/index.ts',
+            'packages/app/package.json',
+            'packages/barrel/extra.ts',
+            'packages/barrel/index.ts',
+            'packages/barrel/package.json',
+          ],
           mutate: (root: string) => writeFile(root, 'packages/barrel/extra.ts', 'export const extra = true;\n'),
-          reason: 'file-set-changed' as const,
+          stagedFiles: 5,
+          totalFiles: 12,
         },
+        {
+          deltaPaths: ['packages/app/index.ts', 'packages/app/package.json', 'packages/barrel/package.json'],
+          mutate: (root: string) => rmSync(join(root, 'packages/barrel/index.ts')),
+          stagedFiles: 3,
+          totalFiles: 10,
+        },
+        {
+          deltaPaths: [
+            'packages/app/index.ts',
+            'packages/app/package.json',
+            'packages/barrel/package.json',
+            'packages/barrel/renamed.ts',
+          ],
+          mutate: (root: string) =>
+            renameSync(join(root, 'packages/barrel/index.ts'), join(root, 'packages/barrel/renamed.ts')),
+          stagedFiles: 4,
+          totalFiles: 11,
+        },
+      ],
+      scenario =>
+        Effect.acquireUseRelease(
+          Effect.sync(createProjectClosureRepository),
+          root =>
+            Effect.gen(function* () {
+              const indexer = yield* CodeGraphIndexer;
+              const path = yield* Path.Path;
+              const store = yield* CodeGraphStore;
+              const incrementalHome = join(root, '.threadnote-file-set-incremental');
+              const fullHome = join(root, '.threadnote-file-set-full');
+              yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+              yield* Effect.sync(() => scenario.mutate(root));
+              const incremental = yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+              const full = yield* indexer.index({
+                cwd: root,
+                incrementalOverlay: false,
+                threadnoteHome: fullHome,
+              });
+              const incrementalLayout = codeGraphLayout(
+                path,
+                incrementalHome,
+                incremental.identity.checkoutId,
+                incremental.identity.worktreeId,
+              );
+              const fullLayout = codeGraphLayout(path, fullHome, full.identity.checkoutId, full.identity.worktreeId);
+              const incrementalGraph = yield* store.loadGraph(incrementalLayout.databasePath, incremental.snapshot.id);
+              const fullGraph = yield* store.loadGraph(fullLayout.databasePath, full.snapshot.id);
+
+              expect(incremental.materialization).toEqual({
+                closureProjects: 2,
+                mode: 'incremental-overlay',
+                resolutionClosure: 'project',
+                stagedFiles: scenario.stagedFiles,
+                totalFiles: scenario.totalFiles,
+              });
+              expect(normalizeGraph(incrementalGraph)).toEqual(normalizeGraph(fullGraph));
+              expect(normalizeCatalog(yield* store.loadVisualizationCatalog(incrementalLayout.databasePath))).toEqual(
+                normalizeCatalog(yield* store.loadVisualizationCatalog(fullLayout.databasePath)),
+              );
+              expect(yield* store.diagnose(incrementalLayout.databasePath)).toMatchObject({
+                foreignKeyViolations: 0,
+                integrity: 'ok',
+              });
+              expect(deltaPaths(incrementalLayout.databasePath, incremental.snapshot.id)).toEqual(scenario.deltaPaths);
+            }),
+          root => Effect.sync(() => rmSync(root, {force: true, recursive: true})),
+        ),
+      {concurrency: 1},
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  it.effect('uses bounded project closures after committed add, delete, and rename file-set changes', () =>
+    Effect.forEach(
+      [
+        {
+          label: 'add',
+          mutate: (root: string) => writeFile(root, 'packages/barrel/extra.ts', 'export const extra = true;\n'),
+          stagedFiles: 5,
+          totalFiles: 12,
+        },
+        {
+          label: 'delete',
+          mutate: (root: string) => rmSync(join(root, 'packages/barrel/index.ts')),
+          stagedFiles: 3,
+          totalFiles: 10,
+        },
+        {
+          label: 'rename',
+          mutate: (root: string) =>
+            renameSync(join(root, 'packages/barrel/index.ts'), join(root, 'packages/barrel/renamed.ts')),
+          stagedFiles: 4,
+          totalFiles: 11,
+        },
+      ],
+      scenario =>
+        Effect.acquireUseRelease(
+          Effect.sync(createProjectClosureRepository),
+          root =>
+            Effect.gen(function* () {
+              const indexer = yield* CodeGraphIndexer;
+              const path = yield* Path.Path;
+              const store = yield* CodeGraphStore;
+              const incrementalHome = join(root, '.threadnote-clean-file-set-incremental');
+              const fullHome = join(root, '.threadnote-clean-file-set-full');
+              yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+              yield* Effect.sync(() => {
+                scenario.mutate(root);
+                git(root, ['add', '-A']);
+                git(root, ['commit', '-qm', `${scenario.label} barrel source`]);
+              });
+              const incremental = yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+              const full = yield* indexer.index({cwd: root, incrementalOverlay: false, threadnoteHome: fullHome});
+              const incrementalLayout = codeGraphLayout(
+                path,
+                incrementalHome,
+                incremental.identity.checkoutId,
+                incremental.identity.worktreeId,
+              );
+              const fullLayout = codeGraphLayout(path, fullHome, full.identity.checkoutId, full.identity.worktreeId);
+
+              expect(incremental.materialization).toEqual({
+                closureProjects: 2,
+                mode: 'incremental-clean',
+                resolutionClosure: 'project',
+                stagedFiles: scenario.stagedFiles,
+                totalFiles: scenario.totalFiles,
+              });
+              expect(
+                normalizeGraph(yield* store.loadGraph(incrementalLayout.databasePath, incremental.snapshot.id)),
+              ).toEqual(normalizeGraph(yield* store.loadGraph(fullLayout.databasePath, full.snapshot.id)));
+            }),
+          root => Effect.sync(() => rmSync(root, {force: true, recursive: true})),
+        ),
+      {concurrency: 1},
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  it.effect('fails closed for global-surface and unreconciled-workspace changes', () =>
+    Effect.forEach(
+      [
         {
           create: () => createProjectClosureRepository(),
           mutate: (root: string) =>

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -137,6 +137,26 @@ async function callCodeGraphUntilReady(client: Client, arguments_: Readonly<Reco
   }
 }
 
+async function callCodeGraphUntilCurrent(client: Client, arguments_: Readonly<Record<string, unknown>>) {
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    const result = await client.callTool({arguments: arguments_, name: 'inspect_code_graph'}, undefined, {
+      timeout: 10_000,
+    });
+    const structured = result.structuredContent as
+      {readonly freshness?: unknown; readonly retryAfterMilliseconds?: unknown; readonly state?: unknown} | undefined;
+    if (structured?.freshness === 'current' && !isRetryableCodeGraphState(structured.state)) return result;
+    if (Date.now() >= deadline) {
+      throw new TestError(
+        `Code graph did not become current within 30 seconds: ${JSON.stringify(result.structuredContent)}.`,
+      );
+    }
+    const requestedDelay =
+      typeof structured?.retryAfterMilliseconds === 'number' ? structured.retryAfterMilliseconds : 250;
+    await new Promise(resolve => setTimeout(resolve, Math.max(50, Math.min(1_000, requestedDelay))));
+  }
+}
+
 function isRetryableCodeGraphState(state: unknown): boolean {
   return state === 'indexing' || state === 'timed-out' || state === 'timed_out';
 }
@@ -1504,6 +1524,136 @@ describe('Threadnote MCP toolsets', () => {
       {toolset: 'core'},
     );
   }, 40_000);
+
+  it('keeps graphs immediately available across new TypeScript, Python, and Rust worktrees and edits', async () => {
+    await withMcpClient(
+      async (client, fixture) => {
+        const repositories = [
+          {
+            after: 'typescriptAfterEdit',
+            before: 'typescriptBeforeEdit',
+            files: {
+              'package.json': '{"name":"typescript-readiness"}\n',
+              'src/index.ts': 'export function typescriptBeforeEdit(): string { return "before"; }\n',
+            },
+            name: 'typescript',
+            sourcePath: 'src/index.ts',
+          },
+          {
+            after: 'python_after_edit',
+            before: 'python_before_edit',
+            files: {
+              'pyproject.toml': '[project]\nname = "python-readiness"\nversion = "0.0.0"\n',
+              'src/readiness.py': 'def python_before_edit():\n    return "before"\n',
+            },
+            name: 'python',
+            sourcePath: 'src/readiness.py',
+          },
+          {
+            after: 'rust_after_edit',
+            before: 'rust_before_edit',
+            files: {
+              'Cargo.toml': '[package]\nname = "rust-readiness"\nversion = "0.0.0"\nedition = "2021"\n',
+              'src/lib.rs': 'pub fn rust_before_edit() -> &\'static str { "before" }\n',
+            },
+            name: 'rust',
+            sourcePath: 'src/lib.rs',
+          },
+        ] as const;
+
+        for (const repositoryFixture of repositories) {
+          const repository = join(fixture.root, `${repositoryFixture.name}-repository`);
+          for (const [relativePath, content] of Object.entries(repositoryFixture.files)) {
+            const path = join(repository, relativePath);
+            await mkdir(join(path, '..'), {recursive: true});
+            await writeFile(path, content, 'utf8');
+          }
+          execFileSync('git', ['init', '-q'], {cwd: repository});
+          execFileSync('git', ['config', 'user.email', 'threadnote@example.test'], {cwd: repository});
+          execFileSync('git', ['config', 'user.name', 'Threadnote Test'], {cwd: repository});
+          execFileSync('git', ['add', '.'], {cwd: repository});
+          execFileSync('git', ['commit', '-qm', 'fixture'], {cwd: repository});
+
+          const first = await callCodeGraphUntilReady(client, {
+            callerCwd: repository,
+            operation: 'query',
+            query: repositoryFixture.before,
+          });
+          const firstStructured = first.structuredContent as
+            | {
+                readonly freshness?: unknown;
+                readonly nodes?: readonly {readonly name?: unknown}[];
+                readonly snapshot?: {readonly id?: unknown; readonly worktreeId?: unknown};
+              }
+            | undefined;
+          expect(firstStructured).toMatchObject({
+            freshness: 'current',
+            nodes: expect.arrayContaining([expect.objectContaining({name: repositoryFixture.before})]),
+          });
+          expect(typeof firstStructured?.snapshot?.id).toBe('string');
+
+          const branch = `${repositoryFixture.name}-linked`;
+          const worktree = join(fixture.root, `${repositoryFixture.name}-worktree`);
+          execFileSync('git', ['branch', branch], {cwd: repository});
+          execFileSync('git', ['worktree', 'add', worktree, branch], {cwd: repository});
+
+          const attachedStartedAt = Date.now();
+          const attached = await client.callTool(
+            {
+              arguments: {callerCwd: worktree, operation: 'query', query: repositoryFixture.before},
+              name: 'inspect_code_graph',
+            },
+            undefined,
+            {timeout: 10_000},
+          );
+          expect(Date.now() - attachedStartedAt).toBeLessThan(5_000);
+          expect(attached.isError).not.toBe(true);
+          expect(attached.structuredContent).toMatchObject({
+            freshness: 'current',
+            nodes: expect.arrayContaining([expect.objectContaining({name: repositoryFixture.before})]),
+            snapshot: {id: firstStructured?.snapshot?.id},
+          });
+          expect((attached.structuredContent as {readonly state?: unknown} | undefined)?.state).toBeUndefined();
+
+          const source = join(worktree, repositoryFixture.sourcePath);
+          await writeFile(
+            source,
+            (await readFile(source, 'utf8')).replace(repositoryFixture.before, repositoryFixture.after),
+            'utf8',
+          );
+          const editedStartedAt = Date.now();
+          const edited = await client.callTool(
+            {
+              arguments: {callerCwd: worktree, operation: 'query', query: repositoryFixture.before},
+              name: 'inspect_code_graph',
+            },
+            undefined,
+            {timeout: 10_000},
+          );
+          const editedStructured = edited.structuredContent as
+            {readonly freshness?: unknown; readonly state?: unknown} | undefined;
+          expect(Date.now() - editedStartedAt).toBeLessThan(5_000);
+          expect(edited.isError).not.toBe(true);
+          expect(editedStructured?.state).toBeUndefined();
+          expect(['current', 'stale']).toContain(editedStructured?.freshness);
+
+          const refreshed = await callCodeGraphUntilCurrent(client, {
+            callerCwd: worktree,
+            operation: 'query',
+            query: repositoryFixture.after,
+          });
+          expect(refreshed.structuredContent).toMatchObject({
+            freshness: 'current',
+            nodes: expect.arrayContaining([expect.objectContaining({name: repositoryFixture.after})]),
+          });
+          expect(
+            (refreshed.structuredContent as {readonly snapshot?: {readonly id?: unknown}} | undefined)?.snapshot?.id,
+          ).not.toBe(firstStructured?.snapshot?.id);
+        }
+      },
+      {environment: {THREADNOTE_CODE_GRAPH_PREWARM: '0'}, toolset: 'core'},
+    );
+  }, 120_000);
 
   it('keeps inspected repositories fresh with one MCP-session watcher', async () => {
     await withMcpClient(

--- a/test/unit/code-graph.incremental-closure.property.test.ts
+++ b/test/unit/code-graph.incremental-closure.property.test.ts
@@ -1,6 +1,10 @@
 import {describe, expect, it} from '@effect/vitest';
 import * as FC from 'effect/testing/FastCheck';
-import {assessProjectClosureSeeds, planProjectIncrementalClosure} from '../../src/code_graph/incremental_closure.js';
+import {
+  assessProjectClosureSeeds,
+  assessProjectFileSetClosureSeeds,
+  planProjectIncrementalClosure,
+} from '../../src/code_graph/incremental_closure.js';
 import {resolvePersistedReexportTerminals} from '../../src/code_graph/indexer.js';
 import type {CodeGraphWorkspaceProject} from '../../src/code_graph/languages/types.js';
 import type {CodeGraphReusableReexport} from '../../src/code_graph/store.js';
@@ -72,6 +76,70 @@ describe('project incremental closure', () => {
         projects,
       }),
     ).toEqual({mode: 'fallback', reason: 'resolution-surface-changed'});
+  });
+
+  it.prop(
+    'selects file-set closure seeds deterministically from added, modified, and deleted project paths',
+    {
+      currentMask: FC.integer({max: 65_535, min: 0}),
+      deletedMask: FC.integer({max: 65_535, min: 0}),
+      projectCount: FC.integer({max: 16, min: 1}),
+      reverse: FC.boolean(),
+    },
+    ({currentMask, deletedMask, projectCount, reverse}) => {
+      const boundedMask = (1 << projectCount) - 1;
+      const maskedCurrent = currentMask & boundedMask;
+      const effectiveDeletedMask = deletedMask & boundedMask;
+      const effectiveCurrentMask = (maskedCurrent | effectiveDeletedMask) === 0 ? 1 : maskedCurrent;
+      const projects = Array.from({length: projectCount}, (_, index) => project(`p${index}`));
+      const paths = (mask: number) =>
+        projects.filter((_, index) => (mask & (1 << index)) !== 0).map(value => `${value.root}/index.ts`);
+      const expected = projects
+        .filter((_, index) => ((effectiveCurrentMask | effectiveDeletedMask) & (1 << index)) !== 0)
+        .map(value => value.id)
+        .sort();
+      const input = {
+        baseProjects: reverse ? [...projects].reverse() : projects,
+        currentChangedPaths: reverse ? paths(effectiveCurrentMask).reverse() : paths(effectiveCurrentMask),
+        currentProjects: reverse ? [...projects].reverse() : projects,
+        deletedPaths: reverse ? paths(effectiveDeletedMask).reverse() : paths(effectiveDeletedMask),
+      };
+      const first = assessProjectFileSetClosureSeeds(input);
+      const second = assessProjectFileSetClosureSeeds(input);
+
+      expect(first).toEqual(second);
+      expect(first).toMatchObject({mode: 'eligible', seedProjectIds: expected});
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+
+  it('fails closed when a file-set change lacks stable declared ownership in both workspace models', () => {
+    const declared = project('a');
+    const input = {
+      baseProjects: [declared],
+      currentChangedPaths: ['packages/a/added.ts'],
+      currentProjects: [declared],
+      deletedPaths: [] as readonly string[],
+    };
+
+    expect(assessProjectFileSetClosureSeeds({...input, currentChangedPaths: ['unowned.ts']})).toEqual({
+      mode: 'fallback',
+      reason: 'project-closure-incomplete',
+    });
+    expect(
+      assessProjectFileSetClosureSeeds({
+        ...input,
+        currentProjects: [{...declared, provenance: 'inferred'}],
+      }),
+    ).toEqual({mode: 'fallback', reason: 'project-closure-incomplete'});
+    expect(assessProjectFileSetClosureSeeds({...input, currentProjects: []})).toEqual({
+      mode: 'fallback',
+      reason: 'project-closure-incomplete',
+    });
+    expect(assessProjectFileSetClosureSeeds({...input, currentProjects: [declared, declared]})).toEqual({
+      mode: 'fallback',
+      reason: 'project-closure-incomplete',
+    });
   });
 
   it('fails closed for inferred, ambiguous, diagnostic, incomplete, missing-cache, and oversized closure evidence', () => {

--- a/test/unit/code-graph.project-closure-store.test.ts
+++ b/test/unit/code-graph.project-closure-store.test.ts
@@ -46,7 +46,7 @@ describe('project-closure persisted store', () => {
             [{...facts, path: added.path}],
             {resolutionClosure: 'project'},
           ),
-        ).toBe(false);
+        ).toBe(true);
         expect(
           yield* store.preparePersistedIncrementalActivation(
             databasePath,
@@ -62,6 +62,12 @@ describe('project-closure persisted store', () => {
             resolutionClosure: 'project',
           }),
         ).toBe(false);
+        expect(
+          yield* store.preparePersistedIncrementalActivation(databasePath, base.id, [], [], {
+            deletedPaths: [file.path],
+            resolutionClosure: 'project',
+          }),
+        ).toBe(true);
         expect(
           yield* store.preparePersistedIncrementalActivation(databasePath, base.id, [file], [facts], {
             deletedPaths: ['packages/deleted/index.ts'],


### PR DESCRIPTION
## What changed

- reuse a declared, complete, bounded project closure when eligible source files are added, deleted, or renamed
- support both dirty overlays and committed clean changes without forcing whole-repository materialization
- validate reusable receipts against the base file-set fingerprint
- preserve immediate clean-snapshot attachment and isolated simultaneous graph builds for linked worktrees
- add end-to-end readiness coverage across TypeScript, Python, and Rust repositories
- prepare package version and curated release notes for Threadnote 4.2.2

## Why

Threadnote 4.2.1 treated every eligible file-set change as `file-set-changed`, even when project ownership and reverse dependencies gave it a safe bounded closure. That caused avoidable full graph materialization during ordinary worktree edits and committed changes.

## User impact

New linked worktrees continue to attach warm clean snapshots immediately. After edits, callers retain usable current or stale evidence while refresh converges. File additions, deletions, and renames inside bounded declared projects now stage only the affected project closure; ambiguous or unbounded cases continue to fail closed to a full rebuild.

## Validation

- `bun run precommit`
- native code-graph lifecycle suite: 96/96
- project closure/store/property suite: 25/25
- related graph unit tests: 155/155
- MCP cold/stale/watcher/cross-language readiness scenarios: 4/4
- release workflow contract tests: 11/11
- website/release boundary tests: 58/58
- exact-HEAD global install and doctor verification
- global CLI project-closure smoke with query of the newly added symbol