### PR TITLE
Fix partition-dependent graph shard reuse

### DIFF
--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -693,7 +693,6 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
           inventory: input.inventory,
           languagePacks: input.languagePacks,
           layout: input.layout,
-          persistentCapacityProtector: codeGraphDirectPersistentCapacityProtector(input),
           store: input.store,
         };
         const boundedAssessment = yield* assessReusableCleanBaseCompatibility(
@@ -758,7 +757,7 @@ const attemptReusableCleanSnapshot = Effect.fn('codeGraph.attemptReusableCleanSn
             deletedPaths: incrementalAssessment.deletedPaths,
             resolutionClosure: incrementalAssessment.resolutionClosure,
           },
-          assessmentInput.persistentCapacityProtector,
+          codeGraphDirectPersistentCapacityProtector(input),
         );
         if (!prepared) {
           return Option.some<ReusableCleanSnapshotAttempt>({mode: 'fallback', reason: 'staging-identity-mismatch'});
@@ -920,7 +919,6 @@ export const attemptReusableDirtyBase = Effect.fn('codeGraph.attemptReusableDirt
     inventory: input.inventory,
     languagePacks: input.languagePacks,
     layout: input.layout,
-    persistentCapacityProtector: input.persistentCapacityProtector,
     store: input.store,
   };
   const boundedAssessment = yield* assessReusableCleanBaseCompatibility(assessmentInput, workspace, modifiedFiles);
@@ -1519,50 +1517,41 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         unit: 'files',
       }) ?? Effect.void;
       const loadingStartedAt = yield* Clock.currentTimeMillis;
-      // Every shard is bound to the exact extractor, workspace, graph-content,
-      // content-hash, and path derivation above. Load one bounded source batch
-      // at a time and reuse valid peers independently; a missing or malformed
-      // shard only falls back to its raw parser facts.
+      // Final attribution can inspect peer raw facts in this deterministic,
+      // bounded source batch (for example while flattening TypeScript barrel
+      // reexports). Reuse the batch only as a complete unit; otherwise replay
+      // and reattribute every raw peer so a hit/miss partition cannot become a
+      // persisted derivation input.
       const materializedShards = yield* input.store.loadMaterializedFileShards(
         input.layout.databasePath,
         files,
         input.building.extractorSet,
         shardDerivationIdentity,
       );
-      const missingShardFiles = files.filter(file => !materializedShards.facts.has(file.path));
-      const cached = yield* loadCachedFacts(
-        input.store,
-        input.layout.databasePath,
-        missingShardFiles,
-        input.languagePacks,
-      );
+      const materializedShardBatchComplete = materializedShards.facts.size === files.length;
+      const fallbackFiles = materializedShardBatchComplete ? [] : files;
+      const cached = yield* loadCachedFacts(input.store, input.layout.databasePath, fallbackFiles, input.languagePacks);
+      // Count every decoded cache payload, including valid final shards that
+      // were inspected before an incomplete batch fell back to all raw facts.
+      const batchReplayBytes = Math.min(Number.MAX_SAFE_INTEGER, materializedShards.bytes + cached.bytes);
       cachedFactReplayBytesCompleted = Math.min(
         Number.MAX_SAFE_INTEGER,
-        cachedFactReplayBytesCompleted + materializedShards.bytes + cached.bytes,
+        cachedFactReplayBytesCompleted + batchReplayBytes,
       );
-      const batchChangedShardBytes = selectedDecodedFactBytes(
-        materializedShards.bytesByPath,
-        files
-          .filter(file => changedCurrentPaths.has(file.path) && materializedShards.facts.has(file.path))
-          .map(file => file.path),
-      );
-      const batchChangedRawBytes = selectedDecodedFactBytes(
-        cached.bytesByPath,
-        missingShardFiles.filter(file => changedCurrentPaths.has(file.path)).map(file => file.path),
+      // Changed-fact bytes are the logical selected representation used as the
+      // replay-amplification denominator, not every physical cache decode.
+      const batchChangedFactBytes = selectedDecodedFactBytes(
+        materializedShardBatchComplete ? materializedShards.bytesByPath : cached.bytesByPath,
+        files.filter(file => changedCurrentPaths.has(file.path)).map(file => file.path),
       );
       changedFactBytesCompleted =
-        changedFactBytesCompleted === undefined ||
-        batchChangedShardBytes === undefined ||
-        batchChangedRawBytes === undefined
+        changedFactBytesCompleted === undefined || batchChangedFactBytes === undefined
           ? undefined
-          : Math.min(
-              Number.MAX_SAFE_INTEGER,
-              changedFactBytesCompleted + batchChangedShardBytes + batchChangedRawBytes,
-            );
+          : Math.min(Number.MAX_SAFE_INTEGER, changedFactBytesCompleted + batchChangedFactBytes);
       const batchLoadingMilliseconds = (yield* Clock.currentTimeMillis) - loadingStartedAt;
       loadingMilliseconds += batchLoadingMilliseconds;
       stageMilliseconds['loading-cache'] = loadingMilliseconds;
-      if (missingShardFiles.some(file => !cached.facts.has(file.path))) {
+      if (fallbackFiles.some(file => !cached.facts.has(file.path))) {
         return yield* Effect.fail(
           new CodeGraphIndexOperationError(
             'A cached code graph fact disappeared during indexing; retry with a full rebuild.',
@@ -1573,7 +1562,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         activity: {
           batchCompleted: batchesCompleted,
           batchTotal: batchesTotal,
-          cachedFactBytes: Math.min(Number.MAX_SAFE_INTEGER, materializedShards.bytes + cached.bytes),
+          cachedFactBytes: batchReplayBytes,
           elapsedMilliseconds: batchLoadingMilliseconds,
           sourceBytes,
           stage: 'attributing',
@@ -1586,24 +1575,26 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         unit: 'files',
       }) ?? Effect.void;
       const attributionStartedAt = yield* Clock.currentTimeMillis;
-      const attributedMissingFacts = attributeFacts(
-        missingShardFiles.map(file => input.languagePacks.postprocessFile(file, cached.facts.get(file.path)!)),
+      const attributedFallbackFacts = attributeFacts(
+        fallbackFiles.map(file => input.languagePacks.postprocessFile(file, cached.facts.get(file.path)!)),
       );
-      if (missingShardFiles.length > 0) {
+      if (fallbackFiles.length > 0) {
         yield* input.store.cacheMaterializedFileShards(
           input.layout.databasePath,
-          missingShardFiles,
-          attributedMissingFacts.map(fact => serializeBoundedCodeGraphFact(fact)),
+          fallbackFiles,
+          attributedFallbackFacts.map(fact => serializeBoundedCodeGraphFact(fact)),
           input.building.extractorSet,
           shardDerivationIdentity,
           protectDirectPersistentWrite,
         );
       }
-      const attributedMissingByPath = new Map(attributedMissingFacts.map(fact => [fact.path, fact]));
-      const facts = files.map(
-        file => materializedShards.facts.get(file.path) ?? attributedMissingByPath.get(file.path)!,
+      const attributedFallbackByPath = new Map(attributedFallbackFacts.map(fact => [fact.path, fact]));
+      const facts = files.map(file =>
+        materializedShardBatchComplete
+          ? materializedShards.facts.get(file.path)!
+          : attributedFallbackByPath.get(file.path)!,
       );
-      materializedShardFilesReused += files.length - missingShardFiles.length;
+      materializedShardFilesReused += materializedShardBatchComplete ? files.length : 0;
       const batchAttributionMilliseconds = (yield* Clock.currentTimeMillis) - attributionStartedAt;
       attributionMilliseconds += batchAttributionMilliseconds;
       stageMilliseconds.attributing = attributionMilliseconds;

--- a/src/code_graph/indexer_incremental.ts
+++ b/src/code_graph/indexer_incremental.ts
@@ -1,7 +1,7 @@
 import {Effect} from 'effect';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {createRepositoryFactAttributor} from './extractor.js';
-import {finalCodeGraphFactBatches, serializeBoundedCodeGraphFact} from './fact_budget.js';
+import {finalCodeGraphFactBatches} from './fact_budget.js';
 import {
   assessProjectClosureSeeds,
   assessProjectFileSetClosureSeeds,
@@ -16,7 +16,6 @@ import {
   cachedFactsMetadata,
   extractorSetIdentity,
   extractorSetIdentityFromPackProvenance,
-  graphContentIdentity,
   loadCachedFacts,
   loadCachedFactsWithPackProvenance,
 } from './indexer_materialization.js';
@@ -40,8 +39,6 @@ import {
 } from './resolution_surface.js';
 import {
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
-  materializedShardDerivationIdentity,
-  type CodeGraphDirectPersistentCapacityProtector,
   type CodeGraphReusableCleanBase,
   type CodeGraphReusableReexport,
   type CodeGraphReusableReexportSeed,
@@ -318,7 +315,6 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
       readonly inventory: CodeGraphInventory;
       readonly languagePacks: CodeGraphLanguagePackRegistryShape;
       readonly layout: CodeGraphLayout;
-      readonly persistentCapacityProtector: CodeGraphDirectPersistentCapacityProtector;
       readonly store: CodeGraphStoreShape;
     },
     workspace: CodeGraphWorkspace,
@@ -457,18 +453,9 @@ export const assessReusableCleanBaseCompatibility = Effect.fn('codeGraph.assessR
     if (finalCodeGraphFactBatches(currentFacts).length !== 1) {
       return {mode: 'fallback', reason: 'fact-budget-expanded'} satisfies IncrementalOverlayPreassessment;
     }
-    yield* input.store.cacheMaterializedFileShards(
-      input.layout.databasePath,
-      modifiedFiles,
-      currentFacts.map(fact => serializeBoundedCodeGraphFact(fact)),
-      currentExtractorSet,
-      materializedShardDerivationIdentity(
-        currentExtractorSet,
-        workspace.fingerprint,
-        graphContentIdentity(currentExtractorSet, input.inventory.files),
-      ),
-      input.persistentCapacityProtector,
-    );
+    // Incremental facts are attributed from a candidate-specific subset. They
+    // must not populate the full-materialization shard namespace: different
+    // bases can otherwise union into a falsely complete deterministic batch.
     return {
       baseFileSetFingerprint: reusableBaseFileSetFingerprint(input.candidate.files),
       committedWorkspace: workspace,

--- a/src/code_graph/store_cache.ts
+++ b/src/code_graph/store_cache.ts
@@ -104,7 +104,7 @@ export function materializedShardDerivationIdentity(
   graphContentId: string,
 ): string {
   return `cgfd_${sha256HexSync(
-    `materialized-file-derivation-v2\n${extractorSet}\n${workspaceFingerprint}\n${graphContentId}`,
+    `materialized-file-derivation-v3\n${extractorSet}\n${workspaceFingerprint}\n${graphContentId}`,
   ).slice(0, 40)}`;
 }
 

--- a/test/integration/code-graph.cross-session-incremental.test.ts
+++ b/test/integration/code-graph.cross-session-incremental.test.ts
@@ -17,7 +17,11 @@ import {
   type CodeGraphLanguagePackRegistryShape,
 } from '../../src/code_graph/languages/registry.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
-import {CodeGraphStore, type CodeGraphVisualizationCatalog} from '../../src/code_graph/store.js';
+import {
+  CodeGraphStore,
+  materializedShardDerivationIdentity,
+  type CodeGraphVisualizationCatalog,
+} from '../../src/code_graph/store.js';
 import {CODE_GRAPH_EXTRACTOR_GENERATION, type CodeGraphIndexSummary} from '../../src/code_graph/types.js';
 
 describe('cross-session code graph increments', () => {
@@ -122,6 +126,55 @@ describe('cross-session code graph increments', () => {
       provideTestLayer(ApplicationLayer),
       TestClock.withLive,
       Effect.ensuring(removeTemporaryPaths(() => [root, incrementalHome, fullHome])),
+    );
+  });
+
+  it.effect('does not union different-base clean increments into full-materialization shards', () => {
+    let home: string | undefined;
+    let root: string | undefined;
+    let siblingRoot: string | undefined;
+    return Effect.gen(function* () {
+      const fixture = createConvergentIncrementalRepository();
+      root = fixture.root;
+      siblingRoot = fixture.siblingRoot;
+      home = mkdtempSync(join(tmpdir(), 'threadnote-convergent-incremental-home-'));
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+
+      const baseA = yield* indexer.index({cwd: root, force: true, threadnoteHome: home});
+      git(root, ['checkout', '-q', 'target-a']);
+      const targetA = yield* indexAndLoadEffect(root, home);
+      const baseB = yield* indexer.index({cwd: siblingRoot, force: true, threadnoteHome: home});
+      git(siblingRoot, ['checkout', '-q', 'target-b']);
+      const targetB = yield* indexAndLoadEffect(siblingRoot, home);
+
+      expect(targetA.summary.materialization?.mode).toBe('incremental-clean');
+      expect(targetB.summary.materialization?.mode).toBe('incremental-clean');
+      expect(targetA.summary.snapshot.baseSnapshotId).toBe(baseA.snapshot.id);
+      expect(targetB.summary.snapshot.baseSnapshotId).toBe(baseB.snapshot.id);
+      expect(targetA.summary.snapshot.graphContentId).toBeDefined();
+      expect(targetB.summary.snapshot.graphContentId).toBe(targetA.summary.snapshot.graphContentId);
+      expect(projectGraph(targetB.graph)).toEqual(projectGraph(targetA.graph));
+      const [receiptA, receiptB] = yield* Effect.all(
+        [
+          store.reusableBaseReceipt(targetA.databasePath, baseA.snapshot.id),
+          store.reusableBaseReceipt(targetB.databasePath, baseB.snapshot.id),
+        ],
+        {concurrency: 1},
+      );
+      expect(receiptA).toBeDefined();
+      expect(receiptB?.workspaceFingerprint).toBe(receiptA?.workspaceFingerprint);
+      const targetDerivation = materializedShardDerivationIdentity(
+        targetA.summary.snapshot.extractorSet,
+        receiptA!.workspaceFingerprint,
+        targetA.summary.snapshot.graphContentId!,
+      );
+
+      expect(materializedShardCount(targetA.databasePath, targetDerivation)).toBe(0);
+    }).pipe(
+      provideTestLayer(ApplicationLayer),
+      TestClock.withLive,
+      Effect.ensuring(removeTemporaryPaths(() => [siblingRoot, root, home])),
     );
   });
 
@@ -487,6 +540,21 @@ function persistedSnapshotState(databasePath: string, snapshotId: string): strin
   }
 }
 
+function materializedShardCount(databasePath: string, derivationIdentity: string): number {
+  const database = new Database(databasePath, {readonly: true});
+  try {
+    return Number(
+      database
+        .query<{readonly count: number}, [string]>(
+          'SELECT COUNT(*) AS count FROM materialized_file_shards WHERE derivation_identity = ?',
+        )
+        .get(derivationIdentity)?.count ?? 0,
+    );
+  } finally {
+    database.close();
+  }
+}
+
 function normalizeCatalog(catalog: CodeGraphVisualizationCatalog | undefined): unknown {
   if (catalog === undefined) return undefined;
   const {activatedAt: _activatedAt, snapshot, ...stable} = catalog;
@@ -520,6 +588,41 @@ function createRepository(passiveFiles = 0): string {
   git(root, ['add', '.']);
   git(root, ['commit', '-qm', 'fixture']);
   return root;
+}
+
+function createConvergentIncrementalRepository(): {readonly root: string; readonly siblingRoot: string} {
+  const root = mkdtempSync(join(tmpdir(), 'threadnote-convergent-incremental-'));
+  const siblingRoot = `${root}-sibling`;
+  mkdirSync(join(root, 'src'), {recursive: true});
+  writeFileSync(join(root, 'src/a.ts'), 'export const a = "old-a";\n');
+  writeFileSync(join(root, 'src/b.ts'), 'export const b = "old-b";\n');
+  git(root, ['init', '-q']);
+  configureTestGitIdentity(root);
+  git(root, ['add', '.']);
+  git(root, ['commit', '-qm', 'common']);
+  const common = execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], {encoding: 'utf8'}).trim();
+
+  git(root, ['checkout', '-qb', 'target-a', common]);
+  writeFileSync(join(root, 'src/b.ts'), 'export const b = "final-b";\n');
+  git(root, ['add', 'src/b.ts']);
+  git(root, ['commit', '-qm', 'base a']);
+  git(root, ['branch', 'base-a']);
+  writeFileSync(join(root, 'src/a.ts'), 'export const a = "final-a";\n');
+  git(root, ['add', 'src/a.ts']);
+  git(root, ['commit', '-qm', 'target a']);
+
+  git(root, ['checkout', '-qb', 'target-b', common]);
+  writeFileSync(join(root, 'src/a.ts'), 'export const a = "final-a";\n');
+  git(root, ['add', 'src/a.ts']);
+  git(root, ['commit', '-qm', 'base b']);
+  git(root, ['branch', 'base-b']);
+  writeFileSync(join(root, 'src/b.ts'), 'export const b = "final-b";\n');
+  git(root, ['add', 'src/b.ts']);
+  git(root, ['commit', '-qm', 'target b']);
+
+  git(root, ['checkout', '-q', 'base-a']);
+  git(root, ['worktree', 'add', '-q', siblingRoot, 'base-b']);
+  return {root, siblingRoot};
 }
 
 function createBarrelRepository(): string {

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -926,7 +926,6 @@ describe('native code graph lifecycle', () => {
       const probesPerObservation = statSync(root).dev === statSync(tmpdir()).dev ? 1 : 2;
       expect(Object.fromEntries(probes)).toEqual({
         'cache code graph file facts': probesPerObservation,
-        'cache materialized code graph file shards': probesPerObservation,
         'prepare temporary incremental code graph activation': probesPerObservation,
         'promote ready code graph snapshot': probesPerObservation,
         'publish temporary code graph snapshot': probesPerObservation,
@@ -1117,9 +1116,9 @@ describe('native code graph lifecycle', () => {
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
-  effectIt.effect('reuses valid peers from a partial materialized shard set', () =>
+  effectIt.effect('reattributes an incomplete deterministic batch while reusing a complete peer batch', () =>
     Effect.gen(function* () {
-      const root = createManySourceRepository(12);
+      const root = createManySourceRepository(130);
       const home = join(root, '.threadnote-test-home');
       const progress: CodeGraphProgress[] = [];
       const indexer = yield* CodeGraphIndexer;
@@ -1131,18 +1130,18 @@ describe('native code graph lifecycle', () => {
         const database = new Database(databasePath);
         try {
           const missing = database
-            .query<{readonly id: string; readonly path: string}, []>(
-              `SELECT id, path_hint AS path FROM materialized_file_shards ORDER BY id LIMIT 1`,
+            .query<{readonly id: string; readonly path: string}, [string]>(
+              `SELECT id, path_hint AS path FROM materialized_file_shards WHERE path_hint = ?`,
             )
-            .get();
+            .get('src/file-129.ts');
           if (!missing) throw new Error('Expected a materialized shard to remove.');
-          const missingRawBytes =
+          const rawFactBytes =
             database
-              .query<{readonly bytes: number}, [string]>(
+              .query<{readonly bytes: number}, [string, string]>(
                 `SELECT COALESCE(SUM(${storedCodeGraphFactRawBytesSql('facts_json')}), 0) AS bytes
-                 FROM file_blobs WHERE path_hint = ?`,
+                 FROM file_blobs WHERE path_hint IN (?, ?)`,
               )
-              .get(missing.path)?.bytes ?? 0;
+              .get('src/file-128.ts', 'src/file-129.ts')?.bytes ?? 0;
           database.query('DELETE FROM materialized_file_shards WHERE id = ?').run(missing.id);
           database.exec(`
             CREATE TABLE materialized_shard_write_audit (
@@ -1172,7 +1171,7 @@ describe('native code graph lifecycle', () => {
                  FROM materialized_file_shards`,
               )
               .get()?.bytes ?? 0;
-          return {missingPath: missing.path, missingRawBytes, reusedShardBytes};
+          return {missingPath: missing.path, rawFactBytes, reusedShardBytes};
         } finally {
           database.close();
         }
@@ -1207,17 +1206,128 @@ describe('native code graph lifecycle', () => {
         }
       });
 
-      expect(rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 11 file(s).');
-      expect(partialShardState.missingRawBytes).toBeGreaterThan(0);
+      expect(rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 128 file(s).');
+      expect(partialShardState.rawFactBytes).toBeGreaterThan(0);
       expect(partialShardState.reusedShardBytes).toBeGreaterThan(0);
       expect(metrics.cachedFactReplayBytesCompleted).toBe(
-        partialShardState.missingRawBytes + partialShardState.reusedShardBytes,
+        partialShardState.rawFactBytes + partialShardState.reusedShardBytes,
       );
-      expect(persistedReuse).toEqual({
-        associations: 12,
-        writes: [{operation: 'insert', path: partialShardState.missingPath}],
-      });
+      expect(persistedReuse.associations).toBe(130);
+      expect(persistedReuse.writes).toHaveLength(2);
+      expect(persistedReuse.writes.filter(write => write.operation === 'insert')).toEqual([
+        {operation: 'insert', path: partialShardState.missingPath},
+      ]);
+      expect(persistedReuse.writes.filter(write => write.operation === 'update')).toEqual([
+        {operation: 'update', path: 'src/file-128.ts'},
+      ]);
       expect(normalizeStoredGraph(rebuiltGraph)).toEqual(normalizeStoredGraph(firstGraph));
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('counts one logical changed-fact representation when an incomplete batch replays twice', () =>
+    Effect.gen(function* () {
+      const root = createManySourceRepository(2);
+      const home = temporaryDirectory('threadnote-code-graph-changed-fact-overlap-');
+      const changedPath = join(root, 'src/file-000.ts');
+      writeFileSync(changedPath, readFileSync(changedPath, 'utf8').replace('return 0;', 'return 100;'));
+      const indexer = yield* CodeGraphIndexer;
+      const first = yield* indexer.index({cwd: root, ensureVectors: false, force: true, threadnoteHome: home});
+      const databasePath = codeGraphDatabasePath(home, first);
+      const replayState = yield* Effect.sync(() => {
+        const database = new Database(databasePath);
+        try {
+          const bytes = database
+            .query<
+              {readonly changedRaw: number; readonly raw: number; readonly retainedShard: number},
+              [string, string]
+            >(
+              `SELECT
+                 COALESCE(SUM(${storedCodeGraphFactRawBytesSql('blob.facts_json')}), 0) AS raw,
+                 COALESCE(SUM(CASE WHEN shard.path_hint = ?
+                   THEN ${storedCodeGraphFactRawBytesSql('blob.facts_json')} ELSE 0 END), 0) AS changedRaw,
+                 COALESCE(SUM(CASE WHEN shard.path_hint <> ?
+                   THEN ${storedCodeGraphFactRawBytesSql('shard.facts_json')} ELSE 0 END), 0) AS retainedShard
+               FROM materialized_file_shards AS shard
+               JOIN file_blobs AS blob
+                 ON blob.content_hash = shard.content_hash
+                AND blob.path_hint = shard.path_hint`,
+            )
+            .get('src/file-000.ts', 'src/file-001.ts');
+          const missing = database
+            .query<{readonly id: string}, [string]>('SELECT id FROM materialized_file_shards WHERE path_hint = ?')
+            .get('src/file-001.ts');
+          if (!bytes || !missing) throw new TestError('Expected complete materialized and raw fact cache rows.');
+          database.query('DELETE FROM materialized_file_shards WHERE id = ?').run(missing.id);
+          return bytes;
+        } finally {
+          database.close();
+        }
+      });
+      const progress: CodeGraphProgress[] = [];
+      yield* indexer.index({
+        cwd: root,
+        ensureVectors: false,
+        force: true,
+        onProgress: current => Effect.sync(() => progress.push(current)),
+        threadnoteHome: home,
+      });
+      const metrics = finalFullMaterializationMetrics(progress);
+
+      expect(replayState.changedRaw).toBeGreaterThan(0);
+      expect(replayState.retainedShard).toBeGreaterThan(0);
+      expect(metrics.cachedFactReplayBytesCompleted).toBe(replayState.raw + replayState.retainedShard);
+      expect(metrics.changedFactBytesCompleted).toBe(replayState.changedRaw);
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('keeps a regenerated barrel caller shard and graph equal to a clean full build', () =>
+    Effect.gen(function* () {
+      const root = createAmbientOverloadBarrelRepository();
+      const mixedHome = temporaryDirectory('threadnote-code-graph-ambient-overload-mixed-');
+      const freshHome = temporaryDirectory('threadnote-code-graph-ambient-overload-fresh-');
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const first = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: mixedHome});
+      const mixedDatabasePath = codeGraphDatabasePath(mixedHome, first);
+      yield* Effect.sync(() => {
+        const database = new Database(mixedDatabasePath);
+        try {
+          const caller = database
+            .query<{readonly id: string}, [string]>('SELECT id FROM materialized_file_shards WHERE path_hint = ?')
+            .get('src/caller.ts');
+          if (!caller) throw new TestError('Expected the caller materialized shard to remove.');
+          database.query('DELETE FROM materialized_file_shards WHERE id = ?').run(caller.id);
+        } finally {
+          database.close();
+        }
+      });
+
+      const rebuilt = yield* indexer.index({
+        cwd: root,
+        ensureVectors: false,
+        force: true,
+        threadnoteHome: mixedHome,
+      });
+      const fresh = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: freshHome});
+      const freshDatabasePath = codeGraphDatabasePath(freshHome, fresh);
+      const rebuiltGraph = yield* store.loadGraph(mixedDatabasePath, rebuilt.snapshot.id);
+      const freshGraph = yield* store.loadGraph(freshDatabasePath, fresh.snapshot.id);
+      const [rebuiltCaller, freshCaller] = yield* Effect.sync(
+        () =>
+          [
+            materializedShardFacts(mixedDatabasePath, 'src/caller.ts'),
+            materializedShardFacts(freshDatabasePath, 'src/caller.ts'),
+          ] as const,
+      );
+      const expectedTarget = freshGraph.symbols.find(
+        symbol => symbol.path === 'src/leaf.ts' && symbol.name === 'target' && symbol.arity === 2,
+      );
+      const call = freshGraph.edges.find(edge => edge.evidencePath === 'src/caller.ts' && edge.relation === 'calls');
+
+      expect(expectedTarget).toBeDefined();
+      expect(call).toMatchObject({confidence: 1, provenance: 'resolved', targetId: expectedTarget!.id});
+      expect(rebuiltCaller).toEqual(freshCaller);
+      expect(normalizeStoredGraph(rebuiltGraph)).toEqual(normalizeStoredGraph(freshGraph));
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
@@ -1337,7 +1447,9 @@ describe('native code graph lifecycle', () => {
         }
 
         expect(rebuilt.materialization).toEqual({mode: 'full', stagedFiles: 2, totalFiles: 2});
-        expect(rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 1 file(s).');
+        expect(
+          rebuilt.diagnostics.some(value => value.startsWith('Reused content-addressed materialized shards')),
+        ).toBe(false);
         expect(normalizeStoredGraph(rebuiltGraph)).toEqual(normalizeStoredGraph(firstGraph));
       }).pipe(provideTestLayer(ApplicationLayer)),
     ),
@@ -4951,6 +5063,26 @@ function createManySourceRepository(count: number): string {
   return root;
 }
 
+function createAmbientOverloadBarrelRepository(): string {
+  const root = temporaryDirectory('threadnote-code-graph-ambient-overload-barrel-');
+  mkdirSync(join(root, 'src'), {recursive: true});
+  git(root, ['init', '-q']);
+  writeFileSync(join(root, 'package.json'), `${JSON.stringify({name: 'ambient-overload-barrel', type: 'module'})}\n`);
+  writeFileSync(
+    join(root, 'src/leaf.ts'),
+    'export declare function target(value: string): string;\n' +
+      'export declare function target(value: string, suffix: string): string;\n',
+  );
+  writeFileSync(join(root, 'src/barrel.ts'), 'export {target} from "./leaf";\n');
+  writeFileSync(
+    join(root, 'src/caller.ts'),
+    'import {target} from "./barrel";\nexport const result = target("x", "y");\n',
+  );
+  git(root, ['add', '.']);
+  git(root, ['-c', 'user.name=Threadnote Test', '-c', 'user.email=test@threadnote.local', 'commit', '-qm', 'fixture']);
+  return root;
+}
+
 function updateManySourceRepository(root: string, count: number, prefix: string): void {
   for (let index = 0; index < count; index += 1) {
     writeFileSync(
@@ -5161,6 +5293,21 @@ function createFactBudgetExpandedRepository(): string {
 
 function codeGraphDatabasePath(home: string, indexed: {readonly identity: {readonly checkoutId: string}}): string {
   return join(home, 'indexes', 'code-graph', 'repositories', indexed.identity.checkoutId, 'graph-v3.sqlite');
+}
+
+function materializedShardFacts(databasePath: string, path: string) {
+  const database = new Database(databasePath, {readonly: true});
+  try {
+    const row = database
+      .query<{readonly factsJson: string}, [string]>(
+        'SELECT facts_json AS factsJson FROM materialized_file_shards WHERE path_hint = ?',
+      )
+      .get(path);
+    if (!row) throw new TestError(`Expected a materialized shard for ${path}.`);
+    return decodeStoredCodeGraphFact(row.factsJson, path).facts;
+  } finally {
+    database.close();
+  }
 }
 
 function snapshotLeaseCount(databasePath: string): number {

--- a/test/unit/code-graph.attribution.property.test.ts
+++ b/test/unit/code-graph.attribution.property.test.ts
@@ -11,7 +11,7 @@ const attributionCase = FC.record({
   rotation: FC.integer({max: 31, min: 0}),
 });
 
-const mixedReuseCase = FC.record({
+const batchReuseCase = FC.record({
   batchWidth: FC.integer({max: 5, min: 1}),
   hitMask: FC.array(FC.boolean(), {maxLength: 24, minLength: 1}),
   packageCount: FC.integer({max: 12, min: 1}),
@@ -51,28 +51,28 @@ describe('code graph repository-attribution properties', () => {
   );
 
   it.prop(
-    'matches one-shot attribution when arbitrary final-shard hits are mixed with batched raw misses',
-    {scenario: mixedReuseCase},
+    'matches canonical batch attribution when only complete final-shard batches are reused',
+    {scenario: batchReuseCase},
     ({scenario}) => {
       const files = repositoryFiles(scenario.packageCount);
       const workspace = discoverManifestWorkspace(files);
       const raw = syntheticFacts(files);
       const attributeBatch = createCachedCodeGraphFactsAttributor(files, workspace);
-      const expected = attributeBatch(raw);
-      const hitPaths = new Set(
-        raw.filter((_, index) => scenario.hitMask[index % scenario.hitMask.length]).map(file => file.path),
-      );
-      const hitFacts = new Map(expected.filter(file => hitPaths.has(file.path)).map(file => [file.path, file]));
-      const misses = raw.filter(file => !hitPaths.has(file.path));
-      const rotation = misses.length === 0 ? 0 : scenario.rotation % misses.length;
-      const reorderedMisses = [...misses.slice(rotation), ...misses.slice(0, rotation)];
-      const attributedMisses = new Map<string, CodeGraphFileFacts>();
-      for (let index = 0; index < reorderedMisses.length; index += scenario.batchWidth) {
-        for (const fact of attributeBatch(reorderedMisses.slice(index, index + scenario.batchWidth))) {
-          attributedMisses.set(fact.path, fact);
-        }
+      const rotation = scenario.rotation % raw.length;
+      const reordered = [...raw.slice(rotation), ...raw.slice(0, rotation)];
+      const rawBatches: (readonly CodeGraphFileFacts[])[] = [];
+      for (let index = 0; index < reordered.length; index += scenario.batchWidth) {
+        rawBatches.push(reordered.slice(index, index + scenario.batchWidth));
       }
-      const merged = raw.map(file => hitFacts.get(file.path) ?? attributedMisses.get(file.path)!);
+      const canonicalBatches = rawBatches.map(batch => attributeBatch(batch));
+      const expected = canonicalBatches.flat();
+      const hitPaths = new Set(
+        expected.filter((_, index) => scenario.hitMask[index % scenario.hitMask.length]).map(file => file.path),
+      );
+      const merged = rawBatches.flatMap((batch, index) => {
+        const canonical = canonicalBatches[index]!;
+        return canonical.every(file => hitPaths.has(file.path)) ? canonical : attributeBatch(batch);
+      });
 
       expect(normalizeFacts(merged)).toEqual(normalizeFacts(expected));
     },

--- a/test/unit/code-graph.indexer.property.test.ts
+++ b/test/unit/code-graph.indexer.property.test.ts
@@ -151,6 +151,17 @@ describe('code graph indexer properties', () => {
     );
   });
 
+  it('does not admit materialized shards derived by the partition-dependent v2 algorithm', () => {
+    const extractor = 'extractor-set';
+    const workspace = 'workspace-fingerprint';
+    const graphContent = 'graph-content';
+    const legacy = `cgfd_${sha256HexSync(
+      `materialized-file-derivation-v2\n${extractor}\n${workspace}\n${graphContent}`,
+    ).slice(0, 40)}`;
+
+    expect(materializedShardDerivationIdentity(extractor, workspace, graphContent)).not.toBe(legacy);
+  });
+
   it('splits high-density low-source-byte facts before one SQLite writer transaction becomes pathological', () => {
     const files = Array.from({length: 7}, (_, index) => ({path: `src/dense-${index}.ts`, size: 32}));
     const factBytes = new Map(files.map(file => [file.path, 4 * 1_048_576]));


### PR DESCRIPTION
## Critical correctness fix
Merged per-file mixed materialized-shard reuse could persist attribution derived from an arbitrary hit/miss partition. In a valid TypeScript overload-through-barrel fixture, deleting only the caller shard and rebuilding left a two-argument call syntactic/unresolved; a clean build resolved it to the arity-2 leaf declaration.

## Fix
- admit materialized shards only as a complete deterministic `factMaterializationBatches` unit
- replay, reattribute, and rewrite the entire bounded batch when any member is missing or malformed; other complete batches remain reusable
- bump the materialized derivation algorithm from v2 to v3 so partition-poisoned rows are lookup-invisible
- make the full deterministic batch writer the sole v3 producer; incremental subset paths no longer write into that namespace
- preserve physical replay-byte accounting while keeping changed-fact bytes to one logical representation per path

## Correctness evidence
- ambient overload/barrel differential: regenerated caller shard equals an independent clean build; normalized full graph matches; call resolves with confidence 1 to the arity-2 leaf target
- two different clean bases converge through disjoint incremental-clean changes to the same final inventory/graphContent; neither path produces target-v3 materialized rows
- 130-file/two-batch case reuses the complete 128-file batch and rewrites only the incomplete 2-file batch with exact replay accounting
- malformed/wrong-path shard still falls back safely

## Verification
- unit/property: 20/20
- focused lifecycle: 4/4
- focused cross-session incremental: 3/3
- project-closure integration: 11/11
- source/test/site TypeScript, strict targeted lint, file-length lint, Prettier, and diff checks
- two rounds of independent review; final result CLEAN

## Property assessment
The Fast-check invariant now models complete-batch reuse: arbitrary batch widths, ordering, and hit masks must equal canonical batch attribution, with any partial batch fully reattributed.