### PR TITLE
fix(graph): reclaim orphan provenance sidecars

### DIFF
--- a/src/code_graph/diagnostics.ts
+++ b/src/code_graph/diagnostics.ts
@@ -23,8 +23,9 @@ import {
   type CodeGraphLocalAssociation,
 } from './local_provenance.js';
 import {classifyCodeGraphLifecycle, type CodeGraphLifecycleClassification} from './lifecycle_classification.js';
-import {runCodeGraphLifecycleOpportunity} from './lifecycle_opportunity.js';
+import {runCodeGraphLifecycleOpportunity, type CodeGraphLifecycleOpportunityResult} from './lifecycle_opportunity.js';
 import {CodeGraphMaintenanceCoordinator} from './maintenance_coordinator.js';
+import {CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC} from './orphan_provenance_cleanup.js';
 import {diagnoseCodeGraphDatabase} from './deep_diagnostics.js';
 
 const DIAGNOSTIC_CATALOG_PAGE_SIZE = 64;
@@ -46,7 +47,12 @@ export interface CodeGraphDiagnosticsProgress {
 }
 
 export interface CodeGraphDiagnosticsIssue {
-  readonly code: 'active-build' | 'analysis-failed' | 'catalog-unavailable' | 'health-check-failed';
+  readonly code:
+    | 'active-build'
+    | 'analysis-failed'
+    | 'catalog-unavailable'
+    | 'health-check-failed'
+    | 'orphan-provenance-cursor-recovered';
   readonly message: string;
 }
 
@@ -349,7 +355,7 @@ export const inspectAllCodeGraphsLocal = Effect.fn('codeGraph.inspectAllDiagnost
     [inspectAllCodeGraphs(threadnoteHome, options), readAllCodeGraphBuildStatuses(threadnoteHome)],
     {concurrency: 2},
   );
-  const databases = yield* Effect.forEach(
+  let databases = yield* Effect.forEach(
     report.databases,
     database =>
       Effect.gen(function* () {
@@ -394,7 +400,7 @@ export const inspectAllCodeGraphsLocal = Effect.fn('codeGraph.inspectAllDiagnost
   const path = yield* Path.Path;
   const databasePaths = yield* codeGraphDatabasePaths(threadnoteHome);
   if (lifecycleMaintenance._tag === 'Some') {
-    yield* runCodeGraphLifecycleOpportunity({
+    const lifecycle = yield* runCodeGraphLifecycleOpportunity({
       opportunity: 'diagnostics',
       targets: databases.flatMap(database => {
         const databasePath = databasePaths.find(
@@ -418,9 +424,36 @@ export const inspectAllCodeGraphsLocal = Effect.fn('codeGraph.inspectAllDiagnost
       maintenance: lifecycleMaintenance.value,
       threadnoteHome,
     }).pipe(Effect.catch(() => Effect.void));
+    const lifecycleIssue = codeGraphLifecycleDiagnosticIssue(lifecycle);
+    if (lifecycleIssue !== undefined && lifecycle?.state === 'completed') {
+      databases = databases.map(database =>
+        database.checkoutId === lifecycle.checkoutId
+          ? {
+              ...database,
+              issues: [...database.issues, lifecycleIssue],
+            }
+          : database,
+      );
+    }
   }
   return {...report, databases, version: 2} satisfies CodeGraphLocalDiagnosticsReport;
 });
+
+/** @internal Project only closed maintenance receipts into privacy-safe diagnostics. */
+export function codeGraphLifecycleDiagnosticIssue(
+  lifecycle: CodeGraphLifecycleOpportunityResult | void,
+): CodeGraphDiagnosticsIssue | undefined {
+  if (
+    lifecycle?.state !== 'completed' ||
+    !lifecycle.result.diagnostics?.includes(CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC)
+  ) {
+    return undefined;
+  }
+  return {
+    code: CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC,
+    message: 'Recovered an invalid orphan provenance cleanup cursor; bounded rotation restarted.',
+  };
+}
 
 export function renderCodeGraphDiagnostics(
   report: CodeGraphDiagnosticsReport | CodeGraphLocalDiagnosticsReport,

--- a/src/code_graph/local_provenance.ts
+++ b/src/code_graph/local_provenance.ts
@@ -1,7 +1,7 @@
 import {Clock, Crypto, Effect, FileSystem, Option, Path, PlatformError} from 'effect';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
-import {SystemInfo} from '../effect/system.js';
+import {runtimeTextDirectoryNamePage, SystemInfo} from '../effect/system.js';
 import {
   captureCodeGraphGitWorktreeRegistration,
   observeCodeGraphRecordedWorktreePaths,
@@ -25,6 +25,7 @@ const LOCAL_PROVENANCE_SCHEMA_VERSION = 2 as const;
 const LOCAL_PROVENANCE_BYTES_LIMIT = 8 * 1_024;
 const LOCAL_PATH_LENGTH_LIMIT = 4_096;
 const LOCAL_PROVENANCE_REFRESH_MILLISECONDS = 5 * 60_000;
+export const CODE_GRAPH_LOCAL_PROVENANCE_INVENTORY_ENTRY_LIMIT = 4_096;
 const HASH_ID = /^[0-9a-f]{64}$/;
 const COMMIT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 
@@ -148,6 +149,60 @@ export type CodeGraphLocalProvenanceCleanupResult =
       readonly observedState: CodeGraphLocalAssociationState;
       readonly state: 'preserved';
     };
+
+export type CodeGraphLocalProvenanceInventory =
+  {readonly state: 'ready'; readonly worktreeIds: readonly string[]} | {readonly state: 'unavailable'};
+
+/**
+ * List one checkout's private provenance identities without returning paths or
+ * reading record contents. The closed absolute entry ceiling keeps automatic
+ * maintenance bounded; overflow and containment ambiguity fail closed.
+ */
+export const inspectCodeGraphLocalProvenanceInventory = Effect.fn('codeGraph.inspectLocalProvenanceInventory')(
+  function* (threadnoteHome: string, checkoutId: string) {
+    if (!HASH_ID.test(checkoutId)) {
+      return {state: 'unavailable'} as const satisfies CodeGraphLocalProvenanceInventory;
+    }
+    return yield* Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const checkoutRoot = yield* inspectCheckoutRoot(fs, path, threadnoteHome, checkoutId);
+      if (checkoutRoot === undefined) {
+        return {state: 'ready', worktreeIds: []} as const satisfies CodeGraphLocalProvenanceInventory;
+      }
+      const localContext = path.join(checkoutRoot, LOCAL_CONTEXT_DIRECTORY);
+      if (Option.isSome(yield* fs.readLink(localContext).pipe(Effect.option))) {
+        return {state: 'unavailable'} as const satisfies CodeGraphLocalProvenanceInventory;
+      }
+      if (!(yield* fs.exists(localContext))) {
+        return {state: 'ready', worktreeIds: []} as const satisfies CodeGraphLocalProvenanceInventory;
+      }
+      const canonicalContext = yield* inspectPrivateContainedDirectory(fs, path, checkoutRoot, localContext);
+      const worktrees = path.join(canonicalContext, LOCAL_WORKTREES_DIRECTORY);
+      if (Option.isSome(yield* fs.readLink(worktrees).pipe(Effect.option))) {
+        return {state: 'unavailable'} as const satisfies CodeGraphLocalProvenanceInventory;
+      }
+      if (!(yield* fs.exists(worktrees))) {
+        return {state: 'ready', worktreeIds: []} as const satisfies CodeGraphLocalProvenanceInventory;
+      }
+      const canonicalWorktrees = yield* inspectPrivateContainedDirectory(fs, path, canonicalContext, worktrees);
+      const page = yield* runtimeTextDirectoryNamePage(
+        canonicalWorktrees,
+        CODE_GRAPH_LOCAL_PROVENANCE_INVENTORY_ENTRY_LIMIT,
+      );
+      if (page.overflow) {
+        return {state: 'unavailable'} as const satisfies CodeGraphLocalProvenanceInventory;
+      }
+      const worktreeIds = page.names
+        .filter(name => /^[0-9a-f]{64}\.json$/.test(name))
+        .map(name => name.slice(0, -5))
+        .sort();
+      return {state: 'ready', worktreeIds} as const satisfies CodeGraphLocalProvenanceInventory;
+    }).pipe(
+      Effect.catch(() => Effect.succeed({state: 'unavailable'} as const satisfies CodeGraphLocalProvenanceInventory)),
+    );
+  },
+);
 
 /**
  * Persist a path only after the caller resolved the complete Git identity. Failures are represented

--- a/src/code_graph/maintenance_coordinator.ts
+++ b/src/code_graph/maintenance_coordinator.ts
@@ -27,6 +27,7 @@ import {
   withPreparedCodeGraphRemovedViewVectorUnit,
 } from './vector_maintenance.js';
 import {makeLiveCodeGraphWorktreeReconciler} from './worktree_reconciliation.js';
+import {makeLiveCodeGraphOrphanProvenanceCleaner} from './orphan_provenance_cleanup.js';
 import {inspectCodeGraphViewDatabaseTarget} from './view_removal.js';
 import {type CodeGraphStoragePressure} from './storage_pressure.js';
 import {codeGraphAnonymousTelemetryComponent, emitCodeGraphBackgroundFailure} from './anonymous_telemetry.js';
@@ -175,6 +176,7 @@ export class CodeGraphMaintenanceCoordinator extends Context.Service<
       const crypto = yield* Crypto.Crypto;
       const system = yield* SystemInfo;
       const reconciler = yield* makeLiveCodeGraphWorktreeReconciler();
+      const orphanProvenanceCleaner = yield* makeLiveCodeGraphOrphanProvenanceCleaner();
       const runRoutineMaintenance = (input: CodeGraphRoutineMaintenanceTick) =>
         store.runRoutineMaintenance(input.databasePath, {
           checkoutId: input.checkoutId,
@@ -307,24 +309,51 @@ export class CodeGraphMaintenanceCoordinator extends Context.Service<
         residualWorker.tick(input).pipe(Effect.map(result => residualMaintenanceResult(result)));
       const runReconciliation: CodeGraphRoutineMaintenanceRun = input =>
         reconciler.tick(input).pipe(
-          Effect.flatMap(result =>
-            result.state === 'removed'
-              ? Effect.succeed({
-                  cleanup: 'removed-worktree-view',
-                  expiredLeases: 0,
-                  remaining: true,
-                  retiredSnapshots: result.retiredSnapshots,
-                  rowsDeleted: 0,
-                  state: 'completed',
-                } as const satisfies CodeGraphRoutineMaintenanceResult)
-              : result.reason === 'external-maintenance'
-                ? Effect.succeed({reason: 'external-maintenance', state: 'deferred'} as const)
-                : result.state === 'deferred' && result.reason === 'writer-busy'
-                  ? Effect.succeed({reason: 'writer-busy', state: 'deferred'} as const)
-                  : result.state === 'deferred' && result.reason === 'catalog-unavailable'
-                    ? Effect.succeed({reason: 'schema-unavailable', state: 'skipped'} as const)
-                    : Effect.succeed(emptyMaintenanceResult()),
-          ),
+          Effect.flatMap(result => {
+            if (result.state === 'removed') {
+              return Effect.succeed({
+                cleanup: 'removed-worktree-view',
+                expiredLeases: 0,
+                remaining: true,
+                retiredSnapshots: result.retiredSnapshots,
+                rowsDeleted: 0,
+                state: 'completed',
+              } as const satisfies CodeGraphRoutineMaintenanceResult);
+            }
+            if (result.reason === 'external-maintenance') {
+              return Effect.succeed({reason: 'external-maintenance', state: 'deferred'} as const);
+            }
+            if (result.state === 'deferred' && result.reason === 'writer-busy') {
+              return Effect.succeed({reason: 'writer-busy', state: 'deferred'} as const);
+            }
+            if (result.state === 'deferred' && result.reason === 'catalog-unavailable') {
+              return Effect.succeed({reason: 'schema-unavailable', state: 'skipped'} as const);
+            }
+            return orphanProvenanceCleaner.tick(input).pipe(
+              Effect.map(orphan => {
+                if (orphan.state === 'removed') {
+                  return {
+                    cleanup: 'orphan-provenance',
+                    expiredLeases: 0,
+                    remaining: true,
+                    retiredSnapshots: 0,
+                    rowsDeleted: 0,
+                    state: 'completed',
+                  } as const satisfies CodeGraphRoutineMaintenanceResult;
+                }
+                if (orphan.reason === 'external-maintenance') {
+                  return {reason: 'external-maintenance', state: 'deferred'} as const;
+                }
+                if (orphan.state === 'deferred' && orphan.reason === 'writer-busy') {
+                  return {reason: 'writer-busy', state: 'deferred'} as const;
+                }
+                if (orphan.state === 'deferred' && orphan.reason === 'catalog-unavailable') {
+                  return {reason: 'schema-unavailable', state: 'skipped'} as const;
+                }
+                return emptyMaintenanceResult();
+              }),
+            );
+          }),
         );
       const runReconciliationOrPreparationWithoutHistory: CodeGraphRoutineMaintenanceRun = input => {
         if (input.anchorIdentity === undefined && input.anchorPath === undefined) {

--- a/src/code_graph/maintenance_coordinator.ts
+++ b/src/code_graph/maintenance_coordinator.ts
@@ -27,7 +27,10 @@ import {
   withPreparedCodeGraphRemovedViewVectorUnit,
 } from './vector_maintenance.js';
 import {makeLiveCodeGraphWorktreeReconciler} from './worktree_reconciliation.js';
-import {makeLiveCodeGraphOrphanProvenanceCleaner} from './orphan_provenance_cleanup.js';
+import {
+  CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC,
+  makeLiveCodeGraphOrphanProvenanceCleaner,
+} from './orphan_provenance_cleanup.js';
 import {inspectCodeGraphViewDatabaseTarget} from './view_removal.js';
 import {type CodeGraphStoragePressure} from './storage_pressure.js';
 import {codeGraphAnonymousTelemetryComponent, emitCodeGraphBackgroundFailure} from './anonymous_telemetry.js';
@@ -309,7 +312,7 @@ export class CodeGraphMaintenanceCoordinator extends Context.Service<
         residualWorker.tick(input).pipe(Effect.map(result => residualMaintenanceResult(result)));
       const runReconciliation: CodeGraphRoutineMaintenanceRun = input =>
         reconciler.tick(input).pipe(
-          Effect.flatMap(result => {
+          Effect.flatMap((result): Effect.Effect<CodeGraphRoutineMaintenanceResult> => {
             if (result.state === 'removed') {
               return Effect.succeed({
                 cleanup: 'removed-worktree-view',
@@ -330,10 +333,15 @@ export class CodeGraphMaintenanceCoordinator extends Context.Service<
               return Effect.succeed({reason: 'schema-unavailable', state: 'skipped'} as const);
             }
             return orphanProvenanceCleaner.tick(input).pipe(
-              Effect.map(orphan => {
+              Effect.map((orphan): CodeGraphRoutineMaintenanceResult => {
+                const diagnostics =
+                  orphan.cursorRecovery === undefined
+                    ? {}
+                    : {diagnostics: [CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC] as const};
                 if (orphan.state === 'removed') {
                   return {
                     cleanup: 'orphan-provenance',
+                    ...diagnostics,
                     expiredLeases: 0,
                     remaining: true,
                     retiredSnapshots: 0,
@@ -342,15 +350,15 @@ export class CodeGraphMaintenanceCoordinator extends Context.Service<
                   } as const satisfies CodeGraphRoutineMaintenanceResult;
                 }
                 if (orphan.reason === 'external-maintenance') {
-                  return {reason: 'external-maintenance', state: 'deferred'} as const;
+                  return {reason: 'external-maintenance', ...diagnostics, state: 'deferred'} as const;
                 }
                 if (orphan.state === 'deferred' && orphan.reason === 'writer-busy') {
-                  return {reason: 'writer-busy', state: 'deferred'} as const;
+                  return {reason: 'writer-busy', ...diagnostics, state: 'deferred'} as const;
                 }
                 if (orphan.state === 'deferred' && orphan.reason === 'catalog-unavailable') {
-                  return {reason: 'schema-unavailable', state: 'skipped'} as const;
+                  return {reason: 'schema-unavailable', ...diagnostics, state: 'skipped'} as const;
                 }
-                return emptyMaintenanceResult();
+                return {...emptyMaintenanceResult(), ...diagnostics};
               }),
             );
           }),
@@ -381,7 +389,7 @@ export class CodeGraphMaintenanceCoordinator extends Context.Service<
             waitTimeoutMilliseconds: 0,
           })
           .pipe(
-            Effect.flatMap(result =>
+            Effect.flatMap((result): Effect.Effect<CodeGraphRoutineMaintenanceResult, CodeGraphStoreError> =>
               result.state === 'prepared'
                 ? Effect.succeed({
                     cleanup: 'reconciliation-index',
@@ -743,8 +751,13 @@ export const makeCodeGraphMaintenanceCoordinator = Effect.fn('codeGraph.makeMain
       Effect.gen(function* () {
         const exit = yield* restore(
           externalMaintenanceActive(input.threadnoteHome).pipe(
-            Effect.flatMap(active =>
-              active ? Effect.succeed({reason: 'external-maintenance', state: 'deferred'} as const) : run(input),
+            Effect.flatMap((active): Effect.Effect<CodeGraphRoutineMaintenanceResult, CodeGraphStoreError> =>
+              active
+                ? Effect.succeed({
+                    reason: 'external-maintenance',
+                    state: 'deferred',
+                  } as const satisfies CodeGraphRoutineMaintenanceResult)
+                : run(input),
             ),
           ),
         ).pipe(Effect.exit);

--- a/src/code_graph/orphan_provenance_cleanup.ts
+++ b/src/code_graph/orphan_provenance_cleanup.ts
@@ -1,0 +1,492 @@
+import {Crypto, Effect, FileSystem, Path, Schema} from 'effect';
+import {CommandExecutor} from '../effect/command.js';
+import {SystemInfo} from '../effect/system.js';
+import {
+  observeCodeGraphWorktreeReconciliationAuthority,
+  type CodeGraphWorktreeReconciliationAuthorityObservation,
+  type CodeGraphWorktreeReconciliationAuthorityTarget,
+} from './git_worktree_registration.js';
+import {
+  cleanupMissingCodeGraphLocalProvenance,
+  inspectCodeGraphLocalProvenanceInventory,
+  readCodeGraphWorktreeReconciliationEvidenceCandidate,
+  sameCodeGraphWorktreeReconciliationEvidenceCandidate,
+  type CodeGraphLocalProvenanceCleanupEvidence,
+  type CodeGraphLocalProvenanceCleanupResult,
+  type CodeGraphLocalProvenanceInventory,
+  type CodeGraphWorktreeReconciliationEvidenceCandidate,
+} from './local_provenance.js';
+import {
+  codeGraphMaintenanceIntentActive,
+  CodeGraphMaintenanceActiveError,
+  withCodeGraphTargetWorktreeLock,
+} from './maintenance_gate.js';
+import {resolveRepositoryIdentity} from './repository.js';
+import {
+  CodeGraphStore,
+  type CodeGraphOrphanProvenanceCandidatePage,
+  type CodeGraphOrphanProvenanceViewObservation,
+} from './store.js';
+import {CodeGraphStoreBusyError, type RepositoryIdentity} from './types.js';
+import {inspectCodeGraphViewDatabaseTarget} from './view_removal.js';
+import {
+  codeGraphWorktreeReconciliationAuthorized,
+  type CodeGraphWorktreeReconciliationTick,
+} from './worktree_reconciliation.js';
+
+export const CODE_GRAPH_ORPHAN_PROVENANCE_CANDIDATE_LIMIT = 32;
+
+class CodeGraphOrphanProvenanceAuthorityChanged extends Schema.TaggedError<CodeGraphOrphanProvenanceAuthorityChanged>()(
+  'CodeGraphOrphanProvenanceAuthorityChanged',
+  {message: Schema.String},
+) {}
+
+export type CodeGraphOrphanProvenanceCleanupResult =
+  | {readonly state: 'removed'; readonly worktreeId: string}
+  | {
+      readonly reason:
+        | 'active-view'
+        | 'already-removed'
+        | 'anchor-unavailable'
+        | 'evidence-changed'
+        | 'external-maintenance'
+        | 'no-anchor'
+        | 'no-candidates'
+        | 'no-missing-candidates'
+        | 'registered'
+        | 'registry-changed';
+      readonly state: 'preserved';
+    }
+  | {
+      readonly reason:
+        | 'catalog-unavailable'
+        | 'inventory-unavailable'
+        | 'registry-unavailable'
+        | 'sidecar-unavailable'
+        | 'target-busy'
+        | 'writer-busy';
+      readonly state: 'deferred';
+    };
+
+export interface CodeGraphOrphanProvenanceCleanupDependencies {
+  readonly claimCandidates: (
+    input: CodeGraphWorktreeReconciliationTick,
+    worktreeIds: readonly string[],
+    limit: number,
+  ) => Effect.Effect<CodeGraphOrphanProvenanceCandidatePage, unknown>;
+  readonly cleanupProvenance: (
+    threadnoteHome: string,
+    target: {readonly checkoutId: string; readonly worktreeId: string},
+    expectedEvidence: CodeGraphLocalProvenanceCleanupEvidence,
+  ) => Effect.Effect<CodeGraphLocalProvenanceCleanupResult, unknown>;
+  readonly inspectInventory: (
+    threadnoteHome: string,
+    checkoutId: string,
+  ) => Effect.Effect<CodeGraphLocalProvenanceInventory, unknown>;
+  readonly maintenanceIntentActive: (threadnoteHome: string) => Effect.Effect<boolean, unknown>;
+  readonly observeAuthority: (
+    identity: Pick<RepositoryIdentity, 'checkoutId' | 'gitCommonDirectory'>,
+    targets: readonly CodeGraphWorktreeReconciliationAuthorityTarget[],
+  ) => Effect.Effect<CodeGraphWorktreeReconciliationAuthorityObservation, unknown>;
+  readonly observeView: (
+    input: CodeGraphWorktreeReconciliationTick,
+    worktreeId: string,
+  ) => Effect.Effect<CodeGraphOrphanProvenanceViewObservation, unknown>;
+  readonly readEvidenceCandidate: (
+    threadnoteHome: string,
+    target: {readonly checkoutId: string; readonly worktreeId: string},
+  ) => Effect.Effect<CodeGraphWorktreeReconciliationEvidenceCandidate, unknown>;
+  readonly resolveAnchor: (cwd: string) => Effect.Effect<RepositoryIdentity, unknown>;
+  readonly withTargetLock: <A, E>(
+    input: CodeGraphWorktreeReconciliationTick,
+    worktreeId: string,
+    effect: Effect.Effect<A, E>,
+  ) => Effect.Effect<A, E | unknown>;
+}
+
+export interface CodeGraphOrphanProvenanceCleanerShape {
+  readonly tick: (
+    input: CodeGraphWorktreeReconciliationTick,
+  ) => Effect.Effect<CodeGraphOrphanProvenanceCleanupResult, never>;
+}
+
+type ProvenanceCandidate = Extract<CodeGraphWorktreeReconciliationEvidenceCandidate, {readonly state: 'candidate'}>;
+
+export const makeCodeGraphOrphanProvenanceCleaner = Effect.fn('codeGraph.makeOrphanProvenanceCleaner')(
+  (dependencies: CodeGraphOrphanProvenanceCleanupDependencies) =>
+    Effect.sync(() => {
+      const tick = (input: CodeGraphWorktreeReconciliationTick) =>
+        Effect.gen(function* () {
+          const expectedAnchor = yield* resolveExpectedAnchor(dependencies, input);
+          if (expectedAnchor === undefined) {
+            return {
+              reason:
+                input.anchorIdentity === undefined && input.anchorPath === undefined
+                  ? 'no-anchor'
+                  : 'anchor-unavailable',
+              state: 'preserved',
+            } as const;
+          }
+          const inventory = yield* dependencies
+            .inspectInventory(input.threadnoteHome, input.checkoutId)
+            .pipe(Effect.catch(() => Effect.succeed({state: 'unavailable'} as const)));
+          if (inventory.state === 'unavailable') {
+            return {reason: 'inventory-unavailable', state: 'deferred'} as const;
+          }
+          if (inventory.worktreeIds.length === 0) {
+            return {reason: 'no-candidates', state: 'preserved'} as const;
+          }
+          const claimed = yield* dependencies
+            .claimCandidates(input, inventory.worktreeIds, CODE_GRAPH_ORPHAN_PROVENANCE_CANDIDATE_LIMIT)
+            .pipe(
+              Effect.match({
+                onFailure: error => ({error, state: 'failure'}) as const,
+                onSuccess: value => ({state: 'success', value}) as const,
+              }),
+            );
+          if (claimed.state === 'failure') {
+            if (claimed.error instanceof CodeGraphMaintenanceActiveError) {
+              return {reason: 'external-maintenance', state: 'preserved'} as const;
+            }
+            return {
+              reason: claimed.error instanceof CodeGraphStoreBusyError ? 'writer-busy' : 'catalog-unavailable',
+              state: 'deferred',
+            } as const;
+          }
+          if (claimed.value.worktreeIds.length === 0) {
+            return {reason: 'no-candidates', state: 'preserved'} as const;
+          }
+          const evidenceCandidates = yield* readEvidenceCandidates(
+            dependencies,
+            input,
+            claimed.value.worktreeIds,
+            expectedAnchor,
+          );
+          if (evidenceCandidates.length === 0) {
+            return {reason: 'no-candidates', state: 'preserved'} as const;
+          }
+          const initialAnchor = yield* dependencies.resolveAnchor(expectedAnchor.repoRoot).pipe(Effect.option);
+          if (initialAnchor._tag === 'None' || !sameLiveAnchor(initialAnchor.value, expectedAnchor, input.checkoutId)) {
+            return {reason: 'anchor-unavailable', state: 'preserved'} as const;
+          }
+          const initialAuthority = yield* dependencies
+            .observeAuthority(initialAnchor.value, evidenceCandidates.map(authorityTarget))
+            .pipe(Effect.option);
+          if (initialAuthority._tag === 'None' || initialAuthority.value.state === 'unknown') {
+            return {reason: 'registry-unavailable', state: 'deferred'} as const;
+          }
+          const completeInitialAuthority = initialAuthority.value;
+          if (
+            completeInitialAuthority.pathStates.length !== evidenceCandidates.length ||
+            completeInitialAuthority.registryStates.length !== evidenceCandidates.length
+          ) {
+            return {reason: 'registry-unavailable', state: 'deferred'} as const;
+          }
+          const targetIndex = evidenceCandidates.findIndex(
+            (_candidate, index) =>
+              completeInitialAuthority.pathStates[index] === 'missing' &&
+              completeInitialAuthority.registryStates[index] === 'absent',
+          );
+          if (targetIndex < 0) {
+            return {
+              reason: completeInitialAuthority.pathStates.includes('missing') ? 'registered' : 'no-missing-candidates',
+              state: 'preserved',
+            } as const;
+          }
+          const target = evidenceCandidates[targetIndex]!;
+          return yield* dependencies
+            .withTargetLock(
+              input,
+              target.worktreeId,
+              cleanupLockedTarget(
+                dependencies,
+                input,
+                expectedAnchor,
+                initialAnchor.value,
+                completeInitialAuthority,
+                targetIndex,
+                target,
+              ),
+            )
+            .pipe(
+              Effect.catch(error =>
+                Effect.succeed({
+                  reason:
+                    error instanceof CodeGraphStoreBusyError
+                      ? ('target-busy' as const)
+                      : ('catalog-unavailable' as const),
+                  state: 'deferred' as const,
+                }),
+              ),
+            );
+        });
+      return {tick} satisfies CodeGraphOrphanProvenanceCleanerShape;
+    }),
+);
+
+const cleanupLockedTarget = (
+  dependencies: CodeGraphOrphanProvenanceCleanupDependencies,
+  input: CodeGraphWorktreeReconciliationTick,
+  expectedAnchor: RepositoryIdentity,
+  initialAnchor: RepositoryIdentity,
+  initialAuthority: Extract<CodeGraphWorktreeReconciliationAuthorityObservation, {readonly state: 'complete'}>,
+  targetIndex: number,
+  target: ProvenanceCandidate,
+) =>
+  Effect.gen(function* () {
+    const maintenanceIntent = yield* dependencies.maintenanceIntentActive(input.threadnoteHome).pipe(Effect.option);
+    if (maintenanceIntent._tag === 'None') {
+      return {reason: 'catalog-unavailable', state: 'deferred'} as const;
+    }
+    if (maintenanceIntent.value) {
+      return {reason: 'external-maintenance', state: 'preserved'} as const;
+    }
+    const finalEvidence = yield* dependencies
+      .readEvidenceCandidate(input.threadnoteHome, {
+        checkoutId: input.checkoutId,
+        worktreeId: target.worktreeId,
+      })
+      .pipe(Effect.option);
+    if (
+      finalEvidence._tag === 'None' ||
+      finalEvidence.value.state !== 'candidate' ||
+      !sameCodeGraphWorktreeReconciliationEvidenceCandidate(finalEvidence.value, target)
+    ) {
+      return {reason: 'evidence-changed', state: 'preserved'} as const;
+    }
+    const finalAnchor = yield* dependencies.resolveAnchor(expectedAnchor.repoRoot).pipe(Effect.option);
+    if (
+      finalAnchor._tag === 'None' ||
+      !sameLiveAnchor(finalAnchor.value, initialAnchor, input.checkoutId) ||
+      finalAnchor.value.worktreeId === target.worktreeId
+    ) {
+      return {reason: 'anchor-unavailable', state: 'preserved'} as const;
+    }
+    const finalAuthority = yield* dependencies
+      .observeAuthority(finalAnchor.value, [authorityTarget(finalEvidence.value)])
+      .pipe(Effect.option);
+    if (finalAuthority._tag === 'None' || finalAuthority.value.state === 'unknown') {
+      return {reason: 'registry-unavailable', state: 'deferred'} as const;
+    }
+    if (finalAuthority.value.pathStates.length !== 1 || finalAuthority.value.registryStates.length !== 1) {
+      return {reason: 'registry-unavailable', state: 'deferred'} as const;
+    }
+    if (finalAuthority.value.pathStates[0] !== 'missing') {
+      return {reason: 'evidence-changed', state: 'preserved'} as const;
+    }
+    if (finalAuthority.value.registryStates[0] === 'present') {
+      return {reason: 'registered', state: 'preserved'} as const;
+    }
+    if (
+      finalAuthority.value.registryRootKind !== initialAuthority.registryRootKind ||
+      finalAuthority.value.registryRootIdentity !== initialAuthority.registryRootIdentity
+    ) {
+      return {reason: 'registry-changed', state: 'preserved'} as const;
+    }
+    if (
+      !codeGraphWorktreeReconciliationAuthorized({
+        anchorMatches: true,
+        evidenceStable: true,
+        finalRegistryState: finalAuthority.value.registryStates[0]!,
+        initialRegistryState: initialAuthority.registryStates[targetIndex]!,
+        maintenanceActive: false,
+        missingEvidence: true,
+        registrationKind: finalEvidence.value.registration.kind,
+        registryRootStable: true,
+      })
+    ) {
+      return {reason: 'evidence-changed', state: 'preserved'} as const;
+    }
+    const postAuthorityAnchor = yield* dependencies.resolveAnchor(expectedAnchor.repoRoot).pipe(Effect.option);
+    if (
+      postAuthorityAnchor._tag === 'None' ||
+      !sameLiveAnchor(postAuthorityAnchor.value, finalAnchor.value, input.checkoutId) ||
+      postAuthorityAnchor.value.worktreeId === target.worktreeId
+    ) {
+      return {reason: 'anchor-unavailable', state: 'preserved'} as const;
+    }
+    const postAuthorityEvidence = yield* dependencies
+      .readEvidenceCandidate(input.threadnoteHome, {
+        checkoutId: input.checkoutId,
+        worktreeId: target.worktreeId,
+      })
+      .pipe(Effect.option);
+    if (
+      postAuthorityEvidence._tag === 'None' ||
+      postAuthorityEvidence.value.state !== 'candidate' ||
+      !sameCodeGraphWorktreeReconciliationEvidenceCandidate(postAuthorityEvidence.value, finalEvidence.value)
+    ) {
+      return {reason: 'evidence-changed', state: 'preserved'} as const;
+    }
+    const postAuthorityMaintenanceIntent = yield* dependencies
+      .maintenanceIntentActive(input.threadnoteHome)
+      .pipe(Effect.option);
+    if (postAuthorityMaintenanceIntent._tag === 'None') {
+      return {reason: 'catalog-unavailable', state: 'deferred'} as const;
+    }
+    if (postAuthorityMaintenanceIntent.value) {
+      return {reason: 'external-maintenance', state: 'preserved'} as const;
+    }
+    // The target lock is the builder's publication gate. Once this final
+    // writer-gated observation is absent, no product path can republish the
+    // view before the exact sidecar removal below completes.
+    const view = yield* dependencies.observeView(input, target.worktreeId).pipe(
+      Effect.match({
+        onFailure: error => ({error, state: 'failure'}) as const,
+        onSuccess: value => ({state: 'success', value}) as const,
+      }),
+    );
+    if (view.state === 'failure') {
+      return {
+        reason:
+          view.error instanceof CodeGraphStoreBusyError ? ('writer-busy' as const) : ('catalog-unavailable' as const),
+        state: 'deferred',
+      } as const;
+    }
+    if (view.value.state === 'active') {
+      return {reason: 'active-view', state: 'preserved'} as const;
+    }
+    const cleanupEvidence: CodeGraphLocalProvenanceCleanupEvidence = {
+      checkoutId: input.checkoutId,
+      recordDigest: postAuthorityEvidence.value.recordDigest,
+      recordIdentity: postAuthorityEvidence.value.recordIdentity,
+      repositoryId: postAuthorityEvidence.value.repositoryId,
+      worktreeId: target.worktreeId,
+    };
+    const cleanup = yield* dependencies
+      .cleanupProvenance(
+        input.threadnoteHome,
+        {checkoutId: input.checkoutId, worktreeId: target.worktreeId},
+        cleanupEvidence,
+      )
+      .pipe(Effect.catch(() => Effect.succeed({state: 'unavailable'} as const)));
+    return cleanupResult(target.worktreeId, cleanup);
+  });
+
+export const makeLiveCodeGraphOrphanProvenanceCleaner = Effect.fn('codeGraph.makeLiveOrphanProvenanceCleaner')(
+  function* () {
+    const command = yield* CommandExecutor;
+    const crypto = yield* Crypto.Crypto;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const store = yield* CodeGraphStore;
+    const system = yield* SystemInfo;
+    const provideLive = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.provideService(CommandExecutor, command),
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.provideService(FileSystem.FileSystem, fs),
+        Effect.provideService(Path.Path, path),
+        Effect.provideService(SystemInfo, system),
+      );
+    const verifyDatabaseAuthority = (input: CodeGraphWorktreeReconciliationTick, operation: string) =>
+      Effect.gen(function* () {
+        const inspected = yield* provideLive(
+          inspectCodeGraphViewDatabaseTarget(input.threadnoteHome, input.checkoutId),
+        );
+        if (inspected.state !== 'ready' || inspected.databasePath !== input.databasePath) {
+          return yield* Effect.fail(
+            new CodeGraphOrphanProvenanceAuthorityChanged({
+              message: `Code graph database target changed before ${operation}.`,
+            }),
+          );
+        }
+        if (yield* provideLive(codeGraphMaintenanceIntentActive(input.threadnoteHome))) {
+          return yield* Effect.fail(new CodeGraphMaintenanceActiveError());
+        }
+      });
+    return yield* makeCodeGraphOrphanProvenanceCleaner({
+      claimCandidates: (input, worktreeIds, limit) =>
+        store.claimOrphanProvenanceCandidates(input.databasePath, worktreeIds, limit, {
+          beforeDatabaseOpen: () => verifyDatabaseAuthority(input, 'orphan provenance scan'),
+          waitTimeoutMilliseconds: 0,
+        }),
+      cleanupProvenance: (threadnoteHome, target, expectedEvidence) =>
+        provideLive(cleanupMissingCodeGraphLocalProvenance(threadnoteHome, target, {expectedEvidence})),
+      inspectInventory: (threadnoteHome, checkoutId) =>
+        provideLive(inspectCodeGraphLocalProvenanceInventory(threadnoteHome, checkoutId)),
+      maintenanceIntentActive: threadnoteHome => provideLive(codeGraphMaintenanceIntentActive(threadnoteHome)),
+      observeAuthority: (identity, targets) =>
+        provideLive(observeCodeGraphWorktreeReconciliationAuthority(identity, targets)),
+      observeView: (input, worktreeId) =>
+        store.observeOrphanProvenanceView(input.databasePath, worktreeId, {
+          beforeDatabaseOpen: () => verifyDatabaseAuthority(input, 'orphan provenance cleanup'),
+          waitTimeoutMilliseconds: 0,
+        }),
+      readEvidenceCandidate: (threadnoteHome, target) =>
+        provideLive(readCodeGraphWorktreeReconciliationEvidenceCandidate(threadnoteHome, target)),
+      resolveAnchor: cwd => provideLive(resolveRepositoryIdentity(cwd)),
+      withTargetLock: (input, worktreeId, effect) =>
+        provideLive(withCodeGraphTargetWorktreeLock(input.threadnoteHome, input.checkoutId, worktreeId, effect)),
+    });
+  },
+);
+
+function resolveExpectedAnchor(
+  dependencies: CodeGraphOrphanProvenanceCleanupDependencies,
+  input: CodeGraphWorktreeReconciliationTick,
+): Effect.Effect<RepositoryIdentity | undefined> {
+  if (input.anchorIdentity !== undefined) {
+    return Effect.succeed(input.anchorIdentity.checkoutId === input.checkoutId ? input.anchorIdentity : undefined);
+  }
+  if (input.anchorPath === undefined) return Effect.succeed(undefined);
+  return dependencies.resolveAnchor(input.anchorPath).pipe(
+    Effect.map(identity => (identity.checkoutId === input.checkoutId ? identity : undefined)),
+    Effect.catch(() => Effect.succeed(undefined)),
+  );
+}
+
+function readEvidenceCandidates(
+  dependencies: CodeGraphOrphanProvenanceCleanupDependencies,
+  input: CodeGraphWorktreeReconciliationTick,
+  worktreeIds: readonly string[],
+  expectedAnchor: RepositoryIdentity,
+) {
+  return Effect.forEach(
+    worktreeIds,
+    worktreeId =>
+      dependencies
+        .readEvidenceCandidate(input.threadnoteHome, {checkoutId: input.checkoutId, worktreeId})
+        .pipe(Effect.catch(() => Effect.succeed({state: 'invalid'} as const))),
+    {concurrency: 1},
+  ).pipe(
+    Effect.map(evidence =>
+      evidence.filter(
+        (candidate): candidate is ProvenanceCandidate =>
+          candidate.state === 'candidate' &&
+          candidate.repositoryId === expectedAnchor.repositoryId &&
+          candidate.worktreeId !== expectedAnchor.worktreeId,
+      ),
+    ),
+  );
+}
+
+function sameLiveAnchor(observed: RepositoryIdentity, expected: RepositoryIdentity, checkoutId: string): boolean {
+  return (
+    observed.checkoutId === checkoutId &&
+    observed.checkoutId === expected.checkoutId &&
+    observed.repositoryId === expected.repositoryId &&
+    observed.worktreeId === expected.worktreeId &&
+    observed.repoRoot === expected.repoRoot &&
+    observed.gitCommonDirectory === expected.gitCommonDirectory &&
+    observed.objectFormat === expected.objectFormat
+  );
+}
+
+function authorityTarget(evidence: ProvenanceCandidate): CodeGraphWorktreeReconciliationAuthorityTarget {
+  return {
+    adminNameKeys: evidence.registration.adminNameKeys,
+    canonicalWorktreePath: evidence.canonicalWorktreePath,
+    evidenceToken: evidence.evidenceToken,
+  };
+}
+
+function cleanupResult(
+  worktreeId: string,
+  result: CodeGraphLocalProvenanceCleanupResult,
+): CodeGraphOrphanProvenanceCleanupResult {
+  if (result.state === 'removed') return {state: 'removed', worktreeId};
+  if (result.state === 'not-found') return {reason: 'already-removed', state: 'preserved'};
+  if (result.state === 'unavailable') return {reason: 'sidecar-unavailable', state: 'deferred'};
+  return {reason: 'evidence-changed', state: 'preserved'};
+}

--- a/src/code_graph/orphan_provenance_cleanup.ts
+++ b/src/code_graph/orphan_provenance_cleanup.ts
@@ -35,6 +35,7 @@ import {
 } from './worktree_reconciliation.js';
 
 export const CODE_GRAPH_ORPHAN_PROVENANCE_CANDIDATE_LIMIT = 32;
+export const CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC = 'orphan-provenance-cursor-recovered' as const;
 
 class CodeGraphOrphanProvenanceAuthorityChanged extends Schema.TaggedError<CodeGraphOrphanProvenanceAuthorityChanged>()(
   'CodeGraphOrphanProvenanceAuthorityChanged',
@@ -42,8 +43,15 @@ class CodeGraphOrphanProvenanceAuthorityChanged extends Schema.TaggedError<CodeG
 ) {}
 
 export type CodeGraphOrphanProvenanceCleanupResult =
-  | {readonly state: 'removed'; readonly worktreeId: string}
   | {
+      /** Advisory scheduler repair only; deletion still requires every independent authority gate. */
+      readonly cursorRecovery?: 'invalid-format';
+      readonly state: 'removed';
+      readonly worktreeId: string;
+    }
+  | {
+      /** Advisory scheduler repair only; deletion still requires every independent authority gate. */
+      readonly cursorRecovery?: 'invalid-format';
       readonly reason:
         | 'active-view'
         | 'already-removed'
@@ -58,6 +66,8 @@ export type CodeGraphOrphanProvenanceCleanupResult =
       readonly state: 'preserved';
     }
   | {
+      /** Advisory scheduler repair only; deletion still requires every independent authority gate. */
+      readonly cursorRecovery?: 'invalid-format';
       readonly reason:
         | 'catalog-unavailable'
         | 'inventory-unavailable'
@@ -117,15 +127,9 @@ export const makeCodeGraphOrphanProvenanceCleaner = Effect.fn('codeGraph.makeOrp
     Effect.sync(() => {
       const tick = (input: CodeGraphWorktreeReconciliationTick) =>
         Effect.gen(function* () {
-          const expectedAnchor = yield* resolveExpectedAnchor(dependencies, input);
-          if (expectedAnchor === undefined) {
-            return {
-              reason:
-                input.anchorIdentity === undefined && input.anchorPath === undefined
-                  ? 'no-anchor'
-                  : 'anchor-unavailable',
-              state: 'preserved',
-            } as const;
+          let expectedAnchor = input.anchorIdentity;
+          if (expectedAnchor !== undefined && expectedAnchor.checkoutId !== input.checkoutId) {
+            return {reason: 'anchor-unavailable', state: 'preserved'} as const;
           }
           const inventory = yield* dependencies
             .inspectInventory(input.threadnoteHome, input.checkoutId)
@@ -153,48 +157,66 @@ export const makeCodeGraphOrphanProvenanceCleaner = Effect.fn('codeGraph.makeOrp
               state: 'deferred',
             } as const;
           }
+          const cursorRecovery = claimed.value.cursorRecovery;
+          const withCursorRecovery = <Result extends CodeGraphOrphanProvenanceCleanupResult>(
+            result: Result,
+          ): CodeGraphOrphanProvenanceCleanupResult =>
+            cursorRecovery === undefined ? result : {...result, cursorRecovery};
           if (claimed.value.worktreeIds.length === 0) {
-            return {reason: 'no-candidates', state: 'preserved'} as const;
+            return withCursorRecovery({reason: 'no-candidates', state: 'preserved'} as const);
           }
-          const evidenceCandidates = yield* readEvidenceCandidates(
-            dependencies,
-            input,
-            claimed.value.worktreeIds,
-            expectedAnchor,
-          );
+          const evidenceCandidates = yield* readEvidenceCandidates(dependencies, input, claimed.value.worktreeIds);
           if (evidenceCandidates.length === 0) {
-            return {reason: 'no-candidates', state: 'preserved'} as const;
+            return withCursorRecovery({reason: 'no-candidates', state: 'preserved'} as const);
+          }
+          if (expectedAnchor === undefined) {
+            if (input.anchorPath === undefined) {
+              return withCursorRecovery({reason: 'no-anchor', state: 'preserved'} as const);
+            }
+            const resolved = yield* dependencies.resolveAnchor(input.anchorPath).pipe(Effect.option);
+            if (resolved._tag === 'None' || resolved.value.checkoutId !== input.checkoutId) {
+              return withCursorRecovery({reason: 'anchor-unavailable', state: 'preserved'} as const);
+            }
+            expectedAnchor = resolved.value;
+          }
+          const repositoryCandidates = evidenceCandidates.filter(
+            candidate =>
+              candidate.repositoryId === expectedAnchor.repositoryId &&
+              candidate.worktreeId !== expectedAnchor.worktreeId,
+          );
+          if (repositoryCandidates.length === 0) {
+            return withCursorRecovery({reason: 'no-candidates', state: 'preserved'} as const);
           }
           const initialAnchor = yield* dependencies.resolveAnchor(expectedAnchor.repoRoot).pipe(Effect.option);
           if (initialAnchor._tag === 'None' || !sameLiveAnchor(initialAnchor.value, expectedAnchor, input.checkoutId)) {
-            return {reason: 'anchor-unavailable', state: 'preserved'} as const;
+            return withCursorRecovery({reason: 'anchor-unavailable', state: 'preserved'} as const);
           }
           const initialAuthority = yield* dependencies
-            .observeAuthority(initialAnchor.value, evidenceCandidates.map(authorityTarget))
+            .observeAuthority(initialAnchor.value, repositoryCandidates.map(authorityTarget))
             .pipe(Effect.option);
           if (initialAuthority._tag === 'None' || initialAuthority.value.state === 'unknown') {
-            return {reason: 'registry-unavailable', state: 'deferred'} as const;
+            return withCursorRecovery({reason: 'registry-unavailable', state: 'deferred'} as const);
           }
           const completeInitialAuthority = initialAuthority.value;
           if (
-            completeInitialAuthority.pathStates.length !== evidenceCandidates.length ||
-            completeInitialAuthority.registryStates.length !== evidenceCandidates.length
+            completeInitialAuthority.pathStates.length !== repositoryCandidates.length ||
+            completeInitialAuthority.registryStates.length !== repositoryCandidates.length
           ) {
-            return {reason: 'registry-unavailable', state: 'deferred'} as const;
+            return withCursorRecovery({reason: 'registry-unavailable', state: 'deferred'} as const);
           }
-          const targetIndex = evidenceCandidates.findIndex(
+          const targetIndex = repositoryCandidates.findIndex(
             (_candidate, index) =>
               completeInitialAuthority.pathStates[index] === 'missing' &&
               completeInitialAuthority.registryStates[index] === 'absent',
           );
           if (targetIndex < 0) {
-            return {
+            return withCursorRecovery({
               reason: completeInitialAuthority.pathStates.includes('missing') ? 'registered' : 'no-missing-candidates',
               state: 'preserved',
-            } as const;
+            } as const);
           }
-          const target = evidenceCandidates[targetIndex]!;
-          return yield* dependencies
+          const target = repositoryCandidates[targetIndex]!;
+          const result = yield* dependencies
             .withTargetLock(
               input,
               target.worktreeId,
@@ -219,6 +241,7 @@ export const makeCodeGraphOrphanProvenanceCleaner = Effect.fn('codeGraph.makeOrp
                 }),
               ),
             );
+          return withCursorRecovery(result);
         });
       return {tick} satisfies CodeGraphOrphanProvenanceCleanerShape;
     }),
@@ -422,25 +445,10 @@ export const makeLiveCodeGraphOrphanProvenanceCleaner = Effect.fn('codeGraph.mak
   },
 );
 
-function resolveExpectedAnchor(
-  dependencies: CodeGraphOrphanProvenanceCleanupDependencies,
-  input: CodeGraphWorktreeReconciliationTick,
-): Effect.Effect<RepositoryIdentity | undefined> {
-  if (input.anchorIdentity !== undefined) {
-    return Effect.succeed(input.anchorIdentity.checkoutId === input.checkoutId ? input.anchorIdentity : undefined);
-  }
-  if (input.anchorPath === undefined) return Effect.succeed(undefined);
-  return dependencies.resolveAnchor(input.anchorPath).pipe(
-    Effect.map(identity => (identity.checkoutId === input.checkoutId ? identity : undefined)),
-    Effect.catch(() => Effect.succeed(undefined)),
-  );
-}
-
 function readEvidenceCandidates(
   dependencies: CodeGraphOrphanProvenanceCleanupDependencies,
   input: CodeGraphWorktreeReconciliationTick,
   worktreeIds: readonly string[],
-  expectedAnchor: RepositoryIdentity,
 ) {
   return Effect.forEach(
     worktreeIds,
@@ -451,12 +459,7 @@ function readEvidenceCandidates(
     {concurrency: 1},
   ).pipe(
     Effect.map(evidence =>
-      evidence.filter(
-        (candidate): candidate is ProvenanceCandidate =>
-          candidate.state === 'candidate' &&
-          candidate.repositoryId === expectedAnchor.repositoryId &&
-          candidate.worktreeId !== expectedAnchor.worktreeId,
-      ),
+      evidence.filter((candidate): candidate is ProvenanceCandidate => candidate.state === 'candidate'),
     ),
   );
 }

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -207,6 +207,8 @@ export interface CodeGraphDatabaseRepair {
   readonly removedSnapshots: number;
 }
 
+export type CodeGraphRoutineMaintenanceDiagnostic = 'orphan-provenance-cursor-recovered';
+
 export type CodeGraphRoutineMaintenanceResult =
   | {
       readonly cleanup:
@@ -221,6 +223,8 @@ export type CodeGraphRoutineMaintenanceResult =
         | 'removed-worktree-view'
         | 'schema-migration'
         | 'retired-snapshot';
+      /** Closed, path-free maintenance observations safe for CLI and Manager diagnostics. */
+      readonly diagnostics?: readonly CodeGraphRoutineMaintenanceDiagnostic[];
       readonly expiredLeases: number;
       readonly remaining: boolean;
       readonly retiredSnapshots: number;
@@ -237,9 +241,13 @@ export type CodeGraphRoutineMaintenanceResult =
         | 'status-sidecar-unavailable'
         | 'worktree-busy'
         | 'writer-busy';
+      /** Closed, path-free maintenance observations safe for CLI and Manager diagnostics. */
+      readonly diagnostics?: readonly CodeGraphRoutineMaintenanceDiagnostic[];
       readonly state: 'deferred';
     }
   | {
+      /** Closed, path-free maintenance observations safe for CLI and Manager diagnostics. */
+      readonly diagnostics?: readonly CodeGraphRoutineMaintenanceDiagnostic[];
       readonly reason: 'database-missing' | 'schema-unavailable' | 'writer-lock-unavailable';
       readonly state: 'skipped';
     };
@@ -585,6 +593,8 @@ export interface CodeGraphWorktreeReconciliationCandidate {
 }
 
 export interface CodeGraphOrphanProvenanceCandidatePage {
+  /** Advisory cursor repair performed atomically with this claim. Never grants deletion authority. */
+  readonly cursorRecovery?: 'invalid-format';
   readonly worktreeIds: readonly string[];
 }
 

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -216,6 +216,7 @@ export type CodeGraphRoutineMaintenanceResult =
         | 'file-blob-cache'
         | 'materialized-shard-cache'
         | 'none'
+        | 'orphan-provenance'
         | 'reconciliation-index'
         | 'removed-worktree-view'
         | 'schema-migration'
@@ -582,6 +583,13 @@ export interface CodeGraphWorktreeReconciliationCandidate {
   readonly snapshotId: string;
   readonly worktreeId: string;
 }
+
+export interface CodeGraphOrphanProvenanceCandidatePage {
+  readonly worktreeIds: readonly string[];
+}
+
+export type CodeGraphOrphanProvenanceViewObservation =
+  {readonly state: 'absent'} | {readonly snapshotId: string; readonly state: 'active'};
 
 export const CODE_GRAPH_REMOVED_VIEW_CLEANUP_PHASES = [
   'vector-pointers',

--- a/src/code_graph/store_reconciliation.ts
+++ b/src/code_graph/store_reconciliation.ts
@@ -22,7 +22,11 @@ import {
   removedViewCleanupRecordedRevision,
 } from './store_removed_view_schema_inspection.js';
 import {normalizeSchemaDefinition} from './store_schema_normalization.js';
-import {inspectBoundedSchemaMetadataValue} from './store_schema_metadata.js';
+import {
+  REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
+  inspectBoundedSchemaMetadataRowCount,
+  inspectBoundedSchemaMetadataValue,
+} from './store_schema_metadata.js';
 import {CODE_GRAPH_SCHEMA_VERSION, CodeGraphStoreError} from './types.js';
 import {
   allocateRemovedViewCleanupEpoch,
@@ -159,14 +163,18 @@ const claimOrphanProvenanceCandidates = Effect.fn('codeGraph.claimOrphanProvenan
       if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql))) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation schema is unavailable.'));
       }
-      const cursorRows = yield* sql.unsafe<{readonly value: unknown}>(
-        `SELECT value FROM schema_metadata WHERE key = ? LIMIT 1`,
-        [ORPHAN_PROVENANCE_CURSOR_KEY],
-      );
-      const cursor = cursorRows[0]?.value;
-      if (cursor !== undefined && (typeof cursor !== 'string' || !/^[0-9a-f]{64}$/.test(cursor))) {
-        return yield* Effect.fail(new CodeGraphStoreError('Code graph provenance reconciliation cursor is invalid.'));
+      const cursorInspection = yield* inspectBoundedSchemaMetadataValue(sql, ORPHAN_PROVENANCE_CURSOR_KEY, 64);
+      if (cursorInspection.state === 'invalid') {
+        return yield* Effect.fail(
+          new CodeGraphStoreError('Code graph provenance reconciliation cursor metadata is invalid.'),
+        );
       }
+      const cursor =
+        cursorInspection.state === 'recorded' && /^[0-9a-f]{64}$/u.test(cursorInspection.value)
+          ? cursorInspection.value
+          : undefined;
+      const cursorRecovery =
+        cursorInspection.state === 'recorded' && cursor === undefined ? ('invalid-format' as const) : undefined;
       const selectPage = (boundary: 'after' | 'through', pageLimit: number) => {
         const predicate =
           cursor === undefined ? '' : boundary === 'after' ? 'AND candidate.value > ?' : 'AND candidate.value <= ?';
@@ -204,14 +212,49 @@ const claimOrphanProvenanceCandidates = Effect.fn('codeGraph.claimOrphanProvenan
       const selected = rows.map(row => row.worktree_id as string);
       const nextCursor = selected.at(-1);
       if (nextCursor !== undefined) {
-        yield* sql.unsafe(
-          `INSERT INTO schema_metadata (key, value)
-           VALUES (?, ?)
-           ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-          [ORPHAN_PROVENANCE_CURSOR_KEY, nextCursor],
-        );
+        if (cursorInspection.state === 'missing') {
+          const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(sql);
+          const removedViewAdmissionCursor = yield* inspectRemovedViewCleanupAdmissionCursor(sql);
+          const metadataRowLimit =
+            removedViewAdmissionCursor.cursor === undefined
+              ? REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - 1
+              : REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS;
+          if (
+            metadataRowCount === undefined ||
+            !removedViewAdmissionCursor.current ||
+            metadataRowCount >= metadataRowLimit
+          ) {
+            return yield* Effect.fail(
+              new CodeGraphStoreError('Code graph provenance reconciliation cursor metadata has no capacity.'),
+            );
+          }
+          yield* sql.unsafe(`INSERT INTO schema_metadata (key, value) VALUES (?, ?)`, [
+            ORPHAN_PROVENANCE_CURSOR_KEY,
+            nextCursor,
+          ]);
+        } else {
+          yield* sql.unsafe(`UPDATE schema_metadata SET value = ? WHERE key = ? AND value = ?`, [
+            nextCursor,
+            ORPHAN_PROVENANCE_CURSOR_KEY,
+            cursorInspection.value,
+          ]);
+          if ((yield* lastStatementChangeCount(sql)) !== 1) {
+            return yield* Effect.fail(new CodeGraphStoreError('Code graph provenance reconciliation cursor changed.'));
+          }
+        }
+      } else if (cursorRecovery !== undefined && cursorInspection.state === 'recorded') {
+        yield* sql.unsafe(`DELETE FROM schema_metadata WHERE key = ? AND value = ?`, [
+          ORPHAN_PROVENANCE_CURSOR_KEY,
+          cursorInspection.value,
+        ]);
+        if ((yield* lastStatementChangeCount(sql)) !== 1) {
+          return yield* Effect.fail(new CodeGraphStoreError('Code graph provenance reconciliation cursor changed.'));
+        }
       }
-      return {worktreeIds: selected} as const satisfies CodeGraphOrphanProvenanceCandidatePage;
+      return {
+        ...(cursorRecovery === undefined ? {} : {cursorRecovery}),
+        worktreeIds: selected,
+      } as const satisfies CodeGraphOrphanProvenanceCandidatePage;
     }),
   );
 });

--- a/src/code_graph/store_reconciliation.ts
+++ b/src/code_graph/store_reconciliation.ts
@@ -5,6 +5,8 @@ import {
   CODE_GRAPH_REMOVED_VIEW_CLEANUP_CLAIM_LEASE_MILLISECONDS,
   CODE_GRAPH_REMOVED_VIEW_CLEANUP_PAGE_ROWS,
   CODE_GRAPH_REMOVED_VIEW_CLEANUP_PHASES,
+  type CodeGraphOrphanProvenanceCandidatePage,
+  type CodeGraphOrphanProvenanceViewObservation,
   type CodeGraphRemovedViewCleanupEntry,
   type CodeGraphRemovedViewCleanupEvidence,
   type CodeGraphRemovedViewCleanupUpdate,
@@ -62,6 +64,9 @@ import {
 } from './store_maintenance_core.js';
 import {lastStatementChangeCount} from './store_activation_core.js';
 import {type CodeGraphSqlQueryStatement} from './store_visualization_sql.js';
+
+const ORPHAN_PROVENANCE_CURSOR_KEY = 'orphan_provenance_cursor';
+const ORPHAN_PROVENANCE_WORKTREE_ID_LIMIT = 4_096;
 
 const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktreeReconciliationCandidates')(function* (
   sql: SqlClient.SqlClient,
@@ -124,6 +129,122 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
           snapshotId: row.snapshot_id,
           worktreeId: row.worktree_id,
         })) satisfies readonly CodeGraphWorktreeReconciliationCandidate[];
+    }),
+  );
+});
+
+const claimOrphanProvenanceCandidates = Effect.fn('codeGraph.claimOrphanProvenanceCandidates')(function* (
+  sql: SqlClient.SqlClient,
+  requestedWorktreeIds: readonly string[],
+  requestedLimit: number,
+) {
+  if (
+    requestedWorktreeIds.length > ORPHAN_PROVENANCE_WORKTREE_ID_LIMIT ||
+    requestedWorktreeIds.some(worktreeId => !/^[0-9a-f]{64}$/.test(worktreeId))
+  ) {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph provenance candidate inventory is invalid.'));
+  }
+  const worktreeIds = [...new Set(requestedWorktreeIds)].sort();
+  if (worktreeIds.length !== requestedWorktreeIds.length) {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph provenance candidate inventory is invalid.'));
+  }
+  if (worktreeIds.length === 0) {
+    return {worktreeIds: []} as const satisfies CodeGraphOrphanProvenanceCandidatePage;
+  }
+  const limit = Number.isSafeInteger(requestedLimit) ? Math.max(1, Math.min(32, requestedLimit)) : 32;
+  const encodedWorktreeIds = JSON.stringify(worktreeIds);
+  const worktreeIdSet = new Set(worktreeIds);
+  return yield* sql.withTransaction(
+    Effect.gen(function* () {
+      if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql))) {
+        return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation schema is unavailable.'));
+      }
+      const cursorRows = yield* sql.unsafe<{readonly value: unknown}>(
+        `SELECT value FROM schema_metadata WHERE key = ? LIMIT 1`,
+        [ORPHAN_PROVENANCE_CURSOR_KEY],
+      );
+      const cursor = cursorRows[0]?.value;
+      if (cursor !== undefined && (typeof cursor !== 'string' || !/^[0-9a-f]{64}$/.test(cursor))) {
+        return yield* Effect.fail(new CodeGraphStoreError('Code graph provenance reconciliation cursor is invalid.'));
+      }
+      const selectPage = (boundary: 'after' | 'through', pageLimit: number) => {
+        const predicate =
+          cursor === undefined ? '' : boundary === 'after' ? 'AND candidate.value > ?' : 'AND candidate.value <= ?';
+        const parameters =
+          cursor === undefined ? [encodedWorktreeIds, pageLimit] : [encodedWorktreeIds, cursor, pageLimit];
+        return sql.unsafe<{readonly worktree_id: unknown}>(
+          `SELECT candidate.value AS worktree_id
+           FROM json_each(?) AS candidate
+           LEFT JOIN active_snapshots AS active ON active.worktree_id = candidate.value
+           WHERE candidate.type = 'text'
+             AND active.worktree_id IS NULL
+             ${predicate}
+           ORDER BY candidate.value
+           LIMIT ?`,
+          parameters,
+        );
+      };
+      const after = yield* selectPage('after', limit);
+      const rows =
+        cursor === undefined || after.length >= limit
+          ? after
+          : [...after, ...(yield* selectPage('through', limit - after.length))];
+      if (
+        rows.some(
+          row =>
+            typeof row.worktree_id !== 'string' ||
+            !/^[0-9a-f]{64}$/.test(row.worktree_id) ||
+            !worktreeIdSet.has(row.worktree_id),
+        )
+      ) {
+        return yield* Effect.fail(
+          new CodeGraphStoreError('Code graph provenance reconciliation candidate is invalid.'),
+        );
+      }
+      const selected = rows.map(row => row.worktree_id as string);
+      const nextCursor = selected.at(-1);
+      if (nextCursor !== undefined) {
+        yield* sql.unsafe(
+          `INSERT INTO schema_metadata (key, value)
+           VALUES (?, ?)
+           ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+          [ORPHAN_PROVENANCE_CURSOR_KEY, nextCursor],
+        );
+      }
+      return {worktreeIds: selected} as const satisfies CodeGraphOrphanProvenanceCandidatePage;
+    }),
+  );
+});
+
+const observeOrphanProvenanceView = Effect.fn('codeGraph.observeOrphanProvenanceView')(function* (
+  sql: SqlClient.SqlClient,
+  worktreeId: string,
+) {
+  if (!/^[0-9a-f]{64}$/.test(worktreeId)) {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph worktree identity is invalid.'));
+  }
+  return yield* sql.withTransaction(
+    Effect.gen(function* () {
+      if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql))) {
+        return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation schema is unavailable.'));
+      }
+      const rows = yield* sql.unsafe<{readonly snapshot_id: unknown}>(
+        `SELECT snapshot_id FROM active_snapshots WHERE worktree_id = ? LIMIT 2`,
+        [worktreeId],
+      );
+      if (
+        rows.length > 1 ||
+        (rows[0] !== undefined &&
+          (typeof rows[0].snapshot_id !== 'string' || !CODE_GRAPH_SNAPSHOT_ID.test(rows[0].snapshot_id)))
+      ) {
+        return yield* Effect.fail(new CodeGraphStoreError('Code graph view authority is invalid.'));
+      }
+      return rows[0] === undefined
+        ? ({state: 'absent'} as const satisfies CodeGraphOrphanProvenanceViewObservation)
+        : ({
+            snapshotId: rows[0].snapshot_id as string,
+            state: 'active',
+          } as const satisfies CodeGraphOrphanProvenanceViewObservation);
     }),
   );
 });
@@ -731,7 +852,9 @@ export {
   ensureRemovedViewCleanupEpoch,
   validRemovedViewCleanupUpdate,
   admitRemovedViewCleanupEpoch,
+  claimOrphanProvenanceCandidates,
   claimWorktreeReconciliationCandidates,
+  observeOrphanProvenanceView,
   claimRemovedViewCleanupCandidates,
   authorizeRemovedViewCleanup,
   updateRemovedViewCleanup,

--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -5,6 +5,8 @@ import {CODE_GRAPH_CACHE_TRANSACTION_LIMITS, codeGraphTextFieldsCapacityBytes} f
 import {saturatingCapacityAdd} from './disk_capacity.js';
 import {ensureBoundedCodeGraphFact} from './fact_budget.js';
 import {
+  type CodeGraphOrphanProvenanceCandidatePage,
+  type CodeGraphOrphanProvenanceViewObservation,
   type CodeGraphSnapshotPurgeObservationResult,
   type CodeGraphSnapshotPurgeStoreResult,
   type CodeGraphViewObservationResult,
@@ -49,8 +51,10 @@ import {
 import {validatedSnapshotLeaseDuration} from './store_maintenance_core.js';
 import {validateSnapshotPurgeInput, observeSnapshotPurge} from './store_cleanup_core.js';
 import {
+  claimOrphanProvenanceCandidates,
   claimWorktreeReconciliationCandidates,
   claimRemovedViewCleanupCandidates,
+  observeOrphanProvenanceView,
   authorizeRemovedViewCleanup,
   updateRemovedViewCleanup,
 } from './store_reconciliation.js';
@@ -89,7 +93,9 @@ type CodeGraphStoreLifecycleMethods = Pick<
   | 'promote'
   | 'observeView'
   | 'observeSnapshotPurge'
+  | 'claimOrphanProvenanceCandidates'
   | 'claimWorktreeReconciliationCandidates'
+  | 'observeOrphanProvenanceView'
   | 'prepareWorktreeReconciliationIndexes'
   | 'removeView'
   | 'purgeSnapshot'
@@ -707,6 +713,56 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
           }),
         );
       }).pipe(Effect.mapError(cause => storeError('observe code graph snapshot purge', cause))),
+    claimOrphanProvenanceCandidates: (databasePath, worktreeIds, limit, options) =>
+      withWriterGate(
+        databasePath,
+        Effect.gen(function* () {
+          yield* options?.beforeDatabaseOpen?.() ?? Effect.void;
+          if (!(yield* fs.exists(databasePath))) {
+            return {worktreeIds: []} as const satisfies CodeGraphOrphanProvenanceCandidatePage;
+          }
+          if (Option.isSome(yield* fs.readLink(databasePath).pipe(Effect.option))) {
+            return yield* Effect.fail(new CodeGraphStoreError('Code graph database target is a symbolic link.'));
+          }
+          if ((yield* fs.stat(databasePath)).type !== 'File') {
+            return yield* Effect.fail(new CodeGraphStoreError('Code graph database target is not a regular file.'));
+          }
+          return yield* useExistingDatabase(
+            databasePath,
+            Effect.gen(function* () {
+              const sql = yield* SqlClient.SqlClient;
+              yield* sql.unsafe('PRAGMA busy_timeout = 0');
+              return yield* claimOrphanProvenanceCandidates(sql, worktreeIds, limit);
+            }),
+          );
+        }),
+        options?.waitTimeoutMilliseconds ?? 0,
+      ).pipe(Effect.mapError(cause => storeError('claim code graph orphan provenance candidates', cause))),
+    observeOrphanProvenanceView: (databasePath, worktreeId, options) =>
+      withWriterGate(
+        databasePath,
+        Effect.gen(function* () {
+          yield* options?.beforeDatabaseOpen?.() ?? Effect.void;
+          if (!(yield* fs.exists(databasePath))) {
+            return {state: 'absent'} as const satisfies CodeGraphOrphanProvenanceViewObservation;
+          }
+          if (Option.isSome(yield* fs.readLink(databasePath).pipe(Effect.option))) {
+            return yield* Effect.fail(new CodeGraphStoreError('Code graph database target is a symbolic link.'));
+          }
+          if ((yield* fs.stat(databasePath)).type !== 'File') {
+            return yield* Effect.fail(new CodeGraphStoreError('Code graph database target is not a regular file.'));
+          }
+          return yield* useExistingDatabase(
+            databasePath,
+            Effect.gen(function* () {
+              const sql = yield* SqlClient.SqlClient;
+              yield* sql.unsafe('PRAGMA busy_timeout = 0');
+              return yield* observeOrphanProvenanceView(sql, worktreeId);
+            }),
+          );
+        }),
+        options?.waitTimeoutMilliseconds ?? 0,
+      ).pipe(Effect.mapError(cause => storeError('observe code graph orphan provenance view', cause))),
     claimWorktreeReconciliationCandidates: (databasePath, limit, options) =>
       withWriterGate(
         databasePath,

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -27,6 +27,8 @@ import type {
   CodeGraphMaterializationSpoolContext,
   CodeGraphMaterializedShardAssociationBatch,
   CodeGraphMaterializedShardCacheBatch,
+  CodeGraphOrphanProvenanceCandidatePage,
+  CodeGraphOrphanProvenanceViewObservation,
   CodeGraphRemovedViewCleanupAuthorizationResult,
   CodeGraphRemovedViewCleanupEntry,
   CodeGraphRemovedViewCleanupStoreOptions,
@@ -187,6 +189,17 @@ export interface CodeGraphStoreShape {
     limit: number,
     options?: CodeGraphWorktreeReconciliationClaimOptions,
   ) => Effect.Effect<readonly CodeGraphWorktreeReconciliationCandidate[], CodeGraphStoreError>;
+  readonly claimOrphanProvenanceCandidates: (
+    databasePath: string,
+    worktreeIds: readonly string[],
+    limit: number,
+    options?: CodeGraphWorktreeReconciliationClaimOptions,
+  ) => Effect.Effect<CodeGraphOrphanProvenanceCandidatePage, CodeGraphStoreError>;
+  readonly observeOrphanProvenanceView: (
+    databasePath: string,
+    worktreeId: string,
+    options?: CodeGraphWorktreeReconciliationClaimOptions,
+  ) => Effect.Effect<CodeGraphOrphanProvenanceViewObservation, CodeGraphStoreError>;
   readonly prepareWorktreeReconciliationIndexes: (
     databasePath: string,
     options?: CodeGraphWorktreeReconciliationClaimOptions,

--- a/test/unit/code-graph.diagnostics.test.ts
+++ b/test/unit/code-graph.diagnostics.test.ts
@@ -4,6 +4,7 @@ import {it as effectIt} from '@effect/vitest';
 import {Effect, FileSystem, PlatformError} from 'effect';
 import {afterEach, describe, expect, it} from 'vitest';
 import {
+  codeGraphLifecycleDiagnosticIssue,
   inspectAllCodeGraphs,
   inspectAllCodeGraphsLocal,
   renderCodeGraphDiagnostics,
@@ -55,6 +56,33 @@ describe('all-code-graph diagnostics', () => {
       THREADNOTE_CODE_GRAPH_DEEP_DIAGNOSTICS_WORKER: '1',
       THREADNOTE_HOME: '/threadnote-home',
     });
+  });
+
+  it('projects cursor recovery as one fixed path-free diagnostics issue', () => {
+    const privateMarker = '/private/repository/malformed-cursor-value';
+    const lifecycle = {
+      checkoutId: 'a'.repeat(64),
+      opportunity: 'diagnostics',
+      result: {
+        cleanup: 'none',
+        diagnostics: ['orphan-provenance-cursor-recovered'],
+        expiredLeases: 0,
+        privateMarker,
+        remaining: false,
+        retiredSnapshots: 0,
+        rowsDeleted: 0,
+        state: 'completed',
+      },
+      state: 'completed',
+    } as const;
+    const issue = codeGraphLifecycleDiagnosticIssue(lifecycle);
+
+    expect(issue).toEqual({
+      code: 'orphan-provenance-cursor-recovered',
+      message: 'Recovered an invalid orphan provenance cleanup cursor; bounded rotation restarted.',
+    });
+    expect(JSON.stringify(issue)).not.toContain(privateMarker);
+    expect(codeGraphLifecycleDiagnosticIssue({opportunity: 'diagnostics', state: 'no-target'})).toBeUndefined();
   });
 
   effectIt.effect('reports every database without a repository cwd and keeps JSON privacy-safe', () =>

--- a/test/unit/code-graph.orphan-provenance-cleanup.test.ts
+++ b/test/unit/code-graph.orphan-provenance-cleanup.test.ts
@@ -14,7 +14,7 @@ import {join} from '../helpers/node-path.js';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {it as effectIt} from '@effect/vitest';
 import {Database} from 'bun:sqlite';
-import {Effect, Layer, Path, Ref} from 'effect';
+import {Effect, FileSystem, Layer, Path, Ref} from 'effect';
 import {TestClock} from 'effect/testing';
 import fc from 'fast-check';
 import {afterEach, describe, expect} from 'vitest';
@@ -24,14 +24,20 @@ import {
   type CodeGraphWorktreeReconciliationEvidenceCandidate,
 } from '../../src/code_graph/local_provenance.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {
+  makeCodeGraphLifecycleOpportunityRunner,
+  type CodeGraphLifecycleOpportunityTarget,
+} from '../../src/code_graph/lifecycle_opportunity.js';
 import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
 import {
   CODE_GRAPH_ORPHAN_PROVENANCE_CANDIDATE_LIMIT,
+  CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC,
   makeCodeGraphOrphanProvenanceCleaner,
   type CodeGraphOrphanProvenanceCleanupDependencies,
 } from '../../src/code_graph/orphan_provenance_cleanup.js';
 import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS} from '../../src/code_graph/store_schema_metadata.js';
 import {CODE_GRAPH_EXTRACTOR_GENERATION, type RepositoryIdentity} from '../../src/code_graph/types.js';
 import {CommandExecutor} from '../../src/effect/command.js';
 import {SystemInfo} from '../../src/effect/system.js';
@@ -82,6 +88,35 @@ afterEach(() => {
 });
 
 describe('automatic orphan provenance cleanup', () => {
+  effectIt.effect('does not resolve a path anchor before bounded orphan admission finds a candidate', () =>
+    Effect.gen(function* () {
+      const cases = [
+        {
+          claimCandidates: () => Effect.die('claim should not run for an empty inventory'),
+          inspectInventory: () => Effect.succeed({state: 'ready', worktreeIds: []} as const),
+        },
+        {
+          claimCandidates: () => Effect.succeed({worktreeIds: []}),
+          inspectInventory: () => Effect.succeed({state: 'ready', worktreeIds: [targetWorktreeId]} as const),
+        },
+      ] as const;
+
+      for (const testCase of cases) {
+        const anchorResolutions = yield* Ref.make(0);
+        const dependencies = successfulDependencies({
+          claimCandidates: testCase.claimCandidates,
+          inspectInventory: testCase.inspectInventory,
+          resolveAnchor: () => Ref.update(anchorResolutions, count => count + 1).pipe(Effect.as(anchor)),
+        });
+        const cleaner = yield* makeCodeGraphOrphanProvenanceCleaner(dependencies);
+        const result = yield* cleaner.tick(pathAnchorTick());
+
+        expect(result).toEqual({reason: 'no-candidates', state: 'preserved'});
+        expect(yield* Ref.get(anchorResolutions)).toBe(0);
+      }
+    }),
+  );
+
   effectIt.effect.prop(
     'removes only when every generated authority predicate remains exact and no active view exists',
     {
@@ -181,11 +216,177 @@ describe('automatic orphan provenance cleanup', () => {
         });
         expect(yield* store.observeOrphanProvenanceView(databasePath, worktreeIds[0]!)).toEqual({state: 'absent'});
 
-        const malformed = yield* Effect.sync(() => corruptOrphanCursor(databasePath)).pipe(
+        const malformed = yield* Effect.sync(() => writeOrphanCursor(databasePath, 'malformed')).pipe(
           Effect.andThen(store.claimOrphanProvenanceCandidates(databasePath, worktreeIds, 1).pipe(Effect.exit)),
         );
-        expect(malformed._tag).toBe('Failure');
+        expect(malformed._tag).toBe('Success');
+        if (malformed._tag === 'Success') {
+          expect(malformed.value).toEqual({
+            cursorRecovery: 'invalid-format',
+            worktreeIds: [worktreeIds[0]!],
+          });
+        }
+        expect(readOrphanCursor(databasePath)).toBe(worktreeIds[0]);
+
+        const resumed = yield* store.claimOrphanProvenanceCandidates(databasePath, worktreeIds, 1);
+        expect(resumed).toEqual({worktreeIds: [worktreeIds[1]!]});
+
+        yield* Effect.sync(() => writeOrphanCursor(databasePath, 'x'.repeat(65)));
+        const structurallyInvalid = yield* store
+          .claimOrphanProvenanceCandidates(databasePath, worktreeIds, 1)
+          .pipe(Effect.exit);
+        expect(structurallyInvalid._tag).toBe('Failure');
+        expect(readOrphanCursor(databasePath)).toBe('x'.repeat(65));
+
+        yield* Effect.sync(() => writeOrphanCursor(databasePath, 'malformed'));
+        const allActive = yield* store.claimOrphanProvenanceCandidates(databasePath, [worktreeIds.at(-1)!], 1);
+        expect(allActive).toEqual({cursorRecovery: 'invalid-format', worktreeIds: []});
+        expect(readOrphanCursor(databasePath)).toBeUndefined();
+
+        const ambiguousBefore = yield* Effect.sync(() => {
+          writeSchemaMetadata(databasePath, 'ORPHAN_PROVENANCE_CURSOR', 'malformed');
+          return readSchemaMetadata(databasePath);
+        });
+        const ambiguous = yield* store.claimOrphanProvenanceCandidates(databasePath, worktreeIds, 1).pipe(Effect.exit);
+        expect(ambiguous._tag).toBe('Failure');
+        expect(readSchemaMetadata(databasePath)).toEqual(ambiguousBefore);
       }).pipe(provideTestLayer(storeLayer)),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'recovers every bounded noncanonical cursor without changing candidate membership',
+    {
+      malformedCursor: fc
+        .string({maxLength: 32})
+        .filter(value => new TextEncoder().encode(value).byteLength <= 64 && !/^[0-9a-f]{64}$/u.test(value)),
+    },
+    ({malformedCursor}) =>
+      TestClock.withLive(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-orphan-cursor-property-'});
+            const databasePath = join(root, 'repositories', checkoutId, 'graph-v3.sqlite');
+            const store = yield* CodeGraphStore;
+            yield* store.initialize(databasePath);
+            const worktreeIds = Array.from({length: 4}, (_, index) => index.toString(16).padStart(64, '0'));
+            yield* Effect.sync(() => {
+              seedActiveView(databasePath, worktreeIds[3]!);
+              writeOrphanCursor(databasePath, malformedCursor);
+            });
+
+            const recovered = yield* store.claimOrphanProvenanceCandidates(databasePath, worktreeIds, 2);
+            expect(recovered).toEqual({
+              cursorRecovery: 'invalid-format',
+              worktreeIds: [worktreeIds[0]!, worktreeIds[1]!],
+            });
+            expect(readOrphanCursor(databasePath)).toBe(worktreeIds[1]);
+
+            const resumed = yield* store.claimOrphanProvenanceCandidates(databasePath, worktreeIds, 2);
+            expect(resumed).toEqual({worktreeIds: [worktreeIds[2]!, worktreeIds[0]!]});
+            expect(new Set([...recovered.worktreeIds, ...resumed.worktreeIds])).toEqual(
+              new Set(worktreeIds.slice(0, 3)),
+            );
+          }),
+        ).pipe(provideTestLayer(storeLayer)),
+      ),
+    {fastCheck: {numRuns: 24}},
+  );
+
+  effectIt.effect('fails closed before a missing cursor can exceed bounded metadata capacity', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        for (const withRemovedViewCursor of [false, true]) {
+          const root = mkdtempSync(join(tmpdir(), 'threadnote-orphan-provenance-capacity-'));
+          temporaryRoots.push(root);
+          const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+          yield* store.initialize(databasePath);
+          if (withRemovedViewCursor) {
+            yield* Effect.sync(() =>
+              upsertSchemaMetadata(databasePath, 'removed_view_cleanup_admission_cursor', 'f'.repeat(64)),
+            );
+          }
+          const before = yield* Effect.sync(() => fillOrphanCursorMetadataCapacity(databasePath));
+
+          const claimed = yield* store
+            .claimOrphanProvenanceCandidates(databasePath, ['0'.repeat(64)], 1)
+            .pipe(Effect.exit);
+
+          expect(claimed._tag).toBe('Failure');
+          expect(readSchemaMetadata(databasePath)).toEqual(before);
+          expect(readOrphanCursor(databasePath)).toBeUndefined();
+          expect(before).toHaveLength(
+            withRemovedViewCursor
+              ? REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS
+              : REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - 1,
+          );
+        }
+      }).pipe(provideTestLayer(storeLayer)),
+    ),
+  );
+
+  effectIt.effect('advances later-database orphan cleanup across fresh explicit diagnostics runners', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const root = realpathSync(mkdtempSync(join(tmpdir(), 'threadnote-orphan-provenance-multi-')));
+        temporaryRoots.push(root);
+        const home = join(root, 'threadnote-home');
+        const fixtures = yield* Effect.forEach(
+          ['first', 'second'],
+          name => createLiveOrphanRepositoryFixture(root, home, name),
+          {concurrency: 1},
+        );
+        const [earlier, later] = [...fixtures].sort((left, right) =>
+          left.mainIdentity.checkoutId.localeCompare(right.mainIdentity.checkoutId),
+        );
+        expect(earlier).toBeDefined();
+        expect(later).toBeDefined();
+        yield* Effect.sync(() => {
+          execFileSync('git', ['-C', later!.main, 'worktree', 'remove', later!.linked], {encoding: 'utf8'});
+          writeOrphanCursor(later!.databasePath, 'malformed-cursor');
+        });
+        const maintenance = yield* CodeGraphMaintenanceCoordinator;
+        const targets: readonly CodeGraphLifecycleOpportunityTarget[] = [earlier!, later!].map(fixture => ({
+          anchorIdentity: fixture.mainIdentity,
+          checkoutId: fixture.mainIdentity.checkoutId,
+          databasePath: fixture.databasePath,
+        }));
+
+        const first = yield* makeCodeGraphLifecycleOpportunityRunner()({
+          maintenance,
+          opportunity: 'diagnostics',
+          targets,
+          threadnoteHome: home,
+        });
+        const second = yield* makeCodeGraphLifecycleOpportunityRunner()({
+          maintenance,
+          opportunity: 'diagnostics',
+          targets,
+          threadnoteHome: home,
+        });
+
+        expect(first).toMatchObject({
+          checkoutId: earlier!.mainIdentity.checkoutId,
+          result: {cleanup: 'none'},
+          state: 'completed',
+        });
+        expect(second).toMatchObject({
+          checkoutId: later!.mainIdentity.checkoutId,
+          result: {
+            cleanup: 'orphan-provenance',
+            diagnostics: [CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC],
+          },
+          state: 'completed',
+        });
+        expect(existsSync(earlier!.sidecar)).toBe(true);
+        expect(existsSync(later!.sidecar)).toBe(false);
+        expect(readFileSync(later!.mainFile, 'utf8')).toBe('main source\n');
+        const serialized = JSON.stringify([first, second]);
+        expect(serialized).not.toContain(root);
+        expect(serialized).not.toContain('malformed-cursor');
+      }).pipe(provideTestLayer(maintenanceLayer)),
     ),
   );
 
@@ -277,6 +478,16 @@ function tick() {
   } as const;
 }
 
+function pathAnchorTick() {
+  return {
+    anchorPath: anchor.repoRoot,
+    checkoutId,
+    databasePath: '/derived/graph-v3.sqlite',
+    threadnoteHome: '/derived/threadnote-home',
+    writerLockPath: '/derived/database-writer.lock',
+  } as const;
+}
+
 function seedActiveView(databasePath: string, worktreeId: string): void {
   const database = new Database(databasePath, {strict: true});
   try {
@@ -308,10 +519,92 @@ function seedActiveView(databasePath: string, worktreeId: string): void {
   }
 }
 
-function corruptOrphanCursor(databasePath: string): void {
+function writeOrphanCursor(databasePath: string, value: string): void {
   const database = new Database(databasePath, {strict: true});
   try {
-    database.query("UPDATE schema_metadata SET value = 'malformed' WHERE key = 'orphan_provenance_cursor'").run();
+    database
+      .query(
+        `INSERT INTO schema_metadata (key, value)
+         VALUES ('orphan_provenance_cursor', ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(value);
+  } finally {
+    database.close(false);
+  }
+}
+
+function writeSchemaMetadata(databasePath: string, key: string, value: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.query('INSERT INTO schema_metadata (key, value) VALUES (?, ?)').run(key, value);
+  } finally {
+    database.close(false);
+  }
+}
+
+function upsertSchemaMetadata(databasePath: string, key: string, value: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database
+      .query(
+        `INSERT INTO schema_metadata (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(key, value);
+  } finally {
+    database.close(false);
+  }
+}
+
+function readOrphanCursor(databasePath: string): string | undefined {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return (
+      database.query("SELECT value FROM schema_metadata WHERE key = 'orphan_provenance_cursor'").get() as {
+        value: string;
+      } | null
+    )?.value;
+  } finally {
+    database.close(false);
+  }
+}
+
+function readSchemaMetadata(databasePath: string): readonly {readonly key: string; readonly value: string}[] {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return database.query('SELECT key, value FROM schema_metadata ORDER BY key').all() as readonly {
+      readonly key: string;
+      readonly value: string;
+    }[];
+  } finally {
+    database.close(false);
+  }
+}
+
+function fillOrphanCursorMetadataCapacity(
+  databasePath: string,
+): readonly {readonly key: string; readonly value: string}[] {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    const admissionCursor = database
+      .query("SELECT 1 FROM schema_metadata WHERE key = 'removed_view_cleanup_admission_cursor'")
+      .get();
+    const limit =
+      admissionCursor === null
+        ? REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - 1
+        : REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS;
+    let count = Number(
+      (database.query('SELECT COUNT(*) AS count FROM schema_metadata').get() as {count: number}).count,
+    );
+    while (count < limit) {
+      database.query('INSERT INTO schema_metadata (key, value) VALUES (?, ?)').run(`capacity-${count}`, 'bounded');
+      count += 1;
+    }
+    return database.query('SELECT key, value FROM schema_metadata ORDER BY key').all() as readonly {
+      readonly key: string;
+      readonly value: string;
+    }[];
   } finally {
     database.close(false);
   }
@@ -320,52 +613,57 @@ function corruptOrphanCursor(databasePath: string): void {
 const createLiveOrphanFixture = Effect.gen(function* () {
   const root = realpathSync(mkdtempSync(join(tmpdir(), 'threadnote-orphan-provenance-live-')));
   temporaryRoots.push(root);
-  const main = join(root, 'main');
-  const linked = join(root, 'linked');
   const home = join(root, 'threadnote-home');
-  const mainFile = join(main, 'main.txt');
-  yield* Effect.sync(() => {
-    mkdirSync(main, {recursive: true});
-    execFileSync('git', ['init', '--initial-branch=main', main], {encoding: 'utf8'});
-    execFileSync('git', ['-C', main, 'config', 'user.email', 'threadnote@example.invalid'], {encoding: 'utf8'});
-    execFileSync('git', ['-C', main, 'config', 'user.name', 'Threadnote Test'], {encoding: 'utf8'});
-    writeFileSync(mainFile, 'main source\n');
-    execFileSync('git', ['-C', main, 'add', 'main.txt'], {encoding: 'utf8'});
-    execFileSync('git', ['-C', main, 'commit', '-m', 'initial'], {encoding: 'utf8'});
-    execFileSync('git', ['-C', main, 'worktree', 'add', '-b', 'linked-test', linked], {encoding: 'utf8'});
-  });
-  const mainIdentity = yield* resolveRepositoryIdentity(main);
-  const linkedIdentity = yield* resolveRepositoryIdentity(linked);
-  const association = yield* recordVerifiedCodeGraphLocalAssociation(home, linkedIdentity);
-  expect(association.state).toBe('verified');
-  const path = yield* Path.Path;
-  const layout = codeGraphLayout(path, home, mainIdentity.checkoutId, mainIdentity.worktreeId);
-  const store = yield* CodeGraphStore;
-  yield* store.initialize(layout.databasePath);
-  const sidecar = join(
-    home,
-    'indexes',
-    'code-graph',
-    'repositories',
-    mainIdentity.checkoutId,
-    'local-context',
-    'worktrees',
-    `${linkedIdentity.worktreeId}.json`,
-  );
-  expect(existsSync(sidecar)).toBe(true);
-  return {
-    databasePath: layout.databasePath,
-    home,
-    layout,
-    linked,
-    linkedIdentity,
-    main,
-    mainFile,
-    mainIdentity,
-    root,
-    sidecar,
-  };
+  return yield* createLiveOrphanRepositoryFixture(root, home, 'single');
 });
+
+const createLiveOrphanRepositoryFixture = (root: string, home: string, name: string) =>
+  Effect.gen(function* () {
+    const main = join(root, `${name}-main`);
+    const linked = join(root, `${name}-linked`);
+    const mainFile = join(main, 'main.txt');
+    yield* Effect.sync(() => {
+      mkdirSync(main, {recursive: true});
+      execFileSync('git', ['init', '--initial-branch=main', main], {encoding: 'utf8'});
+      execFileSync('git', ['-C', main, 'config', 'user.email', 'threadnote@example.invalid'], {encoding: 'utf8'});
+      execFileSync('git', ['-C', main, 'config', 'user.name', 'Threadnote Test'], {encoding: 'utf8'});
+      writeFileSync(mainFile, 'main source\n');
+      execFileSync('git', ['-C', main, 'add', 'main.txt'], {encoding: 'utf8'});
+      execFileSync('git', ['-C', main, 'commit', '-m', 'initial'], {encoding: 'utf8'});
+      execFileSync('git', ['-C', main, 'worktree', 'add', '-b', `${name}-linked-test`, linked], {encoding: 'utf8'});
+    });
+    const mainIdentity = yield* resolveRepositoryIdentity(main);
+    const linkedIdentity = yield* resolveRepositoryIdentity(linked);
+    const association = yield* recordVerifiedCodeGraphLocalAssociation(home, linkedIdentity);
+    expect(association.state).toBe('verified');
+    const path = yield* Path.Path;
+    const layout = codeGraphLayout(path, home, mainIdentity.checkoutId, mainIdentity.worktreeId);
+    const store = yield* CodeGraphStore;
+    yield* store.initialize(layout.databasePath);
+    const sidecar = join(
+      home,
+      'indexes',
+      'code-graph',
+      'repositories',
+      mainIdentity.checkoutId,
+      'local-context',
+      'worktrees',
+      `${linkedIdentity.worktreeId}.json`,
+    );
+    expect(existsSync(sidecar)).toBe(true);
+    return {
+      databasePath: layout.databasePath,
+      home,
+      layout,
+      linked,
+      linkedIdentity,
+      main,
+      mainFile,
+      mainIdentity,
+      root,
+      sidecar,
+    };
+  });
 
 function readGraphRowCounts(databasePath: string) {
   const database = new Database(databasePath, {readonly: true, strict: true});

--- a/test/unit/code-graph.orphan-provenance-cleanup.test.ts
+++ b/test/unit/code-graph.orphan-provenance-cleanup.test.ts
@@ -1,0 +1,385 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {execFileSync} from '../helpers/node-child-process.js';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from '../helpers/node-fs.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Database} from 'bun:sqlite';
+import {Effect, Layer, Path, Ref} from 'effect';
+import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
+import {afterEach, describe, expect} from 'vitest';
+import type {CodeGraphWorktreeReconciliationAuthorityObservation} from '../../src/code_graph/git_worktree_registration.js';
+import {
+  recordVerifiedCodeGraphLocalAssociation,
+  type CodeGraphWorktreeReconciliationEvidenceCandidate,
+} from '../../src/code_graph/local_provenance.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
+import {
+  CODE_GRAPH_ORPHAN_PROVENANCE_CANDIDATE_LIMIT,
+  makeCodeGraphOrphanProvenanceCleaner,
+  type CodeGraphOrphanProvenanceCleanupDependencies,
+} from '../../src/code_graph/orphan_provenance_cleanup.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {CODE_GRAPH_EXTRACTOR_GENERATION, type RepositoryIdentity} from '../../src/code_graph/types.js';
+import {CommandExecutor} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+
+const checkoutId = 'a'.repeat(64);
+const repositoryId = 'b'.repeat(64);
+const anchorWorktreeId = 'c'.repeat(64);
+const targetWorktreeId = 'd'.repeat(64);
+const registryRootIdentity = 'e'.repeat(64);
+const privateRoot = '/private/threadnote/orphan-provenance-test';
+const temporaryRoots: string[] = [];
+const storeLayer = CodeGraphStore.layer.pipe(
+  Layer.provideMerge(SystemInfo.layer),
+  Layer.provideMerge(BunServices.layer),
+);
+const maintenanceLayer = CodeGraphMaintenanceCoordinator.layer.pipe(
+  Layer.provideMerge(Layer.merge(CodeGraphStore.layer, CommandExecutor.layer)),
+  Layer.provideMerge(SystemInfo.layer),
+  Layer.provideMerge(BunServices.layer),
+);
+
+const anchor: RepositoryIdentity = {
+  caseMode: 'sensitive',
+  checkoutId,
+  displayName: 'threadnote/orphan-provenance-test',
+  gitCommonDirectory: `${privateRoot}/.git`,
+  headCommit: '1'.repeat(40),
+  objectFormat: 'sha1',
+  repositoryId,
+  repoRoot: privateRoot,
+  worktreeId: anchorWorktreeId,
+};
+
+const linkedEvidence: Extract<CodeGraphWorktreeReconciliationEvidenceCandidate, {readonly state: 'candidate'}> = {
+  canonicalWorktreePath: `${privateRoot}/removed-linked-worktree`,
+  checkoutId,
+  evidenceToken: '2'.repeat(64),
+  recordDigest: '3'.repeat(64),
+  recordIdentity: '4'.repeat(64),
+  registration: {adminNameKeys: ['5'.repeat(64)], kind: 'linked'},
+  repositoryId,
+  state: 'candidate',
+  worktreeId: targetWorktreeId,
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0).reverse()) rmSync(root, {force: true, recursive: true});
+});
+
+describe('automatic orphan provenance cleanup', () => {
+  effectIt.effect.prop(
+    'removes only when every generated authority predicate remains exact and no active view exists',
+    {
+      activeView: fc.boolean(),
+      anchorStable: fc.boolean(),
+      evidenceStable: fc.boolean(),
+      finalAbsent: fc.boolean(),
+      initialAbsent: fc.boolean(),
+      maintenanceInactive: fc.boolean(),
+      missingPath: fc.boolean(),
+      registryRootStable: fc.boolean(),
+    },
+    predicates =>
+      Effect.gen(function* () {
+        const cleanups = yield* Ref.make(0);
+        let authorityReads = 0;
+        let evidenceReads = 0;
+        let anchorReads = 0;
+        const dependencies = successfulDependencies({
+          cleanupProvenance: () => Ref.update(cleanups, count => count + 1).pipe(Effect.as({state: 'removed'})),
+          maintenanceIntentActive: () => Effect.succeed(!predicates.maintenanceInactive),
+          observeAuthority: () =>
+            Effect.sync(() => {
+              authorityReads += 1;
+              const initial = authorityReads === 1;
+              return completeAuthority({
+                missing: predicates.missingPath,
+                registryAbsent: initial ? predicates.initialAbsent : predicates.finalAbsent,
+                registryRootIdentity:
+                  !initial && !predicates.registryRootStable ? 'f'.repeat(64) : registryRootIdentity,
+              });
+            }),
+          observeView: () =>
+            Effect.succeed(
+              predicates.activeView
+                ? ({snapshotId: `cgsn_${'6'.repeat(40)}`, state: 'active'} as const)
+                : ({state: 'absent'} as const),
+            ),
+          readEvidenceCandidate: () =>
+            Effect.sync(() => {
+              evidenceReads += 1;
+              return evidenceReads > 1 && !predicates.evidenceStable
+                ? {...linkedEvidence, recordDigest: '7'.repeat(64)}
+                : linkedEvidence;
+            }),
+          resolveAnchor: () =>
+            Effect.sync(() => {
+              anchorReads += 1;
+              return anchorReads > 1 && !predicates.anchorStable ? {...anchor, repositoryId: '8'.repeat(64)} : anchor;
+            }),
+        });
+
+        const result = yield* (yield* makeCodeGraphOrphanProvenanceCleaner(dependencies)).tick(tick());
+        const expectedRemoval =
+          !predicates.activeView &&
+          predicates.anchorStable &&
+          predicates.evidenceStable &&
+          predicates.finalAbsent &&
+          predicates.initialAbsent &&
+          predicates.maintenanceInactive &&
+          predicates.missingPath &&
+          predicates.registryRootStable;
+
+        expect(result.state === 'removed').toBe(expectedRemoval);
+        expect(yield* Ref.get(cleanups)).toBe(expectedRemoval ? 1 : 0);
+      }),
+  );
+
+  effectIt.effect('keeps a durable bounded cursor and excludes an active view from sidecar candidates', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const root = mkdtempSync(join(tmpdir(), 'threadnote-orphan-provenance-cursor-'));
+        temporaryRoots.push(root);
+        const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        const worktreeIds = Array.from({length: 70}, (_, index) => index.toString(16).padStart(64, '0'));
+        yield* Effect.sync(() => seedActiveView(databasePath, worktreeIds.at(-1)!));
+
+        const pages = yield* Effect.all(
+          Array.from({length: 3}, () =>
+            store.claimOrphanProvenanceCandidates(
+              databasePath,
+              worktreeIds,
+              CODE_GRAPH_ORPHAN_PROVENANCE_CANDIDATE_LIMIT,
+              {waitTimeoutMilliseconds: 5_000},
+            ),
+          ),
+          {concurrency: 1},
+        );
+        const claimed = new Set(pages.flatMap(page => page.worktreeIds));
+        expect(pages.map(page => page.worktreeIds.length)).toEqual([32, 32, 32]);
+        expect(claimed.size).toBe(69);
+        expect(claimed.has(worktreeIds.at(-1)!)).toBe(false);
+        expect(yield* store.observeOrphanProvenanceView(databasePath, worktreeIds.at(-1)!)).toMatchObject({
+          state: 'active',
+        });
+        expect(yield* store.observeOrphanProvenanceView(databasePath, worktreeIds[0]!)).toEqual({state: 'absent'});
+
+        const malformed = yield* Effect.sync(() => corruptOrphanCursor(databasePath)).pipe(
+          Effect.andThen(store.claimOrphanProvenanceCandidates(databasePath, worktreeIds, 1).pipe(Effect.exit)),
+        );
+        expect(malformed._tag).toBe('Failure');
+      }).pipe(provideTestLayer(storeLayer)),
+    ),
+  );
+
+  effectIt.effect('removes a real deleted linked-worktree sidecar through routine maintenance', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fixture = yield* createLiveOrphanFixture;
+        const maintenance = yield* CodeGraphMaintenanceCoordinator;
+        expect(readGraphRowCounts(fixture.databasePath)).toEqual({
+          activeSnapshots: 0,
+          cleanupRows: 0,
+          snapshots: 0,
+        });
+
+        yield* Effect.sync(() =>
+          execFileSync('git', ['-C', fixture.main, 'worktree', 'remove', fixture.linked], {encoding: 'utf8'}),
+        );
+        const input = {
+          anchorIdentity: fixture.mainIdentity,
+          automaticTail: false as const,
+          checkoutId: fixture.mainIdentity.checkoutId,
+          databasePath: fixture.databasePath,
+          threadnoteHome: fixture.home,
+          writerLockPath: fixture.layout.databaseWriteLockPath,
+        };
+        const results = yield* Effect.forEach(Array.from({length: 3}), () => maintenance.tick(input), {
+          concurrency: 1,
+        });
+
+        expect(results).toContainEqual({
+          cleanup: 'orphan-provenance',
+          expiredLeases: 0,
+          remaining: true,
+          retiredSnapshots: 0,
+          rowsDeleted: 0,
+          state: 'completed',
+        });
+        expect(existsSync(fixture.sidecar)).toBe(false);
+        expect(readFileSync(fixture.mainFile, 'utf8')).toBe('main source\n');
+        expect(readGraphRowCounts(fixture.databasePath)).toEqual({
+          activeSnapshots: 0,
+          cleanupRows: 0,
+          snapshots: 0,
+        });
+        expect(JSON.stringify(results)).not.toContain(fixture.root);
+      }).pipe(provideTestLayer(maintenanceLayer)),
+    ),
+  );
+});
+
+function successfulDependencies(
+  overrides: Partial<CodeGraphOrphanProvenanceCleanupDependencies> = {},
+): CodeGraphOrphanProvenanceCleanupDependencies {
+  return {
+    claimCandidates: () => Effect.succeed({worktreeIds: [targetWorktreeId]}),
+    cleanupProvenance: () => Effect.succeed({state: 'removed'}),
+    inspectInventory: () => Effect.succeed({state: 'ready', worktreeIds: [targetWorktreeId]}),
+    maintenanceIntentActive: () => Effect.succeed(false),
+    observeAuthority: () => Effect.succeed(completeAuthority()),
+    observeView: () => Effect.succeed({state: 'absent'}),
+    readEvidenceCandidate: () => Effect.succeed(linkedEvidence),
+    resolveAnchor: () => Effect.succeed(anchor),
+    withTargetLock: (_input, _worktreeId, effect) => effect,
+    ...overrides,
+  };
+}
+
+function completeAuthority(
+  options: {readonly missing?: boolean; readonly registryAbsent?: boolean; readonly registryRootIdentity?: string} = {},
+): Extract<CodeGraphWorktreeReconciliationAuthorityObservation, {readonly state: 'complete'}> {
+  return {
+    contentDigest: '9'.repeat(64),
+    entryCount: 0,
+    pathStates: [options.missing === false ? 'present' : 'missing'],
+    registryRootIdentity: options.registryRootIdentity ?? registryRootIdentity,
+    registryRootKind: 'directory',
+    registryStates: [options.registryAbsent === false ? 'present' : 'absent'],
+    state: 'complete',
+  };
+}
+
+function tick() {
+  return {
+    anchorIdentity: anchor,
+    checkoutId,
+    databasePath: '/derived/graph-v3.sqlite',
+    threadnoteHome: '/derived/threadnote-home',
+    writerLockPath: '/derived/database-writer.lock',
+  } as const;
+}
+
+function seedActiveView(databasePath: string, worktreeId: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    const snapshotId = `cgsn_${'a'.repeat(40)}`;
+    database
+      .query(
+        `INSERT INTO repositories (id, display_name, object_format, created_at, last_used_at)
+         VALUES (?, 'threadnote/orphan-provenance-cursor', 'sha1', ?, ?)`,
+      )
+      .run(repositoryId, new Date(0).toISOString(), new Date(0).toISOString());
+    database
+      .query(
+        `INSERT INTO snapshots (
+           id, repository_id, worktree_id, commit_id, graph_content_id, base_snapshot_id, extractor_set,
+           dirty, overlay_fingerprint, state, file_count, symbol_count, edge_count, started_at, completed_at,
+           failure_summary
+         ) VALUES (?, ?, ?, ?, 'orphan-provenance-content', NULL, 'orphan-provenance-test',
+                   0, NULL, 'ready', 0, 0, 0, ?, ?, NULL)`,
+      )
+      .run(snapshotId, repositoryId, worktreeId, 'b'.repeat(40), new Date(0).toISOString(), new Date(1).toISOString());
+    database
+      .query('INSERT INTO snapshot_extractor_generations (snapshot_id, generation) VALUES (?, ?)')
+      .run(snapshotId, CODE_GRAPH_EXTRACTOR_GENERATION);
+    database
+      .query('INSERT INTO active_snapshots (worktree_id, snapshot_id, activated_at) VALUES (?, ?, ?)')
+      .run(worktreeId, snapshotId, new Date(2).toISOString());
+  } finally {
+    database.close(false);
+  }
+}
+
+function corruptOrphanCursor(databasePath: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.query("UPDATE schema_metadata SET value = 'malformed' WHERE key = 'orphan_provenance_cursor'").run();
+  } finally {
+    database.close(false);
+  }
+}
+
+const createLiveOrphanFixture = Effect.gen(function* () {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'threadnote-orphan-provenance-live-')));
+  temporaryRoots.push(root);
+  const main = join(root, 'main');
+  const linked = join(root, 'linked');
+  const home = join(root, 'threadnote-home');
+  const mainFile = join(main, 'main.txt');
+  yield* Effect.sync(() => {
+    mkdirSync(main, {recursive: true});
+    execFileSync('git', ['init', '--initial-branch=main', main], {encoding: 'utf8'});
+    execFileSync('git', ['-C', main, 'config', 'user.email', 'threadnote@example.invalid'], {encoding: 'utf8'});
+    execFileSync('git', ['-C', main, 'config', 'user.name', 'Threadnote Test'], {encoding: 'utf8'});
+    writeFileSync(mainFile, 'main source\n');
+    execFileSync('git', ['-C', main, 'add', 'main.txt'], {encoding: 'utf8'});
+    execFileSync('git', ['-C', main, 'commit', '-m', 'initial'], {encoding: 'utf8'});
+    execFileSync('git', ['-C', main, 'worktree', 'add', '-b', 'linked-test', linked], {encoding: 'utf8'});
+  });
+  const mainIdentity = yield* resolveRepositoryIdentity(main);
+  const linkedIdentity = yield* resolveRepositoryIdentity(linked);
+  const association = yield* recordVerifiedCodeGraphLocalAssociation(home, linkedIdentity);
+  expect(association.state).toBe('verified');
+  const path = yield* Path.Path;
+  const layout = codeGraphLayout(path, home, mainIdentity.checkoutId, mainIdentity.worktreeId);
+  const store = yield* CodeGraphStore;
+  yield* store.initialize(layout.databasePath);
+  const sidecar = join(
+    home,
+    'indexes',
+    'code-graph',
+    'repositories',
+    mainIdentity.checkoutId,
+    'local-context',
+    'worktrees',
+    `${linkedIdentity.worktreeId}.json`,
+  );
+  expect(existsSync(sidecar)).toBe(true);
+  return {
+    databasePath: layout.databasePath,
+    home,
+    layout,
+    linked,
+    linkedIdentity,
+    main,
+    mainFile,
+    mainIdentity,
+    root,
+    sidecar,
+  };
+});
+
+function readGraphRowCounts(databasePath: string) {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return {
+      activeSnapshots: Number(
+        (database.query('SELECT COUNT(*) AS count FROM active_snapshots').get() as {count: number}).count,
+      ),
+      cleanupRows: Number(
+        (database.query('SELECT COUNT(*) AS count FROM removed_view_cleanup').get() as {count: number}).count,
+      ),
+      snapshots: Number((database.query('SELECT COUNT(*) AS count FROM snapshots').get() as {count: number}).count),
+    };
+  } finally {
+    database.close(false);
+  }
+}


### PR DESCRIPTION
## Summary

- page private worktree provenance identities with a closed 4,096-entry ceiling and a durable, independently bounded SQLite cursor
- require duplicate missing-path and absent-Git-registration authority, then prove no active view under the target builder lock before deleting an unchanged sidecar
- integrate orphan cleanup with the existing bounded reconciliation lane and the #255 durable diagnostics target-by-lane rotation, so a later database advances across fresh CLI processes without adding healthy status/catalog cursor I/O
- recover only exact, bounded semantic corruption of the advisory orphan cursor in the existing writer transaction; oversized values, case ambiguity, and exhausted metadata capacity remain fail-closed
- surface recovery through one fixed path-free receipt and diagnostics code without retaining the corrupt value, path, or raw cause

## Defect

Removed linked worktrees that never owned an active graph snapshot had no active-snapshot, snapshot, or removed-view-cleanup row. Automatic reconciliation only admitted active snapshots, so their private local provenance sidecars remained indefinitely.

A malformed advisory orphan cursor could also disable the new cleanup permanently through a generic schema-unavailable result. The promoted implementation now resets only bounded exact-key semantic invalidity, preserves all destructive authority gates, and reserves the absent authoritative removed-view cursor slot before adding metadata.

## Verification

- focused affected suite: 4 files / 41 tests passed
- live two-database regression: independent fresh diagnostics runners service the earlier healthy database, then delete the later orphan-only sidecar through #255 explicit reconciliation rotation
- cursor recovery Fast-check property: 24 runs over bounded noncanonical values; eligible membership remains exact, active views stay excluded, and the next claim resumes from a canonical cursor
- concrete store regressions: one-shot recovery receipt, all-active cursor deletion, oversized/case-ambiguous fail-closed behavior, and both 65/66-row metadata capacity reservations
- path-free CLI/Manager diagnostics projection covered with a fixed recovery code
- root/test/site typechecks, full lint and file-length checks, standalone build, Prettier, and diff check passed after rebase onto `cd0c61d1`

The shared global development runtime was intentionally not replaced because the active 4.4 release task owns it; the exact live production coordinator path was exercised in temporary isolated fixtures.