### PR TITLE
test: harden Windows release metadata probes

### DIFF
--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -1,3 +1,4 @@
+import {TestError} from '../helpers/test-error.js';
 import {execFile} from '../helpers/node-child-process.js';
 import {mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
@@ -9,6 +10,8 @@ import {expect, it} from 'vitest';
 
 const execute = promisify(execFile);
 const windowsIt = process.platform === 'win32' ? it : it.skip;
+const releaseMetadataProbeTimeoutMilliseconds = 180_000;
+const failureOutputLimit = 8_192;
 
 windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release', async () => {
   const root = await mkdtemp(join(tmpdir(), 'threadnote windows bootstrap-'));
@@ -127,14 +130,12 @@ windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release
           THREADNOTE_RELEASE_DOWNLOAD_ROOT: `http://127.0.0.1:${server.port}/selection`,
           THREADNOTE_RELEASE_SOURCE: `http://127.0.0.1:${server.port}/stable-winner-releases`,
         },
-        timeout: 60_000,
+        timeout: releaseMetadataProbeTimeoutMilliseconds,
       }).catch((cause: unknown) => cause);
-      expect(String((stableWinnerFailure as {readonly stdout?: unknown}).stdout)).toContain(
-        'Downloading Threadnote 9.0.0',
-      );
-      expect(String((stableWinnerFailure as {readonly stderr?: unknown}).stderr)).toContain(
-        'Release metadata does not match Threadnote 9.0.0',
-      );
+      expectInstallerFailure(stableWinnerFailure, 'stable-winner release metadata probe', {
+        stderr: 'Release metadata does not match Threadnote 9.0.0',
+        stdout: 'Downloading Threadnote 9.0.0',
+      });
       const stableOnlyFailure = await execute(
         join(powerShellDirectory, 'powershell.exe'),
         installerArguments.filter(argument => argument !== '-Beta'),
@@ -145,15 +146,13 @@ windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release
             THREADNOTE_INSTALL_ROOT: join(root, 'stable-only-install'),
             THREADNOTE_RELEASE_DOWNLOAD_ROOT: `http://127.0.0.1:${server.port}/selection`,
           },
-          timeout: 60_000,
+          timeout: releaseMetadataProbeTimeoutMilliseconds,
         },
       ).catch((cause: unknown) => cause);
-      expect(String((stableOnlyFailure as {readonly stdout?: unknown}).stdout)).toContain(
-        'Downloading Threadnote 4.1.1',
-      );
-      expect(String((stableOnlyFailure as {readonly stderr?: unknown}).stderr)).toContain(
-        'Release metadata does not match Threadnote 4.1.1',
-      );
+      expectInstallerFailure(stableOnlyFailure, 'stable-only release metadata probe', {
+        stderr: 'Release metadata does not match Threadnote 4.1.1',
+        stdout: 'Downloading Threadnote 4.1.1',
+      });
       for (const rejectedVersion of ['4.0.0-beta.6', '4.0.0-beta.5', '4.0.0-beta.4']) {
         const requestsBefore = assetRequests.length;
         const failure = await execute(join(powerShellDirectory, 'powershell.exe'), installerArguments, {
@@ -282,3 +281,41 @@ windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release
     await rm(root, {force: true, recursive: true});
   }
 });
+
+function expectInstallerFailure(
+  outcome: unknown,
+  scenario: string,
+  expected: {readonly stderr: string; readonly stdout: string},
+): void {
+  const failure = outcome as {
+    readonly code?: unknown;
+    readonly killed?: boolean;
+    readonly signal?: unknown;
+    readonly stderr?: unknown;
+    readonly stdout?: unknown;
+  };
+  const stderr = String(failure.stderr ?? '');
+  const stdout = String(failure.stdout ?? '');
+  const diagnostics = boundedFailureOutput(
+    `code: ${String(failure.code ?? 'unknown')}\nkilled: ${String(failure.killed ?? false)}\nsignal: ${String(
+      failure.signal ?? 'none',
+    )}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+  );
+  if (!(outcome instanceof Error)) {
+    throw new TestError(`${scenario} unexpectedly succeeded.\n${diagnostics}`);
+  }
+  if (failure.killed === true) {
+    throw new TestError(
+      `${scenario} exceeded the ${releaseMetadataProbeTimeoutMilliseconds} ms deadline (signal ${String(
+        failure.signal ?? 'unknown',
+      )}).\n${diagnostics}`,
+      {cause: outcome},
+    );
+  }
+  expect(stdout, diagnostics).toContain(expected.stdout);
+  expect(stderr, diagnostics).toContain(expected.stderr);
+}
+
+function boundedFailureOutput(output: string): string {
+  return output.length <= failureOutputLimit ? output : `${output.slice(0, failureOutputLimit)}\n[output truncated]`;
+}


### PR DESCRIPTION
## Summary

- give the two full-archive Windows release-metadata probes a named 180-second deadline
- fail explicitly when PowerShell is killed by the deadline or unexpectedly succeeds
- retain the original download and metadata-mismatch assertions, with bounded combined stdout/stderr diagnostics

## Evidence

The first attempt of CI run 33120526488 failed only the Windows self-contained job: the test reached `Downloading Threadnote 9.0.0`, then its hard-coded 60-second child-process timeout fired before the metadata rejection, producing empty stderr. The same exact head passed on attempt 2 (job 98688351285); the full Windows installer test completed in 69.846 seconds. That pass/fail split confirms a load-sensitive test bound rather than a changed installer contract.

Focused local checks after rebasing onto current main:

- strict oxlint for the changed E2E file
- Prettier check for the changed E2E file
- test TypeScript project typecheck
- targeted Vitest import/collection (expected skip on macOS; PowerShell E2E remains Windows CI-only)
- `git diff --check`

Property testing is not applicable: this is a platform subprocess wall-clock bound and diagnostic harness, with no meaningful generated input space or invariant.