### PR TITLE
fix(mcp): persist read cursors across processes

### DIFF
--- a/src/mcp_server_recall.ts
+++ b/src/mcp_server_recall.ts
@@ -49,13 +49,17 @@ import {
   MEMORY_READ_DEFAULT_BUDGET_TOKENS,
   MEMORY_READ_MAXIMUM_BUDGET_TOKENS,
   MEMORY_READ_MINIMUM_BUDGET_TOKENS,
-  MemoryReadCursorStore,
   memoryReadCursorToken,
   memoryReadSourceHashes,
   memoryReadSourcesMatch,
   projectMemoryReadPage,
   type MemoryReadResource,
 } from './memory_read_projection.js';
+import {
+  memoryReadCursorNamespace,
+  putPersistentMemoryReadCursor,
+  takePersistentMemoryReadCursor,
+} from './memory_read_cursor_store.js';
 import {
   buildCandidateReview,
   candidateReviewWithAuditEvent,
@@ -1180,7 +1184,12 @@ export function registerReadTool(
   description: string,
   memoryScope?: CursorCloudMemoryScope,
 ): void {
-  const cursorStore = new MemoryReadCursorStore();
+  const cursorNamespace = memoryReadCursorNamespace({
+    account: config.account,
+    ...(memoryScope ? {memoryRoot: memoryScope.root, team: memoryScope.team} : {}),
+    toolName: name,
+    user: config.user,
+  });
   server.registerTool(
     name,
     {
@@ -1216,7 +1225,14 @@ export function registerReadTool(
       }
       return Effect.gen(function* () {
         const now = yield* Clock.currentTimeMillis;
-        const continuation = requestedCursor ? cursorStore.take(requestedCursor, now) : undefined;
+        const continuationResult = requestedCursor
+          ? yield* takePersistentMemoryReadCursor(config.agentContextHome, cursorNamespace, requestedCursor, now).pipe(
+              Effect.map(value => ({ok: true as const, value})),
+              Effect.catch(error => Effect.succeed({error, ok: false as const})),
+            )
+          : {ok: true as const, value: undefined};
+        if (!continuationResult.ok) return mcpErrorResult(continuationResult.error);
+        const continuation = continuationResult.value;
         if (requestedCursor && !continuation) {
           return argumentError(`${name} cursor is invalid, expired, or already consumed; restart from the URI.`);
         }
@@ -1280,7 +1296,10 @@ export function registerReadTool(
         if (Result.isFailure(projected)) return argumentError(errorMessage(projected.failure));
         const page = projected.success;
         if (!page.complete) {
-          cursorStore.put(
+          const cursorIssuedAt = yield* Clock.currentTimeMillis;
+          const stored = yield* putPersistentMemoryReadCursor(
+            config.agentContextHome,
+            cursorNamespace,
             continuationCursor,
             {
               mode: continuation?.mode ?? mode ?? 'content',
@@ -1289,8 +1308,12 @@ export function registerReadTool(
               sourceHashes: memoryReadSourceHashes(resources),
               uris: requestedUris,
             },
-            now,
+            cursorIssuedAt,
+          ).pipe(
+            Effect.map(() => ({ok: true as const})),
+            Effect.catch(error => Effect.succeed({error, ok: false as const})),
           );
+          if (!stored.ok) return mcpErrorResult(stored.error);
         }
         return {
           _meta: {

--- a/src/memory_read_cursor_store.ts
+++ b/src/memory_read_cursor_store.ts
@@ -1,0 +1,338 @@
+import {Database} from 'bun:sqlite';
+import {Effect, FileSystem, Path} from 'effect';
+import {sha256HexSync} from './crypto/sha256.js';
+import {MEMORY_READ_CURSOR_TTL_MILLISECONDS, type MemoryReadCursorState} from './memory_read_projection.js';
+
+const CURSOR_TOKEN = /^tnrc_[0-9a-f]{32}$/u;
+const NAMESPACE = /^[0-9a-f]{64}$/u;
+const SOURCE_HASH = /^[0-9a-f]{64}$/u;
+const CURSOR_DATABASE_FILENAME = 'read-context-cursors-v1.sqlite';
+const CURSOR_DATABASE_BUSY_TIMEOUT_MILLISECONDS = 5_000;
+const CURSOR_STATE_MAXIMUM_BYTES = 262_144;
+const CURSOR_STORE_MAXIMUM_ENTRIES = 256;
+
+interface StoredCursorRow {
+  readonly expires_at: unknown;
+  readonly state_json: unknown;
+}
+
+interface StoredCursorEnvelopeV1 {
+  readonly expiresAt: number;
+  readonly state: MemoryReadCursorState;
+  readonly version: 1;
+}
+
+export class PersistentMemoryReadCursorStoreError extends Error {
+  override readonly name = 'PersistentMemoryReadCursorStoreError';
+}
+
+export interface PersistentMemoryReadCursorStoreOptions {
+  readonly maximumEntries?: number;
+  readonly ttlMilliseconds?: number;
+}
+
+export function memoryReadCursorNamespace(input: {
+  readonly account: string;
+  readonly memoryRoot?: string;
+  readonly team?: string;
+  readonly toolName: string;
+  readonly user: string;
+}): string {
+  return sha256HexSync(
+    JSON.stringify({
+      account: input.account,
+      memoryRoot: input.memoryRoot ?? null,
+      team: input.team ?? null,
+      toolName: input.toolName,
+      user: input.user,
+      version: 1,
+    }),
+  );
+}
+
+export function serializePersistentMemoryReadCursorState(state: MemoryReadCursorState, expiresAt: number): string {
+  assertCursorState(state);
+  if (!validTimestamp(expiresAt))
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor expiry is invalid.');
+  const serialized = JSON.stringify({expiresAt, state, version: 1} satisfies StoredCursorEnvelopeV1);
+  if (new TextEncoder().encode(serialized).byteLength > CURSOR_STATE_MAXIMUM_BYTES) {
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor state exceeds its bounded size.');
+  }
+  return serialized;
+}
+
+export function parsePersistentMemoryReadCursorState(serialized: string): StoredCursorEnvelopeV1 {
+  if (new TextEncoder().encode(serialized).byteLength > CURSOR_STATE_MAXIMUM_BYTES) {
+    throw new PersistentMemoryReadCursorStoreError('Stored memory read cursor state exceeds its bounded size.');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    throw new PersistentMemoryReadCursorStoreError('Stored memory read cursor state is not valid JSON.');
+  }
+  if (!exactRecord(parsed, ['expiresAt', 'state', 'version']) || parsed.version !== 1) {
+    throw new PersistentMemoryReadCursorStoreError('Stored memory read cursor envelope is invalid.');
+  }
+  if (!validTimestamp(parsed.expiresAt)) {
+    throw new PersistentMemoryReadCursorStoreError('Stored memory read cursor expiry is invalid.');
+  }
+  assertCursorState(parsed.state);
+  return parsed as unknown as StoredCursorEnvelopeV1;
+}
+
+export const putPersistentMemoryReadCursor = Effect.fn('memoryReadCursorStore.put')(function* (
+  threadnoteHome: string,
+  namespace: string,
+  cursor: string,
+  state: MemoryReadCursorState,
+  now: number,
+  options: PersistentMemoryReadCursorStoreOptions = {},
+) {
+  const {expiresAt, maximumEntries, serialized} = yield* Effect.try({
+    try: () => {
+      assertStoreIdentity(namespace, cursor, now);
+      const ttlMilliseconds = options.ttlMilliseconds ?? MEMORY_READ_CURSOR_TTL_MILLISECONDS;
+      const maximumEntries = options.maximumEntries ?? CURSOR_STORE_MAXIMUM_ENTRIES;
+      if (
+        !Number.isSafeInteger(ttlMilliseconds) ||
+        ttlMilliseconds < 1 ||
+        ttlMilliseconds > MEMORY_READ_CURSOR_TTL_MILLISECONDS
+      ) {
+        throw new PersistentMemoryReadCursorStoreError('Memory read cursor TTL is invalid.');
+      }
+      if (
+        !Number.isSafeInteger(maximumEntries) ||
+        maximumEntries < 1 ||
+        maximumEntries > CURSOR_STORE_MAXIMUM_ENTRIES
+      ) {
+        throw new PersistentMemoryReadCursorStoreError('Memory read cursor capacity is invalid.');
+      }
+      const expiresAt = now + ttlMilliseconds;
+      if (!validTimestamp(expiresAt)) {
+        throw new PersistentMemoryReadCursorStoreError('Memory read cursor expiry is invalid.');
+      }
+      return {expiresAt, maximumEntries, serialized: serializePersistentMemoryReadCursorState(state, expiresAt)};
+    },
+    catch: persistentCursorStoreError,
+  });
+  yield* useCursorDatabase(threadnoteHome, database => {
+    inImmediateTransaction(database, () => {
+      database.query('DELETE FROM read_context_cursors WHERE expires_at <= ?').run(now);
+      database
+        .query(
+          `INSERT INTO read_context_cursors
+             (namespace, token, state_json, created_at, expires_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(namespace, cursor, serialized, now, expiresAt);
+      const count = Number(
+        database.query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM read_context_cursors').get()
+          ?.count ?? 0,
+      );
+      const excess = Math.max(0, count - maximumEntries);
+      if (excess > 0) {
+        database
+          .query(
+            `DELETE FROM read_context_cursors
+             WHERE rowid IN (
+               SELECT rowid FROM read_context_cursors
+               WHERE NOT (namespace = ? AND token = ?)
+               ORDER BY created_at, expires_at, token
+               LIMIT ?
+             )`,
+          )
+          .run(namespace, cursor, excess);
+      }
+    });
+  });
+});
+
+export const takePersistentMemoryReadCursor = Effect.fn('memoryReadCursorStore.take')(function* (
+  threadnoteHome: string,
+  namespace: string,
+  cursor: string,
+  now: number,
+) {
+  yield* Effect.try({
+    try: () => assertStoreIdentity(namespace, cursor, now),
+    catch: persistentCursorStoreError,
+  });
+  return yield* useCursorDatabase(threadnoteHome, database => {
+    const row = inImmediateTransaction(database, () => {
+      database.query('DELETE FROM read_context_cursors WHERE expires_at <= ?').run(now);
+      const selected = database
+        .query<StoredCursorRow, [string, string]>(
+          'SELECT state_json, expires_at FROM read_context_cursors WHERE namespace = ? AND token = ?',
+        )
+        .get(namespace, cursor);
+      if (selected) {
+        database.query('DELETE FROM read_context_cursors WHERE namespace = ? AND token = ?').run(namespace, cursor);
+      }
+      return selected;
+    });
+    if (!row) return undefined;
+    if (typeof row.state_json !== 'string' || !validTimestamp(row.expires_at)) {
+      throw new PersistentMemoryReadCursorStoreError('Stored memory read cursor row is invalid.');
+    }
+    const envelope = parsePersistentMemoryReadCursorState(row.state_json);
+    if (envelope.expiresAt !== row.expires_at || envelope.expiresAt <= now) return undefined;
+    return envelope.state;
+  });
+});
+
+function useCursorDatabase<Value>(
+  threadnoteHome: string,
+  use: (database: Database) => Value,
+): Effect.Effect<Value, PersistentMemoryReadCursorStoreError, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const root = path.join(threadnoteHome, 'threadnote', 'mcp');
+    const databasePath = path.join(root, CURSOR_DATABASE_FILENAME);
+    yield* fs
+      .makeDirectory(root, {recursive: true, mode: 0o700})
+      .pipe(
+        Effect.mapError(() => new PersistentMemoryReadCursorStoreError('Memory read cursor directory is unavailable.')),
+      );
+    yield* fs
+      .chmod(root, 0o700)
+      .pipe(
+        Effect.mapError(() => new PersistentMemoryReadCursorStoreError('Memory read cursor permissions are invalid.')),
+      );
+    const result = yield* Effect.acquireUseRelease(
+      Effect.try({
+        try: () => new Database(databasePath, {create: true, strict: true}),
+        catch: () => new PersistentMemoryReadCursorStoreError('Memory read cursor database could not be opened.'),
+      }),
+      database =>
+        Effect.try({
+          try: () => {
+            configureCursorDatabase(database);
+            initializeCursorDatabase(database);
+            return use(database);
+          },
+          catch: error =>
+            error instanceof PersistentMemoryReadCursorStoreError
+              ? error
+              : new PersistentMemoryReadCursorStoreError('Memory read cursor database operation failed.'),
+        }),
+      database => Effect.sync(() => database.close()),
+    );
+    yield* fs
+      .chmod(databasePath, 0o600)
+      .pipe(
+        Effect.mapError(() => new PersistentMemoryReadCursorStoreError('Memory read cursor permissions are invalid.')),
+      );
+    return result;
+  });
+}
+
+function configureCursorDatabase(database: Database): void {
+  database.exec(`
+    PRAGMA busy_timeout = ${CURSOR_DATABASE_BUSY_TIMEOUT_MILLISECONDS};
+    PRAGMA journal_mode = DELETE;
+    PRAGMA synchronous = FULL;
+    PRAGMA temp_store = MEMORY;
+  `);
+}
+
+function initializeCursorDatabase(database: Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS read_context_cursors (
+      namespace TEXT NOT NULL,
+      token TEXT NOT NULL,
+      state_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL,
+      PRIMARY KEY (namespace, token)
+    ) STRICT;
+    CREATE INDEX IF NOT EXISTS read_context_cursors_expiry
+      ON read_context_cursors(expires_at, created_at, namespace, token);
+  `);
+}
+
+function inImmediateTransaction<Value>(database: Database, use: () => Value): Value {
+  database.exec('BEGIN IMMEDIATE');
+  try {
+    const result = use();
+    database.exec('COMMIT');
+    return result;
+  } catch (error) {
+    try {
+      database.exec('ROLLBACK');
+    } catch {
+      // Preserve the original operation failure.
+    }
+    throw error;
+  }
+}
+
+function assertStoreIdentity(namespace: string, cursor: string, now: number): void {
+  if (!NAMESPACE.test(namespace))
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor namespace is invalid.');
+  if (!CURSOR_TOKEN.test(cursor))
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor token is invalid.');
+  if (!validTimestamp(now)) throw new PersistentMemoryReadCursorStoreError('Memory read cursor timestamp is invalid.');
+}
+
+function assertCursorState(value: unknown): asserts value is MemoryReadCursorState {
+  if (!exactRecord(value, ['mode', 'position', 'section', 'sourceHashes', 'uris'], ['section'])) {
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor state is invalid.');
+  }
+  if (value.mode !== 'content' && value.mode !== 'outline') {
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor mode is invalid.');
+  }
+  if (!exactRecord(value.position, ['characterOffset', 'resourceIndex'])) {
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor position is invalid.');
+  }
+  const characterOffset = value.position.characterOffset;
+  const resourceIndex = value.position.resourceIndex;
+  if (
+    typeof characterOffset !== 'number' ||
+    !Number.isSafeInteger(characterOffset) ||
+    characterOffset < 0 ||
+    typeof resourceIndex !== 'number' ||
+    !Number.isSafeInteger(resourceIndex) ||
+    resourceIndex < 0
+  ) {
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor position is invalid.');
+  }
+  if (!Array.isArray(value.uris) || value.uris.length === 0 || !value.uris.every(uri => typeof uri === 'string')) {
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor resource identities are invalid.');
+  }
+  if (
+    !Array.isArray(value.sourceHashes) ||
+    value.sourceHashes.length !== value.uris.length ||
+    !value.sourceHashes.every(hash => typeof hash === 'string' && SOURCE_HASH.test(hash))
+  ) {
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor source hashes are invalid.');
+  }
+  if (resourceIndex >= value.uris.length || (value.section !== undefined && typeof value.section !== 'string')) {
+    throw new PersistentMemoryReadCursorStoreError('Memory read cursor state is inconsistent.');
+  }
+}
+
+function exactRecord(
+  value: unknown,
+  keys: readonly string[],
+  optional: readonly string[] = [],
+): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const expected = new Set(keys);
+  const actual = Object.keys(value);
+  return (
+    actual.every(key => expected.has(key)) &&
+    keys.every(key => optional.includes(key) || Object.prototype.hasOwnProperty.call(value, key))
+  );
+}
+
+function validTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 && value <= 253_402_300_799_999;
+}
+
+function persistentCursorStoreError(error: unknown): PersistentMemoryReadCursorStoreError {
+  return error instanceof PersistentMemoryReadCursorStoreError
+    ? error
+    : new PersistentMemoryReadCursorStoreError('Memory read cursor input is invalid.');
+}

--- a/src/memory_read_projection.ts
+++ b/src/memory_read_projection.ts
@@ -7,7 +7,6 @@ export const MEMORY_READ_CURSOR_TTL_MILLISECONDS = 10 * 60 * 1_000;
 
 const MEMORY_READ_ESTIMATED_BYTES_PER_TOKEN = 3;
 const MEMORY_READ_CURSOR_PREFIX = 'tnrc_';
-const MEMORY_READ_CURSOR_MAXIMUM_ENTRIES = 256;
 const MEMORY_READ_WARNING_MAXIMUM_BYTES = 160;
 const UTF8 = new TextEncoder();
 
@@ -59,57 +58,6 @@ export interface MemoryReadPage {
 
 export class MemoryReadProjectionError extends Error {
   override readonly name = 'MemoryReadProjectionError';
-}
-
-interface StoredCursor {
-  readonly expiresAt: number;
-  readonly state: MemoryReadCursorState;
-}
-
-/**
- * Process-local cursors deliberately contain no source identity. They are
- * single-use so retries cannot race two divergent continuations, and bounded
- * so abandoned reads cannot grow the MCP process without limit.
- */
-export class MemoryReadCursorStore {
-  readonly #entries = new Map<string, StoredCursor>();
-
-  constructor(
-    readonly ttlMilliseconds = MEMORY_READ_CURSOR_TTL_MILLISECONDS,
-    readonly maximumEntries = MEMORY_READ_CURSOR_MAXIMUM_ENTRIES,
-  ) {
-    if (!Number.isSafeInteger(ttlMilliseconds) || ttlMilliseconds < 1) {
-      throw new MemoryReadProjectionError('Memory read cursor TTL must be a positive integer.');
-    }
-    if (!Number.isSafeInteger(maximumEntries) || maximumEntries < 1) {
-      throw new MemoryReadProjectionError('Memory read cursor capacity must be a positive integer.');
-    }
-  }
-
-  put(cursor: string, state: MemoryReadCursorState, now: number): void {
-    this.#prune(now);
-    this.#entries.delete(cursor);
-    while (this.#entries.size >= this.maximumEntries) {
-      const oldest = this.#entries.keys().next().value as string | undefined;
-      if (oldest === undefined) break;
-      this.#entries.delete(oldest);
-    }
-    this.#entries.set(cursor, {expiresAt: now + this.ttlMilliseconds, state});
-  }
-
-  take(cursor: string, now: number): MemoryReadCursorState | undefined {
-    this.#prune(now);
-    const stored = this.#entries.get(cursor);
-    if (!stored) return undefined;
-    this.#entries.delete(cursor);
-    return stored.state;
-  }
-
-  #prune(now: number): void {
-    for (const [cursor, stored] of this.#entries) {
-      if (stored.expiresAt <= now) this.#entries.delete(cursor);
-    }
-  }
 }
 
 export function memoryReadCursorToken(entropy: string): string {

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -81,25 +81,54 @@ const ADVANCED_TOOL_NAMES = [
   'install_shared_skill',
 ];
 
+interface McpFixture {
+  readonly home: string;
+  readonly root: string;
+}
+
+interface McpClientOptions {
+  readonly environment?: Readonly<Record<string, string>>;
+  readonly maxBufferSize?: number;
+  readonly toolset?: 'core' | 'full' | null;
+}
+
 async function withMcpClient<T>(
-  fn: (client: Client, fixture: {readonly home: string; readonly root: string}) => Promise<T>,
-  options: {
-    readonly environment?: Readonly<Record<string, string>>;
-    readonly maxBufferSize?: number;
-    readonly toolset?: 'core' | 'full' | null;
-  } = {},
+  fn: (client: Client, fixture: McpFixture) => Promise<T>,
+  options: McpClientOptions = {},
 ): Promise<T> {
   const root = await mkdtemp(join(tmpdir(), 'threadnote-mcp-native-'));
   const home = join(root, 'home');
   await mkdir(home, {recursive: true});
+  const fixture = {home, root};
+  try {
+    return await withMcpClientForFixture(fixture, fn, options);
+  } finally {
+    await rm(root, {force: true, recursive: true});
+  }
+}
+
+async function withMcpClientForFixture<T>(
+  fixture: McpFixture,
+  fn: (client: Client, fixture: McpFixture) => Promise<T>,
+  options: McpClientOptions = {},
+): Promise<T> {
+  const client = await connectMcpClient(fixture, options);
+  try {
+    return await fn(client, fixture);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+async function connectMcpClient(fixture: McpFixture, options: McpClientOptions = {}): Promise<Client> {
   const repoRoot = process.cwd();
   const environment = {
     ...process.env,
     ...options.environment,
     THREADNOTE_ACCOUNT: 'local',
     THREADNOTE_AGENT_ID: 'threadnote',
-    THREADNOTE_HOME: home,
-    THREADNOTE_MANIFEST: join(home, 'seed-manifest.yaml'),
+    THREADNOTE_HOME: fixture.home,
+    THREADNOTE_MANIFEST: join(fixture.home, 'seed-manifest.yaml'),
     THREADNOTE_USER: 'test-user',
   } as Record<string, string>;
   if (options.toolset === null) {
@@ -118,10 +147,10 @@ async function withMcpClient<T>(
   const client = new Client({name: 'threadnote-test', version: '0.0.0'});
   try {
     await client.connect(transport);
-    return await fn(client, {home, root});
-  } finally {
+    return client;
+  } catch (error) {
     await client.close().catch(() => undefined);
-    await rm(root, {force: true, recursive: true});
+    throw error;
   }
 }
 
@@ -882,6 +911,81 @@ describe('Threadnote MCP toolsets', () => {
     );
   }, 40_000);
 
+  it('continues read_context in a separate MCP process and atomically consumes a raced cursor', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-mcp-cross-process-read-'));
+    const fixture = {home: join(root, 'home'), root};
+    await mkdir(fixture.home, {recursive: true});
+    try {
+      const uri = 'threadnote://user/test-user/memories/durable/projects/threadnote/cross-process-read.md';
+      const content = canonicalMemoryContent(
+        'cross-process-read',
+        `${'cross-process evidence 🙂漢字\n'.repeat(3_000)}terminal`,
+      );
+      await writeCanonicalMemory(fixture.home, 'cross-process-read.md', content);
+
+      let initialCursor: string | undefined;
+      let initialText = '';
+      await withMcpClientForFixture(
+        fixture,
+        async client => {
+          const first = await client.callTool({arguments: {budgetTokens: 128, uri}, name: 'read_context'}, undefined, {
+            timeout: 30_000,
+          });
+          expect(first.isError, JSON.stringify(first)).not.toBe(true);
+          const structured = first.structuredContent as ReadPageStructuredContent | undefined;
+          initialCursor = structured?.cursor;
+          initialText = structured?.content ?? '';
+          expect(initialCursor).toMatch(/^tnrc_[0-9a-f]{32}$/u);
+        },
+        {toolset: 'core'},
+      );
+      if (!initialCursor) throw new TestError('First MCP process did not issue a continuation cursor.');
+
+      let raceCursor: string | undefined;
+      await withMcpClientForFixture(
+        fixture,
+        async client => {
+          const continued = await client.callTool(
+            {arguments: {budgetTokens: 128, cursor: initialCursor}, name: 'read_context'},
+            undefined,
+            {timeout: 30_000},
+          );
+          expect(continued.isError, JSON.stringify(continued)).not.toBe(true);
+          const structured = continued.structuredContent as ReadPageStructuredContent | undefined;
+          expect(structured?.content).not.toBe(initialText);
+          raceCursor = structured?.cursor;
+          expect(raceCursor).toMatch(/^tnrc_[0-9a-f]{32}$/u);
+        },
+        {toolset: 'core'},
+      );
+      if (!raceCursor) throw new TestError('Second MCP process did not issue a continuation cursor.');
+
+      const [left, right] = await Promise.all([
+        connectMcpClient(fixture, {toolset: 'core'}),
+        connectMcpClient(fixture, {toolset: 'core'}),
+      ]);
+      try {
+        const results = await Promise.all(
+          [left, right].map(client =>
+            client.callTool({arguments: {budgetTokens: 128, cursor: raceCursor}, name: 'read_context'}, undefined, {
+              timeout: 30_000,
+            }),
+          ),
+        );
+        const successful = results.filter(result => result.isError !== true);
+        const rejected = results.filter(result => result.isError === true);
+        expect(successful).toHaveLength(1);
+        expect(rejected).toHaveLength(1);
+        const rejectionContent = Array.isArray(rejected[0]?.content) ? rejected[0].content : [];
+        expect((rejectionContent[0] as TextContent | undefined)?.text).toContain('already consumed');
+      } finally {
+        await Promise.all([left.close().catch(() => undefined), right.close().catch(() => undefined)]);
+      }
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  }, 60_000);
+
   it('advances read_context across repeated pages of one resource and then later resources', async () => {
     await withMcpClient(
       async (client, fixture) => {
@@ -962,6 +1066,8 @@ describe('Threadnote MCP toolsets', () => {
         const firstContent = Array.isArray(first.content) ? first.content : [];
         expect((firstContent[1] as TextContent | undefined)?.text).toContain('Continue with read cursor');
 
+        const wrongTool = await client.callTool({arguments: {budgetTokens: 128, cursor}, name: 'read_context'});
+        expect(wrongTool.isError).toBe(true);
         const continued = await client.callTool({arguments: {budgetTokens: 128, cursor}, name: 'read'});
         expect(continued.isError, JSON.stringify(continued)).not.toBe(true);
       },

--- a/test/unit/memory-read-cursor-store.test.ts
+++ b/test/unit/memory-read-cursor-store.test.ts
@@ -1,0 +1,257 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {Database} from 'bun:sqlite';
+import {expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {
+  memoryReadCursorNamespace,
+  PersistentMemoryReadCursorStoreError,
+  putPersistentMemoryReadCursor,
+  takePersistentMemoryReadCursor,
+} from '../../src/memory_read_cursor_store.js';
+import {
+  MEMORY_READ_CURSOR_TTL_MILLISECONDS,
+  memoryReadCursorToken,
+  memoryReadSourceHashes,
+  type MemoryReadCursorState,
+} from '../../src/memory_read_projection.js';
+
+const CURSOR_DATABASE_RELATIVE_PATH = ['threadnote', 'mcp', 'read-context-cursors-v1.sqlite'] as const;
+
+effectIt.effect('persists private opaque cursors for exactly ten minutes across store instances', () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-memory-read-cursors-'});
+      const namespace = namespaceFor({});
+      const now = 10_000;
+      const usableCursor = memoryReadCursorToken('usable-private-cursor');
+      const expiredCursor = memoryReadCursorToken('expired-private-cursor');
+      const isolatedCursor = memoryReadCursorToken('namespace-private-cursor');
+      const state = stateFor('primary');
+
+      yield* putPersistentMemoryReadCursor(home, namespace, usableCursor, state, now);
+      yield* putPersistentMemoryReadCursor(home, namespace, expiredCursor, state, now);
+      yield* putPersistentMemoryReadCursor(home, namespace, isolatedCursor, state, now);
+
+      expect(
+        yield* takePersistentMemoryReadCursor(
+          home,
+          namespace,
+          usableCursor,
+          now + MEMORY_READ_CURSOR_TTL_MILLISECONDS - 1,
+        ),
+      ).toEqual(state);
+      expect(yield* takePersistentMemoryReadCursor(home, namespace, usableCursor, now)).toBeUndefined();
+
+      const otherNamespace = namespaceFor({user: 'other-user'});
+      expect(yield* takePersistentMemoryReadCursor(home, otherNamespace, isolatedCursor, now)).toBeUndefined();
+      expect(yield* takePersistentMemoryReadCursor(home, namespace, isolatedCursor, now)).toEqual(state);
+      expect(
+        yield* takePersistentMemoryReadCursor(
+          home,
+          namespace,
+          expiredCursor,
+          now + MEMORY_READ_CURSOR_TTL_MILLISECONDS,
+        ),
+      ).toBeUndefined();
+
+      expect(usableCursor).toMatch(/^tnrc_[0-9a-f]{32}$/u);
+      expect(usableCursor).not.toContain(state.uris[0]);
+      const databasePath = path.join(home, ...CURSOR_DATABASE_RELATIVE_PATH);
+      if (process.platform !== 'win32') {
+        expect((yield* fs.stat(path.dirname(databasePath))).mode & 0o777).toBe(0o700);
+        expect((yield* fs.stat(databasePath)).mode & 0o777).toBe(0o600);
+      }
+    }),
+  ).pipe(provideTestLayer(BunServices.layer)),
+);
+
+effectIt.effect('isolates every authority dimension and fails closed on collisions and corrupt state', () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-memory-read-cursor-corruption-'});
+      const namespaces = [
+        namespaceFor({}),
+        namespaceFor({account: 'other-account'}),
+        namespaceFor({memoryRoot: 'threadnote://shared/team/memories', team: 'team'}),
+        namespaceFor({toolName: 'read'}),
+        namespaceFor({user: 'other-user'}),
+      ];
+      expect([...new Set(namespaces)]).toHaveLength(namespaces.length);
+      expect(namespaces.every(namespace => /^[0-9a-f]{64}$/u.test(namespace))).toBe(true);
+
+      const state = stateFor('collision');
+      for (const options of [{ttlMilliseconds: MEMORY_READ_CURSOR_TTL_MILLISECONDS + 1}, {maximumEntries: 257}]) {
+        const rejectedBound = yield* putPersistentMemoryReadCursor(
+          home,
+          namespaces[0]!,
+          memoryReadCursorToken(JSON.stringify(options)),
+          state,
+          99,
+          options,
+        ).pipe(Effect.match({onFailure: error => error, onSuccess: () => undefined}));
+        expect(rejectedBound).toBeInstanceOf(PersistentMemoryReadCursorStoreError);
+      }
+      const collisionCursor = memoryReadCursorToken('collision');
+      yield* putPersistentMemoryReadCursor(home, namespaces[0]!, collisionCursor, state, 100);
+      const collision = yield* putPersistentMemoryReadCursor(
+        home,
+        namespaces[0]!,
+        collisionCursor,
+        stateFor('replacement-must-not-win'),
+        101,
+      ).pipe(Effect.match({onFailure: error => error, onSuccess: () => undefined}));
+      expect(collision).toBeInstanceOf(PersistentMemoryReadCursorStoreError);
+      expect(yield* takePersistentMemoryReadCursor(home, namespaces[0]!, collisionCursor, 102)).toEqual(state);
+
+      const corruptCursor = memoryReadCursorToken('corrupt');
+      yield* putPersistentMemoryReadCursor(home, namespaces[0]!, corruptCursor, state, 200);
+      const databasePath = path.join(home, ...CURSOR_DATABASE_RELATIVE_PATH);
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database
+            .query('UPDATE read_context_cursors SET state_json = ? WHERE namespace = ? AND token = ?')
+            .run('{"version":1}', namespaces[0]!, corruptCursor);
+        } finally {
+          database.close();
+        }
+      });
+      const corrupt = yield* takePersistentMemoryReadCursor(home, namespaces[0]!, corruptCursor, 201).pipe(
+        Effect.match({onFailure: error => error, onSuccess: () => undefined}),
+      );
+      expect(corrupt).toBeInstanceOf(PersistentMemoryReadCursorStoreError);
+      expect(yield* takePersistentMemoryReadCursor(home, namespaces[0]!, corruptCursor, 201)).toBeUndefined();
+    }),
+  ).pipe(provideTestLayer(BunServices.layer)),
+);
+
+effectIt.effect.prop(
+  'matches a bounded global single-use TTL model across namespace and time interleavings',
+  {
+    steps: FC.array(
+      FC.record({
+        advanceMilliseconds: FC.integer({max: 12, min: 0}),
+        putNamespace: FC.integer({max: 2, min: 0}),
+        takeNamespace: FC.integer({max: 2, min: 0}),
+        takeToken: FC.nat(40),
+      }),
+      {maxLength: 24, minLength: 1},
+    ),
+  },
+  ({steps}) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-memory-read-cursor-property-'});
+        const namespaces = [namespaceFor({}), namespaceFor({toolName: 'read'}), namespaceFor({user: 'other-user'})];
+        const capacity = 3;
+        const ttlMilliseconds = 20;
+        const model = new Map<
+          string,
+          {
+            readonly createdAt: number;
+            readonly expiresAt: number;
+            readonly namespace: string;
+            readonly state: MemoryReadCursorState;
+            readonly token: string;
+          }
+        >();
+        let now = 0;
+
+        for (const [index, step] of steps.entries()) {
+          now += step.advanceMilliseconds;
+          pruneModel(model, now);
+          const namespace = namespaces[step.putNamespace]!;
+          const token = memoryReadCursorToken(`property-${index}`);
+          const state = stateFor(`property-${index}`);
+          yield* putPersistentMemoryReadCursor(home, namespace, token, state, now, {
+            maximumEntries: capacity,
+            ttlMilliseconds,
+          });
+          const insertedKey = modelKey(namespace, token);
+          model.set(insertedKey, {createdAt: now, expiresAt: now + ttlMilliseconds, namespace, state, token});
+          evictModelToCapacity(model, capacity, insertedKey);
+
+          const targetIndex = step.takeToken % (index + 1);
+          const targetToken = memoryReadCursorToken(`property-${targetIndex}`);
+          const targetNamespace = namespaces[step.takeNamespace]!;
+          pruneModel(model, now);
+          const targetKey = modelKey(targetNamespace, targetToken);
+          const expected = model.get(targetKey)?.state;
+          model.delete(targetKey);
+          expect(yield* takePersistentMemoryReadCursor(home, targetNamespace, targetToken, now)).toEqual(expected);
+
+          const databasePath = path.join(home, ...CURSOR_DATABASE_RELATIVE_PATH);
+          const count = yield* Effect.sync(() => {
+            const database = new Database(databasePath, {readonly: true, strict: true});
+            try {
+              return Number(
+                database.query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM read_context_cursors').get()
+                  ?.count ?? 0,
+              );
+            } finally {
+              database.close();
+            }
+          });
+          expect(count).toBe(model.size);
+          expect(count).toBeLessThanOrEqual(capacity);
+        }
+      }),
+    ).pipe(provideTestLayer(BunServices.layer)),
+  {fastCheck: {numRuns: 30}},
+);
+
+function namespaceFor(override: Partial<Parameters<typeof memoryReadCursorNamespace>[0]>): string {
+  return memoryReadCursorNamespace({
+    account: 'local',
+    toolName: 'read_context',
+    user: 'test-user',
+    ...override,
+  });
+}
+
+function stateFor(identity: string): MemoryReadCursorState {
+  const resource = {text: `canonical ${identity}`, uri: `threadnote://test/${identity}.md`};
+  return {
+    mode: 'content',
+    position: {characterOffset: Math.min(3, resource.text.length), resourceIndex: 0},
+    sourceHashes: memoryReadSourceHashes([resource]),
+    uris: [resource.uri],
+  };
+}
+
+function modelKey(namespace: string, token: string): string {
+  return `${namespace}:${token}`;
+}
+
+function pruneModel<Entry extends {readonly expiresAt: number}>(model: Map<string, Entry>, now: number): void {
+  for (const [key, entry] of model) if (entry.expiresAt <= now) model.delete(key);
+}
+
+function evictModelToCapacity<
+  Entry extends {
+    readonly createdAt: number;
+    readonly expiresAt: number;
+    readonly namespace: string;
+    readonly token: string;
+  },
+>(model: Map<string, Entry>, capacity: number, insertedKey: string): void {
+  const excess = Math.max(0, model.size - capacity);
+  const victims = [...model.entries()]
+    .filter(([key]) => key !== insertedKey)
+    .sort(
+      (left, right) =>
+        left[1].createdAt - right[1].createdAt ||
+        left[1].expiresAt - right[1].expiresAt ||
+        left[1].token.localeCompare(right[1].token),
+    )
+    .slice(0, excess);
+  for (const [key] of victims) model.delete(key);
+}

--- a/test/unit/memory-read-projection.test.ts
+++ b/test/unit/memory-read-projection.test.ts
@@ -1,7 +1,6 @@
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {
-  MemoryReadCursorStore,
   memoryMarkdownOutline,
   memoryReadCursorToken,
   memoryReadPageEstimatedTokens,
@@ -185,7 +184,7 @@ describe('bounded memory read projection', () => {
     );
   });
 
-  it('uses opaque single-use cursors that expire and rejects changed sources', () => {
+  it('uses opaque cursor tokens and rejects changed sources', () => {
     const cursor = memoryReadCursorToken('private entropy and threadnote://secret/source.md');
     expect(cursor).toMatch(/^tnrc_[0-9a-f]{32}$/u);
     expect(cursor).not.toContain('secret');
@@ -197,13 +196,6 @@ describe('bounded memory read projection', () => {
       sourceHashes: memoryReadSourceHashes(resources),
       uris: resources.map(resource => resource.uri),
     };
-    const store = new MemoryReadCursorStore(10, 2);
-    store.put(cursor, state, 100);
-    expect(store.take(cursor, 109)).toEqual(state);
-    expect(store.take(cursor, 109)).toBeUndefined();
-
-    store.put(cursor, state, 200);
-    expect(store.take(cursor, 210)).toBeUndefined();
     expect(memoryReadSourcesMatch(resources, state.sourceHashes)).toBe(true);
     expect(memoryReadSourcesMatch([{...resources[0]!, text: 'changed'}], state.sourceHashes)).toBe(false);
   });


### PR DESCRIPTION
## Summary

- replace process-local read_context continuation state with a private Bun SQLite cursor store shared by MCP server processes
- retain opaque tnrc tokens while isolating state by tool, scope, account, and user
- enforce a hard ten-minute TTL, atomic single-use consumption, source-hash validation, and a globally bounded 256-entry / 256-KiB-per-state capacity
- fail closed on invalid identities, collisions, corrupt rows, permission failures, and storage failures

## Verification

- bun --bun vitest run test/unit/memory-read-cursor-store.test.ts test/unit/memory-read-projection.test.ts
- bun --bun vitest run test/integration/mcp.native-tools.test.ts -t "read_context|keeps compatibility-alias continuations"
- bun run lint
- bun run typecheck

The focused Effect-aware store suite includes a 30-run bounded Fast-check state-machine property against an independent TTL/capacity/namespace model. The integration regression issues a cursor in one real MCP child process, continues it in a second process, then races two separate MCP processes and verifies exactly one consumes the next cursor.

## Runtime note

A global development install is intentionally deferred while the exact-HEAD graph benchmark owns the shared runtime lease.