### PR TITLE
Reuse graph shard batches across generations

### DIFF
--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -75,8 +75,12 @@ import {codeGraphRequestBuildLockPath, codeGraphSnapshotBuildLockPath, type Code
 import {compareCodeUnits} from './ordering.js';
 import {
   CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION,
-  materializedShardDerivationIdentity,
+  materializedBatchShardDerivationIdentity,
+  materializedFileShardIdentity,
+  materializedShardRepositorySemanticEnvelope,
+  shardDonorIds,
   type CodeGraphDirectPersistentCapacityProtector,
+  type CodeGraphMaterializedShardAssociationBatch,
   type CodeGraphRetiredSnapshotCleanupProgress,
   type CodeGraphReusableCleanBase,
   type CodeGraphStagingProgress,
@@ -1196,11 +1200,9 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
   }
   if (!incrementalApplied) {
     const attributeFacts = createCachedCodeGraphFactsAttributor(input.inventory.files, workspace);
-    const shardDerivationIdentity = materializedShardDerivationIdentity(
-      input.building.extractorSet,
-      workspace.fingerprint,
-      graphContentIdentity(input.building.extractorSet, input.inventory.files),
-    );
+    const currentGraphContentId = graphContentIdentity(input.building.extractorSet, input.inventory.files);
+    const repositorySemanticEnvelope = materializedShardRepositorySemanticEnvelope(input.inventory.files);
+    const donorSnapshotIds = shardDonorIds(input.building.id, input.committedBase?.snapshot.id, input.existing?.id);
     const sourceBytesTotal = input.inventory.files.reduce((total, file) => total + file.size, 0);
     const cachedMetadata = yield* cachedFactsMetadata(
       input.store,
@@ -1392,6 +1394,19 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       readonly symbols: readonly CodeGraphSymbol[];
     }
     const pendingBatches: PendingMaterializationBatch[] = [];
+    const pendingShardAssociationBatches: CodeGraphMaterializedShardAssociationBatch[] = [];
+    const flushPendingShardAssociations = () =>
+      Effect.gen(function* () {
+        if (pendingShardAssociationBatches.length === 0) return;
+        const group = pendingShardAssociationBatches.splice(0, pendingShardAssociationBatches.length);
+        yield* input.store.associateMaterializedFileShardBatches(
+          input.layout.databasePath,
+          input.building.id,
+          input.persistentOwnerToken!,
+          group,
+          protectDirectPersistentWrite,
+        );
+      });
     const reportStagingProgress = (batch: PendingMaterializationBatch, progress: CodeGraphStagingProgress) => {
       if (progress.temporaryDatabaseBytes !== undefined) {
         temporaryDatabaseBytes = progress.temporaryDatabaseBytes;
@@ -1503,6 +1518,12 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         }
       });
     for (const files of batches) {
+      const shardDerivationIdentity = materializedBatchShardDerivationIdentity(
+        input.building.extractorSet,
+        workspace.fingerprint,
+        repositorySemanticEnvelope,
+        files,
+      );
       const sourceBytes = files.reduce((total, file) => total + file.size, 0);
       yield* input.onProgress?.({
         activity: {
@@ -1524,20 +1545,37 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       // reexports). Reuse the batch only as a complete unit; otherwise replay
       // and reattribute every raw peer so a hit/miss partition cannot become a
       // persisted derivation input.
-      const materializedShards = yield* input.store.loadMaterializedFileShards(
-        input.layout.databasePath,
-        files,
-        input.building.extractorSet,
-        shardDerivationIdentity,
-      );
-      const materializedShardBatchComplete = materializedShards.facts.size === files.length;
+      const materializedShards = directPersistentMaterialization
+        ? yield* input.store.loadMaterializedFileShards(
+            input.layout.databasePath,
+            files,
+            input.building.extractorSet,
+            shardDerivationIdentity,
+            {currentGraphContentId, snapshotIds: donorSnapshotIds},
+          )
+        : {
+            bytes: 0,
+            bytesByPath: new Map<string, number>(),
+            exactGenerationFiles: 0,
+            facts: new Map(),
+            materializedShardIdsByPath: new Map<string, string>(),
+          };
+      const exactGenerationShardFiles = materializedShards.exactGenerationFiles;
+      const materializedShardBatchComplete =
+        directPersistentMaterialization &&
+        exactGenerationShardFiles !== undefined &&
+        Number.isSafeInteger(exactGenerationShardFiles) &&
+        exactGenerationShardFiles >= 0 &&
+        exactGenerationShardFiles <= files.length &&
+        materializedShards.facts.size === files.length &&
+        materializedShards.materializedShardIdsByPath?.size === files.length;
       const fallbackFiles = materializedShardBatchComplete ? [] : files;
       const cached = yield* loadCachedFacts(input.store, input.layout.databasePath, fallbackFiles, input.languagePacks);
-      // Count every decoded cache payload, including valid final shards that
-      // were inspected before an incomplete batch fell back to all raw facts.
+      // Count valid final-shard decodes even when an incomplete batch falls back to raw facts.
       const batchReplayBytes = Math.min(Number.MAX_SAFE_INTEGER, materializedShards.bytes + cached.bytes);
       replayMetrics = addMaterializationReplayMetrics(replayMetrics, {
-        exactGenerationShardFiles: materializedShardBatchComplete ? files.length : 0,
+        crossGenerationShardFiles: materializedShardBatchComplete ? files.length - exactGenerationShardFiles : 0,
+        exactGenerationShardFiles: materializedShardBatchComplete ? exactGenerationShardFiles : 0,
         materializedShardReplayBytes: materializedShards.bytes,
         rawFactReplayBytes: cached.bytes,
       });
@@ -1582,7 +1620,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
         fallbackFiles.map(file => input.languagePacks.postprocessFile(file, cached.facts.get(file.path)!)),
       );
       replayMetrics = addMaterializationReplayMetrics(replayMetrics, {attributedFiles: fallbackFiles.length});
-      if (fallbackFiles.length > 0) {
+      if (fallbackFiles.length > 0 && directPersistentMaterialization) {
         yield* input.store.cacheMaterializedFileShards(
           input.layout.databasePath,
           fallbackFiles,
@@ -1591,6 +1629,30 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
           shardDerivationIdentity,
           protectDirectPersistentWrite,
         );
+      }
+      if (directPersistentMaterialization) {
+        const selectedShardIds = materializedShardBatchComplete
+          ? materializedShards.materializedShardIdsByPath!
+          : new Map(
+              files.map(file => [
+                file.path,
+                materializedFileShardIdentity(
+                  file.contentHash,
+                  input.building.extractorSet,
+                  shardDerivationIdentity,
+                  file.path,
+                ),
+              ]),
+            );
+        pendingShardAssociationBatches.push({
+          derivationIdentity: shardDerivationIdentity,
+          extractorSet: input.building.extractorSet,
+          files,
+          selectedShardIds,
+        });
+        if (pendingShardAssociationBatches.length >= persistentTransactionBatchLimit) {
+          yield* flushPendingShardAssociations();
+        }
       }
       const attributedFallbackByPath = new Map(attributedFallbackFacts.map(fact => [fact.path, fact]));
       const facts = files.map(file =>
@@ -1692,6 +1754,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       }
     }
     yield* flushPendingBatches();
+    yield* flushPendingShardAssociations();
     batchesTotal = persistentBatchCursor;
     if (directPersistentMaterialization) {
       yield* input.store.finalizePersistentMaterializationPlan(
@@ -1774,6 +1837,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
           ).pipe(Effect.catch(() => Effect.void)),
         persistentCapacityGuard,
         input.languagePacks.activePackProvenance(input.inventory.files.map(file => file.path)),
+        directPersistentMaterialization && !incrementalApplied,
       ),
       lease =>
         Option.match(lease, {

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -51,6 +51,7 @@ export {codeGraphPersistentExtensionSchemaCompatible} from './store_schema_inspe
 export {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION} from './types.js';
 export {nextPersistentActivationBatchRows} from './store_activation_core.js';
 export {codeGraphPersistedEndpointValidationPageStatement} from './store_activation_persistent.js';
+export {persistentFullShardPublicationPlan} from './store_activation_persistent.js';
 export {
   codeGraphAnalysisEdgeAggregatePageStatement,
   codeGraphAnalysisSummaryDigest,
@@ -60,8 +61,11 @@ export {CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION} from './store_build_core.js';
 export {codeGraphCompactLexicalDeepAuditStatement} from './store_build_preparation.js';
 export {
   codeGraphMaterializedShardAssociationPageStatement,
+  materializedBatchShardDerivationIdentity,
   materializedFileShardIdentity,
+  materializedShardRepositorySemanticEnvelope,
   materializedShardDerivationIdentity,
+  shardDonorIds,
 } from './store_cache.js';
 export {
   codeGraphCompactLexicalCleanupPageStatement,
@@ -81,7 +85,11 @@ export {
   isCanonicalAbsoluteBazelLabel,
   type CodeGraphSymbolPathClass,
 } from './store_query_core.js';
-export {codeGraphEffectiveSymbolTermsQueryStatement, codeGraphTermCandidateQueryStatement} from './store_queries.js';
+export {
+  codeGraphCompleteMaterializedShardDonorStatement,
+  codeGraphEffectiveSymbolTermsQueryStatement,
+  codeGraphTermCandidateQueryStatement,
+} from './store_queries.js';
 export {
   codeGraphRemovedViewCleanupAdmissionPageStatement,
   codeGraphRemovedViewCleanupDuePageStatement,

--- a/src/code_graph/store_activation_persistent.ts
+++ b/src/code_graph/store_activation_persistent.ts
@@ -1,6 +1,10 @@
 import {Effect, Option} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
-import {saturatingCapacityAdd, type CodeGraphDirectPersistentCapacityBoundary} from './disk_capacity.js';
+import {
+  saturatingCapacityAdd,
+  saturatingCapacityMultiply,
+  type CodeGraphDirectPersistentCapacityBoundary,
+} from './disk_capacity.js';
 import {
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   type CodeGraphActivationProgressCallback,
@@ -578,6 +582,37 @@ const drainCompletedPersistentBuildRows = Effect.fn('codeGraph.drainCompletedPer
   return {deleted: totalDeleted, remaining};
 });
 
+export function persistentFullShardPublicationPlan(
+  fileCount: number,
+  materializedFileShardAssociationsComplete: boolean,
+  snapshotPackProvenanceCount: number,
+): {
+  readonly associateLegacyMaterializedFileShards: boolean;
+  readonly rowCount: number;
+} {
+  if (
+    !Number.isSafeInteger(fileCount) ||
+    fileCount < 0 ||
+    !Number.isSafeInteger(snapshotPackProvenanceCount) ||
+    snapshotPackProvenanceCount < 0
+  ) {
+    return {
+      associateLegacyMaterializedFileShards: !materializedFileShardAssociationsComplete,
+      rowCount: Number.NaN,
+    };
+  }
+  // Publication replaces pack provenance. Count both the prior-row deletes
+  // and the replacement inserts so a retry or recovered building snapshot
+  // cannot understate the transaction's physical write demand.
+  const fixedRowCount = saturatingCapacityAdd(6, saturatingCapacityMultiply(snapshotPackProvenanceCount, 2));
+  return materializedFileShardAssociationsComplete
+    ? {associateLegacyMaterializedFileShards: false, rowCount: fixedRowCount}
+    : {
+        associateLegacyMaterializedFileShards: true,
+        rowCount: saturatingCapacityAdd(fileCount, fixedRowCount),
+      };
+}
+
 const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFullSnapshot')(function* (
   sql: SqlClient.SqlClient,
   identity: RepositoryIdentity,
@@ -589,6 +624,7 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
   writerGate?: CodeGraphWriterGate,
   persistentCapacityProtector?: CodeGraphDirectPersistentCapacityProtector,
   snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
+  materializedFileShardAssociationsComplete = false,
 ) {
   const runWrite: CodeGraphWriterGate = writerGate ?? (effect => effect);
   const observe = activationProgressObserver(onProgress);
@@ -665,16 +701,19 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
   yield* configurePublicationDurability(sql);
   yield* observe('recording-completion', 'started');
   yield* observe('committing-snapshot', 'started');
+  const shardPublicationPlan = persistentFullShardPublicationPlan(
+    snapshot.fileCount,
+    materializedFileShardAssociationsComplete,
+    snapshotPackProvenance?.length ?? 0,
+  );
   const publicationCapacity: CodeGraphDirectPersistentCapacityBoundary = {
     finalFactBytes: 0,
     operation: 'publish persistent code graph snapshot',
-    // File-shard association can publish one row per inventory file. The six
-    // fixed rows conservatively cover lexical/extractor/reuse/lease receipts,
-    // the ready-state update, and build-owner deletion.
-    rowCount:
-      Number.isSafeInteger(snapshot.fileCount) && snapshot.fileCount >= 0
-        ? saturatingCapacityAdd(snapshot.fileCount, 6)
-        : Number.NaN,
+    // V4 rows were associated by bounded materialization batches. Legacy
+    // callers can still publish one v3 association per inventory file. The
+    // Fixed rows cover lexical/extractor/reuse/lease receipts, the ready state
+    // update, build-owner deletion, and pack-provenance delete/insert writes.
+    rowCount: shardPublicationPlan.rowCount,
   };
   let readyTransactionStartedAt = 0;
   const readyTransaction = Effect.suspend(() => {
@@ -685,7 +724,9 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
           yield* assertPersistentBuildOwner(sql, snapshot.id, ownerToken);
           yield* assertPersistentMaterializationComplete(sql, snapshot.id, ownerToken);
           yield* publishCompactLexicalFormat(sql, snapshot.id, compactLexicalReceipt);
-          yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
+          if (shardPublicationPlan.associateLegacyMaterializedFileShards) {
+            yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
+          }
           yield* recordSnapshotExtractorGeneration(sql, snapshot.id);
           if (snapshotPackProvenance !== undefined) {
             yield* recordSnapshotPackProvenance(sql, snapshot.id, snapshotPackProvenance);

--- a/src/code_graph/store_cache.ts
+++ b/src/code_graph/store_cache.ts
@@ -23,6 +23,7 @@ import {useDatabase} from './store_session.js';
 import {type CodeGraphInventoryFile, type CodeGraphSnapshot, CodeGraphStoreError} from './types.js';
 import {CodeGraphCacheCapacityPlanChanged} from './store_internal_models.js';
 import {lastStatementChangeCount} from './store_activation_core.js';
+import {assertPersistentBuildOwner} from './store_build_core.js';
 
 interface PlannedFreshFactCacheRow extends CodeGraphCacheCapacityRow {
   readonly blobId?: string;
@@ -108,6 +109,57 @@ export function materializedShardDerivationIdentity(
   ).slice(0, 40)}`;
 }
 
+type MaterializedShardRepositoryEnvelopeFile = Pick<
+  CodeGraphInventoryFile,
+  'contentHash' | 'language' | 'mode' | 'path' | 'source'
+>;
+
+function retainedMaterializationContext(path: string): boolean {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  return name.toLowerCase() === 'package.json' || /^tsconfig(?:\.[^/]+)?\.json$/iu.test(name);
+}
+
+/**
+ * Captures every repository path that can affect attribution, while retaining
+ * content only for manifests consumed outside the deterministic source batch.
+ * Ordinary source bodies are intentionally represented by their batch key.
+ */
+export function materializedShardRepositorySemanticEnvelope(
+  files: readonly MaterializedShardRepositoryEnvelopeFile[],
+): string {
+  const entries = [...files]
+    .sort((left, right) => compareCodeUnits(left.path, right.path))
+    .map(file => [
+      file.path,
+      file.language,
+      file.mode,
+      retainedMaterializationContext(file.path) ? file.contentHash : null,
+    ]);
+  return `cgfe_${sha256HexSync(`materialized-repository-semantic-envelope-v1\n${JSON.stringify(entries)}`).slice(
+    0,
+    40,
+  )}`;
+}
+
+/**
+ * V4 final-fact derivation identity. The ordered batch is part of the key so
+ * attribution never observes a hit/miss partition that differs from the one
+ * that originally produced the shard rows.
+ */
+export function materializedBatchShardDerivationIdentity(
+  extractorSet: string,
+  workspaceFingerprint: string,
+  repositorySemanticEnvelope: string,
+  files: readonly MaterializedShardRepositoryEnvelopeFile[],
+): string {
+  const orderedBatchMembers = files.map(file => [file.path, file.contentHash, file.language, file.mode, file.source]);
+  return `cgfd_${sha256HexSync(
+    `materialized-file-derivation-v4\n${extractorSet}\n${workspaceFingerprint}\n${repositorySemanticEnvelope}\n${JSON.stringify(
+      orderedBatchMembers,
+    )}`,
+  ).slice(0, 40)}`;
+}
+
 export function materializedFileShardIdentity(
   contentHash: string,
   extractorSet: string,
@@ -118,6 +170,73 @@ export function materializedFileShardIdentity(
     `materialized-file-shard-v1\n${contentHash}\n${extractorSet}\n${derivationIdentity}\n${path}`,
   ).slice(0, 40)}`;
 }
+
+export function shardDonorIds(...candidates: readonly (string | undefined)[]): readonly string[] {
+  return [...new Set(candidates.filter((value): value is string => value !== undefined))].slice(0, 2);
+}
+
+const associateMaterializedFileShardBatch = Effect.fn('codeGraph.associateMaterializedFileShardBatch')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  ownerToken: string,
+  files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[],
+  extractorSet: string,
+  derivationIdentity: string,
+  selectedShardIds: ReadonlyMap<string, string>,
+) {
+  if (
+    files.length === 0 ||
+    new Set(files.map(file => file.path)).size !== files.length ||
+    selectedShardIds.size !== files.length
+  ) {
+    return yield* Effect.fail(new CodeGraphStoreError('Materialized file shard batch association is incomplete.'));
+  }
+  const expected = files.map(file => ({
+    contentHash: file.contentHash,
+    id: materializedFileShardIdentity(file.contentHash, extractorSet, derivationIdentity, file.path),
+    path: file.path,
+  }));
+  if (expected.some(row => selectedShardIds.get(row.path) !== row.id)) {
+    return yield* Effect.fail(new CodeGraphStoreError('Materialized file shard batch selection changed.'));
+  }
+
+  yield* assertPersistentBuildOwner(sql, snapshotId, ownerToken);
+  const requested = JSON.stringify(expected);
+  const rows = yield* sql<{
+    readonly content_hash: string;
+    readonly id: string;
+    readonly path: string;
+  }>`
+    SELECT shard.id, file.path, file.content_hash
+    FROM json_each(${requested}) AS requested
+    JOIN snapshot_files AS file
+      ON file.snapshot_id = ${snapshotId}
+     AND file.path = json_extract(requested.value, '$.path')
+     AND file.content_hash = json_extract(requested.value, '$.contentHash')
+    JOIN materialized_file_shards AS shard
+      ON shard.id = json_extract(requested.value, '$.id')
+     AND shard.content_hash = file.content_hash
+     AND shard.path_hint = file.path
+     AND shard.extractor_set = ${extractorSet}
+     AND shard.derivation_identity = ${derivationIdentity}
+  `;
+  const stored = new Map(rows.map(row => [row.path, row]));
+  if (
+    stored.size !== expected.length ||
+    expected.some(row => {
+      const actual = stored.get(row.path);
+      return actual?.id !== row.id || actual.content_hash !== row.contentHash;
+    })
+  ) {
+    return yield* Effect.fail(new CodeGraphStoreError('Materialized file shard batch is unavailable.'));
+  }
+  yield* sql.unsafe(
+    `INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id)
+     VALUES ${expected.map(() => '(?, ?, ?)').join(', ')}
+     ON CONFLICT(snapshot_id, path) DO UPDATE SET shard_id = excluded.shard_id`,
+    expected.flatMap(row => [snapshotId, row.path, row.id]),
+  );
+});
 
 const associateSnapshotFileShards = Effect.fn('codeGraph.associateSnapshotFileShards')(function* (
   sql: SqlClient.SqlClient,
@@ -140,7 +259,7 @@ const associateSnapshotFileShards = Effect.fn('codeGraph.associateSnapshotFileSh
      AND shard.extractor_set = ${snapshot.extractorSet}
      AND shard.derivation_identity = ${derivationIdentity}
     WHERE file.snapshot_id = ${snapshot.id}
-    ON CONFLICT(snapshot_id, path) DO UPDATE SET shard_id = excluded.shard_id
+    ON CONFLICT(snapshot_id, path) DO NOTHING
   `;
 });
 
@@ -744,6 +863,7 @@ export {
   MaterializedShardRepairPlan,
   storeNormalMaterializedShardRows,
   validMaterializedShardText,
+  associateMaterializedFileShardBatch,
   associateSnapshotFileShards,
   MaterializedShardCacheWriteInput,
   writeNormalMaterializedShardCacheRows,

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -37,6 +37,13 @@ export interface CodeGraphLanguagePackProvenance {
   readonly resolutionVersion: string;
 }
 
+export interface CodeGraphMaterializedShardAssociationBatch {
+  readonly derivationIdentity: string;
+  readonly extractorSet: string;
+  readonly files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[];
+  readonly selectedShardIds: ReadonlyMap<string, string>;
+}
+
 export interface CodeGraphReusableBaseReceipt extends CodeGraphReusableBaseReceiptInput {
   readonly aliasCount: number;
   readonly formatVersion: number;
@@ -206,9 +213,13 @@ export interface LoadedCodeGraphFacts {
   /** UTF-8 bytes occupied by the successfully decoded cached fact payloads. */
   readonly bytes: number;
   readonly bytesByPath?: ReadonlyMap<string, number>;
+  /** Materialized shard paths with provenance in the current graph-content generation. */
+  readonly exactGenerationFiles?: number;
   readonly facts: ReadonlyMap<string, CodeGraphFileFacts>;
   /** Paths represented by stored rows, also populated for metadata-only reads. */
   readonly keys?: ReadonlySet<string>;
+  /** Stable shard IDs selected for each decoded materialized path. */
+  readonly materializedShardIdsByPath?: ReadonlyMap<string, string>;
 }
 
 export type CodeGraphStagingStage =

--- a/src/code_graph/store_queries.ts
+++ b/src/code_graph/store_queries.ts
@@ -602,15 +602,106 @@ const selectCachedFacts = Effect.fn('codeGraph.selectCachedFacts')(function* (
   return {bytes, bytesByPath, facts: output, keys} satisfies LoadedCodeGraphFacts;
 });
 
+interface MaterializedShardDonor {
+  readonly exactGeneration: boolean;
+  readonly snapshotId: string;
+}
+
+/** @internal Exposed so regression tests can verify the requested-first access plan. */
+export function codeGraphCompleteMaterializedShardDonorStatement(
+  snapshotId: string,
+  files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[],
+  extractorSet: string,
+  derivationIdentity: string,
+): CodeGraphSqlQueryStatement {
+  const requested = JSON.stringify(
+    files.map(file => ({
+      contentHash: file.contentHash,
+      id: materializedFileShardIdentity(file.contentHash, extractorSet, derivationIdentity, file.path),
+      path: file.path,
+    })),
+  );
+  return {
+    parameters: [requested, snapshotId, extractorSet, derivationIdentity],
+    text: `SELECT COUNT(*) AS association_count,
+                  COALESCE(snapshot.graph_content_id, snapshot.id) AS graph_content_id
+           FROM json_each(?) AS requested
+           CROSS JOIN snapshots AS snapshot
+           CROSS JOIN snapshot_file_shards AS association
+           CROSS JOIN materialized_file_shards AS shard
+           WHERE snapshot.id = ?
+             AND snapshot.extractor_set = ?
+             AND association.snapshot_id = snapshot.id
+             AND association.path = json_extract(requested.value, '$.path')
+             AND shard.id = association.shard_id
+             AND shard.id = json_extract(requested.value, '$.id')
+             AND shard.content_hash = json_extract(requested.value, '$.contentHash')
+             AND shard.path_hint = association.path
+             AND shard.extractor_set = snapshot.extractor_set
+             AND shard.derivation_identity = ?
+           GROUP BY snapshot.id, snapshot.graph_content_id`,
+  };
+}
+
+const selectCompleteMaterializedShardDonor = Effect.fn('codeGraph.selectCompleteMaterializedShardDonor')(function* (
+  sql: SqlClient.SqlClient,
+  files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[],
+  extractorSet: string,
+  derivationIdentity: string,
+  currentGraphContentId: string,
+  snapshotIds: readonly string[],
+) {
+  if (files.length === 0 || new Set(files.map(file => file.path)).size !== files.length) return undefined;
+  for (const snapshotId of [...new Set(snapshotIds)].slice(0, 2)) {
+    const statement = codeGraphCompleteMaterializedShardDonorStatement(
+      snapshotId,
+      files,
+      extractorSet,
+      derivationIdentity,
+    );
+    const rows = yield* sql.unsafe<{
+      readonly association_count: number;
+      readonly graph_content_id: string;
+    }>(statement.text, statement.parameters);
+    const row = rows[0];
+    if (
+      row !== undefined &&
+      Number(row.association_count) === files.length &&
+      typeof row.graph_content_id === 'string'
+    ) {
+      return {
+        exactGeneration: row.graph_content_id === currentGraphContentId,
+        snapshotId,
+      } satisfies MaterializedShardDonor;
+    }
+  }
+  return undefined;
+});
+
 const selectMaterializedFileShards = Effect.fn('codeGraph.selectMaterializedFileShards')(function* (
   files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[],
   extractorSet: string,
   derivationIdentity: string,
+  provenance?: {
+    readonly currentGraphContentId: string;
+    readonly snapshotIds: readonly string[];
+  },
 ) {
   const sql = yield* SqlClient.SqlClient;
   yield* configureConnection(sql);
+  const donor = provenance
+    ? yield* selectCompleteMaterializedShardDonor(
+        sql,
+        files,
+        extractorSet,
+        derivationIdentity,
+        provenance.currentGraphContentId,
+        provenance.snapshotIds,
+      )
+    : undefined;
   const output = new Map<string, CodeGraphFileFacts>();
   const bytesByPath = new Map<string, number>();
+  const materializedShardIdsByPath = new Map<string, string>();
   const keys = new Set<string>();
   let bytes = 0;
   for (const batch of chunk(files, 200)) {
@@ -622,11 +713,26 @@ const selectMaterializedFileShards = Effect.fn('codeGraph.selectMaterializedFile
       readonly id: string;
       readonly path_hint: string;
     }>(
-      `SELECT id, content_hash, path_hint, facts_json, ${storedCodeGraphFactRawBytesSql('facts_json')} AS facts_bytes
-       FROM materialized_file_shards
-       WHERE extractor_set = ? AND derivation_identity = ?
-         AND (${batch.map(() => '(content_hash = ? AND path_hint = ?)').join(' OR ')})`,
-      [extractorSet, derivationIdentity, ...batch.flatMap(file => [file.contentHash, file.path])],
+      `SELECT shard.id, shard.content_hash, shard.path_hint, shard.facts_json,
+              ${storedCodeGraphFactRawBytesSql('shard.facts_json')} AS facts_bytes
+       FROM materialized_file_shards AS shard
+       ${
+         provenance === undefined
+           ? ''
+           : `JOIN snapshot_file_shards AS association
+                ON association.snapshot_id = ?
+               AND association.path = shard.path_hint
+               AND association.shard_id = shard.id`
+       }
+       WHERE shard.extractor_set = ? AND shard.derivation_identity = ?
+         AND (${batch.map(() => '(shard.content_hash = ? AND shard.path_hint = ?)').join(' OR ')})
+         ${provenance !== undefined && donor === undefined ? 'AND 0' : ''}`,
+      [
+        ...(provenance === undefined ? [] : [donor?.snapshotId ?? '']),
+        extractorSet,
+        derivationIdentity,
+        ...batch.flatMap(file => [file.contentHash, file.path]),
+      ],
     );
     for (const row of rows) {
       const bounded = decodeStoredCodeGraphFactOption(row.facts_json, row.path_hint);
@@ -638,13 +744,21 @@ const selectMaterializedFileShards = Effect.fn('codeGraph.selectMaterializedFile
         continue;
       }
       output.set(row.path_hint, bounded.facts);
+      materializedShardIdsByPath.set(row.path_hint, row.id);
       keys.add(row.path_hint);
       const factBytes = bounded.bytes;
       bytes += factBytes;
       bytesByPath.set(row.path_hint, factBytes);
     }
   }
-  return {bytes, bytesByPath, facts: output, keys} satisfies LoadedCodeGraphFacts;
+  return {
+    bytes,
+    bytesByPath,
+    ...(provenance === undefined ? {} : {exactGenerationFiles: donor?.exactGeneration === true ? output.size : 0}),
+    facts: output,
+    keys,
+    materializedShardIdsByPath,
+  } satisfies LoadedCodeGraphFacts;
 });
 
 function decodeStoredCodeGraphFactOption(json: string, path: string) {

--- a/src/code_graph/store_service_data.ts
+++ b/src/code_graph/store_service_data.ts
@@ -286,10 +286,13 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
         ),
         Effect.mapError(cause => storeError('load cached code graph facts', cause)),
       ),
-    loadMaterializedFileShards: (databasePath, files, extractorSet, derivationIdentity) =>
+    loadMaterializedFileShards: (databasePath, files, extractorSet, derivationIdentity, provenance) =>
       prepare(databasePath).pipe(
         Effect.andThen(
-          useReadOnlyDatabase(databasePath, selectMaterializedFileShards(files, extractorSet, derivationIdentity)),
+          useReadOnlyDatabase(
+            databasePath,
+            selectMaterializedFileShards(files, extractorSet, derivationIdentity, provenance),
+          ),
         ),
         Effect.mapError(cause => storeError('load materialized code graph file shards', cause)),
       ),

--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -1,6 +1,8 @@
 import {Effect, Option} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import * as SqlError from 'effect/unstable/sql/SqlError';
+import {CODE_GRAPH_CACHE_TRANSACTION_LIMITS, codeGraphTextFieldsCapacityBytes} from './cache_capacity.js';
+import {saturatingCapacityAdd} from './disk_capacity.js';
 import {ensureBoundedCodeGraphFact} from './fact_budget.js';
 import {
   type CodeGraphSnapshotPurgeObservationResult,
@@ -36,6 +38,7 @@ import {
 } from './store_build_core.js';
 import {validateViewRemovalTarget, observeActiveView} from './store_reconciliation_core.js';
 import {
+  associateMaterializedFileShardBatch,
   cacheCapacityPlanningError,
   prepareFreshFactCacheChunks,
   storeFreshFactRows,
@@ -81,6 +84,7 @@ type CodeGraphStoreLifecycleMethods = Pick<
   | 'activateCleanSnapshotAlias'
   | 'cacheFacts'
   | 'cacheMaterializedFileShards'
+  | 'associateMaterializedFileShardBatches'
   | 'promote'
   | 'observeView'
   | 'observeSnapshotPurge'
@@ -341,6 +345,7 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
       onProgress,
       persistentCapacityProtector,
       snapshotPackProvenance,
+      materializedFileShardAssociationsComplete,
     ) =>
       Effect.gen(function* () {
         const activationPackProvenance = snapshotPackProvenance ?? reusableBaseReceipt?.packProvenance;
@@ -392,6 +397,7 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
                 effect => withWriterGate(databasePath, effect),
                 persistentCapacityProtector,
                 activationPackProvenance,
+                materializedFileShardAssociationsComplete,
               );
               return snapshot.id;
             }
@@ -504,6 +510,71 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
           });
         }
       }).pipe(Effect.mapError(cause => storeError('cache materialized code graph file shards', cause))),
+    associateMaterializedFileShardBatches: (
+      databasePath,
+      snapshotId,
+      ownerToken,
+      batches,
+      persistentCapacityProtector,
+    ) =>
+      Effect.gen(function* () {
+        const rowCount = batches.reduce((total, batch) => saturatingCapacityAdd(total, batch.files.length), 0);
+        if (batches.length === 0) return;
+        if (rowCount > CODE_GRAPH_CACHE_TRANSACTION_LIMITS.rows) {
+          return yield* Effect.fail(new CodeGraphStoreError('Materialized file shard association group is too large.'));
+        }
+        const finalFactBytes = batches.reduce(
+          (total, batch) =>
+            batch.files.reduce(
+              (batchTotal, file) =>
+                saturatingCapacityAdd(
+                  batchTotal,
+                  codeGraphTextFieldsCapacityBytes(snapshotId, file.path, batch.selectedShardIds.get(file.path) ?? ''),
+                ),
+              total,
+            ),
+          0,
+        );
+        if (finalFactBytes > CODE_GRAPH_CACHE_TRANSACTION_LIMITS.payloadBytes) {
+          return yield* Effect.fail(
+            new CodeGraphStoreError('Materialized file shard association group payload is too large.'),
+          );
+        }
+        yield* prepare(databasePath);
+        yield* persistentCapacityProtector(
+          {
+            finalFactBytes,
+            operation: 'cache materialized code graph file shards',
+            rowCount,
+          },
+          withWriterGate(
+            databasePath,
+            useDatabase(
+              databasePath,
+              Effect.gen(function* () {
+                const sql = yield* SqlClient.SqlClient;
+                yield* ensureSchemaInitialized(databasePath, sql);
+                yield* sql.withTransaction(
+                  Effect.forEach(
+                    batches,
+                    batch =>
+                      associateMaterializedFileShardBatch(
+                        sql,
+                        snapshotId,
+                        ownerToken,
+                        batch.files,
+                        batch.extractorSet,
+                        batch.derivationIdentity,
+                        batch.selectedShardIds,
+                      ),
+                    {discard: true},
+                  ),
+                );
+              }),
+            ),
+          ),
+        );
+      }).pipe(Effect.mapError(cause => storeError('associate materialized code graph file shard batches', cause))),
     promote: (databasePath, identity, snapshotId, options) =>
       Effect.gen(function* () {
         yield* prepare(databasePath);

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -16,6 +16,7 @@ import type {
   CodeGraphEdgeCursor,
   CodeGraphPersistentBuildClaim,
   CodeGraphLanguagePackProvenance,
+  CodeGraphMaterializedShardAssociationBatch,
   CodeGraphRemovedViewCleanupAuthorizationResult,
   CodeGraphRemovedViewCleanupEntry,
   CodeGraphRemovedViewCleanupStoreOptions,
@@ -102,6 +103,7 @@ export interface CodeGraphStoreShape {
     onProgress?: CodeGraphActivationProgressCallback,
     persistentCapacityProtector?: CodeGraphDirectPersistentCapacityProtector,
     snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
+    materializedFileShardAssociationsComplete?: boolean,
   ) => Effect.Effect<Option.Option<string>, CodeGraphStoreError>;
   readonly activateCleanSnapshotAlias?: (
     databasePath: string,
@@ -122,6 +124,13 @@ export interface CodeGraphStoreShape {
     facts: readonly CodeGraphCacheFactInput[],
     extractorSet: string,
     derivationIdentity: string,
+    persistentCapacityProtector: CodeGraphDirectPersistentCapacityProtector,
+  ) => Effect.Effect<void, CodeGraphStoreError>;
+  readonly associateMaterializedFileShardBatches: (
+    databasePath: string,
+    snapshotId: string,
+    ownerToken: string,
+    batches: readonly CodeGraphMaterializedShardAssociationBatch[],
     persistentCapacityProtector: CodeGraphDirectPersistentCapacityProtector,
   ) => Effect.Effect<void, CodeGraphStoreError>;
   readonly acquireSnapshotLease: (
@@ -250,6 +259,10 @@ export interface CodeGraphStoreShape {
     files: readonly Pick<CodeGraphInventoryFile, 'contentHash' | 'path'>[],
     extractorSet: string,
     derivationIdentity: string,
+    provenance?: {
+      readonly currentGraphContentId: string;
+      readonly snapshotIds: readonly string[];
+    },
   ) => Effect.Effect<LoadedCodeGraphFacts, CodeGraphStoreError>;
   readonly loadGraph: (databasePath: string, snapshotId: string) => Effect.Effect<StoredCodeGraph, CodeGraphStoreError>;
   readonly loadSymbols: (

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -54,7 +54,12 @@ import {
 } from '../../src/code_graph/maintenance.js';
 import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
 import {compactCodeGraphStorage} from '../../src/code_graph/storage.js';
-import {CodeGraphStore, type StoredCodeGraph} from '../../src/code_graph/store.js';
+import {
+  CodeGraphStore,
+  materializedFileShardIdentity,
+  materializedShardDerivationIdentity,
+  type StoredCodeGraph,
+} from '../../src/code_graph/store.js';
 import {
   CODE_GRAPH_SCHEMA_VERSION,
   CodeGraphStoreNoSpaceError,
@@ -1175,14 +1180,14 @@ describe('native code graph lifecycle', () => {
               INSERT INTO materialized_shard_write_audit VALUES ('delete', OLD.path_hint);
             END;
           `);
-          const reusedShardBytes =
+          const completeShardBytes =
             database
-              .query<{readonly bytes: number}, []>(
+              .query<{readonly bytes: number}, [string, string]>(
                 `SELECT COALESCE(SUM(${storedCodeGraphFactRawBytesSql('facts_json')}), 0) AS bytes
-                 FROM materialized_file_shards`,
+                 FROM materialized_file_shards WHERE path_hint NOT IN (?, ?)`,
               )
-              .get()?.bytes ?? 0;
-          return {missingPath: missing.path, rawFactBytes, reusedShardBytes};
+              .get('src/file-128.ts', 'src/file-129.ts')?.bytes ?? 0;
+          return {completeShardBytes, missingPath: missing.path, rawFactBytes};
         } finally {
           database.close();
         }
@@ -1219,12 +1224,12 @@ describe('native code graph lifecycle', () => {
 
       expect(rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 128 file(s).');
       expect(partialShardState.rawFactBytes).toBeGreaterThan(0);
-      expect(partialShardState.reusedShardBytes).toBeGreaterThan(0);
+      expect(partialShardState.completeShardBytes).toBeGreaterThan(0);
       expect(metrics.cachedFactReplayBytesCompleted).toBe(
-        partialShardState.rawFactBytes + partialShardState.reusedShardBytes,
+        partialShardState.rawFactBytes + partialShardState.completeShardBytes,
       );
       expect(metrics.rawFactReplayBytesCompleted).toBe(partialShardState.rawFactBytes);
-      expect(metrics.materializedShardReplayBytesCompleted).toBe(partialShardState.reusedShardBytes);
+      expect(metrics.materializedShardReplayBytesCompleted).toBe(partialShardState.completeShardBytes);
       expect(metrics.attributedFilesCompleted).toBe(2);
       expect(metrics.exactGenerationShardFilesCompleted).toBe(128);
       expect(metrics.crossGenerationShardFilesCompleted).toBe(0);
@@ -1291,9 +1296,9 @@ describe('native code graph lifecycle', () => {
 
       expect(replayState.changedRaw).toBeGreaterThan(0);
       expect(replayState.retainedShard).toBeGreaterThan(0);
-      expect(metrics.cachedFactReplayBytesCompleted).toBe(replayState.raw + replayState.retainedShard);
+      expect(metrics.cachedFactReplayBytesCompleted).toBe(replayState.raw);
       expect(metrics.rawFactReplayBytesCompleted).toBe(replayState.raw);
-      expect(metrics.materializedShardReplayBytesCompleted).toBe(replayState.retainedShard);
+      expect(metrics.materializedShardReplayBytesCompleted).toBe(0);
       expect(metrics.attributedFilesCompleted).toBe(2);
       expect(metrics.exactGenerationShardFilesCompleted).toBe(0);
       expect(metrics.crossGenerationShardFilesCompleted).toBe(0);
@@ -1349,6 +1354,363 @@ describe('native code graph lifecycle', () => {
       expect(call).toMatchObject({confidence: 1, provenance: 'resolved', targetId: expectedTarget!.id});
       expect(rebuiltCaller).toEqual(freshCaller);
       expect(normalizeStoredGraph(rebuiltGraph)).toEqual(normalizeStoredGraph(freshGraph));
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('reuses an unchanged ambient-overload batch across a body-only generation', () =>
+    Effect.gen(function* () {
+      const root = createAmbientOverloadBarrelRepository(126);
+      const reusedHome = temporaryDirectory('threadnote-code-graph-cross-generation-overload-');
+      const freshHome = temporaryDirectory('threadnote-code-graph-cross-generation-overload-fresh-');
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const first = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: reusedHome});
+      const changedPath = join(root, 'src/filler-125.ts');
+      yield* Effect.sync(() => {
+        writeFileSync(changedPath, readFileSync(changedPath, 'utf8').replace('return 125;', 'return 1125;'));
+      });
+      const progress: CodeGraphProgress[] = [];
+      const rebuilt = yield* indexer.index({
+        cwd: root,
+        ensureVectors: false,
+        force: true,
+        onProgress: current => Effect.sync(() => progress.push(current)),
+        threadnoteHome: reusedHome,
+      });
+      const fresh = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: freshHome});
+      const reusedDatabasePath = codeGraphDatabasePath(reusedHome, rebuilt);
+      const freshDatabasePath = codeGraphDatabasePath(freshHome, fresh);
+      const rebuiltGraph = yield* store.loadGraph(reusedDatabasePath, rebuilt.snapshot.id);
+      const freshGraph = yield* store.loadGraph(freshDatabasePath, fresh.snapshot.id);
+      const metrics = finalFullMaterializationMetrics(progress);
+      const freshTarget = freshGraph.symbols.find(
+        symbol => symbol.path === 'src/leaf.ts' && symbol.name === 'target' && symbol.arity === 2,
+      );
+      const rebuiltCall = rebuiltGraph.edges.find(
+        edge => edge.evidencePath === 'src/caller.ts' && edge.relation === 'calls',
+      );
+
+      expect(first.snapshot.graphContentId).not.toBe(rebuilt.snapshot.graphContentId);
+      expect(rebuilt.diagnostics).toContain('Reused content-addressed materialized shards for 128 file(s).');
+      expect(metrics.exactGenerationShardFilesCompleted).toBe(0);
+      expect(metrics.crossGenerationShardFilesCompleted).toBe(128);
+      expect(metrics.attributedFilesCompleted).toBe(2);
+      expect(metrics.rawFactReplayBytesCompleted).toBeGreaterThan(0);
+      expect(metrics.materializedShardReplayBytesCompleted).toBeGreaterThan(0);
+      expect(freshTarget).toBeDefined();
+      expect(rebuiltCall).toMatchObject({confidence: 1, provenance: 'resolved', targetId: freshTarget!.id});
+      expect(materializedShardFacts(reusedDatabasePath, 'src/caller.ts')).toEqual(
+        materializedShardFacts(freshDatabasePath, 'src/caller.ts'),
+      );
+      expect(normalizeStoredGraph(rebuiltGraph)).toEqual(normalizeStoredGraph(freshGraph));
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('invalidates every v4 batch when retained context or path membership changes', () =>
+    Effect.forEach(
+      [
+        {
+          label: 'package context',
+          mutate: (root: string) =>
+            writeFileSync(join(root, 'package.json'), `${JSON.stringify({name: 'ambient-overload-renamed'})}\n`),
+        },
+        {
+          label: 'tsconfig context',
+          mutate: (root: string) =>
+            writeFileSync(
+              join(root, 'tsconfig.json'),
+              `${JSON.stringify({compilerOptions: {baseUrl: '.', paths: {'@/*': ['src/*']}}})}\n`,
+            ),
+        },
+        {
+          label: 'path membership',
+          mutate: (root: string) => renameSync(join(root, 'src/leaf.ts'), join(root, 'src/renamed-leaf.ts')),
+        },
+      ] as const,
+      ({label, mutate}) =>
+        Effect.gen(function* () {
+          const root = createAmbientOverloadBarrelRepository();
+          const home = temporaryDirectory(`threadnote-code-graph-v4-invalidation-${label.replaceAll(' ', '-')}-`);
+          yield* Effect.sync(() => {
+            writeFileSync(join(root, 'tsconfig.json'), `${JSON.stringify({compilerOptions: {baseUrl: '.'}})}\n`);
+            git(root, ['add', 'tsconfig.json']);
+            git(root, [
+              '-c',
+              'user.name=Threadnote Test',
+              '-c',
+              'user.email=test@threadnote.local',
+              'commit',
+              '-qm',
+              'add retained attribution context',
+            ]);
+          });
+          const indexer = yield* CodeGraphIndexer;
+          yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: home});
+          yield* Effect.sync(() => {
+            mutate(root);
+            git(root, ['add', '-A']);
+            git(root, [
+              '-c',
+              'user.name=Threadnote Test',
+              '-c',
+              'user.email=test@threadnote.local',
+              'commit',
+              '-qm',
+              `change ${label}`,
+            ]);
+          });
+          const progress: CodeGraphProgress[] = [];
+          yield* indexer.index({
+            cwd: root,
+            ensureVectors: false,
+            force: true,
+            onProgress: current => Effect.sync(() => progress.push(current)),
+            threadnoteHome: home,
+          });
+          const metrics = finalFullMaterializationMetrics(progress);
+
+          expect(metrics.exactGenerationShardFilesCompleted, label).toBe(0);
+          expect(metrics.crossGenerationShardFilesCompleted, label).toBe(0);
+          expect(metrics.attributedFilesCompleted, label).toBe(5);
+          expect(metrics.materializedShardReplayBytesCompleted, label).toBe(0);
+          expect(metrics.rawFactReplayBytesCompleted, label).toBeGreaterThan(0);
+        }),
+      {concurrency: 1},
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('fails closed on partial association provenance or malformed v4 payloads', () =>
+    Effect.forEach(
+      [
+        {
+          label: 'partial association',
+          mutate: (database: Database, snapshotId: string) => {
+            expect(
+              database
+                .query('DELETE FROM snapshot_file_shards WHERE snapshot_id = ? AND path = ?')
+                .run(snapshotId, 'src/file-001.ts').changes,
+            ).toBe(1);
+          },
+        },
+        {
+          label: 'malformed payload',
+          mutate: (database: Database) => {
+            expect(
+              database
+                .query("UPDATE materialized_file_shards SET facts_json = '{' WHERE path_hint = ?")
+                .run('src/file-001.ts').changes,
+            ).toBe(1);
+          },
+        },
+      ] as const,
+      ({label, mutate}) =>
+        Effect.gen(function* () {
+          const root = createManySourceRepository(2);
+          const home = temporaryDirectory(`threadnote-code-graph-v4-fail-closed-${label.replaceAll(' ', '-')}-`);
+          const indexer = yield* CodeGraphIndexer;
+          const store = yield* CodeGraphStore;
+          const first = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: home});
+          const databasePath = codeGraphDatabasePath(home, first);
+          const firstGraph = yield* store.loadGraph(databasePath, first.snapshot.id);
+          yield* Effect.sync(() => {
+            const database = new Database(databasePath);
+            try {
+              mutate(database, first.snapshot.id);
+            } finally {
+              database.close();
+            }
+          });
+          const progress: CodeGraphProgress[] = [];
+          const rebuilt = yield* indexer.index({
+            cwd: root,
+            ensureVectors: false,
+            force: true,
+            onProgress: current => Effect.sync(() => progress.push(current)),
+            threadnoteHome: home,
+          });
+          const rebuiltGraph = yield* store.loadGraph(databasePath, rebuilt.snapshot.id);
+          const metrics = finalFullMaterializationMetrics(progress);
+
+          expect(metrics.exactGenerationShardFilesCompleted, label).toBe(0);
+          expect(metrics.crossGenerationShardFilesCompleted, label).toBe(0);
+          expect(metrics.attributedFilesCompleted, label).toBe(2);
+          expect(metrics.rawFactReplayBytesCompleted, label).toBeGreaterThan(0);
+          expect(
+            rebuilt.diagnostics.some(value => value.startsWith('Reused content-addressed materialized shards')),
+          ).toBe(false);
+          expect(normalizeStoredGraph(rebuiltGraph), label).toEqual(normalizeStoredGraph(firstGraph));
+        }),
+      {concurrency: 1},
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('does not synthesize one complete batch from complementary partial donors', () =>
+    Effect.gen(function* () {
+      const root = createManySourceRepository(2);
+      const home = temporaryDirectory('threadnote-code-graph-complementary-shard-donors-');
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const first = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: home});
+      const databasePath = codeGraphDatabasePath(home, first);
+      const donor = yield* Effect.sync(() => {
+        const database = new Database(databasePath);
+        try {
+          const rows = database
+            .query<
+              {
+                readonly contentHash: string;
+                readonly derivationIdentity: string;
+                readonly extractorSet: string;
+                readonly id: string;
+                readonly path: string;
+              },
+              []
+            >(
+              `SELECT id, content_hash AS contentHash, extractor_set AS extractorSet,
+                      derivation_identity AS derivationIdentity, path_hint AS path
+               FROM materialized_file_shards ORDER BY path_hint`,
+            )
+            .all();
+          expect(rows).toHaveLength(2);
+          expect(new Set(rows.map(row => row.derivationIdentity)).size).toBe(1);
+          const secondSnapshotId = 'cgsn_complementary_partial_donor';
+          database
+            .query(
+              `INSERT INTO snapshots (
+                 id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id,
+                 extractor_set, dirty, overlay_fingerprint, state, file_count, symbol_count,
+                 edge_count, started_at, completed_at, failure_summary
+               )
+               SELECT ?, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id,
+                      extractor_set, dirty, overlay_fingerprint, state, file_count, symbol_count,
+                      edge_count, started_at, completed_at, failure_summary
+               FROM snapshots WHERE id = ?`,
+            )
+            .run(secondSnapshotId, first.snapshot.id);
+          database
+            .query('INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id) VALUES (?, ?, ?)')
+            .run(secondSnapshotId, rows[1]!.path, rows[1]!.id);
+          expect(
+            database
+              .query('DELETE FROM snapshot_file_shards WHERE snapshot_id = ? AND path = ?')
+              .run(first.snapshot.id, rows[1]!.path).changes,
+          ).toBe(1);
+          return {
+            derivationIdentity: rows[0]!.derivationIdentity,
+            extractorSet: rows[0]!.extractorSet,
+            files: rows.map(row => ({contentHash: row.contentHash, path: row.path})),
+            secondSnapshotId,
+          };
+        } finally {
+          database.close();
+        }
+      });
+      const loaded = yield* store.loadMaterializedFileShards(
+        databasePath,
+        donor.files,
+        donor.extractorSet,
+        donor.derivationIdentity,
+        {
+          currentGraphContentId: first.snapshot.graphContentId ?? first.snapshot.id,
+          snapshotIds: [first.snapshot.id, donor.secondSnapshotId],
+        },
+      );
+
+      expect(loaded.facts.size).toBe(0);
+      expect(loaded.materializedShardIdsByPath?.size).toBe(0);
+      expect(loaded.exactGenerationFiles).toBe(0);
+      expect(loaded.bytes).toBe(0);
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('does not admit associated v3 shard rows into a v4 materialization batch', () =>
+    Effect.gen(function* () {
+      const root = createManySourceRepository(2);
+      const home = temporaryDirectory('threadnote-code-graph-v3-shard-ineligible-');
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const first = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: home});
+      const databasePath = codeGraphDatabasePath(home, first);
+      const receipt = yield* store.reusableBaseReceipt(databasePath, first.snapshot.id);
+      if (!receipt) return yield* Effect.fail(new TestError('Expected a reusable base receipt.'));
+      const v3Derivation = materializedShardDerivationIdentity(
+        first.snapshot.extractorSet,
+        receipt.workspaceFingerprint,
+        first.snapshot.graphContentId ?? first.snapshot.id,
+      );
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath);
+        try {
+          const rows = database
+            .query<
+              {
+                readonly contentHash: string;
+                readonly extractorSet: string;
+                readonly factsJson: string;
+                readonly path: string;
+              },
+              []
+            >(
+              `SELECT content_hash AS contentHash, extractor_set AS extractorSet,
+                      facts_json AS factsJson, path_hint AS path
+               FROM materialized_file_shards ORDER BY path_hint`,
+            )
+            .all();
+          expect(rows).toHaveLength(2);
+          database.query('DELETE FROM snapshot_file_shards WHERE snapshot_id = ?').run(first.snapshot.id);
+          database.exec('DELETE FROM materialized_file_shards');
+          const insertShard = database.prepare(
+            `INSERT INTO materialized_file_shards (
+               id, content_hash, extractor_set, derivation_identity, path_hint,
+               facts_json, created_at, last_used_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          );
+          const associate = database.prepare(
+            'INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id) VALUES (?, ?, ?)',
+          );
+          for (const row of rows) {
+            const id = materializedFileShardIdentity(row.contentHash, row.extractorSet, v3Derivation, row.path);
+            const now = new Date().toISOString();
+            insertShard.run(id, row.contentHash, row.extractorSet, v3Derivation, row.path, row.factsJson, now, now);
+            associate.run(first.snapshot.id, row.path, id);
+          }
+        } finally {
+          database.close();
+        }
+      });
+      const progress: CodeGraphProgress[] = [];
+      const rebuilt = yield* indexer.index({
+        cwd: root,
+        ensureVectors: false,
+        force: true,
+        onProgress: current => Effect.sync(() => progress.push(current)),
+        threadnoteHome: home,
+      });
+      const metrics = finalFullMaterializationMetrics(progress);
+      const selectedDerivations = yield* Effect.sync(() => {
+        const database = new Database(databasePath, {readonly: true});
+        try {
+          return database
+            .query<{readonly derivation: string}, [string]>(
+              `SELECT DISTINCT shard.derivation_identity AS derivation
+               FROM snapshot_file_shards AS association
+               JOIN materialized_file_shards AS shard ON shard.id = association.shard_id
+               WHERE association.snapshot_id = ?`,
+            )
+            .all(rebuilt.snapshot.id)
+            .map(row => row.derivation);
+        } finally {
+          database.close();
+        }
+      });
+
+      expect(metrics.exactGenerationShardFilesCompleted).toBe(0);
+      expect(metrics.crossGenerationShardFilesCompleted).toBe(0);
+      expect(metrics.attributedFilesCompleted).toBe(2);
+      expect(metrics.materializedShardReplayBytesCompleted).toBe(0);
+      expect(metrics.rawFactReplayBytesCompleted).toBeGreaterThan(0);
+      expect(selectedDerivations).toHaveLength(1);
+      expect(selectedDerivations).not.toContain(v3Derivation);
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
@@ -5084,7 +5446,7 @@ function createManySourceRepository(count: number): string {
   return root;
 }
 
-function createAmbientOverloadBarrelRepository(): string {
+function createAmbientOverloadBarrelRepository(fillerCount = 0): string {
   const root = temporaryDirectory('threadnote-code-graph-ambient-overload-barrel-');
   mkdirSync(join(root, 'src'), {recursive: true});
   git(root, ['init', '-q']);
@@ -5099,6 +5461,12 @@ function createAmbientOverloadBarrelRepository(): string {
     join(root, 'src/caller.ts'),
     'import {target} from "./barrel";\nexport const result = target("x", "y");\n',
   );
+  for (let index = 0; index < fillerCount; index += 1) {
+    writeFileSync(
+      join(root, `src/filler-${String(index).padStart(3, '0')}.ts`),
+      `export function filler${index}(): number { return ${index}; }\n`,
+    );
+  }
   git(root, ['add', '.']);
   git(root, ['-c', 'user.name=Threadnote Test', '-c', 'user.email=test@threadnote.local', 'commit', '-qm', 'fixture']);
   return root;

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -4223,12 +4223,14 @@ describe('native code graph lifecycle', () => {
       expect(failure).toMatchObject({code: 'no-space', recovery: 'free-space'});
       // The parser cache coalesces the 128-row/2-row inventory callbacks into
       // one protected 130-row write before staging.
-      // Inventory and workspace each observe once. Facts allow one transaction,
-      // then observe pressure and the one bounded cleanup retry. Shared storage
-      // never spawns duplicate df or PowerShell probes at a boundary.
+      // Inventory and workspace each observe once. The two deterministic source
+      // batches each protect both their v4 shard write and owner-verified
+      // association write. Facts allow one transaction, then observe pressure
+      // and the one bounded cleanup retry. Shared storage never spawns duplicate
+      // df or PowerShell probes at a boundary.
       expect(Object.fromEntries(probes)).toEqual({
         'cache code graph file facts': probesPerObservation,
-        'cache materialized code graph file shards': probesPerObservation * 2,
+        'cache materialized code graph file shards': probesPerObservation * 4,
         'stage persistent code graph facts': probesPerObservation * 3,
         'stage persistent code graph inventory': probesPerObservation,
         'stage persistent code graph workspace': probesPerObservation,
@@ -4416,11 +4418,13 @@ describe('native code graph lifecycle', () => {
       });
       // The parser cache coalesces the 128-row/2-row inventory callbacks into
       // one protected 130-row write before staging.
-      // The second fact boundary fails closed after one observation; unlike
-      // positive pressure it does not perform cleanup or a fresh re-observation.
+      // The two deterministic source batches each protect both their v4 shard
+      // write and owner-verified association write. The second fact boundary
+      // fails closed after one observation; unlike positive pressure it does
+      // not perform cleanup or a fresh re-observation.
       expect(Object.fromEntries(probes)).toEqual({
         'cache code graph file facts': probesPerObservation,
-        'cache materialized code graph file shards': probesPerObservation * 2,
+        'cache materialized code graph file shards': probesPerObservation * 4,
         'stage persistent code graph facts': probesPerObservation * 2,
         'stage persistent code graph inventory': probesPerObservation,
         'stage persistent code graph workspace': probesPerObservation,

--- a/test/unit/code-graph.indexer.property.test.ts
+++ b/test/unit/code-graph.indexer.property.test.ts
@@ -22,8 +22,11 @@ import {
 import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {
   CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION,
+  materializedBatchShardDerivationIdentity,
   materializedFileShardIdentity,
+  materializedShardRepositorySemanticEnvelope,
   materializedShardDerivationIdentity,
+  persistentFullShardPublicationPlan,
 } from '../../src/code_graph/store.js';
 import type {CodeGraphEdge, CodeGraphMaterializationRows, CodeGraphReference} from '../../src/code_graph/types.js';
 
@@ -203,6 +206,122 @@ describe('code graph indexer properties', () => {
     ).slice(0, 40)}`;
 
     expect(materializedShardDerivationIdentity(extractor, workspace, graphContent)).not.toBe(legacy);
+  });
+
+  it('derives v4 batch identities from an independently canonicalized repository envelope', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(
+          fc.record({
+            contentHash: fc.stringMatching(/^[a-f0-9]{1,24}$/),
+            language: fc.constantFrom('typescript', 'python', 'markdown'),
+            mode: fc.constantFrom('100644', '100755'),
+            path: fc.stringMatching(/^src\/[a-z][a-z0-9]{0,8}\.ts$/),
+            source: fc.constant<'commit'>('commit'),
+          }),
+          {maxLength: 20, minLength: 3, selector: file => file.path},
+        ),
+        files => {
+          const canonicalEntries = [...files]
+            .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0))
+            .map(file => [file.path, file.language, file.mode, null]);
+          const expectedEnvelope = `cgfe_${sha256HexSync(
+            `materialized-repository-semantic-envelope-v1\n${JSON.stringify(canonicalEntries)}`,
+          ).slice(0, 40)}`;
+          const envelope = materializedShardRepositorySemanticEnvelope(files);
+          const batch = files.slice(0, 2);
+          const expectedDerivation = `cgfd_${sha256HexSync(
+            `materialized-file-derivation-v4\nextractor\nworkspace\n${expectedEnvelope}\n${JSON.stringify(
+              batch.map(file => [file.path, file.contentHash, file.language, file.mode, file.source]),
+            )}`,
+          ).slice(0, 40)}`;
+          const derivation = materializedBatchShardDerivationIdentity('extractor', 'workspace', envelope, batch);
+          const outsideBodyChanged = files.map((file, index) =>
+            index === 2 ? {...file, contentHash: `${file.contentHash}0`, source: 'worktree' as const} : file,
+          );
+
+          expect(envelope).toBe(expectedEnvelope);
+          expect(materializedShardRepositorySemanticEnvelope([...files].reverse())).toBe(envelope);
+          expect(derivation).toBe(expectedDerivation);
+          expect(materializedBatchShardDerivationIdentity('extractor-v2', 'workspace', envelope, batch)).not.toBe(
+            derivation,
+          );
+          expect(materializedBatchShardDerivationIdentity('extractor', 'workspace-v2', envelope, batch)).not.toBe(
+            derivation,
+          );
+          expect(
+            materializedBatchShardDerivationIdentity('extractor', 'workspace', envelope, [...batch].reverse()),
+          ).not.toBe(derivation);
+          expect(
+            materializedBatchShardDerivationIdentity('extractor', 'workspace', envelope, [
+              {...batch[0]!, contentHash: `${batch[0]!.contentHash}0`},
+              batch[1]!,
+            ]),
+          ).not.toBe(derivation);
+          expect(
+            materializedBatchShardDerivationIdentity(
+              'extractor',
+              'workspace',
+              materializedShardRepositorySemanticEnvelope(outsideBodyChanged),
+              batch,
+            ),
+          ).toBe(derivation);
+        },
+      ),
+      {numRuns: 200},
+    );
+  });
+
+  it('invalidates v4 repository envelopes on retained context or path membership changes', () => {
+    const source = {
+      contentHash: 'source-a',
+      language: 'typescript',
+      mode: '100644',
+      path: 'src/index.ts',
+      source: 'commit' as const,
+    };
+    const packageManifest = {
+      contentHash: 'package-a',
+      language: 'npm-manifest',
+      mode: '100644',
+      path: 'package.json',
+      source: 'commit' as const,
+    };
+    const tsconfig = {
+      contentHash: 'tsconfig-a',
+      language: 'typescript-config',
+      mode: '100644',
+      path: 'tsconfig.json',
+      source: 'commit' as const,
+    };
+    const files = [packageManifest, source, tsconfig];
+    const envelope = materializedShardRepositorySemanticEnvelope(files);
+
+    expect(
+      materializedShardRepositorySemanticEnvelope([{...source, contentHash: 'source-b'}, packageManifest, tsconfig]),
+    ).toBe(envelope);
+    expect(
+      materializedShardRepositorySemanticEnvelope([{...packageManifest, contentHash: 'package-b'}, source, tsconfig]),
+    ).not.toBe(envelope);
+    expect(
+      materializedShardRepositorySemanticEnvelope([packageManifest, source, {...tsconfig, contentHash: 'tsconfig-b'}]),
+    ).not.toBe(envelope);
+    expect(materializedShardRepositorySemanticEnvelope([packageManifest, tsconfig])).not.toBe(envelope);
+    expect(materializedBatchShardDerivationIdentity('extractor', 'workspace', envelope, [source])).not.toBe(
+      materializedShardDerivationIdentity('extractor', 'workspace', 'graph-content'),
+    );
+  });
+
+  it('skips the legacy repository-wide shard scan and file reserve after v4 batch association', () => {
+    expect(persistentFullShardPublicationPlan(2, true, 7)).toEqual({
+      associateLegacyMaterializedFileShards: false,
+      rowCount: 20,
+    });
+    expect(persistentFullShardPublicationPlan(2, false, 7)).toEqual({
+      associateLegacyMaterializedFileShards: true,
+      rowCount: 22,
+    });
+    expect(Number.isNaN(persistentFullShardPublicationPlan(2, true, -1).rowCount)).toBe(true);
   });
 
   it('splits high-density low-source-byte facts before one SQLite writer transaction becomes pathological', () => {

--- a/test/unit/code-graph.materialization-store.test.ts
+++ b/test/unit/code-graph.materialization-store.test.ts
@@ -24,6 +24,7 @@ import {extractStructuredSchemaFacts} from '../../src/code_graph/languages/schem
 import {augmentRationaleFacts} from '../../src/code_graph/rationale.js';
 import {
   CodeGraphStore,
+  codeGraphCompleteMaterializedShardDonorStatement,
   codeGraphMaterializedShardAssociationPageStatement,
   codeGraphCompactLexicalDeepAuditStatement,
   codeGraphEffectiveSymbolTermsQueryStatement,
@@ -75,6 +76,56 @@ function observedStoreFailure(cause: unknown) {
 }
 
 describe('code graph full-build materialization store', () => {
+  it('proves complete shard donors through requested-first primary-key lookups', () => {
+    const database = new Database(':memory:', {strict: true});
+    try {
+      database.exec(`
+        CREATE TABLE snapshots (
+          id TEXT PRIMARY KEY NOT NULL,
+          extractor_set TEXT NOT NULL,
+          graph_content_id TEXT
+        ) WITHOUT ROWID;
+        CREATE TABLE materialized_file_shards (
+          id TEXT PRIMARY KEY NOT NULL,
+          content_hash TEXT NOT NULL,
+          extractor_set TEXT NOT NULL,
+          derivation_identity TEXT NOT NULL,
+          path_hint TEXT NOT NULL
+        ) WITHOUT ROWID;
+        CREATE TABLE snapshot_file_shards (
+          snapshot_id TEXT NOT NULL,
+          path TEXT NOT NULL,
+          shard_id TEXT NOT NULL,
+          PRIMARY KEY (snapshot_id, path)
+        ) WITHOUT ROWID;
+      `);
+      const statement = codeGraphCompleteMaterializedShardDonorStatement(
+        'cgs_donor',
+        [
+          {contentHash: 'hash-a', path: 'src/a.ts'},
+          {contentHash: 'hash-b', path: 'src/b.ts'},
+        ],
+        'extractor-v4',
+        'derivation-v4',
+      );
+      const plan = (
+        database.query(`EXPLAIN QUERY PLAN ${statement.text}`).all(...statement.parameters) as readonly {
+          readonly detail: string;
+        }[]
+      ).map(row => row.detail);
+      const requestedScan = plan.findIndex(detail => detail.includes('SCAN requested VIRTUAL TABLE'));
+      const associationLookup = plan.findIndex(detail =>
+        detail.includes('SEARCH association USING PRIMARY KEY (snapshot_id=? AND path=?)'),
+      );
+
+      expect(requestedScan).toBeGreaterThanOrEqual(0);
+      expect(associationLookup).toBeGreaterThan(requestedScan);
+      expect(plan.join('\n')).not.toMatch(/SEARCH association USING PRIMARY KEY \(snapshot_id=\?\)(?! AND path)/u);
+    } finally {
+      database.close(false);
+    }
+  });
+
   it('uses bounded in-memory pager surfaces for a persistent full-build writer', async () => {
     const fixture = await materializationFixture();
     const pager = await runEffect(


### PR DESCRIPTION
## Summary

- derive content-addressed v4 materialized shards per deterministic attribution batch
- reuse only one complete, owner-proven donor batch across graph-content generations
- keep package, tsconfig, workspace, file-set, extractor, and batch membership changes fail-closed
- preserve exact/cross-generation replay counters without changing anonymous telemetry schema
- drive donor proof from at most 128 requested members into indexed snapshot/path lookups
- skip the legacy repository-wide v3 association scan after bounded v4 association publication

## Correctness

This follows the complete-batch repair in #185. It never combines partial donors, never admits v3 rows, and never lets incremental subsets publish the v4 namespace. Ambient-overload and barrel fixtures compare decoded shards and the final stored graph with a fresh full build. The final independent review found no critical or important issues.

## Evidence

Three alternating isolated runs per variant used the same deterministic 130-file ambient-overload fixture. After a first full build, a body-only edit changed the final out-of-batch filler and forced a second full materialization.

- attribution median: 140 ms to 16 ms (-88.6%)
- end-to-end build median: 2167.662 ms to 2100.132 ms (-3.12%)
- raw replay: 238,665 B to 4,476 B (-98.1%)
- 128 of 130 files reused cross-generation; 2 attributed
- all six stored-graph digests were identical

Physical cached replay bytes increase because final attributed shards are richer than raw parser facts; the intended win is attribution CPU, not a lower combined replay-byte counter.

## Verification

- focused v4 identity and SQLite access-plan tests
- focused lifecycle cross-generation, invalidation, complementary-donor, and v3 exclusion tests
- source, test, and website TypeScript checks
- strict lint, Prettier, file-length, and diff checks
- no full local suite; CI is authoritative
