### PR TITLE
Return bounded topology for large graphs

### DIFF
--- a/src/code_graph/analysis.ts
+++ b/src/code_graph/analysis.ts
@@ -234,6 +234,7 @@ export interface CodeGraphAnalysisCoverage {
   readonly complete: boolean;
   readonly edgeMetricsComplete: boolean;
   readonly edgesComplete: boolean;
+  /** Every snapshot symbol participated; false means topology is a bounded path-prefix observation. */
   readonly nodesComplete: boolean;
   readonly topology: {
     readonly complete: boolean;
@@ -572,7 +573,10 @@ export const analyzeCodeGraph = Effect.fn('codeGraph.analyze')(function* (
   let confidenceTotal = edgeAggregateSupported ? edgeAggregates.confidenceTotal : 0;
   let invalidConfidenceEdgeCount = edgeAggregateSupported ? edgeAggregates.invalidConfidenceEdgeCount : 0;
   const firstEdgeBudget = Math.min(budget.maxEdges, budget.maxEdgeVisits);
-  const topologyEnabled = needsTopology && nodesComplete;
+  // A non-empty bounded node prefix can still support an honest partial topology
+  // observation. Coverage keeps nodesComplete=false, so none of its connectivity
+  // or degree observations can be mistaken for whole-graph conclusions.
+  const topologyEnabled = needsTopology && (nodesComplete || nodes.length > 0);
   const needsPrimaryEdgeScan = topologyEnabled || needsConfidenceFindingScan;
   const topologyScan = !needsPrimaryEdgeScan
     ? emptyEdgeScan(false)
@@ -658,13 +662,6 @@ export const analyzeCodeGraph = Effect.fn('codeGraph.analyze')(function* (
     topologyScan.visits >= options.snapshot.edgeCount ||
     options.snapshot.edgeCount === 0;
   const observedTopologyNodeCount = nodes.length;
-  if (needsTopology && !topologyEnabled) {
-    // A path-prefix node slice without the complete endpoint set cannot support
-    // truthful connectivity, isolation, hub, or community claims. Preserve the
-    // observed row count for coverage, but derive no topology from that slice.
-    nodes.length = 0;
-    nodeIndex.clear();
-  }
 
   const componentGroups = new Map<number, MutableGroup>();
   const communityGroups = new Map<number, MutableGroup>();
@@ -1042,7 +1039,11 @@ export const analyzeCodeGraph = Effect.fn('codeGraph.analyze')(function* (
   }
   if (needsTopology && !nodesComplete) {
     warnings.push(
-      `Topology was not derived because only ${observedTopologyNodeCount.toLocaleString()} of ${options.snapshot.symbolCount.toLocaleString()} symbols fit the node/time budget.`,
+      topologyEnabled
+        ? edgesComplete
+          ? `Topology is a bounded path-prefix induced subgraph over ${observedTopologyNodeCount.toLocaleString()} of ${options.snapshot.symbolCount.toLocaleString()} symbols. Connectivity, degree, isolation, hub, component, community, and absence claims apply only to retained nodes.`
+          : `Topology is a bounded observation over a path-prefix node set (${observedTopologyNodeCount.toLocaleString()} of ${options.snapshot.symbolCount.toLocaleString()} symbols) and the relationship rows that fit the edge/time budget. Connectivity, degree, isolation, hub, component, community, and absence claims are not whole-graph conclusions.`
+        : `Topology was not derived because none of ${options.snapshot.symbolCount.toLocaleString()} symbols fit the node/time budget.`,
     );
   }
   if (needsTopology && topologyEnabled && !edgesComplete)

--- a/src/code_graph/analysis_render.ts
+++ b/src/code_graph/analysis_render.ts
@@ -82,7 +82,11 @@ export function renderCodeGraphReport(
                 `| ${markdownCell(hub.node.label)} | ${hub.classification} | ${hub.degree} | ${hub.incoming} | ${hub.outgoing} | \`${markdownCode(hub.node.path)}\` |`,
             ),
           ]
-        : ['No hubs met the deterministic threshold.']),
+        : [
+            result.coverage.topology.complete
+              ? 'No hubs met the deterministic threshold.'
+              : 'No hubs were observed in bounded topology; absence is not proven.',
+          ]),
     '',
     '## Confidence audit',
     '',
@@ -101,7 +105,11 @@ export function renderCodeGraphReport(
                 `| ${markdownCell(community.label)} | ${community.memberCount} | ${community.internalEdgeCount} | ${community.crossCommunityIncoming + community.crossCommunityOutgoing} | \`${markdownCode(community.representative.path)}\` |`,
             ),
           ]
-        : ['No structural communities were found.']),
+        : [
+            result.coverage.topology.complete
+              ? 'No structural communities were found.'
+              : 'No structural communities were observed in bounded topology; absence is not proven.',
+          ]),
     '',
     '## Surprising cross-community links',
     '',
@@ -113,7 +121,11 @@ export function renderCodeGraphReport(
               `- ${markdownText(link.source.label)} **${link.relation}** ${markdownText(link.target.label)} ` +
               `(score ${link.score.toFixed(3)}, ${link.provenance}, confidence ${link.confidence.toFixed(2)})`,
           )
-        : ['No cross-community links met the deterministic ranking criteria.']),
+        : [
+            result.coverage.topology.complete
+              ? 'No cross-community links met the deterministic ranking criteria.'
+              : 'No cross-community links were observed in bounded topology; absence is not proven.',
+          ]),
     '',
     '## Structural relationship groups',
     '',
@@ -125,7 +137,11 @@ export function renderCodeGraphReport(
               `- ${markdownText(group.center.label)} (${group.direction}, ${group.relationshipCount} relationships; ` +
               `${group.members.length} bounded member${group.members.length === 1 ? '' : 's'})`,
           )
-        : ['No high-degree fan-in or fan-out groups met the deterministic threshold.']),
+        : [
+            result.coverage.topology.complete
+              ? 'No high-degree fan-in or fan-out groups met the deterministic threshold.'
+              : 'No high-degree fan-in or fan-out groups were observed in bounded topology; absence is not proven.',
+          ]),
     '',
     '## Questions this graph can answer',
     '',
@@ -147,11 +163,24 @@ function renderStatistics(result: CodeGraphAnalysisResult): readonly string[] {
     `- Confidence (${result.confidenceAudit.summaryComplete ? 'exact' : 'observed'}): average ${result.confidenceAudit.averageConfidence.toFixed(2)}; ${formatConfidenceBands(result.confidenceAudit)}`,
   ];
   if (result.coverage.topology.state === 'complete' || result.coverage.topology.state === 'partial') {
+    const boundedNodePrefix = !result.coverage.nodesComplete;
+    const partialTopology = !result.coverage.topology.complete;
+    const boundedTopologyLabel = boundedNodePrefix
+      ? result.coverage.edgesComplete
+        ? 'bounded path-prefix induced subgraph'
+        : 'bounded path/relationship-prefix observation'
+      : 'bounded relationship-prefix observation';
     lines.splice(
       1,
       0,
-      `- Topology (${result.coverage.topology.state}): ${statistics.connectedComponentCount.toLocaleString()} connected components; ${statistics.communityCount.toLocaleString()} structural communities`,
-      `- Topology (${result.coverage.topology.state}): ${statistics.isolatedNodeCount.toLocaleString()} isolated nodes; average degree ${statistics.averageDegree.toFixed(2)}; maximum degree ${statistics.maximumDegree.toLocaleString()}`,
+      partialTopology
+        ? `- Topology (${boundedTopologyLabel}): ${statistics.connectedComponentCount.toLocaleString()} observed connected components; ${statistics.communityCount.toLocaleString()} observed structural communities`
+        : `- Topology (${result.coverage.topology.state}): ${statistics.connectedComponentCount.toLocaleString()} connected components; ${statistics.communityCount.toLocaleString()} structural communities`,
+      partialTopology
+        ? boundedNodePrefix
+          ? `- Topology (retained nodes only): ${statistics.isolatedNodeCount.toLocaleString()} retained nodes with zero observed degree; average observed degree ${statistics.averageDegree.toFixed(2)}; maximum observed degree ${statistics.maximumDegree.toLocaleString()}`
+          : `- Topology (bounded relationship scan): ${statistics.isolatedNodeCount.toLocaleString()} nodes with zero observed degree; average observed degree ${statistics.averageDegree.toFixed(2)}; maximum observed degree ${statistics.maximumDegree.toLocaleString()}`
+        : `- Topology (${result.coverage.topology.state}): ${statistics.isolatedNodeCount.toLocaleString()} isolated nodes; average degree ${statistics.averageDegree.toFixed(2)}; maximum degree ${statistics.maximumDegree.toLocaleString()}`,
     );
   } else {
     lines.splice(
@@ -211,7 +240,13 @@ function renderConfidenceAudit(audit: CodeGraphConfidenceAudit): readonly string
 function renderCommunities(result: CodeGraphAnalysisResult): readonly string[] {
   if (topologyUnavailable(result)) return ['Communities: unavailable because topology was not derived'];
   const communities = result.communities;
-  if (communities.length === 0) return ['Communities: none'];
+  if (communities.length === 0) {
+    return [
+      result.coverage.topology.complete
+        ? 'Communities: none'
+        : 'Communities: none observed in bounded topology; absence is not proven',
+    ];
+  }
   return [
     result.coverage.topology.state === 'partial' ? 'Communities (observed partial topology):' : 'Communities:',
     ...communities.map(
@@ -239,7 +274,13 @@ function renderCommunityDrillDown(drillDown: CodeGraphCommunityDrillDown | undef
 function renderHubs(result: CodeGraphAnalysisResult): readonly string[] {
   if (topologyUnavailable(result)) return ['Hubs: unavailable because topology was not derived'];
   const hubs = result.hubs;
-  if (hubs.length === 0) return ['Hubs: none met the deterministic threshold'];
+  if (hubs.length === 0) {
+    return [
+      result.coverage.topology.complete
+        ? 'Hubs: none met the deterministic threshold'
+        : 'Hubs: none observed in bounded topology; absence is not proven',
+    ];
+  }
   return [
     result.coverage.topology.state === 'partial' ? 'Hubs (observed partial topology):' : 'Hubs:',
     ...hubs.map(
@@ -255,7 +296,13 @@ function renderRelationshipGroups(result: CodeGraphAnalysisResult): readonly str
     return ['Structural relationship groups: unavailable because topology was not derived'];
   }
   const groups = result.relationshipGroups;
-  if (groups.length === 0) return ['Structural relationship groups: none met the deterministic threshold'];
+  if (groups.length === 0) {
+    return [
+      result.coverage.topology.complete
+        ? 'Structural relationship groups: none met the deterministic threshold'
+        : 'Structural relationship groups: none observed in bounded topology; absence is not proven',
+    ];
+  }
   return [
     `Structural relationship groups (derived n-ary evidence${result.coverage.topology.state === 'partial' ? '; observed partial topology' : ''}):`,
     ...groups.map(
@@ -270,7 +317,13 @@ function renderRelationshipGroups(result: CodeGraphAnalysisResult): readonly str
 function renderSurprises(result: CodeGraphAnalysisResult): readonly string[] {
   if (topologyUnavailable(result)) return ['Surprising links: unavailable because topology was not derived'];
   const links = result.surprisingLinks;
-  if (links.length === 0) return ['Surprising links: none'];
+  if (links.length === 0) {
+    return [
+      result.coverage.topology.complete
+        ? 'Surprising links: none'
+        : 'Surprising links: none observed in bounded topology; absence is not proven',
+    ];
+  }
   return [
     result.coverage.topology.state === 'partial'
       ? 'Surprising cross-community links (observed partial topology):'

--- a/src/code_graph/diagnostics.ts
+++ b/src/code_graph/diagnostics.ts
@@ -491,9 +491,17 @@ export function renderCodeGraphDiagnostics(
         lines.push(`Folder: ${codeGraphLocalAssociationLabel(view.localAssociation)} · ${view.localAssociation.state}`);
       }
       if (view.analysis) {
-        lines.push(
-          `Analysis: ${view.analysis.coverage.complete ? 'complete' : 'partial'} · ${view.analysis.statistics.connectedComponentCount} component(s) · ${view.analysis.statistics.communityCount} communit${view.analysis.statistics.communityCount === 1 ? 'y' : 'ies'}`,
-        );
+        const topology = view.analysis.coverage.topology;
+        if (topology.state === 'complete' || topology.state === 'partial') {
+          const observed = topology.complete ? '' : 'observed ';
+          lines.push(
+            `Analysis: ${view.analysis.coverage.complete ? 'complete' : 'partial'} · ${view.analysis.statistics.connectedComponentCount} ${observed}component(s) · ${view.analysis.statistics.communityCount} ${observed}communit${view.analysis.statistics.communityCount === 1 ? 'y' : 'ies'}`,
+          );
+        } else {
+          lines.push(
+            `Analysis: ${view.analysis.coverage.complete ? 'complete' : 'partial'} · topology ${topology.state}`,
+          );
+        }
       }
     }
     for (const issue of database.issues) lines.push(`Warning: ${issue.code}: ${issue.message}`);

--- a/src/manager_graph_model.ts
+++ b/src/manager_graph_model.ts
@@ -1251,6 +1251,7 @@ export interface GraphAnalysis {
   }[];
   readonly coverage: {
     readonly complete: boolean;
+    readonly nodesComplete: boolean;
     readonly topology: {
       readonly complete: boolean;
       readonly state: 'complete' | 'not-requested' | 'partial' | 'unavailable';
@@ -1286,7 +1287,7 @@ export function graphAnalysisCoverageLabel(analysis: GraphAnalysis): string {
     case 'complete':
       return analysis.coverage.complete ? 'Complete' : 'Topology complete';
     case 'partial':
-      return 'Topology partial';
+      return analysis.coverage.nodesComplete ? 'Topology partial' : 'Bounded topology';
     case 'not-requested':
       return 'Topology not requested';
     case 'unavailable':

--- a/src/manager_graph_panels.tsx
+++ b/src/manager_graph_panels.tsx
@@ -52,6 +52,7 @@ export function GraphSummary(props: {
   readonly onAnalyze: () => void;
   readonly sizeMetric: GraphSizeMetric;
 }): React.ReactElement {
+  const partialTopology = props.analysis?.coverage.topology.state === 'partial';
   return (
     <div className="graph-summary">
       <p className="eyebrow">{props.graph.mode === 'overview' ? 'Repository overview' : 'Component working set'}</p>
@@ -115,7 +116,7 @@ export function GraphSummary(props: {
       <section className="graph-analysis-summary">
         <header>
           <div>
-            <p className="eyebrow">Whole-graph analysis</p>
+            <p className="eyebrow">{partialTopology ? 'Bounded graph analysis' : 'Whole-graph analysis'}</p>
             <h4>Architecture signals</h4>
           </div>
           <button className="quiet-button" disabled={props.analysisLoading} onClick={props.onAnalyze} type="button">
@@ -126,7 +127,7 @@ export function GraphSummary(props: {
           <>
             <dl className="metric-list graph-analysis-metrics">
               <div>
-                <dt>Communities</dt>
+                <dt>{partialTopology ? 'Observed communities' : 'Communities'}</dt>
                 <dd>
                   {graphAnalysisTopologyAvailable(props.analysis)
                     ? compactNumber(props.analysis.statistics.communityCount)
@@ -134,7 +135,7 @@ export function GraphSummary(props: {
                 </dd>
               </div>
               <div>
-                <dt>Components</dt>
+                <dt>{partialTopology ? 'Observed components' : 'Components'}</dt>
                 <dd>
                   {graphAnalysisTopologyAvailable(props.analysis)
                     ? compactNumber(props.analysis.statistics.connectedComponentCount)
@@ -142,7 +143,7 @@ export function GraphSummary(props: {
                 </dd>
               </div>
               <div>
-                <dt>Hubs</dt>
+                <dt>{partialTopology ? 'Observed hubs' : 'Hubs'}</dt>
                 <dd>
                   {graphAnalysisTopologyAvailable(props.analysis)
                     ? compactNumber(props.analysis.hubs.length)
@@ -156,7 +157,7 @@ export function GraphSummary(props: {
             </dl>
             {props.analysis.hubs.length > 0 ? (
               <div className="graph-analysis-list">
-                <h5>Highest-connectivity nodes</h5>
+                <h5>{partialTopology ? 'Highest observed-connectivity nodes' : 'Highest-connectivity nodes'}</h5>
                 {props.analysis.hubs.slice(0, 4).map(hub => (
                   <div key={`${hub.node.path}:${hub.node.label}`}>
                     <span>
@@ -709,6 +710,8 @@ export function GraphAdministration(props: {
                         snapshot: candidate.snapshot,
                         worktreeId: candidate.viewWorktreeId,
                       });
+                      const partialTopology = candidate.analysis?.coverage.topology.state === 'partial';
+                      const boundedNodePrefix = partialTopology && !candidate.analysis?.coverage.nodesComplete;
                       return (
                         <div key={`${database.checkoutId}:${candidate.viewWorktreeId}`}>
                           <strong>{candidate.repository.displayName}</strong>
@@ -730,11 +733,18 @@ export function GraphAdministration(props: {
                               {candidate.analysis.coverage.topology.state === 'complete' ||
                               candidate.analysis.coverage.topology.state === 'partial' ? (
                                 <>
-                                  {candidate.analysis.statistics.connectedComponentCount.toLocaleString()} components ·{' '}
-                                  {candidate.analysis.statistics.communityCount.toLocaleString()} communities · average
-                                  degree {candidate.analysis.statistics.averageDegree.toFixed(2)} · maximum{' '}
+                                  {candidate.analysis.statistics.connectedComponentCount.toLocaleString()}{' '}
+                                  {partialTopology ? 'observed components' : 'components'} ·{' '}
+                                  {candidate.analysis.statistics.communityCount.toLocaleString()}{' '}
+                                  {partialTopology ? 'observed communities' : 'communities'} ·{' '}
+                                  {partialTopology ? 'observed average' : 'average'} degree{' '}
+                                  {candidate.analysis.statistics.averageDegree.toFixed(2)} ·{' '}
+                                  {partialTopology ? 'observed maximum' : 'maximum'}{' '}
                                   {candidate.analysis.statistics.maximumDegree.toLocaleString()} ·{' '}
-                                  {candidate.analysis.statistics.isolatedNodeCount.toLocaleString()} isolated
+                                  {candidate.analysis.statistics.isolatedNodeCount.toLocaleString()}{' '}
+                                  {partialTopology
+                                    ? `${boundedNodePrefix ? 'retained nodes' : 'nodes'} with zero observed degree`
+                                    : 'isolated'}
                                 </>
                               ) : (
                                 <>topology {candidate.analysis.coverage.topology.state}</>

--- a/test/unit/code-graph.analysis-render.test.ts
+++ b/test/unit/code-graph.analysis-render.test.ts
@@ -54,7 +54,7 @@ describe('code graph analysis rendering', () => {
     }),
   );
 
-  effectIt.effect('does not turn unavailable partial topology into false zero or none claims', () =>
+  effectIt.effect('labels bounded topology without making whole-graph zero or absence claims', () =>
     Effect.gen(function* () {
       const symbols = Array.from({length: 8}, (_, index) =>
         analysisSymbol(`node-${index}`, '@acme/partial', `src/${index}.ts`),
@@ -69,16 +69,49 @@ describe('code graph analysis rendering', () => {
       });
       const rendered = renderCodeGraphAnalysis(result, 'full');
       const report = renderCodeGraphReport(result, {displayName: 'partial', repositoryId: 'repository'});
-      expect(result.coverage.topology.state).toBe('unavailable');
-      expect(rendered).toContain('Topology: unavailable');
-      expect(rendered).toContain('Communities: unavailable because topology was not derived');
-      expect(rendered).not.toContain('0 isolated nodes');
-      expect(rendered).not.toContain('Communities: none');
-      expect(report).toContain(
-        'Community analysis was unavailable because the complete symbol endpoint set did not fit',
+      expect(result.coverage).toMatchObject({nodesComplete: false, topology: {state: 'partial'}});
+      expect(rendered).toContain('Topology (bounded path/relationship-prefix observation)');
+      expect(rendered).toContain('retained nodes with zero observed degree');
+      expect(rendered).toContain('Communities (observed partial topology):');
+      expect(rendered).toContain('bounded observation over a path-prefix node set (3 of 8 symbols)');
+      expect(rendered).not.toContain(' isolated nodes');
+      expect(report).toContain('bounded observation over a path-prefix node set (3 of 8 symbols)');
+      expect(report).not.toContain(' isolated nodes');
+
+      const noEdgeResult = yield* analyzeCodeGraph(pagedAnalysisStore(symbols, []), {
+        budget: {maxNodes: 3, pageSize: 2},
+        databasePath: ':memory:',
+        snapshot: analysisSnapshot(symbols, []),
+      });
+      const noEdgeRendered = renderCodeGraphAnalysis(noEdgeResult, 'full');
+      const noEdgeReport = renderCodeGraphReport(noEdgeResult, {
+        displayName: 'partial',
+        repositoryId: 'repository',
+      });
+      expect(noEdgeRendered).toContain('Hubs: none observed in bounded topology; absence is not proven');
+      expect(noEdgeRendered).toContain(
+        'Structural relationship groups: none observed in bounded topology; absence is not proven',
       );
-      expect(report).not.toContain('0 isolated nodes');
-      expect(report).not.toContain('No high-degree fan-in or fan-out groups met the deterministic threshold.');
+      expect(noEdgeRendered).toContain('Surprising links: none observed in bounded topology; absence is not proven');
+      expect(noEdgeReport).toContain('No hubs were observed in bounded topology; absence is not proven.');
+      expect(noEdgeReport).toContain(
+        'No cross-community links were observed in bounded topology; absence is not proven.',
+      );
+      expect(noEdgeReport).toContain(
+        'No high-degree fan-in or fan-out groups were observed in bounded topology; absence is not proven.',
+      );
+
+      const edgePartialResult = yield* analyzeCodeGraph(pagedAnalysisStore(symbols, edges), {
+        budget: {maxEdges: 2, maxEdgeVisits: 2, maxNodes: symbols.length, pageSize: 2},
+        databasePath: ':memory:',
+        snapshot: analysisSnapshot(symbols, edges),
+      });
+      const edgePartialRendered = renderCodeGraphAnalysis(edgePartialResult, 'stats');
+      expect(edgePartialResult.coverage).toMatchObject({nodesComplete: true, topology: {state: 'partial'}});
+      expect(edgePartialRendered).toContain('Topology (bounded relationship-prefix observation)');
+      expect(edgePartialRendered).toContain('observed connected components');
+      expect(edgePartialRendered).toContain('nodes with zero observed degree');
+      expect(edgePartialRendered).not.toContain(' isolated nodes');
     }),
   );
 });

--- a/test/unit/code-graph.analysis.property.test.ts
+++ b/test/unit/code-graph.analysis.property.test.ts
@@ -18,6 +18,20 @@ const analysisCase = FC.record({
   ),
 });
 
+const boundedAnalysisCase = FC.record({
+  nodeCount: FC.integer({max: 18, min: 2}),
+  packageCount: FC.integer({max: 5, min: 1}),
+  prefixSeed: FC.nat({max: 31}),
+  rawEdges: FC.array(
+    FC.record({
+      relation: FC.constantFrom<CodeGraphEdge['relation']>('calls', 'contains', 'extends', 'imports', 'references'),
+      source: FC.integer({max: 31, min: 0}),
+      target: FC.integer({max: 31, min: 0}),
+    }),
+    {maxLength: 48},
+  ),
+});
+
 describe('code graph analysis properties', () => {
   it.effect.prop(
     'keeps partitions, identifiers, labels, and ranking stable across input order and page size',
@@ -83,6 +97,73 @@ describe('code graph analysis properties', () => {
       });
     },
     {fastCheck: {numRuns: 80}},
+  );
+
+  it.effect.prop(
+    'keeps bounded induced topology deterministic and excludes relationships to omitted nodes',
+    {fixture: boundedAnalysisCase},
+    ({fixture}) => {
+      const symbols = Array.from({length: fixture.nodeCount}, (_, index) =>
+        analysisSymbol(
+          `node-${index.toString().padStart(2, '0')}`,
+          `package-${index % fixture.packageCount}`,
+          `packages/p${index % fixture.packageCount}/src/${index}.ts`,
+        ),
+      );
+      const uniqueEdges = new Map<string, CodeGraphEdge>();
+      for (const [index, raw] of fixture.rawEdges.entries()) {
+        const source = symbols[raw.source % symbols.length]!;
+        const target = symbols[raw.target % symbols.length]!;
+        const key = `${source.id}:${raw.relation}:${target.id}`;
+        if (!uniqueEdges.has(key)) {
+          uniqueEdges.set(key, analysisEdge(`edge-${index.toString().padStart(3, '0')}`, source, target, raw.relation));
+        }
+      }
+      const edges = [...uniqueEdges.values()];
+      const snapshot = analysisSnapshot(symbols, edges);
+      const prefixSize = 1 + (fixture.prefixSeed % (symbols.length - 1));
+      const orderedSymbols = [...symbols].sort(
+        (left, right) =>
+          left.path.localeCompare(right.path) ||
+          left.qualifiedName.localeCompare(right.qualifiedName) ||
+          left.id.localeCompare(right.id),
+      );
+      const retainedIds = new Set(orderedSymbols.slice(0, prefixSize).map(symbol => symbol.id));
+      const expectedInducedEdges = edges.filter(
+        edge => retainedIds.has(edge.sourceId!) && retainedIds.has(edge.targetId!),
+      ).length;
+      const budget = {
+        aggregatePageSize: 1,
+        maxEdges: edges.length,
+        maxEdgeVisits: edges.length * 2,
+        maxNodes: prefixSize,
+        pageSize: 1,
+      } as const;
+
+      return Effect.gen(function* () {
+        const first = yield* analyzeCodeGraph(pagedAnalysisStore(symbols, edges), {
+          budget,
+          databasePath: '/property/bounded.sqlite',
+          snapshot,
+        });
+        const second = yield* analyzeCodeGraph(pagedAnalysisStore([...symbols].reverse(), [...edges].reverse()), {
+          budget: {...budget, aggregatePageSize: 7, pageSize: 7},
+          databasePath: '/property/bounded.sqlite',
+          snapshot,
+        });
+
+        expect(stableProjection(second)).toEqual(stableProjection(first));
+        expect(first.coverage).toMatchObject({
+          nodesComplete: false,
+          topology: {complete: false, state: 'partial'},
+        });
+        expect(first.statistics.analyzedNodeCount).toBe(prefixSize);
+        expect(first.statistics.analyzedEdgeCount).toBe(expectedInducedEdges);
+        expect(new Set(first.memberships.map(item => item.node.id))).toEqual(retainedIds);
+        expect(first.warnings).toContainEqual(expect.stringContaining('bounded path-prefix induced subgraph'));
+      });
+    },
+    {fastCheck: {numRuns: 60}},
   );
 });
 

--- a/test/unit/code-graph.analysis.test.ts
+++ b/test/unit/code-graph.analysis.test.ts
@@ -431,7 +431,7 @@ describe('code graph analysis', () => {
     }),
   );
 
-  it.effect('returns an honest partial result when node, edge, visit, and output limits are exhausted', () =>
+  it.effect('returns honest bounded topology when node, edge, visit, and output limits are exhausted', () =>
     Effect.gen(function* () {
       const symbols = Array.from({length: 8}, (_, index) =>
         analysisSymbol(`node-${index}`, `package-${index % 2}`, `src/${index}.ts`),
@@ -457,18 +457,18 @@ describe('code graph analysis', () => {
         edgeMetricsComplete: false,
         edgesComplete: false,
         nodesComplete: false,
-        topology: {complete: false, state: 'unavailable'},
+        topology: {complete: false, state: 'partial'},
       });
       expect(result.statistics.analyzedNodeCount).toBe(3);
-      expect(result.statistics.analyzedEdgeCount).toBe(0);
+      expect(result.statistics.analyzedEdgeCount).toBeLessThanOrEqual(2);
       expect(result.statistics.scannedEdgeCount).toBe(2);
-      expect(result.usage.edgeVisits).toBe(2);
-      expect(result.memberships).toHaveLength(0);
+      expect(result.usage.edgeVisits).toBe(3);
+      expect(result.memberships).toHaveLength(1);
       expect(result.warnings).toEqual(
         expect.arrayContaining([
           expect.stringContaining('Symbol aggregates cover 3 of 8'),
           expect.stringContaining('Relationship aggregates cover 2 of 8'),
-          expect.stringContaining('Topology was not derived'),
+          expect.stringContaining('bounded observation over a path-prefix node set'),
         ]),
       );
       expect(Math.max(...observation.symbolPageLimits, ...observation.edgePageLimits)).toBeLessThanOrEqual(2);

--- a/test/unit/code-graph.diagnostics.test.ts
+++ b/test/unit/code-graph.diagnostics.test.ts
@@ -110,6 +110,30 @@ describe('all-code-graph diagnostics', () => {
       expect(ordinaryStorage.pageStorage).not.toHaveProperty('attribution');
       expect(JSON.stringify(report)).not.toContain(home);
       expect(renderCodeGraphDiagnostics(report)).toContain('Native code graph diagnostics');
+      const partialReport = {
+        ...report,
+        databases: report.databases.map(database => ({
+          ...database,
+          views: database.views.map(view =>
+            view.analysis
+              ? {
+                  ...view,
+                  analysis: {
+                    ...view.analysis,
+                    coverage: {
+                      ...view.analysis.coverage,
+                      complete: false,
+                      topology: {...view.analysis.coverage.topology, complete: false, state: 'partial' as const},
+                    },
+                  },
+                }
+              : view,
+          ),
+        })),
+      };
+      expect(renderCodeGraphDiagnostics(partialReport)).toContain(
+        'Analysis: partial · 0 observed component(s) · 0 observed communities',
+      );
 
       const deepReport = yield* inspectAllCodeGraphs(home, {deep: true});
       const deepStorage = deepReport.databases.find(database => database.checkoutId === healthyCheckoutId)?.storage;

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -48,6 +48,7 @@ import {
   type GraphRepositoryGroup,
   type GraphQueryVisualization,
 } from '../../src/manager_graph.js';
+import {GraphSummary} from '../../src/manager_graph_panels.js';
 
 describe('manager graph focus', () => {
   it('carries the complete selected graph identity into administration actions', () => {
@@ -974,10 +975,29 @@ describe('manager graph focus', () => {
     const unavailable = graphAnalysis('unavailable', false);
     expect(graphAnalysisTopologyAvailable(unavailable)).toBe(false);
     expect(graphAnalysisCoverageLabel(unavailable)).toBe('Topology unavailable');
-    const partial = graphAnalysis('partial', false);
+    const partial = graphAnalysis('partial', false, true);
     expect(graphAnalysisTopologyAvailable(partial)).toBe(true);
     expect(graphAnalysisCoverageLabel(partial)).toBe('Topology partial');
+    expect(graphAnalysisCoverageLabel(graphAnalysis('partial', false, false))).toBe('Bounded topology');
     expect(graphAnalysisCoverageLabel(graphAnalysis('complete', true))).toBe('Complete');
+  });
+
+  it('labels every partial topology as bounded observed evidence in the graph summary', () => {
+    const markup = renderToStaticMarkup(
+      createElement(GraphSummary, {
+        analysis: graphAnalysis('partial', false, true),
+        analysisError: '',
+        analysisLoading: false,
+        graph: queryVisualization('partial analysis'),
+        onAnalyze: () => undefined,
+        sizeMetric: 'connections',
+      }),
+    );
+    expect(markup).toContain('Bounded graph analysis');
+    expect(markup).toContain('Observed communities');
+    expect(markup).toContain('Observed components');
+    expect(markup).toContain('Observed hubs');
+    expect(markup).not.toContain('Whole-graph analysis');
   });
 
   it('centers a searched detail node and zooms into its labels', () => {
@@ -1435,10 +1455,14 @@ describe('manager graph focus', () => {
   });
 });
 
-function graphAnalysis(state: GraphAnalysis['coverage']['topology']['state'], complete: boolean): GraphAnalysis {
+function graphAnalysis(
+  state: GraphAnalysis['coverage']['topology']['state'],
+  complete: boolean,
+  nodesComplete = state === 'complete',
+): GraphAnalysis {
   return {
     communities: [],
-    coverage: {complete, topology: {complete: state === 'complete', state}},
+    coverage: {complete, nodesComplete, topology: {complete: state === 'complete', state}},
     hubs: [],
     statistics: {
       analyzedEdgeCount: 0,

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -652,7 +652,7 @@ describe('MCP code graph indexing progress', () => {
   );
 
   effectIt.effect(
-    'marks MCP topology unavailable above the retained-node cap without changing the analysis defaults',
+    'returns explicitly partial MCP topology above the retained-node cap without changing the analysis defaults',
     () =>
       Effect.gen(function* () {
         const symbols = [analysisSymbol('one', '@acme/capped', 'src/one.ts')];
@@ -665,9 +665,9 @@ describe('MCP code graph indexing progress', () => {
         });
 
         expect(result.budget).toMatchObject(codeGraphMcpAnalysisBudget());
-        expect(result.coverage.topology.state).toBe('unavailable');
+        expect(result.coverage).toMatchObject({nodesComplete: false, topology: {complete: false, state: 'partial'}});
         expect(result.warnings).toContain(
-          `Topology was not derived because only 1 of ${snapshot.symbolCount.toLocaleString()} symbols fit the node/time budget.`,
+          `Topology is a bounded path-prefix induced subgraph over 1 of ${snapshot.symbolCount.toLocaleString()} symbols. Connectivity, degree, isolation, hub, component, community, and absence claims apply only to retained nodes.`,
         );
       }),
   );


### PR DESCRIPTION
## Summary

- retain and analyze a deterministic bounded node prefix instead of discarding all topology when the node budget is incomplete
- distinguish a full induced-edge scan from a truncated path/relationship-prefix observation
- qualify partial metrics and empty results across CLI, reports, diagnostics, MCP, and Manager
- update the 4.3 large-repository performance plan with the implemented P3 slice and residual limits

## Verified A/B evidence

On exact baseline `ecaede30` versus PR head `26a8c34a`, a deterministic 100,001-symbol star exceeded the actual MCP 100,000-node cap by one. The budget was the production MCP budget: 100k nodes, 500k edges, 1m visits, and 25 seconds.

| Evidence | Baseline | PR #179 |
|---|---:|---:|
| Topology state | `unavailable` | `partial` |
| Retained observations | 100,000 | 100,000 |
| Analyzed topology edges | 0 | 99,999 |
| Hubs returned | 0 | 1 |
| Center hub degree | — | 99,999 |
| Omitted endpoint leaked | No | No |

The single edge to omitted `node-100000` was neither counted nor projected: center degree is 99,999 rather than 100,000, and the omitted ID is absent from both source and MCP topology projections. MCP text explicitly identifies the result as a bounded path-prefix induced subgraph over 100,000 of 100,001 symbols.

Three in-process analysis samples had medians of about 91.5 ms on baseline and 416.4 ms on the PR. This is useful-work overhead—the baseline discarded topology—rather than a speed win, while remaining roughly 60× below the 25-second envelope. The harness exercised production analysis and MCP projection through the paging contract with an in-memory deterministic store; it did not claim SQLite, transport, production-repository, or single-sample RSS evidence.

## Verification

- independent review and re-review: zero critical or important findings
- 6 focused test files, 94 tests passed
- 60-run Effect Fast-check determinism and omitted-endpoint property
- source, test, and website typechecks passed
- strict targeted lint, Prettier, file-length, and diff checks passed
- exact HEAD 26a8c34a installed globally; no superseded processes remain
- installed hubs analysis completed on the ready 58,293-node / 175,555-edge Threadnote snapshot in about 2 seconds
- full local suite intentionally deferred to CI

## Limits

The retained prefix is deterministic but path-biased and budget-dependent. This slice removes the all-or-nothing availability cliff; it does not yet provide representative million-scale topology, lower the 100k-node memory cap, or replace persisted degree, hub, SCC, and CSR summaries.

