### PR TITLE
Release Threadnote v4.3.5

### DIFF
--- a/.github/release-notes/v4.3.5.md
+++ b/.github/release-notes/v4.3.5.md
@@ -1,0 +1,31 @@
+## What's new
+
+Threadnote 4.3.5 keeps accelerated one-file graph updates warm when Git refreshes only index bookkeeping, restores
+machine-readable release checks, and makes automatic-update failure telemetry preserve the underlying typed failure.
+
+### Stable large-repository status acceleration
+
+- A private Git-status cache now distinguishes physical index rewrites from real staged-tree changes.
+- On metadata-only churn, Threadnote compares a bounded digest of the raw staged entries and index flags before reusing
+  the warmed private index.
+- Real staged changes, missing or malformed evidence, races, and oversized observations still fail closed to private
+  index reinitialization or the ordinary read-only status path.
+
+In the pinned IntelliJ investigation, a private status observation took 5.27 seconds initially, 1.48 seconds after a
+content-neutral index rewrite, and 272 milliseconds on the following warm observation. The exact v4.3.5 release-scale
+benchmark is retained separately from this component evidence.
+
+### Reliable updater checks and diagnostics
+
+- `threadnote update --check --json` and `threadnote update --stable --check --json` again emit one versioned
+  `threadnote-update-check` document; `threadnote update --json` remains the automatic-update status shorthand.
+- A failed automatic-update worker now remains a failed Effect after its durable status is written, so telemetry
+  reports `outcome=failure` with the existing privacy-safe error classification.
+- Coordinator contention remains classified as busy, while lock failures raised inside the updater retain their real
+  failure type.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- release the semantic Git-index receipt cache that preserves safe warm reuse across metadata-only index rewrites
- include the restored JSON update-check CLI contract and typed automatic-update failure telemetry
- document measured IntelliJ component evidence for the admission-path fix

## Local validation

- focused release-note, website boundary, and website content tests: 70 passed
- website production build passed
- commit gate passed lint, formatting, root and test typechecks, and website typecheck
- exact clean HEAD installed globally as `4.3.5-local.gb85faf22098b36e8cac94c7b7a6bd9046d742165`
- `threadnote update --check --json` and `threadnote update --stable --check --json` returned valid v1 documents
- telemetry remained enabled
- repair plus doctor completed with 0 failures and 2 known warnings

The exact-tag IntelliJ benchmark will start only after this PR is merged and `v4.3.5` is published, so the public performance evidence binds to the shipped artifact.