### PR TITLE
fix(graph): keep exact symbols in bounded result pages

### DIFF
--- a/src/code_graph/store_queries.ts
+++ b/src/code_graph/store_queries.ts
@@ -1282,7 +1282,16 @@ const selectSearchSymbolsWithSql = Effect.fn('codeGraph.selectSearchSymbolsWithS
     const current = byId.get(row.id);
     if (!current || compareRows(row, current) < 0) byId.set(row.id, row);
   }
-  return [...byId.values()].sort(compareRows).slice(0, safeLimit).map(rankedNode);
+  const ranked = [...byId.values()].sort(compareRows);
+  const exactIds = new Set(exactRows.map(row => row.id));
+  // Admit exact identities before the bounded page is truncated, then retain
+  // the established path and side-effect-owner ordering within that page.
+  const reservedExact = ranked.filter(row => exactIds.has(row.id)).slice(0, safeLimit);
+  const selected = [
+    ...reservedExact,
+    ...ranked.filter(row => !exactIds.has(row.id)).slice(0, safeLimit - reservedExact.length),
+  ].sort(compareRows);
+  return selected.map(rankedNode);
 });
 
 const selectSearchSymbolsMany = Effect.fn('codeGraph.selectSearchSymbolsMany')(function* (

--- a/test/unit/code-graph.exact-symbol-ranking.test.ts
+++ b/test/unit/code-graph.exact-symbol-ranking.test.ts
@@ -1,0 +1,120 @@
+import {Database} from 'bun:sqlite';
+import {expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const exactSymbol = 'runIsolatedCodeGraphIndexSnapshot';
+const repositoryId = 'repository-exact-symbol-ranking';
+const snapshotId = 'snapshot-exact-symbol-ranking';
+const timestamp = '2026-08-27T00:00:00.000Z';
+const worktreeId = 'worktree-exact-symbol-ranking';
+const spanJson = JSON.stringify({column: 1, endColumn: 2, endLine: 1, line: 1});
+
+effectIt.effect('keeps an exact variable match in a full page of boosted mutation owners', () =>
+  Effect.scoped(
+    queryExactSymbolRanking(10, 10).pipe(
+      Effect.tap(results =>
+        Effect.sync(() => {
+          expect(results).toHaveLength(10);
+          expect(results.find(result => result.name === exactSymbol)).toMatchObject({score: 1});
+        }),
+      ),
+    ),
+  ).pipe(provideTestLayer(ApplicationLayer)),
+);
+
+effectIt.effect.prop(
+  'keeps exact identity in bounded result pages above the lexical candidate floor',
+  {
+    distractorCount: FC.integer({max: 140, min: 101}),
+    limit: FC.integer({max: 5, min: 1}),
+  },
+  ({distractorCount, limit}) =>
+    Effect.scoped(
+      queryExactSymbolRanking(distractorCount, limit).pipe(
+        Effect.tap(results =>
+          Effect.sync(() => {
+            expect(results.some(result => result.name === exactSymbol)).toBe(true);
+          }),
+        ),
+        Effect.asVoid,
+      ),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  {fastCheck: {numRuns: 30}},
+);
+
+const queryExactSymbolRanking = Effect.fn('test.queryExactSymbolRanking')(function* (
+  distractorCount: number,
+  limit: number,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const store = yield* CodeGraphStore;
+  const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-exact-ranking-'});
+  const databasePath = path.join(root, 'graph-v3.sqlite');
+  yield* store.initialize(databasePath);
+  yield* Effect.sync(() => insertExactSymbolRankingFixture(databasePath, distractorCount));
+  return yield* store.searchSymbols(databasePath, snapshotId, exactSymbol, limit);
+});
+
+function insertExactSymbolRankingFixture(databasePath: string, distractorCount: number): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.transaction(() => {
+      database
+        .query(
+          `INSERT INTO repositories (id, display_name, object_format, created_at, last_used_at)
+           VALUES (?, 'exact-symbol-ranking', 'sha1', ?, ?)`,
+        )
+        .run(repositoryId, timestamp, timestamp);
+      database
+        .query(
+          `INSERT INTO snapshots (
+             id, repository_id, worktree_id, commit_id, extractor_set, dirty, overlay_fingerprint,
+             state, file_count, symbol_count, edge_count, started_at, completed_at, failure_summary
+           ) VALUES (?, ?, ?, 'commit', 'exact-symbol-ranking', 0, NULL, 'ready', 0, ?, 0, ?, ?, NULL)`,
+        )
+        .run(snapshotId, repositoryId, worktreeId, distractorCount + 1, timestamp, timestamp);
+      const insertSymbol = database.query(`INSERT INTO symbols (
+        snapshot_id, id, content_hash, kind, name, qualified_name, path, language, arity,
+        lookup_keys_json, resolution_domain, resolution_scope_id, package_name, exported,
+        signature, documentation, span_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 'typescript', NULL, '[]', 'typescript', NULL, NULL, 1, NULL, NULL, ?)`);
+      insertSymbol.run(
+        snapshotId,
+        'exact-symbol',
+        'hash-exact-symbol',
+        'variable',
+        exactSymbol,
+        exactSymbol,
+        'src/code_graph/isolated_index.ts',
+        spanJson,
+      );
+      const insertTerm = database.query(
+        'INSERT INTO symbol_terms (snapshot_id, term, symbol_id, weight) VALUES (?, ?, ?, ?)',
+      );
+      for (let index = 0; index < distractorCount; index += 1) {
+        const id = `mutation-owner-${index}`;
+        const name = `purgeCodeGraphSnapshot${index}`;
+        insertSymbol.run(
+          snapshotId,
+          id,
+          `hash-${id}`,
+          'function',
+          name,
+          name,
+          `src/code_graph/maintenance-${index}.ts`,
+          spanJson,
+        );
+        for (const term of ['code', 'graph', 'index', 'isolated', 'run', 'snapshot']) {
+          insertTerm.run(snapshotId, term, id, 5);
+        }
+      }
+    })();
+  } finally {
+    database.close(false);
+  }
+}


### PR DESCRIPTION
## Summary

- reserve exact symbol identities before the bounded candidate page is truncated
- preserve the established path and side-effect-owner ranking within the selected page
- cover the concrete exported `Effect.fn`-shaped miss and the general admission invariant above the 100-candidate lexical floor

## Dogfood reproduction

The extractor and snapshot were correct: the exact exported variable row existed with the highest exact rank. Ten boosted mutation-owner lexical matches could nevertheless fill a ten-node result page before the exact row was admitted.

## Verification

- `bun run test test/unit/code-graph.exact-symbol-ranking.test.ts test/unit/code-graph.store-query.property.test.ts` (18 passed)
- `bun run test test/unit/code-graph.materialization-store.test.ts` (65 passed)
- targeted original ranking regressions (5 passed)
- 30-run Fast-check property with 101–140 distractors and limits 1–5
- repository lint, file-length, Prettier write, source/test/site TypeScript checks via precommit
- `git diff --check`

Global development install was intentionally deferred because the Manager worktree owns the shared runtime; the combined release head will be installed and dogfooded after merge.