### PR TITLE
perf(context-brief): validate workset citations from catalog

### DIFF
--- a/src/code_graph/repository.ts
+++ b/src/code_graph/repository.ts
@@ -1,6 +1,6 @@
 import {Effect, FileSystem, Path} from 'effect';
 import {sha256HexSync} from '../crypto/sha256.js';
-import {runBinaryCommandEffect, runCommandEffect} from '../effect/command.js';
+import {type CommandExecutor, runBinaryCommandEffect, runCommandEffect} from '../effect/command.js';
 import {platformPathFor, SystemInfo} from '../effect/system.js';
 import {CodeGraphRepositoryError, type RepositoryIdentity, type RepositoryIdentityExpectation} from './types.js';
 
@@ -201,6 +201,114 @@ export const revalidateRepositoryIdentityFence = Effect.fn('codeGraph.revalidate
     return yield* Effect.fail(new CodeGraphRepositoryError('Repository identity changed during the graph read.'));
   }
   return identity;
+});
+
+export interface PublishedRepositoryReadFenceInterlock {
+  /** @internal Deterministic race hook for focused validation tests. */
+  readonly afterInitialIdentity?: () => Effect.Effect<void, unknown, CommandExecutor>;
+  /** @internal Deterministic race hook for focused validation tests. */
+  readonly afterWorktreeObservation?: () => Effect.Effect<void, unknown, CommandExecutor>;
+}
+
+/**
+ * Bracket repository identity and worktree observations so caller retargets
+ * and edits across an earlier observation cannot satisfy the closing proof.
+ */
+export const resolvePublishedRepositoryReadFence = Effect.fn('codeGraph.resolvePublishedRepositoryReadFence')(
+  function* (cwd: string, expected: RepositoryIdentityExpectation, interlock?: PublishedRepositoryReadFenceInterlock) {
+    const system = yield* SystemInfo;
+    const initial = yield* observeRepositoryReadFenceMetadata(cwd);
+    yield* interlock?.afterInitialIdentity?.() ?? Effect.void;
+    const initialWorktree = yield* observeRepositoryReadFenceWorktree(initial.repoRoot, initial.objectFormat);
+    if (initialWorktree.headCommit !== initial.headCommit) {
+      return yield* Effect.fail(new CodeGraphRepositoryError('Repository changed during the graph read.'));
+    }
+    yield* interlock?.afterWorktreeObservation?.() ?? Effect.void;
+    const [final, remoteResult] = yield* Effect.all(
+      [observeRepositoryReadFenceMetadata(cwd), runGit(cwd, ['remote', 'get-url', 'origin'], true)],
+      {concurrency: 2},
+    ).pipe(Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')));
+    if (
+      final.repoRoot !== initial.repoRoot ||
+      final.gitCommonDirectory !== initial.gitCommonDirectory ||
+      final.objectFormat !== initial.objectFormat ||
+      final.headCommit !== initial.headCommit
+    ) {
+      return yield* Effect.fail(new CodeGraphRepositoryError('Repository identity changed during the graph read.'));
+    }
+    const remoteIdentity =
+      remoteResult.exitCode === 0 ? normalizeCredentialFreeRemote(remoteResult.stdout.trim()) : undefined;
+    const repositorySource =
+      remoteIdentity ?? `local:${normalizeLocalIdentity(final.gitCommonDirectory, system.platform)}`;
+    const identity = {
+      checkoutId: checkoutIdForGitCommonDirectory(final.gitCommonDirectory),
+      headCommit: final.headCommit,
+      repositoryId: sha256HexSync(`repository-v${IDENTITY_FORMAT_VERSION}\n${repositorySource}`),
+      worktreeId: worktreeIdForRoot(final.repoRoot),
+    };
+    if (!repositoryIdentityMatchesExpectation(identity, expected)) {
+      return yield* Effect.fail(new CodeGraphRepositoryError('Repository identity changed during the graph read.'));
+    }
+    const finalWorktree = yield* observeRepositoryReadFenceWorktree(final.repoRoot, final.objectFormat);
+    if (finalWorktree.headCommit !== final.headCommit) {
+      return yield* Effect.fail(new CodeGraphRepositoryError('Repository changed during the graph read.'));
+    }
+    return {...identity, worktreeChanged: initialWorktree.changed || finalWorktree.changed};
+  },
+);
+
+const observeRepositoryReadFenceWorktree = Effect.fn('codeGraph.observeRepositoryReadFenceWorktree')(function* (
+  repoRoot: string,
+  objectFormat: RepositoryIdentity['objectFormat'],
+) {
+  const status = yield* runCommandEffect(
+    'git',
+    ['--no-optional-locks', '-C', repoRoot, 'status', '--porcelain=v2', '-z', '--branch', '--untracked-files=normal'],
+    {maxOutputBytes: REPOSITORY_STATUS_OBSERVATION_BYTES_MAXIMUM, timeoutMs: 10_000},
+  ).pipe(Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')));
+  const worktree = parseRepositoryIdentityWorktreeObservation(status.stdout, objectFormat);
+  if (worktree === undefined) {
+    return yield* Effect.fail(new CodeGraphRepositoryError('Repository changed during the graph read.'));
+  }
+  return worktree;
+});
+
+const observeRepositoryReadFenceMetadata = Effect.fn('codeGraph.observeRepositoryReadFenceMetadata')(function* (
+  cwd: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const result = yield* runGit(cwd, [
+    'rev-parse',
+    '--path-format=absolute',
+    '--show-toplevel',
+    '--git-common-dir',
+    '--show-object-format',
+    'HEAD',
+  ]).pipe(Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')));
+  const metadata = result.stdout.replace(/\r?\n$/u, '').split(/\r?\n/u);
+  if (metadata.length !== 4) {
+    return yield* Effect.fail(new CodeGraphRepositoryError('Git repository identity metadata is invalid.'));
+  }
+  const repoRoot = yield* fs.realPath(metadata[0]!);
+  const commonRaw = metadata[1]!;
+  const commonAbsolute = path.isAbsolute(commonRaw) ? commonRaw : path.resolve(repoRoot, commonRaw);
+  const gitCommonDirectory = yield* fs.realPath(commonAbsolute);
+  const objectFormat = metadata[2]!;
+  if (objectFormat !== 'sha1' && objectFormat !== 'sha256') {
+    return yield* Effect.fail(new CodeGraphRepositoryError(`Unsupported Git object format: ${objectFormat}`));
+  }
+  const headCommit = metadata[3]!;
+  const expectedLength = objectFormat === 'sha256' ? 64 : 40;
+  if (!new RegExp(`^[0-9a-f]{${expectedLength}}$`, 'u').test(headCommit)) {
+    return yield* Effect.fail(new CodeGraphRepositoryError('Git repository identity metadata is invalid.'));
+  }
+  return {
+    gitCommonDirectory,
+    headCommit,
+    objectFormat: objectFormat as RepositoryIdentity['objectFormat'],
+    repoRoot,
+  };
 });
 
 /**

--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -162,7 +162,8 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
         completedSnapshotId: undefined,
         routinePhysical: false,
       };
-      return useDatabaseDirect(
+      const useSessionDatabase = options?.existingOnly === true ? useExistingDatabase : useDatabaseDirect;
+      return useSessionDatabase(
         databasePath,
         Effect.gen(function* () {
           const sql = yield* SqlClient.SqlClient;

--- a/src/code_graph/store_session.ts
+++ b/src/code_graph/store_session.ts
@@ -1,5 +1,5 @@
 import * as SqliteClient from '@effect/sql-sqlite-bun/SqliteClient';
-import {Context, Effect, Layer, Option, Path} from 'effect';
+import {Cause, Context, Effect, Layer, Option, Path} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import * as SqlError from 'effect/unstable/sql/SqlError';
 import type {
@@ -54,7 +54,7 @@ export function useReadOnlyDatabase<A, E, R>(
 export function useExistingDatabase<A, E, R>(
   databasePath: string,
   effect: Effect.Effect<A, E, R | SqlClient.SqlClient>,
-): Effect.Effect<A, E, Exclude<R, SqlClient.SqlClient>> {
+): Effect.Effect<A, E | CodeGraphStoreError, Exclude<R, SqlClient.SqlClient>> {
   return Effect.scoped(
     Layer.build(
       SqliteClient.layer({
@@ -64,7 +64,14 @@ export function useExistingDatabase<A, E, R>(
         readonly: false,
         readwrite: true,
       }),
-    ).pipe(Effect.flatMap(context => effect.pipe(Effect.provide(context)))),
+    ).pipe(
+      Effect.catchCause(cause =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.failCause(cause)
+          : Effect.fail(new CodeGraphStoreError('Existing code graph database could not be opened.')),
+      ),
+      Effect.flatMap(context => effect.pipe(Effect.provide(context))),
+    ),
   );
 }
 

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -630,6 +630,8 @@ export interface CodeGraphStoreShape {
 }
 
 export interface CodeGraphDatabaseSessionOptions {
+  /** @internal Open a writable connection only when the database already exists. */
+  readonly existingOnly?: boolean;
   /** @internal Open a non-creating, query-only SQLite connection without WAL bootstrap writes. */
   readonly readOnly?: boolean;
   /** @internal Ordinary index sessions reclaim a bounded page of completed build-only rows after foreground work. */

--- a/src/context_brief/citation_validation.ts
+++ b/src/context_brief/citation_validation.ts
@@ -1,4 +1,4 @@
-import {Clock, Effect, FileSystem} from 'effect';
+import {Clock, Effect, FileSystem, Path} from 'effect';
 import {
   createCodeGraphSourceSpanCanonicalizer,
   type CodeGraphEffectiveFileHashMatches,
@@ -10,8 +10,15 @@ import {
 import {codeGraphCitationSourceKey, readCodeGraphCitationSources} from '../code_graph/citation_source.js';
 import {worktreeOverlayState} from '../code_graph/inventory.js';
 import {decodeUtf8} from '../code_graph/inventory_content.js';
+import {CodeGraphLanguagePackRegistry} from '../code_graph/languages/registry.js';
+import {codeGraphLayout} from '../code_graph/layout.js';
 import {CodeGraphQueryService} from '../code_graph/query.js';
-import {observeCleanRepositoryWorktree, revalidateRepositoryIdentityFence} from '../code_graph/repository.js';
+import {codeGraphSnapshotRuntimeCurrent} from '../code_graph/query_snapshot_runtime.js';
+import {
+  observeCleanRepositoryWorktree,
+  resolvePublishedRepositoryReadFence,
+  revalidateRepositoryIdentityFence,
+} from '../code_graph/repository.js';
 import {CodeGraphStore} from '../code_graph/store.js';
 import type {
   CodeGraphSnapshot,
@@ -27,6 +34,7 @@ import type {
 } from '../code_graph/workset_catalog/types.js';
 import {codeGraphWorksetManifestDigest} from '../code_graph/workset_catalog/workset.js';
 import {sha256Hex} from '../effect/digest.js';
+import {CommandExecutor} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
 import {requireWorkset} from '../manifest.js';
 import type {MemoryCodeCitationV1} from '../memory_code_citation.js';
@@ -53,7 +61,20 @@ interface CitationTask {
   readonly uri: string;
 }
 
-interface ReadyRepository {
+interface RepositoryValidationInput {
+  readonly databasePath: string;
+  readonly finalFence: Effect.Effect<boolean, unknown, RepositoryValidationFenceRequirements>;
+  readonly objectFormat: RepositoryIdentity['objectFormat'];
+  readonly repositoryId: string;
+  readonly snapshot: CodeGraphSnapshot;
+  readonly sourceRoot: string;
+  readonly worktreeId: string;
+}
+
+type RepositoryValidationFenceRequirements =
+  CodeGraphQueryService | CodeGraphStore | CommandExecutor | FileSystem.FileSystem | Path.Path | SystemInfo;
+
+interface StatusReadyRepository {
   readonly cwd: string;
   readonly expected?: RepositoryIdentityExpectation;
   readonly status: CodeGraphStatus;
@@ -62,6 +83,7 @@ interface ReadyRepository {
 interface ValidationRepositoryTarget {
   readonly cwd: string;
   readonly expected?: RepositoryIdentityExpectation;
+  readonly published?: CodeGraphWorksetCatalogPublishedMemberV1;
 }
 
 interface ValidationScopeResolution {
@@ -148,14 +170,26 @@ export const validateContextBriefMemoryCitations = Effect.fn('contextBrief.valid
         ) {
           return Effect.succeed(undefined);
         }
-        const repository = {...target, status} satisfies ReadyRepository;
+        const repository = {...target, status} satisfies StatusReadyRepository;
         if (status.readySnapshot === undefined || status.stale || status.freshness !== 'current') {
           return Effect.succeed({
             repositoryId,
             tuples: tasks.map(task => [task, unknown(task.citation, 'graph-stale'), false] as const),
           });
         }
-        return validateRepositoryTasks(config, repository, tasks, observedAt).pipe(
+        return validateRepositoryTasks(
+          {
+            databasePath: status.databasePath,
+            finalFence: statusRepositoryFinalFence(config, repository),
+            objectFormat: status.identity.objectFormat,
+            repositoryId,
+            snapshot: status.readySnapshot,
+            sourceRoot: status.identity.repoRoot,
+            worktreeId: status.identity.worktreeId,
+          },
+          tasks,
+          observedAt,
+        ).pipe(
           Effect.map(results => ({
             repositoryId,
             tuples: tasks.map((task, index) => [task, results[index]!.receipt, results[index]!.cacheHit] as const),
@@ -174,6 +208,26 @@ export const validateContextBriefMemoryCitations = Effect.fn('contextBrief.valid
             ? query.status(config.agentContextHome, target.cwd, statusOptions)
             : query.statusForPublishedIdentity(config.agentContextHome, target.cwd, target.expected, statusOptions)
           ).pipe(Effect.flatMap(use));
+      if (target.published !== undefined) {
+        const repositoryId = target.published.repositoryId;
+        const tasks = eligibleByRepository.get(repositoryId);
+        if (tasks === undefined) return Effect.succeed(undefined).pipe(Effect.option);
+        if (!tasks.every(task => task.citation.target.kind === 'file')) return statusAndValidate.pipe(Effect.option);
+        return validatePublishedRepositoryTasks(config, target.cwd, target.published, tasks, observedAt).pipe(
+          Effect.catch(() => Effect.succeed(undefined)),
+          Effect.flatMap(results =>
+            results === undefined
+              ? statusAndValidate
+              : Effect.succeed({
+                  repositoryId,
+                  tuples: tasks.map(
+                    (task, index) => [task, results[index]!.receipt, results[index]!.cacheHit] as const,
+                  ),
+                }),
+          ),
+          Effect.option,
+        );
+      }
       return statusAndValidate.pipe(Effect.option);
     },
     {concurrency: VALIDATION_CONCURRENCY},
@@ -234,24 +288,132 @@ export const validateContextBriefMemoryCitations = Effect.fn('contextBrief.valid
   }) as readonly ContextBriefMemoryCitationValidationV2[];
 });
 
-const validateRepositoryTasks = Effect.fn('contextBrief.validateRepositoryCitationTasks')(function* (
+const validatePublishedRepositoryTasks = Effect.fn('contextBrief.validatePublishedRepositoryCitationTasks')(function* (
   config: RuntimeConfig,
-  repository: ReadyRepository,
+  cwd: string,
+  published: CodeGraphWorksetCatalogPublishedMemberV1,
+  tasks: readonly CitationTask[],
+  observedAt: string,
+) {
+  const path = yield* Path.Path;
+  const query = yield* CodeGraphQueryService;
+  const store = yield* CodeGraphStore;
+  const languagePacks = yield* CodeGraphLanguagePackRegistry;
+  const layout = codeGraphLayout(path, config.agentContextHome, published.checkoutId, published.worktreeId);
+  return yield* store.withSession(
+    layout.databasePath,
+    Effect.gen(function* () {
+      const snapshot = yield* store.readySnapshotById(layout.databasePath, published.snapshotId);
+      if (snapshot?.dirty === true) return undefined;
+      const runtimeCurrent =
+        snapshot !== undefined && cleanPublishedCatalogSnapshotMatches(published, snapshot)
+          ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, snapshot, languagePacks)
+          : false;
+      if (snapshot === undefined || !cleanPublishedCatalogSnapshotMatches(published, snapshot) || !runtimeCurrent) {
+        return tasks.map(task => ({
+          cacheHit: false,
+          receipt: unknownReceipt(task.citation, 'graph-stale', observedAt),
+        })) satisfies readonly ValidatedCitation[];
+      }
+      return yield* validateRepositoryTasks(
+        {
+          databasePath: layout.databasePath,
+          finalFence: resolvePublishedRepositoryReadFence(cwd, published).pipe(
+            Effect.flatMap(observation =>
+              Effect.gen(function* () {
+                if (observation.worktreeChanged) {
+                  const policyAwareStatus = yield* query.statusForPublishedIdentity(
+                    config.agentContextHome,
+                    cwd,
+                    published,
+                    {observeWorktree: true, requestMaintenance: false},
+                  );
+                  if (
+                    policyAwareStatus.freshness !== 'current' ||
+                    policyAwareStatus.stale ||
+                    !cleanPublishedCatalogFenceMatches(
+                      published,
+                      snapshot,
+                      policyAwareStatus.identity,
+                      policyAwareStatus.readySnapshot,
+                    )
+                  ) {
+                    return false;
+                  }
+                }
+                const activeSnapshot = yield* store.readySnapshot(layout.databasePath, published.worktreeId);
+                return cleanPublishedCatalogFenceMatches(published, snapshot, observation, activeSnapshot);
+              }),
+            ),
+          ),
+          objectFormat: snapshot.commit.length === 64 ? 'sha256' : 'sha1',
+          repositoryId: published.repositoryId,
+          snapshot,
+          sourceRoot: cwd,
+          worktreeId: published.worktreeId,
+        },
+        tasks,
+        observedAt,
+      );
+    }),
+    {existingOnly: true},
+  );
+});
+
+const statusRepositoryFinalFence = (
+  config: RuntimeConfig,
+  repository: StatusReadyRepository,
+): Effect.Effect<boolean, unknown, RepositoryValidationFenceRequirements> =>
+  Effect.gen(function* () {
+    const query = yield* CodeGraphQueryService;
+    const store = yield* CodeGraphStore;
+    const snapshot = repository.status.readySnapshot!;
+    if (repository.expected !== undefined && snapshot.dirty === false) {
+      return yield* Effect.all(
+        [
+          revalidateRepositoryIdentityFence(repository.cwd, repository.status.identity),
+          observeCleanRepositoryWorktree(repository.status.identity.repoRoot),
+          store.readySnapshot(repository.status.databasePath, repository.status.identity.worktreeId),
+        ],
+        {concurrency: 3},
+      ).pipe(
+        Effect.flatMap(([identity, cleanOverlay, activeSnapshot]) =>
+          resolveContextBriefFinalFenceOverlay(identity, cleanOverlay).pipe(
+            Effect.map(overlay =>
+              cleanPublishedCitationFenceMatches(repository.status, identity, overlay, activeSnapshot),
+            ),
+          ),
+        ),
+      );
+    }
+    const after = yield* repository.expected === undefined
+      ? query.status(config.agentContextHome, repository.cwd, {
+          observeWorktree: true,
+          requestMaintenance: false,
+        })
+      : query.statusForPublishedIdentity(config.agentContextHome, repository.cwd, repository.expected, {
+          observeWorktree: true,
+          requestMaintenance: false,
+        });
+    return sameExactSnapshot(repository.status, after);
+  });
+
+const validateRepositoryTasks = Effect.fn('contextBrief.validateRepositoryCitationTasks')(function* (
+  repository: RepositoryValidationInput,
   tasks: readonly CitationTask[],
   observedAt: string,
 ) {
   const store = yield* CodeGraphStore;
-  const query = yield* CodeGraphQueryService;
   const fs = yield* FileSystem.FileSystem;
-  const snapshot = repository.status.readySnapshot!;
+  const snapshot = repository.snapshot;
   return yield* Effect.scoped(
     Effect.gen(function* () {
-      yield* Effect.acquireRelease(
-        store.acquireSnapshotLease(repository.status.databasePath, snapshot.id, 60_000),
-        token =>
-          store.releaseSnapshotLease(repository.status.databasePath, token).pipe(Effect.catch(() => Effect.void)),
+      yield* Effect.acquireRelease(store.acquireSnapshotLease(repository.databasePath, snapshot.id, 60_000), token =>
+        store.releaseSnapshotLease(repository.databasePath, token).pipe(Effect.catch(() => Effect.void)),
       );
-      const cacheKeys = tasks.map(task => validationCacheKey(repository.status, snapshot.id, task.citation.id));
+      const cacheKeys = tasks.map(task =>
+        validationCacheKey(repository.repositoryId, repository.worktreeId, snapshot.id, task.citation.id),
+      );
       const cached = cacheKeys.map(validationCacheGet);
       const uncachedTasks = tasks.filter((_, index) => cached[index] === undefined);
       const computed = new Map<CitationTask, ContextBriefCitationValidationReceiptV2>();
@@ -266,7 +428,7 @@ const validateRepositoryTasks = Effect.fn('contextBrief.validateRepositoryCitati
           } => citation.target.kind === 'symbol',
         );
         const locators = symbolCitations.map(symbolLocator);
-        const evidence = yield* store.effectiveSnapshotCitationEvidence(repository.status.databasePath, snapshot.id, {
+        const evidence = yield* store.effectiveSnapshotCitationEvidence(repository.databasePath, snapshot.id, {
           fileRelocationFallbacks: citations.map(citation => ({
             contentHash: citation.fileContentHash.value,
             path: citation.path,
@@ -291,10 +453,10 @@ const validateRepositoryTasks = Effect.fn('contextBrief.validateRepositoryCitati
         const sourceBytes =
           symbolCitations.length === 0
             ? new Map<string, Uint8Array>()
-            : yield* fs.realPath(repository.status.identity.repoRoot).pipe(
+            : yield* fs.realPath(repository.sourceRoot).pipe(
                 Effect.flatMap(repositoryRoot =>
                   readCodeGraphCitationSources({
-                    objectFormat: repository.status.identity.objectFormat,
+                    objectFormat: repository.objectFormat,
                     repositoryRoot,
                     sourceCommit: snapshot.commit,
                     sources: symbolCitations.flatMap(citation =>
@@ -366,37 +528,7 @@ const validateRepositoryTasks = Effect.fn('contextBrief.validateRepositoryCitati
         for (const [index, task] of uncachedTasks.entries()) computed.set(task, receipts[index]!);
       }
 
-      const fenceCurrent =
-        repository.expected !== undefined && snapshot.dirty === false
-          ? yield* Effect.all(
-              [
-                revalidateRepositoryIdentityFence(repository.cwd, repository.status.identity),
-                observeCleanRepositoryWorktree(repository.status.identity.repoRoot),
-                store.readySnapshot(repository.status.databasePath, repository.status.identity.worktreeId),
-              ],
-              {concurrency: 3},
-            ).pipe(
-              Effect.flatMap(([identity, cleanOverlay, activeSnapshot]) =>
-                resolveContextBriefFinalFenceOverlay(identity, cleanOverlay).pipe(
-                  Effect.map(overlay =>
-                    cleanPublishedCitationFenceMatches(repository.status, identity, overlay, activeSnapshot),
-                  ),
-                ),
-              ),
-              Effect.catch(() => Effect.succeed(false)),
-            )
-          : sameExactSnapshot(
-              repository.status,
-              yield* repository.expected === undefined
-                ? query.status(config.agentContextHome, repository.cwd, {
-                    observeWorktree: true,
-                    requestMaintenance: false,
-                  })
-                : query.statusForPublishedIdentity(config.agentContextHome, repository.cwd, repository.expected, {
-                    observeWorktree: true,
-                    requestMaintenance: false,
-                  }),
-            );
+      const fenceCurrent = yield* repository.finalFence.pipe(Effect.catch(() => Effect.succeed(false)));
       if (!fenceCurrent) {
         return tasks.map(task => ({
           cacheHit: false,
@@ -850,7 +982,9 @@ const validationScopeTargets = Effect.fn('contextBrief.validationScopeTargets')(
     route.members,
     member =>
       expandPath(member.projectPath).pipe(
-        Effect.map(cwd => ({cwd, expected: member.published}) satisfies ValidationRepositoryTarget),
+        Effect.map(
+          cwd => ({cwd, expected: member.published, published: member.published}) satisfies ValidationRepositoryTarget,
+        ),
         Effect.option,
       ),
     {concurrency: VALIDATION_CONCURRENCY},
@@ -943,6 +1077,49 @@ function sameExactSnapshot(before: CodeGraphStatus, after: CodeGraphStatus): boo
   );
 }
 
+/** Immutable published-catalog receipt required before citation evidence reads. */
+export function cleanPublishedCatalogSnapshotMatches(
+  published: CodeGraphWorksetCatalogPublishedMemberV1,
+  snapshot: CodeGraphSnapshot,
+): boolean {
+  return (
+    snapshot.state === 'ready' &&
+    snapshot.dirty === false &&
+    snapshot.id === published.snapshotId &&
+    snapshot.repositoryId === published.repositoryId &&
+    snapshot.commit === published.commitId &&
+    snapshot.symbolCount === published.symbolCount
+  );
+}
+
+/** Final catalog-first fence after the complete live repository observation. */
+export function cleanPublishedCatalogFenceMatches(
+  published: CodeGraphWorksetCatalogPublishedMemberV1,
+  selected: CodeGraphSnapshot,
+  identity: Pick<RepositoryIdentity, 'checkoutId' | 'headCommit' | 'repositoryId' | 'worktreeId'>,
+  active: CodeGraphSnapshot | undefined,
+): boolean {
+  return (
+    cleanPublishedCatalogSnapshotMatches(published, selected) &&
+    identity.checkoutId === published.checkoutId &&
+    identity.repositoryId === published.repositoryId &&
+    identity.worktreeId === published.worktreeId &&
+    identity.headCommit === selected.commit &&
+    active?.state === 'ready' &&
+    active.dirty === false &&
+    active.id === selected.id &&
+    active.repositoryId === selected.repositoryId &&
+    active.commit === selected.commit &&
+    active.symbolCount === selected.symbolCount &&
+    active.extractorSet === selected.extractorSet &&
+    active.graphContentId === selected.graphContentId &&
+    active.baseSnapshotId === selected.baseSnapshotId &&
+    active.fileCount === selected.fileCount &&
+    active.edgeCount === selected.edgeCount &&
+    active.overlayFingerprint === selected.overlayFingerprint
+  );
+}
+
 /** Exact final fence for a clean snapshot selected from a published Workset. */
 export function cleanPublishedCitationFenceMatches(
   before: CodeGraphStatus,
@@ -974,8 +1151,8 @@ export const resolveContextBriefFinalFenceOverlay = Effect.fn('contextBrief.reso
   return cleanOverlay ?? (yield* worktreeOverlayState(identity));
 });
 
-function validationCacheKey(status: CodeGraphStatus, snapshotId: string, citationId: string): string {
-  return `${status.identity.repositoryId}\u0000${status.identity.worktreeId}\u0000${snapshotId}\u0000${citationId}`;
+function validationCacheKey(repositoryId: string, worktreeId: string, snapshotId: string, citationId: string): string {
+  return `${repositoryId}\u0000${worktreeId}\u0000${snapshotId}\u0000${citationId}`;
 }
 
 function validationCacheGet(key: string): ContextBriefCitationValidationReceiptV2 | undefined {

--- a/src/evaluation/context-brief-citation-scale.ts
+++ b/src/evaluation/context-brief-citation-scale.ts
@@ -306,6 +306,11 @@ export function makeContextBriefCitationScaleGraphInstrumentation(): ContextBrie
           observeDatabasePath(databasePath);
           counters.statusObservations += 1;
         }).pipe(Effect.andThen(store.readySnapshot(databasePath, worktreeId))),
+      readySnapshotById: (databasePath, snapshotId) =>
+        Effect.sync(() => {
+          observeDatabasePath(databasePath);
+          counters.statusObservations += 1;
+        }).pipe(Effect.andThen(store.readySnapshotById(databasePath, snapshotId))),
       releaseSnapshotLease: (databasePath, token, options) =>
         store.releaseSnapshotLease(databasePath, token, options).pipe(
           Effect.tap(() =>

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -63,6 +63,7 @@ import {
 } from '../../src/code_graph/store.js';
 import {
   CODE_GRAPH_SCHEMA_VERSION,
+  CodeGraphStoreError,
   CodeGraphStoreNoSpaceError,
   type CodeGraphMaterializationMetrics,
   type CodeGraphProgress,
@@ -619,6 +620,37 @@ describe('native code graph lifecycle', () => {
           database.close();
         }
       });
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('opens existing-only writable sessions without creating a missing graph database', () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.sync(createFixtureRepository);
+      const home = join(root, '.threadnote-test-home');
+      const indexer = yield* CodeGraphIndexer;
+      const store = yield* CodeGraphStore;
+      const fs = yield* FileSystem.FileSystem;
+      const indexed = yield* indexer.index({cwd: root, threadnoteHome: home});
+      const databasePath = codeGraphDatabasePath(home, indexed);
+      const selected = yield* store.withSession(
+        databasePath,
+        Effect.scoped(
+          Effect.acquireUseRelease(
+            store.acquireSnapshotLease(databasePath, indexed.snapshot.id, 60_000),
+            () => store.readySnapshot(databasePath, indexed.identity.worktreeId),
+            token => store.releaseSnapshotLease(databasePath, token),
+          ),
+        ),
+        {existingOnly: true},
+      );
+      expect(selected?.id).toBe(indexed.snapshot.id);
+
+      const missing = join(home, 'indexes', 'code-graph', 'missing.sqlite');
+      expect(yield* fs.exists(missing)).toBe(false);
+      const failure = yield* store.withSession(missing, Effect.void, {existingOnly: true}).pipe(Effect.flip);
+      expect(failure).toBeInstanceOf(CodeGraphStoreError);
+      expect(failure.message).toBe('Existing code graph database could not be opened.');
+      expect(yield* fs.exists(missing)).toBe(false);
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 

--- a/test/integration/context-brief-citation-workset.test.ts
+++ b/test/integration/context-brief-citation-workset.test.ts
@@ -1,0 +1,151 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe, expect} from 'vitest';
+import {
+  codeGraphWorksetRuntimeConfig,
+  indexPreparedCodeGraphWorksetFixture,
+  publishIndexedCodeGraphWorksetCatalog,
+} from '../../scripts/support/code-graph-workset-harness.js';
+import {
+  prepareCodeGraphWorksetFixture,
+  removePreparedCodeGraphWorksetFixture,
+} from '../../scripts/support/code-graph-workset-fixture.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import type {CodeGraphStoreShape} from '../../src/code_graph/store_shape.js';
+import {validateContextBriefMemoryCitations} from '../../src/context_brief/citation_validation.js';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {captureMemoryCodeCitations} from '../../src/memory_code_citation_capture.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {TestError} from '../helpers/test-error.js';
+
+describe('Context Brief published Workset citation validation', () => {
+  effectIt.effect(
+    'preserves policy-excluded changes and balances the lease when a HEAD race turns evidence stale',
+    () =>
+      Effect.acquireUseRelease(
+        Effect.tryPromise({
+          try: () => prepareCodeGraphWorksetFixture({size: 1, stateProfile: 'all-clean'}),
+          catch: cause => new TestError('Could not prepare the citation Workset fixture.', {cause}),
+        }),
+        fixture =>
+          Effect.gen(function* () {
+            const repository = fixture.repositories[0];
+            if (repository === undefined)
+              return yield* Effect.fail(new TestError('Citation Workset fixture has no repository.'));
+            const config = codeGraphWorksetRuntimeConfig(fixture);
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const excludedPath = path.join(repository.path, 'assets', 'logo.svg');
+            yield* fs.makeDirectory(path.dirname(excludedPath), {recursive: true});
+            yield* fs.writeFileString(excludedPath, '<svg/>\n');
+            yield* git(repository.path, ['add', 'assets/logo.svg']);
+            yield* git(repository.path, [
+              '-c',
+              'user.name=Threadnote Test',
+              '-c',
+              'user.email=test@threadnote.local',
+              'commit',
+              '-qm',
+              'add excluded fixture',
+            ]);
+            yield* indexPreparedCodeGraphWorksetFixture(fixture);
+            yield* publishIndexedCodeGraphWorksetCatalog(fixture, [fixture.identity.worksetName]);
+            const citations = yield* captureMemoryCodeCitations(config, {
+              callerCwd: repository.path,
+              refs: ['src/session.ts'],
+            });
+            expect(citations).toHaveLength(1);
+            expect(citations[0]?.target.kind).toBe('file');
+
+            const candidate = {
+              citationErrorCount: 0,
+              codeCitations: citations,
+              excerpt: 'The session resolver owns the published contract.',
+              kind: 'durable' as const,
+              project: repository.projectName,
+              rank: 0,
+              topic: 'session-resolver',
+              uri: 'threadnote://user/test/memories/durable/projects/workset/session-resolver.md',
+            };
+            const baseStore = yield* CodeGraphStore;
+            let acquired = 0;
+            let evidenceReads = 0;
+            let released = 0;
+            let sessions = 0;
+            const countedStore = CodeGraphStore.of({
+              ...baseStore,
+              acquireSnapshotLease: (...args: Parameters<CodeGraphStoreShape['acquireSnapshotLease']>) =>
+                Effect.sync(() => void ++acquired).pipe(Effect.andThen(baseStore.acquireSnapshotLease(...args))),
+              effectiveSnapshotCitationEvidence: (
+                ...args: Parameters<CodeGraphStoreShape['effectiveSnapshotCitationEvidence']>
+              ) =>
+                Effect.sync(() => void ++evidenceReads).pipe(
+                  Effect.andThen(baseStore.effectiveSnapshotCitationEvidence(...args)),
+                ),
+              releaseSnapshotLease: (...args: Parameters<CodeGraphStoreShape['releaseSnapshotLease']>) =>
+                baseStore.releaseSnapshotLease(...args).pipe(Effect.tap(() => Effect.sync(() => void ++released))),
+              withSession: (...args: Parameters<CodeGraphStoreShape['withSession']>) => {
+                expect(args[2]).toMatchObject({existingOnly: true});
+                return Effect.sync(() => void ++sessions).pipe(Effect.andThen(baseStore.withSession(...args)));
+              },
+            } as CodeGraphStoreShape);
+            const validate = () =>
+              validateContextBriefMemoryCitations(config, {kind: 'workset', name: fixture.identity.worksetName}, [
+                candidate,
+              ]).pipe(Effect.provideService(CodeGraphStore, countedStore));
+
+            const exact = yield* validate();
+            expect(exact[0]?.receipts).toMatchObject([{reason: 'exact', status: 'exact'}]);
+            expect({acquired, evidenceReads, released, sessions}).toEqual({
+              acquired: 1,
+              evidenceReads: 1,
+              released: 1,
+              sessions: 1,
+            });
+
+            yield* fs.writeFileString(excludedPath, '<svg>excluded change</svg>\n');
+            const policyClean = yield* validate();
+            expect(policyClean[0]?.receipts).toMatchObject([{reason: 'exact', status: 'exact'}]);
+            expect({acquired, evidenceReads, released, sessions}).toEqual({
+              acquired: 2,
+              evidenceReads: 1,
+              released: 2,
+              sessions: 2,
+            });
+
+            yield* fs.writeFileString(excludedPath, '<svg/>\n');
+            yield* git(repository.path, [
+              '-c',
+              'user.name=Threadnote Test',
+              '-c',
+              'user.email=test@threadnote.local',
+              'commit',
+              '--allow-empty',
+              '-qm',
+              'move published head',
+            ]);
+
+            const stale = yield* validate();
+            expect(stale[0]?.receipts).toMatchObject([{reason: 'graph-stale', status: 'unknown'}]);
+            expect({acquired, evidenceReads, released, sessions}).toEqual({
+              acquired: 3,
+              evidenceReads: 1,
+              released: 3,
+              sessions: 3,
+            });
+          }),
+        fixture =>
+          Effect.tryPromise({
+            try: () => removePreparedCodeGraphWorksetFixture(fixture),
+            catch: cause => new TestError('Could not remove the citation Workset fixture.', {cause}),
+          }),
+      ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    {timeout: 120_000},
+  );
+});
+
+const git = Effect.fn('contextBriefCitationWorksetTest.git')((cwd: string, args: readonly string[]) =>
+  runCommandEffect('git', ['-C', cwd, ...args], {maxOutputBytes: 1_048_576, timeoutMs: 30_000}),
+);

--- a/test/unit/code-graph.repository-expected-identity.test.ts
+++ b/test/unit/code-graph.repository-expected-identity.test.ts
@@ -8,6 +8,7 @@ import {
   resolveRepositoryIdentity,
   resolveRepositoryIdentityForExpectation,
   resolveRepositoryIdentityForExpectationAndWorktree,
+  resolvePublishedRepositoryReadFence,
   revalidateRepositoryIdentityFence,
 } from '../../src/code_graph/repository.js';
 import {runCommandEffect} from '../../src/effect/command.js';
@@ -117,6 +118,84 @@ describe('code graph expected repository identity', () => {
             yield* git(root, ['remote', 'add', 'origin', 'https://github.com/example/replaced.git']);
             const failure = yield* revalidateRepositoryIdentityFence(root, before).pipe(Effect.flip);
             expect(failure.message).toBe('Repository identity changed during the graph read.');
+          }),
+        ),
+      ),
+    );
+
+    it.effect('brackets a clean published read across caller-path and HEAD observations', () =>
+      TestClock.withLive(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const parent = yield* Effect.acquireRelease(
+              fs.makeTempDirectory({prefix: 'threadnote-published-read-fence-'}),
+              directory => fs.remove(directory, {force: true, recursive: true}).pipe(Effect.orDie),
+            );
+            const first = path.join(parent, 'first');
+            const second = path.join(parent, 'second');
+            const caller = path.join(parent, 'caller');
+            yield* fs.makeDirectory(first);
+            yield* git(first, ['init', '-q']);
+            yield* fs.writeFileString(path.join(first, 'tracked.ts'), 'export const tracked = 1;\n');
+            yield* git(first, ['add', 'tracked.ts']);
+            yield* git(first, [
+              '-c',
+              'user.name=Threadnote Test',
+              '-c',
+              'user.email=test@threadnote.local',
+              'commit',
+              '--allow-empty',
+              '-qm',
+              'fixture',
+            ]);
+            yield* git(first, ['remote', 'add', 'origin', 'https://github.com/example/read-fence.git']);
+            yield* git(parent, ['clone', '--quiet', first, second]);
+            yield* git(second, ['remote', 'set-url', 'origin', 'https://github.com/example/read-fence.git']);
+            yield* fs.symlink(first, caller);
+            const identity = yield* resolveRepositoryIdentity(caller);
+            const expected = {
+              checkoutId: identity.checkoutId,
+              repositoryId: identity.repositoryId,
+              worktreeId: identity.worktreeId,
+            };
+            expect(yield* resolvePublishedRepositoryReadFence(caller, expected)).toEqual({
+              ...expected,
+              headCommit: identity.headCommit,
+              worktreeChanged: false,
+            });
+
+            const failure = yield* resolvePublishedRepositoryReadFence(caller, expected, {
+              afterInitialIdentity: () => fs.remove(caller).pipe(Effect.andThen(fs.symlink(second, caller))),
+            }).pipe(Effect.flip);
+            expect(failure).toBeInstanceOf(Error);
+            expect((failure as Error).message).toBe('Repository identity changed during the graph read.');
+
+            yield* fs.remove(caller);
+            yield* fs.symlink(first, caller);
+            const changed = yield* resolvePublishedRepositoryReadFence(caller, expected, {
+              afterWorktreeObservation: () =>
+                fs.writeFileString(path.join(first, 'tracked.ts'), 'export const tracked = 2;\n'),
+            });
+            expect(changed).toEqual({...expected, headCommit: identity.headCommit, worktreeChanged: true});
+            yield* fs.writeFileString(path.join(first, 'tracked.ts'), 'export const tracked = 1;\n');
+
+            const headFailure = yield* resolvePublishedRepositoryReadFence(caller, expected, {
+              afterWorktreeObservation: () =>
+                git(first, [
+                  '-c',
+                  'user.name=Threadnote Test',
+                  '-c',
+                  'user.email=test@threadnote.local',
+                  'commit',
+                  '--allow-empty',
+                  '-qm',
+                  'interlocked next head',
+                ]).pipe(Effect.asVoid),
+            }).pipe(Effect.flip);
+            expect(headFailure).toBeInstanceOf(Error);
+            expect((headFailure as Error).message).toBe('Repository identity changed during the graph read.');
           }),
         ),
       ),

--- a/test/unit/context-brief-citations.test.ts
+++ b/test/unit/context-brief-citations.test.ts
@@ -5,6 +5,8 @@ import {Effect, Layer} from 'effect';
 import {describe, expect, it} from 'vitest';
 import {
   aggregatePreciseStatus,
+  cleanPublishedCatalogFenceMatches,
+  cleanPublishedCatalogSnapshotMatches,
   cleanPublishedCitationFenceMatches,
   routeContextBriefWorksetValidation,
   validateContextBriefFileCitation,
@@ -21,6 +23,7 @@ import type {
 } from '../../src/code_graph/types.js';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {codeGraphWorksetManifestDigest} from '../../src/code_graph/workset_catalog/workset.js';
+import type {CodeGraphWorksetCatalogPublishedMemberV1} from '../../src/code_graph/workset_catalog/types.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import type {ResolvedWorkset} from '../../src/types.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
@@ -51,6 +54,18 @@ const snapshot: CodeGraphSnapshot = {
   state: 'ready',
   symbolCount: 0,
   worktreeId: '2'.repeat(64),
+};
+const published: CodeGraphWorksetCatalogPublishedMemberV1 = {
+  checkoutId: '3'.repeat(64),
+  commitId: snapshot.commit,
+  ordinal: 0,
+  projectionDigest: '4'.repeat(64),
+  repositoryId: snapshot.repositoryId,
+  repositoryKey: 'threadnote',
+  snapshotDigest: '5'.repeat(64),
+  snapshotId: snapshot.id,
+  symbolCount: snapshot.symbolCount,
+  worktreeId: snapshot.worktreeId,
 };
 
 describe('Context Brief code-citation classification', () => {
@@ -111,6 +126,81 @@ describe('Context Brief code-citation classification', () => {
       ),
       {numRuns: 100},
     );
+  });
+
+  it('rejects every mutated catalog-first snapshot or final-fence component', () => {
+    const identity = {
+      checkoutId: published.checkoutId,
+      headCommit: published.commitId,
+      repositoryId: published.repositoryId,
+      worktreeId: published.worktreeId,
+    };
+    expect(cleanPublishedCatalogSnapshotMatches(published, snapshot)).toBe(true);
+    expect(
+      cleanPublishedCatalogFenceMatches(published, snapshot, identity, {
+        ...snapshot,
+        worktreeId: 'shared-clean-row'.padEnd(64, '0'),
+      }),
+    ).toBe(true);
+
+    const mutations = [
+      'selected-id',
+      'selected-repository',
+      'selected-commit',
+      'selected-symbols',
+      'selected-dirty',
+      'selected-state',
+      'identity-checkout',
+      'identity-repository',
+      'identity-worktree',
+      'identity-head',
+      'active-id',
+      'active-repository',
+      'active-commit',
+      'active-symbols',
+      'active-extractor',
+      'active-content',
+      'active-base',
+      'active-files',
+      'active-edges',
+      'active-overlay',
+      'active-dirty',
+      'active-state',
+    ] as const;
+    for (const mutation of mutations) {
+      const selected: CodeGraphSnapshot = {
+        ...snapshot,
+        ...(mutation === 'selected-id' ? {id: `cgsn_${'9'.repeat(40)}`} : {}),
+        ...(mutation === 'selected-repository' ? {repositoryId: '9'.repeat(64)} : {}),
+        ...(mutation === 'selected-commit' ? {commit: '9'.repeat(40)} : {}),
+        ...(mutation === 'selected-symbols' ? {symbolCount: snapshot.symbolCount + 1} : {}),
+        ...(mutation === 'selected-dirty' ? {dirty: true} : {}),
+        ...(mutation === 'selected-state' ? {state: 'retired' as const} : {}),
+      };
+      const observedIdentity = {
+        ...identity,
+        ...(mutation === 'identity-checkout' ? {checkoutId: '9'.repeat(64)} : {}),
+        ...(mutation === 'identity-repository' ? {repositoryId: '9'.repeat(64)} : {}),
+        ...(mutation === 'identity-worktree' ? {worktreeId: '9'.repeat(64)} : {}),
+        ...(mutation === 'identity-head' ? {headCommit: '9'.repeat(40)} : {}),
+      };
+      const active: CodeGraphSnapshot = {
+        ...snapshot,
+        ...(mutation === 'active-id' ? {id: `cgsn_${'9'.repeat(40)}`} : {}),
+        ...(mutation === 'active-repository' ? {repositoryId: '9'.repeat(64)} : {}),
+        ...(mutation === 'active-commit' ? {commit: '9'.repeat(40)} : {}),
+        ...(mutation === 'active-symbols' ? {symbolCount: snapshot.symbolCount + 1} : {}),
+        ...(mutation === 'active-extractor' ? {extractorSet: 'changed-extractor'} : {}),
+        ...(mutation === 'active-content' ? {graphContentId: `cgc_${'9'.repeat(40)}`} : {}),
+        ...(mutation === 'active-base' ? {baseSnapshotId: `cgsn_${'9'.repeat(40)}`} : {}),
+        ...(mutation === 'active-files' ? {fileCount: snapshot.fileCount + 1} : {}),
+        ...(mutation === 'active-edges' ? {edgeCount: snapshot.edgeCount + 1} : {}),
+        ...(mutation === 'active-overlay' ? {overlayFingerprint: 'changed-overlay'} : {}),
+        ...(mutation === 'active-dirty' ? {dirty: true} : {}),
+        ...(mutation === 'active-state' ? {state: 'retired' as const} : {}),
+      };
+      expect(cleanPublishedCatalogFenceMatches(published, selected, observedIdentity, active)).toBe(false);
+    }
   });
 
   it('classifies exact and relocated file evidence while abstaining on incomplete or ambiguous absence', () => {

--- a/test/unit/memory-code-citation-capture.test.ts
+++ b/test/unit/memory-code-citation-capture.test.ts
@@ -6,6 +6,7 @@ import type {CodeGraphStoreShape} from '../../src/code_graph/store_shape.js';
 import {codeGraphCommittedFileContentHash} from '../../src/code_graph/content_identity.js';
 import {CodeGraphQueryService} from '../../src/code_graph/query.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {CodeGraphLanguagePackRegistry} from '../../src/code_graph/languages/registry.js';
 import type {
   CodeGraphEffectiveSnapshotCitationEvidence,
   CodeGraphEffectiveSnapshotCitationEvidenceRequest,
@@ -75,12 +76,12 @@ describe('memory code citation capture and validation', () => {
       };
       const first = yield* validateContextBriefMemoryCitations(CONFIG, {callerCwd: root, kind: 'repository'}, [
         candidate,
-      ]).pipe(provideTestLayer(fixture.layer));
+      ]).pipe(provideTestLayer(Layer.merge(fixture.layer, CodeGraphLanguagePackRegistry.layer)));
       const callsAfterFirstValidation = fixture.evidenceCalls();
       yield* TestClock.adjust('1 second');
       const second = yield* validateContextBriefMemoryCitations(CONFIG, {callerCwd: root, kind: 'repository'}, [
         candidate,
-      ]).pipe(provideTestLayer(fixture.layer));
+      ]).pipe(provideTestLayer(Layer.merge(fixture.layer, CodeGraphLanguagePackRegistry.layer)));
 
       expect(first[0]?.receipts.map(receipt => receipt.status)).toEqual(['exact', 'exact']);
       expect(first[0]?.cacheHits).toBeUndefined();


### PR DESCRIPTION
## Summary

- validate clean file-only Workset citations directly from the immutable published catalog snapshot
- keep one existing-only SQLite session and lease per cited repository, with a closing Git/worktree and active-snapshot fence
- preserve the prior policy-aware path for dirty, symbol, mixed, stale, missing, or changing repositories
- add deterministic race, fallback, lifecycle, Workset integration, legacy-capture, and scale-counter coverage

## Verification

- dev-cycle: 3 iterations; final incremental review has zero findings at every severity
- focused Vitest: 23/23 passed across citation, repository-fence, Workset integration, store lifecycle, and legacy-v1 coverage
- source, test, and website TypeScript checks passed via the commit hook
- strict lint, file-length, Prettier, and diff checks passed
- exact local 100k-memory gate passed (98,016 legacy v1 candidates): workset-50 validation p95 423.99 ms; workset-128 validation p95 856.01 ms; exact receipts 64/96; peak leases 4; zero cold builds or maintenance

## Release gate

Do not merge/release from local timing alone. Require green PR CI and the pinned Linux Context Brief citations 100k/50/128 workflow on the exact candidate commit. After squash merge, rerun the same mandatory workflow on the exact final main SHA before tagging v4.4.1.