### PR TITLE
test: normalize recall vector benchmark noise

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,6 +15,7 @@ on:
       - 'scripts/generate-code-graph-production-ratchet.ts'
       - 'scripts/code-graph-benchmark-sampler.ts'
       - 'scripts/benchmark-recall-vectors.ts'
+      - 'scripts/recall-vector-performance-budget.ts'
       - 'scripts/code-graph-fixture.ts'
       - 'scripts/code-graph-heavy-tail-fixture.ts'
       - 'test/evaluation/baselines/code-graph-v1/heavy-tail-scheduler-ratchet.json'
@@ -107,10 +108,11 @@ jobs:
           --output artifacts/recall-vectors-pr-10000-Linux-${{ runner.arch }}.json
 
       - uses: actions/upload-artifact@v7
+        if: always()
         with:
           name: recall-vector-benchmark-pr-10000-Linux-${{ runner.arch }}
-          path: artifacts/
-          if-no-files-found: error
+          path: artifacts/recall-vectors-pr-10000-Linux-${{ runner.arch }}.json
+          if-no-files-found: warn
           retention-days: 14
 
   code-graph-pr-scale:

--- a/scripts/benchmark-recall-vectors.ts
+++ b/scripts/benchmark-recall-vectors.ts
@@ -15,6 +15,7 @@ import {
   vectorIndexDatabaseFilename,
   type VectorIndexProgress,
 } from '../src/search/vector-index.js';
+import {assessRecallVectorPerformance} from './recall-vector-performance-budget.js';
 import {assessVectorDatabaseStorage, createCompactedSqliteSnapshot} from './recall-vector-storage-budget.js';
 
 const NANOSECONDS_PER_MILLISECOND = 1_000_000;
@@ -155,7 +156,19 @@ const program = Effect.scoped(
       {compactedBytes: incrementalCompactedBytes, databaseBytes: incrementalDatabaseBytes},
     );
     const sortedQueryDurations = queryDurations.sort((left, right) => left - right);
+    const initialBuildMilliseconds = Number(initialFinishedAt - initialStartedAt) / NANOSECONDS_PER_MILLISECOND;
+    const incrementalBuildMilliseconds =
+      Number(incrementalFinishedAt - incrementalStartedAt) / NANOSECONDS_PER_MILLISECOND;
+    const semanticQueryP95Milliseconds = percentile(sortedQueryDurations, 0.95);
+    const performanceBudget = assessRecallVectorPerformance(options.documents, {
+      incrementalBuildMilliseconds,
+      initialBuildMilliseconds,
+      semanticQueryP95Milliseconds,
+    });
     const result = {
+      budgets: {
+        performance: performanceBudget,
+      },
       database: {
         bytesAfterIncremental: incrementalDatabaseBytes,
         bytesAfterInitial: initialDatabaseBytes,
@@ -178,18 +191,18 @@ const program = Effect.scoped(
       scenarios: {
         incrementalBuild: {
           embeddedChunks: incremental.embeddedChunkCount,
-          milliseconds: Number(incrementalFinishedAt - incrementalStartedAt) / NANOSECONDS_PER_MILLISECOND,
+          milliseconds: incrementalBuildMilliseconds,
           peakRssBytes: incrementalPeakRssBytes,
           reusedChunks: incremental.reusedChunkCount,
         },
         initialBuild: {
           embeddedChunks: initial.embeddedChunkCount,
-          milliseconds: Number(initialFinishedAt - initialStartedAt) / NANOSECONDS_PER_MILLISECOND,
+          milliseconds: initialBuildMilliseconds,
           peakRssBytes: initialPeakRssBytes,
         },
         semanticQuery: {
           p50Milliseconds: percentile(sortedQueryDurations, 0.5),
-          p95Milliseconds: percentile(sortedQueryDurations, 0.95),
+          p95Milliseconds: semanticQueryP95Milliseconds,
           peakRssBytes: queryRssAfterBytes,
           resultCount: Math.min(VECTOR_QUERY_RESULT_LIMIT, options.documents),
           rssDeltaBytes: Math.max(0, queryRssAfterBytes - queryRssBeforeBytes),
@@ -207,17 +220,18 @@ const program = Effect.scoped(
       yield* fs.writeFileString(options.output, `${JSON.stringify(result, undefined, 2)}\n`);
     }
     if (options.failOnBudget) {
-      const scale = options.documents / DEFAULT_DOCUMENT_COUNT;
-      const boundedScale = Math.max(1, scale);
-      if (result.scenarios.semanticQuery.p95Milliseconds > boundedScale * 750) {
+      if (!performanceBudget.semanticQueryWithinBudget) {
         return yield* Effect.fail(new ScriptError('Semantic vector query exceeded its linear scale budget.'));
       }
-      if (result.scenarios.initialBuild.milliseconds > boundedScale * 15_000) {
+      if (!performanceBudget.initialBuildWithinBudget) {
         return yield* Effect.fail(new ScriptError('Initial vector build exceeded its linear scale budget.'));
       }
-      if (result.scenarios.incrementalBuild.milliseconds > boundedScale * 3_000) {
-        return yield* Effect.fail(new ScriptError('Incremental vector build exceeded its linear scale budget.'));
+      if (!performanceBudget.incrementalBuildWithinBudget) {
+        return yield* Effect.fail(
+          new ScriptError('Incremental vector build exceeded its linear or same-runner normalized budget.'),
+        );
       }
+      const boundedScale = Math.max(1, options.documents / DEFAULT_DOCUMENT_COUNT);
       if (result.scenarios.initialBuild.peakRssBytes > boundedScale * 768 * MEBIBYTE) {
         return yield* Effect.fail(new ScriptError('Initial vector build exceeded its bounded-memory budget.'));
       }

--- a/scripts/recall-vector-performance-budget.ts
+++ b/scripts/recall-vector-performance-budget.ts
@@ -1,0 +1,74 @@
+import {ScriptError} from './effect/errors.js';
+
+const BASE_DOCUMENT_COUNT = 10_000;
+const SEMANTIC_QUERY_MILLISECONDS_PER_BASE = 750;
+const INITIAL_BUILD_MILLISECONDS_PER_BASE = 15_000;
+const INCREMENTAL_BUILD_MILLISECONDS_PER_BASE = 3_000;
+
+// Shared runners can throttle both builds together. Require incremental work to remain at least 40% faster
+// while normalizing only when the same-runner initial build proves the absolute floor is not representative.
+export const INCREMENTAL_BUILD_TO_INITIAL_RATIO_MAXIMUM = 0.6;
+
+export interface RecallVectorPerformanceMeasurement {
+  readonly incrementalBuildMilliseconds: number;
+  readonly initialBuildMilliseconds: number;
+  readonly semanticQueryP95Milliseconds: number;
+}
+
+export interface RecallVectorPerformanceBudget {
+  readonly incrementalBuildLinearMaximumMilliseconds: number;
+  readonly incrementalBuildMaximumMilliseconds: number;
+  readonly incrementalBuildSameRunnerMaximumMilliseconds: number;
+  readonly incrementalBuildWithinBudget: boolean;
+  readonly initialBuildMaximumMilliseconds: number;
+  readonly initialBuildWithinBudget: boolean;
+  readonly semanticQueryP95MaximumMilliseconds: number;
+  readonly semanticQueryWithinBudget: boolean;
+  readonly sharedRunnerAdjustmentApplied: boolean;
+}
+
+export function assessRecallVectorPerformance(
+  documents: number,
+  measurement: RecallVectorPerformanceMeasurement,
+): RecallVectorPerformanceBudget {
+  if (!Number.isSafeInteger(documents) || documents <= 0) {
+    throw new ScriptError('Recall vector performance budget requires a positive document count.');
+  }
+  assertMeasurement(measurement);
+
+  const boundedScale = Math.max(1, documents / BASE_DOCUMENT_COUNT);
+  const semanticQueryP95MaximumMilliseconds = boundedScale * SEMANTIC_QUERY_MILLISECONDS_PER_BASE;
+  const initialBuildMaximumMilliseconds = boundedScale * INITIAL_BUILD_MILLISECONDS_PER_BASE;
+  const incrementalBuildLinearMaximumMilliseconds = boundedScale * INCREMENTAL_BUILD_MILLISECONDS_PER_BASE;
+  const incrementalBuildSameRunnerMaximumMilliseconds =
+    measurement.initialBuildMilliseconds * INCREMENTAL_BUILD_TO_INITIAL_RATIO_MAXIMUM;
+  const incrementalBuildMaximumMilliseconds = Math.min(
+    initialBuildMaximumMilliseconds,
+    Math.max(incrementalBuildLinearMaximumMilliseconds, incrementalBuildSameRunnerMaximumMilliseconds),
+  );
+
+  return {
+    incrementalBuildLinearMaximumMilliseconds,
+    incrementalBuildMaximumMilliseconds,
+    incrementalBuildSameRunnerMaximumMilliseconds,
+    incrementalBuildWithinBudget: measurement.incrementalBuildMilliseconds <= incrementalBuildMaximumMilliseconds,
+    initialBuildMaximumMilliseconds,
+    initialBuildWithinBudget: measurement.initialBuildMilliseconds <= initialBuildMaximumMilliseconds,
+    semanticQueryP95MaximumMilliseconds,
+    semanticQueryWithinBudget: measurement.semanticQueryP95Milliseconds <= semanticQueryP95MaximumMilliseconds,
+    sharedRunnerAdjustmentApplied:
+      incrementalBuildSameRunnerMaximumMilliseconds > incrementalBuildLinearMaximumMilliseconds,
+  };
+}
+
+function assertMeasurement(measurement: RecallVectorPerformanceMeasurement): void {
+  for (const value of [
+    measurement.incrementalBuildMilliseconds,
+    measurement.initialBuildMilliseconds,
+    measurement.semanticQueryP95Milliseconds,
+  ]) {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new ScriptError('Invalid recall vector performance measurement.');
+    }
+  }
+}

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -68,6 +68,7 @@ describe('platform benchmark workflow', () => {
         'scripts/benchmark-code-graph-workset.ts',
         'scripts/code-graph-benchmark-sampler.ts',
         'scripts/benchmark-recall-vectors.ts',
+        'scripts/recall-vector-performance-budget.ts',
         'scripts/evaluate-recall.ts',
         'src/code_graph/**',
         'src/effect/ai/**',
@@ -93,6 +94,14 @@ describe('platform benchmark workflow', () => {
     expect(recallCommand).toContain('bun run bench:recall:vectors');
     expect(recallCommand).toContain('--documents 10000');
     expect(recallCommand).toContain('--fail-on-budget');
+    const recallArtifactStep = recallJob.steps?.find(
+      step =>
+        step.uses === 'actions/upload-artifact@v7' &&
+        step.with?.name === 'recall-vector-benchmark-pr-10000-Linux-${{ runner.arch }}',
+    );
+    expect(recallArtifactStep?.if).toBe('always()');
+    expect(recallArtifactStep?.with?.['if-no-files-found']).toBe('warn');
+    expect(recallArtifactStep?.with?.path).toBe('artifacts/recall-vectors-pr-10000-Linux-${{ runner.arch }}.json');
     expect(worksetJob.if).toContain("github.event_name == 'schedule'");
     expect(worksetJob.if).toContain("github.event_name == 'workflow_dispatch'");
     expect(worksetJob['runs-on']).toBe('ubuntu-24.04');

--- a/test/unit/recall-vector-performance-budget.test.ts
+++ b/test/unit/recall-vector-performance-budget.test.ts
@@ -1,0 +1,92 @@
+import {describe, expect, it} from '@effect/vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {
+  assessRecallVectorPerformance,
+  INCREMENTAL_BUILD_TO_INITIAL_RATIO_MAXIMUM,
+} from '../../scripts/recall-vector-performance-budget.js';
+
+describe('recall vector performance budget', () => {
+  it('normalizes the preserved failed sample against its same-runner initial build', () => {
+    const budget = assessRecallVectorPerformance(10_000, {
+      incrementalBuildMilliseconds: 3_899.673482,
+      initialBuildMilliseconds: 8_730.164416,
+      semanticQueryP95Milliseconds: 55.508846,
+    });
+
+    expect(budget.incrementalBuildLinearMaximumMilliseconds).toBe(3_000);
+    expect(budget.incrementalBuildSameRunnerMaximumMilliseconds).toBeCloseTo(5_238.09865, 5);
+    expect(budget.sharedRunnerAdjustmentApplied).toBe(true);
+    expect(budget.initialBuildWithinBudget).toBe(true);
+    expect(budget.incrementalBuildWithinBudget).toBe(true);
+    expect(budget.semanticQueryWithinBudget).toBe(true);
+  });
+
+  it('still rejects a disproportionate incremental regression on an ordinary runner', () => {
+    const budget = assessRecallVectorPerformance(10_000, {
+      incrementalBuildMilliseconds: 3_001,
+      initialBuildMilliseconds: 2_500,
+      semanticQueryP95Milliseconds: 50,
+    });
+
+    expect(budget.sharedRunnerAdjustmentApplied).toBe(false);
+    expect(budget.incrementalBuildMaximumMilliseconds).toBe(3_000);
+    expect(budget.incrementalBuildWithinBudget).toBe(false);
+  });
+
+  it('retains the independent initial-build and semantic-query watchdogs', () => {
+    const budget = assessRecallVectorPerformance(10_000, {
+      incrementalBuildMilliseconds: 1_200,
+      initialBuildMilliseconds: 15_001,
+      semanticQueryP95Milliseconds: 751,
+    });
+
+    expect(budget.initialBuildMaximumMilliseconds).toBe(15_000);
+    expect(budget.initialBuildWithinBudget).toBe(false);
+    expect(budget.semanticQueryP95MaximumMilliseconds).toBe(750);
+    expect(budget.semanticQueryWithinBudget).toBe(false);
+  });
+
+  it.prop(
+    'preserves a ratio-bounded result under common runner slowdown while the initial watchdog holds',
+    {
+      initialBuildMilliseconds: FC.integer({max: 3_000, min: 1_500}),
+      ratioBasisPoints: FC.integer({max: 6_000, min: 1_000}),
+      slowdown: FC.integer({max: 5, min: 2}),
+    },
+    ({initialBuildMilliseconds, ratioBasisPoints, slowdown}) => {
+      const incrementalBuildMilliseconds = initialBuildMilliseconds * (ratioBasisPoints / 10_000);
+      const measurement = {
+        incrementalBuildMilliseconds: incrementalBuildMilliseconds * slowdown,
+        initialBuildMilliseconds: initialBuildMilliseconds * slowdown,
+        semanticQueryP95Milliseconds: 50,
+      };
+      const budget = assessRecallVectorPerformance(10_000, measurement);
+
+      expect(budget.initialBuildWithinBudget).toBe(true);
+      expect(budget.incrementalBuildWithinBudget).toBe(true);
+      if (measurement.initialBuildMilliseconds * INCREMENTAL_BUILD_TO_INITIAL_RATIO_MAXIMUM > 3_000) {
+        expect(budget.sharedRunnerAdjustmentApplied).toBe(true);
+      }
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+
+  it.prop(
+    'rejects incremental work above both the linear floor and same-runner ratio',
+    {
+      initialBuildMilliseconds: FC.integer({max: 15_000, min: 5_000}),
+      excessMilliseconds: FC.integer({max: 1_000, min: 1}),
+    },
+    ({excessMilliseconds, initialBuildMilliseconds}) => {
+      const budget = assessRecallVectorPerformance(10_000, {
+        incrementalBuildMilliseconds:
+          initialBuildMilliseconds * INCREMENTAL_BUILD_TO_INITIAL_RATIO_MAXIMUM + excessMilliseconds,
+        initialBuildMilliseconds,
+        semanticQueryP95Milliseconds: 50,
+      });
+
+      expect(budget.incrementalBuildWithinBudget).toBe(false);
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+});


### PR DESCRIPTION
## Summary

- preserve the existing 3,000 ms incremental-vector ratchet on normal runners
- when the same runner also has a slow initial build, allow only a same-runner-normalized ceiling of `0.60 × initial`, so incremental work must remain at least 40% faster and can never exceed the existing 15,000 ms initial watchdog
- record the effective performance budgets in the benchmark artifact
- upload the exact recall-vector artifact even when its gate fails

## Diagnosis and preserved failure evidence

PR #231 changes only `package.json` and release notes. Its [failed run](https://github.com/Kashkovsky/threadnote/actions/runs/32958158906/job/98144358755) retained correct vector behavior:

- initial build: 8,730.164 ms
- incremental build: 3,899.673 ms
- ratio: 0.447
- reuse: 9,999 unchanged chunks reused; one changed chunk embedded
- compacted incremental growth: 0 bytes
- query p95: 55.509 ms

Twenty consecutive successful Linux artifacts immediately around the failure show:

- initial median 2,374.466 ms, max 3,137.804 ms
- incremental median 1,195.016 ms, max 1,903.567 ms
- incremental/initial median 0.522, max 0.795

The failed runner therefore slowed both database-build phases by roughly the same factor while the normalized incremental ratio improved. The old n=1 absolute incremental gate could not distinguish this shared slowdown from an incremental-path regression.

The new rule keeps the 3,000 ms limit unless `0.60 ×` the same-run initial build is larger. For the preserved failure it yields a 5,238.099 ms cap. At the 15,000 ms initial watchdog, the adaptive cap is at most 9,000 ms. Structural reuse, row cardinality, storage-growth, memory, query, and initial-build gates remain unchanged.

## Verification

- focused unit/property/workflow tests: 14/14 passed
- local 10k benchmark with `--fail-on-budget`: initial 2,255.268 ms, incremental 833.791 ms (ratio 0.370), query p95 43.235 ms; the unchanged 3,000 ms floor applied
- strict oxlint on changed TypeScript: passed
- Prettier check on changed files: passed
- main and test TypeScript no-emit checks: passed
- pre-commit full lint, Prettier, and typecheck hooks: passed

Property coverage proves common multiplicative runner slowdown remains accepted through the exact 0.60 boundary while the initial watchdog holds, and any incremental result above both the linear floor and same-runner ratio is rejected.
