### PR TITLE
test(remote-memory): observe blocked cancellation state

### DIFF
--- a/test/integration/remote-memory-postgres.test.ts
+++ b/test/integration/remote-memory-postgres.test.ts
@@ -713,14 +713,20 @@ postgresDescribe('remote memory PostgreSQL service', () => {
         const rows = await withTenant(
           fixture.migratorSql,
           TENANT_A,
-          transaction => transaction<{reserved: boolean}[]>`
-            SELECT EXISTS(
-              SELECT 1 FROM remote_memory.idempotency_records
-              WHERE principal_id = ${PRINCIPAL_A} AND operation_id = ${input.operationId}
-            ) AS reserved
+          transaction => transaction<{blocked: boolean; reserved: boolean}[]>`
+            SELECT
+              EXISTS(
+                SELECT 1 FROM remote_memory.idempotency_records
+                WHERE principal_id = ${PRINCIPAL_A} AND operation_id = ${input.operationId}
+              ) AS reserved,
+              EXISTS(
+                SELECT 1 FROM pg_locks waiting
+                WHERE waiting.locktype = 'advisory' AND waiting.granted = false
+                  AND waiting.database = (SELECT oid FROM pg_database WHERE datname = current_database())
+              ) AS blocked
           `,
         );
-        return rows[0]?.reserved === true;
+        return rows[0]?.reserved === true && rows[0]?.blocked === true;
       });
       controller.abort();
       expect(await settled).toMatchObject({kind: 'rejected'});


### PR DESCRIPTION
## Summary

- wait until the mutation is actually queued on the held advisory lock before aborting it
- retain the durable idempotency-reservation check while making the advertised blocked-write scenario deterministic
- keep the change isolated to the PostgreSQL integration fixture

## Diagnosis

This is a recurring CI flake, independent of PR #224's code-graph changes. The same test timed out at exactly 30 seconds in:

- https://github.com/Kashkovsky/threadnote/actions/runs/32922656883 (job 98039147726)
- https://github.com/Kashkovsky/threadnote/actions/runs/32802304843 (job 97666628346)

The test held an advisory lock, started `remember`, and aborted as soon as the separate idempotency reservation became visible. That reservation commits before the mutation transaction reaches the advisory lock, so runner scheduling could deliver cancellation before the write was actually blocked. The test therefore exercised several different driver states despite claiming one specific blocked-query scenario.

The fixture now observes both the durable reservation and an ungranted advisory lock in its isolated PostgreSQL database before aborting.

## Verification

- before the fix: 10/10 local runs passed, but 8 used the full five-second PostgreSQL timeout fallback and only 2 cancelled promptly
- after the fix: 30/30 local runs cancelled promptly; test bodies completed in 0.38-0.54 seconds
- after rebasing onto main with PR #224 merged: the complete PostgreSQL integration file passed 21/21 in 1.61 seconds
- strict oxlint on the changed file
- Prettier check on the changed file
- `bun --bun tsc -p test/tsconfig.json --noEmit`

No property test was added: this regression is a single external PostgreSQL coordination state with no meaningful generated input model; the explicit database-state barrier is the focused invariant.
