### PR TITLE
chore(release): prepare 4.3.6

### DIFF
--- a/.github/release-notes/v4.3.6.md
+++ b/.github/release-notes/v4.3.6.md
@@ -1,0 +1,24 @@
+## What's new
+
+Threadnote 4.3.6 lets foreground graph indexing begin without first reclaiming unreachable rows from a previously
+published build. Schema admission and all durability checks still run before foreground work; the same bounded cleanup
+now runs when the indexing session exits and remains included in end-to-end indexing time.
+
+### Faster incremental graph admission
+
+- Published build-only rows remain invisible to readers and are no longer an input to the next indexing admission.
+- Threadnote reclaims one bounded page from each completed-build table after foreground work, then schedules the
+  existing best-effort continuation when more rows remain.
+- Cleanup failures keep their previous non-fatal contract, and worktree race checks, SQLite durability, graph parity,
+  and transaction behavior are unchanged.
+
+The retained exact v4.3.5 IntelliJ observation passed the cold, one-file total, post-scan, parity, proportionality,
+transaction, and failure-counter gates, but registration took 5,233.720 milliseconds and missed its strict five-second
+gate by 233.720 milliseconds. That failed observation was preserved rather than rerun for a favorable sample. The exact
+v4.3.6 release-scale observation will likewise be retained separately after publication.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone release version to 4.3.6
- publish release notes for deferred completed-build cleanup
- preserve the exact v4.3.5 registration miss as failed evidence

## Verification

- focused release workflow and package contract tests: 21 passed
- commit hook: lint, Prettier, typecheck
- full suite delegated to PR CI