### PR TITLE
chore(release): prepare 4.3.3

### DIFF
--- a/.github/release-notes/v4.3.3.md
+++ b/.github/release-notes/v4.3.3.md
@@ -1,0 +1,39 @@
+## What's new
+
+Threadnote 4.3.3 makes code-graph indexing substantially faster and more predictable on large repositories, while
+fixing cross-process `read_context` paging and tightening standalone process cleanup.
+
+### Faster large-repository graphs
+
+- Cold graph builds now materialize through a bounded, resumable sorted spool, reducing database write amplification
+  while preserving deterministic graph content and interruption safety.
+- Compiled Tree-sitter queries are reused, parser work is scheduled in wider bounded windows, and large repositories
+  reuse a private validated Git-status cache without changing the repository's real Git index or configuration.
+- Reference-resolution and SQLite work are batched adaptively: ordinary graphs retain conservative transactions while
+  larger reference sets can use wider bounded batches.
+- New stores use 8 KiB SQLite pages, defer cold-only query indexes until the graph is ready, and bulk-build those
+  indexes after materialization.
+
+### Proportional incremental indexing
+
+- Safe body-only edits reuse persisted inventory and load only the changed files' base facts.
+- Export, re-export, and other resolution-surface edits rebuild a bounded dependency-aware project closure instead of
+  automatically replaying the full repository.
+- Additions, deletions, ambiguous attribution, malformed cache evidence, or an oversized dependency closure still
+  fail closed to a complete rebuild.
+
+### More reliable agent and installer behavior
+
+- Concurrent cold graph builds can no longer expose a partially restored query-index schema to another worktree.
+- `read_context` continuation cursors now persist across MCP processes, remain single-use, expire after ten minutes,
+  and are isolated by tool, scope, account, and user.
+- `threadnote graph query --help` now states that paging and token budgets require a named Workset and shows the
+  accepted budget range.
+- Development and standalone cleanup now retires stale MCP broker children when superseded Threadnote processes are
+  terminated.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone version to 4.3.3
- add curated release notes covering graph indexing, proportional incremental work, cross-process paging, graph help, and process cleanup

## Focused verification

- `bun run test:smoke:release`
- `bun --bun vitest run test/unit/website-release-boundary.test.ts`
- `bun --bun prettier --check package.json .github/release-notes/v4.3.3.md`
- pre-commit lint, formatting, and typecheck

After merge, the exact merged commit will be tagged and pushed immediately as `v4.3.3`. The single pinned IntelliJ benchmark remains manual exact-tag website evidence and is not a CI ratchet.