### PR TITLE
fix(graph): reclaim orphaned materialization spools

### DIFF
--- a/.github/release-notes/v4.4.2.md
+++ b/.github/release-notes/v4.4.2.md
@@ -28,6 +28,8 @@ queries, update checks, and runtime diagnostics without changing memory formats 
   warning that deleted-path recovery was skipped.
 - Deep graph repair reclaims orphaned materialization spools from interrupted builds while preserving lease-protected
   resumable state.
+- Graph repair now previews and applies the v4.3.8 citation-index migration consistently, preserving leased resumable
+  builds and validating citation schema/index contracts before a migrated graph is marked healthy.
 - Slow vector benchmark failures retain their evidence artifact, and Windows release-metadata probes keep their
   substantive verification while allowing for load-sensitive archive startup.
 

--- a/.github/release-notes/v4.4.2.md
+++ b/.github/release-notes/v4.4.2.md
@@ -26,6 +26,8 @@ queries, update checks, and runtime diagnostics without changing memory formats 
 - Isolated MCP impact reads no longer spend their fixed 20-second budget starting a base-commit graph build. They
   reuse a ready current-format base snapshot when available; otherwise they return current evidence with an explicit
   warning that deleted-path recovery was skipped.
+- Deep graph repair reclaims orphaned materialization spools from interrupted builds while preserving lease-protected
+  resumable state.
 - Slow vector benchmark failures retain their evidence artifact, and Windows release-metadata probes keep their
   substantive verification while allowing for load-sensitive archive startup.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,7 @@ jobs:
           test/unit/windows-support.test.ts
           test/unit/effect-command.test.ts
           test/unit/effect-system.test.ts
+          test/unit/code-graph.maintenance-bounded.test.ts
           test/unit/local-ai.test.ts
           test/unit/update.test.ts
           test/unit/mcp.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,10 +268,14 @@ jobs:
           test/unit/windows-support.test.ts
           test/unit/effect-command.test.ts
           test/unit/effect-system.test.ts
-          test/unit/code-graph.maintenance-bounded.test.ts
           test/unit/local-ai.test.ts
           test/unit/update.test.ts
           test/unit/mcp.test.ts
+      - name: Graph repair quarantine smoke
+        run: >-
+          bun --bun vitest run
+          test/unit/code-graph.maintenance-bounded.test.ts
+          -t "removes a database-less orphan spool"
 
   standalone-targets:
     name: Bytecode compile · ${{ matrix.target }}

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -269,7 +269,7 @@ function codeGraphRepairProgressMessage(progress: CodeGraphMaintenanceProgress, 
     case 'cleaning-snapshots':
       return `${dryRun ? 'Would clean' : 'Cleaning'} ${progress.snapshots ?? 0} incomplete snapshot(s) from ${database}.`;
     case 'cleaning-vectors':
-      return `Checking temporary vector state for ${database}.`;
+      return `Checking temporary graph state for ${database}.`;
     case 'discarding':
       return `${dryRun ? 'Would discard' : 'Discarding'} unreadable derived ${database}.`;
     case 'deferred':

--- a/src/code_graph/commands.ts
+++ b/src/code_graph/commands.ts
@@ -233,7 +233,7 @@ export const runCodeGraphRepair = Effect.fn('codeGraph.command.repair')(function
     `${options.dryRun ? 'Would repair' : 'Repaired'} ${summary.databases} native code graph database(s): ` +
       `${summary.migratedDatabases} schema migration(s), ${summary.deferredDatabases} deferred, ` +
       `${summary.discarded} disposable rebuild(s), ${summary.removedIncompleteSnapshots} incomplete snapshot(s), ` +
-      `${summary.removedTemporaryFiles} temporary vector file(s).`,
+      `${summary.removedTemporaryFiles} temporary graph file(s).`,
   );
   if (completion) {
     yield* Console.log(

--- a/src/code_graph/deep_diagnostics.ts
+++ b/src/code_graph/deep_diagnostics.ts
@@ -198,6 +198,24 @@ function decodeDatabaseHealth(value: unknown): CodeGraphDatabaseHealth | undefin
   if (!['corrupt', 'incompatible', 'migration-pending', 'ok'].includes(String(record.integrity))) {
     return undefined;
   }
+  if (
+    ![
+      'column-only',
+      'column-only-with-authority',
+      'column-only-with-predecessor-authority',
+      'current',
+      'incompatible',
+      'released-absent',
+      'released-absent-with-predecessor-authority',
+      'released-absent-with-authority',
+      'table-absent',
+    ].includes(String(record.snapshotFileCitationSchema))
+  ) {
+    return undefined;
+  }
+  if (!['current', 'incompatible', 'missing'].includes(String(record.snapshotFileCitationBaseIndexes))) {
+    return undefined;
+  }
   for (const revision of [record.persistentExtensionSchemaRevision, record.schemaVersion]) {
     if (revision !== undefined && (typeof revision !== 'number' || !Number.isSafeInteger(revision))) return undefined;
   }

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -15,18 +15,18 @@ import {
   withCodeGraphMaintenanceIntent,
 } from './maintenance_gate.js';
 import {CodeGraphStore, type CodeGraphDatabaseHealth} from './store.js';
-import {CODE_GRAPH_SCHEMA_VERSION} from './types.js';
+import {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION, CODE_GRAPH_SCHEMA_VERSION} from './types.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY} from './languages/registry.js';
 import {diagnoseCodeGraphDatabaseReadOnly} from './store_health.js';
 import {diagnoseCodeGraphDatabase} from './deep_diagnostics.js';
+import {CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT} from './store_reconciliation_preparation.js';
+import {codeGraphSchemaMigrationPreservesIncompleteSnapshots} from './store_schema_migration.js';
 
 export {diagnoseCodeGraphDatabaseReadOnly} from './store_health.js';
 
 class CodeGraphMaintenanceError extends Error {
   readonly _tag = 'CodeGraphMaintenanceError' as const;
 }
-
-const CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT = 8;
 
 export interface CodeGraphRepairSummary {
   readonly databases: number;
@@ -350,6 +350,31 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                 Effect.gen(function* () {
                   let diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(Effect.option);
                   let previewingSchemaMigration = false;
+                  let previewedMigrationPreservesIncompleteSnapshots = false;
+                  // A same-name alias index can belong to another table or carry
+                  // incompatible keys. The initializer must never bless that drift.
+                  // Quick repair preserves the derived store for an explicit deep
+                  // decision; deep repair can discard it identically in preview and
+                  // apply without claiming that schema migration succeeded.
+                  if (
+                    diagnosed._tag === 'Some' &&
+                    diagnosed.value.integrity === 'incompatible' &&
+                    (diagnosed.value.snapshotFileCitationBaseIndexes === 'incompatible' ||
+                      diagnosed.value.snapshotFileCitationSchema === 'incompatible' ||
+                      diagnosed.value.snapshotFileCitationSchema === 'column-only-with-authority' ||
+                      (diagnosed.value.snapshotFileCitationSchema === 'released-absent-with-authority' &&
+                        diagnosed.value.persistentExtensionSchemaRevision !==
+                          CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION - 1))
+                  ) {
+                    return deep ? ('discard' as const) : ('schema-upgrade-on-use' as const);
+                  }
+                  const schemaMigrationPreservesIncompleteSnapshots =
+                    diagnosed._tag === 'Some' &&
+                    codeGraphSchemaMigrationPreservesIncompleteSnapshots(
+                      diagnosed.value.persistentExtensionSchemaRevision,
+                      diagnosed.value.snapshotFileCitationSchema,
+                      diagnosed.value.snapshotFileCitationBaseIndexes,
+                    );
                   if (
                     diagnosed._tag === 'Some' &&
                     diagnosed.value?.schemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
@@ -358,10 +383,28 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                     if (options.migrateSchema) {
                       yield* progress({phase: 'migrating-schema'});
                       if (dryRun) {
+                        if (
+                          diagnosed.value.integrity === 'migration-pending' ||
+                          schemaMigrationPreservesIncompleteSnapshots
+                        ) {
+                          const preparation = yield* store.prepareWorktreeReconciliationIndexes(database, {
+                            preview: true,
+                          });
+                          if (preparation.state === 'deferred') return 'schema-upgrade-on-use' as const;
+                          previewedMigrationPreservesIncompleteSnapshots =
+                            codeGraphSchemaMigrationPreservesIncompleteSnapshots(
+                              diagnosed.value.persistentExtensionSchemaRevision,
+                              diagnosed.value.snapshotFileCitationSchema,
+                              diagnosed.value.snapshotFileCitationBaseIndexes,
+                            );
+                        }
                         migratedDatabases += 1;
                         previewingSchemaMigration = true;
                       } else {
-                        if (diagnosed.value.integrity === 'migration-pending') {
+                        if (
+                          diagnosed.value.integrity === 'migration-pending' ||
+                          schemaMigrationPreservesIncompleteSnapshots
+                        ) {
                           let preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
                           for (
                             let step = 1;
@@ -407,9 +450,14 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                   readySnapshots += diagnosed.value.readySnapshots;
                   if (!deep && incomplete > 0) return 'deep-check-required' as const;
                   if (!deep) return 'maintained' as const;
-                  if (incomplete > 0 && !previewingSchemaMigration) {
+                  if (
+                    incomplete > 0 &&
+                    (!previewingSchemaMigration || previewedMigrationPreservesIncompleteSnapshots)
+                  ) {
                     yield* progress({phase: 'cleaning-snapshots', snapshots: incomplete});
-                    const repaired = yield* store.repair(database, dryRun);
+                    const repaired = yield* store.repair(database, dryRun, {
+                      allowSchemaMigrationPreview: previewedMigrationPreservesIncompleteSnapshots,
+                    });
                     const removed = repaired?.removedSnapshots ?? 0;
                     retainedIncompleteSnapshotIds = repaired?.retainedIncompleteSnapshotIds ?? [];
                     removedIncompleteSnapshots += removed;

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -1,4 +1,4 @@
-import {Crypto, Effect, FileSystem, Option, Path} from 'effect';
+import {Clock, Crypto, Effect, FileSystem, Option, Path} from 'effect';
 import type {DoctorCheck} from '../types.js';
 import {isFileLockTimeout, withExclusiveFileLock} from '../effect/file_lock.js';
 import {
@@ -96,6 +96,17 @@ interface CodeGraphIndexPurgeTarget {
 export interface CodeGraphRepairCompletion {
   readonly doctorCheck: DoctorCheck;
   readonly summary: CodeGraphRepairSummary;
+}
+
+export interface CodeGraphRepairInterlock {
+  /** @internal Deterministic race seam after the first worktree-builder drain. */
+  readonly afterWorktreeDrain?: (database: string) => Effect.Effect<void, unknown>;
+  /** @internal Deterministic filesystem-authority seam before spool cleanup verification. */
+  readonly beforeSpoolCleanupVerification?: (repositoryRoot: string) => Effect.Effect<void, unknown>;
+  /** @internal Deterministic race seam after authority verification and before quarantine. */
+  readonly beforeSpoolQuarantine?: (spoolPath: string) => Effect.Effect<void, unknown>;
+  /** @internal Deterministic race seam after quarantine verification and before removal. */
+  readonly beforeSpoolRemoval?: (quarantinePath: string) => Effect.Effect<void, unknown>;
 }
 
 export interface CodeGraphMaintenanceProgress {
@@ -278,6 +289,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
   onProgress?: CodeGraphProgressHandler,
   onComplete?: CodeGraphRepairCompletionHandler<R>,
   options: {
+    readonly interlock?: CodeGraphRepairInterlock;
     readonly migrateSchema?: boolean;
     readonly mode?: 'deep' | 'quick';
     readonly targetCheckoutId?: string;
@@ -291,6 +303,11 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
   }
   const repair = Effect.gen(function* () {
     const allDatabases = yield* codeGraphDatabasePaths(threadnoteHome);
+    const allRepositoryCheckoutIds = yield* codeGraphRepositoryCheckoutIds(threadnoteHome);
+    const repositoryCheckoutIds =
+      options.targetCheckoutId === undefined
+        ? allRepositoryCheckoutIds
+        : allRepositoryCheckoutIds.filter(checkoutId => checkoutId === options.targetCheckoutId);
     const databases =
       options.targetCheckoutId === undefined
         ? allDatabases
@@ -301,6 +318,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
         : emptyObsoleteInventory();
     const deep = options.mode !== 'quick';
     let deferredDatabases = 0;
+    let databaseCount = databases.length;
     let discarded = 0;
     let migratedDatabases = 0;
     let removedIncompleteSnapshots = 0;
@@ -318,96 +336,120 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
         threadnoteHome,
         database,
         Effect.gen(function* () {
-          const decision = yield* store.withSession(
-            database,
+          const decision = yield* Effect.scoped(
             Effect.gen(function* () {
-              let diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(Effect.option);
-              if (
-                diagnosed._tag === 'Some' &&
-                diagnosed.value?.schemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
-                (diagnosed.value.integrity === 'incompatible' || diagnosed.value.integrity === 'migration-pending')
-              ) {
-                if (options.migrateSchema) {
-                  yield* progress({phase: 'migrating-schema'});
-                  if (dryRun) {
-                    migratedDatabases += 1;
-                    return 'maintained' as const;
-                  }
-                  if (diagnosed.value.integrity === 'migration-pending') {
-                    let preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
-                    for (
-                      let step = 1;
-                      preparation.state === 'prepared' && step < CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT;
-                      step += 1
-                    ) {
-                      preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
+              const checkoutId = path.basename(repositoryRoot);
+              const repositoryTarget = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+              if (repositoryTarget === undefined) {
+                return yield* Effect.fail(
+                  new CodeGraphMaintenanceError('Code graph checkout target changed before repair.'),
+                );
+              }
+              return yield* store.withSession(
+                database,
+                Effect.gen(function* () {
+                  let diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(Effect.option);
+                  let previewingSchemaMigration = false;
+                  if (
+                    diagnosed._tag === 'Some' &&
+                    diagnosed.value?.schemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
+                    (diagnosed.value.integrity === 'incompatible' || diagnosed.value.integrity === 'migration-pending')
+                  ) {
+                    if (options.migrateSchema) {
+                      yield* progress({phase: 'migrating-schema'});
+                      if (dryRun) {
+                        migratedDatabases += 1;
+                        previewingSchemaMigration = true;
+                      } else {
+                        if (diagnosed.value.integrity === 'migration-pending') {
+                          let preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
+                          for (
+                            let step = 1;
+                            preparation.state === 'prepared' &&
+                            step < CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT;
+                            step += 1
+                          ) {
+                            preparation = yield* store.prepareWorktreeReconciliationIndexes(database);
+                          }
+                          if (preparation.state === 'deferred') return 'schema-upgrade-on-use' as const;
+                        }
+                        yield* store.initialize(database);
+                        diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(
+                          Effect.option,
+                        );
+                        if (diagnosed._tag === 'Some' && diagnosed.value?.integrity === 'ok') {
+                          migratedDatabases += 1;
+                        } else {
+                          return 'schema-upgrade-on-use' as const;
+                        }
+                      }
+                    } else {
+                      // Same-version beta databases with a missing revision or an
+                      // incompatible extension-table contract are recoverable on the
+                      // next ordinary writer open.
+                      // Never discard their ready snapshots as if the canonical graph
+                      // rows were corrupt merely because this maintenance pass is
+                      // deliberately read-only while holding the checkout gate.
+                      return 'schema-upgrade-on-use' as const;
                     }
-                    if (preparation.state === 'deferred') return 'schema-upgrade-on-use' as const;
                   }
-                  yield* store.initialize(database);
-                  diagnosed = yield* diagnoseCodeGraphDatabase(threadnoteHome, database, deep).pipe(Effect.option);
-                  if (diagnosed._tag === 'Some' && diagnosed.value?.integrity === 'ok') {
-                    migratedDatabases += 1;
-                  } else {
-                    return 'schema-upgrade-on-use' as const;
+                  // A failed diagnostic is not evidence of corruption. In particular,
+                  // transient I/O, permissions, or an unreadable schema must never turn
+                  // an explicit deep check into recursive deletion of the graph store.
+                  if (diagnosed._tag === 'None') {
+                    return deep ? ('unreadable-database' as const) : ('deep-check-required' as const);
                   }
-                } else {
-                  // Same-version beta databases with a missing revision or an
-                  // incompatible extension-table contract are recoverable on the
-                  // next ordinary writer open.
-                  // Never discard their ready snapshots as if the canonical graph
-                  // rows were corrupt merely because this maintenance pass is
-                  // deliberately read-only while holding the checkout gate.
-                  return 'schema-upgrade-on-use' as const;
-                }
-              }
-              // A failed diagnostic is not evidence of corruption. In particular,
-              // transient I/O, permissions, or an unreadable schema must never turn
-              // an explicit deep check into recursive deletion of the graph store.
-              if (diagnosed._tag === 'None' || diagnosed.value === undefined) {
-                return deep ? ('unreadable-database' as const) : ('deep-check-required' as const);
-              }
-              if (diagnosed.value.integrity !== 'ok') {
-                return deep ? ('discard' as const) : ('deep-check-required' as const);
-              }
-              const incomplete = diagnosed.value.buildingSnapshots + diagnosed.value.failedSnapshots;
-              let retainedIncompleteSnapshotIds: readonly string[] = [];
-              readySnapshots += diagnosed.value.readySnapshots;
-              if (!deep && incomplete > 0) return 'deep-check-required' as const;
-              if (!deep) return 'maintained' as const;
-              if (incomplete > 0) {
-                yield* progress({phase: 'cleaning-snapshots', snapshots: incomplete});
-                const repaired = yield* store.repair(database, dryRun);
-                const removed = repaired?.removedSnapshots ?? 0;
-                retainedIncompleteSnapshotIds = repaired?.retainedIncompleteSnapshotIds ?? [];
-                removedIncompleteSnapshots += removed;
-                remainingIncompleteSnapshots += Math.max(0, incomplete - removed);
-              }
-              // Build-time cache GC can delete parser facts belonging to another
-              // linked worktree before that worktree activates its snapshot. This
-              // path has drained every worktree lock for the checkout, so
-              // it is safe to collect cache facts shared by its linked worktrees.
-              if (!dryRun) {
-                yield* store.pruneRetiredSnapshots(database);
-                yield* store.pruneCachedFacts(database, BUILTIN_LANGUAGE_PACK_REGISTRY.cacheIdentities);
-              }
-              yield* progress({phase: 'cleaning-vectors'});
-              removedTemporaryFiles += yield* cleanTemporaryMaterializationSpoolFiles(
-                fs,
-                path,
-                repositoryRoot,
-                new Set(retainedIncompleteSnapshotIds),
-                dryRun,
+                  if (!previewingSchemaMigration && diagnosed.value.integrity !== 'ok') {
+                    return deep ? ('discard' as const) : ('deep-check-required' as const);
+                  }
+                  const incomplete = diagnosed.value.buildingSnapshots + diagnosed.value.failedSnapshots;
+                  let retainedIncompleteSnapshotIds: readonly string[] = [];
+                  readySnapshots += diagnosed.value.readySnapshots;
+                  if (!deep && incomplete > 0) return 'deep-check-required' as const;
+                  if (!deep) return 'maintained' as const;
+                  if (incomplete > 0 && !previewingSchemaMigration) {
+                    yield* progress({phase: 'cleaning-snapshots', snapshots: incomplete});
+                    const repaired = yield* store.repair(database, dryRun);
+                    const removed = repaired?.removedSnapshots ?? 0;
+                    retainedIncompleteSnapshotIds = repaired?.retainedIncompleteSnapshotIds ?? [];
+                    removedIncompleteSnapshots += removed;
+                    remainingIncompleteSnapshots += Math.max(0, incomplete - removed);
+                  }
+                  // Build-time cache GC can delete parser facts belonging to another
+                  // linked worktree before that worktree activates its snapshot. This
+                  // path has drained every worktree lock for the checkout, so
+                  // it is safe to collect cache facts shared by its linked worktrees.
+                  if (!dryRun) {
+                    yield* store.pruneRetiredSnapshots(database);
+                    yield* store.pruneCachedFacts(database, BUILTIN_LANGUAGE_PACK_REGISTRY.cacheIdentities);
+                  }
+                  yield* progress({phase: 'cleaning-vectors'});
+                  yield* options.interlock?.beforeSpoolCleanupVerification?.(repositoryTarget.path) ?? Effect.void;
+                  removedTemporaryFiles += yield* cleanTemporaryMaterializationSpoolFiles(
+                    fs,
+                    path,
+                    threadnoteHome,
+                    checkoutId,
+                    repositoryTarget,
+                    new Set(retainedIncompleteSnapshotIds),
+                    dryRun,
+                    options.interlock,
+                  );
+                  removedTemporaryFiles += yield* cleanTemporaryVectorFiles(
+                    fs,
+                    path,
+                    threadnoteHome,
+                    checkoutId,
+                    repositoryTarget,
+                    path.join(repositoryRoot, 'vectors'),
+                    dryRun,
+                    options.interlock,
+                  );
+                  return 'maintained' as const;
+                }),
+                {writerGateHeld: true},
               );
-              removedTemporaryFiles += yield* cleanTemporaryVectorFiles(
-                fs,
-                path,
-                path.join(repositoryRoot, 'vectors'),
-                dryRun,
-              );
-              return 'maintained' as const;
             }),
-            {writerGateHeld: true},
           );
           if (decision !== 'discard') return decision;
 
@@ -421,6 +463,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
           return 'maintained' as const;
         }),
         0,
+        options.interlock?.afterWorktreeDrain,
       ).pipe(
         Effect.catch(cause =>
           isFileLockTimeout(cause) ? Effect.succeed('active-build' as const) : Effect.fail(cause),
@@ -432,6 +475,49 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
           phase: 'deferred',
           reason: maintained,
         });
+      }
+    }
+    const databaseCheckoutIds = new Set(databases.map(database => path.basename(path.dirname(database))));
+    const spoolOnlyCheckoutIds = deep
+      ? repositoryCheckoutIds.filter(checkoutId => !databaseCheckoutIds.has(checkoutId))
+      : [];
+    for (const checkoutId of spoolOnlyCheckoutIds) {
+      const repositoryRoot = codeGraphRepositoryRoot(path, threadnoteHome, checkoutId);
+      const database = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+      const cleaned = yield* withDatabaseLock(
+        fs,
+        path,
+        threadnoteHome,
+        database,
+        Effect.scoped(
+          Effect.gen(function* () {
+            // The root was database-less during inventory, but a builder may
+            // have completed before this checkout's gates were acquired. Do
+            // not apply the empty-retention model to its newly durable state.
+            if (yield* fs.exists(database)) return undefined;
+            const repositoryTarget = yield* openCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+            if (repositoryTarget === undefined) return 0 as number | undefined;
+            yield* options.interlock?.beforeSpoolCleanupVerification?.(repositoryTarget.path) ?? Effect.void;
+            return yield* cleanTemporaryMaterializationSpoolFiles(
+              fs,
+              path,
+              threadnoteHome,
+              checkoutId,
+              repositoryTarget,
+              new Set(),
+              dryRun,
+              options.interlock,
+            );
+          }),
+        ),
+        0,
+        options.interlock?.afterWorktreeDrain,
+      ).pipe(Effect.catch(cause => (isFileLockTimeout(cause) ? Effect.succeed(0) : Effect.fail(cause))));
+      if (cleaned === undefined) {
+        databaseCount += 1;
+        deferredDatabases += 1;
+      } else {
+        removedTemporaryFiles += cleaned;
       }
     }
     const currentDatabases =
@@ -447,7 +533,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
           ? obsoleteBefore
           : yield* inspectObsoleteCodeGraphStores(threadnoteHome);
     const summary = {
-      databases: databases.length,
+      databases: databaseCount,
       deferredDatabases,
       discarded,
       migratedDatabases,
@@ -473,8 +559,8 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
     return summary;
   });
   if (options.targetCheckoutId !== undefined) {
-    // Checkout, linked-worktree, and database-writer gates fully isolate this
-    // repository. Avoid the home-global intent so unrelated graph builds keep running.
+    // The checkout gate plus the under-writer-gate builder recheck isolates this
+    // repository without pausing builders for unrelated checkouts.
     return yield* repair;
   }
   return yield* withExclusiveFileLock(
@@ -545,6 +631,18 @@ export const codeGraphDatabasePaths = Effect.fn('codeGraph.databasePaths')(funct
   }
   return output.sort();
 });
+
+function codeGraphRepositoryCheckoutIds(threadnoteHome: string) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const repositories = codeGraphRepositoriesRoot(path, threadnoteHome);
+    if (Option.isSome(yield* fs.readLink(repositories).pipe(Effect.option))) return [];
+    const info = yield* fs.stat(repositories).pipe(Effect.option);
+    if (Option.isNone(info) || info.value.type !== 'Directory') return [];
+    return (yield* fs.readDirectory(repositories)).filter(name => /^[0-9a-f]{64}$/u.test(name)).sort();
+  });
+}
 
 /**
  * Explicitly removes only older schema-version SQLite artifacts from one checkout.
@@ -751,14 +849,35 @@ export const purgeAllCodeGraphIndexes = Effect.fn('codeGraph.purgeAllIndexes')(f
 function cleanTemporaryVectorFiles(
   fs: FileSystem.FileSystem,
   path: Path.Path,
+  threadnoteHome: string,
+  checkoutId: string,
+  repositoryTarget: CodeGraphIndexPurgeTarget,
   directory: string,
   dryRun: boolean,
-): Effect.Effect<number, unknown> {
+  interlock?: CodeGraphRepairInterlock,
+): Effect.Effect<number, unknown, Crypto.Crypto> {
   return Effect.gen(function* () {
+    const verified = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+    if (!sameCodeGraphIndexPurgeTarget(repositoryTarget, verified)) {
+      return yield* Effect.fail(
+        new CodeGraphMaintenanceError('Code graph checkout target changed before temporary-file cleanup.'),
+      );
+    }
     if ((yield* fs.readLink(directory).pipe(Effect.option))._tag === 'Some') return 0;
     if (!(yield* fs.exists(directory))) return 0;
     const root = yield* fs.realPath(directory);
-    return yield* cleanTemporaryVectorFilesContained(fs, path, root, root, dryRun);
+    if (!isContained(path, repositoryTarget.path, root)) return 0;
+    return yield* cleanTemporaryVectorFilesContained(
+      fs,
+      path,
+      threadnoteHome,
+      checkoutId,
+      repositoryTarget,
+      root,
+      root,
+      dryRun,
+      interlock,
+    );
   });
 }
 
@@ -770,14 +889,21 @@ export function codeGraphTemporaryMaterializationSpoolSnapshotId(fileName: strin
 function cleanTemporaryMaterializationSpoolFiles(
   fs: FileSystem.FileSystem,
   path: Path.Path,
-  repositoryRoot: string,
+  threadnoteHome: string,
+  checkoutId: string,
+  repositoryTarget: CodeGraphIndexPurgeTarget,
   retainedIncompleteSnapshotIds: ReadonlySet<string>,
   dryRun: boolean,
-): Effect.Effect<number, unknown> {
+  interlock?: CodeGraphRepairInterlock,
+): Effect.Effect<number, unknown, Crypto.Crypto> {
   return Effect.gen(function* () {
-    if ((yield* fs.readLink(repositoryRoot).pipe(Effect.option))._tag === 'Some') return 0;
-    if (!(yield* fs.exists(repositoryRoot))) return 0;
-    const root = yield* fs.realPath(repositoryRoot);
+    const verified = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+    if (!sameCodeGraphIndexPurgeTarget(repositoryTarget, verified)) {
+      return yield* Effect.fail(
+        new CodeGraphMaintenanceError('Code graph checkout target changed before spool cleanup.'),
+      );
+    }
+    const root = repositoryTarget.path;
     let removed = 0;
     for (const name of (yield* fs.readDirectory(root)).sort()) {
       const snapshotId = codeGraphTemporaryMaterializationSpoolSnapshotId(name);
@@ -792,22 +918,130 @@ function cleanTemporaryMaterializationSpoolFiles(
       ) {
         continue;
       }
-      const info = yield* fs.stat(canonical.value);
-      if (info.type !== 'File') continue;
-      removed += 1;
-      if (!dryRun) yield* fs.remove(canonical.value, {force: true});
+      removed += yield* cleanTemporaryMaterializationSpoolFile(
+        fs,
+        path,
+        threadnoteHome,
+        checkoutId,
+        repositoryTarget,
+        canonical.value,
+        name,
+        dryRun,
+        interlock,
+      );
     }
     return removed;
   });
 }
 
+function cleanTemporaryMaterializationSpoolFile(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  threadnoteHome: string,
+  checkoutId: string,
+  repositoryTarget: CodeGraphIndexPurgeTarget,
+  candidate: string,
+  fileName: string,
+  dryRun: boolean,
+  interlock?: CodeGraphRepairInterlock,
+): Effect.Effect<number, unknown, Crypto.Crypto> {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const info = yield* fs.stat(candidate);
+      const ino = Option.getOrUndefined(info.ino);
+      if (info.type !== 'File' || ino === undefined) return 0;
+      const target = {dev: info.dev, ino, path: candidate} satisfies CodeGraphIndexPurgeTarget;
+      const opened = yield* fs.open(candidate, {flag: 'r'});
+      const openedInfo = yield* opened.stat;
+      const openedIno = Option.getOrUndefined(openedInfo.ino);
+      if (
+        openedInfo.type !== 'File' ||
+        openedIno === undefined ||
+        target.dev !== openedInfo.dev ||
+        target.ino !== openedIno
+      ) {
+        return yield* Effect.fail(new CodeGraphMaintenanceError('Temporary graph file changed while opening.'));
+      }
+      yield* verifyCodeGraphSpoolCleanupAuthority(fs, path, threadnoteHome, checkoutId, repositoryTarget, target);
+      if (dryRun) return 1;
+      yield* interlock?.beforeSpoolQuarantine?.(candidate) ?? Effect.void;
+      const crypto = yield* Crypto.Crypto;
+      const quarantine = path.join(repositoryTarget.path, `.${fileName}.${yield* crypto.randomUUIDv4}.repair`);
+      yield* fs.rename(candidate, quarantine);
+      return yield* Effect.gen(function* () {
+        yield* verifyCodeGraphSpoolCleanupAuthority(fs, path, threadnoteHome, checkoutId, repositoryTarget, {
+          ...target,
+          path: quarantine,
+        });
+        yield* interlock?.beforeSpoolRemoval?.(quarantine) ?? Effect.void;
+        yield* verifyCodeGraphSpoolCleanupAuthority(fs, path, threadnoteHome, checkoutId, repositoryTarget, {
+          ...target,
+          path: quarantine,
+        });
+        yield* fs.remove(quarantine, {force: true});
+        return 1;
+      }).pipe(Effect.ensuring(restoreQuarantinedSpool(fs, quarantine, candidate)));
+    }),
+  );
+}
+
+function verifyCodeGraphSpoolCleanupAuthority(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  threadnoteHome: string,
+  checkoutId: string,
+  repositoryTarget: CodeGraphIndexPurgeTarget,
+  fileTarget: CodeGraphIndexPurgeTarget,
+) {
+  return Effect.gen(function* () {
+    const currentRepository = yield* inspectCodeGraphIndexPurgeTarget(fs, path, threadnoteHome, checkoutId);
+    if (!sameCodeGraphIndexPurgeTarget(repositoryTarget, currentRepository)) {
+      return yield* Effect.fail(
+        new CodeGraphMaintenanceError('Code graph checkout target changed during spool cleanup.'),
+      );
+    }
+    if (Option.isSome(yield* fs.readLink(fileTarget.path).pipe(Effect.option))) {
+      return yield* Effect.fail(new CodeGraphMaintenanceError('Temporary graph file became a symbolic link.'));
+    }
+    const currentInfo = yield* fs.stat(fileTarget.path).pipe(Effect.option);
+    const currentIno = Option.isSome(currentInfo) ? Option.getOrUndefined(currentInfo.value.ino) : undefined;
+    if (
+      Option.isNone(currentInfo) ||
+      currentInfo.value.type !== 'File' ||
+      currentIno === undefined ||
+      currentInfo.value.dev !== fileTarget.dev ||
+      currentIno !== fileTarget.ino
+    ) {
+      return yield* Effect.fail(new CodeGraphMaintenanceError('Temporary graph file target changed during cleanup.'));
+    }
+  });
+}
+
+function restoreQuarantinedSpool(
+  fs: FileSystem.FileSystem,
+  quarantine: string,
+  original: string,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const quarantineIsLink = Option.isSome(yield* fs.readLink(quarantine).pipe(Effect.option));
+    const originalIsLink = Option.isSome(yield* fs.readLink(original).pipe(Effect.option));
+    if ((!quarantineIsLink && !(yield* fs.exists(quarantine))) || originalIsLink || (yield* fs.exists(original)))
+      return;
+    yield* fs.rename(quarantine, original);
+  }).pipe(Effect.catch(() => Effect.void));
+}
+
 function cleanTemporaryVectorFilesContained(
   fs: FileSystem.FileSystem,
   path: Path.Path,
+  threadnoteHome: string,
+  checkoutId: string,
+  repositoryTarget: CodeGraphIndexPurgeTarget,
   root: string,
   directory: string,
   dryRun: boolean,
-): Effect.Effect<number, unknown> {
+  interlock?: CodeGraphRepairInterlock,
+): Effect.Effect<number, unknown, Crypto.Crypto> {
   return Effect.gen(function* () {
     let removed = 0;
     for (const name of yield* fs.readDirectory(directory)) {
@@ -817,10 +1051,29 @@ function cleanTemporaryVectorFilesContained(
       if (canonical._tag === 'None' || !isContained(path, root, canonical.value)) continue;
       const info = yield* fs.stat(child);
       if (info.type === 'Directory') {
-        removed += yield* cleanTemporaryVectorFilesContained(fs, path, root, canonical.value, dryRun);
+        removed += yield* cleanTemporaryVectorFilesContained(
+          fs,
+          path,
+          threadnoteHome,
+          checkoutId,
+          repositoryTarget,
+          root,
+          canonical.value,
+          dryRun,
+          interlock,
+        );
       } else if (info.type === 'File' && (name.endsWith('.tmp') || name.endsWith('.staging'))) {
-        removed += 1;
-        if (!dryRun) yield* fs.remove(canonical.value, {force: true});
+        removed += yield* cleanTemporaryMaterializationSpoolFile(
+          fs,
+          path,
+          threadnoteHome,
+          checkoutId,
+          repositoryTarget,
+          canonical.value,
+          name,
+          dryRun,
+          interlock,
+        );
       }
     }
     return removed;
@@ -834,15 +1087,38 @@ function withDatabaseLock<A, E, R>(
   database: string,
   effect: Effect.Effect<A, E, R>,
   waitTimeoutMilliseconds = CODE_GRAPH_LOCK_OPTIONS.waitTimeoutMilliseconds,
+  afterWorktreeDrain?: (database: string) => Effect.Effect<void, unknown>,
 ) {
   const repositoryId = path.basename(path.dirname(database));
   return withExclusiveFileLock(
     fs,
     codeGraphRepositoryLockPath(path, threadnoteHome, repositoryId),
     {...CODE_GRAPH_LOCK_OPTIONS, waitTimeoutMilliseconds},
-    awaitCodeGraphWorktreeBuilds(threadnoteHome, repositoryId, waitTimeoutMilliseconds).pipe(
-      Effect.andThen(withCodeGraphDatabaseWriteLock(threadnoteHome, repositoryId, effect, waitTimeoutMilliseconds)),
-    ),
+    Effect.gen(function* () {
+      const startedAt = yield* Clock.currentTimeMillis;
+      for (;;) {
+        const remaining = Math.max(0, waitTimeoutMilliseconds - ((yield* Clock.currentTimeMillis) - startedAt));
+        yield* awaitCodeGraphWorktreeBuilds(threadnoteHome, repositoryId, remaining);
+        yield* afterWorktreeDrain?.(database) ?? Effect.void;
+        type DatabaseLockAttempt = {readonly state: 'completed'; readonly value: A} | {readonly state: 'late-builder'};
+        const acquired = yield* withCodeGraphDatabaseWriteLock(
+          threadnoteHome,
+          repositoryId,
+          codeGraphWorktreeBuildActive(threadnoteHome, repositoryId).pipe(
+            Effect.flatMap(active =>
+              active
+                ? Effect.succeed<DatabaseLockAttempt>({state: 'late-builder'})
+                : effect.pipe(Effect.map(value => ({state: 'completed', value}) satisfies DatabaseLockAttempt)),
+            ),
+          ),
+          remaining,
+        );
+        if (acquired.state === 'completed') return acquired.value;
+        // Release the database writer gate before waiting. A late builder can
+        // otherwise deadlock while holding its worktree lock and waiting to
+        // publish its BUILDING row through this same writer gate.
+      }
+    }),
   );
 }
 
@@ -911,6 +1187,13 @@ function inspectCodeGraphIndexPurgeTarget(
       );
     }
     const canonicalRepositories = yield* fs.realPath(repositories);
+    const canonicalHome = yield* fs.realPath(threadnoteHome);
+    const expectedRepositories = path.join(canonicalHome, 'indexes', 'code-graph', 'repositories');
+    if (canonicalRepositories !== expectedRepositories) {
+      return yield* Effect.fail(
+        new CodeGraphMaintenanceError('Refusing code graph purge outside the canonical Threadnote home.'),
+      );
+    }
     const repositoryRoot = codeGraphRepositoryRoot(path, threadnoteHome, checkoutId);
     if (!(yield* fs.exists(repositoryRoot))) return undefined;
     if (yield* isSymbolicLink(fs, repositoryRoot)) {

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -113,6 +113,8 @@ type CodeGraphQuickCheck =
   {readonly health: CodeGraphDatabaseHealth; readonly state: 'checked'} | {readonly state: 'unreadable'};
 
 const OBSOLETE_GRAPH_FILE_PATTERN = /^graph-v([1-9]\d*)\.sqlite(?:-(wal|shm))?$/;
+const MATERIALIZATION_SPOOL_FILE_PATTERN =
+  /^materialization-spool-v1-(cgsn_[0-9a-f]{40}(?:-direct|-full-[0-9a-f]{16})?)\.sqlite(?:-(?:journal|shm|wal))?$/u;
 
 /**
  * Inventories obsolete checkout-local SQLite artifacts using directory metadata only.
@@ -369,6 +371,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                 return deep ? ('discard' as const) : ('deep-check-required' as const);
               }
               const incomplete = diagnosed.value.buildingSnapshots + diagnosed.value.failedSnapshots;
+              let retainedIncompleteSnapshotIds: readonly string[] = [];
               readySnapshots += diagnosed.value.readySnapshots;
               if (!deep && incomplete > 0) return 'deep-check-required' as const;
               if (!deep) return 'maintained' as const;
@@ -376,6 +379,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                 yield* progress({phase: 'cleaning-snapshots', snapshots: incomplete});
                 const repaired = yield* store.repair(database, dryRun);
                 const removed = repaired?.removedSnapshots ?? 0;
+                retainedIncompleteSnapshotIds = repaired?.retainedIncompleteSnapshotIds ?? [];
                 removedIncompleteSnapshots += removed;
                 remainingIncompleteSnapshots += Math.max(0, incomplete - removed);
               }
@@ -388,6 +392,13 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                 yield* store.pruneCachedFacts(database, BUILTIN_LANGUAGE_PACK_REGISTRY.cacheIdentities);
               }
               yield* progress({phase: 'cleaning-vectors'});
+              removedTemporaryFiles += yield* cleanTemporaryMaterializationSpoolFiles(
+                fs,
+                path,
+                repositoryRoot,
+                new Set(retainedIncompleteSnapshotIds),
+                dryRun,
+              );
               removedTemporaryFiles += yield* cleanTemporaryVectorFiles(
                 fs,
                 path,
@@ -748,6 +759,45 @@ function cleanTemporaryVectorFiles(
     if (!(yield* fs.exists(directory))) return 0;
     const root = yield* fs.realPath(directory);
     return yield* cleanTemporaryVectorFilesContained(fs, path, root, root, dryRun);
+  });
+}
+
+/** @internal Exact basename parser shared with spool-repair property tests. */
+export function codeGraphTemporaryMaterializationSpoolSnapshotId(fileName: string): string | undefined {
+  return MATERIALIZATION_SPOOL_FILE_PATTERN.exec(fileName)?.[1];
+}
+
+function cleanTemporaryMaterializationSpoolFiles(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  repositoryRoot: string,
+  retainedIncompleteSnapshotIds: ReadonlySet<string>,
+  dryRun: boolean,
+): Effect.Effect<number, unknown> {
+  return Effect.gen(function* () {
+    if ((yield* fs.readLink(repositoryRoot).pipe(Effect.option))._tag === 'Some') return 0;
+    if (!(yield* fs.exists(repositoryRoot))) return 0;
+    const root = yield* fs.realPath(repositoryRoot);
+    let removed = 0;
+    for (const name of (yield* fs.readDirectory(root)).sort()) {
+      const snapshotId = codeGraphTemporaryMaterializationSpoolSnapshotId(name);
+      if (snapshotId === undefined || retainedIncompleteSnapshotIds.has(snapshotId)) continue;
+      const child = path.join(root, name);
+      if ((yield* fs.readLink(child).pipe(Effect.option))._tag === 'Some') continue;
+      const canonical = yield* fs.realPath(child).pipe(Effect.option);
+      if (
+        canonical._tag === 'None' ||
+        path.dirname(canonical.value) !== root ||
+        path.basename(canonical.value) !== name
+      ) {
+        continue;
+      }
+      const info = yield* fs.stat(canonical.value);
+      if (info.type !== 'File') continue;
+      removed += 1;
+      if (!dryRun) yield* fs.remove(canonical.value, {force: true});
+    }
+    return removed;
   });
 }
 

--- a/src/code_graph/store_diagnostics.ts
+++ b/src/code_graph/store_diagnostics.ts
@@ -6,6 +6,7 @@ import {type CodeGraphSnapshot, CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION}
 import {codeGraphRemovedViewCleanupSchemaAdmission} from './store_schema_migration.js';
 import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconciliation.js';
 import {codeGraphDatabaseIntegrity} from './store_health.js';
+import {inspectCodeGraphSnapshotFileCitationSchema} from './store_file_alias_schema.js';
 
 const diagnoseDatabase = Effect.fn('codeGraph.diagnoseDatabase')(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -18,9 +19,12 @@ const diagnoseDatabase = Effect.fn('codeGraph.diagnoseDatabase')(function* () {
   const schemaVersion = Number.parseInt(schemaRows[0]?.value ?? '', 10);
   const cleanupAdmission = yield* codeGraphRemovedViewCleanupSchemaAdmission(sql);
   const persistentExtensionSchemaRevision = cleanupAdmission.persistentExtensionSchemaRevision;
+  const snapshotFileCitation = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
   const persistentExtensionCurrent =
     persistentExtensionSchemaRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION &&
     (yield* codeGraphPersistentExtensionSchemaCompatible(sql)) &&
+    snapshotFileCitation.baseIndexes === 'current' &&
+    snapshotFileCitation.state === 'current' &&
     cleanupAdmission.current;
   const coreReadSchemaCompatible = yield* codeGraphWorktreeReconciliationSchemaCompatible(
     sql,
@@ -51,6 +55,8 @@ const diagnoseDatabase = Effect.fn('codeGraph.diagnoseDatabase')(function* () {
       persistentExtensionSchemaRevision,
       schemaVersion: Number.isSafeInteger(schemaVersion) ? schemaVersion : undefined,
     }),
+    snapshotFileCitationBaseIndexes: snapshotFileCitation.baseIndexes,
+    snapshotFileCitationSchema: snapshotFileCitation.state,
     readySnapshots: counts.get('ready') ?? 0,
     persistentExtensionSchemaRevision,
     schemaVersion: Number.isSafeInteger(schemaVersion) ? schemaVersion : undefined,

--- a/src/code_graph/store_file_alias_schema.ts
+++ b/src/code_graph/store_file_alias_schema.ts
@@ -13,6 +13,8 @@ import {
   CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION,
   CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   CODE_GRAPH_SCHEMA_VERSION,
+  type CodeGraphSnapshotFileCitationBaseIndexState,
+  type CodeGraphSnapshotFileCitationSchemaState,
   CodeGraphStoreError,
 } from './types.js';
 
@@ -90,22 +92,14 @@ const CODE_GRAPH_SNAPSHOT_FILES_MIGRATED_TABLE_SQL = `
   ) WITHOUT ROWID
 `;
 
-export type CodeGraphSnapshotFileCitationSchemaState =
-  | 'column-only'
-  | 'column-only-with-authority'
-  | 'column-only-with-predecessor-authority'
-  | 'current'
-  | 'incompatible'
-  | 'released-absent'
-  | 'released-absent-with-predecessor-authority'
-  | 'released-absent-with-authority'
-  | 'table-absent';
-
-export type CodeGraphSnapshotFileCitationBaseIndexState = 'current' | 'incompatible' | 'missing';
-
 export interface CodeGraphSnapshotFileCitationSchemaInspection {
   readonly baseIndexes: CodeGraphSnapshotFileCitationBaseIndexState;
   readonly state: CodeGraphSnapshotFileCitationSchemaState;
+}
+
+export interface CodeGraphSnapshotFileCitationSchemaAuthorization {
+  readonly allowColumnAuthority: boolean;
+  readonly allowReleasedAuthority: boolean;
 }
 
 function citationSchemaInspection(
@@ -579,35 +573,48 @@ export const assertCodeGraphSnapshotFileCitationSchemaMigratable = Effect.fn(
   ) {
     return yield* Effect.fail(new CodeGraphStoreError('Code graph snapshot file citation schema is incompatible.'));
   }
-  return (
-    inspection.state === 'released-absent-with-authority' &&
-    revision !== undefined &&
-    Number.isSafeInteger(revision) &&
-    revision >= CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION &&
-    revision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
-  );
+  return {
+    allowColumnAuthority: inspection.state === 'column-only-with-predecessor-authority',
+    allowReleasedAuthority:
+      inspection.state === 'released-absent-with-authority' ||
+      inspection.state === 'released-absent-with-predecessor-authority',
+  } satisfies CodeGraphSnapshotFileCitationSchemaAuthorization;
 });
 
 export const ensureCodeGraphSnapshotFileCitationSchema = Effect.fn('codeGraph.ensureSnapshotFileCitationSchema')(
-  function* (sql: SqlClient.SqlClient, allowLegacyReleasedAuthority: boolean) {
+  function* (sql: SqlClient.SqlClient, authorization: CodeGraphSnapshotFileCitationSchemaAuthorization) {
     const before = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
+    const columnAuthority =
+      before.state === 'column-only-with-authority' || before.state === 'column-only-with-predecessor-authority';
+    const releasedAuthority =
+      before.state === 'released-absent-with-authority' ||
+      before.state === 'released-absent-with-predecessor-authority';
     if (
       before.state === 'incompatible' ||
-      before.state === 'table-absent' ||
-      before.state === 'column-only-with-authority' ||
-      (before.state === 'released-absent-with-authority' && !allowLegacyReleasedAuthority) ||
-      before.baseIndexes !== 'current'
+      before.baseIndexes === 'incompatible' ||
+      (columnAuthority && !authorization.allowColumnAuthority) ||
+      (releasedAuthority && !authorization.allowReleasedAuthority)
     ) {
       return yield* Effect.fail(new CodeGraphStoreError('Code graph snapshot file citation schema is incompatible.'));
     }
+    yield* sql.unsafe(
+      CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL.replace('CREATE TABLE', 'CREATE TABLE IF NOT EXISTS'),
+    );
+    for (const index of [
+      CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX,
+      CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX,
+    ]) {
+      yield* sql.unsafe(index.definition.replace('CREATE INDEX', 'CREATE INDEX IF NOT EXISTS'));
+    }
+    const alias = before.state === 'table-absent' ? 'column-only' : before.state;
     if (
-      before.state === 'released-absent' ||
-      before.state === 'released-absent-with-authority' ||
-      before.state === 'released-absent-with-predecessor-authority'
+      alias === 'released-absent' ||
+      alias === 'released-absent-with-authority' ||
+      alias === 'released-absent-with-predecessor-authority'
     ) {
       yield* sql.unsafe('ALTER TABLE snapshot_files ADD COLUMN raw_content_hash TEXT');
     }
-    if (before.state !== 'current') yield* sql.unsafe(CODE_GRAPH_RAW_CONTENT_ALIAS_INDEX_SQL);
+    if (alias !== 'current') yield* sql.unsafe(CODE_GRAPH_RAW_CONTENT_ALIAS_INDEX_SQL);
     const after = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
     if (after.state !== 'current' || after.baseIndexes !== 'current') {
       return yield* Effect.fail(new CodeGraphStoreError('Code graph snapshot file citation schema is unavailable.'));

--- a/src/code_graph/store_file_alias_schema.ts
+++ b/src/code_graph/store_file_alias_schema.ts
@@ -1,0 +1,616 @@
+import {Effect} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {normalizeSchemaDefinition} from './store_schema_normalization.js';
+import {inspectBoundedSchemaMetadataValue} from './store_schema_metadata.js';
+import {
+  CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE,
+  CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE_SQL,
+  CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM,
+  CODE_GRAPH_SQLITE_SCHEMA_VERSION_MINIMUM,
+  nextCodeGraphSqliteSchemaVersion,
+} from './store_schema_receipt.js';
+import {
+  CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION,
+  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+  CODE_GRAPH_SCHEMA_VERSION,
+  CodeGraphStoreError,
+} from './types.js';
+
+interface CodeGraphReferenceIndex {
+  readonly columns: readonly string[];
+  readonly definition: string;
+  readonly name: string;
+  readonly table: string;
+}
+
+export const CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX = {
+  columns: ['path', 'content_hash'],
+  definition: 'CREATE INDEX snapshot_files_blob ON snapshot_files(path, content_hash)',
+  name: 'snapshot_files_blob',
+  table: 'snapshot_files',
+} as const satisfies CodeGraphReferenceIndex;
+
+export const CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX = {
+  columns: ['content_hash'],
+  definition: 'CREATE INDEX snapshot_files_content_hash ON snapshot_files(content_hash)',
+  name: 'snapshot_files_content_hash',
+  table: 'snapshot_files',
+} as const satisfies CodeGraphReferenceIndex;
+
+export const CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX = {
+  columns: ['raw_content_hash'],
+  definition:
+    'CREATE INDEX snapshot_files_raw_content_hash ON snapshot_files(raw_content_hash) WHERE raw_content_hash IS NOT NULL',
+  name: 'snapshot_files_raw_content_hash',
+  table: 'snapshot_files',
+} as const satisfies CodeGraphReferenceIndex;
+
+export const CODE_GRAPH_RAW_CONTENT_ALIAS_INDEX = CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX.name;
+export const CODE_GRAPH_RAW_CONTENT_ALIAS_INDEX_SQL = CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX.definition;
+
+const CODE_GRAPH_SNAPSHOT_FILES_RELEASED_TABLE_SQL = `
+  CREATE TABLE snapshot_files (
+    snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+    path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    language TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    size INTEGER NOT NULL CHECK (size >= 0),
+    source TEXT NOT NULL CHECK (source IN ('commit', 'worktree')),
+    PRIMARY KEY (snapshot_id, path)
+  ) WITHOUT ROWID
+`;
+
+export const CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL = `
+  CREATE TABLE snapshot_files (
+    snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+    path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    raw_content_hash TEXT,
+    language TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    size INTEGER NOT NULL CHECK (size >= 0),
+    source TEXT NOT NULL CHECK (source IN ('commit', 'worktree')),
+    PRIMARY KEY (snapshot_id, path)
+  ) WITHOUT ROWID
+`;
+
+/** SQLite's exact table definition after adding the v16 alias to a released v15 table. */
+const CODE_GRAPH_SNAPSHOT_FILES_MIGRATED_TABLE_SQL = `
+  CREATE TABLE snapshot_files (
+    snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+    path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    language TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    size INTEGER NOT NULL CHECK (size >= 0),
+    source TEXT NOT NULL CHECK (source IN ('commit', 'worktree')),
+    raw_content_hash TEXT,
+    PRIMARY KEY (snapshot_id, path)
+  ) WITHOUT ROWID
+`;
+
+export type CodeGraphSnapshotFileCitationSchemaState =
+  | 'column-only'
+  | 'column-only-with-authority'
+  | 'column-only-with-predecessor-authority'
+  | 'current'
+  | 'incompatible'
+  | 'released-absent'
+  | 'released-absent-with-predecessor-authority'
+  | 'released-absent-with-authority'
+  | 'table-absent';
+
+export type CodeGraphSnapshotFileCitationBaseIndexState = 'current' | 'incompatible' | 'missing';
+
+export interface CodeGraphSnapshotFileCitationSchemaInspection {
+  readonly baseIndexes: CodeGraphSnapshotFileCitationBaseIndexState;
+  readonly state: CodeGraphSnapshotFileCitationSchemaState;
+}
+
+function citationSchemaInspection(
+  baseIndexes: CodeGraphSnapshotFileCitationBaseIndexState,
+  state: CodeGraphSnapshotFileCitationSchemaState,
+): CodeGraphSnapshotFileCitationSchemaInspection {
+  return {baseIndexes, state};
+}
+
+/** Exact row-preserving admission shared by repair preview and initialization. */
+export function codeGraphSnapshotFileCitationSchemaMigrationPreserves(
+  revision: number | undefined,
+  state: CodeGraphSnapshotFileCitationSchemaState,
+  baseIndexes: CodeGraphSnapshotFileCitationBaseIndexState,
+): boolean {
+  if (baseIndexes === 'incompatible') return false;
+  if (revision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION - 1) {
+    return (
+      state === 'released-absent' ||
+      state === 'released-absent-with-authority' ||
+      state === 'released-absent-with-predecessor-authority' ||
+      state === 'column-only' ||
+      state === 'current'
+    );
+  }
+  if (revision !== CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) return false;
+  return (
+    state === 'released-absent' ||
+    state === 'released-absent-with-predecessor-authority' ||
+    state === 'column-only' ||
+    state === 'column-only-with-predecessor-authority' ||
+    (baseIndexes === 'missing' && state === 'current')
+  );
+}
+
+/** Exact citation-schema admission; other extension migrations retain their own authority rules. */
+export function codeGraphSnapshotFileCitationSchemaMigrationAdmitted(
+  revision: number | undefined,
+  state: CodeGraphSnapshotFileCitationSchemaState,
+  baseIndexes: CodeGraphSnapshotFileCitationBaseIndexState,
+): boolean {
+  if (baseIndexes === 'incompatible') return false;
+  switch (state) {
+    case 'released-absent-with-authority':
+      return (
+        revision !== undefined &&
+        Number.isSafeInteger(revision) &&
+        revision >= CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION &&
+        revision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
+      );
+    case 'released-absent-with-predecessor-authority':
+      return revision === 15 || revision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION;
+    case 'column-only-with-predecessor-authority':
+      return revision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION;
+    case 'column-only-with-authority':
+    case 'incompatible':
+      return false;
+    default:
+      return true;
+  }
+}
+
+export const codeGraphCacheReferenceIndexState = Effect.fn('codeGraph.cacheReferenceIndexState')(function* (
+  sql: SqlClient.SqlClient,
+  index: CodeGraphReferenceIndex,
+) {
+  const definitions = yield* sql.unsafe<{
+    readonly bounded_sql: unknown;
+    readonly name: unknown;
+    readonly sql_bytes: unknown;
+    readonly tbl_name: unknown;
+    readonly type: unknown;
+  }>(
+    `SELECT name, type, tbl_name,
+            CASE
+              WHEN typeof(sql) = 'text' AND length(CAST(sql AS BLOB)) <= 1024 THEN sql
+              ELSE NULL
+            END AS bounded_sql,
+            length(CAST(sql AS BLOB)) AS sql_bytes
+     FROM sqlite_master
+     WHERE name = ? COLLATE NOCASE
+     LIMIT 2`,
+    [index.name],
+  );
+  if (definitions.length === 0) return 'missing' as const;
+  const definition = definitions[0];
+  if (
+    definitions.length !== 1 ||
+    definition?.name !== index.name ||
+    definition.type !== 'index' ||
+    definition.tbl_name !== index.table ||
+    typeof definition.sql_bytes !== 'number' ||
+    !Number.isSafeInteger(definition.sql_bytes) ||
+    definition.sql_bytes > 1024 ||
+    typeof definition.bounded_sql !== 'string' ||
+    normalizeSchemaDefinition(definition.bounded_sql) !== normalizeSchemaDefinition(index.definition)
+  ) {
+    return 'incompatible' as const;
+  }
+  const xinfo = yield* sql.unsafe<{
+    readonly coll: unknown;
+    readonly desc: unknown;
+    readonly key: unknown;
+    readonly name: unknown;
+    readonly seqno: unknown;
+  }>(`SELECT seqno, name, desc, coll, key FROM pragma_index_xinfo(?) LIMIT 8`, [index.name]);
+  const keyColumns = xinfo
+    .filter(column => Number(column.key) === 1)
+    .sort((left, right) => {
+      return Number(left.seqno) - Number(right.seqno);
+    });
+  return xinfo.length > 0 &&
+    xinfo.length < 8 &&
+    keyColumns.length === index.columns.length &&
+    keyColumns.every(
+      (column, columnIndex) =>
+        column.name === index.columns[columnIndex] &&
+        typeof column.coll === 'string' &&
+        column.coll.toUpperCase() === 'BINARY' &&
+        column.desc === 0,
+    )
+    ? ('ready' as const)
+    : ('incompatible' as const);
+});
+
+const snapshotAuthorityState = Effect.fn('codeGraph.snapshotAuthorityState')(function* (
+  sql: SqlClient.SqlClient,
+  includeSnapshotFiles = false,
+) {
+  const objects = yield* sql.unsafe<{readonly name: unknown; readonly type: unknown}>(
+    `SELECT name, type
+       FROM sqlite_master
+       WHERE name = 'snapshots' COLLATE NOCASE
+          OR name = 'active_snapshots' COLLATE NOCASE
+          OR (${includeSnapshotFiles ? '1' : '0'} = 1 AND name = 'snapshot_files' COLLATE NOCASE)
+       LIMIT 4`,
+  );
+  if (
+    objects.length > (includeSnapshotFiles ? 3 : 2) ||
+    objects.some(
+      object =>
+        object.type !== 'table' ||
+        (object.name !== 'snapshots' &&
+          object.name !== 'active_snapshots' &&
+          (!includeSnapshotFiles || object.name !== 'snapshot_files')),
+    )
+  ) {
+    return 'incompatible' as const;
+  }
+  for (const table of [
+    'snapshots',
+    'active_snapshots',
+    ...(includeSnapshotFiles ? (['snapshot_files'] as const) : []),
+  ] as const) {
+    if (!objects.some(object => object.name === table)) continue;
+    const authority = yield* sql.unsafe<{readonly present: unknown}>(`SELECT 1 AS present FROM ${table} LIMIT 1`);
+    if (authority.length > 0) return 'present' as const;
+  }
+  return 'absent' as const;
+});
+
+const predecessorInitializationReceiptPresent = Effect.fn('codeGraph.predecessorInitializationReceiptPresent')(
+  function* (sql: SqlClient.SqlClient, cookieTransition: 'next' | 'same') {
+    const definitions = yield* sql.unsafe<{readonly name: unknown; readonly sql: unknown; readonly type: unknown}>(
+      `SELECT name,
+              CASE WHEN typeof(sql) = 'text' AND length(CAST(sql AS BLOB)) <= 2048 THEN sql ELSE NULL END AS sql,
+              type
+       FROM sqlite_master
+       WHERE name = '${CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE}' COLLATE NOCASE
+       LIMIT 2`,
+    );
+    if (
+      definitions.length !== 1 ||
+      definitions[0]?.name !== CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE ||
+      definitions[0].type !== 'table' ||
+      typeof definitions[0].sql !== 'string' ||
+      normalizeSchemaDefinition(definitions[0].sql) !==
+        normalizeSchemaDefinition(CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE_SQL)
+    ) {
+      return false;
+    }
+    const receipts = yield* sql.unsafe<{
+      readonly contract_revision: unknown;
+      readonly contract_revision_type: unknown;
+      readonly core_schema_version: unknown;
+      readonly core_schema_version_type: unknown;
+      readonly persistent_extension_revision: unknown;
+      readonly persistent_extension_revision_type: unknown;
+      readonly singleton: unknown;
+      readonly singleton_type: unknown;
+      readonly sqlite_schema_version: unknown;
+      readonly sqlite_schema_version_type: unknown;
+    }>(
+      `SELECT CASE WHEN typeof(singleton) = 'integer' THEN singleton ELSE NULL END AS singleton,
+              typeof(singleton) AS singleton_type,
+              CASE WHEN typeof(contract_revision) = 'integer' THEN contract_revision ELSE NULL END
+                AS contract_revision,
+              typeof(contract_revision) AS contract_revision_type,
+              CASE WHEN typeof(core_schema_version) = 'integer' THEN core_schema_version ELSE NULL END
+                AS core_schema_version,
+              typeof(core_schema_version) AS core_schema_version_type,
+              CASE
+                WHEN typeof(persistent_extension_revision) = 'integer' THEN persistent_extension_revision
+                ELSE NULL
+              END AS persistent_extension_revision,
+              typeof(persistent_extension_revision) AS persistent_extension_revision_type,
+              CASE WHEN typeof(sqlite_schema_version) = 'integer' THEN sqlite_schema_version ELSE NULL END
+                AS sqlite_schema_version,
+              typeof(sqlite_schema_version) AS sqlite_schema_version_type
+       FROM ${CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE}
+       LIMIT 2`,
+    );
+    const receipt = receipts[0];
+    const schemaVersions = yield* sql.unsafe<{readonly schema_version: unknown}>('PRAGMA schema_version');
+    const schemaVersion = schemaVersions[0]?.schema_version;
+    const receiptSchemaVersion = receipt?.sqlite_schema_version;
+    const expectedSchemaVersion =
+      typeof receiptSchemaVersion === 'number' && Number.isSafeInteger(receiptSchemaVersion)
+        ? cookieTransition === 'same'
+          ? receiptSchemaVersion
+          : nextCodeGraphSqliteSchemaVersion(receiptSchemaVersion)
+        : undefined;
+    return (
+      receipts.length === 1 &&
+      receipt?.singleton_type === 'integer' &&
+      receipt?.singleton === 1 &&
+      receipt.contract_revision_type === 'integer' &&
+      receipt.contract_revision === 2 &&
+      receipt.core_schema_version_type === 'integer' &&
+      receipt.core_schema_version === CODE_GRAPH_SCHEMA_VERSION &&
+      receipt.persistent_extension_revision_type === 'integer' &&
+      receipt.persistent_extension_revision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION - 1 &&
+      receipt.sqlite_schema_version_type === 'integer' &&
+      typeof receiptSchemaVersion === 'number' &&
+      Number.isSafeInteger(receiptSchemaVersion) &&
+      receiptSchemaVersion >= CODE_GRAPH_SQLITE_SCHEMA_VERSION_MINIMUM &&
+      receiptSchemaVersion <= CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM &&
+      typeof schemaVersion === 'number' &&
+      Number.isSafeInteger(schemaVersion) &&
+      schemaVersion === expectedSchemaVersion
+    );
+  },
+);
+
+const snapshotFileSchemaObjectsExact = Effect.fn('codeGraph.snapshotFileSchemaObjectsExact')(function* (
+  sql: SqlClient.SqlClient,
+) {
+  const indexes = yield* sql.unsafe<{
+    readonly name: unknown;
+    readonly origin: unknown;
+    readonly partial: unknown;
+    readonly unique: unknown;
+  }>(
+    `SELECT name, origin, partial, "unique" AS "unique"
+     FROM pragma_index_list('snapshot_files')
+     LIMIT 5`,
+  );
+  const expected = new Map<string, {readonly origin: string; readonly partial: number; readonly unique: number}>([
+    ['sqlite_autoindex_snapshot_files_1', {origin: 'pk', partial: 0, unique: 1}],
+    [CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX.name, {origin: 'c', partial: 0, unique: 0}],
+    [CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX.name, {origin: 'c', partial: 0, unique: 0}],
+    [CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX.name, {origin: 'c', partial: 1, unique: 0}],
+  ]);
+  if (
+    indexes.length >= 5 ||
+    indexes.some(index => {
+      if (typeof index.name !== 'string') return true;
+      const contract = expected.get(index.name);
+      return (
+        contract === undefined ||
+        index.origin !== contract.origin ||
+        index.partial !== contract.partial ||
+        index.unique !== contract.unique
+      );
+    }) ||
+    !indexes.some(index => index.name === 'sqlite_autoindex_snapshot_files_1')
+  ) {
+    return false;
+  }
+  const triggers = yield* sql.unsafe(
+    `SELECT 1
+     FROM sqlite_master
+     WHERE type = 'trigger' AND tbl_name = 'snapshot_files' COLLATE NOCASE
+     LIMIT 1`,
+  );
+  return triggers.length === 0;
+});
+
+export const inspectCodeGraphSnapshotFileCitationSchema = Effect.fn('codeGraph.inspectSnapshotFileCitationSchema')(
+  function* (sql: SqlClient.SqlClient) {
+    const tables = yield* sql.unsafe<{
+      readonly bounded_sql: unknown;
+      readonly name: unknown;
+      readonly sql_bytes: unknown;
+      readonly type: unknown;
+    }>(
+      `SELECT name, type,
+            CASE
+              WHEN typeof(sql) = 'text' AND length(CAST(sql AS BLOB)) <= 4096 THEN sql
+              ELSE NULL
+            END AS bounded_sql,
+            length(CAST(sql AS BLOB)) AS sql_bytes
+       FROM sqlite_master
+       WHERE name = 'snapshot_files' COLLATE NOCASE
+       LIMIT 2`,
+    );
+    if (tables.length === 0) {
+      return (yield* snapshotAuthorityState(sql)) === 'absent'
+        ? citationSchemaInspection('missing', 'table-absent')
+        : citationSchemaInspection('incompatible', 'incompatible');
+    }
+    const table = tables[0];
+    if (
+      tables.length !== 1 ||
+      table?.name !== 'snapshot_files' ||
+      table.type !== 'table' ||
+      typeof table.sql_bytes !== 'number' ||
+      !Number.isSafeInteger(table.sql_bytes) ||
+      table.sql_bytes > 4096 ||
+      typeof table.bounded_sql !== 'string'
+    ) {
+      return citationSchemaInspection('incompatible', 'incompatible');
+    }
+    const normalizedTable = normalizeSchemaDefinition(table.bounded_sql);
+    const releasedTable = normalizedTable === normalizeSchemaDefinition(CODE_GRAPH_SNAPSHOT_FILES_RELEASED_TABLE_SQL);
+    const currentTable = [
+      CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL,
+      CODE_GRAPH_SNAPSHOT_FILES_MIGRATED_TABLE_SQL,
+    ].some(definition => normalizedTable === normalizeSchemaDefinition(definition));
+    if (!releasedTable && !currentTable) return citationSchemaInspection('incompatible', 'incompatible');
+
+    const columns = yield* sql.unsafe<{
+      readonly dflt_value: unknown;
+      readonly hidden: unknown;
+      readonly name: unknown;
+      readonly notnull: unknown;
+      readonly pk: unknown;
+      readonly type: unknown;
+    }>(
+      `SELECT name, type, "notnull" AS "notnull", dflt_value, pk, hidden
+       FROM pragma_table_xinfo('snapshot_files')
+       WHERE name = 'raw_content_hash' COLLATE NOCASE
+       LIMIT 2`,
+    );
+    const column = columns[0];
+    const columnCurrent =
+      columns.length === 1 &&
+      column?.name === 'raw_content_hash' &&
+      column.type === 'TEXT' &&
+      column.notnull === 0 &&
+      column.dflt_value === null &&
+      column.pk === 0 &&
+      column.hidden === 0;
+    if ((releasedTable && columns.length !== 0) || (currentTable && !columnCurrent)) {
+      return citationSchemaInspection('incompatible', 'incompatible');
+    }
+
+    const baseIndexes = yield* Effect.all(
+      [
+        codeGraphCacheReferenceIndexState(sql, CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX),
+        codeGraphCacheReferenceIndexState(sql, CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX),
+      ],
+      {concurrency: 1},
+    );
+    const rawIndex = yield* codeGraphCacheReferenceIndexState(
+      sql,
+      CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX,
+    );
+    const authorityState = yield* snapshotAuthorityState(sql, true);
+    if (authorityState === 'incompatible') return citationSchemaInspection('incompatible', 'incompatible');
+    const releasedAuthorityState = releasedTable && authorityState === 'present';
+    const aliasState = releasedTable
+      ? rawIndex === 'missing'
+        ? releasedAuthorityState
+          ? (yield* predecessorInitializationReceiptPresent(sql, 'same'))
+            ? ('released-absent-with-predecessor-authority' as const)
+            : ('released-absent-with-authority' as const)
+          : ('released-absent' as const)
+        : ('incompatible' as const)
+      : rawIndex === 'missing'
+        ? authorityState === 'present'
+          ? (yield* predecessorInitializationReceiptPresent(sql, 'next'))
+            ? ('column-only-with-predecessor-authority' as const)
+            : ('column-only-with-authority' as const)
+          : ('column-only' as const)
+        : rawIndex === 'ready'
+          ? ('current' as const)
+          : ('incompatible' as const);
+    if (aliasState === 'incompatible' || !(yield* snapshotFileSchemaObjectsExact(sql))) {
+      return citationSchemaInspection('incompatible', 'incompatible');
+    }
+    return citationSchemaInspection(
+      baseIndexes.some(state => state === 'incompatible')
+        ? 'incompatible'
+        : baseIndexes.some(state => state === 'missing')
+          ? authorityState === 'present'
+            ? 'incompatible'
+            : 'missing'
+          : 'current',
+      aliasState,
+    );
+  },
+);
+
+export const codeGraphSnapshotFileCitationSchemaState = Effect.fn('codeGraph.snapshotFileCitationSchemaState')(
+  function* (sql: SqlClient.SqlClient) {
+    return (yield* inspectCodeGraphSnapshotFileCitationSchema(sql)).state;
+  },
+);
+
+export const prepareCodeGraphSnapshotFileCitationSchema = Effect.fn('codeGraph.prepareSnapshotFileCitationSchema')(
+  function* (sql: SqlClient.SqlClient, revision: number | undefined) {
+    const inspection = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
+    const authoritySensitive =
+      inspection.state === 'released-absent-with-authority' ||
+      inspection.state === 'released-absent-with-predecessor-authority' ||
+      inspection.state === 'column-only-with-authority' ||
+      inspection.state === 'column-only-with-predecessor-authority';
+    if (
+      inspection.state === 'incompatible' ||
+      inspection.state === 'table-absent' ||
+      inspection.baseIndexes === 'incompatible' ||
+      (authoritySensitive &&
+        !codeGraphSnapshotFileCitationSchemaMigrationAdmitted(revision, inspection.state, inspection.baseIndexes))
+    ) {
+      return {state: 'incompatible'} as const;
+    }
+    if (inspection.baseIndexes !== 'missing') {
+      return {citationSchema: inspection.state, state: 'ready'} as const;
+    }
+    for (const index of [
+      CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX,
+      CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX,
+    ]) {
+      const indexState = yield* codeGraphCacheReferenceIndexState(sql, index);
+      if (indexState === 'incompatible') return {state: 'incompatible'} as const;
+      if (indexState !== 'missing') continue;
+      yield* sql.unsafe(index.definition);
+      if ((yield* codeGraphCacheReferenceIndexState(sql, index)) !== 'ready') {
+        return yield* Effect.fail(
+          new CodeGraphStoreError('Code graph snapshot file citation index changed during setup.'),
+        );
+      }
+      return {index: index.name, state: 'prepared'} as const;
+    }
+    return yield* Effect.fail(
+      new CodeGraphStoreError('Code graph snapshot file citation schema changed during setup.'),
+    );
+  },
+);
+
+export const assertCodeGraphSnapshotFileCitationSchemaMigratable = Effect.fn(
+  'codeGraph.assertSnapshotFileCitationSchemaMigratable',
+)(function* (sql: SqlClient.SqlClient) {
+  const inspection = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
+  if (inspection.state === 'incompatible' || inspection.baseIndexes === 'incompatible') {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph snapshot file citation schema is incompatible.'));
+  }
+  const revisionObservation = yield* inspectBoundedSchemaMetadataValue(sql, 'persistent_extension_schema_revision', 16);
+  const revisionValue = revisionObservation.state === 'recorded' ? revisionObservation.value : undefined;
+  const revision =
+    typeof revisionValue === 'string' && /^(?:0|[1-9][0-9]*)$/u.test(revisionValue) ? Number(revisionValue) : undefined;
+  const authoritySensitive =
+    inspection.state === 'released-absent-with-authority' ||
+    inspection.state === 'released-absent-with-predecessor-authority' ||
+    inspection.state === 'column-only-with-authority' ||
+    inspection.state === 'column-only-with-predecessor-authority';
+  if (
+    authoritySensitive &&
+    !codeGraphSnapshotFileCitationSchemaMigrationAdmitted(revision, inspection.state, inspection.baseIndexes)
+  ) {
+    return yield* Effect.fail(new CodeGraphStoreError('Code graph snapshot file citation schema is incompatible.'));
+  }
+  return (
+    inspection.state === 'released-absent-with-authority' &&
+    revision !== undefined &&
+    Number.isSafeInteger(revision) &&
+    revision >= CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION &&
+    revision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
+  );
+});
+
+export const ensureCodeGraphSnapshotFileCitationSchema = Effect.fn('codeGraph.ensureSnapshotFileCitationSchema')(
+  function* (sql: SqlClient.SqlClient, allowLegacyReleasedAuthority: boolean) {
+    const before = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
+    if (
+      before.state === 'incompatible' ||
+      before.state === 'table-absent' ||
+      before.state === 'column-only-with-authority' ||
+      (before.state === 'released-absent-with-authority' && !allowLegacyReleasedAuthority) ||
+      before.baseIndexes !== 'current'
+    ) {
+      return yield* Effect.fail(new CodeGraphStoreError('Code graph snapshot file citation schema is incompatible.'));
+    }
+    if (
+      before.state === 'released-absent' ||
+      before.state === 'released-absent-with-authority' ||
+      before.state === 'released-absent-with-predecessor-authority'
+    ) {
+      yield* sql.unsafe('ALTER TABLE snapshot_files ADD COLUMN raw_content_hash TEXT');
+    }
+    if (before.state !== 'current') yield* sql.unsafe(CODE_GRAPH_RAW_CONTENT_ALIAS_INDEX_SQL);
+    const after = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
+    if (after.state !== 'current' || after.baseIndexes !== 'current') {
+      return yield* Effect.fail(new CodeGraphStoreError('Code graph snapshot file citation schema is unavailable.'));
+    }
+  },
+);

--- a/src/code_graph/store_health.ts
+++ b/src/code_graph/store_health.ts
@@ -5,7 +5,9 @@ import {type CodeGraphDatabaseHealth} from './store_models.js';
 import {codeGraphPersistentExtensionSchemaCompatible} from './store_schema_inspection.js';
 import {codeGraphRemovedViewCleanupSchemaAdmission} from './store_schema_migration.js';
 import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconciliation.js';
+import {inspectCodeGraphSnapshotFileCitationSchema} from './store_file_alias_schema.js';
 import {
+  CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION,
   CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   CODE_GRAPH_SCHEMA_VERSION,
   type CodeGraphSnapshot,
@@ -13,8 +15,7 @@ import {
 
 export type CodeGraphDatabaseIntegrity = 'corrupt' | 'incompatible' | 'migration-pending' | 'ok';
 
-/** Oldest released additive extension revision that the current reader can safely serve. */
-export const CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION = 6;
+export {CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION} from './types.js';
 
 export function codeGraphDatabaseIntegrity(input: {
   readonly coreReadSchemaCompatible: boolean;
@@ -53,9 +54,12 @@ export const diagnoseCodeGraphDatabaseReadOnly = Effect.fn('codeGraph.diagnoseDa
     const schemaVersion = Number.parseInt(schemaRows[0]?.value ?? '', 10);
     const cleanupAdmission = yield* codeGraphRemovedViewCleanupSchemaAdmission(sql);
     const persistentExtensionSchemaRevision = cleanupAdmission.persistentExtensionSchemaRevision;
+    const snapshotFileCitation = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
     const persistentExtensionCurrent =
       persistentExtensionSchemaRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION &&
       (yield* codeGraphPersistentExtensionSchemaCompatible(sql)) &&
+      snapshotFileCitation.baseIndexes === 'current' &&
+      snapshotFileCitation.state === 'current' &&
       cleanupAdmission.current;
     const coreReadSchemaCompatible = yield* codeGraphWorktreeReconciliationSchemaCompatible(
       sql,
@@ -86,6 +90,8 @@ export const diagnoseCodeGraphDatabaseReadOnly = Effect.fn('codeGraph.diagnoseDa
         persistentExtensionSchemaRevision,
         schemaVersion: Number.isSafeInteger(schemaVersion) ? schemaVersion : undefined,
       }),
+      snapshotFileCitationBaseIndexes: snapshotFileCitation.baseIndexes,
+      snapshotFileCitationSchema: snapshotFileCitation.state,
       readySnapshots: counts.get('ready') ?? 0,
       persistentExtensionSchemaRevision,
       schemaVersion: Number.isSafeInteger(schemaVersion) ? schemaVersion : undefined,

--- a/src/code_graph/store_maintenance_core.ts
+++ b/src/code_graph/store_maintenance_core.ts
@@ -4,7 +4,12 @@ import {SystemInfo} from '../effect/system.js';
 import {classifyCodeGraphBuildOwner} from './build_owner.js';
 import {MAXIMUM_CANONICAL_DATE_MILLISECONDS} from './store_removed_view_schema_contracts.js';
 import {removedViewCleanupRecordedRevision} from './store_removed_view_schema_inspection.js';
-import {normalizeSchemaDefinition} from './store_schema_normalization.js';
+import {
+  codeGraphCacheReferenceIndexState,
+  CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX,
+  CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX,
+  CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX,
+} from './store_file_alias_schema.js';
 import {
   CODE_GRAPH_ABANDONED_BUILD_CANDIDATE_LIMIT,
   CODE_GRAPH_ABANDONED_BUILD_CURSOR_KEY,
@@ -24,28 +29,6 @@ const CODE_GRAPH_ROUTINE_CACHE_PAGE_SIZE = 100;
 
 /** Fresh facts are written before the durable building snapshot owns its inventory. */
 const CODE_GRAPH_ROUTINE_CACHE_MINIMUM_AGE_MILLISECONDS = 24 * 60 * 60_000;
-
-const CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX = {
-  columns: ['path', 'content_hash'],
-  definition: 'CREATE INDEX snapshot_files_blob ON snapshot_files(path, content_hash)',
-  name: 'snapshot_files_blob',
-  table: 'snapshot_files',
-} as const;
-
-const CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX = {
-  columns: ['content_hash'],
-  definition: 'CREATE INDEX snapshot_files_content_hash ON snapshot_files(content_hash)',
-  name: 'snapshot_files_content_hash',
-  table: 'snapshot_files',
-} as const;
-
-const CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX = {
-  columns: ['raw_content_hash'],
-  definition:
-    'CREATE INDEX snapshot_files_raw_content_hash ON snapshot_files(raw_content_hash) WHERE raw_content_hash IS NOT NULL',
-  name: 'snapshot_files_raw_content_hash',
-  table: 'snapshot_files',
-} as const;
 
 const CODE_GRAPH_MATERIALIZED_SHARD_REFERENCE_INDEX = {
   columns: ['shard_id'],
@@ -372,72 +355,6 @@ const routineCacheSchemaCurrent = Effect.fn('codeGraph.routineCacheSchemaCurrent
   );
 });
 
-type CodeGraphCacheReferenceIndex =
-  | typeof CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX
-  | typeof CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX
-  | typeof CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX
-  | typeof CODE_GRAPH_MATERIALIZED_SHARD_REFERENCE_INDEX;
-
-const codeGraphCacheReferenceIndexState = Effect.fn('codeGraph.cacheReferenceIndexState')(function* (
-  sql: SqlClient.SqlClient,
-  index: CodeGraphCacheReferenceIndex,
-) {
-  const definitions = yield* sql.unsafe<{
-    readonly bounded_sql: unknown;
-    readonly name: unknown;
-    readonly sql_bytes: unknown;
-    readonly tbl_name: unknown;
-    readonly type: unknown;
-  }>(
-    `SELECT name, type, tbl_name,
-            CASE
-              WHEN typeof(sql) = 'text' AND length(CAST(sql AS BLOB)) <= 1024 THEN sql
-              ELSE NULL
-            END AS bounded_sql,
-            length(CAST(sql AS BLOB)) AS sql_bytes
-     FROM sqlite_master
-     WHERE name = ? COLLATE NOCASE
-     LIMIT 2`,
-    [index.name],
-  );
-  if (definitions.length === 0) return 'missing' as const;
-  if (
-    definitions.length !== 1 ||
-    definitions[0]?.name !== index.name ||
-    definitions[0]?.type !== 'index' ||
-    definitions[0]?.tbl_name !== index.table ||
-    typeof definitions[0]?.sql_bytes !== 'number' ||
-    !Number.isSafeInteger(definitions[0].sql_bytes) ||
-    definitions[0].sql_bytes > 1024 ||
-    typeof definitions[0]?.bounded_sql !== 'string' ||
-    normalizeSchemaDefinition(definitions[0].bounded_sql) !== normalizeSchemaDefinition(index.definition)
-  ) {
-    return 'incompatible' as const;
-  }
-  const xinfo = yield* sql.unsafe<{
-    readonly coll: string;
-    readonly desc: number;
-    readonly key: number;
-    readonly name: string | null;
-    readonly seqno: number;
-  }>(`SELECT * FROM pragma_index_xinfo(?) LIMIT 8`, [index.name]);
-  const keyColumns = xinfo.filter(column => Number(column.key) === 1).sort((left, right) => left.seqno - right.seqno);
-  // WITHOUT ROWID secondary indexes carry the table primary-key columns as
-  // non-key payload. The stored SQL fixes the declared key surface; admit the
-  // SQLite-added payload while still requiring the exact ordered BINARY keys.
-  return xinfo.length > 0 &&
-    xinfo.length < 8 &&
-    keyColumns.length === index.columns.length &&
-    keyColumns.every(
-      (column, columnIndex) =>
-        column.name === index.columns[columnIndex] &&
-        column.coll.toUpperCase() === 'BINARY' &&
-        Number(column.desc) === 0,
-    )
-    ? ('ready' as const)
-    : ('incompatible' as const);
-});
-
 interface RawRoutineCacheCleanupState {
   readonly file_content_hash: unknown;
   readonly file_extractor_set: unknown;
@@ -745,7 +662,6 @@ export {
   decodeSnapshotLeaseManifest,
   RawRoutineCacheCleanupState,
   RoutineExpiredLeasePage,
-  CodeGraphCacheReferenceIndex,
   codeGraphCacheReferenceIndexState,
   routineCacheSchemaCurrent,
   decodeRoutineCacheCleanupState,

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -2,6 +2,10 @@ import type {Effect, Option} from 'effect';
 import type {CodeGraphBuildOwnerIdentity} from './build_owner.js';
 import type {CodeGraphDirectPersistentCapacityBoundary} from './disk_capacity.js';
 import type {CodeGraphCacheFactInput} from './fact_budget.js';
+import type {
+  CodeGraphSnapshotFileCitationBaseIndexState,
+  CodeGraphSnapshotFileCitationSchemaState,
+} from './store_file_alias_schema.js';
 import type {CodeGraphMonikerV1} from './cross_repository/types.js';
 import type {
   CodeGraphWorkspaceBuildSystem,
@@ -199,6 +203,8 @@ export interface CodeGraphDatabaseHealth {
   readonly foreignKeyViolations: number;
   readonly integrity: 'corrupt' | 'incompatible' | 'migration-pending' | 'ok';
   readonly persistentExtensionSchemaRevision?: number;
+  readonly snapshotFileCitationBaseIndexes: CodeGraphSnapshotFileCitationBaseIndexState;
+  readonly snapshotFileCitationSchema: CodeGraphSnapshotFileCitationSchemaState;
   readonly readySnapshots: number;
   readonly schemaVersion?: number;
 }
@@ -593,6 +599,13 @@ export interface CodeGraphViewRemovalStoreOptions extends CodeGraphSnapshotLease
 export interface CodeGraphWorktreeReconciliationClaimOptions extends CodeGraphSnapshotLeaseWriterOptions {
   /** Final containment proof run under the writer gate immediately before SQLite is opened. */
   readonly beforeDatabaseOpen?: () => Effect.Effect<void, unknown>;
+}
+
+export interface CodeGraphWorktreeReconciliationPreparationOptions extends CodeGraphWorktreeReconciliationClaimOptions {
+  /** @internal Deterministic rollback seam after the preview transaction starts. */
+  readonly afterPreviewTransactionStarted?: () => Effect.Effect<void, unknown>;
+  /** Simulate the bounded preparation transaction and roll every schema change back before returning. */
+  readonly preview?: boolean;
 }
 
 export interface CodeGraphWorktreeReconciliationCandidate {

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -205,6 +205,8 @@ export interface CodeGraphDatabaseHealth {
 
 export interface CodeGraphDatabaseRepair {
   readonly removedSnapshots: number;
+  /** Incomplete snapshots whose live leases still protect resumable spool state. */
+  readonly retainedIncompleteSnapshotIds: readonly string[];
 }
 
 export type CodeGraphRoutineMaintenanceDiagnostic = 'orphan-provenance-cursor-recovered';

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -2,10 +2,6 @@ import type {Effect, Option} from 'effect';
 import type {CodeGraphBuildOwnerIdentity} from './build_owner.js';
 import type {CodeGraphDirectPersistentCapacityBoundary} from './disk_capacity.js';
 import type {CodeGraphCacheFactInput} from './fact_budget.js';
-import type {
-  CodeGraphSnapshotFileCitationBaseIndexState,
-  CodeGraphSnapshotFileCitationSchemaState,
-} from './store_file_alias_schema.js';
 import type {CodeGraphMonikerV1} from './cross_repository/types.js';
 import type {
   CodeGraphWorkspaceBuildSystem,
@@ -16,6 +12,8 @@ import type {
 import {
   CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   CODE_GRAPH_SCHEMA_VERSION,
+  type CodeGraphSnapshotFileCitationBaseIndexState,
+  type CodeGraphSnapshotFileCitationSchemaState,
   type CodeGraphEdge,
   type CodeGraphFileFacts,
   type CodeGraphInventoryFile,

--- a/src/code_graph/store_reconciliation_preparation.ts
+++ b/src/code_graph/store_reconciliation_preparation.ts
@@ -9,6 +9,7 @@ import {codeGraphPersistentExtensionSchemaCompatible} from './store_schema_inspe
 import {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION, CodeGraphStoreError} from './types.js';
 import {
   codeGraphRemovedViewCleanupSchemaAdmission,
+  codeGraphSchemaMigrationPreservesIncompleteSnapshots,
   ensureRemovedViewCleanupSchema,
   preflightRemovedViewCleanupSchema,
 } from './store_schema_migration.js';
@@ -21,6 +22,9 @@ import {
 } from './store_reconciliation_core.js';
 import {initializeRoutineMaintenanceSchema} from './store_leases.js';
 import {CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION} from './store_health.js';
+import {prepareCodeGraphSnapshotFileCitationSchema} from './store_file_alias_schema.js';
+
+export const CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT = 8;
 
 /** @internal Indexed cursor-page statement retained for query-plan and high-cardinality regressions. */
 
@@ -90,7 +94,21 @@ const prepareWorktreeReconciliationIndex = Effect.fn('codeGraph.prepareWorktreeR
   if (!preflightReady || !(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql, false, false))) {
     return {reason: 'incompatible-schema', state: 'deferred'} as const;
   }
-  if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql, false))) {
+  const revision = yield* removedViewCleanupRecordedRevision(sql);
+  const recordedRevision = revision.state === 'recorded' ? revision.value : undefined;
+  const citationPreparation = yield* prepareCodeGraphSnapshotFileCitationSchema(sql, recordedRevision);
+  if (citationPreparation.state === 'incompatible') {
+    return {reason: 'incompatible-schema', state: 'deferred'} as const;
+  }
+  if (citationPreparation.state === 'prepared') return citationPreparation;
+  const snapshotFileCitationSchema = citationPreparation.citationSchema;
+  const snapshotPreservingSchemaMigration =
+    codeGraphSchemaMigrationPreservesIncompleteSnapshots(
+      recordedRevision,
+      snapshotFileCitationSchema,
+      citationPreparation.state === 'ready' ? 'current' : 'missing',
+    ) && (yield* codeGraphPersistentExtensionSchemaCompatible(sql));
+  if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql, false)) && !snapshotPreservingSchemaMigration) {
     const cleanupState = yield* removedViewCleanupSchemaState(sql);
     if (cleanupState !== 'absent') return {reason: 'incompatible-schema', state: 'deferred'} as const;
   }
@@ -110,8 +128,7 @@ const prepareWorktreeReconciliationIndex = Effect.fn('codeGraph.prepareWorktreeR
     }
     return {index: missing.index.name, state: 'prepared'} as const;
   }
-  const revision = yield* removedViewCleanupRecordedRevision(sql);
-  const recordedRevision = revision.state === 'recorded' ? revision.value : undefined;
+  if (snapshotPreservingSchemaMigration) return {state: 'migration-ready'} as const;
   if (
     recordedRevision !== undefined &&
     recordedRevision >= CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION &&
@@ -124,4 +141,22 @@ const prepareWorktreeReconciliationIndex = Effect.fn('codeGraph.prepareWorktreeR
   return {state: 'ready'} as const;
 });
 
-export {prepareRemovedViewCleanupExtension, prepareWorktreeReconciliationIndex};
+const prepareWorktreeReconciliationIndexesBounded = Effect.fn('codeGraph.prepareWorktreeReconciliationIndexesBounded')(
+  function* (sql: SqlClient.SqlClient) {
+    let preparation = yield* prepareWorktreeReconciliationIndex(sql);
+    for (
+      let step = 1;
+      preparation.state === 'prepared' && step < CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT;
+      step += 1
+    ) {
+      preparation = yield* prepareWorktreeReconciliationIndex(sql);
+    }
+    return preparation;
+  },
+);
+
+export {
+  prepareRemovedViewCleanupExtension,
+  prepareWorktreeReconciliationIndex,
+  prepareWorktreeReconciliationIndexesBounded,
+};

--- a/src/code_graph/store_repair.ts
+++ b/src/code_graph/store_repair.ts
@@ -17,6 +17,17 @@ const repairDatabase = Effect.fn('codeGraph.repairDatabase')(function* (dryRun: 
     );
   }
   const now = yield* Clock.currentTimeMillis;
+  const retainedIncompleteSnapshots = yield* sql<{readonly id: string}>`
+    SELECT snapshot.id
+    FROM snapshots AS snapshot
+    WHERE snapshot.state IN ('building', 'failed')
+      AND EXISTS (
+        SELECT 1 FROM snapshot_leases AS lease
+        WHERE lease.snapshot_id = snapshot.id AND lease.expires_at > ${now}
+      )
+    ORDER BY snapshot.id
+  `;
+  const retainedIncompleteSnapshotIds = retainedIncompleteSnapshots.map(snapshot => snapshot.id);
   if (dryRun) {
     const candidates = yield* sql<{readonly count: number}>`
       SELECT COUNT(*) AS count
@@ -27,7 +38,10 @@ const repairDatabase = Effect.fn('codeGraph.repairDatabase')(function* (dryRun: 
           WHERE lease.snapshot_id = snapshot.id AND lease.expires_at > ${now}
         )
     `;
-    return {removedSnapshots: Number(candidates[0]?.count ?? 0)} satisfies CodeGraphDatabaseRepair;
+    return {
+      removedSnapshots: Number(candidates[0]?.count ?? 0),
+      retainedIncompleteSnapshotIds,
+    } satisfies CodeGraphDatabaseRepair;
   }
   const candidates = yield* sql<{readonly count: number}>`
     SELECT COUNT(*) AS count
@@ -57,7 +71,7 @@ const repairDatabase = Effect.fn('codeGraph.repairDatabase')(function* (dryRun: 
   );
   yield* pruneRetiredSnapshotRows();
   yield* sql.withTransaction(pruneUnreferencedFileBlobs(sql));
-  return {removedSnapshots} satisfies CodeGraphDatabaseRepair;
+  return {removedSnapshots, retainedIncompleteSnapshotIds} satisfies CodeGraphDatabaseRepair;
 });
 
 export {repairDatabase};

--- a/src/code_graph/store_repair.ts
+++ b/src/code_graph/store_repair.ts
@@ -5,13 +5,28 @@ import {CodeGraphStoreError} from './types.js';
 import {diagnoseDatabase} from './store_diagnostics.js';
 import {pruneRetiredSnapshotRows} from './store_retirement.js';
 import {pruneUnreferencedFileBlobs} from './store_cleanup_core.js';
+import {codeGraphPersistentExtensionSchemaCompatible} from './store_schema_inspection.js';
+import {codeGraphSchemaMigrationPreservesIncompleteSnapshots} from './store_schema_migration.js';
 
-/** Exact read-only admission shared by cleanup writers and both health paths. */
+/** Exact read-only cleanup admission, including a preparation-proven migration preview. */
 
-const repairDatabase = Effect.fn('codeGraph.repairDatabase')(function* (dryRun: boolean) {
+const repairDatabase = Effect.fn('codeGraph.repairDatabase')(function* (
+  dryRun: boolean,
+  allowSchemaMigrationPreview = false,
+) {
   const sql = yield* SqlClient.SqlClient;
   const health = yield* diagnoseDatabase();
-  if (health.integrity !== 'ok') {
+  const schemaMigrationPreviewAllowed =
+    dryRun &&
+    allowSchemaMigrationPreview &&
+    (health.integrity === 'incompatible' || health.integrity === 'migration-pending') &&
+    codeGraphSchemaMigrationPreservesIncompleteSnapshots(
+      health.persistentExtensionSchemaRevision,
+      health.snapshotFileCitationSchema,
+      health.snapshotFileCitationBaseIndexes,
+    ) &&
+    (yield* codeGraphPersistentExtensionSchemaCompatible(sql));
+  if (health.integrity !== 'ok' && !schemaMigrationPreviewAllowed) {
     return yield* Effect.fail(
       new CodeGraphStoreError(`Code graph database is ${health.integrity}; discard and rebuild it.`),
     );

--- a/src/code_graph/store_schema_initialization.ts
+++ b/src/code_graph/store_schema_initialization.ts
@@ -16,13 +16,7 @@ import {
 } from './store_schema_core.js';
 import {ensureInitialReconciliationIndexes} from './store_reconciliation_core.js';
 import {ensureCodeGraphFileBlobAuthority} from './store_cache_authority.js';
-import {
-  assertCodeGraphSnapshotFileCitationSchemaMigratable,
-  CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL,
-  CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX,
-  CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX,
-  ensureCodeGraphSnapshotFileCitationSchema,
-} from './store_file_alias_schema.js';
+import {assertCodeGraphSnapshotFileCitationSchemaMigratable} from './store_file_alias_schema.js';
 import {
   codeGraphSchemaInitializationReceiptCurrent,
   recordCodeGraphSchemaInitializationReceipt,
@@ -95,7 +89,7 @@ const initializeSchemaFully = Effect.fn('codeGraph.initializeSchemaFully')(funct
       ),
     );
   }
-  const allowLegacyReleasedAuthority = yield* assertCodeGraphSnapshotFileCitationSchemaMigratable(sql);
+  const snapshotFileCitationAuthorization = yield* assertCodeGraphSnapshotFileCitationSchemaMigratable(sql);
   yield* sql.unsafe(`
     CREATE TABLE IF NOT EXISTS repositories (
       id TEXT PRIMARY KEY NOT NULL,
@@ -156,15 +150,7 @@ const initializeSchemaFully = Effect.fn('codeGraph.initializeSchemaFully')(funct
   );
   yield* ensureSnapshotLeaseSchema(sql);
   yield* ensureInitialReconciliationIndexes(sql);
-  yield* migratePersistentExtensionTables(sql);
-  yield* sql.unsafe(CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL.replace('CREATE TABLE', 'CREATE TABLE IF NOT EXISTS'));
-  yield* sql.unsafe(
-    CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX.definition.replace('CREATE INDEX', 'CREATE INDEX IF NOT EXISTS'),
-  );
-  yield* sql.unsafe(
-    CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX.definition.replace('CREATE INDEX', 'CREATE INDEX IF NOT EXISTS'),
-  );
-  yield* ensureCodeGraphSnapshotFileCitationSchema(sql, allowLegacyReleasedAuthority);
+  yield* migratePersistentExtensionTables(sql, snapshotFileCitationAuthorization);
   yield* sql.unsafe(`
     CREATE TABLE IF NOT EXISTS snapshot_file_deletions (
       snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,

--- a/src/code_graph/store_schema_initialization.ts
+++ b/src/code_graph/store_schema_initialization.ts
@@ -17,6 +17,13 @@ import {
 import {ensureInitialReconciliationIndexes} from './store_reconciliation_core.js';
 import {ensureCodeGraphFileBlobAuthority} from './store_cache_authority.js';
 import {
+  assertCodeGraphSnapshotFileCitationSchemaMigratable,
+  CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL,
+  CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX,
+  CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX,
+  ensureCodeGraphSnapshotFileCitationSchema,
+} from './store_file_alias_schema.js';
+import {
   codeGraphSchemaInitializationReceiptCurrent,
   recordCodeGraphSchemaInitializationReceipt,
 } from './store_schema_receipt.js';
@@ -88,6 +95,7 @@ const initializeSchemaFully = Effect.fn('codeGraph.initializeSchemaFully')(funct
       ),
     );
   }
+  const allowLegacyReleasedAuthority = yield* assertCodeGraphSnapshotFileCitationSchemaMigratable(sql);
   yield* sql.unsafe(`
     CREATE TABLE IF NOT EXISTS repositories (
       id TEXT PRIMARY KEY NOT NULL,
@@ -149,20 +157,14 @@ const initializeSchemaFully = Effect.fn('codeGraph.initializeSchemaFully')(funct
   yield* ensureSnapshotLeaseSchema(sql);
   yield* ensureInitialReconciliationIndexes(sql);
   yield* migratePersistentExtensionTables(sql);
-  yield* sql.unsafe(`
-    CREATE TABLE IF NOT EXISTS snapshot_files (
-      snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
-      path TEXT NOT NULL,
-      content_hash TEXT NOT NULL,
-      raw_content_hash TEXT,
-      language TEXT NOT NULL,
-      mode TEXT NOT NULL,
-      size INTEGER NOT NULL CHECK (size >= 0),
-      source TEXT NOT NULL CHECK (source IN ('commit', 'worktree')),
-      PRIMARY KEY (snapshot_id, path)
-    ) WITHOUT ROWID
-  `);
-  yield* ensureColumn(sql, 'snapshot_files', 'raw_content_hash', 'TEXT');
+  yield* sql.unsafe(CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL.replace('CREATE TABLE', 'CREATE TABLE IF NOT EXISTS'));
+  yield* sql.unsafe(
+    CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX.definition.replace('CREATE INDEX', 'CREATE INDEX IF NOT EXISTS'),
+  );
+  yield* sql.unsafe(
+    CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX.definition.replace('CREATE INDEX', 'CREATE INDEX IF NOT EXISTS'),
+  );
+  yield* ensureCodeGraphSnapshotFileCitationSchema(sql, allowLegacyReleasedAuthority);
   yield* sql.unsafe(`
     CREATE TABLE IF NOT EXISTS snapshot_file_deletions (
       snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
@@ -500,11 +502,6 @@ const initializeSchemaFully = Effect.fn('codeGraph.initializeSchemaFully')(funct
   yield* sql.unsafe('CREATE INDEX IF NOT EXISTS snapshot_leases_expiry ON snapshot_leases(expires_at)');
   yield* sql.unsafe(
     'CREATE INDEX IF NOT EXISTS snapshot_leases_snapshot_expiry ON snapshot_leases(snapshot_id, expires_at)',
-  );
-  yield* sql.unsafe('CREATE INDEX IF NOT EXISTS snapshot_files_blob ON snapshot_files(path, content_hash)');
-  yield* sql.unsafe('CREATE INDEX IF NOT EXISTS snapshot_files_content_hash ON snapshot_files(content_hash)');
-  yield* sql.unsafe(
-    'CREATE INDEX IF NOT EXISTS snapshot_files_raw_content_hash ON snapshot_files(raw_content_hash) WHERE raw_content_hash IS NOT NULL',
   );
   yield* sql.unsafe(`
     CREATE INDEX IF NOT EXISTS file_blobs_blob_reuse

--- a/src/code_graph/store_schema_migration.ts
+++ b/src/code_graph/store_schema_migration.ts
@@ -32,18 +32,23 @@ import {
   inspectBoundedSchemaMetadataValue,
 } from './store_schema_metadata.js';
 import {CodeGraphDatabaseSession, tableExists} from './store_session.js';
-import {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION, CodeGraphStoreError} from './types.js';
+import {
+  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+  type CodeGraphSnapshotFileCitationBaseIndexState,
+  type CodeGraphSnapshotFileCitationSchemaState,
+  CodeGraphStoreError,
+} from './types.js';
 import {
   CODE_GRAPH_SNAPSHOT_LEASE_EXPIRY_INDEX,
   codeGraphReconciliationIndexState,
 } from './store_reconciliation_core.js';
 import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconciliation.js';
 import {ensureCodeGraphFileBlobAuthority} from './store_cache_authority.js';
-import type {
-  CodeGraphSnapshotFileCitationBaseIndexState,
-  CodeGraphSnapshotFileCitationSchemaState,
+import {
+  type CodeGraphSnapshotFileCitationSchemaAuthorization,
+  codeGraphSnapshotFileCitationSchemaMigrationPreserves,
+  ensureCodeGraphSnapshotFileCitationSchema,
 } from './store_file_alias_schema.js';
-import {codeGraphSnapshotFileCitationSchemaMigrationPreserves} from './store_file_alias_schema.js';
 import {CODE_GRAPH_QUERY_INDEX_DEFINITIONS, ensureCodeGraphQueryIndexes} from './store_query_indexes.js';
 import {
   codeGraphRemovedViewCleanupBaseSchemaAdmission,
@@ -229,6 +234,7 @@ const ensureCurrentCodeGraphQueryIndexes = Effect.fn('codeGraph.ensureCurrentQue
 
 const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentExtensionTables')(function* (
   sql: SqlClient.SqlClient,
+  snapshotFileCitationAuthorization: CodeGraphSnapshotFileCitationSchemaAuthorization,
 ) {
   const session = yield* Effect.serviceOption(CodeGraphDatabaseSession);
   const observe = Option.isSome(session) ? session.value.onPersistentSchemaMigrationPhase : undefined;
@@ -251,6 +257,7 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
       if (!(yield* codeGraphWorktreeReconciliationSchemaCompatible(sql, true, false))) {
         return yield* Effect.fail(new CodeGraphStoreError('Code graph cleanup authority schema is incompatible.'));
       }
+      yield* ensureCodeGraphSnapshotFileCitationSchema(sql, snapshotFileCitationAuthorization);
       const cleanupSchemaState = yield* removedViewCleanupSchemaState(sql);
       yield* ensureRemovedViewCleanupSchema(sql);
       if (cleanupSchemaState === 'absent') {

--- a/src/code_graph/store_schema_migration.ts
+++ b/src/code_graph/store_schema_migration.ts
@@ -39,6 +39,11 @@ import {
 } from './store_reconciliation_core.js';
 import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconciliation.js';
 import {ensureCodeGraphFileBlobAuthority} from './store_cache_authority.js';
+import type {
+  CodeGraphSnapshotFileCitationBaseIndexState,
+  CodeGraphSnapshotFileCitationSchemaState,
+} from './store_file_alias_schema.js';
+import {codeGraphSnapshotFileCitationSchemaMigrationPreserves} from './store_file_alias_schema.js';
 import {CODE_GRAPH_QUERY_INDEX_DEFINITIONS, ensureCodeGraphQueryIndexes} from './store_query_indexes.js';
 import {
   codeGraphRemovedViewCleanupBaseSchemaAdmission,
@@ -48,6 +53,19 @@ import {
 
 /** Revision that first made the exact cleanup queue part of durable graph authority. */
 const REMOVED_VIEW_CLEANUP_EXTENSION_REVISION = 8;
+
+/** Revision 16 only adds the raw-content alias column/index after extension migration. */
+export function codeGraphSchemaMigrationPreservesIncompleteSnapshots(
+  revision: number | undefined,
+  snapshotFileCitationSchema: CodeGraphSnapshotFileCitationSchemaState,
+  snapshotFileCitationBaseIndexes: CodeGraphSnapshotFileCitationBaseIndexState,
+): boolean {
+  return codeGraphSnapshotFileCitationSchemaMigrationPreserves(
+    revision,
+    snapshotFileCitationSchema,
+    snapshotFileCitationBaseIndexes,
+  );
+}
 
 const preflightRemovedViewCleanupSchema = Effect.fn('codeGraph.preflightRemovedViewCleanupSchema')(function* (
   sql: SqlClient.SqlClient,

--- a/src/code_graph/store_schema_receipt.ts
+++ b/src/code_graph/store_schema_receipt.ts
@@ -21,11 +21,18 @@ import {
 // Bump when the full initializer gains a required invariant that is not
 // already represented by a main-schema DDL change or one of the exact mutable
 // metadata observations below.
-export const CODE_GRAPH_SCHEMA_INITIALIZATION_CONTRACT_REVISION = 2;
+export const CODE_GRAPH_SCHEMA_INITIALIZATION_CONTRACT_REVISION = 3;
 export const CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE = 'schema_initialization_receipt';
 // SQLite stores the schema cookie as a signed 32-bit database-header integer.
 export const CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM = 2_147_483_647;
 export const CODE_GRAPH_SQLITE_SCHEMA_VERSION_MINIMUM = -2_147_483_648;
+
+/** @internal SQLite advances the signed 32-bit schema cookie with wraparound. */
+export function nextCodeGraphSqliteSchemaVersion(schemaVersion: number): number {
+  return schemaVersion === CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM
+    ? CODE_GRAPH_SQLITE_SCHEMA_VERSION_MINIMUM
+    : schemaVersion + 1;
+}
 
 export const CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS ${CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE} (

--- a/src/code_graph/store_service_data.ts
+++ b/src/code_graph/store_service_data.ts
@@ -852,10 +852,12 @@ export function makeCodeGraphStoreDataMethods(runtime: CodeGraphStoreRuntime): C
         ),
         Effect.mapError(cause => storeError('prune retired code graph snapshots', cause)),
       ),
-    repair: (databasePath, dryRun = false) =>
+    repair: (databasePath, dryRun = false, options) =>
       fs.exists(databasePath).pipe(
         Effect.flatMap(exists =>
-          exists ? useDatabase(databasePath, repairDatabase(dryRun)) : Effect.succeed(undefined),
+          exists
+            ? useDatabase(databasePath, repairDatabase(dryRun, options?.allowSchemaMigrationPreview === true))
+            : Effect.succeed(undefined),
         ),
         Effect.mapError(cause => storeError('repair code graph database', cause)),
       ),

--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -67,7 +67,10 @@ import {
   activatePersistedFullSnapshot,
   activateCleanSnapshotAlias,
 } from './store_activation_persistent.js';
-import {prepareWorktreeReconciliationIndex} from './store_reconciliation_preparation.js';
+import {
+  prepareWorktreeReconciliationIndex,
+  prepareWorktreeReconciliationIndexesBounded,
+} from './store_reconciliation_preparation.js';
 import {activateStagedSnapshot, activatePersistedIncrementalSnapshot} from './store_activation.js';
 import {prepareSnapshotPromotionCapacity} from './store_build_preparation.js';
 import {promoteSnapshot} from './store_resolution.js';
@@ -807,7 +810,14 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
               const sql = yield* SqlClient.SqlClient;
               yield* sql.unsafe('PRAGMA foreign_keys = ON');
               yield* sql.unsafe('PRAGMA busy_timeout = 0');
-              return yield* sql.withTransaction(prepareWorktreeReconciliationIndex(sql));
+              if (options?.preview !== true) {
+                return yield* sql.withTransaction(prepareWorktreeReconciliationIndex(sql));
+              }
+              yield* sql.unsafe('BEGIN IMMEDIATE');
+              return yield* (options.afterPreviewTransactionStarted?.() ?? Effect.void).pipe(
+                Effect.andThen(prepareWorktreeReconciliationIndexesBounded(sql)),
+                Effect.ensuring(sql.unsafe('ROLLBACK').pipe(Effect.orDie)),
+              );
             }),
           );
         }),

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -73,6 +73,7 @@ import type {
   CodeGraphWorktreeReconciliationCandidate,
   CodeGraphWorktreeReconciliationClaimOptions,
   CodeGraphWorktreeReconciliationIndexPreparationResult,
+  CodeGraphWorktreeReconciliationPreparationOptions,
   LoadedCodeGraphFacts,
   StoredCodeGraph,
 } from './store_models.js';
@@ -203,7 +204,7 @@ export interface CodeGraphStoreShape {
   ) => Effect.Effect<CodeGraphOrphanProvenanceViewObservation, CodeGraphStoreError>;
   readonly prepareWorktreeReconciliationIndexes: (
     databasePath: string,
-    options?: CodeGraphWorktreeReconciliationClaimOptions,
+    options?: CodeGraphWorktreeReconciliationPreparationOptions,
   ) => Effect.Effect<CodeGraphWorktreeReconciliationIndexPreparationResult, CodeGraphStoreError>;
   readonly removeView: (
     databasePath: string,
@@ -563,6 +564,10 @@ export interface CodeGraphStoreShape {
   readonly repair: (
     databasePath: string,
     dryRun?: boolean,
+    options?: {
+      /** @internal Set only after bounded preparation proves that migration preserves incomplete snapshots. */
+      readonly allowSchemaMigrationPreview?: boolean;
+    },
   ) => Effect.Effect<CodeGraphDatabaseRepair | undefined, CodeGraphStoreError>;
   readonly runRoutineMaintenance: (
     databasePath: string,

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -10,6 +10,19 @@ export const CODE_GRAPH_RESULT_VERSION = 1 as const;
 export const CODE_GRAPH_EXTRACTOR_GENERATION = 13 as const;
 export const CODE_GRAPH_EXTRACTOR_SET_VERSION = `native-code-graph-${CODE_GRAPH_EXTRACTOR_GENERATION}` as const;
 
+export type CodeGraphSnapshotFileCitationSchemaState =
+  | 'column-only'
+  | 'column-only-with-authority'
+  | 'column-only-with-predecessor-authority'
+  | 'current'
+  | 'incompatible'
+  | 'released-absent'
+  | 'released-absent-with-predecessor-authority'
+  | 'released-absent-with-authority'
+  | 'table-absent';
+
+export type CodeGraphSnapshotFileCitationBaseIndexState = 'current' | 'incompatible' | 'missing';
+
 export type CodeGraphProvenance = 'declared' | 'heuristic' | 'model' | 'resolved' | 'syntactic';
 export type CodeGraphRelation =
   | 'calls'

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -4,6 +4,8 @@ import type {CodeGraphMonikerV1} from './cross_repository/types.js';
 export const CODE_GRAPH_SCHEMA_VERSION = 3 as const;
 /** Additive persistent surfaces that preserve the public graph-v3 row contract. */
 export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 16 as const;
+/** Oldest released additive extension revision that the current reader can safely serve. */
+export const CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION = 6 as const;
 export const CODE_GRAPH_RESULT_VERSION = 1 as const;
 export const CODE_GRAPH_EXTRACTOR_GENERATION = 13 as const;
 export const CODE_GRAPH_EXTRACTOR_SET_VERSION = `native-code-graph-${CODE_GRAPH_EXTRACTOR_GENERATION}` as const;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -490,7 +490,7 @@ function codeGraphMaintenanceProgressMessage(progress: CodeGraphMaintenanceProgr
     case 'cleaning-snapshots':
       return `${dryRun ? 'Would clean' : 'Cleaning'} ${progress.snapshots ?? 0} incomplete snapshot(s) from ${database}.`;
     case 'cleaning-vectors':
-      return `Checking temporary vector state for ${database}.`;
+      return `Checking temporary graph state for ${database}.`;
     case 'deferred':
       if (progress.reason === 'active-build') {
         return `Deferred ${database}: an active graph build owns the checkout; update and repair will not wait for it.`;
@@ -526,7 +526,7 @@ function codeGraphRepairSummaryMessage(
     (summary.migratedDatabases > 0 ? `${summary.migratedDatabases} schema migration(s), ` : '') +
     `${summary.discarded} disposable rebuild(s), ` +
     `${summary.removedIncompleteSnapshots} incomplete snapshot(s), ` +
-    `${summary.removedTemporaryFiles} temporary vector file(s).` +
+    `${summary.removedTemporaryFiles} temporary graph file(s).` +
     (summary.obsoleteStoreFiles > 0
       ? ` Preserved ${summary.obsoleteStoreFiles} obsolete store file(s), ${summary.obsoleteStoreBytes} byte(s), ` +
         `across ${summary.obsoleteStoreCheckouts} checkout(s); remove explicitly with \`threadnote graph purge --obsolete\`.`

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -5497,7 +5497,7 @@ describe('native code graph lifecycle', () => {
     ).toHaveLength(2);
     expect(output.repair).toContain(
       'Would repair 2 native code graph database(s): 2 deferred, 0 disposable rebuild(s), 0 incomplete snapshot(s), ' +
-        '0 temporary vector file(s).',
+        '0 temporary graph file(s).',
     );
     expect(output.repair).toContain(
       'WARN native code graph: 2 database(s); 1 ready snapshot(s); 0 incomplete snapshot(s); ' +

--- a/test/unit/code-graph.citation-schema-repair.test.ts
+++ b/test/unit/code-graph.citation-schema-repair.test.ts
@@ -1,0 +1,1016 @@
+import {Database} from 'bun:sqlite';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, Exit, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe, expect, it} from 'vitest';
+import {repairCodeGraphIndexes} from '../../src/code_graph/maintenance.js';
+import {
+  CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL,
+  CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX,
+  CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX,
+  CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX,
+} from '../../src/code_graph/store_file_alias_schema.js';
+import {
+  CODE_GRAPH_SCHEMA_INITIALIZATION_CONTRACT_REVISION,
+  CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM,
+  CODE_GRAPH_SQLITE_SCHEMA_VERSION_MINIMUM,
+  nextCodeGraphSqliteSchemaVersion,
+} from '../../src/code_graph/store_schema_receipt.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {
+  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+  CODE_GRAPH_SCHEMA_VERSION,
+  type CodeGraphInventoryFile,
+  type CodeGraphSnapshot,
+  type RepositoryIdentity,
+} from '../../src/code_graph/types.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {join} from '../helpers/effect-filesystem.js';
+
+describe('code graph snapshot-file citation schema repair', () => {
+  effectIt.effect('migrates revision 15 with dry-run parity while preserving live lease authority', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-migration-lease-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const snapshot = repairBuildingSnapshot(identity, '1');
+      const citationIdentity = {...identity, worktreeId: 'b'.repeat(64)};
+      const citationSnapshot = {...legacyReadySnapshot(citationIdentity, '2'), fileCount: 1};
+      const citationFile = {
+        blobId: '3'.repeat(40),
+        contentHash: 'f'.repeat(64),
+        language: 'typescript',
+        mode: '100644',
+        path: 'src/citation.ts',
+        size: 16,
+        source: 'commit',
+      } as const satisfies CodeGraphInventoryFile;
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', identity.checkoutId);
+      const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+      const spool = path.join(repositoryRoot, `materialization-spool-v1-${snapshot.id}.sqlite`);
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* store.activate(databasePath, citationIdentity, citationSnapshot, [citationFile], [], []);
+      yield* store.promote(databasePath, citationIdentity, citationSnapshot.id);
+      yield* store.claimPersistentBuild(databasePath, identity, snapshot, {
+        logicalSnapshotId: `cgsn_${'1'.repeat(40)}`,
+        owner: {buildId: '11111111-1111-1111', processId: process.pid},
+      });
+      yield* Effect.sync(() => {
+        downgradeToRevision15FileAliases(databasePath);
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database.exec('CREATE TABLE citation_schema_cookie_bump (id INTEGER)');
+          database.exec('DROP TABLE citation_schema_cookie_bump');
+          database
+            .query('INSERT INTO snapshot_leases (token, snapshot_id, expires_at) VALUES (?, ?, ?)')
+            .run('migration-preview-live-lease', snapshot.id, Date.now() + 60_000);
+        } finally {
+          database.close(false);
+        }
+      });
+      yield* fs.writeFile(spool, new Uint8Array([1]));
+
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(preview).toMatchObject({
+        deferredDatabases: 0,
+        migratedDatabases: 1,
+        removedIncompleteSnapshots: 0,
+        removedTemporaryFiles: 0,
+      });
+      expect(yield* fs.exists(spool)).toBe(true);
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        buildingSnapshots: 1,
+        integrity: 'migration-pending',
+        persistentExtensionSchemaRevision: 15,
+      });
+
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(applied).toEqual(preview);
+      expect(yield* fs.exists(spool)).toBe(true);
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        buildingSnapshots: 1,
+        integrity: 'ok',
+        persistentExtensionSchemaRevision: CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+      });
+      const citationMatches = yield* store.effectiveSnapshotFilesByContentHashes(
+        databasePath,
+        citationSnapshot.id,
+        [citationFile.contentHash],
+        1,
+      );
+      expect(citationMatches.map(match => match.files.map(file => file.path))).toEqual([[citationFile.path]]);
+      const migratedIdentity = {...identity, worktreeId: 'c'.repeat(64)};
+      const migratedSnapshot = {...legacyReadySnapshot(migratedIdentity, '3'), fileCount: 1};
+      const migratedFile = {
+        ...citationFile,
+        blobId: '4'.repeat(40),
+        contentHash: 'd'.repeat(64),
+        path: 'src/migrated-citation.ts',
+        rawContentHash: 'e'.repeat(64),
+      } as const satisfies CodeGraphInventoryFile;
+      yield* store.activate(databasePath, migratedIdentity, migratedSnapshot, [migratedFile], [], []);
+      yield* store.promote(databasePath, migratedIdentity, migratedSnapshot.id);
+      const migratedMatches = yield* store.effectiveSnapshotFilesByContentHashes(
+        databasePath,
+        migratedSnapshot.id,
+        [migratedFile.contentHash, migratedFile.rawContentHash],
+        1,
+      );
+      expect(migratedMatches.map(match => match.files.map(file => file.path))).toEqual([
+        [migratedFile.path],
+        [migratedFile.path],
+      ]);
+      expect(
+        yield* Effect.sync(() => {
+          const database = new Database(databasePath, {readonly: true, strict: true});
+          try {
+            return Number(
+              database
+                .query<{readonly count: number}, [string]>(
+                  'SELECT COUNT(*) AS count FROM snapshot_leases WHERE token = ?',
+                )
+                .get('migration-preview-live-lease')?.count ?? 0,
+            );
+          } finally {
+            database.close(false);
+          }
+        }),
+      ).toBe(1);
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('post-update quick repair migrates an exact revision-15 alias schema', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-revision-15-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const databasePath = path.join(
+        home,
+        'indexes',
+        'code-graph',
+        'repositories',
+        identity.checkoutId,
+        `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+      );
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* Effect.sync(() => downgradeToRevision15FileAliases(databasePath));
+
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(preview).toMatchObject({
+        deferredDatabases: 0,
+        migratedDatabases: 1,
+        removedIncompleteSnapshots: 0,
+        removedTemporaryFiles: 0,
+      });
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        integrity: 'migration-pending',
+        persistentExtensionSchemaRevision: 15,
+      });
+
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(applied).toEqual(preview);
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        integrity: 'ok',
+        persistentExtensionSchemaRevision: CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+      });
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('preserves leased build spools across safe revision-16 alias interruptions', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const store = yield* CodeGraphStore;
+      for (const [index, aliasState] of (['released-absent', 'column-only'] as const).entries()) {
+        const home = yield* fs.makeTempDirectoryScoped({
+          prefix: `threadnote-graph-repair-revision-16-${aliasState}-`,
+        });
+        const identity = legacyRepositoryIdentity(home, index === 0 ? 'a' : 'b');
+        const snapshot = repairBuildingSnapshot(identity, index === 0 ? '1' : '2');
+        const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', identity.checkoutId);
+        const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+        const spool = path.join(repositoryRoot, `materialization-spool-v1-${snapshot.id}.sqlite`);
+        yield* store.initialize(databasePath);
+        yield* store.claimPersistentBuild(databasePath, identity, snapshot, {
+          logicalSnapshotId: `cgsn_${index === 0 ? '1'.repeat(40) : '2'.repeat(40)}`,
+          owner: {
+            buildId: index === 0 ? '11111111-1111-1111' : '22222222-2222-2222',
+            processId: process.pid,
+          },
+        });
+        yield* Effect.sync(() => {
+          downgradeToRevision15FileAliases(databasePath);
+          const database = new Database(databasePath, {strict: true});
+          try {
+            database.exec(
+              `UPDATE schema_metadata
+               SET value = '16'
+               WHERE key = 'persistent_extension_schema_revision'`,
+            );
+            if (aliasState === 'column-only') {
+              database.exec('ALTER TABLE snapshot_files ADD COLUMN raw_content_hash TEXT');
+            }
+            database
+              .query('INSERT INTO snapshot_leases (token, snapshot_id, expires_at) VALUES (?, ?, ?)')
+              .run(`revision-16-${aliasState}-lease`, snapshot.id, Date.now() + 60_000);
+          } finally {
+            database.close(false);
+          }
+        });
+        yield* fs.writeFile(spool, new Uint8Array([1]));
+        expect(yield* store.diagnose(databasePath)).toMatchObject({
+          buildingSnapshots: 1,
+          integrity: 'incompatible',
+          persistentExtensionSchemaRevision: CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+          snapshotFileCitationSchema:
+            aliasState === 'released-absent'
+              ? 'released-absent-with-predecessor-authority'
+              : 'column-only-with-predecessor-authority',
+        });
+
+        const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'deep',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(preview).toMatchObject({
+          deferredDatabases: 0,
+          migratedDatabases: 1,
+          removedIncompleteSnapshots: 0,
+          removedTemporaryFiles: 0,
+        });
+        expect(yield* fs.exists(spool)).toBe(true);
+        const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'deep',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(applied).toEqual(preview);
+        expect(yield* fs.exists(spool)).toBe(true);
+        expect(yield* store.diagnose(databasePath)).toMatchObject({
+          buildingSnapshots: 1,
+          integrity: 'ok',
+          snapshotFileCitationSchema: 'current',
+        });
+      }
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('defers a drifted revision-15 schema without claiming lease or spool authority', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-revision-15-drift-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const snapshot = repairBuildingSnapshot(identity, '1');
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', identity.checkoutId);
+      const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+      const spool = path.join(repositoryRoot, `materialization-spool-v1-${snapshot.id}.sqlite`);
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* store.claimPersistentBuild(databasePath, identity, snapshot, {
+        logicalSnapshotId: `cgsn_${'1'.repeat(40)}`,
+        owner: {buildId: '11111111-1111-1111', processId: process.pid},
+      });
+      yield* Effect.sync(() => {
+        downgradeToRevision15FileAliases(databasePath);
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database.exec('CREATE INDEX snapshot_files_raw_content_hash ON file_blobs(content_hash)');
+          database
+            .query('INSERT INTO snapshot_leases (token, snapshot_id, expires_at) VALUES (?, ?, ?)')
+            .run('migration-drift-live-lease', snapshot.id, Date.now() + 60_000);
+        } finally {
+          database.close(false);
+        }
+      });
+      yield* fs.writeFile(spool, new Uint8Array([1]));
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        buildingSnapshots: 1,
+        integrity: 'migration-pending',
+        persistentExtensionSchemaRevision: 15,
+      });
+
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(preview).toMatchObject({
+        deferredDatabases: 1,
+        migratedDatabases: 0,
+        removedIncompleteSnapshots: 0,
+        removedTemporaryFiles: 0,
+      });
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(applied).toEqual(preview);
+      expect(yield* fs.exists(spool)).toBe(true);
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        buildingSnapshots: 1,
+        integrity: 'migration-pending',
+        persistentExtensionSchemaRevision: 15,
+      });
+      const initialization = yield* store.initialize(databasePath).pipe(Effect.exit);
+      expect(Exit.isFailure(initialization)).toBe(true);
+      if (Exit.isFailure(initialization)) {
+        expect(String(initialization.cause)).toContain('snapshot file citation schema is incompatible');
+      }
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('rejects a legacy current receipt that blessed a wrong raw-content alias index', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-alias-receipt-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const databasePath = path.join(
+        home,
+        'indexes',
+        'code-graph',
+        'repositories',
+        identity.checkoutId,
+        `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+      );
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database.exec(`
+            DROP INDEX snapshot_files_raw_content_hash;
+            CREATE INDEX snapshot_files_raw_content_hash ON file_blobs(content_hash);
+          `);
+          const schemaVersion = database.query<{readonly schema_version: number}, []>('PRAGMA schema_version').get();
+          database
+            .query(
+              `UPDATE schema_initialization_receipt
+               SET contract_revision = ?, sqlite_schema_version = ?
+               WHERE singleton = 1`,
+            )
+            .run(CODE_GRAPH_SCHEMA_INITIALIZATION_CONTRACT_REVISION - 1, schemaVersion?.schema_version ?? -1);
+        } finally {
+          database.close(false);
+        }
+      });
+
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        integrity: 'incompatible',
+        persistentExtensionSchemaRevision: CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+        snapshotFileCitationSchema: 'incompatible',
+      });
+      const quickPreview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(quickPreview).toMatchObject({
+        deferredDatabases: 1,
+        discarded: 0,
+        migratedDatabases: 0,
+        removedTemporaryFiles: 0,
+      });
+      const quickApplied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(quickApplied).toEqual(quickPreview);
+      const initialization = yield* store.initialize(databasePath).pipe(Effect.exit);
+      expect(Exit.isFailure(initialization)).toBe(true);
+      if (Exit.isFailure(initialization)) {
+        expect(String(initialization.cause)).toContain('snapshot file citation schema is incompatible');
+      }
+      expect(
+        yield* Effect.sync(() => {
+          const database = new Database(databasePath, {readonly: true, strict: true});
+          try {
+            return database
+              .query("SELECT tbl_name FROM sqlite_master WHERE name = 'snapshot_files_raw_content_hash'")
+              .get();
+          } finally {
+            database.close(false);
+          }
+        }),
+      ).toEqual({tbl_name: 'file_blobs'});
+      const deepPreview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(deepPreview).toMatchObject({
+        deferredDatabases: 0,
+        discarded: 1,
+        migratedDatabases: 0,
+        removedTemporaryFiles: 0,
+      });
+      const deepApplied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(deepApplied).toEqual(deepPreview);
+      expect(yield* fs.exists(databasePath)).toBe(false);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('refuses to recreate missing snapshot-file authority beneath an active ready snapshot', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-missing-files-authority-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const snapshot = legacyReadySnapshot(identity, '1');
+      const databasePath = path.join(
+        home,
+        'indexes',
+        'code-graph',
+        'repositories',
+        identity.checkoutId,
+        `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+      );
+      const store = yield* CodeGraphStore;
+      yield* store.activate(databasePath, identity, snapshot, [], [], []);
+      yield* store.promote(databasePath, identity, snapshot.id);
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database.exec('DROP TABLE snapshot_files');
+        } finally {
+          database.close(false);
+        }
+      });
+
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        activeSnapshots: 1,
+        integrity: 'incompatible',
+        snapshotFileCitationSchema: 'incompatible',
+        readySnapshots: 1,
+      });
+      const quickPreview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(quickPreview).toMatchObject({deferredDatabases: 1, discarded: 0, migratedDatabases: 0});
+      const quickApplied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(quickApplied).toEqual(quickPreview);
+      const initialization = yield* store.initialize(databasePath).pipe(Effect.exit);
+      expect(Exit.isFailure(initialization)).toBe(true);
+      if (Exit.isFailure(initialization)) {
+        expect(String(initialization.cause)).toContain('snapshot file citation schema is incompatible');
+      }
+      const deepPreview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(deepPreview).toMatchObject({deferredDatabases: 0, discarded: 1, migratedDatabases: 0});
+      const deepApplied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(deepApplied).toEqual(deepPreview);
+      expect(yield* fs.exists(databasePath)).toBe(false);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('recreates an interrupted empty snapshot-files table with dry-run parity', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-empty-files-table-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const databasePath = path.join(
+        home,
+        'indexes',
+        'code-graph',
+        'repositories',
+        identity.checkoutId,
+        `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+      );
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database.exec('DROP TABLE snapshot_files');
+        } finally {
+          database.close(false);
+        }
+      });
+
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        activeSnapshots: 0,
+        integrity: 'incompatible',
+        snapshotFileCitationSchema: 'table-absent',
+        readySnapshots: 0,
+      });
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(preview).toMatchObject({deferredDatabases: 0, discarded: 0, migratedDatabases: 1});
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(applied).toEqual(preview);
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        integrity: 'ok',
+        snapshotFileCitationSchema: 'current',
+      });
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  it('advances the SQLite schema cookie across its signed wrap boundary', () => {
+    expect(nextCodeGraphSqliteSchemaVersion(0)).toBe(1);
+    expect(nextCodeGraphSqliteSchemaVersion(CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM)).toBe(
+      CODE_GRAPH_SQLITE_SCHEMA_VERSION_MINIMUM,
+    );
+  });
+
+  effectIt.effect('rejects post-v16 alias loss beneath ready citation authority', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const store = yield* CodeGraphStore;
+      for (const [index, aliasState] of (['column-only', 'released-absent'] as const).entries()) {
+        const home = yield* fs.makeTempDirectoryScoped({prefix: `threadnote-graph-alias-loss-${aliasState}-`});
+        const identity = legacyRepositoryIdentity(home, index === 0 ? 'c' : 'd');
+        const snapshot = {...legacyReadySnapshot(identity, index === 0 ? '4' : '5'), fileCount: 1};
+        const file = {
+          blobId: index === 0 ? '6'.repeat(40) : '7'.repeat(40),
+          contentHash: index === 0 ? '8'.repeat(64) : '9'.repeat(64),
+          language: 'typescript',
+          mode: '100644',
+          path: `src/${aliasState}.ts`,
+          rawContentHash: index === 0 ? 'a'.repeat(64) : 'b'.repeat(64),
+          size: 32,
+          source: 'commit',
+        } as const satisfies CodeGraphInventoryFile;
+        const databasePath = path.join(
+          home,
+          'indexes',
+          'code-graph',
+          'repositories',
+          identity.checkoutId,
+          `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+        );
+        yield* store.activate(databasePath, identity, snapshot, [file], [], []);
+        yield* store.promote(databasePath, identity, snapshot.id);
+        expect(
+          (yield* store.effectiveSnapshotFilesByContentHashes(databasePath, snapshot.id, [file.rawContentHash], 1))[0]
+            ?.files,
+        ).toMatchObject([{path: file.path}]);
+
+        yield* Effect.sync(() => {
+          const database = new Database(databasePath, {strict: true});
+          try {
+            database.exec('DROP INDEX snapshot_files_raw_content_hash');
+            if (aliasState === 'released-absent') {
+              database.exec('ALTER TABLE snapshot_files DROP COLUMN raw_content_hash');
+              database.exec(
+                `UPDATE schema_initialization_receipt
+                 SET contract_revision = 2, persistent_extension_revision = 15
+                 WHERE singleton = 1`,
+              );
+            }
+          } finally {
+            database.close(false);
+          }
+        });
+        const before = snapshotFileSchemaFingerprint(databasePath);
+        expect(yield* store.diagnose(databasePath)).toMatchObject({
+          activeSnapshots: 1,
+          integrity: 'incompatible',
+          readySnapshots: 1,
+          snapshotFileCitationSchema: `${aliasState}-with-authority`,
+        });
+
+        const quickPreview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'quick',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(quickPreview).toMatchObject({deferredDatabases: 1, discarded: 0, migratedDatabases: 0});
+        const quickApplied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'quick',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(quickApplied).toEqual(quickPreview);
+        expect(snapshotFileSchemaFingerprint(databasePath)).toBe(before);
+        expect(Exit.isFailure(yield* store.initialize(databasePath).pipe(Effect.exit))).toBe(true);
+
+        const deepPreview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'deep',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(deepPreview).toMatchObject({deferredDatabases: 0, discarded: 1, migratedDatabases: 0});
+        const deepApplied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'deep',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(deepApplied).toEqual(deepPreview);
+        expect(yield* fs.exists(databasePath)).toBe(false);
+      }
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('rejects exact citation-schema drift without mutating it during quick repair', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const store = yield* CodeGraphStore;
+      const mutations: readonly {
+        readonly mutate: (database: Database) => void;
+        readonly name: string;
+      }[] = [
+        {
+          name: 'raw-nocase-column',
+          mutate: database =>
+            rebuildSnapshotFiles(
+              database,
+              CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL.replace(
+                'raw_content_hash TEXT,',
+                'raw_content_hash TEXT COLLATE NOCASE,',
+              ),
+            ),
+        },
+        {
+          name: 'raw-check-constraint',
+          mutate: database =>
+            rebuildSnapshotFiles(
+              database,
+              CODE_GRAPH_SNAPSHOT_FILES_CURRENT_TABLE_SQL.replace(
+                'raw_content_hash TEXT,',
+                'raw_content_hash TEXT CHECK(raw_content_hash IS NULL),',
+              ),
+            ),
+        },
+        {
+          name: 'wrong-content-index-table',
+          mutate: database =>
+            database.exec(
+              `DROP INDEX snapshot_files_content_hash;
+               CREATE INDEX snapshot_files_content_hash ON file_blobs(content_hash)`,
+            ),
+        },
+        {
+          name: 'extra-unique-index',
+          mutate: database =>
+            database.exec('CREATE UNIQUE INDEX snapshot_files_raw_unique ON snapshot_files(raw_content_hash)'),
+        },
+        {
+          name: 'extra-expression-index',
+          mutate: database => database.exec('CREATE INDEX snapshot_files_path_folded ON snapshot_files(lower(path))'),
+        },
+        {
+          name: 'aborting-trigger',
+          mutate: database =>
+            database.exec(
+              `CREATE TRIGGER snapshot_files_abort_insert
+               BEFORE INSERT ON snapshot_files
+               BEGIN
+                 SELECT RAISE(ABORT, 'blocked');
+               END`,
+            ),
+        },
+      ];
+      for (const [index, mutation] of mutations.entries()) {
+        const home = yield* fs.makeTempDirectoryScoped({prefix: `threadnote-graph-citation-drift-${mutation.name}-`});
+        const identity = legacyRepositoryIdentity(home, String(index + 1));
+        const databasePath = path.join(
+          home,
+          'indexes',
+          'code-graph',
+          'repositories',
+          identity.checkoutId,
+          `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+        );
+        yield* store.initialize(databasePath);
+        yield* Effect.sync(() => {
+          const database = new Database(databasePath, {strict: true});
+          try {
+            mutation.mutate(database);
+          } finally {
+            database.close(false);
+          }
+        });
+        const before = snapshotFileSchemaFingerprint(databasePath);
+        expect(yield* store.diagnose(databasePath)).toMatchObject({integrity: 'incompatible'});
+        const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'quick',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(preview).toMatchObject({deferredDatabases: 1, migratedDatabases: 0});
+        const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'quick',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(applied).toEqual(preview);
+        expect(snapshotFileSchemaFingerprint(databasePath)).toBe(before);
+        expect(Exit.isFailure(yield* store.initialize(databasePath).pipe(Effect.exit))).toBe(true);
+      }
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('recreates missing base citation indexes only without snapshot authority', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const store = yield* CodeGraphStore;
+      for (const [index, missingIndex] of [
+        CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX.name,
+        CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX.name,
+      ].entries()) {
+        const home = yield* fs.makeTempDirectoryScoped({prefix: `threadnote-graph-missing-${missingIndex}-`});
+        const identity = legacyRepositoryIdentity(home, index === 0 ? 'e' : 'f');
+        const databasePath = path.join(
+          home,
+          'indexes',
+          'code-graph',
+          'repositories',
+          identity.checkoutId,
+          `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+        );
+        yield* store.initialize(databasePath);
+        yield* Effect.sync(() => dropIndex(databasePath, missingIndex));
+        expect(yield* store.diagnose(databasePath)).toMatchObject({
+          activeSnapshots: 0,
+          integrity: 'incompatible',
+          readySnapshots: 0,
+          snapshotFileCitationBaseIndexes: 'missing',
+        });
+        const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'quick',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(preview).toMatchObject({deferredDatabases: 0, migratedDatabases: 1});
+        const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+          migrateSchema: true,
+          mode: 'quick',
+          targetCheckoutId: identity.checkoutId,
+        });
+        expect(applied).toEqual(preview);
+        expect(yield* store.diagnose(databasePath)).toMatchObject({
+          integrity: 'ok',
+          snapshotFileCitationBaseIndexes: 'current',
+        });
+      }
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('defers missing base citation indexes beneath ready authority', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-missing-base-authority-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const snapshot = legacyReadySnapshot(identity, '6');
+      const databasePath = path.join(
+        home,
+        'indexes',
+        'code-graph',
+        'repositories',
+        identity.checkoutId,
+        `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+      );
+      const store = yield* CodeGraphStore;
+      yield* store.activate(databasePath, identity, snapshot, [], [], []);
+      yield* store.promote(databasePath, identity, snapshot.id);
+      yield* Effect.sync(() => dropIndex(databasePath, CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX.name));
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        activeSnapshots: 1,
+        integrity: 'incompatible',
+        readySnapshots: 1,
+        snapshotFileCitationBaseIndexes: 'incompatible',
+      });
+
+      const quickPreview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(quickPreview).toMatchObject({deferredDatabases: 1, discarded: 0, migratedDatabases: 0});
+      const quickApplied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(quickApplied).toEqual(quickPreview);
+      expect(Exit.isFailure(yield* store.initialize(databasePath).pipe(Effect.exit))).toBe(true);
+      const deepPreview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(deepPreview).toMatchObject({deferredDatabases: 0, discarded: 1, migratedDatabases: 0});
+      const deepApplied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(deepApplied).toEqual(deepPreview);
+      expect(yield* fs.exists(databasePath)).toBe(false);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('treats orphan snapshot-file rows as citation authority', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-orphan-file-authority-'});
+      const identity = legacyRepositoryIdentity(home, 'b');
+      const databasePath = path.join(
+        home,
+        'indexes',
+        'code-graph',
+        'repositories',
+        identity.checkoutId,
+        `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+      );
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database.exec('PRAGMA foreign_keys = OFF');
+          database
+            .query(
+              `INSERT INTO snapshot_files (
+                 snapshot_id, path, content_hash, raw_content_hash, language, mode, size, source
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            )
+            .run('cgsn_orphan', 'src/orphan.ts', '1'.repeat(64), null, 'typescript', '100644', 1, 'commit');
+          database.exec('DROP INDEX snapshot_files_content_hash');
+        } finally {
+          database.close(false);
+        }
+      });
+      expect(yield* store.diagnose(databasePath)).toMatchObject({
+        activeSnapshots: 0,
+        integrity: 'incompatible',
+        readySnapshots: 0,
+        snapshotFileCitationBaseIndexes: 'incompatible',
+      });
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(preview).toMatchObject({deferredDatabases: 1, migratedDatabases: 0});
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(applied).toEqual(preview);
+      expect(Exit.isFailure(yield* store.initialize(databasePath).pipe(Effect.exit))).toBe(true);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+});
+
+function legacyRepositoryIdentity(home: string, seed: string): RepositoryIdentity {
+  return {
+    caseMode: 'sensitive',
+    checkoutId: seed.repeat(64),
+    displayName: 'acme/legacy-graph',
+    gitCommonDirectory: join(home, '.git'),
+    headCommit: seed.repeat(40),
+    objectFormat: 'sha1',
+    repoRoot: home,
+    repositoryId: seed.repeat(64),
+    worktreeId: seed.repeat(64),
+  };
+}
+
+function legacyReadySnapshot(identity: RepositoryIdentity, seed: string): CodeGraphSnapshot {
+  return {
+    commit: identity.headCommit,
+    completedAt: '2026-08-10T00:00:00.000Z',
+    dirty: false,
+    edgeCount: 0,
+    extractorSet: 'citation-schema-regression',
+    fileCount: 0,
+    id: `cgsn_${seed.repeat(40)}`,
+    repositoryId: identity.repositoryId,
+    state: 'ready',
+    symbolCount: 0,
+    worktreeId: identity.worktreeId,
+  };
+}
+
+function repairBuildingSnapshot(identity: RepositoryIdentity, seed: string): CodeGraphSnapshot {
+  return {
+    commit: identity.headCommit,
+    dirty: false,
+    edgeCount: 0,
+    extractorSet: 'citation-schema-regression',
+    fileCount: 0,
+    id: `cgsn_${seed.repeat(40)}-direct`,
+    repositoryId: identity.repositoryId,
+    state: 'building',
+    symbolCount: 0,
+    worktreeId: identity.worktreeId,
+  };
+}
+
+function dropIndex(databasePath: string, index: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.exec(`DROP INDEX ${index}`);
+  } finally {
+    database.close(false);
+  }
+}
+
+function rebuildSnapshotFiles(database: Database, tableDefinition: string): void {
+  database.exec('PRAGMA foreign_keys = OFF');
+  database.exec('DROP TABLE snapshot_files');
+  database.exec(tableDefinition);
+  database.exec(CODE_GRAPH_SNAPSHOT_FILE_BLOB_REFERENCE_INDEX.definition);
+  database.exec(CODE_GRAPH_SNAPSHOT_FILE_CONTENT_REFERENCE_INDEX.definition);
+  database.exec(CODE_GRAPH_SNAPSHOT_FILE_RAW_CONTENT_REFERENCE_INDEX.definition);
+  database.exec('PRAGMA foreign_keys = ON');
+}
+
+function snapshotFileSchemaFingerprint(databasePath: string): string {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return JSON.stringify(
+      database
+        .query(
+          `SELECT type, name, tbl_name, sql
+           FROM sqlite_master
+           WHERE tbl_name = 'snapshot_files' COLLATE NOCASE
+              OR name LIKE 'snapshot_files_%' ESCAPE '\\'
+           ORDER BY type, name`,
+        )
+        .all(),
+    );
+  } finally {
+    database.close(false);
+  }
+}
+
+function downgradeToRevision15FileAliases(databasePath: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.exec(`
+      DROP INDEX snapshot_files_raw_content_hash;
+      ALTER TABLE snapshot_files DROP COLUMN raw_content_hash;
+      UPDATE schema_metadata
+      SET value = '15'
+      WHERE key = 'persistent_extension_schema_revision';
+    `);
+    const schemaVersion = database.query<{readonly schema_version: number}, []>('PRAGMA schema_version').get();
+    database
+      .query(
+        `UPDATE schema_initialization_receipt
+         SET contract_revision = 2, persistent_extension_revision = 15, sqlite_schema_version = ?
+         WHERE singleton = 1`,
+      )
+      .run(schemaVersion?.schema_version ?? -1);
+  } finally {
+    database.close(false);
+  }
+}

--- a/test/unit/code-graph.citation-schema-repair.test.ts
+++ b/test/unit/code-graph.citation-schema-repair.test.ts
@@ -27,6 +27,7 @@ import {
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {join} from '../helpers/effect-filesystem.js';
+import {TestError} from '../helpers/test-error.js';
 
 describe('code graph snapshot-file citation schema repair', () => {
   effectIt.effect('migrates revision 15 with dry-run parity while preserving live lease authority', () =>
@@ -194,6 +195,71 @@ describe('code graph snapshot-file citation schema repair', () => {
         integrity: 'ok',
         persistentExtensionSchemaRevision: CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
       });
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('rolls back a released revision-6 alias migration before publishing revision 16', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-revision-6-alias-fault-'});
+      const identity = legacyRepositoryIdentity(home, 'd');
+      const ready = {...legacyReadySnapshot(identity, '4'), fileCount: 1};
+      const file = {
+        blobId: '5'.repeat(40),
+        contentHash: '6'.repeat(64),
+        language: 'typescript',
+        mode: '100644',
+        path: 'src/revision-6-citation.ts',
+        size: 32,
+        source: 'commit',
+      } as const satisfies CodeGraphInventoryFile;
+      const databasePath = path.join(
+        home,
+        'indexes',
+        'code-graph',
+        'repositories',
+        identity.checkoutId,
+        `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`,
+      );
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* store.activate(databasePath, identity, ready, [file], [], []);
+      yield* store.promote(databasePath, identity, ready.id);
+      yield* Effect.sync(() => downgradeToReleasedRevision6(databasePath));
+
+      const failed = yield* store
+        .withSession(databasePath, store.initialize(databasePath), {
+          onPersistentSchemaMigrationPhase: phase =>
+            phase === 'recorded-revision'
+              ? Effect.die(new TestError('fault after citation schema revision publication'))
+              : Effect.void,
+        })
+        .pipe(Effect.exit);
+      expect(Exit.isFailure(failed)).toBe(true);
+      expect(yield* Effect.sync(() => readAliasPublicationState(databasePath, ready.id))).toEqual({
+        activeSnapshotId: ready.id,
+        rawColumnPresent: false,
+        rawIndexPresent: false,
+        revision: 6,
+        snapshotState: 'ready',
+      });
+
+      yield* store.initialize(databasePath);
+      expect(yield* Effect.sync(() => readAliasPublicationState(databasePath, ready.id))).toEqual({
+        activeSnapshotId: ready.id,
+        rawColumnPresent: true,
+        rawIndexPresent: true,
+        revision: CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+        snapshotState: 'ready',
+      });
+      const citationMatches = yield* store.effectiveSnapshotFilesByContentHashes(
+        databasePath,
+        ready.id,
+        [file.contentHash],
+        1,
+      );
+      expect(citationMatches.map(match => match.files.map(candidate => candidate.path))).toEqual([[file.path]]);
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 
@@ -1010,6 +1076,75 @@ function downgradeToRevision15FileAliases(databasePath: string): void {
          WHERE singleton = 1`,
       )
       .run(schemaVersion?.schema_version ?? -1);
+  } finally {
+    database.close(false);
+  }
+}
+
+function downgradeToReleasedRevision6(databasePath: string): void {
+  const database = new Database(databasePath, {strict: true});
+  try {
+    database.run('PRAGMA foreign_keys = OFF');
+    database.run('BEGIN IMMEDIATE');
+    try {
+      database.exec(`
+        DROP TRIGGER IF EXISTS removed_views_cleanup_revoke_delete;
+        DROP TRIGGER IF EXISTS removed_views_cleanup_revoke_insert;
+        DROP TRIGGER IF EXISTS removed_views_cleanup_revoke_update;
+        DROP TABLE IF EXISTS removed_view_cleanup;
+        DROP TABLE IF EXISTS snapshot_build_owner_instances;
+        DROP TABLE IF EXISTS snapshot_component_edge_aggregate_receipts;
+        DROP TABLE IF EXISTS snapshot_component_edge_aggregates;
+        DROP TABLE IF EXISTS removed_views;
+        DROP INDEX IF EXISTS snapshot_files_raw_content_hash;
+        ALTER TABLE snapshot_files DROP COLUMN raw_content_hash;
+        DELETE FROM schema_metadata
+        WHERE key IN ('removed_view_cleanup_admission_cursor', 'removed_view_cleanup_epoch_sequence');
+        UPDATE schema_metadata
+        SET value = '6'
+        WHERE key = 'persistent_extension_schema_revision';
+      `);
+      database.run('COMMIT');
+    } catch (error) {
+      if (database.inTransaction) database.run('ROLLBACK');
+      throw error;
+    } finally {
+      database.run('PRAGMA foreign_keys = ON');
+    }
+  } finally {
+    database.close(false);
+  }
+}
+
+function readAliasPublicationState(databasePath: string, snapshotId: string) {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    const columns = database.query<{readonly name: string}, []>('PRAGMA table_info(snapshot_files)').all();
+    const rawIndex = database
+      .query<{readonly present: number}, []>(
+        `SELECT 1 AS present
+         FROM sqlite_master
+         WHERE type = 'index' AND name = 'snapshot_files_raw_content_hash'`,
+      )
+      .get();
+    const revision = database
+      .query<{readonly value: string}, []>(
+        "SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision'",
+      )
+      .get();
+    const snapshot = database
+      .query<{readonly state: string}, [string]>('SELECT state FROM snapshots WHERE id = ?')
+      .get(snapshotId);
+    const active = database
+      .query<{readonly snapshot_id: string}, [string]>('SELECT snapshot_id FROM active_snapshots WHERE snapshot_id = ?')
+      .get(snapshotId);
+    return {
+      activeSnapshotId: active?.snapshot_id,
+      rawColumnPresent: columns.some(column => column.name === 'raw_content_hash'),
+      rawIndexPresent: rawIndex?.present === 1,
+      revision: Number(revision?.value),
+      snapshotState: snapshot?.state,
+    };
   } finally {
     database.close(false);
   }

--- a/test/unit/code-graph.maintenance-bounded.test.ts
+++ b/test/unit/code-graph.maintenance-bounded.test.ts
@@ -4,9 +4,11 @@ import {Database} from 'bun:sqlite';
 import {it as effectIt} from '@effect/vitest';
 import {Clock, Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
 import {runCodeGraphRepair} from '../../src/code_graph/commands.js';
 import {
+  codeGraphTemporaryMaterializationSpoolSnapshotId,
   codeGraphDoctorCheck,
   diagnoseCodeGraphDatabaseReadOnly,
   repairCodeGraphIndexes,
@@ -96,6 +98,124 @@ describe('bounded code graph maintenance', () => {
     });
     expect(progress).toEqual(['checking:none', 'deferred:active-build']);
     expect(await Bun.file(databasePath).text()).toContain('must never be opened');
+  });
+
+  effectIt.effect('deep repair removes orphaned spools while preserving live leased build state', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-spool-'});
+      const checkoutId = 'a'.repeat(64);
+      const repositoryId = 'b'.repeat(64);
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+      const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+      const identity: RepositoryIdentity = {
+        caseMode: 'sensitive',
+        checkoutId,
+        displayName: 'repair-spool-fixture',
+        gitCommonDirectory: home,
+        headCommit: 'c'.repeat(40),
+        objectFormat: 'sha1',
+        repoRoot: home,
+        repositoryId,
+        worktreeId: 'd'.repeat(64),
+      };
+      const unleasedSnapshot = repairBuildingSnapshot(identity, '1');
+      const leasedIdentity = {...identity, worktreeId: 'e'.repeat(64)};
+      const leasedSnapshot = repairBuildingSnapshot(leasedIdentity, '2');
+      const orphanSnapshotId = `cgsn_${'3'.repeat(40)}-direct`;
+      const spoolPath = (snapshotId: string) =>
+        path.join(repositoryRoot, `materialization-spool-v1-${snapshotId}.sqlite`);
+      const ignoredPath = path.join(repositoryRoot, `materialization-spool-v2-${orphanSnapshotId}.sqlite`);
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* store.claimPersistentBuild(databasePath, identity, unleasedSnapshot, {
+        logicalSnapshotId: `cgsn_${'1'.repeat(40)}`,
+        owner: {buildId: '11111111-1111-1111', processId: process.pid},
+      });
+      yield* store.claimPersistentBuild(databasePath, leasedIdentity, leasedSnapshot, {
+        logicalSnapshotId: `cgsn_${'2'.repeat(40)}`,
+        owner: {buildId: '22222222-2222-2222', processId: process.pid},
+      });
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database
+            .query('INSERT INTO snapshot_leases (token, snapshot_id, expires_at) VALUES (?, ?, ?)')
+            .run('repair-spool-live-lease', leasedSnapshot.id, Date.now() + 60_000);
+        } finally {
+          database.close(false);
+        }
+      });
+      for (const file of [
+        spoolPath(unleasedSnapshot.id),
+        spoolPath(leasedSnapshot.id),
+        spoolPath(orphanSnapshotId),
+        ignoredPath,
+      ]) {
+        yield* fs.writeFile(file, new Uint8Array([1]));
+      }
+
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {mode: 'deep'});
+      expect(preview).toMatchObject({removedIncompleteSnapshots: 1, removedTemporaryFiles: 2});
+      for (const file of [
+        spoolPath(unleasedSnapshot.id),
+        spoolPath(leasedSnapshot.id),
+        spoolPath(orphanSnapshotId),
+        ignoredPath,
+      ]) {
+        expect(yield* fs.exists(file)).toBe(true);
+      }
+
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {mode: 'deep'});
+      expect(applied).toMatchObject({removedIncompleteSnapshots: 1, removedTemporaryFiles: 2});
+      expect(yield* fs.exists(spoolPath(unleasedSnapshot.id))).toBe(false);
+      expect(yield* fs.exists(spoolPath(orphanSnapshotId))).toBe(false);
+      expect(yield* fs.exists(spoolPath(leasedSnapshot.id))).toBe(true);
+      expect(yield* fs.exists(ignoredPath)).toBe(true);
+      expect(yield* store.diagnose(databasePath)).toMatchObject({buildingSnapshots: 1});
+
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database.query('DELETE FROM snapshot_leases WHERE token = ?').run('repair-spool-live-lease');
+        } finally {
+          database.close(false);
+        }
+      });
+      const released = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {mode: 'deep'});
+      expect(released).toMatchObject({removedIncompleteSnapshots: 1, removedTemporaryFiles: 1});
+      expect(yield* fs.exists(spoolPath(leasedSnapshot.id))).toBe(false);
+      expect(yield* fs.exists(ignoredPath)).toBe(true);
+      expect(yield* store.diagnose(databasePath)).toMatchObject({buildingSnapshots: 0, integrity: 'ok'});
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  it('recognizes exactly the canonical persistent spool filename family', () => {
+    const hexadecimal = (length: number) =>
+      fc
+        .array(fc.constantFrom(...'0123456789abcdef'), {maxLength: length, minLength: length})
+        .map(value => value.join(''));
+    fc.assert(
+      fc.property(
+        hexadecimal(40),
+        fc.oneof(
+          fc.constant(''),
+          fc.constant('-direct'),
+          hexadecimal(16).map(value => `-full-${value}`),
+        ),
+        fc.constantFrom('', '-journal', '-shm', '-wal'),
+        (digest, mode, companion) => {
+          const snapshotId = `cgsn_${digest}${mode}`;
+          const fileName = `materialization-spool-v1-${snapshotId}.sqlite${companion}`;
+          expect(codeGraphTemporaryMaterializationSpoolSnapshotId(fileName)).toBe(snapshotId);
+          expect(codeGraphTemporaryMaterializationSpoolSnapshotId(`prefix-${fileName}`)).toBeUndefined();
+          expect(codeGraphTemporaryMaterializationSpoolSnapshotId(`${fileName}.extra`)).toBeUndefined();
+          expect(codeGraphTemporaryMaterializationSpoolSnapshotId(fileName.replace('-v1-', '-v2-'))).toBeUndefined();
+        },
+      ),
+      {numRuns: 100},
+    );
   });
 
   it('recovers an orphaned checkout lock instead of deferring doctor forever', async () => {
@@ -820,6 +940,21 @@ function legacyReadySnapshot(identity: RepositoryIdentity, seed: string): CodeGr
     id: `cgsn_${seed.repeat(40)}`,
     repositoryId: identity.repositoryId,
     state: 'ready',
+    symbolCount: 0,
+    worktreeId: identity.worktreeId,
+  };
+}
+
+function repairBuildingSnapshot(identity: RepositoryIdentity, seed: string): CodeGraphSnapshot {
+  return {
+    commit: identity.headCommit,
+    dirty: false,
+    edgeCount: 0,
+    extractorSet: 'repair-spool-regression',
+    fileCount: 0,
+    id: `cgsn_${seed.repeat(40)}-direct`,
+    repositoryId: identity.repositoryId,
+    state: 'building',
     symbolCount: 0,
     worktreeId: identity.worktreeId,
   };

--- a/test/unit/code-graph.maintenance-bounded.test.ts
+++ b/test/unit/code-graph.maintenance-bounded.test.ts
@@ -849,6 +849,65 @@ describe('bounded code graph maintenance', () => {
       yield* store.initialize(databasePath);
       yield* Effect.sync(() => makePreReconciliationIndexRevision7(databasePath));
 
+      const schemaBeforePreview = yield* Effect.sync(() => readReconciliationPreparationState(databasePath));
+      const filesBeforePreview = yield* Effect.promise(() => readDatabaseDurabilityEvidence(databasePath));
+      const repeated = yield* Effect.forEach(
+        [1, 2, 3, 4, 5],
+        () => store.prepareWorktreeReconciliationIndexes(databasePath, {preview: true}),
+        {concurrency: 1},
+      );
+      expect(repeated).toEqual(repeated.map(() => ({state: 'migration-ready'})));
+      const typedFailure = yield* store
+        .prepareWorktreeReconciliationIndexes(databasePath, {
+          afterPreviewTransactionStarted: () => Effect.fail(new TestError('stop preview')),
+          preview: true,
+        })
+        .pipe(Effect.exit);
+      expect(Exit.isFailure(typedFailure)).toBe(true);
+      const previewStarted = yield* Deferred.make<void>();
+      const interruptedPreview = yield* Effect.forkChild(
+        store.prepareWorktreeReconciliationIndexes(databasePath, {
+          afterPreviewTransactionStarted: () =>
+            Deferred.succeed(previewStarted, undefined).pipe(Effect.andThen(Effect.never)),
+          preview: true,
+        }),
+      );
+      yield* Deferred.await(previewStarted);
+      yield* Fiber.interrupt(interruptedPreview);
+      const filesAfterPreview = yield* Effect.promise(() => readDatabaseDurabilityEvidence(databasePath));
+      expect(filesAfterPreview).toEqual(filesBeforePreview);
+      expect(yield* Effect.sync(() => readReconciliationPreparationState(databasePath))).toEqual(schemaBeforePreview);
+
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'quick',
+      });
+      expect(preview).toMatchObject({deferredDatabases: 0, migratedDatabases: 1});
+      expect(
+        yield* Effect.sync(() => {
+          const database = new Database(databasePath, {readonly: true, strict: true});
+          try {
+            return {
+              indexes: database
+                .query(
+                  `SELECT name FROM sqlite_master
+                   WHERE type = 'index' AND name IN (
+                     'active_snapshots_snapshot_worktree',
+                     'snapshots_base_state_id',
+                     'snapshot_leases_snapshot_expiry'
+                   )`,
+                )
+                .all(),
+              revision: database
+                .query("SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision'")
+                .get(),
+            };
+          } finally {
+            database.close(false);
+          }
+        }),
+      ).toEqual({indexes: [], revision: {value: '7'}});
+
       const progress: string[] = [];
       const repair = yield* repairCodeGraphIndexes(
         home,
@@ -858,7 +917,7 @@ describe('bounded code graph maintenance', () => {
         {migrateSchema: true, mode: 'quick'},
       );
 
-      expect(repair).toMatchObject({deferredDatabases: 0, migratedDatabases: 1});
+      expect(repair).toEqual(preview);
       expect(progress).toEqual(['checking', 'migrating-schema']);
       expect(yield* codeGraphDoctorCheck(home)).toMatchObject({status: 'ok'});
       expect(
@@ -893,7 +952,7 @@ describe('bounded code graph maintenance', () => {
         ],
         revision: {value: String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)},
       });
-    }).pipe(provideTestLayer(ApplicationLayer)),
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
   effectIt.effect('keeps revision-6 ready snapshots readable while background maintenance migrates them', () =>
@@ -1137,6 +1196,46 @@ function readCleanupHealthSurface(database: Database): {
   };
 }
 
+function readReconciliationPreparationState(databasePath: string): {
+  readonly metadata: readonly unknown[];
+  readonly schema: readonly unknown[];
+  readonly schemaVersion: unknown;
+} {
+  const database = new Database(databasePath, {readonly: true, strict: true});
+  try {
+    return {
+      metadata: database.query('SELECT key, value FROM schema_metadata ORDER BY key').all(),
+      schema: database
+        .query(
+          `SELECT type, name, tbl_name, sql
+           FROM sqlite_master
+           WHERE type IN ('index', 'table', 'trigger')
+           ORDER BY type, name`,
+        )
+        .all(),
+      schemaVersion: database.query('PRAGMA schema_version').get(),
+    };
+  } finally {
+    database.close(false);
+  }
+}
+
+async function readDatabaseDurabilityEvidence(databasePath: string): Promise<{
+  readonly database: {readonly bytes: number; readonly sha256: string} | {readonly missing: true};
+  readonly wal: {readonly bytes: number; readonly sha256: string} | {readonly missing: true};
+}> {
+  const inspect = async (filePath: string) => {
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) return {missing: true} as const;
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    return {
+      bytes: bytes.byteLength,
+      sha256: new Bun.CryptoHasher('sha256').update(bytes).digest('hex'),
+    } as const;
+  };
+  return {database: await inspect(databasePath), wal: await inspect(`${databasePath}-wal`)};
+}
+
 function makeRecoverableInterruptedExtension(databasePath: string): void {
   const database = new Database(databasePath, {strict: true});
   try {
@@ -1216,6 +1315,8 @@ function downgradeToReleasedRevision6(databasePath: string): void {
         DROP INDEX IF EXISTS active_snapshots_snapshot_worktree;
         DROP INDEX IF EXISTS snapshots_base_state_id;
         DROP INDEX IF EXISTS snapshot_leases_snapshot_expiry;
+        DROP INDEX IF EXISTS snapshot_files_raw_content_hash;
+        ALTER TABLE snapshot_files DROP COLUMN raw_content_hash;
         DELETE FROM schema_metadata
         WHERE key IN ('removed_view_cleanup_admission_cursor', 'removed_view_cleanup_epoch_sequence');
         UPDATE schema_metadata

--- a/test/unit/code-graph.maintenance-bounded.test.ts
+++ b/test/unit/code-graph.maintenance-bounded.test.ts
@@ -2,7 +2,7 @@ import {TestError} from '../helpers/test-error.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {Database} from 'bun:sqlite';
 import {it as effectIt} from '@effect/vitest';
-import {Clock, Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
+import {Clock, Crypto, Deferred, Effect, Exit, Fiber, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import fc from 'fast-check';
 import {afterEach, describe, expect, it} from 'vitest';
@@ -31,6 +31,7 @@ import type {RuntimeConfig} from '../../src/types.js';
 import {join, mkdir, mkdtemp, rm, writeFile} from '../helpers/effect-filesystem.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
 import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
 import {inspectCodeGraphViewDatabaseTarget} from '../../src/code_graph/view_removal.js';
 
@@ -127,6 +128,7 @@ describe('bounded code graph maintenance', () => {
       const spoolPath = (snapshotId: string) =>
         path.join(repositoryRoot, `materialization-spool-v1-${snapshotId}.sqlite`);
       const ignoredPath = path.join(repositoryRoot, `materialization-spool-v2-${orphanSnapshotId}.sqlite`);
+      const vectorTemporaryPath = path.join(repositoryRoot, 'vectors', 'model', 'scratch.tmp');
       const store = yield* CodeGraphStore;
       yield* store.initialize(databasePath);
       yield* store.claimPersistentBuild(databasePath, identity, unleasedSnapshot, {
@@ -155,9 +157,11 @@ describe('bounded code graph maintenance', () => {
       ]) {
         yield* fs.writeFile(file, new Uint8Array([1]));
       }
+      yield* fs.makeDirectory(path.dirname(vectorTemporaryPath), {recursive: true});
+      yield* fs.writeFile(vectorTemporaryPath, new Uint8Array([1]));
 
       const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {mode: 'deep'});
-      expect(preview).toMatchObject({removedIncompleteSnapshots: 1, removedTemporaryFiles: 2});
+      expect(preview).toMatchObject({removedIncompleteSnapshots: 1, removedTemporaryFiles: 3});
       for (const file of [
         spoolPath(unleasedSnapshot.id),
         spoolPath(leasedSnapshot.id),
@@ -166,13 +170,15 @@ describe('bounded code graph maintenance', () => {
       ]) {
         expect(yield* fs.exists(file)).toBe(true);
       }
+      expect(yield* fs.exists(vectorTemporaryPath)).toBe(true);
 
       const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {mode: 'deep'});
-      expect(applied).toMatchObject({removedIncompleteSnapshots: 1, removedTemporaryFiles: 2});
+      expect(applied).toMatchObject({removedIncompleteSnapshots: 1, removedTemporaryFiles: 3});
       expect(yield* fs.exists(spoolPath(unleasedSnapshot.id))).toBe(false);
       expect(yield* fs.exists(spoolPath(orphanSnapshotId))).toBe(false);
       expect(yield* fs.exists(spoolPath(leasedSnapshot.id))).toBe(true);
       expect(yield* fs.exists(ignoredPath)).toBe(true);
+      expect(yield* fs.exists(vectorTemporaryPath)).toBe(false);
       expect(yield* store.diagnose(databasePath)).toMatchObject({buildingSnapshots: 1});
 
       yield* Effect.sync(() => {
@@ -188,6 +194,351 @@ describe('bounded code graph maintenance', () => {
       expect(yield* fs.exists(spoolPath(leasedSnapshot.id))).toBe(false);
       expect(yield* fs.exists(ignoredPath)).toBe(true);
       expect(yield* store.diagnose(databasePath)).toMatchObject({buildingSnapshots: 0, integrity: 'ok'});
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('defers a targeted repair when a builder enters after the initial drain', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-late-builder-'});
+        const identity = legacyRepositoryIdentity(home, 'a');
+        const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', identity.checkoutId);
+        const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+        const building = repairBuildingSnapshot(identity, '1');
+        const spoolPath = path.join(repositoryRoot, `materialization-spool-v1-${building.id}.sqlite`);
+        const store = yield* CodeGraphStore;
+        yield* store.initialize(databasePath);
+        const drained = yield* Deferred.make<void>();
+        const continueRepair = yield* Deferred.make<void>();
+        const builderClaimed = yield* Deferred.make<void>();
+        const releaseBuilder = yield* Deferred.make<void>();
+        const repair = yield* Effect.forkScoped(
+          repairCodeGraphIndexes(home, false, undefined, undefined, {
+            interlock: {
+              afterWorktreeDrain: () =>
+                Deferred.succeed(drained, undefined).pipe(Effect.andThen(Deferred.await(continueRepair))),
+            },
+            mode: 'deep',
+            targetCheckoutId: identity.checkoutId,
+          }),
+        );
+        yield* Deferred.await(drained);
+        const builder = yield* Effect.forkScoped(
+          withExclusiveFileLock(
+            fs,
+            codeGraphWorktreeLockPath(path, home, identity.checkoutId, identity.worktreeId),
+            {
+              heartbeatIntervalMilliseconds: 20,
+              retryIntervalMilliseconds: 5,
+              staleAfterMilliseconds: 100,
+              waitTimeoutMilliseconds: 5_000,
+            },
+            Effect.gen(function* () {
+              yield* store.claimPersistentBuild(databasePath, identity, building, {
+                logicalSnapshotId: `cgsn_${'1'.repeat(40)}`,
+                owner: {buildId: '11111111-1111-1111', processId: process.pid},
+              });
+              yield* fs.writeFile(spoolPath, new Uint8Array([1]));
+              yield* Deferred.succeed(builderClaimed, undefined);
+              yield* Deferred.await(releaseBuilder);
+            }),
+          ),
+        );
+        yield* Deferred.await(builderClaimed);
+        yield* Deferred.succeed(continueRepair, undefined);
+
+        const summary = yield* Fiber.join(repair);
+        expect(summary).toMatchObject({
+          databases: 1,
+          deferredDatabases: 1,
+          removedIncompleteSnapshots: 0,
+          removedTemporaryFiles: 0,
+        });
+        expect(yield* fs.exists(spoolPath)).toBe(true);
+        expect(yield* store.diagnose(databasePath)).toMatchObject({buildingSnapshots: 1});
+
+        yield* Deferred.succeed(releaseBuilder, undefined);
+        yield* Fiber.join(builder);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('reports orphan spool cleanup during a schema-migration dry-run', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-migration-preview-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const leasedIdentity = {...identity, worktreeId: 'b'.repeat(64)};
+      const unleasedSnapshot = repairBuildingSnapshot(identity, '1');
+      const leasedSnapshot = repairBuildingSnapshot(leasedIdentity, '2');
+      const orphanSnapshotId = `cgsn_${'3'.repeat(40)}-direct`;
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', identity.checkoutId);
+      const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+      const spoolPath = (snapshotId: string) =>
+        path.join(repositoryRoot, `materialization-spool-v1-${snapshotId}.sqlite`);
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* store.claimPersistentBuild(databasePath, identity, unleasedSnapshot, {
+        logicalSnapshotId: `cgsn_${'1'.repeat(40)}`,
+        owner: {buildId: '11111111-1111-1111', processId: process.pid},
+      });
+      yield* store.claimPersistentBuild(databasePath, leasedIdentity, leasedSnapshot, {
+        logicalSnapshotId: `cgsn_${'2'.repeat(40)}`,
+        owner: {buildId: '22222222-2222-2222', processId: process.pid},
+      });
+      yield* Effect.sync(() => {
+        const database = new Database(databasePath, {strict: true});
+        try {
+          database
+            .query('INSERT INTO snapshot_leases (token, snapshot_id, expires_at) VALUES (?, ?, ?)')
+            .run('migration-preview-live-lease', leasedSnapshot.id, Date.now() + 60_000);
+        } finally {
+          database.close(false);
+        }
+      });
+      yield* Effect.sync(() => makeRecoverableInterruptedExtension(databasePath));
+      for (const snapshotId of [unleasedSnapshot.id, leasedSnapshot.id, orphanSnapshotId]) {
+        yield* fs.writeFile(spoolPath(snapshotId), new Uint8Array([1]));
+      }
+
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(preview).toMatchObject({
+        migratedDatabases: 1,
+        removedIncompleteSnapshots: 0,
+        removedTemporaryFiles: 3,
+      });
+      for (const snapshotId of [unleasedSnapshot.id, leasedSnapshot.id, orphanSnapshotId]) {
+        expect(yield* fs.exists(spoolPath(snapshotId))).toBe(true);
+      }
+
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        migrateSchema: true,
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+      expect(applied).toMatchObject({
+        migratedDatabases: 1,
+        removedIncompleteSnapshots: 0,
+        removedTemporaryFiles: 3,
+      });
+      expect(yield* fs.exists(spoolPath(unleasedSnapshot.id))).toBe(false);
+      expect(yield* fs.exists(spoolPath(orphanSnapshotId))).toBe(false);
+      expect(yield* fs.exists(spoolPath(leasedSnapshot.id))).toBe(false);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('removes a database-less orphan spool', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-database-less-'});
+      const checkoutId = 'a'.repeat(64);
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+      const spoolPath = path.join(repositoryRoot, `materialization-spool-v1-cgsn_${'1'.repeat(40)}-direct.sqlite`);
+      yield* fs.makeDirectory(repositoryRoot, {recursive: true});
+      yield* fs.writeFile(spoolPath, new Uint8Array([1]));
+
+      const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
+        mode: 'deep',
+        targetCheckoutId: checkoutId,
+      });
+      expect(preview).toMatchObject({databases: 0, removedTemporaryFiles: 1});
+      expect(yield* fs.exists(spoolPath)).toBe(true);
+
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        mode: 'deep',
+        targetCheckoutId: checkoutId,
+      });
+      expect(applied).toMatchObject({databases: 0, removedTemporaryFiles: 1});
+      expect(yield* fs.exists(spoolPath)).toBe(false);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('defers database-less cleanup when a builder publishes durable state after inventory', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const crypto = yield* Crypto.Crypto;
+      const system = yield* SystemInfo;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-database-appeared-'});
+      const identity = legacyRepositoryIdentity(home, 'a');
+      const building = repairBuildingSnapshot(identity, '1');
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', identity.checkoutId);
+      const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+      const spoolPath = path.join(repositoryRoot, `materialization-spool-v1-${building.id}.sqlite`);
+      const store = yield* CodeGraphStore;
+      yield* fs.makeDirectory(repositoryRoot, {recursive: true});
+      let built = false;
+
+      const summary = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        interlock: {
+          afterWorktreeDrain: () =>
+            Effect.gen(function* () {
+              if (built) return;
+              built = true;
+              yield* withExclusiveFileLock(
+                fs,
+                codeGraphWorktreeLockPath(path, home, identity.checkoutId, identity.worktreeId),
+                {
+                  heartbeatIntervalMilliseconds: 20,
+                  retryIntervalMilliseconds: 5,
+                  staleAfterMilliseconds: 100,
+                  waitTimeoutMilliseconds: 5_000,
+                },
+                Effect.gen(function* () {
+                  yield* store.initialize(databasePath);
+                  yield* store.claimPersistentBuild(databasePath, identity, building, {
+                    logicalSnapshotId: `cgsn_${'1'.repeat(40)}`,
+                    owner: {buildId: '11111111-1111-1111', processId: process.pid},
+                  });
+                  yield* Effect.sync(() => {
+                    const database = new Database(databasePath, {strict: true});
+                    try {
+                      database
+                        .query('INSERT INTO snapshot_leases (token, snapshot_id, expires_at) VALUES (?, ?, ?)')
+                        .run('database-appeared-live-lease', building.id, Date.now() + 60_000);
+                    } finally {
+                      database.close(false);
+                    }
+                  });
+                  yield* fs.writeFile(spoolPath, new Uint8Array([1]));
+                }),
+              ).pipe(
+                Effect.provideService(Crypto.Crypto, crypto),
+                Effect.provideService(Path.Path, path),
+                Effect.provideService(SystemInfo, system),
+              );
+            }),
+        },
+        mode: 'deep',
+        targetCheckoutId: identity.checkoutId,
+      });
+
+      expect(summary).toMatchObject({
+        databases: 1,
+        deferredDatabases: 1,
+        removedIncompleteSnapshots: 0,
+        removedTemporaryFiles: 0,
+      });
+      expect(yield* fs.exists(spoolPath)).toBe(true);
+      expect(yield* store.diagnose(databasePath)).toMatchObject({buildingSnapshots: 1});
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
+
+  effectIt.effect('never follows a spool-shaped child symbolic link', () =>
+    Effect.gen(function* () {
+      if (process.platform === 'win32') return;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-child-link-'});
+      const external = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-external-'});
+      const checkoutId = 'a'.repeat(64);
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+      const externalVictim = path.join(external, 'victim.sqlite');
+      const linkedSpool = path.join(repositoryRoot, `materialization-spool-v1-cgsn_${'1'.repeat(40)}-direct.sqlite`);
+      yield* fs.makeDirectory(repositoryRoot, {recursive: true});
+      yield* fs.writeFile(externalVictim, new Uint8Array([1]));
+      yield* fs.symlink(externalVictim, linkedSpool);
+
+      const applied = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        mode: 'deep',
+        targetCheckoutId: checkoutId,
+      });
+      expect(applied).toMatchObject({databases: 0, removedTemporaryFiles: 0});
+      expect(yield* fs.exists(linkedSpool)).toBe(true);
+      expect(yield* fs.exists(externalVictim)).toBe(true);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('refuses spool cleanup after the repositories ancestor is swapped', () =>
+    Effect.gen(function* () {
+      if (process.platform === 'win32') return;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-ancestor-swap-'});
+      const externalRepositories = yield* fs.makeTempDirectoryScoped({
+        prefix: 'threadnote-graph-repair-external-repositories-',
+      });
+      const checkoutId = 'a'.repeat(64);
+      const repositories = path.join(home, 'indexes', 'code-graph', 'repositories');
+      const repositoryRoot = path.join(repositories, checkoutId);
+      const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+      const movedRepositories = `${repositories}.original`;
+      const externalCheckout = path.join(externalRepositories, checkoutId);
+      const spoolName = `materialization-spool-v1-cgsn_${'1'.repeat(40)}-direct.sqlite`;
+      const originalSpool = path.join(repositoryRoot, spoolName);
+      const externalVictim = path.join(externalCheckout, 'victim.sqlite');
+      const externalReplacementSpool = path.join(externalCheckout, spoolName);
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* fs.writeFile(originalSpool, new Uint8Array([1]));
+      yield* fs.makeDirectory(externalCheckout, {recursive: true});
+      yield* fs.writeFile(externalVictim, new Uint8Array([1]));
+      yield* fs.symlink(externalVictim, externalReplacementSpool);
+
+      const result = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        interlock: {
+          beforeSpoolQuarantine: () =>
+            fs
+              .rename(repositories, movedRepositories)
+              .pipe(Effect.andThen(fs.symlink(externalRepositories, repositories))),
+        },
+        mode: 'deep',
+        targetCheckoutId: checkoutId,
+      }).pipe(Effect.exit);
+
+      expect(Exit.isFailure(result)).toBe(true);
+      expect(yield* fs.exists(externalReplacementSpool)).toBe(true);
+      expect(yield* fs.readLink(externalReplacementSpool)).toBe(externalVictim);
+      expect(yield* fs.exists(externalVictim)).toBe(true);
+      expect(yield* fs.exists(path.join(movedRepositories, checkoutId, spoolName))).toBe(true);
+      expect((yield* fs.readDirectory(externalCheckout)).some(name => name.endsWith('.repair'))).toBe(false);
+    }).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('refuses spool cleanup after the checkout root is swapped', () =>
+    Effect.gen(function* () {
+      if (process.platform === 'win32') return;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-repair-root-swap-'});
+      const externalCheckout = yield* fs.makeTempDirectoryScoped({
+        prefix: 'threadnote-graph-repair-external-checkout-',
+      });
+      const checkoutId = 'a'.repeat(64);
+      const repositoryRoot = path.join(home, 'indexes', 'code-graph', 'repositories', checkoutId);
+      const databasePath = path.join(repositoryRoot, `graph-v${CODE_GRAPH_SCHEMA_VERSION}.sqlite`);
+      const movedRepositoryRoot = `${repositoryRoot}.original`;
+      const spoolName = `materialization-spool-v1-cgsn_${'1'.repeat(40)}-direct.sqlite`;
+      const originalSpool = path.join(repositoryRoot, spoolName);
+      const externalVictim = path.join(externalCheckout, spoolName);
+      const store = yield* CodeGraphStore;
+      yield* store.initialize(databasePath);
+      yield* fs.writeFile(originalSpool, new Uint8Array([1]));
+      yield* fs.writeFile(externalVictim, new Uint8Array([1]));
+
+      const result = yield* repairCodeGraphIndexes(home, false, undefined, undefined, {
+        interlock: {
+          beforeSpoolQuarantine: () =>
+            fs
+              .rename(repositoryRoot, movedRepositoryRoot)
+              .pipe(Effect.andThen(fs.symlink(externalCheckout, repositoryRoot))),
+        },
+        mode: 'deep',
+        targetCheckoutId: checkoutId,
+      }).pipe(Effect.exit);
+
+      expect(Exit.isFailure(result)).toBe(true);
+      expect(yield* fs.exists(externalVictim)).toBe(true);
+      expect(yield* fs.exists(path.join(movedRepositoryRoot, spoolName))).toBe(true);
+      expect((yield* fs.readDirectory(externalCheckout)).some(name => name.endsWith('.repair'))).toBe(false);
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 


### PR DESCRIPTION
## Summary
- Teach deep graph repair to inventory and reclaim canonical materialization spool families left by interrupted builds, including database-less residues.
- Preserve ordinary lease-protected resumable state, model schema-migration cleanup consistently in dry-run/apply, and defer if a database appears after inventory.
- Close targeted-repair late-builder admission and bind temporary graph deletion to pinned, reverified checkout/file identities with quarantine-before-remove.
- Report spool files through the existing temporary-graph summary and document the 4.4.2 behavior.

## Verification
- Focused Effect regressions cover ordinary orphan/lease cleanup, a late builder after the first drain, a database appearing after inventory, migration dry-run/apply parity, database-less spools, child symlinks, and ancestor/checkout-root swaps.
- Vector temporary files use the same pinned/quarantine deletion path; existing vector-symlink coverage remains green.
- Fast-check property: 100 runs across canonical snapshot modes and SQLite companion suffixes.
- Maintenance-bounded: 21/21; maintenance-gate/purge/obsolete: 12/12; targeted lifecycle repair/discard/vector checks green.
- Commit hooks: strict lint, Prettier, production/test/site typechecks.

## Dogfood evidence
An interrupted graph worker left a 238 MiB materialization-spool-v1 SQLite file after its building snapshot and owner rows were reclaimed. Existing 4.4.1 deep repair reported zero temporary files. Global exact-head smoke is deferred to the primary release checkout because it owns the active development runtime; it will run dry-run/apply on this real orphan after merge and before tagging.