### PR TITLE
fix(site): retain historical performance evidence

### DIFF
--- a/scripts/site-performance-evidence.ts
+++ b/scripts/site-performance-evidence.ts
@@ -48,6 +48,9 @@ export const measuredPerformanceSourcePathspecs = [
   ...performanceSiteOnlyGeneratorPaths.map(path => `:(exclude)${path}`),
 ] as const;
 
+const measuredPerformanceSourceTreeRoots = performanceSourcePathspecs.filter(path => path !== 'package.json');
+const measuredPerformanceSourceTreeExclusions = new Set<string>(performanceSiteOnlyGeneratorPaths);
+
 const cleanPerformanceSourcePathspecs = [
   ...performanceSourcePathspecs,
   ...performanceSiteOnlyGeneratorPaths.map(path => `:(exclude)${path}`),
@@ -161,13 +164,14 @@ export function bindRetainedPerformanceArtifact(input: {
   readonly artifactBytes: Uint8Array;
   readonly artifactPublicUrl: string;
   readonly binding: unknown;
+  // Legacy field names retained for callers; all three values describe binding.sourceThreadnoteCommit, never HEAD.
   readonly currentLockfileSha256: string;
   readonly currentPackageManifestSha256: string;
   readonly currentSourceTreeSha256: string;
 }): PerformanceEvidence {
   const binding = validatePerformanceArtifactBinding(input.binding);
   if (!sha256Pattern.test(input.currentSourceTreeSha256)) {
-    throw new ScriptError('Current performance source-tree digest is invalid.');
+    throw new ScriptError('Measured performance source-tree digest is invalid.');
   }
   const actualArtifactSha256 = sha256Hex(input.artifactBytes);
   if (actualArtifactSha256 !== binding.artifactSha256) {
@@ -176,7 +180,7 @@ export function bindRetainedPerformanceArtifact(input: {
     );
   }
   if (input.currentSourceTreeSha256 !== binding.sourceTreeSha256) {
-    throw new ScriptError('Retained performance evidence does not match the current Threadnote source tree.');
+    throw new ScriptError('Retained performance evidence does not match its measured Threadnote source tree.');
   }
 
   const payload = parseRetainedPerformanceArtifactBytes(input.artifactBytes);
@@ -210,6 +214,18 @@ function requireSuccessfulGit(result: ReturnType<typeof Bun.spawnSync>, operatio
   if (result.exitCode !== 0) {
     throw new ScriptError(
       `Could not ${operation}: ${decodeOutput(result.stderr) || `git exited with ${result.exitCode}`}.`,
+    );
+  }
+}
+
+function assertPerformanceSourceCommitAvailable(repositoryRoot: string, sourceCommit: string): void {
+  if (!sha40Pattern.test(sourceCommit)) {
+    throw new ScriptError('Retained performance source commit must be a lowercase 40-character Git commit.');
+  }
+  const commit = runGit(repositoryRoot, ['cat-file', '-e', `${sourceCommit}^{commit}`]);
+  if (commit.exitCode !== 0) {
+    throw new ScriptError(
+      `Retained performance source commit ${sourceCommit} is unavailable; use a full Git checkout for the website build.`,
     );
   }
 }
@@ -252,12 +268,7 @@ export function assertPerformancePackageManifestMatchesCommit(repositoryRoot: st
 
 export function assertPerformanceSourcesMatchCommit(repositoryRoot: string, sourceCommit: string): void {
   assertPerformanceSourceClean(repositoryRoot);
-  const commit = runGit(repositoryRoot, ['cat-file', '-e', `${sourceCommit}^{commit}`]);
-  if (commit.exitCode !== 0) {
-    throw new ScriptError(
-      `Retained performance source commit ${sourceCommit} is unavailable; use a full Git checkout for the website build.`,
-    );
-  }
+  assertPerformanceSourceCommitAvailable(repositoryRoot, sourceCommit);
   const changed = runGit(repositoryRoot, [
     'diff',
     '--quiet',
@@ -324,11 +335,28 @@ function verifyReleaseEvidenceSource(repositoryRoot: string, payload: RetainedPe
   }
 }
 
-export async function computePerformanceSourceTreeSha256(repositoryRoot: string): Promise<string> {
-  assertPerformanceSourceClean(repositoryRoot);
-  const listed = runGit(repositoryRoot, ['ls-files', '--stage', '-z', '--', ...measuredPerformanceSourcePathspecs]);
+type PerformanceSourceTreeEntry = Readonly<{
+  mode: string;
+  objectId: string;
+  path: string;
+}>;
+
+function performanceSourceTreeEntriesAtCommit(
+  repositoryRoot: string,
+  sourceCommit: string,
+): readonly PerformanceSourceTreeEntry[] {
+  assertPerformanceSourceCommitAvailable(repositoryRoot, sourceCommit);
+  const listed = runGit(repositoryRoot, [
+    'ls-tree',
+    '-r',
+    '-z',
+    '--full-tree',
+    sourceCommit,
+    '--',
+    ...measuredPerformanceSourceTreeRoots,
+  ]);
   if (listed.exitCode !== 0) {
-    throw new ScriptError(`Could not inventory performance-bound sources: ${decodeOutput(listed.stderr)}.`);
+    throw new ScriptError(`Could not inventory measured performance sources: ${decodeOutput(listed.stderr)}.`);
   }
   const entries = new TextDecoder()
     .decode(listed.stdout)
@@ -339,34 +367,84 @@ export async function computePerformanceSourceTreeSha256(repositoryRoot: string)
       if (tabIndex === -1) throw new ScriptError('Git returned an invalid performance source entry.');
       const metadata = entry.slice(0, tabIndex).split(' ');
       const mode = metadata[0];
+      const type = metadata[1];
+      const objectId = metadata[2];
       const path = entry.slice(tabIndex + 1);
-      if (!mode || !path) throw new ScriptError('Git returned an incomplete performance source entry.');
-      return {mode, path};
+      if (!mode || type !== 'blob' || !objectId || !sha40Pattern.test(objectId) || !path) {
+        throw new ScriptError('Git returned an incomplete performance source entry.');
+      }
+      return {mode, objectId, path};
     })
+    .filter(entry => !measuredPerformanceSourceTreeExclusions.has(entry.path))
     .sort((left, right) => left.path.localeCompare(right.path));
   if (entries.length === 0) throw new ScriptError('Performance source inventory is empty.');
+  return entries;
+}
+
+function hashPerformanceSourceTreeEntries(
+  repositoryRoot: string,
+  entries: readonly PerformanceSourceTreeEntry[],
+): string {
+  const batch = Bun.spawnSync({
+    cmd: ['git', 'cat-file', '--batch'],
+    cwd: repositoryRoot,
+    stdin: new TextEncoder().encode(`${entries.map(entry => entry.objectId).join('\n')}\n`),
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  requireSuccessfulGit(batch, 'read measured performance source blobs');
+  const output = batch.stdout ?? new Uint8Array();
 
   const hasher = new Bun.CryptoHasher('sha256');
+  let offset = 0;
   for (const entry of entries) {
-    const bytes = new Uint8Array(await Bun.file(`${repositoryRoot}/${entry.path}`).arrayBuffer());
-    hasher.update(`${entry.mode}\0${entry.path}\0${bytes.byteLength}\0`);
-    hasher.update(bytes);
+    const headerEnd = output.indexOf(10, offset);
+    if (headerEnd === -1) throw new ScriptError('Git returned an incomplete performance source blob header.');
+    const [objectId, type, sizeText] = new TextDecoder().decode(output.subarray(offset, headerEnd)).split(' ');
+    const size = Number(sizeText);
+    if (objectId !== entry.objectId || type !== 'blob' || !Number.isSafeInteger(size) || size < 0) {
+      throw new ScriptError('Git returned an invalid performance source blob header.');
+    }
+    const blobStart = headerEnd + 1;
+    const blobEnd = blobStart + size;
+    if (blobEnd >= output.byteLength || output[blobEnd] !== 10) {
+      throw new ScriptError('Git returned an incomplete performance source blob.');
+    }
+    hasher.update(`${entry.mode}\0${entry.path}\0${size}\0`);
+    hasher.update(output.subarray(blobStart, blobEnd));
     hasher.update('\0');
+    offset = blobEnd + 1;
   }
+  if (offset !== output.byteLength) throw new ScriptError('Git returned unexpected performance source blob data.');
   return hasher.digest('hex');
 }
 
-async function currentSourceDependencyHashes(
+export function computePerformanceSourceTreeSha256AtCommit(repositoryRoot: string, sourceCommit: string): string {
+  return hashPerformanceSourceTreeEntries(
+    repositoryRoot,
+    performanceSourceTreeEntriesAtCommit(repositoryRoot, sourceCommit),
+  );
+}
+
+export async function computePerformanceSourceTreeSha256(repositoryRoot: string): Promise<string> {
+  assertPerformanceSourceClean(repositoryRoot);
+  const head = runGit(repositoryRoot, ['rev-parse', '--verify', 'HEAD^{commit}']);
+  requireSuccessfulGit(head, 'resolve the current performance source commit');
+  return computePerformanceSourceTreeSha256AtCommit(repositoryRoot, decodeOutput(head.stdout));
+}
+
+export function performanceSourceDependencyHashesAtCommit(
   repositoryRoot: string,
   sourceCommit: string,
-): Promise<{
+): {
   readonly lockfileSha256: string;
   readonly packageManifestSha256: string;
-}> {
-  const lockfile = await Bun.file(`${repositoryRoot}/bun.lock`).arrayBuffer();
+} {
+  assertPerformanceSourceCommitAvailable(repositoryRoot, sourceCommit);
+  const lockfile = gitFileAt(repositoryRoot, sourceCommit, 'bun.lock');
   const packageManifest = gitFileAt(repositoryRoot, sourceCommit, 'package.json');
   return {
-    lockfileSha256: sha256Hex(new Uint8Array(lockfile)),
+    lockfileSha256: sha256Hex(lockfile),
     packageManifestSha256: sha256Hex(packageManifest),
   };
 }
@@ -394,11 +472,12 @@ export async function loadRetainedPerformanceEvidence(
     throw new ScriptError('Retained performance binding is not valid JSON.');
   }
   const binding = validatePerformanceArtifactBinding(bindingInput);
-  assertPerformanceSourcesMatchCommit(repositoryRoot, binding.sourceThreadnoteCommit);
-  const [artifactBuffer, currentSourceTreeSha256, dependencyHashes] = await Promise.all([
+  // This page publishes historical release evidence. Later runtime changes must not rewrite its source identity;
+  // new bindings remain strict against the current clean HEAD in writePerformanceArtifactBinding below.
+  const [artifactBuffer, measuredSourceTreeSha256, dependencyHashes] = await Promise.all([
     artifactFile.arrayBuffer(),
-    computePerformanceSourceTreeSha256(repositoryRoot),
-    currentSourceDependencyHashes(repositoryRoot, binding.sourceThreadnoteCommit),
+    computePerformanceSourceTreeSha256AtCommit(repositoryRoot, binding.sourceThreadnoteCommit),
+    performanceSourceDependencyHashesAtCommit(repositoryRoot, binding.sourceThreadnoteCommit),
   ]);
   const artifactBytes = new Uint8Array(artifactBuffer);
   verifyReleaseEvidenceSource(repositoryRoot, parseRetainedPerformanceArtifactBytes(artifactBytes));
@@ -408,7 +487,7 @@ export async function loadRetainedPerformanceEvidence(
     binding,
     currentLockfileSha256: dependencyHashes.lockfileSha256,
     currentPackageManifestSha256: dependencyHashes.packageManifestSha256,
-    currentSourceTreeSha256,
+    currentSourceTreeSha256: measuredSourceTreeSha256,
   });
 }
 
@@ -426,7 +505,7 @@ export async function writePerformanceArtifactBinding(repositoryRoot: string): P
   verifyReleaseEvidenceSource(repositoryRoot, payload);
   const [sourceTreeSha256, dependencyHashes] = await Promise.all([
     computePerformanceSourceTreeSha256(repositoryRoot),
-    currentSourceDependencyHashes(repositoryRoot, payload.environment.commit),
+    performanceSourceDependencyHashesAtCommit(repositoryRoot, payload.environment.commit),
   ]);
   const binding = validatePerformanceArtifactBinding({
     schemaVersion: 1,

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -1670,7 +1670,7 @@ Make the bottleneck observable.
         currentPackageManifestSha256: fixturePackageManifestSha256,
         currentSourceTreeSha256: '8'.repeat(64),
       }),
-    ).toThrow('does not match the current Threadnote source tree');
+    ).toThrow('does not match its measured Threadnote source tree');
   });
 
   it('rejects partial, extra, and mixed retained result payloads', () => {

--- a/test/unit/website-release-boundary.test.ts
+++ b/test/unit/website-release-boundary.test.ts
@@ -9,7 +9,11 @@ import {
   assertPerformanceSourceClean,
   assertPerformanceSourcesMatchCommit,
   canonicalPerformanceRuntimePackageManifest,
+  computePerformanceSourceTreeSha256AtCommit,
+  loadRetainedPerformanceEvidence,
   measuredPerformanceSourcePathspecs,
+  performanceSourceDependencyHashesAtCommit,
+  writePerformanceArtifactBinding,
 } from '../../scripts/site-performance-evidence.js';
 import {loadLatestMajorWebsiteReleases} from '../../scripts/site-release-notes.js';
 
@@ -296,6 +300,155 @@ describe('website and standalone release boundary', () => {
       commit('commit', '-m', 'dependency drift');
       expect(() => assertPerformanceSourcesMatchCommit(repository, sourceCommit)).toThrow(
         'package manifest changed outside site-only scripts',
+      );
+    } finally {
+      await rm(repository, {force: true, recursive: true});
+    }
+  });
+
+  it('keeps retained source identity bound to the measured commit after later runtime changes', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'threadnote-performance-history-'));
+    const git = (...arguments_: string[]) =>
+      execFileSync('git', arguments_, {cwd: repository, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']}).trim();
+    const commit = (...arguments_: string[]) =>
+      git('-c', 'user.name=Threadnote Test', '-c', 'user.email=threadnote@example.invalid', ...arguments_);
+    try {
+      await mkdir(join(repository, 'src'));
+      await writeFile(join(repository, 'bun.lock'), 'lockfileVersion = 1\n');
+      await writeFile(
+        join(repository, 'package.json'),
+        `${JSON.stringify({dependencies: {effect: '4.0.0-rc.111'}, name: 'threadnote', version: '4.3.8'})}\n`,
+      );
+      await writeFile(join(repository, 'src', 'runtime.ts'), 'export const runtime = 1;\n');
+      git('init');
+      git('add', '.');
+      commit('commit', '-m', 'measured runtime');
+      const sourceCommit = git('rev-parse', 'HEAD');
+      const measuredSourceTree = computePerformanceSourceTreeSha256AtCommit(repository, sourceCommit);
+      const measuredDependencies = performanceSourceDependencyHashesAtCommit(repository, sourceCommit);
+
+      await writeFile(join(repository, 'bun.lock'), 'lockfileVersion = 2\n');
+      await writeFile(
+        join(repository, 'package.json'),
+        `${JSON.stringify({dependencies: {effect: '4.0.0-rc.112'}, name: 'threadnote', version: '4.3.8'})}\n`,
+      );
+      await writeFile(join(repository, 'src', 'runtime.ts'), 'export const runtime = 2;\n');
+      git('add', '.');
+      commit('commit', '-m', 'later runtime');
+      const laterCommit = git('rev-parse', 'HEAD');
+
+      expect(computePerformanceSourceTreeSha256AtCommit(repository, sourceCommit)).toBe(measuredSourceTree);
+      expect(performanceSourceDependencyHashesAtCommit(repository, sourceCommit)).toEqual(measuredDependencies);
+      expect(computePerformanceSourceTreeSha256AtCommit(repository, laterCommit)).not.toBe(measuredSourceTree);
+      expect(performanceSourceDependencyHashesAtCommit(repository, laterCommit)).not.toEqual(measuredDependencies);
+      expect(() => assertPerformanceSourcesMatchCommit(repository, sourceCommit)).toThrow(
+        'runtime sources changed after the retained performance run',
+      );
+      expect(() => computePerformanceSourceTreeSha256AtCommit(repository, '0'.repeat(40))).toThrow(
+        'source commit 0000000000000000000000000000000000000000 is unavailable',
+      );
+    } finally {
+      await rm(repository, {force: true, recursive: true});
+    }
+  });
+
+  it('loads the exact historical artifact after a later runtime and dependency commit', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'threadnote-performance-load-history-'));
+    const repository = join(temporaryRoot, 'repository');
+    try {
+      const sourceHead = execFileSync('git', ['rev-parse', 'HEAD'], {cwd: root, encoding: 'utf8'}).trim();
+      execFileSync('git', ['clone', '--shared', '--no-checkout', root, repository], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const git = (...arguments_: string[]) =>
+        execFileSync('git', arguments_, {cwd: repository, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']}).trim();
+      const commit = (...arguments_: string[]) =>
+        git('-c', 'user.name=Threadnote Test', '-c', 'user.email=threadnote@example.invalid', ...arguments_);
+      git('checkout', '--detach', sourceHead);
+      const manifest = JSON.parse(await readFile(join(repository, 'package.json'), 'utf8')) as Record<string, unknown>;
+      await writeFile(join(repository, 'src', 'later-runtime.ts'), 'export const laterRuntime = true;\n');
+      await writeFile(join(repository, 'bun.lock'), 'later dependency lock\n');
+      await writeFile(
+        join(repository, 'package.json'),
+        `${JSON.stringify({...manifest, dependencies: {...(manifest.dependencies as object), effect: 'later'}})}\n`,
+      );
+      git('add', '.');
+      commit('commit', '-m', 'later runtime and dependencies');
+
+      const evidence = await loadRetainedPerformanceEvidence(repository, '/');
+      expect(evidence.state).toBe('verified');
+      if (evidence.state !== 'verified') throw new Error('Expected retained performance evidence.');
+      expect(evidence.artifact.source.threadnote).toMatchObject({
+        commit: 'f1e4102a78e4df2127fca0c4d59da39ffb5f70a6',
+        version: 'v4.3.8',
+      });
+      expect(evidence.artifact.artifact.sha256).toBe(
+        'b56994fe99c3d68be80f79315b88d4420a7241a76de72c317d2fc3d84de23b39',
+      );
+      await expect(writePerformanceArtifactBinding(repository)).rejects.toThrow(
+        'runtime sources changed after the retained performance run',
+      );
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  it('keeps measured hashes invariant across arbitrary subsequent runtime commits', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'threadnote-performance-history-property-'));
+    const git = (...arguments_: string[]) =>
+      execFileSync('git', arguments_, {cwd: repository, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']}).trim();
+    const commit = (...arguments_: string[]) =>
+      git('-c', 'user.name=Threadnote Test', '-c', 'user.email=threadnote@example.invalid', ...arguments_);
+    try {
+      await mkdir(join(repository, 'src'));
+      await writeFile(join(repository, 'bun.lock'), 'baseline lock\n');
+      await writeFile(
+        join(repository, 'package.json'),
+        `${JSON.stringify({dependencies: {effect: 'baseline'}, name: 'threadnote', version: '4.3.8'})}\n`,
+      );
+      await writeFile(join(repository, 'src', 'runtime.ts'), 'export const baseline = true;\n');
+      git('init');
+      git('add', '.');
+      commit('commit', '-m', 'measured runtime');
+      const sourceCommit = git('rev-parse', 'HEAD');
+      const measuredSourceTree = computePerformanceSourceTreeSha256AtCommit(repository, sourceCommit);
+      const measuredDependencies = performanceSourceDependencyHashesAtCommit(repository, sourceCommit);
+      let sequence = 0;
+
+      await fc.assert(
+        fc.asyncProperty(
+          fc.record({
+            dependency: fc.string({maxLength: 32}),
+            lockfile: fc.string({maxLength: 80}),
+            runtime: fc.string({maxLength: 80}),
+          }),
+          async change => {
+            sequence += 1;
+            await writeFile(join(repository, 'bun.lock'), `${change.lockfile}\nproperty-run = ${sequence}\n`);
+            await writeFile(
+              join(repository, 'package.json'),
+              `${JSON.stringify({
+                dependencies: {effect: change.dependency},
+                name: 'threadnote',
+                propertyRun: sequence,
+                version: '4.3.8',
+              })}\n`,
+            );
+            await writeFile(
+              join(repository, 'src', 'runtime.ts'),
+              `${change.runtime}\nexport const propertyRun = ${sequence};\n`,
+            );
+            git('add', '.');
+            commit('commit', '-m', `later runtime ${sequence}`);
+
+            expect(computePerformanceSourceTreeSha256AtCommit(repository, sourceCommit)).toBe(measuredSourceTree);
+            expect(performanceSourceDependencyHashesAtCommit(repository, sourceCommit)).toEqual(measuredDependencies);
+            expect(() => assertPerformanceSourcesMatchCommit(repository, sourceCommit)).toThrow(
+              'runtime sources changed after the retained performance run',
+            );
+          },
+        ),
+        {numRuns: 10},
       );
     } finally {
       await rm(repository, {force: true, recursive: true});


### PR DESCRIPTION
## Summary

- validate retained website performance evidence against the immutable measured Git commit instead of later HEAD
- hash governed source blobs plus lockfile and package manifest from that commit
- keep new binding creation strict against a clean byte-equivalent current HEAD
- cover exact v4.3.8 publication after later runtime/dependency commits and arbitrary commit drift

## Verification

- exact binder regenerated idempotently: artifact b56994fe99c3d68be80f79315b88d4420a7241a76de72c317d2fc3d84de23b39, source tree 87809e6f57aae71f1d3a69b1e921e8d3d3eee2dcaacc5be3c7832ddda65c72f9
- focused website tests: 72 passed
- bounded property: 10 runs, 1.88s test body
- repository lint and file-length checks
- source, test, and website typechecks
- Prettier check
- production site build with immutable content-addressed evidence asset