### PR TITLE
fix(graph): recover reconciliation cursor metadata

### DIFF
--- a/src/code_graph/store_reconciliation.ts
+++ b/src/code_graph/store_reconciliation.ts
@@ -22,14 +22,14 @@ import {
 import {normalizeSchemaDefinition} from './store_schema_normalization.js';
 import {
   REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
+  type SchemaMetadataMaximumRows,
   inspectBoundedSchemaMetadataRowCount,
   inspectBoundedSchemaMetadataValue,
 } from './store_schema_metadata.js';
 import {
+  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   CODE_GRAPH_SCHEMA_VERSION,
-  CodeGraphStoreCorruptionError,
   CodeGraphStoreError,
-  CodeGraphStoreIncompatibleSchemaError,
 } from './types.js';
 import {
   allocateRemovedViewCleanupEpoch,
@@ -73,8 +73,98 @@ import {lastStatementChangeCount} from './store_activation_core.js';
 import {type CodeGraphSqlQueryStatement} from './store_visualization_sql.js';
 
 const WORKTREE_RECONCILIATION_CURSOR_KEY = 'worktree_reconciliation_cursor';
-const WORKTREE_RECONCILIATION_CURSOR_PATTERN = /^[0-9a-f]{64}$/u;
-const WORKTREE_RECONCILIATION_CURSOR_OPERATION = 'claim code graph reconciliation candidates';
+const WORKTREE_RECONCILIATION_CURSOR = /^[0-9a-f]{64}$/u;
+const WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS = 67 satisfies SchemaMetadataMaximumRows;
+
+interface WorktreeReconciliationCursor {
+  readonly recorded: boolean;
+  readonly value: string | undefined;
+}
+
+const admitOrRecoverWorktreeReconciliationSchema = Effect.fn('codeGraph.admitOrRecoverWorktreeReconciliationSchema')(
+  function* (sql: SqlClient.SqlClient) {
+    if (yield* codeGraphWorktreeReconciliationSchemaCompatible(sql)) return true;
+
+    const revision = yield* removedViewCleanupRecordedRevision(
+      sql,
+      WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
+    );
+    if (revision.state !== 'recorded' || revision.value !== CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) {
+      return false;
+    }
+    const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(
+      sql,
+      WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
+    );
+    const cleanupCursor = yield* inspectRemovedViewCleanupAdmissionCursor(
+      sql,
+      WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
+    );
+    const admittedRows =
+      REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - (cleanupCursor.cursor === undefined ? 1 : 0);
+    if (!cleanupCursor.current || metadataRowCount !== admittedRows + 1) return false;
+
+    const cursor = yield* inspectBoundedSchemaMetadataValue(
+      sql,
+      WORKTREE_RECONCILIATION_CURSOR_KEY,
+      64,
+      WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
+    );
+    if (cursor.state === 'missing') return false;
+    yield* sql.unsafe('DELETE FROM schema_metadata WHERE key = ? COLLATE NOCASE', [WORKTREE_RECONCILIATION_CURSOR_KEY]);
+    if ((yield* lastStatementChangeCount(sql)) < 1) {
+      return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation cursor recovery changed.'));
+    }
+    return yield* codeGraphWorktreeReconciliationSchemaCompatible(sql);
+  },
+);
+
+const inspectWorktreeReconciliationCursor = Effect.fn('codeGraph.inspectWorktreeReconciliationCursor')(function* (
+  sql: SqlClient.SqlClient,
+) {
+  const inspection = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
+  if (inspection.state === 'recorded' && WORKTREE_RECONCILIATION_CURSOR.test(inspection.value)) {
+    return {recorded: true, value: inspection.value} satisfies WorktreeReconciliationCursor;
+  }
+  if (inspection.state === 'missing') {
+    return {recorded: false, value: undefined} satisfies WorktreeReconciliationCursor;
+  }
+  // This cursor schedules advisory work only. Once the surrounding schema and
+  // authoritative cleanup cursor are admitted, discard only this bounded key
+  // family and restart from the beginning instead of disabling reconciliation.
+  yield* sql.unsafe('DELETE FROM schema_metadata WHERE key = ? COLLATE NOCASE', [WORKTREE_RECONCILIATION_CURSOR_KEY]);
+  return {recorded: false, value: undefined} satisfies WorktreeReconciliationCursor;
+});
+
+const recordWorktreeReconciliationCursor = Effect.fn('codeGraph.recordWorktreeReconciliationCursor')(function* (
+  sql: SqlClient.SqlClient,
+  current: WorktreeReconciliationCursor,
+  nextCursor: string,
+) {
+  if (current.recorded) {
+    yield* sql.unsafe('UPDATE schema_metadata SET value = ? WHERE key = ? COLLATE BINARY', [
+      nextCursor,
+      WORKTREE_RECONCILIATION_CURSOR_KEY,
+    ]);
+    if ((yield* lastStatementChangeCount(sql)) !== 1) {
+      return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation cursor changed.'));
+    }
+    return;
+  }
+
+  const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(sql);
+  const cleanupCursor = yield* inspectRemovedViewCleanupAdmissionCursor(sql);
+  if (metadataRowCount === undefined || !cleanupCursor.current) {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation schema is unavailable.'));
+  }
+  const maximumRows = REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - (cleanupCursor.cursor === undefined ? 1 : 0);
+  if (metadataRowCount >= maximumRows) return;
+
+  yield* sql.unsafe('INSERT INTO schema_metadata (key, value) VALUES (?, ?)', [
+    WORKTREE_RECONCILIATION_CURSOR_KEY,
+    nextCursor,
+  ]);
+});
 
 const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktreeReconciliationCandidates')(function* (
   sql: SqlClient.SqlClient,
@@ -83,23 +173,11 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
   const limit = Number.isSafeInteger(requestedLimit) ? Math.max(1, Math.min(32, requestedLimit)) : 32;
   return yield* sql.withTransaction(
     Effect.gen(function* () {
-      if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql))) {
+      if (!(yield* admitOrRecoverWorktreeReconciliationSchema(sql))) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation schema is unavailable.'));
       }
-      const cursorInspection = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
-      if (cursorInspection.state === 'invalid') {
-        return yield* Effect.fail(
-          new CodeGraphStoreCorruptionError('Code graph reconciliation cursor metadata is structurally invalid.', {
-            operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
-          }),
-        );
-      }
-      const recordedCursor = cursorInspection.state === 'recorded' ? cursorInspection.value : undefined;
-      const cursor =
-        recordedCursor !== undefined && WORKTREE_RECONCILIATION_CURSOR_PATTERN.test(recordedCursor)
-          ? recordedCursor
-          : undefined;
-      const resetMalformedCursor = recordedCursor !== undefined && cursor === undefined;
+      const cursorState = yield* inspectWorktreeReconciliationCursor(sql);
+      const cursor = cursorState.value;
       const selectPage = (boundary: 'after' | 'through', pageLimit: number) => {
         const statement = codeGraphWorktreeReconciliationCandidatePageStatement(cursor, boundary, pageLimit);
         return sql.unsafe<{
@@ -129,54 +207,8 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
       ) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation candidate is invalid.'));
       }
-      let cursorRecorded = recordedCursor !== undefined;
-      if (resetMalformedCursor) {
-        yield* sql`
-          DELETE FROM schema_metadata
-          WHERE key = ${WORKTREE_RECONCILIATION_CURSOR_KEY}
-            AND value = ${recordedCursor}
-        `;
-        if ((yield* lastStatementChangeCount(sql)) !== 1) {
-          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
-        }
-        cursorRecorded = false;
-      }
       if (nextCursor !== undefined) {
-        if (cursorRecorded) {
-          yield* sql`
-            UPDATE schema_metadata
-            SET value = ${nextCursor}
-            WHERE key = ${WORKTREE_RECONCILIATION_CURSOR_KEY}
-              AND value = ${recordedCursor}
-          `;
-        } else {
-          const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(sql);
-          if (
-            metadataRowCount === undefined ||
-            metadataRowCount >= REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS
-          ) {
-            return yield* Effect.fail(
-              new CodeGraphStoreIncompatibleSchemaError(
-                'Code graph reconciliation cursor metadata capacity is unavailable.',
-                {
-                  operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
-                },
-              ),
-            );
-          }
-          yield* sql`
-            INSERT INTO schema_metadata (key, value)
-            VALUES (${WORKTREE_RECONCILIATION_CURSOR_KEY}, ${nextCursor})
-            ON CONFLICT(key) DO NOTHING
-          `;
-        }
-        if ((yield* lastStatementChangeCount(sql)) !== 1) {
-          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
-        }
-        const advancedCursor = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
-        if (advancedCursor.state !== 'recorded' || advancedCursor.value !== nextCursor) {
-          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
-        }
+        yield* recordWorktreeReconciliationCursor(sql, cursorState, nextCursor);
       }
       return rows
         .filter(row => row.snapshot_state === 'ready' && Number(row.tombstoned) === 0)
@@ -188,15 +220,6 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
     }),
   );
 });
-
-function worktreeReconciliationCursorChangedError(): CodeGraphStoreError {
-  return new CodeGraphStoreCorruptionError(
-    'Code graph reconciliation cursor metadata changed before it could advance.',
-    {
-      operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
-    },
-  );
-}
 
 /** @internal Indexed cursor-page statement retained for query-plan and high-cardinality regressions. */
 
@@ -295,7 +318,9 @@ const codeGraphWorktreeReconciliationSchemaCompatible: (
     }
     const removedForeignKeys = yield* sql.unsafe(`SELECT 1 FROM pragma_foreign_key_list('removed_views') LIMIT 1`);
     if (removedForeignKeys.length !== 0) return false;
-    if (requireCleanup && !(yield* codeGraphRemovedViewCleanupBaseSchemaAdmission(sql)).current) return false;
+    if (requireCleanup && !(yield* codeGraphRemovedViewCleanupBaseSchemaAdmission(sql)).current) {
+      return false;
+    }
     const snapshotForeignKeys = yield* sql.unsafe<{
       readonly from: string;
       readonly match: string;

--- a/src/code_graph/store_reconciliation.ts
+++ b/src/code_graph/store_reconciliation.ts
@@ -24,10 +24,12 @@ import {
 import {normalizeSchemaDefinition} from './store_schema_normalization.js';
 import {
   REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
+  type SchemaMetadataMaximumRows,
   inspectBoundedSchemaMetadataRowCount,
   inspectBoundedSchemaMetadataValue,
 } from './store_schema_metadata.js';
 import {
+  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   CODE_GRAPH_SCHEMA_VERSION,
   CodeGraphStoreCorruptionError,
   CodeGraphStoreError,
@@ -77,8 +79,125 @@ import {type CodeGraphSqlQueryStatement} from './store_visualization_sql.js';
 const WORKTREE_RECONCILIATION_CURSOR_KEY = 'worktree_reconciliation_cursor';
 const WORKTREE_RECONCILIATION_CURSOR_PATTERN = /^[0-9a-f]{64}$/u;
 const WORKTREE_RECONCILIATION_CURSOR_OPERATION = 'claim code graph reconciliation candidates';
+const WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS = 67 satisfies SchemaMetadataMaximumRows;
 const ORPHAN_PROVENANCE_CURSOR_KEY = 'orphan_provenance_cursor';
 const ORPHAN_PROVENANCE_WORKTREE_ID_LIMIT = 4_096;
+
+type WorktreeReconciliationCursorState =
+  {readonly recorded: true; readonly value: string} | {readonly recorded: false; readonly value: undefined};
+
+const admitOrRecoverWorktreeReconciliationSchema = Effect.fn('codeGraph.admitOrRecoverWorktreeReconciliationSchema')(
+  function* (sql: SqlClient.SqlClient) {
+    if (yield* codeGraphWorktreeReconciliationSchemaCompatible(sql)) return true;
+
+    const revision = yield* removedViewCleanupRecordedRevision(
+      sql,
+      WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
+    );
+    if (revision.state !== 'recorded' || revision.value !== CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) {
+      return false;
+    }
+    const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(
+      sql,
+      WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
+    );
+    const cleanupCursor = yield* inspectRemovedViewCleanupAdmissionCursor(
+      sql,
+      WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
+    );
+    if (!cleanupCursor.current) return false;
+    const admittedRows =
+      REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - (cleanupCursor.cursor === undefined ? 1 : 0);
+    if (metadataRowCount !== admittedRows + 1) return false;
+
+    const cursor = yield* inspectBoundedSchemaMetadataValue(
+      sql,
+      WORKTREE_RECONCILIATION_CURSOR_KEY,
+      64,
+      WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
+    );
+    if (cursor.state === 'invalid') {
+      return yield* Effect.fail(worktreeReconciliationCursorStructuralError());
+    }
+    if (cursor.state === 'missing') return false;
+    yield* clearWorktreeReconciliationCursor(sql, cursor.value);
+    return yield* codeGraphWorktreeReconciliationSchemaCompatible(sql);
+  },
+);
+
+const inspectWorktreeReconciliationCursor = Effect.fn('codeGraph.inspectWorktreeReconciliationCursor')(function* (
+  sql: SqlClient.SqlClient,
+) {
+  const inspection = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
+  if (inspection.state === 'invalid') {
+    return yield* Effect.fail(worktreeReconciliationCursorStructuralError());
+  }
+  if (inspection.state === 'missing') {
+    return {recorded: false, value: undefined} satisfies WorktreeReconciliationCursorState;
+  }
+  if (WORKTREE_RECONCILIATION_CURSOR_PATTERN.test(inspection.value)) {
+    return {recorded: true, value: inspection.value} satisfies WorktreeReconciliationCursorState;
+  }
+  yield* clearWorktreeReconciliationCursor(sql, inspection.value);
+  return {recorded: false, value: undefined} satisfies WorktreeReconciliationCursorState;
+});
+
+const clearWorktreeReconciliationCursor = Effect.fn('codeGraph.clearWorktreeReconciliationCursor')(function* (
+  sql: SqlClient.SqlClient,
+  recordedCursor: string,
+) {
+  yield* sql.unsafe(
+    `DELETE FROM schema_metadata
+     WHERE key = ? COLLATE BINARY
+       AND value = ? COLLATE BINARY`,
+    [WORKTREE_RECONCILIATION_CURSOR_KEY, recordedCursor],
+  );
+  if ((yield* lastStatementChangeCount(sql)) !== 1) {
+    return yield* Effect.fail(worktreeReconciliationCursorChangedError());
+  }
+  const clearedCursor = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
+  if (clearedCursor.state !== 'missing') {
+    return yield* Effect.fail(worktreeReconciliationCursorChangedError());
+  }
+});
+
+const recordWorktreeReconciliationCursor = Effect.fn('codeGraph.recordWorktreeReconciliationCursor')(function* (
+  sql: SqlClient.SqlClient,
+  current: WorktreeReconciliationCursorState,
+  nextCursor: string,
+) {
+  if (current.recorded) {
+    yield* sql.unsafe(
+      `UPDATE schema_metadata
+       SET value = ?
+       WHERE key = ? COLLATE BINARY
+         AND value = ? COLLATE BINARY`,
+      [nextCursor, WORKTREE_RECONCILIATION_CURSOR_KEY, current.value],
+    );
+  } else {
+    const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(sql);
+    const cleanupCursor = yield* inspectRemovedViewCleanupAdmissionCursor(sql);
+    if (metadataRowCount === undefined || !cleanupCursor.current) {
+      return yield* Effect.fail(worktreeReconciliationCursorCapacityError());
+    }
+    const maximumRows =
+      REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - (cleanupCursor.cursor === undefined ? 1 : 0);
+    if (metadataRowCount >= maximumRows) return;
+    yield* sql.unsafe(
+      `INSERT INTO schema_metadata (key, value)
+       VALUES (?, ?)
+       ON CONFLICT(key) DO NOTHING`,
+      [WORKTREE_RECONCILIATION_CURSOR_KEY, nextCursor],
+    );
+  }
+  if ((yield* lastStatementChangeCount(sql)) !== 1) {
+    return yield* Effect.fail(worktreeReconciliationCursorChangedError());
+  }
+  const advancedCursor = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
+  if (advancedCursor.state !== 'recorded' || advancedCursor.value !== nextCursor) {
+    return yield* Effect.fail(worktreeReconciliationCursorChangedError());
+  }
+});
 
 const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktreeReconciliationCandidates')(function* (
   sql: SqlClient.SqlClient,
@@ -87,23 +206,11 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
   const limit = Number.isSafeInteger(requestedLimit) ? Math.max(1, Math.min(32, requestedLimit)) : 32;
   return yield* sql.withTransaction(
     Effect.gen(function* () {
-      if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql))) {
+      if (!(yield* admitOrRecoverWorktreeReconciliationSchema(sql))) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation schema is unavailable.'));
       }
-      const cursorInspection = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
-      if (cursorInspection.state === 'invalid') {
-        return yield* Effect.fail(
-          new CodeGraphStoreCorruptionError('Code graph reconciliation cursor metadata is structurally invalid.', {
-            operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
-          }),
-        );
-      }
-      const recordedCursor = cursorInspection.state === 'recorded' ? cursorInspection.value : undefined;
-      const cursor =
-        recordedCursor !== undefined && WORKTREE_RECONCILIATION_CURSOR_PATTERN.test(recordedCursor)
-          ? recordedCursor
-          : undefined;
-      const resetMalformedCursor = recordedCursor !== undefined && cursor === undefined;
+      const cursorState = yield* inspectWorktreeReconciliationCursor(sql);
+      const cursor = cursorState.value;
       const selectPage = (boundary: 'after' | 'through', pageLimit: number) => {
         const statement = codeGraphWorktreeReconciliationCandidatePageStatement(cursor, boundary, pageLimit);
         return sql.unsafe<{
@@ -133,54 +240,8 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
       ) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation candidate is invalid.'));
       }
-      let cursorRecorded = recordedCursor !== undefined;
-      if (resetMalformedCursor) {
-        yield* sql`
-          DELETE FROM schema_metadata
-          WHERE key = ${WORKTREE_RECONCILIATION_CURSOR_KEY}
-            AND value = ${recordedCursor}
-        `;
-        if ((yield* lastStatementChangeCount(sql)) !== 1) {
-          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
-        }
-        cursorRecorded = false;
-      }
       if (nextCursor !== undefined) {
-        if (cursorRecorded) {
-          yield* sql`
-            UPDATE schema_metadata
-            SET value = ${nextCursor}
-            WHERE key = ${WORKTREE_RECONCILIATION_CURSOR_KEY}
-              AND value = ${recordedCursor}
-          `;
-        } else {
-          const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(sql);
-          if (
-            metadataRowCount === undefined ||
-            metadataRowCount >= REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS
-          ) {
-            return yield* Effect.fail(
-              new CodeGraphStoreIncompatibleSchemaError(
-                'Code graph reconciliation cursor metadata capacity is unavailable.',
-                {
-                  operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
-                },
-              ),
-            );
-          }
-          yield* sql`
-            INSERT INTO schema_metadata (key, value)
-            VALUES (${WORKTREE_RECONCILIATION_CURSOR_KEY}, ${nextCursor})
-            ON CONFLICT(key) DO NOTHING
-          `;
-        }
-        if ((yield* lastStatementChangeCount(sql)) !== 1) {
-          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
-        }
-        const advancedCursor = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
-        if (advancedCursor.state !== 'recorded' || advancedCursor.value !== nextCursor) {
-          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
-        }
+        yield* recordWorktreeReconciliationCursor(sql, cursorState, nextCursor);
       }
       return rows
         .filter(row => row.snapshot_state === 'ready' && Number(row.tombstoned) === 0)
@@ -193,9 +254,24 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
   );
 });
 
+function worktreeReconciliationCursorStructuralError(): CodeGraphStoreCorruptionError {
+  return new CodeGraphStoreCorruptionError('Code graph reconciliation cursor metadata is structurally invalid.', {
+    operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
+  });
+}
+
 function worktreeReconciliationCursorChangedError(): CodeGraphStoreError {
   return new CodeGraphStoreCorruptionError(
     'Code graph reconciliation cursor metadata changed before it could advance.',
+    {
+      operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
+    },
+  );
+}
+
+function worktreeReconciliationCursorCapacityError(): CodeGraphStoreIncompatibleSchemaError {
+  return new CodeGraphStoreIncompatibleSchemaError(
+    'Code graph reconciliation cursor metadata capacity is unavailable.',
     {
       operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
     },

--- a/src/code_graph/store_reconciliation.ts
+++ b/src/code_graph/store_reconciliation.ts
@@ -20,8 +20,17 @@ import {
   removedViewCleanupRecordedRevision,
 } from './store_removed_view_schema_inspection.js';
 import {normalizeSchemaDefinition} from './store_schema_normalization.js';
-import {inspectBoundedSchemaMetadataValue} from './store_schema_metadata.js';
-import {CODE_GRAPH_SCHEMA_VERSION, CodeGraphStoreError} from './types.js';
+import {
+  REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
+  inspectBoundedSchemaMetadataRowCount,
+  inspectBoundedSchemaMetadataValue,
+} from './store_schema_metadata.js';
+import {
+  CODE_GRAPH_SCHEMA_VERSION,
+  CodeGraphStoreCorruptionError,
+  CodeGraphStoreError,
+  CodeGraphStoreIncompatibleSchemaError,
+} from './types.js';
 import {
   allocateRemovedViewCleanupEpoch,
   authorityPrimaryKeyBinary,
@@ -63,6 +72,10 @@ import {
 import {lastStatementChangeCount} from './store_activation_core.js';
 import {type CodeGraphSqlQueryStatement} from './store_visualization_sql.js';
 
+const WORKTREE_RECONCILIATION_CURSOR_KEY = 'worktree_reconciliation_cursor';
+const WORKTREE_RECONCILIATION_CURSOR_PATTERN = /^[0-9a-f]{64}$/u;
+const WORKTREE_RECONCILIATION_CURSOR_OPERATION = 'claim code graph reconciliation candidates';
+
 const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktreeReconciliationCandidates')(function* (
   sql: SqlClient.SqlClient,
   requestedLimit: number,
@@ -73,14 +86,20 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
       if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql))) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation schema is unavailable.'));
       }
-      const cursorRows = yield* sql<{readonly value: string}>`
-          SELECT value FROM schema_metadata WHERE key = 'worktree_reconciliation_cursor' LIMIT 1
-        `;
-      const recordedCursor = cursorRows[0]?.value;
-      if (recordedCursor !== undefined && !/^[0-9a-f]{64}$/.test(recordedCursor)) {
-        return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation cursor is invalid.'));
+      const cursorInspection = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
+      if (cursorInspection.state === 'invalid') {
+        return yield* Effect.fail(
+          new CodeGraphStoreCorruptionError('Code graph reconciliation cursor metadata is structurally invalid.', {
+            operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
+          }),
+        );
       }
-      const cursor = recordedCursor;
+      const recordedCursor = cursorInspection.state === 'recorded' ? cursorInspection.value : undefined;
+      const cursor =
+        recordedCursor !== undefined && WORKTREE_RECONCILIATION_CURSOR_PATTERN.test(recordedCursor)
+          ? recordedCursor
+          : undefined;
+      const resetMalformedCursor = recordedCursor !== undefined && cursor === undefined;
       const selectPage = (boundary: 'after' | 'through', pageLimit: number) => {
         const statement = codeGraphWorktreeReconciliationCandidatePageStatement(cursor, boundary, pageLimit);
         return sql.unsafe<{
@@ -110,12 +129,54 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
       ) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph reconciliation candidate is invalid.'));
       }
-      if (nextCursor !== undefined) {
+      let cursorRecorded = recordedCursor !== undefined;
+      if (resetMalformedCursor) {
         yield* sql`
-            INSERT INTO schema_metadata (key, value)
-            VALUES ('worktree_reconciliation_cursor', ${nextCursor})
-            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+          DELETE FROM schema_metadata
+          WHERE key = ${WORKTREE_RECONCILIATION_CURSOR_KEY}
+            AND value = ${recordedCursor}
+        `;
+        if ((yield* lastStatementChangeCount(sql)) !== 1) {
+          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
+        }
+        cursorRecorded = false;
+      }
+      if (nextCursor !== undefined) {
+        if (cursorRecorded) {
+          yield* sql`
+            UPDATE schema_metadata
+            SET value = ${nextCursor}
+            WHERE key = ${WORKTREE_RECONCILIATION_CURSOR_KEY}
+              AND value = ${recordedCursor}
           `;
+        } else {
+          const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(sql);
+          if (
+            metadataRowCount === undefined ||
+            metadataRowCount >= REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS
+          ) {
+            return yield* Effect.fail(
+              new CodeGraphStoreIncompatibleSchemaError(
+                'Code graph reconciliation cursor metadata capacity is unavailable.',
+                {
+                  operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
+                },
+              ),
+            );
+          }
+          yield* sql`
+            INSERT INTO schema_metadata (key, value)
+            VALUES (${WORKTREE_RECONCILIATION_CURSOR_KEY}, ${nextCursor})
+            ON CONFLICT(key) DO NOTHING
+          `;
+        }
+        if ((yield* lastStatementChangeCount(sql)) !== 1) {
+          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
+        }
+        const advancedCursor = yield* inspectBoundedSchemaMetadataValue(sql, WORKTREE_RECONCILIATION_CURSOR_KEY, 64);
+        if (advancedCursor.state !== 'recorded' || advancedCursor.value !== nextCursor) {
+          return yield* Effect.fail(worktreeReconciliationCursorChangedError());
+        }
       }
       return rows
         .filter(row => row.snapshot_state === 'ready' && Number(row.tombstoned) === 0)
@@ -127,6 +188,15 @@ const claimWorktreeReconciliationCandidates = Effect.fn('codeGraph.claimWorktree
     }),
   );
 });
+
+function worktreeReconciliationCursorChangedError(): CodeGraphStoreError {
+  return new CodeGraphStoreCorruptionError(
+    'Code graph reconciliation cursor metadata changed before it could advance.',
+    {
+      operation: WORKTREE_RECONCILIATION_CURSOR_OPERATION,
+    },
+  );
+}
 
 /** @internal Indexed cursor-page statement retained for query-plan and high-cardinality regressions. */
 

--- a/src/code_graph/store_removed_view_schema_inspection.ts
+++ b/src/code_graph/store_removed_view_schema_inspection.ts
@@ -7,7 +7,12 @@ import {
   REMOVED_VIEW_CLEANUP_TABLE_SQL,
   REMOVED_VIEW_CLEANUP_TRIGGER_DEFINITIONS,
 } from './store_removed_view_schema_contracts.js';
-import {SCHEMA_METADATA_TABLE_SQL, inspectBoundedSchemaMetadataValue} from './store_schema_metadata.js';
+import {
+  REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
+  SCHEMA_METADATA_TABLE_SQL,
+  type SchemaMetadataMaximumRows,
+  inspectBoundedSchemaMetadataValue,
+} from './store_schema_metadata.js';
 import {normalizeSchemaDefinition} from './store_schema_normalization.js';
 
 export const removedViewAuthorityTableState = Effect.fn('codeGraph.removedViewAuthorityTableState')(function* (
@@ -274,6 +279,7 @@ export const removedViewCleanupSchemaState = Effect.fn('codeGraph.removedViewCle
 
 export const removedViewCleanupRecordedRevision = Effect.fn('codeGraph.removedViewCleanupRecordedRevision')(function* (
   sql: SqlClient.SqlClient,
+  maximumMetadataRows: SchemaMetadataMaximumRows = REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
 ) {
   const metadataObjects = yield* sql.unsafe<{
     readonly name: unknown;
@@ -381,7 +387,12 @@ export const removedViewCleanupRecordedRevision = Effect.fn('codeGraph.removedVi
   );
   if (foreignKeys.length !== 0 || triggers.length !== 0) return {state: 'invalid'};
 
-  const revision = yield* inspectBoundedSchemaMetadataValue(sql, 'persistent_extension_schema_revision', 16);
+  const revision = yield* inspectBoundedSchemaMetadataValue(
+    sql,
+    'persistent_extension_schema_revision',
+    16,
+    maximumMetadataRows,
+  );
   if (revision.state === 'missing') return {metadataPresent: true, state: 'missing'};
   if (
     revision.state === 'invalid' ||

--- a/src/code_graph/store_schema_core.ts
+++ b/src/code_graph/store_schema_core.ts
@@ -12,6 +12,7 @@ import {
 } from './store_removed_view_schema_inspection.js';
 import {
   REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
+  type SchemaMetadataMaximumRows,
   inspectBoundedSchemaMetadataRowCount,
   inspectBoundedSchemaMetadataValue,
 } from './store_schema_metadata.js';
@@ -25,8 +26,16 @@ const removedViewCleanupSchemaCurrent = Effect.fn('codeGraph.removedViewCleanupS
 });
 
 const inspectRemovedViewCleanupAdmissionCursor = Effect.fn('codeGraph.inspectRemovedViewCleanupAdmissionCursor')(
-  function* (sql: SqlClient.SqlClient) {
-    const inspection = yield* inspectBoundedSchemaMetadataValue(sql, REMOVED_VIEW_CLEANUP_ADMISSION_CURSOR_KEY, 64);
+  function* (
+    sql: SqlClient.SqlClient,
+    maximumMetadataRows: SchemaMetadataMaximumRows = REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
+  ) {
+    const inspection = yield* inspectBoundedSchemaMetadataValue(
+      sql,
+      REMOVED_VIEW_CLEANUP_ADMISSION_CURSOR_KEY,
+      64,
+      maximumMetadataRows,
+    );
     if (inspection.state === 'missing') return {current: true, cursor: undefined} as const;
     if (inspection.state === 'invalid' || !/^[0-9a-f]{64}$/u.test(inspection.value)) {
       return {current: false, cursor: undefined} as const;

--- a/src/code_graph/store_schema_metadata.ts
+++ b/src/code_graph/store_schema_metadata.ts
@@ -6,6 +6,7 @@ import {CodeGraphRuntimeReconnectRequiredError, CodeGraphStoreError} from './typ
 
 export const REMOVED_VIEW_CLEANUP_LEGACY_MAXIMUM_METADATA_ROWS = 64;
 export const REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS = 66;
+export type SchemaMetadataMaximumRows = 66 | 67;
 
 export const SCHEMA_METADATA_TABLE_SQL = `CREATE TABLE IF NOT EXISTS schema_metadata (
   key TEXT PRIMARY KEY NOT NULL,
@@ -13,11 +14,12 @@ export const SCHEMA_METADATA_TABLE_SQL = `CREATE TABLE IF NOT EXISTS schema_meta
 )`;
 
 export const inspectBoundedSchemaMetadataRowCount = Effect.fn('codeGraph.inspectBoundedSchemaMetadataRowCount')(
-  function* (sql: SqlClient.SqlClient) {
-    const rows = yield* sql.unsafe(
-      `SELECT 1 FROM schema_metadata LIMIT ${REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS + 1}`,
-    );
-    return rows.length > REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS ? undefined : rows.length;
+  function* (
+    sql: SqlClient.SqlClient,
+    maximumRows: SchemaMetadataMaximumRows = REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
+  ) {
+    const rows = yield* sql.unsafe(`SELECT 1 FROM schema_metadata LIMIT ${maximumRows + 1}`);
+    return rows.length > maximumRows ? undefined : rows.length;
   },
 );
 
@@ -25,8 +27,9 @@ export const inspectBoundedSchemaMetadataValue = Effect.fn('codeGraph.inspectBou
   sql: SqlClient.SqlClient,
   key: string,
   maximumValueBytes: number,
+  maximumRows: SchemaMetadataMaximumRows = REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS,
 ) {
-  if ((yield* inspectBoundedSchemaMetadataRowCount(sql)) === undefined) {
+  if ((yield* inspectBoundedSchemaMetadataRowCount(sql, maximumRows)) === undefined) {
     return {state: 'invalid'} as const;
   }
   const rows = yield* sql.unsafe<{

--- a/test/unit/code-graph.worktree-reconciliation.test.ts
+++ b/test/unit/code-graph.worktree-reconciliation.test.ts
@@ -42,7 +42,6 @@ import {
   CodeGraphStoreError,
   type CodeGraphSnapshot,
 } from '../../src/code_graph/types.js';
-import {REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS} from '../../src/code_graph/store_schema_metadata.js';
 import type {RepositoryIdentity} from '../../src/code_graph/types.js';
 import {
   CODE_GRAPH_WORKTREE_RECONCILIATION_CANDIDATE_LIMIT,
@@ -60,10 +59,6 @@ const targetWorktreeId = 'd'.repeat(64);
 const expectedSnapshotId = `cgsn_${'e'.repeat(40)}`;
 const privateRoot = '/private/threadnote/repository';
 const registryRootIdentity = 'f'.repeat(64);
-const boundedMalformedReconciliationCursor = fc
-  .array(fc.constantFrom(...'0123456789abcdefxyz_-'.split('')), {maxLength: 64})
-  .map(characters => characters.join(''))
-  .filter(value => !/^[0-9a-f]{64}$/u.test(value));
 const temporaryRoots: string[] = [];
 const storeLayer = CodeGraphStore.layer.pipe(
   Layer.provideMerge(SystemInfo.layer),
@@ -450,7 +445,7 @@ describe('automatic missing-worktree reconciliation', () => {
     }),
   );
 
-  effectIt.effect('claims a durable cross-process cursor page and recovers bounded malformed state', () =>
+  effectIt.effect('repairs only malformed advisory cursor state and keeps authoritative state fail closed', () =>
     TestClock.withLive(
       Effect.gen(function* () {
         const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-'));
@@ -472,21 +467,58 @@ describe('automatic missing-worktree reconciliation', () => {
         expect(claimed.size).toBe(69);
         expect(claimed.has(worktreeIds.at(-1)!)).toBe(false);
 
-        const recovered = yield* Effect.sync(() => {
+        const cleanupCursor = 'e'.repeat(64);
+        const repaired = yield* Effect.sync(() => {
           const database = new Database(databasePath, {strict: true});
           try {
             database
-              .query("UPDATE schema_metadata SET value = 'malformed' WHERE key = 'worktree_reconciliation_cursor'")
-              .run();
+              .query('INSERT INTO schema_metadata (key, value) VALUES (?, ?)')
+              .run('removed_view_cleanup_admission_cursor', cleanupCursor);
+            database
+              .query('UPDATE schema_metadata SET value = ? WHERE key = ?')
+              .run('malformed'.repeat(128), 'worktree_reconciliation_cursor');
+            database
+              .query('INSERT INTO schema_metadata (key, value) VALUES (?, ?)')
+              .run('WORKTREE_RECONCILIATION_CURSOR', 'f'.repeat(64));
+          } finally {
+            database.close(false);
+          }
+        }).pipe(Effect.andThen(store.claimWorktreeReconciliationCandidates(databasePath, 32)));
+        expect(repaired).toHaveLength(32);
+        expect(readSchemaMetadataFamily(databasePath, 'worktree_reconciliation_cursor')).toEqual([
+          {key: 'worktree_reconciliation_cursor', value: worktreeIds[31]},
+        ]);
+        expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(cleanupCursor);
+
+        const authoritative = yield* Effect.sync(() => {
+          const database = new Database(databasePath, {strict: true});
+          try {
+            database
+              .query('UPDATE schema_metadata SET value = ? WHERE key = ?')
+              .run('malformed-authoritative', 'removed_view_cleanup_admission_cursor');
           } finally {
             database.close(false);
           }
         }).pipe(Effect.andThen(store.claimWorktreeReconciliationCandidates(databasePath, 32).pipe(Effect.exit)));
-        expect(recovered._tag).toBe('Success');
-        if (recovered._tag === 'Success') {
-          expect(recovered.value.map(entry => entry.worktreeId)).toEqual(worktreeIds.slice(0, 32));
+        expect(authoritative._tag).toBe('Failure');
+        if (authoritative._tag === 'Failure') {
+          expect(String(authoritative.cause)).not.toContain('malformed-authoritative');
+          expect(String(authoritative.cause)).not.toContain(root);
         }
+        expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(
+          'malformed-authoritative',
+        );
         expect(readReconciliationCursor(databasePath)).toBe(worktreeIds[31]);
+        yield* Effect.sync(() => {
+          const database = new Database(databasePath, {strict: true});
+          try {
+            database
+              .query('UPDATE schema_metadata SET value = ? WHERE key = ?')
+              .run(cleanupCursor, 'removed_view_cleanup_admission_cursor');
+          } finally {
+            database.close(false);
+          }
+        });
 
         const incompatibleVersion = yield* Effect.sync(() => {
           const database = new Database(databasePath, {strict: true});
@@ -537,53 +569,102 @@ describe('automatic missing-worktree reconciliation', () => {
     ),
   );
 
-  effectIt.effect('bounds invalid cursor diagnostics and refuses a missing cursor at metadata capacity', () =>
+  effectIt.effect('does not consume the authoritative cleanup cursor reservation at either metadata ceiling', () =>
     TestClock.withLive(
       Effect.gen(function* () {
-        const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-bounds-'));
-        temporaryRoots.push(root);
-        const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
         const store = yield* CodeGraphStore;
-        yield* store.initialize(databasePath);
-        const worktreeIds = ['0'.repeat(64), '1'.repeat(64)];
-        yield* Effect.sync(() => seedCandidateViews(databasePath, worktreeIds, false));
+        for (const cleanupCursorRecorded of [false, true]) {
+          const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-capacity-'));
+          temporaryRoots.push(root);
+          const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+          yield* store.initialize(databasePath);
+          yield* Effect.sync(() => {
+            seedCandidateViews(databasePath, [targetWorktreeId], false);
+            if (cleanupCursorRecorded) {
+              executeDatabaseSql(
+                databasePath,
+                `INSERT INTO schema_metadata (key, value)
+                 VALUES ('removed_view_cleanup_admission_cursor', '${'e'.repeat(64)}')`,
+              );
+            }
+          });
+          const maximumRows = cleanupCursorRecorded ? 66 : 65;
+          const fillerKeys = yield* Effect.sync(() => fillSchemaMetadataToCount(databasePath, maximumRows));
 
-        const oversized = 'private-cursor-content-'.repeat(4_096);
-        yield* Effect.sync(() => writeReconciliationCursor(databasePath, oversized));
-        const invalid = yield* Effect.flip(store.claimWorktreeReconciliationCandidates(databasePath, 1));
-        expect(invalid).toBeInstanceOf(CodeGraphStoreError);
-        expect(invalid.message).toBe('Code graph reconciliation cursor metadata is structurally invalid.');
-        expect(invalid.code).toBe('confirmed-corruption');
-        expect(invalid.operation).toBe('claim code graph reconciliation candidates');
-        expect(invalid.recovery).toBe('manual-rebuild');
-        expect(invalid.message).not.toContain(oversized.slice(0, 32));
-        expect(readReconciliationCursor(databasePath)).toBe(oversized);
+          expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+          expect(readReconciliationCursor(databasePath)).toBeUndefined();
+          expect(yield* store.claimWorktreeReconciliationCandidates(databasePath, 1)).toHaveLength(1);
+          expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+          expect(readReconciliationCursor(databasePath)).toBeUndefined();
+          expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(
+            cleanupCursorRecorded ? 'e'.repeat(64) : undefined,
+          );
 
-        yield* Effect.sync(() => {
-          deleteReconciliationCursor(databasePath);
-          fillSchemaMetadataToCapacity(databasePath);
-        });
-        const capacity = yield* Effect.flip(store.claimWorktreeReconciliationCandidates(databasePath, 1));
-        expect(capacity).toBeInstanceOf(CodeGraphStoreError);
-        expect(capacity.message).toBe('Code graph reconciliation cursor metadata capacity is unavailable.');
-        expect(capacity.code).toBe('incompatible-schema');
-        expect(capacity.operation).toBe('claim code graph reconciliation candidates');
-        expect(capacity.recovery).toBe('manual-migration');
-        expect(readReconciliationCursor(databasePath)).toBeUndefined();
-        expect(readSchemaMetadataRowCount(databasePath)).toBe(REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS);
+          const legacyCursor = cleanupCursorRecorded ? 'a'.repeat(64) : 'malformed'.repeat(128);
+          yield* Effect.sync(() => {
+            const database = new Database(databasePath, {strict: true});
+            try {
+              database
+                .query('INSERT INTO schema_metadata (key, value) VALUES (?, ?)')
+                .run('worktree_reconciliation_cursor', legacyCursor);
+              if (cleanupCursorRecorded) {
+                database
+                  .query('UPDATE schema_metadata SET value = ? WHERE key = ?')
+                  .run('malformed-authoritative', 'removed_view_cleanup_admission_cursor');
+              }
+            } finally {
+              database.close(false);
+            }
+          });
+          expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows + 1);
+          if (cleanupCursorRecorded) {
+            const refused = yield* store.claimWorktreeReconciliationCandidates(databasePath, 1).pipe(Effect.exit);
+            expect(refused._tag).toBe('Failure');
+            expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows + 1);
+            expect(readReconciliationCursor(databasePath)).toBe(legacyCursor);
+            expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(
+              'malformed-authoritative',
+            );
+            yield* Effect.sync(() => {
+              const database = new Database(databasePath, {strict: true});
+              try {
+                database
+                  .query('UPDATE schema_metadata SET value = ? WHERE key = ?')
+                  .run('e'.repeat(64), 'removed_view_cleanup_admission_cursor');
+              } finally {
+                database.close(false);
+              }
+            });
+          }
 
-        yield* Effect.sync(() => deleteOneFillerMetadataRow(databasePath));
-        const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 1);
-        expect(claimed.map(entry => entry.worktreeId)).toEqual([worktreeIds[0]]);
-        expect(readReconciliationCursor(databasePath)).toBe(worktreeIds[0]);
-        expect(readSchemaMetadataRowCount(databasePath)).toBe(REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS);
+          expect(yield* store.claimWorktreeReconciliationCandidates(databasePath, 1)).toHaveLength(1);
+          expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+          expect(readReconciliationCursor(databasePath)).toBeUndefined();
+          expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(
+            cleanupCursorRecorded ? 'e'.repeat(64) : undefined,
+          );
+          expect(yield* store.claimWorktreeReconciliationCandidates(databasePath, 1)).toHaveLength(1);
+          expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+          expect(readReconciliationCursor(databasePath)).toBeUndefined();
+
+          yield* Effect.sync(() =>
+            executeDatabaseSql(databasePath, `DELETE FROM schema_metadata WHERE key = '${fillerKeys.at(-1)}'`),
+          );
+          expect(yield* store.claimWorktreeReconciliationCandidates(databasePath, 1)).toHaveLength(1);
+          expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+          expect(readReconciliationCursor(databasePath)).toBe(targetWorktreeId);
+        }
       }).pipe(provideTestLayer(storeLayer)),
     ),
   );
 
   effectIt.effect.prop(
-    'atomically replaces every bounded semantic-invalid cursor with the claimed page boundary',
-    {malformedCursor: boundedMalformedReconciliationCursor},
+    'canonicalizes every bounded malformed advisory cursor without changing authoritative cursor state',
+    {
+      malformedCursor: fc
+        .oneof(fc.string({maxLength: 96}), fc.string({maxLength: 192, minLength: 65}))
+        .filter(value => !/^[0-9a-f]{64}$/u.test(value)),
+    },
     ({malformedCursor}) =>
       TestClock.withLive(
         Effect.gen(function* () {
@@ -591,19 +672,30 @@ describe('automatic missing-worktree reconciliation', () => {
           temporaryRoots.push(root);
           const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
           const store = yield* CodeGraphStore;
+          const cleanupCursor = 'e'.repeat(64);
           yield* store.initialize(databasePath);
-          const worktreeIds = ['0'.repeat(64), '1'.repeat(64), '2'.repeat(64)];
           yield* Effect.sync(() => {
-            seedCandidateViews(databasePath, worktreeIds, false);
-            writeReconciliationCursor(databasePath, malformedCursor);
+            seedCandidateViews(databasePath, [targetWorktreeId], false);
+            const database = new Database(databasePath, {strict: true});
+            try {
+              database
+                .query('INSERT INTO schema_metadata (key, value) VALUES (?, ?), (?, ?)')
+                .run(
+                  'removed_view_cleanup_admission_cursor',
+                  cleanupCursor,
+                  'worktree_reconciliation_cursor',
+                  malformedCursor,
+                );
+            } finally {
+              database.close(false);
+            }
           });
-          const beforeRows = readSchemaMetadataRowCount(databasePath);
 
-          const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 2);
-
-          expect(claimed.map(entry => entry.worktreeId)).toEqual(worktreeIds.slice(0, 2));
-          expect(readReconciliationCursor(databasePath)).toBe(worktreeIds[1]);
-          expect(readSchemaMetadataRowCount(databasePath)).toBe(beforeRows);
+          expect(yield* store.claimWorktreeReconciliationCandidates(databasePath, 1)).toHaveLength(1);
+          expect(readSchemaMetadataFamily(databasePath, 'worktree_reconciliation_cursor')).toEqual([
+            {key: 'worktree_reconciliation_cursor', value: targetWorktreeId},
+          ]);
+          expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(cleanupCursor);
         }).pipe(provideTestLayer(storeLayer)),
       ),
     {fastCheck: {numRuns: 24}},
@@ -1789,85 +1881,62 @@ function removeViewTombstone(databasePath: string, worktreeId: string): void {
 }
 
 function readReconciliationCursor(databasePath: string): string | undefined {
+  return readSchemaMetadataValue(databasePath, 'worktree_reconciliation_cursor');
+}
+
+function readSchemaMetadataValue(databasePath: string, key: string): string | undefined {
   const database = new Database(databasePath, {readonly: true, strict: true});
   try {
-    const row = database
-      .query("SELECT value FROM schema_metadata WHERE key = 'worktree_reconciliation_cursor'")
-      .get() as {readonly value: string} | null;
+    const row = database.query('SELECT value FROM schema_metadata WHERE key = ? COLLATE BINARY').get(key) as {
+      readonly value: string;
+    } | null;
     return row?.value;
   } finally {
     database.close(false);
   }
 }
 
-function writeReconciliationCursor(databasePath: string, value: string): void {
-  const database = new Database(databasePath, {strict: true});
+function readSchemaMetadataFamily(
+  databasePath: string,
+  key: string,
+): readonly {readonly key: string; readonly value: string}[] {
+  const database = new Database(databasePath, {readonly: true, strict: true});
   try {
-    database
-      .query(
-        `INSERT INTO schema_metadata (key, value) VALUES ('worktree_reconciliation_cursor', ?)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-      )
-      .run(value);
+    return database
+      .query('SELECT key, value FROM schema_metadata WHERE key = ? COLLATE NOCASE ORDER BY key')
+      .all(key) as readonly {readonly key: string; readonly value: string}[];
   } finally {
     database.close(false);
   }
 }
 
-function deleteReconciliationCursor(databasePath: string): void {
-  const database = new Database(databasePath, {strict: true});
+function readSchemaMetadataCount(databasePath: string): number {
+  const database = new Database(databasePath, {readonly: true, strict: true});
   try {
-    database.query("DELETE FROM schema_metadata WHERE key = 'worktree_reconciliation_cursor'").run();
+    const row = database.query('SELECT COUNT(*) AS count FROM schema_metadata').get() as {
+      readonly count: number;
+    };
+    return Number(row.count);
   } finally {
     database.close(false);
   }
 }
 
-function fillSchemaMetadataToCapacity(databasePath: string): void {
+function fillSchemaMetadataToCount(databasePath: string, targetCount: number): readonly string[] {
   const database = new Database(databasePath, {strict: true});
   try {
-    database
-      .query(
-        `INSERT INTO schema_metadata (key, value) VALUES ('removed_view_cleanup_admission_cursor', ?)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-      )
-      .run('f'.repeat(64));
-    const count = Number(
-      database.query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM schema_metadata').get()?.count ?? 0,
+    const current = Number(
+      (database.query('SELECT COUNT(*) AS count FROM schema_metadata').get() as {count: number}).count,
+    );
+    const keys = Array.from(
+      {length: Math.max(0, targetCount - current)},
+      (_, index) => `reconciliation_cursor_capacity_${index.toString().padStart(2, '0')}`,
     );
     const insert = database.prepare('INSERT INTO schema_metadata (key, value) VALUES (?, ?)');
     database.transaction(() => {
-      for (let index = count; index < REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS; index += 1) {
-        insert.run(`cursor-capacity-filler-${index}`, 'bounded');
-      }
+      for (const key of keys) insert.run(key, 'bounded-fixture');
     })();
-  } finally {
-    database.close(false);
-  }
-}
-
-function deleteOneFillerMetadataRow(databasePath: string): void {
-  const database = new Database(databasePath, {strict: true});
-  try {
-    database
-      .query(
-        `DELETE FROM schema_metadata
-         WHERE key = (
-           SELECT key FROM schema_metadata WHERE key LIKE 'cursor-capacity-filler-%' ORDER BY key LIMIT 1
-         )`,
-      )
-      .run();
-  } finally {
-    database.close(false);
-  }
-}
-
-function readSchemaMetadataRowCount(databasePath: string): number {
-  const database = new Database(databasePath, {readonly: true, strict: true});
-  try {
-    return Number(
-      database.query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM schema_metadata').get()?.count ?? -1,
-    );
+    return keys;
   } finally {
     database.close(false);
   }

--- a/test/unit/code-graph.worktree-reconciliation.test.ts
+++ b/test/unit/code-graph.worktree-reconciliation.test.ts
@@ -537,46 +537,195 @@ describe('automatic missing-worktree reconciliation', () => {
     ),
   );
 
-  effectIt.effect('bounds invalid cursor diagnostics and refuses a missing cursor at metadata capacity', () =>
+  effectIt.effect('fails closed on structural cursor metadata with fixed path-free diagnostics', () =>
     TestClock.withLive(
       Effect.gen(function* () {
-        const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-bounds-'));
-        temporaryRoots.push(root);
-        const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
         const store = yield* CodeGraphStore;
-        yield* store.initialize(databasePath);
-        const worktreeIds = ['0'.repeat(64), '1'.repeat(64)];
-        yield* Effect.sync(() => seedCandidateViews(databasePath, worktreeIds, false));
-
         const oversized = 'private-cursor-content-'.repeat(4_096);
-        yield* Effect.sync(() => writeReconciliationCursor(databasePath, oversized));
-        const invalid = yield* Effect.flip(store.claimWorktreeReconciliationCandidates(databasePath, 1));
-        expect(invalid).toBeInstanceOf(CodeGraphStoreError);
-        expect(invalid.message).toBe('Code graph reconciliation cursor metadata is structurally invalid.');
-        expect(invalid.code).toBe('confirmed-corruption');
-        expect(invalid.operation).toBe('claim code graph reconciliation candidates');
-        expect(invalid.recovery).toBe('manual-rebuild');
-        expect(invalid.message).not.toContain(oversized.slice(0, 32));
-        expect(readReconciliationCursor(databasePath)).toBe(oversized);
+        const cases = [
+          {
+            entries: [['worktree_reconciliation_cursor', oversized]] as const,
+            name: 'oversized exact key',
+            privateValue: oversized,
+          },
+          {
+            entries: [['WORKTREE_RECONCILIATION_CURSOR', 'private-wrong-case-cursor']] as const,
+            name: 'wrong-case key',
+            privateValue: 'private-wrong-case-cursor',
+          },
+          {
+            entries: [
+              ['worktree_reconciliation_cursor', 'a'.repeat(64)],
+              ['WORKTREE_RECONCILIATION_CURSOR', 'private-ambiguous-cursor'],
+            ] as const,
+            name: 'ambiguous key family',
+            privateValue: 'private-ambiguous-cursor',
+          },
+        ];
 
-        yield* Effect.sync(() => {
-          deleteReconciliationCursor(databasePath);
-          fillSchemaMetadataToCapacity(databasePath);
-        });
-        const capacity = yield* Effect.flip(store.claimWorktreeReconciliationCandidates(databasePath, 1));
-        expect(capacity).toBeInstanceOf(CodeGraphStoreError);
-        expect(capacity.message).toBe('Code graph reconciliation cursor metadata capacity is unavailable.');
-        expect(capacity.code).toBe('incompatible-schema');
-        expect(capacity.operation).toBe('claim code graph reconciliation candidates');
-        expect(capacity.recovery).toBe('manual-migration');
-        expect(readReconciliationCursor(databasePath)).toBeUndefined();
-        expect(readSchemaMetadataRowCount(databasePath)).toBe(REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS);
+        for (const testCase of cases) {
+          const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-bounds-'));
+          temporaryRoots.push(root);
+          const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+          yield* store.initialize(databasePath);
+          yield* Effect.sync(() => {
+            seedCandidateViews(databasePath, [targetWorktreeId], false);
+            for (const [key, value] of testCase.entries) insertSchemaMetadata(databasePath, key, value);
+          });
+          const before = readSchemaMetadataFamily(databasePath, 'worktree_reconciliation_cursor');
 
-        yield* Effect.sync(() => deleteOneFillerMetadataRow(databasePath));
-        const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 1);
-        expect(claimed.map(entry => entry.worktreeId)).toEqual([worktreeIds[0]]);
-        expect(readReconciliationCursor(databasePath)).toBe(worktreeIds[0]);
-        expect(readSchemaMetadataRowCount(databasePath)).toBe(REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS);
+          const invalid = yield* Effect.flip(store.claimWorktreeReconciliationCandidates(databasePath, 1));
+
+          expect(invalid, testCase.name).toBeInstanceOf(CodeGraphStoreError);
+          expect(invalid.message, testCase.name).toBe(
+            'Code graph reconciliation cursor metadata is structurally invalid.',
+          );
+          expect(invalid.code, testCase.name).toBe('confirmed-corruption');
+          expect(invalid.operation, testCase.name).toBe('claim code graph reconciliation candidates');
+          expect(invalid.recovery, testCase.name).toBe('manual-rebuild');
+          expect(JSON.stringify(invalid), testCase.name).not.toContain(testCase.privateValue.slice(0, 32));
+          expect(JSON.stringify(invalid), testCase.name).not.toContain(root);
+          expect(readSchemaMetadataFamily(databasePath, 'worktree_reconciliation_cursor'), testCase.name).toEqual(
+            before,
+          );
+        }
+      }).pipe(provideTestLayer(storeLayer)),
+    ),
+  );
+
+  effectIt.effect('preserves cursor capacity and next-call liveness at both authoritative metadata ceilings', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        for (const cleanupCursorRecorded of [false, true]) {
+          const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-capacity-'));
+          temporaryRoots.push(root);
+          const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+          yield* store.initialize(databasePath);
+          yield* Effect.sync(() => {
+            seedCandidateViews(databasePath, [targetWorktreeId], false);
+            if (cleanupCursorRecorded) {
+              insertSchemaMetadata(databasePath, 'removed_view_cleanup_admission_cursor', 'e'.repeat(64));
+            }
+          });
+          const maximumRows = REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - (cleanupCursorRecorded ? 0 : 1);
+          const fillerKeys = yield* Effect.sync(() => fillSchemaMetadataToCount(databasePath, maximumRows));
+
+          for (let call = 0; call < 2; call += 1) {
+            const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 1);
+            expect(claimed.map(entry => entry.worktreeId)).toEqual([targetWorktreeId]);
+            expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+            expect(readReconciliationCursor(databasePath)).toBeUndefined();
+          }
+          expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(
+            cleanupCursorRecorded ? 'e'.repeat(64) : undefined,
+          );
+
+          yield* Effect.sync(() => deleteSchemaMetadata(databasePath, fillerKeys.at(-1)!));
+          const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 1);
+          expect(claimed.map(entry => entry.worktreeId)).toEqual([targetWorktreeId]);
+          expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+          expect(readReconciliationCursor(databasePath)).toBe(targetWorktreeId);
+        }
+      }).pipe(provideTestLayer(storeLayer)),
+    ),
+  );
+
+  effectIt.effect('recovers only a unique exact bounded legacy overflow at the 66- and 67-row bounds', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        for (const cleanupCursorRecorded of [false, true]) {
+          for (const legacyCursor of ['a'.repeat(64), 'bounded-malformed-cursor']) {
+            const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-legacy-overflow-'));
+            temporaryRoots.push(root);
+            const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+            yield* store.initialize(databasePath);
+            yield* Effect.sync(() => {
+              seedCandidateViews(databasePath, [targetWorktreeId], false);
+              if (cleanupCursorRecorded) {
+                insertSchemaMetadata(databasePath, 'removed_view_cleanup_admission_cursor', 'e'.repeat(64));
+              }
+            });
+            const maximumRows = REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - (cleanupCursorRecorded ? 0 : 1);
+            const fillerKeys = yield* Effect.sync(() => fillSchemaMetadataToCount(databasePath, maximumRows));
+            yield* Effect.sync(() =>
+              insertSchemaMetadata(databasePath, 'worktree_reconciliation_cursor', legacyCursor),
+            );
+            expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows + 1);
+
+            for (let call = 0; call < 2; call += 1) {
+              const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 1);
+              expect(claimed.map(entry => entry.worktreeId)).toEqual([targetWorktreeId]);
+              expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+              expect(readReconciliationCursor(databasePath)).toBeUndefined();
+            }
+            expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(
+              cleanupCursorRecorded ? 'e'.repeat(64) : undefined,
+            );
+
+            yield* Effect.sync(() => deleteSchemaMetadata(databasePath, fillerKeys.at(-1)!));
+            expect(yield* store.claimWorktreeReconciliationCandidates(databasePath, 1)).toHaveLength(1);
+            expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+            expect(readReconciliationCursor(databasePath)).toBe(targetWorktreeId);
+          }
+        }
+      }).pipe(provideTestLayer(storeLayer)),
+    ),
+  );
+
+  effectIt.effect('does not recover structurally invalid legacy overflow cursor families', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        const structuralCases = [
+          {
+            entries: [['worktree_reconciliation_cursor', 'private-oversized-cursor'.repeat(64)]] as const,
+            fillerRows: 66,
+            name: 'oversized exact key',
+          },
+          {
+            entries: [['WORKTREE_RECONCILIATION_CURSOR', 'private-wrong-case-cursor']] as const,
+            fillerRows: 66,
+            name: 'wrong-case key',
+          },
+          {
+            entries: [
+              ['worktree_reconciliation_cursor', 'a'.repeat(64)],
+              ['WORKTREE_RECONCILIATION_CURSOR', 'private-ambiguous-cursor'],
+            ] as const,
+            fillerRows: 65,
+            name: 'ambiguous key family',
+          },
+        ];
+
+        for (const testCase of structuralCases) {
+          const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-legacy-structural-'));
+          temporaryRoots.push(root);
+          const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+          yield* store.initialize(databasePath);
+          yield* Effect.sync(() => {
+            seedCandidateViews(databasePath, [targetWorktreeId], false);
+            insertSchemaMetadata(databasePath, 'removed_view_cleanup_admission_cursor', 'e'.repeat(64));
+            fillSchemaMetadataToCount(databasePath, testCase.fillerRows);
+            for (const [key, value] of testCase.entries) insertSchemaMetadata(databasePath, key, value);
+          });
+          const before = readSchemaMetadataFamily(databasePath, 'worktree_reconciliation_cursor');
+          expect(readSchemaMetadataCount(databasePath), testCase.name).toBe(67);
+
+          const invalid = yield* Effect.flip(store.claimWorktreeReconciliationCandidates(databasePath, 1));
+
+          expect(invalid.message, testCase.name).toBe(
+            'Code graph reconciliation cursor metadata is structurally invalid.',
+          );
+          expect(invalid.code, testCase.name).toBe('confirmed-corruption');
+          expect(JSON.stringify(invalid), testCase.name).not.toContain(root);
+          expect(readSchemaMetadataCount(databasePath), testCase.name).toBe(67);
+          expect(readSchemaMetadataFamily(databasePath, 'worktree_reconciliation_cursor'), testCase.name).toEqual(
+            before,
+          );
+          expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe('e'.repeat(64));
+        }
       }).pipe(provideTestLayer(storeLayer)),
     ),
   );
@@ -597,16 +746,55 @@ describe('automatic missing-worktree reconciliation', () => {
             seedCandidateViews(databasePath, worktreeIds, false);
             writeReconciliationCursor(databasePath, malformedCursor);
           });
-          const beforeRows = readSchemaMetadataRowCount(databasePath);
+          const beforeRows = readSchemaMetadataCount(databasePath);
 
           const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 2);
 
           expect(claimed.map(entry => entry.worktreeId)).toEqual(worktreeIds.slice(0, 2));
           expect(readReconciliationCursor(databasePath)).toBe(worktreeIds[1]);
-          expect(readSchemaMetadataRowCount(databasePath)).toBe(beforeRows);
+          expect(readSchemaMetadataCount(databasePath)).toBe(beforeRows);
         }).pipe(provideTestLayer(storeLayer)),
       ),
     {fastCheck: {numRuns: 24}},
+  );
+
+  effectIt.effect.prop(
+    'recovers bounded semantic legacy overflow without consuming either metadata reservation',
+    {
+      cleanupCursorRecorded: fc.boolean(),
+      legacyCursor: fc.oneof(fc.constant('a'.repeat(64)), boundedMalformedReconciliationCursor),
+    },
+    ({cleanupCursorRecorded, legacyCursor}) =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-legacy-property-'));
+          temporaryRoots.push(root);
+          const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+          const store = yield* CodeGraphStore;
+          yield* store.initialize(databasePath);
+          yield* Effect.sync(() => {
+            seedCandidateViews(databasePath, [targetWorktreeId], false);
+            if (cleanupCursorRecorded) {
+              insertSchemaMetadata(databasePath, 'removed_view_cleanup_admission_cursor', 'e'.repeat(64));
+            }
+          });
+          const maximumRows = REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS - (cleanupCursorRecorded ? 0 : 1);
+          yield* Effect.sync(() => {
+            fillSchemaMetadataToCount(databasePath, maximumRows);
+            insertSchemaMetadata(databasePath, 'worktree_reconciliation_cursor', legacyCursor);
+          });
+
+          for (let call = 0; call < 2; call += 1) {
+            expect(yield* store.claimWorktreeReconciliationCandidates(databasePath, 1)).toHaveLength(1);
+            expect(readSchemaMetadataCount(databasePath)).toBe(maximumRows);
+            expect(readReconciliationCursor(databasePath)).toBeUndefined();
+          }
+          expect(readSchemaMetadataValue(databasePath, 'removed_view_cleanup_admission_cursor')).toBe(
+            cleanupCursorRecorded ? 'e'.repeat(64) : undefined,
+          );
+        }).pipe(provideTestLayer(storeLayer)),
+      ),
+    {fastCheck: {numRuns: 16}},
   );
 
   effectIt.effect('uses indexed cursor pages without a temporary sort across ten thousand real views', () =>
@@ -1789,12 +1977,49 @@ function removeViewTombstone(databasePath: string, worktreeId: string): void {
 }
 
 function readReconciliationCursor(databasePath: string): string | undefined {
+  return readSchemaMetadataValue(databasePath, 'worktree_reconciliation_cursor');
+}
+
+function readSchemaMetadataValue(databasePath: string, key: string): string | undefined {
   const database = new Database(databasePath, {readonly: true, strict: true});
   try {
-    const row = database
-      .query("SELECT value FROM schema_metadata WHERE key = 'worktree_reconciliation_cursor'")
-      .get() as {readonly value: string} | null;
+    const row = database.query('SELECT value FROM schema_metadata WHERE key = ? COLLATE BINARY').get(key) as {
+      readonly value: string;
+    } | null;
     return row?.value;
+  } finally {
+    database.close(false);
+  }
+}
+
+function readSchemaMetadataFamily(
+  databasePath: string,
+  key: string,
+): readonly {readonly key: string; readonly value: string}[] {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return database
+      .query('SELECT key, value FROM schema_metadata WHERE key = ? COLLATE NOCASE ORDER BY key')
+      .all(key) as readonly {readonly key: string; readonly value: string}[];
+  } finally {
+    database.close(false);
+  }
+}
+
+function readSchemaMetadataCount(databasePath: string): number {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    const row = database.query('SELECT COUNT(*) AS count FROM schema_metadata').get() as {readonly count: number};
+    return Number(row.count);
+  } finally {
+    database.close(false);
+  }
+}
+
+function insertSchemaMetadata(databasePath: string, key: string, value: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.query('INSERT INTO schema_metadata (key, value) VALUES (?, ?)').run(key, value);
   } finally {
     database.close(false);
   }
@@ -1814,60 +2039,30 @@ function writeReconciliationCursor(databasePath: string, value: string): void {
   }
 }
 
-function deleteReconciliationCursor(databasePath: string): void {
+function fillSchemaMetadataToCount(databasePath: string, targetCount: number): readonly string[] {
   const database = new Database(databasePath, {strict: true});
   try {
-    database.query("DELETE FROM schema_metadata WHERE key = 'worktree_reconciliation_cursor'").run();
-  } finally {
-    database.close(false);
-  }
-}
-
-function fillSchemaMetadataToCapacity(databasePath: string): void {
-  const database = new Database(databasePath, {strict: true});
-  try {
-    database
-      .query(
-        `INSERT INTO schema_metadata (key, value) VALUES ('removed_view_cleanup_admission_cursor', ?)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-      )
-      .run('f'.repeat(64));
-    const count = Number(
-      database.query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM schema_metadata').get()?.count ?? 0,
+    const current = Number(
+      (database.query('SELECT COUNT(*) AS count FROM schema_metadata').get() as {count: number}).count,
+    );
+    const keys = Array.from(
+      {length: Math.max(0, targetCount - current)},
+      (_, index) => `reconciliation_cursor_capacity_${(current + index).toString().padStart(2, '0')}`,
     );
     const insert = database.prepare('INSERT INTO schema_metadata (key, value) VALUES (?, ?)');
     database.transaction(() => {
-      for (let index = count; index < REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS; index += 1) {
-        insert.run(`cursor-capacity-filler-${index}`, 'bounded');
-      }
+      for (const key of keys) insert.run(key, 'bounded-fixture');
     })();
+    return keys;
   } finally {
     database.close(false);
   }
 }
 
-function deleteOneFillerMetadataRow(databasePath: string): void {
+function deleteSchemaMetadata(databasePath: string, key: string): void {
   const database = new Database(databasePath, {strict: true});
   try {
-    database
-      .query(
-        `DELETE FROM schema_metadata
-         WHERE key = (
-           SELECT key FROM schema_metadata WHERE key LIKE 'cursor-capacity-filler-%' ORDER BY key LIMIT 1
-         )`,
-      )
-      .run();
-  } finally {
-    database.close(false);
-  }
-}
-
-function readSchemaMetadataRowCount(databasePath: string): number {
-  const database = new Database(databasePath, {readonly: true, strict: true});
-  try {
-    return Number(
-      database.query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM schema_metadata').get()?.count ?? -1,
-    );
+    database.query('DELETE FROM schema_metadata WHERE key = ? COLLATE BINARY').run(key);
   } finally {
     database.close(false);
   }

--- a/test/unit/code-graph.worktree-reconciliation.test.ts
+++ b/test/unit/code-graph.worktree-reconciliation.test.ts
@@ -42,6 +42,7 @@ import {
   CodeGraphStoreError,
   type CodeGraphSnapshot,
 } from '../../src/code_graph/types.js';
+import {REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS} from '../../src/code_graph/store_schema_metadata.js';
 import type {RepositoryIdentity} from '../../src/code_graph/types.js';
 import {
   CODE_GRAPH_WORKTREE_RECONCILIATION_CANDIDATE_LIMIT,
@@ -59,6 +60,10 @@ const targetWorktreeId = 'd'.repeat(64);
 const expectedSnapshotId = `cgsn_${'e'.repeat(40)}`;
 const privateRoot = '/private/threadnote/repository';
 const registryRootIdentity = 'f'.repeat(64);
+const boundedMalformedReconciliationCursor = fc
+  .array(fc.constantFrom(...'0123456789abcdefxyz_-'.split('')), {maxLength: 64})
+  .map(characters => characters.join(''))
+  .filter(value => !/^[0-9a-f]{64}$/u.test(value));
 const temporaryRoots: string[] = [];
 const storeLayer = CodeGraphStore.layer.pipe(
   Layer.provideMerge(SystemInfo.layer),
@@ -445,7 +450,7 @@ describe('automatic missing-worktree reconciliation', () => {
     }),
   );
 
-  effectIt.effect('claims a durable cross-process cursor page and fails closed on malformed state', () =>
+  effectIt.effect('claims a durable cross-process cursor page and recovers bounded malformed state', () =>
     TestClock.withLive(
       Effect.gen(function* () {
         const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-'));
@@ -467,7 +472,7 @@ describe('automatic missing-worktree reconciliation', () => {
         expect(claimed.size).toBe(69);
         expect(claimed.has(worktreeIds.at(-1)!)).toBe(false);
 
-        const malformed = yield* Effect.sync(() => {
+        const recovered = yield* Effect.sync(() => {
           const database = new Database(databasePath, {strict: true});
           try {
             database
@@ -477,7 +482,11 @@ describe('automatic missing-worktree reconciliation', () => {
             database.close(false);
           }
         }).pipe(Effect.andThen(store.claimWorktreeReconciliationCandidates(databasePath, 32).pipe(Effect.exit)));
-        expect(malformed._tag).toBe('Failure');
+        expect(recovered._tag).toBe('Success');
+        if (recovered._tag === 'Success') {
+          expect(recovered.value.map(entry => entry.worktreeId)).toEqual(worktreeIds.slice(0, 32));
+        }
+        expect(readReconciliationCursor(databasePath)).toBe(worktreeIds[31]);
 
         const incompatibleVersion = yield* Effect.sync(() => {
           const database = new Database(databasePath, {strict: true});
@@ -526,6 +535,78 @@ describe('automatic missing-worktree reconciliation', () => {
         expect(cascadingTombstone._tag).toBe('Failure');
       }).pipe(provideTestLayer(storeLayer)),
     ),
+  );
+
+  effectIt.effect('bounds invalid cursor diagnostics and refuses a missing cursor at metadata capacity', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-bounds-'));
+        temporaryRoots.push(root);
+        const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        const worktreeIds = ['0'.repeat(64), '1'.repeat(64)];
+        yield* Effect.sync(() => seedCandidateViews(databasePath, worktreeIds, false));
+
+        const oversized = 'private-cursor-content-'.repeat(4_096);
+        yield* Effect.sync(() => writeReconciliationCursor(databasePath, oversized));
+        const invalid = yield* Effect.flip(store.claimWorktreeReconciliationCandidates(databasePath, 1));
+        expect(invalid).toBeInstanceOf(CodeGraphStoreError);
+        expect(invalid.message).toBe('Code graph reconciliation cursor metadata is structurally invalid.');
+        expect(invalid.code).toBe('confirmed-corruption');
+        expect(invalid.operation).toBe('claim code graph reconciliation candidates');
+        expect(invalid.recovery).toBe('manual-rebuild');
+        expect(invalid.message).not.toContain(oversized.slice(0, 32));
+        expect(readReconciliationCursor(databasePath)).toBe(oversized);
+
+        yield* Effect.sync(() => {
+          deleteReconciliationCursor(databasePath);
+          fillSchemaMetadataToCapacity(databasePath);
+        });
+        const capacity = yield* Effect.flip(store.claimWorktreeReconciliationCandidates(databasePath, 1));
+        expect(capacity).toBeInstanceOf(CodeGraphStoreError);
+        expect(capacity.message).toBe('Code graph reconciliation cursor metadata capacity is unavailable.');
+        expect(capacity.code).toBe('incompatible-schema');
+        expect(capacity.operation).toBe('claim code graph reconciliation candidates');
+        expect(capacity.recovery).toBe('manual-migration');
+        expect(readReconciliationCursor(databasePath)).toBeUndefined();
+        expect(readSchemaMetadataRowCount(databasePath)).toBe(REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS);
+
+        yield* Effect.sync(() => deleteOneFillerMetadataRow(databasePath));
+        const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 1);
+        expect(claimed.map(entry => entry.worktreeId)).toEqual([worktreeIds[0]]);
+        expect(readReconciliationCursor(databasePath)).toBe(worktreeIds[0]);
+        expect(readSchemaMetadataRowCount(databasePath)).toBe(REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS);
+      }).pipe(provideTestLayer(storeLayer)),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'atomically replaces every bounded semantic-invalid cursor with the claimed page boundary',
+    {malformedCursor: boundedMalformedReconciliationCursor},
+    ({malformedCursor}) =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const root = mkdtempSync(join(tmpdir(), 'threadnote-reconciliation-cursor-property-'));
+          temporaryRoots.push(root);
+          const databasePath = join(root, 'indexes', 'code-graph', 'repositories', checkoutId, 'graph-v3.sqlite');
+          const store = yield* CodeGraphStore;
+          yield* store.initialize(databasePath);
+          const worktreeIds = ['0'.repeat(64), '1'.repeat(64), '2'.repeat(64)];
+          yield* Effect.sync(() => {
+            seedCandidateViews(databasePath, worktreeIds, false);
+            writeReconciliationCursor(databasePath, malformedCursor);
+          });
+          const beforeRows = readSchemaMetadataRowCount(databasePath);
+
+          const claimed = yield* store.claimWorktreeReconciliationCandidates(databasePath, 2);
+
+          expect(claimed.map(entry => entry.worktreeId)).toEqual(worktreeIds.slice(0, 2));
+          expect(readReconciliationCursor(databasePath)).toBe(worktreeIds[1]);
+          expect(readSchemaMetadataRowCount(databasePath)).toBe(beforeRows);
+        }).pipe(provideTestLayer(storeLayer)),
+      ),
+    {fastCheck: {numRuns: 24}},
   );
 
   effectIt.effect('uses indexed cursor pages without a temporary sort across ten thousand real views', () =>
@@ -1714,6 +1795,79 @@ function readReconciliationCursor(databasePath: string): string | undefined {
       .query("SELECT value FROM schema_metadata WHERE key = 'worktree_reconciliation_cursor'")
       .get() as {readonly value: string} | null;
     return row?.value;
+  } finally {
+    database.close(false);
+  }
+}
+
+function writeReconciliationCursor(databasePath: string, value: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database
+      .query(
+        `INSERT INTO schema_metadata (key, value) VALUES ('worktree_reconciliation_cursor', ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(value);
+  } finally {
+    database.close(false);
+  }
+}
+
+function deleteReconciliationCursor(databasePath: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.query("DELETE FROM schema_metadata WHERE key = 'worktree_reconciliation_cursor'").run();
+  } finally {
+    database.close(false);
+  }
+}
+
+function fillSchemaMetadataToCapacity(databasePath: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database
+      .query(
+        `INSERT INTO schema_metadata (key, value) VALUES ('removed_view_cleanup_admission_cursor', ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run('f'.repeat(64));
+    const count = Number(
+      database.query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM schema_metadata').get()?.count ?? 0,
+    );
+    const insert = database.prepare('INSERT INTO schema_metadata (key, value) VALUES (?, ?)');
+    database.transaction(() => {
+      for (let index = count; index < REMOVED_VIEW_CLEANUP_CURRENT_MAXIMUM_METADATA_ROWS; index += 1) {
+        insert.run(`cursor-capacity-filler-${index}`, 'bounded');
+      }
+    })();
+  } finally {
+    database.close(false);
+  }
+}
+
+function deleteOneFillerMetadataRow(databasePath: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database
+      .query(
+        `DELETE FROM schema_metadata
+         WHERE key = (
+           SELECT key FROM schema_metadata WHERE key LIKE 'cursor-capacity-filler-%' ORDER BY key LIMIT 1
+         )`,
+      )
+      .run();
+  } finally {
+    database.close(false);
+  }
+}
+
+function readSchemaMetadataRowCount(databasePath: string): number {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return Number(
+      database.query<{readonly count: number}, []>('SELECT COUNT(*) AS count FROM schema_metadata').get()?.count ?? -1,
+    );
   } finally {
     database.close(false);
   }


### PR DESCRIPTION
## Summary

- keep `worktree_reconciliation_cursor` advisory and privacy-safe
- recover bounded semantic-invalid state only when it is the unique exact-case cursor row
- leave oversized, wrong-case, and ambiguous cursor families unchanged with fixed typed corruption diagnostics
- preserve the authoritative metadata reservation: 65 rows without `removed_view_cleanup_admission_cursor`, 66 rows with it
- return reconciliation candidates without writing a cursor at either full ceiling, preserving next-call liveness
- recover only the exact one-row legacy overflow at 66 or 67 rows

This cursor schedules reconciliation pages only; it is not deletion authority. The orphan-provenance cleanup introduced by #246 remains intact. The public branch history is ancestry-preserved through the concurrent hardening commits and current main.

## Safety

Legacy recovery runs only after normal full schema admission fails, then proves the canonical trigger-free metadata table, current extension revision, current authoritative cleanup cursor state, and exactly one excess metadata row. The candidate cursor must be a unique exact-case text key with a value bounded to 64 bytes.

Recovery uses an exact binary key-and-old-value CAS delete, requires exactly one changed row, verifies that the cursor is absent, and reruns full schema admission in the same transaction. Cursor updates also use exact old-value CAS and post-write verification. Missing-key insertion rechecks both row count and authoritative reservation in the same transaction. No case-insensitive deletion is used, no cleanup or deletion authority is widened, and unrelated schema drift rolls the transaction back.

Diagnostics contain fixed operation text only; stored cursor values and local paths are never included.

## Verification

- 89 focused tests across worktree reconciliation, orphan provenance cleanup, removed-view cleanup storage, and schema migration
- Effect Vitest coverage for 65, 66, and 67 row boundaries, next-call liveness, authoritative rollback, structural fail-closed cases, and exact recovery
- 24-run bounded semantic-invalid cursor property plus 16-run 66/67 legacy-overflow property
- strict lint and file-length checks
- source, test, and site typechecks
- standalone build
- `git diff --check` and clean checkout
- independent critical/important review of `bac1f216`: CLEAN
- independent post-main tree-equivalence review of pushed head `ff89f603`: CLEAN; all five reviewed #258 files are byte-for-byte unchanged

Global development installation was attempted and correctly refused by the active-worktree ownership guard. No takeover was performed. Full-suite validation is delegated to fresh PR CI.