### PR TITLE
fix(cli): document workset query paging bounds

### DIFF
--- a/src/code_graph/workset_evidence.ts
+++ b/src/code_graph/workset_evidence.ts
@@ -11,6 +11,7 @@ import type {CodeGraphProvenance, CodeGraphRelation, CodeGraphSpan} from './type
 export const CODE_GRAPH_WORKSET_EVIDENCE_RESULT_VERSION = 2 as const;
 export const CODE_GRAPH_WORKSET_EVIDENCE_PROJECTOR_VERSION = 1 as const;
 export const CODE_GRAPH_WORKSET_EVIDENCE_DEFAULT_ESTIMATED_TOKENS = 1_250 as const;
+export const CODE_GRAPH_WORKSET_EVIDENCE_MINIMUM_ESTIMATED_TOKENS = 1 as const;
 export const CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS = 1_500 as const;
 
 export const CODE_GRAPH_WORKSET_EVIDENCE_REPOSITORY_STATES = [
@@ -778,9 +779,13 @@ function relationshipKey(relationship: CompactEvidenceRelationshipV1): string {
 
 function projectionMaximumBytes(options: CodeGraphWorksetEvidenceProjectionOptionsV1): number {
   const tokens = options.maximumEstimatedTokens ?? CODE_GRAPH_WORKSET_EVIDENCE_DEFAULT_ESTIMATED_TOKENS;
-  if (!Number.isSafeInteger(tokens) || tokens < 1 || tokens > CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS) {
+  if (
+    !Number.isSafeInteger(tokens) ||
+    tokens < CODE_GRAPH_WORKSET_EVIDENCE_MINIMUM_ESTIMATED_TOKENS ||
+    tokens > CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS
+  ) {
     throw invalid(
-      `Workset evidence token budget must be an integer from 1 to ${CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS}.`,
+      `Workset evidence token budget must be an integer from ${CODE_GRAPH_WORKSET_EVIDENCE_MINIMUM_ESTIMATED_TOKENS} to ${CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS}.`,
     );
   }
   const tokenBytes = tokens * AGENT_RESPONSE_ESTIMATED_BYTES_PER_TOKEN;

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -109,6 +109,10 @@ import {
   runCodeGraphWorksetStatus,
   runCodeGraphWorksetTopology,
 } from '../code_graph/commands.js';
+import {
+  CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS,
+  CODE_GRAPH_WORKSET_EVIDENCE_MINIMUM_ESTIMATED_TOKENS,
+} from '../code_graph/workset_evidence.js';
 import {runProcessDiagnostics} from '../process_diagnostics.js';
 import {runContextBrief} from '../context_brief/commands.js';
 import {runTelemetryDisable, runTelemetryEnable, runTelemetryStatus} from '../telemetry/commands.js';
@@ -724,12 +728,19 @@ const graphQuery = Command.make(
     budgetTokens: optional(
       describeFlag(
         integerFlag('budget-tokens').pipe(
-          Flag.withSchema(Schema.Int.check(Schema.isBetween({minimum: 1, maximum: 1_500}))),
+          Flag.withSchema(
+            Schema.Int.check(
+              Schema.isBetween({
+                minimum: CODE_GRAPH_WORKSET_EVIDENCE_MINIMUM_ESTIMATED_TOKENS,
+                maximum: CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS,
+              }),
+            ),
+          ),
         ),
-        'Maximum estimated tokens for the compact workset agent response',
+        `Requires --workset; maximum estimated tokens (${CODE_GRAPH_WORKSET_EVIDENCE_MINIMUM_ESTIMATED_TOKENS}-${CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS}) for the compact agent response`,
       ),
     ),
-    cursor: optionalString('cursor', 'Opaque cgwc_ continuation from a prior workset query'),
+    cursor: optionalString('cursor', 'Requires --workset; opaque cgwc_ continuation from a prior query'),
     packageName: optionalString('package', 'Restrict results to one exact indexed package or workspace component'),
     query: optionalString('query', 'Concept, symbol, module, path, or documentation query'),
     workset: optionalString(

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -167,6 +167,13 @@ describe('Effect CLI', () => {
     expect(repair.stdout).toContain('--dry-run');
   });
 
+  it('documents graph query paging scope and token bounds before execution', async () => {
+    const query = await runCli(['graph', 'query', '--help']);
+
+    expect(query.stdout).toContain('Requires --workset; maximum estimated tokens (1-1500)');
+    expect(query.stdout).toContain('Requires --workset; opaque cgwc_ continuation from a prior query');
+  });
+
   it('emits a path-free aggregate graph inventory preview', async () => {
     const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-inventory-'));
     try {


### PR DESCRIPTION
## Summary

- document that `graph query --budget-tokens` and `--cursor` require `--workset`
- show the accepted `--budget-tokens` range (`1-1500`) in command help
- derive the CLI schema and displayed range from the workset evidence bounds
- add focused CLI help regression coverage

## Verification

- `THREADNOTE_HOME=/private/tmp/threadnote-graph-query-help-home bun src/standalone.ts graph query --help`
- `bun --bun vitest run test/integration/cli.effect.test.ts test/unit/code-graph.workset-evidence.test.ts` (37 passed)
- `bun --bun prettier --check src/code_graph/workset_evidence.ts src/effect/cli.ts test/integration/cli.effect.test.ts`
- targeted strict oxlint for the three changed files
- `bun --bun tsc --noEmit`
- `bun --bun tsc -p test/tsconfig.json --noEmit`

A global development install was intentionally not run: the active performance benchmark owns the global runtime, and this patch changes CLI help/contract copy only.

## Property testing

No new property test was added because this is static help copy with no meaningful input space; existing projection tests continue to exercise the shared numeric contract.
