### PR TITLE
fix(ci): isolate cold registration host latency

### DIFF
--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -6870,6 +6870,14 @@ const PRODUCTION_RATCHET_DETAILED_MILLISECOND_RELATIVE_HEADROOM = 0.75;
 // end-to-end cold and incremental objectives this ratchet exists to protect.
 const PRODUCTION_RATCHET_MILLISECOND_NOISE_HEADROOM = 100;
 const PRODUCTION_RATCHET_DETAILED_MILLISECOND_NOISE_HEADROOM = 300;
+// Cold registration includes two race-fenced Git status observations and
+// synchronous fresh SQLite setup on hosted virtual storage. Preserve a strict
+// sub-five-second wall objective while allowing the independently ratcheted
+// CPU, work, and storage measurements to distinguish host wait from product
+// regressions. Same-overlay registration retains its narrower envelope.
+const PRODUCTION_RATCHET_COLD_REGISTRATION_RELATIVE_HEADROOM = 5;
+const PRODUCTION_RATCHET_SAME_OVERLAY_REGISTRATION_RELATIVE_HEADROOM = 2;
+const PRODUCTION_RATCHET_REGISTRATION_MILLISECOND_TARGET = 5_000 - 1;
 // A zero-byte seed can still observe a tiny SQLite journal or filesystem
 // bookkeeping file on another hosted VM. Govern storage growth from the first
 // material MiB instead of treating a 512-byte observation as a regression.
@@ -6884,11 +6892,13 @@ const PRODUCTION_RATCHET_REDUCED_PROFILE_FILES_MAXIMUM = 3_000;
 const PRODUCTION_RATCHET_REDUCED_PROFILE_SYMBOLS_MAXIMUM = 110_000;
 const PRODUCTION_RATCHET_MILLISECOND_TARGETS = new Map<string, number>([
   ['cold-index', 60 * 60_000 - 1],
+  ['cold-registration-lock-and-database-setup', PRODUCTION_RATCHET_REGISTRATION_MILLISECOND_TARGET],
   ['cold-reference-resolution-longest-transaction-n1', 15_000 - 1],
   ['one-file-reindex-index', 30_000 - 1],
   ['one-file-reindex-post-committed-scan-overlay-and-workspace', 5_000 - 1],
-  ['one-file-reindex-registration-lock-and-database-setup', 5_000 - 1],
+  ['one-file-reindex-registration-lock-and-database-setup', PRODUCTION_RATCHET_REGISTRATION_MILLISECOND_TARGET],
   ['one-file-reindex-reference-resolution-longest-transaction-n1', 15_000 - 1],
+  ['same-overlay-reference-registration-lock-and-database-setup', PRODUCTION_RATCHET_REGISTRATION_MILLISECOND_TARGET],
   ['same-overlay-reference-reference-resolution-longest-transaction-n1', 15_000 - 1],
 ]);
 
@@ -7191,14 +7201,15 @@ function productionMeasurementRatchet(
   if (unit === 'milliseconds') {
     const objective = PRODUCTION_RATCHET_MILLISECOND_TARGETS.get(name);
     const detailedTiming = name.endsWith('-n1') && objective === undefined;
-    const fullBuildRegistration =
-      name === 'cold-registration-lock-and-database-setup' ||
-      name === 'same-overlay-reference-registration-lock-and-database-setup';
-    const relativeHeadroom = fullBuildRegistration
-      ? 2
-      : detailedTiming
-        ? PRODUCTION_RATCHET_DETAILED_MILLISECOND_RELATIVE_HEADROOM
-        : PRODUCTION_RATCHET_RELATIVE_HEADROOM;
+    const coldRegistration = name === 'cold-registration-lock-and-database-setup';
+    const sameOverlayRegistration = name === 'same-overlay-reference-registration-lock-and-database-setup';
+    const relativeHeadroom = coldRegistration
+      ? PRODUCTION_RATCHET_COLD_REGISTRATION_RELATIVE_HEADROOM
+      : sameOverlayRegistration
+        ? PRODUCTION_RATCHET_SAME_OVERLAY_REGISTRATION_RELATIVE_HEADROOM
+        : detailedTiming
+          ? PRODUCTION_RATCHET_DETAILED_MILLISECOND_RELATIVE_HEADROOM
+          : PRODUCTION_RATCHET_RELATIVE_HEADROOM;
     const absoluteHeadroom = detailedTiming
       ? PRODUCTION_RATCHET_DETAILED_MILLISECOND_NOISE_HEADROOM
       : PRODUCTION_RATCHET_MILLISECOND_NOISE_HEADROOM;

--- a/test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
+++ b/test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
@@ -904,7 +904,7 @@
     "cold-registration-lock-and-database-setup": {
       "samplesMinimum": 1,
       "unit": "milliseconds",
-      "p95Maximum": 2398
+      "p95Maximum": 4796
     },
     "cold-registration-process-cpu-n1": {
       "samplesMinimum": 1,

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1006,6 +1006,8 @@ describe('code graph release evidence', () => {
           ...requiredReleaseMeasurements(PRODUCTION_RELEASE_EVIDENCE_MEASUREMENTS),
           benchmarkMeasurement('cold-index', 'milliseconds', [coldIndexMilliseconds]),
           benchmarkMeasurement('cold-registration-lock-and-database-setup', 'milliseconds', [coldIndexMilliseconds]),
+          benchmarkMeasurement('cold-registration-process-cpu-n1', 'milliseconds', [coldIndexMilliseconds]),
+          benchmarkMeasurement('cold-sqlite-wal-peak-observed', 'bytes', [coldIndexMilliseconds]),
           benchmarkMeasurement('same-overlay-reference-registration-lock-and-database-setup', 'milliseconds', [
             coldIndexMilliseconds + 10,
           ]),
@@ -1151,17 +1153,49 @@ describe('code graph release evidence', () => {
     }
     expect(ratchet.measurements['cold-external-rss-peak-observed-n1']).toMatchObject({p95Maximum: 1_048_576});
     expect(ratchet.measurements['cold-external-rss-peak-observed-n1']).not.toHaveProperty('minimum');
-    for (const registrationName of [
-      'cold-registration-lock-and-database-setup',
-      'same-overlay-reference-registration-lock-and-database-setup',
-    ]) {
+    for (const [registrationName, multiplier] of [
+      ['cold-registration-lock-and-database-setup', 6],
+      ['same-overlay-reference-registration-lock-and-database-setup', 3],
+    ] as const) {
       const observedMaximum = Math.max(
         ...artifacts.map(
           artifact => artifact.measurements.find(measurement => measurement.name === registrationName)!.p50,
         ),
       );
-      expect(ratchet.measurements[registrationName]).toMatchObject({p95Maximum: Math.ceil(observedMaximum * 3)});
+      expect(ratchet.measurements[registrationName]).toMatchObject({
+        p95Maximum: Math.min(Math.ceil(observedMaximum * multiplier), 4_999),
+      });
     }
+    fc.assert(
+      fc.property(
+        fc.integer({max: 4_999, min: 1}),
+        fc.integer({max: 4_999, min: 1}),
+        (coldRegistration, referenceRegistration) => {
+          const registrations: Readonly<Record<string, number>> = {
+            'cold-registration-lock-and-database-setup': coldRegistration,
+            'same-overlay-reference-registration-lock-and-database-setup': referenceRegistration,
+          };
+          const varied = artifacts.map(artifact => ({
+            ...artifact,
+            measurements: artifact.measurements.map(measurement =>
+              registrations[measurement.name] === undefined
+                ? measurement
+                : benchmarkMeasurement(measurement.name, measurement.unit, [registrations[measurement.name]!]),
+            ),
+          }));
+          const variedRatchet = createCodeGraphProductionRatchet(varied);
+          for (const [name, observed, multiplier] of [
+            ['cold-registration-lock-and-database-setup', coldRegistration, 6],
+            ['same-overlay-reference-registration-lock-and-database-setup', referenceRegistration, 3],
+          ] as const) {
+            expect(variedRatchet.measurements[name]).toMatchObject({
+              p95Maximum: Math.min(Math.ceil(Math.max(observed * multiplier, observed + 100)), 4_999),
+            });
+          }
+        },
+      ),
+      {numRuns: 25},
+    );
     fc.assert(
       fc.property(fc.integer({max: 10_000, min: 1}), samplerCount => {
         const observed = {
@@ -1208,6 +1242,35 @@ describe('code graph release evidence', () => {
     expect(() => createCodeGraphProductionRatchet(overTarget)).toThrow(
       /objective one-file-reindex-index has not been attained/,
     );
+    const overRegistrationTarget = artifacts.map(artifact => ({
+      ...artifact,
+      measurements: artifact.measurements.map(measurement =>
+        measurement.name === 'cold-registration-lock-and-database-setup'
+          ? benchmarkMeasurement(measurement.name, measurement.unit, [5_000])
+          : measurement,
+      ),
+    }));
+    expect(() => createCodeGraphProductionRatchet(overRegistrationTarget)).toThrow(
+      /objective cold-registration-lock-and-database-setup has not been attained/,
+    );
+    for (const governedName of [
+      'cold-registration-process-cpu-n1',
+      'one-file-reindex-incremental-work-planned-rows-n1',
+      'cold-sqlite-wal-peak-observed',
+    ]) {
+      const governedLimit = ratchet.measurements[governedName];
+      expect(governedLimit, governedName).toBeDefined();
+      const maximum = governedLimit!.maximum ?? governedLimit!.p95Maximum!;
+      const regression = {
+        ...artifacts[0]!,
+        measurements: artifacts[0]!.measurements.map(measurement =>
+          measurement.name === governedName
+            ? benchmarkMeasurement(measurement.name, measurement.unit, [maximum + 1])
+            : measurement,
+        ),
+      };
+      expect(() => enforceCodeGraphBenchmarkRatchet(regression, ratchet)).toThrow(new RegExp(governedName));
+    }
     expect(Object.keys(ratchet.measurements)).toHaveLength(artifacts[0]!.measurements.length - 8);
     expect(Object.keys(ratchet.measurements).some(name => name.includes('-progress-external-'))).toBe(false);
     expect(Object.keys(ratchet.measurements).some(name => name.endsWith('-boundary-rss-n1'))).toBe(false);


### PR DESCRIPTION
## Summary

- calibrate only the cold composite registration/setup wall envelope from 3x to 6x observed headroom
- keep a hard 4,999 ms objective for cold, one-file, and same-overlay registration
- retain the same-overlay 3x / 888 ms envelope and all CPU, work, WAL/storage, and end-to-end cold-index guards
- add a bounded property over the capped envelope plus explicit CPU, planned-work, and WAL regression assertions

## Evidence

Seven recent passing hosted artifacts measured cold registration at 624–1,070 ms. Two distinct #270 rerun hosts measured 3,434.728 ms and 3,000.621 ms, but used less CPU (406.191/361.888 ms versus the #269 pass at 542.741 ms), retained the same approximately 1.77 MB registration WAL footprint, and completed the overall cold index about 8% faster. The preserved failed artifacts are 9662429029 and 9662612159.

The exact #270 versus #269 source delta is workset-only. #267 and #268 are test-only and cannot affect this path. A three-run exact reduced-fixture local probe measured the full registration path at 348–408 ms. This points to hosted virtual-filesystem / scheduler wait inside the composite cold phase rather than extra product work.

The sole baseline field changed is cold-registration-lock-and-database-setup.p95Maximum: 2398 -> 4796 ms. same-overlay-reference-registration-lock-and-database-setup remains 888 ms.

## Verification

- focused release-evidence tests: 45/45
- bounded property: 25 runs across cold and same-overlay registration inputs
- both preserved #270 failed artifacts accepted by the repaired ratchet
- main and test TypeScript checks
- targeted strict lint and Prettier
- independent review and re-review: zero critical or important findings

This PR is intentionally separate from #269 and #270 and should remain unmerged until the release SHA is settled.