### PR TITLE
test(benchmark): synchronize live process fixture

### DIFF
--- a/test/unit/code-graph.benchmark-sampler.test.ts
+++ b/test/unit/code-graph.benchmark-sampler.test.ts
@@ -562,6 +562,9 @@ describe('code graph benchmark sampler artifact', () => {
     'captures a live recursive process tree without command metadata',
     async () => {
       const root = await mkdtemp(join(tmpdir(), 'threadnote-benchmark-process-tree-'));
+      const parentReady = join(root, 'parent-ready');
+      const parentStop = join(root, 'parent-stop');
+      let parent: ReturnType<typeof Bun.spawn> | undefined;
       try {
         const phase = join(root, 'phase');
         const output = join(root, 'output.json');
@@ -569,16 +572,18 @@ describe('code graph benchmark sampler artifact', () => {
         const ready = join(root, 'ready.json');
         const stop = join(root, 'stop');
         await writeFile(phase, 'scanning');
-        const parent = Bun.spawn({
-          cmd: [
-            process.execPath,
-            '-e',
-            "const child=Bun.spawn([process.execPath,'-e','await Bun.sleep(500)']); await child.exited;",
-          ],
+        const childProgram = `while (!(await Bun.file(${JSON.stringify(parentStop)}).exists())) await Bun.sleep(10);`;
+        const parentProgram = [
+          `const child=Bun.spawn([process.execPath,'-e',${JSON.stringify(childProgram)}]);`,
+          `await Bun.write(${JSON.stringify(parentReady)},'ready');`,
+          'await child.exited;',
+        ].join('');
+        parent = Bun.spawn({
+          cmd: [process.execPath, '-e', parentProgram],
           stderr: 'ignore',
           stdout: 'ignore',
         });
-        await Bun.sleep(50);
+        await waitForText(parentReady, 5_000);
         const sampler = Bun.spawn({
           cmd: [
             process.execPath,
@@ -607,7 +612,7 @@ describe('code graph benchmark sampler artifact', () => {
           stderr: 'pipe',
           stdout: 'ignore',
         });
-        await waitForText(ready);
+        await waitForText(ready, 5_000);
         await writeFile(stop, 'complete');
         expect(await sampler.exited).toBe(0);
         const artifact = parseCodeGraphBenchmarkSamplerArtifact(JSON.parse(await readFile(output, 'utf8')));
@@ -625,12 +630,15 @@ describe('code graph benchmark sampler artifact', () => {
           Object.values(artifact.phases).reduce((total, sample) => total + (sample.processSampleFailures ?? 0), 0),
         ).toBe(0);
         expect(JSON.stringify(artifact)).not.toContain('command');
+        await writeFile(parentStop, 'complete');
         await parent.exited;
       } finally {
+        await writeFile(parentStop, 'complete').catch(() => undefined);
+        if (parent) await parent.exited;
         await rm(root, {force: true, recursive: true});
       }
     },
-    2_000,
+    10_000,
   );
 
   it.skipIf(!['darwin', 'linux'].includes(process.platform))(

--- a/test/unit/code-graph.benchmark-sampler.test.ts
+++ b/test/unit/code-graph.benchmark-sampler.test.ts
@@ -564,13 +564,14 @@ describe('code graph benchmark sampler artifact', () => {
       const root = await mkdtemp(join(tmpdir(), 'threadnote-benchmark-process-tree-'));
       const parentReady = join(root, 'parent-ready');
       const parentStop = join(root, 'parent-stop');
+      const samplerStop = join(root, 'sampler-stop');
       let parent: ReturnType<typeof Bun.spawn> | undefined;
+      let sampler: ReturnType<typeof Bun.spawn> | undefined;
       try {
         const phase = join(root, 'phase');
         const output = join(root, 'output.json');
         const checkpoint = join(root, 'checkpoint.json');
         const ready = join(root, 'ready.json');
-        const stop = join(root, 'stop');
         await writeFile(phase, 'scanning');
         const childProgram = `while (!(await Bun.file(${JSON.stringify(parentStop)}).exists())) await Bun.sleep(10);`;
         const parentProgram = [
@@ -584,7 +585,7 @@ describe('code graph benchmark sampler artifact', () => {
           stdout: 'ignore',
         });
         await waitForText(parentReady, 5_000);
-        const sampler = Bun.spawn({
+        sampler = Bun.spawn({
           cmd: [
             process.execPath,
             fileURLToPath(new URL('../../scripts/code-graph-benchmark-sampler.ts', import.meta.url)),
@@ -597,7 +598,7 @@ describe('code graph benchmark sampler artifact', () => {
             '--phase',
             phase,
             '--stop',
-            stop,
+            samplerStop,
             '--output',
             output,
             '--checkpoint-output',
@@ -613,7 +614,7 @@ describe('code graph benchmark sampler artifact', () => {
           stdout: 'ignore',
         });
         await waitForText(ready, 5_000);
-        await writeFile(stop, 'complete');
+        await writeFile(samplerStop, 'complete');
         expect(await sampler.exited).toBe(0);
         const artifact = parseCodeGraphBenchmarkSamplerArtifact(JSON.parse(await readFile(output, 'utf8')));
         expect(artifact.processTelemetry).toMatchObject({
@@ -633,6 +634,8 @@ describe('code graph benchmark sampler artifact', () => {
         await writeFile(parentStop, 'complete');
         await parent.exited;
       } finally {
+        await writeFile(samplerStop, 'complete').catch(() => undefined);
+        if (sampler) await sampler.exited;
         await writeFile(parentStop, 'complete').catch(() => undefined);
         if (parent) await parent.exited;
         await rm(root, {force: true, recursive: true});


### PR DESCRIPTION
## Summary

- keep the live parent/child fixture alive until the test explicitly releases it
- publish a fixture-ready marker after the child is spawned instead of assuming 50 ms is enough
- clean up the fixture in `finally` and raise only the slow-runner timeout ceiling

## Diagnosis

The failing CI run expected recursive process telemetry but received the sampler's valid `parent-inspection-unavailable` result. The fixture's child lived for only 500 ms, while a focused local invocation already takes roughly that long end to end. On a loaded hosted runner, the parent/child tree can exit before the sampler's initial `/proc` inspection.

The replacement uses ready/stop files, so fixture lifetime is determined by test state rather than scheduler timing.

Failure evidence: https://github.com/Kashkovsky/threadnote/actions/runs/32800270401

## Verification

- `bun --bun vitest run test/unit/code-graph.benchmark-sampler.test.ts` (47/47)
- live-process example repeated 25 times (25/25)
- strict oxlint on the changed test
- Prettier check on the changed test
- `bun --bun tsc -p test/tsconfig.json --noEmit`

No property test was added: this is a single operating-system process synchronization boundary with no meaningful generated input model; the deterministic ready/stop regression example directly covers the defect.
