### PR TITLE
perf(context): close published citation fence

### DIFF
--- a/src/code_graph/repository.ts
+++ b/src/code_graph/repository.ts
@@ -204,74 +204,133 @@ export const revalidateRepositoryIdentityFence = Effect.fn('codeGraph.revalidate
 });
 
 export interface PublishedRepositoryReadFenceInterlock {
-  /** @internal Deterministic race hook for focused validation tests. */
+  /** @internal Deterministic caller-retarget hook for focused validation tests. */
   readonly afterInitialIdentity?: () => Effect.Effect<void, unknown, CommandExecutor>;
-  /** @internal Deterministic race hook for focused validation tests. */
-  readonly afterWorktreeObservation?: () => Effect.Effect<void, unknown, CommandExecutor>;
+  /** @internal Deterministic closing-observation hook for focused validation tests. */
+  readonly beforeClosingWorktreeObservation?: () => Effect.Effect<void, unknown, CommandExecutor>;
 }
 
 /**
- * Bracket repository identity and worktree observations so caller retargets
- * and edits across an earlier observation cannot satisfy the closing proof.
+ * Close a published repository read after immutable evidence has been read.
+ * Remote identity is read from the resolved root, then the original caller
+ * receives the last code-bearing observation and reports the root/common-dir
+ * Git actually opened. An intervening retarget, edit, or HEAD move cannot
+ * satisfy the proof.
  */
 export const resolvePublishedRepositoryReadFence = Effect.fn('codeGraph.resolvePublishedRepositoryReadFence')(
   function* (cwd: string, expected: RepositoryIdentityExpectation, interlock?: PublishedRepositoryReadFenceInterlock) {
     const system = yield* SystemInfo;
-    const initial = yield* observeRepositoryReadFenceMetadata(cwd);
+    const observed = yield* observeRepositoryReadFenceMetadata(cwd);
     yield* interlock?.afterInitialIdentity?.() ?? Effect.void;
-    const initialWorktree = yield* observeRepositoryReadFenceWorktree(initial.repoRoot, initial.objectFormat);
-    if (initialWorktree.headCommit !== initial.headCommit) {
-      return yield* Effect.fail(new CodeGraphRepositoryError('Repository changed during the graph read.'));
-    }
-    yield* interlock?.afterWorktreeObservation?.() ?? Effect.void;
-    const [final, remoteResult] = yield* Effect.all(
-      [observeRepositoryReadFenceMetadata(cwd), runGit(cwd, ['remote', 'get-url', 'origin'], true)],
-      {concurrency: 2},
-    ).pipe(Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')));
-    if (
-      final.repoRoot !== initial.repoRoot ||
-      final.gitCommonDirectory !== initial.gitCommonDirectory ||
-      final.objectFormat !== initial.objectFormat ||
-      final.headCommit !== initial.headCommit
-    ) {
-      return yield* Effect.fail(new CodeGraphRepositoryError('Repository identity changed during the graph read.'));
-    }
+    const remoteResult = yield* runGit(observed.repoRoot, ['remote', 'get-url', 'origin'], true).pipe(
+      Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')),
+    );
     const remoteIdentity =
       remoteResult.exitCode === 0 ? normalizeCredentialFreeRemote(remoteResult.stdout.trim()) : undefined;
     const repositorySource =
-      remoteIdentity ?? `local:${normalizeLocalIdentity(final.gitCommonDirectory, system.platform)}`;
+      remoteIdentity ?? `local:${normalizeLocalIdentity(observed.gitCommonDirectory, system.platform)}`;
     const identity = {
-      checkoutId: checkoutIdForGitCommonDirectory(final.gitCommonDirectory),
-      headCommit: final.headCommit,
+      checkoutId: checkoutIdForGitCommonDirectory(observed.gitCommonDirectory),
+      headCommit: observed.headCommit,
       repositoryId: sha256HexSync(`repository-v${IDENTITY_FORMAT_VERSION}\n${repositorySource}`),
-      worktreeId: worktreeIdForRoot(final.repoRoot),
+      worktreeId: worktreeIdForRoot(observed.repoRoot),
     };
     if (!repositoryIdentityMatchesExpectation(identity, expected)) {
       return yield* Effect.fail(new CodeGraphRepositoryError('Repository identity changed during the graph read.'));
     }
-    const finalWorktree = yield* observeRepositoryReadFenceWorktree(final.repoRoot, final.objectFormat);
-    if (finalWorktree.headCommit !== final.headCommit) {
-      return yield* Effect.fail(new CodeGraphRepositoryError('Repository changed during the graph read.'));
+    yield* interlock?.beforeClosingWorktreeObservation?.() ?? Effect.void;
+    const worktree = yield* observeRepositoryReadFenceClosingWorktree(cwd, observed.objectFormat);
+    if (
+      worktree.repoRoot !== observed.repoRoot ||
+      worktree.gitCommonDirectory !== observed.gitCommonDirectory ||
+      worktree.headCommit !== observed.headCommit
+    ) {
+      return yield* Effect.fail(new CodeGraphRepositoryError('Repository identity changed during the graph read.'));
     }
-    return {...identity, worktreeChanged: initialWorktree.changed || finalWorktree.changed};
+    return {...identity, worktreeChanged: worktree.changed};
   },
 );
 
-const observeRepositoryReadFenceWorktree = Effect.fn('codeGraph.observeRepositoryReadFenceWorktree')(function* (
-  repoRoot: string,
-  objectFormat: RepositoryIdentity['objectFormat'],
-) {
-  const status = yield* runCommandEffect(
-    'git',
-    ['--no-optional-locks', '-C', repoRoot, 'status', '--porcelain=v2', '-z', '--branch', '--untracked-files=normal'],
-    {maxOutputBytes: REPOSITORY_STATUS_OBSERVATION_BYTES_MAXIMUM, timeoutMs: 10_000},
-  ).pipe(Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')));
-  const worktree = parseRepositoryIdentityWorktreeObservation(status.stdout, objectFormat);
-  if (worktree === undefined) {
-    return yield* Effect.fail(new CodeGraphRepositoryError('Repository changed during the graph read.'));
+const observeRepositoryReadFenceClosingWorktree = Effect.fn('codeGraph.observeRepositoryReadFenceClosingWorktree')(
+  function* (cwd: string, objectFormat: RepositoryIdentity['objectFormat']) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
+    const status = yield* runCommandEffect(
+      'git',
+      ['--no-optional-locks', '-C', cwd, 'status', '--porcelain=v2', '-z', '--branch', '--untracked-files=normal'],
+      {
+        env: repositoryReadFenceTraceEnvironment(system.environment()),
+        maxOutputBytes: REPOSITORY_STATUS_OBSERVATION_BYTES_MAXIMUM,
+        timeoutMs: 10_000,
+      },
+    ).pipe(Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')));
+    const worktree = parseRepositoryIdentityWorktreeObservation(status.stdout, objectFormat);
+    const setup = parseRepositoryReadFenceSetupObservation(status.stderr);
+    if (worktree === undefined || setup === undefined) {
+      return yield* Effect.fail(new CodeGraphRepositoryError('Repository read fence could not be revalidated.'));
+    }
+    const repoRoot = yield* fs
+      .realPath(setup.worktree)
+      .pipe(Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')));
+    const commonPath = path.isAbsolute(setup.gitCommonDirectory)
+      ? setup.gitCommonDirectory
+      : path.resolve(repoRoot, setup.gitCommonDirectory);
+    const gitCommonDirectory = yield* fs
+      .realPath(commonPath)
+      .pipe(Effect.mapError(() => new CodeGraphRepositoryError('Repository read fence could not be revalidated.')));
+    return {...worktree, gitCommonDirectory, repoRoot};
+  },
+);
+
+export function parseRepositoryReadFenceSetupObservation(
+  output: string,
+): {readonly gitCommonDirectory: string; readonly worktree: string} | undefined {
+  const markers = {
+    gitCommonDirectory: 'setup: git_common_dir: ',
+    worktree: 'setup: worktree: ',
+  } as const;
+  const matches = {gitCommonDirectory: [] as string[], worktree: [] as string[]};
+  for (const line of output.split(/\r?\n/u)) {
+    for (const key of Object.keys(markers) as Array<keyof typeof markers>) {
+      const index = line.indexOf(markers[key]);
+      if (index >= 0) matches[key].push(line.slice(index + markers[key].length));
+    }
   }
-  return worktree;
-});
+  if (matches.gitCommonDirectory.length !== 1 || matches.worktree.length !== 1) return undefined;
+  const gitCommonDirectory = matches.gitCommonDirectory[0]!;
+  const worktree = matches.worktree[0]!;
+  if (
+    gitCommonDirectory.length === 0 ||
+    worktree.length === 0 ||
+    gitCommonDirectory === '(null)' ||
+    worktree === '(null)' ||
+    hasControlCharacter(gitCommonDirectory) ||
+    hasControlCharacter(worktree) ||
+    /\p{Bidi_Control}/u.test(gitCommonDirectory) ||
+    /\p{Bidi_Control}/u.test(worktree)
+  ) {
+    return undefined;
+  }
+  return {gitCommonDirectory, worktree};
+}
+
+function repositoryReadFenceTraceEnvironment(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...environment,
+    GIT_TRACE: '0',
+    GIT_TRACE2: '0',
+    GIT_TRACE2_EVENT: '0',
+    GIT_TRACE2_PERF: '0',
+    GIT_TRACE_BARE: '0',
+    GIT_TRACE_CURL: '0',
+    GIT_TRACE_PACKET: '0',
+    GIT_TRACE_PERFORMANCE: '0',
+    GIT_TRACE_REFS: '0',
+    GIT_TRACE_SETUP: '1',
+    GIT_TRACE_SHALLOW: '0',
+  };
+}
 
 const observeRepositoryReadFenceMetadata = Effect.fn('codeGraph.observeRepositoryReadFenceMetadata')(function* (
   cwd: string,

--- a/src/code_graph/store_active_views.ts
+++ b/src/code_graph/store_active_views.ts
@@ -1,9 +1,28 @@
 import {Effect} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
-import {type CodeGraphActiveViewIdentity} from './store_models.js';
+import {type CodeGraphActiveViewFence, type CodeGraphActiveViewIdentity} from './store_models.js';
+import {CODE_GRAPH_SNAPSHOT_ID, validCanonicalTimestamp} from './store_reconciliation_core.js';
+import {MAXIMUM_CANONICAL_DATE_MILLISECONDS} from './store_removed_view_schema_contracts.js';
 import {configureConnection, tableExists} from './store_session.js';
+import {CodeGraphStoreError} from './types.js';
 
 const ACTIVE_VIEW_IDENTITY_LIMIT_MAXIMUM = 64;
+
+/** Advance a canonical wall-clock candidate past every durable view generation. */
+export function nextCodeGraphActiveViewActivationTimestamp(
+  candidate: string,
+  previous: readonly (string | undefined)[],
+): string | undefined {
+  if (!validCanonicalTimestamp(candidate)) return undefined;
+  let nextMilliseconds = Date.parse(candidate);
+  for (const value of previous) {
+    if (value === undefined) continue;
+    if (!validCanonicalTimestamp(value)) return undefined;
+    nextMilliseconds = Math.max(nextMilliseconds, Date.parse(value) + 1);
+  }
+  if (nextMilliseconds > MAXIMUM_CANONICAL_DATE_MILLISECONDS) return undefined;
+  return new Date(nextMilliseconds).toISOString();
+}
 
 /** Cheap bounded pointer read for Manager's cross-process catalog revision. */
 export const selectActiveViewIdentities = Effect.fn('codeGraph.selectActiveViewIdentities')(function* (limit: number) {
@@ -46,4 +65,36 @@ export const selectActiveViewIdentities = Effect.fn('codeGraph.selectActiveViewI
         worktreeId: row.worktree_id,
       }) satisfies CodeGraphActiveViewIdentity,
   );
+});
+
+/** Read one exact active-pointer generation without opening another database session. */
+export const selectActiveViewFence = Effect.fn('codeGraph.selectActiveViewFence')(function* (worktreeId: string) {
+  if (!/^[0-9a-f]{64}$/u.test(worktreeId)) {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph worktree identity is invalid.'));
+  }
+  const sql = yield* SqlClient.SqlClient;
+  yield* configureConnection(sql);
+  const rows = yield* sql.unsafe<{
+    readonly activated_at: unknown;
+    readonly snapshot_id: unknown;
+  }>(
+    `SELECT activated_at, snapshot_id
+     FROM active_snapshots
+     WHERE worktree_id = ?
+     LIMIT 2`,
+    [worktreeId],
+  );
+  if (rows.length === 0) return undefined;
+  const activatedAt = rows[0]?.activated_at;
+  const snapshotId = rows[0]?.snapshot_id;
+  if (
+    rows.length !== 1 ||
+    typeof activatedAt !== 'string' ||
+    !validCanonicalTimestamp(activatedAt) ||
+    typeof snapshotId !== 'string' ||
+    !CODE_GRAPH_SNAPSHOT_ID.test(snapshotId)
+  ) {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph active view authority is invalid.'));
+  }
+  return {activatedAt, snapshotId, worktreeId} satisfies CodeGraphActiveViewFence;
 });

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -482,6 +482,13 @@ export interface CodeGraphActiveViewIdentity {
   readonly worktreeId: string;
 }
 
+/** Exact active-pointer generation used to fence a read across external work. */
+export interface CodeGraphActiveViewFence {
+  readonly activatedAt: string;
+  readonly snapshotId: string;
+  readonly worktreeId: string;
+}
+
 export interface CodeGraphVisualizationRelationshipSummary {
   readonly incoming: number;
   readonly outgoing: number;

--- a/src/code_graph/store_resolution.ts
+++ b/src/code_graph/store_resolution.ts
@@ -44,6 +44,7 @@ import {
   markSnapshotLeaseRetirementBaton,
 } from './store_reconciliation.js';
 import {CODE_GRAPH_SNAPSHOT_ID, validCanonicalTimestamp} from './store_reconciliation_core.js';
+import {nextCodeGraphActiveViewActivationTimestamp} from './store_active_views.js';
 import {CodeGraphPromotionCapacityPlanChanged, type EdgeRow} from './store_internal_models.js';
 import {lastStatementChangeCount, nextPersistentActivationBatchRows} from './store_activation_core.js';
 
@@ -867,18 +868,24 @@ const promoteSnapshot = Effect.fn('codeGraph.promoteSnapshot')(function* (
           new CodeGraphStoreError(`Ready snapshot ${snapshotId} was built by an incompatible extractor generation.`),
         );
       }
-      const active = yield* sql.unsafe<{readonly snapshot_id: unknown}>(
+      const active = yield* sql.unsafe<{readonly activated_at: unknown; readonly snapshot_id: unknown}>(
         `SELECT CASE
            WHEN typeof(snapshot_id) = 'text' AND length(CAST(snapshot_id AS BLOB)) BETWEEN 45 AND 67
-           THEN snapshot_id ELSE NULL END AS snapshot_id
+           THEN snapshot_id ELSE NULL END AS snapshot_id,
+           CASE WHEN typeof(activated_at) = 'text' AND length(CAST(activated_at AS BLOB)) = 24
+             THEN activated_at ELSE NULL END AS activated_at
          FROM active_snapshots WHERE worktree_id = ? LIMIT 2`,
         [identity.worktreeId],
       );
       const displacedSnapshotId = active[0]?.snapshot_id;
+      const displacedActivatedAt = active[0]?.activated_at;
       if (
         active.length > 1 ||
         (displacedSnapshotId !== undefined &&
-          (typeof displacedSnapshotId !== 'string' || !CODE_GRAPH_SNAPSHOT_ID.test(displacedSnapshotId)))
+          (typeof displacedSnapshotId !== 'string' ||
+            !CODE_GRAPH_SNAPSHOT_ID.test(displacedSnapshotId) ||
+            typeof displacedActivatedAt !== 'string' ||
+            !validCanonicalTimestamp(displacedActivatedAt)))
       ) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph active view authority is invalid.'));
       }
@@ -918,10 +925,17 @@ const promoteSnapshot = Effect.fn('codeGraph.promoteSnapshot')(function* (
       ) {
         return yield* Effect.fail(new CodeGraphPromotionCapacityPlanChanged());
       }
+      const activatedAt = nextCodeGraphActiveViewActivationTimestamp(capacity.activatedAt, [
+        typeof displacedActivatedAt === 'string' ? displacedActivatedAt : undefined,
+        typeof removedAt === 'string' ? removedAt : undefined,
+      ]);
+      if (activatedAt === undefined) {
+        return yield* Effect.fail(new CodeGraphStoreError('Code graph active view generation is invalid.'));
+      }
       const now = yield* Clock.currentTimeMillis;
       yield* sql`
         INSERT INTO active_snapshots (worktree_id, snapshot_id, activated_at)
-        VALUES (${identity.worktreeId}, ${snapshotId}, ${capacity.activatedAt})
+        VALUES (${identity.worktreeId}, ${snapshotId}, ${activatedAt})
         ON CONFLICT(worktree_id) DO UPDATE SET
           snapshot_id = excluded.snapshot_id,
           activated_at = excluded.activated_at

--- a/src/code_graph/store_service_data.ts
+++ b/src/code_graph/store_service_data.ts
@@ -57,7 +57,7 @@ import {
   selectVisualizationScopeEdgeSummary,
   selectVisualizationSymbols,
 } from './store_visualization.js';
-import {selectActiveViewIdentities} from './store_active_views.js';
+import {selectActiveViewFence, selectActiveViewIdentities} from './store_active_views.js';
 import {repairDatabase} from './store_repair.js';
 import {
   preparePersistedFullActivation,
@@ -117,6 +117,7 @@ type CodeGraphStoreDataMethods = Pick<
   | 'loadEmbeddingSymbolPage'
   | 'loadVisualizationCatalog'
   | 'loadActiveViewIdentities'
+  | 'loadActiveViewFence'
   | 'loadVisualizationCatalogs'
   | 'loadVisualizationScopeEdges'
   | 'loadVisualizationScopeEdgeSummary'
@@ -463,6 +464,13 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
           exists ? useReadOnlyDatabase(databasePath, selectActiveViewIdentities(limit)) : Effect.succeed([]),
         ),
         Effect.mapError(cause => storeError('load active code graph view identities', cause)),
+      ),
+    loadActiveViewFence: (databasePath, worktreeId) =>
+      fs.exists(databasePath).pipe(
+        Effect.flatMap(exists =>
+          exists ? useReadOnlyDatabase(databasePath, selectActiveViewFence(worktreeId)) : Effect.succeed(undefined),
+        ),
+        Effect.mapError(cause => storeError('load active code graph view fence', cause)),
       ),
     loadVisualizationCatalogs: (databasePath, metrics = 'complete', options = {}) =>
       fs.exists(databasePath).pipe(

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -14,6 +14,7 @@ import type {
 } from './citation_primitives.js';
 import type {
   CodeGraphActivationProgressCallback,
+  CodeGraphActiveViewFence,
   CodeGraphActiveViewIdentity,
   CodeGraphAnalysisEdgeAggregatePage,
   CodeGraphAnalysisSummary,
@@ -363,6 +364,10 @@ export interface CodeGraphStoreShape {
     databasePath: string,
     limit: number,
   ) => Effect.Effect<readonly CodeGraphActiveViewIdentity[], CodeGraphStoreError>;
+  readonly loadActiveViewFence: (
+    databasePath: string,
+    worktreeId: string,
+  ) => Effect.Effect<CodeGraphActiveViewFence | undefined, CodeGraphStoreError>;
   readonly loadVisualizationCatalogs: (
     databasePath: string,
     metrics?: 'complete' | 'deferred',

--- a/src/code_graph/store_view_cleanup.ts
+++ b/src/code_graph/store_view_cleanup.ts
@@ -28,6 +28,7 @@ import {
   ensureRemovedViewCleanupEpoch,
 } from './store_reconciliation.js';
 import {type CompactLexicalSnapshotKeyRow, validatedCompactLexicalCount} from './store_build_core.js';
+import {nextCodeGraphActiveViewActivationTimestamp} from './store_active_views.js';
 
 /** @internal Bounded keyset page retained for admission query-plan and load regressions. */
 
@@ -115,10 +116,12 @@ const removeActiveView = Effect.fn('codeGraph.removeActiveView')(function* (
           ),
         );
       }
-      const active = yield* sql.unsafe<{readonly snapshot_id: unknown}>(
+      const active = yield* sql.unsafe<{readonly activated_at: unknown; readonly snapshot_id: unknown}>(
         `SELECT CASE
            WHEN typeof(snapshot_id) = 'text' AND length(CAST(snapshot_id AS BLOB)) BETWEEN 45 AND 67
-           THEN snapshot_id ELSE NULL END AS snapshot_id
+           THEN snapshot_id ELSE NULL END AS snapshot_id,
+           CASE WHEN typeof(activated_at) = 'text' AND length(CAST(activated_at AS BLOB)) = 24
+             THEN activated_at ELSE NULL END AS activated_at
          FROM active_snapshots WHERE worktree_id = ? LIMIT 2`,
         [worktreeId],
       );
@@ -136,13 +139,17 @@ const removeActiveView = Effect.fn('codeGraph.removeActiveView')(function* (
         [worktreeId],
       );
       const activeSnapshotId = active[0]?.snapshot_id;
+      const activeActivatedAt = active[0]?.activated_at;
       const removedSnapshotId = removed[0]?.expected_snapshot_id;
       const removedAtValue = removed[0]?.removed_at;
 
       if (
         active.length > 1 ||
         (activeSnapshotId !== undefined &&
-          (typeof activeSnapshotId !== 'string' || !CODE_GRAPH_SNAPSHOT_ID.test(activeSnapshotId))) ||
+          (typeof activeSnapshotId !== 'string' ||
+            !CODE_GRAPH_SNAPSHOT_ID.test(activeSnapshotId) ||
+            typeof activeActivatedAt !== 'string' ||
+            !validCanonicalTimestamp(activeActivatedAt))) ||
         removed.length > 1 ||
         (removedSnapshotId !== undefined &&
           (typeof removedSnapshotId !== 'string' || !CODE_GRAPH_SNAPSHOT_ID.test(removedSnapshotId))) ||
@@ -202,7 +209,13 @@ const removeActiveView = Effect.fn('codeGraph.removeActiveView')(function* (
         true,
         alreadyRemoved ? undefined : cleanupEvidence,
       );
-      const removedAt = alreadyRemoved ? removedAtValue! : new Date().toISOString();
+      const removedAt = nextCodeGraphActiveViewActivationTimestamp(new Date().toISOString(), [
+        typeof activeActivatedAt === 'string' ? activeActivatedAt : undefined,
+        typeof removedAtValue === 'string' ? removedAtValue : undefined,
+      ]);
+      if (removedAt === undefined) {
+        return yield* Effect.fail(new CodeGraphStoreError('Code graph removed view generation is invalid.'));
+      }
       yield* sql`
         INSERT INTO removed_views (worktree_id, expected_snapshot_id, removed_at)
         VALUES (${worktreeId}, ${expectedSnapshotId}, ${removedAt})

--- a/src/context_brief/citation_validation.ts
+++ b/src/context_brief/citation_validation.ts
@@ -318,34 +318,36 @@ const validatePublishedRepositoryTasks = Effect.fn('contextBrief.validatePublish
       return yield* validateRepositoryTasks(
         {
           databasePath: layout.databasePath,
-          finalFence: resolvePublishedRepositoryReadFence(cwd, published).pipe(
-            Effect.flatMap(observation =>
-              Effect.gen(function* () {
-                if (observation.worktreeChanged) {
-                  const policyAwareStatus = yield* query.statusForPublishedIdentity(
-                    config.agentContextHome,
-                    cwd,
-                    published,
-                    {observeWorktree: true, requestMaintenance: false},
-                  );
-                  if (
-                    policyAwareStatus.freshness !== 'current' ||
-                    policyAwareStatus.stale ||
-                    !cleanPublishedCatalogFenceMatches(
-                      published,
-                      snapshot,
-                      policyAwareStatus.identity,
-                      policyAwareStatus.readySnapshot,
-                    )
-                  ) {
-                    return false;
-                  }
-                }
-                const activeSnapshot = yield* store.readySnapshot(layout.databasePath, published.worktreeId);
-                return cleanPublishedCatalogFenceMatches(published, snapshot, observation, activeSnapshot);
-              }),
-            ),
-          ),
+          finalFence: Effect.gen(function* () {
+            const beforeActive = yield* store.loadActiveViewFence(layout.databasePath, published.worktreeId);
+            if (
+              !cleanPublishedCatalogSnapshotMatches(published, snapshot) ||
+              beforeActive?.snapshotId !== snapshot.id
+            ) {
+              return false;
+            }
+            const policyAwareFence = query
+              .statusForPublishedIdentity(config.agentContextHome, cwd, published, {
+                observeWorktree: true,
+                requestMaintenance: false,
+              })
+              .pipe(
+                Effect.map(
+                  status =>
+                    status.freshness === 'current' &&
+                    !status.stale &&
+                    cleanPublishedCatalogFenceMatches(published, snapshot, status.identity, status.readySnapshot),
+                ),
+              );
+            const observation = yield* resolvePublishedRepositoryReadFence(cwd, published).pipe(Effect.option);
+            const repositoryCurrent =
+              observation._tag === 'None' || observation.value.worktreeChanged
+                ? yield* policyAwareFence
+                : cleanPublishedCatalogFenceMatches(published, snapshot, observation.value, snapshot);
+            if (!repositoryCurrent) return false;
+            const afterActive = yield* store.loadActiveViewFence(layout.databasePath, published.worktreeId);
+            return sameActiveViewFence(beforeActive, afterActive);
+          }),
           objectFormat: snapshot.commit.length === 64 ? 'sha256' : 'sha1',
           repositoryId: published.repositoryId,
           snapshot,
@@ -359,6 +361,18 @@ const validatePublishedRepositoryTasks = Effect.fn('contextBrief.validatePublish
     {existingOnly: true},
   );
 });
+
+function sameActiveViewFence(
+  before: {readonly activatedAt: string; readonly snapshotId: string; readonly worktreeId: string},
+  after: {readonly activatedAt: string; readonly snapshotId: string; readonly worktreeId: string} | undefined,
+): boolean {
+  return (
+    after !== undefined &&
+    before.activatedAt === after.activatedAt &&
+    before.snapshotId === after.snapshotId &&
+    before.worktreeId === after.worktreeId
+  );
+}
 
 const statusRepositoryFinalFence = (
   config: RuntimeConfig,

--- a/src/evaluation/context-brief-citation-scale-contract.ts
+++ b/src/evaluation/context-brief-citation-scale-contract.ts
@@ -26,6 +26,7 @@ export interface ContextBriefCitationScaleBudgetV1 {
 }
 
 export interface ContextBriefCitationScaleCountersV1 {
+  readonly activeViewFenceObservations: number;
   readonly coldGraphBuilds: number;
   readonly distinctGraphDatabasePaths: number;
   readonly effectiveEvidenceBatches: number;
@@ -55,6 +56,7 @@ export interface ContextBriefCitationScaleObservationV1 {
 export interface ContextBriefCitationScaleProfileResultV1 {
   readonly coldReadyGraphObservation: ContextBriefCitationScaleObservationV1;
   readonly counters: {
+    readonly maximumActiveViewFenceObservations: number;
     readonly maximumDistinctGraphDatabasePaths: number;
     readonly maximumEffectiveEvidenceBatches: number;
     readonly maximumLeaseBalance: number;
@@ -163,6 +165,7 @@ export function evaluateContextBriefCitationScaleProfile(
     ),
   };
   const counters = {
+    maximumActiveViewFenceObservations: maximum(all, observation => observation.counters.activeViewFenceObservations),
     maximumDistinctGraphDatabasePaths: maximum(all, observation => observation.counters.distinctGraphDatabasePaths),
     maximumEffectiveEvidenceBatches: maximum(all, observation => observation.counters.effectiveEvidenceBatches),
     maximumLeaseBalance: maximum(all, observation => observation.counters.leaseBalance),
@@ -233,6 +236,8 @@ function observationFailures(
 ): readonly string[] {
   const prefix = `${profile.id} observation ${index}`;
   const counters = observation.counters;
+  const expectedStatusObservations = profile.citedRepositories * (profile.id === 'local-100k' ? 2 : 1);
+  const expectedActiveViewFenceObservations = profile.id === 'local-100k' ? 0 : profile.citedRepositories * 2;
   return [
     observation.profile === profile.id ? '' : `${prefix} has wrong profile ${observation.profile}`,
     observation.selectedMemories === profile.selectedMemories
@@ -256,9 +261,12 @@ function observationFailures(
     counters.effectiveEvidenceBatches === profile.citedRepositories
       ? ''
       : `${prefix} issued ${counters.effectiveEvidenceBatches}/${profile.citedRepositories} repository evidence batches`,
-    counters.statusObservations === profile.citedRepositories * 2
+    counters.statusObservations === expectedStatusObservations
       ? ''
-      : `${prefix} made ${counters.statusObservations}/${profile.citedRepositories * 2} initial/final status observations`,
+      : `${prefix} made ${counters.statusObservations}/${expectedStatusObservations} snapshot status observations`,
+    counters.activeViewFenceObservations === expectedActiveViewFenceObservations
+      ? ''
+      : `${prefix} made ${counters.activeViewFenceObservations}/${expectedActiveViewFenceObservations} active-view fence observations`,
     counters.snapshotLeaseAcquisitions === profile.citedRepositories &&
     counters.snapshotLeaseReleases === profile.citedRepositories &&
     counters.leaseBalance === 0

--- a/src/evaluation/context-brief-citation-scale.ts
+++ b/src/evaluation/context-brief-citation-scale.ts
@@ -255,6 +255,7 @@ const runObservation = Effect.fn('evaluation.contextBriefCitationScaleObservatio
 });
 
 interface MutableCounters {
+  activeViewFenceObservations: number;
   coldGraphBuilds: number;
   databasePaths: Set<string>;
   effectiveEvidenceBatches: number;
@@ -301,6 +302,11 @@ export function makeContextBriefCitationScaleGraphInstrumentation(): ContextBrie
           observeDatabasePath(databasePath);
           counters.effectiveEvidenceBatches += 1;
         }).pipe(Effect.andThen(store.effectiveSnapshotCitationEvidence(databasePath, snapshotId, request))),
+      loadActiveViewFence: (databasePath, worktreeId) =>
+        Effect.sync(() => {
+          observeDatabasePath(databasePath);
+          counters.activeViewFenceObservations += 1;
+        }).pipe(Effect.andThen(store.loadActiveViewFence(databasePath, worktreeId))),
       readySnapshot: (databasePath, worktreeId) =>
         Effect.sync(() => {
           observeDatabasePath(databasePath);
@@ -328,6 +334,7 @@ export function makeContextBriefCitationScaleGraphInstrumentation(): ContextBrie
         }).pipe(Effect.andThen(store.withSession(databasePath, effect, options))),
     });
   const snapshot = (): ContextBriefCitationScaleCountersV1 => ({
+    activeViewFenceObservations: counters.activeViewFenceObservations,
     coldGraphBuilds: counters.coldGraphBuilds,
     distinctGraphDatabasePaths: counters.databasePaths.size,
     effectiveEvidenceBatches: counters.effectiveEvidenceBatches,
@@ -400,6 +407,7 @@ function fixtureBudgetTokens(_prepared: ContextBriefCitationScalePreparedProfile
 
 function emptyCounters(): MutableCounters {
   return {
+    activeViewFenceObservations: 0,
     coldGraphBuilds: 0,
     databasePaths: new Set(),
     effectiveEvidenceBatches: 0,

--- a/test/evaluation/README.md
+++ b/test/evaluation/README.md
@@ -34,11 +34,12 @@ The profiles are local/96 citations, workset-50/16 cited repositories/64 citatio
 repositories/96 citations. Every warmup and measured sample selects a different set of canonical schema-v4 memories,
 so validation receipts are not process-cache hits. The artifact records 25-sample p95 latency after five warmups, added
 RSS, selected memories, all validation receipts, distinct graph database paths, production graph-store sessions,
-snapshot leases, effective-evidence batches, status observations, maintenance requests, and cold graph builds. The
+snapshot leases, effective-evidence batches, snapshot-status observations, active-view fence observations, maintenance
+requests, and cold graph builds. The
 session counter wraps calls that reach the real `CodeGraphStore.withSession` implementation against the prebuilt SQLite
 files; OS file-descriptor opens are not separately counted. The production query boundary owns that session across the
-initial status, lease, evidence read, final status fence, and release. Lease/evidence/status operations remain separate
-counters so session reuse cannot hide fan-out or skipped work.
+snapshot selection, lease, evidence read, two-sided active-view fence, and release. Lease, evidence, snapshot-status,
+and active-view-fence operations remain separate counters so session reuse cannot hide fan-out or skipped work.
 
 ```sh
 # Scheduled/manual release-quality distribution; ordinary pull-request CI does not run this job.

--- a/test/integration/context-brief-citation-workset.test.ts
+++ b/test/integration/context-brief-citation-workset.test.ts
@@ -14,7 +14,7 @@ import {
 import {CodeGraphStore} from '../../src/code_graph/store.js';
 import type {CodeGraphStoreShape} from '../../src/code_graph/store_shape.js';
 import {validateContextBriefMemoryCitations} from '../../src/context_brief/citation_validation.js';
-import {runCommandEffect} from '../../src/effect/command.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {captureMemoryCodeCitations} from '../../src/memory_code_citation_capture.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
@@ -22,7 +22,7 @@ import {TestError} from '../helpers/test-error.js';
 
 describe('Context Brief published Workset citation validation', () => {
   effectIt.effect(
-    'preserves policy-excluded changes and balances the lease when a HEAD race turns evidence stale',
+    'preserves policy-excluded changes and balances the lease when closing-fence races turn evidence stale',
     () =>
       Effect.acquireUseRelease(
         Effect.tryPromise({
@@ -74,6 +74,31 @@ describe('Context Brief published Workset citation validation', () => {
             let evidenceReads = 0;
             let released = 0;
             let sessions = 0;
+            let activeFenceReads = 0;
+            let changedActivationFenceRead: number | undefined;
+            let mutateBeforeActiveFence = false;
+            let suppressClosingTrace = false;
+            const citedPath = path.join(repository.path, 'src', 'session.ts');
+            const citedSource = yield* fs.readFileString(citedPath);
+            const baseCommand = yield* CommandExecutor;
+            const faultableCommand = CommandExecutor.of({
+              ...baseCommand,
+              execute: (executable, args, options) =>
+                baseCommand.execute(executable, args, options).pipe(
+                  Effect.map(result => {
+                    if (
+                      suppressClosingTrace &&
+                      executable === 'git' &&
+                      args.includes('status') &&
+                      options?.env?.GIT_TRACE_SETUP === '1'
+                    ) {
+                      suppressClosingTrace = false;
+                      return {...result, stderr: ''};
+                    }
+                    return result;
+                  }),
+                ),
+            });
             const countedStore = CodeGraphStore.of({
               ...baseStore,
               acquireSnapshotLease: (...args: Parameters<CodeGraphStoreShape['acquireSnapshotLease']>) =>
@@ -86,6 +111,23 @@ describe('Context Brief published Workset citation validation', () => {
                 ),
               releaseSnapshotLease: (...args: Parameters<CodeGraphStoreShape['releaseSnapshotLease']>) =>
                 baseStore.releaseSnapshotLease(...args).pipe(Effect.tap(() => Effect.sync(() => void ++released))),
+              loadActiveViewFence: (...args: Parameters<CodeGraphStoreShape['loadActiveViewFence']>) =>
+                Effect.gen(function* () {
+                  const read = ++activeFenceReads;
+                  if (mutateBeforeActiveFence) {
+                    mutateBeforeActiveFence = false;
+                    yield* fs.writeFileString(citedPath, `${citedSource}\n// closing-fence mutation\n`);
+                  }
+                  const fence = yield* baseStore.loadActiveViewFence(...args);
+                  if (fence !== undefined && read === changedActivationFenceRead) {
+                    changedActivationFenceRead = undefined;
+                    return {
+                      ...fence,
+                      activatedAt: new Date(Date.parse(fence.activatedAt) + 1).toISOString(),
+                    };
+                  }
+                  return fence;
+                }),
               withSession: (...args: Parameters<CodeGraphStoreShape['withSession']>) => {
                 expect(args[2]).toMatchObject({existingOnly: true});
                 return Effect.sync(() => void ++sessions).pipe(Effect.andThen(baseStore.withSession(...args)));
@@ -94,28 +136,67 @@ describe('Context Brief published Workset citation validation', () => {
             const validate = () =>
               validateContextBriefMemoryCitations(config, {kind: 'workset', name: fixture.identity.worksetName}, [
                 candidate,
-              ]).pipe(Effect.provideService(CodeGraphStore, countedStore));
+              ]).pipe(
+                Effect.provideService(CodeGraphStore, countedStore),
+                Effect.provideService(CommandExecutor, faultableCommand),
+              );
 
             const exact = yield* validate();
             expect(exact[0]?.receipts).toMatchObject([{reason: 'exact', status: 'exact'}]);
-            expect({acquired, evidenceReads, released, sessions}).toEqual({
+            expect({acquired, activeFenceReads, evidenceReads, released, sessions}).toEqual({
               acquired: 1,
+              activeFenceReads: 2,
               evidenceReads: 1,
               released: 1,
               sessions: 1,
             });
 
-            yield* fs.writeFileString(excludedPath, '<svg>excluded change</svg>\n');
-            const policyClean = yield* validate();
-            expect(policyClean[0]?.receipts).toMatchObject([{reason: 'exact', status: 'exact'}]);
-            expect({acquired, evidenceReads, released, sessions}).toEqual({
+            suppressClosingTrace = true;
+            const fallbackExact = yield* validate();
+            expect(fallbackExact[0]?.receipts).toMatchObject([{reason: 'exact', status: 'exact'}]);
+            expect({acquired, activeFenceReads, evidenceReads, released, sessions}).toEqual({
               acquired: 2,
+              activeFenceReads: 4,
               evidenceReads: 1,
               released: 2,
               sessions: 2,
             });
 
+            yield* fs.writeFileString(excludedPath, '<svg>excluded change</svg>\n');
+            const policyClean = yield* validate();
+            expect(policyClean[0]?.receipts).toMatchObject([{reason: 'exact', status: 'exact'}]);
+            expect({acquired, activeFenceReads, evidenceReads, released, sessions}).toEqual({
+              acquired: 3,
+              activeFenceReads: 6,
+              evidenceReads: 1,
+              released: 3,
+              sessions: 3,
+            });
+
             yield* fs.writeFileString(excludedPath, '<svg/>\n');
+            mutateBeforeActiveFence = true;
+            const lateEdit = yield* validate();
+            expect(lateEdit[0]?.receipts).toMatchObject([{reason: 'graph-stale', status: 'unknown'}]);
+            expect({acquired, activeFenceReads, evidenceReads, released, sessions}).toEqual({
+              acquired: 4,
+              activeFenceReads: 7,
+              evidenceReads: 1,
+              released: 4,
+              sessions: 4,
+            });
+            yield* fs.writeFileString(citedPath, citedSource);
+
+            changedActivationFenceRead = activeFenceReads + 2;
+            const promoted = yield* validate();
+            expect(promoted[0]?.receipts).toMatchObject([{reason: 'graph-stale', status: 'unknown'}]);
+            expect({acquired, activeFenceReads, evidenceReads, released, sessions}).toEqual({
+              acquired: 5,
+              activeFenceReads: 9,
+              evidenceReads: 1,
+              released: 5,
+              sessions: 5,
+            });
+
             yield* git(repository.path, [
               '-c',
               'user.name=Threadnote Test',
@@ -129,11 +210,12 @@ describe('Context Brief published Workset citation validation', () => {
 
             const stale = yield* validate();
             expect(stale[0]?.receipts).toMatchObject([{reason: 'graph-stale', status: 'unknown'}]);
-            expect({acquired, evidenceReads, released, sessions}).toEqual({
-              acquired: 3,
+            expect({acquired, activeFenceReads, evidenceReads, released, sessions}).toEqual({
+              acquired: 6,
+              activeFenceReads: 10,
               evidenceReads: 1,
-              released: 3,
-              sessions: 3,
+              released: 6,
+              sessions: 6,
             });
           }),
         fixture =>

--- a/test/unit/code-graph.active-view-fence.test.ts
+++ b/test/unit/code-graph.active-view-fence.test.ts
@@ -1,0 +1,49 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {nextCodeGraphActiveViewActivationTimestamp} from '../../src/code_graph/store_active_views.js';
+
+const canonicalTimestamp = fc
+  .date({
+    max: new Date('9998-12-31T23:59:59.999Z'),
+    min: new Date('2000-01-01T00:00:00.000Z'),
+    noInvalidDate: true,
+  })
+  .map(value => value.toISOString());
+
+describe('code graph active-view fence', () => {
+  it('advances every prior activation generation', () => {
+    fc.assert(
+      fc.property(canonicalTimestamp, fc.array(canonicalTimestamp, {maxLength: 4}), (candidate, previous) => {
+        const next = nextCodeGraphActiveViewActivationTimestamp(candidate, previous);
+        expect(next).toBeDefined();
+        expect(Date.parse(next!)).toBeGreaterThanOrEqual(Date.parse(candidate));
+        for (const value of previous) expect(Date.parse(next!)).toBeGreaterThan(Date.parse(value));
+      }),
+      {numRuns: 100},
+    );
+  });
+
+  it('fails closed when the canonical timestamp range cannot advance', () => {
+    const maximum = '9999-12-31T23:59:59.999Z';
+    expect(nextCodeGraphActiveViewActivationTimestamp(maximum, [maximum])).toBeUndefined();
+    expect(nextCodeGraphActiveViewActivationTimestamp('not-a-timestamp', [])).toBeUndefined();
+  });
+
+  it('never restores the same generation through a same-clock promote/remove ABA sequence', () => {
+    const clock = '2026-08-27T20:00:00.000Z';
+    const firstB = nextCodeGraphActiveViewActivationTimestamp(clock, []);
+    const removedB = nextCodeGraphActiveViewActivationTimestamp(clock, [firstB]);
+    const activeA = nextCodeGraphActiveViewActivationTimestamp(clock, [removedB]);
+    const removedA = nextCodeGraphActiveViewActivationTimestamp(clock, [activeA]);
+    const finalB = nextCodeGraphActiveViewActivationTimestamp(clock, [removedA]);
+
+    expect([firstB, removedB, activeA, removedA, finalB]).toEqual([
+      '2026-08-27T20:00:00.000Z',
+      '2026-08-27T20:00:00.001Z',
+      '2026-08-27T20:00:00.002Z',
+      '2026-08-27T20:00:00.003Z',
+      '2026-08-27T20:00:00.004Z',
+    ]);
+    expect(finalB).not.toBe(firstB);
+  });
+});

--- a/test/unit/code-graph.removed-view-cleanup-store.test.ts
+++ b/test/unit/code-graph.removed-view-cleanup-store.test.ts
@@ -479,6 +479,51 @@ describe('removed code graph view cleanup queue', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
+  effectIt.effect('keeps view generations monotonic through a same-clock promote/remove ABA sequence', () =>
+    withFixture('threadnote-removed-cleanup-generation-aba-', ({databasePath, identity}) =>
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        const initialGeneration = '2099-01-01T00:00:00.000Z';
+        yield* Effect.sync(() => {
+          const database = new Database(databasePath, {strict: true});
+          try {
+            seedSnapshot(database, SNAPSHOT_ID, WORKTREE_ID, 'ready');
+            seedSnapshot(database, NEW_SNAPSHOT_ID, WORKTREE_ID, 'ready');
+            database
+              .query('INSERT INTO active_snapshots (worktree_id, snapshot_id, activated_at) VALUES (?, ?, ?)')
+              .run(WORKTREE_ID, NEW_SNAPSHOT_ID, initialGeneration);
+          } finally {
+            database.close(false);
+          }
+        });
+        yield* Effect.acquireRelease(store.acquireSnapshotLease(databasePath, SNAPSHOT_ID, 60_000), token =>
+          store.releaseSnapshotLease(databasePath, token).pipe(Effect.orDie),
+        );
+        yield* Effect.acquireRelease(store.acquireSnapshotLease(databasePath, NEW_SNAPSHOT_ID, 60_000), token =>
+          store.releaseSnapshotLease(databasePath, token).pipe(Effect.orDie),
+        );
+
+        const firstB = yield* store.loadActiveViewFence(databasePath, WORKTREE_ID);
+        expect(firstB).toMatchObject({activatedAt: initialGeneration, snapshotId: NEW_SNAPSHOT_ID});
+        yield* store.removeView(databasePath, WORKTREE_ID, NEW_SNAPSHOT_ID);
+        const removedB = readRemovedViewGeneration(databasePath);
+        yield* store.promote(databasePath, identity, SNAPSHOT_ID);
+        const activeA = yield* store.loadActiveViewFence(databasePath, WORKTREE_ID);
+        yield* store.removeView(databasePath, WORKTREE_ID, SNAPSHOT_ID);
+        const removedA = readRemovedViewGeneration(databasePath);
+        yield* store.promote(databasePath, identity, NEW_SNAPSHOT_ID);
+        const finalB = yield* store.loadActiveViewFence(databasePath, WORKTREE_ID);
+
+        expect(
+          [firstB!.activatedAt, removedB, activeA!.activatedAt, removedA, finalB!.activatedAt].map(Date.parse),
+        ).toEqual([0, 1, 2, 3, 4].map(offset => Date.parse(initialGeneration) + offset));
+        expect(finalB).toMatchObject({snapshotId: NEW_SNAPSHOT_ID});
+        expect(finalB!.activatedAt).not.toBe(firstB!.activatedAt);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('binds one shared snapshot removal without disturbing the other worktree authority', () =>
     withFixture('threadnote-removed-cleanup-shared-snapshot-', ({databasePath}) =>
       Effect.gen(function* () {
@@ -1349,6 +1394,19 @@ function readLeaseCarriers(databasePath: string): readonly string[] {
       )
       .all()
       .map(row => row.token);
+  } finally {
+    database.close(false);
+  }
+}
+
+function readRemovedViewGeneration(databasePath: string): string {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    const row = database
+      .query<{readonly removed_at: string}, [string]>('SELECT removed_at FROM removed_views WHERE worktree_id = ?')
+      .get(WORKTREE_ID);
+    if (row === null) throw new TestError('missing removed view generation');
+    return row.removed_at;
   } finally {
     database.close(false);
   }

--- a/test/unit/code-graph.repository-expected-identity.test.ts
+++ b/test/unit/code-graph.repository-expected-identity.test.ts
@@ -5,13 +5,14 @@ import {TestClock} from 'effect/testing';
 import {describe, expect, it} from 'vitest';
 import {
   parseRepositoryIdentityWorktreeObservation,
+  parseRepositoryReadFenceSetupObservation,
   resolveRepositoryIdentity,
   resolveRepositoryIdentityForExpectation,
   resolveRepositoryIdentityForExpectationAndWorktree,
   resolvePublishedRepositoryReadFence,
   revalidateRepositoryIdentityFence,
 } from '../../src/code_graph/repository.js';
-import {runCommandEffect} from '../../src/effect/command.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 
 describe('code graph expected repository identity', () => {
@@ -123,7 +124,7 @@ describe('code graph expected repository identity', () => {
       ),
     );
 
-    it.effect('brackets a clean published read across caller-path and HEAD observations', () =>
+    it.effect('closes a clean published read across caller-path, worktree, and HEAD observations', () =>
       TestClock.withLive(
         Effect.scoped(
           Effect.gen(function* () {
@@ -160,11 +161,29 @@ describe('code graph expected repository identity', () => {
               repositoryId: identity.repositoryId,
               worktreeId: identity.worktreeId,
             };
-            expect(yield* resolvePublishedRepositoryReadFence(caller, expected)).toEqual({
+            const command = yield* CommandExecutor;
+            const invocations: string[][] = [];
+            const recording = CommandExecutor.of({
+              ...command,
+              execute: (executable, args, options) =>
+                Effect.sync(() => {
+                  if (executable === 'git') invocations.push([...args]);
+                }).pipe(Effect.andThen(command.execute(executable, args, options))),
+            });
+            expect(
+              yield* resolvePublishedRepositoryReadFence(caller, expected).pipe(
+                Effect.provideService(CommandExecutor, recording),
+              ),
+            ).toEqual({
               ...expected,
               headCommit: identity.headCommit,
               worktreeChanged: false,
             });
+            expect(invocations).toHaveLength(3);
+            expect(invocations.filter(args => args.includes('status'))).toHaveLength(1);
+            expect(
+              invocations.map(args => args.find(argument => ['remote', 'rev-parse', 'status'].includes(argument))),
+            ).toEqual(['rev-parse', 'remote', 'status']);
 
             const failure = yield* resolvePublishedRepositoryReadFence(caller, expected, {
               afterInitialIdentity: () => fs.remove(caller).pipe(Effect.andThen(fs.symlink(second, caller))),
@@ -174,15 +193,56 @@ describe('code graph expected repository identity', () => {
 
             yield* fs.remove(caller);
             yield* fs.symlink(first, caller);
+            const remoteFailure = yield* resolvePublishedRepositoryReadFence(caller, expected, {
+              afterInitialIdentity: () =>
+                git(first, ['remote', 'set-url', 'origin', 'https://github.com/example/replaced.git']).pipe(
+                  Effect.asVoid,
+                ),
+            }).pipe(Effect.flip);
+            expect(remoteFailure).toBeInstanceOf(Error);
+            expect((remoteFailure as Error).message).toBe('Repository identity changed during the graph read.');
+            yield* git(first, ['remote', 'set-url', 'origin', 'https://github.com/example/read-fence.git']);
+
+            const lateRetargetFailure = yield* resolvePublishedRepositoryReadFence(caller, expected, {
+              beforeClosingWorktreeObservation: () =>
+                fs.remove(caller).pipe(Effect.andThen(fs.symlink(second, caller))),
+            }).pipe(Effect.flip);
+            expect(lateRetargetFailure).toBeInstanceOf(Error);
+            expect((lateRetargetFailure as Error).message).toBe('Repository identity changed during the graph read.');
+
+            yield* fs.remove(caller);
+            yield* fs.symlink(first, caller);
             const changed = yield* resolvePublishedRepositoryReadFence(caller, expected, {
-              afterWorktreeObservation: () =>
+              beforeClosingWorktreeObservation: () =>
                 fs.writeFileString(path.join(first, 'tracked.ts'), 'export const tracked = 2;\n'),
             });
             expect(changed).toEqual({...expected, headCommit: identity.headCommit, worktreeChanged: true});
             yield* fs.writeFileString(path.join(first, 'tracked.ts'), 'export const tracked = 1;\n');
 
+            const firstGitDirectory = path.join(first, '.git');
+            const savedFirstGitDirectory = path.join(first, '.git-before-retarget');
+            const commonDirectoryFailure = yield* resolvePublishedRepositoryReadFence(caller, expected, {
+              beforeClosingWorktreeObservation: () =>
+                fs
+                  .rename(firstGitDirectory, savedFirstGitDirectory)
+                  .pipe(
+                    Effect.andThen(fs.writeFileString(firstGitDirectory, `gitdir: ${path.join(second, '.git')}\n`)),
+                  ),
+            }).pipe(
+              Effect.ensuring(
+                fs
+                  .remove(firstGitDirectory, {force: true})
+                  .pipe(Effect.andThen(fs.rename(savedFirstGitDirectory, firstGitDirectory)), Effect.orDie),
+              ),
+              Effect.flip,
+            );
+            expect(commonDirectoryFailure).toBeInstanceOf(Error);
+            expect((commonDirectoryFailure as Error).message).toBe(
+              'Repository identity changed during the graph read.',
+            );
+
             const headFailure = yield* resolvePublishedRepositoryReadFence(caller, expected, {
-              afterWorktreeObservation: () =>
+              beforeClosingWorktreeObservation: () =>
                 git(first, [
                   '-c',
                   'user.name=Threadnote Test',
@@ -212,6 +272,46 @@ describe('code graph expected repository identity', () => {
           headCommit: head,
         });
       }),
+      {numRuns: 100},
+    );
+  });
+
+  it('parses one bounded setup identity and rejects missing, duplicate, or unsafe fields', () => {
+    const prefix = '00:00:00.000000 trace.c:1 setup: ';
+    expect(
+      parseRepositoryReadFenceSetupObservation(
+        `${prefix}git_common_dir: /repo/.git\n${prefix}worktree: /repo with spaces\n`,
+      ),
+    ).toEqual({gitCommonDirectory: '/repo/.git', worktree: '/repo with spaces'});
+    expect(parseRepositoryReadFenceSetupObservation(`${prefix}worktree: /repo\n`)).toBeUndefined();
+    expect(
+      parseRepositoryReadFenceSetupObservation(
+        `${prefix}git_common_dir: /repo/.git\n${prefix}worktree: /repo\n${prefix}worktree: /other\n`,
+      ),
+    ).toBeUndefined();
+    expect(
+      parseRepositoryReadFenceSetupObservation(
+        `${prefix}git_common_dir: /repo/.git\n${prefix}worktree: /repo\u0000other\n`,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('rejects every duplicated setup identity field', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[A-Za-z0-9._-]{1,32}$/u),
+        fc.constantFrom('git_common_dir', 'worktree'),
+        (segment, duplicate) => {
+          const prefix = '00:00:00.000000 trace.c:1 setup: ';
+          const gitCommonDirectory = `/repo/${segment}/.git`;
+          const worktree = `/repo/${segment}`;
+          const base = `${prefix}git_common_dir: ${gitCommonDirectory}\n${prefix}worktree: ${worktree}\n`;
+          const repeated = duplicate === 'git_common_dir' ? gitCommonDirectory : worktree;
+          expect(
+            parseRepositoryReadFenceSetupObservation(`${base}${prefix}${duplicate}: ${repeated}\n`),
+          ).toBeUndefined();
+        },
+      ),
       {numRuns: 100},
     );
   });

--- a/test/unit/context-brief-citation-scale-benchmark.test.ts
+++ b/test/unit/context-brief-citation-scale-benchmark.test.ts
@@ -52,6 +52,15 @@ describe('Context Brief citation scale benchmark', () => {
     );
   });
 
+  it('fails when a published Workset omits either active-view fence observation', () => {
+    const profile = budget.profiles.find(candidate => candidate.id === 'workset-50')!;
+    const observation = scaleObservation(profile, {
+      activeViewFenceObservations: profile.citedRepositories,
+    });
+    const evaluated = evaluateContextBriefCitationScaleProfile(budget, profile.id, observation, [observation]);
+    expect(evaluated.failures).toContain('workset-50 observation 0 made 16/32 active-view fence observations');
+  });
+
   it('keeps aggregation invariant under sample order while enforcing fan-out counters', () => {
     const profile = budget.profiles.find(candidate => candidate.id === 'workset-50')!;
     fc.assert(
@@ -118,6 +127,7 @@ function scaleObservation(
     addedRssBytes: 1_024,
     contextBriefMilliseconds: 10,
     counters: {
+      activeViewFenceObservations: profile.id === 'local-100k' ? 0 : profile.citedRepositories * 2,
       coldGraphBuilds: 0,
       distinctGraphDatabasePaths: profile.citedRepositories,
       effectiveEvidenceBatches: profile.citedRepositories,
@@ -127,7 +137,7 @@ function scaleObservation(
       productionStoreSessionCalls: profile.citedRepositories,
       snapshotLeaseAcquisitions: profile.citedRepositories,
       snapshotLeaseReleases: profile.citedRepositories,
-      statusObservations: profile.citedRepositories * 2,
+      statusObservations: profile.citedRepositories * (profile.id === 'local-100k' ? 2 : 1),
       ...counters,
     },
     estimatedTokens: 1_000,


### PR DESCRIPTION
## Summary

- collapse clean published-Workset validation to three ordered Git processes per cited repository
- fence the active graph generation on both sides of the closing Git observation, including promote/remove ABA transitions
- preserve policy-aware fallback and legacy v1 recall behavior
- make the citation scale gate assert one snapshot selection plus two active-view fence reads per published repository

## Focused verification

- 25 focused active-view/removal/citation race tests
- legacy v1 Context Brief compatibility test
- source and test TypeScript checks
- strict targeted lint, Prettier, file-length, and diff checks
- dev-cycle: clean after one full and two incremental reviews
- exact-HEAD global install and real CLI Workset citation smoke: exact/current-complete, no stale conflicts

## Local 100k diagnostic (5 samples / 1 warmup)

- local validation p95: 116.7 ms (250 ms budget)
- Workset 50 validation p95: 359.8 ms (500 ms budget)
- Workset 128 validation p95: 681.1 ms (1000 ms budget)
- all receipts exact; one store session/evidence batch/lease per cited repository; two active-view fence observations; no cold graph builds or maintenance requests

The authoritative release gate remains the 25-sample/5-warmup pinned Linux job.