### PR TITLE
perf(context-brief): defer file relocation scans

### DIFF
--- a/src/code_graph/citation_primitives.ts
+++ b/src/code_graph/citation_primitives.ts
@@ -37,8 +37,19 @@ export interface CodeGraphEffectiveSymbolLocatorMatches {
   readonly truncated: boolean;
 }
 
+export interface CodeGraphCitationFileRelocationFallbackV1 {
+  readonly contentHash: string;
+  readonly path: string;
+}
+
 export interface CodeGraphEffectiveSnapshotCitationEvidenceRequest {
   readonly contentHashes?: readonly string[];
+  /**
+   * Query a content hash only when its paired original path is absent from the
+   * effective snapshot. This keeps the common exact/changed path proof inside
+   * the same database session without paying for an unused relocation scan.
+   */
+  readonly fileRelocationFallbacks?: readonly CodeGraphCitationFileRelocationFallbackV1[];
   /** Defaults to 2 and is capped by CODE_GRAPH_CITATION_QUERY_MAX_MATCHES_PER_TARGET. */
   readonly limitPerContentHash?: number;
   /** Defaults to 2 and is capped by CODE_GRAPH_CITATION_QUERY_MAX_MATCHES_PER_TARGET. */
@@ -56,6 +67,7 @@ export interface CodeGraphEffectiveSnapshotCitationEvidence {
    * deletion result; every missing or partial proof must remain `incomplete`.
    */
   readonly fileInventoryCoverage: 'complete' | 'incomplete';
+  /** Eager hashes plus fallback hashes whose paired original path was absent. */
   readonly filesByContentHashes: readonly CodeGraphEffectiveFileHashMatches[];
   readonly filesByPaths: readonly CodeGraphEffectiveFilePathObservation[];
   readonly symbolsByIds: readonly CodeGraphSymbol[];

--- a/src/code_graph/citation_primitives.ts
+++ b/src/code_graph/citation_primitives.ts
@@ -42,6 +42,19 @@ export interface CodeGraphCitationFileRelocationFallbackV1 {
   readonly path: string;
 }
 
+/** Select eager hashes plus fallbacks whose original path is absent. */
+export function selectCodeGraphCitationContentHashTargets(
+  eagerContentHashes: readonly string[],
+  fileRelocationFallbacks: readonly CodeGraphCitationFileRelocationFallbackV1[],
+  presentPaths: ReadonlySet<string>,
+): readonly string[] {
+  const requestedContentHashes = new Set(eagerContentHashes);
+  for (const fallback of fileRelocationFallbacks) {
+    if (!presentPaths.has(fallback.path)) requestedContentHashes.add(fallback.contentHash);
+  }
+  return [...requestedContentHashes];
+}
+
 export interface CodeGraphEffectiveSnapshotCitationEvidenceRequest {
   readonly contentHashes?: readonly string[];
   /**

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -46,6 +46,7 @@ export {
   type CodeGraphEffectiveSnapshotCitationEvidence,
   type CodeGraphEffectiveSnapshotCitationEvidenceRequest,
   type CodeGraphEffectiveSymbolLocatorMatches,
+  type CodeGraphCitationFileRelocationFallbackV1,
   type CodeGraphSourceSpanFragmentFailureReason,
   type CodeGraphSourceSpanCanonicalizerV1,
   type CodeGraphSourceSpanFragmentResult,

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -41,6 +41,7 @@ export {
   CODE_GRAPH_SOURCE_SPAN_CANONICALIZATION_V1,
   codeGraphSourceSpanFragment,
   createCodeGraphSourceSpanCanonicalizer,
+  selectCodeGraphCitationContentHashTargets,
   type CodeGraphEffectiveFileHashMatches,
   type CodeGraphEffectiveFilePathObservation,
   type CodeGraphEffectiveSnapshotCitationEvidence,

--- a/src/code_graph/store_citation_queries.ts
+++ b/src/code_graph/store_citation_queries.ts
@@ -3,6 +3,7 @@ import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {
   CODE_GRAPH_CITATION_QUERY_MAX_MATCHES_PER_TARGET,
   CODE_GRAPH_CITATION_QUERY_MAX_TARGETS,
+  selectCodeGraphCitationContentHashTargets,
   type CodeGraphCitationFileRelocationFallbackV1,
   type CodeGraphEffectiveFileHashMatches,
   type CodeGraphEffectiveFilePathObservation,
@@ -440,19 +441,6 @@ function inventoryFileFromRow(row: EffectiveFileRow): CodeGraphInventoryFile {
     size: Number(row.size),
     source: row.source,
   };
-}
-
-/** @internal Deterministic target selection shared with bounded property tests. */
-export function selectCodeGraphCitationContentHashTargets(
-  eagerContentHashes: readonly string[],
-  fileRelocationFallbacks: readonly CodeGraphCitationFileRelocationFallbackV1[],
-  presentPaths: ReadonlySet<string>,
-): readonly string[] {
-  const requestedContentHashes = new Set(eagerContentHashes);
-  for (const fallback of fileRelocationFallbacks) {
-    if (!presentPaths.has(fallback.path)) requestedContentHashes.add(fallback.contentHash);
-  }
-  return [...requestedContentHashes];
 }
 
 function validateCitationPaths(paths: readonly string[]) {

--- a/src/code_graph/store_citation_queries.ts
+++ b/src/code_graph/store_citation_queries.ts
@@ -3,6 +3,7 @@ import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {
   CODE_GRAPH_CITATION_QUERY_MAX_MATCHES_PER_TARGET,
   CODE_GRAPH_CITATION_QUERY_MAX_TARGETS,
+  type CodeGraphCitationFileRelocationFallbackV1,
   type CodeGraphEffectiveFileHashMatches,
   type CodeGraphEffectiveFilePathObservation,
   type CodeGraphEffectiveSnapshotCitationEvidence,
@@ -292,8 +293,17 @@ export const selectEffectiveSnapshotSymbolsBySemanticLocators = Effect.fn(
  */
 export const selectEffectiveSnapshotCitationEvidence = Effect.fn('codeGraph.selectEffectiveSnapshotCitationEvidence')(
   function* (snapshotId: string, request: CodeGraphEffectiveSnapshotCitationEvidenceRequest) {
-    const paths = yield* validateCitationPaths(request.paths ?? []);
-    const contentHashes = yield* validateCitationContentHashes(request.contentHashes ?? []);
+    const fileRelocationFallbacks = yield* validateCitationFileRelocationFallbacks(
+      request.fileRelocationFallbacks ?? [],
+    );
+    const eagerPaths = yield* validateCitationPaths(request.paths ?? []);
+    const paths = yield* validateCitationPaths([
+      ...new Set([...eagerPaths, ...fileRelocationFallbacks.map(fallback => fallback.path)]),
+    ]);
+    const eagerContentHashes = yield* validateCitationContentHashes(request.contentHashes ?? []);
+    yield* validateCitationContentHashes([
+      ...new Set([...eagerContentHashes, ...fileRelocationFallbacks.map(fallback => fallback.contentHash)]),
+    ]);
     const symbolIds = yield* validateCitationSymbolIds(request.symbolIds ?? []);
     const semanticLocators = yield* validateSemanticLocators(request.semanticLocators ?? []);
     const limitPerContentHash = yield* validateMatchLimit(request.limitPerContentHash ?? 2);
@@ -326,6 +336,11 @@ export const selectEffectiveSnapshotCitationEvidence = Effect.fn('codeGraph.sele
             sql,
             codeGraphEffectiveFilesByPathsQueryStatement(snapshotId, baseSnapshotId, paths),
           );
+    const contentHashes = selectCodeGraphCitationContentHashTargets(
+      eagerContentHashes,
+      fileRelocationFallbacks,
+      new Set(pathRows.flatMap(row => (row.path === null ? [] : [row.requested_path]))),
+    );
     const hashRows =
       contentHashes.length === 0
         ? []
@@ -427,29 +442,59 @@ function inventoryFileFromRow(row: EffectiveFileRow): CodeGraphInventoryFile {
   };
 }
 
+/** @internal Deterministic target selection shared with bounded property tests. */
+export function selectCodeGraphCitationContentHashTargets(
+  eagerContentHashes: readonly string[],
+  fileRelocationFallbacks: readonly CodeGraphCitationFileRelocationFallbackV1[],
+  presentPaths: ReadonlySet<string>,
+): readonly string[] {
+  const requestedContentHashes = new Set(eagerContentHashes);
+  for (const fallback of fileRelocationFallbacks) {
+    if (!presentPaths.has(fallback.path)) requestedContentHashes.add(fallback.contentHash);
+  }
+  return [...requestedContentHashes];
+}
+
 function validateCitationPaths(paths: readonly string[]) {
-  return validateUniqueTargets(
-    paths,
-    path => path,
-    path =>
-      typeof path === 'string' &&
-      path.length > 0 &&
-      path.length <= 4_096 &&
-      !path.includes('\0') &&
-      !path.includes('\\') &&
-      !path.startsWith('/') &&
-      path.split('/').every(segment => segment.length > 0 && segment !== '.' && segment !== '..'),
-    'repository-relative code graph path',
-  );
+  return validateUniqueTargets(paths, path => path, validCitationPath, 'repository-relative code graph path');
 }
 
 function validateCitationContentHashes(contentHashes: readonly string[]) {
   return validateUniqueTargets(
     contentHashes,
     contentHash => contentHash,
-    contentHash => typeof contentHash === 'string' && /^[0-9a-f]{64}$/u.test(contentHash),
+    validCitationContentHash,
     'SHA-256 code graph content hash',
   );
+}
+
+function validateCitationFileRelocationFallbacks(fallbacks: readonly CodeGraphCitationFileRelocationFallbackV1[]) {
+  return validateUniqueTargets(
+    fallbacks,
+    fallback => `${fallback.path}\0${fallback.contentHash}`,
+    fallback =>
+      typeof fallback === 'object' &&
+      fallback !== null &&
+      validCitationPath(fallback.path) &&
+      validCitationContentHash(fallback.contentHash),
+    'code graph file relocation fallback',
+  );
+}
+
+function validCitationPath(path: unknown): path is string {
+  return (
+    typeof path === 'string' &&
+    path.length > 0 &&
+    path.length <= 4_096 &&
+    !path.includes('\0') &&
+    !path.includes('\\') &&
+    !path.startsWith('/') &&
+    path.split('/').every(segment => segment.length > 0 && segment !== '.' && segment !== '..')
+  );
+}
+
+function validCitationContentHash(contentHash: unknown): contentHash is string {
+  return typeof contentHash === 'string' && /^[0-9a-f]{64}$/u.test(contentHash);
 }
 
 function validateCitationSymbolIds(symbolIds: readonly string[]) {

--- a/src/context_brief/citation_validation.ts
+++ b/src/context_brief/citation_validation.ts
@@ -267,10 +267,12 @@ const validateRepositoryTasks = Effect.fn('contextBrief.validateRepositoryCitati
         );
         const locators = symbolCitations.map(symbolLocator);
         const evidence = yield* store.effectiveSnapshotCitationEvidence(repository.status.databasePath, snapshot.id, {
-          contentHashes: citations.map(citation => citation.fileContentHash.value),
+          fileRelocationFallbacks: citations.map(citation => ({
+            contentHash: citation.fileContentHash.value,
+            path: citation.path,
+          })),
           limitPerContentHash: RELOCATION_MATCH_LIMIT,
           limitPerSemanticLocator: RELOCATION_MATCH_LIMIT,
-          paths: citations.map(citation => citation.path),
           semanticLocators: locators,
           symbolIds: symbolCitations.flatMap(citation =>
             citation.target.kind === 'symbol' ? [citation.target.nodeId] : [],

--- a/src/evaluation/context-brief-citation-runtime.ts
+++ b/src/evaluation/context-brief-citation-runtime.ts
@@ -6,6 +6,7 @@ import type {
 import {codeGraphCommittedFileContentHash} from '../code_graph/content_identity.js';
 import {CodeGraphQueryService} from '../code_graph/query.js';
 import {CodeGraphStore} from '../code_graph/store.js';
+import {selectCodeGraphCitationContentHashTargets} from '../code_graph/store_citation_queries.js';
 import type {CodeGraphStoreShape} from '../code_graph/store_shape.js';
 import type {CodeGraphInventoryFile, CodeGraphSnapshot, CodeGraphStatus} from '../code_graph/types.js';
 import {
@@ -253,15 +254,23 @@ function makeScenarioGraph(
         ? [sourceFile]
         : currentFiles(fixture.source.path, fixture.source.content, sourceHash, changedHash, scenario.kind);
     const byPath = new Map(files.map(file => [file.path, file]));
+    const paths = [
+      ...new Set([...(request.paths ?? []), ...(request.fileRelocationFallbacks ?? []).map(item => item.path)]),
+    ];
+    const contentHashes = selectCodeGraphCitationContentHashTargets(
+      [...new Set(request.contentHashes ?? [])],
+      request.fileRelocationFallbacks ?? [],
+      new Set(files.map(file => file.path)),
+    );
     return {
       fileInventoryCoverage:
         phase === 'capture' || scenario.snapshotState === 'current-complete' ? 'complete' : 'incomplete',
-      filesByContentHashes: (request.contentHashes ?? []).map(contentHash => ({
+      filesByContentHashes: contentHashes.map(contentHash => ({
         contentHash,
         files: files.filter(file => file.contentHash === contentHash),
         truncated: false,
       })),
-      filesByPaths: (request.paths ?? []).map(repositoryPath => ({
+      filesByPaths: paths.map(repositoryPath => ({
         ...(byPath.get(repositoryPath) === undefined ? {} : {file: byPath.get(repositoryPath)!}),
         path: repositoryPath,
       })),

--- a/src/evaluation/context-brief-citation-runtime.ts
+++ b/src/evaluation/context-brief-citation-runtime.ts
@@ -1,12 +1,12 @@
 import {Effect, FileSystem, Layer, Path} from 'effect';
-import type {
-  CodeGraphEffectiveSnapshotCitationEvidence,
-  CodeGraphEffectiveSnapshotCitationEvidenceRequest,
+import {
+  selectCodeGraphCitationContentHashTargets,
+  type CodeGraphEffectiveSnapshotCitationEvidence,
+  type CodeGraphEffectiveSnapshotCitationEvidenceRequest,
 } from '../code_graph/citation_primitives.js';
 import {codeGraphCommittedFileContentHash} from '../code_graph/content_identity.js';
 import {CodeGraphQueryService} from '../code_graph/query.js';
 import {CodeGraphStore} from '../code_graph/store.js';
-import {selectCodeGraphCitationContentHashTargets} from '../code_graph/store_citation_queries.js';
 import type {CodeGraphStoreShape} from '../code_graph/store_shape.js';
 import type {CodeGraphInventoryFile, CodeGraphSnapshot, CodeGraphStatus} from '../code_graph/types.js';
 import {

--- a/test/unit/code-graph.citation-primitives.test.ts
+++ b/test/unit/code-graph.citation-primitives.test.ts
@@ -12,6 +12,7 @@ import {
   createCodeGraphSourceSpanCanonicalizer,
   type CodeGraphSymbolSemanticLocatorV1,
 } from '../../src/code_graph/store.js';
+import {selectCodeGraphCitationContentHashTargets} from '../../src/code_graph/store_citation_queries.js';
 import {
   codeGraphCommittedFileContentHash,
   codeGraphFileContentHashMatchesBytes,
@@ -56,6 +57,45 @@ const inheritedLocator = {
 } as const satisfies CodeGraphSymbolSemanticLocatorV1;
 
 describe('code graph citation query primitives', () => {
+  effectIt.prop(
+    'queries eager hashes and only missing-path relocation fallbacks in first-seen order',
+    {
+      eagerContentHashes: FC.array(
+        FC.integer({max: 5, min: 0}).map(value => String(value).repeat(64)),
+        {
+          maxLength: 8,
+        },
+      ),
+      fallbacks: FC.array(
+        FC.record({
+          contentHash: FC.integer({max: 5, min: 0}).map(value => String(value).repeat(64)),
+          path: FC.integer({max: 5, min: 0}).map(value => `src/${value}.ts`),
+        }),
+        {maxLength: 12},
+      ),
+      presentPaths: FC.uniqueArray(
+        FC.integer({max: 5, min: 0}).map(value => `src/${value}.ts`),
+        {
+          maxLength: 6,
+        },
+      ),
+    },
+    ({eagerContentHashes, fallbacks, presentPaths}) => {
+      const potential = [...new Set([...eagerContentHashes, ...fallbacks.map(fallback => fallback.contentHash)])];
+      const present = new Set(presentPaths);
+      const selected = selectCodeGraphCitationContentHashTargets([...new Set(eagerContentHashes)], fallbacks, present);
+      const expected = [
+        ...new Set([
+          ...eagerContentHashes,
+          ...fallbacks.filter(fallback => !present.has(fallback.path)).map(fallback => fallback.contentHash),
+        ]),
+      ];
+      expect(selected).toEqual(expected);
+      expect(selected.every(contentHash => potential.includes(contentHash))).toBe(true);
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
   effectIt.prop(
     'matches current Git-blob envelopes and legacy raw hashes to the same source bytes',
     {
@@ -256,6 +296,37 @@ describe('code graph citation query primitives', () => {
         expect(combined.symbolsBySemanticLocators[0]).toEqual(
           expect.objectContaining({truncated: true, symbols: [expect.objectContaining({id: 'symbol-new-target-b'})]}),
         );
+
+        const exactPathFallback = yield* store.effectiveSnapshotCitationEvidence(databasePath, currentSnapshotId, {
+          fileRelocationFallbacks: [{contentHash: keepHash, path: 'src/keep.ts'}],
+        });
+        expect(exactPathFallback.filesByPaths).toEqual([
+          {file: expect.objectContaining({contentHash: keepHash}), path: 'src/keep.ts'},
+        ]);
+        expect(exactPathFallback.filesByContentHashes).toEqual([]);
+
+        const duplicateMaximumFallback = yield* store.effectiveSnapshotCitationEvidence(
+          databasePath,
+          currentSnapshotId,
+          {
+            fileRelocationFallbacks: Array.from({length: 400}, () => ({
+              contentHash: keepHash,
+              path: 'src/keep.ts',
+            })),
+            paths: Array.from({length: 400}, () => 'src/keep.ts'),
+          },
+        );
+        expect(duplicateMaximumFallback.filesByPaths).toHaveLength(1);
+        expect(duplicateMaximumFallback.filesByContentHashes).toEqual([]);
+
+        const missingPathFallback = yield* store.effectiveSnapshotCitationEvidence(databasePath, currentSnapshotId, {
+          fileRelocationFallbacks: [{contentHash: duplicateHash, path: 'src/missing.ts'}],
+        });
+        expect(missingPathFallback.filesByPaths).toEqual([{path: 'src/missing.ts'}]);
+        expect(missingPathFallback.filesByContentHashes[0]?.files.map(file => file.path)).toEqual([
+          'src/base-copy.ts',
+          'src/current-copy.ts',
+        ]);
 
         yield* withCitationDatabase(databasePath, database => {
           const pathPlan = queryPlan(

--- a/test/unit/code-graph.citation-primitives.test.ts
+++ b/test/unit/code-graph.citation-primitives.test.ts
@@ -10,9 +10,9 @@ import {
   codeGraphSourceSpanFragment,
   CodeGraphStore,
   createCodeGraphSourceSpanCanonicalizer,
+  selectCodeGraphCitationContentHashTargets,
   type CodeGraphSymbolSemanticLocatorV1,
 } from '../../src/code_graph/store.js';
-import {selectCodeGraphCitationContentHashTargets} from '../../src/code_graph/store_citation_queries.js';
 import {
   codeGraphCommittedFileContentHash,
   codeGraphFileContentHashMatchesBytes,

--- a/test/unit/memory-code-citation-capture.test.ts
+++ b/test/unit/memory-code-citation-capture.test.ts
@@ -167,14 +167,25 @@ function citationFixture(root: string) {
   let validationSessions = 0;
   const evidence = (request: CodeGraphEffectiveSnapshotCitationEvidenceRequest) => {
     evidenceCalls += 1;
+    const paths = [
+      ...new Set([...(request.paths ?? []), ...(request.fileRelocationFallbacks ?? []).map(item => item.path)]),
+    ];
+    const contentHashes = [
+      ...new Set([
+        ...(request.contentHashes ?? []),
+        ...(request.fileRelocationFallbacks ?? [])
+          .filter(item => item.path !== file.path)
+          .map(item => item.contentHash),
+      ]),
+    ];
     return {
       fileInventoryCoverage: 'complete',
-      filesByContentHashes: (request.contentHashes ?? []).map(contentHash => ({
+      filesByContentHashes: contentHashes.map(contentHash => ({
         contentHash,
         files: contentHash === SOURCE_HASH ? [file] : [],
         truncated: false,
       })),
-      filesByPaths: (request.paths ?? []).map(repositoryPath => ({
+      filesByPaths: paths.map(repositoryPath => ({
         ...(repositoryPath === file.path ? {file} : {}),
         path: repositoryPath,
       })),


### PR DESCRIPTION
## Summary

- query citation paths before requesting content-hash relocation evidence
- request relocation candidates only for citations whose original path is absent, within the same repository evidence session
- preserve eager hash callers and enforce unique combined request limits after stable deduplication
- model the fallback contract in the deterministic evaluation runtime

## Diagnosis

The exact-main scale fixture uses existing file citations. Validation nevertheless ran the content-hash relocation query for every citation. That query is a four-branch `UNION ALL` with a `ROW_NUMBER` window and its result is never consulted when the original path exists. This change skips that work on the common/exact path while retaining it for moved or deleted files. No latency budget was changed.

The failed release run also showed substantial runner variance: the same runtime had previously passed at 482/903 ms, failed once at 520/966 ms, and a retry rose to 854/2129 ms despite unchanged correctness. The unnecessary relocation query is still a justified source-level optimization and restores margin rather than treating host noise as correctness evidence.

## Correctness

- existing-path file and symbol citations skip relocation lookup
- missing-path citations still receive content-hash relocation candidates
- eager content-hash callers retain their existing behavior
- eager and fallback inputs are validated independently, stably deduplicated, and then checked against the combined unique target limit
- bounded Fast-check property covers selection, ordering, deduplication, and the missing-path predicate

## Local verification

- `bun --bun vitest run test/unit/code-graph.citation-primitives.test.ts test/unit/memory-code-citation-capture.test.ts test/unit/context-brief-citations.test.ts test/unit/context-brief-citation-scale-benchmark.test.ts test/unit/evaluation.context-brief-citation-runtime.test.ts` (30/30)
- `bun --bun vitest run test/integration/code-graph.cross-session-incremental.test.ts` (17/17)
- `bun --bun tsc --noEmit`
- `bun --bun tsc -p test/tsconfig.json --noEmit`
- commit hook: lint, formatting, production/test/site typechecks

A controlled 25-sample local comparison at the same 1,500-memory shape improved workset-50 p95 from 396.260 ms to 372.591 ms (~6%). Workset-128 was noise-flat (728.215 ms vs 729.936 ms). The authoritative 100k corpus scale workflow is required before release; these local numbers are diagnostic only.