### PR TITLE
Align telemetry dashboard with Grafana normalization

### DIFF
--- a/infra/telemetry-dashboard/threadnote-telemetry.artifact
+++ b/infra/telemetry-dashboard/threadnote-telemetry.artifact
@@ -1667,7 +1667,6 @@
           }
         ],
         "title": "Automatic update results",
-        "transformations": [],
         "type": "timeseries"
       },
       {

--- a/infra/telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json
+++ b/infra/telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json
@@ -1701,7 +1701,6 @@
         }
       ],
       "title": "Automatic update results",
-      "transformations": [],
       "type": "timeseries"
     },
     {

--- a/test/unit/telemetry-gateway-dashboard.test.ts
+++ b/test/unit/telemetry-gateway-dashboard.test.ts
@@ -519,7 +519,7 @@ describe('Threadnote Grafana dashboard', () => {
       expect(automaticUpdates?.title).toBe('Automatic update results');
       expect(automaticUpdates?.type).toBe('timeseries');
       expect(automaticUpdates?.targets).toHaveLength(1);
-      expect(automaticUpdates?.transformations).toEqual([]);
+      expect(automaticUpdates?.transformations).toBeUndefined();
       const automaticUpdateQuery = automaticUpdates?.targets[0]?.query;
       expect(automaticUpdateQuery).toContain(autoUpdateSchemaPredicate);
       expect(automaticUpdateQuery).toContain(canaryExclusionPredicate);


### PR DESCRIPTION
## Summary

- omit panel 21's redundant empty `transformations` list from the canonical dashboard source and artifact
- assert the server-normalized optional field remains absent
- restore exact live-vs-artifact reconciliation after Grafana accepted the 25-panel update

## Evidence

- dashboard render check passed
- focused dashboard suites: 33/33 passed
- repository lint, formatting, and configured typechecks passed
- independent review: no critical or important findings
- read-only live comparison: exact semantic equality, 25 panels / 65,504 canonical bytes

## Rollout

After merge, the protected dashboard workflow should reconcile as a no-op and continue through private ACL and bounded Tempo-query verification.