### PR TITLE
fix(graph): complete absent residual provenance cleanup

### DIFF
--- a/src/code_graph/local_provenance.ts
+++ b/src/code_graph/local_provenance.ts
@@ -519,6 +519,14 @@ const cleanupMissingCodeGraphLocalProvenanceUnsafe = Effect.fn('codeGraph.cleanu
     if (!validTarget(target)) return {state: 'unavailable'} as const satisfies CodeGraphLocalProvenanceCleanupResult;
     const evidence = yield* readCodeGraphLocalReconciliationEvidence(threadnoteHome, target);
     if (evidence.state !== 'verified') {
+      if (
+        evidence.state === 'legacy-unknown' &&
+        options.expectedEvidence !== undefined &&
+        validLocalProvenanceCleanupEvidenceTarget(options.expectedEvidence, target) &&
+        (yield* codeGraphLocalProvenanceSidecarAbsent(threadnoteHome, target))
+      ) {
+        return {state: 'not-found'} as const satisfies CodeGraphLocalProvenanceCleanupResult;
+      }
       return {
         observedState: evidence.state,
         state: 'preserved',
@@ -583,6 +591,30 @@ const cleanupMissingCodeGraphLocalProvenanceUnsafe = Effect.fn('codeGraph.cleanu
     return {state: 'removed'} as const satisfies CodeGraphLocalProvenanceCleanupResult;
   },
 );
+
+const codeGraphLocalProvenanceSidecarAbsent = Effect.fn('codeGraph.localProvenanceSidecarAbsent')(function* (
+  threadnoteHome: string,
+  target: CodeGraphLocalAssociationTarget,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const checkoutRoot = yield* inspectCheckoutRoot(fs, path, threadnoteHome, target.checkoutId);
+  if (checkoutRoot === undefined) return true;
+
+  const localContext = path.join(checkoutRoot, LOCAL_CONTEXT_DIRECTORY);
+  if (Option.isSome(yield* fs.readLink(localContext).pipe(Effect.option))) return false;
+  if (!(yield* fs.exists(localContext))) return true;
+  const canonicalContext = yield* inspectPrivateContainedDirectory(fs, path, checkoutRoot, localContext);
+  const worktrees = path.join(canonicalContext, LOCAL_WORKTREES_DIRECTORY);
+  if (Option.isSome(yield* fs.readLink(worktrees).pipe(Effect.option))) return false;
+  if (!(yield* fs.exists(worktrees))) return true;
+  const canonicalWorktrees = yield* inspectPrivateContainedDirectory(fs, path, canonicalContext, worktrees);
+
+  const file = path.join(canonicalWorktrees, `${target.worktreeId}.json`);
+  if (Option.isSome(yield* fs.readLink(file).pipe(Effect.option))) return false;
+  if (Option.isSome(yield* optionOnNotFound(fs.stat(file)))) return false;
+  return Option.isNone(yield* fs.readLink(file).pipe(Effect.option)) && !(yield* fs.exists(file));
+});
 
 export const cleanupMissingCodeGraphLocalProvenance = Effect.fn('codeGraph.cleanupMissingLocalProvenance')(function* (
   threadnoteHome: string,
@@ -697,6 +729,20 @@ function localProvenanceCleanupEvidenceMatchesCandidate(
     evidence.repositoryId === candidate.record.repositoryId &&
     evidence.recordDigest === candidate.recordDigest &&
     evidence.recordIdentity === candidate.recordIdentity
+  );
+}
+
+function validLocalProvenanceCleanupEvidenceTarget(
+  evidence: CodeGraphLocalProvenanceCleanupEvidence,
+  target: CodeGraphLocalAssociationTarget,
+): boolean {
+  return (
+    evidence.checkoutId === target.checkoutId &&
+    evidence.worktreeId === target.worktreeId &&
+    (target.repositoryId === undefined || evidence.repositoryId === target.repositoryId) &&
+    HASH_ID.test(evidence.repositoryId) &&
+    HASH_ID.test(evidence.recordDigest) &&
+    HASH_ID.test(evidence.recordIdentity)
   );
 }
 

--- a/test/unit/code-graph.local-provenance-cleanup.test.ts
+++ b/test/unit/code-graph.local-provenance-cleanup.test.ts
@@ -34,6 +34,11 @@ describe('code graph local provenance cleanup', () => {
           Effect.gen(function* () {
             const fixture = yield* provenanceCleanupFixture;
             const beforeSource = yield* fixture.fs.readFileString(fixture.sourceSentinel);
+            const expectedEvidence = yield* captureCodeGraphLocalProvenanceCleanupEvidence(fixture.home, {
+              checkoutId: CHECKOUT_ID,
+              worktreeId: WORKTREE_ID,
+            });
+            expect(expectedEvidence).toBeDefined();
             const result = yield* cleanupMissingCodeGraphLocalProvenance(fixture.home, {
               checkoutId: CHECKOUT_ID,
               worktreeId: WORKTREE_ID,
@@ -43,6 +48,13 @@ describe('code graph local provenance cleanup', () => {
             expect(yield* fixture.fs.exists(fixture.sidecar)).toBe(false);
             expect(yield* fixture.fs.exists(fixture.neighborSidecar)).toBe(true);
             expect(yield* fixture.fs.readFileString(fixture.sourceSentinel)).toBe(beforeSource);
+            expect(
+              yield* cleanupMissingCodeGraphLocalProvenance(
+                fixture.home,
+                {checkoutId: CHECKOUT_ID, worktreeId: WORKTREE_ID},
+                {expectedEvidence: expectedEvidence!},
+              ),
+            ).toEqual({state: 'not-found'});
           }),
         ),
     );

--- a/test/unit/code-graph.maintenance-residual-live.test.ts
+++ b/test/unit/code-graph.maintenance-residual-live.test.ts
@@ -47,6 +47,7 @@ describe('live removed-view residual maintenance', () => {
         const path = yield* Path.Path;
         const coordinator = yield* CodeGraphMaintenanceCoordinator;
         yield* seedExactTerminalBuildStatus(fs, path, fixture.home);
+        const provenanceSidecar = yield* seedExactProvenance(fs, path, fixture.home);
 
         const foreground = yield* removeCodeGraphView(
           fixture.home,
@@ -60,10 +61,11 @@ describe('live removed-view residual maintenance', () => {
 
         expect(foreground).toMatchObject({
           applied: true,
-          cleanup: {vectors: null},
+          cleanup: {provenance: {state: 'removed'}, vectors: null},
           state: 'removed',
           warnings: [],
         });
+        expect(yield* fs.exists(provenanceSidecar)).toBe(false);
         expect(readVectorCounts(fixture.vectorDatabasePath!)).toMatchObject({pointers: 1});
         expect(readCleanupRow(fixture.databasePath)).toMatchObject({phase: 'vector-pointers', revision: 0});
 
@@ -341,6 +343,34 @@ function seedExactTerminalBuildStatus(fs: FileSystem.FileSystem, path: Path.Path
       `${JSON.stringify({buildId: BUILD_ID, schemaVersion: 1, worktreePath: '/private/missing-worktree'})}\n`,
       {flag: 'wx', mode: 0o600},
     );
+  });
+}
+
+function seedExactProvenance(fs: FileSystem.FileSystem, path: Path.Path, home: string) {
+  return Effect.gen(function* () {
+    const localContext = path.join(home, 'indexes', 'code-graph', 'repositories', CHECKOUT_ID, 'local-context');
+    const worktrees = path.join(localContext, 'worktrees');
+    yield* fs.makeDirectory(worktrees, {recursive: true, mode: 0o700});
+    if (process.platform !== 'win32') {
+      yield* fs.chmod(localContext, 0o700);
+      yield* fs.chmod(worktrees, 0o700);
+    }
+    const sidecar = path.join(worktrees, `${WORKTREE_ID}.json`);
+    yield* fs.writeFileString(
+      sidecar,
+      `${JSON.stringify({
+        canonicalWorktreePath: path.join(home, 'missing-worktree'),
+        checkoutId: CHECKOUT_ID,
+        headCommit: 'f'.repeat(40),
+        observedAt: new Date(0).toISOString(),
+        registration: {kind: 'main'},
+        repositoryId: REPOSITORY_ID,
+        schemaVersion: 2,
+        worktreeId: WORKTREE_ID,
+      })}\n`,
+      {flag: 'wx', mode: 0o600},
+    );
+    return sidecar;
   });
 }
 


### PR DESCRIPTION
## Summary

- terminalize durable provenance cleanup when its exact bound v2 sidecar was already removed by foreground view cleanup
- prove target absence through the private contained directory chain while preserving malformed, symlinked, legacy-v1, mismatched, and ambiguous state
- cover the complete foreground removal to residual completion path with Effect-native tests

## Defect

Foreground graph view removal captures v2 provenance evidence, commits durable residual cleanup authority, and then removes the exact sidecar. When residual maintenance later reached provenance, the missing sidecar read as legacy-unknown and was retried forever as invalid-sidecar.

## Safety

The new terminal path requires a syntactically valid stored token for the exact checkout and worktree plus a containment-safe current absence proof under the shared provenance lock. Existing legacy-v1, invalid, symlinked, replacement, permission-ambiguous, or containment-ambiguous state remains preserved or deferred.

## Verification

- focused changed-surface Vitest: 10 files, 88 tests passed
- source and test TypeScript checks passed
- strict changed-file oxlint and Prettier passed
- git diff check passed
- independent critical/important review: clean

Property-testing assessment: no new property was added because this is one exact two-stage regression; existing removed-view worker properties already cover generalized phase and retry transitions.

Global development install is intentionally deferred while the Threadnote 4.4 release worktree owns the singleton runtime.