### PR TITLE
Add graph freshness backend prerequisite gate

### DIFF
--- a/docs/4.3-large-repository-graph-performance-plan.md
+++ b/docs/4.3-large-repository-graph-performance-plan.md
@@ -62,6 +62,13 @@ Replace repeat Git observation for exact-current reads only after the receipt st
 strict-read retry contract, and exact-Git fallback are covered by deterministic tests. This slice remains independently
 reversible to the current exact observation path.
 
+A behavior-neutral prerequisite gate now makes the qualification boundary executable without granting authority. It
+enumerates the required full worktree and Git control-plane coverage, linearizable checkpoint/exact-observation fences,
+overflow and sequence-loss handling, snapshot binding, epoch retirement, reconciliation, alias isolation, and
+fail-closed malformed-input behavior. The current Effect/Node watcher remains gated, and even complete declarative
+evidence can become only a backend conformance candidate: the module exposes no receipt, read token, capture, validate,
+or currentness-minting API. Runtime integration remains blocked on a real qualified backend and conformance harness.
+
 ### P2 first bounded slice — mixed materialized-shard reuse: implemented
 
 Full materialization now consumes valid content-addressed final-fact shards independently within each bounded source
@@ -622,3 +629,8 @@ version cohort, fixture parity, and retained exact-HEAD artifact before declarin
   rewrite their shard rows. A lifecycle regression audits one missing-row insert, zero peer rewrites, complete snapshot
   association, and graph parity; a 100-run Fast-check property covers arbitrary hit subsets, miss permutations, and
   attribution batch widths. Whole-graph derivation remains intentionally fail-closed across content changes.
+- 2026-08-20: added a non-authorizing Slice 3 prerequisite gate. Its closed conformance checklist and bounded
+  property tests fail closed over delayed notifications, silent Git/control-plane changes, watcher lifecycle and
+  sequence loss, unsupported environments, reconciliation mismatch, stale epoch reuse, aliased inputs, and malformed
+  evidence. Every assessment has `authorizesCurrentness: false`; no watcher or query runtime imports it, so ordinary
+  reads remain deferred and strict reads retain exact Git observation.

--- a/src/code_graph/freshness_receipt.ts
+++ b/src/code_graph/freshness_receipt.ts
@@ -1,0 +1,261 @@
+/**
+ * Slice 3 remains gated. This module describes the evidence a future watcher
+ * backend must prove before any receipt authority can be implemented.
+ *
+ * Deliberately, this module exports no valid-receipt constructor, read token,
+ * capture API, or validation API. A complete assessment is only a candidate
+ * for backend conformance and never authorizes graph currentness.
+ */
+
+export const CODE_GRAPH_FRESHNESS_RECEIPT_RUNTIME_PREREQUISITES = Object.freeze([
+  'baseline-checkout-repository-worktree-head-dirty-overlay-ready-snapshot-bound',
+  'backend-restart-close-end-error-invalidates-before-reuse',
+  'backend-identity',
+  'capture-exact-observation-between-checkpoints',
+  'capture-fresh-linearizable-checkpoints',
+  'capture-queued-mutation-rejected-before-notification',
+  'checkpoint-reuse-rejected',
+  'explicit-overflow-signal',
+  'exact-reconciliation-mismatch-invalidates-before-reuse',
+  'git-config-change-coverage',
+  'git-configuration-read-only',
+  'git-control-plane-change-coverage',
+  'git-head-change-coverage',
+  'git-index-change-coverage',
+  'git-ref-change-coverage',
+  'ingress-egress-alias-isolation',
+  'invalid-unqualified-epoch-reuse-rejected',
+  'opaque-owner-minted-epoch',
+  'replacement-epoch-reuse-rejected',
+  'retired-epoch-never-reusable',
+  'sequence-checkpoint-loss-invalidates-before-reuse',
+  'sequence-contiguous-monotonic',
+  'selected-snapshot-exact-baseline-bound',
+  'silent-git-mutation-visible-before-notification',
+  'unknown-input-total-fail-closed',
+  'unsupported-filesystem-environment-falls-back',
+  'validate-fresh-linearizable-checkpoints',
+  'validate-exact-observation-between-checkpoints',
+  'validate-queued-mutation-rejected-before-notification',
+  'worktree-recursive-change-coverage',
+] as const);
+
+/** The frozen runtime tuple is the single source of truth for this closed set. */
+export type CodeGraphFreshnessReceiptRuntimePrerequisite =
+  (typeof CODE_GRAPH_FRESHNESS_RECEIPT_RUNTIME_PREREQUISITES)[number];
+
+/**
+ * Declarative conformance evidence only. It is intentionally structural
+ * because satisfying it still cannot mint authority.
+ */
+export interface CodeGraphFreshnessReceiptCandidateEvidence {
+  readonly aliasIsolation: 'deep-clone-freeze-except-opaque-epoch';
+  readonly coverage: {
+    readonly gitConfig: 'complete';
+    readonly gitControlPlane: 'complete';
+    readonly gitHead: 'complete';
+    readonly gitIndex: 'complete';
+    readonly gitRefs: 'complete';
+    readonly recursiveWorktree: 'complete';
+    readonly silentGitMutation: 'checkpoint-visible-before-notification';
+  };
+  readonly epochs: {
+    readonly identity: 'opaque-owner-minted';
+    readonly invalidThenUnqualifiedReuse: 'rejected';
+    readonly replacementInvalidationReuse: 'rejected';
+    readonly retirement: 'monotonic-never-reusable';
+  };
+  readonly binding: {
+    readonly baseline: 'checkout-repository-worktree-head-dirty-overlay-fingerprint-ready-snapshot';
+    readonly selectedSnapshot: 'exact-baseline-snapshot';
+  };
+  readonly fences: {
+    readonly captureCheckpoints: 'fresh-linearizable-before-and-after';
+    readonly captureObservation: 'exact-git-worktree-between-checkpoints';
+    readonly captureQueuedMutation: 'advance-rejected-before-notification';
+    readonly reuse: 'rejected';
+    readonly validateCheckpoints: 'fresh-linearizable-before-and-after';
+    readonly validateObservation: 'exact-git-worktree-between-checkpoints';
+    readonly validateQueuedMutation: 'advance-rejected-before-notification';
+  };
+  readonly failClosed: {
+    readonly lifecycle: 'restart-close-end-error-invalidates-before-reuse';
+    readonly reconciliationMismatch: 'exact-observation-invalidates-before-reuse';
+    readonly sequenceOrCheckpointLoss: 'invalidates-before-reuse';
+    readonly unsupportedScope: 'filesystem-environment-falls-back';
+  };
+  readonly gitConfigurationAccess: 'read-only';
+  readonly overflow: 'explicit';
+  readonly sequence: 'contiguous-monotonic';
+  readonly unknownInputHandling: 'total-fail-closed';
+}
+
+export interface CodeGraphFreshnessReceiptCandidate {
+  readonly backend: string;
+  readonly evidence: CodeGraphFreshnessReceiptCandidateEvidence;
+}
+
+export interface CodeGraphFreshnessReceiptCandidateAssessment {
+  /** This precursor is incapable of granting currentness authority. */
+  readonly authorizesCurrentness: false;
+  readonly backend?: string;
+  readonly missing: readonly CodeGraphFreshnessReceiptRuntimePrerequisite[];
+  readonly state: 'candidate-for-conformance' | 'gated';
+}
+
+/**
+ * Current Effect/Node watching can schedule refreshes, but does not provide
+ * qualified checkpoint, sequence, overflow, or full Git control-plane proof.
+ */
+export const CODE_GRAPH_EFFECT_NODE_WATCH_QUALIFICATION: CodeGraphFreshnessReceiptCandidateAssessment =
+  freezeAssessment({
+    authorizesCurrentness: false,
+    backend: 'effect-node-fs-watch',
+    missing: CODE_GRAPH_FRESHNESS_RECEIPT_RUNTIME_PREREQUISITES,
+    state: 'gated',
+  });
+
+/**
+ * Total, fail-closed assessment of untrusted declarative evidence.
+ *
+ * Even when every prerequisite is present, the result only admits the backend
+ * to a future platform conformance harness. It never creates a receipt or read
+ * authority and is not wired into watcher or query runtime behavior. Extractor
+ * and indexer currentness remain a separate query-layer prerequisite.
+ */
+export function assessCodeGraphFreshnessReceiptCandidate(input: unknown): CodeGraphFreshnessReceiptCandidateAssessment {
+  try {
+    const candidate = record(input);
+    const backend = nonEmptyString(candidate?.backend);
+    const evidence = record(candidate?.evidence);
+    const binding = record(evidence?.binding);
+    const coverage = record(evidence?.coverage);
+    const epochs = record(evidence?.epochs);
+    const fences = record(evidence?.fences);
+    const failClosed = record(evidence?.failClosed);
+    const satisfied = new Set<CodeGraphFreshnessReceiptRuntimePrerequisite>();
+
+    satisfy(
+      satisfied,
+      'baseline-checkout-repository-worktree-head-dirty-overlay-ready-snapshot-bound',
+      binding?.baseline === 'checkout-repository-worktree-head-dirty-overlay-fingerprint-ready-snapshot',
+    );
+    satisfy(
+      satisfied,
+      'backend-restart-close-end-error-invalidates-before-reuse',
+      failClosed?.lifecycle === 'restart-close-end-error-invalidates-before-reuse',
+    );
+    satisfy(satisfied, 'backend-identity', backend !== undefined);
+    satisfy(
+      satisfied,
+      'capture-exact-observation-between-checkpoints',
+      fences?.captureObservation === 'exact-git-worktree-between-checkpoints',
+    );
+    satisfy(
+      satisfied,
+      'capture-fresh-linearizable-checkpoints',
+      fences?.captureCheckpoints === 'fresh-linearizable-before-and-after',
+    );
+    satisfy(
+      satisfied,
+      'capture-queued-mutation-rejected-before-notification',
+      fences?.captureQueuedMutation === 'advance-rejected-before-notification',
+    );
+    satisfy(satisfied, 'checkpoint-reuse-rejected', fences?.reuse === 'rejected');
+    satisfy(satisfied, 'explicit-overflow-signal', evidence?.overflow === 'explicit');
+    satisfy(
+      satisfied,
+      'exact-reconciliation-mismatch-invalidates-before-reuse',
+      failClosed?.reconciliationMismatch === 'exact-observation-invalidates-before-reuse',
+    );
+    satisfy(satisfied, 'git-config-change-coverage', coverage?.gitConfig === 'complete');
+    satisfy(satisfied, 'git-configuration-read-only', evidence?.gitConfigurationAccess === 'read-only');
+    satisfy(satisfied, 'git-control-plane-change-coverage', coverage?.gitControlPlane === 'complete');
+    satisfy(satisfied, 'git-head-change-coverage', coverage?.gitHead === 'complete');
+    satisfy(satisfied, 'git-index-change-coverage', coverage?.gitIndex === 'complete');
+    satisfy(satisfied, 'git-ref-change-coverage', coverage?.gitRefs === 'complete');
+    satisfy(
+      satisfied,
+      'ingress-egress-alias-isolation',
+      evidence?.aliasIsolation === 'deep-clone-freeze-except-opaque-epoch',
+    );
+    satisfy(satisfied, 'invalid-unqualified-epoch-reuse-rejected', epochs?.invalidThenUnqualifiedReuse === 'rejected');
+    satisfy(satisfied, 'opaque-owner-minted-epoch', epochs?.identity === 'opaque-owner-minted');
+    satisfy(satisfied, 'replacement-epoch-reuse-rejected', epochs?.replacementInvalidationReuse === 'rejected');
+    satisfy(satisfied, 'retired-epoch-never-reusable', epochs?.retirement === 'monotonic-never-reusable');
+    satisfy(
+      satisfied,
+      'sequence-checkpoint-loss-invalidates-before-reuse',
+      failClosed?.sequenceOrCheckpointLoss === 'invalidates-before-reuse',
+    );
+    satisfy(satisfied, 'sequence-contiguous-monotonic', evidence?.sequence === 'contiguous-monotonic');
+    satisfy(
+      satisfied,
+      'selected-snapshot-exact-baseline-bound',
+      binding?.selectedSnapshot === 'exact-baseline-snapshot',
+    );
+    satisfy(
+      satisfied,
+      'silent-git-mutation-visible-before-notification',
+      coverage?.silentGitMutation === 'checkpoint-visible-before-notification',
+    );
+    satisfy(satisfied, 'unknown-input-total-fail-closed', evidence?.unknownInputHandling === 'total-fail-closed');
+    satisfy(
+      satisfied,
+      'unsupported-filesystem-environment-falls-back',
+      failClosed?.unsupportedScope === 'filesystem-environment-falls-back',
+    );
+    satisfy(
+      satisfied,
+      'validate-fresh-linearizable-checkpoints',
+      fences?.validateCheckpoints === 'fresh-linearizable-before-and-after',
+    );
+    satisfy(
+      satisfied,
+      'validate-exact-observation-between-checkpoints',
+      fences?.validateObservation === 'exact-git-worktree-between-checkpoints',
+    );
+    satisfy(
+      satisfied,
+      'validate-queued-mutation-rejected-before-notification',
+      fences?.validateQueuedMutation === 'advance-rejected-before-notification',
+    );
+    satisfy(satisfied, 'worktree-recursive-change-coverage', coverage?.recursiveWorktree === 'complete');
+
+    const missing = CODE_GRAPH_FRESHNESS_RECEIPT_RUNTIME_PREREQUISITES.filter(item => !satisfied.has(item));
+    return freezeAssessment({
+      authorizesCurrentness: false,
+      ...(backend === undefined ? {} : {backend}),
+      missing,
+      state: missing.length === 0 ? 'candidate-for-conformance' : 'gated',
+    });
+  } catch {
+    return freezeAssessment({
+      authorizesCurrentness: false,
+      missing: CODE_GRAPH_FRESHNESS_RECEIPT_RUNTIME_PREREQUISITES,
+      state: 'gated',
+    });
+  }
+}
+
+function freezeAssessment(
+  assessment: CodeGraphFreshnessReceiptCandidateAssessment,
+): CodeGraphFreshnessReceiptCandidateAssessment {
+  return Object.freeze({...assessment, missing: Object.freeze([...assessment.missing])});
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function record(value: unknown): Record<PropertyKey, unknown> | undefined {
+  return typeof value === 'object' && value !== null ? (value as Record<PropertyKey, unknown>) : undefined;
+}
+
+function satisfy(
+  satisfied: Set<CodeGraphFreshnessReceiptRuntimePrerequisite>,
+  prerequisite: CodeGraphFreshnessReceiptRuntimePrerequisite,
+  condition: boolean,
+): void {
+  if (condition) satisfied.add(prerequisite);
+}

--- a/test/unit/code-graph.freshness-receipt.property.test.ts
+++ b/test/unit/code-graph.freshness-receipt.property.test.ts
@@ -1,0 +1,299 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  assessCodeGraphFreshnessReceiptCandidate,
+  CODE_GRAPH_EFFECT_NODE_WATCH_QUALIFICATION,
+  CODE_GRAPH_FRESHNESS_RECEIPT_RUNTIME_PREREQUISITES,
+  type CodeGraphFreshnessReceiptCandidate,
+  type CodeGraphFreshnessReceiptRuntimePrerequisite,
+} from '../../src/code_graph/freshness_receipt.js';
+
+const allPrerequisites = CODE_GRAPH_FRESHNESS_RECEIPT_RUNTIME_PREREQUISITES;
+
+describe('code graph freshness receipt runtime gate', () => {
+  it('keeps the current Effect and Node watcher fully gated and immutable', () => {
+    expect(CODE_GRAPH_EFFECT_NODE_WATCH_QUALIFICATION).toEqual({
+      authorizesCurrentness: false,
+      backend: 'effect-node-fs-watch',
+      missing: allPrerequisites,
+      state: 'gated',
+    });
+    expect(Object.isFrozen(CODE_GRAPH_EFFECT_NODE_WATCH_QUALIFICATION)).toBe(true);
+    expect(Object.isFrozen(CODE_GRAPH_EFFECT_NODE_WATCH_QUALIFICATION.missing)).toBe(true);
+    expect(Reflect.set(CODE_GRAPH_EFFECT_NODE_WATCH_QUALIFICATION, 'state', 'candidate-for-conformance')).toBe(false);
+  });
+
+  it('treats complete declarative evidence only as a non-authorizing conformance candidate', () => {
+    const assessment = assessCodeGraphFreshnessReceiptCandidate(completeCandidate());
+
+    expect(assessment).toEqual({
+      authorizesCurrentness: false,
+      backend: 'test-qualified-watch',
+      missing: [],
+      state: 'candidate-for-conformance',
+    });
+    expect(Object.isFrozen(assessment)).toBe(true);
+    expect(Object.isFrozen(assessment.missing)).toBe(true);
+  });
+
+  it.each([
+    ['a mutation queued before capture notification delivery', 'capture-queued-mutation-rejected-before-notification'],
+    [
+      'a mutation queued before post-read validation notification delivery',
+      'validate-queued-mutation-rejected-before-notification',
+    ],
+    ['a silent Git control-plane mutation', 'silent-git-mutation-visible-before-notification'],
+    ['reuse after invalid then unqualified downgrade', 'invalid-unqualified-epoch-reuse-rejected'],
+    ['reuse of either epoch after replacement invalidation', 'replacement-epoch-reuse-rejected'],
+  ] as const)('requires proof that rejects %s', (_label, missingPrerequisite) => {
+    const satisfied = new Set<CodeGraphFreshnessReceiptRuntimePrerequisite>(allPrerequisites);
+    satisfied.delete(missingPrerequisite);
+
+    expect(assessCodeGraphFreshnessReceiptCandidate(candidateFromSatisfied(satisfied))).toMatchObject({
+      authorizesCurrentness: false,
+      missing: [missingPrerequisite],
+      state: 'gated',
+    });
+  });
+
+  it.each([
+    'backend-restart-close-end-error-invalidates-before-reuse',
+    'sequence-checkpoint-loss-invalidates-before-reuse',
+    'unsupported-filesystem-environment-falls-back',
+    'exact-reconciliation-mismatch-invalidates-before-reuse',
+  ] as const)('requires the fail-closed lifecycle prerequisite %s', missingPrerequisite => {
+    const satisfied = new Set<CodeGraphFreshnessReceiptRuntimePrerequisite>(allPrerequisites);
+    satisfied.delete(missingPrerequisite);
+
+    expect(assessCodeGraphFreshnessReceiptCandidate(candidateFromSatisfied(satisfied))).toMatchObject({
+      authorizesCurrentness: false,
+      missing: [missingPrerequisite],
+      state: 'gated',
+    });
+  });
+
+  it.each([
+    'capture-fresh-linearizable-checkpoints',
+    'capture-exact-observation-between-checkpoints',
+    'validate-fresh-linearizable-checkpoints',
+    'validate-exact-observation-between-checkpoints',
+    'baseline-checkout-repository-worktree-head-dirty-overlay-ready-snapshot-bound',
+    'selected-snapshot-exact-baseline-bound',
+  ] as const)('requires the closed read-fence and snapshot binding prerequisite %s', missingPrerequisite => {
+    const satisfied = new Set<CodeGraphFreshnessReceiptRuntimePrerequisite>(allPrerequisites);
+    satisfied.delete(missingPrerequisite);
+
+    expect(assessCodeGraphFreshnessReceiptCandidate(candidateFromSatisfied(satisfied))).toMatchObject({
+      authorizesCurrentness: false,
+      missing: [missingPrerequisite],
+      state: 'gated',
+    });
+  });
+
+  it.each([
+    'worktree-recursive-change-coverage',
+    'git-head-change-coverage',
+    'git-ref-change-coverage',
+    'git-index-change-coverage',
+    'git-config-change-coverage',
+    'git-control-plane-change-coverage',
+  ] as const)('requires full dependency-surface coverage for %s', missingPrerequisite => {
+    const satisfied = new Set<CodeGraphFreshnessReceiptRuntimePrerequisite>(allPrerequisites);
+    satisfied.delete(missingPrerequisite);
+
+    expect(assessCodeGraphFreshnessReceiptCandidate(candidateFromSatisfied(satisfied))).toMatchObject({
+      authorizesCurrentness: false,
+      missing: [missingPrerequisite],
+      state: 'gated',
+    });
+  });
+
+  it('does not retain caller aliases and freezes every returned wrapper', () => {
+    const candidate = completeCandidate();
+    const assessment = assessCodeGraphFreshnessReceiptCandidate(candidate);
+    const mutable = candidate as unknown as {
+      backend: string;
+      evidence: {
+        binding: {baseline: string};
+        coverage: {gitHead: string};
+        fences: {captureCheckpoints: string};
+      };
+    };
+
+    mutable.backend = 'mutated-backend';
+    mutable.evidence.binding.baseline = 'mutated';
+    mutable.evidence.coverage.gitHead = 'mutated';
+    mutable.evidence.fences.captureCheckpoints = 'mutated';
+
+    expect(assessment).toEqual({
+      authorizesCurrentness: false,
+      backend: 'test-qualified-watch',
+      missing: [],
+      state: 'candidate-for-conformance',
+    });
+    expect(Reflect.set(assessment, 'backend', 'mutated-output')).toBe(false);
+    expect(Reflect.set(assessment.missing, '0', 'backend-identity')).toBe(false);
+    expect(assessCodeGraphFreshnessReceiptCandidate(candidate)).toMatchObject({
+      authorizesCurrentness: false,
+      state: 'gated',
+    });
+  });
+
+  it('is total and fail-closed for malformed values and throwing accessors', () => {
+    const throwing = new Proxy<Record<string, never>>(
+      {},
+      {
+        get() {
+          throw new Error('untrusted getter');
+        },
+      },
+    );
+    const malformed: readonly unknown[] = [
+      undefined,
+      null,
+      true,
+      1,
+      1n,
+      'candidate',
+      [],
+      {},
+      {backend: {trim: 'not-a-function'}, evidence: null},
+      {backend: 'backend', evidence: {coverage: throwing}},
+      throwing,
+    ];
+
+    for (const value of malformed) {
+      expect(() => assessCodeGraphFreshnessReceiptCandidate(value)).not.toThrow();
+      const assessment = assessCodeGraphFreshnessReceiptCandidate(value);
+      expect(assessment.authorizesCurrentness).toBe(false);
+      expect(assessment.state).toBe('gated');
+      expect(assessment.missing.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never grants currentness for arbitrary unknown input (property)', () => {
+    fc.assert(
+      fc.property(fc.anything(), input => {
+        const assessment = assessCodeGraphFreshnessReceiptCandidate(input);
+        expect(assessment.authorizesCurrentness).toBe(false);
+        expect(['candidate-for-conformance', 'gated']).toContain(assessment.state);
+        expect(Object.isFrozen(assessment)).toBe(true);
+        expect(Object.isFrozen(assessment.missing)).toBe(true);
+      }),
+      {numRuns: 500},
+    );
+  });
+
+  it('matches an independent prerequisite model for arbitrary evidence subsets (property)', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.boolean(), {maxLength: allPrerequisites.length, minLength: allPrerequisites.length}),
+        proofs => {
+          const satisfied = new Set<CodeGraphFreshnessReceiptRuntimePrerequisite>();
+          for (const [index, prerequisite] of allPrerequisites.entries()) {
+            if (proofs[index]) satisfied.add(prerequisite);
+          }
+          const expectedMissing = allPrerequisites.filter(prerequisite => !satisfied.has(prerequisite));
+          const assessment = assessCodeGraphFreshnessReceiptCandidate(candidateFromSatisfied(satisfied));
+
+          expect(assessment).toEqual({
+            authorizesCurrentness: false,
+            ...(satisfied.has('backend-identity') ? {backend: 'test-qualified-watch'} : {}),
+            missing: expectedMissing,
+            state: expectedMissing.length === 0 ? 'candidate-for-conformance' : 'gated',
+          });
+        },
+      ),
+      {numRuns: 500},
+    );
+  });
+
+  it('returns the same complete assessment for the same arbitrary evidence (property)', () => {
+    fc.assert(
+      fc.property(fc.anything(), input => {
+        expect(assessCodeGraphFreshnessReceiptCandidate(input)).toEqual(
+          assessCodeGraphFreshnessReceiptCandidate(input),
+        );
+      }),
+      {numRuns: 250},
+    );
+  });
+});
+
+function completeCandidate(): CodeGraphFreshnessReceiptCandidate {
+  return candidateFromSatisfied(
+    new Set<CodeGraphFreshnessReceiptRuntimePrerequisite>(allPrerequisites),
+  ) as CodeGraphFreshnessReceiptCandidate;
+}
+
+function candidateFromSatisfied(satisfied: ReadonlySet<CodeGraphFreshnessReceiptRuntimePrerequisite>): unknown {
+  const proven = (prerequisite: CodeGraphFreshnessReceiptRuntimePrerequisite): boolean => satisfied.has(prerequisite);
+  return {
+    backend: proven('backend-identity') ? 'test-qualified-watch' : ' ',
+    evidence: {
+      aliasIsolation: proven('ingress-egress-alias-isolation') ? 'deep-clone-freeze-except-opaque-epoch' : 'not-proven',
+      binding: {
+        baseline: proven('baseline-checkout-repository-worktree-head-dirty-overlay-ready-snapshot-bound')
+          ? 'checkout-repository-worktree-head-dirty-overlay-fingerprint-ready-snapshot'
+          : 'not-proven',
+        selectedSnapshot: proven('selected-snapshot-exact-baseline-bound') ? 'exact-baseline-snapshot' : 'not-proven',
+      },
+      coverage: {
+        gitConfig: proven('git-config-change-coverage') ? 'complete' : 'not-proven',
+        gitControlPlane: proven('git-control-plane-change-coverage') ? 'complete' : 'not-proven',
+        gitHead: proven('git-head-change-coverage') ? 'complete' : 'not-proven',
+        gitIndex: proven('git-index-change-coverage') ? 'complete' : 'not-proven',
+        gitRefs: proven('git-ref-change-coverage') ? 'complete' : 'not-proven',
+        recursiveWorktree: proven('worktree-recursive-change-coverage') ? 'complete' : 'not-proven',
+        silentGitMutation: proven('silent-git-mutation-visible-before-notification')
+          ? 'checkpoint-visible-before-notification'
+          : 'not-proven',
+      },
+      epochs: {
+        identity: proven('opaque-owner-minted-epoch') ? 'opaque-owner-minted' : 'not-proven',
+        invalidThenUnqualifiedReuse: proven('invalid-unqualified-epoch-reuse-rejected') ? 'rejected' : 'not-proven',
+        replacementInvalidationReuse: proven('replacement-epoch-reuse-rejected') ? 'rejected' : 'not-proven',
+        retirement: proven('retired-epoch-never-reusable') ? 'monotonic-never-reusable' : 'not-proven',
+      },
+      failClosed: {
+        lifecycle: proven('backend-restart-close-end-error-invalidates-before-reuse')
+          ? 'restart-close-end-error-invalidates-before-reuse'
+          : 'not-proven',
+        reconciliationMismatch: proven('exact-reconciliation-mismatch-invalidates-before-reuse')
+          ? 'exact-observation-invalidates-before-reuse'
+          : 'not-proven',
+        sequenceOrCheckpointLoss: proven('sequence-checkpoint-loss-invalidates-before-reuse')
+          ? 'invalidates-before-reuse'
+          : 'not-proven',
+        unsupportedScope: proven('unsupported-filesystem-environment-falls-back')
+          ? 'filesystem-environment-falls-back'
+          : 'not-proven',
+      },
+      fences: {
+        captureCheckpoints: proven('capture-fresh-linearizable-checkpoints')
+          ? 'fresh-linearizable-before-and-after'
+          : 'not-proven',
+        captureObservation: proven('capture-exact-observation-between-checkpoints')
+          ? 'exact-git-worktree-between-checkpoints'
+          : 'not-proven',
+        captureQueuedMutation: proven('capture-queued-mutation-rejected-before-notification')
+          ? 'advance-rejected-before-notification'
+          : 'not-proven',
+        reuse: proven('checkpoint-reuse-rejected') ? 'rejected' : 'not-proven',
+        validateCheckpoints: proven('validate-fresh-linearizable-checkpoints')
+          ? 'fresh-linearizable-before-and-after'
+          : 'not-proven',
+        validateObservation: proven('validate-exact-observation-between-checkpoints')
+          ? 'exact-git-worktree-between-checkpoints'
+          : 'not-proven',
+        validateQueuedMutation: proven('validate-queued-mutation-rejected-before-notification')
+          ? 'advance-rejected-before-notification'
+          : 'not-proven',
+      },
+      gitConfigurationAccess: proven('git-configuration-read-only') ? 'read-only' : 'not-proven',
+      overflow: proven('explicit-overflow-signal') ? 'explicit' : 'not-proven',
+      sequence: proven('sequence-contiguous-monotonic') ? 'contiguous-monotonic' : 'not-proven',
+      unknownInputHandling: proven('unknown-input-total-fail-closed') ? 'total-fail-closed' : 'not-proven',
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a pure, total conformance-assessment surface for a future qualified graph watcher backend
- enumerate the full worktree and Git control-plane coverage, linearizable before/after exact-observation fences, overflow/sequence/lifecycle failure handling, snapshot binding, epoch retirement, reconciliation, and alias isolation prerequisites
- keep the current Effect/Node watcher explicitly gated and every assessment permanently non-authorizing
- add bounded example and Fast-check coverage for malformed evidence and arbitrary prerequisite subsets

## Safety boundary

This change does not alter freshness behavior. The module is imported only by its focused test: watcher, query, runtime, MCP, and telemetry code do not reference it. It exposes no receipt constructor, read token, capture, validate, usable-authority, or currentness-minting API. Every result has authorizesCurrentness=false, including a complete declarative candidate.

Runtime integration remains blocked on a real backend plus an independent conformance harness. Ordinary reads stay deferred and strict reads retain exact Git observation.

## Verification

- focused Vitest: 1 file / 28 tests
- bounded Fast-check: 500 unknown inputs, 500 independent prerequisite subsets, and 250 deterministic replays
- source, test, and website TypeScript checks
- strict targeted lint, Prettier, file-length, no-wiring search, and diff checks
- two independent review passes: zero critical or important findings after completeness fixes
- exact HEAD 42cc39f5 installed globally; doctor finished with 0 failures
- installed graph query still returned bounded stale evidence, confirming no currentness behavior change

The full local test suite was intentionally not run; CI is the broad gate.