### PR TITLE
fix(logs): preserve Windows lifecycle entries under contention

### DIFF
--- a/src/effect/production_log.ts
+++ b/src/effect/production_log.ts
@@ -35,9 +35,9 @@ const PRODUCTION_LOG_LOCK_RETRY_MILLISECONDS = 25;
 const PRODUCTION_LOG_LOCK_STALE_MILLISECONDS = 30_000;
 const PRODUCTION_LOG_LOCK_WAIT_MILLISECONDS = 2_000;
 const PRODUCTION_LOG_PROCESS_WAIT_MILLISECONDS = PRODUCTION_LOG_LOCK_WAIT_MILLISECONDS + 500;
-// Eight standalone Windows processes can occupy the low-volume log lock beyond two seconds under hosted-runner
+// Eight standalone Windows processes can occupy the low-volume log lock beyond five seconds under hosted-runner
 // scheduling. Keep the queue bounded while preserving both lifecycle entries for commands that already completed.
-const PRODUCTION_LOG_WINDOWS_LOCK_WAIT_MILLISECONDS = 5_000;
+const PRODUCTION_LOG_WINDOWS_LOCK_WAIT_MILLISECONDS = 10_000;
 const PRODUCTION_LOG_RUNTIME_NAME = 'bun';
 const PRODUCTION_LOG_UNKNOWN_ERROR_TYPE = 'UnknownError';
 const PRODUCTION_LOG_REPORTED_ERROR_TYPE = 'ReportedError';

--- a/test/unit/production-log.test.ts
+++ b/test/unit/production-log.test.ts
@@ -1,8 +1,9 @@
 import {TestError} from '../helpers/test-error.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {it as effectIt} from '@effect/vitest';
-import {Cause, Effect, Exit, Fiber, FileSystem, Path} from 'effect';
+import {Cause, Deferred, Effect, Exit, Fiber, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
 import {describe, expect} from 'vitest';
 import {
   PRODUCTION_LOG_FILE_NAME,
@@ -14,6 +15,7 @@ import {
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import {captureConsole} from '../../src/effect/console.js';
+import {withExclusiveFileLock} from '../../src/effect/file_lock.js';
 import {SystemInfo} from '../../src/effect/system.js';
 
 interface ParsedProductionLogEntry {
@@ -263,6 +265,46 @@ describe('production log writer', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
+  effectIt.effect('preserves both Windows lifecycle entries when lock contention exceeds five seconds', () =>
+    windowsEntriesAfterLockContention(5_500).pipe(
+      Effect.flatMap(entries =>
+        Effect.sync(() => {
+          expect(entries).toHaveLength(2);
+          expect(entries.map(entry => entry.event)).toEqual(['invocation.started', 'invocation.finished']);
+          expect(entries[0]?.invocationId).toBe(entries[1]?.invocationId);
+        }),
+      ),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'preserves correlated Windows lifecycle entries across the extended bounded contention window',
+    {releaseAfterMilliseconds: fc.integer({min: 5_025, max: 9_500})},
+    ({releaseAfterMilliseconds}) =>
+      windowsEntriesAfterLockContention(releaseAfterMilliseconds).pipe(
+        Effect.flatMap(entries =>
+          Effect.sync(() => {
+            expect(entries).toHaveLength(2);
+            expect(entries[0]?.event).toBe('invocation.started');
+            expect(entries[1]?.event).toBe('invocation.finished');
+            expect(entries[0]?.invocationId).toBe(entries[1]?.invocationId);
+          }),
+        ),
+      ),
+    {fastCheck: {numRuns: 12}},
+  );
+
+  effectIt.effect('keeps Windows production logging best-effort at the ten-second contention bound', () =>
+    windowsEntriesAfterLockContention(10_025).pipe(
+      Effect.flatMap(entries =>
+        Effect.sync(() => {
+          expect(entries).toHaveLength(1);
+          expect(entries[0]?.event).toBe('invocation.finished');
+        }),
+      ),
+    ),
+  );
+
   effectIt.effect('does not replace existing log history when Windows reports non-POSIX file modes', () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -423,6 +465,60 @@ function ownedTestHome(label: string) {
     );
     return {fs, home, path};
   });
+}
+
+function windowsEntriesAfterLockContention(releaseAfterMilliseconds: number) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const {fs, home, path} = yield* ownedTestHome(`windows-contention-${releaseAfterMilliseconds}`);
+      const lockPath = path.join(home, 'locks', 'production-log.lock');
+      const acquired = yield* Deferred.make<void>();
+      const contentionObserved = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const ownerFiber = yield* withExclusiveFileLock(
+        fs,
+        lockPath,
+        {
+          retryIntervalMilliseconds: 25,
+          staleAfterMilliseconds: 30_000,
+          waitTimeoutMilliseconds: 20_000,
+        },
+        Effect.gen(function* () {
+          yield* Deferred.succeed(acquired, undefined);
+          yield* Deferred.await(release);
+        }),
+      ).pipe(Effect.forkChild({startImmediately: true}));
+      yield* Deferred.await(acquired);
+
+      const observedFs = FileSystem.FileSystem.of({
+        ...fs,
+        writeFileString: (candidate, content, options) =>
+          fs
+            .writeFileString(candidate, content, options)
+            .pipe(
+              Effect.tapError(() =>
+                candidate === lockPath ? Deferred.succeed(contentionObserved, undefined) : Effect.void,
+              ),
+            ),
+      });
+      const nativeSystem = yield* SystemInfo;
+      const windowsSystem = SystemInfo.of({...nativeSystem, platform: 'win32'});
+      const writerFiber = yield* withProductionLogging(home, {component: 'cli', operation: 'logs'}, Effect.void).pipe(
+        Effect.provideService(FileSystem.FileSystem, observedFs),
+        Effect.provideService(SystemInfo, windowsSystem),
+        Effect.forkChild({startImmediately: true}),
+      );
+      yield* Deferred.await(contentionObserved);
+
+      yield* TestClock.adjust(releaseAfterMilliseconds);
+      yield* Deferred.succeed(release, undefined);
+      yield* Fiber.join(ownerFiber);
+      yield* TestClock.adjust(25);
+      yield* Fiber.join(writerFiber);
+
+      return parseEntries(yield* fs.readFileString(productionLogPath(path, home)));
+    }),
+  ).pipe(provideTestLayer(ApplicationLayer));
 }
 
 function productionLogPath(path: Path.Path, home: string): string {


### PR DESCRIPTION
## Summary

- extend only the Windows production-log lock wait from 5 seconds to 10 seconds after two independent hosted-runner losses at the existing bound
- add a deterministic Effect-native regression for contention beyond 5 seconds
- add a bounded Fast-check property across 5.025–9.5 seconds and an explicit just-after-10-second best-effort boundary case

## Diagnosis

Eight standalone Windows processes each write started and finished lifecycle entries. The cross-process lock gives up after 5 seconds and production logging intentionally swallows that timeout, so one command can succeed while one of 16 records is absent. The same 15/16 failure repeated on two unrelated PR heads; the second failed test lasted 5.682 seconds.

## Safety

- non-Windows lock waits remain 2 seconds
- stale-lock recovery remains 30 seconds
- the outer process timeout remains the selected lock wait plus 500 ms
- MCP tool writes retain their independent 500 ms cap
- privacy scrubbing, path validation, rotation, and best-effort failure handling are unchanged

## Verification

- pre-fix deterministic regression and property both reproduced a single retained lifecycle entry
- focused production-log unit suite: 16/16 passed
- exact standalone-process E2E: 1 passed, 17 skipped
- standalone build passed
- source and test TypeScript checks passed
- strict focused lint, Prettier, and diff checks passed
- commit hooks passed repository lint, formatting, source/test/site typechecks
- independent critical/important review: CLEAN

CI is authoritative for the full suite and the Windows hosted-runner reproduction.