### PR TITLE
Fix telemetry storage canary polling

### DIFF
--- a/infra/telemetry-gateway/cmd/canary/main.go
+++ b/infra/telemetry-gateway/cmd/canary/main.go
@@ -10,12 +10,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -214,37 +220,122 @@ func queryTrace(
 	if err != nil || len(body) > maxResponse {
 		return false, errors.New("invalid Tempo response")
 	}
-	if !validStoredTrace(body, ids) {
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/protobuf" {
+		return false, errors.New("Tempo returned an unexpected media type")
+	}
+	state, err := inspectStoredTrace(body, ids)
+	if err != nil {
 		return false, errors.New("Tempo returned a trace outside the canary contract")
 	}
-	return true, nil
+	return state == storedTraceMatched, nil
 }
 
-func validStoredTrace(body []byte, ids canaryIDs) bool {
-	response, err := parseMessage(body)
+type storedTraceState uint8
+
+const (
+	storedTracePending storedTraceState = iota
+	storedTraceMatched
+)
+
+func inspectStoredTrace(body []byte, ids canaryIDs) (storedTraceState, error) {
+	tracePayload, present, err := tempoTracePayload(body)
 	if err != nil {
-		return false
+		return storedTracePending, err
 	}
-	for _, trace := range response.messages(1) {
-		for _, resourceSpans := range trace.messages(1) {
-			resources := resourceSpans.messages(1)
-			if len(resources) != 1 {
+	if !present {
+		return storedTracePending, nil
+	}
+	trace := &tracepb.TracesData{}
+	if err := (proto.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(tracePayload, trace); err != nil {
+		return storedTracePending, errors.New("invalid Tempo trace protobuf")
+	}
+	if len(trace.ResourceSpans) == 0 {
+		return storedTracePending, nil
+	}
+	for _, resourceSpans := range trace.ResourceSpans {
+		if resourceSpans == nil {
+			continue
+		}
+		resource := resourceSpans.GetResource()
+		if resource == nil || !hasStringAttribute(resource.Attributes, "service.name", "threadnote") ||
+			!hasStringAttribute(resource.Attributes, "service.version", canaryVersion) ||
+			!hasStringAttribute(resource.Attributes, "session.id", ids.sessionID) {
+			continue
+		}
+		for _, scopeSpans := range resourceSpans.ScopeSpans {
+			if scopeSpans == nil {
 				continue
 			}
-			resource, valid := protoAttributes(resources[0].messages(1))
-			if !valid || resource["service.name"] != "threadnote" || resource["service.version"] != canaryVersion || resource["session.id"] != ids.sessionID {
-				continue
-			}
-			for _, scopeSpans := range resourceSpans.messages(2) {
-				for _, span := range scopeSpans.messages(2) {
-					attributes, valid := protoAttributes(span.messages(9))
-					if valid && bytes.Equal(span.firstBytes(1), ids.traceID) && string(span.firstBytes(5)) == "threadnote.anonymous-diagnostic" &&
-						attributes["threadnote.component"] == "cli" && attributes["threadnote.operation"] == "health" &&
-						attributes["threadnote.event"] == "completion" && attributes["threadnote.outcome"] == "success" {
-						return true
-					}
+			for _, span := range scopeSpans.Spans {
+				if span == nil {
+					continue
+				}
+				if bytes.Equal(span.TraceId, ids.traceID) && bytes.Equal(span.SpanId, ids.spanID) &&
+					span.Name == "threadnote.anonymous-diagnostic" &&
+					hasStringAttribute(span.Attributes, "threadnote.component", "cli") &&
+					hasStringAttribute(span.Attributes, "threadnote.operation", "health") &&
+					hasStringAttribute(span.Attributes, "threadnote.event", "completion") &&
+					hasStringAttribute(span.Attributes, "threadnote.outcome", "success") {
+					return storedTraceMatched, nil
 				}
 			}
+		}
+	}
+	return storedTracePending, errors.New("stored trace does not match the canary")
+}
+
+func tempoTracePayload(payload []byte) ([]byte, bool, error) {
+	var tracePayload []byte
+	seen := make(map[protowire.Number]struct{}, 4)
+	for len(payload) > 0 {
+		number, wireType, tagLength := protowire.ConsumeTag(payload)
+		if tagLength < 0 {
+			return nil, false, errors.New("invalid Tempo response tag")
+		}
+		expectedType, admitted := map[protowire.Number]protowire.Type{
+			1: protowire.BytesType,
+			2: protowire.BytesType,
+			3: protowire.VarintType,
+			4: protowire.BytesType,
+		}[number]
+		if !admitted || wireType != expectedType {
+			return nil, false, errors.New("invalid Tempo response field")
+		}
+		if _, duplicate := seen[number]; duplicate {
+			return nil, false, errors.New("duplicate Tempo response field")
+		}
+		seen[number] = struct{}{}
+		payload = payload[tagLength:]
+
+		var consumed int
+		switch wireType {
+		case protowire.BytesType:
+			value, length := protowire.ConsumeBytes(payload)
+			consumed = length
+			if number == 1 && length >= 0 {
+				tracePayload = append([]byte(nil), value...)
+			}
+		case protowire.VarintType:
+			_, consumed = protowire.ConsumeVarint(payload)
+		}
+		if consumed < 0 {
+			return nil, false, errors.New("invalid Tempo response value")
+		}
+		payload = payload[consumed:]
+	}
+	_, present := seen[1]
+	return tracePayload, present, nil
+}
+
+func hasStringAttribute(attributes []*commonpb.KeyValue, key string, expected string) bool {
+	for _, attribute := range attributes {
+		if attribute == nil || attribute.GetKey() != key || attribute.Value == nil {
+			continue
+		}
+		value, ok := attribute.Value.Value.(*commonpb.AnyValue_StringValue)
+		if ok {
+			return value.StringValue == expected
 		}
 	}
 	return false
@@ -311,98 +402,6 @@ func buildEnvelope(ids canaryIDs, timestamp time.Time) []byte {
 	resourceSpans := message(1, resource)
 	resourceSpans = append(resourceSpans, message(2, scopeSpans)...)
 	return message(1, resourceSpans)
-}
-
-type protoMessage map[uint64][][]byte
-
-func parseMessage(payload []byte) (protoMessage, error) {
-	message := make(protoMessage)
-	for len(payload) > 0 {
-		key, consumed, ok := readVarint(payload)
-		if !ok || key == 0 {
-			return nil, errors.New("invalid protobuf key")
-		}
-		payload = payload[consumed:]
-		field := key >> 3
-		switch key & 7 {
-		case 0:
-			_, consumed, ok = readVarint(payload)
-			if !ok {
-				return nil, errors.New("invalid protobuf varint")
-			}
-			payload = payload[consumed:]
-		case 1:
-			if len(payload) < 8 {
-				return nil, errors.New("invalid protobuf fixed64")
-			}
-			payload = payload[8:]
-		case 2:
-			length, lengthBytes, lengthOK := readVarint(payload)
-			if !lengthOK || length > uint64(len(payload)-lengthBytes) {
-				return nil, errors.New("invalid protobuf bytes")
-			}
-			start, end := lengthBytes, lengthBytes+int(length)
-			message[field] = append(message[field], payload[start:end])
-			payload = payload[end:]
-		case 5:
-			if len(payload) < 4 {
-				return nil, errors.New("invalid protobuf fixed32")
-			}
-			payload = payload[4:]
-		default:
-			return nil, errors.New("unsupported protobuf wire type")
-		}
-	}
-	return message, nil
-}
-
-func (message protoMessage) messages(field uint64) []protoMessage {
-	result := make([]protoMessage, 0, len(message[field]))
-	for _, payload := range message[field] {
-		parsed, err := parseMessage(payload)
-		if err == nil {
-			result = append(result, parsed)
-		}
-	}
-	return result
-}
-
-func (message protoMessage) firstBytes(field uint64) []byte {
-	if len(message[field]) == 0 {
-		return nil
-	}
-	return message[field][0]
-}
-
-func protoAttributes(attributes []protoMessage) (map[string]string, bool) {
-	values := make(map[string]string, len(attributes))
-	for _, attribute := range attributes {
-		key := string(attribute.firstBytes(1))
-		anyValues := attribute.messages(2)
-		if key == "" || len(anyValues) != 1 {
-			return nil, false
-		}
-		// The canary's identity fields are strings. Numeric attributes such as
-		// schema_version and duration_ms are valid but irrelevant to this readback.
-		if len(anyValues[0][1]) == 1 {
-			values[key] = string(anyValues[0][1][0])
-		}
-	}
-	return values, true
-}
-
-func readVarint(payload []byte) (uint64, int, bool) {
-	var value uint64
-	for index, current := range payload {
-		if index == 10 || (index == 9 && current > 1) {
-			return 0, 0, false
-		}
-		value |= uint64(current&0x7f) << (7 * index)
-		if current&0x80 == 0 {
-			return value, index + 1, true
-		}
-	}
-	return 0, 0, false
 }
 
 func keyValue(key string, anyValue []byte) []byte {

--- a/infra/telemetry-gateway/cmd/canary/main_test.go
+++ b/infra/telemetry-gateway/cmd/canary/main_test.go
@@ -42,11 +42,11 @@ func TestCanaryPostsExactTraceThenProvesStorage(t *testing.T) {
 			queryCount++
 			current := queryCount
 			mu.Unlock()
+			response.Header().Set("Content-Type", "application/protobuf")
 			if current == 1 {
-				response.WriteHeader(http.StatusNotFound)
+				response.WriteHeader(http.StatusOK)
 				return
 			}
-			response.Header().Set("Content-Type", "application/protobuf")
 			_, _ = response.Write(storedResponse)
 		default:
 			t.Fatalf("unexpected request path %s", request.URL.Path)
@@ -81,7 +81,10 @@ func TestCanaryFailsClosedOnAcceptedButMissingOrWrongTrace(t *testing.T) {
 		wantError string
 	}{
 		{name: "missing", queryCode: http.StatusNotFound, wantError: "did not become queryable"},
+		{name: "empty while pending", queryCode: http.StatusOK, wantError: "did not become queryable"},
 		{name: "wrong payload", queryCode: http.StatusOK, queryBody: tempoResponse(buildEnvelope(canaryIDs{traceID: bytes.Repeat([]byte{9}, 16), spanID: ids.spanID, sessionID: ids.sessionID}, time.Now())), wantError: "outside the canary contract"},
+		{name: "wrong span", queryCode: http.StatusOK, queryBody: tempoResponse(buildEnvelope(canaryIDs{traceID: ids.traceID, spanID: bytes.Repeat([]byte{9}, 8), sessionID: ids.sessionID}, time.Now())), wantError: "outside the canary contract"},
+		{name: "wrong media type", queryCode: http.StatusOK, queryBody: tempoResponse(buildEnvelope(ids, time.Now())), wantError: "unexpected media type"},
 		{name: "unauthorized", queryCode: http.StatusUnauthorized, wantError: "Tempo returned status 401"},
 	}
 	for _, test := range tests {
@@ -90,6 +93,9 @@ func TestCanaryFailsClosedOnAcceptedButMissingOrWrongTrace(t *testing.T) {
 				if request.URL.Path == "/v1/traces" {
 					response.WriteHeader(http.StatusOK)
 					return
+				}
+				if test.name != "wrong media type" && test.queryCode == http.StatusOK {
+					response.Header().Set("Content-Type", "application/protobuf")
 				}
 				response.WriteHeader(test.queryCode)
 				_, _ = response.Write(test.queryBody)
@@ -100,7 +106,7 @@ func TestCanaryFailsClosedOnAcceptedButMissingOrWrongTrace(t *testing.T) {
 			gateway.Path, tempo.Path = "/v1/traces", "/tempo"
 			now := time.Now()
 			queryDeadline := 2 * time.Millisecond
-			if test.name == "missing" {
+			if test.name == "missing" || test.name == "empty while pending" {
 				queryDeadline = 0
 			}
 			configuration := config{
@@ -149,9 +155,23 @@ func TestEnvironmentRejectsNonProductionOrCredentialBearingURLs(t *testing.T) {
 func TestStoredTraceParserRejectsMalformedProtobuf(t *testing.T) {
 	ids := fixedIDs()
 	for _, body := range [][]byte{{0xff}, {0x0a, 0xff}, message(1, []byte{0xff})} {
-		if validStoredTrace(body, ids) {
+		if _, err := inspectStoredTrace(body, ids); err == nil {
 			t.Fatalf("accepted malformed response %x", body)
 		}
+	}
+}
+
+func TestStoredTraceParserTreatsOnlyAnEmptyTraceAsPending(t *testing.T) {
+	ids := fixedIDs()
+	for _, body := range [][]byte{nil, message(1, nil)} {
+		state, err := inspectStoredTrace(body, ids)
+		if err != nil || state != storedTracePending {
+			t.Fatalf("state = %d, error = %v, want pending", state, err)
+		}
+	}
+	state, err := inspectStoredTrace(tempoResponse(buildEnvelope(ids, time.Now())), ids)
+	if err != nil || state != storedTraceMatched {
+		t.Fatalf("state = %d, error = %v, want matched", state, err)
 	}
 }
 
@@ -164,10 +184,6 @@ func fixedIDs() canaryIDs {
 }
 
 func tempoResponse(exportEnvelope []byte) []byte {
-	request, err := parseMessage(exportEnvelope)
-	if err != nil || len(request[1]) != 1 {
-		panic("invalid fixture")
-	}
 	// ExportTraceServiceRequest and Tempo's Trace both encode ResourceSpans as
 	// field 1, so the complete export envelope is the Trace message body.
 	return message(1, exportEnvelope)


### PR DESCRIPTION
## What changed

- treat a valid empty Tempo v2 trace response as an eventual-consistency state and continue polling
- decode the wrapped Tempo trace with the official OTLP protobuf types
- require the exact generated trace ID, span ID, session ID, service metadata, and canary attributes
- reject unexpected media types, malformed protobuf, duplicate or unknown wrapper fields, and non-empty mismatched traces

## Why

The first production canary successfully posted through `telemetry.threadnote.io`, and Grafana stored the generated trace. Tempo initially returned `200 OK` with an empty `TraceByIDResponse`, which our canary incorrectly classified as a contract violation instead of retrying. Tempo's v2 API explicitly permits an empty successful response while recent ingestion becomes visible.

## Impact

The scheduled canary will only report success after the exact synthetic trace is queryable. Legitimate propagation delay no longer causes a false failure, while malformed or mismatched data still fails closed and skips the success heartbeat.

## Validation

- focused `go test ./cmd/canary`
- focused `go vet ./cmd/canary`
- repository lint, formatting, and TypeScript typecheck via the commit hook
- broader testing intentionally delegated to CI
