### PR TITLE
perf(code-graph): accelerate cache admission

### DIFF
--- a/src/code_graph/anonymous_telemetry.ts
+++ b/src/code_graph/anonymous_telemetry.ts
@@ -217,7 +217,15 @@ export function codeGraphAnonymousTelemetryFields(progress: CodeGraphProgress): 
   const phase = `graph.${progress.phase}` as AnonymousTelemetryFields['phase'];
   switch (progress.phase) {
     case 'registering':
-      return {phase};
+      return {
+        phase,
+        ...(progress.activity === undefined
+          ? {}
+          : {
+              elapsedMilliseconds: progress.activity.elapsedMilliseconds,
+              stage: progress.activity.stage,
+            }),
+      };
     case 'waiting':
       return {phase, ...(progress.reason === undefined ? {} : {waitingReason: progress.reason})};
     case 'reclaiming':

--- a/src/code_graph/build_status.ts
+++ b/src/code_graph/build_status.ts
@@ -36,6 +36,7 @@ import type {
   CodeGraphIndexSummary,
   CodeGraphMaterializationActivity,
   CodeGraphMaterializationMetrics,
+  CodeGraphRegistrationActivity,
   CodeGraphOverlayFallbackReason,
   CodeGraphProgress,
   CodeGraphResolutionActivity,
@@ -115,6 +116,10 @@ export interface CodeGraphBuildResolution {
   readonly activity: CodeGraphResolutionActivity & {readonly startedAt: string};
 }
 
+export interface CodeGraphBuildRegistration {
+  readonly activity: CodeGraphRegistrationActivity;
+}
+
 export interface CodeGraphBuildStatus {
   readonly activation?: CodeGraphBuildActivation;
   /** Privacy-safe in-flight activity; repository paths and content are intentionally omitted. */
@@ -148,6 +153,7 @@ export interface CodeGraphBuildStatus {
     /** Privacy-safe identity for callers waiting on the same source and extraction pipeline. */
     readonly key: string;
   };
+  readonly registration?: CodeGraphBuildRegistration;
   readonly resolution?: CodeGraphBuildResolution;
   readonly result?: {
     readonly dirty: boolean;
@@ -769,6 +775,7 @@ function observeProgress(
       extraction: progressExtraction(current.status.extraction, progress, pathHashSalt),
       materialization: progressMaterialization(current.status.materialization, progress, timestamp),
       phase: progress.phase,
+      registration: progressRegistration(progress),
       resolution: progressResolution(current.status.resolution, progress, timestamp),
       state: progress.phase === 'waiting' ? 'queued' : 'running',
       subphase: progressSubphase(progress),
@@ -817,6 +824,10 @@ function progressResolution(
   };
 }
 
+function progressRegistration(progress: CodeGraphProgress): CodeGraphBuildRegistration | undefined {
+  return progress.phase === 'registering' && progress.activity ? {activity: progress.activity} : undefined;
+}
+
 function progressSubphase(progress: CodeGraphProgress): string {
   if ('subphase' in progress && typeof progress.subphase === 'string') return boundedText(progress.subphase, 64);
   switch (progress.phase) {
@@ -827,7 +838,7 @@ function progressSubphase(progress: CodeGraphProgress): string {
     case 'materializing':
       return progress.activity?.stage ?? 'facts';
     case 'registering':
-      return 'registration';
+      return progress.activity?.stage ?? 'registration';
     case 'reclaiming':
       return 'superseded-snapshots';
     case 'scanning':

--- a/src/code_graph/build_status_codec.ts
+++ b/src/code_graph/build_status_codec.ts
@@ -27,6 +27,7 @@ import type {
   CodeGraphBuildCounters,
   CodeGraphBuildExtraction,
   CodeGraphBuildMaterialization,
+  CodeGraphBuildRegistration,
   CodeGraphBuildResolution,
   CodeGraphBuildState,
   CodeGraphBuildStatus,
@@ -110,6 +111,8 @@ export function parseCodeGraphBuildStatus(value: unknown): CodeGraphBuildStatus 
   if (value.timings !== undefined && !timings) return undefined;
   const materialization = parseMaterialization(value.materialization);
   if (value.materialization !== undefined && !materialization) return undefined;
+  const registration = parseRegistration(value.registration);
+  if (value.registration !== undefined && !registration) return undefined;
   const ownerStart = value.owner.processStartIdentity;
   if (ownerStart !== undefined && !isText(ownerStart, 256)) return undefined;
   const subphase = value.subphase;
@@ -144,6 +147,7 @@ export function parseCodeGraphBuildStatus(value: unknown): CodeGraphBuildStatus 
       worktreeId: value.identity.worktreeId,
     },
     ...(materialization ? {materialization} : {}),
+    ...(registration ? {registration} : {}),
     owner: {
       processId: Number(value.owner.processId),
       ...(ownerStart ? {processStartIdentity: ownerStart} : {}),
@@ -165,6 +169,29 @@ export function parseCodeGraphBuildStatus(value: unknown): CodeGraphBuildStatus 
       phaseStartedAt: timestamps.phaseStartedAt,
       startedAt: timestamps.startedAt,
       updatedAt: timestamps.updatedAt,
+    },
+  };
+}
+
+function parseRegistration(value: unknown): CodeGraphBuildRegistration | undefined {
+  if (!isRecord(value) || !isRecord(value.activity)) return undefined;
+  const activity = value.activity;
+  if (
+    activity.stage !== 'loading-cache' ||
+    !isNonNegativeFinite(activity.elapsedMilliseconds) ||
+    !Number.isSafeInteger(activity.generations) ||
+    Number(activity.generations) < 0 ||
+    !Number.isSafeInteger(activity.keys) ||
+    Number(activity.keys) < 0
+  ) {
+    return undefined;
+  }
+  return {
+    activity: {
+      elapsedMilliseconds: Number(activity.elapsedMilliseconds),
+      generations: Number(activity.generations),
+      keys: Number(activity.keys),
+      stage: 'loading-cache',
     },
   };
 }

--- a/src/code_graph/cache_capacity.ts
+++ b/src/code_graph/cache_capacity.ts
@@ -43,14 +43,26 @@ interface CodeGraphMaterializedShardCapacityFields extends CodeGraphFileBlobCapa
 }
 
 export function codeGraphFileBlobCapacityBytes(fields: CodeGraphFileBlobCapacityFields): number {
-  return codeGraphTextFieldsCapacityBytes(
-    fields.blobId ?? '',
-    fields.contentHash,
-    fields.extractorSet,
-    fields.path,
-    fields.factsJson,
-    fields.createdAt,
-    fields.reuseClass ?? '',
+  return saturatingCapacityAdd(
+    codeGraphTextFieldsCapacityBytes(
+      fields.blobId ?? '',
+      fields.contentHash,
+      fields.extractorSet,
+      fields.path,
+      fields.factsJson,
+      fields.createdAt,
+      fields.reuseClass ?? '',
+    ),
+    // The trigger-maintained admission authority duplicates only bounded hot
+    // metadata, never the fact payload. Reserve it in the same transaction so
+    // cache acceleration cannot weaken WAL/durable capacity protection.
+    codeGraphTextFieldsCapacityBytes(
+      fields.extractorSet,
+      fields.path,
+      fields.contentHash,
+      fields.blobId ?? '',
+      fields.reuseClass ?? '',
+    ),
   );
 }
 

--- a/src/code_graph/indexer_materialization.ts
+++ b/src/code_graph/indexer_materialization.ts
@@ -1,4 +1,4 @@
-import {Crypto, Effect, FileSystem, Option, Path} from 'effect';
+import {Clock, Crypto, Effect, FileSystem, Option, Path} from 'effect';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {SystemInfo} from '../effect/system.js';
 import {codeGraphBlobExtractionReuseClass, codeGraphBlobReuseCacheKey} from './blob_reuse.js';
@@ -1398,24 +1398,40 @@ export function cachedFileKeys(
   store: CodeGraphStoreShape,
   databasePath: string,
   languagePacks: CodeGraphLanguagePackRegistryShape,
+  onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void, unknown>,
 ): Effect.Effect<ReadonlySet<string>, unknown> {
-  return Effect.forEach(
-    codeGraphParserCacheLookupGenerations(languagePacks.cacheIdentities),
-    generation =>
-      store
-        .cachedCommittedFileKeys(databasePath, generation.storedIdentity)
-        .pipe(
-          Effect.map(
-            keys =>
-              new Set(
-                [...keys].map(key =>
-                  codeGraphActiveParserCacheKey(key, generation.storedIdentity, generation.activeIdentity),
+  return Effect.gen(function* () {
+    const startedAt = yield* Clock.currentTimeMillis;
+    const generations = codeGraphParserCacheLookupGenerations(languagePacks.cacheIdentities);
+    const sets = yield* Effect.forEach(
+      generations,
+      generation =>
+        store
+          .cachedCommittedFileKeys(databasePath, generation.storedIdentity)
+          .pipe(
+            Effect.map(
+              keys =>
+                new Set(
+                  [...keys].map(key =>
+                    codeGraphActiveParserCacheKey(key, generation.storedIdentity, generation.activeIdentity),
+                  ),
                 ),
-              ),
+            ),
           ),
-        ),
-    {concurrency: 1},
-  ).pipe(Effect.map(sets => new Set(sets.flatMap(set => [...set]))));
+      {concurrency: 1},
+    );
+    const keys = new Set(sets.flatMap(set => [...set]));
+    yield* onProgress?.({
+      activity: {
+        elapsedMilliseconds: Math.max(0, (yield* Clock.currentTimeMillis) - startedAt),
+        generations: generations.length,
+        keys: keys.size,
+        stage: 'loading-cache',
+      },
+      phase: 'registering',
+    }) ?? Effect.void;
+    return keys;
+  });
 }
 
 export function loadCachedFacts(

--- a/src/code_graph/indexer_service.ts
+++ b/src/code_graph/indexer_service.ts
@@ -265,7 +265,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       }
                       const cachedCommittedFileKeys = options.force
                         ? new Set<string>()
-                        : yield* cachedFileKeys(store, layout.databasePath, languagePacks);
+                        : yield* cachedFileKeys(store, layout.databasePath, languagePacks, options.onProgress);
                       const cacheCoalescer = cacheContentBatch({
                         databasePath: layout.databasePath,
                         languagePacks,
@@ -879,7 +879,12 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       );
                       yield* store.initialize(layout.databasePath);
                       const identity = {...currentIdentity, headCommit: options.commit};
-                      const cachedCommittedFileKeys = yield* cachedFileKeys(store, layout.databasePath, languagePacks);
+                      const cachedCommittedFileKeys = yield* cachedFileKeys(
+                        store,
+                        layout.databasePath,
+                        languagePacks,
+                        options.onProgress,
+                      );
                       const cacheCoalescer = cacheContentBatch({
                         databasePath: layout.databasePath,
                         languagePacks,

--- a/src/code_graph/isolated_builder.ts
+++ b/src/code_graph/isolated_builder.ts
@@ -139,13 +139,16 @@ export function codeGraphIsolatedBuilderSpawnPlan(
 export function codeGraphProgressFromBuildStatus(
   status: Pick<
     CodeGraphBuildStatus,
-    'activation' | 'counters' | 'materialization' | 'phase' | 'resolution' | 'subphase' | 'timings'
+    'activation' | 'counters' | 'materialization' | 'phase' | 'registration' | 'resolution' | 'subphase' | 'timings'
   >,
 ): CodeGraphProgress {
   const counters = status.counters;
   switch (status.phase) {
     case 'registering':
-      return {phase: 'registering'};
+      return {
+        ...(status.registration ? {activity: status.registration.activity} : {}),
+        phase: 'registering',
+      };
     case 'waiting':
       return {
         phase: 'waiting',

--- a/src/code_graph/json_progress.ts
+++ b/src/code_graph/json_progress.ts
@@ -93,7 +93,7 @@ function codeGraphJsonProgressSubstage(progress: CodeGraphProgress): string {
     case 'materializing':
       return `${progress.phase}/${progress.activity?.stage ?? 'facts'}`;
     case 'registering':
-      return `${progress.phase}/registration`;
+      return `${progress.phase}/${progress.activity?.stage ?? 'registration'}`;
     case 'reclaiming':
       return `${progress.phase}/superseded-snapshots`;
     case 'scanning':

--- a/src/code_graph/storage_attribution.ts
+++ b/src/code_graph/storage_attribution.ts
@@ -125,7 +125,11 @@ export function readCodeGraphStorageSemanticAttribution(
 }
 
 export function codeGraphStorageSemanticGroup(name: string): CodeGraphStorageSemanticGroupName {
-  if (/^(?:sqlite_autoindex_)?(?:file_blobs|materialized_file_shards|snapshot_file_shards)/u.test(name)) {
+  if (
+    /^(?:sqlite_autoindex_)?(?:file_blob_authority|file_blobs|materialized_file_shards|snapshot_file_shards)/u.test(
+      name,
+    )
+  ) {
     return 'facts-cache';
   }
   if (/^(?:sqlite_autoindex_)?(?:lexical_|symbol_terms)/u.test(name)) return 'lexical';

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -48,6 +48,7 @@ export {
   type CodeGraphPersistentSchemaMigrationPhase,
 } from './store_schema_contracts.js';
 export {codeGraphPersistentExtensionSchemaCompatible} from './store_schema_inspection.js';
+export {CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE} from './store_cache_authority.js';
 export {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION} from './types.js';
 export {nextPersistentActivationBatchRows} from './store_activation_core.js';
 export {codeGraphPersistedEndpointValidationPageStatement} from './store_activation_persistent.js';
@@ -77,6 +78,7 @@ export {
 } from './store_maintenance_core.js';
 export {
   codeGraphAdjacencyQueryStatement,
+  codeGraphCachedCommittedFileKeysStatement,
   codeGraphExactSymbolQueryStatement,
   codeGraphSymbolPathClass,
   codeGraphSymbolPathScoreMultiplier,

--- a/src/code_graph/store_cache_authority.ts
+++ b/src/code_graph/store_cache_authority.ts
@@ -1,0 +1,133 @@
+import {Effect} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {tableExists} from './store_session.js';
+import {CodeGraphStoreError} from './types.js';
+
+export const CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE = 'file_blob_authority';
+
+export const CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE} (
+    extractor_set TEXT NOT NULL,
+    path_hint TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    blob_id TEXT,
+    reuse_class TEXT,
+    PRIMARY KEY (extractor_set, path_hint, content_hash)
+  ) WITHOUT ROWID
+`;
+
+function authorityExpression(prefix = ''): string {
+  return `CASE
+    WHEN json_valid(${prefix}facts_json)
+    THEN json_extract(${prefix}facts_json, '$.path') = ${prefix}path_hint
+    ELSE 0
+  END`;
+}
+
+const CODE_GRAPH_FILE_BLOB_AUTHORITY_TRIGGERS = [
+  {
+    name: 'file_blobs_authority_insert',
+    sql: `CREATE TRIGGER IF NOT EXISTS file_blobs_authority_insert
+   AFTER INSERT ON file_blobs
+   WHEN (${authorityExpression('NEW.')}) = 1
+   BEGIN
+     INSERT INTO ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE} (
+       extractor_set, path_hint, content_hash, blob_id, reuse_class
+     ) VALUES (NEW.extractor_set, NEW.path_hint, NEW.content_hash, NEW.blob_id, NEW.reuse_class);
+   END`,
+  },
+  {
+    name: 'file_blobs_authority_delete',
+    sql: `CREATE TRIGGER IF NOT EXISTS file_blobs_authority_delete
+   AFTER DELETE ON file_blobs
+   BEGIN
+     DELETE FROM ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE}
+     WHERE extractor_set = OLD.extractor_set
+       AND path_hint = OLD.path_hint
+       AND content_hash = OLD.content_hash;
+   END`,
+  },
+  {
+    name: 'file_blobs_authority_update',
+    sql: `CREATE TRIGGER IF NOT EXISTS file_blobs_authority_update
+   AFTER UPDATE OF content_hash, extractor_set, path_hint, blob_id, reuse_class, facts_json ON file_blobs
+   BEGIN
+     DELETE FROM ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE}
+     WHERE extractor_set = OLD.extractor_set
+       AND path_hint = OLD.path_hint
+       AND content_hash = OLD.content_hash;
+     INSERT INTO ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE} (
+       extractor_set, path_hint, content_hash, blob_id, reuse_class
+     )
+     SELECT NEW.extractor_set, NEW.path_hint, NEW.content_hash, NEW.blob_id, NEW.reuse_class
+     WHERE (${authorityExpression('NEW.')}) = 1;
+   END`,
+  },
+] as const;
+
+export const CODE_GRAPH_FILE_BLOB_AUTHORITY_TRIGGER_SQL = CODE_GRAPH_FILE_BLOB_AUTHORITY_TRIGGERS.map(
+  trigger => trigger.sql,
+);
+
+const CODE_GRAPH_FILE_BLOB_AUTHORITY_BACKFILL_SQL = `
+  INSERT INTO ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE} (
+    extractor_set, path_hint, content_hash, blob_id, reuse_class
+  )
+  SELECT extractor_set, path_hint, content_hash, blob_id, reuse_class
+  FROM file_blobs
+  WHERE (${authorityExpression()}) = 1
+`;
+
+/**
+ * Publishes the narrow cache-authority projection and backfills it only when
+ * first created. Triggers keep later mutations atomic with their source row.
+ */
+export const ensureCodeGraphFileBlobAuthority = Effect.fn('codeGraph.ensureFileBlobAuthority')(function* (
+  sql: SqlClient.SqlClient,
+) {
+  if (!(yield* tableExists(sql, 'file_blobs'))) return;
+  const expected = new Map([
+    [CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE, {sql: CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE_SQL, type: 'table'}],
+    ...CODE_GRAPH_FILE_BLOB_AUTHORITY_TRIGGERS.map(
+      trigger => [trigger.name, {sql: trigger.sql, type: 'trigger'}] as const,
+    ),
+  ]);
+  const observed = yield* sql.unsafe<{readonly name: unknown; readonly sql: unknown; readonly type: unknown}>(
+    `SELECT name, type, sql
+     FROM sqlite_master
+     WHERE name IN (${[...expected].map(() => '?').join(', ')})`,
+    [...expected.keys()],
+  );
+  const conflictingObject = observed.some(row => {
+    const contract = typeof row.name === 'string' ? expected.get(row.name) : undefined;
+    return contract === undefined || row.type !== contract.type;
+  });
+  if (conflictingObject) {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph file cache authority schema is incompatible.'));
+  }
+  const current =
+    observed.length === expected.size &&
+    observed.every(row => {
+      const contract = expected.get(String(row.name));
+      return contract !== undefined && normalizedSchemaSql(row.sql) === normalizedSchemaSql(contract.sql);
+    });
+  if (current) return;
+
+  for (const trigger of CODE_GRAPH_FILE_BLOB_AUTHORITY_TRIGGERS) {
+    yield* sql.unsafe(`DROP TRIGGER IF EXISTS ${trigger.name}`);
+  }
+  yield* sql.unsafe(`DROP TABLE IF EXISTS ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE}`);
+  yield* sql.unsafe(CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE_SQL);
+  for (const trigger of CODE_GRAPH_FILE_BLOB_AUTHORITY_TRIGGER_SQL) yield* sql.unsafe(trigger);
+  yield* sql.unsafe(CODE_GRAPH_FILE_BLOB_AUTHORITY_BACKFILL_SQL);
+});
+
+function normalizedSchemaSql(value: unknown): string | undefined {
+  return typeof value === 'string'
+    ? value
+        .replace(/\bIF\s+NOT\s+EXISTS\b/giu, '')
+        .replace(/\s+/gu, ' ')
+        .trim()
+        .toLowerCase()
+    : undefined;
+}

--- a/src/code_graph/store_query_core.ts
+++ b/src/code_graph/store_query_core.ts
@@ -6,6 +6,7 @@ import {
   type CodeGraphBlobReuseFile,
 } from './blob_reuse.js';
 import {configureConnection} from './store_session.js';
+import {CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE} from './store_cache_authority.js';
 import {CODE_GRAPH_STORED_FACT_CODEC, storedCodeGraphFactRawBytesSql} from './fact_storage.js';
 import {type CodeGraphProvenance, CodeGraphStoreError} from './types.js';
 import {sqlTextOption} from './store_utilities.js';
@@ -151,18 +152,10 @@ function reusableFileBlobFirstDonorSubquery(): string {
       AND json_extract(donor.facts_json, '$.path') = donor.path_hint`;
 }
 
-const selectCachedCommittedFileKeys = Effect.fn('codeGraph.selectCachedCommittedFileKeys')(function* (
-  extractorSet: string,
-) {
-  const sql = yield* SqlClient.SqlClient;
-  yield* configureConnection(sql);
-  const rows = yield* sql<{
-    readonly blob_id: unknown;
-    readonly content_hash: string;
-    readonly path_hint: string;
-    readonly reuse_class: unknown;
-  }>`
-    SELECT
+export function codeGraphCachedCommittedFileKeysStatement(extractorSet: string): CodeGraphSqlQueryStatement {
+  return {
+    parameters: [extractorSet],
+    text: `SELECT
       CASE
         WHEN typeof(blob_id) = 'text' AND length(CAST(blob_id AS BLOB)) IN (40, 64) THEN blob_id
         ELSE NULL
@@ -173,13 +166,23 @@ const selectCachedCommittedFileKeys = Effect.fn('codeGraph.selectCachedCommitted
         WHEN typeof(reuse_class) = 'text' AND length(CAST(reuse_class AS BLOB)) <= 128 THEN reuse_class
         ELSE NULL
       END AS reuse_class
-    FROM file_blobs
-    WHERE extractor_set = ${extractorSet}
-      AND CASE
-        WHEN json_valid(facts_json) THEN json_extract(facts_json, '$.path')
-        ELSE NULL
-      END = path_hint
-  `;
+    FROM ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE}
+    WHERE extractor_set = ?`,
+  };
+}
+
+const selectCachedCommittedFileKeys = Effect.fn('codeGraph.selectCachedCommittedFileKeys')(function* (
+  extractorSet: string,
+) {
+  const sql = yield* SqlClient.SqlClient;
+  yield* configureConnection(sql);
+  const statement = codeGraphCachedCommittedFileKeysStatement(extractorSet);
+  const rows = yield* sql.unsafe<{
+    readonly blob_id: unknown;
+    readonly content_hash: string;
+    readonly path_hint: string;
+    readonly reuse_class: unknown;
+  }>(statement.text, statement.parameters);
   const keys = new Set(rows.map(row => `${row.path_hint}\0${row.content_hash}\0${extractorSet}`));
   for (const row of rows) {
     if (

--- a/src/code_graph/store_schema_initialization.ts
+++ b/src/code_graph/store_schema_initialization.ts
@@ -15,6 +15,7 @@ import {
   ensureSnapshotLeaseSchema,
 } from './store_schema_core.js';
 import {ensureInitialReconciliationIndexes} from './store_reconciliation_core.js';
+import {ensureCodeGraphFileBlobAuthority} from './store_cache_authority.js';
 
 /** Exact read-only admission shared by cleanup writers and both health paths. */
 
@@ -442,6 +443,7 @@ const initializeSchema = Effect.fn('codeGraph.initializeSchema')(function* (sql:
     ON file_blobs(blob_id, content_hash, extractor_set, reuse_class, path_hint)
     WHERE blob_id IS NOT NULL AND reuse_class IS NOT NULL
   `);
+  yield* ensureCodeGraphFileBlobAuthority(sql);
   // Routine cache reclamation resolves references from a disposable shard
   // back to snapshot-owned associations. Keep that reverse lookup indexed so
   // a bounded deletion page cannot hide a full association-table scan.

--- a/src/code_graph/store_schema_migration.ts
+++ b/src/code_graph/store_schema_migration.ts
@@ -38,6 +38,7 @@ import {
   codeGraphReconciliationIndexState,
 } from './store_reconciliation_core.js';
 import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconciliation.js';
+import {ensureCodeGraphFileBlobAuthority} from './store_cache_authority.js';
 import {
   codeGraphRemovedViewCleanupBaseSchemaAdmission,
   type CodeGraphRemovedViewCleanupSchemaAdmission,
@@ -206,6 +207,12 @@ const ensureCurrentCodeGraphQueryIndexes = Effect.fn('codeGraph.ensureCurrentQue
     CREATE INDEX IF NOT EXISTS edges_evidence_path
     ON edges(snapshot_id, evidence_path)
   `);
+  // Cache admission runs before inventory and previously evaluated JSON
+  // authority from every fact payload in the selected extractor generation.
+  // A narrow trigger-maintained table materializes that authority at write
+  // time and serves every admission projection without reading fact payloads
+  // or weakening corrupt-row rejection.
+  yield* ensureCodeGraphFileBlobAuthority(sql);
 });
 
 const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentExtensionTables')(function* (
@@ -325,6 +332,7 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
           recordedRevision === 8 ||
           recordedRevision === 9 ||
           recordedRevision === 10 ||
+          recordedRevision === 11 ||
           recordedRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) &&
         extensionSchemaCompatible
       ) {

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -3,7 +3,7 @@ import type {CodeGraphMonikerV1} from './cross_repository/types.js';
 
 export const CODE_GRAPH_SCHEMA_VERSION = 3 as const;
 /** Additive persistent surfaces that preserve the public graph-v3 row contract. */
-export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 11 as const;
+export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 12 as const;
 export const CODE_GRAPH_RESULT_VERSION = 1 as const;
 export const CODE_GRAPH_EXTRACTOR_GENERATION = 13 as const;
 export const CODE_GRAPH_EXTRACTOR_SET_VERSION = `native-code-graph-${CODE_GRAPH_EXTRACTOR_GENERATION}` as const;
@@ -329,8 +329,17 @@ export interface CodeGraphActivationActivity {
   readonly transactionMilliseconds?: number;
 }
 
+/** Path-free observation of the cache-authority admission gate. */
+export interface CodeGraphRegistrationActivity {
+  readonly elapsedMilliseconds: number;
+  readonly generations: number;
+  readonly keys: number;
+  readonly stage: 'loading-cache';
+}
+
 export type CodeGraphProgress =
   | {
+      readonly activity?: CodeGraphRegistrationActivity;
       readonly phase: 'registering';
     }
   | {

--- a/test/unit/code-graph.anonymous-telemetry.property.test.ts
+++ b/test/unit/code-graph.anonymous-telemetry.property.test.ts
@@ -29,6 +29,12 @@ import {provideTestLayer} from '../helpers/effect-layer.js';
 describe('code graph anonymous telemetry', () => {
   it('maps graph phases to the closed anonymous progress vocabulary', () => {
     expect(codeGraphAnonymousTelemetryFields({phase: 'registering'})).toEqual({phase: 'graph.registering'});
+    expect(
+      codeGraphAnonymousTelemetryFields({
+        activity: {elapsedMilliseconds: 250, generations: 2, keys: 400, stage: 'loading-cache'},
+        phase: 'registering',
+      }),
+    ).toEqual({elapsedMilliseconds: 250, phase: 'graph.registering', stage: 'loading-cache'});
     expect(codeGraphAnonymousTelemetryFields({phase: 'waiting', reason: 'database-writer'})).toEqual({
       phase: 'graph.waiting',
       waitingReason: 'database-writer',

--- a/test/unit/code-graph.build-status.property.test.ts
+++ b/test/unit/code-graph.build-status.property.test.ts
@@ -138,6 +138,33 @@ describe('code graph build-status properties', () => {
   });
 
   it.prop(
+    'round-trips bounded cache-admission observations and rejects invalid counters',
+    {
+      elapsedMilliseconds: FC.integer({max: 10_000_000, min: 0}),
+      generations: FC.integer({max: 100, min: 0}),
+      keys: FC.integer({max: 10_000_000, min: 0}),
+    },
+    activity => {
+      const status = buildStatus('running', true);
+      const registering: CodeGraphBuildStatus = {
+        ...status,
+        phase: 'registering',
+        registration: {activity: {...activity, stage: 'loading-cache'}},
+      };
+      expect(parseCodeGraphBuildStatus(JSON.parse(JSON.stringify(registering)))?.registration).toEqual(
+        registering.registration,
+      );
+      expect(
+        parseCodeGraphBuildStatus({
+          ...registering,
+          registration: {activity: {...registering.registration!.activity, keys: -1}},
+        }),
+      ).toBeUndefined();
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
+  it.prop(
     'never throws while validating arbitrary JSON values and only returns bounded schema-v1 records',
     {value: FC.jsonValue()},
     ({value}) => {

--- a/test/unit/code-graph.cache-capacity.property.test.ts
+++ b/test/unit/code-graph.cache-capacity.property.test.ts
@@ -40,6 +40,11 @@ describe('code graph persistent cache capacity planning', () => {
           fields.factsJson,
           fields.createdAt,
           fields.reuseClass,
+          fields.extractorSet,
+          fields.path,
+          fields.contentHash,
+          fields.blobId,
+          fields.reuseClass,
         ),
       );
       expect(codeGraphMaterializedShardCapacityBytes(fields)).toBe(

--- a/test/unit/code-graph.isolated-builder.test.ts
+++ b/test/unit/code-graph.isolated-builder.test.ts
@@ -238,8 +238,17 @@ describe('codeGraphProgressFromBuildStatus', () => {
   const cases = [
     {
       description: 'registering',
-      input: {counters: {}, phase: 'registering' as const},
-      expected: {phase: 'registering'},
+      input: {
+        counters: {},
+        phase: 'registering' as const,
+        registration: {
+          activity: {elapsedMilliseconds: 250, generations: 2, keys: 400, stage: 'loading-cache' as const},
+        },
+      },
+      expected: {
+        activity: {elapsedMilliseconds: 250, generations: 2, keys: 400, stage: 'loading-cache'},
+        phase: 'registering',
+      },
     },
     {
       description: 'scanning counters',

--- a/test/unit/code-graph.json-progress.test.ts
+++ b/test/unit/code-graph.json-progress.test.ts
@@ -39,6 +39,10 @@ describe('code graph JSON progress coalescing', () => {
   it('preserves phase and substage transitions without waiting for the liveness interval', () => {
     const events: readonly CodeGraphProgress[] = [
       {phase: 'registering'},
+      {
+        activity: {elapsedMilliseconds: 250, generations: 2, keys: 400, stage: 'loading-cache'},
+        phase: 'registering',
+      },
       {phase: 'waiting', reason: 'repository-lock'},
       {phase: 'waiting', reason: 'database-writer'},
       scanning(0, 10),

--- a/test/unit/code-graph.ready-query-evidence.test.ts
+++ b/test/unit/code-graph.ready-query-evidence.test.ts
@@ -367,7 +367,7 @@ function validArtifact(): MutableReadyQueryEvidence {
     runtime: {
       compatible: true,
       extractorSet: 'native-code-graph-13',
-      persistentExtensionRevision: 11,
+      persistentExtensionRevision: 12,
       resultVersion: 1,
       schemaVersion: 3,
     },

--- a/test/unit/code-graph.removed-view-cleanup-store.test.ts
+++ b/test/unit/code-graph.removed-view-cleanup-store.test.ts
@@ -137,7 +137,7 @@ describe('removed code graph view cleanup queue', () => {
           }
         });
 
-        expect(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION).toBe(11);
+        expect(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION).toBe(12);
         expect(observed.revision).toEqual({value: String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)});
         expect(observed.ready).toEqual({state: 'ready'});
         expect(observed.building).toEqual({state: 'building'});

--- a/test/unit/code-graph.schema-migration.test.ts
+++ b/test/unit/code-graph.schema-migration.test.ts
@@ -6,6 +6,7 @@ import {Deferred, Effect, Exit, Fiber, Option} from 'effect';
 import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
 import {
+  CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE,
   CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   CodeGraphStore,
   codeGraphRuntimeSchemaRequiresReconnect,
@@ -125,6 +126,110 @@ describe('code graph persistent schema migration', () => {
       {numRuns: 10},
     );
   });
+
+  effectIt.effect('atomically upgrades revision 11 with the cache-authority admission table', () =>
+    Effect.gen(function* () {
+      const fixture = yield* Effect.promise(migrationFixture);
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(fixture.databasePath);
+      yield* Effect.sync(() => {
+        const database = new Database(fixture.databasePath, {strict: true});
+        try {
+          database.exec(`
+            DROP TRIGGER file_blobs_authority_insert;
+            DROP TRIGGER file_blobs_authority_delete;
+            DROP TRIGGER file_blobs_authority_update;
+            DROP TABLE ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE};
+            UPDATE schema_metadata
+            SET value = '11'
+            WHERE key = 'persistent_extension_schema_revision';
+          `);
+          database
+            .query(
+              `INSERT INTO file_blobs (
+                 content_hash, extractor_set, path_hint, blob_id, reuse_class, facts_json, created_at
+               ) VALUES (?, 'revision-11-cache', ?, NULL, NULL, ?, '2026-08-22T00:00:00.000Z')`,
+            )
+            .run('a'.repeat(40), 'src/valid.ts', JSON.stringify({path: 'src/valid.ts'}));
+          database
+            .query(
+              `INSERT INTO file_blobs (
+                 content_hash, extractor_set, path_hint, blob_id, reuse_class, facts_json, created_at
+               ) VALUES (?, 'revision-11-cache', ?, NULL, NULL, ?, '2026-08-22T00:00:00.000Z')`,
+            )
+            .run('b'.repeat(40), 'src/invalid.ts', '{');
+        } finally {
+          database.close(false);
+        }
+      });
+
+      const phases: CodeGraphPersistentSchemaMigrationPhase[] = [];
+      yield* store.withSession(fixture.databasePath, store.initialize(fixture.databasePath), {
+        onPersistentSchemaMigrationPhase: phase => Effect.sync(() => phases.push(phase)),
+      });
+      const observed = yield* Effect.sync(() => {
+        const database = new Database(fixture.databasePath, {readonly: true, strict: true});
+        try {
+          return {
+            authority: database
+              .query<{readonly sql: string}, [string]>(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+              )
+              .get(CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE),
+            authorityRows: database
+              .query<{readonly path_hint: string}, []>(
+                `SELECT path_hint FROM ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE} ORDER BY path_hint`,
+              )
+              .all(),
+            revision: database
+              .query<{readonly value: string}, []>(
+                "SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision'",
+              )
+              .get(),
+          };
+        } finally {
+          database.close(false);
+        }
+      });
+
+      expect(phases).toContain('migrated-query-indexes');
+      expect(observed.authority?.sql).toMatch(/PRIMARY\s+KEY\s*\(extractor_set,\s*path_hint,\s*content_hash\)/iu);
+      expect(observed.authorityRows).toEqual([{path_hint: 'src/valid.ts'}]);
+      expect(observed.revision?.value).toBe(String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION));
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('rebuilds a drifted cache-authority trigger before serving admission', () =>
+    Effect.gen(function* () {
+      const fixture = yield* Effect.promise(migrationFixture);
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(fixture.databasePath);
+      yield* Effect.sync(() => {
+        const database = new Database(fixture.databasePath, {strict: true});
+        try {
+          database
+            .query(
+              `INSERT INTO file_blobs (
+                 content_hash, extractor_set, path_hint, blob_id, reuse_class, facts_json, created_at
+               ) VALUES (?, 'drifted-cache', ?, NULL, NULL, ?, '2026-08-22T00:00:00.000Z')`,
+            )
+            .run('c'.repeat(40), 'src/drifted.ts', JSON.stringify({path: 'src/drifted.ts'}));
+          database.exec(`
+            DROP TRIGGER file_blobs_authority_update;
+            CREATE TRIGGER file_blobs_authority_update
+            AFTER UPDATE OF facts_json ON file_blobs
+            BEGIN SELECT 1; END;
+            UPDATE file_blobs SET facts_json = '{' WHERE extractor_set = 'drifted-cache';
+          `);
+        } finally {
+          database.close(false);
+        }
+      });
+
+      yield* store.initialize(fixture.databasePath);
+      expect(yield* store.cachedCommittedFileKeys(fixture.databasePath, 'drifted-cache')).toEqual(new Set());
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
 
   effectIt.effect('atomically upgrades revision 9 query indexes before serving adjacency', () =>
     Effect.gen(function* () {

--- a/test/unit/code-graph.store-query.property.test.ts
+++ b/test/unit/code-graph.store-query.property.test.ts
@@ -5,6 +5,7 @@ import {Effect, FileSystem, Path} from 'effect';
 import * as FC from 'effect/testing/FastCheck';
 import {
   codeGraphAdjacencyQueryStatement,
+  codeGraphCachedCommittedFileKeysStatement,
   codeGraphCompactLexicalCleanupPageStatement,
   codeGraphEffectiveSymbolTermsQueryStatement,
   codeGraphExactSymbolQueryStatement,
@@ -13,9 +14,14 @@ import {
   codeGraphSymbolSearchScoreMultiplier,
   codeGraphSymbolsByIdsQueryStatement,
   codeGraphTermCandidateQueryStatement,
+  CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE,
   CodeGraphStore,
   isCanonicalAbsoluteBazelLabel,
 } from '../../src/code_graph/store.js';
+import {
+  CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE_SQL,
+  CODE_GRAPH_FILE_BLOB_AUTHORITY_TRIGGER_SQL,
+} from '../../src/code_graph/store_cache_authority.js';
 import type {CodeGraphEdge, CodeGraphProvenance} from '../../src/code_graph/types.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 
@@ -83,8 +89,114 @@ const symbolFileName = FC.constantFrom(
   'widget.spec.tsx',
 );
 const symbolQueryTerm = FC.constantFrom('docs', 'md', 'mcp', 'recall_context', 'spec', 'test');
+const cacheAuthorityKind = FC.constantFrom('invalid-json', 'match', 'mismatch', 'missing-path');
 
 describe('code graph indexed query properties', () => {
+  it('serves cache admission from the authority table without evaluating stored fact JSON', () => {
+    const database = cacheAuthorityDatabase();
+    try {
+      const statement = codeGraphCachedCommittedFileKeysStatement('extractor-current');
+      const plan = database.query(`EXPLAIN QUERY PLAN ${statement.text}`).all(...statement.parameters) as readonly {
+        readonly detail: string;
+      }[];
+      const bytecode = database.query(`EXPLAIN ${statement.text}`).all(...statement.parameters) as readonly {
+        readonly opcode: string;
+        readonly p4: unknown;
+      }[];
+
+      expect(plan.map(row => row.detail).join('\n')).toContain(
+        `SEARCH ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE} USING PRIMARY KEY (extractor_set=?)`,
+      );
+      expect(bytecode.filter(row => row.opcode === 'Function').map(row => row.p4)).not.toContainEqual(
+        expect.stringMatching(/^json_/u),
+      );
+    } finally {
+      database.close(false);
+    }
+  });
+
+  it('revokes and restores cache authority atomically when a stored fact row changes', () => {
+    const database = cacheAuthorityDatabase();
+    try {
+      const path = 'src/authority.ts';
+      const insert = database.query(
+        `INSERT INTO file_blobs (
+           content_hash, extractor_set, path_hint, blob_id, reuse_class, facts_json, created_at
+         ) VALUES (?, 'extractor-current', ?, NULL, NULL, ?, '2026-08-22T00:00:00.000Z')`,
+      );
+      const statement = codeGraphCachedCommittedFileKeysStatement('extractor-current');
+      insert.run('a'.repeat(40), path, JSON.stringify({path}));
+      expect(database.query(statement.text).all(...statement.parameters)).toHaveLength(1);
+
+      database.query('UPDATE file_blobs SET facts_json = ?').run('{');
+      expect(database.query(statement.text).all(...statement.parameters)).toHaveLength(0);
+
+      database.query('UPDATE file_blobs SET facts_json = ?').run(JSON.stringify({path}));
+      expect(database.query(statement.text).all(...statement.parameters)).toHaveLength(1);
+
+      database.query('DELETE FROM file_blobs').run();
+      expect(database.query(statement.text).all(...statement.parameters)).toHaveLength(0);
+    } finally {
+      database.close(false);
+    }
+  });
+
+  it.prop(
+    'admits exactly current-generation rows whose stored fact path matches their authority path',
+    {
+      rows: FC.array(
+        FC.record({
+          authority: cacheAuthorityKind,
+          currentGeneration: FC.boolean(),
+        }),
+        {maxLength: 40},
+      ),
+    },
+    ({rows}) => {
+      const database = cacheAuthorityDatabase();
+      try {
+        const insert = database.query(
+          `INSERT INTO file_blobs (
+             content_hash, extractor_set, path_hint, blob_id, reuse_class, facts_json, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, '2026-08-22T00:00:00.000Z')`,
+        );
+        const expectedPaths: string[] = [];
+        for (const [index, row] of rows.entries()) {
+          const path = `src/file-${index}.ts`;
+          const extractorSet = row.currentGeneration ? 'extractor-current' : 'extractor-old';
+          const factsJson =
+            row.authority === 'invalid-json'
+              ? '{'
+              : row.authority === 'match'
+                ? JSON.stringify({path})
+                : row.authority === 'mismatch'
+                  ? JSON.stringify({path: `${path}.other`})
+                  : JSON.stringify({diagnostics: []});
+          insert.run(
+            index.toString(16).padStart(40, '0'),
+            extractorSet,
+            path,
+            (index + 1).toString(16).padStart(40, '0'),
+            'structured-object-v1:json:full',
+            factsJson,
+          );
+          if (row.currentGeneration && row.authority === 'match') expectedPaths.push(path);
+        }
+
+        const statement = codeGraphCachedCommittedFileKeysStatement('extractor-current');
+        const actual = (
+          database.query(statement.text).all(...statement.parameters) as readonly {readonly path_hint: string}[]
+        )
+          .map(row => row.path_hint)
+          .sort();
+        expect(actual).toEqual(expectedPaths.sort());
+      } finally {
+        database.close(false);
+      }
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
   it.prop(
     'never scores a test or documentation symbol path above an implementation path',
     {
@@ -551,6 +663,25 @@ describe('code graph indexed query properties', () => {
     {fastCheck: {numRuns: 100}},
   );
 });
+
+function cacheAuthorityDatabase(): Database {
+  const database = new Database(':memory:', {strict: true});
+  database.exec(`
+    CREATE TABLE file_blobs (
+      content_hash TEXT NOT NULL,
+      extractor_set TEXT NOT NULL,
+      path_hint TEXT NOT NULL,
+      blob_id TEXT,
+      reuse_class TEXT,
+      facts_json TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (content_hash, extractor_set, path_hint)
+    ) WITHOUT ROWID;
+    ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TABLE_SQL};
+    ${CODE_GRAPH_FILE_BLOB_AUTHORITY_TRIGGER_SQL.join(';\n')};
+  `);
+  return database;
+}
 
 function lastEdgeById(values: readonly EdgeSpec[]): ReadonlyMap<string, CodeGraphEdge> {
   const output = new Map<string, CodeGraphEdge>();


### PR DESCRIPTION
## Summary

- materialize fail-closed file-blob cache authority in a narrow trigger-maintained SQLite table
- read committed cache keys by extractor generation without scanning or parsing stored fact payloads
- emit path-free cache-admission timing and counts through progress, build status, JSON progress, and anonymous telemetry
- reserve and attribute the additional bounded metadata, and atomically migrate revision 11 databases to revision 12

## Performance evidence

Bounded internal-SSD smoke at the production-large file count (225,852 rows):

- 4 KiB facts: median 902.1 ms legacy versus 67.2 ms authority table, 13.4x faster
- 32 KiB facts / 7.57 GB database: median 6,119.6 ms legacy versus 66.9 ms authority table, 91.4x faster
- 32 KiB population: 20.44 s with authority maintenance versus 21.06 s control, with no measured cold-write regression
- query plan: `SEARCH file_blob_authority USING PRIMARY KEY (extractor_set=?)`; VM bytecode performs no JSON function work

Temporary benchmark data was removed after capture. These are focused microbenchmark results, not replacement release-grade production-large evidence.

## Verification

- focused Vitest: 180 unit tests passed across query, migration, materialization, telemetry, build-status, capacity, storage-attribution, and schema coverage
- focused lifecycle regression: invalid cached fact recovery passed
- post-rebase focused Vitest: 53 tests passed
- source and test TypeScript typechecks passed
- lint and formatting passed
- property coverage proves exact authority admission over valid, mismatched, missing, and malformed fact payloads; schema migration and drift repair have concrete regressions

Full suite is delegated to PR CI per repository policy.