### PR TITLE
Prepare Threadnote 4.3.0

### DIFF
--- a/.github/release-notes/v4.3.0.md
+++ b/.github/release-notes/v4.3.0.md
@@ -1,0 +1,88 @@
+## What's new
+
+Threadnote 4.3 makes native code intelligence substantially more responsive and predictable in large repositories,
+improves recall across monorepos and shared memory, and makes long-running Workset and graph operations easier to
+understand and control.
+
+### Faster, bounded code-graph reads
+
+- Ordinary `query`, `node`, `neighbors`, and `explain` operations can use an existing ready snapshot immediately while
+  exact-current `path` and `impact` operations remain strict.
+- `threadnote graph analyze` and its statistics, community, group, hub, surprise, and confidence aliases now use this
+  worktree's ready snapshot by default instead of silently rebuilding a stale repository. Use `--freshness current`
+  for an explicit refresh or `--freshness allow-stale` to guarantee that no index is started.
+- Required foreground refreshes have a 25-second default budget, configurable with `--read-timeout-ms`. Timeouts
+  return an explicit state instead of continuing into analysis. `graph report` remains strict-current and never writes
+  stale or partial output after a timeout.
+- Large topology analysis returns a clearly qualified bounded result instead of discarding all useful topology when
+  the complete graph exceeds the analysis budget.
+
+### Less graph rematerialization work
+
+- Threadnote reuses complete, correctness-proven materialized graph batches within and across graph generations.
+  Incomplete, malformed, or ambiguous batches rebuild together rather than mixing attribution contexts.
+- A controlled 130-file differential reduced attribution from a 140 ms median to 16 ms while preserving identical
+  stored-graph digests. This is bounded component evidence, not a universal production latency claim.
+- Unchanged static TypeScript reexports remain incremental, and multiple valid declared-evidence records for one
+  structural dependency no longer force a false `project-closure-incomplete` fallback.
+- Ready-read, snapshot-release, and graph-analysis paths avoid redundant snapshot, provenance, cleanup, and maintenance
+  work.
+- Build status and Manager now separate raw-fact replay from materialized-shard replay and distinguish attributed,
+  exact-generation, and cross-generation files.
+
+### Better recall and memory hygiene
+
+- Explicit Project, Workset, and approved-authority boundaries are applied before lexical and vector result limits, so
+  unrelated records cannot crowd out eligible evidence. Omit `project` for global recall or use a Workset for its
+  configured repository union.
+- Nested `callerCwd` values add monorepo package context without turning packages into hard silos. Repo-wide records
+  and bounded stronger sibling-package evidence remain available.
+- Exact camelCase and PascalCase identifiers, canonical recency, pinned URIs, and shared-memory aliases are handled
+  more accurately. Identical authorized copies collapse into one result with aliases retained; divergent copies stay
+  visible for review.
+- `recall_context` returns a bounded unread-pointer queue, and large `read_context` responses use opaque continuation
+  cursors. Session-start guidance explicitly requires reading those pointers before treating memory as evidence.
+- `compact` remains preview-first while adding conservative lifecycle archival, provenance-preserving duplicate
+  retirement, and read-only cross-share merge review.
+- Managed memory paths now require `remember_context`; raw `add_resource` writes are rejected so identity and locking
+  guarantees cannot be bypassed.
+
+### Clearer Workset preparation
+
+- CLI and Manager show the active repository, retry attempt, indexing phase and counters, completed-member count,
+  catalog, bridge, publication phases, and elapsed time.
+- Retryable repository failures receive one bounded retry.
+- Final receipts distinguish publication success from complete or incomplete member coverage and include typed
+  recovery guidance. Live progress stays on stderr while the final machine-readable receipt stays on stdout.
+
+### Expanded privacy-safe operations telemetry
+
+- Optional anonymous telemetry can report a closed automatic-update result and whether an applied update still needs
+  repair.
+- Graph-query telemetry adds only closed request and scope classes, stage timing, snapshot selection and freshness,
+  and power-of-two snapshot-size buckets. It never includes repository identity, paths, commits, query text, symbols,
+  results, or exact graph counts.
+- The operated dashboard definition adds automatic-update and graph-query views, excludes synthetic canary traffic
+  from every Tempo query, and handles an empty unexpected-full-build denominator safely.
+
+This is a material expansion of the optional telemetry contract. Existing consent-v1, consent-v2, and consent-v3
+configurations fail closed after the upgrade; review the current preview and opt in again only if you agree:
+
+```sh
+threadnote telemetry status
+threadnote telemetry enable
+threadnote telemetry enable --apply
+```
+
+Restart already-connected MCP clients after changing telemetry consent; CLI changes apply on the next invocation. The
+production schema-v4 gateway, all-version canary, and v4-capable dashboard must be deployed and verified before the 4.3
+application binaries are published.
+
+Older materialized-shard cache derivations are safely ignored and repopulated as needed, and disposable recall indexes
+rebuild automatically. Canonical memories and ready graphs are not rewritten.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/.github/release-notes/v4.3.0.md
+++ b/.github/release-notes/v4.3.0.md
@@ -34,16 +34,22 @@ understand and control.
 
 - Explicit Project, Workset, and approved-authority boundaries are applied before lexical and vector result limits, so
   unrelated records cannot crowd out eligible evidence. Omit `project` for global recall or use a Workset for its
-  configured repository union.
+  configured repository union. The default topical relevance threshold is now `0.3`; explicit or environment-provided
+  thresholds are strict `0..1` filters and are not bypassed by exact-match rescue.
 - Nested `callerCwd` values add monorepo package context without turning packages into hard silos. Repo-wide records
-  and bounded stronger sibling-package evidence remain available.
+  and bounded stronger sibling-package evidence remain available. New memories persist the nearest package/app as
+  `workspace_scope`, legacy memories stay repo-wide, and explicit current-branch queries receive branch affinity.
 - Exact camelCase and PascalCase identifiers, canonical recency, pinned URIs, and shared-memory aliases are handled
   more accurately. Identical authorized copies collapse into one result with aliases retained; divergent copies stay
   visible for review.
-- `recall_context` returns a bounded unread-pointer queue, and large `read_context` responses use opaque continuation
-  cursors. Session-start guidance explicitly requires reading those pointers before treating memory as evidence.
-- `compact` remains preview-first while adding conservative lifecycle archival, provenance-preserving duplicate
-  retirement, and read-only cross-share merge review.
+- `recall_context` returns a bounded unread-pointer queue; full reasons, signals, expansions, and warnings require
+  `explain: true`. Standard MCP `resources/read` is capped at 4,500 bytes, while `read_context` pages content at up to
+  1,500 estimated tokens with opaque, process-local, single-use cursors that expire after ten minutes. It also supports
+  outlines and exact-heading section reads. Session-start guidance explicitly requires reading returned pointers before
+  treating memory as evidence.
+- `compact` remains preview-first while adding expiry archival, seven-day terminal-handoff archival, review of
+  nonterminal handoffs after fourteen days, thirty-day active-handoff archival unless explicitly pending,
+  provenance-preserving exact-duplicate retirement, and read-only cross-share merge review.
 - Managed memory paths now require `remember_context`; raw `add_resource` writes are rejected so identity and locking
   guarantees cannot be bypassed.
 
@@ -59,6 +65,8 @@ understand and control.
 
 - Optional anonymous telemetry can report a closed automatic-update result and whether an applied update still needs
   repair.
+- Workset preparation can report only closed phase/checkpoint, bounded work-unit, terminal coverage, and failure-class
+  evidence through the existing privacy-safe operation fields.
 - Graph-query telemetry adds only closed request and scope classes, stage timing, snapshot selection and freshness,
   and power-of-two snapshot-size buckets. It never includes repository identity, paths, commits, query text, symbols,
   results, or exact graph counts.

--- a/.github/release-notes/v4.3.0.md
+++ b/.github/release-notes/v4.3.0.md
@@ -43,10 +43,10 @@ understand and control.
   more accurately. Identical authorized copies collapse into one result with aliases retained; divergent copies stay
   visible for review.
 - `recall_context` returns a bounded unread-pointer queue; full reasons, signals, expansions, and warnings require
-  `explain: true`. Standard MCP `resources/read` is capped at 4,500 bytes, while `read_context` pages content at up to
-  1,500 estimated tokens with opaque, process-local, single-use cursors that expire after ten minutes. It also supports
-  outlines and exact-heading section reads. Session-start guidance explicitly requires reading returned pointers before
-  treating memory as evidence.
+  `explain: true`. Standard MCP `resources/read` is capped at 4,500 bytes, while local `read_context` pages content at
+  up to 1,500 estimated tokens with opaque, process-local, single-use cursors that expire after ten minutes. It also
+  supports outlines and exact-heading section reads. Session-start guidance explicitly requires reading returned
+  pointers before treating memory as evidence.
 - `compact` remains preview-first while adding expiry archival, seven-day terminal-handoff archival, review of
   nonterminal handoffs after fourteen days, thirty-day active-handoff archival unless explicitly pending,
   provenance-preserving exact-duplicate retirement, and read-only cross-share merge review.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.2.7",
+  "version": "4.3.0",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump the standalone package version from 4.2.7 to 4.3.0
- add curated v4.3.0 release notes covering all 19 merged PRs since immutable v4.2.7
- document graph read/materialization improvements, recall and memory changes, Workset progress, telemetry v4, compatibility boundaries, and the normal update flow
- record the compatibility-sensitive MCP read/paging, recall-threshold, workspace-affinity, compact-lifecycle, and Workset-telemetry changes

## Release boundary
- previous production tag: `v4.2.7` / `297cdb92bd164ed2ea58dd6c366c60c67aba97cf`
- candidate base: `5ebd2c643f9df2d88b4783b4f6e10236b75e42ee`
- exact PR head: `91712267439e9c3e0e9d2177a7314cdf85ef9a2d`
- range: 19 merged PRs, 224 changed files
- the internal implementation plan remains absent

## Verification
- independent release-note/change-inventory review: clean
- final memory-contract and migration review: clean
- release contract tests: 11 passed
- website/release-note contracts: 60 passed
- full source, test, and website typechecks passed in the commit hooks
- repository lint, formatting, file-length, and diff checks passed
- exact-head PR CI: 41 success, 17 conditional skips, 0 failures
- exact-head global development install and ready/current graph-analysis smoke passed
- manual pre-tag signing rehearsal [32429868004](https://github.com/Kashkovsky/threadnote/actions/runs/32429868004): both macOS architectures passed strict doctor, real-model smoke, Developer ID signing, notarization, archive creation, and private artifact upload; publication jobs stayed skipped

## Candidate evidence disposition
Exact-base Platform run [32424499911](https://github.com/Kashkovsky/threadnote/actions/runs/32424499911) produced mixed, bounded evidence:

- 100k lexical, Workset, load, 10k pinned-vector, and heavy-tail lanes passed
- heavy-tail passed all seven correctness/resume assertions
- production-large timed out at the intentional 20-minute capture bound on both observations; the repeat reached materialization and retained a second privacy-safe checkpoint, but neither observation completed
- 100k pinned-vector repeated the known 60-minute cancellation signature and produced no result artifact; it was not blindly rerun
- the governed >=200k ready-query environment is still unprovisioned and has no qualifying run

Therefore this candidate does **not** establish completed 73k production-shaped indexing, a cold-index speedup, successful 100k-vector evidence, or verified >=200k readiness. The bounded 130-file attribution improvement in the release note remains the only performance claim.

## Do not merge or tag yet
This PR must remain draft until:

1. the two least-privilege Grafana service-account credentials are rotated;
2. the corrected 25-panel dashboard deploys and passes live verification after the existing HTTP 401 failures;
3. the release owner explicitly accepts or blocks on the incomplete production-large/100k-vector evidence described above.

Pushing `v4.3.0` is the public publication authorization point. No tag or GitHub Release should be created manually from this draft.