### PR TITLE
perf(code-graph): retain private Git status acceleration

### DIFF
--- a/src/code_graph/git_status_cache.ts
+++ b/src/code_graph/git_status_cache.ts
@@ -191,11 +191,7 @@ function initializePrivateIndex(
       ['-c', 'core.untrackedCache=true', '-C', identity.repoRoot, 'update-index', '--untracked-cache'],
       {maxOutputBytes: 16_384, timeoutMs: 30_000, trustedGitIndexFile: privateIndex},
     );
-    yield* runCommandEffect(
-      'git',
-      ['-c', 'core.fsmonitor=true', '-C', identity.repoRoot, 'fsmonitor--daemon', 'start'],
-      {maxOutputBytes: 16_384, timeoutMs: 30_000},
-    );
+    yield* ensureFsmonitorDaemon(identity);
     yield* runCommandEffect(
       'git',
       ['-c', 'core.fsmonitor=true', '-C', identity.repoRoot, 'update-index', '--fsmonitor'],
@@ -209,6 +205,26 @@ function initializePrivateIndex(
     ),
   );
 }
+
+const fsmonitorDaemon = (identity: RepositoryIdentity, operation: 'start' | 'status') =>
+  runCommandEffect('git', ['-c', 'core.fsmonitor=true', '-C', identity.repoRoot, 'fsmonitor--daemon', operation], {
+    allowFailure: true,
+    maxOutputBytes: 16_384,
+    timeoutMs: 30_000,
+  });
+
+const ensureFsmonitorDaemon = Effect.fn('codeGraph.ensureFsmonitorDaemon')(function* (identity: RepositoryIdentity) {
+  const observed = yield* fsmonitorDaemon(identity, 'status');
+  if (observed.exitCode === 0) return;
+  // Another process may start the repository daemon after the failed status
+  // observation. Git 2.39 reports that idempotent `start` race as exit 128, so
+  // stderr text is not a stable contract: re-observe the daemon instead.
+  yield* fsmonitorDaemon(identity, 'start');
+  const verified = yield* fsmonitorDaemon(identity, 'status');
+  if (verified.exitCode !== 0) {
+    return yield* Effect.fail(new CodeGraphGitStatusCacheUnavailable('Git fsmonitor daemon is unavailable.'));
+  }
+});
 
 function ensurePrivateCacheDirectory(
   fs: FileSystem.FileSystem,

--- a/test/integration/code-graph.git-status-cache.test.ts
+++ b/test/integration/code-graph.git-status-cache.test.ts
@@ -46,15 +46,20 @@ describe('code graph private Git status cache', () => {
 
       expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
       expect(calls.filter(call => call.args.includes('update-index'))).toHaveLength(2);
+      expect(fsmonitorOperations(calls, 'status')).toHaveLength(1);
+      expect(fsmonitorOperations(calls, 'start')).toHaveLength(0);
       assertPrivateStatusCall(calls.at(-1), home);
 
       expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
       expect(calls.filter(call => call.args.includes('update-index'))).toHaveLength(2);
+      expect(fsmonitorOperations(calls, 'status')).toHaveLength(1);
       assertPrivateStatusCall(calls.at(-1), home);
 
       writeFileSync(sourceIndex, 'source-index-v2');
       expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
       expect(calls.filter(call => call.args.includes('update-index'))).toHaveLength(4);
+      expect(fsmonitorOperations(calls, 'status')).toHaveLength(2);
+      expect(fsmonitorOperations(calls, 'start')).toHaveLength(0);
       assertPrivateStatusCall(calls.at(-1), home);
       expect(calls.every(call => !call.args.includes('--no-optional-locks') || call.args.includes('rev-parse'))).toBe(
         true,
@@ -107,7 +112,110 @@ describe('code graph private Git status cache', () => {
       provideTestLayer(ApplicationLayer),
     );
   });
+
+  it.effect('accepts a concurrent fsmonitor start after verifying the final daemon state', () => {
+    let root: string | undefined;
+    return Effect.gen(function* () {
+      root = mkdtempSync(join(tmpdir(), 'threadnote-git-status-fsmonitor-race-'));
+      const repository = join(root, 'repository');
+      const gitDirectory = join(repository, '.git');
+      const sourceIndex = join(gitDirectory, 'index');
+      const home = join(root, 'home');
+      mkdirSync(gitDirectory, {recursive: true});
+      mkdirSync(home, {recursive: true});
+      writeFileSync(sourceIndex, 'source-index-v1');
+      const calls: Array<{args: readonly string[]; options?: CommandOptions}> = [];
+      let fsmonitorStatusCalls = 0;
+      const base = yield* CommandExecutor;
+      const command = CommandExecutor.of({
+        ...base,
+        execute: (executable, args, options) => {
+          expect(executable).toBe('git');
+          calls.push({args, options});
+          if (args.includes('rev-parse')) return Effect.succeed(result(`${sourceIndex}\n`));
+          if (args.includes('update-index')) return Effect.succeed(result(''));
+          if (args.includes('fsmonitor--daemon') && args.includes('status')) {
+            fsmonitorStatusCalls += 1;
+            return Effect.succeed(result('', fsmonitorStatusCalls === 1 ? 1 : 0));
+          }
+          if (args.includes('fsmonitor--daemon') && args.includes('start')) {
+            return Effect.succeed(result('', 128));
+          }
+          if (args.includes('status')) return Effect.succeed(result(' M src/index.ts\0'));
+          return Effect.fail(commandFailure(args));
+        },
+      });
+      const observe = () =>
+        worktreeStatusWithPrivateCache(repositoryIdentity(repository), home, STATUS_ARGUMENTS, {
+          minimumIndexBytes: 1,
+        }).pipe(Effect.provideService(CommandExecutor, command));
+
+      expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
+      expect(fsmonitorOperations(calls, 'status')).toHaveLength(2);
+      expect(fsmonitorOperations(calls, 'start')).toHaveLength(1);
+      expect(calls.filter(call => call.args.includes('--no-optional-locks') && call.args.includes('status'))).toEqual(
+        [],
+      );
+
+      expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
+      expect(fsmonitorOperations(calls, 'status')).toHaveLength(2);
+      expect(fsmonitorOperations(calls, 'start')).toHaveLength(1);
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
+      ),
+      provideTestLayer(ApplicationLayer),
+    );
+  });
+
+  it.effect('falls back when fsmonitor remains unavailable after the start attempt', () => {
+    let root: string | undefined;
+    return Effect.gen(function* () {
+      root = mkdtempSync(join(tmpdir(), 'threadnote-git-status-fsmonitor-unavailable-'));
+      const repository = join(root, 'repository');
+      const gitDirectory = join(repository, '.git');
+      const sourceIndex = join(gitDirectory, 'index');
+      const home = join(root, 'home');
+      mkdirSync(gitDirectory, {recursive: true});
+      mkdirSync(home, {recursive: true});
+      writeFileSync(sourceIndex, 'source-index-v1');
+      const calls: Array<{args: readonly string[]; options?: CommandOptions}> = [];
+      const base = yield* CommandExecutor;
+      const command = CommandExecutor.of({
+        ...base,
+        execute: (executable, args, options) => {
+          expect(executable).toBe('git');
+          calls.push({args, options});
+          if (args.includes('rev-parse')) return Effect.succeed(result(`${sourceIndex}\n`));
+          if (args.includes('update-index')) return Effect.succeed(result(''));
+          if (args.includes('fsmonitor--daemon')) return Effect.succeed(result('', 1));
+          if (args.includes('status')) return Effect.succeed(result('?? src/new.ts\0'));
+          return Effect.fail(commandFailure(args));
+        },
+      });
+
+      const observed = yield* worktreeStatusWithPrivateCache(repositoryIdentity(repository), home, STATUS_ARGUMENTS, {
+        minimumIndexBytes: 1,
+      }).pipe(Effect.provideService(CommandExecutor, command));
+
+      expect(observed.stdout).toBe('?? src/new.ts\0');
+      expect(fsmonitorOperations(calls, 'status')).toHaveLength(2);
+      expect(fsmonitorOperations(calls, 'start')).toHaveLength(1);
+      const fallback = calls.at(-1);
+      expect(fallback?.args.slice(0, 3)).toEqual(['--no-optional-locks', '-C', repository]);
+      expect(fallback?.options?.trustedGitIndexFile).toBeUndefined();
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),
+      ),
+      provideTestLayer(ApplicationLayer),
+    );
+  });
 });
+
+function fsmonitorOperations(calls: ReadonlyArray<{readonly args: readonly string[]}>, operation: 'start' | 'status') {
+  return calls.filter(call => call.args.includes('fsmonitor--daemon') && call.args.includes(operation));
+}
 
 function assertPrivateStatusCall(
   call: {args: readonly string[]; options?: CommandOptions} | undefined,
@@ -133,8 +241,8 @@ function repositoryIdentity(repoRoot: string): RepositoryIdentity {
   };
 }
 
-function result(stdout: string) {
-  return {exitCode: 0, stderr: '', stdout};
+function result(stdout: string, exitCode = 0) {
+  return {exitCode, stderr: '', stdout};
 }
 
 function commandFailure(args: readonly string[]) {


### PR DESCRIPTION
## Summary

- keep the private Git status accelerator when the repository fsmonitor daemon is already running
- observe daemon status before starting it, then verify final state after a concurrent/idempotent start race
- retain the read-only plain-status fallback when fsmonitor is genuinely unavailable

## Why

The exact v4.3.3 IntelliJ benchmark left registration at 9.366s. Profiling showed repeated full Git status calls at roughly 3.4s each. On Git 2.39, fsmonitor--daemon start exits 128 if another daemon already owns the repository, so cache initialization discarded an otherwise valid private index and never wrote its receipt.

## Evidence

On the pinned IntelliJ checkout with a 45.9MB Git index, a fresh exact-HEAD cache wrote its receipt successfully. The next build-request observation took 108ms and the direct cached status path took 107ms, versus roughly 3.4s for the repeated fallback before this fix.

Focused Effect/Vitest coverage proves:

- an already-running daemon skips start
- a concurrent start race accepts exit 128 only after final status succeeds
- genuinely unavailable fsmonitor falls back to read-only plain status
- receipts reuse and refresh only the private index

Checks passed: focused integration tests (4/4), lint, Prettier, file-length policy, and TypeScript checks. The deterministic reduced performance benchmark and PR CI are the authoritative broader gates.

A property test was not added: this is a finite external-command handshake, and explicit status/start/final-status examples provide a clearer independent contract.

Advances #203. Keep the issue open until an exact merged-HEAD pinned IntelliJ run proves registration below five seconds.