### PR TITLE
fix(manager): hide updates for development builds

### DIFF
--- a/src/manager_state.ts
+++ b/src/manager_state.ts
@@ -6,7 +6,7 @@ import type {RuntimeConfig} from './types.js';
 import {currentPackageVersion, fetchLatestVersion, releaseSource} from './update.js';
 import {selectUpdateChannel} from './update_channel.js';
 import {findExecutable} from './utils.js';
-import {compareVersions} from './version_compare.js';
+import {compareVersions, isDevelopmentBuildVersion} from './version_compare.js';
 import {readAutoUpdateStatus} from './auto_update.js';
 
 export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationAgents')(function* (
@@ -35,8 +35,22 @@ export const detectConsolidationAgents = Effect.fn('manager.detectConsolidationA
 });
 
 export function managerUpdateAvailable(currentVersion: string, latestVersion?: string): boolean {
-  return latestVersion !== undefined && compareVersions(latestVersion, currentVersion) > 0;
+  return (
+    !isDevelopmentBuildVersion(currentVersion) &&
+    latestVersion !== undefined &&
+    compareVersions(latestVersion, currentVersion) > 0
+  );
 }
+
+export const fetchManagerLatestVersion = Effect.fn('manager.fetchLatestVersion')(function* (
+  currentVersion: string,
+  source: string,
+) {
+  if (isDevelopmentBuildVersion(currentVersion)) return undefined;
+  return yield* fetchLatestVersion(source, selectUpdateChannel(currentVersion)).pipe(
+    Effect.catch(() => Effect.succeed(undefined)),
+  );
+});
 
 export const readManagerRuntimeState = Effect.fn('manager.readRuntimeState')(function* (
   config: Pick<RuntimeConfig, 'agentContextHome'>,
@@ -47,10 +61,7 @@ export const readManagerRuntimeState = Effect.fn('manager.readRuntimeState')(fun
     readAutoUpdateStatus(),
     currentPackageVersion(),
   ]);
-  const latestVersion = yield* fetchLatestVersion(
-    releaseSource(system.environment()),
-    selectUpdateChannel(version),
-  ).pipe(Effect.catch(() => Effect.succeed(undefined)));
+  const latestVersion = yield* fetchManagerLatestVersion(version, releaseSource(system.environment()));
   return {
     agents,
     autoUpdate,

--- a/test/unit/manager-state.test.ts
+++ b/test/unit/manager-state.test.ts
@@ -1,6 +1,9 @@
+import {it as effectIt} from '@effect/vitest';
 import fc from 'fast-check';
+import {Effect} from 'effect';
 import {describe, expect, it} from 'vitest';
-import {managerUpdateAvailable} from '../../src/manager_state.js';
+import {HttpService} from '../../src/effect/http.js';
+import {fetchManagerLatestVersion, managerUpdateAvailable} from '../../src/manager_state.js';
 import {managerUpdateIndicator} from '../../src/manager_update_indicator.js';
 
 describe('Manager runtime state', () => {
@@ -9,6 +12,11 @@ describe('Manager runtime state', () => {
     {current: '4.2.0-beta.2', expected: false, latest: '4.2.0-beta.2'},
     {current: '4.2.0', expected: false, latest: '4.2.0-beta.9'},
     {current: '4.2.0-beta.2', expected: false, latest: '4.1.9'},
+    {
+      current: '4.4.2-local.g9d9e0358d2d1ac4736480fcf199a3cafdbb62249',
+      expected: false,
+      latest: '4.4.2',
+    },
     {current: '4.2.0', expected: false, latest: undefined},
   ])('reports $latest over $current as updateAvailable=$expected', ({current, expected, latest}) => {
     expect(managerUpdateAvailable(current, latest)).toBe(expected);
@@ -32,6 +40,46 @@ describe('Manager runtime state', () => {
       }),
     );
   });
+
+  it('never advertises a release update from a development runtime', () => {
+    const version = fc.tuple(
+      fc.integer({max: 99, min: 0}),
+      fc.integer({max: 99, min: 0}),
+      fc.integer({max: 99, min: 0}),
+    );
+    const commit = fc
+      .array(fc.constantFrom(...'0123456789abcdef'), {maxLength: 40, minLength: 40})
+      .map(characters => characters.join(''));
+    fc.assert(
+      fc.property(version, version, commit, (current, latest, revision) => {
+        const currentVersion = `${current.join('.')}-local.g${revision}`;
+        expect(managerUpdateAvailable(currentVersion, latest.join('.'))).toBe(false);
+      }),
+    );
+  });
+
+  effectIt.effect('does not check releases while reading development-runtime Manager state', () =>
+    Effect.gen(function* () {
+      let requests = 0;
+      const http = HttpService.of({
+        downloadToFile: () => Effect.die('not used'),
+        getJson: () =>
+          Effect.sync(() => {
+            requests += 1;
+            return {body: [], status: 200};
+          }),
+        getStatus: () => Effect.die('not used'),
+        getText: () => Effect.die('not used'),
+      });
+      const latestVersion = yield* fetchManagerLatestVersion(
+        `4.4.2-local.g${'a'.repeat(40)}`,
+        'https://example.invalid/releases',
+      ).pipe(Effect.provideService(HttpService, http));
+
+      expect(latestVersion).toBeUndefined();
+      expect(requests).toBe(0);
+    }),
+  );
 
   it.each([
     {


### PR DESCRIPTION
## Summary
- suppress Manager release-update availability for development runtime versions
- skip the release network check entirely for development runtimes
- keep Manager aligned with the existing notifier and auto-update eligibility policy
- cover the concrete regression, arbitrary valid local builds, and zero HTTP requests

## Reproduction
A `4.4.2-local.g<40-hex-commit>` runtime with latest release `4.4.2` previously produced `updateAvailable: true` and `Update queued`, even though development runtimes are explicitly ineligible for notification or automatic replacement.

## Validation
- focused Vitest: 13 passed
- strict targeted Oxlint
- targeted Prettier check
- production and test TypeScript checks
- pre-commit checks (lint, file length, formatting, production/test/site typechecks)
- independent amended-head review: clean, zero critical/important findings
