### PR TITLE
Reuse valid partial graph materialization shards

### DIFF
--- a/docs/4.3-large-repository-graph-performance-plan.md
+++ b/docs/4.3-large-repository-graph-performance-plan.md
@@ -1,7 +1,8 @@
 # Threadnote 4.3 large-repository graph performance plan
 
 Status: approved; Slice 1 implemented; Slice 2 schema-v4 foundation and first bounded stage slice implemented in
-[draft PR #174](https://github.com/Kashkovsky/threadnote/pull/174); rollout gated
+[draft PR #174](https://github.com/Kashkovsky/threadnote/pull/174); first bounded P2 partial-shard reuse slice
+implemented on `codex/large-repo-partial-shard-reuse`; rollout gated
 
 Baseline date: 2026-08-20
 
@@ -60,6 +61,19 @@ bounded result classifications remain follow-up work before Slice 2 is declared 
 Replace repeat Git observation for exact-current reads only after the receipt state machine, watcher-overflow behavior,
 strict-read retry contract, and exact-Git fallback are covered by deterministic tests. This slice remains independently
 reversible to the current exact observation path.
+
+### P2 first bounded slice — mixed materialized-shard reuse: implemented
+
+Full materialization now consumes valid content-addressed final-fact shards independently within each bounded source
+batch. A missing, evicted, or malformed shard replays, attributes, and rewrites only its raw parser facts; valid peers
+are not decoded a second time from the raw cache or rewritten into the shard cache. Publication still stages every
+graph row into the new atomic snapshot, so interruption and prior-ready generation guarantees are unchanged.
+
+This optimization is deliberately limited to the exact same graph-content derivation, including extractor set,
+workspace fingerprint, whole inventory identity, content hash, and path. It improves forced, repair, and resumed builds
+with partial shard-cache coverage. It does not reuse final shards across a content-changing dirty build and therefore
+does not yet reduce the production dirty replay-amplification cohort; P1 resolution read-sets/output fingerprints and
+the later structural base-plus-delta slice remain prerequisites for that broader reuse.
 
 ## Evidence baseline
 
@@ -379,6 +393,7 @@ Acceptance:
 ## P2 — partial materialization and generation sharing
 
 1. Reuse each compatible materialized shard independently instead of requiring an all-or-nothing reusable shard set.
+   The first exact-content, batch-bounded slice is implemented; cross-generation reuse remains gated on P1 evidence.
 2. Pipeline extraction, normalization, staging, and resolution through queues bounded by source bytes, fact bytes, and
    rows, not only file count.
 3. Schedule work using historical extraction/fact cost and isolate heavy-tail files into observable lanes.
@@ -602,3 +617,8 @@ version cohort, fixture parity, and retained exact-HEAD artifact before declarin
   a fallback execution, preserves ordinary results when telemetry is absent or disabled, and gives analyze requests the
   same status/snapshot/execute lifecycle as inspect requests. Candidate selection, hydration, traversal, and deeper
   database-read attribution remain pending; schemas v1, v2, and v3 are unchanged.
+- 2026-08-20: the first bounded P2 slice replaced all-or-nothing final-shard consumption with batch-local mixed reuse.
+  Valid exact-derivation peers are consumed directly, while only missing or malformed paths replay raw facts and
+  rewrite their shard rows. A lifecycle regression audits one missing-row insert, zero peer rewrites, complete snapshot
+  association, and graph parity; a 100-run Fast-check property covers arbitrary hit subsets, miss permutations, and
+  attribution batch widths. Whole-graph derivation remains intentionally fail-closed across content changes.

--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -1208,13 +1208,6 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       input.inventory.files,
       input.languagePacks,
     );
-    const materializedShards = yield* input.store.loadMaterializedFileShards(
-      input.layout.databasePath,
-      input.inventory.files,
-      input.building.extractorSet,
-      shardDerivationIdentity,
-    );
-    const materializedShardSetComplete = materializedShards.facts.size === input.inventory.files.length;
     if (cachedMetadata.files !== input.inventory.files.length) {
       return yield* Effect.fail(
         new CodeGraphIndexOperationError(
@@ -1230,13 +1223,8 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         .filter(file => committedHashesByPath.get(file.path) !== file.contentHash)
         .map(file => file.path),
     );
-    // A complete materialized-shard set is consumed directly. Partial sets are
-    // discarded as a unit, so only the raw cache payloads loaded below count as
-    // replayed bytes for that path.
-    let cachedFactReplayBytesCompleted = materializedShardSetComplete ? materializedShards.bytes : 0;
-    let changedFactBytesCompleted = materializedShardSetComplete
-      ? selectedDecodedFactBytes(materializedShards.bytesByPath, [...changedCurrentPaths])
-      : 0;
+    let cachedFactReplayBytesCompleted = 0;
+    let changedFactBytesCompleted: number | undefined = 0;
     const storageEstimate = estimatedMaterializationStorageBytes(
       cachedFactBytesTotal,
       sourceBytesTotal,
@@ -1531,22 +1519,46 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         unit: 'files',
       }) ?? Effect.void;
       const loadingStartedAt = yield* Clock.currentTimeMillis;
-      const missingShardFiles = materializedShardSetComplete ? [] : files;
+      // Every shard is bound to the exact extractor, workspace, graph-content,
+      // content-hash, and path derivation above. Load one bounded source batch
+      // at a time and reuse valid peers independently; a missing or malformed
+      // shard only falls back to its raw parser facts.
+      const materializedShards = yield* input.store.loadMaterializedFileShards(
+        input.layout.databasePath,
+        files,
+        input.building.extractorSet,
+        shardDerivationIdentity,
+      );
+      const missingShardFiles = files.filter(file => !materializedShards.facts.has(file.path));
       const cached = yield* loadCachedFacts(
         input.store,
         input.layout.databasePath,
         missingShardFiles,
         input.languagePacks,
       );
-      cachedFactReplayBytesCompleted = Math.min(Number.MAX_SAFE_INTEGER, cachedFactReplayBytesCompleted + cached.bytes);
-      const batchChangedFactBytes = selectedDecodedFactBytes(
+      cachedFactReplayBytesCompleted = Math.min(
+        Number.MAX_SAFE_INTEGER,
+        cachedFactReplayBytesCompleted + materializedShards.bytes + cached.bytes,
+      );
+      const batchChangedShardBytes = selectedDecodedFactBytes(
+        materializedShards.bytesByPath,
+        files
+          .filter(file => changedCurrentPaths.has(file.path) && materializedShards.facts.has(file.path))
+          .map(file => file.path),
+      );
+      const batchChangedRawBytes = selectedDecodedFactBytes(
         cached.bytesByPath,
         missingShardFiles.filter(file => changedCurrentPaths.has(file.path)).map(file => file.path),
       );
       changedFactBytesCompleted =
-        changedFactBytesCompleted === undefined || batchChangedFactBytes === undefined
+        changedFactBytesCompleted === undefined ||
+        batchChangedShardBytes === undefined ||
+        batchChangedRawBytes === undefined
           ? undefined
-          : Math.min(Number.MAX_SAFE_INTEGER, changedFactBytesCompleted + batchChangedFactBytes);
+          : Math.min(
+              Number.MAX_SAFE_INTEGER,
+              changedFactBytesCompleted + batchChangedShardBytes + batchChangedRawBytes,
+            );
       const batchLoadingMilliseconds = (yield* Clock.currentTimeMillis) - loadingStartedAt;
       loadingMilliseconds += batchLoadingMilliseconds;
       stageMilliseconds['loading-cache'] = loadingMilliseconds;
@@ -1561,7 +1573,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         activity: {
           batchCompleted: batchesCompleted,
           batchTotal: batchesTotal,
-          cachedFactBytes: cached.bytes,
+          cachedFactBytes: Math.min(Number.MAX_SAFE_INTEGER, materializedShards.bytes + cached.bytes),
           elapsedMilliseconds: batchLoadingMilliseconds,
           sourceBytes,
           stage: 'attributing',
@@ -1588,10 +1600,8 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         );
       }
       const attributedMissingByPath = new Map(attributedMissingFacts.map(fact => [fact.path, fact]));
-      const facts = files.map(file =>
-        materializedShardSetComplete
-          ? materializedShards.facts.get(file.path)!
-          : attributedMissingByPath.get(file.path)!,
+      const facts = files.map(
+        file => materializedShards.facts.get(file.path) ?? attributedMissingByPath.get(file.path)!,
       );
       materializedShardFilesReused += files.length - missingShardFiles.length;
       const batchAttributionMilliseconds = (yield* Clock.currentTimeMillis) - attributionStartedAt;

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -212,7 +212,7 @@ export interface CodeGraphMaterializationMetrics {
   readonly batchesTotal: number;
   readonly cachedFactBytesCompleted?: number;
   readonly cachedFactBytesTotal?: number;
-  /** Exact UTF-8 bytes of decoded cached facts actually consumed by attribution. */
+  /** Exact UTF-8 bytes of decoded facts consumed by materialization: final-shard hits plus raw-cache misses. */
   readonly cachedFactReplayBytesCompleted?: number;
   /** Exact consumed cached-fact bytes for current paths changed from the committed inventory. */
   readonly changedFactBytesCompleted?: number;

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -1117,7 +1117,7 @@ describe('native code graph lifecycle', () => {
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
-  effectIt.effect('falls back to raw replay without counting a partial materialized shard set', () =>
+  effectIt.effect('reuses valid peers from a partial materialized shard set', () =>
     Effect.gen(function* () {
       const root = createManySourceRepository(12);
       const home = join(root, '.threadnote-test-home');
@@ -1127,19 +1127,52 @@ describe('native code graph lifecycle', () => {
       const first = yield* indexer.index({cwd: root, threadnoteHome: home});
       const databasePath = codeGraphDatabasePath(home, first);
       const firstGraph = yield* store.loadGraph(databasePath, first.snapshot.id);
-      const discardedShardBytes = yield* Effect.sync(() => {
+      const partialShardState = yield* Effect.sync(() => {
         const database = new Database(databasePath);
         try {
-          database.exec(`DELETE FROM materialized_file_shards
-                         WHERE id = (SELECT id FROM materialized_file_shards ORDER BY id LIMIT 1)`);
-          return (
+          const missing = database
+            .query<{readonly id: string; readonly path: string}, []>(
+              `SELECT id, path_hint AS path FROM materialized_file_shards ORDER BY id LIMIT 1`,
+            )
+            .get();
+          if (!missing) throw new Error('Expected a materialized shard to remove.');
+          const missingRawBytes =
+            database
+              .query<{readonly bytes: number}, [string]>(
+                `SELECT COALESCE(SUM(${storedCodeGraphFactRawBytesSql('facts_json')}), 0) AS bytes
+                 FROM file_blobs WHERE path_hint = ?`,
+              )
+              .get(missing.path)?.bytes ?? 0;
+          database.query('DELETE FROM materialized_file_shards WHERE id = ?').run(missing.id);
+          database.exec(`
+            CREATE TABLE materialized_shard_write_audit (
+              operation TEXT NOT NULL,
+              path_hint TEXT NOT NULL
+            );
+            CREATE TRIGGER materialized_shard_insert_audit
+            AFTER INSERT ON materialized_file_shards
+            BEGIN
+              INSERT INTO materialized_shard_write_audit VALUES ('insert', NEW.path_hint);
+            END;
+            CREATE TRIGGER materialized_shard_update_audit
+            AFTER UPDATE ON materialized_file_shards
+            BEGIN
+              INSERT INTO materialized_shard_write_audit VALUES ('update', NEW.path_hint);
+            END;
+            CREATE TRIGGER materialized_shard_delete_audit
+            AFTER DELETE ON materialized_file_shards
+            BEGIN
+              INSERT INTO materialized_shard_write_audit VALUES ('delete', OLD.path_hint);
+            END;
+          `);
+          const reusedShardBytes =
             database
               .query<{readonly bytes: number}, []>(
                 `SELECT COALESCE(SUM(${storedCodeGraphFactRawBytesSql('facts_json')}), 0) AS bytes
                  FROM materialized_file_shards`,
               )
-              .get()?.bytes ?? 0
-          );
+              .get()?.bytes ?? 0;
+          return {missingPath: missing.path, missingRawBytes, reusedShardBytes};
         } finally {
           database.close();
         }
@@ -1153,17 +1186,37 @@ describe('native code graph lifecycle', () => {
       });
       const rebuiltGraph = yield* store.loadGraph(databasePath, rebuilt.snapshot.id);
       const metrics = finalFullMaterializationMetrics(progress);
+      const persistedReuse = yield* Effect.sync(() => {
+        const database = new Database(databasePath, {readonly: true});
+        try {
+          const associations =
+            database
+              .query<{readonly count: number}, [string]>(
+                'SELECT COUNT(*) AS count FROM snapshot_file_shards WHERE snapshot_id = ?',
+              )
+              .get(rebuilt.snapshot.id)?.count ?? 0;
+          const writes = database
+            .query<{readonly operation: string; readonly path: string}, []>(
+              `SELECT operation, path_hint AS path
+               FROM materialized_shard_write_audit ORDER BY rowid`,
+            )
+            .all();
+          return {associations, writes};
+        } finally {
+          database.close();
+        }
+      });
 
-      expect(
-        rebuilt.diagnostics.some(diagnostic =>
-          diagnostic.startsWith('Reused content-addressed materialized shards for'),
-        ),
-      ).toBe(false);
-      expect(discardedShardBytes).toBeGreaterThan(0);
-      expect(metrics.cachedFactReplayBytesCompleted).toBe(metrics.cachedFactBytesTotal);
-      expect(metrics.cachedFactReplayBytesCompleted).not.toBe(
-        (metrics.cachedFactBytesTotal ?? 0) + discardedShardBytes,
+      expect(rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 11 file(s).');
+      expect(partialShardState.missingRawBytes).toBeGreaterThan(0);
+      expect(partialShardState.reusedShardBytes).toBeGreaterThan(0);
+      expect(metrics.cachedFactReplayBytesCompleted).toBe(
+        partialShardState.missingRawBytes + partialShardState.reusedShardBytes,
       );
+      expect(persistedReuse).toEqual({
+        associations: 12,
+        writes: [{operation: 'insert', path: partialShardState.missingPath}],
+      });
       expect(normalizeStoredGraph(rebuiltGraph)).toEqual(normalizeStoredGraph(firstGraph));
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
@@ -1284,11 +1337,7 @@ describe('native code graph lifecycle', () => {
         }
 
         expect(rebuilt.materialization).toEqual({mode: 'full', stagedFiles: 2, totalFiles: 2});
-        expect(
-          rebuilt.diagnostics.some(diagnostic =>
-            diagnostic.startsWith('Reused content-addressed materialized shards for'),
-          ),
-        ).toBe(false);
+        expect(rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 1 file(s).');
         expect(normalizeStoredGraph(rebuiltGraph)).toEqual(normalizeStoredGraph(firstGraph));
       }).pipe(provideTestLayer(ApplicationLayer)),
     ),

--- a/test/unit/code-graph.attribution.property.test.ts
+++ b/test/unit/code-graph.attribution.property.test.ts
@@ -11,6 +11,13 @@ const attributionCase = FC.record({
   rotation: FC.integer({max: 31, min: 0}),
 });
 
+const mixedReuseCase = FC.record({
+  batchWidth: FC.integer({max: 5, min: 1}),
+  hitMask: FC.array(FC.boolean(), {maxLength: 24, minLength: 1}),
+  packageCount: FC.integer({max: 12, min: 1}),
+  rotation: FC.integer({max: 31, min: 0}),
+});
+
 describe('code graph repository-attribution properties', () => {
   it.prop(
     'matches one-shot attribution across arbitrary cache-batch boundaries and multi-package references',
@@ -39,6 +46,35 @@ describe('code graph repository-attribution properties', () => {
             .every(symbol => symbol.packageName === `package-${index}`),
         ).toBe(true);
       }
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
+  it.prop(
+    'matches one-shot attribution when arbitrary final-shard hits are mixed with batched raw misses',
+    {scenario: mixedReuseCase},
+    ({scenario}) => {
+      const files = repositoryFiles(scenario.packageCount);
+      const workspace = discoverManifestWorkspace(files);
+      const raw = syntheticFacts(files);
+      const attributeBatch = createCachedCodeGraphFactsAttributor(files, workspace);
+      const expected = attributeBatch(raw);
+      const hitPaths = new Set(
+        raw.filter((_, index) => scenario.hitMask[index % scenario.hitMask.length]).map(file => file.path),
+      );
+      const hitFacts = new Map(expected.filter(file => hitPaths.has(file.path)).map(file => [file.path, file]));
+      const misses = raw.filter(file => !hitPaths.has(file.path));
+      const rotation = misses.length === 0 ? 0 : scenario.rotation % misses.length;
+      const reorderedMisses = [...misses.slice(rotation), ...misses.slice(0, rotation)];
+      const attributedMisses = new Map<string, CodeGraphFileFacts>();
+      for (let index = 0; index < reorderedMisses.length; index += scenario.batchWidth) {
+        for (const fact of attributeBatch(reorderedMisses.slice(index, index + scenario.batchWidth))) {
+          attributedMisses.set(fact.path, fact);
+        }
+      }
+      const merged = raw.map(file => hitFacts.get(file.path) ?? attributedMisses.get(file.path)!);
+
+      expect(normalizeFacts(merged)).toEqual(normalizeFacts(expected));
     },
     {fastCheck: {numRuns: 100}},
   );


### PR DESCRIPTION
## Summary

- reuse valid content-addressed materialized graph shards independently within each bounded source batch
- replay, attribute, and rewrite raw cached facts only for missing, evicted, or malformed shard paths
- preserve original file ordering, whole-graph derivation checks, atomic full-snapshot publication, and cross-generation fail-closed behavior
- include final-shard decode time in the materialization loading stage and clarify replay-byte semantics
- update the 4.3 large-repository performance plan with the bounded P2 slice and its limits

## Safety boundary

Shard reuse still requires the exact extractor set, workspace fingerprint, whole graph-content identity, content hash, and path. This PR does **not** reuse final shards across a content-changing dirty build, does not weaken project-closure rules, and does not yet avoid staging final graph rows. Broader cross-generation base+delta reuse remains gated on P1 resolution read-sets/output fingerprints.

## Evidence

- lifecycle regression removes 1 of 12 shards, then proves exactly one shard insert, zero peer updates/deletes, all 12 snapshot associations, exact replay-byte accounting, and full graph parity
- corrupt/wrong-path payload regression now proves the valid peer remains reusable while the malformed shard is rebuilt
- 100-run Fast-check property covers arbitrary final-shard hit subsets, raw-miss permutations, and attribution batch widths against one-shot attribution
- poison-derivation regression proves content-changing graph generations cannot consume prior-generation final shards

## Validation

- focused lifecycle: 3/3 green
- mixed-reuse attribution properties: 2/2 green (100 runs per property)
- focused project-closure poison-derivation regression: green
- production/test/site TypeScript typechecks
- lint, file-length, Prettier, and diff checks
- independent review: no critical or important findings
- exact-HEAD global install at `1e19c5bb103b187e8d316c7ea1c6db58332b7e05`
- installed CLI smoke: delete one of five final shards, force rebuild, observe `Reused content-addressed materialized shards for 4 file(s).` and a ready five-file graph

The full local suite was intentionally not run; broad validation is delegated to CI.

## Integration

#174 is merged. This PR is rebased directly onto `main`; full main-targeted CI is running.
