### PR TITLE
chore(release): prepare 4.3.7

### DIFF
--- a/.github/release-notes/v4.3.7.md
+++ b/.github/release-notes/v4.3.7.md
@@ -1,0 +1,35 @@
+## What's new
+
+Threadnote 4.3.7 bounds the remaining large-repository registration work in native code-graph indexing.
+
+### Code-graph registration
+
+- Replaces a repository-wide `git ls-files --stage -v -z` semantic fallback with a bounded, checksummed Git-index
+  fingerprint for ordinary index formats 2, 3, and 4.
+- Ignores only documented stat-cache fields and optional cache extensions while preserving mode, object ID, merge
+  stage, relevant index flags, and raw path bytes.
+- Fails closed to Git's canonical observation for malformed input, split or sparse indexes, unknown required
+  extensions, source-index races, or unsupported evidence.
+- Keeps Threadnote's Bun runtime free of Node-library imports.
+
+### Evidence discipline
+
+The preceding exact v4.3.6 IntelliJ observation passed cold indexing, total one-file indexing, post-scan work,
+proportionality, parity, transaction bounds, polyglot controls, and all failure controls, but registration measured
+5.178 seconds against the strict 5.000-second gate. That artifact remains retained; it was not rerun unchanged.
+
+On the same pinned 45.9 MB / 278,115-entry Git index, the direct semantic fingerprint took 153.720 milliseconds. Under
+a controlled metadata-only source-index rewrite, the complete v4.3.6 observation took 1,430.342 milliseconds and the
+corrected candidate took 440.104 milliseconds.
+
+The tree-identical optimization PR merge ref passed the governed reduced production ratchet and the 10k and 100k
+lexical benchmark checks. The ratchet keeps independent timing, storage, correctness, graph-shape, proportional-work,
+and failure controls so a win in one metric cannot hide a regression in another.
+
+The exact v4.3.7 IntelliJ release-scale observation will be retained separately after publication.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone release version to 4.3.7
- publish release notes for bounded Git-index semantic admission
- preserve the exact v4.3.6 registration miss and the evidence discipline used for the correction

## Verification

- focused release workflow, package contract, and website release-boundary tests: 21 passed
- commit hook: strict lint, repository-wide Prettier, source/test/site typechecks
- property-test assessment: release metadata and static copy have no meaningful generated input space; existing release contract tests cover the versioned-note invariant
- full suite delegated to PR CI

## Retained CI observation

The metadata-only release PR preserved a governed-ratchet failure rather than rerunning it: cold registration measured
7,929.609 ms against the hosted envelope, while process CPU was 399.110 ms, the phase wrote the same bounded 2.1 MB,
and one-file registration passed at 555.967 ms. The byte-identical product tree had passed at 919.334 ms immediately
before this PR on a different Azure CPU class. Artifact SHA-256:
`fc79c1b41a50a335dab179f29ae296f917ada0df6459043774ba740bdbff8e57`.

No benchmark rerun is planned. PR #229 makes strictly version-and-release-note-only PRs reuse the already-green
product-tree evidence while continuing to run the ratchet for dependency, runtime, harness, workflow, or baseline
changes. This PR remains blocked until #229 is merged and this branch is rebased onto that classifier.
