### PR TITLE
perf(code-graph): widen resolution capacity windows

### DIFF
--- a/src/code_graph/store_resolution.ts
+++ b/src/code_graph/store_resolution.ts
@@ -27,13 +27,15 @@ import {
   capturePersistedAnalysisResolutionEdges,
   codeGraphPersistedDeltaResolutionPageStatement,
   codeGraphPersistentReferencePageStatement,
+  PERSISTENT_FULL_RESOLUTION_RESERVATION_PAGES,
+  planPersistentReferenceResolutionPages,
   persistentFullReferencePageTotal,
   persistentReferenceResolutionCapacityBoundary,
 } from './store_resolution_core.js';
 import {resolvePersistedFullReferencePage} from './store_resolution_matching.js';
 import {expandTransitiveReexportAliases} from './store_persistent_build.js';
 import {activationEdgeId, chunk, lookupDomain, parseLookupKeys, sqlTextOption} from './store_utilities.js';
-import {snapshotPromotionLeaseCapacity} from './store_staging_core.js';
+import {type CodeGraphPersistentReferencePageLimits, snapshotPromotionLeaseCapacity} from './store_staging_core.js';
 import {
   codeGraphWorktreeReconciliationSchemaCompatible,
   markSnapshotLeaseRetirementBaton,
@@ -43,11 +45,6 @@ import {CodeGraphPromotionCapacityPlanChanged} from './store_internal_models.js'
 import {lastStatementChangeCount} from './store_activation_core.js';
 
 export const CODE_GRAPH_RESOLUTION_PASS_MAXIMUM = 32;
-
-// Matching pages retain the existing candidate-count and payload bounds. Only
-// their compact resolved rows are grouped, amortizing the durable reservation,
-// writer-lock, and commit cost without multiplying lookup-summary memory.
-const PERSISTENT_FULL_RESOLUTION_TRANSACTION_PAGES = 4;
 
 interface ResolutionTransactionPage {
   readonly aliases: readonly (readonly [string, string, string, number, 'alias', string, string])[];
@@ -150,6 +147,7 @@ const resolveActivationReferences = Effect.fn('codeGraph.resolveActivationRefere
   onProgress?: CodeGraphResolutionProgressCallback,
   writerGate?: CodeGraphWriterGate,
   persistentCapacityProtector?: CodeGraphDirectPersistentCapacityProtector,
+  persistentPageLimits?: CodeGraphPersistentReferencePageLimits,
 ) {
   const sql = yield* SqlClient.SqlClient;
   const startedAt = yield* Clock.currentTimeMillis;
@@ -195,7 +193,10 @@ const resolveActivationReferences = Effect.fn('codeGraph.resolveActivationRefere
       `;
   const preparationReferencesTotal = Number(preparationCountRows[0]?.count ?? 0);
   const preparationPageTotal = persistentFull
-    ? persistentFullReferencePageTotal(preparationCountRows[0] ?? {candidate_count: 0, count: 0, payload_bytes: 0})
+    ? persistentFullReferencePageTotal(
+        preparationCountRows[0] ?? {candidate_count: 0, count: 0, payload_bytes: 0},
+        persistentPageLimits,
+      )
     : Math.ceil(preparationReferencesTotal / pageRows);
   matchingMilliseconds += (yield* Clock.currentTimeMillis) - preparationCountStartedAt;
   const reportPreparation = (aliases: number) =>
@@ -258,18 +259,41 @@ const resolveActivationReferences = Effect.fn('codeGraph.resolveActivationRefere
     }
     const pass = passesCompleted + 1;
     let pageTotal = persistentFull
-      ? persistentFullReferencePageTotal(countRows[0] ?? {candidate_count: 0, count: 0, payload_bytes: 0})
+      ? persistentFullReferencePageTotal(
+          countRows[0] ?? {candidate_count: 0, count: 0, payload_bytes: 0},
+          persistentPageLimits,
+        )
       : Math.ceil(referencesTotal / pageRows);
     let cursor = '';
     let pageCompleted = 0;
     let referencesCompleted = 0;
     let resolvedInPass = 0;
     let aliasesInPass = 0;
-    const transactionPageLimit =
-      persistentFull && persistentCapacityProtector ? PERSISTENT_FULL_RESOLUTION_TRANSACTION_PAGES : 1;
-    const transactionPages: ResolutionTransactionPage[] = [];
-    const flushTransactionPages = Effect.fn('codeGraph.flushResolutionTransactionPages')(function* () {
-      if (transactionPages.length === 0) return;
+    const reservationPageLimit =
+      persistentFull && persistentCapacityProtector ? PERSISTENT_FULL_RESOLUTION_RESERVATION_PAGES : 1;
+    const reservationPages: ResolutionTransactionPage[] = [];
+    const reportResolutionProgress = (reportedMatchingMilliseconds = matchingMilliseconds) =>
+      Effect.gen(function* () {
+        if (onProgress === undefined) return;
+        yield* onProgress({
+          aliasesDiscovered,
+          elapsedMilliseconds: (yield* Clock.currentTimeMillis) - startedAt,
+          matchingMilliseconds: reportedMatchingMilliseconds,
+          pageCompleted,
+          pageTotal,
+          pagesCompleted,
+          pass,
+          referencesCompleted,
+          referencesExamined,
+          referencesTotal,
+          resolved,
+          transactionMilliseconds,
+          transactionStageMilliseconds: transactionStageMilliseconds(),
+        });
+      });
+    const commitTransactionPages = Effect.fn('codeGraph.commitResolutionTransactionPages')(function* (
+      transactionPages: readonly ResolutionTransactionPage[],
+    ) {
       const resolutions: ActivationResolutionRow[] = [];
       const aliases: Array<readonly [string, string, string, number, 'alias', string, string]> = [];
       for (const page of transactionPages) {
@@ -277,7 +301,6 @@ const resolveActivationReferences = Effect.fn('codeGraph.resolveActivationRefere
         for (const alias of page.aliases) aliases.push(alias);
       }
       if (resolutions.length > 0) {
-        const transactionStartedAt = yield* Clock.currentTimeMillis;
         const transaction = sql.withTransaction(
           Effect.gen(function* () {
             let transactionStageStartedAt = yield* Clock.currentTimeMillis;
@@ -413,41 +436,59 @@ const resolveActivationReferences = Effect.fn('codeGraph.resolveActivationRefere
           }),
         );
         const gatedTransaction = mode?.mode === 'persisted-full' && writerGate ? writerGate(transaction) : transaction;
-        yield* persistentCapacityProtector
-          ? persistentCapacityProtector(
-              aggregatePersistentReferenceResolutionCapacityBoundaries(transactionPages.map(page => page.capacity)),
-              gatedTransaction,
-            )
-          : gatedTransaction;
-        transactionMilliseconds += (yield* Clock.currentTimeMillis) - transactionStartedAt;
+        yield* gatedTransaction;
       }
+      // A later transaction in the same reservation can fail after this group
+      // commits. Advance counters per committed group so a resumed pass never
+      // pretends the durable prefix was rolled back.
       aliasesInPass += aliases.length;
       aliasesDiscovered += aliases.length;
       resolvedInPass += resolutions.length;
       resolved += resolutions.length;
-      transactionPages.length = 0;
     });
-    yield* onProgress?.({
-      aliasesDiscovered,
-      elapsedMilliseconds: (yield* Clock.currentTimeMillis) - startedAt,
-      matchingMilliseconds,
-      pageCompleted,
-      pageTotal,
-      pagesCompleted,
-      pass,
-      referencesCompleted,
-      referencesExamined,
-      referencesTotal,
-      resolved,
-      transactionMilliseconds,
-      transactionStageMilliseconds: transactionStageMilliseconds(),
-    }) ?? Effect.void;
+    const flushReservationPages = Effect.fn('codeGraph.flushResolutionReservationPages')(function* () {
+      if (reservationPages.length === 0) return;
+      const reservations = planPersistentReferenceResolutionPages(reservationPages);
+      for (const reservation of reservations) {
+        const transactions = Effect.gen(function* () {
+          for (let index = 0; index < reservation.transactions.length; index += 1) {
+            yield* commitTransactionPages(reservation.transactions[index]!);
+            if (index + 1 < reservation.transactions.length) {
+              // The writer lock is released at this boundary. Preserve the
+              // established four-page progress cadence without reacquiring the
+              // wider disk-capacity reservation for the next transaction.
+              yield* reportResolutionProgress();
+              yield* Effect.yieldNow;
+            }
+          }
+        });
+        const hasResolutions = reservation.pages.some(page => page.resolutions.length > 0);
+        if (hasResolutions) {
+          const transactionStartedAt = yield* Clock.currentTimeMillis;
+          yield* persistentCapacityProtector
+            ? persistentCapacityProtector(
+                aggregatePersistentReferenceResolutionCapacityBoundaries(reservation.pages.map(page => page.capacity)),
+                transactions,
+              )
+            : transactions;
+          transactionMilliseconds += (yield* Clock.currentTimeMillis) - transactionStartedAt;
+        } else {
+          yield* transactions;
+        }
+      }
+      reservationPages.length = 0;
+    });
+    yield* reportResolutionProgress();
     yield* Effect.yieldNow;
     for (;;) {
       const pageStartedAt = yield* Clock.currentTimeMillis;
       let persistentPage = Option.none<readonly PersistedFullReferencePageRow[]>();
       if (persistentFull) {
-        const statement = codeGraphPersistentReferencePageStatement(persistentFull.snapshotId, cursor);
+        const statement = codeGraphPersistentReferencePageStatement(
+          persistentFull.snapshotId,
+          cursor,
+          persistentPageLimits,
+        );
         persistentPage = Option.some(
           yield* sql.unsafe<PersistedFullReferencePageRow>(statement.text, statement.parameters),
         );
@@ -474,21 +515,9 @@ const resolveActivationReferences = Effect.fn('codeGraph.resolveActivationRefere
               batchEnd,
               () =>
                 Effect.gen(function* () {
-                  yield* onProgress?.({
-                    aliasesDiscovered,
-                    elapsedMilliseconds: (yield* Clock.currentTimeMillis) - startedAt,
-                    matchingMilliseconds: matchingMilliseconds + (yield* Clock.currentTimeMillis) - pageStartedAt,
-                    pageCompleted,
-                    pageTotal,
-                    pagesCompleted,
-                    pass,
-                    referencesCompleted,
-                    referencesExamined,
-                    referencesTotal,
-                    resolved,
-                    transactionMilliseconds,
-                    transactionStageMilliseconds: transactionStageMilliseconds(),
-                  }) ?? Effect.void;
+                  yield* reportResolutionProgress(
+                    matchingMilliseconds + (yield* Clock.currentTimeMillis) - pageStartedAt,
+                  );
                 }),
             )
           : persistedBaseSnapshotId
@@ -591,7 +620,7 @@ const resolveActivationReferences = Effect.fn('codeGraph.resolveActivationRefere
           ]);
         }
       }
-      transactionPages.push({
+      reservationPages.push({
         aliases,
         capacity: persistentReferenceResolutionCapacityBoundary(
           mode?.mode === 'persisted-full' ? mode.snapshotId : (persistedBaseSnapshotId ?? 'temporary'),
@@ -611,45 +640,17 @@ const resolveActivationReferences = Effect.fn('codeGraph.resolveActivationRefere
       pagesCompleted += 1;
       referencesCompleted += pending.length;
       referencesExamined += pending.length;
-      if (transactionPages.length >= transactionPageLimit) yield* flushTransactionPages();
-      yield* onProgress?.({
-        aliasesDiscovered,
-        elapsedMilliseconds: (yield* Clock.currentTimeMillis) - startedAt,
-        matchingMilliseconds,
-        pageCompleted,
-        pageTotal,
-        pagesCompleted,
-        pass,
-        referencesCompleted,
-        referencesExamined,
-        referencesTotal,
-        resolved,
-        transactionMilliseconds,
-        transactionStageMilliseconds: transactionStageMilliseconds(),
-      }) ?? Effect.void;
+      if (reservationPages.length >= reservationPageLimit) yield* flushReservationPages();
+      yield* reportResolutionProgress();
       // Reference resolution is synchronous SQLite work. Yield after every
       // bounded page so the independent build heartbeat and observers cannot
       // be starved for the duration of an entire repository-sized pass.
       yield* Effect.yieldNow;
     }
-    const hadTransactionRemainder = transactionPages.length > 0;
-    yield* flushTransactionPages();
-    if (hadTransactionRemainder) {
-      yield* onProgress?.({
-        aliasesDiscovered,
-        elapsedMilliseconds: (yield* Clock.currentTimeMillis) - startedAt,
-        matchingMilliseconds,
-        pageCompleted,
-        pageTotal,
-        pagesCompleted,
-        pass,
-        referencesCompleted,
-        referencesExamined,
-        referencesTotal,
-        resolved,
-        transactionMilliseconds,
-        transactionStageMilliseconds: transactionStageMilliseconds(),
-      }) ?? Effect.void;
+    const hadReservationRemainder = reservationPages.length > 0;
+    yield* flushReservationPages();
+    if (hadReservationRemainder) {
+      yield* reportResolutionProgress();
       yield* Effect.yieldNow;
     }
     passesCompleted += 1;

--- a/src/code_graph/store_resolution_core.ts
+++ b/src/code_graph/store_resolution_core.ts
@@ -406,16 +406,48 @@ function positivePageLimit(value: number, fallback: number): number {
   return Number.isSafeInteger(value) && value > 0 ? value : fallback;
 }
 
-function persistentFullReferencePageTotal(row: PersistedFullReferenceTotalsRow): number {
+function persistentFullReferencePageTotal(
+  row: PersistedFullReferenceTotalsRow,
+  limits: CodeGraphPersistentReferencePageLimits = {
+    candidateCount: PERSISTENT_FULL_RESOLUTION_PAGE_CANDIDATES,
+    payloadBytes: PERSISTENT_FULL_RESOLUTION_PAGE_PAYLOAD_BYTES,
+    references: PERSISTENT_FULL_RESOLUTION_PAGE_ROWS,
+  },
+): number {
   const references = Number(row.count);
   if (!Number.isSafeInteger(references) || references <= 0) return 0;
   const candidates = Math.max(0, Number(row.candidate_count));
   const payloadBytes = Math.max(0, Number(row.payload_bytes));
+  const referenceLimit = positivePageLimit(limits.references, PERSISTENT_FULL_RESOLUTION_PAGE_ROWS);
+  const candidateLimit = positivePageLimit(limits.candidateCount, PERSISTENT_FULL_RESOLUTION_PAGE_CANDIDATES);
+  const payloadLimit = positivePageLimit(limits.payloadBytes, PERSISTENT_FULL_RESOLUTION_PAGE_PAYLOAD_BYTES);
   return Math.max(
-    Math.ceil(references / PERSISTENT_FULL_RESOLUTION_PAGE_ROWS),
-    Math.ceil(candidates / PERSISTENT_FULL_RESOLUTION_PAGE_CANDIDATES),
-    Math.ceil(payloadBytes / PERSISTENT_FULL_RESOLUTION_PAGE_PAYLOAD_BYTES),
+    Math.ceil(references / referenceLimit),
+    Math.ceil(candidates / candidateLimit),
+    Math.ceil(payloadBytes / payloadLimit),
   );
+}
+
+export const PERSISTENT_FULL_RESOLUTION_TRANSACTION_PAGES = 4;
+export const PERSISTENT_FULL_RESOLUTION_RESERVATION_PAGES = 8;
+
+export interface PersistentReferenceResolutionReservation<Value> {
+  readonly pages: readonly Value[];
+  readonly transactions: readonly (readonly Value[])[];
+}
+
+/**
+ * Reserve capacity across a wider page window without increasing the SQLite
+ * transaction size. The two independent bounds make durable receipt/fsync work
+ * less frequent while keeping WAL, rollback, and writer-lock exposure fixed.
+ */
+export function planPersistentReferenceResolutionPages<const Value>(
+  pages: readonly Value[],
+): readonly PersistentReferenceResolutionReservation<Value>[] {
+  return [...chunk(pages, PERSISTENT_FULL_RESOLUTION_RESERVATION_PAGES)].map(reservationPages => ({
+    pages: reservationPages,
+    transactions: [...chunk(reservationPages, PERSISTENT_FULL_RESOLUTION_TRANSACTION_PAGES)],
+  }));
 }
 
 /** @internal Exposed so regression tests can verify the SQLite access plan. */

--- a/test/unit/code-graph.resolution-bounds.property.test.ts
+++ b/test/unit/code-graph.resolution-bounds.property.test.ts
@@ -4,7 +4,12 @@ import {
   CODE_GRAPH_RESOLUTION_PASS_MAXIMUM,
   codeGraphResolutionPassAdmitted,
 } from '../../src/code_graph/store_resolution.js';
-import {aggregatePersistentReferenceResolutionCapacityBoundaries} from '../../src/code_graph/store_resolution_core.js';
+import {
+  aggregatePersistentReferenceResolutionCapacityBoundaries,
+  PERSISTENT_FULL_RESOLUTION_RESERVATION_PAGES,
+  PERSISTENT_FULL_RESOLUTION_TRANSACTION_PAGES,
+  planPersistentReferenceResolutionPages,
+} from '../../src/code_graph/store_resolution_core.js';
 
 describe('code graph resolution pass bounds', () => {
   it('admits exactly the finite non-negative pass prefix', () => {
@@ -73,5 +78,37 @@ describe('code graph resolution pass bounds', () => {
         {finalFactBytes: Number.NaN, operation: 'resolve persistent code graph references', rowCount: 1},
       ]),
     ).toMatchObject({finalFactBytes: Number.NaN, rowCount: Number.NaN});
+  });
+
+  it('widens reservation windows without widening transactions or changing page order', () => {
+    expect(PERSISTENT_FULL_RESOLUTION_RESERVATION_PAGES).toBe(2 * PERSISTENT_FULL_RESOLUTION_TRANSACTION_PAGES);
+    fc.assert(
+      fc.property(fc.array(fc.integer(), {maxLength: 257}), pages => {
+        const reservations = planPersistentReferenceResolutionPages(pages);
+        expect(reservations.flatMap(reservation => reservation.pages)).toEqual(pages);
+        expect(reservations).toHaveLength(Math.ceil(pages.length / PERSISTENT_FULL_RESOLUTION_RESERVATION_PAGES));
+        for (const reservation of reservations) {
+          expect(reservation.pages.length).toBeGreaterThan(0);
+          expect(reservation.pages.length).toBeLessThanOrEqual(PERSISTENT_FULL_RESOLUTION_RESERVATION_PAGES);
+          expect(reservation.transactions.flat()).toEqual(reservation.pages);
+          for (const transaction of reservation.transactions) {
+            expect(transaction.length).toBeGreaterThan(0);
+            expect(transaction.length).toBeLessThanOrEqual(PERSISTENT_FULL_RESOLUTION_TRANSACTION_PAGES);
+          }
+        }
+        expect(reservations.flatMap(reservation => reservation.transactions)).toHaveLength(
+          Math.ceil(pages.length / PERSISTENT_FULL_RESOLUTION_TRANSACTION_PAGES),
+        );
+      }),
+      {numRuns: 250},
+    );
+
+    const boundary = planPersistentReferenceResolutionPages(Array.from({length: 17}, (_, index) => index));
+    expect(boundary.map(reservation => reservation.pages.length)).toEqual([8, 8, 1]);
+    expect(boundary.map(reservation => reservation.transactions.map(transaction => transaction.length))).toEqual([
+      [4, 4],
+      [4, 4],
+      [1],
+    ]);
   });
 });

--- a/test/unit/code-graph.resolution-progress.test.ts
+++ b/test/unit/code-graph.resolution-progress.test.ts
@@ -1,18 +1,26 @@
 import {it as effectIt} from '@effect/vitest';
 import {Deferred, Effect, Ref} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {TestClock} from 'effect/testing';
 import {afterEach, describe, expect, it} from 'vitest';
 import {CodeGraphStore, type CodeGraphResolutionProgressCallback} from '../../src/code_graph/store.js';
+import {
+  type CodeGraphWriterGate,
+  PERSISTENT_FULL_RESOLUTION_PAGE_CANDIDATES,
+  PERSISTENT_FULL_RESOLUTION_PAGE_PAYLOAD_BYTES,
+} from '../../src/code_graph/store_build_core.js';
+import {resolveActivationReferences} from '../../src/code_graph/store_resolution.js';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
-import type {
-  CodeGraphEdge,
-  CodeGraphInventoryFile,
-  CodeGraphReference,
-  CodeGraphResolutionActivity,
-  CodeGraphSnapshot,
-  CodeGraphSymbol,
-  RepositoryIdentity,
+import {
+  type CodeGraphEdge,
+  type CodeGraphInventoryFile,
+  type CodeGraphReference,
+  type CodeGraphResolutionActivity,
+  type CodeGraphSnapshot,
+  CodeGraphStoreError,
+  type CodeGraphSymbol,
+  type RepositoryIdentity,
 } from '../../src/code_graph/types.js';
 import {claimPersistentBuildForTest} from '../helpers/code-graph-build.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
@@ -172,6 +180,111 @@ describe('code graph reference-resolution progress', () => {
           ),
         );
         expect(semanticDigest).toBe('db81d8f0de093727cacb3d934d779743287400d78764fafd2386d029a0bafba4');
+      }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    30_000,
+  );
+
+  effectIt.effect(
+    'resumes a committed transaction prefix inside a wider capacity reservation',
+    () =>
+      Effect.gen(function* () {
+        const fixture = yield* Effect.promise(() => resolutionFixture());
+        const target = symbol('window-target', 'windowTarget');
+        const callers = Array.from({length: 9}, (_, index) => symbol(`window-caller-${index}`, `windowCaller${index}`));
+        const unresolved = callers.map((caller, index) => resolvableReference(fixture.file, caller, target, index));
+        const snapshot = persistentSnapshot(fixture.identity, callers.length + 1, unresolved.length);
+        const firstCapacityRows: number[] = [];
+        const firstProgress: CodeGraphResolutionActivity[] = [];
+        const resumedCapacityRows: number[] = [];
+        let firstTransactionAttempts = 0;
+        let resumedTransactions = 0;
+
+        const result = yield* Effect.gen(function* () {
+          const store = yield* CodeGraphStore;
+          return yield* store.withSession(
+            fixture.databasePath,
+            Effect.gen(function* () {
+              const ownerToken = yield* claimPersistentBuildForTest(store, fixture.databasePath, fixture.identity, {
+                ...snapshot,
+                state: 'building',
+              });
+              yield* store.prepareActivation(fixture.databasePath, [fixture.file], snapshot.id, 1, ownerToken);
+              yield* store.stageActivationFacts(
+                fixture.databasePath,
+                [target, ...callers],
+                unresolved.map(entry => entry.edge),
+                unresolved.map(entry => entry.reference),
+                undefined,
+                0,
+              );
+              const failSecondTransaction: CodeGraphWriterGate = transaction =>
+                Effect.gen(function* () {
+                  firstTransactionAttempts += 1;
+                  if (firstTransactionAttempts === 2) {
+                    return yield* Effect.fail(
+                      new CodeGraphStoreError('Injected second resolution transaction failure.'),
+                    );
+                  }
+                  return yield* transaction;
+                });
+              const pageLimits = {
+                candidateCount: PERSISTENT_FULL_RESOLUTION_PAGE_CANDIDATES,
+                payloadBytes: PERSISTENT_FULL_RESOLUTION_PAGE_PAYLOAD_BYTES,
+                references: 1,
+              };
+              const firstFailure = yield* resolveActivationReferences(
+                progress => Effect.sync(() => firstProgress.push(progress)),
+                failSecondTransaction,
+                (boundary, transactions) =>
+                  Effect.sync(() => firstCapacityRows.push(boundary.rowCount)).pipe(Effect.andThen(transactions)),
+                pageLimits,
+              ).pipe(Effect.flip);
+              const sql = yield* SqlClient.SqlClient;
+              const afterFailure = yield* sql<{readonly remaining: number; readonly resolved: number}>`
+                SELECT
+                  (SELECT COUNT(*) FROM building_references WHERE snapshot_id = ${snapshot.id}) AS remaining,
+                  (SELECT COUNT(*) FROM edges
+                   WHERE snapshot_id = ${snapshot.id} AND target_id IS NOT NULL) AS resolved
+              `;
+              const resumed = yield* resolveActivationReferences(
+                undefined,
+                transaction =>
+                  Effect.sync(() => {
+                    resumedTransactions += 1;
+                  }).pipe(Effect.andThen(transaction)),
+                (boundary, transactions) =>
+                  Effect.sync(() => resumedCapacityRows.push(boundary.rowCount)).pipe(Effect.andThen(transactions)),
+                pageLimits,
+              );
+              const afterResume = yield* sql<{readonly remaining: number; readonly resolved: number}>`
+                SELECT
+                  (SELECT COUNT(*) FROM building_references WHERE snapshot_id = ${snapshot.id}) AS remaining,
+                  (SELECT COUNT(*) FROM edges
+                   WHERE snapshot_id = ${snapshot.id} AND target_id IS NOT NULL) AS resolved
+              `;
+              yield* store.activateStaged(fixture.databasePath, fixture.identity, snapshot);
+              return {
+                afterFailure: afterFailure[0]!,
+                afterResume: afterResume[0]!,
+                firstFailure,
+                graph: yield* store.loadGraph(fixture.databasePath, snapshot.id),
+                resumed,
+              };
+            }),
+          );
+        });
+
+        expect(result.firstFailure).toBeInstanceOf(CodeGraphStoreError);
+        expect(firstCapacityRows).toEqual([88]);
+        expect(firstTransactionAttempts).toBe(2);
+        expect(result.afterFailure).toEqual({remaining: 5, resolved: 4});
+        expect(firstProgress.at(-1)).toMatchObject({pageCompleted: 8, resolved: 4});
+        expect(resumedCapacityRows).toEqual([55]);
+        expect(resumedTransactions).toBe(2);
+        expect(result.resumed).toMatchObject({pagesCompleted: 5, referencesExamined: 5, resolved: 5});
+        expect(result.afterResume).toEqual({remaining: 0, resolved: 9});
+        expect(result.graph.edges).toHaveLength(9);
+        expect(result.graph.edges.every(edge => edge.targetId === target.id)).toBe(true);
       }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
     30_000,
   );


### PR DESCRIPTION
## Summary

- reserve disk capacity across 8 bounded persistent reference-resolution pages while keeping each SQLite transaction and writer-lock exposure at the existing 4-page limit;
- commit and account for each 4-page prefix independently, so interruption or a later transaction failure resumes from the durable prefix;
- emit a progress heartbeat after the first transaction while the wider capacity reservation remains held, preserving the existing ~4-page liveness cadence;
- add a pure reservation/transaction planner, a 250-run Fast-check grouping property, and an Effect regression that injects failure in the second transaction and verifies both the committed prefix and intermediate heartbeat.

Part of #203.

## Governed evidence

Two exact clean `a35732e1` controls bracketed the first candidate, followed by two exact clean final-HEAD runs at `62df1aac9927da18d40986dc977e9e603e2528f7`. All runs used the same production-large v2 fixture, Apple M1 Max runner identity, Bun 1.3.14, lexical-only retrieval, four parser workers, internal APFS/Apple Fabric SSD, and at least 158 GiB free.

| Metric | control mean | candidate mean | delta |
| --- | ---: | ---: | ---: |
| cold index | 130,869 ms | 129,936 ms | -0.71% |
| reference resolution | 23,776 ms | 23,462 ms | -1.32% |
| reservation-side residual outside matching/SQLite transactions | 2,632 ms | 2,392 ms | -9.12% |
| cold process CPU | 142,024 ms | 141,242 ms | -0.55% |
| recursive cold CPU | 162,315 ms | 161,270 ms | -0.64% |
| maximum cold progress gap | 3,093 ms | 3,083 ms | -0.33% |
| resolution-local RSS | 1,292 MB | 1,333 MB | +41 MB |
| SQLite main peak | 1,755,906,048 B | 1,755,906,048 B | exact |
| SQLite WAL peak | 265,686,472 B | 265,686,472 B | exact |
| incremental SQLite TEMP peak | 417,792 B | 417,792 B | exact |

The RSS increase is the bounded extra four-page compact buffer. It is constant rather than repository-sized; against the retained pinned-IntelliJ resolution peak of 5.10 GiB it is under 1%. The independent recursive whole-cold RSS peak decreased by 11 MB. This bounded cost must be retained in the final independent resource ratchet.

Both candidate artifacts have exact incremental-versus-independent-full structural and primary-query parity. Cross-run primary-query digests match the controls, every semantic count/shape/production-attainment metric is exact, and all external sampler failure counters are zero.

Artifact SHA-256 values:

- control 1: `1ec8d2d8e9c399e9d61769414a2b72f450e698d9043cd17bb206605f50fb7530`
- control 2: `9e95c8f468b7a829a9c6efd2c74dea5e08c98a15172d584a7fa1ec128d434ba6`
- final candidate 1: `2262e9c93d55eefe6c0f3d574c5245d66f15b3fb7c738a715c6437d64b6249e8`
- final candidate 2: `b860fdd6f04e8507e7f05d377585e7a460c1f323567b4c0a313732ec010174f4`

## Verification

- focused Vitest: 43 relevant examples/properties across resolution, parity, status, analysis, and materialization resume behavior;
- `bun run lint` (including Bun/Node runtime boundaries and file-length policy);
- `bun run typecheck`;
- exact clean global install at `62df1aac`, followed by a real installed full graph build and query smoke;
- installed smoke observed the intermediate transaction heartbeat (`resolved: 15,731`) before the second transaction completed (`resolved: 31,515`).

The complete local test suite was intentionally not run; PR CI is authoritative per repository policy.
