### PR TITLE
Bundle the core embedding model in standalone executables

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/models/licenses/bge-small-en-v1.5.LICENSE text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ permissions:
 
 env:
   BUN_VERSION: 1.3.14
-  E2E_EMBEDDING_MODEL_ID: bge-small-en-v1.5-q8
-  E2E_EMBEDDING_MODEL_SHA256: f046db1dc724cf4f6f0a0c5917e922823b73eb1d27b8f9a9c2797f7866974804
 
 jobs:
   changes:
@@ -233,42 +231,6 @@ jobs:
           test/unit/update.test.ts
           test/unit/mcp.test.ts
 
-  prepare-e2e-model:
-    name: Prepare pinned E2E model
-    needs: changes
-    if: needs.changes.outputs.release == 'true'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-
-      - run: bun install --frozen-lockfile
-
-      - name: Restore verified model cache
-        id: model-cache
-        uses: actions/cache@v6
-        with:
-          key: threadnote-e2e-model-${{ env.E2E_EMBEDDING_MODEL_SHA256 }}
-          path: artifacts/e2e-model-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}
-
-      - name: Download and verify pinned model once
-        if: steps.model-cache.outputs.cache-hit != 'true'
-        run: >-
-          bun src/standalone.ts
-          --home artifacts/e2e-model-home
-          models install ${{ env.E2E_EMBEDDING_MODEL_ID }}
-
-      - name: Share pinned model with platform E2E jobs
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-core-embedding-model
-          path: artifacts/e2e-model-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}/${{ env.E2E_EMBEDDING_MODEL_SHA256 }}.gguf
-          retention-days: 1
-
   standalone-targets:
     name: Bytecode compile · ${{ matrix.target }}
     needs: changes
@@ -301,8 +263,8 @@ jobs:
 
   self-contained-distribution:
     name: Self-contained Bun release · ${{ matrix.os }}
-    needs: [changes, prepare-e2e-model]
-    if: needs.changes.outputs.release == 'true' && needs.prepare-e2e-model.result == 'success'
+    needs: changes
+    if: needs.changes.outputs.release == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -320,12 +282,6 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: Download pinned E2E model
-        uses: actions/download-artifact@v8
-        with:
-          name: e2e-core-embedding-model
-          path: artifacts/e2e-model-fixture
-
       - run: bun run check:self-contained
       - name: Platform process identity smoke
         run: bun --bun vitest run test/unit/effect-system.test.ts
@@ -333,5 +289,3 @@ jobs:
 
       - name: Installed release E2E
         run: bun run test:e2e:local-bins
-        env:
-          THREADNOTE_E2E_MODEL_PATH: ${{ github.workspace }}/artifacts/e2e-model-fixture/${{ env.E2E_EMBEDDING_MODEL_SHA256 }}.gguf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,6 @@ concurrency:
 
 env:
   BUN_VERSION: 1.3.14
-  E2E_EMBEDDING_MODEL_ID: bge-small-en-v1.5-q8
-  E2E_EMBEDDING_MODEL_SHA256: f046db1dc724cf4f6f0a0c5917e922823b73eb1d27b8f9a9c2797f7866974804
 
 jobs:
   verify:
@@ -63,52 +61,10 @@ jobs:
       - name: Run release contract smokes
         run: bun run test:smoke:release
 
-  prepare-release-model:
-    name: Prepare pinned release model
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-
-      - run: bun install --frozen-lockfile
-
-      - name: Restore verified model cache
-        id: release-model-cache
-        uses: actions/cache@v6
-        with:
-          key: threadnote-e2e-model-${{ env.E2E_EMBEDDING_MODEL_SHA256 }}
-          path: artifacts/e2e-model-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}
-
-      - name: Download pinned model on cache miss
-        if: steps.release-model-cache.outputs.cache-hit != 'true'
-        run: >-
-          bun src/standalone.ts
-          --home artifacts/e2e-model-home
-          models install ${{ env.E2E_EMBEDDING_MODEL_ID }}
-
-      # A restored Actions cache is untrusted input; publish an artifact only after manifest checksum validation.
-      - name: Verify pinned model checksum
-        run: >-
-          bun src/standalone.ts
-          --home artifacts/e2e-model-home
-          models verify ${{ env.E2E_EMBEDDING_MODEL_ID }}
-
-      - name: Share pinned model with release jobs
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-core-embedding-model
-          path: artifacts/e2e-model-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}/${{ env.E2E_EMBEDDING_MODEL_SHA256 }}.gguf
-          if-no-files-found: error
-          retention-days: 1
-
   linux:
     name: Linux · ${{ matrix.architecture }}
     if: github.event_name == 'push'
-    needs: prepare-release-model
+    needs: verify
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -133,11 +89,6 @@ jobs:
         env:
           THREADNOTE_BUILD_TARGET: ${{ matrix.target }}
       - run: ./dist/threadnote --version
-      - name: Download pinned release model
-        uses: actions/download-artifact@v8
-        with:
-          name: release-core-embedding-model
-          path: ${{ runner.temp }}/threadnote-release-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}
       - name: Prepare strict doctor fixture
         shell: bash
         env:
@@ -160,8 +111,6 @@ jobs:
         run: ./dist/threadnote --home "$THREADNOTE_HOME" doctor --dry-run --strict
       - name: Produce a real embedding with the release payload
         run: bun --bun vitest run --config vitest.e2e.config.ts test/e2e/local-bins.e2e.ts
-        env:
-          THREADNOTE_E2E_MODEL_PATH: ${{ runner.temp }}/threadnote-release-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}/${{ env.E2E_EMBEDDING_MODEL_SHA256 }}.gguf
       - run: bun run archive:release
         env:
           THREADNOTE_RELEASE_TARGET: linux-${{ matrix.architecture }}
@@ -174,7 +123,7 @@ jobs:
 
   macos:
     name: macOS · ${{ matrix.architecture }}
-    needs: prepare-release-model
+    needs: verify
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -199,11 +148,6 @@ jobs:
         env:
           THREADNOTE_BUILD_TARGET: ${{ matrix.target }}
       - run: ./dist/threadnote --version
-      - name: Download pinned release model
-        uses: actions/download-artifact@v8
-        with:
-          name: release-core-embedding-model
-          path: ${{ runner.temp }}/threadnote-release-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}
       - name: Prepare strict doctor fixture
         shell: bash
         env:
@@ -226,8 +170,6 @@ jobs:
         run: ./dist/threadnote --home "$THREADNOTE_HOME" doctor --dry-run --strict
       - name: Produce a real embedding with the release payload
         run: bun --bun vitest run --config vitest.e2e.config.ts test/e2e/local-bins.e2e.ts
-        env:
-          THREADNOTE_E2E_MODEL_PATH: ${{ runner.temp }}/threadnote-release-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}/${{ env.E2E_EMBEDDING_MODEL_SHA256 }}.gguf
 
       - name: Import and select Developer ID certificate
         shell: bash
@@ -314,7 +256,7 @@ jobs:
     name: Windows build · ${{ matrix.architecture }} · disabled
     # Windows 4 release artifacts stay unavailable until Authenticode signing is approved and verified.
     if: ${{ false }}
-    needs: [verify, prepare-release-model]
+    needs: verify
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -338,11 +280,6 @@ jobs:
       - run: bun run build
         env:
           THREADNOTE_BUILD_TARGET: ${{ matrix.target }}
-      - name: Download pinned release model
-        uses: actions/download-artifact@v8
-        with:
-          name: release-core-embedding-model
-          path: ${{ runner.temp }}/threadnote-release-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}
       - name: Prepare fixture and verify with strict read-only doctor
         shell: pwsh
         env:
@@ -362,8 +299,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Produce a real embedding with the release payload
         run: bun --bun vitest run --config vitest.e2e.config.ts test/e2e/local-bins.e2e.ts
-        env:
-          THREADNOTE_E2E_MODEL_PATH: ${{ runner.temp }}/threadnote-release-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}/${{ env.E2E_EMBEDDING_MODEL_SHA256 }}.gguf
 
       - uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -393,7 +393,8 @@ See the [Obsidian bridge guide](docs/obsidian.md) for setup, trust boundaries, d
 
 ## Recall
 
-`threadnote install` automatically downloads, verifies, and selects the pinned 36.7 MB BGE Small embedding model.
+`threadnote install` extracts, verifies, and selects the pinned 36.7 MB BGE Small embedding model bundled in the
+standalone executable, so first-run semantic recall does not require a separate model download.
 Recall combines local `node-llama-cpp` vectors with deterministic lexical, field, scope, lifecycle, authority,
 time, graph, and feedback signals. The lexical path remains available as a fail-open fallback if native inference is
 temporarily unavailable.

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -40,8 +40,9 @@ Direct runtime software and packages bundled into the published JavaScript retai
 
 Grammar and parser license copies, source revisions, ABIs, and SHA-256 checksums are included under
 `assets/code-graph/`. Consult those files and each installed package's metadata for the authoritative terms. The
-pinned MIT-licensed BGE Small embedding model is installed automatically by `threadnote install`; other model files
-require an explicit `threadnote models install` action. Catalog entries identify every model source and license.
+pinned MIT-licensed BGE Small embedding model is embedded in the standalone executable and installed automatically by
+`threadnote install`; other model files require an explicit `threadnote models install` action. Catalog entries identify
+every model source and license.
 
 ### `yaml` 2.9.0 license notice
 

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -42,7 +42,8 @@ Grammar and parser license copies, source revisions, ABIs, and SHA-256 checksums
 `assets/code-graph/`. Consult those files and each installed package's metadata for the authoritative terms. The
 pinned MIT-licensed BGE Small embedding model is embedded in the standalone executable and installed automatically by
 `threadnote install`; other model files require an explicit `threadnote models install` action. Catalog entries identify
-every model source and license.
+every model source and license. The complete upstream BGE/FlagEmbedding MIT notice is included in release archives at
+`assets/models/licenses/bge-small-en-v1.5.LICENSE`.
 
 ### `yaml` 2.9.0 license notice
 

--- a/assets/models/licenses/bge-small-en-v1.5.LICENSE
+++ b/assets/models/licenses/bge-small-en-v1.5.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 staoxiao
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,9 +9,9 @@ file, durable close, and atomic rename. Derived index generations are activated 
 the full generation exists.
 
 Model artifacts are pinned by immutable repository revision, byte count, SHA-256, role, runtime version, and license.
-Install and repair provision the core embedding model automatically; additional model roles require an explicit
-selection. Partial downloads are never loaded. The llama adapter requests prebuilt binaries and refuses runtime
-compilation or implicit binary download.
+Install and repair extract and verify the core embedding model embedded in the standalone executable; additional model
+roles require an explicit selection and download. Partial downloads are never loaded. The llama adapter requests
+prebuilt binaries and refuses runtime compilation or implicit binary download.
 
 Share publishing scrubs known credential and machine-local path patterns before writing or pushing. Handoffs and
 preferences are not publishable. Publish order preserves the personal source until the shared canonical write,

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   ],
   "scripts": {
     "archive:release": "bun scripts/archive-release.ts",
-    "build": "bun run generate:code-graph-languages && bun run clean && bun scripts/build.ts",
-    "check:self-contained": "bun scripts/check-self-contained.ts",
+    "build": "bun scripts/check-embedded-core-model.ts && bun run generate:code-graph-languages && bun run clean && bun scripts/build.ts",
+    "check:self-contained": "bun scripts/check-embedded-core-model.ts && bun scripts/check-self-contained.ts",
     "clean": "bun scripts/clean.ts",
-    "compile:targets": "bun scripts/compile-targets.ts",
+    "compile:targets": "bun scripts/check-embedded-core-model.ts && bun scripts/compile-targets.ts",
     "cursor-plugin:check": "bun --bun vitest run test/unit/cursor-plugin.test.ts",
     "dev": "bun src/standalone.ts",
     "dev:install-global": "bun scripts/install-local-standalone.ts",

--- a/scripts/check-embedded-core-model.ts
+++ b/scripts/check-embedded-core-model.ts
@@ -1,0 +1,20 @@
+import {
+  BUNDLED_CORE_EMBEDDING_ASSET_RELATIVE_PATH,
+  BUNDLED_CORE_EMBEDDING_MANIFEST,
+} from '../src/models/core-embedding-asset.js';
+
+const source = Bun.file(new URL(`../${BUNDLED_CORE_EMBEDDING_ASSET_RELATIVE_PATH}`, import.meta.url));
+if (!(await source.exists())) {
+  throw new Error(`Bundled core embedding model is missing: ${BUNDLED_CORE_EMBEDDING_ASSET_RELATIVE_PATH}`);
+}
+if (source.size !== BUNDLED_CORE_EMBEDDING_MANIFEST.size) {
+  throw new Error(
+    `Bundled core embedding model has ${source.size} bytes; expected ${BUNDLED_CORE_EMBEDDING_MANIFEST.size}.`,
+  );
+}
+const sha256 = new Bun.CryptoHasher('sha256').update(await source.arrayBuffer()).digest('hex');
+if (sha256 !== BUNDLED_CORE_EMBEDDING_MANIFEST.sha256) {
+  throw new Error('Bundled core embedding model checksum does not match its manifest.');
+}
+
+await Bun.write(Bun.stdout, 'Embedded core model source checks passed.\n');

--- a/scripts/check-embedded-core-model.ts
+++ b/scripts/check-embedded-core-model.ts
@@ -3,7 +3,9 @@ import {
   BUNDLED_CORE_EMBEDDING_MANIFEST,
 } from '../src/models/core-embedding-asset.js';
 
+const BUNDLED_MODEL_LICENSE_SHA256 = '587a673933425dbc36ec61268d3b954051b2d3ef3c9b322ede357976055ffdd5';
 const source = Bun.file(new URL(`../${BUNDLED_CORE_EMBEDDING_ASSET_RELATIVE_PATH}`, import.meta.url));
+const license = Bun.file(new URL('../assets/models/licenses/bge-small-en-v1.5.LICENSE', import.meta.url));
 if (!(await source.exists())) {
   throw new Error(`Bundled core embedding model is missing: ${BUNDLED_CORE_EMBEDDING_ASSET_RELATIVE_PATH}`);
 }
@@ -12,9 +14,17 @@ if (source.size !== BUNDLED_CORE_EMBEDDING_MANIFEST.size) {
     `Bundled core embedding model has ${source.size} bytes; expected ${BUNDLED_CORE_EMBEDDING_MANIFEST.size}.`,
   );
 }
-const sha256 = new Bun.CryptoHasher('sha256').update(await source.arrayBuffer()).digest('hex');
+const hash = new Bun.CryptoHasher('sha256');
+for await (const chunk of source.stream()) hash.update(chunk);
+const sha256 = hash.digest('hex');
 if (sha256 !== BUNDLED_CORE_EMBEDDING_MANIFEST.sha256) {
   throw new Error('Bundled core embedding model checksum does not match its manifest.');
+}
+if (!(await license.exists())) {
+  throw new Error('Bundled core embedding model license notice is missing.');
+}
+if (new Bun.CryptoHasher('sha256').update(await license.arrayBuffer()).digest('hex') !== BUNDLED_MODEL_LICENSE_SHA256) {
+  throw new Error('Bundled core embedding model license notice does not match the pinned upstream notice.');
 }
 
 await Bun.write(Bun.stdout, 'Embedded core model source checks passed.\n');

--- a/scripts/check-self-contained.ts
+++ b/scripts/check-self-contained.ts
@@ -169,6 +169,8 @@ const checkSelfContained = Effect.gen(function* () {
   if (yield* fs.exists(path.join(root, 'dist'))) {
     const canonicalLogo = path.join(root, 'assets', 'brand', 'threadnote-logo.svg');
     const packagedLogo = path.join(root, 'dist', 'assets', 'brand', 'threadnote-logo.svg');
+    const canonicalModelLicense = path.join(root, 'assets', 'models', 'licenses', 'bge-small-en-v1.5.LICENSE');
+    const packagedModelLicense = path.join(root, 'dist', 'assets', 'models', 'licenses', 'bge-small-en-v1.5.LICENSE');
     for (const directory of FORBIDDEN_RELEASE_DIRECTORIES) {
       if (yield* fs.exists(path.join(root, 'dist', directory))) {
         failures.push(`standalone build output contains website content: dist/${directory}`);
@@ -185,6 +187,7 @@ const checkSelfContained = Effect.gen(function* () {
       path.join(root, 'dist', 'cursor-plugin', 'rules', 'threadnote.mdc'),
       path.join(root, 'dist', 'cursor-plugin', 'LICENSE'),
       packagedLogo,
+      packagedModelLicense,
       path.join(root, 'dist', 'assets', 'code-graph', 'manifest.json'),
       path.join(root, 'dist', 'assets', 'code-graph', 'runtime', 'web-tree-sitter.wasm'),
       path.join(root, 'dist', 'assets', 'code-graph', 'grammars', 'java.wasm'),
@@ -205,6 +208,13 @@ const checkSelfContained = Effect.gen(function* () {
       (yield* sha256FileHex(canonicalLogo)) !== (yield* sha256FileHex(packagedLogo))
     ) {
       failures.push('standalone build output does not contain the canonical Threadnote logo');
+    }
+    if (
+      (yield* fs.exists(canonicalModelLicense)) &&
+      (yield* fs.exists(packagedModelLicense)) &&
+      (yield* sha256FileHex(canonicalModelLicense)) !== (yield* sha256FileHex(packagedModelLicense))
+    ) {
+      failures.push('standalone build output does not contain the pinned BGE Small license notice');
     }
     if (yield* fs.exists(path.join(root, 'dist', 'assets', 'code-graph', 'manifest.json'))) {
       yield* validateCodeGraphAssets(fs, path, path.join(root, 'dist', 'assets', 'code-graph'), failures);

--- a/src/model-assets.d.ts
+++ b/src/model-assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.gguf' {
+  const path: string;
+  export default path;
+}

--- a/src/models/bundled-model-source.ts
+++ b/src/models/bundled-model-source.ts
@@ -1,0 +1,12 @@
+import {Effect} from 'effect';
+import {fromPromise} from '../effect/errors.js';
+
+export type BundledModelSourceExtractor = (
+  sourcePath: string,
+  destinationPath: string,
+) => Effect.Effect<number, unknown>;
+
+export const extractBundledModelSource: BundledModelSourceExtractor = Effect.fn('models.extractBundledModelSource')(
+  (sourcePath, destinationPath) =>
+    fromPromise('extract bundled model', () => Bun.write(destinationPath, Bun.file(sourcePath))),
+);

--- a/src/models/commands.ts
+++ b/src/models/commands.ts
@@ -2,6 +2,7 @@ import {Console, Effect} from 'effect';
 import type {RuntimeConfig} from '../types.js';
 import {LocalModelRuntime} from '../effect/ai/local-model-runtime.js';
 import {LocalModelCatalog, type LocalModelRole} from './catalog.js';
+import {bundledCoreEmbeddingSource} from './core-embedding-asset.js';
 import {LocalModelStore, modelDownloadUrl} from './store.js';
 import {readModelSelection, selectLocalModel} from './selection.js';
 
@@ -33,16 +34,23 @@ export const runModelInstall = Effect.fn('models.command.install')(function* (
   const catalog = yield* LocalModelCatalog;
   const manifest = yield* catalog.get(modelId);
   const store = yield* LocalModelStore;
+  const bundledSource = bundledCoreEmbeddingSource(manifest);
   if (options.dryRun === true) {
-    yield* Console.log(`Would download ${modelDownloadUrl(manifest)}.`);
+    yield* Console.log(
+      bundledSource
+        ? `Would install ${manifest.id} from the Threadnote executable.`
+        : `Would download ${modelDownloadUrl(manifest)}.`,
+    );
     yield* Console.log(`Would verify ${manifest.size} bytes and SHA-256 ${manifest.sha256}.`);
     yield* Console.log(`Would install to the Threadnote ${manifest.role} model store.`);
     return;
   }
   yield* Console.log(
-    `Downloading ${manifest.id} (${formatBytes(manifest.size)}); interrupted downloads are resumable.`,
+    bundledSource
+      ? `Installing bundled ${manifest.id} (${formatBytes(manifest.size)}).`
+      : `Downloading ${manifest.id} (${formatBytes(manifest.size)}); interrupted downloads are resumable.`,
   );
-  const installed = yield* store.install(config.agentContextHome, manifest);
+  const installed = yield* store.install(config.agentContextHome, manifest, bundledSource);
   yield* Console.log(
     `${installed.resumed ? 'Resumed and installed' : 'Installed'} ${manifest.id}; checksum verified at ${installed.path}.`,
   );

--- a/src/models/core-embedding-asset.ts
+++ b/src/models/core-embedding-asset.ts
@@ -1,0 +1,30 @@
+import coreEmbeddingModelPath from '../../embedded/models/bge-small-en-v1.5-q8/f046db1dc724cf4f6f0a0c5917e922823b73eb1d27b8f9a9c2797f7866974804.gguf' with {type: 'file'};
+import type {LocalModelManifest} from './catalog.js';
+import {BUILTIN_MODEL_MANIFESTS, CORE_EMBEDDING_MODEL_ID} from './builtin.js';
+
+export const BUNDLED_CORE_EMBEDDING_ASSET_RELATIVE_PATH =
+  'embedded/models/bge-small-en-v1.5-q8/f046db1dc724cf4f6f0a0c5917e922823b73eb1d27b8f9a9c2797f7866974804.gguf';
+
+export const BUNDLED_CORE_EMBEDDING_MANIFEST = BUILTIN_MODEL_MANIFESTS.find(
+  manifest => manifest.id === CORE_EMBEDDING_MODEL_ID,
+)!;
+
+export interface BundledModelSource {
+  readonly sourcePath: string;
+  readonly sourceUrl: string;
+}
+
+export function bundledCoreEmbeddingSource(manifest: LocalModelManifest): BundledModelSource | undefined {
+  if (
+    manifest.id !== BUNDLED_CORE_EMBEDDING_MANIFEST.id ||
+    manifest.role !== 'embedding' ||
+    manifest.sha256 !== BUNDLED_CORE_EMBEDDING_MANIFEST.sha256 ||
+    manifest.size !== BUNDLED_CORE_EMBEDDING_MANIFEST.size
+  ) {
+    return undefined;
+  }
+  return {
+    sourcePath: coreEmbeddingModelPath,
+    sourceUrl: `embedded://threadnote/${manifest.id}/${manifest.sha256}.gguf`,
+  };
+}

--- a/src/models/core-embedding.ts
+++ b/src/models/core-embedding.ts
@@ -2,6 +2,7 @@ import {Console, Effect, Result} from 'effect';
 import type {RuntimeConfig} from '../types.js';
 import {CORE_EMBEDDING_MODEL_ID} from './builtin.js';
 import {LocalModelCatalog, type LocalModelManifest} from './catalog.js';
+import {bundledCoreEmbeddingSource} from './core-embedding-asset.js';
 import {readModelSelection, selectLocalModel} from './selection.js';
 import {LocalModelStore, modelDownloadUrl} from './store.js';
 
@@ -27,10 +28,15 @@ export const provisionCoreEmbedding = Effect.fn('models.provisionCoreEmbedding')
       : yield* catalog.get(CORE_EMBEDDING_MODEL_ID);
   const status = yield* store.status(config.agentContextHome, manifest);
   const needsSelection = selection.roles.embedding !== manifest.id;
+  const bundledSource = bundledCoreEmbeddingSource(manifest);
 
   if (options.dryRun === true) {
     if (!status.installed) {
-      yield* Console.log(`Would download core embedding model ${manifest.id} from ${modelDownloadUrl(manifest)}.`);
+      yield* Console.log(
+        bundledSource
+          ? `Would install bundled core embedding model ${manifest.id}.`
+          : `Would download core embedding model ${manifest.id} from ${modelDownloadUrl(manifest)}.`,
+      );
       yield* Console.log(`Would verify ${manifest.size} bytes and SHA-256 ${manifest.sha256}.`);
     } else {
       yield* Console.log(`Would verify installed core embedding model ${manifest.id}.`);
@@ -44,16 +50,20 @@ export const provisionCoreEmbedding = Effect.fn('models.provisionCoreEmbedding')
   }
 
   if (!status.installed) {
-    yield* Console.log(`Downloading core embedding model ${manifest.id}; interrupted downloads are resumable.`);
+    yield* Console.log(
+      bundledSource
+        ? `Installing bundled core embedding model ${manifest.id}.`
+        : `Downloading core embedding model ${manifest.id}; interrupted downloads are resumable.`,
+    );
   }
-  const install = store.install(config.agentContextHome, manifest);
+  const install = store.install(config.agentContextHome, manifest, bundledSource);
   if (status.installed) {
     yield* install.pipe(
       Effect.catchTag('ModelChecksumMismatch', () =>
         Effect.gen(function* () {
-          yield* Console.warn(`Installed ${manifest.id} failed verification; downloading a verified replacement.`);
+          yield* Console.warn(`Installed ${manifest.id} failed verification; installing a verified replacement.`);
           yield* store.remove(config.agentContextHome, manifest);
-          yield* store.install(config.agentContextHome, manifest);
+          yield* store.install(config.agentContextHome, manifest, bundledSource);
         }),
       ),
     );

--- a/src/models/store.ts
+++ b/src/models/store.ts
@@ -6,6 +6,7 @@ import {
   ModelNotInstalled,
 } from '../effect/ai/errors.js';
 import {sha256FileHex} from '../effect/digest.js';
+import {fromPromise} from '../effect/errors.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
 import {HttpService, type HttpServiceShape} from '../effect/http.js';
 import {SystemInfo, type SystemInfoShape} from '../effect/system.js';
@@ -23,6 +24,11 @@ export interface LocalModelInstallation {
 export interface LocalModelInstallResult extends LocalModelInstallation {
   readonly resumed: boolean;
   readonly sourceUrl: string;
+}
+
+export interface LocalModelInstallOptions {
+  readonly sourcePath?: string;
+  readonly sourceUrl?: string;
 }
 
 export interface LocalModelLockEvent {
@@ -51,7 +57,7 @@ export interface LocalModelStoreShape {
   readonly install: (
     home: string,
     manifest: LocalModelManifest,
-    options?: {readonly sourceUrl?: string},
+    options?: LocalModelInstallOptions,
   ) => Effect.Effect<LocalModelInstallResult, LocalModelStoreError>;
   readonly path: (home: string, manifest: LocalModelManifest) => string;
   readonly remove: (home: string, manifest: LocalModelManifest) => Effect.Effect<boolean, LocalModelStoreError>;
@@ -229,6 +235,7 @@ function makeLocalModelStore(
         'install',
         Effect.gen(function* () {
           const current = yield* status(home, manifest);
+          const sourcePath = options?.sourcePath;
           const sourceUrl = options?.sourceUrl ?? modelDownloadUrl(manifest);
           const directory = modelDirectory(path, home, manifest);
           if (current.installed) {
@@ -244,7 +251,10 @@ function makeLocalModelStore(
           }
           const partial = partialPath(home, manifest);
           yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
-          let offset = current.partialBytes;
+          let offset = sourcePath === undefined ? current.partialBytes : 0;
+          if (sourcePath !== undefined && current.partialBytes > 0) {
+            yield* fs.remove(partial, {force: true});
+          }
           if (offset > manifest.size) {
             yield* fs.remove(partial, {force: true});
             offset = 0;
@@ -261,23 +271,46 @@ function makeLocalModelStore(
             ),
           );
           if (availableBytes !== undefined) {
-            yield* assertSufficientModelDiskSpace(manifest, availableBytes, manifest.size - offset);
+            yield* assertSufficientModelDiskSpace(
+              manifest,
+              availableBytes,
+              sourcePath === undefined ? manifest.size - offset : manifest.size,
+            );
           }
-          const response = yield* http.downloadToFile(sourceUrl, partial, {offset}).pipe(
-            Effect.mapError(
-              cause =>
-                new ModelDownloadFailed({
-                  cause,
-                  message: `Could not download model ${manifest.id}: ${cause.message}`,
-                  modelId: manifest.id,
-                }),
-            ),
-          );
+          const resumed =
+            sourcePath === undefined
+              ? yield* http.downloadToFile(sourceUrl, partial, {offset}).pipe(
+                  Effect.map(response => offset > 0 && response.resumed),
+                  Effect.mapError(
+                    cause =>
+                      new ModelDownloadFailed({
+                        cause,
+                        message: `Could not download model ${manifest.id}: ${cause.message}`,
+                        modelId: manifest.id,
+                      }),
+                  ),
+                )
+              : yield* fromPromise('extract bundled model', () => Bun.write(partial, Bun.file(sourcePath))).pipe(
+                  Effect.mapError(
+                    cause =>
+                      new ModelStoreIoFailed({
+                        cause,
+                        message: `Could not extract bundled model ${manifest.id}.`,
+                        modelId: manifest.id,
+                        operation: 'extract-bundled-source',
+                      }),
+                  ),
+                  Effect.as(false),
+                );
           const downloadedBytes = Number((yield* fs.stat(partial)).size);
           if (downloadedBytes !== manifest.size) {
+            if (sourcePath !== undefined) yield* fs.remove(partial, {force: true});
             return yield* new ModelDownloadFailed({
               cause: {actualBytes: downloadedBytes, expectedBytes: manifest.size},
-              message: `Model ${manifest.id} download has ${downloadedBytes} bytes; expected ${manifest.size}. The partial file was retained for resume.`,
+              message:
+                sourcePath === undefined
+                  ? `Model ${manifest.id} download has ${downloadedBytes} bytes; expected ${manifest.size}. The partial file was retained for resume.`
+                  : `Bundled model ${manifest.id} has ${downloadedBytes} bytes; expected ${manifest.size}.`,
               modelId: manifest.id,
             });
           }
@@ -296,7 +329,7 @@ function makeLocalModelStore(
             modelId: manifest.id,
             partialBytes: 0,
             path: installedPath,
-            resumed: offset > 0 && response.resumed,
+            resumed,
             sourceUrl,
             verified: true,
           };

--- a/src/models/store.ts
+++ b/src/models/store.ts
@@ -6,10 +6,10 @@ import {
   ModelNotInstalled,
 } from '../effect/ai/errors.js';
 import {sha256FileHex} from '../effect/digest.js';
-import {fromPromise} from '../effect/errors.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
 import {HttpService, type HttpServiceShape} from '../effect/http.js';
 import {SystemInfo, type SystemInfoShape} from '../effect/system.js';
+import {extractBundledModelSource, type BundledModelSourceExtractor} from './bundled-model-source.js';
 import type {LocalModelManifest} from './catalog.js';
 
 export interface LocalModelInstallation {
@@ -38,6 +38,7 @@ export interface LocalModelLockEvent {
 }
 
 export interface LocalModelStoreLayerOptions {
+  readonly extractBundledSource?: BundledModelSourceExtractor;
   readonly onModelLockAcquired?: (event: LocalModelLockEvent) => Effect.Effect<void, never>;
   readonly onModelLockCompleted?: (event: LocalModelLockEvent) => Effect.Effect<void, never>;
   readonly onModelLockContention?: (event: LocalModelLockEvent) => Effect.Effect<void, never>;
@@ -228,115 +229,118 @@ function makeLocalModelStore(
     );
   };
   return {
-    install: (home, manifest, options) =>
-      withModelLock(
+    install: (home, manifest, options) => {
+      const sourcePath = options?.sourcePath;
+      const install = Effect.gen(function* () {
+        const current = yield* status(home, manifest);
+        const sourceUrl = options?.sourceUrl ?? modelDownloadUrl(manifest);
+        const directory = modelDirectory(path, home, manifest);
+        if (current.installed) {
+          const verified = yield* verifyUnlocked(home, manifest, false).pipe(Effect.result);
+          if (Result.isSuccess(verified)) {
+            return {...verified.success, resumed: false, sourceUrl};
+          }
+          if (!(verified.failure instanceof ModelChecksumMismatch)) {
+            return yield* Effect.fail(verified.failure);
+          }
+          yield* fs.remove(modelPath(home, manifest), {force: true});
+          yield* fs.remove(path.join(directory, 'manifest.json'), {force: true});
+        }
+        const partial = partialPath(home, manifest);
+        yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
+        let offset = sourcePath === undefined ? current.partialBytes : 0;
+        if (sourcePath !== undefined && current.partialBytes > 0) {
+          yield* fs.remove(partial, {force: true});
+        }
+        if (offset > manifest.size) {
+          yield* fs.remove(partial, {force: true});
+          offset = 0;
+        }
+        const availableBytes = yield* system.availableDiskBytes(directory).pipe(
+          Effect.mapError(
+            cause =>
+              new ModelStoreIoFailed({
+                cause,
+                message: `Could not inspect free space before downloading ${manifest.id}.`,
+                modelId: manifest.id,
+                operation: 'disk-space-preflight',
+              }),
+          ),
+        );
+        if (availableBytes !== undefined) {
+          yield* assertSufficientModelDiskSpace(
+            manifest,
+            availableBytes,
+            sourcePath === undefined ? manifest.size - offset : manifest.size,
+          );
+        }
+        const resumed =
+          sourcePath === undefined
+            ? yield* http.downloadToFile(sourceUrl, partial, {offset}).pipe(
+                Effect.map(response => offset > 0 && response.resumed),
+                Effect.mapError(
+                  cause =>
+                    new ModelDownloadFailed({
+                      cause,
+                      message: `Could not download model ${manifest.id}: ${cause.message}`,
+                      modelId: manifest.id,
+                    }),
+                ),
+              )
+            : yield* (layerOptions.extractBundledSource ?? extractBundledModelSource)(sourcePath, partial).pipe(
+                Effect.tapError(() => fs.remove(partial, {force: true}).pipe(Effect.ignore)),
+                Effect.mapError(
+                  cause =>
+                    new ModelStoreIoFailed({
+                      cause,
+                      message: `Could not extract bundled model ${manifest.id}.`,
+                      modelId: manifest.id,
+                      operation: 'extract-bundled-source',
+                    }),
+                ),
+                Effect.as(false),
+              );
+        const downloadedBytes = Number((yield* fs.stat(partial)).size);
+        if (downloadedBytes !== manifest.size) {
+          if (sourcePath !== undefined) yield* fs.remove(partial, {force: true});
+          return yield* new ModelDownloadFailed({
+            cause: {actualBytes: downloadedBytes, expectedBytes: manifest.size},
+            message:
+              sourcePath === undefined
+                ? `Model ${manifest.id} download has ${downloadedBytes} bytes; expected ${manifest.size}. The partial file was retained for resume.`
+                : `Bundled model ${manifest.id} has ${downloadedBytes} bytes; expected ${manifest.size}.`,
+            modelId: manifest.id,
+          });
+        }
+        const digest = yield* providePlatform(sha256FileHex(partial));
+        if (digest !== manifest.sha256) {
+          yield* fs.remove(partial, {force: true});
+          return yield* checksumMismatch(manifest, digest);
+        }
+        const installedPath = modelPath(home, manifest);
+        yield* fs.rename(partial, installedPath);
+        yield* fs.chmod(installedPath, 0o600);
+        yield* writeManifestReceipt(fs, path, directory, manifest);
+        const installed = {
+          bytes: downloadedBytes,
+          installed: true,
+          modelId: manifest.id,
+          partialBytes: 0,
+          path: installedPath,
+          resumed,
+          sourceUrl,
+          verified: true,
+        };
+        yield* cacheVerifiedInstallation(home, manifest, installed);
+        return installed;
+      });
+      return withModelLock(
         home,
         manifest,
         'install',
-        Effect.gen(function* () {
-          const current = yield* status(home, manifest);
-          const sourcePath = options?.sourcePath;
-          const sourceUrl = options?.sourceUrl ?? modelDownloadUrl(manifest);
-          const directory = modelDirectory(path, home, manifest);
-          if (current.installed) {
-            const verified = yield* verifyUnlocked(home, manifest, false).pipe(Effect.result);
-            if (Result.isSuccess(verified)) {
-              return {...verified.success, resumed: false, sourceUrl};
-            }
-            if (!(verified.failure instanceof ModelChecksumMismatch)) {
-              return yield* Effect.fail(verified.failure);
-            }
-            yield* fs.remove(modelPath(home, manifest), {force: true});
-            yield* fs.remove(path.join(directory, 'manifest.json'), {force: true});
-          }
-          const partial = partialPath(home, manifest);
-          yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
-          let offset = sourcePath === undefined ? current.partialBytes : 0;
-          if (sourcePath !== undefined && current.partialBytes > 0) {
-            yield* fs.remove(partial, {force: true});
-          }
-          if (offset > manifest.size) {
-            yield* fs.remove(partial, {force: true});
-            offset = 0;
-          }
-          const availableBytes = yield* system.availableDiskBytes(directory).pipe(
-            Effect.mapError(
-              cause =>
-                new ModelStoreIoFailed({
-                  cause,
-                  message: `Could not inspect free space before downloading ${manifest.id}.`,
-                  modelId: manifest.id,
-                  operation: 'disk-space-preflight',
-                }),
-            ),
-          );
-          if (availableBytes !== undefined) {
-            yield* assertSufficientModelDiskSpace(
-              manifest,
-              availableBytes,
-              sourcePath === undefined ? manifest.size - offset : manifest.size,
-            );
-          }
-          const resumed =
-            sourcePath === undefined
-              ? yield* http.downloadToFile(sourceUrl, partial, {offset}).pipe(
-                  Effect.map(response => offset > 0 && response.resumed),
-                  Effect.mapError(
-                    cause =>
-                      new ModelDownloadFailed({
-                        cause,
-                        message: `Could not download model ${manifest.id}: ${cause.message}`,
-                        modelId: manifest.id,
-                      }),
-                  ),
-                )
-              : yield* fromPromise('extract bundled model', () => Bun.write(partial, Bun.file(sourcePath))).pipe(
-                  Effect.mapError(
-                    cause =>
-                      new ModelStoreIoFailed({
-                        cause,
-                        message: `Could not extract bundled model ${manifest.id}.`,
-                        modelId: manifest.id,
-                        operation: 'extract-bundled-source',
-                      }),
-                  ),
-                  Effect.as(false),
-                );
-          const downloadedBytes = Number((yield* fs.stat(partial)).size);
-          if (downloadedBytes !== manifest.size) {
-            if (sourcePath !== undefined) yield* fs.remove(partial, {force: true});
-            return yield* new ModelDownloadFailed({
-              cause: {actualBytes: downloadedBytes, expectedBytes: manifest.size},
-              message:
-                sourcePath === undefined
-                  ? `Model ${manifest.id} download has ${downloadedBytes} bytes; expected ${manifest.size}. The partial file was retained for resume.`
-                  : `Bundled model ${manifest.id} has ${downloadedBytes} bytes; expected ${manifest.size}.`,
-              modelId: manifest.id,
-            });
-          }
-          const digest = yield* providePlatform(sha256FileHex(partial));
-          if (digest !== manifest.sha256) {
-            yield* fs.remove(partial, {force: true});
-            return yield* checksumMismatch(manifest, digest);
-          }
-          const installedPath = modelPath(home, manifest);
-          yield* fs.rename(partial, installedPath);
-          yield* fs.chmod(installedPath, 0o600);
-          yield* writeManifestReceipt(fs, path, directory, manifest);
-          const installed = {
-            bytes: downloadedBytes,
-            installed: true,
-            modelId: manifest.id,
-            partialBytes: 0,
-            path: installedPath,
-            resumed,
-            sourceUrl,
-            verified: true,
-          };
-          yield* cacheVerifiedInstallation(home, manifest, installed);
-          return installed;
-        }),
-      ),
+        sourcePath === undefined ? install : Effect.uninterruptible(install),
+      );
+    },
     path: modelPath,
     remove: (home, manifest) =>
       withModelLock(

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -238,8 +238,8 @@ describe('platform benchmark workflow', () => {
       release_ref: '${{ github.ref }}',
       release_sha: '${{ github.sha }}',
     });
-    expect(linux.needs).toBe('prepare-release-model');
-    expect(macos.needs).toBe('prepare-release-model');
+    expect(linux.needs).toBe('verify');
+    expect(macos.needs).toBe('verify');
 
     expect(publish.needs).toEqual(['verify', 'linux', 'macos']);
     expect(publish.if).toContain("needs.verify.result == 'success'");

--- a/test/unit/ci-workflow.test.ts
+++ b/test/unit/ci-workflow.test.ts
@@ -147,7 +147,7 @@ describe('dependency-aware CI workflow', () => {
     ]);
   });
 
-  it('gates quality, Windows, bytecode, model, and release matrices independently', () => {
+  it('gates quality, Windows, bytecode, and self-contained release matrices independently', () => {
     const jobs = workflow('.github/workflows/ci.yml').jobs;
 
     expect(jobs['recall-quality']).toMatchObject({
@@ -158,15 +158,14 @@ describe('dependency-aware CI workflow', () => {
       needs: 'changes',
       if: "needs.changes.outputs.windows == 'true'",
     });
-    for (const name of ['prepare-e2e-model', 'standalone-targets']) {
-      expect(jobs[name]).toMatchObject({
-        needs: 'changes',
-        if: "needs.changes.outputs.release == 'true'",
-      });
-    }
+    expect(jobs['prepare-e2e-model']).toBeUndefined();
+    expect(jobs['standalone-targets']).toMatchObject({
+      needs: 'changes',
+      if: "needs.changes.outputs.release == 'true'",
+    });
     expect(jobs['self-contained-distribution']).toMatchObject({
-      needs: ['changes', 'prepare-e2e-model'],
-      if: "needs.changes.outputs.release == 'true' && needs.prepare-e2e-model.result == 'success'",
+      needs: 'changes',
+      if: "needs.changes.outputs.release == 'true'",
     });
   });
 

--- a/test/unit/model-store-bundled.property.test.ts
+++ b/test/unit/model-store-bundled.property.test.ts
@@ -1,0 +1,106 @@
+import {createHash} from 'node:crypto';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path, Result} from 'effect';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import type {LocalModelManifest} from '../../src/models/catalog.js';
+import {BUNDLED_CORE_EMBEDDING_MANIFEST, bundledCoreEmbeddingSource} from '../../src/models/core-embedding-asset.js';
+import {BUILTIN_MODEL_MANIFESTS} from '../../src/models/builtin.js';
+import {LocalModelStore} from '../../src/models/store.js';
+
+describe('bundled model installation', () => {
+  it('routes only the exact pinned core embedding manifest to the executable asset', () => {
+    expect(bundledCoreEmbeddingSource(BUNDLED_CORE_EMBEDDING_MANIFEST)).toMatchObject({
+      sourceUrl: `embedded://threadnote/${BUNDLED_CORE_EMBEDDING_MANIFEST.id}/${BUNDLED_CORE_EMBEDDING_MANIFEST.sha256}.gguf`,
+    });
+    for (const manifest of BUILTIN_MODEL_MANIFESTS.filter(
+      candidate => candidate.id !== BUNDLED_CORE_EMBEDDING_MANIFEST.id,
+    )) {
+      expect(bundledCoreEmbeddingSource(manifest)).toBeUndefined();
+    }
+    expect(bundledCoreEmbeddingSource({...BUNDLED_CORE_EMBEDDING_MANIFEST, sha256: '0'.repeat(64)})).toBeUndefined();
+  });
+
+  effectIt.layer(ApplicationLayer)(layerIt => {
+    layerIt.effect.prop(
+      'atomically promotes exactly the verified bundled bytes and rejects same-size mutations',
+      {bytes: fc.uint8Array({maxLength: 128, minLength: 1})},
+      ({bytes}) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const store = yield* LocalModelStore;
+            const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-bundled-model-property-'});
+            const source = path.join(root, 'source.gguf');
+            const validHome = path.join(root, 'valid-home');
+            const invalidHome = path.join(root, 'invalid-home');
+            const truncatedHome = path.join(root, 'truncated-home');
+            const manifest = fixtureManifest(bytes);
+
+            yield* fs.writeFile(source, bytes);
+            const installed = yield* store.install(validHome, manifest, {
+              sourcePath: source,
+              sourceUrl: 'embedded://threadnote/fixture.gguf',
+            });
+            expect(installed).toMatchObject({
+              bytes: bytes.length,
+              installed: true,
+              resumed: false,
+              sourceUrl: 'embedded://threadnote/fixture.gguf',
+              verified: true,
+            });
+            expect(Uint8Array.from(yield* fs.readFile(installed.path))).toEqual(bytes);
+            expect(yield* fs.exists(`${installed.path}.partial`)).toBe(false);
+
+            const mutated = Uint8Array.from(bytes);
+            mutated[0] = mutated[0]! ^ 0xff;
+            yield* fs.writeFile(source, mutated);
+            const rejected = yield* store
+              .install(invalidHome, manifest, {sourcePath: source, sourceUrl: 'embedded://threadnote/fixture.gguf'})
+              .pipe(Effect.result);
+            expect(Result.isFailure(rejected)).toBe(true);
+            if (Result.isFailure(rejected)) expect(rejected.failure._tag).toBe('ModelChecksumMismatch');
+            const invalidPath = store.path(invalidHome, manifest);
+            expect(yield* fs.exists(invalidPath)).toBe(false);
+            expect(yield* fs.exists(`${invalidPath}.partial`)).toBe(false);
+
+            yield* fs.writeFile(source, bytes.subarray(1));
+            const truncated = yield* store
+              .install(truncatedHome, manifest, {sourcePath: source, sourceUrl: 'embedded://threadnote/fixture.gguf'})
+              .pipe(Effect.result);
+            expect(Result.isFailure(truncated)).toBe(true);
+            if (Result.isFailure(truncated)) expect(truncated.failure._tag).toBe('ModelDownloadFailed');
+            const truncatedPath = store.path(truncatedHome, manifest);
+            expect(yield* fs.exists(truncatedPath)).toBe(false);
+            expect(yield* fs.exists(`${truncatedPath}.partial`)).toBe(false);
+          }),
+        ),
+      {fastCheck: {numRuns: 50}},
+    );
+  });
+});
+
+function fixtureManifest(bytes: Uint8Array): LocalModelManifest {
+  return {
+    architecture: 'bert',
+    contextLimit: 512,
+    dimensions: 384,
+    file: 'fixture.gguf',
+    id: 'fixture-embedding',
+    license: 'test-only',
+    minimumRamBytes: 1,
+    normalization: 'l2',
+    promptPrefixes: {document: '', query: ''},
+    quantization: 'F32',
+    repository: 'threadnote/fixtures',
+    revision: 'a'.repeat(40),
+    role: 'embedding',
+    runtime: {nodeLlamaCpp: '3.19.1'},
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+    size: bytes.length,
+    task: 'retrieval',
+    version: 1,
+  };
+}

--- a/test/unit/model-store-bundled.property.test.ts
+++ b/test/unit/model-store-bundled.property.test.ts
@@ -1,13 +1,25 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
 import {createHash} from 'node:crypto';
 import {it as effectIt} from '@effect/vitest';
-import {Effect, FileSystem, Path, Result} from 'effect';
+import {Deferred, Effect, Fiber, FileSystem, Layer, Path, Result} from 'effect';
+import {TestClock} from 'effect/testing';
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
-import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {HttpService} from '../../src/effect/http.js';
+import {SystemInfo} from '../../src/effect/system.js';
 import type {LocalModelManifest} from '../../src/models/catalog.js';
 import {BUNDLED_CORE_EMBEDDING_MANIFEST, bundledCoreEmbeddingSource} from '../../src/models/core-embedding-asset.js';
 import {BUILTIN_MODEL_MANIFESTS} from '../../src/models/builtin.js';
-import {LocalModelStore} from '../../src/models/store.js';
+import {LocalModelStore, type LocalModelStoreLayerOptions} from '../../src/models/store.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {TestError} from '../helpers/test-error.js';
+
+const modelStoreTestLayer = (options: LocalModelStoreLayerOptions = {}) =>
+  LocalModelStore.layerWith(options).pipe(
+    Layer.provideMerge(HttpService.layer),
+    Layer.provideMerge(SystemInfo.layer),
+    Layer.provideMerge(BunServices.layer),
+  );
 
 describe('bundled model installation', () => {
   it('routes only the exact pinned core embedding manifest to the executable asset', () => {
@@ -22,7 +34,7 @@ describe('bundled model installation', () => {
     expect(bundledCoreEmbeddingSource({...BUNDLED_CORE_EMBEDDING_MANIFEST, sha256: '0'.repeat(64)})).toBeUndefined();
   });
 
-  effectIt.layer(ApplicationLayer)(layerIt => {
+  effectIt.layer(modelStoreTestLayer())(layerIt => {
     layerIt.effect.prop(
       'atomically promotes exactly the verified bundled bytes and rejects same-size mutations',
       {bytes: fc.uint8Array({maxLength: 128, minLength: 1})},
@@ -80,6 +92,82 @@ describe('bundled model installation', () => {
       {fastCheck: {numRuns: 50}},
     );
   });
+
+  effectIt.effect('holds the model lock until interrupted bundled extraction settles', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-bundled-model-interruption-'});
+        const home = path.join(root, 'home');
+        const bytes = Uint8Array.from([1, 2, 3, 4]);
+        const manifest = fixtureManifest(bytes);
+        const extractionStarted = yield* Deferred.make<void>();
+        const releaseExtraction = yield* Deferred.make<void>();
+        const removeContended = yield* Deferred.make<void>();
+        const completionOrder: string[] = [];
+        const layer = modelStoreTestLayer({
+          extractBundledSource: (_sourcePath, destinationPath) =>
+            Deferred.succeed(extractionStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseExtraction)),
+              Effect.andThen(fs.writeFile(destinationPath, bytes)),
+              Effect.as(bytes.length),
+            ),
+          onModelLockCompleted: event => Effect.sync(() => completionOrder.push(event.operation)).pipe(Effect.asVoid),
+          onModelLockContention: event =>
+            event.operation === 'remove'
+              ? Deferred.succeed(removeContended, undefined).pipe(Effect.asVoid)
+              : Effect.void,
+        });
+
+        yield* Effect.gen(function* () {
+          const store = yield* LocalModelStore;
+          const install = yield* store
+            .install(home, manifest, {sourcePath: 'embedded://fixture', sourceUrl: 'embedded://fixture'})
+            .pipe(Effect.forkChild({startImmediately: true}));
+          yield* Deferred.await(extractionStarted);
+          const interruption = yield* Fiber.interrupt(install).pipe(Effect.forkChild({startImmediately: true}));
+          const remove = yield* store.remove(home, manifest).pipe(Effect.forkChild({startImmediately: true}));
+
+          yield* Deferred.await(removeContended);
+          expect(completionOrder).toEqual([]);
+          yield* Deferred.succeed(releaseExtraction, undefined);
+          yield* Fiber.join(interruption);
+          expect(yield* Fiber.join(remove)).toBe(true);
+          expect(completionOrder).toEqual(['install', 'remove']);
+          expect(yield* fs.exists(store.path(home, manifest))).toBe(false);
+          expect(yield* fs.exists(`${store.path(home, manifest)}.partial`)).toBe(false);
+        }).pipe(provideTestLayer(layer));
+      }).pipe(provideTestLayer(BunServices.layer), Effect.scoped),
+    ),
+  );
+
+  effectIt.effect('cleans a bundled partial when extraction fails', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-bundled-model-failure-'});
+      const home = path.join(root, 'home');
+      const bytes = Uint8Array.from([1, 2, 3, 4]);
+      const manifest = fixtureManifest(bytes);
+      const layer = modelStoreTestLayer({
+        extractBundledSource: (_sourcePath, destinationPath) =>
+          fs
+            .writeFile(destinationPath, bytes)
+            .pipe(Effect.andThen(Effect.fail(new TestError('fixture extraction failed')))),
+      });
+
+      yield* Effect.gen(function* () {
+        const store = yield* LocalModelStore;
+        const result = yield* store
+          .install(home, manifest, {sourcePath: 'embedded://fixture', sourceUrl: 'embedded://fixture'})
+          .pipe(Effect.result);
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) expect(result.failure._tag).toBe('ModelStoreIoFailed');
+        expect(yield* fs.exists(`${store.path(home, manifest)}.partial`)).toBe(false);
+      }).pipe(provideTestLayer(layer));
+    }).pipe(provideTestLayer(BunServices.layer), Effect.scoped),
+  );
 });
 
 function fixtureManifest(bytes: Uint8Array): LocalModelManifest {

--- a/test/unit/publish-workflow.test.ts
+++ b/test/unit/publish-workflow.test.ts
@@ -145,6 +145,7 @@ describe('standalone release workflows', () => {
       const ci = yield* readProjectFile('.github/workflows/ci.yml');
       const asset = yield* readProjectFile('src/models/core-embedding-asset.ts');
       const checker = yield* readProjectFile('scripts/check-embedded-core-model.ts');
+      const modelLicense = yield* readProjectFile('assets/models/licenses/bge-small-en-v1.5.LICENSE');
       const packageManifest = JSON.parse(yield* readProjectFile('package.json')) as {
         readonly scripts?: Readonly<Record<string, string>>;
       };
@@ -153,6 +154,9 @@ describe('standalone release workflows', () => {
       expect(asset).toContain(`${model.sha256}.gguf`);
       expect(asset).toContain("type: 'file'");
       expect(checker).toContain('BUNDLED_CORE_EMBEDDING_MANIFEST.sha256');
+      expect(checker).toContain('BUNDLED_MODEL_LICENSE_SHA256');
+      expect(modelLicense).toContain('Copyright (c) 2022 staoxiao');
+      expect(modelLicense).toContain('The above copyright notice and this permission notice shall be included');
       expect(packageManifest.scripts?.build).toMatch(/^bun scripts\/check-embedded-core-model\.ts && /);
       expect(packageManifest.scripts?.['compile:targets']).toMatch(/^bun scripts\/check-embedded-core-model\.ts && /);
       for (const content of [ci, workflow]) {

--- a/test/unit/publish-workflow.test.ts
+++ b/test/unit/publish-workflow.test.ts
@@ -139,36 +139,30 @@ describe('standalone release workflows', () => {
     }),
   );
 
-  it.effect('prepares one checksum-verified model artifact for every native release runner', () =>
+  it.effect('embeds the checksum-pinned core model in every standalone executable', () =>
     Effect.gen(function* () {
       const workflow = yield* readProjectFile('.github/workflows/publish.yml');
       const ci = yield* readProjectFile('.github/workflows/ci.yml');
+      const asset = yield* readProjectFile('src/models/core-embedding-asset.ts');
+      const checker = yield* readProjectFile('scripts/check-embedded-core-model.ts');
+      const packageManifest = JSON.parse(yield* readProjectFile('package.json')) as {
+        readonly scripts?: Readonly<Record<string, string>>;
+      };
       const model = BUILTIN_MODEL_MANIFESTS.find(candidate => candidate.id === CORE_EMBEDDING_MODEL_ID)!;
-      const fixtureDirectory =
-        '${{ runner.temp }}/threadnote-release-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}';
-      const fixturePath = `${fixtureDirectory}/` + '${{ env.E2E_EMBEDDING_MODEL_SHA256 }}.gguf';
 
-      for (const sharedModelContract of [
-        `E2E_EMBEDDING_MODEL_ID: ${model.id}`,
-        `E2E_EMBEDDING_MODEL_SHA256: ${model.sha256}`,
-        'key: threadnote-e2e-model-${{ env.E2E_EMBEDDING_MODEL_SHA256 }}',
-        'path: artifacts/e2e-model-home/models/embedding/${{ env.E2E_EMBEDDING_MODEL_ID }}',
-      ]) {
-        expect(ci).toContain(sharedModelContract);
-        expect(workflow).toContain(sharedModelContract);
+      expect(asset).toContain(`${model.sha256}.gguf`);
+      expect(asset).toContain("type: 'file'");
+      expect(checker).toContain('BUNDLED_CORE_EMBEDDING_MANIFEST.sha256');
+      expect(packageManifest.scripts?.build).toMatch(/^bun scripts\/check-embedded-core-model\.ts && /);
+      expect(packageManifest.scripts?.['compile:targets']).toMatch(/^bun scripts\/check-embedded-core-model\.ts && /);
+      for (const content of [ci, workflow]) {
+        expect(content).not.toContain('THREADNOTE_E2E_MODEL_PATH');
+        expect(content).not.toContain('E2E_EMBEDDING_MODEL_SHA256');
       }
-      expect(workflow).toContain('prepare-release-model:');
-      expect(workflow).toContain('uses: actions/cache@v6');
-      expect(workflow).toContain("if: steps.release-model-cache.outputs.cache-hit != 'true'");
-      expect(workflow).toContain('models install ${{ env.E2E_EMBEDDING_MODEL_ID }}');
-      expect(workflow).toContain('models verify ${{ env.E2E_EMBEDDING_MODEL_ID }}');
-      expect(workflow).toContain('if-no-files-found: error');
-      expect(workflow.match(/name: release-core-embedding-model/g)).toHaveLength(4);
-      expect(workflow.match(/name: Download pinned release model/g)).toHaveLength(3);
-      expect(workflow.match(/needs: prepare-release-model/g)).toHaveLength(2);
-      expect(workflow).toContain('needs: [verify, prepare-release-model]');
-      expect(workflow.split(`path: ${fixtureDirectory}`).length - 1).toBe(3);
-      expect(workflow.split(`THREADNOTE_E2E_MODEL_PATH: ${fixturePath}`).length - 1).toBe(3);
+      expect(ci).not.toContain('prepare-e2e-model:');
+      expect(workflow).not.toContain('prepare-release-model:');
+      expect(workflow).not.toContain('name: Download pinned release model');
+      expect(workflow.match(/needs: verify/g)).toHaveLength(3);
       expect(workflow.match(/install --no-start/g)).toHaveLength(3);
       expect(workflow.match(/doctor --dry-run --strict/g)).toHaveLength(3);
     }),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,7 @@ if (ciLongRunningGroupName && !ciLongRunningGroup) {
 const ciLongRunningTests = [...new Set(Object.values(ciLongRunningTestGroups).flat())];
 
 export default defineConfig({
+  assetsInclude: ['**/*.gguf'],
   test: {
     // Test files use isolated Threadnote homes, so the production home-scoped
     // parser-slot locks cannot bound child processes across Vitest workers.

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -452,7 +452,7 @@ threadnote doctor`,
           },
           {
             type: 'paragraph',
-            text: "The bootstrap installer downloads an immutable GitHub release, verifies SHA-256, atomically promotes it, and invokes threadnote install. That lifecycle initializes ~/.threadnote, downloads and selects the core BGE Small embedding model, builds recall indexes, and writes supported user-level instructions for Codex, Claude Code, and Copilot. Cursor instructions are installed separately through Cursor's Marketplace. Existing verified models and canonical data are preserved during updates.",
+            text: "The bootstrap installer downloads an immutable GitHub release, verifies SHA-256, atomically promotes it, and invokes threadnote install. That lifecycle initializes ~/.threadnote, extracts and selects the core BGE Small embedding model bundled in the executable, builds recall indexes, and writes supported user-level instructions for Codex, Claude Code, and Copilot. Cursor instructions are installed separately through Cursor's Marketplace. Existing verified models and canonical data are preserved during updates.",
           },
           {
             type: 'note',
@@ -827,7 +827,7 @@ threadnote recall --query "checkout retry contract" --threshold 0.3 --caller-cwd
         body: [
           {
             type: 'paragraph',
-            text: 'Install and repair automatically download, verify, select, and preserve the pinned 36.7 MB BGE Small embedding model. Model manifests pin revision, filename, byte size, SHA-256, license, runtime compatibility, and memory class before atomic promotion.',
+            text: 'Install and repair automatically extract, verify, select, and preserve the pinned 36.7 MB BGE Small embedding model bundled in the standalone executable. Model manifests pin revision, filename, byte size, SHA-256, license, runtime compatibility, and memory class before atomic promotion.',
           },
           {
             type: 'paragraph',
@@ -1746,7 +1746,7 @@ threadnote repair`,
           },
           {
             type: 'paragraph',
-            text: 'Model downloads are resumable. A partial or checksum-mismatched artifact is never selected. A verified existing model is preserved across reinstall and update.',
+            text: 'The bundled core model is installed without a network request. Downloads for additional models are resumable, and a partial or checksum-mismatched artifact is never selected. A verified existing model is preserved across reinstall and update.',
           },
           {
             type: 'paragraph',


### PR DESCRIPTION
## What changed

- embed the pinned 36.7 MB BGE Small GGUF directly in every Bun standalone executable
- extract, checksum-verify, and atomically promote the bundled model during install and repair
- retain resumable network downloads for non-core and custom models
- validate the embedded asset and exact MIT notice before local, CI, and release builds
- remove the redundant CI and release model download and artifact-sharing jobs
- document offline first-run behavior and the bundled-model license boundary

## Why

Some users cannot reliably download the embedding model even from GitHub release artifacts. The model is small enough to ship with Threadnote, so the core semantic-recall path should not require a second network transfer after the executable is installed.

## Impact

Fresh installs can provision and select the default embedding model without network access. Existing verified installations remain preserved. Corrupt local copies are replaced from the verified executable payload. Additional models keep the resumable download path.

## Validation

- rebased onto current origin/main at 7fa11014, post-v4.2.2
- typecheck, lint, focused self-contained checks, and standalone build
- focused unit and property tests, including a 50-run property
- offline executable install, verify, and doctor smoke with dead proxy settings
- dev-cycle full review followed by incremental re-review with zero critical or important findings
- full suite delegated to CI as requested
- Windows CRLF regression fixed with an exact-path LF checkout rule and verified by Windows self-contained CI
