### PR TITLE
fix: isolate release update version checks

### DIFF
--- a/src/installations.ts
+++ b/src/installations.ts
@@ -237,6 +237,13 @@ export const activeInstalledVersion = Effect.fn('installations.activeVersion')(f
   return (yield* activeInstalledRelease())?.version;
 });
 
+export const executingInstalledRelease = Effect.fn('installations.executingRelease')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  return yield* readValidatedRelease(fs, path, path.dirname(system.executablePath), installationRoot(path, system));
+});
+
 export const pruneStandaloneReleases = Effect.fn('installations.pruneReleases')(function* (
   activeReleaseRoot: string,
   dryRun: boolean,

--- a/src/update.ts
+++ b/src/update.ts
@@ -21,6 +21,7 @@ import {SystemInfo, type SystemInfoShape} from './effect/system.js';
 import {
   activeInstalledVersion,
   activateStandaloneRelease,
+  executingInstalledRelease,
   installationRoot,
   promoteStandaloneReleaseDirectory,
   pruneStandaloneReleases,
@@ -33,6 +34,7 @@ import {whatsNewLinesForVersionRange} from './release_notes.js';
 import type {JsonObject, PostUpdateOptions, RuntimeConfig, UpdateOptions} from './types.js';
 import {selectUpdateChannel, type UpdateChannel} from './update_channel.js';
 import {isDevelopmentBuildVersion} from './version_compare.js';
+import {isStandaloneThreadnoteBuild} from './version.js';
 import {
   compareVersions,
   ensureDirectory,
@@ -723,10 +725,19 @@ function getUpdateInfo(
 ) {
   return Effect.gen(function* () {
     const packageVersion = yield* currentPackageVersion();
-    const installedVersion =
-      options.preferInstalledVersion && !requiresFreshStandaloneInstall(packageVersion)
-        ? yield* activeInstalledVersion()
-        : undefined;
+    const standaloneBuild = isStandaloneThreadnoteBuild();
+    const runningInstalledRelease =
+      options.preferInstalledVersion && standaloneBuild && !isDevelopmentBuildVersion(packageVersion)
+        ? (yield* executingInstalledRelease()) !== undefined
+        : false;
+    const installedVersion = shouldPreferActiveInstalledVersion({
+      packageVersion,
+      preferInstalledVersion: options.preferInstalledVersion,
+      runningInstalledRelease,
+      standaloneBuild,
+    })
+      ? yield* activeInstalledVersion()
+      : undefined;
     const currentVersion = installedVersion ?? packageVersion;
     const inferredChannel = selectUpdateChannel(currentVersion);
     const channel = selectUpdateChannel(currentVersion, options.requestedChannel);
@@ -759,6 +770,19 @@ function getUpdateInfo(
       usedCache: cached !== undefined,
     };
   });
+}
+
+export function shouldPreferActiveInstalledVersion(options: {
+  readonly packageVersion: string;
+  readonly preferInstalledVersion: boolean;
+  readonly runningInstalledRelease: boolean;
+  readonly standaloneBuild: boolean;
+}): boolean {
+  return (
+    options.preferInstalledVersion &&
+    !requiresFreshStandaloneInstall(options.packageVersion) &&
+    (!options.standaloneBuild || isDevelopmentBuildVersion(options.packageVersion) || options.runningInstalledRelease)
+  );
 }
 
 export function requestedUpdateChannel(options: Pick<UpdateOptions, 'beta' | 'stable'>): UpdateChannel | undefined {

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -27,6 +27,14 @@ vi.mock('../../src/utils.js', async importOriginal => {
   };
 });
 
+vi.mock('../../src/version.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../src/version.js')>();
+  return {
+    ...actual,
+    isStandaloneThreadnoteBuild: vi.fn(() => false),
+  };
+});
+
 import {
   fetchLatestVersion,
   isUpdateTargetAllowed,
@@ -41,9 +49,11 @@ import {
   resolveReleaseSource,
   runPostUpdate,
   runUpdate,
+  shouldPreferActiveInstalledVersion,
   verifyOfficialPlatformSignature,
 } from '../../src/update.js';
 import * as utils from '../../src/utils.js';
+import * as version from '../../src/version.js';
 
 const OFFICIAL_RELEASE_SOURCE = 'https://api.github.com/repos/Kashkovsky/threadnote/releases?per_page=100';
 const RELEASE_VERSION = '4.0.0';
@@ -56,6 +66,7 @@ beforeEach(async () => {
   isolatedInstallationRoot = await mkdtemp(join(tmpdir(), 'threadnote-update-installation-'));
   process.env.THREADNOTE_INSTALL_ROOT = isolatedInstallationRoot;
   vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(RELEASE_VERSION));
+  vi.mocked(version.isStandaloneThreadnoteBuild).mockReturnValue(false);
   if (defaultToolRootImplementation) {
     vi.mocked(utils.toolRoot).mockImplementation(defaultToolRootImplementation);
   }
@@ -80,6 +91,37 @@ describe('standalone release selection', () => {
   it('requires a fresh install before the standalone 4.x updater boundary', () => {
     expect(requiresFreshStandaloneInstall('3.0.5')).toBe(true);
     expect(requiresFreshStandaloneInstall('4.0.0-beta.1')).toBe(false);
+  });
+
+  it('selects active installation metadata only for source, development, or installed runtimes', () => {
+    fc.assert(
+      fc.property(
+        fc.boolean(),
+        fc.boolean(),
+        fc.boolean(),
+        fc.boolean(),
+        (preferInstalledVersion, standaloneBuild, developmentBuild, runningInstalledRelease) => {
+          const packageVersion = developmentBuild ? `4.4.1-local.g${'a'.repeat(40)}` : '4.4.1';
+          expect(
+            shouldPreferActiveInstalledVersion({
+              packageVersion,
+              preferInstalledVersion,
+              runningInstalledRelease,
+              standaloneBuild,
+            }),
+          ).toBe(preferInstalledVersion && (!standaloneBuild || developmentBuild || runningInstalledRelease));
+        },
+      ),
+      {numRuns: 100},
+    );
+    expect(
+      shouldPreferActiveInstalledVersion({
+        packageVersion: '3.0.5',
+        preferInstalledVersion: true,
+        runningInstalledRelease: true,
+        standaloneBuild: true,
+      }),
+    ).toBe(false);
   });
 
   it('labels the inclusive beta channel without describing a stable winner as a beta release', () => {
@@ -422,6 +464,62 @@ describe('update notifications', () => {
 });
 
 describe('standalone updater', () => {
+  effectIt.effect('keeps an extracted release binary independent from an unrelated active development install', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const releaseVersion = '4.4.1';
+        const activeVersion = `4.4.1-local.g${'b'.repeat(40)}`;
+        vi.mocked(utils.currentPackageVersion).mockReturnValue(Effect.succeed(releaseVersion));
+        vi.mocked(version.isStandaloneThreadnoteBuild).mockReturnValue(true);
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-extracted-update-check-'});
+        const installRoot = path.join(temporaryRoot, 'install');
+        const activeReleaseRoot = path.join(installRoot, 'versions', activeVersion);
+        const extractedRoot = path.join(temporaryRoot, 'extracted-release');
+        yield* fs.makeDirectory(activeReleaseRoot, {recursive: true});
+        yield* fs.makeDirectory(extractedRoot, {recursive: true});
+        yield* fs.writeFileString(
+          path.join(activeReleaseRoot, 'release.json'),
+          `${JSON.stringify({version: activeVersion})}\n`,
+        );
+        yield* fs.writeFileString(
+          path.join(extractedRoot, 'release.json'),
+          `${JSON.stringify({version: releaseVersion})}\n`,
+        );
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({
+            ...baseSystem.environment(),
+            THREADNOTE_INSTALL_ROOT: installRoot,
+          }),
+          executablePath: path.join(extractedRoot, baseSystem.platform === 'win32' ? 'threadnote.exe' : 'threadnote'),
+        });
+        yield* activateStandaloneRelease(activeReleaseRoot, false).pipe(Effect.provideService(SystemInfo, testSystem));
+        const http = HttpService.of({
+          downloadToFile: () => Effect.die('update check must not download'),
+          getJson: () => Effect.succeed({body: [releaseResponse(releaseVersion, false)], status: 200}),
+          getStatus: () => Effect.die('not used'),
+          getText: () => Effect.die('not used'),
+        });
+
+        const captured = yield* captureConsole(
+          runUpdate(runtimeConfig(path.join(temporaryRoot, 'home')), {check: true, json: true}).pipe(
+            Effect.provideService(HttpService, http),
+            Effect.provideService(SystemInfo, testSystem),
+          ),
+        );
+
+        expect(JSON.parse(captured.output)).toMatchObject({
+          currentVersion: releaseVersion,
+          isUpdateAvailable: false,
+          latestVersion: releaseVersion,
+        });
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('emits one versioned JSON document for a release check', () =>
     Effect.gen(function* () {
       const captured = yield* captureDryRunUpdateSelection(


### PR DESCRIPTION
## Summary

- report an independently extracted release binary's own version during update checks
- continue using the active installed version for source/dev runtimes and binaries running from the managed installation
- preserve the fresh-install boundary
- add an Effect regression test and a bounded property for version-source selection

## Reproduction

The signed 4.4.1 release binary reports 4.4.1 from --version, but update --check --json inherited the machine's unrelated active 4.4.1-local development installation and falsely reported an available update.

## Validation

- focused update tests (46/46)
- 100-run version-source property
- exact standalone build
- built 4.4.1 binary smoke: --version and update JSON both report 4.4.1; update available is false
- source/test TypeScript, strict lint, Prettier, file-length, and commit-hook checks

Global installation was intentionally not taken over from the active release task.
