### PR TITLE
fix(memory): return citation recovery guidance

### DIFF
--- a/docs/memory-code-citations.md
+++ b/docs/memory-code-citations.md
@@ -57,8 +57,15 @@ Capture never starts or refreshes indexing. Check the graph first and prepare it
 
 ```sh
 threadnote graph status
-threadnote graph query --freshness current --query RetryPolicy
+threadnote graph index --no-vectors
 ```
+
+When an MCP citation write reaches a missing, stale, or deferred graph admission state, it fails before changing memory
+and returns a `memory-code-citation-write-recovery` receipt in `structuredContent`. The receipt keeps paths and graph
+identities out of the response and reports `writeApplied: false` and `indexingStarted: false`. Caller-local references
+use the command above from `callerCwd`; a `cgr_` reference routed through a named Workset returns an explicit
+`threadnote workset prepare` action and the Workset name as a separate argument. Retry the same write only after the
+selected preparation reports current ready evidence.
 
 A newly written memory accepts at most eight citations. Each canonical citation line is limited to 8 KiB and total
 citation metadata to 64 KiB.

--- a/src/code_graph/workset_query_v2.ts
+++ b/src/code_graph/workset_query_v2.ts
@@ -165,6 +165,7 @@ export interface ResolvedCodeGraphQualifiedRefTargetV1 {
   readonly nodeId: string;
   readonly ref: string;
   readonly repositoryId: string;
+  readonly route: {readonly kind: 'caller'} | {readonly kind: 'workset'; readonly name: string};
   readonly status: CodeGraphStatus;
 }
 
@@ -515,29 +516,38 @@ export const resolveCodeGraphQualifiedRefTargets = Effect.fn('codeGraphWorksetV2
       return published.members.flatMap(member => {
         if (!requestedRepositoryIds.has(member.repositoryId)) return [];
         const project = projectsByKey.get(member.repositoryKey);
-        return project === undefined ? [] : [project.path];
+        return project === undefined
+          ? []
+          : [{path: project.path, route: {kind: 'workset' as const, name: workset.name}}];
       });
     });
-    const orderedPaths = [...(caller === undefined ? [] : [caller]), ...publishedPaths];
-    const uniquePaths: string[] = [];
+    const orderedPaths = [
+      ...(caller === undefined ? [] : [{path: caller, route: {kind: 'caller' as const}}]),
+      ...publishedPaths,
+    ];
+    const uniquePaths: {
+      readonly cwd: string;
+      readonly route: {readonly kind: 'caller'} | {readonly kind: 'workset'; readonly name: string};
+    }[] = [];
     const seenPaths = new Set<string>();
     for (const candidate of orderedPaths) {
-      const cwd = yield* expandPath(candidate);
+      const cwd = yield* expandPath(candidate.path);
       if (seenPaths.has(cwd)) continue;
       seenPaths.add(cwd);
-      uniquePaths.push(cwd);
+      uniquePaths.push({cwd, route: candidate.route});
     }
     const matches = yield* Effect.forEach(
       uniquePaths,
-      cwd =>
+      candidate =>
         Effect.gen(function* () {
+          const {cwd} = candidate;
           if (!(yield* fs.exists(cwd))) return undefined;
           const status = yield* queryService.status(
             config.agentContextHome,
             cwd,
             CODE_GRAPH_QUALIFIED_REF_TARGET_STATUS_OPTIONS,
           );
-          return status.readySnapshot === undefined ? undefined : ({cwd, status} as const);
+          return status.readySnapshot === undefined ? undefined : ({...candidate, status} as const);
         }).pipe(Effect.catch(() => Effect.succeed(undefined))),
       {concurrency: 4},
     );
@@ -567,6 +577,7 @@ export const resolveCodeGraphQualifiedRefTargets = Effect.fn('codeGraphWorksetV2
         nodeId: record.nodeId,
         ref: record.ref,
         repositoryId: record.repositoryId,
+        route: selected.route,
         status: selected.status,
       } satisfies ResolvedCodeGraphQualifiedRefTargetV1;
     });

--- a/src/mcp/memory_code_citation.ts
+++ b/src/mcp/memory_code_citation.ts
@@ -1,0 +1,59 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {Effect} from 'effect';
+import {captureMemoryCodeCitations, MemoryCodeCitationCaptureError} from '../memory_code_citation_capture.js';
+import {mcpErrorResult} from '../mcp_server_common.js';
+import type {RuntimeConfig} from '../types.js';
+
+export function captureMemoryCodeCitationsForMcp(
+  config: RuntimeConfig,
+  input: {readonly callerCwd: string; readonly refs: readonly string[]},
+  operation: string,
+) {
+  if (input.refs.length === 0) {
+    return Effect.succeed({citations: [] as const, ok: true as const});
+  }
+  return captureMemoryCodeCitations(config, input).pipe(
+    Effect.match({
+      onFailure: error => ({error: memoryCodeCitationCaptureErrorResult(error, operation), ok: false as const}),
+      onSuccess: citations => ({citations, ok: true as const}),
+    }),
+  );
+}
+
+function memoryCodeCitationCaptureErrorResult(error: unknown, operation: string): CallToolResult {
+  const result = mcpErrorResult(error);
+  if (!(error instanceof MemoryCodeCitationCaptureError) || error.recovery === undefined) return result;
+  const recovery = error.recovery;
+  const preparation = recovery.preparation;
+  result.content = [
+    {
+      type: 'text',
+      text: [
+        error.message,
+        'No memory was written.',
+        `After preparation reports current ready evidence, retry the same ${operation} request unchanged.`,
+      ].join(' '),
+    },
+  ];
+  result.structuredContent = {
+    code: recovery.code,
+    graph: recovery.observedGraph,
+    indexingStarted: recovery.indexingStarted,
+    operation,
+    recovery: {
+      action: preparation.action,
+      arguments: preparation.arguments,
+      command: preparation.command,
+      retry: 'same-request',
+      runFrom: preparation.target === 'callerCwd' ? 'callerCwd' : 'any-directory',
+      target: preparation.target,
+    },
+    retryCondition: recovery.retryCondition,
+    retryable: recovery.retryable,
+    state: 'blocked',
+    type: 'memory-code-citation-write-recovery',
+    version: 1,
+    writeApplied: false,
+  };
+  return result;
+}

--- a/src/mcp_server_recall.ts
+++ b/src/mcp_server_recall.ts
@@ -51,7 +51,7 @@ import {
   memoryArchiveBody,
   type MemoryMetadata,
 } from './memory_document.js';
-import {captureMemoryCodeCitations} from './memory_code_citation_capture.js';
+import {captureMemoryCodeCitationsForMcp} from './mcp/memory_code_citation.js';
 import {MEMORY_SCHEMA_VERSION} from './memory_code_citation.js';
 import {
   memoryCodeCitationSharingBlocker,
@@ -226,10 +226,13 @@ export function registerCandidateMemoryTools(server: EffectMcpServerAdapter, con
         if (requestedCodeRefs.length > 0 && !callerCwd) {
           return argumentError('review_session_context requires absolute callerCwd when codeRefs are provided.');
         }
-        const codeCitations =
-          requestedCodeRefs.length === 0
-            ? []
-            : yield* captureMemoryCodeCitations(config, {callerCwd: callerCwd!, refs: requestedCodeRefs});
+        const captured = yield* captureMemoryCodeCitationsForMcp(
+          config,
+          {callerCwd: callerCwd!, refs: requestedCodeRefs},
+          'review_session_context',
+        );
+        if (!captured.ok) return captured.error;
+        const codeCitations = captured.citations;
         const rawCloseout: SessionCloseoutInput = {
           ...(codeCitations.length === 0 ? {} : {codeCitations}),
           decisions: candidatePolicy === 'handoff-only' ? [] : stringList(decisions),
@@ -1515,10 +1518,13 @@ export function registerStoreTool(
         if (requestedCodeRefs.length > 0 && !callerCwd) {
           return argumentError(`${name} requires absolute callerCwd when codeRefs are provided.`);
         }
-        const codeCitations =
-          requestedCodeRefs.length === 0
-            ? []
-            : yield* captureMemoryCodeCitations(config, {callerCwd: callerCwd!, refs: requestedCodeRefs});
+        const captured = yield* captureMemoryCodeCitationsForMcp(
+          config,
+          {callerCwd: callerCwd!, refs: requestedCodeRefs},
+          name,
+        );
+        if (!captured.ok) return captured.error;
+        const codeCitations = captured.citations;
         const workspaceComponent = callerCwd
           ? yield* resolveWorkspaceComponentContext({cwd: callerCwd, includeProcessCwd: false})
           : undefined;

--- a/src/memory_code_citation_capture.ts
+++ b/src/memory_code_citation_capture.ts
@@ -8,7 +8,10 @@ import {decodeUtf8} from './code_graph/inventory_content.js';
 import {CodeGraphQueryService} from './code_graph/query.js';
 import {CodeGraphStore} from './code_graph/store.js';
 import type {CodeGraphStatus, CodeGraphSymbol} from './code_graph/types.js';
-import {resolveCodeGraphQualifiedRefTargets} from './code_graph/workset_query_v2.js';
+import {
+  resolveCodeGraphQualifiedRefTargets,
+  type ResolvedCodeGraphQualifiedRefTargetV1,
+} from './code_graph/workset_query_v2.js';
 import {sha256Hex} from './effect/digest.js';
 import {SystemInfo} from './effect/system.js';
 import {
@@ -22,13 +25,55 @@ import type {RuntimeConfig} from './types.js';
 const LOCAL_SYMBOL_REF = /^cgs_(?:[0-9a-f]{32}|[0-9a-f]{40}|[0-9a-f]{64})$/u;
 const QUALIFIED_SYMBOL_REF = /^cgr_[0-9a-f]{40}$/u;
 
+export const MEMORY_CODE_CITATION_GRAPH_PREPARATION_COMMAND = 'threadnote graph index --no-vectors' as const;
+export const MEMORY_CODE_CITATION_WORKSET_PREPARATION_COMMAND = 'threadnote workset prepare' as const;
+
+export type MemoryCodeCitationCaptureRecoveryCode = 'exact-current-evidence-unavailable' | 'ready-graph-unavailable';
+
+export type MemoryCodeCitationGraphPreparationV1 =
+  | {
+      readonly action: 'index-current-graph';
+      readonly arguments: readonly [];
+      readonly command: typeof MEMORY_CODE_CITATION_GRAPH_PREPARATION_COMMAND;
+      readonly target: 'callerCwd';
+    }
+  | {
+      readonly action: 'prepare-workset';
+      readonly arguments: readonly [worksetName: string];
+      readonly command: typeof MEMORY_CODE_CITATION_WORKSET_PREPARATION_COMMAND;
+      readonly target: 'workset';
+    };
+
+export interface MemoryCodeCitationCaptureRecoveryV1 {
+  readonly code: MemoryCodeCitationCaptureRecoveryCode;
+  readonly indexingStarted: false;
+  readonly observedGraph: {
+    readonly freshness: CodeGraphStatus['freshness'];
+    readonly readySnapshot: 'absent' | 'available';
+    readonly stale: boolean;
+  };
+  readonly preparation: MemoryCodeCitationGraphPreparationV1;
+  readonly recovery: 'prepare-current-graph';
+  readonly retryCondition: 'after-current-graph-ready';
+  readonly retryable: true;
+  readonly type: 'memory-code-citation-capture-recovery';
+  readonly version: 1;
+}
+
 export class MemoryCodeCitationCaptureError extends Error {
   override readonly name = 'MemoryCodeCitationCaptureError';
+  readonly recovery?: MemoryCodeCitationCaptureRecoveryV1;
+
+  constructor(message: string, recovery?: MemoryCodeCitationCaptureRecoveryV1) {
+    super(message);
+    this.recovery = recovery;
+  }
 }
 
 interface CaptureTarget {
   readonly cwd: string;
   readonly index: number;
+  readonly preparation: MemoryCodeCitationGraphPreparationV1;
   readonly ref: string;
   readonly target: {readonly kind: 'file'; readonly path: string} | {readonly kind: 'symbol'; readonly nodeId: string};
 }
@@ -91,7 +136,7 @@ function resolveCaptureTarget(
   callerCwd: string,
   ref: string,
   index: number,
-  qualifiedByRef: ReadonlyMap<string, {readonly cwd: string; readonly nodeId: string}>,
+  qualifiedByRef: ReadonlyMap<string, ResolvedCodeGraphQualifiedRefTargetV1>,
 ) {
   return Effect.gen(function* () {
     if (QUALIFIED_SYMBOL_REF.test(ref)) {
@@ -104,17 +149,31 @@ function resolveCaptureTarget(
       return {
         cwd: target.cwd,
         index,
+        preparation:
+          target.route.kind === 'caller' ? callerGraphPreparation() : worksetGraphPreparation(target.route.name),
         ref,
         target: {kind: 'symbol', nodeId: target.nodeId},
       } satisfies CaptureTarget;
     }
     if (LOCAL_SYMBOL_REF.test(ref)) {
-      return {cwd: callerCwd, index, ref, target: {kind: 'symbol', nodeId: ref}} satisfies CaptureTarget;
+      return {
+        cwd: callerCwd,
+        index,
+        preparation: callerGraphPreparation(),
+        ref,
+        target: {kind: 'symbol', nodeId: ref},
+      } satisfies CaptureTarget;
     }
     if (ref.startsWith('cgs_')) {
       return yield* Effect.fail(new MemoryCodeCitationCaptureError(`Invalid local code graph reference: ${ref}.`));
     }
-    return {cwd: callerCwd, index, ref, target: {kind: 'file', path: ref}} satisfies CaptureTarget;
+    return {
+      cwd: callerCwd,
+      index,
+      preparation: callerGraphPreparation(),
+      ref,
+      target: {kind: 'file', path: ref},
+    } satisfies CaptureTarget;
   });
 }
 
@@ -133,7 +192,7 @@ const captureRepositoryGroup = Effect.fn('memoryCodeCitation.captureRepositoryGr
     })
     .pipe(Effect.mapError(error => captureError(cwd, error)));
   const snapshot = yield* Effect.try({
-    try: () => requireExactCurrentSnapshot(before),
+    try: () => requireExactCurrentSnapshot(before, captureGroupPreparation(targets)),
     catch: cause => captureError(cwd, cause),
   });
   return yield* Effect.scoped(
@@ -383,18 +442,73 @@ function createCitation(input: Parameters<typeof createMemoryCodeCitation>[0]) {
   });
 }
 
-function requireExactCurrentSnapshot(status: CodeGraphStatus): NonNullable<CodeGraphStatus['readySnapshot']> {
+function requireExactCurrentSnapshot(
+  status: CodeGraphStatus,
+  preparation: MemoryCodeCitationGraphPreparationV1,
+): NonNullable<CodeGraphStatus['readySnapshot']> {
   if (status.readySnapshot === undefined) {
     throw new MemoryCodeCitationCaptureError(
-      'Code citations require an already-published ready graph; run `threadnote graph status` and prepare it first.',
+      `Code citations require an already-published ready graph; ${captureRecoveryMessage(preparation)} No indexing was started.`,
+      captureRecovery(status, 'ready-graph-unavailable', preparation),
     );
   }
   if (status.stale || status.freshness !== 'current') {
     throw new MemoryCodeCitationCaptureError(
-      'Code citations require exact current graph evidence; wait for indexing to finish and retry.',
+      `Code citations require exact current graph evidence; ${captureRecoveryMessage(preparation)} No indexing was started.`,
+      captureRecovery(status, 'exact-current-evidence-unavailable', preparation),
     );
   }
   return status.readySnapshot;
+}
+
+function captureRecovery(
+  status: CodeGraphStatus,
+  code: MemoryCodeCitationCaptureRecoveryCode,
+  preparation: MemoryCodeCitationGraphPreparationV1,
+): MemoryCodeCitationCaptureRecoveryV1 {
+  return {
+    code,
+    indexingStarted: false,
+    observedGraph: {
+      freshness: status.freshness,
+      readySnapshot: status.readySnapshot === undefined ? 'absent' : 'available',
+      stale: status.stale,
+    },
+    preparation,
+    recovery: 'prepare-current-graph',
+    retryCondition: 'after-current-graph-ready',
+    retryable: true,
+    type: 'memory-code-citation-capture-recovery',
+    version: 1,
+  };
+}
+
+function callerGraphPreparation(): MemoryCodeCitationGraphPreparationV1 {
+  return {
+    action: 'index-current-graph',
+    arguments: [],
+    command: MEMORY_CODE_CITATION_GRAPH_PREPARATION_COMMAND,
+    target: 'callerCwd',
+  };
+}
+
+function worksetGraphPreparation(worksetName: string): MemoryCodeCitationGraphPreparationV1 {
+  return {
+    action: 'prepare-workset',
+    arguments: [worksetName],
+    command: MEMORY_CODE_CITATION_WORKSET_PREPARATION_COMMAND,
+    target: 'workset',
+  };
+}
+
+function captureGroupPreparation(targets: readonly CaptureTarget[]): MemoryCodeCitationGraphPreparationV1 {
+  return targets.find(target => target.preparation.target === 'callerCwd')?.preparation ?? targets[0]!.preparation;
+}
+
+function captureRecoveryMessage(preparation: MemoryCodeCitationGraphPreparationV1): string {
+  return preparation.target === 'callerCwd'
+    ? `run \`${preparation.command}\` from callerCwd, then retry.`
+    : `prepare the routed Workset ${JSON.stringify(preparation.arguments[0])} with \`${preparation.command} <workset>\`, then retry.`;
 }
 
 function sameExactSnapshot(before: CodeGraphStatus, after: CodeGraphStatus): boolean {

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -1961,7 +1961,7 @@ describe('Threadnote MCP toolsets', () => {
     );
   }, 40_000);
 
-  it('returns a ready stale graph without waiting for refresh during dirty and clean repository changes', async () => {
+  it('serves ready stale graphs and rejects cited replacements with typed recovery before mutation', async () => {
     await withMcpClient(
       async (client, fixture) => {
         const repository = join(fixture.root, 'stale-ready-repository');
@@ -1990,6 +1990,28 @@ describe('Threadnote MCP toolsets', () => {
         const firstSnapshotId = (first.structuredContent as {readonly snapshot?: {readonly id?: unknown}} | undefined)
           ?.snapshot?.id;
         expect(typeof firstSnapshotId).toBe('string');
+        const citationTopic = 'deferred-citation-retry';
+        const citationUri = `threadnote://user/test-user/memories/durable/projects/threadnote/${citationTopic}.md`;
+        const citationPath = join(
+          fixture.home,
+          'data',
+          'local',
+          'user',
+          'test-user',
+          'memories',
+          'durable',
+          'projects',
+          'threadnote',
+          `${citationTopic}.md`,
+        );
+        await callText(client, 'remember_context', {
+          callerCwd: repository,
+          kind: 'durable',
+          project: 'threadnote',
+          text: 'Original memory that must survive a rejected cited replacement.',
+          topic: citationTopic,
+        });
+        const citationBefore = await readFile(citationPath, 'utf8');
 
         const gitCommonDirectory = await realpath(
           execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
@@ -2036,6 +2058,48 @@ describe('Threadnote MCP toolsets', () => {
             snapshot: {commit: indexedCommit, id: firstSnapshotId},
           });
           expect((dirtyStale.structuredContent as {readonly state?: unknown} | undefined)?.state).toBeUndefined();
+
+          const rejectedCitation = await client.callTool(
+            {
+              arguments: {
+                callerCwd: repository,
+                codeRefs: ['src/index.ts'],
+                kind: 'durable',
+                project: 'threadnote',
+                replaceUri: citationUri,
+                text: 'This replacement must remain unapplied until exact-current graph evidence exists.',
+                topic: citationTopic,
+              },
+              name: 'remember_context',
+            },
+            undefined,
+            {timeout: 5_000},
+          );
+          expect(rejectedCitation.isError).toBe(true);
+          expect(rejectedCitation.structuredContent).toMatchObject({
+            code: 'exact-current-evidence-unavailable',
+            graph: {readySnapshot: 'available', stale: true},
+            indexingStarted: false,
+            operation: 'remember_context',
+            recovery: {
+              action: 'index-current-graph',
+              arguments: [],
+              command: 'threadnote graph index --no-vectors',
+              retry: 'same-request',
+              runFrom: 'callerCwd',
+              target: 'callerCwd',
+            },
+            retryCondition: 'after-current-graph-ready',
+            retryable: true,
+            state: 'blocked',
+            type: 'memory-code-citation-write-recovery',
+            version: 1,
+            writeApplied: false,
+          });
+          expect(JSON.stringify(rejectedCitation.content)).toContain('No memory was written');
+          expect(JSON.stringify(rejectedCitation.content)).toContain('threadnote graph index --no-vectors');
+          expect(JSON.stringify(rejectedCitation)).not.toContain(repository);
+          await expect(readFile(citationPath, 'utf8')).resolves.toBe(citationBefore);
 
           execFileSync('git', ['add', '.'], {cwd: repository});
           execFileSync('git', ['commit', '-qm', 'clean pulled commit'], {cwd: repository});

--- a/test/unit/code-graph.qualified-ref-targets.test.ts
+++ b/test/unit/code-graph.qualified-ref-targets.test.ts
@@ -106,14 +106,31 @@ describe('batched repository-qualified reference routing', () => {
             repositoryId: projects[77]!.repositoryId,
           }),
         );
+        const callerRef = yield* catalogTestEffect(
+          registerCodeGraphQualifiedRef(home, {
+            nodeId: `cgs_${'c'.repeat(32)}`,
+            repositoryId: projects[0]!.repositoryId,
+          }),
+        );
 
         const resolved = yield* resolveCodeGraphQualifiedRefTargets(
           config,
-          [first.ref, second.ref, first.ref],
+          [first.ref, second.ref, callerRef.ref, first.ref],
           projects[0]!.cwd,
         );
 
-        expect(resolved.map(target => target.cwd)).toEqual([projects[5]!.cwd, projects[77]!.cwd, projects[5]!.cwd]);
+        expect(resolved.map(target => target.cwd)).toEqual([
+          projects[5]!.cwd,
+          projects[77]!.cwd,
+          projects[0]!.cwd,
+          projects[5]!.cwd,
+        ]);
+        expect(resolved.map(target => target.route)).toEqual([
+          {kind: 'workset', name: 'citation-routing'},
+          {kind: 'workset', name: 'citation-routing'},
+          {kind: 'caller'},
+          {kind: 'workset', name: 'citation-routing'},
+        ]);
         expect(statusCalls).toBe(3);
       }).pipe(
         provideTestLayer(

--- a/test/unit/memory-code-citation-capture.test.ts
+++ b/test/unit/memory-code-citation-capture.test.ts
@@ -1,12 +1,21 @@
 import {it as effectIt} from '@effect/vitest';
 import {Effect, FileSystem, Layer, Path} from 'effect';
 import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
 import {describe, expect} from 'vitest';
 import type {CodeGraphStoreShape} from '../../src/code_graph/store_shape.js';
 import {codeGraphCommittedFileContentHash} from '../../src/code_graph/content_identity.js';
 import {CodeGraphQueryService} from '../../src/code_graph/query.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
 import {CodeGraphLanguagePackRegistry} from '../../src/code_graph/languages/registry.js';
+import {createCodeGraphWorksetRoutingProjection} from '../../src/code_graph/workset_catalog/projection.js';
+import {
+  publishCodeGraphWorksetCatalogGeneration,
+  registerCodeGraphQualifiedRef,
+  stageCodeGraphWorksetCatalogGeneration,
+} from '../../src/code_graph/workset_catalog/store.js';
+import {CODE_GRAPH_WORKSET_CATALOG_PROJECTOR_VERSION} from '../../src/code_graph/workset_catalog/types.js';
+import {codeGraphWorksetManifestDigest} from '../../src/code_graph/workset_catalog/workset.js';
 import type {
   CodeGraphEffectiveSnapshotCitationEvidence,
   CodeGraphEffectiveSnapshotCitationEvidenceRequest,
@@ -14,7 +23,12 @@ import type {
 import type {CodeGraphInventoryFile, CodeGraphStatus, CodeGraphSymbol} from '../../src/code_graph/types.js';
 import {validateContextBriefMemoryCitations} from '../../src/context_brief/citation_validation.js';
 import {StandaloneBrokerLayer} from '../../src/effect/runtime.js';
-import {captureMemoryCodeCitations} from '../../src/memory_code_citation_capture.js';
+import {
+  captureMemoryCodeCitations,
+  MEMORY_CODE_CITATION_GRAPH_PREPARATION_COMMAND,
+  MEMORY_CODE_CITATION_WORKSET_PREPARATION_COMMAND,
+  MemoryCodeCitationCaptureError,
+} from '../../src/memory_code_citation_capture.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 
@@ -97,9 +111,155 @@ describe('memory code citation capture and validation', () => {
       expect(fixture.validationSessions()).toBe(2);
     }).pipe(provideTestLayer(StandaloneBrokerLayer)),
   );
+
+  effectIt.effect('routes qualified-reference recovery through its published Workset before unchanged retry', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-citation-qualified-recovery-'});
+      const caller = path.join(root, 'caller');
+      const sibling = path.join(root, 'sibling');
+      const home = path.join(root, 'home');
+      yield* fs.makeDirectory(caller, {recursive: true});
+      yield* fs.makeDirectory(path.join(sibling, 'src'), {recursive: true});
+      yield* fs.makeDirectory(home, {recursive: true});
+      yield* fs.writeFileString(path.join(sibling, 'src', 'value.ts'), SOURCE);
+      const project = {
+        name: 'sibling',
+        path: sibling,
+        seed: [] as const,
+        uri: 'threadnote://resources/repos/sibling',
+      };
+      const workset = {name: 'citation-routing', projects: [project], unresolvedProjects: [] as const};
+      const manifestPath = path.join(home, 'seed-manifest.yaml');
+      yield* fs.writeFileString(
+        manifestPath,
+        [
+          'version: 1',
+          'projects:',
+          '  - name: sibling',
+          `    path: ${JSON.stringify(sibling)}`,
+          '    uri: threadnote://resources/repos/sibling',
+          '    seed: []',
+          'worksets:',
+          '  - name: citation-routing',
+          '    projects:',
+          '      - sibling',
+          '',
+        ].join('\n'),
+      );
+      const staged = yield* catalogTestEffect(
+        stageCodeGraphWorksetCatalogGeneration(home, {
+          manifestDigest: codeGraphWorksetManifestDigest(workset),
+          members: [{projection: routingProjection(), repositoryKey: project.name}],
+          worksetName: workset.name,
+        }),
+      );
+      yield* catalogTestEffect(
+        publishCodeGraphWorksetCatalogGeneration(home, {
+          generationId: staged.id,
+          worksetName: workset.name,
+        }),
+      );
+      const qualified = yield* catalogTestEffect(
+        registerCodeGraphQualifiedRef(home, {nodeId: SYMBOL_ID, repositoryId: REPOSITORY_ID}),
+      );
+      let siblingCurrent = false;
+      const fixture = citationFixture(sibling, {
+        statusFor: (cwd, observeWorktree) => {
+          if (cwd === caller) return callerStatus(caller);
+          return observeWorktree === false || siblingCurrent
+            ? fixture.status
+            : {...fixture.status, freshness: 'stale', stale: true};
+        },
+      });
+      const config = {...CONFIG, agentContextHome: home, manifestPath};
+
+      const failure = yield* captureMemoryCodeCitations(config, {
+        callerCwd: caller,
+        refs: [qualified.ref],
+      }).pipe(provideTestLayer(fixture.layer), Effect.flip);
+      expect(failure).toBeInstanceOf(MemoryCodeCitationCaptureError);
+      if (!(failure instanceof MemoryCodeCitationCaptureError)) return;
+      expect(failure.recovery?.preparation).toEqual({
+        action: 'prepare-workset',
+        arguments: [workset.name],
+        command: MEMORY_CODE_CITATION_WORKSET_PREPARATION_COMMAND,
+        target: 'workset',
+      });
+      expect(failure.message).toContain(`Workset ${JSON.stringify(workset.name)}`);
+      expect(failure.message).not.toContain(sibling);
+      expect(JSON.stringify(failure.recovery)).not.toContain(sibling);
+
+      siblingCurrent = true;
+      const citations = yield* captureMemoryCodeCitations(config, {
+        callerCwd: caller,
+        refs: [qualified.ref],
+      }).pipe(provideTestLayer(fixture.layer));
+      expect(citations).toMatchObject([{path: 'src/value.ts', target: {kind: 'symbol', nodeId: SYMBOL_ID}}]);
+    }).pipe(provideTestLayer(StandaloneBrokerLayer)),
+  );
+
+  effectIt.effect.prop(
+    'returns bounded manual recovery for every non-exact graph admission state',
+    {
+      status: fc
+        .record({
+          freshness: fc.constantFrom('current' as const, 'deferred' as const, 'stale' as const),
+          hasReadySnapshot: fc.boolean(),
+          stale: fc.boolean(),
+        })
+        .filter(value => !value.hasReadySnapshot || value.stale || value.freshness !== 'current'),
+    },
+    ({status}) =>
+      Effect.gen(function* () {
+        const fixture = citationFixture('/fixture', {
+          freshness: status.freshness,
+          stale: status.stale,
+          withoutReadySnapshot: !status.hasReadySnapshot,
+        });
+        const failure = yield* captureMemoryCodeCitations(CONFIG, {
+          callerCwd: '/fixture',
+          refs: ['src/value.ts'],
+        }).pipe(provideTestLayer(fixture.layer), Effect.flip);
+
+        expect(failure).toBeInstanceOf(MemoryCodeCitationCaptureError);
+        if (!(failure instanceof MemoryCodeCitationCaptureError)) return;
+        expect(failure.recovery).toEqual({
+          code: status.hasReadySnapshot ? 'exact-current-evidence-unavailable' : 'ready-graph-unavailable',
+          indexingStarted: false,
+          observedGraph: {
+            freshness: status.freshness,
+            readySnapshot: status.hasReadySnapshot ? 'available' : 'absent',
+            stale: status.stale,
+          },
+          preparation: {
+            action: 'index-current-graph',
+            arguments: [],
+            command: MEMORY_CODE_CITATION_GRAPH_PREPARATION_COMMAND,
+            target: 'callerCwd',
+          },
+          recovery: 'prepare-current-graph',
+          retryCondition: 'after-current-graph-ready',
+          retryable: true,
+          type: 'memory-code-citation-capture-recovery',
+          version: 1,
+        });
+        expect(JSON.stringify(failure.recovery)).not.toContain('/fixture');
+      }).pipe(provideTestLayer(StandaloneBrokerLayer)),
+    {fastCheck: {numRuns: 36}},
+  );
 });
 
-function citationFixture(root: string) {
+function citationFixture(
+  root: string,
+  statusOptions: {
+    readonly freshness?: CodeGraphStatus['freshness'];
+    readonly stale?: boolean;
+    readonly statusFor?: (cwd: string, observeWorktree: boolean | undefined) => CodeGraphStatus;
+    readonly withoutReadySnapshot?: boolean;
+  } = {},
+) {
   const file: CodeGraphInventoryFile = {
     blobId: 'fixture-blob',
     contentHash: SOURCE_HASH,
@@ -132,7 +292,7 @@ function citationFixture(root: string) {
   };
   const status: CodeGraphStatus = {
     databasePath: `${root}/graph.sqlite`,
-    freshness: 'current',
+    freshness: statusOptions.freshness ?? 'current',
     identity: {
       caseMode: 'sensitive',
       checkoutId: 'fixture-checkout',
@@ -146,21 +306,25 @@ function citationFixture(root: string) {
       worktreeId: 'fixture-worktree',
     },
     languagePacks: [],
-    readySnapshot: {
-      commit: COMMIT,
-      completedAt: '2026-08-26T00:00:00.000Z',
-      dirty: false,
-      edgeCount: 0,
-      extractorSet: 'fixture-extractor-set',
-      fileCount: 1,
-      graphContentId: `cgc_${'5'.repeat(40)}`,
-      id: SNAPSHOT_ID,
-      repositoryId: REPOSITORY_ID,
-      state: 'ready',
-      symbolCount: 1,
-      worktreeId: 'fixture-worktree',
-    },
-    stale: false,
+    ...(statusOptions.withoutReadySnapshot
+      ? {}
+      : {
+          readySnapshot: {
+            commit: COMMIT,
+            completedAt: '2026-08-26T00:00:00.000Z',
+            dirty: false,
+            edgeCount: 0,
+            extractorSet: 'fixture-extractor-set',
+            fileCount: 1,
+            graphContentId: `cgc_${'5'.repeat(40)}`,
+            id: SNAPSHOT_ID,
+            repositoryId: REPOSITORY_ID,
+            state: 'ready' as const,
+            symbolCount: 1,
+            worktreeId: 'fixture-worktree',
+          },
+        }),
+    stale: statusOptions.stale ?? false,
   };
   let evidenceCalls = 0;
   let acquired = 0;
@@ -215,15 +379,85 @@ function citationFixture(root: string) {
     use,
   ) => Effect.sync(() => void ++validationSessions).pipe(Effect.andThen(use(status)));
   const query = CodeGraphQueryService.of({
-    status: () => Effect.succeed(status),
+    status: (_home: string, cwd: string, options?: {readonly observeWorktree?: boolean}) =>
+      Effect.sync(() => statusOptions.statusFor?.(cwd, options?.observeWorktree) ?? status),
     withStatusSession,
   } as unknown as Parameters<typeof CodeGraphQueryService.of>[0]);
   return {
     evidenceCalls: () => evidenceCalls,
     layer: Layer.merge(Layer.succeed(CodeGraphStore, store), Layer.succeed(CodeGraphQueryService, query)),
     leases: () => ({acquired, released}),
+    status,
     symbol,
     validationSessions: () => validationSessions,
+  };
+}
+
+function catalogTestEffect<A, E>(effect: Effect.Effect<A, E, unknown>): Effect.Effect<A, E> {
+  // The enclosing platform layer provides the catalog's concrete services.
+  // oxlint-disable-next-line effecttsgo/unsafe-effect-type-assertion -- narrow the fully provided test boundary
+  return effect as Effect.Effect<A, E>;
+}
+
+function routingProjection() {
+  return createCodeGraphWorksetRoutingProjection({
+    checkoutId: '7'.repeat(64),
+    commitId: COMMIT,
+    componentCount: 1,
+    extractorGeneration: 13,
+    projectorVersion: CODE_GRAPH_WORKSET_CATALOG_PROJECTOR_VERSION,
+    repositoryId: REPOSITORY_ID,
+    snapshotDigest: '8'.repeat(64),
+    snapshotId: SNAPSHOT_ID,
+    symbols: [
+      {
+        exported: true,
+        kind: 'function',
+        language: 'typescript',
+        lookupKeys: ['value'],
+        name: 'value',
+        nodeId: SYMBOL_ID,
+        path: 'src/value.ts',
+        qualifiedName: 'value',
+        span: {column: 1, endColumn: 2, endLine: 3, line: 1},
+        terms: [{term: 'value', weight: 4}],
+      },
+    ],
+    worktreeId: '9'.repeat(64),
+  });
+}
+
+function callerStatus(root: string): CodeGraphStatus {
+  const repositoryId = 'a'.repeat(64);
+  return {
+    databasePath: `${root}/graph.sqlite`,
+    freshness: 'current',
+    identity: {
+      caseMode: 'sensitive',
+      checkoutId: 'caller-checkout',
+      displayName: 'example/caller',
+      gitCommonDirectory: `${root}/.git`,
+      headCommit: COMMIT,
+      objectFormat: 'sha1',
+      remoteIdentity: 'https://github.com/example/caller.git',
+      repoRoot: root,
+      repositoryId,
+      worktreeId: 'caller-worktree',
+    },
+    languagePacks: [],
+    readySnapshot: {
+      commit: COMMIT,
+      dirty: false,
+      edgeCount: 0,
+      extractorSet: 'fixture-extractor-set',
+      fileCount: 0,
+      id: `cgsn_${'a'.repeat(40)}`,
+      repositoryId,
+      state: 'ready',
+      symbolCount: 0,
+      worktreeId: 'caller-worktree',
+    },
+    stale: false,
   };
 }
 


### PR DESCRIPTION
## Summary

- return a versioned typed MCP recovery receipt when cited memory writes lack exact-current graph evidence
- preserve fail-closed writes and explicitly report that no indexing or memory mutation occurred
- route local references to graph index preparation and qualified cross-repository references to their published Workset preparation
- document the bounded prepare-and-retry contract

## Verification

- focused Effect unit tests and a 36-run Fast-check recovery-state property
- real MCP integration: dirty overlay is deferred, cited replacement is rejected before mutation, and the response contains no repository path
- cross-repository Workset route regression and successful unchanged retry after preparation
- lint, file-length guard, source/test/site typechecks, and precommit passed
- dev-cycle completed in two iterations with zero critical or important findings
- guarded global install was correctly refused because another active worktree owns the runtime; exact-HEAD checkout-local dogfood verified rejection, unchanged memory, explicit preparation, and successful retry

The full suite is intentionally left to PR CI per repository policy.