### PR TITLE
Fix seamless MCP runtime promotion for 4.2.2

### DIFF
--- a/.github/release-notes/v4.2.2.md
+++ b/.github/release-notes/v4.2.2.md
@@ -1,7 +1,17 @@
 ## What's new
 
 Threadnote 4.2.2 keeps native code graphs available while work moves across linked worktrees and reduces unnecessary
-whole-repository graph rebuilds after ordinary source-file changes.
+whole-repository graph rebuilds after ordinary source-file changes. It also keeps existing MCP transports connected
+when a standalone update or exact-HEAD development install activates a new runtime.
+
+### MCP sessions survive runtime promotion
+
+- MCP launchers now keep a small stable session broker on editor-owned stdio and promote the versioned Threadnote MCP
+  runtime behind it at a request boundary.
+- Requests already admitted to the previous runtime finish there. Threadnote never automatically replays a tool call
+  whose outcome could be unknown.
+- `threadnote update` and exact-HEAD development installs use the same active-release promotion contract. Sessions
+  started before this release still need one host restart to enter the brokered architecture.
 
 ### Ready graphs across active worktrees
 

--- a/scripts/install-local-standalone.ts
+++ b/scripts/install-local-standalone.ts
@@ -16,6 +16,7 @@ import {
   withStandaloneInstallationLock,
 } from '../src/installations.js';
 import {
+  preservedStandaloneProcessIds,
   readStandaloneProcessLeaseVerification,
   terminateSupersededStandaloneProcesses,
 } from '../src/standalone_process_lease.js';
@@ -483,11 +484,18 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
       cleanupIssues.add('process-inspection');
     } else {
       if (live.value.truncated || live.value.unverified.length > 0) cleanupIssues.add('process-inspection');
-      for (const lease of [...live.value.verified, ...live.value.unverified]) {
-        if (lease.version === input.version) continue;
+      const superseded = [...live.value.verified, ...live.value.unverified].filter(
+        lease => lease.version !== input.version,
+      );
+      const preservedProcessIds = preservedStandaloneProcessIds(superseded);
+      for (const lease of superseded) {
         if (preservedMcpSessionProcessIds.has(lease.processId)) continue;
-        if (lease.retirementPolicy === 'preserve-session') preservedMcpSessionProcessIds.add(lease.processId);
-        else unresolvedProcessIds.add(lease.processId);
+        if (preservedProcessIds.has(lease.processId)) {
+          preservedMcpSessionProcessIds.add(lease.processId);
+          unresolvedProcessIds.delete(lease.processId);
+        } else {
+          unresolvedProcessIds.add(lease.processId);
+        }
       }
     }
     if (Option.isSome(input.stagedRoot)) {

--- a/scripts/install-local-standalone.ts
+++ b/scripts/install-local-standalone.ts
@@ -69,6 +69,7 @@ export interface LocalStandaloneInstallResult extends DevelopmentRuntimeEvidence
   readonly cleanupIssues: readonly LocalStandaloneCleanupIssue[];
   readonly doctorVerified: true;
   readonly launchersVerified: true;
+  readonly preservedMcpSessionProcesses: number;
   readonly remainingSupersededProcesses: number;
   readonly reused: boolean;
   readonly terminatedSupersededProcesses: number;
@@ -196,6 +197,11 @@ export const installLocalStandalone = Effect.fn('developmentInstall.run')(functi
     yield* Console.log(`Installed exact-HEAD Threadnote ${result.version}.`);
     yield* Console.log(`Source commit: ${result.sourceCommit}`);
     yield* Console.log(`Executable SHA-256: ${result.executableSha256}`);
+    if (result.preservedMcpSessionProcesses > 0) {
+      yield* Console.log(
+        `${result.preservedMcpSessionProcesses} live MCP session process(es) remain safely pinned and will promote behind their stable transport.`,
+      );
+    }
     const processStateUnknown = result.cleanupIssues.some(
       (issue: LocalStandaloneCleanupIssue) => issue === 'process-inspection' || issue === 'process-termination',
     );
@@ -450,6 +456,7 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
     );
 
     let terminatedSupersededProcesses = 0;
+    const preservedMcpSessionProcessIds = new Set<number>();
     const unresolvedProcessIds = new Set<number>();
     const cleanupIssues = new Set<LocalStandaloneCleanupIssue>();
     if (input.terminateSuperseded) {
@@ -464,6 +471,7 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
           cleanupIssues.add('process-termination');
         } else {
           terminatedSupersededProcesses = termination.value.signaled.length;
+          for (const lease of termination.value.preserved) preservedMcpSessionProcessIds.add(lease.processId);
           for (const lease of [...termination.value.skippedUnverified, ...termination.value.remaining]) {
             unresolvedProcessIds.add(lease.processId);
           }
@@ -476,7 +484,10 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
     } else {
       if (live.value.truncated || live.value.unverified.length > 0) cleanupIssues.add('process-inspection');
       for (const lease of [...live.value.verified, ...live.value.unverified]) {
-        if (lease.version !== input.version) unresolvedProcessIds.add(lease.processId);
+        if (lease.version === input.version) continue;
+        if (preservedMcpSessionProcessIds.has(lease.processId)) continue;
+        if (lease.retirementPolicy === 'preserve-session') preservedMcpSessionProcessIds.add(lease.processId);
+        else unresolvedProcessIds.add(lease.processId);
       }
     }
     if (Option.isSome(input.stagedRoot)) {
@@ -502,6 +513,7 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
       cleanupIssues: [...cleanupIssues].sort(),
       doctorVerified: true,
       launchersVerified: true,
+      preservedMcpSessionProcesses: preservedMcpSessionProcessIds.size,
       remainingSupersededProcesses: unresolvedProcessIds.size,
       reused,
       terminatedSupersededProcesses,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,7 +92,7 @@ render_expected_launcher() {
   launcher_entry="$(canonical_launcher_quote "$launcher_executable")"
   case "$launcher_mode" in
     cli) launcher_mode_argument="" ;;
-    mcp) launcher_mode_argument=" mcp-server" ;;
+    mcp) launcher_mode_argument=" mcp-broker" ;;
     *) die "Unknown launcher mode: $launcher_mode" ;;
   esac
   printf '%s\n' \

--- a/src/command-shim.ts
+++ b/src/command-shim.ts
@@ -138,7 +138,7 @@ export const renderCommandShim = Effect.fn('commandShim.render')(function* (
   const system = yield* SystemInfo;
   const root = releaseRoot ?? (yield* toolRoot());
   const executable = path.join(root, system.platform === 'win32' ? 'threadnote.exe' : 'threadnote');
-  const modeArguments = mode === 'mcp' ? ['mcp-server'] : [];
+  const modeArguments = mode === 'mcp' ? ['mcp-broker'] : [];
   if (system.platform === 'win32') {
     const command = [cmdQuote(executable), ...modeArguments, '%*'].join(' ');
     return [

--- a/src/cursor_cloud.ts
+++ b/src/cursor_cloud.ts
@@ -29,7 +29,7 @@ export interface CursorCloudProfileV1 {
 }
 
 export interface CursorCloudMcpConfig {
-  readonly args: readonly ['-lc', 'exec "$HOME/.local/bin/threadnote" mcp-server'];
+  readonly args: readonly ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'];
   readonly command: '/bin/sh';
   readonly env: Readonly<{
     THREADNOTE_ACCOUNT: string;
@@ -101,7 +101,7 @@ export function buildCursorCloudProfile(
 
 export function buildCursorCloudMcpConfig(profile: CursorCloudProfileV1): CursorCloudMcpConfig {
   return {
-    args: ['-lc', 'exec "$HOME/.local/bin/threadnote" mcp-server'],
+    args: ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'],
     command: '/bin/sh',
     env: {
       THREADNOTE_ACCOUNT: profile.account,

--- a/src/effect/mcp_broker_process.ts
+++ b/src/effect/mcp_broker_process.ts
@@ -1,10 +1,6 @@
 import {Cause, Effect, Queue} from 'effect';
 import {activeInstalledRelease} from '../installations.js';
-import {
-  McpBrokerError,
-  runMcpBroker,
-  type McpBrokerChild,
-} from '../mcp_broker.js';
+import {McpBrokerError, runMcpBroker, type McpBrokerChild} from '../mcp_broker.js';
 import type {StandaloneActiveRelease} from '../standalone_process_lease.js';
 import {SystemInfo, type SystemInfoShape} from './system.js';
 

--- a/src/effect/mcp_broker_process.ts
+++ b/src/effect/mcp_broker_process.ts
@@ -1,0 +1,77 @@
+import {Cause, Effect, Queue} from 'effect';
+import {activeInstalledRelease} from '../installations.js';
+import {
+  McpBrokerError,
+  runMcpBroker,
+  type McpBrokerChild,
+} from '../mcp_broker.js';
+import type {StandaloneActiveRelease} from '../standalone_process_lease.js';
+import {SystemInfo, type SystemInfoShape} from './system.js';
+
+interface ActiveReleaseRequest {
+  readonly reject: (cause: unknown) => void;
+  readonly resolve: (release: StandaloneActiveRelease | undefined) => void;
+}
+
+/** Runtime boundary for the stable MCP broker's stdio and child process. */
+export const mcpBrokerEffect = Effect.gen(function* () {
+  const system = yield* SystemInfo;
+  const activeReleaseRequests = yield* Queue.unbounded<ActiveReleaseRequest>();
+  yield* Effect.forkScoped(
+    Effect.forever(
+      Queue.take(activeReleaseRequests).pipe(
+        Effect.flatMap(request =>
+          activeInstalledRelease().pipe(
+            Effect.matchCauseEffect({
+              onFailure: cause => Effect.sync(() => request.reject(new McpBrokerError(Cause.pretty(cause)))),
+              onSuccess: release => Effect.sync(() => request.resolve(release)),
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+  yield* Effect.tryPromise({
+    try: () =>
+      runMcpBroker({
+        input: Bun.stdin.stream() as AsyncIterable<Uint8Array>,
+        readActiveRelease: () =>
+          new Promise((resolve, reject) => {
+            if (!Queue.offerUnsafe(activeReleaseRequests, {reject, resolve})) {
+              reject(new McpBrokerError('Threadnote MCP broker active-release reader is unavailable.'));
+            }
+          }),
+        spawn: release => spawnMcpRuntime(release, system),
+        writeOutput: writeBrokerOutput,
+      }),
+    catch: cause =>
+      cause instanceof McpBrokerError
+        ? cause
+        : new McpBrokerError(cause instanceof Error ? cause.message : String(cause)),
+  });
+});
+
+function spawnMcpRuntime(release: StandaloneActiveRelease, system: SystemInfoShape): McpBrokerChild {
+  const separator = release.releaseRoot.endsWith('/') || release.releaseRoot.endsWith('\\') ? '' : '/';
+  const executable = `${release.releaseRoot}${separator}${system.platform === 'win32' ? 'threadnote.exe' : 'threadnote'}`;
+  const child = Bun.spawn({
+    cmd: [executable, 'mcp-server'],
+    env: {...system.environment(), THREADNOTE_MCP_BROKER_CHILD: '1'},
+    stdin: 'pipe',
+    stderr: 'inherit',
+    stdout: 'pipe',
+  });
+  return {
+    exited: child.exited,
+    input: child.stdin,
+    kill: signal => child.kill(signal),
+    output: child.stdout as ReadableStream<Uint8Array> & AsyncIterable<Uint8Array>,
+    processId: child.pid,
+  };
+}
+
+function writeBrokerOutput(line: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(`${line}\n`, error => (error ? reject(error) : resolve()));
+  });
+}

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -21,6 +21,7 @@ import {CodeGraphAnalysis} from '../code_graph/analysis.js';
 import {CodeGraphParserPool} from '../code_graph/parser_worker.js';
 
 const systemLayer = SystemInfo.layer;
+export const StandaloneBrokerLayer = Layer.merge(systemLayer, BunServices.layer);
 const commandLayer = CommandExecutor.layer.pipe(Layer.provide(systemLayer));
 const resourceStoreLayer = ResourceStore.layer.pipe(Layer.provide(systemLayer));
 const localModelStoreLayer = LocalModelStore.layer.pipe(

--- a/src/installations.ts
+++ b/src/installations.ts
@@ -211,11 +211,26 @@ export const activeInstalledRelease = Effect.fn('installations.activeRelease')(f
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
   const root = installationRoot(path, system);
-  const active = yield* readActiveRelease(fs, path.join(root, ACTIVE_RELEASE_FILE));
-  if (!active) return undefined;
-  const validated = yield* readValidatedRelease(fs, path, active.releaseRoot, root);
-  if (validated?.version === active.version) return validated;
-  return undefined;
+  const readValidatedPointer = (pointerPath: string) =>
+    Effect.gen(function* () {
+      const pointer = yield* readActiveRelease(fs, pointerPath);
+      if (!pointer) return undefined;
+      const validated = yield* readValidatedRelease(fs, path, pointer.releaseRoot, root);
+      return validated?.version === pointer.version ? validated : undefined;
+    });
+  const active = yield* readValidatedPointer(path.join(root, ACTIVE_RELEASE_FILE));
+  if (active) return active;
+
+  // Activation briefly moves the old pointer aside before atomically promoting
+  // the replacement. A broker starting in that bounded gap may keep serving the
+  // validated previous release, but only while an exact, valid promotion
+  // journal proves that the backup belongs to this installation. This is a
+  // read-only fallback: installation-lock recovery remains the sole mutator.
+  const journalPath = path.join(root, ACTIVE_RELEASE_JOURNAL_FILE);
+  const promotion = yield* readActiveReleasePromotion(fs, path, root, journalPath).pipe(
+    Effect.catch(() => Effect.succeed(undefined)),
+  );
+  return promotion ? yield* readValidatedPointer(promotion.backupPath) : undefined;
 });
 
 export const activeInstalledVersion = Effect.fn('installations.activeVersion')(function* () {

--- a/src/installations.ts
+++ b/src/installations.ts
@@ -206,7 +206,7 @@ export const recoverStandaloneReleasePromotion = Effect.fn('installations.recove
   return true;
 });
 
-export const activeInstalledVersion = Effect.fn('installations.activeVersion')(function* () {
+export const activeInstalledRelease = Effect.fn('installations.activeRelease')(function* () {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
@@ -214,8 +214,12 @@ export const activeInstalledVersion = Effect.fn('installations.activeVersion')(f
   const active = yield* readActiveRelease(fs, path.join(root, ACTIVE_RELEASE_FILE));
   if (!active) return undefined;
   const validated = yield* readValidatedRelease(fs, path, active.releaseRoot, root);
-  if (validated?.version === active.version) return active.version;
+  if (validated?.version === active.version) return validated;
   return undefined;
+});
+
+export const activeInstalledVersion = Effect.fn('installations.activeVersion')(function* () {
+  return (yield* activeInstalledRelease())?.version;
 });
 
 export const pruneStandaloneReleases = Effect.fn('installations.pruneReleases')(function* (

--- a/src/manager_processes_view.tsx
+++ b/src/manager_processes_view.tsx
@@ -173,6 +173,8 @@ function processRoleLabel(role: ManageableThreadnoteProcessDiagnostic['role']): 
       return 'Manager';
     case 'mcp':
       return 'MCP server';
+    case 'mcp-broker':
+      return 'MCP session broker';
   }
 }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -65,6 +65,16 @@ export function runMcpInstall(config: RuntimeConfig, agent: AgentClient, options
       return;
     }
 
+    if (
+      yield* cliMcpConfigurationMatches(config, agent, agentExecutable, name, {
+        scope: options.scope,
+        toolset,
+      })
+    ) {
+      yield* Console.log(`Already configured: ${agent} MCP ${name}`);
+      return;
+    }
+
     yield* maybeRunEffect(false, removeCommand.executable, removeCommand.args, {
       allowFailure: true,
       cwd: removeCommand.cwd,
@@ -88,12 +98,15 @@ export const mcpConfigurationChecks = Effect.fn('mcp.configurationChecks')(funct
       timeoutMs: 5_000,
     }).pipe(Effect.option);
     const configured = result._tag === 'Some' && result.value.exitCode === 0;
+    const current = configured && isBrokerMcpCommandOutput(result.value.stdout);
     checks.push({
-      detail: configured
-        ? `${THREADNOTE_MCP_NAME} server configured`
-        : `missing or unreadable; repair will configure ${THREADNOTE_MCP_NAME}`,
+      detail: current
+        ? `${THREADNOTE_MCP_NAME} broker configured`
+        : configured
+          ? `${THREADNOTE_MCP_NAME} uses the legacy direct server command; repair will migrate it to the session broker`
+          : `missing or unreadable; repair will configure ${THREADNOTE_MCP_NAME}`,
       name: `${agent} MCP`,
-      status: configured ? 'ok' : 'warn',
+      status: current ? 'ok' : 'warn',
     });
   }
 
@@ -118,17 +131,150 @@ function jsonMcpConfigurationCheck(name: string, configPath: string, containerKe
     const raw = yield* readFileIfExists(configPath);
     const parsed = raw ? parseJsonConfigObject(raw) : undefined;
     const container = parsed?.[containerKey];
-    const configured =
-      typeof container === 'object' &&
-      container !== null &&
-      !Array.isArray(container) &&
-      THREADNOTE_MCP_NAME in container;
+    const server =
+      isJsonObject(container) && isJsonObject(container[THREADNOTE_MCP_NAME])
+        ? container[THREADNOTE_MCP_NAME]
+        : undefined;
+    const configured = server !== undefined;
+    const current = configured && isBrokerMcpServerConfig(server);
     return {
-      detail: configured ? `${THREADNOTE_MCP_NAME} server configured in ${configPath}` : `${configPath} missing entry`,
+      detail: current
+        ? `${THREADNOTE_MCP_NAME} broker configured in ${configPath}`
+        : configured
+          ? `${configPath} uses the legacy direct server command; repair will migrate it to the session broker`
+          : `${configPath} missing entry`,
       name,
-      status: configured ? ('ok' as const) : ('warn' as const),
+      status: current ? ('ok' as const) : ('warn' as const),
     };
   });
+}
+
+function isBrokerMcpCommandOutput(output: string): boolean {
+  return /(?:^|[\\/])threadnote-mcp-server(?:\.cmd)?(?:\s|$)/im.test(output);
+}
+
+function isBrokerMcpServerConfig(server: JsonObject): boolean {
+  const command = server.command;
+  const arguments_ = server.args;
+  const values = [command, ...(Array.isArray(arguments_) ? arguments_ : [])];
+  return values.some(
+    value => typeof value === 'string' && /(?:^|[\\/])threadnote-mcp-server(?:\.cmd)?$/i.test(value.trim()),
+  );
+}
+
+const cliMcpConfigurationMatches = Effect.fn('mcp.cliConfigurationMatches')(function* (
+  config: RuntimeConfig,
+  agent: 'claude' | 'codex',
+  agentExecutable: string,
+  name: string,
+  options: {
+    readonly scope?: ClaudeMcpScope;
+    readonly toolset: McpToolset;
+  },
+) {
+  const result = yield* runCommandEffect(
+    agentExecutable,
+    agent === 'codex' ? ['mcp', 'get', name, '--json'] : ['mcp', 'get', name],
+    {
+      allowFailure: true,
+      maxOutputBytes: 64 * 1024,
+      timeoutMs: 5_000,
+    },
+  ).pipe(Effect.option);
+  if (result._tag === 'None' || result.value.exitCode !== 0) return false;
+
+  const command = yield* mcpAdapterCommand();
+  const environment = mcpEnvironmentObject(config, options.toolset);
+  return agent === 'codex'
+    ? codexMcpConfigurationMatches(result.value.stdout, command, environment)
+    : claudeMcpConfigurationMatches(result.value.stdout, command, environment, options.scope ?? 'user');
+});
+
+function codexMcpConfigurationMatches(output: string, command: readonly string[], environment: JsonObject): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    return false;
+  }
+  if (!isJsonObject(parsed) || parsed.enabled !== true || !isJsonObject(parsed.transport)) return false;
+  const transport = parsed.transport;
+  return (
+    transport.type === 'stdio' &&
+    transport.command === command[0] &&
+    stringArrayEquals(transport.args, command.slice(1)) &&
+    managedMcpEnvironmentMatches(transport.env, environment)
+  );
+}
+
+function claudeMcpConfigurationMatches(
+  output: string,
+  command: readonly string[],
+  environment: JsonObject,
+  scope: ClaudeMcpScope,
+): boolean {
+  const lines = output.split(/\r?\n/);
+  const field = (name: string) =>
+    lines
+      .find(line => line.startsWith(`  ${name}:`))
+      ?.slice(name.length + 3)
+      .trim();
+  const environmentStart = lines.findIndex(line => line.trim() === 'Environment:');
+  if (environmentStart < 0) return false;
+  const actualEnvironment: Record<string, string> = {};
+  for (const line of lines.slice(environmentStart + 1)) {
+    if (!line.startsWith('    ')) break;
+    const entry = line.trim();
+    const equalsAt = entry.indexOf('=');
+    if (equalsAt <= 0) return false;
+    actualEnvironment[entry.slice(0, equalsAt)] = entry.slice(equalsAt + 1);
+  }
+  const expectedScope = scope === 'user' ? 'User config' : scope === 'local' ? 'Local config' : 'Project config';
+  return (
+    field('Type') === 'stdio' &&
+    field('Command') === command[0] &&
+    field('Args') === command.slice(1).join(' ') &&
+    field('Scope')?.startsWith(expectedScope) === true &&
+    managedMcpEnvironmentMatches(actualEnvironment, environment)
+  );
+}
+
+function stringArrayEquals(value: unknown, expected: readonly string[]): boolean {
+  return (
+    Array.isArray(value) && value.length === expected.length && value.every((entry, index) => entry === expected[index])
+  );
+}
+
+function managedMcpEnvironmentMatches(value: unknown, expected: JsonObject): boolean {
+  return isJsonObject(value) && Object.entries(expected).every(([key, expectedValue]) => value[key] === expectedValue);
+}
+
+function jsonMcpConfigurationMatches(
+  currentContent: string | undefined,
+  containerKey: 'mcpServers' | 'servers',
+  name: string,
+  expected: JsonObject,
+): boolean {
+  if (currentContent === undefined) return false;
+  const parsed = parseJsonConfigObject(currentContent);
+  const container = parsed?.[containerKey];
+  const actual = isJsonObject(container) && isJsonObject(container[name]) ? container[name] : undefined;
+  const expectedArgs = expected.args;
+  if (
+    actual === undefined ||
+    typeof expected.command !== 'string' ||
+    !Array.isArray(expectedArgs) ||
+    !expectedArgs.every(argument => typeof argument === 'string') ||
+    !isJsonObject(expected.env)
+  ) {
+    return false;
+  }
+  return (
+    actual.command === expected.command &&
+    stringArrayEquals(actual.args, expectedArgs) &&
+    (expected.type === undefined || actual.type === expected.type) &&
+    managedMcpEnvironmentMatches(actual.env, expected.env)
+  );
 }
 
 const runCursorMcpInstall = Effect.fn('mcp.runCursorInstall')(function* (
@@ -147,6 +293,7 @@ const runCursorMcpInstall = Effect.fn('mcp.runCursorInstall')(function* (
     toolset: options.toolset,
   });
   const currentContent = yield* readFileIfExists(path);
+  const current = jsonMcpConfigurationMatches(currentContent, 'mcpServers', name, serverConfig);
   const nextContent = renderCursorMcpConfig(path, currentContent, name, serverConfig);
 
   if (!options.apply) {
@@ -161,7 +308,7 @@ const runCursorMcpInstall = Effect.fn('mcp.runCursorInstall')(function* (
     return;
   }
 
-  if (currentContent === nextContent) {
+  if (current || currentContent === nextContent) {
     yield* Console.log(`Already configured: ${path}`);
     return;
   }
@@ -188,6 +335,7 @@ const runCopilotMcpInstall = Effect.fn('mcp.runCopilotInstall')(function* (
     toolset: options.toolset,
   });
   const currentContent = yield* readFileIfExists(path);
+  const current = jsonMcpConfigurationMatches(currentContent, 'servers', name, serverConfig);
   const nextContent = renderCopilotMcpConfig(path, currentContent, name, serverConfig);
 
   if (!options.apply) {
@@ -202,7 +350,7 @@ const runCopilotMcpInstall = Effect.fn('mcp.runCopilotInstall')(function* (
     return;
   }
 
-  if (currentContent === nextContent) {
+  if (current || currentContent === nextContent) {
     yield* Console.log(`Already configured: ${path}`);
     return;
   }
@@ -300,12 +448,12 @@ const buildMcpInstallCommand = Effect.fn('mcp.buildInstallCommand')(function* (
 
 export const mcpAdapterCommand = Effect.fn('mcp.adapterCommand')(function* () {
   const system = yield* SystemInfo;
+  const launcher = yield* commandLauncherPath('mcp');
   if (system.platform === 'win32') {
-    const launcher = yield* commandLauncherPath('mcp');
     const comSpec = system.environment().ComSpec ?? system.environment().COMSPEC ?? 'C:\\Windows\\System32\\cmd.exe';
     return [comSpec, '/d', '/c', launcher];
   }
-  return [yield* commandLauncherPath('cli'), 'mcp-server'];
+  return [launcher];
 });
 
 const buildMcpRemoveCommand = Effect.fn('mcp.buildRemoveCommand')(function* (

--- a/src/mcp_broker.ts
+++ b/src/mcp_broker.ts
@@ -27,6 +27,7 @@ export interface McpBrokerChild {
 export interface McpBrokerDependencies {
   readonly input: AsyncIterable<Uint8Array>;
   readonly readActiveRelease: () => Promise<StandaloneActiveRelease | undefined>;
+  readonly replayTimeoutMilliseconds?: number;
   readonly spawn: (release: StandaloneActiveRelease) => McpBrokerChild;
   readonly writeOutput: (line: string) => Promise<void>;
 }
@@ -35,17 +36,25 @@ interface JsonRpcEnvelope {
   readonly error?: unknown;
   readonly id?: unknown;
   readonly method?: unknown;
+  readonly params?: unknown;
   readonly result?: unknown;
 }
 
 interface ActiveBrokerChild {
   readonly child: McpBrokerChild;
+  readonly generation: number;
   readonly release: StandaloneActiveRelease;
   replay?: {
     readonly idKey: string;
     readonly reject: (cause: unknown) => void;
     readonly resolve: () => void;
   };
+}
+
+interface ServerRequestRoute {
+  readonly child: ActiveBrokerChild;
+  readonly externalId: string;
+  readonly originalId: string | number;
 }
 
 /**
@@ -62,12 +71,23 @@ export async function runMcpBroker(dependencies: McpBrokerDependencies): Promise
 class McpBroker {
   readonly #clientRequests = new Map<string, string | number>();
   readonly #dependencies: McpBrokerDependencies;
-  readonly #serverRequests = new Set<string>();
+  readonly #serverRequestRoutes = new Map<string, ServerRequestRoute>();
+  readonly #serverRequestRoutesByChildId = new Map<string, ServerRequestRoute>();
   #child: ActiveBrokerChild | undefined;
+  #nextChildGeneration = 0;
+  #nextServerRequestSequence = 0;
   #initializeLine: string | undefined;
   #initializeRequestId: string | number | undefined;
   #initializedLine: string | undefined;
   #outputTail = Promise.resolve();
+  #pendingInitialize:
+    | {
+        readonly child: ActiveBrokerChild;
+        readonly idKey: string;
+        readonly line: string;
+        readonly requestId: string | number;
+      }
+    | undefined;
 
   constructor(dependencies: McpBrokerDependencies) {
     this.#dependencies = dependencies;
@@ -86,19 +106,56 @@ class McpBroker {
 
   async #handleClientLine(line: string): Promise<void> {
     const envelope = parseJsonRpcEnvelope(line);
-    const current = await this.#ensureCurrentChild();
-    if (envelope?.method === 'initialize' && isJsonRpcId(envelope.id)) {
-      this.#initializeLine = line;
-      this.#initializeRequestId = envelope.id;
-    } else if (envelope?.method === 'notifications/initialized') {
-      this.#initializedLine = line;
+    if (envelope?.method === undefined && isJsonRpcId(envelope?.id)) {
+      await this.#handleClientResponse(line, envelope.id);
+      return;
     }
-    if (envelope?.method !== undefined && isJsonRpcId(envelope.id)) {
-      this.#clientRequests.set(jsonRpcIdKey(envelope.id), envelope.id);
-    } else if (envelope?.method === undefined && isJsonRpcId(envelope?.id)) {
-      this.#serverRequests.delete(jsonRpcIdKey(envelope.id));
+
+    const requestId = envelope?.method !== undefined && isJsonRpcId(envelope.id) ? envelope.id : undefined;
+    let trackedRequest = false;
+    try {
+      const current = await this.#ensureCurrentChild();
+      if (envelope?.method === 'initialize' && requestId !== undefined) {
+        this.#pendingInitialize = {
+          child: current,
+          idKey: jsonRpcIdKey(requestId),
+          line,
+          requestId,
+        };
+      } else if (envelope?.method === 'notifications/initialized') {
+        this.#initializedLine = line;
+      } else if (envelope?.method === 'notifications/cancelled') {
+        const cancelledId = cancelledRequestId(envelope.params);
+        if (cancelledId !== undefined) {
+          const cancelledKey = jsonRpcIdKey(cancelledId);
+          if (!this.#clientRequests.has(cancelledKey)) return;
+          this.#clientRequests.delete(cancelledKey);
+        }
+      }
+      if (requestId !== undefined) {
+        this.#clientRequests.set(jsonRpcIdKey(requestId), requestId);
+        trackedRequest = true;
+      }
+      await writeChildLine(current.child, line);
+    } catch {
+      const pending = [...this.#clientRequests.values()];
+      this.#clientRequests.clear();
+      if (requestId !== undefined && !trackedRequest) pending.push(requestId);
+      await this.#stopCurrentChild();
+      for (const id of pending) await this.#queueRequestFailure(id);
     }
-    await writeChildLine(current.child, line);
+  }
+
+  async #handleClientResponse(line: string, externalId: string | number): Promise<void> {
+    const route = this.#serverRequestRoutes.get(jsonRpcIdKey(externalId));
+    if (route === undefined) return;
+    this.#deleteServerRequestRoute(route);
+    if (this.#child !== route.child) return;
+    try {
+      await writeChildLine(route.child.child, replaceJsonRpcId(line, route.originalId));
+    } catch {
+      await this.#stopCurrentChild();
+    }
   }
 
   async #ensureCurrentChild(): Promise<ActiveBrokerChild> {
@@ -114,19 +171,24 @@ class McpBroker {
     ) {
       return this.#child;
     }
-    if (this.#child !== undefined && (this.#clientRequests.size > 0 || this.#serverRequests.size > 0)) {
+    if (this.#child !== undefined && (this.#clientRequests.size > 0 || this.#serverRequestRoutes.size > 0)) {
       return this.#child;
     }
     await this.#stopCurrentChild();
     const next = this.#startChild(active);
     if (this.#initializeLine !== undefined && this.#initializeRequestId !== undefined) {
       await this.#replayInitialization(next);
+      if (this.#initializedLine !== undefined) await this.#queueListChangedNotifications();
     }
     return next;
   }
 
   #startChild(release: StandaloneActiveRelease): ActiveBrokerChild {
-    const active = {child: this.#dependencies.spawn(release), release} satisfies ActiveBrokerChild;
+    const active = {
+      child: this.#dependencies.spawn(release),
+      generation: (this.#nextChildGeneration += 1),
+      release,
+    } satisfies ActiveBrokerChild;
     this.#child = active;
     void this.#observeChild(active);
     return active;
@@ -136,19 +198,15 @@ class McpBroker {
     await Promise.all([this.#readChildOutput(active), active.child.exited.catch(() => -1)]).catch(() => undefined);
     if (this.#child !== active) return;
     this.#child = undefined;
+    if (this.#pendingInitialize?.child === active) this.#pendingInitialize = undefined;
     active.replay?.reject(new McpBrokerError('Threadnote MCP runtime exited during session promotion.'));
     active.replay = undefined;
     const pending = [...this.#clientRequests.values()];
     this.#clientRequests.clear();
-    this.#serverRequests.clear();
+    await this.#cancelServerRequestRoutes(active);
+    this.#deleteServerRequestRoutes(active);
     for (const id of pending) {
-      await this.#queueOutput(
-        JSON.stringify({
-          error: {code: -32_603, message: MCP_BROKER_RUNTIME_EXIT_ERROR},
-          id,
-          jsonrpc: '2.0',
-        }),
-      );
+      await this.#queueRequestFailure(id);
     }
   }
 
@@ -156,6 +214,7 @@ class McpBroker {
     for await (const line of ndjsonLines(active.child.output)) {
       if (this.#child !== active) continue;
       const envelope = parseJsonRpcEnvelope(line);
+      let outgoingLine = line;
       if (isJsonRpcId(envelope?.id)) {
         const idKey = jsonRpcIdKey(envelope.id);
         if (active.replay?.idKey === idKey && envelope?.method === undefined) {
@@ -165,10 +224,30 @@ class McpBroker {
           else replay.reject(new McpBrokerError('The promoted MCP runtime rejected the replayed initialization.'));
           continue;
         }
-        if (envelope?.method === undefined) this.#clientRequests.delete(idKey);
-        else this.#serverRequests.add(idKey);
+        if (this.#pendingInitialize?.child === active && this.#pendingInitialize.idKey === idKey) {
+          const pending = this.#pendingInitialize;
+          this.#pendingInitialize = undefined;
+          if (envelope.error === undefined && envelope.result !== undefined) {
+            this.#initializeLine = pending.line;
+            this.#initializeRequestId = pending.requestId;
+          }
+        }
+        if (envelope?.method === undefined) {
+          this.#clientRequests.delete(idKey);
+        } else {
+          const route = this.#createServerRequestRoute(active, envelope.id);
+          outgoingLine = replaceJsonRpcId(line, route.externalId);
+        }
+      } else if (envelope?.method === 'notifications/cancelled') {
+        const requestId = cancelledRequestId(envelope.params);
+        if (requestId !== undefined) {
+          const route = this.#serverRequestRoutesByChildId.get(childRequestIdKey(active, requestId));
+          if (route === undefined) continue;
+          this.#deleteServerRequestRoute(route);
+          outgoingLine = replaceCancelledRequestId(line, route.externalId);
+        }
       }
-      await this.#queueOutput(line);
+      await this.#queueOutput(outgoingLine);
     }
   }
 
@@ -182,7 +261,7 @@ class McpBroker {
     await writeChildLine(active.child, initializeLine);
     await Promise.race([
       replayed,
-      Bun.sleep(MCP_BROKER_REPLAY_TIMEOUT_MILLISECONDS).then(() => {
+      Bun.sleep(this.#dependencies.replayTimeoutMilliseconds ?? MCP_BROKER_REPLAY_TIMEOUT_MILLISECONDS).then(() => {
         throw new McpBrokerError('Timed out initializing the promoted Threadnote MCP runtime.');
       }),
     ]);
@@ -193,6 +272,9 @@ class McpBroker {
     const active = this.#child;
     if (active === undefined) return;
     this.#child = undefined;
+    if (this.#pendingInitialize?.child === active) this.#pendingInitialize = undefined;
+    await this.#cancelServerRequestRoutes(active);
+    this.#deleteServerRequestRoutes(active);
     active.replay?.reject(new McpBrokerError('Threadnote MCP runtime promotion was superseded.'));
     active.replay = undefined;
     await Promise.resolve(active.child.input.end()).catch(() => undefined);
@@ -209,6 +291,55 @@ class McpBroker {
       // The child already exited.
     }
     await exitsWithin(active.child, MCP_BROKER_CHILD_STOP_WAIT_MILLISECONDS);
+  }
+
+  #createServerRequestRoute(active: ActiveBrokerChild, originalId: string | number): ServerRequestRoute {
+    const previous = this.#serverRequestRoutesByChildId.get(childRequestIdKey(active, originalId));
+    if (previous !== undefined) this.#deleteServerRequestRoute(previous);
+    const externalId = `threadnote-broker:${active.generation}:${(this.#nextServerRequestSequence += 1)}`;
+    const route = {child: active, externalId, originalId} satisfies ServerRequestRoute;
+    this.#serverRequestRoutes.set(jsonRpcIdKey(externalId), route);
+    this.#serverRequestRoutesByChildId.set(childRequestIdKey(active, originalId), route);
+    return route;
+  }
+
+  #deleteServerRequestRoute(route: ServerRequestRoute): void {
+    this.#serverRequestRoutes.delete(jsonRpcIdKey(route.externalId));
+    this.#serverRequestRoutesByChildId.delete(childRequestIdKey(route.child, route.originalId));
+  }
+
+  #deleteServerRequestRoutes(active: ActiveBrokerChild): void {
+    for (const route of this.#serverRequestRoutes.values()) {
+      if (route.child === active) this.#deleteServerRequestRoute(route);
+    }
+  }
+
+  async #cancelServerRequestRoutes(active: ActiveBrokerChild): Promise<void> {
+    for (const route of this.#serverRequestRoutes.values()) {
+      if (route.child !== active) continue;
+      await this.#queueOutput(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'notifications/cancelled',
+          params: {reason: 'Threadnote MCP runtime exited.', requestId: route.externalId},
+        }),
+      );
+    }
+  }
+
+  async #queueListChangedNotifications(): Promise<void> {
+    await this.#queueOutput(JSON.stringify({jsonrpc: '2.0', method: 'notifications/tools/list_changed'}));
+    await this.#queueOutput(JSON.stringify({jsonrpc: '2.0', method: 'notifications/resources/list_changed'}));
+  }
+
+  #queueRequestFailure(id: string | number): Promise<void> {
+    return this.#queueOutput(
+      JSON.stringify({
+        error: {code: -32_603, message: MCP_BROKER_RUNTIME_EXIT_ERROR},
+        id,
+        jsonrpc: '2.0',
+      }),
+    );
   }
 
   #queueOutput(line: string): Promise<void> {
@@ -254,7 +385,9 @@ async function* ndjsonLines(input: AsyncIterable<Uint8Array>): AsyncGenerator<st
 function parseJsonRpcEnvelope(line: string): JsonRpcEnvelope | undefined {
   try {
     const value = JSON.parse(line) as unknown;
-    return typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as JsonRpcEnvelope) : undefined;
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? (value as JsonRpcEnvelope)
+      : undefined;
   } catch {
     return undefined;
   }
@@ -266,4 +399,28 @@ function isJsonRpcId(value: unknown): value is string | number {
 
 function jsonRpcIdKey(value: string | number): string {
   return `${typeof value}:${String(value)}`;
+}
+
+function childRequestIdKey(active: ActiveBrokerChild, id: string | number): string {
+  return `${active.generation}:${jsonRpcIdKey(id)}`;
+}
+
+function replaceJsonRpcId(line: string, id: string | number): string {
+  return JSON.stringify({...JSON.parse(line), id});
+}
+
+function replaceCancelledRequestId(line: string, requestId: string | number): string {
+  const envelope = JSON.parse(line) as {readonly params?: unknown};
+  const params =
+    typeof envelope.params === 'object' && envelope.params !== null && !Array.isArray(envelope.params)
+      ? envelope.params
+      : {};
+  return JSON.stringify({...envelope, params: {...params, requestId}});
+}
+
+function cancelledRequestId(params: unknown): string | number | undefined {
+  if (typeof params !== 'object' || params === null || Array.isArray(params) || !('requestId' in params)) {
+    return undefined;
+  }
+  return isJsonRpcId(params.requestId) ? params.requestId : undefined;
 }

--- a/src/mcp_broker.ts
+++ b/src/mcp_broker.ts
@@ -1,0 +1,269 @@
+import type {StandaloneActiveRelease} from './standalone_process_lease.js';
+
+const MCP_BROKER_MAX_LINE_BYTES = 32 * 1024 * 1024;
+const MCP_BROKER_REPLAY_TIMEOUT_MILLISECONDS = 10_000;
+const MCP_BROKER_CHILD_STOP_WAIT_MILLISECONDS = 1_000;
+const MCP_BROKER_RUNTIME_EXIT_ERROR =
+  'Threadnote MCP runtime exited before responding. The request outcome is unknown; inspect state before retrying a mutating operation.';
+
+export class McpBrokerError extends Error {
+  readonly _tag = 'McpBrokerError' as const;
+}
+
+interface McpBrokerChildInput {
+  end(): Promise<unknown> | unknown;
+  flush(): Promise<unknown> | unknown;
+  write(value: string): number | Promise<number>;
+}
+
+export interface McpBrokerChild {
+  readonly exited: Promise<number>;
+  readonly input: McpBrokerChildInput;
+  kill(signal?: number | NodeJS.Signals): void;
+  readonly output: AsyncIterable<Uint8Array>;
+  readonly processId: number;
+}
+
+export interface McpBrokerDependencies {
+  readonly input: AsyncIterable<Uint8Array>;
+  readonly readActiveRelease: () => Promise<StandaloneActiveRelease | undefined>;
+  readonly spawn: (release: StandaloneActiveRelease) => McpBrokerChild;
+  readonly writeOutput: (line: string) => Promise<void>;
+}
+
+interface JsonRpcEnvelope {
+  readonly error?: unknown;
+  readonly id?: unknown;
+  readonly method?: unknown;
+  readonly result?: unknown;
+}
+
+interface ActiveBrokerChild {
+  readonly child: McpBrokerChild;
+  readonly release: StandaloneActiveRelease;
+  replay?: {
+    readonly idKey: string;
+    readonly reject: (cause: unknown) => void;
+    readonly resolve: () => void;
+  };
+}
+
+/**
+ * Keeps the editor-owned stdio transport stable while versioned MCP runtimes
+ * are promoted behind it. Requests already admitted by the old runtime are
+ * allowed to finish; the next request starts the active release and replays the
+ * MCP initialization handshake before forwarding new work.
+ */
+export async function runMcpBroker(dependencies: McpBrokerDependencies): Promise<void> {
+  const broker = new McpBroker(dependencies);
+  await broker.run();
+}
+
+class McpBroker {
+  readonly #clientRequests = new Map<string, string | number>();
+  readonly #dependencies: McpBrokerDependencies;
+  readonly #serverRequests = new Set<string>();
+  #child: ActiveBrokerChild | undefined;
+  #initializeLine: string | undefined;
+  #initializeRequestId: string | number | undefined;
+  #initializedLine: string | undefined;
+  #outputTail = Promise.resolve();
+
+  constructor(dependencies: McpBrokerDependencies) {
+    this.#dependencies = dependencies;
+  }
+
+  async run(): Promise<void> {
+    try {
+      for await (const line of ndjsonLines(this.#dependencies.input)) {
+        await this.#handleClientLine(line);
+      }
+    } finally {
+      await this.#stopCurrentChild();
+      await this.#outputTail.catch(() => undefined);
+    }
+  }
+
+  async #handleClientLine(line: string): Promise<void> {
+    const envelope = parseJsonRpcEnvelope(line);
+    const current = await this.#ensureCurrentChild();
+    if (envelope?.method === 'initialize' && isJsonRpcId(envelope.id)) {
+      this.#initializeLine = line;
+      this.#initializeRequestId = envelope.id;
+    } else if (envelope?.method === 'notifications/initialized') {
+      this.#initializedLine = line;
+    }
+    if (envelope?.method !== undefined && isJsonRpcId(envelope.id)) {
+      this.#clientRequests.set(jsonRpcIdKey(envelope.id), envelope.id);
+    } else if (envelope?.method === undefined && isJsonRpcId(envelope?.id)) {
+      this.#serverRequests.delete(jsonRpcIdKey(envelope.id));
+    }
+    await writeChildLine(current.child, line);
+  }
+
+  async #ensureCurrentChild(): Promise<ActiveBrokerChild> {
+    const active = await this.#dependencies.readActiveRelease();
+    if (active === undefined) {
+      if (this.#child !== undefined) return this.#child;
+      throw new McpBrokerError('Threadnote has no valid active standalone release for the MCP broker.');
+    }
+    if (
+      this.#child !== undefined &&
+      this.#child.release.version === active.version &&
+      this.#child.release.releaseRoot === active.releaseRoot
+    ) {
+      return this.#child;
+    }
+    if (this.#child !== undefined && (this.#clientRequests.size > 0 || this.#serverRequests.size > 0)) {
+      return this.#child;
+    }
+    await this.#stopCurrentChild();
+    const next = this.#startChild(active);
+    if (this.#initializeLine !== undefined && this.#initializeRequestId !== undefined) {
+      await this.#replayInitialization(next);
+    }
+    return next;
+  }
+
+  #startChild(release: StandaloneActiveRelease): ActiveBrokerChild {
+    const active = {child: this.#dependencies.spawn(release), release} satisfies ActiveBrokerChild;
+    this.#child = active;
+    void this.#observeChild(active);
+    return active;
+  }
+
+  async #observeChild(active: ActiveBrokerChild): Promise<void> {
+    await Promise.all([this.#readChildOutput(active), active.child.exited.catch(() => -1)]).catch(() => undefined);
+    if (this.#child !== active) return;
+    this.#child = undefined;
+    active.replay?.reject(new McpBrokerError('Threadnote MCP runtime exited during session promotion.'));
+    active.replay = undefined;
+    const pending = [...this.#clientRequests.values()];
+    this.#clientRequests.clear();
+    this.#serverRequests.clear();
+    for (const id of pending) {
+      await this.#queueOutput(
+        JSON.stringify({
+          error: {code: -32_603, message: MCP_BROKER_RUNTIME_EXIT_ERROR},
+          id,
+          jsonrpc: '2.0',
+        }),
+      );
+    }
+  }
+
+  async #readChildOutput(active: ActiveBrokerChild): Promise<void> {
+    for await (const line of ndjsonLines(active.child.output)) {
+      if (this.#child !== active) continue;
+      const envelope = parseJsonRpcEnvelope(line);
+      if (isJsonRpcId(envelope?.id)) {
+        const idKey = jsonRpcIdKey(envelope.id);
+        if (active.replay?.idKey === idKey && envelope?.method === undefined) {
+          const replay = active.replay;
+          active.replay = undefined;
+          if (envelope.error === undefined && envelope.result !== undefined) replay.resolve();
+          else replay.reject(new McpBrokerError('The promoted MCP runtime rejected the replayed initialization.'));
+          continue;
+        }
+        if (envelope?.method === undefined) this.#clientRequests.delete(idKey);
+        else this.#serverRequests.add(idKey);
+      }
+      await this.#queueOutput(line);
+    }
+  }
+
+  async #replayInitialization(active: ActiveBrokerChild): Promise<void> {
+    const initializeLine = this.#initializeLine;
+    const initializeRequestId = this.#initializeRequestId;
+    if (initializeLine === undefined || initializeRequestId === undefined) return;
+    const replayed = new Promise<void>((resolve, reject) => {
+      active.replay = {idKey: jsonRpcIdKey(initializeRequestId), reject, resolve};
+    });
+    await writeChildLine(active.child, initializeLine);
+    await Promise.race([
+      replayed,
+      Bun.sleep(MCP_BROKER_REPLAY_TIMEOUT_MILLISECONDS).then(() => {
+        throw new McpBrokerError('Timed out initializing the promoted Threadnote MCP runtime.');
+      }),
+    ]);
+    if (this.#initializedLine !== undefined) await writeChildLine(active.child, this.#initializedLine);
+  }
+
+  async #stopCurrentChild(): Promise<void> {
+    const active = this.#child;
+    if (active === undefined) return;
+    this.#child = undefined;
+    active.replay?.reject(new McpBrokerError('Threadnote MCP runtime promotion was superseded.'));
+    active.replay = undefined;
+    await Promise.resolve(active.child.input.end()).catch(() => undefined);
+    if (await exitsWithin(active.child, MCP_BROKER_CHILD_STOP_WAIT_MILLISECONDS)) return;
+    try {
+      active.child.kill('SIGTERM');
+    } catch {
+      // The child can exit between the bounded wait and the signal.
+    }
+    if (await exitsWithin(active.child, MCP_BROKER_CHILD_STOP_WAIT_MILLISECONDS)) return;
+    try {
+      active.child.kill('SIGKILL');
+    } catch {
+      // The child already exited.
+    }
+    await exitsWithin(active.child, MCP_BROKER_CHILD_STOP_WAIT_MILLISECONDS);
+  }
+
+  #queueOutput(line: string): Promise<void> {
+    const write = this.#outputTail.then(() => this.#dependencies.writeOutput(line));
+    this.#outputTail = write.catch(() => undefined);
+    return write;
+  }
+}
+
+async function writeChildLine(child: McpBrokerChild, line: string): Promise<void> {
+  await child.input.write(`${line}\n`);
+  await child.input.flush();
+}
+
+async function exitsWithin(child: McpBrokerChild, timeoutMilliseconds: number): Promise<boolean> {
+  return Promise.race([
+    child.exited.then(() => true).catch(() => true),
+    Bun.sleep(timeoutMilliseconds).then(() => false),
+  ]);
+}
+
+async function* ndjsonLines(input: AsyncIterable<Uint8Array>): AsyncGenerator<string> {
+  const decoder = new TextDecoder();
+  let buffered = '';
+  for await (const chunk of input) {
+    buffered += decoder.decode(chunk, {stream: true});
+    if (new TextEncoder().encode(buffered).byteLength > MCP_BROKER_MAX_LINE_BYTES) {
+      throw new McpBrokerError('Threadnote MCP broker received an oversized protocol line.');
+    }
+    for (;;) {
+      const newline = buffered.indexOf('\n');
+      if (newline < 0) break;
+      const line = buffered.slice(0, newline).replace(/\r$/u, '');
+      buffered = buffered.slice(newline + 1);
+      if (line.length > 0) yield line;
+    }
+  }
+  buffered += decoder.decode();
+  const line = buffered.replace(/\r$/u, '');
+  if (line.length > 0) yield line;
+}
+
+function parseJsonRpcEnvelope(line: string): JsonRpcEnvelope | undefined {
+  try {
+    const value = JSON.parse(line) as unknown;
+    return typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as JsonRpcEnvelope) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isJsonRpcId(value: unknown): value is string | number {
+  return typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value));
+}
+
+function jsonRpcIdKey(value: string | number): string {
+  return `${typeof value}:${String(value)}`;
+}

--- a/src/mcp_server_memory.ts
+++ b/src/mcp_server_memory.ts
@@ -25,7 +25,7 @@ import {
   writeMemoryFile,
   writeSharedWorktreeFile,
 } from './share.js';
-import {errorMessage, safeTimestamp, sha256} from './utils.js';
+import {currentPackageVersion, errorMessage, safeTimestamp, sha256} from './utils.js';
 import {EffectMcpServerAdapter, McpInput} from './effect/ai/mcp.js';
 import {sha256Hex} from './effect/digest.js';
 import {withMemoryUriLocks} from './effect/memory_lock.js';
@@ -925,16 +925,18 @@ export function runNativeGlobTool(
 export const runNativeHealthTool = Effect.fn('mcp_server.runNativeHealthTool')(function* (config: RuntimeConfig) {
   const fs = yield* FileSystem.FileSystem;
   const homeExists = yield* fs.exists(config.agentContextHome);
+  const runtimeVersion = yield* currentPackageVersion();
   return {
     content: [
       {
         type: 'text' as const,
-        text: `Threadnote native runtime: ok\nHome: ${config.agentContextHome}\nHome initialized: ${homeExists ? 'yes' : 'no'}`,
+        text: `Threadnote native runtime: ok\nVersion: ${runtimeVersion}\nHome: ${config.agentContextHome}\nHome initialized: ${homeExists ? 'yes' : 'no'}`,
       },
     ],
     structuredContent: {
       home: config.agentContextHome,
       homeInitialized: homeExists,
+      runtimeVersion,
       status: 'ok',
       storage: 'native',
     },

--- a/src/process_diagnostics.ts
+++ b/src/process_diagnostics.ts
@@ -22,7 +22,8 @@ export type ThreadnoteProcessRole =
   | 'legacy'
   | 'local-model-worker'
   | 'manager'
-  | 'mcp';
+  | 'mcp'
+  | 'mcp-broker';
 export type RegisteredThreadnoteProcessRole = Exclude<ThreadnoteProcessRole, 'legacy'>;
 
 interface ProcessRegistrationFile {
@@ -680,7 +681,8 @@ function isRegisteredThreadnoteProcessRole(value: unknown): value is RegisteredT
     value === 'graph-waiter' ||
     value === 'local-model-worker' ||
     value === 'manager' ||
-    value === 'mcp'
+    value === 'mcp' ||
+    value === 'mcp-broker'
   );
 }
 

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -17,6 +17,7 @@ const isCodeGraphParserWorker = arguments_[0] === CODE_GRAPH_PARSER_WORKER_ARGUM
 const isCodeGraphCompactionWorker = arguments_[0] === CODE_GRAPH_COMPACTION_WORKER_ARGUMENT;
 const isCodeGraphDeepDiagnosticsWorker = arguments_[0] === CODE_GRAPH_DEEP_DIAGNOSTICS_WORKER_ARGUMENT;
 const isGitWorktreeRegistrationWorker = arguments_[0] === CODE_GRAPH_GIT_WORKTREE_REGISTRATION_WORKER_ARGUMENT;
+const isMcpBroker = arguments_[0] === 'mcp-broker';
 const isMcpServer = executableName?.startsWith('threadnote-mcp-server') === true || arguments_[0] === 'mcp-server';
 const runSignalTransparentMain = Runtime.makeRunMain(({fiber, teardown}) => {
   fiber.addObserver(exit => {
@@ -42,11 +43,14 @@ if (isCodeGraphDeepDiagnosticsWorker || isCodeGraphCompactionWorker) {
       ? await codeGraphParserWorkerProgram(arguments_)
       : isGitWorktreeRegistrationWorker
         ? await gitWorktreeRegistrationWorkerProgram()
-        : await applicationProgram(arguments_, isMcpServer);
+        : await applicationProgram(arguments_, isMcpServer, isMcpBroker);
 
   BunRuntime.runMain(program, {
     disableErrorReporting:
-      isLocalModelWorker || isCodeGraphParserWorker || isGitWorktreeRegistrationWorker || !isMcpServer,
+      isLocalModelWorker ||
+      isCodeGraphParserWorker ||
+      isGitWorktreeRegistrationWorker ||
+      (!isMcpServer && !isMcpBroker),
   });
 }
 
@@ -158,12 +162,30 @@ async function codeGraphParserWorkerProgram(arguments_: readonly string[]) {
   );
 }
 
-async function applicationProgram(arguments_: readonly string[], isMcpServer: boolean) {
+async function applicationProgram(arguments_: readonly string[], isMcpServer: boolean, isMcpBroker: boolean) {
   const [runtime, processDiagnostics, processLease] = await Promise.all([
     import('./effect/runtime.js'),
     import('./process_diagnostics.js'),
     import('./standalone_process_lease.js'),
   ]);
+  if (isMcpBroker) {
+    const {mcpBrokerEffect} = await import('./effect/mcp_broker_process.js');
+    const processHome = normalizedProcessHome(arguments_, processDiagnostics.threadnoteHomeForProcess);
+    return processHome.pipe(
+      Effect.flatMap(home =>
+        processLease.withStandaloneProcessLease(
+          processDiagnostics.withThreadnoteProcessRegistration(
+            home,
+            'mcp-broker',
+            Effect.scoped(mcpBrokerEffect),
+            'mcp-broker',
+          ),
+          {retirementPolicy: 'preserve-session'},
+        ),
+      ),
+      Effect.provide(runtime.StandaloneBrokerLayer),
+    );
+  }
   if (isMcpServer) {
     const {mcpServerEffect} = await import('./mcp_server.js');
     const processHome = normalizedProcessHome(arguments_, processDiagnostics.threadnoteHomeForProcess);
@@ -176,6 +198,7 @@ async function applicationProgram(arguments_: readonly string[], isMcpServer: bo
             Effect.scoped(mcpServerEffect),
             'mcp-server',
           ),
+          {retirementPolicy: 'preserve-session'},
         ),
       ),
       Effect.provide(runtime.ApplicationLayer),

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -198,7 +198,6 @@ async function applicationProgram(arguments_: readonly string[], isMcpServer: bo
             Effect.scoped(mcpServerEffect),
             'mcp-server',
           ),
-          {retirementPolicy: 'preserve-session'},
         ),
       ),
       Effect.provide(runtime.ApplicationLayer),

--- a/src/standalone_process_lease.ts
+++ b/src/standalone_process_lease.ts
@@ -20,10 +20,13 @@ interface ProcessLeaseFile {
   readonly parentProcessId: Option.Option<number>;
   readonly processId: number;
   readonly processStartIdentity: Option.Option<string>;
+  readonly retirementPolicy: StandaloneProcessRetirementPolicy;
   readonly startedAt: Option.Option<string>;
   readonly token: string;
   readonly version: string;
 }
+
+export type StandaloneProcessRetirementPolicy = 'preserve-session' | 'terminate';
 
 /**
  * Privacy-safe process evidence retained by standalone releases predating the
@@ -33,6 +36,7 @@ interface ProcessLeaseFile {
 export interface StandaloneProcessLease {
   readonly parentProcessId: Option.Option<number>;
   readonly processId: number;
+  readonly retirementPolicy: StandaloneProcessRetirementPolicy;
   readonly startedAt: Option.Option<string>;
   readonly version: string;
 }
@@ -60,6 +64,7 @@ interface ObservedStandaloneProcessLease extends StandaloneProcessLease {
 }
 
 export interface SupersededStandaloneProcessTermination {
+  readonly preserved: readonly StandaloneProcessLease[];
   readonly remaining: readonly StandaloneProcessLease[];
   readonly signaled: readonly StandaloneProcessLease[];
   readonly skippedUnverified: readonly StandaloneProcessLease[];
@@ -82,7 +87,10 @@ export function installationRoot(path: Path.Path, system: SystemInfoShape): stri
  * processes acquire their own lease so a killed parent cannot prune code that
  * a still-running child is executing.
  */
-export function withStandaloneProcessLease<A, E, R>(effect: Effect.Effect<A, E, R>) {
+export function withStandaloneProcessLease<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  options: {readonly retirementPolicy?: StandaloneProcessRetirementPolicy} = {},
+) {
   return Effect.scoped(
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -105,6 +113,7 @@ export function withStandaloneProcessLease<A, E, R>(effect: Effect.Effect<A, E, 
             parentProcessId: process.ppid,
             processId: system.processId,
             processStartIdentity,
+            retirementPolicy: options.retirementPolicy ?? 'terminate',
             startedAt: new Date(yield* Clock.currentTimeMillis).toISOString(),
             token,
             version: release.version,
@@ -258,8 +267,11 @@ export const terminateSupersededStandaloneProcesses = Effect.fn('installations.t
     const superseded = scan.leases.filter(
       lease => lease.version !== activeVersion && lease.processId !== system.processId,
     );
-    const verified = superseded.filter(lease => lease.identityVerified);
-    const skippedUnverified = superseded.filter(lease => !lease.identityVerified).map(publicLease);
+    const preservedIds = preservedStandaloneProcessIds(superseded);
+    const preserved = superseded.filter(lease => preservedIds.has(lease.processId));
+    const eligible = superseded.filter(lease => !preservedIds.has(lease.processId));
+    const verified = eligible.filter(lease => lease.identityVerified);
+    const skippedUnverified = eligible.filter(lease => !lease.identityVerified).map(publicLease);
     const candidateIds = new Set(verified.map(lease => lease.processId));
     const roots = verified.filter(
       lease => Option.isNone(lease.parentProcessId) || !candidateIds.has(lease.parentProcessId.value),
@@ -285,6 +297,7 @@ export const terminateSupersededStandaloneProcesses = Effect.fn('installations.t
     }
     yield* waitForLeasesToExit(system, verified, 1_000);
     return {
+      preserved: preserved.map(publicLease).sort((left, right) => left.processId - right.processId),
       remaining: verified.filter(lease => system.isProcessRunning(lease.processId)).map(publicLease),
       signaled: [...signaled.values()].sort((left, right) => left.processId - right.processId),
       skippedUnverified: skippedUnverified.sort((left, right) => left.processId - right.processId),
@@ -356,6 +369,7 @@ const liveStandaloneProcessLeases = Effect.fn('installations.liveProcessLeases')
           parentProcessId: lease.value.parentProcessId,
           processId,
           processStartIdentity: lease.value.processStartIdentity,
+          retirementPolicy: lease.value.retirementPolicy,
           startedAt: lease.value.startedAt,
           version,
         });
@@ -371,9 +385,34 @@ function publicLease(lease: ObservedStandaloneProcessLease): StandaloneProcessLe
   return {
     parentProcessId: lease.parentProcessId,
     processId: lease.processId,
+    retirementPolicy: lease.retirementPolicy,
     startedAt: lease.startedAt,
     version: lease.version,
   };
+}
+
+/** @internal Pure ancestry closure used by process-retirement tests. */
+export function preservedStandaloneProcessIds(
+  leases: readonly Pick<StandaloneProcessLease, 'parentProcessId' | 'processId' | 'retirementPolicy'>[],
+): ReadonlySet<number> {
+  const preserved = new Set(
+    leases.filter(lease => lease.retirementPolicy === 'preserve-session').map(lease => lease.processId),
+  );
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const lease of leases) {
+      if (
+        !preserved.has(lease.processId) &&
+        Option.isSome(lease.parentProcessId) &&
+        preserved.has(lease.parentProcessId.value)
+      ) {
+        preserved.add(lease.processId);
+        changed = true;
+      }
+    }
+  }
+  return preserved;
 }
 
 function signalLeaseIfStillOwned(
@@ -477,10 +516,15 @@ function readProcessLease(fs: FileSystem.FileSystem, leasePath: string) {
         'startedAt' in value && typeof value.startedAt === 'string' && Number.isFinite(Date.parse(value.startedAt))
           ? Option.some(value.startedAt)
           : Option.none<string>();
+      const retirementPolicy =
+        'retirementPolicy' in value && value.retirementPolicy === 'preserve-session'
+          ? 'preserve-session'
+          : 'terminate';
       return Option.some({
         parentProcessId,
         processId: value.processId,
         processStartIdentity,
+        retirementPolicy,
         startedAt,
         token: value.token,
         version: value.version,

--- a/src/standalone_process_lease.ts
+++ b/src/standalone_process_lease.ts
@@ -517,9 +517,7 @@ function readProcessLease(fs: FileSystem.FileSystem, leasePath: string) {
           ? Option.some(value.startedAt)
           : Option.none<string>();
       const retirementPolicy =
-        'retirementPolicy' in value && value.retirementPolicy === 'preserve-session'
-          ? 'preserve-session'
-          : 'terminate';
+        'retirementPolicy' in value && value.retirementPolicy === 'preserve-session' ? 'preserve-session' : 'terminate';
       return Option.some({
         parentProcessId,
         processId: value.processId,

--- a/src/update.ts
+++ b/src/update.ts
@@ -286,7 +286,7 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     yield* Console.log('Skipping repair because --no-repair was provided.');
   }
   yield* Console.log(
-    'Update complete. Restart Cursor, Copilot, Codex, Claude, or open a fresh agent session so MCP tools reload.',
+    'Update complete. Brokered MCP sessions will use the new version on their next request. Sessions started before Threadnote 4.2.2 require one host restart.',
   );
   yield* withStandaloneInstallationLock(pruneStandaloneReleases(releaseRoot, dryRun), dryRun);
   yield* printWhatsNewIfAvailable(info);

--- a/src/update.ts
+++ b/src/update.ts
@@ -231,6 +231,9 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
       );
     }
     yield* Console.log(success('Threadnote is up to date.'));
+    yield* Console.log(
+      'Managed launchers are current. If an MCP host still uses the legacy direct server command, run `threadnote repair`, then restart that host once.',
+    );
     return;
   }
 
@@ -283,10 +286,14 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
     yield* Console.log('Repairing local Threadnote setup after standalone update.');
     yield* runStreamingSubcommand(dryRun, threadnoteCommand, ['repair', '--no-post-update']);
   } else {
-    yield* Console.log('Skipping repair because --no-repair was provided.');
+    yield* Console.log(
+      'Skipping local integration repair because --no-repair was provided. MCP host configurations were not refreshed.',
+    );
   }
   yield* Console.log(
-    'Update complete. Brokered MCP sessions will use the new version on their next request. Sessions started before Threadnote 4.2.2 require one host restart.',
+    shouldRepair
+      ? 'Update complete. Brokered MCP sessions will use the new version on their next request. Legacy direct-server sessions migrated by repair require one host restart.'
+      : 'Update complete. Brokered MCP sessions will use the new version on their next request. Hosts still using the legacy direct server command must run `threadnote repair` and restart once.',
   );
   yield* withStandaloneInstallationLock(pruneStandaloneReleases(releaseRoot, dryRun), dryRun);
   yield* printWhatsNewIfAvailable(info);

--- a/test/e2e/posix-installer.e2e.ts
+++ b/test/e2e/posix-installer.e2e.ts
@@ -604,6 +604,22 @@ esac
       await expect(stat(promotionBackup)).rejects.toThrow();
       await expect(stat(promotionJournal)).resolves.toMatchObject({size: expect.any(Number)});
 
+      const cursorConfigPath = join(userHome, '.cursor', 'mcp.json');
+      await mkdir(join(userHome, '.cursor'), {recursive: true});
+      await Bun.write(
+        cursorConfigPath,
+        `${JSON.stringify(
+          {
+            mcpServers: {
+              other: {args: ['serve'], command: '/opt/example-mcp'},
+              threadnote: {args: ['mcp-server'], command: join(binRoot, 'threadnote')},
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
       const update = await execute(
         join(binRoot, 'threadnote'),
         [
@@ -615,7 +631,6 @@ esac
           '--source',
           `http://127.0.0.1:${server.port}/releases`,
           '--allow-untrusted-source',
-          '--no-repair',
           '--no-post-update',
         ],
         {
@@ -632,6 +647,15 @@ esac
       expect(`${update.stdout}${update.stderr}`).toContain(
         `Installed standalone Threadnote ${packageManifest.version}`,
       );
+      expect(`${update.stdout}${update.stderr}`).toContain('Repairing local Threadnote setup after standalone update.');
+      const cursorConfig = JSON.parse(await readFile(cursorConfigPath, 'utf8')) as {
+        readonly mcpServers: Record<string, {readonly args?: readonly string[]; readonly command?: string}>;
+      };
+      expect(cursorConfig.mcpServers.other).toEqual({args: ['serve'], command: '/opt/example-mcp'});
+      expect(cursorConfig.mcpServers.threadnote).toMatchObject({
+        args: [],
+        command: join(binRoot, 'threadnote-mcp-server'),
+      });
       await expect(stat(promotionBackup)).rejects.toThrow();
       await expect(stat(promotionJournal)).rejects.toThrow();
       const transport = new StdioClientTransport({

--- a/test/integration/cursor-cloud.test.ts
+++ b/test/integration/cursor-cloud.test.ts
@@ -56,6 +56,8 @@ describe('Cursor Cloud integration', () => {
       ]);
       expect(secondConfig.stdout).toBe(firstConfig.stdout);
       expect(JSON.parse(firstConfig.stdout)).toMatchObject({
+        args: ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'],
+        command: '/bin/sh',
         env: {
           THREADNOTE_CURSOR_CLOUD_TEAM: 'engineering',
           THREADNOTE_MCP_TOOLSET: 'cursor-cloud',

--- a/test/unit/cursor-cloud.test.ts
+++ b/test/unit/cursor-cloud.test.ts
@@ -32,13 +32,19 @@ describe('Cursor Cloud profile', () => {
       team: 'engineering',
       user: 'cloud-user',
     });
-    expect(buildCursorCloudMcpConfig(profile)).toEqual(buildCursorCloudMcpConfig(profile));
-    expect(buildCursorCloudMcpConfig(profile).env).toEqual({
-      THREADNOTE_ACCOUNT: 'local',
-      THREADNOTE_AGENT_ID: 'cursor-agent',
-      THREADNOTE_CURSOR_CLOUD_TEAM: 'engineering',
-      THREADNOTE_MCP_TOOLSET: 'cursor-cloud',
-      THREADNOTE_USER: 'cloud-user',
+    const mcpConfig = buildCursorCloudMcpConfig(profile);
+    expect(mcpConfig).toEqual(buildCursorCloudMcpConfig(profile));
+    expect(mcpConfig).toEqual({
+      args: ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'],
+      command: '/bin/sh',
+      env: {
+        THREADNOTE_ACCOUNT: 'local',
+        THREADNOTE_AGENT_ID: 'cursor-agent',
+        THREADNOTE_CURSOR_CLOUD_TEAM: 'engineering',
+        THREADNOTE_MCP_TOOLSET: 'cursor-cloud',
+        THREADNOTE_USER: 'cloud-user',
+      },
+      type: 'stdio',
     });
   });
 

--- a/test/unit/development-runtime.test.ts
+++ b/test/unit/development-runtime.test.ts
@@ -907,6 +907,114 @@ describe('exact-head development runtime', () => {
       }),
   );
 
+  effectIt.effect('reports the complete preserved session tree when superseded processes remain running', () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseSystem = yield* SystemInfo;
+          const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-development-preserved-session-'});
+          const installRoot = path.join(root, 'install');
+          const binRoot = path.join(root, 'bin');
+          const sourceCommit = '7'.repeat(40);
+          const version = developmentBuildVersion('4.0.0-beta.30', sourceCommit);
+          const supersededVersion = '4.0.0-beta.29';
+          const releaseRoot = path.join(installRoot, 'versions', version);
+          const executableName = baseSystem.platform === 'win32' ? 'threadnote.exe' : 'threadnote';
+          yield* writeDevelopmentReleaseFixture(
+            fs,
+            path,
+            releaseRoot,
+            version,
+            sourceCommit,
+            executableName,
+            'preserved-session-release',
+          );
+          const leases = [
+            {
+              processId: 45_001,
+              processStartIdentity: 'broker-process',
+              retirementPolicy: 'preserve-session',
+            },
+            {
+              parentProcessId: 45_001,
+              processId: 45_002,
+              processStartIdentity: 'mcp-process',
+              retirementPolicy: 'terminate',
+            },
+            {
+              parentProcessId: 45_002,
+              processId: 45_003,
+              processStartIdentity: 'worker-process',
+              retirementPolicy: 'terminate',
+            },
+            {
+              processId: 45_004,
+              processStartIdentity: 'cli-process',
+              retirementPolicy: 'terminate',
+            },
+          ] as const;
+          const leasesRoot = path.join(installRoot, 'leases', supersededVersion);
+          yield* fs.makeDirectory(leasesRoot, {recursive: true});
+          for (const lease of leases) {
+            yield* fs.writeFileString(
+              path.join(leasesRoot, `${lease.processId}.json`),
+              `${JSON.stringify({
+                ...lease,
+                startedAt: '2026-08-02T08:00:00.000Z',
+                token: `lease-${lease.processId}`,
+                version: supersededVersion,
+              })}\n`,
+            );
+          }
+          const identities = new Map<number, string>(
+            leases.map(lease => [lease.processId, lease.processStartIdentity]),
+          );
+          const running = new Set<number>(leases.map(lease => lease.processId));
+          const testSystem = SystemInfo.of({
+            ...baseSystem,
+            environment: () => ({
+              ...baseSystem.environment(),
+              THREADNOTE_BIN_DIR: binRoot,
+              THREADNOTE_INSTALL_ROOT: installRoot,
+            }),
+            isProcessRunning: processId => running.has(processId),
+            processId: 99_999,
+            processStartIdentity: processId => Effect.succeed(identities.get(processId)),
+            signalProcess: () => {
+              throw new TestError('Installer must not signal processes without --terminate-superseded');
+            },
+          });
+          return yield* activateLocalStandaloneRelease({
+            canonicalInstallRoot: yield* fs.realPath(installRoot),
+            canonicalVersionsRoot: yield* fs.realPath(path.join(installRoot, 'versions')),
+            commit: sourceCommit,
+            executableName,
+            releaseRoot,
+            reused: true,
+            sourceCheckoutId: 'a'.repeat(64),
+            stagedRoot: Option.none(),
+            takeOverGlobalRuntime: false,
+            terminateSuperseded: false,
+            version,
+          }).pipe(
+            Effect.provideService(CommandExecutor, versionCommandExecutor(version)),
+            Effect.provideService(SystemInfo, testSystem),
+          );
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer));
+
+      expect(result).toMatchObject({
+        cleanupComplete: false,
+        cleanupIssues: [],
+        preservedMcpSessionProcesses: 3,
+        remainingSupersededProcesses: 1,
+        terminatedSupersededProcesses: 0,
+      });
+    }),
+  );
+
   effectIt.effect('restores the prior active pointer and launchers when launcher verification fails', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(

--- a/test/unit/effect-architecture.test.ts
+++ b/test/unit/effect-architecture.test.ts
@@ -68,6 +68,7 @@ describe('Effect architecture boundaries', () => {
       'src/effect/cli_output.ts',
       'src/effect/console.ts',
       'src/effect/errors.ts',
+      'src/effect/mcp_broker_process.ts',
       'src/effect/system.ts',
       'src/mcp_server.ts',
     ]);
@@ -162,6 +163,7 @@ describe('Effect architecture boundaries', () => {
   it('keeps runtime globals inside the SystemInfo, process-adapter, and executable boundaries', async () => {
     const allowed = new Set([
       'src/effect/ai/isolated-local-model-runtime.ts',
+      'src/effect/mcp_broker_process.ts',
       'src/effect/system.ts',
       'src/standalone.ts',
     ]);

--- a/test/unit/installations.test.ts
+++ b/test/unit/installations.test.ts
@@ -7,6 +7,7 @@ import {describe, expect} from 'vitest';
 import {SystemInfo, type SystemInfoShape} from '../../src/effect/system.js';
 import {
   activateStandaloneRelease,
+  activeInstalledRelease,
   activeInstalledVersion,
   promoteStandaloneReleaseDirectory,
   pruneStandaloneReleases,
@@ -261,6 +262,12 @@ describe('standalone release lifecycle', () => {
                 : Effect.void,
           }).pipe(Effect.provideService(SystemInfo, testSystem), Effect.flip);
           const activeMissingAfterCrash = !(yield* fs.exists(path.join(installRoot, 'active-release.json')));
+          const readableDuringGap = yield* activeInstalledRelease().pipe(Effect.provideService(SystemInfo, testSystem));
+          const gapAfterRead = {
+            activeMissing: !(yield* fs.exists(path.join(installRoot, 'active-release.json'))),
+            backupExists: yield* fs.exists(path.join(installRoot, 'active-release.previous.json')),
+            journalExists: yield* fs.exists(path.join(installRoot, 'active-release.promotion.json')),
+          };
 
           yield* activateStandaloneRelease(newRelease, false).pipe(Effect.provideService(SystemInfo, testSystem));
           return {
@@ -269,8 +276,10 @@ describe('standalone release lifecycle', () => {
             },
             activeMissingAfterCrash,
             backupExists: yield* fs.exists(path.join(installRoot, 'active-release.previous.json')),
+            gapAfterRead,
             interrupted: String(interrupted),
             journalExists: yield* fs.exists(path.join(installRoot, 'active-release.promotion.json')),
+            readableDuringGap,
           };
         }),
       ).pipe(provideTestLayer(ApplicationLayer));
@@ -279,7 +288,9 @@ describe('standalone release lifecycle', () => {
         active: {version: '4.0.2'},
         activeMissingAfterCrash: true,
         backupExists: false,
+        gapAfterRead: {activeMissing: true, backupExists: true, journalExists: true},
         journalExists: false,
+        readableDuringGap: {releaseRoot: expect.any(String), version: '4.0.1'},
       });
       expect(result.interrupted).toContain('simulated active pointer crash');
     }),
@@ -614,24 +625,8 @@ describe('standalone release lifecycle', () => {
             undefined,
             'preserve-session',
           );
-          yield* writeProcessLease(
-            fs,
-            path,
-            installRoot,
-            '4.0.0',
-            mcpProcessId,
-            'mcp-process',
-            brokerProcessId,
-          );
-          yield* writeProcessLease(
-            fs,
-            path,
-            installRoot,
-            '4.0.0',
-            workerProcessId,
-            'worker-process',
-            mcpProcessId,
-          );
+          yield* writeProcessLease(fs, path, installRoot, '4.0.0', mcpProcessId, 'mcp-process', brokerProcessId);
+          yield* writeProcessLease(fs, path, installRoot, '4.0.0', workerProcessId, 'worker-process', mcpProcessId);
           yield* writeProcessLease(fs, path, installRoot, '4.0.0', cliProcessId, 'cli-process');
           const running = new Set([brokerProcessId, mcpProcessId, workerProcessId, cliProcessId]);
           const identity = new Map([

--- a/test/unit/installations.test.ts
+++ b/test/unit/installations.test.ts
@@ -591,6 +591,80 @@ describe('standalone release lifecycle', () => {
     }),
   );
 
+  effectIt.effect('preserves an MCP session process and its complete descendant tree during retirement', () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseSystem = yield* SystemInfo;
+          const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mcp-session-retirement-'});
+          const installRoot = path.join(temporaryRoot, 'install');
+          const brokerProcessId = 44_001;
+          const mcpProcessId = 44_002;
+          const workerProcessId = 44_003;
+          const cliProcessId = 44_004;
+          yield* writeProcessLease(
+            fs,
+            path,
+            installRoot,
+            '4.0.0',
+            brokerProcessId,
+            'broker-process',
+            undefined,
+            'preserve-session',
+          );
+          yield* writeProcessLease(
+            fs,
+            path,
+            installRoot,
+            '4.0.0',
+            mcpProcessId,
+            'mcp-process',
+            brokerProcessId,
+          );
+          yield* writeProcessLease(
+            fs,
+            path,
+            installRoot,
+            '4.0.0',
+            workerProcessId,
+            'worker-process',
+            mcpProcessId,
+          );
+          yield* writeProcessLease(fs, path, installRoot, '4.0.0', cliProcessId, 'cli-process');
+          const running = new Set([brokerProcessId, mcpProcessId, workerProcessId, cliProcessId]);
+          const identity = new Map([
+            [brokerProcessId, 'broker-process'],
+            [mcpProcessId, 'mcp-process'],
+            [workerProcessId, 'worker-process'],
+            [cliProcessId, 'cli-process'],
+          ]);
+          const signals: Array<readonly [number, NodeJS.Signals]> = [];
+          const testSystem = SystemInfo.of({
+            ...baseSystem,
+            environment: () => ({...baseSystem.environment(), THREADNOTE_INSTALL_ROOT: installRoot}),
+            isProcessRunning: processId => running.has(processId),
+            processId: 99_999,
+            processStartIdentity: processId => Effect.succeed(identity.get(processId)),
+            signalProcess: (processId, signal) => {
+              signals.push([processId, signal]);
+              running.delete(processId);
+            },
+          });
+          const termination = yield* terminateSupersededStandaloneProcesses('4.0.1', {
+            gracefulWaitMilliseconds: 0,
+          }).pipe(Effect.provideService(SystemInfo, testSystem));
+          return {running, signals, termination};
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer));
+
+      expect(result.signals).toEqual([[44_004, 'SIGTERM']]);
+      expect(result.termination.preserved.map(lease => lease.processId)).toEqual([44_001, 44_002, 44_003]);
+      expect([...result.running].sort()).toEqual([44_001, 44_002, 44_003]);
+    }),
+  );
+
   effectIt.effect(
     'fails closed on malformed live leases and retains every release while inspection is incomplete',
     () =>
@@ -682,6 +756,7 @@ function writeProcessLease(
   processId: number,
   processStartIdentity?: string,
   parentProcessId?: number,
+  retirementPolicy?: 'preserve-session' | 'terminate',
 ) {
   const leaseRoot = path.join(installRoot, 'leases', version);
   return Effect.gen(function* () {
@@ -692,6 +767,7 @@ function writeProcessLease(
         parentProcessId,
         processId,
         processStartIdentity,
+        retirementPolicy,
         startedAt: '2026-08-02T08:00:00.000Z',
         token: `lease-${processId}`,
         version,

--- a/test/unit/mcp-broker.test.ts
+++ b/test/unit/mcp-broker.test.ts
@@ -1,9 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {
-  runMcpBroker,
-  type McpBrokerChild,
-  type McpBrokerDependencies,
-} from '../../src/mcp_broker.js';
+import {runMcpBroker, type McpBrokerChild, type McpBrokerDependencies} from '../../src/mcp_broker.js';
 import type {StandaloneActiveRelease} from '../../src/standalone_process_lease.js';
 
 describe('MCP session broker', () => {
@@ -31,15 +27,13 @@ describe('MCP session broker', () => {
     clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
     expect(await clientOutput.nextLine()).toContain('4.2.2-a');
     clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
-    clientInput.pushLine(
-      JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}),
-    );
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
     expect(await clientOutput.nextLine()).toContain('4.2.2-a');
 
     active = releases.second;
-    clientInput.pushLine(
-      JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}),
-    );
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/tools/list_changed'});
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/resources/list_changed'});
     expect(await clientOutput.nextLine()).toContain('4.2.2-b');
     expect(spawned).toHaveLength(2);
     expect(spawned[1]?.received.map(line => JSON.parse(line).method)).toEqual([
@@ -86,16 +80,359 @@ describe('MCP session broker', () => {
     expect(failure.error.message).toContain('outcome is unknown');
     expect(spawned).toHaveLength(1);
 
-    clientInput.pushLine(
-      JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}),
-    );
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
     const replacement = await waitForSpawnedChild(spawned, 1);
     await replacement.receivedCount(3);
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/tools/list_changed'});
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/resources/list_changed'});
     expect(replacement.received.map(line => JSON.parse(line).method)).toEqual([
       'initialize',
       'notifications/initialized',
       'tools/call',
     ]);
+
+    clientInput.end();
+    await running;
+  });
+
+  it('retries a rejected initialization exactly once on a replacement runtime', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const release = {releaseRoot: '/threadnote/versions/4.2.2', version: '4.2.2'};
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => release,
+      spawn: () => {
+        const child = new FakeMcpChild(release.version, {rejectInitialize: spawned.length === 0});
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(await clientOutput.nextLine()).toContain('initialization rejected');
+    spawned[0]!.exitUnexpectedly();
+    await new Promise(resolve => setTimeout(resolve, 1));
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(await clientOutput.nextLine()).toContain('4.2.2');
+
+    const replacement = await waitForSpawnedChild(spawned, 1);
+    expect(replacement.received.map(line => JSON.parse(line).method)).toEqual(['initialize']);
+
+    clientInput.end();
+    await running;
+  });
+
+  it('promotes after a cancelled request without replaying the cancelled work', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const releases = {
+      first: {releaseRoot: '/threadnote/versions/4.2.2-a', version: '4.2.2-a'},
+      second: {releaseRoot: '/threadnote/versions/4.2.2-b', version: '4.2.2-b'},
+    } satisfies Record<string, StandaloneActiveRelease>;
+    let active = releases.first;
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => active,
+      spawn: release => {
+        const child = new FakeMcpChild(release.version, {respondToTools: spawned.length > 0});
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    await spawned[0]!.receivedCount(3);
+
+    active = releases.second;
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/cancelled', params: {requestId: 2}}));
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/tools/list_changed'});
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/resources/list_changed'});
+    expect(await clientOutput.nextLine()).toContain('4.2.2-b');
+
+    expect(spawned[0]!.received.map(line => JSON.parse(line).method)).toEqual([
+      'initialize',
+      'notifications/initialized',
+      'tools/call',
+      'notifications/cancelled',
+    ]);
+    expect(spawned[1]!.received.map(line => JSON.parse(line).method)).toEqual([
+      'initialize',
+      'notifications/initialized',
+      'tools/call',
+    ]);
+
+    clientInput.end();
+    await running;
+  });
+
+  it('contains a child exit between admission and write and serves the next request on the same transport', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const release = {releaseRoot: '/threadnote/versions/4.2.2', version: '4.2.2'};
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => release,
+      spawn: () => {
+        const child = new FakeMcpChild(release.version, {exitBeforeFirstToolWrite: spawned.length === 0});
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({error: {code: -32_603}, id: 2});
+
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/tools/list_changed'});
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/resources/list_changed'});
+    expect(await clientOutput.nextLine()).toContain('4.2.2');
+    expect(spawned).toHaveLength(2);
+
+    clientInput.end();
+    await running;
+  });
+
+  it('contains a promoted initialization rejection and retries on the next request', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const releases = {
+      first: {releaseRoot: '/threadnote/versions/4.2.2-a', version: '4.2.2-a'},
+      second: {releaseRoot: '/threadnote/versions/4.2.2-b', version: '4.2.2-b'},
+    } satisfies Record<string, StandaloneActiveRelease>;
+    let active = releases.first;
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => active,
+      spawn: release => {
+        const child = new FakeMcpChild(release.version, {rejectInitialize: spawned.length === 1});
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    await spawned[0]!.receivedCount(2);
+    active = releases.second;
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({error: {code: -32_603}, id: 2});
+
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/tools/list_changed'});
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/resources/list_changed'});
+    expect(await clientOutput.nextLine()).toContain('4.2.2-b');
+    expect(spawned).toHaveLength(3);
+
+    clientInput.end();
+    await running;
+  });
+
+  it('contains a promoted initialization timeout and retries on the next request', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const releases = {
+      first: {releaseRoot: '/threadnote/versions/4.2.2-a', version: '4.2.2-a'},
+      second: {releaseRoot: '/threadnote/versions/4.2.2-b', version: '4.2.2-b'},
+    } satisfies Record<string, StandaloneActiveRelease>;
+    let active = releases.first;
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => active,
+      replayTimeoutMilliseconds: 1,
+      spawn: release => {
+        const child = new FakeMcpChild(release.version, {ignoreInitialize: spawned.length === 1});
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    await spawned[0]!.receivedCount(2);
+    active = releases.second;
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({error: {code: -32_603}, id: 2});
+
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/tools/list_changed'});
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/resources/list_changed'});
+    expect(await clientOutput.nextLine()).toContain('4.2.2-b');
+    expect(spawned).toHaveLength(3);
+
+    clientInput.end();
+    await running;
+  });
+
+  it('rewrites server request ids and drops an old-generation late response', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const releases = {
+      first: {releaseRoot: '/threadnote/versions/4.2.2-a', version: '4.2.2-a'},
+      second: {releaseRoot: '/threadnote/versions/4.2.2-b', version: '4.2.2-b'},
+    } satisfies Record<string, StandaloneActiveRelease>;
+    let active = releases.first;
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => active,
+      spawn: release => {
+        const child = new FakeMcpChild(release.version);
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    spawned[0]!.emitServerRequest(7);
+    const oldExternalId = (JSON.parse(await clientOutput.nextLine()) as {id: string}).id;
+    expect(oldExternalId).not.toBe('7');
+    spawned[0]!.exitUnexpectedly();
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({
+      method: 'notifications/cancelled',
+      params: {requestId: oldExternalId},
+    });
+
+    clientInput.pushLine(JSON.stringify({id: oldExternalId, jsonrpc: '2.0', result: {late: true}}));
+    active = releases.second;
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/tools/list_changed'});
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/resources/list_changed'});
+    await clientOutput.nextLine();
+    spawned[1]!.emitServerRequest(7);
+    const newExternalId = (JSON.parse(await clientOutput.nextLine()) as {id: string}).id;
+    expect(newExternalId).not.toBe(oldExternalId);
+
+    clientInput.pushLine(JSON.stringify({id: oldExternalId, jsonrpc: '2.0', result: {late: true}}));
+    clientInput.pushLine(JSON.stringify({id: newExternalId, jsonrpc: '2.0', result: {accepted: true}}));
+    await spawned[1]!.receivedCount(4);
+    expect(JSON.parse(spawned[1]!.received[3]!)).toEqual({id: 7, jsonrpc: '2.0', result: {accepted: true}});
+
+    clientInput.end();
+    await running;
+  });
+
+  it('retires a server request when the runtime cancels it so promotion can proceed', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const releases = {
+      first: {releaseRoot: '/threadnote/versions/4.2.2-a', version: '4.2.2-a'},
+      second: {releaseRoot: '/threadnote/versions/4.2.2-b', version: '4.2.2-b'},
+    } satisfies Record<string, StandaloneActiveRelease>;
+    let active = releases.first;
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => active,
+      spawn: release => {
+        const child = new FakeMcpChild(release.version);
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    spawned[0]!.emitServerRequest('sample');
+    const externalId = (JSON.parse(await clientOutput.nextLine()) as {id: string}).id;
+    spawned[0]!.emitServerCancellation('sample');
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({
+      method: 'notifications/cancelled',
+      params: {requestId: externalId},
+    });
+
+    active = releases.second;
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/tools/list_changed'});
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({method: 'notifications/resources/list_changed'});
+    expect(await clientOutput.nextLine()).toContain('4.2.2-b');
+
+    clientInput.end();
+    await running;
+  });
+
+  it('cancels a host-side server request when its runtime exits', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const release = {releaseRoot: '/threadnote/versions/4.2.2', version: '4.2.2'};
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => release,
+      spawn: () => {
+        const child = new FakeMcpChild(release.version);
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    spawned[0]!.emitServerRequest(7);
+    const externalId = (JSON.parse(await clientOutput.nextLine()) as {id: string}).id;
+    spawned[0]!.exitUnexpectedly();
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({
+      method: 'notifications/cancelled',
+      params: {requestId: externalId},
+    });
+
+    clientInput.end();
+    await running;
+  });
+
+  it('cancels outstanding server requests when a child write fails', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const release = {releaseRoot: '/threadnote/versions/4.2.2', version: '4.2.2'};
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => release,
+      spawn: () => {
+        const child = new FakeMcpChild(release.version, {exitBeforeFirstToolWrite: true});
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    spawned[0]!.emitServerRequest('sample');
+    const externalId = (JSON.parse(await clientOutput.nextLine()) as {id: string}).id;
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({
+      method: 'notifications/cancelled',
+      params: {requestId: externalId},
+    });
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({error: {code: -32_603}, id: 2});
 
     clientInput.end();
     await running;
@@ -115,7 +452,12 @@ class FakeMcpChild implements McpBrokerChild {
 
   constructor(
     readonly version: string,
-    readonly options: {readonly respondToTools?: boolean} = {},
+    readonly options: {
+      readonly exitBeforeFirstToolWrite?: boolean;
+      readonly ignoreInitialize?: boolean;
+      readonly rejectInitialize?: boolean;
+      readonly respondToTools?: boolean;
+    } = {},
   ) {
     let resolveExit: (code: number) => void = () => undefined;
     this.exited = new Promise<number>(resolve => {
@@ -146,18 +488,37 @@ class FakeMcpChild implements McpBrokerChild {
     }
   }
 
+  emitServerCancellation(requestId: string | number): void {
+    this.#output.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/cancelled', params: {requestId}}));
+  }
+
+  emitServerRequest(id: string | number): void {
+    this.#output.pushLine(JSON.stringify({id, jsonrpc: '2.0', method: 'sampling/createMessage', params: {}}));
+  }
+
   #handle(line: string): void {
+    if (this.#ended) throw new Error('Child input is closed.');
     this.received.push(line);
     for (const resolve of this.#receivedWaiters.splice(0)) resolve();
     const envelope = JSON.parse(line) as {readonly id?: string | number; readonly method?: string};
     if (envelope.method === 'initialize') {
+      if (this.options.ignoreInitialize) return;
       this.#output.pushLine(
-        JSON.stringify({
-          id: envelope.id,
-          jsonrpc: '2.0',
-          result: {protocolVersion: '2025-11-25', serverInfo: {name: 'threadnote', version: this.version}},
-        }),
+        this.options.rejectInitialize
+          ? JSON.stringify({
+              error: {code: -32_602, message: 'initialization rejected'},
+              id: envelope.id,
+              jsonrpc: '2.0',
+            })
+          : JSON.stringify({
+              id: envelope.id,
+              jsonrpc: '2.0',
+              result: {protocolVersion: '2025-11-25', serverInfo: {name: 'threadnote', version: this.version}},
+            }),
       );
+    } else if (envelope.method === 'tools/call' && this.options.exitBeforeFirstToolWrite) {
+      this.#end();
+      throw new Error('Child exited before accepting the request.');
     } else if (envelope.method === 'tools/call' && this.options.respondToTools !== false) {
       this.#output.pushLine(JSON.stringify({id: envelope.id, jsonrpc: '2.0', result: {version: this.version}}));
     }

--- a/test/unit/mcp-broker.test.ts
+++ b/test/unit/mcp-broker.test.ts
@@ -1,0 +1,225 @@
+import {describe, expect, it} from 'vitest';
+import {
+  runMcpBroker,
+  type McpBrokerChild,
+  type McpBrokerDependencies,
+} from '../../src/mcp_broker.js';
+import type {StandaloneActiveRelease} from '../../src/standalone_process_lease.js';
+
+describe('MCP session broker', () => {
+  it('promotes the runtime at a request boundary without closing or reinitializing the client transport', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const releases = {
+      first: {releaseRoot: '/threadnote/versions/4.2.2-a', version: '4.2.2-a'},
+      second: {releaseRoot: '/threadnote/versions/4.2.2-b', version: '4.2.2-b'},
+    } satisfies Record<string, StandaloneActiveRelease>;
+    let active = releases.first;
+    const spawned: FakeMcpChild[] = [];
+    const dependencies: McpBrokerDependencies = {
+      input: clientInput,
+      readActiveRelease: async () => active,
+      spawn: release => {
+        const child = new FakeMcpChild(release.version);
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    };
+    const running = runMcpBroker(dependencies);
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(await clientOutput.nextLine()).toContain('4.2.2-a');
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    clientInput.pushLine(
+      JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}),
+    );
+    expect(await clientOutput.nextLine()).toContain('4.2.2-a');
+
+    active = releases.second;
+    clientInput.pushLine(
+      JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}),
+    );
+    expect(await clientOutput.nextLine()).toContain('4.2.2-b');
+    expect(spawned).toHaveLength(2);
+    expect(spawned[1]?.received.map(line => JSON.parse(line).method)).toEqual([
+      'initialize',
+      'notifications/initialized',
+      'tools/call',
+    ]);
+    expect(clientOutput.availableLines()).toBe(0);
+
+    clientInput.end();
+    await running;
+  });
+
+  it('does not replay a pending tool request when its child exits with an unknown outcome', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const release = {releaseRoot: '/threadnote/versions/4.2.2', version: '4.2.2'};
+    const spawned: FakeMcpChild[] = [];
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => release,
+      spawn: () => {
+        const child = new FakeMcpChild(release.version, {respondToTools: false});
+        spawned.push(child);
+        return child;
+      },
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+    clientInput.pushLine(
+      JSON.stringify({id: 'mutation-1', jsonrpc: '2.0', method: 'tools/call', params: {name: 'remember_context'}}),
+    );
+    await spawned[0]!.receivedCount(3);
+    spawned[0]!.exitUnexpectedly();
+
+    const failure = JSON.parse(await clientOutput.nextLine()) as {
+      readonly error: {readonly message: string};
+      readonly id: string;
+    };
+    expect(failure.id).toBe('mutation-1');
+    expect(failure.error.message).toContain('outcome is unknown');
+    expect(spawned).toHaveLength(1);
+
+    clientInput.pushLine(
+      JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}),
+    );
+    const replacement = await waitForSpawnedChild(spawned, 1);
+    await replacement.receivedCount(3);
+    expect(replacement.received.map(line => JSON.parse(line).method)).toEqual([
+      'initialize',
+      'notifications/initialized',
+      'tools/call',
+    ]);
+
+    clientInput.end();
+    await running;
+  });
+});
+
+class FakeMcpChild implements McpBrokerChild {
+  readonly #output = new AsyncByteQueue();
+  readonly #resolveExit: (code: number) => void;
+  readonly exited: Promise<number>;
+  readonly input;
+  readonly output = this.#output;
+  readonly processId = 1;
+  readonly received: string[] = [];
+  readonly #receivedWaiters: Array<() => void> = [];
+  #ended = false;
+
+  constructor(
+    readonly version: string,
+    readonly options: {readonly respondToTools?: boolean} = {},
+  ) {
+    let resolveExit: (code: number) => void = () => undefined;
+    this.exited = new Promise<number>(resolve => {
+      resolveExit = resolve;
+    });
+    this.#resolveExit = resolveExit;
+    this.input = {
+      end: () => this.#end(),
+      flush: async () => undefined,
+      write: (value: string) => {
+        for (const line of value.trimEnd().split('\n')) this.#handle(line);
+        return value.length;
+      },
+    };
+  }
+
+  kill(): void {
+    this.#end();
+  }
+
+  exitUnexpectedly(): void {
+    this.#end();
+  }
+
+  async receivedCount(count: number): Promise<void> {
+    while (this.received.length < count) {
+      await new Promise<void>(resolve => this.#receivedWaiters.push(resolve));
+    }
+  }
+
+  #handle(line: string): void {
+    this.received.push(line);
+    for (const resolve of this.#receivedWaiters.splice(0)) resolve();
+    const envelope = JSON.parse(line) as {readonly id?: string | number; readonly method?: string};
+    if (envelope.method === 'initialize') {
+      this.#output.pushLine(
+        JSON.stringify({
+          id: envelope.id,
+          jsonrpc: '2.0',
+          result: {protocolVersion: '2025-11-25', serverInfo: {name: 'threadnote', version: this.version}},
+        }),
+      );
+    } else if (envelope.method === 'tools/call' && this.options.respondToTools !== false) {
+      this.#output.pushLine(JSON.stringify({id: envelope.id, jsonrpc: '2.0', result: {version: this.version}}));
+    }
+  }
+
+  #end(): void {
+    if (this.#ended) return;
+    this.#ended = true;
+    this.#output.end();
+    this.#resolveExit(0);
+  }
+}
+
+async function waitForSpawnedChild(children: readonly FakeMcpChild[], index: number): Promise<FakeMcpChild> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const child = children[index];
+    if (child !== undefined) return child;
+    await new Promise(resolve => setTimeout(resolve, 1));
+  }
+  throw new Error(`MCP broker did not spawn child ${index}.`);
+}
+
+class AsyncByteQueue implements AsyncIterable<Uint8Array> {
+  readonly #queued: Array<IteratorResult<Uint8Array>> = [];
+  readonly #waiters: Array<(value: IteratorResult<Uint8Array>) => void> = [];
+  #ended = false;
+
+  [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+    return {next: () => this.#next()};
+  }
+
+  availableLines(): number {
+    return this.#queued.filter(entry => !entry.done).length;
+  }
+
+  end(): void {
+    if (this.#ended) return;
+    this.#ended = true;
+    this.#deliver({done: true, value: undefined});
+  }
+
+  async nextLine(): Promise<string> {
+    const next = await this.#next();
+    if (next.done) throw new Error('Queue ended before a line was available.');
+    return new TextDecoder().decode(next.value).trimEnd();
+  }
+
+  pushLine(line: string): void {
+    if (this.#ended) throw new Error('Cannot write to an ended queue.');
+    this.#deliver({done: false, value: new TextEncoder().encode(`${line}\n`)});
+  }
+
+  #deliver(value: IteratorResult<Uint8Array>): void {
+    const waiter = this.#waiters.shift();
+    if (waiter) waiter(value);
+    else this.#queued.push(value);
+  }
+
+  #next(): Promise<IteratorResult<Uint8Array>> {
+    const queued = this.#queued.shift();
+    if (queued) return Promise.resolve(queued);
+    if (this.#ended) return Promise.resolve({done: true, value: undefined});
+    return new Promise(resolve => this.#waiters.push(resolve));
+  }
+}

--- a/test/unit/mcp-json-idempotence.property.test.ts
+++ b/test/unit/mcp-json-idempotence.property.test.ts
@@ -1,0 +1,72 @@
+import {it} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {expect} from 'vitest';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {runMcpInstall} from '../../src/mcp.js';
+import type {RuntimeConfig} from '../../src/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const runtime: RuntimeConfig = {
+  account: 'local',
+  agentContextHome: '/tmp/threadnote-test',
+  agentId: 'threadnote',
+  manifestPath: '/tmp/threadnote-test/seed-manifest.yaml',
+  user: 'test-user',
+};
+
+it.effect.prop(
+  'preserves semantically current JSON host configs across formatting, key order, and unrelated fields',
+  {
+    extraEnvironmentValue: FC.string({maxLength: 24}),
+    extraFieldValue: FC.oneof(FC.boolean(), FC.integer(), FC.string({maxLength: 24})),
+    indentation: FC.constantFrom(0, 1, 2, 4),
+    reverseEntryOrder: FC.boolean(),
+    reverseRootOrder: FC.boolean(),
+  },
+  ({extraEnvironmentValue, extraFieldValue, indentation, reverseEntryOrder, reverseRootOrder}) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-json-mcp-property-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const broker = path.join(bin, 'threadnote-mcp-server');
+        const configPath = path.join(user, '.cursor', 'mcp.json');
+        const environment = {
+          EXTRA_USER_VALUE: extraEnvironmentValue,
+          THREADNOTE_ACCOUNT: 'local',
+          THREADNOTE_AGENT_ID: 'threadnote',
+          THREADNOTE_HOME: '/tmp/threadnote-test',
+          THREADNOTE_MCP_TOOLSET: 'core',
+          THREADNOTE_USER: 'test-user',
+        };
+        const server = reverseEntryOrder
+          ? {userMetadata: extraFieldValue, env: environment, args: [], command: broker}
+          : {command: broker, args: [], env: environment, userMetadata: extraFieldValue};
+        const servers = reverseEntryOrder
+          ? {unrelated: {command: 'user-server'}, threadnote: server}
+          : {threadnote: server, unrelated: {command: 'user-server'}};
+        const config = reverseRootOrder
+          ? {userSetting: extraFieldValue, mcpServers: servers}
+          : {mcpServers: servers, userSetting: extraFieldValue};
+        const original = JSON.stringify(config, null, indentation);
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(path.dirname(configPath), {recursive: true});
+        yield* fs.writeFileString(configPath, original);
+
+        yield* runMcpInstall(runtime, 'cursor', {apply: true}).pipe(Effect.provideService(SystemInfo, testSystem));
+
+        expect(yield* fs.readFileString(configPath)).toBe(original);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  {fastCheck: {numRuns: 40}},
+);

--- a/test/unit/mcp.doctor.test.ts
+++ b/test/unit/mcp.doctor.test.ts
@@ -7,7 +7,7 @@ import {SystemInfo} from '../../src/effect/system.js';
 import {mcpConfigurationChecks} from '../../src/mcp.js';
 
 describe('MCP doctor checks', () => {
-  it.effect('reports a configured Codex MCP server', () =>
+  it.effect('reports a configured Codex MCP broker', () =>
     Effect.scoped(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -19,7 +19,7 @@ describe('MCP doctor checks', () => {
         yield* fs.makeDirectory(bin, {recursive: true});
         yield* fs.writeFileString(
           codex,
-          '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "codex-cli 1"; exit 0; fi\nif [ "$1 $2 $3" = "mcp get threadnote" ]; then echo "threadnote configured"; exit 0; fi\nexit 1\n',
+          '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "codex-cli 1"; exit 0; fi\nif [ "$1 $2 $3" = "mcp get threadnote" ]; then echo "command: /home/test/.local/bin/threadnote-mcp-server"; exit 0; fi\nexit 1\n',
         );
         yield* fs.chmod(codex, 0o755);
         const testSystem = SystemInfo.of({
@@ -30,8 +30,83 @@ describe('MCP doctor checks', () => {
 
         const checks = yield* mcpConfigurationChecks().pipe(Effect.provideService(SystemInfo, testSystem));
         expect(checks).toContainEqual({
-          detail: 'threadnote server configured',
+          detail: 'threadnote broker configured',
           name: 'codex MCP',
+          status: 'ok',
+        });
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  it.effect('warns when Codex and JSON hosts still invoke the direct MCP server', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mcp-doctor-legacy-'});
+        const bin = path.join(root, 'bin');
+        const codex = path.join(bin, 'codex');
+        const user = path.join(root, 'user');
+        yield* fs.makeDirectory(path.join(user, '.cursor'), {recursive: true});
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.writeFileString(
+          codex,
+          '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "codex-cli 1"; exit 0; fi\nif [ "$1 $2 $3" = "mcp get threadnote" ]; then echo "command: /home/test/.local/bin/threadnote\nargs: mcp-server"; exit 0; fi\nexit 1\n',
+        );
+        yield* fs.chmod(codex, 0o755);
+        yield* fs.writeFileString(
+          path.join(user, '.cursor', 'mcp.json'),
+          JSON.stringify({
+            mcpServers: {threadnote: {args: ['mcp-server'], command: '/home/test/.local/bin/threadnote'}},
+          }),
+        );
+        const testSystem = SystemInfo.of({
+          ...system,
+          environment: () => ({...system.environment(), PATH: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+
+        const checks = yield* mcpConfigurationChecks().pipe(Effect.provideService(SystemInfo, testSystem));
+        for (const name of ['codex MCP', 'cursor MCP']) {
+          expect(checks).toContainEqual({
+            detail: expect.stringContaining('legacy direct server command'),
+            name,
+            status: 'warn',
+          });
+        }
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  it.effect('recognizes a Windows JSON host that launches the broker through ComSpec', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mcp-doctor-windows-broker-'});
+        const user = path.join(root, 'user');
+        const cursorConfig = path.join(user, '.cursor', 'mcp.json');
+        yield* fs.makeDirectory(path.dirname(cursorConfig), {recursive: true});
+        yield* fs.writeFileString(
+          cursorConfig,
+          JSON.stringify({
+            mcpServers: {
+              threadnote: {
+                args: ['/d', '/c', 'C:\\Threadnote\\bin\\threadnote-mcp-server.cmd'],
+                command: 'C:\\Windows\\System32\\cmd.exe',
+              },
+            },
+          }),
+        );
+        const testSystem = SystemInfo.of({...system, homeDirectory: user, platform: 'win32'});
+
+        const checks = yield* mcpConfigurationChecks().pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(checks).toContainEqual({
+          detail: `threadnote broker configured in ${cursorConfig}`,
+          name: 'cursor MCP',
           status: 'ok',
         });
       }),

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -75,28 +75,34 @@ describe('MCP toolsets', () => {
   effectIt.effect('uses the stable MCP broker launcher instead of a direct server command', () =>
     Effect.gen(function* () {
       const baseSystem = yield* SystemInfo;
+      const path = yield* Path.Path;
+      const binDirectory = '/opt/threadnote/bin';
+      const brokerLauncher = path.join(binDirectory, 'threadnote-mcp-server');
       const testSystem = SystemInfo.of({
         ...baseSystem,
         environment: () => ({
           ...baseSystem.environment(),
-          THREADNOTE_BIN_DIR: '/opt/threadnote/bin',
+          THREADNOTE_BIN_DIR: binDirectory,
         }),
         platform: 'linux',
       });
       const command = yield* mcpAdapterCommand().pipe(Effect.provideService(SystemInfo, testSystem));
 
-      expect(command).toEqual(['/opt/threadnote/bin/threadnote-mcp-server']);
+      expect(command).toEqual([brokerLauncher]);
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 
   effectIt.effect('renders the broker launcher for every supported MCP host', () =>
     Effect.gen(function* () {
       const baseSystem = yield* SystemInfo;
+      const path = yield* Path.Path;
+      const binDirectory = '/opt/threadnote/bin';
+      const brokerLauncher = path.join(binDirectory, 'threadnote-mcp-server');
       const testSystem = SystemInfo.of({
         ...baseSystem,
         environment: () => ({
           ...baseSystem.environment(),
-          THREADNOTE_BIN_DIR: '/opt/threadnote/bin',
+          THREADNOTE_BIN_DIR: binDirectory,
         }),
         platform: 'linux',
       });
@@ -105,7 +111,7 @@ describe('MCP toolsets', () => {
         const result = yield* captureConsole(runMcpInstall(runtime(), agent, {})).pipe(
           Effect.provideService(SystemInfo, testSystem),
         );
-        expect(result.output, agent).toContain('/opt/threadnote/bin/threadnote-mcp-server');
+        expect(result.output, agent).toContain(brokerLauncher);
         expect(result.output, agent).not.toMatch(/\bthreadnote\s+mcp-server\b/);
       }
     }).pipe(provideTestLayer(ApplicationLayer)),

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -4,7 +4,7 @@ import {runEffect} from '../helpers/effect-runtime.js';
 import {chmod, mkdtemp, readFile, rm, writeFile} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {delimiter, join} from '../helpers/node-path.js';
-import {Effect} from 'effect';
+import {Effect, FileSystem, Path} from 'effect';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 import {captureConsole} from '../../src/effect/console.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
@@ -31,16 +31,23 @@ function dryRunOutput(toolset?: 'core' | 'full') {
 }
 
 const originalPath = process.env.PATH;
+const originalThreadnoteBinDirectory = process.env.THREADNOTE_BIN_DIR;
 const temporaryDirectories: string[] = [];
 const posixIt = process.platform === 'win32' ? it.skip : it;
 
-async function codexLauncher(script: string): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), 'threadnote-codex-'));
+async function agentLauncher(agent: 'claude' | 'codex', script: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), `threadnote-${agent}-`));
   temporaryDirectories.push(directory);
-  const launcher = join(directory, 'codex');
+  const launcher = join(directory, agent);
   await writeFile(launcher, `#!/bin/sh\n${script}\n`);
   await chmod(launcher, 0o755);
   return launcher;
+}
+
+const codexLauncher = (script: string) => agentLauncher('codex', script);
+
+function shellLiteral(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 afterEach(async () => {
@@ -49,6 +56,11 @@ afterEach(async () => {
     delete process.env.PATH;
   } else {
     process.env.PATH = originalPath;
+  }
+  if (originalThreadnoteBinDirectory === undefined) {
+    delete process.env.THREADNOTE_BIN_DIR;
+  } else {
+    process.env.THREADNOTE_BIN_DIR = originalThreadnoteBinDirectory;
   }
   await Promise.all(temporaryDirectories.splice(0).map(path => rm(path, {force: true, recursive: true})));
 });
@@ -60,12 +72,43 @@ describe('MCP toolsets', () => {
     }),
   );
 
-  effectIt.effect('uses the stable standalone launcher instead of POSIX env', () =>
+  effectIt.effect('uses the stable MCP broker launcher instead of a direct server command', () =>
     Effect.gen(function* () {
-      const output = yield* dryRunOutput();
-      expect(output).toContain('mcp-server');
-      expect(output).not.toContain('/usr/bin/env');
-    }),
+      const baseSystem = yield* SystemInfo;
+      const testSystem = SystemInfo.of({
+        ...baseSystem,
+        environment: () => ({
+          ...baseSystem.environment(),
+          THREADNOTE_BIN_DIR: '/opt/threadnote/bin',
+        }),
+        platform: 'linux',
+      });
+      const command = yield* mcpAdapterCommand().pipe(Effect.provideService(SystemInfo, testSystem));
+
+      expect(command).toEqual(['/opt/threadnote/bin/threadnote-mcp-server']);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('renders the broker launcher for every supported MCP host', () =>
+    Effect.gen(function* () {
+      const baseSystem = yield* SystemInfo;
+      const testSystem = SystemInfo.of({
+        ...baseSystem,
+        environment: () => ({
+          ...baseSystem.environment(),
+          THREADNOTE_BIN_DIR: '/opt/threadnote/bin',
+        }),
+        platform: 'linux',
+      });
+
+      for (const agent of ['codex', 'claude', 'cursor', 'copilot'] as const) {
+        const result = yield* captureConsole(runMcpInstall(runtime(), agent, {})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(result.output, agent).toContain('/opt/threadnote/bin/threadnote-mcp-server');
+        expect(result.output, agent).not.toMatch(/\bthreadnote\s+mcp-server\b/);
+      }
+    }).pipe(provideTestLayer(ApplicationLayer)),
   );
 
   effectIt.effect('installs the full stdio toolset when requested', () =>
@@ -128,7 +171,241 @@ describe('MCP toolsets', () => {
   );
 });
 
+describe('JSON MCP host configuration', () => {
+  effectIt.effect('preserves differently formatted current Cursor and Copilot entries byte-for-byte', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-json-mcp-current-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const broker = path.join(bin, 'threadnote-mcp-server');
+        const cursorPath = path.join(user, '.cursor', 'mcp.json');
+        const copilotPath = path.join(root, 'copilot-mcp.json');
+        const managedEnvironment = {
+          THREADNOTE_USER: 'test-user',
+          THREADNOTE_MCP_TOOLSET: 'core',
+          THREADNOTE_HOME: '/tmp/threadnote-test',
+          THREADNOTE_AGENT_ID: 'threadnote',
+          THREADNOTE_ACCOUNT: 'local',
+          USER_EXTENSION: 'preserved',
+        };
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({
+            ...baseSystem.environment(),
+            THREADNOTE_BIN_DIR: bin,
+            THREADNOTE_COPILOT_MCP_CONFIG: copilotPath,
+          }),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+
+        for (const agent of ['cursor', 'copilot'] as const) {
+          const configPath = agent === 'cursor' ? cursorPath : copilotPath;
+          const containerKey = agent === 'cursor' ? 'mcpServers' : 'servers';
+          const original = JSON.stringify(
+            {
+              userSetting: true,
+              [containerKey]: {
+                unrelated: {command: 'unrelated-server'},
+                threadnote: {
+                  userMetadata: {preserve: true},
+                  env: managedEnvironment,
+                  command: broker,
+                  args: [],
+                  ...(agent === 'copilot' ? {type: 'stdio'} : {}),
+                },
+              },
+            },
+            null,
+            agent === 'cursor' ? 4 : 0,
+          );
+          yield* fs.makeDirectory(path.dirname(configPath), {recursive: true});
+          yield* fs.writeFileString(configPath, original);
+
+          const result = yield* captureConsole(runMcpInstall(runtime(), agent, {apply: true})).pipe(
+            Effect.provideService(SystemInfo, testSystem),
+          );
+
+          expect(result.output, agent).toContain(`Already configured: ${configPath}`);
+          expect(yield* fs.readFileString(configPath), agent).toBe(original);
+        }
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('rewrites drifted Cursor and Copilot entries while preserving unrelated configuration', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-json-mcp-drift-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const broker = path.join(bin, 'threadnote-mcp-server');
+        const cursorPath = path.join(user, '.cursor', 'mcp.json');
+        const copilotPath = path.join(root, 'copilot-mcp.json');
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({
+            ...baseSystem.environment(),
+            THREADNOTE_BIN_DIR: bin,
+            THREADNOTE_COPILOT_MCP_CONFIG: copilotPath,
+          }),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+
+        for (const agent of ['cursor', 'copilot'] as const) {
+          const configPath = agent === 'cursor' ? cursorPath : copilotPath;
+          const containerKey = agent === 'cursor' ? 'mcpServers' : 'servers';
+          yield* fs.makeDirectory(path.dirname(configPath), {recursive: true});
+          yield* fs.writeFileString(
+            configPath,
+            JSON.stringify({
+              userSetting: true,
+              [containerKey]: {
+                unrelated: {command: 'unrelated-server'},
+                threadnote: {
+                  args: ['mcp-server'],
+                  command: path.join(bin, 'threadnote'),
+                  env: {
+                    THREADNOTE_ACCOUNT: 'local',
+                    THREADNOTE_AGENT_ID: 'threadnote',
+                    THREADNOTE_HOME: '/tmp/threadnote-test',
+                    THREADNOTE_MCP_TOOLSET: 'full',
+                    THREADNOTE_USER: 'test-user',
+                  },
+                  ...(agent === 'copilot' ? {type: 'stdio'} : {}),
+                },
+              },
+            }),
+          );
+
+          const result = yield* captureConsole(runMcpInstall(runtime(), agent, {apply: true})).pipe(
+            Effect.provideService(SystemInfo, testSystem),
+          );
+          const updated: unknown = JSON.parse(yield* fs.readFileString(configPath));
+
+          expect(result.output, agent).toContain('Updated');
+          expect(updated, agent).toMatchObject({
+            userSetting: true,
+            [containerKey]: {
+              unrelated: {command: 'unrelated-server'},
+              threadnote: {
+                args: [],
+                command: broker,
+                env: {THREADNOTE_MCP_TOOLSET: 'core'},
+                ...(agent === 'copilot' ? {type: 'stdio'} : {}),
+              },
+            },
+          });
+        }
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+});
+
 describe('MCP agent executable resolution', () => {
+  posixIt('does not remove or add semantically current Codex and Claude broker configurations', async () => {
+    const bin = await mkdtemp(join(tmpdir(), 'threadnote-managed-bin-'));
+    temporaryDirectories.push(bin);
+    process.env.THREADNOTE_BIN_DIR = bin;
+    const broker = join(bin, 'threadnote-mcp-server');
+    const managedEnvironment = {
+      THREADNOTE_ACCOUNT: 'local',
+      THREADNOTE_AGENT_ID: 'threadnote',
+      THREADNOTE_HOME: '/tmp/threadnote-test',
+      THREADNOTE_MCP_TOOLSET: 'core',
+      THREADNOTE_USER: 'test-user',
+    };
+
+    for (const agent of ['codex', 'claude'] as const) {
+      const callsPath = join(tmpdir(), `threadnote-${agent}-current-calls-${process.pid}-${Date.now()}`);
+      const output =
+        agent === 'codex'
+          ? JSON.stringify({
+              enabled: true,
+              transport: {args: [], command: broker, env: managedEnvironment, type: 'stdio'},
+            })
+          : [
+              'threadnote:',
+              '  Scope: User config (available in all your projects)',
+              '  Status: ✘ Failed to connect',
+              '  Type: stdio',
+              `  Command: ${broker}`,
+              '  Args:',
+              '  Environment:',
+              ...Object.entries(managedEnvironment).map(([key, value]) => `    ${key}=${value}`),
+            ].join('\n');
+      const launcher = await agentLauncher(
+        agent,
+        `if [ "$1" = "--version" ]; then printf '%s\\n' '${agent} 1'; exit 0; fi\nprintf '%s\\n' "$*" >> ${shellLiteral(callsPath)}\nprintf '%s\\n' ${shellLiteral(output)}`,
+      );
+      process.env.PATH = [join(launcher, '..'), '/usr/bin', '/bin'].join(delimiter);
+
+      await runEffect(runMcpInstall(runtime(), agent, {apply: true}));
+
+      const calls = await readFile(callsPath, 'utf8');
+      expect(calls, agent).toContain('mcp get threadnote');
+      expect(calls, agent).not.toContain('mcp remove');
+      expect(calls, agent).not.toContain('mcp add');
+      await rm(callsPath, {force: true});
+    }
+  });
+
+  posixIt('migrates legacy direct Codex and Claude server configurations to the broker launcher', async () => {
+    const bin = await mkdtemp(join(tmpdir(), 'threadnote-managed-bin-'));
+    temporaryDirectories.push(bin);
+    process.env.THREADNOTE_BIN_DIR = bin;
+    const broker = join(bin, 'threadnote-mcp-server');
+    const legacyCommand = join(bin, 'threadnote');
+    const managedEnvironment = {
+      THREADNOTE_ACCOUNT: 'local',
+      THREADNOTE_AGENT_ID: 'threadnote',
+      THREADNOTE_HOME: '/tmp/threadnote-test',
+      THREADNOTE_MCP_TOOLSET: 'core',
+      THREADNOTE_USER: 'test-user',
+    };
+
+    for (const agent of ['codex', 'claude'] as const) {
+      const callsPath = join(tmpdir(), `threadnote-${agent}-legacy-calls-${process.pid}-${Date.now()}`);
+      const output =
+        agent === 'codex'
+          ? JSON.stringify({
+              enabled: true,
+              transport: {args: ['mcp-server'], command: legacyCommand, env: managedEnvironment, type: 'stdio'},
+            })
+          : [
+              'threadnote:',
+              '  Scope: User config (available in all your projects)',
+              '  Status: ✘ Failed to connect',
+              '  Type: stdio',
+              `  Command: ${legacyCommand}`,
+              '  Args: mcp-server',
+              '  Environment:',
+              ...Object.entries(managedEnvironment).map(([key, value]) => `    ${key}=${value}`),
+            ].join('\n');
+      const launcher = await agentLauncher(
+        agent,
+        `if [ "$1" = "--version" ]; then printf '%s\\n' '${agent} 1'; exit 0; fi\nprintf '%s\\n' "$*" >> ${shellLiteral(callsPath)}\ncase "$*" in\n  "mcp get threadnote"*) printf '%s\\n' ${shellLiteral(output)} ;;\nesac`,
+      );
+      process.env.PATH = [join(launcher, '..'), '/usr/bin', '/bin'].join(delimiter);
+
+      await runEffect(runMcpInstall(runtime(), agent, {apply: true}));
+
+      const calls = await readFile(callsPath, 'utf8');
+      expect(calls, agent).toContain('mcp remove threadnote');
+      expect(calls, agent).toContain('mcp add');
+      expect(calls, agent).toContain(broker);
+      await rm(callsPath, {force: true});
+    }
+  });
+
   posixIt('uses a healthy later PATH entry when the first Codex launcher is stale', async () => {
     const broken = await codexLauncher("printf '%s\\n' 'missing native binary' >&2\nexit 1");
     const callsPath = join(tmpdir(), `threadnote-codex-calls-${process.pid}-${Date.now()}`);

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -111,7 +111,9 @@ describe('MCP toolsets', () => {
         const result = yield* captureConsole(runMcpInstall(runtime(), agent, {})).pipe(
           Effect.provideService(SystemInfo, testSystem),
         );
-        expect(result.output, agent).toContain(brokerLauncher);
+        const renderedBrokerLauncher =
+          agent === 'cursor' || agent === 'copilot' ? JSON.stringify(brokerLauncher).slice(1, -1) : brokerLauncher;
+        expect(result.output, agent).toContain(renderedBrokerLauncher);
         expect(result.output, agent).not.toMatch(/\bthreadnote\s+mcp-server\b/);
       }
     }).pipe(provideTestLayer(ApplicationLayer)),

--- a/test/unit/standalone-process-lease.property.test.ts
+++ b/test/unit/standalone-process-lease.property.test.ts
@@ -1,0 +1,56 @@
+import {Option} from 'effect';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  preservedStandaloneProcessIds,
+  type StandaloneProcessLease,
+} from '../../src/standalone_process_lease.js';
+
+describe('standalone process retirement properties', () => {
+  it('preserves exactly the processes rooted beneath preserve-session leases', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.boolean(), {minLength: 1, maxLength: 40}),
+        fc.array(fc.nat(), {minLength: 1, maxLength: 40}),
+        (preserveFlags, parentSeeds) => {
+          const size = Math.min(preserveFlags.length, parentSeeds.length);
+          const leases: Pick<
+            StandaloneProcessLease,
+            'parentProcessId' | 'processId' | 'retirementPolicy'
+          >[] = [];
+          for (let index = 0; index < size; index += 1) {
+            const processId = index + 1;
+            const parentIndex = index === 0 ? undefined : parentSeeds[index]! % (index + 1);
+            leases.push({
+              parentProcessId:
+                parentIndex === undefined || parentIndex === index
+                  ? Option.none()
+                  : Option.some(parentIndex + 1),
+              processId,
+              retirementPolicy: preserveFlags[index] ? 'preserve-session' : 'terminate',
+            });
+          }
+
+          const expected = new Set<number>();
+          for (const lease of leases) {
+            let cursor: (typeof leases)[number] | undefined = lease;
+            while (cursor !== undefined) {
+              if (cursor.retirementPolicy === 'preserve-session') {
+                expected.add(lease.processId);
+                break;
+              }
+              cursor = Option.isSome(cursor.parentProcessId)
+                ? leases[cursor.parentProcessId.value - 1]
+                : undefined;
+            }
+          }
+
+          expect([...preservedStandaloneProcessIds(leases)].sort((left, right) => left - right)).toEqual(
+            [...expected].sort((left, right) => left - right),
+          );
+        },
+      ),
+      {numRuns: 200},
+    );
+  });
+});

--- a/test/unit/standalone-process-lease.property.test.ts
+++ b/test/unit/standalone-process-lease.property.test.ts
@@ -1,10 +1,7 @@
 import {Option} from 'effect';
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
-import {
-  preservedStandaloneProcessIds,
-  type StandaloneProcessLease,
-} from '../../src/standalone_process_lease.js';
+import {preservedStandaloneProcessIds, type StandaloneProcessLease} from '../../src/standalone_process_lease.js';
 
 describe('standalone process retirement properties', () => {
   it('preserves exactly the processes rooted beneath preserve-session leases', () => {
@@ -14,18 +11,13 @@ describe('standalone process retirement properties', () => {
         fc.array(fc.nat(), {minLength: 1, maxLength: 40}),
         (preserveFlags, parentSeeds) => {
           const size = Math.min(preserveFlags.length, parentSeeds.length);
-          const leases: Pick<
-            StandaloneProcessLease,
-            'parentProcessId' | 'processId' | 'retirementPolicy'
-          >[] = [];
+          const leases: Pick<StandaloneProcessLease, 'parentProcessId' | 'processId' | 'retirementPolicy'>[] = [];
           for (let index = 0; index < size; index += 1) {
             const processId = index + 1;
             const parentIndex = index === 0 ? undefined : parentSeeds[index]! % (index + 1);
             leases.push({
               parentProcessId:
-                parentIndex === undefined || parentIndex === index
-                  ? Option.none()
-                  : Option.some(parentIndex + 1),
+                parentIndex === undefined || parentIndex === index ? Option.none() : Option.some(parentIndex + 1),
               processId,
               retirementPolicy: preserveFlags[index] ? 'preserve-session' : 'terminate',
             });
@@ -39,9 +31,7 @@ describe('standalone process retirement properties', () => {
                 expected.add(lease.processId);
                 break;
               }
-              cursor = Option.isSome(cursor.parentProcessId)
-                ? leases[cursor.parentProcessId.value - 1]
-                : undefined;
+              cursor = Option.isSome(cursor.parentProcessId) ? leases[cursor.parentProcessId.value - 1] : undefined;
             }
           }
 

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -927,7 +927,7 @@ describe('standalone updater', () => {
       expect(JSON.parse(result.activeRelease)).toMatchObject({version: RELEASE_VERSION});
       expect(JSON.parse(result.releaseMetadata)).toMatchObject({version: RELEASE_VERSION});
       expect(result.launcher).toContain(`versions/${RELEASE_VERSION}/threadnote`.replaceAll('/', pathSeparator()));
-      expect(result.mcpLauncher).toContain('mcp-server');
+      expect(result.mcpLauncher).toContain('mcp-broker');
       if (result.platform === 'darwin') {
         expect(result.signatureCommands.join('\n')).toContain('codesign --verify --strict --verbose=2');
         expect(result.signatureCommands.join('\n')).toContain('libfixture.so');

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -526,6 +526,7 @@ describe('standalone updater', () => {
       );
 
       expect(captured.output).toContain('Threadnote is up to date.');
+      expect(captured.output).toContain('run `threadnote repair`, then restart that host once');
       expect(downloadAttempted).toBe(false);
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
@@ -687,6 +688,8 @@ describe('standalone updater', () => {
 
       expect(captured.output).toContain(`Would install standalone Threadnote to:`);
       expect(captured.output).toContain(stableVersion);
+      expect(captured.output).toContain('MCP host configurations were not refreshed');
+      expect(captured.output).toContain('must run `threadnote repair` and restart once');
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -1580,12 +1580,13 @@ describe('Threadnote 4 website content', () => {
     expect(content).toContain('kind=handoff');
     expect(content).toContain('commits and pushes');
     expect(content).toContain('capability-enforced cloud profile');
+    expect(content).toContain('stable `threadnote-mcp-server` launcher brokers');
 
     if (!mcpConfiguration || mcpConfiguration.type !== 'code') {
       throw new TestError('Missing Cursor Cloud MCP configuration.');
     }
     expect(JSON.parse(mcpConfiguration.code)).toMatchObject({
-      args: ['-lc', 'exec "$HOME/.local/bin/threadnote" mcp-server'],
+      args: ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'],
       command: '/bin/sh',
       env: {
         THREADNOTE_ACCOUNT: 'local',

--- a/website/src/content/docsCursorCloud.ts
+++ b/website/src/content/docsCursorCloud.ts
@@ -111,7 +111,7 @@ threadnote version`,
           code: `{
   "type": "stdio",
   "command": "/bin/sh",
-  "args": ["-lc", "exec \\"$HOME/.local/bin/threadnote\\" mcp-server"],
+  "args": ["-lc", "exec \\"$HOME/.local/bin/threadnote-mcp-server\\""],
   "env": {
     "THREADNOTE_ACCOUNT": "local",
     "THREADNOTE_USER": "cursor-cloud",
@@ -120,6 +120,10 @@ threadnote version`,
     "THREADNOTE_MCP_TOOLSET": "cursor-cloud"
   }
 }`,
+        },
+        {
+          type: 'paragraph',
+          text: 'The stable `threadnote-mcp-server` launcher brokers the Dashboard-owned stdio session. After a standalone update activates a new runtime, the next MCP request uses that runtime without changing this configuration.',
         },
         {
           type: 'warning',


### PR DESCRIPTION
## Summary

- keep editor-owned MCP stdio stable with a managed broker and promote active runtimes at safe request boundaries
- migrate Codex, Claude, Cursor, Copilot, and Cursor Cloud configs to the broker; make ordinary repair/update configuration idempotent
- contain child exit, initialization, cancellation, and server-request races without replaying work of unknown outcome
- preserve broker process trees and active-release availability across exact-HEAD/update activation windows

## Validation

- `bun run test` (307 files, 3014 passed, 1 skipped)
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun scripts/smoke-self-contained.ts`
- POSIX installer/update E2E (legacy Cursor config -> broker, unrelated entry preserved)
- exact-HEAD A -> B global install with a live MCP client: same transport reported B on the next request
- global Codex/Cursor/Copilot migration plus repeated idempotence smoke

## Property coverage

- preserve-session ancestry closure
- semantic JSON MCP configuration idempotence across formatting, ordering, and unrelated fields
