### PR TITLE
fix(manager): index configured projects without snapshots

### DIFF
--- a/manager/app.css
+++ b/manager/app.css
@@ -1156,10 +1156,66 @@ dd {
 }
 
 .graph-administration-toolbar button,
+.graph-configured-project-controls button,
 .graph-database-actions button {
   font-size: 10px;
   min-height: 30px;
   padding: 5px 9px;
+}
+
+.graph-configured-project-index {
+  background: rgba(103, 232, 199, 0.035);
+  border: 1px solid var(--accent-line);
+  border-radius: 9px;
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+}
+
+.graph-configured-project-index > header {
+  display: grid;
+  gap: 2px;
+}
+
+.graph-configured-project-index > header small,
+.graph-configured-project-detail {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.graph-configured-project-controls {
+  align-items: end;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(180px, 0.85fr) minmax(180px, 1.15fr) auto;
+  min-width: 0;
+}
+
+.graph-configured-project-controls label {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.graph-configured-project-controls label > span {
+  color: var(--dim);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.graph-configured-project-controls select,
+.graph-configured-project-detail {
+  min-width: 0;
+  width: 100%;
+}
+
+.graph-configured-project-detail {
+  overflow: hidden;
+  padding-bottom: 7px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .graph-force-compact {
@@ -3728,6 +3784,19 @@ dd {
 
   .graph-control-actions {
     grid-template-columns: 1fr;
+  }
+
+  .graph-configured-project-controls {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .graph-configured-project-controls button {
+    width: 100%;
+  }
+
+  .graph-configured-project-detail {
+    padding-bottom: 0;
   }
 
   .graph-filterbar {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -87,6 +87,7 @@ import {
   isManagerWorksetApiPath,
   managerWorksetRequestAllowedDuringMaintenance,
 } from './manager_worksets.js';
+import * as graphProjects from './manager_graph_projects.js';
 import {
   cleanupMode,
   consolidationAgent,
@@ -127,7 +128,6 @@ import {removeCodeGraphView, renderCodeGraphViewRemovalResult} from './code_grap
 import {
   managerGraphAnalysis,
   managerGraphBuildCatalog,
-  managerGraphCatalog,
   managerGraphCatalogPage,
   managerGraphNodeDetail,
   managerGraphQuery,
@@ -167,6 +167,7 @@ interface ManagerDirectoryEntry {
 class ManagerOperationError extends Error {
   readonly _tag = 'ManagerOperationError' as const;
 }
+
 function managerOperationError(cause: unknown): ManagerOperationError {
   return cause instanceof ManagerOperationError ? cause : new ManagerOperationError(errorMessage(cause), {cause});
 }
@@ -534,6 +535,8 @@ function handleRequestEffect(
           writeJson(response, 409, {code: 'graph-view-stale', error: error.message, retryAfterMilliseconds: 0});
           return;
         }
+        if (error instanceof graphProjects.ManagerGraphProjectActionError)
+          return writeJson(response, 409, {code: error.code, error: error.message, retryAfterMilliseconds: 0});
         writeJson(response, 500, {error: errorMessage(error)});
       }),
     ),
@@ -599,10 +602,8 @@ const handleRequestLegacy = Effect.fn('manager.handleRequestLegacy')(function* (
     writeJson(response, 200, {resourcesTree: resourceTree, tree});
     return;
   }
-  if (request.method === 'GET' && url.pathname === '/api/graphs') {
-    writeJson(response, 200, yield* managerGraphCatalog(context.config.agentContextHome));
-    return;
-  }
+  if (request.method === 'GET' && url.pathname === '/api/graphs')
+    return writeJson(response, 200, yield* graphProjects.managerGraphProjectCatalog(context.config));
   if (request.method === 'GET' && url.pathname === '/api/graphs/status') {
     const automaticCompaction = context.automaticCompactionStatus
       ? yield* Ref.get(context.automaticCompactionStatus)
@@ -1607,6 +1608,7 @@ const runManagerGraphAction = Effect.fn('manager.runGraphAction')(function* (
   if (action === 'purge-all') {
     return yield* runCaptured(() => runCodeGraphPurge(config, {all: true, dryRun}), runEffect);
   }
+  if (action === 'index-project') return yield* graphProjects.runManagerManifestProjectGraphIndex(config, body);
   const checkoutId = yield* Effect.try({
     try: () => requireGraphIdentity(body.checkoutId, 'checkoutId'),
     catch: managerOperationError,

--- a/src/manager_graph.tsx
+++ b/src/manager_graph.tsx
@@ -48,6 +48,7 @@ export {
   type GraphCatalog,
   type GraphCatalogEmptyState,
   type GraphCatalogDiagnostic,
+  type GraphConfiguredProject,
   type GraphCatalogPage,
   type GraphCatalogSearchOptions,
   type GraphEdge,

--- a/src/manager_graph_model.ts
+++ b/src/manager_graph_model.ts
@@ -82,13 +82,22 @@ export interface GraphCatalogDiagnostic {
   readonly message: string;
 }
 
+export interface GraphConfiguredProject {
+  readonly folder: string;
+  readonly graphState: 'not-indexed' | 'ready' | 'unknown';
+  readonly name: string;
+  readonly path: string;
+}
+
 export interface GraphCatalog {
   readonly automaticCompaction?: CodeGraphAutomaticCompactionStatus;
   readonly builds: readonly GraphBuildStatus[];
   readonly catalogRevision?: string;
+  readonly configuredProjects?: readonly GraphConfiguredProject[];
   readonly diagnostics: readonly GraphCatalogDiagnostic[];
   readonly lifecyclePending?: boolean;
   readonly maintenance?: CodeGraphMaintenanceStatus;
+  readonly manifestRevision?: string;
   readonly repositories: readonly GraphRepositoryGroup[];
   readonly storage?: Readonly<Record<string, ManagerGraphStorageSummary>>;
   readonly waiterCount: number;
@@ -105,6 +114,12 @@ export type GraphAdministrationAction =
       readonly full?: boolean;
       readonly repositoryId: string;
       readonly worktreeId: string;
+    }
+  | {
+      readonly action: 'index-project';
+      readonly expectedRevision: string;
+      readonly full?: boolean;
+      readonly project: string;
     }
   | {
       readonly action: 'purge' | 'purge-obsolete';

--- a/src/manager_graph_panels.tsx
+++ b/src/manager_graph_panels.tsx
@@ -30,6 +30,7 @@ import {
   type GraphAdministrationAction,
   type GraphAnalysis,
   type GraphBuildStatus,
+  type GraphConfiguredProject,
   type GraphEdge,
   type GraphMaterializationRows,
   type GraphMaterializationStage,
@@ -459,6 +460,8 @@ export function NodeInspector(props: {
 
 export function GraphAdministration(props: {
   readonly busy?: string;
+  readonly configuredProjects?: readonly GraphConfiguredProject[];
+  readonly expectedManifestRevision?: string;
   readonly onAction: (action: GraphAdministrationAction) => void;
   readonly onDiagnostics: (options: {readonly analyze: boolean; readonly deep: boolean}) => void;
   readonly output?: string;
@@ -468,7 +471,10 @@ export function GraphAdministration(props: {
   const [analyze, setAnalyze] = useState(false);
   const [deep, setDeep] = useState(false);
   const [forceCompact, setForceCompact] = useState(false);
+  const [selectedProjectName, setSelectedProjectName] = useState('');
   const blocked = props.busy !== undefined;
+  const selectedProject =
+    props.configuredProjects?.find(project => project.name === selectedProjectName) ?? props.configuredProjects?.[0];
   const confirmAction = async (options: ManagerDialogOptions, action: GraphAdministrationAction): Promise<void> => {
     if (await dialogs.confirm(options)) props.onAction(action);
   };
@@ -523,6 +529,57 @@ export function GraphAdministration(props: {
         </span>
       </summary>
       <div className="graph-administration-body">
+        {props.configuredProjects === undefined ? null : (
+          <section className="graph-configured-project-index">
+            <header>
+              <strong>Configured projects</strong>
+              <small>Initialize a missing graph, or refresh an existing ready snapshot, from this Manager.</small>
+            </header>
+            <div className="graph-configured-project-controls">
+              <label>
+                <span>Project</span>
+                <select
+                  disabled={blocked || props.configuredProjects.length === 0}
+                  onChange={event => setSelectedProjectName(event.target.value)}
+                  value={selectedProject?.name ?? ''}
+                >
+                  {props.configuredProjects.length === 0 ? (
+                    <option value="">No configured projects</option>
+                  ) : (
+                    props.configuredProjects.map(project => (
+                      <option key={project.name} value={project.name}>
+                        {project.name} · {graphConfiguredProjectStateLabel(project.graphState)}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </label>
+              <span className="graph-configured-project-detail" title={selectedProject?.path}>
+                {selectedProject
+                  ? `${graphConfiguredProjectStateDetail(selectedProject.graphState)} · ${selectedProject.path}`
+                  : 'Add a project to the seed manifest before indexing from Manager.'}
+              </span>
+              <button
+                disabled={blocked || !selectedProject || !props.expectedManifestRevision}
+                onClick={() => {
+                  if (!selectedProject || !props.expectedManifestRevision) return;
+                  props.onAction({
+                    action: 'index-project',
+                    expectedRevision: props.expectedManifestRevision,
+                    project: selectedProject.name,
+                  });
+                }}
+                type="button"
+              >
+                {selectedProject?.graphState === 'ready'
+                  ? 'Refresh graph'
+                  : selectedProject?.graphState === 'unknown'
+                    ? 'Index / refresh graph'
+                    : 'Index graph'}
+              </button>
+            </div>
+          </section>
+        )}
         <div className="graph-administration-toolbar">
           <label className="check-row">
             <input
@@ -928,6 +985,28 @@ export function GraphAdministration(props: {
       </div>
     </details>
   );
+}
+
+function graphConfiguredProjectStateLabel(state: GraphConfiguredProject['graphState']): string {
+  switch (state) {
+    case 'not-indexed':
+      return 'needs initialization';
+    case 'ready':
+      return 'ready snapshot';
+    case 'unknown':
+      return 'ready state not shown';
+  }
+}
+
+function graphConfiguredProjectStateDetail(state: GraphConfiguredProject['graphState']): string {
+  switch (state) {
+    case 'not-indexed':
+      return 'No ready snapshot';
+    case 'ready':
+      return 'Ready snapshot';
+    case 'unknown':
+      return 'Ready state is outside the bounded catalog';
+  }
 }
 
 export function GraphMaintenanceProgress(props: {
@@ -1514,11 +1593,14 @@ function formatGraphPercentage(completed: number, total: number): string {
 }
 
 export function GraphEmptyState(props: {
+  readonly configuredProjectCount?: number;
+  readonly onOpenAdministration?: () => void;
   readonly state: 'building' | 'empty' | 'recovering' | 'retrying';
 }): React.ReactElement {
   const building = props.state === 'building';
   const recovering = props.state === 'recovering';
   const retrying = props.state === 'retrying';
+  const hasConfiguredProjects = (props.configuredProjectCount ?? 0) > 0;
   return (
     <div className="graph-empty">
       <span className="empty-orbit" aria-hidden="true" />
@@ -1538,9 +1620,17 @@ export function GraphEmptyState(props: {
             ? 'Threadnote is retrying the indexed repository catalog. Existing indexes will return here automatically.'
             : building
               ? 'The newest phase and counters appear above. A ready snapshot will open here automatically.'
-              : 'Build a native graph from a repository, then refresh this workspace.'}
+              : hasConfiguredProjects
+                ? `${props.configuredProjectCount?.toLocaleString()} configured project${props.configuredProjectCount === 1 ? ' is' : 's are'} ready to initialize from Manager.`
+                : 'Build a native graph from a repository, then refresh this workspace.'}
       </p>
-      {building || recovering || retrying ? null : <code>threadnote graph index</code>}
+      {building || recovering || retrying ? null : hasConfiguredProjects ? (
+        <button onClick={props.onOpenAdministration} type="button">
+          Choose a configured project
+        </button>
+      ) : (
+        <code>threadnote graph index</code>
+      )}
     </div>
   );
 }

--- a/src/manager_graph_projects.ts
+++ b/src/manager_graph_projects.ts
@@ -1,0 +1,291 @@
+import {Console, Effect, FileSystem, Option, Path} from 'effect';
+import {runIsolatedCodeGraphIndexSnapshot} from './code_graph/isolated_index.js';
+import {resolveAndRecordCodeGraphLocalAssociation} from './code_graph/local_provenance.js';
+import type {RepositoryIdentityExpectation} from './code_graph/types.js';
+import {managerGraphCatalog} from './code_graph/visualization.js';
+import {sha256HexSync} from './crypto/sha256.js';
+import {captureConsole} from './effect/console.js';
+import {parseSeedManifest} from './manifest.js';
+import type {GraphCatalog, GraphConfiguredProject} from './manager_graph_model.js';
+import {managerProjectPathIsForeign, observeManagerManifestProjects} from './manager_project_roots.js';
+import {requireString} from './manager_request_inputs.js';
+import {SystemInfo} from './effect/system.js';
+import type {ProjectManifest, RuntimeConfig, SeedManifest} from './types.js';
+import {expandPath} from './utils.js';
+
+const UTF8 = new TextEncoder();
+const MANAGER_GRAPH_PROJECT_MAXIMUM = 4_096;
+const MANAGER_GRAPH_PROJECT_NAME_BYTES_MAXIMUM = 256;
+const MANAGER_GRAPH_PROJECT_PATH_BYTES_MAXIMUM = 4_096;
+
+interface ManagerGraphManifestProject {
+  readonly display: {
+    readonly folder: string;
+    readonly name: string;
+    readonly path: string;
+  };
+  readonly manifest: ProjectManifest;
+}
+
+interface ManagerGraphManifestCatalog {
+  readonly projects: readonly ManagerGraphManifestProject[];
+  readonly revision: string;
+}
+
+class ManagerGraphProjectCatalogError extends Error {
+  readonly _tag = 'ManagerGraphProjectCatalogError' as const;
+}
+
+export class ManagerGraphProjectActionError extends Error {
+  readonly _tag = 'ManagerGraphProjectActionError' as const;
+
+  constructor(
+    readonly code: 'graph-project-stale' | 'graph-project-unavailable',
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/** Add a bounded manifest inventory without making Graph Manager spawn branch probes. */
+export const managerGraphProjectCatalog = Effect.fn('managerGraphProjects.catalogWithConfiguredProjects')(function* (
+  config: RuntimeConfig,
+) {
+  const [catalog, manifestCatalog] = yield* Effect.all(
+    [
+      managerGraphCatalog(config.agentContextHome),
+      readManagerGraphManifestCatalog(config).pipe(Effect.option),
+    ] as const,
+    {concurrency: 2},
+  );
+  if (Option.isNone(manifestCatalog)) return catalog;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const graphCatalog: GraphCatalog = catalog;
+  const readyWorktreePaths = graphCatalog.repositories.flatMap(repository =>
+    repository.views.flatMap(view =>
+      view.localAssociation.state === 'verified' && view.localAssociation.path ? [view.localAssociation.path] : [],
+    ),
+  );
+  const readinessMayBeTruncated = graphCatalog.repositories.some(repository => repository.viewsTruncated);
+  const configuredProjects = yield* Effect.forEach(
+    manifestCatalog.value.projects,
+    project =>
+      configuredProjectGraphState(
+        fs,
+        path,
+        system.platform,
+        project.manifest.path,
+        readyWorktreePaths,
+        readinessMayBeTruncated,
+      ).pipe(Effect.map(graphState => ({...project.display, graphState}) satisfies GraphConfiguredProject)),
+    {concurrency: 16},
+  );
+  return {
+    ...catalog,
+    configuredProjects,
+    manifestRevision: manifestCatalog.value.revision,
+  } satisfies GraphCatalog;
+});
+
+export const runManagerManifestProjectGraphIndex = Effect.fn('managerGraphProjects.runManifestProjectGraphIndex')(
+  function* (config: RuntimeConfig, body: Record<string, unknown>) {
+    const projectName = yield* Effect.try({
+      try: () => requireString(body.project, 'project'),
+      catch: cause => new ManagerGraphProjectActionError('graph-project-unavailable', String(cause)),
+    });
+    const expectedRevision = yield* Effect.try({
+      try: () => requireManifestRevision(body.expectedRevision),
+      catch: cause => new ManagerGraphProjectActionError('graph-project-unavailable', String(cause)),
+    });
+    const catalog = yield* readManagerGraphManifestCatalog(config).pipe(
+      Effect.mapError(
+        () =>
+          new ManagerGraphProjectActionError(
+            'graph-project-unavailable',
+            'Configured projects could not be read. Refresh Manager and retry.',
+          ),
+      ),
+    );
+    if (catalog.revision !== expectedRevision) {
+      return yield* Effect.fail(
+        new ManagerGraphProjectActionError(
+          'graph-project-stale',
+          'Configured projects changed. Refresh Manager before choosing a project to index.',
+        ),
+      );
+    }
+    const project = catalog.projects.find(
+      candidate => candidate.manifest.name.toLowerCase() === projectName.toLowerCase(),
+    );
+    if (!project) {
+      return yield* Effect.fail(
+        new ManagerGraphProjectActionError(
+          'graph-project-stale',
+          'The selected configured project is no longer available. Refresh Manager and choose again.',
+        ),
+      );
+    }
+    const {identity} = yield* Effect.gen(function* () {
+      const system = yield* SystemInfo;
+      if (managerProjectPathIsForeign(project.manifest.path, system.platform)) {
+        return yield* Effect.fail(new ManagerGraphProjectCatalogError('Configured project path is for another host.'));
+      }
+      const exactPath = yield* expandPath(project.manifest.path);
+      return yield* resolveAndRecordCodeGraphLocalAssociation(config.agentContextHome, exactPath);
+    }).pipe(
+      Effect.mapError(
+        () =>
+          new ManagerGraphProjectActionError(
+            'graph-project-unavailable',
+            'The selected configured project is not an available local Git repository. Check its manifest path and retry.',
+          ),
+      ),
+    );
+    const expectedIdentity = {
+      checkoutId: identity.checkoutId,
+      repositoryId: identity.repositoryId,
+      worktreeId: identity.worktreeId,
+    } satisfies RepositoryIdentityExpectation;
+    const captured = yield* captureConsole(
+      runIsolatedCodeGraphIndexSnapshot({
+        cwd: identity.repoRoot,
+        expectedIdentity,
+        force: body.full === true,
+        threadnoteHome: config.agentContextHome,
+      }).pipe(
+        Effect.flatMap(summary =>
+          Console.log(
+            `Ready in an isolated process · ${summary.snapshot.fileCount.toLocaleString()} files · ` +
+              `${summary.snapshot.symbolCount.toLocaleString()} symbols · ` +
+              `${summary.snapshot.edgeCount.toLocaleString()} edges`,
+          ),
+        ),
+      ),
+    );
+    return {output: captured.output};
+  },
+);
+
+const readManagerGraphManifestCatalog = Effect.fn('managerGraphProjects.readManifestCatalog')(function* (
+  config: RuntimeConfig,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const raw = yield* fs.readFileString(config.manifestPath);
+  const manifest = yield* Effect.try({
+    try: () => parseSeedManifest(raw, config.manifestPath),
+    catch: () => new ManagerGraphProjectCatalogError('Configured projects could not be parsed.'),
+  });
+  yield* Effect.try({
+    try: () => assertManagerGraphProjectManifest(manifest),
+    catch: cause =>
+      cause instanceof ManagerGraphProjectCatalogError
+        ? cause
+        : new ManagerGraphProjectCatalogError('Configured projects are invalid.'),
+  });
+  const observed = yield* observeManagerManifestProjects(manifest.projects, 0);
+  return {
+    projects: observed.map((display, index) => ({
+      display: {folder: display.folder, name: display.name, path: display.path},
+      manifest: manifest.projects[index]!,
+    })),
+    revision: sha256HexSync(raw),
+  } satisfies ManagerGraphManifestCatalog;
+});
+
+function configuredProjectGraphState(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  platform: NodeJS.Platform,
+  manifestPath: string,
+  readyWorktreePaths: readonly string[],
+  readinessMayBeTruncated: boolean,
+) {
+  const foreignState = foreignConfiguredProjectGraphState(manifestPath, platform, readinessMayBeTruncated);
+  if (foreignState !== undefined) return Effect.succeed(foreignState);
+  if (readyWorktreePaths.length === 0) {
+    return Effect.succeed(readinessMayBeTruncated ? ('unknown' as const) : ('not-indexed' as const));
+  }
+  return Effect.gen(function* () {
+    const expandedPath = yield* expandPath(manifestPath);
+    const canonicalPath = yield* fs.realPath(expandedPath).pipe(Effect.option);
+    if (
+      Option.isSome(canonicalPath) &&
+      canonicalConfiguredProjectHasReadyGraph(path, canonicalPath.value, readyWorktreePaths)
+    ) {
+      return 'ready' as const;
+    }
+    return readinessMayBeTruncated ? ('unknown' as const) : ('not-indexed' as const);
+  });
+}
+
+export function foreignConfiguredProjectGraphState(
+  manifestPath: string,
+  platform: NodeJS.Platform,
+  readinessMayBeTruncated: boolean,
+): GraphConfiguredProject['graphState'] | undefined {
+  if (!managerProjectPathIsForeign(manifestPath, platform)) return undefined;
+  return readinessMayBeTruncated ? 'unknown' : 'not-indexed';
+}
+
+export function canonicalConfiguredProjectHasReadyGraph(
+  path: Path.Path,
+  projectPath: string,
+  readyWorktreePaths: readonly string[],
+): boolean {
+  return readyWorktreePaths.some(worktreePath => {
+    if (!path.isAbsolute(projectPath) || !path.isAbsolute(worktreePath)) return false;
+    const relative = path.relative(worktreePath, projectPath);
+    return (
+      relative === '' || (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
+    );
+  });
+}
+
+function assertManagerGraphProjectManifest(manifest: SeedManifest): void {
+  if (manifest.projects.length > MANAGER_GRAPH_PROJECT_MAXIMUM) {
+    throw new ManagerGraphProjectCatalogError('The seed manifest has too many configured projects.');
+  }
+  const names = new Set<string>();
+  for (const project of manifest.projects) {
+    if (!managerGraphProjectNameIsSafe(project.name) || !managerGraphProjectPathIsSafe(project.path)) {
+      throw new ManagerGraphProjectCatalogError('A configured project name or path is invalid.');
+    }
+    const key = project.name.toLowerCase();
+    if (names.has(key)) throw new ManagerGraphProjectCatalogError('Configured project names must be unique.');
+    names.add(key);
+  }
+}
+
+function managerGraphProjectNameIsSafe(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value === value.trim() &&
+    UTF8.encode(value).byteLength <= MANAGER_GRAPH_PROJECT_NAME_BYTES_MAXIMUM &&
+    !hasControlCharacter(value)
+  );
+}
+
+function managerGraphProjectPathIsSafe(value: string): boolean {
+  return (
+    value.length > 0 &&
+    UTF8.encode(value).byteLength <= MANAGER_GRAPH_PROJECT_PATH_BYTES_MAXIMUM &&
+    !hasControlCharacter(value)
+  );
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some(character => {
+    const code = character.codePointAt(0) ?? 0;
+    return code <= 31 || code === 127;
+  });
+}
+
+function requireManifestRevision(value: unknown): string {
+  const revision = requireString(value, 'expectedRevision');
+  if (!/^[0-9a-f]{64}$/.test(revision)) {
+    throw new ManagerGraphProjectCatalogError('Provide expectedRevision as an exact manifest revision.');
+  }
+  return revision;
+}

--- a/src/manager_graph_workspace.tsx
+++ b/src/manager_graph_workspace.tsx
@@ -722,6 +722,8 @@ export function GraphWorkspace(props: {
         <div className="graph-notices">
           <GraphAdministration
             busy={props.administrationBusy}
+            configuredProjects={props.catalog?.configuredProjects}
+            expectedManifestRevision={props.catalog?.manifestRevision}
             onAction={props.onAdministrationAction ?? (() => undefined)}
             onDiagnostics={props.onDiagnostics ?? (() => undefined)}
             output={props.administrationOutput}
@@ -1132,7 +1134,11 @@ export function GraphWorkspace(props: {
                 <span>Loading indexed repositories…</span>
               </div>
             ) : repositories.length === 0 ? (
-              <GraphEmptyState state={emptyState} />
+              <GraphEmptyState
+                configuredProjectCount={props.catalog.configuredProjects?.length ?? 0}
+                onOpenAdministration={() => setActiveTab('administration')}
+                state={emptyState}
+              />
             ) : activeQuery && selectedRepositoryIsIndexing && !queryGraph ? (
               <div aria-live="polite" className="graph-loading" role="status">
                 <span className="spinner" aria-hidden="true" />

--- a/src/manager_ui.tsx
+++ b/src/manager_ui.tsx
@@ -528,7 +528,7 @@ function App(): React.ReactElement {
       } else {
         result = await api<{readonly output: string}>('/api/graphs/action', {
           ...action,
-          confirm: action.dryRun !== true,
+          confirm: !('dryRun' in action) || action.dryRun !== true,
         });
       }
       await refreshGraphCatalog(false);

--- a/src/manager_ui_support.tsx
+++ b/src/manager_ui_support.tsx
@@ -209,6 +209,8 @@ export function graphAdministrationActionLabel(action: GraphAdministrationAction
       return action.dryRun ? 'Compaction preview' : 'Graph compaction';
     case 'index':
       return action.full ? 'Graph reindex' : 'Graph index';
+    case 'index-project':
+      return action.full ? 'Configured project reindex' : 'Configured project index';
     case 'purge':
       return action.dryRun ? 'Graph purge preview' : 'Graph purge';
     case 'purge-all':

--- a/test/unit/manager-graph-projects.property.test.ts
+++ b/test/unit/manager-graph-projects.property.test.ts
@@ -1,0 +1,40 @@
+import * as BunPath from '@effect/platform-bun/BunPath';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, Path} from 'effect';
+import fc from 'fast-check';
+import {expect} from 'vitest';
+import {
+  canonicalConfiguredProjectHasReadyGraph,
+  foreignConfiguredProjectGraphState,
+} from '../../src/manager_graph_projects.js';
+import {managerProjectPathIsForeign} from '../../src/manager_project_roots.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const pathSegment = fc
+  .string({minLength: 1, maxLength: 24, unit: fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789-_')})
+  .filter(value => value !== '..');
+
+effectIt.effect.prop(
+  'recognizes only canonical descendants at a complete path boundary (property)',
+  {segment: pathSegment},
+  ({segment}) =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const readyRoot = path.join(path.sep, 'repos', 'app');
+      const nestedProject = path.join(readyRoot, 'packages', segment);
+      const prefixSibling = `${readyRoot}-${segment}`;
+
+      expect(canonicalConfiguredProjectHasReadyGraph(path, readyRoot, [readyRoot])).toBe(true);
+      expect(canonicalConfiguredProjectHasReadyGraph(path, nestedProject, [readyRoot])).toBe(true);
+      expect(canonicalConfiguredProjectHasReadyGraph(path, prefixSibling, [readyRoot])).toBe(false);
+      expect(managerProjectPathIsForeign(`C:\\${segment}`, 'linux')).toBe(true);
+      expect(managerProjectPathIsForeign(`C:/${segment}`, 'darwin')).toBe(true);
+      expect(managerProjectPathIsForeign(`/${segment}`, 'win32')).toBe(true);
+      expect(managerProjectPathIsForeign(`/${segment}`, 'linux')).toBe(false);
+      expect(managerProjectPathIsForeign(`C:\\${segment}`, 'win32')).toBe(false);
+      expect(foreignConfiguredProjectGraphState(`C:\\${segment}`, 'linux', false)).toBe('not-indexed');
+      expect(foreignConfiguredProjectGraphState(`/${segment}`, 'win32', true)).toBe('unknown');
+      expect(foreignConfiguredProjectGraphState(`/${segment}`, 'linux', false)).toBeUndefined();
+    }).pipe(provideTestLayer(BunPath.layer)),
+  {fastCheck: {numRuns: 64}},
+);

--- a/test/unit/manager-graph.test.ts
+++ b/test/unit/manager-graph.test.ts
@@ -227,6 +227,85 @@ describe('manager graph focus', () => {
     expect(css).toMatch(/\.graph-administration\[open\] \.graph-administration-caret\s*{[^}]*rotate\(0deg\)/s);
   });
 
+  it('offers configured projects for first-time indexing and distinguishes ready snapshots', () => {
+    const neverResolves = () => new Promise<never>(() => undefined);
+    const markup = renderToStaticMarkup(
+      createElement(GraphWorkspace, {
+        catalog: {
+          builds: [],
+          configuredProjects: [
+            {
+              folder: 'cold-project',
+              graphState: 'not-indexed',
+              name: 'cold-project',
+              path: '/repos/cold-project',
+            },
+            {
+              folder: 'ready-project',
+              graphState: 'ready',
+              name: 'ready-project',
+              path: '/repos/ready-project',
+            },
+            {
+              folder: 'hidden-project',
+              graphState: 'unknown',
+              name: 'hidden-project',
+              path: '/repos/hidden-project',
+            },
+          ],
+          diagnostics: [],
+          manifestRevision: 'a'.repeat(64),
+          repositories: [],
+          waiterCount: 0,
+          waiters: [],
+        },
+        loadAnalysis: neverResolves,
+        loadCatalogPage: neverResolves,
+        loadGraph: neverResolves,
+        loadNodeDetail: neverResolves,
+        loadQuery: neverResolves,
+        loadViewsPage: neverResolves,
+        onAdministrationAction: () => undefined,
+        onRefresh: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('<strong>Configured projects</strong>');
+    expect(markup).toContain('cold-project · needs initialization');
+    expect(markup).toContain('ready-project · ready snapshot');
+    expect(markup).toContain('hidden-project · ready state not shown');
+    expect(markup).toContain('No ready snapshot · /repos/cold-project');
+    expect(markup).toContain('>Index graph</button>');
+    expect(markup).toContain('3 configured projects are ready to initialize from Manager.');
+    expect(markup).toContain('>Choose a configured project</button>');
+    expect(markup).not.toContain('<code>threadnote graph index</code>');
+
+    const emptyMarkup = renderToStaticMarkup(
+      createElement(GraphWorkspace, {
+        catalog: {
+          builds: [],
+          configuredProjects: [],
+          diagnostics: [],
+          manifestRevision: 'a'.repeat(64),
+          repositories: [],
+          waiterCount: 0,
+          waiters: [],
+        },
+        loadAnalysis: neverResolves,
+        loadCatalogPage: neverResolves,
+        loadGraph: neverResolves,
+        loadNodeDetail: neverResolves,
+        loadQuery: neverResolves,
+        loadViewsPage: neverResolves,
+        onAdministrationAction: () => undefined,
+        onRefresh: () => undefined,
+      }),
+    );
+    expect(emptyMarkup).toContain('No configured projects');
+    expect(emptyMarkup).toMatch(/<button disabled="" type="button">Index graph<\/button>/);
+    expect(emptyMarkup).toContain('<code>threadnote graph index</code>');
+  });
+
   it('orders build status banners by stable folder or checkout identity', () => {
     const earlier = {
       ...graphBuildStatus('running'),
@@ -676,14 +755,28 @@ describe('manager graph focus', () => {
       snapshotId: `cgsn_${'b'.repeat(40)}-direct`,
       total: 5,
     };
+    const configuredProject = {
+      folder: 'cold-project',
+      graphState: 'not-indexed' as const,
+      name: 'cold-project',
+      path: '/repos/cold-project',
+    };
     const afterMaintenance = mergeGraphCatalogStatus(
-      {...merged, catalogRevision: 'visible-revision', maintenance: previousMaintenance},
+      {
+        ...merged,
+        catalogRevision: 'visible-revision',
+        configuredProjects: [configuredProject],
+        maintenance: previousMaintenance,
+        manifestRevision: 'manifest-revision',
+      },
       {builds: [reclaiming], lifecyclePending: false, waiterCount: 0, waiters: []},
     );
     expect(afterMaintenance.catalogRevision).toBe('visible-revision');
     expect(afterMaintenance.maintenance).toBeUndefined();
     expect(afterMaintenance.automaticCompaction).toEqual(merged.automaticCompaction);
     expect(afterMaintenance.storage).toEqual(merged.storage);
+    expect(afterMaintenance.configuredProjects).toEqual([configuredProject]);
+    expect(afterMaintenance.manifestRevision).toBe('manifest-revision');
   });
 
   it('shows only a bounded actionable administration job summary', () => {

--- a/test/unit/manager.test.ts
+++ b/test/unit/manager.test.ts
@@ -32,9 +32,13 @@ import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {withMemoryUriLocks} from '../../src/effect/memory_lock.js';
 import {withSharedRepositoryLock} from '../../src/effect/share_lock.js';
 import * as automaticCompaction from '../../src/code_graph/automatic_compaction.js';
+import * as isolatedIndex from '../../src/code_graph/isolated_index.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {makeCodeGraphBuildReporter} from '../../src/code_graph/build_status.js';
-import {recordVerifiedCodeGraphLocalAssociation} from '../../src/code_graph/local_provenance.js';
+import {
+  readCodeGraphLocalAssociation,
+  recordVerifiedCodeGraphLocalAssociation,
+} from '../../src/code_graph/local_provenance.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
 import {
   withCodeGraphMaintenanceIntent,
@@ -53,6 +57,7 @@ import {
 import {runEffect} from '../helpers/effect-runtime.js';
 import {createMemoryCodeCitation, MEMORY_SCHEMA_VERSION} from '../../src/memory_code_citation.js';
 import {formatMemoryDocument, parseMemoryDocument} from '../../src/memory_document.js';
+import {sha256HexSync} from '../../src/crypto/sha256.js';
 
 const MANAGER_GRAPH_SNAPSHOT_ID = `cgsn_${'1'.repeat(40)}`;
 const MANAGER_GRAPH_REPLACEMENT_SNAPSHOT_ID = `cgsn_${'2'.repeat(40)}`;
@@ -91,6 +96,11 @@ vi.mock('../../src/seeding.js', async importOriginal => {
 vi.mock('../../src/code_graph/automatic_compaction.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/code_graph/automatic_compaction.js')>();
   return {...actual, compactCodeGraphStorageIsolated: vi.fn(actual.compactCodeGraphStorageIsolated)};
+});
+
+vi.mock('../../src/code_graph/isolated_index.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../src/code_graph/isolated_index.js')>();
+  return {...actual, runIsolatedCodeGraphIndexSnapshot: vi.fn(actual.runIsolatedCodeGraphIndexSnapshot)};
 });
 
 async function makeRuntime(): Promise<RuntimeConfig> {
@@ -673,6 +683,7 @@ describe('manager http API', () => {
 
   beforeEach(() => {
     vi.mocked(automaticCompaction.compactCodeGraphStorageIsolated).mockClear();
+    vi.mocked(isolatedIndex.runIsolatedCodeGraphIndexSnapshot).mockClear();
     vi.mocked(lifecycle.runRepair)
       .mockReset()
       .mockImplementation((_config, options) => Console.log(options.dryRun ? 'repair dry run' : 'repair applied'));
@@ -1879,6 +1890,285 @@ describe('manager http API', () => {
       expect(analysisResponse.status).toBe(200);
       expect(analysis.statistics).toMatchObject({analyzedEdgeCount: 1_602, analyzedNodeCount: 523});
       expect(analysis.trust.classification).toBe('untrusted-repository-data');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('exposes and isolated-indexes a configured project before any graph database exists', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const repositoryRoot = join(config.agentContextHome, 'configured-project');
+    const secondRepositoryRoot = join(config.agentContextHome, 'second-project');
+    initializeGitRepository(repositoryRoot);
+    initializeGitRepository(secondRepositoryRoot);
+    const identity = await runEffect(resolveRepositoryIdentity(repositoryRoot));
+    const secondIdentity = await runEffect(resolveRepositoryIdentity(secondRepositoryRoot));
+    const manifestFor = (projectPath: string): string =>
+      [
+        'version: 1',
+        'projects:',
+        '  - name: configured-project',
+        `    path: ${JSON.stringify(projectPath)}`,
+        '    uri: threadnote://resources/repos/configured-project',
+        '    seed: []',
+        '',
+      ].join('\n');
+    await writeFile(config.manifestPath, manifestFor(repositoryRoot));
+    const snapshot: CodeGraphSnapshot = {
+      commit: identity.headCommit,
+      completedAt: '2026-08-27T12:00:00.000Z',
+      dirty: false,
+      edgeCount: 0,
+      extractorSet: CODE_GRAPH_EXTRACTOR_SET_VERSION,
+      fileCount: 1,
+      id: `cgsn_${'9'.repeat(40)}-direct`,
+      repositoryId: identity.repositoryId,
+      state: 'ready',
+      symbolCount: 2,
+      worktreeId: identity.worktreeId,
+    };
+    const secondSnapshot = {
+      ...snapshot,
+      commit: secondIdentity.headCommit,
+      id: `cgsn_${'8'.repeat(40)}-direct`,
+      repositoryId: secondIdentity.repositoryId,
+      worktreeId: secondIdentity.worktreeId,
+    } satisfies CodeGraphSnapshot;
+    vi.mocked(isolatedIndex.runIsolatedCodeGraphIndexSnapshot)
+      .mockReturnValueOnce(Effect.succeed({durationMs: 1, identity, snapshot}))
+      .mockReturnValueOnce(Effect.succeed({durationMs: 1, identity: secondIdentity, snapshot: secondSnapshot}))
+      .mockReturnValueOnce(Effect.succeed({durationMs: 1, identity, snapshot}));
+    const server = await startServer(config, 'secret');
+    try {
+      const headers = {authorization: 'Bearer secret', 'content-type': 'application/json'};
+      const response = await fetch(`${server.url}/api/graphs`, {headers});
+      const catalog = (await response.json()) as {
+        readonly configuredProjects: readonly {
+          readonly graphState: string;
+          readonly name: string;
+          readonly path: string;
+        }[];
+        readonly manifestRevision: string;
+        readonly repositories: readonly unknown[];
+      };
+      expect(response.status).toBe(200);
+      expect(catalog.repositories).toEqual([]);
+      expect(catalog.configuredProjects).toEqual([
+        {
+          folder: 'configured-project',
+          graphState: 'not-indexed',
+          name: 'configured-project',
+          path: repositoryRoot,
+        },
+      ]);
+      expect(catalog.manifestRevision).toMatch(/^[0-9a-f]{64}$/);
+
+      const indexResponse = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({
+          action: 'index-project',
+          expectedRevision: catalog.manifestRevision,
+          project: 'configured-project',
+        }),
+        headers,
+        method: 'POST',
+      });
+      expect(indexResponse.status).toBe(200);
+      expect(await indexResponse.json()).toEqual({
+        output: 'Ready in an isolated process · 1 files · 2 symbols · 0 edges',
+      });
+      expect(isolatedIndex.runIsolatedCodeGraphIndexSnapshot).toHaveBeenNthCalledWith(1, {
+        cwd: identity.repoRoot,
+        expectedIdentity: {
+          checkoutId: identity.checkoutId,
+          repositoryId: identity.repositoryId,
+          worktreeId: identity.worktreeId,
+        },
+        force: false,
+        threadnoteHome: config.agentContextHome,
+      });
+      expect(await runEffect(readCodeGraphLocalAssociation(config.agentContextHome, identity))).toMatchObject({
+        path: identity.repoRoot,
+        state: 'verified',
+      });
+
+      await runEffect(
+        Effect.gen(function* () {
+          const path = yield* Path.Path;
+          const store = yield* CodeGraphStore;
+          const layout = codeGraphLayout(path, config.agentContextHome, identity.checkoutId, identity.worktreeId);
+          const symbol = graphSymbol(
+            'configured-symbol',
+            'configuredSymbol',
+            'src/index.ts',
+            'configured-project',
+            'function',
+            'configured-project',
+          );
+          const secondSymbol = graphSymbol(
+            'configured-second-symbol',
+            'configuredSecondSymbol',
+            symbol.path,
+            'configured-project',
+            'function',
+            'configured-project',
+          );
+          yield* store.activate(
+            layout.databasePath,
+            identity,
+            snapshot,
+            [graphFile(symbol.path, symbol.id)],
+            [symbol, secondSymbol],
+            [],
+          );
+          yield* store.promote(layout.databasePath, identity, snapshot.id);
+        }),
+      );
+      const refreshedCatalogResponse = await fetch(`${server.url}/api/graphs`, {headers});
+      const refreshedCatalog = (await refreshedCatalogResponse.json()) as {
+        readonly configuredProjects: readonly {readonly graphState: string; readonly name: string}[];
+      };
+      expect(refreshedCatalogResponse.status).toBe(200);
+      expect(refreshedCatalog.configuredProjects).toEqual([
+        expect.objectContaining({graphState: 'ready', name: 'configured-project'}),
+      ]);
+
+      const nestedSymlink = join(repositoryRoot, 'linked-project');
+      await symlink(secondRepositoryRoot, nestedSymlink, 'dir');
+      await writeFile(config.manifestPath, manifestFor(nestedSymlink));
+      const symlinkCatalogResponse = await fetch(`${server.url}/api/graphs`, {headers});
+      const symlinkCatalog = (await symlinkCatalogResponse.json()) as {
+        readonly configuredProjects: readonly {readonly graphState: string; readonly name: string}[];
+        readonly manifestRevision: string;
+      };
+      expect(symlinkCatalogResponse.status).toBe(200);
+      expect(symlinkCatalog.configuredProjects).toEqual([
+        expect.objectContaining({graphState: 'not-indexed', name: 'configured-project'}),
+      ]);
+      const symlinkIndexResponse = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({
+          action: 'index-project',
+          expectedRevision: symlinkCatalog.manifestRevision,
+          project: 'configured-project',
+        }),
+        headers,
+        method: 'POST',
+      });
+      expect(symlinkIndexResponse.status).toBe(200);
+      expect(isolatedIndex.runIsolatedCodeGraphIndexSnapshot).toHaveBeenNthCalledWith(2, {
+        cwd: secondIdentity.repoRoot,
+        expectedIdentity: {
+          checkoutId: secondIdentity.checkoutId,
+          repositoryId: secondIdentity.repositoryId,
+          worktreeId: secondIdentity.worktreeId,
+        },
+        force: false,
+        threadnoteHome: config.agentContextHome,
+      });
+
+      const staleResponse = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({
+          action: 'index-project',
+          expectedRevision: '0'.repeat(64),
+          project: 'configured-project',
+        }),
+        headers,
+        method: 'POST',
+      });
+      expect(staleResponse.status).toBe(409);
+      expect(await staleResponse.json()).toEqual({
+        code: 'graph-project-stale',
+        error: 'Configured projects changed. Refresh Manager before choosing a project to index.',
+        retryAfterMilliseconds: 0,
+      });
+
+      const existingIndexResponse = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({
+          action: 'index',
+          checkoutId: identity.checkoutId,
+          cwd: repositoryRoot,
+          full: true,
+          repositoryId: identity.repositoryId,
+          worktreeId: identity.worktreeId,
+        }),
+        headers,
+        method: 'POST',
+      });
+      expect(existingIndexResponse.status).toBe(200);
+      expect(isolatedIndex.runIsolatedCodeGraphIndexSnapshot).toHaveBeenNthCalledWith(3, {
+        cwd: identity.repoRoot,
+        expectedIdentity: {
+          checkoutId: identity.checkoutId,
+          repositoryId: identity.repositoryId,
+          worktreeId: identity.worktreeId,
+        },
+        force: true,
+        threadnoteHome: config.agentContextHome,
+      });
+
+      const unsafeManifest = manifestFor(`${secondRepositoryRoot}\t`);
+      await writeFile(config.manifestPath, unsafeManifest);
+      const unsafeResponse = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({
+          action: 'index-project',
+          expectedRevision: sha256HexSync(unsafeManifest),
+          project: 'configured-project',
+        }),
+        headers,
+        method: 'POST',
+      });
+      expect(unsafeResponse.status).toBe(409);
+      expect(await unsafeResponse.json()).toEqual({
+        code: 'graph-project-unavailable',
+        error: 'Configured projects could not be read. Refresh Manager and retry.',
+        retryAfterMilliseconds: 0,
+      });
+      expect(isolatedIndex.runIsolatedCodeGraphIndexSnapshot).toHaveBeenCalledTimes(3);
+
+      const foreignManifest = manifestFor('C:\\foreign\\configured-project');
+      await writeFile(config.manifestPath, foreignManifest);
+      const foreignResponse = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({
+          action: 'index-project',
+          expectedRevision: sha256HexSync(foreignManifest),
+          project: 'configured-project',
+        }),
+        headers,
+        method: 'POST',
+      });
+      const foreign = await foreignResponse.json();
+      expect(foreignResponse.status).toBe(409);
+      expect(foreign).toEqual({
+        code: 'graph-project-unavailable',
+        error:
+          'The selected configured project is not an available local Git repository. Check its manifest path and retry.',
+        retryAfterMilliseconds: 0,
+      });
+      expect(JSON.stringify(foreign)).not.toContain('foreign\\configured-project');
+      expect(isolatedIndex.runIsolatedCodeGraphIndexSnapshot).toHaveBeenCalledTimes(3);
+
+      const missingManifest = manifestFor(repositoryRoot);
+      await writeFile(config.manifestPath, missingManifest);
+      await rm(repositoryRoot, {force: true, recursive: true});
+      const unavailableResponse = await fetch(`${server.url}/api/graphs/action`, {
+        body: JSON.stringify({
+          action: 'index-project',
+          expectedRevision: sha256HexSync(missingManifest),
+          project: 'configured-project',
+        }),
+        headers,
+        method: 'POST',
+      });
+      const unavailable = await unavailableResponse.json();
+      expect(unavailableResponse.status).toBe(409);
+      expect(unavailable).toEqual({
+        code: 'graph-project-unavailable',
+        error:
+          'The selected configured project is not an available local Git repository. Check its manifest path and retry.',
+        retryAfterMilliseconds: 0,
+      });
+      expect(JSON.stringify(unavailable)).not.toContain(repositoryRoot);
+      expect(isolatedIndex.runIsolatedCodeGraphIndexSnapshot).toHaveBeenCalledTimes(3);
     } finally {
       await server.close();
     }


### PR DESCRIPTION
## Summary

- list configured manifest projects in Manager Graph Status even when no graph snapshot exists
- let operators cold-index or refresh a selected configured project through the existing isolated index runner
- distinguish ready, needs initialization, and readiness unknown states, including the truncated-catalog case
- preserve the existing graph-database index action unchanged

## Safety and correctness

- fence actions to the exact manifest revision and resolve the exact raw manifest path only on the server
- canonicalize existing paths before ready-snapshot containment checks so symlink escapes cannot inherit another repository state
- reject foreign-platform path syntax before expansion and return fixed, path-free 409 responses for unavailable projects
- disable the action when no configured project is selected

## Verification

- bun --bun vitest run test/unit/manager.test.ts test/unit/manager-graph.test.ts test/unit/manager-graph-projects.property.test.ts — 96 passed
- bun --bun tsc --noEmit
- bun --bun tsc -p test/tsconfig.json --noEmit
- focused strict oxlint and Prettier checks
- bun run lint:file-length
- commit hooks also ran repository lint, formatting, source/test/site typechecks

A bounded Effect-aware Fast-check property covers canonical root/descendant acceptance, prefix-sibling rejection, and POSIX/Windows foreign-path classification including truncated and native states.

## Dev-cycle review

- iteration 1 found and fixed two important issues: display-path authority and lexical-only symlink containment; it also identified truncated-catalog readiness
- iteration 2 verified those fixes and found the foreign-platform pre-expansion action issue
- iteration 3 verified the action fix with zero critical/important findings and identified the matching catalog-readiness minor
- iteration 4 verified the shared platform classification and property coverage with zero critical/important findings

Live browser QA was unavailable because this session had no browser runtime. Focused HTTP/API integration and SSR UI tests cover the behavior; PR CI remains authoritative for the full suite.