### PR TITLE
perf(code-graph): bound Git index semantic admission

### DIFF
--- a/src/code_graph/git_index_semantic.ts
+++ b/src/code_graph/git_index_semantic.ts
@@ -1,0 +1,139 @@
+const GIT_INDEX_HEADER_BYTES = 12;
+const GIT_INDEX_SIGNATURE = Uint8Array.of(0x44, 0x49, 0x52, 0x43); // DIRC
+const GIT_INDEX_ENTRY_STAT_BYTES = 40;
+const GIT_INDEX_FLAGS_BYTES = 2;
+const GIT_INDEX_OPTIONAL_EXTENSION_HEADER_BYTES = 8;
+const GIT_INDEX_SEMANTIC_FLAGS_MASK = 0xf000;
+const GIT_INDEX_EXTENDED_FLAG = 0x4000;
+const GIT_INDEX_NAME_LENGTH_MASK = 0x0fff;
+const GIT_INDEX_NAME_LENGTH_SENTINEL = GIT_INDEX_NAME_LENGTH_MASK;
+const GIT_INDEX_SEMANTIC_DIGEST_VERSION = 1;
+
+/**
+ * Hash the staged/index semantics without Git's mutable stat and cache data.
+ *
+ * Unsupported required extensions and malformed indexes return `undefined`,
+ * allowing the caller to fail closed to Git's canonical `ls-files` view.
+ */
+export function codeGraphGitIndexSemanticSha256(
+  index: Uint8Array,
+  objectFormat: 'sha1' | 'sha256',
+): string | undefined {
+  const objectIdBytes = objectFormat === 'sha1' ? 20 : 32;
+  const checksumBytes = objectIdBytes;
+  if (index.byteLength < GIT_INDEX_HEADER_BYTES + checksumBytes) return undefined;
+  for (let offset = 0; offset < GIT_INDEX_SIGNATURE.byteLength; offset += 1) {
+    if (index[offset] !== GIT_INDEX_SIGNATURE[offset]) return undefined;
+  }
+
+  const view = new DataView(index.buffer, index.byteOffset, index.byteLength);
+  const version = view.getUint32(4, false);
+  if (version !== 2 && version !== 3 && version !== 4) return undefined;
+  const entryCount = view.getUint32(8, false);
+  const contentEnd = index.byteLength - checksumBytes;
+  if (!validGitIndexChecksum(index, contentEnd, objectFormat)) return undefined;
+
+  const digest = new Bun.CryptoHasher('sha256');
+  digest.update(`threadnote-git-index-semantic-v${GIT_INDEX_SEMANTIC_DIGEST_VERSION}\0${objectFormat}\0`);
+  digest.update(index.subarray(8, 12));
+  const canonicalEntry = new Uint8Array(12);
+  const canonicalView = new DataView(canonicalEntry.buffer);
+  let previousPath: Uint8Array<ArrayBufferLike> = new Uint8Array();
+  let offset = GIT_INDEX_HEADER_BYTES;
+
+  for (let entryIndex = 0; entryIndex < entryCount; entryIndex += 1) {
+    const entryStart = offset;
+    const flagsOffset = entryStart + GIT_INDEX_ENTRY_STAT_BYTES + objectIdBytes;
+    if (flagsOffset + GIT_INDEX_FLAGS_BYTES > contentEnd) return undefined;
+    const flags = view.getUint16(flagsOffset, false);
+    offset = flagsOffset + GIT_INDEX_FLAGS_BYTES;
+    let extendedFlags = 0;
+    if ((flags & GIT_INDEX_EXTENDED_FLAG) !== 0) {
+      if (version === 2 || offset + 2 > contentEnd) return undefined;
+      extendedFlags = view.getUint16(offset, false);
+      offset += 2;
+    }
+
+    let path: Uint8Array<ArrayBufferLike>;
+    if (version === 4) {
+      const decoded = decodeGitIndexVariableWidthInteger(index, offset, contentEnd);
+      if (decoded === undefined || decoded.value > previousPath.byteLength) return undefined;
+      offset = decoded.nextOffset;
+      const terminator = index.indexOf(0, offset);
+      if (terminator < 0 || terminator >= contentEnd) return undefined;
+      const suffix = index.subarray(offset, terminator);
+      path = new Uint8Array(previousPath.byteLength - decoded.value + suffix.byteLength);
+      path.set(previousPath.subarray(0, previousPath.byteLength - decoded.value));
+      path.set(suffix, previousPath.byteLength - decoded.value);
+      offset = terminator + 1;
+    } else {
+      const terminator = index.indexOf(0, offset);
+      if (terminator < 0 || terminator >= contentEnd) return undefined;
+      path = index.subarray(offset, terminator);
+      const entryBytes = terminator + 1 - entryStart;
+      const paddedEntryBytes = Math.ceil(entryBytes / 8) * 8;
+      offset = entryStart + paddedEntryBytes;
+      if (offset > contentEnd) return undefined;
+      for (let paddingOffset = terminator + 1; paddingOffset < offset; paddingOffset += 1) {
+        if (index[paddingOffset] !== 0) return undefined;
+      }
+    }
+    const declaredPathBytes = flags & GIT_INDEX_NAME_LENGTH_MASK;
+    if (declaredPathBytes !== GIT_INDEX_NAME_LENGTH_SENTINEL && declaredPathBytes !== path.byteLength) {
+      return undefined;
+    }
+
+    canonicalEntry.set(index.subarray(entryStart + 24, entryStart + 28), 0);
+    canonicalView.setUint16(4, flags & GIT_INDEX_SEMANTIC_FLAGS_MASK, false);
+    canonicalView.setUint16(6, extendedFlags, false);
+    canonicalView.setUint32(8, path.byteLength, false);
+    digest.update(canonicalEntry);
+    digest.update(index.subarray(entryStart + GIT_INDEX_ENTRY_STAT_BYTES, flagsOffset));
+    digest.update(path);
+    previousPath = path;
+  }
+
+  while (offset < contentEnd) {
+    if (offset + GIT_INDEX_OPTIONAL_EXTENSION_HEADER_BYTES > contentEnd) return undefined;
+    const signature = index.subarray(offset, offset + 4);
+    const extensionBytes = view.getUint32(offset + 4, false);
+    const extensionEnd = offset + GIT_INDEX_OPTIONAL_EXTENSION_HEADER_BYTES + extensionBytes;
+    if (extensionEnd > contentEnd) return undefined;
+    // Lowercase signatures are required extensions. Split and sparse indexes
+    // change entry interpretation, so this bounded parser deliberately asks
+    // Git for the canonical view instead of guessing.
+    if (signature[0]! >= 0x61 && signature[0]! <= 0x7a) return undefined;
+    offset = extensionEnd;
+  }
+  if (offset !== contentEnd) return undefined;
+  return digest.digest('hex');
+}
+
+function validGitIndexChecksum(index: Uint8Array, contentEnd: number, objectFormat: 'sha1' | 'sha256'): boolean {
+  const expected = bytesToHex(index.subarray(contentEnd));
+  const actual = new Bun.CryptoHasher(objectFormat).update(index.subarray(0, contentEnd)).digest('hex');
+  return actual === expected;
+}
+
+function decodeGitIndexVariableWidthInteger(
+  bytes: Uint8Array,
+  start: number,
+  end: number,
+): {readonly nextOffset: number; readonly value: number} | undefined {
+  let offset = start;
+  if (offset >= end) return undefined;
+  let byte = bytes[offset++]!;
+  let value = byte & 0x7f;
+  while ((byte & 0x80) !== 0) {
+    if (offset >= end || value > Math.floor(Number.MAX_SAFE_INTEGER / 128) - 1) return undefined;
+    byte = bytes[offset++]!;
+    value = (value + 1) * 128 + (byte & 0x7f);
+  }
+  return {nextOffset: offset, value};
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let value = '';
+  for (const byte of bytes) value += byte.toString(16).padStart(2, '0');
+  return value;
+}

--- a/src/code_graph/git_index_semantic.ts
+++ b/src/code_graph/git_index_semantic.ts
@@ -99,10 +99,11 @@ export function codeGraphGitIndexSemanticSha256(
     const extensionBytes = view.getUint32(offset + 4, false);
     const extensionEnd = offset + GIT_INDEX_OPTIONAL_EXTENSION_HEADER_BYTES + extensionBytes;
     if (extensionEnd > contentEnd) return undefined;
-    // Lowercase signatures are required extensions. Split and sparse indexes
-    // change entry interpretation, so this bounded parser deliberately asks
-    // Git for the canonical view instead of guessing.
-    if (signature[0]! >= 0x61 && signature[0]! <= 0x7a) return undefined;
+    // Only uppercase signatures are optional. Lowercase signatures are
+    // required extensions; split and sparse indexes change entry
+    // interpretation. Invalid or required formats deliberately ask Git for
+    // the canonical view instead of guessing.
+    if (signature[0]! < 0x41 || signature[0]! > 0x5a) return undefined;
     offset = extensionEnd;
   }
   if (offset !== contentEnd) return undefined;

--- a/src/code_graph/git_status_cache.ts
+++ b/src/code_graph/git_status_cache.ts
@@ -189,10 +189,13 @@ const observeSourceIndexSemanticSha256 = Effect.fn('codeGraph.observeSourceIndex
   sourceIndex: string,
   expectedIdentity: CodeGraphGitIndexIdentity,
 ) {
-  const direct = yield* fs.readFile(sourceIndex).pipe(
-    Effect.map(bytes => codeGraphGitIndexSemanticSha256(bytes, identity.objectFormat)),
-    Effect.catch(() => Effect.succeed(undefined)),
-  );
+  const direct =
+    expectedIdentity.indexBytes <= SEMANTIC_INDEX_OUTPUT_BYTES_MAXIMUM
+      ? yield* fs.readFile(sourceIndex).pipe(
+          Effect.map(bytes => codeGraphGitIndexSemanticSha256(bytes, identity.objectFormat)),
+          Effect.catch(() => Effect.succeed(undefined)),
+        )
+      : undefined;
   const semanticSha256 =
     direct ??
     sha256HexSync(

--- a/src/code_graph/git_status_cache.ts
+++ b/src/code_graph/git_status_cache.ts
@@ -2,9 +2,10 @@ import {Effect, FileSystem, Option, Path} from 'effect';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {runBinaryCommandEffect, runCommandEffect} from '../effect/command.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
+import {codeGraphGitIndexSemanticSha256} from './git_index_semantic.js';
 import type {RepositoryIdentity} from './types.js';
 
-export const CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION = 2 as const;
+export const CODE_GRAPH_GIT_STATUS_CACHE_RECEIPT_VERSION = 3 as const;
 // Avoid a persistent Git monitor and private-index setup for repositories
 // whose ordinary status scan is already cheaper than cache initialization.
 export const CODE_GRAPH_GIT_STATUS_CACHE_INDEX_BYTES_MINIMUM = 8 * 1_048_576;
@@ -120,7 +121,7 @@ function runCachedStatus(
   return Effect.gen(function* () {
     yield* ensurePrivateCacheDirectory(fs, path, privateHome, cacheRoot);
     const privateIndex = path.join(cacheRoot, 'index');
-    const receiptPath = path.join(cacheRoot, 'receipt-v2.json');
+    const receiptPath = path.join(cacheRoot, 'receipt-v3.json');
     const receipt = yield* readReceipt(fs, receiptPath);
     const privateIndexAvailable = yield* privateRegularFileWithinBound(fs, privateIndex);
     const metadataReusable =
@@ -188,16 +189,24 @@ const observeSourceIndexSemanticSha256 = Effect.fn('codeGraph.observeSourceIndex
   sourceIndex: string,
   expectedIdentity: CodeGraphGitIndexIdentity,
 ) {
-  const stagedEntries = yield* runBinaryCommandEffect(
-    'git',
-    ['--no-optional-locks', '-C', identity.repoRoot, 'ls-files', '--stage', '-v', '-z'],
-    {maxOutputBytes: SEMANTIC_INDEX_OUTPUT_BYTES_MAXIMUM, timeoutMs: 30_000},
+  const direct = yield* fs.readFile(sourceIndex).pipe(
+    Effect.map(bytes => codeGraphGitIndexSemanticSha256(bytes, identity.objectFormat)),
+    Effect.catch(() => Effect.succeed(undefined)),
   );
+  const semanticSha256 =
+    direct ??
+    sha256HexSync(
+      (yield* runBinaryCommandEffect(
+        'git',
+        ['--no-optional-locks', '-C', identity.repoRoot, 'ls-files', '--stage', '-v', '-z'],
+        {maxOutputBytes: SEMANTIC_INDEX_OUTPUT_BYTES_MAXIMUM, timeoutMs: 30_000},
+      )).stdout,
+    );
   const finalIdentity = codeGraphGitIndexIdentity(yield* fs.stat(sourceIndex));
   if (finalIdentity === undefined || !sameCodeGraphGitIndexIdentity(finalIdentity, expectedIdentity)) {
     return yield* Effect.fail(new CodeGraphGitStatusCacheUnavailable('Git index changed during semantic observation.'));
   }
-  return sha256HexSync(stagedEntries.stdout);
+  return semanticSha256;
 });
 
 function initializePrivateIndex(
@@ -339,7 +348,7 @@ function writeReceipt(
   receiptPath: string,
   receipt: CodeGraphGitStatusCacheReceipt,
 ) {
-  const temporary = path.join(path.dirname(receiptPath), '.receipt-v2.tmp');
+  const temporary = path.join(path.dirname(receiptPath), '.receipt-v3.tmp');
   const content = `${JSON.stringify(receipt)}\n`;
   return rejectSymbolicTarget(fs, receiptPath).pipe(
     Effect.andThen(rejectSymbolicTarget(fs, temporary)),

--- a/test/integration/code-graph.git-status-cache.test.ts
+++ b/test/integration/code-graph.git-status-cache.test.ts
@@ -23,13 +23,14 @@ describe('code graph private Git status cache', () => {
       const home = join(root, 'home');
       mkdirSync(gitDirectory, {recursive: true});
       mkdirSync(home, {recursive: true});
-      writeFileSync(sourceIndex, 'source-index-v1');
+      let sourceIndexObjectIdByte = 7;
+      let cacheExtensionBytes = 0;
+      const writeSourceIndex = () =>
+        writeFileSync(sourceIndex, testGitIndex(sourceIndexObjectIdByte, cacheExtensionBytes));
+      writeSourceIndex();
       const identity = repositoryIdentity(repository);
       const base = yield* CommandExecutor;
       const calls: Array<{args: readonly string[]; options?: CommandOptions}> = [];
-      // Distinct invalid UTF-8 bytes would both decode to the replacement
-      // character, so this also guards the raw-byte digest boundary.
-      let sourceIndexSemanticIdentity = Uint8Array.of(0x80);
       const command = CommandExecutor.of({
         ...base,
         execute: (executable, args, options) => {
@@ -41,18 +42,8 @@ describe('code graph private Git status cache', () => {
           if (args.includes('status')) return Effect.succeed(result(' M src/index.ts\0'));
           return Effect.fail(commandFailure(args));
         },
-        executeBytes: (executable, args, options) => {
-          expect(executable).toBe('git');
-          calls.push({args, options});
-          if (args.includes('ls-files')) {
-            return Effect.succeed({
-              exitCode: 0,
-              stderr: '',
-              stdout: sourceIndexSemanticIdentity,
-            });
-          }
-          return Effect.die(new Error(`Unexpected binary command: ${args.join(' ')}`));
-        },
+        executeBytes: (_executable, args) =>
+          Effect.die(new Error(`Direct index semantics unexpectedly fell back to: ${args.join(' ')}`)),
       });
       const observe = () =>
         worktreeStatusWithPrivateCache(identity, home, STATUS_ARGUMENTS, {minimumIndexBytes: 1}).pipe(
@@ -70,18 +61,20 @@ describe('code graph private Git status cache', () => {
       expect(fsmonitorOperations(calls, 'status')).toHaveLength(1);
       assertPrivateStatusCall(calls.at(-1), home);
 
-      writeFileSync(sourceIndex, 'source-index-metadata-refresh');
+      cacheExtensionBytes = 3;
+      writeSourceIndex();
       expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
       expect(calls.filter(call => call.args.includes('update-index'))).toHaveLength(2);
       expect(fsmonitorOperations(calls, 'status')).toHaveLength(1);
 
-      sourceIndexSemanticIdentity = Uint8Array.of(0x81);
-      writeFileSync(sourceIndex, 'source-index-staged-change');
+      sourceIndexObjectIdByte = 8;
+      cacheExtensionBytes = 5;
+      writeSourceIndex();
       expect((yield* observe()).stdout).toBe(' M src/index.ts\0');
       expect(calls.filter(call => call.args.includes('update-index'))).toHaveLength(4);
       expect(fsmonitorOperations(calls, 'status')).toHaveLength(2);
       expect(fsmonitorOperations(calls, 'start')).toHaveLength(0);
-      expect(calls.filter(call => call.args.includes('ls-files'))).toHaveLength(3);
+      expect(calls.filter(call => call.args.includes('ls-files'))).toHaveLength(0);
       assertPrivateStatusCall(calls.at(-1), home);
       expect(
         calls.every(
@@ -281,4 +274,29 @@ function commandFailure(args: readonly string[]) {
     stderr: 'unsupported private index',
     stdout: '',
   });
+}
+
+function testGitIndex(objectIdByte: number, cacheExtensionBytes: number): Uint8Array {
+  const path = new TextEncoder().encode('src/index.ts');
+  const unpaddedEntryBytes = 40 + 20 + 2 + path.byteLength + 1;
+  const entryBytes = Math.ceil(unpaddedEntryBytes / 8) * 8;
+  const extensionBytes = cacheExtensionBytes === 0 ? 0 : 8 + cacheExtensionBytes;
+  const contentBytes = 12 + entryBytes + extensionBytes;
+  const index = new Uint8Array(contentBytes + 20);
+  index.set(new TextEncoder().encode('DIRC'));
+  const view = new DataView(index.buffer);
+  view.setUint32(4, 2, false);
+  view.setUint32(8, 1, false);
+  view.setUint32(12 + 24, 0o100644, false);
+  index.fill(objectIdByte, 12 + 40, 12 + 60);
+  view.setUint16(12 + 60, path.byteLength, false);
+  index.set(path, 12 + 62);
+  if (cacheExtensionBytes > 0) {
+    const extensionOffset = 12 + entryBytes;
+    index.set(new TextEncoder().encode('TREE'), extensionOffset);
+    view.setUint32(extensionOffset + 4, cacheExtensionBytes, false);
+    index.fill(0x41, extensionOffset + 8, extensionOffset + 8 + cacheExtensionBytes);
+  }
+  index.set(new Bun.CryptoHasher('sha1').update(index.subarray(0, contentBytes)).digest(), contentBytes);
+  return index;
 }

--- a/test/unit/code-graph.git-index-semantic.property.test.ts
+++ b/test/unit/code-graph.git-index-semantic.property.test.ts
@@ -67,6 +67,9 @@ describe('Git index semantic fingerprint', () => {
     expect(
       codeGraphGitIndexSemanticSha256(buildGitIndex(2, base, {data: Uint8Array.of(1), signature: 'link'}), 'sha1'),
     ).toBeUndefined();
+    expect(
+      codeGraphGitIndexSemanticSha256(buildGitIndex(2, base, {data: Uint8Array.of(1), signature: '1BAD'}), 'sha1'),
+    ).toBeUndefined();
 
     const corrupt = plain.slice();
     corrupt[12] = corrupt[12]! ^ 1;

--- a/test/unit/code-graph.git-index-semantic.property.test.ts
+++ b/test/unit/code-graph.git-index-semantic.property.test.ts
@@ -1,0 +1,178 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {codeGraphGitIndexSemanticSha256} from '../../src/code_graph/git_index_semantic.js';
+
+const SHA1_BYTES = 20;
+const REGULAR_FILE_MODE = 0o100644;
+
+describe('Git index semantic fingerprint', () => {
+  it('is invariant to arbitrary stat-cache fields while retaining staged semantics', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.integer({max: 0xffff_ffff, min: 0}), {maxLength: 9, minLength: 9}),
+        fc.array(fc.integer({max: 0xffff_ffff, min: 0}), {maxLength: 9, minLength: 9}),
+        fc.uint8Array({maxLength: SHA1_BYTES, minLength: SHA1_BYTES}),
+        fc.array(fc.integer({max: 255, min: 1}), {maxLength: 48, minLength: 1}),
+        fc.boolean(),
+        fc.integer({max: 3, min: 0}),
+        (firstStat, secondStat, objectId, pathValues, assumeValid, stage) => {
+          const path = Uint8Array.from(pathValues);
+          const semanticFlags = (assumeValid ? 0x8000 : 0) | (stage << 12);
+          const first = buildGitIndex(2, [entry(firstStat, objectId, path, semanticFlags)]);
+          const second = buildGitIndex(2, [entry(secondStat, objectId, path, semanticFlags)]);
+          expect(codeGraphGitIndexSemanticSha256(first, 'sha1')).toBe(codeGraphGitIndexSemanticSha256(second, 'sha1'));
+
+          const changedObjectId = objectId.slice();
+          changedObjectId[0] = changedObjectId[0]! ^ 1;
+          const changed = buildGitIndex(2, [entry(firstStat, changedObjectId, path, semanticFlags)]);
+          expect(codeGraphGitIndexSemanticSha256(changed, 'sha1')).not.toBe(
+            codeGraphGitIndexSemanticSha256(first, 'sha1'),
+          );
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it('preserves raw path bytes, extended flags, and v4 prefix-compressed paths', () => {
+    const stat = Array.from({length: 9}, () => 0);
+    const objectId = Uint8Array.from({length: SHA1_BYTES}, (_, index) => index);
+    const invalidUtf8A = buildGitIndex(2, [entry(stat, objectId, Uint8Array.of(0x80), 0)]);
+    const invalidUtf8B = buildGitIndex(2, [entry(stat, objectId, Uint8Array.of(0x81), 0)]);
+    expect(codeGraphGitIndexSemanticSha256(invalidUtf8A, 'sha1')).not.toBe(
+      codeGraphGitIndexSemanticSha256(invalidUtf8B, 'sha1'),
+    );
+
+    const ordinary = buildGitIndex(3, [entry(stat, objectId, new TextEncoder().encode('src/index.ts'), 0)]);
+    const skipWorktree = buildGitIndex(3, [entry(stat, objectId, new TextEncoder().encode('src/index.ts'), 0, 0x4000)]);
+    expect(codeGraphGitIndexSemanticSha256(ordinary, 'sha1')).not.toBe(
+      codeGraphGitIndexSemanticSha256(skipWorktree, 'sha1'),
+    );
+
+    const v4 = buildGitIndex(4, [
+      entry(stat, objectId, new TextEncoder().encode('src/a.ts'), 0),
+      entry(stat, objectId, new TextEncoder().encode('src/b.ts'), 0),
+      entry(stat, objectId, new TextEncoder().encode(`other/${'x'.repeat(180)}.ts`), 0),
+    ]);
+    expect(codeGraphGitIndexSemanticSha256(v4, 'sha1')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('ignores optional cache extensions and rejects required or corrupt input', () => {
+    const stat = Array.from({length: 9}, () => 0);
+    const objectId = new Uint8Array(SHA1_BYTES).fill(7);
+    const base = [entry(stat, objectId, new TextEncoder().encode('src/index.ts'), 0)] as const;
+    const plain = buildGitIndex(2, base);
+    const cached = buildGitIndex(2, base, {data: Uint8Array.of(1, 2, 3), signature: 'TREE'});
+    expect(codeGraphGitIndexSemanticSha256(cached, 'sha1')).toBe(codeGraphGitIndexSemanticSha256(plain, 'sha1'));
+    expect(
+      codeGraphGitIndexSemanticSha256(buildGitIndex(2, base, {data: Uint8Array.of(1), signature: 'link'}), 'sha1'),
+    ).toBeUndefined();
+
+    const corrupt = plain.slice();
+    corrupt[12] = corrupt[12]! ^ 1;
+    expect(codeGraphGitIndexSemanticSha256(corrupt, 'sha1')).toBeUndefined();
+  });
+});
+
+interface TestEntry {
+  readonly extendedFlags: number;
+  readonly flags: number;
+  readonly mode: number;
+  readonly objectId: Uint8Array;
+  readonly path: Uint8Array;
+  readonly stat: readonly number[];
+}
+
+function entry(
+  stat: readonly number[],
+  objectId: Uint8Array,
+  path: Uint8Array,
+  flags: number,
+  extendedFlags = 0,
+): TestEntry {
+  return {extendedFlags, flags, mode: REGULAR_FILE_MODE, objectId, path, stat};
+}
+
+function buildGitIndex(
+  version: 2 | 3 | 4,
+  entries: readonly TestEntry[],
+  extension?: {readonly data: Uint8Array; readonly signature: string},
+): Uint8Array {
+  const encodedEntries: Uint8Array[] = [];
+  let previousPath: Uint8Array<ArrayBufferLike> = new Uint8Array();
+  for (const current of entries) {
+    const hasExtendedFlags = current.extendedFlags !== 0;
+    const fixedBytes = 40 + SHA1_BYTES + 2 + (hasExtendedFlags ? 2 : 0);
+    let pathPrefix: Uint8Array<ArrayBufferLike> = new Uint8Array();
+    let pathSuffix = current.path;
+    if (version === 4) {
+      let common = 0;
+      while (
+        common < previousPath.byteLength &&
+        common < current.path.byteLength &&
+        previousPath[common] === current.path[common]
+      ) {
+        common += 1;
+      }
+      const removed = previousPath.byteLength - common;
+      pathPrefix = encodeGitIndexVariableWidthInteger(removed);
+      pathSuffix = current.path.subarray(common);
+    }
+    const unpaddedBytes = fixedBytes + pathPrefix.byteLength + pathSuffix.byteLength + 1;
+    const entryBytes = version === 4 ? unpaddedBytes : Math.ceil(unpaddedBytes / 8) * 8;
+    const encoded = new Uint8Array(entryBytes);
+    const view = new DataView(encoded.buffer);
+    const statOffsets = [0, 4, 8, 12, 16, 20, 28, 32, 36] as const;
+    statOffsets.forEach((offset, index) => view.setUint32(offset, current.stat[index] ?? 0, false));
+    view.setUint32(24, current.mode, false);
+    encoded.set(current.objectId, 40);
+    let offset = 40 + SHA1_BYTES;
+    view.setUint16(
+      offset,
+      current.flags | (hasExtendedFlags ? 0x4000 : 0) | Math.min(current.path.byteLength, 0x0fff),
+      false,
+    );
+    offset += 2;
+    if (hasExtendedFlags) {
+      view.setUint16(offset, current.extendedFlags, false);
+      offset += 2;
+    }
+    encoded.set(pathPrefix, offset);
+    offset += pathPrefix.byteLength;
+    encoded.set(pathSuffix, offset);
+    encodedEntries.push(encoded);
+    previousPath = current.path;
+  }
+
+  const extensionBytes = extension === undefined ? 0 : 8 + extension.data.byteLength;
+  const contentBytes = 12 + encodedEntries.reduce((sum, value) => sum + value.byteLength, 0) + extensionBytes;
+  const index = new Uint8Array(contentBytes + SHA1_BYTES);
+  index.set(new TextEncoder().encode('DIRC'));
+  const view = new DataView(index.buffer);
+  view.setUint32(4, version, false);
+  view.setUint32(8, entries.length, false);
+  let offset = 12;
+  for (const encoded of encodedEntries) {
+    index.set(encoded, offset);
+    offset += encoded.byteLength;
+  }
+  if (extension !== undefined) {
+    index.set(new TextEncoder().encode(extension.signature), offset);
+    view.setUint32(offset + 4, extension.data.byteLength, false);
+    index.set(extension.data, offset + 8);
+  }
+  index.set(new Bun.CryptoHasher('sha1').update(index.subarray(0, contentBytes)).digest(), contentBytes);
+  return index;
+}
+
+function encodeGitIndexVariableWidthInteger(value: number): Uint8Array {
+  const encoded = [value & 0x7f];
+  let remaining = Math.floor(value / 128);
+  while (remaining > 0) {
+    remaining -= 1;
+    encoded.push(0x80 | (remaining & 0x7f));
+    remaining = Math.floor(remaining / 128);
+  }
+  encoded.reverse();
+  return Uint8Array.from(encoded);
+}


### PR DESCRIPTION
## Summary

- replace the repository-wide `git ls-files --stage -v -z` semantic fallback with a bounded direct Git-index fingerprint
- ignore only mutable stat-cache fields and optional cache extensions while retaining mode, object ID, stage, relevant index flags, and raw path bytes
- verify the Git index checksum and fail closed to Git for malformed input, split/sparse indexes, or unknown required extensions
- bump the private-status receipt so older semantic digests cannot be mixed with the new contract

## Why

The exact v4.3.6 IntelliJ release run passed cold indexing, total one-file indexing, post-scan work, proportionality, parity, and every correctness control, but registration measured 5.178 s against the strict 5.000 s gate.

Component isolation on the pinned 45.9 MB / 278,115-entry IntelliJ Git index found that metadata churn sent admission through a repository-wide `ls-files` observation plus a pure-JavaScript digest. Under the same warmed-index churn control, v4.3.6 took 1.430 s and this candidate took 440 ms; an unchanged warm observation was about 120 ms. The direct semantic fingerprint itself parses, checksum-verifies, and hashes the real index in 154 ms. This removes substantially more than the exact release's 178 ms miss without changing the measured phase boundary.

[Git documents index formats 2, 3, and 4](https://git-scm.com/docs/gitformat-index) as a checksummed header, sorted entries, and extensions. Entry stat fields are explicitly cache data, while mode, object ID, stage, flags, and path define staged semantics. Optional uppercase extensions may be ignored; required lowercase extensions must be understood. This implementation follows that boundary and delegates unsupported required formats back to Git.

## Verification

- focused Vitest: 14/14
- Fast-check: arbitrary stat-cache rewrites preserve the digest; staged object changes alter it
- real Git probes: v4 prefix-compressed SHA-1 and SHA-256 indexes accepted; staged changes alter the digest; split index fails closed
- exact IntelliJ component probe: v4.3.6 metadata-churn observation 1,430.342 ms; candidate 440.104 ms; direct fingerprint 153.720 ms
- TypeScript source/test/site typechecks
- strict lint and file-length policy
- repository-wide Prettier check
- governed reduced production profile: green at GitHub merge ref `b9b458e`; its tree `55060f0` is byte-identical to current head `6bcf786`
- provisional local reduced profile at predecessor `e26df5d`: 1,430.455 ms one-file total, including 359.441 ms registration; retained as non-authoritative because the branch advanced before completion
- exact-head global install and pinned IntelliJ status smoke: green; two identical status envelopes completed in 4.92 s and 4.58 s end to end

## Runtime contract

- Bun-native only; no Node-library imports
- no anonymous telemetry expansion
- no relaxed private-index size, symlink, checksum, or source-identity bounds
- direct semantic reads are capped at 128 MiB; larger indexes retain the canonical Git fallback
- unsupported or racy evidence retains the existing canonical Git fallback

Closes the residual registration implementation blocker in #203; the issue itself remains open until one exact tagged IntelliJ run passes every release gate.
