### PR TITLE
test: harden live diagnostics synchronization

### DIFF
--- a/test/unit/code-graph.orphan-provenance-cleanup.test.ts
+++ b/test/unit/code-graph.orphan-provenance-cleanup.test.ts
@@ -366,22 +366,61 @@ describe('automatic orphan provenance cleanup', () => {
           targets,
           threadnoteHome: home,
         });
-
-        expect(first).toMatchObject({
-          checkoutId: earlier!.mainIdentity.checkoutId,
-          result: {cleanup: 'none'},
-          state: 'completed',
-        });
-        expect(second).toMatchObject({
+        const persistedCursor = JSON.parse(
+          readFileSync(
+            join(home, 'locks', 'indexes', 'code-graph', 'lifecycle-opportunities', 'diagnostics.cursor-v1.json'),
+            'utf8',
+          ),
+        ) as {readonly checkoutId?: unknown; readonly lane?: unknown};
+        expect(persistedCursor).toMatchObject({
           checkoutId: later!.mainIdentity.checkoutId,
-          result: {
-            cleanup: 'orphan-provenance',
-            diagnostics: [CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC],
-          },
-          state: 'completed',
+          lane: 'reconciliation',
         });
+
+        if (first.state === 'completed') {
+          expect(first).toMatchObject({
+            checkoutId: earlier!.mainIdentity.checkoutId,
+            result: {cleanup: 'none'},
+          });
+        } else {
+          expect(first).toEqual({opportunity: 'diagnostics', reason: 'deadline', state: 'deferred'});
+        }
+
+        if (second.state === 'completed') {
+          expect(second).toMatchObject({
+            checkoutId: later!.mainIdentity.checkoutId,
+            result: {
+              cleanup: 'orphan-provenance',
+              diagnostics: [CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC],
+            },
+          });
+        } else {
+          expect(second).toEqual({opportunity: 'diagnostics', reason: 'deadline', state: 'deferred'});
+          if (existsSync(later!.sidecar)) {
+            // The foreground deadline is a valid production result. Finish the same live lane
+            // directly so this test verifies cleanup correctness without stretching that guard.
+            const cursorBeforeRetry = readOrphanCursor(later!.databasePath);
+            const completed = yield* maintenance.kickReconciliation({
+              allowIndexPreparation: true,
+              anchorIdentity: later!.mainIdentity,
+              automaticTail: false,
+              checkoutId: later!.mainIdentity.checkoutId,
+              databasePath: later!.databasePath,
+              joinActive: false,
+              threadnoteHome: home,
+              writerLockPath: later!.layout.databaseWriteLockPath,
+            });
+            expect(completed).toMatchObject({cleanup: 'orphan-provenance', state: 'completed'});
+            if (cursorBeforeRetry === 'malformed-cursor') {
+              expect(completed).toMatchObject({
+                diagnostics: [CODE_GRAPH_ORPHAN_PROVENANCE_CURSOR_RECOVERY_DIAGNOSTIC],
+              });
+            }
+          }
+        }
         expect(existsSync(earlier!.sidecar)).toBe(true);
         expect(existsSync(later!.sidecar)).toBe(false);
+        expect(readOrphanCursor(later!.databasePath)).not.toBe('malformed-cursor');
         expect(readFileSync(later!.mainFile, 'utf8')).toBe('main source\n');
         const serialized = JSON.stringify([first, second]);
         expect(serialized).not.toContain(root);

--- a/test/unit/effect-command.test.ts
+++ b/test/unit/effect-command.test.ts
@@ -1,5 +1,5 @@
 import {TestError} from '../helpers/test-error.js';
-import {mkdtemp, readFile, rm} from '../helpers/node-fs-promises.js';
+import {mkdtemp, readFile, rm, writeFile} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import {Clock, Effect, Fiber, FileSystem, Path, Result} from 'effect';
@@ -138,6 +138,21 @@ describe('Effect CommandExecutor', () => {
     expect(result).toEqual({exitCode: 0, stderr: '', stdout: ''});
   });
 
+  it('waits for a complete detached-child receipt instead of treating file creation as completion', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'threadnote-detached-receipt-'));
+    const receiptPath = join(directory, 'environment.json');
+    try {
+      await writeFile(receiptPath, '{', 'utf8');
+      const receipt = readCompleteEnvironmentReceipt(receiptPath);
+      await new Promise(resolve => setTimeout(resolve, 20));
+      await writeFile(receiptPath, JSON.stringify({THREADNOTE_DETACHED_SAFE_VALUE: 'complete'}), 'utf8');
+
+      await expect(receipt).resolves.toEqual({THREADNOTE_DETACHED_SAFE_VALUE: 'complete'});
+    } finally {
+      await rm(directory, {force: true, recursive: true});
+    }
+  });
+
   it('scrubs telemetry correlation state from detached children', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'threadnote-detached-command-'));
     const receiptPath = join(directory, 'environment.json');
@@ -157,18 +172,10 @@ describe('Effect CommandExecutor', () => {
         ),
       );
       expect(spawned).toBe(true);
-      let childEnvironment: Record<string, string> | undefined;
-      for (let attempt = 0; attempt < 100; attempt += 1) {
-        const receipt = await readFile(receiptPath, 'utf8').catch(() => undefined);
-        if (receipt !== undefined) {
-          childEnvironment = JSON.parse(receipt) as Record<string, string>;
-          break;
-        }
-        await new Promise(resolve => setTimeout(resolve, 10));
-      }
+      const childEnvironment = await readCompleteEnvironmentReceipt(receiptPath);
       expect(childEnvironment).toEqual(expect.objectContaining({THREADNOTE_DETACHED_SAFE_VALUE: 'preserved'}));
       for (const variable of Object.keys(privateValues)) {
-        expect(childEnvironment?.[variable]).toBeUndefined();
+        expect(childEnvironment[variable]).toBeUndefined();
       }
     } finally {
       await rm(directory, {force: true, recursive: true});
@@ -198,15 +205,7 @@ describe('Effect CommandExecutor', () => {
         ),
       );
       expect(spawned).toBe(true);
-      let childEnvironment: Record<string, string> | undefined;
-      for (let attempt = 0; attempt < 100; attempt += 1) {
-        const receipt = await readFile(receiptPath, 'utf8').catch(() => undefined);
-        if (receipt !== undefined) {
-          childEnvironment = JSON.parse(receipt) as Record<string, string>;
-          break;
-        }
-        await new Promise(resolve => setTimeout(resolve, 10));
-      }
+      const childEnvironment = await readCompleteEnvironmentReceipt(receiptPath);
       expect(childEnvironment).toEqual(
         expect.objectContaining({
           [TELEMETRY_AGENT_SESSION_ENVIRONMENT_VARIABLE]: sessionId,
@@ -215,13 +214,31 @@ describe('Effect CommandExecutor', () => {
           THREADNOTE_DETACHED_SAFE_VALUE: 'preserved',
         }),
       );
-      expect(childEnvironment?.[TELEMETRY_PROVIDER_ENVIRONMENT_VARIABLE]).toBeUndefined();
-      expect(childEnvironment?.[TELEMETRY_PROVIDER_SESSION_TOKEN_ENVIRONMENT_VARIABLE]).toBeUndefined();
+      expect(childEnvironment[TELEMETRY_PROVIDER_ENVIRONMENT_VARIABLE]).toBeUndefined();
+      expect(childEnvironment[TELEMETRY_PROVIDER_SESSION_TOKEN_ENVIRONMENT_VARIABLE]).toBeUndefined();
     } finally {
       await rm(directory, {force: true, recursive: true});
     }
   });
 });
+
+async function readCompleteEnvironmentReceipt(path: string): Promise<Record<string, string>> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const receipt = await readFile(path, 'utf8').catch(() => undefined);
+    if (receipt !== undefined) {
+      try {
+        const parsed: unknown = JSON.parse(receipt);
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+          return parsed as Record<string, string>;
+        }
+      } catch {
+        // A detached writer can create the file before its complete JSON payload is visible.
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new TestError('Detached child did not publish a complete environment receipt.');
+}
 
 function isProcessRunning(pid: number): boolean {
   try {


### PR DESCRIPTION
Summary:
- accept the intentional 2-second diagnostics deadline in the live orphan-provenance test while proving durable rotation selected the later repository
- finish the same live reconciliation lane directly only when the foreground deadline fires, preserving the production guardrail
- wait for parseable detached-child environment receipts and cover a deliberately partial JSON publication

Verification:
- focused Vitest: 18/18 passed
- repository lint, Prettier, root/test/site TypeScript passed via pre-commit
- no production source changed; no global install required

CI evidence addressed: run 33104801254, job 98631736039.