### PR TITLE
Fix Grafana dashboard permission audit

### DIFF
--- a/infra/telemetry-dashboard/README.md
+++ b/infra/telemetry-dashboard/README.md
@@ -56,9 +56,11 @@ Before a write, the provisioner requires all of the following:
 - a live semantic model equal to either the current canonical artifact or one
   of at most 64 validated first-parent historical artifacts; and
 - an effective writer permission set limited to exact-target dashboard
-  read/write plus exact-folder read and permission-read. Dashboard/folder
-  create/delete, folder/ACL write, query, admin, and wildcard grants are
-  rejected.
+  read/write plus exact-folder read and permission-read. Grafana also reports
+  its built-in `folders:uid:sharedwithme` virtual folder for every authenticated
+  account; that one additional `folders:read` scope is accepted, while any
+  other extra, duplicate, or wildcard scope is rejected. Dashboard/folder
+  create/delete, folder/ACL write, query, and admin grants are rejected.
 
 If live already equals current, deployment is a no-op. If it equals a trusted
 historical artifact, the provisioner updates to current. Any third state is
@@ -121,6 +123,10 @@ a maintenance window before setting the enable variable:
 4. Create a read-only service account for `dashboards:read`, `folders:read`,
    `folders.permissions:read`, `datasources:read`, and `datasources:query`,
    scoped to the exact dashboard, folder, and `grafanacloud-traces` datasource.
+   Grafana may derive the exact datasource read scope from the query grant;
+   audit the effective permissions rather than duplicating it in the custom
+   role. The effective folder-read scopes must be exactly the private folder
+   and Grafana's built-in `folders:uid:sharedwithme` virtual folder.
    Store its token only as `THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN` in the
    existing `telemetry-dashboard-production` Environment. Keep that Environment
    main-only and read-only (`deployment: false`).

--- a/scripts/telemetry-dashboard.ts
+++ b/scripts/telemetry-dashboard.ts
@@ -46,6 +46,7 @@ const grafanaCloudNamespacePattern = /^stacks-[1-9][0-9]*$/u;
 const gitCommitPattern = /^[0-9a-f]{40}$/u;
 const dashboardApiVersion = 'dashboard.grafana.app/v1';
 const folderApiVersion = 'folder.grafana.app/v1';
+const grafanaSharedWithMeFolderScope = 'folders:uid:sharedwithme';
 
 function record(value: unknown, path: string): Record<string, unknown> {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
@@ -453,7 +454,7 @@ function validatePrivateFolderPermissions(value: unknown): void {
 function validateExactPermissions(
   value: unknown,
   actor: 'reader' | 'writer',
-  exactScopes: Readonly<Record<string, string>>,
+  exactScopes: Readonly<Record<string, readonly string[]>>,
 ): void {
   const permissions = record(value, 'Grafana effective permissions response');
   for (const [action, scopesValue] of Object.entries(permissions)) {
@@ -464,14 +465,25 @@ function validateExactPermissions(
     if (!Object.hasOwn(exactScopes, action) || scopes.some(scope => scope === '*' || scope.endsWith(':*'))) {
       throw new ScriptError(`Grafana dashboard ${actor} has a forbidden permission action or scope.`);
     }
-    const expectedScope = exactScopes[action];
-    if (expectedScope === undefined || scopes.length !== 1 || scopes[0] !== expectedScope) {
+    const expectedScopes = exactScopes[action];
+    if (
+      expectedScopes === undefined ||
+      scopes.length !== expectedScopes.length ||
+      new Set(scopes).size !== scopes.length ||
+      expectedScopes.some(scope => !scopes.includes(scope))
+    ) {
       throw new ScriptError(`Grafana dashboard ${actor} is not restricted to the exact allowed targets.`);
     }
   }
-  for (const [action, expectedScope] of Object.entries(exactScopes)) {
+  for (const [action, expectedScopes] of Object.entries(exactScopes)) {
     const scopes = permissions[action];
-    if (!Array.isArray(scopes) || scopes.length !== 1 || scopes[0] !== expectedScope) {
+    if (
+      !Array.isArray(scopes) ||
+      scopes.some(scope => typeof scope !== 'string') ||
+      scopes.length !== expectedScopes.length ||
+      new Set(scopes).size !== scopes.length ||
+      expectedScopes.some(scope => !scopes.includes(scope as string))
+    ) {
       throw new ScriptError(`Grafana dashboard ${actor} is missing a required exact-target permission.`);
     }
   }
@@ -479,20 +491,20 @@ function validateExactPermissions(
 
 export function validateWriterPermissions(value: unknown): void {
   validateExactPermissions(value, 'writer', {
-    'dashboards:read': `dashboards:uid:${telemetryDashboardUid}`,
-    'dashboards:write': `dashboards:uid:${telemetryDashboardUid}`,
-    'folders.permissions:read': `folders:uid:${telemetryDashboardFolderUid}`,
-    'folders:read': `folders:uid:${telemetryDashboardFolderUid}`,
+    'dashboards:read': [`dashboards:uid:${telemetryDashboardUid}`],
+    'dashboards:write': [`dashboards:uid:${telemetryDashboardUid}`],
+    'folders.permissions:read': [`folders:uid:${telemetryDashboardFolderUid}`],
+    'folders:read': [`folders:uid:${telemetryDashboardFolderUid}`, grafanaSharedWithMeFolderScope],
   });
 }
 
 export function validateReaderPermissions(value: unknown): void {
   validateExactPermissions(value, 'reader', {
-    'dashboards:read': `dashboards:uid:${telemetryDashboardUid}`,
-    'datasources:query': `datasources:uid:${telemetryDashboardDatasourceUid}`,
-    'datasources:read': `datasources:uid:${telemetryDashboardDatasourceUid}`,
-    'folders.permissions:read': `folders:uid:${telemetryDashboardFolderUid}`,
-    'folders:read': `folders:uid:${telemetryDashboardFolderUid}`,
+    'dashboards:read': [`dashboards:uid:${telemetryDashboardUid}`],
+    'datasources:query': [`datasources:uid:${telemetryDashboardDatasourceUid}`],
+    'datasources:read': [`datasources:uid:${telemetryDashboardDatasourceUid}`],
+    'folders.permissions:read': [`folders:uid:${telemetryDashboardFolderUid}`],
+    'folders:read': [`folders:uid:${telemetryDashboardFolderUid}`, grafanaSharedWithMeFolderScope],
   });
 }
 

--- a/test/unit/telemetry-dashboard-provisioning.test.ts
+++ b/test/unit/telemetry-dashboard-provisioning.test.ts
@@ -31,6 +31,7 @@ import {
 const testGrafanaNamespace = 'stacks-123456';
 const testGrafanaUrl = 'https://threadnote-test.grafana.net';
 const currentSha = 'a'.repeat(40);
+const grafanaSharedWithMeFolderScope = 'folders:uid:sharedwithme';
 
 type WorkflowJob = Readonly<{
   environment?: string | Readonly<{deployment?: boolean; name: string}>;
@@ -147,7 +148,7 @@ function writerPermissions(overrides: Readonly<Record<string, readonly string[]>
     'dashboards:read': [`dashboards:uid:${telemetryDashboardUid}`],
     'dashboards:write': [`dashboards:uid:${telemetryDashboardUid}`],
     'folders.permissions:read': [`folders:uid:${telemetryDashboardFolderUid}`],
-    'folders:read': [`folders:uid:${telemetryDashboardFolderUid}`],
+    'folders:read': [`folders:uid:${telemetryDashboardFolderUid}`, grafanaSharedWithMeFolderScope],
     ...overrides,
   };
 }
@@ -158,7 +159,7 @@ function readerPermissions(overrides: Readonly<Record<string, readonly string[]>
     'datasources:query': [`datasources:uid:${telemetryDashboardDatasourceUid}`],
     'datasources:read': [`datasources:uid:${telemetryDashboardDatasourceUid}`],
     'folders.permissions:read': [`folders:uid:${telemetryDashboardFolderUid}`],
-    'folders:read': [`folders:uid:${telemetryDashboardFolderUid}`],
+    'folders:read': [`folders:uid:${telemetryDashboardFolderUid}`, grafanaSharedWithMeFolderScope],
     ...overrides,
   };
 }
@@ -564,7 +565,30 @@ describe('direct Grafana dashboard provisioning', () => {
     expect(() => validateWriterPermissions({'dashboards:read': [`dashboards:uid:${telemetryDashboardUid}`]})).toThrow(
       /missing/u,
     );
+    for (const scopes of [
+      [`folders:uid:${telemetryDashboardFolderUid}`],
+      [`folders:uid:${telemetryDashboardFolderUid}`, `folders:uid:${telemetryDashboardFolderUid}`],
+      [`folders:uid:${telemetryDashboardFolderUid}`, grafanaSharedWithMeFolderScope, 'folders:uid:other'],
+    ]) {
+      expect(() => validateWriterPermissions(writerPermissions({'folders:read': scopes}))).toThrow(
+        /exact allowed targets/u,
+      );
+    }
   });
+
+  it.prop(
+    'treats the exact Grafana folder-read scopes as an order-independent set',
+    {actor: FC.constantFrom('reader' as const, 'writer' as const), reverse: FC.boolean()},
+    ({actor, reverse}) => {
+      const scopes = [`folders:uid:${telemetryDashboardFolderUid}`, grafanaSharedWithMeFolderScope];
+      if (reverse) scopes.reverse();
+      const permissions =
+        actor === 'reader' ? readerPermissions({'folders:read': scopes}) : writerPermissions({'folders:read': scopes});
+      const validate = actor === 'reader' ? validateReaderPermissions : validateWriterPermissions;
+      expect(() => validate(permissions)).not.toThrow();
+    },
+    {fastCheck: {numRuns: 20}},
+  );
 
   it('requires a reader token restricted to exact dashboard, folder, and datasource scopes', async () => {
     expect(() => validateReaderPermissions(readerPermissions())).not.toThrow();


### PR DESCRIPTION
## What changed

- Treat Grafana's built-in `folders:uid:sharedwithme` virtual folder as the only permitted second `folders:read` scope for the dashboard reader and writer.
- Compare every permission action as an exact, order-independent scope set while continuing to reject missing, duplicate, wildcard, substituted, or additional scopes.
- Document the effective Grafana RBAC shape and avoid duplicating the datasource-read grant that Grafana derives from datasource query access.

## Why

The first enabled read-only dashboard verification failed before touching the dashboard because Grafana automatically adds the `sharedwithme` virtual folder scope to every authenticated service account. The reader role also duplicated `datasources:read` when it was granted explicitly in addition to `datasources:query`; the live role has been corrected so the effective datasource-read scope appears exactly once.

This keeps the production audit fail-closed while accepting Grafana's unavoidable system-owned scope.

## Validation

- TDD regression: focused provisioning suite failed before the implementation and passed afterward.
- `bun scripts/telemetry-dashboard.ts check`
- `bun --bun vitest run test/unit/telemetry-dashboard-provisioning.test.ts test/unit/telemetry-gateway-dashboard.test.ts` (29 tests)
- strict targeted Oxlint
- source and test TypeScript checks
- Prettier and `git diff --check`
- Dev-cycle full review: 0 critical, important, minor, or informational findings
- Commit hook: repository lint, formatting, source/test/site typechecks

Property coverage verifies the exact two-scope set is order-independent; examples reject missing, duplicate, and extra folder scopes.
