### PR TITLE
perf(code-graph): reuse semantically stable Git index cache

### DIFF
--- a/src/code_graph/git_status_cache.ts
+++ b/src/code_graph/git_status_cache.ts
@@ -1,15 +1,18 @@
 import {Effect, FileSystem, Option, Path} from 'effect';
-import {runCommandEffect} from '../effect/command.js';
+import {sha256HexSync} from '../crypto/sha256.js';
+import {runBinaryCommandEffect, runCommandEffect} from '../effect/command.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
 import type {RepositoryIdentity} from './types.js';
 
-export const CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION = 1 as const;
+export const CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION = 2 as const;
 // Avoid a persistent Git monitor and private-index setup for repositories
 // whose ordinary status scan is already cheaper than cache initialization.
 export const CODE_GRAPH_GIT_STATUS_CACHE_INDEX_BYTES_MINIMUM = 8 * 1_048_576;
 export const CODE_GRAPH_GIT_STATUS_CACHE_INDEX_BYTES_MAXIMUM = 512 * 1_048_576;
 
 const RECEIPT_BYTES_MAXIMUM = 1_024;
+const SEMANTIC_INDEX_OUTPUT_BYTES_MAXIMUM = 128 * 1_048_576;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const STATUS_CACHE_LOCK_OPTIONS = {
   retryIntervalMilliseconds: 100,
   staleAfterMilliseconds: 120_000,
@@ -21,10 +24,11 @@ export interface CodeGraphGitStatusCacheReceipt {
   readonly sourceIndexDevice: number;
   readonly sourceIndexInode: number;
   readonly sourceIndexModifiedAtMilliseconds: number;
+  readonly sourceIndexSemanticSha256?: string;
   readonly version: typeof CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION;
 }
 
-type CodeGraphGitIndexIdentity = Omit<CodeGraphGitStatusCacheReceipt, 'version'>;
+type CodeGraphGitIndexIdentity = Omit<CodeGraphGitStatusCacheReceipt, 'sourceIndexSemanticSha256' | 'version'>;
 
 export interface CodeGraphGitStatusCacheOptions {
   readonly minimumIndexBytes?: number;
@@ -116,15 +120,30 @@ function runCachedStatus(
   return Effect.gen(function* () {
     yield* ensurePrivateCacheDirectory(fs, path, privateHome, cacheRoot);
     const privateIndex = path.join(cacheRoot, 'index');
-    const receiptPath = path.join(cacheRoot, 'receipt-v1.json');
+    const receiptPath = path.join(cacheRoot, 'receipt-v2.json');
     const receipt = yield* readReceipt(fs, receiptPath);
-    const reusable =
-      receipt !== undefined &&
-      sameCodeGraphGitIndexIdentity(receipt, sourceIdentity) &&
-      (yield* privateRegularFileWithinBound(fs, privateIndex));
+    const privateIndexAvailable = yield* privateRegularFileWithinBound(fs, privateIndex);
+    const metadataReusable =
+      receipt !== undefined && sameCodeGraphGitIndexIdentity(receipt, sourceIdentity) && privateIndexAvailable;
+    let sourceIndexSemanticSha256: string | undefined;
+    let reusable = metadataReusable;
+    // Git may atomically rewrite its real index for stat-cache housekeeping
+    // without changing staged entries or index flags. Preserve the warmed
+    // private fsmonitor index across that metadata-only churn, but fail closed
+    // to initialization when the bounded semantic observation is unavailable
+    // or names different staged content.
+    if (!reusable && privateIndexAvailable && receipt?.sourceIndexSemanticSha256 !== undefined) {
+      sourceIndexSemanticSha256 = Option.getOrUndefined(
+        yield* observeSourceIndexSemanticSha256(fs, identity, sourceIndex, sourceIdentity).pipe(Effect.option),
+      );
+      reusable = sourceIndexSemanticSha256 === receipt.sourceIndexSemanticSha256;
+    }
     if (!reusable) {
       yield* rejectSymbolicTarget(fs, receiptPath);
       yield* fs.remove(receiptPath, {force: true});
+      sourceIndexSemanticSha256 ??= Option.getOrUndefined(
+        yield* observeSourceIndexSemanticSha256(fs, identity, sourceIndex, sourceIdentity).pipe(Effect.option),
+      );
       yield* initializePrivateIndex(fs, path, identity, sourceIndex, sourceIdentity, privateIndex);
     }
 
@@ -152,12 +171,34 @@ function runCachedStatus(
     if (finalSourceIdentity === undefined || !sameCodeGraphGitIndexIdentity(finalSourceIdentity, sourceIdentity)) {
       return yield* Effect.fail(new CodeGraphGitStatusCacheUnavailable('Git index changed during observation.'));
     }
-    if (!reusable) {
-      yield* writeReceipt(fs, path, receiptPath, {...sourceIdentity, version: 1});
+    if (!metadataReusable) {
+      yield* writeReceipt(fs, path, receiptPath, {
+        ...sourceIdentity,
+        ...(sourceIndexSemanticSha256 === undefined ? {} : {sourceIndexSemanticSha256}),
+        version: CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION,
+      });
     }
     return result;
   });
 }
+
+const observeSourceIndexSemanticSha256 = Effect.fn('codeGraph.observeSourceIndexSemanticSha256')(function* (
+  fs: FileSystem.FileSystem,
+  identity: RepositoryIdentity,
+  sourceIndex: string,
+  expectedIdentity: CodeGraphGitIndexIdentity,
+) {
+  const stagedEntries = yield* runBinaryCommandEffect(
+    'git',
+    ['--no-optional-locks', '-C', identity.repoRoot, 'ls-files', '--stage', '-v', '-z'],
+    {maxOutputBytes: SEMANTIC_INDEX_OUTPUT_BYTES_MAXIMUM, timeoutMs: 30_000},
+  );
+  const finalIdentity = codeGraphGitIndexIdentity(yield* fs.stat(sourceIndex));
+  if (finalIdentity === undefined || !sameCodeGraphGitIndexIdentity(finalIdentity, expectedIdentity)) {
+    return yield* Effect.fail(new CodeGraphGitStatusCacheUnavailable('Git index changed during semantic observation.'));
+  }
+  return sha256HexSync(stagedEntries.stdout);
+});
 
 function initializePrivateIndex(
   fs: FileSystem.FileSystem,
@@ -298,7 +339,7 @@ function writeReceipt(
   receiptPath: string,
   receipt: CodeGraphGitStatusCacheReceipt,
 ) {
-  const temporary = path.join(path.dirname(receiptPath), '.receipt-v1.tmp');
+  const temporary = path.join(path.dirname(receiptPath), '.receipt-v2.tmp');
   const content = `${JSON.stringify(receipt)}\n`;
   return rejectSymbolicTarget(fs, receiptPath).pipe(
     Effect.andThen(rejectSymbolicTarget(fs, temporary)),
@@ -323,7 +364,10 @@ export function parseCodeGraphGitStatusCacheReceipt(value: string): CodeGraphGit
       candidate.indexBytes! > CODE_GRAPH_GIT_STATUS_CACHE_INDEX_BYTES_MAXIMUM ||
       !validNonNegativeSafeInteger(candidate.sourceIndexDevice) ||
       !validNonNegativeSafeInteger(candidate.sourceIndexInode) ||
-      !validNonNegativeSafeInteger(candidate.sourceIndexModifiedAtMilliseconds)
+      !validNonNegativeSafeInteger(candidate.sourceIndexModifiedAtMilliseconds) ||
+      (candidate.sourceIndexSemanticSha256 !== undefined &&
+        (typeof candidate.sourceIndexSemanticSha256 !== 'string' ||
+          !SHA256_PATTERN.test(candidate.sourceIndexSemanticSha256)))
     ) {
       return undefined;
     }
@@ -332,6 +376,9 @@ export function parseCodeGraphGitStatusCacheReceipt(value: string): CodeGraphGit
       sourceIndexDevice: candidate.sourceIndexDevice!,
       sourceIndexInode: candidate.sourceIndexInode!,
       sourceIndexModifiedAtMilliseconds: candidate.sourceIndexModifiedAtMilliseconds!,
+      ...(candidate.sourceIndexSemanticSha256 === undefined
+        ? {}
+        : {sourceIndexSemanticSha256: candidate.sourceIndexSemanticSha256}),
       version: CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION,
     };
   } catch {

--- a/test/integration/code-graph.git-status-cache.test.ts
+++ b/test/integration/code-graph.git-status-cache.test.ts
@@ -27,6 +27,9 @@ describe('code graph private Git status cache', () => {
       const identity = repositoryIdentity(repository);
       const base = yield* CommandExecutor;
       const calls: Array<{args: readonly string[]; options?: CommandOptions}> = [];
+      // Distinct invalid UTF-8 bytes would both decode to the replacement
+      // character, so this also guards the raw-byte digest boundary.
+      let sourceIndexSemanticIdentity = Uint8Array.of(0x80);
       const command = CommandExecutor.of({
         ...base,
         execute: (executable, args, options) => {
@@ -37,6 +40,18 @@ describe('code graph private Git status cache', () => {
           if (args.includes('fsmonitor--daemon')) return Effect.succeed(result(''));
           if (args.includes('status')) return Effect.succeed(result(' M src/index.ts\0'));
           return Effect.fail(commandFailure(args));
+        },
+        executeBytes: (executable, args, options) => {
+          expect(executable).toBe('git');
+          calls.push({args, options});
+          if (args.includes('ls-files')) {
+            return Effect.succeed({
+              exitCode: 0,
+              stderr: '',
+              stdout: sourceIndexSemanticIdentity,
+            });
+          }
+          return Effect.die(new Error(`Unexpected binary command: ${args.join(' ')}`));
         },
       });
       const observe = () =>
@@ -55,15 +70,27 @@ describe('code graph private Git status cache', () => {
       expect(fsmonitorOperations(calls, 'status')).toHaveLength(1);
       assertPrivateStatusCall(calls.at(-1), home);
 
-      writeFileSync(sourceIndex, 'source-index-v2');
+      writeFileSync(sourceIndex, 'source-index-metadata-refresh');
+      expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
+      expect(calls.filter(call => call.args.includes('update-index'))).toHaveLength(2);
+      expect(fsmonitorOperations(calls, 'status')).toHaveLength(1);
+
+      sourceIndexSemanticIdentity = Uint8Array.of(0x81);
+      writeFileSync(sourceIndex, 'source-index-staged-change');
       expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
       expect(calls.filter(call => call.args.includes('update-index'))).toHaveLength(4);
       expect(fsmonitorOperations(calls, 'status')).toHaveLength(2);
       expect(fsmonitorOperations(calls, 'start')).toHaveLength(0);
+      expect(calls.filter(call => call.args.includes('ls-files'))).toHaveLength(3);
       assertPrivateStatusCall(calls.at(-1), home);
-      expect(calls.every(call => !call.args.includes('--no-optional-locks') || call.args.includes('rev-parse'))).toBe(
-        true,
-      );
+      expect(
+        calls.every(
+          call =>
+            !call.args.includes('--no-optional-locks') ||
+            call.args.includes('rev-parse') ||
+            call.args.includes('ls-files'),
+        ),
+      ).toBe(true);
     }).pipe(
       Effect.ensuring(
         Effect.sync(() => (root === undefined ? undefined : rmSync(root, {force: true, recursive: true}))),

--- a/test/unit/code-graph.git-status-cache.property.test.ts
+++ b/test/unit/code-graph.git-status-cache.property.test.ts
@@ -14,12 +14,14 @@ describe('code graph private Git status cache receipt', () => {
         fc.nat(Number.MAX_SAFE_INTEGER),
         fc.nat(Number.MAX_SAFE_INTEGER),
         fc.nat(Number.MAX_SAFE_INTEGER),
-        (indexBytes, sourceIndexDevice, sourceIndexInode, sourceIndexModifiedAtMilliseconds) => {
+        fc.option(fc.stringMatching(/^[0-9a-f]{64}$/), {nil: undefined}),
+        (indexBytes, sourceIndexDevice, sourceIndexInode, sourceIndexModifiedAtMilliseconds, semanticSha256) => {
           const receipt = {
             indexBytes,
             sourceIndexDevice,
             sourceIndexInode,
             sourceIndexModifiedAtMilliseconds,
+            ...(semanticSha256 === undefined ? {} : {sourceIndexSemanticSha256: semanticSha256}),
             version: CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION,
           };
           expect(parseCodeGraphGitStatusCacheReceipt(JSON.stringify(receipt))).toEqual(receipt);
@@ -35,18 +37,25 @@ describe('code graph private Git status cache receipt', () => {
       sourceIndexDevice: 1,
       sourceIndexInode: 1,
       sourceIndexModifiedAtMilliseconds: 1,
-      version: 1,
+      version: CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION,
     },
     {
       indexBytes: CODE_GRAPH_GIT_STATUS_CACHE_INDEX_BYTES_MAXIMUM + 1,
       sourceIndexDevice: 1,
       sourceIndexInode: 1,
       sourceIndexModifiedAtMilliseconds: 1,
-      version: 1,
+      version: CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION,
     },
     {
       indexBytes: 1,
       sourceIndexDevice: -1,
+      sourceIndexInode: 1,
+      sourceIndexModifiedAtMilliseconds: 1,
+      version: CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION,
+    },
+    {
+      indexBytes: 1,
+      sourceIndexDevice: 1,
       sourceIndexInode: 1,
       sourceIndexModifiedAtMilliseconds: 1,
       version: 1,
@@ -56,7 +65,15 @@ describe('code graph private Git status cache receipt', () => {
       sourceIndexDevice: 1,
       sourceIndexInode: 1,
       sourceIndexModifiedAtMilliseconds: 1,
-      version: 2,
+      version: CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION + 1,
+    },
+    {
+      indexBytes: 1,
+      sourceIndexDevice: 1,
+      sourceIndexInode: 1,
+      sourceIndexModifiedAtMilliseconds: 1,
+      sourceIndexSemanticSha256: 'not-a-digest',
+      version: CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION,
     },
   ])('rejects an invalid receipt %#', receipt => {
     expect(parseCodeGraphGitStatusCacheReceipt(JSON.stringify(receipt))).toBeUndefined();


### PR DESCRIPTION
## Summary

- preserve the exact Git-index metadata fast path
- when Git rewrites only index bookkeeping, compare a bounded semantic digest of staged entries and flags before reusing the warmed private index
- rebuild on real staged changes, missing evidence, malformed receipts, races, or oversized output
- keep the Bun runtime free of Node-library dependencies

## Why

Large repositories can rewrite the real Git index during harmless status/stat-cache housekeeping. The previous receipt keyed inode, size, and mtime, so this invalidated Threadnote’s warmed private fsmonitor index even though staged semantics were unchanged. On the IntelliJ fixture, that pushed the v4.3.4 registration gate to 5.191–5.212 seconds versus the strict sub-5-second target.

## Evidence

- disposable IntelliJ probe: initial status 5.27s; semantically unchanged metadata rewrite then 1.48s; subsequent warm status 272ms
- semantic digest command itself: about 150ms over about 39MB
- focused Effect/Fast-check suite: 11/11
- lint, root typecheck, and diff check pass

## Regression coverage

- metadata-only churn reuses the private index without another update-index/fsmonitor initialization
- a real staged semantic change reinitializes it
- receipt v2 serialization/parsing remains property-tested; legacy or malformed receipts fail closed

Full-suite authority remains PR CI.