### PR TITLE
fix(manager): separate graph status from explorer

### DIFF
--- a/manager/app.css
+++ b/manager/app.css
@@ -1085,13 +1085,44 @@ dd {
   display: flex;
   gap: 14px;
   justify-content: space-between;
-  list-style-position: inside;
+  list-style: none;
   padding: 9px 12px;
 }
 
-.graph-administration > summary > span {
+.graph-administration > summary::-webkit-details-marker {
+  display: none;
+}
+
+.graph-administration > summary::marker {
+  content: '';
+}
+
+.graph-administration-title {
   display: inline-grid;
   gap: 2px;
+}
+
+.graph-administration-summary-state {
+  align-items: center;
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.graph-administration-caret {
+  fill: none;
+  height: 16px;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.75;
+  transform: rotate(-90deg);
+  transition: transform 140ms ease;
+  width: 16px;
+}
+
+.graph-administration[open] .graph-administration-caret {
+  transform: rotate(0deg);
 }
 
 .graph-administration > summary small,

--- a/manager/app.css
+++ b/manager/app.css
@@ -971,7 +971,7 @@ dd {
 .graph-workspace {
   display: grid;
   gap: 14px;
-  grid-template-rows: auto auto auto auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto minmax(0, 1fr);
   height: 100%;
   min-height: 0;
   padding: 20px;
@@ -981,10 +981,92 @@ dd {
   grid-row: 1;
 }
 
+.graph-page-tabs {
+  background: rgba(8, 11, 16, 0.56);
+  border: 1px solid var(--line-soft);
+  border-radius: 10px;
+  display: grid;
+  gap: 3px;
+  grid-row: 2;
+  grid-template-columns: repeat(2, minmax(0, max-content));
+  justify-content: start;
+  padding: 3px;
+}
+
+.graph-page-tabs button {
+  align-items: center;
+  background: transparent;
+  border-color: transparent;
+  display: inline-flex;
+  font-size: 11px;
+  gap: 7px;
+  justify-content: center;
+  min-height: 34px;
+  padding: 6px 12px;
+}
+
+.graph-page-tabs button[aria-selected='true'] {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--accent);
+}
+
+.graph-page-tabs small {
+  align-items: center;
+  background: rgba(103, 232, 199, 0.12);
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 9px;
+  font-weight: 700;
+  justify-content: center;
+  min-height: 18px;
+  min-width: 18px;
+  padding: 1px 5px;
+}
+
+.graph-tab-panel {
+  grid-row: 3;
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.graph-tab-panel[hidden] {
+  display: none;
+}
+
+.graph-explorer-tab {
+  display: grid;
+  gap: 14px;
+  grid-template-rows: auto auto minmax(440px, 1fr) auto;
+  height: 100%;
+}
+
+.graph-explorer-tab .graph-toolbar {
+  grid-row: 1;
+}
+
+.graph-explorer-tab .graph-filterbar {
+  grid-row: 2;
+}
+
+.graph-explorer-tab .graph-body {
+  grid-row: 3;
+}
+
+.graph-explorer-tab .graph-notes {
+  grid-row: 4;
+}
+
+.graph-administration-tab {
+  padding-right: 4px;
+}
+
 .graph-notices {
   display: grid;
   gap: 8px;
-  grid-row: 2;
 }
 
 .graph-notices:empty {
@@ -1027,6 +1109,11 @@ dd {
   max-height: min(460px, 56vh);
   overflow: auto;
   padding: 10px 12px 12px;
+}
+
+.graph-administration-tab .graph-administration-body {
+  max-height: none;
+  overflow: visible;
 }
 
 .graph-administration-toolbar,
@@ -1360,18 +1447,6 @@ dd {
   grid-area: scope;
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   min-width: 0;
-}
-
-.graph-filterbar {
-  grid-row: 4;
-}
-
-.graph-body {
-  grid-row: 5;
-}
-
-.graph-notes {
-  grid-row: 6;
 }
 
 .graph-toolbar label,

--- a/src/manager_graph.tsx
+++ b/src/manager_graph.tsx
@@ -35,6 +35,7 @@ export {
   managerGraphDebouncedQueryCandidate,
   managerGraphQueryCandidate,
   mergeGraphRepositoryGroups,
+  orderGraphBuildStatuses,
   resolveGraphSelection,
   type GraphAdministrationAction,
   type GraphAdministrationJobSelection,

--- a/src/manager_graph_model.ts
+++ b/src/manager_graph_model.ts
@@ -404,6 +404,28 @@ export function graphBuildShouldDisplay(build: GraphBuildStatus): boolean {
   return build.state === 'failed' || graphBuildIsActive(build);
 }
 
+/** Keep status banners anchored to a worktree instead of moving as progress timestamps change. */
+export function orderGraphBuildStatuses(
+  builds: readonly GraphBuildStatus[],
+  repositories: readonly GraphRepositoryGroup[] = [],
+): readonly GraphBuildStatus[] {
+  const location = (build: GraphBuildStatus): string => {
+    const repository = repositories.find(candidate => candidate.repositoryId === build.identity.repositoryId);
+    const view = repository?.views.find(
+      candidate =>
+        candidate.checkoutId === build.identity.checkoutId && candidate.worktreeId === build.identity.worktreeId,
+    );
+    return view?.localAssociation.displayPath ?? build.managerContext?.worktreePath ?? build.identity.checkoutId;
+  };
+  return [...builds].sort(
+    (left, right) =>
+      compareCodeUnits(location(left), location(right)) ||
+      compareCodeUnits(left.identity.checkoutId, right.identity.checkoutId) ||
+      compareCodeUnits(left.identity.worktreeId, right.identity.worktreeId) ||
+      compareCodeUnits(left.buildId, right.buildId),
+  );
+}
+
 export const GRAPH_ADMINISTRATION_JOB_LIMIT = 4;
 
 export interface GraphAdministrationJobSelection {

--- a/src/manager_graph_panels.tsx
+++ b/src/manager_graph_panels.tsx
@@ -504,9 +504,9 @@ export function GraphAdministration(props: {
     props.onAction(targeted);
   };
   return (
-    <details className="graph-administration">
+    <details className="graph-administration" open>
       <summary>
-        <span>
+        <span className="graph-administration-title">
           <strong>Graph administration</strong>
           <small>
             {props.report
@@ -514,7 +514,12 @@ export function GraphAdministration(props: {
               : 'Load home-wide status, diagnostics, and maintenance controls'}
           </small>
         </span>
-        {props.busy ? <em>{props.busy}…</em> : null}
+        <span className="graph-administration-summary-state">
+          {props.busy ? <em>{props.busy}…</em> : null}
+          <svg aria-hidden="true" className="graph-administration-caret" viewBox="0 0 16 16">
+            <path d="m4 6 4 4 4-4" />
+          </svg>
+        </span>
       </summary>
       <div className="graph-administration-body">
         <div className="graph-administration-toolbar">

--- a/src/manager_graph_workspace.tsx
+++ b/src/manager_graph_workspace.tsx
@@ -28,6 +28,7 @@ import {
   MAX_QUERY_WORKING_SET,
   MAX_WORKING_SET,
   mergeGraphRepositoryGroups,
+  orderGraphBuildStatuses,
   relationLabel,
   resolveGraphSelection,
   type GraphAdministrationAction,
@@ -100,6 +101,7 @@ export function GraphWorkspace(props: {
   readonly onDiagnostics?: (options: {readonly analyze: boolean; readonly deep: boolean}) => void;
   readonly onRefresh: () => void;
 }): React.ReactElement {
+  const [activeTab, setActiveTab] = useState<'administration' | 'explore'>('explore');
   const [repositoryId, setRepositoryId] = useState('');
   const [viewId, setViewId] = useState('');
   const [projectId, setProjectId] = useState('all');
@@ -182,8 +184,16 @@ export function GraphWorkspace(props: {
     () => [...new Set(graph?.edges.map(edge => edge.relation) ?? [])].sort(compareCodeUnits),
     [graph],
   );
-  const activeBuilds = (props.catalog?.builds ?? []).filter(graphBuildShouldDisplay);
-  const selectedRepositoryIsIndexing = activeBuilds.some(
+  const visibleBuilds = useMemo(
+    () => orderGraphBuildStatuses((props.catalog?.builds ?? []).filter(graphBuildShouldDisplay), repositories),
+    [props.catalog?.builds, repositories],
+  );
+  const statusNoticeCount =
+    visibleBuilds.length +
+    (props.catalog?.automaticCompaction ? 1 : 0) +
+    (props.catalog?.maintenance ? 1 : 0) +
+    (props.catalog?.diagnostics.length ?? 0);
+  const selectedRepositoryIsIndexing = visibleBuilds.some(
     build =>
       repository !== undefined &&
       build.identity.checkoutId === repository.checkoutId &&
@@ -648,497 +658,561 @@ export function GraphWorkspace(props: {
         </button>
       </header>
 
-      <div className="graph-notices">
-        <GraphAdministration
-          busy={props.administrationBusy}
-          onAction={props.onAdministrationAction ?? (() => undefined)}
-          onDiagnostics={props.onDiagnostics ?? (() => undefined)}
-          output={props.administrationOutput}
-          report={props.administration}
-        />
-        {props.catalog?.automaticCompaction ? (
-          <GraphAutomaticCompactionProgress repositories={repositories} status={props.catalog.automaticCompaction} />
-        ) : null}
-        {props.catalog?.maintenance ? (
-          <GraphMaintenanceProgress repositories={repositories} status={props.catalog.maintenance} />
-        ) : null}
-        {activeBuilds.length > 0 ? (
-          <div className="graph-build-status" aria-live="polite">
-            {activeBuilds.map(build => (
-              <GraphBuildProgress
-                build={build}
-                key={`${build.identity.checkoutId}:${build.identity.worktreeId}:${build.buildId}`}
-                repositories={repositories}
-                storage={props.catalog?.storage?.[build.identity.checkoutId]}
-                waiters={props.catalog?.waiters ?? []}
-              />
-            ))}
-          </div>
-        ) : null}
-
-        {props.catalog?.diagnostics.length ? (
-          <div className="graph-catalog-diagnostics" role="status">
-            <strong>Some indexed views need attention</strong>
-            {props.catalog.diagnostics.map(diagnostic => (
-              <span key={`${diagnostic.checkoutId}:${diagnostic.code}`}>{diagnostic.message}</span>
-            ))}
-          </div>
-        ) : null}
+      <div className="graph-page-tabs" aria-label="Knowledge graph sections" role="tablist">
+        <button
+          aria-controls="graph-explore-panel"
+          aria-selected={activeTab === 'explore'}
+          id="graph-explore-tab"
+          onClick={() => setActiveTab('explore')}
+          onKeyDown={event => {
+            if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+            event.preventDefault();
+            setActiveTab('administration');
+            window.requestAnimationFrame(() => document.getElementById('graph-administration-tab')?.focus());
+          }}
+          role="tab"
+          tabIndex={activeTab === 'explore' ? 0 : -1}
+          type="button"
+        >
+          Graph view
+        </button>
+        <button
+          aria-controls="graph-administration-panel"
+          aria-selected={activeTab === 'administration'}
+          id="graph-administration-tab"
+          onClick={() => setActiveTab('administration')}
+          onKeyDown={event => {
+            if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+            event.preventDefault();
+            setActiveTab('explore');
+            window.requestAnimationFrame(() => document.getElementById('graph-explore-tab')?.focus());
+          }}
+          role="tab"
+          tabIndex={activeTab === 'administration' ? 0 : -1}
+          type="button"
+        >
+          <span>Status &amp; administration</span>
+          {statusNoticeCount > 0 ? (
+            <small aria-label={`${statusNoticeCount} status notices`}>{statusNoticeCount}</small>
+          ) : null}
+        </button>
       </div>
 
-      <div className="graph-toolbar">
-        <div className="graph-toolbar-scope">
-          <label>
-            <span>Repository</span>
-            <select
-              aria-label="Repository"
-              disabled={repositories.length === 0}
-              onChange={event => chooseRepository(event.target.value)}
-              value={repositoryGroup?.id ?? ''}
-            >
-              {repositories.map(item => (
-                <option key={item.id} value={item.id}>
-                  {graphRepositoryOptionLabel(item, repositories)}
-                </option>
+      <div
+        aria-labelledby="graph-administration-tab"
+        className="graph-tab-panel graph-administration-tab"
+        hidden={activeTab !== 'administration'}
+        id="graph-administration-panel"
+        role="tabpanel"
+        tabIndex={0}
+      >
+        <div className="graph-notices">
+          <GraphAdministration
+            busy={props.administrationBusy}
+            onAction={props.onAdministrationAction ?? (() => undefined)}
+            onDiagnostics={props.onDiagnostics ?? (() => undefined)}
+            output={props.administrationOutput}
+            report={props.administration}
+          />
+          {props.catalog?.automaticCompaction ? (
+            <GraphAutomaticCompactionProgress repositories={repositories} status={props.catalog.automaticCompaction} />
+          ) : null}
+          {props.catalog?.maintenance ? (
+            <GraphMaintenanceProgress repositories={repositories} status={props.catalog.maintenance} />
+          ) : null}
+          {visibleBuilds.length > 0 ? (
+            <div className="graph-build-status" aria-live="polite">
+              {visibleBuilds.map(build => (
+                <GraphBuildProgress
+                  build={build}
+                  key={`${build.identity.checkoutId}:${build.identity.worktreeId}:${build.buildId}`}
+                  repositories={repositories}
+                  storage={props.catalog?.storage?.[build.identity.checkoutId]}
+                  waiters={props.catalog?.waiters ?? []}
+                />
               ))}
-            </select>
-          </label>
-          {repositoryGroup && (repositoryGroup.views.length > 1 || viewCatalogHasMore) ? (
+            </div>
+          ) : null}
+
+          {props.catalog?.diagnostics.length ? (
+            <div className="graph-catalog-diagnostics" role="status">
+              <strong>Some indexed views need attention</strong>
+              {props.catalog.diagnostics.map(diagnostic => (
+                <span key={`${diagnostic.checkoutId}:${diagnostic.code}`}>{diagnostic.message}</span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div
+        aria-labelledby="graph-explore-tab"
+        className="graph-tab-panel graph-explorer-tab"
+        hidden={activeTab !== 'explore'}
+        id="graph-explore-panel"
+        role="tabpanel"
+        tabIndex={0}
+      >
+        <div className="graph-toolbar">
+          <div className="graph-toolbar-scope">
             <label>
-              <span>Indexed view</span>
+              <span>Repository</span>
               <select
-                aria-label="Indexed view"
-                onChange={event => chooseView(event.target.value)}
-                value={repository?.id ?? ''}
+                aria-label="Repository"
+                disabled={repositories.length === 0}
+                onChange={event => chooseRepository(event.target.value)}
+                value={repositoryGroup?.id ?? ''}
               >
-                {repositoryGroup.views.map(view => (
-                  <option key={view.id} value={view.id}>
-                    {view.label}
-                    {view.localAssociation.branch ? ` · observed branch ${view.localAssociation.branch}` : ''} · folder{' '}
-                    {graphLocalAssociationText(view.localAssociation)}
+                {repositories.map(item => (
+                  <option key={item.id} value={item.id}>
+                    {graphRepositoryOptionLabel(item, repositories)}
                   </option>
                 ))}
               </select>
             </label>
-          ) : null}
-          <label>
-            <span>Component</span>
-            <select
-              aria-label="Component"
-              disabled={!repository}
-              onChange={event => chooseProject(event.target.value)}
-              value={projectId}
-            >
-              <option value="all">All components</option>
-              {(repository?.workspaces ?? []).map(workspace => {
-                const projects = repository?.projects.filter(project => project.workspaceId === workspace.id) ?? [];
-                return projects.length > 0 ? (
-                  <optgroup
-                    key={workspace.id}
-                    label={`${workspace.name} · ${workspace.buildSystem} · ${workspace.root || 'repository root'}`}
-                  >
-                    {projects.map(project => (
-                      <option key={project.id} value={project.id}>
-                        {project.label} · {graphProjectBadge(project)} ·{' '}
-                        {repository?.metrics === 'deferred'
-                          ? 'count on demand'
-                          : compactNumber(project.symbolCount ?? 0)}
-                      </option>
-                    ))}
-                  </optgroup>
-                ) : null;
-              })}
-              {(repository?.projects ?? [])
-                .filter(
-                  project =>
-                    !project.workspaceId ||
-                    !repository?.workspaces.some(workspace => workspace.id === project.workspaceId),
-                )
-                .map(project => (
-                  <option key={project.id} value={project.id}>
-                    {project.label} · {graphProjectBadge(project)} ·{' '}
-                    {repository?.metrics === 'deferred' ? 'count on demand' : compactNumber(project.symbolCount ?? 0)}
+            {repositoryGroup && (repositoryGroup.views.length > 1 || viewCatalogHasMore) ? (
+              <label>
+                <span>Indexed view</span>
+                <select
+                  aria-label="Indexed view"
+                  onChange={event => chooseView(event.target.value)}
+                  value={repository?.id ?? ''}
+                >
+                  {repositoryGroup.views.map(view => (
+                    <option key={view.id} value={view.id}>
+                      {view.label}
+                      {view.localAssociation.branch ? ` · observed branch ${view.localAssociation.branch}` : ''} ·
+                      folder {graphLocalAssociationText(view.localAssociation)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+            <label>
+              <span>Component</span>
+              <select
+                aria-label="Component"
+                disabled={!repository}
+                onChange={event => chooseProject(event.target.value)}
+                value={projectId}
+              >
+                <option value="all">All components</option>
+                {(repository?.workspaces ?? []).map(workspace => {
+                  const projects = repository?.projects.filter(project => project.workspaceId === workspace.id) ?? [];
+                  return projects.length > 0 ? (
+                    <optgroup
+                      key={workspace.id}
+                      label={`${workspace.name} · ${workspace.buildSystem} · ${workspace.root || 'repository root'}`}
+                    >
+                      {projects.map(project => (
+                        <option key={project.id} value={project.id}>
+                          {project.label} · {graphProjectBadge(project)} ·{' '}
+                          {repository?.metrics === 'deferred'
+                            ? 'count on demand'
+                            : compactNumber(project.symbolCount ?? 0)}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ) : null;
+                })}
+                {(repository?.projects ?? [])
+                  .filter(
+                    project =>
+                      !project.workspaceId ||
+                      !repository?.workspaces.some(workspace => workspace.id === project.workspaceId),
+                  )
+                  .map(project => (
+                    <option key={project.id} value={project.id}>
+                      {project.label} · {graphProjectBadge(project)} ·{' '}
+                      {repository?.metrics === 'deferred' ? 'count on demand' : compactNumber(project.symbolCount ?? 0)}
+                    </option>
+                  ))}
+              </select>
+            </label>
+          </div>
+          <div className="graph-control graph-catalog-continuation">
+            <label htmlFor="graph-catalog-search">Find component or indexed view</label>
+            <div className="graph-control-actions">
+              <input
+                aria-describedby="graph-catalog-search-status"
+                disabled={!repository || catalogLoading}
+                id="graph-catalog-search"
+                maxLength={256}
+                onChange={event => {
+                  setCatalogQuery(event.target.value);
+                  setCatalogSearchResult(undefined);
+                  setCatalogError('');
+                }}
+                onKeyDown={event => {
+                  if (event.key !== 'Enter') return;
+                  event.preventDefault();
+                  loadCatalogContinuation(catalogQuery);
+                }}
+                placeholder="Component, workspace, commit, or view"
+                type="search"
+                value={catalogQuery}
+              />
+              <button
+                disabled={!repository || catalogLoading || catalogQuery.trim().length === 0}
+                onClick={() => loadCatalogContinuation(catalogQuery)}
+                type="button"
+              >
+                {catalogLoading && catalogQuery.trim().length > 0 ? 'Searching…' : 'Find options'}
+              </button>
+            </div>
+            {projectCatalogHasMore || workspaceCatalogHasMore || viewCatalogHasMore ? (
+              <button
+                className="quiet-button"
+                disabled={!repository || catalogLoading}
+                onClick={() => loadCatalogContinuation('')}
+                type="button"
+              >
+                {catalogLoading && catalogQuery.trim().length === 0 ? 'Loading…' : 'Load more options'}
+              </button>
+            ) : null}
+            {catalogError ? <small role="alert">{catalogError}</small> : null}
+            {catalogSearchResult ? (
+              <div
+                className="graph-search-results graph-catalog-results"
+                id="graph-catalog-search-status"
+                role="status"
+              >
+                {catalogSearchResult.options.projects.length + catalogSearchResult.options.views.length > 0 ? (
+                  <>
+                    <p>
+                      Found{' '}
+                      {(
+                        catalogSearchResult.options.projects.length + catalogSearchResult.options.views.length
+                      ).toLocaleString()}{' '}
+                      options for “{catalogSearchResult.query}”
+                    </p>
+                    {catalogSearchResult.options.projects.length > 0 ? (
+                      <div className="graph-catalog-result-group">
+                        <span>Components and workspace matches</span>
+                        {catalogSearchResult.options.projects.map(option => (
+                          <button
+                            key={`${option.viewId}:${option.id}`}
+                            onClick={() => chooseProject(option.id)}
+                            type="button"
+                          >
+                            <strong>{option.label}</strong>
+                            <span>{option.description}</span>
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                    {catalogSearchResult.options.views.length > 0 ? (
+                      <div className="graph-catalog-result-group">
+                        <span>Indexed views</span>
+                        {catalogSearchResult.options.views.map(option => (
+                          <button
+                            key={`${option.repositoryId}:${option.id}`}
+                            onClick={() => chooseCatalogView(option.repositoryId, option.id)}
+                            type="button"
+                          >
+                            <strong>{option.label}</strong>
+                            <span>{option.description}</span>
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </>
+                ) : (
+                  <p>No catalog matches for “{catalogSearchResult.query}”</p>
+                )}
+              </div>
+            ) : (
+              <span className="sr-only" id="graph-catalog-search-status">
+                Search results appear here.
+              </span>
+            )}
+          </div>
+          <div className="graph-control graph-search graph-node-search">
+            <label htmlFor="graph-current-view-search">Find in current view</label>
+            <input
+              id="graph-current-view-search"
+              disabled={!graph}
+              onChange={event => setSearch(event.target.value)}
+              placeholder={graph?.mode === 'overview' ? 'Search components' : 'Name, path, or symbol'}
+              type="search"
+              value={search}
+            />
+            {search.trim() ? (
+              <div className="graph-search-results">
+                {searchResults.length > 0 ? (
+                  searchResults.map(node => (
+                    <button
+                      key={node.id}
+                      onClick={() => {
+                        selectNode(node.id, true);
+                        setSearch('');
+                      }}
+                      type="button"
+                    >
+                      <strong>{node.label}</strong>
+                      <span>{node.path ?? node.kind}</span>
+                    </button>
+                  ))
+                ) : (
+                  <p>No matching nodes</p>
+                )}
+              </div>
+            ) : null}
+          </div>
+          <div className="graph-control graph-search graph-code-query">
+            <label htmlFor="graph-code-query">Query the code graph</label>
+            <div className="graph-control-actions">
+              <input
+                disabled={!repository}
+                id="graph-code-query"
+                maxLength={GRAPH_QUERY_MAXIMUM_LENGTH}
+                onChange={event => setQueryInput(event.target.value)}
+                onKeyDown={event => {
+                  if (event.key !== 'Enter') return;
+                  event.preventDefault();
+                  submitCodeQuery();
+                }}
+                placeholder="Concept, path, module, or symbol"
+                type="search"
+                value={queryInput}
+              />
+              <button
+                disabled={!repository || managerGraphQueryCandidate(queryInput) === undefined || queryLoading}
+                onClick={submitCodeQuery}
+                type="button"
+              >
+                {queryLoading ? 'Searching…' : 'Query graph'}
+              </button>
+            </div>
+            {activeQuery ? (
+              <button className="quiet-button" onClick={clearCodeQuery} type="button">
+                Back to {projectId === 'all' ? 'overview' : 'component'}
+              </button>
+            ) : null}
+            {!activeQuery && queryError ? <small role="alert">{queryError}</small> : null}
+          </div>
+          <div className="graph-stats" aria-label="Graph rendering status">
+            <span>{graph ? compactNumber(graph.stats.renderedNodes) : '—'} nodes</span>
+            <span>{graph ? compactNumber(graph.stats.renderedEdges) : '—'} links</span>
+            {graph?.paging.hasMore ? (
+              <button
+                disabled={(activeQuery ? queryLoading : loading) || workingSetAtMaximum}
+                onClick={() => {
+                  if (activeQuery) {
+                    setQueryWorkingSet(current => ({
+                      edgeLimit: Math.min(MAX_QUERY_WORKING_SET.edgeLimit, current.edgeLimit * 2),
+                      nodeLimit: Math.min(MAX_QUERY_WORKING_SET.nodeLimit, current.nodeLimit * 2),
+                    }));
+                  } else {
+                    setWorkingSet(current => ({
+                      edgeLimit: Math.min(MAX_WORKING_SET.edgeLimit, current.edgeLimit * 2),
+                      nodeLimit: Math.min(MAX_WORKING_SET.nodeLimit, current.nodeLimit * 2),
+                    }));
+                  }
+                }}
+                type="button"
+              >
+                {(activeQuery ? queryLoading : loading)
+                  ? 'Expanding…'
+                  : workingSetAtMaximum
+                    ? activeQuery
+                      ? 'Query capped'
+                      : 'View capped'
+                    : activeQuery
+                      ? 'Expand results'
+                      : 'Expand view'}
+              </button>
+            ) : null}
+            <span className="gpu-badge">WebGL</span>
+          </div>
+        </div>
+
+        {graph ? (
+          <div className="graph-filterbar">
+            <label>
+              <span>Relationship</span>
+              <select
+                aria-label="Filter relationships"
+                onChange={event => setRelationFilter(event.target.value)}
+                value={relationFilter}
+              >
+                <option value="all">All relationships</option>
+                {relations.map(relation => (
+                  <option key={relation} value={relation}>
+                    {relationLabel(relation)}
                   </option>
                 ))}
-            </select>
-          </label>
-        </div>
-        <div className="graph-control graph-catalog-continuation">
-          <label htmlFor="graph-catalog-search">Find component or indexed view</label>
-          <div className="graph-control-actions">
-            <input
-              aria-describedby="graph-catalog-search-status"
-              disabled={!repository || catalogLoading}
-              id="graph-catalog-search"
-              maxLength={256}
-              onChange={event => {
-                setCatalogQuery(event.target.value);
-                setCatalogSearchResult(undefined);
-                setCatalogError('');
-              }}
-              onKeyDown={event => {
-                if (event.key !== 'Enter') return;
-                event.preventDefault();
-                loadCatalogContinuation(catalogQuery);
-              }}
-              placeholder="Component, workspace, commit, or view"
-              type="search"
-              value={catalogQuery}
-            />
-            <button
-              disabled={!repository || catalogLoading || catalogQuery.trim().length === 0}
-              onClick={() => loadCatalogContinuation(catalogQuery)}
-              type="button"
-            >
-              {catalogLoading && catalogQuery.trim().length > 0 ? 'Searching…' : 'Find options'}
-            </button>
-          </div>
-          {projectCatalogHasMore || workspaceCatalogHasMore || viewCatalogHasMore ? (
-            <button
-              className="quiet-button"
-              disabled={!repository || catalogLoading}
-              onClick={() => loadCatalogContinuation('')}
-              type="button"
-            >
-              {catalogLoading && catalogQuery.trim().length === 0 ? 'Loading…' : 'Load more options'}
-            </button>
-          ) : null}
-          {catalogError ? <small role="alert">{catalogError}</small> : null}
-          {catalogSearchResult ? (
-            <div className="graph-search-results graph-catalog-results" id="graph-catalog-search-status" role="status">
-              {catalogSearchResult.options.projects.length + catalogSearchResult.options.views.length > 0 ? (
-                <>
-                  <p>
-                    Found{' '}
-                    {(
-                      catalogSearchResult.options.projects.length + catalogSearchResult.options.views.length
-                    ).toLocaleString()}{' '}
-                    options for “{catalogSearchResult.query}”
-                  </p>
-                  {catalogSearchResult.options.projects.length > 0 ? (
-                    <div className="graph-catalog-result-group">
-                      <span>Components and workspace matches</span>
-                      {catalogSearchResult.options.projects.map(option => (
-                        <button
-                          key={`${option.viewId}:${option.id}`}
-                          onClick={() => chooseProject(option.id)}
-                          type="button"
-                        >
-                          <strong>{option.label}</strong>
-                          <span>{option.description}</span>
-                        </button>
-                      ))}
-                    </div>
-                  ) : null}
-                  {catalogSearchResult.options.views.length > 0 ? (
-                    <div className="graph-catalog-result-group">
-                      <span>Indexed views</span>
-                      {catalogSearchResult.options.views.map(option => (
-                        <button
-                          key={`${option.repositoryId}:${option.id}`}
-                          onClick={() => chooseCatalogView(option.repositoryId, option.id)}
-                          type="button"
-                        >
-                          <strong>{option.label}</strong>
-                          <span>{option.description}</span>
-                        </button>
-                      ))}
-                    </div>
-                  ) : null}
-                </>
-              ) : (
-                <p>No catalog matches for “{catalogSearchResult.query}”</p>
-              )}
-            </div>
-          ) : (
-            <span className="sr-only" id="graph-catalog-search-status">
-              Search results appear here.
-            </span>
-          )}
-        </div>
-        <div className="graph-control graph-search graph-node-search">
-          <label htmlFor="graph-current-view-search">Find in current view</label>
-          <input
-            id="graph-current-view-search"
-            disabled={!graph}
-            onChange={event => setSearch(event.target.value)}
-            placeholder={graph?.mode === 'overview' ? 'Search components' : 'Name, path, or symbol'}
-            type="search"
-            value={search}
-          />
-          {search.trim() ? (
-            <div className="graph-search-results">
-              {searchResults.length > 0 ? (
-                searchResults.map(node => (
+              </select>
+            </label>
+            {graph.mode === 'detail' ? (
+              <label>
+                <span>Node size</span>
+                <select
+                  aria-label="Node size metric"
+                  onChange={event => setSizeMetric(event.target.value as GraphSizeMetric)}
+                  value={sizeMetric}
+                >
+                  <option value="connections">Connections</option>
+                  <option value="incoming">Incoming</option>
+                  <option value="outgoing">Outgoing</option>
+                </select>
+              </label>
+            ) : (
+              <div className="graph-size-readout">
+                <span>Node size</span>
+                <strong>{graphOverviewSizeLabel(graph)}</strong>
+              </div>
+            )}
+            <div className="graph-focus-control">
+              <span>Selection focus</span>
+              <div className="segmented-control" aria-label="Selection focus">
+                {(
+                  [
+                    ['all', 'All'],
+                    ['neighbors', 'Neighbors'],
+                    ['incoming', 'Incoming'],
+                    ['outgoing', 'Outgoing'],
+                  ] as const
+                ).map(([mode, label]) => (
                   <button
-                    key={node.id}
-                    onClick={() => {
-                      selectNode(node.id, true);
-                      setSearch('');
-                    }}
+                    aria-pressed={focusMode === mode}
+                    disabled={!selectedNode}
+                    key={mode}
+                    onClick={() => setFocusMode(mode)}
                     type="button"
                   >
-                    <strong>{node.label}</strong>
-                    <span>{node.path ?? node.kind}</span>
+                    {label}
                   </button>
-                ))
-              ) : (
-                <p>No matching nodes</p>
-              )}
+                ))}
+              </div>
             </div>
-          ) : null}
-        </div>
-        <div className="graph-control graph-search graph-code-query">
-          <label htmlFor="graph-code-query">Query the code graph</label>
-          <div className="graph-control-actions">
-            <input
-              disabled={!repository}
-              id="graph-code-query"
-              maxLength={GRAPH_QUERY_MAXIMUM_LENGTH}
-              onChange={event => setQueryInput(event.target.value)}
-              onKeyDown={event => {
-                if (event.key !== 'Enter') return;
-                event.preventDefault();
-                submitCodeQuery();
-              }}
-              placeholder="Concept, path, module, or symbol"
-              type="search"
-              value={queryInput}
-            />
-            <button
-              disabled={!repository || managerGraphQueryCandidate(queryInput) === undefined || queryLoading}
-              onClick={submitCodeQuery}
-              type="button"
-            >
-              {queryLoading ? 'Searching…' : 'Query graph'}
-            </button>
+            {selectedNode ? (
+              <button className="graph-clear-selection" onClick={() => selectNode(undefined)} type="button">
+                Clear selection
+              </button>
+            ) : (
+              <p>Select a node to isolate its neighborhood and direction.</p>
+            )}
           </div>
-          {activeQuery ? (
-            <button className="quiet-button" onClick={clearCodeQuery} type="button">
-              Back to {projectId === 'all' ? 'overview' : 'component'}
-            </button>
-          ) : null}
-          {!activeQuery && queryError ? <small role="alert">{queryError}</small> : null}
-        </div>
-        <div className="graph-stats" aria-label="Graph rendering status">
-          <span>{graph ? compactNumber(graph.stats.renderedNodes) : '—'} nodes</span>
-          <span>{graph ? compactNumber(graph.stats.renderedEdges) : '—'} links</span>
-          {graph?.paging.hasMore ? (
-            <button
-              disabled={(activeQuery ? queryLoading : loading) || workingSetAtMaximum}
-              onClick={() => {
-                if (activeQuery) {
-                  setQueryWorkingSet(current => ({
-                    edgeLimit: Math.min(MAX_QUERY_WORKING_SET.edgeLimit, current.edgeLimit * 2),
-                    nodeLimit: Math.min(MAX_QUERY_WORKING_SET.nodeLimit, current.nodeLimit * 2),
-                  }));
-                } else {
-                  setWorkingSet(current => ({
-                    edgeLimit: Math.min(MAX_WORKING_SET.edgeLimit, current.edgeLimit * 2),
-                    nodeLimit: Math.min(MAX_WORKING_SET.nodeLimit, current.nodeLimit * 2),
-                  }));
-                }
-              }}
-              type="button"
-            >
-              {(activeQuery ? queryLoading : loading)
-                ? 'Expanding…'
-                : workingSetAtMaximum
-                  ? activeQuery
-                    ? 'Query capped'
-                    : 'View capped'
-                  : activeQuery
-                    ? 'Expand results'
-                    : 'Expand view'}
-            </button>
-          ) : null}
-          <span className="gpu-badge">WebGL</span>
-        </div>
-      </div>
+        ) : null}
 
-      {graph ? (
-        <div className="graph-filterbar">
-          <label>
-            <span>Relationship</span>
-            <select
-              aria-label="Filter relationships"
-              onChange={event => setRelationFilter(event.target.value)}
-              value={relationFilter}
-            >
-              <option value="all">All relationships</option>
-              {relations.map(relation => (
-                <option key={relation} value={relation}>
-                  {relationLabel(relation)}
-                </option>
-              ))}
-            </select>
-          </label>
-          {graph.mode === 'detail' ? (
-            <label>
-              <span>Node size</span>
-              <select
-                aria-label="Node size metric"
-                onChange={event => setSizeMetric(event.target.value as GraphSizeMetric)}
-                value={sizeMetric}
-              >
-                <option value="connections">Connections</option>
-                <option value="incoming">Incoming</option>
-                <option value="outgoing">Outgoing</option>
-              </select>
-            </label>
-          ) : (
-            <div className="graph-size-readout">
-              <span>Node size</span>
-              <strong>{graphOverviewSizeLabel(graph)}</strong>
-            </div>
-          )}
-          <div className="graph-focus-control">
-            <span>Selection focus</span>
-            <div className="segmented-control" aria-label="Selection focus">
-              {(
-                [
-                  ['all', 'All'],
-                  ['neighbors', 'Neighbors'],
-                  ['incoming', 'Incoming'],
-                  ['outgoing', 'Outgoing'],
-                ] as const
-              ).map(([mode, label]) => (
-                <button
-                  aria-pressed={focusMode === mode}
-                  disabled={!selectedNode}
-                  key={mode}
-                  onClick={() => setFocusMode(mode)}
-                  type="button"
-                >
-                  {label}
+        <div className="graph-body">
+          <section className="graph-stage">
+            {!props.catalog && props.catalogError ? (
+              <div className="graph-empty" role="status">
+                <span className="empty-orbit" aria-hidden="true" />
+                <h3>Indexed repositories unavailable</h3>
+                <p>{props.catalogError}</p>
+                <button onClick={props.onRefresh} type="button">
+                  Try again
                 </button>
-              ))}
-            </div>
-          </div>
-          {selectedNode ? (
-            <button className="graph-clear-selection" onClick={() => selectNode(undefined)} type="button">
-              Clear selection
-            </button>
-          ) : (
-            <p>Select a node to isolate its neighborhood and direction.</p>
-          )}
+              </div>
+            ) : !props.catalog ? (
+              <div aria-live="polite" className="graph-loading" role="status">
+                <span className="spinner" aria-hidden="true" />
+                <span>Loading indexed repositories…</span>
+              </div>
+            ) : repositories.length === 0 ? (
+              <GraphEmptyState
+                building={visibleBuilds.some(build => build.state === 'queued' || build.state === 'running')}
+              />
+            ) : activeQuery && selectedRepositoryIsIndexing && !queryGraph ? (
+              <div aria-live="polite" className="graph-loading" role="status">
+                <span className="spinner" aria-hidden="true" />
+                <span>
+                  Code graph indexing is in progress. Search will use the pinned ready snapshot when available.
+                </span>
+              </div>
+            ) : activeQuery && queryError ? (
+              <div className="graph-empty" role="status">
+                <span className="empty-orbit" aria-hidden="true" />
+                <h3>Code search unavailable</h3>
+                <p>{queryError}</p>
+                <button onClick={submitCodeQuery} type="button">
+                  Try query again
+                </button>
+                <button className="quiet-button" onClick={clearCodeQuery} type="button">
+                  Return to graph
+                </button>
+              </div>
+            ) : !activeQuery && error ? (
+              <div className="graph-empty">
+                <span className="empty-orbit" aria-hidden="true" />
+                <h3>Graph unavailable</h3>
+                <p>{error}</p>
+                <button onClick={props.onRefresh} type="button">
+                  Try again
+                </button>
+              </div>
+            ) : (activeQuery ? queryLoading : loading) || !graph ? (
+              <div aria-live="polite" className="graph-loading" role="status">
+                <span className="spinner" aria-hidden="true" />
+                <span>{activeQuery ? `Searching for “${activeQuery}”…` : 'Preparing a bounded graph view…'}</span>
+              </div>
+            ) : activeQuery && (graph.query?.matchedNodes === 0 || graph.nodes.length === 0) ? (
+              <div className="graph-empty" role="status">
+                <span className="empty-orbit" aria-hidden="true" />
+                <h3>No code graph matches</h3>
+                <p>
+                  No concept, path, module, or symbol was returned for “{activeQuery}” by this bounded snapshot search.
+                  Review any partial-result warning below or refine the query.
+                </p>
+                <button className="quiet-button" onClick={clearCodeQuery} type="button">
+                  Return to graph
+                </button>
+              </div>
+            ) : (
+              <ThreeGraph
+                graph={graph}
+                focusMode={focusMode}
+                key={`${graph.repository.id}:${graph.repository.snapshot.id}:${graph.projectId}:${graph.query?.text ?? ''}`}
+                onOpenProject={chooseProject}
+                onSelectNode={nodeId => selectNode(nodeId, Boolean(nodeId))}
+                relationFilter={relationFilter}
+                sizeMetric={sizeMetric}
+                focusRequest={focusRequest}
+                selectedNodeId={selectedNodeId}
+              />
+            )}
+          </section>
+
+          <aside className="graph-inspector">
+            {selectedNode ? (
+              <NodeInspector
+                graph={graph!}
+                detail={nodeDetail}
+                detailError={nodeDetailError}
+                detailLoading={nodeDetailLoading}
+                node={selectedNode}
+                onOpenProject={() => chooseProject(selectedNode.projectId)}
+                onSelectNode={nodeId => selectNode(nodeId, true)}
+              />
+            ) : graph ? (
+              <GraphSummary
+                analysis={analysis}
+                analysisError={analysisError}
+                analysisLoading={analysisLoading}
+                graph={graph}
+                onAnalyze={loadAnalysis}
+                sizeMetric={sizeMetric}
+              />
+            ) : (
+              <div className="inspector-placeholder">
+                <span className="inspector-dot" />
+                <p>Select a node to inspect its role, source location, and relationships.</p>
+              </div>
+            )}
+          </aside>
         </div>
-      ) : null}
 
-      <div className="graph-body">
-        <section className="graph-stage">
-          {!props.catalog && props.catalogError ? (
-            <div className="graph-empty" role="status">
-              <span className="empty-orbit" aria-hidden="true" />
-              <h3>Indexed repositories unavailable</h3>
-              <p>{props.catalogError}</p>
-              <button onClick={props.onRefresh} type="button">
-                Try again
-              </button>
-            </div>
-          ) : !props.catalog ? (
-            <div aria-live="polite" className="graph-loading" role="status">
-              <span className="spinner" aria-hidden="true" />
-              <span>Loading indexed repositories…</span>
-            </div>
-          ) : repositories.length === 0 ? (
-            <GraphEmptyState
-              building={activeBuilds.some(build => build.state === 'queued' || build.state === 'running')}
-            />
-          ) : activeQuery && selectedRepositoryIsIndexing && !queryGraph ? (
-            <div aria-live="polite" className="graph-loading" role="status">
-              <span className="spinner" aria-hidden="true" />
-              <span>Code graph indexing is in progress. Search will use the pinned ready snapshot when available.</span>
-            </div>
-          ) : activeQuery && queryError ? (
-            <div className="graph-empty" role="status">
-              <span className="empty-orbit" aria-hidden="true" />
-              <h3>Code search unavailable</h3>
-              <p>{queryError}</p>
-              <button onClick={submitCodeQuery} type="button">
-                Try query again
-              </button>
-              <button className="quiet-button" onClick={clearCodeQuery} type="button">
-                Return to graph
-              </button>
-            </div>
-          ) : !activeQuery && error ? (
-            <div className="graph-empty">
-              <span className="empty-orbit" aria-hidden="true" />
-              <h3>Graph unavailable</h3>
-              <p>{error}</p>
-              <button onClick={props.onRefresh} type="button">
-                Try again
-              </button>
-            </div>
-          ) : (activeQuery ? queryLoading : loading) || !graph ? (
-            <div aria-live="polite" className="graph-loading" role="status">
-              <span className="spinner" aria-hidden="true" />
-              <span>{activeQuery ? `Searching for “${activeQuery}”…` : 'Preparing a bounded graph view…'}</span>
-            </div>
-          ) : activeQuery && (graph.query?.matchedNodes === 0 || graph.nodes.length === 0) ? (
-            <div className="graph-empty" role="status">
-              <span className="empty-orbit" aria-hidden="true" />
-              <h3>No code graph matches</h3>
-              <p>
-                No concept, path, module, or symbol was returned for “{activeQuery}” by this bounded snapshot search.
-                Review any partial-result warning below or refine the query.
-              </p>
-              <button className="quiet-button" onClick={clearCodeQuery} type="button">
-                Return to graph
-              </button>
-            </div>
-          ) : (
-            <ThreeGraph
-              graph={graph}
-              focusMode={focusMode}
-              key={`${graph.repository.id}:${graph.repository.snapshot.id}:${graph.projectId}:${graph.query?.text ?? ''}`}
-              onOpenProject={chooseProject}
-              onSelectNode={nodeId => selectNode(nodeId, Boolean(nodeId))}
-              relationFilter={relationFilter}
-              sizeMetric={sizeMetric}
-              focusRequest={focusRequest}
-              selectedNodeId={selectedNodeId}
-            />
-          )}
-        </section>
-
-        <aside className="graph-inspector">
-          {selectedNode ? (
-            <NodeInspector
-              graph={graph!}
-              detail={nodeDetail}
-              detailError={nodeDetailError}
-              detailLoading={nodeDetailLoading}
-              node={selectedNode}
-              onOpenProject={() => chooseProject(selectedNode.projectId)}
-              onSelectNode={nodeId => selectNode(nodeId, true)}
-            />
-          ) : graph ? (
-            <GraphSummary
-              analysis={analysis}
-              analysisError={analysisError}
-              analysisLoading={analysisLoading}
-              graph={graph}
-              onAnalyze={loadAnalysis}
-              sizeMetric={sizeMetric}
-            />
-          ) : (
-            <div className="inspector-placeholder">
-              <span className="inspector-dot" />
-              <p>Select a node to inspect its role, source location, and relationships.</p>
-            </div>
-          )}
-        </aside>
+        {graph && [...new Set([...graph.warnings, ...(graph.query?.warnings ?? [])])].length ? (
+          <footer className="graph-notes">
+            {[...new Set([...graph.warnings, ...(graph.query?.warnings ?? [])])].map(warning => (
+              <span key={warning}>{warning}</span>
+            ))}
+          </footer>
+        ) : null}
       </div>
-
-      {graph && [...new Set([...graph.warnings, ...(graph.query?.warnings ?? [])])].length ? (
-        <footer className="graph-notes">
-          {[...new Set([...graph.warnings, ...(graph.query?.warnings ?? [])])].map(warning => (
-            <span key={warning}>{warning}</span>
-          ))}
-        </footer>
-      ) : null}
     </section>
   );
 }

--- a/test/unit/manager-graph.property.test.ts
+++ b/test/unit/manager-graph.property.test.ts
@@ -6,6 +6,7 @@ import {
   graphFocusTarget,
   graphWheelZoomFactor,
   graphWithNodeNeighborhood,
+  orderGraphBuildStatuses,
   type GraphBuildStatus,
   type GraphNodeDetail,
   type GraphVisualization,
@@ -95,6 +96,50 @@ describe('Manager graph properties', () => {
           expect(forward.total).toBe(expectedTotal);
           expect(new Set(forward.jobs.map(job => job.buildId)).size).toBe(forward.jobs.length);
           expect(forward.jobs.every(job => job.state !== 'completed')).toBe(true);
+        },
+      ),
+      {numRuns: 120},
+    );
+  });
+
+  it('keeps build banner order invariant across polling order and progress updates', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(
+          fc.record({
+            buildNumber: fc.integer({min: 0, max: 1_000_000}),
+            locationNumber: fc.integer({min: 0, max: 100}),
+            progressAt: fc.integer({min: 0, max: 2_000_000_000}),
+          }),
+          {maxLength: 80, selector: item => item.buildNumber},
+        ),
+        records => {
+          const statuses = records.map(record => ({
+            ...graphBuildStatus(
+              `build-${record.buildNumber}`,
+              record.buildNumber.toString(16).padStart(12, '0'),
+              record.progressAt,
+              'running',
+            ),
+            identity: {
+              checkoutId: `checkout-${record.buildNumber.toString().padStart(7, '0')}`,
+              commit: record.buildNumber.toString(16).padStart(12, '0'),
+              repositoryId: 'repository',
+              worktreeId: `worktree-${record.buildNumber.toString().padStart(7, '0')}`,
+            },
+            managerContext: {worktreePath: `/worktrees/${record.locationNumber.toString().padStart(3, '0')}`},
+          }));
+          const expected = orderGraphBuildStatuses(statuses).map(status => status.buildId);
+          const polled = [...statuses].reverse().map((status, index) => ({
+            ...status,
+            timestamps: {
+              ...status.timestamps,
+              lastProgressAt: new Date(2_000_000_000 - index).toISOString(),
+            },
+          }));
+
+          expect(orderGraphBuildStatuses(polled).map(status => status.buildId)).toEqual(expected);
+          expect(statuses.map(status => status.buildId)).toEqual(records.map(record => `build-${record.buildNumber}`));
         },
       ),
       {numRuns: 120},

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -122,6 +122,8 @@ describe('manager graph focus', () => {
     );
 
     expect(markup).toContain('1 graph database · 3 stored ready snapshots · 1 active worktree view');
+    expect(markup).toContain('<details class="graph-administration" open="">');
+    expect(markup).toContain('class="graph-administration-caret"');
     expect(markup).toContain('<dt>Stored ready snapshots</dt><dd>3</dd>');
     expect(markup).toContain('<dt>Active worktree views</dt><dd>1</dd>');
     expect(markup).toContain('Snapshot and view counts can differ');
@@ -218,6 +220,8 @@ describe('manager graph focus', () => {
     expect(markup).toContain('id="graph-explore-panel" role="tabpanel" tabindex="0"');
     expect(css).toMatch(/\.graph-tab-panel\s*{[^}]*overflow: auto;/s);
     expect(css).toMatch(/\.graph-explorer-tab\s*{[^}]*minmax\(440px, 1fr\)/s);
+    expect(css).toMatch(/\.graph-administration-caret\s*{[^}]*transform: rotate\(-90deg\)/s);
+    expect(css).toMatch(/\.graph-administration\[open\] \.graph-administration-caret\s*{[^}]*rotate\(0deg\)/s);
   });
 
   it('orders build status banners by stable folder or checkout identity', () => {

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -41,6 +41,7 @@ import {
   managerGraphQueryCandidate,
   mergeGraphCatalogStatus,
   mergeGraphRepositoryGroups,
+  orderGraphBuildStatuses,
   resolveGraphSelection,
   type GraphEdge,
   type GraphAnalysis,
@@ -192,6 +193,70 @@ describe('manager graph focus', () => {
         }),
       ),
     ).not.toThrow();
+  });
+
+  it('separates the scrollable graph view from status and administration', async () => {
+    const neverResolves = () => new Promise<never>(() => undefined);
+    const markup = renderToStaticMarkup(
+      createElement(GraphWorkspace, {
+        catalog: {builds: [], diagnostics: [], repositories: [], waiterCount: 0, waiters: []},
+        loadAnalysis: neverResolves,
+        loadCatalogPage: neverResolves,
+        loadGraph: neverResolves,
+        loadNodeDetail: neverResolves,
+        loadQuery: neverResolves,
+        loadViewsPage: neverResolves,
+        onRefresh: () => undefined,
+      }),
+    );
+    const css = await Bun.file(new URL('../../manager/app.css', import.meta.url)).text();
+
+    expect(markup).toContain('role="tablist"');
+    expect(markup).toContain('id="graph-explore-tab"');
+    expect(markup).toContain('aria-controls="graph-administration-panel"');
+    expect(markup).toMatch(/class="graph-tab-panel graph-administration-tab" hidden=""[^>]*role="tabpanel"/);
+    expect(markup).toContain('id="graph-explore-panel" role="tabpanel" tabindex="0"');
+    expect(css).toMatch(/\.graph-tab-panel\s*{[^}]*overflow: auto;/s);
+    expect(css).toMatch(/\.graph-explorer-tab\s*{[^}]*minmax\(440px, 1fr\)/s);
+  });
+
+  it('orders build status banners by stable folder or checkout identity', () => {
+    const earlier = {
+      ...graphBuildStatus('running'),
+      buildId: 'build-z',
+      identity: {
+        ...graphBuildStatus('running').identity,
+        checkoutId: 'checkout-z',
+        worktreeId: 'worktree-z',
+      },
+      managerContext: {worktreePath: '/worktrees/zeta'},
+      timestamps: {
+        ...graphBuildStatus('running').timestamps,
+        lastProgressAt: '2026-07-31T12:00:00.000Z',
+      },
+    };
+    const later = {
+      ...graphBuildStatus('running'),
+      buildId: 'build-a',
+      identity: {
+        ...graphBuildStatus('running').identity,
+        checkoutId: 'checkout-a',
+        worktreeId: 'worktree-a',
+      },
+      managerContext: {worktreePath: '/worktrees/alpha'},
+      timestamps: {
+        ...graphBuildStatus('running').timestamps,
+        lastProgressAt: '2026-07-31T13:00:00.000Z',
+      },
+    };
+
+    expect(orderGraphBuildStatuses([earlier, later]).map(build => build.buildId)).toEqual(['build-a', 'build-z']);
+    expect(
+      orderGraphBuildStatuses([
+        {...earlier, managerContext: undefined},
+        {...later, managerContext: undefined},
+      ]).map(build => build.buildId),
+    ).toEqual(['build-a', 'build-z']);
   });
 
   it('renders selected snapshot purge progress alongside graph build progress', () => {


### PR DESCRIPTION
## What changed

- Separate the interactive graph explorer from graph status and administration using accessible tabs.
- Keep both tab panels independently scrollable and preserve a usable minimum graph canvas height on smaller viewports.
- Order build-status banners by stable folder or checkout identity so progress updates do not reshuffle them.
- Expand graph administration by default and add an explicit caret that reflects its collapsed or expanded state.

## Why

Multiple status banners could consume the graph page height and squeeze the actual visualization into an unreadable area. Recency-based banner ordering also made concurrent builds difficult to track because cards moved whenever progress timestamps changed. The administration disclosure lacked a clear affordance and started collapsed.

## Impact

The graph visualization remains usable during concurrent indexing activity, status cards stay anchored in a predictable order, and administration controls are immediately discoverable while remaining collapsible.

## Validation

- Focused Manager graph suites: 53 tests passed
- Changed-file formatting and lint passed
- Full TypeScript checks passed
- Standalone build passed
- Exact rebased HEAD installed globally
- Live Manager browser QA covered tab rendering, initial expanded state, collapse/reopen behavior, caret rotation, accessibility-tree visibility, and console errors
