### PR TITLE
fix(code-graph): close cold-index claim race

### DIFF
--- a/src/code_graph/store_persistent_build.ts
+++ b/src/code_graph/store_persistent_build.ts
@@ -114,22 +114,29 @@ const claimPersistentSnapshotBuild = Effect.fn('codeGraph.claimPersistentSnapsho
     yield* pruneRetiredSnapshotRows(runWrite, snapshot.id);
   }
   yield* runWrite(
-    sql.withTransaction(
-      Effect.gen(function* () {
-        yield* upsertRepository(sql, identity);
-        const existing = yield* sql<SnapshotRow>`SELECT * FROM snapshots WHERE id = ${snapshot.id} LIMIT 1`;
-        if (existing[0]) {
-          const current = snapshotFromRow(existing[0]);
-          if (
-            !persistentSnapshotBuildIdentityMatches(current, snapshot) ||
-            !['building', 'failed'].includes(current.state)
-          ) {
-            return yield* Effect.fail(
-              new CodeGraphStoreError('Persistent build claim does not match the existing snapshot identity.'),
-            );
-          }
-        } else {
-          yield* sql`
+    Effect.gen(function* () {
+      // Revalidate the schema in the same checkout-writer critical section
+      // that publishes this build. A cold build may defer global query indexes
+      // after this claim's initial schema check but before its snapshot row is
+      // visible; publishing without this second check leaves the new build able
+      // to reach endpoint validation while those indexes are absent.
+      yield* initializeSchema(sql);
+      yield* sql.withTransaction(
+        Effect.gen(function* () {
+          yield* upsertRepository(sql, identity);
+          const existing = yield* sql<SnapshotRow>`SELECT * FROM snapshots WHERE id = ${snapshot.id} LIMIT 1`;
+          if (existing[0]) {
+            const current = snapshotFromRow(existing[0]);
+            if (
+              !persistentSnapshotBuildIdentityMatches(current, snapshot) ||
+              !['building', 'failed'].includes(current.state)
+            ) {
+              return yield* Effect.fail(
+                new CodeGraphStoreError('Persistent build claim does not match the existing snapshot identity.'),
+              );
+            }
+          } else {
+            yield* sql`
           INSERT INTO snapshots (
             id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id, extractor_set,
             dirty, overlay_fingerprint, state, file_count, symbol_count, edge_count, started_at
@@ -140,15 +147,15 @@ const claimPersistentSnapshotBuild = Effect.fn('codeGraph.claimPersistentSnapsho
             ${snapshot.overlayFingerprint ?? null}, 'building', 0, 0, 0, ${new Date().toISOString()}
           )
         `;
-        }
-        yield* sql`
+          }
+          yield* sql`
           INSERT INTO snapshot_build_owners (snapshot_id, owner_token, claimed_at)
           VALUES (${snapshot.id}, ${ownerToken}, ${new Date().toISOString()})
           ON CONFLICT(snapshot_id) DO UPDATE SET
             owner_token = excluded.owner_token,
             claimed_at = excluded.claimed_at
         `;
-        yield* sql`
+          yield* sql`
           INSERT INTO snapshot_build_owner_instances (
             snapshot_id, owner_token, build_id, process_id, process_start_identity, logical_snapshot_id
           ) VALUES (
@@ -162,8 +169,9 @@ const claimPersistentSnapshotBuild = Effect.fn('codeGraph.claimPersistentSnapsho
             process_start_identity = excluded.process_start_identity,
             logical_snapshot_id = excluded.logical_snapshot_id
         `;
-      }),
-    ),
+        }),
+      );
+    }),
   );
 });
 

--- a/test/unit/code-graph.cold-index-deferral.test.ts
+++ b/test/unit/code-graph.cold-index-deferral.test.ts
@@ -8,8 +8,12 @@ import {
   type CodeGraphDirectPersistentCapacityBoundary,
 } from '../../src/code_graph/disk_capacity.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
-import {codeGraphColdIndexDeferralEligible} from '../../src/code_graph/store_cold_index_deferral.js';
+import {
+  codeGraphColdIndexDeferralEligible,
+  deferCodeGraphQueryIndexesForColdBuild,
+} from '../../src/code_graph/store_cold_index_deferral.js';
 import type {CodeGraphDirectPersistentCapacityProtector} from '../../src/code_graph/store_models.js';
+import {claimPersistentSnapshotBuild} from '../../src/code_graph/store_persistent_build.js';
 import {
   CODE_GRAPH_QUERY_INDEX_DEFINITIONS,
   inspectCodeGraphQueryIndexes,
@@ -191,6 +195,76 @@ describe('code graph cold query-index deferral', () => {
           fixture.databasePath,
           Effect.gen(function* () {
             const sql = yield* SqlClient.SqlClient;
+            expect((yield* inspectCodeGraphQueryIndexes(sql)).missing).toEqual([]);
+            expect(yield* codeGraphSchemaInitializationReceiptCurrent(sql)).toBe(true);
+          }),
+          {writerLockPath: fixture.writerLockPath},
+        );
+      }).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
+
+  effectIt.effect('revalidates indexes atomically when a claim races cold deferral', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* coldIndexFixture('claim-race');
+        const store = yield* CodeGraphStore;
+        yield* store.withSession(
+          fixture.databasePath,
+          Effect.gen(function* () {
+            yield* store.initialize(fixture.databasePath);
+            const firstOwnerToken = yield* claimPersistentBuildForTest(
+              store,
+              fixture.databasePath,
+              fixture.identity,
+              fixture.snapshot,
+            );
+            // A known batch count keeps the first build's preparation eager so
+            // the test can place deferral exactly inside the second claim.
+            yield* store.prepareActivation(
+              fixture.databasePath,
+              [fixture.file],
+              fixture.snapshot.id,
+              1,
+              firstOwnerToken,
+            );
+
+            const sql = yield* SqlClient.SqlClient;
+            const secondIdentity = {...fixture.identity, worktreeId: 'v'.repeat(64)};
+            const secondSnapshot = {
+              ...fixture.snapshot,
+              id: 'claim-race-second-snapshot',
+              worktreeId: secondIdentity.worktreeId,
+            };
+            let writerAcquisitions = 0;
+            let deferredBetweenSchemaCheckAndPublication = false;
+            const writerGate = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+              Effect.suspend(() => {
+                writerAcquisitions += 1;
+                if (writerAcquisitions !== 3) return effect;
+                return deferCodeGraphQueryIndexesForColdBuild(sql, fixture.snapshot.id, firstOwnerToken).pipe(
+                  Effect.tap(deferred =>
+                    Effect.sync(() => {
+                      deferredBetweenSchemaCheckAndPublication = deferred;
+                    }),
+                  ),
+                  Effect.andThen(effect),
+                );
+              });
+
+            yield* claimPersistentSnapshotBuild(
+              secondIdentity,
+              secondSnapshot,
+              'claim-race-owner-token',
+              {
+                logicalSnapshotId: `cgsn_${'0'.repeat(40)}`,
+                owner: {buildId: '11111111-1111-1111', processId: process.pid},
+              },
+              writerGate,
+            );
+
+            expect(writerAcquisitions).toBe(3);
+            expect(deferredBetweenSchemaCheckAndPublication).toBe(true);
             expect((yield* inspectCodeGraphQueryIndexes(sql)).missing).toEqual([]);
             expect(yield* codeGraphSchemaInitializationReceiptCurrent(sql)).toBe(true);
           }),


### PR DESCRIPTION
## Summary

- revalidate the code-graph schema inside the checkout-writer critical section that publishes a persistent build claim
- prevent a cold build from dropping global query indexes between another claim's initial schema check and snapshot-row publication
- add a deterministic Effect regression that forces that exact interleaving and verifies the full query-index set and schema receipt are restored before the second claim becomes usable

## Root cause

A new persistent claim previously checked/initialized the schema under one writer-gate acquisition, released the gate, and published its `building` snapshot in a later acquisition. A concurrent cold build could prove that no other snapshot was visible and drop all query indexes in that gap. The second claim would then become visible and reach endpoint validation, whose explicit `INDEXED BY edges_source` / `edges_target_resolved` contract failed with `no such index: edges_source`.

The fix keeps the expensive cold-build materialization and per-index restoration boundaries unchanged. It only repeats the normally receipt-fast schema validation in the same critical section as claim publication, which creates a two-order invariant: either the claim is visible and cold deferral is refused, or deferral wins and the claim restores the indexes before publishing itself.

## Evidence

- Linux pre-fix reproduction: repeated linked-worktree isolation failed with native SQLite `no such index: edges_source` (including iterations 8 and 25); the earlier restoration-only attempt still failed at iteration 6
- Linux post-fix: deterministic claim-race regression passed and 36 consecutive linked-worktree isolation runs passed
- `bun --bun vitest run test/unit/code-graph.cold-index-deferral.test.ts` (5/5)
- exact v4.3.3 package-version verification of both release failure surfaces: `code-graph.performance-evidence.test.ts` + `code-graph.benchmark-preflight.test.ts` (13/13)
- `bun run typecheck`
- focused strict oxlint + formatting; commit hook also ran repository lint, formatting, and typecheck

## Property testing

No new property was added: the defect is a specific temporal interleaving, so a deterministic writer-gate schedule is the stronger regression. The adjacent cold-deferral admission predicate already has a bounded Fast-check property.