### PR TITLE
Fix Grafana v42 dashboard normalization

### DIFF
--- a/.github/workflows/telemetry-dashboard.yml
+++ b/.github/workflows/telemetry-dashboard.yml
@@ -109,8 +109,8 @@ jobs:
       - name: Fail closed when writer configuration is incomplete
         if: steps.freshness.outputs.stale != 'true'
         env:
-          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
-          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_URL }}
+          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
+          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_URL }}
           THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN }}
         run: |
           if [[ -z "$THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE" ]]; then
@@ -151,8 +151,8 @@ jobs:
         if: steps.freshness.outputs.stale != 'true' && steps.final_freshness.outputs.stale != 'true'
         env:
           THREADNOTE_TELEMETRY_DASHBOARD_CURRENT_SHA: ${{ github.sha }}
-          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
-          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_URL }}
+          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
+          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_URL }}
           THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN }}
         run: >-
           bun --config=/dev/null --no-env-file --no-install
@@ -185,8 +185,8 @@ jobs:
 
       - name: Fail closed when read-only verification configuration is incomplete
         env:
-          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
-          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_URL }}
+          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
+          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_URL }}
           THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN }}
         run: |
           if [[ -z "$THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE" ]]; then
@@ -204,8 +204,8 @@ jobs:
 
       - name: Verify exact live state, private ACLs, and every Tempo query
         env:
-          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
-          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ vars.THREADNOTE_TELEMETRY_GRAFANA_URL }}
+          THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE }}
+          THREADNOTE_TELEMETRY_GRAFANA_URL: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_URL }}
           THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN: ${{ secrets.THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN }}
         run: >-
           bun --config=/dev/null --no-env-file --no-install

--- a/infra/telemetry-dashboard/README.md
+++ b/infra/telemetry-dashboard/README.md
@@ -79,10 +79,13 @@ source, or generated artifact.
 Grafana owns the root `schemaVersion`. The PUT preserves the exact live value
 and the post-write GET requires it to remain unchanged, preventing schema
 downgrades. Semantic comparison ignores that root field and the other App API
-server fields. The only structural migration noise tolerated is omission of
-an exactly empty `{defaults: {}, overrides: []}` `fieldConfig` on the six
-known panels 14–19. Query, panel, nonempty field configuration, layout, and all
-other differences remain drift.
+server fields. It also normalizes only the exact Grafana v42 defaults observed
+on this dashboard: empty plugin versions; known empty mappings, overrides, and
+field configuration members; the empty templating/week-start defaults; the
+standard refresh-interval list; `preload: false`; and the Mixed parent
+datasource for the fixed Tempo-plus-expression panel. Query targets, nonempty
+or unknown defaults, panel content, layout, and all other differences remain
+drift.
 
 After a successful PUT, a second GET must show the same immutable UID, a
 different resourceVersion, the preserved schemaVersion, and the exact intended
@@ -147,7 +150,8 @@ a maintenance window before setting the enable variable:
    trusted operator, and remove administrator bypass. Add a second independent
    trusted reviewer before enabling self-review prevention. Configure
    `THREADNOTE_TELEMETRY_GRAFANA_URL` and
-   `THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE` as variables in both Environments.
+   `THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE` as secrets in both Environments so
+   GitHub masks the private deployment identifiers in workflow logs.
    The URL must be an uncredentialed root Grafana Cloud HTTPS origin whose
    hostname ends in `.grafana.net`, with no non-default port. The namespace must
    use the private `stacks-<numeric Stack ID>` form and must not be printed.

--- a/scripts/telemetry-dashboard.ts
+++ b/scripts/telemetry-dashboard.ts
@@ -42,6 +42,9 @@ type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<
 const datasourcePlaceholder = '${DS_TEMPO}';
 const serverOwnedDashboardKeys = new Set(['id', 'iteration', 'schemaVersion', 'uid', 'version']);
 const migrationEmptyFieldConfigPanelIds = new Set([14, 15, 16, 17, 18, 19]);
+const migrationEmptyMappingsPanelIds = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+const migrationEmptyOverridesPanelIds = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13]);
+const grafanaDefaultRefreshIntervals = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'];
 const grafanaCloudNamespacePattern = /^stacks-[1-9][0-9]*$/u;
 const gitCommitPattern = /^[0-9a-f]{40}$/u;
 const dashboardApiVersion = 'dashboard.grafana.app/v1';
@@ -244,19 +247,111 @@ function isMigrationEmptyFieldConfig(value: unknown): boolean {
   );
 }
 
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isExactStringArray(value: unknown, expected: readonly string[]): boolean {
+  return (
+    Array.isArray(value) && value.length === expected.length && value.every((item, index) => item === expected[index])
+  );
+}
+
+function isDatasource(value: unknown, type: string, uid: string): boolean {
+  return isObject(value) && Object.keys(value).length === 2 && value.type === type && value.uid === uid;
+}
+
+function exactTempoDatasourceUid(value: unknown): string | undefined {
+  if (
+    !isObject(value) ||
+    Object.keys(value).length !== 2 ||
+    value.type !== 'tempo' ||
+    typeof value.uid !== 'string' ||
+    value.uid.length === 0
+  ) {
+    return undefined;
+  }
+  return value.uid;
+}
+
+function mixedTempoExpressionTargetDatasourceUid(panel: Record<string, unknown>): string | undefined {
+  if (panel.id !== 13 || !Array.isArray(panel.targets) || panel.targets.length !== 3) return undefined;
+  const [left, right, expression] = panel.targets;
+  if (!isObject(left) || !isObject(right) || !isObject(expression)) return undefined;
+  const leftDatasourceUid = exactTempoDatasourceUid(left.datasource);
+  const rightDatasourceUid = exactTempoDatasourceUid(right.datasource);
+  if (
+    left.refId !== 'A' ||
+    right.refId !== 'B' ||
+    expression.refId !== 'C' ||
+    leftDatasourceUid === undefined ||
+    leftDatasourceUid !== rightDatasourceUid ||
+    !isDatasource(expression.datasource, '__expr__', '__expr__')
+  ) {
+    return undefined;
+  }
+  return leftDatasourceUid;
+}
+
+function normalizePanelMigrationNoise(panel: Record<string, unknown>): void {
+  if (panel.pluginVersion === '') delete panel.pluginVersion;
+  if (typeof panel.id !== 'number') return;
+  const targetDatasourceUid = mixedTempoExpressionTargetDatasourceUid(panel);
+  if (
+    targetDatasourceUid !== undefined &&
+    (isDatasource(panel.datasource, 'tempo', targetDatasourceUid) ||
+      isDatasource(panel.datasource, 'mixed', '-- Mixed --'))
+  ) {
+    delete panel.datasource;
+  }
+  if (migrationEmptyFieldConfigPanelIds.has(panel.id) && isMigrationEmptyFieldConfig(panel.fieldConfig)) {
+    delete panel.fieldConfig;
+    return;
+  }
+  if (!isObject(panel.fieldConfig)) return;
+  const fieldConfig = panel.fieldConfig;
+  if (isObject(fieldConfig.defaults)) {
+    if (
+      migrationEmptyMappingsPanelIds.has(panel.id) &&
+      Array.isArray(fieldConfig.defaults.mappings) &&
+      fieldConfig.defaults.mappings.length === 0
+    ) {
+      delete fieldConfig.defaults.mappings;
+    }
+    if (panel.id === 20 && Object.keys(fieldConfig.defaults).length === 0) delete fieldConfig.defaults;
+  }
+  if (
+    migrationEmptyOverridesPanelIds.has(panel.id) &&
+    Array.isArray(fieldConfig.overrides) &&
+    fieldConfig.overrides.length === 0
+  ) {
+    delete fieldConfig.overrides;
+  }
+}
+
 export function canonicalDashboardSemantics(value: unknown): string {
   const dashboard = record(cloneJson(value, 'dashboard spec'), 'dashboard spec');
   for (const key of serverOwnedDashboardKeys) delete dashboard[key];
+  if (dashboard.preload === false) delete dashboard.preload;
+  if (dashboard.weekStart === '') delete dashboard.weekStart;
+  if (
+    isObject(dashboard.templating) &&
+    Object.keys(dashboard.templating).length === 1 &&
+    Array.isArray(dashboard.templating.list) &&
+    dashboard.templating.list.length === 0
+  ) {
+    delete dashboard.templating;
+  }
+  if (
+    isObject(dashboard.timepicker) &&
+    isExactStringArray(dashboard.timepicker.refresh_intervals, grafanaDefaultRefreshIntervals)
+  ) {
+    delete dashboard.timepicker.refresh_intervals;
+  }
   if (Array.isArray(dashboard.panels)) {
     dashboard.panels = dashboard.panels.map((panelValue, index) => {
       const panel = record(panelValue, `dashboard spec.panels[${index}]`);
-      if (
-        typeof panel.id === 'number' &&
-        migrationEmptyFieldConfigPanelIds.has(panel.id) &&
-        isMigrationEmptyFieldConfig(panel.fieldConfig)
-      ) {
-        delete panel.fieldConfig;
-      }
+      normalizePanelMigrationNoise(panel);
       return panel;
     });
   }

--- a/test/unit/telemetry-dashboard-provisioning.test.ts
+++ b/test/unit/telemetry-dashboard-provisioning.test.ts
@@ -32,6 +32,7 @@ const testGrafanaNamespace = 'stacks-123456';
 const testGrafanaUrl = 'https://threadnote-test.grafana.net';
 const currentSha = 'a'.repeat(40);
 const grafanaSharedWithMeFolderScope = 'folders:uid:sharedwithme';
+const grafanaDefaultRefreshIntervals = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'];
 
 type WorkflowJob = Readonly<{
   environment?: string | Readonly<{deployment?: boolean; name: string}>;
@@ -71,6 +72,28 @@ function readDashboardArtifact(): DashboardArtifact {
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function grafanaV42DashboardSpec(spec: Readonly<Record<string, JsonValue>>): Record<string, JsonValue> {
+  const migrated = clone(spec) as Record<string, JsonValue>;
+  migrated.schemaVersion = 42;
+  migrated.preload = false;
+  delete migrated.templating;
+  migrated.timepicker = {refresh_intervals: grafanaDefaultRefreshIntervals};
+  delete migrated.weekStart;
+  const panels = migrated.panels as Record<string, JsonValue>[];
+  for (const panel of panels) {
+    panel.pluginVersion = '';
+    if (typeof panel.id !== 'number') continue;
+    const fieldConfig = panel.fieldConfig as Record<string, JsonValue>;
+    const defaults = fieldConfig.defaults as Record<string, JsonValue>;
+    if (panel.id >= 1 && panel.id <= 12) delete defaults.mappings;
+    if ((panel.id >= 1 && panel.id <= 11) || panel.id === 13) delete fieldConfig.overrides;
+    if (panel.id >= 14 && panel.id <= 19) delete panel.fieldConfig;
+    if (panel.id === 20) delete fieldConfig.defaults;
+    if (panel.id === 13) panel.datasource = {type: 'mixed', uid: '-- Mixed --'};
+  }
+  return migrated;
 }
 
 function artifactWithTitle(resource: DashboardArtifact, title: string): DashboardArtifact {
@@ -250,12 +273,7 @@ describe('direct Grafana dashboard provisioning', () => {
 
   it('normalizes only proven Grafana migration noise', () => {
     const resource = readDashboardArtifact();
-    const migrated = clone(resource.spec) as Record<string, JsonValue>;
-    migrated.schemaVersion = 42;
-    const panels = migrated.panels as Record<string, JsonValue>[];
-    for (const panel of panels) {
-      if (typeof panel.id === 'number' && panel.id >= 14 && panel.id <= 19) delete panel.fieldConfig;
-    }
+    const migrated = grafanaV42DashboardSpec(resource.spec);
     expect(canonicalDashboardSemantics(migrated)).toBe(canonicalDashboardSemantics(resource.spec));
 
     const queryDrift = clone(migrated);
@@ -267,7 +285,56 @@ describe('direct Grafana dashboard provisioning', () => {
     const unapprovedEmptyRemoval = clone(resource.spec);
     delete (unapprovedEmptyRemoval.panels as Record<string, JsonValue>[])[19]!.fieldConfig;
     expect(canonicalDashboardSemantics(unapprovedEmptyRemoval)).not.toBe(canonicalDashboardSemantics(resource.spec));
+
+    const wrongRefreshIntervals = clone(migrated);
+    wrongRefreshIntervals.timepicker = {refresh_intervals: ['17s']};
+    expect(canonicalDashboardSemantics(wrongRefreshIntervals)).not.toBe(canonicalDashboardSemantics(resource.spec));
+
+    const wrongMixedDatasource = clone(migrated);
+    (wrongMixedDatasource.panels as Record<string, JsonValue>[])[12]!.datasource = {
+      type: 'mixed',
+      uid: 'other',
+    };
+    expect(canonicalDashboardSemantics(wrongMixedDatasource)).not.toBe(canonicalDashboardSemantics(resource.spec));
+
+    const mismatchedTargetDatasources = clone(migrated);
+    const expressionTargets = (mismatchedTargetDatasources.panels as Record<string, JsonValue>[])[12]!
+      .targets as Record<string, JsonValue>[];
+    expressionTargets[1]!.datasource = {type: 'tempo', uid: 'other'};
+    expect(canonicalDashboardSemantics(mismatchedTargetDatasources)).not.toBe(
+      canonicalDashboardSemantics(resource.spec),
+    );
   });
+
+  it.prop(
+    'normalizes panel 13 from the exact shared Tempo target datasource across reviewed datasource migrations',
+    {datasourceUid: FC.string({maxLength: 32, minLength: 1})},
+    ({datasourceUid}) => {
+      const historical = clone(readDashboardArtifact().spec);
+      const panel = (historical.panels as Record<string, JsonValue>[])[12]!;
+      panel.datasource = {type: 'tempo', uid: datasourceUid};
+      const targets = panel.targets as Record<string, JsonValue>[];
+      targets[0]!.datasource = {type: 'tempo', uid: datasourceUid};
+      targets[1]!.datasource = {type: 'tempo', uid: datasourceUid};
+
+      expect(canonicalDashboardSemantics(grafanaV42DashboardSpec(historical))).toBe(
+        canonicalDashboardSemantics(historical),
+      );
+    },
+    {fastCheck: {numRuns: 40}},
+  );
+
+  it.prop(
+    'preserves arbitrary nonempty panel plugin versions as semantic drift',
+    {pluginVersion: FC.string({maxLength: 32, minLength: 1})},
+    ({pluginVersion}) => {
+      const resource = readDashboardArtifact();
+      const drift = clone(resource.spec) as Record<string, JsonValue>;
+      (drift.panels as Record<string, JsonValue>[])[0]!.pluginVersion = pluginVersion;
+      expect(canonicalDashboardSemantics(drift)).not.toBe(canonicalDashboardSemantics(resource.spec));
+    },
+    {fastCheck: {numRuns: 40}},
+  );
 
   it.prop(
     'updates only from a trusted historical state and otherwise fails closed',
@@ -295,7 +362,11 @@ describe('direct Grafana dashboard provisioning', () => {
         requestBody = body;
       },
       putResponse: new Response(null, {status: 200}),
-      updated: liveDashboard(current, {resourceVersion: 'next-rv', schemaVersion: 43}),
+      updated: liveDashboard(current, {
+        resourceVersion: 'next-rv',
+        schemaVersion: 43,
+        spec: grafanaV42DashboardSpec(current.spec),
+      }),
     });
 
     await expect(
@@ -391,6 +462,11 @@ describe('direct Grafana dashboard provisioning', () => {
     const firstTarget = (firstPanel.targets as Record<string, JsonValue>[])[0]!;
     firstPanel.datasource = {type: 'tempo', uid: 'previous-traces-datasource'};
     firstTarget.datasource = {type: 'tempo', uid: 'previous-traces-datasource'};
+    const expressionPanel = (historical.spec.panels as Record<string, JsonValue>[])[12]!;
+    expressionPanel.datasource = {type: 'tempo', uid: 'previous-traces-datasource'};
+    const expressionTargets = expressionPanel.targets as Record<string, JsonValue>[];
+    expressionTargets[0]!.datasource = {type: 'tempo', uid: 'previous-traces-datasource'};
+    expressionTargets[1]!.datasource = {type: 'tempo', uid: 'previous-traces-datasource'};
     const reader = async (args: readonly string[]): Promise<string | undefined> => {
       if (args[0] === 'log') {
         expect(args).toEqual([
@@ -413,7 +489,10 @@ describe('direct Grafana dashboard provisioning', () => {
     const artifacts = await loadHistoricalArtifacts('/unused-in-injected-test', currentSha, reader);
     expect(artifacts).toEqual([historical]);
     const current = readDashboardArtifact();
-    const harness = deploymentFetcher({current, live: liveDashboard(historical)});
+    const harness = deploymentFetcher({
+      current,
+      live: liveDashboard(historical, {spec: grafanaV42DashboardSpec(historical.spec)}),
+    });
     await expect(
       deployDashboard({
         baseUrl: testGrafanaUrl,
@@ -625,7 +704,9 @@ describe('direct Grafana dashboard provisioning', () => {
         const url = String(input);
         requests.push({method: init?.method, url});
         if (url.endsWith('/api/access-control/user/permissions')) return Response.json(readerPermissions());
-        if (url.includes('/apis/dashboard.grafana.app/')) return Response.json(liveDashboard(resource));
+        if (url.includes('/apis/dashboard.grafana.app/')) {
+          return Response.json(liveDashboard(resource, {spec: grafanaV42DashboardSpec(resource.spec)}));
+        }
         if (url.includes('/apis/folder.grafana.app/')) return Response.json(liveFolder());
         if (url.endsWith('/permissions')) return Response.json([]);
         return Response.json(successfulQueryResponse(resource));
@@ -729,6 +810,10 @@ describe('direct Grafana dashboard provisioning', () => {
     expect(deployment.if).toContain("THREADNOTE_TELEMETRY_GRAFANA_DIRECT_ENABLED == 'true'");
     expect(deploymentText).toContain('THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN');
     expect(deploymentText).not.toContain('THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN');
+    expect(deploymentText).toContain('secrets.THREADNOTE_TELEMETRY_GRAFANA_URL');
+    expect(deploymentText).toContain('secrets.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE');
+    expect(deploymentText).not.toContain('vars.THREADNOTE_TELEMETRY_GRAFANA_URL');
+    expect(deploymentText).not.toContain('vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE');
     expect(deploymentText).not.toContain('bun install');
     expect(deploymentText).toContain('git merge-base --is-ancestor');
     expect(deploymentText).toContain('git diff --quiet --no-ext-diff --no-textconv');
@@ -745,6 +830,10 @@ describe('direct Grafana dashboard provisioning', () => {
     expect(verification.if).toContain("github.repository == 'Kashkovsky/threadnote'");
     expect(verificationText).toContain('THREADNOTE_TELEMETRY_GRAFANA_READ_TOKEN');
     expect(verificationText).not.toContain('THREADNOTE_TELEMETRY_GRAFANA_WRITE_TOKEN');
+    expect(verificationText).toContain('secrets.THREADNOTE_TELEMETRY_GRAFANA_URL');
+    expect(verificationText).toContain('secrets.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE');
+    expect(verificationText).not.toContain('vars.THREADNOTE_TELEMETRY_GRAFANA_URL');
+    expect(verificationText).not.toContain('vars.THREADNOTE_TELEMETRY_GRAFANA_NAMESPACE');
     expect(verificationText).not.toContain('bun install');
     expect(verificationText).toContain(
       'bun --config=/dev/null --no-env-file --no-install scripts/telemetry-dashboard.ts verify-live',


### PR DESCRIPTION
## What changed

- Normalize only the exact Grafana v42 serialization defaults observed on the existing telemetry dashboard.
- Derive panel 13's Tempo datasource identity from its exact A/B targets so reviewed historical datasource migrations remain valid.
- Exercise the v42 representation through canonical comparison, post-write verification, read-only verification, and bounded property tests.
- Read the private Grafana URL and stack namespace from masked environment secrets instead of workflow variables.

## Why

The first protected production reconciliation failed closed before writing because Grafana v42 had reserialized the unchanged dashboard with default fields and a Mixed parent datasource for the Tempo-plus-expression panel. The canonical comparison admitted too little server-owned representation noise. It also tied that panel to the current datasource UID, which would reject a reviewed historical artifact after a datasource migration.

All query targets, expressions, nonempty or unknown defaults, panel content, layout, and mismatched datasource identities remain semantic drift.

## Validation

- canonical artifact check
- 41 focused Vitest tests
- source, test, and website TypeScript checks via the pre-commit gate
- strict Oxlint and repository lint/file-length checks
- Prettier and git diff hygiene
- Actionlint 1.7.12

The full suite was intentionally left to CI.
