### PR TITLE
fix(graph): service pending view reconciliation

### DIFF
--- a/scripts/benchmark-context-brief-citations-target.ts
+++ b/scripts/benchmark-context-brief-citations-target.ts
@@ -178,6 +178,7 @@ const queryDependencies = Layer.mergeAll(
     CodeGraphMaintenanceCoordinator,
     CodeGraphMaintenanceCoordinator.of({
       kickOrdinary: () => Effect.die(new Error('Scale benchmark must not run ordinary graph maintenance.')),
+      kickReconciliation: () => Effect.die(new Error('Scale benchmark must not run graph reconciliation maintenance.')),
       kickResidual: () => Effect.die(new Error('Scale benchmark must not run residual graph maintenance.')),
       request: () => graphInstrumentation.recordMaintenanceRequest,
       tick: () => Effect.die(new Error('Scale benchmark must not tick graph maintenance.')),

--- a/src/code_graph/diagnostics.ts
+++ b/src/code_graph/diagnostics.ts
@@ -411,6 +411,7 @@ export const inspectAllCodeGraphsLocal = Effect.fn('codeGraph.inspectAllDiagnost
             ...(database.accounting?.pressure === 'critical' || database.accounting?.pressure === 'elevated'
               ? {pressure: database.accounting.pressure}
               : {}),
+            reconciliationPending: database.views.some(view => view.localAssociation.state === 'missing'),
           },
         ];
       }),

--- a/src/code_graph/lifecycle_opportunity.ts
+++ b/src/code_graph/lifecycle_opportunity.ts
@@ -1,4 +1,7 @@
-import {Effect, Option, Path} from 'effect';
+import {Effect, FileSystem, Option, Path} from 'effect';
+import {sha256HexSync} from '../crypto/sha256.js';
+import {syncDirectoryBestEffort, syncWritableFile} from '../effect/file_durability.js';
+import {withExclusiveFileLock} from '../effect/file_lock.js';
 import {codeGraphDatabaseWriteLockPath, codeGraphLayout} from './layout.js';
 import {readCodeGraphLocalAssociation} from './local_provenance.js';
 import {codeGraphDatabasePaths} from './maintenance.js';
@@ -48,7 +51,31 @@ export type CodeGraphLifecycleOpportunityResult =
 
 const LIFECYCLE_OPPORTUNITY_CURSOR_LIMIT = 128;
 export const CODE_GRAPH_LIFECYCLE_OPPORTUNITY_UNIT_MILLISECONDS = 2_000;
-const opportunityCursors = new Map<string, string>();
+const LIFECYCLE_OPPORTUNITY_CURSOR_BYTES_LIMIT = 512;
+const LIFECYCLE_OPPORTUNITY_CURSOR_SCHEMA_VERSION = 1 as const;
+const LIFECYCLE_OPPORTUNITY_CURSOR_LOCK_OPTIONS = {
+  retryIntervalMilliseconds: 10,
+  staleAfterMilliseconds: 120_000,
+  waitTimeoutMilliseconds: 0,
+} as const;
+
+interface PersistedLifecycleOpportunityCursor {
+  readonly checkoutId: string;
+  readonly databasePathDigest: string;
+  readonly lane: CodeGraphLifecycleOpportunityUnitLane;
+  readonly schemaVersion: typeof LIFECYCLE_OPPORTUNITY_CURSOR_SCHEMA_VERSION;
+}
+
+export type CodeGraphLifecycleOpportunityUnitLane = 'ordinary' | 'reconciliation' | 'residual' | 'rotating';
+
+export interface CodeGraphLifecycleOpportunityUnit {
+  readonly lane: CodeGraphLifecycleOpportunityUnitLane;
+  readonly target: CodeGraphLifecycleOpportunityTarget;
+}
+
+class CodeGraphLifecycleOpportunityCursorError extends Error {
+  readonly _tag = 'CodeGraphLifecycleOpportunityCursorError' as const;
+}
 
 /** Read bounded active-pointer provenance without invoking Git on the healthy hot path. */
 export const observeCodeGraphLifecycleOpportunityTargets = Effect.fn('codeGraph.observeLifecycleOpportunityTargets')(
@@ -96,56 +123,76 @@ export const observeCodeGraphLifecycleOpportunityTargets = Effect.fn('codeGraph.
 
 /**
  * Await one zero-wait maintenance unit at a foreground lifecycle opportunity.
- * Distinct databases rotate in code-unit order; a short-lived CLI therefore
- * commits one bounded unit instead of abandoning a detached request at exit.
+ * Pending cleanup and explicit diagnostics durably rotate database-by-lane;
+ * healthy hot paths retain their in-process target rotation without cursor I/O.
+ * A short-lived CLI therefore commits one bounded unit before exit.
  */
-export const runCodeGraphLifecycleOpportunity = Effect.fn('codeGraph.runLifecycleOpportunity')(function* (input: {
-  readonly maintenance: CodeGraphMaintenanceCoordinatorShape;
-  readonly opportunity: CodeGraphLifecycleOpportunity;
-  readonly pressure?: Extract<CodeGraphStoragePressure, 'critical' | 'elevated'>;
-  readonly targets: readonly CodeGraphLifecycleOpportunityTarget[];
-  readonly threadnoteHome: string;
-}) {
-  const path = yield* Path.Path;
-  const cursorKey = `${input.threadnoteHome}\0${input.opportunity}`;
-  const target = selectCodeGraphLifecycleOpportunityTarget(input.targets, opportunityCursors.get(cursorKey));
-  if (target === undefined) return {opportunity: input.opportunity, state: 'no-target'} as const;
-  rememberOpportunityCursor(cursorKey, lifecycleTargetKey(target));
+export function makeCodeGraphLifecycleOpportunityRunner() {
+  const opportunityCursors = new Map<string, string>();
+  return Effect.fn('codeGraph.runLifecycleOpportunity')(function* (input: {
+    readonly maintenance: CodeGraphMaintenanceCoordinatorShape;
+    readonly opportunity: CodeGraphLifecycleOpportunity;
+    readonly pressure?: Extract<CodeGraphStoragePressure, 'critical' | 'elevated'>;
+    readonly targets: readonly CodeGraphLifecycleOpportunityTarget[];
+    readonly threadnoteHome: string;
+  }) {
+    const path = yield* Path.Path;
+    const cursorKey = `${input.threadnoteHome}\0${input.opportunity}`;
+    const memoryCursor = opportunityCursors.get(cursorKey);
+    const units = codeGraphLifecycleOpportunityUnits(input.targets, input.opportunity);
+    const persistentRotation = units.some(unit => unit.lane === 'reconciliation');
+    const unit = persistentRotation
+      ? yield* claimPersistedLifecycleOpportunityUnit({...input, units}).pipe(
+          Effect.catch(() => Effect.sync(() => selectCodeGraphLifecycleOpportunityUnit(units, memoryCursor))),
+        )
+      : selectCodeGraphLifecycleOpportunityUnit(units, memoryCursor);
+    if (unit === undefined) return {opportunity: input.opportunity, state: 'no-target'} as const;
+    rememberOpportunityCursor(opportunityCursors, cursorKey, lifecycleOpportunityUnitKey(unit));
+    const target = unit.target;
 
-  let anchorIdentity = target.anchorIdentity;
-  if (anchorIdentity !== undefined) {
-    const layout = codeGraphLayout(path, input.threadnoteHome, anchorIdentity.checkoutId, anchorIdentity.worktreeId);
-    if (anchorIdentity.checkoutId !== target.checkoutId || layout.databasePath !== target.databasePath) {
-      anchorIdentity = undefined;
+    let anchorIdentity = target.anchorIdentity;
+    if (anchorIdentity !== undefined) {
+      const layout = codeGraphLayout(path, input.threadnoteHome, anchorIdentity.checkoutId, anchorIdentity.worktreeId);
+      if (anchorIdentity.checkoutId !== target.checkoutId || layout.databasePath !== target.databasePath) {
+        anchorIdentity = undefined;
+      }
     }
-  }
-  const pressure = target.pressure ?? input.pressure;
-  const tick = {
-    ...(anchorIdentity === undefined ? {} : {allowIndexPreparation: true as const, anchorIdentity}),
-    ...(anchorIdentity === undefined && target.anchorPath !== undefined
-      ? {allowIndexPreparation: true as const, anchorPath: target.anchorPath}
-      : {}),
-    automaticTail: false,
-    checkoutId: target.checkoutId,
-    databasePath: target.databasePath,
-    joinActive: false,
-    ...(pressure === undefined ? {} : {pressure}),
-    threadnoteHome: input.threadnoteHome,
-    writerLockPath: codeGraphDatabaseWriteLockPath(path, input.threadnoteHome, target.checkoutId),
-  } as const;
-  const observed = yield* (
-    input.opportunity === 'index-completion' ? input.maintenance.kickOrdinary(tick) : input.maintenance.tick(tick)
-  ).pipe(Effect.timeoutOption(CODE_GRAPH_LIFECYCLE_OPPORTUNITY_UNIT_MILLISECONDS));
-  if (Option.isNone(observed)) {
-    return {opportunity: input.opportunity, reason: 'deadline', state: 'deferred'} as const;
-  }
-  return {
-    checkoutId: target.checkoutId,
-    opportunity: input.opportunity,
-    result: observed.value,
-    state: 'completed',
-  } as const;
-});
+    const pressure = target.pressure ?? input.pressure;
+    const tick = {
+      ...(anchorIdentity === undefined ? {} : {allowIndexPreparation: true as const, anchorIdentity}),
+      ...(anchorIdentity === undefined && target.anchorPath !== undefined
+        ? {allowIndexPreparation: true as const, anchorPath: target.anchorPath}
+        : {}),
+      automaticTail: false,
+      checkoutId: target.checkoutId,
+      databasePath: target.databasePath,
+      joinActive: false,
+      ...(pressure === undefined ? {} : {pressure}),
+      threadnoteHome: input.threadnoteHome,
+      writerLockPath: codeGraphDatabaseWriteLockPath(path, input.threadnoteHome, target.checkoutId),
+    } as const;
+    const observed = yield* (
+      unit.lane === 'ordinary'
+        ? input.maintenance.kickOrdinary(tick)
+        : unit.lane === 'reconciliation'
+          ? input.maintenance.kickReconciliation(tick)
+          : unit.lane === 'residual'
+            ? input.maintenance.kickResidual(tick)
+            : input.maintenance.tick(tick)
+    ).pipe(Effect.timeoutOption(CODE_GRAPH_LIFECYCLE_OPPORTUNITY_UNIT_MILLISECONDS));
+    if (Option.isNone(observed)) {
+      return {opportunity: input.opportunity, reason: 'deadline', state: 'deferred'} as const;
+    }
+    return {
+      checkoutId: target.checkoutId,
+      opportunity: input.opportunity,
+      result: observed.value,
+      state: 'completed',
+    } as const;
+  });
+}
+
+export const runCodeGraphLifecycleOpportunity = makeCodeGraphLifecycleOpportunityRunner();
 
 /** @internal Pure round-robin selector retained for fairness properties. */
 export function selectCodeGraphLifecycleOpportunityTarget(
@@ -160,20 +207,194 @@ export function selectCodeGraphLifecycleOpportunityTarget(
   }
   const ordered = [...unique.entries()].sort(([left], [right]) => compareCodeUnits(left, right));
   if (ordered.length === 0) return undefined;
-  if (cursor === undefined) return ordered[0]![1];
+  if (cursor === undefined) {
+    return (ordered.find(
+      ([, target]) =>
+        target.reconciliationPending === true &&
+        (target.anchorIdentity !== undefined || target.anchorPath !== undefined),
+    ) ?? ordered[0])[1];
+  }
   return (ordered.find(([key]) => compareCodeUnits(key, cursor) > 0) ?? ordered[0])![1];
+}
+
+/** @internal Plan one deterministic bounded ring without deriving deletion authority. */
+export function codeGraphLifecycleOpportunityUnits(
+  targets: readonly CodeGraphLifecycleOpportunityTarget[],
+  opportunity: CodeGraphLifecycleOpportunity,
+): readonly CodeGraphLifecycleOpportunityUnit[] {
+  const ordered = orderedCodeGraphLifecycleOpportunityTargets(targets);
+  if (opportunity === 'index-completion') {
+    return ordered.map(target => ({lane: 'ordinary', target}));
+  }
+  const reconciliation = ordered.filter(
+    target =>
+      (opportunity === 'diagnostics' || target.reconciliationPending === true) &&
+      (target.anchorIdentity !== undefined || target.anchorPath !== undefined),
+  );
+  if (reconciliation.length === 0) return ordered.map(target => ({lane: 'rotating', target}));
+  return [
+    ...reconciliation.map(target => ({lane: 'reconciliation' as const, target})),
+    ...ordered.map(target => ({lane: 'ordinary' as const, target})),
+    ...ordered.map(target => ({lane: 'residual' as const, target})),
+  ];
+}
+
+/** @internal Pure round-robin unit selector retained for fairness properties. */
+export function selectCodeGraphLifecycleOpportunityUnit(
+  units: readonly CodeGraphLifecycleOpportunityUnit[],
+  cursor?: string,
+): CodeGraphLifecycleOpportunityUnit | undefined {
+  if (units.length === 0) return undefined;
+  if (cursor === undefined) return units[0];
+  const cursorIndex = units.findIndex(unit => lifecycleOpportunityUnitKey(unit) === cursor);
+  return cursorIndex < 0 ? units[0] : units[(cursorIndex + 1) % units.length];
 }
 
 function lifecycleTargetKey(target: CodeGraphLifecycleOpportunityTarget): string {
   return `${target.checkoutId}\0${target.databasePath}`;
 }
 
-function rememberOpportunityCursor(key: string, cursor: string): void {
-  opportunityCursors.delete(key);
-  opportunityCursors.set(key, cursor);
-  while (opportunityCursors.size > LIFECYCLE_OPPORTUNITY_CURSOR_LIMIT) {
-    const oldest = opportunityCursors.keys().next().value as string | undefined;
+function lifecycleOpportunityUnitKey(unit: CodeGraphLifecycleOpportunityUnit): string {
+  return `${unit.lane}\0${lifecycleTargetKey(unit.target)}`;
+}
+
+function orderedCodeGraphLifecycleOpportunityTargets(
+  targets: readonly CodeGraphLifecycleOpportunityTarget[],
+): readonly CodeGraphLifecycleOpportunityTarget[] {
+  const unique = new Map<string, CodeGraphLifecycleOpportunityTarget>();
+  for (const target of targets) {
+    if (/^[0-9a-f]{64}$/u.test(target.checkoutId) && target.databasePath.length > 0) {
+      unique.set(lifecycleTargetKey(target), target);
+    }
+  }
+  return [...unique.entries()].sort(([left], [right]) => compareCodeUnits(left, right)).map(([, target]) => target);
+}
+
+const claimPersistedLifecycleOpportunityUnit = Effect.fn('codeGraph.claimLifecycleOpportunityUnit')(function* (input: {
+  readonly opportunity: CodeGraphLifecycleOpportunity;
+  readonly threadnoteHome: string;
+  readonly units: readonly CodeGraphLifecycleOpportunityUnit[];
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = path.join(input.threadnoteHome, 'locks', 'indexes', 'code-graph', 'lifecycle-opportunities');
+  const cursorPath = path.join(root, `${input.opportunity}.cursor-v1.json`);
+  const lockPath = path.join(root, `${input.opportunity}.cursor.lock`);
+  return yield* withExclusiveFileLock(
+    fs,
+    lockPath,
+    LIFECYCLE_OPPORTUNITY_CURSOR_LOCK_OPTIONS,
+    Effect.gen(function* () {
+      const persisted = yield* readPersistedLifecycleOpportunityCursor(fs, cursorPath);
+      const cursor = persistedLifecycleOpportunityUnitKey(input.units, persisted);
+      const selected = selectCodeGraphLifecycleOpportunityUnit(input.units, cursor);
+      if (selected === undefined) return undefined;
+      yield* writePersistedLifecycleOpportunityCursor(fs, path, root, cursorPath, {
+        checkoutId: selected.target.checkoutId,
+        databasePathDigest: sha256HexSync(selected.target.databasePath),
+        lane: selected.lane,
+        schemaVersion: LIFECYCLE_OPPORTUNITY_CURSOR_SCHEMA_VERSION,
+      });
+      return selected;
+    }),
+  );
+});
+
+function readPersistedLifecycleOpportunityCursor(
+  fs: FileSystem.FileSystem,
+  cursorPath: string,
+): Effect.Effect<PersistedLifecycleOpportunityCursor | undefined, CodeGraphLifecycleOpportunityCursorError> {
+  return Effect.gen(function* () {
+    if (!(yield* fs.exists(cursorPath))) return undefined;
+    if (Option.isSome(yield* fs.readLink(cursorPath).pipe(Effect.option))) {
+      return yield* Effect.fail(new CodeGraphLifecycleOpportunityCursorError('Lifecycle cursor is not a file.'));
+    }
+    const info = yield* fs.stat(cursorPath);
+    if (info.type !== 'File' || Number(info.size) > LIFECYCLE_OPPORTUNITY_CURSOR_BYTES_LIMIT) return undefined;
+    const content = yield* fs.readFileString(cursorPath);
+    if (new TextEncoder().encode(content).byteLength > LIFECYCLE_OPPORTUNITY_CURSOR_BYTES_LIMIT) return undefined;
+    return decodePersistedLifecycleOpportunityCursor(content);
+  }).pipe(Effect.mapError(() => new CodeGraphLifecycleOpportunityCursorError('Could not read lifecycle cursor.')));
+}
+
+const writePersistedLifecycleOpportunityCursor = Effect.fn('codeGraph.writeLifecycleOpportunityCursor')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  root: string,
+  cursorPath: string,
+  cursor: PersistedLifecycleOpportunityCursor,
+) {
+  if (Option.isSome(yield* fs.readLink(cursorPath).pipe(Effect.option))) {
+    return yield* Effect.fail(new CodeGraphLifecycleOpportunityCursorError('Lifecycle cursor is not a file.'));
+  }
+  const content = `${JSON.stringify(cursor)}\n`;
+  if (new TextEncoder().encode(content).byteLength > LIFECYCLE_OPPORTUNITY_CURSOR_BYTES_LIMIT) {
+    return yield* Effect.fail(new CodeGraphLifecycleOpportunityCursorError('Lifecycle cursor is too large.'));
+  }
+  const temporary = path.join(root, `.${path.basename(cursorPath)}.tmp`);
+  yield* Effect.gen(function* () {
+    // The opportunity lock gives this publication path a single writer. Reuse
+    // one deterministic temporary so a hard crash can strand at most one file,
+    // and the next claim recovers it before publishing.
+    yield* fs.remove(temporary, {force: true});
+    yield* fs.writeFileString(temporary, content, {flag: 'wx', mode: 0o600});
+    yield* syncWritableFile(fs, temporary);
+    if (Option.isSome(yield* fs.readLink(cursorPath).pipe(Effect.option))) {
+      return yield* Effect.fail(new CodeGraphLifecycleOpportunityCursorError('Lifecycle cursor changed type.'));
+    }
+    yield* fs.rename(temporary, cursorPath);
+    yield* syncDirectoryBestEffort(fs, root);
+  }).pipe(Effect.ensuring(fs.remove(temporary, {force: true}).pipe(Effect.catch(() => Effect.void))));
+});
+
+function decodePersistedLifecycleOpportunityCursor(content: string): PersistedLifecycleOpportunityCursor | undefined {
+  try {
+    const parsed = JSON.parse(content) as Partial<PersistedLifecycleOpportunityCursor>;
+    if (
+      parsed.schemaVersion !== LIFECYCLE_OPPORTUNITY_CURSOR_SCHEMA_VERSION ||
+      typeof parsed.checkoutId !== 'string' ||
+      !/^[0-9a-f]{64}$/u.test(parsed.checkoutId) ||
+      typeof parsed.databasePathDigest !== 'string' ||
+      !/^[0-9a-f]{64}$/u.test(parsed.databasePathDigest) ||
+      !isCodeGraphLifecycleOpportunityUnitLane(parsed.lane)
+    ) {
+      return undefined;
+    }
+    return {
+      checkoutId: parsed.checkoutId,
+      databasePathDigest: parsed.databasePathDigest,
+      lane: parsed.lane,
+      schemaVersion: LIFECYCLE_OPPORTUNITY_CURSOR_SCHEMA_VERSION,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function persistedLifecycleOpportunityUnitKey(
+  units: readonly CodeGraphLifecycleOpportunityUnit[],
+  cursor: PersistedLifecycleOpportunityCursor | undefined,
+): string | undefined {
+  if (cursor === undefined) return undefined;
+  const unit = units.find(
+    candidate =>
+      candidate.lane === cursor.lane &&
+      candidate.target.checkoutId === cursor.checkoutId &&
+      sha256HexSync(candidate.target.databasePath) === cursor.databasePathDigest,
+  );
+  return unit === undefined ? undefined : lifecycleOpportunityUnitKey(unit);
+}
+
+function isCodeGraphLifecycleOpportunityUnitLane(value: unknown): value is CodeGraphLifecycleOpportunityUnitLane {
+  return value === 'ordinary' || value === 'reconciliation' || value === 'residual' || value === 'rotating';
+}
+
+function rememberOpportunityCursor(cursors: Map<string, string>, key: string, cursor: string): void {
+  cursors.delete(key);
+  cursors.set(key, cursor);
+  while (cursors.size > LIFECYCLE_OPPORTUNITY_CURSOR_LIMIT) {
+    const oldest = cursors.keys().next().value as string | undefined;
     if (oldest === undefined) break;
-    opportunityCursors.delete(oldest);
+    cursors.delete(oldest);
   }
 }

--- a/src/code_graph/maintenance_coordinator.ts
+++ b/src/code_graph/maintenance_coordinator.ts
@@ -65,6 +65,10 @@ export interface CodeGraphMaintenanceCoordinatorShape {
   readonly kickOrdinary: (
     input: CodeGraphRoutineMaintenanceTick,
   ) => Effect.Effect<CodeGraphRoutineMaintenanceResult, CodeGraphStoreError>;
+  /** Run exactly one nonblocking missing-worktree reconciliation unit without rotating through other lanes. */
+  readonly kickReconciliation: (
+    input: CodeGraphRoutineMaintenanceTick,
+  ) => Effect.Effect<CodeGraphRoutineMaintenanceResult, CodeGraphStoreError>;
   /** Run exactly one nonblocking residual unit without starting a full maintenance round. */
   readonly kickResidual: (
     input: CodeGraphRoutineMaintenanceTick,
@@ -439,6 +443,7 @@ export class CodeGraphMaintenanceCoordinator extends Context.Service<
         },
         runResidualCleanup,
         runRoutineMaintenance,
+        runReconciliationOrPreparationWithoutHistory,
       );
     }),
   );
@@ -692,6 +697,7 @@ export const makeCodeGraphMaintenanceCoordinator = Effect.fn('codeGraph.makeMain
   interlocks: CodeGraphMaintenanceCoordinatorInterlocks = {},
   kickResidual: CodeGraphRoutineMaintenanceRun = run,
   kickOrdinary: CodeGraphRoutineMaintenanceRun = run,
+  kickReconciliation: CodeGraphRoutineMaintenanceRun = run,
 ) {
   const scope = yield* Effect.scope;
   const stateByHome = yield* SynchronizedRef.make(new Map<string, HomeMaintenanceState>());
@@ -900,7 +906,7 @@ export const makeCodeGraphMaintenanceCoordinator = Effect.fn('codeGraph.makeMain
       }),
     );
 
-  return CodeGraphMaintenanceCoordinator.of({kickOrdinary, kickResidual, request, tick});
+  return CodeGraphMaintenanceCoordinator.of({kickOrdinary, kickReconciliation, kickResidual, request, tick});
 });
 
 function automaticTailBudgetAvailable(budget: MaintenanceExecutionBudget, observedAt: number): boolean {

--- a/src/code_graph/visualization.ts
+++ b/src/code_graph/visualization.ts
@@ -443,6 +443,8 @@ export const managerGraphCatalog = Effect.fn('codeGraph.managerCatalog')(functio
           ...(anchor === undefined ? {} : {anchorPath: anchor}),
           checkoutId: entry.checkoutId,
           databasePath: entry.databasePath,
+          reconciliationPending:
+            'catalogs' in entry && entry.catalogs.some(observed => observed.localAssociation.state === 'missing'),
         };
       }),
       maintenance: lifecycleMaintenance.value,

--- a/src/code_graph/watcher.ts
+++ b/src/code_graph/watcher.ts
@@ -414,6 +414,7 @@ export class CodeGraphWatcher extends Context.Service<CodeGraphWatcher, CodeGrap
                     : ({reason: 'schema-unavailable', state: 'skipped'} as const),
                 ),
                 Effect.provideService(CommandExecutor, commandExecutor),
+                Effect.provideService(Crypto.Crypto, crypto),
                 Effect.provideService(FileSystem.FileSystem, fs),
                 Effect.provideService(Path.Path, path),
                 Effect.provideService(SystemInfo, systemInfo),

--- a/test/unit/code-graph.diagnostics.test.ts
+++ b/test/unit/code-graph.diagnostics.test.ts
@@ -296,7 +296,7 @@ describe('all-code-graph diagnostics', () => {
       }).pipe(provideTestLayer(ApplicationLayer)),
   );
 
-  effectIt.effect('advances missing-view reconciliation through the live Manager status poll', () =>
+  effectIt.effect('advances one missing-view reconciliation during a local diagnostics opportunity', () =>
     Effect.gen(function* () {
       const temporaryHome = yield* Effect.promise(() => mkdtemp('threadnote-graph-live-status-'));
       const fileSystem = yield* FileSystem.FileSystem;
@@ -350,24 +350,19 @@ describe('all-code-graph diagnostics', () => {
         execFileSync('git', ['-C', repository, 'worktree', 'remove', '--force', linked], {stdio: 'pipe'}),
       );
 
+      const beforeRevision = yield* observeManagerGraphCatalogRevision(home);
       const stale = yield* inspectAllCodeGraphsLocal(home);
       expect(stale.summary.viewCount).toBe(2);
       expect(stale.databases[0]?.views).toContainEqual(
         expect.objectContaining({localAssociation: expect.objectContaining({state: 'missing'})}),
       );
 
-      const beforeRevision = yield* observeManagerGraphCatalogRevision(home);
-      let status = yield* managerGraphBuildCatalog(home);
-      let activeViews = yield* store.loadActiveViewIdentities(database, 8);
-      expect(status.lifecyclePending || activeViews.length === 1).toBe(true);
-      for (let attempt = 0; attempt < 8 && activeViews.length > 1; attempt += 1) {
-        status = yield* managerGraphBuildCatalog(home);
-        activeViews = yield* store.loadActiveViewIdentities(database, 8);
-      }
+      const activeViews = yield* store.loadActiveViewIdentities(database, 8);
       expect(activeViews).toHaveLength(1);
       expect(activeViews[0]?.worktreeId).toBe(mainIdentity.worktreeId);
+      const status = yield* managerGraphBuildCatalog(home);
       expect(status.catalogRevision).not.toBe(beforeRevision);
-      expect((yield* managerGraphBuildCatalog(home)).lifecyclePending).toBe(false);
+      expect(status.lifecyclePending).toBe(false);
 
       const refreshed = yield* inspectAllCodeGraphsLocal(home);
       expect(refreshed.summary.viewCount).toBe(1);

--- a/test/unit/code-graph.lifecycle-classification.property.test.ts
+++ b/test/unit/code-graph.lifecycle-classification.property.test.ts
@@ -9,7 +9,11 @@ import {
   type CodeGraphLifecycleProtection,
   type CodeGraphLifecycleState,
 } from '../../src/code_graph/lifecycle_classification.js';
-import {selectCodeGraphLifecycleOpportunityTarget} from '../../src/code_graph/lifecycle_opportunity.js';
+import {
+  codeGraphLifecycleOpportunityUnits,
+  selectCodeGraphLifecycleOpportunityTarget,
+  selectCodeGraphLifecycleOpportunityUnit,
+} from '../../src/code_graph/lifecycle_opportunity.js';
 
 const reclaimableState = fc.constantFrom<CodeGraphLifecycleState>(
   'missing-view',
@@ -109,6 +113,68 @@ describe('code graph lifecycle classification properties', () => {
         }
         expect(visited).toEqual(['0'.repeat(64), '1'.repeat(64), '2'.repeat(64), '3'.repeat(64)]);
         expect(selectCodeGraphLifecycleOpportunityTarget(targets, cursor)?.checkoutId).toBe('0'.repeat(64));
+      }),
+      {numRuns: 40},
+    );
+  });
+
+  it('prioritizes cold pending reconciliation without breaking fair rotation', () => {
+    fc.assert(
+      fc.property(fc.shuffledSubarray([0, 1, 2, 3], {maxLength: 4, minLength: 4}), order => {
+        const targets = order.map(index => ({
+          ...(index % 2 === 1 ? {anchorPath: `/repository/${index}`} : {}),
+          checkoutId: index.toString(16).repeat(64),
+          databasePath: `/database/${index}`,
+          reconciliationPending: index % 2 === 1,
+        }));
+        const visited: string[] = [];
+        let cursor: string | undefined;
+        for (let index = 0; index < targets.length; index += 1) {
+          const selected = selectCodeGraphLifecycleOpportunityTarget(targets, cursor);
+          if (!selected) throw new TestError('valid lifecycle target was not selected');
+          visited.push(selected.checkoutId);
+          cursor = `${selected.checkoutId}\0${selected.databasePath}`;
+        }
+        expect(visited[0]).toBe('1'.repeat(64));
+        expect(new Set(visited)).toEqual(new Set(targets.map(target => target.checkoutId)));
+        const unanchored = targets.map(target => ({
+          checkoutId: target.checkoutId,
+          databasePath: target.databasePath,
+          reconciliationPending: target.reconciliationPending,
+        }));
+        expect(selectCodeGraphLifecycleOpportunityTarget(unanchored)?.checkoutId).toBe('0'.repeat(64));
+      }),
+      {numRuns: 40},
+    );
+  });
+
+  it('builds a bounded pending unit ring that visits every explicit lane exactly once', () => {
+    fc.assert(
+      fc.property(fc.shuffledSubarray([0, 1, 2, 3], {maxLength: 4, minLength: 4}), order => {
+        const targets = order.map(index => ({
+          ...(index === 1 || index === 3 ? {anchorPath: `/repository/${index}`} : {}),
+          checkoutId: index.toString(16).repeat(64),
+          databasePath: `/database/${index}`,
+          reconciliationPending: index === 1 || index === 2,
+        }));
+        const units = codeGraphLifecycleOpportunityUnits(targets, 'status');
+        const expected = [
+          `reconciliation:${'1'.repeat(64)}`,
+          ...[0, 1, 2, 3].map(index => `ordinary:${index.toString(16).repeat(64)}`),
+          ...[0, 1, 2, 3].map(index => `residual:${index.toString(16).repeat(64)}`),
+        ];
+        const visited: string[] = [];
+        let cursor: string | undefined;
+        for (let index = 0; index < units.length; index += 1) {
+          const selected = selectCodeGraphLifecycleOpportunityUnit(units, cursor);
+          if (!selected) throw new TestError('valid lifecycle unit was not selected');
+          visited.push(`${selected.lane}:${selected.target.checkoutId}`);
+          cursor = `${selected.lane}\0${selected.target.checkoutId}\0${selected.target.databasePath}`;
+        }
+
+        expect(visited).toEqual(expected);
+        expect(new Set(visited).size).toBe(units.length);
+        expect(selectCodeGraphLifecycleOpportunityUnit(units, cursor)).toEqual(units[0]);
       }),
       {numRuns: 40},
     );

--- a/test/unit/code-graph.lifecycle-opportunity.test.ts
+++ b/test/unit/code-graph.lifecycle-opportunity.test.ts
@@ -1,0 +1,427 @@
+import {TestError} from '../helpers/test-error.js';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path, Ref} from 'effect';
+import {describe, expect} from 'vitest';
+import {
+  makeCodeGraphLifecycleOpportunityRunner,
+  runCodeGraphLifecycleOpportunity,
+  type CodeGraphLifecycleOpportunityTarget,
+} from '../../src/code_graph/lifecycle_opportunity.js';
+import type {
+  CodeGraphMaintenanceCoordinatorShape,
+  CodeGraphRoutineMaintenanceTick,
+} from '../../src/code_graph/maintenance_coordinator.js';
+import {SystemInfo} from '../../src/effect/system.js';
+
+describe('code graph lifecycle opportunities', () => {
+  effectIt.layer(Layer.merge(BunServices.layer, SystemInfo.layer))(layerIt => {
+    layerIt.effect('services a pending reconciliation directly on a cold one-shot opportunity', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const threadnoteHome = yield* fs.makeTempDirectoryScoped({
+            prefix: 'threadnote-lifecycle-opportunity-cold-',
+          });
+          const calls = yield* Ref.make<readonly CodeGraphRoutineMaintenanceTick[]>([]);
+          const unexpected = (operation: string) =>
+            Effect.die(new TestError(`pending opportunity unexpectedly called ${operation}`));
+          const maintenance: CodeGraphMaintenanceCoordinatorShape = {
+            kickOrdinary: () => unexpected('ordinary maintenance'),
+            kickReconciliation: input =>
+              Ref.update(calls, current => [...current, input]).pipe(
+                Effect.as({
+                  cleanup: 'removed-worktree-view',
+                  expiredLeases: 0,
+                  remaining: true,
+                  retiredSnapshots: 1,
+                  rowsDeleted: 0,
+                  state: 'completed',
+                } as const),
+              ),
+            kickResidual: () => unexpected('residual maintenance'),
+            request: () => unexpected('detached maintenance'),
+            tick: () => unexpected('rotating maintenance'),
+          };
+          const targets: readonly CodeGraphLifecycleOpportunityTarget[] = [
+            {checkoutId: '0'.repeat(64), databasePath: '/database/healthy'},
+            {
+              anchorPath: '/repository/live-anchor',
+              checkoutId: 'f'.repeat(64),
+              databasePath: '/database/missing-view',
+              reconciliationPending: true,
+            },
+          ];
+
+          const result = yield* runCodeGraphLifecycleOpportunity({
+            maintenance,
+            opportunity: 'diagnostics',
+            targets,
+            threadnoteHome,
+          });
+
+          expect(result).toMatchObject({checkoutId: 'f'.repeat(64), state: 'completed'});
+          expect(yield* Ref.get(calls)).toEqual([
+            expect.objectContaining({
+              anchorPath: '/repository/live-anchor',
+              automaticTail: false,
+              checkoutId: 'f'.repeat(64),
+              databasePath: '/database/missing-view',
+              joinActive: false,
+            }),
+          ]);
+        }),
+      ),
+    );
+
+    layerIt.effect('persists cold rotation when an earlier pending database makes no progress', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const threadnoteHome = yield* fs.makeTempDirectoryScoped({
+            prefix: 'threadnote-lifecycle-opportunity-cursor-',
+          });
+          const firstCheckoutId = '0'.repeat(64);
+          const secondCheckoutId = '1'.repeat(64);
+          const calls = yield* Ref.make<readonly string[]>([]);
+          const unexpected = (operation: string) =>
+            Effect.die(new TestError(`pending opportunity unexpectedly called ${operation}`));
+          const maintenance: CodeGraphMaintenanceCoordinatorShape = {
+            kickOrdinary: () => unexpected('ordinary maintenance'),
+            kickReconciliation: input =>
+              Ref.update(calls, current => [...current, input.checkoutId]).pipe(
+                Effect.as(
+                  input.checkoutId === firstCheckoutId
+                    ? ({
+                        cleanup: 'none',
+                        expiredLeases: 0,
+                        remaining: false,
+                        retiredSnapshots: 0,
+                        rowsDeleted: 0,
+                        state: 'completed',
+                      } as const)
+                    : ({
+                        cleanup: 'removed-worktree-view',
+                        expiredLeases: 0,
+                        remaining: true,
+                        retiredSnapshots: 1,
+                        rowsDeleted: 0,
+                        state: 'completed',
+                      } as const),
+                ),
+              ),
+            kickResidual: () => unexpected('residual maintenance'),
+            request: () => unexpected('detached maintenance'),
+            tick: () => unexpected('rotating maintenance'),
+          };
+          const targets: readonly CodeGraphLifecycleOpportunityTarget[] = [
+            {
+              anchorPath: '/repository/unprovable-anchor',
+              checkoutId: firstCheckoutId,
+              databasePath: '/database/unprovable-missing-view',
+              reconciliationPending: true,
+            },
+            {
+              anchorPath: '/repository/actionable-anchor',
+              checkoutId: secondCheckoutId,
+              databasePath: '/database/actionable-missing-view',
+              reconciliationPending: true,
+            },
+          ];
+          const cursorRoot = path.join(threadnoteHome, 'locks', 'indexes', 'code-graph', 'lifecycle-opportunities');
+          const strandedTemporary = path.join(cursorRoot, '.diagnostics.cursor-v1.json.tmp');
+          yield* fs.makeDirectory(cursorRoot, {recursive: true});
+          yield* fs.writeFileString(strandedTemporary, 'stranded publication');
+
+          const firstProcess = makeCodeGraphLifecycleOpportunityRunner();
+          const first = yield* firstProcess({
+            maintenance,
+            opportunity: 'diagnostics',
+            targets,
+            threadnoteHome,
+          });
+          const secondProcess = makeCodeGraphLifecycleOpportunityRunner();
+          const second = yield* secondProcess({
+            maintenance,
+            opportunity: 'diagnostics',
+            targets,
+            threadnoteHome,
+          });
+
+          expect(first).toMatchObject({checkoutId: firstCheckoutId, result: {cleanup: 'none'}, state: 'completed'});
+          expect(second).toMatchObject({
+            checkoutId: secondCheckoutId,
+            result: {cleanup: 'removed-worktree-view'},
+            state: 'completed',
+          });
+          expect(yield* Ref.get(calls)).toEqual([firstCheckoutId, secondCheckoutId]);
+          const cursor = yield* fs.readFileString(path.join(cursorRoot, 'diagnostics.cursor-v1.json'));
+          expect(cursor).not.toContain('/database/');
+          expect(cursor).not.toContain('/repository/');
+          expect(yield* fs.exists(strandedTemporary)).toBe(false);
+        }),
+      ),
+    );
+
+    layerIt.effect('rotates every explicit lane for one unprovable pending database across fresh processes', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const threadnoteHome = yield* fs.makeTempDirectoryScoped({
+            prefix: 'threadnote-lifecycle-opportunity-sole-pending-',
+          });
+          const calls = yield* Ref.make<readonly string[]>([]);
+          const record = (lane: string) =>
+            Ref.update(calls, current => [...current, lane]).pipe(Effect.as(emptyMaintenanceResult()));
+          const maintenance: CodeGraphMaintenanceCoordinatorShape = {
+            kickOrdinary: () => record('ordinary'),
+            kickReconciliation: () => record('reconciliation'),
+            kickResidual: () => record('residual'),
+            request: () => Effect.die(new TestError('foreground opportunity unexpectedly detached maintenance')),
+            tick: () => Effect.die(new TestError('pending opportunity unexpectedly used process-local rotation')),
+          };
+          const target: CodeGraphLifecycleOpportunityTarget = {
+            anchorPath: '/repository/unprovable-anchor',
+            checkoutId: '4'.repeat(64),
+            databasePath: '/database/unprovable-missing-view',
+            reconciliationPending: true,
+          };
+
+          for (let index = 0; index < 3; index += 1) {
+            const freshProcess = makeCodeGraphLifecycleOpportunityRunner();
+            yield* freshProcess({
+              maintenance,
+              opportunity: 'status',
+              targets: [target],
+              threadnoteHome,
+            });
+          }
+
+          expect(yield* Ref.get(calls)).toEqual(['reconciliation', 'ordinary', 'residual']);
+        }),
+      ),
+    );
+
+    layerIt.effect('services a healthy sibling while one pending database remains unprovable', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const threadnoteHome = yield* fs.makeTempDirectoryScoped({
+            prefix: 'threadnote-lifecycle-opportunity-healthy-sibling-',
+          });
+          const calls = yield* Ref.make<readonly string[]>([]);
+          const record = (lane: string, input: CodeGraphRoutineMaintenanceTick) =>
+            Ref.update(calls, current => [...current, `${lane}:${input.checkoutId[0]}`]).pipe(
+              Effect.as(emptyMaintenanceResult()),
+            );
+          const maintenance: CodeGraphMaintenanceCoordinatorShape = {
+            kickOrdinary: input => record('ordinary', input),
+            kickReconciliation: input => record('reconciliation', input),
+            kickResidual: input => record('residual', input),
+            request: () => Effect.die(new TestError('foreground opportunity unexpectedly detached maintenance')),
+            tick: () => Effect.die(new TestError('pending opportunity unexpectedly used process-local rotation')),
+          };
+          const targets: readonly CodeGraphLifecycleOpportunityTarget[] = [
+            {
+              anchorPath: '/repository/unprovable-anchor',
+              checkoutId: '5'.repeat(64),
+              databasePath: '/database/unprovable-missing-view',
+              reconciliationPending: true,
+            },
+            {checkoutId: '6'.repeat(64), databasePath: '/database/healthy'},
+          ];
+
+          for (let index = 0; index < 5; index += 1) {
+            const freshProcess = makeCodeGraphLifecycleOpportunityRunner();
+            yield* freshProcess({maintenance, opportunity: 'catalog', targets, threadnoteHome});
+          }
+
+          expect(yield* Ref.get(calls)).toEqual([
+            'reconciliation:5',
+            'ordinary:5',
+            'ordinary:6',
+            'residual:5',
+            'residual:6',
+          ]);
+        }),
+      ),
+    );
+
+    layerIt.effect('rotates diagnostics through later anchored databases without a pending-view signal', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const threadnoteHome = yield* fs.makeTempDirectoryScoped({
+            prefix: 'threadnote-lifecycle-opportunity-diagnostics-sweep-',
+          });
+          const calls = yield* Ref.make<readonly string[]>([]);
+          const unexpected = (operation: string) =>
+            Effect.die(new TestError(`diagnostics sweep unexpectedly called ${operation}`));
+          const maintenance: CodeGraphMaintenanceCoordinatorShape = {
+            kickOrdinary: () => unexpected('ordinary maintenance before reconciliation sweep'),
+            kickReconciliation: input =>
+              Ref.update(calls, current => [...current, input.checkoutId]).pipe(Effect.as(emptyMaintenanceResult())),
+            kickResidual: () => unexpected('residual maintenance before reconciliation sweep'),
+            request: () => unexpected('detached maintenance'),
+            tick: () => unexpected('process-local rotation'),
+          };
+          const targets: readonly CodeGraphLifecycleOpportunityTarget[] = [
+            {
+              anchorPath: '/repository/first-anchor',
+              checkoutId: '7'.repeat(64),
+              databasePath: '/database/first',
+            },
+            {
+              anchorPath: '/repository/later-anchor',
+              checkoutId: '8'.repeat(64),
+              databasePath: '/database/later-hidden-candidate',
+            },
+          ];
+
+          for (let index = 0; index < 2; index += 1) {
+            const freshProcess = makeCodeGraphLifecycleOpportunityRunner();
+            yield* freshProcess({maintenance, opportunity: 'diagnostics', targets, threadnoteHome});
+          }
+
+          expect(yield* Ref.get(calls)).toEqual(['7'.repeat(64), '8'.repeat(64)]);
+        }),
+      ),
+    );
+
+    layerIt.effect('keeps healthy status opportunities free of durable cursor writes', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const threadnoteHome = yield* fs.makeTempDirectoryScoped({
+            prefix: 'threadnote-lifecycle-opportunity-healthy-status-',
+          });
+          const unexpected = (operation: string) =>
+            Effect.die(new TestError(`healthy status unexpectedly called ${operation}`));
+          const maintenance: CodeGraphMaintenanceCoordinatorShape = {
+            kickOrdinary: () => unexpected('direct ordinary maintenance'),
+            kickReconciliation: () => unexpected('direct reconciliation'),
+            kickResidual: () => unexpected('direct residual maintenance'),
+            request: () => unexpected('detached maintenance'),
+            tick: () => Effect.succeed(emptyMaintenanceResult()),
+          };
+          const target: CodeGraphLifecycleOpportunityTarget = {
+            anchorPath: '/repository/healthy-anchor',
+            checkoutId: '9'.repeat(64),
+            databasePath: '/database/healthy',
+          };
+
+          yield* makeCodeGraphLifecycleOpportunityRunner()({
+            maintenance,
+            opportunity: 'status',
+            targets: [target],
+            threadnoteHome,
+          });
+
+          expect(
+            yield* fs.exists(
+              path.join(
+                threadnoteHome,
+                'locks',
+                'indexes',
+                'code-graph',
+                'lifecycle-opportunities',
+                'status.cursor-v1.json',
+              ),
+            ),
+          ).toBe(false);
+        }),
+      ),
+    );
+
+    layerIt.effect('advances durable rotation before claimed maintenance crashes', () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const threadnoteHome = yield* fs.makeTempDirectoryScoped({
+            prefix: 'threadnote-lifecycle-opportunity-crash-',
+          });
+          const firstCheckoutId = '2'.repeat(64);
+          const secondCheckoutId = '3'.repeat(64);
+          const calls = yield* Ref.make<readonly string[]>([]);
+          const unexpected = (operation: string) =>
+            Effect.die(new TestError(`pending opportunity unexpectedly called ${operation}`));
+          const shared = {
+            kickOrdinary: () => unexpected('ordinary maintenance'),
+            kickResidual: () => unexpected('residual maintenance'),
+            request: () => unexpected('detached maintenance'),
+            tick: () => unexpected('rotating maintenance'),
+          } satisfies Omit<CodeGraphMaintenanceCoordinatorShape, 'kickReconciliation'>;
+          const targets: readonly CodeGraphLifecycleOpportunityTarget[] = [
+            {
+              anchorPath: '/repository/crashing-anchor',
+              checkoutId: firstCheckoutId,
+              databasePath: '/database/crashing-missing-view',
+              reconciliationPending: true,
+            },
+            {
+              anchorPath: '/repository/recovery-anchor',
+              checkoutId: secondCheckoutId,
+              databasePath: '/database/recovery-missing-view',
+              reconciliationPending: true,
+            },
+          ];
+          const firstProcess = makeCodeGraphLifecycleOpportunityRunner();
+          const firstExit = yield* firstProcess({
+            maintenance: {
+              ...shared,
+              kickReconciliation: input =>
+                Ref.update(calls, current => [...current, input.checkoutId]).pipe(
+                  Effect.andThen(Effect.die(new TestError('simulated process crash after cursor claim'))),
+                ),
+            },
+            opportunity: 'diagnostics',
+            targets,
+            threadnoteHome,
+          }).pipe(Effect.exit);
+
+          const secondProcess = makeCodeGraphLifecycleOpportunityRunner();
+          const second = yield* secondProcess({
+            maintenance: {
+              ...shared,
+              kickReconciliation: input =>
+                Ref.update(calls, current => [...current, input.checkoutId]).pipe(
+                  Effect.as({
+                    cleanup: 'removed-worktree-view',
+                    expiredLeases: 0,
+                    remaining: true,
+                    retiredSnapshots: 1,
+                    rowsDeleted: 0,
+                    state: 'completed',
+                  } as const),
+                ),
+            },
+            opportunity: 'diagnostics',
+            targets,
+            threadnoteHome,
+          });
+
+          expect(firstExit._tag).toBe('Failure');
+          expect(second).toMatchObject({
+            checkoutId: secondCheckoutId,
+            result: {cleanup: 'removed-worktree-view'},
+            state: 'completed',
+          });
+          expect(yield* Ref.get(calls)).toEqual([firstCheckoutId, secondCheckoutId]);
+        }),
+      ),
+    );
+  });
+});
+
+function emptyMaintenanceResult() {
+  return {
+    cleanup: 'none',
+    expiredLeases: 0,
+    remaining: false,
+    retiredSnapshots: 0,
+    rowsDeleted: 0,
+    state: 'completed',
+  } as const;
+}

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -166,6 +166,8 @@ describe('code graph query budgets', () => {
           CodeGraphMaintenanceCoordinator,
           CodeGraphMaintenanceCoordinator.of({
             kickOrdinary: () => Effect.die(new TestError('query trigger test must not kick ordinary maintenance')),
+            kickReconciliation: () =>
+              Effect.die(new TestError('query trigger test must not kick reconciliation maintenance')),
             kickResidual: () => Effect.die(new TestError('query trigger test must not kick residual maintenance')),
             request: input =>
               Ref.update(requests, current => [


### PR DESCRIPTION
## Summary

- surface exact missing-view evidence from diagnostics and Manager catalog/status reads
- durably rotate a bounded target-by-lane ring whenever exact pending evidence exists, so one unprovable database cannot monopolize fresh CLI processes or suppress sibling/ordinary/residual work
- make explicit diagnostics rotate reconciliation across every anchored database, allowing PR #246's orphan-provenance worker to progress without a speculative healthy-path scan or pending signal
- claim one unit before maintenance under a zero-wait recoverable file lock; each opportunity still executes at most one unit
- keep healthy startup/status/catalog paths on their existing in-process rotation with no cursor I/O
- persist only lane, checkout ID, and a SHA-256 database-path digest; publish atomically through one deterministic temporary so hard-crash leftovers stay bounded and self-recovering

## Defect

Removed linked worktrees remained as active graph view pointers when only short-lived diagnostics/catalog commands were running. Every fresh process began the in-memory database and maintenance-lane rotations from the same state, so valid missing-path plus absent-Git-registration authority could be observed indefinitely without reaching reconciliation.

`localAssociation.state == missing` is only an observational signal, not deletion authority. A legacy v1 record, still-registered linked worktree, or otherwise unprovable first database can return no progress forever. Persisting only the selected database fixed the multi-pending case but left a sole unprovable pending database able to suppress its ordinary/residual lanes and healthy siblings. The final scheduler therefore rotates explicit reconciliation, ordinary, and residual units across fresh processes. The cursor advances before work, so no-progress results and post-claim crashes cannot pin the ring.

Deletion authority is unchanged and remains inside the existing reconciliation/residual workers. A cursor claim only schedules a bounded attempt.

## Relationship to PR #246

PR #246 reclaims orphan local-provenance sidecars with no graph row; this PR retires still-active views whose linked worktree was removed. A sidecar without an active view is not itself an exact orphan signal because live, never-indexed worktrees legitimately have that shape. Instead of adding false-positive scans to status/catalog hot paths, explicit diagnostics now durably visits reconciliation for every anchored database. Once #246 is rebased here, its existing authority worker can therefore reach a later orphan candidate without either PR broadening deletion authority.

## Verification

- focused diagnostics, lifecycle opportunity/property, maintenance-lane, Manager catalog, query/telemetry, and watcher neighborhood: 117/117
- deterministic fresh-runner regression: one permanently unprovable pending database receives reconciliation, ordinary, and residual units in a complete bounded ring
- deterministic sibling regression: a healthy database receives ordinary/residual service while the pending database continues to return no progress
- deterministic diagnostics regression: a later anchored database receives reconciliation without a missing-view signal, covering PR #246 integration
- deterministic crash regression: a process defects after its durable claim and the next process advances
- stranded-publication regression: one deterministic temporary is recovered on the next claim; repeated hard crashes cannot accumulate UUID temporaries
- bounded Fast-check property: shuffled targets produce the same complete, duplicate-free explicit unit ring
- healthy-status regression: no durable cursor is created when no exact pending signal exists
- cursor privacy assertions: repository/database paths are never persisted
- exact built 4.4.0 isolated-home smoke: two packaged `graph diagnostics` calls advanced reconciliation to ordinary, and the cursor contained only schema/lane plus hashed identities
- full source/test/site typechecks; strict lint and file-length checks; standalone build; Prettier and diff checks
- independent review: CLEAN, no critical/important/minor findings

The shared global runtime was intentionally not replaced because the release/Manager task owns it.
