### PR TITLE
Fix performance evidence deployment after squash

### DIFF
--- a/scripts/site-performance-evidence.ts
+++ b/scripts/site-performance-evidence.ts
@@ -35,6 +35,11 @@ export const performanceSourcePathspecs = [
   'tsconfig.json',
 ] as const;
 
+export const measuredPerformanceSourcePathspecs = [
+  ...performanceSourcePathspecs,
+  ':(exclude)scripts/site-performance-evidence.ts',
+] as const;
+
 export type PerformanceArtifactBinding = Readonly<{
   schemaVersion: 1;
   artifactSha256: string;
@@ -165,37 +170,31 @@ function requireSuccessfulGit(result: ReturnType<typeof Bun.spawnSync>, operatio
 }
 
 export function assertPerformanceSourceClean(repositoryRoot: string): void {
-  const unstaged = runGit(repositoryRoot, ['diff', '--quiet', '--', ...performanceSourcePathspecs]);
+  const unstaged = runGit(repositoryRoot, ['diff', '--quiet', '--', ...measuredPerformanceSourcePathspecs]);
   if (unstaged.exitCode === 1) {
     throw new ScriptError('Performance-bound sources contain tracked working-tree modifications.');
   }
   requireSuccessfulGit(unstaged, 'inspect tracked performance-source modifications');
 
-  const staged = runGit(repositoryRoot, ['diff', '--cached', '--quiet', '--', ...performanceSourcePathspecs]);
+  const staged = runGit(repositoryRoot, ['diff', '--cached', '--quiet', '--', ...measuredPerformanceSourcePathspecs]);
   if (staged.exitCode === 1) {
     throw new ScriptError('Performance-bound sources contain staged modifications.');
   }
   requireSuccessfulGit(staged, 'inspect staged performance-source modifications');
 
-  const untracked = runGit(repositoryRoot, ['ls-files', '--others', '-z', '--', ...performanceSourcePathspecs]);
+  const untracked = runGit(repositoryRoot, ['ls-files', '--others', '-z', '--', ...measuredPerformanceSourcePathspecs]);
   requireSuccessfulGit(untracked, 'inspect untracked performance sources');
   if ((untracked.stdout?.byteLength ?? 0) > 0) {
     throw new ScriptError('Performance-bound sources contain untracked files.');
   }
 }
 
-function verifySourceCommit(repositoryRoot: string, sourceCommit: string): void {
+export function assertPerformanceSourcesMatchCommit(repositoryRoot: string, sourceCommit: string): void {
   assertPerformanceSourceClean(repositoryRoot);
   const commit = runGit(repositoryRoot, ['cat-file', '-e', `${sourceCommit}^{commit}`]);
   if (commit.exitCode !== 0) {
     throw new ScriptError(
       `Retained performance source commit ${sourceCommit} is unavailable; use a full Git checkout for the website build.`,
-    );
-  }
-  const ancestor = runGit(repositoryRoot, ['merge-base', '--is-ancestor', sourceCommit, 'HEAD']);
-  if (ancestor.exitCode !== 0) {
-    throw new ScriptError(
-      `Retained performance source commit ${sourceCommit} is not an ancestor of the website build.`,
     );
   }
   const changed = runGit(repositoryRoot, [
@@ -204,7 +203,7 @@ function verifySourceCommit(repositoryRoot: string, sourceCommit: string): void 
     sourceCommit,
     'HEAD',
     '--',
-    ...performanceSourcePathspecs,
+    ...measuredPerformanceSourcePathspecs,
   ]);
   if (changed.exitCode !== 0) {
     throw new ScriptError(
@@ -265,7 +264,7 @@ function verifyReleaseEvidenceSource(repositoryRoot: string, payload: RetainedPe
 
 export async function computePerformanceSourceTreeSha256(repositoryRoot: string): Promise<string> {
   assertPerformanceSourceClean(repositoryRoot);
-  const listed = runGit(repositoryRoot, ['ls-files', '--stage', '-z', '--', ...performanceSourcePathspecs]);
+  const listed = runGit(repositoryRoot, ['ls-files', '--stage', '-z', '--', ...measuredPerformanceSourcePathspecs]);
   if (listed.exitCode !== 0) {
     throw new ScriptError(`Could not inventory performance-bound sources: ${decodeOutput(listed.stderr)}.`);
   }
@@ -332,7 +331,7 @@ export async function loadRetainedPerformanceEvidence(
     throw new ScriptError('Retained performance binding is not valid JSON.');
   }
   const binding = validatePerformanceArtifactBinding(bindingInput);
-  verifySourceCommit(repositoryRoot, binding.sourceThreadnoteCommit);
+  assertPerformanceSourcesMatchCommit(repositoryRoot, binding.sourceThreadnoteCommit);
   const [artifactBuffer, currentSourceTreeSha256, dependencyHashes] = await Promise.all([
     artifactFile.arrayBuffer(),
     computePerformanceSourceTreeSha256(repositoryRoot),
@@ -360,7 +359,7 @@ export async function writePerformanceArtifactBinding(repositoryRoot: string): P
 
   const artifactBytes = new Uint8Array(await artifactFile.arrayBuffer());
   const payload = parseRetainedPerformanceArtifactBytes(artifactBytes);
-  verifySourceCommit(repositoryRoot, payload.environment.commit);
+  assertPerformanceSourcesMatchCommit(repositoryRoot, payload.environment.commit);
   verifyReleaseEvidenceSource(repositoryRoot, payload);
   const [sourceTreeSha256, dependencyHashes] = await Promise.all([
     computePerformanceSourceTreeSha256(repositoryRoot),

--- a/test/unit/website-release-boundary.test.ts
+++ b/test/unit/website-release-boundary.test.ts
@@ -4,7 +4,10 @@ import {access, mkdir, mkdtemp, readFile, rm, stat, writeFile} from '../helpers/
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import {describe, expect, it} from 'vitest';
-import {assertPerformanceSourceClean} from '../../scripts/site-performance-evidence.js';
+import {
+  assertPerformanceSourceClean,
+  assertPerformanceSourcesMatchCommit,
+} from '../../scripts/site-performance-evidence.js';
 import {loadLatestMajorWebsiteReleases} from '../../scripts/site-release-notes.js';
 
 const root = process.cwd();
@@ -114,6 +117,7 @@ describe('website and standalone release boundary', () => {
     });
     expect(evidenceBuild).toContain('writePerformanceArtifactBinding');
     expect(evidenceBuild).toContain('assertPerformanceSourceClean');
+    expect(evidenceBuild).toContain("':(exclude)scripts/site-performance-evidence.ts'");
     expect(standaloneBuild).toContain(
       "const FORBIDDEN_RELEASE_DIRECTORIES = ['docs', 'training', 'website', 'site-dist'] as const;",
     );
@@ -148,6 +152,36 @@ describe('website and standalone release boundary', () => {
 
       await writeFile(join(repository, 'src', 'ignored.ts'), 'export const ignored = true;\n');
       expect(() => assertPerformanceSourceClean(repository)).toThrow('untracked files');
+    } finally {
+      await rm(repository, {force: true, recursive: true});
+    }
+  });
+
+  it('accepts byte-identical governed sources after a squash merge and rejects source drift', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'threadnote-performance-squash-'));
+    const git = (...arguments_: string[]) =>
+      execFileSync('git', arguments_, {cwd: repository, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']}).trim();
+    const commit = (...arguments_: string[]) =>
+      git('-c', 'user.name=Threadnote Test', '-c', 'user.email=threadnote@example.invalid', ...arguments_);
+    try {
+      await mkdir(join(repository, 'src'));
+      await writeFile(join(repository, 'src', 'governed.ts'), 'export const value = 1;\n');
+      git('init');
+      git('add', '.');
+      commit('commit', '-m', 'benchmark source');
+      const sourceCommit = git('rev-parse', 'HEAD');
+      const sourceTree = git('rev-parse', 'HEAD^{tree}');
+      const squashCommit = commit('commit-tree', sourceTree, '-m', 'squash merge');
+      git('switch', '--detach', squashCommit);
+
+      expect(() => assertPerformanceSourcesMatchCommit(repository, sourceCommit)).not.toThrow();
+
+      await writeFile(join(repository, 'src', 'governed.ts'), 'export const value = 2;\n');
+      git('add', '.');
+      commit('commit', '-m', 'runtime drift');
+      expect(() => assertPerformanceSourcesMatchCommit(repository, sourceCommit)).toThrow(
+        'runtime sources changed after the retained performance run',
+      );
     } finally {
       await rm(repository, {force: true, recursive: true});
     }

--- a/website/performance/evidence.binding.json
+++ b/website/performance/evidence.binding.json
@@ -3,5 +3,5 @@
   "artifactSha256": "7aa70fd5bf6912335deb6331264d1d37945409ad6857a122d2831dc934fe9494",
   "generatedAt": "2026-08-22T07:10:44.442Z",
   "sourceThreadnoteCommit": "c051c53a6621de23d5104a7fd5bf7c322305f73b",
-  "sourceTreeSha256": "33b3cbb6e5a3be071c39acb5fe0c87de8500d353e0f00f72e6e6de462a8d8c86"
+  "sourceTreeSha256": "a8e6afb56c6dd8fe405be364231e4adf556e00f6f6eaee0550f9de9a3c5aae19"
 }


### PR DESCRIPTION
## Summary\n- accept squash-merged benchmark sources when governed runtime bytes remain identical\n- exclude the publication-only evidence verifier from the measured runtime digest while retaining it in reviewed harness-delta validation\n- rebind the unchanged retained artifact and add a squash-regression test\n\n## Verification\n- focused website suite: 61 tests passed\n- test and website TypeScript checks passed\n- strict focused lint and Prettier passed\n- production website build passed with 47 crawler-visible documentation pages\n\nFixes the post-merge Website workflow failure from #196.