### PR TITLE
fix(manager): name repository-root workspaces

### DIFF
--- a/src/code_graph/workspace_primitives.ts
+++ b/src/code_graph/workspace_primitives.ts
@@ -63,7 +63,7 @@ export function materializeBuildWorkspaces(
       buildSystem: project.buildSystem,
       diagnostics: unique([...(existing?.diagnostics ?? []), ...project.diagnostics]).sort(compareCodeUnits),
       id: project.workspaceId,
-      name: existing?.name ?? root.split('/').at(-1) ?? project.name,
+      name: existing?.name ?? (root === '' ? project.name : basename(root)),
       provenance: existing?.provenance === 'declared' || project.provenance === 'declared' ? 'declared' : 'inferred',
       root,
     });

--- a/test/unit/code-graph.workspace.property.test.ts
+++ b/test/unit/code-graph.workspace.property.test.ts
@@ -132,6 +132,40 @@ describe('code graph workspace properties', () => {
     {fastCheck: {numRuns: 150}},
   );
 
+  it('uses the declared project name for a repository-root workspace', () => {
+    const workspace = discoverManifestWorkspace([
+      workspaceFile(
+        'package.json',
+        JSON.stringify({name: 'threadnote-root', private: true, workspaces: ['packages/*']}),
+        'npm-manifest',
+      ),
+    ]);
+
+    expect(workspace.workspaces).toContainEqual(expect.objectContaining({name: 'threadnote-root', root: ''}));
+  });
+
+  it.prop(
+    'never derives an empty repository-root workspace name from a non-empty declared project name',
+    {name: shortText},
+    ({name}) => {
+      const workspace = discoverManifestWorkspace([
+        workspaceFile(
+          'package.json',
+          JSON.stringify({name, private: true, workspaces: ['packages/*']}),
+          'npm-manifest',
+        ),
+      ]);
+
+      const rootProject = workspace.projects.find(project => project.root === '');
+      const rootWorkspace = workspace.workspaces.find(candidate => candidate.root === '');
+      expect(rootProject).toBeDefined();
+      expect(rootWorkspace).toBeDefined();
+      expect(rootProject!.name).not.toBe('');
+      expect(rootWorkspace!.name).toBe(rootProject!.name);
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
   it('discovers npm, Bun, pnpm, and TypeScript-reference package hierarchy without hiding nested polyglot workspaces', () => {
     const workspace = discoverManifestWorkspace([
       workspaceFile(


### PR DESCRIPTION
## Summary

- use the declared root project name when a build workspace lives at the repository root
- preserve existing basename labels for nested workspaces
- cover the regression with a focused example and a bounded property

## Verification

- 79 focused workspace, Manager catalog, and Manager graph tests
- source and test TypeScript checks
- strict lint and Prettier
- dev-cycle: zero critical or important findings

## Dogfood

The guarded global development installer correctly refused because another active checkout owns the runtime. No takeover was attempted.