### PR TITLE
Prepare Threadnote 4.2.6

### DIFF
--- a/.github/release-notes/v4.2.6.md
+++ b/.github/release-notes/v4.2.6.md
@@ -1,0 +1,32 @@
+## What's new
+
+Threadnote 4.2.6 makes code graph indexing resilient to busy worktrees, so ordinary inspections stay fast while explicit
+current-only operations can safely refresh the graph.
+
+### Stable inspection during active development
+
+- `query`, `node`, `neighbors`, and `explain` now serve an existing ready snapshot with stale context instead of
+  starting a repository-wide rebuild. `path`, `impact`, `analyze_code_graph`, and explicit `graph index` remain
+  current-only.
+- Filesystem and periodic refreshes only resume incremental overlay work after a compatible assessment for the current
+  ready base. Otherwise Threadnote keeps serving the stale snapshot and explains how to request current state.
+
+### Reuse finished work when the worktree moves
+
+- A snapshot that finishes committing before HEAD or the local overlay changes is retained as a reusable base instead
+  of being discarded and rebuilt from scratch.
+- Retirement after interrupted or incomplete builds is page-budgeted, retaining storage backpressure without extending
+  the activation window.
+
+### Bounded builders and safer incremental TypeScript edits
+
+- Repository-sized builders are coalesced per worktree across Threadnote hosts and limited to two concurrent builders
+  per home. Explicit current requests get the next available slot ahead of background refreshes.
+- Private TypeScript declarations whose lookup keys are proven local to their own path stay on the incremental overlay
+  path. Other resolution domains and published-surface changes remain fail-closed.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone package version from 4.2.5 to 4.2.6
- add curated v4.2.6 release notes for the high-churn code graph rematerialization fixes merged in #166
- prepare the website unreleased stable-version entry and the tag-triggered publication contract

## Why

Large, actively changing worktrees could repeatedly discard completed graph work and start repository-sized rematerializations. Threadnote 4.2.6 documents the merged behavior that serves stale-safe ordinary reads, retains reusable committed bases, bounds builder concurrency and retirement, and keeps proven path-local TypeScript declarations incremental.

## Impact

After this PR merges and exact-main CI passes, an annotated `v4.2.6` tag at the resulting squash commit can trigger the immutable standalone release workflow. This PR does not create the tag or publish a release.

## Validation

- `bun run test:smoke:release` — 11 tests passed
- `bun run site:check` — 60 tests passed plus site typecheck/lint
- `bun run site:build`
- `bunx prettier --check package.json .github/release-notes/v4.2.6.md`
- `git diff --check`
- commit hook: repository lint, global 2000-line lint, Prettier, and typecheck

The full local test suite was intentionally not run; CI remains authoritative.
