### PR TITLE
fix: stabilize process registration diagnostics

### DIFF
--- a/src/process_diagnostics.ts
+++ b/src/process_diagnostics.ts
@@ -222,6 +222,16 @@ const readThreadnoteProcessSnapshot = Effect.fn('processDiagnostics.readSnapshot
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
+
+  // Standalone release leases are acquired immediately before runtime process
+  // registration. Observe leases first so a process that finishes registering
+  // during this snapshot is classified from its registry row instead of being
+  // reported transiently as a pre-registry release.
+  const releaseLeaseDiagnostics = yield* readLiveStandaloneProcessLeases().pipe(
+    Effect.catch(() => Effect.succeed({leases: [] as const, truncated: false})),
+  );
+  const releaseLeases = releaseLeaseDiagnostics.leases;
+
   const directory = processDiagnosticsDirectory(path, config.agentContextHome);
   const names = yield* fs.readDirectory(directory).pipe(Effect.catch(() => Effect.succeed([] as string[])));
   const eligibleNames = names.filter(name => /^[1-9]\d*\.json$/.test(name));
@@ -257,10 +267,6 @@ const readThreadnoteProcessSnapshot = Effect.fn('processDiagnostics.readSnapshot
   // PID/start-identity-bound lease so updates do not delete their executable.
   // Merge only that bounded installation evidence; never inspect or expose
   // arbitrary process command lines, which may contain memory text or paths.
-  const releaseLeaseDiagnostics = yield* readLiveStandaloneProcessLeases().pipe(
-    Effect.catch(() => Effect.succeed({leases: [] as const, truncated: false})),
-  );
-  const releaseLeases = releaseLeaseDiagnostics.leases;
   const releaseLeaseByProcess = new Map(releaseLeases.map(lease => [lease.processId, lease] as const));
   const registeredProcessIds = new Set(live.map(value => value.processId));
   const now = Date.now();

--- a/test/unit/process-diagnostics.test.ts
+++ b/test/unit/process-diagnostics.test.ts
@@ -529,6 +529,70 @@ describe('process diagnostics', () => {
     }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
   );
 
+  it.effect('does not report a process that registers while its release lease snapshot is being read', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-registering-process-home-'});
+      const processId = 1_234_568;
+      const version = '4.4.1-local.g0123456789abcdef0123456789abcdef01234567';
+      const leaseDirectory = join(installationTemporaryRoot!, 'leases', version);
+      const registrationDirectory = join(home, 'runtime', 'processes');
+      const registrationPath = join(registrationDirectory, `${processId}.json`);
+      yield* fileSystem.makeDirectory(leaseDirectory, {recursive: true});
+      yield* fileSystem.makeDirectory(registrationDirectory, {recursive: true});
+      yield* fileSystem.writeFileString(
+        join(leaseDirectory, `${processId}.json`),
+        `${JSON.stringify({
+          parentProcessId: 7654,
+          processId,
+          processStartIdentity: 'matching-process-identity',
+          startedAt: '2026-08-27T00:00:00.000Z',
+          token: 'private-ownership-token',
+          version,
+        })}\n`,
+      );
+
+      let registrationWritten = false;
+      const registeringFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        readDirectory: directory =>
+          fileSystem.readDirectory(directory).pipe(
+            Effect.tap(() => {
+              if (directory !== leaseDirectory || registrationWritten) return Effect.void;
+              registrationWritten = true;
+              return fileSystem.writeFileString(
+                registrationPath,
+                `${JSON.stringify(
+                  testRegistration(processId, 'mcp', 'matching-process-identity', 'registry-token-value'),
+                )}\n`,
+              );
+            }),
+          ),
+      });
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: candidate => candidate === processId,
+        processStartIdentity: candidate =>
+          Effect.succeed(candidate === processId ? 'matching-process-identity' : undefined),
+      });
+
+      const diagnostics = yield* readThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+        Effect.provideService(FileSystem.FileSystem, registeringFileSystem),
+        Effect.provideService(SystemInfo, testSystem),
+      );
+
+      expect(registrationWritten).toBe(true);
+      expect(diagnostics.processes).toEqual([
+        expect.objectContaining({
+          processId,
+          releaseVersion: version,
+          role: 'mcp',
+        }),
+      ]);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
+
   it.effect('keeps process identity as ROLE while nested activities update OPERATION and title', () =>
     Effect.gen(function* () {
       temporaryRoot = yield* Effect.promise(() => mkdtemp(join(tmpdir(), 'threadnote-process-diagnostics-')));


### PR DESCRIPTION
## Summary

- observe standalone release leases before runtime registrations
- prevent a process finishing normal startup from being transiently labeled pre-registry
- preserve privacy-safe legacy process reporting
- add a deterministic Effect regression test for the lease-to-registry handoff

## Reproduction

A disposable-home probe observed the release lease before the matching registry row in 20/20 normal CLI starts. The original doctor warning cleared on its next invocation and all current-release processes were registered, confirming a startup snapshot race rather than a stranded process.

## Validation

- focused process-diagnostics tests (17/17)
- source and test TypeScript checks
- strict targeted lint
- Prettier and file-length checks
- commit hook full lint/typecheck
