### PR TITLE
Publish governed Threadnote 4.2.5 IntelliJ performance evidence

### DIFF
--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -52,6 +52,7 @@ import {
 } from '../src/evaluation/benchmark.js';
 import {
   EXTERNAL_REPOSITORY_REQUIRED_MEASUREMENTS,
+  RELEASE_EVIDENCE_HARNESS_DELTA_PATHS,
   isReviewedPublicBenchmarkRepository,
   projectExternalEvidenceMetadata,
   validateExternalRepositoryEvidence,
@@ -1408,8 +1409,11 @@ const benchmarkCodeGraph = Effect.scoped(
         ...(largeEvidenceRun && releaseEvidenceSource
           ? {
               releaseEvidenceRef: releaseEvidenceSource.ref,
+              releaseEvidenceHarnessCommit: releaseEvidenceSource.harnessCommit,
+              releaseEvidenceHarnessDeltaPaths: releaseEvidenceSource.harnessDeltaPaths,
               releaseEvidenceResolvedSha: releaseEvidenceSource.resolvedSha,
               releaseEvidenceSha: releaseEvidenceSource.sha,
+              releaseEvidenceSourceMode: releaseEvidenceSource.sourceMode,
             }
           : {}),
         ...(runtimeProvenance ? benchmarkRuntimeProvenanceMetadata(runtimeProvenance) : {}),
@@ -4195,12 +4199,35 @@ function missingReleaseSourceProvenance(artifact: BenchmarkArtifactV1): readonly
   const ref = artifact.metadata.releaseEvidenceRef;
   const resolvedSha = artifact.metadata.releaseEvidenceResolvedSha;
   const sha = artifact.metadata.releaseEvidenceSha;
+  const sourceMode = artifact.metadata.releaseEvidenceSourceMode;
+  const harnessCommit = artifact.metadata.releaseEvidenceHarnessCommit;
+  let harnessDeltaPaths: readonly string[] = [];
+  try {
+    const parsed = JSON.parse(String(artifact.metadata.releaseEvidenceHarnessDeltaPaths ?? '[]'));
+    if (Array.isArray(parsed) && parsed.every(path => typeof path === 'string')) harnessDeltaPaths = parsed;
+  } catch {
+    // The shared missing-evidence result below reports malformed provenance.
+  }
+  const canonicalHarnessDelta =
+    harnessDeltaPaths.length > 0 &&
+    new Set(harnessDeltaPaths).size === harnessDeltaPaths.length &&
+    harnessDeltaPaths.every(path => (RELEASE_EVIDENCE_HARNESS_DELTA_PATHS as readonly string[]).includes(path)) &&
+    JSON.stringify([...harnessDeltaPaths].sort()) === JSON.stringify(harnessDeltaPaths);
+  const sourceModeValid =
+    (sourceMode === 'exact-release' &&
+      harnessCommit === sha &&
+      artifact.environment.commit === sha &&
+      artifact.metadata.releaseEvidenceHarnessDeltaPaths === '[]') ||
+    (sourceMode === 'release-plus-reviewed-harness-delta' &&
+      harnessCommit === artifact.environment.commit &&
+      harnessCommit !== sha &&
+      canonicalHarnessDelta);
   return typeof ref === 'string' &&
     THREADNOTE_4_RELEASE_REF_PATTERN.test(ref) &&
     typeof sha === 'string' &&
     EXACT_GIT_COMMIT_PATTERN.test(sha) &&
     resolvedSha === sha &&
-    sha === artifact.environment.commit &&
+    sourceModeValid &&
     !artifact.environment.dirty
     ? []
     : ['clean exact release source provenance'];
@@ -4236,7 +4263,7 @@ function missingBenchmarkRuntimeProvenance(artifact: BenchmarkArtifactV1): reado
     metadata.benchmarkValidatedManagedProcessLeaseInspection === 'complete' &&
     metadata.benchmarkValidatedManagedDependencyInstallation === 'bun install --frozen-lockfile' &&
     typeof managedVersion === 'string' &&
-    managedVersion.endsWith(`.local.g${sourceCommit}`) &&
+    (managedVersion.endsWith(`-local.g${sourceCommit}`) || managedVersion.endsWith(`.local.g${sourceCommit}`)) &&
     typeof metadata.benchmarkValidatedManagedPayloadFileCount === 'number' &&
     metadata.benchmarkValidatedManagedPayloadFileCount > 0 &&
     typeof metadata.benchmarkValidatedManagedPayloadBytes === 'number' &&
@@ -4429,19 +4456,42 @@ export function resolvedReleaseEvidenceSource(
   resolvedSha: string,
   checkoutCommit: string,
   dirty: boolean,
-): {readonly ref: string; readonly resolvedSha: string; readonly sha: string} {
+  harnessDeltaPaths: readonly string[] = [],
+  releaseIsAncestor = checkoutCommit === sha,
+): {
+  readonly ref: string;
+  readonly resolvedSha: string;
+  readonly sha: string;
+  readonly harnessCommit: string;
+  readonly harnessDeltaPaths: string;
+  readonly sourceMode: 'exact-release' | 'release-plus-reviewed-harness-delta';
+} {
+  const normalizedDeltaPaths = [...harnessDeltaPaths].sort();
+  const reviewedDelta =
+    checkoutCommit !== sha &&
+    releaseIsAncestor &&
+    normalizedDeltaPaths.length > 0 &&
+    new Set(normalizedDeltaPaths).size === normalizedDeltaPaths.length &&
+    normalizedDeltaPaths.every(path => (RELEASE_EVIDENCE_HARNESS_DELTA_PATHS as readonly string[]).includes(path));
   if (
     !THREADNOTE_4_RELEASE_REF_PATTERN.test(ref) ||
     !EXACT_GIT_COMMIT_PATTERN.test(sha) ||
     resolvedSha !== sha ||
-    checkoutCommit !== sha ||
+    (!reviewedDelta && (checkoutCommit !== sha || harnessDeltaPaths.length > 0)) ||
     dirty
   ) {
     throw new ScriptError(
-      'Release benchmark provenance requires a locally resolvable tag, its exact commit SHA, and a clean checkout.',
+      'Release benchmark provenance requires a locally resolvable tag and either its clean exact commit or a clean descendant with only reviewed harness changes.',
     );
   }
-  return {ref, resolvedSha, sha};
+  return {
+    ref,
+    resolvedSha,
+    sha,
+    harnessCommit: checkoutCommit,
+    harnessDeltaPaths: JSON.stringify(normalizedDeltaPaths),
+    sourceMode: reviewedDelta ? 'release-plus-reviewed-harness-delta' : 'exact-release',
+  };
 }
 
 const validateReleaseEvidenceSource = Effect.fn('benchmarkCodeGraph.validateReleaseEvidenceSource')(function* (
@@ -4468,7 +4518,42 @@ const validateReleaseEvidenceSource = Effect.fn('benchmarkCodeGraph.validateRele
     ],
     {concurrency: 3},
   );
-  return yield* Effect.try(() => resolvedReleaseEvidenceSource(ref, sha, resolvedSha, commit, dirty.length > 0));
+  const [releaseMergeBase, harnessDeltaOutput] =
+    commit === sha
+      ? [sha, '']
+      : yield* Effect.all(
+          [
+            threadnoteSourceGit(sourceRoot, ['merge-base', sha, commit]),
+            threadnoteSourceGit(sourceRoot, [
+              'diff',
+              '--name-only',
+              '--diff-filter=ACDMRTUXB',
+              `${sha}..${commit}`,
+              '--',
+              'src',
+              'scripts',
+              'manager',
+              'config',
+              'assets',
+              'package.json',
+              'bun.lock',
+              'tsconfig.json',
+            ]),
+          ],
+          {concurrency: 2},
+        );
+  const harnessDeltaPaths = harnessDeltaOutput.split('\n').filter(Boolean);
+  return yield* Effect.try(() =>
+    resolvedReleaseEvidenceSource(
+      ref,
+      sha,
+      resolvedSha,
+      commit,
+      dirty.length > 0,
+      harnessDeltaPaths,
+      releaseMergeBase === sha,
+    ),
+  );
 });
 
 export interface CodeGraphBenchmarkOptions {

--- a/scripts/site-performance-evidence.ts
+++ b/scripts/site-performance-evidence.ts
@@ -1,5 +1,6 @@
 import {ScriptError} from './effect/errors.js';
 import {parseBenchmarkArtifactV1} from '../src/evaluation/benchmark.js';
+import {RELEASE_EVIDENCE_HARNESS_DELTA_PATHS} from '../src/evaluation/external_evidence.js';
 import {
   pendingPerformanceEvidence,
   retainedPerformanceArtifactFromHarness,
@@ -214,10 +215,51 @@ function verifySourceCommit(repositoryRoot: string, sourceCommit: string): void 
 
 function verifyReleaseEvidenceSource(repositoryRoot: string, payload: RetainedPerformancePayload): void {
   const ref = String(payload.metadata.releaseEvidenceRef);
+  const releaseSha = String(payload.metadata.releaseEvidenceSha);
+  const sourceMode = String(payload.metadata.releaseEvidenceSourceMode);
+  const harnessCommit = String(payload.metadata.releaseEvidenceHarnessCommit);
   const resolved = runGit(repositoryRoot, ['rev-parse', '--verify', `${ref}^{commit}`]);
   requireSuccessfulGit(resolved, 'resolve the retained performance release tag');
-  if (decodeOutput(resolved.stdout) !== payload.environment.commit) {
-    throw new ScriptError('Retained performance release tag does not resolve to the measured Threadnote commit.');
+  if (decodeOutput(resolved.stdout) !== releaseSha) {
+    throw new ScriptError('Retained performance release tag does not resolve to its recorded release commit.');
+  }
+  if (
+    sourceMode === 'exact-release' &&
+    harnessCommit === releaseSha &&
+    payload.environment.commit === releaseSha &&
+    payload.metadata.releaseEvidenceHarnessDeltaPaths === '[]'
+  ) {
+    return;
+  }
+  if (
+    sourceMode !== 'release-plus-reviewed-harness-delta' ||
+    harnessCommit !== payload.environment.commit ||
+    harnessCommit === releaseSha
+  ) {
+    throw new ScriptError('Retained performance evidence has invalid release/harness source binding.');
+  }
+  const mergeBase = runGit(repositoryRoot, ['merge-base', releaseSha, harnessCommit]);
+  requireSuccessfulGit(mergeBase, 'verify the retained performance harness ancestry');
+  if (decodeOutput(mergeBase.stdout) !== releaseSha) {
+    throw new ScriptError('Retained performance harness commit is not a descendant of its release commit.');
+  }
+  const changed = runGit(repositoryRoot, [
+    'diff',
+    '--name-only',
+    '--diff-filter=ACDMRTUXB',
+    `${releaseSha}..${harnessCommit}`,
+    '--',
+    ...performanceSourcePathspecs,
+  ]);
+  requireSuccessfulGit(changed, 'inspect the retained performance harness delta');
+  const deltaPaths = decodeOutput(changed.stdout).split('\n').filter(Boolean).sort();
+  const recordedDelta = String(payload.metadata.releaseEvidenceHarnessDeltaPaths);
+  if (
+    JSON.stringify(deltaPaths) !== recordedDelta ||
+    deltaPaths.length === 0 ||
+    deltaPaths.some(path => !(RELEASE_EVIDENCE_HARNESS_DELTA_PATHS as readonly string[]).includes(path))
+  ) {
+    throw new ScriptError('Retained performance harness delta contains unreviewed runtime-source changes.');
   }
 }
 

--- a/src/evaluation/external_evidence.ts
+++ b/src/evaluation/external_evidence.ts
@@ -134,6 +134,12 @@ const CORE_REQUIRED_MEASUREMENTS = [
 
 export const EXTERNAL_REPOSITORY_REQUIRED_MEASUREMENTS = CORE_REQUIRED_MEASUREMENTS;
 
+export const RELEASE_EVIDENCE_HARNESS_DELTA_PATHS = [
+  'scripts/benchmark-code-graph.ts',
+  'scripts/site-performance-evidence.ts',
+  'src/evaluation/external_evidence.ts',
+] as const;
+
 const RELEASE_SITE_REQUIRED_MEASUREMENTS = [
   {name: 'cold-index', unit: 'milliseconds'},
   {name: 'cold-registration-lock-and-database-setup', unit: 'milliseconds'},
@@ -200,8 +206,11 @@ export const EXTERNAL_PUBLIC_METADATA_KEYS = [
   'oneFileReindexMaterializationMode',
   'oneFileReindexMaterializationStorageMode',
   'releaseEvidenceRef',
+  'releaseEvidenceHarnessCommit',
+  'releaseEvidenceHarnessDeltaPaths',
   'releaseEvidenceResolvedSha',
   'releaseEvidenceSha',
+  'releaseEvidenceSourceMode',
   'retrievalMode',
   'runnerClass',
   'runnerIdentity',
@@ -221,9 +230,10 @@ export const EXTERNAL_PUBLIC_METADATA_KEYS = [
 ] as const;
 
 const EXTERNAL_PUBLIC_METADATA_KEY_SET = new Set<string>(EXTERNAL_PUBLIC_METADATA_KEYS);
+const RELEASE_EVIDENCE_HARNESS_DELTA_PATH_SET = new Set<string>(RELEASE_EVIDENCE_HARNESS_DELTA_PATHS);
 const EXACT_GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
-const RELEASE_REF_PATTERN = /^refs\/tags\/v4\.0\.0(?:-(?:beta|rc)\.\d+)?$/;
+const RELEASE_REF_PATTERN = /^refs\/tags\/v(4\.\d+\.\d+(?:-(?:beta|rc)\.\d+)?)$/;
 const SAFE_RUNNER_CLASS = /^(?:github-hosted-linux-(?:arm64|x64)|local-unclassified|other)$/;
 const SAFE_RUNNER_IDENTITY = /^(?:local|runner-[0-9a-f]{16})$/;
 const LOCAL_PATH_PATTERN =
@@ -736,6 +746,13 @@ function validateLanguageControls(
 
 function validateProvenance(artifact: BenchmarkArtifactV1, releaseBound: boolean, missing: string[]): void {
   const metadata = artifact.metadata;
+  const releaseRef = metadata.releaseEvidenceRef;
+  const releaseMatch = typeof releaseRef === 'string' ? RELEASE_REF_PATTERN.exec(releaseRef) : null;
+  const managedVersion = metadata.benchmarkValidatedManagedVersion;
+  const managedVersionMatchesCommit =
+    typeof managedVersion === 'string' &&
+    (managedVersion.endsWith(`-local.g${artifact.environment.commit}`) ||
+      managedVersion.endsWith(`.local.g${artifact.environment.commit}`));
   if (
     metadata.benchmarkMeasuredExecutionMode !== 'local-source-application-layer' ||
     metadata.benchmarkMeasuredSourceCommit !== artifact.environment.commit ||
@@ -766,8 +783,7 @@ function validateProvenance(artifact: BenchmarkArtifactV1, releaseBound: boolean
       metadata.benchmarkValidatedManagedRuntime.length === 0 ||
       typeof metadata.benchmarkValidatedManagedTarget !== 'string' ||
       metadata.benchmarkValidatedManagedTarget.length === 0 ||
-      typeof metadata.benchmarkValidatedManagedVersion !== 'string' ||
-      !metadata.benchmarkValidatedManagedVersion.endsWith(`.local.g${artifact.environment.commit}`)
+      !managedVersionMatchesCommit
     ) {
       missing.push('complete separately validated exact-HEAD managed payload provenance');
     }
@@ -778,15 +794,41 @@ function validateProvenance(artifact: BenchmarkArtifactV1, releaseBound: boolean
     missing.push('release evidence with separately validated managed exact-HEAD payload');
   }
   if (releaseBound) {
-    const ref = metadata.releaseEvidenceRef;
     const sha = metadata.releaseEvidenceSha;
+    const sourceMode = metadata.releaseEvidenceSourceMode;
+    const harnessCommit = metadata.releaseEvidenceHarnessCommit;
+    const harnessDeltaPaths = metadata.releaseEvidenceHarnessDeltaPaths;
+    let parsedHarnessDeltaPaths: readonly string[] = [];
+    try {
+      const parsed = JSON.parse(String(harnessDeltaPaths ?? '[]'));
+      if (Array.isArray(parsed) && parsed.every(path => typeof path === 'string')) parsedHarnessDeltaPaths = parsed;
+    } catch {
+      // Report the invalid release provenance through the shared missing-evidence path below.
+    }
+    const canonicalHarnessDelta =
+      parsedHarnessDeltaPaths.length > 0 &&
+      new Set(parsedHarnessDeltaPaths).size === parsedHarnessDeltaPaths.length &&
+      parsedHarnessDeltaPaths.every(path => RELEASE_EVIDENCE_HARNESS_DELTA_PATH_SET.has(path)) &&
+      JSON.stringify([...parsedHarnessDeltaPaths].sort()) === JSON.stringify(parsedHarnessDeltaPaths);
+    const sourceModeValid =
+      (sourceMode === 'exact-release' &&
+        harnessCommit === sha &&
+        artifact.environment.commit === sha &&
+        harnessDeltaPaths === '[]') ||
+      (sourceMode === 'release-plus-reviewed-harness-delta' &&
+        typeof harnessCommit === 'string' &&
+        EXACT_GIT_COMMIT_PATTERN.test(harnessCommit) &&
+        harnessCommit === artifact.environment.commit &&
+        harnessCommit !== sha &&
+        canonicalHarnessDelta);
     if (
-      typeof ref !== 'string' ||
-      !RELEASE_REF_PATTERN.test(ref) ||
+      !releaseMatch ||
+      (managedVersion !== `${releaseMatch[1]}-local.g${artifact.environment.commit}` &&
+        managedVersion !== `${releaseMatch[1]}.local.g${artifact.environment.commit}`) ||
       typeof sha !== 'string' ||
       !EXACT_GIT_COMMIT_PATTERN.test(sha) ||
       metadata.releaseEvidenceResolvedSha !== sha ||
-      sha !== artifact.environment.commit ||
+      !sourceModeValid ||
       artifact.environment.dirty
     ) {
       missing.push('clean exact release source provenance');

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1152,6 +1152,23 @@ describe('code graph release evidence', () => {
 
     expect(() => assertExternalPerformanceEvidence(artifact)).not.toThrow();
     expect(() => validateRetainedPerformancePayload(artifact)).not.toThrow();
+    const harnessDeltaArtifact: BenchmarkArtifactV1 = {
+      ...artifact,
+      metadata: {
+        ...artifact.metadata,
+        releaseEvidenceHarnessCommit: artifact.environment.commit,
+        releaseEvidenceHarnessDeltaPaths: JSON.stringify([
+          'scripts/benchmark-code-graph.ts',
+          'scripts/site-performance-evidence.ts',
+          'src/evaluation/external_evidence.ts',
+        ]),
+        releaseEvidenceResolvedSha: 'f'.repeat(40),
+        releaseEvidenceSha: 'f'.repeat(40),
+        releaseEvidenceSourceMode: 'release-plus-reviewed-harness-delta',
+      },
+    };
+    expect(() => assertExternalPerformanceEvidence(harnessDeltaArtifact)).not.toThrow();
+    expect(() => validateRetainedPerformancePayload(harnessDeltaArtifact)).not.toThrow();
     const projected = retainedPerformanceArtifactFromHarness(artifact, {
       artifactSha256: 'f'.repeat(64),
       artifactUrl: '/performance/performance-evidence.json',

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -225,6 +225,9 @@ describe('code graph release evidence', () => {
       ref: 'refs/tags/v4.0.0-beta.30',
       resolvedSha: commit,
       sha: commit,
+      harnessCommit: commit,
+      harnessDeltaPaths: '[]',
+      sourceMode: 'exact-release',
     });
     const sha256Commit = 'a'.repeat(64);
     expect(
@@ -243,7 +246,7 @@ describe('code graph release evidence', () => {
       /locally resolvable tag/,
     );
     expect(() => resolvedReleaseEvidenceSource('refs/tags/v4.0.0-beta.30', commit, commit, commit, true)).toThrow(
-      /clean checkout/,
+      /clean exact commit|clean descendant/,
     );
   });
 
@@ -261,10 +264,60 @@ describe('code graph release evidence', () => {
           ref,
           resolvedSha: commit,
           sha: commit,
+          harnessCommit: commit,
+          harnessDeltaPaths: '[]',
+          sourceMode: 'exact-release',
         });
       }),
       {numRuns: 250},
     );
+  });
+
+  it('accepts a clean release descendant only when every runtime delta is a reviewed harness path', () => {
+    const releaseCommit = '0'.repeat(40);
+    const harnessCommit = '1'.repeat(40);
+    const reviewedPaths = ['scripts/benchmark-code-graph.ts', 'src/evaluation/external_evidence.ts'];
+
+    expect(
+      resolvedReleaseEvidenceSource(
+        'refs/tags/v4.2.5',
+        releaseCommit,
+        releaseCommit,
+        harnessCommit,
+        false,
+        reviewedPaths,
+        true,
+      ),
+    ).toEqual({
+      ref: 'refs/tags/v4.2.5',
+      resolvedSha: releaseCommit,
+      sha: releaseCommit,
+      harnessCommit,
+      harnessDeltaPaths: JSON.stringify(reviewedPaths),
+      sourceMode: 'release-plus-reviewed-harness-delta',
+    });
+    expect(() =>
+      resolvedReleaseEvidenceSource(
+        'refs/tags/v4.2.5',
+        releaseCommit,
+        releaseCommit,
+        harnessCommit,
+        false,
+        ['src/code_graph.ts'],
+        true,
+      ),
+    ).toThrow(/reviewed harness changes/);
+    expect(() =>
+      resolvedReleaseEvidenceSource(
+        'refs/tags/v4.2.5',
+        releaseCommit,
+        releaseCommit,
+        harnessCommit,
+        false,
+        reviewedPaths,
+        false,
+      ),
+    ).toThrow(/reviewed harness changes/);
   });
 
   it.each([
@@ -1042,7 +1095,7 @@ describe('code graph release evidence', () => {
         benchmarkValidatedManagedReleaseMetadataSha256: 'e'.repeat(64),
         benchmarkValidatedManagedRuntime: 'bun-test',
         benchmarkValidatedManagedTarget: 'linux-x64',
-        benchmarkValidatedManagedVersion: `4.0.0.local.g${commit}`,
+        benchmarkValidatedManagedVersion: `4.0.0-beta.32-local.g${commit}`,
         coldMaterializationStorageMode: 'direct-persistent',
         externalQueryControlTimeoutMilliseconds: 120_000,
         externalControlCount: 4,
@@ -1072,8 +1125,11 @@ describe('code graph release evidence', () => {
         oneFileReindexMaterializationMode: 'incremental-overlay',
         oneFileReindexMaterializationStorageMode: 'temporary-staged',
         releaseEvidenceRef: 'refs/tags/v4.0.0-beta.32',
+        releaseEvidenceHarnessCommit: commit,
+        releaseEvidenceHarnessDeltaPaths: '[]',
         releaseEvidenceResolvedSha: commit,
         releaseEvidenceSha: commit,
+        releaseEvidenceSourceMode: 'exact-release',
         retrievalMode: 'lexical-only',
         sameOverlayReferenceMaterializationMode: 'full',
         sameOverlayReferenceMaterializationStorageMode: 'direct-persistent',
@@ -1341,8 +1397,11 @@ function benchmarkArtifact(
         ? {
             ...productionProfileArtifactMetadata(PRODUCTION_LARGE_CODE_GRAPH_PROFILE),
             releaseEvidenceRef: 'refs/tags/v4.0.0-beta.30',
+            releaseEvidenceHarnessCommit: commit,
+            releaseEvidenceHarnessDeltaPaths: '[]',
             releaseEvidenceResolvedSha: commit,
             releaseEvidenceSha: commit,
+            releaseEvidenceSourceMode: 'exact-release',
           }
         : {}),
       ...metadata,

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -304,7 +304,7 @@ function verifiedPerformanceFixture(): Record<string, unknown> {
       benchmarkValidatedManagedReleaseMetadataSha256: '5'.repeat(64),
       benchmarkValidatedManagedRuntime: 'bun-1.3.14',
       benchmarkValidatedManagedTarget: 'darwin-arm64',
-      benchmarkValidatedManagedVersion: `4.0.0-beta.32.local.g${sourceCommit}`,
+      benchmarkValidatedManagedVersion: `4.2.5-local.g${sourceCommit}`,
       coldMaterializationStorageMode: 'direct-persistent',
       externalControlCount: 4,
       externalControlEvidence: JSON.stringify(controls),
@@ -333,9 +333,12 @@ function verifiedPerformanceFixture(): Record<string, unknown> {
       mcpOperationCount: 6,
       oneFileReindexMaterializationMode: 'incremental-overlay',
       oneFileReindexMaterializationStorageMode: 'temporary-staged',
-      releaseEvidenceRef: 'refs/tags/v4.0.0-beta.32',
+      releaseEvidenceRef: 'refs/tags/v4.2.5',
+      releaseEvidenceHarnessCommit: sourceCommit,
+      releaseEvidenceHarnessDeltaPaths: '[]',
       releaseEvidenceResolvedSha: sourceCommit,
       releaseEvidenceSha: sourceCommit,
+      releaseEvidenceSourceMode: 'exact-release',
       retrievalMode: 'lexical-only',
       runnerClass: 'local-unclassified',
       runnerIdentity: 'runner-0123456789abcdef',
@@ -690,8 +693,8 @@ describe('Threadnote 4 website content', () => {
     expect(landingSource).toContain('JSON, GraphML, HTML, or SVG');
     expect(landingSource).toContain('Open the Manager demo');
     expect(landingSource).toContain("siteHref('performance/')");
-    expect(landingSource).toContain('reuses a warm graph instead of rebuilding every new worktree');
-    expect(landingSource).toContain('same-machine, five-sample comparison measured 13.2× faster');
+    expect(landingSource).toContain('Threadnote 4.2.5 build and query a pinned IntelliJ Community checkout');
+    expect(landingSource).toContain('cold and one-file incremental timings');
     expect(scenarios).toContain('current commit + isolated dirty overlay');
     expect(scenarios).toContain('paged SQLite analysis · no repository admission cap');
   });
@@ -998,7 +1001,8 @@ describe('Threadnote 4 website content', () => {
     expect(performancePage).toContain('Threadnote 4.1 also gates large-worktree safety');
     expect(performancePage).toContain('never merged into a universal latency percentile');
     expect(performancePage).toContain('deliberately makes no “maximum performance” claim');
-    expect(landingPage).toContain('public IntelliJ evidence still covers 232,750 files');
+    expect(landingPage).toContain('Threadnote 4.2.5 build and query a pinned IntelliJ Community checkout');
+    expect(landingPage).not.toContain('Threadnote 4.0.1');
     expect(landingPage).not.toMatch(/values stay visibly pending|retained artifact is complete/i);
   });
 
@@ -1102,6 +1106,12 @@ describe('Threadnote 4 website content', () => {
         'credential metadata',
         fixture => {
           (fixture.metadata as Record<string, unknown>).runnerIdentity = 'token=github_pat_example';
+        },
+      ],
+      [
+        'release tag outside Threadnote 4',
+        fixture => {
+          (fixture.metadata as Record<string, unknown>).releaseEvidenceRef = 'refs/tags/v5.0.0';
         },
       ],
       [
@@ -1443,9 +1453,8 @@ describe('Threadnote 4 website content', () => {
     expect(pageSource).toContain('Repository size is never an admission test');
     expect(pageSource).toContain('bounded parser worker pool');
     expect(pageSource).toContain('one backpressured SQLite writer');
-    expect(pageSource).toContain('A warm worktree is ready in seconds');
-    expect(pageSource).toContain('Graph-equivalent commit');
-    expect(pageSource).toContain('One-file clean commit');
+    expect(pageSource).not.toContain('Measured in Threadnote 4.0.1');
+    expect(pageSource).not.toContain('warm worktree readiness evidence');
     expect(pageSource).toContain('Graph responses stay deliberately bounded');
     expect(pageSource).toContain('returns the complete record');
     expect(pageSource).toContain('Your agents will love it');

--- a/website/src/content/performance.ts
+++ b/website/src/content/performance.ts
@@ -2,7 +2,10 @@ import {
   privacySafeExternalControlPath,
   privacySafeExternalControlQuery,
 } from '../../../src/evaluation/public_controls.js';
-import {validateExternalRepositoryEvidence} from '../../../src/evaluation/external_evidence.js';
+import {
+  RELEASE_EVIDENCE_HARNESS_DELTA_PATHS,
+  validateExternalRepositoryEvidence,
+} from '../../../src/evaluation/external_evidence.js';
 import type {BenchmarkArtifactV1} from '../../../src/evaluation/benchmark.js';
 
 export const performanceControlLanguages = ['java', 'kotlin', 'typescript', 'bazel'] as const;
@@ -11,6 +14,7 @@ const retainedManagerNodeBudget = 500;
 const retainedManagerEdgeBudget = 1_500;
 const retainedWorktreeIsolationTopology = 'bounded-synthetic-linked-worktrees-in-measured-primary-home';
 const retainedWorktreeIsolationIndexedFiles = 2;
+const threadnote4ReleaseRefPattern = /^refs\/tags\/v(4\.\d+\.\d+(?:-(?:beta|rc)\.\d+)?)$/;
 
 export type PerformanceControlLanguage = (typeof performanceControlLanguages)[number];
 
@@ -816,7 +820,15 @@ function validateHarnessRuntimeProvenance(
   positiveNumberAt(metadata, 'benchmarkValidatedManagedPayloadBytes', 'harness.metadata', true);
   positiveNumberAt(metadata, 'benchmarkValidatedManagedPayloadFileCount', 'harness.metadata', true);
   const managedVersion = metadataString(metadata, 'benchmarkValidatedManagedVersion');
-  if (!managedVersion.endsWith(`.local.g${commit}`)) {
+  const releaseMatch = threadnote4ReleaseRefPattern.exec(metadataString(metadata, 'releaseEvidenceRef'));
+  if (!releaseMatch) {
+    throw new Error('Performance harness release evidence does not name a Threadnote 4 release tag.');
+  }
+  const releaseVersion = releaseMatch[1];
+  if (
+    managedVersion !== `${releaseVersion}-local.g${commit}` &&
+    managedVersion !== `${releaseVersion}.local.g${commit}`
+  ) {
     throw new Error('Performance harness managed version is not bound to its source commit.');
   }
   const managedRuntime = metadataString(metadata, 'benchmarkValidatedManagedRuntime');
@@ -1026,13 +1038,40 @@ export function validateRetainedPerformancePayload(input: unknown): RetainedPerf
   } catch {
     throw new Error('Performance harness repository name and public GitHub URL do not match.');
   }
-  if (metadataString(metadata, 'releaseEvidenceSha') !== sourceCommit) {
-    throw new Error('Performance harness release evidence is not bound to its source commit.');
+  const releaseEvidenceSha = metadataString(metadata, 'releaseEvidenceSha');
+  const releaseEvidenceHarnessCommit = metadataString(metadata, 'releaseEvidenceHarnessCommit');
+  const releaseEvidenceSourceMode = metadataString(metadata, 'releaseEvidenceSourceMode');
+  let releaseEvidenceHarnessDeltaPaths: readonly string[] = [];
+  try {
+    const parsed = JSON.parse(metadataString(metadata, 'releaseEvidenceHarnessDeltaPaths'));
+    if (Array.isArray(parsed) && parsed.every(path => typeof path === 'string')) {
+      releaseEvidenceHarnessDeltaPaths = parsed;
+    }
+  } catch {
+    // The fail-closed provenance check below reports malformed path evidence.
   }
-  if (!/^refs\/tags\/v4\.0\.0(?:-(?:beta|rc)\.\d+)?$/.test(metadataString(metadata, 'releaseEvidenceRef'))) {
-    throw new Error('Performance harness release evidence does not name a Threadnote 4 release tag.');
+  const canonicalHarnessDelta =
+    releaseEvidenceHarnessDeltaPaths.length > 0 &&
+    new Set(releaseEvidenceHarnessDeltaPaths).size === releaseEvidenceHarnessDeltaPaths.length &&
+    releaseEvidenceHarnessDeltaPaths.every(path =>
+      (RELEASE_EVIDENCE_HARNESS_DELTA_PATHS as readonly string[]).includes(path),
+    ) &&
+    JSON.stringify([...releaseEvidenceHarnessDeltaPaths].sort()) === JSON.stringify(releaseEvidenceHarnessDeltaPaths);
+  if (
+    (releaseEvidenceSourceMode === 'exact-release' &&
+      (releaseEvidenceSha !== sourceCommit ||
+        releaseEvidenceHarnessCommit !== sourceCommit ||
+        metadata.releaseEvidenceHarnessDeltaPaths !== '[]')) ||
+    (releaseEvidenceSourceMode === 'release-plus-reviewed-harness-delta' &&
+      (releaseEvidenceHarnessCommit !== sourceCommit ||
+        releaseEvidenceSha === sourceCommit ||
+        !canonicalHarnessDelta)) ||
+    (releaseEvidenceSourceMode !== 'exact-release' &&
+      releaseEvidenceSourceMode !== 'release-plus-reviewed-harness-delta')
+  ) {
+    throw new Error('Performance harness release evidence is not bound to its source and reviewed harness delta.');
   }
-  literalAt(metadata, 'releaseEvidenceResolvedSha', 'harness.metadata', sourceCommit);
+  literalAt(metadata, 'releaseEvidenceResolvedSha', 'harness.metadata', releaseEvidenceSha);
   positiveNumberAt(metadata, 'benchmarkLogicalCpuCount', 'harness.metadata', true);
   metadataString(metadata, 'benchmarkDiskMedium');
   metadataString(metadata, 'benchmarkDiskFilesystem');

--- a/website/src/pages/LandingPage.tsx
+++ b/website/src/pages/LandingPage.tsx
@@ -195,12 +195,12 @@ function GraphSearchShowcase() {
 
       <a className="graph-showcase__performance-cta" href={siteHref('performance/')}>
         <div>
-          <span className="eyebrow">Large repositories · fast worktrees</span>
-          <h3>See how Threadnote 4.0.1 reuses a warm graph instead of rebuilding every new worktree.</h3>
+          <span className="eyebrow">Large repositories · retained evidence</span>
+          <h3>See Threadnote 4.2.5 build and query a pinned IntelliJ Community checkout.</h3>
         </div>
         <p>
-          A same-machine, five-sample comparison measured 13.2× faster graph-equivalent readiness and 9.9× faster
-          one-file readiness. The separate public IntelliJ evidence still covers 232,750 files and polyglot controls.
+          The release-bound run retains cold and one-file incremental timings, resource high-water marks, independent
+          rebuild parity, and Java, Kotlin, TypeScript, and Bazel controls from one governed artifact.
         </p>
         <Icon name="arrow" aria-hidden="true" />
       </a>

--- a/website/src/pages/PerformancePage.tsx
+++ b/website/src/pages/PerformancePage.tsx
@@ -8,7 +8,6 @@ import {
 } from '../content/performance';
 import {performanceEvidence} from '../content/performanceEvidence';
 import {checkedInPerformanceEvidence} from '../content/performanceHighlights';
-import {checkedInWorktreeReadinessEvidence} from '../content/worktreeReadiness';
 import {docsArticleHref, setDocumentMeta, siteHref} from '../lib/site';
 
 const integerFormatter = new Intl.NumberFormat('en-US');
@@ -27,10 +26,6 @@ function formatDuration(milliseconds: number): string {
   if (milliseconds < 1_000) return `${milliseconds.toFixed(1)} ms`;
   if (milliseconds < 60_000) return `${(milliseconds / 1_000).toFixed(1)} s`;
   return `${(milliseconds / 60_000).toFixed(1)} min`;
-}
-
-function formatReadinessDuration(milliseconds: number): string {
-  return `${(milliseconds / 1_000).toFixed(2)} s`;
 }
 
 function formatEmbeddingDuration(milliseconds: number): string {
@@ -525,84 +520,6 @@ export default function PerformancePage() {
         </div>
       </section>
 
-      <section className="performance-worktrees">
-        <div className="performance-worktrees__copy">
-          <span className="eyebrow">Measured in Threadnote 4.0.1</span>
-          <h2>A warm worktree is ready in seconds—not another full build.</h2>
-          <p>
-            On the same pinned {formatInteger(checkedInWorktreeReadinessEvidence.scale.files)}-file Threadnote checkout
-            and M1 Max runner, five alternating samples compared v4.0.1 with its immediate pre-feature parent. The graph
-            shape and a controlled query matched in every pair.
-          </p>
-          <ul>
-            <li>
-              <Icon name="check" aria-hidden="true" /> Graph-equivalent commits alias the ready content without staging
-              files
-            </li>
-            <li>
-              <Icon name="check" aria-hidden="true" /> Compatible clean commits materialize only their bounded delta
-            </li>
-            <li>
-              <Icon name="check" aria-hidden="true" /> Exact lexical queries become usable before optional enrichment
-            </li>
-          </ul>
-          <p className="performance-worktrees__evidence">
-            Same-machine engineering comparison, not a portable SLA.{' '}
-            <a href={siteHref(checkedInWorktreeReadinessEvidence.artifactPath)} target="_blank" rel="noreferrer">
-              Inspect all raw samples and provenance
-            </a>
-            .
-          </p>
-        </div>
-        <div className="performance-worktrees__diagram" aria-label="Threadnote 4.0.1 warm worktree readiness evidence">
-          <div className="performance-worktrees__base">
-            <span>Measured warm anchor · v4.0.1</span>
-            <strong>
-              {formatInteger(checkedInWorktreeReadinessEvidence.scale.files)} files ·{' '}
-              {formatInteger(checkedInWorktreeReadinessEvidence.scale.symbols)} symbols
-            </strong>
-            <code>{checkedInWorktreeReadinessEvidence.source.candidate.commit.slice(0, 12)}</code>
-          </div>
-          <div className="performance-worktrees__branches">
-            <article>
-              <span>Graph-equivalent commit</span>
-              <strong>
-                {formatReadinessDuration(
-                  checkedInWorktreeReadinessEvidence.graphEquivalentCommit.candidate.medianMilliseconds,
-                )}{' '}
-                median
-              </strong>
-              <small>
-                {checkedInWorktreeReadinessEvidence.graphEquivalentCommit.medianSpeedup.toFixed(1)}× faster · 0 files
-                staged
-              </small>
-            </article>
-            <article>
-              <span>One-file clean commit</span>
-              <strong>
-                {formatReadinessDuration(checkedInWorktreeReadinessEvidence.oneFileChange.candidate.medianMilliseconds)}{' '}
-                median
-              </strong>
-              <small>
-                {checkedInWorktreeReadinessEvidence.oneFileChange.medianSpeedup.toFixed(1)}× faster · 1 file staged
-              </small>
-            </article>
-            <article>
-              <span>Immediate predecessor</span>
-              <strong>
-                {formatReadinessDuration(
-                  checkedInWorktreeReadinessEvidence.graphEquivalentCommit.baseline.medianMilliseconds,
-                )}
-                –{formatReadinessDuration(checkedInWorktreeReadinessEvidence.oneFileChange.baseline.medianMilliseconds)}
-              </strong>
-              <small>
-                full materialization · {formatInteger(checkedInWorktreeReadinessEvidence.scale.files)} files staged
-              </small>
-            </article>
-          </div>
-        </div>
-      </section>
-
       <section className="performance-section performance-surfaces">
         <header className="section-heading">
           <span className="eyebrow">Right detail for the reader</span>
@@ -635,14 +552,23 @@ export default function PerformancePage() {
             paths working at that shape. It does not promise identical times for every repository, disk, operating
             system, or machine.
           </p>
+          {artifact ? (
+            <p>
+              The comprehensive release-run adapter verified {retainedPerformanceArtifactFieldPaths.length} retained
+              fields and fails closed on malformed, stale, or mixed evidence. Every headline value above is derived from
+              the same bound artifact.
+            </p>
+          ) : (
+            <p>
+              A comprehensive release-run adapter still requires {retainedPerformanceArtifactFieldPaths.length} retained
+              fields and fails closed on malformed or mixed evidence. Until that artifact is available, this page shows
+              narrower checked-in engineering measurements with their exact scope instead of empty cards.
+            </p>
+          )}
           <p>
-            A comprehensive release-run adapter still requires {retainedPerformanceArtifactFieldPaths.length} retained
-            fields and fails closed on malformed or mixed evidence. Until that artifact is available, this page shows
-            narrower checked-in engineering measurements with their exact scope instead of empty cards.
-          </p>
-          <p>
-            The public IntelliJ run covers {formatInteger(checkedInPerformanceEvidence.scale.indexedFiles)} files and
-            polyglot Java, Kotlin, TypeScript, and Bazel controls. The separate 100k-symbol lexical artifact records{' '}
+            The public IntelliJ run covers{' '}
+            {formatInteger(artifact?.inventory.indexedFiles ?? checkedInPerformanceEvidence.scale.indexedFiles)} files
+            and polyglot Java, Kotlin, TypeScript, and Bazel controls. The separate 100k-symbol lexical artifact records{' '}
             {checkedInPerformanceEvidence.lexicalStorage.storageReductionPercent.toFixed(1)}% less allocated storage
             than Threadnote's previous lexical index format, with canonical, query, and posting-count parity.
           </p>


### PR DESCRIPTION
## What changed

- allows release-bound performance evidence to name the immutable v4.2.5 tag while recording a clean descendant harness commit
- restricts that descendant runtime-source delta to three reviewed benchmark, validation, and binding files and verifies Git ancestry and the exact path set again during site binding
- accepts the current 4.2.5-local.g<sha> development receipt format
- removes the stale visible v4.0.1 worktree block and updates the landing-page performance callout

## Why

The v4.2.5 benchmark validator still hardcoded v4.0.0 and the older development-version spelling. A full IntelliJ run would complete its expensive measurements and fail before writing the artifact. The governed harness-delta mode fixes that without changing the released graph runtime or moving the immutable release tag.

## Validation

- 83 focused release-evidence and website-content tests
- source, test, and website TypeScript checks
- lint, Prettier, and file-length policy via commit hooks
- exact v4.2.5 descendant preflight against pinned IntelliJ Community commit 3cbdad9ee6c8a5135fc0f01cc90114fc25c0655c

The reviewed benchmark artifact and generated website binding will be added after the full run finishes.