### PR TITLE
test(logs): stabilize contention deadline coverage

### DIFF
--- a/test/unit/production-log.test.ts
+++ b/test/unit/production-log.test.ts
@@ -295,7 +295,7 @@ describe('production log writer', () => {
   );
 
   effectIt.effect('keeps Windows production logging best-effort at the ten-second contention bound', () =>
-    windowsEntriesAfterLockContention(10_025).pipe(
+    windowsEntriesAfterLockContention(10_025, {awaitApplicationStartBeforeRelease: true}).pipe(
       Effect.flatMap(entries =>
         Effect.sync(() => {
           expect(entries).toHaveLength(1);
@@ -467,13 +467,17 @@ function ownedTestHome(label: string) {
   });
 }
 
-function windowsEntriesAfterLockContention(releaseAfterMilliseconds: number) {
+function windowsEntriesAfterLockContention(
+  releaseAfterMilliseconds: number,
+  options: {readonly awaitApplicationStartBeforeRelease?: boolean} = {},
+) {
   return Effect.scoped(
     Effect.gen(function* () {
       const {fs, home, path} = yield* ownedTestHome(`windows-contention-${releaseAfterMilliseconds}`);
       const lockPath = path.join(home, 'locks', 'production-log.lock');
       const acquired = yield* Deferred.make<void>();
       const contentionObserved = yield* Deferred.make<void>();
+      const applicationStarted = yield* Deferred.make<void>();
       const release = yield* Deferred.make<void>();
       const ownerFiber = yield* withExclusiveFileLock(
         fs,
@@ -503,7 +507,11 @@ function windowsEntriesAfterLockContention(releaseAfterMilliseconds: number) {
       });
       const nativeSystem = yield* SystemInfo;
       const windowsSystem = SystemInfo.of({...nativeSystem, platform: 'win32'});
-      const writerFiber = yield* withProductionLogging(home, {component: 'cli', operation: 'logs'}, Effect.void).pipe(
+      const writerFiber = yield* withProductionLogging(
+        home,
+        {component: 'cli', operation: 'logs'},
+        Deferred.succeed(applicationStarted, undefined),
+      ).pipe(
         Effect.provideService(FileSystem.FileSystem, observedFs),
         Effect.provideService(SystemInfo, windowsSystem),
         Effect.forkChild({startImmediately: true}),
@@ -511,6 +519,11 @@ function windowsEntriesAfterLockContention(releaseAfterMilliseconds: number) {
       yield* Deferred.await(contentionObserved);
 
       yield* TestClock.adjust(releaseAfterMilliseconds);
+      if (options.awaitApplicationStartBeforeRelease === true) {
+        // Keep the owner locked until the first log write has observed the virtual deadline. Otherwise a busy host can
+        // resume the owner before the contender after TestClock's cooperative wake-up and make this boundary racy.
+        yield* Deferred.await(applicationStarted);
+      }
       yield* Deferred.succeed(release, undefined);
       yield* Fiber.join(ownerFiber);
       yield* TestClock.adjust(25);


### PR DESCRIPTION
## Summary

- keep the Windows contention owner locked until the initial production-log write has observably completed at the virtual ten-second deadline
- prevent host scheduler load from racing the owner release against TestClock's cooperative wake-up
- preserve the original contract: the started entry is dropped only after the bounded wait, the application runs once, and the finished entry is retained

## Root cause

PR #257 fresh CI exposed a scheduler-sensitive test race in production-log.test.ts. TestClock.adjust wakes retry sleepers cooperatively; on a busy runner, the test could release the owner before the contender resumed to observe the elapsed deadline. The contender then legitimately acquired the released lock and wrote both lifecycle entries, so the assertion expected one entry but received two.

This is test determinism only; no production runtime behavior changes.

## Verification

- pre-fix 32-process stress reproduction failed in 3 observed workers with the same 2-vs-1 assertion
- post-fix identical 32-process stress passed 32/32
- focused production-log suite passed 16/16
- test TypeScript check passed
- strict lint, Prettier, and diff checks passed
- pre-commit repository lint, formatting, source/test/site typechecks passed

Property-testing note: the existing 12-run Fast-check property already covers the generated in-window release invariant. This regression is the concrete scheduler-boundary case, so no duplicate property was added.