### PR TITLE
fix(logs): retry transient Windows sharing failures

### DIFF
--- a/src/effect/file_lock.ts
+++ b/src/effect/file_lock.ts
@@ -8,6 +8,8 @@ export interface ExclusiveFileLockOptions {
   readonly onCompleted?: (lockPath: string) => Effect.Effect<void, never>;
   readonly onContention?: (lockPath: string) => Effect.Effect<void, never>;
   readonly retryIntervalMilliseconds: number;
+  /** @internal Maximum short retries for Windows sharing-shaped exclusive-create failures. */
+  readonly windowsSharingViolationRetryLimit?: number;
   /** @internal Select the versioned, cross-observer process identity channel. */
   readonly useCanonicalProcessStartIdentity?: boolean;
   /**
@@ -118,7 +120,15 @@ function tryAcquireFileLock(
 ): Effect.Effect<boolean, unknown, Crypto.Crypto | SystemInfo> {
   return Effect.gen(function* () {
     yield* recoverStaleFileLock(fs, lockPath, options);
-    if (!(yield* tryWriteLockToken(fs, lockPath, token))) {
+    if (
+      !(yield* tryWriteLockToken(
+        fs,
+        lockPath,
+        token,
+        options.windowsSharingViolationRetryLimit,
+        options.retryIntervalMilliseconds,
+      ))
+    ) {
       return false;
     }
     if (yield* fs.exists(recoveryGuardPath(lockPath))) {
@@ -232,15 +242,53 @@ function staleDeadLockToken(
   });
 }
 
-function tryWriteLockToken(fs: FileSystem.FileSystem, path: string, token: string): Effect.Effect<boolean, unknown> {
-  return fs.writeFileString(path, `${token}\n`, {flag: 'wx', mode: 0o600}).pipe(
-    Effect.as(true),
-    Effect.catch(error =>
-      error instanceof PlatformError.PlatformError && error.reason._tag === 'AlreadyExists'
-        ? Effect.succeed(false)
-        : Effect.fail(error),
-    ),
-  );
+function tryWriteLockToken(
+  fs: FileSystem.FileSystem,
+  path: string,
+  token: string,
+  windowsSharingViolationRetryLimit = 0,
+  retryIntervalMilliseconds = 0,
+): Effect.Effect<boolean, unknown, SystemInfo> {
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    const retryLimit =
+      Number.isSafeInteger(windowsSharingViolationRetryLimit) && windowsSharingViolationRetryLimit > 0
+        ? windowsSharingViolationRetryLimit
+        : 0;
+    for (let retry = 0; ; retry += 1) {
+      const attempted = yield* fs.writeFileString(path, `${token}\n`, {flag: 'wx', mode: 0o600}).pipe(
+        Effect.as({status: 'acquired'} as const),
+        Effect.catch(error => Effect.succeed({error, status: 'failed'} as const)),
+      );
+      if (attempted.status === 'acquired') return true;
+      if (attempted.error instanceof PlatformError.PlatformError && attempted.error.reason._tag === 'AlreadyExists') {
+        return false;
+      }
+      if (retry >= retryLimit || !isWindowsSharingViolation(attempted.error, system.platform)) {
+        return yield* Effect.fail(attempted.error);
+      }
+      yield* Effect.sleep(retryIntervalMilliseconds);
+    }
+  });
+}
+
+function isWindowsSharingViolation(error: unknown, platform: NodeJS.Platform): boolean {
+  if (!(error instanceof PlatformError.PlatformError)) return false;
+  if (platform !== 'win32') return false;
+
+  // Windows can report an exclusive create against a live lock as a sharing/access failure instead of EEXIST.
+  // Treat only the normalized contention-shaped failures as a missed acquisition so the bounded lock loop retries;
+  // unrelated errors such as a full disk still fail immediately.
+  if (error.reason._tag === 'Busy' || error.reason._tag === 'PermissionDenied' || error.reason._tag === 'WouldBlock') {
+    return true;
+  }
+  if (error.reason._tag !== 'Unknown') return false;
+  const cause = error.reason.cause;
+  const code =
+    typeof cause === 'object' && cause !== null && 'code' in cause
+      ? (cause as {readonly code?: unknown}).code
+      : undefined;
+  return code === 'EACCES' || code === 'EAGAIN' || code === 'EBUSY' || code === 'EPERM';
 }
 
 function recoveryGuardPath(lockPath: string): string {

--- a/src/effect/production_log.ts
+++ b/src/effect/production_log.ts
@@ -38,6 +38,9 @@ const PRODUCTION_LOG_PROCESS_WAIT_MILLISECONDS = PRODUCTION_LOG_LOCK_WAIT_MILLIS
 // Eight standalone Windows processes can occupy the low-volume log lock beyond five seconds under hosted-runner
 // scheduling. Keep the queue bounded while preserving both lifecycle entries for commands that already completed.
 const PRODUCTION_LOG_WINDOWS_LOCK_WAIT_MILLISECONDS = 10_000;
+// Windows can briefly report a sharing/access violation while a lock-file delete settles. Retry that distinct error
+// for at most 4 * 25 ms; permanent access failures remain best-effort without consuming the ten-second queue bound.
+const PRODUCTION_LOG_WINDOWS_SHARING_VIOLATION_RETRY_LIMIT = 4;
 const PRODUCTION_LOG_RUNTIME_NAME = 'bun';
 const PRODUCTION_LOG_UNKNOWN_ERROR_TYPE = 'UnknownError';
 const PRODUCTION_LOG_REPORTED_ERROR_TYPE = 'ReportedError';
@@ -391,7 +394,11 @@ function appendProductionLogs(
     const lockPath = path.join(home, PRODUCTION_LOG_LOCK_DIRECTORY_NAME, PRODUCTION_LOG_LOCK_FILE_NAME);
     const lockOptions =
       system.platform === 'win32'
-        ? {...PRODUCTION_LOG_LOCK_OPTIONS, waitTimeoutMilliseconds: PRODUCTION_LOG_WINDOWS_LOCK_WAIT_MILLISECONDS}
+        ? {
+            ...PRODUCTION_LOG_LOCK_OPTIONS,
+            waitTimeoutMilliseconds: PRODUCTION_LOG_WINDOWS_LOCK_WAIT_MILLISECONDS,
+            windowsSharingViolationRetryLimit: PRODUCTION_LOG_WINDOWS_SHARING_VIOLATION_RETRY_LIMIT,
+          }
         : PRODUCTION_LOG_LOCK_OPTIONS;
     const serialized = entries.map(entry => JSON.stringify(entry)).join('\n') + '\n';
     const serializedBytes = BigInt(new TextEncoder().encode(serialized).byteLength);

--- a/test/unit/effect-file-lock.test.ts
+++ b/test/unit/effect-file-lock.test.ts
@@ -1,7 +1,7 @@
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {it as effectIt} from '@effect/vitest';
-import {Deferred, Effect, Fiber, FileSystem, Layer} from 'effect';
+import {Deferred, Effect, Exit, Fiber, FileSystem, Layer, PlatformError} from 'effect';
 import {TestClock} from 'effect/testing';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {FileLockTimeout, withExclusiveFileLock} from '../../src/effect/file_lock.js';
@@ -94,6 +94,43 @@ describe('Effect file lock', () => {
         expect(yield* fs.exists(lockPath)).toBe(false);
       }).pipe(provideTestLayer(FILE_LOCK_TEST_LAYER)),
     ),
+  );
+
+  effectIt.effect('keeps Windows sharing-shaped failures fail-fast unless the caller opts into bounded retries', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const system = yield* SystemInfo;
+      let attempts = 0;
+      const failedFs = FileSystem.FileSystem.of({
+        ...fs,
+        writeFileString: (path, content, options) =>
+          path === lockPath
+            ? Effect.sync(() => {
+                attempts += 1;
+              }).pipe(
+                Effect.andThen(
+                  Effect.fail(
+                    PlatformError.systemError({
+                      _tag: 'PermissionDenied',
+                      cause: {code: 'EACCES'},
+                      method: 'writeFileString',
+                      module: 'FileSystem',
+                      pathOrDescriptor: path,
+                    }),
+                  ),
+                ),
+              )
+            : fs.writeFileString(path, content, options),
+      });
+      const failed = yield* Effect.exit(
+        withExclusiveFileLock(failedFs, lockPath, TEST_LOCK_OPTIONS, Effect.void).pipe(
+          Effect.provideService(SystemInfo, SystemInfo.of({...system, platform: 'win32'})),
+        ),
+      );
+
+      expect(Exit.isFailure(failed)).toBe(true);
+      expect(attempts).toBe(1);
+    }).pipe(provideTestLayer(FILE_LOCK_TEST_LAYER)),
   );
 
   it('reports lock contention with a typed timeout', async () => {

--- a/test/unit/production-log.test.ts
+++ b/test/unit/production-log.test.ts
@@ -1,7 +1,7 @@
 import {TestError} from '../helpers/test-error.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {it as effectIt} from '@effect/vitest';
-import {Cause, Deferred, Effect, Exit, Fiber, FileSystem, Path} from 'effect';
+import {Cause, Deferred, Effect, Exit, Fiber, FileSystem, Path, PlatformError} from 'effect';
 import {TestClock} from 'effect/testing';
 import fc from 'fast-check';
 import {describe, expect} from 'vitest';
@@ -263,6 +263,55 @@ describe('production log writer', () => {
         expect(new Set(entries.map(entry => entry.invocationId)).size).toBe(invocationCount);
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('retries a Windows sharing violation instead of dropping a lifecycle entry', () =>
+    TestClock.withLive(
+      windowsEntriesAfterTransientLockContention(1, 'PermissionDenied').pipe(
+        Effect.flatMap(entries =>
+          Effect.sync(() => {
+            expect(entries).toHaveLength(2);
+            expect(entries.map(entry => entry.event)).toEqual(['invocation.started', 'invocation.finished']);
+            expect(entries[0]?.invocationId).toBe(entries[1]?.invocationId);
+          }),
+        ),
+      ),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'preserves Windows lifecycle pairs across bounded transient exclusive-create failures',
+    {
+      failures: fc.integer({min: 1, max: 4}),
+      reason: fc.constantFrom('Busy' as const, 'PermissionDenied' as const, 'Unknown' as const, 'WouldBlock' as const),
+    },
+    ({failures, reason}) =>
+      TestClock.withLive(
+        windowsEntriesAfterTransientLockContention(failures, reason).pipe(
+          Effect.flatMap(entries =>
+            Effect.sync(() => {
+              expect(entries).toHaveLength(2);
+              expect(entries[0]?.event).toBe('invocation.started');
+              expect(entries[1]?.event).toBe('invocation.finished');
+              expect(entries[0]?.invocationId).toBe(entries[1]?.invocationId);
+            }),
+          ),
+        ),
+      ),
+    {fastCheck: {numRuns: 12}},
+  );
+
+  effectIt.effect('keeps a persistent Windows sharing violation best-effort after the short retry cap', () =>
+    TestClock.withLive(
+      windowsEntriesAfterTransientLockContention(5, 'PermissionDenied').pipe(
+        Effect.flatMap(entries =>
+          Effect.sync(() => {
+            expect(entries).toHaveLength(1);
+            expect(entries[0]?.event).toBe('invocation.finished');
+          }),
+        ),
+      ),
+    ),
   );
 
   effectIt.effect('preserves both Windows lifecycle entries when lock contention exceeds five seconds', () =>
@@ -528,6 +577,49 @@ function windowsEntriesAfterLockContention(
       yield* Fiber.join(ownerFiber);
       yield* TestClock.adjust(25);
       yield* Fiber.join(writerFiber);
+
+      return parseEntries(yield* fs.readFileString(productionLogPath(path, home)));
+    }),
+  ).pipe(provideTestLayer(ApplicationLayer));
+}
+
+function windowsEntriesAfterTransientLockContention(
+  failureCount: number,
+  reason: 'Busy' | 'PermissionDenied' | 'Unknown' | 'WouldBlock',
+) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const {fs, home, path} = yield* ownedTestHome(`windows-transient-contention-${reason}-${failureCount}`);
+      const lockPath = path.join(home, 'locks', 'production-log.lock');
+      let remainingFailures = failureCount;
+      const contendedFs = FileSystem.FileSystem.of({
+        ...fs,
+        writeFileString: (candidate, content, options) =>
+          candidate === lockPath && remainingFailures > 0
+            ? Effect.sync(() => {
+                remainingFailures -= 1;
+              }).pipe(
+                Effect.andThen(
+                  Effect.fail(
+                    PlatformError.systemError({
+                      _tag: reason,
+                      cause: reason === 'Unknown' ? {code: 'EPERM'} : undefined,
+                      method: 'writeFileString',
+                      module: 'FileSystem',
+                      pathOrDescriptor: candidate,
+                    }),
+                  ),
+                ),
+              )
+            : fs.writeFileString(candidate, content, options),
+      });
+      const nativeSystem = yield* SystemInfo;
+      const windowsSystem = SystemInfo.of({...nativeSystem, platform: 'win32'});
+
+      yield* withProductionLogging(home, {component: 'cli', operation: 'logs'}, Effect.void).pipe(
+        Effect.provideService(FileSystem.FileSystem, contendedFs),
+        Effect.provideService(SystemInfo, windowsSystem),
+      );
 
       return parseEntries(yield* fs.readFileString(productionLogPath(path, home)));
     }),


### PR DESCRIPTION
## Summary

- retry transient Windows sharing/access errors during the exclusive-create step used by production-log writes
- keep generic file-lock callers fail-fast; only Windows production logs opt in to four 25 ms retries (100 ms maximum)
- add Effect-native regression coverage, a bounded Fast-check property across retryable error shapes, and a retry-cap regression

## Root cause

The [#261 exact-head Windows self-contained E2E](https://github.com/Kashkovsky/threadnote/actions/runs/33086307155/job/98567634798) completed all eight commands successfully but observed only 15 of 16 expected lifecycle entries. The test failed after 5.877 seconds, below the existing ten-second lock queue bound, so extending that queue in #253 could not explain this loss.

The lock's exclusive-create path treated every error except AlreadyExists as terminal. On Windows, a rapid lock-file delete/recreate can briefly surface sharing/access errors while a handle is still being released or the deletion is pending ([CreateFile documentation](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew)). Production logging is intentionally best-effort, so that terminal acquisition error was swallowed and one lifecycle entry disappeared.

This change retries only the bounded Windows error shapes at that create boundary. Persistent access failures still stop after at most 100 ms and do not consume the ten-second contention timeout.

## Verification

- pre-fix proof: the concrete regression produced 1/2 lifecycle entries; the property shrank to one transient Busy failure
- bunx vitest run test/unit/effect-file-lock.test.ts test/unit/production-log.test.ts (34/34)
- bun run typecheck
- bun run lint
- bun run build
- bunx vitest run test/e2e/local-bins.e2e.ts -t "writes privacy-safe production logs across concurrent standalone processes" (1 passed, 17 skipped)
- bun run check:self-contained
- independent critical/important review: clean

Full cross-platform validation is left to PR CI per repository policy.
