### PR TITLE
fix(site): contain Pro Tips mobile layout

### DIFF
--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -2384,6 +2384,21 @@ Measure the system before changing its implementation language.
     );
   });
 
+  it('keeps the Pro Tips explorer contained at mobile widths', async () => {
+    const styles = await readFile(join(root, 'website', 'src', 'styles.css'), 'utf8');
+    const tabletStart = styles.indexOf('@media (max-width: 980px)');
+    const mobileStart = styles.indexOf('@media (max-width: 680px)', tabletStart);
+    const tabletStyles = styles.slice(tabletStart, mobileStart);
+    const mobileStyles = styles.slice(mobileStart);
+
+    expect(styles).toMatch(/\.tips-layout\s*{[^}]*min-width: 0;/s);
+    expect(styles).toMatch(/\.tips-index\s*{[^}]*min-width: 0;/s);
+    expect(styles).toMatch(/\.tip-detail\s*{[^}]*min-width: 0;/s);
+    expect(tabletStyles).toMatch(/\.tips-layout\s*{[^}]*grid-template-columns: minmax\(0, 1fr\);/s);
+    expect(tabletStyles).toMatch(/\.tips-index\s*{[^}]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\);/s);
+    expect(mobileStyles).toMatch(/\.tips-index\s*{[^}]*grid-template-columns: minmax\(0, 1fr\);/s);
+  });
+
   it('wraps inline post code without disabling code-block or table scrolling', async () => {
     const styles = await readFile(join(root, 'website', 'src', 'styles.css'), 'utf8');
 

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -2148,18 +2148,20 @@ p {
   display: grid;
   grid-template-columns: 320px minmax(0, 1fr);
   gap: 60px;
+  min-width: 0;
 }
 
 .tips-index {
   align-self: start;
   position: sticky;
   top: 100px;
+  min-width: 0;
   border-top: 1px solid var(--line);
 }
 
 .tips-index button {
   display: grid;
-  grid-template-columns: 30px 1fr 16px;
+  grid-template-columns: 30px minmax(0, 1fr) 16px;
   gap: 12px;
   align-items: center;
   width: 100%;
@@ -2193,9 +2195,11 @@ p {
 }
 
 .tips-index button strong {
+  min-width: 0;
   font-size: 14px;
   font-weight: 540;
   line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .tips-index button svg {
@@ -2222,6 +2226,10 @@ p {
 .tip-detail > header {
   max-width: 760px;
   margin-bottom: 34px;
+}
+
+.tip-detail {
+  min-width: 0;
 }
 
 .tip-detail > header h2 {
@@ -5961,13 +5969,13 @@ p {
   }
 
   .tips-layout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .tips-index {
     position: static;
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     border-left: 1px solid var(--line);
   }
 
@@ -6490,7 +6498,7 @@ p {
   }
 
   .tips-index {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .release-hero {


### PR DESCRIPTION
## Summary

- preserve zero-minimum grid tracks when Pro Tips collapses from desktop to tablet and mobile
- constrain both explorer children and long scenario titles so Safari cannot expand the page intrinsic width
- add a focused regression covering the desktop, tablet, and mobile containment contract

## Diagnosis

The supplied iOS Safari screenshot is consistent with page shrink-to-fit caused by a min-content grid track. The desktop explorer uses `minmax(0, 1fr)`, but both responsive overrides replaced that containment with bare `1fr` tracks. Chromium at 390 px stays at 390 px today, which makes this a Safari-specific rendering path rather than a generic viewport-tag failure.

## Verification

- `bun run site:check` — 76 tests passed; website typecheck and lint passed
- `bun run site:build` — production site build passed
- repository pre-commit lint, formatting, root/test/site typechecks passed
- `git diff --check` passed

Property testing is not useful for this fixed CSS breakpoint contract because the repository test environment does not implement layout. The focused regression instead locks the exact zero-minimum track invariants that Safari needs.