### PR TITLE
fix(telemetry): classify graph view target refusals

### DIFF
--- a/src/code_graph/view_removal.ts
+++ b/src/code_graph/view_removal.ts
@@ -1,4 +1,5 @@
 import {Effect, FileSystem, Option, Path, PlatformError} from 'effect';
+import {attachAnonymousTelemetryDiagnostic, attachAnonymousTelemetryReportedOutcome} from '../telemetry/diagnostic.js';
 import {
   captureCodeGraphLocalProvenanceCleanupEvidence,
   cleanupMissingCodeGraphLocalProvenance,
@@ -291,12 +292,23 @@ export function renderCodeGraphViewRemovalResult(result: CodeGraphViewRemovalAct
 
 export function codeGraphViewRemovalTargetFailure(result: CodeGraphViewRemovalActionResult): Error | undefined {
   if (result.state === 'stale-target') {
-    return new CodeGraphViewRemovalError('The selected code graph view changed; refresh the view inventory and retry.');
+    return codeGraphViewRemovalTargetError(
+      'The selected code graph view changed; refresh the view inventory and retry.',
+    );
   }
   if (result.state === 'not-found') {
-    return new CodeGraphViewRemovalError('The selected code graph view does not exist; refresh the view inventory.');
+    return codeGraphViewRemovalTargetError('The selected code graph view does not exist; refresh the view inventory.');
   }
   return undefined;
+}
+
+function codeGraphViewRemovalTargetError(message: string): CodeGraphViewRemovalError {
+  return attachAnonymousTelemetryReportedOutcome(
+    attachAnonymousTelemetryDiagnostic(new CodeGraphViewRemovalError(message), {
+      errorType: 'CodeGraphViewRemovalError',
+    }),
+    'unavailable',
+  );
 }
 
 function actionResult(

--- a/src/effect/telemetry.ts
+++ b/src/effect/telemetry.ts
@@ -11,6 +11,7 @@ import {
   closedTelemetryErrorType,
   projectAnonymousTelemetryDiagnostic,
   readAnonymousTelemetryDiagnostic,
+  readAnonymousTelemetryReportedOutcome,
   type AnonymousTelemetryReportedOutcome,
   type AnonymousTelemetryDiagnostic,
 } from '../telemetry/diagnostic.js';
@@ -797,10 +798,11 @@ function unsafeCompletionClassification<A, E>(
   const diagnostic = projectAnonymousTelemetryDiagnostic(
     readAnonymousTelemetryDiagnostic(error) ?? anonymousTelemetryDiagnosticFromError(error),
   );
+  const reportedOutcome = readAnonymousTelemetryReportedOutcome(error);
   return {
     ...(diagnostic === undefined ? {} : {diagnostic}),
     errorType: diagnostic?.errorType ?? 'UnknownError',
-    outcome: 'failure',
+    outcome: reportedOutcome ?? 'failure',
   };
 }
 

--- a/test/unit/code-graph.view-removal-command.test.ts
+++ b/test/unit/code-graph.view-removal-command.test.ts
@@ -24,6 +24,11 @@ import {withExclusiveFileLock} from '../../src/effect/file_lock.js';
 import {CommandExecutor} from '../../src/effect/command.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import {withCodeGraphTargetWorktreeLock} from '../../src/code_graph/maintenance_gate.js';
+import {
+  anonymousTelemetryDiagnosticFromError,
+  readAnonymousTelemetryDiagnostic,
+  readAnonymousTelemetryReportedOutcome,
+} from '../../src/telemetry/diagnostic.js';
 
 const CHECKOUT_ID = 'a'.repeat(64);
 const WORKTREE_ID = '1'.repeat(64);
@@ -43,6 +48,7 @@ describe('code graph remove-view command core', () => {
 
           const preview = yield* removeCodeGraphView(fixture.home, target);
           const stale = yield* removeCodeGraphView(fixture.home, {...target, snapshotId: `cgsn_${'d'.repeat(40)}`});
+          const notFound = yield* removeCodeGraphView(fixture.home, {...target, worktreeId: '2'.repeat(64)});
           expect(preview).toMatchObject({applied: false, cleanup: {provenance: null, vectors: null}, state: 'ready'});
           expect(activeView(fixture.databasePath)).toBe(SNAPSHOT_ID);
           expect(removedView(fixture.databasePath)).toBeUndefined();
@@ -52,7 +58,16 @@ describe('code graph remove-view command core', () => {
             observedState: 'active',
             state: 'stale-target',
           });
-          expect(codeGraphViewRemovalTargetFailure(stale)?.message).toMatch(/changed/);
+          expect(notFound).toMatchObject({applied: false, state: 'not-found'});
+          for (const result of [stale, notFound]) {
+            const failure = codeGraphViewRemovalTargetFailure(result);
+            expect(failure?.message).toMatch(result.state === 'stale-target' ? /changed/ : /does not exist/);
+            expect(anonymousTelemetryDiagnosticFromError(failure)).toEqual({
+              errorType: 'CodeGraphViewRemovalError',
+            });
+            expect(readAnonymousTelemetryDiagnostic(failure)).toEqual({errorType: 'CodeGraphViewRemovalError'});
+            expect(readAnonymousTelemetryReportedOutcome(failure)).toBe('unavailable');
+          }
 
           const first = yield* removeCodeGraphView(fixture.home, target, {apply: true});
           const retry = yield* removeCodeGraphView(fixture.home, target, {apply: true});

--- a/test/unit/telemetry-runtime.test.ts
+++ b/test/unit/telemetry-runtime.test.ts
@@ -243,6 +243,29 @@ describe('anonymous telemetry runtime', () => {
     }).pipe(provideTestLayer(anonymousTelemetryTestLayer({system: systemInfoStub(), tracer: capture.tracer})));
   });
 
+  effectIt.effect('preserves closed reported outcomes attached to failed carriers', () => {
+    const capture = capturingTracer();
+    const cases = ['timed-out', 'unavailable', 'failure'] as const;
+
+    return Effect.gen(function* () {
+      for (const outcome of cases) {
+        const error = attachAnonymousTelemetryReportedOutcome(
+          new TestError('private target detail at /Users/private/repository'),
+          outcome,
+        );
+        const exit = yield* Effect.exit(
+          withAnonymousTelemetry({component: 'cli', operation: 'graph.remove-view'}, Effect.fail(error)),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBe(error);
+      }
+
+      expect(capture.spans.map(span => spanAttributes(span)['threadnote.outcome'])).toEqual(cases);
+      expect(capture.spans.map(span => spanAttributes(span)['error.type'])).toEqual(cases.map(() => 'UnknownError'));
+      expect(JSON.stringify(capture.spans.map(spanAttributes))).not.toContain('private');
+    }).pipe(provideTestLayer(anonymousTelemetryTestLayer({system: systemInfoStub(), tracer: capture.tracer})));
+  });
+
   effectIt.effect('buckets start/end memory and never exports exact byte counts', () => {
     const capture = capturingTracer();
     const mebibytes = 1_024 * 1_024;


### PR DESCRIPTION
## Summary

- retain the existing nonzero `graph remove-view` contract for stale and missing targets
- carry those expected target refusals through anonymous telemetry as the closed `unavailable` outcome with the existing `CodeGraphViewRemovalError` type
- keep genuine removal and cleanup faults classified as `failure`, without adding fields or changing immutable telemetry schema v5
- preserve the exact application error and Effect exit while honoring closed outcome metadata on failed carriers

This is a non-blocking dogfood follow-up from weekly telemetry triage. It does not alter graph cleanup behavior or the 4.4 release work.

## Verification

- `bun --bun vitest run test/unit/telemetry-runtime.test.ts test/unit/code-graph.view-removal-command.test.ts` (27 passed)
- `bun --bun vitest run test/unit/telemetry-diagnostic.test.ts` (10 passed)
- focused CLI integration for preview, stale target, missing target, apply, and retry (1 passed; 30 skipped by selector)
- source and test TypeScript checks
- strict oxlint for the four changed files
- commit hook lint, Prettier, source/test/site typechecks
- source-level CLI telemetry smoke: missing target remained exit 1 and emitted `graph.remove-view` + `CodeGraphViewRemovalError` + `unavailable`

Property testing was assessed. The changed classification has a closed three-value outcome carrier and a finite five-state removal result; focused table/loop examples state the contract more directly than a generated property.

## Runtime note

The shared global Threadnote runtime was not reinstalled or taken over because the active 4.4 release work owns it. CI should run the complete suite.