### PR TITLE
Stabilize graph telemetry handler coverage

### DIFF
--- a/test/integration/code-graph.telemetry.test.ts
+++ b/test/integration/code-graph.telemetry.test.ts
@@ -1,3 +1,4 @@
+import * as BunPath from '@effect/platform-bun/BunPath';
 import {it as effectIt} from '@effect/vitest';
 import {execFileSync} from '../helpers/node-child-process.js';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from '../helpers/node-fs.js';
@@ -7,7 +8,10 @@ import {Effect, Exit, Layer, Option, Tracer} from 'effect';
 import {TestClock} from 'effect/testing';
 import {McpSchema, McpServer} from 'effect/unstable/ai';
 import {describe, expect} from 'vitest';
+import {CodeGraphAnalysis, analyzeCodeGraph} from '../../src/code_graph/analysis.js';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {CodeGraphQueryService} from '../../src/code_graph/query.js';
+import type {CodeGraphQueryResult, CodeGraphStatus, RepositoryIdentity} from '../../src/code_graph/types.js';
 import {CodeGraphWatcher} from '../../src/code_graph/watcher.js';
 import {EffectMcpServerAdapter, type EffectMcpServer} from '../../src/effect/ai/mcp.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
@@ -15,205 +19,123 @@ import type {SystemInfoShape} from '../../src/effect/system.js';
 import {anonymousTelemetryTestLayer} from '../../src/effect/telemetry.js';
 import {registerCodeGraphTool} from '../../src/mcp_server_code_graph.js';
 import type {RuntimeConfig} from '../../src/types.js';
+import {analysisSnapshot, pagedAnalysisStore} from '../helpers/code-graph-analysis.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 
 describe('code graph terminal telemetry wiring', () => {
-  effectIt.effect(
-    'emits complete privacy-safe inspect and analyze lifecycles through the registered MCP tools',
-    () => {
-      const capture = capturingTracer();
-      let watcherEnsures = 0;
+  effectIt.effect('emits complete privacy-safe inspect and analyze lifecycles through the registered MCP tools', () => {
+    const capture = capturingTracer();
+    let watcherEnsures = 0;
+    const harness = registeredTelemetryHarness(capture.tracer, () => watcherEnsures++);
+    const privateQuery = 'private telemetry query';
 
-      return Effect.acquireUseRelease(
-        Effect.sync(createRepositoryFixture),
-        fixture => {
-          const config = runtimeConfig(fixture.home);
-          const server = new EffectMcpServerAdapter('threadnote-graph-telemetry-test', '1.0.0', 'Test server.');
-          registerCodeGraphTool(server, config);
-          type AddedTool = Parameters<EffectMcpServer['addTool']>[0];
-          let analyzeHandle: AddedTool['handle'] | undefined;
-          let inspectHandle: AddedTool['handle'] | undefined;
-          const mcpLayer = Layer.succeed(McpServer.McpServer, {
-            addTool: (options: AddedTool) =>
-              Effect.sync(() => {
-                if (options.tool.name === 'analyze_code_graph') analyzeHandle = options.handle;
-                if (options.tool.name === 'inspect_code_graph') inspectHandle = options.handle;
-              }),
-          } as unknown as EffectMcpServer);
-          const applicationLayer = Layer.merge(
-            ApplicationLayer,
-            Layer.succeed(
-              CodeGraphWatcher,
-              CodeGraphWatcher.of({
-                ensure: () => Effect.sync(() => watcherEnsures++).pipe(Effect.asVoid),
-                metrics: Effect.succeed({
-                  activeRefreshKeys: 0,
-                  activeWatches: 0,
-                  executingRefreshes: 0,
-                  executingRefreshHighWater: 0,
-                  idleSweepFibers: 0,
-                  maximumWatchers: 0,
-                  pendingTrailingRefreshes: 0,
-                  retainedStatuses: 0,
-                }),
-                refresh: () => Effect.succeed(false),
-                status: () => Effect.succeed(Option.none()),
-                watch: () => Effect.void,
-              }),
-            ),
-          );
-          const layer = server
-            .registrationLayer()
-            .pipe(
-              Layer.provideMerge(mcpLayer),
-              Layer.provideMerge(applicationLayer),
-              Layer.provideMerge(
-                anonymousTelemetryTestLayer({system: telemetrySystemInfoStub(), tracer: capture.tracer}),
-              ),
-            );
+    return Effect.gen(function* () {
+      const result = yield* harness.inspect({
+        callerCwd: TELEMETRY_REPOSITORY_ROOT,
+        nodeLimit: 1,
+        operation: 'query',
+        query: privateQuery,
+      });
 
-          return Effect.gen(function* () {
-            const indexer = yield* CodeGraphIndexer;
-            yield* indexer.index({cwd: fixture.root, ensureVectors: false, threadnoteHome: fixture.home});
-            const handle = inspectHandle;
-            if (handle === undefined) return yield* Effect.die('inspect_code_graph was not registered');
-            const privateQuery = 'value';
-            const result = yield* handle({
-              callerCwd: fixture.root,
-              nodeLimit: 1,
-              operation: 'query',
-              query: privateQuery,
-            }).pipe(
-              Effect.provideService(
-                McpSchema.McpServerClient,
-                McpSchema.McpServerClient.of({
-                  clientId: 0,
-                  getClient: Effect.never,
-                  initializePayload: {
-                    capabilities: {},
-                    clientInfo: {name: 'telemetry-test', version: '1.0.0'},
-                    protocolVersion: '2025-06-18',
-                  },
-                }),
-              ),
-            );
+      expect(result.isError).not.toBe(true);
+      expect(watcherEnsures).toBe(1);
+      const spans = capture.spans
+        .map(span => Object.fromEntries(span.attributes))
+        .filter(attributes => attributes['threadnote.operation'] === 'inspect_code_graph');
+      expect(spans).toHaveLength(8);
+      expect(spans.slice(0, 7).map(attributes => attributes['threadnote.phase'])).toEqual([
+        'graph.query.status',
+        'graph.query.status',
+        'graph.query.status',
+        'graph.query.snapshot',
+        'graph.query.execute',
+        'graph.query.execute',
+        'graph.query.execute',
+      ]);
+      expect(spans.slice(0, 7).map(attributes => attributes['threadnote.stage'])).toEqual([
+        'query-repository-identity',
+        'query-worktree-observation',
+        undefined,
+        undefined,
+        'query-strict-reobservation',
+        undefined,
+        'query-serialization',
+      ]);
+      expect(spans[1]).toMatchObject({'threadnote.subphase': 'skipped'});
+      expect(spans[4]).toMatchObject({'threadnote.subphase': 'skipped'});
+      for (const attributes of spans) {
+        expect(attributes).toMatchObject({
+          'threadnote.graph.request_kind': 'inspect.query',
+          'threadnote.graph.request_scope': 'local',
+        });
+      }
+      for (const attributes of [spans[0], spans[1], spans[2], spans[4], spans[6]]) {
+        expect(attributes).not.toHaveProperty('threadnote.graph.snapshot_selection');
+      }
+      for (const attributes of [spans[3], spans[5], spans[7]]) {
+        expect(attributes).toMatchObject({
+          'threadnote.graph.snapshot_edges_bucket': expect.stringMatching(/^(?:0|2\^\d+)$/u),
+          'threadnote.graph.snapshot_files_bucket': expect.stringMatching(/^(?:0|2\^\d+)$/u),
+          'threadnote.graph.snapshot_freshness': 'deferred',
+          'threadnote.graph.snapshot_selection': 'active',
+          'threadnote.graph.snapshot_symbols_bucket': expect.stringMatching(/^(?:0|2\^\d+)$/u),
+        });
+      }
+      expect(spans[7]).toMatchObject({
+        'threadnote.event': 'completion',
+        'threadnote.outcome': 'success',
+      });
+      const serialized = JSON.stringify(spans);
+      expect(serialized).not.toContain(TELEMETRY_REPOSITORY_ROOT);
+      expect(serialized).not.toContain(privateQuery);
 
-            expect(result.isError).not.toBe(true);
-            expect(watcherEnsures).toBe(1);
-            const spans = capture.spans
-              .map(span => Object.fromEntries(span.attributes))
-              .filter(attributes => attributes['threadnote.operation'] === 'inspect_code_graph');
-            expect(spans).toHaveLength(8);
-            expect(spans.slice(0, 7).map(attributes => attributes['threadnote.phase'])).toEqual([
-              'graph.query.status',
-              'graph.query.status',
-              'graph.query.status',
-              'graph.query.snapshot',
-              'graph.query.execute',
-              'graph.query.execute',
-              'graph.query.execute',
-            ]);
-            expect(spans.slice(0, 7).map(attributes => attributes['threadnote.stage'])).toEqual([
-              'query-repository-identity',
-              'query-worktree-observation',
-              undefined,
-              undefined,
-              'query-strict-reobservation',
-              undefined,
-              'query-serialization',
-            ]);
-            expect(spans[1]).toMatchObject({'threadnote.subphase': 'skipped'});
-            expect(spans[4]).toMatchObject({'threadnote.subphase': 'skipped'});
-            for (const attributes of spans) {
-              expect(attributes).toMatchObject({
-                'threadnote.graph.request_kind': 'inspect.query',
-                'threadnote.graph.request_scope': 'local',
-              });
-            }
-            for (const attributes of [spans[0], spans[1], spans[2], spans[4], spans[6]]) {
-              expect(attributes).not.toHaveProperty('threadnote.graph.snapshot_selection');
-            }
-            for (const attributes of [spans[3], spans[5], spans[7]]) {
-              expect(attributes).toMatchObject({
-                'threadnote.graph.snapshot_edges_bucket': expect.stringMatching(/^(?:0|2\^\d+)$/u),
-                'threadnote.graph.snapshot_files_bucket': expect.stringMatching(/^(?:0|2\^\d+)$/u),
-                'threadnote.graph.snapshot_freshness': 'deferred',
-                'threadnote.graph.snapshot_selection': 'active',
-                'threadnote.graph.snapshot_symbols_bucket': expect.stringMatching(/^(?:0|2\^\d+)$/u),
-              });
-            }
-            expect(spans[7]).toMatchObject({
-              'threadnote.event': 'completion',
-              'threadnote.outcome': 'success',
-            });
-            const serialized = JSON.stringify(spans);
-            expect(serialized).not.toContain(fixture.root);
-            expect(serialized).not.toContain(privateQuery);
+      const analyzeResult = yield* harness.analyze({
+        callerCwd: TELEMETRY_REPOSITORY_ROOT,
+        operation: 'stats',
+      });
 
-            const analyze = analyzeHandle;
-            if (analyze === undefined) return yield* Effect.die('analyze_code_graph was not registered');
-            const analyzeResult = yield* analyze({callerCwd: fixture.root, operation: 'stats'}).pipe(
-              Effect.provideService(
-                McpSchema.McpServerClient,
-                McpSchema.McpServerClient.of({
-                  clientId: 0,
-                  getClient: Effect.never,
-                  initializePayload: {
-                    capabilities: {},
-                    clientInfo: {name: 'telemetry-test', version: '1.0.0'},
-                    protocolVersion: '2025-06-18',
-                  },
-                }),
-              ),
-            );
-
-            expect(analyzeResult.isError).not.toBe(true);
-            const analyzeSpans = capture.spans
-              .map(span => Object.fromEntries(span.attributes))
-              .filter(attributes => attributes['threadnote.operation'] === 'analyze_code_graph');
-            expect(analyzeSpans).toHaveLength(7);
-            expect(analyzeSpans.slice(0, 6).map(attributes => attributes['threadnote.phase'])).toEqual([
-              'graph.query.status',
-              'graph.query.status',
-              'graph.query.status',
-              'graph.query.snapshot',
-              'graph.query.execute',
-              'graph.query.execute',
-            ]);
-            expect(analyzeSpans.slice(0, 6).map(attributes => attributes['threadnote.stage'])).toEqual([
-              'query-repository-identity',
-              'query-worktree-observation',
-              undefined,
-              undefined,
-              undefined,
-              'query-serialization',
-            ]);
-            for (const attributes of analyzeSpans) {
-              expect(attributes).toMatchObject({
-                'threadnote.graph.request_kind': 'analyze.stats',
-                'threadnote.graph.request_scope': 'local',
-              });
-            }
-            for (const attributes of [analyzeSpans[0], analyzeSpans[1], analyzeSpans[2], analyzeSpans[5]]) {
-              expect(attributes).not.toHaveProperty('threadnote.graph.snapshot_selection');
-            }
-            for (const attributes of [analyzeSpans[3], analyzeSpans[4], analyzeSpans[6]]) {
-              expect(attributes).toMatchObject({
-                'threadnote.graph.snapshot_selection': 'active',
-              });
-            }
-            expect(analyzeSpans[6]).toMatchObject({
-              'threadnote.event': 'completion',
-              'threadnote.outcome': 'success',
-            });
-            expect(JSON.stringify(analyzeSpans)).not.toContain(fixture.root);
-          }).pipe(TestClock.withLive, provideTestLayer(layer));
-        },
-        fixture => Effect.sync(() => rmSync(fixture.root, {force: true, recursive: true})),
-      );
-    },
-    {timeout: 90_000},
-  );
+      expect(analyzeResult.isError).not.toBe(true);
+      const analyzeSpans = capture.spans
+        .map(span => Object.fromEntries(span.attributes))
+        .filter(attributes => attributes['threadnote.operation'] === 'analyze_code_graph');
+      expect(analyzeSpans).toHaveLength(7);
+      expect(analyzeSpans.slice(0, 6).map(attributes => attributes['threadnote.phase'])).toEqual([
+        'graph.query.status',
+        'graph.query.status',
+        'graph.query.status',
+        'graph.query.snapshot',
+        'graph.query.execute',
+        'graph.query.execute',
+      ]);
+      expect(analyzeSpans.slice(0, 6).map(attributes => attributes['threadnote.stage'])).toEqual([
+        'query-repository-identity',
+        'query-worktree-observation',
+        undefined,
+        undefined,
+        undefined,
+        'query-serialization',
+      ]);
+      for (const attributes of analyzeSpans) {
+        expect(attributes).toMatchObject({
+          'threadnote.graph.request_kind': 'analyze.stats',
+          'threadnote.graph.request_scope': 'local',
+        });
+      }
+      for (const attributes of [analyzeSpans[0], analyzeSpans[1], analyzeSpans[2], analyzeSpans[5]]) {
+        expect(attributes).not.toHaveProperty('threadnote.graph.snapshot_selection');
+      }
+      for (const attributes of [analyzeSpans[3], analyzeSpans[4], analyzeSpans[6]]) {
+        expect(attributes).toMatchObject({
+          'threadnote.graph.snapshot_selection': 'active',
+        });
+      }
+      expect(analyzeSpans[6]).toMatchObject({
+        'threadnote.event': 'completion',
+        'threadnote.outcome': 'success',
+      });
+      expect(JSON.stringify(analyzeSpans)).not.toContain(TELEMETRY_REPOSITORY_ROOT);
+    }).pipe(provideTestLayer(harness.layer));
+  });
 
   effectIt.effect('emits a terminal lifecycle surface for a short detached commit build', () => {
     const capture = capturingTracer();
@@ -402,6 +324,153 @@ describe('code graph terminal telemetry wiring', () => {
     ).pipe(TestClock.withLive, provideTestLayer(layer));
   });
 });
+
+const TELEMETRY_HOME = '/threadnote-telemetry-handler-home';
+const TELEMETRY_REPOSITORY_ROOT = '/workspace/private-telemetry-repository';
+
+function registeredTelemetryHarness(tracer: Tracer.Tracer, onWatcherEnsure: () => void) {
+  const snapshot = analysisSnapshot([], []);
+  const identity: RepositoryIdentity = {
+    caseMode: 'sensitive',
+    checkoutId: 'telemetry-checkout',
+    displayName: 'Fixture/telemetry',
+    gitCommonDirectory: `${TELEMETRY_REPOSITORY_ROOT}/.git`,
+    headCommit: snapshot.commit,
+    objectFormat: 'sha1',
+    repoRoot: TELEMETRY_REPOSITORY_ROOT,
+    repositoryId: snapshot.repositoryId,
+    worktreeId: snapshot.worktreeId,
+  };
+  const status = (observeWorktree: boolean): CodeGraphStatus => ({
+    databasePath: `${TELEMETRY_HOME}/graph.sqlite`,
+    freshness: observeWorktree ? 'current' : 'deferred',
+    identity,
+    languagePacks: [],
+    readySnapshot: snapshot,
+    stale: false,
+  });
+  const query = CodeGraphQueryService.of({
+    attachSharedReadySnapshot: () => Effect.die('Unexpected shared-ready attachment.'),
+    inspect: options =>
+      Effect.gen(function* () {
+        yield* options.telemetry?.skip('graph.query.execute', 'query-strict-reobservation') ?? Effect.void;
+        return telemetryQueryResult(status(false));
+      }),
+    purge: () => Effect.die('Unexpected graph purge.'),
+    status: (_threadnoteHome, _cwd, options) =>
+      Effect.gen(function* () {
+        const observedIdentity = yield* options?.telemetry?.stage(
+          'graph.query.status',
+          'query-repository-identity',
+          Effect.succeed(identity),
+        ) ?? Effect.succeed(identity);
+        yield* options?.afterIdentityObserved?.(observedIdentity) ?? Effect.void;
+        const observesWorktree = options?.observeWorktree !== false;
+        if (observesWorktree) {
+          yield* options?.telemetry?.stage('graph.query.status', 'query-worktree-observation', Effect.void) ??
+            Effect.void;
+        } else {
+          yield* options?.telemetry?.skip('graph.query.status', 'query-worktree-observation') ?? Effect.void;
+        }
+        return status(observesWorktree);
+      }),
+    statusForIdentity: () => Effect.die('Unexpected identity status.'),
+    statusForPublishedIdentity: () => Effect.die('Unexpected published identity status.'),
+  });
+  const watcher = CodeGraphWatcher.of({
+    ensure: () => Effect.sync(onWatcherEnsure),
+    metrics: Effect.succeed({
+      activeRefreshKeys: 0,
+      activeWatches: 0,
+      executingRefreshes: 0,
+      executingRefreshHighWater: 0,
+      idleSweepFibers: 0,
+      maximumWatchers: 0,
+      pendingTrailingRefreshes: 0,
+      retainedStatuses: 0,
+    }),
+    refresh: () => Effect.succeed(false),
+    status: () => Effect.succeed(Option.none()),
+    watch: () => Effect.die('Unexpected graph watch.'),
+  });
+  const store = pagedAnalysisStore([], []);
+  const analysis = CodeGraphAnalysis.of({analyze: options => analyzeCodeGraph(store, options)});
+  const server = new EffectMcpServerAdapter('threadnote-graph-telemetry-test', '1.0.0', 'Test server.');
+  registerCodeGraphTool(server, runtimeConfig(TELEMETRY_HOME));
+  type AddedTool = Parameters<EffectMcpServer['addTool']>[0];
+  let analyzeHandle: AddedTool['handle'] | undefined;
+  let inspectHandle: AddedTool['handle'] | undefined;
+  const mcpLayer = Layer.succeed(McpServer.McpServer, {
+    addTool: (options: AddedTool) =>
+      Effect.sync(() => {
+        if (options.tool.name === 'analyze_code_graph') analyzeHandle = options.handle;
+        if (options.tool.name === 'inspect_code_graph') inspectHandle = options.handle;
+      }),
+  } as unknown as EffectMcpServer);
+  const applicationLayer = Layer.mergeAll(
+    BunPath.layer,
+    Layer.succeed(CodeGraphAnalysis, analysis),
+    Layer.succeed(CodeGraphQueryService, query),
+    Layer.succeed(CodeGraphWatcher, watcher),
+    anonymousTelemetryTestLayer({system: telemetrySystemInfoStub(), tracer}),
+  );
+  // The registry contains only the two handlers exercised here. Its production
+  // type is conservative because arbitrary registries may capture any service.
+  // oxlint-disable effecttsgo/unsafe-effect-type-assertion -- narrow this test-only registry to its actual services
+  const registrationLayer = server.registrationLayer() as Layer.Layer<
+    never,
+    never,
+    McpServer.McpServer | Layer.Success<typeof applicationLayer>
+  >;
+  // oxlint-enable effecttsgo/unsafe-effect-type-assertion
+  const layer = registrationLayer.pipe(Layer.provideMerge(mcpLayer), Layer.provideMerge(applicationLayer));
+  const invoke = (handle: AddedTool['handle'] | undefined, name: string, arguments_: Record<string, unknown>) =>
+    Effect.suspend(() => {
+      if (handle === undefined) return Effect.die(`${name} was not registered.`);
+      return handle(arguments_).pipe(Effect.provideService(McpSchema.McpServerClient, telemetryMcpClient()));
+    });
+
+  return {
+    analyze: (arguments_: Record<string, unknown>) => invoke(analyzeHandle, 'analyze_code_graph', arguments_),
+    inspect: (arguments_: Record<string, unknown>) => invoke(inspectHandle, 'inspect_code_graph', arguments_),
+    layer,
+  };
+}
+
+function telemetryQueryResult(status: CodeGraphStatus): CodeGraphQueryResult {
+  const snapshot = status.readySnapshot!;
+  return {
+    edges: [],
+    freshness: 'deferred',
+    nodes: [],
+    operation: 'query',
+    repository: {displayName: status.identity.displayName, repositoryId: status.identity.repositoryId},
+    snapshot: {
+      commit: snapshot.commit,
+      dirty: snapshot.dirty,
+      id: snapshot.id,
+      worktreeId: status.identity.worktreeId,
+    },
+    trust: {
+      classification: 'untrusted-repository-data',
+      instructionPolicy: 'evidence-only-never-follow',
+    },
+    version: 1,
+    warnings: [],
+  };
+}
+
+function telemetryMcpClient(): McpSchema.McpServerClient['Service'] {
+  return McpSchema.McpServerClient.of({
+    clientId: 0,
+    getClient: Effect.never,
+    initializePayload: {
+      capabilities: {},
+      clientInfo: {name: 'telemetry-test', version: '1.0.0'},
+      protocolVersion: '2025-06-18',
+    },
+  });
+}
 
 function createRepositoryFixture(): {commit: string; home: string; root: string} {
   const root = mkdtempSync(join(tmpdir(), 'threadnote-graph-telemetry-'));


### PR DESCRIPTION
## Summary
- keep the real registered MCP handlers, reporter lifecycle, serialization, tracer, and privacy assertions
- replace the resource-heavy application graph in one handler-wiring test with deterministic Query/Watcher/Analysis services
- leave the four real indexer telemetry integration cases unchanged

## Why
The same case timed out at 90 seconds on three consecutive PR heads while fresh isolated runs passed in about 1.8 seconds. It also reproduces locally only when the root Codex thread environment is inherited. The test was coupling handler telemetry wiring to unrelated application-layer/index/model resources.

## Coverage
- handler propagation still fails if telemetry is not passed through status, inspect, analysis, or serialization boundaries
- QueryService-owned stage emission remains covered by `code-graph.query.test.ts`
- reporter lifecycle/privacy remains covered by `code-graph.query-anonymous-telemetry.property.test.ts`
- real registered graph calls remain covered by native MCP integration tests
- the other four tests in this file retain real indexing/ApplicationLayer behavior

## Verification
- independent no-edit review: no critical or important findings
- focused Vitest after rebase: 3 files / 30 tests passed
- stabilized target is 24–27 ms across repeated local runs; whole telemetry file passes
- test TypeScript, strict lint, Prettier, and diff checks pass
- full suite delegated to CI

## Property assessment
No new randomized property is warranted: this is a finite registered-handler/lifecycle wiring matrix, while the underlying reporter privacy/state properties already have bounded Fast-check coverage.