### PR TITLE
Prepare Threadnote 4.2.7

### DIFF
--- a/.github/release-notes/v4.2.7.md
+++ b/.github/release-notes/v4.2.7.md
@@ -1,0 +1,24 @@
+## What's new
+
+Threadnote 4.2.7 keeps code graph search available immediately in newly created linked worktrees, even when their HEAD
+has diverged from the repository's last ready snapshot.
+
+### Immediate graph evidence in new worktrees
+
+- `query`, `node`, `neighbors`, and `explain` can borrow the newest compatible clean ready snapshot from another
+  worktree in the same repository instead of returning an indexing response while a fresh build is pending.
+- Borrowed results are explicitly stale, remain protected by the normal snapshot lease, and never become the new
+  worktree's active snapshot.
+
+### Current-only operations stay exact
+
+- `path`, `impact`, `analyze_code_graph`, workset queries, and explicit current reads still require their governed
+  current or published snapshot.
+- CLI `graph query --freshness allow-stale` now follows the same bounded fallback contract as ordinary MCP graph
+  inspection.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone version to 4.2.7
- add curated user-facing release notes for immediate graph evidence in divergent linked worktrees
- preserve current-only semantics for strict graph operations

## Release basis

- includes the fully green fix from PR #168
- release-contract tests passed: 16 tests across release notes, publishing workflow, and package boundaries
- formatting and all TypeScript checks passed
- exact candidate installed globally and doctor completed with zero failures

The tag will be created only after this release PR is green and merged. The tag-triggered workflow owns archive signing, notarization, immutable GitHub Release publication, and exact-tag evidence.