### PR TITLE
perf(code-graph): bound sparse overlay admission

### DIFF
--- a/src/code_graph/indexer_sparse.ts
+++ b/src/code_graph/indexer_sparse.ts
@@ -158,10 +158,9 @@ export const attemptSparseReusableOverlay = Effect.fn('codeGraph.attemptSparseRe
   };
   yield* input.anonymousTelemetry.observeInventory(inventory);
   yield* input.anonymousTelemetry.observeExtractedFactBytes(yield* input.cacheCoalescer.extractedFactBytes);
-  yield* Effect.sync(() => {
-    Bun.gc(true);
-    Bun.shrink();
-  });
+  // Sparse admission hydrates only the bounded changed/fanout slice. A forced
+  // heap-wide collection scales with the process's prior high-water instead of
+  // that slice, turning one-file indexing into repository-sized pause time.
   yield* Effect.yieldNow;
 
   const logicalSnapshotId = sparseOverlaySnapshotIdentity(

--- a/src/code_graph/inventory.ts
+++ b/src/code_graph/inventory.ts
@@ -18,6 +18,7 @@ import {
   shouldOmitRepositoryContent,
 } from './inventory_content.js';
 import {CodeGraphInventoryError} from './inventory_error.js';
+import {parsePorcelainV1Status} from './inventory_porcelain.js';
 import {
   codeGraphAttributionContextFilesForReceipt,
   codeGraphInventoryReuseContract,
@@ -894,7 +895,17 @@ export const worktreeBuildRequestObservation = Effect.fn('codeGraph.worktreeBuil
   const pathspec = excludedPathPrefix === undefined ? [] : ['--', '.', `:(top,exclude,literal)${excludedPathPrefix}`];
   const porcelain = yield* runCommandEffect(
     'git',
-    ['-C', identity.repoRoot, 'status', '--porcelain=v1', '-z', '--untracked-files=normal', ...pathspec],
+    [
+      '--no-optional-locks',
+      '-C',
+      identity.repoRoot,
+      'status',
+      '--porcelain=v1',
+      '-z',
+      '--untracked-files=all',
+      '--renames',
+      ...pathspec,
+    ],
     {maxOutputBytes: 0, timeoutMs: 0},
   );
   if (porcelain.stdout.length === 0) {
@@ -903,21 +914,19 @@ export const worktreeBuildRequestObservation = Effect.fn('codeGraph.worktreeBuil
       state: {dirty: false, fingerprint: undefined},
     } satisfies CodeGraphBuildRequestObservation;
   }
-  const tree = yield* readInventoryPreviewTree(identity, path, [], true, excludedPathPrefix);
+  const overlay = parsePorcelainV1Status(porcelain.stdout);
   const threadnoteIgnore = yield* readOptionalText(fs, path.join(identity.repoRoot, '.threadnoteignore'));
   const fileRows: string[] = [];
   const observedFiles: CodeGraphObservedOverlayFile[] = [];
   const skippedRows: string[] = [];
-  for (const relative of [...tree.changes.changed].sort(compareCodeUnits)) {
-    if (tree.changes.deleted.has(relative)) continue;
-    const metadata = tree.changedMetadata.get(relative);
+  for (const relative of [...overlay.changed].sort(compareCodeUnits)) {
+    if (overlay.deleted.has(relative)) continue;
     const materialized = yield* materializeContainedStableRegularFile(
       fs,
       path,
       repositoryRoot,
       relative,
       () => true,
-      metadata?.size,
     ).pipe(Effect.option);
     if (Option.isSome(materialized)) {
       fileRows.push(`F\0${relative}\0${materialized.value.contentHash}`);
@@ -928,14 +937,14 @@ export const worktreeBuildRequestObservation = Effect.fn('codeGraph.worktreeBuil
       });
     } else skippedRows.push(`S\0${relative}`);
   }
-  const dirty = tree.changes.changed.size > 0 || tree.changes.deleted.size > 0;
+  const dirty = overlay.changed.size > 0 || overlay.deleted.size > 0;
   return {
     overlay: {
-      addedPaths: [...tree.changes.added].sort(compareCodeUnits),
-      changedPaths: [...tree.changes.changed].sort(compareCodeUnits),
-      deletedPaths: [...tree.changes.deleted].sort(compareCodeUnits),
+      addedPaths: [...overlay.added].sort(compareCodeUnits),
+      changedPaths: [...overlay.changed].sort(compareCodeUnits),
+      deletedPaths: [...overlay.deleted].sort(compareCodeUnits),
       files: observedFiles.sort((left, right) => compareCodeUnits(left.path, right.path)),
-      untrackedPaths: [...tree.untracked].sort(compareCodeUnits),
+      untrackedPaths: [...overlay.untracked].sort(compareCodeUnits),
     },
     state: {
       dirty,
@@ -944,7 +953,7 @@ export const worktreeBuildRequestObservation = Effect.fn('codeGraph.worktreeBuil
             [
               'build-request-overlay-v1',
               `I\0${sha256HexSync(threadnoteIgnore)}`,
-              ...[...tree.changes.deleted].sort(compareCodeUnits).map(relative => `D\0${relative}`),
+              ...[...overlay.deleted].sort(compareCodeUnits).map(relative => `D\0${relative}`),
               ...fileRows,
               ...skippedRows,
             ].join('\n'),

--- a/src/code_graph/inventory_porcelain.ts
+++ b/src/code_graph/inventory_porcelain.ts
@@ -1,0 +1,56 @@
+/**
+ * Parses Git's stable porcelain-v1 `-z` contract. Rename/copy records use the
+ * documented destination-then-source order, while untracked rows remain
+ * distinguishable for exact overlay admission.
+ */
+export function parsePorcelainV1Status(output: string): {
+  readonly added: Set<string>;
+  readonly changed: Set<string>;
+  readonly deleted: Set<string>;
+  readonly untracked: Set<string>;
+} {
+  const added = new Set<string>();
+  const changed = new Set<string>();
+  const deleted = new Set<string>();
+  const untracked = new Set<string>();
+  const fields = output.split('\0');
+  for (let index = 0; index < fields.length;) {
+    const record = fields[index++];
+    if (!record || record.length < 4 || record[2] !== ' ') continue;
+    const status = record.slice(0, 2);
+    const path = normalizeRepositoryPath(record.slice(3));
+    if (!path) continue;
+    if (status === '??') {
+      added.add(path);
+      changed.add(path);
+      untracked.add(path);
+      continue;
+    }
+    const rename = status.includes('R');
+    const copy = status.includes('C');
+    if (rename || copy) {
+      const source = normalizeRepositoryPath(fields[index++] ?? '');
+      if (rename && source) deleted.add(source);
+      added.add(path);
+      changed.add(path);
+      continue;
+    }
+    const [indexStatus, worktreeStatus] = status;
+    // Every two-letter unmerged state containing D still represents a
+    // conflicted worktree path. Only the ordinary staged/unstaged delete
+    // states remove the path without hashing a possible conflict file.
+    if (status === 'D ' || status === ' D') {
+      deleted.add(path);
+      continue;
+    }
+    if (status !== '  ' && status !== '!!') {
+      changed.add(path);
+      if (indexStatus === 'A' || worktreeStatus === 'A') added.add(path);
+    }
+  }
+  return {added, changed, deleted, untracked};
+}
+
+function normalizeRepositoryPath(value: string): string {
+  return value.replace(/^\.\/+/, '');
+}

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -3265,9 +3265,26 @@ describe('native code graph lifecycle', () => {
         writeFileSync(join(root, 'packages/app/src/untracked.ts'), 'export const untracked = true;\n');
       });
       const identity = yield* resolveRepositoryIdentity(root);
-      const observation = yield* worktreeBuildRequestObservation(identity);
-      const independentlyScanned = yield* inventoryRepository(identity);
       const command = yield* CommandExecutor;
+      const observationCommands: string[] = [];
+      const observationCommand = CommandExecutor.of({
+        ...command,
+        execute: (executable, args, options) => {
+          if (
+            executable === 'git' &&
+            (args.includes('status') ||
+              args.includes('diff') ||
+              (args.includes('ls-files') && args.includes('--others')))
+          ) {
+            observationCommands.push(args.join(' '));
+          }
+          return command.execute(executable, args, options);
+        },
+      });
+      const observation = yield* worktreeBuildRequestObservation(identity).pipe(
+        Effect.provideService(CommandExecutor, observationCommand),
+      );
+      const independentlyScanned = yield* inventoryRepository(identity);
       const repeatedOverlayCommands: string[] = [];
       const observedCommand = CommandExecutor.of({
         ...command,
@@ -3291,6 +3308,8 @@ describe('native code graph lifecycle', () => {
       ]);
       expect(observation.overlay.deletedPaths).toEqual(['docs/architecture.md']);
       expect(observation.overlay.untrackedPaths).toEqual(['packages/app/src/untracked.ts']);
+      expect(observationCommands).toHaveLength(1);
+      expect(observationCommands[0]).toContain('status --porcelain=v1 -z --untracked-files=all --renames');
       expect(repeatedOverlayCommands).toEqual([]);
       expect(reused).toEqual(independentlyScanned);
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),

--- a/test/unit/code-graph.property.test.ts
+++ b/test/unit/code-graph.property.test.ts
@@ -9,6 +9,7 @@ import {
   parseNameStatus,
   summarizeCodeGraphInventoryPreview,
 } from '../../src/code_graph/inventory.js';
+import {parsePorcelainV1Status} from '../../src/code_graph/inventory_porcelain.js';
 import {
   CODE_GRAPH_GENERIC_JSON_EXCLUSION_BYTES,
   CODE_GRAPH_HIGH_SIGNAL_JSON_HARD_CAP_BYTES,
@@ -76,6 +77,33 @@ const nameStatusChangeArbitrary: FC.Arbitrary<NameStatusChange> = FC.oneof(
     kind: FC.constantFrom('C' as const, 'R' as const),
     score: FC.integer({max: 100, min: 0}),
     to: repositoryPathArbitrary,
+  }),
+);
+
+type PorcelainStatusChange =
+  | NameStatusChange
+  | {readonly kind: '?'; readonly path: string}
+  | {
+      readonly kind: 'U';
+      readonly path: string;
+      readonly status: 'AA' | 'AU' | 'DD' | 'DU' | 'UA' | 'UD' | 'UU';
+    };
+
+const porcelainStatusChangeArbitrary: FC.Arbitrary<PorcelainStatusChange> = FC.oneof(
+  nameStatusChangeArbitrary,
+  FC.record({kind: FC.constant('?' as const), path: repositoryPathArbitrary}),
+  FC.record({
+    kind: FC.constant('U' as const),
+    path: repositoryPathArbitrary,
+    status: FC.constantFrom(
+      'AA' as const,
+      'AU' as const,
+      'DD' as const,
+      'DU' as const,
+      'UA' as const,
+      'UD' as const,
+      'UU' as const,
+    ),
   }),
 );
 
@@ -226,6 +254,23 @@ describe('native code graph parser properties', () => {
     },
     {fastCheck: {numRuns: 200}},
   );
+
+  it.prop(
+    'matches a reference model for porcelain-v1 add, modify, delete, copy, rename, and untracked records',
+    {
+      changes: FC.array(porcelainStatusChangeArbitrary, {maxLength: 40}),
+    },
+    ({changes}) => {
+      const actual = parsePorcelainV1Status(encodePorcelainStatus(changes));
+      const expected = modelPorcelainStatus(changes);
+
+      expect([...actual.added].sort()).toEqual([...expected.added].sort());
+      expect([...actual.changed].sort()).toEqual([...expected.changed].sort());
+      expect([...actual.deleted].sort()).toEqual([...expected.deleted].sort());
+      expect([...actual.untracked].sort()).toEqual([...expected.untracked].sort());
+    },
+    {fastCheck: {numRuns: 200}},
+  );
 });
 
 function inventoryPolicyPath(
@@ -372,6 +417,23 @@ function encodeNameStatus(changes: readonly NameStatusChange[]): string {
   return `${fields.join('\0')}\0`;
 }
 
+function encodePorcelainStatus(changes: readonly PorcelainStatusChange[]): string {
+  const fields: string[] = [];
+  for (const change of changes) {
+    if ('from' in change) {
+      fields.push(`${change.kind}  ${change.to}`, change.from);
+    } else if (change.kind === '?') {
+      fields.push(`?? ${change.path}`);
+    } else if (change.kind === 'U') {
+      fields.push(`${change.status} ${change.path}`);
+    } else {
+      const status = change.kind === 'M' ? ' M' : `${change.kind} `;
+      fields.push(`${status} ${change.path}`);
+    }
+  }
+  return `${fields.join('\0')}\0`;
+}
+
 function modelNameStatus(changes: readonly NameStatusChange[]): {
   readonly added: Set<string>;
   readonly changed: Set<string>;
@@ -397,6 +459,33 @@ function modelNameStatus(changes: readonly NameStatusChange[]): {
     }
   }
   return {added, changed, deleted};
+}
+
+function modelPorcelainStatus(changes: readonly PorcelainStatusChange[]): {
+  readonly added: Set<string>;
+  readonly changed: Set<string>;
+  readonly deleted: Set<string>;
+  readonly untracked: Set<string>;
+} {
+  const tracked = modelNameStatus(
+    changes.filter((change): change is NameStatusChange => change.kind !== '?' && change.kind !== 'U'),
+  );
+  const untracked = new Set(
+    changes
+      .filter((change): change is Extract<PorcelainStatusChange, {readonly kind: '?'}> => change.kind === '?')
+      .map(change => normalizeRepositoryPath(change.path)),
+  );
+  for (const path of untracked) {
+    tracked.added.add(path);
+    tracked.changed.add(path);
+  }
+  for (const change of changes) {
+    if (change.kind !== 'U') continue;
+    const path = normalizeRepositoryPath(change.path);
+    tracked.changed.add(path);
+    if (change.status.includes('A')) tracked.added.add(path);
+  }
+  return {...tracked, untracked};
 }
 
 function graphNode(index: number): CodeGraphQueryNode {


### PR DESCRIPTION
## Summary

- derive the exact dirty overlay from one no-optional-locks porcelain status observation instead of separate status, diff, and ls-files scans
- preserve exact content hashing, rename/copy handling, deletions, and unmerged conflict states
- avoid forced full-heap collection before the already bounded sparse route
- add an independent Fast-check model plus Effect integration coverage

## Measured evidence

Pinned IntelliJ repository, alternating command-level observations on the same one-file dirty overlay:

- previous observation route median: about 6.47 seconds
- single porcelain status median: about 3.28 seconds
- command-level reduction: about 49%

This is a component result, not yet a full one-file indexing claim. The PR remains draft until exact global install/smoke and governed graph timing, RSS, SQLite main/TEMP/WAL, and digest gates complete.

## Validation

- focused unit/property tests: 2 files, 19 tests
- focused Effect lifecycle integration: passed
- TypeScript typecheck: passed
- lint: passed
- Prettier: passed
- no Node runtime library imports
- exact clean global install: v4.3.2-local.g173542b358ae9c8d2c8248a46b5bee1466ce642d
- installed executable SHA-256: 7aa5610755320d19632caa932f1dadc4440b681e7628349fa747cadc31a2a427
- installed CLI cold plus dirty-overlay smoke: passed
- doctor after recall-index repair: zero failures

## Scope

The admitted body-only sparse route already joins snapshot_files only for its bounded requested-path slice; this PR preserves that contract. Legacy retained-overlay and ordinary fail-closed fallback routes can still hydrate complete snapshot metadata, so the system does not claim universal O(changed-set) behavior. This change removes duplicate Git scans and heap-wide GC from the safe sparse route while retaining exact final validation.