### PR TITLE
fix(update): restore JSON release checks

### DIFF
--- a/src/auto_update.ts
+++ b/src/auto_update.ts
@@ -71,6 +71,8 @@ export interface AutoUpdateStatus extends AutoUpdateState {
   readonly policySource: 'default' | 'environment' | 'file';
 }
 
+export type ThreadnoteUpdateCommandMode = 'invalid' | 'policy' | 'release' | 'status';
+
 export type AutoUpdateWorkerResult =
   | {readonly result: 'busy' | 'current' | 'disabled' | 'failed'}
   | {readonly repairRequired: boolean; readonly result: 'updated'};
@@ -198,9 +200,26 @@ export const runAutoUpdateStatusCommand = Effect.fn('autoUpdate.statusCommand')(
 });
 
 export function runThreadnoteUpdateCommand(config: RuntimeConfig, options: UpdateOptions) {
+  const mode = threadnoteUpdateCommandMode(options);
+  if (mode === 'invalid') {
+    return Effect.fail(
+      applicationError(
+        'validate update command',
+        new Error('Choose one update mode: automatic-update policy, status, or release installation.'),
+      ),
+    );
+  }
+  if (mode === 'policy') {
+    return runAutoUpdatePolicyCommand(options.auto === 'on' ? 'automatic' : 'notify', options.dryRun);
+  }
+  if (mode === 'status') return runAutoUpdateStatusCommand(options.json === true);
+  return runUpdate(config, options);
+}
+
+/** @internal Pure update-mode dispatcher used by CLI regression tests. */
+export function threadnoteUpdateCommandMode(options: UpdateOptions): ThreadnoteUpdateCommandMode {
   const policyMode = options.auto !== undefined;
-  const statusMode = options.status === true || options.json === true;
-  const updateOnlyOption = Boolean(
+  const releaseMode = Boolean(
     options.allowUntrustedSource ||
     options.beta ||
     options.check ||
@@ -211,19 +230,15 @@ export function runThreadnoteUpdateCommand(config: RuntimeConfig, options: Updat
     options.stable ||
     options.yes,
   );
-  if ((policyMode && statusMode) || ((policyMode || statusMode) && updateOnlyOption)) {
-    return Effect.fail(
-      applicationError(
-        'validate update command',
-        new Error('Choose one update mode: automatic-update policy, status, or release installation.'),
-      ),
-    );
-  }
-  if (options.auto) {
-    return runAutoUpdatePolicyCommand(options.auto === 'on' ? 'automatic' : 'notify', options.dryRun);
-  }
-  if (statusMode) return runAutoUpdateStatusCommand(options.json === true);
-  return runUpdate(config, options);
+  // `--json` predates an explicit status subcommand as a convenient status
+  // shorthand. When paired with `--check`, however, it modifies that release
+  // check's output instead of selecting a second command mode.
+  const statusMode = options.status === true || (options.json === true && options.check !== true);
+  const selectedModeCount = Number(policyMode) + Number(statusMode) + Number(releaseMode);
+  if (selectedModeCount > 1) return 'invalid';
+  if (policyMode) return 'policy';
+  if (statusMode) return 'status';
+  return 'release';
 }
 
 /**

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -350,7 +350,7 @@ const update = Command.make(
     check: boolean('check', 'Only check whether a newer version is available'),
     dryRun: boolean('dry-run', 'Print update and repair commands without running them'),
     force: boolean('force', 'Reinstall the selected standalone release even if already current'),
-    json: boolean('json', 'Emit versioned machine-readable update status'),
+    json: boolean('json', 'Emit versioned machine-readable status or update-check output'),
     postUpdate: negatedBoolean('post-update', 'Skip post-update migration prompts'),
     repair: negatedBoolean('repair', 'Skip threadnote repair after updating the package'),
     source: optionalString('source', 'GitHub-compatible releases API URL'),

--- a/src/update.ts
+++ b/src/update.ts
@@ -14,6 +14,7 @@ import {maybeRunEffect, runCommandEffect, runStreamingCommandEffect} from './eff
 import {applicationError, fromSync} from './effect/errors.js';
 import {syncDirectoryBestEffort, syncWritableFile} from './effect/file_durability.js';
 import {withExclusiveFileLock} from './effect/file_lock.js';
+import {writeFinalCliOutput} from './effect/cli_output.js';
 import {getJsonEffect, HttpService} from './effect/http.js';
 import {sha256FileHex} from './effect/digest.js';
 import {SystemInfo, type SystemInfoShape} from './effect/system.js';
@@ -175,6 +176,32 @@ export const runUpdate = Effect.fn('runUpdate')(function* (config: RuntimeConfig
       requestedChannel,
     }),
   );
+
+  if (options.check === true && options.json === true) {
+    if (requiresFreshStandaloneInstall(info.currentVersion)) {
+      return yield* Effect.fail(
+        new UpdateOperationError(
+          'Threadnote 3 cannot update across the standalone-runtime boundary. Install Threadnote 4 fresh from the GitHub release installer.',
+        ),
+      );
+    }
+    yield* writeFinalCliOutput(
+      JSON.stringify({
+        channel: info.channel,
+        currentVersion: info.currentVersion,
+        isChannelSwitch: info.isChannelSwitch,
+        isUpdateAvailable: info.isUpdateAvailable,
+        isVersionUpgrade: info.isVersionUpgrade,
+        latestVersion: info.latestVersion ?? null,
+        requestedChannel: requestedChannel ?? null,
+        source: info.source,
+        type: 'threadnote-update-check',
+        usedCache: info.usedCache,
+        version: 1,
+      }),
+    );
+    return;
+  }
 
   yield* Console.log(keyValue('Current version', infoText(info.currentVersion)));
   yield* Console.log(

--- a/test/unit/auto-update.test.ts
+++ b/test/unit/auto-update.test.ts
@@ -14,6 +14,7 @@ import {
   setAutoUpdatePolicy,
   stateAfterFailedAutoUpdateSpawn,
   terminalAutoUpdateState,
+  threadnoteUpdateCommandMode,
   type AutoUpdateState,
   type AutoUpdateWorkerResult,
 } from '../../src/auto_update.js';
@@ -23,6 +24,18 @@ import {provideTestLayer} from '../helpers/effect-layer.js';
 const AutoUpdateTestLayer = Layer.mergeAll(BunServices.layer, SystemInfo.layer);
 
 describe('automatic update state', () => {
+  it('treats JSON as an output modifier for release checks without weakening mode conflicts', () => {
+    fc.assert(
+      fc.property(fc.boolean(), fc.boolean(), (beta, stable) => {
+        expect(threadnoteUpdateCommandMode({beta, check: true, json: true, stable})).toBe('release');
+      }),
+    );
+    expect(threadnoteUpdateCommandMode({json: true})).toBe('status');
+    expect(threadnoteUpdateCommandMode({json: true, status: true})).toBe('status');
+    expect(threadnoteUpdateCommandMode({auto: 'off', json: true})).toBe('invalid');
+    expect(threadnoteUpdateCommandMode({check: true, json: true, status: true})).toBe('invalid');
+  });
+
   effectIt.effect('defaults to notify and persists explicit policy changes atomically', () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -422,6 +422,33 @@ describe('update notifications', () => {
 });
 
 describe('standalone updater', () => {
+  effectIt.effect('emits one versioned JSON document for a release check', () =>
+    Effect.gen(function* () {
+      const captured = yield* captureDryRunUpdateSelection(
+        '4.1.0',
+        [
+          ['4.2.0-beta.1', true],
+          ['4.1.1', false],
+        ],
+        {check: true, json: true, stable: true},
+      );
+
+      expect(JSON.parse(captured.output)).toEqual({
+        channel: 'latest',
+        currentVersion: '4.1.0',
+        isChannelSwitch: false,
+        isUpdateAvailable: true,
+        isVersionUpgrade: true,
+        latestVersion: '4.1.1',
+        requestedChannel: 'latest',
+        source: OFFICIAL_RELEASE_SOURCE,
+        type: 'threadnote-update-check',
+        usedCache: false,
+        version: 1,
+      });
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('updates an installed beta to a newer stable release without an explicit channel flag', () =>
     Effect.gen(function* () {
       const captured = yield* captureDryRunUpdateSelection(

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -1772,7 +1772,7 @@ threadnote update --check`,
           },
           {
             type: 'paragraph',
-            text: "The beta channel is an inclusive preview channel: it selects the newest immutable Threadnote release across stable and prerelease builds, so an invoked update can graduate an older beta to a fresher stable without --stable. After that graduation, ordinary updates follow stable; use --beta to re-enter preview selection. Use --stable to request stable explicitly, even when it is numerically lower than an installed prerelease. Updates verify immutable release assets, promote atomically, preserve ~/.threadnote data and verified model files, then repair Threadnote-owned integrations. Cursor Marketplace plugin updates remain owned by Cursor and the organization's policy.",
+            text: "The beta channel is an inclusive preview channel: it selects the newest immutable Threadnote release across stable and prerelease builds, so an invoked update can graduate an older beta to a fresher stable without --stable. After that graduation, ordinary updates follow stable; use --beta to re-enter preview selection. Use --stable to request stable explicitly, even when it is numerically lower than an installed prerelease. Add --json to --check for a versioned machine-readable result. Updates verify immutable release assets, promote atomically, preserve ~/.threadnote data and verified model files, then repair Threadnote-owned integrations. Cursor Marketplace plugin updates remain owned by Cursor and the organization's policy.",
           },
           {
             type: 'paragraph',


### PR DESCRIPTION
## Summary

- restore `threadnote update --check --json` and `threadnote update --stable --check --json`
- preserve `--json` as the existing automatic-update status shorthand when no release check is selected
- emit one versioned `threadnote-update-check` JSON document and document the supported combination
- retain mixed-mode rejection for automatic policy/status conflicts

## Diagnosis

The automatic-update dispatcher introduced in `2b1cb071` treated `--json` as an unconditional status-mode selector. Pairing it with `--check` therefore selected both status and release modes and failed before the release check. Plain `--check` remained functional.

## Verification

- exact installed `c2833ad` reproduction for both failing commands; plain `--check` succeeds
- focused Effect unit suites: 54 tests passed
- focused CLI integration suite: 30 tests passed
- website content/release-boundary suites: 65 tests passed
- source CLI smoke: default and explicit-stable JSON checks each emitted a single parseable versioned document; `update --json` still emitted automatic-update status
- lint, root/test/site typechecks, Prettier, and `git diff --check` passed
- Fast-check property covers JSON-check routing across beta/stable flag combinations while examples retain mode-conflict regressions

A privacy-safe `threadnote report-issue` preview was prepared; no public issue was created.
