### PR TITLE
Fix stale graph reads in divergent worktrees

### DIFF
--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -1062,12 +1062,14 @@ export const runCodeGraphInspect = Effect.fn('codeGraph.command.inspect')(functi
     qualifiedTarget === undefined ? options : {...options, cwd: qualifiedTarget.cwd, nodeId: qualifiedTarget.nodeId};
   const service = yield* CodeGraphQueryService;
   const cwd = yield* commandCwd(effectiveOptions.cwd);
+  const freshness = options.freshness ?? defaultCodeGraphCliFreshness(options.operation);
   let status = yield* service.status(config.agentContextHome, cwd);
   const identity = status.identity;
   if (status.stale || !status.readySnapshot) {
-    status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status);
+    status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status, {
+      allowBorrowedStale: freshness !== 'current',
+    });
   }
-  const freshness = options.freshness ?? defaultCodeGraphCliFreshness(options.operation);
   const readPlan = codeGraphCliReadPlan(freshness, status);
   if (readPlan.unavailable) {
     const unavailable = codeGraphCliReadState(status, freshness, options.operation, 'no-ready-snapshot');

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -95,11 +95,15 @@ export interface CodeGraphTraversalTimeBudgets {
 }
 
 export interface CodeGraphStatusObservation {
+  /** Read-only shared evidence selected without changing this worktree's active pointer. */
+  readonly borrowedSnapshotId?: string;
   readonly identity: RepositoryIdentity;
   readonly overlay: {readonly dirty: boolean; readonly fingerprint?: string};
 }
 
 export interface CodeGraphSharedReadyAttachInterlock {
+  /** Allow local ordinary reads to borrow stale evidence without promoting it. */
+  readonly allowBorrowedStale?: boolean;
   /** @internal Deterministic barrier after the optimistic candidate read and before target-lock acquisition. */
   readonly afterOptimisticCandidate?: () => Effect.Effect<void>;
   /** @internal Deterministic barrier after promotion and before final identity validation. */
@@ -200,7 +204,9 @@ export class CodeGraphQueryService extends Context.Service<
   {
     /**
      * Promote a shared clean ready snapshot for HEAD onto this worktree when
-     * the worktree is clean and has no matching active pointer yet.
+     * the worktree is clean and has no matching active pointer yet. An explicit
+     * local-read interlock may instead select compatible clean repository
+     * evidence as stale without changing the worktree pointer.
      */
     readonly attachSharedReadySnapshot: (
       threadnoteHome: string,
@@ -302,7 +308,7 @@ export class CodeGraphQueryService extends Context.Service<
           } satisfies CodeGraphStatus;
           return attachCodeGraphStatusObservation(status, overlay === undefined ? undefined : {identity, overlay});
         });
-      const attachSharedReadySnapshot = (
+      const attachExactSharedReadySnapshot = (
         threadnoteHome: string,
         identity: RepositoryIdentity,
         observedStatus?: CodeGraphStatus,
@@ -441,13 +447,56 @@ export class CodeGraphQueryService extends Context.Service<
             ),
           );
         });
+      const borrowSharedReadySnapshot = Effect.fn('codeGraph.query.borrowSharedReadySnapshot')(function* (
+        threadnoteHome: string,
+        status: CodeGraphStatus,
+      ) {
+        if (status.readySnapshot) return status;
+        const identity = status.identity;
+        const observation = observationFromCodeGraphStatus(status);
+        const overlay = observation?.overlay ?? (yield* worktreeOverlayState(identity));
+        const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
+        const candidate = yield* store.latestReadySnapshotForRepository(layout.databasePath, identity.repositoryId);
+        if (
+          candidate === undefined ||
+          !(yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, candidate, languagePacks))
+        ) {
+          return status;
+        }
+        return attachCodeGraphStatusObservation(
+          {
+            ...status,
+            freshness: 'stale',
+            readySnapshot: {...candidate, worktreeId: identity.worktreeId},
+            stale: true,
+          },
+          {borrowedSnapshotId: candidate.id, identity, overlay},
+        );
+      });
+      const attachSharedReadySnapshot = (
+        threadnoteHome: string,
+        identity: RepositoryIdentity,
+        observedStatus?: CodeGraphStatus,
+        interlock?: CodeGraphSharedReadyAttachInterlock,
+      ) => {
+        const exact = attachExactSharedReadySnapshot(threadnoteHome, identity, observedStatus, interlock);
+        return interlock?.allowBorrowedStale === true
+          ? exact.pipe(Effect.flatMap(status => borrowSharedReadySnapshot(threadnoteHome, status)))
+          : exact;
+      };
       return CodeGraphQueryService.of({
         attachSharedReadySnapshot: (threadnoteHome, identity, observedStatus, interlock) => {
           const attach = attachSharedReadySnapshot(threadnoteHome, identity, observedStatus, interlock);
           return withRepositoryServices(
             interlock?.requestMaintenance === false
               ? attach
-              : attach.pipe(Effect.tap(status => requestMaintenance(threadnoteHome, status.identity))),
+              : attach.pipe(
+                  Effect.tap(status =>
+                    observationFromCodeGraphStatus(status)?.borrowedSnapshotId
+                      ? Effect.void
+                      : requestMaintenance(threadnoteHome, status.identity),
+                  ),
+                ),
           );
         },
         inspect: options =>
@@ -458,7 +507,9 @@ export class CodeGraphQueryService extends Context.Service<
                 statusObservation?.identity ??
                 (yield* resolveAndRecordCodeGraphLocalAssociation(options.threadnoteHome, options.cwd)).identity;
               const layout = codeGraphLayout(path, options.threadnoteHome, identity.checkoutId, identity.worktreeId);
-              const existing = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+              const existing = statusObservation?.borrowedSnapshotId
+                ? yield* store.readySnapshotById(layout.databasePath, statusObservation.borrowedSnapshotId)
+                : yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
               const runtimeCurrent = existing
                 ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, existing, languagePacks)
                 : false;
@@ -491,6 +542,7 @@ export class CodeGraphQueryService extends Context.Service<
                   const read = () =>
                     inspectReadyGraph({
                       baseSnapshotId,
+                      borrowedSnapshotId: rebuilt ? undefined : statusObservation?.borrowedSnapshotId,
                       embedding,
                       expectedRepositoryId: identity.repositoryId,
                       layout,
@@ -1083,6 +1135,7 @@ const observeWorktree = Effect.fn('codeGraph.observeWorktree')(function* (
 
 const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (input: {
   readonly baseSnapshotId?: string;
+  readonly borrowedSnapshotId?: string;
   readonly deferWorktreeObservation: boolean;
   readonly embedding: CodeGraphEmbeddingIndexShape;
   readonly expectedRepositoryId: string;
@@ -1105,8 +1158,10 @@ const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (in
   const overlay =
     input.observation?.overlay ??
     (input.deferWorktreeObservation ? undefined : yield* observeWorktree(identity, input.options.interlock));
-  const storedSnapshot = yield* input.store.readySnapshot(input.layout.databasePath, identity.worktreeId);
-  if (!storedSnapshot) {
+  const storedSnapshot = input.borrowedSnapshotId
+    ? yield* input.store.readySnapshotById(input.layout.databasePath, input.borrowedSnapshotId)
+    : yield* input.store.readySnapshot(input.layout.databasePath, identity.worktreeId);
+  if (!storedSnapshot || storedSnapshot.repositoryId !== identity.repositoryId) {
     return yield* Effect.fail(
       new CodeGraphSnapshotUnavailable(
         'No ready native code graph snapshot exists. Run `threadnote graph index` first.',

--- a/src/code_graph/store_queries.ts
+++ b/src/code_graph/store_queries.ts
@@ -133,6 +133,31 @@ const selectReadySnapshotForCommit = Effect.fn('codeGraph.selectReadySnapshotFor
   return rows[0] ? snapshotFromRow(rows[0]) : undefined;
 });
 
+const selectLatestReadySnapshotForRepository = Effect.fn('codeGraph.selectLatestReadySnapshotForRepository')(function* (
+  repositoryId: string,
+) {
+  const sql = yield* SqlClient.SqlClient;
+  yield* configureConnection(sql);
+  if (!(yield* tableExists(sql, 'snapshots')) || !(yield* tableExists(sql, 'lexical_storage_formats'))) {
+    return undefined;
+  }
+  const rows = yield* sql<SnapshotRow>`
+    SELECT *
+    FROM snapshots
+    WHERE repository_id = ${repositoryId}
+      AND dirty = 0
+      AND state = 'ready'
+      AND EXISTS (
+        SELECT 1 FROM lexical_storage_formats AS lexical
+        WHERE lexical.snapshot_id = snapshots.id
+          AND lexical.format_version = ${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}
+      )
+    ORDER BY completed_at DESC, id
+    LIMIT 1
+  `;
+  return rows[0] ? snapshotFromRow(rows[0]) : undefined;
+});
+
 const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(function* (
   repositoryId: string,
   extractorSet: string,
@@ -1048,6 +1073,7 @@ export {
   selectReadySnapshotById,
   selectCurrentLexicalReadySnapshotById,
   selectReadySnapshotForCommit,
+  selectLatestReadySnapshotForRepository,
   selectReusableCleanBase,
   selectReusableOverlayBase,
   selectReusableReexports,

--- a/src/code_graph/store_service_data.ts
+++ b/src/code_graph/store_service_data.ts
@@ -12,6 +12,7 @@ import {
   selectReadySnapshotById,
   selectCurrentLexicalReadySnapshotById,
   selectReadySnapshotForCommit,
+  selectLatestReadySnapshotForRepository,
   selectReusableCleanBase,
   selectReusableOverlayBase,
   selectReusableReexports,
@@ -110,6 +111,7 @@ type CodeGraphStoreDataMethods = Pick<
   | 'readySnapshotById'
   | 'currentLexicalReadySnapshotById'
   | 'readySnapshotForCommit'
+  | 'latestReadySnapshotForRepository'
   | 'reusableBaseReceipt'
   | 'snapshotPackProvenance'
   | 'reusableCleanBase'
@@ -557,6 +559,15 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
             : Effect.succeed(undefined),
         ),
         Effect.mapError(cause => storeError('load ready code graph snapshot for commit', cause)),
+      ),
+    latestReadySnapshotForRepository: (databasePath, repositoryId) =>
+      fs.exists(databasePath).pipe(
+        Effect.flatMap(exists =>
+          exists
+            ? useReadOnlyDatabase(databasePath, selectLatestReadySnapshotForRepository(repositoryId))
+            : Effect.succeed(undefined),
+        ),
+        Effect.mapError(cause => storeError('load latest ready code graph snapshot for repository', cause)),
       ),
     reusableBaseReceipt: (databasePath, snapshotId, options) =>
       fs.exists(databasePath).pipe(

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -408,6 +408,10 @@ export interface CodeGraphStoreShape {
     commit: string,
     extractorSet?: string,
   ) => Effect.Effect<CodeGraphSnapshot | undefined, CodeGraphStoreError>;
+  readonly latestReadySnapshotForRepository: (
+    databasePath: string,
+    repositoryId: string,
+  ) => Effect.Effect<CodeGraphSnapshot | undefined, CodeGraphStoreError>;
   readonly reusableBaseReceipt: (
     databasePath: string,
     snapshotId: string,

--- a/src/mcp_server_code_graph.ts
+++ b/src/mcp_server_code_graph.ts
@@ -332,7 +332,9 @@ export function registerCodeGraphTool(
         const allowStaleReadySnapshot = codeGraphInspectionAllowsStaleReady(operation);
         const strictFreshness = !allowStaleReadySnapshot;
         if (status.stale || !status.readySnapshot) {
-          status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status);
+          status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status, {
+            allowBorrowedStale: allowStaleReadySnapshot,
+          });
         }
         let refreshStarted = false;
         if (codeGraphInspectionStartsRefresh(status, operation)) {
@@ -348,7 +350,9 @@ export function registerCodeGraphTool(
           status = yield* service.status(config.agentContextHome, inspectionCwd);
           identity = status.identity;
           if (status.stale || !status.readySnapshot) {
-            status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status);
+            status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status, {
+              allowBorrowedStale: allowStaleReadySnapshot,
+            });
           }
           if (!status.readySnapshot || (status.stale && strictFreshness)) {
             const refreshStatus = Option.getOrUndefined(yield* watcher.status(identity.worktreeId, refreshTarget));

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -699,7 +699,15 @@ describe('native code graph lifecycle', () => {
           'export function divergentHeadOnly(): string { return "divergent"; }\n',
         );
         git(worktreeB, ['add', 'divergent-head.ts']);
-        git(worktreeB, ['commit', '-m', 'diverge graph worktree']);
+        git(worktreeB, [
+          '-c',
+          'user.name=Threadnote Test',
+          '-c',
+          'user.email=test@threadnote.local',
+          'commit',
+          '-m',
+          'diverge graph worktree',
+        ]);
         return {home: join(root, '.threadnote-test-home'), worktreeA, worktreeB};
       });
       const graph = yield* CodeGraphQueryService;

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -683,6 +683,75 @@ describe('native code graph lifecycle', () => {
     expect(result.found.nodes.some(node => node.name === 'ensureVectorIndex')).toBe(true);
   });
 
+  effectIt.effect('borrows a divergent-HEAD clean snapshot as stale evidence without promotion', () =>
+    Effect.gen(function* () {
+      const {home, worktreeA, worktreeB} = yield* Effect.sync(() => {
+        const root = createFixtureRepository();
+        git(root, ['branch', 'graph-borrow-a']);
+        git(root, ['branch', 'graph-borrow-b']);
+        const worktreeRoot = temporaryDirectory('threadnote-code-graph-borrow-worktrees-');
+        const worktreeA = join(worktreeRoot, 'worktree-a');
+        const worktreeB = join(worktreeRoot, 'worktree-b');
+        git(root, ['worktree', 'add', worktreeA, 'graph-borrow-a']);
+        git(root, ['worktree', 'add', worktreeB, 'graph-borrow-b']);
+        writeFileSync(
+          join(worktreeB, 'divergent-head.ts'),
+          'export function divergentHeadOnly(): string { return "divergent"; }\n',
+        );
+        git(worktreeB, ['add', 'divergent-head.ts']);
+        git(worktreeB, ['commit', '-m', 'diverge graph worktree']);
+        return {home: join(root, '.threadnote-test-home'), worktreeA, worktreeB};
+      });
+      const graph = yield* CodeGraphQueryService;
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const indexed = yield* indexer.index({cwd: worktreeA, threadnoteHome: home});
+      const identityB = yield* resolveRepositoryIdentity(worktreeB);
+      const before = yield* graph.statusForIdentity(home, identityB, {requestMaintenance: false});
+      const exactOnly = yield* graph.attachSharedReadySnapshot(home, identityB, before, {
+        requestMaintenance: false,
+      });
+      const borrowed = yield* graph.attachSharedReadySnapshot(home, identityB, exactOnly, {
+        allowBorrowedStale: true,
+        requestMaintenance: false,
+      });
+      const activeAfterBorrow = yield* store.readySnapshot(borrowed.databasePath, identityB.worktreeId);
+      const found = yield* graph.inspect({
+        cwd: worktreeB,
+        operation: 'query',
+        query: 'ensureVectorIndex',
+        refresh: false,
+        requestMaintenance: false,
+        statusObservation: observationFromCodeGraphStatus(borrowed),
+        strictFreshness: false,
+        threadnoteHome: home,
+      });
+
+      expect(before.readySnapshot).toBeUndefined();
+      expect(exactOnly.readySnapshot).toBeUndefined();
+      expect(borrowed).toMatchObject({
+        freshness: 'stale',
+        readySnapshot: {
+          commit: indexed.snapshot.commit,
+          id: indexed.snapshot.id,
+          worktreeId: identityB.worktreeId,
+        },
+        stale: true,
+      });
+      expect(activeAfterBorrow).toBeUndefined();
+      expect(found).toMatchObject({
+        freshness: 'stale',
+        snapshot: {
+          commit: indexed.snapshot.commit,
+          id: indexed.snapshot.id,
+          worktreeId: identityB.worktreeId,
+        },
+      });
+      expect(found.nodes.some(node => node.name === 'ensureVectorIndex')).toBe(true);
+      expect(found.nodes.some(node => node.name === 'divergentHeadOnly')).toBe(false);
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
   it('attaches a shared clean base while a sibling worktree keeps a dirty overlay', async () => {
     const root = createFixtureRepository();
     git(root, ['branch', 'graph-sibling-a']);

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -1505,6 +1505,97 @@ describe('Threadnote MCP toolsets', () => {
     );
   }, 40_000);
 
+  it('serves a divergent-HEAD new worktree from stale shared evidence while its builder is blocked', async () => {
+    await withMcpClient(
+      async (client, fixture) => {
+        const repository = join(fixture.root, 'divergent-worktree-repository');
+        await mkdir(join(repository, 'src'), {recursive: true});
+        await writeFile(join(repository, 'package.json'), '{"name":"divergent-worktree-repository"}\n', 'utf8');
+        await writeFile(
+          join(repository, 'src', 'index.ts'),
+          'export function sharedBeforeDivergence(): string { return "shared"; }\n',
+          'utf8',
+        );
+        execFileSync('git', ['init', '-q'], {cwd: repository});
+        execFileSync('git', ['config', 'user.email', 'threadnote@example.test'], {cwd: repository});
+        execFileSync('git', ['config', 'user.name', 'Threadnote Test'], {cwd: repository});
+        execFileSync('git', ['add', '.'], {cwd: repository});
+        execFileSync('git', ['commit', '-qm', 'shared graph base'], {cwd: repository});
+
+        const first = await callCodeGraphUntilReady(client, {
+          callerCwd: repository,
+          operation: 'query',
+          query: 'sharedBeforeDivergence',
+        });
+        const firstSnapshot = (
+          first.structuredContent as
+            {readonly snapshot?: {readonly commit?: unknown; readonly id?: unknown}} | undefined
+        )?.snapshot;
+        expect(typeof firstSnapshot?.id).toBe('string');
+        expect(typeof firstSnapshot?.commit).toBe('string');
+
+        const branch = 'divergent-linked';
+        const worktree = join(fixture.root, 'divergent-linked-worktree');
+        execFileSync('git', ['branch', branch], {cwd: repository});
+        execFileSync('git', ['worktree', 'add', worktree, branch], {cwd: repository});
+        await writeFile(
+          join(worktree, 'src', 'divergent.ts'),
+          'export function divergentHeadOnly(): string { return "divergent"; }\n',
+          'utf8',
+        );
+        execFileSync('git', ['add', '.'], {cwd: worktree});
+        execFileSync('git', ['commit', '-qm', 'divergent graph head'], {cwd: worktree});
+
+        const gitCommonDirectory = await realpath(
+          execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+            cwd: worktree,
+            encoding: 'utf8',
+          }).trim(),
+        );
+        const checkoutId = createHash('sha256').update(`checkout-v1\n${gitCommonDirectory}`).digest('hex');
+        const worktreeId = createHash('sha256')
+          .update(`worktree-v1\n${await realpath(worktree)}`)
+          .digest('hex');
+        const graphLock = join(
+          fixture.home,
+          'locks',
+          'indexes',
+          'code-graph',
+          'worktrees',
+          checkoutId,
+          `${worktreeId}.lock`,
+        );
+        await mkdir(join(graphLock, '..'), {recursive: true});
+        await writeFile(graphLock, `${process.pid}:divergent-worktree-test\n`, {encoding: 'utf8', mode: 0o600});
+
+        try {
+          const startedAt = Date.now();
+          const borrowed = await client.callTool(
+            {
+              arguments: {callerCwd: worktree, operation: 'query', query: 'sharedBeforeDivergence'},
+              name: 'inspect_code_graph',
+            },
+            undefined,
+            {timeout: 5_000},
+          );
+          expect(Date.now() - startedAt).toBeLessThan(5_000);
+          expect(borrowed.isError).not.toBe(true);
+          expect(borrowed.structuredContent).toMatchObject({
+            freshness: 'stale',
+            nodes: expect.arrayContaining([expect.objectContaining({name: 'sharedBeforeDivergence'})]),
+            operation: 'query',
+            snapshot: {commit: firstSnapshot?.commit, id: firstSnapshot?.id},
+          });
+          expect((borrowed.structuredContent as {readonly state?: unknown} | undefined)?.state).toBeUndefined();
+          expect(JSON.stringify(borrowed.structuredContent)).not.toContain('divergentHeadOnly');
+        } finally {
+          await rm(graphLock, {force: true});
+        }
+      },
+      {environment: {THREADNOTE_CODE_GRAPH_PREWARM: '0'}, toolset: 'core'},
+    );
+  }, 40_000);
+
   it('keeps graphs immediately available across new TypeScript, Python, and Rust worktrees and edits', async () => {
     await withMcpClient(
       async (client, fixture) => {

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -63,6 +63,32 @@ describe('MCP code graph indexing progress', () => {
     {fastCheck: {numRuns: 100}},
   );
 
+  it.prop(
+    'serves a borrowed stale snapshot only for ordinary inspections',
+    {
+      operation: FC.constantFrom(
+        'query' as const,
+        'node' as const,
+        'neighbors' as const,
+        'explain' as const,
+        'path' as const,
+        'impact' as const,
+      ),
+    },
+    ({operation}) => {
+      const borrowed = {id: 'borrowed'};
+      const status = {readySnapshot: borrowed, stale: true};
+      const allowStale = codeGraphInspectionAllowsStaleReady(operation);
+      const indexing = indexingStatus(60_000);
+
+      expect(codeGraphInspectionStartsRefresh(status, operation)).toBe(!allowStale);
+      expect(selectCodeGraphReadySnapshotForInspection(status, indexing, allowStale)).toBe(
+        allowStale ? borrowed : undefined,
+      );
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
   it('allows an explicitly safe ready graph to serve while background indexing continues', () => {
     const indexing = indexingStatus(60_000);
 


### PR DESCRIPTION
## Summary

- Let stale-tolerant code-graph reads borrow the newest compatible ready snapshot from another clean worktree in the same repository.
- Preserve exact-HEAD activation and keep strict operations on current or published snapshot semantics.
- Avoid mutating the new worktree active-snapshot pointer while borrowed evidence is served.

## Telemetry evidence

The weekly two-user sample showed `inspect_code_graph` at 218 successes, 124 unavailable outcomes, and 8 failures, versus a preceding baseline of 245 successes, 27 unavailable outcomes, and 2 failures. `graph.index` showed 61 successes, 53 unavailable outcomes, and 7 failures, versus 345 successes, 32 unavailable outcomes, and 5 failures. The repeated user-visible pattern was a newly created divergent worktree reporting that its graph was indexing even though clean same-repository evidence was already usable.

Schema-v2 materialization telemetry also contained 17 isolated high-amplification builds, primarily under the closed `project-closure-incomplete` fallback label; this PR does not change materialization behavior.

## Root cause and fix

Snapshot reuse required an exact HEAD match. A new linked worktree with a divergent commit could not attach the repository ready snapshot, so ordinary MCP search waited on or reported a fresh build instead of returning bounded stale evidence.

The query service now has an explicit stale-borrow opt-in. Ordinary MCP graph inspection operations and CLI `allow-stale` reads enable it; strict and current reads do not. Borrowed snapshots are leased and repository-validated, but never promoted as the divergent worktree active snapshot.

## Verification

- Focused code-graph lifecycle regression tests.
- Focused native MCP regression tests, including a blocked builder in a divergent worktree.
- Bounded FastCheck property covering ordinary versus strict operation policy.
- Related query, store, and CLI unit tests.
- `bun run typecheck`.
- `bun run lint`.
- `bun run prettier:check`.
- `git diff --check`.
- Guarded global development install of the exact commit.
- Installed CLI smoke: a divergent worktree returned expected stale graph evidence without an indexing response.

Full test suite is delegated to CI.