### PR TITLE
perf(code-graph): compact sparse admission receipts

### DIFF
--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -7174,6 +7174,12 @@ function productionMeasurementRatchet(
     // is lower-bounded; the separately ratcheted failure counters remain zero.
     return {...base, minimum: 1};
   }
+  if (productionNonIncreasingWorkMeasurement(name, unit)) {
+    // These counters measure the bounded work needed for the same parity-
+    // checked one-file result. Less work is an improvement; retain the
+    // observed ceiling without freezing a lower bound that would reject it.
+    return {...base, maximum};
+  }
   if (productionDeterministicMeasurement(name, unit)) {
     if (minimum !== maximum) {
       throw new ScriptError(
@@ -7222,6 +7228,15 @@ function productionMeasurementRatchet(
   }
   if (unit === 'percent') return {...base, minimum};
   return {...base, maximum: Math.ceil(maximum * (1 + PRODUCTION_RATCHET_RELATIVE_HEADROOM))};
+}
+
+function productionNonIncreasingWorkMeasurement(name: string, unit: BenchmarkMeasurementUnit): boolean {
+  return (
+    unit === 'count' &&
+    /^one-file-reindex-incremental-work-(?:attribution-context-files|base-facts-loaded|inventory-files-inspected|planned-rows|probed-dependency-paths)-n1$/u.test(
+      name,
+    )
+  );
 }
 
 function productionCoverageMeasurement(name: string, unit: BenchmarkMeasurementUnit): boolean {

--- a/src/code_graph/extractor.ts
+++ b/src/code_graph/extractor.ts
@@ -71,7 +71,7 @@ interface ResolutionAliasScope {
   readonly root: string;
 }
 
-interface ResolutionAliasIndex {
+export interface ResolutionAliasIndex {
   readonly observer: CodeGraphResolutionObserver;
   readonly scopeBySourcePath: Map<string, ResolutionAliasScope | undefined>;
   readonly scopes: readonly ResolutionAliasScope[];
@@ -160,13 +160,13 @@ export function createResolutionAttributorFromIndex(
   files: readonly CodeGraphInventoryFile[],
   packages: PackageIndex,
   existingPaths: ReadonlySet<string> = new Set(files.map(file => file.path)),
+  aliases: ResolutionAliasIndex = discoverResolutionAliases(files, {}),
 ): (facts: readonly CodeGraphFileFacts[]) => readonly CodeGraphFileFacts[] {
   const packageNameCounts = new Map<string, number>();
   for (const candidate of packages.all) {
     packageNameCounts.set(candidate.name, (packageNameCounts.get(candidate.name) ?? 0) + 1);
   }
   const duplicatePackages = new Set([...packageNameCounts].filter(([, count]) => count > 1).map(([name]) => name));
-  const aliases = discoverResolutionAliases(files, {});
   const resolutionCache: ResolutionCache = {importedSymbols: new Map(), modulePaths: new Map()};
   return facts => {
     const factsByPath = new Map(facts.map(file => [file.path, file]));
@@ -1282,7 +1282,7 @@ function packageForPath(path: string, packages: PackageIndex): string | undefine
   }
 }
 
-function discoverResolutionAliases(
+export function discoverResolutionAliases(
   files: readonly CodeGraphInventoryFile[],
   observer: CodeGraphResolutionObserver,
 ): ResolutionAliasIndex {

--- a/src/code_graph/extractor_context.ts
+++ b/src/code_graph/extractor_context.ts
@@ -1,16 +1,55 @@
-import {createPackageAttributorFromIndex, createResolutionAttributorFromIndex, discoverPackages} from './extractor.js';
+import {
+  createPackageAttributorFromIndex,
+  createResolutionAttributorFromIndex,
+  discoverPackages,
+  discoverResolutionAliases,
+} from './extractor.js';
 import {compareCodeUnits} from './ordering.js';
 import type {CodeGraphFileFacts, CodeGraphInventoryFile} from './types.js';
+
+export interface RepositoryFactAttributionContext {
+  readonly attribute: (
+    existingPaths: ReadonlySet<string>,
+  ) => (facts: readonly CodeGraphFileFacts[]) => readonly CodeGraphFileFacts[];
+  readonly candidatePaths: (facts: readonly CodeGraphFileFacts[]) => readonly string[];
+}
+
+/** Exact manifest paths consumed by repository-level fact attribution. */
+export function isRepositoryFactAttributionContextPath(path: string): boolean {
+  return /package\.json$/i.test(path) || /(?:^|\/)tsconfig\.json$/i.test(path);
+}
 
 /** Attribute changed facts from bounded context plus exact path-membership evidence. */
 export function createRepositoryFactAttributorFromContext(
   contextFiles: readonly CodeGraphInventoryFile[],
   existingPaths: ReadonlySet<string>,
 ): (facts: readonly CodeGraphFileFacts[]) => readonly CodeGraphFileFacts[] {
-  const packages = discoverPackages(contextFiles);
+  return createRepositoryFactAttributionContext(contextFiles).attribute(existingPaths);
+}
+
+/**
+ * Parse package and resolution manifests once, then reuse that immutable
+ * context for both candidate discovery and exact path-backed attribution.
+ */
+export function createRepositoryFactAttributionContext(
+  contextFiles: readonly CodeGraphInventoryFile[],
+): RepositoryFactAttributionContext {
+  const attributionFiles = contextFiles.filter(file => isRepositoryFactAttributionContextPath(file.path));
+  const packages = discoverPackages(attributionFiles);
+  const aliases = discoverResolutionAliases(attributionFiles, {});
   const attributePackages = createPackageAttributorFromIndex(packages);
-  const attributeResolution = createResolutionAttributorFromIndex(contextFiles, packages, existingPaths);
-  return facts => attributeResolution(attributePackages(facts));
+  const attribute = (existingPaths: ReadonlySet<string>) => {
+    const attributeResolution = createResolutionAttributorFromIndex(attributionFiles, packages, existingPaths, aliases);
+    return (facts: readonly CodeGraphFileFacts[]) => attributeResolution(attributePackages(facts));
+  };
+  return {
+    attribute,
+    candidatePaths: (facts: readonly CodeGraphFileFacts[]) => {
+      const candidates = new RecordingExistingPaths();
+      attribute(candidates)(facts);
+      return [...candidates].sort(compareCodeUnits);
+    },
+  };
 }
 
 /** Record every repository-membership dependency for one exact batch probe. */
@@ -18,9 +57,7 @@ export function repositoryFactCandidatePaths(
   contextFiles: readonly CodeGraphInventoryFile[],
   facts: readonly CodeGraphFileFacts[],
 ): readonly string[] {
-  const candidates = new RecordingExistingPaths();
-  createRepositoryFactAttributorFromContext(contextFiles, candidates)(facts);
-  return [...candidates].sort(compareCodeUnits);
+  return createRepositoryFactAttributionContext(contextFiles).candidatePaths(facts);
 }
 
 class RecordingExistingPaths extends Set<string> {

--- a/src/code_graph/indexer_sparse.ts
+++ b/src/code_graph/indexer_sparse.ts
@@ -2,7 +2,7 @@ import {Effect, FileSystem, Option} from 'effect';
 import type {CodeGraphBuildAnonymousTelemetryReporter} from './anonymous_telemetry.js';
 import {buildAndActivate, retiredSnapshotCleanupReporter, reuseReadySnapshot} from './indexer_build.js';
 import {assessIncrementalOverlay} from './indexer_incremental.js';
-import {createRepositoryFactAttributorFromContext, repositoryFactCandidatePaths} from './extractor_context.js';
+import {createRepositoryFactAttributionContext, type RepositoryFactAttributionContext} from './extractor_context.js';
 import {finalCodeGraphFactBatches} from './fact_budget.js';
 import {
   assessProjectClosureSeeds,
@@ -429,10 +429,8 @@ export const assessReusableOverlayAdmissionCompatibility = Effect.fn(
     return {mode: 'fallback', reason: 'cache-incomplete'} satisfies IncrementalOverlayPreassessment;
   }
   const completeBaseRawFacts = orderedBaseRawFacts as readonly CodeGraphFileFacts[];
-  const candidates = repositoryFactCandidatePaths(inventoryReceipt.attributionFiles, [
-    ...completeBaseRawFacts,
-    ...currentRawFacts,
-  ]);
+  const repositoryAttribution = createRepositoryFactAttributionContext(inventoryReceipt.attributionFiles);
+  const candidates = repositoryAttribution.candidatePaths([...completeBaseRawFacts, ...currentRawFacts]);
   const existingPaths = yield* input.store.existingSnapshotFilePaths(
     input.layout.databasePath,
     base.snapshot.id,
@@ -441,10 +439,7 @@ export const assessReusableOverlayAdmissionCompatibility = Effect.fn(
   if (existingPaths === undefined) {
     return {mode: 'fallback', reason: 'project-closure-unbounded'} satisfies IncrementalOverlayPreassessment;
   }
-  const attributeRepository = createRepositoryFactAttributorFromContext(
-    inventoryReceipt.attributionFiles,
-    new Set(existingPaths),
-  );
+  const attributeRepository = repositoryAttribution.attribute(new Set(existingPaths));
   const attributeWorkspace = createWorkspaceAttributor(input.admission.workspace);
   const currentFacts = attributeWorkspace(attributeRepository(currentRawFacts));
   const attributedBaseRawFacts = attributeWorkspace(attributeRepository(completeBaseRawFacts));
@@ -476,6 +471,7 @@ export const assessReusableOverlayAdmissionCompatibility = Effect.fn(
       currentFacts,
       languagePacks: input.languagePacks,
       layout: input.layout,
+      repositoryAttribution,
       store: input.store,
     });
   }
@@ -504,6 +500,7 @@ const assessSparseProjectClosure = Effect.fn('codeGraph.assessSparseProjectClosu
   readonly currentFacts: readonly CodeGraphFileFacts[];
   readonly languagePacks: CodeGraphLanguagePackRegistryShape;
   readonly layout: CodeGraphLayout;
+  readonly repositoryAttribution: RepositoryFactAttributionContext;
   readonly store: CodeGraphStoreShape;
 }) {
   if (input.store.snapshotProjectClosureFiles === undefined || input.store.existingSnapshotFilePaths === undefined) {
@@ -576,7 +573,7 @@ const assessSparseProjectClosure = Effect.fn('codeGraph.assessSparseProjectClosu
   }
   const rawFacts = affectedFiles.map(file => input.languagePacks.postprocessFile(file, cache.facts.get(file.path)!));
   const inventoryReceipt = base.receipt.inventory!;
-  const candidates = repositoryFactCandidatePaths(inventoryReceipt.attributionFiles, rawFacts);
+  const candidates = input.repositoryAttribution.candidatePaths(rawFacts);
   const existingPaths = yield* input.store.existingSnapshotFilePaths(
     input.layout.databasePath,
     base.snapshot.id,
@@ -585,10 +582,7 @@ const assessSparseProjectClosure = Effect.fn('codeGraph.assessSparseProjectClosu
   if (existingPaths === undefined) {
     return {mode: 'fallback', reason: 'project-closure-unbounded'} satisfies IncrementalOverlayPreassessment;
   }
-  const attributeRepository = createRepositoryFactAttributorFromContext(
-    inventoryReceipt.attributionFiles,
-    new Set(existingPaths),
-  );
+  const attributeRepository = input.repositoryAttribution.attribute(new Set(existingPaths));
   const attributeWorkspace = createWorkspaceAttributor(input.admission.workspace);
   const facts = attributeWorkspace(attributeRepository(rawFacts));
   if (finalCodeGraphFactBatches(facts).length !== 1) {

--- a/src/code_graph/inventory_reuse.ts
+++ b/src/code_graph/inventory_reuse.ts
@@ -19,6 +19,7 @@ import type {CodeGraphInventoryFile, RepositoryIdentity} from './types.js';
 import {codeGraphUtf8ByteLength} from './disk_capacity.js';
 import {compareCodeUnits} from './ordering.js';
 import type {CodeGraphAttributionContextFile} from './store_models.js';
+import {isRepositoryFactAttributionContextPath} from './extractor_context.js';
 
 const ATTRIBUTION_CONTEXT_FILES_MAXIMUM = 10_000;
 const ATTRIBUTION_CONTEXT_BYTES_MAXIMUM = 16 * 1_048_576;
@@ -30,7 +31,7 @@ export function codeGraphAttributionContextFilesForReceipt(
   const context: CodeGraphAttributionContextFile[] = [];
   let contentBytes = 0;
   for (const file of files) {
-    if (!languagePacks.isResolutionContext(file.path)) continue;
+    if (!languagePacks.isResolutionContext(file.path) || !isRepositoryFactAttributionContextPath(file.path)) continue;
     if (file.content === undefined || file.source !== 'commit') return undefined;
     const bytes = codeGraphUtf8ByteLength(file.content);
     if (
@@ -50,7 +51,7 @@ export function codeGraphAttributionContextFilesForReceipt(
  * matcher or inventory policy revision. Persisted inventory reuse is denied
  * across different contract hashes.
  */
-export const CODE_GRAPH_INVENTORY_REUSE_CONTRACT_VERSION = 1 as const;
+export const CODE_GRAPH_INVENTORY_REUSE_CONTRACT_VERSION = 2 as const;
 
 export const readCodeGraphInventoryReuseEnvironment = Effect.fn('codeGraph.readInventoryReuseEnvironment')(function* (
   identity: RepositoryIdentity,

--- a/test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
+++ b/test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
@@ -1612,14 +1612,12 @@
     "one-file-reindex-incremental-work-attribution-context-files-n1": {
       "samplesMinimum": 1,
       "unit": "count",
-      "maximum": 1035,
-      "minimum": 1035
+      "maximum": 1035
     },
     "one-file-reindex-incremental-work-base-facts-loaded-n1": {
       "samplesMinimum": 1,
       "unit": "count",
-      "maximum": 1,
-      "minimum": 1
+      "maximum": 1
     },
     "one-file-reindex-incremental-work-changed-files-n1": {
       "samplesMinimum": 1,
@@ -1641,20 +1639,17 @@
     "one-file-reindex-incremental-work-inventory-files-inspected-n1": {
       "samplesMinimum": 1,
       "unit": "count",
-      "maximum": 1,
-      "minimum": 1
+      "maximum": 1
     },
     "one-file-reindex-incremental-work-planned-rows-n1": {
       "samplesMinimum": 1,
       "unit": "count",
-      "maximum": 989,
-      "minimum": 989
+      "maximum": 989
     },
     "one-file-reindex-incremental-work-probed-dependency-paths-n1": {
       "samplesMinimum": 1,
       "unit": "count",
-      "maximum": 0,
-      "minimum": 0
+      "maximum": 0
     },
     "one-file-reindex-incremental-work-source-bytes-n1": {
       "samplesMinimum": 1,

--- a/test/unit/code-graph.extractor.test.ts
+++ b/test/unit/code-graph.extractor.test.ts
@@ -11,6 +11,7 @@ import {
   extractRepositoryFileFacts,
 } from '../../src/code_graph/extractor.js';
 import {
+  createRepositoryFactAttributionContext,
   createRepositoryFactAttributorFromContext,
   repositoryFactCandidatePaths,
 } from '../../src/code_graph/extractor_context.js';
@@ -218,17 +219,54 @@ describe('native code graph extraction', () => {
         const repositoryFiles = [...contextFiles, dependency, consumer];
         const rawConsumer = extractRepositoryFileFacts([consumer]);
         const candidates = repositoryFactCandidatePaths(contextFiles, rawConsumer);
+        const attribution = createRepositoryFactAttributionContext(contextFiles);
         const repositoryPaths = new Set(repositoryFiles.map(file => file.path));
         const existingCandidates = new Set(candidates.filter(path => repositoryPaths.has(path)));
 
+        const expected = createRepositoryFactAttributor(repositoryFiles)(rawConsumer);
         expect(createRepositoryFactAttributorFromContext(contextFiles, existingCandidates)(rawConsumer)).toEqual(
-          createRepositoryFactAttributor(repositoryFiles)(rawConsumer),
+          expected,
         );
+        expect(attribution.attribute(existingCandidates)(rawConsumer)).toEqual(expected);
+        expect(attribution.candidatePaths(rawConsumer)).toEqual(candidates);
+        expect(attribution.candidatePaths(rawConsumer)).toEqual(attribution.candidatePaths(rawConsumer));
         expect(existingCandidates.has(dependency.path)).toBe(true);
         expect(candidates.length).toBeLessThanOrEqual(16);
       }),
       {numRuns: 100},
     );
+  });
+
+  it('reuses parsed manifest context across candidate discovery and exact attribution', () => {
+    let manifestReads = 0;
+    const manifest = sourceFile('packages/app/package.json', '{"name":"app"}\n');
+    Object.defineProperty(manifest, 'content', {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        manifestReads += 1;
+        return '{"name":"app"}\n';
+      },
+    });
+    const dependency = sourceFile(
+      'packages/app/src/dependency.ts',
+      'export function dependency(): number { return 1; }\n',
+    );
+    const consumer = sourceFile(
+      'packages/app/src/consumer.ts',
+      'import {dependency} from "./dependency.js";\n' + 'export function consumer(): number { return dependency(); }\n',
+    );
+    const rawConsumer = extractRepositoryFileFacts([consumer]);
+    const expected = createRepositoryFactAttributor([manifest, dependency, consumer])(rawConsumer);
+    manifestReads = 0;
+    const attribution = createRepositoryFactAttributionContext([manifest]);
+    const parsedManifestReads = manifestReads;
+    const candidates = attribution.candidatePaths(rawConsumer);
+    const existing = new Set(candidates.filter(path => path === dependency.path));
+
+    expect(attribution.attribute(existing)(rawConsumer)).toEqual(expected);
+    expect(parsedManifestReads).toBe(2);
+    expect(manifestReads).toBe(parsedManifestReads);
   });
 
   it('indexes documentation without promoting prose similarity to a source dependency', () => {

--- a/test/unit/code-graph.inventory-reuse.property.test.ts
+++ b/test/unit/code-graph.inventory-reuse.property.test.ts
@@ -1,9 +1,11 @@
 import {describe, expect, it} from '@effect/vitest';
 import * as FC from 'effect/testing/FastCheck';
 import {
+  codeGraphAttributionContextFilesForReceipt,
   decodeCodeGraphInventoryReuseReceipt,
   encodeCodeGraphInventoryReuseReceipt,
 } from '../../src/code_graph/inventory_reuse.js';
+import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../../src/code_graph/languages/registry.js';
 import {CODE_GRAPH_INVENTORY_EXCLUSION_REASONS} from '../../src/code_graph/inventory_policy.js';
 import {CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION} from '../../src/code_graph/store_models.js';
 import {mergeCodeGraphWorkspaces} from '../../src/code_graph/workspace.js';
@@ -11,6 +13,29 @@ import {mergeCodeGraphWorkspaces} from '../../src/code_graph/workspace.js';
 const emptyWorkspace = mergeCodeGraphWorkspaces([]);
 
 describe('code graph inventory reuse receipts', () => {
+  it('retains only manifests consumed by repository attribution', () => {
+    const file = (path: string, content: string) => ({
+      blobId: `blob:${path}`,
+      content,
+      contentHash: 'a'.repeat(64),
+      language: 'fixture',
+      mode: '100644',
+      path,
+      size: new TextEncoder().encode(content).byteLength,
+      source: 'commit' as const,
+    });
+    const files = [
+      file('package.json', '{"name":"root"}'),
+      file('packages/app/tsconfig.json', '{"compilerOptions":{"baseUrl":"."}}'),
+      file('pom.xml', '<project/>'),
+      file('packages/app/BUILD.bazel', 'java_library(name = "app")'),
+    ];
+
+    expect(
+      codeGraphAttributionContextFilesForReceipt(files, BUILTIN_LANGUAGE_PACK_REGISTRY)?.map(item => item.path),
+    ).toEqual(['package.json', 'packages/app/tsconfig.json']);
+  });
+
   it.prop(
     'round-trips bounded admission evidence without changing its normalized workspace',
     {

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1138,6 +1138,17 @@ describe('code graph release evidence', () => {
     expect(ratchet.measurements['hosted-sampler-samples-n1']).toMatchObject({minimum: 1, unit: 'count'});
     expect(ratchet.measurements['hosted-sampler-samples-n1']).not.toHaveProperty('maximum');
     expect(ratchet.measurements['cold-materialized-file-rows']).toMatchObject({maximum: 1, minimum: 1});
+    const nonIncreasingWorkMeasurements = [
+      'one-file-reindex-incremental-work-attribution-context-files-n1',
+      'one-file-reindex-incremental-work-base-facts-loaded-n1',
+      'one-file-reindex-incremental-work-inventory-files-inspected-n1',
+      'one-file-reindex-incremental-work-planned-rows-n1',
+      'one-file-reindex-incremental-work-probed-dependency-paths-n1',
+    ];
+    for (const name of nonIncreasingWorkMeasurements) {
+      expect(ratchet.measurements[name]).toMatchObject({maximum: 1, unit: 'count'});
+      expect(ratchet.measurements[name]).not.toHaveProperty('minimum');
+    }
     expect(ratchet.measurements['cold-external-rss-peak-observed-n1']).toMatchObject({p95Maximum: 1_048_576});
     expect(ratchet.measurements['cold-external-rss-peak-observed-n1']).not.toHaveProperty('minimum');
     for (const registrationName of [
@@ -1206,6 +1217,16 @@ describe('code graph release evidence', () => {
     expect(Object.keys(ratchet.measurements).some(name => name.endsWith('-filesystem-available-n1'))).toBe(false);
     expect(ratchet.measurements['cold-external-rss-peak-observed-n1']).toBeDefined();
     expect(() => enforceCodeGraphBenchmarkRatchet(artifacts[0]!, ratchet)).not.toThrow();
+    for (const name of nonIncreasingWorkMeasurements) {
+      const withWork = (value: number): BenchmarkArtifactV1 => ({
+        ...artifacts[0]!,
+        measurements: artifacts[0]!.measurements.map(measurement =>
+          measurement.name === name ? benchmarkMeasurement(name, 'count', [value]) : measurement,
+        ),
+      });
+      expect(() => enforceCodeGraphBenchmarkRatchet(withWork(0), ratchet)).not.toThrow();
+      expect(() => enforceCodeGraphBenchmarkRatchet(withWork(2), ratchet)).toThrow(new RegExp(name));
+    }
     fc.assert(
       fc.property(fc.integer({max: 200 * 1_073_741_824, min: 20 * 1_073_741_824}), availableBytes => {
         const expandedCapacity = {


### PR DESCRIPTION
## Summary

- persist only package.json and tsconfig.json content consumed by repository attribution while retaining the complete derived workspace
- parse and reuse repository attribution context once across candidate discovery, exact attribution, and closure fallback
- ratchet proportional-work counts as non-increasing ceilings so improvements pass and regressions fail

## Evidence

- focused extraction, receipt, cross-session, and project-closure tests: 63 passed
- release-evidence ratchet tests: 45 passed
- lint, formatting, source/test/site typecheck: passed
- exact clean HEAD a144744 reduced production profile (4 workers): cold 71.075s; one-file 1.281s; registration 300.465ms; post-scan 60.133ms; one changed/inspected file; zero dependency probes; primary-query and structural parity passed
- artifact SHA-256: 084db3df35d3ffc4d7e9239ea9b0b0ccf1b29450b19c56ecbe036200e91b3d4b
- IntelliJ receipt model: 3,417 resolution contexts / 10.1MB encoded reduced to 87 consumed attribution manifests / 251KB; decode median 272.4ms to 6.7ms

Full suite and authoritative Linux ratchet are delegated to PR CI.