### PR TITLE
fix(manager): support fresh Threadnote homes

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -82,6 +82,7 @@ import {collectDoctorChecks, runRepair, runStart} from './lifecycle.js';
 import {runSeed, runSeedSkills} from './seeding.js';
 import {readManagerRuntimeState} from './manager_state.js';
 import {handleManagerProcessRequest} from './manager_processes.js';
+import {emptyManagerTree, isMissingManagerTreePath} from './manager_tree.js';
 import {
   handleManagerWorksetRequest,
   isManagerWorksetApiPath,
@@ -404,7 +405,12 @@ export function createManagerServer(
 
 export const memoryTree = Effect.fn('manager.memoryTree')(function* (config: RuntimeConfig) {
   const root = yield* localMemoriesRoot(config);
-  return yield* readTree(config, root, `threadnote://user/${uriSegment(config.user)}/memories`, '');
+  const uri = `threadnote://user/${uriSegment(config.user)}/memories`;
+  return yield* readTree(config, root, uri, '').pipe(
+    Effect.catch(error =>
+      isMissingManagerTreePath(error) ? Effect.succeed(emptyManagerTree('memories', uri)) : Effect.fail(error),
+    ),
+  );
 });
 
 export const resourcesTree = Effect.fn('manager.resourcesTree')(function* (config: RuntimeConfig) {
@@ -413,20 +419,11 @@ export const resourcesTree = Effect.fn('manager.resourcesTree')(function* (confi
     parseMemoryDocuments: false,
     rootName: 'resources',
   }).pipe(
-    Effect.catch(error => {
-      if (!isMissingPathError(error)) {
-        return Effect.fail(error);
-      }
-      return Effect.succeed({
-        children: [],
-        isDir: true as const,
-        isShared: false,
-        isSystem: false,
-        name: 'resources',
-        relativePath: '',
-        uri: 'threadnote://resources',
-      });
-    }),
+    Effect.catch(error =>
+      isMissingManagerTreePath(error)
+        ? Effect.succeed(emptyManagerTree('resources', 'threadnote://resources'))
+        : Effect.fail(error),
+    ),
   );
 });
 
@@ -1912,19 +1909,6 @@ const localPathForMemoryUri = Effect.fn('manager.localPathForMemoryUri')(functio
   }
   return yield* pathJoin(yield* localMemoriesRoot(config), ...segments);
 });
-
-function isMissingPathError(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    (('code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') ||
-      ('reason' in err &&
-        typeof err.reason === 'object' &&
-        err.reason !== null &&
-        '_tag' in err.reason &&
-        err.reason._tag === 'NotFound'))
-  );
-}
 
 const localPathToMemoryUri = Effect.fn('manager.localPathToMemoryUri')(function* (config: RuntimeConfig, path: string) {
   const relativePath = yield* pathRelative(yield* localMemoriesRoot(config), path);

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -82,7 +82,7 @@ import {collectDoctorChecks, runRepair, runStart} from './lifecycle.js';
 import {runSeed, runSeedSkills} from './seeding.js';
 import {readManagerRuntimeState} from './manager_state.js';
 import {handleManagerProcessRequest} from './manager_processes.js';
-import {emptyManagerTree, isMissingManagerTreePath} from './manager_tree.js';
+import {emptyManagerTree, readManagerTreeRoot} from './manager_tree.js';
 import {
   handleManagerWorksetRequest,
   isManagerWorksetApiPath,
@@ -406,24 +406,16 @@ export function createManagerServer(
 export const memoryTree = Effect.fn('manager.memoryTree')(function* (config: RuntimeConfig) {
   const root = yield* localMemoriesRoot(config);
   const uri = `threadnote://user/${uriSegment(config.user)}/memories`;
-  return yield* readTree(config, root, uri, '').pipe(
-    Effect.catch(error =>
-      isMissingManagerTreePath(error) ? Effect.succeed(emptyManagerTree('memories', uri)) : Effect.fail(error),
-    ),
-  );
+  return yield* readManagerTreeRoot(lstat(root), readTree(config, root, uri, ''), emptyManagerTree('memories', uri));
 });
 
 export const resourcesTree = Effect.fn('manager.resourcesTree')(function* (config: RuntimeConfig) {
   const root = yield* localResourcesRoot(config);
-  return yield* readTree(config, root, 'threadnote://resources', '', {
-    parseMemoryDocuments: false,
-    rootName: 'resources',
-  }).pipe(
-    Effect.catch(error =>
-      isMissingManagerTreePath(error)
-        ? Effect.succeed(emptyManagerTree('resources', 'threadnote://resources'))
-        : Effect.fail(error),
-    ),
+  const uri = 'threadnote://resources';
+  return yield* readManagerTreeRoot(
+    lstat(root),
+    readTree(config, root, uri, '', {parseMemoryDocuments: false, rootName: 'resources'}),
+    emptyManagerTree('resources', uri),
   );
 });
 

--- a/src/manager_refresh.ts
+++ b/src/manager_refresh.ts
@@ -1,0 +1,19 @@
+export interface ManagerRefreshTask {
+  readonly label: string;
+  readonly run: () => Promise<void>;
+}
+
+export async function settleManagerRefreshTasks(tasks: readonly ManagerRefreshTask[]): Promise<readonly string[]> {
+  const outcomes = await Promise.all(
+    tasks.map(async task => {
+      try {
+        await task.run();
+        return undefined;
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        return `${task.label}: ${message}`;
+      }
+    }),
+  );
+  return outcomes.filter((outcome): outcome is string => outcome !== undefined);
+}

--- a/src/manager_tree.ts
+++ b/src/manager_tree.ts
@@ -1,3 +1,5 @@
+import {Effect} from 'effect';
+
 export function emptyManagerTree(name: string, uri: string) {
   return {
     children: [],
@@ -20,5 +22,18 @@ export function isMissingManagerTreePath(cause: unknown): boolean {
         cause.reason !== null &&
         '_tag' in cause.reason &&
         cause.reason._tag === 'NotFound'))
+  );
+}
+
+export function readManagerTreeRoot<A, B, E1, E2, R1, R2>(
+  rootLookup: Effect.Effect<A, E1, R1>,
+  readTree: Effect.Effect<B, E2, R2>,
+  emptyTree: B,
+): Effect.Effect<B, E1 | E2, R1 | R2> {
+  return rootLookup.pipe(
+    Effect.matchEffect({
+      onFailure: cause => (isMissingManagerTreePath(cause) ? Effect.succeed(emptyTree) : Effect.fail(cause)),
+      onSuccess: () => readTree,
+    }),
   );
 }

--- a/src/manager_tree.ts
+++ b/src/manager_tree.ts
@@ -1,0 +1,24 @@
+export function emptyManagerTree(name: string, uri: string) {
+  return {
+    children: [],
+    isDir: true as const,
+    isShared: false,
+    isSystem: false,
+    name,
+    relativePath: '',
+    uri,
+  };
+}
+
+export function isMissingManagerTreePath(cause: unknown): boolean {
+  return (
+    typeof cause === 'object' &&
+    cause !== null &&
+    (('code' in cause && (cause as NodeJS.ErrnoException).code === 'ENOENT') ||
+      ('reason' in cause &&
+        typeof cause.reason === 'object' &&
+        cause.reason !== null &&
+        '_tag' in cause.reason &&
+        cause.reason._tag === 'NotFound'))
+  );
+}

--- a/src/manager_ui.tsx
+++ b/src/manager_ui.tsx
@@ -6,6 +6,7 @@ import type {CodeGraphLocalDiagnosticsReport} from './code_graph/diagnostics.js'
 import {ManagerAutocompleteInput, ManagerDialogProvider, useManagerDialogs} from './manager_dialog.js';
 import {WorksetsPanel} from './manager_worksets_view.js';
 import {ProcessesPanel} from './manager_processes_view.js';
+import {settleManagerRefreshTasks} from './manager_refresh.js';
 import {managerUpdateIndicator} from './manager_update_indicator.js';
 import {
   graphViewRemovalApprovalDialog,
@@ -427,28 +428,39 @@ function App(): React.ReactElement {
   );
 
   async function refreshAll(): Promise<void> {
-    const graphRequest = api<GraphCatalog>('/api/graphs', undefined, {
-      timeoutMilliseconds: GRAPH_CATALOG_REQUEST_TIMEOUT_MILLISECONDS,
-    }).then(
-      catalog => {
-        graphCatalogAuthoritativeRef.current = true;
-        graphCatalogRef.current = catalog;
-        setGraphCatalog(catalog);
-        setGraphCatalogError('');
+    const failures = await settleManagerRefreshTasks([
+      {
+        label: 'Graph indexes',
+        run: async () => {
+          try {
+            const catalog = await api<GraphCatalog>('/api/graphs', undefined, {
+              timeoutMilliseconds: GRAPH_CATALOG_REQUEST_TIMEOUT_MILLISECONDS,
+            });
+            graphCatalogAuthoritativeRef.current = true;
+            graphCatalogRef.current = catalog;
+            setGraphCatalog(catalog);
+            setGraphCatalogError('');
+          } catch (cause) {
+            setGraphCatalogError(errorMessage(cause));
+            throw cause;
+          }
+        },
       },
-      cause => setGraphCatalogError(errorMessage(cause)),
-    );
-    const [nextState, nextTree, nextShares] = await Promise.all([
-      api<StateResponse>('/api/state'),
-      api<TreeResponse>('/api/tree'),
-      api<{shares: readonly ShareSummary[]}>('/api/shares'),
+      {label: 'Runtime', run: async () => setState(await api<StateResponse>('/api/state'))},
+      {
+        label: 'Memory library',
+        run: async () => {
+          const next = await api<TreeResponse>('/api/tree');
+          setTree(next.tree);
+          setResourceTree(next.resourcesTree);
+        },
+      },
+      {
+        label: 'Shares',
+        run: async () => setShares((await api<{shares: readonly ShareSummary[]}>('/api/shares')).shares),
+      },
     ]);
-    setState(nextState);
-    setTree(nextTree.tree);
-    setResourceTree(nextTree.resourcesTree);
-    setShares(nextShares.shares);
-    await graphRequest;
-    toastMessage('Refreshed');
+    toastMessage(failures.length === 0 ? 'Refreshed' : `Refresh incomplete · ${failures.join(' · ')}`);
   }
 
   async function refreshGraphCatalog(notify = true): Promise<void> {

--- a/test/unit/manager-refresh.test.ts
+++ b/test/unit/manager-refresh.test.ts
@@ -1,0 +1,43 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {settleManagerRefreshTasks} from '../../src/manager_refresh.js';
+
+describe('Manager refresh isolation', () => {
+  it('keeps successful refreshes when one endpoint fails', async () => {
+    const completed: string[] = [];
+    const failures = await settleManagerRefreshTasks([
+      {label: 'Runtime', run: async () => void completed.push('runtime')},
+      {
+        label: 'Memory library',
+        run: async () => {
+          throw new Error('tree unavailable');
+        },
+      },
+      {label: 'Shares', run: async () => void completed.push('shares')},
+    ]);
+
+    expect(completed).toEqual(['runtime', 'shares']);
+    expect(failures).toEqual(['Memory library: tree unavailable']);
+  });
+
+  it('attempts every refresh once and reports failures in task order', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.array(fc.boolean(), {maxLength: 12}), async shouldFail => {
+        const calls = shouldFail.map(() => 0);
+        const failures = await settleManagerRefreshTasks(
+          shouldFail.map((fail, index) => ({
+            label: `task-${index}`,
+            run: async () => {
+              calls[index] += 1;
+              if (fail) throw new Error(`failed-${index}`);
+            },
+          })),
+        );
+
+        expect(calls).toEqual(shouldFail.map(() => 1));
+        expect(failures).toEqual(shouldFail.flatMap((fail, index) => (fail ? [`task-${index}: failed-${index}`] : [])));
+      }),
+      {numRuns: 64},
+    );
+  });
+});

--- a/test/unit/manager-tree.test.ts
+++ b/test/unit/manager-tree.test.ts
@@ -1,0 +1,17 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect} from 'effect';
+import {expect} from 'vitest';
+import {emptyManagerTree, readManagerTreeRoot} from '../../src/manager_tree.js';
+
+effectIt.effect('does not mistake a disappearing descendant for an absent Manager tree root', () =>
+  Effect.gen(function* () {
+    const missingDescendant = {reason: {_tag: 'NotFound'}} as const;
+    const failure = yield* readManagerTreeRoot(
+      Effect.void,
+      Effect.fail(missingDescendant),
+      emptyManagerTree('memories', 'threadnote://user/denys/memories'),
+    ).pipe(Effect.flip);
+
+    expect(failure).toBe(missingDescendant);
+  }),
+);

--- a/test/unit/manager.test.ts
+++ b/test/unit/manager.test.ts
@@ -715,6 +715,34 @@ describe('manager http API', () => {
     }
   });
 
+  it('serves an empty memory tree from a fresh Threadnote home', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'threadnote-manager-fresh-'));
+    homes.push(home);
+    const config: RuntimeConfig = {
+      account: 'local',
+      agentContextHome: home,
+      agentId: 'threadnote',
+      manifestPath: join(home, 'manifest.yaml'),
+      user: 'denys',
+    };
+    const server = await startServer(config, 'secret');
+    try {
+      const response = await fetch(`${server.url}/api/tree`, {headers: {authorization: 'Bearer secret'}});
+      const body = (await response.json()) as {readonly tree?: TreeNode};
+
+      expect(response.status).toBe(200);
+      expect(body.tree).toMatchObject({
+        children: [],
+        isDir: true,
+        name: 'memories',
+        relativePath: '',
+        uri: 'threadnote://user/denys/memories',
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
   effectIt.effect('serializes raw personal Manager saves with the managed-memory URI lock', () =>
     TestClock.withLive(
       Effect.scoped(


### PR DESCRIPTION
## Summary

- return an empty memories root when Manager starts before the local memory directory exists
- settle state, tree, shares, and graph refreshes independently so one failed endpoint cannot strand unrelated UI state
- preserve actionable partial-refresh feedback and the persistent graph error display
- scope missing-root recovery to the root lookup so descendant churn cannot erase a populated library view

## Verification

- reproduced the original API failure: fresh home returned HTTP 500
- focused Manager tests: 52 passed
- added a bounded property proving every refresh task runs exactly once and failures remain in task order
- added an Effect regression proving a disappearing descendant propagates instead of becoming an empty tree
- full production/test/site typechecks passed
- strict lint, production file-length lint, Prettier, and precommit passed
- Dev Cycle: full iteration found one important catch-scope issue; incremental iteration verified it resolved with zero remaining findings

Global installation is intentionally deferred because release QA owns the active global runtime.