### PR TITLE
ci(telemetry): provision Grafana dashboard safely

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -7,3 +7,7 @@ paths:
     # GitHub supports queue:max; Actionlint 1.7.12 predates that workflow syntax.
     ignore:
       - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'
+  .github/workflows/telemetry-dashboard.yml:
+    # GitHub supports queue:max; Actionlint 1.7.12 predates that workflow syntax.
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'

--- a/.github/workflows/telemetry-dashboard.yml
+++ b/.github/workflows/telemetry-dashboard.yml
@@ -27,12 +27,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: telemetry-dashboard-${{ github.ref }}
-  cancel-in-progress: true
+  group: telemetry-dashboard-${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && 'production' || github.run_id }}
+  queue: max
+  cancel-in-progress: false
 
 jobs:
   validate:
-    name: Validate canonical Grafana resource
+    name: Validate canonical Grafana dashboard
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -45,29 +46,130 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: Require the provisioned resource to match its portable source
+      - name: Require the deployment artifact to match its portable source
         run: bun scripts/telemetry-dashboard.ts check
 
-      - name: Validate dashboard privacy, query, rendering, and workflow contracts
+      - name: Validate dashboard privacy, drift, query, rendering, and workflow contracts
         run: >-
           bun --bun vitest run
           test/unit/telemetry-gateway-dashboard.test.ts
           test/unit/telemetry-dashboard-provisioning.test.ts
 
-      - name: Report intentionally disabled live verification
+      - name: Report intentionally disabled live reconciliation
         if: >-
           github.event_name != 'pull_request' &&
-          vars.THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_ENABLED != 'true'
+          vars.THREADNOTE_TELEMETRY_GRAFANA_DIRECT_ENABLED != 'true'
         run: >-
-          echo '::notice::Grafana Git Sync live verification is disabled until the controlled migration is complete.'
+          echo '::notice::Direct Grafana dashboard reconciliation is disabled until the controlled activation is complete.'
+
+  deploy:
+    name: Update the existing Grafana dashboard
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'Kashkovsky/threadnote' &&
+      vars.THREADNOTE_TELEMETRY_GRAFANA_DIRECT_ENABLED == 'true'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: telemetry-dashboard-production-deploy
+    outputs:
+      stale: ${{ steps.freshness.outputs.stale == 'true' || steps.final_freshness.outputs.stale == 'true' }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+
+      - name: Refuse stale deployment control-plane code
+        id: freshness
+        shell: bash
+        run: |
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
+            echo '::error::The deployment commit is no longer an ancestor of main.'
+            exit 1
+          fi
+          if git diff --quiet --no-ext-diff --no-textconv "$GITHUB_SHA" refs/remotes/origin/main -- \
+            .github/workflows/telemetry-dashboard.yml \
+            infra/telemetry-dashboard/threadnote-telemetry.artifact \
+            infra/telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json \
+            scripts/telemetry-dashboard.ts; then
+            echo 'stale=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'stale=true' >> "$GITHUB_OUTPUT"
+            echo '::notice::A newer main commit changed dashboard deployment inputs; its protected run will reconcile.'
+          fi
+
+      - name: Fail closed when writer configuration is incomplete
+        if: steps.freshness.outputs.stale != 'true'
+        env:
+          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
+          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_URL }}
+          THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN }}
+        run: |
+          if [[ -z "$THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE" ]]; then
+            echo '::error::THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE is required.'
+            exit 1
+          fi
+          if [[ -z "$THREADNOTE_TELEMETRY_GRAFANA_URL" ]]; then
+            echo '::error::THREADNOTE_TELEMETRY_GRAFANA_URL is required.'
+            exit 1
+          fi
+          if [[ -z "$THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN" ]]; then
+            echo '::error::THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN is required.'
+            exit 1
+          fi
+
+      - name: Recheck deployment freshness immediately before the write
+        id: final_freshness
+        if: steps.freshness.outputs.stale != 'true'
+        shell: bash
+        run: |
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
+            echo '::error::The deployment commit is no longer an ancestor of main.'
+            exit 1
+          fi
+          if git diff --quiet --no-ext-diff --no-textconv "$GITHUB_SHA" refs/remotes/origin/main -- \
+            .github/workflows/telemetry-dashboard.yml \
+            infra/telemetry-dashboard/threadnote-telemetry.artifact \
+            infra/telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json \
+            scripts/telemetry-dashboard.ts; then
+            echo 'stale=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'stale=true' >> "$GITHUB_OUTPUT"
+            echo '::notice::A newer main commit changed dashboard deployment inputs; its protected run will reconcile.'
+          fi
+
+      - name: Reconcile through the update-only Grafana App API
+        if: steps.freshness.outputs.stale != 'true' && steps.final_freshness.outputs.stale != 'true'
+        env:
+          THREADNOTE_TELEMETRY_DASHBOARD_CURRENT_SHA: ${{ github.sha }}
+          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
+          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_URL }}
+          THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN }}
+        run: >-
+          bun --config=/dev/null --no-env-file --no-install
+          scripts/telemetry-dashboard.ts deploy
 
   verify-live:
-    name: Verify Grafana Git Sync convergence and Tempo queries
+    name: Verify live dashboard and bounded Tempo queries
     if: >-
+      always() &&
+      needs.validate.result == 'success' &&
       github.event_name != 'pull_request' &&
       github.ref == 'refs/heads/main' &&
-      vars.THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_ENABLED == 'true'
-    needs: validate
+      github.repository == 'Kashkovsky/threadnote' &&
+      vars.THREADNOTE_TELEMETRY_GRAFANA_DIRECT_ENABLED == 'true' &&
+      (github.event_name != 'push' ||
+       (needs.deploy.result == 'success' && needs.deploy.outputs.stale != 'true'))
+    needs: [validate, deploy]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment:
@@ -83,15 +185,10 @@ jobs:
 
       - name: Fail closed when read-only verification configuration is incomplete
         env:
-          THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID }}
           THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
           THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_URL }}
           THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN }}
         run: |
-          if [[ -z "$THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID" ]]; then
-            echo '::error::THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID is required.'
-            exit 1
-          fi
           if [[ -z "$THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE" ]]; then
             echo '::error::THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE is required.'
             exit 1
@@ -105,10 +202,40 @@ jobs:
             exit 1
           fi
 
-      - name: Wait for Git Sync and verify every bounded Tempo query
+      - name: Verify exact live state, private ACLs, and every Tempo query
         env:
-          THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID }}
           THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
           THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_URL }}
           THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN }}
-        run: bun scripts/telemetry-dashboard.ts verify-live
+        run: >-
+          bun --config=/dev/null --no-env-file --no-install
+          scripts/telemetry-dashboard.ts verify-live
+
+  complete:
+    name: Dashboard checks complete
+    if: always()
+    needs: [validate, deploy, verify-live]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require every applicable dashboard check to pass
+        env:
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          DIRECT_ENABLED: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_DIRECT_ENABLED }}
+          EVENT_NAME: ${{ github.event_name }}
+          STALE_DEPLOYMENT: ${{ needs.deploy.outputs.stale }}
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          VERIFY_RESULT: ${{ needs.verify-live.result }}
+        run: |
+          if [[ "$VALIDATE_RESULT" != 'success' ]]; then
+            echo '::error::Dashboard validation did not succeed.'
+            exit 1
+          fi
+          if [[ "$DIRECT_ENABLED" == 'true' && "$EVENT_NAME" == 'push' && "$DEPLOY_RESULT" != 'success' ]]; then
+            echo '::error::Dashboard deployment did not succeed.'
+            exit 1
+          fi
+          if [[ "$DIRECT_ENABLED" == 'true' && "$EVENT_NAME" != 'pull_request' && "$STALE_DEPLOYMENT" != 'true' && "$VERIFY_RESULT" != 'success' ]]; then
+            echo '::error::Live dashboard verification did not succeed.'
+            exit 1
+          fi

--- a/infra/telemetry-dashboard/README.md
+++ b/infra/telemetry-dashboard/README.md
@@ -1,19 +1,28 @@
-# Threadnote telemetry dashboard Git Sync
+# Threadnote telemetry dashboard deployment
 
-This directory is the dashboard-only deployment surface for Grafana Cloud Git
-Sync. The portable import model remains
-[`../telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json`](../telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json),
-and `scripts/telemetry-dashboard.ts` deterministically converts it into the
-Grafana App Platform resource under `git-sync/` by:
+This directory is the reviewable deployment surface for the existing private
+Grafana Cloud dashboard. The portable import model remains
+[`../telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json`](../telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json).
+`scripts/telemetry-dashboard.ts` deterministically renders it into
+`threadnote-telemetry.artifact` by replacing `${DS_TEMPO}` with the operated
+`grafanacloud-traces` UID, removing import-only and server-owned root fields,
+fixing the dashboard and folder identities, and canonicalizing object keys
+without reordering arrays.
 
-- replacing `${DS_TEMPO}` with the operated `grafanacloud-traces` data-source
-  UID;
-- removing import-only and server-owned root fields;
-- wrapping the Classic dashboard model in the required
-  `dashboard.grafana.app/v1` resource; and
-- canonicalizing object keys while preserving array order.
+The generated file deliberately has neither a Git Sync-recognized
+`.json`/`.yaml` extension nor `apiVersion`, `kind`, or `metadata` resource
+fields. The provisioner constructs the fixed App API resource only in memory
+after all live checks pass. This prevents a broadly rooted legacy Git Sync
+connection from discovering the direct-deployment history file on merge.
 
-Do not hand-edit the generated dashboard. After changing the portable source,
+The legacy resources under `git-sync/` are intentionally retained in this
+slice. Removing them while an unknown Git Sync connection is still active
+could make Grafana delete the live folder or dashboard. Treat them as inert
+migration/rollback material; remove them only in a later reviewed cleanup after
+direct deployment is live and an operator has confirmed that no repository
+reconciler remains.
+
+Do not hand-edit the generated artifact. After changing the portable source,
 run:
 
 ```sh
@@ -23,91 +32,143 @@ bun --bun vitest run test/unit/telemetry-gateway-dashboard.test.ts \
   test/unit/telemetry-dashboard-provisioning.test.ts
 ```
 
-## One-time production migration
+## Safety contract
 
-The existing unmanaged dashboard needs an explicit migration into Git Sync;
-do not assume that an ordinary repository pull will safely adopt it. Perform
-the migration in a controlled maintenance window:
+GitHub Actions updates only the already-existing Dashboard resource at the
+fixed App API path
+`/apis/dashboard.grafana.app/v1/namespaces/<stack>/dashboards/threadnote-telemetry`.
+It never calls a create, delete, folder-write, permission-write, or legacy
+dashboard-save endpoint. Every PUT carries the exact non-empty opaque
+`metadata.resourceVersion` read immediately beforehand. Grafana therefore
+rejects a stale update or a dashboard deleted between GET and PUT rather than
+creating a replacement. Only HTTP 200 is accepted; 404, 409, 412, 500, and all
+other statuses fail terminally. A transport failure is never retried: one GET
+classifies whether the first PUT completed, and any old or unexpected state
+fails closed.
 
-1. Export the live dashboard and compare its normalized model with the
-   generated resource. Retain the export privately as rollback evidence; it can
-   contain operational table configuration and must not be published.
-2. In Grafana Cloud, create a Git Sync connection for this repository's `main`
-   branch and set its exact repository path to
-   `infra/telemetry-dashboard/git-sync`. Configure the repository as read-only
-   in Grafana so the UI cannot write dashboard changes back to Git; changes must
-   originate in the portable source and pass review. Do not grant Actions a
-   dashboard writer token, and retain repository protection on `main`.
-3. If setup offers **Migrate existing resources**, prefer that provider flow
-   only when its preview can be bounded to this dashboard and folder. Require
-   it to retain UID `threadnote-telemetry`, emit a model semantically equal to
-   the generated resource, and leave no unrelated repository changes. Stop and
-   investigate rather than accepting a broader migration.
-4. If the bounded migration flow is unavailable, use Grafana's documented
-   export fallback: while stack access is limited to administrators, delete
-   only the exported unmanaged dashboard, trigger a pull, and require Grafana
-   to recreate the same UID in the `threadnote-telemetry-private` provisioned
-   folder. This fallback does not carry dashboard history or permissions; the
-   private export is its rollback evidence.
-5. In either flow, remove the provisioned folder's default Viewer and Editor
-   role grants before reopening ordinary stack access. Leave only explicit
-   service-owner user/team entries; Grafana administrators retain inherent
-   access. The checked-in `_folder.json` gives this folder a stable UID so its
-   permissions survive repository path moves.
-6. Enable post-sync verification only after the first pull succeeds. Set the
-   repository variable `THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_ENABLED=true`,
-   create the protected `telemetry-dashboard-production` GitHub Environment,
-   restrict it to `main`, and configure:
-   - Environment variable `THREADNOTE_TELEMETRY_GRAFANA_URL` with the
-     uncredentialed Grafana Cloud HTTPS origin.
-   - Environment variable `THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE` with the
-     stack namespace from Grafana Cloud, in the exact
-     `stacks-<numeric Stack ID>` form. `default` is only an on-premises example
-     namespace and is rejected by this workflow.
-   - Environment variable
-     `THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID` with the exact
-     Kubernetes `metadata.name` of the Grafana Git Sync Repository resource,
-     not its display title or Git URL.
-   - Environment secret `THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN` with a
-     read-only service-account token scoped as narrowly as Grafana supports. It
-     needs `dashboards:read`, `folders:read`, `folders.permissions:read`,
-     `datasources:read`, and `datasources:query`; bind dashboard and data-source
-     actions to these exact UIDs. Grafana's legacy folder-permission read API
-     may require the read-only `folders:*` scope. It must have no dashboard,
-     folder, data-source, or alert write permission.
+Before a write, the provisioner requires all of the following:
 
-Treat the namespace and Repository resource name as private deployment
-metadata: configure them only in the protected Environment and do not print
-them in workflow output. Before enabling verification, confirm the Git Sync
-Repository reports that exact resource name and that its configured root is
-`infra/telemetry-dashboard/git-sync`.
+- the exact dashboard UID, immutable `metadata.uid`, namespace, folder
+  annotation, folder UID/title, and private folder ACL;
+- no current or legacy Grafana managed/provisioned metadata, including the
+  `managedBy`, manager, source, repository, and `provisioning.grafana.app/*`
+  annotation/label families;
+- a live semantic model equal to either the current canonical artifact or one
+  of at most 64 validated first-parent historical artifacts; and
+- an effective writer permission set limited to exact-target dashboard
+  read/write plus exact-folder read and permission-read. Dashboard/folder
+  create/delete, folder/ACL write, query, admin, and wildcard grants are
+  rejected.
 
-Until the enable variable is exactly `true`, pull requests and `main` validate
-the generated resource but the live verification job is intentionally skipped.
-Once enabled, every dashboard-path change and the daily 03:17 UTC drift check
-run the same main-only protected-Environment verification. Missing credentials,
-non-HTTPS configuration, dashboard/folder sync drift, broad default folder
-grants, query parse errors, and query responses missing a target fail closed.
-Verification uses a five-minute range, one point/result per query, and never
-logs response bodies, permission principals, trace identifiers, stack
-namespaces, or Repository resource names. The live check reads the Grafana App
-Platform Dashboard and Folder resources in the configured Cloud namespace and
-requires exact Git Sync provenance:
-`grafana.app/managedBy=repo`, the configured `grafana.app/managerId`, source
-paths `threadnote-telemetry/threadnote-telemetry.json` and
-`threadnote-telemetry`, and folder UID `threadnote-telemetry-private` on the
-dashboard. It compares the canonical resource specs after omitting dashboard
-`uid`, `id`, and `version`, which Grafana's Git Sync parser owns and removes
-before storage.
+If live already equals current, deployment is a no-op. If it equals a trusted
+historical artifact, the provisioner updates to current. Any third state is
+treated as out-of-band drift and is not overwritten. This bounded history
+allows a newer run to recover when an intermediate run was skipped or failed;
+it does not trust dispatch order. Historical artifacts are read as the
+reviewed canonical models committed on protected first-parent history and are
+validated for fixed identity and JSON shape without reapplying the current
+renderer contract. That keeps a prior model eligible during an intentional
+renderer or datasource migration. `queue: max` and
+`cancel-in-progress: false` prevent relevant main runs from replacing one
+another, while two content-aware remote-main checks prevent an older run from
+executing after a newer commit changes the workflow, provisioner, portable
+source, or generated artifact.
 
-Grafana Git Sync is the deployment mechanism. GitHub Actions waits for the
-read-only live model to converge and then parser-checks every bounded TraceQL
-target; it never pushes dashboard state through the Grafana API. Roll back with
-a reviewed Git revert and require the same verification job to pass.
+Grafana owns the root `schemaVersion`. The PUT preserves the exact live value
+and the post-write GET requires it to remain unchanged, preventing schema
+downgrades. Semantic comparison ignores that root field and the other App API
+server fields. The only structural migration noise tolerated is omission of
+an exactly empty `{defaults: {}, overrides: []}` `fieldConfig` on the six
+known panels 14–19. Query, panel, nonempty field configuration, layout, and all
+other differences remain drift.
+
+After a successful PUT, a second GET must show the same immutable UID, a
+different resourceVersion, the preserved schemaVersion, and the exact intended
+semantics. A separate read-only job then checks folder privacy and submits one
+bounded five-minute Tempo parser/query request for every TraceQL target. It
+first audits that credential against a closed allowlist of exact dashboard,
+folder, ACL-read, datasource-read, and datasource-query scopes. It then
+requires an HTTP 200 result with every expected refId, no target error or
+failing status, and a frames array; empty frames are valid. No response body,
+permission principal, trace ID, namespace, token, or other private deployment
+identifier is logged.
+
+There is no automatic rollback. Revert the portable source through normal
+review; the same history check, optimistic update, post-read, and query
+verification apply to the rollback.
+
+## Controlled production activation
+
+The repository intentionally contains no live credential and does not create,
+delete, or move production resources. Complete this migration interactively in
+a maintenance window before setting the enable variable:
+
+1. Disable and remove any Grafana Git Sync repository that can reconcile this
+   dashboard or folder. Read the raw Dashboard and Folder resources and confirm
+   that no management/provisioning annotations or labels remain. Do not delete
+   the retained `git-sync/` files in this activation change.
+2. Export the existing dashboard privately as rollback evidence. In Grafana,
+   create folder UID `threadnote-telemetry-private` with title
+   `Threadnote private telemetry`, move only dashboard UID
+   `threadnote-telemetry` into it, and remove default Viewer and Editor grants.
+   Leave only explicit service-owner user/team access; administrators retain
+   inherent access. These are deliberate UI/admin operations because CI has no
+   folder-create, move, or ACL-write permission.
+3. Compare the raw App API model with the checked-in artifact using the narrow
+   semantic normalization above. First activation is allowed only when live is
+   already semantically current; it performs no write. Do not enable the lane
+   to adopt a different live model.
+4. Create a read-only service account for `dashboards:read`, `folders:read`,
+   `folders.permissions:read`, `datasources:read`, and `datasources:query`,
+   scoped to the exact dashboard, folder, and `grafanacloud-traces` datasource.
+   Store its token only as `THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN` in the
+   existing `telemetry-dashboard-production` Environment. Keep that Environment
+   main-only and read-only (`deployment: false`).
+5. Create a separate service account with basic role **None**. Grant only
+   `dashboards:read` and `dashboards:write` on dashboard UID
+   `threadnote-telemetry`, plus `folders:read` and
+   `folders.permissions:read` on folder UID
+   `threadnote-telemetry-private`. It must have no dashboard create/delete,
+   folder/ACL write, datasource query, wildcard, or admin permission. Store its
+   token only as `THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN` in a new
+   `telemetry-dashboard-production-deploy` Environment.
+   If the Grafana Cloud plan cannot express these exact custom RBAC scopes,
+   leave direct mode and telemetry ingestion disabled. Do not substitute basic
+   Editor/Admin access or a broader token; the runtime permission audit rejects
+   those grants.
+6. Restrict the deploy Environment to `main`, require the service owner as a
+   reviewer, leave self-review allowed while the repository has only that one
+   trusted operator, and remove administrator bypass. Add a second independent
+   trusted reviewer before enabling self-review prevention. Configure
+   `THREADNOTE_TELEMETRY_GRAFANA_URL` and
+   `THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE` as variables in both Environments.
+   The URL must be an uncredentialed root Grafana Cloud HTTPS origin whose
+   hostname ends in `.grafana.net`, with no non-default port. The namespace must
+   use the private `stacks-<numeric Stack ID>` form and must not be printed.
+7. Keep the repository ruleset, CODEOWNERS rules, signed/linear history, and
+   code-owner review active. The deploy job also requires the exact repository
+   identity `Kashkovsky/threadnote`. This workflow uses only GitHub
+   `contents: read`; it has no GitHub write credential.
+8. After this code has been on `main` long enough to provide a historical
+   canonical baseline, set repository variable
+   `THREADNOTE_TELEMETRY_GRAFANA_DIRECT_ENABLED=true` and land a reviewed
+   dashboard-path change. The protected push job should report a no-op and the
+   read-only verification should pass. Leave the variable unset or anything
+   other than exact `true` until every gate above is complete.
+
+The `telemetry-dashboard-production-deploy` Environment and both credentials
+are not provisioned by this repository. Missing configuration fails a selected
+live job closed; with the enable variable disabled, PRs and `main` remain
+secretless validation only. Scheduled and manually dispatched runs are always
+read-only. The daily drift check runs at 03:17 UTC once enabled.
+
+`Dashboard checks complete` is path-filtered and must not yet be configured as
+a repository-wide required check: unrelated pull requests would never produce
+it. Add it to a compatible path-scoped ruleset, or make this workflow trigger
+and classify every pull request, only after the first enabled run is green.
 
 Provider references:
 
-- [Grafana Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/)
 - [Grafana App Platform API structure](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/apis/)
-- [Export an unmanaged dashboard for Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/export-resources/)
-- [Provisioned dashboards](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/provisioned-dashboards/)
+- [Grafana dashboard API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/dashboard/)
+- [Grafana RBAC HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/access_control/)

--- a/infra/telemetry-dashboard/threadnote-telemetry.artifact
+++ b/infra/telemetry-dashboard/threadnote-telemetry.artifact
@@ -1,0 +1,1670 @@
+{
+  "dashboardUid": "threadnote-telemetry",
+  "folderUid": "threadnote-telemetry-private",
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Anonymous Threadnote CLI and MCP operational telemetry from Grafana Cloud Traces. Every query is scoped to service.name=threadnote and only uses gateway-allowlisted attributes.",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 1,
+    "links": [
+      {
+        "asDropdown": false,
+        "icon": "external link",
+        "includeVars": false,
+        "keepTime": true,
+        "tags": [],
+        "targetBlank": true,
+        "title": "TraceQL documentation",
+        "tooltip": "Grafana Tempo TraceQL reference",
+        "type": "link",
+        "url": "https://grafana.com/docs/tempo/latest/traceql/"
+      }
+    ],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Completed CLI and MCP operations split by closed component and outcome values.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 12,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" } | count_over_time() by (span.threadnote.component, span.threadnote.outcome)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Completions by component and outcome",
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "^\\{span\\.threadnote\\.component=\"([^\"]+)\", span\\.threadnote\\.outcome=\"([^\"]+)\"\\}$",
+              "renamePattern": "$1: $2"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Completed diagnostic spans split by anonymous app version metadata.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 35,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" } | count_over_time() by (resource.service.version) | topk(10)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Completions by app version",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "The 20 highest-volume closed operation/outcome combinations in the selected period.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" } | count_over_time() by (span.threadnote.operation, span.threadnote.outcome) | topk(20)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Top completion operations",
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "^\\{span\\.threadnote\\.operation=\"([^\"]+)\", span\\.threadnote\\.outcome=\"([^\"]+)\"\\}$",
+              "renamePattern": "$1: $2"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Non-successful completions split by closed operation and outcome values.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 35,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" && span.threadnote.outcome != \"success\" } | count_over_time() by (span.threadnote.operation, span.threadnote.outcome) | topk(20)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Non-successful operations",
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "^\\{span\\.threadnote\\.operation=\"([^\"]+)\", span\\.threadnote\\.outcome=\"([^\"]+)\"\\}$",
+              "renamePattern": "$1: $2"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Slowest operation wall-time p50, p95, and p99 values across the selected window from the bounded numeric threadnote.duration_ms attribute, ordered longest first. Long-lived MCP process lifecycles, the manager UI lifetime, and OTLP span duration are intentionally excluded.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "mappings": [],
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 17
+        },
+        "id": 5,
+        "options": {
+          "displayMode": "gradient",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "left",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": ["lastNotNull"],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "color"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "instant",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" && span.threadnote.duration_ms != nil && span.threadnote.operation != \"mcp-server\" && span.threadnote.operation != \"mcp-broker\" && span.threadnote.operation != \"manage\" } | quantile_over_time(span.threadnote.duration_ms, .5, .95, .99) by (span.threadnote.operation) | topk(20)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Operation duration quantiles",
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "^\\{p=([0-9.]+), span\\.threadnote\\.operation=\"([^\"]+)\"\\}$",
+              "renamePattern": "$2: p$1"
+            }
+          },
+          {
+            "id": "reduce",
+            "options": {
+              "includeTimeField": false,
+              "mode": "seriesToRows",
+              "reducers": ["lastNotNull"]
+            }
+          },
+          {
+            "id": "sortBy",
+            "options": {
+              "fields": {},
+              "sort": [
+                {
+                  "desc": true,
+                  "field": "Last *"
+                }
+              ]
+            }
+          },
+          {
+            "id": "rowsToFields",
+            "options": {
+              "mappings": [
+                {
+                  "fieldName": "Field",
+                  "handlerKey": "field.name"
+                },
+                {
+                  "fieldName": "Last *",
+                  "handlerKey": "field.value"
+                }
+              ]
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Phase elapsed-time p50 and p95 from checkpoint spans only, ordered longest first and avoiding completion copies of the last phase.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "mappings": [],
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 17
+        },
+        "id": 6,
+        "options": {
+          "displayMode": "gradient",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "left",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": ["lastNotNull"],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "color"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "instant",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"checkpoint\" && span.threadnote.phase.elapsed_ms != nil } | quantile_over_time(span.threadnote.phase.elapsed_ms, .5, .95) by (span.threadnote.phase)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Phase elapsed-time quantiles",
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "^\\{p=([0-9.]+), span\\.threadnote\\.phase=\"([^\"]+)\"\\}$",
+              "renamePattern": "$2: p$1"
+            }
+          },
+          {
+            "id": "reduce",
+            "options": {
+              "includeTimeField": false,
+              "mode": "seriesToRows",
+              "reducers": ["lastNotNull"]
+            }
+          },
+          {
+            "id": "sortBy",
+            "options": {
+              "fields": {},
+              "sort": [
+                {
+                  "desc": true,
+                  "field": "Last *"
+                }
+              ]
+            }
+          },
+          {
+            "id": "rowsToFields",
+            "options": {
+              "mappings": [
+                {
+                  "fieldName": "Field",
+                  "handlerKey": "field.name"
+                },
+                {
+                  "fieldName": "Last *",
+                  "handlerKey": "field.value"
+                }
+              ]
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Checkpoint volume grouped by closed phase and phase-outcome values.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 26
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"checkpoint\" && span.threadnote.phase != nil } | count_over_time() by (span.threadnote.phase, span.threadnote.phase.outcome) | topk(20)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Phase checkpoints",
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "^\\{span\\.threadnote\\.phase=\"([^\"]+)\", span\\.threadnote\\.phase\\.outcome=\"([^\"]+)\"\\}$",
+              "renamePattern": "$1: $2"
+            }
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Closed, privacy-safe error classifications attached to non-successful operations.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 35,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 26
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" && span.threadnote.outcome != \"success\" && span.error.type != nil } | count_over_time() by (span.error.type) | topk(20)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Errors by type",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Completed operations by coarse resident-set-size bucket. No exact byte values are exported.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 35,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 8,
+          "x": 0,
+          "y": 35
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" && span.threadnote.memory.rss.end_bucket != nil } | count_over_time() by (span.threadnote.memory.rss.end_bucket)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "RSS end buckets",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Completed operations by coarse JavaScript heap-used bucket.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 35,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 8,
+          "x": 8,
+          "y": 35
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" && span.threadnote.memory.heap.end_bucket != nil } | count_over_time() by (span.threadnote.memory.heap.end_bucket)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Heap end buckets",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Completed operations by coarse process peak-RSS bucket.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 35,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 4,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              }
+            },
+            "mappings": [],
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 35
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": ["sum"],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" && span.threadnote.memory.peak_rss.end_bucket != nil } | count_over_time() by (span.threadnote.memory.peak_rss.end_bucket)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Peak RSS end buckets",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "description": "Most recent failure, timed-out, and unavailable completion spans with opaque session/invocation correlation IDs and privacy-safe diagnostics. Expected lifecycle interruptions are excluded; IDs are not grouped or charted.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": []
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "service.version"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "App version"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "session.id"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Session"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.session.scope"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Session scope"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.component"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Component"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.operation"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Operation"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.outcome"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Outcome"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "error.type"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Error type"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.duration_ms"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Duration"
+                },
+                {
+                  "id": "unit",
+                  "value": "ms"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.failure.domain"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Failure domain"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.failure.code"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Failure code"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.failure.recovery"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Recovery"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.invocation.id"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Invocation"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 24,
+          "x": 0,
+          "y": 44
+        },
+        "id": 12,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": ["sum"],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "limit": 100,
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && (resource.threadnote.telemetry.schema_version = 1 || resource.threadnote.telemetry.schema_version = 2) && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"completion\" && span.threadnote.outcome != \"success\" && span.threadnote.outcome != \"interrupted\" } | select(resource.service.version, resource.session.id, resource.threadnote.session.scope, span.threadnote.component, span.threadnote.operation, span.threadnote.outcome, span.error.type, span.threadnote.duration_ms, span.threadnote.failure.domain, span.threadnote.failure.code, span.threadnote.failure.recovery, span.threadnote.invocation.id) with (most_recent=true)",
+            "queryType": "traceql",
+            "refId": "A",
+            "spanLimit": 3,
+            "tableType": "spans"
+          }
+        ],
+        "title": "Recent operational failures",
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 54
+        },
+        "id": 13,
+        "options": {
+          "legend": {
+            "calcs": ["lastNotNull"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "hide": true,
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"lifecycle\" && span.threadnote.operation = \"graph-build\" && span.threadnote.outcome = \"success\" && span.threadnote.graph.build_kind = \"dirty\" && (span.threadnote.graph.efficiency_class = \"small-delta-full\" || span.threadnote.graph.efficiency_class = \"high-amplification-full\" || span.threadnote.graph.efficiency_class = \"critical-amplification-full\") } | count_over_time()",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          },
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "hide": true,
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"lifecycle\" && span.threadnote.operation = \"graph-build\" && span.threadnote.outcome = \"success\" && span.threadnote.graph.build_kind = \"dirty\" } | count_over_time()",
+            "queryType": "traceql",
+            "refId": "B",
+            "tableType": "traces"
+          },
+          {
+            "datasource": {
+              "type": "__expr__",
+              "uid": "__expr__"
+            },
+            "expression": "$A / $B * 100",
+            "refId": "C",
+            "type": "math"
+          }
+        ],
+        "title": "Unexpected full-build percentage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 62
+        },
+        "id": 14,
+        "options": {
+          "legend": {
+            "calcs": ["lastNotNull"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"lifecycle\" && span.threadnote.operation = \"graph-build\" && span.threadnote.outcome = \"success\" } | count_over_time() by (resource.service.version) | topk(10)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Graph builds by app version",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 8,
+          "y": 62
+        },
+        "id": 15,
+        "options": {
+          "legend": {
+            "calcs": ["lastNotNull"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"lifecycle\" && span.threadnote.operation = \"graph-build\" && span.threadnote.outcome = \"success\" } | count_over_time() by (span.threadnote.graph.materialization_mode, span.threadnote.graph.efficiency_class)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Graph builds by mode and efficiency",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 62
+        },
+        "id": 16,
+        "options": {
+          "legend": {
+            "calcs": ["lastNotNull"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"lifecycle\" && span.threadnote.operation = \"graph-build\" && span.threadnote.outcome = \"success\" && span.threadnote.graph.materialization_mode = \"full\" } | count_over_time() by (span.threadnote.graph.fallback_reason, span.threadnote.graph.efficiency_class)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Full-build fallback reasons",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 70
+        },
+        "id": 17,
+        "options": {
+          "legend": {
+            "calcs": ["lastNotNull"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"lifecycle\" && span.threadnote.operation = \"graph-build\" && span.threadnote.outcome = \"success\" && span.threadnote.graph.build_kind = \"dirty\" && span.threadnote.graph.delta_files_bucket != \"0\" } | count_over_time() by (span.threadnote.graph.rewrite_amplification_bucket)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Rewrite amplification buckets",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 8,
+          "y": 70
+        },
+        "id": 18,
+        "options": {
+          "legend": {
+            "calcs": ["lastNotNull"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"lifecycle\" && span.threadnote.operation = \"graph-build\" && span.threadnote.outcome = \"success\" && span.threadnote.graph.build_kind = \"dirty\" && span.threadnote.graph.delta_files_bucket != \"0\" } | count_over_time() by (span.threadnote.graph.cached_fact_replay_bytes_bucket)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Cached fact replay bytes buckets",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 70
+        },
+        "id": 19,
+        "options": {
+          "legend": {
+            "calcs": ["lastNotNull"],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span:name = \"threadnote.anonymous-diagnostic\" && span.threadnote.event = \"lifecycle\" && span.threadnote.operation = \"graph-build\" && span.threadnote.outcome = \"success\" && span.threadnote.graph.build_kind = \"dirty\" && span.threadnote.graph.changed_fact_bytes_bucket != \"0\" } | count_over_time() by (span.threadnote.graph.fact_replay_amplification_bucket)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Fact replay amplification buckets",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "grafanacloud-traces"
+        },
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "service.version"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "App version"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.duration_ms"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Duration"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.cached_fact_replay_bytes_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Cached replay bytes"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.delta_files_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Delta files"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.efficiency_class"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Efficiency class"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.fact_replay_amplification_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Replay amplification"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.fallback_reason"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Fallback reason"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.materialization_mode"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Materialization mode"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.rewrite_amplification_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Rewrite amplification"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.build_kind"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Build kind"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.changed_fact_bytes_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Changed fact bytes"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.changed_files_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Changed files"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.deleted_files_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Deleted files"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.extracted_files_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Extracted files"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.final_fact_bytes_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Final fact bytes"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.resolution_closure"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Resolution closure"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.reused_files_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Reused files"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.staged_files_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Staged files"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "threadnote.graph.total_files_bucket"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Total files"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 24,
+          "x": 0,
+          "y": 78
+        },
+        "id": 20,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": ["sum"],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "grafanacloud-traces"
+            },
+            "limit": 100,
+            "metricsQueryType": "range",
+            "query": "{ resource.service.name = \"threadnote\" && resource.threadnote.telemetry.schema_version = 2 && span.threadnote.graph.efficiency_class =~ \"(small|high|critical).*full\" } | select(resource.service.version,span.threadnote.graph.build_kind,span.threadnote.graph.materialization_mode,span.threadnote.graph.fallback_reason,span.threadnote.graph.resolution_closure,span.threadnote.graph.efficiency_class,span.threadnote.graph.changed_files_bucket,span.threadnote.graph.deleted_files_bucket,span.threadnote.graph.delta_files_bucket,span.threadnote.graph.extracted_files_bucket,span.threadnote.graph.reused_files_bucket,span.threadnote.graph.staged_files_bucket,span.threadnote.graph.total_files_bucket,span.threadnote.graph.cached_fact_replay_bytes_bucket,span.threadnote.graph.changed_fact_bytes_bucket,span.threadnote.graph.final_fact_bytes_bucket,span.threadnote.graph.rewrite_amplification_bucket,span.threadnote.graph.fact_replay_amplification_bucket,span.threadnote.duration_ms) with (most_recent=true)",
+            "queryType": "traceql",
+            "refId": "A",
+            "spanLimit": 3,
+            "tableType": "spans"
+          }
+        ],
+        "title": "Recent inefficient graph materializations",
+        "type": "table"
+      }
+    ],
+    "refresh": "30s",
+    "tags": ["threadnote", "telemetry", "tempo"],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Threadnote anonymous telemetry",
+    "weekStart": ""
+  }
+}

--- a/scripts/telemetry-dashboard.ts
+++ b/scripts/telemetry-dashboard.ts
@@ -6,17 +6,19 @@ class GrafanaHttpError extends ScriptError {
   }
 }
 
+class GrafanaTransportError extends ScriptError {
+  constructor() {
+    super('Grafana API request failed before receiving a response.');
+  }
+}
+
 export const telemetryDashboardSourcePath = 'infra/telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json';
-export const telemetryDashboardProvisionedPath =
-  'infra/telemetry-dashboard/git-sync/threadnote-telemetry/threadnote-telemetry.json';
-export const telemetryDashboardFolderPath = 'infra/telemetry-dashboard/git-sync/threadnote-telemetry/_folder.json';
+export const telemetryDashboardArtifactPath = 'infra/telemetry-dashboard/threadnote-telemetry.artifact';
 export const telemetryDashboardDatasourceUid = 'grafanacloud-traces';
 export const telemetryDashboardFolderUid = 'threadnote-telemetry-private';
 export const telemetryDashboardFolderTitle = 'Threadnote private telemetry';
 export const telemetryDashboardUid = 'threadnote-telemetry';
 export const telemetryDashboardQueryLengthLimit = 1024;
-export const telemetryDashboardSourcePathInGitSync = 'threadnote-telemetry/threadnote-telemetry.json';
-export const telemetryDashboardFolderSourcePathInGitSync = 'threadnote-telemetry';
 
 type JsonPrimitive = boolean | null | number | string;
 interface JsonArray extends ReadonlyArray<JsonValue> {
@@ -27,34 +29,34 @@ interface JsonObject {
 }
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
-export type ProvisionedDashboard = Readonly<{
-  apiVersion: 'dashboard.grafana.app/v1';
-  kind: 'Dashboard';
-  metadata: Readonly<{name: typeof telemetryDashboardUid}>;
+export type DashboardArtifact = Readonly<{
+  dashboardUid: typeof telemetryDashboardUid;
+  folderUid: typeof telemetryDashboardFolderUid;
   spec: Readonly<Record<string, JsonValue>>;
 }>;
 
-export type ProvisionedFolder = Readonly<{
-  apiVersion: 'folder.grafana.app/v1';
-  kind: 'Folder';
-  metadata: Readonly<{name: typeof telemetryDashboardFolderUid}>;
-  spec: Readonly<{title: typeof telemetryDashboardFolderTitle}>;
-}>;
+export type DashboardDeploymentDecision = 'noop' | 'update';
 
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 const datasourcePlaceholder = '${DS_TEMPO}';
-// Grafana's Git Sync parser removes these repository-authored fields before it
-// writes a Dashboard resource. The stable UID remains metadata.name.
-const serverOwnedDashboardKeys = new Set(['id', 'iteration', 'uid', 'version']);
+const serverOwnedDashboardKeys = new Set(['id', 'iteration', 'schemaVersion', 'uid', 'version']);
+const migrationEmptyFieldConfigPanelIds = new Set([14, 15, 16, 17, 18, 19]);
 const grafanaCloudNamespacePattern = /^stacks-[1-9][0-9]*$/u;
-const dns1123LabelPattern = /^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$/u;
+const gitCommitPattern = /^[0-9a-f]{40}$/u;
+const dashboardApiVersion = 'dashboard.grafana.app/v1';
+const folderApiVersion = 'folder.grafana.app/v1';
 
 function record(value: unknown, path: string): Record<string, unknown> {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw new ScriptError(`${path} must be an object.`);
   }
   return value as Record<string, unknown>;
+}
+
+function optionalRecord(value: unknown, path: string): Record<string, unknown> {
+  if (value === undefined) return {};
+  return record(value, path);
 }
 
 export function validateGrafanaCloudNamespace(value: string): string {
@@ -64,17 +66,8 @@ export function validateGrafanaCloudNamespace(value: string): string {
   return value;
 }
 
-export function validateGrafanaGitSyncManagerId(value: string): string {
-  const labels = value.split('.');
-  if (
-    value.length === 0 ||
-    value.length > 253 ||
-    labels.some(label => label.length === 0 || label.length > 63 || !dns1123LabelPattern.test(label))
-  ) {
-    throw new ScriptError(
-      'THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID must be a valid lowercase repository resource name.',
-    );
-  }
+export function validateGitCommit(value: string, variableName: string): string {
+  if (!gitCommitPattern.test(value)) throw new ScriptError(`${variableName} must be a full lowercase Git commit SHA.`);
   return value;
 }
 
@@ -128,24 +121,9 @@ export function canonicalJson(value: JsonValue): string {
   return `${JSON.stringify(sortedJson(value), null, 2)}\n`;
 }
 
-export function validateProvisionedFolder(value: unknown): ProvisionedFolder {
-  const folder = cloneJson(value, 'provisioned folder');
-  const expected: ProvisionedFolder = {
-    apiVersion: 'folder.grafana.app/v1',
-    kind: 'Folder',
-    metadata: {name: telemetryDashboardFolderUid},
-    spec: {title: telemetryDashboardFolderTitle},
-  };
-  if (canonicalJson(folder) !== canonicalJson(expected)) {
-    throw new ScriptError('Provisioned folder must retain its exact private Git Sync identity and title.');
-  }
-  return value as ProvisionedFolder;
-}
-
 function validateImportContract(source: Record<string, unknown>): void {
-  if (source.uid !== telemetryDashboardUid) {
+  if (source.uid !== telemetryDashboardUid)
     throw new ScriptError(`Dashboard uid must remain ${telemetryDashboardUid}.`);
-  }
   const inputs = source.__inputs;
   if (!Array.isArray(inputs) || inputs.length !== 1) {
     throw new ScriptError('Dashboard import source must declare exactly one Tempo input.');
@@ -156,26 +134,21 @@ function validateImportContract(source: Record<string, unknown>): void {
   }
 }
 
-export function renderProvisionedDashboard(source: unknown): ProvisionedDashboard {
+export function renderDashboardArtifact(source: unknown): DashboardArtifact {
   const sourceRecord = record(source, 'dashboard');
   validateImportContract(sourceRecord);
   const replacements = {count: 0};
   const resolved = record(cloneResolvingDatasource(sourceRecord, 'dashboard', replacements), 'dashboard');
   if (replacements.count === 0) throw new ScriptError('Dashboard import source does not use the DS_TEMPO placeholder.');
-  delete resolved.__inputs;
-  delete resolved.__requires;
-  delete resolved.id;
-  delete resolved.iteration;
-  delete resolved.version;
+  for (const key of ['__inputs', '__requires', ...serverOwnedDashboardKeys]) delete resolved[key];
 
-  const provisioned: ProvisionedDashboard = {
-    apiVersion: 'dashboard.grafana.app/v1',
-    kind: 'Dashboard',
-    metadata: {name: telemetryDashboardUid},
+  const artifact: DashboardArtifact = {
+    dashboardUid: telemetryDashboardUid,
+    folderUid: telemetryDashboardFolderUid,
     spec: resolved as Readonly<Record<string, JsonValue>>,
   };
-  validateProvisionedDashboard(provisioned);
-  return provisioned;
+  validateDashboardArtifact(artifact);
+  return artifact;
 }
 
 type TempoQuery = Readonly<{
@@ -185,9 +158,9 @@ type TempoQuery = Readonly<{
   targetIndex: number;
 }>;
 
-export function collectTempoQueries(resource: ProvisionedDashboard): readonly TempoQuery[] {
+export function collectTempoQueries(resource: DashboardArtifact): readonly TempoQuery[] {
   const panels = resource.spec.panels;
-  if (!Array.isArray(panels) || panels.length === 0) throw new ScriptError('Provisioned dashboard has no panels.');
+  if (!Array.isArray(panels) || panels.length === 0) throw new ScriptError('Dashboard artifact has no panels.');
   const queries: TempoQuery[] = [];
   for (const [panelIndex, panelValue] of panels.entries()) {
     const panel = record(panelValue, `dashboard.panels[${panelIndex}]`);
@@ -218,49 +191,90 @@ export function collectTempoQueries(resource: ProvisionedDashboard): readonly Te
           `Dashboard panel ${panelId} target ${targetIndex} exceeds the ${telemetryDashboardQueryLengthLimit}-character Tempo query limit.`,
         );
       }
-      queries.push({
-        panelId,
-        query: target.query,
-        target: target as Readonly<Record<string, JsonValue>>,
-        targetIndex,
-      });
+      queries.push({panelId, query: target.query, target: target as Readonly<Record<string, JsonValue>>, targetIndex});
     }
   }
-  if (queries.length === 0) throw new ScriptError('Provisioned dashboard has no Tempo queries.');
+  if (queries.length === 0) throw new ScriptError('Dashboard artifact has no Tempo queries.');
   return queries;
 }
 
-export function validateProvisionedDashboard(resource: ProvisionedDashboard): void {
-  if (
-    resource.apiVersion !== 'dashboard.grafana.app/v1' ||
-    resource.kind !== 'Dashboard' ||
-    resource.metadata.name !== telemetryDashboardUid ||
-    resource.spec.uid !== telemetryDashboardUid
-  ) {
-    throw new ScriptError('Provisioned dashboard CRD identity is invalid.');
-  }
-  const rendered = canonicalJson(resource);
+export function validateDashboardArtifact(value: unknown): DashboardArtifact {
+  const artifact = validateHistoricalDashboardArtifact(value);
+  const artifactRecord = artifact as Readonly<Record<string, JsonValue>>;
+  const spec = artifact.spec;
+  const rendered = canonicalJson(cloneJson(artifactRecord, 'dashboard artifact'));
   if (rendered.includes(datasourcePlaceholder)) {
-    throw new ScriptError('Provisioned dashboard still contains an unresolved Tempo data-source placeholder.');
+    throw new ScriptError('Dashboard artifact still contains an unresolved Tempo data-source placeholder.');
   }
-  for (const key of ['__inputs', '__requires', 'id', 'iteration', 'version']) {
-    if (Object.hasOwn(resource.spec, key))
-      throw new ScriptError(`Provisioned dashboard retains volatile field ${key}.`);
+  for (const key of ['__inputs', '__requires', ...serverOwnedDashboardKeys]) {
+    if (Object.hasOwn(spec, key)) throw new ScriptError(`Dashboard artifact retains server-owned field ${key}.`);
   }
-  collectTempoQueries(resource);
+  collectTempoQueries(artifact);
+  return artifact;
 }
 
-export function canonicalDashboardSpec(value: unknown): string {
-  const dashboard = record(value, 'live dashboard');
-  const normalized: Record<string, JsonValue> = {};
-  for (const [key, item] of Object.entries(dashboard)) {
-    if (serverOwnedDashboardKeys.has(key)) continue;
-    normalized[key] = cloneJson(item, `live dashboard.${key}`);
+export function validateHistoricalDashboardArtifact(value: unknown): DashboardArtifact {
+  const artifactRecord = record(value, 'dashboard artifact');
+  record(artifactRecord.spec, 'dashboard artifact.spec');
+  if (
+    artifactRecord.dashboardUid !== telemetryDashboardUid ||
+    artifactRecord.folderUid !== telemetryDashboardFolderUid ||
+    Object.keys(artifactRecord).length !== 3 ||
+    Object.keys(artifactRecord).some(key => !['dashboardUid', 'folderUid', 'spec'].includes(key))
+  ) {
+    throw new ScriptError('Dashboard artifact must retain its exact dashboard and folder identity.');
   }
-  return canonicalJson(normalized);
+  cloneJson(artifactRecord, 'dashboard artifact');
+  return value as DashboardArtifact;
 }
 
-export function buildTempoQueryRequest(resource: ProvisionedDashboard, now = Date.now()): JsonValue {
+function isMigrationEmptyFieldConfig(value: unknown): boolean {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const fieldConfig = value as Record<string, unknown>;
+  const defaults = fieldConfig.defaults;
+  return (
+    Object.keys(fieldConfig).length === 2 &&
+    defaults !== null &&
+    typeof defaults === 'object' &&
+    !Array.isArray(defaults) &&
+    Object.keys(defaults).length === 0 &&
+    Array.isArray(fieldConfig.overrides) &&
+    fieldConfig.overrides.length === 0
+  );
+}
+
+export function canonicalDashboardSemantics(value: unknown): string {
+  const dashboard = record(cloneJson(value, 'dashboard spec'), 'dashboard spec');
+  for (const key of serverOwnedDashboardKeys) delete dashboard[key];
+  if (Array.isArray(dashboard.panels)) {
+    dashboard.panels = dashboard.panels.map((panelValue, index) => {
+      const panel = record(panelValue, `dashboard spec.panels[${index}]`);
+      if (
+        typeof panel.id === 'number' &&
+        migrationEmptyFieldConfigPanelIds.has(panel.id) &&
+        isMigrationEmptyFieldConfig(panel.fieldConfig)
+      ) {
+        delete panel.fieldConfig;
+      }
+      return panel;
+    });
+  }
+  return canonicalJson(dashboard as JsonObject);
+}
+
+export function assessDashboardThreeWay(
+  options: Readonly<{
+    current: string;
+    historical: readonly string[];
+    live: string;
+  }>,
+): DashboardDeploymentDecision {
+  if (options.live === options.current) return 'noop';
+  if (options.historical.includes(options.live)) return 'update';
+  throw new ScriptError('Live Grafana dashboard drifted from the current and trusted historical canonical artifacts.');
+}
+
+export function buildTempoQueryRequest(resource: DashboardArtifact, now = Date.now()): JsonValue {
   const queries = collectTempoQueries(resource).map(({panelId, target, targetIndex}) => ({
     ...target,
     datasource: {type: 'tempo', uid: telemetryDashboardDatasourceUid},
@@ -270,11 +284,7 @@ export function buildTempoQueryRequest(resource: ProvisionedDashboard, now = Dat
     refId: `P${panelId}T${targetIndex}`,
     spanLimit: 1,
   }));
-  return {
-    from: String(now - 5 * 60_000),
-    queries,
-    to: String(now),
-  };
+  return {from: String(now - 5 * 60_000), queries, to: String(now)};
 }
 
 function grafanaUrl(baseUrl: string, path: string): URL {
@@ -284,13 +294,31 @@ function grafanaUrl(baseUrl: string, path: string): URL {
   } catch {
     throw new ScriptError('THREADNOTE_TELEMETRY_GRAFANA_URL must be an absolute HTTPS URL.');
   }
-  if (base.protocol !== 'https:' || base.username || base.password || base.search || base.hash) {
-    throw new ScriptError('THREADNOTE_TELEMETRY_GRAFANA_URL must be an uncredentialed HTTPS origin.');
+  const labels = base.hostname.split('.');
+  if (
+    base.protocol !== 'https:' ||
+    base.username ||
+    base.password ||
+    base.port ||
+    base.pathname !== '/' ||
+    base.search ||
+    base.hash ||
+    base.hostname === 'grafana.net' ||
+    !base.hostname.endsWith('.grafana.net') ||
+    labels.some(label => label.length === 0)
+  ) {
+    throw new ScriptError('THREADNOTE_TELEMETRY_GRAFANA_URL must be an uncredentialed Grafana Cloud HTTPS origin.');
   }
   return new URL(path, `${base.origin}/`);
 }
 
-async function fetchJson(fetcher: FetchLike, url: URL, token: string, init?: RequestInit): Promise<unknown> {
+async function fetchResponse(
+  fetcher: FetchLike,
+  url: URL,
+  token: string,
+  init?: RequestInit,
+  expectedStatus?: number,
+): Promise<Response> {
   let response: Response;
   try {
     response = await fetcher(url, {
@@ -304,11 +332,22 @@ async function fetchJson(fetcher: FetchLike, url: URL, token: string, init?: Req
       signal: AbortSignal.timeout(30_000),
     });
   } catch {
-    // Do not let transport errors echo a private Grafana stack namespace or
-    // repository manager identity from a request URL.
-    throw new ScriptError('Grafana API request failed before receiving a response.');
+    throw new GrafanaTransportError();
   }
-  if (!response.ok) throw new GrafanaHttpError(response.status);
+  if (expectedStatus === undefined ? !response.ok : response.status !== expectedStatus) {
+    throw new GrafanaHttpError(response.status);
+  }
+  return response;
+}
+
+async function fetchJson(
+  fetcher: FetchLike,
+  url: URL,
+  token: string,
+  init?: RequestInit,
+  expectedStatus?: number,
+): Promise<unknown> {
+  const response = await fetchResponse(fetcher, url, token, init, expectedStatus);
   try {
     return await response.json();
   } catch {
@@ -316,57 +355,145 @@ async function fetchJson(fetcher: FetchLike, url: URL, token: string, init?: Req
   }
 }
 
-type ExpectedGitSyncResource = Readonly<{
-  apiVersion: string;
-  folderUid?: string;
-  kind: string;
-  managerId: string;
-  name: string;
+type LiveDashboard = Readonly<{
+  annotations: JsonObject;
+  internalUid: string;
+  labels: JsonObject;
   namespace: string;
-  sourcePath: string;
+  resourceVersion: string;
+  schemaVersion: number;
+  spec: Record<string, unknown>;
 }>;
 
-function gitSyncResource(
-  value: unknown,
-  expected: ExpectedGitSyncResource,
-): Readonly<{
-  matches: boolean;
-  spec: Record<string, unknown>;
-}> {
-  const resource = record(value, 'Grafana resource response');
-  const metadata = record(resource.metadata, 'Grafana resource response.metadata');
-  const spec = record(resource.spec, 'Grafana resource response.spec');
-  const annotations =
-    metadata.annotations !== null && typeof metadata.annotations === 'object' && !Array.isArray(metadata.annotations)
-      ? (metadata.annotations as Record<string, unknown>)
-      : {};
+function annotationsFromMetadata(metadata: Record<string, unknown>, path: string): Record<string, unknown> {
+  return optionalRecord(metadata.annotations, `${path}.annotations`);
+}
+
+function rejectManagedResource(metadata: Record<string, unknown>): void {
+  const annotations = annotationsFromMetadata(metadata, 'Grafana resource metadata');
+  const labels = optionalRecord(metadata.labels, 'Grafana resource metadata.labels');
+  const isReservedProvenanceKey = (key: string): boolean =>
+    key.startsWith('grafana.app/managed') ||
+    key.startsWith('grafana.app/manager') ||
+    key.startsWith('grafana.app/repo') ||
+    key.startsWith('grafana.app/source') ||
+    key.startsWith('provisioning.grafana.app/');
+  if ([...Object.keys(annotations), ...Object.keys(labels)].some(isReservedProvenanceKey)) {
+    throw new ScriptError('Direct dashboard provisioning refuses a managed or provisioned Grafana resource.');
+  }
+}
+
+function parseLiveDashboard(value: unknown, namespace: string): LiveDashboard {
+  const resource = record(value, 'Grafana dashboard response');
+  const metadata = record(resource.metadata, 'Grafana dashboard response.metadata');
+  const annotations = annotationsFromMetadata(metadata, 'Grafana dashboard response.metadata');
+  const spec = record(resource.spec, 'Grafana dashboard response.spec');
+  rejectManagedResource(metadata);
+  if (
+    resource.apiVersion !== dashboardApiVersion ||
+    resource.kind !== 'Dashboard' ||
+    metadata.name !== telemetryDashboardUid ||
+    metadata.namespace !== namespace ||
+    annotations['grafana.app/folder'] !== telemetryDashboardFolderUid
+  ) {
+    throw new ScriptError('Grafana dashboard identity or folder does not match the fixed deployment target.');
+  }
+  if (typeof metadata.resourceVersion !== 'string' || metadata.resourceVersion.length === 0) {
+    throw new ScriptError('Grafana dashboard response is missing metadata.resourceVersion.');
+  }
+  if (typeof metadata.uid !== 'string' || metadata.uid.length === 0) {
+    throw new ScriptError('Grafana dashboard response is missing its immutable metadata.uid.');
+  }
+  if (!Number.isInteger(spec.schemaVersion) || (spec.schemaVersion as number) < 1) {
+    throw new ScriptError('Grafana dashboard response is missing a valid server schemaVersion.');
+  }
   return {
-    matches:
-      resource.apiVersion === expected.apiVersion &&
-      resource.kind === expected.kind &&
-      metadata.name === expected.name &&
-      metadata.namespace === expected.namespace &&
-      annotations['grafana.app/managedBy'] === 'repo' &&
-      annotations['grafana.app/managerId'] === expected.managerId &&
-      annotations['grafana.app/sourcePath'] === expected.sourcePath &&
-      (expected.folderUid === undefined || annotations['grafana.app/folder'] === expected.folderUid),
+    annotations: cloneJson(annotations, 'Grafana dashboard response.metadata.annotations') as JsonObject,
+    internalUid: metadata.uid,
+    labels: cloneJson(
+      optionalRecord(metadata.labels, 'Grafana dashboard response.metadata.labels'),
+      'Grafana dashboard response.metadata.labels',
+    ) as JsonObject,
+    namespace,
+    resourceVersion: metadata.resourceVersion,
+    schemaVersion: spec.schemaVersion as number,
     spec,
   };
 }
 
+function validateLiveFolder(value: unknown, namespace: string): void {
+  const resource = record(value, 'Grafana folder response');
+  const metadata = record(resource.metadata, 'Grafana folder response.metadata');
+  const annotations = annotationsFromMetadata(metadata, 'Grafana folder response.metadata');
+  const spec = record(resource.spec, 'Grafana folder response.spec');
+  rejectManagedResource(metadata);
+  if (
+    resource.apiVersion !== folderApiVersion ||
+    resource.kind !== 'Folder' ||
+    metadata.name !== telemetryDashboardFolderUid ||
+    metadata.namespace !== namespace ||
+    spec.title !== telemetryDashboardFolderTitle ||
+    Object.hasOwn(annotations, 'grafana.app/folder')
+  ) {
+    throw new ScriptError('Grafana private folder identity or title does not match the fixed deployment target.');
+  }
+}
+
 function validatePrivateFolderPermissions(value: unknown): void {
   if (!Array.isArray(value)) throw new ScriptError('Grafana folder permissions response must be an array.');
-  let broadPermissionCount = 0;
   for (const [index, item] of value.entries()) {
     const permission = record(item, `Grafana folder permissions response[${index}]`);
     const role = typeof permission.role === 'string' ? permission.role.toLowerCase() : '';
     if (role === 'viewer' || role === 'editor' || permission.folderId === -1 || permission.dashboardId === -1) {
-      broadPermissionCount += 1;
+      throw new ScriptError('Grafana private folder still grants broad default Viewer or Editor access.');
     }
   }
-  if (broadPermissionCount > 0) {
-    throw new ScriptError('Grafana provisioned folder still grants broad default Viewer or Editor access.');
+}
+
+function validateExactPermissions(
+  value: unknown,
+  actor: 'reader' | 'writer',
+  exactScopes: Readonly<Record<string, string>>,
+): void {
+  const permissions = record(value, 'Grafana effective permissions response');
+  for (const [action, scopesValue] of Object.entries(permissions)) {
+    if (!Array.isArray(scopesValue) || scopesValue.some(scope => typeof scope !== 'string')) {
+      throw new ScriptError('Grafana effective permissions response has an invalid scope list.');
+    }
+    const scopes = scopesValue as string[];
+    if (!Object.hasOwn(exactScopes, action) || scopes.some(scope => scope === '*' || scope.endsWith(':*'))) {
+      throw new ScriptError(`Grafana dashboard ${actor} has a forbidden permission action or scope.`);
+    }
+    const expectedScope = exactScopes[action];
+    if (expectedScope === undefined || scopes.length !== 1 || scopes[0] !== expectedScope) {
+      throw new ScriptError(`Grafana dashboard ${actor} is not restricted to the exact allowed targets.`);
+    }
   }
+  for (const [action, expectedScope] of Object.entries(exactScopes)) {
+    const scopes = permissions[action];
+    if (!Array.isArray(scopes) || scopes.length !== 1 || scopes[0] !== expectedScope) {
+      throw new ScriptError(`Grafana dashboard ${actor} is missing a required exact-target permission.`);
+    }
+  }
+}
+
+export function validateWriterPermissions(value: unknown): void {
+  validateExactPermissions(value, 'writer', {
+    'dashboards:read': `dashboards:uid:${telemetryDashboardUid}`,
+    'dashboards:write': `dashboards:uid:${telemetryDashboardUid}`,
+    'folders.permissions:read': `folders:uid:${telemetryDashboardFolderUid}`,
+    'folders:read': `folders:uid:${telemetryDashboardFolderUid}`,
+  });
+}
+
+export function validateReaderPermissions(value: unknown): void {
+  validateExactPermissions(value, 'reader', {
+    'dashboards:read': `dashboards:uid:${telemetryDashboardUid}`,
+    'datasources:query': `datasources:uid:${telemetryDashboardDatasourceUid}`,
+    'datasources:read': `datasources:uid:${telemetryDashboardDatasourceUid}`,
+    'folders.permissions:read': `folders:uid:${telemetryDashboardFolderUid}`,
+    'folders:read': `folders:uid:${telemetryDashboardFolderUid}`,
+  });
 }
 
 function queryErrors(value: unknown, expectedReferenceIds: readonly string[]): readonly string[] {
@@ -387,89 +514,180 @@ function queryErrors(value: unknown, expectedReferenceIds: readonly string[]): r
   return errors;
 }
 
-export async function verifyLiveDashboard(options: {
-  readonly baseUrl: string;
-  readonly fetcher?: FetchLike;
-  readonly folder: ProvisionedFolder;
-  readonly managerId: string;
-  readonly namespace: string;
-  readonly pollIntervalMs?: number;
-  readonly resource: ProvisionedDashboard;
-  readonly syncTimeoutMs?: number;
-  readonly token: string;
-}): Promise<void> {
-  if (options.token.trim().length === 0) {
-    throw new ScriptError('THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN is required when Git Sync verification is enabled.');
-  }
-  const namespace = validateGrafanaCloudNamespace(options.namespace);
-  const managerId = validateGrafanaGitSyncManagerId(options.managerId);
-  const fetcher = options.fetcher ?? fetch;
-  const pollIntervalMs = options.pollIntervalMs ?? 10_000;
-  const syncTimeoutMs = options.syncTimeoutMs ?? 5 * 60_000;
-  const expected = canonicalDashboardSpec(options.resource.spec);
-  const dashboardUrl = grafanaUrl(
-    options.baseUrl,
+function dashboardUrl(baseUrl: string, namespace: string): URL {
+  return grafanaUrl(
+    baseUrl,
     `/apis/dashboard.grafana.app/v1/namespaces/${namespace}/dashboards/${telemetryDashboardUid}`,
   );
-  const folderUrl = grafanaUrl(
-    options.baseUrl,
+}
+
+function folderUrl(baseUrl: string, namespace: string): URL {
+  return grafanaUrl(
+    baseUrl,
     `/apis/folder.grafana.app/v1/namespaces/${namespace}/folders/${telemetryDashboardFolderUid}`,
   );
-  const deadline = Date.now() + syncTimeoutMs;
-  let synchronized = false;
-  do {
-    try {
-      const liveDashboard = gitSyncResource(await fetchJson(fetcher, dashboardUrl, options.token), {
-        apiVersion: options.resource.apiVersion,
-        folderUid: telemetryDashboardFolderUid,
-        kind: options.resource.kind,
-        managerId,
-        name: telemetryDashboardUid,
-        namespace,
-        sourcePath: telemetryDashboardSourcePathInGitSync,
-      });
-      if (liveDashboard.matches && canonicalDashboardSpec(liveDashboard.spec) === expected) {
-        const liveFolder = gitSyncResource(await fetchJson(fetcher, folderUrl, options.token), {
-          apiVersion: options.folder.apiVersion,
-          kind: options.folder.kind,
-          managerId,
-          name: telemetryDashboardFolderUid,
-          namespace,
-          sourcePath: telemetryDashboardFolderSourcePathInGitSync,
-        });
-        if (
-          liveFolder.matches &&
-          canonicalDashboardSpec(liveFolder.spec) === canonicalDashboardSpec(options.folder.spec)
-        ) {
-          synchronized = true;
-          break;
-        }
-      }
-    } catch (error) {
-      if (!(error instanceof GrafanaHttpError) || error.status !== 404) throw error;
-    }
-    if (Date.now() < deadline) await Bun.sleep(pollIntervalMs);
-  } while (Date.now() < deadline);
-  if (!synchronized) {
-    throw new ScriptError('Grafana Git Sync did not converge to the canonical dashboard before the timeout.');
-  }
+}
 
-  const permissionsUrl = grafanaUrl(options.baseUrl, `/api/folders/${telemetryDashboardFolderUid}/permissions`);
-  validatePrivateFolderPermissions(await fetchJson(fetcher, permissionsUrl, options.token));
+async function readAndValidateFolder(
+  fetcher: FetchLike,
+  baseUrl: string,
+  namespace: string,
+  token: string,
+): Promise<void> {
+  validateLiveFolder(await fetchJson(fetcher, folderUrl(baseUrl, namespace), token, undefined, 200), namespace);
+  validatePrivateFolderPermissions(
+    await fetchJson(
+      fetcher,
+      grafanaUrl(baseUrl, `/api/folders/${telemetryDashboardFolderUid}/permissions`),
+      token,
+      undefined,
+      200,
+    ),
+  );
+}
 
-  const request = buildTempoQueryRequest(options.resource);
-  const queryUrl = grafanaUrl(options.baseUrl, '/api/ds/query');
-  const response = await fetchJson(fetcher, queryUrl, options.token, {
-    body: JSON.stringify(request),
-    method: 'POST',
-  });
+async function verifyTempoQueries(
+  fetcher: FetchLike,
+  baseUrl: string,
+  token: string,
+  resource: DashboardArtifact,
+): Promise<void> {
+  const request = buildTempoQueryRequest(resource);
+  const response = await fetchJson(
+    fetcher,
+    grafanaUrl(baseUrl, '/api/ds/query'),
+    token,
+    {body: JSON.stringify(request), method: 'POST'},
+    200,
+  );
   const requestRecord = record(request, 'Grafana query request');
   const queries = requestRecord.queries as readonly Readonly<Record<string, JsonValue>>[];
-  const referenceIds = queries.map(query => query.refId as string);
-  const errors = queryErrors(response, referenceIds);
-  if (errors.length > 0) {
-    throw new ScriptError(`Grafana rejected ${errors.length} bounded dashboard query targets.`);
+  const errors = queryErrors(
+    response,
+    queries.map(query => query.refId as string),
+  );
+  if (errors.length > 0) throw new ScriptError(`Grafana rejected ${errors.length} bounded dashboard query targets.`);
+}
+
+export async function verifyLiveDashboard(
+  options: Readonly<{
+    baseUrl: string;
+    fetcher?: FetchLike;
+    namespace: string;
+    resource: DashboardArtifact;
+    token: string;
+  }>,
+): Promise<void> {
+  if (options.token.trim().length === 0) {
+    throw new ScriptError('THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN is required when live verification is enabled.');
   }
+  const namespace = validateGrafanaCloudNamespace(options.namespace);
+  const fetcher = options.fetcher ?? fetch;
+  validateReaderPermissions(
+    await fetchJson(
+      fetcher,
+      grafanaUrl(options.baseUrl, '/api/access-control/user/permissions'),
+      options.token,
+      undefined,
+      200,
+    ),
+  );
+  const live = parseLiveDashboard(
+    await fetchJson(fetcher, dashboardUrl(options.baseUrl, namespace), options.token, undefined, 200),
+    namespace,
+  );
+  if (canonicalDashboardSemantics(live.spec) !== canonicalDashboardSemantics(options.resource.spec)) {
+    throw new ScriptError('Live Grafana dashboard does not match the canonical dashboard artifact.');
+  }
+  await readAndValidateFolder(fetcher, options.baseUrl, namespace, options.token);
+  await verifyTempoQueries(fetcher, options.baseUrl, options.token, options.resource);
+}
+
+function buildDashboardUpdate(live: LiveDashboard, resource: DashboardArtifact, currentSha: string): JsonObject {
+  return {
+    apiVersion: dashboardApiVersion,
+    kind: 'Dashboard',
+    metadata: {
+      annotations: {
+        ...live.annotations,
+        'grafana.app/folder': telemetryDashboardFolderUid,
+        'grafana.app/message': `Threadnote telemetry dashboard ${currentSha}`,
+      },
+      labels: live.labels,
+      name: telemetryDashboardUid,
+      namespace: live.namespace,
+      resourceVersion: live.resourceVersion,
+      uid: live.internalUid,
+    },
+    spec: {...resource.spec, schemaVersion: live.schemaVersion},
+  };
+}
+
+function validatePostUpdate(previous: LiveDashboard, updated: LiveDashboard, expected: DashboardArtifact): void {
+  if (
+    updated.internalUid !== previous.internalUid ||
+    updated.resourceVersion === previous.resourceVersion ||
+    updated.schemaVersion !== previous.schemaVersion ||
+    canonicalDashboardSemantics(updated.spec) !== canonicalDashboardSemantics(expected.spec)
+  ) {
+    throw new ScriptError('Grafana dashboard post-update state failed its identity, CAS, schema, or semantic check.');
+  }
+}
+
+export async function deployDashboard(
+  options: Readonly<{
+    baseUrl: string;
+    current: DashboardArtifact;
+    currentSha: string;
+    fetcher?: FetchLike;
+    historical: readonly DashboardArtifact[];
+    namespace: string;
+    token: string;
+  }>,
+): Promise<DashboardDeploymentDecision> {
+  if (options.token.trim().length === 0) {
+    throw new ScriptError('THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN is required when direct deployment is enabled.');
+  }
+  const namespace = validateGrafanaCloudNamespace(options.namespace);
+  const currentSha = validateGitCommit(options.currentSha, 'THREADNOTE_TELEMETRY_DASHBOARD_CURRENT_SHA');
+  const fetcher = options.fetcher ?? fetch;
+  validateDashboardArtifact(options.current);
+  for (const artifact of options.historical) validateHistoricalDashboardArtifact(artifact);
+  validateWriterPermissions(
+    await fetchJson(
+      fetcher,
+      grafanaUrl(options.baseUrl, '/api/access-control/user/permissions'),
+      options.token,
+      undefined,
+      200,
+    ),
+  );
+  await readAndValidateFolder(fetcher, options.baseUrl, namespace, options.token);
+  const url = dashboardUrl(options.baseUrl, namespace);
+  const live = parseLiveDashboard(await fetchJson(fetcher, url, options.token, undefined, 200), namespace);
+  const decision = assessDashboardThreeWay({
+    current: canonicalDashboardSemantics(options.current.spec),
+    historical: options.historical.map(artifact => canonicalDashboardSemantics(artifact.spec)),
+    live: canonicalDashboardSemantics(live.spec),
+  });
+  if (decision === 'noop') return decision;
+
+  const body = buildDashboardUpdate(live, options.current, currentSha);
+  try {
+    await fetchResponse(fetcher, url, options.token, {body: JSON.stringify(body), method: 'PUT'}, 200);
+  } catch (error) {
+    if (!(error instanceof GrafanaTransportError)) throw error;
+    const observed = parseLiveDashboard(await fetchJson(fetcher, url, options.token, undefined, 200), namespace);
+    try {
+      validatePostUpdate(live, observed, options.current);
+      return decision;
+    } catch {
+      throw new ScriptError('Grafana dashboard update outcome is indeterminate after a transport failure.');
+    }
+  }
+  const updated = parseLiveDashboard(await fetchJson(fetcher, url, options.token, undefined, 200), namespace);
+  validatePostUpdate(live, updated, options.current);
+  return decision;
 }
 
 async function loadSource(repositoryRoot: string): Promise<unknown> {
@@ -483,63 +701,127 @@ async function loadSource(repositoryRoot: string): Promise<unknown> {
   }
 }
 
-async function loadProvisionedFolder(repositoryRoot: string): Promise<ProvisionedFolder> {
-  const folder = Bun.file(`${repositoryRoot}/${telemetryDashboardFolderPath}`);
-  if (!(await folder.exists())) {
-    throw new ScriptError(`Provisioned folder is missing at ${telemetryDashboardFolderPath}.`);
-  }
+async function loadArtifact(repositoryRoot: string): Promise<DashboardArtifact> {
+  const artifact = Bun.file(`${repositoryRoot}/${telemetryDashboardArtifactPath}`);
+  if (!(await artifact.exists()))
+    throw new ScriptError(`Dashboard artifact is missing at ${telemetryDashboardArtifactPath}.`);
   try {
-    return validateProvisionedFolder(await folder.json());
+    return validateDashboardArtifact(await artifact.json());
   } catch (error) {
     if (error instanceof ScriptError) throw error;
-    throw new ScriptError(`Provisioned folder at ${telemetryDashboardFolderPath} is not valid JSON.`);
+    throw new ScriptError(`Dashboard artifact at ${telemetryDashboardArtifactPath} is not valid JSON.`);
   }
+}
+
+type GitReader = (args: readonly string[]) => Promise<string | undefined>;
+
+async function tryRunGit(repositoryRoot: string, args: readonly string[]): Promise<string | undefined> {
+  const child = Bun.spawn(['git', ...args], {cwd: repositoryRoot, stderr: 'ignore', stdout: 'pipe'});
+  const output = await new Response(child.stdout).text();
+  if ((await child.exited) !== 0) return undefined;
+  return output.trim();
+}
+
+async function runGit(repositoryRoot: string, args: readonly string[]): Promise<string> {
+  const output = await tryRunGit(repositoryRoot, args);
+  if (output === undefined) throw new ScriptError('Git history does not contain the required deployment baseline.');
+  return output;
+}
+
+export async function loadHistoricalArtifacts(
+  repositoryRoot: string,
+  currentSha: string,
+  readGit: GitReader = args => tryRunGit(repositoryRoot, args),
+): Promise<readonly DashboardArtifact[]> {
+  validateGitCommit(currentSha, 'THREADNOTE_TELEMETRY_DASHBOARD_CURRENT_SHA');
+  const history = await readGit([
+    'log',
+    '--first-parent',
+    '--format=%H',
+    '--max-count=65',
+    currentSha,
+    '--',
+    telemetryDashboardArtifactPath,
+  ]);
+  if (history === undefined) throw new ScriptError('Git history does not contain the required deployment baseline.');
+  const revisions = history
+    .split('\n')
+    .filter(revision => revision.length > 0 && revision !== currentSha)
+    .slice(0, 64);
+  const artifacts: DashboardArtifact[] = [];
+  for (const revision of revisions) {
+    const json = await readGit(['show', `${revision}:${telemetryDashboardArtifactPath}`]);
+    if (json === undefined) continue;
+    try {
+      artifacts.push(validateHistoricalDashboardArtifact(JSON.parse(json)));
+    } catch (error) {
+      if (error instanceof ScriptError) throw error;
+      throw new ScriptError('A trusted historical dashboard artifact is not valid JSON.');
+    }
+  }
+  return artifacts;
 }
 
 export async function renderTelemetryDashboard(repositoryRoot = process.cwd()): Promise<string> {
-  return canonicalJson(renderProvisionedDashboard(await loadSource(repositoryRoot)));
+  return canonicalJson(renderDashboardArtifact(await loadSource(repositoryRoot)));
 }
 
-async function formatProvisionedDashboard(rendered: string): Promise<string> {
+export async function formatDashboardArtifact(rendered: string): Promise<string> {
   const {format} = await import('prettier');
   return format(rendered, {parser: 'json', printWidth: 120});
 }
 
+export function validateDashboardArtifactBytes(actual: string, expected: string): void {
+  if (actual !== expected) {
+    throw new ScriptError(`Dashboard artifact is stale; run bun scripts/telemetry-dashboard.ts render.`);
+  }
+}
+
 async function run(command: string | undefined): Promise<void> {
-  const rendered = await renderTelemetryDashboard();
-  const folder = await loadProvisionedFolder(process.cwd());
+  const repositoryRoot = process.cwd();
+  const rendered = await renderTelemetryDashboard(repositoryRoot);
   if (command === 'render') {
-    await Bun.write(telemetryDashboardProvisionedPath, await formatProvisionedDashboard(rendered));
-    process.stdout.write(`Rendered ${telemetryDashboardProvisionedPath}\n`);
+    await Bun.write(telemetryDashboardArtifactPath, await formatDashboardArtifact(rendered));
+    process.stdout.write(`Rendered ${telemetryDashboardArtifactPath}\n`);
     return;
+  }
+  const resource = await loadArtifact(repositoryRoot);
+  if (canonicalJson(resource) !== canonicalJson(JSON.parse(rendered) as JsonValue)) {
+    throw new ScriptError(`Dashboard artifact is stale; run bun scripts/telemetry-dashboard.ts render.`);
   }
   if (command === 'check') {
-    const artifact = Bun.file(telemetryDashboardProvisionedPath);
-    if (!(await artifact.exists()) || (await artifact.text()) !== (await formatProvisionedDashboard(rendered))) {
-      throw new ScriptError(`Provisioned dashboard is stale; run bun scripts/telemetry-dashboard.ts render.`);
-    }
-    process.stdout.write(`Verified ${telemetryDashboardProvisionedPath}\n`);
+    validateDashboardArtifactBytes(
+      await Bun.file(`${repositoryRoot}/${telemetryDashboardArtifactPath}`).text(),
+      await formatDashboardArtifact(rendered),
+    );
+    process.stdout.write(`Verified ${telemetryDashboardArtifactPath}\n`);
     return;
   }
+  const baseUrl = Bun.env.THREADNOTE_TELEMETRY_GRAFANA_URL?.trim() ?? '';
+  const namespace = Bun.env.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE?.trim() ?? '';
   if (command === 'verify-live') {
-    const baseUrl = Bun.env.THREADNOTE_TELEMETRY_GRAFANA_URL?.trim() ?? '';
-    const managerId = Bun.env.THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID?.trim() ?? '';
-    const namespace = Bun.env.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE?.trim() ?? '';
     const token = Bun.env.THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN?.trim() ?? '';
-    await verifyLiveDashboard({
-      baseUrl,
-      folder,
-      managerId,
-      namespace,
-      resource: JSON.parse(rendered) as ProvisionedDashboard,
-      token,
-    });
+    await verifyLiveDashboard({baseUrl, namespace, resource, token});
+    process.stdout.write(`Verified Grafana dashboard ${telemetryDashboardUid} and its bounded Tempo queries.\n`);
+    return;
+  }
+  if (command === 'deploy') {
+    const currentSha = Bun.env.THREADNOTE_TELEMETRY_DASHBOARD_CURRENT_SHA?.trim() ?? '';
+    const token = Bun.env.THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN?.trim() ?? '';
+    validateGitCommit(currentSha, 'THREADNOTE_TELEMETRY_DASHBOARD_CURRENT_SHA');
+    if ((await runGit(repositoryRoot, ['rev-parse', 'HEAD'])) !== currentSha) {
+      throw new ScriptError('Checked-out HEAD does not match the requested dashboard deployment commit.');
+    }
+    const historical = await loadHistoricalArtifacts(repositoryRoot, currentSha);
+    const decision = await deployDashboard({baseUrl, current: resource, currentSha, historical, namespace, token});
     process.stdout.write(
-      `Verified synchronized Grafana dashboard ${telemetryDashboardUid} and its bounded Tempo queries.\n`,
+      decision === 'noop'
+        ? `Grafana dashboard ${telemetryDashboardUid} already matches the canonical artifact.\n`
+        : `Updated Grafana dashboard ${telemetryDashboardUid} with optimistic concurrency.\n`,
     );
     return;
   }
-  throw new ScriptError('Usage: bun scripts/telemetry-dashboard.ts <render|check|verify-live>');
+  throw new ScriptError('Usage: bun scripts/telemetry-dashboard.ts <render|check|deploy|verify-live>');
 }
 
 if (import.meta.main) {

--- a/test/unit/publish-workflow.test.ts
+++ b/test/unit/publish-workflow.test.ts
@@ -213,6 +213,10 @@ describe('standalone release workflows', () => {
           '    # GitHub supports queue:max; Actionlint 1.7.12 predates that workflow syntax.',
           '    ignore:',
           `      - '^unexpected key "queue" for "concurrency" section\\. expected one of "cancel-in-progress", "group"$'`,
+          '  .github/workflows/telemetry-dashboard.yml:',
+          '    # GitHub supports queue:max; Actionlint 1.7.12 predates that workflow syntax.',
+          '    ignore:',
+          `      - '^unexpected key "queue" for "concurrency" section\\. expected one of "cancel-in-progress", "group"$'`,
           '',
         ].join('\n'),
       );

--- a/test/unit/telemetry-dashboard-provisioning.test.ts
+++ b/test/unit/telemetry-dashboard-provisioning.test.ts
@@ -3,49 +3,53 @@ import {describe, expect, it} from '@effect/vitest';
 import * as FC from 'effect/testing/FastCheck';
 import {JSON_SCHEMA, load} from 'js-yaml';
 import {
+  assessDashboardThreeWay,
   buildTempoQueryRequest,
-  canonicalDashboardSpec,
+  canonicalDashboardSemantics,
   canonicalJson,
   collectTempoQueries,
-  renderProvisionedDashboard,
+  deployDashboard,
+  formatDashboardArtifact,
+  loadHistoricalArtifacts,
+  renderDashboardArtifact,
+  telemetryDashboardArtifactPath,
   telemetryDashboardDatasourceUid,
-  telemetryDashboardFolderPath,
-  telemetryDashboardFolderSourcePathInGitSync,
   telemetryDashboardFolderTitle,
   telemetryDashboardFolderUid,
-  telemetryDashboardProvisionedPath,
   telemetryDashboardQueryLengthLimit,
   telemetryDashboardSourcePath,
-  telemetryDashboardSourcePathInGitSync,
   telemetryDashboardUid,
   validateGrafanaCloudNamespace,
-  validateGrafanaGitSyncManagerId,
+  validateDashboardArtifactBytes,
+  validateReaderPermissions,
+  validateWriterPermissions,
   verifyLiveDashboard,
+  type DashboardArtifact,
   type JsonValue,
-  type ProvisionedDashboard,
-  type ProvisionedFolder,
 } from '../../scripts/telemetry-dashboard.js';
 
 const testGrafanaNamespace = 'stacks-123456';
-const testGitSyncManagerId = 'repository-threadnote-telemetry';
+const testGrafanaUrl = 'https://threadnote-test.grafana.net';
+const currentSha = 'a'.repeat(40);
 
 type WorkflowJob = Readonly<{
-  environment?: string | Readonly<{deployment: boolean; name: string}>;
+  environment?: string | Readonly<{deployment?: boolean; name: string}>;
   if?: string;
-  needs?: string;
-  permissions?: Readonly<Record<string, string>>;
+  needs?: string | readonly string[];
+  outputs?: Readonly<Record<string, string>>;
   steps?: readonly Readonly<{
     env?: Readonly<Record<string, string>>;
+    id?: string;
     if?: string;
     name?: string;
     run?: string;
     uses?: string;
+    with?: Readonly<Record<string, unknown>>;
   }>[];
-  'timeout-minutes'?: number;
 }>;
 
 type DashboardWorkflow = Readonly<{
-  concurrency: Readonly<{'cancel-in-progress': boolean; group: string}>;
+  concurrency: Readonly<{'cancel-in-progress': boolean; group: string; queue: string}>;
   jobs: Readonly<Record<string, WorkflowJob>>;
   on: Readonly<{
     pull_request: Readonly<{branches: readonly string[]; paths: readonly string[]}>;
@@ -60,12 +64,16 @@ function readDashboardSource(): unknown {
   return JSON.parse(readFileSync(telemetryDashboardSourcePath, 'utf8'));
 }
 
-function readProvisionedDashboard(): ProvisionedDashboard {
-  return JSON.parse(readFileSync(telemetryDashboardProvisionedPath, 'utf8')) as ProvisionedDashboard;
+function readDashboardArtifact(): DashboardArtifact {
+  return JSON.parse(readFileSync(telemetryDashboardArtifactPath, 'utf8')) as DashboardArtifact;
 }
 
-function readProvisionedFolder(): ProvisionedFolder {
-  return JSON.parse(readFileSync(telemetryDashboardFolderPath, 'utf8')) as ProvisionedFolder;
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function artifactWithTitle(resource: DashboardArtifact, title: string): DashboardArtifact {
+  return {...resource, spec: {...resource.spec, title}};
 }
 
 function permuteObjectKeys(value: unknown, choices: readonly number[], offset = {value: 0}): unknown {
@@ -79,62 +87,143 @@ function permuteObjectKeys(value: unknown, choices: readonly number[], offset = 
   return Object.fromEntries(rotated.map(([key, item]) => [key, permuteObjectKeys(item, choices, offset)]));
 }
 
-function successfulQueryResponse(resource: ProvisionedDashboard): unknown {
+function successfulQueryResponse(resource: DashboardArtifact): unknown {
   const request = buildTempoQueryRequest(resource) as Readonly<Record<string, JsonValue>>;
   const queries = request.queries as readonly Readonly<Record<string, JsonValue>>[];
   return {results: Object.fromEntries(queries.map(query => [query.refId, {frames: []}]))};
 }
 
-function storedDashboardSpec(resource: ProvisionedDashboard): Readonly<Record<string, JsonValue>> {
-  return Object.fromEntries(Object.entries(resource.spec).filter(([key]) => !['id', 'uid', 'version'].includes(key)));
-}
-
-function liveGitSyncResource(
-  resource: ProvisionedDashboard | ProvisionedFolder,
+function liveDashboard(
+  resource: DashboardArtifact,
   options: Readonly<{
-    folderUid?: string;
-    managedBy?: string;
-    managerId?: string;
-    namespace?: string;
-    sourcePath: string;
+    annotations?: Readonly<Record<string, string>>;
+    internalUid?: string;
+    labels?: Readonly<Record<string, string>>;
+    resourceVersion?: string;
+    schemaVersion?: number;
     spec?: Readonly<Record<string, JsonValue>>;
-  }>,
+  }> = {},
 ): unknown {
   return {
-    apiVersion: resource.apiVersion,
-    kind: resource.kind,
+    access: {canEdit: true},
+    apiVersion: 'dashboard.grafana.app/v1',
+    kind: 'Dashboard',
     metadata: {
-      annotations: {
-        'grafana.app/managedBy': options.managedBy ?? 'repo',
-        'grafana.app/managerId': options.managerId ?? testGitSyncManagerId,
-        'grafana.app/sourcePath': options.sourcePath,
-        ...(options.folderUid === undefined ? {} : {'grafana.app/folder': options.folderUid}),
-      },
-      name: resource.metadata.name,
-      namespace: options.namespace ?? testGrafanaNamespace,
+      annotations: {'grafana.app/folder': telemetryDashboardFolderUid, ...options.annotations},
+      labels: options.labels ?? {},
+      name: telemetryDashboardUid,
+      namespace: testGrafanaNamespace,
+      resourceVersion: options.resourceVersion ?? '101',
+      uid: options.internalUid ?? 'immutable-dashboard-uid',
     },
-    spec: options.spec ?? resource.spec,
+    spec: {...(options.spec ?? resource.spec), schemaVersion: options.schemaVersion ?? 42},
   };
 }
 
-describe('Grafana Git Sync dashboard provisioning', () => {
-  it('keeps the canonical provisioned resource fresh and strips import/server state', () => {
-    const source = readDashboardSource();
-    const expected = renderProvisionedDashboard(source);
-    const checkedIn = readProvisionedDashboard();
+function liveFolder(
+  options: Readonly<{
+    annotations?: Readonly<Record<string, string>>;
+    labels?: Readonly<Record<string, string>>;
+    title?: string;
+  }> = {},
+): unknown {
+  return {
+    apiVersion: 'folder.grafana.app/v1',
+    kind: 'Folder',
+    metadata: {
+      annotations: options.annotations ?? {},
+      labels: options.labels ?? {},
+      name: telemetryDashboardFolderUid,
+      namespace: testGrafanaNamespace,
+      resourceVersion: '51',
+      uid: 'immutable-folder-uid',
+    },
+    spec: {title: options.title ?? telemetryDashboardFolderTitle},
+  };
+}
+
+function writerPermissions(overrides: Readonly<Record<string, readonly string[]>> = {}): unknown {
+  return {
+    'dashboards:read': [`dashboards:uid:${telemetryDashboardUid}`],
+    'dashboards:write': [`dashboards:uid:${telemetryDashboardUid}`],
+    'folders.permissions:read': [`folders:uid:${telemetryDashboardFolderUid}`],
+    'folders:read': [`folders:uid:${telemetryDashboardFolderUid}`],
+    ...overrides,
+  };
+}
+
+function readerPermissions(overrides: Readonly<Record<string, readonly string[]>> = {}): unknown {
+  return {
+    'dashboards:read': [`dashboards:uid:${telemetryDashboardUid}`],
+    'datasources:query': [`datasources:uid:${telemetryDashboardDatasourceUid}`],
+    'datasources:read': [`datasources:uid:${telemetryDashboardDatasourceUid}`],
+    'folders.permissions:read': [`folders:uid:${telemetryDashboardFolderUid}`],
+    'folders:read': [`folders:uid:${telemetryDashboardFolderUid}`],
+    ...overrides,
+  };
+}
+
+function deploymentFetcher(
+  options: Readonly<{
+    current: DashboardArtifact;
+    live?: unknown;
+    onPut?: (body: Record<string, unknown>) => void;
+    permissions?: unknown;
+    putResponse?: Response | 'transport-error';
+    updated?: unknown;
+  }>,
+): {fetcher: (input: string | URL | Request, init?: RequestInit) => Promise<Response>; requests: string[]} {
+  const requests: string[] = [];
+  let dashboardReads = 0;
+  return {
+    requests,
+    fetcher: async (input, init) => {
+      const url = String(input);
+      requests.push(`${init?.method ?? 'GET'} ${url}`);
+      if (url.endsWith('/api/access-control/user/permissions')) {
+        return Response.json(options.permissions ?? writerPermissions());
+      }
+      if (url.includes('/apis/folder.grafana.app/')) return Response.json(liveFolder());
+      if (url.endsWith(`/api/folders/${telemetryDashboardFolderUid}/permissions`)) return Response.json([]);
+      if (url.includes('/apis/dashboard.grafana.app/')) {
+        if (init?.method === 'PUT') {
+          const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+          options.onPut?.(body);
+          if (options.putResponse === 'transport-error') throw new Error('private transport failure');
+          return options.putResponse ?? Response.json({}, {status: 200});
+        }
+        dashboardReads += 1;
+        if (dashboardReads === 1) return Response.json(options.live ?? liveDashboard(options.current));
+        return Response.json(
+          options.updated ?? liveDashboard(options.current, {resourceVersion: '102', schemaVersion: 42}),
+        );
+      }
+      throw new Error('unexpected test URL');
+    },
+  };
+}
+
+describe('direct Grafana dashboard provisioning', () => {
+  it('keeps the canonical deployment artifact byte-exact, portable, and free of server state', async () => {
+    const expected = renderDashboardArtifact(readDashboardSource());
+    const checkedIn = readDashboardArtifact();
+    const expectedBytes = await formatDashboardArtifact(canonicalJson(expected));
 
     expect(canonicalJson(checkedIn)).toBe(canonicalJson(expected));
+    expect(readFileSync(telemetryDashboardArtifactPath, 'utf8')).toBe(expectedBytes);
+    expect(() => validateDashboardArtifactBytes(expectedBytes, expectedBytes)).not.toThrow();
+    expect(() => validateDashboardArtifactBytes(`${expectedBytes}\n`, expectedBytes)).toThrow(/artifact is stale/u);
     expect(checkedIn).toMatchObject({
-      apiVersion: 'dashboard.grafana.app/v1',
-      kind: 'Dashboard',
-      metadata: {name: telemetryDashboardUid},
-      spec: {uid: telemetryDashboardUid},
+      dashboardUid: telemetryDashboardUid,
+      folderUid: telemetryDashboardFolderUid,
     });
-    expect(checkedIn.spec).not.toHaveProperty('__inputs');
-    expect(checkedIn.spec).not.toHaveProperty('__requires');
-    expect(checkedIn.spec).not.toHaveProperty('id');
-    expect(checkedIn.spec).not.toHaveProperty('iteration');
-    expect(checkedIn.spec).not.toHaveProperty('version');
+    expect(checkedIn).not.toHaveProperty('apiVersion');
+    expect(checkedIn).not.toHaveProperty('kind');
+    expect(checkedIn).not.toHaveProperty('metadata');
+    expect(telemetryDashboardArtifactPath).not.toMatch(/\.(?:json|ya?ml)$/u);
+    for (const key of ['__inputs', '__requires', 'id', 'iteration', 'schemaVersion', 'uid', 'version']) {
+      expect(checkedIn.spec).not.toHaveProperty(key);
+    }
     expect(canonicalJson(checkedIn)).not.toContain('${DS_TEMPO}');
 
     const queries = collectTempoQueries(checkedIn);
@@ -151,372 +240,431 @@ describe('Grafana Git Sync dashboard provisioning', () => {
     {choices: FC.array(FC.integer(), {maxLength: 80, minLength: 1})},
     ({choices}) => {
       const source = readDashboardSource();
-      const permuted = permuteObjectKeys(source, choices);
-      expect(canonicalJson(renderProvisionedDashboard(permuted))).toBe(
-        canonicalJson(renderProvisionedDashboard(source)),
+      expect(canonicalJson(renderDashboardArtifact(permuteObjectKeys(source, choices)))).toBe(
+        canonicalJson(renderDashboardArtifact(source)),
       );
     },
     {fastCheck: {numRuns: 40}},
   );
 
-  it('normalizes live server fields and builds one bounded parser request for every Tempo target', () => {
-    const resource = readProvisionedDashboard();
-    const live = {...storedDashboardSpec(resource), id: 42, iteration: 1_723_000_000_000, version: 17};
-    expect(canonicalDashboardSpec(live)).toBe(canonicalDashboardSpec(resource.spec));
-    expect(
-      canonicalDashboardSpec(
-        JSON.parse(JSON.stringify(resource.spec).replaceAll(telemetryDashboardDatasourceUid, '${DS_TEMPO}')),
-      ),
-    ).not.toBe(canonicalDashboardSpec(resource.spec));
+  it('normalizes only proven Grafana migration noise', () => {
+    const resource = readDashboardArtifact();
+    const migrated = clone(resource.spec) as Record<string, JsonValue>;
+    migrated.schemaVersion = 42;
+    const panels = migrated.panels as Record<string, JsonValue>[];
+    for (const panel of panels) {
+      if (typeof panel.id === 'number' && panel.id >= 14 && panel.id <= 19) delete panel.fieldConfig;
+    }
+    expect(canonicalDashboardSemantics(migrated)).toBe(canonicalDashboardSemantics(resource.spec));
 
-    const request = buildTempoQueryRequest(resource, 1_800_000_000_000) as Readonly<Record<string, JsonValue>>;
-    const queries = request.queries as readonly Readonly<Record<string, JsonValue>>[];
-    expect(request.from).toBe('1799999700000');
-    expect(request.to).toBe('1800000000000');
-    expect(queries).toHaveLength(collectTempoQueries(resource).length);
-    expect(new Set(queries.map(query => query.refId)).size).toBe(queries.length);
-    for (const query of queries) {
-      expect(query.datasource).toEqual({type: 'tempo', uid: telemetryDashboardDatasourceUid});
-      expect(query.limit).toBe(1);
-      expect(query.maxDataPoints).toBe(1);
-      expect(query.spanLimit).toBe(1);
+    const queryDrift = clone(migrated);
+    const firstPanel = (queryDrift.panels as Record<string, JsonValue>[])[0]!;
+    const firstTarget = (firstPanel.targets as Record<string, JsonValue>[])[0]!;
+    firstTarget.query = '{}';
+    expect(canonicalDashboardSemantics(queryDrift)).not.toBe(canonicalDashboardSemantics(resource.spec));
+
+    const unapprovedEmptyRemoval = clone(resource.spec);
+    delete (unapprovedEmptyRemoval.panels as Record<string, JsonValue>[])[19]!.fieldConfig;
+    expect(canonicalDashboardSemantics(unapprovedEmptyRemoval)).not.toBe(canonicalDashboardSemantics(resource.spec));
+  });
+
+  it.prop(
+    'updates only from a trusted historical state and otherwise fails closed',
+    {states: FC.uniqueArray(FC.string(), {maxLength: 3, minLength: 3})},
+    ({states: [current, historical, drift]}) => {
+      expect(assessDashboardThreeWay({current, historical: [historical], live: current})).toBe('noop');
+      expect(assessDashboardThreeWay({current, historical: [historical], live: historical})).toBe('update');
+      expect(() => assessDashboardThreeWay({current, historical: [historical], live: drift})).toThrow(/drifted/u);
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
+  it('preserves the live schema and exact resourceVersion in an update-only PUT, then re-reads exact state', async () => {
+    const previous = readDashboardArtifact();
+    const current = artifactWithTitle(previous, 'Updated telemetry title');
+    let requestBody: Record<string, unknown> | undefined;
+    const harness = deploymentFetcher({
+      current,
+      live: liveDashboard(previous, {
+        labels: {'threadnote.dev/owner': 'telemetry'},
+        resourceVersion: 'opaque-rv',
+        schemaVersion: 43,
+      }),
+      onPut: body => {
+        requestBody = body;
+      },
+      putResponse: new Response(null, {status: 200}),
+      updated: liveDashboard(current, {resourceVersion: 'next-rv', schemaVersion: 43}),
+    });
+
+    await expect(
+      deployDashboard({
+        baseUrl: testGrafanaUrl,
+        current,
+        currentSha,
+        fetcher: harness.fetcher,
+        historical: [previous],
+        namespace: testGrafanaNamespace,
+        token: 'narrow-writer-token',
+      }),
+    ).resolves.toBe('update');
+
+    const metadata = requestBody?.metadata as Record<string, unknown>;
+    const spec = requestBody?.spec as Record<string, unknown>;
+    expect(metadata.name).toBe(telemetryDashboardUid);
+    expect(metadata.resourceVersion).toBe('opaque-rv');
+    expect(metadata.uid).toBe('immutable-dashboard-uid');
+    expect(metadata.labels).toEqual({'threadnote.dev/owner': 'telemetry'});
+    expect(spec.schemaVersion).toBe(43);
+    expect(spec.title).toBe('Updated telemetry title');
+    expect(requestBody).not.toHaveProperty('access');
+    expect(harness.requests.filter(request => request.startsWith('PUT '))).toHaveLength(1);
+    expect(harness.requests.at(-1)).toMatch(/^GET .*\/dashboards\/threadnote-telemetry$/u);
+  });
+
+  it('does not write when live already equals current', async () => {
+    const current = readDashboardArtifact();
+    const harness = deploymentFetcher({current});
+    await expect(
+      deployDashboard({
+        baseUrl: testGrafanaUrl,
+        current,
+        currentSha,
+        fetcher: harness.fetcher,
+        historical: [artifactWithTitle(current, 'Previous title')],
+        namespace: testGrafanaNamespace,
+        token: 'narrow-writer-token',
+      }),
+    ).resolves.toBe('noop');
+    expect(harness.requests.some(request => request.startsWith('PUT '))).toBe(false);
+  });
+
+  it('allows the first direct artifact commit to adopt only an already-current dashboard without history', async () => {
+    const current = readDashboardArtifact();
+    const harness = deploymentFetcher({current});
+    await expect(
+      deployDashboard({
+        baseUrl: testGrafanaUrl,
+        current,
+        currentSha,
+        fetcher: harness.fetcher,
+        historical: [],
+        namespace: testGrafanaNamespace,
+        token: 'narrow-writer-token',
+      }),
+    ).resolves.toBe('noop');
+    expect(harness.requests.some(request => request.startsWith('PUT '))).toBe(false);
+
+    const drifted = deploymentFetcher({
+      current,
+      live: liveDashboard(artifactWithTitle(current, 'Untrusted old title')),
+    });
+    await expect(
+      deployDashboard({
+        baseUrl: testGrafanaUrl,
+        current,
+        currentSha,
+        fetcher: drifted.fetcher,
+        historical: [],
+        namespace: testGrafanaNamespace,
+        token: 'narrow-writer-token',
+      }),
+    ).rejects.toThrow(/trusted historical/u);
+    expect(drifted.requests.some(request => request.startsWith('PUT '))).toBe(false);
+  });
+
+  it('skips source-history commits from before the direct artifact existed', async () => {
+    const oldSourceCommit = 'b'.repeat(40);
+    const artifacts = await loadHistoricalArtifacts('/unused-in-injected-test', currentSha, async args => {
+      if (args[0] === 'log') return `${currentSha}\n${oldSourceCommit}`;
+      if (args[0] === 'show' && String(args[1]).startsWith(oldSourceCommit)) return undefined;
+      throw new Error('unexpected Git command');
+    });
+    expect(artifacts).toEqual([]);
+  });
+
+  it('loads reviewed historical artifacts without applying the current renderer contract', async () => {
+    const historicalCommit = 'b'.repeat(40);
+    const historical = clone(readDashboardArtifact());
+    const firstPanel = (historical.spec.panels as Record<string, JsonValue>[])[0]!;
+    const firstTarget = (firstPanel.targets as Record<string, JsonValue>[])[0]!;
+    firstPanel.datasource = {type: 'tempo', uid: 'previous-traces-datasource'};
+    firstTarget.datasource = {type: 'tempo', uid: 'previous-traces-datasource'};
+    const reader = async (args: readonly string[]): Promise<string | undefined> => {
+      if (args[0] === 'log') {
+        expect(args).toEqual([
+          'log',
+          '--first-parent',
+          '--format=%H',
+          '--max-count=65',
+          currentSha,
+          '--',
+          telemetryDashboardArtifactPath,
+        ]);
+        return historicalCommit;
+      }
+      if (args[0] === 'show' && String(args[1]).endsWith(`:${telemetryDashboardArtifactPath}`)) {
+        return JSON.stringify(historical);
+      }
+      throw new Error('historical loading must not re-run current source rendering');
+    };
+
+    const artifacts = await loadHistoricalArtifacts('/unused-in-injected-test', currentSha, reader);
+    expect(artifacts).toEqual([historical]);
+    const current = readDashboardArtifact();
+    const harness = deploymentFetcher({current, live: liveDashboard(historical)});
+    await expect(
+      deployDashboard({
+        baseUrl: testGrafanaUrl,
+        current,
+        currentSha,
+        fetcher: harness.fetcher,
+        historical: artifacts,
+        namespace: testGrafanaNamespace,
+        token: 'narrow-writer-token',
+      }),
+    ).resolves.toBe('update');
+
+    const wrongIdentity = {...historical, dashboardUid: 'different-dashboard'};
+    await expect(
+      loadHistoricalArtifacts('/unused-in-injected-test', currentSha, async args => {
+        if (args[0] === 'log') return historicalCommit;
+        return JSON.stringify(wrongIdentity);
+      }),
+    ).rejects.toThrow(/exact dashboard and folder identity/u);
+  });
+
+  it.each([404, 409, 412, 500])('fails terminally on HTTP %i without retrying or falling back', async status => {
+    const previous = readDashboardArtifact();
+    const current = artifactWithTitle(previous, 'Updated title');
+    const harness = deploymentFetcher({
+      current,
+      live: liveDashboard(previous),
+      putResponse: new Response(null, {status}),
+    });
+    await expect(
+      deployDashboard({
+        baseUrl: testGrafanaUrl,
+        current,
+        currentSha,
+        fetcher: harness.fetcher,
+        historical: [previous],
+        namespace: testGrafanaNamespace,
+        token: 'narrow-writer-token',
+      }),
+    ).rejects.toThrow(`HTTP ${status}`);
+    expect(harness.requests.filter(request => request.startsWith('PUT '))).toHaveLength(1);
+  });
+
+  it('classifies an ambiguous transport outcome by one re-read without retrying the write', async () => {
+    const previous = readDashboardArtifact();
+    const current = artifactWithTitle(previous, 'Updated title');
+    const applied = deploymentFetcher({
+      current,
+      live: liveDashboard(previous),
+      putResponse: 'transport-error',
+      updated: liveDashboard(current, {resourceVersion: '102'}),
+    });
+    await expect(
+      deployDashboard({
+        baseUrl: testGrafanaUrl,
+        current,
+        currentSha,
+        fetcher: applied.fetcher,
+        historical: [previous],
+        namespace: testGrafanaNamespace,
+        token: 'narrow-writer-token',
+      }),
+    ).resolves.toBe('update');
+    expect(applied.requests.filter(request => request.startsWith('PUT '))).toHaveLength(1);
+
+    const unchanged = deploymentFetcher({
+      current,
+      live: liveDashboard(previous),
+      putResponse: 'transport-error',
+      updated: liveDashboard(previous),
+    });
+    await expect(
+      deployDashboard({
+        baseUrl: testGrafanaUrl,
+        current,
+        currentSha,
+        fetcher: unchanged.fetcher,
+        historical: [previous],
+        namespace: testGrafanaNamespace,
+        token: 'narrow-writer-token',
+      }),
+    ).rejects.toThrow(/indeterminate/u);
+    expect(unchanged.requests.filter(request => request.startsWith('PUT '))).toHaveLength(1);
+  });
+
+  it('rejects drift, Git Sync provenance, stale folders, and broad ACLs before any PUT', async () => {
+    const previous = readDashboardArtifact();
+    const current = artifactWithTitle(previous, 'Current title');
+    const managedMetadataKeys = [
+      'grafana.app/managedBy',
+      'grafana.app/managerAllowsEdits',
+      'grafana.app/managerId',
+      'grafana.app/managerSuspended',
+      'grafana.app/repoHash',
+      'grafana.app/repoName',
+      'grafana.app/repoPath',
+      'grafana.app/repoTimestamp',
+      'grafana.app/sourceChecksum',
+      'grafana.app/sourcePath',
+      'grafana.app/sourceTimestamp',
+    ] as const;
+    const cases: readonly Readonly<{folder?: unknown; live?: unknown; permissions?: unknown}>[] = [
+      {live: liveDashboard(artifactWithTitle(previous, 'Out-of-band title'))},
+      ...managedMetadataKeys.map(key => ({live: liveDashboard(previous, {annotations: {[key]: 'reserved'}})})),
+      {live: liveDashboard(previous, {labels: {'provisioning.grafana.app/repository': 'other-manager'}})},
+      {live: liveDashboard(previous, {labels: {'grafana.app/managedBy': 'other-manager'}})},
+      {folder: liveFolder({title: 'Wrong folder'})},
+      {folder: liveFolder({annotations: {'grafana.app/folder': 'unexpected-parent'}})},
+      {folder: liveFolder({annotations: {'grafana.app/repoPath': 'legacy/path'}})},
+      {folder: liveFolder({labels: {'grafana.app/sourceTimestamp': 'legacy-timestamp'}})},
+      {permissions: [{folderId: -1, role: 'Viewer'}]},
+    ];
+    for (const testCase of cases) {
+      let putAttempted = false;
+      const fetcher = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (init?.method === 'PUT') putAttempted = true;
+        if (url.endsWith('/api/access-control/user/permissions')) return Response.json(writerPermissions());
+        if (url.includes('/apis/folder.grafana.app/')) return Response.json(testCase.folder ?? liveFolder());
+        if (url.endsWith('/permissions')) return Response.json(testCase.permissions ?? []);
+        return Response.json(testCase.live ?? liveDashboard(previous));
+      };
+      await expect(
+        deployDashboard({
+          baseUrl: testGrafanaUrl,
+          current,
+          currentSha,
+          fetcher,
+          historical: [previous],
+          namespace: testGrafanaNamespace,
+          token: 'narrow-writer-token',
+        }),
+      ).rejects.toThrow();
+      expect(putAttempted).toBe(false);
     }
   });
 
-  it('accepts only an explicit Grafana Cloud stack namespace and Kubernetes Repository resource name', () => {
-    expect(validateGrafanaCloudNamespace(testGrafanaNamespace)).toBe(testGrafanaNamespace);
-    expect(() => validateGrafanaCloudNamespace('default')).toThrow(/stacks-<numeric-stack-id>/u);
-    expect(() => validateGrafanaCloudNamespace('stacks-private')).toThrow(/stacks-<numeric-stack-id>/u);
-    expect(() => validateGrafanaCloudNamespace('stacks-0123')).toThrow(/stacks-<numeric-stack-id>/u);
-
-    expect(validateGrafanaGitSyncManagerId(testGitSyncManagerId)).toBe(testGitSyncManagerId);
-    expect(() => validateGrafanaGitSyncManagerId('Repository Threadnote')).toThrow(/repository resource name/u);
-    expect(() => validateGrafanaGitSyncManagerId('repository/threadnote')).toThrow(/repository resource name/u);
+  it('requires a writer token restricted to exact dashboard and folder read/update scopes', () => {
+    expect(() => validateWriterPermissions(writerPermissions())).not.toThrow();
+    expect(() => validateWriterPermissions(writerPermissions({'dashboards:create': ['folders:*']}))).toThrow(
+      /forbidden/u,
+    );
+    expect(() => validateWriterPermissions(writerPermissions({'alert.rules:read': ['folders:uid:private']}))).toThrow(
+      /forbidden/u,
+    );
+    expect(() => validateWriterPermissions(writerPermissions({'dashboards:write': ['dashboards:uid:other']}))).toThrow(
+      /exact allowed targets/u,
+    );
+    expect(() => validateWriterPermissions({'dashboards:read': [`dashboards:uid:${telemetryDashboardUid}`]})).toThrow(
+      /missing/u,
+    );
   });
 
-  it('requires exact repository ownership, manager, source paths, namespace, and folder provenance', async () => {
-    const resource = readProvisionedDashboard();
-    const folder = readProvisionedFolder();
-    const mismatches: readonly Readonly<{
-      dashboard?: Readonly<{folderUid?: string; managerId?: string; namespace?: string; sourcePath?: string}>;
-      folder?: Readonly<{managerId?: string; namespace?: string; sourcePath?: string}>;
-    }>[] = [
-      {dashboard: {managerId: 'repository-other'}},
-      {dashboard: {namespace: 'stacks-654321'}},
-      {dashboard: {sourcePath: 'threadnote-telemetry/other.json'}},
-      {dashboard: {folderUid: 'other-folder'}},
-      {folder: {managerId: 'repository-other'}},
-      {folder: {sourcePath: 'other-folder'}},
-    ];
-
-    for (const mismatch of mismatches) {
-      let permissionsOrQueriesAttempted = false;
-      const fetcher = async (input: string | URL | Request): Promise<Response> => {
-        const url = String(input);
-        if (url.includes('/apis/dashboard.grafana.app/')) {
-          return Response.json(
-            liveGitSyncResource(resource, {
-              folderUid: telemetryDashboardFolderUid,
-              sourcePath: telemetryDashboardSourcePathInGitSync,
-              spec: storedDashboardSpec(resource),
-              ...mismatch.dashboard,
-            }),
-          );
-        }
-        if (url.includes('/apis/folder.grafana.app/')) {
-          return Response.json(
-            liveGitSyncResource(folder, {
-              sourcePath: telemetryDashboardFolderSourcePathInGitSync,
-              ...mismatch.folder,
-            }),
-          );
-        }
-        permissionsOrQueriesAttempted = true;
-        return Response.json([]);
-      };
-
+  it('requires a reader token restricted to exact dashboard, folder, and datasource scopes', async () => {
+    expect(() => validateReaderPermissions(readerPermissions())).not.toThrow();
+    for (const permissions of [
+      readerPermissions({'dashboards:write': [`dashboards:uid:${telemetryDashboardUid}`]}),
+      readerPermissions({'alert.rules:read': ['folders:uid:private']}),
+      readerPermissions({'datasources:query': ['datasources:uid:*']}),
+      readerPermissions({'datasources:read': ['datasources:uid:other']}),
+    ]) {
+      let requests = 0;
       await expect(
         verifyLiveDashboard({
-          baseUrl: 'https://grafana.example.test',
-          fetcher,
-          folder,
-          managerId: testGitSyncManagerId,
+          baseUrl: testGrafanaUrl,
+          fetcher: async input => {
+            requests += 1;
+            expect(String(input)).toBe(`${testGrafanaUrl}/api/access-control/user/permissions`);
+            return Response.json(permissions);
+          },
           namespace: testGrafanaNamespace,
-          pollIntervalMs: 0,
-          resource,
-          syncTimeoutMs: 0,
-          token: 'read-only-test-token',
+          resource: readDashboardArtifact(),
+          token: 'overprivileged-reader-token',
         }),
-      ).rejects.toThrow(/did not converge/u);
-      expect(permissionsOrQueriesAttempted).toBe(false);
+      ).rejects.toThrow();
+      expect(requests).toBe(1);
     }
   });
 
-  it('does not expose private deployment identifiers when a Grafana transport request fails', async () => {
-    const resource = readProvisionedDashboard();
-    const folder = readProvisionedFolder();
-    const privateNamespace = 'stacks-987654321';
-    const privateManagerId = 'repository-private-deployment';
-    const error = await verifyLiveDashboard({
-      baseUrl: 'https://grafana.example.test',
-      fetcher: async () => {
-        throw new Error(`failed request for ${privateNamespace}/${privateManagerId}`);
+  it('verifies exact live state, private ACLs, and every bounded Tempo query using only reads and query POST', async () => {
+    const resource = readDashboardArtifact();
+    const requests: {method?: string; url: string}[] = [];
+    await verifyLiveDashboard({
+      baseUrl: testGrafanaUrl,
+      fetcher: async (input, init) => {
+        const url = String(input);
+        requests.push({method: init?.method, url});
+        if (url.endsWith('/api/access-control/user/permissions')) return Response.json(readerPermissions());
+        if (url.includes('/apis/dashboard.grafana.app/')) return Response.json(liveDashboard(resource));
+        if (url.includes('/apis/folder.grafana.app/')) return Response.json(liveFolder());
+        if (url.endsWith('/permissions')) return Response.json([]);
+        return Response.json(successfulQueryResponse(resource));
       },
-      folder,
-      managerId: privateManagerId,
-      namespace: privateNamespace,
-      pollIntervalMs: 0,
-      resource,
-      syncTimeoutMs: 0,
-      token: 'read-only-test-token',
-    }).then(
-      () => undefined,
-      failure => failure,
-    );
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe('Grafana API request failed before receiving a response.');
-    expect((error as Error).message).not.toContain(privateNamespace);
-    expect((error as Error).message).not.toContain(privateManagerId);
-  });
-
-  it('verifies synchronized dashboard state and all query results through read-only API calls', async () => {
-    const resource = readProvisionedDashboard();
-    const folder = readProvisionedFolder();
-    const requests: {body?: string; method?: string; url: string}[] = [];
-    const fetcher = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
-      const url = String(input);
-      requests.push({body: init?.body as string | undefined, method: init?.method, url});
-      if (url.includes('/apis/dashboard.grafana.app/')) {
-        return Response.json(
-          liveGitSyncResource(resource, {
-            folderUid: telemetryDashboardFolderUid,
-            sourcePath: telemetryDashboardSourcePathInGitSync,
-            spec: storedDashboardSpec(resource),
-          }),
-        );
-      }
-      if (url.includes('/apis/folder.grafana.app/')) {
-        return Response.json(liveGitSyncResource(folder, {sourcePath: telemetryDashboardFolderSourcePathInGitSync}));
-      }
-      if (url.endsWith(`/api/folders/${telemetryDashboardFolderUid}/permissions`)) return Response.json([]);
-      return Response.json(successfulQueryResponse(resource));
-    };
-
-    await verifyLiveDashboard({
-      baseUrl: 'https://grafana.example.test',
-      fetcher,
-      folder,
-      managerId: testGitSyncManagerId,
       namespace: testGrafanaNamespace,
-      pollIntervalMs: 0,
       resource,
-      syncTimeoutMs: 0,
-      token: 'read-only-test-token',
+      token: 'read-only-token',
     });
-
-    expect(requests.map(request => request.url)).toEqual([
-      `https://grafana.example.test/apis/dashboard.grafana.app/v1/namespaces/${testGrafanaNamespace}/dashboards/${telemetryDashboardUid}`,
-      `https://grafana.example.test/apis/folder.grafana.app/v1/namespaces/${testGrafanaNamespace}/folders/${telemetryDashboardFolderUid}`,
-      `https://grafana.example.test/api/folders/${telemetryDashboardFolderUid}/permissions`,
-      'https://grafana.example.test/api/ds/query',
-    ]);
-    expect(requests[0]?.method).toBeUndefined();
-    expect(requests[3]?.method).toBe('POST');
-    expect(requests[3]?.body).not.toContain('${DS_TEMPO}');
+    expect(requests.map(request => request.method ?? 'GET')).toEqual(['GET', 'GET', 'GET', 'GET', 'POST']);
+    expect(requests.at(-1)?.url).toBe(`${testGrafanaUrl}/api/ds/query`);
   });
 
-  it('retries a missing dashboard while the first Git Sync pull is converging', async () => {
-    const resource = readProvisionedDashboard();
-    const folder = readProvisionedFolder();
-    let dashboardAttempts = 0;
-    const fetcher = async (input: string | URL | Request): Promise<Response> => {
-      if (String(input).includes('/apis/dashboard.grafana.app/')) {
-        dashboardAttempts += 1;
-        if (dashboardAttempts === 1) return new Response(null, {status: 404});
-        return Response.json(
-          liveGitSyncResource(resource, {
-            folderUid: telemetryDashboardFolderUid,
-            sourcePath: telemetryDashboardSourcePathInGitSync,
-            spec: storedDashboardSpec(resource),
-          }),
-        );
-      }
-      if (String(input).includes('/apis/folder.grafana.app/')) {
-        return Response.json(liveGitSyncResource(folder, {sourcePath: telemetryDashboardFolderSourcePathInGitSync}));
-      }
-      if (String(input).includes('/permissions')) return Response.json([]);
-      return Response.json(successfulQueryResponse(resource));
-    };
-
-    await verifyLiveDashboard({
-      baseUrl: 'https://grafana.example.test',
-      fetcher,
-      folder,
-      managerId: testGitSyncManagerId,
-      namespace: testGrafanaNamespace,
-      pollIntervalMs: 0,
-      resource,
-      syncTimeoutMs: 1_000,
-      token: 'read-only-test-token',
-    });
-    expect(dashboardAttempts).toBe(2);
-  });
-
-  it('does not accept a matching unmanaged dashboard as Git Sync convergence', async () => {
-    const resource = readProvisionedDashboard();
-    const folder = readProvisionedFolder();
-    let queryAttempted = false;
-    const fetcher = async (input: string | URL | Request): Promise<Response> => {
-      if (String(input).includes('/apis/dashboard.grafana.app/')) {
-        return Response.json(
-          liveGitSyncResource(resource, {
-            folderUid: telemetryDashboardFolderUid,
-            managedBy: 'kubectl',
-            sourcePath: telemetryDashboardSourcePathInGitSync,
-            spec: storedDashboardSpec(resource),
-          }),
-        );
-      }
-      queryAttempted = true;
-      return Response.json(successfulQueryResponse(resource));
-    };
-
+  it('fails closed when any bounded Tempo query result is absent', async () => {
+    const resource = readDashboardArtifact();
     await expect(
       verifyLiveDashboard({
-        baseUrl: 'https://grafana.example.test',
-        fetcher,
-        folder,
-        managerId: testGitSyncManagerId,
+        baseUrl: testGrafanaUrl,
+        fetcher: async input => {
+          const url = String(input);
+          if (url.endsWith('/api/access-control/user/permissions')) return Response.json(readerPermissions());
+          if (url.includes('/apis/dashboard.grafana.app/')) return Response.json(liveDashboard(resource));
+          if (url.includes('/apis/folder.grafana.app/')) return Response.json(liveFolder());
+          if (url.endsWith('/permissions')) return Response.json([]);
+          return Response.json({results: {}});
+        },
         namespace: testGrafanaNamespace,
-        pollIntervalMs: 0,
         resource,
-        syncTimeoutMs: 0,
-        token: 'read-only-test-token',
-      }),
-    ).rejects.toThrow(/did not converge/u);
-    expect(queryAttempted).toBe(false);
-  });
-
-  it('fails closed when Grafana omits even one parser result', async () => {
-    const resource = readProvisionedDashboard();
-    const folder = readProvisionedFolder();
-    const fetcher = async (input: string | URL | Request): Promise<Response> => {
-      if (String(input).includes('/apis/dashboard.grafana.app/')) {
-        return Response.json(
-          liveGitSyncResource(resource, {
-            folderUid: telemetryDashboardFolderUid,
-            sourcePath: telemetryDashboardSourcePathInGitSync,
-            spec: storedDashboardSpec(resource),
-          }),
-        );
-      }
-      if (String(input).includes('/apis/folder.grafana.app/')) {
-        return Response.json(liveGitSyncResource(folder, {sourcePath: telemetryDashboardFolderSourcePathInGitSync}));
-      }
-      if (String(input).includes('/permissions')) return Response.json([]);
-      return Response.json({results: {}});
-    };
-
-    await expect(
-      verifyLiveDashboard({
-        baseUrl: 'https://grafana.example.test',
-        fetcher,
-        folder,
-        managerId: testGitSyncManagerId,
-        namespace: testGrafanaNamespace,
-        pollIntervalMs: 0,
-        resource,
-        syncTimeoutMs: 0,
-        token: 'read-only-test-token',
+        token: 'read-only-token',
       }),
     ).rejects.toThrow(/rejected \d+ bounded dashboard query targets/u);
   });
 
-  it('does not accept a stale Git Sync folder when the dashboard itself is current', async () => {
-    const resource = readProvisionedDashboard();
-    const folder = readProvisionedFolder();
-    let permissionsOrQueriesAttempted = false;
-    const fetcher = async (input: string | URL | Request): Promise<Response> => {
-      if (String(input).includes('/apis/dashboard.grafana.app/')) {
-        return Response.json(
-          liveGitSyncResource(resource, {
-            folderUid: telemetryDashboardFolderUid,
-            sourcePath: telemetryDashboardSourcePathInGitSync,
-            spec: storedDashboardSpec(resource),
-          }),
-        );
-      }
-      if (String(input).includes('/apis/folder.grafana.app/')) {
-        return Response.json(
-          liveGitSyncResource(folder, {
-            sourcePath: telemetryDashboardFolderSourcePathInGitSync,
-            spec: {title: 'Stale folder title'},
-          }),
-        );
-      }
-      permissionsOrQueriesAttempted = true;
-      return Response.json([]);
-    };
-
-    await expect(
-      verifyLiveDashboard({
-        baseUrl: 'https://grafana.example.test',
-        fetcher,
-        folder,
-        managerId: testGitSyncManagerId,
-        namespace: testGrafanaNamespace,
-        pollIntervalMs: 0,
-        resource,
-        syncTimeoutMs: 0,
-        token: 'read-only-test-token',
-      }),
-    ).rejects.toThrow(/did not converge/u);
-    expect(permissionsOrQueriesAttempted).toBe(false);
+  it('accepts only an explicit Grafana Cloud stack namespace', () => {
+    expect(validateGrafanaCloudNamespace(testGrafanaNamespace)).toBe(testGrafanaNamespace);
+    expect(() => validateGrafanaCloudNamespace('default')).toThrow(/stacks-<numeric-stack-id>/u);
+    expect(() => validateGrafanaCloudNamespace('stacks-private')).toThrow(/stacks-<numeric-stack-id>/u);
+    expect(() => validateGrafanaCloudNamespace('stacks-0123')).toThrow(/stacks-<numeric-stack-id>/u);
   });
 
-  it('rejects the broad default Viewer and Editor grants on the private folder', async () => {
-    const resource = readProvisionedDashboard();
-    const folder = readProvisionedFolder();
-    let queryAttempted = false;
-    const fetcher = async (input: string | URL | Request): Promise<Response> => {
-      const url = String(input);
-      if (url.includes('/apis/dashboard.grafana.app/')) {
-        return Response.json(
-          liveGitSyncResource(resource, {
-            folderUid: telemetryDashboardFolderUid,
-            sourcePath: telemetryDashboardSourcePathInGitSync,
-            spec: storedDashboardSpec(resource),
-          }),
-        );
-      }
-      if (url.includes('/apis/folder.grafana.app/')) {
-        return Response.json(liveGitSyncResource(folder, {sourcePath: telemetryDashboardFolderSourcePathInGitSync}));
-      }
-      if (url.includes('/permissions')) {
-        return Response.json([{folderId: -1, permission: 1, role: 'Viewer'}]);
-      }
-      queryAttempted = true;
-      return Response.json(successfulQueryResponse(resource));
-    };
-
+  it.each([
+    'http://threadnote-test.grafana.net',
+    'https://threadnote-test.grafana.net.evil.test',
+    'https://threadnote-test.grafana.net/private-path',
+    'https://user@threadnote-test.grafana.net',
+    'https://threadnote-test.grafana.net:8443',
+  ])('refuses to send a Grafana token to non-Cloud origin %s', async baseUrl => {
+    let requested = false;
     await expect(
       verifyLiveDashboard({
-        baseUrl: 'https://grafana.example.test',
-        fetcher,
-        folder,
-        managerId: testGitSyncManagerId,
+        baseUrl,
+        fetcher: async () => {
+          requested = true;
+          return Response.json({});
+        },
         namespace: testGrafanaNamespace,
-        pollIntervalMs: 0,
-        resource,
-        syncTimeoutMs: 0,
-        token: 'read-only-test-token',
+        resource: readDashboardArtifact(),
+        token: 'private-token',
       }),
-    ).rejects.toThrow(/broad default Viewer or Editor access/u);
-    expect(queryAttempted).toBe(false);
+    ).rejects.toThrow(/Grafana Cloud HTTPS origin/u);
+    expect(requested).toBe(false);
   });
 
-  it('keeps validation secretless and live verification main-only, read-only, and configuration-gated', () => {
+  it('keeps PR validation secretless and isolates serialized push deployment from read-only daily verification', () => {
     const workflow = load(readFileSync('.github/workflows/telemetry-dashboard.yml', 'utf8'), {
       schema: JSON_SCHEMA,
     }) as DashboardWorkflow;
@@ -533,42 +681,67 @@ describe('Grafana Git Sync dashboard provisioning', () => {
     expect(workflow.on.push).toEqual({branches: ['main'], paths: expectedPaths});
     expect(workflow.on.pull_request).toEqual({branches: ['main'], paths: expectedPaths});
     expect(workflow.on.schedule).toEqual([{cron: '17 3 * * *'}]);
-    expect(workflow.concurrency).toEqual({
-      'cancel-in-progress': true,
-      group: 'telemetry-dashboard-${{ github.ref }}',
-    });
+    expect(workflow.concurrency['cancel-in-progress']).toBe(false);
+    expect(workflow.concurrency.queue).toBe('max');
+    expect(workflow.concurrency.group).toContain("github.event_name != 'pull_request'");
+    expect(workflow.concurrency.group).toContain("'production' || github.run_id");
 
     const validation = workflow.jobs.validate!;
+    const deployment = workflow.jobs.deploy!;
     const verification = workflow.jobs['verify-live']!;
+    const completion = workflow.jobs.complete!;
     const validationText = JSON.stringify(validation);
+    const deploymentText = JSON.stringify(deployment);
     const verificationText = JSON.stringify(verification);
+
     expect(validation.environment).toBeUndefined();
     expect(validationText).not.toContain('secrets.');
-    expect(validationText).not.toContain('verify-live');
     expect(validationText).toContain('bun install --frozen-lockfile');
+
+    expect(deployment.environment).toEqual({name: 'telemetry-dashboard-production-deploy'});
+    expect(deployment.if).toContain("github.event_name == 'push'");
+    expect(deployment.if).toContain("github.ref == 'refs/heads/main'");
+    expect(deployment.if).toContain("github.repository == 'Kashkovsky/threadnote'");
+    expect(deployment.if).toContain("THREADNOTE_TELEMETRY_GRAFANA_DIRECT_ENABLED == 'true'");
+    expect(deploymentText).toContain('THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN');
+    expect(deploymentText).not.toContain('THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN');
+    expect(deploymentText).not.toContain('bun install');
+    expect(deploymentText).toContain('git merge-base --is-ancestor');
+    expect(deploymentText).toContain('git diff --quiet --no-ext-diff --no-textconv');
+    expect(deploymentText).toContain(telemetryDashboardArtifactPath);
+    expect(deploymentText.match(/git fetch --no-tags origin/gu)).toHaveLength(2);
+    expect(deploymentText).not.toContain('github.event.before');
+    expect(deploymentText).toContain(
+      'bun --config=/dev/null --no-env-file --no-install scripts/telemetry-dashboard.ts deploy',
+    );
+
     expect(verification.environment).toEqual({deployment: false, name: 'telemetry-dashboard-production'});
-    expect(verification.needs).toBe('validate');
     expect(verification.if).toContain("github.event_name != 'pull_request'");
     expect(verification.if).toContain("github.ref == 'refs/heads/main'");
-    expect(verification.if).toContain("THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_ENABLED == 'true'");
+    expect(verification.if).toContain("github.repository == 'Kashkovsky/threadnote'");
     expect(verificationText).toContain('THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN');
-    expect(verificationText).toContain('THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE');
-    expect(verificationText).toContain('THREADNOTE_TELEMETRY_GRAFANA_GIT_SYNC_MANAGER_ID');
+    expect(verificationText).not.toContain('THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN');
     expect(verificationText).not.toContain('bun install');
-    expect(verificationText).not.toMatch(/WRITE_TOKEN|dashboard.*write|gcx resources push/iu);
-    expect(verificationText).toContain('bun scripts/telemetry-dashboard.ts verify-live');
-    expect(
-      `${validationText}\n${verificationText}`.match(/oven-sh\/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6/gu),
-    ).toHaveLength(2);
-  });
+    expect(verificationText).toContain(
+      'bun --config=/dev/null --no-env-file --no-install scripts/telemetry-dashboard.ts verify-live',
+    );
 
-  it('pins a stable private folder identity for Git Sync permissions', () => {
-    const folder = readProvisionedFolder();
-    expect(folder).toEqual({
-      apiVersion: 'folder.grafana.app/v1',
-      kind: 'Folder',
-      metadata: {name: 'threadnote-telemetry-private'},
-      spec: {title: telemetryDashboardFolderTitle},
-    });
+    expect(completion.if).toBe('always()');
+    expect(completion.needs).toEqual(['validate', 'deploy', 'verify-live']);
+    expect(completion.steps?.at(-1)?.run).toContain("$EVENT_NAME\" != 'pull_request'");
+    expect(
+      `${validationText}\n${deploymentText}\n${verificationText}`.match(
+        /oven-sh\/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6/gu,
+      ),
+    ).toHaveLength(3);
+
+    const codeowners = readFileSync('.github/CODEOWNERS', 'utf8');
+    expect(codeowners).toContain('/.github/CODEOWNERS @Kashkovsky');
+    expect(codeowners).toContain('/.github/workflows/ @Kashkovsky');
+    expect(codeowners).toContain('/infra/telemetry-dashboard/ @Kashkovsky');
+
+    const actionlint = readFileSync('.github/actionlint.yml', 'utf8');
+    expect(actionlint).toContain('.github/workflows/telemetry-dashboard.yml:');
+    expect(actionlint).toContain('unexpected key "queue" for "concurrency" section');
   });
 });


### PR DESCRIPTION
## What

- replace the stalled Grafana Git Sync rollout with update-only dashboard reconciliation through the Grafana App API
- enforce exact resource-version CAS, bounded three-way drift detection, closed token permissions, private-folder ACL checks, and post-write verification
- keep the portable dashboard source and legacy Git Sync resources unchanged; add a non-provisionable generated artifact and protected direct-delivery workflow

## Why

The current live dashboard is unmanaged and Git Sync could not be activated safely. Direct reconciliation gives us a bounded, auditable migration path without create/delete privileges or silent overwrite behavior.

## Safety and rollout

- direct provisioning remains disabled until the private folder, exact-scope service accounts, protected environments, and enable variable are configured
- public OTLP ingestion remains disabled during review and migration
- scheduled/manual verification is read-only; writes are main-only and reviewer-gated
- no runtime or product source changed, so no global Threadnote reinstall is required

## Validation

- dashboard artifact freshness and hardened Bun invocation checks
- 38 focused Vitest tests
- source and test TypeScript checks
- targeted Prettier and strict Oxlint
- Actionlint 1.7.12
- git diff --check
- two clean review iterations with zero critical, important, or minor findings

No full local test suite was run, per request.