### PR TITLE
fix(installer): stabilize doctor after concurrent recall writes

### DIFF
--- a/scripts/install-local-standalone.ts
+++ b/scripts/install-local-standalone.ts
@@ -564,6 +564,8 @@ const verifyActivatedDevelopmentRelease = Effect.fn('developmentInstall.verifyAc
   } as const;
   const runDoctorStrict = () =>
     runCommandEffect(executable, ['doctor', '--dry-run', '--strict'], {...commandOptions, allowFailure: true});
+  const repair = () =>
+    runCommandEffect(executable, ['development-install-repair', '--expected-version', expectedVersion], commandOptions);
   const initial = yield* runDoctorStrict();
   const initialFailures = developmentDoctorFailureCount(initial.stdout);
   if (initialFailures === undefined || (initial.exitCode !== 0 && initialFailures === 0)) {
@@ -573,13 +575,23 @@ const verifyActivatedDevelopmentRelease = Effect.fn('developmentInstall.verifyAc
   }
   if (initial.exitCode === 0 && initialFailures === 0) return;
 
-  yield* runCommandEffect(
-    executable,
-    ['development-install-repair', '--expected-version', expectedVersion],
-    commandOptions,
-  );
+  yield* repair();
   const repaired = yield* runDoctorStrict();
-  if (repaired.exitCode !== 0 || developmentDoctorFailureCount(repaired.stdout) !== 0) {
+  const repairedFailures = developmentDoctorFailureCount(repaired.stdout);
+  if (repaired.exitCode === 0 && repairedFailures === 0) return;
+  if (
+    repaired.exitCode === 0 ||
+    repairedFailures === undefined ||
+    !developmentDoctorHasOnlyConcurrentRecallProjectionFailures(repaired.stdout, repairedFailures)
+  ) {
+    return yield* Effect.fail(
+      new ScriptError('The activated development executable still has doctor failures after repair.'),
+    );
+  }
+
+  yield* repair();
+  const stabilized = yield* runDoctorStrict();
+  if (stabilized.exitCode !== 0 || developmentDoctorFailureCount(stabilized.stdout) !== 0) {
     return yield* Effect.fail(
       new ScriptError('The activated development executable still has doctor failures after repair.'),
     );
@@ -591,6 +603,31 @@ function developmentDoctorFailureCount(stdout: string): number | undefined {
   if (match?.[1] === undefined) return undefined;
   const failures = Number(match[1]);
   return Number.isSafeInteger(failures) ? failures : undefined;
+}
+
+export function developmentDoctorHasOnlyConcurrentRecallProjectionFailures(
+  stdout: string,
+  failureCount: number,
+): boolean {
+  const failures = stdout
+    .split(/\r?\n/u)
+    .map(line => /^FAIL\s+([^:]+):\s*(.*)$/u.exec(line.trim()))
+    .filter((match): match is RegExpExecArray => match !== null)
+    .map(match => ({detail: match[2] ?? '', name: match[1] ?? ''}));
+  return (
+    failures.length === failureCount &&
+    failures.length > 0 &&
+    failures.every(({detail, name}) => {
+      if (name === 'lexical recall index') {
+        return detail === 'canonical documents changed; run `threadnote repair`';
+      }
+      if (name !== 'vector recall index') return false;
+      return (
+        detail === 'unavailable until the lexical recall index is ready' ||
+        /; stale; canonical documents changed; run `threadnote repair`$/u.test(detail)
+      );
+    })
+  );
 }
 
 function requireEvidenceVersion(evidence: DevelopmentRuntimeEvidence, expectedVersion: string) {

--- a/test/unit/development-runtime.test.ts
+++ b/test/unit/development-runtime.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../../scripts/development-runtime.js';
 import {
   activateLocalStandaloneRelease,
+  developmentDoctorHasOnlyConcurrentRecallProjectionFailures,
   developmentRuntimeOwnershipConflict,
   parseLocalStandaloneInstallArguments,
 } from '../../scripts/install-local-standalone.js';
@@ -38,9 +39,70 @@ const sourceCommitArbitrary = fc
       .array(fc.constantFrom(...'0123456789abcdef'), {maxLength: length, minLength: length})
       .map(characters => characters.join('')),
   );
+const doctorFieldArbitrary = fc
+  .array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz '), {maxLength: 40, minLength: 1})
+  .map(characters => characters.join('').trim())
+  .filter(value => value.length > 0);
+const lexicalInvalidationDetail = 'canonical documents changed; run `threadnote repair`';
+const vectorUnavailableDetail = 'unavailable until the lexical recall index is ready';
+const vectorStaleSuffix = '; stale; canonical documents changed; run `threadnote repair`';
+const doctorFailureArbitrary = fc.oneof(
+  fc.constant({allowed: true, detail: lexicalInvalidationDetail, name: 'lexical recall index'}),
+  fc.constant({allowed: true, detail: vectorUnavailableDetail, name: 'vector recall index'}),
+  doctorFieldArbitrary.map(model => ({
+    allowed: true,
+    detail: `${model}${vectorStaleSuffix}`,
+    name: 'vector recall index',
+  })),
+  doctorFieldArbitrary
+    .filter(detail => detail !== lexicalInvalidationDetail)
+    .map(detail => ({allowed: false, detail, name: 'lexical recall index'})),
+  doctorFieldArbitrary
+    .filter(detail => detail !== vectorUnavailableDetail && !detail.endsWith(vectorStaleSuffix))
+    .map(detail => ({allowed: false, detail, name: 'vector recall index'})),
+  fc
+    .tuple(
+      doctorFieldArbitrary.filter(name => name !== 'lexical recall index' && name !== 'vector recall index'),
+      doctorFieldArbitrary,
+    )
+    .map(([name, detail]) => ({allowed: false, detail, name})),
+);
 const TEST_TARGET = `bun-${process.platform === 'win32' ? 'windows' : process.platform}-${process.arch}`;
 
 describe('exact-head development runtime', () => {
+  it('matches the fail-closed recall invalidation allowlist for arbitrary doctor reports', () => {
+    fc.assert(
+      fc.property(
+        fc.array(doctorFailureArbitrary, {maxLength: 6, minLength: 1}),
+        fc.integer({max: 7, min: 0}),
+        fc.constantFrom('\n', '\r\n'),
+        (failures, declaredFailureCount, lineEnding) => {
+          const output = [
+            ...failures.map(({detail, name}) => `FAIL ${name}: ${detail}`),
+            `Summary: ${declaredFailureCount} failure(s), 0 warning(s)`,
+            '',
+          ].join(lineEnding);
+          const expected = declaredFailureCount === failures.length && failures.every(({allowed}) => allowed === true);
+          expect(developmentDoctorHasOnlyConcurrentRecallProjectionFailures(output, declaredFailureCount)).toBe(
+            expected,
+          );
+        },
+      ),
+      {numRuns: 200},
+    );
+  });
+
+  it.each(['\n', '\r\n'])('recognizes bounded recall invalidation with %j line endings', lineEnding => {
+    const output = [
+      'FAIL lexical recall index: canonical documents changed; run `threadnote repair`',
+      'FAIL vector recall index: unavailable until the lexical recall index is ready',
+      'Summary: 2 failure(s), 0 warning(s)',
+      '',
+    ].join(lineEnding);
+    expect(developmentDoctorHasOnlyConcurrentRecallProjectionFailures(output, 2)).toBe(true);
+    expect(developmentDoctorHasOnlyConcurrentRecallProjectionFailures(output, 1)).toBe(false);
+  });
+
   it('parses only the explicit developer installer switches', () => {
     expect(parseLocalStandaloneInstallArguments(['--', '--terminate-superseded', '--json'])).toEqual({
       json: true,
@@ -930,7 +992,7 @@ describe('exact-head development runtime', () => {
       }),
   );
 
-  effectIt.effect('repairs failed doctor state after activation and requires a clean recheck', () =>
+  effectIt.effect('stabilizes recall projections invalidated by a concurrent write during repair', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -969,11 +1031,17 @@ describe('exact-head development runtime', () => {
               if (arguments_[0] === 'doctor') {
                 const strict = arguments_.includes('--strict');
                 if (strict) strictDoctorChecks += 1;
-                const failures = strict && strictDoctorChecks > 1 ? 0 : 2;
+                const failures = strict && strictDoctorChecks > 2 ? 0 : 2;
                 return Effect.succeed({
                   exitCode: strict && failures > 0 ? 1 : 0,
                   stderr: '',
-                  stdout: `Running Threadnote doctor checks.\nSummary: ${failures} failure(s), 1 warning(s)\n`,
+                  stdout:
+                    'Running Threadnote doctor checks.\n' +
+                    (failures > 0
+                      ? 'FAIL lexical recall index: canonical documents changed; run `threadnote repair`\n' +
+                        'FAIL vector recall index: unavailable until the lexical recall index is ready\n'
+                      : '') +
+                    `Summary: ${failures} failure(s), 1 warning(s)\n`,
                 });
               }
               if (arguments_[0] === 'development-install-repair') {
@@ -1008,11 +1076,10 @@ describe('exact-head development runtime', () => {
 
       expect(result.installed.doctorVerified).toBe(true);
       expect(result.repairObservedInstallationLock).toBe(true);
-      expect(result.strictDoctorChecks).toBe(2);
-      expect(result.invocations).toContainEqual([
-        'development-install-repair',
-        '--expected-version',
-        result.installed.version,
+      expect(result.strictDoctorChecks).toBe(3);
+      expect(result.invocations.filter(invocation => invocation[0] === 'development-install-repair')).toEqual([
+        ['development-install-repair', '--expected-version', result.installed.version],
+        ['development-install-repair', '--expected-version', result.installed.version],
       ]);
       expect(result.invocations.at(-1)).toEqual(['doctor', '--dry-run', '--strict']);
     }),


### PR DESCRIPTION
## Summary
- recognize only the fail-closed lexical/vector projection state caused by a canonical write racing the development installer repair
- perform one bounded stabilization repair and require a final strict doctor result with zero failures
- preserve immediate failure for malformed or unrelated doctor failures

## Verification
- 45 focused installer and doctor tests passed
- production and test TypeScript checks passed
- strict lint, repository precommit, and formatting checks passed
- 200-run Fast-check allowlist property covers mixed failures, wrong details, count mismatches, and LF/CRLF output
- Dev Cycle completed in one iteration with 0 critical and 0 important findings; its one minor property-boundary finding was addressed in final polish

## Reproduction
A deterministic Effect test models the observed sequence: initial stale recall projections, successful repair, a concurrent canonical write that invalidates the repaired projections, a second bounded repair, then a clean strict doctor result.