### PR TITLE
chore: prepare v4.4.3

### DIFF
--- a/.github/release-notes/v4.4.3.md
+++ b/.github/release-notes/v4.4.3.md
@@ -1,0 +1,20 @@
+## What's new
+
+Threadnote 4.4.3 is a focused Manager reliability patch. A brand-new Threadnote home now opens cleanly before any
+memories have been created, and partial refresh failures no longer leave the whole interface stuck in a loading state.
+
+### Start cleanly on a fresh home
+
+- A new home with no memories yet opens as an empty library instead of failing its initial load.
+- Runtime, memory, share, and graph refreshes settle independently, so one unavailable data source no longer strands
+  every pane at “Connecting…”.
+- Incomplete refreshes identify the affected area while graph-specific failures remain visible and actionable.
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```
+
+Existing v1, v2, v3, and unversioned memories remain recallable. A Workset is not required for local repository recall
+or code-graph use; it remains an explicit prepared scope for cross-repository queries.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump the standalone version to 4.4.3
- add curated release notes for the fresh-home Manager reliability fix
- retain explicit v1/v2/v3/unversioned recall compatibility and optional-Workset guidance

## Verification

- focused release and website contracts: 91 passed
- release smoke contracts: 12 passed
- precommit lint, formatting, production/test/site typechecks passed
- targeted Prettier and git diff checks passed

This PR only prepares the release source. It does not create or push a version tag or publish a GitHub release.