### PR TITLE
Avoid duplicate no-refresh graph reads

### DIFF
--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -478,9 +478,12 @@ export class CodeGraphQueryService extends Context.Service<
                   'fallback',
                 )).identity;
               const layout = codeGraphLayout(path, options.threadnoteHome, identity.checkoutId, identity.worktreeId);
-              const existing = statusObservation?.borrowedSnapshotId
-                ? yield* store.readySnapshotById(layout.databasePath, statusObservation.borrowedSnapshotId)
-                : yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+              const existing =
+                options.refresh === false
+                  ? undefined
+                  : statusObservation?.borrowedSnapshotId
+                    ? yield* store.readySnapshotById(layout.databasePath, statusObservation.borrowedSnapshotId)
+                    : yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
               const runtimeCurrent = existing
                 ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, existing, languagePacks)
                 : false;

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -108,7 +108,7 @@ const embedding = {
 } as unknown as CodeGraphEmbeddingIndexShape;
 
 describe('code graph query budgets', () => {
-  it.effect('requests one path-free maintenance opportunity unless an internal evidence read opts out', () =>
+  it.effect('avoids duplicate refresh:false snapshot reads and requests one path-free maintenance opportunity', () =>
     Effect.scoped(
       Effect.gen(function* () {
         const fixtureRoot = yield* Effect.acquireRelease(
@@ -176,14 +176,26 @@ describe('code graph query budgets', () => {
           }),
         );
         const snapshotRef = yield* Ref.make<CodeGraphSnapshot | undefined>(undefined);
+        const emptyStoreReads = () => ({
+          leasesAcquired: 0,
+          leasesReleased: 0,
+          provenance: 0,
+          readyById: 0,
+          readyByWorktree: 0,
+        });
+        const storeReads = yield* Ref.make(emptyStoreReads());
+        const recordStoreRead = (
+          field: 'leasesAcquired' | 'leasesReleased' | 'provenance' | 'readyById' | 'readyByWorktree',
+        ) => Ref.update(storeReads, current => ({...current, [field]: current[field] + 1}));
         const storeLayer = Layer.succeed(
           CodeGraphStore,
           CodeGraphStore.of({
-            acquireSnapshotLease: () => Effect.succeed('lease'),
-            readySnapshot: () => Ref.get(snapshotRef),
+            acquireSnapshotLease: () => recordStoreRead('leasesAcquired').pipe(Effect.as('lease')),
+            readySnapshot: () => recordStoreRead('readyByWorktree').pipe(Effect.andThen(Ref.get(snapshotRef))),
+            readySnapshotById: () => recordStoreRead('readyById').pipe(Effect.andThen(Ref.get(snapshotRef))),
             readySnapshotForCommit: () => Effect.succeed(undefined),
-            releaseSnapshotLease: () => Effect.void,
-            snapshotPackProvenance: () => Effect.succeed([]),
+            releaseSnapshotLease: () => recordStoreRead('leasesReleased'),
+            snapshotPackProvenance: () => recordStoreRead('provenance').pipe(Effect.as([])),
             symbolsByIds: () => Effect.succeed([]),
             withSession: (_databasePath: string, effect: Effect.Effect<unknown, unknown, unknown>) => effect,
           } as unknown as CodeGraphStoreShape),
@@ -260,6 +272,7 @@ describe('code graph query budgets', () => {
           expect(statusCommandCalls.some(call => call.executable === 'git')).toBe(true);
           expect(JSON.stringify(deferredHotStatus)).not.toContain('statusObservation');
           yield* Ref.set(commandCalls, []);
+          yield* Ref.set(storeReads, emptyStoreReads());
           const deferredHotInspection = yield* query.inspect({
             cwd: fixtureRoot.repository,
             nodeId: `cgs_${'a'.repeat(32)}`,
@@ -271,6 +284,33 @@ describe('code graph query budgets', () => {
           });
           expect(deferredHotInspection.freshness).toBe('deferred');
           expect(yield* Ref.get(commandCalls)).toEqual([]);
+          expect(yield* Ref.get(storeReads)).toEqual({
+            leasesAcquired: 1,
+            leasesReleased: 1,
+            provenance: 1,
+            readyById: 0,
+            readyByWorktree: 1,
+          });
+          for (const refresh of [undefined, true] as const) {
+            yield* Ref.set(storeReads, emptyStoreReads());
+            const refreshedInspection = yield* query.inspect({
+              cwd: fixtureRoot.repository,
+              nodeId: `cgs_${'a'.repeat(32)}`,
+              operation: 'node',
+              ...(refresh === undefined ? {} : {refresh}),
+              requestMaintenance: false,
+              statusObservation: observationFromCodeGraphStatus(deferredHotStatus),
+              threadnoteHome: fixtureRoot.home,
+            });
+            expect(refreshedInspection.freshness).toBe('current');
+            expect(yield* Ref.get(storeReads)).toEqual({
+              leasesAcquired: 1,
+              leasesReleased: 1,
+              provenance: 2,
+              readyById: 0,
+              readyByWorktree: 2,
+            });
+          }
 
           const telemetryStatus = yield* query.status(fixtureRoot.home, fixtureRoot.repository, {
             observeWorktree: false,
@@ -289,6 +329,7 @@ describe('code graph query budgets', () => {
             telemetry,
           });
           telemetryEvents.splice(0);
+          yield* Ref.set(storeReads, emptyStoreReads());
           const strictInspection = yield* query.inspect({
             cwd: fixtureRoot.repository,
             nodeId: `cgs_${'a'.repeat(32)}`,
@@ -304,7 +345,15 @@ describe('code graph query budgets', () => {
           expect(telemetryEvents.splice(0)).toEqual([
             {phase: 'graph.query.execute', stage: 'query-strict-reobservation'},
           ]);
+          expect(yield* Ref.get(storeReads)).toEqual({
+            leasesAcquired: 1,
+            leasesReleased: 1,
+            provenance: 1,
+            readyById: 0,
+            readyByWorktree: 1,
+          });
 
+          yield* Ref.set(storeReads, emptyStoreReads());
           const fallbackInspection = yield* query.inspect({
             cwd: fixtureRoot.repository,
             nodeId: `cgs_${'a'.repeat(32)}`,
@@ -324,6 +373,13 @@ describe('code graph query budgets', () => {
             {disposition: 'skipped', phase: 'graph.query.execute', stage: 'query-worktree-observation'},
             {disposition: 'skipped', phase: 'graph.query.execute', stage: 'query-strict-reobservation'},
           ]);
+          expect(yield* Ref.get(storeReads)).toEqual({
+            leasesAcquired: 1,
+            leasesReleased: 1,
+            provenance: 1,
+            readyById: 0,
+            readyByWorktree: 1,
+          });
 
           const assertOneRequest = Effect.fn(function* (run: Effect.Effect<unknown, unknown>) {
             yield* Ref.set(requests, []);


### PR DESCRIPTION
## Summary
- skip the dead first ready-snapshot/runtime-provenance preflight when `refresh:false`
- retain the final active-or-borrowed snapshot selection, runtime provenance validation, lease, read session, and strict re-observation
- exhaustively cover the refresh false/undefined/true call-count contract

## Evidence
- deterministic store instrumentation: ready-snapshot reads `2 -> 1` and snapshot-pack provenance reads `2 -> 1` for `refresh:false`; lease acquire/release remains `1/1`
- refresh omitted/true remains `2/2`; strict and no-status-observation `refresh:false` remain `1/1`
- bounded actual-SQLite hot node-query A/B, 2x80 samples per side with identical result digest: p50 `15.77 -> 13.83 ms` (-12.3%), p95 `18.48 -> 15.80 ms` (-14.5%), mean `16.06 -> 13.92 ms` (-13.3%)
- timing is directional component evidence only, not an end-to-end or production-large claim

## Verification
- `bun --bun vitest run test/unit/code-graph.query.test.ts test/unit/code-graph.query-anonymous-telemetry.property.test.ts test/unit/mcp-code-graph-progress.test.ts` (50/50)
- source, test, and website TypeScript checks
- strict targeted Oxlint, Prettier, and diff checks
- independent review: clean

## Property assessment
The meaningful state space is the finite refresh tri-state plus strict/status-observation variants; explicit exhaustive call-count examples are clearer than a randomized property.