### PR TITLE
ci: skip graph ratchet for strict release metadata

### DIFF
--- a/.github/workflows/code-graph-production-ratchet.yml
+++ b/.github/workflows/code-graph-production-ratchet.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/code-graph-benchmark-sampler.ts'
       - 'scripts/code-graph-fixture.ts'
       - 'scripts/generate-code-graph-language-catalog.ts'
+      - 'test/ci/code-graph-production-ratchet-scope.ts'
       - 'src/code_graph/**'
       - 'src/crypto/**'
       - 'src/effect/command.ts'
@@ -30,6 +31,7 @@ on:
       - 'src/worker_protocol.ts'
       - 'test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json'
       - 'test/evaluation/fixtures/code-graph-v1/**'
+      - 'test/unit/code-graph.production-ratchet-scope.property.test.ts'
 
 permissions:
   contents: read
@@ -42,21 +44,53 @@ env:
   BUN_VERSION: 1.3.14
 
 jobs:
-  ratchet:
-    name: Governed reduced production profile · Linux
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+  classify:
+    name: Classify production ratchet scope
+    runs-on: ubuntu-latest
+    outputs:
+      release_metadata_only: ${{ steps.scope.outputs.release_metadata_only }}
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - id: scope
+        name: Skip only a strict release-metadata diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bun test/ci/code-graph-production-ratchet-scope.ts --base "$BASE_SHA" --head "$HEAD_SHA"
+
+  ratchet:
+    name: Governed reduced production profile · Linux
+    needs: classify
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Record strict release-metadata skip
+        if: needs.classify.result == 'success' && needs.classify.outputs.release_metadata_only == 'true'
+        run: echo 'Governed benchmark skipped because only the top-level package version and release notes changed.'
+
+      - uses: actions/checkout@v7
+        if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
+
+      - uses: oven-sh/setup-bun@v2
+        if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
       - run: bun install --frozen-lockfile
+        if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
 
       - name: Gate the governed reduced production profile
+        if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
         env:
           THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-ubuntu-24.04-${{ runner.arch }}
           THREADNOTE_BENCHMARK_RUNNER_ID: ${{ runner.name }}
@@ -74,7 +108,9 @@ jobs:
           --output artifacts/code-graph-production-ratchet-Linux-${{ runner.arch }}.json
 
       - uses: actions/upload-artifact@v7
-        if: always()
+        if: >-
+          always() &&
+          (needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true')
         with:
           name: code-graph-production-ratchet-Linux-${{ runner.arch }}
           path: artifacts/

--- a/test/ci/code-graph-production-ratchet-scope.ts
+++ b/test/ci/code-graph-production-ratchet-scope.ts
@@ -1,0 +1,179 @@
+export interface CodeGraphProductionRatchetDiff {
+  readonly afterPackageJson?: string;
+  readonly beforePackageJson?: string;
+  readonly changedPaths: Iterable<string>;
+}
+
+export interface CodeGraphProductionRatchetScope {
+  readonly changedCount: number;
+  readonly paths: readonly string[];
+  readonly releaseMetadataOnly: boolean;
+}
+
+type JsonObject = Readonly<Record<string, unknown>>;
+
+function normalizeGitPath(path: string): string | undefined {
+  if (
+    path.length === 0 ||
+    path.startsWith('/') ||
+    path.includes('\\') ||
+    path.includes('\0') ||
+    path.split('/').some(segment => segment === '' || segment === '.' || segment === '..')
+  ) {
+    return undefined;
+  }
+  return path;
+}
+
+function isReleaseNotePath(path: string): boolean {
+  return /^\.github\/release-notes\/v[^/\n\r]+\.md$/u.test(path);
+}
+
+function parseJsonObject(source: string | undefined): JsonObject | undefined {
+  if (source === undefined) return undefined;
+  try {
+    const value: unknown = JSON.parse(source);
+    return value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as JsonObject) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => jsonValuesEqual(value, right[index]))
+    );
+  }
+  if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') return false;
+
+  const leftObject = left as JsonObject;
+  const rightObject = right as JsonObject;
+  const leftKeys = Object.keys(leftObject).sort();
+  const rightKeys = Object.keys(rightObject).sort();
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key, index) => key === rightKeys[index] && jsonValuesEqual(leftObject[key], rightObject[key]))
+  );
+}
+
+function changesOnlyTopLevelVersion(beforeSource: string | undefined, afterSource: string | undefined): boolean {
+  const before = parseJsonObject(beforeSource);
+  const after = parseJsonObject(afterSource);
+  if (!before || !after) return false;
+  if (typeof before.version !== 'string' || typeof after.version !== 'string' || before.version === after.version) {
+    return false;
+  }
+
+  const beforeKeys = Object.keys(before)
+    .filter(key => key !== 'version')
+    .sort();
+  const afterKeys = Object.keys(after)
+    .filter(key => key !== 'version')
+    .sort();
+  return (
+    beforeKeys.length === afterKeys.length &&
+    beforeKeys.every((key, index) => key === afterKeys[index] && jsonValuesEqual(before[key], after[key]))
+  );
+}
+
+export function classifyCodeGraphProductionRatchetScope(
+  diff: CodeGraphProductionRatchetDiff,
+): CodeGraphProductionRatchetScope {
+  const paths = new Set<string>();
+  let invalidPath = false;
+  for (const path of diff.changedPaths) {
+    const normalized = normalizeGitPath(path);
+    if (normalized) paths.add(normalized);
+    else invalidPath = true;
+  }
+
+  const sortedPaths = [...paths].sort();
+  const packageChanged = paths.has('package.json');
+  const pathsAreReleaseMetadata = sortedPaths.every(path => path === 'package.json' || isReleaseNotePath(path));
+  const releaseMetadataOnly =
+    !invalidPath &&
+    sortedPaths.length > 0 &&
+    packageChanged &&
+    pathsAreReleaseMetadata &&
+    changesOnlyTopLevelVersion(diff.beforePackageJson, diff.afterPackageJson);
+
+  return {changedCount: sortedPaths.length, paths: sortedPaths, releaseMetadataOnly};
+}
+
+function commitArgument(name: '--base' | '--head'): string | undefined {
+  const index = Bun.argv.indexOf(name);
+  return index === -1 ? undefined : Bun.argv[index + 1];
+}
+
+function isCommitId(value: string | undefined): value is string {
+  return Boolean(value && /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/iu.test(value) && !/^0+$/u.test(value));
+}
+
+function runGit(arguments_: readonly string[]): {readonly exitCode: number; readonly stdout: Uint8Array} {
+  const result = Bun.spawnSync({cmd: ['git', ...arguments_], stderr: 'pipe', stdout: 'pipe'});
+  return {exitCode: result.exitCode, stdout: result.stdout};
+}
+
+function readGitFile(commit: string, path: string): string | undefined {
+  const result = runGit(['show', `${commit}:${path}`]);
+  return result.exitCode === 0 ? new TextDecoder().decode(result.stdout) : undefined;
+}
+
+function classifyCurrentDiff(
+  base: string | undefined,
+  head: string | undefined,
+): {
+  readonly reason: string;
+  readonly scope: CodeGraphProductionRatchetScope;
+} {
+  const failSafe = (reason: string): {readonly reason: string; readonly scope: CodeGraphProductionRatchetScope} => ({
+    reason,
+    scope: classifyCodeGraphProductionRatchetScope({changedPaths: []}),
+  });
+  if (!isCommitId(base) || !isCommitId(head)) return failSafe('missing-or-invalid-commit-range');
+
+  const mergeBaseResult = runGit(['merge-base', base, head]);
+  const mergeBase = new TextDecoder().decode(mergeBaseResult.stdout).trim();
+  if (mergeBaseResult.exitCode !== 0 || !isCommitId(mergeBase)) return failSafe('git-merge-base-failed');
+
+  const diffResult = runGit(['diff', '--name-only', '--no-renames', '-z', `${mergeBase}..${head}`, '--']);
+  if (diffResult.exitCode !== 0) return failSafe(`git-diff-failed-${diffResult.exitCode}`);
+  const changedPaths = new TextDecoder().decode(diffResult.stdout).split('\0').filter(Boolean);
+  const scope = classifyCodeGraphProductionRatchetScope({
+    afterPackageJson: readGitFile(head, 'package.json'),
+    beforePackageJson: readGitFile(mergeBase, 'package.json'),
+    changedPaths,
+  });
+  return {
+    reason: scope.releaseMetadataOnly ? 'release-metadata-only' : 'ratchet-relevant-or-ambiguous-diff',
+    scope,
+  };
+}
+
+async function writeGitHubOutput(scope: CodeGraphProductionRatchetScope, reason: string): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    await Bun.write(
+      outputPath,
+      `release_metadata_only=${String(scope.releaseMetadataOnly)}\nchanged_count=${scope.changedCount}\nreason=${reason}\n`,
+    );
+  }
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    await Bun.write(
+      summaryPath,
+      `### Code graph production ratchet scope\n\n- Changed paths: ${scope.changedCount}\n- Reason: \`${reason}\`\n- Run benchmark: ${scope.releaseMetadataOnly ? 'no' : 'yes'}\n`,
+    );
+  }
+}
+
+if (import.meta.main) {
+  const {reason, scope} = classifyCurrentDiff(commitArgument('--base'), commitArgument('--head'));
+  await writeGitHubOutput(scope, reason);
+  process.stdout.write(`${JSON.stringify({reason, ...scope})}\n`);
+}

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -6,6 +6,7 @@ interface WorkflowJob {
   readonly env?: Readonly<Record<string, string>>;
   readonly if?: string;
   readonly needs?: string | readonly string[];
+  readonly outputs?: Readonly<Record<string, string>>;
   readonly permissions?: Readonly<Record<string, string>>;
   readonly 'runs-on'?: string;
   readonly steps?: readonly {
@@ -132,6 +133,7 @@ describe('platform benchmark workflow', () => {
       schema: JSON_SCHEMA,
     }) as BenchmarkWorkflow;
     const paths = ratchetWorkflow.on.pull_request?.paths ?? [];
+    const classifier = ratchetWorkflow.jobs.classify!;
     const job = ratchetWorkflow.jobs.ratchet!;
     const command = job.steps?.flatMap(step => (step.run ? [step.run] : [])).join('\n') ?? '';
 
@@ -139,6 +141,7 @@ describe('platform benchmark workflow', () => {
       expect.arrayContaining([
         '.github/workflows/code-graph-production-ratchet.yml',
         'scripts/benchmark-code-graph.ts',
+        'test/ci/code-graph-production-ratchet-scope.ts',
         'src/code_graph/**',
         'src/effect/errors.ts',
         'src/effect/file_durability.ts',
@@ -148,12 +151,36 @@ describe('platform benchmark workflow', () => {
         'src/utils.ts',
         'src/worker_protocol.ts',
         'test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json',
+        'test/unit/code-graph.production-ratchet-scope.property.test.ts',
       ]),
     );
     expect(paths).not.toContain('src/recall/**');
     expect(paths.join('\n').toLowerCase()).not.toContain('intellij');
     expect(job['runs-on']).toBe('ubuntu-24.04');
     expect(job['timeout-minutes']).toBe(15);
+    expect(job.needs).toBe('classify');
+    expect(job.if).toBe('always()');
+    expect(classifier.outputs?.release_metadata_only).toBe('${{ steps.scope.outputs.release_metadata_only }}');
+    expect(classifier.steps?.find(step => step.id === 'scope')).toMatchObject({
+      name: 'Skip only a strict release-metadata diff',
+      run: 'bun test/ci/code-graph-production-ratchet-scope.ts --base "$BASE_SHA" --head "$HEAD_SHA"',
+    });
+    const guardedSteps = job.steps?.filter(
+      step =>
+        step.uses === 'actions/checkout@v7' ||
+        step.uses === 'oven-sh/setup-bun@v2' ||
+        step.run === 'bun install --frozen-lockfile' ||
+        step.name === 'Gate the governed reduced production profile',
+    );
+    expect(guardedSteps).toHaveLength(4);
+    for (const step of guardedSteps ?? []) {
+      expect(step.if).toBe(
+        "needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'",
+      );
+    }
+    expect(job.steps?.find(step => step.uses === 'actions/upload-artifact@v7')?.if).toContain(
+      "needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'",
+    );
     expect(command.match(/--samples 1/g)).toHaveLength(1);
     expect(command).toContain('--profile production-large');
     expect(command).toContain('--profile-files 3000');

--- a/test/unit/code-graph.production-ratchet-scope.property.test.ts
+++ b/test/unit/code-graph.production-ratchet-scope.property.test.ts
@@ -1,0 +1,126 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {classifyCodeGraphProductionRatchetScope} from '../ci/code-graph-production-ratchet-scope.js';
+
+const baseManifest = {
+  dependencies: {effect: '4.0.0-beta.102'},
+  name: 'threadnote',
+  scripts: {test: 'vitest run'},
+  version: '4.3.6',
+};
+
+function manifest(version: string, overrides: Readonly<Record<string, unknown>> = {}): string {
+  return JSON.stringify({...baseManifest, ...overrides, version});
+}
+
+function isReleaseOnly(
+  changedPaths: readonly string[],
+  before = manifest('4.3.6'),
+  after = manifest('4.3.7'),
+): boolean {
+  return classifyCodeGraphProductionRatchetScope({
+    afterPackageJson: after,
+    beforePackageJson: before,
+    changedPaths,
+  }).releaseMetadataOnly;
+}
+
+describe('code graph production ratchet diff scope', () => {
+  it('skips a version-only release diff with release notes', () => {
+    expect(isReleaseOnly(['package.json', '.github/release-notes/v4.3.7.md'])).toBe(true);
+    expect(isReleaseOnly(['package.json'])).toBe(true);
+  });
+
+  it('runs for dependency, script, source, workflow, baseline, lockfile, and ambiguous changes', () => {
+    expect(
+      isReleaseOnly(
+        ['package.json', '.github/release-notes/v4.3.7.md'],
+        manifest('4.3.6'),
+        manifest('4.3.7', {dependencies: {effect: '4.0.0-rc.1'}}),
+      ),
+    ).toBe(false);
+    expect(
+      isReleaseOnly(['package.json'], manifest('4.3.6'), manifest('4.3.7', {scripts: {test: 'vitest run --changed'}})),
+    ).toBe(false);
+
+    for (const path of [
+      'src/code_graph/index.ts',
+      '.github/workflows/code-graph-production-ratchet.yml',
+      'test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json',
+      'bun.lock',
+      '.github/release-notes/../workflows/publish.yml',
+      '.github/release-notes/archive/v4.3.7.md',
+      '.github/release-notes/v4.3.7.txt',
+      '.github/release-notes/notes.md',
+    ]) {
+      expect(isReleaseOnly(['package.json', '.github/release-notes/v4.3.7.md', path])).toBe(false);
+    }
+    expect(isReleaseOnly(['.github/release-notes/v4.3.7.md'])).toBe(false);
+    expect(isReleaseOnly([])).toBe(false);
+    expect(isReleaseOnly(['package.json'], '{', manifest('4.3.7'))).toBe(false);
+    expect(isReleaseOnly(['package.json'], manifest('4.3.7'), manifest('4.3.7'))).toBe(false);
+  });
+
+  it('compares package objects semantically while preserving nested and array ordering', () => {
+    const reordered = JSON.stringify({
+      version: '4.3.7',
+      scripts: baseManifest.scripts,
+      name: baseManifest.name,
+      dependencies: baseManifest.dependencies,
+    });
+    expect(isReleaseOnly(['package.json'], manifest('4.3.6'), reordered)).toBe(true);
+    expect(
+      isReleaseOnly(
+        ['package.json'],
+        JSON.stringify({...baseManifest, files: ['dist', 'assets']}),
+        JSON.stringify({...baseManifest, files: ['assets', 'dist'], version: '4.3.7'}),
+      ),
+    ).toBe(false);
+  });
+
+  it('is invariant to release-note order and duplicate paths', () => {
+    fc.assert(
+      fc.property(fc.array(fc.stringMatching(/^[a-z0-9][a-z0-9.-]{0,24}$/u), {maxLength: 12}), versions => {
+        const paths = ['package.json', ...versions.map(version => `.github/release-notes/v${version}.md`)];
+        expect(isReleaseOnly(paths)).toBe(true);
+        expect(isReleaseOnly([...paths].reverse())).toBe(true);
+        expect(isReleaseOnly([...paths, ...paths])).toBe(true);
+      }),
+      {numRuns: 200},
+    );
+  });
+
+  it('never skips after adding a path outside the release-note directory', () => {
+    const repositoryPath = fc
+      .tuple(
+        fc.constantFrom('src', 'scripts', 'test', '.github/workflows', 'website'),
+        fc.stringMatching(/^[a-z][a-z0-9_-]{0,20}$/u),
+      )
+      .map(([directory, name]) => `${directory}/${name}.ts`);
+
+    fc.assert(
+      fc.property(repositoryPath, path => {
+        expect(isReleaseOnly(['package.json', '.github/release-notes/v4.3.7.md', path])).toBe(false);
+      }),
+      {numRuns: 200},
+    );
+  });
+
+  it('never skips when any non-version package field changes', () => {
+    const field = fc
+      .stringMatching(/^[a-z][a-z0-9_-]{0,16}$/u)
+      .filter(value => value !== 'name' && value !== 'version');
+    const changedValues = fc
+      .tuple(fc.jsonValue(), fc.jsonValue())
+      .filter(([before, after]) => JSON.stringify(before) !== JSON.stringify(after));
+
+    fc.assert(
+      fc.property(field, changedValues, (key, [beforeValue, afterValue]) => {
+        const before = JSON.stringify({...baseManifest, [key]: beforeValue});
+        const after = JSON.stringify({...baseManifest, [key]: afterValue, version: '4.3.7'});
+        expect(isReleaseOnly(['package.json', '.github/release-notes/v4.3.7.md'], before, after)).toBe(false);
+      }),
+      {numRuns: 200},
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- classify pull-request diffs before the governed code-graph production ratchet
- skip the expensive benchmark only when package.json changes solely in its top-level version and every other path is a flat versioned Markdown release note
- fail closed for invalid commit ranges, Git failures, malformed manifests, nested notes, dependencies, scripts, source, workflows, baselines, lockfiles, or any other path
- keep the existing governed-ratchet job present; if classification fails or is ambiguous, its expensive steps still run

## Preserved evidence

PR #228 is a strict release-metadata diff, but its hosted ratchet ran and failed cold registration wall time at 7929.609 ms while process CPU was only 399.11 ms. The previous product tree passed at 919.334 ms, and one-file registration in the failed run passed at 555.967 ms. That result remains preserved as hosted-runner evidence; no benchmark was manually rerun for this classifier fix.

The classifier reproduces PR #228 as release-metadata-only from its exact base and head commits. It classifies this PR itself as ratchet-relevant because the workflow and classifier contract change, so the new skip cannot conceal its own changes.

## Verification

- focused Vitest: 13/13 passing
- bounded Fast-check properties: release-note order/duplicate invariance, arbitrary non-release path fail-closed behavior, and arbitrary non-version manifest mutation rejection (200 runs each)
- full lint, Prettier, and TypeScript checks passing
- git diff checks passing

No runtime/product behavior changed, so a global Threadnote reinstall is not required.
