### PR TITLE
Bound CLI graph analysis freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ worktree; that refresh has a 25-second foreground budget by default and reports 
 the budget expires. `--read-timeout-ms` changes the budget, while `--freshness allow-stale` guarantees that the read
 will not start indexing. `graph path` remains current by default, and `graph impact` remains strict-current.
 
+`graph analyze` and its statistics, community, group, hub, surprise, and confidence aliases likewise analyze an
+existing ready snapshot by default. Their output labels the selected snapshot freshness. Use `--freshness current` to
+refresh before analysis, or `--freshness allow-stale` to return an unavailable state instead of starting a cold index
+when no ready snapshot exists. A required refresh has the same 25-second foreground budget by default;
+`--read-timeout-ms` changes it, and a timeout returns an explicit state without running analysis. `graph report`
+remains strict-current and uses the same bounded refresh contract; for a large stale graph, run `graph index` explicitly
+before writing the report.
+
 TypeScript and JavaScript retain the compiler-backed extractor that shipped with the first native graph. Java,
 Kotlin, Swift, Bash, C, C++, C#, Dart, Elixir, Go, HCL/Terraform, Julia, Lua, Objective-C, PHP, PowerShell, Python,
 Ruby, Rust, Scala, Solidity, Svelte, SystemVerilog/Verilog, Vue, and Zig use exact-pinned, bundled Tree-sitter WASM

--- a/src/code_graph/analysis_cli.ts
+++ b/src/code_graph/analysis_cli.ts
@@ -1,0 +1,166 @@
+import {Effect} from 'effect';
+import type {RuntimeConfig} from '../types.js';
+import type {CodeGraphAnalysisView} from './analysis_render.js';
+import {
+  CODE_GRAPH_CLI_READ_RETRY_MILLISECONDS,
+  CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS,
+  codeGraphCliReadPlan,
+  type CodeGraphCliFreshnessPolicy,
+} from './cli_freshness.js';
+import {CodeGraphQueryService} from './query.js';
+import type {CodeGraphStatus} from './types.js';
+
+class CodeGraphAnalysisCommandError extends Error {
+  readonly _tag = 'CodeGraphAnalysisCommandError' as const;
+}
+
+export interface CodeGraphCliAnalysisState {
+  readonly budgetMilliseconds?: number;
+  readonly freshness: CodeGraphStatus['freshness'];
+  readonly freshnessPolicy: CodeGraphCliFreshnessPolicy;
+  readonly operation: CodeGraphAnalysisView | 'report';
+  readonly reason: 'no-ready-snapshot' | 'read-timeout';
+  readonly repository: {
+    readonly displayName: string;
+    readonly repositoryId: string;
+  };
+  readonly retryAfterMilliseconds: number;
+  readonly snapshot?: {
+    readonly commit: string;
+    readonly dirty: boolean;
+    readonly id: string;
+  };
+  readonly state: 'timed-out' | 'unavailable';
+  readonly type: 'code-graph-analysis-state';
+  readonly version: 1;
+}
+
+function codeGraphCliAnalysisState(
+  status: CodeGraphStatus,
+  policy: CodeGraphCliFreshnessPolicy,
+  operation: CodeGraphCliAnalysisState['operation'],
+  reason: CodeGraphCliAnalysisState['reason'],
+  budgetMilliseconds?: number,
+): CodeGraphCliAnalysisState {
+  return {
+    ...(budgetMilliseconds === undefined ? {} : {budgetMilliseconds}),
+    freshness: status.freshness,
+    freshnessPolicy: policy,
+    operation,
+    reason,
+    repository: {
+      displayName: status.identity.displayName,
+      repositoryId: status.identity.repositoryId,
+    },
+    retryAfterMilliseconds: CODE_GRAPH_CLI_READ_RETRY_MILLISECONDS,
+    ...(status.readySnapshot
+      ? {
+          snapshot: {
+            commit: status.readySnapshot.commit,
+            dirty: status.readySnapshot.dirty,
+            id: status.readySnapshot.id,
+          },
+        }
+      : {}),
+    state: reason === 'read-timeout' ? 'timed-out' : 'unavailable',
+    type: 'code-graph-analysis-state',
+    version: 1,
+  };
+}
+
+export function renderCodeGraphCliAnalysisState(state: CodeGraphCliAnalysisState): string {
+  if (state.state === 'unavailable') {
+    return (
+      'No ready code graph snapshot is available, and --freshness allow-stale never starts indexing. ' +
+      'No analysis ran. Run graph index, or use --freshness ready/current to allow a bounded refresh.\n'
+    );
+  }
+  const readyHint =
+    state.operation === 'report'
+      ? ' Run graph index explicitly, then retry the report.'
+      : state.snapshot === undefined
+        ? ' Run graph index, then retry.'
+        : ' A ready snapshot remains available; retry with --freshness ready to analyze it without waiting.';
+  return (
+    `Code graph ${state.freshnessPolicy} ${state.operation === 'report' ? 'report' : 'analysis'} refresh exceeded ` +
+    `Threadnote's ${(state.budgetMilliseconds ?? CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS) / 1_000}-second ` +
+    `foreground budget. No analysis ran.${readyHint}\n`
+  );
+}
+
+/** @internal Exported for focused freshness-policy verification. */
+export function resolveCodeGraphAnalysisSnapshot<RefreshError, RefreshRequirements>(
+  config: RuntimeConfig,
+  cwd: string,
+  freshnessPolicy: CodeGraphCliFreshnessPolicy,
+  refresh: () => Effect.Effect<unknown, RefreshError, RefreshRequirements>,
+  options: {
+    readonly operation: CodeGraphCliAnalysisState['operation'];
+    readonly readTimeoutMilliseconds?: number;
+  },
+) {
+  return Effect.gen(function* () {
+    const query = yield* CodeGraphQueryService;
+    let status = yield* query.status(config.agentContextHome, cwd, {requestMaintenance: false});
+    const identity = status.identity;
+    if (status.stale || !status.readySnapshot) {
+      status = yield* query.attachSharedReadySnapshot(config.agentContextHome, identity, status, {
+        allowBorrowedStale: false,
+        requestMaintenance: false,
+      });
+    }
+    const readPlan = codeGraphCliReadPlan(freshnessPolicy, status);
+    if (readPlan.unavailable) {
+      return {
+        ready: false as const,
+        state: codeGraphCliAnalysisState(status, freshnessPolicy, options.operation, 'no-ready-snapshot'),
+      };
+    }
+    if (readPlan.refresh) {
+      const readTimeoutMilliseconds = options.readTimeoutMilliseconds ?? CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS;
+      const refreshed = yield* refresh().pipe(
+        Effect.as(true),
+        Effect.timeoutOrElse({
+          duration: readTimeoutMilliseconds,
+          orElse: () => Effect.succeed(false),
+        }),
+      );
+      if (!refreshed) {
+        return {
+          ready: false as const,
+          state: codeGraphCliAnalysisState(
+            status,
+            freshnessPolicy,
+            options.operation,
+            'read-timeout',
+            readTimeoutMilliseconds,
+          ),
+        };
+      }
+      status = yield* query.status(config.agentContextHome, cwd, {requestMaintenance: false});
+    }
+    if (freshnessPolicy === 'current' && (status.stale || status.freshness !== 'current')) {
+      return yield* Effect.fail(
+        new CodeGraphAnalysisCommandError(
+          'A current native code graph snapshot is unavailable after indexing; the worktree may have changed during the refresh.',
+        ),
+      );
+    }
+    if (!status.readySnapshot) {
+      return yield* Effect.fail(
+        new CodeGraphAnalysisCommandError('No ready native code graph snapshot exists after indexing.'),
+      );
+    }
+    return {
+      databasePath: status.databasePath,
+      freshness: status.freshness,
+      freshnessPolicy,
+      ready: true as const,
+      repository: {
+        displayName: status.identity.displayName,
+        repositoryId: status.identity.repositoryId,
+      },
+      snapshot: status.readySnapshot,
+    };
+  });
+}

--- a/src/code_graph/cli_freshness.ts
+++ b/src/code_graph/cli_freshness.ts
@@ -1,0 +1,26 @@
+import type {CodeGraphStatus} from './types.js';
+
+export type CodeGraphCliFreshnessPolicy = 'allow-stale' | 'current' | 'ready';
+
+export interface CodeGraphCliReadPlan {
+  readonly refresh: boolean;
+  readonly strictFreshness: boolean;
+  readonly unavailable: boolean;
+}
+
+export const CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS = 25_000;
+export const CODE_GRAPH_CLI_READ_RETRY_MILLISECONDS = 1_000;
+
+export function codeGraphCliReadPlan(
+  policy: CodeGraphCliFreshnessPolicy,
+  status: Pick<CodeGraphStatus, 'readySnapshot' | 'stale'>,
+): CodeGraphCliReadPlan {
+  const hasReadySnapshot = status.readySnapshot !== undefined;
+  const strictFreshness = policy === 'current';
+  const unavailable = policy === 'allow-stale' && !hasReadySnapshot;
+  return {
+    refresh: !unavailable && (!hasReadySnapshot || (status.stale && strictFreshness)),
+    strictFreshness,
+    unavailable,
+  };
+}

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -53,6 +53,18 @@ import {
   renderCodeGraphReport,
   type CodeGraphAnalysisView,
 } from './analysis_render.js';
+import {
+  renderCodeGraphCliAnalysisState,
+  resolveCodeGraphAnalysisSnapshot,
+  type CodeGraphCliAnalysisState,
+} from './analysis_cli.js';
+import {
+  CODE_GRAPH_CLI_READ_RETRY_MILLISECONDS,
+  CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS,
+  codeGraphCliReadPlan,
+  type CodeGraphCliFreshnessPolicy,
+  type CodeGraphCliReadPlan,
+} from './cli_freshness.js';
 import {exportCodeGraph, type CodeGraphExportFormat, type CodeGraphExportLimit} from './export.js';
 import {
   readCodeGraphBuildStatuses,
@@ -79,33 +91,11 @@ interface CwdOption {
   readonly cwd?: string;
 }
 
-export type CodeGraphCliFreshnessPolicy = 'allow-stale' | 'current' | 'ready';
-
-export interface CodeGraphCliReadPlan {
-  readonly refresh: boolean;
-  readonly strictFreshness: boolean;
-  readonly unavailable: boolean;
-}
+export {CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS, codeGraphCliReadPlan};
+export type {CodeGraphCliFreshnessPolicy, CodeGraphCliReadPlan};
 
 class CodeGraphCommandError extends Error {
   readonly _tag = 'CodeGraphCommandError' as const;
-}
-
-export const CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS = 25_000;
-const CODE_GRAPH_CLI_READ_RETRY_MILLISECONDS = 1_000;
-
-export function codeGraphCliReadPlan(
-  policy: CodeGraphCliFreshnessPolicy,
-  status: Pick<CodeGraphStatus, 'readySnapshot' | 'stale'>,
-): CodeGraphCliReadPlan {
-  const hasReadySnapshot = status.readySnapshot !== undefined;
-  const strictFreshness = policy === 'current';
-  const unavailable = policy === 'allow-stale' && !hasReadySnapshot;
-  return {
-    refresh: !unavailable && (!hasReadySnapshot || (status.stale && strictFreshness)),
-    strictFreshness,
-    unavailable,
-  };
 }
 
 export function defaultCodeGraphCliFreshness(
@@ -908,10 +898,12 @@ export const runCodeGraphAnalysis = Effect.fn('codeGraph.command.analysis')(func
   config: RuntimeConfig,
   options: CwdOption & {
     readonly communityId?: string;
+    readonly freshness?: CodeGraphCliFreshnessPolicy;
     readonly includeHeuristic?: boolean;
     readonly includeModelAssociations?: boolean;
     readonly json?: boolean;
     readonly memberLimit?: number;
+    readonly readTimeoutMilliseconds?: number;
     readonly view: CodeGraphAnalysisView;
   },
 ) {
@@ -924,7 +916,22 @@ export const runCodeGraphAnalysis = Effect.fn('codeGraph.command.analysis')(func
       ),
     );
   }
-  const status = yield* ensureAnalysisSnapshot(config, cwd, options.json === true);
+  const freshness = options.freshness ?? 'ready';
+  const resolution = yield* ensureAnalysisSnapshot(
+    config,
+    cwd,
+    options.json === true,
+    freshness,
+    options.view,
+    options.readTimeoutMilliseconds,
+  );
+  if (!resolution.ready) {
+    yield* writeFinalCliOutput(
+      options.json ? JSON.stringify(resolution.state) : renderCodeGraphCliAnalysisState(resolution.state).trimEnd(),
+    );
+    return;
+  }
+  const status = resolution;
   const analysis = yield* CodeGraphAnalysis;
   const result = yield* analysis.analyze({
     allowedProvenances: [
@@ -942,6 +949,8 @@ export const runCodeGraphAnalysis = Effect.fn('codeGraph.command.analysis')(func
   if (options.json) {
     yield* writeFinalCliOutput(
       JSON.stringify({
+        freshness: status.freshness,
+        freshnessPolicy: status.freshnessPolicy,
         type: 'code-graph-analysis',
         repository: status.repository,
         result,
@@ -950,7 +959,9 @@ export const runCodeGraphAnalysis = Effect.fn('codeGraph.command.analysis')(func
     );
     return;
   }
-  yield* writeFinalCliOutput(renderCodeGraphAnalysis(result, options.view).trimEnd());
+  const rendered = renderCodeGraphAnalysis(result, options.view).trimEnd().split('\n');
+  rendered.splice(1, 0, `Snapshot freshness: ${status.freshness} (requested ${status.freshnessPolicy})`);
+  yield* writeFinalCliOutput(rendered.join('\n'));
 });
 
 export const runCodeGraphReport = Effect.fn('codeGraph.command.report')(function* (
@@ -959,6 +970,7 @@ export const runCodeGraphReport = Effect.fn('codeGraph.command.report')(function
     readonly includeHeuristic?: boolean;
     readonly includeModelAssociations?: boolean;
     readonly output: string;
+    readonly readTimeoutMilliseconds?: number;
   },
 ) {
   const fs = yield* FileSystem.FileSystem;
@@ -967,7 +979,22 @@ export const runCodeGraphReport = Effect.fn('codeGraph.command.report')(function
   const output = path.resolve(options.output);
   if (yield* fs.exists(output))
     return yield* Effect.fail(new CodeGraphCommandError(`Report output already exists: ${output}`));
-  const status = yield* ensureAnalysisSnapshot(config, cwd, false);
+  const resolution = yield* ensureAnalysisSnapshot(
+    config,
+    cwd,
+    false,
+    'current',
+    'report',
+    options.readTimeoutMilliseconds,
+  );
+  if (!resolution.ready) {
+    return yield* Effect.fail(
+      new CodeGraphCommandError(
+        `${renderCodeGraphCliAnalysisState(resolution.state).trim()} The report output was not created.`,
+      ),
+    );
+  }
+  const status = resolution;
   const analysis = yield* CodeGraphAnalysis;
   const result = yield* analysis.analyze({
     allowedProvenances: [
@@ -1664,49 +1691,39 @@ const ensureAnalysisSnapshot = Effect.fn('codeGraph.command.ensureAnalysisSnapsh
   config: RuntimeConfig,
   cwd: string,
   json: boolean,
+  freshnessPolicy: CodeGraphCliFreshnessPolicy,
+  operation: CodeGraphCliAnalysisState['operation'],
+  readTimeoutMilliseconds = CODE_GRAPH_CLI_READ_TIMEOUT_MILLISECONDS,
 ) {
-  const query = yield* CodeGraphQueryService;
   const indexer = yield* CodeGraphIndexer;
-  let status = yield* query.status(config.agentContextHome, cwd);
-  const identity = status.identity;
-  if (status.stale || !status.readySnapshot) {
-    status = yield* query.attachSharedReadySnapshot(config.agentContextHome, identity, status);
-  }
-  if (status.stale) {
-    if (json) {
-      const reportProgress = yield* makeCodeGraphJsonProgressReporter();
-      yield* indexer.index({
-        cwd,
-        ensureVectors: false,
-        onProgress: reportProgress,
-        threadnoteHome: config.agentContextHome,
-      });
-    } else {
-      yield* Effect.acquireUseRelease(
-        startProgress('Refreshing repository graph before analysis.'),
-        progress =>
-          indexer.index({
-            cwd,
-            ensureVectors: false,
-            onProgress: state => progress.update(progressMessage(state)).pipe(Effect.catch(() => Effect.void)),
-            threadnoteHome: config.agentContextHome,
-          }),
-        progress => progress.stop.pipe(Effect.catch(() => Effect.void)),
-      );
-    }
-    status = yield* query.status(config.agentContextHome, cwd);
-  }
-  if (!status.readySnapshot) {
-    return yield* Effect.fail(new CodeGraphCommandError('No ready native code graph snapshot exists after indexing.'));
-  }
-  return {
-    databasePath: status.databasePath,
-    repository: {
-      displayName: status.identity.displayName,
-      repositoryId: status.identity.repositoryId,
-    },
-    snapshot: status.readySnapshot,
-  };
+  return yield* resolveCodeGraphAnalysisSnapshot(
+    config,
+    cwd,
+    freshnessPolicy,
+    () =>
+      json
+        ? Effect.gen(function* () {
+            const reportProgress = yield* makeCodeGraphJsonProgressReporter();
+            yield* indexer.index({
+              cwd,
+              ensureVectors: false,
+              onProgress: reportProgress,
+              threadnoteHome: config.agentContextHome,
+            });
+          })
+        : Effect.acquireUseRelease(
+            startProgress('Refreshing repository graph before analysis.'),
+            progress =>
+              indexer.index({
+                cwd,
+                ensureVectors: false,
+                onProgress: state => progress.update(progressMessage(state)).pipe(Effect.catch(() => Effect.void)),
+                threadnoteHome: config.agentContextHome,
+              }),
+            progress => progress.stop.pipe(Effect.catch(() => Effect.void)),
+          ),
+    {operation, readTimeoutMilliseconds},
+  );
 });
 
 function progressMessage(progress: CodeGraphProgress): string {

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -818,9 +818,16 @@ const graphTopology = Command.make(
 
 const graphAnalysisBounds = {
   cwd: graphBounds.cwd,
+  freshness: defaultChoice(
+    'freshness',
+    ['ready', 'current', 'allow-stale'],
+    'Ready uses an existing snapshot, current refreshes before analysis, and allow-stale never starts indexing',
+    'ready',
+  ),
   includeHeuristic: graphBounds.includeHeuristic,
   includeModelAssociations: graphBounds.includeModelAssociations,
   json: graphBounds.json,
+  readTimeoutMilliseconds: graphBounds.readTimeoutMilliseconds,
 } as const;
 
 const graphCommunityMemberLimit = optional(
@@ -891,6 +898,7 @@ const graphReport = Command.make(
     includeHeuristic: graphBounds.includeHeuristic,
     includeModelAssociations: graphBounds.includeModelAssociations,
     output: requiredString('output', 'New Markdown report path; existing files are never overwritten'),
+    readTimeoutMilliseconds: graphBounds.readTimeoutMilliseconds,
   },
   options => withRuntimeEffect(config => runCodeGraphReport(config, options)),
 ).pipe(Command.withDescription('Write a deterministic architecture report with suggested graph questions'));

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -85,6 +85,7 @@ describe('Effect CLI', () => {
     const contextBrief = await runCli(['context', 'brief', '--help']);
     const inventory = await runCli(['graph', 'inventory', '--help']);
     const analyze = await runCli(['graph', 'analyze', '--help']);
+    const report = await runCli(['graph', 'report', '--help']);
     const diagnostics = await runCli(['graph', 'diagnostics', '--help']);
     const exportHelp = await runCli(['graph', 'export', '--help']);
     const purge = await runCli(['graph', 'purge', '--help']);
@@ -135,6 +136,10 @@ describe('Effect CLI', () => {
       'choices: stats, communities, community, groups, hubs, surprises, confidence, full',
     );
     expect(analyze.stdout).toContain('--community-id string');
+    expect(analyze.stdout).toContain('--freshness choice');
+    expect(analyze.stdout).toContain('choices: ready, current, allow-stale');
+    expect(analyze.stdout).toContain('--read-timeout-ms integer');
+    expect(report.stdout).toContain('--read-timeout-ms integer');
     expect(diagnostics.stdout).toContain('--analyze');
     expect(diagnostics.stdout).toContain('--deep');
     expect(diagnostics.stdout).not.toContain('--cwd');
@@ -440,6 +445,161 @@ describe('Effect CLI', () => {
       expect(graph.snapshot?.commit).toBe(indexedCommit);
       expect(graph.nodes?.some(node => node.name === 'indexedBeforePull')).toBe(true);
       expect(result.stderr).toBe('');
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  }, 30_000);
+
+  it('bounds cold analysis and report refreshes without leaving an indexing owner or report', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-graph-analysis-timeout-'));
+    const home = join(root, '.threadnote-test-home');
+    const report = join(root, 'architecture.md');
+    try {
+      await writeFile(join(root, 'package.json'), '{"name":"analysis-timeout"}\n');
+      await writeFile(join(root, 'index.ts'), 'export function boundedAnalysis(): number { return 1; }\n');
+      await execFilePromise('git', ['-C', root, 'init', '-q']);
+      await execFilePromise('git', ['-C', root, 'add', '.']);
+      await execFilePromise('git', [
+        '-C',
+        root,
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=test@threadnote.local',
+        'commit',
+        '-qm',
+        'fixture',
+      ]);
+
+      const timedOut = await runCli([
+        'graph',
+        'analyze',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--view',
+        'stats',
+        '--read-timeout-ms',
+        '1',
+        '--json',
+      ]);
+      expect(JSON.parse(timedOut.stdout)).toMatchObject({
+        budgetMilliseconds: 1,
+        freshnessPolicy: 'ready',
+        operation: 'stats',
+        reason: 'read-timeout',
+        state: 'timed-out',
+        type: 'code-graph-analysis-state',
+        version: 1,
+      });
+      expect(timedOut.stdout).not.toContain('"result"');
+
+      const reportFailure = await runCli([
+        'graph',
+        'report',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--output',
+        report,
+        '--read-timeout-ms',
+        '1',
+      ]).catch(cause => cause as NodeJS.ErrnoException & {stderr?: string});
+      expect(reportFailure).toMatchObject({code: 1});
+      expect(String(reportFailure.stderr)).toContain('No analysis ran');
+      expect(String(reportFailure.stderr)).toContain('Run graph index explicitly');
+      expect(String(reportFailure.stderr)).toContain('report output was not created');
+      await expect(access(report)).rejects.toMatchObject({code: 'ENOENT'});
+
+      const recovered = JSON.parse(
+        (await runCli(['graph', 'index', '--home', home, '--cwd', root, '--json'])).stdout,
+      ) as {readonly snapshot?: {readonly fileCount?: number}};
+      expect(recovered.snapshot?.fileCount).toBe(2);
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  }, 30_000);
+
+  it('analyzes a stale ready snapshot by default and refreshes only when current is requested', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-graph-stale-analysis-'));
+    const home = join(root, '.threadnote-test-home');
+    try {
+      await writeFile(join(root, 'package.json'), '{"name":"stale-analysis"}\n');
+      await writeFile(join(root, 'index.ts'), 'export function indexedForAnalysis(): number { return 1; }\n');
+      await execFilePromise('git', ['-C', root, 'init', '-q']);
+      await execFilePromise('git', ['-C', root, 'add', '.']);
+      await execFilePromise('git', [
+        '-C',
+        root,
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=test@threadnote.local',
+        'commit',
+        '-qm',
+        'fixture',
+      ]);
+
+      const unavailable = await runCli([
+        'graph',
+        'analyze',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--view',
+        'stats',
+        '--freshness',
+        'allow-stale',
+        '--json',
+      ]);
+      expect(JSON.parse(unavailable.stdout)).toMatchObject({
+        freshnessPolicy: 'allow-stale',
+        operation: 'stats',
+        reason: 'no-ready-snapshot',
+        state: 'unavailable',
+        type: 'code-graph-analysis-state',
+        version: 1,
+      });
+      expect(unavailable.stderr).toBe('');
+
+      const indexed = JSON.parse(
+        (await runCli(['graph', 'index', '--home', home, '--cwd', root, '--json'])).stdout,
+      ) as {readonly snapshot: {readonly id: string}};
+      await writeFile(join(root, 'index.ts'), 'export function changedForAnalysis(): number { return 2; }\n');
+
+      const ready = await runCli(['graph', 'analyze', '--home', home, '--cwd', root, '--view', 'stats', '--json']);
+      const readyAnalysis = JSON.parse(ready.stdout) as {
+        readonly freshness: string;
+        readonly freshnessPolicy: string;
+        readonly result: {readonly snapshot: {readonly id: string}};
+      };
+      expect(readyAnalysis).toMatchObject({freshness: 'stale', freshnessPolicy: 'ready'});
+      expect(readyAnalysis.result.snapshot.id).toBe(indexed.snapshot.id);
+      expect(ready.stderr).toBe('');
+
+      const current = await runCli([
+        'graph',
+        'analyze',
+        '--home',
+        home,
+        '--cwd',
+        root,
+        '--view',
+        'stats',
+        '--freshness',
+        'current',
+        '--json',
+      ]);
+      const currentAnalysis = JSON.parse(current.stdout) as {
+        readonly freshness: string;
+        readonly freshnessPolicy: string;
+        readonly result: {readonly snapshot: {readonly id: string}};
+      };
+      expect(currentAnalysis).toMatchObject({freshness: 'current', freshnessPolicy: 'current'});
+      expect(currentAnalysis.result.snapshot.id).not.toBe(indexed.snapshot.id);
     } finally {
       await rm(root, {force: true, recursive: true});
     }

--- a/test/unit/code-graph.commands-analysis.test.ts
+++ b/test/unit/code-graph.commands-analysis.test.ts
@@ -1,0 +1,200 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect, Fiber, Layer, Ref} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe, expect} from 'vitest';
+import {resolveCodeGraphAnalysisSnapshot} from '../../src/code_graph/analysis_cli.js';
+import type {CodeGraphCliFreshnessPolicy} from '../../src/code_graph/cli_freshness.js';
+import {
+  CodeGraphQueryService,
+  type CodeGraphSharedReadyAttachInterlock,
+  type CodeGraphStatusOptions,
+} from '../../src/code_graph/query.js';
+import type {CodeGraphSnapshot, CodeGraphStatus, RepositoryIdentity} from '../../src/code_graph/types.js';
+import type {RuntimeConfig} from '../../src/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('code graph CLI analysis freshness', () => {
+  effectIt.effect('never borrows repository-level stale evidence for analysis', () => {
+    const unavailable = codeGraphStatus({ready: false, stale: true});
+    const harness = analysisSnapshotHarness({attachResults: [unavailable], statuses: [unavailable]});
+
+    return Effect.gen(function* () {
+      const result = yield* resolve(harness, 'allow-stale');
+
+      expect(result).toMatchObject({
+        ready: false,
+        state: {
+          freshnessPolicy: 'allow-stale',
+          operation: 'stats',
+          reason: 'no-ready-snapshot',
+          state: 'unavailable',
+          type: 'code-graph-analysis-state',
+          version: 1,
+        },
+      });
+      expect(harness.observation.attachOptions).toEqual([{allowBorrowedStale: false, requestMaintenance: false}]);
+      expect(harness.observation.statusOptions).toEqual([{requestMaintenance: false}]);
+      expect(harness.observation.refreshes).toBe(0);
+    }).pipe(provideTestLayer(harness.layer));
+  });
+
+  effectIt.effect('fails current analysis closed when refresh leaves only a stale snapshot', () => {
+    const stale = codeGraphStatus({ready: true, stale: true});
+    const harness = analysisSnapshotHarness({attachResults: [stale], statuses: [stale, stale]});
+
+    return Effect.gen(function* () {
+      const error = yield* Effect.flip(resolve(harness, 'current'));
+
+      expect(String(error)).toContain('current native code graph snapshot is unavailable after indexing');
+      expect(harness.observation.attachOptions).toEqual([{allowBorrowedStale: false, requestMaintenance: false}]);
+      expect(harness.observation.statusOptions).toEqual([{requestMaintenance: false}, {requestMaintenance: false}]);
+      expect(harness.observation.refreshes).toBe(1);
+    }).pipe(provideTestLayer(harness.layer));
+  });
+
+  effectIt.effect('interrupts a timed-out cold refresh and returns no analysis snapshot', () => {
+    const unavailable = codeGraphStatus({ready: false, stale: true});
+    const harness = analysisSnapshotHarness({attachResults: [unavailable], statuses: [unavailable]});
+
+    return Effect.gen(function* () {
+      const interrupted = yield* Ref.make(false);
+      const resolution = yield* resolveCodeGraphAnalysisSnapshot<never, never>(
+        runtimeConfig(),
+        TEST_REPOSITORY,
+        'ready',
+        () => Effect.never.pipe(Effect.ensuring(Ref.set(interrupted, true))),
+        {operation: 'stats', readTimeoutMilliseconds: 25_000},
+      ).pipe(Effect.forkChild({startImmediately: true}));
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust(25_000);
+      const result = yield* Fiber.join(resolution);
+
+      expect(result).toMatchObject({
+        ready: false,
+        state: {
+          budgetMilliseconds: 25_000,
+          operation: 'stats',
+          reason: 'read-timeout',
+          state: 'timed-out',
+          type: 'code-graph-analysis-state',
+          version: 1,
+        },
+      });
+      expect(yield* Ref.get(interrupted)).toBe(true);
+      expect(harness.observation.attachOptions).toEqual([{allowBorrowedStale: false, requestMaintenance: false}]);
+      expect(harness.observation.statusOptions).toEqual([{requestMaintenance: false}]);
+    }).pipe(provideTestLayer(harness.layer));
+  });
+});
+
+const TEST_HOME = '/threadnote-analysis-command-home';
+const TEST_REPOSITORY = '/workspace/divergent-analysis-worktree';
+
+interface AnalysisSnapshotHarnessInput {
+  readonly attachResults: readonly CodeGraphStatus[];
+  readonly statuses: readonly CodeGraphStatus[];
+}
+
+function analysisSnapshotHarness(input: AnalysisSnapshotHarnessInput) {
+  const attachOptions: Array<CodeGraphSharedReadyAttachInterlock | undefined> = [];
+  const statusOptions: Array<CodeGraphStatusOptions | undefined> = [];
+  let refreshes = 0;
+  let attachIndex = 0;
+  let statusIndex = 0;
+  const query = CodeGraphQueryService.of({
+    attachSharedReadySnapshot: (_threadnoteHome, _identity, _status, options) =>
+      Effect.suspend(() => {
+        attachOptions.push(options);
+        const result = input.attachResults[attachIndex];
+        attachIndex += 1;
+        return result === undefined
+          ? Effect.die(new Error(`Unexpected analysis attachment ${attachIndex}.`))
+          : Effect.succeed(result);
+      }),
+    inspect: () => Effect.die(new Error('Analysis snapshot resolution must not inspect the graph.')),
+    purge: () => Effect.die(new Error('Analysis snapshot resolution must not purge the graph.')),
+    status: (_threadnoteHome, _cwd, options) =>
+      Effect.suspend(() => {
+        statusOptions.push(options);
+        const result = input.statuses[statusIndex];
+        statusIndex += 1;
+        return result === undefined
+          ? Effect.die(new Error(`Unexpected analysis status ${statusIndex}.`))
+          : Effect.succeed(result);
+      }),
+    statusForIdentity: () => Effect.die(new Error('Analysis snapshot resolution must not query another identity.')),
+    statusForPublishedIdentity: () =>
+      Effect.die(new Error('Analysis snapshot resolution must not query a published identity.')),
+  });
+
+  return {
+    layer: Layer.succeed(CodeGraphQueryService, query),
+    observation: {
+      attachOptions,
+      statusOptions,
+      get refreshes() {
+        return refreshes;
+      },
+    },
+    refresh: () =>
+      Effect.sync(() => {
+        refreshes += 1;
+      }),
+  };
+}
+
+function resolve(harness: ReturnType<typeof analysisSnapshotHarness>, freshness: CodeGraphCliFreshnessPolicy) {
+  return resolveCodeGraphAnalysisSnapshot(runtimeConfig(), TEST_REPOSITORY, freshness, harness.refresh, {
+    operation: 'stats',
+    readTimeoutMilliseconds: 25_000,
+  });
+}
+
+function codeGraphStatus(options: {readonly ready: boolean; readonly stale: boolean}): CodeGraphStatus {
+  const snapshot = analysisSnapshot();
+  const identity: RepositoryIdentity = {
+    caseMode: 'sensitive',
+    checkoutId: 'analysis-checkout',
+    displayName: 'Fixture/divergent-analysis',
+    gitCommonDirectory: '/workspace/repository/.git',
+    headCommit: '2'.repeat(40),
+    objectFormat: 'sha1',
+    repoRoot: TEST_REPOSITORY,
+    repositoryId: snapshot.repositoryId,
+    worktreeId: snapshot.worktreeId,
+  };
+  return {
+    databasePath: `${TEST_HOME}/graph.sqlite`,
+    freshness: options.stale ? 'stale' : 'current',
+    identity,
+    languagePacks: [],
+    ...(options.ready ? {readySnapshot: snapshot} : {}),
+    stale: options.stale,
+  };
+}
+
+function analysisSnapshot(): CodeGraphSnapshot {
+  return {
+    commit: '1'.repeat(40),
+    dirty: false,
+    edgeCount: 0,
+    extractorSet: 'analysis-fixture',
+    fileCount: 1,
+    graphContentId: 'analysis-content',
+    id: 'analysis-snapshot',
+    repositoryId: 'analysis-repository',
+    state: 'ready',
+    symbolCount: 1,
+    worktreeId: 'analysis-worktree',
+  };
+}
+
+function runtimeConfig(): RuntimeConfig {
+  return {
+    account: 'local',
+    agentContextHome: TEST_HOME,
+    agentId: 'analysis-command-test',
+    manifestPath: `${TEST_HOME}/seed-manifest.yaml`,
+    user: 'analysis-command-test',
+  };
+}


### PR DESCRIPTION
## Summary
- make `threadnote graph analyze` and its view aliases default to exact ready-snapshot reads instead of silently refreshing a stale large worktree
- add explicit `ready | current | allow-stale` policy and a 25s foreground refresh budget (`--read-timeout-ms`, 1..600000)
- keep `graph report` strict-current, but bound its refresh and fail without writing stale or partial output
- return versioned `code-graph-analysis-state` unavailable/timed-out results before analysis, disable repository stale borrowing and request-side maintenance

## Dogfood evidence
On the installed pre-fix build, `graph analyze --view stats --json` against a stale Threadnote worktree silently spent about 53s on a full rebuild and replayed about 145.6 MB before returning analysis. Warm analysis after the graph became current completed in about 0.43s. This change makes default-ready analysis reuse this worktree's ready snapshot and requires explicit `current` for a bounded refresh.

## Verification
- independent critical/important review: clean
- Effect/TestClock resolver tests: 3 passed
- bounded CLI refresh/report tests and stale-ready/current tests: 3 passed
- bounded Fast-check freshness policy suite: 4 passed
- source, test, and site TypeScript checks passed
- strict targeted lint, Prettier, file-length, and diff checks passed
- no full local suite; CI is authoritative

The removed large-repository implementation plan remains absent.
