### PR TITLE
feat(site): publish authored whats-new posts

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/pages.yml'
       - 'package.json'
       - 'scripts/site-doc-pages.ts'
+      - 'scripts/site-articles.ts'
       - 'scripts/site-performance-evidence.ts'
       - 'scripts/site-release-notes.ts'
       - 'src/evaluation/benchmark.ts'

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mcp-server": "bun src/standalone.ts mcp-server",
     "typecheck": "bun --bun tsc --noEmit && bun --bun tsc -p test/tsconfig.json --noEmit && bun run site:typecheck",
     "site:dev": "bun --bun vite --config website/vite.config.ts",
-    "site:build": "bun --bun vite build --config website/vite.config.ts && bun scripts/site-doc-pages.ts",
+    "site:build": "bun --bun vite build --config website/vite.config.ts && bun scripts/site-doc-pages.ts && bun scripts/site-articles.ts",
     "site:preview": "bun --bun vite preview --config website/vite.config.ts",
     "site:typecheck": "bun --bun tsc -p website/tsconfig.json --noEmit",
     "site:test": "bun --bun vitest run test/unit/website-content.test.ts test/unit/website-release-boundary.test.ts",

--- a/scripts/site-articles.ts
+++ b/scripts/site-articles.ts
@@ -1,0 +1,446 @@
+import * as BunRuntime from '@effect/platform-bun/BunRuntime';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {Console, Effect, FileSystem, Path} from 'effect';
+import {createElement} from 'react';
+import ReactMarkdown from 'react-markdown';
+import {renderToStaticMarkup} from 'react-dom/server';
+import remarkGfm from 'remark-gfm';
+import {parse as parseYaml} from 'yaml';
+import {provideScriptLayer, ScriptError} from './effect/errors.js';
+import {loadLatestMajorWebsiteReleases, type WebsiteRelease} from './site-release-notes.js';
+import {orderWebsiteUpdatesDescending, type WebsiteArticle} from '../website/src/content/websiteArticles.js';
+import {whatsNewArticlePath, whatsNewReleasePath} from '../website/src/lib/routes.js';
+
+const publicOrigin = 'https://threadnote.io/';
+const articleFilePattern = /^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z)--([a-z0-9]+(?:-[a-z0-9]+)*)\.md$/;
+const articleSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const exactTimestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+const generatedSitemapStart = '  <!-- BEGIN GENERATED WHATS NEW POSTS -->';
+const generatedSitemapEnd = '  <!-- END GENERATED WHATS NEW POSTS -->';
+const articleMetadataKeys = new Set(['author', 'authorUrl', 'publishedAt', 'slug', 'summary', 'title']);
+
+type ArticleMetadata = Readonly<{
+  author: string;
+  authorUrl?: string;
+  publishedAt: string;
+  slug: string;
+  summary: string;
+  title: string;
+}>;
+
+export type WebsitePost =
+  WebsiteArticle | (WebsiteRelease & {readonly author: 'Threadnote'; readonly kind: 'release'; readonly title: string});
+
+function articleError(fileName: string, detail: string): ScriptError {
+  return new ScriptError(`website/articles/${fileName}: ${detail}`);
+}
+
+function plainText(markdown: string): string {
+  return markdown
+    .replace(/\[([^\]]+)]\([^\s)]+(?:\s+"[^"]*")?\)/g, '$1')
+    .replace(/[`*_~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function articleHighlights(body: string): readonly string[] {
+  return [
+    ...new Set(
+      body
+        .split('\n')
+        .map(line => /^#{2,3}\s+(.+)$/.exec(line.trim())?.[1])
+        .filter((heading): heading is string => Boolean(heading))
+        .map(plainText)
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function requiredMetadataString(
+  metadata: Readonly<Record<string, unknown>>,
+  key: keyof ArticleMetadata,
+  fileName: string,
+): string {
+  const value = metadata[key];
+  if (typeof value !== 'string' || !value.trim()) throw articleError(fileName, `frontmatter ${key} must be a string`);
+  if (value !== value.trim()) throw articleError(fileName, `frontmatter ${key} must not have surrounding whitespace`);
+  return value;
+}
+
+function parseArticleMetadata(
+  fileName: string,
+  source: string,
+): {readonly body: string; readonly metadata: ArticleMetadata} {
+  const normalized = source.replace(/\r\n?/g, '\n');
+  const document = /^---\n([\s\S]*?)\n---\n+([\s\S]*)$/.exec(normalized);
+  if (!document?.[1] || !document[2]?.trim()) {
+    throw articleError(fileName, 'expected YAML frontmatter followed by a non-empty Markdown body');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(document[1]);
+  } catch (error) {
+    throw articleError(fileName, `frontmatter is not valid YAML: ${String(error)}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw articleError(fileName, 'frontmatter must be a mapping');
+  }
+  const raw = parsed as Readonly<Record<string, unknown>>;
+  const unknownKeys = Object.keys(raw).filter(key => !articleMetadataKeys.has(key));
+  if (unknownKeys.length > 0) throw articleError(fileName, `unknown frontmatter field(s): ${unknownKeys.join(', ')}`);
+
+  const title = requiredMetadataString(raw, 'title', fileName);
+  const summary = requiredMetadataString(raw, 'summary', fileName);
+  const author = requiredMetadataString(raw, 'author', fileName);
+  const publishedAt = requiredMetadataString(raw, 'publishedAt', fileName);
+  const slug = requiredMetadataString(raw, 'slug', fileName);
+  const authorUrlValue = raw.authorUrl;
+  if (authorUrlValue !== undefined && (typeof authorUrlValue !== 'string' || !authorUrlValue.trim())) {
+    throw articleError(fileName, 'frontmatter authorUrl must be a non-empty HTTPS URL when present');
+  }
+  const authorUrl = authorUrlValue as string | undefined;
+  if (authorUrl && authorUrl !== authorUrl.trim()) {
+    throw articleError(fileName, 'frontmatter authorUrl must not have surrounding whitespace');
+  }
+
+  if (title.length > 140) throw articleError(fileName, 'frontmatter title must be at most 140 characters');
+  if (summary.length > 280) throw articleError(fileName, 'frontmatter summary must be at most 280 characters');
+  if (author.length > 100) throw articleError(fileName, 'frontmatter author must be at most 100 characters');
+  if (!articleSlugPattern.test(slug)) throw articleError(fileName, `frontmatter slug is not URL-safe: ${slug}`);
+  const parsedPublishedAt = Date.parse(publishedAt);
+  const canonicalPublishedAt = Number.isFinite(parsedPublishedAt)
+    ? new Date(parsedPublishedAt).toISOString().replace('.000Z', 'Z')
+    : undefined;
+  if (!exactTimestampPattern.test(publishedAt) || canonicalPublishedAt !== publishedAt) {
+    throw articleError(fileName, 'frontmatter publishedAt must be an exact UTC timestamp such as 2026-08-26T14:30:00Z');
+  }
+  if (authorUrl) {
+    let url: URL;
+    try {
+      url = new URL(authorUrl);
+    } catch {
+      throw articleError(fileName, 'frontmatter authorUrl must be a valid HTTPS URL');
+    }
+    if (url.protocol !== 'https:' || url.username || url.password) {
+      throw articleError(fileName, 'frontmatter authorUrl must be a credential-free HTTPS URL');
+    }
+  }
+
+  const fileMatch = articleFilePattern.exec(fileName);
+  if (!fileMatch) {
+    throw articleError(fileName, 'filename must be <UTC timestamp>--<slug>.md with colons written as hyphens');
+  }
+  const fileTimestamp = fileMatch[1]!.replace(/T(\d{2})-(\d{2})-(\d{2})Z$/, 'T$1:$2:$3Z');
+  if (fileTimestamp !== publishedAt || fileMatch[2] !== slug) {
+    throw articleError(fileName, 'filename timestamp and slug must exactly match frontmatter publishedAt and slug');
+  }
+
+  return {
+    body: document[2].trim(),
+    metadata: {author, ...(authorUrl ? {authorUrl} : {}), publishedAt, slug, summary, title},
+  };
+}
+
+export function parseWebsiteArticle(fileName: string, source: string): WebsiteArticle {
+  if (/publication placeholder/i.test(source)) {
+    throw articleError(fileName, 'publication placeholders are forbidden in published articles');
+  }
+  const {body, metadata} = parseArticleMetadata(fileName, source);
+  return {...metadata, body, highlights: articleHighlights(body), kind: 'article'};
+}
+
+export async function loadWebsiteArticles(repositoryRoot: string): Promise<readonly WebsiteArticle[]> {
+  const fileNames: string[] = [];
+  const glob = new Bun.Glob('website/articles/*.md');
+  for await (const path of glob.scan({cwd: repositoryRoot, onlyFiles: true})) {
+    const fileName = path.slice(path.lastIndexOf('/') + 1);
+    if (fileName.toLowerCase() !== 'readme.md') fileNames.push(fileName);
+  }
+  fileNames.sort();
+
+  const articles = await Promise.all(
+    fileNames.map(async fileName =>
+      parseWebsiteArticle(fileName, await Bun.file(`${repositoryRoot}/website/articles/${fileName}`).text()),
+    ),
+  );
+  const slugs = new Set<string>();
+  for (const article of articles) {
+    if (slugs.has(article.slug))
+      throw articleError(fileNames[articles.indexOf(article)]!, `duplicate slug: ${article.slug}`);
+    slugs.add(article.slug);
+  }
+  return articles.sort(
+    (left, right) =>
+      Date.parse(right.publishedAt) - Date.parse(left.publishedAt) || left.slug.localeCompare(right.slug),
+  );
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceTagAttribute(
+  html: string,
+  tagName: string,
+  identifyingAttribute: string,
+  identifyingValue: string,
+  updatedAttribute: string,
+  updatedValue: string,
+): string {
+  const tagPattern = new RegExp(
+    `<${tagName}\\b[^>]*\\b${escapeRegExp(identifyingAttribute)}="${escapeRegExp(identifyingValue)}"[^>]*>`,
+    'i',
+  );
+  const tag = html.match(tagPattern)?.[0];
+  if (!tag)
+    throw new ScriptError(
+      `What's New HTML template is missing ${tagName}[${identifyingAttribute}="${identifyingValue}"]`,
+    );
+  const attributePattern = new RegExp(`\\b${escapeRegExp(updatedAttribute)}="[^"]*"`, 'i');
+  if (!attributePattern.test(tag)) {
+    throw new ScriptError(
+      `What's New HTML template ${tagName}[${identifyingAttribute}="${identifyingValue}"] is missing ${updatedAttribute}`,
+    );
+  }
+  const updatedTag = tag.replace(attributePattern, `${updatedAttribute}="${escapeHtml(updatedValue)}"`);
+  return html.replace(tagPattern, updatedTag);
+}
+
+function postDetails(post: WebsitePost): {
+  readonly author: string;
+  readonly body: string;
+  readonly canonicalUrl: string;
+  readonly kindLabel: string;
+  readonly pageTitle: string;
+} {
+  if (post.kind === 'article') {
+    return {
+      author: post.author,
+      body: post.body,
+      canonicalUrl: new URL(whatsNewArticlePath(post.slug), publicOrigin).href,
+      kindLabel: 'Article',
+      pageTitle: `${post.title} — Threadnote`,
+    };
+  }
+  return {
+    author: post.author,
+    body: post.body,
+    canonicalUrl: new URL(whatsNewReleasePath(post.version), publicOrigin).href,
+    kindLabel: 'Release',
+    pageTitle: `${post.title} — Threadnote`,
+  };
+}
+
+function crawlerFallback(post: WebsitePost): string {
+  const details = postDetails(post);
+  const shareText = encodeURIComponent(post.title);
+  const shareUrl = encodeURIComponent(details.canonicalUrl);
+  const markdown = renderToStaticMarkup(createElement(ReactMarkdown, {remarkPlugins: [remarkGfm]}, details.body));
+  return [
+    '<main class="crawler-post">',
+    '<article>',
+    `<p>${details.kindLabel} · ${escapeHtml(post.publishedAt)} · By ${escapeHtml(details.author)}</p>`,
+    `<h1>${escapeHtml(post.title)}</h1>`,
+    `<p>${escapeHtml(post.summary)}</p>`,
+    markdown,
+    '<aside aria-label="Share this post">',
+    `<label>Permanent public URL <input readonly value="${escapeHtml(details.canonicalUrl)}" /></label>`,
+    `<p><a href="https://x.com/intent/post?text=${shareText}&amp;url=${shareUrl}">Share on X</a> · ` +
+      `<a href="https://www.linkedin.com/sharing/share-offsite/?url=${shareUrl}">Share on LinkedIn</a></p>`,
+    '</aside>',
+    '</article>',
+    '</main>',
+  ].join('');
+}
+
+function postStableId(post: WebsitePost): string {
+  return post.kind === 'article' ? `article:${post.slug}` : `release:${post.version}`;
+}
+
+export function orderWebsitePostsDescending(posts: readonly WebsitePost[]): readonly WebsitePost[] {
+  return orderWebsiteUpdatesDescending(
+    posts.map(post => ({post, publishedAt: post.publishedAt, stableId: postStableId(post)})),
+  ).map(({post}) => post);
+}
+
+function crawlerIndexFallback(posts: readonly WebsitePost[]): string {
+  return [
+    '<main class="crawler-post crawler-post--index">',
+    "<header><p>What's new</p><h1>Threadnote articles and releases</h1>",
+    '<p>Engineering stories and stable release posts, ordered by publication time.</p></header>',
+    '<ol>',
+    ...posts.map(post => {
+      const details = postDetails(post);
+      return [
+        '<li><article>',
+        `<p>${details.kindLabel} · ${escapeHtml(post.publishedAt)} · By ${escapeHtml(details.author)}</p>`,
+        `<h2><a href="${escapeHtml(details.canonicalUrl)}">${escapeHtml(post.title)}</a></h2>`,
+        `<p>${escapeHtml(post.summary)}</p>`,
+        '</article></li>',
+      ].join('');
+    }),
+    '</ol>',
+    '</main>',
+  ].join('');
+}
+
+export function renderWhatsNewIndexHtml(template: string, posts: readonly WebsitePost[]): string {
+  const orderedPosts = orderWebsitePostsDescending(posts);
+  if (!template.includes('<div id="root"></div>')) throw new ScriptError("What's New HTML template is missing #root");
+  if (!template.includes('</head>')) throw new ScriptError("What's New HTML template is missing </head>");
+  const itemList = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    hasPart: orderedPosts.map(post => {
+      const details = postDetails(post);
+      return {
+        '@type': post.kind === 'article' ? 'Article' : 'TechArticle',
+        name: post.title,
+        url: details.canonicalUrl,
+      };
+    }),
+    name: "What's new in Threadnote",
+    url: new URL('whats-new/', publicOrigin).href,
+  };
+  const structuredData = JSON.stringify(itemList).replaceAll('<', '\\u003c');
+  return template
+    .replace(
+      '</head>',
+      `    <script type="application/ld+json" data-threadnote-index>${structuredData}</script>\n  </head>`,
+    )
+    .replace('<div id="root"></div>', `<div id="root">${crawlerIndexFallback(orderedPosts)}</div>`);
+}
+
+function postStructuredData(post: WebsitePost): Readonly<Record<string, unknown>> {
+  const details = postDetails(post);
+  const author =
+    post.kind === 'article'
+      ? {'@type': 'Person', name: post.author, ...(post.authorUrl ? {url: post.authorUrl} : {})}
+      : {'@type': 'Organization', name: 'Threadnote', url: publicOrigin};
+  return {
+    '@context': 'https://schema.org',
+    '@type': post.kind === 'article' ? 'Article' : 'TechArticle',
+    author,
+    datePublished: post.publishedAt,
+    description: post.summary,
+    headline: post.title,
+    mainEntityOfPage: details.canonicalUrl,
+    publisher: {'@type': 'Organization', name: 'Threadnote', url: publicOrigin},
+    url: details.canonicalUrl,
+  };
+}
+
+export function renderWebsitePostHtml(template: string, post: WebsitePost): string {
+  const details = postDetails(post);
+  let html = template;
+  html = replaceTagAttribute(html, 'meta', 'name', 'description', 'content', post.summary);
+  html = replaceTagAttribute(html, 'link', 'rel', 'canonical', 'href', details.canonicalUrl);
+  html = replaceTagAttribute(html, 'link', 'rel', 'icon', 'href', '../../../threadnote-logo.svg');
+  html = replaceTagAttribute(html, 'meta', 'property', 'og:title', 'content', details.pageTitle);
+  html = replaceTagAttribute(html, 'meta', 'property', 'og:description', 'content', post.summary);
+  html = replaceTagAttribute(html, 'meta', 'property', 'og:type', 'content', 'article');
+  html = replaceTagAttribute(html, 'meta', 'property', 'og:url', 'content', details.canonicalUrl);
+  html = replaceTagAttribute(html, 'meta', 'name', 'twitter:title', 'content', details.pageTitle);
+  html = replaceTagAttribute(html, 'meta', 'name', 'twitter:description', 'content', post.summary);
+  if (!/<title>[^<]*<\/title>/i.test(html)) throw new ScriptError("What's New HTML template is missing its title");
+  html = html.replace(/<title>[^<]*<\/title>/i, `<title>${escapeHtml(details.pageTitle)}</title>`);
+
+  const structuredData = JSON.stringify(postStructuredData(post)).replaceAll('<', '\\u003c');
+  const postMetadata = [
+    `<meta property="article:published_time" content="${escapeHtml(post.publishedAt)}" />`,
+    `<meta property="article:author" content="${escapeHtml(details.author)}" />`,
+    `<script type="application/ld+json" data-threadnote-post>${structuredData}</script>`,
+  ].join('\n    ');
+  if (!html.includes('</head>')) throw new ScriptError("What's New HTML template is missing </head>");
+  html = html.replace('</head>', `    ${postMetadata}\n  </head>`);
+  if (!html.includes('<div id="root"></div>')) throw new ScriptError("What's New HTML template is missing #root");
+  return html.replace('<div id="root"></div>', `<div id="root">${crawlerFallback(post)}</div>`);
+}
+
+export function renderWebsitePostsSitemap(sitemap: string, posts: readonly WebsitePost[]): string {
+  const generated = [
+    generatedSitemapStart,
+    ...posts.map(post => {
+      const path = post.kind === 'article' ? whatsNewArticlePath(post.slug) : whatsNewReleasePath(post.version);
+      return `  <url><loc>${new URL(path, publicOrigin).href}</loc><lastmod>${post.publishedAt}</lastmod></url>`;
+    }),
+    generatedSitemapEnd,
+  ].join('\n');
+  const generatedPattern = new RegExp(
+    `${escapeRegExp(generatedSitemapStart)}[\\s\\S]*?${escapeRegExp(generatedSitemapEnd)}`,
+  );
+  if (generatedPattern.test(sitemap)) return sitemap.replace(generatedPattern, generated);
+  if (!sitemap.includes('</urlset>')) throw new ScriptError('Website sitemap is missing </urlset>');
+  return sitemap.replace('</urlset>', `${generated}\n</urlset>`);
+}
+
+export const generateWebsitePostPages = Effect.fn('siteArticles.generatePostPages')(function* (siteDist?: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const repositoryRoot = process.cwd();
+  const outputRoot = siteDist ?? path.resolve(repositoryRoot, 'site-dist');
+  const articles = yield* Effect.tryPromise({
+    try: () => loadWebsiteArticles(repositoryRoot),
+    catch: error =>
+      error instanceof ScriptError ? error : new ScriptError(`Could not load website articles: ${String(error)}`),
+  });
+  const releases = yield* Effect.try({
+    try: () => loadLatestMajorWebsiteReleases(repositoryRoot),
+    catch: error =>
+      error instanceof ScriptError ? error : new ScriptError(`Could not load website releases: ${String(error)}`),
+  });
+  const posts = orderWebsitePostsDescending([
+    ...articles,
+    ...releases.map(release => ({
+      ...release,
+      author: 'Threadnote' as const,
+      kind: 'release' as const,
+      title: `Threadnote ${release.version.replace(/^v/, '')}`,
+    })),
+  ]);
+  const templatePath = path.join(outputRoot, 'whats-new', 'index.html');
+  const [template, sitemap] = yield* Effect.all(
+    [fs.readFileString(templatePath), fs.readFileString(path.join(outputRoot, 'sitemap.xml'))],
+    {concurrency: 2},
+  );
+
+  yield* Effect.forEach(
+    posts,
+    post =>
+      Effect.gen(function* () {
+        const relativePath =
+          post.kind === 'article' ? whatsNewArticlePath(post.slug) : whatsNewReleasePath(post.version);
+        const outputPath = path.join(outputRoot, relativePath, 'index.html');
+        yield* fs.makeDirectory(path.dirname(outputPath), {recursive: true});
+        yield* fs.writeFileString(outputPath, renderWebsitePostHtml(template, post));
+      }),
+    {concurrency: 1},
+  );
+
+  yield* fs.writeFileString(path.join(outputRoot, 'sitemap.xml'), renderWebsitePostsSitemap(sitemap, posts));
+  yield* fs.writeFileString(templatePath, renderWhatsNewIndexHtml(template, posts));
+  return {articleCount: articles.length, releaseCount: releases.length};
+});
+
+if (import.meta.main) {
+  BunRuntime.runMain(
+    provideScriptLayer(
+      generateWebsitePostPages().pipe(
+        Effect.tap(({articleCount, releaseCount}) =>
+          Console.log(`Generated ${articleCount} article page(s) and ${releaseCount} release post page(s).`),
+        ),
+      ),
+      BunServices.layer,
+    ),
+  );
+}

--- a/scripts/site-release-notes.ts
+++ b/scripts/site-release-notes.ts
@@ -11,6 +11,7 @@ export interface PublishedReleaseRef extends StableReleaseVersion {
 }
 
 export interface WebsiteRelease extends PublishedReleaseRef {
+  readonly body: string;
   readonly summary: string;
   readonly highlights: readonly string[];
   readonly releaseUrl: string;
@@ -177,6 +178,7 @@ export function loadLatestMajorWebsiteReleases(repositoryRoot: string): readonly
     if (!summary) throw new ScriptError(`${releaseNotePath} needs an introductory release summary.`);
     return {
       ...release,
+      body: markdown,
       highlights,
       releaseUrl: `https://github.com/Kashkovsky/threadnote/releases/tag/${release.version}`,
       summary,

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -1,7 +1,8 @@
 import {TestError} from '../helpers/test-error.js';
 import {execFileSync} from '../helpers/node-child-process.js';
-import {access, readFile} from '../helpers/node-fs-promises.js';
+import {access, mkdir, mkdtemp, readFile, rm, writeFile} from '../helpers/node-fs-promises.js';
 import {join} from '../helpers/node-path.js';
+import {tmpdir} from '../helpers/node-os.js';
 import fc from 'fast-check';
 import {createElement} from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
@@ -11,6 +12,14 @@ import {
   performanceArtifactPublicUrl,
   sha256Hex,
 } from '../../scripts/site-performance-evidence.js';
+import {
+  loadWebsiteArticles,
+  orderWebsitePostsDescending,
+  parseWebsiteArticle,
+  renderWhatsNewIndexHtml,
+  renderWebsitePostHtml,
+  renderWebsitePostsSitemap,
+} from '../../scripts/site-articles.js';
 import {
   loadLatestMajorWebsiteReleases,
   parseStableReleaseVersion,
@@ -56,9 +65,13 @@ import {
   isSameDocumentNavigation,
   siteCanonicalUrlForPathname,
   sitePageForPathname,
+  whatsNewArticlePath,
+  whatsNewPostForPathname,
+  whatsNewReleasePath,
   type SitePage,
 } from '../../website/src/lib/routes.js';
 import {renderDocsArticleHtml, renderDocsSitemap} from '../../scripts/site-doc-pages.js';
+import {orderWebsiteUpdatesDescending} from '../../website/src/content/websiteArticles.js';
 import type {BenchmarkArtifactV1} from '../../src/evaluation/benchmark.js';
 import {proTips} from '../../website/src/content/proTips.js';
 import {EXTERNAL_REPOSITORY_REQUIRED_MEASUREMENTS} from '../../src/evaluation/external_evidence.js';
@@ -512,6 +525,104 @@ describe('Threadnote 4 website content', () => {
     );
   });
 
+  it('validates authored Markdown articles and loads them newest first', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'threadnote-website-articles-'));
+    const article = (publishedAt: string, slug: string, title: string) => `---
+author: Denys Kashkovskyi
+publishedAt: ${publishedAt}
+slug: ${slug}
+summary: ${title} has a standalone summary for readers and social previews.
+title: ${title}
+---
+
+An external-facing introduction.
+
+## Evidence first
+
+The body remains ordinary **Markdown**.
+`;
+    try {
+      await mkdir(join(repository, 'website', 'articles'), {recursive: true});
+      await writeFile(
+        join(repository, 'website', 'articles', '2026-08-25T09-00-00Z--earlier-story.md'),
+        article('2026-08-25T09:00:00Z', 'earlier-story', 'Earlier story'),
+      );
+      await writeFile(
+        join(repository, 'website', 'articles', '2026-08-26T14-30-00Z--evidence-before-rewrites.md'),
+        article('2026-08-26T14:30:00Z', 'evidence-before-rewrites', 'Evidence before rewrites'),
+      );
+
+      const loaded = await loadWebsiteArticles(repository);
+      expect(loaded.map(entry => entry.slug)).toEqual(['evidence-before-rewrites', 'earlier-story']);
+      expect(loaded[0]).toMatchObject({
+        author: 'Denys Kashkovskyi',
+        highlights: ['Evidence first'],
+        kind: 'article',
+        publishedAt: '2026-08-26T14:30:00Z',
+      });
+      expect(() =>
+        parseWebsiteArticle(
+          '2026-08-26T14-30-00Z--wrong-slug.md',
+          article('2026-08-26T14:30:00Z', 'evidence-before-rewrites', 'Evidence before rewrites'),
+        ),
+      ).toThrow('filename timestamp and slug must exactly match');
+      expect(() =>
+        parseWebsiteArticle(
+          '2026-08-26T14-30-00Z--evidence-before-rewrites.md',
+          article('2026-08-26T14:30:00Z', 'evidence-before-rewrites', 'Evidence before rewrites').replace(
+            'title: Evidence before rewrites',
+            'category: engineering\ntitle: Evidence before rewrites',
+          ),
+        ),
+      ).toThrow('unknown frontmatter field');
+      expect(() =>
+        parseWebsiteArticle(
+          '2026-08-26T14-30-00Z--evidence-before-rewrites.md',
+          article('2026-08-26T14:30:00Z', 'evidence-before-rewrites', 'Evidence before rewrites').replace(
+            'An external-facing introduction.',
+            'Publication placeholder: replace this before shipping.',
+          ),
+        ),
+      ).toThrow('publication placeholders are forbidden');
+      expect(() =>
+        parseWebsiteArticle(
+          '2026-02-31T14-30-00Z--evidence-before-rewrites.md',
+          article('2026-02-31T14:30:00Z', 'evidence-before-rewrites', 'Evidence before rewrites'),
+        ),
+      ).toThrow('publishedAt must be an exact UTC timestamp');
+    } finally {
+      await rm(repository, {force: true, recursive: true});
+    }
+  });
+
+  it('orders release and article updates deterministically without mutating the input', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.record({second: fc.integer({min: 0, max: 59}), stableId: fc.uuid()}), {maxLength: 80}),
+        updates => {
+          const input = updates.map(({second, stableId}) => ({
+            publishedAt: `2026-08-26T14:30:${String(second).padStart(2, '0')}Z`,
+            stableId,
+          }));
+          const before = structuredClone(input);
+          const ordered = orderWebsiteUpdatesDescending(input);
+
+          expect(input).toEqual(before);
+          expect(ordered).toHaveLength(input.length);
+          for (let index = 1; index < ordered.length; index += 1) {
+            const previous = ordered[index - 1]!;
+            const current = ordered[index]!;
+            expect(
+              Date.parse(previous.publishedAt) > Date.parse(current.publishedAt) ||
+                (previous.publishedAt === current.publishedAt && previous.stableId <= current.stableId),
+            ).toBe(true);
+          }
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
   it('covers the complete 4.0 documentation map with unique article anchors', () => {
     const articles = docsSections.flatMap(section => section.articles);
     const articleIds = articles.map(article => article.id);
@@ -923,12 +1034,28 @@ describe('Threadnote 4 website content', () => {
     expect(sitePageForPathname('/threadnote', '/threadnote/')).toBe('home');
     expect(sitePageForPathname('/threadnote/docs/worksets/', '/threadnote/')).toBe('docs');
     expect(docsArticleIdForPathname('/threadnote/docs/worksets/', '/threadnote/')).toBe('worksets');
+    expect(sitePageForPathname('/threadnote/whats-new/articles/evidence-before-rewrites/', '/threadnote/')).toBe(
+      'whats-new',
+    );
+    expect(whatsNewPostForPathname('/threadnote/whats-new/articles/evidence-before-rewrites/', '/threadnote/')).toEqual(
+      {kind: 'article', slug: 'evidence-before-rewrites'},
+    );
+    expect(whatsNewPostForPathname('/threadnote/whats-new/releases/v4.3.8/', '/threadnote/')).toEqual({
+      kind: 'release',
+      version: 'v4.3.8',
+    });
     expect(sitePageForPathname('/threadnote/docs/nested/extra/', '/threadnote/')).toBeUndefined();
     expect(sitePageForPathname('/other/docs/', '/threadnote/')).toBeUndefined();
     expect(siteCanonicalUrlForPathname('/performance/', '/')).toBe('https://threadnote.io/performance/');
     expect(siteCanonicalUrlForPathname('/threadnote/docs/', '/threadnote/')).toBe('https://threadnote.io/docs/');
     expect(siteCanonicalUrlForPathname('/threadnote/docs/worksets/', '/threadnote/')).toBe(
       'https://threadnote.io/docs/worksets/',
+    );
+    expect(
+      siteCanonicalUrlForPathname('/threadnote/whats-new/articles/evidence-before-rewrites/', '/threadnote/'),
+    ).toBe('https://threadnote.io/whats-new/articles/evidence-before-rewrites/');
+    expect(siteCanonicalUrlForPathname('/threadnote/whats-new/releases/v4.3.8/', '/threadnote/')).toBe(
+      'https://threadnote.io/whats-new/releases/v4.3.8/',
     );
     expect(
       isSameDocumentNavigation(
@@ -960,6 +1087,30 @@ describe('Threadnote 4 website content', () => {
     );
   });
 
+  it('round-trips stable article and release post paths under every supported site base', () => {
+    const slug = fc
+      .array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789-'), {minLength: 1, maxLength: 48})
+      .map(parts => parts.join(''))
+      .filter(value => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value));
+
+    fc.assert(
+      fc.property(slug, fc.constantFrom('/', '/threadnote/'), (articleSlug, basePath) => {
+        const articlePathname = `${basePath}${whatsNewArticlePath(articleSlug)}`.replace(/\/+/g, '/');
+        const releasePathname = `${basePath}${whatsNewReleasePath('v4.3.8')}`.replace(/\/+/g, '/');
+        expect(sitePageForPathname(articlePathname, basePath)).toBe('whats-new');
+        expect(whatsNewPostForPathname(articlePathname, basePath)).toEqual({kind: 'article', slug: articleSlug});
+        expect(siteCanonicalUrlForPathname(articlePathname, basePath)).toBe(
+          `https://threadnote.io/${whatsNewArticlePath(articleSlug)}`,
+        );
+        expect(whatsNewPostForPathname(releasePathname, basePath)).toEqual({kind: 'release', version: 'v4.3.8'});
+        expect(siteCanonicalUrlForPathname(releasePathname, basePath)).toBe(
+          `https://threadnote.io/${whatsNewReleasePath('v4.3.8')}`,
+        );
+      }),
+      {numRuns: 100},
+    );
+  });
+
   it('renders crawler-visible metadata and sitemap entries for exact documentation articles', async () => {
     const worksets = docsSections.flatMap(section => section.articles).find(article => article.id === 'worksets');
     expect(worksets).toBeDefined();
@@ -979,6 +1130,66 @@ describe('Threadnote 4 website content', () => {
     expect(rendered).toContain(`content="${worksets!.summary}"`);
     expect(renderedSitemap).toContain('<loc>https://threadnote.io/docs/worksets/</loc>');
     expect(renderDocsSitemap(renderedSitemap, [worksets!])).toBe(renderedSitemap);
+  });
+
+  it('renders crawlable, authored article and release post pages with social metadata', async () => {
+    const article = parseWebsiteArticle(
+      '2026-08-26T14-30-00Z--evidence-before-rewrites.md',
+      `---
+author: Denys Kashkovskyi
+publishedAt: 2026-08-26T14:30:00Z
+slug: evidence-before-rewrites
+summary: An evidence-led engineering story for readers outside the Threadnote project.
+title: Evidence before rewrites
+---
+
+The full article remains visible to crawlers before the client application starts.
+
+## Measure the system
+
+Make the bottleneck observable.
+`,
+    );
+    const release = loadLatestMajorWebsiteReleases(root)[0]!;
+    const releasePost = {
+      ...release,
+      author: 'Threadnote' as const,
+      kind: 'release' as const,
+      title: `Threadnote ${release.version.replace(/^v/, '')}`,
+    };
+    const [template, sitemap] = await Promise.all([
+      readFile(join(root, 'website', 'whats-new', 'index.html'), 'utf8'),
+      readFile(join(root, 'website', 'public', 'sitemap.xml'), 'utf8'),
+    ]);
+    const renderedArticle = renderWebsitePostHtml(template, article);
+    const renderedRelease = renderWebsitePostHtml(template, releasePost);
+    const renderedIndex = renderWhatsNewIndexHtml(template, [releasePost, article]);
+    const renderedSitemap = renderWebsitePostsSitemap(sitemap, [article, releasePost]);
+
+    expect(renderedArticle).toContain('<title>Evidence before rewrites — Threadnote</title>');
+    expect(renderedArticle).toContain(
+      '<link rel="canonical" href="https://threadnote.io/whats-new/articles/evidence-before-rewrites/" />',
+    );
+    expect(renderedArticle).toContain('<meta property="og:type" content="article" />');
+    expect(renderedArticle).toContain('<meta property="article:author" content="Denys Kashkovskyi" />');
+    expect(renderedArticle).toContain('"@type":"Article"');
+    expect(renderedArticle).toContain('"name":"Denys Kashkovskyi"');
+    expect(renderedArticle).toContain('<h1>Evidence before rewrites</h1>');
+    expect(renderedArticle).toContain('<h2>Measure the system</h2>');
+    expect(renderedArticle).toContain('Permanent public URL');
+    expect(renderedArticle).toContain('https://x.com/intent/post?');
+    expect(renderedArticle).toContain('https://www.linkedin.com/sharing/share-offsite/?url=');
+    expect(renderedRelease).toContain(
+      `<link rel="canonical" href="https://threadnote.io/whats-new/releases/${release.version}/" />`,
+    );
+    expect(renderedRelease).toContain('"@type":"TechArticle"');
+    expect(renderedSitemap).toContain('<loc>https://threadnote.io/whats-new/articles/evidence-before-rewrites/</loc>');
+    expect(renderedSitemap).toContain(`<loc>https://threadnote.io/whats-new/releases/${release.version}/</loc>`);
+    expect(renderWebsitePostsSitemap(renderedSitemap, [article, releasePost])).toBe(renderedSitemap);
+    expect(renderedIndex).toContain('data-threadnote-index');
+    expect(renderedIndex).toContain('<h1>Threadnote articles and releases</h1>');
+    const orderedTitles = orderWebsitePostsDescending([releasePost, article]).map(post => post.title);
+    expect(renderedIndex.indexOf(orderedTitles[0]!)).toBeLessThan(renderedIndex.indexOf(orderedTitles[1]!));
   });
 
   it('shows checked-in public measurements instead of placeholder performance cards', async () => {

--- a/test/unit/website-release-boundary.test.ts
+++ b/test/unit/website-release-boundary.test.ts
@@ -95,6 +95,7 @@ describe('website and standalone release boundary', () => {
 
     expect(manifest.scripts.build).not.toContain('site:');
     expect(manifest.scripts['site:build']).toBeDefined();
+    expect(manifest.scripts['site:build']).toContain('scripts/site-articles.ts');
     expect(manifest.scripts['site:check']).toContain('site:test');
   });
 
@@ -202,6 +203,7 @@ describe('website and standalone release boundary', () => {
     expect(pushTrigger).toContain("'package.json'");
     expect(pushTrigger).toContain("'website/**'");
     expect(pushTrigger).toContain("'scripts/site-doc-pages.ts'");
+    expect(pushTrigger).toContain("'scripts/site-articles.ts'");
     expect(pushTrigger).toContain("'scripts/site-performance-evidence.ts'");
     expect(pushTrigger).toContain("'scripts/site-release-notes.ts'");
     expect(pushTrigger).toContain("'src/evaluation/benchmark.ts'");

--- a/website/articles/README.md
+++ b/website/articles/README.md
@@ -1,0 +1,24 @@
+# Website articles
+
+Authored articles on Threadnote’s “What’s New” timeline live here as Markdown. Each article uses this contract:
+
+```md
+---
+author: Denys Kashkovskyi
+publishedAt: 2026-08-26T14:30:00Z
+slug: evidence-before-rewrites
+summary: A concise, standalone description for cards, search results, and social previews.
+title: Evidence before rewrites
+---
+
+Article body in Markdown.
+```
+
+Name the file `2026-08-26T14-30-00Z--evidence-before-rewrites.md`. The filename timestamp and slug must exactly match
+the frontmatter. This makes chronology reviewable in the repository while the explicit slug remains the stable public
+URL at `/whats-new/articles/evidence-before-rewrites/`.
+
+`author`, `publishedAt`, `slug`, `summary`, and `title` are required. `authorUrl` is optional and must be a
+credential-free HTTPS URL. The site build rejects duplicate slugs, invalid timestamps, unknown frontmatter fields, and
+empty bodies. It emits crawler-readable HTML, canonical and social metadata, Article JSON-LD, and sitemap entries for
+every valid article.

--- a/website/src/components/PostShare.tsx
+++ b/website/src/components/PostShare.tsx
@@ -1,0 +1,53 @@
+import {useRef, useState} from 'react';
+
+export function PostShare({title, url}: {readonly title: string; readonly url: string}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [copyStatus, setCopyStatus] = useState('Copy link');
+  const shareText = encodeURIComponent(title);
+  const shareUrl = encodeURIComponent(url);
+
+  const copy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopyStatus('Copied');
+    } catch {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+      setCopyStatus('Select and copy');
+    }
+  };
+
+  return (
+    <section className="post-share" aria-labelledby="post-share-title">
+      <div>
+        <span className="eyebrow" id="post-share-title">
+          Share this post
+        </span>
+        <label htmlFor="post-share-url">Permanent public URL</label>
+      </div>
+      <div className="post-share__target">
+        <input
+          id="post-share-url"
+          ref={inputRef}
+          readOnly
+          value={url}
+          onFocus={event => event.currentTarget.select()}
+        />
+        <button type="button" onClick={() => void copy()}>
+          {copyStatus}
+        </button>
+      </div>
+      <div className="post-share__platforms" aria-label="Share on a social platform">
+        <a href={`https://x.com/intent/post?text=${shareText}&url=${shareUrl}`} target="_blank" rel="noreferrer">
+          Share on X
+        </a>
+        <a href={`https://www.linkedin.com/sharing/share-offsite/?url=${shareUrl}`} target="_blank" rel="noreferrer">
+          Share on LinkedIn
+        </a>
+      </div>
+      <p className="sr-only" aria-live="polite">
+        {copyStatus === 'Copy link' ? '' : copyStatus}
+      </p>
+    </section>
+  );
+}

--- a/website/src/content/websiteArticles.ts
+++ b/website/src/content/websiteArticles.ts
@@ -1,0 +1,23 @@
+export interface WebsiteArticle {
+  readonly author: string;
+  readonly authorUrl?: string;
+  readonly body: string;
+  readonly highlights: readonly string[];
+  readonly kind: 'article';
+  readonly publishedAt: string;
+  readonly slug: string;
+  readonly summary: string;
+  readonly title: string;
+}
+
+export interface WebsiteUpdateOrderRef {
+  readonly publishedAt: string;
+  readonly stableId: string;
+}
+
+export function orderWebsiteUpdatesDescending<T extends WebsiteUpdateOrderRef>(updates: readonly T[]): readonly T[] {
+  return [...updates].sort(
+    (left, right) =>
+      Date.parse(right.publishedAt) - Date.parse(left.publishedAt) || left.stableId.localeCompare(right.stableId),
+  );
+}

--- a/website/src/lib/routes.ts
+++ b/website/src/lib/routes.ts
@@ -39,6 +39,14 @@ export function docsArticlePath(articleId: string): string {
   return `docs/${encodeURIComponent(articleId)}/`;
 }
 
+export function whatsNewArticlePath(slug: string): string {
+  return `whats-new/articles/${encodeURIComponent(slug)}/`;
+}
+
+export function whatsNewReleasePath(version: string): string {
+  return `whats-new/releases/${encodeURIComponent(version)}/`;
+}
+
 export function docsArticleIdForPathname(pathname: string, basePath: string): string | undefined {
   const relativePath = siteRelativePathname(pathname, basePath);
   const match = relativePath?.match(/^docs\/([^/]+)$/);
@@ -51,16 +59,48 @@ export function docsArticleIdForPathname(pathname: string, basePath: string): st
   }
 }
 
+export type WhatsNewPostRoute =
+  Readonly<{kind: 'article'; slug: string}> | Readonly<{kind: 'release'; version: string}>;
+
+export function whatsNewPostForPathname(pathname: string, basePath: string): WhatsNewPostRoute | undefined {
+  const relativePath = siteRelativePathname(pathname, basePath);
+  const match = relativePath?.match(/^whats-new\/(articles|releases)\/([^/]+)$/);
+  if (!match?.[1] || !match[2]) return undefined;
+  try {
+    const id = decodeURIComponent(match[2]);
+    if (match[1] === 'articles' && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) {
+      return {kind: 'article', slug: id};
+    }
+    if (match[1] === 'releases' && /^v\d+\.\d+\.\d+$/.test(id)) {
+      return {kind: 'release', version: id};
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function sitePageForPathname(pathname: string, basePath: string): SitePage | undefined {
   const relativePath = siteRelativePathname(pathname, basePath);
   if (relativePath === undefined) return undefined;
 
-  return pagesByPath.get(relativePath) ?? (docsArticleIdForPathname(pathname, basePath) ? 'docs' : undefined);
+  return (
+    pagesByPath.get(relativePath) ??
+    (docsArticleIdForPathname(pathname, basePath) ? 'docs' : undefined) ??
+    (whatsNewPostForPathname(pathname, basePath) ? 'whats-new' : undefined)
+  );
 }
 
 export function siteCanonicalUrlForPathname(pathname: string, basePath: string): string {
   const docsArticleId = docsArticleIdForPathname(pathname, basePath);
   if (docsArticleId) return new URL(docsArticlePath(docsArticleId), 'https://threadnote.io/').href;
+  const whatsNewPost = whatsNewPostForPathname(pathname, basePath);
+  if (whatsNewPost?.kind === 'article') {
+    return new URL(whatsNewArticlePath(whatsNewPost.slug), 'https://threadnote.io/').href;
+  }
+  if (whatsNewPost?.kind === 'release') {
+    return new URL(whatsNewReleasePath(whatsNewPost.version), 'https://threadnote.io/').href;
+  }
   const page = sitePageForPathname(pathname, basePath) ?? 'home';
   const route = sitePagePaths[page];
   return new URL(route ? `${route}/` : '', 'https://threadnote.io/').href;

--- a/website/src/lib/site.ts
+++ b/website/src/lib/site.ts
@@ -1,4 +1,4 @@
-import {docsArticlePath, siteCanonicalUrlForPathname} from './routes.js';
+import {docsArticlePath, siteCanonicalUrlForPathname, whatsNewArticlePath, whatsNewReleasePath} from './routes.js';
 
 const base = import.meta.env.BASE_URL;
 
@@ -9,6 +9,14 @@ export function siteHref(path = ''): string {
 
 export function docsArticleHref(articleId: string): string {
   return siteHref(docsArticlePath(articleId));
+}
+
+export function whatsNewArticleHref(slug: string): string {
+  return siteHref(whatsNewArticlePath(slug));
+}
+
+export function whatsNewReleaseHref(version: string): string {
+  return siteHref(whatsNewReleasePath(version));
 }
 
 export const githubUrl = 'https://github.com/Kashkovsky/threadnote';

--- a/website/src/pages/WhatsNewPage.tsx
+++ b/website/src/pages/WhatsNewPage.tsx
@@ -1,54 +1,128 @@
 import {useEffect} from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import articles from 'virtual:threadnote-articles';
 import releases from 'virtual:threadnote-release-notes';
 import {Icon} from '../components/Icons';
+import {PostShare} from '../components/PostShare';
 import {SiteShell} from '../components/SiteShell';
-import {docsArticleHref, setDocumentMeta} from '../lib/site';
+import {orderWebsiteUpdatesDescending} from '../content/websiteArticles';
+import {whatsNewArticlePath, whatsNewPostForPathname, whatsNewReleasePath} from '../lib/routes';
+import {docsArticleHref, setDocumentMeta, siteHref, whatsNewArticleHref, whatsNewReleaseHref} from '../lib/site';
 
-const releaseDate = new Intl.DateTimeFormat('en', {
+const postDate = new Intl.DateTimeFormat('en', {
   day: 'numeric',
   month: 'long',
   timeZone: 'UTC',
   year: 'numeric',
 });
 
-function displayVersion(version: string): string {
-  return version.replace(/^v/, '');
+type WebsiteUpdate = Readonly<{
+  author: string;
+  body: string;
+  canonicalUrl: string;
+  externalHref?: string;
+  highlights: readonly string[];
+  href: string;
+  kind: 'article' | 'release';
+  publishedAt: string;
+  stableId: string;
+  summary: string;
+  title: string;
+  version?: string;
+}>;
+
+function websiteUpdates(): readonly WebsiteUpdate[] {
+  return orderWebsiteUpdatesDescending([
+    ...articles.map(article => ({
+      author: article.author,
+      body: article.body,
+      canonicalUrl: new URL(whatsNewArticlePath(article.slug), 'https://threadnote.io/').href,
+      highlights: article.highlights,
+      href: whatsNewArticleHref(article.slug),
+      kind: 'article' as const,
+      publishedAt: article.publishedAt,
+      stableId: `article:${article.slug}`,
+      summary: article.summary,
+      title: article.title,
+    })),
+    ...releases.map(release => ({
+      author: 'Threadnote',
+      body: release.body,
+      canonicalUrl: new URL(whatsNewReleasePath(release.version), 'https://threadnote.io/').href,
+      externalHref: release.releaseUrl,
+      highlights: release.highlights,
+      href: whatsNewReleaseHref(release.version),
+      kind: 'release' as const,
+      publishedAt: release.publishedAt,
+      stableId: `release:${release.version}`,
+      summary: release.summary,
+      title: `Threadnote ${release.version.replace(/^v/, '')}`,
+      version: release.version,
+    })),
+  ]);
 }
 
-function ReleaseMeta({publishedAt, version}: {readonly publishedAt: string; readonly version: string}) {
+function UpdateMeta({update}: {readonly update: WebsiteUpdate}) {
   return (
-    <div className="release-meta">
-      <span>Release</span>
-      <strong>{version}</strong>
-      <time dateTime={publishedAt}>{releaseDate.format(new Date(publishedAt))}</time>
+    <div className={`release-meta release-meta--${update.kind}`}>
+      <span>{update.kind === 'article' ? 'Article' : 'Release'}</span>
+      <strong>{update.kind === 'article' ? `By ${update.author}` : update.version}</strong>
+      <time dateTime={update.publishedAt}>{postDate.format(new Date(update.publishedAt))}</time>
     </div>
   );
 }
 
-export default function WhatsNewPage() {
-  const latest = releases[0]!;
-  const earlier = releases.slice(1);
-
+function UpdateDetail({update}: {readonly update: WebsiteUpdate}) {
   useEffect(() => {
-    setDocumentMeta(
-      "What's new",
-      `The latest Threadnote ${latest.major} releases, improvements, and upgrade highlights.`,
-    );
-  }, [latest.major]);
+    setDocumentMeta(update.title, update.summary);
+  }, [update.summary, update.title]);
 
   return (
     <SiteShell page="whats-new" fullBleed>
-      <section className="release-hero" aria-labelledby="latest-release-title">
+      <article className="post-detail">
+        <a className="post-detail__back" href={siteHref('whats-new/')}>
+          <span aria-hidden="true">←</span> All articles and releases
+        </a>
+        <header className="post-detail__header">
+          <UpdateMeta update={update} />
+          <h1>{update.title}</h1>
+          <p>{update.summary}</p>
+          {update.kind === 'release' && update.externalHref ? (
+            <a className="button button--ghost" href={update.externalHref} target="_blank" rel="noreferrer">
+              GitHub release
+              <Icon name="arrow" aria-hidden="true" />
+            </a>
+          ) : null}
+        </header>
+        <div className="post-detail__body">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{update.body}</ReactMarkdown>
+        </div>
+        <PostShare title={update.title} url={update.canonicalUrl} />
+      </article>
+    </SiteShell>
+  );
+}
+
+function WhatsNewIndex({updates}: {readonly updates: readonly WebsiteUpdate[]}) {
+  const latest = updates[0]!;
+  const earlier = updates.slice(1);
+
+  useEffect(() => {
+    setDocumentMeta("What's new", 'Threadnote articles, stable releases, engineering stories, and upgrade highlights.');
+  }, []);
+
+  return (
+    <SiteShell page="whats-new" fullBleed>
+      <section className="release-hero" aria-labelledby="latest-update-title">
         <div className="release-hero__intro">
-          <ReleaseMeta publishedAt={latest.publishedAt} version={latest.version} />
-          <span className="eyebrow">What&apos;s new in Threadnote {latest.major}</span>
-          <h1 id="latest-release-title">
-            Threadnote {displayVersion(latest.version)} <span>is here.</span>
-          </h1>
+          <UpdateMeta update={latest} />
+          <span className="eyebrow">Latest from Threadnote</span>
+          <h1 id="latest-update-title">{latest.title}</h1>
           <p>{latest.summary}</p>
           <div className="release-hero__actions">
-            <a className="button" href={latest.releaseUrl} target="_blank" rel="noreferrer">
-              Read the full release notes
+            <a className="button" href={latest.href}>
+              {latest.kind === 'article' ? 'Read the article' : 'Read the release post'}
               <Icon name="arrow" aria-hidden="true" />
             </a>
             <a className="button button--ghost" href={docsArticleHref('installation')}>
@@ -57,10 +131,10 @@ export default function WhatsNewPage() {
           </div>
         </div>
 
-        <div className="release-hero__highlights" aria-label={`${latest.version} highlights`}>
+        <div className="release-hero__highlights" aria-label={`${latest.title} highlights`}>
           <div className="release-hero__index">
-            <span>Latest stable</span>
-            <strong>{String(latest.major).padStart(2, '0')}</strong>
+            <span>Latest {latest.kind}</span>
+            <strong>{latest.kind === 'article' ? 'A' : 'R'}</strong>
           </div>
           <ol>
             {latest.highlights.slice(0, 4).map((highlight, index) => (
@@ -76,33 +150,33 @@ export default function WhatsNewPage() {
       <section className="release-archive" aria-labelledby="release-archive-title">
         <header className="release-archive__heading">
           <div>
-            <span className="eyebrow">Release archive</span>
-            <h2 id="release-archive-title">Earlier in Threadnote {latest.major}.</h2>
+            <span className="eyebrow">Articles and releases</span>
+            <h2 id="release-archive-title">The Threadnote timeline.</h2>
           </div>
           <p>
-            {releases.length} stable releases in the current major line, ordered newest first. Prereleases and older
-            major versions stay out of this view.
+            {updates.length} public posts, ordered by publication time. Each article and stable release has its own
+            permanent, shareable page.
           </p>
         </header>
 
         <div className="release-grid">
-          {earlier.map((release, index) => (
-            <article className="release-card" key={release.version}>
-              <ReleaseMeta publishedAt={release.publishedAt} version={release.version} />
+          {earlier.map((update, index) => (
+            <article className={`release-card release-card--${update.kind}`} key={update.stableId}>
+              <UpdateMeta update={update} />
               <div className="release-card__number" aria-hidden="true">
                 {String(index + 2).padStart(2, '0')}
               </div>
-              <h3>Threadnote {displayVersion(release.version)}</h3>
-              <p>{release.summary}</p>
-              {release.highlights.length > 0 ? (
+              <h3>{update.title}</h3>
+              <p>{update.summary}</p>
+              {update.highlights.length > 0 ? (
                 <ul>
-                  {release.highlights.slice(0, 3).map(highlight => (
+                  {update.highlights.slice(0, 3).map(highlight => (
                     <li key={highlight}>{highlight}</li>
                   ))}
                 </ul>
               ) : null}
-              <a className="text-link" href={release.releaseUrl} target="_blank" rel="noreferrer">
-                View release notes
+              <a className="text-link" href={update.href}>
+                {update.kind === 'article' ? 'Read article' : 'Read release post'}
                 <Icon name="arrow" aria-hidden="true" />
               </a>
             </article>
@@ -111,4 +185,18 @@ export default function WhatsNewPage() {
       </section>
     </SiteShell>
   );
+}
+
+export default function WhatsNewPage() {
+  const updates = websiteUpdates();
+  const route = whatsNewPostForPathname(window.location.pathname, import.meta.env.BASE_URL);
+  const selected = route
+    ? updates.find(update =>
+        route.kind === 'article'
+          ? update.stableId === `article:${route.slug}`
+          : update.stableId === `release:${route.version}`,
+      )
+    : undefined;
+
+  return selected ? <UpdateDetail update={selected} /> : <WhatsNewIndex updates={updates} />;
 }

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -2582,6 +2582,260 @@ p {
   margin-top: auto;
 }
 
+.release-meta--article > span,
+.release-card--article > ul li::before {
+  color: var(--blue);
+}
+
+.release-card--article::before {
+  background: var(--blue);
+}
+
+.post-detail,
+.crawler-post {
+  width: min(calc(100% - 48px), 980px);
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.post-detail {
+  padding-top: 54px;
+  padding-bottom: 140px;
+}
+
+.post-detail__back {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 80px;
+  color: var(--muted);
+  font:
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
+    monospace;
+  text-transform: uppercase;
+}
+
+.post-detail__back:hover {
+  color: var(--teal);
+}
+
+.post-detail__header {
+  padding-bottom: 64px;
+  border-bottom: 1px solid var(--line);
+}
+
+.post-detail__header > .release-meta {
+  margin-bottom: 46px;
+}
+
+.post-detail__header h1 {
+  max-width: 920px;
+  margin-bottom: 28px;
+  font-size: clamp(48px, 7vw, 82px);
+  font-weight: 590;
+  line-height: 0.98;
+}
+
+.post-detail__header > p {
+  max-width: 800px;
+  margin-bottom: 32px;
+  color: var(--text-soft);
+  font-size: clamp(18px, 2vw, 22px);
+  line-height: 1.55;
+}
+
+.post-detail__body {
+  padding: 72px 0;
+  color: var(--text-soft);
+  font-size: 17px;
+  line-height: 1.75;
+}
+
+.post-detail__body > :first-child {
+  margin-top: 0;
+}
+
+.post-detail__body h2,
+.post-detail__body h3,
+.post-detail__body h4 {
+  color: var(--text);
+  scroll-margin-top: 110px;
+}
+
+.post-detail__body h2 {
+  padding-top: 44px;
+  margin: 58px 0 22px;
+  font-size: clamp(30px, 4vw, 46px);
+  font-weight: 570;
+  line-height: 1.12;
+  border-top: 1px solid var(--line-soft);
+}
+
+.post-detail__body h3 {
+  margin: 42px 0 16px;
+  font-size: 25px;
+  font-weight: 560;
+}
+
+.post-detail__body p,
+.post-detail__body ul,
+.post-detail__body ol,
+.post-detail__body blockquote,
+.post-detail__body pre,
+.post-detail__body table {
+  margin-top: 0;
+  margin-bottom: 24px;
+}
+
+.post-detail__body ul,
+.post-detail__body ol {
+  padding-left: 28px;
+}
+
+.post-detail__body li + li {
+  margin-top: 8px;
+}
+
+.post-detail__body a {
+  color: var(--teal);
+  text-decoration: underline;
+  text-decoration-color: rgba(103, 232, 199, 0.4);
+  text-underline-offset: 4px;
+}
+
+.post-detail__body blockquote {
+  padding: 20px 24px;
+  color: var(--text);
+  background: rgba(103, 232, 199, 0.06);
+  border-left: 3px solid var(--teal);
+}
+
+.post-detail__body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.post-detail__body code {
+  padding: 2px 6px;
+  color: var(--text);
+  font-family: 'JetBrains Mono Variable', monospace;
+  font-size: 0.86em;
+  background: rgba(126, 139, 153, 0.12);
+  border: 1px solid var(--line-soft);
+  border-radius: 4px;
+}
+
+.post-detail__body pre {
+  padding: 22px;
+  overflow-x: auto;
+  background: var(--ink-soft);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+.post-detail__body pre code {
+  padding: 0;
+  background: transparent;
+  border: 0;
+}
+
+.post-detail__body table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.post-detail__body th,
+.post-detail__body td {
+  min-width: 140px;
+  padding: 13px 15px;
+  text-align: left;
+  border: 1px solid var(--line);
+}
+
+.post-detail__body th {
+  color: var(--text);
+  background: var(--ink-soft);
+}
+
+.post-detail__body hr {
+  margin: 52px 0;
+  border: 0;
+  border-top: 1px solid var(--line);
+}
+
+.post-share {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.55fr) minmax(280px, 1.45fr);
+  gap: 28px 40px;
+  padding: 34px;
+  background: var(--ink-soft);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.post-share label {
+  display: block;
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.post-share__target {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.post-share__target input,
+.post-share__target button {
+  min-height: 48px;
+  border: 1px solid var(--line);
+}
+
+.post-share__target input {
+  min-width: 0;
+  padding: 0 14px;
+  color: var(--text-soft);
+  font-family: 'JetBrains Mono Variable', monospace;
+  font-size: 12px;
+  background: var(--ink);
+  border-radius: 5px 0 0 5px;
+}
+
+.post-share__target button {
+  padding: 0 18px;
+  color: var(--ink);
+  font-weight: 650;
+  cursor: pointer;
+  background: var(--teal);
+  border-color: var(--teal);
+  border-radius: 0 5px 5px 0;
+}
+
+.post-share__platforms {
+  display: flex;
+  grid-column: 2;
+  gap: 18px;
+}
+
+.post-share__platforms a {
+  color: var(--text-soft);
+  font:
+    var(--font-size-min)/1.4 'JetBrains Mono Variable',
+    monospace;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.post-share__platforms a:hover {
+  color: var(--teal);
+}
+
+.crawler-post {
+  padding-top: 64px;
+  padding-bottom: 100px;
+}
+
 /* FAQ and comparison */
 
 .subpage-hero--faq {
@@ -5919,6 +6173,8 @@ p {
   .performance-methodology,
   .release-hero,
   .release-archive,
+  .post-detail,
+  .crawler-post,
   .subpage-hero {
     width: min(calc(100% - 32px), var(--content));
   }
@@ -6247,6 +6503,49 @@ p {
 
   .release-card {
     min-height: 430px;
+  }
+
+  .post-detail {
+    padding-top: 32px;
+    padding-bottom: 90px;
+  }
+
+  .post-detail__back {
+    margin-bottom: 54px;
+  }
+
+  .post-detail__header {
+    padding-bottom: 46px;
+  }
+
+  .post-detail__header > .release-meta {
+    align-items: flex-start;
+    flex-direction: column;
+    margin-bottom: 34px;
+  }
+
+  .post-detail__header > .release-meta time {
+    padding-left: 0;
+    border-left: 0;
+  }
+
+  .post-detail__header h1 {
+    font-size: clamp(42px, 12.5vw, 58px);
+  }
+
+  .post-detail__body {
+    padding: 54px 0;
+    font-size: 16px;
+  }
+
+  .post-share {
+    grid-template-columns: 1fr;
+    padding: 24px;
+  }
+
+  .post-share__platforms {
+    grid-column: 1;
+    flex-wrap: wrap;
   }
 
   .tip-detail__why {

--- a/website/src/vite-env.d.ts
+++ b/website/src/vite-env.d.ts
@@ -9,3 +9,8 @@ declare module 'virtual:threadnote-release-notes' {
   const releases: readonly import('../../scripts/site-release-notes').WebsiteRelease[];
   export default releases;
 }
+
+declare module 'virtual:threadnote-articles' {
+  const articles: readonly import('./content/websiteArticles').WebsiteArticle[];
+  export default articles;
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,5 +1,6 @@
 import react from '@vitejs/plugin-react';
 import {defineConfig, type Plugin} from 'vite';
+import {loadWebsiteArticles} from '../scripts/site-articles.ts';
 import {loadRetainedPerformanceEvidence} from '../scripts/site-performance-evidence.ts';
 import {loadLatestMajorWebsiteReleases} from '../scripts/site-release-notes.ts';
 import {embeddingContextPerformanceArtifactPath} from './src/content/embeddingContextPerformance.ts';
@@ -12,6 +13,8 @@ const virtualEvidenceId = 'virtual:threadnote-performance-evidence';
 const resolvedVirtualEvidenceId = `\0${virtualEvidenceId}`;
 const virtualReleaseNotesId = 'virtual:threadnote-release-notes';
 const resolvedVirtualReleaseNotesId = `\0${virtualReleaseNotesId}`;
+const virtualArticlesId = 'virtual:threadnote-articles';
+const resolvedVirtualArticlesId = `\0${virtualArticlesId}`;
 const worktreeReadinessArtifactSource =
   `${repositoryRoot}/test/evaluation/candidates/threadnote-4.0.1/benchmarks/` +
   'darwin-arm64-m1-max/code-graph-worktree-readiness-2026-08-04.json';
@@ -43,6 +46,18 @@ const releaseNotesPlugin: Plugin = {
   },
 };
 
+const articlesPlugin: Plugin = {
+  name: 'threadnote-articles',
+  resolveId(id: string) {
+    return id === virtualArticlesId ? resolvedVirtualArticlesId : undefined;
+  },
+  async load(id: string) {
+    if (id !== resolvedVirtualArticlesId) return undefined;
+    const articles = await loadWebsiteArticles(repositoryRoot);
+    return `export default ${JSON.stringify(articles)};`;
+  },
+};
+
 const worktreeReadinessEvidencePlugin: Plugin = {
   name: 'threadnote-worktree-readiness-evidence',
   async generateBundle() {
@@ -68,6 +83,7 @@ export default defineConfig({
     react(),
     performanceEvidencePlugin,
     releaseNotesPlugin,
+    articlesPlugin,
     worktreeReadinessEvidencePlugin,
     embeddingContextPerformanceEvidencePlugin,
   ],

--- a/website/whats-new/index.html
+++ b/website/whats-new/index.html
@@ -4,14 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
-    <meta name="description" content="The latest stable Threadnote releases, improvements, and upgrade highlights." />
+    <meta
+      name="description"
+      content="Threadnote articles, stable releases, engineering stories, and upgrade highlights."
+    />
     <meta name="theme-color" content="#080b10" />
     <link rel="canonical" href="https://threadnote.io/whats-new/" />
     <link rel="icon" href="../threadnote-logo.svg" type="image/svg+xml" sizes="any" />
     <meta property="og:title" content="What's new — Threadnote" />
     <meta
       property="og:description"
-      content="The latest stable Threadnote releases, improvements, and upgrade highlights."
+      content="Threadnote articles, stable releases, engineering stories, and upgrade highlights."
     />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Threadnote" />
@@ -20,15 +23,15 @@
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1731" />
     <meta property="og:image:height" content="909" />
-    <meta property="og:image:alt" content="What's new — Threadnote 4.1" />
+    <meta property="og:image:alt" content="What's new — Threadnote articles and releases" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="What's new — Threadnote" />
     <meta
       name="twitter:description"
-      content="The latest stable Threadnote releases, improvements, and upgrade highlights."
+      content="Threadnote articles, stable releases, engineering stories, and upgrade highlights."
     />
     <meta name="twitter:image" content="https://threadnote.io/whats-new-og.png" />
-    <meta name="twitter:image:alt" content="What's new — Threadnote 4.1" />
+    <meta name="twitter:image:alt" content="What's new — Threadnote articles and releases" />
     <title>What&apos;s new — Threadnote</title>
   </head>
   <body data-page="whats-new">


### PR DESCRIPTION
## Summary

- add a strict timestamped Markdown contract for authored articles, including explicit author/byline metadata and stable slugs
- merge articles and stable releases into one reverse-chronological What's New timeline with distinct internal detail routes
- generate crawlable article and release HTML, a crawlable chronological index, canonical/social metadata, Article or TechArticle JSON-LD, and sitemap entries
- add selectable canonical URLs plus X and LinkedIn share affordances in both the live UI and no-JS output
- reject publication placeholders and validate timestamp/filename/slug agreement, duplicate slugs, unknown metadata, HTTPS author URLs, and non-empty bodies

This PR intentionally adds the publishing infrastructure only. The finalized performance journey article will follow once its content/evidence publication guard is bound.

## Verification

- bun run site:test — 69 tests passed
- bun run site:typecheck
- strict oxlint for site, generator, and focused tests
- bun scripts/lint-file-length.ts website/src
- bun run site:build — 47 docs pages and 30 distinct release posts generated
- root and /threadnote/ base builds inspected for canonical/share URL correctness, static index/detail content, JSON-LD, sitemap coverage, and placeholder absence
- commit hooks: lint, formatting, root/test/site typechecks

## Property coverage

- mixed article/release ordering is descending, deterministic on ties, and non-mutating
- article and release detail routes round-trip under root and project-directory deployment bases