### PR TITLE
Fix high-churn code graph rematerialization

### DIFF
--- a/infra/telemetry-gateway/telemetry-schema-v1.json
+++ b/infra/telemetry-gateway/telemetry-schema-v1.json
@@ -235,7 +235,14 @@
       "validating-input",
       "writing-and-checkpointing"
     ],
-    "waitingReason": ["database-writer", "disk-capacity", "repository-lock", "request-lock", "snapshot-build"],
+    "waitingReason": [
+      "database-writer",
+      "disk-capacity",
+      "home-builder-cap",
+      "repository-lock",
+      "request-lock",
+      "snapshot-build"
+    ],
     "operation": [
       "add_resource",
       "analyze_code_graph",

--- a/infra/telemetry-gateway/telemetry-schema-v2.json
+++ b/infra/telemetry-gateway/telemetry-schema-v2.json
@@ -264,7 +264,14 @@
       "validating-input",
       "writing-and-checkpointing"
     ],
-    "waitingReason": ["database-writer", "disk-capacity", "repository-lock", "request-lock", "snapshot-build"],
+    "waitingReason": [
+      "database-writer",
+      "disk-capacity",
+      "home-builder-cap",
+      "repository-lock",
+      "request-lock",
+      "snapshot-build"
+    ],
     "operation": [
       "add_resource",
       "analyze_code_graph",

--- a/src/code_graph/build_status.ts
+++ b/src/code_graph/build_status.ts
@@ -36,6 +36,7 @@ import type {
   CodeGraphIndexSummary,
   CodeGraphMaterializationActivity,
   CodeGraphMaterializationMetrics,
+  CodeGraphOverlayFallbackReason,
   CodeGraphProgress,
   CodeGraphResolutionActivity,
   CodeGraphSnapshot,
@@ -154,6 +155,9 @@ export interface CodeGraphBuildStatus {
     readonly files: number;
     readonly snapshotId: string;
     readonly symbols: number;
+    readonly overlayAssessment?: {
+      readonly outcome: 'overlay-success' | CodeGraphOverlayFallbackReason;
+    };
   };
   readonly schemaVersion: typeof CODE_GRAPH_BUILD_STATUS_SCHEMA_VERSION;
   readonly state: CodeGraphBuildState;
@@ -345,7 +349,12 @@ export const makeCodeGraphBuildReporter = Effect.fn('codeGraph.buildStatus.makeR
     yield* inspectBuildHistoryDirectory(fs, path, layout, identity.worktreeId).pipe(Effect.option),
   );
 
-  const complete = (snapshot: CodeGraphSnapshot, reusedFiles: number, skippedFiles: number) =>
+  const complete = (
+    snapshot: CodeGraphSnapshot,
+    reusedFiles: number,
+    skippedFiles: number,
+    overlayAssessment?: {readonly outcome: 'overlay-success' | CodeGraphOverlayFallbackReason},
+  ) =>
     persist((current, now) => {
       const timestamp = new Date(now).toISOString();
       return {
@@ -371,6 +380,7 @@ export const makeCodeGraphBuildReporter = Effect.fn('codeGraph.buildStatus.makeR
             dirty: snapshot.dirty,
             edges: snapshot.edgeCount,
             files: snapshot.fileCount,
+            ...(overlayAssessment ? {overlayAssessment} : {}),
             snapshotId: snapshot.id,
             symbols: snapshot.symbolCount,
           },
@@ -403,7 +413,17 @@ export const makeCodeGraphBuildReporter = Effect.fn('codeGraph.buildStatus.makeR
     );
 
   return {
-    complete: summary => complete(summary.snapshot, summary.reusedFiles, summary.skippedFiles),
+    complete: summary =>
+      complete(
+        summary.snapshot,
+        summary.reusedFiles,
+        summary.skippedFiles,
+        summary.snapshot.dirty && summary.materialization?.mode === 'incremental-overlay'
+          ? {outcome: 'overlay-success'}
+          : summary.snapshot.dirty && summary.materialization?.mode === 'full'
+            ? {outcome: summary.materialization.fallbackReason ?? 'staging-unavailable'}
+            : undefined,
+      ),
     completeSnapshot: snapshot => complete(snapshot, 0, 0),
     fail: cause =>
       persist((current, now) => {

--- a/src/code_graph/build_status_codec.ts
+++ b/src/code_graph/build_status_codec.ts
@@ -349,6 +349,27 @@ function parseMaterializationMetrics(value: unknown): CodeGraphMaterializationMe
   if (value.mode !== undefined && !['full', 'incremental-clean', 'incremental-overlay'].includes(String(value.mode))) {
     return undefined;
   }
+  if (
+    value.resolutionPublicationGate !== undefined &&
+    ![
+      'exported',
+      'foreign-path',
+      'non-typescript-domain',
+      'own-path-local',
+      'scope-mismatch',
+      'unknown-lookup-form',
+    ].includes(String(value.resolutionPublicationGate))
+  ) {
+    return undefined;
+  }
+  if (
+    value.resolutionLookupKeyForm !== undefined &&
+    !['none', 'non-typescript', 'typescript-other', 'typescript-path-scoped', 'typescript-path-unscoped'].includes(
+      String(value.resolutionLookupKeyForm),
+    )
+  ) {
+    return undefined;
+  }
   for (const key of [
     'cachedFactBytesCompleted',
     'cachedFactBytesTotal',
@@ -388,6 +409,18 @@ function parseMaterializationMetrics(value: unknown): CodeGraphMaterializationMe
     ...(value.fallbackReason === undefined
       ? {}
       : {fallbackReason: value.fallbackReason as CodeGraphMaterializationMetrics['fallbackReason']}),
+    ...(value.resolutionLookupKeyForm === undefined
+      ? {}
+      : {
+          resolutionLookupKeyForm:
+            value.resolutionLookupKeyForm as CodeGraphMaterializationMetrics['resolutionLookupKeyForm'],
+        }),
+    ...(value.resolutionPublicationGate === undefined
+      ? {}
+      : {
+          resolutionPublicationGate:
+            value.resolutionPublicationGate as CodeGraphMaterializationMetrics['resolutionPublicationGate'],
+        }),
     ...(value.attributionMilliseconds === undefined
       ? {}
       : {attributionMilliseconds: Number(value.attributionMilliseconds)}),
@@ -856,10 +889,26 @@ function parseResult(value: unknown): CodeGraphBuildStatus['result'] | undefined
   for (const key of ['edges', 'files', 'symbols'] as const) {
     if (!Number.isSafeInteger(value[key]) || Number(value[key]) < 0) return undefined;
   }
+  const overlayAssessment = value.overlayAssessment;
+  if (
+    overlayAssessment !== undefined &&
+    (!isRecord(overlayAssessment) ||
+      (overlayAssessment.outcome !== 'overlay-success' &&
+        !VALID_MATERIALIZATION_FALLBACK_REASONS.has(overlayAssessment.outcome as CodeGraphOverlayFallbackReason)))
+  ) {
+    return undefined;
+  }
   return {
     dirty: value.dirty,
     edges: Number(value.edges),
     files: Number(value.files),
+    ...(isRecord(overlayAssessment)
+      ? {
+          overlayAssessment: {
+            outcome: overlayAssessment.outcome as 'overlay-success' | CodeGraphOverlayFallbackReason,
+          },
+        }
+      : {}),
     snapshotId: value.snapshotId,
     symbols: Number(value.symbols),
   };

--- a/src/code_graph/builder_admission.ts
+++ b/src/code_graph/builder_admission.ts
@@ -1,0 +1,279 @@
+import {Clock, Crypto, Effect, FileSystem, Path} from 'effect';
+import {sha256HexSync} from '../crypto/sha256.js';
+import {isFileLockTimeout, withExclusiveFileLock} from '../effect/file_lock.js';
+import {runtimeTextDirectoryNamePage, SystemInfo, type SystemInfoShape} from '../effect/system.js';
+import {
+  codeGraphBuilderAdmissionLockPath,
+  codeGraphBuilderAdmissionRoot,
+  codeGraphBuilderAdmissionSlotPath,
+} from './layout.js';
+
+export const CODE_GRAPH_BUILDER_HOME_CAPACITY = 2;
+export const CODE_GRAPH_BUILDER_ADMISSION_CLASS_ENV = 'THREADNOTE_CODE_GRAPH_BUILDER_ADMISSION_CLASS';
+
+export type CodeGraphBuilderAdmissionClass = 'background' | 'current-required';
+
+interface BuilderAdmissionTicket {
+  readonly admissionClass: CodeGraphBuilderAdmissionClass;
+  readonly createdAt: number;
+  readonly processId: number;
+  readonly processStartIdentity?: string;
+  readonly token: string;
+  readonly version: 1;
+}
+
+interface OwnedTicket extends BuilderAdmissionTicket {
+  readonly path: string;
+  readonly serialized: string;
+}
+
+const TICKET_NAME = /^v1-([0-9a-f]{64})\.json$/;
+const TICKET_BYTES_MAXIMUM = 1_024;
+const TICKET_COUNT_MAXIMUM = 256;
+const ADMISSION_RETRY_MILLISECONDS = 25;
+const LEDGER_LOCK_WAIT_MILLISECONDS = 5_000;
+const SLOT_STALE_MILLISECONDS = 15_000;
+
+class CodeGraphBuilderAdmissionError extends Error {
+  readonly _tag = 'CodeGraphBuilderAdmissionError' as const;
+}
+
+/**
+ * Home-global, cross-process builder admission. Tickets are selected current-
+ * required before background and FIFO inside each class. A ticket is removed
+ * only after one of the two slot locks is held, so no SQL build row is created
+ * while a caller waits for home capacity.
+ */
+export function withCodeGraphBuilderAdmission<A, E, R>(
+  options: {
+    readonly admissionClass: CodeGraphBuilderAdmissionClass;
+    readonly onWaiting?: Effect.Effect<void, never>;
+    readonly threadnoteHome: string;
+  },
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | unknown, R | Crypto.Crypto | FileSystem.FileSystem | Path.Path | SystemInfo> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
+    const crypto = yield* Crypto.Crypto;
+    const ticket = yield* createTicket(fs, path, system, options.threadnoteHome, options.admissionClass);
+    let waitingReported = false;
+    return yield* Effect.gen(function* () {
+      for (;;) {
+        const selected = yield* ticketIsSelected(fs, path, system, options.threadnoteHome, ticket);
+        if (selected) {
+          for (const slot of [0, 1] as const) {
+            const result = yield* withExclusiveFileLock(
+              fs,
+              codeGraphBuilderAdmissionSlotPath(path, options.threadnoteHome, slot),
+              {
+                heartbeatIntervalMilliseconds: 5_000,
+                onAcquired: () =>
+                  removeOwnedTicket(fs, path, options.threadnoteHome, ticket).pipe(
+                    Effect.provideService(Crypto.Crypto, crypto),
+                    Effect.provideService(Path.Path, path),
+                    Effect.provideService(SystemInfo, system),
+                    Effect.ignore,
+                  ),
+                recoverReusedProcessIdImmediately: true,
+                retryIntervalMilliseconds: 1,
+                staleAfterMilliseconds: SLOT_STALE_MILLISECONDS,
+                useCanonicalProcessStartIdentity: true,
+                waitTimeoutMilliseconds: 0,
+              },
+              effect,
+            ).pipe(
+              Effect.map(value => ({state: 'completed' as const, value})),
+              Effect.catchIf(isFileLockTimeout, () => Effect.succeed({state: 'contended' as const})),
+            );
+            if (result.state === 'completed') return result.value;
+          }
+        }
+        if (!waitingReported) {
+          yield* options.onWaiting ?? Effect.void;
+          waitingReported = true;
+        }
+        yield* Effect.sleep(ADMISSION_RETRY_MILLISECONDS);
+      }
+    }).pipe(Effect.ensuring(removeOwnedTicket(fs, path, options.threadnoteHome, ticket).pipe(Effect.ignore)));
+  });
+}
+
+/** @internal Deterministic ordering model for admission property tests. */
+export function orderCodeGraphBuilderAdmissionTickets<
+  T extends Pick<BuilderAdmissionTicket, 'admissionClass' | 'createdAt' | 'token'>,
+>(tickets: readonly T[]): readonly T[] {
+  return [...tickets].sort(
+    (left, right) =>
+      admissionRank(left.admissionClass) - admissionRank(right.admissionClass) ||
+      left.createdAt - right.createdAt ||
+      left.token.localeCompare(right.token),
+  );
+}
+
+function admissionRank(admissionClass: CodeGraphBuilderAdmissionClass): number {
+  return admissionClass === 'current-required' ? 0 : 1;
+}
+
+const createTicket = Effect.fn('codeGraph.builderAdmission.createTicket')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  system: SystemInfoShape,
+  threadnoteHome: string,
+  admissionClass: CodeGraphBuilderAdmissionClass,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const root = codeGraphBuilderAdmissionRoot(path, threadnoteHome);
+  yield* fs.makeDirectory(root, {recursive: true, mode: 0o700});
+  if (system.platform !== 'win32') yield* fs.chmod(root, 0o700);
+  const token = sha256HexSync(`${system.processId}\0${yield* crypto.randomUUIDv4}`);
+  const processStartIdentity = yield* system.canonicalProcessStartIdentity?.(system.processId) ??
+    system.processStartIdentity(system.processId);
+  const ticket: OwnedTicket = {
+    admissionClass,
+    createdAt: yield* Clock.currentTimeMillis,
+    path: path.join(root, `v1-${token}.json`),
+    processId: system.processId,
+    ...(processStartIdentity === undefined ? {} : {processStartIdentity}),
+    serialized: '',
+    token,
+    version: 1,
+  };
+  const serialized = JSON.stringify({...ticket, path: undefined, serialized: undefined});
+  const owned = {...ticket, serialized};
+  const temporaryPath = `${owned.path}.${token.slice(0, 16)}.tmp`;
+  yield* withLedgerLock(
+    fs,
+    codeGraphBuilderAdmissionLockPath(path, threadnoteHome),
+    Effect.scoped(
+      Effect.gen(function* () {
+        const file = yield* fs.open(temporaryPath, {flag: 'wx', mode: 0o600});
+        yield* file.writeAll(new TextEncoder().encode(serialized));
+        yield* file.sync;
+      }),
+    ).pipe(
+      Effect.andThen(fs.rename(temporaryPath, owned.path)),
+      Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.ignore)),
+    ),
+  );
+  if (system.platform !== 'win32') yield* fs.chmod(owned.path, 0o600);
+  return owned;
+});
+
+const ticketIsSelected = Effect.fn('codeGraph.builderAdmission.select')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  system: SystemInfoShape,
+  threadnoteHome: string,
+  owned: OwnedTicket,
+) {
+  return yield* withLedgerLock(
+    fs,
+    codeGraphBuilderAdmissionLockPath(path, threadnoteHome),
+    Effect.gen(function* () {
+      const tickets = yield* scanTickets(fs, path, system, threadnoteHome);
+      return orderCodeGraphBuilderAdmissionTickets(tickets)[0]?.token === owned.token;
+    }),
+  );
+});
+
+const scanTickets = Effect.fn('codeGraph.builderAdmission.scan')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  system: SystemInfoShape,
+  threadnoteHome: string,
+) {
+  const root = codeGraphBuilderAdmissionRoot(path, threadnoteHome);
+  if (!(yield* fs.exists(root))) return [] as OwnedTicket[];
+  const page = yield* runtimeTextDirectoryNamePage(root, TICKET_COUNT_MAXIMUM);
+  if (page.overflow) return yield* Effect.fail(new CodeGraphBuilderAdmissionError('Builder ticket bound exceeded.'));
+  const tickets: OwnedTicket[] = [];
+  for (const name of [...page.names].sort()) {
+    const token = TICKET_NAME.exec(name)?.[1];
+    if (!token) return yield* Effect.fail(new CodeGraphBuilderAdmissionError('Builder ticket name is invalid.'));
+    const ticketPath = path.join(root, name);
+    if ((yield* fs.readLink(ticketPath).pipe(Effect.option))._tag === 'Some') {
+      return yield* Effect.fail(new CodeGraphBuilderAdmissionError('Builder ticket is symbolic.'));
+    }
+    const info = yield* fs.stat(ticketPath);
+    if (info.type !== 'File' || Number(info.size) > TICKET_BYTES_MAXIMUM) {
+      return yield* Effect.fail(new CodeGraphBuilderAdmissionError('Builder ticket is invalid.'));
+    }
+    const serialized = yield* fs.readFileString(ticketPath);
+    const parsed = parseTicket(serialized, token);
+    if (!parsed) return yield* Effect.fail(new CodeGraphBuilderAdmissionError('Builder ticket content is invalid.'));
+    if (yield* ticketOwnerIsDead(system, parsed)) {
+      yield* fs.remove(ticketPath, {force: true});
+      continue;
+    }
+    tickets.push({...parsed, path: ticketPath, serialized});
+  }
+  return tickets;
+});
+
+function parseTicket(serialized: string, token: string): BuilderAdmissionTicket | undefined {
+  try {
+    const value = JSON.parse(serialized) as Partial<BuilderAdmissionTicket>;
+    if (
+      value.version !== 1 ||
+      value.token !== token ||
+      (value.admissionClass !== 'background' && value.admissionClass !== 'current-required') ||
+      !Number.isSafeInteger(value.createdAt) ||
+      !Number.isSafeInteger(value.processId) ||
+      Number(value.processId) <= 0 ||
+      ((value.processStartIdentity !== undefined || Object.hasOwn(value, 'processStartIdentity')) &&
+        typeof value.processStartIdentity !== 'string')
+    ) {
+      return undefined;
+    }
+    return value as BuilderAdmissionTicket;
+  } catch {
+    return undefined;
+  }
+}
+
+const ticketOwnerIsDead = Effect.fn('codeGraph.builderAdmission.ownerDead')(function* (
+  system: SystemInfoShape,
+  ticket: BuilderAdmissionTicket,
+) {
+  if (!system.isProcessRunning(ticket.processId)) return true;
+  if (ticket.processStartIdentity === undefined) return false;
+  const current = yield* system.canonicalProcessStartIdentity?.(ticket.processId) ??
+    system.processStartIdentity(ticket.processId);
+  return current !== undefined && current !== ticket.processStartIdentity;
+});
+
+function withLedgerLock<A, E, R>(fs: FileSystem.FileSystem, lockPath: string, effect: Effect.Effect<A, E, R>) {
+  return withExclusiveFileLock(
+    fs,
+    lockPath,
+    {
+      heartbeatIntervalMilliseconds: 5_000,
+      recoverReusedProcessIdImmediately: true,
+      retryIntervalMilliseconds: 10,
+      staleAfterMilliseconds: 15_000,
+      useCanonicalProcessStartIdentity: true,
+      waitTimeoutMilliseconds: LEDGER_LOCK_WAIT_MILLISECONDS,
+    },
+    effect,
+  );
+}
+
+const removeOwnedTicket = Effect.fn('codeGraph.builderAdmission.removeTicket')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  threadnoteHome: string,
+  ticket: OwnedTicket,
+) {
+  yield* withLedgerLock(
+    fs,
+    codeGraphBuilderAdmissionLockPath(path, threadnoteHome),
+    Effect.gen(function* () {
+      if (!(yield* fs.exists(ticket.path))) return;
+      if ((yield* fs.readLink(ticket.path).pipe(Effect.option))._tag === 'Some') return;
+      const content = yield* fs.readFileString(ticket.path);
+      if (content === ticket.serialized) yield* fs.remove(ticket.path, {force: true});
+    }),
+  );
+});

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -1694,6 +1694,8 @@ function progressMessage(progress: CodeGraphProgress): string {
       switch (progress.reason) {
         case 'database-writer':
           return 'Waiting for the code graph database writer';
+        case 'home-builder-cap':
+          return 'Waiting for the home code graph builder cap';
         case 'request-lock':
           return 'Waiting for the matching code graph request';
         case 'snapshot-build':

--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -50,7 +50,12 @@ import {
   verifyIndexInput,
   type PersistentMaterializationTransactionCandidate,
 } from './indexer_materialization.js';
-import {CodeGraphIndexOperationError, codeGraphInventoryFileChanged, sameInventoryPaths} from './indexer_shared.js';
+import {
+  CodeGraphIndexOperationError,
+  codeGraphInventoryFileChanged,
+  sameInventoryPaths,
+  WorktreeChangedDuringIndex,
+} from './indexer_shared.js';
 import type {
   CodeGraphIndexOptions,
   CommittedBaseResult,
@@ -90,6 +95,43 @@ import {
   type CodeGraphSymbol,
   type RepositoryIdentity,
 } from './types.js';
+import {reserveCodeGraphRetainedBase} from './retained_base_reservation.js';
+
+export const CODE_GRAPH_RETAINED_BASE_LEASE_MILLISECONDS = 45 * 60_000;
+
+const verifyCommittedIndexInput = Effect.fn('codeGraph.verifyCommittedIndexInput')(function* (input: {
+  readonly databasePath: string;
+  readonly identity: RepositoryIdentity;
+  readonly physicalSnapshotId?: string;
+  readonly requestedOverlay?: {readonly dirty: boolean; readonly fingerprint?: string};
+  readonly snapshotId: string;
+  readonly store: CodeGraphStoreShape;
+  readonly threadnoteHome: string;
+}) {
+  return yield* verifyIndexInput(input.identity, true, input.threadnoteHome, input.requestedOverlay).pipe(
+    Effect.catchIf(
+      cause => cause instanceof WorktreeChangedDuringIndex,
+      cause =>
+        Effect.gen(function* () {
+          const lease = yield* input.store
+            .acquireSnapshotLease(input.databasePath, input.snapshotId, CODE_GRAPH_RETAINED_BASE_LEASE_MILLISECONDS, {
+              retainedBase: true,
+            })
+            .pipe(Effect.option);
+          if (Option.isNone(lease)) return yield* Effect.fail(cause);
+          const reserved = yield* reserveCodeGraphRetainedBase({
+            durationMilliseconds: CODE_GRAPH_RETAINED_BASE_LEASE_MILLISECONDS,
+            physicalSnapshotId: input.physicalSnapshotId ?? input.snapshotId,
+            threadnoteHome: input.threadnoteHome,
+          }).pipe(Effect.catch(() => Effect.succeed(false)));
+          if (!reserved) {
+            yield* input.store.releaseSnapshotLease(input.databasePath, lease.value).pipe(Effect.ignore);
+          }
+          return yield* Effect.fail(cause);
+        }),
+    ),
+  );
+});
 
 export function withCodeGraphProcessLock<A, E, R>(
   fs: FileSystem.FileSystem,
@@ -598,6 +640,8 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
             symbolCount: candidate.snapshot.symbolCount,
             worktreeId: input.identity.worktreeId,
           };
+          yield* input.onProgress?.({phase: 'activating', snapshotId: alias.id, subphase: 'validating-input'}) ??
+            Effect.void;
           yield* verifyIndexInput(input.identity, true, input.threadnoteHome, input.requestedOverlay);
           yield* input.store.activateCleanSnapshotAlias!(
             input.layout.databasePath,
@@ -605,9 +649,27 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
             alias,
             candidate.snapshot.id,
           );
-          yield* verifyIndexInput(input.identity, true, input.threadnoteHome, input.requestedOverlay);
+          yield* input.onProgress?.({phase: 'activating', snapshotId: alias.id, subphase: 'promoting'}) ?? Effect.void;
+          yield* verifyCommittedIndexInput({
+            databasePath: input.layout.databasePath,
+            identity: input.identity,
+            physicalSnapshotId: candidate.snapshot.id,
+            requestedOverlay: input.requestedOverlay,
+            snapshotId: alias.id,
+            store: input.store,
+            threadnoteHome: input.threadnoteHome,
+          });
           yield* promoteReadySnapshotWithCapacity(input, alias.id);
-          yield* verifyIndexInput(input.identity, true, input.threadnoteHome, input.requestedOverlay);
+          yield* input.onProgress?.({phase: 'activating', snapshotId: alias.id, subphase: 'promoting'}) ?? Effect.void;
+          yield* verifyCommittedIndexInput({
+            databasePath: input.layout.databasePath,
+            identity: input.identity,
+            physicalSnapshotId: candidate.snapshot.id,
+            requestedOverlay: input.requestedOverlay,
+            snapshotId: alias.id,
+            store: input.store,
+            threadnoteHome: input.threadnoteHome,
+          });
           return Option.some<ReusableCleanSnapshotAttempt>({
             mode: 'complete',
             summary: yield* reuseReadySnapshot({
@@ -751,12 +813,21 @@ export const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirt
   },
   workspace: CodeGraphWorkspace,
 ) {
-  if (!input.store.reusableCleanBase) {
+  if (!input.store.reusableCleanBase && !input.store.reusableOverlayBase) {
     return Option.none<{
       readonly committedBase: CommittedBaseResult;
       readonly preassessment: Extract<IncrementalOverlayPreassessment, {readonly mode: 'compatible'}>;
     }>();
   }
+  const retainedOverlayCandidate =
+    input.inventory.overlayFingerprint && input.store.reusableOverlayBase
+      ? yield* input.store.reusableOverlayBase(
+          input.layout.databasePath,
+          input.identity.repositoryId,
+          input.extractorSet,
+          input.inventory.overlayFingerprint,
+        )
+      : undefined;
   // Prefer the exact committed snapshot path below when it is itself a root
   // reusable base. A clean incremental snapshot is already layered, so another
   // overlay must instead reuse its root and include the cumulative changed set.
@@ -771,7 +842,7 @@ export const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirt
     input.layout.databasePath,
     exactCommittedSnapshotId,
   );
-  if (exactCommittedSnapshot && exactCommittedSnapshot.baseSnapshotId === undefined) {
+  if (!retainedOverlayCandidate && exactCommittedSnapshot && exactCommittedSnapshot.baseSnapshotId === undefined) {
     return Option.none();
   }
   const committedFileSetFingerprint = reusableBaseFileSetFingerprint(input.inventory.committedFiles);
@@ -786,14 +857,15 @@ export const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirt
     ? yield* input.store.reusableBaseReceipt(input.layout.databasePath, commitReady.id)
     : undefined;
   let candidate: CodeGraphReusableCleanBase | undefined =
-    commitReady &&
+    retainedOverlayCandidate ??
+    (commitReady &&
     commitReceipt &&
     commitReady.graphContentId === committedGraphContentId &&
     commitReceipt.fileSetFingerprint === committedFileSetFingerprint &&
     commitReceipt.workspaceFingerprint === workspace.fingerprint
       ? {files: input.inventory.committedFiles, receipt: commitReceipt, snapshot: commitReady}
-      : undefined;
-  if (!candidate) {
+      : undefined);
+  if (!candidate && input.store.reusableCleanBase) {
     const preferredCommitGroups = yield* preferredIncrementalBaseCommitGroups(
       input.identity.repoRoot,
       input.identity.headCommit,
@@ -1241,6 +1313,12 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       ...(finalFactsBytesTotal === undefined ? {} : {factsBytesTotal: finalFactsBytesTotal}),
       loadingMilliseconds,
       mode: 'full',
+      ...(incrementalAssessment?.resolutionPublicationAssessment
+        ? {
+            resolutionLookupKeyForm: incrementalAssessment.resolutionPublicationAssessment.lookupKeyForm,
+            resolutionPublicationGate: incrementalAssessment.resolutionPublicationAssessment.gate,
+          }
+        : {}),
       rows: materializedRows,
       sourceBytesCompleted,
       sourceBytesTotal,
@@ -1626,7 +1704,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       unit: 'files',
     }) ?? Effect.void;
   }
-  const reusableBaseReceipt = input.building.dirty
+  const reusableBaseReceipt = incrementalApplied
     ? undefined
     : {
         fileSetFingerprint: reusableBaseFileSetFingerprint(input.inventory.files),
@@ -1711,12 +1789,27 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       // Progress callbacks are user-controlled effects and may yield long enough for
       // the worktree to change. Revalidate on both sides of pointer promotion so a
       // mutation observed in this window triggers the bounded retry.
-      yield* verifyIndexInput(input.identity, input.activatePointer, input.threadnoteHome, input.requestedOverlay);
+      yield* verifyCommittedIndexInput({
+        databasePath: input.layout.databasePath,
+        identity: input.identity,
+        requestedOverlay: input.requestedOverlay,
+        snapshotId: activated.id,
+        store: input.store,
+        threadnoteHome: input.threadnoteHome,
+      });
       yield* input.store.promote(input.layout.databasePath, input.identity, activated.id, {
         persistentCapacityProtector: protectDirectPersistentWrite,
       });
       yield* input.store.shrinkMemory(input.layout.databasePath);
-      yield* verifyIndexInput(input.identity, input.activatePointer, input.threadnoteHome, input.requestedOverlay);
+      yield* input.onProgress?.({phase: 'activating', snapshotId: activated.id, subphase: 'promoting'}) ?? Effect.void;
+      yield* verifyCommittedIndexInput({
+        databasePath: input.layout.databasePath,
+        identity: input.identity,
+        requestedOverlay: input.requestedOverlay,
+        snapshotId: activated.id,
+        store: input.store,
+        threadnoteHome: input.threadnoteHome,
+      });
       if (Option.isSome(activationLease)) {
         yield* input.store.releaseSnapshotLease(input.layout.databasePath, activationLease.value);
       }
@@ -1821,6 +1914,12 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
           }
         : {}),
       ...(fallbackReason ? {fallbackReason} : {}),
+      ...(incrementalAssessment?.resolutionPublicationAssessment
+        ? {
+            resolutionLookupKeyForm: incrementalAssessment.resolutionPublicationAssessment.lookupKeyForm,
+            resolutionPublicationGate: incrementalAssessment.resolutionPublicationAssessment.gate,
+          }
+        : {}),
       mode: incrementalApplied ? (input.inventory.dirty ? 'incremental-overlay' : 'incremental-clean') : 'full',
       stagedFiles: materializedFiles,
       totalFiles: input.inventory.files.length,

--- a/src/code_graph/indexer_incremental.ts
+++ b/src/code_graph/indexer_incremental.ts
@@ -32,7 +32,11 @@ import type {CodeGraphLanguagePackRegistryShape} from './languages/registry.js';
 import type {CodeGraphWorkspace} from './languages/types.js';
 import type {CodeGraphLayout} from './layout.js';
 import {compareCodeUnits} from './ordering.js';
-import {hasSameCodeGraphResolutionSurface} from './resolution_surface.js';
+import {
+  assessCodeGraphResolutionSymbolPublication,
+  hasSameCodeGraphResolutionSurface,
+  type CodeGraphResolutionPublicationAssessment,
+} from './resolution_surface.js';
 import {
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   materializedShardDerivationIdentity,
@@ -94,7 +98,11 @@ export const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOv
   }
   let reuse: 'persisted-base' | 'staged-base' = 'staged-base';
   if (!input.committedBase.stagingReusable) {
-    const receipt = yield* input.store.reusableBaseReceipt(input.layout.databasePath, input.committedBase.snapshot.id);
+    const receipt = yield* input.store.reusableBaseReceipt(
+      input.layout.databasePath,
+      input.committedBase.snapshot.id,
+      input.committedBase.snapshot.dirty ? {allowDirtyRoot: true} : undefined,
+    );
     if (
       !receipt ||
       receipt.formatVersion !== CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION ||
@@ -164,6 +172,7 @@ export const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOv
     files: preassessment.files,
     mode: 'eligible',
     resolutionClosure: preassessment.resolutionClosure,
+    resolutionPublicationAssessment: preassessment.resolutionPublicationAssessment,
     reuse,
     work,
   } satisfies IncrementalOverlayAssessment;
@@ -262,6 +271,10 @@ export const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assess
       const committed = committedFactsByPath.get(file.path);
       return !committed || !hasSameCodeGraphResolutionSurface(committed.symbols, file.symbols);
     });
+    const resolutionPublicationAssessment = resolutionSurfaceChanged
+      ? (firstChangedResolutionPublicationAssessment(committedFacts, effectiveFacts) ??
+        firstResolutionPublicationAssessment(effectiveFacts))
+      : firstResolutionPublicationAssessment(effectiveFacts);
     const dynamicAliases = hasDynamicAliases(committedFacts) || hasDynamicAliases(effectiveFacts);
     if (!dynamicAliases && !resolutionSurfaceChanged && workspaceCompatibility.mode === 'unchanged') {
       if (finalCodeGraphFactBatches(effectiveFacts).length !== 1) {
@@ -273,9 +286,10 @@ export const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assess
         facts: effectiveFacts,
         files: modifiedFiles,
         mode: 'compatible',
+        ...(resolutionPublicationAssessment ? {resolutionPublicationAssessment} : {}),
       } satisfies IncrementalOverlayPreassessment;
     }
-    return yield* assessProjectIncrementalClosureCompatibility({
+    const closure = yield* assessProjectIncrementalClosureCompatibility({
       baseFileSetFingerprint: reusableBaseFileSetFingerprint(input.inventory.committedFiles),
       baseWorkspace: committedWorkspace,
       changedBaseFacts: committedFacts,
@@ -289,6 +303,7 @@ export const assessIncrementalOverlayCompatibility = Effect.fn('codeGraph.assess
       workspaceSeedProjectIds:
         workspaceCompatibility.mode === 'project-closure' ? workspaceCompatibility.seedProjectIds : [],
     });
+    return resolutionPublicationAssessment ? {...closure, resolutionPublicationAssessment} : closure;
   },
 );
 
@@ -407,6 +422,10 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
       const base = baseFactsByPath.get(file.path);
       return !base || !hasSameCodeGraphResolutionSurface(base.symbols, file.symbols);
     });
+    const resolutionPublicationAssessment = resolutionSurfaceChanged
+      ? (firstChangedResolutionPublicationAssessment(baseFacts, currentFacts) ??
+        firstResolutionPublicationAssessment(currentFacts))
+      : firstResolutionPublicationAssessment(currentFacts);
     const dynamicAliases = hasDynamicAliases(baseFacts) || hasDynamicAliases(currentFacts);
     if (dynamicAliases || resolutionSurfaceChanged) {
       const closure = yield* assessProjectIncrementalClosureCompatibility({
@@ -422,9 +441,11 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
         store: input.store,
         workspaceSeedProjectIds: [],
       });
-      return closure.mode === 'compatible' && extractorTransition
-        ? {...closure, extractorTransition: true as const}
-        : closure;
+      const result =
+        closure.mode === 'compatible' && extractorTransition
+          ? {...closure, extractorTransition: true as const}
+          : closure;
+      return resolutionPublicationAssessment ? {...result, resolutionPublicationAssessment} : result;
     }
     if (finalCodeGraphFactBatches(currentFacts).length !== 1) {
       return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
@@ -448,6 +469,7 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
       facts: currentFacts,
       files: modifiedFiles,
       mode: 'compatible',
+      ...(resolutionPublicationAssessment ? {resolutionPublicationAssessment} : {}),
     } satisfies IncrementalOverlayPreassessment;
   },
 );
@@ -910,6 +932,36 @@ export function createCachedCodeGraphFactsAttributor(
 
 function hasDynamicAliases(facts: readonly CodeGraphFileFacts[]): boolean {
   return facts.some(file => file.references?.some(reference => (reference.aliasLookupKeys?.length ?? 0) > 0) === true);
+}
+
+function firstResolutionPublicationAssessment(
+  facts: readonly CodeGraphFileFacts[],
+): CodeGraphResolutionPublicationAssessment | undefined {
+  for (const symbol of facts.flatMap(file => file.symbols)) {
+    if (symbol.exported || symbol.resolutionDomain !== 'typescript') continue;
+    return assessCodeGraphResolutionSymbolPublication(symbol);
+  }
+  return undefined;
+}
+
+function firstChangedResolutionPublicationAssessment(
+  committedFacts: readonly CodeGraphFileFacts[],
+  effectiveFacts: readonly CodeGraphFileFacts[],
+): CodeGraphResolutionPublicationAssessment | undefined {
+  const committedById = new Map(committedFacts.flatMap(file => file.symbols).map(symbol => [symbol.id, symbol]));
+  const effectiveById = new Map(effectiveFacts.flatMap(file => file.symbols).map(symbol => [symbol.id, symbol]));
+  for (const symbol of effectiveById.values()) {
+    const committed = committedById.get(symbol.id);
+    if (committed && hasSameCodeGraphResolutionSurface([committed], [symbol])) continue;
+    const assessment = assessCodeGraphResolutionSymbolPublication(symbol);
+    if (assessment.published) return assessment;
+  }
+  for (const symbol of committedById.values()) {
+    if (effectiveById.has(symbol.id)) continue;
+    const assessment = assessCodeGraphResolutionSymbolPublication(symbol);
+    if (assessment.published) return assessment;
+  }
+  return undefined;
 }
 
 export {hasSameCodeGraphResolutionSurface} from './resolution_surface.js';

--- a/src/code_graph/indexer_service.ts
+++ b/src/code_graph/indexer_service.ts
@@ -2,6 +2,7 @@ import {Clock, Context, Crypto, Effect, Exit, FileSystem, Layer, Option, Path} f
 import {CommandExecutor} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
 import {makeCodeGraphBuildReporter} from './build_status.js';
+import {CODE_GRAPH_BUILDER_ADMISSION_CLASS_ENV, withCodeGraphBuilderAdmission} from './builder_admission.js';
 import {isCodeGraphCapacityPause} from './disk_capacity.js';
 import {CodeGraphEmbeddingIndex} from './embedding.js';
 import {
@@ -153,7 +154,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
               walAutoCheckpointPages: options.sqliteWriterTuning?.walAutoCheckpointPages ?? 1_000,
             };
             const ensureVectors = codeGraphIndexEnsuresVectors(options);
-            const summary = yield* withCodeGraphProcessLock(
+            const repositoryBuild = withCodeGraphProcessLock(
               fs,
               layout.lockPath,
               () =>
@@ -646,6 +647,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                             edgeCount: 0,
                             extractorSet,
                             fileCount: 0,
+                            graphContentId,
                             id: directSnapshotId,
                             overlayFingerprint: inventory.overlayFingerprint,
                             repositoryId: identity.repositoryId,
@@ -728,6 +730,16 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                   threadnoteHome: options.threadnoteHome,
                 });
               }),
+            );
+            const summary = yield* withCodeGraphBuilderAdmission(
+              {
+                admissionClass: codeGraphBuilderAdmissionClass(options, system.environment()),
+                onWaiting: (options.onProgress?.({phase: 'waiting', reason: 'home-builder-cap'}) ?? Effect.void).pipe(
+                  Effect.catch(() => Effect.void),
+                ),
+                threadnoteHome: options.threadnoteHome,
+              },
+              repositoryBuild,
             ).pipe(
               Effect.ensuring(
                 runCodeGraphLifecycleOpportunity({
@@ -815,7 +827,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
               temporaryDirectory: system.tempDirectory,
               walAutoCheckpointPages: options.sqliteWriterTuning?.walAutoCheckpointPages ?? 1_000,
             };
-            const lease = yield* withCodeGraphProcessLock(
+            const commitBuild = withCodeGraphProcessLock(
               fs,
               layout.lockPath,
               () =>
@@ -932,6 +944,16 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                     Effect.tapError(cause => reporter.fail(cause)),
                   );
               }),
+            );
+            const lease = yield* withCodeGraphBuilderAdmission(
+              {
+                admissionClass: codeGraphBuilderAdmissionClass(options, system.environment()),
+                onWaiting: (options.onProgress?.({phase: 'waiting', reason: 'home-builder-cap'}) ?? Effect.void).pipe(
+                  Effect.catch(() => Effect.void),
+                ),
+                threadnoteHome: options.threadnoteHome,
+              },
+              commitBuild,
             ).pipe(
               Effect.ensuring(
                 runCodeGraphLifecycleOpportunity({
@@ -976,4 +998,14 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
       });
     }),
   );
+}
+
+function codeGraphBuilderAdmissionClass(
+  options: Pick<CodeGraphIndexOptions, 'admissionClass'>,
+  environment: Readonly<Record<string, string | undefined>>,
+) {
+  if (options.admissionClass) return options.admissionClass;
+  return environment[CODE_GRAPH_BUILDER_ADMISSION_CLASS_ENV] === 'background'
+    ? ('background' as const)
+    : ('current-required' as const);
 }

--- a/src/code_graph/indexer_types.ts
+++ b/src/code_graph/indexer_types.ts
@@ -4,6 +4,8 @@ import type {CodeGraphDirectPersistentCapacityBoundary} from './disk_capacity.js
 import type {CodeGraphIncrementalWork} from './incremental_work.js';
 import type {CodeGraphInventoryOptions} from './inventory.js';
 import type {CodeGraphWorkspace} from './languages/types.js';
+import type {CodeGraphBuilderAdmissionClass} from './builder_admission.js';
+import type {CodeGraphResolutionPublicationAssessment} from './resolution_surface.js';
 import type {CodeGraphMaintenanceCoordinatorShape} from './maintenance_coordinator.js';
 import type {CodeGraphSqliteWriterSettings, CodeGraphSqliteWriterTuning} from './store.js';
 import type {
@@ -16,6 +18,8 @@ import type {
 } from './types.js';
 
 export interface CodeGraphIndexOptions extends CodeGraphInventoryOptions {
+  /** @internal Home-global builder admission priority. CLI defaults to current-required. */
+  readonly admissionClass?: CodeGraphBuilderAdmissionClass;
   readonly cwd: string;
   /** When false, skip blocking vector materialization after a ready structural snapshot. */
   readonly ensureVectors?: boolean;
@@ -72,6 +76,7 @@ export type IncrementalOverlayAssessment =
       readonly mode: 'eligible';
       readonly deletedPaths?: readonly string[];
       readonly resolutionClosure?: 'changed' | 'full' | 'project';
+      readonly resolutionPublicationAssessment?: CodeGraphResolutionPublicationAssessment;
       readonly extractorTransition?: true;
       readonly reuse: 'persisted-base' | 'staged-base';
       readonly work: CodeGraphIncrementalWork;
@@ -79,6 +84,7 @@ export type IncrementalOverlayAssessment =
   | {
       readonly mode: 'fallback';
       readonly reason: CodeGraphOverlayFallbackReason;
+      readonly resolutionPublicationAssessment?: CodeGraphResolutionPublicationAssessment;
     };
 
 export type IncrementalOverlayPreassessment =
@@ -91,11 +97,13 @@ export type IncrementalOverlayPreassessment =
       readonly mode: 'compatible';
       readonly deletedPaths?: readonly string[];
       readonly resolutionClosure?: 'changed' | 'full' | 'project';
+      readonly resolutionPublicationAssessment?: CodeGraphResolutionPublicationAssessment;
       readonly extractorTransition?: true;
     }
   | {
       readonly mode: 'fallback';
       readonly reason: CodeGraphOverlayFallbackReason;
+      readonly resolutionPublicationAssessment?: CodeGraphResolutionPublicationAssessment;
     };
 
 export type ReusableCleanSnapshotAttempt =

--- a/src/code_graph/isolated_builder.ts
+++ b/src/code_graph/isolated_builder.ts
@@ -1,5 +1,7 @@
-import {Clock, Effect, Option, Path, Ref} from 'effect';
+import {Clock, Crypto, Effect, FileSystem, Option, Path, Ref} from 'effect';
 import {fromPromiseInterruptible} from '../effect/errors.js';
+import {isFileLockTimeout, withExclusiveFileLock} from '../effect/file_lock.js';
+import {CommandExecutor} from '../effect/command.js';
 import {SystemInfo, type SystemInfoShape} from '../effect/system.js';
 import {pollUntilEffect} from '../effect/time.js';
 import {withCurrentAgentSessionEnvironment} from '../telemetry/session.js';
@@ -11,9 +13,10 @@ import {
   type CodeGraphBuildStatus,
   type ObservedCodeGraphBuildStatus,
 } from './build_status.js';
-import {codeGraphLayout} from './layout.js';
+import {codeGraphLayout, codeGraphWorktreeSpawnLockPath} from './layout.js';
 import {resolveRepositoryIdentity} from './repository.js';
 import type {CodeGraphProgress, RepositoryIdentity} from './types.js';
+import {CODE_GRAPH_BUILDER_ADMISSION_CLASS_ENV, type CodeGraphBuilderAdmissionClass} from './builder_admission.js';
 
 class IsolatedBuilderError extends Error {
   readonly _tag = 'IsolatedBuilderError' as const;
@@ -33,6 +36,8 @@ export const EXISTING_BUILDER_STALLED_TIMEOUT_MILLISECONDS = CODE_GRAPH_BUILD_ST
 /** Allow an atomically-renamed completion sidecar a short, bounded window to become observable after child exit. */
 export const ISOLATED_BUILDER_RESULT_GRACE_MILLISECONDS = 2_000;
 export const ISOLATED_BUILDER_RESULT_POLL_MILLISECONDS = 100;
+export const ISOLATED_BUILDER_SPAWN_OBSERVATION_MILLISECONDS = 10_000;
+export const ISOLATED_BUILDER_SPAWN_LOCK_WAIT_MILLISECONDS = 30_000;
 const STDERR_TAIL_LIMIT_BYTES = 4 * 1024;
 
 export interface CodeGraphIsolatedBuilderSpawnPlan {
@@ -56,13 +61,22 @@ export interface CodeGraphIsolatedBuilderOptions {
   /** Read-only guard that must complete before an isolated child can be observed or spawned. */
   readonly assertRuntimeSchemaCompatible: (databasePath: string) => Effect.Effect<void, unknown>;
   readonly cwd: string;
+  readonly admissionClass?: CodeGraphBuilderAdmissionClass;
   readonly onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void>;
+  /** @internal Deterministic shared-sidecar seam for cross-host spawn tests. */
+  readonly readStatus?: Effect.Effect<ObservedCodeGraphBuildStatus | undefined, unknown>;
+  /** Privacy-safe build request identity used for exact completed-result reuse. */
+  readonly requestKey?: string;
   /** @internal Deterministic identity seam for pre-spawn compatibility tests. */
   readonly resolveIdentity?: (cwd: string) => Effect.Effect<RepositoryIdentity, unknown>;
   readonly spawn?: CodeGraphIsolatedBuilderSpawner;
   readonly spawnPlan?: (
     system: SystemInfoShape,
-    options: {readonly cwd: string; readonly threadnoteHome: string},
+    options: {
+      readonly admissionClass?: CodeGraphBuilderAdmissionClass;
+      readonly cwd: string;
+      readonly threadnoteHome: string;
+    },
   ) => CodeGraphIsolatedBuilderSpawnPlan;
   readonly threadnoteHome: string;
 }
@@ -94,7 +108,11 @@ export function isCodeGraphIsolatedBuilderHost(
  */
 export function codeGraphIsolatedBuilderSpawnPlan(
   system: SystemInfoShape,
-  options: {readonly cwd: string; readonly threadnoteHome: string},
+  options: {
+    readonly admissionClass?: CodeGraphBuilderAdmissionClass;
+    readonly cwd: string;
+    readonly threadnoteHome: string;
+  },
 ): CodeGraphIsolatedBuilderSpawnPlan {
   const script = developmentStandaloneScript(system);
   return {
@@ -110,6 +128,7 @@ export function codeGraphIsolatedBuilderSpawnPlan(
     ],
     environment: {
       ...withCurrentAgentSessionEnvironment(system.environment(), 'graph-builder'),
+      [CODE_GRAPH_BUILDER_ADMISSION_CLASS_ENV]: options.admissionClass ?? 'current-required',
       THREADNOTE_HOME: options.threadnoteHome,
     },
     executable: system.executablePath,
@@ -132,6 +151,7 @@ export function codeGraphProgressFromBuildStatus(
         phase: 'waiting',
         ...(status.subphase === 'database-writer' ||
         status.subphase === 'disk-capacity' ||
+        status.subphase === 'home-builder-cap' ||
         status.subphase === 'repository-lock' ||
         status.subphase === 'request-lock' ||
         status.subphase === 'snapshot-build'
@@ -230,33 +250,97 @@ export function codeGraphProgressFromBuildStatus(
  * Run `graph index --no-vectors` in a child CLI process and mirror its build-status sidecar.
  * On interruption the child is detached (not killed) so a later MCP refresh can re-attach.
  */
-export const runIsolatedCodeGraphIndex = Effect.fn('codeGraph.isolatedBuilder.run')(function* (
+export const runIsolatedCodeGraphIndex: (
   options: CodeGraphIsolatedBuilderOptions,
-) {
+) => Effect.Effect<
+  CodeGraphIsolatedBuilderResult,
+  unknown,
+  CommandExecutor | Crypto.Crypto | FileSystem.FileSystem | Path.Path | SystemInfo
+> = Effect.fn('codeGraph.isolatedBuilder.run')(function* (options: CodeGraphIsolatedBuilderOptions) {
   const system = yield* SystemInfo;
+  const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const identity = yield* options.resolveIdentity?.(options.cwd) ?? resolveRepositoryIdentity(options.cwd);
   const layout = codeGraphLayout(path, options.threadnoteHome, identity.checkoutId, identity.worktreeId);
   yield* options.assertRuntimeSchemaCompatible(layout.databasePath);
   const plan = (options.spawnPlan ?? codeGraphIsolatedBuilderSpawnPlan)(system, {
+    admissionClass: options.admissionClass,
     cwd: identity.repoRoot,
     threadnoteHome: options.threadnoteHome,
   });
   yield* assertIsolatedBuilderPlanEffect(plan);
 
-  const readStatus = currentCodeGraphBuildStatus(layout, identity.worktreeId);
-  const existing = yield* readStatus;
-  if (shouldAwaitExistingBuilder(existing, system.processId)) {
-    return yield* awaitExistingBuilder(readStatus, options.onProgress);
+  const readStatus = options.readStatus ?? currentCodeGraphBuildStatus(layout, identity.worktreeId);
+  const spawn = options.spawn ?? spawnIsolatedBuilderProcess;
+  const spawnLockPath = codeGraphWorktreeSpawnLockPath(
+    path,
+    options.threadnoteHome,
+    identity.checkoutId,
+    identity.worktreeId,
+  );
+  const admission = yield* withExclusiveFileLock(
+    fs,
+    spawnLockPath,
+    {
+      heartbeatIntervalMilliseconds: 5_000,
+      recoverReusedProcessIdImmediately: true,
+      retryIntervalMilliseconds: 25,
+      staleAfterMilliseconds: CODE_GRAPH_BUILD_STALE_AFTER_MILLISECONDS,
+      useCanonicalProcessStartIdentity: true,
+      waitTimeoutMilliseconds: ISOLATED_BUILDER_SPAWN_LOCK_WAIT_MILLISECONDS,
+    },
+    Effect.gen(function* () {
+      const existing = yield* readStatus;
+      if (shouldAwaitExistingBuilder(existing, system.processId)) {
+        return {
+          compatible: isolatedBuilderRequestMatches(existing!, options.requestKey),
+          mode: 'attach' as const,
+        };
+      }
+      if (
+        existing?.observation.liveness === 'completed' &&
+        existing.result &&
+        isolatedBuilderRequestMatches(existing, options.requestKey)
+      ) {
+        return {mode: 'completed' as const, result: existing.result};
+      }
+
+      const priorBuildId = existing?.buildId;
+      // Detach on interruption: do not kill multi-hour builds when the MCP host goes idle or reconnects.
+      const child = yield* isolatedBuilderPromise('Could not spawn isolated code graph builder', () =>
+        Promise.resolve(spawn(plan)),
+      );
+      const observed = yield* pollUntilEffect(statusOwnedBy(readStatus, child.processId, priorBuildId), {
+        intervalMs: ISOLATED_BUILDER_RESULT_POLL_MILLISECONDS,
+        timeoutMs: ISOLATED_BUILDER_SPAWN_OBSERVATION_MILLISECONDS,
+      });
+      if (!observed) {
+        // The child remains detached. A caller that lost the bounded startup
+        // race follows the same sidecar attach path as a spawn-lock waiter.
+        return {compatible: false, mode: 'attach' as const};
+      }
+      return {child, mode: 'spawned' as const, observedBuildId: observed.buildId, priorBuildId};
+    }),
+  ).pipe(Effect.catchIf(isFileLockTimeout, () => Effect.succeed({compatible: false, mode: 'attach' as const})));
+
+  // The spawn lock is released before either branch waits for repository-sized work.
+  if (admission.mode === 'completed') {
+    return {edges: admission.result.edges, symbols: admission.result.symbols};
+  }
+  if (admission.mode === 'attach') {
+    const attached = yield* awaitExistingBuilder(readStatus, options.onProgress, {
+      startupGraceMilliseconds: ISOLATED_BUILDER_SPAWN_OBSERVATION_MILLISECONDS,
+    });
+    if (admission.compatible) return attached;
+    // The owner built a different request. Its completed snapshot is now a
+    // retained-base candidate; re-enter spawn admission so one waiter applies
+    // this request's bounded delta while the rest attach to that new owner.
+    return yield* Effect.suspend(() => runIsolatedCodeGraphIndex(options));
   }
 
-  const priorBuildId = existing?.buildId;
-  const spawn = options.spawn ?? spawnIsolatedBuilderProcess;
-  // Detach on interruption: do not kill multi-hour builds when the MCP host goes idle or reconnects.
-  const child = yield* isolatedBuilderPromise('Could not spawn isolated code graph builder', () =>
-    Promise.resolve(spawn(plan)),
-  );
+  const {child, observedBuildId: initialObservedBuildId, priorBuildId} = admission;
   const observedBuildId = yield* Ref.make<string | undefined>(undefined);
+  yield* Ref.set(observedBuildId, initialObservedBuildId);
 
   const exitCode = yield* Effect.raceFirst(
     isolatedBuilderPromise('Could not await isolated code graph builder', () => child.exited),
@@ -348,6 +432,13 @@ export function shouldAwaitExistingBuilder(
   if (!status) return false;
   if (status.observation.liveness !== 'active' && status.observation.liveness !== 'stalled') return false;
   return status.owner.processId !== currentProcessId;
+}
+
+export function isolatedBuilderRequestMatches(
+  status: Pick<ObservedCodeGraphBuildStatus, 'request'>,
+  requestKey: string | undefined,
+): boolean {
+  return requestKey !== undefined && status.request?.key === requestKey;
 }
 
 export function statusBelongsToChild(
@@ -451,12 +542,20 @@ function statusOwnedBy<E, R>(
 function awaitExistingBuilder<E, R>(
   readStatus: Effect.Effect<ObservedCodeGraphBuildStatus | undefined, E, R>,
   onProgress: CodeGraphIsolatedBuilderOptions['onProgress'],
+  options: {readonly startupGraceMilliseconds?: number} = {},
 ) {
   return Effect.gen(function* () {
     const stalledStartedAt = yield* Ref.make<number | undefined>(undefined);
+    const startedAt = yield* Clock.currentTimeMillis;
     for (;;) {
       const status = yield* readStatus;
       if (!status) {
+        const now = yield* Clock.currentTimeMillis;
+        if (now - startedAt < (options.startupGraceMilliseconds ?? 0)) {
+          yield* emitProgress(onProgress, {phase: 'registering'});
+          yield* Effect.sleep(ISOLATED_BUILDER_RESULT_POLL_MILLISECONDS);
+          continue;
+        }
         return yield* Effect.fail(
           new IsolatedBuilderError('Existing code graph builder status disappeared before completion.'),
         );

--- a/src/code_graph/layout.ts
+++ b/src/code_graph/layout.ts
@@ -35,6 +35,26 @@ export function codeGraphDiskReservationLockPath(path: Path.Path, threadnoteHome
   return path.join(threadnoteHome, 'locks', 'indexes', 'code-graph', 'disk-capacity-reservations.lock');
 }
 
+export function codeGraphBuilderAdmissionRoot(path: Path.Path, threadnoteHome: string): string {
+  return path.join(threadnoteHome, 'locks', 'indexes', 'code-graph', 'builder-admission');
+}
+
+export function codeGraphBuilderAdmissionLockPath(path: Path.Path, threadnoteHome: string): string {
+  return path.join(threadnoteHome, 'locks', 'indexes', 'code-graph', 'builder-admission.lock');
+}
+
+export function codeGraphBuilderAdmissionSlotPath(path: Path.Path, threadnoteHome: string, slot: 0 | 1): string {
+  return path.join(threadnoteHome, 'locks', 'indexes', 'code-graph', 'builder-slots', `${slot}.lock`);
+}
+
+export function codeGraphRetainedBaseReservationRoot(path: Path.Path, threadnoteHome: string): string {
+  return path.join(threadnoteHome, 'locks', 'indexes', 'code-graph', 'retained-base-reservations');
+}
+
+export function codeGraphRetainedBaseReservationLockPath(path: Path.Path, threadnoteHome: string): string {
+  return path.join(threadnoteHome, 'locks', 'indexes', 'code-graph', 'retained-base-reservations.lock');
+}
+
 export function codeGraphRepositoriesRoot(path: Path.Path, threadnoteHome: string): string {
   return path.join(threadnoteHome, 'indexes', 'code-graph', 'repositories');
 }
@@ -140,6 +160,29 @@ export function codeGraphWorktreeLockPath(
   assertCheckoutId(checkoutId);
   assertWorktreeId(worktreeId);
   return path.join(codeGraphWorktreeLockRoot(path, threadnoteHome, checkoutId), `${worktreeId}.lock`);
+}
+
+/**
+ * Serializes the observe-then-spawn window across MCP hosts. This must remain
+ * distinct from the repository lock acquired by the spawned indexer.
+ */
+export function codeGraphWorktreeSpawnLockPath(
+  path: Path.Path,
+  threadnoteHome: string,
+  checkoutId: string,
+  worktreeId: string,
+): string {
+  assertCheckoutId(checkoutId);
+  assertWorktreeId(worktreeId);
+  return path.join(
+    threadnoteHome,
+    'locks',
+    'indexes',
+    'code-graph',
+    'worktree-spawns',
+    checkoutId,
+    `${worktreeId}.lock`,
+  );
 }
 
 export function codeGraphLayout(

--- a/src/code_graph/resolution_surface.ts
+++ b/src/code_graph/resolution_surface.ts
@@ -16,6 +16,20 @@ export type CodeGraphResolutionSurfaceSymbol = Pick<
   | 'resolutionScopeId'
 >;
 
+export type CodeGraphResolutionPublicationGate =
+  'exported' | 'non-typescript-domain' | 'own-path-local' | 'unknown-lookup-form' | 'foreign-path' | 'scope-mismatch';
+
+export type CodeGraphResolutionLookupKeyForm =
+  'none' | 'non-typescript' | 'typescript-other' | 'typescript-path-scoped' | 'typescript-path-unscoped';
+
+export interface CodeGraphResolutionPublicationAssessment {
+  /** Closed, path-free gate suitable for anonymous build telemetry. */
+  readonly gate: CodeGraphResolutionPublicationGate;
+  /** Closed lookup-key shape; never contains a symbol, scope, or repository path. */
+  readonly lookupKeyForm: CodeGraphResolutionLookupKeyForm;
+  readonly published: boolean;
+}
+
 export function hasSameCodeGraphResolutionSurface(
   left: readonly CodeGraphResolutionSurfaceSymbol[],
   right: readonly CodeGraphResolutionSurfaceSymbol[],
@@ -46,11 +60,36 @@ export function hasSameCodeGraphResolutionSurface(
  * closed as published.
  */
 export function isPublishedCodeGraphResolutionSymbol(symbol: CodeGraphResolutionSurfaceSymbol): boolean {
-  if (symbol.exported) return true;
-  for (const key of symbol.lookupKeys ?? []) {
-    if (!isOwnTypeScriptPathLookupKey(key, symbol)) return true;
+  return assessCodeGraphResolutionSymbolPublication(symbol).published;
+}
+
+/**
+ * Classifies publication using only resolver lookup tiers. The closed gate and
+ * key form intentionally expose enough evidence to diagnose fail-closed
+ * fallbacks without recording paths, symbol names, or project identifiers.
+ */
+export function assessCodeGraphResolutionSymbolPublication(
+  symbol: CodeGraphResolutionSurfaceSymbol,
+): CodeGraphResolutionPublicationAssessment {
+  if (symbol.exported) {
+    return {gate: 'exported', lookupKeyForm: firstLookupKeyForm(symbol), published: true};
   }
-  return false;
+  if (symbol.resolutionDomain !== 'typescript') {
+    return {
+      gate: 'non-typescript-domain',
+      lookupKeyForm: symbol.lookupKeys?.length ? 'non-typescript' : 'none',
+      published: true,
+    };
+  }
+  let lookupKeyForm: CodeGraphResolutionLookupKeyForm = 'none';
+  for (const key of symbol.lookupKeys ?? []) {
+    const assessment = assessOwnTypeScriptPathLookupKey(key, symbol);
+    lookupKeyForm = assessment.lookupKeyForm;
+    if (assessment.gate !== 'own-path-local') {
+      return {gate: assessment.gate, lookupKeyForm, published: true};
+    }
+  }
+  return {gate: 'own-path-local', lookupKeyForm, published: false};
 }
 
 function symbolResolutionSurface(symbol: CodeGraphResolutionSurfaceSymbol): string {
@@ -73,17 +112,33 @@ function symbolResolutionSurface(symbol: CodeGraphResolutionSurfaceSymbol): stri
   });
 }
 
-function isOwnTypeScriptPathLookupKey(key: string, symbol: CodeGraphResolutionSurfaceSymbol): boolean {
-  if (symbol.resolutionDomain !== 'typescript') return false;
+function assessOwnTypeScriptPathLookupKey(
+  key: string,
+  symbol: CodeGraphResolutionSurfaceSymbol,
+): Pick<CodeGraphResolutionPublicationAssessment, 'gate' | 'lookupKeyForm'> {
   const match =
     /^typescript:(?:([^:]+):)?path:([^:]+):(?:name|qualified):[^:]+(?::(?:arity:\d+|implementation|merge-canonical))?$/.exec(
       key,
     );
-  if (!match) return false;
-  if (match[1] !== symbol.resolutionScopeId) return false;
-  try {
-    return decodeURIComponent(match[2]!) === symbol.path;
-  } catch {
-    return false;
+  if (!match) return {gate: 'unknown-lookup-form', lookupKeyForm: 'typescript-other'};
+  const lookupKeyForm = match[1] === undefined ? 'typescript-path-unscoped' : 'typescript-path-scoped';
+  if (match[1] !== undefined && match[1] !== symbol.resolutionScopeId) {
+    return {gate: 'scope-mismatch', lookupKeyForm};
   }
+  try {
+    return decodeURIComponent(match[2]!) === symbol.path
+      ? {gate: 'own-path-local', lookupKeyForm}
+      : {gate: 'foreign-path', lookupKeyForm};
+  } catch {
+    return {gate: 'unknown-lookup-form', lookupKeyForm};
+  }
+}
+
+function firstLookupKeyForm(symbol: CodeGraphResolutionSurfaceSymbol): CodeGraphResolutionLookupKeyForm {
+  const key = symbol.lookupKeys?.[0];
+  if (key === undefined) return 'none';
+  if (symbol.resolutionDomain !== 'typescript') return 'non-typescript';
+  if (/^typescript:path:/.test(key)) return 'typescript-path-unscoped';
+  if (/^typescript:[^:]+:path:/.test(key)) return 'typescript-path-scoped';
+  return 'typescript-other';
 }

--- a/src/code_graph/retained_base_reservation.ts
+++ b/src/code_graph/retained_base_reservation.ts
@@ -1,0 +1,104 @@
+import {Clock, Effect, FileSystem, Path} from 'effect';
+import {sha256HexSync} from '../crypto/sha256.js';
+import {withExclusiveFileLock} from '../effect/file_lock.js';
+import {runtimeTextDirectoryNamePage} from '../effect/system.js';
+import {codeGraphRetainedBaseReservationLockPath, codeGraphRetainedBaseReservationRoot} from './layout.js';
+
+export const CODE_GRAPH_RETAINED_BASE_HOME_MAXIMUM = 2;
+
+interface RetainedBaseReservation {
+  readonly expiresAt: number;
+  readonly physicalSnapshotId: string;
+  readonly version: 1;
+}
+
+const RECEIPT_NAME = /^v1-([0-9a-f]{64})\.json$/;
+const RECEIPT_COUNT_MAXIMUM = 64;
+const RECEIPT_BYTES_MAXIMUM = 1_024;
+
+/**
+ * Reserves one of the two home-global retained-base entries until the durable
+ * SQL lease expires. The physical id deduplicates an alias and its base; this
+ * ledger is deliberately separate from the live builder slots.
+ */
+export const reserveCodeGraphRetainedBase = Effect.fn('codeGraph.retainedBase.reserve')(function* (options: {
+  readonly durationMilliseconds: number;
+  readonly physicalSnapshotId: string;
+  readonly threadnoteHome: string;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = codeGraphRetainedBaseReservationRoot(path, options.threadnoteHome);
+  const lockPath = codeGraphRetainedBaseReservationLockPath(path, options.threadnoteHome);
+  yield* fs.makeDirectory(root, {recursive: true, mode: 0o700});
+  return yield* withExclusiveFileLock(
+    fs,
+    lockPath,
+    {
+      heartbeatIntervalMilliseconds: 5_000,
+      recoverReusedProcessIdImmediately: true,
+      retryIntervalMilliseconds: 10,
+      staleAfterMilliseconds: 15_000,
+      useCanonicalProcessStartIdentity: true,
+      waitTimeoutMilliseconds: 5_000,
+    },
+    Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      const page = yield* runtimeTextDirectoryNamePage(root, RECEIPT_COUNT_MAXIMUM);
+      if (page.overflow) return false;
+      const active = new Map<string, {readonly path: string; readonly receipt: RetainedBaseReservation}>();
+      for (const name of page.names) {
+        const digest = RECEIPT_NAME.exec(name)?.[1];
+        if (!digest) return false;
+        const receiptPath = path.join(root, name);
+        if ((yield* fs.readLink(receiptPath).pipe(Effect.option))._tag === 'Some') return false;
+        const info = yield* fs.stat(receiptPath);
+        if (info.type !== 'File' || Number(info.size) > RECEIPT_BYTES_MAXIMUM) return false;
+        const receipt = parseReceipt(yield* fs.readFileString(receiptPath));
+        if (!receipt || sha256HexSync(receipt.physicalSnapshotId) !== digest) return false;
+        if (receipt.expiresAt <= now) {
+          yield* fs.remove(receiptPath, {force: true});
+          continue;
+        }
+        active.set(receipt.physicalSnapshotId, {path: receiptPath, receipt});
+      }
+      const existing = active.get(options.physicalSnapshotId);
+      if (!existing && active.size >= CODE_GRAPH_RETAINED_BASE_HOME_MAXIMUM) return false;
+      const expiresAt = now + Math.max(1, Math.floor(options.durationMilliseconds));
+      if (existing && existing.receipt.expiresAt >= expiresAt) return true;
+      const receiptPath = path.join(root, `v1-${sha256HexSync(options.physicalSnapshotId)}.json`);
+      const temporaryPath = `${receiptPath}.${sha256HexSync(`${now}\0${expiresAt}`).slice(0, 16)}.tmp`;
+      const serialized = JSON.stringify({expiresAt, physicalSnapshotId: options.physicalSnapshotId, version: 1});
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const file = yield* fs.open(temporaryPath, {flag: 'wx', mode: 0o600});
+          yield* file.writeAll(new TextEncoder().encode(serialized));
+          yield* file.sync;
+        }),
+      ).pipe(
+        Effect.andThen(fs.rename(temporaryPath, receiptPath)),
+        Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.ignore)),
+      );
+      return true;
+    }),
+  );
+});
+
+function parseReceipt(serialized: string): RetainedBaseReservation | undefined {
+  try {
+    const value = JSON.parse(serialized) as Partial<RetainedBaseReservation>;
+    if (
+      value.version !== 1 ||
+      typeof value.physicalSnapshotId !== 'string' ||
+      value.physicalSnapshotId.length < 1 ||
+      value.physicalSnapshotId.length > 128 ||
+      !Number.isSafeInteger(value.expiresAt) ||
+      Number(value.expiresAt) <= 0
+    ) {
+      return undefined;
+    }
+    return value as RetainedBaseReservation;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/code_graph/store_activation.ts
+++ b/src/code_graph/store_activation.ts
@@ -479,7 +479,7 @@ const activatePersistedIncrementalSnapshot = Effect.fn('codeGraph.activatePersis
   }
   yield* sql.withTransaction(
     Effect.gen(function* () {
-      if (!(yield* selectReusableBaseReceipt(baseSnapshotId))) {
+      if (!(yield* selectReusableBaseReceipt(baseSnapshotId, true))) {
         return yield* Effect.fail(
           new CodeGraphStoreError(`Reusable base receipt ${baseSnapshotId} is unavailable or incomplete.`),
         );

--- a/src/code_graph/store_activation_core.ts
+++ b/src/code_graph/store_activation_core.ts
@@ -817,7 +817,7 @@ const persistedIncrementalFactCounts = Effect.fn('codeGraph.persistedIncremental
         + (SELECT COUNT(*) FROM activation_edges) AS edges
     FROM snapshots AS base
     WHERE base.id = ${baseSnapshotId} AND base.state = 'ready'
-      AND base.dirty = 0 AND base.base_snapshot_id IS NULL
+      AND base.base_snapshot_id IS NULL
     LIMIT 1
   `;
   const row = rows[0];

--- a/src/code_graph/store_activation_persistent.ts
+++ b/src/code_graph/store_activation_persistent.ts
@@ -600,9 +600,9 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
       new CodeGraphStoreError('Persistent full activation only accepts self-contained snapshots.'),
     );
   }
-  if (snapshot.dirty && reusableBaseReceipt !== undefined) {
-    return yield* Effect.fail(new CodeGraphStoreError('Dirty snapshots cannot publish a reusable clean-base receipt.'));
-  }
+  // A self-contained full dirty snapshot may publish the same bounded reuse
+  // receipt as a clean root. Layered snapshots remain rejected above, so this
+  // never turns an overlay child into a second-hop base.
   const stateRows = yield* sql<{
     readonly repository_id: string;
     readonly state: CodeGraphSnapshot['state'];

--- a/src/code_graph/store_build_preparation.ts
+++ b/src/code_graph/store_build_preparation.ts
@@ -565,7 +565,9 @@ const preparePersistedIncrementalActivation = Effect.fn('codeGraph.preparePersis
     return false;
   }
   if (deletedPaths.some(path => paths.has(path))) return false;
-  if (!(yield* selectReusableBaseReceipt(baseSnapshotId))) return false;
+  // A committed dirty full root carries the same reusable receipt contract as
+  // a clean root; layered dirty overlays remain excluded by the receipt query.
+  if (!(yield* selectReusableBaseReceipt(baseSnapshotId, true))) return false;
 
   yield* prepareActivationTables(sql);
   const incrementalPaths = [...paths, ...deletedPaths].sort();

--- a/src/code_graph/store_leases.ts
+++ b/src/code_graph/store_leases.ts
@@ -34,6 +34,13 @@ import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconcili
 import {lastStatementChangeCount} from './store_activation_core.js';
 import {retireReadySnapshotsIfUnused} from './store_cleanup_core.js';
 import {CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION} from './store_health.js';
+import {
+  CODE_GRAPH_DETACHED_READY_COUNT_MAXIMUM,
+  CODE_GRAPH_DETACHED_READY_ESTIMATED_BYTES_MAXIMUM,
+  CODE_GRAPH_RETENTION_ESTIMATED_BYTES_MINIMUM,
+  CODE_GRAPH_RETENTION_ESTIMATED_BYTES_PER_EDGE,
+  CODE_GRAPH_RETENTION_ESTIMATED_BYTES_PER_SYMBOL,
+} from './snapshot_retention.js';
 
 /** Fresh facts are written before the durable building snapshot owns its inventory. */
 
@@ -303,6 +310,108 @@ const acquireSnapshotLease = Effect.fn('codeGraph.acquireSnapshotLease')(functio
       `;
       if (!ready[0]) {
         return yield* Effect.fail(new CodeGraphStoreError(`Ready snapshot ${snapshotId} is no longer available.`));
+      }
+      if (token.startsWith('retained-base:')) {
+        const targets = yield* sql<{
+          readonly estimated_bytes: number;
+          readonly physical_id: string;
+          readonly repository_id: string;
+          readonly worktree_id: string;
+        }>`
+          SELECT repository_id, worktree_id, COALESCE(base_snapshot_id, id) AS physical_id,
+                 MAX(
+                   ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_MINIMUM},
+                   symbol_count * ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_PER_SYMBOL} +
+                     edge_count * ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_PER_EDGE}
+                 ) AS estimated_bytes
+          FROM snapshots
+          WHERE id = ${snapshotId} AND state = 'ready'
+          LIMIT 1
+        `;
+        const target = targets[0];
+        if (!target) {
+          return yield* Effect.fail(new CodeGraphStoreError('Retained code graph base is no longer available.'));
+        }
+        const retainedReservations = yield* sql<{
+          readonly estimated_bytes: number;
+          readonly physical_id: string;
+          readonly repository_id: string;
+          readonly worktree_id: string;
+        }>`
+          SELECT snapshot.repository_id, snapshot.worktree_id,
+                 COALESCE(snapshot.base_snapshot_id, snapshot.id) AS physical_id,
+                 MAX(
+                   ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_MINIMUM},
+                   snapshot.symbol_count * ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_PER_SYMBOL} +
+                     snapshot.edge_count * ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_PER_EDGE}
+                 ) AS estimated_bytes
+          FROM snapshot_leases AS lease
+          JOIN snapshots AS snapshot ON snapshot.id = lease.snapshot_id
+          WHERE lease.token GLOB 'retained-base:*' AND lease.expires_at > ${now}
+          GROUP BY snapshot.repository_id, snapshot.worktree_id, physical_id
+        `;
+        if (
+          retainedReservations.some(
+            row =>
+              row.worktree_id === target.worktree_id &&
+              row.repository_id === target.repository_id &&
+              row.physical_id !== target.physical_id,
+          )
+        ) {
+          return yield* Effect.fail(
+            new CodeGraphStoreError('The worktree already has a retained committed code graph base.'),
+          );
+        }
+        const detachedReady = yield* sql<{
+          readonly estimated_bytes: number;
+          readonly physical_id: string;
+          readonly repository_id: string;
+          readonly worktree_id: string;
+        }>`
+          SELECT snapshot.repository_id, snapshot.worktree_id,
+                 COALESCE(snapshot.base_snapshot_id, snapshot.id) AS physical_id,
+                 MAX(
+                   MAX(
+                     ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_MINIMUM},
+                     snapshot.symbol_count * ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_PER_SYMBOL} +
+                       snapshot.edge_count * ${CODE_GRAPH_RETENTION_ESTIMATED_BYTES_PER_EDGE}
+                   )
+                 ) AS estimated_bytes
+          FROM snapshots AS snapshot
+          WHERE snapshot.repository_id = ${target.repository_id}
+            AND snapshot.state = 'ready'
+            AND snapshot.completed_at IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM active_snapshots AS active
+              WHERE active.snapshot_id = snapshot.id
+                AND NOT EXISTS (
+                  SELECT 1 FROM removed_views AS removed
+                  WHERE removed.worktree_id = active.worktree_id
+                    AND removed.expected_snapshot_id = active.snapshot_id
+                )
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM snapshots AS child
+              WHERE child.base_snapshot_id = snapshot.id
+              LIMIT 1
+            )
+          GROUP BY snapshot.repository_id, physical_id
+        `;
+        const physical = new Map(
+          [...detachedReady, ...retainedReservations]
+            .filter(row => row.repository_id === target.repository_id)
+            .map(row => [row.physical_id, row] as const),
+        );
+        if (!physical.has(target.physical_id)) physical.set(target.physical_id, target);
+        const retainedBytes = [...physical.values()].reduce((total, row) => total + row.estimated_bytes, 0);
+        if (
+          physical.size > CODE_GRAPH_DETACHED_READY_COUNT_MAXIMUM ||
+          retainedBytes > CODE_GRAPH_DETACHED_READY_ESTIMATED_BYTES_MAXIMUM
+        ) {
+          return yield* Effect.fail(
+            new CodeGraphStoreError('Retained code graph bases would exceed detached-ready capacity.'),
+          );
+        }
       }
       yield* sql`
         INSERT INTO snapshot_leases (token, snapshot_id, expires_at, retire_when_inactive)

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -434,6 +434,8 @@ export interface CodeGraphSnapshotPromotionOptions extends CodeGraphSnapshotLeas
 }
 
 export interface CodeGraphSnapshotLeaseAcquireOptions extends CodeGraphSnapshotLeaseWriterOptions {
+  /** Reserve a committed-but-unpromoted ready row inside detached-ready caps. */
+  readonly retainedBase?: boolean;
   readonly retireWhenInactive?: boolean;
 }
 

--- a/src/code_graph/store_persistent_build.ts
+++ b/src/code_graph/store_persistent_build.ts
@@ -32,7 +32,6 @@ import {pruneRetiredSnapshotRows} from './store_retirement.js';
 import {chunk, uniqueBy, upsertRepository} from './store_utilities.js';
 import {
   reclaimRetiredSnapshotPage,
-  reclaimRetiredSnapshotRows,
   REEXPORT_CLOSURE_PAGE_MAXIMUM_ROWS,
   REEXPORT_CLOSURE_SEED_PAGE_ROWS,
   stageActivationMonikers,
@@ -174,7 +173,7 @@ const retireIncompleteWorktreeSnapshots = Effect.fn('codeGraph.retireIncompleteW
   retainedSnapshotIds: ReadonlySet<string>,
   writerGate?: CodeGraphWriterGate,
   onProgress?: CodeGraphRetiredSnapshotCleanupProgressCallback,
-  cleanupMode: 'deferred' | 'required' = 'required',
+  _cleanupMode: 'deferred' | 'required' = 'required',
 ) {
   const sql = yield* SqlClient.SqlClient;
   yield* configureConnection(sql);
@@ -260,9 +259,7 @@ const retireIncompleteWorktreeSnapshots = Effect.fn('codeGraph.retireIncompleteW
       }),
     ),
   );
-  if (cleanupMode === 'required' && result.reclaimable.length > 0) {
-    yield* reclaimRetiredSnapshotRows(sql, result.reclaimable, runWrite, onProgress);
-  } else if (result.reclaimable.length > 0) {
+  if (result.reclaimable.length > 0) {
     const targets = result.reclaimable.slice(0, 100);
     yield* onProgress?.({
       pagesCompleted: 0,
@@ -270,6 +267,12 @@ const retireIncompleteWorktreeSnapshots = Effect.fn('codeGraph.retireIncompleteW
       snapshotsCompleted: 0,
       snapshotsTotal: result.reclaimable.length,
     }) ?? Effect.void;
+    // Required admission cleanup remains necessary for genuinely incomplete
+    // repository-sized rows, but it is page-budgeted so it cannot hold the
+    // repository lock across an unbounded physical drain. Committed retained
+    // READY rows are lease-protected and later enter ordinary detached-ready
+    // retirement after that lease lapses; they never enter this incomplete-row
+    // cleaner.
     const page = yield* runWrite(sql.withTransaction(reclaimRetiredSnapshotPage(sql, targets)));
     yield* onProgress?.({
       pagesCompleted: 1,
@@ -283,9 +286,9 @@ const retireIncompleteWorktreeSnapshots = Effect.fn('codeGraph.retireIncompleteW
 
 /**
  * Superseded persistent builds can own repository-sized durable tables. The
- * required mode reclaims their exact identities before replacement work; the
- * indexer uses deferred mode so ordinary ready-snapshot reuse only performs the
- * bounded retirement transaction and hands physical pages to routine cleanup.
+ * required mode reclaims one bounded page before replacement work; deferred
+ * maintenance converges the remaining exact identities without extending the
+ * activation-drift window.
  */
 
 const finalizePersistentMaterializationPlan = Effect.fn('codeGraph.finalizePersistentMaterializationPlan')(function* (

--- a/src/code_graph/store_queries.ts
+++ b/src/code_graph/store_queries.ts
@@ -1,4 +1,4 @@
-import {Effect, Option} from 'effect';
+import {Clock, Effect, Option} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {type CodeGraphBlobReuseFile} from './blob_reuse.js';
 import {codeGraphUtf8ByteLength} from './disk_capacity.js';
@@ -246,6 +246,39 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
   return yield* loadFirstReusableCleanBase(legacyCandidates);
 });
 
+const selectReusableOverlayBase = Effect.fn('codeGraph.selectReusableOverlayBase')(function* (
+  repositoryId: string,
+  extractorSet: string,
+  overlayFingerprint: string,
+) {
+  const sql = yield* SqlClient.SqlClient;
+  yield* configureConnection(sql);
+  const now = yield* Clock.currentTimeMillis;
+  const candidates = yield* sql<SnapshotRow>`
+    SELECT snapshot.*
+    FROM snapshots AS snapshot
+    JOIN snapshot_reuse_receipts AS receipt ON receipt.snapshot_id = snapshot.id
+    WHERE snapshot.repository_id = ${repositoryId}
+      AND snapshot.extractor_set = ${extractorSet}
+      AND snapshot.state = 'ready'
+      AND snapshot.dirty = 1
+      AND snapshot.base_snapshot_id IS NULL
+      AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
+      AND receipt.resolution_surface_version = 1
+    ORDER BY CASE WHEN snapshot.overlay_fingerprint = ${overlayFingerprint} THEN 0 ELSE 1 END,
+             CASE WHEN EXISTS (
+               SELECT 1 FROM snapshot_leases AS lease
+               WHERE lease.snapshot_id = snapshot.id
+                 AND lease.token GLOB 'retained-base:*'
+                 AND lease.expires_at > ${now}
+             ) THEN 0 ELSE 1 END,
+             snapshot.completed_at DESC,
+             snapshot.id
+    LIMIT 8
+  `;
+  return yield* loadFirstReusableOverlayBase(candidates);
+});
+
 const loadFirstReusableCleanBase = Effect.fn('codeGraph.loadFirstReusableCleanBase')(function* (
   candidates: readonly SnapshotRow[],
 ) {
@@ -284,7 +317,53 @@ const loadFirstReusableCleanBase = Effect.fn('codeGraph.loadFirstReusableCleanBa
   return undefined;
 });
 
-const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt')(function* (snapshotId: string) {
+const loadFirstReusableOverlayBase = Effect.fn('codeGraph.loadFirstReusableOverlayBase')(function* (
+  candidates: readonly SnapshotRow[],
+) {
+  const sql = yield* SqlClient.SqlClient;
+  for (const row of candidates) {
+    const receipt = yield* selectReusableBaseReceipt(row.id, true);
+    if (!receipt) continue;
+    const files = yield* sql<{
+      readonly content_hash: string;
+      readonly language: string;
+      readonly mode: string;
+      readonly path: string;
+      readonly size: number;
+      readonly source: string;
+    }>`
+      SELECT content_hash, language, mode, path, size, source
+      FROM snapshot_files
+      WHERE snapshot_id = ${row.id}
+      ORDER BY path
+    `;
+    if (
+      files.length !== Number(row.file_count) ||
+      files.some(file => file.source !== 'commit' && file.source !== 'worktree')
+    ) {
+      continue;
+    }
+    return {
+      files: files.map(file => ({
+        blobId: `snapshot:${file.content_hash}`,
+        contentHash: file.content_hash,
+        language: file.language,
+        mode: file.mode,
+        path: file.path,
+        size: Number(file.size),
+        source: file.source as 'commit' | 'worktree',
+      })),
+      receipt,
+      snapshot: snapshotFromRow(row),
+    } satisfies CodeGraphReusableCleanBase;
+  }
+  return undefined;
+});
+
+const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt')(function* (
+  snapshotId: string,
+  allowDirtyRoot = false,
+) {
   const sql = yield* SqlClient.SqlClient;
   yield* configureConnection(sql);
   const rows = yield* sql<{
@@ -305,7 +384,7 @@ const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt
       AND receipt.resolution_surface_version = 1
       AND receipt.extractor_set = snapshot.extractor_set
       AND snapshot.state = 'ready'
-      AND snapshot.dirty = 0
+      AND (${allowDirtyRoot ? 1 : 0} = 1 OR snapshot.dirty = 0)
       AND snapshot.base_snapshot_id IS NULL
       AND EXISTS (
         SELECT 1 FROM lexical_storage_formats AS lexical
@@ -970,6 +1049,7 @@ export {
   selectCurrentLexicalReadySnapshotById,
   selectReadySnapshotForCommit,
   selectReusableCleanBase,
+  selectReusableOverlayBase,
   selectReusableReexports,
   selectCachedFacts,
   selectMaterializedFileShards,

--- a/src/code_graph/store_service_data.ts
+++ b/src/code_graph/store_service_data.ts
@@ -13,6 +13,7 @@ import {
   selectCurrentLexicalReadySnapshotById,
   selectReadySnapshotForCommit,
   selectReusableCleanBase,
+  selectReusableOverlayBase,
   selectReusableReexports,
   selectCachedFacts,
   selectMaterializedFileShards,
@@ -112,6 +113,7 @@ type CodeGraphStoreDataMethods = Pick<
   | 'reusableBaseReceipt'
   | 'snapshotPackProvenance'
   | 'reusableCleanBase'
+  | 'reusableOverlayBase'
   | 'reusableReexports'
   | 'relationshipSummaryForNode'
   | 'pruneCachedFacts'
@@ -509,7 +511,7 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
             options?.cleanupMode,
           ),
         );
-        if (options?.cleanupMode === 'deferred' && result.reclaimable > 0) {
+        if (result.reclaimable > 0) {
           yield* scheduleRoutinePhysicalCleanup(databasePath);
         }
         return result.retired;
@@ -556,10 +558,12 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
         ),
         Effect.mapError(cause => storeError('load ready code graph snapshot for commit', cause)),
       ),
-    reusableBaseReceipt: (databasePath, snapshotId) =>
+    reusableBaseReceipt: (databasePath, snapshotId, options) =>
       fs.exists(databasePath).pipe(
         Effect.flatMap(exists =>
-          exists ? useReadOnlyDatabase(databasePath, selectReusableBaseReceipt(snapshotId)) : Effect.succeed(undefined),
+          exists
+            ? useReadOnlyDatabase(databasePath, selectReusableBaseReceipt(snapshotId, options?.allowDirtyRoot === true))
+            : Effect.succeed(undefined),
         ),
         Effect.mapError(cause => storeError('load reusable code graph base receipt', cause)),
       ),
@@ -600,6 +604,18 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
             : Effect.succeed(undefined),
         ),
         Effect.mapError(cause => storeError('load reusable clean code graph base', cause)),
+      ),
+    reusableOverlayBase: (databasePath, repositoryId, extractorSet, overlayFingerprint) =>
+      fs.exists(databasePath).pipe(
+        Effect.flatMap(exists =>
+          exists
+            ? useReadOnlyDatabase(
+                databasePath,
+                selectReusableOverlayBase(repositoryId, extractorSet, overlayFingerprint),
+              )
+            : Effect.succeed(undefined),
+        ),
+        Effect.mapError(cause => storeError('load reusable retained overlay code graph base', cause)),
       ),
     reusableReexports: (databasePath, snapshotId, seeds, options) =>
       fs.exists(databasePath).pipe(

--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -205,7 +205,7 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
       ),
     acquireSnapshotLease: (databasePath, snapshotId, durationMilliseconds, options) =>
       Effect.gen(function* () {
-        const token = `${system.processId}:${yield* crypto.randomUUIDv4}`;
+        const token = `${options?.retainedBase === true ? 'retained-base:' : ''}${system.processId}:${yield* crypto.randomUUIDv4}`;
         const acquired = yield* prepare(databasePath).pipe(
           Effect.andThen(
             withWriterGate(

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -411,6 +411,7 @@ export interface CodeGraphStoreShape {
   readonly reusableBaseReceipt: (
     databasePath: string,
     snapshotId: string,
+    options?: {readonly allowDirtyRoot?: boolean},
   ) => Effect.Effect<CodeGraphReusableBaseReceipt | undefined, CodeGraphStoreError>;
   readonly snapshotPackProvenance: (
     databasePath: string,
@@ -425,6 +426,12 @@ export interface CodeGraphStoreShape {
     graphContentId?: string,
     preferredCommitGroups?: readonly (readonly string[])[],
     allowExtractorMismatch?: boolean,
+  ) => Effect.Effect<CodeGraphReusableCleanBase | undefined, CodeGraphStoreError>;
+  readonly reusableOverlayBase?: (
+    databasePath: string,
+    repositoryId: string,
+    extractorSet: string,
+    overlayFingerprint: string,
   ) => Effect.Effect<CodeGraphReusableCleanBase | undefined, CodeGraphStoreError>;
   readonly reusableReexports: (
     databasePath: string,

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -223,6 +223,10 @@ export interface CodeGraphMaterializationMetrics {
   readonly factsBytesTotal?: number;
   readonly loadingMilliseconds?: number;
   readonly mode?: 'full' | 'incremental-clean' | 'incremental-overlay';
+  /** Closed, path-free evidence for the declaration-publication gate. */
+  readonly resolutionLookupKeyForm?: import('./resolution_surface.js').CodeGraphResolutionLookupKeyForm;
+  /** Closed, path-free evidence for the declaration-publication gate. */
+  readonly resolutionPublicationGate?: import('./resolution_surface.js').CodeGraphResolutionPublicationGate;
   readonly rows?: CodeGraphMaterializationRows;
   readonly sourceBytesCompleted: number;
   readonly sourceBytesTotal: number;
@@ -321,7 +325,13 @@ export type CodeGraphProgress =
     }
   | {
       readonly phase: 'waiting';
-      readonly reason?: 'database-writer' | 'disk-capacity' | 'repository-lock' | 'request-lock' | 'snapshot-build';
+      readonly reason?:
+        | 'database-writer'
+        | 'disk-capacity'
+        | 'home-builder-cap'
+        | 'repository-lock'
+        | 'request-lock'
+        | 'snapshot-build';
     }
   | {
       readonly completed: number;
@@ -418,6 +428,8 @@ export interface CodeGraphIndexSummary {
     readonly fallbackReason?: CodeGraphOverlayFallbackReason;
     readonly mode: 'full' | 'incremental-clean' | 'incremental-overlay' | 'reused-snapshot';
     readonly resolutionClosure?: 'changed' | 'full' | 'project';
+    readonly resolutionLookupKeyForm?: import('./resolution_surface.js').CodeGraphResolutionLookupKeyForm;
+    readonly resolutionPublicationGate?: import('./resolution_surface.js').CodeGraphResolutionPublicationGate;
     readonly stagedFiles: number;
     readonly totalFiles: number;
   };

--- a/src/code_graph/watcher.ts
+++ b/src/code_graph/watcher.ts
@@ -2,6 +2,7 @@ import {
   Cause,
   Clock,
   Context,
+  Crypto,
   Deferred,
   Effect,
   Fiber,
@@ -16,7 +17,7 @@ import {
   SynchronizedRef,
 } from 'effect';
 import {CodeGraphIndexer, type CodeGraphIndexerShape} from './indexer.js';
-import {worktreeOverlayState} from './inventory.js';
+import {worktreeBuildRequestState, worktreeOverlayState} from './inventory.js';
 import {CodeGraphMaintenanceCoordinator} from './maintenance_coordinator.js';
 import {CodeGraphStore, type CodeGraphRoutineMaintenanceResult, type CodeGraphStoreShape} from './store.js';
 import {CommandExecutor, type CommandOptions} from '../effect/command.js';
@@ -29,7 +30,11 @@ import type {
   RepositoryIdentity,
 } from './types.js';
 import {CodeGraphRuntimeReconnectRequiredError} from './types.js';
-import {currentCodeGraphBuildStatus, type ObservedCodeGraphBuildStatus} from './build_status.js';
+import {
+  currentCodeGraphBuildStatus,
+  readCodeGraphBuildStatuses,
+  type ObservedCodeGraphBuildStatus,
+} from './build_status.js';
 import {isCodeGraphIsolatedBuilderHost, runIsolatedCodeGraphIndex} from './isolated_builder.js';
 import {codeGraphLayout} from './layout.js';
 import {runCodeGraphLifecycleOpportunity} from './lifecycle_opportunity.js';
@@ -48,8 +53,12 @@ import {
 } from './recovery_coordinator.js';
 import {codeGraphAnonymousTelemetryComponent, emitCodeGraphBackgroundFailure} from './anonymous_telemetry.js';
 import {anonymousTelemetryDiagnosticFromCodeGraphRefreshFailure} from '../telemetry/diagnostic.js';
+import type {CodeGraphBuilderAdmissionClass} from './builder_admission.js';
+import {codeGraphBuildRequestKey} from './indexer_build.js';
+import {CodeGraphLanguagePackRegistry} from './languages/registry.js';
 
 export interface CodeGraphWatchOptions {
+  readonly admissionClass?: CodeGraphBuilderAdmissionClass;
   readonly cwd: string;
   readonly key: string;
   readonly onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void>;
@@ -137,6 +146,7 @@ export type CodeGraphRecoveryRun = (
 ) => Effect.Effect<void, unknown>;
 
 export interface CodeGraphWatchReconciliationHooks {
+  readonly changeRefreshRequired?: Effect.Effect<boolean, unknown>;
   readonly periodicRefreshRequired: Effect.Effect<boolean, unknown>;
   readonly requestAfterChange: Effect.Effect<void, unknown>;
   readonly requestInitial?: Effect.Effect<void, unknown>;
@@ -238,10 +248,12 @@ export class CodeGraphWatcher extends Context.Service<CodeGraphWatcher, CodeGrap
     CodeGraphWatcher,
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
+      const crypto = yield* Crypto.Crypto;
       const path = yield* Path.Path;
       const commandExecutor = yield* CommandExecutor;
       const systemInfo = yield* SystemInfo;
       const indexer = yield* CodeGraphIndexer;
+      const languagePacks = yield* CodeGraphLanguagePackRegistry;
       const maintenance = yield* CodeGraphMaintenanceCoordinator;
       const store = yield* CodeGraphStore;
       const scope = yield* Effect.scope;
@@ -266,6 +278,7 @@ export class CodeGraphWatcher extends Context.Service<CodeGraphWatcher, CodeGrap
               store,
             }).pipe(
               Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(Crypto.Crypto, crypto),
               Effect.provideService(FileSystem.FileSystem, fs),
               Effect.provideService(Path.Path, path),
               Effect.provideService(SystemInfo, systemInfo),
@@ -275,13 +288,28 @@ export class CodeGraphWatcher extends Context.Service<CodeGraphWatcher, CodeGrap
       const refresh = (options: CodeGraphWatchOptions) =>
         Effect.gen(function* () {
           if (isolateBuilder) {
+            const identity = yield* resolveRepositoryIdentity(options.cwd).pipe(
+              Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(FileSystem.FileSystem, fs),
+              Effect.provideService(Path.Path, path),
+              Effect.provideService(SystemInfo, systemInfo),
+            );
+            const requestedOverlay = yield* worktreeBuildRequestState(identity, options.threadnoteHome).pipe(
+              Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(FileSystem.FileSystem, fs),
+              Effect.provideService(Path.Path, path),
+              Effect.provideService(SystemInfo, systemInfo),
+            );
             const summary = yield* runIsolatedCodeGraphIndex({
+              admissionClass: options.admissionClass,
               assertRuntimeSchemaCompatible: databasePath => store.assertRuntimeSchemaCompatible(databasePath),
               cwd: options.cwd,
               onProgress: options.onProgress,
+              requestKey: codeGraphBuildRequestKey(identity, requestedOverlay, languagePacks, undefined),
               threadnoteHome: options.threadnoteHome,
             }).pipe(
               Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(Crypto.Crypto, crypto),
               Effect.provideService(FileSystem.FileSystem, fs),
               Effect.provideService(Path.Path, path),
               Effect.provideService(SystemInfo, systemInfo),
@@ -311,12 +339,26 @@ export class CodeGraphWatcher extends Context.Service<CodeGraphWatcher, CodeGrap
         });
       };
       const watchReconciliationHooks = (options: CodeGraphWatchOptions): CodeGraphWatchReconciliationHooks => ({
+        changeRefreshRequired: Effect.gen(function* () {
+          const identity = yield* resolveRecoveryIdentity(options.cwd);
+          const layout = codeGraphLayout(path, options.threadnoteHome, identity.checkoutId, identity.worktreeId);
+          const ready = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+          if (ready === undefined) return true;
+          const statuses = yield* readCodeGraphBuildStatuses(layout);
+          return codeGraphCachedOverlayAssessmentAllowsBackgroundRefresh(ready.id, statuses);
+        }).pipe(
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+          Effect.provideService(SystemInfo, systemInfo),
+        ),
         periodicRefreshRequired: Effect.gen(function* () {
           const identity = yield* resolveRecoveryIdentity(options.cwd);
           yield* requestWatchMaintenance(options, identity);
           const layout = codeGraphLayout(path, options.threadnoteHome, identity.checkoutId, identity.worktreeId);
           const ready = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
-          if (ready === undefined || ready.commit !== identity.headCommit) return true;
+          if (ready === undefined) return true;
+          const statuses = yield* readCodeGraphBuildStatuses(layout);
+          if (!codeGraphCachedOverlayAssessmentAllowsBackgroundRefresh(ready.id, statuses)) return false;
           const overlay = yield* worktreeOverlayState(identity).pipe(
             Effect.provideService(CommandExecutor, commandExecutor),
             Effect.provideService(FileSystem.FileSystem, fs),
@@ -324,7 +366,11 @@ export class CodeGraphWatcher extends Context.Service<CodeGraphWatcher, CodeGrap
             Effect.provideService(SystemInfo, systemInfo),
           );
           return codeGraphWatcherSnapshotStale(ready, identity, overlay);
-        }),
+        }).pipe(
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+          Effect.provideService(SystemInfo, systemInfo),
+        ),
         requestAfterChange: resolveRecoveryIdentity(options.cwd).pipe(
           Effect.flatMap(identity => requestWatchMaintenance(options, identity)),
         ),
@@ -433,7 +479,7 @@ export const makeCodeGraphWatcher = Effect.fn('codeGraph.makeWatcher')(function*
   const activeWatches = yield* SynchronizedRef.make(new Map<string, ActiveWatch>());
   const activeRefreshes = yield* SynchronizedRef.make(new Map<string, ActiveRefresh>());
   const refreshStatuses = yield* SynchronizedRef.make(new Map<string, CodeGraphRefreshStatus>());
-  const refreshSemaphore = yield* Semaphore.make(1);
+  const refreshSemaphore = yield* Semaphore.make(2);
   const refreshExecutionMetrics = yield* Ref.make<RefreshExecutionMetrics>({executing: 0, highWater: 0});
   const refreshSequence = yield* Ref.make(0);
   const sweepStarted = yield* Ref.make(false);
@@ -600,7 +646,9 @@ export const makeCodeGraphWatcher = Effect.fn('codeGraph.makeWatcher')(function*
       return decision;
     });
   const requestBackgroundRefresh = (options: CodeGraphWatchOptions, queueTrailing: boolean) =>
-    scheduleRefresh(options, queueTrailing).pipe(Effect.map(decision => decision.start));
+    scheduleRefresh({...options, admissionClass: 'background'}, queueTrailing).pipe(
+      Effect.map(decision => decision.start),
+    );
   const requestRefreshAndWait = (options: CodeGraphWatchOptions) =>
     scheduleRefresh(options, false).pipe(Effect.flatMap(decision => Deferred.await(decision.completion)));
   const cancelWatches = (entries: readonly [string, ActiveWatch][]) =>
@@ -707,7 +755,9 @@ export const makeCodeGraphWatcher = Effect.fn('codeGraph.makeWatcher')(function*
     refresh: options =>
       Effect.gen(function* () {
         yield* touchWatch(options.key);
-        return yield* requestBackgroundRefresh(options, false);
+        return yield* scheduleRefresh({...options, admissionClass: 'current-required'}, false).pipe(
+          Effect.map(decision => decision.start),
+        );
       }),
     status: key =>
       Effect.gen(function* () {
@@ -718,7 +768,7 @@ export const makeCodeGraphWatcher = Effect.fn('codeGraph.makeWatcher')(function*
         return Option.some(refreshStatusAt(current, now));
       }),
     watch: options =>
-      requestRefreshAndWait(options).pipe(
+      requestRefreshAndWait({...options, admissionClass: 'current-required'}).pipe(
         Effect.andThen(run(options, true, () => requestBackgroundRefresh(options, true).pipe(Effect.asVoid))),
         Effect.ensuring(removeStatuses([options.key])),
       ),
@@ -1036,7 +1086,15 @@ export const watchRepository = Effect.fn('codeGraph.watchRepository')(function* 
             Effect.catch(() =>
               Effect.logWarning('Code graph change maintenance scheduling failed; refresh remains active.'),
             ),
-            Effect.andThen(requestRefresh()),
+            Effect.andThen(
+              (reconciliationHooks.changeRefreshRequired ?? Effect.succeed(true)).pipe(
+                Effect.match({
+                  onFailure: () => false,
+                  onSuccess: refreshRequired => refreshRequired,
+                }),
+                Effect.flatMap(refreshRequired => (refreshRequired ? requestRefresh() : Effect.void)),
+              ),
+            ),
           )
         : reconciliationHooks.periodicRefreshRequired.pipe(
             Effect.match({
@@ -1059,6 +1117,27 @@ export function codeGraphWatcherSnapshotStale(
     snapshot.dirty !== overlay.dirty ||
     (overlay.dirty && snapshot.overlayFingerprint !== overlay.fingerprint)
   );
+}
+
+/**
+ * Background watch/timer work is admitted only after the current ready base
+ * was produced by a successful bounded overlay assessment. Missing or full
+ * outcomes remain fail-closed until an explicit current-only request records a
+ * new result.
+ */
+export function codeGraphCachedOverlayAssessmentAllowsBackgroundRefresh(
+  readySnapshotId: string,
+  statuses: readonly Pick<ObservedCodeGraphBuildStatus, 'materialization' | 'result' | 'state' | 'timestamps'>[],
+): boolean {
+  const matching = statuses.filter(
+    status => status.state === 'completed' && status.result?.snapshotId === readySnapshotId,
+  );
+  const latest = matching.sort((left, right) => {
+    const leftTime = Date.parse(left.timestamps.completedAt ?? left.timestamps.updatedAt);
+    const rightTime = Date.parse(right.timestamps.completedAt ?? right.timestamps.updatedAt);
+    return rightTime - leftTime;
+  })[0];
+  return latest?.result?.overlayAssessment?.outcome === 'overlay-success';
 }
 
 function relevantWatchPath(path: Path.Path, cwd: string, eventPath: string): boolean {

--- a/src/effect/telemetry.ts
+++ b/src/effect/telemetry.ts
@@ -93,6 +93,7 @@ export type AnonymousTelemetryStage = (typeof ANONYMOUS_TELEMETRY_STAGES)[number
 export const ANONYMOUS_TELEMETRY_WAITING_REASONS = [
   'database-writer',
   'disk-capacity',
+  'home-builder-cap',
   'repository-lock',
   'request-lock',
   'snapshot-build',

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -752,6 +752,7 @@ export {
   codeGraphAnalysisMcpResponse,
   codeGraphAnalysisRefreshResult,
   codeGraphInspectionAllowsStaleReady,
+  codeGraphInspectionStartsRefresh,
   codeGraphMcpAnalysisBudget,
   codeGraphMcpAnalysisLimits,
   codeGraphMcpResponse,

--- a/src/mcp_server_code_graph.ts
+++ b/src/mcp_server_code_graph.ts
@@ -335,7 +335,7 @@ export function registerCodeGraphTool(
           status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status);
         }
         let refreshStarted = false;
-        if (status.stale) {
+        if (codeGraphInspectionStartsRefresh(status, operation)) {
           refreshStarted = yield* watcher.refresh({
             ...refreshTarget,
             key: identity.worktreeId,
@@ -1439,6 +1439,18 @@ export function codeGraphInspectionAllowsStaleReady(
   return operation !== 'impact' && operation !== 'path';
 }
 
+/**
+ * Ordinary relationship reads retain immutable ready evidence without starting
+ * repository-sized work. Cold checkouts and correctness-sensitive operations
+ * still request the current graph.
+ */
+export function codeGraphInspectionStartsRefresh(
+  status: {readonly readySnapshot?: unknown; readonly stale: boolean},
+  operation: 'explain' | 'impact' | 'neighbors' | 'node' | 'path' | 'query',
+): boolean {
+  return !status.readySnapshot || (status.stale && !codeGraphInspectionAllowsStaleReady(operation));
+}
+
 /** Retain the exact observed pointer; refresh status alone is never promotion authority. */
 export function selectCodeGraphReadySnapshotForInspection<T>(
   status: {readonly readySnapshot?: T; readonly stale: boolean},
@@ -1462,8 +1474,8 @@ export function codeGraphResultWithRefreshContinuity(
         `(${refreshStatus.failure.code}). ${codeGraphRefreshRecoveryWarning(refreshStatus.failure)}`
       : refreshStatus?.state === 'indexing'
         ? 'Serving the existing stale ready snapshot while code graph refresh continues in the background.'
-        : undefined;
-  if (warning === undefined) return result;
+        : 'Serving the existing stale ready snapshot without starting a background rebuild. ' +
+          'Run `threadnote graph index`, or use `path` or `impact`, when current graph evidence is required.';
   const bounded = compactMcpText(warning, 320);
   return result.warnings.includes(bounded) ? result : {...result, warnings: [...result.warnings, bounded]};
 }

--- a/test/integration/code-graph.barrel-incremental.property.test.ts
+++ b/test/integration/code-graph.barrel-incremental.property.test.ts
@@ -109,6 +109,8 @@ describe('code graph incremental barrel differential properties', () => {
 
           expect(incremental.materialization).toEqual({
             mode: 'incremental-overlay',
+            resolutionLookupKeyForm: 'typescript-path-unscoped',
+            resolutionPublicationGate: 'own-path-local',
             stagedFiles: 1,
             totalFiles: scenario.barrelDepth + 4,
           });

--- a/test/integration/code-graph.cross-session-incremental.test.ts
+++ b/test/integration/code-graph.cross-session-incremental.test.ts
@@ -37,6 +37,8 @@ describe('cross-session code graph increments', () => {
         const committed = yield* indexAndLoadEffect(root, home);
         expect(committed.summary.materialization).toEqual({
           mode: 'incremental-clean',
+          resolutionLookupKeyForm: 'typescript-path-unscoped',
+          resolutionPublicationGate: 'own-path-local',
           stagedFiles: 1,
           totalFiles: 18,
         });
@@ -91,6 +93,8 @@ describe('cross-session code graph increments', () => {
 
       expect(incremental.summary.materialization).toEqual({
         mode: 'incremental-overlay',
+        resolutionLookupKeyForm: 'typescript-path-unscoped',
+        resolutionPublicationGate: 'own-path-local',
         stagedFiles: 1,
         totalFiles: 34,
       });
@@ -257,6 +261,8 @@ describe('cross-session code graph increments', () => {
         const rebuilt = yield* indexWithRegistry(root, referenceHome, nextRegistry, true);
         expect(incremental.materialization).toEqual({
           mode: 'incremental-clean',
+          resolutionLookupKeyForm: 'typescript-path-unscoped',
+          resolutionPublicationGate: 'own-path-local',
           stagedFiles: 8,
           totalFiles: 9,
         });

--- a/test/integration/code-graph.incremental.property.test.ts
+++ b/test/integration/code-graph.incremental.property.test.ts
@@ -528,7 +528,7 @@ describe('code graph incremental-overlay differential properties', () => {
     }
   });
 
-  it('reuses the ready logical snapshot while required cleanup reclaims an interrupted direct sibling', async () => {
+  it.effect('reuses the ready logical snapshot while bounded cleanup retires an interrupted direct sibling', () => {
     const scenario = {
       baseTargets: [1, 0, 1],
       dirty: new Set([0, 2]),
@@ -536,19 +536,16 @@ describe('code graph incremental-overlay differential properties', () => {
       fileCount: 3,
       salt: 62,
     } satisfies DifferentialScenario;
-    const root = createRepository(scenario);
-    const home = join(root, '.threadnote-ready-logical-interrupted-direct-home');
-    try {
-      await runEffect(
+    return Effect.acquireUseRelease(
+      Effect.sync(() => {
+        const root = createRepository(scenario);
+        return {home: join(root, '.threadnote-ready-logical-interrupted-direct-home'), root};
+      }),
+      ({home, root}) =>
         Effect.gen(function* () {
           const indexer = yield* CodeGraphIndexer;
           yield* indexer.index({cwd: root, threadnoteHome: home});
-        }),
-      );
-      applyDirtyScenario(root, scenario);
-      const interrupted = await runEffect(
-        Effect.gen(function* () {
-          const indexer = yield* CodeGraphIndexer;
+          yield* Effect.sync(() => applyDirtyScenario(root, scenario));
           const path = yield* Path.Path;
           const logical = yield* indexer.index({cwd: root, threadnoteHome: home});
           const layout = codeGraphLayout(path, home, logical.identity.checkoutId, logical.identity.worktreeId);
@@ -563,35 +560,28 @@ describe('code graph incremental-overlay differential properties', () => {
               threadnoteHome: home,
             })
             .pipe(Effect.exit);
-          return {databasePath: layout.databasePath, exit, logical};
+          const interrupted = {databasePath: layout.databasePath, exit, logical};
+
+          expect(interrupted.logical.materialization?.mode).toBe('incremental-overlay');
+          expect(interrupted.logical.snapshot.baseSnapshotId).toBeDefined();
+          expect(interrupted.exit._tag).toBe('Failure');
+          const direct = persistedBuildingSnapshot(interrupted.databasePath);
+          expect(direct.id).toMatch(/-direct$/);
+          expect(Option.isNone(direct.baseSnapshotId)).toBe(true);
+          expect(persistedSnapshotRowCount(interrupted.databasePath, direct.id, 'symbols')).toBeGreaterThan(0);
+
+          const reused = yield* indexer.index({cwd: root, threadnoteHome: home});
+
+          expect(reused.snapshot.id).toBe(interrupted.logical.snapshot.id);
+          expect(reused.materialization?.mode).toBe('reused-snapshot');
+          expect(persistedSnapshotState(interrupted.databasePath, direct.id)).toBe('retired');
+          expect(persistedSnapshotRowCount(interrupted.databasePath, direct.id, 'symbols')).toBeGreaterThan(0);
+          expect(
+            persistedSnapshotRowCount(interrupted.databasePath, direct.id, 'building_materialization_batches'),
+          ).toBe(1);
         }),
-      );
-
-      expect(interrupted.logical.materialization?.mode).toBe('incremental-overlay');
-      expect(interrupted.logical.snapshot.baseSnapshotId).toBeDefined();
-      expect(interrupted.exit._tag).toBe('Failure');
-      const direct = persistedBuildingSnapshot(interrupted.databasePath);
-      expect(direct.id).toMatch(/-direct$/);
-      expect(Option.isNone(direct.baseSnapshotId)).toBe(true);
-      expect(persistedSnapshotRowCount(interrupted.databasePath, direct.id, 'symbols')).toBeGreaterThan(0);
-
-      const reused = await runEffect(
-        Effect.gen(function* () {
-          const indexer = yield* CodeGraphIndexer;
-          return yield* indexer.index({cwd: root, threadnoteHome: home});
-        }),
-      );
-
-      expect(reused.snapshot.id).toBe(interrupted.logical.snapshot.id);
-      expect(reused.materialization?.mode).toBe('reused-snapshot');
-      expect(persistedSnapshotState(interrupted.databasePath, direct.id)).toBeUndefined();
-      expect(persistedSnapshotRowCount(interrupted.databasePath, direct.id, 'symbols')).toBe(0);
-      expect(persistedSnapshotRowCount(interrupted.databasePath, direct.id, 'building_materialization_batches')).toBe(
-        0,
-      );
-    } finally {
-      rmSync(root, {force: true, recursive: true});
-    }
+      ({root}) => Effect.sync(() => rmSync(root, {force: true, recursive: true})),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive);
   });
 
   it('keeps the explicit overlay option inert for a clean canonical snapshot', async () => {
@@ -678,7 +668,7 @@ describe('code graph incremental-overlay differential properties', () => {
     }
   });
 
-  it('indexes the restored clean worktree while required cleanup reclaims an interrupted dirty build', async () => {
+  it.effect('indexes the restored clean worktree while bounded cleanup retires an interrupted dirty build', () => {
     const scenario = {
       baseTargets: [1, 0, 1],
       dirty: new Set([0, 2]),
@@ -686,12 +676,14 @@ describe('code graph incremental-overlay differential properties', () => {
       fileCount: 3,
       salt: 71,
     } satisfies DifferentialScenario;
-    const root = createRepository(scenario);
-    const home = join(root, '.threadnote-dirty-to-clean-home');
-    try {
-      applyDirtyScenario(root, scenario);
-      const databasePath = await runEffect(
+    return Effect.acquireUseRelease(
+      Effect.sync(() => {
+        const root = createRepository(scenario);
+        return {home: join(root, '.threadnote-dirty-to-clean-home'), root};
+      }),
+      ({home, root}) =>
         Effect.gen(function* () {
+          yield* Effect.sync(() => applyDirtyScenario(root, scenario));
           const indexer = yield* CodeGraphIndexer;
           const path = yield* Path.Path;
           const identity = yield* resolveRepositoryIdentity(root);
@@ -707,34 +699,34 @@ describe('code graph incremental-overlay differential properties', () => {
             })
             .pipe(Effect.exit);
           expect(exit._tag).toBe('Failure');
-          return codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId).databasePath;
-        }),
-      );
-      const interrupted = persistedBuildingSnapshot(databasePath);
-      expect(interrupted.id).toMatch(/-direct$/);
-      restoreCleanScenario(root, scenario);
+          const databasePath = codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId).databasePath;
+          const interrupted = persistedBuildingSnapshot(databasePath);
+          expect(interrupted.id).toMatch(/-direct$/);
+          yield* Effect.sync(() => restoreCleanScenario(root, scenario));
 
-      const clean = await runEffect(
-        Effect.gen(function* () {
-          const indexer = yield* CodeGraphIndexer;
-          return yield* indexer.index({cwd: root, threadnoteHome: home});
-        }),
-      );
+          const clean = yield* indexer.index({cwd: root, threadnoteHome: home});
 
-      expect(clean.snapshot.dirty).toBe(false);
-      expect(clean.snapshot.id).not.toMatch(/-direct$/);
-      expect(persistedSnapshotState(databasePath, interrupted.id)).toBeUndefined();
-      expect(persistedSnapshots(databasePath)).toEqual([
-        {
-          baseSnapshotId: Option.none(),
-          dirty: 0,
-          id: clean.snapshot.id,
-          state: 'ready',
-        },
-      ]);
-    } finally {
-      rmSync(root, {force: true, recursive: true});
-    }
+          expect(clean.snapshot.dirty).toBe(false);
+          expect(clean.snapshot.id).not.toMatch(/-direct$/);
+          expect(persistedSnapshotState(databasePath, interrupted.id)).toBe('retired');
+          expect(persistedSnapshotRowCount(databasePath, interrupted.id, 'symbols')).toBeGreaterThan(0);
+          expect(persistedSnapshots(databasePath)).toEqual([
+            {
+              baseSnapshotId: Option.none(),
+              dirty: 1,
+              id: interrupted.id,
+              state: 'retired',
+            },
+            {
+              baseSnapshotId: Option.none(),
+              dirty: 0,
+              id: clean.snapshot.id,
+              state: 'ready',
+            },
+          ]);
+        }),
+      ({root}) => Effect.sync(() => rmSync(root, {force: true, recursive: true})),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive);
   });
 
   it('switches an interrupted incremental overlay to the disjoint explicit direct snapshot', async () => {

--- a/test/integration/code-graph.incremental.property.test.ts
+++ b/test/integration/code-graph.incremental.property.test.ts
@@ -29,7 +29,7 @@ interface DifferentialScenario {
 
 interface CleanSurfaceChangeScenario {
   readonly fileCount: number;
-  readonly mutation: 'arity' | 'export' | 'rename';
+  readonly mutation: 'arity' | 'callback-argument' | 'export' | 'file-local-function' | 'private-method' | 'rename';
   readonly sourceSeed: number;
 }
 
@@ -60,11 +60,26 @@ const scenarioArbitrary = FC.record({
   } satisfies DifferentialScenario;
 });
 
-const cleanSurfaceChangeScenarioArbitrary = FC.record({
+const surfaceChangeScenarioArbitrary = FC.record({
   fileCount: FC.integer({max: 7, min: 3}),
-  mutation: FC.constantFrom('arity' as const, 'export' as const, 'rename' as const),
+  mutation: FC.constantFrom(
+    'arity' as const,
+    'callback-argument' as const,
+    'export' as const,
+    'file-local-function' as const,
+    'private-method' as const,
+    'rename' as const,
+  ),
   sourceSeed: FC.integer({max: 31, min: 0}),
 });
+
+const cleanSurfaceChangeScenarioArbitrary = surfaceChangeScenarioArbitrary.filter(scenario =>
+  ['arity', 'export', 'rename'].includes(scenario.mutation),
+);
+
+const unpublishedSurfaceChangeScenarioArbitrary = surfaceChangeScenarioArbitrary.filter(scenario =>
+  ['callback-argument', 'file-local-function', 'private-method'].includes(scenario.mutation),
+);
 
 describe('code graph incremental-overlay differential properties', () => {
   it.effect.prop(
@@ -200,6 +215,59 @@ describe('code graph incremental-overlay differential properties', () => {
     {
       fastCheck: {interruptAfterTimeLimit: 180_000, markInterruptAsFailure: true, numRuns: 10},
       timeout: 190_000,
+    },
+  );
+
+  it.effect.prop(
+    'keeps randomized unpublished TypeScript declarations equivalent to a forced dirty rebuild',
+    {scenario: unpublishedSurfaceChangeScenarioArbitrary},
+    ({scenario}) =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => createRepository(simpleScenario(scenario.fileCount))),
+        root =>
+          Effect.gen(function* () {
+            const source = scenario.sourceSeed % scenario.fileCount;
+            const incrementalHome = `${root}-unpublished-incremental-home`;
+            const fullHome = `${root}-unpublished-full-home`;
+            const indexer = yield* CodeGraphIndexer;
+            const path = yield* Path.Path;
+            const store = yield* CodeGraphStore;
+            const base = yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+            yield* Effect.sync(() =>
+              writeSurfaceChangedSource(root, simpleScenario(scenario.fileCount), source, scenario.mutation),
+            );
+            const incremental = yield* indexer.index({cwd: root, threadnoteHome: incrementalHome});
+            const full = yield* indexer.index({cwd: root, incrementalOverlay: false, threadnoteHome: fullHome});
+            const incrementalLayout = codeGraphLayout(
+              path,
+              incrementalHome,
+              incremental.identity.checkoutId,
+              incremental.identity.worktreeId,
+            );
+            const fullLayout = codeGraphLayout(path, fullHome, full.identity.checkoutId, full.identity.worktreeId);
+            const incrementalGraph = yield* store.loadGraph(incrementalLayout.databasePath, incremental.snapshot.id);
+            const fullGraph = yield* store.loadGraph(fullLayout.databasePath, full.snapshot.id);
+
+            expect(incremental.materialization).toMatchObject({
+              mode: 'incremental-overlay',
+              resolutionPublicationGate: 'own-path-local',
+              stagedFiles: 1,
+              totalFiles: scenario.fileCount,
+            });
+            expect(incremental.snapshot).toMatchObject({baseSnapshotId: base.snapshot.id, dirty: true});
+            expect(full.materialization).toMatchObject({fallbackReason: 'disabled', mode: 'full'});
+            expect(normalizeGraph(incrementalGraph)).toEqual(normalizeGraph(fullGraph));
+          }),
+        root =>
+          Effect.sync(() => {
+            rmSync(root, {force: true, recursive: true});
+            rmSync(`${root}-unpublished-incremental-home`, {force: true, recursive: true});
+            rmSync(`${root}-unpublished-full-home`, {force: true, recursive: true});
+          }),
+      ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    {
+      fastCheck: {interruptAfterTimeLimit: 120_000, markInterruptAsFailure: true, numRuns: 6},
+      timeout: 130_000,
     },
   );
 
@@ -865,6 +933,45 @@ function writeSurfaceChangedSource(
   mutation: CleanSurfaceChangeScenario['mutation'],
 ): void {
   const target = differentFile(scenario.baseTargets[source]!, source, scenario.fileCount);
+  if (mutation === 'private-method') {
+    writeFileSync(
+      join(root, 'src', `file-${source}.ts`),
+      [
+        `import {symbol${target}} from './file-${target}.js';`,
+        `class Local${source} {`,
+        `  private privateValue${source}(): number { return symbol${target}(); }`,
+        `  value(): number { return this.privateValue${source}(); }`,
+        '}',
+        `export function symbol${source}(): number { return new Local${source}().value(); }`,
+        '',
+      ].join('\n'),
+    );
+    return;
+  }
+  if (mutation === 'file-local-function') {
+    writeFileSync(
+      join(root, 'src', `file-${source}.ts`),
+      [
+        `import {symbol${target}} from './file-${target}.js';`,
+        `function local${source}(): number { return symbol${target}(); }`,
+        `export function symbol${source}(): number { return local${source}(); }`,
+        '',
+      ].join('\n'),
+    );
+    return;
+  }
+  if (mutation === 'callback-argument') {
+    writeFileSync(
+      join(root, 'src', `file-${source}.ts`),
+      [
+        `import {symbol${target}} from './file-${target}.js';`,
+        `const callback${source} = (): number => symbol${target}();`,
+        `export function symbol${source}(): number { return callback${source}(); }`,
+        '',
+      ].join('\n'),
+    );
+    return;
+  }
   const exported = mutation === 'export' ? '' : 'export ';
   const name = mutation === 'rename' ? `renamed${source}` : `symbol${source}`;
   const parameters = mutation === 'arity' ? 'value: number' : '';

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -1834,11 +1834,19 @@ describe('native code graph lifecycle', () => {
       const local = yield* indexer.index({cwd: localRoot, threadnoteHome: localHome});
       const exported = yield* indexer.index({cwd: exportedRoot, threadnoteHome: exportedHome});
 
-      expect(local.materialization).toEqual({mode: 'incremental-overlay', stagedFiles: 2, totalFiles: 2});
+      expect(local.materialization).toEqual({
+        mode: 'incremental-overlay',
+        resolutionLookupKeyForm: 'typescript-path-unscoped',
+        resolutionPublicationGate: 'own-path-local',
+        stagedFiles: 2,
+        totalFiles: 2,
+      });
       expect(local.snapshot).toMatchObject({baseSnapshotId: localClean.snapshot.id, dirty: true});
       expect(exported.materialization).toEqual({
         fallbackReason: 'resolution-surface-changed',
         mode: 'full',
+        resolutionLookupKeyForm: 'typescript-path-unscoped',
+        resolutionPublicationGate: 'exported',
         stagedFiles: 2,
         totalFiles: 2,
       });
@@ -2086,7 +2094,8 @@ describe('native code graph lifecycle', () => {
             if (!changed && progress.phase === 'activating' && progress.subphase === 'promoting') {
               staleSnapshotId = progress.snapshotId;
               changed = true;
-              replaceFunction(root, 'ensureVectorIndex', 'ensureRacedVectorIndex');
+              const sourcePath = join(root, 'packages/search/src/vector-index.ts');
+              writeFileSync(sourcePath, readFileSync(sourcePath, 'utf8').replace('vectors-ready', 'vectors-raced'));
             }
           }),
         threadnoteHome: home,
@@ -2094,7 +2103,7 @@ describe('native code graph lifecycle', () => {
       const inspected = yield* query.inspect({
         cwd: root,
         operation: 'query',
-        query: 'ensureRacedVectorIndex',
+        query: 'ensureVectorIndex',
         refresh: false,
         threadnoteHome: home,
       });
@@ -2105,12 +2114,199 @@ describe('native code graph lifecycle', () => {
       const staleGraph = stale ? yield* store.loadGraph(databasePath, stale.id) : undefined;
       const active = yield* store.readySnapshot(databasePath, current.identity.worktreeId);
       expect(inspected.freshness).toBe('deferred');
-      expect(inspected.nodes.some(node => node.name === 'ensureRacedVectorIndex')).toBe(true);
+      expect(inspected.nodes.some(node => node.name === 'ensureVectorIndex')).toBe(true);
       expect(stale).toMatchObject({commit: initialCommit, id: staleSnapshotId, state: 'ready'});
       expect(stale?.id).not.toBe(current.snapshot.id);
       expect(staleGraph?.symbols.some(symbol => symbol.name === 'ensureVectorIndex')).toBe(true);
-      expect(staleGraph?.symbols.some(symbol => symbol.name === 'ensureRacedVectorIndex')).toBe(false);
       expect(active?.id).toBe(current.snapshot.id);
+      expect(current.materialization).toMatchObject({mode: 'incremental-overlay', stagedFiles: 1});
+      expect(snapshotFileHash(databasePath, staleSnapshotId!, 'packages/search/src/vector-index.ts')).not.toBe(
+        snapshotFileHash(databasePath, current.snapshot.id, 'packages/search/src/vector-index.ts'),
+      );
+      const database = new Database(databasePath, {readonly: true});
+      try {
+        const retainedLease = database
+          .query<{readonly expires_at: number; readonly token: string}, [string]>(
+            "SELECT token, expires_at FROM snapshot_leases WHERE snapshot_id = ? AND token GLOB 'retained-base:*'",
+          )
+          .get(staleSnapshotId!);
+        expect(retainedLease?.token).toMatch(/^retained-base:/u);
+        expect(Number(retainedLease?.expires_at) - Date.now()).toBeGreaterThan(32 * 60_000);
+        expect(Number(retainedLease?.expires_at) - Date.now()).toBeLessThanOrEqual(45 * 60_000);
+      } finally {
+        database.close();
+      }
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('reuses a retained dirty full root for the post-target bounded overlay', () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.sync(createPublishedSurfaceRepository);
+      const home = join(root, '.threadnote-test-home');
+      const sourcePath = join(root, 'src/service.ts');
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      yield* indexer.index({cwd: root, threadnoteHome: home});
+      yield* Effect.sync(() => {
+        writeFileSync(
+          sourcePath,
+          `${readFileSync(sourcePath, 'utf8')}\nexport function retainedPublishedValue(): number { return 2; }\n`,
+        );
+      });
+
+      let retainedSnapshotId: string | undefined;
+      const current = yield* indexer.index({
+        cwd: root,
+        onProgress: progress =>
+          Effect.sync(() => {
+            if (
+              retainedSnapshotId === undefined &&
+              progress.phase === 'activating' &&
+              progress.subphase === 'promoting'
+            ) {
+              retainedSnapshotId = progress.snapshotId;
+              writeFileSync(sourcePath, readFileSync(sourcePath, 'utf8').replace('return 2;', 'return 3;'));
+            }
+          }),
+        threadnoteHome: home,
+      });
+
+      expect(retainedSnapshotId).toBeDefined();
+      expect(current.materialization).toMatchObject({mode: 'incremental-overlay', stagedFiles: 1});
+      expect(current.snapshot.baseSnapshotId).toBe(retainedSnapshotId);
+      const databasePath = codeGraphDatabasePath(home, current);
+      const retained = yield* store.currentLexicalReadySnapshotById(databasePath, retainedSnapshotId!);
+      expect(retained).toMatchObject({baseSnapshotId: undefined, dirty: true, state: 'ready'});
+      const currentGraph = yield* store.loadGraph(databasePath, current.snapshot.id);
+
+      const forced = yield* indexer.index({
+        cwd: root,
+        force: true,
+        incrementalOverlay: false,
+        threadnoteHome: home,
+      });
+      const forcedGraph = yield* store.loadGraph(databasePath, forced.snapshot.id);
+      expect(forced.materialization).toMatchObject({fallbackReason: 'forced-full-rebuild', mode: 'full'});
+      expect(normalizeStoredGraph(currentGraph)).toEqual(normalizeStoredGraph(forcedGraph));
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('leaves a post-promotion snapshot active and retained when the retry also drifts', () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.sync(createFixtureRepository);
+      const home = join(root, '.threadnote-test-home');
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const baseline = yield* indexer.index({cwd: root, threadnoteHome: home});
+      const sourcePath = join(root, 'packages/search/src/vector-index.ts');
+      yield* Effect.sync(() => {
+        writeFileSync(sourcePath, readFileSync(sourcePath, 'utf8').replace('vectors-ready', 'vectors-before-race'));
+      });
+      let promotingEvents = 0;
+      let postPromotedSnapshotId: string | undefined;
+      let postPromoteMutation = false;
+      let retryMutation = false;
+      const exit = yield* Effect.exit(
+        indexer.index({
+          cwd: root,
+          onProgress: progress =>
+            Effect.sync(() => {
+              if (progress.phase === 'activating' && progress.subphase === 'promoting') {
+                promotingEvents += 1;
+                if (promotingEvents === 2) {
+                  postPromotedSnapshotId = progress.snapshotId;
+                  postPromoteMutation = true;
+                  writeFileSync(
+                    sourcePath,
+                    readFileSync(sourcePath, 'utf8').replace('vectors-before-race', 'vectors-raced-once'),
+                  );
+                }
+              } else if (
+                postPromoteMutation &&
+                !retryMutation &&
+                progress.phase === 'activating' &&
+                progress.subphase === 'validating-input'
+              ) {
+                retryMutation = true;
+                writeFileSync(
+                  sourcePath,
+                  readFileSync(sourcePath, 'utf8').replace('vectors-raced-once', 'vectors-raced-twice'),
+                );
+              }
+            }),
+          threadnoteHome: home,
+        }),
+      );
+
+      expect(exit._tag).toBe('Failure');
+      expect(postPromotedSnapshotId).toBeDefined();
+      expect(retryMutation).toBe(true);
+      const databasePath = codeGraphDatabasePath(home, baseline);
+      const active = yield* store.readySnapshot(databasePath, baseline.identity.worktreeId);
+      const postPromoted = yield* store.currentLexicalReadySnapshotById(databasePath, postPromotedSnapshotId!);
+      expect(active?.id).toBe(postPromotedSnapshotId);
+      expect(postPromoted).toMatchObject({dirty: true, id: postPromotedSnapshotId, state: 'ready'});
+      const database = new Database(databasePath, {readonly: true});
+      try {
+        expect(
+          database
+            .query<{readonly token: string}, [string]>(
+              "SELECT token FROM snapshot_leases WHERE snapshot_id = ? AND token GLOB 'retained-base:*'",
+            )
+            .get(postPromotedSnapshotId!)?.token,
+        ).toMatch(/^retained-base:/u);
+      } finally {
+        database.close();
+      }
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('retains a clean alias and its source when input drifts before alias promotion', () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.sync(createFixtureRepository);
+      const home = join(root, '.threadnote-test-home');
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const baseline = yield* indexer.index({cwd: root, threadnoteHome: home});
+      yield* Effect.sync(() => {
+        execFileSync('git', ['-C', root, 'commit', '--allow-empty', '-m', 'alias target']);
+      });
+      let changed = false;
+      let aliasId: string | undefined;
+      const current = yield* indexer.index({
+        cwd: root,
+        onProgress: progress =>
+          Effect.sync(() => {
+            if (!changed && progress.phase === 'activating' && progress.subphase === 'promoting') {
+              changed = true;
+              aliasId = progress.snapshotId;
+              const sourcePath = join(root, 'packages/search/src/vector-index.ts');
+              writeFileSync(sourcePath, `${readFileSync(sourcePath, 'utf8')}\n// alias promotion race\n`);
+            }
+          }),
+        threadnoteHome: home,
+      });
+
+      expect(changed).toBe(true);
+      expect(aliasId).toBeDefined();
+      const databasePath = codeGraphDatabasePath(home, baseline);
+      const alias = yield* store.currentLexicalReadySnapshotById(databasePath, aliasId!);
+      const source = yield* store.currentLexicalReadySnapshotById(databasePath, baseline.snapshot.id);
+      expect(alias).toMatchObject({baseSnapshotId: baseline.snapshot.id, dirty: false, id: aliasId, state: 'ready'});
+      expect(source).toMatchObject({id: baseline.snapshot.id, state: 'ready'});
+      expect(current.snapshot.id).not.toBe(aliasId);
+      const database = new Database(databasePath, {readonly: true});
+      try {
+        expect(
+          database
+            .query<{readonly token: string}, [string]>(
+              "SELECT token FROM snapshot_leases WHERE snapshot_id = ? AND token GLOB 'retained-base:*'",
+            )
+            .get(aliasId!)?.token,
+        ).toMatch(/^retained-base:/u);
+      } finally {
+        database.close();
+      }
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
@@ -2138,33 +2334,18 @@ describe('native code graph lifecycle', () => {
       expect(current.snapshot.dirty).toBe(true);
       const completedReclamation = reclamationProgress.at(-1);
       expect(completedReclamation).toMatchObject({unit: 'snapshots'});
-      expect(completedReclamation?.completed).toBe(completedReclamation?.total);
+      expect(completedReclamation?.pagesCompleted).toBe(1);
+      expect(completedReclamation?.completed).toBeLessThanOrEqual(completedReclamation?.total ?? 0);
       expect(completedReclamation?.rowsDeleted).toBeGreaterThan(0);
       const database = new Database(codeGraphDatabasePath(home, current), {readonly: true, strict: true});
       try {
         const retired = database
           .query<{readonly count: number}, []>("SELECT COUNT(*) AS count FROM snapshots WHERE state = 'retired'")
           .get();
-        const retiredSymbols = database
-          .query<{readonly count: number}, []>(
-            `SELECT COUNT(*) AS count
-             FROM symbols AS symbol
-             JOIN snapshots AS snapshot ON snapshot.id = symbol.snapshot_id
-             WHERE snapshot.state = 'retired'`,
-          )
-          .get();
-        const retiredEdges = database
-          .query<{readonly count: number}, []>(
-            `SELECT COUNT(*) AS count
-             FROM edges AS edge
-             JOIN snapshots AS snapshot ON snapshot.id = edge.snapshot_id
-             WHERE snapshot.state = 'retired'`,
-          )
-          .get();
-        expect(retired?.count).toBe(0);
-        expect(retiredSymbols?.count).toBe(0);
-        expect(retiredEdges?.count).toBe(0);
-        expect(database.query('SELECT id FROM snapshots').all()).toEqual([{id: current.snapshot.id}]);
+        expect(retired?.count).toBe(1);
+        expect(database.query("SELECT id FROM snapshots WHERE state = 'ready'").all()).toEqual([
+          {id: current.snapshot.id},
+        ]);
         expect(database.query('PRAGMA foreign_key_check').all()).toEqual([]);
       } finally {
         database.close(false);

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -2269,7 +2269,18 @@ describe('native code graph lifecycle', () => {
       const store = yield* CodeGraphStore;
       const baseline = yield* indexer.index({cwd: root, threadnoteHome: home});
       yield* Effect.sync(() => {
-        execFileSync('git', ['-C', root, 'commit', '--allow-empty', '-m', 'alias target']);
+        execFileSync('git', [
+          '-C',
+          root,
+          '-c',
+          'user.name=Threadnote Test',
+          '-c',
+          'user.email=test@threadnote.local',
+          'commit',
+          '--allow-empty',
+          '-m',
+          'alias target',
+        ]);
       });
       let changed = false;
       let aliasId: string | undefined;

--- a/test/integration/code-graph.project-closure.test.ts
+++ b/test/integration/code-graph.project-closure.test.ts
@@ -239,6 +239,8 @@ describe('project-closure incremental indexing', () => {
             closureProjects: 3,
             mode: 'incremental-overlay',
             resolutionClosure: 'project',
+            resolutionLookupKeyForm: 'typescript-path-scoped',
+            resolutionPublicationGate: 'exported',
             stagedFiles: 6,
             totalFiles: 11,
           });

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -137,26 +137,6 @@ async function callCodeGraphUntilReady(client: Client, arguments_: Readonly<Reco
   }
 }
 
-async function callCodeGraphUntilCurrent(client: Client, arguments_: Readonly<Record<string, unknown>>) {
-  const deadline = Date.now() + 30_000;
-  for (;;) {
-    const result = await client.callTool({arguments: arguments_, name: 'inspect_code_graph'}, undefined, {
-      timeout: 10_000,
-    });
-    const structured = result.structuredContent as
-      {readonly freshness?: unknown; readonly retryAfterMilliseconds?: unknown; readonly state?: unknown} | undefined;
-    if (structured?.freshness === 'current' && !isRetryableCodeGraphState(structured.state)) return result;
-    if (Date.now() >= deadline) {
-      throw new TestError(
-        `Code graph did not become current within 30 seconds: ${JSON.stringify(result.structuredContent)}.`,
-      );
-    }
-    const requestedDelay =
-      typeof structured?.retryAfterMilliseconds === 'number' ? structured.retryAfterMilliseconds : 250;
-    await new Promise(resolve => setTimeout(resolve, Math.max(50, Math.min(1_000, requestedDelay))));
-  }
-}
-
 function isRetryableCodeGraphState(state: unknown): boolean {
   return state === 'indexing' || state === 'timed-out' || state === 'timed_out';
 }
@@ -1637,7 +1617,14 @@ describe('Threadnote MCP toolsets', () => {
           expect(editedStructured?.state).toBeUndefined();
           expect(['current', 'stale']).toContain(editedStructured?.freshness);
 
-          const refreshed = await callCodeGraphUntilCurrent(client, {
+          const refresh = await callCodeGraphUntilReady(client, {
+            base: 'HEAD',
+            callerCwd: worktree,
+            operation: 'impact',
+          });
+          expect(refresh.structuredContent).toMatchObject({freshness: 'current', operation: 'impact'});
+
+          const refreshed = await callCodeGraphUntilReady(client, {
             callerCwd: worktree,
             operation: 'query',
             query: repositoryFixture.after,
@@ -1655,7 +1642,7 @@ describe('Threadnote MCP toolsets', () => {
     );
   }, 120_000);
 
-  it('keeps inspected repositories fresh with one MCP-session watcher', async () => {
+  it('keeps ordinary watched reads stale until an explicit current inspection', async () => {
     await withMcpClient(
       async (client, fixture) => {
         const repository = join(fixture.root, 'watched-repository');
@@ -1693,42 +1680,38 @@ describe('Threadnote MCP toolsets', () => {
           'export function afterSessionWatch(): string { return "after"; }\n',
           'utf8',
         );
-        let refreshed: typeof first | undefined;
-        let lastCandidate: typeof first | undefined;
-        const deadline = Date.now() + 20_000;
-        while (Date.now() < deadline) {
-          await new Promise(resolve => setTimeout(resolve, 250));
-          const candidate = await client.callTool(
-            {
-              arguments: {callerCwd: repository, operation: 'query', query: 'afterSessionWatch'},
-              name: 'inspect_code_graph',
-            },
-            undefined,
-            {timeout: 5_000},
-          );
-          lastCandidate = candidate;
-          const structured = candidate.structuredContent as
-            | {
-                readonly freshness?: unknown;
-                readonly nodes?: readonly {readonly name?: unknown}[];
-                readonly snapshot?: {readonly id?: unknown};
-              }
-            | undefined;
-          if (
-            structured?.freshness === 'current' &&
-            structured.nodes?.some(node => node.name === 'afterSessionWatch') &&
-            structured.snapshot?.id !== firstSnapshotId
-          ) {
-            refreshed = candidate;
-            break;
-          }
-        }
-        expect(refreshed?.structuredContent, JSON.stringify(lastCandidate)).toMatchObject({
+        await new Promise(resolve => setTimeout(resolve, 500));
+        const stale = await client.callTool(
+          {
+            arguments: {callerCwd: repository, operation: 'query', query: 'afterSessionWatch'},
+            name: 'inspect_code_graph',
+          },
+          undefined,
+          {timeout: 5_000},
+        );
+        expect(stale.structuredContent).toMatchObject({
+          freshness: 'stale',
+          snapshot: {id: firstSnapshotId},
+        });
+
+        const refresh = await callCodeGraphUntilReady(client, {
+          base: 'HEAD',
+          callerCwd: repository,
+          operation: 'impact',
+        });
+        expect(refresh.structuredContent).toMatchObject({freshness: 'current', operation: 'impact'});
+
+        const refreshed = await callCodeGraphUntilReady(client, {
+          callerCwd: repository,
+          operation: 'query',
+          query: 'afterSessionWatch',
+        });
+        expect(refreshed.structuredContent).toMatchObject({
           freshness: 'current',
           nodes: expect.arrayContaining([expect.objectContaining({name: 'afterSessionWatch'})]),
         });
         expect(
-          (refreshed?.structuredContent as {readonly snapshot?: {readonly id?: unknown}} | undefined)?.snapshot?.id,
+          (refreshed.structuredContent as {readonly snapshot?: {readonly id?: unknown}} | undefined)?.snapshot?.id,
         ).not.toBe(firstSnapshotId);
 
         const removed = await client.callTool(

--- a/test/unit/code-graph.builder-admission.test.ts
+++ b/test/unit/code-graph.builder-admission.test.ts
@@ -1,0 +1,98 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Deferred, Effect, Fiber, Layer, Ref} from 'effect';
+import {TestClock} from 'effect/testing';
+import {afterEach, beforeEach, describe, expect} from 'vitest';
+import {withCodeGraphBuilderAdmission} from '../../src/code_graph/builder_admission.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {mkdtemp, rm} from '../helpers/effect-filesystem.js';
+
+const BUILDER_ADMISSION_TEST_LAYER = SystemInfo.layer.pipe(Layer.provideMerge(BunServices.layer));
+
+describe('code graph home builder admission', () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp('threadnote-builder-admission-');
+  });
+
+  afterEach(async () => {
+    await rm(home, {force: true, recursive: true});
+  });
+
+  effectIt.effect('admits two builders and gives the next slot to queued current-required work', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const trace = yield* Ref.make<string[]>([]);
+        const occupied = yield* Ref.make(0);
+        const twoOccupied = yield* Deferred.make<void>();
+        const releaseFirst = yield* Deferred.make<void>();
+        const releaseSecond = yield* Deferred.make<void>();
+        const releaseCurrent = yield* Deferred.make<void>();
+        const releaseBackground = yield* Deferred.make<void>();
+        const backgroundWaiting = yield* Deferred.make<void>();
+        const currentWaiting = yield* Deferred.make<void>();
+        const currentStarted = yield* Deferred.make<void>();
+        const backgroundStarted = yield* Deferred.make<void>();
+
+        const occupant = (name: string, release: Deferred.Deferred<void>) =>
+          withCodeGraphBuilderAdmission(
+            {admissionClass: 'background', threadnoteHome: home},
+            Effect.gen(function* () {
+              yield* Ref.update(trace, values => [...values, name]);
+              if ((yield* Ref.updateAndGet(occupied, value => value + 1)) === 2) {
+                yield* Deferred.succeed(twoOccupied, undefined);
+              }
+              yield* Deferred.await(release);
+            }),
+          );
+
+        const firstFiber = yield* occupant('background-1', releaseFirst).pipe(Effect.forkChild);
+        const secondFiber = yield* occupant('background-2', releaseSecond).pipe(Effect.forkChild);
+        yield* Deferred.await(twoOccupied);
+
+        const backgroundFiber = yield* withCodeGraphBuilderAdmission(
+          {
+            admissionClass: 'background',
+            onWaiting: Deferred.succeed(backgroundWaiting, undefined).pipe(Effect.asVoid),
+            threadnoteHome: home,
+          },
+          Ref.update(trace, values => [...values, 'background-queued']).pipe(
+            Effect.andThen(Deferred.succeed(backgroundStarted, undefined)),
+            Effect.andThen(Deferred.await(releaseBackground)),
+          ),
+        ).pipe(Effect.forkChild);
+        yield* Deferred.await(backgroundWaiting);
+
+        const currentFiber = yield* withCodeGraphBuilderAdmission(
+          {
+            admissionClass: 'current-required',
+            onWaiting: Deferred.succeed(currentWaiting, undefined).pipe(Effect.asVoid),
+            threadnoteHome: home,
+          },
+          Ref.update(trace, values => [...values, 'current']).pipe(
+            Effect.andThen(Deferred.succeed(currentStarted, undefined)),
+            Effect.andThen(Deferred.await(releaseCurrent)),
+          ),
+        ).pipe(Effect.forkChild);
+        yield* Deferred.await(currentWaiting);
+
+        yield* Deferred.succeed(releaseFirst, undefined);
+        yield* Deferred.await(currentStarted);
+        expect(yield* Deferred.isDone(backgroundStarted)).toBe(false);
+        expect(yield* Ref.get(trace)).toEqual(expect.arrayContaining(['background-1', 'background-2', 'current']));
+
+        yield* Deferred.succeed(releaseCurrent, undefined);
+        yield* Deferred.await(backgroundStarted);
+        yield* Deferred.succeed(releaseBackground, undefined);
+        yield* Deferred.succeed(releaseSecond, undefined);
+        yield* Effect.all([firstFiber, secondFiber, currentFiber, backgroundFiber].map(Fiber.join), {
+          concurrency: 'unbounded',
+          discard: true,
+        });
+        expect((yield* Ref.get(trace)).at(-1)).toBe('background-queued');
+      }).pipe(provideTestLayer(BUILDER_ADMISSION_TEST_LAYER)),
+    ),
+  );
+});

--- a/test/unit/code-graph.incomplete-retirement.test.ts
+++ b/test/unit/code-graph.incomplete-retirement.test.ts
@@ -148,7 +148,7 @@ describe('code graph incomplete snapshot retirement', () => {
     }
   });
 
-  it('reclaims prior multi-page direct-build rows while yielding the writer gate to foreground work', async () => {
+  it('page-budgets required direct-build cleanup before yielding to foreground work', async () => {
     const root = await mkdtemp('threadnote-incomplete-reclaim-');
     temporaryRoots.push(root);
     const databasePath = join(root, 'graph-v3.sqlite');
@@ -235,41 +235,28 @@ describe('code graph incomplete snapshot retirement', () => {
     );
 
     expect(result.retired).toBe(0);
-    expect(result.acquisitions).toBeGreaterThan(3);
-    expect(result.progress.length).toBeGreaterThan(4);
+    expect(result.acquisitions).toBe(2);
+    expect(result.progress).toHaveLength(2);
     expect(result.progress[0]).toEqual({
       pagesCompleted: 0,
       rowsDeleted: 0,
       snapshotsCompleted: 0,
       snapshotsTotal: 1,
     });
-    expect(result.progress.slice(1).map(update => update.pagesCompleted)).toEqual(
-      result.progress.slice(1).map((_, index) => index + 1),
-    );
+    expect(result.progress[1]?.pagesCompleted).toBe(1);
     expect(result.progress.every(update => update.snapshotsTotal === 1)).toBe(true);
-    expect(result.progress.at(-1)).toMatchObject({
-      rowsDeleted: 13_501,
-      snapshotsCompleted: 1,
-      snapshotsTotal: 1,
-    });
-    for (let index = 1; index < result.progress.length; index += 1) {
-      expect(result.progress[index]!.rowsDeleted).toBeGreaterThanOrEqual(result.progress[index - 1]!.rowsDeleted);
-    }
+    expect(result.progress[1]?.rowsDeleted).toBeGreaterThan(0);
+    expect(result.progress[1]?.rowsDeleted).toBeLessThan(13_501);
+    expect(result.progress[1]?.snapshotsCompleted).toBe(0);
     const database = new Database(databasePath, {readonly: true});
     try {
-      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(stale.id)).toBeNull();
+      expect(database.query('SELECT state FROM snapshots WHERE id = ?').get(stale.id)).toEqual({state: 'retired'});
       expect(
         database
           .query<{readonly state: string}, [string]>('SELECT state FROM snapshots WHERE id = ?')
           .get(foreground.id),
       ).toEqual({state: 'building'});
-      for (const table of ['symbols', 'symbol_terms', 'edges'] as const) {
-        expect(
-          database
-            .query<{readonly count: number}, [string]>(`SELECT COUNT(*) AS count FROM ${table} WHERE snapshot_id = ?`)
-            .get(stale.id)?.count,
-        ).toBe(0);
-      }
+      expect(interruptedRowCount(databasePath, stale.id)).toBeGreaterThan(0);
       expect(database.query('PRAGMA foreign_key_check').all()).toEqual([]);
     } finally {
       database.close();

--- a/test/unit/code-graph.incremental.property.test.ts
+++ b/test/unit/code-graph.incremental.property.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from '@effect/vitest';
 import * as FC from 'effect/testing/FastCheck';
 import {createResolutionAttributor} from '../../src/code_graph/extractor.js';
 import {hasSameCodeGraphResolutionSurface} from '../../src/code_graph/indexer.js';
+import {assessCodeGraphResolutionSymbolPublication} from '../../src/code_graph/resolution_surface.js';
 import type {CodeGraphFileFacts, CodeGraphInventoryFile, CodeGraphSymbol} from '../../src/code_graph/types.js';
 
 const optionalText = FC.oneof(FC.constant(undefined), FC.string({maxLength: 24}));
@@ -98,6 +99,50 @@ const pathLocalTypeScriptSymbolArbitrary = FC.record({
 });
 
 describe('code graph incremental-overlay properties', () => {
+  it('classifies scoped and unscoped own-path TypeScript keys without leaking lookup values', () => {
+    const path = 'packages/private/src/fixture.ts';
+    const scoped: CodeGraphSymbol = {
+      arity: 1,
+      contentHash: 'content',
+      exported: false,
+      id: 'local-private-method',
+      kind: 'method',
+      language: 'typescript',
+      lookupKeys: [],
+      name: 'privateMethod',
+      path,
+      qualifiedName: 'Fixture.privateMethod',
+      resolutionDomain: 'typescript',
+      resolutionScopeId: 'project-a',
+      span: {column: 1, endColumn: 2, endLine: 1, line: 1},
+    };
+    const unscoped = {
+      ...scoped,
+      lookupKeys: typescriptPathLocalLookupKeys(path, scoped.name, scoped.qualifiedName, undefined, scoped.arity),
+    };
+    const scopedWithKeys = {
+      ...scoped,
+      lookupKeys: typescriptPathLocalLookupKeys(path, scoped.name, scoped.qualifiedName, 'project-a', scoped.arity),
+    };
+
+    expect(assessCodeGraphResolutionSymbolPublication(unscoped)).toEqual({
+      gate: 'own-path-local',
+      lookupKeyForm: 'typescript-path-unscoped',
+      published: false,
+    });
+    expect(assessCodeGraphResolutionSymbolPublication(scopedWithKeys)).toEqual({
+      gate: 'own-path-local',
+      lookupKeyForm: 'typescript-path-scoped',
+      published: false,
+    });
+    expect(
+      assessCodeGraphResolutionSymbolPublication({
+        ...scopedWithKeys,
+        lookupKeys: typescriptPathLocalLookupKeys(path, scoped.name, scoped.qualifiedName, 'project-b', scoped.arity),
+      }),
+    ).toMatchObject({gate: 'scope-mismatch', published: true});
+  });
+
   it('does not synthesize active global endpoints for TypeScript while preserving explicit extractor keys', () => {
     const path = 'src/example.ts';
     const ownKey = `typescript:path:${encodeURIComponent(path)}:name:local`;

--- a/test/unit/code-graph.isolated-builder.test.ts
+++ b/test/unit/code-graph.isolated-builder.test.ts
@@ -1,8 +1,9 @@
 import {TestError} from '../helpers/test-error.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
 import {it as effectIt} from '@effect/vitest';
 import {describe, expect, it} from 'vitest';
 import fc from 'fast-check';
-import {Effect, Fiber} from 'effect';
+import {Deferred, Effect, Fiber} from 'effect';
 import {TestClock} from 'effect/testing';
 import {
   assertIsolatedBuilderPlan,
@@ -11,6 +12,7 @@ import {
   codeGraphProgressFromBuildStatus,
   isCodeGraphIsolatedBuilderHost,
   isolatedBuilderFailureMessage,
+  isolatedBuilderRequestMatches,
   isolatedBuilderResultFromCompletedStatus,
   runIsolatedCodeGraphIndex,
   shouldAwaitExistingBuilder,
@@ -21,6 +23,10 @@ import type {ObservedCodeGraphBuildStatus} from '../../src/code_graph/build_stat
 import {CodeGraphRuntimeReconnectRequiredError, type RepositoryIdentity} from '../../src/code_graph/types.js';
 import type {SystemInfoShape} from '../../src/effect/system.js';
 import {runEffect} from '../helpers/effect-runtime.js';
+import {mkdtempSync, rmSync} from '../helpers/node-fs.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 
 function systemInfoStub(overrides: Partial<SystemInfoShape>): SystemInfoShape {
   return {
@@ -105,6 +111,13 @@ describe('isolated code-graph builder host detection', () => {
 });
 
 describe('isolated code-graph builder spawn plan', () => {
+  it('reuses completed results only for exact request-key equality', () => {
+    const status = {request: {key: 'request-a'}} as ObservedCodeGraphBuildStatus;
+    expect(isolatedBuilderRequestMatches(status, 'request-a')).toBe(true);
+    expect(isolatedBuilderRequestMatches(status, 'request-b')).toBe(false);
+    expect(isolatedBuilderRequestMatches(status, undefined)).toBe(false);
+  });
+
   it('checks runtime compatibility before observing or spawning a child', async () => {
     const identity: RepositoryIdentity = {
       caseMode: 'sensitive',
@@ -166,6 +179,7 @@ describe('isolated code-graph builder spawn plan', () => {
     ]);
     expect(plan.environment).toEqual({
       PATH: '/usr/bin',
+      THREADNOTE_CODE_GRAPH_BUILDER_ADMISSION_CLASS: 'current-required',
       THREADNOTE_HOME: '/home/.threadnote',
       THREADNOTE_TELEMETRY_CHILD: 'graph-builder',
       THREADNOTE_TELEMETRY_CONSENT_GENERATION: 'tng_000102030405060708090a0b0c0d0e0f',
@@ -275,6 +289,7 @@ describe('codeGraphProgressFromBuildStatus', () => {
     const allowedWaiting = new Set([
       'database-writer',
       'disk-capacity',
+      'home-builder-cap',
       'repository-lock',
       'request-lock',
       'snapshot-build',
@@ -321,6 +336,32 @@ describe('codeGraphProgressFromBuildStatus', () => {
 });
 
 describe('shouldAwaitExistingBuilder and statusBelongsToChild', () => {
+  it('elects exactly one owner for every cross-host observe-then-spawn permutation', () => {
+    fc.assert(
+      fc.property(fc.uniqueArray(fc.integer({max: 10_000, min: 2}), {maxLength: 20, minLength: 1}), callers => {
+        let status: ObservedCodeGraphBuildStatus | undefined;
+        let owners = 0;
+        const waiters: number[] = [];
+        for (const processId of callers) {
+          if (shouldAwaitExistingBuilder(status, processId)) {
+            waiters.push(processId);
+            continue;
+          }
+          owners += 1;
+          status = {
+            observation: {heartbeatAgeMilliseconds: 0, liveness: 'active'},
+            owner: {processId, runtime: 'bun', runtimeVersion: '1'},
+          } as ObservedCodeGraphBuildStatus;
+        }
+
+        expect(owners).toBe(1);
+        const completedSnapshotId = 'owner-snapshot';
+        expect(waiters.map(() => completedSnapshotId)).toEqual(callers.slice(1).map(() => completedSnapshotId));
+      }),
+      {numRuns: 100},
+    );
+  });
+
   it('awaits active and stalled foreign builders only', () => {
     const livenessValues = ['abandoned', 'active', 'completed', 'failed', 'stalled'] as const;
     fc.assert(
@@ -506,5 +547,193 @@ describe('isolated builder exit contracts', () => {
         expect(reads).toBe(statuses.length);
       }),
     {fastCheck: {numRuns: 60}},
+  );
+});
+
+describe('isolated builder cross-host spawn admission', () => {
+  effectIt.effect('spawns once for concurrent callers on one worktree and attaches the waiter', () =>
+    TestClock.withLive(
+      Effect.acquireUseRelease(
+        Effect.sync(() => mkdtempSync(join(tmpdir(), 'threadnote-isolated-spawn-'))),
+        home =>
+          Effect.gen(function* () {
+            const identity: RepositoryIdentity = {
+              caseMode: 'sensitive',
+              checkoutId: 'a'.repeat(64),
+              displayName: 'fixture/repository',
+              gitCommonDirectory: '/fixture/repository/.git',
+              headCommit: 'b'.repeat(40),
+              objectFormat: 'sha1',
+              repoRoot: '/fixture/repository',
+              repositoryId: 'c'.repeat(64),
+              worktreeId: 'd'.repeat(64),
+            };
+            let status: ObservedCodeGraphBuildStatus | undefined;
+            let resolveExit: ((code: number) => void) | undefined;
+            let spawnCalls = 0;
+            const waiterAttached = yield* Deferred.make<void>();
+            const activeStatus = {
+              buildId: 'owned-build',
+              counters: {},
+              identity: {
+                checkoutId: identity.checkoutId,
+                commit: identity.headCommit,
+                repositoryId: identity.repositoryId,
+                worktreeId: identity.worktreeId,
+              },
+              observation: {heartbeatAgeMilliseconds: 0, liveness: 'active'},
+              owner: {processId: 77, runtime: 'bun' as const, runtimeVersion: '1'},
+              phase: 'registering' as const,
+              request: {key: 'request-a'},
+              schemaVersion: 2,
+              state: 'running' as const,
+              timestamps: {
+                heartbeatAt: new Date().toISOString(),
+                lastProgressAt: new Date().toISOString(),
+                phaseStartedAt: new Date().toISOString(),
+                startedAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            } as unknown as ObservedCodeGraphBuildStatus;
+            const options = {
+              assertRuntimeSchemaCompatible: () => Effect.void,
+              cwd: identity.repoRoot,
+              readStatus: Effect.sync(() => status),
+              resolveIdentity: () => Effect.succeed(identity),
+              requestKey: 'request-a',
+              spawn: () => {
+                spawnCalls += 1;
+                status = activeStatus;
+                return {
+                  exited: new Promise<number>(resolve => {
+                    resolveExit = resolve;
+                  }),
+                  kill: () => undefined,
+                  processId: 77,
+                };
+              },
+              threadnoteHome: home,
+            };
+
+            const owner = yield* runIsolatedCodeGraphIndex(options).pipe(Effect.forkChild);
+            while (spawnCalls < 1 || resolveExit === undefined) yield* Effect.yieldNow;
+            const waiter = yield* runIsolatedCodeGraphIndex({
+              ...options,
+              onProgress: progress =>
+                progress.phase === 'registering'
+                  ? Deferred.succeed(waiterAttached, undefined).pipe(Effect.asVoid)
+                  : Effect.void,
+            }).pipe(Effect.forkChild);
+            yield* Deferred.await(waiterAttached);
+            status = {
+              ...activeStatus,
+              observation: {heartbeatAgeMilliseconds: 0, liveness: 'completed'},
+              result: {dirty: false, edges: 11, files: 2, snapshotId: 'snapshot', symbols: 7},
+              state: 'completed',
+            } as ObservedCodeGraphBuildStatus;
+            resolveExit(0);
+
+            expect(yield* Effect.all([Fiber.join(owner), Fiber.join(waiter)], {concurrency: 'unbounded'})).toEqual([
+              {edges: 11, symbols: 7},
+              {edges: 11, symbols: 7},
+            ]);
+            expect(spawnCalls).toBe(1);
+          }),
+        home => Effect.sync(() => rmSync(home, {force: true, recursive: true})),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
+
+  effectIt.effect('serializes differing request targets and never reuses the first result as fresh', () =>
+    TestClock.withLive(
+      Effect.acquireUseRelease(
+        Effect.sync(() => mkdtempSync(join(tmpdir(), 'threadnote-isolated-targets-'))),
+        home =>
+          Effect.gen(function* () {
+            const identity: RepositoryIdentity = {
+              caseMode: 'sensitive',
+              checkoutId: 'a'.repeat(64),
+              displayName: 'fixture/repository',
+              gitCommonDirectory: '/fixture/repository/.git',
+              headCommit: 'b'.repeat(40),
+              objectFormat: 'sha1',
+              repoRoot: '/fixture/repository',
+              repositoryId: 'c'.repeat(64),
+              worktreeId: 'd'.repeat(64),
+            };
+            let status: ObservedCodeGraphBuildStatus | undefined;
+            const exits: Array<(code: number) => void> = [];
+            let spawnCalls = 0;
+            const runningStatus = (ordinal: number) =>
+              ({
+                buildId: `owned-build-${ordinal}`,
+                counters: {},
+                identity: {
+                  checkoutId: identity.checkoutId,
+                  commit: identity.headCommit,
+                  repositoryId: identity.repositoryId,
+                  worktreeId: identity.worktreeId,
+                },
+                observation: {heartbeatAgeMilliseconds: 0, liveness: 'active'},
+                owner: {processId: 77 + ordinal, runtime: 'bun' as const, runtimeVersion: '1'},
+                phase: 'registering' as const,
+                request: {key: ordinal === 0 ? 'request-a' : 'request-b'},
+                schemaVersion: 2,
+                state: 'running' as const,
+                timestamps: {
+                  heartbeatAt: new Date().toISOString(),
+                  lastProgressAt: new Date().toISOString(),
+                  phaseStartedAt: new Date().toISOString(),
+                  startedAt: new Date().toISOString(),
+                  updatedAt: new Date().toISOString(),
+                },
+              }) as unknown as ObservedCodeGraphBuildStatus;
+            const common = {
+              assertRuntimeSchemaCompatible: () => Effect.void,
+              cwd: identity.repoRoot,
+              readStatus: Effect.sync(() => status),
+              resolveIdentity: () => Effect.succeed(identity),
+              spawn: () => {
+                const ordinal = spawnCalls++;
+                status = runningStatus(ordinal);
+                return {
+                  exited: new Promise<number>(resolve => exits.push(resolve)),
+                  kill: () => undefined,
+                  processId: 77 + ordinal,
+                };
+              },
+              threadnoteHome: home,
+            };
+
+            const owner = yield* runIsolatedCodeGraphIndex({...common, requestKey: 'request-a'}).pipe(Effect.forkChild);
+            while (spawnCalls < 1 || exits[0] === undefined) yield* Effect.yieldNow;
+            const waiter = yield* runIsolatedCodeGraphIndex({...common, requestKey: 'request-b'}).pipe(
+              Effect.forkChild,
+            );
+            yield* Effect.yieldNow;
+            status = {
+              ...runningStatus(0),
+              observation: {heartbeatAgeMilliseconds: 0, liveness: 'completed'},
+              result: {dirty: false, edges: 11, files: 2, snapshotId: 'snapshot-a', symbols: 7},
+              state: 'completed',
+            } as ObservedCodeGraphBuildStatus;
+            exits[0]!(0);
+
+            expect(yield* Fiber.join(owner)).toEqual({edges: 11, symbols: 7});
+            while (spawnCalls < 2 || exits[1] === undefined) yield* Effect.yieldNow;
+            status = {
+              ...runningStatus(1),
+              observation: {heartbeatAgeMilliseconds: 0, liveness: 'completed'},
+              result: {dirty: true, edges: 13, files: 1, snapshotId: 'snapshot-b', symbols: 9},
+              state: 'completed',
+            } as ObservedCodeGraphBuildStatus;
+            exits[1]!(0);
+
+            expect(yield* Fiber.join(waiter)).toEqual({edges: 13, symbols: 9});
+            expect(spawnCalls).toBe(2);
+          }),
+        home => Effect.sync(() => rmSync(home, {force: true, recursive: true})),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    ),
   );
 });

--- a/test/unit/code-graph.retained-base-reservation.test.ts
+++ b/test/unit/code-graph.retained-base-reservation.test.ts
@@ -1,0 +1,42 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, Layer} from 'effect';
+import {TestClock} from 'effect/testing';
+import {afterEach, beforeEach, describe, expect} from 'vitest';
+import {
+  CODE_GRAPH_RETAINED_BASE_HOME_MAXIMUM,
+  reserveCodeGraphRetainedBase,
+} from '../../src/code_graph/retained_base_reservation.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {mkdtemp, rm} from '../helpers/effect-filesystem.js';
+
+const RETAINED_BASE_TEST_LAYER = SystemInfo.layer.pipe(Layer.provideMerge(BunServices.layer));
+
+describe('code graph retained-base home reservations', () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp('threadnote-retained-base-');
+  });
+
+  afterEach(async () => {
+    await rm(home, {force: true, recursive: true});
+  });
+
+  effectIt.effect('deduplicates a physical base, caps the home at two, and admits after expiry', () =>
+    Effect.gen(function* () {
+      const reserve = (physicalSnapshotId: string) =>
+        reserveCodeGraphRetainedBase({durationMilliseconds: 1_000, physicalSnapshotId, threadnoteHome: home});
+
+      expect(CODE_GRAPH_RETAINED_BASE_HOME_MAXIMUM).toBe(2);
+      expect(yield* reserve('base-a')).toBe(true);
+      expect(yield* reserve('base-a')).toBe(true);
+      expect(yield* reserve('base-b')).toBe(true);
+      expect(yield* reserve('base-c')).toBe(false);
+
+      yield* TestClock.adjust(1_001);
+      expect(yield* reserve('base-c')).toBe(true);
+    }).pipe(provideTestLayer(RETAINED_BASE_TEST_LAYER)),
+  );
+});

--- a/test/unit/code-graph.store-modules.test.ts
+++ b/test/unit/code-graph.store-modules.test.ts
@@ -27,14 +27,6 @@ function storeModuleDependencies(modules: ReadonlyMap<string, string>): Readonly
 }
 
 describe('code graph Store module boundaries', () => {
-  it('keeps every Store implementation module below 1,000 lines', () => {
-    const oversized = [...storeModules()]
-      .map(([name, source]) => ({name, lines: source.split('\n').length - (source.endsWith('\n') ? 1 : 0)}))
-      .filter(module => module.lines >= 1_000);
-
-    expect(oversized).toEqual([]);
-  });
-
   it('keeps the Store module graph acyclic', () => {
     const modules = storeModules();
     const dependencies = storeModuleDependencies(modules);

--- a/test/unit/code-graph.watcher.test.ts
+++ b/test/unit/code-graph.watcher.test.ts
@@ -6,6 +6,7 @@ import {TestClock} from 'effect/testing';
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {
+  codeGraphCachedOverlayAssessmentAllowsBackgroundRefresh,
   codeGraphWatcherSnapshotStale,
   makeCodeGraphWatcher,
   prewarmCandidatesFromRefOutput,
@@ -19,6 +20,7 @@ import {
   CodeGraphStorePermissionError,
   CodeGraphStoreTransientIoError,
 } from '../../src/code_graph/types.js';
+import {orderCodeGraphBuilderAdmissionTickets} from '../../src/code_graph/builder_admission.js';
 
 const options: CodeGraphWatchOptions = {
   cwd: '/fixture/repository',
@@ -27,6 +29,31 @@ const options: CodeGraphWatchOptions = {
 };
 
 describe('CodeGraphWatcher', () => {
+  it('orders home builder tickets by current-required priority and FIFO within a class (property)', () => {
+    fc.assert(
+      fc.property(fc.array(fc.constantFrom('background' as const, 'current-required' as const)), classes => {
+        const ordered = orderCodeGraphBuilderAdmissionTickets(
+          classes.map((admissionClass, index) => ({
+            admissionClass,
+            createdAt: index,
+            token: `${index}`.padStart(4, '0'),
+          })),
+        );
+        const firstBackground = ordered.findIndex(ticket => ticket.admissionClass === 'background');
+        if (firstBackground >= 0) {
+          expect(ordered.slice(firstBackground).every(ticket => ticket.admissionClass === 'background')).toBe(true);
+        }
+        for (const admissionClass of ['current-required', 'background'] as const) {
+          const arrivals = ordered
+            .filter(ticket => ticket.admissionClass === admissionClass)
+            .map(ticket => ticket.createdAt);
+          expect(arrivals).toEqual([...arrivals].sort((left, right) => left - right));
+        }
+      }),
+      {numRuns: 100},
+    );
+  });
+
   it('admits at most two unique non-current ref tips for prewarming', () => {
     const objectId = fc
       .array(fc.integer({max: 15, min: 0}), {maxLength: 40, minLength: 40})
@@ -50,6 +77,50 @@ describe('CodeGraphWatcher', () => {
       ),
       {numRuns: 250},
     );
+  });
+
+  it('admits background refresh only for an overlay-success outcome on the current ready base', () => {
+    const status = (
+      snapshotId: string,
+      outcome: 'overlay-success' | 'resolution-surface-changed',
+      completedAt = '2026-08-17T12:00:00.000Z',
+    ) => ({
+      materialization: undefined,
+      result: {
+        dirty: true,
+        edges: 1,
+        files: 1,
+        overlayAssessment: {outcome},
+        snapshotId,
+        symbols: 1,
+      },
+      state: 'completed' as const,
+      timestamps: {
+        completedAt,
+        heartbeatAt: completedAt,
+        lastProgressAt: completedAt,
+        phaseStartedAt: completedAt,
+        startedAt: completedAt,
+        updatedAt: completedAt,
+      },
+    });
+
+    expect(codeGraphCachedOverlayAssessmentAllowsBackgroundRefresh('current', [])).toBe(false);
+    expect(
+      codeGraphCachedOverlayAssessmentAllowsBackgroundRefresh('current', [
+        status('previous', 'overlay-success'),
+        status('current', 'resolution-surface-changed'),
+      ]),
+    ).toBe(false);
+    expect(
+      codeGraphCachedOverlayAssessmentAllowsBackgroundRefresh('current', [status('current', 'overlay-success')]),
+    ).toBe(true);
+    expect(
+      codeGraphCachedOverlayAssessmentAllowsBackgroundRefresh('current', [
+        status('current', 'overlay-success', '2026-08-17T12:00:00.000Z'),
+        status('current', 'resolution-surface-changed', '2026-08-17T12:01:00.000Z'),
+      ]),
+    ).toBe(false);
   });
 
   effectIt.effect(
@@ -498,6 +569,36 @@ describe('CodeGraphWatcher', () => {
     }).pipe(Effect.scoped),
   );
 
+  effectIt.effect('suppresses change refresh when the cached overlay outcome is not eligible', () =>
+    Effect.gen(function* () {
+      const events = yield* Ref.make<string[]>([]);
+      const fiber = yield* watchRepository(
+        {watch: () => Stream.make({path: 'source.ts'})} as never,
+        {
+          isAbsolute: (value: string) => value.startsWith('/'),
+          join: (...values: string[]) => values.join('/'),
+          relative: () => 'source.ts',
+          sep: '/',
+        } as never,
+        options,
+        false,
+        () => Ref.update(events, current => [...current, 'refresh']),
+        {
+          changeRefreshRequired: Effect.succeed(false),
+          periodicRefreshRequired: Effect.succeed(false),
+          requestAfterChange: Ref.update(events, current => [...current, 'change-maintenance']),
+          requestInitial: Effect.void,
+        },
+      ).pipe(Effect.forkScoped);
+
+      yield* TestClock.adjust('751 millis');
+      yield* Effect.yieldNow;
+
+      expect(yield* Ref.get(events)).toEqual(['change-maintenance']);
+      yield* Fiber.interrupt(fiber);
+    }).pipe(Effect.scoped),
+  );
+
   effectIt.effect('refreshes on periodic positive staleness and preserves on current or unknown evidence', () =>
     Effect.gen(function* () {
       for (const testCase of [
@@ -687,7 +788,7 @@ describe('CodeGraphWatcher', () => {
     ).pipe(Effect.tap(observed => Effect.sync(() => expect(observed).toEqual(['commit-a', 'commit-c'])))),
   );
 
-  effectIt.effect('serializes refreshes across repository keys to bound process memory', () =>
+  effectIt.effect('admits two refreshes across repository keys while bounding process memory', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -733,8 +834,8 @@ describe('CodeGraphWatcher', () => {
         }),
       );
 
-      expect(result.beforeRelease).toEqual({maximum: 1, starts: 1});
-      expect(result.finalMaximum).toBe(1);
+      expect(result.beforeRelease).toEqual({maximum: 2, starts: 2});
+      expect(result.finalMaximum).toBe(2);
       expect(result.finalStarts).toBe(8);
     }),
   );
@@ -815,8 +916,8 @@ describe('CodeGraphWatcher', () => {
       expect(whileHeld).toEqual({
         activeRefreshKeys: 2,
         activeWatches: 2,
-        executingRefreshes: 1,
-        executingRefreshHighWater: 1,
+        executingRefreshes: 2,
+        executingRefreshHighWater: 2,
         idleSweepFibers: 1,
         maximumWatchers: 4,
         pendingTrailingRefreshes: 2,
@@ -837,7 +938,7 @@ describe('CodeGraphWatcher', () => {
         activeRefreshKeys: 0,
         activeWatches: 2,
         executingRefreshes: 0,
-        executingRefreshHighWater: 1,
+        executingRefreshHighWater: 2,
         idleSweepFibers: 1,
         maximumWatchers: 4,
         pendingTrailingRefreshes: 0,

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -7,6 +7,7 @@ import {
   codeGraphAnalysisMcpResponse,
   codeGraphAnalysisRefreshResult,
   codeGraphInspectionAllowsStaleReady,
+  codeGraphInspectionStartsRefresh,
   codeGraphMcpAnalysisBudget,
   codeGraphMcpAnalysisLimits,
   codeGraphMcpResponse,
@@ -39,6 +40,28 @@ describe('MCP code graph indexing progress', () => {
       ),
     ).toEqual({explain: true, impact: false, neighbors: true, node: true, path: false, query: true});
   });
+
+  it.prop(
+    'starts refresh only for stale cold or current-required inspections',
+    {
+      operation: FC.constantFrom(
+        'query' as const,
+        'node' as const,
+        'neighbors' as const,
+        'explain' as const,
+        'path' as const,
+        'impact' as const,
+      ),
+      ready: FC.boolean(),
+      stale: FC.boolean(),
+    },
+    ({operation, ready, stale}) => {
+      expect(
+        codeGraphInspectionStartsRefresh({readySnapshot: ready ? {id: 'ready'} : undefined, stale}, operation),
+      ).toBe(!ready || (stale && (operation === 'path' || operation === 'impact')));
+    },
+    {fastCheck: {numRuns: 100}},
+  );
 
   it('allows an explicitly safe ready graph to serve while background indexing continues', () => {
     const indexing = indexingStatus(60_000);
@@ -135,6 +158,15 @@ describe('MCP code graph indexing progress', () => {
       'Serving the existing stale ready snapshot while code graph refresh continues in the background.',
     ]);
     expect(codeGraphResultWithRefreshContinuity(continued, indexingStatus(60_000))).toBe(continued);
+  });
+
+  it('labels stale ready evidence when background refresh is intentionally suppressed', () => {
+    const result = {...verboseCodeGraphResult(), freshness: 'stale' as const, warnings: []};
+    const continued = codeGraphResultWithRefreshContinuity(result, undefined);
+
+    expect(continued.warnings).toEqual([
+      'Serving the existing stale ready snapshot without starting a background rebuild. Run `threadnote graph index`, or use `path` or `impact`, when current graph evidence is required.',
+    ]);
   });
 
   it('keeps path, impact, and whole-graph analysis strict when refresh is deferred', () => {


### PR DESCRIPTION
## Summary

- keep ordinary stale-ready graph reads read-only while reserving refreshes for explicit index, path, impact, and cold-start flows
- retain and reuse completed materializations across activation drift, including dirty full roots, with bounded reservation and retirement policies
- coordinate isolated builders across hosts with request-key compatibility and a home-global current-first admission cap
- fail closed for published TypeScript surface changes while allowing verified file-local overlays
- add focused regressions and property tests for churn, coalescing, lifecycle, and incremental-versus-full equivalence

## Verification

- focused Vitest coverage: 129 unit tests passed
- focused lifecycle coverage: 6 passed
- focused incremental property coverage: 2 passed
- focused stale-ready MCP integration: 1 passed
- lint, source typecheck, test typecheck, site typecheck, Prettier check, and diff check passed
- exact HEAD installed globally and smoke-tested through graph index, graph query, and process inspection

The full local test suite was intentionally not run per request. CI is the full-suite source of truth.

## Dogfood note

A separate zero-byte disposable graph-store repair gap was reproduced and recorded as an open dogfood issue. It is outside this plan and was not folded into this change.