### PR TITLE
chore: prepare v4.4.1

### DIFF
--- a/.github/release-notes/v4.4.1.md
+++ b/.github/release-notes/v4.4.1.md
@@ -1,0 +1,45 @@
+## What's new
+
+Threadnote 4.4.1 is a reliability and performance patch for the 4.4 memory-to-code citation release. It keeps legacy
+uncited memory recall unchanged while hardening graph lifecycle cleanup, isolated graph work, and concurrent logging.
+
+### Keep graph work bounded and the Manager responsive
+
+- Manager-launched graph indexing and Workset preparation run in isolated workers, preserving the Manager service
+  process while concurrent builds report progress independently.
+- MCP impact queries now run behind a hard operating-system timeout with bounded output and child-process cleanup, so
+  a stuck native query cannot hold the MCP server indefinitely.
+- Incremental TypeScript project closure validates dependencies within the changed resolver domain. Unrelated ambiguous
+  package domains no longer force a full rebuild; incomplete or over-bound relevant closure still falls back safely to
+  one full rebuild.
+- Exact-symbol paging and impact-selector resolution preserve precise results at bounded query limits.
+
+### Reclaim stale graph state safely
+
+- Maintenance now reconciles pending view removals, recovers missing or damaged reconciliation cursors, and removes
+  orphaned provenance sidecars and snapshots left behind by deleted worktrees.
+- Cleanup remains lease-aware and fail-closed: active or protected graph generations are not reclaimed, and partial
+  evidence is retried instead of guessed away.
+
+### Improve cross-platform reliability
+
+- Windows production logging retries the narrow, transient sharing failures caused by rapid lock-file replacement.
+  Generic lock callers remain fail-fast, and persistent failures remain bounded.
+- Closed output pipes no longer crash successful CLI work, reused option names are disambiguated, and Bun child-build
+  failures retain their original diagnostics.
+- PDF extraction, telemetry gRPC, YAML tooling, and CI actions receive reviewed dependency updates.
+
+### Polish the 4.4 website guidance
+
+- The home page, Pro Tips, and FAQ explain memory-to-code citations, stale-link warnings, legacy-memory compatibility,
+  and when a Workset is useful.
+- Pro Tips now stays within narrow mobile viewports, including long workflow titles and the horizontal filter strip.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```
+
+Existing v1, v2, v3, and unversioned memories remain recallable. A Workset is not required for local repository recall
+or code-graph use; it is an explicit prepared scope for cross-repository queries.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump the standalone release version to 4.4.1
- document the post-4.4 graph lifecycle, isolation, timeout, logging, dependency, and website fixes
- restate legacy-memory compatibility and optional Workset scope

## Validation
- requested dev-cycle: 0 critical, 0 important; one wording minor polished
- release contract smoke: 12/12
- focused compatibility and regression suite: 143/143
- site contracts: 76/76
- site production build: 48 docs, 2 articles, 31 release pages
- standalone build reports v4.4.1 and self-contained check passes
- pre-commit lint, formatting, source/test/site typecheck pass

Property-testing assessment: this patch changes static release metadata and prose, so no new behavioral input space warrants an additional property test. The existing release-contract and production-ratchet scope properties cover this release-only diff.