### PR TITLE
Split code graph replay evidence

### DIFF
--- a/scripts/benchmark-code-graph-dirty-overlay.ts
+++ b/scripts/benchmark-code-graph-dirty-overlay.ts
@@ -2,7 +2,11 @@ import {provideScriptLayer, ScriptError} from './effect/errors.js';
 import * as BunRuntime from '@effect/platform-bun/BunRuntime';
 import {Clock, Effect, FileSystem, Path} from 'effect';
 import {CodeGraphIndexer, type CodeGraphIndexerShape} from '../src/code_graph/indexer.js';
-import type {CodeGraphIndexSummary, CodeGraphProgress} from '../src/code_graph/types.js';
+import type {
+  CodeGraphIndexSummary,
+  CodeGraphMaterializationMetrics,
+  CodeGraphProgress,
+} from '../src/code_graph/types.js';
 import {ApplicationLayer} from '../src/effect/runtime.js';
 import {SystemInfo} from '../src/effect/system.js';
 import {atomicWrite, printJson, scriptArguments} from './effect/script.js';
@@ -27,10 +31,21 @@ interface DirtyOverlayObservation {
   readonly fallbackReason?: string;
   readonly materializationMilliseconds: number;
   readonly materializationMode: string;
+  readonly replay: DirtyOverlayReplayEvidence;
   readonly rewriteAmplification?: number;
   readonly stagedFiles: number;
   readonly symbols: number;
   readonly totalFiles: number;
+}
+
+export interface DirtyOverlayReplayEvidence {
+  readonly attributedFiles: number;
+  readonly cachedFactReplayBytes: number;
+  readonly changedFactBytes: number;
+  readonly crossGenerationShardFiles: number;
+  readonly exactGenerationShardFiles: number;
+  readonly materializedShardReplayBytes: number;
+  readonly rawFactReplayBytes: number;
 }
 
 const benchmarkCodeGraphDirtyOverlay = Effect.scoped(
@@ -103,6 +118,7 @@ const benchmarkCodeGraphDirtyOverlay = Effect.scoped(
               }
             : {}),
           materializationMilliseconds: fullMaterialization,
+          replay: full[0]!.replay,
           stagedFiles: full[0]?.stagedFiles ?? 0,
         },
         incremental: {
@@ -116,6 +132,7 @@ const benchmarkCodeGraphDirtyOverlay = Effect.scoped(
               }
             : {}),
           materializationMilliseconds: incrementalMaterialization,
+          replay: incremental[0]!.replay,
           stagedFiles: incremental[0]?.stagedFiles ?? 0,
         },
         improvement: {
@@ -158,7 +175,7 @@ const runDirtyOverlayIndex = Effect.fn('benchmarkCodeGraphDirtyOverlay.run')(fun
     Clock.currentTimeNanos.pipe(
       Effect.tap(now =>
         Effect.sync(() => {
-          if (scenario === 'unchanged-static-reexport' && progress.phase === 'materializing') {
+          if (progress.phase === 'materializing') {
             if (previousProgressPhase !== 'materializing') finalMaterializationMetrics = undefined;
             if (progress.metrics !== undefined) finalMaterializationMetrics = progress.metrics;
           }
@@ -188,10 +205,13 @@ const runDirtyOverlayIndex = Effect.fn('benchmarkCodeGraphDirtyOverlay.run')(fun
   if (scenario === 'unchanged-static-reexport' && changedFactBytes <= 0) {
     return yield* Effect.fail(new ScriptError('Dirty-overlay benchmark did not retain changed-fact byte evidence.'));
   }
+  const replay = incrementalOverlay
+    ? incrementalDirtyOverlayReplayEvidence(changedFactBytes)
+    : dirtyOverlayReplayEvidence(finalMaterializationMetrics, changedFactBytes);
   const amplification =
     scenario === 'unchanged-static-reexport'
       ? dirtyOverlayAmplificationEvidence({
-          cachedFactReplayBytes: finalMaterializationMetrics?.cachedFactReplayBytesCompleted ?? 0,
+          cachedFactReplayBytes: replay.cachedFactReplayBytes,
           changedFactBytes,
           deltaFiles: 1,
           stagedFiles: summary.materialization?.stagedFiles ?? 0,
@@ -211,11 +231,59 @@ const runDirtyOverlayIndex = Effect.fn('benchmarkCodeGraphDirtyOverlay.run')(fun
     ...(summary.materialization?.fallbackReason ? {fallbackReason: summary.materialization.fallbackReason} : {}),
     materializationMilliseconds: Number(materializationNanoseconds) / NANOSECONDS_PER_MILLISECOND,
     materializationMode: summary.materialization?.mode ?? 'unreported',
+    replay,
     stagedFiles: summary.materialization?.stagedFiles ?? -1,
     symbols: summary.snapshot.symbolCount,
     totalFiles: summary.materialization?.totalFiles ?? -1,
   } satisfies DirtyOverlayObservation;
 });
+
+export function dirtyOverlayReplayEvidence(
+  metrics: CodeGraphMaterializationMetrics | undefined,
+  changedFactBytes: number,
+): DirtyOverlayReplayEvidence {
+  if (
+    metrics?.attributedFilesCompleted === undefined ||
+    metrics.cachedFactReplayBytesCompleted === undefined ||
+    metrics.changedFactBytesCompleted === undefined ||
+    metrics.crossGenerationShardFilesCompleted === undefined ||
+    metrics.exactGenerationShardFilesCompleted === undefined ||
+    metrics.materializedShardReplayBytesCompleted === undefined ||
+    metrics.rawFactReplayBytesCompleted === undefined
+  ) {
+    throw new ScriptError('Dirty-overlay benchmark did not retain complete physical replay evidence.');
+  }
+  const cachedFactReplayBytes = metrics.cachedFactReplayBytesCompleted;
+  const materializedShardReplayBytes = metrics.materializedShardReplayBytesCompleted;
+  const rawFactReplayBytes = metrics.rawFactReplayBytesCompleted;
+  if (cachedFactReplayBytes !== Math.min(Number.MAX_SAFE_INTEGER, materializedShardReplayBytes + rawFactReplayBytes)) {
+    throw new ScriptError('Dirty-overlay benchmark replay-byte split is inconsistent.');
+  }
+  if (changedFactBytes !== metrics.changedFactBytesCompleted) {
+    throw new ScriptError('Dirty-overlay benchmark changed-fact byte evidence is inconsistent.');
+  }
+  return {
+    attributedFiles: metrics.attributedFilesCompleted,
+    cachedFactReplayBytes,
+    changedFactBytes,
+    crossGenerationShardFiles: metrics.crossGenerationShardFilesCompleted,
+    exactGenerationShardFiles: metrics.exactGenerationShardFilesCompleted,
+    materializedShardReplayBytes,
+    rawFactReplayBytes,
+  };
+}
+
+function incrementalDirtyOverlayReplayEvidence(changedFactBytes: number): DirtyOverlayReplayEvidence {
+  return {
+    attributedFiles: 0,
+    cachedFactReplayBytes: 0,
+    changedFactBytes,
+    crossGenerationShardFiles: 0,
+    exactGenerationShardFiles: 0,
+    materializedShardReplayBytes: 0,
+    rawFactReplayBytes: 0,
+  };
+}
 
 export function dirtyOverlayAmplificationEvidence(input: {
   readonly cachedFactReplayBytes: number;

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -313,6 +313,18 @@ const SAMPLER_RELEASE_EVIDENCE_MEASUREMENTS = (['cold', 'one-file-reindex', 'sam
   ],
 );
 
+const MATERIALIZATION_REPLAY_RELEASE_EVIDENCE_MEASUREMENTS = (['cold', 'same-overlay-reference'] as const).flatMap(
+  prefix => [
+    {name: `${prefix}-materialization-attributed-files-n1`, unit: 'count'} as const,
+    {name: `${prefix}-materialization-cached-fact-replay-bytes-n1`, unit: 'bytes'} as const,
+    {name: `${prefix}-materialization-changed-fact-bytes-n1`, unit: 'bytes'} as const,
+    {name: `${prefix}-materialization-cross-generation-shard-files-n1`, unit: 'count'} as const,
+    {name: `${prefix}-materialization-exact-generation-shard-files-n1`, unit: 'count'} as const,
+    {name: `${prefix}-materialization-materialized-shard-replay-bytes-n1`, unit: 'bytes'} as const,
+    {name: `${prefix}-materialization-raw-fact-replay-bytes-n1`, unit: 'bytes'} as const,
+  ],
+);
+
 export const PRODUCTION_RELEASE_EVIDENCE_MEASUREMENTS = [
   {name: 'cold-materialization', unit: 'milliseconds'},
   {name: 'cold-materialization-process-cpu-n1', unit: 'milliseconds'},
@@ -351,6 +363,7 @@ export const PRODUCTION_RELEASE_EVIDENCE_MEASUREMENTS = [
   {name: 'production-shape-symbol-target-attainment', unit: 'percent'},
   {name: 'production-shape-edge-target-attainment', unit: 'percent'},
   {name: 'production-shape-lexical-term-target-attainment', unit: 'percent'},
+  ...MATERIALIZATION_REPLAY_RELEASE_EVIDENCE_MEASUREMENTS,
   ...SAMPLER_RELEASE_EVIDENCE_MEASUREMENTS,
   ...ACTIVATION_RELEASE_EVIDENCE_MEASUREMENTS,
 ] as const;
@@ -1889,9 +1902,14 @@ export class IndexPhaseTimeline {
         }
         if (progress.metrics?.storage) {
           this.#materializationStorage = {
+            attributedFilesCompleted: progress.metrics.attributedFilesCompleted,
             ...(progress.metrics.cachedFactBytesTotal === undefined
               ? {}
               : {cachedFactBytesTotal: progress.metrics.cachedFactBytesTotal}),
+            cachedFactReplayBytesCompleted: progress.metrics.cachedFactReplayBytesCompleted,
+            changedFactBytesCompleted: progress.metrics.changedFactBytesCompleted,
+            crossGenerationShardFilesCompleted: progress.metrics.crossGenerationShardFilesCompleted,
+            exactGenerationShardFilesCompleted: progress.metrics.exactGenerationShardFilesCompleted,
             ...(progress.metrics.factsBytesTotal === undefined
               ? {}
               : {finalFactBytesTotal: progress.metrics.factsBytesTotal}),
@@ -1905,7 +1923,9 @@ export class IndexPhaseTimeline {
             estimatedTemporaryFilesystemRequiredBytes:
               progress.metrics.storage.estimatedTemporaryFilesystemRequiredBytes,
             filesystemsShared: progress.metrics.storage.filesystemsShared,
+            materializedShardReplayBytesCompleted: progress.metrics.materializedShardReplayBytesCompleted,
             materializationMode: progress.metrics.storage.materializationMode,
+            rawFactReplayBytesCompleted: progress.metrics.rawFactReplayBytesCompleted,
             temporaryAvailableBytes: progress.metrics.storage.temporaryAvailableBytes,
           };
         }
@@ -2108,7 +2128,12 @@ export function measureSampledBenchmarkIndex<A>(
 }
 
 export interface IndexMaterializationStorageEvidence {
+  readonly attributedFilesCompleted?: number;
   readonly cachedFactBytesTotal?: number;
+  readonly cachedFactReplayBytesCompleted?: number;
+  readonly changedFactBytesCompleted?: number;
+  readonly crossGenerationShardFilesCompleted?: number;
+  readonly exactGenerationShardFilesCompleted?: number;
   readonly finalFactBytesTotal?: number;
   readonly durableAvailableBytes?: number;
   readonly durableDatabaseGrowthHighWaterBytes?: number;
@@ -2119,7 +2144,9 @@ export interface IndexMaterializationStorageEvidence {
   readonly estimatedDurableFilesystemRequiredBytes?: number;
   readonly estimatedTemporaryFilesystemRequiredBytes?: number;
   readonly filesystemsShared?: boolean;
+  readonly materializedShardReplayBytesCompleted?: number;
   readonly materializationMode?: 'direct-persistent' | 'temporary-staged';
+  readonly rawFactReplayBytesCompleted?: number;
   readonly temporaryAvailableBytes?: number;
 }
 
@@ -2204,8 +2231,15 @@ export function materializationStorageMeasurements(
   const add = (name: string, unit: 'bytes' | 'count', value: number | undefined) => {
     if (value !== undefined) measurements.push(benchmarkMeasurement(`${prefix}-${name}`, unit, [value]));
   };
+  add('materialization-attributed-files-n1', 'count', storage.attributedFilesCompleted);
   add('materialization-cached-fact-bytes-total-n1', 'bytes', storage.cachedFactBytesTotal);
+  add('materialization-cached-fact-replay-bytes-n1', 'bytes', storage.cachedFactReplayBytesCompleted);
+  add('materialization-changed-fact-bytes-n1', 'bytes', storage.changedFactBytesCompleted);
+  add('materialization-cross-generation-shard-files-n1', 'count', storage.crossGenerationShardFilesCompleted);
+  add('materialization-exact-generation-shard-files-n1', 'count', storage.exactGenerationShardFilesCompleted);
   add('materialization-final-fact-bytes-total-n1', 'bytes', storage.finalFactBytesTotal);
+  add('materialization-materialized-shard-replay-bytes-n1', 'bytes', storage.materializedShardReplayBytesCompleted);
+  add('materialization-raw-fact-replay-bytes-n1', 'bytes', storage.rawFactReplayBytesCompleted);
   add(
     'materialization-estimated-temp-filesystem-required-n1',
     'bytes',
@@ -4150,6 +4184,7 @@ function assertProductionLargeEvidence(artifact: BenchmarkArtifactV1, requireRel
     const measurement = measurements.get(required.name);
     return measurement?.unit === required.unit ? [] : [`${required.name} (${required.unit})`];
   });
+  missing.push(...missingMaterializationReplayEquations(measurements));
   if (artifact.metadata.oneFileReindexMaterializationMode !== 'incremental-overlay') {
     missing.push('one-file reindex incremental-overlay materialization mode');
   }
@@ -4174,6 +4209,44 @@ function assertProductionLargeEvidence(artifact: BenchmarkArtifactV1, requireRel
   if (missing.length > 0) {
     throw new ScriptError(`Production release evidence is incomplete: ${missing.join(', ')}.`);
   }
+}
+
+function missingMaterializationReplayEquations(
+  measurements: ReadonlyMap<string, BenchmarkArtifactV1['measurements'][number]>,
+): readonly string[] {
+  return (['cold', 'same-overlay-reference'] as const).flatMap(prefix => {
+    const cached = measurements.get(`${prefix}-materialization-cached-fact-replay-bytes-n1`);
+    const materialized = measurements.get(`${prefix}-materialization-materialized-shard-replay-bytes-n1`);
+    const raw = measurements.get(`${prefix}-materialization-raw-fact-replay-bytes-n1`);
+    if (!cached || !materialized || !raw) return [];
+    const cachedBytes = exactSingleSampleCount(cached);
+    const materializedBytes = exactSingleSampleCount(materialized);
+    const rawBytes = exactSingleSampleCount(raw);
+    return cachedBytes !== undefined &&
+      materializedBytes !== undefined &&
+      rawBytes !== undefined &&
+      cachedBytes === Math.min(Number.MAX_SAFE_INTEGER, materializedBytes + rawBytes)
+      ? []
+      : [`${prefix} materialization replay-byte equation`];
+  });
+}
+
+function exactSingleSampleCount(measurement: BenchmarkArtifactV1['measurements'][number]): number | undefined {
+  const values = [
+    measurement.minimum,
+    measurement.maximum,
+    measurement.mean,
+    measurement.p50,
+    measurement.p95,
+    measurement.p99,
+  ];
+  const value = values[0];
+  return measurement.samples === 1 &&
+    value !== undefined &&
+    Number.isSafeInteger(value) &&
+    values.every(candidate => candidate === value)
+    ? value
+    : undefined;
 }
 
 function missingProductionShapeTargetAttainment(

--- a/src/code_graph/build_status_codec.ts
+++ b/src/code_graph/build_status_codec.ts
@@ -371,14 +371,34 @@ function parseMaterializationMetrics(value: unknown): CodeGraphMaterializationMe
     return undefined;
   }
   for (const key of [
+    'attributedFilesCompleted',
     'cachedFactBytesCompleted',
     'cachedFactBytesTotal',
     'cachedFactReplayBytesCompleted',
     'changedFactBytesCompleted',
+    'crossGenerationShardFilesCompleted',
+    'exactGenerationShardFilesCompleted',
     'factsBytesCompleted',
     'factsBytesTotal',
+    'materializedShardReplayBytesCompleted',
+    'rawFactReplayBytesCompleted',
   ] as const) {
     if (value[key] !== undefined && !isNonNegativeSafeInteger(value[key])) return undefined;
+  }
+  const hasReplaySplit =
+    value.materializedShardReplayBytesCompleted !== undefined || value.rawFactReplayBytesCompleted !== undefined;
+  if (
+    hasReplaySplit &&
+    (value.cachedFactReplayBytesCompleted === undefined ||
+      value.materializedShardReplayBytesCompleted === undefined ||
+      value.rawFactReplayBytesCompleted === undefined ||
+      Number(value.cachedFactReplayBytesCompleted) !==
+        Math.min(
+          Number.MAX_SAFE_INTEGER,
+          Number(value.materializedShardReplayBytesCompleted) + Number(value.rawFactReplayBytesCompleted),
+        ))
+  ) {
+    return undefined;
   }
   if (
     value.cachedFactBytesCompleted !== undefined &&
@@ -406,6 +426,9 @@ function parseMaterializationMetrics(value: unknown): CodeGraphMaterializationMe
   if (storage?.estimateBasis === 'cached-fact-bytes' && value.cachedFactBytesTotal === undefined) return undefined;
   if (storage?.estimateBasis === 'final-fact-bytes' && value.factsBytesTotal === undefined) return undefined;
   return {
+    ...(value.attributedFilesCompleted === undefined
+      ? {}
+      : {attributedFilesCompleted: Number(value.attributedFilesCompleted)}),
     ...(value.fallbackReason === undefined
       ? {}
       : {fallbackReason: value.fallbackReason as CodeGraphMaterializationMetrics['fallbackReason']}),
@@ -436,10 +459,22 @@ function parseMaterializationMetrics(value: unknown): CodeGraphMaterializationMe
     ...(value.changedFactBytesCompleted === undefined
       ? {}
       : {changedFactBytesCompleted: Number(value.changedFactBytesCompleted)}),
+    ...(value.crossGenerationShardFilesCompleted === undefined
+      ? {}
+      : {crossGenerationShardFilesCompleted: Number(value.crossGenerationShardFilesCompleted)}),
+    ...(value.exactGenerationShardFilesCompleted === undefined
+      ? {}
+      : {exactGenerationShardFilesCompleted: Number(value.exactGenerationShardFilesCompleted)}),
     ...(value.factsBytesCompleted === undefined ? {} : {factsBytesCompleted: Number(value.factsBytesCompleted)}),
     ...(value.factsBytesTotal === undefined ? {} : {factsBytesTotal: Number(value.factsBytesTotal)}),
     ...(value.loadingMilliseconds === undefined ? {} : {loadingMilliseconds: Number(value.loadingMilliseconds)}),
+    ...(value.materializedShardReplayBytesCompleted === undefined
+      ? {}
+      : {materializedShardReplayBytesCompleted: Number(value.materializedShardReplayBytesCompleted)}),
     ...(value.mode === undefined ? {} : {mode: value.mode as CodeGraphMaterializationMetrics['mode']}),
+    ...(value.rawFactReplayBytesCompleted === undefined
+      ? {}
+      : {rawFactReplayBytesCompleted: Number(value.rawFactReplayBytesCompleted)}),
     ...(rows ? {rows} : {}),
     sourceBytesCompleted: Number(value.sourceBytesCompleted),
     sourceBytesTotal: Number(value.sourceBytesTotal),

--- a/src/code_graph/indexer.ts
+++ b/src/code_graph/indexer.ts
@@ -25,6 +25,7 @@ export {
   reusableBaseFileSetFingerprint,
 } from './indexer_incremental.js';
 export {
+  addMaterializationReplayMetrics,
   addMaterializationRows,
   cacheContentBatch,
   codeGraphActiveParserCacheKey,
@@ -32,6 +33,7 @@ export {
   codeGraphParserCacheLookupGenerations,
   deduplicateMaterializationRelationships,
   directFullSnapshotIdentity,
+  emptyMaterializationReplayMetrics,
   estimatedMaterializationStorageBytes,
   extractorSetIdentity,
   extractorSetIdentityFromPackProvenance,
@@ -47,6 +49,8 @@ export {
   type CodeGraphCacheContentCoalescer,
   type CodeGraphCacheExtractedRow,
   type DirectPersistentCapacityContext,
+  type CodeGraphMaterializationReplayMetrics,
+  type CodeGraphMaterializationReplayObservation,
   type MaterializationStorageAvailability,
   type MaterializationStoragePlan,
   type PersistentMaterializationTransactionCandidate,

--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -23,11 +23,13 @@ import {
   PERSISTENT_MATERIALIZATION_TRANSACTION_FACT_BYTES,
   PERSISTENT_MATERIALIZATION_TRANSACTION_FILES,
   PERSISTENT_MATERIALIZATION_TRANSACTION_SOURCE_BYTES,
+  addMaterializationReplayMetrics,
   addMaterializationRows,
   cachedFactsMetadata,
   codeGraphDirectPersistentCapacityProtector,
   deduplicateMaterializationRelationships,
   embeddingSymbolSource,
+  emptyMaterializationReplayMetrics,
   estimatedMaterializationStorageBytes,
   extractorSetIdentity,
   extractorSetIdentityFromPackProvenance,
@@ -1221,7 +1223,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         .filter(file => committedHashesByPath.get(file.path) !== file.contentHash)
         .map(file => file.path),
     );
-    let cachedFactReplayBytesCompleted = 0;
+    let replayMetrics = emptyMaterializationReplayMetrics();
     let changedFactBytesCompleted: number | undefined = 0;
     const storageEstimate = estimatedMaterializationStorageBytes(
       cachedFactBytesTotal,
@@ -1292,7 +1294,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       batchesTotal,
       cachedFactBytesCompleted,
       cachedFactBytesTotal,
-      cachedFactReplayBytesCompleted,
+      ...replayMetrics,
       ...(changedFactBytesCompleted === undefined ? {} : {changedFactBytesCompleted}),
       ...(fallbackReason === undefined ? {} : {fallbackReason}),
       factsBytesCompleted,
@@ -1534,10 +1536,11 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       // Count every decoded cache payload, including valid final shards that
       // were inspected before an incomplete batch fell back to all raw facts.
       const batchReplayBytes = Math.min(Number.MAX_SAFE_INTEGER, materializedShards.bytes + cached.bytes);
-      cachedFactReplayBytesCompleted = Math.min(
-        Number.MAX_SAFE_INTEGER,
-        cachedFactReplayBytesCompleted + batchReplayBytes,
-      );
+      replayMetrics = addMaterializationReplayMetrics(replayMetrics, {
+        exactGenerationShardFiles: materializedShardBatchComplete ? files.length : 0,
+        materializedShardReplayBytes: materializedShards.bytes,
+        rawFactReplayBytes: cached.bytes,
+      });
       // Changed-fact bytes are the logical selected representation used as the
       // replay-amplification denominator, not every physical cache decode.
       const batchChangedFactBytes = selectedDecodedFactBytes(
@@ -1578,6 +1581,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       const attributedFallbackFacts = attributeFacts(
         fallbackFiles.map(file => input.languagePacks.postprocessFile(file, cached.facts.get(file.path)!)),
       );
+      replayMetrics = addMaterializationReplayMetrics(replayMetrics, {attributedFiles: fallbackFiles.length});
       if (fallbackFiles.length > 0) {
         yield* input.store.cacheMaterializedFileShards(
           input.layout.databasePath,

--- a/src/code_graph/indexer_materialization.ts
+++ b/src/code_graph/indexer_materialization.ts
@@ -1083,6 +1083,63 @@ function saturatingAdd(...values: readonly number[]): number {
   return values.reduce((total, value) => Math.min(Number.MAX_SAFE_INTEGER, total + value), 0);
 }
 
+export interface CodeGraphMaterializationReplayMetrics {
+  readonly attributedFilesCompleted: number;
+  readonly cachedFactReplayBytesCompleted: number;
+  readonly crossGenerationShardFilesCompleted: number;
+  readonly exactGenerationShardFilesCompleted: number;
+  readonly materializedShardReplayBytesCompleted: number;
+  readonly rawFactReplayBytesCompleted: number;
+}
+
+export interface CodeGraphMaterializationReplayObservation {
+  readonly attributedFiles?: number;
+  readonly crossGenerationShardFiles?: number;
+  readonly exactGenerationShardFiles?: number;
+  readonly materializedShardReplayBytes?: number;
+  readonly rawFactReplayBytes?: number;
+}
+
+export function emptyMaterializationReplayMetrics(): CodeGraphMaterializationReplayMetrics {
+  return {
+    attributedFilesCompleted: 0,
+    cachedFactReplayBytesCompleted: 0,
+    crossGenerationShardFilesCompleted: 0,
+    exactGenerationShardFilesCompleted: 0,
+    materializedShardReplayBytesCompleted: 0,
+    rawFactReplayBytesCompleted: 0,
+  };
+}
+
+/** Adds one physical replay observation while retaining an exact, safely bounded split. */
+export function addMaterializationReplayMetrics(
+  current: CodeGraphMaterializationReplayMetrics,
+  observation: CodeGraphMaterializationReplayObservation,
+): CodeGraphMaterializationReplayMetrics {
+  const materializedShardReplayBytesCompleted = saturatingAdd(
+    current.materializedShardReplayBytesCompleted,
+    observation.materializedShardReplayBytes ?? 0,
+  );
+  const rawFactReplayBytesCompleted = saturatingAdd(
+    current.rawFactReplayBytesCompleted,
+    observation.rawFactReplayBytes ?? 0,
+  );
+  return {
+    attributedFilesCompleted: saturatingAdd(current.attributedFilesCompleted, observation.attributedFiles ?? 0),
+    cachedFactReplayBytesCompleted: saturatingAdd(materializedShardReplayBytesCompleted, rawFactReplayBytesCompleted),
+    crossGenerationShardFilesCompleted: saturatingAdd(
+      current.crossGenerationShardFilesCompleted,
+      observation.crossGenerationShardFiles ?? 0,
+    ),
+    exactGenerationShardFilesCompleted: saturatingAdd(
+      current.exactGenerationShardFilesCompleted,
+      observation.exactGenerationShardFiles ?? 0,
+    ),
+    materializedShardReplayBytesCompleted,
+    rawFactReplayBytesCompleted,
+  };
+}
+
 export function factMaterializationBatches<T extends {readonly path: string; readonly size: number}>(
   values: readonly T[],
   cachedFactBytesByPath: ReadonlyMap<string, number> = new Map(),

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -207,22 +207,32 @@ export interface CodeGraphMaterializationActivity {
 
 /** Cumulative, privacy-safe measurements for the current materialization phase. */
 export interface CodeGraphMaterializationMetrics {
+  /** Files whose parser facts were postprocessed and attributed during this materialization. */
+  readonly attributedFilesCompleted?: number;
   readonly attributionMilliseconds?: number;
   readonly batchesCompleted: number;
   readonly batchesTotal: number;
   readonly cachedFactBytesCompleted?: number;
   readonly cachedFactBytesTotal?: number;
-  /** Exact UTF-8 bytes of decoded facts consumed by materialization: final-shard hits plus raw-cache misses. */
+  /** Saturating sum of materialized-shard and raw-fact replay bytes. */
   readonly cachedFactReplayBytesCompleted?: number;
   /** Exact consumed cached-fact bytes for current paths changed from the committed inventory. */
   readonly changedFactBytesCompleted?: number;
+  /** Files selected from future cross-generation materialized-shard batches; zero until eligibility exists. */
+  readonly crossGenerationShardFilesCompleted?: number;
+  /** Files selected from complete materialized-shard batches for the current exact derivation. */
+  readonly exactGenerationShardFilesCompleted?: number;
   /** Exact bounded reason a repository-wide rewrite was selected, when known. */
   readonly fallbackReason?: CodeGraphOverlayFallbackReason;
   /** Exact UTF-8 JSON bytes of final postprocessed and attributed facts. */
   readonly factsBytesCompleted?: number;
   readonly factsBytesTotal?: number;
   readonly loadingMilliseconds?: number;
+  /** Exact UTF-8 bytes decoded from materialized shards, including inspected shards later discarded by batch fallback. */
+  readonly materializedShardReplayBytesCompleted?: number;
   readonly mode?: 'full' | 'incremental-clean' | 'incremental-overlay';
+  /** Exact UTF-8 bytes decoded from raw parser-fact cache rows for attribution. */
+  readonly rawFactReplayBytesCompleted?: number;
   /** Closed, path-free evidence for the declaration-publication gate. */
   readonly resolutionLookupKeyForm?: import('./resolution_surface.js').CodeGraphResolutionLookupKeyForm;
   /** Closed, path-free evidence for the declaration-publication gate. */

--- a/src/manager_graph_model.ts
+++ b/src/manager_graph_model.ts
@@ -266,6 +266,7 @@ export interface GraphBuildStatus {
       readonly transactionMilliseconds?: number;
     };
     readonly metrics?: {
+      readonly attributedFilesCompleted?: number;
       readonly attributionMilliseconds?: number;
       readonly batchesCompleted: number;
       readonly batchesTotal: number;
@@ -273,11 +274,15 @@ export interface GraphBuildStatus {
       readonly cachedFactBytesTotal?: number;
       readonly cachedFactReplayBytesCompleted?: number;
       readonly changedFactBytesCompleted?: number;
+      readonly crossGenerationShardFilesCompleted?: number;
+      readonly exactGenerationShardFilesCompleted?: number;
       readonly fallbackReason?: string;
       readonly factsBytesCompleted?: number;
       readonly factsBytesTotal?: number;
       readonly loadingMilliseconds?: number;
+      readonly materializedShardReplayBytesCompleted?: number;
       readonly mode?: 'full' | 'incremental-clean' | 'incremental-overlay';
+      readonly rawFactReplayBytesCompleted?: number;
       readonly rows?: GraphMaterializationRows;
       readonly sourceBytesCompleted: number;
       readonly sourceBytesTotal: number;

--- a/src/manager_graph_panels.tsx
+++ b/src/manager_graph_panels.tsx
@@ -1269,6 +1269,37 @@ export function GraphBuildProgress(props: {
               ? ''
               : ` · transactions ${formatGraphMilliseconds(build.materialization.metrics.transactionMilliseconds)}`}
           </p>
+          {build.materialization.metrics.attributedFilesCompleted === undefined &&
+          build.materialization.metrics.crossGenerationShardFilesCompleted === undefined &&
+          build.materialization.metrics.exactGenerationShardFilesCompleted === undefined &&
+          build.materialization.metrics.materializedShardReplayBytesCompleted === undefined &&
+          build.materialization.metrics.rawFactReplayBytesCompleted === undefined ? null : (
+            <p>
+              Physical cache replay
+              {build.materialization.metrics.cachedFactReplayBytesCompleted === undefined
+                ? ''
+                : `: ${formatGraphBytes(build.materialization.metrics.cachedFactReplayBytesCompleted)} total decoded`}
+              {build.materialization.metrics.materializedShardReplayBytesCompleted === undefined
+                ? ''
+                : ` · ${formatGraphBytes(
+                    build.materialization.metrics.materializedShardReplayBytesCompleted,
+                  )} materialized-shard payloads decoded`}
+              {build.materialization.metrics.rawFactReplayBytesCompleted === undefined
+                ? ''
+                : ` · ${formatGraphBytes(
+                    build.materialization.metrics.rawFactReplayBytesCompleted,
+                  )} raw parser-fact payloads decoded`}
+              {build.materialization.metrics.attributedFilesCompleted === undefined
+                ? ''
+                : ` · ${build.materialization.metrics.attributedFilesCompleted.toLocaleString()} raw parser-fact files postprocessed and attributed`}
+              {build.materialization.metrics.exactGenerationShardFilesCompleted === undefined
+                ? ''
+                : ` · ${build.materialization.metrics.exactGenerationShardFilesCompleted.toLocaleString()} files selected from exact-generation materialized shards`}
+              {build.materialization.metrics.crossGenerationShardFilesCompleted === undefined
+                ? ''
+                : ` · ${build.materialization.metrics.crossGenerationShardFilesCompleted.toLocaleString()} files selected from cross-generation materialized shards`}
+            </p>
+          )}
           {build.materialization.metrics.storage ? (
             <>
               <p>

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -1063,6 +1063,11 @@ describe('native code graph lifecycle', () => {
       const metrics = finalFullMaterializationMetrics(progress);
       expect(metrics.cachedFactReplayBytesCompleted).toBe(metrics.cachedFactBytesTotal);
       expect(metrics.cachedFactReplayBytesCompleted).toBeGreaterThan(0);
+      expect(metrics.rawFactReplayBytesCompleted).toBe(metrics.cachedFactBytesTotal);
+      expect(metrics.materializedShardReplayBytesCompleted).toBe(0);
+      expect(metrics.attributedFilesCompleted).toBe(12);
+      expect(metrics.exactGenerationShardFilesCompleted).toBe(0);
+      expect(metrics.crossGenerationShardFilesCompleted).toBe(0);
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
@@ -1111,7 +1116,13 @@ describe('native code graph lifecycle', () => {
       expect(rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 12 file(s).');
       expect(shardState.shards).toBe(12);
       expect(shardState.references).toBe(12);
-      expect(finalFullMaterializationMetrics(progress).cachedFactReplayBytesCompleted).toBe(shardState.bytes);
+      const metrics = finalFullMaterializationMetrics(progress);
+      expect(metrics.cachedFactReplayBytesCompleted).toBe(shardState.bytes);
+      expect(metrics.rawFactReplayBytesCompleted).toBe(0);
+      expect(metrics.materializedShardReplayBytesCompleted).toBe(shardState.bytes);
+      expect(metrics.attributedFilesCompleted).toBe(0);
+      expect(metrics.exactGenerationShardFilesCompleted).toBe(12);
+      expect(metrics.crossGenerationShardFilesCompleted).toBe(0);
       expect(normalizeStoredGraph(rebuiltGraph)).toEqual(normalizeStoredGraph(firstGraph));
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
@@ -1212,6 +1223,11 @@ describe('native code graph lifecycle', () => {
       expect(metrics.cachedFactReplayBytesCompleted).toBe(
         partialShardState.rawFactBytes + partialShardState.reusedShardBytes,
       );
+      expect(metrics.rawFactReplayBytesCompleted).toBe(partialShardState.rawFactBytes);
+      expect(metrics.materializedShardReplayBytesCompleted).toBe(partialShardState.reusedShardBytes);
+      expect(metrics.attributedFilesCompleted).toBe(2);
+      expect(metrics.exactGenerationShardFilesCompleted).toBe(128);
+      expect(metrics.crossGenerationShardFilesCompleted).toBe(0);
       expect(persistedReuse.associations).toBe(130);
       expect(persistedReuse.writes).toHaveLength(2);
       expect(persistedReuse.writes.filter(write => write.operation === 'insert')).toEqual([
@@ -1276,6 +1292,11 @@ describe('native code graph lifecycle', () => {
       expect(replayState.changedRaw).toBeGreaterThan(0);
       expect(replayState.retainedShard).toBeGreaterThan(0);
       expect(metrics.cachedFactReplayBytesCompleted).toBe(replayState.raw + replayState.retainedShard);
+      expect(metrics.rawFactReplayBytesCompleted).toBe(replayState.raw);
+      expect(metrics.materializedShardReplayBytesCompleted).toBe(replayState.retainedShard);
+      expect(metrics.attributedFilesCompleted).toBe(2);
+      expect(metrics.exactGenerationShardFilesCompleted).toBe(0);
+      expect(metrics.crossGenerationShardFilesCompleted).toBe(0);
       expect(metrics.changedFactBytesCompleted).toBe(replayState.changedRaw);
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );

--- a/test/unit/code-graph.build-status.property.test.ts
+++ b/test/unit/code-graph.build-status.property.test.ts
@@ -23,10 +23,14 @@ const observationCase = FC.record({
 });
 
 const materializationCase = FC.record({
+  attributedFiles: FC.integer({max: 1_000_000, min: 0}),
   availableBytes: FC.integer({max: 1_000_000_000, min: 0}),
   batchCompleted: FC.integer({max: 100, min: 0}),
   cachedFactBytes: FC.integer({max: 1_000_000_000, min: 0}),
   edges: FC.integer({max: 1_000_000, min: 0}),
+  exactGenerationShardFiles: FC.integer({max: 1_000_000, min: 0}),
+  materializedShardReplayBytes: FC.integer({max: 1_000_000_000, min: 0}),
+  rawFactReplayBytes: FC.integer({max: 1_000_000_000, min: 0}),
   sourceBytes: FC.integer({max: 1_000_000_000, min: 0}),
   stagingBytes: FC.integer({max: 1_000_000_000, min: 0}),
   symbols: FC.integer({max: 1_000_000, min: 0}),
@@ -177,12 +181,17 @@ describe('code graph build-status properties', () => {
             startedAt: status.timestamps.phaseStartedAt,
           },
           metrics: {
+            attributedFilesCompleted: sample.attributedFiles,
             batchesCompleted: sample.batchCompleted,
             batchesTotal,
             cachedFactBytesCompleted: sample.cachedFactBytes,
             cachedFactBytesTotal: sample.cachedFactBytes,
-            cachedFactReplayBytesCompleted: sample.cachedFactBytes,
+            cachedFactReplayBytesCompleted: sample.materializedShardReplayBytes + sample.rawFactReplayBytes,
             changedFactBytesCompleted: sample.cachedFactBytes,
+            crossGenerationShardFilesCompleted: 0,
+            exactGenerationShardFilesCompleted: sample.exactGenerationShardFiles,
+            materializedShardReplayBytesCompleted: sample.materializedShardReplayBytes,
+            rawFactReplayBytesCompleted: sample.rawFactReplayBytes,
             rows: {
               deduplicatedEdges: sample.edges,
               deduplicatedReferences: sample.symbols,
@@ -214,6 +223,19 @@ describe('code graph build-status properties', () => {
       expect(parseCodeGraphBuildStatus(JSON.parse(JSON.stringify(materializing)))?.materialization).toEqual(
         materializing.materialization,
       );
+      expect(
+        parseCodeGraphBuildStatus({
+          ...materializing,
+          materialization: {
+            ...materializing.materialization,
+            metrics: {
+              ...materializing.materialization!.metrics!,
+              cachedFactReplayBytesCompleted:
+                materializing.materialization!.metrics!.cachedFactReplayBytesCompleted! + 1,
+            },
+          },
+        }),
+      ).toBeUndefined();
       expect(
         parseCodeGraphBuildStatus({
           ...materializing,

--- a/test/unit/code-graph.dirty-overlay-benchmark.test.ts
+++ b/test/unit/code-graph.dirty-overlay-benchmark.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest';
 import {
   dirtyOverlayAmplificationEvidence,
   dirtyOverlayChangedSource,
+  dirtyOverlayReplayEvidence,
   parseDirtyOverlayBenchmarkArguments,
 } from '../../scripts/benchmark-code-graph-dirty-overlay.js';
 import {generatedStaticReexportControlStatement} from '../../scripts/code-graph-fixture.js';
@@ -51,5 +52,39 @@ describe('code graph dirty-overlay benchmark evidence', () => {
         stagedFiles: 102,
       }),
     ).toEqual({factReplayAmplification: 128, rewriteAmplification: 102});
+  });
+
+  it('projects the local physical replay split and rejects inconsistent benchmark evidence', () => {
+    const metrics = {
+      attributedFilesCompleted: 7,
+      batchesCompleted: 1,
+      batchesTotal: 1,
+      cachedFactReplayBytesCompleted: 4_096,
+      changedFactBytesCompleted: 256,
+      crossGenerationShardFilesCompleted: 0,
+      exactGenerationShardFilesCompleted: 5,
+      materializedShardReplayBytesCompleted: 3_072,
+      rawFactReplayBytesCompleted: 1_024,
+      sourceBytesCompleted: 2_048,
+      sourceBytesTotal: 2_048,
+    };
+
+    expect(dirtyOverlayReplayEvidence(metrics, 256)).toEqual({
+      attributedFiles: 7,
+      cachedFactReplayBytes: 4_096,
+      changedFactBytes: 256,
+      crossGenerationShardFiles: 0,
+      exactGenerationShardFiles: 5,
+      materializedShardReplayBytes: 3_072,
+      rawFactReplayBytes: 1_024,
+    });
+    expect(() => dirtyOverlayReplayEvidence({...metrics, cachedFactReplayBytesCompleted: 4_095}, 256)).toThrow(
+      'replay-byte split is inconsistent',
+    );
+    expect(() => dirtyOverlayReplayEvidence({...metrics, rawFactReplayBytesCompleted: undefined}, 256)).toThrow(
+      'did not retain complete physical replay evidence',
+    );
+    expect(() => dirtyOverlayReplayEvidence(undefined, 0)).toThrow('did not retain complete physical replay evidence');
+    expect(() => dirtyOverlayReplayEvidence(metrics, 255)).toThrow('changed-fact byte evidence is inconsistent');
   });
 });

--- a/test/unit/code-graph.indexer.property.test.ts
+++ b/test/unit/code-graph.indexer.property.test.ts
@@ -2,11 +2,13 @@ import {describe, expect, it} from '@effect/vitest';
 import * as FC from 'effect/testing/FastCheck';
 import fc from 'fast-check';
 import {
+  addMaterializationReplayMetrics,
   addMaterializationRows,
   compactCachedFileRelationships,
   codeGraphActiveParserCacheKey,
   codeGraphParserCacheLookupGenerations,
   deduplicateMaterializationRelationships,
+  emptyMaterializationReplayMetrics,
   estimatedMaterializationStorageBytes,
   factMaterializationBatches,
   graphContentIdentity,
@@ -40,6 +42,47 @@ const materializationRows = FC.record({
 });
 
 describe('code graph indexer properties', () => {
+  it.prop(
+    'keeps physical replay components bounded, order-independent, and equal to their combined counter',
+    {
+      observations: FC.array(
+        FC.record({
+          attributedFiles: byteCount,
+          crossGenerationShardFiles: byteCount,
+          exactGenerationShardFiles: byteCount,
+          materializedShardReplayBytes: byteCount,
+          rawFactReplayBytes: byteCount,
+        }),
+        {maxLength: 24},
+      ),
+    },
+    ({observations}) => {
+      const aggregate = observations.reduce(addMaterializationReplayMetrics, emptyMaterializationReplayMetrics());
+      const reversed = [...observations]
+        .reverse()
+        .reduce(addMaterializationReplayMetrics, emptyMaterializationReplayMetrics());
+      const bounded = (values: readonly number[]): number => {
+        const exact = values.reduce((total, value) => total + BigInt(value), 0n);
+        return Number(exact > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : exact);
+      };
+      const expectedRaw = bounded(observations.map(observation => observation.rawFactReplayBytes));
+      const expectedMaterialized = bounded(observations.map(observation => observation.materializedShardReplayBytes));
+      const expectedAttributed = bounded(observations.map(observation => observation.attributedFiles));
+      const expectedCrossGeneration = bounded(observations.map(observation => observation.crossGenerationShardFiles));
+      const expectedExactGeneration = bounded(observations.map(observation => observation.exactGenerationShardFiles));
+
+      expect(aggregate).toEqual(reversed);
+      expect(aggregate.attributedFilesCompleted).toBe(expectedAttributed);
+      expect(aggregate.crossGenerationShardFilesCompleted).toBe(expectedCrossGeneration);
+      expect(aggregate.exactGenerationShardFilesCompleted).toBe(expectedExactGeneration);
+      expect(aggregate.rawFactReplayBytesCompleted).toBe(expectedRaw);
+      expect(aggregate.materializedShardReplayBytesCompleted).toBe(expectedMaterialized);
+      expect(aggregate.cachedFactReplayBytesCompleted).toBe(bounded([expectedRaw, expectedMaterialized]));
+      expect(Object.values(aggregate).every(value => Number.isSafeInteger(value) && value >= 0)).toBe(true);
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
   it.prop(
     'admits both active and degraded parser cache generations deterministically',
     {

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -379,35 +379,63 @@ describe('code graph release evidence', () => {
     ).toThrow(/reviewed default production-large profile/);
   });
 
-  it('retains and requires split storage planning and relationship deduplication counters', () => {
+  it('retains and requires split replay, storage planning, and relationship deduplication counters', () => {
     expect(PRODUCTION_RELEASE_EVIDENCE_MEASUREMENTS).toEqual(
       expect.arrayContaining([
+        {name: 'cold-materialization-attributed-files-n1', unit: 'count'},
         {name: 'cold-materialization-cached-fact-bytes-total-n1', unit: 'bytes'},
+        {name: 'cold-materialization-cached-fact-replay-bytes-n1', unit: 'bytes'},
+        {name: 'cold-materialization-changed-fact-bytes-n1', unit: 'bytes'},
+        {name: 'cold-materialization-cross-generation-shard-files-n1', unit: 'count'},
+        {name: 'cold-materialization-exact-generation-shard-files-n1', unit: 'count'},
         {name: 'cold-materialization-estimated-temp-filesystem-required-n1', unit: 'bytes'},
         {name: 'cold-materialization-estimated-durable-filesystem-required-n1', unit: 'bytes'},
         {name: 'cold-materialization-temp-filesystem-available-n1', unit: 'bytes'},
         {name: 'cold-materialization-durable-filesystem-available-n1', unit: 'bytes'},
         {name: 'cold-materialization-filesystems-shared-n1', unit: 'count'},
+        {name: 'cold-materialization-materialized-shard-replay-bytes-n1', unit: 'bytes'},
+        {name: 'cold-materialization-raw-fact-replay-bytes-n1', unit: 'bytes'},
         {name: 'cold-materialization-deduplicated-edge-rows-n1', unit: 'count'},
         {name: 'cold-materialization-deduplicated-reference-rows-n1', unit: 'count'},
         {name: 'one-file-reindex-materialization-deduplicated-edge-rows-n1', unit: 'count'},
         {name: 'one-file-reindex-materialization-deduplicated-reference-rows-n1', unit: 'count'},
+        {name: 'same-overlay-reference-materialization-attributed-files-n1', unit: 'count'},
+        {name: 'same-overlay-reference-materialization-cached-fact-replay-bytes-n1', unit: 'bytes'},
+        {name: 'same-overlay-reference-materialization-changed-fact-bytes-n1', unit: 'bytes'},
+        {name: 'same-overlay-reference-materialization-cross-generation-shard-files-n1', unit: 'count'},
+        {name: 'same-overlay-reference-materialization-exact-generation-shard-files-n1', unit: 'count'},
+        {name: 'same-overlay-reference-materialization-materialized-shard-replay-bytes-n1', unit: 'bytes'},
+        {name: 'same-overlay-reference-materialization-raw-fact-replay-bytes-n1', unit: 'bytes'},
       ]),
     );
     const retained = new Map(
       materializationStorageMeasurements('cold', {
+        attributedFilesCompleted: 6,
         cachedFactBytesTotal: 10,
+        cachedFactReplayBytesCompleted: 12,
+        changedFactBytesCompleted: 2,
+        crossGenerationShardFilesCompleted: 0,
         durableAvailableBytes: 20,
         estimateBasis: 'cached-fact-bytes',
         estimatedDurableFilesystemRequiredBytes: 30,
         estimatedTemporaryFilesystemRequiredBytes: 40,
         filesystemsShared: false,
+        exactGenerationShardFilesCompleted: 3,
+        materializedShardReplayBytesCompleted: 8,
+        rawFactReplayBytesCompleted: 4,
         temporaryAvailableBytes: 50,
       }).map(measurement => [measurement.name, measurement.minimum]),
     );
     expect(retained).toEqual(
       new Map([
+        ['cold-materialization-attributed-files-n1', 6],
         ['cold-materialization-cached-fact-bytes-total-n1', 10],
+        ['cold-materialization-cached-fact-replay-bytes-n1', 12],
+        ['cold-materialization-changed-fact-bytes-n1', 2],
+        ['cold-materialization-cross-generation-shard-files-n1', 0],
+        ['cold-materialization-exact-generation-shard-files-n1', 3],
+        ['cold-materialization-materialized-shard-replay-bytes-n1', 8],
+        ['cold-materialization-raw-fact-replay-bytes-n1', 4],
         ['cold-materialization-estimated-temp-filesystem-required-n1', 40],
         ['cold-materialization-estimated-durable-filesystem-required-n1', 30],
         ['cold-materialization-temp-filesystem-available-n1', 50],
@@ -427,10 +455,24 @@ describe('code graph release evidence', () => {
       'code-graph-production-large-v1',
     );
     for (const missing of [
+      'cold-materialization-attributed-files-n1',
+      'cold-materialization-cached-fact-replay-bytes-n1',
+      'cold-materialization-changed-fact-bytes-n1',
+      'cold-materialization-cross-generation-shard-files-n1',
+      'cold-materialization-exact-generation-shard-files-n1',
+      'cold-materialization-materialized-shard-replay-bytes-n1',
+      'cold-materialization-raw-fact-replay-bytes-n1',
       'cold-materialization-estimated-temp-filesystem-required-n1',
       'cold-materialization-estimated-durable-filesystem-required-n1',
       'cold-materialization-deduplicated-edge-rows-n1',
       'cold-materialization-deduplicated-reference-rows-n1',
+      'same-overlay-reference-materialization-attributed-files-n1',
+      'same-overlay-reference-materialization-cached-fact-replay-bytes-n1',
+      'same-overlay-reference-materialization-changed-fact-bytes-n1',
+      'same-overlay-reference-materialization-cross-generation-shard-files-n1',
+      'same-overlay-reference-materialization-exact-generation-shard-files-n1',
+      'same-overlay-reference-materialization-materialized-shard-replay-bytes-n1',
+      'same-overlay-reference-materialization-raw-fact-replay-bytes-n1',
     ]) {
       expect(() =>
         assertProductionReleaseEvidence({
@@ -438,6 +480,18 @@ describe('code graph release evidence', () => {
           measurements: artifact.measurements.filter(measurement => measurement.name !== missing),
         }),
       ).toThrow(new RegExp(missing));
+    }
+    for (const prefix of ['cold', 'same-overlay-reference'] as const) {
+      expect(() =>
+        assertProductionReleaseEvidence({
+          ...artifact,
+          measurements: artifact.measurements.map(measurement =>
+            measurement.name === `${prefix}-materialization-cached-fact-replay-bytes-n1`
+              ? benchmarkMeasurement(measurement.name, 'bytes', [3])
+              : measurement,
+          ),
+        }),
+      ).toThrow(new RegExp(`${prefix} materialization replay-byte equation`));
     }
   });
 
@@ -1363,18 +1417,20 @@ function requiredReleaseMeasurements(
     benchmarkMeasurement(measurement.name, measurement.unit, [
       measurement.name === 'cold-activation-observed-stages-n1'
         ? 3
-        : measurement.name.startsWith('production-shape-')
-          ? 100
-          : measurement.name.startsWith('cold-activation-copying-') && measurement.name.endsWith('-observed-n1')
-            ? 0
-            : measurement.name.endsWith('-activation-observed-stages-n1')
-              ? 32
-              : measurement.name.endsWith('-external-sampler-version-n1')
-                ? 4
-                : measurement.name.endsWith('-external-process-tree-failures-n1') ||
-                    measurement.name.endsWith('-external-open-temp-process-tree-failures-n1')
-                  ? 0
-                  : 1,
+        : measurement.name.endsWith('-materialization-cached-fact-replay-bytes-n1')
+          ? 2
+          : measurement.name.startsWith('production-shape-')
+            ? 100
+            : measurement.name.startsWith('cold-activation-copying-') && measurement.name.endsWith('-observed-n1')
+              ? 0
+              : measurement.name.endsWith('-activation-observed-stages-n1')
+                ? 32
+                : measurement.name.endsWith('-external-sampler-version-n1')
+                  ? 4
+                  : measurement.name.endsWith('-external-process-tree-failures-n1') ||
+                      measurement.name.endsWith('-external-open-temp-process-tree-failures-n1')
+                    ? 0
+                    : 1,
     ]),
   );
 }

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -425,10 +425,16 @@ describe('manager graph focus', () => {
       counters: {completed: 37_209, reused: 58_482, total: 59_076, unit: 'files'},
       materialization: {
         metrics: {
+          attributedFilesCompleted: 6,
           batchesCompleted: 707,
           batchesTotal: 933,
+          cachedFactReplayBytesCompleted: 12_288,
+          crossGenerationShardFilesCompleted: 0,
+          exactGenerationShardFilesCompleted: 3,
           fallbackReason: 'file-set-changed',
+          materializedShardReplayBytesCompleted: 8_192,
           mode: 'full' as const,
+          rawFactReplayBytesCompleted: 4_096,
           sourceBytesCompleted: 1,
           sourceBytesTotal: 2,
         },
@@ -450,6 +456,12 @@ describe('manager graph focus', () => {
 
     expect(markup).toContain('Full materialization selected');
     expect(markup).toContain('incremental fallback: file set changed');
+    expect(markup).toContain('Physical cache replay: 12.0 KiB total decoded');
+    expect(markup).toContain('8.00 KiB materialized-shard payloads decoded');
+    expect(markup).toContain('4.00 KiB raw parser-fact payloads decoded');
+    expect(markup).toContain('6 raw parser-fact files postprocessed and attributed');
+    expect(markup).toContain('3 files selected from exact-generation materialized shards');
+    expect(markup).toContain('0 files selected from cross-generation materialized shards');
   });
 
   it('shows the active owner, latest queued target, and stale queryable snapshot without claiming FIFO order', () => {


### PR DESCRIPTION
## Summary
- split cached fact replay into raw parser-fact bytes and materialized-shard bytes while preserving the existing saturating combined total
- count attributed files, exact-generation shard files, and future cross-generation shard files (currently always zero)
- expose the counters in build status, Manager, dirty-overlay artifacts, and production release evidence
- make retained evidence fail closed on missing, malformed, multi-sample, or arithmetically inconsistent replay measurements

## Why
The existing replay-amplification numerator combines raw facts and final shards. That makes it impossible to tell whether a future shard-reuse optimization reduced attribution work or merely changed the decoded representation. This is a behavior-neutral measurement precursor; it does not add cross-generation eligibility or change anonymous telemetry/schema v4.

## Invariants
- `cachedFactReplayBytesCompleted = saturating(rawFactReplayBytesCompleted + materializedShardReplayBytesCompleted)`
- incomplete batches count inspected shard bytes plus raw fallback physically, while changed-fact bytes retain one logical representation per changed path
- complete exact batches count exact-generation files; fallback batches count attributed files; cross-generation remains zero until a later eligibility slice

## Verification
- independent implementation review and final re-review: no critical or important findings
- focused post-rebase unit suite: 5 files / 105 tests passed
- focused real lifecycle replay cases and build-status property passed
- source/test TypeScript, strict lint, Prettier, file-length, and diff checks passed
- small static-reexport benchmark smoke retained exact split counters
- full suite delegated to CI

## Property coverage
Bounded Fast-check now uses an independent saturating model for both replay byte components and all three file counters, including ordering and safe-integer bounds.