### PR TITLE
Fix cleanup of stale MCP broker children

### DIFF
--- a/scripts/install-local-standalone.ts
+++ b/scripts/install-local-standalone.ts
@@ -16,6 +16,7 @@ import {
   withStandaloneInstallationLock,
 } from '../src/installations.js';
 import {
+  explicitlyPreservedStandaloneProcessIds,
   preservedStandaloneProcessIds,
   readStandaloneProcessLeaseVerification,
   terminateSupersededStandaloneProcesses,
@@ -487,7 +488,9 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
       const superseded = [...live.value.verified, ...live.value.unverified].filter(
         lease => lease.version !== input.version,
       );
-      const preservedProcessIds = preservedStandaloneProcessIds(superseded);
+      const preservedProcessIds = input.terminateSuperseded
+        ? explicitlyPreservedStandaloneProcessIds(superseded)
+        : preservedStandaloneProcessIds(superseded);
       for (const lease of superseded) {
         if (preservedMcpSessionProcessIds.has(lease.processId)) continue;
         if (preservedProcessIds.has(lease.processId)) {

--- a/src/standalone_process_lease.ts
+++ b/src/standalone_process_lease.ts
@@ -267,7 +267,11 @@ export const terminateSupersededStandaloneProcesses = Effect.fn('installations.t
     const superseded = scan.leases.filter(
       lease => lease.version !== activeVersion && lease.processId !== system.processId,
     );
-    const preservedIds = preservedStandaloneProcessIds(superseded);
+    // The stable broker is explicitly session-pinned, but its versioned MCP
+    // runtime and workers retain the default terminate policy. An explicit
+    // maintenance cleanup must therefore preserve only leases that opted in,
+    // rather than treating every descendant of the broker as pinned too.
+    const preservedIds = explicitlyPreservedStandaloneProcessIds(superseded);
     const preserved = superseded.filter(lease => preservedIds.has(lease.processId));
     const eligible = superseded.filter(lease => !preservedIds.has(lease.processId));
     const verified = eligible.filter(lease => lease.identityVerified);
@@ -395,9 +399,7 @@ function publicLease(lease: ObservedStandaloneProcessLease): StandaloneProcessLe
 export function preservedStandaloneProcessIds(
   leases: readonly Pick<StandaloneProcessLease, 'parentProcessId' | 'processId' | 'retirementPolicy'>[],
 ): ReadonlySet<number> {
-  const preserved = new Set(
-    leases.filter(lease => lease.retirementPolicy === 'preserve-session').map(lease => lease.processId),
-  );
+  const preserved = new Set(explicitlyPreservedStandaloneProcessIds(leases));
   let changed = true;
   while (changed) {
     changed = false;
@@ -413,6 +415,13 @@ export function preservedStandaloneProcessIds(
     }
   }
   return preserved;
+}
+
+/** @internal Explicit preserve-session leases remain alive during requested retirement. */
+export function explicitlyPreservedStandaloneProcessIds(
+  leases: readonly Pick<StandaloneProcessLease, 'processId' | 'retirementPolicy'>[],
+): ReadonlySet<number> {
+  return new Set(leases.filter(lease => lease.retirementPolicy === 'preserve-session').map(lease => lease.processId));
 }
 
 function signalLeaseIfStillOwned(

--- a/test/unit/development-runtime.test.ts
+++ b/test/unit/development-runtime.test.ts
@@ -1001,7 +1001,7 @@ describe('exact-head development runtime', () => {
       }),
   );
 
-  effectIt.effect('reports the complete preserved session tree when superseded processes remain running', () =>
+  effectIt.effect('retires the old MCP runtime below a preserved stable broker when requested', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -1066,6 +1066,8 @@ describe('exact-head development runtime', () => {
             leases.map(lease => [lease.processId, lease.processStartIdentity]),
           );
           const running = new Set<number>(leases.map(lease => lease.processId));
+          const signals: Array<readonly [number, NodeJS.Signals]> = [];
+          let terminationRequested = false;
           const testSystem = SystemInfo.of({
             ...baseSystem,
             environment: () => ({
@@ -1076,11 +1078,15 @@ describe('exact-head development runtime', () => {
             isProcessRunning: processId => running.has(processId),
             processId: 99_999,
             processStartIdentity: processId => Effect.succeed(identities.get(processId)),
-            signalProcess: () => {
-              throw new TestError('Installer must not signal processes without --terminate-superseded');
+            signalProcess: (processId, signal) => {
+              if (!terminationRequested) {
+                throw new TestError('Installer must not signal processes without --terminate-superseded');
+              }
+              signals.push([processId, signal]);
+              running.delete(processId);
             },
           });
-          return yield* activateLocalStandaloneRelease({
+          const activation = {
             canonicalInstallRoot: yield* fs.realPath(installRoot),
             canonicalVersionsRoot: yield* fs.realPath(path.join(installRoot, 'versions')),
             commit: sourceCommit,
@@ -1092,20 +1098,40 @@ describe('exact-head development runtime', () => {
             takeOverGlobalRuntime: false,
             terminateSuperseded: false,
             version,
-          }).pipe(
+          } as const;
+          const preserved = yield* activateLocalStandaloneRelease(activation).pipe(
             Effect.provideService(CommandExecutor, versionCommandExecutor(version)),
             Effect.provideService(SystemInfo, testSystem),
           );
+          terminationRequested = true;
+          const cleaned = yield* activateLocalStandaloneRelease({...activation, terminateSuperseded: true}).pipe(
+            Effect.provideService(CommandExecutor, versionCommandExecutor(version)),
+            Effect.provideService(SystemInfo, testSystem),
+          );
+          return {cleaned, preserved, running, signals};
         }),
       ).pipe(provideTestLayer(ApplicationLayer));
 
-      expect(result).toMatchObject({
+      expect(result.preserved).toMatchObject({
         cleanupComplete: false,
         cleanupIssues: [],
         preservedMcpSessionProcesses: 3,
         remainingSupersededProcesses: 1,
         terminatedSupersededProcesses: 0,
       });
+      expect(result.signals).toEqual([
+        [45_002, 'SIGTERM'],
+        [45_004, 'SIGTERM'],
+        [45_003, 'SIGTERM'],
+      ]);
+      expect(result.cleaned).toMatchObject({
+        cleanupComplete: true,
+        cleanupIssues: [],
+        preservedMcpSessionProcesses: 1,
+        remainingSupersededProcesses: 0,
+        terminatedSupersededProcesses: 3,
+      });
+      expect([...result.running]).toEqual([45_001]);
     }),
   );
 

--- a/test/unit/installations.test.ts
+++ b/test/unit/installations.test.ts
@@ -602,7 +602,7 @@ describe('standalone release lifecycle', () => {
     }),
   );
 
-  effectIt.effect('preserves an MCP session process and its complete descendant tree during retirement', () =>
+  effectIt.effect('preserves the stable MCP broker while retiring its superseded runtime tree', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -654,9 +654,14 @@ describe('standalone release lifecycle', () => {
         }),
       ).pipe(provideTestLayer(ApplicationLayer));
 
-      expect(result.signals).toEqual([[44_004, 'SIGTERM']]);
-      expect(result.termination.preserved.map(lease => lease.processId)).toEqual([44_001, 44_002, 44_003]);
-      expect([...result.running].sort()).toEqual([44_001, 44_002, 44_003]);
+      expect(result.signals).toEqual([
+        [44_002, 'SIGTERM'],
+        [44_004, 'SIGTERM'],
+        [44_003, 'SIGTERM'],
+      ]);
+      expect(result.termination.preserved.map(lease => lease.processId)).toEqual([44_001]);
+      expect(result.termination.signaled.map(lease => lease.processId)).toEqual([44_002, 44_003, 44_004]);
+      expect([...result.running]).toEqual([44_001]);
     }),
   );
 

--- a/test/unit/standalone-process-lease.property.test.ts
+++ b/test/unit/standalone-process-lease.property.test.ts
@@ -1,7 +1,11 @@
 import {Option} from 'effect';
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
-import {preservedStandaloneProcessIds, type StandaloneProcessLease} from '../../src/standalone_process_lease.js';
+import {
+  explicitlyPreservedStandaloneProcessIds,
+  preservedStandaloneProcessIds,
+  type StandaloneProcessLease,
+} from '../../src/standalone_process_lease.js';
 
 describe('standalone process retirement properties', () => {
   it('preserves exactly the processes rooted beneath preserve-session leases', () => {
@@ -40,6 +44,22 @@ describe('standalone process retirement properties', () => {
           );
         },
       ),
+      {numRuns: 200},
+    );
+  });
+
+  it('explicit retirement preserves exactly the leases that opt into session preservation', () => {
+    fc.assert(
+      fc.property(fc.array(fc.boolean(), {minLength: 1, maxLength: 40}), preserveFlags => {
+        const leases = preserveFlags.map((preserve, index) => ({
+          processId: index + 1,
+          retirementPolicy: preserve ? ('preserve-session' as const) : ('terminate' as const),
+        }));
+
+        expect([...explicitlyPreservedStandaloneProcessIds(leases)]).toEqual(
+          leases.filter(lease => lease.retirementPolicy === 'preserve-session').map(lease => lease.processId),
+        );
+      }),
       {numRuns: 200},
     );
   });


### PR DESCRIPTION
## Summary
- preserve only explicitly `preserve-session` leases during requested process retirement
- keep ancestry-based preservation for passive installer reporting, but do not let it hide stale broker children after `--terminate-superseded`
- cover broker/MCP/worker cleanup with Effect-native regressions and a bounded Fast-check property

## Verification
- `bun --bun vitest run test/unit/installations.test.ts test/unit/development-runtime.test.ts test/unit/standalone-process-lease.property.test.ts` (43 passed)
- `bun run typecheck`
- `bun run lint`
- pre-commit formatting and checks

## Runtime smoke
Pending the active global-runtime owner task; the installer ownership guard correctly refused takeover.