### PR TITLE
perf(code-graph): defer completed-build cleanup

### DIFF
--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -190,14 +190,16 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
             ...options,
           } satisfies CodeGraphDatabaseSessionShape;
           return yield* Effect.gen(function* () {
+            let completedBuildCleanup = Effect.void;
             // Indexing sessions identify themselves with the checkout-wide
-            // writer lock. Reclaim one bounded page from every completed
-            // build table before normal work, then let a best-effort fiber
-            // continue. A process killed immediately after the ready CAS
-            // therefore self-heals on the next ordinary index without
-            // making graph queries pay cleanup latency.
+            // writer lock. Validate the schema before normal work, but defer
+            // completed-build reclamation until the session effect exits.
+            // Build-only rows are unreachable after publication, so putting
+            // their bounded maintenance after admission keeps worktree
+            // registration proportional without weakening cleanup or making
+            // graph queries pay the latency.
             if (options?.cleanupCompletedBuildRows && (yield* tableExists(sql, 'snapshots'))) {
-              // Initialize once under the checkout writer gate before cleanup.
+              // Initialize once under the checkout writer gate before work.
               // The receipt makes the ordinary path bounded, and marking this
               // session avoids replaying the same admission when the indexing
               // effect calls store.initialize immediately afterward.
@@ -209,17 +211,19 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
                 ),
                 Effect.asVoid,
               );
-              const cleanup = yield* drainCompletedPersistentBuildRows(
-                sql,
-                undefined,
-                write => withWriterGate(databasePath, write),
-                1,
-              ).pipe(Effect.option);
-              if (Option.isSome(cleanup) && cleanup.value.remaining) {
-                yield* scheduleCompletedBuildCleanup(databasePath);
-              }
+              completedBuildCleanup = Effect.gen(function* () {
+                const cleanup = yield* drainCompletedPersistentBuildRows(
+                  sql,
+                  undefined,
+                  write => withWriterGate(databasePath, write),
+                  1,
+                ).pipe(Effect.option);
+                if (Option.isSome(cleanup) && cleanup.value.remaining) {
+                  yield* scheduleCompletedBuildCleanup(databasePath);
+                }
+              });
             }
-            return yield* effect;
+            return yield* effect.pipe(Effect.ensuring(completedBuildCleanup));
           }).pipe(Effect.provideService(CodeGraphDatabaseSession, session));
         }),
         options?.readOnly === true,

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -580,7 +580,7 @@ export interface CodeGraphStoreShape {
 export interface CodeGraphDatabaseSessionOptions {
   /** @internal Open a non-creating, query-only SQLite connection without WAL bootstrap writes. */
   readonly readOnly?: boolean;
-  /** @internal Ordinary index sessions opportunistically reclaim completed build-only rows. */
+  /** @internal Ordinary index sessions reclaim a bounded page of completed build-only rows after foreground work. */
   readonly cleanupCompletedBuildRows?: boolean;
   /** @internal Observes the point at which gated background cleanup may open SQLite. */
   readonly onCompletedBuildCleanupConnection?: () => Effect.Effect<void, never>;

--- a/test/unit/code-graph.materialization-store.test.ts
+++ b/test/unit/code-graph.materialization-store.test.ts
@@ -2095,20 +2095,29 @@ describe('code graph full-build materialization store', () => {
           database.exec('DROP TRIGGER reject_completed_receipt_cleanup');
           database.close(false);
         });
-        yield* Effect.gen(function* () {
+        const rowsDuringForegroundWork = yield* Effect.gen(function* () {
           const store = yield* CodeGraphStore;
-          yield* store.withSession(
+          return yield* store.withSession(
             fixture.databasePath,
-            store.cacheFacts(
-              fixture.databasePath,
-              [fixture.file],
-              [nextIndexFacts],
-              'next-index-cache',
-              unprotectedCacheWrite,
-            ),
+            Effect.gen(function* () {
+              const rows = yield* Effect.sync(() => readCompletedBuildRows(fixture.databasePath, snapshot.id));
+              yield* store.cacheFacts(
+                fixture.databasePath,
+                [fixture.file],
+                [nextIndexFacts],
+                'next-index-cache',
+                unprotectedCacheWrite,
+              );
+              return rows;
+            }),
             {cleanupCompletedBuildRows: true, writerLockPath},
           );
         }).pipe(provideTestLayer(ApplicationLayer));
+        expect(rowsDuringForegroundWork).toEqual({
+          batches: 1,
+          candidates: 0,
+          refs: 0,
+        });
         expect(readCompletedBuildRows(fixture.databasePath, snapshot.id)).toEqual({
           batches: 0,
           candidates: 0,


### PR DESCRIPTION
## Summary

- keep exact schema admission before foreground indexing work
- defer the bounded completed-build row drain until the indexing session exits
- preserve the same one-page-per-table cleanup and best-effort continuation contract
- assert that published build-only rows remain present during foreground work and are reclaimed before the session returns

## Why

The exact v4.3.5 IntelliJ release observation preserved a 5,233.720 ms registration result, missing the hard `<5,000 ms` gate by 233.720 ms while cold, one-file total, post-scan, parity, proportionality, transaction, and failure-counter gates all passed. Registration currently includes maintenance over unreachable completed-build rows left by the prior cold publication. Those rows are not admission inputs and are invisible to readers, but the synchronous drain runs before scanning begins.

This moves the same bounded maintenance to session finalization. It improves time-to-foreground-work without dropping cleanup, weakening worktree race checks, changing SQLite durability, or hiding the cost from end-to-end indexing time.

## Evidence

- exact v4.3.5 IntelliJ artifact retained at `/private/tmp/threadnote-v4.3.5-intellij-r1.json`, SHA-256 `cc337e8778eb8e2d0590b995f43985f21f6da3ec50ec2bdb53d201cbce1110f7`
- candidate medium production-shaped artifact: `/private/tmp/threadnote-deferred-cleanup-medium-98864f8-r1.json`, SHA-256 `ce116634f40e8a90d05fffcedef9c8bf768b3b5977eb67b8190b0dff9c42f43f`
  - cold: 71.214 s
  - one-file: 1.403 s
  - registration: 354.158 ms
  - post-scan: 73.660 ms
  - incremental/reference structural digests match
  - every retained sampler failure counter is zero
- `bun run typecheck`
- `bun run lint`
- Prettier check and `git diff --check`
- the modified Effect test reached every behavioral assertion locally; its file-level teardown timeout reproduces unchanged on the v4.3.5 baseline, so PR CI remains authoritative for the full suite

## Property-testing assessment

This is a single ordering transition around one session boundary, with no meaningful generated input space beyond the deterministic lifecycle regression. Existing parity and production-ratchet properties continue to govern graph output and assessed metrics.
