### PR TITLE
fix(graph): recover from invalid cached facts

### DIFF
--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -60,7 +60,12 @@ import {
 } from './indexer_materialization.js';
 import {type PendingMaterializationBatch, secondaryIndexRestorationReporter} from './indexer_materialization_batch.js';
 import {verifyCommittedIndexInput} from './indexer_input_verification.js';
-import {CodeGraphIndexOperationError, codeGraphInventoryFileChanged, sameInventoryPaths} from './indexer_shared.js';
+import {
+  CachedCodeGraphFactUnavailableDuringIndex,
+  CodeGraphIndexOperationError,
+  codeGraphInventoryFileChanged,
+  sameInventoryPaths,
+} from './indexer_shared.js';
 import type {
   CodeGraphIndexOptions,
   CommittedBaseResult,
@@ -1555,11 +1560,7 @@ export const buildAndActivate = Effect.fn('codeGraph.buildAndActivate')(function
       loadingMilliseconds += batchLoadingMilliseconds;
       stageMilliseconds['loading-cache'] = loadingMilliseconds;
       if (fallbackFiles.some(file => !cached.facts.has(file.path))) {
-        return yield* Effect.fail(
-          new CodeGraphIndexOperationError(
-            'A cached code graph fact disappeared during indexing; retry with a full rebuild.',
-          ),
-        );
+        return yield* Effect.fail(new CachedCodeGraphFactUnavailableDuringIndex());
       }
       yield* input.onProgress?.({
         activity: {

--- a/src/code_graph/indexer_service.ts
+++ b/src/code_graph/indexer_service.ts
@@ -36,6 +36,7 @@ import {
   sparseOverlayGraphContentIdentity,
 } from './indexer_materialization.js';
 import {
+  CachedCodeGraphFactUnavailableDuringIndex,
   CodeGraphIndexOperationError,
   RepositoryMaintenanceInterrupted,
   RepositoryRegistrationLost,
@@ -97,6 +98,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
         request: CodeGraphIndexOptions,
         anonymousTelemetry: CodeGraphBuildAnonymousTelemetryReporter,
         attempt = 0,
+        bypassCachedFacts = false,
       ): Effect.Effect<CodeGraphIndexSummary, unknown> =>
         Effect.scoped(
           Effect.gen(function* () {
@@ -306,25 +308,29 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       });
                       let bypassReusableInventoryBase = false;
                       yield* cacheCoalescer.beginSparseExtractionTracking;
-                      const sparseOverlay = yield* attemptSparseReusableOverlay({
-                        anonymousTelemetry,
-                        cacheCoalescer,
-                        capacityProtection,
-                        embedding,
-                        ensureVectors,
-                        fs,
-                        identity,
-                        languagePacks,
-                        layout,
-                        observation: inventoryOverlayObservation,
-                        onInvalidBaseCache: Effect.sync(() => {
-                          bypassReusableInventoryBase = true;
-                        }),
-                        options,
-                        requestedOverlay,
-                        startedAt,
-                        store,
-                      }).pipe(
+                      const sparseOverlay = yield* (
+                        bypassCachedFacts
+                          ? Effect.succeed(Option.none<CodeGraphIndexSummary>())
+                          : attemptSparseReusableOverlay({
+                              anonymousTelemetry,
+                              cacheCoalescer,
+                              capacityProtection,
+                              embedding,
+                              ensureVectors,
+                              fs,
+                              identity,
+                              languagePacks,
+                              layout,
+                              observation: inventoryOverlayObservation,
+                              onInvalidBaseCache: Effect.sync(() => {
+                                bypassReusableInventoryBase = true;
+                              }),
+                              options,
+                              requestedOverlay,
+                              startedAt,
+                              store,
+                            })
+                      ).pipe(
                         Effect.ensuring(
                           cacheCoalescer.endSparseExtractionTracking.pipe(
                             Effect.andThen(cacheCoalescer.discard),
@@ -338,6 +344,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                           inventoryOverlayObservation.changedPaths.length +
                           inventoryOverlayObservation.deletedPaths.length;
                         const reusableInventoryBase =
+                          !bypassCachedFacts &&
                           !bypassReusableInventoryBase &&
                           !options.force &&
                           options.incrementalOverlay !== false &&
@@ -372,9 +379,10 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                           );
                           if (Option.isSome(reusedInventory)) return reusedInventory.value;
                         }
-                        const cachedCommittedFileKeys = options.force
-                          ? new Set<string>()
-                          : yield* cachedFileKeys(store, layout.databasePath, languagePacks, options.onProgress);
+                        const cachedCommittedFileKeys =
+                          options.force || bypassCachedFacts
+                            ? new Set<string>()
+                            : yield* cachedFileKeys(store, layout.databasePath, languagePacks, options.onProgress);
                         return yield* inventoryRepository(identity, {
                           ...options,
                           cachedCommittedFileKeys,
@@ -874,7 +882,11 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
           Effect.provideService(SystemInfo, system),
           Effect.catchIf(
             cause => cause instanceof WorktreeChangedDuringIndex && attempt === 0,
-            () => indexAttempt(request, anonymousTelemetry, attempt + 1),
+            () => indexAttempt(request, anonymousTelemetry, attempt + 1, bypassCachedFacts),
+          ),
+          Effect.catchIf(
+            cause => cause instanceof CachedCodeGraphFactUnavailableDuringIndex && !bypassCachedFacts,
+            () => indexAttempt(request, anonymousTelemetry, attempt, true),
           ),
         );
       const index = (request: CodeGraphIndexOptions) =>
@@ -888,7 +900,8 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
       const ensureCommitWithSummary = (
         request: Omit<CodeGraphIndexOptions, 'force' | 'includeOverlay'> & {readonly commit: string},
         anonymousTelemetry: CodeGraphBuildAnonymousTelemetryReporter,
-      ) =>
+        bypassCachedFacts = false,
+      ): Effect.Effect<{readonly lease: CodeGraphCommitLease; readonly summary: CodeGraphIndexSummary}, unknown> =>
         Effect.scoped(
           Effect.gen(function* () {
             const initialIdentity = yield* resolveRepositoryIdentity(request.cwd);
@@ -991,12 +1004,9 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       );
                       yield* store.initialize(layout.databasePath);
                       const identity = {...currentIdentity, headCommit: options.commit};
-                      const cachedCommittedFileKeys = yield* cachedFileKeys(
-                        store,
-                        layout.databasePath,
-                        languagePacks,
-                        options.onProgress,
-                      );
+                      const cachedCommittedFileKeys = bypassCachedFacts
+                        ? new Set<string>()
+                        : yield* cachedFileKeys(store, layout.databasePath, languagePacks, options.onProgress);
                       const cacheCoalescer = cacheContentBatch({
                         databasePath: layout.databasePath,
                         languagePacks,
@@ -1091,6 +1101,10 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
           Effect.provideService(FileSystem.FileSystem, fs),
           Effect.provideService(Path.Path, path),
           Effect.provideService(SystemInfo, system),
+          Effect.catchIf(
+            cause => cause instanceof CachedCodeGraphFactUnavailableDuringIndex && !bypassCachedFacts,
+            () => ensureCommitWithSummary(request, anonymousTelemetry, true),
+          ),
         );
       const ensureCommit = (
         request: Omit<CodeGraphIndexOptions, 'force' | 'includeOverlay'> & {readonly commit: string},

--- a/src/code_graph/indexer_shared.ts
+++ b/src/code_graph/indexer_shared.ts
@@ -63,6 +63,14 @@ export class WorktreeChangedDuringIndex extends Error {
   }
 }
 
+export class CachedCodeGraphFactUnavailableDuringIndex extends CodeGraphIndexOperationError {
+  override readonly name = 'CachedCodeGraphFactUnavailableDuringIndex';
+
+  constructor() {
+    super('A cached code graph fact disappeared during indexing; retry with a full rebuild.');
+  }
+}
+
 export class RepositoryRegistrationLost extends Error {
   override readonly name = 'RepositoryRegistrationLost';
 }

--- a/test/integration/code-graph.lifecycle.test.ts
+++ b/test/integration/code-graph.lifecycle.test.ts
@@ -1827,6 +1827,106 @@ describe('native code graph lifecycle', () => {
     }
   });
 
+  effectIt.effect('retries full inventory materialization without a parser cache after a cached fact disappears', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const root = createManySourceRepository(12);
+        const home = join(root, '.threadnote-test-home');
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const first = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: home});
+        const databasePath = codeGraphDatabasePath(home, first);
+        yield* Effect.sync(() => {
+          invalidateCachedFactFallback(databasePath, first.snapshot.id, 'src/file-000.ts');
+          writeFileSync(join(root, 'src/file-012.ts'), 'export const file012 = 12;\n');
+          git(root, ['add', 'src/file-012.ts']);
+          git(root, [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '-qm',
+            'full cache recovery target',
+          ]);
+        });
+        const extractionCompletions: string[] = [];
+
+        const recovered = yield* indexer.index({
+          cwd: root,
+          ensureVectors: false,
+          onProgress: progress =>
+            Effect.sync(() => {
+              if (
+                progress.phase === 'scanning' &&
+                progress.activity?.stage === 'extracting' &&
+                progress.activity.parseMilliseconds !== undefined
+              ) {
+                extractionCompletions.push(progress.activity.path);
+              }
+            }),
+          threadnoteHome: home,
+        });
+        const recoveredGraph = yield* store.loadGraph(databasePath, recovered.snapshot.id);
+        const oracleHome = join(root, '.threadnote-oracle-home');
+        const oracle = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: oracleHome});
+        const oracleGraph = yield* store.loadGraph(codeGraphDatabasePath(oracleHome, oracle), oracle.snapshot.id);
+
+        expect(recovered.materialization).toMatchObject({mode: 'full', stagedFiles: 13, totalFiles: 13});
+        expect(extractionCompletions).toHaveLength(14);
+        for (let index = 0; index < 13; index += 1) {
+          const path = `src/file-${String(index).padStart(3, '0')}.ts`;
+          expect(extractionCompletions.filter(candidate => candidate === path)).toHaveLength(index === 12 ? 2 : 1);
+        }
+        expect(normalizeStoredGraph(recoveredGraph)).toEqual(normalizeStoredGraph(oracleGraph));
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('retries committed-base materialization without a parser cache after a cached fact disappears', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const root = createManySourceRepository(4);
+        const home = join(root, '.threadnote-test-home');
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const first = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: home});
+        const databasePath = codeGraphDatabasePath(home, first);
+        const commit = yield* Effect.sync(() => {
+          invalidateCachedFactFallback(databasePath, first.snapshot.id, 'src/file-000.ts');
+          writeFileSync(join(root, 'src/file-003.ts'), 'export const file003 = 4;\n');
+          git(root, ['add', 'src/file-003.ts']);
+          git(root, [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '-qm',
+            'committed cache recovery target',
+          ]);
+          return execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], {encoding: 'utf8'}).trim();
+        });
+
+        const ensured = yield* Effect.acquireUseRelease(
+          indexer.ensureCommit({commit, cwd: root, ensureVectors: false, threadnoteHome: home}),
+          lease =>
+            store
+              .loadGraph(databasePath, lease.snapshot.id)
+              .pipe(Effect.map(graph => ({graph, snapshot: lease.snapshot}))),
+          lease => store.releaseSnapshotLease(databasePath, lease.leaseToken),
+        );
+        const oracleHome = join(root, '.threadnote-oracle-home');
+        const oracle = yield* indexer.index({cwd: root, ensureVectors: false, threadnoteHome: oracleHome});
+        const oracleGraph = yield* store.loadGraph(codeGraphDatabasePath(oracleHome, oracle), oracle.snapshot.id);
+
+        expect(ensured.snapshot.commit).toBe(commit);
+        expect(ensured.snapshot.fileCount).toBe(4);
+        expect(normalizeStoredGraph(ensured.graph)).toEqual(normalizeStoredGraph(oracleGraph));
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('rebuilds a valid materialized shard payload stored under the wrong path', () =>
     TestClock.withLive(
       Effect.gen(function* () {
@@ -5957,6 +6057,23 @@ function normalizeStoredGraph(graph: StoredCodeGraph): Pick<StoredCodeGraph, 'ed
     edges: [...graph.edges].sort((left, right) => left.id.localeCompare(right.id)),
     symbols: [...graph.symbols].sort((left, right) => left.id.localeCompare(right.id)),
   };
+}
+
+function invalidateCachedFactFallback(databasePath: string, snapshotId: string, path: string): void {
+  const database = new Database(databasePath);
+  try {
+    expect(
+      database
+        .query('UPDATE file_blobs SET facts_json = ? WHERE path_hint = ?')
+        .run(JSON.stringify({diagnostics: [], edges: [null], path, symbols: []}), path).changes,
+    ).toBeGreaterThan(0);
+    expect(
+      database.query('DELETE FROM snapshot_file_shards WHERE snapshot_id = ? AND path = ?').run(snapshotId, path)
+        .changes,
+    ).toBe(1);
+  } finally {
+    database.close();
+  }
 }
 
 function finalFullMaterializationMetrics(progress: readonly CodeGraphProgress[]): CodeGraphMaterializationMetrics {


### PR DESCRIPTION
## Summary

- recognize the internal missing-fact materialization failure without changing the public graph error contract
- retry index and committed-base preparation once with parser-cache reuse disabled
- preserve ordinary snapshot semantics and leave a second failure fail-closed
- cover valid cache-authority rows whose nested fact payload fails decoding, default admission recovery, bounded retry counts, and parity against fresh-home rebuilds

## Verification

- focused lifecycle regressions: 3 passed
- SQLite session integration: 6 passed
- source, test, and website typechecks
- strict lint and file-length checks
- Prettier and diff checks
- dev-cycle: 0 critical, 0 important; 2 test-quality minors polished

Property testing was assessed but not added: this is an OS/SQLite-backed recovery transition with no useful pure input model; bounded corruption examples plus independent fresh-home parity directly cover the contract.