### PR TITLE
fix(worksets): calibrate projection capacity

### DIFF
--- a/src/code_graph/workset_catalog/layout.ts
+++ b/src/code_graph/workset_catalog/layout.ts
@@ -1,6 +1,6 @@
 import type {Path} from 'effect';
 
-export const CODE_GRAPH_WORKSET_CATALOG_SCHEMA_VERSION = 3 as const;
+export const CODE_GRAPH_WORKSET_CATALOG_SCHEMA_VERSION = 4 as const;
 
 export interface CodeGraphWorksetCatalogLayout {
   readonly databasePath: string;

--- a/src/code_graph/workset_catalog/projection_storage.ts
+++ b/src/code_graph/workset_catalog/projection_storage.ts
@@ -18,6 +18,9 @@ export function codeGraphWorksetRoutingProjectionLogicalBytesAppend(
   if (!Number.isSafeInteger(currentBytes) || currentBytes < 0) {
     throw new CodeGraphWorksetCatalogError('invalid-input', 'Workset routing projection byte state is invalid.');
   }
+  if (currentBytes > CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum) {
+    throw projectionCapacityError();
+  }
   let bytes = currentBytes;
   for (const symbol of symbols) {
     bytes += Buffer.byteLength(JSON.stringify(symbol), 'utf8') + ROUTING_ROW_STORAGE_CHARGE_BYTES;
@@ -34,11 +37,15 @@ export function codeGraphWorksetRoutingProjectionLogicalBytesAppend(
         ROUTING_ROW_STORAGE_CHARGE_BYTES;
     }
     if (!Number.isSafeInteger(bytes) || bytes > CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum) {
-      throw new CodeGraphWorksetCatalogError(
-        'capacity',
-        'Workset routing projection exceeds the supported aggregate byte bound.',
-      );
+      throw projectionCapacityError();
     }
   }
   return bytes;
+}
+
+function projectionCapacityError(): CodeGraphWorksetCatalogError {
+  return new CodeGraphWorksetCatalogError(
+    'capacity',
+    'Workset routing projection exceeds the supported aggregate byte bound.',
+  );
 }

--- a/src/code_graph/workset_catalog/snapshot_projection.ts
+++ b/src/code_graph/workset_catalog/snapshot_projection.ts
@@ -2,6 +2,7 @@ import {Cause, Effect, Option, Ref, Result} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {sha256HexSync} from '../../crypto/sha256.js';
 import {CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION} from '../store_build_core.js';
+import {classifyCodeGraphStoreFailure} from '../store_failure.js';
 import {effectiveSnapshotParameters, effectiveSymbolsCte} from '../store_query_core.js';
 import type {CodeGraphStoreShape} from '../store_shape.js';
 import type {CodeGraphSnapshot} from '../types.js';
@@ -34,6 +35,97 @@ const MAXIMUM_SPAN_JSON_BYTES = 4 * 1_024;
 const SHA256_HEX = /^[0-9a-f]{64}$/u;
 const PROJECTION_LOOKUP_TABLE = 'workset_projection_lookup';
 const PROJECTION_TERMS_TABLE = 'workset_projection_terms';
+const PROJECTION_LOOKUP_MATERIALIZATION_SQL = `WITH effective_lookup AS (
+  SELECT lookup.symbol_id, lookup.lookup_key
+  FROM snapshot_symbol_lookup AS lookup
+  WHERE lookup.snapshot_id = ?
+  UNION ALL
+  SELECT lookup.symbol_id, lookup.lookup_key
+  FROM snapshot_symbol_lookup AS lookup
+  WHERE lookup.snapshot_id = ?
+    AND NOT EXISTS (
+      SELECT 1 FROM symbols AS overrides
+      WHERE overrides.snapshot_id = ? AND overrides.id = lookup.symbol_id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM snapshot_symbol_deletions AS deletions
+      WHERE deletions.snapshot_id = ? AND deletions.symbol_id = lookup.symbol_id
+    )
+)
+INSERT INTO temp.${PROJECTION_LOOKUP_TABLE} (symbol_id, lookup_key)
+SELECT symbol_id, lookup_key
+FROM effective_lookup
+WHERE TRUE
+ON CONFLICT(symbol_id, lookup_key) DO NOTHING`;
+const PROJECTION_TERMS_MATERIALIZATION_SQL = `WITH effective_terms AS (
+  SELECT legacy.symbol_id, legacy.term, legacy.weight
+  FROM symbol_terms AS legacy
+  WHERE legacy.snapshot_id = ?
+    AND NOT EXISTS (
+      SELECT 1 FROM lexical_storage_formats AS storage
+      WHERE storage.snapshot_id = legacy.snapshot_id
+    )
+  UNION ALL
+  SELECT compact_symbol.symbol_id, compact_term.term, posting.weight
+  FROM lexical_compact_snapshots AS compact_snapshot
+  JOIN lexical_storage_formats AS storage
+    ON storage.snapshot_id = compact_snapshot.snapshot_id
+   AND storage.format_version = ${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}
+  JOIN lexical_compact_terms AS compact_term
+    ON compact_term.snapshot_key = compact_snapshot.snapshot_key
+  JOIN lexical_compact_postings AS posting
+    ON posting.snapshot_key = compact_snapshot.snapshot_key
+   AND posting.term_key = compact_term.term_key
+  JOIN lexical_compact_symbols AS compact_symbol
+    ON compact_symbol.snapshot_key = compact_snapshot.snapshot_key
+   AND compact_symbol.symbol_key = posting.symbol_key
+  WHERE compact_snapshot.snapshot_id = ?
+  UNION ALL
+  SELECT legacy.symbol_id, legacy.term, legacy.weight
+  FROM symbol_terms AS legacy
+  WHERE legacy.snapshot_id = ?
+    AND NOT EXISTS (
+      SELECT 1 FROM lexical_storage_formats AS storage
+      WHERE storage.snapshot_id = legacy.snapshot_id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM symbols AS overrides
+      WHERE overrides.snapshot_id = ? AND overrides.id = legacy.symbol_id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM snapshot_symbol_deletions AS deletions
+      WHERE deletions.snapshot_id = ? AND deletions.symbol_id = legacy.symbol_id
+    )
+  UNION ALL
+  SELECT compact_symbol.symbol_id, compact_term.term, posting.weight
+  FROM lexical_compact_snapshots AS compact_snapshot
+  JOIN lexical_storage_formats AS storage
+    ON storage.snapshot_id = compact_snapshot.snapshot_id
+   AND storage.format_version = ${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}
+  JOIN lexical_compact_terms AS compact_term
+    ON compact_term.snapshot_key = compact_snapshot.snapshot_key
+  JOIN lexical_compact_postings AS posting
+    ON posting.snapshot_key = compact_snapshot.snapshot_key
+   AND posting.term_key = compact_term.term_key
+  JOIN lexical_compact_symbols AS compact_symbol
+    ON compact_symbol.snapshot_key = compact_snapshot.snapshot_key
+   AND compact_symbol.symbol_key = posting.symbol_key
+  WHERE compact_snapshot.snapshot_id = ?
+    AND NOT EXISTS (
+      SELECT 1 FROM symbols AS overrides
+      WHERE overrides.snapshot_id = ? AND overrides.id = compact_symbol.symbol_id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM snapshot_symbol_deletions AS deletions
+      WHERE deletions.snapshot_id = ? AND deletions.symbol_id = compact_symbol.symbol_id
+    )
+)
+INSERT INTO temp.${PROJECTION_TERMS_TABLE} (symbol_id, term, weight)
+SELECT symbol_id, term, weight
+FROM effective_terms
+WHERE TRUE
+ON CONFLICT(symbol_id, term) DO UPDATE
+SET weight = MAX(${PROJECTION_TERMS_TABLE}.weight, excluded.weight)`;
 
 export interface CodeGraphReadySnapshotRoutingProjectionInputV1 {
   readonly checkoutId: string;
@@ -362,7 +454,12 @@ function readProjection(selected: CodeGraphSnapshot, input: NormalizedProjection
         invalid('The ready snapshot has more symbols than one routing projection can represent.'),
       );
     }
-    yield* prepareProjectionRoutingSurface(sql, selected.id, baseSnapshotId, input.observePreparedRoutingSurface);
+    yield* prepareCodeGraphWorksetProjectionRoutingSurface(
+      sql,
+      selected.id,
+      baseSnapshotId,
+      input.observePreparedRoutingSurface,
+    );
 
     const stats: MutableProjectionStats = {
       componentCount,
@@ -499,7 +596,12 @@ function readProjectionStreamed<E, R>(
       expectedSymbolCount,
       safeCount(before.edge_count, 'snapshot edge count'),
     );
-    yield* prepareProjectionRoutingSurface(sql, selected.id, baseSnapshotId, input.observePreparedRoutingSurface);
+    yield* prepareCodeGraphWorksetProjectionRoutingSurface(
+      sql,
+      selected.id,
+      baseSnapshotId,
+      input.observePreparedRoutingSurface,
+    );
     const stats = projectionStats(componentCount, dependencyCount);
     let reservedLogicalBytes = 0;
     const firstPass = yield* scanProjectionSymbolPages(sql, selected.id, baseSnapshotId, input, stats, symbols =>
@@ -557,7 +659,12 @@ function readProjectionStreamed<E, R>(
       // Re-read the immutable source surface for the verification/publication
       // pass. Reusing the first TEMP projection would make lookup/term drift
       // invisible to the existing cross-pass digest fence.
-      yield* prepareProjectionRoutingSurface(sql, selected.id, baseSnapshotId, input.observePreparedRoutingSurface);
+      yield* prepareCodeGraphWorksetProjectionRoutingSurface(
+        sql,
+        selected.id,
+        baseSnapshotId,
+        input.observePreparedRoutingSurface,
+      );
       const verificationStats = projectionStats(componentCount, dependencyCount);
       const secondPass = yield* scanProjectionSymbolPages(
         sql,
@@ -857,14 +964,135 @@ function selectLookupRows(sql: SqlClient.SqlClient, nodeIds: readonly string[]) 
   );
 }
 
+export interface CodeGraphWorksetProjectionTemporaryStorageSettings {
+  readonly journalMode: 'memory';
+  readonly maximumBytes: number;
+  readonly maximumPages: number;
+  readonly pageSizeBytes: number;
+  readonly storage: 'file';
+}
+
 /**
  * The enclosing store session opens main with SQLite's read-only flag. Select
- * file-backed TEMP storage now; each preparation below relaxes the additional
- * query_only belt only for its connection-local TEMP writes.
+ * file-backed TEMP storage under the per-projection envelope; preparation
+ * relaxes the additional query_only belt only for connection-local writes.
+ * @internal
  */
+export const configureCodeGraphWorksetProjectionTemporaryStorage = Effect.fn(
+  'codeGraphWorksetCatalog.configureProjectionTemporaryStorage',
+)(function* (
+  sql: SqlClient.SqlClient,
+  maximumBytes: number = CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum,
+) {
+  if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 1) {
+    return yield* Effect.fail(invalid('Workset projection temporary storage bound is invalid.'));
+  }
+  yield* sql.unsafe('PRAGMA query_only = OFF');
+  return yield* Effect.gen(function* () {
+    yield* sql.unsafe('PRAGMA temp_store = FILE');
+    if ((yield* selectProjectionTemporaryPragma(sql, 'temp_store')) !== 1) {
+      return yield* Effect.fail(temporaryStorageIncompatible());
+    }
+    // The surface is disposable and rebuilt after any failed statement. Keep
+    // its rollback journal off disk so max_page_count bounds physical TEMP
+    // growth instead of leaving a second repository-sized journal beside it.
+    yield* sql.unsafe('PRAGMA temp.journal_mode = MEMORY');
+    if ((yield* selectProjectionTemporaryTextPragma(sql, 'journal_mode')) !== 'memory') {
+      return yield* Effect.fail(temporaryStorageIncompatible());
+    }
+    const pageSizeBytes = yield* selectProjectionTemporaryPragma(sql, 'page_size');
+    const maximumPages = Math.floor(maximumBytes / pageSizeBytes);
+    if (!Number.isSafeInteger(maximumPages) || maximumPages < 1) {
+      return yield* Effect.fail(temporaryStorageIncompatible());
+    }
+    yield* sql.unsafe(`PRAGMA temp.max_page_count = ${String(maximumPages)}`);
+    const configuredMaximumPages = yield* selectProjectionTemporaryPragma(sql, 'max_page_count');
+    if (configuredMaximumPages !== maximumPages) {
+      return yield* Effect.fail(temporaryStorageIncompatible());
+    }
+    return {
+      journalMode: 'memory',
+      maximumBytes: configuredMaximumPages * pageSizeBytes,
+      maximumPages: configuredMaximumPages,
+      pageSizeBytes,
+      storage: 'file',
+    } satisfies CodeGraphWorksetProjectionTemporaryStorageSettings;
+  }).pipe(Effect.ensuring(sql.unsafe('PRAGMA query_only = ON').pipe(Effect.orDie)));
+});
+
 function configureProjectionTemporaryStorage(sql: SqlClient.SqlClient) {
-  return sql.unsafe('PRAGMA temp_store = FILE');
+  return configureCodeGraphWorksetProjectionTemporaryStorage(sql).pipe(Effect.asVoid);
 }
+
+function selectProjectionTemporaryTextPragma(sql: SqlClient.SqlClient, pragma: 'journal_mode') {
+  return sql.unsafe<Record<string, unknown>>(`PRAGMA temp.${pragma}`).pipe(
+    Effect.flatMap(rows => {
+      const value = rows[0]?.[pragma];
+      return typeof value === 'string' && value.length > 0
+        ? Effect.succeed(value.toLowerCase())
+        : Effect.fail(temporaryStorageIncompatible());
+    }),
+  );
+}
+
+function selectProjectionTemporaryPragma(
+  sql: SqlClient.SqlClient,
+  pragma: 'max_page_count' | 'page_size' | 'temp_store',
+) {
+  const statement = pragma === 'temp_store' ? 'PRAGMA temp_store' : `PRAGMA temp.${pragma}`;
+  return sql.unsafe<Record<string, unknown>>(statement).pipe(
+    Effect.flatMap(rows => {
+      const value = rows[0]?.[pragma];
+      const parsed = typeof value === 'bigint' ? Number(value) : value;
+      return typeof parsed === 'number' && Number.isSafeInteger(parsed) && parsed > 0
+        ? Effect.succeed(parsed)
+        : Effect.fail(temporaryStorageIncompatible());
+    }),
+  );
+}
+
+function temporaryStorageIncompatible(): CodeGraphWorksetCatalogError {
+  return new CodeGraphWorksetCatalogError(
+    'incompatible',
+    'SQLite temporary routing storage cannot enforce the bounded projection capacity.',
+  );
+}
+
+function projectionLookupParameters(snapshotId: string, baseId: string): readonly string[] {
+  return [snapshotId, baseId, snapshotId, snapshotId];
+}
+
+function projectionTermsParameters(snapshotId: string, baseId: string): readonly string[] {
+  return [snapshotId, snapshotId, baseId, snapshotId, snapshotId, baseId, snapshotId, snapshotId];
+}
+
+interface ProjectionPreparationQueryPlanRow {
+  readonly detail: unknown;
+}
+
+/** @internal Inspect the exact materialization statements after the TEMP target tables exist. */
+export const inspectCodeGraphWorksetProjectionPreparationQueryPlan = Effect.fn(
+  'codeGraphWorksetCatalog.inspectProjectionPreparationQueryPlan',
+)(function* (sql: SqlClient.SqlClient, snapshotId: string, baseSnapshotId: string | undefined) {
+  const baseId = baseSnapshotId ?? '';
+  const [lookupRows, termRows] = yield* Effect.all(
+    [
+      sql.unsafe<ProjectionPreparationQueryPlanRow>(
+        `EXPLAIN QUERY PLAN ${PROJECTION_LOOKUP_MATERIALIZATION_SQL}`,
+        projectionLookupParameters(snapshotId, baseId),
+      ),
+      sql.unsafe<ProjectionPreparationQueryPlanRow>(
+        `EXPLAIN QUERY PLAN ${PROJECTION_TERMS_MATERIALIZATION_SQL}`,
+        projectionTermsParameters(snapshotId, baseId),
+      ),
+    ] as const,
+    {concurrency: 1},
+  );
+  return {
+    lookup: lookupRows.map(row => requiredText(row.detail, 'routing lookup query-plan detail')),
+    terms: termRows.map(row => requiredText(row.detail, 'routing term query-plan detail')),
+  };
+});
 
 /**
  * Materialize one symbol-first TEMP projection of the immutable routing surface.
@@ -877,13 +1105,15 @@ function configureProjectionTemporaryStorage(sql: SqlClient.SqlClient) {
  * then both digest/publication passes use symbol-first TEMP primary keys
  * without adding persistent graph indexes or graph-build write amplification.
  */
-function prepareProjectionRoutingSurface(
+export const prepareCodeGraphWorksetProjectionRoutingSurface = Effect.fn(
+  'codeGraphWorksetCatalog.prepareProjectionRoutingSurface',
+)(function* (
   sql: SqlClient.SqlClient,
   snapshotId: string,
   baseSnapshotId: string | undefined,
   observe?: (counts: {readonly lookupKeys: number; readonly terms: number}) => void,
 ) {
-  return Effect.gen(function* () {
+  yield* Effect.gen(function* () {
     yield* sql.unsafe('PRAGMA query_only = OFF');
     const counts = yield* Effect.gen(function* () {
       yield* sql.unsafe(`DROP TABLE IF EXISTS temp.${PROJECTION_LOOKUP_TABLE}`);
@@ -894,31 +1124,11 @@ function prepareProjectionRoutingSurface(
       PRIMARY KEY (symbol_id, lookup_key)
     ) WITHOUT ROWID`);
       const baseId = baseSnapshotId ?? '';
-      yield* sql.unsafe(
-        `WITH effective_lookup AS (
-       SELECT lookup.symbol_id, lookup.lookup_key
-       FROM snapshot_symbol_lookup AS lookup
-       WHERE lookup.snapshot_id = ?
-       UNION ALL
-       SELECT lookup.symbol_id, lookup.lookup_key
-       FROM snapshot_symbol_lookup AS lookup
-       WHERE lookup.snapshot_id = ?
-         AND NOT EXISTS (
-           SELECT 1 FROM symbols AS overrides
-           WHERE overrides.snapshot_id = ? AND overrides.id = lookup.symbol_id
-         )
-         AND NOT EXISTS (
-           SELECT 1 FROM snapshot_symbol_deletions AS deletions
-           WHERE deletions.snapshot_id = ? AND deletions.symbol_id = lookup.symbol_id
-         )
-     )
-     INSERT INTO temp.${PROJECTION_LOOKUP_TABLE} (symbol_id, lookup_key)
-     SELECT symbol_id, lookup_key
-     FROM effective_lookup
-     GROUP BY symbol_id, lookup_key`,
-        [snapshotId, baseId, snapshotId, snapshotId],
-      );
-      const lookupKeys = observe === undefined ? 0 : yield* selectChangedRowCount(sql, 'routing lookup preparation');
+      yield* sql.unsafe(PROJECTION_LOOKUP_MATERIALIZATION_SQL, projectionLookupParameters(snapshotId, baseId));
+      const lookupKeys =
+        observe === undefined
+          ? 0
+          : yield* selectTemporaryRowCount(sql, PROJECTION_LOOKUP_TABLE, 'routing lookup preparation');
 
       yield* sql.unsafe(`CREATE TEMP TABLE ${PROJECTION_TERMS_TABLE} (
       symbol_id TEXT NOT NULL,
@@ -926,87 +1136,36 @@ function prepareProjectionRoutingSurface(
       weight INTEGER NOT NULL,
       PRIMARY KEY (symbol_id, term)
     ) WITHOUT ROWID`);
-      yield* sql.unsafe(
-        `WITH effective_terms AS (
-       SELECT legacy.symbol_id, legacy.term, legacy.weight
-       FROM symbol_terms AS legacy
-       WHERE legacy.snapshot_id = ?
-         AND NOT EXISTS (
-           SELECT 1 FROM lexical_storage_formats AS storage
-           WHERE storage.snapshot_id = legacy.snapshot_id
-         )
-       UNION ALL
-       SELECT compact_symbol.symbol_id, compact_term.term, posting.weight
-       FROM lexical_compact_snapshots AS compact_snapshot
-       JOIN lexical_storage_formats AS storage
-         ON storage.snapshot_id = compact_snapshot.snapshot_id
-        AND storage.format_version = ${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}
-       JOIN lexical_compact_terms AS compact_term
-         ON compact_term.snapshot_key = compact_snapshot.snapshot_key
-       JOIN lexical_compact_postings AS posting
-         ON posting.snapshot_key = compact_snapshot.snapshot_key
-        AND posting.term_key = compact_term.term_key
-       JOIN lexical_compact_symbols AS compact_symbol
-         ON compact_symbol.snapshot_key = compact_snapshot.snapshot_key
-        AND compact_symbol.symbol_key = posting.symbol_key
-       WHERE compact_snapshot.snapshot_id = ?
-       UNION ALL
-       SELECT legacy.symbol_id, legacy.term, legacy.weight
-       FROM symbol_terms AS legacy
-       WHERE legacy.snapshot_id = ?
-         AND NOT EXISTS (
-           SELECT 1 FROM lexical_storage_formats AS storage
-           WHERE storage.snapshot_id = legacy.snapshot_id
-         )
-         AND NOT EXISTS (
-           SELECT 1 FROM symbols AS overrides
-           WHERE overrides.snapshot_id = ? AND overrides.id = legacy.symbol_id
-         )
-         AND NOT EXISTS (
-           SELECT 1 FROM snapshot_symbol_deletions AS deletions
-           WHERE deletions.snapshot_id = ? AND deletions.symbol_id = legacy.symbol_id
-         )
-       UNION ALL
-       SELECT compact_symbol.symbol_id, compact_term.term, posting.weight
-       FROM lexical_compact_snapshots AS compact_snapshot
-       JOIN lexical_storage_formats AS storage
-         ON storage.snapshot_id = compact_snapshot.snapshot_id
-        AND storage.format_version = ${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}
-       JOIN lexical_compact_terms AS compact_term
-         ON compact_term.snapshot_key = compact_snapshot.snapshot_key
-       JOIN lexical_compact_postings AS posting
-         ON posting.snapshot_key = compact_snapshot.snapshot_key
-        AND posting.term_key = compact_term.term_key
-       JOIN lexical_compact_symbols AS compact_symbol
-         ON compact_symbol.snapshot_key = compact_snapshot.snapshot_key
-        AND compact_symbol.symbol_key = posting.symbol_key
-       WHERE compact_snapshot.snapshot_id = ?
-         AND NOT EXISTS (
-           SELECT 1 FROM symbols AS overrides
-           WHERE overrides.snapshot_id = ? AND overrides.id = compact_symbol.symbol_id
-         )
-         AND NOT EXISTS (
-           SELECT 1 FROM snapshot_symbol_deletions AS deletions
-           WHERE deletions.snapshot_id = ? AND deletions.symbol_id = compact_symbol.symbol_id
-         )
-     )
-     INSERT INTO temp.${PROJECTION_TERMS_TABLE} (symbol_id, term, weight)
-     SELECT symbol_id, term, MAX(weight) AS weight
-     FROM effective_terms
-     GROUP BY symbol_id, term`,
-        [snapshotId, snapshotId, baseId, snapshotId, snapshotId, baseId, snapshotId, snapshotId],
-      );
+      yield* sql.unsafe(PROJECTION_TERMS_MATERIALIZATION_SQL, projectionTermsParameters(snapshotId, baseId));
       return observe === undefined
         ? undefined
-        : {lookupKeys, terms: yield* selectChangedRowCount(sql, 'routing term preparation')};
+        : {
+            lookupKeys,
+            terms: yield* selectTemporaryRowCount(sql, PROJECTION_TERMS_TABLE, 'routing term preparation'),
+          };
     }).pipe(Effect.ensuring(sql.unsafe('PRAGMA query_only = ON').pipe(Effect.orDie)));
     if (counts !== undefined) observe?.(counts);
-  });
+  }).pipe(Effect.mapError(projectionTemporaryStorageFailure));
+});
+
+function projectionTemporaryStorageFailure(cause: unknown): unknown {
+  if (cause instanceof CodeGraphWorksetCatalogError) return cause;
+  const classified = classifyCodeGraphStoreFailure('prepare workset routing projection temporary storage', cause);
+  return classified.code === 'no-space'
+    ? new CodeGraphWorksetCatalogError(
+        'capacity',
+        'The temporary routing projection reached its bounded storage envelope.',
+        {cause},
+      )
+    : cause;
 }
 
-function selectChangedRowCount(sql: SqlClient.SqlClient, label: string) {
+function selectTemporaryRowCount(sql: SqlClient.SqlClient, table: string, label: string) {
   return Effect.gen(function* () {
-    const rows = yield* sql.unsafe<CountRow>('SELECT changes() AS count');
+    if (table !== PROJECTION_LOOKUP_TABLE && table !== PROJECTION_TERMS_TABLE) {
+      return yield* Effect.fail(corrupt(`The ${label} table is invalid.`));
+    }
+    const rows = yield* sql.unsafe<CountRow>(`SELECT COUNT(*) AS count FROM temp.${table}`);
     if (rows.length !== 1) return yield* Effect.fail(corrupt(`The ${label} count is unavailable.`));
     return safeCount(rows[0]!.count, `${label} count`);
   });

--- a/src/code_graph/workset_catalog/store_support.ts
+++ b/src/code_graph/workset_catalog/store_support.ts
@@ -171,17 +171,19 @@ export function withCatalogWriter<A, E, R>(
           }),
         );
         yield* fs.chmod(layout.databasePath, 0o600);
-        yield* removeObsoleteCatalogV2Files(fs, path, threadnoteHome);
+        yield* removeObsoleteCatalogFiles(fs, path, threadnoteHome);
         return result;
       }),
     );
   }).pipe(mapCatalogError('write workset catalog'));
 }
 
-function removeObsoleteCatalogV2Files(fs: FileSystem.FileSystem, path: Path.Path, threadnoteHome: string) {
-  const legacyDatabase = path.join(threadnoteHome, 'indexes', 'code-graph', 'worksets', 'catalog-v2.sqlite');
+function removeObsoleteCatalogFiles(fs: FileSystem.FileSystem, path: Path.Path, threadnoteHome: string) {
+  const obsoleteDatabases = [2, 3].map(version =>
+    path.join(threadnoteHome, 'indexes', 'code-graph', 'worksets', `catalog-v${String(version)}.sqlite`),
+  );
   return Effect.forEach(
-    [legacyDatabase, `${legacyDatabase}-journal`, `${legacyDatabase}-shm`, `${legacyDatabase}-wal`],
+    obsoleteDatabases.flatMap(database => [database, `${database}-journal`, `${database}-shm`, `${database}-wal`]),
     candidate => fs.remove(candidate, {force: true}),
     {concurrency: 1, discard: true},
   );

--- a/src/code_graph/workset_catalog/types.ts
+++ b/src/code_graph/workset_catalog/types.ts
@@ -10,7 +10,7 @@ export const CODE_GRAPH_WORKSET_CATALOG_LIMITS = {
   exactKeysPerSymbol: 256,
   lookupKeysPerSymbol: 64,
   membersPerGeneration: 4_096,
-  projectionBytesMaximum: 128 * 1_024 * 1_024,
+  projectionBytesMaximum: 512 * 1_024 * 1_024,
   projectionPageBytesMaximum: 8 * 1_024 * 1_024,
   readPageMaximum: 1_000,
   resultSetBytesMaximum: 2 * 1_024 * 1_024,

--- a/test/unit/code-graph.workset-catalog-projection.test.ts
+++ b/test/unit/code-graph.workset-catalog-projection.test.ts
@@ -3,6 +3,7 @@ import {it as effectIt} from '@effect/vitest';
 import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
 import {Effect, FileSystem} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
 import {CODE_GRAPH_EXTRACTOR_GENERATION} from '../../src/code_graph/types.js';
@@ -11,7 +12,15 @@ import {
   buildCodeGraphWorksetRoutingProjectionScoped,
   stageCodeGraphWorksetRoutingProjectionScoped,
 } from '../../src/code_graph/workset_catalog/projection_builder.js';
-import {CodeGraphWorksetCatalogError} from '../../src/code_graph/workset_catalog/types.js';
+import {
+  configureCodeGraphWorksetProjectionTemporaryStorage,
+  inspectCodeGraphWorksetProjectionPreparationQueryPlan,
+  prepareCodeGraphWorksetProjectionRoutingSurface,
+} from '../../src/code_graph/workset_catalog/snapshot_projection.js';
+import {
+  CODE_GRAPH_WORKSET_CATALOG_LIMITS,
+  CodeGraphWorksetCatalogError,
+} from '../../src/code_graph/workset_catalog/types.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {join, mkdtemp, rm} from '../helpers/effect-filesystem.js';
@@ -452,6 +461,141 @@ describe('code graph ready-snapshot workset routing projections', () => {
 
         expect(preparations).toBe(2);
         expect(failure).toMatchObject({reason: 'corrupt'} satisfies Partial<CodeGraphWorksetCatalogError>);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('bounds file-backed projection TEMP storage to the per-projection envelope', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const store = yield* CodeGraphStore;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-workset-projection-temp-bound-'});
+        const identity = repositoryIdentity('temp-bound');
+        const graphPath = databasePath(home, identity.checkoutId);
+        yield* store.initialize(graphPath);
+
+        const configured = yield* store.withSession(
+          graphPath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            const settings = yield* configureCodeGraphWorksetProjectionTemporaryStorage(sql);
+            const queryOnlyRows = yield* sql.unsafe<{readonly query_only: number}>('PRAGMA query_only');
+            return {queryOnly: queryOnlyRows[0]?.query_only, settings};
+          }),
+          {readOnly: true},
+        );
+        const {settings} = configured;
+
+        expect(configured.queryOnly).toBe(1);
+        expect(settings).toMatchObject({journalMode: 'memory', storage: 'file'});
+        expect(settings.maximumBytes).toBe(CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum);
+        expect(settings.maximumPages * settings.pageSizeBytes).toBeLessThanOrEqual(
+          CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum,
+        );
+        expect((settings.maximumPages + 1) * settings.pageSizeBytes).toBeGreaterThan(
+          CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum,
+        );
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('streams routing materialization without an unbounded sorter TEMP B-tree', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const store = yield* CodeGraphStore;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-workset-projection-temp-plan-'});
+        const identity = repositoryIdentity('temp-plan');
+        const snapshotId = snapshotIdentity('temp-plan');
+        const graphPath = databasePath(home, identity.checkoutId);
+        yield* store.initialize(graphPath);
+        yield* Effect.sync(() =>
+          seedGraph(
+            home,
+            identity,
+            [
+              {
+                compact: true,
+                effectiveSymbolCount: 1,
+                id: snapshotId,
+                symbols: [symbol('planned', {aliases: ['planned.alias'], terms: [{term: 'planned', weight: 5}]})],
+                worktreeId: identity.worktreeId,
+              },
+            ],
+            [{snapshotId, worktreeId: identity.worktreeId}],
+          ),
+        );
+
+        const plans = yield* store.withSession(
+          graphPath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            yield* configureCodeGraphWorksetProjectionTemporaryStorage(sql);
+            yield* prepareCodeGraphWorksetProjectionRoutingSurface(sql, snapshotId, undefined);
+            return yield* inspectCodeGraphWorksetProjectionPreparationQueryPlan(sql, snapshotId, undefined);
+          }),
+          {readOnly: true},
+        );
+        const details = [...plans.lookup, ...plans.terms];
+
+        expect(plans.lookup.length).toBeGreaterThan(0);
+        expect(plans.terms.length).toBeGreaterThan(0);
+        expect(details.some(detail => detail.toUpperCase().includes('USE TEMP B-TREE'))).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('classifies a tiny TEMP page ceiling as capacity and restores query_only', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const store = yield* CodeGraphStore;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-workset-projection-temp-full-'});
+        const identity = repositoryIdentity('temp-full');
+        const snapshotId = snapshotIdentity('temp-full');
+        const graphPath = databasePath(home, identity.checkoutId);
+        const symbols = Array.from({length: 32}, (_, index) =>
+          symbol(`full${index.toString().padStart(2, '0')}`, {
+            aliases: [`full.alias.${index}.${'x'.repeat(256)}`],
+            terms: [{term: `full-term-${index}-${'y'.repeat(128)}`, weight: 5}],
+          }),
+        );
+        yield* store.initialize(graphPath);
+        yield* Effect.sync(() =>
+          seedGraph(
+            home,
+            identity,
+            [
+              {
+                compact: true,
+                effectiveSymbolCount: symbols.length,
+                id: snapshotId,
+                symbols,
+                worktreeId: identity.worktreeId,
+              },
+            ],
+            [{snapshotId, worktreeId: identity.worktreeId}],
+          ),
+        );
+
+        const result = yield* store.withSession(
+          graphPath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            const settings = yield* configureCodeGraphWorksetProjectionTemporaryStorage(sql, 4_096);
+            const failure = yield* prepareCodeGraphWorksetProjectionRoutingSurface(sql, snapshotId, undefined).pipe(
+              Effect.flip,
+            );
+            const queryOnlyRows = yield* sql.unsafe<{readonly query_only: number}>('PRAGMA query_only');
+            return {failure, queryOnly: queryOnlyRows[0]?.query_only, settings};
+          }),
+          {readOnly: true},
+        );
+
+        expect(result.settings.maximumBytes).toBe(4_096);
+        expect(result.failure).toMatchObject({reason: 'capacity'} satisfies Partial<CodeGraphWorksetCatalogError>);
+        expect(result.queryOnly).toBe(1);
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );

--- a/test/unit/code-graph.workset-catalog.test.ts
+++ b/test/unit/code-graph.workset-catalog.test.ts
@@ -1,9 +1,11 @@
 import {Database} from 'bun:sqlite';
-import {Effect} from 'effect';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem} from 'effect';
 import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {SystemInfo} from '../../src/effect/system.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {
   CODE_GRAPH_WORKSET_CATALOG_SCHEMA_VERSION,
   codeGraphWorksetCatalogDatabasePath,
@@ -34,12 +36,15 @@ import {
   withCodeGraphWorksetCatalogWriter,
 } from '../../src/code_graph/workset_catalog/store.js';
 import {
+  CODE_GRAPH_WORKSET_CATALOG_LIMITS,
   CODE_GRAPH_WORKSET_CATALOG_PROJECTOR_VERSION,
   CodeGraphWorksetCatalogError,
   type CodeGraphWorksetCatalogGenerationInputV1,
   type CodeGraphWorksetCatalogGenerationMemberV1,
   type CodeGraphWorksetRoutingProjectionV1,
+  type CodeGraphWorksetRoutingSymbolV1,
 } from '../../src/code_graph/workset_catalog/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
 import {join, mkdir, mkdtemp, readFile, rm, stat, writeFile} from '../helpers/effect-filesystem.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
@@ -729,7 +734,100 @@ describe('code graph workset catalog', () => {
       {numRuns: 100},
     );
   });
+
+  it('admits the observed ordinary 66k-symbol routing density inside the calibrated projection envelope', () => {
+    const symbolCount = 66_067;
+    let logicalBytes = 0;
+    for (let offset = 0; offset < symbolCount; offset += 257) {
+      const length = Math.min(257, symbolCount - offset);
+      const page = Array.from({length}, (_, index) => calibratedProjectionSymbol(offset + index));
+      logicalBytes = codeGraphWorksetRoutingProjectionLogicalBytesAppend(logicalBytes, page);
+    }
+
+    expect(logicalBytes).toBeGreaterThan(128 * 1_024 * 1_024);
+    expect(logicalBytes).toBeLessThanOrEqual(CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum);
+  });
+
+  it('accepts the exact projection limit and rejects an already-over-limit accumulator', () => {
+    const maximum = CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum;
+    expect(codeGraphWorksetRoutingProjectionLogicalBytesAppend(maximum, [])).toBe(maximum);
+    let failure: unknown;
+    try {
+      codeGraphWorksetRoutingProjectionLogicalBytesAppend(maximum + 1, []);
+    } catch (cause) {
+      failure = cause;
+    }
+    expect(failure).toMatchObject({reason: 'capacity'} satisfies Partial<CodeGraphWorksetCatalogError>);
+  });
+
+  effectIt.effect('preserves the independent 4 GiB aggregate projection capacity guard', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const system = yield* SystemInfo;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-workset-aggregate-capacity-'});
+        const projectionMaximum = CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionBytesMaximum;
+        const projectionSlots = CODE_GRAPH_WORKSET_CATALOG_LIMITS.catalogPhysicalBytesMaximum / projectionMaximum;
+        expect(Number.isSafeInteger(projectionSlots)).toBe(true);
+        const ampleDisk = SystemInfo.of({
+          ...system,
+          availableDiskBytes: () => Effect.succeed(Number.MAX_SAFE_INTEGER),
+        });
+
+        for (let index = 0; index < projectionSlots; index += 1) {
+          const begun = yield* beginCodeGraphWorksetCatalogProjection(
+            home,
+            projectionReceipt(projection(10_000 + index)),
+            projectionMaximum,
+          ).pipe(Effect.provideService(SystemInfo, ampleDisk));
+          expect(begun.state).toBe('staging');
+        }
+        const failure = yield* beginCodeGraphWorksetCatalogProjection(
+          home,
+          projectionReceipt(projection(20_000)),
+          projectionMaximum,
+        ).pipe(Effect.provideService(SystemInfo, ampleDisk), Effect.flip);
+        expect(failure).toMatchObject({reason: 'capacity'} satisfies Partial<CodeGraphWorksetCatalogError>);
+
+        const capacity = yield* Effect.sync(() => {
+          const database = new Database(catalogPath(home), {readonly: true, strict: true});
+          try {
+            return database
+              .query<{readonly projection_logical_bytes: number}, []>(
+                'SELECT projection_logical_bytes FROM catalog_capacity WHERE singleton = 1',
+              )
+              .get()?.projection_logical_bytes;
+          } finally {
+            database.close(false);
+          }
+        });
+        expect(capacity).toBe(CODE_GRAPH_WORKSET_CATALOG_LIMITS.catalogPhysicalBytesMaximum);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
 });
+
+function calibratedProjectionSymbol(index: number): CodeGraphWorksetRoutingSymbolV1 {
+  const padded = index.toString().padStart(5, '0');
+  const lookupCount = index % 5 < 3 ? 3 : 2;
+  const termCount = index % 100 < 46 ? 11 : 10;
+  return {
+    exported: index % 3 === 0,
+    kind: 'function',
+    language: 'typescript',
+    lookupKeys: Array.from({length: lookupCount}, (_, key) => `workset.catalog.${padded}.lookup-${key}`),
+    name: `prepareRoutingProjection${padded}`,
+    nodeId: `cgs_${digest(`calibrated-node-${index}`).slice(0, 32)}`,
+    packageName: 'threadnote',
+    path: `src/workset/routing-${padded}.ts`,
+    qualifiedName: `WorksetCatalog.prepareRoutingProjection${padded}`,
+    span: {column: 1, endColumn: 48, endLine: index + 2, line: index + 1},
+    terms: Array.from({length: termCount}, (_, term) => ({
+      term: `routing-projection-${padded}-term-${term.toString().padStart(2, '0')}`,
+      weight: 5 - (term % 5),
+    })),
+  };
+}
 
 async function temporaryHome(homes: string[]): Promise<string> {
   const home = await mkdtemp('threadnote-workset-catalog-');

--- a/test/unit/code-graph.workset-continuation.test.ts
+++ b/test/unit/code-graph.workset-continuation.test.ts
@@ -1,8 +1,10 @@
 import {Database} from 'bun:sqlite';
-import {Effect} from 'effect';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
 import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {
   CODE_GRAPH_WORKSET_EVIDENCE_PROJECTOR_VERSION,
   codeGraphEvidenceCardId,
@@ -32,7 +34,8 @@ import {
   type CodeGraphWorksetResultSetPageV1,
   type CodeGraphWorksetRoutingProjectionV1,
 } from '../../src/code_graph/workset_catalog/types.js';
-import {join, mkdir, mkdtemp, rm, stat, writeFile} from '../helpers/effect-filesystem.js';
+import {join, mkdtemp, rm, stat} from '../helpers/effect-filesystem.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
 describe('code graph workset qualified refs and continuation', () => {
@@ -42,27 +45,44 @@ describe('code graph workset qualified refs and continuation', () => {
     await Promise.all(homes.splice(0).map(home => rm(home, {force: true, recursive: true})));
   });
 
-  it('creates v3 before removing the obsolete disposable v2 catalog', async () => {
-    const home = await temporaryHome(homes);
-    const root = join(home, 'indexes', 'code-graph', 'worksets');
-    await mkdir(root, {recursive: true});
-    const legacyPath = join(root, 'catalog-v2.sqlite');
-    const legacy = new Database(legacyPath, {create: true, strict: true});
-    try {
-      legacy.exec('CREATE TABLE legacy_ready_projection (id TEXT PRIMARY KEY)');
-      legacy.query('INSERT INTO legacy_ready_projection (id) VALUES (?)').run('pre-normalized-routing');
-    } finally {
-      legacy.close(false);
-    }
-    const legacySidecars = ['-journal', '-shm', '-wal'].map(suffix => `${legacyPath}${suffix}`);
-    for (const sidecar of legacySidecars) await writeFile(sidecar, 'obsolete disposable sidecar');
+  effectIt.effect('creates v4 before removing obsolete disposable v2 and v3 catalogs', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-workset-catalog-upgrade-'});
+        const root = path.join(home, 'indexes', 'code-graph', 'worksets');
+        yield* fs.makeDirectory(root, {recursive: true});
+        const obsoleteDatabases = [2, 3].map(version => path.join(root, `catalog-v${String(version)}.sqlite`));
+        const obsoleteFiles = obsoleteDatabases.flatMap(databasePath => [
+          databasePath,
+          `${databasePath}-journal`,
+          `${databasePath}-shm`,
+          `${databasePath}-wal`,
+        ]);
 
-    await runEffect(ensureCodeGraphWorksetCatalog(home));
-    expect(catalogPath(home)).toBe(join(root, 'catalog-v3.sqlite'));
-    await expect(stat(legacyPath)).rejects.toBeDefined();
-    for (const sidecar of legacySidecars) await expect(stat(sidecar)).rejects.toBeDefined();
-    expect(await runEffect(inspectCodeGraphWorksetCatalog(home))).toMatchObject({schemaVersion: 3, state: 'ok'});
-  });
+        for (const databasePath of obsoleteDatabases) {
+          yield* Effect.sync(() => {
+            const legacy = new Database(databasePath, {create: true, strict: true});
+            try {
+              legacy.exec('CREATE TABLE legacy_ready_projection (id TEXT PRIMARY KEY)');
+              legacy.query('INSERT INTO legacy_ready_projection (id) VALUES (?)').run('pre-normalized-routing');
+            } finally {
+              legacy.close(false);
+            }
+          });
+          for (const suffix of ['-journal', '-shm', '-wal']) {
+            yield* fs.writeFile(`${databasePath}${suffix}`, new TextEncoder().encode('obsolete disposable sidecar'));
+          }
+        }
+
+        yield* ensureCodeGraphWorksetCatalog(home);
+        expect(catalogPath(home)).toBe(path.join(root, 'catalog-v4.sqlite'));
+        for (const candidate of obsoleteFiles) expect(yield* fs.exists(candidate)).toBe(false);
+        expect(yield* inspectCodeGraphWorksetCatalog(home)).toMatchObject({schemaVersion: 4, state: 'ok'});
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
 
   it('isolates cgr handles by repository while accepting every local node-id width', async () => {
     const home = await temporaryHome(homes);


### PR DESCRIPTION
## Summary

- raise the independently reviewed per-projection logical/TEMP envelope from 128 MiB to 512 MiB while preserving the 256-symbol page, 4 GiB aggregate, and free-disk guards
- move the disposable workset catalog to schema/path v4 and remove obsolete v2/v3 databases plus sidecars after successful initialization
- materialize reverse lookup and lexical routing with streaming conflict handling so SQLite does not create an unbounded sorter outside the TEMP page ceiling
- classify TEMP `SQLITE_FULL` as a bounded capacity result and restore `query_only` after both success and failure

Depends on #269. This PR is intentionally stacked on `fix/workset-projection-progress`; merge that performance-only prerequisite first.

## Capacity evidence

- Representative 66,159-symbol current-source snapshot: 514,912,146 logical bytes (491.058 MiB), admitted below 512 MiB
- Fresh APFS clone, two-pass dummy sink: 27.61 s; warm repeat: 17.82 s; 259 appended pages; deterministic digest; maximum RSS 410,517,504 bytes cold and 388,448,256 bytes warm
- Synthetic 66,067-symbol ordinary profile: 480.605 MiB, rejected by 128 MiB and admitted by 512 MiB
- Exact boundary checks: 512 MiB accepted; 512 MiB + 1 byte rejected
- Aggregate boundary checks: eight 512 MiB reservations reach exactly 4 GiB; a ninth is rejected
- `EXPLAIN QUERY PLAN` over the exact shipped lookup and term materialization statements contains no `USE TEMP B-TREE`
- An injected 4 KiB TEMP ceiling reaches `SQLITE_FULL`, maps to `capacity`, and restores `PRAGMA query_only = 1`

The benchmark ran only against a disposable clone; it did not mutate the installed graph or publish a catalog generation. The clone was removed after measurement.

## Focused verification

- 37/37 focused workset catalog projection/catalog/continuation tests
- source and test TypeScript checks
- strict lint and file-length checks
- Prettier and `git diff --check`
- pre-commit lint, formatting, source/test/site typechecks

Property coverage retains the page-partition invariance check for logical storage charge. Concrete regressions cover exact capacity boundaries, aggregate monotonicity, legacy catalog cleanup, exact query plans, and forced TEMP overflow.

## Review

Independent review is clean with no critical or important findings after replacing the original aggregate sorter. Non-blocking reviewer guidance to rerun the representative snapshot under the changed insertion order was completed above.
