### PR TITLE
fix(cli): treat closed output pipes as normal termination

### DIFF
--- a/src/effect/cli_output.ts
+++ b/src/effect/cli_output.ts
@@ -28,20 +28,32 @@ interface CliOutputSink {
   readonly write: (chunk: string) => number | Promise<number>;
 }
 
+const isBrokenPipeError = (cause: unknown): boolean =>
+  typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'EPIPE';
+
 /** @internal Exported so pipe-backpressure ordering can be regression-tested without a real subprocess. */
 export function makeQueuedCliWriter(open: () => CliOutputSink) {
   let sink: CliOutputSink | undefined;
   let tail = Promise.resolve();
   let failure: unknown;
   let ended = false;
+  let consumerClosed = false;
   const write = (output: string): Promise<void> => {
     const write = tail.then(async () => {
-      sink ??= open();
-      // Bun may complete a pipe write asynchronously once the OS pipe reaches
-      // backpressure. Flushing before that promise settles can close a large
-      // final JSON payload at an arbitrary prefix on slower hosts.
-      await sink.write(`${output}\n`);
-      await sink.flush();
+      if (consumerClosed) return;
+      try {
+        sink ??= open();
+        // Bun may complete a pipe write asynchronously once the OS pipe reaches
+        // backpressure. Flushing before that promise settles can close a large
+        // final JSON payload at an arbitrary prefix on slower hosts.
+        await sink.write(`${output}\n`);
+        await sink.flush();
+      } catch (cause) {
+        // A downstream Unix consumer such as `head` closing after its requested
+        // prefix is normal pipeline control flow, not a failed CLI operation.
+        if (!isBrokenPipeError(cause)) throw cause;
+        consumerClosed = true;
+      }
     });
     tail = write.catch(cause => {
       failure ??= cause;
@@ -55,9 +67,14 @@ export function makeQueuedCliWriter(open: () => CliOutputSink) {
   return {
     drain: async (): Promise<void> => {
       await flush();
-      if (sink !== undefined && !ended) {
+      if (sink !== undefined && !ended && !consumerClosed) {
         ended = true;
-        await sink.end();
+        try {
+          await sink.end();
+        } catch (cause) {
+          if (!isBrokenPipeError(cause)) throw cause;
+          consumerClosed = true;
+        }
       }
     },
     enqueue: (output: string): void => {

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -808,6 +808,48 @@ describe('Effect CLI', () => {
     }
   });
 
+  it('treats an early-closing stdout consumer as a normal CLI termination', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-broken-pipe-'));
+    const input = `consumer-prefix\n${'synthetic-memory-line\n'.repeat(64 * 1024)}`;
+    try {
+      const child = Bun.spawn(
+        [
+          process.execPath,
+          'src/standalone.ts',
+          'remember',
+          '--home',
+          home,
+          '--dry-run',
+          '--stdin',
+          '--project',
+          'threadnote',
+          '--topic',
+          'synthetic-broken-pipe',
+        ],
+        {
+          cwd: process.cwd(),
+          env: {...process.env, NO_COLOR: '1'},
+          stdin: 'pipe',
+          stderr: 'pipe',
+          stdout: 'pipe',
+        },
+      );
+      child.stdin.write(input);
+      child.stdin.end();
+
+      const stdout = child.stdout.getReader();
+      const prefix = await stdout.read();
+      await stdout.cancel();
+      const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+
+      expect(new TextDecoder().decode(prefix.value)).toContain('consumer-prefix');
+      expect(stderr).toBe('');
+      expect(exitCode).toBe(0);
+    } finally {
+      await rm(home, {force: true, recursive: true});
+    }
+  });
+
   it('includes eligible untracked files in Git-base impact analysis', async () => {
     const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-graph-'));
     const home = join(root, '.threadnote-test-home');

--- a/test/unit/cli-ui.progress.test.ts
+++ b/test/unit/cli-ui.progress.test.ts
@@ -1,6 +1,7 @@
 import {it as effectIt} from '@effect/vitest';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {Console, Effect, Terminal} from 'effect';
+import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {promptForSelection, startProgress} from '../../src/cli_ui.js';
 import {CliOutput, makeQueuedCliWriter, withCliOutputConsole} from '../../src/effect/cli_output.js';
@@ -67,6 +68,59 @@ describe('CLI progress indicator', () => {
     await writer.drain();
 
     expect(events).toEqual(['write:complete-json\n', 'written', 'flush', 'end']);
+  });
+
+  it.each(['write', 'flush', 'end'] as const)(
+    'silently stops writing after a downstream consumer closes the pipe during %s',
+    async failureStage => {
+      const events: string[] = [];
+      const brokenPipe = Object.assign(new Error('broken pipe'), {code: 'EPIPE'});
+      const sinkOperation = (operation: 'end' | 'flush' | 'write') => {
+        events.push(operation);
+        if (failureStage === operation) throw brokenPipe;
+        return 0;
+      };
+      const writer = makeQueuedCliWriter(() => ({
+        end: () => sinkOperation('end'),
+        flush: () => sinkOperation('flush'),
+        write: () => sinkOperation('write'),
+      }));
+
+      await writer.write('requested-prefix');
+      await writer.drain();
+      await writer.write('unrequested-suffix');
+      await writer.drain();
+
+      expect(events).toEqual(
+        failureStage === 'write'
+          ? ['write']
+          : failureStage === 'flush'
+            ? ['write', 'flush']
+            : ['write', 'flush', 'end'],
+      );
+    },
+  );
+
+  it('preserves arbitrary non-EPIPE sink failures', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string().filter(code => code !== 'EPIPE'),
+        async code => {
+          const failure = Object.assign(new Error('sink failure'), {code});
+          const writer = makeQueuedCliWriter(() => ({
+            end: () => 0,
+            flush: () => 0,
+            write: () => {
+              throw failure;
+            },
+          }));
+
+          await expect(writer.write('complete-json')).rejects.toBe(failure);
+          await expect(writer.flush()).rejects.toBe(failure);
+        },
+      ),
+      {numRuns: 64},
+    );
   });
 
   effectIt.effect('renders each explicit milestone immediately in an interactive terminal', () =>


### PR DESCRIPTION
## Summary

- treat a downstream stdout or stderr consumer closing with `EPIPE` as normal CLI pipeline control flow
- stop touching that sink after pipe closure while preserving queued backpressure and every non-EPIPE failure
- add a portable real-process regression plus write, flush, end, and bounded non-EPIPE coverage

## Verification

- pre-fix regression: requested prefix arrived, stderr stayed empty, producer exited 1
- post-fix source smoke: producer pipeline statuses `0 0 0 0`
- focused suites: 2 files, 43 tests passed
- source and test TypeScript checks passed
- strict changed-file lint, production file-length policy, Prettier, and diff checks passed
- commit hook passed repository lint, formatting, source/test/site typechecks
- independent critical/important review: CLEAN

The bounded Fast-check property runs 64 arbitrary non-EPIPE error codes and proves they remain fatal. The test is a Promise and operating-system child-process boundary, so plain Vitest is intentional under the Effect test policy.

Global development installation is intentionally deferred: the active Manager isolation worktree owns the shared runtime, and this branch did not take it over.