### PR TITLE
fix(bench): stabilize vector budget equality

### DIFF
--- a/scripts/recall-vector-performance-budget.ts
+++ b/scripts/recall-vector-performance-budget.ts
@@ -4,6 +4,9 @@ const BASE_DOCUMENT_COUNT = 10_000;
 const SEMANTIC_QUERY_MILLISECONDS_PER_BASE = 750;
 const INITIAL_BUILD_MILLISECONDS_PER_BASE = 15_000;
 const INCREMENTAL_BUILD_MILLISECONDS_PER_BASE = 3_000;
+// Equality can reach the gate through differently associated scale and ratio arithmetic. Bound only the
+// resulting four-operation roundoff envelope; any measurement-scale overrun remains a failure.
+const BUDGET_COMPARISON_ROUNDING_OPERATIONS = 4;
 
 // Shared runners can throttle both builds together. Require incremental work to remain at least 40% faster
 // while normalizing only when the same-runner initial build proves the absolute floor is not representative.
@@ -51,14 +54,30 @@ export function assessRecallVectorPerformance(
     incrementalBuildLinearMaximumMilliseconds,
     incrementalBuildMaximumMilliseconds,
     incrementalBuildSameRunnerMaximumMilliseconds,
-    incrementalBuildWithinBudget: measurement.incrementalBuildMilliseconds <= incrementalBuildMaximumMilliseconds,
+    incrementalBuildWithinBudget: withinFloatingPointBudget(
+      measurement.incrementalBuildMilliseconds,
+      incrementalBuildMaximumMilliseconds,
+    ),
     initialBuildMaximumMilliseconds,
-    initialBuildWithinBudget: measurement.initialBuildMilliseconds <= initialBuildMaximumMilliseconds,
+    initialBuildWithinBudget: withinFloatingPointBudget(
+      measurement.initialBuildMilliseconds,
+      initialBuildMaximumMilliseconds,
+    ),
     semanticQueryP95MaximumMilliseconds,
-    semanticQueryWithinBudget: measurement.semanticQueryP95Milliseconds <= semanticQueryP95MaximumMilliseconds,
+    semanticQueryWithinBudget: withinFloatingPointBudget(
+      measurement.semanticQueryP95Milliseconds,
+      semanticQueryP95MaximumMilliseconds,
+    ),
     sharedRunnerAdjustmentApplied:
       incrementalBuildSameRunnerMaximumMilliseconds > incrementalBuildLinearMaximumMilliseconds,
   };
+}
+
+function withinFloatingPointBudget(measurement: number, maximum: number): boolean {
+  if (measurement <= maximum) return true;
+  const magnitude = Math.max(Math.abs(measurement), Math.abs(maximum));
+  const roundingTolerance = magnitude * Number.EPSILON * BUDGET_COMPARISON_ROUNDING_OPERATIONS;
+  return measurement - maximum <= roundingTolerance;
 }
 
 function assertMeasurement(measurement: RecallVectorPerformanceMeasurement): void {

--- a/test/unit/recall-vector-performance-budget.test.ts
+++ b/test/unit/recall-vector-performance-budget.test.ts
@@ -6,6 +6,24 @@ import {
 } from '../../scripts/recall-vector-performance-budget.js';
 
 describe('recall vector performance budget', () => {
+  it('accepts the exact 60% boundary after a threefold common-runner slowdown', () => {
+    const initialBuildMilliseconds = 2_992;
+    const ratioBasisPoints = 6_000;
+    const slowdown = 3;
+    const ratio = ratioBasisPoints / 10_000;
+    const measurement = {
+      incrementalBuildMilliseconds: initialBuildMilliseconds * ratio * slowdown,
+      initialBuildMilliseconds: initialBuildMilliseconds * slowdown,
+      semanticQueryP95Milliseconds: 50,
+    };
+    const budget = assessRecallVectorPerformance(10_000, measurement);
+
+    expect(ratio).toBe(INCREMENTAL_BUILD_TO_INITIAL_RATIO_MAXIMUM);
+    expect(measurement.incrementalBuildMilliseconds).toBeGreaterThan(budget.incrementalBuildMaximumMilliseconds);
+    expect(budget.initialBuildWithinBudget).toBe(true);
+    expect(budget.incrementalBuildWithinBudget).toBe(true);
+  });
+
   it('normalizes the preserved failed sample against its same-runner initial build', () => {
     const budget = assessRecallVectorPerformance(10_000, {
       incrementalBuildMilliseconds: 3_899.673482,
@@ -86,6 +104,32 @@ describe('recall vector performance budget', () => {
       });
 
       expect(budget.incrementalBuildWithinBudget).toBe(false);
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+
+  it.prop(
+    'accepts reassociated equality without admitting a one-nanosecond ratio overrun',
+    {
+      initialBuildMilliseconds: FC.integer({max: 3_000, min: 2_501}),
+      slowdown: FC.integer({max: 5, min: 2}),
+    },
+    ({initialBuildMilliseconds, slowdown}) => {
+      const incrementalBuildMilliseconds =
+        initialBuildMilliseconds * INCREMENTAL_BUILD_TO_INITIAL_RATIO_MAXIMUM * slowdown;
+      const measurement = {
+        incrementalBuildMilliseconds,
+        initialBuildMilliseconds: initialBuildMilliseconds * slowdown,
+        semanticQueryP95Milliseconds: 50,
+      };
+
+      expect(assessRecallVectorPerformance(10_000, measurement).incrementalBuildWithinBudget).toBe(true);
+      expect(
+        assessRecallVectorPerformance(10_000, {
+          ...measurement,
+          incrementalBuildMilliseconds: incrementalBuildMilliseconds + 0.000_001,
+        }).incrementalBuildWithinBudget,
+      ).toBe(false);
     },
     {fastCheck: {numRuns: 200}},
   );


### PR DESCRIPTION
Summary:
- treat only a magnitude-scaled four-operation IEEE-754 roundoff envelope as budget equality
- preserve the exact 2992 ms / 6000 bp / 3x CI counterexample
- prove one-nanosecond real overruns remain rejected with bounded property coverage

Checks:
- focused recall-vector performance budget tests (7/7)
- lint
- Prettier
- source, test, and website typecheck

Full-suite validation is delegated to pull-request CI per repository policy.