### PR TITLE
perf(graph): defer ordinary MCP freshness scans

### DIFF
--- a/docs/4.3-large-repository-graph-performance-plan.md
+++ b/docs/4.3-large-repository-graph-performance-plan.md
@@ -1,0 +1,578 @@
+# Threadnote 4.3 large-repository graph performance plan
+
+Status: approved; Slice 1 runtime fast path and benchmark instrumentation implemented
+
+Baseline date: 2026-08-20
+
+Source baseline: Threadnote 4.2.7 at `297cdb92bd164ed2ea58dd6c366c60c67aba97cf`
+
+## Objective
+
+Make graph inspection predictably fast and available for repositories with hundreds of thousands of files and
+millions of graph nodes without weakening Threadnote's exact-current contracts.
+
+The priority order is:
+
+1. remove blocking whole-worktree observation from ordinary immutable-snapshot reads and establish an exact-HEAD
+   benchmark contract;
+2. introduce query-stage telemetry through a gateway-first schema-v3 and consent-v3 rollout;
+3. replace repeated whole-worktree freshness scans with a watcher-backed exact receipt;
+4. replace repository-wide dirty-build replay with fine-grained dependency invalidation;
+5. reuse partial materialization and structurally share graph generations;
+6. add traversal-oriented storage and preprocessing for large topology operations; and
+7. improve lexical and semantic candidate retrieval after the dominant current costs are controlled.
+
+SQLite remains the publication, metadata, lease, stable-ID, and lexical-search authority unless measurements prove a
+specific replacement is necessary. Distributed indexing, remote graph service dependencies, and a wholesale storage
+rewrite are not part of the first delivery phases.
+
+## Current execution
+
+### Slice 1 — ordinary deferred-freshness reads and benchmark instrumentation: implemented
+
+Let local `query`, `node`, `neighbors`, and `explain` read an existing immutable ready snapshot without first blocking
+on an exact dirty-worktree observation. The response is explicitly `deferred`, never falsely `current`; `path` and
+`impact` retain their exact-current pre/post-observation contract. Pair the behavior change with the exact-HEAD
+large-repository benchmark contract so its effect is measured independently. The paired exact/deferred orchestration
+measurement is implemented; a retained run on the governed >=200,000-file fixture remains a release acceptance gate.
+
+### Slice 2 — telemetry schema v3: next, gateway-first
+
+The deployed telemetry schema v2 and consent v2 are immutable. Query-stage and repository-shape buckets are a material
+new data category and must not be added to v2. Define schema v3, bump consent to v3, deploy/validate the gateway and
+storage canary first, and release a producer only after dual-version ingestion is proven.
+
+### Slice 3 — watcher-backed freshness receipt: gated
+
+Replace repeat Git observation for exact-current reads only after the receipt state machine, watcher-overflow behavior,
+strict-read retry contract, and exact-Git fallback are covered by deterministic tests. This slice remains independently
+reversible to the current exact observation path.
+
+## Evidence baseline
+
+### Anonymous production telemetry
+
+The live Grafana/Tempo assessment covered 2026-07-21 through 2026-08-20 UTC. Graph telemetry existed only during the
+last seven days of that window. Canary traffic was excluded from the stable-release cohort.
+
+| Signal                                        |                                                                                                                Observation | Planning consequence                                                            |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------- |
+| Stable-release `inspect_code_graph` outcomes  |                                                   590 events: 73.2% success, 24.7% unavailable, 1.7% failure, 0.3% timeout | Availability and currentness are part of the latency problem.                   |
+| Successful non-canary inspection duration     |                                                                             p50 <= 512 ms, p95 <= 8.192 s, p99 <= 32.768 s | Tail latency requires stage-level attribution.                                  |
+| Dirty graph builds                            |                                                                         38 total; 23 full; 21 classified unexpectedly full | Small dirty changes frequently fail over to repository-wide work.               |
+| Eligible dirty builds with non-zero delta     |                    17 of 26 had at least 256x rewrite amplification; 14 of 26 had at least 1024x fact-replay amplification | Changed-file count is not a useful proxy for graph work.                        |
+| Full-build fallback reasons                   |       16 `project-closure-incomplete`, 4 `resolution-surface-changed`, 2 `project-closure-unbounded`, 1 `file-set-changed` | Conservative resolution closure is the main observed fallback class.            |
+| Repositories in the 32,768–65,535-file bucket | Four full builds took at most 69.9–279.6 minutes and peaked at 2–4 GiB RSS; two snapshot reuses took at most 4.096 seconds | Reuse has orders-of-magnitude more leverage than constant-factor writer tuning. |
+
+These are event counts, not unique repositories or users. The duration values are histogram-bucket upper bounds, and
+the stable cohort can include more than one released runtime version. `unexpectedly full` is a work-amplification
+classification, not a correctness failure. The telemetry intentionally contains no repository identity, path, query,
+symbol, or source content, so it cannot currently correlate latency to an exact repository shape. The dashboard source
+is [threadnote-anonymous-telemetry-dashboard.json](../infra/telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json).
+
+### Checked-in large-repository evidence
+
+The strongest checked-in query fixture is historical and must not be presented as a 4.2.7 result. The dirty
+Threadnote 4.0 candidate benchmark used a pinned IntelliJ snapshot with 232,750 files, 2,666,762 symbols, 7,340,596
+edges, and a 35.34 GB database. Hot indexed search plus adjacency took about 43.7 ms, but end-to-end MCP operations
+took 3.54–4.67 seconds for query, 3.97 seconds for neighbors, 6.92 seconds for path, and 7.95 seconds for impact. The
+artifact attributes most of the gap to exact worktree observation and, for strict path/impact, a second observation:
+
+- [IntelliJ query benchmark](../test/evaluation/candidates/threadnote-4.0.0/benchmarks/darwin-arm64-m1-max/code-graph-intellij-query-2026-08-01.json)
+- [IntelliJ analysis benchmark](../test/evaluation/candidates/threadnote-4.0.0/benchmarks/darwin-arm64-m1-max/code-graph-intellij-analysis-summary-2026-08-01.json)
+
+Historical cold-build evidence on the same graph recorded roughly 2.9 hours total, a 33.35 GB database, an 8.36 GiB
+RSS peak, and materialization as the largest phase. It motivates the program but does not replace an exact-current-HEAD
+benchmark.
+
+### Current-source bottlenecks
+
+1. Freshness observation starts with `git status --porcelain` for ordinary local reads. Dirty observation can add a
+   recursive `git ls-tree`, workspace discovery, ignore evaluation, and dirty-overlay hashing. Strict path and impact
+   reads reobserve after traversal. See [inventory.ts](../src/code_graph/inventory.ts) and
+   [query.ts](../src/code_graph/query.ts).
+2. Incremental work fails closed when its bounded file, byte, row, workspace, or resolution-surface closure cannot be
+   proven. Current TypeScript logic no longer treats private path-local declarations as a published resolution-surface
+   change; old telemetry from before that correction must not be generalized to 4.2.7. See
+   [incremental_work.ts](../src/code_graph/incremental_work.ts),
+   [incremental_closure.ts](../src/code_graph/incremental_closure.ts), and
+   [resolution_surface.ts](../src/code_graph/resolution_surface.ts).
+3. Partial materialized-shard sets are not consumed independently. If the complete reusable set is unavailable,
+   materialization enters a serial decode, attribution, staging, and reference-resolution tail. See
+   [indexer_build.ts](../src/code_graph/indexer_build.ts) and
+   [indexer_materialization.ts](../src/code_graph/indexer_materialization.ts).
+4. Whole-graph topology is all-or-nothing. If all nodes cannot be loaded within the MCP budget, topology is disabled
+   and the already-read subset is discarded. The MCP node budget is below the historical multi-million-node graph.
+   See [analysis.ts](../src/code_graph/analysis.ts) and [mcp_server_code_graph.ts](../src/mcp_server_code_graph.ts).
+5. Path uses outgoing-only, unidirectional BFS, and semantic search decodes and scores every stored graph vector. See
+   [query.ts](../src/code_graph/query.ts), [embedding.ts](../src/code_graph/embedding.ts), and
+   [vector-search.ts](../src/search/vector-search.ts).
+
+## Non-negotiable invariants
+
+- A current result is never returned from an uncertain freshness receipt.
+- Watcher overflow, restart, unsupported filesystems, sequence gaps, and reconciliation mismatch fail closed to exact
+  Git observation; they do not silently downgrade correctness.
+- Ordinary reads may return a labelled ready/stale snapshot under their existing policy. `path` and `impact` retain
+  strict-current behavior unless an explicit future contract changes it.
+- Incremental and forced-full builds of the same repository state have the same canonical graph.
+- Approximate indexes can generate candidates or prove safe negative reachability only. They cannot create
+  authoritative edges, remove possible paths, or replace exact final verification.
+- Ready-snapshot publication remains atomic. Interruption, cancellation, failed migration, or failed compaction leaves
+  the previous ready snapshot queryable.
+- Repository size limits bound memory, time, and response shape; they do not silently omit persisted graph facts.
+- Telemetry remains low-cardinality and privacy-safe. It never records repository identity, commit, branch, path,
+  query text, symbol name, source text, or stable graph IDs.
+- Telemetry schemas are immutable. Query-stage and repository-shape fields require schema v3, consent v3, and a
+  gateway-first rollout; they are never appended to frozen schema v2.
+- Every new schema or storage representation has a versioned compatibility boundary and an independently testable
+  fallback to the previous read path during rollout.
+
+## Delivery phases
+
+## P0 — remove ordinary-read freshness blocking and establish measurement
+
+### P0.1 / Slice 1 — ordinary deferred-freshness fast path
+
+For local MCP `query`, `node`, `neighbors`, and `explain`, request status with worktree observation deliberately
+disabled. When the ready snapshot is runtime-current and has the same exact Git `HEAD`, return that immutable snapshot
+without first hydrating or hashing dirty worktree bytes. Carry the non-serializing status identity/`HEAD` evidence into
+inspection so the deferred path does not repeat repository identity discovery merely because no overlay was observed.
+
+The result contract is:
+
+- select the ready status as usable rather than stale, then return `freshness: deferred`; `deferred` means worktree
+  bytes were deliberately not Git-observed and must never be presented as `current`;
+- do not start a refresh solely because worktree observation was deferred when a usable ready snapshot exists;
+- allow the existing session watcher to coalesce an eligible background refresh after filesystem events, without
+  treating watcher silence as proof of currentness;
+- let that watcher own maintenance scheduling instead of enqueueing the same maintenance request from status,
+  shared-snapshot selection, and inspection;
+- preserve the current refresh behavior when no ready snapshot exists;
+- preserve stale/unavailable behavior when the ready pointer, exact `HEAD`, or runtime compatibility does not match;
+  and
+- retain exact pre/post worktree observation and current-only behavior for `path`, `impact`, explicit CLI/current
+  reads, shared-snapshot attach/promotion, index activation, and every other correctness-sensitive path.
+
+Node/Effect filesystem watchers can coalesce events or omit filenames and do not expose a portable overflow token.
+Slice 1 therefore uses the watcher only to request work, never to upgrade a result from `deferred` to `current`. A
+watcher defect, eviction, restart, or uncertainty changes nothing about the ordinary deferred result and retains exact
+observation for current-only operations.
+
+Slice 1 fast-path acceptance:
+
+- a matching runtime-current ready snapshot serves ordinary local reads without calling dirty-worktree observation;
+- the result is `deferred`, not `current`, and structured output explains that distinction;
+- dirty bytes cannot be mistaken for bytes represented by the ready snapshot;
+- ordinary reads do not start repository-sized refresh work merely to establish currentness;
+- cold/no-ready inspection retains its bounded refresh path;
+- `path`, `impact`, explicit-current reads, attach/promotion, and activation retain exact observation;
+- HEAD/runtime/pointer mismatch still returns stale, refresh, or unavailable according to the existing contract; and
+- focused regressions cover clean, preexisting dirty, mutation during read, divergent worktree, no-ready, runtime
+  mismatch, and watcher lifecycle cases.
+
+### P0.2 / Slice 1 — exact-HEAD benchmark contract
+
+Add or extend the large-repository benchmark so every retained result records:
+
+- clean Threadnote commit and dirty-state assertion;
+- pinned public fixture commit, inventory size, graph shape, and vector intent;
+- executable/version, feature flags, schema revisions, and freshness policy;
+- OS, architecture, CPU, memory, storage class, and cold/warm cache classification;
+- warmup and measurement counts plus the request schedule;
+- end-to-end and stage durations, CPU, RSS, logical/physical I/O, and SQLite/WAL/TEMP peaks;
+- candidate, hydration, traversal, and completeness controls; and
+- structural/query digest parity against the selected baseline.
+
+Measure `query`, `node`, `neighbors`, `explain`, `path`, `impact`, and persisted/whole-topology analysis separately.
+Retain p50/p95/p99 distributions. An open-loop request schedule or equivalent latency recorder must avoid coordinated
+omission. A dirty source checkout, unpinned fixture, missing stage metrics, failed digest control, or host-contended run
+cannot publish a release-gate result.
+
+The historical IntelliJ artifact remains a directional control until the exact-HEAD benchmark is rerun; it is not
+silently replaced or compared as if hardware and runtime were identical.
+
+Slice 1 benchmark acceptance:
+
+- the contract fails closed on unpinned or dirty inputs;
+- one fixture reproduces the recorded graph shape and query controls deterministically;
+- stage totals reconcile with end-to-end duration within documented instrumentation overhead;
+- a control run proves instrumentation does not materially change graph output, p95 latency, or peak RSS; and
+- retained artifacts identify the exact implementation commit and distinguish cold, warm, ready, stale, and strict
+  current reads.
+
+### P0.3 / Slice 2 — gateway-first telemetry schema v3
+
+Schema v1 and schema v2 are immutable allowlists. Schema v2 consent covers terminal graph-build classifications, not
+query-stage or repository-shape observations. Define query observability as schema v3 and treat it as a material data
+category that invalidates consent v2. Preserve the traces-only isolation in [telemetry.md](telemetry.md): do not enable
+the application's existing Effect span tree for export. A dedicated reporter emits only the closed v3 stage surface.
+
+The schema-v3 rollout order is a hard compatibility gate:
+
+1. Specify the closed v3 resource/span envelope, field combinations, byte/rate budget, privacy review, documentation,
+   and consent-v3 preview text.
+2. Deploy a gateway/Collector revision that admits frozen v1, frozen v2, and candidate v3. Do not release a v3
+   producer yet.
+3. Extend the synthetic storage canary and require all supported versions to be accepted, stored, and queryable.
+4. Deploy v3 dashboard panels and verify their queries against synthetic v3 data.
+5. Release the producer with `TELEMETRY_CONSENT_VERSION = 3`. Existing v1/v2 opt-ins fail closed until the user reviews
+   and reapplies consent; Threadnote never migrates consent silently.
+6. Keep v1/v2 ingress and canaries until their supported producers are retired in a separate reviewed change.
+
+This preserves the gateway-first compatibility rule in the
+[production telemetry runbook](operations/telemetry-production.md); a v3 canary rejection blocks the producer release
+even when the health endpoint and older canaries pass.
+
+Schema v3 measures these nested graph-inspection stages independently:
+
+```text
+request
+  -> repository identity
+  -> Git/worktree observation
+  -> dirty-overlay construction
+  -> snapshot selection and database open
+  -> exact/lexical candidate selection
+  -> semantic candidate selection
+  -> node/edge hydration
+  -> adjacency or traversal
+  -> final strict reobservation
+  -> response serialization
+```
+
+The event/span attributes are bounded enums or logarithmic buckets:
+
+- operation: `query`, `node`, `neighbors`, `explain`, `path`, `impact`, or analysis operation;
+- outcome and structured unavailability/fallback reason;
+- requested freshness policy and returned freshness class;
+- stage name and whether it was skipped, reused, exact, stale, deferred, or cancelled;
+- repository file-count, graph-node-count, graph-edge-count, and database-size buckets;
+- candidate, hydrated-node, visited-node, and visited-edge count buckets;
+- freshness receipt result, exact-Git fallback class, and strict-retry count bucket;
+- lexical/semantic/vector index availability and candidate-source class; and
+- duration through spans plus existing RSS/phase instrumentation where available.
+
+Do not use raw numeric repository sizes as labels. High-volume counts belong in histogram values or bounded buckets,
+not unbounded label dimensions. If anonymous telemetry is disabled or consent is older than v3, query telemetry remains
+disabled. Local benchmark artifacts may retain exact aggregate counts but never repository-derived text.
+
+Add Grafana views for:
+
+- operation outcome and unavailability rate;
+- p50/p95/p99 end-to-end duration by operation and size bucket;
+- stage-duration contribution by operation;
+- freshness source, deferred-read rate, exact-Git fallback, and strict-retry rate;
+- traversal completeness and budget-exhaustion reason; and
+- version/schema/cohort comparison suitable for canary and rollback decisions.
+
+Slice 2 acceptance:
+
+- frozen schema-v2 fixtures and producers remain byte-for-byte compatible;
+- the v3 gateway rejects v2/v3 surface mixing, unknown fields, invalid combinations, and over-budget envelopes;
+- every v3 graph operation produces one terminal outcome and balanced stage spans;
+- cancellation and timeout produce terminal telemetry without detached spans;
+- skipped stages are distinguishable from zero-duration completed stages;
+- schema tests reject raw repository-, path-, query-, symbol-, and graph-ID-like fields;
+- consent v2 fails closed after the producer requires consent v3, and preview/apply is explicit;
+- Grafana can separate Git observation from indexed graph-read time and cohort by operation and size bucket; and
+- telemetry-disabled operation performs no external telemetry write.
+
+### P0.4 / Slice 3 — watcher-backed freshness receipt
+
+First qualify or introduce a watcher backend that exposes a monotonic sequence and explicit overflow/completeness
+signal on every supported platform. Node/Effect `fs.watch` alone is not sufficient: event coalescing, silent filename
+omission, and the lack of a portable overflow token mean watcher silence cannot prove currentness. Unsupported or
+unqualified backends keep ordinary results `deferred` and strict operations on exact Git observation.
+
+A qualified per-worktree receipt contains an exact Git baseline, monotonic watcher sequence, watcher instance
+identity, last reconciliation point, and validity state.
+
+```text
+unknown/invalid
+    -> exact Git observation
+    -> qualified watcher/journal handoff
+    -> valid receipt at sequence E
+    -> unchanged read reuses receipt only with continuity proof
+    -> filesystem event advances sequence
+    -> build/observation refreshes baseline
+
+overflow | watcher restart | sequence gap | unsupported filesystem | reconcile mismatch
+    -> invalid
+    -> exact Git observation
+```
+
+Reads may reuse the receipt only while watcher identity, sequence continuity, and overflow state remain proven. Strict
+reads capture the sequence before graph work and validate it after traversal; a changed or uncertain sequence retries
+through exact observation within the existing budget or returns structured indexing/deferred state. Periodic exact Git
+reconciliation audits the backend but is not used to excuse an unobservable gap.
+
+Threadnote may detect and recommend Git's untracked cache and built-in FSMonitor on supported repositories, following
+[Git's status guidance](https://git-scm.com/docs/git-status). It must not silently change repository or global Git
+configuration.
+
+Slice 3 acceptance:
+
+- an unchanged read can be labelled current without a recursive Git worktree scan only after an exact baseline and
+  continuous qualified watcher receipt are established;
+- watcher overflow/restart and deliberately dropped events never return a false-current result;
+- a mutation during strict traversal causes retry or structured incompleteness, never a mixed-state path/impact;
+- exact reconciliation repairs a stale receipt and records the fallback reason;
+- unsupported/unqualified environments keep ordinary reads deferred and current-only operations on exact Git; and
+- on an exact-HEAD >=200,000-file ready fixture, ordinary inspection targets p95 below 500 ms after warmup, with
+  freshness overhead separately visible and below its reviewed budget.
+
+## P1 — fine-grained invalidation and change pruning
+
+Persist the dependencies consulted while resolving each reference/file shard:
+
+```text
+reference or shard
+  -> ordered lookup keys consulted
+  -> positive and negative lookup outcomes
+  -> selected definition/output fingerprint
+  -> project/workspace surface dependencies
+```
+
+When a file changes, recompute the affected lookup keys and output fingerprints. If a result is value-equal, mark the
+computation green and stop reverse invalidation. Negative dependencies are required: adding a previously absent
+definition must invalidate references whose old lookup returned no candidate. Unknown dynamic resolution continues to
+fail closed.
+
+This follows the change-pruning model used by rustc's
+[red-green query system](https://rustc-dev-guide.rust-lang.org/queries/incremental-compilation.html) and the exact
+reverse-dependency invalidation model in [Bazel Skyframe](https://bazel.build/reference/skyframe). Use the existing
+published resolution surface and project closure as conservative outer bounds while the finer read-set rolls out.
+
+Dependencies:
+
+- P0 exact-HEAD benchmark and deterministic incremental/full parity fixture; production expansion additionally uses
+  the schema-v3 stage telemetry cohort when available;
+- stable versioned lookup-key and output-fingerprint contracts; and
+- bounded reverse-dependency storage with migration and cleanup behavior.
+
+Acceptance:
+
+- forced-full and incremental canonical graphs match for arbitrary bounded edit sequences;
+- definition add/delete/rename, import alias, re-export, ambiguity, and previously unresolved references invalidate
+  the correct closure;
+- private implementation-only changes do not invalidate unrelated projects;
+- eligible one-file edits stage only the changed facts and affected closure;
+- benchmark rewrite-amplification p95 is below 32x for the governed one-file workload;
+- production `unexpectedly full` falls below 5% after a statistically useful cohort, with fallback reasons retained;
+  and
+- any dependency-model uncertainty selects the existing safe full path.
+
+## P2 — partial materialization and generation sharing
+
+1. Reuse each compatible materialized shard independently instead of requiring an all-or-nothing reusable shard set.
+2. Pipeline extraction, normalization, staging, and resolution through queues bounded by source bytes, fact bytes, and
+   rows, not only file count.
+3. Schedule work using historical extraction/fact cost and isolate heavy-tail files into observable lanes.
+4. Keep Git blob access in persistent `cat-file --batch` processes where profiling proves process launch is material.
+5. Build reconstructable shadow generations with sorted bulk insertion, deferred nonessential indexes, validation, and
+   atomic ready publication.
+6. Extend the current base/tombstone representation to share clean generations, with explicit overlay-depth,
+   read-amplification, byte, and age compaction thresholds.
+
+This phase must be selected from isolated, same-host experiments. The existing
+[SQLite writer tuning experiment](sqlite-writer-tuning-experiment.md) remains the template: change one variable,
+preserve digest/query controls, and reject memory, liveness, durability, or publication regressions.
+
+Acceptance:
+
+- one missing or invalid shard does not force compatible shards to be decoded and rewritten;
+- interruption at every stage leaves the previous ready generation queryable;
+- pre- and post-compaction query results, topology summaries, and structural digests match;
+- overlay depth and read amplification remain within committed limits under long edit/commit/revert sequences;
+- no repository-sized JavaScript symbol/reference collection is introduced; and
+- cold and incremental improvements are demonstrated on exact-HEAD same-host runs, not inferred from microbenchmarks.
+
+## P3 — traversal-oriented storage and topology
+
+Add generation-local dense integer ordinals and immutable outgoing/incoming compressed sparse row (CSR) adjacency
+packs. SQLite remains the source of stable external IDs, evidence, metadata, deltas, and publication state. A small
+delta/tombstone overlay serves changes until background compaction produces the next immutable pack. This follows the
+immutable-base-plus-delta approach described by [LLAMA](https://www.seltzer.com/assets/publications/LLAMA.pdf).
+
+At generation publication:
+
+- compute strongly connected components in `O(V + E)` and persist the condensation DAG;
+- persist in/out degree, component, project-level edge counts, and top-hub summaries;
+- optionally compute bounded/scoped Leiden communities for visualization only;
+- generate GRAIL interval labels for fast negative reachability pruning; and
+- retain enough provenance to rebuild every derived pack from authoritative SQLite rows.
+
+Path uses exact bidirectional BFS over the condensation DAG and expands the smaller frontier. GRAIL may reject proven
+non-reachable pairs, but any possible result proceeds to exact traversal. Impact uses incoming CSR plus compressed or
+Roaring frontier sets and direction-aware sparse/dense traversal. See the
+[GRAIL paper](https://scispace.com/pdf/grail-a-scalable-index-for-reachability-queries-in-very-2ca6qjuckq.pdf),
+[Roaring bitmap paper](https://arxiv.org/abs/1402.6407), and
+[Leiden paper](https://doi.org/10.1038/s41598-019-41695-z).
+
+Acceptance:
+
+- `neighbors(v)` reads only `O(degree(v))` adjacency data plus bounded overlay work;
+- path results match the existing exact BFS on bounded randomized graphs;
+- reachability labels have zero false negatives; possible positives are exactly verified;
+- persisted stats/hubs avoid query-time whole-graph scans;
+- multi-million-node analysis returns complete persisted summaries or an explicitly scoped/partial result instead of
+  reading 100,000 nodes and discarding them; and
+- cancellation is observed within 250 ms and always reports structured completeness/budget state.
+
+## P4 — lexical and semantic candidate retrieval
+
+1. Push package, path, language, and project scope into indexed candidate selection before top-k truncation.
+2. Evaluate Block-Max WAND over the existing compact lexical postings for exact top-k early termination. See the
+   [Block-Max WAND paper](https://research.engineering.nyu.edu/~suel/papers/bmw.pdf).
+3. Replace exact all-vector scanning with a versioned ANN candidate index such as HNSW, IVF-PQ, or DiskANN, followed
+   by exact metadata and graph filtering. See the [HNSW paper](https://arxiv.org/abs/1603.09320).
+4. Trigger semantic candidates from lexical confidence/margin, not only when lexical returns fewer than its seed
+   limit.
+5. Keep embeddings selective, asynchronous, reusable, and optional. A query never starts a repository-sized embedding
+   rebuild.
+
+Acceptance:
+
+- package/project-scoped recall is not reduced by global prefilter truncation;
+- lexical top-k matches the exact scorer on bounded randomized posting lists;
+- ANN recall/latency/memory are measured against exact scoring on frozen fixtures;
+- ANN is never used for exact IDs, adjacency, path, impact, or authoritative resolution; and
+- semantic unavailability leaves deterministic lexical/exact graph operations intact.
+
+## P5 — shared and remote graph bases, deferred
+
+Consider content-addressed shared bases across worktrees or remote prebuilt graph artifacts only after deterministic
+extraction, fine-grained dependency closure, and incremental/full equivalence are proven locally. Any remote artifact
+must be authenticated, versioned, content-addressed, reconstructable, and layered beneath a local exact worktree
+overlay. clangd's local dynamic index over background/remote bases is a useful model:
+[clangd indexing design](https://clangd.llvm.org/design/indexing).
+
+This phase is not required to meet the local large-repository latency targets.
+
+## Dependency order
+
+| Work                             | Requires                                                                       | Blocks                                 |
+| -------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------- |
+| Deferred ordinary-read fast path | Existing immutable ready-snapshot and deferred-freshness contracts             | Immediate ordinary-read latency target |
+| P0 exact-HEAD benchmark          | Deterministic pinned fixture and digest controls                               | Performance acceptance for all phases  |
+| Schema-v3 query telemetry        | Gateway-first v3 allowlist/canary plus explicit consent v3                     | Production cohort rollout decisions    |
+| Watcher freshness receipt        | Qualified overflow-aware backend, stage metrics, and state-machine/fault tests | Exact-current no-scan target           |
+| Fine-grained invalidation        | Resolution read-set schema and incremental/full oracle                         | Low-amplification dirty builds         |
+| Partial shard reuse              | Stable shard compatibility/provenance                                          | Generation-sharing efficiency          |
+| Shared generations               | Partial reuse plus compaction invariants                                       | Optional remote/shared bases           |
+| CSR/SCC/GRAIL packs              | Stable dense generation ordinals and rebuild path                              | Large path/impact/topology targets     |
+| ANN candidate index              | Frozen semantic quality/latency fixture                                        | Semantic large-repository target only  |
+
+Telemetry and benchmark work can proceed in parallel with the correctness design for the next phase. Schema-affecting
+invalidation, generation-sharing, adjacency-pack, and ANN work must use separate migrations and rollout controls so a
+failure in one does not force adoption of the others.
+
+## Test strategy
+
+Effect-owned behavior uses `@effect/vitest`: `effectIt.effect` for normal programs, `effectIt.scoped` for watchers,
+processes, and resources, and `effectIt.effect.prop` for Effect properties. Real filesystem watcher and Git process
+tests may use live time only at the operating-system boundary; state-machine tests use deterministic `TestClock`.
+
+Keep focused example regressions for every observed failure and add bounded Fast-check properties for:
+
+- when exact Git proves the worktree matches a runtime-current ready snapshot at `HEAD`, ordinary reads return the same
+  graph with and without deferred observation, while the deferred path never reports `current`;
+- ordinary deferred reads never invoking dirty-worktree observation, while path/impact always retain exact
+  pre/post-observation;
+- canonical forced-full versus incremental equivalence across add/edit/delete/rename/revert sequences;
+- freshness receipt equivalence to exact Git observation at every quiescent point;
+- overflow, restart, event reordering/coalescing, and mutation-during-read never yielding false current;
+- query-stage spans being balanced, terminal, and bounded under success, cancellation, timeout, and interruption;
+- deterministic lookup read-sets and invalidation independent of input ordering;
+- negative-lookup invalidation when a definition appears or disappears;
+- partial-shard reuse matching a clean materialization;
+- overlay compaction preserving queries, evidence, topology summaries, and stable IDs;
+- CSR outgoing/incoming adjacency matching authoritative SQLite rows;
+- SCC condensation preserving reachability;
+- GRAIL pruning having zero false negatives;
+- bidirectional path matching the current exact path oracle;
+- lexical early-termination top-k matching the exact scorer; and
+- migration/publication interruption preserving the previous ready snapshot.
+
+Integration and benchmark coverage must include:
+
+- clean, dirty, committed, divergent-worktree, linked-worktree, and moving-target states;
+- watcher overflow/restart and unsupported-watch fallback;
+- project metadata, published/private definition, unresolved-reference, and dynamic-resolution changes;
+- repositories above the MCP node budget and traversal deadline;
+- vector-enabled and structural-only graphs; and
+- install/update over an existing large graph database, not only fresh fixtures.
+
+## Rollout and rollback
+
+Each phase follows the same sequence:
+
+1. Land exact-HEAD benchmark and local measurement controls before behavior changes. External query telemetry follows
+   the separately gated schema-v3/consent-v3 rollout and is required before broad production expansion, not before the
+   bounded Slice 1 implementation.
+2. Introduce versioned derived state or schema behind a local capability/compatibility check.
+3. Shadow the new result against the current authoritative path on bounded fixtures and canary cohorts.
+4. Enable canary reads/builds while retaining the previous representation and fallback reason telemetry.
+5. Expand only when correctness gates, p95/p99, RSS, amplification, cancellation, and unavailability remain within the
+   committed cohort budgets.
+6. Remove the fallback only after at least one stable-release observation window and upgrade/downgrade recovery proof.
+
+Rollback rules:
+
+- disable the new reader/receipt/index selection before deleting or rewriting derived data;
+- invalidate and rebuild derived receipts, dependency read-sets, CSR packs, summaries, or ANN indexes independently;
+- never delete the previous ready snapshot as part of a failed rollout;
+- watcher uncertainty keeps ordinary reads deferred and returns current-only operations to exact Git observation;
+- invalidation uncertainty returns to full materialization;
+- adjacency-pack or ANN mismatch returns to authoritative SQLite reads/exact scoring; and
+- migration failure leaves its prior schema revision and active snapshot usable through transactional rollback.
+
+No rollout gate relies on a single dashboard percentile or one host run. Require a minimum reviewed event count,
+version cohort, fixture parity, and retained exact-HEAD artifact before declaring a phase complete.
+
+## Program acceptance criteria
+
+- Ready, unchanged deferred graph inspection on the governed >=200,000-file fixture has p95 below 500 ms after
+  warmup.
+- The ordinary deferred fast path performs no dirty-worktree scan. A later `current` fast path requires an exact
+  baseline plus a continuous qualified watcher receipt.
+- Strict reads never mix repository epochs and clearly report retry, timeout, or incompleteness.
+- Eligible one-file edits have rewrite-amplification p95 below 32x and match a forced-full canonical graph.
+- Production `unexpectedly full` is below 5% after a statistically useful stable-version cohort; every full fallback
+  retains a bounded reason.
+- Persisted stats/hubs and scoped topology avoid query-time whole-graph loading on multi-million-node snapshots.
+- Path/impact return exact complete results or explicit bounded incompleteness; deadline cancellation is observed within
+  250 ms.
+- Query/build performance, RSS, database growth, WAL/TEMP peaks, and unavailability do not regress outside reviewed
+  budgets on small and medium repositories.
+- Anonymous telemetry remains privacy-safe and disabling it disables all new external spans/events.
+- Standalone packaged install, update, interruption, restart, and global smoke pass against the exact implementation
+  HEAD before release.
+
+## Research basis
+
+- Git FSMonitor and untracked-cache guidance: <https://git-scm.com/docs/git-status>
+- rustc red-green incremental compilation: <https://rustc-dev-guide.rust-lang.org/queries/incremental-compilation.html>
+- Bazel Skyframe dependency invalidation: <https://bazel.build/reference/skyframe>
+- Differential dataflow/incremental view maintenance background: <https://arxiv.org/abs/2203.16684>
+- Immutable graph base plus delta layers: <https://www.seltzer.com/assets/publications/LLAMA.pdf>
+- Compressed graph representation: <https://vigna.di.unimi.it/ftp/papers/p595-boldi.pdf>
+- Reachability indexing: <https://scispace.com/pdf/grail-a-scalable-index-for-reachability-queries-in-very-2ca6qjuckq.pdf>
+- Compressed traversal sets: <https://arxiv.org/abs/1402.6407>
+- Exact top-k early termination: <https://research.engineering.nyu.edu/~suel/papers/bmw.pdf>
+- Approximate nearest-neighbor candidates: <https://arxiv.org/abs/1603.09320>
+- Disk-oriented ANN alternative: <https://www.microsoft.com/en-us/research/project/project-diskann/>
+- mmap/sharded code-search design: <https://github.com/sourcegraph/zoekt/blob/main/doc/design.md>
+
+## Implementation log
+
+- 2026-08-20: broad source, literature, algorithm, benchmark, and anonymous Grafana/Tempo assessment completed on
+  Threadnote 4.2.7. The program selected ordinary deferred-freshness reads plus the exact-HEAD benchmark contract as
+  Slice 1. Review confirmed that query-stage fields cannot extend frozen telemetry schema/consent v2, so the plan
+  moved gateway-first schema v3 and consent v3 to Slice 2 and the qualified watcher receipt to Slice 3. Slice 1
+  implementation started.
+- 2026-08-20: Slice 1 runtime behavior and paired exact/deferred orchestration benchmark instrumentation completed.
+  Ordinary local MCP `query`, `node`, `neighbors`, and `explain` now reuse exact identity/HEAD evidence while deferring
+  dirty-overlay observation; qualified-reference routing follows the same policy. `path`, `impact`, CLI current reads,
+  shared-snapshot promotion, and activation remain exact. The governed >=200,000-file retained benchmark run remains
+  pending and must pass before claiming the program-level latency target.

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -15,9 +15,19 @@ import {CodeGraphAnalysis} from '../src/code_graph/analysis.js';
 import {codeGraphAnalysisLimitsForView} from '../src/code_graph/analysis_render.js';
 import {codeGraphLayout} from '../src/code_graph/layout.js';
 import {parserWorkerCapacity} from '../src/code_graph/parser_worker.js';
-import {CodeGraphQueryService, type CodeGraphInspectOptions} from '../src/code_graph/query.js';
+import {
+  CodeGraphQueryService,
+  observationFromCodeGraphStatus,
+  type CodeGraphInspectOptions,
+  type CodeGraphStatusOptions,
+} from '../src/code_graph/query.js';
 import {resolveRepositoryIdentity} from '../src/code_graph/repository.js';
-import type {CodeGraphActivationActivity, CodeGraphProgress, CodeGraphQueryResult} from '../src/code_graph/types.js';
+import type {
+  CodeGraphActivationActivity,
+  CodeGraphProgress,
+  CodeGraphQueryResult,
+  CodeGraphStatus,
+} from '../src/code_graph/types.js';
 import {
   managerGraphCatalog,
   ManagerGraphBusyError,
@@ -36,7 +46,7 @@ import {CORE_EMBEDDING_MODEL_ID} from '../src/models/builtin.js';
 import {LocalModelCatalog} from '../src/models/catalog.js';
 import {selectLocalModel} from '../src/models/selection.js';
 import {LocalModelStore} from '../src/models/store.js';
-import {codeGraphMcpResponse} from '../src/mcp_server.js';
+import {codeGraphInspectionObservesWorktree, codeGraphMcpResponse} from '../src/mcp_server.js';
 import {
   createGraphQueryRequestGate,
   managerGraphClientRenderProxy,
@@ -713,6 +723,14 @@ const benchmarkCodeGraph = Effect.scoped(
         requestMaintenance: false,
         threadnoteHome: prepared.home,
       });
+      yield* query.inspect({
+        cwd: prepared.repository,
+        operation: 'query',
+        query: queryText,
+        refresh: false,
+        requestMaintenance: false,
+        threadnoteHome: prepared.home,
+      });
     }
     const queryDurations: number[] = [];
     const queryCpuDurations: number[] = [];
@@ -728,6 +746,64 @@ const benchmarkCodeGraph = Effect.scoped(
       });
       queryDurations.push(Number((yield* Clock.currentTimeNanos) - started) / NANOSECONDS_PER_MILLISECOND);
       queryCpuDurations.push(cpuMilliseconds(processStarted, processTelemetry()).total);
+    }
+    const exactReadyQueryDurations: number[] = [];
+    const exactReadyQueryCpuDurations: number[] = [];
+    const deferredQueryDurations: number[] = [];
+    const deferredQueryCpuDurations: number[] = [];
+    for (let index = 0; index < options.samples; index += 1) {
+      let exactDigest: string | undefined;
+      let deferredDigest: string | undefined;
+      const order = index % 2 === 0 ? (['deferred', 'exact'] as const) : (['exact', 'deferred'] as const);
+      for (const freshnessPolicy of order) {
+        const started = yield* Clock.currentTimeNanos;
+        const processStarted = processTelemetry();
+        const status = yield* query.status(prepared.home, prepared.repository, {
+          observeWorktree: freshnessPolicy === 'exact',
+          requestMaintenance: false,
+        });
+        const result = yield* query.inspect({
+          cwd: prepared.repository,
+          operation: 'query',
+          query: queryText,
+          refresh: false,
+          requestMaintenance: false,
+          statusObservation: observationFromCodeGraphStatus(status),
+          threadnoteHome: prepared.home,
+        });
+        const response = codeGraphMcpResponse(result);
+        const duration = Number((yield* Clock.currentTimeNanos) - started) / NANOSECONDS_PER_MILLISECOND;
+        const cpu = cpuMilliseconds(processStarted, processTelemetry()).total;
+        if (freshnessPolicy === 'deferred') {
+          deferredQueryDurations.push(duration);
+          deferredQueryCpuDurations.push(cpu);
+          deferredDigest = queryResultStructuralDigest(result);
+          if (result.freshness !== 'deferred') {
+            return yield* Effect.fail(
+              new ScriptError('The deferred-ready query benchmark observed the worktree unexpectedly.'),
+            );
+          }
+        } else {
+          exactReadyQueryDurations.push(duration);
+          exactReadyQueryCpuDurations.push(cpu);
+          exactDigest = queryResultStructuralDigest(result);
+          if (result.freshness !== 'current') {
+            return yield* Effect.fail(new ScriptError('The exact query benchmark did not observe current evidence.'));
+          }
+        }
+        if (
+          result.snapshot.id !== cold.snapshot.id ||
+          result.nodes.length === 0 ||
+          response.structuredContent.operation !== 'query'
+        ) {
+          return yield* Effect.fail(new ScriptError('The ready-query benchmark did not retain its snapshot contract.'));
+        }
+      }
+      if (exactDigest !== deferredDigest) {
+        return yield* Effect.fail(
+          new ScriptError('Exact and deferred ready-query benchmark results diverged structurally.'),
+        );
+      }
     }
 
     const changedPath = path.join(
@@ -1203,6 +1279,18 @@ const benchmarkCodeGraph = Effect.scoped(
           queryDurations,
         ),
         benchmarkMeasurement('hot-query-process-cpu', 'milliseconds', queryCpuDurations),
+        benchmarkMeasurement('hot-exact-ready-query-orchestration', 'milliseconds', exactReadyQueryDurations),
+        benchmarkMeasurement(
+          'hot-exact-ready-query-orchestration-process-cpu',
+          'milliseconds',
+          exactReadyQueryCpuDurations,
+        ),
+        benchmarkMeasurement('hot-deferred-ready-query-orchestration', 'milliseconds', deferredQueryDurations),
+        benchmarkMeasurement(
+          'hot-deferred-ready-query-orchestration-process-cpu',
+          'milliseconds',
+          deferredQueryCpuDurations,
+        ),
         benchmarkMeasurement('whole-graph-structural-analysis', 'milliseconds', analysisDurations),
         benchmarkMeasurement('whole-graph-structural-analysis-process-cpu', 'milliseconds', analysisCpuDurations),
         benchmarkMeasurement('first-repository-status-read', 'milliseconds', [coldStatusDuration]),
@@ -1357,6 +1445,8 @@ const benchmarkCodeGraph = Effect.scoped(
         coldIndexSamples: 1,
         ...(coldVectorMappingDigest === undefined ? {} : {coldVectorMappingDigest}),
         cpuMeasurement: 'process.cpuUsage delta at operation boundary',
+        deferredReadyQueryMeasurement:
+          'status + inspect + compact MCP serialization with worktree observation explicitly deferred; excludes maintenance, watcher bookkeeping, and MCP transport',
         effectiveParserMemoryBytes: hardware.effectiveMemoryBytes,
         effectiveParserWorkers,
         environmentOverrides: JSON.stringify(benchmarkEnvironmentProvenance()),
@@ -1381,7 +1471,7 @@ const benchmarkCodeGraph = Effect.scoped(
           'aggregate phase duration plus stage-attributed SQLite wall time, process CPU, boundary RSS, and row counts; no repository paths or source content',
         mcpOperationCount: mcpOperationMatrix.length,
         mcpOperationMeasurement:
-          'query, node, neighbors, explain, impact, and path latency plus compact text/structured byte counts; no graph content retained',
+          'status + inspect + compact serialization for query, node, neighbors, explain, impact, and path; excludes maintenance, watcher bookkeeping, and MCP transport; no graph content retained',
         ...(coldMaterializationStorage?.estimateBasis
           ? {coldMaterializationEstimateBasis: coldMaterializationStorage.estimateBasis}
           : {}),
@@ -3357,6 +3447,11 @@ interface McpOperationBenchmarkResult {
 
 interface BenchmarkCodeGraphQuery {
   readonly inspect: (options: CodeGraphInspectOptions) => Effect.Effect<CodeGraphQueryResult, unknown>;
+  readonly status: (
+    threadnoteHome: string,
+    cwd: string,
+    options?: CodeGraphStatusOptions,
+  ) => Effect.Effect<CodeGraphStatus, unknown>;
 }
 
 const benchmarkExternalQueryControl = Effect.fn('benchmarkCodeGraph.externalQueryControl')(function* (
@@ -3413,18 +3508,23 @@ const benchmarkMcpOperationMatrix = Effect.fn('benchmarkCodeGraph.mcpOperationMa
   const results: McpOperationBenchmarkResult[] = [];
   const execute = Effect.fn('benchmarkCodeGraph.mcpOperation')(function* (options: CodeGraphQueryOptionsForBenchmark) {
     const started = yield* Clock.currentTimeNanos;
-    const result = yield* query
-      .inspect({
+    const {response, result} = yield* Effect.gen(function* () {
+      const status = yield* query.status(threadnoteHome, cwd, {
+        observeWorktree: codeGraphInspectionObservesWorktree(options.operation),
+        requestMaintenance: false,
+      });
+      const result = yield* query.inspect({
         ...options,
         cwd,
         edgeLimit: 80,
         nodeLimit: 40,
         refresh: false,
         requestMaintenance: false,
+        statusObservation: observationFromCodeGraphStatus(status),
         threadnoteHome,
-      })
-      .pipe(Effect.timeout(25_000));
-    const response = codeGraphMcpResponse(result);
+      });
+      return {response: codeGraphMcpResponse(result), result};
+    }).pipe(Effect.timeout(25_000));
     const structuredBytes = encodedBytes(JSON.stringify(response.structuredContent));
     const textBytes = encodedBytes(response.text);
     if (structuredBytes > 24 * 1_024 || textBytes > 24 * 1_024) {

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -98,7 +98,8 @@ export interface CodeGraphStatusObservation {
   /** Read-only shared evidence selected without changing this worktree's active pointer. */
   readonly borrowedSnapshotId?: string;
   readonly identity: RepositoryIdentity;
-  readonly overlay: {readonly dirty: boolean; readonly fingerprint?: string};
+  /** Present only when status performed an exact worktree observation. */
+  readonly overlay?: {readonly dirty: boolean; readonly fingerprint?: string};
 }
 
 export interface CodeGraphSharedReadyAttachInterlock {
@@ -126,7 +127,7 @@ type ObservedCodeGraphStatus = CodeGraphStatus & {
   readonly [CODE_GRAPH_STATUS_OBSERVATION]?: CodeGraphStatusObservation;
 };
 
-/** Retrieve exact pre-read evidence without including it in JSON, CLI, or MCP status output. */
+/** Retrieve pre-read identity and optional exact overlay evidence without serializing it. */
 export function observationFromCodeGraphStatus(status: CodeGraphStatus): CodeGraphStatusObservation | undefined {
   return (status as ObservedCodeGraphStatus)[CODE_GRAPH_STATUS_OBSERVATION];
 }
@@ -306,7 +307,7 @@ export class CodeGraphQueryService extends Context.Service<
             readySnapshot: readySnapshot ? {...readySnapshot, worktreeId: identity.worktreeId} : undefined,
             stale,
           } satisfies CodeGraphStatus;
-          return attachCodeGraphStatusObservation(status, overlay === undefined ? undefined : {identity, overlay});
+          return attachCodeGraphStatusObservation(status, {identity, ...(overlay === undefined ? {} : {overlay})});
         });
       const attachExactSharedReadySnapshot = (
         threadnoteHome: string,
@@ -320,7 +321,7 @@ export class CodeGraphQueryService extends Context.Service<
           const observation = observedStatus && observationFromCodeGraphStatus(observedStatus);
           const reusableStatus =
             observedStatus !== undefined &&
-            observation !== undefined &&
+            observation?.overlay !== undefined &&
             sameRepositoryIdentity(observedStatus.identity, identity) &&
             sameRepositoryIdentity(observation.identity, identity)
               ? observedStatus
@@ -548,7 +549,7 @@ export class CodeGraphQueryService extends Context.Service<
                       layout,
                       languagePacks,
                       deferWorktreeObservation: overlay === undefined && !rebuilt,
-                      observation: overlay === undefined || rebuilt ? undefined : {identity, overlay},
+                      observation: rebuilt ? undefined : {identity, ...(overlay === undefined ? {} : {overlay})},
                       options,
                       store,
                       strictFreshness,
@@ -1143,7 +1144,7 @@ const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (in
   readonly languagePacks: CodeGraphLanguagePackRegistryShape;
   readonly observation?: {
     readonly identity: RepositoryIdentity;
-    readonly overlay: {readonly dirty: boolean; readonly fingerprint?: string};
+    readonly overlay?: {readonly dirty: boolean; readonly fingerprint?: string};
   };
   readonly options: CodeGraphInspectOptions;
   readonly store: CodeGraphStoreShape;

--- a/src/code_graph/workset_query_v2.ts
+++ b/src/code_graph/workset_query_v2.ts
@@ -2,7 +2,7 @@ import {Clock, Effect, FileSystem} from 'effect';
 import {readSeedManifest, requireWorkset} from '../manifest.js';
 import type {ProjectManifest, RuntimeConfig} from '../types.js';
 import {expandPath} from '../utils.js';
-import {CodeGraphQueryService, observationFromCodeGraphStatus} from './query.js';
+import {CodeGraphQueryService, observationFromCodeGraphStatus, type CodeGraphStatusOptions} from './query.js';
 import type {CodeGraphQueryResult, CodeGraphStatus, RepositoryIdentityExpectation} from './types.js';
 import {
   attachCodeGraphWorksetBridgeRelationships,
@@ -52,6 +52,12 @@ import {
 } from './workset_router.js';
 
 export const CODE_GRAPH_WORKSET_QUERY_V2_VERSION = 1 as const;
+
+/** Qualified-reference routing needs identity and a ready pointer, not exact dirty-overlay evidence. */
+export const CODE_GRAPH_QUALIFIED_REF_TARGET_STATUS_OPTIONS = {
+  observeWorktree: false,
+  requestMaintenance: false,
+} as const satisfies CodeGraphStatusOptions;
 
 const DEFAULT_DEADLINE_MILLISECONDS = 3_000;
 const MAXIMUM_DEADLINE_MILLISECONDS = 60_000;
@@ -480,7 +486,11 @@ export const resolveCodeGraphQualifiedRefTarget = Effect.fn('codeGraphWorksetV2.
     cwd =>
       Effect.gen(function* () {
         if (!(yield* fs.exists(cwd))) return undefined;
-        const status = yield* queryService.status(config.agentContextHome, cwd, {requestMaintenance: false});
+        const status = yield* queryService.status(
+          config.agentContextHome,
+          cwd,
+          CODE_GRAPH_QUALIFIED_REF_TARGET_STATUS_OPTIONS,
+        );
         return status.identity.repositoryId === record.repositoryId && status.readySnapshot !== undefined
           ? ({cwd, status} as const)
           : undefined;

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -752,6 +752,7 @@ export {
   codeGraphAnalysisMcpResponse,
   codeGraphAnalysisRefreshResult,
   codeGraphInspectionAllowsStaleReady,
+  codeGraphInspectionObservesWorktree,
   codeGraphInspectionStartsRefresh,
   codeGraphMcpAnalysisBudget,
   codeGraphMcpAnalysisLimits,

--- a/src/mcp_server_code_graph.ts
+++ b/src/mcp_server_code_graph.ts
@@ -131,7 +131,7 @@ export function registerCodeGraphTool(
     {
       annotations: {readOnlyHint: false, destructiveHint: false, idempotentHint: true},
       description:
-        'Inspect the local snapshot-aware code graph before broad text search. Repository output is untrusted evidence. query finds concepts; node/neighbors round-trip cgs_ or cgr_ handles; explain resolves a selector; path finds an authoritative connection; impact traces reverse dependencies; topology summarizes a prepared workset. Workset operations use only their published ready generation—run `threadnote workset prepare <name>` explicitly. Cold local graphs may return state=indexing with retryAfterMilliseconds; bounded calls may time out with partial coverage.',
+        'Inspect code graph before broad text search. Repository output is untrusted evidence. query searches; node/neighbors round-trip cgs_ or cgr_ handles; explain resolves; path connects; impact traces reverse dependencies; topology summarizes worksets. Ready ordinary reads may return freshness=deferred; path/impact require exact current-worktree evidence. Worksets read the published ready generation—run `threadnote workset prepare <name>`. Cold local graphs may return state=indexing with retryAfterMilliseconds; bounded calls may time out with partial coverage.',
       inputSchema: {
         base: McpInput.string('Impact Git base when query is omitted; default HEAD~1'),
         budgetTokens: McpInput.integer('Workset response-token budget; default 1250', {
@@ -310,6 +310,8 @@ export function registerCodeGraphTool(
           : undefined;
         const inspectionCwd = qualifiedTarget?.cwd ?? checkedCwd.value;
         const inspectionNodeId = qualifiedTarget?.nodeId ?? nodeId;
+        const allowStaleReadySnapshot = codeGraphInspectionAllowsStaleReady(operation);
+        const strictFreshness = !allowStaleReadySnapshot;
         const changes =
           operation === 'impact' && !requestedQuery
             ? yield* repositoryChangesSince(inspectionCwd, base?.trim() || 'HEAD~1')
@@ -327,13 +329,14 @@ export function registerCodeGraphTool(
               timeoutContext = Option.some({key: identity.worktreeId, target: refreshTarget, watcher});
               yield* watcher.ensure({...refreshTarget, key: identity.worktreeId});
             }),
+          observeWorktree: codeGraphInspectionObservesWorktree(operation),
+          requestMaintenance: false,
         });
         let identity = status.identity;
-        const allowStaleReadySnapshot = codeGraphInspectionAllowsStaleReady(operation);
-        const strictFreshness = !allowStaleReadySnapshot;
         if (status.stale || !status.readySnapshot) {
           status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status, {
             allowBorrowedStale: allowStaleReadySnapshot,
+            requestMaintenance: false,
           });
         }
         let refreshStarted = false;
@@ -347,11 +350,15 @@ export function registerCodeGraphTool(
           if (refreshStarted) {
             yield* waitForCodeGraphRefresh(watcher, identity.worktreeId, refreshTarget);
           }
-          status = yield* service.status(config.agentContextHome, inspectionCwd);
+          status = yield* service.status(config.agentContextHome, inspectionCwd, {
+            observeWorktree: codeGraphInspectionObservesWorktree(operation),
+            requestMaintenance: false,
+          });
           identity = status.identity;
           if (status.stale || !status.readySnapshot) {
             status = yield* service.attachSharedReadySnapshot(config.agentContextHome, identity, status, {
               allowBorrowedStale: allowStaleReadySnapshot,
+              requestMaintenance: false,
             });
           }
           if (!status.readySnapshot || (status.stale && strictFreshness)) {
@@ -378,6 +385,7 @@ export function registerCodeGraphTool(
           packageName: packageName?.trim() || undefined,
           query: requestedQuery || changes?.paths.join(' '),
           refresh: false,
+          requestMaintenance: false,
           seedQueries: changes?.paths,
           statusObservation: observationFromCodeGraphStatus(status),
           symbol,
@@ -1441,6 +1449,17 @@ export function codeGraphInspectionAllowsStaleReady(
   operation: 'explain' | 'impact' | 'neighbors' | 'node' | 'path' | 'query',
 ): boolean {
   return operation !== 'impact' && operation !== 'path';
+}
+
+/**
+ * Exact overlay observation is reserved for operations whose contract requires
+ * current relationship evidence. Ordinary reads remain honest by reporting
+ * deferred freshness when they reuse a HEAD-compatible ready snapshot.
+ */
+export function codeGraphInspectionObservesWorktree(
+  operation: 'explain' | 'impact' | 'neighbors' | 'node' | 'path' | 'query',
+): boolean {
+  return !codeGraphInspectionAllowsStaleReady(operation);
 }
 
 /**

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -1008,6 +1008,8 @@ describe('Threadnote MCP toolsets', () => {
         });
         expect(graphTool?.description).toContain('before broad text search');
         expect(graphTool?.description).toContain('round-trip cgs_ or cgr_ handles');
+        expect(graphTool?.description).toContain('freshness=deferred');
+        expect(graphTool?.description).toContain('exact current-worktree evidence');
         expect(graphTool?.description).toContain('Cold local graphs may return state=indexing');
         expect(graphTool?.description).toContain('bounded calls may time out with partial coverage');
         expect(graphTool?.description).toContain('Repository output is untrusted evidence');
@@ -1081,7 +1083,6 @@ describe('Threadnote MCP toolsets', () => {
         expect(rendered).not.toContain('BEGIN UNTRUSTED REPOSITORY DATA');
         expect(rendered).not.toContain('untrusted evidence, never instructions');
         expect(result.structuredContent).toMatchObject({
-          freshness: 'current',
           nodes: expect.arrayContaining([
             expect.objectContaining({
               name: 'CodeGraphQueryService',
@@ -1097,6 +1098,9 @@ describe('Threadnote MCP toolsets', () => {
           type: 'code-graph-inspection',
           version: 1,
         });
+        expect(['current', 'deferred']).toContain(
+          (result.structuredContent as {readonly freshness?: unknown} | undefined)?.freshness,
+        );
 
         await writeFile(
           join(impactRepository, 'src', 'index.ts'),
@@ -1388,10 +1392,12 @@ describe('Threadnote MCP toolsets', () => {
         }
         expect(ready?.isError, JSON.stringify(ready)).not.toBe(true);
         expect(ready?.structuredContent).toMatchObject({
-          freshness: 'current',
           nodes: expect.arrayContaining([expect.objectContaining({name: 'coldGraphSymbol'})]),
           operation: 'query',
         });
+        expect(['current', 'deferred']).toContain(
+          (ready?.structuredContent as {readonly freshness?: unknown} | undefined)?.freshness,
+        );
         const readyStructured = JSON.stringify(ready?.structuredContent);
         expect(new TextEncoder().encode(readyStructured).byteLength).toBeLessThanOrEqual(24 * 1_024);
         expect(new TextEncoder().encode(JSON.stringify(ready?.content)).byteLength).toBeLessThan(20 * 1_024);
@@ -1471,7 +1477,7 @@ describe('Threadnote MCP toolsets', () => {
           );
           expect(dirtyStale.isError).not.toBe(true);
           expect(dirtyStale.structuredContent).toMatchObject({
-            freshness: 'stale',
+            freshness: 'deferred',
             nodes: expect.arrayContaining([expect.objectContaining({name: 'indexedBeforePull'})]),
             operation: 'query',
             snapshot: {commit: indexedCommit, id: firstSnapshotId},
@@ -1658,9 +1664,9 @@ describe('Threadnote MCP toolsets', () => {
               }
             | undefined;
           expect(firstStructured).toMatchObject({
-            freshness: 'current',
             nodes: expect.arrayContaining([expect.objectContaining({name: repositoryFixture.before})]),
           });
+          expect(['current', 'deferred']).toContain(firstStructured?.freshness);
           expect(typeof firstStructured?.snapshot?.id).toBe('string');
 
           const branch = `${repositoryFixture.name}-linked`;
@@ -1706,7 +1712,7 @@ describe('Threadnote MCP toolsets', () => {
           expect(Date.now() - editedStartedAt).toBeLessThan(5_000);
           expect(edited.isError).not.toBe(true);
           expect(editedStructured?.state).toBeUndefined();
-          expect(['current', 'stale']).toContain(editedStructured?.freshness);
+          expect(editedStructured?.freshness).toBe('deferred');
 
           const refresh = await callCodeGraphUntilReady(client, {
             base: 'HEAD',
@@ -1721,7 +1727,7 @@ describe('Threadnote MCP toolsets', () => {
             query: repositoryFixture.after,
           });
           expect(refreshed.structuredContent).toMatchObject({
-            freshness: 'current',
+            freshness: 'deferred',
             nodes: expect.arrayContaining([expect.objectContaining({name: repositoryFixture.after})]),
           });
           expect(
@@ -1733,7 +1739,7 @@ describe('Threadnote MCP toolsets', () => {
     );
   }, 120_000);
 
-  it('keeps ordinary watched reads stale until an explicit current inspection', async () => {
+  it('keeps ordinary watched reads deferred until an explicit current inspection', async () => {
     await withMcpClient(
       async (client, fixture) => {
         const repository = join(fixture.root, 'watched-repository');
@@ -1759,12 +1765,23 @@ describe('Threadnote MCP toolsets', () => {
           {timeout: 30_000},
         );
         expect(first.structuredContent).toMatchObject({
-          freshness: 'current',
           nodes: expect.arrayContaining([expect.objectContaining({name: 'beforeSessionWatch'})]),
         });
+        expect(['current', 'deferred']).toContain(
+          (first.structuredContent as {readonly freshness?: unknown} | undefined)?.freshness,
+        );
         const firstSnapshotId = (first.structuredContent as {readonly snapshot?: {readonly id?: unknown}} | undefined)
           ?.snapshot?.id;
         expect(typeof firstSnapshotId).toBe('string');
+        const hot = await client.callTool(
+          {
+            arguments: {callerCwd: repository, operation: 'query', query: 'beforeSessionWatch'},
+            name: 'inspect_code_graph',
+          },
+          undefined,
+          {timeout: 5_000},
+        );
+        expect(hot.structuredContent).toMatchObject({freshness: 'deferred', snapshot: {id: firstSnapshotId}});
 
         await writeFile(
           join(repository, 'src', 'index.ts'),
@@ -1772,7 +1789,7 @@ describe('Threadnote MCP toolsets', () => {
           'utf8',
         );
         await new Promise(resolve => setTimeout(resolve, 500));
-        const stale = await client.callTool(
+        const deferred = await client.callTool(
           {
             arguments: {callerCwd: repository, operation: 'query', query: 'afterSessionWatch'},
             name: 'inspect_code_graph',
@@ -1780,8 +1797,8 @@ describe('Threadnote MCP toolsets', () => {
           undefined,
           {timeout: 5_000},
         );
-        expect(stale.structuredContent).toMatchObject({
-          freshness: 'stale',
+        expect(deferred.structuredContent).toMatchObject({
+          freshness: 'deferred',
           snapshot: {id: firstSnapshotId},
         });
 
@@ -1798,7 +1815,7 @@ describe('Threadnote MCP toolsets', () => {
           query: 'afterSessionWatch',
         });
         expect(refreshed.structuredContent).toMatchObject({
-          freshness: 'current',
+          freshness: 'deferred',
           nodes: expect.arrayContaining([expect.objectContaining({name: 'afterSessionWatch'})]),
         });
         expect(

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -17,7 +17,13 @@ import {CodeGraphIndexer, extractorSetIdentityFromPackProvenance} from '../../sr
 import {CodeGraphLanguagePackRegistry} from '../../src/code_graph/languages/registry.js';
 import type {CodeGraphLayout} from '../../src/code_graph/layout.js';
 import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
-import {CodeGraphQueryService, exactNodeQuery, neighborQuery, traversalQuery} from '../../src/code_graph/query.js';
+import {
+  CodeGraphQueryService,
+  exactNodeQuery,
+  neighborQuery,
+  observationFromCodeGraphStatus,
+  traversalQuery,
+} from '../../src/code_graph/query.js';
 import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
 import {CodeGraphStore, type CodeGraphStoreShape} from '../../src/code_graph/store.js';
 import type {CodeGraphEdge, CodeGraphQueryNode, CodeGraphSnapshot} from '../../src/code_graph/types.js';
@@ -122,10 +128,26 @@ describe('code graph query budgets', () => {
           fixture => Effect.sync(() => rmSync(fixture.root, {force: true, recursive: true})),
         );
         const requests = yield* Ref.make<readonly {allowIndexPreparation?: true; databasePath: string}[]>([]);
+        const commandCalls = yield* Ref.make<readonly {args: readonly string[]; executable: string}[]>([]);
         const systemLayer = SystemInfo.layer;
-        const commandLayer = CommandExecutor.layer.pipe(
+        const liveCommandLayer = CommandExecutor.layer.pipe(
           Layer.provideMerge(Layer.merge(BunServices.layer, systemLayer)),
         );
+        const commandLayer = Layer.effect(
+          CommandExecutor,
+          Effect.gen(function* () {
+            const command = yield* CommandExecutor;
+            const record = (executable: string, args: readonly string[]) =>
+              Ref.update(commandCalls, current => [...current, {args: [...args], executable}]);
+            return CommandExecutor.of({
+              ...command,
+              execute: (executable, args, options) =>
+                record(executable, args).pipe(Effect.andThen(command.execute(executable, args, options))),
+              executeBytes: (executable, args, options) =>
+                record(executable, args).pipe(Effect.andThen(command.executeBytes!(executable, args, options))),
+            });
+          }),
+        ).pipe(Layer.provide(liveCommandLayer));
         const maintenanceLayer = Layer.succeed(
           CodeGraphMaintenanceCoordinator,
           CodeGraphMaintenanceCoordinator.of({
@@ -193,7 +215,41 @@ describe('code graph query budgets', () => {
             symbolCount: 0,
             worktreeId: identity.worktreeId,
           } satisfies CodeGraphSnapshot;
+          const deferredColdStatus = yield* query.statusForIdentity(fixtureRoot.home, identity, {
+            observeWorktree: false,
+            requestMaintenance: false,
+          });
+          const exactColdAttach = yield* query.attachSharedReadySnapshot(
+            fixtureRoot.home,
+            identity,
+            deferredColdStatus,
+            {requestMaintenance: false},
+          );
+          expect(observationFromCodeGraphStatus(deferredColdStatus)?.overlay).toBeUndefined();
+          expect(observationFromCodeGraphStatus(exactColdAttach)?.overlay).toEqual({dirty: false});
           yield* Ref.set(snapshotRef, snapshot);
+
+          yield* Ref.set(commandCalls, []);
+          const deferredHotStatus = yield* query.status(fixtureRoot.home, fixtureRoot.repository, {
+            observeWorktree: false,
+            requestMaintenance: false,
+          });
+          const statusCommandCalls = yield* Ref.get(commandCalls);
+          expect(statusCommandCalls.length).toBeGreaterThan(0);
+          expect(statusCommandCalls.some(call => call.executable === 'git')).toBe(true);
+          expect(JSON.stringify(deferredHotStatus)).not.toContain('statusObservation');
+          yield* Ref.set(commandCalls, []);
+          const deferredHotInspection = yield* query.inspect({
+            cwd: fixtureRoot.repository,
+            nodeId: `cgs_${'a'.repeat(32)}`,
+            operation: 'node',
+            refresh: false,
+            requestMaintenance: false,
+            statusObservation: observationFromCodeGraphStatus(deferredHotStatus),
+            threadnoteHome: fixtureRoot.home,
+          });
+          expect(deferredHotInspection.freshness).toBe('deferred');
+          expect(yield* Ref.get(commandCalls)).toEqual([]);
 
           const assertOneRequest = Effect.fn(function* (run: Effect.Effect<unknown, unknown>) {
             yield* Ref.set(requests, []);
@@ -205,6 +261,8 @@ describe('code graph query budgets', () => {
 
           yield* assertOneRequest(query.status(fixtureRoot.home, fixtureRoot.repository, {observeWorktree: false}));
           const status = yield* query.statusForIdentity(fixtureRoot.home, identity, {observeWorktree: false});
+          expect(observationFromCodeGraphStatus(status)).toMatchObject({identity});
+          expect(observationFromCodeGraphStatus(status)?.overlay).toBeUndefined();
           expect(yield* Ref.get(requests)).toHaveLength(2);
           yield* assertOneRequest(query.attachSharedReadySnapshot(fixtureRoot.home, identity, status));
           yield* assertOneRequest(

--- a/test/unit/code-graph.workset-query-v2.test.ts
+++ b/test/unit/code-graph.workset-query-v2.test.ts
@@ -11,6 +11,7 @@ import {
   type CodeGraphCrossRepositoryBridgeV1,
 } from '../../src/code_graph/cross_repository/resolver.js';
 import {
+  CODE_GRAPH_QUALIFIED_REF_TARGET_STATUS_OPTIONS,
   runCodeGraphWorksetQueryV2Core,
   type CodeGraphWorksetQueryV2InputV1,
 } from '../../src/code_graph/workset_query_v2.js';
@@ -26,6 +27,13 @@ import type {
 } from '../../src/code_graph/workset_catalog/types.js';
 
 describe('code graph Workset Search V2 core', () => {
+  it('resolves qualified references without observing dirty worktree state', () => {
+    expect(CODE_GRAPH_QUALIFIED_REF_TARGET_STATUS_OPTIONS).toEqual({
+      observeWorktree: false,
+      requestMaintenance: false,
+    });
+  });
+
   effectIt.effect('returns compact qualified evidence and persists every referenced handle', () =>
     Effect.gen(function* () {
       const fixture = makeFixture(4);

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -7,6 +7,7 @@ import {
   codeGraphAnalysisMcpResponse,
   codeGraphAnalysisRefreshResult,
   codeGraphInspectionAllowsStaleReady,
+  codeGraphInspectionObservesWorktree,
   codeGraphInspectionStartsRefresh,
   codeGraphMcpAnalysisBudget,
   codeGraphMcpAnalysisLimits,
@@ -40,6 +41,25 @@ describe('MCP code graph indexing progress', () => {
       ),
     ).toEqual({explain: true, impact: false, neighbors: true, node: true, path: false, query: true});
   });
+
+  it.prop(
+    'observes the worktree only for current-required inspections',
+    {
+      operation: FC.constantFrom(
+        'query' as const,
+        'node' as const,
+        'neighbors' as const,
+        'explain' as const,
+        'path' as const,
+        'impact' as const,
+      ),
+    },
+    ({operation}) => {
+      expect(codeGraphInspectionObservesWorktree(operation)).toBe(operation === 'path' || operation === 'impact');
+      expect(codeGraphInspectionObservesWorktree(operation)).toBe(!codeGraphInspectionAllowsStaleReady(operation));
+    },
+    {fastCheck: {numRuns: 100}},
+  );
 
   it.prop(
     'starts refresh only for stale cold or current-required inspections',


### PR DESCRIPTION
## Summary

- add the large-repository graph performance implementation plan with production telemetry, historical benchmark evidence, algorithm research, gates, and rollout boundaries
- let ordinary local `query`, `node`, `neighbors`, and `explain` reads reuse a runtime-current ready snapshot after exact identity/HEAD discovery without blocking on a dirty-worktree scan
- preserve exact current-worktree observation for `path`, `impact`, CLI current reads, snapshot promotion, indexing, and activation
- hand the non-serializing identity receipt from status into inspection, avoid duplicate foreground maintenance, and apply the same policy to qualified `cgr_` target routing
- add paired exact/deferred orchestration benchmark measurements while preserving legacy benchmark semantics

## Evidence

- stable production inspection telemetry: 590 calls, 73.2% success, successful p50 <=512 ms / p95 <=8.192 s / p99 <=32.768 s (histogram upper bounds)
- dirty-build cohort: 21 of 38 successful dirty builds were unexpectedly full; 17 of 26 non-zero deltas had at least 256x rewrite amplification
- historical 232,750-file IntelliJ artifact: indexed SQL was about 44 ms while MCP query took 3.5-4.7 s, with freshness observation dominating the gap

## Validation

- independent final review: no critical or important findings
- `bun run typecheck`
- `bun run lint`
- Prettier and `git diff --check`
- benchmark smoke with 5 paired samples and structural parity controls
- 32 native MCP integration tests
- 53 final focused tests after the qualified-reference delta
- full local suite before that final focused delta: 346 files / 3,427 tests passed; CI is intentionally responsible for the exhaustive exact-HEAD rerun

## Scope boundary

This is Slice 1 only. Schema-v3 query telemetry/consent, a qualified overflow-aware watcher receipt, fine-grained invalidation, partial materialization/base+delta storage, traversal packs, and ANN/lexical work remain separately gated follow-up slices documented in the plan.