### PR TITLE
fix(ci): classify production evidence admission

### DIFF
--- a/.github/workflows/production-large-evidence.yml
+++ b/.github/workflows/production-large-evidence.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   code-graph-production-large:
-    name: Code graph production-large · n=1 · pinned Linux class
+    name: Code graph production-large admission and bounded capture · pinned Linux class
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
@@ -54,11 +54,77 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      - id: classify_production_large_admission
+        name: Classify governed production-large runner capacity
+        shell: bash
+        env:
+          ADMISSION_ARTIFACT: artifacts/code-graph-production-large-admission-${{ runner.os }}-${{ runner.arch }}-${{ inputs.release_sha || github.sha }}.json
+          MINIMUM_FREE_GIB: 120
+          RUNNER_ARCHITECTURE: ${{ runner.arch }}
+          RUNNER_ENVIRONMENT_CLASS: ${{ runner.environment }}
+          RUNNER_OPERATING_SYSTEM: ${{ runner.os }}
+          SOURCE_REF: ${{ inputs.release_ref || github.ref }}
+          SOURCE_SHA: ${{ inputs.release_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts "$RUNNER_TEMP/threadnote-production-large-admission"
+          required_bytes=$((MINIMUM_FREE_GIB * 1024 * 1024 * 1024))
+          available_kib=$(df -Pk "$RUNNER_TEMP/threadnote-production-large-admission" | awk 'END {print $4}')
+          available_bytes=$((available_kib * 1024))
+          filesystem=$(df -Pk "$RUNNER_TEMP/threadnote-production-large-admission" | awk 'END {print $1}')
+          admitted=false
+          classification=not-admitted-insufficient-capacity
+          if (( available_bytes >= required_bytes )); then
+            admitted=true
+            classification=admitted
+          fi
+          jq -n \
+            --arg classification "$classification" \
+            --arg sourceRef "$SOURCE_REF" \
+            --arg sourceSha "$SOURCE_SHA" \
+            --arg runnerArchitecture "$RUNNER_ARCHITECTURE" \
+            --arg runnerEnvironment "$RUNNER_ENVIRONMENT_CLASS" \
+            --arg runnerName "$RUNNER_NAME" \
+            --arg runnerOperatingSystem "$RUNNER_OPERATING_SYSTEM" \
+            --arg filesystem "$filesystem" \
+            --argjson availableBytes "$available_bytes" \
+            --argjson minimumFreeBytes "$required_bytes" \
+            '{
+              type: "threadnote-production-large-admission",
+              version: 1,
+              classification: $classification,
+              source: {ref: $sourceRef, sha: $sourceSha},
+              runner: {
+                architecture: $runnerArchitecture,
+                environment: $runnerEnvironment,
+                name: $runnerName,
+                operatingSystem: $runnerOperatingSystem
+              },
+              storage: {
+                probe: "runner-temp",
+                filesystem: $filesystem,
+                availableBytes: $availableBytes,
+                minimumFreeBytes: $minimumFreeBytes
+              }
+            }' > "$ADMISSION_ARTIFACT"
+          {
+            echo "admitted=$admitted"
+            echo "available_bytes=$available_bytes"
+            echo "classification=$classification"
+            echo "minimum_free_bytes=$required_bytes"
+          } >> "$GITHUB_OUTPUT"
+          if [[ "$admitted" != true ]]; then
+            echo "::warning title=Production-large evidence not admitted::Runner temp has ${available_bytes} bytes free; governed capture requires ${required_bytes} bytes."
+          fi
+
       - id: capture_production_large
         name: Capture one production-large observation with phase and storage telemetry
+        if: steps.classify_production_large_admission.outputs.admitted == 'true'
         continue-on-error: true
         timeout-minutes: 20
         env:
+          SQLITE_TMPDIR: ${{ runner.temp }}
+          TMPDIR: ${{ runner.temp }}
           THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-ubuntu-24.04-${{ runner.arch }}
           THREADNOTE_BENCHMARK_RUNNER_ID: ${{ runner.name }}
           THREADNOTE_BENCHMARK_RELEASE_REF: ${{ inputs.release_ref }}
@@ -66,6 +132,7 @@ jobs:
         run: >-
           bun run bench:code-graph --
           --profile production-large
+          --minimum-free-gib 120
           --samples 1
           --warmups 0
           --output artifacts/code-graph-production-large-n1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.release_sha || github.sha }}.json
@@ -75,8 +142,10 @@ jobs:
         if: always()
         timeout-minutes: 5
         with:
-          name: code-graph-production-large-n1-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
-          path: artifacts/code-graph-production-large-n1-*.json
+          name: code-graph-production-large-evidence-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          path: |
+            artifacts/code-graph-production-large-admission-*.json
+            artifacts/code-graph-production-large-n1-*.json
           if-no-files-found: error
           retention-days: 90
 
@@ -86,12 +155,17 @@ jobs:
         env:
           ARTIFACT_DIGEST: ${{ steps.upload-production-large.outputs.artifact-digest }}
           ARTIFACT_URL: ${{ steps.upload-production-large.outputs.artifact-url }}
+          ADMISSION_AVAILABLE_BYTES: ${{ steps.classify_production_large_admission.outputs.available_bytes }}
+          ADMISSION_CLASSIFICATION: ${{ steps.classify_production_large_admission.outputs.classification }}
+          ADMISSION_MINIMUM_FREE_BYTES: ${{ steps.classify_production_large_admission.outputs.minimum_free_bytes }}
           SOURCE_REF: ${{ inputs.release_ref || github.ref }}
           SOURCE_SHA: ${{ inputs.release_sha || github.sha }}
           MEASUREMENT_OUTCOME: ${{ steps.capture_production_large.outcome }}
           STRICT_EVIDENCE: ${{ inputs.strict }}
         run: |
-          if [[ "$STRICT_EVIDENCE" == "true" ]]; then
+          if [[ "$ADMISSION_CLASSIFICATION" != "admitted" ]]; then
+            evidence_policy='benchmark not attempted; capacity classification retained and this independent evidence workflow fails'
+          elif [[ "$STRICT_EVIDENCE" == "true" ]]; then
             evidence_policy='must complete for this evidence workflow to pass'
           else
             evidence_policy='bounded observation retained without blocking release publication'
@@ -101,6 +175,9 @@ jobs:
             echo
             echo "- Source ref: \`${SOURCE_REF}\`"
             echo "- Source commit: \`${SOURCE_SHA}\`"
+            echo "- Admission classification: \`${ADMISSION_CLASSIFICATION:-classification-unavailable}\`"
+            echo "- Runner-temp available bytes: \`${ADMISSION_AVAILABLE_BYTES:-unknown}\`"
+            echo "- Required free bytes: \`${ADMISSION_MINIMUM_FREE_BYTES:-unknown}\`"
             echo "- Measurement outcome: \`${MEASUREMENT_OUTCOME}\`"
             echo "- Evidence policy: ${evidence_policy}"
             echo "- Retained artifact digest: \`${ARTIFACT_DIGEST:-not-produced}\`"
@@ -110,8 +187,19 @@ jobs:
             echo '- Workspace policy: package-manager exclusion never removes active source from graph eligibility.'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Enforce production-large admission
+        if: always() && steps.classify_production_large_admission.outputs.admitted != 'true'
+        env:
+          ADMISSION_AVAILABLE_BYTES: ${{ steps.classify_production_large_admission.outputs.available_bytes }}
+          ADMISSION_CLASSIFICATION: ${{ steps.classify_production_large_admission.outputs.classification }}
+          ADMISSION_MINIMUM_FREE_BYTES: ${{ steps.classify_production_large_admission.outputs.minimum_free_bytes }}
+        shell: bash
+        run: |
+          echo "::error::Production-large evidence admission was ${ADMISSION_CLASSIFICATION:-classification-unavailable}: ${ADMISSION_AVAILABLE_BYTES:-unknown} bytes free, ${ADMISSION_MINIMUM_FREE_BYTES:-unknown} required."
+          exit 1
+
       - name: Enforce strict evidence completion
-        if: inputs.strict && steps.capture_production_large.outcome != 'success'
+        if: inputs.strict && steps.classify_production_large_admission.outputs.admitted == 'true' && steps.capture_production_large.outcome != 'success'
         env:
           MEASUREMENT_OUTCOME: ${{ steps.capture_production_large.outcome }}
         shell: bash

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -1,4 +1,4 @@
-name: Retain bounded production-large release evidence
+name: Classify or retain bounded production-large release evidence
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   production-large-evidence:
-    name: Retain bounded exact-tag production-large evidence
+    name: Classify or retain bounded exact-tag production-large evidence
     uses: ./.github/workflows/production-large-evidence.yml
     with:
       strict: false

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -64,8 +64,9 @@ creates a GitHub prerelease; do not use an unnumbered `-beta` suffix.
    validation/checks section.
 2. Merge the release source and ensure ordinary CI is green.
 3. Review the candidate's retained production-large and heavy-tail evidence plus required PR checks when assessing
-   graph correctness and performance. The tag starts one separate exact-tag `code-graph-production-large-n1`
-   observation automatically; do not dispatch a duplicate production-large run for that tag.
+   graph correctness and performance. The tag starts one separate exact-tag production-large capacity classification
+   and, only on an admitted runner, one `code-graph-production-large-n1` observation automatically. Do not dispatch a
+   duplicate hosted run for that tag; if the runner is not admitted, use a separately governed capable environment.
 4. Confirm immutable releases are enabled and the Apple signing secrets below are configured.
 5. Create and push the version tag matching both `package.json` and the release-notes filename, for example
    `v4.0.1`.
@@ -84,11 +85,17 @@ not combine them into a synthetic percentile. The current beta closeout contract
 [`4.1.0-beta.2-release-evidence.md`](./4.1.0-beta.2-release-evidence.md).
 
 Every Threadnote 4 version tag starts a separate production-large evidence workflow on `ubuntu-24.04`; publication
-never waits for it. The evidence job has a hard 30-minute ceiling: its measured phase gets 20 minutes, leaving bounded
-time to upload the latest privacy-safe checkpoint and summary. Incomplete release observations are reported but never delay publication;
+never waits for it. Before fixture construction, the workflow pins benchmark temporary storage to the runner-temp
+filesystem and records whether that filesystem satisfies the unchanged 120 GiB governed admission floor. A runner
+that does not satisfy the floor does not start the benchmark: the exact-tag capacity classification is retained, and
+the independent evidence workflow fails so a missing observation cannot look successful. This failure does not affect
+release publication. This fallback does not name or assume a self-hosted runner. Configure a capable runner explicitly
+before changing `runs-on`; do not add a speculative label.
+On an admitted runner, the evidence job has a hard 30-minute ceiling: its measured phase gets 20
+minutes, leaving bounded time to upload the latest privacy-safe checkpoint and summary. Incomplete admitted release observations are reported but never delay publication;
 scheduled or explicitly requested strict runs still fail when the profile does not complete inside the same bound.
-Aggregate phase/materialization evidence, failure checkpoints, exact source commit, and upload digest are retained for
-90 days. Treat a successful result as `n=1` same-runner evidence, not as a portable p95. The heavy-tail job remains
+Capacity classifications, aggregate phase/materialization evidence, failure checkpoints, exact source commit, and
+upload digest are retained for 90 days. Treat a successful completed result as `n=1` same-runner evidence, not as a portable p95. The heavy-tail job remains
 separate parser/cache coverage and must not be used as a substitute for production-scale materialization evidence.
 
 Completed release evidence remains provenance-strict: the artifact must name the Threadnote 4 tag and exact matching commit,

--- a/test/evaluation/README.md
+++ b/test/evaluation/README.md
@@ -447,7 +447,11 @@ indexed concurrently, and are queried concurrently with positive and cross-negat
 identity sharing without worktree leakage. The control reports its own duration and two indexed files; it does not
 repeat the public repository cold build.
 
-The production-large workflow additionally starts a 25 ms external sampler before it constructs the fixture, then
+The production-large workflow first pins all benchmark temporary homes to the runner-temp filesystem and writes an
+exact-source capacity-classification artifact. The unchanged governed 120 GiB floor is checked before fixture
+construction. An ineligible runner does not attempt the benchmark; its explicit `not-admitted-insufficient-capacity`
+classification is retained and the independent evidence workflow fails without blocking release publication. An
+admitted run additionally starts a 25 ms external sampler before it constructs the fixture, then
 uses distinct, non-overlapping bootstrap, cold-index, incremental-index, and same-overlay reference samplers. A prior
 sampler is stopped before the next measured sampler starts, so CPU, RSS, I/O, and temporary-file totals cannot leak
 between measurements. Each sampler must publish a parseable readiness marker before the parent enters the measured

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -240,8 +240,10 @@ describe('platform benchmark workflow', () => {
     const job = evidence.jobs['code-graph-production-large']!;
     const command = job.steps?.flatMap(step => (step.run ? [step.run] : [])).join('\n') ?? '';
     const capture = job.steps?.find(step => step.run?.includes('--profile production-large'));
+    const admission = job.steps?.find(step => step.id === 'classify_production_large_admission');
     const upload = job.steps?.find(step => step.uses?.startsWith('actions/upload-artifact@'));
     const summary = job.steps?.find(step => step.run?.includes('Production-large release evidence'));
+    const admissionEnforcement = job.steps?.find(step => step.name === 'Enforce production-large admission');
     const enforcement = job.steps?.find(step => step.name === 'Enforce strict evidence completion');
     const productionInput = workflow.on.workflow_dispatch?.inputs?.include_production_large as
       {readonly description?: string} | undefined;
@@ -257,11 +259,26 @@ describe('platform benchmark workflow', () => {
     expect(job['runs-on']).toBe('ubuntu-24.04');
     expect(job['timeout-minutes']).toBe(30);
     expect(command).toContain('--profile production-large');
+    expect(command).toContain('--minimum-free-gib 120');
     expect(command).toContain('--samples 1');
     expect(command).toContain('--warmups 0');
     expect(command).toContain('code-graph-production-large-n1-');
     expect(job.env).toBeUndefined();
+    expect(admission?.run).toContain('MINIMUM_FREE_GIB * 1024 * 1024 * 1024');
+    expect(admission?.run).toContain('df -Pk "$RUNNER_TEMP/threadnote-production-large-admission"');
+    expect(admission?.run).toContain('threadnote-production-large-admission');
+    expect(admission?.run).toContain('not-admitted-insufficient-capacity');
+    expect(admission?.run).toContain('available_bytes >= required_bytes');
+    expect(admission?.env).toMatchObject({
+      MINIMUM_FREE_GIB: 120,
+      SOURCE_REF: '${{ inputs.release_ref || github.ref }}',
+      SOURCE_SHA: '${{ inputs.release_sha || github.sha }}',
+    });
+    expect(job.steps?.indexOf(admission!)).toBeLessThan(job.steps?.indexOf(capture!) ?? 0);
+    expect(capture?.if).toContain("steps.classify_production_large_admission.outputs.admitted == 'true'");
     expect(capture?.env).toMatchObject({
+      SQLITE_TMPDIR: '${{ runner.temp }}',
+      TMPDIR: '${{ runner.temp }}',
       THREADNOTE_BENCHMARK_RUNNER_CLASS: 'github-hosted-ubuntu-24.04-${{ runner.arch }}',
       THREADNOTE_BENCHMARK_RUNNER_ID: '${{ runner.name }}',
       THREADNOTE_BENCHMARK_RELEASE_REF: '${{ inputs.release_ref }}',
@@ -274,14 +291,21 @@ describe('platform benchmark workflow', () => {
     expect(upload?.uses).toBe('actions/upload-artifact@v7');
     expect(upload?.if).toBe('always()');
     expect(upload?.['timeout-minutes']).toBeLessThanOrEqual(5);
-    expect(upload?.with?.path).toBe('artifacts/code-graph-production-large-n1-*.json');
+    expect(upload?.with?.path).toContain('artifacts/code-graph-production-large-admission-*.json');
+    expect(upload?.with?.path).toContain('artifacts/code-graph-production-large-n1-*.json');
     expect(upload?.with?.['if-no-files-found']).toBe('error');
     expect(upload?.with?.['retention-days']).toBe(90);
     expect(enforcement?.if).toContain('inputs.strict');
+    expect(enforcement?.if).toContain("steps.classify_production_large_admission.outputs.admitted == 'true'");
     expect(enforcement?.if).toContain("steps.capture_production_large.outcome != 'success'");
     expect(enforcement?.run).toContain('exit 1');
     expect(job.steps?.indexOf(enforcement!)).toBeGreaterThan(job.steps?.indexOf(upload!) ?? -1);
     expect(job.steps?.indexOf(enforcement!)).toBeGreaterThan(job.steps?.indexOf(summary!) ?? -1);
+    expect(admissionEnforcement?.if).toContain('always()');
+    expect(admissionEnforcement?.if).toContain("outputs.admitted != 'true'");
+    expect(admissionEnforcement?.run).toContain('exit 1');
+    expect(job.steps?.indexOf(admissionEnforcement!)).toBeGreaterThan(job.steps?.indexOf(upload!) ?? -1);
+    expect(job.steps?.indexOf(admissionEnforcement!)).toBeGreaterThan(job.steps?.indexOf(summary!) ?? -1);
     expect(summary?.run).toContain('six declared linked-worktree churn scenarios');
     expect(summary?.run).toContain('actual-versus-target counts');
     expect(summary?.run).toContain('package-manager exclusion never removes active source');
@@ -340,11 +364,14 @@ describe('platform benchmark workflow', () => {
     const summary = job.steps?.find(step => step.run?.includes('Production-large release evidence'));
 
     expect(summary?.env).toMatchObject({
+      ADMISSION_CLASSIFICATION: '${{ steps.classify_production_large_admission.outputs.classification }}',
       MEASUREMENT_OUTCOME: '${{ steps.capture_production_large.outcome }}',
       STRICT_EVIDENCE: '${{ inputs.strict }}',
     });
     expect(summary?.run).toContain('must complete for this evidence workflow to pass');
     expect(summary?.run).toContain('bounded observation retained without blocking release publication');
+    expect(summary?.run).toContain('benchmark not attempted; capacity classification retained');
+    expect(summary?.run).toContain('Admission classification');
   });
 
   it('runs the large-monorepo heavy-tail regression only by schedule or explicit opt-in', () => {

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -2421,7 +2421,18 @@ describe('code graph release evidence', () => {
     expect(verifyRef?.run).toContain('test "$resolved" = "$RELEASE_SHA"');
     const upload = production.steps?.find(step => step.id === 'upload-production-large');
     expect(upload?.with).toMatchObject({'if-no-files-found': 'error', 'retention-days': 90});
+    expect(upload?.with?.path).toContain('code-graph-production-large-admission-*.json');
+    expect(upload?.with?.path).toContain('code-graph-production-large-n1-*.json');
+    const admission = production.steps?.find(step => step.id === 'classify_production_large_admission');
+    expect(admission?.run).toContain('not-admitted-insufficient-capacity');
+    expect(admission?.run).toContain('available_bytes >= required_bytes');
+    const admissionEnforcement = production.steps?.find(step => step.name === 'Enforce production-large admission');
+    expect(admissionEnforcement?.if).toContain("outputs.admitted != 'true'");
+    expect(admissionEnforcement?.run).toContain('exit 1');
     const capture = production.steps?.find(step => step.name?.includes('Capture one production-large'));
+    expect(production.steps?.indexOf(admission!)).toBeLessThan(production.steps?.indexOf(capture!) ?? 0);
+    expect(capture?.if).toContain("steps.classify_production_large_admission.outputs.admitted == 'true'");
+    expect(capture?.run).toContain('--minimum-free-gib 120');
     expect(capture?.env).toMatchObject({
       THREADNOTE_BENCHMARK_RELEASE_REF: '${{ inputs.release_ref }}',
       THREADNOTE_BENCHMARK_RELEASE_SHA: '${{ inputs.release_sha }}',

--- a/test/unit/publish-workflow.test.ts
+++ b/test/unit/publish-workflow.test.ts
@@ -85,6 +85,9 @@ describe('standalone release workflows', () => {
       expect(evidence).toContain('timeout-minutes: 30');
       expect(evidence).toContain('timeout-minutes: 20');
       expect(evidence).toContain('continue-on-error: true');
+      expect(evidence).toContain('not-admitted-insufficient-capacity');
+      expect(evidence).toContain('Enforce production-large admission');
+      expect(evidence).toContain('--minimum-free-gib 120');
       expect(evidence).toContain('if-no-files-found: error');
       expect(evidence).toContain('retention-days: 90');
       expect(benchmarks).not.toContain("startsWith(github.ref, 'refs/tags/v4.0.0-");


### PR DESCRIPTION
## Summary

- classify the governed production-large runner-temp capacity before constructing the 73k-file fixture
- retain an exact-ref/SHA admission artifact and skip capture when the unchanged 120 GiB floor is not met
- fail the independent evidence workflow after artifact upload on non-admission, while keeping release publication fully uncoupled
- pin admitted benchmark homes to the classified runner-temp filesystem and keep the benchmark’s own 120 GiB recheck
- document the distinction between a retained capacity classification and completed `n=1` release evidence

## Retained v4.3.4–v4.3.8 evidence

The automatic exact-tag lane failed the same governed admission on five consecutive releases, while `continue-on-error` and `strict: false` left each workflow green:

| Tag | Run | Retained result |
| --- | --- | --- |
| v4.3.4 | [32847327903](https://github.com/Kashkovsky/threadnote/actions/runs/32847327903) | failed run checkpoint + aborted bootstrap sampler |
| v4.3.5 | [32910718405](https://github.com/Kashkovsky/threadnote/actions/runs/32910718405) | failed run checkpoint + aborted bootstrap sampler |
| v4.3.6 | [32924204631](https://github.com/Kashkovsky/threadnote/actions/runs/32924204631) | failed run checkpoint + aborted bootstrap sampler |
| v4.3.7 | [32940940020](https://github.com/Kashkovsky/threadnote/actions/runs/32940940020) | failed run checkpoint + aborted bootstrap sampler |
| v4.3.8 | [32961264026](https://github.com/Kashkovsky/threadnote/actions/runs/32961264026) | failed run checkpoint + aborted bootstrap sampler |

Every log reports: `Production-large benchmark requires at least 120 GiB free on every benchmark-home filesystem.` The historical artifacts remain retained and untouched.

The repository runner API reports zero configured runners. A self-hosted label is referenced by a different workflow but has no configured runner behind it, so this change does not invent or select an infrastructure label that would queue indefinitely.

## Outcome semantics

- Not admitted: upload the privacy-safe capacity classification, summarize `not-admitted-insufficient-capacity`, then fail this evidence workflow.
- Admitted + non-strict capture failure: preserve the existing bounded-checkpoint behavior.
- Admitted + strict capture failure: fail after upload as before.
- Release publication: unchanged and independent; there is no `needs` edge to this workflow.

## Verification

- `bun --bun vitest run test/unit/benchmark-workflow.test.ts test/unit/code-graph.release-evidence.test.ts test/unit/publish-workflow.test.ts` (62 passed)
- `bun run lint`
- `bun run typecheck`
- touched-file Prettier write/check
- `git diff --check`
- commit hook repeated lint, repository formatting, and typecheck successfully

No property test was added: this is static GitHub Actions orchestration with fixed threshold, ordering, and publication-decoupling contracts; generated inputs would not add a meaningful independent invariant. No global runtime install is required because the change is workflow/docs/test-only.