### PR TITLE
fix(code-graph): resolve exact impact selectors

### DIFF
--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -43,6 +43,13 @@ import {
 } from './query_contract.js';
 import {codeGraphSnapshotRuntimeCurrent} from './query_snapshot_runtime.js';
 import {
+  codeGraphEndpointMatches,
+  exactCodeGraphImpactSelectorMatches,
+  isStableCodeGraphNodeId,
+  parseCodeGraphEndpointSelector,
+  selectCodeGraphEndpoint,
+} from './query_selector.js';
+import {
   codeGraphLanguagePackStatuses,
   repositoryIdentityObservation,
   resolvePublishedRepositoryIdentityObservation,
@@ -740,27 +747,44 @@ export const traversalQuery = Effect.fn('codeGraph.traversalQuery')(function* (
   );
   let deadline = (yield* Clock.currentTimeMillis) + traversalTimeBudgetMilliseconds;
   const requestedSeedQueries = (seedQueries?.length ? seedQueries : [query]).slice(0, MAX_IMPACT_SEED_QUERIES);
+  const impactSelector = impact && !seedQueries?.length ? parseCodeGraphEndpointSelector(query) : undefined;
+  const structuredImpactSelector =
+    impactSelector !== undefined &&
+    (impactSelector.path !== undefined || isStableCodeGraphNodeId(impactSelector.symbol));
   const seedLimit = impact ? MAX_IMPACT_SEED_SYMBOLS : Math.min(nodeLimit, 12);
   const perSeedLimit = impact
     ? Math.max(1, Math.min(20, Math.ceil(MAX_IMPACT_SEED_SYMBOLS / requestedSeedQueries.length)))
     : Math.max(1, seedLimit);
   const normalizedPackageName = packageName?.trim().toLocaleLowerCase('en-US');
   const lexicalCandidateLimit = normalizedPackageName ? Math.min(500, Math.max(200, perSeedLimit * 20)) : perSeedLimit;
-  const lexicalCandidateGroups =
-    impact && seedQueries?.length
-      ? yield* store.searchSymbolsByPaths(databasePath, snapshotId, requestedSeedQueries, lexicalCandidateLimit)
-      : yield* store.searchSymbolsMany(databasePath, snapshotId, requestedSeedQueries, lexicalCandidateLimit);
+  const lexicalCandidateGroups = impactSelector?.path
+    ? [yield* store.findSymbolsByPathAndName(databasePath, snapshotId, impactSelector.path, impactSelector.symbol)]
+    : impactSelector && isStableCodeGraphNodeId(impactSelector.symbol)
+      ? [
+          (yield* store.symbolsByIds(databasePath, snapshotId, [impactSelector.symbol])).map(node => ({
+            ...node,
+            score: 1,
+          })),
+        ]
+      : impact && seedQueries?.length
+        ? yield* store.searchSymbolsByPaths(databasePath, snapshotId, requestedSeedQueries, lexicalCandidateLimit)
+        : yield* store.searchSymbolsMany(databasePath, snapshotId, requestedSeedQueries, lexicalCandidateLimit);
   // The elapsed budget governs graph traversal, not an already-completed
   // lexical seed lookup that SQLite cannot interrupt. Impact keeps one
   // absolute budget across path recovery and traversal; ordinary queries get
   // the same complete traversal window regardless of snapshot representation.
   if (!impact) deadline = (yield* Clock.currentTimeMillis) + traversalTimeBudgetMilliseconds;
-  const lexicalGroups = lexicalCandidateGroups.map(group =>
-    (normalizedPackageName
+  const exactImpactSelectorGroups = impactSelector
+    ? lexicalCandidateGroups.map(group => exactCodeGraphImpactSelectorMatches(impactSelector, group))
+    : [];
+  const impactSelectorResolvedExactly = exactImpactSelectorGroups.some(group => group.length > 0);
+  const lexicalGroups = lexicalCandidateGroups.map(group => {
+    const packageMatches = normalizedPackageName
       ? group.filter(node => node.packageName?.toLocaleLowerCase('en-US') === normalizedPackageName)
-      : group
-    ).slice(0, perSeedLimit),
-  );
+      : group;
+    const exactMatches = impactSelector ? exactCodeGraphImpactSelectorMatches(impactSelector, packageMatches) : [];
+    return (impactSelectorResolvedExactly ? exactMatches : packageMatches).slice(0, perSeedLimit);
+  });
   const lexicalCandidatesExamined = lexicalCandidateGroups.reduce((total, group) => total + group.length, 0);
   const lexicalPackageMatches = lexicalGroups.reduce((total, group) => total + group.length, 0);
   let timedOut = yield* deadlineReached(deadline);
@@ -795,7 +819,12 @@ export const traversalQuery = Effect.fn('codeGraph.traversalQuery')(function* (
     : [...lexicalById.values()]
         .sort((left, right) => right.score - left.score || compareCodeUnits(left.id, right.id))
         .slice(0, seedLimit);
-  const semanticEligible = !timedOut && !(impact && seedQueries?.length) && lexicalSeeds.length < seedLimit;
+  const semanticEligible =
+    !timedOut &&
+    !(impact && seedQueries?.length) &&
+    !structuredImpactSelector &&
+    !impactSelectorResolvedExactly &&
+    lexicalSeeds.length < seedLimit;
   const semanticResult = !semanticEligible
     ? {scores: new Map<string, number>(), timedOut: false}
     : yield* embedding.search(threadnoteHome, layout, snapshotId, query, Math.min(nodeLimit, 12)).pipe(
@@ -920,8 +949,10 @@ export const traversalQuery = Effect.fn('codeGraph.traversalQuery')(function* (
       `Impact analysis evaluated ${MAX_IMPACT_SEED_QUERIES} of ${seedQueries.length} changed paths; results are partial.`,
     );
   }
-  if (impact && unresolvedSeedQueries > 0) {
+  if (impact && seedQueries?.length && unresolvedSeedQueries > 0) {
     warnings.push(`${unresolvedSeedQueries} changed path(s) did not resolve to indexed code symbols.`);
+  } else if (impact && !seedQueries?.length && seeds.length === 0) {
+    warnings.push('Impact selector did not resolve to indexed code symbols.');
   }
   if (recovered.recoveredPaths > 0) {
     warnings.push(
@@ -1581,13 +1612,13 @@ const pathQuery = Effect.fn('codeGraph.pathQuery')(function* (
   allowedProvenances: readonly CodeGraphProvenance[],
 ) {
   const deadline = (yield* Clock.currentTimeMillis) + QUERY_TRAVERSAL_TIME_BUDGET_MILLISECONDS;
-  const fromSelector = parseEndpointSelector(from);
-  const toSelector = parseEndpointSelector(to);
-  const fromMatches = yield* endpointMatches(store, databasePath, snapshotId, fromSelector);
+  const fromSelector = parseCodeGraphEndpointSelector(from);
+  const toSelector = parseCodeGraphEndpointSelector(to);
+  const fromMatches = yield* codeGraphEndpointMatches(store, databasePath, snapshotId, fromSelector);
   if (yield* deadlineReached(deadline)) {
     return {edges: [], nodes: [], warnings: ['Path search reached its elapsed-time budget; results are partial.']};
   }
-  const toMatches = yield* endpointMatches(store, databasePath, snapshotId, toSelector);
+  const toMatches = yield* codeGraphEndpointMatches(store, databasePath, snapshotId, toSelector);
   if (yield* deadlineReached(deadline)) {
     return {
       edges: [],
@@ -1595,8 +1626,8 @@ const pathQuery = Effect.fn('codeGraph.pathQuery')(function* (
       warnings: ['Path search reached its elapsed-time budget; results are partial.'],
     };
   }
-  const startSelection = selectEndpoint(fromMatches, fromSelector);
-  const targetSelection = selectEndpoint(toMatches, toSelector);
+  const startSelection = selectCodeGraphEndpoint(fromMatches, fromSelector);
+  const targetSelection = selectCodeGraphEndpoint(toMatches, toSelector);
   const start = startSelection.node;
   const target = targetSelection.node;
   const selectorWarnings = [...startSelection.warnings, ...targetSelection.warnings];
@@ -1695,76 +1726,6 @@ const pathQuery = Effect.fn('codeGraph.pathQuery')(function* (
     warnings: [],
   };
 });
-
-interface EndpointSelector {
-  readonly original: string;
-  readonly path?: string;
-  readonly symbol: string;
-}
-
-function endpointMatches(
-  store: CodeGraphStoreShape,
-  databasePath: string,
-  snapshotId: string,
-  selector: EndpointSelector,
-): Effect.Effect<readonly CodeGraphQueryNode[], unknown> {
-  if (!selector.path && isStableCodeGraphNodeId(selector.symbol)) {
-    return store
-      .symbolsByIds(databasePath, snapshotId, [selector.symbol])
-      .pipe(Effect.map(symbols => symbols.map(symbol => ({...symbol, score: 1}))));
-  }
-  return selector.path
-    ? store.findSymbolsByPathAndName(databasePath, snapshotId, selector.path, selector.symbol)
-    : store.searchSymbols(databasePath, snapshotId, selector.symbol, 20);
-}
-
-function isStableCodeGraphNodeId(value: string): boolean {
-  return /^cgs_[a-f0-9]{32,64}$/u.test(value);
-}
-
-function parseEndpointSelector(value: string): EndpointSelector {
-  const separator = value.lastIndexOf('#');
-  if (separator <= 0 || separator >= value.length - 1) {
-    return {original: value, symbol: value};
-  }
-  return {
-    original: value,
-    path: value
-      .slice(0, separator)
-      .replaceAll('\\', '/')
-      .replace(/^\.\/+/, ''),
-    symbol: value.slice(separator + 1),
-  };
-}
-
-function selectEndpoint(
-  matches: readonly CodeGraphQueryNode[],
-  selector: EndpointSelector,
-): {readonly node?: CodeGraphQueryNode; readonly warnings: readonly string[]} {
-  const normalizedSymbol = selector.symbol.toLocaleLowerCase('en-US');
-  const candidates = matches.filter(node => {
-    if (selector.path && node.path.replaceAll('\\', '/') !== selector.path) return false;
-    return (
-      node.name.toLocaleLowerCase('en-US') === normalizedSymbol ||
-      node.qualifiedName.toLocaleLowerCase('en-US') === normalizedSymbol
-    );
-  });
-  if (candidates.length === 1) return {node: candidates[0], warnings: []};
-  if (candidates.length === 0 && matches.length === 1 && !selector.path) {
-    return {node: matches[0], warnings: []};
-  }
-  const visible = (candidates.length > 0 ? candidates : matches)
-    .slice(0, 5)
-    .map(node => `${node.path}#${node.qualifiedName}`)
-    .join(', ');
-  return {
-    warnings: [
-      visible.length > 0
-        ? `Path endpoint "${selector.original}" is ambiguous; use path#symbol. Candidates: ${visible}.`
-        : `Path endpoint "${selector.original}" was not found.`,
-    ],
-  };
-}
 
 export type CodeGraphRenderTarget = 'mcp' | 'standalone';
 

--- a/src/code_graph/query_selector.ts
+++ b/src/code_graph/query_selector.ts
@@ -1,0 +1,94 @@
+import {Effect} from 'effect';
+import {type CodeGraphStoreShape} from './store.js';
+import {type CodeGraphQueryNode} from './types.js';
+
+export interface CodeGraphEndpointSelector {
+  readonly original: string;
+  readonly path?: string;
+  readonly symbol: string;
+}
+
+export function codeGraphEndpointMatches(
+  store: CodeGraphStoreShape,
+  databasePath: string,
+  snapshotId: string,
+  selector: CodeGraphEndpointSelector,
+): Effect.Effect<readonly CodeGraphQueryNode[], unknown> {
+  if (!selector.path && isStableCodeGraphNodeId(selector.symbol)) {
+    return store
+      .symbolsByIds(databasePath, snapshotId, [selector.symbol])
+      .pipe(Effect.map(symbols => symbols.map(symbol => ({...symbol, score: 1}))));
+  }
+  return selector.path
+    ? store.findSymbolsByPathAndName(databasePath, snapshotId, selector.path, selector.symbol)
+    : store.searchSymbols(databasePath, snapshotId, selector.symbol, 20);
+}
+
+export function isStableCodeGraphNodeId(value: string): boolean {
+  return /^cgs_[a-f0-9]{32,64}$/u.test(value);
+}
+
+export function parseCodeGraphEndpointSelector(value: string): CodeGraphEndpointSelector {
+  const separator = value.lastIndexOf('#');
+  if (separator <= 0 || separator >= value.length - 1) {
+    return {original: value, symbol: value};
+  }
+  return {
+    original: value,
+    path: value
+      .slice(0, separator)
+      .replaceAll('\\', '/')
+      .replace(/^\.\/+/, ''),
+    symbol: value.slice(separator + 1),
+  };
+}
+
+export function exactCodeGraphImpactSelectorMatches(
+  selector: CodeGraphEndpointSelector,
+  matches: readonly CodeGraphQueryNode[],
+): readonly CodeGraphQueryNode[] {
+  if (!selector.path && isStableCodeGraphNodeId(selector.symbol)) return matches;
+  const normalizedSymbol = selector.symbol.toLocaleLowerCase('en-US');
+  const normalizedPath = (selector.path ?? selector.symbol)
+    .replaceAll('\\', '/')
+    .replace(/^\.\/+/, '')
+    .toLocaleLowerCase('en-US');
+  return matches.filter(node => {
+    const nodePath = node.path.replaceAll('\\', '/').toLocaleLowerCase('en-US');
+    if (selector.path && nodePath !== normalizedPath) return false;
+    return (
+      node.name.toLocaleLowerCase('en-US') === normalizedSymbol ||
+      node.qualifiedName.toLocaleLowerCase('en-US') === normalizedSymbol ||
+      (!selector.path && nodePath === normalizedPath)
+    );
+  });
+}
+
+export function selectCodeGraphEndpoint(
+  matches: readonly CodeGraphQueryNode[],
+  selector: CodeGraphEndpointSelector,
+): {readonly node?: CodeGraphQueryNode; readonly warnings: readonly string[]} {
+  const normalizedSymbol = selector.symbol.toLocaleLowerCase('en-US');
+  const candidates = matches.filter(node => {
+    if (selector.path && node.path.replaceAll('\\', '/') !== selector.path) return false;
+    return (
+      node.name.toLocaleLowerCase('en-US') === normalizedSymbol ||
+      node.qualifiedName.toLocaleLowerCase('en-US') === normalizedSymbol
+    );
+  });
+  if (candidates.length === 1) return {node: candidates[0], warnings: []};
+  if (candidates.length === 0 && matches.length === 1 && !selector.path) {
+    return {node: matches[0], warnings: []};
+  }
+  const visible = (candidates.length > 0 ? candidates : matches)
+    .slice(0, 5)
+    .map(node => `${node.path}#${node.qualifiedName}`)
+    .join(', ');
+  return {
+    warnings: [
+      visible.length > 0
+        ? `Path endpoint "${selector.original}" is ambiguous; use path#symbol. Candidates: ${visible}.`
+        : `Path endpoint "${selector.original}" was not found.`,
+    ],
+  };
+}

--- a/test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
+++ b/test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
@@ -1144,14 +1144,14 @@
     "mcp-impact-returned-edges": {
       "samplesMinimum": 1,
       "unit": "count",
-      "maximum": 0,
-      "minimum": 0
+      "maximum": 1,
+      "minimum": 1
     },
     "mcp-impact-returned-nodes": {
       "samplesMinimum": 1,
       "unit": "count",
-      "maximum": 0,
-      "minimum": 0
+      "maximum": 2,
+      "minimum": 2
     },
     "mcp-impact-structured-output": {
       "samplesMinimum": 1,

--- a/test/unit/code-graph.property.test.ts
+++ b/test/unit/code-graph.property.test.ts
@@ -306,6 +306,64 @@ function inventoryPolicyPath(
 
 describe('native code graph traversal properties', () => {
   it.effect.prop(
+    'keeps exact impact selectors independent of fuzzy candidate order and score',
+    {
+      lowercaseQuery: FC.boolean(),
+      noiseScores: FC.array(FC.integer({max: 100, min: 1}), {maxLength: 20}),
+      position: FC.integer({max: 100, min: 0}),
+    },
+    ({lowercaseQuery, noiseScores, position}) => {
+      const exact = {
+        ...graphNode(0),
+        id: 'exact-impact-target',
+        name: 'TargetSelector',
+        qualifiedName: 'TargetSelector',
+        score: 0.01,
+      };
+      const candidates = noiseScores.map((score, index) => ({
+        ...graphNode(index + 1),
+        id: `noise-${index}`,
+        name: `TargetSelectorNoise${index}`,
+        qualifiedName: `TargetSelectorNoise${index}`,
+        score: score / 100,
+      }));
+      candidates.splice(position % (candidates.length + 1), 0, exact);
+      const inspectedSeeds: string[][] = [];
+      const store = {
+        edgesForNodes: (_databasePath: string, _snapshotId: string, ids: readonly string[]) =>
+          Effect.sync(() => {
+            inspectedSeeds.push([...ids]);
+            return [];
+          }),
+        searchSymbolsMany: () => Effect.succeed([candidates]),
+        symbolsByIds: () => Effect.succeed([]),
+      } as unknown as CodeGraphStoreShape;
+
+      return Effect.gen(function* () {
+        const result = yield* traversalQuery(
+          store,
+          layout.databasePath,
+          'snapshot',
+          lowercaseQuery ? exact.name.toLocaleLowerCase('en-US') : exact.name,
+          'incoming',
+          20,
+          40,
+          1,
+          ['resolved'],
+          emptyEmbedding,
+          '/property/home',
+          layout,
+          true,
+        );
+
+        expect(inspectedSeeds).toEqual([[exact.id]]);
+        expect(result.nodes.map(node => node.id)).toEqual([exact.id]);
+      });
+    },
+    {fastCheck: {numRuns: 80}},
+  );
+
+  it.effect.prop(
     'matches breadth-first reachability and terminates on generated cyclic graphs',
     {
       graph: graphCaseArbitrary,

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -917,19 +917,20 @@ describe('code graph query budgets', () => {
     }),
   );
 
-  it.effect('round-trips exact impact node IDs and diagnoses a missing ID as a selector', () =>
+  it.effect('round-trips exact impact node IDs with the same reverse dependencies as an exact name', () =>
     Effect.gen(function* () {
       let lexicalSearches = 0;
       let semanticSearches = 0;
       const store = {
-        edgesForNodes: () => Effect.succeed([]),
+        edgesForNodes: (_databasePath: string, _snapshotId: string, ids: readonly string[]) =>
+          Effect.succeed(ids.includes(stableSeed.id) ? [stableEdge] : []),
         searchSymbolsMany: () =>
           Effect.sync(() => {
             lexicalSearches += 1;
-            return [[]];
+            return [[stableSeed]];
           }),
         symbolsByIds: (_databasePath: string, _snapshotId: string, ids: readonly string[]) =>
-          Effect.succeed(ids.includes(stableSeed.id) ? [stableSeed] : []),
+          Effect.succeed([stableSeed, stableDependent].filter(node => ids.includes(node.id))),
       } as unknown as CodeGraphStoreShape;
       const unusedEmbedding = {
         search: () =>
@@ -955,14 +956,16 @@ describe('code graph query budgets', () => {
           true,
         );
 
-      const found = yield* impact(stableSeed.id);
+      const byName = yield* impact(stableSeed.name);
+      const byId = yield* impact(stableSeed.id);
       const missing = yield* impact(`cgs_${'f'.repeat(32)}`);
 
-      expect(found.nodes.map(node => node.id)).toEqual([stableSeed.id]);
-      expect(found.warnings).toEqual([]);
+      expect(byName.nodes.map(node => node.id)).toEqual([stableDependent.id, stableSeed.id]);
+      expect(byName.edges.map(candidate => candidate.id)).toEqual([stableEdge.id]);
+      expect(byId).toEqual(byName);
       expect(missing.nodes).toEqual([]);
       expect(missing.warnings).toContain('Impact selector did not resolve to indexed code symbols.');
-      expect(lexicalSearches).toBe(0);
+      expect(lexicalSearches).toBe(1);
       expect(semanticSearches).toBe(0);
     }),
   );

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -847,6 +847,126 @@ describe('code graph query budgets', () => {
     }),
   );
 
+  it.effect('narrows an exact impact symbol before reverse traversal', () =>
+    Effect.gen(function* () {
+      const exact = {
+        ...seed,
+        id: 'exact-impact-seed',
+        name: 'unsafeCompletionClassification',
+        qualifiedName: 'unsafeCompletionClassification',
+        score: 0.01,
+      };
+      const fuzzy = {
+        ...seed,
+        id: 'fuzzy-impact-seed',
+        name: 'ResourcePathUnsafe',
+        path: 'src/effect/resource-store.ts',
+        qualifiedName: 'ResourcePathUnsafe',
+        score: 1,
+      };
+      const exactDependent = {
+        ...dependent,
+        id: 'exact-impact-dependent',
+        name: 'completionClassification',
+        qualifiedName: 'completionClassification',
+      };
+      const fuzzyDependent = {...dependent, id: 'fuzzy-impact-dependent'};
+      const inspectedSeeds: string[][] = [];
+      let semanticSearches = 0;
+      const store = {
+        edgesForNodes: (_databasePath: string, _snapshotId: string, ids: readonly string[]) =>
+          Effect.sync(() => {
+            inspectedSeeds.push([...ids]);
+            return [
+              {...edge, id: 'exact-edge', sourceId: exactDependent.id, targetId: exact.id},
+              {...edge, id: 'fuzzy-edge', sourceId: fuzzyDependent.id, targetId: fuzzy.id},
+            ].filter(candidate => candidate.targetId !== undefined && ids.includes(candidate.targetId));
+          }),
+        searchSymbolsMany: () => Effect.succeed([[fuzzy, exact]]),
+        symbolsByIds: (_databasePath: string, _snapshotId: string, ids: readonly string[]) =>
+          Effect.succeed([exactDependent, fuzzyDependent].filter(node => ids.includes(node.id))),
+      } as unknown as CodeGraphStoreShape;
+      const unusedEmbedding = {
+        search: () =>
+          Effect.sync(() => {
+            semanticSearches += 1;
+            return new Map<string, number>();
+          }),
+      } as unknown as CodeGraphEmbeddingIndexShape;
+
+      const result = yield* traversalQuery(
+        store,
+        layout.databasePath,
+        'snapshot',
+        exact.name,
+        'incoming',
+        20,
+        40,
+        1,
+        ['resolved'],
+        unusedEmbedding,
+        '/fixture/home',
+        layout,
+        true,
+      );
+
+      expect(inspectedSeeds).toEqual([[exact.id]]);
+      expect(result.nodes.map(node => node.id)).toEqual([exactDependent.id, exact.id]);
+      expect(result.edges.map(candidate => candidate.id)).toEqual(['exact-edge']);
+      expect(semanticSearches).toBe(0);
+    }),
+  );
+
+  it.effect('round-trips exact impact node IDs and diagnoses a missing ID as a selector', () =>
+    Effect.gen(function* () {
+      let lexicalSearches = 0;
+      let semanticSearches = 0;
+      const store = {
+        edgesForNodes: () => Effect.succeed([]),
+        searchSymbolsMany: () =>
+          Effect.sync(() => {
+            lexicalSearches += 1;
+            return [[]];
+          }),
+        symbolsByIds: (_databasePath: string, _snapshotId: string, ids: readonly string[]) =>
+          Effect.succeed(ids.includes(stableSeed.id) ? [stableSeed] : []),
+      } as unknown as CodeGraphStoreShape;
+      const unusedEmbedding = {
+        search: () =>
+          Effect.sync(() => {
+            semanticSearches += 1;
+            return new Map<string, number>();
+          }),
+      } as unknown as CodeGraphEmbeddingIndexShape;
+      const impact = (query: string) =>
+        traversalQuery(
+          store,
+          layout.databasePath,
+          'snapshot',
+          query,
+          'incoming',
+          20,
+          40,
+          1,
+          ['resolved'],
+          unusedEmbedding,
+          '/fixture/home',
+          layout,
+          true,
+        );
+
+      const found = yield* impact(stableSeed.id);
+      const missing = yield* impact(`cgs_${'f'.repeat(32)}`);
+
+      expect(found.nodes.map(node => node.id)).toEqual([stableSeed.id]);
+      expect(found.warnings).toEqual([]);
+      expect(missing.nodes).toEqual([]);
+      expect(missing.warnings).toContain('Impact selector did not resolve to indexed code symbols.');
+      expect(lexicalSearches).toBe(0);
+      expect(semanticSearches).toBe(0);
+    }),
+  );
+
   for (const phase of ['search', 'adjacency', 'hydration'] as const) {
     it.effect(`enforces the absolute deadline after ${phase}`, () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- narrow exact symbol and path selectors before reverse-impact traversal
- round-trip stable `cgs_` node IDs through local impact queries
- retain fuzzy concept expansion only when no exact selector resolves
- report missing explicit IDs as impact selectors instead of changed paths

## Why

`inspect_code_graph impact` treated `unsafeCompletionClassification` as a broad lexical query. It traversed unrelated `unsafe` and `classification` candidates and could exclude the exact seed from bounded output even though ordinary query resolved it at score 1.0. This reproduces on a clean exact-current snapshot, so the defect is selector resolution rather than overlay indexing.

## Verification

- `bun --bun vitest run test/unit/code-graph.query.test.ts test/unit/code-graph.property.test.ts` (24/24)
- source and test TypeScript checks
- strict lint and file-length policy
- commit hooks: lint, formatting, source/test/site typechecks
- source-level CLI dogfood on a current dirty overlay: bare exact symbol and returned stable ID produced identical reverse-impact evidence with no unrelated resource-store, home-migration, or benchmark nodes

A bounded Fast-check property varies fuzzy candidate ordering, scores, and selector casing and proves that an exact impact selector remains the sole traversal seed. The shared global development runtime was not reinstalled because the active 4.4 release work owns it.