### PR TITLE
chore(release): prepare 4.3.8

### DIFF
--- a/.github/release-notes/v4.3.8.md
+++ b/.github/release-notes/v4.3.8.md
@@ -1,0 +1,39 @@
+## What's new
+
+Threadnote 4.3.8 reduces the remaining large-repository registration cost for native code-graph indexing while
+strengthening the permanent proportional-work ratchet.
+
+### Faster sparse admission
+
+- Shrinks reusable inventory receipts to the `package.json` and `tsconfig.json` content actually consumed by
+  repository attribution, while retaining the complete derived workspace needed for cross-language indexing.
+- Reuses the parsed attribution plan across candidate discovery, exact path-backed attribution, and bounded project
+  closure instead of rebuilding it within one admission attempt.
+- Bumps the reuse contract so older, broader receipts fail safely to normal inventory once and are replaced by the
+  compact format.
+
+On the pinned IntelliJ fixture, the reusable receipt model fell from 3,417 resolution-context files and 10.1 MB of
+encoded JSON to 87 consumed attribution manifests and 251 KB. Deep receipt validation fell from a 272.4-millisecond
+median to 6.7 milliseconds in the same-machine component probe.
+
+### Regression protection
+
+- Treats bounded-work counters as non-increasing ceilings: doing less work is accepted as an improvement, while any
+  increase still fails the governed production ratchet.
+- Keeps exact graph and primary-query parity, one-file changed/inspected/fanout counts, timing, storage, transaction,
+  graph-shape, and failure controls independently enforced.
+
+The exact v4.3.7 IntelliJ observation remains retained as a failed product gate: cold indexing, total one-file time,
+post-scan work, parity, proportionality, transaction bounds, polyglot controls, and all failure controls passed, but
+registration measured 5.255 seconds against the strict 5.000-second goal. It was not rerun unchanged.
+
+The exact clean development HEAD passed the reduced governed shape locally with four workers: cold indexing 71.075
+seconds, one-file indexing 1.281 seconds, registration 300 milliseconds, post-scan 60 milliseconds, one changed and
+inspected file, zero dependency probes, and exact structural parity. The authoritative Linux ratchet, 10k and 100k
+lexical benchmarks, full test matrix, and release builds passed in pull-request CI.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone release version to 4.3.8
- add curated release notes for compact sparse-admission receipts and proportional-work ratchets
- retain the exact v4.3.7 registration miss in the public evidence narrative

## Verification

- focused release-note, publish-workflow, and website release-boundary tests: 25 passed
- commit hooks: strict lint, formatting, source/test/site typecheck passed
- graph-indexing source is identical to merged PR #230, whose full CI and governed Linux ratchet passed

After this release-metadata-only PR passes CI, it is ready to merge and tag immediately.