### PR TITLE
chore: prepare v4.4.2

### DIFF
--- a/.github/release-notes/v4.4.2.md
+++ b/.github/release-notes/v4.4.2.md
@@ -1,0 +1,39 @@
+## What's new
+
+Threadnote 4.4.2 is a post-release reliability patch for 4.4. It improves Manager graph operations, bounded impact
+queries, update checks, and runtime diagnostics without changing memory formats or recall behavior.
+
+### Start and refresh graphs directly from Manager
+
+- Graph Status now lists configured manifest projects before they have a graph snapshot, so a first index can be
+  started without leaving Manager.
+- Project indexing still runs in an isolated process. Actions are fenced to the exact manifest revision, the
+  server-reread project path, and the resolved repository identity. Foreign, missing, or changed entries fail safely,
+  and symlinked paths are canonicalized before readiness and identity checks.
+- Manager distinguishes ready graphs, projects that need initialization, and projects whose readiness is unknown
+  because the bounded catalog was truncated.
+
+### Keep active work visible and diagnostics dependable
+
+- Active graph and Workset operations appear ahead of idle services and legacy runtimes in Manager, including when
+  the process inventory reaches its 100-row bound. Ordinary CLI process diagnostics retain chronological ordering.
+- Doctor tolerates the narrow registration window while a live process atomically publishes its diagnostic record.
+- Extracted standalone release checks use their bundled version instead of inheriting an unrelated development
+  installation's version.
+
+### Keep bounded graph reads bounded
+
+- Isolated MCP impact reads no longer spend their fixed 20-second budget starting a base-commit graph build. They
+  reuse a ready current-format base snapshot when available; otherwise they return current evidence with an explicit
+  warning that deleted-path recovery was skipped.
+- Slow vector benchmark failures retain their evidence artifact, and Windows release-metadata probes keep their
+  substantive verification while allowing for load-sensitive archive startup.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```
+
+Existing v1, v2, v3, and unversioned memories remain recallable. A Workset is still optional for local repository
+recall and graph use.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone release version to 4.4.2
- add user-facing notes for Manager cold indexing, active-process visibility, bounded impact reads, update/process diagnostics, and release guardrails
- restate legacy-memory compatibility and optional Workset behavior

## Verification

- focused release/publish/website contract tests: 31/31
- package and release-note Prettier checks
- commit hook lint, formatting, source/test/site typechecks
- independent release-note review: zero critical/important findings

This is a release-only commit. The 4.4.1 exact Context Brief 100k citation gate remains authoritative because this patch does not change recall, Context Brief, citation validation, or memory formats.