### PR TITLE
fix(build): preserve Bun child diagnostics

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,5 @@
 import {provideScriptLayer, ScriptError} from './effect/errors.js';
+import {runBunBuild} from './effect/bun-build.js';
 import * as BunRuntime from '@effect/platform-bun/BunRuntime';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {Console, Effect, FileSystem, Path} from 'effect';
@@ -65,7 +66,7 @@ const build = Effect.gen(function* () {
     yield* fs.copyFile(path.join(root, file), path.join(outputRoot, file));
   }
 
-  yield* runBuild({
+  yield* runBunBuild({
     compile: {
       autoloadBunfig: false,
       autoloadDotenv: false,
@@ -90,7 +91,7 @@ const build = Effect.gen(function* () {
     yield* fs.chmod(executablePath, 0o755);
   }
 
-  yield* runBuild({
+  yield* runBunBuild({
     entrypoints: [path.join(root, 'src', 'manager_ui.tsx')],
     format: 'iife',
     minify: true,
@@ -214,28 +215,8 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function runBuild(options: Bun.BuildConfig) {
-  return Effect.tryPromise({
-    try: () => Bun.build(options),
-    catch: cause => new ScriptError('Bun could not build the standalone artifact.', {cause}),
-  }).pipe(
-    Effect.flatMap(result =>
-      result.success
-        ? Effect.void
-        : Effect.fail(
-            new ScriptError(
-              result.logs
-                .map(log => log.message)
-                .filter(Boolean)
-                .join('\n'),
-            ),
-          ),
-    ),
-  );
-}
-
 function bundleNativeRuntime(entrypoint: string, outfile: string, nativePackage: string, nativeRuntimeVersion: string) {
-  return runBuild({
+  return runBunBuild({
     entrypoints: [entrypoint],
     minify: true,
     naming: outfile.replaceAll('\\', '/').split('/').at(-1),

--- a/scripts/effect/bun-build.ts
+++ b/scripts/effect/bun-build.ts
@@ -1,0 +1,65 @@
+import {Effect} from 'effect';
+import {ScriptError} from './errors.js';
+
+type BunBuild = (options: Bun.BuildConfig) => Promise<Bun.BuildOutput>;
+
+const BUILD_FAILURE_MESSAGE = 'Bun could not build the standalone artifact.';
+
+export function runBunBuild(options: Bun.BuildConfig, build: BunBuild = Bun.build) {
+  return Effect.tryPromise({
+    try: () => build(options),
+    catch: cause => bunBuildScriptError(cause),
+  }).pipe(
+    Effect.flatMap(result =>
+      result.success
+        ? Effect.void
+        : Effect.fail(
+            new ScriptError(
+              result.logs
+                .map(log => log.message)
+                .filter(Boolean)
+                .join('\n'),
+            ),
+          ),
+    ),
+  );
+}
+
+function bunBuildScriptError(cause: unknown): ScriptError {
+  const diagnostics = cause instanceof AggregateError ? cause.errors.map(renderBuildDiagnostic).filter(Boolean) : [];
+  return new ScriptError(renderBuildFailure(diagnostics), {cause});
+}
+
+function renderBuildFailure(diagnostics: ReadonlyArray<string>): string {
+  return diagnostics.length === 0
+    ? BUILD_FAILURE_MESSAGE
+    : `${BUILD_FAILURE_MESSAGE}\nBuild diagnostics:\n${diagnostics.join('\n')}`;
+}
+
+function renderBuildDiagnostic(value: unknown): string {
+  const message = diagnosticMessage(value);
+  if (!message) return '';
+
+  const position = isRecord(value) && isRecord(value.position) ? value.position : undefined;
+  const file = position && typeof position.file === 'string' ? position.file : undefined;
+  const line = position && typeof position.line === 'number' ? position.line : undefined;
+  const column = position && typeof position.column === 'number' ? position.column : undefined;
+  const location = file
+    ? [file, line, column].filter((part): part is string | number => part !== undefined).join(':')
+    : undefined;
+  const lineText = position && typeof position.lineText === 'string' ? position.lineText.trimEnd() : undefined;
+
+  return [`${location ? `${location}: ` : ''}${message}`, lineText ? `  ${lineText}` : undefined]
+    .filter((part): part is string => part !== undefined)
+    .join('\n');
+}
+
+function diagnosticMessage(value: unknown): string {
+  if (value instanceof Error) return value.message.trim();
+  if (isRecord(value) && typeof value.message === 'string') return value.message.trim();
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/test/unit/build-diagnostics.test.ts
+++ b/test/unit/build-diagnostics.test.ts
@@ -1,0 +1,36 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect} from 'effect';
+import {describe, expect} from 'vitest';
+import {runBunBuild} from '../../scripts/effect/bun-build.js';
+import {ScriptError} from '../../scripts/effect/errors.js';
+
+describe('Bun build diagnostics', () => {
+  effectIt.effect('preserves rejected child diagnostics and the original cause', () =>
+    Effect.gen(function* () {
+      const diagnostic = Object.assign(new Error('Browser build cannot import Bun builtin: "bun:sqlite".'), {
+        position: {
+          column: 3,
+          file: '/workspace/src/fixture.ts',
+          line: 7,
+          lineText: "import {Database} from 'bun:sqlite';",
+        },
+      });
+      const cause = new AggregateError([diagnostic], 'Bundle failed');
+
+      const failure = yield* runBunBuild({entrypoints: ['/workspace/src/fixture.ts']}, () =>
+        Promise.reject(cause),
+      ).pipe(Effect.flip);
+
+      expect(failure).toBeInstanceOf(ScriptError);
+      expect(failure.cause).toBe(cause);
+      expect(failure.message).toBe(
+        [
+          'Bun could not build the standalone artifact.',
+          'Build diagnostics:',
+          '/workspace/src/fixture.ts:7:3: Browser build cannot import Bun builtin: "bun:sqlite".',
+          "  import {Database} from 'bun:sqlite';",
+        ].join('\n'),
+      );
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

- move the existing Bun build Effect wrapper into a focused helper
- render AggregateError child diagnostics, including source position and source line, in the visible ScriptError message
- preserve the original AggregateError as the typed failure cause and keep build failures nonzero

## Reproduction

A browser-target Bun.build rejection containing the Manager boundary failures (`bun:sqlite`, `bun:ffi`, and Node `module`) previously surfaced through `bun run build` only as `AggregateError: Bundle failed`. The fixed wrapper renders each child diagnostic with file, line, column, and source text.

## Verification

- `bun --bun vitest run test/unit/build-diagnostics.test.ts`
- `bun --bun tsc --noEmit`
- `bun --bun tsc -p test/tsconfig.json --noEmit`
- focused strict oxlint and Prettier
- `bun run lint:file-length`
- `bun run build`
- real rejected Bun.build probe: actionable diagnostics rendered and process exit remained 1

Full-suite validation is left to PR CI per repository policy. Global development installation is intentionally deferred because the Manager worktree owns the active runtime.