### PR TITLE
fix(manager): surface active processes first

### DIFF
--- a/src/manager_processes_view.tsx
+++ b/src/manager_processes_view.tsx
@@ -14,6 +14,8 @@ export function ProcessesPanel(): React.ReactElement {
   const [loadError, setLoadError] = useState('');
   const [operationError, setOperationError] = useState('');
   const [terminating, setTerminating] = useState<string>();
+  const displayedProcesses =
+    diagnostics === undefined ? undefined : orderManagerProcessesForPresentation(diagnostics.processes);
 
   const load = async (signal?: AbortSignal): Promise<void> => {
     try {
@@ -73,8 +75,8 @@ export function ProcessesPanel(): React.ReactElement {
           <p className="eyebrow">Runtime inventory</p>
           <h2>Threadnote processes</h2>
           <p>
-            Registered processes and identity-verified legacy runtimes. Arguments, environment variables, and private
-            registration data are never exposed.
+            Active operations appear first, followed by other registered processes and identity-verified legacy
+            runtimes. Arguments, environment variables, and private registration data are never exposed.
           </p>
         </div>
         <button
@@ -100,10 +102,10 @@ export function ProcessesPanel(): React.ReactElement {
       <div aria-label="Threadnote process inventory" className="process-list" role="list">
         {diagnostics === undefined ? (
           <p className="process-empty">Loading registered processes…</p>
-        ) : diagnostics.processes.length === 0 ? (
+        ) : displayedProcesses?.length === 0 ? (
           <p className="process-empty">No registered Threadnote processes are visible.</p>
         ) : (
-          diagnostics.processes.map(process => (
+          displayedProcesses?.map(process => (
             <article className="process-card" key={`${process.processId}:${process.startedAt}`} role="listitem">
               <div className="process-card-main">
                 <div className="process-card-title">
@@ -149,6 +151,32 @@ export function ProcessesPanel(): React.ReactElement {
       </div>
     </div>
   );
+}
+
+export function orderManagerProcessesForPresentation(
+  processes: readonly ManageableThreadnoteProcessDiagnostic[],
+): readonly ManageableThreadnoteProcessDiagnostic[] {
+  return processes
+    .map((process, inputIndex) => ({inputIndex, process}))
+    .sort(
+      (left, right) =>
+        processPresentationRank(left.process) - processPresentationRank(right.process) ||
+        left.process.startedAt.localeCompare(right.process.startedAt) ||
+        left.process.processId - right.process.processId ||
+        left.inputIndex - right.inputIndex,
+    )
+    .map(entry => entry.process);
+}
+
+function processPresentationRank(process: ManageableThreadnoteProcessDiagnostic): number {
+  if (process.role === 'legacy') return 2;
+  if (
+    process.activityRole !== undefined ||
+    (process.currentOperation !== undefined && process.currentOperation !== 'manager-ui')
+  ) {
+    return 0;
+  }
+  return 1;
 }
 
 function processRoleLabel(role: ManageableThreadnoteProcessDiagnostic['role']): string {

--- a/src/manager_processes_view.tsx
+++ b/src/manager_processes_view.tsx
@@ -5,6 +5,7 @@ import type {
   ManageableThreadnoteProcessDiagnostic,
   ManageableThreadnoteProcessDiagnostics,
 } from './process_diagnostics.js';
+import {orderThreadnoteProcessesByAttention} from './process_diagnostics.js';
 
 const PROCESS_POLL_MILLISECONDS = 2_000;
 
@@ -156,44 +157,7 @@ export function ProcessesPanel(): React.ReactElement {
 export function orderManagerProcessesForPresentation(
   processes: readonly ManageableThreadnoteProcessDiagnostic[],
 ): readonly ManageableThreadnoteProcessDiagnostic[] {
-  return processes
-    .map((process, inputIndex) => ({inputIndex, process}))
-    .sort(
-      (left, right) =>
-        processPresentationRank(left.process) - processPresentationRank(right.process) ||
-        left.process.startedAt.localeCompare(right.process.startedAt) ||
-        left.process.processId - right.process.processId ||
-        left.inputIndex - right.inputIndex,
-    )
-    .map(entry => entry.process);
-}
-
-function processPresentationRank(process: ManageableThreadnoteProcessDiagnostic): number {
-  if (process.role === 'legacy') return 2;
-  if (
-    process.activityRole !== undefined ||
-    (process.currentOperation !== undefined && !isProcessBaselineOperation(process))
-  ) {
-    return 0;
-  }
-  return 1;
-}
-
-function isProcessBaselineOperation(process: ManageableThreadnoteProcessDiagnostic): boolean {
-  switch (process.role) {
-    case 'manager':
-      return process.currentOperation === 'manager-ui';
-    case 'mcp':
-      return process.currentOperation === 'mcp-server';
-    case 'mcp-broker':
-      return process.currentOperation === 'mcp-broker';
-    case 'local-model-worker':
-      return process.currentOperation === 'model-stdio';
-    case 'graph-parser-worker':
-      return process.currentOperation === 'parser-stdio';
-    default:
-      return false;
-  }
+  return orderThreadnoteProcessesByAttention(processes);
 }
 
 function processRoleLabel(role: ManageableThreadnoteProcessDiagnostic['role']): string {

--- a/src/manager_processes_view.tsx
+++ b/src/manager_processes_view.tsx
@@ -172,11 +172,28 @@ function processPresentationRank(process: ManageableThreadnoteProcessDiagnostic)
   if (process.role === 'legacy') return 2;
   if (
     process.activityRole !== undefined ||
-    (process.currentOperation !== undefined && process.currentOperation !== 'manager-ui')
+    (process.currentOperation !== undefined && !isProcessBaselineOperation(process))
   ) {
     return 0;
   }
   return 1;
+}
+
+function isProcessBaselineOperation(process: ManageableThreadnoteProcessDiagnostic): boolean {
+  switch (process.role) {
+    case 'manager':
+      return process.currentOperation === 'manager-ui';
+    case 'mcp':
+      return process.currentOperation === 'mcp-server';
+    case 'mcp-broker':
+      return process.currentOperation === 'mcp-broker';
+    case 'local-model-worker':
+      return process.currentOperation === 'model-stdio';
+    case 'graph-parser-worker':
+      return process.currentOperation === 'parser-stdio';
+    default:
+      return false;
+  }
 }
 
 function processRoleLabel(role: ManageableThreadnoteProcessDiagnostic['role']): string {

--- a/src/manager_processes_view.tsx
+++ b/src/manager_processes_view.tsx
@@ -1,11 +1,11 @@
 import React, {useEffect, useState} from 'react';
 import {useManagerDialogs} from './manager_dialog.js';
+import {orderThreadnoteProcessesByAttention} from './process_attention.js';
 import {api, errorMessage} from './manager_ui_support.js';
 import type {
   ManageableThreadnoteProcessDiagnostic,
   ManageableThreadnoteProcessDiagnostics,
 } from './process_diagnostics.js';
-import {orderThreadnoteProcessesByAttention} from './process_diagnostics.js';
 
 const PROCESS_POLL_MILLISECONDS = 2_000;
 

--- a/src/process_attention.ts
+++ b/src/process_attention.ts
@@ -1,0 +1,44 @@
+import type {ThreadnoteProcessDiagnostic} from './process_diagnostics.js';
+
+export function orderThreadnoteProcessesByAttention<T extends ThreadnoteProcessDiagnostic>(
+  processes: readonly T[],
+): readonly T[] {
+  return processes
+    .map((process, inputIndex) => ({inputIndex, process}))
+    .sort(
+      (left, right) =>
+        processAttentionRank(left.process) - processAttentionRank(right.process) ||
+        left.process.startedAt.localeCompare(right.process.startedAt) ||
+        left.process.processId - right.process.processId ||
+        left.inputIndex - right.inputIndex,
+    )
+    .map(entry => entry.process);
+}
+
+function processAttentionRank(process: ThreadnoteProcessDiagnostic): number {
+  if (process.role === 'legacy') return 2;
+  if (
+    process.activityRole !== undefined ||
+    (process.currentOperation !== undefined && !isProcessBaselineOperation(process))
+  ) {
+    return 0;
+  }
+  return 1;
+}
+
+function isProcessBaselineOperation(process: ThreadnoteProcessDiagnostic): boolean {
+  switch (process.role) {
+    case 'manager':
+      return process.currentOperation === 'manager-ui';
+    case 'mcp':
+      return process.currentOperation === 'mcp-server';
+    case 'mcp-broker':
+      return process.currentOperation === 'mcp-broker';
+    case 'local-model-worker':
+      return process.currentOperation === 'model-stdio';
+    case 'graph-parser-worker':
+      return process.currentOperation === 'parser-stdio';
+    default:
+      return false;
+  }
+}

--- a/src/process_diagnostics.ts
+++ b/src/process_diagnostics.ts
@@ -4,6 +4,7 @@ import type {RuntimeConfig} from './types.js';
 import {SystemInfo} from './effect/system.js';
 import {readLiveStandaloneProcessLeases} from './standalone_process_lease.js';
 import {sha256HexSync} from './crypto/sha256.js';
+import {orderThreadnoteProcessesByAttention} from './process_attention.js';
 import {withoutTelemetrySessionEnvironment} from './telemetry/session.js';
 
 const PROCESS_DIAGNOSTICS_SCHEMA_VERSION = 1;
@@ -70,49 +71,6 @@ export interface ManageableThreadnoteProcessDiagnostics {
   readonly processes: readonly ManageableThreadnoteProcessDiagnostic[];
   readonly schemaVersion: typeof PROCESS_DIAGNOSTICS_SCHEMA_VERSION;
   readonly truncated: boolean;
-}
-
-export function orderThreadnoteProcessesByAttention<T extends ThreadnoteProcessDiagnostic>(
-  processes: readonly T[],
-): readonly T[] {
-  return processes
-    .map((process, inputIndex) => ({inputIndex, process}))
-    .sort(
-      (left, right) =>
-        processAttentionRank(left.process) - processAttentionRank(right.process) ||
-        left.process.startedAt.localeCompare(right.process.startedAt) ||
-        left.process.processId - right.process.processId ||
-        left.inputIndex - right.inputIndex,
-    )
-    .map(entry => entry.process);
-}
-
-function processAttentionRank(process: ThreadnoteProcessDiagnostic): number {
-  if (process.role === 'legacy') return 2;
-  if (
-    process.activityRole !== undefined ||
-    (process.currentOperation !== undefined && !isProcessBaselineOperation(process))
-  ) {
-    return 0;
-  }
-  return 1;
-}
-
-function isProcessBaselineOperation(process: ThreadnoteProcessDiagnostic): boolean {
-  switch (process.role) {
-    case 'manager':
-      return process.currentOperation === 'manager-ui';
-    case 'mcp':
-      return process.currentOperation === 'mcp-server';
-    case 'mcp-broker':
-      return process.currentOperation === 'mcp-broker';
-    case 'local-model-worker':
-      return process.currentOperation === 'model-stdio';
-    case 'graph-parser-worker':
-      return process.currentOperation === 'parser-stdio';
-    default:
-      return false;
-  }
 }
 
 export type ThreadnoteProcessTerminationErrorCode =

--- a/src/process_diagnostics.ts
+++ b/src/process_diagnostics.ts
@@ -72,6 +72,49 @@ export interface ManageableThreadnoteProcessDiagnostics {
   readonly truncated: boolean;
 }
 
+export function orderThreadnoteProcessesByAttention<T extends ThreadnoteProcessDiagnostic>(
+  processes: readonly T[],
+): readonly T[] {
+  return processes
+    .map((process, inputIndex) => ({inputIndex, process}))
+    .sort(
+      (left, right) =>
+        processAttentionRank(left.process) - processAttentionRank(right.process) ||
+        left.process.startedAt.localeCompare(right.process.startedAt) ||
+        left.process.processId - right.process.processId ||
+        left.inputIndex - right.inputIndex,
+    )
+    .map(entry => entry.process);
+}
+
+function processAttentionRank(process: ThreadnoteProcessDiagnostic): number {
+  if (process.role === 'legacy') return 2;
+  if (
+    process.activityRole !== undefined ||
+    (process.currentOperation !== undefined && !isProcessBaselineOperation(process))
+  ) {
+    return 0;
+  }
+  return 1;
+}
+
+function isProcessBaselineOperation(process: ThreadnoteProcessDiagnostic): boolean {
+  switch (process.role) {
+    case 'manager':
+      return process.currentOperation === 'manager-ui';
+    case 'mcp':
+      return process.currentOperation === 'mcp-server';
+    case 'mcp-broker':
+      return process.currentOperation === 'mcp-broker';
+    case 'local-model-worker':
+      return process.currentOperation === 'model-stdio';
+    case 'graph-parser-worker':
+      return process.currentOperation === 'parser-stdio';
+    default:
+      return false;
+  }
+}
+
 export type ThreadnoteProcessTerminationErrorCode =
   | 'current-manager'
   | 'invalid-process-target'
@@ -218,6 +261,7 @@ export function withThreadnoteProcessActivity<A, E, R>(
 
 const readThreadnoteProcessSnapshot = Effect.fn('processDiagnostics.readSnapshot')(function* (
   config: Pick<RuntimeConfig, 'agentContextHome'>,
+  selection: 'attention' | 'chronological' = 'chronological',
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -311,7 +355,10 @@ const readThreadnoteProcessSnapshot = Effect.fn('processDiagnostics.readSnapshot
   // Bound the OS memory query to the same privacy-safe rows the command can
   // return. A damaged private lease tree must not turn diagnostics into an
   // unbounded command line or PowerShell query.
-  const selected = candidates.slice(0, PROCESS_DIAGNOSTICS_LIMIT);
+  const selected = (selection === 'attention' ? orderThreadnoteProcessesByAttention(candidates) : candidates).slice(
+    0,
+    PROCESS_DIAGNOSTICS_LIMIT,
+  );
   const memoryByProcess = new Map(
     processMemoryBytes(
       selected.map(value => value.processId),
@@ -353,7 +400,7 @@ export const readManageableThreadnoteProcessDiagnostics = Effect.fn('processDiag
   config: Pick<RuntimeConfig, 'agentContextHome'>,
 ) {
   const system = yield* SystemInfo;
-  const snapshot = yield* readThreadnoteProcessSnapshot(config);
+  const snapshot = yield* readThreadnoteProcessSnapshot(config, 'attention');
   const diagnostics = snapshot.diagnostics;
   const processes: ManageableThreadnoteProcessDiagnostic[] = yield* Effect.forEach(
     diagnostics.processes,

--- a/test/unit/manager-processes-ui.test.ts
+++ b/test/unit/manager-processes-ui.test.ts
@@ -158,6 +158,30 @@ describe('Manager Processes panel', () => {
     );
   });
 
+  it('keeps idle service baselines behind active work even when the services are older', () => {
+    const process = (
+      processId: number,
+      role: ManageableThreadnoteProcessDiagnostic['role'],
+      currentOperation: string,
+    ): ManageableThreadnoteProcessDiagnostic => ({
+      ageMilliseconds: 1,
+      currentOperation,
+      parentProcessId: 1,
+      processId,
+      role,
+      startedAt: `2026-08-0${processId}T00:00:00.000Z`,
+      terminable: true,
+    });
+    const ordered = orderManagerProcessesForPresentation([
+      process(1, 'mcp', 'mcp-server'),
+      process(2, 'mcp-broker', 'mcp-broker'),
+      process(3, 'local-model-worker', 'model-stdio'),
+      process(4, 'graph-parser-worker', 'parser-stdio'),
+      process(5, 'cli', 'index-repository'),
+    ]);
+    expect(ordered.map(value => value.processId)).toEqual([5, 1, 2, 3, 4]);
+  });
+
   it('confirms termination and posts the exact opaque process reference with the PID', async () => {
     await renderProcesses();
     const stop = document.querySelector<HTMLButtonElement>(
@@ -221,10 +245,29 @@ function jsonResponse(body: unknown, status = 200): Response {
 const processDiagnosticArbitrary: FC.Arbitrary<ManageableThreadnoteProcessDiagnostic> = FC.record({
   activityRole: FC.option(FC.constant('graph-builder' as const), {nil: undefined}),
   ageMilliseconds: FC.nat(),
-  currentOperation: FC.option(FC.constantFrom('index-repository', 'manager-ui'), {nil: undefined}),
+  currentOperation: FC.option(
+    FC.constantFrom(
+      'index-repository',
+      'manager-ui',
+      'mcp-server',
+      'mcp-broker',
+      'model-stdio',
+      'parser-stdio',
+      'embed-many',
+    ),
+    {nil: undefined},
+  ),
   parentProcessId: FC.nat(),
   processId: FC.integer({min: 1, max: 1_000_000}),
-  role: FC.constantFrom('cli' as const, 'manager' as const, 'mcp' as const, 'legacy' as const),
+  role: FC.constantFrom(
+    'cli' as const,
+    'manager' as const,
+    'mcp' as const,
+    'mcp-broker' as const,
+    'local-model-worker' as const,
+    'graph-parser-worker' as const,
+    'legacy' as const,
+  ),
   startedAt: FC.date({
     max: new Date('2030-01-01T00:00:00.000Z'),
     min: new Date('2020-01-01T00:00:00.000Z'),
@@ -236,7 +279,17 @@ const processDiagnosticArbitrary: FC.Arbitrary<ManageableThreadnoteProcessDiagno
 function presentationRank(process: ManageableThreadnoteProcessDiagnostic): number {
   if (process.role === 'legacy') return 2;
   return process.activityRole !== undefined ||
-    (process.currentOperation !== undefined && process.currentOperation !== 'manager-ui')
+    (process.currentOperation !== undefined && !isBaselineOperationForRole(process.role, process.currentOperation))
     ? 0
     : 1;
+}
+
+function isBaselineOperationForRole(role: ManageableThreadnoteProcessDiagnostic['role'], operation: string): boolean {
+  return (
+    (role === 'manager' && operation === 'manager-ui') ||
+    (role === 'mcp' && operation === 'mcp-server') ||
+    (role === 'mcp-broker' && operation === 'mcp-broker') ||
+    (role === 'local-model-worker' && operation === 'model-stdio') ||
+    (role === 'graph-parser-worker' && operation === 'parser-stdio')
+  );
 }

--- a/test/unit/manager-processes-ui.test.ts
+++ b/test/unit/manager-processes-ui.test.ts
@@ -2,9 +2,11 @@
 
 import React, {act} from 'react';
 import {createRoot, type Root} from 'react-dom/client';
+import FC from 'fast-check';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {ManagerDialogProvider} from '../../src/manager_dialog.js';
-import {ProcessesPanel} from '../../src/manager_processes_view.js';
+import {orderManagerProcessesForPresentation, ProcessesPanel} from '../../src/manager_processes_view.js';
+import type {ManageableThreadnoteProcessDiagnostic} from '../../src/process_diagnostics.js';
 import {readFile} from '../helpers/node-fs-promises.js';
 import {join} from '../helpers/node-path.js';
 
@@ -27,6 +29,16 @@ beforeEach(() => {
     return Promise.resolve(
       jsonResponse({
         processes: [
+          {
+            ageMilliseconds: 86_400_000,
+            parentProcessId: 1,
+            processId: 80100,
+            releaseVersion: '4.3.8',
+            role: 'legacy',
+            startedAt: '2026-08-11T00:00:00.000Z',
+            terminable: false,
+            terminationBlockedReason: 'legacy-process',
+          },
           {
             ageMilliseconds: 540_000,
             currentOperation: 'compact-graph-storage',
@@ -91,7 +103,7 @@ describe('Manager Processes panel', () => {
     await renderProcesses();
     const processList = document.querySelector('[aria-label="Threadnote process inventory"]');
     expect(processList?.getAttribute('role')).toBe('list');
-    expect(processList?.querySelectorAll('[role="listitem"]')).toHaveLength(4);
+    expect(processList?.querySelectorAll('[role="listitem"]')).toHaveLength(5);
     expect(document.body.textContent).toContain('Graph compaction worker');
     expect(document.body.textContent).toContain('Compact graph storage');
     expect(document.body.textContent).toContain('Manager · PID 80276');
@@ -109,6 +121,41 @@ describe('Manager Processes panel', () => {
     expect(stop?.disabled).toBe(false);
     expect(managerStop?.title).toBe('The current Manager process is protected');
     expect(managerStop?.disabled).toBe(true);
+  });
+
+  it('puts active work ahead of idle registered and legacy runtimes', async () => {
+    await renderProcesses();
+    const titles = [...document.querySelectorAll('.process-card-title strong')].map(element => element.textContent);
+    expect(titles).toEqual([
+      'Graph compaction worker',
+      'MCP server',
+      'Graph query worker',
+      'Manager',
+      'Legacy runtime',
+    ]);
+    expect(document.body.textContent).toContain('Active operations appear first');
+  });
+
+  it('orders every process by attention rank without mutating the API response', () => {
+    FC.assert(
+      FC.property(
+        FC.uniqueArray(processDiagnosticArbitrary, {maxLength: 40, selector: process => process.processId}),
+        processes => {
+          const before = [...processes];
+          const ordered = orderManagerProcessesForPresentation(processes);
+          expect(processes).toEqual(before);
+          expect(ordered).toHaveLength(processes.length);
+          expect(new Set(ordered.map(process => process.processId))).toEqual(
+            new Set(processes.map(process => process.processId)),
+          );
+          expect(orderManagerProcessesForPresentation(processes)).toEqual(ordered);
+          for (let index = 1; index < ordered.length; index += 1) {
+            expect(presentationRank(ordered[index - 1]!)).toBeLessThanOrEqual(presentationRank(ordered[index]!));
+          }
+        },
+      ),
+      {numRuns: 100},
+    );
   });
 
   it('confirms termination and posts the exact opaque process reference with the PID', async () => {
@@ -169,4 +216,27 @@ async function waitForElement<T extends Element>(selector: string): Promise<T> {
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {headers: {'content-type': 'application/json'}, status});
+}
+
+const processDiagnosticArbitrary: FC.Arbitrary<ManageableThreadnoteProcessDiagnostic> = FC.record({
+  activityRole: FC.option(FC.constant('graph-builder' as const), {nil: undefined}),
+  ageMilliseconds: FC.nat(),
+  currentOperation: FC.option(FC.constantFrom('index-repository', 'manager-ui'), {nil: undefined}),
+  parentProcessId: FC.nat(),
+  processId: FC.integer({min: 1, max: 1_000_000}),
+  role: FC.constantFrom('cli' as const, 'manager' as const, 'mcp' as const, 'legacy' as const),
+  startedAt: FC.date({
+    max: new Date('2030-01-01T00:00:00.000Z'),
+    min: new Date('2020-01-01T00:00:00.000Z'),
+    noInvalidDate: true,
+  }).map(value => value.toISOString()),
+  terminable: FC.boolean(),
+});
+
+function presentationRank(process: ManageableThreadnoteProcessDiagnostic): number {
+  if (process.role === 'legacy') return 2;
+  return process.activityRole !== undefined ||
+    (process.currentOperation !== undefined && process.currentOperation !== 'manager-ui')
+    ? 0
+    : 1;
 }

--- a/test/unit/manager-processes-ui.test.ts
+++ b/test/unit/manager-processes-ui.test.ts
@@ -139,7 +139,11 @@ describe('Manager Processes panel', () => {
   it('orders every process by attention rank without mutating the API response', () => {
     FC.assert(
       FC.property(
-        FC.uniqueArray(processDiagnosticArbitrary, {maxLength: 40, selector: process => process.processId}),
+        FC.uniqueArray(processDiagnosticArbitrary, {
+          maxLength: 140,
+          minLength: 101,
+          selector: process => process.processId,
+        }),
         processes => {
           const before = [...processes];
           const ordered = orderManagerProcessesForPresentation(processes);
@@ -152,6 +156,7 @@ describe('Manager Processes panel', () => {
           for (let index = 1; index < ordered.length; index += 1) {
             expect(presentationRank(ordered[index - 1]!)).toBeLessThanOrEqual(presentationRank(ordered[index]!));
           }
+          expect(presentationRank(ordered[99]!)).toBeLessThanOrEqual(presentationRank(ordered[100]!));
         },
       ),
       {numRuns: 100},

--- a/test/unit/manager-processes.test.ts
+++ b/test/unit/manager-processes.test.ts
@@ -6,6 +6,7 @@ import {Effect, FileSystem} from 'effect';
 import {describe} from 'vitest';
 import {SystemInfo} from '../../src/effect/system.js';
 import {handleManagerProcessRequest} from '../../src/manager_processes.js';
+import {readThreadnoteProcessDiagnostics} from '../../src/process_diagnostics.js';
 import type {RuntimeConfig} from '../../src/types.js';
 
 describe('Manager process API', () => {
@@ -99,25 +100,86 @@ describe('Manager process API', () => {
       expect(signals).toEqual(['SIGTERM']);
     }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
   );
+
+  it.effect('retains active work when more than 100 older idle services truncate the Manager inventory', () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const nativeSystem = yield* SystemInfo;
+      const home = yield* fileSystem.makeTempDirectoryScoped({prefix: 'threadnote-manager-process-attention-'});
+      const idleProcessIds = Array.from({length: 100}, (_, index) => 1_235_000 + index);
+      const activeProcessId = 1_235_100;
+      yield* Effect.forEach(
+        idleProcessIds,
+        processId => writeRegistration(fileSystem, home, processId, `idle-token-${processId}`),
+        {concurrency: 8},
+      );
+      yield* writeRegistration(fileSystem, home, activeProcessId, 'active-process-token', {
+        baseRole: 'cli',
+        currentOperation: 'index-repository',
+        role: 'cli',
+        startedAt: '2026-08-27T00:00:00.000Z',
+      });
+      const liveProcessIds = new Set([...idleProcessIds, activeProcessId]);
+      const testSystem = SystemInfo.of({
+        ...nativeSystem,
+        isProcessRunning: processId => liveProcessIds.has(processId),
+        processStartIdentity: () => Effect.succeed('identity-a'),
+      });
+      const config = testConfig(home);
+      const listed = yield* handleManagerProcessRequest({
+        body: Effect.succeed({}),
+        config,
+        method: 'GET',
+        url: new URL('http://localhost/api/processes'),
+      }).pipe(Effect.provideService(SystemInfo, testSystem));
+      const managerInventory = listed!.body as {
+        readonly processes: readonly {readonly processId: number}[];
+        readonly truncated: boolean;
+      };
+      expect(managerInventory.truncated).toBe(true);
+      expect(managerInventory.processes).toHaveLength(100);
+      expect(managerInventory.processes[0]?.processId).toBe(activeProcessId);
+      expect(managerInventory.processes.some(process => process.processId === activeProcessId)).toBe(true);
+
+      const chronological = yield* readThreadnoteProcessDiagnostics({agentContextHome: home}).pipe(
+        Effect.provideService(SystemInfo, testSystem),
+      );
+      expect(chronological.truncated).toBe(true);
+      expect(chronological.processes).toHaveLength(100);
+      expect(chronological.processes.some(process => process.processId === activeProcessId)).toBe(false);
+    }).pipe(provideTestLayer(SystemInfo.layer), provideTestLayer(BunServices.layer), Effect.scoped),
+  );
 });
 
-function writeRegistration(fileSystem: FileSystem.FileSystem, home: string, processId: number, token: string) {
+function writeRegistration(
+  fileSystem: FileSystem.FileSystem,
+  home: string,
+  processId: number,
+  token: string,
+  options: {
+    readonly baseRole?: 'cli' | 'mcp';
+    readonly currentOperation?: string;
+    readonly role?: 'cli' | 'mcp';
+    readonly startedAt?: string;
+  } = {},
+) {
+  const startedAt = options.startedAt ?? '2026-08-12T00:00:00.000Z';
   return Effect.gen(function* () {
     const directory = join(home, 'runtime', 'processes');
     yield* fileSystem.makeDirectory(directory, {recursive: true});
     yield* fileSystem.writeFileString(
       join(directory, `${processId}.json`),
       `${JSON.stringify({
-        baseRole: 'mcp',
-        currentOperation: 'mcp-server',
+        baseRole: options.baseRole ?? 'mcp',
+        currentOperation: options.currentOperation ?? 'mcp-server',
         parentProcessId: 42,
         processId,
         processStartIdentity: 'identity-a',
-        role: 'mcp',
+        role: options.role ?? 'mcp',
         schemaVersion: 1,
-        startedAt: '2026-08-12T00:00:00.000Z',
+        startedAt,
         token,
-        updatedAt: '2026-08-12T00:00:00.000Z',
+        updatedAt: startedAt,
       })}\n`,
     );
   });


### PR DESCRIPTION
## Summary
- place active operations ahead of idle registered and legacy runtimes in Manager
- treat the long-lived Manager, MCP, broker, model, and parser base operations as idle while preserving nested and same-role work as active
- apply the same attention ordering before the Manager inventory bound, so newer active work cannot be truncated behind 100 older idle rows
- keep ordinary CLI process diagnostics chronological and preserve deterministic ordering within every attention tier

## Verification
- `bun --bun vitest run test/unit/manager-processes-ui.test.ts test/unit/manager-processes.test.ts test/unit/process-diagnostics.test.ts` (27/27)
- `bun run typecheck`
- `bun run lint`
- focused Prettier and `git diff --check`
- 100-run Fast-check property over 101–140 unique rows, including the 100-row selection boundary
- concrete 101-row Manager/API regression proving active retention and unchanged CLI chronology

## Dogfood evidence
Post-release v4.4.1 browser QA showed live Workset and graph-builder processes below many day-old legacy sessions. The released Manager remained responsive and the actual process tree proved two repository indexers plus parser-worker pools were running concurrently; this patch makes that active work visible at the top, including when the bounded inventory is truncated.