### PR TITLE
Migrate runtime to Effect 4.0.0-rc.112

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@effect/sql-sqlite-bun@4.0.0-rc.112": "patches/@effect%2Fsql-sqlite-bun@4.0.0-rc.112.patch",
+  },
   "overrides": {
     "@effect/platform-node-shared": "4.0.0-rc.112",
     "@hono/node-server": "^2.0.12",

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "threadnote",
       "dependencies": {
-        "@effect/platform-bun": "4.0.0-beta.102",
-        "@effect/sql-sqlite-bun": "4.0.0-beta.102",
+        "@effect/platform-bun": "4.0.0-rc.112",
+        "@effect/sql-sqlite-bun": "4.0.0-rc.112",
         "@modelcontextprotocol/sdk": "1.30.0",
-        "effect": "4.0.0-beta.102",
+        "effect": "4.0.0-rc.112",
         "fflate": "0.8.3",
         "jose": "6.2.3",
         "node-llama-cpp": "3.19.1",
@@ -23,9 +23,9 @@
         "zod": "4.4.3",
       },
       "devDependencies": {
-        "@effect/ai-openai-compat": "4.0.0-beta.102",
-        "@effect/tsgo": "0.36.4",
-        "@effect/vitest": "4.0.0-beta.102",
+        "@effect/ai-openai-compat": "4.0.0-rc.112",
+        "@effect/tsgo": "0.37.0",
+        "@effect/vitest": "4.0.0-rc.112",
         "@fontsource-variable/jetbrains-mono": "5.3.0",
         "@fontsource-variable/spline-sans": "5.3.0",
         "@repomix/tree-sitter-wasms": "0.1.17",
@@ -46,7 +46,7 @@
         "husky": "^9.1.7",
         "js-yaml": "^5.2.2",
         "mitata": "1.0.34",
-        "oxlint": "^1.76.0",
+        "oxlint": "^1.80.0",
         "oxlint-tsgolint": "7.0.2001",
         "prettier": "^3.9.5",
         "react": "^19.2.8",
@@ -63,7 +63,7 @@
     },
   },
   "overrides": {
-    "@effect/platform-node-shared": "4.0.0-beta.102",
+    "@effect/platform-node-shared": "4.0.0-rc.112",
     "@hono/node-server": "^2.0.12",
     "fast-uri": "3.1.5",
     "hono": "4.12.34",
@@ -106,31 +106,31 @@
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
-    "@effect/ai-openai-compat": ["@effect/ai-openai-compat@4.0.0-beta.102", "", { "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-/++aEJNKqVrtbWVmNiHZ2t40QwAk1+/rCWtdOxl8iCG0UtyFYxc/vyT5OOot3VBCJIQ/mw11vNlH+K9bLQBXvA=="],
+    "@effect/ai-openai-compat": ["@effect/ai-openai-compat@4.0.0-rc.112", "", { "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-bfNYHgfjhzKhDwaw2na75JshGACrawSXWqqzTncBtBHpUIhZ+VHF2I5AdgCmfh6fnAuvhxcuJnzrixGOkG9YZw=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.102", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.102" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-hTIb0jjTfXhNgnDq2OX5wrigc0OSvTT0VWWb1PLpMM395RJPu8rCIbTlGhy0NS7kZOd8FfgNi9e0sDhgyu+5Ag=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-rc.112", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.112" }, "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-Y5n2HhV/vsbrJls9ukX42RL7zqXQxISHegWFsP9njsCyDmGTnq7QYSO82rglwrLPwtTrv5dkSRTuGw4+oXxgMg=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.102", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.112", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ=="],
 
-    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.102", "", { "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-pBO6FBJ+a21j2qHmzJDK1DeJsxm7HpUQBgucw6prHQXLMUBkhOsfZofhw1FKEdGRDEhO0sGTjffa2KP7iOuDIg=="],
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-rc.112", "", { "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-EqR8pWZo3VzedRvP6qo5HcfqNmFvSa+sQLWQl3oBMx2KY1FCc8NYjep79wYjNkW0qABnffrPUXCMTOncd1A+5g=="],
 
-    "@effect/tsgo": ["@effect/tsgo@0.36.4", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.36.4", "@effect/tsgo-darwin-x64": "0.36.4", "@effect/tsgo-linux-arm": "0.36.4", "@effect/tsgo-linux-arm64": "0.36.4", "@effect/tsgo-linux-x64": "0.36.4", "@effect/tsgo-win32-arm64": "0.36.4", "@effect/tsgo-win32-x64": "0.36.4" }, "bin": { "effect-tsgo": "dist/effect-tsgo.cjs" } }, "sha512-fNmdUV6FgXnvIcG18AVS1SRXt7z9jsyBh5CKuJYmTsE+DgbLaWF0CevKHx7hQPcidDWRVmdJYfU66Jvc/ZEt6w=="],
+    "@effect/tsgo": ["@effect/tsgo@0.37.0", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.37.0", "@effect/tsgo-darwin-x64": "0.37.0", "@effect/tsgo-linux-arm": "0.37.0", "@effect/tsgo-linux-arm64": "0.37.0", "@effect/tsgo-linux-x64": "0.37.0", "@effect/tsgo-win32-arm64": "0.37.0", "@effect/tsgo-win32-x64": "0.37.0" }, "bin": { "effect-tsgo": "dist/effect-tsgo.cjs" } }, "sha512-jCJIUcNgI0vaoylao/mhOv+7hDfaJRwZJSJrg5kA/FCQ4aGDhAYqyQx+hoZh8AW3pzD9Qp1RWtUsVFqOzIOENw=="],
 
-    "@effect/tsgo-darwin-arm64": ["@effect/tsgo-darwin-arm64@0.36.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oOcWdKQucNch6G4CvidHEzmfgeKEPMvFcz+DXuKGonBLwVHX+i1VYGbZwccEOoiitOg7eWVl4e8S0qKMXg3/gg=="],
+    "@effect/tsgo-darwin-arm64": ["@effect/tsgo-darwin-arm64@0.37.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-D9o2NKswmRklu+sG28HkxZAvtvOa0Mt+bLVjJKydF2kVw+gePxiHuTbbI3e4Kqumv4ucLT3TtqU1a2RirC80lA=="],
 
-    "@effect/tsgo-darwin-x64": ["@effect/tsgo-darwin-x64@0.36.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-4QZh0n/nUoTI7sp4o7gDEviJ/jXH+IFTVqIyQ2w2fqqPoOvaGl9bVoR/2f9j/67hvY4DHcXKaccpmyoRYhaYsw=="],
+    "@effect/tsgo-darwin-x64": ["@effect/tsgo-darwin-x64@0.37.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-3PP9ktZOOYaPhGSP01ySM44pJbeLJZUuF2auCRTIxySHqe2vvhxVAIGGCwmMzOg0qeqowOUG8ew4kofmqRsXCg=="],
 
-    "@effect/tsgo-linux-arm": ["@effect/tsgo-linux-arm@0.36.4", "", { "os": "linux", "cpu": "arm" }, "sha512-10oTUnOK/RCfmTMFvMndNIfk61uviyYBRpbxhDd/SiU6DYCmWlnZ/xhGmgyj5uiysOiFNsp3NKxT0d9y4uAz8g=="],
+    "@effect/tsgo-linux-arm": ["@effect/tsgo-linux-arm@0.37.0", "", { "os": "linux", "cpu": "arm" }, "sha512-JEtNv5gI6gHjtrYMz5ln6uZIMKwUGgxsDHpJgBPUd+yS/Cm48b4SjpLuYRBEvjPJTxPM6asEkyKsBMlboJfoIg=="],
 
-    "@effect/tsgo-linux-arm64": ["@effect/tsgo-linux-arm64@0.36.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-aOv+wVbZWgBt9PGXPA874qgw151GrzkWqaswe+4TXjhdw/M4i35PCUH5T+uaQj3FnQ1NWiPqHIGfNBRjf3xG6w=="],
+    "@effect/tsgo-linux-arm64": ["@effect/tsgo-linux-arm64@0.37.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-7rICv3nNPSo5gPPUOSBJyYU1Hu8yRX2IqRWATXhhuPUJ3yQwLevAim6AyzZp/FMoKUYgr+SZ18dw6BntAdzMrA=="],
 
-    "@effect/tsgo-linux-x64": ["@effect/tsgo-linux-x64@0.36.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+BuwiG5d8dLNrrN1PB5GA3gRkBwvlUYmMkm/XkttaLnppp9jePFkB8CgAiNV8j290q7BVO2nQjao5aPkVwmluw=="],
+    "@effect/tsgo-linux-x64": ["@effect/tsgo-linux-x64@0.37.0", "", { "os": "linux", "cpu": "x64" }, "sha512-gPl5KO83aU55JXEv2lBjOLRdZafP+/fAl2mveZArU+QsOf5MuUnFmSRo+eds0/971wH3a13lW9sWBg+/XZtq8g=="],
 
-    "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.36.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-HsW90wbMWOeorUeNMdTqTcMZIDcCXdkeFGXTUkx9K1R21fXSw+QEdPtTmEyKsRMXEH4vqek/HQa0yMkUT0CJzA=="],
+    "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.37.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-ipmWCTitf6CYn4sAqOxwvv48JlE46SfvDq1I912OPnPHBP3ZnYF1b18RqiOCiL4Z1aQ6pC5NTeyulfW8g9cM7Q=="],
 
-    "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.36.4", "", { "os": "win32", "cpu": "x64" }, "sha512-q4j1q0ESYxxookjA0ECz/84DEH2MsP51K0aZb3uXKfxagHDASPoWDcVu4BJTcwrK5kdZzvw9QrCPjAXe9WZqng=="],
+    "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.37.0", "", { "os": "win32", "cpu": "x64" }, "sha512-h2UGN9UN+wyQ3KxyShOFyCy0CcgxvC9AoKv1OpZACWqw0ewU4ga6kyN5cmOY94JWXolcTgwhd/DUqN3IaEyoPw=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.102", "", { "peerDependencies": { "effect": "^4.0.0-beta.102", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-4dipFAYG6imOzrY3zy3BgzCJkbb9xESyzUef0WSx8bsK0/SpITqbJpdwKeOyDWLZ+rimjua8IbTFMAde865pIQ=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-rc.112", "", { "peerDependencies": { "effect": "^4.0.0-rc.112", "vitest": ">=4.1.0 <5.0.0" } }, "sha512-mEKh/FI64mt8JK1/v9mpOrJYdnp+UFZdRUBMEdZMiKz7klg6NPqVgg/oeAGH6wOOQc2iAPcfc2H9BbAv1KyzMQ=="],
 
     "@emnapi/core": ["@emnapi/core@2.0.0-alpha.3", "", { "dependencies": { "@emnapi/wasi-threads": "2.0.1", "tslib": "^2.4.0" } }, "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g=="],
 
@@ -280,43 +280,43 @@
 
     "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.77.0", "", { "os": "android", "cpu": "arm" }, "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.80.0", "", { "os": "android", "cpu": "arm" }, "sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.77.0", "", { "os": "android", "cpu": "arm64" }, "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.80.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.77.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.80.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.77.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.80.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.77.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.80.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.80.0", "", { "os": "linux", "cpu": "arm" }, "sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.80.0", "", { "os": "linux", "cpu": "arm" }, "sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.80.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.80.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.77.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.80.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.80.0", "", { "os": "linux", "cpu": "none" }, "sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.80.0", "", { "os": "linux", "cpu": "none" }, "sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.77.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.80.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.80.0", "", { "os": "linux", "cpu": "x64" }, "sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.80.0", "", { "os": "linux", "cpu": "x64" }, "sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.77.0", "", { "os": "none", "cpu": "arm64" }, "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.80.0", "", { "os": "none", "cpu": "arm64" }, "sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.77.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.80.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.77.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.80.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.77.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.80.0", "", { "os": "win32", "cpu": "x64" }, "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -616,7 +616,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
+    "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.397", "", {}, "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw=="],
 
@@ -688,8 +688,6 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
-    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
-
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
@@ -756,7 +754,7 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -809,8 +807,6 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
-
-    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "lifecycle-utils": ["lifecycle-utils@3.1.1", "", {}, "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg=="],
 
@@ -980,11 +976,9 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+    "msgpackr": ["msgpackr@2.0.6", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
-
-    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "nanoid": ["nanoid@5.1.16", "", { "bin": "bin/nanoid.js" }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
@@ -1020,7 +1014,7 @@
 
     "ora": ["ora@9.4.1", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw=="],
 
-    "oxlint": ["oxlint@1.77.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.77.0", "@oxlint/binding-android-arm64": "1.77.0", "@oxlint/binding-darwin-arm64": "1.77.0", "@oxlint/binding-darwin-x64": "1.77.0", "@oxlint/binding-freebsd-x64": "1.77.0", "@oxlint/binding-linux-arm-gnueabihf": "1.77.0", "@oxlint/binding-linux-arm-musleabihf": "1.77.0", "@oxlint/binding-linux-arm64-gnu": "1.77.0", "@oxlint/binding-linux-arm64-musl": "1.77.0", "@oxlint/binding-linux-ppc64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-musl": "1.77.0", "@oxlint/binding-linux-s390x-gnu": "1.77.0", "@oxlint/binding-linux-x64-gnu": "1.77.0", "@oxlint/binding-linux-x64-musl": "1.77.0", "@oxlint/binding-openharmony-arm64": "1.77.0", "@oxlint/binding-win32-arm64-msvc": "1.77.0", "@oxlint/binding-win32-ia32-msvc": "1.77.0", "@oxlint/binding-win32-x64-msvc": "1.77.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg=="],
+    "oxlint": ["oxlint@1.80.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.80.0", "@oxlint/binding-android-arm64": "1.80.0", "@oxlint/binding-darwin-arm64": "1.80.0", "@oxlint/binding-darwin-x64": "1.80.0", "@oxlint/binding-freebsd-x64": "1.80.0", "@oxlint/binding-linux-arm-gnueabihf": "1.80.0", "@oxlint/binding-linux-arm-musleabihf": "1.80.0", "@oxlint/binding-linux-arm64-gnu": "1.80.0", "@oxlint/binding-linux-arm64-musl": "1.80.0", "@oxlint/binding-linux-ppc64-gnu": "1.80.0", "@oxlint/binding-linux-riscv64-gnu": "1.80.0", "@oxlint/binding-linux-riscv64-musl": "1.80.0", "@oxlint/binding-linux-s390x-gnu": "1.80.0", "@oxlint/binding-linux-x64-gnu": "1.80.0", "@oxlint/binding-linux-x64-musl": "1.80.0", "@oxlint/binding-openharmony-arm64": "1.80.0", "@oxlint/binding-win32-arm64-msvc": "1.80.0", "@oxlint/binding-win32-ia32-msvc": "1.80.0", "@oxlint/binding-win32-x64-msvc": "1.80.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
@@ -1194,8 +1188,6 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
-
     "tree-sitter": ["tree-sitter@0.21.1", "", { "dependencies": { "node-addon-api": "^8.0.0", "node-gyp-build": "^4.8.0" } }, "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ=="],
 
     "tree-sitter-c": ["tree-sitter-c@0.23.6", "", { "dependencies": { "node-addon-api": "^8.3.0", "node-gyp-build": "^4.8.4" }, "peerDependencies": { "tree-sitter": "^0.22.1" }, "optionalPeers": ["tree-sitter"] }, "sha512-0dxXKznVyUA0s6PjNolJNs2yF87O5aL538A/eR6njA5oqX3C3vH4vnx3QdOKwuUdpKEcFdHuiDpRKLLCA/tjvQ=="],
@@ -1254,8 +1246,6 @@
 
     "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
 
-    "uuid": ["uuid@14.0.1", "", { "bin": "dist-node/bin/uuid" }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
-
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -1306,6 +1296,8 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@effect/platform-node-shared/ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
@@ -1350,13 +1342,11 @@
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": "bin/nanoid.cjs" }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "postcss/nanoid": ["nanoid@3.3.18", "", { "bin": "bin/nanoid.cjs" }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
-
-    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 

--- a/package.json
+++ b/package.json
@@ -148,5 +148,8 @@
     "fast-uri": "3.1.5",
     "hono": "4.12.34",
     "ip-address": "10.4.0"
+  },
+  "patchedDependencies": {
+    "@effect/sql-sqlite-bun@4.0.0-rc.112": "patches/@effect%2Fsql-sqlite-bun@4.0.0-rc.112.patch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,9 +87,9 @@
     "train:reranker:parity": "bun scripts/validate-recall-reranker-parity.ts"
   },
   "devDependencies": {
-    "@effect/ai-openai-compat": "4.0.0-beta.102",
-    "@effect/tsgo": "0.36.4",
-    "@effect/vitest": "4.0.0-beta.102",
+    "@effect/ai-openai-compat": "4.0.0-rc.112",
+    "@effect/tsgo": "0.37.0",
+    "@effect/vitest": "4.0.0-rc.112",
     "@fontsource-variable/jetbrains-mono": "5.3.0",
     "@fontsource-variable/spline-sans": "5.3.0",
     "@repomix/tree-sitter-wasms": "0.1.17",
@@ -110,7 +110,7 @@
     "husky": "^9.1.7",
     "js-yaml": "^5.2.2",
     "mitata": "1.0.34",
-    "oxlint": "^1.76.0",
+    "oxlint": "^1.80.0",
     "oxlint-tsgolint": "7.0.2001",
     "prettier": "^3.9.5",
     "react": "^19.2.8",
@@ -125,11 +125,11 @@
     "vitest": "^4.1.7"
   },
   "dependencies": {
-    "@effect/platform-bun": "4.0.0-beta.102",
-    "@effect/sql-sqlite-bun": "4.0.0-beta.102",
+    "@effect/platform-bun": "4.0.0-rc.112",
+    "@effect/sql-sqlite-bun": "4.0.0-rc.112",
     "@modelcontextprotocol/sdk": "1.30.0",
+    "effect": "4.0.0-rc.112",
     "fflate": "0.8.3",
-    "effect": "4.0.0-beta.102",
     "jose": "6.2.3",
     "node-llama-cpp": "3.19.1",
     "postgres": "3.4.7",
@@ -143,7 +143,7 @@
     "zod": "4.4.3"
   },
   "overrides": {
-    "@effect/platform-node-shared": "4.0.0-beta.102",
+    "@effect/platform-node-shared": "4.0.0-rc.112",
     "@hono/node-server": "^2.0.12",
     "fast-uri": "3.1.5",
     "hono": "4.12.34",

--- a/patches/@effect%2Fsql-sqlite-bun@4.0.0-rc.112.patch
+++ b/patches/@effect%2Fsql-sqlite-bun@4.0.0-rc.112.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/SqliteClient.js b/dist/SqliteClient.js
+index bef1706779e0af97ab4f409d17e8b9e056beea64..27d84a5abd4dd2681286c37010e39c2a40ce6d78 100644
+--- a/dist/SqliteClient.js
++++ b/dist/SqliteClient.js
+@@ -145,7 +145,7 @@ export const make = options => Effect.gen(function* () {
+     acquirer,
+     compiler,
+     transactionAcquirer,
+-    beginTransaction: "BEGIN IMMEDIATE",
++    beginTransaction: options.readonly === true ? "BEGIN" : "BEGIN IMMEDIATE",
+     spanAttributes: [...(options.spanAttributes ? Object.entries(options.spanAttributes) : []), [ATTR_DB_SYSTEM_NAME, "sqlite"]],
+     transformRows
+   }), {
+diff --git a/src/SqliteClient.ts b/src/SqliteClient.ts
+index e54047a1122db25933d1f31d0a41c7cf09287c49..5bf79cf872b64539aa57402f20a528f0e249b5fb 100644
+--- a/src/SqliteClient.ts
++++ b/src/SqliteClient.ts
+@@ -235,7 +235,7 @@ export const make = (
+         acquirer,
+         compiler,
+         transactionAcquirer,
+-        beginTransaction: "BEGIN IMMEDIATE",
++        beginTransaction: options.readonly === true ? "BEGIN" : "BEGIN IMMEDIATE",
+         spanAttributes: [
+           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+           [ATTR_DB_SYSTEM_NAME, "sqlite"]

--- a/scripts/check-self-contained.ts
+++ b/scripts/check-self-contained.ts
@@ -13,7 +13,7 @@ interface PackageManifest {
 
 const ROOT_URL = new URL('..', import.meta.url);
 const EXPECTED_BUN_VERSION = '1.3.14';
-const EXPECTED_EFFECT_VERSION = '4.0.0-beta.102';
+const EXPECTED_EFFECT_VERSION = '4.0.0-rc.112';
 const EXPECTED_NODE_LLAMA_CPP_VERSION = '3.19.1';
 const EXPECTED_TYPESCRIPT_COMPILER_VERSION = 'npm:typescript@5.9.3';
 const EXPECTED_WEB_TREE_SITTER_VERSION = '0.26.11';

--- a/src/code_graph/watcher.ts
+++ b/src/code_graph/watcher.ts
@@ -1067,7 +1067,7 @@ export const watchRepository = Effect.fn('codeGraph.watchRepository')(function* 
   yield* (reconciliationHooks.requestInitial ?? reconciliationHooks.requestAfterChange).pipe(
     Effect.catch(() => Effect.logWarning('Code graph initial maintenance scheduling failed; watch remains active.')),
   );
-  const changes = fs.watch(options.cwd).pipe(
+  const changes = fs.watch(options.cwd, {recursive: true}).pipe(
     Stream.filter(event => relevantWatchPath(path, options.cwd, event.path)),
     Stream.debounce('750 millis'),
     Stream.map(() => 'change' as const),

--- a/src/code_graph/worktree_reconciliation.ts
+++ b/src/code_graph/worktree_reconciliation.ts
@@ -31,7 +31,7 @@ export {type CodeGraphWorktreeReconciliationCandidate} from './store.js';
 
 export const CODE_GRAPH_WORKTREE_RECONCILIATION_CANDIDATE_LIMIT = 32;
 
-class CodeGraphWorktreeAuthorityChanged extends Schema.TaggedErrorClass<CodeGraphWorktreeAuthorityChanged>()(
+class CodeGraphWorktreeAuthorityChanged extends Schema.TaggedError<CodeGraphWorktreeAuthorityChanged>()(
   'CodeGraphWorktreeAuthorityChanged',
   {message: Schema.String},
 ) {}

--- a/src/effect/ai/consolidator.ts
+++ b/src/effect/ai/consolidator.ts
@@ -20,7 +20,7 @@ export interface ResolvedEffectAiConfiguration {
   readonly configuration: EffectAiConfiguration;
 }
 
-export class AiConsolidationFailed extends Schema.TaggedErrorClass<AiConsolidationFailed>()('AiConsolidationFailed', {
+export class AiConsolidationFailed extends Schema.TaggedError<AiConsolidationFailed>()('AiConsolidationFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
 }) {}

--- a/src/effect/ai/enrichment.ts
+++ b/src/effect/ai/enrichment.ts
@@ -27,7 +27,7 @@ export interface MemoryEnrichmentInput {
   readonly topic?: string;
 }
 
-export class AiMemoryEnrichmentFailed extends Schema.TaggedErrorClass<AiMemoryEnrichmentFailed>()(
+export class AiMemoryEnrichmentFailed extends Schema.TaggedError<AiMemoryEnrichmentFailed>()(
   'AiMemoryEnrichmentFailed',
   {
     cause: Schema.Defect(),

--- a/src/effect/ai/errors.ts
+++ b/src/effect/ai/errors.ts
@@ -1,6 +1,6 @@
 import {Schema} from 'effect';
 
-export class NativeRuntimeUnavailable extends Schema.TaggedErrorClass<NativeRuntimeUnavailable>()(
+export class NativeRuntimeUnavailable extends Schema.TaggedError<NativeRuntimeUnavailable>()(
   'NativeRuntimeUnavailable',
   {
     cause: Schema.Defect(),
@@ -8,7 +8,7 @@ export class NativeRuntimeUnavailable extends Schema.TaggedErrorClass<NativeRunt
   },
 ) {}
 
-export class UnsupportedNativeRuntime extends Schema.TaggedErrorClass<UnsupportedNativeRuntime>()(
+export class UnsupportedNativeRuntime extends Schema.TaggedError<UnsupportedNativeRuntime>()(
   'UnsupportedNativeRuntime',
   {
     cause: Schema.Defect(),
@@ -16,73 +16,73 @@ export class UnsupportedNativeRuntime extends Schema.TaggedErrorClass<Unsupporte
   },
 ) {}
 
-export class ModelNotInstalled extends Schema.TaggedErrorClass<ModelNotInstalled>()('ModelNotInstalled', {
+export class ModelNotInstalled extends Schema.TaggedError<ModelNotInstalled>()('ModelNotInstalled', {
   modelId: Schema.String,
   path: Schema.String,
   message: Schema.String,
 }) {}
 
-export class ModelManifestInvalid extends Schema.TaggedErrorClass<ModelManifestInvalid>()('ModelManifestInvalid', {
+export class ModelManifestInvalid extends Schema.TaggedError<ModelManifestInvalid>()('ModelManifestInvalid', {
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class ModelChecksumMismatch extends Schema.TaggedErrorClass<ModelChecksumMismatch>()('ModelChecksumMismatch', {
+export class ModelChecksumMismatch extends Schema.TaggedError<ModelChecksumMismatch>()('ModelChecksumMismatch', {
   actual: Schema.String,
   expected: Schema.String,
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class ModelDownloadFailed extends Schema.TaggedErrorClass<ModelDownloadFailed>()('ModelDownloadFailed', {
+export class ModelDownloadFailed extends Schema.TaggedError<ModelDownloadFailed>()('ModelDownloadFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class InsufficientDiskSpace extends Schema.TaggedErrorClass<InsufficientDiskSpace>()('InsufficientDiskSpace', {
+export class InsufficientDiskSpace extends Schema.TaggedError<InsufficientDiskSpace>()('InsufficientDiskSpace', {
   availableBytes: Schema.Number,
   message: Schema.String,
   modelId: Schema.String,
   requiredBytes: Schema.Number,
 }) {}
 
-export class ModelLoadFailed extends Schema.TaggedErrorClass<ModelLoadFailed>()('ModelLoadFailed', {
+export class ModelLoadFailed extends Schema.TaggedError<ModelLoadFailed>()('ModelLoadFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class InsufficientMemory extends Schema.TaggedErrorClass<InsufficientMemory>()('InsufficientMemory', {
+export class InsufficientMemory extends Schema.TaggedError<InsufficientMemory>()('InsufficientMemory', {
   cause: Schema.Defect(),
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class EmbeddingFailed extends Schema.TaggedErrorClass<EmbeddingFailed>()('EmbeddingFailed', {
+export class EmbeddingFailed extends Schema.TaggedError<EmbeddingFailed>()('EmbeddingFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class RerankingFailed extends Schema.TaggedErrorClass<RerankingFailed>()('RerankingFailed', {
+export class RerankingFailed extends Schema.TaggedError<RerankingFailed>()('RerankingFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class GenerationFailed extends Schema.TaggedErrorClass<GenerationFailed>()('GenerationFailed', {
+export class GenerationFailed extends Schema.TaggedError<GenerationFailed>()('GenerationFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class InvalidModelOutput extends Schema.TaggedErrorClass<InvalidModelOutput>()('InvalidModelOutput', {
+export class InvalidModelOutput extends Schema.TaggedError<InvalidModelOutput>()('InvalidModelOutput', {
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class InferenceInterrupted extends Schema.TaggedErrorClass<InferenceInterrupted>()('InferenceInterrupted', {
+export class InferenceInterrupted extends Schema.TaggedError<InferenceInterrupted>()('InferenceInterrupted', {
   message: Schema.String,
   modelId: Schema.String,
   operation: Schema.String,

--- a/src/effect/ai/isolated-local-model-runtime.ts
+++ b/src/effect/ai/isolated-local-model-runtime.ts
@@ -70,7 +70,7 @@ interface WorkerFailure {
 
 type WorkerResponse = WorkerFailure | WorkerSuccess;
 
-export class LocalModelWorkerTransportError extends Schema.TaggedErrorClass<LocalModelWorkerTransportError>()(
+export class LocalModelWorkerTransportError extends Schema.TaggedError<LocalModelWorkerTransportError>()(
   'LocalModelWorkerTransportError',
   {
     message: Schema.String,

--- a/src/effect/ai/mcp.ts
+++ b/src/effect/ai/mcp.ts
@@ -1,6 +1,6 @@
 import * as BunStdio from '@effect/platform-bun/BunStdio';
 import {Cause, Context, Effect, Layer, Logger, Option, Schema, Sink, Stdio} from 'effect';
-import {McpSchema, McpServer} from 'effect/unstable/ai';
+import {McpProtocol, McpSchema, McpServer} from 'effect/unstable/ai';
 import * as HttpRouter from 'effect/unstable/http/HttpRouter';
 import * as HttpEffect from 'effect/unstable/http/HttpEffect';
 import * as HttpServerRequest from 'effect/unstable/http/HttpServerRequest';
@@ -33,7 +33,14 @@ const MCP_PROGRESS_INTERVAL_MAX_MILLISECONDS = 300_000;
 const MCP_PROGRESS_ENCODER = new TextEncoder();
 const MCP_PROGRESS_DECODER = new TextDecoder();
 const MCP_PROGRESS_BRIDGED_SERVERS = new WeakSet<object>();
+const MCP_PROTOCOLS = [
+  McpProtocol.v2025_11_25,
+  McpProtocol.v2025_06_18,
+  McpProtocol.v2025_03_26,
+  McpProtocol.v2024_11_05,
+] as const;
 const MCP_PROGRESS_GENERATION_METADATA_KEY = 'threadnote.io/private/progress-generation';
+const MCP_INVALID_BATCH_METHOD = 'invalid/json-rpc-batch';
 const MCP_HTTP_CANCELLATION_UNSUPPORTED_MESSAGE =
   'Streamable HTTP cancellation is not supported until requests can be interrupted across POSTs.';
 
@@ -130,6 +137,7 @@ export type McpHttpRequestContextResolver = (
 ) => Effect.Effect<McpHttpRequestContext, HttpServerResponse.HttpServerResponse>;
 
 export interface McpHttpTransportOptions {
+  readonly allowedOrigins?: ReadonlyArray<string>;
   readonly path: HttpRouter.PathInput;
   readonly resolveRequestContext: McpHttpRequestContextResolver;
 }
@@ -190,6 +198,7 @@ const CurrentMcpRequestContext = Context.Reference<McpRequestContext>('threadnot
 
 interface McpProgressRequestAssociation {
   readonly generation: string;
+  readonly progressToken: McpSchema.ProgressToken;
   readonly progressTokenKey: string;
 }
 
@@ -285,47 +294,74 @@ export class EffectMcpServerRegistry {
               name: registration.name,
             }),
             handle: payload =>
-              Effect.flatMap(CurrentMcpToolProgress, progress =>
-                Effect.flatMap(CurrentMcpRequestContext, requestContext => {
-                  const handling = Schema.decodeUnknownEffect(input, {errors: 'all'})(payload).pipe(
-                    Effect.flatMap(parsed =>
-                      toolHandlerEffect(
-                        () => registration.handle(parsed, {progress, requestContext}),
-                        applicationServices,
-                      ).pipe(
-                        Effect.matchCauseEffect({
-                          onFailure: mcpToolFailureResult,
-                          onSuccess: result => Effect.succeed(mcpCallToolResultWithTelemetryMetadata(result)),
-                        }),
-                      ),
-                    ),
-                    Effect.catchCause(mcpToolFailureResult),
-                  );
-                  const loggedHandling =
-                    productionLogHome === undefined
-                      ? handling
-                      : withProductionLogging(
-                          productionLogHome,
-                          {
-                            component: 'mcp',
-                            operation: registration.name,
-                            reportedFailure: result => result.isError === true,
-                            reportedFailureType: 'McpToolError',
-                            writeTimeoutMilliseconds: MCP_PRODUCTION_LOG_WRITE_TIMEOUT_MILLISECONDS,
-                          },
-                          handling,
-                        );
-                  return withAnonymousTelemetry(
-                    {
-                      component: 'mcp',
-                      operation: registration.name,
-                      reportedFailure: result => result.isError === true,
-                      reportedFailureType: 'McpToolError',
-                      reportedOutcome: readAnonymousTelemetryReportedOutcome,
-                    },
-                    loggedHandling,
-                  ).pipe(Effect.provideContext(applicationServices));
-                }),
+              Effect.flatMap(CurrentMcpProgressRequestAssociation, association =>
+                Effect.flatMap(McpSchema.McpServerClient, client =>
+                  Effect.flatMap(CurrentMcpToolProgress, inheritedProgress => {
+                    // RC.112's live protocol handlers dispatch through the
+                    // internal tool core instead of public server.callTool.
+                    // Rehydrate Threadnote progress at this surviving Effect
+                    // context boundary; HTTP has no transport association and
+                    // therefore keeps the inherited disabled implementation.
+                    const progress =
+                      association === undefined
+                        ? inheritedProgress
+                        : makeMcpToolProgress(
+                            admitMcpProgressToken(
+                              association.progressToken,
+                              client.clientId,
+                              server.initializedClients,
+                            ),
+                            notification =>
+                              mcpProgressNotificationForCurrentRequest(notification).pipe(
+                                Effect.flatMap(outgoingNotification =>
+                                  mcpProgressCanRouteToClient(server.initializedClients, client.clientId)
+                                    ? server.notifications['notifications/progress'](outgoingNotification)
+                                    : Effect.void,
+                                ),
+                              ),
+                          );
+                    return Effect.flatMap(CurrentMcpRequestContext, requestContext => {
+                      const handling = Schema.decodeUnknownEffect(input, {errors: 'all'})(payload).pipe(
+                        Effect.flatMap(parsed =>
+                          toolHandlerEffect(
+                            () => registration.handle(parsed, {progress, requestContext}),
+                            applicationServices,
+                          ).pipe(
+                            Effect.matchCauseEffect({
+                              onFailure: mcpToolFailureResult,
+                              onSuccess: result => Effect.succeed(mcpCallToolResultWithTelemetryMetadata(result)),
+                            }),
+                          ),
+                        ),
+                        Effect.catchCause(mcpToolFailureResult),
+                      );
+                      const loggedHandling =
+                        productionLogHome === undefined
+                          ? handling
+                          : withProductionLogging(
+                              productionLogHome,
+                              {
+                                component: 'mcp',
+                                operation: registration.name,
+                                reportedFailure: result => result.isError === true,
+                                reportedFailureType: 'McpToolError',
+                                writeTimeoutMilliseconds: MCP_PRODUCTION_LOG_WRITE_TIMEOUT_MILLISECONDS,
+                              },
+                              handling,
+                            );
+                      return withAnonymousTelemetry(
+                        {
+                          component: 'mcp',
+                          operation: registration.name,
+                          reportedFailure: result => result.isError === true,
+                          reportedFailureType: 'McpToolError',
+                          reportedOutcome: readAnonymousTelemetryReportedOutcome,
+                        },
+                        loggedHandling,
+                      ).pipe(Effect.provideContext(applicationServices));
+                    });
+                  }),
+                ),
               ),
           });
         }
@@ -367,10 +403,12 @@ export class EffectMcpServerAdapter extends EffectMcpServerRegistry {
     // enforces one lifetime client, while Streamable HTTP must preserve SDK
     // client/session isolation for concurrent principals.
     const serverLayer = McpServer.layerHttp({
+      allowedOrigins: options.allowedOrigins,
       name: this.name,
       path: options.path,
+      protocols: MCP_PROTOCOLS,
       version: this.version,
-    }).pipe(Layer.provide(requestContextMiddleware.layer));
+    }).pipe(Layer.orDie, Layer.provide(requestContextMiddleware.layer));
     return this.registrationLayer({productionLogHome: this.productionLogHome}).pipe(Layer.provide(serverLayer));
   }
 }
@@ -469,6 +507,7 @@ interface McpActiveRequest {
   readonly externalId: string | number;
   readonly externalIdKey: string;
   readonly internalId: string;
+  progressToken?: McpSchema.ProgressToken;
   progressTokenKey?: string;
 }
 
@@ -586,11 +625,13 @@ export function makeMcpCancellationCompatibleProtocol(
           const activeRequest = registerRequest(clientId, externalRequest.id);
           const progressToken = callProgressToken(externalRequest);
           if (progressToken !== undefined && activeRequest.progressTokenKey === undefined) {
+            activeRequest.progressToken = progressToken;
             activeRequest.progressTokenKey = mcpProgressTokenKey(progressToken);
           }
-          if (activeRequest.progressTokenKey !== undefined) {
+          if (activeRequest.progressToken !== undefined && activeRequest.progressTokenKey !== undefined) {
             progressAssociation = {
               generation: activeRequest.internalId,
+              progressToken: activeRequest.progressToken,
               progressTokenKey: activeRequest.progressTokenKey,
             };
           }
@@ -672,28 +713,138 @@ function mcpStdioLayer(options: {
   readonly name: string;
   readonly version: string;
 }): Layer.Layer<McpServer.McpServer | McpSchema.McpServerClient, never, Stdio.Stdio> {
-  // Effect beta.102 stringifies notifications/cancelled.requestId before
+  // Effect 4.0.0-rc.112 still stringifies notifications/cancelled.requestId before
   // looking up the running RPC fiber. Move every external request id into a
   // private type-tagged namespace at the transport boundary so cancellation
   // addresses the same fiber without aliasing numeric and string twins. The
   // wrapper restores the original id type on ordinary responses and drops
   // terminal/chunk/progress frames after cancellation because the client has
   // already retired that request.
-  return McpServer.layer(options).pipe(
+  return McpServer.layer({...options, protocols: MCP_PROTOCOLS}).pipe(
+    Layer.orDie,
     Layer.provide(cancellationCompatibleProtocolLayer),
     Layer.provide(RpcServer.layerProtocolStdio),
-    Layer.provide(RpcSerialization.layerNdJsonRpc()),
+    Layer.provide(Layer.succeed(RpcSerialization.RpcSerialization, mcpStdioSerialization(MCP_PROTOCOLS))),
   );
+}
+
+/**
+ * @internal Mirrors Effect 4.0.0-rc.112's revision-aware stdio batch policy
+ * around Threadnote's cancellation protocol wrapper. The encoder additionally
+ * requires the exact synthetic batch failure, avoiding relabeling unrelated
+ * null-id protocol failures.
+ */
+export function mcpStdioSerialization(
+  protocols: readonly [McpProtocol.ProtocolAdapter, ...McpProtocol.ProtocolAdapter[]],
+): RpcSerialization.RpcSerialization['Service'] {
+  const serialization = RpcSerialization.jsonRpc({contentType: 'application/json-rpc'});
+  return RpcSerialization.RpcSerialization.of({
+    codecFor: serialization.codecFor,
+    contentType: serialization.contentType,
+    includesFraming: true,
+    makeUnsafe: () => {
+      const frames = RpcSerialization.ndjson.makeUnsafe();
+      const parser = serialization.makeUnsafe();
+      let selectedProtocol: McpProtocol.ProtocolAdapter | undefined;
+      return {
+        decode: data => {
+          const decoded: unknown[] = [];
+          for (const frame of frames.decode(data)) {
+            if (Array.isArray(frame)) {
+              if (
+                selectedProtocol?.transport.acceptsJsonRpcBatches !== true ||
+                frame.length === 0 ||
+                frame.some(mcpStdioInitializeMessage)
+              ) {
+                decoded.push({_tag: 'Request', headers: [], id: null, payload: null, tag: MCP_INVALID_BATCH_METHOD});
+                continue;
+              }
+            } else if (mcpStdioInitializeMessage(frame)) {
+              const offered = mcpStdioProtocolVersion(frame);
+              selectedProtocol = protocols.find(protocol => protocol.protocolVersion === offered) ?? protocols[0];
+            }
+            decoded.push(...parser.decode(JSON.stringify(frame)));
+          }
+          return decoded;
+        },
+        encode: response => {
+          if (mcpInvalidBatchExit(response)) {
+            return `${JSON.stringify({
+              error: {
+                _tag: 'Cause',
+                code: McpSchema.INVALID_REQUEST_ERROR_CODE,
+                data: response.exit.cause,
+                message: 'JSON-RPC batches are not supported',
+              },
+              id: null,
+              jsonrpc: '2.0',
+            })}\n`;
+          }
+          const encoded = parser.encode(response);
+          return encoded === undefined ? undefined : `${encoded}\n`;
+        },
+      };
+    },
+  });
+}
+
+function mcpStdioInitializeMessage(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && 'method' in value && value.method === 'initialize';
+}
+
+function mcpStdioProtocolVersion(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null || !('params' in value)) return undefined;
+  const params = value.params;
+  if (typeof params !== 'object' || params === null || !('protocolVersion' in params)) return undefined;
+  return typeof params.protocolVersion === 'string' ? params.protocolVersion : undefined;
+}
+
+function mcpInvalidBatchExit(response: unknown): response is {
+  readonly _tag: 'Exit';
+  readonly exit: {readonly _tag: 'Failure'; readonly cause: unknown};
+  readonly requestId: null;
+} {
+  if (
+    typeof response !== 'object' ||
+    response === null ||
+    !('_tag' in response) ||
+    response._tag !== 'Exit' ||
+    !('requestId' in response) ||
+    response.requestId !== null ||
+    !('exit' in response) ||
+    typeof response.exit !== 'object' ||
+    response.exit === null ||
+    !('_tag' in response.exit) ||
+    response.exit._tag !== 'Failure' ||
+    !('cause' in response.exit) ||
+    !Array.isArray(response.exit.cause) ||
+    response.exit.cause.length !== 1
+  ) {
+    return false;
+  }
+  const failure = response.exit.cause[0];
+  if (
+    typeof failure !== 'object' ||
+    failure === null ||
+    !('_tag' in failure) ||
+    failure._tag !== 'Fail' ||
+    !('error' in failure) ||
+    typeof failure.error !== 'object' ||
+    failure.error === null ||
+    !('message' in failure.error)
+  ) {
+    return false;
+  }
+  return failure.error.message === 'JSON-RPC batches are not supported';
 }
 
 export type EffectMcpServer = Context.Service.Shape<typeof McpServer.McpServer>;
 
 export function installCallToolProgressBridge(server: EffectMcpServer): boolean {
-  // Effect 4.0.0-beta.102 decodes CallTool._meta, but callTool forwards only
-  // request.arguments to addTool handlers. Keep the extension at that exact
-  // boundary so the request-local token follows the handler fiber and its
-  // canonical cancellation without changing the transport or timing out the
-  // mutating work performed by some tools.
+  // Effect 4.0.0-rc.112's live protocol handlers bypass public callTool, so
+  // registrationLayer rehydrates their progress from the transport context.
+  // Keep this wrapper for direct callTool consumers and, more importantly,
+  // install the lifetime-single-client recipient guard used by both paths.
   if (MCP_PROGRESS_BRIDGED_SERVERS.has(server)) return true;
   const callToolDescriptor = Object.getOwnPropertyDescriptor(server, 'callTool');
   const clientsDescriptor = Object.getOwnPropertyDescriptor(server, 'initializedClients');
@@ -738,7 +889,7 @@ export function installCallToolProgressBridge(server: EffectMcpServer): boolean 
         .pipe(Effect.provideService(CurrentMcpToolProgress, progress));
     });
   try {
-    // beta.102's canonical notification queue broadcasts at drain time. This
+    // Effect 4.0.0-rc.112's canonical notification queue broadcasts at drain time. This
     // adapter is permanently backed by layerStdio, so replace its recipient
     // registry with a non-replaceable lifetime-single-client set before any
     // request can enqueue progress. A late foreign add is ignored even if the
@@ -795,7 +946,7 @@ function isWritableDataProperty(descriptor: PropertyDescriptor | undefined): des
 }
 
 function mcpProgressCanRouteToClient(initializedClients: ReadonlySet<number>, clientId: number): boolean {
-  // Effect beta.102's canonical outgoing notification queue broadcasts to the
+  // Effect 4.0.0-rc.112's canonical outgoing notification queue broadcasts to the
   // complete initialized-client set. Threadnote's adapter is stdio-only, but
   // fail closed if the service is ever reused with another client so an opaque
   // request token cannot cross client boundaries.
@@ -1123,11 +1274,11 @@ function couldContainEffectRpcCause(input: string | Uint8Array): boolean {
   return false;
 }
 
-// Effect 4.0.0-beta.102's JSON-RPC serializer reads `code` from the outer
-// Fail reason instead of its typed error, so native MCP failures reach clients
-// as code 0. Repair only the exact single-Fail envelopes and protocol error
-// types Threadnote emits; unrelated results, defects, and Cause values pass
-// through byte-for-byte.
+// Effect 4.0.0-rc.112 preserves the typed MCP code on its outer Cause envelope,
+// but clients still require a plain JSON-RPC error object. Repair only the exact
+// single-Fail envelopes and branded protocol errors Threadnote emits. Keep the
+// beta-era code-0 case bounded for compatible stored/test envelopes; unrelated
+// results, defects, and Cause values pass through byte-for-byte.
 function unwrapEffectRpcMcpError(parsed: Record<string, unknown>): Record<string, unknown> {
   const error = parsed.error;
   if (
@@ -1140,7 +1291,7 @@ function unwrapEffectRpcMcpError(parsed: Record<string, unknown>): Record<string
     !('_tag' in error) ||
     error._tag !== 'Cause' ||
     !('code' in error) ||
-    error.code !== 0
+    typeof error.code !== 'number'
   ) {
     return parsed;
   }
@@ -1169,6 +1320,7 @@ function unwrapEffectRpcMcpError(parsed: Record<string, unknown>): Record<string
   ) {
     return parsed;
   }
+  if (error.code !== 0 && error.code !== typed.code) return parsed;
   return {
     ...parsed,
     error: {
@@ -1209,7 +1361,7 @@ function isRecognizedMcpError(error: {readonly code: number} & Record<PropertyKe
     return !('_tag' in error) || error._tag === 'McpErrorBase';
   }
   return (
-    (error.code === -32_602 && error._tag === 'InvalidParams') ||
-    (error.code === -32_603 && error._tag === 'InternalError')
+    (error.code === -32_602 && (!('_tag' in error) || error._tag === 'InvalidParams')) ||
+    (error.code === -32_603 && (!('_tag' in error) || error._tag === 'InternalError'))
   );
 }

--- a/src/effect/ai/mcp.ts
+++ b/src/effect/ai/mcp.ts
@@ -157,7 +157,16 @@ type ToolHandlerResult = ToolResult | Effect.Effect<ToolResult, unknown, Applica
 
 /** @internal Adapt the SDK result class without dropping private telemetry metadata. */
 export function mcpCallToolResultWithTelemetryMetadata(result: ToolResult): McpSchema.CallToolResult {
-  return copyAnonymousTelemetryMetadata(new McpSchema.CallToolResult(result as McpSchema.CallToolResult), result);
+  // Effect 4 validates structuredContent as Schema.Json when the result class is
+  // constructed. Threadnote tool projections use idiomatic optional object
+  // properties, whose undefined values are omitted by the JSON wire format.
+  // Apply that exact wire normalization before validation so the stricter SDK
+  // constructor observes the payload clients would actually receive.
+  const normalized =
+    result.structuredContent === undefined
+      ? result
+      : {...result, structuredContent: JSON.parse(JSON.stringify(result.structuredContent)) as unknown};
+  return copyAnonymousTelemetryMetadata(new McpSchema.CallToolResult(normalized as McpSchema.CallToolResult), result);
 }
 
 interface ResourceTemplateDefinition {

--- a/src/effect/ai/mcp.ts
+++ b/src/effect/ai/mcp.ts
@@ -1259,10 +1259,34 @@ function repairMcpJsonRpcObject(
   instructions: string | undefined,
 ): Record<string, unknown> {
   let transformed = parsed;
-  if (instructions !== undefined && mcpInitializeResponse(parsed)) {
-    transformed = {...parsed, result: {...parsed.result, instructions}};
+  if (mcpInitializeResponse(parsed)) {
+    const capabilities = mcpRecord(parsed.result.capabilities);
+    const resources = mcpRecord(capabilities?.resources);
+    // RC.112 advertises subscriptions when resources are registered, but
+    // Threadnote does not yet emit notifications/resources/updated across its
+    // mutation paths. Keep the wire capability truthful until that complete
+    // lifecycle exists instead of accepting inert subscriptions.
+    const repairedResources = resources === undefined ? undefined : {...resources, subscribe: false};
+    const repairedCapabilities =
+      capabilities === undefined || repairedResources === undefined
+        ? capabilities
+        : {...capabilities, resources: repairedResources};
+    const repairedResult = {
+      ...parsed.result,
+      ...(repairedCapabilities === undefined ? {} : {capabilities: repairedCapabilities}),
+      ...(instructions === undefined ? {} : {instructions}),
+    };
+    if (instructions !== undefined || (resources !== undefined && resources.subscribe !== false)) {
+      transformed = {...parsed, result: repairedResult};
+    }
   }
   return unwrapEffectRpcMcpError(transformed);
+}
+
+function mcpRecord(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : undefined;
 }
 
 function mcpInitializeResponse(parsed: Record<string, unknown>): parsed is Record<string, unknown> & {

--- a/src/effect/ai/mcp_resource.ts
+++ b/src/effect/ai/mcp_resource.ts
@@ -6,8 +6,8 @@ import {MCP_RESOURCE_ERROR_DATA, MCP_RESOURCE_NOT_FOUND_ERROR_DATA} from './mcp.
 
 export const MCP_RESOURCE_READ_MAX_BYTES = 4_500;
 export const MCP_RESOURCE_MIME_TYPE = 'text/plain; charset=utf-8';
-// Effect beta.102 negotiates MCP 2025-06-18, whose resources contract uses
-// this server-error code for a resource that does not exist.
+// The MCP resources contract uses this server-error code for a resource that
+// does not exist across every protocol revision Threadnote advertises.
 export const MCP_RESOURCE_NOT_FOUND_CODE = -32_002;
 
 interface McpResourceConfig {

--- a/src/effect/ai/recall.ts
+++ b/src/effect/ai/recall.ts
@@ -38,21 +38,15 @@ export interface RecallSelectionInput {
   readonly query: string;
 }
 
-export class AiRecallExpansionFailed extends Schema.TaggedErrorClass<AiRecallExpansionFailed>()(
-  'AiRecallExpansionFailed',
-  {
-    cause: Schema.Defect(),
-    message: Schema.String,
-  },
-) {}
+export class AiRecallExpansionFailed extends Schema.TaggedError<AiRecallExpansionFailed>()('AiRecallExpansionFailed', {
+  cause: Schema.Defect(),
+  message: Schema.String,
+}) {}
 
-export class AiRecallSelectionFailed extends Schema.TaggedErrorClass<AiRecallSelectionFailed>()(
-  'AiRecallSelectionFailed',
-  {
-    cause: Schema.Defect(),
-    message: Schema.String,
-  },
-) {}
+export class AiRecallSelectionFailed extends Schema.TaggedError<AiRecallSelectionFailed>()('AiRecallSelectionFailed', {
+  cause: Schema.Defect(),
+  message: Schema.String,
+}) {}
 
 const RecallExpansionDraft = Schema.Struct({
   queries: Schema.Array(

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -171,12 +171,15 @@ const defaultString = (name: string, description: string, value: string): Flag.F
 
 const boolean = (name: string, description: string): Flag.Flag<boolean> => {
   registerCliBooleanFlag(`--${name}`);
-  return describeFlag(Flag.boolean(name), description);
+  return describeFlag(Flag.boolean(name), description).pipe(Flag.withDefault(false));
 };
 
 const negatedBoolean = (name: string, description: string): Flag.Flag<boolean> => {
   registerCliBooleanFlag(`--no-${name}`);
-  return describeFlag(Flag.boolean(`no-${name}`), description).pipe(Flag.map(value => !value));
+  return describeFlag(Flag.boolean(`no-${name}`), description).pipe(
+    Flag.withDefault(false),
+    Flag.map(value => !value),
+  );
 };
 
 const optionalChoice = <const Choices extends readonly string[]>(
@@ -363,7 +366,7 @@ const update = Command.make(
 
 const autoUpdateWorker = Command.make('auto-update-worker', {}, () =>
   withRuntimeEffect(config => runAutoUpdateWorker(config).pipe(Effect.asVoid)),
-).pipe(Command.withDescription('Run one coordinated automatic update attempt'), Command.withHidden);
+).pipe(Command.withDescription('Run one coordinated automatic update attempt'), Command.unlisted);
 
 const postUpdate = Command.make(
   'post-update',
@@ -374,7 +377,7 @@ const postUpdate = Command.make(
     yes: boolean('yes', 'Accept applicable post-update actions without prompting'),
   },
   options => withRuntimeEffect(config => runPostUpdate(config, options)),
-).pipe(Command.withDescription('Run packaged post-update action prompts'), Command.withHidden);
+).pipe(Command.withDescription('Run packaged post-update action prompts'), Command.unlisted);
 
 const repair = Command.make(
   'repair',
@@ -1218,13 +1221,13 @@ const preCompactHook = Command.make(
   'pre-compact-hook',
   {dryRun: boolean('dry-run', 'Print the handoff payload without writing it')},
   options => withRuntimeEffect(config => runPreCompactHook(config, options)),
-).pipe(Command.withDescription('Store a handoff snapshot before context compaction'), Command.withHidden);
+).pipe(Command.withDescription('Store a handoff snapshot before context compaction'), Command.unlisted);
 
 const sessionStartHook = Command.make(
   'session-start-hook',
   {dryRun: boolean('dry-run', 'Print the planned native operation without running it')},
   options => withRuntimeEffect(config => runSessionStartHook(config, options)),
-).pipe(Command.withDescription('Print current repo handoff context at session start'), Command.withHidden);
+).pipe(Command.withDescription('Print current repo handoff context at session start'), Command.unlisted);
 
 const remember = Command.make(
   'remember',
@@ -1306,7 +1309,7 @@ const migrateProjectNames = Command.make('migrate-projects', migrateProjectNames
 
 const migrateProjectNamesCompatibility = Command.make('migrate-project-names', migrateProjectNamesFlags, options =>
   withRuntimeEffect(config => runMigrateProjectNames(config, options)),
-).pipe(Command.withDescription('Compatibility name for migrate-projects'), Command.withHidden);
+).pipe(Command.withDescription('Compatibility name for migrate-projects'), Command.unlisted);
 
 const enrichMemories = Command.make(
   'enrich-memories',

--- a/src/effect/cli_invocation.ts
+++ b/src/effect/cli_invocation.ts
@@ -144,9 +144,10 @@ function parseCliBoolean(value: string | undefined): boolean | undefined {
 }
 
 /**
- * Preserve Commander-compatible string values while Effect 4's beta lexer
- * still tokenizes dash-prefixed values as flags and splits inline values at
- * every equals sign. Remove this shim once the upstream lexer preserves both.
+ * Preserve Commander-compatible string values while Effect 4.0.0-rc.112 still
+ * tokenizes dash-prefixed values as flags. The RC lexer preserves inline
+ * equals values; normalizing both forms here keeps one reversible string-value
+ * path until the remaining dash-prefixed-value gap is fixed upstream.
  */
 export function normalizeCliArguments(args: readonly string[]): readonly string[] {
   const normalized: string[] = [];

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -54,19 +54,19 @@ const CommandFields = {
   message: Schema.String,
 };
 
-export class CommandFailed extends Schema.TaggedErrorClass<CommandFailed>()('CommandFailed', {
+export class CommandFailed extends Schema.TaggedError<CommandFailed>()('CommandFailed', {
   ...CommandFields,
   exitCode: Schema.Number,
   stderr: Schema.String,
   stdout: Schema.String,
 }) {}
 
-export class CommandTimedOut extends Schema.TaggedErrorClass<CommandTimedOut>()('CommandTimedOut', {
+export class CommandTimedOut extends Schema.TaggedError<CommandTimedOut>()('CommandTimedOut', {
   ...CommandFields,
   timeoutMs: Schema.Number,
 }) {}
 
-export class CommandOutputLimitExceeded extends Schema.TaggedErrorClass<CommandOutputLimitExceeded>()(
+export class CommandOutputLimitExceeded extends Schema.TaggedError<CommandOutputLimitExceeded>()(
   'CommandOutputLimitExceeded',
   {
     ...CommandFields,
@@ -74,7 +74,7 @@ export class CommandOutputLimitExceeded extends Schema.TaggedErrorClass<CommandO
   },
 ) {}
 
-export class CommandSpawnFailed extends Schema.TaggedErrorClass<CommandSpawnFailed>()('CommandSpawnFailed', {
+export class CommandSpawnFailed extends Schema.TaggedError<CommandSpawnFailed>()('CommandSpawnFailed', {
   ...CommandFields,
   cause: Schema.Defect(),
 }) {}

--- a/src/effect/errors.ts
+++ b/src/effect/errors.ts
@@ -1,6 +1,6 @@
 import {Effect, Schema} from 'effect';
 
-export class ApplicationError extends Schema.TaggedErrorClass<ApplicationError>()('ApplicationError', {
+export class ApplicationError extends Schema.TaggedError<ApplicationError>()('ApplicationError', {
   cause: Schema.Defect(),
   message: Schema.String,
   operation: Schema.String,

--- a/src/effect/http.ts
+++ b/src/effect/http.ts
@@ -5,14 +5,14 @@ import * as HttpClientRequest from 'effect/unstable/http/HttpClientRequest';
 import type {HttpClientResponse} from 'effect/unstable/http/HttpClientResponse';
 import * as FetchHttpClient from 'effect/unstable/http/FetchHttpClient';
 
-export class HttpRequestFailed extends Schema.TaggedErrorClass<HttpRequestFailed>()('HttpRequestFailed', {
+export class HttpRequestFailed extends Schema.TaggedError<HttpRequestFailed>()('HttpRequestFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   method: Schema.String,
   url: Schema.String,
 }) {}
 
-export class HttpStatusError extends Schema.TaggedErrorClass<HttpStatusError>()('HttpStatusError', {
+export class HttpStatusError extends Schema.TaggedError<HttpStatusError>()('HttpStatusError', {
   message: Schema.String,
   method: Schema.String,
   status: Schema.Number,

--- a/src/effect/resource-store.ts
+++ b/src/effect/resource-store.ts
@@ -73,36 +73,36 @@ export interface ResourceStoreMultiGrepMatch extends ResourceStoreGrepMatch {
   readonly term: string;
 }
 
-export class ResourceAccessDenied extends Schema.TaggedErrorClass<ResourceAccessDenied>()('ResourceAccessDenied', {
+export class ResourceAccessDenied extends Schema.TaggedError<ResourceAccessDenied>()('ResourceAccessDenied', {
   message: Schema.String,
   uri: Schema.String,
 }) {}
 
-export class ResourceAlreadyExists extends Schema.TaggedErrorClass<ResourceAlreadyExists>()('ResourceAlreadyExists', {
+export class ResourceAlreadyExists extends Schema.TaggedError<ResourceAlreadyExists>()('ResourceAlreadyExists', {
   message: Schema.String,
   uri: Schema.String,
 }) {}
 
-export class ResourceConflict extends Schema.TaggedErrorClass<ResourceConflict>()('ResourceConflict', {
+export class ResourceConflict extends Schema.TaggedError<ResourceConflict>()('ResourceConflict', {
   actualFingerprint: Schema.String,
   expectedFingerprint: Schema.String,
   message: Schema.String,
   uri: Schema.String,
 }) {}
 
-export class ResourceIoFailed extends Schema.TaggedErrorClass<ResourceIoFailed>()('ResourceIoFailed', {
+export class ResourceIoFailed extends Schema.TaggedError<ResourceIoFailed>()('ResourceIoFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   operation: Schema.String,
   uri: Schema.String,
 }) {}
 
-export class ResourceNotFound extends Schema.TaggedErrorClass<ResourceNotFound>()('ResourceNotFound', {
+export class ResourceNotFound extends Schema.TaggedError<ResourceNotFound>()('ResourceNotFound', {
   message: Schema.String,
   uri: Schema.String,
 }) {}
 
-export class ResourcePathUnsafe extends Schema.TaggedErrorClass<ResourcePathUnsafe>()('ResourcePathUnsafe', {
+export class ResourcePathUnsafe extends Schema.TaggedError<ResourcePathUnsafe>()('ResourcePathUnsafe', {
   message: Schema.String,
   path: Schema.String,
   uri: Schema.String,

--- a/src/memory_domain/address.ts
+++ b/src/memory_domain/address.ts
@@ -33,12 +33,12 @@ export interface RemoteMemoryAddressResolutionV1 {
   readonly version: typeof REMOTE_MEMORY_ALIAS_VERSION;
 }
 
-export class InvalidRemoteMemoryAddress extends Schema.TaggedErrorClass<InvalidRemoteMemoryAddress>()(
+export class InvalidRemoteMemoryAddress extends Schema.TaggedError<InvalidRemoteMemoryAddress>()(
   'InvalidRemoteMemoryAddress',
   {input: Schema.String, message: Schema.String, reason: Schema.String},
 ) {}
 
-export class InvalidRemoteMemoryAlias extends Schema.TaggedErrorClass<InvalidRemoteMemoryAlias>()(
+export class InvalidRemoteMemoryAlias extends Schema.TaggedError<InvalidRemoteMemoryAlias>()(
   'InvalidRemoteMemoryAlias',
   {input: Schema.String, message: Schema.String, reason: Schema.String},
 ) {}

--- a/src/memory_domain/content.ts
+++ b/src/memory_domain/content.ts
@@ -41,7 +41,7 @@ export interface RemoteMemoryContentPolicy {
   readonly additionalPatterns?: readonly ScrubberPattern[];
 }
 
-export class InvalidRemoteMemoryDocument extends Schema.TaggedErrorClass<InvalidRemoteMemoryDocument>()(
+export class InvalidRemoteMemoryDocument extends Schema.TaggedError<InvalidRemoteMemoryDocument>()(
   'InvalidRemoteMemoryDocument',
   {message: Schema.String, reason: Schema.String},
 ) {}

--- a/src/memory_domain/receipts.ts
+++ b/src/memory_domain/receipts.ts
@@ -40,7 +40,7 @@ export const RemoteMemoryReceiptSchemaV1 = Schema.Struct({
 
 export type RemoteMemoryReceiptV1 = typeof RemoteMemoryReceiptSchemaV1.Type;
 
-export class InvalidRemoteMemoryReceipt extends Schema.TaggedErrorClass<InvalidRemoteMemoryReceipt>()(
+export class InvalidRemoteMemoryReceipt extends Schema.TaggedError<InvalidRemoteMemoryReceipt>()(
   'InvalidRemoteMemoryReceipt',
   {message: Schema.String},
 ) {}

--- a/src/memory_domain/repository.ts
+++ b/src/memory_domain/repository.ts
@@ -16,7 +16,7 @@ export const REMOTE_MEMORY_REPOSITORY_ERROR_CODES = [
 
 export type RemoteMemoryRepositoryErrorCode = (typeof REMOTE_MEMORY_REPOSITORY_ERROR_CODES)[number];
 
-export class RemoteMemoryRepositoryError extends Schema.TaggedErrorClass<RemoteMemoryRepositoryError>()(
+export class RemoteMemoryRepositoryError extends Schema.TaggedError<RemoteMemoryRepositoryError>()(
   'RemoteMemoryRepositoryError',
   {
     code: Schema.Literals(REMOTE_MEMORY_REPOSITORY_ERROR_CODES),

--- a/src/memory_domain/revisions.ts
+++ b/src/memory_domain/revisions.ts
@@ -80,7 +80,7 @@ export type RemoteMutationDecisionV1 =
       readonly version: typeof REMOTE_MEMORY_REVISION_VERSION;
     };
 
-export class InvalidRemoteMutation extends Schema.TaggedErrorClass<InvalidRemoteMutation>()('InvalidRemoteMutation', {
+export class InvalidRemoteMutation extends Schema.TaggedError<InvalidRemoteMutation>()('InvalidRemoteMutation', {
   message: Schema.String,
 }) {}
 

--- a/src/migration/home.ts
+++ b/src/migration/home.ts
@@ -129,18 +129,18 @@ interface RecoveryPreflight {
   readonly skippedLegacyEntries: ReadonlySet<string>;
 }
 
-export class HomeMigrationConflict extends Schema.TaggedErrorClass<HomeMigrationConflict>()('HomeMigrationConflict', {
+export class HomeMigrationConflict extends Schema.TaggedError<HomeMigrationConflict>()('HomeMigrationConflict', {
   message: Schema.String,
   path: Schema.String,
 }) {}
 
-export class HomeMigrationFailed extends Schema.TaggedErrorClass<HomeMigrationFailed>()('HomeMigrationFailed', {
+export class HomeMigrationFailed extends Schema.TaggedError<HomeMigrationFailed>()('HomeMigrationFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   operation: Schema.String,
 }) {}
 
-export class HomeMigrationInsufficientSpace extends Schema.TaggedErrorClass<HomeMigrationInsufficientSpace>()(
+export class HomeMigrationInsufficientSpace extends Schema.TaggedError<HomeMigrationInsufficientSpace>()(
   'HomeMigrationInsufficientSpace',
   {
     availableBytes: Schema.Number,
@@ -149,7 +149,7 @@ export class HomeMigrationInsufficientSpace extends Schema.TaggedErrorClass<Home
   },
 ) {}
 
-export class HomeMigrationUnsafe extends Schema.TaggedErrorClass<HomeMigrationUnsafe>()('HomeMigrationUnsafe', {
+export class HomeMigrationUnsafe extends Schema.TaggedError<HomeMigrationUnsafe>()('HomeMigrationUnsafe', {
   message: Schema.String,
   path: Schema.String,
 }) {}

--- a/src/migration/layout.ts
+++ b/src/migration/layout.ts
@@ -44,7 +44,7 @@ export interface StorageLayoutMigrationResult {
     | 'would_repair_marker';
 }
 
-export class StorageLayoutMigrationConflict extends Schema.TaggedErrorClass<StorageLayoutMigrationConflict>()(
+export class StorageLayoutMigrationConflict extends Schema.TaggedError<StorageLayoutMigrationConflict>()(
   'StorageLayoutMigrationConflict',
   {
     message: Schema.String,

--- a/src/models/store.ts
+++ b/src/models/store.ts
@@ -44,7 +44,7 @@ export interface LocalModelStoreLayerOptions {
   readonly onModelLockContention?: (event: LocalModelLockEvent) => Effect.Effect<void, never>;
 }
 
-export class ModelStoreIoFailed extends Schema.TaggedErrorClass<ModelStoreIoFailed>()('ModelStoreIoFailed', {
+export class ModelStoreIoFailed extends Schema.TaggedError<ModelStoreIoFailed>()('ModelStoreIoFailed', {
   cause: Schema.Defect(),
   message: Schema.String,
   modelId: Schema.String,

--- a/src/remote_memory/operator_files.ts
+++ b/src/remote_memory/operator_files.ts
@@ -15,7 +15,7 @@ const MAX_IMPORT_FILE_BYTES = 1024 * 1024;
 const MAX_IMPORT_TOTAL_BYTES = 100 * 1024 * 1024;
 const MAX_JSON_BYTES = 4 * 1024 * 1024;
 
-export class RemoteMemoryOperatorFileError extends Schema.TaggedErrorClass<RemoteMemoryOperatorFileError>()(
+export class RemoteMemoryOperatorFileError extends Schema.TaggedError<RemoteMemoryOperatorFileError>()(
   'RemoteMemoryOperatorFileError',
   {message: Schema.String},
 ) {}

--- a/src/remote_memory/operator_main.ts
+++ b/src/remote_memory/operator_main.ts
@@ -66,7 +66,7 @@ const ProvisioningInput = z
   })
   .strict();
 
-class RemoteMemoryOperatorInvocationError extends Schema.TaggedErrorClass<RemoteMemoryOperatorInvocationError>()(
+class RemoteMemoryOperatorInvocationError extends Schema.TaggedError<RemoteMemoryOperatorInvocationError>()(
   'RemoteMemoryOperatorInvocationError',
   {message: Schema.String},
 ) {}

--- a/src/report_issue.ts
+++ b/src/report_issue.ts
@@ -40,16 +40,13 @@ interface PreparedIssue {
   readonly title: string;
 }
 
-export class ReportIssueInvalid extends Schema.TaggedErrorClass<ReportIssueInvalid>()('ReportIssueInvalid', {
+export class ReportIssueInvalid extends Schema.TaggedError<ReportIssueInvalid>()('ReportIssueInvalid', {
   message: Schema.String,
 }) {}
 
-export class ReportIssueCreateFailed extends Schema.TaggedErrorClass<ReportIssueCreateFailed>()(
-  'ReportIssueCreateFailed',
-  {
-    message: Schema.String,
-  },
-) {}
+export class ReportIssueCreateFailed extends Schema.TaggedError<ReportIssueCreateFailed>()('ReportIssueCreateFailed', {
+  message: Schema.String,
+}) {}
 
 export const runReportIssue = Effect.fn('reportIssue.runReportIssue')(function* (
   config: RuntimeConfig,

--- a/src/search/vector-index.ts
+++ b/src/search/vector-index.ts
@@ -119,12 +119,12 @@ export interface VectorIndexStatus {
   readonly reusedChunkCount?: number;
 }
 
-export class VectorIndexCorrupt extends Schema.TaggedErrorClass<VectorIndexCorrupt>()('VectorIndexCorrupt', {
+export class VectorIndexCorrupt extends Schema.TaggedError<VectorIndexCorrupt>()('VectorIndexCorrupt', {
   message: Schema.String,
   modelId: Schema.String,
 }) {}
 
-export class VectorCorpusGenerationChanged extends Schema.TaggedErrorClass<VectorCorpusGenerationChanged>()(
+export class VectorCorpusGenerationChanged extends Schema.TaggedError<VectorCorpusGenerationChanged>()(
   'VectorCorpusGenerationChanged',
   {
     message: Schema.String,

--- a/src/search/vector-search.ts
+++ b/src/search/vector-search.ts
@@ -10,7 +10,7 @@ export interface VectorSearchResult {
   readonly score: number;
 }
 
-export class VectorInvalid extends Schema.TaggedErrorClass<VectorInvalid>()('VectorInvalid', {
+export class VectorInvalid extends Schema.TaggedError<VectorInvalid>()('VectorInvalid', {
   message: Schema.String,
 }) {}
 

--- a/src/storage/resource-id.ts
+++ b/src/storage/resource-id.ts
@@ -11,7 +11,7 @@ export interface ResourceId {
   readonly segments: readonly string[];
 }
 
-export class InvalidResourceId extends Schema.TaggedErrorClass<InvalidResourceId>()('InvalidResourceId', {
+export class InvalidResourceId extends Schema.TaggedError<InvalidResourceId>()('InvalidResourceId', {
   input: Schema.String,
   message: Schema.String,
   reason: Schema.String,

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -40,6 +40,27 @@ describe('Effect CLI', () => {
     expect(disable.stdout).toContain('--apply');
   });
 
+  it('keeps regular and negated boolean flags optional with their historical defaults', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-boolean-defaults-'));
+    const environment = {
+      THREADNOTE_HOME: join(root, 'home'),
+      THREADNOTE_INSTALL_ROOT: join(root, 'install'),
+    };
+    try {
+      const textProcesses = await runCli(['processes'], environment);
+      const jsonProcesses = await runCli(['processes', '--json'], environment);
+      const defaultStart = await runCli(['install', '--dry-run'], environment);
+      const disabledStart = await runCli(['install', '--dry-run', '--no-start'], environment);
+
+      expect(textProcesses.stdout).toMatch(/^(?:PID|No live Threadnote processes found\.)/u);
+      expect(JSON.parse(jsonProcesses.stdout)).toMatchObject({schemaVersion: 1});
+      expect(defaultStart.stdout).toContain('no background server is required');
+      expect(disabledStart.stdout).not.toContain('no background server is required');
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  });
+
   it('keeps automatic-update policy dry runs read-only and rejects mixed update modes', async () => {
     const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-auto-update-'));
     const environment = {

--- a/test/integration/code-graph.telemetry.test.ts
+++ b/test/integration/code-graph.telemetry.test.ts
@@ -462,13 +462,16 @@ function telemetryQueryResult(status: CodeGraphStatus): CodeGraphQueryResult {
 
 function telemetryMcpClient(): McpSchema.McpServerClient['Service'] {
   return McpSchema.McpServerClient.of({
+    clientCapabilities: {},
     clientId: 0,
+    clientInfo: {name: 'telemetry-test', version: '1.0.0'},
     getClient: Effect.never,
     initializePayload: {
       capabilities: {},
       clientInfo: {name: 'telemetry-test', version: '1.0.0'},
       protocolVersion: '2025-06-18',
     },
+    protocolVersion: '2025-06-18',
   });
 }
 

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -283,10 +283,7 @@ describe('Threadnote MCP toolsets', () => {
   it('advertises bounded Threadnote resource discovery without enumerating private memories', async () => {
     await withMcpClient(
       async client => {
-        expect(client.getServerCapabilities()?.resources).toEqual({listChanged: true, subscribe: true});
-        const subscribedUri = 'threadnote://user/test-user/memories/durable/projects/threadnote/subscribed.md';
-        await expect(client.subscribeResource({uri: subscribedUri})).resolves.toEqual({});
-        await expect(client.unsubscribeResource({uri: subscribedUri})).resolves.toEqual({});
+        expect(client.getServerCapabilities()?.resources).toEqual({listChanged: true, subscribe: false});
         await expect(client.listResources()).resolves.toEqual({resources: []});
 
         const templates = await client.listResourceTemplates();

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -283,7 +283,10 @@ describe('Threadnote MCP toolsets', () => {
   it('advertises bounded Threadnote resource discovery without enumerating private memories', async () => {
     await withMcpClient(
       async client => {
-        expect(client.getServerCapabilities()?.resources).toEqual({listChanged: true, subscribe: false});
+        expect(client.getServerCapabilities()?.resources).toEqual({listChanged: true, subscribe: true});
+        const subscribedUri = 'threadnote://user/test-user/memories/durable/projects/threadnote/subscribed.md';
+        await expect(client.subscribeResource({uri: subscribedUri})).resolves.toEqual({});
+        await expect(client.unsubscribeResource({uri: subscribedUri})).resolves.toEqual({});
         await expect(client.listResources()).resolves.toEqual({resources: []});
 
         const templates = await client.listResourceTemplates();

--- a/test/unit/bun-package-contract.test.ts
+++ b/test/unit/bun-package-contract.test.ts
@@ -6,6 +6,7 @@ interface PackageManifest {
   readonly dependencies?: Readonly<Record<string, string>>;
   readonly devDependencies?: Readonly<Record<string, string>>;
   readonly engines?: Readonly<Record<string, string>>;
+  readonly overrides?: Readonly<Record<string, string>>;
   readonly packageManager?: string;
   readonly scripts?: Readonly<Record<string, string>>;
 }
@@ -14,15 +15,40 @@ describe('Bun distribution contract', () => {
   it('uses Bun as the only application runtime and build toolchain', async () => {
     const manifest = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8')) as PackageManifest;
     const allDependencies = {...manifest.dependencies, ...manifest.devDependencies};
+    const effectVersion = '4.0.0-rc.112';
 
     expect(manifest.packageManager).toMatch(/^bun@/);
-    expect(manifest.dependencies?.['@effect/platform-bun']).toBe('4.0.0-beta.102');
-    expect(allDependencies['@effect/sql-sqlite-bun']).toBe('4.0.0-beta.102');
+    for (const packageName of [
+      '@effect/ai-openai-compat',
+      '@effect/platform-bun',
+      '@effect/sql-sqlite-bun',
+      '@effect/vitest',
+      'effect',
+    ]) {
+      expect(allDependencies[packageName]).toBe(effectVersion);
+    }
+    expect(manifest.overrides?.['@effect/platform-node-shared']).toBe(effectVersion);
+    expect(manifest.devDependencies?.['@effect/tsgo']).toBe('0.37.0');
     expect(allDependencies['@effect/platform-node']).toBeUndefined();
     expect(allDependencies['@effect/sql-sqlite-node']).toBeUndefined();
     expect(manifest.engines?.node).toBeUndefined();
     expect(manifest.scripts?.build).toMatch(/^bun /);
     expect(manifest.scripts?.test).toMatch(/^bun /);
     expect(Object.values(manifest.scripts ?? {}).join('\n')).not.toMatch(/\b(?:node|npm|npx)\b/);
+  });
+
+  it('patches only the vulnerable PostCSS Nano ID edge', async () => {
+    const [manifestText, lockfile] = await Promise.all([
+      readFile(join(process.cwd(), 'package.json'), 'utf8'),
+      readFile(join(process.cwd(), 'bun.lock'), 'utf8'),
+    ]);
+    const manifest = JSON.parse(manifestText) as PackageManifest;
+
+    expect(manifest.dependencies?.nanoid).toBeUndefined();
+    expect(manifest.devDependencies?.nanoid).toBeUndefined();
+    expect(manifest.overrides?.nanoid).toBeUndefined();
+    expect(lockfile).toContain('"nanoid": ["nanoid@5.1.16"');
+    expect(lockfile).toContain('"postcss/nanoid": ["nanoid@3.3.18"');
+    expect(lockfile).not.toContain('"postcss/nanoid": ["nanoid@3.3.16"');
   });
 });

--- a/test/unit/code-graph.local-provenance.test.ts
+++ b/test/unit/code-graph.local-provenance.test.ts
@@ -938,9 +938,10 @@ function mapOpenedFile(
   read: FileSystem.File['read'],
   mapInfo: (info: FileSystem.File.Info) => FileSystem.File.Info = info => info,
 ): FileSystem.File {
+  const descriptor = (opened as FileSystem.File & {readonly fd?: unknown}).fd;
   return {
     [FileSystem.FileTypeId]: FileSystem.FileTypeId,
-    fd: opened.fd,
+    ...(typeof descriptor === 'number' ? {fd: descriptor} : {}),
     read,
     readAlloc: size => opened.readAlloc(size),
     seek: (offset, from) => opened.seek(offset, from),
@@ -949,7 +950,7 @@ function mapOpenedFile(
     truncate: length => opened.truncate(length),
     write: buffer => opened.write(buffer),
     writeAll: buffer => opened.writeAll(buffer),
-  };
+  } as FileSystem.File;
 }
 
 function escapeRegularExpression(value: string): string {

--- a/test/unit/code-graph.production-ratchet-scope.property.test.ts
+++ b/test/unit/code-graph.production-ratchet-scope.property.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from 'vitest';
 import {classifyCodeGraphProductionRatchetScope} from '../ci/code-graph-production-ratchet-scope.js';
 
 const baseManifest = {
-  dependencies: {effect: '4.0.0-beta.102'},
+  dependencies: {effect: '4.0.0-rc.112'},
   name: 'threadnote',
   scripts: {test: 'vitest run'},
   version: '4.3.6',

--- a/test/unit/code-graph.watcher.test.ts
+++ b/test/unit/code-graph.watcher.test.ts
@@ -569,6 +569,42 @@ describe('CodeGraphWatcher', () => {
     }).pipe(Effect.scoped),
   );
 
+  effectIt.effect('requests recursive filesystem events so nested source changes trigger refresh', () =>
+    Effect.gen(function* () {
+      const events = yield* Ref.make<string[]>([]);
+      let watchOptions: {readonly recursive?: boolean} | undefined;
+      const fiber = yield* watchRepository(
+        {
+          watch: (_root: string, observedOptions?: {readonly recursive?: boolean}) => {
+            watchOptions = observedOptions;
+            return Stream.make({path: 'src/nested/value.ts'});
+          },
+        } as never,
+        {
+          isAbsolute: (value: string) => value.startsWith('/'),
+          join: (...values: string[]) => values.join('/'),
+          relative: (from: string, to: string) => (to.startsWith(`${from}/`) ? to.slice(from.length + 1) : to),
+          sep: '/',
+        } as never,
+        options,
+        false,
+        () => Ref.update(events, current => [...current, 'refresh']),
+        {
+          periodicRefreshRequired: Effect.succeed(false),
+          requestAfterChange: Ref.update(events, current => [...current, 'change-maintenance']),
+          requestInitial: Effect.void,
+        },
+      ).pipe(Effect.forkScoped);
+
+      yield* TestClock.adjust('751 millis');
+      yield* Effect.yieldNow;
+
+      expect(watchOptions).toEqual({recursive: true});
+      expect(yield* Ref.get(events)).toEqual(['change-maintenance', 'refresh']);
+      yield* Fiber.interrupt(fiber);
+    }).pipe(Effect.scoped),
+  );
+
   effectIt.effect('suppresses change refresh when the cached overlay outcome is not eligible', () =>
     Effect.gen(function* () {
       const events = yield* Ref.make<string[]>([]);

--- a/test/unit/effect-ai-mcp-http.test.ts
+++ b/test/unit/effect-ai-mcp-http.test.ts
@@ -21,7 +21,7 @@ interface McpHttpFixture {
   readonly handler: (request: Request) => Promise<Response>;
 }
 
-function makeFixture(): McpHttpFixture {
+function makeFixture(allowedOrigins?: ReadonlyArray<string>): McpHttpFixture {
   const server = new EffectMcpServerAdapter('threadnote-memory-fixture', '1.0.0', 'Remote fixture instructions.');
   server.registerTool(
     HTTP_CONTEXT_TOOL,
@@ -54,6 +54,7 @@ function makeFixture(): McpHttpFixture {
   );
   const httpLayer = server
     .httpLayer({
+      allowedOrigins,
       path: '/mcp',
       resolveRequestContext: request => {
         if (request.headers.authorization !== 'Bearer fixture-token') {
@@ -76,16 +77,24 @@ function makeFixture(): McpHttpFixture {
   return HttpRouter.toWebHandler(httpLayer, {disableLogger: true});
 }
 
-async function initialize(fixture: McpHttpFixture): Promise<string> {
-  const response = await rpcRequest(fixture, {
-    id: 1,
-    method: 'initialize',
-    params: {
-      capabilities: {},
-      clientInfo: {name: 'threadnote-http-fixture', version: '1.0.0'},
-      protocolVersion: MCP_PROTOCOL_VERSION,
+async function initialize(
+  fixture: McpHttpFixture,
+  protocolVersion = MCP_PROTOCOL_VERSION,
+  origin?: string,
+): Promise<string> {
+  const response = await rpcRequest(
+    fixture,
+    {
+      id: 1,
+      method: 'initialize',
+      params: {
+        capabilities: {},
+        clientInfo: {name: 'threadnote-http-fixture', version: '1.0.0'},
+        protocolVersion,
+      },
     },
-  });
+    {origin, protocolVersion},
+  );
   expect(response.status).toBe(200);
   const sessionId = response.headers.get('mcp-session-id');
   expect(sessionId).toBeTruthy();
@@ -95,7 +104,7 @@ async function initialize(fixture: McpHttpFixture): Promise<string> {
     result: {
       capabilities: {tools: {listChanged: true}},
       instructions: 'Remote fixture instructions.',
-      protocolVersion: MCP_PROTOCOL_VERSION,
+      protocolVersion,
       serverInfo: {name: 'threadnote-memory-fixture', version: '1.0.0'},
     },
   });
@@ -107,7 +116,8 @@ async function rpcRequest(
   message: Readonly<Record<string, unknown>> | readonly Readonly<Record<string, unknown>>[],
   options: {
     readonly principal?: string;
-    readonly protocolVersion?: string;
+    readonly origin?: string;
+    readonly protocolVersion?: string | null;
     readonly requestId?: string;
     readonly sessionId?: string;
     readonly token?: string;
@@ -117,11 +127,14 @@ async function rpcRequest(
     accept: 'application/json, text/event-stream',
     authorization: `Bearer ${options.token ?? 'fixture-token'}`,
     'content-type': 'application/json',
-    'mcp-protocol-version': options.protocolVersion ?? MCP_PROTOCOL_VERSION,
     'x-policy-version': 'policy-v1',
     'x-principal': options.principal ?? 'fixture-principal',
     'x-request-id': options.requestId ?? 'fixture-request',
   };
+  if (options.protocolVersion !== null) {
+    headers['mcp-protocol-version'] = options.protocolVersion ?? MCP_PROTOCOL_VERSION;
+  }
+  if (options.origin !== undefined) headers.origin = options.origin;
   if (options.sessionId !== undefined) headers['mcp-session-id'] = options.sessionId;
   const body = Array.isArray(message) ? message.map(item => ({jsonrpc: '2.0', ...item})) : {jsonrpc: '2.0', ...message};
   return fixture.handler(
@@ -213,6 +226,33 @@ describe('Effect MCP Streamable HTTP transport', () => {
     }
   });
 
+  it('rejects browser origins by default and admits only an explicit allowlist', async () => {
+    const origin = 'https://browser.example.test';
+    const rejectedFixture = makeFixture();
+    const allowedFixture = makeFixture([origin]);
+    try {
+      const rejected = await rpcRequest(
+        rejectedFixture,
+        {
+          id: 1,
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: {name: 'browser-fixture', version: '1.0.0'},
+            protocolVersion: MCP_PROTOCOL_VERSION,
+          },
+        },
+        {origin},
+      );
+      const sessionId = await initialize(allowedFixture, MCP_PROTOCOL_VERSION, origin);
+
+      expect(rejected.status).toBe(403);
+      expect(sessionId).not.toBe('');
+    } finally {
+      await Promise.all([rejectedFixture.dispose(), allowedFixture.dispose()]);
+    }
+  });
+
   it('serializes branded resource failures as their MCP protocol error over HTTP', async () => {
     const fixture = makeFixture();
     try {
@@ -237,14 +277,15 @@ describe('Effect MCP Streamable HTTP transport', () => {
   it('repairs every branded resource failure in an HTTP JSON-RPC batch', async () => {
     const fixture = makeFixture();
     try {
-      const sessionId = await initialize(fixture);
+      const protocolVersion = '2025-03-26';
+      const sessionId = await initialize(fixture, protocolVersion);
       const response = await rpcRequest(
         fixture,
         [
           {id: 2, method: 'resources/read', params: {uri: 'threadnote://not-canonical'}},
           {id: 'three', method: 'resources/read', params: {uri: 'threadnote://also-not-canonical'}},
         ],
-        {sessionId},
+        {protocolVersion, sessionId},
       );
 
       expect(response.status).toBe(200);
@@ -264,6 +305,69 @@ describe('Effect MCP Streamable HTTP transport', () => {
       await fixture.dispose();
     }
   });
+
+  it.each(['2024-11-05', '2025-06-18', '2025-11-25'])('rejects JSON-RPC batches for %s', async protocolVersion => {
+    const fixture = makeFixture();
+    try {
+      const sessionId = await initialize(fixture, protocolVersion);
+      const response = await rpcRequest(
+        fixture,
+        [
+          {id: 2, method: 'tools/list', params: {}},
+          {id: 3, method: 'tools/list', params: {}},
+        ],
+        {protocolVersion, sessionId},
+      );
+
+      expect(response.status).toBe(400);
+    } finally {
+      await fixture.dispose();
+    }
+  });
+
+  it.each(['2024-11-05', '2025-03-26'])(
+    'accepts %s session requests without a version header',
+    async protocolVersion => {
+      const fixture = makeFixture();
+      try {
+        const sessionId = await initialize(fixture, protocolVersion);
+        const response = await rpcRequest(
+          fixture,
+          {id: 2, method: 'tools/list', params: {}},
+          {
+            protocolVersion: null,
+            sessionId,
+          },
+        );
+
+        expect(response.status).toBe(200);
+      } finally {
+        await fixture.dispose();
+      }
+    },
+  );
+
+  it.each(['2025-06-18', '2025-11-25'])(
+    'requires the %s version header after initialization',
+    async protocolVersion => {
+      const fixture = makeFixture();
+      try {
+        const sessionId = await initialize(fixture, protocolVersion);
+        const response = await rpcRequest(
+          fixture,
+          {id: 2, method: 'tools/list', params: {}},
+          {
+            protocolVersion: null,
+            sessionId,
+          },
+        );
+
+        expect(response.status).toBe(400);
+      } finally {
+        await fixture.dispose();
+      }
+    },
+  );
 
   it('rejects unsupported cross-POST cancellation instead of falsely acknowledging it', async () => {
     const fixture = makeFixture();

--- a/test/unit/effect-ai-mcp-http.test.ts
+++ b/test/unit/effect-ai-mcp-http.test.ts
@@ -102,7 +102,7 @@ async function initialize(
     id: 1,
     jsonrpc: '2.0',
     result: {
-      capabilities: {tools: {listChanged: true}},
+      capabilities: {resources: {listChanged: true, subscribe: false}, tools: {listChanged: true}},
       instructions: 'Remote fixture instructions.',
       protocolVersion,
       serverInfo: {name: 'threadnote-memory-fixture', version: '1.0.0'},

--- a/test/unit/effect-ai-mcp.test.ts
+++ b/test/unit/effect-ai-mcp.test.ts
@@ -40,11 +40,22 @@ const initializeResponse = JSON.stringify({
   id: 1,
   jsonrpc: '2.0',
   result: {
-    capabilities: {tools: {}},
+    capabilities: {resources: {listChanged: true, subscribe: true}, tools: {}},
     protocolVersion: '2025-06-18',
     serverInfo: {name: 'threadnote', version: '4.0.0'},
   },
 });
+
+const repairedInitializeResponse = {
+  id: 1,
+  jsonrpc: '2.0',
+  result: {
+    capabilities: {resources: {listChanged: true, subscribe: false}, tools: {}},
+    instructions: 'Use Threadnote context.',
+    protocolVersion: '2025-06-18',
+    serverInfo: {name: 'threadnote', version: '4.0.0'},
+  },
+};
 
 describe('Effect MCP initialization instructions', () => {
   it('parses the string initialize response once and passes later large frames through unchanged', () => {
@@ -59,9 +70,7 @@ describe('Effect MCP initialization instructions', () => {
     expect(parseCalls).toBe(1);
     expect(passedThrough).toBe(largeFrame);
     expect(typeof initialized).toBe('string');
-    expect(JSON.parse(initialized as string)).toMatchObject({
-      result: {instructions: 'Use Threadnote context.'},
-    });
+    expect(JSON.parse(initialized as string)).toEqual(repairedInitializeResponse);
   });
 
   it('preserves Uint8Array output and identity for later large frames', () => {
@@ -79,9 +88,7 @@ describe('Effect MCP initialization instructions', () => {
     expect(parseCalls).toBe(0);
     expect(passedThrough).toBe(largeFrame);
     expect(initialized).toBeInstanceOf(Uint8Array);
-    expect(JSON.parse(new TextDecoder().decode(initialized as Uint8Array))).toMatchObject({
-      result: {instructions: 'Use Threadnote context.'},
-    });
+    expect(JSON.parse(new TextDecoder().decode(initialized as Uint8Array))).toEqual(repairedInitializeResponse);
   });
 
   it('unwraps only Effect RPC envelopes carrying recognized MCP protocol errors', () => {

--- a/test/unit/effect-ai-mcp.test.ts
+++ b/test/unit/effect-ai-mcp.test.ts
@@ -3,7 +3,7 @@ import {it as effectIt} from '@effect/vitest';
 import {Cause, Deferred, Effect, Exit, Fiber} from 'effect';
 import {TestClock} from 'effect/testing';
 import fc from 'fast-check';
-import {McpSchema} from 'effect/unstable/ai';
+import {McpProtocol, McpSchema} from 'effect/unstable/ai';
 import {RpcServer} from 'effect/unstable/rpc';
 import {describe, expect, it, vi} from 'vitest';
 import {
@@ -16,6 +16,7 @@ import {
   mcpProgressNotificationForCurrentRequest,
   mcpProgressHeartbeatMilliseconds,
   mcpRequestIdKey,
+  mcpStdioSerialization,
   MCP_PROGRESS_HEARTBEAT_MILLISECONDS,
   MCP_PROGRESS_MESSAGE_MAX_BYTES,
   MCP_PROGRESS_METADATA_KEY,
@@ -89,7 +90,7 @@ describe('Effect MCP initialization instructions', () => {
     const invalidParams = JSON.stringify({
       error: {
         _tag: 'Cause',
-        code: 0,
+        code: -32602,
         data: [
           {
             _tag: 'Fail',
@@ -244,6 +245,112 @@ describe('Effect MCP initialization instructions', () => {
     ];
 
     for (const frame of frames) expect(transform(frame)).toBe(frame);
+  });
+});
+
+describe('Effect MCP stdio protocol revisions', () => {
+  const protocols = [
+    McpProtocol.v2025_11_25,
+    McpProtocol.v2025_06_18,
+    McpProtocol.v2025_03_26,
+    McpProtocol.v2024_11_05,
+  ] as const;
+
+  it.each([
+    ['2024-11-05', false],
+    ['2025-03-26', true],
+    ['2025-06-18', false],
+    ['2025-11-25', false],
+  ] as const)('negotiates %s and applies its JSON-RPC batch policy', (protocolVersion, acceptsBatch) => {
+    const parser = mcpStdioSerialization(protocols).makeUnsafe();
+    const encode = (value: unknown) => new TextEncoder().encode(`${JSON.stringify(value)}\n`);
+    const initialized = parser.decode(
+      encode({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {capabilities: {}, clientInfo: {name: 'stdio-revision-test', version: '1.0.0'}, protocolVersion},
+      }),
+    );
+    const decodedBatch = parser.decode(
+      encode([
+        {id: 2, jsonrpc: '2.0', method: 'tools/list', params: {}},
+        {id: 3, jsonrpc: '2.0', method: 'tools/list', params: {}},
+      ]),
+    ) as readonly {readonly id?: unknown; readonly tag?: unknown}[];
+
+    expect(initialized).toEqual([
+      expect.objectContaining({id: 1, payload: expect.objectContaining({protocolVersion}), tag: 'initialize'}),
+    ]);
+    expect(decodedBatch).toEqual(
+      acceptsBatch
+        ? [expect.objectContaining({id: 2, tag: 'tools/list'}), expect.objectContaining({id: 3, tag: 'tools/list'})]
+        : [expect.objectContaining({id: null, tag: 'invalid/json-rpc-batch'})],
+    );
+  });
+
+  it('encodes a rejected stdio batch as one Invalid Request response', () => {
+    const parser = mcpStdioSerialization(protocols).makeUnsafe();
+    const encoded = parser.encode({
+      _tag: 'Exit',
+      exit: {_tag: 'Failure', cause: [{_tag: 'Fail', error: {message: 'JSON-RPC batches are not supported'}}]},
+      requestId: null,
+    } as never);
+
+    expect(typeof encoded).toBe('string');
+    expect(JSON.parse(encoded as string)).toMatchObject({
+      error: {code: -32_600, message: 'JSON-RPC batches are not supported'},
+      id: null,
+      jsonrpc: '2.0',
+    });
+  });
+
+  it('uses the newest advertised policy for an unsupported offered revision', () => {
+    const parser = mcpStdioSerialization(protocols).makeUnsafe();
+    const encode = (value: unknown) => new TextEncoder().encode(`${JSON.stringify(value)}\n`);
+    parser.decode(
+      encode({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: {name: 'unknown-revision-test', version: '1.0.0'},
+          protocolVersion: '2099-01-01',
+        },
+      }),
+    );
+
+    expect(
+      parser.decode(
+        encode([
+          {id: 2, jsonrpc: '2.0', method: 'tools/list', params: {}},
+          {id: 3, jsonrpc: '2.0', method: 'tools/list', params: {}},
+        ]),
+      ),
+    ).toEqual([expect.objectContaining({id: null, tag: 'invalid/json-rpc-batch'})]);
+  });
+
+  it('does not relabel an unrelated null-id failure as a rejected batch', () => {
+    const parser = mcpStdioSerialization(protocols).makeUnsafe();
+    const encoded = parser.encode({
+      _tag: 'Exit',
+      exit: {
+        _tag: 'Failure',
+        cause: [
+          {
+            _tag: 'Fail',
+            error: {_tag: 'InvalidRequest', code: -32_600, message: 'Unrelated null-id failure'},
+          },
+        ],
+      },
+      requestId: null,
+    } as never);
+
+    expect(JSON.parse(encoded as string)).toMatchObject({
+      error: {code: -32_600, message: 'Unrelated null-id failure'},
+      jsonrpc: '2.0',
+    });
   });
 });
 
@@ -701,7 +808,7 @@ describe('Effect MCP tool progress', () => {
     initializedClients.add(11);
     const queued = [{progressToken: 'client-11-token'}];
 
-    // The Effect beta.102 queue reads recipients only when it drains. The
+    // The Effect 4.0.0-rc.112 queue reads recipients only when it drains. The
     // stdio registry therefore has to reject a foreign add after enqueue, not
     // merely check the set before the notification is offered.
     initializedClients.add(22);
@@ -903,8 +1010,11 @@ function fakeEffectMcpServer(): EffectMcpServer {
 
 function fixtureMcpServerClient(clientId: number): McpSchema.McpServerClient['Service'] {
   return McpSchema.McpServerClient.of({
+    clientCapabilities: {},
     clientId,
+    clientInfo: {name: 'effect-ai-mcp-test', version: '1.0.0'},
     getClient: Effect.never as McpSchema.McpServerClient['Service']['getClient'],
     initializePayload: {} as McpSchema.McpServerClient['Service']['initializePayload'],
+    protocolVersion: '2025-06-18',
   });
 }

--- a/test/unit/effect-ai-mcp.test.ts
+++ b/test/unit/effect-ai-mcp.test.ts
@@ -413,6 +413,30 @@ describe('Effect MCP tool interruption', () => {
     expect(JSON.stringify(adapted)).toBe(JSON.stringify(source));
   });
 
+  it('normalizes optional structured fields with JSON wire semantics before SDK validation', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            optional: fc.option(fc.jsonValue(), {nil: undefined}),
+            required: fc.jsonValue(),
+          }),
+          {maxLength: 8},
+        ),
+        entries => {
+          const structuredContent = {entries};
+          const adapted = mcpCallToolResultWithTelemetryMetadata({
+            content: [{type: 'text', text: 'Structured result.'}],
+            structuredContent,
+          });
+
+          expect(adapted.structuredContent).toEqual(JSON.parse(JSON.stringify(structuredContent)));
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
   effectIt.effect('re-fails transport cancellation instead of returning an isError payload', () =>
     Effect.gen(function* () {
       const fiber = yield* Effect.never.pipe(Effect.catchCause(mcpToolFailureResult), Effect.forkChild);

--- a/test/unit/effect-sqlite-bun-compat.test.ts
+++ b/test/unit/effect-sqlite-bun-compat.test.ts
@@ -1,0 +1,99 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import * as SqliteClient from '@effect/sql-sqlite-bun/SqliteClient';
+import {it as effectIt} from '@effect/vitest';
+import {Database} from 'bun:sqlite';
+import {Cause, Effect, Exit, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {describe, expect} from 'vitest';
+
+describe('Effect 4 Bun SQLite transaction compatibility', () => {
+  effectIt.effect('keeps read-only transactions deferred while writable transactions reserve the writer lock', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-effect-sqlite-compat-'});
+        const databasePath = path.join(root, 'fixture.sqlite');
+        yield* Effect.sync(() => {
+          const database = new Database(databasePath, {strict: true});
+          try {
+            database.exec("CREATE TABLE entries (value TEXT NOT NULL); INSERT INTO entries VALUES ('ready');");
+          } finally {
+            database.close(false);
+          }
+        });
+
+        const readOnly = yield* Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql.unsafe('PRAGMA query_only = ON');
+          const rows = yield* sql.withTransaction(
+            Effect.all(
+              [
+                sql.unsafe<{readonly count: number}>('SELECT COUNT(*) AS count FROM entries'),
+                sql.unsafe<{readonly value: string}>('SELECT value FROM entries'),
+              ],
+              {concurrency: 1},
+            ),
+          );
+          const writeExit = yield* Effect.exit(
+            sql.withTransaction(sql.unsafe("INSERT INTO entries VALUES ('forbidden')")),
+          );
+          return {rows, writeExit};
+        }).pipe(
+          provideTestLayer(
+            SqliteClient.layer({
+              busyTimeout: 0,
+              create: false,
+              disableWAL: true,
+              filename: databasePath,
+              readonly: true,
+              readwrite: false,
+            }),
+          ),
+        );
+
+        expect(readOnly.rows).toEqual([[{count: 1}], [{value: 'ready'}]]);
+        expect(Exit.isFailure(readOnly.writeExit)).toBe(true);
+        if (Exit.isFailure(readOnly.writeExit)) {
+          expect(String(Cause.squash(readOnly.writeExit.cause))).toContain('Failed to execute statement');
+        }
+
+        const blockingWriter = yield* Effect.acquireRelease(
+          Effect.sync(() => new Database(databasePath, {create: false, strict: true})),
+          database =>
+            Effect.sync(() => {
+              try {
+                database.exec('ROLLBACK');
+              } catch {
+                // The transaction may already be absent on an assertion path.
+              }
+              database.close(false);
+            }),
+        );
+        yield* Effect.sync(() => blockingWriter.exec('PRAGMA busy_timeout = 0; BEGIN IMMEDIATE;'));
+        const writableExit = yield* Effect.exit(
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            return yield* sql.withTransaction(sql.unsafe('SELECT value FROM entries'));
+          }).pipe(
+            provideTestLayer(
+              SqliteClient.layer({
+                busyTimeout: 0,
+                create: false,
+                disableWAL: true,
+                filename: databasePath,
+                readwrite: true,
+              }),
+            ),
+          ),
+        );
+        expect(Exit.isFailure(writableExit)).toBe(true);
+        if (Exit.isFailure(writableExit)) {
+          expect(String(Cause.squash(writableExit.cause))).toContain('Failed to execute statement');
+        }
+      }),
+    ).pipe(provideTestLayer(BunServices.layer), TestClock.withLive),
+  );
+});

--- a/test/unit/manager-worksets.test.ts
+++ b/test/unit/manager-worksets.test.ts
@@ -1551,7 +1551,11 @@ describe('Manager Worksets API and human labels', () => {
           });
           expect(detail).toMatchObject({body: {job: {status: 'completed'}}, status: 200});
           expect(jobScope.state._tag).toBe('Open');
-          if (jobScope.state._tag === 'Open') expect(jobScope.state.finalizers.size).toBe(1);
+          if (jobScope.state._tag === 'Open') {
+            const finalizerCount =
+              Number(jobScope.state.finalizer !== undefined) + (jobScope.state.finalizers?.size ?? 0);
+            expect(finalizerCount).toBe(1);
+          }
         }
         const listed = yield* handleManagerWorksetRequest({
           body: Effect.succeed({}),

--- a/test/unit/mcp-code-graph-analysis-handler.test.ts
+++ b/test/unit/mcp-code-graph-analysis-handler.test.ts
@@ -265,12 +265,15 @@ function runtimeConfig(): RuntimeConfig {
 
 function mcpServerClient(): McpSchema.McpServerClient['Service'] {
   return McpSchema.McpServerClient.of({
+    clientCapabilities: {},
     clientId: 0,
+    clientInfo: {name: 'analysis-handler-test', version: '1.0.0'},
     getClient: Effect.never,
     initializePayload: {
       capabilities: {},
       clientInfo: {name: 'analysis-handler-test', version: '1.0.0'},
       protocolVersion: '2025-06-18',
     },
+    protocolVersion: '2025-06-18',
   });
 }

--- a/test/unit/remote-memory-portability-deploy.test.ts
+++ b/test/unit/remote-memory-portability-deploy.test.ts
@@ -39,8 +39,8 @@ describe('remote memory reference deployment', () => {
     expect(dockerfile).toContain('bun install --frozen-lockfile --production --ignore-scripts');
     expect(dockerfile).toContain('CMD ["bun", "src/standalone.ts", "remote-memory-service"]');
     expect(packageJson.dependencies).toMatchObject({
-      '@effect/platform-bun': '4.0.0-beta.102',
-      effect: '4.0.0-beta.102',
+      '@effect/platform-bun': '4.0.0-rc.112',
+      effect: '4.0.0-rc.112',
     });
   });
 

--- a/test/unit/resource-store.test.ts
+++ b/test/unit/resource-store.test.ts
@@ -205,18 +205,21 @@ describe('native ResourceStore', () => {
               ...fs,
               open: (filePath, options) =>
                 fs.open(filePath, options).pipe(
-                  Effect.map(opened => ({
-                    [FileSystem.FileTypeId]: FileSystem.FileTypeId,
-                    fd: opened.fd,
-                    read: buffer => opened.read(buffer),
-                    readAlloc: size => opened.readAlloc(size),
-                    seek: (offset, from) => opened.seek(offset, from),
-                    stat: opened.stat.pipe(Effect.map(withoutIdentity)),
-                    sync: opened.sync,
-                    truncate: length => opened.truncate(length),
-                    write: buffer => opened.write(buffer),
-                    writeAll: buffer => opened.writeAll(buffer),
-                  })),
+                  Effect.map(opened => {
+                    const descriptor = (opened as FileSystem.File & {readonly fd?: unknown}).fd;
+                    return {
+                      [FileSystem.FileTypeId]: FileSystem.FileTypeId,
+                      ...(typeof descriptor === 'number' ? {fd: descriptor} : {}),
+                      read: buffer => opened.read(buffer),
+                      readAlloc: size => opened.readAlloc(size),
+                      seek: (offset, from) => opened.seek(offset, from),
+                      stat: opened.stat.pipe(Effect.map(withoutIdentity)),
+                      sync: opened.sync,
+                      truncate: length => opened.truncate(length),
+                      write: buffer => opened.write(buffer),
+                      writeAll: buffer => opened.writeAll(buffer),
+                    } as FileSystem.File;
+                  }),
                 ),
               stat: filePath => fs.stat(filePath).pipe(Effect.map(withoutIdentity)),
             });


### PR DESCRIPTION
## Summary

- migrate the coordinated Effect runtime surface to exact `4.0.0-rc.112`:
  `effect`, `@effect/platform-bun`, `@effect/sql-sqlite-bun`,
  `@effect/ai-openai-compat`, `@effect/vitest`, and the
  `@effect/platform-node-shared` override
- update `@effect/tsgo` to `0.37.0` and Oxlint to the compatible `1.80.0`
  release without weakening the Effect lint preset or adding Node runtime
  adapters
- migrate the RC APIs (`Schema.TaggedError`, `Command.unlisted`) and preserve
  prior CLI behavior now that bare `Flag.boolean` is required by default
- request recursive filesystem watches explicitly, preserving nested-source
  graph refreshes after the platform backend changed its default
- negotiate every supported MCP revision explicitly, enforce each revision's
  batch/header policy, preserve non-browser Origin behavior, and add an
  explicit Origin allowlist surface
- retain Threadnote's numeric/string cancellation compatibility and make the
  revision-aware stdio serializer compose with it
- repair request-local MCP progress after RC.112 moved live tool dispatch from
  public `server.callTool` into the internal tool core; the transport context
  now carries the opaque token into registered handlers while generation
  stamping and post-cancellation tombstone filtering remain intact
- normalize structured tool projections to their actual JSON-wire shape before
  constructing RC.112 `CallToolResult` values; nested optional `undefined`
  fields no longer fail the new `Schema.Json` runtime validation
- patch RC.112's Bun SQLite transaction opener narrowly so read-only clients
  retain `BEGIN`, while writable clients retain the new `BEGIN IMMEDIATE`
  acquisition behavior
- resolve the PostCSS `nanoid@3.3.16` audit finding narrowly to `3.3.18` while
  preserving the separate runtime `nanoid@5.1.16` edge and avoiding a flat
  override

## Compatibility findings covered

- bare regular and negated booleans retain their historical omitted and
  explicit values
- nested file changes still reach the graph watcher
- MCP 2024-11-05, 2025-03-26, 2025-06-18, and 2025-11-25 initialize and apply
  their exact transport policies
- unsupported offered stdio revisions follow upstream's newest-adapter
  selection, and unrelated null-id failures are not relabeled as batch errors
- real stdio progress remains request-local under concurrent load and keeps
  ordered heartbeat/cancellation behavior
- native `obsidian_publish`, recall, and review tools pass RC.112's structured
  JSON validation; a bounded Fast-check property verifies nested optional
  projections are normalized exactly like a JSON round trip
- RC.112's automatic stdio resource-subscription claim is repaired to
  `subscribe: false`: Threadnote does not yet emit `resources/updated` across
  its mutation paths, so it no longer advertises inert subscriptions
- read-only SQLite `withTransaction` works with `query_only`, still rejects
  writes, and writable transactions still acquire immediate locks
- SQLite first-open, vector-writer, dirty linked-worktree, multiprocess,
  cross-repository catalog, and bounded writer-contention paths remain healthy
  under the RC transaction changes
- test filesystem doubles preserve Bun's runtime-only numeric file descriptor
  so descriptor-path containment remains covered despite its removal from the
  public Effect type

## Verification

- `bun install --frozen-lockfile --force` (including exact patched-dependency
  reapplication)
- `bun run lint`
- `bun run typecheck` (source, tests, and website)
- `bun run check:self-contained` (embedded model plus self-contained Bun/no-Node
  runtime contract)
- `bun audit --json` -> `{}`
- `bun audit --prod --json` -> `{}`
- built-distribution E2E for native core/full MCP toolsets, including
  `obsidian_publish`: 1/1
- MCP unit, native real-stdio, and HTTP suites: 37/37 + 41/41 + 15/15
- exact initialize-response capability transform: 4/4 selected cases
- real stdio resource-discovery capability: 1/1 selected case
- read-only/writable package patch regression: 1/1
- workset catalog/candidate/continuation SQLite matrix: 27/27
- manager catalog, cross-repository traversal/store, and removed-view cleanup:
  50/50
- vector index, vector eligibility, and store-health property coverage: 26/26
- `bun run eval:code-graph-workset -- --sizes 1,8`: coverage accuracy 1,
  authoritative false-edge rate 0, and worktree leakage 0
- package and audit ratchets: 2/2
- CLI RC behavior: 7/7 selected cases
- recursive watcher regression: 1/1
- AI compatibility mocks/layers/TestClock coverage: 23/23
- Manager Scope finalizer and telemetry layer: 2/2 selected cases
- local-provenance and resource-store containment: 49/49
- rebased production site build: pass
- independent compatibility audit: no P0/P1 findings; raw stdio batch framing
  matches both allowed and rejected revisions

Per repository policy, I did not run the complete local suite; PR CI is the
authoritative full-suite run. The nested structured-content normalization has
both a concrete E2E regression and a 100-run Fast-check invariant. The SQLite
patch has a real-file regression spanning the read-only and writable contracts.
The resource capability is a static wire-policy correction, so exact stdio and
HTTP initialization examples provide the relevant regression coverage; no
additional property input space is meaningful.

## Exact-HEAD dogfood

The initial clean migration head
`26bb08bdca20a572faa07cf901b9278ff5d68a17` was globally installed and its
superseded Threadnote releases were terminated. `threadnote --version`, ordinary
`processes --json`, negated install dry-run, and doctor dry-run all executed. A
real MCP SDK client launched the installed `threadnote mcp-server`, received
structured recall content, and observed all five ordered progress phases.

After rebuilding the derived recall indexes, doctor reported 0 failures. Its
two remaining known warnings are pending background code-graph schema migrations
and the Cursor Marketplace installation state; telemetry remains enabled.

Follow-up compatibility fixes are pushed at
`a4df7e4de3658b7a3b360f3cbbf12a6302002e40`. The final exact-HEAD global install is intentionally deferred until this rebased
PR is green, preserving shared-runtime ownership while CI validates the final
candidate.


