### PR TITLE
fix: restore read_context content for structured MCP clients

### DIFF
--- a/.github/release-notes/v4.3.1.md
+++ b/.github/release-notes/v4.3.1.md
@@ -1,0 +1,18 @@
+## What's new
+
+Threadnote 4.3.1 restores paged memory content for MCP clients that prefer structured tool results.
+
+### Reliable paged reads
+
+- Local and remote `read_context` responses now carry the same bounded page body in both standard text content and
+  structured content, so structured-first clients can read and reconstruct the evidence.
+- Whole-response token budgeting accounts for both representations, including JSON escaping, while preserving exact
+  Unicode reconstruction, opaque single-use cursors, source-change detection, and measured token estimates.
+- Tool descriptions now spell out the continuation contract: pass the cursor without URI, mode, or section selectors;
+  `budgetTokens` may still be adjusted between pages.
+
+Restart connected MCP clients after updating. Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/mcp_server_recall.ts
+++ b/src/mcp_server_recall.ts
@@ -1185,13 +1185,15 @@ export function registerReadTool(
     name,
     {
       annotations: {readOnlyHint: true, destructiveHint: false},
-      description: `${description} Paged at no more than 1500 estimated tokens; pass its cursor to continue.`,
+      description: `${description} Paged at no more than 1500 estimated tokens. Start with uri or uris. To continue, pass cursor without uri, uris, mode, or section; budgetTokens may be adjusted.`,
       inputSchema: {
-        budgetTokens: McpInput.integer(undefined, {
+        budgetTokens: McpInput.integer('Whole-response budget; defaults to 1500 tokens', {
           minimum: MEMORY_READ_MINIMUM_BUDGET_TOKENS,
           maximum: MEMORY_READ_MAXIMUM_BUDGET_TOKENS,
         }),
-        cursor: McpInput.string(),
+        cursor: McpInput.string(
+          'Opaque single-use continuation from the prior page; omit uri, uris, mode, and section when present',
+        ),
         mode: McpInput.literals(['content', 'outline']),
         section: McpInput.string(),
         uri: McpInput.string(),

--- a/src/memory_read_projection.ts
+++ b/src/memory_read_projection.ts
@@ -34,6 +34,8 @@ export interface MemoryReadCursorState {
 export interface MemoryReadPageStructuredContent {
   readonly budgetTokens: number;
   readonly complete: boolean;
+  /** Mirrors the text content block for MCP clients that surface only structured results. */
+  readonly content: string;
   readonly contentBytes: number;
   readonly cursor?: string;
   readonly estimatedTokens: number;
@@ -201,59 +203,66 @@ export function projectMemoryReadPage(
     {section, warnings: undefined},
     {section: undefined, warnings: undefined},
   ] as const;
+  const firstBoundary = unicodeBoundariesWithin(resource.text, position.characterOffset, 4)[1];
+  const minimumContent =
+    firstBoundary === undefined ? '' : resource.text.slice(position.characterOffset, firstBoundary);
   const responseOptions = responseOptionCandidates.find(candidate => {
-    const envelope = baseStructuredContent({
-      budgetTokens,
-      complete: false,
-      contentBytes: maximumBytes,
-      cursor: options.continuationCursor,
-      estimatedTokens: budgetTokens,
-      mode,
-      resourceCount: resources.length,
-      resourceIndex: position.resourceIndex,
-      section: candidate.section,
-      warnings: candidate.warnings,
-    });
-    return maximumBytes - utf8Bytes(receipt ?? '') - utf8Bytes(JSON.stringify(envelope)) >= 4;
+    const envelope = finalizedStructuredContent(
+      baseStructuredContent({
+        budgetTokens,
+        complete: false,
+        content: minimumContent,
+        contentBytes: utf8Bytes(minimumContent),
+        cursor: options.continuationCursor,
+        mode,
+        resourceCount: resources.length,
+        resourceIndex: position.resourceIndex,
+        section: candidate.section,
+        warnings: candidate.warnings,
+      }),
+      receipt,
+    );
+    return responseBytes(minimumContent, receipt, envelope) <= maximumBytes;
   }) ?? {section: undefined, warnings: undefined};
+
+  const structuredContentFor = (
+    content: string,
+    complete: boolean,
+    cursor: string | undefined,
+    responseReceipt: string | undefined,
+  ): MemoryReadPageStructuredContent =>
+    finalizedStructuredContent(
+      baseStructuredContent({
+        budgetTokens,
+        complete,
+        content,
+        contentBytes: utf8Bytes(content),
+        ...(cursor === undefined ? {} : {cursor}),
+        mode,
+        resourceCount: resources.length,
+        resourceIndex: position.resourceIndex,
+        section: responseOptions.section,
+        warnings: responseOptions.warnings,
+      }),
+      responseReceipt,
+    );
 
   const completeCandidate = resource.text.slice(position.characterOffset);
   const isLastResource = position.resourceIndex === resources.length - 1;
   if (isLastResource) {
-    const completeEnvelope = baseStructuredContent({
-      budgetTokens,
-      complete: true,
-      contentBytes: utf8Bytes(completeCandidate),
-      mode,
-      resourceCount: resources.length,
-      resourceIndex: position.resourceIndex,
-      section: responseOptions.section,
-      warnings: responseOptions.warnings,
-    });
-    const completed = finalizedStructuredContent(completeEnvelope, completeCandidate);
+    const completed = structuredContentFor(completeCandidate, true, undefined, undefined);
     if (responseBytes(completeCandidate, undefined, completed) <= maximumBytes) {
       return {complete: true, content: completeCandidate, structuredContent: completed, uri: resource.uri};
     }
   }
 
-  const conservativeEnvelope = baseStructuredContent({
-    budgetTokens,
-    complete: false,
-    contentBytes: maximumBytes,
-    cursor: options.continuationCursor,
-    estimatedTokens: budgetTokens,
-    mode,
-    resourceCount: resources.length,
-    resourceIndex: position.resourceIndex,
-    section: responseOptions.section,
-    warnings: responseOptions.warnings,
-  });
-  const availableContentBytes =
-    maximumBytes - utf8Bytes(receipt ?? '') - utf8Bytes(JSON.stringify(conservativeEnvelope));
-  if (availableContentBytes < 1) {
-    throw new MemoryReadProjectionError(`Memory read budgetTokens=${budgetTokens} cannot fit the paging envelope.`);
-  }
-  const slice = utf8Prefix(resource.text, position.characterOffset, availableContentBytes);
+  const slice = largestFittingMemoryReadPrefix(
+    resource.text,
+    position.characterOffset,
+    maximumBytes,
+    receipt,
+    content => structuredContentFor(content, false, options.continuationCursor, receipt),
+  );
   if (slice.end === position.characterOffset && position.characterOffset < resource.text.length) {
     throw new MemoryReadProjectionError(`Memory read budgetTokens=${budgetTokens} cannot fit one Unicode character.`);
   }
@@ -264,18 +273,7 @@ export function projectMemoryReadPage(
   if (nextPosition.resourceIndex >= resources.length) {
     throw new MemoryReadProjectionError('Memory read projection produced an invalid terminal continuation.');
   }
-  const envelope = baseStructuredContent({
-    budgetTokens,
-    complete: false,
-    contentBytes: utf8Bytes(slice.text),
-    cursor: options.continuationCursor,
-    mode,
-    resourceCount: resources.length,
-    resourceIndex: position.resourceIndex,
-    section: responseOptions.section,
-    warnings: responseOptions.warnings,
-  });
-  const structuredContent = finalizedStructuredContent(envelope, slice.text, receipt);
+  const structuredContent = structuredContentFor(slice.text, false, options.continuationCursor, receipt);
   if (responseBytes(slice.text, receipt, structuredContent) > maximumBytes) {
     throw new MemoryReadProjectionError('Memory read projection exceeded its response budget.');
   }
@@ -287,6 +285,50 @@ export function projectMemoryReadPage(
     structuredContent,
     uri: resource.uri,
   };
+}
+
+function largestFittingMemoryReadPrefix(
+  value: string,
+  start: number,
+  maximumBytes: number,
+  receipt: string | undefined,
+  structuredContentFor: (content: string) => MemoryReadPageStructuredContent,
+): {readonly end: number; readonly text: string} {
+  const boundaries = unicodeBoundariesWithin(value, start, maximumBytes);
+  let lower = 0;
+  let upper = boundaries.length - 1;
+  let selected = 0;
+  while (lower <= upper) {
+    const middle = Math.floor((lower + upper) / 2);
+    const end = boundaries[middle]!;
+    const content = value.slice(start, end);
+    const structuredContent = structuredContentFor(content);
+    if (responseBytes(content, receipt, structuredContent) <= maximumBytes) {
+      selected = middle;
+      lower = middle + 1;
+    } else {
+      upper = middle - 1;
+    }
+  }
+  const end = boundaries[selected]!;
+  return {end, text: value.slice(start, end)};
+}
+
+function unicodeBoundariesWithin(value: string, start: number, maximumBytes: number): number[] {
+  const boundaries = [start];
+  let bytes = 0;
+  let end = start;
+  while (end < value.length) {
+    const codePoint = value.codePointAt(end);
+    if (codePoint === undefined) break;
+    const width = codePoint > 0xffff ? 2 : 1;
+    const characterBytes = utf8Bytes(value.slice(end, end + width));
+    if (bytes + characterBytes > maximumBytes) break;
+    bytes += characterBytes;
+    end += width;
+    boundaries.push(end);
+  }
+  return boundaries;
 }
 
 export function memoryReadPageEstimatedTokens(page: MemoryReadPage): number {
@@ -383,6 +425,7 @@ function boundedWarnings(warnings: readonly string[] | undefined): string[] | un
 function baseStructuredContent(input: {
   readonly budgetTokens: number;
   readonly complete: boolean;
+  readonly content: string;
   readonly contentBytes: number;
   readonly cursor?: string;
   readonly estimatedTokens?: number;
@@ -395,6 +438,7 @@ function baseStructuredContent(input: {
   return {
     budgetTokens: input.budgetTokens,
     complete: input.complete,
+    content: input.content,
     contentBytes: input.contentBytes,
     ...(input.cursor === undefined ? {} : {cursor: input.cursor}),
     estimatedTokens: input.estimatedTokens ?? 0,
@@ -410,12 +454,11 @@ function baseStructuredContent(input: {
 
 function finalizedStructuredContent(
   input: MemoryReadPageStructuredContent,
-  content: string,
   receipt?: string,
 ): MemoryReadPageStructuredContent {
   let value = input;
   for (let iteration = 0; iteration < 4; iteration += 1) {
-    const next = {...value, estimatedTokens: estimatedTokens(responseBytes(content, receipt, value))};
+    const next = {...value, estimatedTokens: estimatedTokens(responseBytes(value.content, receipt, value))};
     if (next.estimatedTokens === value.estimatedTokens) return next;
     value = next;
   }

--- a/src/remote_memory/tools.ts
+++ b/src/remote_memory/tools.ts
@@ -74,8 +74,14 @@ const RemoteReadToolInput = z
       .int()
       .min(REMOTE_MEMORY_READ_MINIMUM_BUDGET_TOKENS)
       .max(MEMORY_READ_MAXIMUM_BUDGET_TOKENS)
-      .default(MEMORY_READ_DEFAULT_BUDGET_TOKENS),
-    cursor: z.string().min(1).max(REMOTE_MEMORY_READ_CURSOR_MAXIMUM_BYTES).optional(),
+      .default(MEMORY_READ_DEFAULT_BUDGET_TOKENS)
+      .describe('Whole-response budget; defaults to 1500 tokens'),
+    cursor: z
+      .string()
+      .min(1)
+      .max(REMOTE_MEMORY_READ_CURSOR_MAXIMUM_BYTES)
+      .optional()
+      .describe('Opaque continuation; omit uri, mode, revision, and section when present'),
     mode: z.enum(['content', 'outline']).optional(),
     revision: Identifier.optional(),
     section: z
@@ -172,7 +178,7 @@ export function createRemoteMemoryMcpServer(options: RemoteMemoryMcpServerOption
     {
       annotations: {readOnlyHint: true},
       description:
-        'Read untrusted remote evidence in pages of at most 1500 estimated tokens. Continue with its opaque revision-pinned cursor; mode=outline and exact-heading section reads are supported.',
+        'Read untrusted remote evidence in pages of at most 1500 estimated tokens. Start with uri and version. To continue, pass cursor and version without uri, mode, revision, or section; budgetTokens may be adjusted. mode=outline and exact-heading section reads are supported.',
       inputSchema: RemoteReadToolInput,
     },
     input => invokeRemoteReadTool(requestContext, dependencies, input),

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -26,8 +26,11 @@ interface ThreadnoteProgress {
 interface ReadPageStructuredContent {
   readonly budgetTokens: number;
   readonly complete: boolean;
+  readonly content: string;
   readonly cursor?: string;
   readonly estimatedTokens: number;
+  readonly resource: number;
+  readonly resourceCount: number;
   readonly type: 'threadnote-read-page';
 }
 
@@ -240,9 +243,9 @@ describe('Threadnote MCP toolsets', () => {
         expect(tools.tools.find(tool => tool.name === 'recall_context')?.description).toContain(
           'unread threadnote:// pointers, not evidence',
         );
-        expect(tools.tools.find(tool => tool.name === 'read_context')?.description).toContain(
-          'no more than 1500 estimated tokens',
-        );
+        const readContext = tools.tools.find(tool => tool.name === 'read_context');
+        expect(readContext?.description).toContain('no more than 1500 estimated tokens');
+        expect(readContext?.description).toContain('pass cursor without uri, uris, mode, or section');
       },
       {toolset: null},
     );
@@ -821,7 +824,7 @@ describe('Threadnote MCP toolsets', () => {
     );
   });
 
-  it('bounds read_context by default and reconstructs exact Unicode content through opaque continuations', async () => {
+  it('bounds read_context and reconstructs exact Unicode content for content- and structured-first clients', async () => {
     await withMcpClient(
       async (client, fixture) => {
         const uri = 'threadnote://user/test-user/memories/durable/projects/threadnote/bounded-read.md';
@@ -832,7 +835,7 @@ describe('Threadnote MCP toolsets', () => {
         const reconstructed: string[] = [];
         let cursor: string | undefined;
         let previousCursor: string | undefined;
-        for (let pageNumber = 0; pageNumber < 100; pageNumber += 1) {
+        for (let pageNumber = 0; pageNumber < 1_000; pageNumber += 1) {
           const result = await client.callTool(
             {
               arguments: cursor === undefined ? {budgetTokens, uri} : {budgetTokens, cursor},
@@ -843,8 +846,9 @@ describe('Threadnote MCP toolsets', () => {
           );
           expect(result.isError, JSON.stringify(result)).not.toBe(true);
           const output = Array.isArray(result.content) ? result.content : [];
-          const pageText = (output[0] as TextContent | undefined)?.text ?? '';
           const structured = result.structuredContent as ReadPageStructuredContent;
+          const pageText = structured.content;
+          expect((output[0] as TextContent | undefined)?.text).toBe(pageText);
           const responseBytes =
             output.reduce(
               (total, item) => total + (item.type === 'text' ? Buffer.byteLength(item.text, 'utf8') : 0),
@@ -863,7 +867,7 @@ describe('Threadnote MCP toolsets', () => {
           expect(structured.cursor).not.toContain('threadnote');
           previousCursor = cursor;
           cursor = structured.cursor;
-          if (pageNumber === 99) throw new TestError('Bounded read did not terminate.');
+          if (pageNumber === 999) throw new TestError('Bounded read did not terminate.');
         }
         expect(reconstructed.join('')).toBe(content);
 
@@ -877,6 +881,47 @@ describe('Threadnote MCP toolsets', () => {
       {toolset: 'core'},
     );
   }, 40_000);
+
+  it('advances read_context across repeated pages of one resource and then later resources', async () => {
+    await withMcpClient(
+      async (client, fixture) => {
+        const names = ['multi-one', 'multi-two', 'multi-three'] as const;
+        const uris = names.map(name => `threadnote://user/test-user/memories/durable/projects/threadnote/${name}.md`);
+        const contents = [
+          canonicalMemoryContent(names[0], `${'0123456789'.repeat(260)}first terminal`),
+          canonicalMemoryContent(names[1], 'second resource'),
+          canonicalMemoryContent(names[2], 'third resource'),
+        ];
+        for (const [index, name] of names.entries()) {
+          await writeCanonicalMemory(fixture.home, `${name}.md`, contents[index]!);
+        }
+
+        const resources: number[] = [];
+        const pages: string[] = [];
+        let cursor: string | undefined;
+        for (let pageNumber = 0; pageNumber < 10; pageNumber += 1) {
+          const result = await client.callTool({
+            arguments: cursor === undefined ? {budgetTokens: 1_500, uris} : {budgetTokens: 1_500, cursor},
+            name: 'read_context',
+          });
+          expect(result.isError, JSON.stringify(result)).not.toBe(true);
+          const output = Array.isArray(result.content) ? result.content : [];
+          const structured = result.structuredContent as ReadPageStructuredContent;
+          expect((output[0] as TextContent | undefined)?.text).toBe(structured.content);
+          resources.push(structured.resource);
+          pages.push(structured.content);
+          if (structured.complete) break;
+          cursor = structured.cursor;
+          if (pageNumber === 9) throw new TestError('Multi-resource read did not terminate.');
+        }
+
+        expect(resources).toEqual([1, 1, 2, 3]);
+        expect(pages[0]).not.toBe(pages[1]);
+        expect(pages.join('')).toBe(contents.join(''));
+      },
+      {toolset: 'core'},
+    );
+  });
 
   it('invalidates a read_context cursor when canonical content changes between pages', async () => {
     await withMcpClient(

--- a/test/unit/memory-read-projection.test.ts
+++ b/test/unit/memory-read-projection.test.ts
@@ -29,7 +29,8 @@ describe('bounded memory read projection', () => {
               continuationCursor: memoryReadCursorToken('deterministic-property-cursor'),
               ...(position === undefined ? {} : {position}),
             });
-            reconstructed.push(page.content);
+            expect(page.structuredContent.content).toBe(page.content);
+            reconstructed.push(page.structuredContent.content);
             expect(memoryReadPageEstimatedTokens(page)).toBeLessThanOrEqual(budgetTokens);
             expect(page.structuredContent.estimatedTokens).toBe(memoryReadPageEstimatedTokens(page));
             if (page.complete) break;
@@ -53,6 +54,51 @@ describe('bounded memory read projection', () => {
     expect(projectMemoryReadPage(resources, options)).toEqual(projectMemoryReadPage(resources, options));
   });
 
+  it('reports measured response tokens instead of the allotted budget for a short complete page', () => {
+    const page = projectMemoryReadPage([{text: 'short evidence', uri: 'threadnote://test/short.md'}], {
+      budgetTokens: 1_500,
+      continuationCursor: memoryReadCursorToken('short-page-cursor'),
+    });
+
+    expect(page.complete).toBe(true);
+    expect(page.structuredContent.content).toBe('short evidence');
+    expect(page.structuredContent.estimatedTokens).toBe(memoryReadPageEstimatedTokens(page));
+    expect(page.structuredContent.estimatedTokens).toBeLessThan(page.structuredContent.budgetTokens);
+  });
+
+  it('mirrors a complete outline with its measured response budget', () => {
+    const page = projectMemoryReadPage(
+      [{text: '# Root\nintro\n## Details\nevidence\n', uri: 'threadnote://test/outline.md'}],
+      {
+        budgetTokens: 400,
+        continuationCursor: memoryReadCursorToken('outline-page-cursor'),
+        mode: 'outline',
+      },
+    );
+
+    expect(page.complete).toBe(true);
+    expect(page.content).toContain('## Details');
+    expect(page.structuredContent.content).toBe(page.content);
+    expect(page.structuredContent.estimatedTokens).toBe(memoryReadPageEstimatedTokens(page));
+    expect(page.structuredContent.estimatedTokens).toBeLessThan(page.structuredContent.budgetTokens);
+  });
+
+  it('drops optional metadata before rejecting a leading four-byte Unicode scalar at minimum budget', () => {
+    const page = projectMemoryReadPage(
+      [{text: `🙂${'bounded evidence\n'.repeat(100)}`, uri: 'threadnote://test/minimum-budget.md'}],
+      {
+        budgetTokens: 128,
+        continuationCursor: memoryReadCursorToken('minimum-budget-cursor'),
+        warnings: ['optional warning '.repeat(100)],
+      },
+    );
+
+    expect(page.content.startsWith('🙂')).toBe(true);
+    expect(page.structuredContent.content).toBe(page.content);
+    expect(page.structuredContent.warnings).toBeUndefined();
+    expect(memoryReadPageEstimatedTokens(page)).toBeLessThanOrEqual(128);
+  });
+
   it('retrieves a 100k-character memory exactly through bounded successive pages', () => {
     const content = `${'🙂漢字 bounded memory\n'.repeat(5_000)}terminal`;
     expect(content.length).toBeGreaterThan(100_000);
@@ -65,7 +111,8 @@ describe('bounded memory read projection', () => {
         continuationCursor: memoryReadCursorToken('large-memory-cursor'),
         ...(position === undefined ? {} : {position}),
       });
-      reconstructed.push(page.content);
+      expect(page.structuredContent.content).toBe(page.content);
+      reconstructed.push(page.structuredContent.content);
       if (page.complete) break;
       position = page.nextPosition;
       if (pageNumber === 999) throw new Error('Large memory pagination did not terminate.');

--- a/test/unit/remote-memory-http.test.ts
+++ b/test/unit/remote-memory-http.test.ts
@@ -474,7 +474,7 @@ describe('remote memory HTTP transport', () => {
     expect(test.calls).toContain('read:request-123');
   });
 
-  it('reconstructs a 1 MB remote memory through revision-pinned pages within the declared budget', async () => {
+  it('reconstructs a 1 MB remote memory from structured-first revision-pinned pages within budget', async () => {
     const prefix = 'MEMORY\nkind: durable\n\nREMOTE_PRIVATE_SENTINEL\n';
     const content = `${prefix}${'x'.repeat(1_000_000 - prefix.length)}`;
     const test = fixture({readContent: content, trackRateLimits: true});
@@ -502,8 +502,9 @@ describe('remote memory HTTP transport', () => {
       };
       expect(result.isError, JSON.stringify(payload)).not.toBe(true);
       const blocks = result.content ?? [];
-      const pageContent = blocks[0]?.text ?? '';
       const structured = result.structuredContent ?? {};
+      const pageContent = typeof structured.content === 'string' ? structured.content : '';
+      expect(blocks[0]?.text).toBe(pageContent);
       const responseBytes =
         blocks.reduce(
           (total, block) => total + (block.type === 'text' ? Buffer.byteLength(block.text ?? '', 'utf8') : 0),
@@ -511,7 +512,6 @@ describe('remote memory HTTP transport', () => {
         ) + Buffer.byteLength(JSON.stringify(structured), 'utf8');
       expect(responseBytes).toBeLessThanOrEqual(budgetTokens * 3);
       expect(structured.estimatedTokens).toBe(Math.ceil(responseBytes / 3));
-      expect(structured).not.toHaveProperty('content');
       reconstructed.push(pageContent);
       if (structured.complete === true) {
         expect(structured.cursor).toBeUndefined();
@@ -525,7 +525,9 @@ describe('remote memory HTTP transport', () => {
     expect(reconstructed.join('')).toBe(content);
     expect(test.readInputs[0]).toEqual({uri});
     expect(test.readInputs.slice(1).every(input => input.revision === 'revision-1')).toBe(true);
-    expect(test.readInputs.length).toBeLessThanOrEqual(300);
+    // Both MCP result channels carry the page body, so the bounded 1 MB fixture needs
+    // roughly twice as many requests as the former metadata-only structured result.
+    expect(test.readInputs.length).toBeLessThanOrEqual(650);
     expect(test.calls.filter(call => call === 'rate:read_context')).toHaveLength(test.readInputs.length);
   }, 30_000);
 


### PR DESCRIPTION
## Summary

- mirror each bounded read_context page into structuredContent.content while retaining standard text content
- account for both response representations, JSON escaping, Unicode boundaries, and remote source metadata
- document cursor-only continuation and prepare the 4.3.1 patch release

## Root cause

Claude Code prefers structuredContent when both MCP result channels exist. The v4.3.0 pager returned a metadata-only structured result, so Claude hid the canonical text blocks even though the pager and store were healthy.

## Validation

- 72 focused local, remote, and projection tests
- bounded Fast-check Unicode reconstruction through both channels
- source, test, and website TypeScript; strict lint; Prettier; release and website smokes
- independent review: zero critical or important findings
- exact-HEAD global install and structured-first reconstruction of the reported 6,679-byte memory across four pages
