### PR TITLE
fix(telemetry): surface consent renewal after 4.4 upgrades

### DIFF
--- a/config/post-update-migrations.json
+++ b/config/post-update-migrations.json
@@ -75,6 +75,22 @@
         "Recovery migration finished. Run `threadnote repair`, then verify memory/resource/share counts in `threadnote manager`.",
         "An already-installed verified 3.x generation model is adopted and selected without downloading it again."
       ]
+    },
+    {
+      "id": "telemetry-consent-v5-renewal",
+      "introducedIn": "4.4.0",
+      "title": "Review the current anonymous telemetry contract",
+      "description": [
+        "Threadnote 4.4 added bounded Context Brief citation-quality diagnostics, so an earlier telemetry opt-in no longer covers the current data contract.",
+        "Telemetry remains off and the previous configuration is left untouched until you review the complete current preview and explicitly apply consent again.",
+        "The preview preserves your previously selected endpoint by default; it never sends telemetry or writes configuration."
+      ],
+      "commandArgs": ["telemetry", "enable"],
+      "instructions": [
+        "Current anonymous telemetry consent is enabled. Restart connected MCP clients that started before this consent change."
+      ],
+      "requiresExplicitTelemetryConsent": true,
+      "requiresTelemetryConsentRenewal": true
     }
   ]
 }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -28,6 +28,13 @@ producer: telemetry remains off until the user reviews the current preview and e
 Threadnote never migrates an earlier opt-in silently, even though the gateway continues to admit the frozen v1, v2,
 v3, and v4 wire contracts for older supported producers.
 
+When an upgrade finds an exact enabled v4 consent, its post-update action prints the complete current preview before
+asking interactively whether to apply v5 consent. `--yes` never answers this privacy prompt, and non-interactive or
+automatic updates leave telemetry off and print the manual `threadnote telemetry enable --apply` action. The preview
+reuses the previously selected endpoint unless `--endpoint` is supplied. A non-interactive post-update action also
+sends a best-effort local desktop reminder. `threadnote telemetry status` and `threadnote doctor` distinguish this
+renewal state from malformed configuration and show the same explicit remedy.
+
 Applied disable is observed by active exporters at their next event or transport gate. Queued requests that have not
 started are dropped. A network request that already started cannot be recalled, but no later request is sent. Enabling
 telemetry, changing its endpoint, or re-enabling it after consent was removed requires restarting already-connected

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -21,7 +21,12 @@ import {
 import {mcpConfigurationChecks, removeMcpConfigs, removeMcpSnippets, resolveMcpClients, runMcpInstall} from './mcp.js';
 import {legacyProcessDoctorCheck} from './process_diagnostics.js';
 import {maybeRunPostUpdateAfterRepair} from './update.js';
-import {readTelemetryConfiguration, telemetryEnvironmentOptOut} from './telemetry/config.js';
+import {
+  TELEMETRY_CONSENT_VERSION,
+  readTelemetryConfiguration,
+  readTelemetryConsentRenewal,
+  telemetryEnvironmentOptOut,
+} from './telemetry/config.js';
 import {
   currentRecallCorpusGeneration,
   loadRecallIndexData,
@@ -214,6 +219,14 @@ export const telemetryDoctorCheck = Effect.fn('lifecycle.telemetryDoctorCheck')(
   const system = yield* SystemInfo;
   const loaded = yield* Effect.result(readTelemetryConfiguration(config));
   if (Result.isFailure(loaded)) {
+    const renewal = yield* readTelemetryConsentRenewal(config).pipe(Effect.catch(() => Effect.succeed(undefined)));
+    if (renewal !== undefined) {
+      return {
+        detail: `disabled; consent v${renewal.consentVersion} needs explicit renewal for v${TELEMETRY_CONSENT_VERSION}; run \`threadnote telemetry enable\`, then \`threadnote telemetry enable --apply\` after review`,
+        name: 'anonymous telemetry',
+        status: 'warn' as const,
+      };
+    }
     return {
       detail: 'invalid or unreadable configuration; telemetry fails closed',
       name: 'anonymous telemetry',

--- a/src/telemetry/commands.ts
+++ b/src/telemetry/commands.ts
@@ -3,10 +3,12 @@ import type {RuntimeConfig} from '../types.js';
 import {errorMessage} from '../utils.js';
 import {
   DEFAULT_TELEMETRY_ENDPOINT,
+  TELEMETRY_CONSENT_VERSION,
   TelemetryConfigurationError,
   createEnabledTelemetryConfiguration,
   disabledTelemetryConfiguration,
   normalizeTelemetryEndpoint,
+  readTelemetryConsentRenewal,
   readTelemetryConfiguration,
   telemetryEnvironmentOptOut,
   writeTelemetryConfiguration,
@@ -39,6 +41,19 @@ export const runTelemetryStatus = Effect.fn('telemetry.command.status')(function
   const optOut = telemetryEnvironmentOptOut(system.environment());
   const loaded = yield* Effect.result(readTelemetryConfiguration(config));
   if (Result.isFailure(loaded)) {
+    const renewal = yield* readTelemetryConsentRenewal(config).pipe(Effect.catch(() => Effect.succeed(undefined)));
+    if (renewal !== undefined) {
+      yield* Console.log(
+        `Anonymous telemetry: disabled (consent version ${renewal.consentVersion} does not cover the current version ${TELEMETRY_CONSENT_VERSION} data contract).`,
+      );
+      yield* Console.log('Review the current contract with: threadnote telemetry enable');
+      yield* Console.log('After reviewing it, renew explicitly with: threadnote telemetry enable --apply');
+      yield* Console.log(`Endpoint: ${renewal.endpoint}`);
+      yield* Console.log(telemetryDestinationSummary(renewal.endpoint));
+      yield* Console.log(`Data contract: ${TELEMETRY_DATA_SUMMARY}`);
+      yield* Console.log(`Privacy contract: ${TELEMETRY_EXCLUSION_SUMMARY}`);
+      return;
+    }
     yield* Console.log('Anonymous telemetry: disabled (configuration is invalid and fails closed).');
     yield* Console.log(`Configuration error: ${errorMessage(loaded.failure)}`);
     yield* Console.log(`Data contract: ${TELEMETRY_DATA_SUMMARY}`);
@@ -67,14 +82,20 @@ export const runTelemetryEnable = Effect.fn('telemetry.command.enable')(function
   config: RuntimeConfig,
   options: TelemetryEnableOptions,
 ) {
+  const renewal = yield* readTelemetryConsentRenewal(config).pipe(Effect.catch(() => Effect.succeed(undefined)));
   const endpoint = yield* Effect.try({
-    try: () => normalizeTelemetryEndpoint(options.endpoint ?? DEFAULT_TELEMETRY_ENDPOINT),
+    try: () => normalizeTelemetryEndpoint(options.endpoint ?? renewal?.endpoint ?? DEFAULT_TELEMETRY_ENDPOINT),
     catch: cause =>
       cause instanceof TelemetryConfigurationError
         ? cause
         : new TelemetryConfigurationError('Telemetry endpoint validation failed.', {cause}),
   });
   yield* Console.log('Enable anonymous operational telemetry for Threadnote CLI and MCP diagnostics.');
+  if (renewal !== undefined) {
+    yield* Console.log(
+      `Existing consent version ${renewal.consentVersion} remains fail-closed until you explicitly accept the current version ${TELEMETRY_CONSENT_VERSION} contract.`,
+    );
+  }
   yield* Console.log(`Endpoint: ${endpoint}`);
   yield* Console.log(telemetryDestinationSummary(endpoint));
   yield* Console.log(`Data sent: ${TELEMETRY_DATA_SUMMARY}`);

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -6,6 +6,7 @@ import {isJsonObject} from '../utils.js';
 
 export const TELEMETRY_CONFIGURATION_VERSION = 1 as const;
 export const TELEMETRY_CONSENT_VERSION = 5 as const;
+export const TELEMETRY_RENEWABLE_CONSENT_VERSION = 4 as const;
 export const DEFAULT_TELEMETRY_ENDPOINT = 'https://telemetry.threadnote.io/v1/traces';
 
 export interface DisabledTelemetryConfiguration {
@@ -24,6 +25,16 @@ export interface EnabledTelemetryConfiguration {
 }
 
 export type TelemetryConfiguration = DisabledTelemetryConfiguration | EnabledTelemetryConfiguration;
+
+/**
+ * A previously enabled consent that is structurally valid but does not cover
+ * the current data contract. This is diagnostic state only: it never enables
+ * an exporter until the user applies the current consent explicitly.
+ */
+export interface TelemetryConsentRenewal {
+  readonly consentVersion: typeof TELEMETRY_RENEWABLE_CONSENT_VERSION;
+  readonly endpoint: string;
+}
 
 export type TelemetryEnvironmentOptOut = 'DNT' | 'DO_NOT_TRACK' | 'THREADNOTE_TELEMETRY';
 
@@ -54,28 +65,27 @@ export const telemetryConfigurationPath = Effect.fn('telemetry.configurationPath
 export const readTelemetryConfiguration = Effect.fn('telemetry.readConfiguration')(function* (
   config: Pick<RuntimeConfig, 'agentContextHome'>,
 ) {
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const file = yield* telemetryConfigurationPath(config);
-  if (!(yield* fs.exists(file))) return undefined;
-  yield* assertRegularTelemetryDirectory(fs, path.dirname(file));
-  if (Option.isSome(yield* fs.readLink(file).pipe(Effect.option))) {
-    return yield* Effect.fail(new TelemetryConfigurationError('Telemetry configuration must not be a symbolic link.'));
-  }
-  const info = yield* fs.stat(file);
-  if (info.type !== 'File' || Number(info.size) > TELEMETRY_CONFIGURATION_MAX_BYTES) {
-    return yield* Effect.fail(
-      new TelemetryConfigurationError('Telemetry configuration must be a bounded regular file.'),
-    );
-  }
-  const raw = yield* fs.readFileString(file);
+  const document = yield* readTelemetryConfigurationDocument(config);
+  if (document === undefined) return undefined;
   return yield* Effect.try({
-    try: () => parseTelemetryConfiguration(raw, file),
+    try: () => parseTelemetryConfiguration(document.raw, document.file),
     catch: cause =>
       cause instanceof TelemetryConfigurationError
         ? cause
         : new TelemetryConfigurationError('Telemetry configuration could not be parsed.', {cause}),
   });
+});
+
+/**
+ * Recognizes only the exact enabled v4 shape so update/status UX can explain
+ * why telemetry stopped. Malformed, disabled, older, newer, and current
+ * configurations are not renewal candidates and continue to fail closed.
+ */
+export const readTelemetryConsentRenewal = Effect.fn('telemetry.readConsentRenewal')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+) {
+  const document = yield* readTelemetryConfigurationDocument(config);
+  return document === undefined ? undefined : parseTelemetryConsentRenewal(document.raw, document.file);
 });
 
 /** Invalid, unreadable, absent, disabled, or environment-suppressed consent always resolves to off. */
@@ -161,6 +171,38 @@ export function parseTelemetryConfiguration(
   } catch (cause) {
     if (cause instanceof TelemetryConfigurationError) throw cause;
     throw new TelemetryConfigurationError(`Telemetry configuration is not valid JSON: ${source}`, {cause});
+  }
+}
+
+export function parseTelemetryConsentRenewal(
+  raw: string,
+  source = TELEMETRY_CONFIGURATION_FILE_NAME,
+): TelemetryConsentRenewal | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
+  if (
+    !isJsonObject(value) ||
+    value.version !== TELEMETRY_CONFIGURATION_VERSION ||
+    value.consentVersion !== TELEMETRY_RENEWABLE_CONSENT_VERSION ||
+    value.enabled !== true ||
+    typeof value.endpoint !== 'string' ||
+    typeof value.sessionSalt !== 'string'
+  ) {
+    return undefined;
+  }
+  try {
+    assertExactKeys(value, ['consentVersion', 'enabled', 'endpoint', 'sessionSalt', 'version'], source);
+    normalizeTelemetrySessionSalt(value.sessionSalt);
+    return {
+      consentVersion: TELEMETRY_RENEWABLE_CONSENT_VERSION,
+      endpoint: normalizeTelemetryEndpoint(value.endpoint),
+    };
+  } catch {
+    return undefined;
   }
 }
 
@@ -278,6 +320,26 @@ function prepareTelemetryDirectory(fs: FileSystem.FileSystem, directory: string)
     yield* fs.chmod(directory, TELEMETRY_DIRECTORY_MODE);
   });
 }
+
+const readTelemetryConfigurationDocument = Effect.fn('telemetry.readConfigurationDocument')(function* (
+  config: Pick<RuntimeConfig, 'agentContextHome'>,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const file = yield* telemetryConfigurationPath(config);
+  if (!(yield* fs.exists(file))) return undefined;
+  yield* assertRegularTelemetryDirectory(fs, path.dirname(file));
+  if (Option.isSome(yield* fs.readLink(file).pipe(Effect.option))) {
+    return yield* Effect.fail(new TelemetryConfigurationError('Telemetry configuration must not be a symbolic link.'));
+  }
+  const info = yield* fs.stat(file);
+  if (info.type !== 'File' || Number(info.size) > TELEMETRY_CONFIGURATION_MAX_BYTES) {
+    return yield* Effect.fail(
+      new TelemetryConfigurationError('Telemetry configuration must be a bounded regular file.'),
+    );
+  }
+  return {file, raw: yield* fs.readFileString(file)};
+});
 
 function assertRegularTelemetryDirectory(fs: FileSystem.FileSystem, directory: string) {
   return Effect.gen(function* () {

--- a/src/update.ts
+++ b/src/update.ts
@@ -31,6 +31,8 @@ import {
 import {hasLegacyLifecycleHandoffCandidates, hasProjectNameMigrationCandidates} from './memory.js';
 import {isLegacyHomeMigrationPending, isThreadnoteHomeMigrationPending} from './migration/home.js';
 import {whatsNewLinesForVersionRange} from './release_notes.js';
+import {sendSystemNotification} from './system_notification.js';
+import {readTelemetryConsentRenewal} from './telemetry/config.js';
 import type {JsonObject, PostUpdateOptions, RuntimeConfig, UpdateOptions} from './types.js';
 import {selectUpdateChannel, type UpdateChannel} from './update_channel.js';
 import {isDevelopmentBuildVersion} from './version_compare.js';
@@ -104,10 +106,12 @@ interface PostUpdateMigration {
   readonly instructions: readonly string[];
   readonly introducedIn: string;
   readonly markHandledWhenSkipped?: boolean;
+  readonly requiresExplicitTelemetryConsent?: boolean;
   readonly requiresLegacyHandoffs?: boolean;
   readonly requiresLegacyHomeMigration?: boolean;
   readonly requiresPendingHomeMigration?: boolean;
   readonly requiresProjectNameConsolidation?: boolean;
+  readonly requiresTelemetryConsentRenewal?: boolean;
   readonly title: string;
 }
 
@@ -988,6 +992,42 @@ const runApplicablePostUpdateMigrationsUnlocked = Effect.fn('update.runApplicabl
       yield* Console.log('Post-update actions are available.');
     }
     yield* printPostUpdateMigration(migration);
+    if (migration.requiresExplicitTelemetryConsent === true) {
+      yield* runStreamingSubcommand(options.dryRun, threadnoteCommand, migration.commandArgs);
+      if (options.dryRun) {
+        yield* Console.log('After reviewing the preview, explicit consent would still require:');
+        yield* Console.log(`  ${formatMigrationCommand(threadnoteCommand, [...migration.commandArgs, '--apply'])}`);
+        continue;
+      }
+      const accepted =
+        options.interactive &&
+        (yield* promptForConfirmation('Apply the current anonymous telemetry consent now? [y/N] '));
+      if (!accepted) {
+        yield* Console.log('Telemetry remains disabled. After reviewing the preview, renew explicitly with:');
+        yield* Console.log(`  ${formatMigrationCommand(threadnoteCommand, [...migration.commandArgs, '--apply'])}`);
+        if (!options.interactive) {
+          yield* sendSystemNotification({
+            body: 'Anonymous telemetry remains off after its data contract changed. Run threadnote telemetry enable, review the preview, then apply consent explicitly.',
+            title: 'Threadnote telemetry consent review',
+          });
+        }
+        continue;
+      }
+      yield* runStreamingSubcommand(false, threadnoteCommand, [...migration.commandArgs, '--apply']);
+      if (yield* migrationRequirementsSatisfied(config, migration)) {
+        return yield* Effect.fail(
+          applicationError(
+            'verify post-update telemetry consent',
+            new UpdateOperationError(
+              `Migration ${migration.id} exited successfully but telemetry consent still requires renewal; it was not marked handled.`,
+            ),
+          ),
+        );
+      }
+      yield* checkpoint(migration.id);
+      for (const instruction of migration.instructions) yield* Console.log(instruction);
+      continue;
+    }
     const accepted =
       options.dryRun ||
       options.yes ||
@@ -1037,13 +1077,10 @@ const applicablePostUpdateMigrations = Effect.fn('update.applicableMigrations')(
   const handled = new Set(options.handledMigrationIds);
   const applicable: PostUpdateMigration[] = [];
   for (const migration of migrations) {
-    if (handled.has(migration.id) && !hasAuthoritativeHomeRequirements(migration)) {
+    if (handled.has(migration.id) && !hasAuthoritativeRequirements(migration)) {
       continue;
     }
-    if (
-      compareVersions(options.fromVersion, migration.introducedIn) >= 0 &&
-      !hasAuthoritativeHomeRequirements(migration)
-    ) {
+    if (compareVersions(options.fromVersion, migration.introducedIn) >= 0 && !hasAuthoritativeRequirements(migration)) {
       continue;
     }
     if (!postUpdateMigrationReached(migration, options.fromVersion, options.toVersion)) {
@@ -1079,8 +1116,18 @@ const migrationRequirementsSatisfied = Effect.fn('update.migrationRequirementsSa
   if (migration.requiresProjectNameConsolidation === true && !(yield* hasProjectNameMigrationCandidates(config))) {
     return false;
   }
+  if (
+    migration.requiresTelemetryConsentRenewal === true &&
+    (yield* readTelemetryConsentRenewal(config).pipe(Effect.catch(() => Effect.succeed(undefined)))) === undefined
+  ) {
+    return false;
+  }
   return true;
 });
+
+function hasAuthoritativeRequirements(migration: PostUpdateMigration): boolean {
+  return hasAuthoritativeHomeRequirements(migration) || migration.requiresTelemetryConsentRenewal === true;
+}
 
 function hasAuthoritativeHomeRequirements(migration: PostUpdateMigration): boolean {
   return migration.requiresLegacyHomeMigration === true || migration.requiresPendingHomeMigration === true;
@@ -1114,18 +1161,30 @@ function parsePostUpdateMigration(value: unknown): PostUpdateMigration {
   ) {
     throw new UpdateOperationError(`Invalid entry in ${POST_UPDATE_MIGRATIONS_FILE}.`);
   }
+  const commandArgs = stringArray(value, 'commandArgs');
+  const requiresExplicitTelemetryConsent = value.requiresExplicitTelemetryConsent === true;
+  const requiresTelemetryConsentRenewal = value.requiresTelemetryConsentRenewal === true;
+  if (
+    requiresExplicitTelemetryConsent !== requiresTelemetryConsentRenewal ||
+    (requiresExplicitTelemetryConsent &&
+      (commandArgs.length !== 2 || commandArgs[0] !== 'telemetry' || commandArgs[1] !== 'enable'))
+  ) {
+    throw new UpdateOperationError(`Invalid explicit telemetry consent entry in ${POST_UPDATE_MIGRATIONS_FILE}.`);
+  }
   return {
     appliesToPrereleases: value.appliesToPrereleases === true,
-    commandArgs: stringArray(value, 'commandArgs'),
+    commandArgs,
     description: stringArray(value, 'description'),
     id: value.id,
     instructions: stringArray(value, 'instructions'),
     introducedIn: value.introducedIn,
     markHandledWhenSkipped: value.markHandledWhenSkipped === true,
+    requiresExplicitTelemetryConsent,
     requiresLegacyHandoffs: value.requiresLegacyHandoffs === true,
     requiresLegacyHomeMigration: value.requiresLegacyHomeMigration === true,
     requiresPendingHomeMigration: value.requiresPendingHomeMigration === true,
     requiresProjectNameConsolidation: value.requiresProjectNameConsolidation === true,
+    requiresTelemetryConsentRenewal,
     title: value.title,
   };
 }

--- a/test/unit/lifecycle.doctor.test.ts
+++ b/test/unit/lifecycle.doctor.test.ts
@@ -3,12 +3,13 @@ import {mkdir, mkdtemp, rm, writeFile} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {dirname, join} from '../helpers/node-path.js';
 import {it as effectIt} from '@effect/vitest';
-import {Effect, FileSystem, Path} from 'effect';
+import {Effect, Encoding, FileSystem, Path} from 'effect';
 import {afterEach, describe, expect, it} from 'vitest';
 import {captureConsole} from '../../src/effect/console.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import {memoryProjectConsistencyCheck, runDoctor, telemetryDoctorCheck} from '../../src/lifecycle.js';
+import {DEFAULT_TELEMETRY_ENDPOINT} from '../../src/telemetry/config.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
@@ -130,6 +131,23 @@ describe('doctor report resilience', () => {
         yield* fs.writeFileString(path.join(home, 'telemetry', 'config.json'), '{invalid-json}\n');
         expect(yield* telemetryDoctorCheck(config)).toEqual({
           detail: 'invalid or unreadable configuration; telemetry fails closed',
+          name: 'anonymous telemetry',
+          status: 'warn',
+        });
+
+        yield* fs.writeFileString(
+          path.join(home, 'telemetry', 'config.json'),
+          `${JSON.stringify({
+            consentVersion: 4,
+            enabled: true,
+            endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+            sessionSalt: Encoding.encodeBase64Url(new Uint8Array(32).fill(9)),
+            version: 1,
+          })}\n`,
+        );
+        expect(yield* telemetryDoctorCheck(config)).toEqual({
+          detail:
+            'disabled; consent v4 needs explicit renewal for v5; run `threadnote telemetry enable`, then `threadnote telemetry enable --apply` after review',
           name: 'anonymous telemetry',
           status: 'warn',
         });

--- a/test/unit/telemetry-commands.test.ts
+++ b/test/unit/telemetry-commands.test.ts
@@ -110,14 +110,29 @@ describe('telemetry commands', () => {
         yield* runTelemetryEnable(config, {apply: true});
         const file = yield* telemetryConfigurationPath(config);
         const previous = JSON.parse(yield* fs.readFileString(file)) as Record<string, unknown>;
-        yield* fs.writeFileString(file, `${JSON.stringify({...previous, consentVersion: 4}, undefined, 2)}\n`);
+        const previousEndpoint = 'https://collector.example/v1/traces';
+        yield* fs.writeFileString(
+          file,
+          `${JSON.stringify({...previous, consentVersion: 4, endpoint: previousEndpoint}, undefined, 2)}\n`,
+        );
+
+        const status = yield* captureConsole(runTelemetryStatus(config));
+        expect(status.output).toContain('does not cover the current version 5 data contract');
+        expect(status.output).toContain('threadnote telemetry enable --apply');
+        expect(status.output).toContain(`Endpoint: ${previousEndpoint}`);
 
         const preview = yield* captureConsole(runTelemetryEnable(config, {}));
+        expect(preview.output).toContain('Existing consent version 4 remains fail-closed');
+        expect(preview.output).toContain(`Endpoint: ${previousEndpoint}`);
         expect(preview.output).toContain('No changes made. Re-run with --apply');
         expect(JSON.parse(yield* fs.readFileString(file))).toMatchObject({consentVersion: 4, enabled: true});
 
         yield* runTelemetryEnable(config, {apply: true});
-        expect(yield* readTelemetryConfiguration(config)).toMatchObject({consentVersion: 5, enabled: true});
+        expect(yield* readTelemetryConfiguration(config)).toMatchObject({
+          consentVersion: 5,
+          enabled: true,
+          endpoint: previousEndpoint,
+        });
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );

--- a/test/unit/telemetry-config.test.ts
+++ b/test/unit/telemetry-config.test.ts
@@ -11,7 +11,9 @@ import {
   disabledTelemetryConfiguration,
   enabledTelemetryConfiguration,
   normalizeTelemetryEndpoint,
+  parseTelemetryConsentRenewal,
   parseTelemetryConfiguration,
+  readTelemetryConsentRenewal,
   readTelemetryConfiguration,
   renderTelemetryConfiguration,
   resolveTelemetryConfiguration,
@@ -78,6 +80,37 @@ describe('telemetry configuration', () => {
     {fastCheck: {numRuns: 50}},
   );
 
+  effectIt.effect.prop(
+    'recognizes only the exact renewable enabled-consent generation',
+    {
+      consentVersion: FC.integer({max: 8, min: 1}),
+      enabled: FC.boolean(),
+      extraField: FC.boolean(),
+      validEndpoint: FC.boolean(),
+      validSalt: FC.boolean(),
+      version: FC.integer({max: 2, min: 0}),
+    },
+    ({consentVersion, enabled, extraField, validEndpoint, validSalt, version}) =>
+      Effect.sync(() => {
+        const renewal = parseTelemetryConsentRenewal(
+          JSON.stringify({
+            consentVersion,
+            enabled,
+            endpoint: validEndpoint ? DEFAULT_TELEMETRY_ENDPOINT : 'http://collector.example/v1/traces',
+            sessionSalt: validSalt ? FIXED_SESSION_SALT : 'not-a-canonical-session-salt',
+            ...(extraField ? {unexpected: true} : {}),
+            version,
+          }),
+        );
+        expect(renewal).toEqual(
+          consentVersion === 4 && enabled && !extraField && validEndpoint && validSalt && version === 1
+            ? {consentVersion: 4, endpoint: DEFAULT_TELEMETRY_ENDPOINT}
+            : undefined,
+        );
+      }),
+    {fastCheck: {numRuns: 50}},
+  );
+
   effectIt.effect('persists private config atomically and removes the local salt on disable', () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -127,6 +160,7 @@ describe('telemetry configuration', () => {
         yield* fs.symlink(outside, file);
         expect(yield* resolveTelemetryConfiguration(config)).toBeUndefined();
         expect(yield* Effect.exit(readTelemetryConfiguration(config))).toMatchObject({_tag: 'Failure'});
+        expect(yield* Effect.exit(readTelemetryConsentRenewal(config))).toMatchObject({_tag: 'Failure'});
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
@@ -154,6 +188,10 @@ describe('telemetry configuration', () => {
 
         expect(yield* resolveTelemetryConfiguration(config)).toBeUndefined();
         expect(yield* Effect.exit(readTelemetryConfiguration(config))).toMatchObject({_tag: 'Failure'});
+        expect(yield* readTelemetryConsentRenewal(config)).toEqual({
+          consentVersion: 4,
+          endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+        });
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -5,7 +5,7 @@ import {mkdtemp, rm} from '../helpers/node-fs-promises.js';
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import fc from 'fast-check';
-import {Crypto, Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
+import {Crypto, Deferred, Effect, Encoding, Fiber, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {captureConsole} from '../../src/effect/console.js';
@@ -16,6 +16,13 @@ import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import {activateStandaloneRelease, withStandaloneInstallationLock} from '../../src/installations.js';
 import {migrateThreadnoteStorageLayout} from '../../src/migration/layout.js';
+import {
+  DEFAULT_TELEMETRY_ENDPOINT,
+  enabledTelemetryConfiguration,
+  readTelemetryConfiguration,
+  renderTelemetryConfiguration,
+  telemetryConfigurationPath,
+} from '../../src/telemetry/config.js';
 import type {RuntimeConfig, UpdateOptions} from '../../src/types.js';
 
 vi.mock('../../src/utils.js', async importOriginal => {
@@ -1380,6 +1387,134 @@ describe('post-update validation', () => {
     }),
   );
 
+  effectIt.effect('previews renewed telemetry consent and never lets non-interactive --yes apply it', () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseSystem = yield* SystemInfo;
+          const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-post-update-telemetry-'});
+          const fixtureRoot = path.join(temporaryRoot, 'tool');
+          const home = path.join(temporaryRoot, '.threadnote');
+          const config = runtimeConfig(home);
+          yield* writePostUpdateFixture(fs, path, fixtureRoot, [
+            {
+              ...fixtureMigration('telemetry-consent-renewal', {
+                requiresExplicitTelemetryConsent: true,
+                requiresTelemetryConsentRenewal: true,
+              }),
+              commandArgs: ['telemetry', 'enable'],
+            },
+          ]);
+          yield* Effect.sync(() => {
+            vi.mocked(utils.toolRoot).mockImplementation(() => Effect.succeed(fixtureRoot));
+          });
+          const telemetryFile = yield* telemetryConfigurationPath(config);
+          yield* fs.makeDirectory(path.dirname(telemetryFile), {recursive: true});
+          yield* fs.writeFileString(
+            telemetryFile,
+            `${JSON.stringify({
+              consentVersion: 4,
+              enabled: true,
+              endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+              sessionSalt: Encoding.encodeBase64Url(new Uint8Array(32).fill(5)),
+              version: 1,
+            })}\n`,
+          );
+
+          const attempts: string[][] = [];
+          let notificationAttempts = 0;
+          const commandExecutor = CommandExecutor.of({
+            execute: () =>
+              Effect.sync(() => {
+                notificationAttempts += 1;
+                return {exitCode: 127, stderr: '', stdout: ''};
+              }),
+            executeStreaming: (_executable, args) =>
+              Effect.gen(function* () {
+                attempts.push([...args]);
+                if (args.includes('--apply')) {
+                  yield* fs
+                    .writeFileString(
+                      telemetryFile,
+                      renderTelemetryConfiguration(
+                        enabledTelemetryConfiguration(
+                          DEFAULT_TELEMETRY_ENDPOINT,
+                          Encoding.encodeBase64Url(new Uint8Array(32).fill(6)),
+                        ),
+                      ),
+                    )
+                    .pipe(Effect.orDie);
+                }
+                return {exitCode: 0, stderr: '', stdout: ''};
+              }),
+          });
+          const nonInteractiveSystem = SystemInfo.of({
+            ...baseSystem,
+            homeDirectory: temporaryRoot,
+            stdinIsTTY: false,
+            stdoutIsTTY: false,
+          });
+          const nonInteractive = yield* captureConsole(
+            runPostUpdate(config, {fromVersion: '4.4.3', toVersion: '4.4.4', yes: true}).pipe(
+              Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(SystemInfo, nonInteractiveSystem),
+            ),
+          );
+          const afterNonInteractive = yield* fs.readFileString(telemetryFile);
+          const notificationAttemptsAfterNonInteractive = notificationAttempts;
+
+          const interactiveSystem = SystemInfo.of({
+            ...nonInteractiveSystem,
+            stdinIsTTY: true,
+            stdoutIsTTY: true,
+            readLine: (_prompt, onLine) => {
+              onLine('yes');
+              return () => undefined;
+            },
+          });
+          const interactive = yield* captureConsole(
+            runPostUpdate(config, {fromVersion: '4.4.3', toVersion: '4.4.4', yes: true}).pipe(
+              Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(SystemInfo, interactiveSystem),
+            ),
+          );
+          const second = yield* captureConsole(
+            runPostUpdate(config, {fromVersion: '4.4.3', toVersion: '4.4.4', yes: true}).pipe(
+              Effect.provideService(CommandExecutor, commandExecutor),
+              Effect.provideService(SystemInfo, interactiveSystem),
+            ),
+          );
+          return {
+            afterNonInteractive: JSON.parse(afterNonInteractive),
+            attempts,
+            current: yield* readTelemetryConfiguration(config),
+            interactive: interactive.output,
+            nonInteractive: nonInteractive.output,
+            notificationAttempts,
+            notificationAttemptsAfterNonInteractive,
+            second: second.output,
+          };
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer));
+
+      expect(result.afterNonInteractive).toMatchObject({consentVersion: 4, enabled: true});
+      expect(result.nonInteractive).toContain('Telemetry remains disabled');
+      expect(result.nonInteractive).toContain('telemetry enable --apply');
+      expect(result.attempts).toEqual([
+        ['telemetry', 'enable'],
+        ['telemetry', 'enable'],
+        ['telemetry', 'enable', '--apply'],
+      ]);
+      expect(result.current).toMatchObject({consentVersion: 5, enabled: true});
+      expect(result.interactive).toContain('Finished telemetry-consent-renewal');
+      expect(result.notificationAttemptsAfterNonInteractive).toBe(1);
+      expect(result.notificationAttempts).toBe(1);
+      expect(result.second).toBe('');
+    }),
+  );
+
   effectIt.effect('does not announce an action when migration evidence disappears at the locked recheck', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(
@@ -1901,8 +2036,10 @@ function writeUpdateCacheFixture(
 function fixtureMigration(
   id: string,
   requirements: {
+    readonly requiresExplicitTelemetryConsent?: boolean;
     readonly requiresLegacyHomeMigration?: boolean;
     readonly requiresPendingHomeMigration?: boolean;
+    readonly requiresTelemetryConsentRenewal?: boolean;
   } = {},
 ) {
   return {


### PR DESCRIPTION
## Problem

Threadnote 4.4 correctly fails closed when a previous v4 consent no longer covers the v5 data contract, but the upgrade path leaves a previously enabled user with generic invalid-configuration UX and no informed renewal flow. A read-only Tempo check confirmed that fresh 4.4.3 telemetry arrives once current consent is explicitly re-applied, so this is a local consent-renewal UX defect rather than a gateway or transport failure.

## Fix

- recognize only the exact enabled v4 consent shape as renewal-required while keeping all exporters fail-closed
- make telemetry status and doctor explain the renewal and explicit commands
- preserve a previously selected custom endpoint in the preview and renewed consent
- add an evidence-gated post-update action that prints the complete preview before prompting
- never let non-interactive --yes stand in for privacy consent; leave telemetry off and issue a best-effort desktop reminder
- leave malformed, disabled, older, newer, and current configurations unchanged

No telemetry schema, payload, gateway, dashboard, or infrastructure contract changes.

## Verification

- focused Effect tests: 65 passed
- bounded Fast-check exactness property covers consent generation, enabled state, exact keys, configuration version, endpoint, and salt validity
- source, test, and website typechecks passed
- strict lint, formatting, file-length, and diff checks passed
- isolated exact-source CLI smoke verified renewal diagnosis, endpoint preservation, explicit apply, and enabled status
- dev-cycle full review: 0 critical, 0 important; both minor test-coverage notes polished

The global development install was attempted and correctly refused because another active worktree owns the runtime; the guard was not bypassed. Full-suite validation is delegated to PR CI.