### PR TITLE
fix: keep bounded impact reads non-indexing

### DIFF
--- a/src/code_graph/isolated_impact_query.ts
+++ b/src/code_graph/isolated_impact_query.ts
@@ -2,7 +2,7 @@ import {Effect, Stdio, Stream} from 'effect';
 import {CommandExecutor, CommandTimedOut, type CommandExecutionError} from '../effect/command.js';
 import {SystemInfo, type SystemInfoShape} from '../effect/system.js';
 import {CODE_GRAPH_IMPACT_QUERY_WORKER_ARGUMENT} from '../worker_protocol.js';
-import {CodeGraphQueryService} from './query.js';
+import {CodeGraphQueryService, type CodeGraphInspectOptions} from './query.js';
 import type {CodeGraphQueryResult} from './types.js';
 
 const CODE_GRAPH_IMPACT_QUERY_PROTOCOL = 1 as const;
@@ -111,37 +111,44 @@ export const codeGraphImpactQueryWorkerProgram = (threadnoteHome: string) =>
     const response =
       request === undefined || request.threadnoteHome !== threadnoteHome
         ? ({ok: false, protocol: CODE_GRAPH_IMPACT_QUERY_PROTOCOL} as const)
-        : yield* query
-            .inspect({
-              ...(request.baseCommit === undefined ? {} : {baseCommit: request.baseCommit}),
-              cwd: request.cwd,
-              depth: request.depth,
-              edgeLimit: request.edgeLimit,
-              includeHeuristic: request.includeHeuristic,
-              includeModelAssociations: request.includeModelAssociations,
-              nodeLimit: request.nodeLimit,
-              operation: 'impact',
-              query: request.query,
-              refresh: false,
-              requestMaintenance: false,
-              seedQueryCount: request.seedQueryCount,
-              seedQueries: request.seedQueries,
-              strictFreshness: true,
-              threadnoteHome,
-            })
-            .pipe(
-              Effect.match({
-                onFailure: () => ({ok: false, protocol: CODE_GRAPH_IMPACT_QUERY_PROTOCOL}) as const,
-                onSuccess: result =>
-                  ({
-                    ok: true,
-                    protocol: CODE_GRAPH_IMPACT_QUERY_PROTOCOL,
-                    result,
-                  }) as const satisfies CodeGraphImpactQueryResponse,
-              }),
-            );
+        : yield* query.inspect(impactQueryWorkerInspectOptions(request, threadnoteHome)).pipe(
+            Effect.match({
+              onFailure: () => ({ok: false, protocol: CODE_GRAPH_IMPACT_QUERY_PROTOCOL}) as const,
+              onSuccess: result =>
+                ({
+                  ok: true,
+                  protocol: CODE_GRAPH_IMPACT_QUERY_PROTOCOL,
+                  result,
+                }) as const satisfies CodeGraphImpactQueryResponse,
+            }),
+          );
     yield* writeImpactQueryWorkerResponse(response);
   }).pipe(Effect.catch(() => Effect.void));
+
+/** @internal Keep the bounded read worker incapable of starting base-commit indexing. */
+export function impactQueryWorkerInspectOptions(
+  request: CodeGraphImpactQueryRequest,
+  threadnoteHome: string,
+): CodeGraphInspectOptions {
+  return {
+    ...(request.baseCommit === undefined ? {} : {baseCommit: request.baseCommit}),
+    baseCommitPolicy: 'ready-only',
+    cwd: request.cwd,
+    depth: request.depth,
+    edgeLimit: request.edgeLimit,
+    includeHeuristic: request.includeHeuristic,
+    includeModelAssociations: request.includeModelAssociations,
+    nodeLimit: request.nodeLimit,
+    operation: 'impact',
+    query: request.query,
+    refresh: false,
+    requestMaintenance: false,
+    seedQueryCount: request.seedQueryCount,
+    seedQueries: request.seedQueries,
+    strictFreshness: true,
+    threadnoteHome,
+  };
+}
 
 function encodeImpactQueryRequest(input: IsolatedCodeGraphImpactQueryInput): Uint8Array {
   const seedQueries = input.seedQueries?.slice(0, CODE_GRAPH_IMPACT_QUERY_SEED_LIMIT);

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -69,6 +69,7 @@ export type {
 } from './query_contract.js';
 import {codeGraphSymbolSearchScoreMultiplier, CodeGraphStore, type CodeGraphStoreShape} from './store.js';
 import {CodeGraphEmbeddingIndex, type CodeGraphEmbeddingIndexShape} from './embedding.js';
+import {addUnavailableImpactBaseWarning} from './query_impact_base.js';
 import {
   CODE_GRAPH_RESULT_VERSION,
   CodeGraphRepositoryError,
@@ -88,6 +89,8 @@ import {
 
 export interface CodeGraphInspectOptions extends CodeGraphQueryOptions {
   readonly baseCommit?: string;
+  /** @internal Bounded read workers may reuse a ready base but must never start repository-sized indexing. */
+  readonly baseCommitPolicy?: 'ensure' | 'ready-only';
   readonly interlock?: CodeGraphQueryInterlock;
   /** @internal Evidence harnesses can isolate query work from the detached maintenance lane. */
   readonly requestMaintenance?: boolean;
@@ -577,6 +580,33 @@ export class CodeGraphQueryService extends Context.Service<
                   return result;
                 });
               if (options.operation === 'impact' && options.baseCommit) {
+                if (options.baseCommitPolicy === 'ready-only') {
+                  const readyBase = yield* store.readySnapshotForCommit(
+                    layout.databasePath,
+                    identity.repositoryId,
+                    options.baseCommit,
+                  );
+                  const readyBaseCurrent = readyBase
+                    ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, readyBase, languagePacks)
+                    : false;
+                  const result =
+                    readyBase && readyBaseCurrent
+                      ? yield* Effect.acquireUseRelease(
+                          store
+                            .acquireSnapshotLease(layout.databasePath, readyBase.id, 2 * 60_000)
+                            .pipe(Effect.map(leaseToken => ({leaseToken, snapshot: readyBase}))),
+                          base => inspect(base.snapshot.id),
+                          base =>
+                            store
+                              .releaseSnapshotLease(layout.databasePath, base.leaseToken)
+                              .pipe(Effect.catch(() => Effect.void)),
+                        )
+                      : addUnavailableImpactBaseWarning(yield* inspect());
+                  if (options.requestMaintenance !== false) {
+                    yield* requestMaintenance(options.threadnoteHome, identity);
+                  }
+                  return result;
+                }
                 const result = yield* Effect.acquireUseRelease(
                   indexer.ensureCommit({
                     commit: options.baseCommit,

--- a/src/code_graph/query_impact_base.ts
+++ b/src/code_graph/query_impact_base.ts
@@ -1,0 +1,11 @@
+import type {CodeGraphQueryResult} from './types.js';
+
+export function addUnavailableImpactBaseWarning(result: CodeGraphQueryResult): CodeGraphQueryResult {
+  return {
+    ...result,
+    warnings: [
+      ...result.warnings,
+      'The requested impact base has no ready current-format snapshot; deleted-path recovery was skipped without starting indexing.',
+    ],
+  };
+}

--- a/test/unit/code-graph.isolated-impact-query.test.ts
+++ b/test/unit/code-graph.isolated-impact-query.test.ts
@@ -6,6 +6,7 @@ import {describe, expect, it} from 'vitest';
 import {
   decodeImpactQueryRequest,
   impactQueryTransportSelector,
+  impactQueryWorkerInspectOptions,
   impactQueryWorkerEnvironment,
   impactQueryWorkerInvocation,
   inspectCodeGraphImpactIsolated,
@@ -197,6 +198,25 @@ describe('isolated code graph impact query', () => {
     const oversizedLegacySelector = 'src/very-long-private-path.ts '.repeat(3_000);
     expect(impactQueryTransportSelector(oversizedLegacySelector, ['src/a.ts'])).toBe('changed paths');
     expect(impactQueryTransportSelector('cgs_symbol', undefined)).toBe('cgs_symbol');
+  });
+
+  it('keeps the bounded worker on ready-only base evidence', () => {
+    const request = decodeImpactQueryRequest(
+      JSON.stringify({
+        ...input,
+        protocol: 1,
+        query: 'changed paths',
+        seedQueryCount: input.seedQueries.length,
+      }),
+    );
+    expect(request).toBeDefined();
+    expect(impactQueryWorkerInspectOptions(request!, input.threadnoteHome)).toMatchObject({
+      baseCommit: input.baseCommit,
+      baseCommitPolicy: 'ready-only',
+      refresh: false,
+      requestMaintenance: false,
+      strictFreshness: true,
+    });
   });
 
   it('rejects NUL-bearing, over-count, and non-SHA protocol fields', () => {

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -178,6 +178,15 @@ describe('code graph query budgets', () => {
           }),
         );
         const snapshotRef = yield* Ref.make<CodeGraphSnapshot | undefined>(undefined);
+        const readyBaseRef = yield* Ref.make<CodeGraphSnapshot | undefined>(undefined);
+        const baseLookups = yield* Ref.make<readonly {databasePath: string; repositoryId: string; commit: string}[]>(
+          [],
+        );
+        const leaseEvents = yield* Ref.make<readonly string[]>([]);
+        const searchedSnapshotIds = yield* Ref.make<readonly string[]>([]);
+        const failPathSearch = yield* Ref.make(false);
+        const ensureCommitCalls = yield* Ref.make(0);
+        const readyBaseSnapshotId = `cgsn_${'2'.repeat(40)}`;
         const emptyStoreReads = () => ({
           leasesAcquired: 0,
           leasesReleased: 0,
@@ -193,16 +202,35 @@ describe('code graph query budgets', () => {
         const storeLayer = Layer.succeed(
           CodeGraphStore,
           CodeGraphStore.of({
-            acquireSnapshotLease: () => recordStoreRead('leasesAcquired').pipe(Effect.as('lease')),
-            edgesForNodes: () => Effect.succeed([]),
+            acquireSnapshotLease: (_databasePath: string, snapshotId: string) =>
+              recordStoreRead('leasesAcquired').pipe(
+                Effect.andThen(Ref.update(leaseEvents, current => [...current, `acquire:${snapshotId}`])),
+                Effect.as(`lease:${snapshotId}`),
+              ),
+            edgesForNodes: (_databasePath: string, snapshotId: string, ids: readonly string[]) =>
+              Effect.succeed(snapshotId === readyBaseSnapshotId && ids.includes(stableSeed.id) ? [stableEdge] : []),
             readySnapshot: () => recordStoreRead('readyByWorktree').pipe(Effect.andThen(Ref.get(snapshotRef))),
             readySnapshotById: () => recordStoreRead('readyById').pipe(Effect.andThen(Ref.get(snapshotRef))),
-            readySnapshotForCommit: () => Effect.succeed(undefined),
-            releaseSnapshotLease: () => recordStoreRead('leasesReleased'),
-            searchSymbolsByPaths: (_databasePath: string, _snapshotId: string, queries: readonly string[]) =>
-              Effect.succeed(queries.map(() => [])),
+            readySnapshotForCommit: (databasePath: string, repositoryId: string, commit: string) =>
+              Ref.update(baseLookups, current => [...current, {commit, databasePath, repositoryId}]).pipe(
+                Effect.andThen(Ref.get(readyBaseRef)),
+              ),
+            releaseSnapshotLease: (_databasePath: string, leaseToken: string) =>
+              recordStoreRead('leasesReleased').pipe(
+                Effect.andThen(Ref.update(leaseEvents, current => [...current, `release:${leaseToken}`])),
+              ),
+            searchSymbolsByPaths: (_databasePath: string, snapshotId: string, queries: readonly string[]) =>
+              Ref.update(searchedSnapshotIds, current => [...current, snapshotId]).pipe(
+                Effect.andThen(Ref.get(failPathSearch)),
+                Effect.flatMap(fail =>
+                  fail
+                    ? Effect.fail(new TestError('bounded impact read failed'))
+                    : Effect.succeed(queries.map(() => (snapshotId === readyBaseSnapshotId ? [stableSeed] : []))),
+                ),
+              ),
             snapshotPackProvenance: () => recordStoreRead('provenance').pipe(Effect.as([])),
-            symbolsByIds: () => Effect.succeed([]),
+            symbolsByIds: (_databasePath: string, _snapshotId: string, ids: readonly string[]) =>
+              Effect.succeed([stableSeed, stableDependent].filter(node => ids.includes(node.id))),
             withSession: (_databasePath: string, effect: Effect.Effect<unknown, unknown, unknown>) =>
               Ref.update(sessionCalls, value => value + 1).pipe(Effect.andThen(effect)),
           } as unknown as CodeGraphStoreShape),
@@ -217,7 +245,10 @@ describe('code graph query budgets', () => {
           Layer.succeed(
             CodeGraphIndexer,
             CodeGraphIndexer.of({
-              ensureCommit: () => Effect.die(new TestError('query trigger test must not ensure a commit')),
+              ensureCommit: () =>
+                Ref.update(ensureCommitCalls, count => count + 1).pipe(
+                  Effect.andThen(Effect.fail(new TestError('query trigger test must not ensure a commit'))),
+                ),
               index: () => Effect.die(new TestError('query trigger test must not index')),
             }),
           ),
@@ -371,6 +402,7 @@ describe('code graph query budgets', () => {
             readyById: 0,
             readyByWorktree: 1,
           });
+          expect(yield* Ref.get(ensureCommitCalls)).toBe(0);
           for (const refresh of [undefined, true] as const) {
             yield* Ref.set(storeReads, emptyStoreReads());
             const refreshedInspection = yield* query.inspect({
@@ -449,6 +481,91 @@ describe('code graph query budgets', () => {
           expect(boundedImpact.warnings).toContain(
             'The requested impact base has no ready current-format snapshot; deleted-path recovery was skipped without starting indexing.',
           );
+
+          const readyBase = {
+            ...snapshot,
+            commit: 'f'.repeat(40),
+            dirty: false,
+            id: readyBaseSnapshotId,
+            worktreeId: 'base-worktree',
+          } satisfies CodeGraphSnapshot;
+          yield* Ref.set(readyBaseRef, readyBase);
+          yield* Ref.set(baseLookups, []);
+          yield* Ref.set(leaseEvents, []);
+          yield* Ref.set(searchedSnapshotIds, []);
+          yield* Ref.set(storeReads, emptyStoreReads());
+          const readyBaseImpact = yield* query.inspect({
+            baseCommit: readyBase.commit,
+            baseCommitPolicy: 'ready-only',
+            cwd: fixtureRoot.repository,
+            depth: 1,
+            operation: 'impact',
+            query: 'changed paths',
+            refresh: false,
+            requestMaintenance: false,
+            seedQueries: ['deleted.ts'],
+            strictFreshness: true,
+            threadnoteHome: fixtureRoot.home,
+          });
+          expect(readyBaseImpact.nodes.map(node => node.id)).toContain(stableDependent.id);
+          expect(readyBaseImpact.warnings.join('\n')).toContain(`base snapshot ${readyBaseSnapshotId}`);
+          expect(readyBaseImpact.warnings.join('\n')).not.toContain('deleted-path recovery was skipped');
+          expect(yield* Ref.get(baseLookups)).toEqual([
+            {
+              commit: readyBase.commit,
+              databasePath: join(
+                fixtureRoot.home,
+                'indexes',
+                'code-graph',
+                'repositories',
+                identity.checkoutId,
+                'graph-v3.sqlite',
+              ),
+              repositoryId: identity.repositoryId,
+            },
+          ]);
+          expect(yield* Ref.get(searchedSnapshotIds)).toEqual([snapshot.id, readyBaseSnapshotId]);
+          expect(yield* Ref.get(leaseEvents)).toEqual([
+            `acquire:${readyBaseSnapshotId}`,
+            `acquire:${snapshot.id}`,
+            `release:lease:${snapshot.id}`,
+            `release:lease:${readyBaseSnapshotId}`,
+          ]);
+          expect(yield* Ref.get(ensureCommitCalls)).toBe(0);
+          expect(yield* Ref.get(storeReads)).toEqual({
+            leasesAcquired: 2,
+            leasesReleased: 2,
+            provenance: 2,
+            readyById: 0,
+            readyByWorktree: 1,
+          });
+
+          yield* Ref.set(failPathSearch, true);
+          yield* Ref.set(leaseEvents, []);
+          const failedReadyBaseImpact = yield* query
+            .inspect({
+              baseCommit: readyBase.commit,
+              baseCommitPolicy: 'ready-only',
+              cwd: fixtureRoot.repository,
+              operation: 'impact',
+              query: 'changed paths',
+              refresh: false,
+              requestMaintenance: false,
+              seedQueries: ['deleted.ts'],
+              strictFreshness: true,
+              threadnoteHome: fixtureRoot.home,
+            })
+            .pipe(Effect.flip);
+          expect(failedReadyBaseImpact).toEqual(new TestError('bounded impact read failed'));
+          expect(yield* Ref.get(leaseEvents)).toEqual([
+            `acquire:${readyBaseSnapshotId}`,
+            `acquire:${snapshot.id}`,
+            `release:lease:${snapshot.id}`,
+            `release:lease:${readyBaseSnapshotId}`,
+          ]);
+          expect(yield* Ref.get(ensureCommitCalls)).toBe(0);
+          yield* Ref.set(failPathSearch, false);
+          yield* Ref.set(readyBaseRef, undefined);
 
           yield* Ref.set(storeReads, emptyStoreReads());
           const fallbackInspection = yield* query.inspect({

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -194,10 +194,13 @@ describe('code graph query budgets', () => {
           CodeGraphStore,
           CodeGraphStore.of({
             acquireSnapshotLease: () => recordStoreRead('leasesAcquired').pipe(Effect.as('lease')),
+            edgesForNodes: () => Effect.succeed([]),
             readySnapshot: () => recordStoreRead('readyByWorktree').pipe(Effect.andThen(Ref.get(snapshotRef))),
             readySnapshotById: () => recordStoreRead('readyById').pipe(Effect.andThen(Ref.get(snapshotRef))),
             readySnapshotForCommit: () => Effect.succeed(undefined),
             releaseSnapshotLease: () => recordStoreRead('leasesReleased'),
+            searchSymbolsByPaths: (_databasePath: string, _snapshotId: string, queries: readonly string[]) =>
+              Effect.succeed(queries.map(() => [])),
             snapshotPackProvenance: () => recordStoreRead('provenance').pipe(Effect.as([])),
             symbolsByIds: () => Effect.succeed([]),
             withSession: (_databasePath: string, effect: Effect.Effect<unknown, unknown, unknown>) =>
@@ -429,6 +432,23 @@ describe('code graph query budgets', () => {
             readyById: 0,
             readyByWorktree: 1,
           });
+
+          const boundedImpact = yield* query.inspect({
+            baseCommit: 'f'.repeat(40),
+            baseCommitPolicy: 'ready-only',
+            cwd: fixtureRoot.repository,
+            operation: 'impact',
+            query: 'changed paths',
+            refresh: false,
+            requestMaintenance: false,
+            seedQueries: ['deleted.ts'],
+            strictFreshness: true,
+            threadnoteHome: fixtureRoot.home,
+          });
+          expect(boundedImpact.freshness).toBe('current');
+          expect(boundedImpact.warnings).toContain(
+            'The requested impact base has no ready current-format snapshot; deleted-path recovery was skipped without starting indexing.',
+          );
 
           yield* Ref.set(storeReads, emptyStoreReads());
           const fallbackInspection = yield* query.inspect({


### PR DESCRIPTION
## Summary

- prevent the 20-second isolated MCP impact-read worker from starting repository-sized base-commit indexing
- reuse a ready current-format base snapshot when one exists
- otherwise return current impact evidence with an explicit deleted-path recovery warning
- preserve ordinary CLI and unbounded query behavior, which still ensures the requested base commit

## Root cause

The signal-transparent impact worker introduced by #257 calls `query.inspect` with `baseCommit`. That path calls `indexer.ensureCommit(base)`. When the base snapshot is cold and its build takes longer than the worker's fixed 20-second budget, the parent intentionally terminates the worker and leaves the persistent build checkpoint resumable. Repeated bounded reads could therefore spend their entire budget indexing instead of returning impact evidence.

## Verification

- `bun --bun vitest run test/unit/code-graph.isolated-impact-query.test.ts test/unit/code-graph.query.test.ts` (23/23)
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- actual-process source smoke against a fresh isolated home: absent base returned in 1 second, warning present, SQLite snapshot states `ready=1`, `building=0`

The regression test makes the bounded worker's indexer fail if called and verifies the ready-only fallback warning. Property testing was assessed; this is a single fixed process-boundary policy with no meaningful variable state space beyond the focused side-effect regression, so no new property was added.