### PR TITLE
feat: add graceful automatic updates

### DIFF
--- a/src/auto_update.ts
+++ b/src/auto_update.ts
@@ -1,0 +1,581 @@
+import {Cause, Clock, Console, Crypto, Effect, Exit, FileSystem, Path, Result} from 'effect';
+import {runDetachedCommandEffect} from './effect/command.js';
+import {applicationError} from './effect/errors.js';
+import {syncDirectoryBestEffort, syncWritableFile} from './effect/file_durability.js';
+import {FileLockTimeout, withExclusiveFileLock} from './effect/file_lock.js';
+import {SystemInfo} from './effect/system.js';
+import {activeInstalledVersion, installationRoot} from './installations.js';
+import {redactSensitiveText} from './scrubber.js';
+import {sendSystemNotification, type SystemNotificationDelivery} from './system_notification.js';
+import type {RuntimeConfig, UpdateOptions} from './types.js';
+import {runUpdate} from './update.js';
+import {isJsonObject} from './utils.js';
+import {isStandaloneThreadnoteBuild} from './version.js';
+import {isDevelopmentBuildVersion} from './version_compare.js';
+
+const AUTO_UPDATE_STATE_FILE = 'auto-update.json';
+const AUTO_UPDATE_LOCK_FILE = '.auto-update.lock';
+const AUTO_UPDATE_STATE_VERSION = 1 as const;
+const FAILURE_NOTIFICATION_ATTEMPT = 3;
+const AUTO_UPDATE_CHECK_INTERVAL_MILLISECONDS = 6 * 60 * 60 * 1_000;
+const AUTO_UPDATE_RUNNING_STALE_MILLISECONDS = 30 * 60 * 1_000;
+const AUTO_UPDATE_FAILURE_RETRY_MILLISECONDS = [15 * 60 * 1_000, 60 * 60 * 1_000, 6 * 60 * 60 * 1_000] as const;
+const AUTO_UPDATE_LOCK_OPTIONS = {
+  heartbeatIntervalMilliseconds: 10_000,
+  retryIntervalMilliseconds: 25,
+  staleAfterMilliseconds: 60_000,
+  waitTimeoutMilliseconds: 0,
+} as const;
+const AUTO_UPDATE_POLICY_LOCK_OPTIONS = {
+  ...AUTO_UPDATE_LOCK_OPTIONS,
+  waitTimeoutMilliseconds: 10_000,
+} as const;
+
+export type AutoUpdatePolicy = 'automatic' | 'notify';
+
+export interface AutoUpdateRun {
+  readonly attempt: number;
+  readonly fromVersion: string;
+  readonly startedAt: string;
+}
+
+export interface AutoUpdateSuccess {
+  readonly completedAt: string;
+  readonly fromVersion: string;
+  readonly notification: SystemNotificationDelivery;
+  readonly repairRequired: boolean;
+  readonly toVersion: string;
+}
+
+export interface AutoUpdateFailure {
+  readonly attempt: number;
+  readonly failedAt: string;
+  readonly fromVersion: string;
+  readonly notification?: SystemNotificationDelivery;
+  readonly summary: string;
+}
+
+export interface AutoUpdateState {
+  readonly lastCheckAt?: string;
+  readonly lastFailure?: AutoUpdateFailure;
+  readonly lastSuccess?: AutoUpdateSuccess;
+  readonly policy: AutoUpdatePolicy;
+  readonly running?: AutoUpdateRun;
+  readonly version: typeof AUTO_UPDATE_STATE_VERSION;
+}
+
+export interface AutoUpdateStatus extends AutoUpdateState {
+  readonly effectivePolicy: AutoUpdatePolicy;
+  readonly policySource: 'default' | 'environment' | 'file';
+}
+
+export type AutoUpdateWorkerResult = 'busy' | 'current' | 'disabled' | 'failed' | 'updated';
+
+export const readAutoUpdateStatus = Effect.fn('autoUpdate.readStatus')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const statePath = yield* autoUpdateStatePath();
+  const hasPersistedState = yield* fs.exists(statePath);
+  const persisted = yield* readAutoUpdateState();
+  const effective = yield* effectiveAutoUpdatePolicy(persisted);
+  return {
+    ...persisted,
+    effectivePolicy: effective.policy,
+    policySource: effective.source === 'environment' ? effective.source : hasPersistedState ? 'file' : 'default',
+  } satisfies AutoUpdateStatus;
+});
+
+export const initializeAutoUpdatePolicy = Effect.fn('autoUpdate.initializePolicy')(function* (
+  policy: AutoUpdatePolicy,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const lockPath = yield* autoUpdateLockPath();
+  return yield* withExclusiveFileLock(
+    fs,
+    lockPath,
+    AUTO_UPDATE_POLICY_LOCK_OPTIONS,
+    Effect.gen(function* () {
+      const statePath = yield* autoUpdateStatePath();
+      if (yield* fs.exists(statePath)) return yield* readAutoUpdateState();
+      const state = emptyAutoUpdateState(policy);
+      yield* writeAutoUpdateState(state);
+      return state;
+    }),
+  );
+});
+
+export const setAutoUpdatePolicy = Effect.fn('autoUpdate.setPolicy')(function* (policy: AutoUpdatePolicy) {
+  const fs = yield* FileSystem.FileSystem;
+  const lockPath = yield* autoUpdateLockPath();
+  return yield* withExclusiveFileLock(
+    fs,
+    lockPath,
+    AUTO_UPDATE_POLICY_LOCK_OPTIONS,
+    Effect.gen(function* () {
+      const current = yield* readAutoUpdateState();
+      const next = {
+        ...current,
+        policy,
+        ...(policy === 'notify' ? {running: undefined} : {}),
+      } satisfies AutoUpdateState;
+      yield* writeAutoUpdateState(next);
+      return next;
+    }),
+  );
+});
+
+export const runAutoUpdatePolicyCommand = Effect.fn('autoUpdate.policyCommand')(function* (
+  policy: AutoUpdatePolicy,
+  dryRun = false,
+) {
+  if (dryRun) {
+    yield* Console.log(
+      policy === 'automatic'
+        ? 'Would enable automatic Threadnote updates.'
+        : 'Would disable automatic Threadnote updates.',
+    );
+    return;
+  }
+  yield* setAutoUpdatePolicy(policy);
+  yield* Console.log(
+    policy === 'automatic'
+      ? 'Automatic Threadnote updates are enabled. Stable installations follow stable releases; beta installations follow the beta channel.'
+      : 'Automatic Threadnote updates are disabled. Threadnote will continue to report available updates.',
+  );
+  if (policy === 'automatic') yield* triggerAutoUpdateIfEnabled();
+});
+
+export const runAutoUpdateStatusCommand = Effect.fn('autoUpdate.statusCommand')(function* (json: boolean) {
+  const status = yield* readAutoUpdateStatus();
+  if (json) {
+    yield* Console.log(JSON.stringify(status, null, 2));
+    return;
+  }
+  yield* Console.log(`Automatic updates: ${status.effectivePolicy === 'automatic' ? 'enabled' : 'disabled'}`);
+  yield* Console.log(`Policy source: ${status.policySource}`);
+  if (status.running) {
+    yield* Console.log(
+      `Update in progress: v${status.running.fromVersion} · attempt ${status.running.attempt} · started ${status.running.startedAt}`,
+    );
+  } else if (status.lastSuccess) {
+    yield* Console.log(
+      `Last update: v${status.lastSuccess.fromVersion} -> v${status.lastSuccess.toVersion} · ${status.lastSuccess.completedAt}`,
+    );
+    yield* Console.log(`System notification: ${status.lastSuccess.notification}`);
+    if (status.lastSuccess.repairRequired) yield* Console.log('Local setup repair still requires attention.');
+  } else {
+    yield* Console.log('No automatic update has completed yet.');
+  }
+  if (status.lastFailure) {
+    yield* Console.log(
+      `Last failure: attempt ${status.lastFailure.attempt} · ${status.lastFailure.failedAt} · ${status.lastFailure.summary}`,
+    );
+  }
+});
+
+export function runThreadnoteUpdateCommand(config: RuntimeConfig, options: UpdateOptions) {
+  const policyMode = options.auto !== undefined;
+  const statusMode = options.status === true || options.json === true;
+  const updateOnlyOption = Boolean(
+    options.allowUntrustedSource ||
+    options.beta ||
+    options.check ||
+    options.force ||
+    options.postUpdate === false ||
+    options.repair === false ||
+    options.source ||
+    options.stable ||
+    options.yes,
+  );
+  if ((policyMode && statusMode) || ((policyMode || statusMode) && updateOnlyOption)) {
+    return Effect.fail(
+      applicationError(
+        'validate update command',
+        new Error('Choose one update mode: automatic-update policy, status, or release installation.'),
+      ),
+    );
+  }
+  if (options.auto) {
+    return runAutoUpdatePolicyCommand(options.auto === 'on' ? 'automatic' : 'notify', options.dryRun);
+  }
+  if (statusMode) return runAutoUpdateStatusCommand(options.json === true);
+  return runUpdate(config, options);
+}
+
+/**
+ * Runs the existing verified updater behind an install-scoped, non-waiting
+ * coordinator lock. Duplicate triggers exit immediately; the owner records a
+ * durable result and emits a best-effort desktop notification.
+ */
+export const runAutoUpdateWorker = Effect.fn('autoUpdate.runWorker')(function* (config: RuntimeConfig) {
+  if (!isStandaloneThreadnoteBuild()) return 'disabled' as const;
+  const fs = yield* FileSystem.FileSystem;
+  const lockPath = yield* autoUpdateLockPath();
+  return yield* withExclusiveFileLock(fs, lockPath, AUTO_UPDATE_LOCK_OPTIONS, runOwnedAutoUpdate(config)).pipe(
+    Effect.catch(error => (error instanceof FileLockTimeout ? Effect.succeed('busy' as const) : Effect.fail(error))),
+  );
+});
+
+export const triggerAutoUpdateIfEnabled = Effect.fn('autoUpdate.triggerIfEnabled')(function* () {
+  if (!isStandaloneThreadnoteBuild()) return false;
+  const fs = yield* FileSystem.FileSystem;
+  const lockPath = yield* autoUpdateLockPath();
+  const claim = yield* withExclusiveFileLock(
+    fs,
+    lockPath,
+    AUTO_UPDATE_LOCK_OPTIONS,
+    Effect.gen(function* () {
+      const state = yield* readAutoUpdateState();
+      const effective = yield* effectiveAutoUpdatePolicy(state);
+      const now = yield* Clock.currentTimeMillis;
+      const activeVersion = yield* activeInstalledVersion();
+      if (
+        effective.policy !== 'automatic' ||
+        !activeVersion ||
+        !isAutoUpdateVersionEligible(activeVersion) ||
+        !isAutoUpdateDue(state, now)
+      ) {
+        return undefined;
+      }
+      const claimedAt = new Date(now).toISOString();
+      yield* writeAutoUpdateState({...state, lastCheckAt: claimedAt, running: undefined});
+      return {claimedAt, previousLastCheckAt: state.lastCheckAt};
+    }),
+  ).pipe(Effect.catch(error => (error instanceof FileLockTimeout ? Effect.succeed(undefined) : Effect.fail(error))));
+  if (!claim) return false;
+  const spawned = yield* spawnDetachedAutoUpdateWorker();
+  if (spawned) return true;
+  yield* restoreFailedSpawnClaim(claim);
+  return false;
+});
+
+export const spawnDetachedAutoUpdateWorker = Effect.fn('autoUpdate.spawnWorker')(function* () {
+  if (!isStandaloneThreadnoteBuild()) return false;
+  const system = yield* SystemInfo;
+  return yield* runDetachedCommandEffect(system.executablePath, ['auto-update-worker']);
+});
+
+/** Pure parser used by status readers and state-machine property tests. */
+export function parseAutoUpdateState(value: unknown): AutoUpdateState | undefined {
+  if (!isJsonObject(value) || value.version !== AUTO_UPDATE_STATE_VERSION || !isAutoUpdatePolicy(value.policy)) {
+    return undefined;
+  }
+  const lastCheckAt = optionalTimestamp(value.lastCheckAt);
+  const running = parseRunning(value.running);
+  const lastSuccess = parseSuccess(value.lastSuccess);
+  const lastFailure = parseFailure(value.lastFailure);
+  if (
+    (value.lastCheckAt !== undefined && lastCheckAt === undefined) ||
+    (value.running !== undefined && running === undefined) ||
+    (value.lastSuccess !== undefined && lastSuccess === undefined) ||
+    (value.lastFailure !== undefined && lastFailure === undefined)
+  ) {
+    return undefined;
+  }
+  return {
+    ...(lastCheckAt ? {lastCheckAt} : {}),
+    ...(lastFailure ? {lastFailure} : {}),
+    ...(lastSuccess ? {lastSuccess} : {}),
+    policy: value.policy,
+    ...(running ? {running} : {}),
+    version: AUTO_UPDATE_STATE_VERSION,
+  };
+}
+
+export function nextAutoUpdateAttempt(state: AutoUpdateState, fromVersion: string): number {
+  return state.lastFailure?.fromVersion === fromVersion ? state.lastFailure.attempt + 1 : 1;
+}
+
+export function isAutoUpdateVersionEligible(version: string): boolean {
+  return !isDevelopmentBuildVersion(version);
+}
+
+export function terminalAutoUpdateState(
+  state: AutoUpdateState,
+  changes: Omit<Partial<AutoUpdateState>, 'running'>,
+): AutoUpdateState {
+  return {...state, ...changes, running: undefined};
+}
+
+export function stateAfterFailedAutoUpdateSpawn(
+  current: AutoUpdateState,
+  claim: {readonly claimedAt: string; readonly previousLastCheckAt?: string},
+): AutoUpdateState | undefined {
+  if (current.lastCheckAt !== claim.claimedAt || current.running) return undefined;
+  return {...current, lastCheckAt: claim.previousLastCheckAt, running: undefined};
+}
+
+export function isAutoUpdateDue(state: AutoUpdateState, nowMilliseconds: number): boolean {
+  if (state.running) {
+    return elapsedMilliseconds(state.running.startedAt, nowMilliseconds) >= AUTO_UPDATE_RUNNING_STALE_MILLISECONDS;
+  }
+  const lastAttemptAt = state.lastFailure?.failedAt ?? state.lastCheckAt;
+  if (!lastAttemptAt) return true;
+  const delay = state.lastFailure
+    ? AUTO_UPDATE_FAILURE_RETRY_MILLISECONDS[
+        Math.min(state.lastFailure.attempt - 1, AUTO_UPDATE_FAILURE_RETRY_MILLISECONDS.length - 1)
+      ]
+    : AUTO_UPDATE_CHECK_INTERVAL_MILLISECONDS;
+  return elapsedMilliseconds(lastAttemptAt, nowMilliseconds) >= delay;
+}
+
+function runOwnedAutoUpdate(config: RuntimeConfig) {
+  return Effect.gen(function* () {
+    const state = yield* readAutoUpdateState();
+    const effective = yield* effectiveAutoUpdatePolicy(state);
+    if (effective.policy !== 'automatic') return 'disabled' as const;
+    const fromVersion = yield* activeInstalledVersion();
+    if (!fromVersion || !isAutoUpdateVersionEligible(fromVersion)) return 'disabled' as const;
+    const startedAt = yield* nowIso();
+    const attempt = nextAutoUpdateAttempt(state, fromVersion);
+    yield* writeAutoUpdateState({
+      ...state,
+      lastCheckAt: startedAt,
+      running: {attempt, fromVersion, startedAt},
+    });
+
+    const update = yield* Effect.exit(runUpdate(config, {yes: true}));
+    const toVersion = (yield* activeInstalledVersion()) ?? fromVersion;
+    if (Exit.isSuccess(update) && toVersion === fromVersion) {
+      yield* writeAutoUpdateState(
+        terminalAutoUpdateState(state, {
+          lastCheckAt: yield* nowIso(),
+          lastFailure: undefined,
+          policy: state.policy,
+        }),
+      );
+      return 'current' as const;
+    }
+
+    if (toVersion !== fromVersion) {
+      const repairRequired = Exit.isFailure(update);
+      const completedAt = yield* nowIso();
+      const pending = {
+        completedAt,
+        fromVersion,
+        notification: 'unavailable' as const,
+        repairRequired,
+        toVersion,
+      } satisfies AutoUpdateSuccess;
+      yield* writeAutoUpdateState(
+        terminalAutoUpdateState(state, {
+          lastCheckAt: completedAt,
+          ...(repairRequired
+            ? {
+                lastFailure: {
+                  attempt,
+                  failedAt: completedAt,
+                  fromVersion,
+                  summary: failureSummary(update.cause),
+                } satisfies AutoUpdateFailure,
+              }
+            : {lastFailure: undefined}),
+          lastSuccess: pending,
+          policy: state.policy,
+        }),
+      );
+      const notification = yield* sendSystemNotification({
+        body: repairRequired
+          ? `Version ${toVersion} is active, but local setup repair needs attention. Run threadnote update --status.`
+          : `Updated from ${fromVersion}. New CLI invocations and the next MCP request will use version ${toVersion}.`,
+        title: repairRequired ? 'Threadnote updated — action required' : `Threadnote updated to v${toVersion}`,
+      });
+      yield* writeAutoUpdateState(
+        terminalAutoUpdateState(state, {
+          lastCheckAt: completedAt,
+          ...(repairRequired
+            ? {
+                lastFailure: {
+                  attempt,
+                  failedAt: completedAt,
+                  fromVersion,
+                  summary: failureSummary(update.cause),
+                } satisfies AutoUpdateFailure,
+              }
+            : {lastFailure: undefined}),
+          lastSuccess: {...pending, notification},
+          policy: state.policy,
+        }),
+      );
+      return 'updated' as const;
+    }
+
+    if (Exit.isSuccess(update)) return 'current' as const;
+
+    const failedAt = yield* nowIso();
+    const failure = {
+      attempt,
+      failedAt,
+      fromVersion,
+      summary: failureSummary(update.cause),
+    } satisfies AutoUpdateFailure;
+    yield* writeAutoUpdateState(
+      terminalAutoUpdateState(state, {lastCheckAt: failedAt, lastFailure: failure, policy: state.policy}),
+    );
+    if (attempt === FAILURE_NOTIFICATION_ATTEMPT) {
+      const notification = yield* sendSystemNotification({
+        body: `Your current version ${fromVersion} remains active. Run threadnote update --status for details.`,
+        title: 'Threadnote could not update',
+      });
+      yield* writeAutoUpdateState(
+        terminalAutoUpdateState(state, {
+          lastCheckAt: failedAt,
+          lastFailure: {...failure, notification},
+          policy: state.policy,
+        }),
+      );
+    }
+    return 'failed' as const;
+  });
+}
+
+function restoreFailedSpawnClaim(claim: {readonly claimedAt: string; readonly previousLastCheckAt?: string}) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const lockPath = yield* autoUpdateLockPath();
+    yield* withExclusiveFileLock(
+      fs,
+      lockPath,
+      AUTO_UPDATE_POLICY_LOCK_OPTIONS,
+      Effect.gen(function* () {
+        const current = yield* readAutoUpdateState();
+        const restored = stateAfterFailedAutoUpdateSpawn(current, claim);
+        if (restored) yield* writeAutoUpdateState(restored);
+      }),
+    );
+  }).pipe(Effect.ignore);
+}
+
+const readAutoUpdateState = Effect.fn('autoUpdate.readState')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const statePath = yield* autoUpdateStatePath();
+  const raw = yield* fs.readFileString(statePath).pipe(Effect.option);
+  if (raw._tag === 'None') return emptyAutoUpdateState('notify');
+  const decoded = Result.try((): unknown => JSON.parse(raw.value));
+  return Result.isSuccess(decoded)
+    ? (parseAutoUpdateState(decoded.success) ?? emptyAutoUpdateState('notify'))
+    : emptyAutoUpdateState('notify');
+});
+
+const writeAutoUpdateState = Effect.fn('autoUpdate.writeState')(function* (state: AutoUpdateState) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const crypto = yield* Crypto.Crypto;
+  const target = yield* autoUpdateStatePath();
+  const directory = path.dirname(target);
+  const temporary = path.join(directory, `.${path.basename(target)}.${yield* crypto.randomUUIDv4}.tmp`);
+  yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
+  yield* Effect.gen(function* () {
+    yield* fs.writeFileString(temporary, `${JSON.stringify(state, null, 2)}\n`, {flag: 'wx', mode: 0o600});
+    yield* syncWritableFile(fs, temporary);
+    yield* fs.rename(temporary, target);
+    yield* syncDirectoryBestEffort(fs, directory);
+  }).pipe(Effect.ensuring(fs.remove(temporary, {force: true}).pipe(Effect.catch(() => Effect.void))));
+});
+
+const autoUpdateStatePath = Effect.fn('autoUpdate.statePath')(function* () {
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  return path.join(installationRoot(path, system), AUTO_UPDATE_STATE_FILE);
+});
+
+const autoUpdateLockPath = Effect.fn('autoUpdate.lockPath')(function* () {
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  return path.join(installationRoot(path, system), AUTO_UPDATE_LOCK_FILE);
+});
+
+const effectiveAutoUpdatePolicy = Effect.fn('autoUpdate.effectivePolicy')(function* (state: AutoUpdateState) {
+  const environment = (yield* SystemInfo).environment();
+  if (
+    environment.CI !== undefined ||
+    environment.NO_UPDATE_NOTIFIER !== undefined ||
+    environment.THREADNOTE_NO_UPDATE_CHECK !== undefined
+  ) {
+    return {policy: 'notify' as const, source: 'environment' as const};
+  }
+  const override = environment.THREADNOTE_AUTO_UPDATE?.trim().toLowerCase();
+  if (override === '1' || override === 'true' || override === 'yes' || override === 'on') {
+    return {policy: 'automatic' as const, source: 'environment' as const};
+  }
+  if (override === '0' || override === 'false' || override === 'no' || override === 'off') {
+    return {policy: 'notify' as const, source: 'environment' as const};
+  }
+  return {policy: state.policy, source: 'file' as const};
+});
+
+const nowIso = Effect.fn('autoUpdate.nowIso')(function* () {
+  return new Date(yield* Clock.currentTimeMillis).toISOString();
+});
+
+function emptyAutoUpdateState(policy: AutoUpdatePolicy): AutoUpdateState {
+  return {policy, version: AUTO_UPDATE_STATE_VERSION};
+}
+
+function failureSummary(cause: Cause.Cause<unknown>): string {
+  return redactSensitiveText(Cause.pretty(cause)).replace(/\s+/g, ' ').trim().slice(0, 500);
+}
+
+function isAutoUpdatePolicy(value: unknown): value is AutoUpdatePolicy {
+  return value === 'automatic' || value === 'notify';
+}
+
+function optionalTimestamp(value: unknown): string | undefined {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+
+function versionString(value: unknown): string | undefined {
+  return typeof value === 'string' && /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(value) ? value : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) && Number(value) > 0 ? Number(value) : undefined;
+}
+
+function elapsedMilliseconds(timestamp: string, nowMilliseconds: number): number {
+  return Math.max(0, nowMilliseconds - Date.parse(timestamp));
+}
+
+function parseRunning(value: unknown): AutoUpdateRun | undefined {
+  if (!isJsonObject(value)) return undefined;
+  const attempt = positiveInteger(value.attempt);
+  const fromVersion = versionString(value.fromVersion);
+  const startedAt = optionalTimestamp(value.startedAt);
+  return attempt && fromVersion && startedAt ? {attempt, fromVersion, startedAt} : undefined;
+}
+
+function parseSuccess(value: unknown): AutoUpdateSuccess | undefined {
+  if (!isJsonObject(value)) return undefined;
+  const completedAt = optionalTimestamp(value.completedAt);
+  const fromVersion = versionString(value.fromVersion);
+  const toVersion = versionString(value.toVersion);
+  const notification = notificationDelivery(value.notification);
+  return completedAt && fromVersion && toVersion && notification && typeof value.repairRequired === 'boolean'
+    ? {completedAt, fromVersion, notification, repairRequired: value.repairRequired, toVersion}
+    : undefined;
+}
+
+function parseFailure(value: unknown): AutoUpdateFailure | undefined {
+  if (!isJsonObject(value)) return undefined;
+  const attempt = positiveInteger(value.attempt);
+  const failedAt = optionalTimestamp(value.failedAt);
+  const fromVersion = versionString(value.fromVersion);
+  const notification = value.notification === undefined ? undefined : notificationDelivery(value.notification);
+  return attempt &&
+    failedAt &&
+    fromVersion &&
+    typeof value.summary === 'string' &&
+    value.summary.length <= 500 &&
+    (value.notification === undefined || notification !== undefined)
+    ? {
+        attempt,
+        failedAt,
+        fromVersion,
+        ...(notification ? {notification} : {}),
+        summary: value.summary,
+      }
+    : undefined;
+}
+
+function notificationDelivery(value: unknown): SystemNotificationDelivery | undefined {
+  return value === 'failed' || value === 'sent' || value === 'unavailable' ? value : undefined;
+}

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -73,7 +73,7 @@ import {
   runShareUnpublish,
 } from './share.js';
 import type {RuntimeConfig} from '../types.js';
-import {maybeNotifyUpdate, maybeRunPostUpdateAfterRepair, runPostUpdate, runUpdate} from '../update.js';
+import {maybeNotifyUpdate, maybeRunPostUpdateAfterRepair, runPostUpdate} from '../update.js';
 import {errorMessage} from '../utils.js';
 import {runVersion} from '../version_command.js';
 import {runManage} from '../manager.js';
@@ -111,6 +111,7 @@ import {
 } from '../code_graph/commands.js';
 import {runProcessDiagnostics} from '../process_diagnostics.js';
 import {runContextBrief} from '../context_brief/commands.js';
+import {initializeAutoUpdatePolicy, runAutoUpdateWorker, runThreadnoteUpdateCommand} from '../auto_update.js';
 import {
   cursorCloudRuntimeConfig,
   runCursorCloudBootstrap,
@@ -270,6 +271,7 @@ const install = Command.make(
     withRuntimeEffect(config =>
       Effect.gen(function* () {
         yield* runInstall(config, options);
+        if (!options.dryRun) yield* initializeAutoUpdatePolicy('automatic');
         yield* maybeRunPostUpdateAfterRepair(config, {dryRun: options.dryRun});
         if (options.withHooks) {
           for (const agent of ['claude', 'codex', 'cursor', 'copilot'] as const) {
@@ -311,18 +313,25 @@ const update = Command.make(
   'update',
   {
     allowUntrustedSource: boolean('allow-untrusted-source', 'Allow a non-default release API source'),
+    auto: optionalChoice('auto', ['on', 'off'], 'Persist automatic updates as on or off'),
     beta: boolean('beta', 'Follow the beta channel: install the newest stable or prerelease release'),
     check: boolean('check', 'Only check whether a newer version is available'),
     dryRun: boolean('dry-run', 'Print update and repair commands without running them'),
     force: boolean('force', 'Reinstall the selected standalone release even if already current'),
+    json: boolean('json', 'Emit versioned machine-readable update status'),
     postUpdate: negatedBoolean('post-update', 'Skip post-update migration prompts'),
     repair: negatedBoolean('repair', 'Skip threadnote repair after updating the package'),
     source: optionalString('source', 'GitHub-compatible releases API URL'),
     stable: boolean('stable', 'Switch to the latest stable release'),
+    status: boolean('status', 'Show automatic update policy and the last background result'),
     yes: boolean('yes', 'Accept applicable post-update actions without prompting'),
   },
-  options => withRuntimeEffect(config => runUpdate(config, options)),
+  options => withRuntimeEffect(config => runThreadnoteUpdateCommand(config, options)),
 ).pipe(Command.withDescription('Install a verified standalone Threadnote release, then repair local integrations'));
+
+const autoUpdateWorker = Command.make('auto-update-worker', {}, () =>
+  withRuntimeEffect(config => runAutoUpdateWorker(config).pipe(Effect.asVoid)),
+).pipe(Command.withDescription('Run one coordinated automatic update attempt'), Command.withHidden);
 
 const postUpdate = Command.make(
   'post-update',
@@ -1737,6 +1746,7 @@ const topLevelCommandRegistrations = [
   registerTopLevelCommand('logs', logs),
   registerTopLevelCommand('report-issue', reportIssue, {productionLog: {mode: 'never'}}),
   registerTopLevelCommand('update', update),
+  registerTopLevelCommand('auto-update-worker', autoUpdateWorker),
   registerTopLevelCommand('post-update', postUpdate),
   registerTopLevelCommand('repair', repair),
   registerTopLevelCommand('start', start),

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -28,6 +28,11 @@ export interface CommandInvocation {
   readonly shell?: string;
 }
 
+export interface DetachedCommandOptions {
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
 export interface StreamingCommandOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly inheritOutput?: boolean;
@@ -85,6 +90,11 @@ export class CommandExecutor extends Context.Service<
       args: readonly string[],
       options?: StreamingCommandOptions,
     ) => Effect.Effect<CommandResult>;
+    readonly spawnDetached?: (
+      executable: string,
+      args: readonly string[],
+      options?: DetachedCommandOptions,
+    ) => Effect.Effect<boolean>;
   }
 >()('threadnote/effect/CommandExecutor') {
   static readonly layer = Layer.effect(
@@ -106,6 +116,10 @@ export class CommandExecutor extends Context.Service<
           executeStreamingCommand(executable, args, options, system).pipe(
             Effect.provideService(ChildProcessSpawner, childProcessSpawner),
             Effect.provideService(Stdio.Stdio, stdio),
+          ),
+        spawnDetached: (executable, args, options) =>
+          spawnDetachedCommand(executable, args, options ?? {}, system).pipe(
+            Effect.provideService(ChildProcessSpawner, childProcessSpawner),
           ),
       });
     }),
@@ -147,6 +161,16 @@ export const runStreamingCommandEffect = Effect.fn('runStreamingCommandEffect')(
 ) {
   const command = yield* CommandExecutor;
   return yield* command.executeStreaming(executable, args, options);
+});
+
+export const runDetachedCommandEffect = Effect.fn('runDetachedCommandEffect')(function* (
+  executable: string,
+  args: readonly string[],
+  options: DetachedCommandOptions = {},
+) {
+  const command = yield* CommandExecutor;
+  if (!command.spawnDetached) return false;
+  return yield* command.spawnDetached(executable, args, options);
 });
 
 export const maybeRunEffect = Effect.fn('maybeRunEffect')(function* (
@@ -386,6 +410,28 @@ const executeStreamingCommand = Effect.fn('CommandExecutor.executeStreaming')(fu
       return Effect.succeed({exitCode: 1, stderr: `${message}\n`, stdout: ''});
     }),
   );
+});
+
+const spawnDetachedCommand = Effect.fn('CommandExecutor.spawnDetached')(function* (
+  executable: string,
+  args: readonly string[],
+  options: DetachedCommandOptions,
+  system: SystemInfoShape,
+) {
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const handle = yield* ChildProcess.make(executable, [...args], {
+        cwd: options.cwd,
+        detached: true,
+        env: options.env ?? system.environment(),
+        stdin: 'ignore',
+        stdout: 'ignore',
+        stderr: 'ignore',
+      });
+      yield* handle.unref.pipe(Effect.asVoid);
+      return true;
+    }),
+  ).pipe(Effect.catch(() => Effect.succeed(false)));
 });
 
 function collectCommandOutput(

--- a/src/effect/mcp_broker_process.ts
+++ b/src/effect/mcp_broker_process.ts
@@ -3,6 +3,9 @@ import {activeInstalledRelease} from '../installations.js';
 import {McpBrokerError, runMcpBroker, type McpBrokerChild} from '../mcp_broker.js';
 import type {StandaloneActiveRelease} from '../standalone_process_lease.js';
 import {SystemInfo, type SystemInfoShape} from './system.js';
+import {triggerAutoUpdateIfEnabled} from '../auto_update.js';
+
+const AUTO_UPDATE_CHECK_INTERVAL_MILLISECONDS = 15 * 60 * 1_000;
 
 interface ActiveReleaseRequest {
   readonly reject: (cause: unknown) => void;
@@ -12,6 +15,15 @@ interface ActiveReleaseRequest {
 /** Runtime boundary for the stable MCP broker's stdio and child process. */
 export const mcpBrokerEffect = Effect.gen(function* () {
   const system = yield* SystemInfo;
+  yield* triggerAutoUpdateIfEnabled().pipe(Effect.ignore);
+  yield* Effect.forkScoped(
+    Effect.forever(
+      Effect.sleep(AUTO_UPDATE_CHECK_INTERVAL_MILLISECONDS).pipe(
+        Effect.andThen(triggerAutoUpdateIfEnabled()),
+        Effect.ignore,
+      ),
+    ),
+  );
   const activeReleaseRequests = yield* Queue.unbounded<ActiveReleaseRequest>();
   yield* Effect.forkScoped(
     Effect.forever(

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -21,8 +21,12 @@ import {CodeGraphAnalysis} from '../code_graph/analysis.js';
 import {CodeGraphParserPool} from '../code_graph/parser_worker.js';
 
 const systemLayer = SystemInfo.layer;
-export const StandaloneBrokerLayer = Layer.merge(systemLayer, BunServices.layer);
 const commandLayer = CommandExecutor.layer.pipe(Layer.provide(systemLayer));
+export const StandaloneBrokerLayer = Layer.mergeAll(
+  systemLayer,
+  BunServices.layer,
+  commandLayer.pipe(Layer.provide(BunServices.layer)),
+);
 const resourceStoreLayer = ResourceStore.layer.pipe(Layer.provide(systemLayer));
 const localModelStoreLayer = LocalModelStore.layer.pipe(
   Layer.provideMerge(HttpService.layer),

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -13,9 +13,10 @@ import {runHandoff, runRecall} from './memory.js';
 import {applyScrubber} from './share.js';
 import {distillTrace} from './trace.js';
 import type {AgentClient, HookRunnerOptions, HooksInstallOptions, JsonObject, RuntimeConfig} from './types.js';
-import {checkForThreadnoteUpdate, spawnDetachedAutoUpdate} from './update-check.js';
+import {checkForThreadnoteUpdate} from './update-check.js';
 import {expandPath, exists, isJsonObject, parseJsonConfigObject, resolveRepoName} from './utils.js';
 import {getThreadnoteVersion} from './version.js';
+import {readAutoUpdateStatus, triggerAutoUpdateIfEnabled} from './auto_update.js';
 
 type HookEvent = 'PreCompact' | 'SessionStart';
 
@@ -223,11 +224,11 @@ export function runSessionStartHook(config: RuntimeConfig, options: HookRunnerOp
   // Hooks must never block session start. Failures fall through quietly so the
   // user just gets a normal session without injected context.
   return Effect.gen(function* () {
+    yield* emitUpdateBannerIfOutdated(config);
     const project = yield* resolveRepoName();
     if (!project) {
       return;
     }
-    yield* emitUpdateBannerIfOutdated(config);
     yield* Console.log(`## Threadnote — latest context for ${project}\n`);
     yield* runRecall(config, {
       dryRun: options.dryRun === true,
@@ -314,26 +315,20 @@ const readStdinWithTimeout = Effect.fn('hooks.readStdin')(function* (timeoutMs: 
 });
 
 function emitUpdateBannerIfOutdated(config: RuntimeConfig) {
-  // Cheap, daily-cached check that nags users to upgrade. Failures are folded
-  // in the Effect error channel so a flaky registry never breaks session start.
-  // With THREADNOTE_AUTO_UPDATE=1, the same code path
-  // spawns `threadnote update --yes` as a detached background process and
-  // tells the user the new version will be active next session.
+  // Automatic mode delegates all network and install work to the detached,
+  // install-scoped coordinator. Notify mode retains the cheap daily banner.
   return Effect.gen(function* () {
+    const autoUpdate = yield* readAutoUpdateStatus();
+    if (autoUpdate.effectivePolicy === 'automatic') {
+      yield* triggerAutoUpdateIfEnabled();
+      return;
+    }
     const path = yield* Path.Path;
-    const system = yield* SystemInfo;
     const result = yield* checkForThreadnoteUpdate({
       cachePath: path.join(config.agentContextHome, '.update-state.json'),
       currentVersion: yield* getThreadnoteVersion(),
     });
     if (!result || !result.outdated) {
-      return;
-    }
-    if (system.environment().THREADNOTE_AUTO_UPDATE === '1') {
-      yield* Console.log(
-        `[threadnote] v${result.latestVersion} available (current v${result.currentVersion}). Auto-updating in the background; the new version takes effect next session.\n`,
-      );
-      yield* spawnDetachedAutoUpdate();
       return;
     }
     yield* Console.log(

--- a/src/manager_state.ts
+++ b/src/manager_state.ts
@@ -7,6 +7,7 @@ import {currentPackageVersion, fetchLatestVersion, releaseSource} from './update
 import {selectUpdateChannel} from './update_channel.js';
 import {findExecutable} from './utils.js';
 import {compareVersions} from './version_compare.js';
+import {readAutoUpdateStatus} from './auto_update.js';
 
 export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationAgents')(function* (
   config: Pick<RuntimeConfig, 'agentContextHome'>,
@@ -41,13 +42,18 @@ export const readManagerRuntimeState = Effect.fn('manager.readRuntimeState')(fun
   config: Pick<RuntimeConfig, 'agentContextHome'>,
 ) {
   const system = yield* SystemInfo;
-  const [agents, version] = yield* Effect.all([detectConsolidationAgents(config), currentPackageVersion()]);
+  const [agents, autoUpdate, version] = yield* Effect.all([
+    detectConsolidationAgents(config),
+    readAutoUpdateStatus(),
+    currentPackageVersion(),
+  ]);
   const latestVersion = yield* fetchLatestVersion(
     releaseSource(system.environment()),
     selectUpdateChannel(version),
   ).pipe(Effect.catch(() => Effect.succeed(undefined)));
   return {
     agents,
+    autoUpdate,
     latestVersion,
     updateAvailable: managerUpdateAvailable(version, latestVersion),
     version,

--- a/src/manager_ui.tsx
+++ b/src/manager_ui.tsx
@@ -6,6 +6,7 @@ import type {CodeGraphLocalDiagnosticsReport} from './code_graph/diagnostics.js'
 import {ManagerAutocompleteInput, ManagerDialogProvider, useManagerDialogs} from './manager_dialog.js';
 import {WorksetsPanel} from './manager_worksets_view.js';
 import {ProcessesPanel} from './manager_processes_view.js';
+import {managerUpdateIndicator} from './manager_update_indicator.js';
 import {
   graphViewRemovalApprovalDialog,
   graphViewRemovalTargetIsAbsent,
@@ -136,6 +137,17 @@ interface AgentOption {
 
 interface StateResponse {
   readonly agents: readonly AgentOption[];
+  readonly autoUpdate: {
+    readonly effectivePolicy: 'automatic' | 'notify';
+    readonly lastFailure?: {readonly attempt: number; readonly failedAt: string; readonly summary: string};
+    readonly lastSuccess?: {
+      readonly completedAt: string;
+      readonly fromVersion: string;
+      readonly repairRequired: boolean;
+      readonly toVersion: string;
+    };
+    readonly running?: {readonly attempt: number; readonly fromVersion: string; readonly startedAt: string};
+  };
   readonly config: {
     readonly account: string;
     readonly agentContextHome: string;
@@ -1134,6 +1146,7 @@ function App(): React.ReactElement {
   const doctorBusyMessage = doctorAction ? `${doctorAction}...` : '';
   const metadataFieldsDisabled = Boolean(memory || selectedIsDir || selectedIsResource);
   const appStyle = {'--sidebar-width': `${sidebarWidth}px`} as React.CSSProperties;
+  const updateIndicator = state ? managerUpdateIndicator(state) : undefined;
 
   return (
     <div className="app" style={appStyle}>
@@ -1269,10 +1282,10 @@ function App(): React.ReactElement {
             </div>
           </div>
         )}
-        {state?.updateAvailable && state.latestVersion ? (
+        {updateIndicator ? (
           <div className="sidebar-update">
-            <span>Update available</span>
-            <strong>v{state.latestVersion}</strong>
+            <span>{updateIndicator.label}</span>
+            <strong>{updateIndicator.detail}</strong>
           </div>
         ) : null}
       </aside>

--- a/src/manager_update_indicator.ts
+++ b/src/manager_update_indicator.ts
@@ -1,0 +1,23 @@
+export function managerUpdateIndicator(state: {
+  readonly autoUpdate: {
+    readonly effectivePolicy: 'automatic' | 'notify';
+    readonly lastSuccess?: {readonly repairRequired: boolean; readonly toVersion: string};
+    readonly running?: {readonly fromVersion: string};
+  };
+  readonly latestVersion?: string;
+  readonly updateAvailable: boolean;
+}): {readonly detail: string; readonly label: string} | undefined {
+  if (state.autoUpdate.running) {
+    return {detail: `from v${state.autoUpdate.running.fromVersion}`, label: 'Updating in background'};
+  }
+  if (state.autoUpdate.lastSuccess?.repairRequired) {
+    return {detail: `v${state.autoUpdate.lastSuccess.toVersion}`, label: 'Update needs attention'};
+  }
+  if (state.updateAvailable && state.latestVersion) {
+    return {
+      detail: `v${state.latestVersion}`,
+      label: state.autoUpdate.effectivePolicy === 'automatic' ? 'Update queued' : 'Update available',
+    };
+  }
+  return undefined;
+}

--- a/src/system_notification.ts
+++ b/src/system_notification.ts
@@ -1,0 +1,98 @@
+import {Effect} from 'effect';
+import {runCommandEffect} from './effect/command.js';
+import {SystemInfo} from './effect/system.js';
+
+const NOTIFICATION_TIMEOUT_MILLISECONDS = 5_000;
+const NOTIFICATION_OUTPUT_LIMIT_BYTES = 4 * 1_024;
+
+export interface SystemNotification {
+  readonly body: string;
+  readonly title: string;
+}
+
+export type SystemNotificationDelivery = 'failed' | 'sent' | 'unavailable';
+
+export interface SystemNotificationInvocation {
+  readonly args: readonly string[];
+  readonly env?: NodeJS.ProcessEnv;
+  readonly executable: string;
+}
+
+/**
+ * Builds an argv-safe, dependency-free desktop notification command for the
+ * current platform. User-facing text is passed as argv or environment data and
+ * is never interpolated into AppleScript or PowerShell source.
+ */
+export function systemNotificationInvocation(
+  platform: NodeJS.Platform,
+  environment: NodeJS.ProcessEnv,
+  notification: SystemNotification,
+): SystemNotificationInvocation | undefined {
+  const title = boundedNotificationText(notification.title, 120);
+  const body = boundedNotificationText(notification.body, 500);
+  if (!title || !body) return undefined;
+  switch (platform) {
+    case 'darwin':
+      return {
+        args: [
+          '-e',
+          'on run argv\n  display notification (item 2 of argv) with title (item 1 of argv)\nend run',
+          '--',
+          title,
+          body,
+        ],
+        executable: '/usr/bin/osascript',
+      };
+    case 'linux':
+      return {
+        args: ['--app-name=Threadnote', '--expire-time=10000', title, body],
+        executable: 'notify-send',
+      };
+    case 'win32': {
+      const systemRoot = (environment.SystemRoot ?? environment.SYSTEMROOT ?? 'C:\\Windows').replace(/[\\/]+$/, '');
+      return {
+        args: ['-NoProfile', '-NonInteractive', '-Command', windowsToastScript],
+        env: {
+          ...environment,
+          THREADNOTE_NOTIFICATION_BODY: body,
+          THREADNOTE_NOTIFICATION_TITLE: title,
+        },
+        executable: `${systemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+      };
+    }
+    default:
+      return undefined;
+  }
+}
+
+/** Best-effort delivery. Notification availability never changes update success. */
+export const sendSystemNotification = Effect.fn('systemNotification.send')(function* (
+  notification: SystemNotification,
+) {
+  const system = yield* SystemInfo;
+  const invocation = systemNotificationInvocation(system.platform, system.environment(), notification);
+  if (!invocation) return 'unavailable' as const;
+  const result = yield* runCommandEffect(invocation.executable, invocation.args, {
+    allowFailure: true,
+    env: invocation.env,
+    maxOutputBytes: NOTIFICATION_OUTPUT_LIMIT_BYTES,
+    timeoutMs: NOTIFICATION_TIMEOUT_MILLISECONDS,
+  }).pipe(Effect.catch(() => Effect.succeed({exitCode: 127, stderr: '', stdout: ''})));
+  if (result.exitCode === 0) return 'sent' as const;
+  return result.exitCode === 127 ? ('unavailable' as const) : ('failed' as const);
+});
+
+function boundedNotificationText(value: string, maximumLength: number): string {
+  return value.replaceAll('\0', '').trim().slice(0, maximumLength);
+}
+
+const windowsToastScript = [
+  '[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null',
+  '[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null',
+  '$title=[Security.SecurityElement]::Escape($env:THREADNOTE_NOTIFICATION_TITLE)',
+  '$body=[Security.SecurityElement]::Escape($env:THREADNOTE_NOTIFICATION_BODY)',
+  '$xml=New-Object Windows.Data.Xml.Dom.XmlDocument',
+  '$xml.LoadXml("<toast><visual><binding template=`"ToastGeneric`"><text>$title</text><text>$body</text></binding></visual></toast>")',
+  '$toast=New-Object Windows.UI.Notifications.ToastNotification $xml',
+  '[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("Threadnote").Show($toast)',
+].join('; ');

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,14 +114,17 @@ export interface UninstallOptions {
 
 export interface UpdateOptions {
   readonly allowUntrustedSource?: boolean;
+  readonly auto?: 'off' | 'on';
   readonly beta?: boolean;
   readonly check?: boolean;
   readonly dryRun?: boolean;
   readonly force?: boolean;
+  readonly json?: boolean;
   readonly postUpdate?: boolean;
   readonly repair?: boolean;
   readonly source?: string;
   readonly stable?: boolean;
+  readonly status?: boolean;
   readonly yes?: boolean;
 }
 

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,10 +1,8 @@
 import {Effect, FileSystem, Path, Result} from 'effect';
-import * as ChildProcess from 'effect/unstable/process/ChildProcess';
 import {SystemInfo} from './effect/system.js';
 import {selectUpdateChannel, type UpdateChannel} from './update_channel.js';
 import {fetchLatestVersion, releaseSource} from './update.js';
 import {compareVersions} from './utils.js';
-import {isStandaloneThreadnoteBuild} from './version.js';
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 3000;
@@ -62,37 +60,6 @@ export function checkForThreadnoteUpdate(args: {readonly cachePath: string; read
     return channelCache ? toUpdateCheckResult(args.currentVersion, channelCache.latestVersion) : undefined;
   });
 }
-
-/**
- * Spawns `threadnote update --yes` as a detached background process so the
- * current hook fire can return immediately. The child re-invokes the same
- * standalone executable, inheriting nothing and writing to the null device —
- * its job is to swap the install in time for the next session.
- *
- * Best-effort: silently returns if the spawn fails. The nag banner remains as
- * the fallback signal.
- */
-export const spawnDetachedAutoUpdate = Effect.fn('updateCheck.spawnDetachedAutoUpdate')(function* () {
-  const system = yield* SystemInfo;
-  const developmentEntry = system.processArguments[1];
-  const arguments_ = isStandaloneThreadnoteBuild()
-    ? ['update', '--yes']
-    : typeof developmentEntry === 'string' && developmentEntry.length > 0
-      ? [developmentEntry, 'update', '--yes']
-      : undefined;
-  if (!arguments_) return;
-  yield* Effect.scoped(
-    Effect.gen(function* () {
-      const child = yield* ChildProcess.make(system.executablePath, arguments_, {
-        detached: true,
-        stdin: 'ignore',
-        stdout: 'ignore',
-        stderr: 'ignore',
-      });
-      yield* child.unref.pipe(Effect.asVoid);
-    }),
-  ).pipe(Effect.ignore);
-});
 
 function toUpdateCheckResult(currentVersion: string, latestVersion: string): UpdateCheckResult {
   return {

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -1,6 +1,6 @@
 import {TestError} from '../helpers/test-error.js';
 import {execFile} from '../helpers/node-child-process.js';
-import {mkdir, mkdtemp, rm, writeFile} from '../helpers/node-fs-promises.js';
+import {access, mkdir, mkdtemp, rm, writeFile} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import {promisify} from '../helpers/node-util.js';
@@ -25,6 +25,28 @@ describe('Effect CLI', () => {
     expect(result.stdout).toContain('--beta');
     expect(result.stdout).toContain('newest stable or prerelease release');
     expect(result.stdout).toContain('--stable');
+  });
+
+  it('keeps automatic-update policy dry runs read-only and rejects mixed update modes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-auto-update-'));
+    const environment = {
+      THREADNOTE_HOME: join(root, 'home'),
+      THREADNOTE_INSTALL_ROOT: join(root, 'install'),
+    };
+    try {
+      const preview = await runCli(['update', '--auto', 'on', '--dry-run'], environment);
+      expect(preview.stdout).toContain('Would enable automatic Threadnote updates.');
+      await expect(access(join(root, 'install', 'auto-update.json'))).rejects.toMatchObject({code: 'ENOENT'});
+
+      const mixed = await runCli(['update', '--auto', 'off', '--json'], environment).catch(
+        cause => cause as NodeJS.ErrnoException & {stderr?: string},
+      );
+      expect(mixed).toMatchObject({code: 1});
+      expect(String(mixed.stderr)).toContain('Choose one update mode');
+      await expect(access(join(root, 'install', 'auto-update.json'))).rejects.toMatchObject({code: 'ENOENT'});
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
   });
 
   it('exposes local AI model installation and switching commands', async () => {

--- a/test/unit/auto-update.test.ts
+++ b/test/unit/auto-update.test.ts
@@ -1,0 +1,204 @@
+import {it as effectIt} from '@effect/vitest';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import fc from 'fast-check';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import {describe, expect, it} from 'vitest';
+import {
+  initializeAutoUpdatePolicy,
+  isAutoUpdateDue,
+  isAutoUpdateVersionEligible,
+  nextAutoUpdateAttempt,
+  parseAutoUpdateState,
+  readAutoUpdateStatus,
+  setAutoUpdatePolicy,
+  stateAfterFailedAutoUpdateSpawn,
+  terminalAutoUpdateState,
+  type AutoUpdateState,
+} from '../../src/auto_update.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const AutoUpdateTestLayer = Layer.mergeAll(BunServices.layer, SystemInfo.layer);
+
+describe('automatic update state', () => {
+  effectIt.effect('defaults to notify and persists explicit policy changes atomically', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseSystem = yield* SystemInfo;
+      const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-auto-update-'});
+      const installRoot = path.join(temporaryRoot, 'install');
+      const statePath = path.join(installRoot, 'auto-update.json');
+      const testSystem = SystemInfo.of({
+        ...baseSystem,
+        environment: () => ({...baseSystem.environment(), THREADNOTE_INSTALL_ROOT: installRoot}),
+      });
+
+      const initial = yield* readAutoUpdateStatus().pipe(Effect.provideService(SystemInfo, testSystem));
+      yield* initializeAutoUpdatePolicy('automatic').pipe(Effect.provideService(SystemInfo, testSystem));
+      const enabled = yield* readAutoUpdateStatus().pipe(Effect.provideService(SystemInfo, testSystem));
+      yield* fs.writeFileString(
+        statePath,
+        `${JSON.stringify({
+          policy: 'automatic',
+          running: {attempt: 1, fromVersion: '4.2.2', startedAt: '2026-08-13T08:00:00.000Z'},
+          version: 1,
+        })}\n`,
+      );
+      yield* setAutoUpdatePolicy('notify').pipe(Effect.provideService(SystemInfo, testSystem));
+      const disabled = yield* readAutoUpdateStatus().pipe(Effect.provideService(SystemInfo, testSystem));
+      const persisted = JSON.parse(yield* fs.readFileString(statePath)) as unknown;
+
+      expect(initial).toMatchObject({effectivePolicy: 'notify', policy: 'notify', policySource: 'default'});
+      expect(enabled).toMatchObject({effectivePolicy: 'automatic', policy: 'automatic', policySource: 'file'});
+      expect(disabled).toMatchObject({effectivePolicy: 'notify', policy: 'notify', policySource: 'file'});
+      expect(persisted).toEqual({policy: 'notify', version: 1});
+    }).pipe(provideTestLayer(AutoUpdateTestLayer)),
+  );
+
+  effectIt.effect('honors environment opt-out without rewriting the persisted preference', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseSystem = yield* SystemInfo;
+      const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-auto-update-opt-out-'});
+      const installRoot = path.join(temporaryRoot, 'install');
+      const persistedSystem = SystemInfo.of({
+        ...baseSystem,
+        environment: () => ({...baseSystem.environment(), THREADNOTE_INSTALL_ROOT: installRoot}),
+      });
+      yield* initializeAutoUpdatePolicy('automatic').pipe(Effect.provideService(SystemInfo, persistedSystem));
+      const optedOutSystem = SystemInfo.of({
+        ...persistedSystem,
+        environment: () => ({
+          ...persistedSystem.environment(),
+          THREADNOTE_NO_UPDATE_CHECK: '1',
+        }),
+      });
+      const status = yield* readAutoUpdateStatus().pipe(Effect.provideService(SystemInfo, optedOutSystem));
+
+      expect(status).toMatchObject({effectivePolicy: 'notify', policy: 'automatic', policySource: 'environment'});
+    }).pipe(provideTestLayer(AutoUpdateTestLayer)),
+  );
+
+  it('round-trips every valid fully populated state through JSON parsing', () => {
+    const version = fc
+      .tuple(fc.integer({max: 100, min: 0}), fc.integer({max: 100, min: 0}), fc.integer({max: 100, min: 0}))
+      .map(parts => parts.join('.'));
+    const timestamp = fc
+      .integer({max: Date.parse('2099-12-31T23:59:59.999Z'), min: Date.parse('2000-01-01T00:00:00.000Z')})
+      .map(milliseconds => new Date(milliseconds).toISOString());
+    const notification = fc.constantFrom('failed' as const, 'sent' as const, 'unavailable' as const);
+    const state = fc.record({
+      lastCheckAt: timestamp,
+      lastFailure: fc.record({
+        attempt: fc.integer({max: 1_000, min: 1}),
+        failedAt: timestamp,
+        fromVersion: version,
+        notification,
+        summary: fc.string({maxLength: 500}),
+      }),
+      lastSuccess: fc.record({
+        completedAt: timestamp,
+        fromVersion: version,
+        notification,
+        repairRequired: fc.boolean(),
+        toVersion: version,
+      }),
+      policy: fc.constantFrom('automatic' as const, 'notify' as const),
+      running: fc.record({
+        attempt: fc.integer({max: 1_000, min: 1}),
+        fromVersion: version,
+        startedAt: timestamp,
+      }),
+      version: fc.constant(1 as const),
+    });
+
+    fc.assert(
+      fc.property(state, candidate => {
+        expect(parseAutoUpdateState(JSON.parse(JSON.stringify(candidate)))).toEqual(candidate);
+      }),
+    );
+  });
+
+  it('increments attempts only for consecutive failures from the same active version', () => {
+    const prior = {
+      lastFailure: {
+        attempt: 3,
+        failedAt: '2026-08-13T08:00:00.000Z',
+        fromVersion: '4.2.2',
+        summary: 'network unavailable',
+      },
+      policy: 'automatic',
+      version: 1,
+    } satisfies AutoUpdateState;
+
+    expect(nextAutoUpdateAttempt(prior, '4.2.2')).toBe(4);
+    expect(nextAutoUpdateAttempt(prior, '4.2.3')).toBe(1);
+  });
+
+  it('never permits unattended replacement of a SHA-bound development runtime', () => {
+    expect(isAutoUpdateVersionEligible('4.2.2')).toBe(true);
+    expect(isAutoUpdateVersionEligible(`4.2.2-local.g${'a'.repeat(40)}`)).toBe(false);
+  });
+
+  it('removes every running claim from a terminal state transition', () => {
+    fc.assert(
+      fc.property(fc.integer({max: 1_000, min: 1}), attempt => {
+        const runningState = {
+          policy: 'automatic',
+          running: {attempt, fromVersion: '4.2.2', startedAt: '2026-08-13T08:00:00.000Z'},
+          version: 1,
+        } satisfies AutoUpdateState;
+        const terminal = terminalAutoUpdateState(runningState, {
+          lastCheckAt: '2026-08-13T09:00:00.000Z',
+        });
+        expect(terminal.running).toBe(undefined);
+        expect(terminal).toMatchObject({policy: 'automatic', version: 1});
+      }),
+    );
+  });
+
+  it('does not resurrect a running claim when opt-out wins a failed-spawn race', () => {
+    const claimedAt = '2026-08-13T09:00:00.000Z';
+    const disabledAfterClaim = {
+      lastCheckAt: claimedAt,
+      policy: 'notify',
+      version: 1,
+    } satisfies AutoUpdateState;
+    expect(
+      stateAfterFailedAutoUpdateSpawn(disabledAfterClaim, {
+        claimedAt,
+        previousLastCheckAt: '2026-08-13T08:00:00.000Z',
+      }),
+    ).toEqual({
+      lastCheckAt: '2026-08-13T08:00:00.000Z',
+      policy: 'notify',
+      version: 1,
+    });
+  });
+
+  it('backs off failed checks and eventually recovers a stale running claim', () => {
+    const checkedAt = Date.parse('2026-08-13T08:00:00.000Z');
+    const failure = {
+      lastCheckAt: new Date(checkedAt).toISOString(),
+      lastFailure: {
+        attempt: 1,
+        failedAt: new Date(checkedAt).toISOString(),
+        fromVersion: '4.2.2',
+        summary: 'network unavailable',
+      },
+      policy: 'automatic',
+      version: 1,
+    } satisfies AutoUpdateState;
+    expect(isAutoUpdateDue(failure, checkedAt + 14 * 60 * 1_000)).toBe(false);
+    expect(isAutoUpdateDue(failure, checkedAt + 15 * 60 * 1_000)).toBe(true);
+
+    const running = {
+      ...failure,
+      running: {attempt: 2, fromVersion: '4.2.2', startedAt: new Date(checkedAt).toISOString()},
+    } satisfies AutoUpdateState;
+    expect(isAutoUpdateDue(running, checkedAt + 29 * 60 * 1_000)).toBe(false);
+    expect(isAutoUpdateDue(running, checkedAt + 30 * 60 * 1_000)).toBe(true);
+  });
+});

--- a/test/unit/auto-update.test.ts
+++ b/test/unit/auto-update.test.ts
@@ -31,7 +31,14 @@ describe('automatic update state', () => {
       const statePath = path.join(installRoot, 'auto-update.json');
       const testSystem = SystemInfo.of({
         ...baseSystem,
-        environment: () => ({...baseSystem.environment(), THREADNOTE_INSTALL_ROOT: installRoot}),
+        environment: () => ({
+          ...baseSystem.environment(),
+          CI: undefined,
+          NO_UPDATE_NOTIFIER: undefined,
+          THREADNOTE_AUTO_UPDATE: undefined,
+          THREADNOTE_INSTALL_ROOT: installRoot,
+          THREADNOTE_NO_UPDATE_CHECK: undefined,
+        }),
       });
 
       const initial = yield* readAutoUpdateStatus().pipe(Effect.provideService(SystemInfo, testSystem));

--- a/test/unit/manager-state.test.ts
+++ b/test/unit/manager-state.test.ts
@@ -1,6 +1,7 @@
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {managerUpdateAvailable} from '../../src/manager_state.js';
+import {managerUpdateIndicator} from '../../src/manager_update_indicator.js';
 
 describe('Manager runtime state', () => {
   it.each([
@@ -30,5 +31,41 @@ describe('Manager runtime state', () => {
         expect(managerUpdateAvailable(currentVersion, latestVersion)).toBe(expected);
       }),
     );
+  });
+
+  it.each([
+    {
+      autoUpdate: {
+        effectivePolicy: 'automatic' as const,
+        lastSuccess: {repairRequired: true, toVersion: '4.3.0'},
+        running: {fromVersion: '4.2.2'},
+      },
+      expected: {detail: 'from v4.2.2', label: 'Updating in background'},
+      latestVersion: '4.3.0',
+      updateAvailable: true,
+    },
+    {
+      autoUpdate: {
+        effectivePolicy: 'automatic' as const,
+        lastSuccess: {repairRequired: true, toVersion: '4.3.0'},
+      },
+      expected: {detail: 'v4.3.0', label: 'Update needs attention'},
+      latestVersion: '4.3.0',
+      updateAvailable: true,
+    },
+    {
+      autoUpdate: {effectivePolicy: 'automatic' as const},
+      expected: {detail: 'v4.3.0', label: 'Update queued'},
+      latestVersion: '4.3.0',
+      updateAvailable: true,
+    },
+    {
+      autoUpdate: {effectivePolicy: 'notify' as const},
+      expected: {detail: 'v4.3.0', label: 'Update available'},
+      latestVersion: '4.3.0',
+      updateAvailable: true,
+    },
+  ])('selects the highest-priority update indicator', state => {
+    expect(managerUpdateIndicator(state)).toEqual(state.expected);
   });
 });

--- a/test/unit/system-notification.test.ts
+++ b/test/unit/system-notification.test.ts
@@ -1,0 +1,113 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect} from 'effect';
+import {describe, expect, it} from 'vitest';
+import {CommandExecutor, CommandSpawnFailed} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {sendSystemNotification, systemNotificationInvocation} from '../../src/system_notification.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('system notifications', () => {
+  it('passes macOS notification text as argv instead of AppleScript source', () => {
+    const title = 'Threadnote "updated"';
+    const body = 'New version\\nend run\ndo shell script "unsafe"';
+    const invocation = systemNotificationInvocation('darwin', {}, {body, title});
+
+    expect(invocation).toEqual({
+      args: [
+        '-e',
+        'on run argv\n  display notification (item 2 of argv) with title (item 1 of argv)\nend run',
+        '--',
+        title,
+        body,
+      ],
+      executable: '/usr/bin/osascript',
+    });
+    expect(invocation?.args[1]).not.toContain(title);
+    expect(invocation?.args[1]).not.toContain(body);
+  });
+
+  it('passes Windows notification text through environment data and uses an absolute system executable', () => {
+    const title = 'Threadnote $env:PATH';
+    const body = '</text><script>unsafe</script>';
+    const invocation = systemNotificationInvocation('win32', {SystemRoot: 'D:\\Windows\\'}, {body, title});
+
+    expect(invocation?.executable).toBe('D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe');
+    expect(invocation?.env?.THREADNOTE_NOTIFICATION_TITLE).toBe(title);
+    expect(invocation?.env?.THREADNOTE_NOTIFICATION_BODY).toBe(body);
+    expect(invocation?.args.join('\n')).not.toContain(title);
+    expect(invocation?.args.join('\n')).not.toContain(body);
+  });
+
+  it('uses notify-send on Linux and reports unsupported platforms', () => {
+    expect(systemNotificationInvocation('linux', {}, {body: 'Installed safely', title: 'Threadnote updated'})).toEqual({
+      args: ['--app-name=Threadnote', '--expire-time=10000', 'Threadnote updated', 'Installed safely'],
+      executable: 'notify-send',
+    });
+    expect(systemNotificationInvocation('aix', {}, {body: 'Installed safely', title: 'Threadnote updated'})).toBe(
+      undefined,
+    );
+  });
+
+  it('rejects empty notification text and bounds payload size', () => {
+    expect(systemNotificationInvocation('darwin', {}, {body: '  ', title: 'Threadnote'})).toBe(undefined);
+    const invocation = systemNotificationInvocation('linux', {}, {body: 'b'.repeat(700), title: 't'.repeat(200)});
+    expect(invocation?.args.at(-2)).toHaveLength(120);
+    expect(invocation?.args.at(-1)).toHaveLength(500);
+  });
+
+  effectIt.effect('classifies delivery outcomes without making notification failure fatal', () =>
+    Effect.gen(function* () {
+      const baseSystem = yield* SystemInfo;
+      const linuxSystem = SystemInfo.of({...baseSystem, environment: () => ({}), platform: 'linux'});
+      let recordedOptions: unknown;
+      const executor = (exitCode: number) =>
+        CommandExecutor.of({
+          execute: (_executable, _args, options) => {
+            recordedOptions = options;
+            return Effect.succeed({exitCode, stderr: '', stdout: ''});
+          },
+          executeStreaming: () => Effect.die('not used'),
+        });
+      const notification = {body: 'Installed safely', title: 'Threadnote updated'};
+      const sent = yield* sendSystemNotification(notification).pipe(
+        Effect.provideService(SystemInfo, linuxSystem),
+        Effect.provideService(CommandExecutor, executor(0)),
+      );
+      const failed = yield* sendSystemNotification(notification).pipe(
+        Effect.provideService(SystemInfo, linuxSystem),
+        Effect.provideService(CommandExecutor, executor(2)),
+      );
+      const missing = yield* sendSystemNotification(notification).pipe(
+        Effect.provideService(SystemInfo, linuxSystem),
+        Effect.provideService(CommandExecutor, executor(127)),
+      );
+      const spawnFailure = new CommandSpawnFailed({
+        args: [],
+        cause: new Error('missing notifier'),
+        executable: 'notify-send',
+        message: 'missing notifier',
+      });
+      const unavailable = yield* sendSystemNotification(notification).pipe(
+        Effect.provideService(SystemInfo, linuxSystem),
+        Effect.provideService(
+          CommandExecutor,
+          CommandExecutor.of({
+            execute: () => Effect.fail(spawnFailure),
+            executeStreaming: () => Effect.die('not used'),
+          }),
+        ),
+      );
+      const unsupported = yield* sendSystemNotification(notification).pipe(
+        Effect.provideService(SystemInfo, SystemInfo.of({...baseSystem, platform: 'aix'})),
+        Effect.provideService(CommandExecutor, executor(0)),
+      );
+
+      expect(sent).toBe('sent');
+      expect(failed).toBe('failed');
+      expect(missing).toBe('unavailable');
+      expect(unavailable).toBe('unavailable');
+      expect(unsupported).toBe('unavailable');
+      expect(recordedOptions).toMatchObject({allowFailure: true, maxOutputBytes: 4_096, timeoutMs: 5_000});
+    }).pipe(provideTestLayer(SystemInfo.layer)),
+  );
+});


### PR DESCRIPTION
## What changed

- add an install-scoped automatic-update coordinator with durable policy, status, duplicate suppression, retry backoff, and stale-run recovery
- trigger update checks from session-start hooks and the long-lived MCP broker while preserving safe side-by-side activation and next-request broker handoff
- add `threadnote update --auto on|off` and `threadnote update --status [--json]`, with read-only dry-run behavior
- surface background/update-repair state in Manager
- emit bounded, argv-safe best-effort native notifications on macOS, Linux, and Windows after activation, plus an actionable notification after repeated failures
- protect SHA-bound development runtimes from unattended replacement
- keep the Manager browser bundle isolated from backend and bundled-model dependencies

## Why

Threadnote already had a hidden hook-only background update path, but it had no install-wide coordination, durable result, retry policy, general trigger coverage, or user-visible completion signal. This makes update transitions observable and graceful without introducing an always-running updater daemon.

## Validation

- rebased on the model-bundling main commit `8a5bf632`
- dev-cycle: 3 iterations, 0 final blocking findings
- `bun run lint`
- `bun run typecheck`
- focused Vitest coverage: 85 updater/notification/command/broker/Manager tests
- focused CLI integration test for automatic-update policy dry runs and mixed-mode validation
- Fast-check properties for persisted-state round trips and terminal running-claim cleanup
- `bun run build`, including the embedded core-model preflight and Manager browser bundle
- exact-HEAD global install and local-bin smoke: updater status/policy, bundled-model listing, and SHA-256 verification

The full suite is intentionally delegated to CI.