### PR TITLE
ci(telemetry): wait for post-deploy convergence

### DIFF
--- a/.github/workflows/telemetry-gateway.yml
+++ b/.github/workflows/telemetry-gateway.yml
@@ -374,48 +374,31 @@ jobs:
           checks_file="$RUNNER_TEMP/threadnote-checks-after.json"
           images_file="$RUNNER_TEMP/threadnote-images-after.json"
           expected_digest="${THREADNOTE_TELEMETRY_IMAGE##*@}"
-          deployed_inventory_ready=false
+          deployed_observations_ready=false
           for _ in $(seq 1 20); do
             if flyctl machine list --app threadnote-telemetry --json > "$machines_file" &&
               flyctl image show --app threadnote-telemetry --json > "$images_file" &&
+              flyctl checks list --app threadnote-telemetry --json > "$checks_file" &&
               go run ./cmd/budget < "$machines_file" >/dev/null 2>&1 &&
-              jq -e --arg digest "$expected_digest" '
-                type == "array" and
-                length == 2 and
-                ([.[].MachineID] | unique | length) == 2 and
-                all(.Digest == $digest)
-              ' "$images_file" >/dev/null; then
-              deployed_inventory_ready=true
+              jq -se --arg digest "$expected_digest" '
+                .[0] as $machines |
+                .[1] as $images |
+                .[2] as $checks |
+                ($machines | type == "array" and length == 2 and ([.[].id] | unique | length) == 2) and
+                ($images | type == "array" and length == 2 and ([.[].MachineID] | unique | length) == 2 and all(.Digest == $digest)) and
+                ($checks | type == "object" and length == 2) and
+                ([ $checks[] | .[] | .status ] | length == 2 and all(. == "passing")) and
+                ([ $machines[].id ] | sort) == ([ $images[].MachineID ] | sort) and
+                ([ $machines[].id ] | sort) == ($checks | keys | sort)
+              ' "$machines_file" "$images_file" "$checks_file" >/dev/null; then
+              deployed_observations_ready=true
               break
             fi
             sleep 3
           done
-          if [[ "$deployed_inventory_ready" != 'true' ]]; then
-            echo 'The deployed Machine inventory and image digest did not converge within 60 seconds.' >&2
+          if [[ "$deployed_observations_ready" != 'true' ]]; then
+            echo 'The deployed Machine inventory, image digest, and service checks did not converge within 60 seconds.' >&2
             go run ./cmd/budget < "$machines_file" || true
-            jq -e --arg digest "$expected_digest" '
-              type == "array" and
-              length == 2 and
-              ([.[].MachineID] | unique | length) == 2 and
-              all(.Digest == $digest)
-            ' "$images_file" >/dev/null || true
-            exit 1
-          fi
-
-          healthy=false
-          for _ in $(seq 1 20); do
-            flyctl checks list --app threadnote-telemetry --json > "$checks_file"
-            if jq -e '
-              [.. | objects | select(has("status")) | .status] as $statuses
-              | ($statuses | length == 2) and ($statuses | all(. == "passing"))
-            ' "$checks_file" >/dev/null; then
-              healthy=true
-              break
-            fi
-            sleep 3
-          done
-          if [[ "$healthy" != 'true' ]]; then
-            echo 'Both Fly service checks did not become healthy.' >&2
             exit 1
           fi
           curl --fail --silent --show-error --output /dev/null \

--- a/.github/workflows/telemetry-gateway.yml
+++ b/.github/workflows/telemetry-gateway.yml
@@ -2,6 +2,12 @@ name: Telemetry gateway
 
 on:
   workflow_dispatch:
+    inputs:
+      redeploy_production:
+        description: Redeploy and prove the exact selected main revision
+        required: false
+        default: false
+        type: boolean
   push:
     branches: [main]
   pull_request:
@@ -13,7 +19,7 @@ permissions:
 # A production rollout and its storage proof are one serialized operation. Pull
 # request and manual validation runs use a unique group and remain parallel.
 concurrency:
-  group: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'telemetry-production-gateway' || format('telemetry-gateway-{0}', github.run_id) }}
+  group: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.redeploy_production == true)) && 'telemetry-production-gateway' || format('telemetry-gateway-{0}', github.run_id) }}
   queue: max
   cancel-in-progress: false
 
@@ -37,6 +43,7 @@ jobs:
         shell: bash
         env:
           BEFORE_SHA: ${{ github.event.before }}
+          REDEPLOY_PRODUCTION: ${{ inputs.redeploy_production }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -47,6 +54,10 @@ jobs:
 
           if [[ "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ]]; then
             validate=true
+            if [[ "$REDEPLOY_PRODUCTION" == 'true' ]]; then
+              deploy=true
+              supersede=true
+            fi
           else
             if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
               base_sha="$PR_BASE_SHA"
@@ -165,7 +176,7 @@ jobs:
     name: Deploy immutable production image
     needs: [classify, validate, validate-fly]
     if: >-
-      github.event_name == 'push' &&
+      github.event_name != 'pull_request' &&
       github.ref == 'refs/heads/main' &&
       needs.classify.outputs.deploy == 'true' &&
       needs.validate.result == 'success' &&
@@ -485,6 +496,7 @@ jobs:
           DEPLOY_RESULT: ${{ needs.deploy.result }}
           DEPLOYED: ${{ needs.deploy.outputs.deployed }}
           CANARY_RESULT: ${{ needs.storage-canary.result }}
+          REDEPLOY_PRODUCTION: ${{ inputs.redeploy_production }}
         run: |
           set -euo pipefail
           [[ "$CLASSIFY_RESULT" == 'success' ]]
@@ -501,7 +513,9 @@ jobs:
             [[ "$FLY_VALIDATE_RESULT" == 'skipped' ]]
           fi
 
-          if [[ "$GITHUB_EVENT_NAME" == 'push' && "$GITHUB_REF" == 'refs/heads/main' && "$DEPLOY_REQUIRED" == 'true' ]]; then
+          if [[ "$GITHUB_REF" == 'refs/heads/main' && "$DEPLOY_REQUIRED" == 'true' &&
+            ( "$GITHUB_EVENT_NAME" == 'push' ||
+              ( "$GITHUB_EVENT_NAME" == 'workflow_dispatch' && "$REDEPLOY_PRODUCTION" == 'true' ) ) ]]; then
             [[ "$DEPLOY_RESULT" == 'success' ]]
             if [[ "$DEPLOYED" == 'true' ]]; then
               [[ "$CANARY_RESULT" == 'success' ]]

--- a/.github/workflows/telemetry-gateway.yml
+++ b/.github/workflows/telemetry-gateway.yml
@@ -373,16 +373,34 @@ jobs:
           machines_file="$RUNNER_TEMP/threadnote-machines-after.json"
           checks_file="$RUNNER_TEMP/threadnote-checks-after.json"
           images_file="$RUNNER_TEMP/threadnote-images-after.json"
-          flyctl machine list --app threadnote-telemetry --json > "$machines_file"
-          go run ./cmd/budget < "$machines_file"
-          flyctl image show --app threadnote-telemetry --json > "$images_file"
           expected_digest="${THREADNOTE_TELEMETRY_IMAGE##*@}"
-          jq -e --arg digest "$expected_digest" '
-            type == "array" and
-            length == 2 and
-            ([.[].MachineID] | unique | length) == 2 and
-            all(.Digest == $digest)
-          ' "$images_file" >/dev/null
+          deployed_inventory_ready=false
+          for _ in $(seq 1 20); do
+            if flyctl machine list --app threadnote-telemetry --json > "$machines_file" &&
+              flyctl image show --app threadnote-telemetry --json > "$images_file" &&
+              go run ./cmd/budget < "$machines_file" >/dev/null 2>&1 &&
+              jq -e --arg digest "$expected_digest" '
+                type == "array" and
+                length == 2 and
+                ([.[].MachineID] | unique | length) == 2 and
+                all(.Digest == $digest)
+              ' "$images_file" >/dev/null; then
+              deployed_inventory_ready=true
+              break
+            fi
+            sleep 3
+          done
+          if [[ "$deployed_inventory_ready" != 'true' ]]; then
+            echo 'The deployed Machine inventory and image digest did not converge within 60 seconds.' >&2
+            go run ./cmd/budget < "$machines_file" || true
+            jq -e --arg digest "$expected_digest" '
+              type == "array" and
+              length == 2 and
+              ([.[].MachineID] | unique | length) == 2 and
+              all(.Digest == $digest)
+            ' "$images_file" >/dev/null || true
+            exit 1
+          fi
 
           healthy=false
           for _ in $(seq 1 20); do

--- a/docs/operations/telemetry-production.md
+++ b/docs/operations/telemetry-production.md
@@ -255,6 +255,12 @@ Collector configuration, gateway runtime (including its shared internal budget
 constants), dependencies, or admitted schemas change. Dashboard,
 documentation, test-only, standalone budget-verifier command, storage-canary,
 and workflow-only changes are validated but cannot start a production rollout.
+When a workflow-only rollout-gate fix itself must be proven, dispatch
+`telemetry-gateway.yml` from the exact `main` revision with
+`redeploy_production=true`. That explicit run uses the protected production
+environment, redeploys an immutable image for the selected revision, and must
+pass the same post-deploy convergence and storage-canary gates; the default
+manual dispatch remains validation-only.
 
 The production job first rejects a superseded revision when newer `main` commits
 change a production input. Later workflow, classifier, documentation, or

--- a/infra/telemetry-gateway/scripts/classify-changes.sh
+++ b/infra/telemetry-gateway/scripts/classify-changes.sh
@@ -19,7 +19,6 @@ while IFS= read -r -d '' path; do
 
   case "$path" in
     .dockerignore | fly.toml | \
-      .github/workflows/telemetry-gateway.yml | \
       infra/telemetry-gateway/Dockerfile | \
       infra/telemetry-gateway/collector.yaml | \
       infra/telemetry-gateway/go.mod | \

--- a/infra/telemetry-gateway/scripts/classify-changes.sh
+++ b/infra/telemetry-gateway/scripts/classify-changes.sh
@@ -19,6 +19,7 @@ while IFS= read -r -d '' path; do
 
   case "$path" in
     .dockerignore | fly.toml | \
+      .github/workflows/telemetry-gateway.yml | \
       infra/telemetry-gateway/Dockerfile | \
       infra/telemetry-gateway/collector.yaml | \
       infra/telemetry-gateway/go.mod | \

--- a/infra/telemetry-gateway/scripts/classify-changes.test.sh
+++ b/infra/telemetry-gateway/scripts/classify-changes.test.sh
@@ -28,6 +28,7 @@ assert_classification "$production" infra/telemetry-gateway/telemetry-schema-v3.
 assert_classification "$production" infra/telemetry-gateway/telemetry-schema-v4.json
 assert_classification "$production" infra/telemetry-gateway/telemetry-schema-v5.json
 assert_classification "$production" .dockerignore
+assert_classification "$production" .github/workflows/telemetry-gateway.yml
 assert_classification "$production" docs/telemetry.md infra/telemetry-gateway/schema.go
 # `git diff --no-renames` presents a move as the old deletion plus new addition;
 # the removed runtime path must keep the pair deployable.
@@ -38,7 +39,6 @@ assert_classification "$validation_only" infra/telemetry-gateway/internal/budget
 assert_classification "$validation_only" infra/telemetry-gateway/cmd/canary/main.go
 assert_classification "$validation_only" infra/telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json
 assert_classification "$validation_only" docs/operations/telemetry-production.md
-assert_classification "$validation_only" .github/workflows/telemetry-gateway.yml
 assert_classification "$validation_only" infra/telemetry-gateway/scripts/classify-changes.sh
 
 assert_classification "$irrelevant" README.md src/code_graph/indexer.ts

--- a/infra/telemetry-gateway/scripts/classify-changes.test.sh
+++ b/infra/telemetry-gateway/scripts/classify-changes.test.sh
@@ -28,7 +28,6 @@ assert_classification "$production" infra/telemetry-gateway/telemetry-schema-v3.
 assert_classification "$production" infra/telemetry-gateway/telemetry-schema-v4.json
 assert_classification "$production" infra/telemetry-gateway/telemetry-schema-v5.json
 assert_classification "$production" .dockerignore
-assert_classification "$production" .github/workflows/telemetry-gateway.yml
 assert_classification "$production" docs/telemetry.md infra/telemetry-gateway/schema.go
 # `git diff --no-renames` presents a move as the old deletion plus new addition;
 # the removed runtime path must keep the pair deployable.
@@ -38,6 +37,7 @@ assert_classification "$validation_only" infra/telemetry-gateway/gateway_test.go
 assert_classification "$validation_only" infra/telemetry-gateway/internal/budget/budget_test.go
 assert_classification "$validation_only" infra/telemetry-gateway/cmd/canary/main.go
 assert_classification "$validation_only" infra/telemetry-gateway/threadnote-anonymous-telemetry-dashboard.json
+assert_classification "$validation_only" .github/workflows/telemetry-gateway.yml
 assert_classification "$validation_only" docs/operations/telemetry-production.md
 assert_classification "$validation_only" infra/telemetry-gateway/scripts/classify-changes.sh
 


### PR DESCRIPTION
## Summary

- retry the post-deploy Fly Machine inventory and immutable-image observations for up to 60 seconds
- require both the two-started-Machine budget and reviewed digest to converge before health checks
- retain a terminal aggregate diagnostic without exposing Machine inventory details

## Evidence

The 4.4 release-candidate rollout completed its canary update with both Machines reported healthy, but the first inventory observation immediately after `flyctl deploy` returned a transient non-started state. The existing delivery canary already treats Machine inventory as eventually consistent; this brings the deploy gate in line while remaining bounded and fail-closed.

## Checks

- repository pre-commit lint and typecheck hooks
- Prettier check for `.github/workflows/telemetry-gateway.yml`
- Actionlint 1.7.12 using the CI-pinned digest
- `git diff --check`

No property test was added because this is static workflow orchestration with no independent application input model; the bounded convergence behavior is exercised by the protected production workflow and CI remains authoritative for the full suite.