### PR TITLE
Improve workset preparation feedback and reliability

### DIFF
--- a/manager/app.css
+++ b/manager/app.css
@@ -3116,6 +3116,16 @@ dd {
   min-width: min(100%, 340px);
 }
 
+.worksets-job > div > span {
+  overflow-wrap: anywhere;
+}
+
+.worksets-job > progress {
+  accent-color: var(--accent);
+  flex: 1 1 180px;
+  max-width: 360px;
+}
+
 .worksets-job > span {
   color: var(--muted);
   font-size: 11px;

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -45,6 +45,7 @@ import {
   type CodeGraphWorksetPrepareResultV1,
   type CodeGraphWorksetStatusResultV1,
 } from './workset_catalog/workset.js';
+import {makeCodeGraphWorksetJsonProgressReporter} from './workset_progress.js';
 import {CodeGraphAnalysis} from './analysis.js';
 import {
   codeGraphAnalysisLimitsForView,
@@ -819,7 +820,20 @@ export const runCodeGraphWorksetPrepare = Effect.fn('codeGraph.command.worksetPr
   config: RuntimeConfig,
   options: {readonly concurrency?: number; readonly json?: boolean; readonly name: string},
 ) {
-  const result = yield* prepareCodeGraphWorkset(config, options.name, {concurrency: options.concurrency});
+  const result = options.json
+    ? yield* prepareCodeGraphWorkset(config, options.name, {
+        concurrency: options.concurrency,
+        onProgress: yield* makeCodeGraphWorksetJsonProgressReporter(),
+      })
+    : yield* Effect.acquireUseRelease(
+        startProgress(`Preparing workset ${options.name}.`),
+        progress =>
+          prepareCodeGraphWorkset(config, options.name, {
+            concurrency: options.concurrency,
+            onProgress: event => progress.update(event.message),
+          }),
+        progress => progress.stop.pipe(Effect.catch(() => Effect.void)),
+      );
   yield* writeFinalCliOutput(
     options.json ? JSON.stringify(result) : renderCodeGraphWorksetPrepareResult(result).trimEnd(),
   );
@@ -846,13 +860,20 @@ export function renderCodeGraphWorksetPrepareResult(result: CodeGraphWorksetPrep
   const lines = [
     `Workset prepare: ${result.workset}`,
     `State: ${result.state}`,
-    `Members: ${result.members.filter(member => member.state === 'ready').length}/${result.members.length} ready`,
+    `Coverage: ${result.coverage.ready}/${result.coverage.requested} ready (${result.coverage.complete ? 'complete' : 'incomplete'})`,
   ];
   for (const member of result.members) {
     lines.push(
       member.state === 'ready'
         ? `- ${member.project}: ready (${member.symbolCount} routing symbols)`
-        : `- ${member.project}: ${member.state} (${member.reason})`,
+        : member.state === 'failed'
+          ? `- ${member.project}: failed (${member.reason}; ${member.detail.code}; ${member.detail.summary})`
+          : `- ${member.project}: ${member.state} (${member.reason})`,
+    );
+  }
+  if (!result.coverage.complete) {
+    lines.push(
+      `Warning: published coverage is incomplete (${result.coverage.failed} failed, ${result.coverage.missing} missing, ${result.coverage.excluded} excluded).`,
     );
   }
   if (result.bridges !== undefined) {

--- a/src/code_graph/workset_catalog/workset.ts
+++ b/src/code_graph/workset_catalog/workset.ts
@@ -1,4 +1,4 @@
-import {Effect, Exit, FileSystem, Path, Result} from 'effect';
+import {Cause, Clock, Effect, Exit, FileSystem, Path, Ref, Result, Semaphore} from 'effect';
 import {sha256HexSync} from '../../crypto/sha256.js';
 import {isFileLockTimeout, withExclusiveFileLock} from '../../effect/file_lock.js';
 import {requireWorkset} from '../../manifest.js';
@@ -13,10 +13,18 @@ import {
 } from '../cross_repository/store.js';
 import type {CodeGraphMonikerV1} from '../cross_repository/types.js';
 import {CodeGraphIndexer, type CodeGraphIndexerShape} from '../indexer.js';
+import {
+  RepositoryMaintenanceInterrupted,
+  RepositoryRegistrationLost,
+  WorktreeChangedDuringIndex,
+} from '../indexer_shared.js';
 import {CodeGraphQueryService} from '../query.js';
+import {makeCodeGraphWorksetTelemetryReporter} from '../workset_telemetry.js';
 import {
   CodeGraphRepositoryError,
   CodeGraphStoreError,
+  type CodeGraphIndexSummary,
+  type CodeGraphProgress,
   type CodeGraphSnapshot,
   type CodeGraphStatus,
   type CodeGraphStoreFailureCode,
@@ -43,6 +51,8 @@ import type {
 
 export const CODE_GRAPH_WORKSET_PREPARE_CONCURRENCY_DEFAULT = 2;
 export const CODE_GRAPH_WORKSET_PREPARE_CONCURRENCY_MAXIMUM = 8;
+export const CODE_GRAPH_WORKSET_PREPARE_MEMBER_ATTEMPTS_MAXIMUM = 2;
+const CODE_GRAPH_WORKSET_PREPARE_RETRY_DELAY = '250 millis';
 const WORKSET_PREPARE_LOCK_OPTIONS = {
   heartbeatIntervalMilliseconds: 10_000,
   retryIntervalMilliseconds: 25,
@@ -65,6 +75,7 @@ export type CodeGraphWorksetPrepareMemberV1 =
       readonly state: 'excluded';
     }
   | {
+      readonly detail: CodeGraphWorksetPrepareFailureDetailV1;
       readonly project: string;
       readonly reason: 'index-failed' | 'projection-failed';
       readonly state: 'failed';
@@ -75,8 +86,30 @@ export type CodeGraphWorksetPrepareMemberV1 =
       readonly state: 'missing';
     };
 
+export type CodeGraphWorksetPrepareFailureCodeV1 =
+  CodeGraphStoreFailureCode | 'catalog' | 'repository' | 'worktree-changed' | 'unknown';
+
+export interface CodeGraphWorksetPrepareFailureDetailV1 {
+  readonly code: CodeGraphWorksetPrepareFailureCodeV1;
+  readonly errorType: string;
+  readonly recovery?: CodeGraphStoreRecovery;
+  readonly retryable: boolean;
+  /** Authored, path-free diagnostic safe for CLI and Manager receipts. */
+  readonly summary: string;
+}
+
+export interface CodeGraphWorksetPrepareCoverageV1 {
+  readonly complete: boolean;
+  readonly excluded: number;
+  readonly failed: number;
+  readonly missing: number;
+  readonly ready: number;
+  readonly requested: number;
+}
+
 export interface CodeGraphWorksetPrepareResultV1 {
   readonly bridges?: CodeGraphWorksetPrepareBridgeReceiptV1;
+  readonly coverage: CodeGraphWorksetPrepareCoverageV1;
   readonly manifestDigest: string;
   readonly members: readonly CodeGraphWorksetPrepareMemberV1[];
   readonly published?: CodeGraphWorksetCatalogGenerationReceiptV1;
@@ -122,6 +155,7 @@ export interface CodeGraphWorksetStatusMemberV1 {
     | 'invalid-repository'
     | 'missing-path'
     | 'no-ready-snapshot'
+    | 'not-in-published-generation'
     | 'snapshot-drift'
     | 'status-corrupt'
     | 'status-failed'
@@ -157,6 +191,55 @@ export interface CodeGraphWorksetStatusResultV1 {
 
 export interface PrepareCodeGraphWorksetOptionsV1 {
   readonly concurrency?: number;
+  readonly onProgress?: (progress: CodeGraphWorksetPrepareProgressV1) => Effect.Effect<void, unknown>;
+}
+
+export type CodeGraphWorksetPreparePhaseV1 =
+  | 'bridging'
+  | 'cataloging'
+  | 'completed'
+  | 'failed'
+  | 'indexing'
+  | 'projecting'
+  | 'publishing'
+  | 'starting'
+  | 'waiting';
+
+export interface CodeGraphWorksetPrepareIndexActivityV1 {
+  readonly completed?: number;
+  readonly phase: CodeGraphProgress['phase'];
+  readonly reason?: Extract<CodeGraphProgress, {readonly phase: 'waiting'}>['reason'];
+  readonly subphase?: string;
+  readonly total?: number;
+  readonly unit?: 'files' | 'snapshots' | 'symbols';
+}
+
+export interface CodeGraphWorksetPrepareProgressV1 {
+  readonly activity?: CodeGraphWorksetPrepareIndexActivityV1;
+  readonly attempt?: number;
+  readonly completed: number;
+  readonly elapsedMilliseconds: number;
+  readonly maxAttempts?: number;
+  readonly member?: CodeGraphWorksetPrepareMemberV1;
+  readonly message: string;
+  readonly phase: CodeGraphWorksetPreparePhaseV1;
+  readonly project?: string;
+  readonly resultState?: CodeGraphWorksetPrepareResultV1['state'];
+  readonly total: number;
+  readonly type: 'code-graph-workset-progress';
+  readonly version: 1;
+  readonly workset: string;
+}
+
+interface CodeGraphWorksetPrepareProgressInputV1 {
+  readonly activity?: CodeGraphWorksetPrepareIndexActivityV1;
+  readonly attempt?: number;
+  readonly completed?: number;
+  readonly maxAttempts?: number;
+  readonly member?: CodeGraphWorksetPrepareMemberV1;
+  readonly phase: CodeGraphWorksetPreparePhaseV1;
+  readonly project?: string;
+  readonly resultState?: CodeGraphWorksetPrepareResultV1['state'];
 }
 
 export function codeGraphWorksetManifestDigest(workset: ResolvedWorkset): string {
@@ -192,22 +275,60 @@ const prepareCodeGraphWorksetScoped = Effect.fn('codeGraphWorkset.prepareScoped'
       }),
   });
   const manifestDigest = codeGraphWorksetManifestDigest(workset);
+  const total = workset.projects.length + workset.unresolvedProjects.length;
+  const startedAt = yield* Clock.currentTimeMillis;
+  const completed = yield* Ref.make(0);
+  const progressGate = yield* Semaphore.make(1);
+  const telemetry = yield* makeCodeGraphWorksetTelemetryReporter();
+  const reportAt = (input: CodeGraphWorksetPrepareProgressInputV1) =>
+    progressGate.withPermit(
+      Effect.all([Clock.currentTimeMillis, Ref.get(completed)]).pipe(
+        Effect.flatMap(([now, completedMembers]) =>
+          reportCodeGraphWorksetPrepareProgress(options.onProgress, telemetry.progress, {
+            ...input,
+            completed: input.completed ?? completedMembers,
+            elapsedMilliseconds: Math.max(0, now - startedAt),
+            message: '',
+            total,
+            type: 'code-graph-workset-progress',
+            version: 1,
+            workset: workset.name,
+          }),
+        ),
+        Effect.catchCause(() => Effect.void),
+      ),
+    );
+  const completeMember = (phase: 'indexing' | 'projecting', member: CodeGraphWorksetPrepareMemberV1) =>
+    Ref.updateAndGet(completed, value => Math.min(total, value + 1)).pipe(
+      Effect.flatMap(count => reportAt({completed: count, member, phase, project: member.project})),
+    );
+  yield* reportAt({phase: 'starting'});
+  const unresolved: readonly PreparedMemberWithProjection[] = workset.unresolvedProjects.map(
+    project =>
+      ({
+        project: safeLabel(project),
+        reason: 'unknown-project',
+        state: 'excluded',
+      }) as const satisfies CodeGraphWorksetPrepareMemberV1,
+  );
+  yield* Effect.forEach(unresolved, member => completeMember('indexing', member), {discard: true});
   const indexed = yield* Effect.forEach(
     workset.projects,
-    project => prepareConfiguredSnapshot(config, project, fs, indexer),
+    project => prepareConfiguredSnapshot(config, project, fs, indexer, reportAt, completeMember),
     {concurrency},
   );
   const projectionDigests = new Set<string>();
   let stagedGenerationId: string | undefined;
   const critical = Effect.gen(function* () {
     yield* assertCurrentWorksetManifest(config, workset.name, manifestDigest);
+    yield* reportAt({phase: 'cataloging'});
     yield* drainCodeGraphWorksetCatalogCleanup(config.agentContextHome);
     // Projection reads and catalog appends are deliberately serial: at most one
     // normalized symbol page is live across the complete preparation.
     const configured: readonly PreparedMemberWithProjection[] = yield* Effect.forEach(
       indexed,
       member =>
-        stageConfiguredMember(config, member).pipe(
+        stageConfiguredMember(config, member, reportAt, completeMember).pipe(
           Effect.tap(prepared =>
             Effect.sync(() => {
               if (prepared.state === 'ready') projectionDigests.add(prepared.projectionDigest);
@@ -215,14 +336,6 @@ const prepareCodeGraphWorksetScoped = Effect.fn('codeGraphWorkset.prepareScoped'
           ),
         ),
       {concurrency: 1},
-    );
-    const unresolved: readonly PreparedMemberWithProjection[] = workset.unresolvedProjects.map(
-      project =>
-        ({
-          project: safeLabel(project),
-          reason: 'unknown-project',
-          state: 'excluded',
-        }) as const satisfies CodeGraphWorksetPrepareMemberV1,
     );
     const members: readonly PreparedMemberWithProjection[] = [...configured, ...unresolved];
     const generationMembers = members.flatMap(member =>
@@ -239,8 +352,10 @@ const prepareCodeGraphWorksetScoped = Effect.fn('codeGraphWorkset.prepareScoped'
     });
     stagedGenerationId = staged.state === 'staging' ? staged.id : undefined;
     const bridgeMembers = members.filter((member): member is PreparedReadyMember => member.state === 'ready');
+    yield* reportAt({completed: yield* Ref.get(completed), phase: 'bridging'});
     const bridges = yield* prepareCodeGraphWorksetBridgesForGeneration(config, staged.id, bridgeMembers);
     yield* assertPreparedMemberLeases(members);
+    yield* reportAt({completed: yield* Ref.get(completed), phase: 'publishing'});
     const published = yield* publishCodeGraphWorksetCatalogGeneration(config.agentContextHome, {
       beforePointerSwap: () =>
         assertPreparedMemberLeases(members).pipe(
@@ -263,6 +378,7 @@ const prepareCodeGraphWorksetScoped = Effect.fn('codeGraphWorkset.prepareScoped'
     ),
   );
   const layout = codeGraphWorksetCatalogLayout(path, config.agentContextHome);
+  yield* reportAt({completed: yield* Ref.get(completed), phase: 'waiting'});
   return yield* withExclusiveFileLock(fs, layout.prepareLockPath, WORKSET_PREPARE_LOCK_OPTIONS, critical).pipe(
     Effect.mapError(cause =>
       cause instanceof CodeGraphWorksetCatalogError
@@ -275,8 +391,119 @@ const prepareCodeGraphWorksetScoped = Effect.fn('codeGraphWorkset.prepareScoped'
             {cause},
           ),
     ),
+    Effect.tap(result =>
+      reportAt({completed: total, phase: 'completed', resultState: result.state}).pipe(
+        Effect.andThen(telemetry.terminal(result)),
+      ),
+    ),
+    Effect.onExit(exit =>
+      Exit.isFailure(exit)
+        ? Ref.get(completed).pipe(
+            Effect.flatMap(count =>
+              reportAt({completed: count, phase: 'failed'}).pipe(
+                Effect.andThen(telemetry.failure(Cause.squash(exit.cause), count, total)),
+              ),
+            ),
+          )
+        : Effect.void,
+    ),
   );
 });
+
+function reportCodeGraphWorksetPrepareProgress(
+  reporter: PrepareCodeGraphWorksetOptionsV1['onProgress'],
+  telemetryReporter: (progress: CodeGraphWorksetPrepareProgressV1) => Effect.Effect<void>,
+  progress: CodeGraphWorksetPrepareProgressV1,
+) {
+  const event = {...progress, message: renderCodeGraphWorksetPrepareProgress(progress)};
+  return Effect.all([reporter?.(event) ?? Effect.void, telemetryReporter(event)], {discard: true}).pipe(
+    Effect.catchCause(() => Effect.void),
+  );
+}
+
+export function renderCodeGraphWorksetPrepareProgress(
+  progress: Omit<CodeGraphWorksetPrepareProgressV1, 'message'> | CodeGraphWorksetPrepareProgressV1,
+): string {
+  const count = `${progress.completed}/${progress.total} members · ${formatWorksetPrepareElapsed(progress.elapsedMilliseconds)}`;
+  switch (progress.phase) {
+    case 'starting':
+      return `Workset starting · ${progress.total} member${progress.total === 1 ? '' : 's'}.`;
+    case 'waiting':
+      return `Workset waiting · home-global publication lock · ${count}.`;
+    case 'indexing': {
+      const attempt =
+        progress.attempt === undefined
+          ? ''
+          : ` · attempt ${progress.attempt}/${progress.maxAttempts ?? progress.attempt}`;
+      const activity = renderCodeGraphWorksetIndexActivity(progress.activity);
+      const terminal = progress.member === undefined ? '' : ` · ${renderPrepareMemberTerminal(progress.member)}`;
+      return `Workset indexing · ${progress.project ?? 'member'}${attempt}${activity}${terminal} · ${count}.`;
+    }
+    case 'projecting': {
+      const terminal = progress.member === undefined ? '' : ` · ${renderPrepareMemberTerminal(progress.member)}`;
+      return `Workset projecting · ${progress.project ?? 'member'}${terminal} · ${count}.`;
+    }
+    case 'cataloging':
+      return `Workset cataloging · staging an atomic routing catalog · ${count}.`;
+    case 'bridging':
+      return `Workset bridging · resolving cross-repository bridges · ${count}.`;
+    case 'publishing':
+      return `Workset publishing · atomic generation pointer · ${count}.`;
+    case 'completed':
+      return progress.resultState === 'ready'
+        ? `Workset completed · published generation · ${count}.`
+        : `Workset completed · no ready generation published · ${count}.`;
+    case 'failed':
+      return `Workset failed · previous generation preserved · ${count}.`;
+  }
+}
+
+function formatWorksetPrepareElapsed(milliseconds: number): string {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1_000));
+  if (seconds < 60) return `${seconds}s elapsed`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${seconds % 60}s elapsed`;
+}
+
+function renderCodeGraphWorksetIndexActivity(activity: CodeGraphWorksetPrepareIndexActivityV1 | undefined): string {
+  if (activity === undefined) return '';
+  const phase = activity.subphase === undefined ? activity.phase : `${activity.phase}/${activity.subphase}`;
+  const measured =
+    activity.completed === undefined || activity.total === undefined
+      ? ''
+      : ` ${activity.completed}/${activity.total}${activity.unit === undefined ? '' : ` ${activity.unit}`}`;
+  const reason = activity.reason === undefined ? '' : ` (${activity.reason})`;
+  return ` · ${phase}${measured}${reason}`;
+}
+
+function renderPrepareMemberTerminal(member: CodeGraphWorksetPrepareMemberV1): string {
+  switch (member.state) {
+    case 'ready':
+      return `ready with ${member.symbolCount} routing symbols`;
+    case 'failed':
+      return `${member.reason}: ${member.detail.summary}`;
+    case 'excluded':
+    case 'missing':
+      return `${member.state}: ${member.reason}`;
+  }
+}
+
+function codeGraphWorksetPrepareIndexActivity(progress: CodeGraphProgress): CodeGraphWorksetPrepareIndexActivityV1 {
+  const measured =
+    'completed' in progress && 'total' in progress
+      ? {
+          completed: progress.completed,
+          total: progress.total,
+          ...('unit' in progress ? {unit: progress.unit} : {}),
+        }
+      : {};
+  return {
+    ...measured,
+    phase: progress.phase,
+    ...(progress.phase === 'waiting' && progress.reason !== undefined ? {reason: progress.reason} : {}),
+    ...('subphase' in progress && progress.subphase !== undefined ? {subphase: progress.subphase} : {}),
+  };
+}
 
 function assertCurrentWorksetManifest(config: RuntimeConfig, worksetName: string, expectedDigest: string) {
   return requireWorkset(config.manifestPath, worksetName).pipe(
@@ -356,6 +583,25 @@ export const inspectCodeGraphWorksetStatus = Effect.fn('codeGraphWorkset.status'
     published === undefined ? 'missing' : generationDrift || states.current !== members.length ? 'stale' : 'ready';
   const warnings = [
     ...(published === undefined ? ['No published routing catalog exists; run `threadnote workset prepare`.'] : []),
+    ...(states.uncatalogued > 0
+      ? [
+          `${states.uncatalogued} member(s) have a ready repository snapshot but are absent from the published workset generation; prepare the workset and review its member receipts.`,
+        ]
+      : []),
+    ...(states.deferred > 0
+      ? [
+          `${states.deferred} member(s) need a ready repository snapshot; workset preparation will index them explicitly.`,
+        ]
+      : []),
+    ...(states.failed > 0
+      ? [`${states.failed} member status check(s) failed; review the typed recovery detail below.`]
+      : []),
+    ...(states.missing > 0
+      ? [`${states.missing} configured member path(s) are missing; correct the project path or restore the checkout.`]
+      : []),
+    ...(states.stale > 0
+      ? [`${states.stale} member(s) no longer match the published generation; prepare the workset again.`]
+      : []),
     ...(generationDrift ? ['The published catalog generation does not match the current workset manifest.'] : []),
     ...(unresolved.length > 0 ? ['The workset names projects that are absent from the seed manifest.'] : []),
     ...(published !== undefined && bridges === undefined
@@ -387,39 +633,100 @@ function prepareConfiguredSnapshot(
   project: ProjectManifest,
   fs: FileSystem.FileSystem,
   indexer: CodeGraphIndexerShape,
+  report: (progress: CodeGraphWorksetPrepareProgressInputV1) => Effect.Effect<void>,
+  completeMember: (phase: 'indexing' | 'projecting', member: CodeGraphWorksetPrepareMemberV1) => Effect.Effect<void>,
 ) {
   return Effect.gen(function* () {
     const cwd = yield* expandPath(project.path);
-    if (!(yield* fs.exists(cwd))) return failedPrepareMember(project.name, 'missing-path');
-    const indexed = yield* indexer.index({cwd, ensureVectors: false, threadnoteHome: config.agentContextHome});
+    if (!(yield* fs.exists(cwd))) {
+      const missing = failedPrepareMember(project.name, 'missing-path');
+      yield* completeMember('indexing', missing);
+      return missing;
+    }
+    const projectName = safeLabel(project.name);
+    const indexAttempt = (attempt: number): Effect.Effect<CodeGraphIndexSummary, unknown> =>
+      report({
+        attempt,
+        maxAttempts: CODE_GRAPH_WORKSET_PREPARE_MEMBER_ATTEMPTS_MAXIMUM,
+        phase: 'indexing',
+        project: projectName,
+      }).pipe(
+        Effect.andThen(
+          indexer.index({
+            cwd,
+            ensureVectors: false,
+            onProgress: progress =>
+              report({
+                activity: codeGraphWorksetPrepareIndexActivity(progress),
+                attempt,
+                maxAttempts: CODE_GRAPH_WORKSET_PREPARE_MEMBER_ATTEMPTS_MAXIMUM,
+                phase: 'indexing',
+                project: projectName,
+              }),
+            threadnoteHome: config.agentContextHome,
+          }),
+        ),
+        Effect.catch(error =>
+          attempt < CODE_GRAPH_WORKSET_PREPARE_MEMBER_ATTEMPTS_MAXIMUM &&
+          codeGraphWorksetPrepareFailureDetail(error, 'index').retryable
+            ? Effect.sleep(CODE_GRAPH_WORKSET_PREPARE_RETRY_DELAY).pipe(Effect.andThen(indexAttempt(attempt + 1)))
+            : Effect.fail(error),
+        ),
+      );
+    const outcome = yield* Effect.result(indexAttempt(1));
+    if (Result.isFailure(outcome)) {
+      const failed = failedPrepareMember(project.name, 'index-failed', outcome.failure);
+      yield* completeMember('indexing', failed);
+      return failed;
+    }
+    const indexed = outcome.success;
     return {
       indexed: {identity: indexed.identity, snapshot: indexed.snapshot},
-      project: safeLabel(project.name),
+      project: projectName,
       state: 'indexed',
     } as const;
-  }).pipe(Effect.catch(() => Effect.succeed(failedPrepareMember(project.name, 'index-failed'))));
+  }).pipe(
+    Effect.catch(error => {
+      const failed = failedPrepareMember(project.name, 'index-failed', error);
+      return completeMember('indexing', failed).pipe(Effect.as(failed));
+    }),
+  );
 }
 
-function stageConfiguredMember(config: RuntimeConfig, member: PreparedSnapshotMember) {
+function stageConfiguredMember(
+  config: RuntimeConfig,
+  member: PreparedSnapshotMember,
+  report: (progress: CodeGraphWorksetPrepareProgressInputV1) => Effect.Effect<void>,
+  completeMember: (phase: 'indexing' | 'projecting', member: CodeGraphWorksetPrepareMemberV1) => Effect.Effect<void>,
+) {
   return Effect.gen(function* () {
     if (member.state !== 'indexed') return member;
-    return yield* stageCodeGraphWorksetRoutingProjectionScoped({
-      identity: member.indexed.identity,
-      snapshotId: member.indexed.snapshot.id,
-      threadnoteHome: config.agentContextHome,
-    }).pipe(
-      Effect.map(built => ({
-        assertLease: built.assertLease,
+    yield* report({phase: 'projecting', project: member.project});
+    const outcome = yield* Effect.result(
+      stageCodeGraphWorksetRoutingProjectionScoped({
         identity: member.indexed.identity,
-        project: member.project,
-        projectionDigest: built.receipt.projectionDigest,
-        repositoryId: built.receipt.repositoryId,
-        snapshotId: built.receipt.snapshotId,
-        state: 'ready' as const,
-        symbolCount: built.receipt.symbolCount,
-      })),
-      Effect.catch(() => Effect.succeed(failedPrepareMember(member.project, 'projection-failed'))),
+        snapshotId: member.indexed.snapshot.id,
+        threadnoteHome: config.agentContextHome,
+      }),
     );
+    if (Result.isFailure(outcome)) {
+      const failed = failedPrepareMember(member.project, 'projection-failed', outcome.failure);
+      yield* completeMember('projecting', failed);
+      return failed;
+    }
+    const built = outcome.success;
+    const ready = {
+      assertLease: built.assertLease,
+      identity: member.indexed.identity,
+      project: member.project,
+      projectionDigest: built.receipt.projectionDigest,
+      repositoryId: built.receipt.repositoryId,
+      snapshotId: built.receipt.snapshotId,
+      state: 'ready' as const,
+      symbolCount: built.receipt.symbolCount,
+    };
+    yield* completeMember('projecting', publicPrepareMember(ready));
+    return ready;
   });
 }
 
@@ -491,7 +798,7 @@ export function classifyCodeGraphWorksetStatusMember(
     ...(status.readySnapshot === undefined ? {} : {snapshotId: status.readySnapshot.id}),
   };
   if (status.readySnapshot === undefined) return {...common, reason: 'no-ready-snapshot', state: 'deferred'};
-  if (published === undefined) return {...common, state: 'uncatalogued'};
+  if (published === undefined) return {...common, reason: 'not-in-published-generation', state: 'uncatalogued'};
   if (published.repositoryId !== status.identity.repositoryId)
     return {...common, reason: 'identity-drift', state: 'stale'};
   if (published.checkoutId !== status.identity.checkoutId) return {...common, reason: 'checkout-drift', state: 'stale'};
@@ -546,9 +853,105 @@ type PreparedMemberWithProjection =
 function failedPrepareMember(
   project: string,
   reason: 'index-failed' | 'missing-path' | 'projection-failed',
+  error?: unknown,
 ): Exclude<CodeGraphWorksetPrepareMemberV1, {readonly state: 'excluded' | 'ready'}> {
   if (reason === 'missing-path') return {project: safeLabel(project), reason, state: 'missing'};
-  return {project: safeLabel(project), reason, state: 'failed'};
+  return {
+    detail: codeGraphWorksetPrepareFailureDetail(error, reason === 'index-failed' ? 'index' : 'projection'),
+    project: safeLabel(project),
+    reason,
+    state: 'failed',
+  };
+}
+
+export function codeGraphWorksetPrepareFailureDetail(
+  error: unknown,
+  stage: 'index' | 'projection',
+): CodeGraphWorksetPrepareFailureDetailV1 {
+  if (error instanceof CodeGraphStoreError) {
+    return {
+      code: error.code,
+      errorType: safePrepareErrorType(error),
+      recovery: error.recovery,
+      retryable: error.retryable,
+      summary: worksetStoreRecoverySummary(error.recovery),
+    };
+  }
+  if (error instanceof CodeGraphRepositoryError) {
+    return {
+      code: 'repository',
+      errorType: error.name,
+      retryable: false,
+      summary: 'The configured project path is not a readable Git repository.',
+    };
+  }
+  if (
+    error instanceof WorktreeChangedDuringIndex ||
+    error instanceof RepositoryMaintenanceInterrupted ||
+    error instanceof RepositoryRegistrationLost
+  ) {
+    return {
+      code: 'worktree-changed',
+      errorType: error.name,
+      retryable: true,
+      summary:
+        error instanceof RepositoryMaintenanceInterrupted
+          ? 'Graph maintenance superseded indexing; retry after maintenance completes.'
+          : 'The repository changed while indexing; retry when the checkout is stable.',
+    };
+  }
+  if (error instanceof CodeGraphWorksetCatalogError) {
+    return {
+      code: 'catalog',
+      errorType: error.name,
+      retryable: error.reason === 'busy',
+      summary:
+        error.reason === 'capacity'
+          ? 'The routing projection exceeded a bounded catalog capacity; inspect catalog storage diagnostics.'
+          : 'The routing catalog could not stage this member; inspect catalog diagnostics and retry.',
+    };
+  }
+  return {
+    code: 'unknown',
+    errorType: safePrepareErrorType(error),
+    retryable: false,
+    summary:
+      stage === 'index'
+        ? 'Repository indexing failed; run graph diagnostics for this project and retry.'
+        : 'Routing projection failed; run graph diagnostics for this project and retry.',
+  };
+}
+
+function safePrepareErrorType(error: unknown): string {
+  const name = error instanceof Error ? error.name : 'UnknownError';
+  return /^[A-Za-z][A-Za-z0-9_.-]{0,79}$/u.test(name) ? name : 'UnknownError';
+}
+
+function worksetStoreRecoverySummary(recovery: CodeGraphStoreRecovery): string {
+  const summaries: Readonly<Record<CodeGraphStoreRecovery, string>> = {
+    defer: 'Graph storage is busy; wait for the active operation and retry.',
+    diagnose: 'Graph storage failed; run graph diagnostics for this project.',
+    'fix-permissions': 'Graph storage is not writable; fix its permissions and retry.',
+    'free-space': 'Graph storage is out of safe disk capacity; free space and retry.',
+    'manual-migration': 'Graph storage needs a compatible Threadnote runtime or manual migration.',
+    'manual-rebuild': 'Graph storage is corrupt; diagnose and rebuild this project graph.',
+    'migrate-additive': 'Graph storage needs its additive schema migration before retrying.',
+    'reconnect-runtime': 'Reconnect this Threadnote runtime after the graph schema upgrade.',
+    'retry-read-only': 'Graph storage hit transient I/O; retry after the filesystem settles.',
+  };
+  return summaries[recovery];
+}
+
+export function codeGraphWorksetPrepareCoverage(
+  members: readonly CodeGraphWorksetPrepareMemberV1[],
+): CodeGraphWorksetPrepareCoverageV1 {
+  const coverage = {excluded: 0, failed: 0, missing: 0, ready: 0};
+  for (const member of members) coverage[member.state] += 1;
+  return {
+    ...coverage,
+    complete: coverage.ready === members.length,
+    requested: members.length,
+  };
 }
 
 function prepareResult(
@@ -558,10 +961,12 @@ function prepareResult(
   published: CodeGraphWorksetCatalogGenerationReceiptV1 | undefined,
   bridges?: CodeGraphWorksetPrepareBridgeReceiptV1,
 ): CodeGraphWorksetPrepareResultV1 {
+  const publicMembers = members.map(publicPrepareMember);
   return {
     ...(bridges === undefined ? {} : {bridges}),
+    coverage: codeGraphWorksetPrepareCoverage(publicMembers),
     manifestDigest,
-    members: members.map(publicPrepareMember),
+    members: publicMembers,
     ...(published === undefined ? {} : {published}),
     state: published === undefined ? 'failed' : 'ready',
     type: 'code-graph-workset-prepare',

--- a/src/code_graph/workset_progress.ts
+++ b/src/code_graph/workset_progress.ts
@@ -1,0 +1,64 @@
+import {Clock, Console, Effect, Ref, Semaphore} from 'effect';
+import type {CodeGraphWorksetPrepareProgressV1} from './workset_catalog/workset.js';
+
+export const CODE_GRAPH_WORKSET_JSON_PROGRESS_INTERVAL_MILLISECONDS = 2_000;
+
+export interface CodeGraphWorksetJsonProgressState {
+  readonly completed: number;
+  readonly lastEmittedAtMilliseconds?: number;
+  readonly signature?: string;
+}
+
+export function codeGraphWorksetJsonProgressDecision(
+  state: CodeGraphWorksetJsonProgressState,
+  progress: CodeGraphWorksetPrepareProgressV1,
+  nowMilliseconds: number,
+  intervalMilliseconds = CODE_GRAPH_WORKSET_JSON_PROGRESS_INTERVAL_MILLISECONDS,
+): {readonly emit: boolean; readonly state: CodeGraphWorksetJsonProgressState} {
+  const signature = [
+    progress.phase,
+    progress.project,
+    progress.attempt,
+    progress.activity?.phase,
+    progress.activity?.subphase,
+    progress.activity?.reason,
+  ].join('/');
+  const intervalElapsed =
+    state.lastEmittedAtMilliseconds === undefined ||
+    nowMilliseconds < state.lastEmittedAtMilliseconds ||
+    nowMilliseconds - state.lastEmittedAtMilliseconds >= Math.max(1, intervalMilliseconds);
+  const emit =
+    state.lastEmittedAtMilliseconds === undefined ||
+    signature !== state.signature ||
+    progress.member !== undefined ||
+    progress.completed > state.completed ||
+    progress.phase === 'completed' ||
+    progress.phase === 'failed' ||
+    intervalElapsed;
+  return {
+    emit,
+    state: emit
+      ? {
+          completed: Math.max(state.completed, progress.completed),
+          lastEmittedAtMilliseconds: nowMilliseconds,
+          signature,
+        }
+      : {...state, completed: Math.max(state.completed, progress.completed)},
+  };
+}
+
+export const makeCodeGraphWorksetJsonProgressReporter = Effect.fn('codeGraph.command.makeWorksetJsonProgressReporter')(
+  function* () {
+    const state = yield* Ref.make<CodeGraphWorksetJsonProgressState>({completed: 0});
+    const semaphore = yield* Semaphore.make(1);
+    return (progress: CodeGraphWorksetPrepareProgressV1) =>
+      semaphore.withPermit(
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis;
+          const decision = codeGraphWorksetJsonProgressDecision(yield* Ref.get(state), progress, now);
+          yield* Ref.set(state, decision.state);
+          if (decision.emit) yield* Console.error(JSON.stringify(progress));
+        }),
+      );
+  },
+);

--- a/src/code_graph/workset_telemetry.ts
+++ b/src/code_graph/workset_telemetry.ts
@@ -1,0 +1,159 @@
+import {Clock, Effect} from 'effect';
+import {
+  emitAnonymousTelemetryEvent,
+  recordAnonymousTelemetryFields,
+  type AnonymousTelemetryFields,
+} from '../effect/telemetry.js';
+import {anonymousTelemetryDiagnosticFromError, type AnonymousTelemetryDiagnostic} from '../telemetry/diagnostic.js';
+import type {CodeGraphStoreFailureCode} from './types.js';
+import type {
+  CodeGraphWorksetPrepareFailureDetailV1,
+  CodeGraphWorksetPrepareProgressV1,
+  CodeGraphWorksetPrepareResultV1,
+} from './workset_catalog/workset.js';
+
+const WORKSET_TELEMETRY_CHECKPOINT_INTERVAL_MILLISECONDS = 60_000;
+const STORE_FAILURE_CODES = new Set<CodeGraphStoreFailureCode>([
+  'busy',
+  'confirmed-corruption',
+  'incompatible-schema',
+  'no-space',
+  'permission',
+  'schema-additive',
+  'transient-io',
+  'unknown',
+]);
+
+export const makeCodeGraphWorksetTelemetryReporter = Effect.fn('codeGraph.makeWorksetTelemetryReporter')(() =>
+  Effect.sync(() => {
+    let lastEmittedAt = Number.NEGATIVE_INFINITY;
+    let lastPhase: CodeGraphWorksetPrepareProgressV1['phase'] | undefined;
+    let terminalEmitted = false;
+
+    const progress = (current: CodeGraphWorksetPrepareProgressV1) =>
+      Effect.gen(function* () {
+        const fields = codeGraphWorksetTelemetryFields(current);
+        yield* recordAnonymousTelemetryFields(fields);
+        const now = yield* Clock.currentTimeMillis;
+        if (
+          current.phase === lastPhase &&
+          current.phase !== 'completed' &&
+          current.phase !== 'failed' &&
+          now - lastEmittedAt < WORKSET_TELEMETRY_CHECKPOINT_INTERVAL_MILLISECONDS
+        )
+          return;
+        lastPhase = current.phase;
+        lastEmittedAt = now;
+        yield* emitAnonymousTelemetryEvent({
+          component: 'cli',
+          event: 'checkpoint',
+          fields,
+          operation: 'workset.prepare',
+          ...(current.phase === 'failed' ? {errorType: 'CodeGraphWorksetCatalogError', outcome: 'failure'} : {}),
+        });
+      }).pipe(Effect.catchCause(() => Effect.void));
+
+    const terminal = (result: CodeGraphWorksetPrepareResultV1) =>
+      Effect.suspend(() => {
+        if (terminalEmitted) return Effect.void;
+        terminalEmitted = true;
+        const failure = result.members.find(member => member.state === 'failed');
+        const diagnostic = failure === undefined ? undefined : worksetFailureDiagnostic(failure.detail);
+        const outcome = result.state === 'failed' ? 'failure' : result.coverage.complete ? 'success' : 'unavailable';
+        return emitAnonymousTelemetryEvent({
+          component: 'cli',
+          ...(diagnostic === undefined ? {} : {diagnostic}),
+          ...(outcome === 'success' ? {} : {errorType: diagnostic?.errorType ?? 'ReportedError'}),
+          event: 'lifecycle',
+          fields: {
+            phase: 'storage.writing',
+            phaseOutcome: outcome,
+            stage: 'committing',
+            workUnitsCompleted: result.coverage.ready,
+            workUnitsTotal: result.coverage.requested,
+          },
+          operation: 'workset.prepare',
+          outcome,
+        }).pipe(Effect.catchCause(() => Effect.void));
+      });
+
+    const failure = (error: unknown, completed: number, total: number) =>
+      Effect.suspend(() => {
+        if (terminalEmitted) return Effect.void;
+        terminalEmitted = true;
+        const diagnostic = anonymousTelemetryDiagnosticFromError(error);
+        return emitAnonymousTelemetryEvent({
+          component: 'cli',
+          ...(diagnostic === undefined ? {} : {diagnostic}),
+          errorType: diagnostic?.errorType ?? 'UnknownError',
+          event: 'lifecycle',
+          fields: {
+            phase: 'storage.writing',
+            phaseOutcome: 'failure',
+            stage: 'committing',
+            workUnitsCompleted: completed,
+            workUnitsTotal: total,
+          },
+          operation: 'workset.prepare',
+          outcome: 'failure',
+        }).pipe(Effect.catchCause(() => Effect.void));
+      });
+
+    return {failure, progress, terminal};
+  }),
+);
+
+export function codeGraphWorksetTelemetryFields(progress: CodeGraphWorksetPrepareProgressV1): AnonymousTelemetryFields {
+  return {
+    ...worksetTelemetryPhaseFields(progress),
+    ...(progress.phase === 'completed'
+      ? {phaseOutcome: progress.resultState === 'ready' ? ('success' as const) : ('failure' as const)}
+      : progress.phase === 'failed'
+        ? {phaseOutcome: 'failure' as const}
+        : {}),
+    workUnitsCompleted: progress.completed,
+    workUnitsTotal: progress.total,
+  };
+}
+
+function worksetTelemetryPhaseFields(progress: CodeGraphWorksetPrepareProgressV1): AnonymousTelemetryFields {
+  switch (progress.phase) {
+    case 'starting':
+      return {phase: 'storage.reading', stage: 'validating-input'};
+    case 'waiting':
+      return {phase: 'graph.waiting', waitingReason: 'database-writer'};
+    case 'indexing': {
+      const phase = `graph.${progress.activity?.phase ?? 'registering'}` as NonNullable<
+        AnonymousTelemetryFields['phase']
+      >;
+      return {
+        phase,
+        ...(progress.activity?.phase === 'waiting' && progress.activity.reason !== undefined
+          ? {waitingReason: progress.activity.reason}
+          : {}),
+      };
+    }
+    case 'projecting':
+      return {phase: 'storage.writing', stage: 'writing-symbols'};
+    case 'cataloging':
+      return {phase: 'storage.writing', stage: 'writing-receipt'};
+    case 'bridging':
+      return {phase: 'storage.writing', stage: 'writing-edges'};
+    case 'publishing':
+    case 'completed':
+    case 'failed':
+      return {phase: 'storage.writing', stage: 'committing'};
+  }
+}
+
+function worksetFailureDiagnostic(detail: CodeGraphWorksetPrepareFailureDetailV1): AnonymousTelemetryDiagnostic {
+  const storageCode = STORE_FAILURE_CODES.has(detail.code as CodeGraphStoreFailureCode)
+    ? (detail.code as CodeGraphStoreFailureCode)
+    : undefined;
+  return {
+    ...(storageCode === undefined ? {} : {code: storageCode, domain: 'code-graph-storage' as const}),
+    errorType: detail.errorType,
+    ...(detail.recovery === undefined ? {} : {recovery: detail.recovery}),
+    retryable: detail.retryable,
+  };
+}

--- a/src/manager_workset_progress.ts
+++ b/src/manager_workset_progress.ts
@@ -1,0 +1,27 @@
+import {Effect} from 'effect';
+import type {CodeGraphWorksetPrepareProgressV1} from './code_graph/workset_catalog/workset.js';
+import type {ManagerWorksetPrepareJob} from './manager_worksets.js';
+
+/** Project one core progress event into the bounded Manager job snapshot. */
+export function managerWorksetProgressFromEvent(progress: CodeGraphWorksetPrepareProgressV1) {
+  return {
+    ...(progress.activity === undefined ? {} : {activity: progress.activity}),
+    ...(progress.attempt === undefined ? {} : {attempt: progress.attempt}),
+    completed: progress.completed,
+    elapsedMilliseconds: progress.elapsedMilliseconds,
+    ...(progress.maxAttempts === undefined ? {} : {maxAttempts: progress.maxAttempts}),
+    message: progress.message,
+    phase: progress.phase,
+    ...(progress.project === undefined ? {} : {project: progress.project}),
+    total: progress.total,
+  };
+}
+
+export function updateManagerWorksetPrepareProgress(
+  entry: {job: ManagerWorksetPrepareJob},
+  progress: CodeGraphWorksetPrepareProgressV1,
+) {
+  return Effect.sync(() => {
+    if (entry.job.status === 'running') entry.job = {...entry.job, progress: managerWorksetProgressFromEvent(progress)};
+  });
+}

--- a/src/manager_worksets.ts
+++ b/src/manager_worksets.ts
@@ -11,6 +11,7 @@ import {CodeGraphWorksetCatalogError} from './code_graph/workset_catalog/types.j
 import {
   inspectCodeGraphWorksetStatus,
   prepareCodeGraphWorkset,
+  type CodeGraphWorksetPrepareProgressV1,
   type CodeGraphWorksetPrepareResultV1,
 } from './code_graph/workset_catalog/workset.js';
 import {
@@ -28,6 +29,7 @@ import {
   validateManagerProjectRoots,
   type ManagerProjectRootValidation,
 } from './manager_project_roots.js';
+import {updateManagerWorksetPrepareProgress} from './manager_workset_progress.js';
 import {validateProjectSeedPatterns} from './seed_pattern.js';
 import {parseResourceId} from './storage/resource-id.js';
 import type {ProjectManifest, RuntimeConfig, SeedManifest, WorksetManifest} from './types.js';
@@ -182,13 +184,19 @@ export interface ManagerWorksetPrepareJob {
   readonly finishedAt?: string;
   readonly id: string;
   readonly progress: {
+    readonly activity?: CodeGraphWorksetPrepareProgressV1['activity'];
+    readonly attempt?: number;
     readonly completed?: number;
+    readonly elapsedMilliseconds?: number;
+    readonly maxAttempts?: number;
     readonly message: string;
-    readonly phase: 'cancelled' | 'cancelling' | 'completed' | 'failed' | 'preparing';
+    readonly phase: 'cancelled' | 'cancelling' | CodeGraphWorksetPrepareProgressV1['phase'];
+    readonly project?: string;
     readonly total: number;
   };
   readonly result?: CodeGraphWorksetPrepareResultV1;
   readonly status: ManagerWorksetJobStatus;
+  readonly warning?: string;
   readonly workset: string;
 }
 
@@ -208,7 +216,10 @@ export interface ManagerWorksetApiRequest {
   readonly prepareWorkset?: (
     config: RuntimeConfig,
     worksetName: string,
-    options: {readonly concurrency?: number},
+    options: {
+      readonly concurrency?: number;
+      readonly onProgress?: (progress: CodeGraphWorksetPrepareProgressV1) => Effect.Effect<void, unknown>;
+    },
   ) => Effect.Effect<CodeGraphWorksetPrepareResultV1, unknown, ApplicationServices>;
   readonly url: URL;
 }
@@ -848,8 +859,9 @@ function startManagerWorksetPrepare(request: ManagerWorksetApiRequest, body: Rec
           createdAt,
           id,
           progress: {
-            message: 'Indexing members, building routing projections, and publishing one atomic generation.',
-            phase: 'preparing',
+            completed: 0,
+            message: `Preparing ${total} workset member${total === 1 ? '' : 's'}.`,
+            phase: 'starting',
             total,
           },
           status: 'running',
@@ -859,6 +871,7 @@ function startManagerWorksetPrepare(request: ManagerWorksetApiRequest, body: Rec
       registry.jobs.set(id, entry);
       const fiber = yield* (request.prepareWorkset ?? prepareCodeGraphWorkset)(request.config, workset, {
         ...(concurrency === undefined ? {} : {concurrency}),
+        onProgress: progress => updateManagerWorksetPrepareProgress(entry, progress),
       }).pipe(
         Effect.matchCauseEffect({
           onFailure: cause => finishFailedPrepareJob(entry, cause),
@@ -907,12 +920,20 @@ function finishSuccessfulPrepareJob(entry: InternalManagerWorksetPrepareJob, res
           progress: {
             completed: result.members.length,
             message:
-              result.state === 'ready' ? 'Published the ready generation.' : 'Preparation finished without publishing.',
+              result.state !== 'ready'
+                ? 'Preparation finished without publishing.'
+                : result.coverage.complete
+                  ? 'Published the complete ready generation.'
+                  : `Published a generation with incomplete coverage: ${result.coverage.ready}/${result.coverage.requested} members ready.`,
             phase: result.state === 'ready' ? 'completed' : 'failed',
             total: entry.job.progress.total,
           },
           result,
           status: result.state === 'ready' ? 'completed' : 'failed',
+          warning:
+            result.state === 'ready' && !result.coverage.complete
+              ? 'The generation is usable, but one or more members need attention. Review the receipts below.'
+              : undefined,
         };
       }),
     ),

--- a/src/manager_worksets_view.tsx
+++ b/src/manager_worksets_view.tsx
@@ -896,7 +896,9 @@ function WorksetStatusPanel(props: {
                   <small>{managerWorksetMemberLocation(definitionMember)}</small>
                   <small>
                     {member.reason ?? 'ready snapshot verified'}
+                    {member.detail ? ` · code: ${member.detail.code}` : ''}
                     {member.detail?.recovery ? ` · recovery: ${member.detail.recovery}` : ''}
+                    {member.detail ? ` · ${member.detail.retryable ? 'retryable' : 'not retryable'}` : ''}
                   </small>
                 </article>
               );
@@ -938,8 +940,13 @@ export function PrepareJobPanel(props: {
         </strong>
         <span>{props.job.progress.message}</span>
       </div>
+      <progress
+        aria-label={`${props.job.workset} preparation progress`}
+        max={Math.max(1, props.job.progress.total)}
+        value={Math.min(props.job.progress.total, props.job.progress.completed ?? 0)}
+      />
       <span>
-        {props.job.progress.completed ?? 0}/{props.job.progress.total} member receipts
+        {props.job.progress.completed ?? 0}/{props.job.progress.total} members complete
       </span>
       {active ? (
         <button disabled={props.job.status === 'cancelling'} onClick={props.onCancel} type="button">
@@ -947,6 +954,7 @@ export function PrepareJobPanel(props: {
         </button>
       ) : null}
       {props.job.error ? <p className="worksets-error">{props.job.error}</p> : null}
+      {props.job.warning ? <p className="worksets-warning">{props.job.warning}</p> : null}
       {receipts.length > 0 ? (
         <div className="worksets-job-receipts">
           {receipts.map(member => (
@@ -954,7 +962,13 @@ export function PrepareJobPanel(props: {
               <strong>{member.project}</strong>
               <span className={`worksets-state is-${statusTone(member.state)}`}>{member.state}</span>
               <small>{managerWorksetMemberLocation(findDefinitionMember(props.definition, member.project))}</small>
-              <small>{'reason' in member ? member.reason : `${member.symbolCount} symbols projected`}</small>
+              <small>
+                {member.state === 'failed'
+                  ? `${member.reason} · ${member.detail.code} · ${member.detail.summary}`
+                  : 'reason' in member
+                    ? member.reason
+                    : `${member.symbolCount} symbols projected`}
+              </small>
             </article>
           ))}
           {allReceipts.length > receipts.length ? (

--- a/test/unit/code-graph.workset-prepare.test.ts
+++ b/test/unit/code-graph.workset-prepare.test.ts
@@ -1,18 +1,28 @@
 import {TestError} from '../helpers/test-error.js';
 import {it as effectIt} from '@effect/vitest';
-import {Effect, Exit, FileSystem, Path, Semaphore} from 'effect';
+import {Effect, Exit, Fiber, FileSystem, Path, Semaphore} from 'effect';
+import {TestClock} from 'effect/testing';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {CodeGraphIndexer, type CodeGraphIndexerShape} from '../../src/code_graph/indexer.js';
 import {CodeGraphQueryService} from '../../src/code_graph/query.js';
-import {inspectCodeGraphWorksetStatus, prepareCodeGraphWorkset} from '../../src/code_graph/workset_catalog/workset.js';
+import {
+  inspectCodeGraphWorksetStatus,
+  prepareCodeGraphWorkset,
+  type CodeGraphWorksetPrepareProgressV1,
+} from '../../src/code_graph/workset_catalog/workset.js';
 import {
   CODE_GRAPH_WORKSET_CATALOG_PROJECTOR_VERSION,
   CodeGraphWorksetCatalogError,
   type CodeGraphWorksetCatalogGenerationReceiptInputV1,
   type CodeGraphWorksetCatalogGenerationReceiptV1,
 } from '../../src/code_graph/workset_catalog/types.js';
-import type {CodeGraphIndexSummary, RepositoryIdentity} from '../../src/code_graph/types.js';
+import {
+  CodeGraphStoreBusyError,
+  CodeGraphStoreNoSpaceError,
+  type CodeGraphIndexSummary,
+  type RepositoryIdentity,
+} from '../../src/code_graph/types.js';
 import type {ResolvedWorkset, RuntimeConfig} from '../../src/types.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
@@ -439,6 +449,85 @@ describe('code graph workset mixed-coverage preparation', () => {
         generationId: generation.id,
         projectionDigests: ['b'.repeat(64)],
       });
+    }).pipe(provideTestLayer(ApplicationLayer));
+  });
+
+  effectIt.effect('streams member progress and retries one typed transient index failure', () => {
+    const fs = {exists: (path: string) => Effect.succeed(path === '/ready')} as unknown as FileSystem.FileSystem;
+    const progress: CodeGraphWorksetPrepareProgressV1[] = [];
+    let attempts = 0;
+    const indexer: CodeGraphIndexerShape = {
+      ensureCommit: () => Effect.die('not used'),
+      index: options =>
+        Effect.suspend(() => {
+          attempts += 1;
+          return (options.onProgress?.({phase: 'waiting', reason: 'repository-lock'}) ?? Effect.void).pipe(
+            Effect.andThen(
+              attempts === 1
+                ? Effect.fail(new CodeGraphStoreBusyError('busy fixture', {operation: 'workset member index'}))
+                : Effect.succeed(summary),
+            ),
+          );
+        }),
+    };
+
+    return Effect.gen(function* () {
+      const fiber = yield* prepareCodeGraphWorkset(config, 'engineering', {
+        onProgress: event => Effect.sync(() => progress.push(event)),
+      }).pipe(
+        Effect.provideService(FileSystem.FileSystem, fs),
+        Effect.provideService(CodeGraphIndexer, indexer),
+        Effect.forkChild({startImmediately: true}),
+      );
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust('250 millis');
+      const result = yield* Fiber.join(fiber);
+
+      expect(attempts).toBe(2);
+      expect(result.coverage).toEqual({complete: false, excluded: 0, failed: 0, missing: 1, ready: 1, requested: 2});
+      expect(progress[0]).toMatchObject({completed: 0, phase: 'starting', total: 2});
+      expect(progress).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({attempt: 1, phase: 'indexing', project: 'ready'}),
+          expect.objectContaining({attempt: 2, phase: 'indexing', project: 'ready'}),
+          expect.objectContaining({activity: {phase: 'waiting', reason: 'repository-lock'}, project: 'ready'}),
+          expect.objectContaining({member: expect.objectContaining({project: 'missing', state: 'missing'})}),
+          expect.objectContaining({member: expect.objectContaining({project: 'ready', state: 'ready'})}),
+          expect.objectContaining({completed: 2, phase: 'completed', resultState: 'ready'}),
+        ]),
+      );
+      expect(progress.map(event => event.completed)).toEqual(
+        [...progress.map(event => event.completed)].sort((left, right) => left - right),
+      );
+    }).pipe(provideTestLayer(ApplicationLayer));
+  });
+
+  effectIt.effect('keeps actionable typed detail when every member index fails', () => {
+    const fs = {exists: (path: string) => Effect.succeed(path === '/ready')} as unknown as FileSystem.FileSystem;
+    const indexer: CodeGraphIndexerShape = {
+      ensureCommit: () => Effect.die('not used'),
+      index: () => Effect.fail(new CodeGraphStoreNoSpaceError('no space fixture', {operation: 'workset index'})),
+    };
+
+    return Effect.gen(function* () {
+      const result = yield* prepareCodeGraphWorkset(config, 'engineering').pipe(
+        Effect.provideService(FileSystem.FileSystem, fs),
+        Effect.provideService(CodeGraphIndexer, indexer),
+      );
+
+      expect(result.state).toBe('failed');
+      expect(result.coverage).toEqual({complete: false, excluded: 0, failed: 1, missing: 1, ready: 0, requested: 2});
+      expect(result.members[0]).toMatchObject({
+        detail: {
+          code: 'no-space',
+          errorType: 'CodeGraphStoreNoSpaceError',
+          recovery: 'free-space',
+          retryable: false,
+        },
+        reason: 'index-failed',
+        state: 'failed',
+      });
+      expect(mocks.stageGeneration).not.toHaveBeenCalled();
     }).pipe(provideTestLayer(ApplicationLayer));
   });
 

--- a/test/unit/code-graph.workset-progress.property.test.ts
+++ b/test/unit/code-graph.workset-progress.property.test.ts
@@ -1,0 +1,108 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  codeGraphWorksetPrepareCoverage,
+  type CodeGraphWorksetPrepareMemberV1,
+  type CodeGraphWorksetPrepareProgressV1,
+} from '../../src/code_graph/workset_catalog/workset.js';
+import {
+  CODE_GRAPH_WORKSET_JSON_PROGRESS_INTERVAL_MILLISECONDS,
+  codeGraphWorksetJsonProgressDecision,
+} from '../../src/code_graph/workset_progress.js';
+import {codeGraphWorksetTelemetryFields} from '../../src/code_graph/workset_telemetry.js';
+
+describe('code graph workset progress properties', () => {
+  it('partitions every member receipt exactly and marks only all-ready coverage complete', () => {
+    fc.assert(
+      fc.property(fc.array(fc.constantFrom('excluded', 'failed', 'missing', 'ready'), {maxLength: 128}), states => {
+        const members = states.map((state, index) => member(state, index));
+        const coverage = codeGraphWorksetPrepareCoverage(members);
+        expect(coverage.ready + coverage.failed + coverage.missing + coverage.excluded).toBe(members.length);
+        expect(coverage.requested).toBe(members.length);
+        expect(coverage.complete).toBe(states.every(state => state === 'ready'));
+      }),
+    );
+  });
+
+  it('coalesces identical non-terminal JSON updates inside the interval', () => {
+    fc.assert(
+      fc.property(fc.integer({min: 0, max: 4_096}), fc.integer({min: 0, max: 1_000_000}), (completed, now) => {
+        const progress = progressEvent(completed);
+        const first = codeGraphWorksetJsonProgressDecision({completed: 0}, progress, now);
+        const repeated = codeGraphWorksetJsonProgressDecision(
+          first.state,
+          progress,
+          now + CODE_GRAPH_WORKSET_JSON_PROGRESS_INTERVAL_MILLISECONDS - 1,
+        );
+        expect(first.emit).toBe(true);
+        expect(repeated.emit).toBe(false);
+      }),
+    );
+  });
+
+  it('never regresses the coalescer completed-member high-water mark', () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer({min: 0, max: 4_096}), {maxLength: 256}), samples => {
+        const final = samples.reduce(
+          (state, completed, index) =>
+            codeGraphWorksetJsonProgressDecision(state, progressEvent(completed), index).state,
+          {completed: 0},
+        );
+        expect(final.completed).toBe(Math.max(0, ...samples));
+      }),
+    );
+  });
+
+  it('projects workset progress into path-free anonymous telemetry fields', () => {
+    expect(codeGraphWorksetTelemetryFields(progressEvent(3))).toEqual({
+      phase: 'graph.registering',
+      workUnitsCompleted: 3,
+      workUnitsTotal: 8,
+    });
+  });
+});
+
+function member(state: 'excluded' | 'failed' | 'missing' | 'ready', index: number): CodeGraphWorksetPrepareMemberV1 {
+  const project = `project-${index}`;
+  switch (state) {
+    case 'ready':
+      return {
+        project,
+        projectionDigest: 'a'.repeat(64),
+        repositoryId: 'b'.repeat(64),
+        snapshotId: `cgsn_${'c'.repeat(40)}-direct`,
+        state,
+        symbolCount: index,
+      };
+    case 'failed':
+      return {
+        detail: {
+          code: 'unknown',
+          errorType: 'UnknownError',
+          retryable: false,
+          summary: 'Repository indexing failed; run graph diagnostics for this project and retry.',
+        },
+        project,
+        reason: 'index-failed',
+        state,
+      };
+    case 'missing':
+      return {project, reason: 'missing-path', state};
+    case 'excluded':
+      return {project, reason: 'unknown-project', state};
+  }
+}
+
+function progressEvent(completed: number): CodeGraphWorksetPrepareProgressV1 {
+  return {
+    completed,
+    elapsedMilliseconds: completed * 10,
+    message: 'fixture',
+    phase: 'indexing',
+    project: 'fixture',
+    total: 8,
+    type: 'code-graph-workset-progress',
+    version: 1,
+    workset: 'engineering',
+  };
+}

--- a/test/unit/manager-worksets.test.ts
+++ b/test/unit/manager-worksets.test.ts
@@ -1409,6 +1409,108 @@ describe('Manager Worksets API and human labels', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
+  effectIt.effect('makes live member progress pollable before preparation completes', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const current = yield* fixture(root => manifest(root, 'worksets:\n  - name: platform\n    projects: [api]'));
+        const contextKey = {};
+        const jobScope = yield* Scope.make();
+        const progressObserved = yield* Deferred.make<void>();
+        const release = yield* Deferred.make<void>();
+        const started = yield* handleManagerWorksetRequest({
+          body: Effect.succeed({workset: 'platform'}),
+          config: current.config,
+          contextKey,
+          jobScope,
+          method: 'POST',
+          prepareWorkset: (_config, workset, options) =>
+            (
+              options.onProgress?.({
+                activity: {completed: 5, phase: 'scanning', total: 10, unit: 'files'},
+                attempt: 1,
+                completed: 0,
+                elapsedMilliseconds: 2_500,
+                maxAttempts: 2,
+                message: 'api · indexing · scanning 5/10 files · 0/1 members.',
+                phase: 'indexing',
+                project: 'api',
+                total: 1,
+                type: 'code-graph-workset-progress',
+                version: 1,
+                workset,
+              }) ?? Effect.void
+            ).pipe(
+              Effect.andThen(Deferred.succeed(progressObserved, undefined)),
+              Effect.andThen(Deferred.await(release)),
+              Effect.as({
+                coverage: {complete: true, excluded: 0, failed: 0, missing: 0, ready: 1, requested: 1},
+                manifestDigest: 'd'.repeat(64),
+                members: [
+                  {
+                    project: 'api',
+                    projectionDigest: 'e'.repeat(64),
+                    repositoryId: 'f'.repeat(64),
+                    snapshotId: `cgsn_${'a'.repeat(40)}-direct`,
+                    state: 'ready' as const,
+                    symbolCount: 10,
+                  },
+                ],
+                state: 'ready' as const,
+                type: 'code-graph-workset-prepare' as const,
+                version: 1 as const,
+                workset,
+              }),
+            ),
+          url: new URL('http://127.0.0.1/api/worksets/prepare'),
+        });
+        if (started === undefined) return yield* Effect.fail(new TestError('prepare route was not handled'));
+        const id = (started.body as {readonly job: {readonly id: string}}).job.id;
+        yield* Deferred.await(progressObserved);
+
+        const running = yield* handleManagerWorksetRequest({
+          body: Effect.succeed({}),
+          config: current.config,
+          contextKey,
+          jobScope,
+          method: 'GET',
+          url: new URL(`http://127.0.0.1/api/worksets/jobs/${id}`),
+        });
+        expect(running).toMatchObject({
+          body: {
+            job: {
+              progress: {
+                activity: {completed: 5, phase: 'scanning', total: 10, unit: 'files'},
+                attempt: 1,
+                completed: 0,
+                elapsedMilliseconds: 2_500,
+                phase: 'indexing',
+                project: 'api',
+              },
+              status: 'running',
+            },
+          },
+          status: 200,
+        });
+
+        yield* Deferred.succeed(release, undefined);
+        yield* Effect.yieldNow;
+        const completed = yield* handleManagerWorksetRequest({
+          body: Effect.succeed({}),
+          config: current.config,
+          contextKey,
+          jobScope,
+          method: 'GET',
+          url: new URL(`http://127.0.0.1/api/worksets/jobs/${id}`),
+        });
+        expect(completed).toMatchObject({
+          body: {job: {progress: {completed: 1, phase: 'completed'}, status: 'completed'}},
+          status: 200,
+        });
+        yield* Scope.close(jobScope, Exit.void);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('registers one Manager-lifetime finalizer while retaining only 32 completed jobs', () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -1426,6 +1528,7 @@ describe('Manager Worksets API and human labels', () => {
             method: 'POST',
             prepareWorkset: (_config, workset) =>
               Effect.succeed({
+                coverage: {complete: true, excluded: 0, failed: 0, missing: 0, ready: 0, requested: 0},
                 manifestDigest: 'd'.repeat(64),
                 members: [],
                 state: 'ready',
@@ -1507,6 +1610,7 @@ describe('Manager Worksets API and human labels', () => {
       id: 'cgwj_example',
       progress: {completed: 2, message: 'Preparation finished without publishing.', phase: 'failed' as const, total: 2},
       result: {
+        coverage: {complete: false, excluded: 0, failed: 1, missing: 0, ready: 1, requested: 2},
         manifestDigest: 'd'.repeat(64),
         members: [
           {
@@ -1517,7 +1621,17 @@ describe('Manager Worksets API and human labels', () => {
             state: 'ready' as const,
             symbolCount: 42,
           },
-          {project: 'worker', reason: 'index-failed' as const, state: 'failed' as const},
+          {
+            detail: {
+              code: 'unknown' as const,
+              errorType: 'TestError',
+              retryable: false,
+              summary: 'Repository indexing failed; run graph diagnostics for this project and retry.',
+            },
+            project: 'worker',
+            reason: 'index-failed' as const,
+            state: 'failed' as const,
+          },
         ],
         state: 'failed' as const,
         type: 'code-graph-workset-prepare' as const,

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -1524,7 +1524,7 @@ worksets:
           },
           {
             type: 'paragraph',
-            text: 'Definitions do not build graphs. Choose Prepare to start an explicit background Manager job that indexes the selected repositories, builds exact routing and bridge projections, and atomically publishes one generation. The tab remains usable while the job runs, shows its Workset name and terminal member receipts, supports Stop preparation, and polls only the lightweight job record. Stopping is interruption-safe, but an atomic publication may have completed just before interruption; the selected readiness view is refreshed and remains authoritative.',
+            text: 'Definitions do not build graphs. Choose Prepare to start an explicit background Manager job that indexes the selected repositories, builds exact routing and bridge projections, and atomically publishes one generation. The live job shows the active member, bounded retry attempt, repository-index phase and counters, completed-member count, elapsed time, and later catalog/bridge/publication phases before showing typed terminal receipts. Incomplete published coverage is a visible warning rather than a silent success. The tab remains usable while the job runs, supports Stop preparation, and polls only the lightweight job record. Stopping is interruption-safe, but an atomic publication may have completed just before interruption; the selected readiness view is refreshed and remains authoritative.',
           },
           {type: 'visual', visual: 'manager-prepare-query'},
           {
@@ -1532,7 +1532,7 @@ worksets:
             items: [
               'Reloading the same Manager page rediscovers active and recent jobs. The bounded list retains 32 summaries and fetches one selected job result on demand.',
               'Closing Manager interrupts its active prepare and waits for staging cleanup. Jobs are session state, not a persistent queue or daemon.',
-              'Readiness is loaded only for the selected Workset. It reports current, stale, missing, failed, excluded, deferred, and uncatalogued members plus exact-bridge coverage and recovery guidance.',
+              'Readiness is loaded only for the selected Workset. It reports current, stale, missing, failed, excluded, deferred, and uncatalogued members plus exact-bridge coverage and recovery guidance. Uncatalogued explicitly means that a ready repository snapshot is absent from the published generation.',
               'Status and every read operation use only ready published state and never trigger a cold repository build. Prepare is the only Worksets action that builds.',
             ],
           },

--- a/website/src/content/docsMemoryWorkflows.ts
+++ b/website/src/content/docsMemoryWorkflows.ts
@@ -175,11 +175,11 @@ threadnote workset prepare checkout --json`,
         },
         {
           type: 'paragraph',
-          text: 'Preparation builds or refreshes configured repositories, streams routing projections into the home-global catalog, resolves supported cross-repository monikers, and atomically publishes one cgwg_ generation. It may publish a non-empty ready subset while retaining missing, failed, or excluded member receipts. If no member can be published, the prior ready generation remains the last good state.',
+          text: 'Preparation builds or refreshes configured repositories, streams routing projections into the home-global catalog, resolves supported cross-repository monikers, and atomically publishes one cgwg_ generation. The CLI reports the active member, repository-index phase and counters, projection/catalog/bridge/publication phases, elapsed time, and completed-member count while work continues. A retryable storage or checkout race receives one bounded retry. It may publish a non-empty ready subset while retaining missing, failed, or excluded member receipts; incomplete coverage is called out separately from publication success. If no member can be published, the prior ready generation remains the last good state.',
         },
         {
           type: 'paragraph',
-          text: 'The JSON prepare receipt reports each ready/missing/failed/excluded member, projection symbol counts, the published generation, moniker and bridge counts, resolver version, rejection count, and any unavailable repositories. JSON status separates catalog missing/ready/stale from member current/deferred/excluded/failed/missing/stale/uncatalogued states and includes the published bridge digest/count plus complete, partial, or failed bridge coverage diagnostics.',
+          text: 'The JSON prepare command emits bounded code-graph-workset-progress records on stderr and keeps the final receipt on stdout. The receipt reports complete/incomplete coverage, each ready/missing/failed/excluded member, typed failure code, retryability and recovery guidance, projection symbol counts, the published generation, moniker and bridge counts, resolver version, rejection count, and any unavailable repositories. JSON status separates catalog missing/ready/stale from member current/deferred/excluded/failed/missing/stale/uncatalogued states and includes the published bridge digest/count plus complete, partial, or failed bridge coverage diagnostics. Uncatalogued means a ready repository snapshot is absent from the published Workset generation, not that its repository indexing necessarily failed.',
         },
         {
           type: 'paragraph',


### PR DESCRIPTION
## Summary

- add typed, live workset preparation progress to the CLI and Manager
- retry transient member indexing failures and preserve actionable path-safe diagnostics
- report complete versus partial publication coverage and emit anonymous lifecycle telemetry
- document the workflow and add Effect regressions plus bounded Fast-check properties

## Verification

- full test suite: 3,433 passed, 22 skipped
- focused final suite: 58 passed
- lint, typecheck, Prettier, diff, and file-length checks passed
- exact HEAD installed globally and verified with complete 2/2 and partial 2/3 workset preparation smokes
- Threadnote doctor completed with 0 failures

Go was unavailable locally. The telemetry gateway schema is unchanged, and its TypeScript contract tests passed.
