### PR TITLE
feat(code-graph): add portable checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,11 +267,23 @@ threadnote graph hubs
 threadnote graph surprises
 threadnote graph report --output architecture-report.md
 threadnote graph export --format graphml --output code-graph.graphml
+threadnote graph checkpoint export --output threadnote-graph.cgcp
+threadnote graph checkpoint inspect --input threadnote-graph.cgcp --expected-digest sha256:…
+threadnote graph checkpoint verify --input threadnote-graph.cgcp --expected-digest sha256:…
+threadnote graph checkpoint import --input threadnote-graph.cgcp --expected-digest sha256:…
 threadnote graph index --full
 threadnote graph diagnostics --analyze
 threadnote graph repair --all --dry-run
 threadnote graph compact --dry-run
 ```
+
+Portable graph checkpoints move one deterministic, verified clean graph between local installations without a
+Threadnote account, hosted transport, or Workset. Export never overwrites a file; import requires the same repository
+and a locally available source commit, never fetches Git objects, and activates directly only at the exact clean
+commit. A dirty or descendant checkout rebuilds its current graph from the compatible imported base, while divergent
+history keeps the verified snapshot inactive. Checkpoints affect only disposable graph state, so existing schema-v1
+and uncited legacy memories remain recallable. See [portable code graph checkpoints](./docs/code-graph-checkpoints.md)
+for the digest, ABI, privacy, and publication contract.
 
 `graph status` reports physical SQLite database, WAL, and SHM bytes separately from pages in use and freelist bytes
 already reusable inside the database. A large physical file can therefore contain little live graph data without

--- a/docs/code-graph-checkpoints.md
+++ b/docs/code-graph-checkpoints.md
@@ -1,0 +1,92 @@
+# Portable code graph checkpoints
+
+Threadnote can move one verified native code graph between local installations as a file. Checkpoints are a manual,
+offline transport: they do not require a Threadnote account, a Workset, or a hosted artifact service.
+
+## Export
+
+Index the repository at a clean commit, then export to a new path:
+
+```sh
+threadnote graph index
+threadnote graph checkpoint export --output ./threadnote-graph.cgcp
+```
+
+Export accepts only the exact ready, clean root snapshot for the current `HEAD`. The repository must have a
+credential-free remote identity such as `github.com/org/repository`; local paths, remote credentials, dirty source,
+worktree identifiers, and source file contents are not embedded. Existing output files are never overwritten.
+
+The v1 artifact uses canonical JSON metadata, independently compressed deterministic chunks, and SHA-256 identities
+for the artifact, every chunk, the logical record stream, and its runtime ABI. Export reads SQLite through one
+transaction in bounded pages, verifies committed file identities against Git, and fences the repository before and
+after projection. Re-exporting the same compatible graph produces the same bytes and digest.
+
+## Inspect and verify
+
+`inspect` authenticates the exact artifact bytes against an expected digest and validates its bounded framing without
+inflating graph records:
+
+```sh
+threadnote graph checkpoint inspect \
+  --input ./threadnote-graph.cgcp \
+  --expected-digest sha256:<digest>
+```
+
+Omitting `--expected-digest` computes the artifact digest but does not establish trust in who supplied it. Use
+`verify` when the compressed records must also be inflated and checked for chunk digests, gzip integrity, canonical
+schema, global ordering, counts, coverage, and logical digest:
+
+```sh
+threadnote graph checkpoint verify \
+  --input ./threadnote-graph.cgcp \
+  --expected-digest sha256:<digest>
+```
+
+Both commands reject direct symbolic-link inputs and fail if the opened pathname identity or metadata changes.
+
+## Import
+
+Run import from a checkout of the same repository:
+
+```sh
+threadnote graph checkpoint import \
+  --input ./threadnote-graph.cgcp \
+  --expected-digest sha256:<digest>
+```
+
+Import never fetches source or executes repository code. The source commit must already exist in the receiver's local
+Git object database. Before any graph row is staged, Threadnote checks the repository identity, object format,
+case-sensitivity policy, runtime ABI, artifact and logical integrity, and every declared file against the exact local
+Git tree. A second decoding pass stages only already-verified bounded chunks, and one transaction publishes the ready
+snapshot and immutable import receipt. Interrupted or rejected imports remain unreachable.
+
+Publication depends on receiver state:
+
+| Receiver state                                 | Result                                                                   |
+| ---------------------------------------------- | ------------------------------------------------------------------------ |
+| Exact source commit and clean worktree         | Activate the imported snapshot directly                                  |
+| Exact source commit with local changes         | Build the current dirty graph, reusing the imported base when compatible |
+| Current commit descends from the source commit | Build the current graph, reusing the imported base when compatible       |
+| Divergent history                              | Keep the verified snapshot inactive for later compatible reuse           |
+
+Repeated imports reuse the same logical snapshot instead of duplicating it. An explicitly supplied digest records
+`expected-descriptor-verified` trust; a locally inspected artifact without one records `local-unverified` trust.
+
+## Compatibility and existing memories
+
+Checkpoint compatibility is explicit. The ABI binds the graph schema, checkpoint semantics, lexical format, inventory
+policy, workspace model, reference-resolution surface, and exact language-pack derivation identities. An incompatible
+runtime fails before staging rather than guessing that its rows are equivalent.
+
+Portable checkpoints affect only Threadnote's disposable native code-graph store. Existing schema-v1 memories,
+uncited legacy memories, canonical `threadnote://` URIs, recall indexing, and team memory files are neither migrated nor
+filtered by checkpoint operations. Recall continues to read those memories at coarse or unknown citation freshness.
+A Workset remains optional and is used only for explicitly prepared multi-repository evidence.
+
+## Operational boundaries
+
+- Treat the expected artifact digest like a release checksum and obtain it independently from the checkpoint file.
+- Keep the source commit locally available; import deliberately disables lazy Git fetching.
+- Checkpoints contain derived source structure and identifiers. Review their destination as you would any internal
+  architecture artifact, even though local paths, credentials, and raw source bytes are excluded.
+- Use `--json` on every checkpoint command for a versioned machine-readable receipt.

--- a/src/code_graph/analysis.ts
+++ b/src/code_graph/analysis.ts
@@ -9,6 +9,7 @@ import {
   type ResolvedCodeGraphAnalysisLimits,
 } from './analysis_configuration.js';
 import {compareCodeUnits} from './ordering.js';
+import {sanitizeCodeGraphPresentationText} from './presentation_text.js';
 import type {CodeGraphEdge, CodeGraphProvenance, CodeGraphRelation, CodeGraphSymbol} from './types.js';
 import type {
   CodeGraphAnalysisEdgeAggregate,
@@ -625,12 +626,12 @@ export const analyzeCodeGraph = Effect.fn('codeGraph.analyze')(function* (
               provenance: edge.provenance,
               relation: edge.relation,
               source: {
-                ...(edge.sourceId === undefined ? {} : {id: edge.sourceId}),
-                name: edge.sourceName,
+                ...(edge.sourceId === undefined ? {} : {id: sanitizeCodeGraphPresentationText(edge.sourceId)}),
+                name: sanitizeCodeGraphPresentationText(edge.sourceName),
               },
               target: {
-                ...(edge.targetId === undefined ? {} : {id: edge.targetId}),
-                name: edge.targetName,
+                ...(edge.targetId === undefined ? {} : {id: sanitizeCodeGraphPresentationText(edge.targetId)}),
+                name: sanitizeCodeGraphPresentationText(edge.targetName),
               },
             },
             limits.confidenceFindings,
@@ -1541,16 +1542,16 @@ function groupId(group: MutableGroup, recipe: string, prefix: string): string {
 function nodeState(symbol: CodeGraphSymbol): NodeState {
   return {
     exported: symbol.exported,
-    id: symbol.id,
+    id: sanitizeCodeGraphPresentationText(symbol.id),
     incoming: 0,
-    kind: symbol.kind,
-    language: symbol.language,
-    name: symbol.name,
+    kind: sanitizeCodeGraphPresentationText(symbol.kind),
+    language: sanitizeCodeGraphPresentationText(symbol.language),
+    name: sanitizeCodeGraphPresentationText(symbol.name),
     outgoing: 0,
-    path: symbol.path,
-    qualifiedName: symbol.qualifiedName,
+    path: sanitizeCodeGraphPresentationText(symbol.path),
+    qualifiedName: sanitizeCodeGraphPresentationText(symbol.qualifiedName),
     scope: structuralScope(symbol),
-    scopeLabel: structuralScopeLabel(symbol),
+    scopeLabel: sanitizeCodeGraphPresentationText(structuralScopeLabel(symbol)),
   };
 }
 

--- a/src/code_graph/analysis_render.ts
+++ b/src/code_graph/analysis_render.ts
@@ -4,6 +4,7 @@ import type {
   CodeGraphConfidenceAudit,
   ResolvedCodeGraphAnalysisLimits,
 } from './analysis.js';
+import {sanitizeCodeGraphPresentationValue} from './presentation_text.js';
 
 export type CodeGraphAnalysisView =
   'communities' | 'community' | 'confidence' | 'full' | 'groups' | 'hubs' | 'stats' | 'surprises';
@@ -32,6 +33,7 @@ export function renderCodeGraphAnalysis(
   view: CodeGraphAnalysisView,
   target: CodeGraphAnalysisRenderTarget = 'standalone',
 ): string {
+  result = sanitizeCodeGraphPresentationValue(result);
   const lines = [`Graph analysis: ${result.snapshot.id}`, renderCoverageSummary(result)];
   if (target === 'standalone') {
     lines.push(
@@ -54,6 +56,8 @@ export function renderCodeGraphReport(
   result: CodeGraphAnalysisResult,
   repository: {readonly displayName: string; readonly repositoryId: string},
 ): string {
+  result = sanitizeCodeGraphPresentationValue(result);
+  repository = sanitizeCodeGraphPresentationValue(repository);
   return [
     '# Code graph report',
     '',

--- a/src/code_graph/checkpoint/authority.ts
+++ b/src/code_graph/checkpoint/authority.ts
@@ -1,0 +1,165 @@
+import * as SqliteClient from '@effect/sql-sqlite-bun/SqliteClient';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {
+  codeGraphExtractorSetIdentityFromPackProvenance,
+  createCodeGraphContentIdentityAccumulator,
+} from '../graph_identity.js';
+import type {CodeGraphLanguagePackProvenance} from '../store_models.js';
+import type {
+  CodeGraphCheckpointHeaderV1,
+  CodeGraphCheckpointPackProvenanceRecordV1,
+  CodeGraphCheckpointRecordV1,
+} from './schema.js';
+import {checkpointTerminalText} from './terminal_text.js';
+
+const AUTHORITY_INSERT_ROWS = 1_000;
+const AUTHORITY_READ_ROWS = 1_000;
+
+export class CodeGraphCheckpointAuthorityError extends Error {
+  override readonly name = 'CodeGraphCheckpointAuthorityError';
+}
+
+/**
+ * Binds source identity, ABI provenance, and logical records before any target
+ * graph database is opened. A private SQLite spool preserves the product's
+ * UTF-16 inventory ordering without retaining a repository-sized file list.
+ */
+export function withCodeGraphCheckpointAuthorityVerification<A, E, R>(
+  header: CodeGraphCheckpointHeaderV1,
+  consume: (
+    accept: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, CodeGraphCheckpointAuthorityError>,
+  ) => Effect.Effect<A, E, R>,
+) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const expectedPacks = header.abi.input.languagePacks;
+      const extractorSet = codeGraphExtractorSetIdentityFromPackProvenance(expectedPacks);
+      if (extractorSet !== header.source.extractorSet) {
+        return yield* authorityFailure('Checkpoint source extractor identity does not match its ABI language packs.');
+      }
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-checkpoint-authority-'});
+      const databasePath = path.join(directory, 'authority.sqlite');
+      return yield* Layer.build(SqliteClient.layer({disableWAL: true, filename: databasePath})).pipe(
+        Effect.flatMap(sqliteContext =>
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            yield* sql.unsafe(
+              `CREATE TABLE authority_files (
+             sort_key TEXT PRIMARY KEY NOT NULL,
+             path TEXT UNIQUE NOT NULL,
+             content_hash TEXT NOT NULL,
+             language TEXT NOT NULL,
+             mode TEXT NOT NULL
+           ) WITHOUT ROWID`,
+            );
+            const remainingPacks = new Map(expectedPacks.map(pack => [pack.id, pack] as const));
+            const result = yield* sql.withTransaction(
+              consume(records =>
+                Effect.gen(function* () {
+                  const files = records.filter(record => record.kind === 'file');
+                  for (let offset = 0; offset < files.length; offset += AUTHORITY_INSERT_ROWS) {
+                    const batch = files.slice(offset, offset + AUTHORITY_INSERT_ROWS);
+                    const parameters = batch.flatMap(file => [
+                      utf16SortKey(file.path),
+                      file.path,
+                      file.contentHash,
+                      file.language,
+                      file.mode,
+                    ]);
+                    const placeholders = batch.map(() => '(?, ?, ?, ?, ?)').join(', ');
+                    yield* sql.unsafe(
+                      `INSERT INTO authority_files (sort_key, path, content_hash, language, mode) VALUES ${placeholders}`,
+                      parameters,
+                    );
+                  }
+                  for (const record of records) {
+                    if (record.kind !== 'pack-provenance') continue;
+                    const expected = remainingPacks.get(record.id);
+                    if (expected === undefined || !samePackProvenance(record, expected)) {
+                      return yield* authorityFailure(
+                        `Checkpoint pack provenance does not match its ABI declaration: ${checkpointTerminalText(record.id)}`,
+                      );
+                    }
+                    remainingPacks.delete(record.id);
+                  }
+                }).pipe(Effect.mapError(authorityError)),
+              ),
+            );
+            if (remainingPacks.size > 0) {
+              return yield* authorityFailure('Checkpoint records do not cover every ABI language pack.');
+            }
+            const accumulator = createCodeGraphContentIdentityAccumulator(extractorSet);
+            let cursor = '';
+            for (;;) {
+              const rows = yield* sql.unsafe<{
+                readonly content_hash: string;
+                readonly language: string;
+                readonly mode: string;
+                readonly path: string;
+                readonly sort_key: string;
+              }>(
+                `SELECT sort_key, path, content_hash, language, mode
+             FROM authority_files
+             WHERE sort_key > ?
+             ORDER BY sort_key
+             LIMIT ?`,
+                [cursor, AUTHORITY_READ_ROWS],
+              );
+              for (const row of rows) {
+                accumulator.update({
+                  contentHash: row.content_hash,
+                  language: row.language,
+                  mode: row.mode,
+                  path: row.path,
+                });
+              }
+              if (rows.length < AUTHORITY_READ_ROWS) break;
+              cursor = rows.at(-1)!.sort_key;
+            }
+            if (accumulator.digest() !== header.source.graphContentId) {
+              return yield* authorityFailure(
+                'Checkpoint graph content identity does not match its canonical file inventory.',
+              );
+            }
+            return result;
+          }).pipe(Effect.provide(sqliteContext)),
+        ),
+        Effect.mapError(authorityError),
+      );
+    }),
+  );
+}
+
+function samePackProvenance(
+  record: CodeGraphCheckpointPackProvenanceRecordV1,
+  expected: CodeGraphLanguagePackProvenance,
+): boolean {
+  return (
+    record.cacheIdentity === expected.cacheIdentity &&
+    record.derivationIdentity === expected.derivationIdentity &&
+    record.id === expected.id &&
+    record.resolutionDomain === expected.resolutionDomain &&
+    record.resolutionVersion === expected.resolutionVersion
+  );
+}
+
+function utf16SortKey(value: string): string {
+  let output = '';
+  for (let index = 0; index < value.length; index += 1) {
+    output += value.charCodeAt(index).toString(16).padStart(4, '0');
+  }
+  return output;
+}
+
+function authorityFailure(message: string): Effect.Effect<never, CodeGraphCheckpointAuthorityError> {
+  return Effect.fail(new CodeGraphCheckpointAuthorityError(message));
+}
+
+function authorityError(cause: unknown): CodeGraphCheckpointAuthorityError {
+  return cause instanceof CodeGraphCheckpointAuthorityError
+    ? cause
+    : new CodeGraphCheckpointAuthorityError('Checkpoint authority verification failed.', {cause});
+}

--- a/src/code_graph/checkpoint/canonical_json.ts
+++ b/src/code_graph/checkpoint/canonical_json.ts
@@ -1,0 +1,172 @@
+export type CanonicalJsonPrimitive = boolean | null | number | string;
+export interface CanonicalJsonObject {
+  readonly [key: string]: CanonicalJsonValue;
+}
+export type CanonicalJsonValue = CanonicalJsonPrimitive | readonly CanonicalJsonValue[] | CanonicalJsonObject;
+
+export interface CanonicalJsonLimits {
+  readonly maximumContainerEntries: number;
+  readonly maximumDepth: number;
+  readonly maximumInputCodeUnits: number;
+  readonly maximumStringCodeUnits: number;
+}
+
+export const DEFAULT_CANONICAL_JSON_LIMITS: CanonicalJsonLimits = {
+  maximumContainerEntries: 1_000_000,
+  maximumDepth: 64,
+  maximumInputCodeUnits: 16 * 1_048_576,
+  maximumStringCodeUnits: 8 * 1_048_576,
+};
+
+export class CanonicalJsonError extends Error {
+  override readonly name = 'CanonicalJsonError';
+}
+
+/**
+ * RFC 8785 JSON Canonicalization Scheme serialization for the I-JSON data
+ * model used by checkpoints. JavaScript's primitive serializer supplies the
+ * specified ECMAScript number and string spelling; this traversal supplies
+ * strict input validation and UTF-16 property ordering.
+ */
+export function canonicalJson(value: unknown, limits: Partial<CanonicalJsonLimits> = {}): string {
+  const resolved = resolveLimits(limits);
+  const ancestors = new Set<object>();
+  let entries = 0;
+
+  const visitString = (value: string, label: string): string => {
+    if (value.length > resolved.maximumStringCodeUnits) {
+      throw new CanonicalJsonError(`${label} exceeds the canonical JSON string limit.`);
+    }
+    ensureUnicodeScalarString(value, label);
+    return JSON.stringify(value);
+  };
+
+  const visit = (current: unknown, depth: number): string => {
+    if (depth > resolved.maximumDepth) {
+      throw new CanonicalJsonError('Canonical JSON exceeds the maximum nesting depth.');
+    }
+    if (current === null) return 'null';
+    switch (typeof current) {
+      case 'boolean':
+        return current ? 'true' : 'false';
+      case 'number':
+        if (!Number.isFinite(current)) {
+          throw new CanonicalJsonError('Canonical JSON numbers must be finite IEEE-754 values.');
+        }
+        return JSON.stringify(current);
+      case 'string':
+        return visitString(current, 'Canonical JSON string');
+      case 'object':
+        break;
+      default:
+        throw new CanonicalJsonError(`Canonical JSON does not support ${typeof current} values.`);
+    }
+
+    if (ancestors.has(current)) throw new CanonicalJsonError('Canonical JSON cannot contain cycles.');
+    ancestors.add(current);
+    try {
+      if (Array.isArray(current)) {
+        entries = checkedEntryTotal(entries, current.length, resolved.maximumContainerEntries);
+        const ownKeys = Reflect.ownKeys(current);
+        const expectedKeys = new Set<string>(['length']);
+        for (let index = 0; index < current.length; index += 1) expectedKeys.add(String(index));
+        for (const key of ownKeys) {
+          if (typeof key === 'symbol' || !expectedKeys.has(key)) {
+            throw new CanonicalJsonError('Canonical JSON arrays cannot contain extra own properties.');
+          }
+        }
+        const values: string[] = [];
+        for (let index = 0; index < current.length; index += 1) {
+          const descriptor = Object.getOwnPropertyDescriptor(current, String(index));
+          if (!descriptor?.enumerable || !('value' in descriptor)) {
+            throw new CanonicalJsonError('Canonical JSON array slots must be enumerable data properties.');
+          }
+          values.push(visit(descriptor.value, depth + 1));
+        }
+        return `[${values.join(',')}]`;
+      }
+
+      const prototype = Object.getPrototypeOf(current);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new CanonicalJsonError('Canonical JSON objects must have a plain or null prototype.');
+      }
+      const ownKeys = Reflect.ownKeys(current);
+      if (ownKeys.some(key => typeof key === 'symbol')) {
+        throw new CanonicalJsonError('Canonical JSON objects cannot contain symbol keys.');
+      }
+      const keys = ownKeys as string[];
+      entries = checkedEntryTotal(entries, keys.length, resolved.maximumContainerEntries);
+      const object = current as Record<string, unknown>;
+      const properties: string[] = [];
+      for (const key of keys.sort(compareCodeUnits)) {
+        const descriptor = Object.getOwnPropertyDescriptor(object, key);
+        if (!descriptor?.enumerable || !('value' in descriptor)) {
+          throw new CanonicalJsonError('Canonical JSON objects may contain only enumerable data properties.');
+        }
+        properties.push(`${visitString(key, 'Canonical JSON property name')}:${visit(descriptor.value, depth + 1)}`);
+      }
+      return `{${properties.join(',')}}`;
+    } finally {
+      ancestors.delete(current);
+    }
+  };
+
+  const rendered = visit(value, 0);
+  if (rendered.length > resolved.maximumInputCodeUnits) {
+    throw new CanonicalJsonError('Canonical JSON output exceeds the input limit.');
+  }
+  return rendered;
+}
+
+/** Parse only the single RFC 8785 spelling accepted by {@link canonicalJson}. */
+export function parseCanonicalJson(value: string, limits: Partial<CanonicalJsonLimits> = {}): CanonicalJsonValue {
+  const resolved = resolveLimits(limits);
+  if (value.length > resolved.maximumInputCodeUnits) {
+    throw new CanonicalJsonError('Canonical JSON input exceeds the input limit.');
+  }
+  ensureUnicodeScalarString(value, 'Canonical JSON input');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value) as unknown;
+  } catch (cause) {
+    throw new CanonicalJsonError(cause instanceof Error ? cause.message : 'Canonical JSON is malformed.');
+  }
+  const rendered = canonicalJson(parsed, resolved);
+  if (rendered !== value) throw new CanonicalJsonError('JSON input is not in RFC 8785 canonical form.');
+  return parsed as CanonicalJsonValue;
+}
+
+function resolveLimits(overrides: Partial<CanonicalJsonLimits>): CanonicalJsonLimits {
+  const limits = {...DEFAULT_CANONICAL_JSON_LIMITS, ...overrides};
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new CanonicalJsonError(`${name} must be a non-negative safe integer.`);
+    }
+  }
+  return limits;
+}
+
+function checkedEntryTotal(current: number, added: number, maximum: number): number {
+  if (added > maximum - current) {
+    throw new CanonicalJsonError('Canonical JSON contains too many container entries.');
+  }
+  return current + added;
+}
+
+function ensureUnicodeScalarString(value: string, label: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      if (index + 1 >= value.length) throw new CanonicalJsonError(`${label} contains a lone surrogate.`);
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) throw new CanonicalJsonError(`${label} contains a lone surrogate.`);
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      throw new CanonicalJsonError(`${label} contains a lone surrogate.`);
+    }
+  }
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/src/code_graph/checkpoint/commands.ts
+++ b/src/code_graph/checkpoint/commands.ts
@@ -1,0 +1,926 @@
+import {Console, Crypto, Effect, FileSystem, Option, Path} from 'effect';
+import {sha256HexSync} from '../../crypto/sha256.js';
+import {runBinaryCommandEffect, runCommandEffect} from '../../effect/command.js';
+import {writeFinalCliOutput} from '../../effect/cli_output.js';
+import {SystemInfo} from '../../effect/system.js';
+import type {RuntimeConfig} from '../../types.js';
+import {codeGraphCommittedContentHash} from '../content_identity.js';
+import {CodeGraphIndexer, codeGraphDirectPersistentCapacityProtector} from '../indexer.js';
+import {withCodeGraphProcessLock} from '../indexer_build.js';
+import type {DirectPersistentCapacityProtection} from '../indexer_types.js';
+import {CodeGraphLanguagePackRegistry, type CodeGraphLanguagePackRegistryShape} from '../languages/registry.js';
+import {codeGraphLayout} from '../layout.js';
+import {CodeGraphMaintenanceCoordinator} from '../maintenance_coordinator.js';
+import {
+  observeCleanRepositoryWorktree,
+  resolveRepositoryIdentity,
+  revalidateRepositoryIdentityFence,
+} from '../repository.js';
+import {
+  CodeGraphStore,
+  hydrateCodeGraphCheckpointReusableBaseReceipt,
+  type CodeGraphCheckpointImportReceiptInput,
+} from '../store.js';
+import {CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION} from '../store/schema_revision.js';
+import type {CodeGraphSnapshot, RepositoryIdentity} from '../types.js';
+import {codeGraphCheckpointAbiInputV1, inspectCodeGraphCheckpointCompatibilityV1} from './compatibility.js';
+import {withCodeGraphCheckpointAuthorityVerification} from './authority.js';
+import {
+  CODE_GRAPH_CHECKPOINT_PRELUDE_BYTES,
+  CODE_GRAPH_CHECKPOINT_CHUNK_FRAME_HEADER_BYTES,
+  CodeGraphCheckpointArtifactWriterV1,
+  CodeGraphCheckpointStreamDecoderV1,
+  CodeGraphCheckpointStreamEncoderV1,
+  CodeGraphCheckpointStreamInspectorV1,
+  codeGraphCheckpointReadPlanV1,
+  type CodeGraphCheckpointInspectionV1,
+  type CodeGraphCheckpointPreparedPackV1,
+  type CodeGraphCheckpointVerifiedChunkV1,
+} from './pack.js';
+import {codeGraphCheckpointGitPathBatches, parseGitTreeEntries, projectCodeGraphCheckpointV1} from './projection.js';
+import {
+  CODE_GRAPH_CHECKPOINT_MEDIA_TYPE,
+  type CodeGraphCheckpointDescriptorV1,
+  type CodeGraphCheckpointFileRecordV1,
+  type CodeGraphCheckpointHeaderV1,
+  type CodeGraphCheckpointSha256,
+} from './schema.js';
+import {checkpointTerminalText} from './terminal_text.js';
+
+const CHECKPOINT_IO_CHUNK_BYTES = 64 * 1_024;
+const CHECKPOINT_GIT_OUTPUT_BYTES_MAXIMUM = 16 * 1_024 * 1_024;
+const CHECKPOINT_GIT_TREE_FORMAT = '%(objectmode)%x09%(objecttype)%x09%(objectname)%x09%(objectsize)%x09%(path)';
+const CHECKPOINT_SNAPSHOT_DOMAIN = 'threadnote-code-graph-checkpoint-local-snapshot-v1\0';
+
+export class CodeGraphCheckpointCommandError extends Error {
+  override readonly name = 'CodeGraphCheckpointCommandError';
+}
+
+export interface CodeGraphCheckpointArtifactOptions {
+  readonly expectedDigest?: string;
+  readonly input: string;
+  readonly json?: boolean;
+}
+
+export interface CodeGraphCheckpointExportOptions {
+  readonly cwd?: string;
+  readonly json?: boolean;
+  readonly output: string;
+}
+
+export interface CodeGraphCheckpointImportOptions extends CodeGraphCheckpointArtifactOptions {
+  readonly cwd?: string;
+}
+
+export interface CodeGraphCheckpointImportResultV1 {
+  readonly artifact: CodeGraphCheckpointDescriptorV1;
+  readonly imported: 'created' | 'reused';
+  readonly logicalDigest: string;
+  readonly publication: 'activated' | 'rebuilt' | 'stored';
+  readonly snapshotId: string;
+  readonly trust: CodeGraphCheckpointImportReceiptInput['trust'];
+  readonly type: 'code-graph-checkpoint-import';
+  readonly version: 1;
+}
+
+interface OpenCheckpointInput {
+  readonly assertUnchanged: () => Effect.Effect<void, CodeGraphCheckpointCommandError>;
+  readonly file: FileSystem.File;
+  readonly path: string;
+  readonly size: number;
+}
+
+interface OwnedFileIdentity {
+  readonly birthtimeMilliseconds: number;
+  readonly dev: number;
+  readonly ino: number;
+  readonly mode: number;
+  readonly modifiedAtMilliseconds: number;
+  readonly size: bigint;
+}
+
+export const runCodeGraphCheckpointInspect = Effect.fn('codeGraph.checkpoint.inspect')(function* (
+  options: CodeGraphCheckpointArtifactOptions,
+) {
+  const inspection = yield* withCheckpointInput(options.input, input => inspectCheckpointInput(input, options));
+  const result = {type: 'code-graph-checkpoint-inspection' as const, version: 1 as const, ...inspection};
+  if (options.json) {
+    yield* writeFinalCliOutput(JSON.stringify(result));
+    return result;
+  }
+  yield* Console.log(
+    `Checkpoint ${inspection.descriptor.digest} · ${inspection.descriptor.size} bytes · ` +
+      `${inspection.header.chunks.length} chunk(s) · ${checkpointRecordTotal(inspection.header)} record(s).`,
+  );
+  yield* Console.log(
+    `Source ${checkpointTerminalText(inspection.header.repository.displayName)} at ${inspection.header.source.commit}; ` +
+      `logical sha256:${inspection.header.logical.digest}.`,
+  );
+  return result;
+});
+
+export const runCodeGraphCheckpointVerify = Effect.fn('codeGraph.checkpoint.verify')(function* (
+  options: CodeGraphCheckpointArtifactOptions,
+) {
+  const result = yield* withCheckpointInput(options.input, input =>
+    Effect.gen(function* () {
+      const inspection = yield* inspectCheckpointInput(input, options);
+      const verification = yield* withCodeGraphCheckpointAuthorityVerification(inspection.header, accept =>
+        decodeCheckpointInput(input, inspection, chunk => accept(chunk.records)),
+      );
+      return {type: 'code-graph-checkpoint-verification' as const, version: 1 as const, ...verification};
+    }),
+  );
+  if (options.json) {
+    yield* writeFinalCliOutput(JSON.stringify(result));
+    return result;
+  }
+  yield* Console.log(
+    `Verified ${result.descriptor.digest} · ${result.header.chunks.length} chunk(s) · ` +
+      `${checkpointRecordTotal(result.header)} canonical record(s).`,
+  );
+  return result;
+});
+
+export const runCodeGraphCheckpointExport = Effect.fn('codeGraph.checkpoint.export')(function* (
+  config: RuntimeConfig,
+  options: CodeGraphCheckpointExportOptions,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const crypto = yield* Crypto.Crypto;
+  const cwd = yield* checkpointCommandCwd(options.cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  const layout = codeGraphLayout(path, config.agentContextHome, identity.checkoutId, identity.worktreeId);
+  const store = yield* CodeGraphStore;
+  const snapshot = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+  if (
+    snapshot === undefined ||
+    snapshot.state !== 'ready' ||
+    snapshot.dirty ||
+    snapshot.commit !== identity.headCommit ||
+    snapshot.graphContentId === undefined ||
+    (yield* observeCleanRepositoryWorktree(identity.repoRoot)) === undefined
+  ) {
+    return yield* checkpointFailure(
+      'Checkpoint export requires an exact clean ready root for the current commit. Run `threadnote graph index` after cleaning the worktree.',
+    );
+  }
+  const provenance = yield* store.snapshotPackProvenance(layout.databasePath, snapshot.id);
+  if (provenance === undefined) {
+    return yield* checkpointFailure('The ready graph has no complete language-pack provenance receipt.');
+  }
+  const output = path.resolve(options.output);
+  if (yield* fs.exists(output)) return yield* checkpointFailure(`Checkpoint output already exists: ${output}`);
+  const parent = path.dirname(output);
+  yield* fs.makeDirectory(parent, {recursive: true});
+  const spoolPath = path.join(parent, `.${path.basename(output)}.${yield* crypto.randomUUIDv4}.spool`);
+  const artifact = yield* withPrivateSpool(spoolPath, spool =>
+    Effect.gen(function* () {
+      let encoder: CodeGraphCheckpointStreamEncoderV1 | undefined;
+      yield* projectCodeGraphCheckpointV1({
+        abi: codeGraphCheckpointAbiInputV1(provenance),
+        databasePath: layout.databasePath,
+        identity,
+        snapshotId: snapshot.id,
+        writeMetadata: metadata =>
+          Effect.sync(() => {
+            if (encoder !== undefined)
+              throw new CodeGraphCheckpointCommandError('Checkpoint metadata was emitted twice.');
+            encoder = new CodeGraphCheckpointStreamEncoderV1(metadata);
+          }),
+        writeRecords: records =>
+          Effect.gen(function* () {
+            if (encoder === undefined) {
+              return yield* checkpointFailure('Checkpoint records were emitted before metadata.');
+            }
+            for (const record of records) {
+              const emitted: Uint8Array[] = [];
+              yield* attemptCheckpoint(() =>
+                encoder!.write([record], chunk => {
+                  if (emitted.length > 0) {
+                    throw new CodeGraphCheckpointCommandError(
+                      'Checkpoint encoder emitted more than one chunk for one record.',
+                    );
+                  }
+                  emitted.push(chunk.bytes);
+                }),
+              );
+              if (emitted[0] !== undefined) yield* spool.file.writeAll(emitted[0]);
+            }
+          }),
+      });
+      if (encoder === undefined) return yield* checkpointFailure('Checkpoint projection did not emit metadata.');
+      const finishedEncoder = encoder as CodeGraphCheckpointStreamEncoderV1;
+      const finalChunks: Uint8Array[] = [];
+      const prepared = yield* attemptCheckpoint(() => finishedEncoder.finish(chunk => finalChunks.push(chunk.bytes)));
+      if (finalChunks.length > 1) return yield* checkpointFailure('Checkpoint encoder emitted an invalid final spool.');
+      if (finalChunks[0] !== undefined) yield* spool.file.writeAll(finalChunks[0]);
+      yield* spool.file.sync;
+      return yield* publishPreparedCheckpoint(fs, path, output, prepared, spool);
+    }),
+  );
+  const result = {
+    artifact: artifact.descriptor,
+    logicalDigest: artifact.header.logical.digest,
+    output,
+    sourceCommit: artifact.header.source.commit,
+    type: 'code-graph-checkpoint-export' as const,
+    version: 1 as const,
+  };
+  if (options.json) yield* writeFinalCliOutput(JSON.stringify(result));
+  else yield* Console.log(`Exported code graph checkpoint ${artifact.descriptor.digest}: ${output}`);
+  return result;
+});
+
+export const runCodeGraphCheckpointImport = Effect.fn('codeGraph.checkpoint.import')(function* (
+  config: RuntimeConfig,
+  options: CodeGraphCheckpointImportOptions,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const crypto = yield* Crypto.Crypto;
+  const system = yield* SystemInfo;
+  const store = yield* CodeGraphStore;
+  const indexer = yield* CodeGraphIndexer;
+  const registry = yield* CodeGraphLanguagePackRegistry;
+  const maintenance = yield* CodeGraphMaintenanceCoordinator;
+  const cwd = yield* checkpointCommandCwd(options.cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  const layout = codeGraphLayout(path, config.agentContextHome, identity.checkoutId, identity.worktreeId);
+  const validated = yield* withCheckpointInput(options.input, input =>
+    Effect.gen(function* () {
+      const inspection = yield* inspectCheckpointInput(input, options);
+      validateCheckpointReceiver(inspection.header, identity, registry);
+      yield* requireCheckpointCommit(identity, inspection.header.source.commit);
+      const attribution = checkpointAttributionRecordVerifier(inspection.header);
+      yield* withCodeGraphCheckpointAuthorityVerification(inspection.header, accept =>
+        decodeCheckpointInput(input, inspection, chunk =>
+          verifyCheckpointFiles(identity, inspection.header.source.commit, chunk).pipe(
+            Effect.andThen(attribution.accept(chunk)),
+            Effect.andThen(accept(chunk.records)),
+          ),
+        ),
+      );
+      yield* attribution.finish;
+      return {input, inspection};
+    }),
+  );
+  const receipt = checkpointImportReceipt(validated.inspection, options.expectedDigest !== undefined);
+  const reusableBaseReceipt = yield* hydrateCodeGraphCheckpointReusableBaseReceipt(
+    identity,
+    validated.inspection.header,
+  );
+  const snapshotId = checkpointSnapshotId(validated.inspection.header);
+  const building = checkpointBuildingSnapshot(snapshotId, identity, validated.inspection.header);
+  const capacityProtection: DirectPersistentCapacityProtection = {
+    availableDiskBytes: target => system.availableDiskBytes(target),
+    crypto,
+    maintenance,
+    path,
+    system,
+    temporaryDirectory: system.tempDirectory,
+    walAutoCheckpointPages: 1_000,
+  };
+  const persistentCapacityProtector = codeGraphDirectPersistentCapacityProtector({
+    capacityProtection,
+    fs,
+    identity,
+    layout,
+    threadnoteHome: config.agentContextHome,
+  });
+  const imported = yield* withCodeGraphProcessLock(
+    fs,
+    layout.lockPath,
+    () => Effect.void,
+    'checkpoint-import',
+    Effect.gen(function* () {
+      const reusable = yield* store.readySnapshotByLogicalDigest(
+        layout.databasePath,
+        identity.repositoryId,
+        validated.inspection.header.logical.digest,
+        validated.inspection.header.abi.digest,
+      );
+      if (reusable !== undefined) return {mode: 'reused' as const, snapshot: reusable};
+      const ownerToken = yield* store.claimPersistentBuild(layout.databasePath, identity, building, {
+        logicalSnapshotId: snapshotId,
+        owner: {buildId: yield* crypto.randomUUIDv4, processId: system.processId},
+      });
+      const imported = Effect.gen(function* () {
+        yield* store.bindCheckpointImportBuild(layout.databasePath, snapshotId, {
+          ...receipt,
+          batchCount: validated.inspection.header.chunks.length,
+          packProvenance: validated.inspection.header.abi.input.languagePacks,
+          recordCounts: validated.inspection.header.counts,
+        });
+        yield* withCheckpointInput(validated.input.path, input =>
+          Effect.gen(function* () {
+            if (input.size !== validated.input.size) {
+              return yield* checkpointFailure('Checkpoint input changed before staging.');
+            }
+            yield* decodeCheckpointInput(input, validated.inspection, chunk =>
+              store
+                .stageCheckpointImportRecordPage(layout.databasePath, snapshotId, ownerToken, {
+                  batchIndex: chunk.descriptor.ordinal,
+                  digest: chunk.descriptor.digest,
+                  records: chunk.records,
+                })
+                .pipe(Effect.asVoid),
+            );
+          }),
+        );
+        yield* store.finalizeCheckpointImport(layout.databasePath, identity, building, ownerToken, receipt, {
+          persistentCapacityProtector,
+          ...(reusableBaseReceipt === undefined ? {} : {reusableBaseReceipt}),
+        });
+        const ready = yield* store.readySnapshotById(layout.databasePath, snapshotId);
+        if (ready === undefined || ready.state !== 'ready') {
+          return yield* checkpointFailure('Checkpoint import completed without an exact ready snapshot.');
+        }
+        return {mode: 'created' as const, snapshot: ready};
+      }).pipe(
+        Effect.onError(() =>
+          store
+            .markFailed(layout.databasePath, snapshotId, 'Checkpoint import did not complete.', ownerToken)
+            .pipe(Effect.ignore),
+        ),
+      );
+      return yield* imported;
+    }),
+  );
+  const publication = yield* publishImportedCheckpoint(config, cwd, identity, layout.databasePath, imported.snapshot);
+  const result: CodeGraphCheckpointImportResultV1 = {
+    artifact: validated.inspection.descriptor,
+    imported: imported.mode,
+    logicalDigest: validated.inspection.header.logical.digest,
+    publication: publication.state,
+    snapshotId: publication.snapshotId,
+    trust: receipt.trust,
+    type: 'code-graph-checkpoint-import',
+    version: 1,
+  };
+  if (options.json) yield* writeFinalCliOutput(JSON.stringify(result));
+  else {
+    const action = imported.mode === 'created' ? 'Imported' : 'Reused';
+    yield* Console.log(
+      `${action} code graph checkpoint ${validated.inspection.descriptor.digest}; ` +
+        `${publicationMessage(publication.state)} (${publication.snapshotId}).`,
+    );
+  }
+  return result;
+
+  function publishImportedCheckpoint(
+    runtimeConfig: RuntimeConfig,
+    targetCwd: string,
+    initialIdentity: RepositoryIdentity,
+    databasePath: string,
+    snapshot: CodeGraphSnapshot,
+  ) {
+    return Effect.gen(function* () {
+      const closingIdentity = yield* revalidateRepositoryIdentityFence(targetCwd, initialIdentity);
+      const clean = yield* observeCleanRepositoryWorktree(closingIdentity.repoRoot);
+      if (closingIdentity.headCommit === snapshot.commit && clean !== undefined) {
+        return yield* withCodeGraphProcessLock(
+          fs,
+          layout.lockPath,
+          () => Effect.void,
+          'checkpoint-promote',
+          Effect.gen(function* () {
+            const finalIdentity = yield* revalidateRepositoryIdentityFence(targetCwd, closingIdentity);
+            if (
+              finalIdentity.headCommit !== snapshot.commit ||
+              (yield* observeCleanRepositoryWorktree(finalIdentity.repoRoot)) === undefined
+            ) {
+              return {snapshotId: snapshot.id, state: 'stored' as const};
+            }
+            yield* store.promote(databasePath, finalIdentity, snapshot.id, {persistentCapacityProtector});
+            return {snapshotId: snapshot.id, state: 'activated' as const};
+          }),
+        );
+      }
+      const ancestor = yield* checkpointCommitIsAncestor(closingIdentity, snapshot.commit, closingIdentity.headCommit);
+      if (closingIdentity.headCommit === snapshot.commit || ancestor) {
+        const summary = yield* indexer.index({
+          cwd: targetCwd,
+          ensureVectors: false,
+          threadnoteHome: runtimeConfig.agentContextHome,
+        });
+        return {snapshotId: summary.snapshot.id, state: 'rebuilt' as const};
+      }
+      return {snapshotId: snapshot.id, state: 'stored' as const};
+    });
+  }
+});
+
+function inspectCheckpointInput(
+  input: OpenCheckpointInput,
+  options: Pick<CodeGraphCheckpointArtifactOptions, 'expectedDigest'>,
+) {
+  return Effect.gen(function* () {
+    const expectedDigest = yield* parseExpectedDigest(options.expectedDigest);
+    const inspector = yield* attemptCheckpoint(() => new CodeGraphCheckpointStreamInspectorV1({expectedDigest}));
+    yield* consumeCheckpointInput(input, bytes => attemptCheckpoint(() => inspector.push(bytes)));
+    const inspection = yield* attemptCheckpoint(() => inspector.finish());
+    if (inspection.descriptor.size !== input.size) {
+      return yield* checkpointFailure('Checkpoint descriptor does not match the opened input size.');
+    }
+    yield* input.assertUnchanged();
+    return inspection;
+  });
+}
+
+function decodeCheckpointInput<E, R>(
+  input: OpenCheckpointInput,
+  inspection: CodeGraphCheckpointInspectionV1,
+  onChunk: (chunk: CodeGraphCheckpointVerifiedChunkV1) => Effect.Effect<void, E, R>,
+) {
+  return Effect.gen(function* () {
+    const plan = yield* attemptCheckpoint(() => codeGraphCheckpointReadPlanV1(inspection.header));
+    const verifiedChunks: CodeGraphCheckpointVerifiedChunkV1[] = [];
+    const decoder = yield* attemptCheckpoint(
+      () =>
+        new CodeGraphCheckpointStreamDecoderV1({
+          expectedDescriptor: inspection.descriptor,
+          onVerifiedChunk: chunk => {
+            if (verifiedChunks.length > 0) {
+              throw new CodeGraphCheckpointCommandError('Checkpoint decoder emitted more than one chunk per frame.');
+            }
+            verifiedChunks.push(chunk);
+          },
+        }),
+    );
+    yield* input.file.seek(0, 'start');
+    yield* readCheckpointPart(input.file, plan.prefixBytes).pipe(
+      Effect.flatMap(bytes => attemptCheckpoint(() => decoder.push(bytes))),
+    );
+    for (const frame of plan.chunks) {
+      verifiedChunks.length = 0;
+      const bytes = yield* readCheckpointPart(input.file, frame.frameBytes);
+      yield* attemptCheckpoint(() => decoder.push(bytes));
+      const chunk = verifiedChunks[0];
+      if (verifiedChunks.length !== 1 || chunk === undefined || chunk.descriptor.ordinal !== frame.ordinal) {
+        return yield* checkpointFailure('Checkpoint decoder did not verify the expected chunk frame.');
+      }
+      yield* onChunk(chunk);
+    }
+    yield* requireCheckpointEof(input.file);
+    const verification = yield* attemptCheckpoint(() => decoder.finish());
+    yield* input.assertUnchanged();
+    return verification;
+  });
+}
+
+function verifyCheckpointFiles(
+  identity: RepositoryIdentity,
+  commit: string,
+  chunk: CodeGraphCheckpointVerifiedChunkV1,
+) {
+  return Effect.gen(function* () {
+    const files = chunk.records.filter((record): record is CodeGraphCheckpointFileRecordV1 => record.kind === 'file');
+    if (files.length === 0) return;
+    const system = yield* SystemInfo;
+    for (const batch of codeGraphCheckpointGitPathBatches(files)) {
+      const result = yield* runBinaryCommandEffect(
+        'git',
+        [
+          '-C',
+          identity.repoRoot,
+          'ls-tree',
+          '-z',
+          '--full-tree',
+          `--format=${CHECKPOINT_GIT_TREE_FORMAT}`,
+          commit,
+          '--',
+          ...batch.map(file => file.path),
+        ],
+        {
+          env: {...system.environment(), GIT_LITERAL_PATHSPECS: '1', GIT_NO_LAZY_FETCH: '1'},
+          maxOutputBytes: CHECKPOINT_GIT_OUTPUT_BYTES_MAXIMUM,
+          timeoutMs: 30_000,
+        },
+      );
+      const entries = yield* attemptCheckpoint(() => parseGitTreeEntries(result.stdout, identity.objectFormat));
+      if (entries.size !== batch.length) {
+        return yield* checkpointFailure('Checkpoint file identities are incomplete in the local source commit.');
+      }
+      for (const file of batch) {
+        const entry = entries.get(file.path);
+        if (
+          entry === undefined ||
+          entry.blobId !== file.blobId ||
+          entry.mode !== file.mode ||
+          entry.size !== file.size ||
+          codeGraphCommittedContentHash(identity.objectFormat, entry.blobId) !== file.contentHash
+        ) {
+          return yield* checkpointFailure('Checkpoint file identity does not match the local source commit.');
+        }
+      }
+    }
+  });
+}
+
+/**
+ * Reuse context is executable graph input on a later incremental build. Bind
+ * every portable attribution tuple to the checkpoint's already Git-verified
+ * file record instead of trusting header-only blob claims.
+ */
+function checkpointAttributionRecordVerifier(header: CodeGraphCheckpointHeaderV1) {
+  const remaining = new Map((header.reuse?.inventory?.attributionFiles ?? []).map(file => [file.path, file] as const));
+  return {
+    accept: (chunk: CodeGraphCheckpointVerifiedChunkV1) =>
+      Effect.gen(function* () {
+        for (const record of chunk.records) {
+          if (record.kind !== 'file') continue;
+          const expected = remaining.get(record.path);
+          if (expected === undefined) continue;
+          if (
+            record.blobId !== expected.blobId ||
+            record.size !== expected.blobSize ||
+            record.contentHash !== expected.contentHash ||
+            record.language !== expected.language ||
+            record.mode !== expected.mode ||
+            record.source !== expected.source
+          ) {
+            return yield* checkpointFailure(
+              `Checkpoint attribution context does not match its file record: ${record.path}`,
+            );
+          }
+          remaining.delete(record.path);
+        }
+      }),
+    finish: Effect.suspend(() =>
+      remaining.size === 0
+        ? Effect.void
+        : checkpointFailure('Checkpoint attribution context is not covered by exact graph file records.'),
+    ),
+  };
+}
+
+function validateCheckpointReceiver(
+  header: CodeGraphCheckpointHeaderV1,
+  identity: RepositoryIdentity,
+  registry: CodeGraphLanguagePackRegistryShape,
+): void {
+  if (
+    header.repository.repositoryId !== identity.repositoryId ||
+    header.repository.objectFormat !== identity.objectFormat ||
+    header.repository.caseMode !== identity.caseMode
+  ) {
+    throw new CodeGraphCheckpointCommandError('Checkpoint repository identity does not match this checkout.');
+  }
+  const compatibility = inspectCodeGraphCheckpointCompatibilityV1(header.abi.input, registry);
+  if (!compatibility.compatible) {
+    const detail =
+      compatibility.code === 'language-pack-unavailable'
+        ? ` Missing packs: ${checkpointTerminalText(compatibility.unavailablePackIds?.join(', ') ?? 'unknown')}.`
+        : '';
+    throw new CodeGraphCheckpointCommandError(`Checkpoint runtime ABI is incompatible.${detail}`);
+  }
+}
+
+function requireCheckpointCommit(identity: RepositoryIdentity, commit: string) {
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    const result = yield* runCommandEffect('git', ['-C', identity.repoRoot, 'cat-file', '-e', `${commit}^{commit}`], {
+      allowFailure: true,
+      env: {...system.environment(), GIT_NO_LAZY_FETCH: '1', GIT_OPTIONAL_LOCKS: '0'},
+      maxOutputBytes: 4_096,
+      timeoutMs: 10_000,
+    });
+    if (result.exitCode !== 0) {
+      return yield* checkpointFailure('Checkpoint source commit is not available in the local Git object database.');
+    }
+  });
+}
+
+function checkpointCommitIsAncestor(identity: RepositoryIdentity, ancestor: string, descendant: string) {
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    const result = yield* runCommandEffect(
+      'git',
+      ['-C', identity.repoRoot, 'merge-base', '--is-ancestor', ancestor, descendant],
+      {
+        allowFailure: true,
+        env: {...system.environment(), GIT_NO_LAZY_FETCH: '1', GIT_OPTIONAL_LOCKS: '0'},
+        maxOutputBytes: 4_096,
+        timeoutMs: 10_000,
+      },
+    );
+    if (result.exitCode === 0) return true;
+    if (result.exitCode === 1) return false;
+    return yield* checkpointFailure('Checkpoint source ancestry could not be established locally.');
+  });
+}
+
+function checkpointImportReceipt(
+  inspection: CodeGraphCheckpointInspectionV1,
+  expectedDigestSupplied: boolean,
+): CodeGraphCheckpointImportReceiptInput {
+  return {
+    abi: {algorithm: 'sha256', digest: inspection.header.abi.digest},
+    artifact: {
+      algorithm: 'sha256',
+      digest: inspection.descriptor.digest.slice('sha256:'.length),
+      mediaType: CODE_GRAPH_CHECKPOINT_MEDIA_TYPE,
+      size: inspection.descriptor.size,
+    },
+    baseLogicalDigest: null,
+    coverage: inspection.header.coverage,
+    formatVersion: CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION,
+    logical: inspection.header.logical,
+    source: {
+      commit: inspection.header.source.commit,
+      graphContentId: inspection.header.source.graphContentId,
+      repositoryId: inspection.header.repository.repositoryId,
+    },
+    trust: expectedDigestSupplied ? 'expected-descriptor-verified' : 'local-unverified',
+  };
+}
+
+function checkpointSnapshotId(header: CodeGraphCheckpointHeaderV1): string {
+  return `cgsn_${sha256HexSync(
+    `${CHECKPOINT_SNAPSHOT_DOMAIN}${header.repository.repositoryId}\0${header.source.commit}\0${header.logical.digest}`,
+  ).slice(0, 40)}`;
+}
+
+function checkpointBuildingSnapshot(
+  id: string,
+  identity: RepositoryIdentity,
+  header: CodeGraphCheckpointHeaderV1,
+): CodeGraphSnapshot {
+  return {
+    commit: header.source.commit,
+    dirty: false,
+    edgeCount: header.counts.edge,
+    extractorSet: header.source.extractorSet,
+    fileCount: header.counts.file,
+    graphContentId: header.source.graphContentId,
+    id,
+    repositoryId: identity.repositoryId,
+    state: 'building',
+    symbolCount: header.counts.symbol,
+    worktreeId: identity.worktreeId,
+  };
+}
+
+function withCheckpointInput<A, E, R>(
+  inputPath: string,
+  use: (input: OpenCheckpointInput) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | CodeGraphCheckpointCommandError, R | FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const resolved = path.resolve(inputPath);
+    if (Option.isSome(yield* fs.readLink(resolved).pipe(Effect.option))) {
+      return yield* checkpointFailure('Checkpoint input must not be a symbolic link.');
+    }
+    const initial = yield* requireOwnedFileIdentity(yield* fs.stat(resolved), 'Checkpoint input');
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const file = yield* fs.open(resolved, {flag: 'r'});
+        const opened = yield* requireOwnedFileIdentity(yield* file.stat, 'Opened checkpoint input');
+        const pathOpened = yield* requireOwnedFileIdentity(yield* fs.stat(resolved), 'Checkpoint input');
+        if (!sameOwnedFile(initial, opened) || !sameOwnedFile(initial, pathOpened)) {
+          return yield* checkpointFailure('Checkpoint input changed while it was opened.');
+        }
+        const size = Number(initial.size);
+        if (!Number.isSafeInteger(size) || size < CODE_GRAPH_CHECKPOINT_PRELUDE_BYTES) {
+          return yield* checkpointFailure('Checkpoint input size is invalid.');
+        }
+        const assertUnchanged = () =>
+          Effect.gen(function* () {
+            if (Option.isSome(yield* fs.readLink(resolved).pipe(Effect.option))) {
+              return yield* checkpointFailure('Checkpoint input changed into a symbolic link.');
+            }
+            const descriptor = yield* requireOwnedFileIdentity(yield* file.stat, 'Opened checkpoint input');
+            const pathname = yield* requireOwnedFileIdentity(yield* fs.stat(resolved), 'Checkpoint input');
+            if (!sameOwnedFile(initial, descriptor) || !sameOwnedFile(initial, pathname)) {
+              return yield* checkpointFailure('Checkpoint input changed during verification.');
+            }
+          }).pipe(
+            Effect.mapError(cause => checkpointCommandError('Checkpoint input changed during verification.', cause)),
+          );
+        return yield* use({assertUnchanged, file, path: resolved, size});
+      }),
+    );
+  }).pipe(Effect.mapError(cause => checkpointCommandError('Checkpoint input could not be read.', cause)));
+}
+
+function consumeCheckpointInput(
+  input: OpenCheckpointInput,
+  accept: (bytes: Uint8Array) => Effect.Effect<void, CodeGraphCheckpointCommandError>,
+) {
+  return Effect.gen(function* () {
+    yield* input.file.seek(0, 'start');
+    let remaining = input.size;
+    while (remaining > 0) {
+      const bytes = yield* readCheckpointPart(input.file, Math.min(remaining, CHECKPOINT_IO_CHUNK_BYTES));
+      remaining -= bytes.byteLength;
+      yield* accept(bytes);
+    }
+    yield* requireCheckpointEof(input.file);
+  });
+}
+
+function readCheckpointPart(file: FileSystem.File, length: number) {
+  return Effect.gen(function* () {
+    const bytes = new Uint8Array(length);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const read = Number(yield* file.read(bytes.subarray(offset)));
+      if (!Number.isSafeInteger(read) || read <= 0 || read > bytes.byteLength - offset) {
+        return yield* checkpointFailure('Checkpoint input ended before its declared framing.');
+      }
+      offset += read;
+    }
+    return bytes;
+  });
+}
+
+function requireCheckpointEof(file: FileSystem.File) {
+  return Effect.gen(function* () {
+    const extra = new Uint8Array(1);
+    if (Number(yield* file.read(extra)) !== 0) {
+      return yield* checkpointFailure('Checkpoint input has trailing bytes.');
+    }
+  });
+}
+
+function parseExpectedDigest(value: string | undefined) {
+  if (value === undefined) return Effect.succeed(undefined);
+  const normalized = value.trim().toLowerCase();
+  const prefixed = normalized.startsWith('sha256:') ? normalized : `sha256:${normalized}`;
+  return /^sha256:[0-9a-f]{64}$/u.test(prefixed)
+    ? Effect.succeed(prefixed as CodeGraphCheckpointSha256)
+    : checkpointFailure('--expected-digest must be a lowercase SHA-256 digest.');
+}
+
+function withPrivateSpool<A, E, R>(
+  spoolPath: string,
+  use: (spool: {readonly file: FileSystem.File}) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | CodeGraphCheckpointCommandError, R | FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const file = yield* fs.open(spoolPath, {flag: 'wx+', mode: 0o600});
+        const identity = yield* requireOwnedFileIdentity(yield* file.stat, 'Checkpoint spool');
+        yield* verifyOwnedPath(fs, spoolPath, identity, 'Checkpoint spool');
+        return yield* use({file}).pipe(Effect.ensuring(removeOwnedPath(fs, spoolPath, identity)));
+      }),
+    );
+  }).pipe(Effect.mapError(cause => checkpointCommandError('Checkpoint spool operation failed.', cause)));
+}
+
+function publishPreparedCheckpoint(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  output: string,
+  prepared: CodeGraphCheckpointPreparedPackV1,
+  spool: {readonly file: FileSystem.File},
+) {
+  return Effect.gen(function* () {
+    const crypto = yield* Crypto.Crypto;
+    const parent = path.dirname(output);
+    const temporary = path.join(parent, `.${path.basename(output)}.${yield* crypto.randomUUIDv4}.tmp`);
+    let publicationIdentity: OwnedFileIdentity | undefined;
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const file = yield* fs.open(temporary, {flag: 'wx', mode: 0o600});
+        const writer = yield* attemptCheckpoint(() => new CodeGraphCheckpointArtifactWriterV1(prepared));
+        yield* file.writeAll(writer.prefix);
+        yield* spool.file.seek(0, 'start');
+        let offset = 0;
+        for (const descriptor of prepared.header.chunks) {
+          const frameBytes = CODE_GRAPH_CHECKPOINT_CHUNK_FRAME_HEADER_BYTES + descriptor.compressedBytes;
+          const bytes = yield* readCheckpointPart(spool.file, frameBytes);
+          offset += frameBytes;
+          yield* file.writeAll(yield* attemptCheckpoint(() => writer.write({bytes, ordinal: descriptor.ordinal})));
+        }
+        yield* requireCheckpointEof(spool.file);
+        const spoolSize = Number((yield* spool.file.stat).size);
+        if (offset !== spoolSize) return yield* checkpointFailure('Checkpoint spool framing is inconsistent.');
+        const descriptor = yield* attemptCheckpoint(() => writer.finish());
+        yield* file.sync;
+        const identity = yield* requireOwnedFileIdentity(yield* file.stat, 'Checkpoint output temporary');
+        publicationIdentity = identity;
+        yield* verifyOwnedPath(fs, temporary, identity, 'Checkpoint output temporary');
+        const linked = yield* fs.link(temporary, output).pipe(Effect.result);
+        if (linked._tag === 'Failure') {
+          if (yield* fs.exists(output)) return yield* checkpointFailure(`Checkpoint output already exists: ${output}`);
+          return yield* linked.failure;
+        }
+        yield* verifyOwnedPath(fs, output, identity, 'Published checkpoint output');
+        yield* syncDirectory(fs, parent);
+        yield* removeOwnedPath(fs, temporary, identity);
+        yield* syncDirectory(fs, parent);
+        return {descriptor, header: prepared.header};
+      }).pipe(
+        Effect.ensuring(
+          Effect.suspend(() =>
+            publicationIdentity === undefined ? Effect.void : removeOwnedPath(fs, temporary, publicationIdentity),
+          ),
+        ),
+      ),
+    );
+  });
+}
+
+function requireOwnedFileIdentity(info: FileSystem.File.Info, label: string) {
+  const birthtime = Option.getOrUndefined(info.birthtime);
+  const ino = Option.getOrUndefined(info.ino);
+  const modifiedAt = Option.getOrUndefined(info.mtime);
+  if (info.type !== 'File' || birthtime === undefined || ino === undefined || modifiedAt === undefined) {
+    return checkpointFailure(`${label} has insufficient regular-file identity metadata.`);
+  }
+  return Effect.succeed({
+    birthtimeMilliseconds: birthtime.getTime(),
+    dev: info.dev,
+    ino,
+    mode: info.mode,
+    modifiedAtMilliseconds: modifiedAt.getTime(),
+    size: info.size,
+  } satisfies OwnedFileIdentity);
+}
+
+function sameOwnedFile(left: OwnedFileIdentity, right: OwnedFileIdentity): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.modifiedAtMilliseconds === right.modifiedAtMilliseconds &&
+    left.birthtimeMilliseconds === right.birthtimeMilliseconds
+  );
+}
+
+function verifyOwnedPath(fs: FileSystem.FileSystem, target: string, expected: OwnedFileIdentity, label: string) {
+  return Effect.gen(function* () {
+    if (Option.isSome(yield* fs.readLink(target).pipe(Effect.option))) {
+      return yield* checkpointFailure(`${label} became a symbolic link.`);
+    }
+    const current = yield* requireOwnedFileIdentity(yield* fs.stat(target), label);
+    if (!sameOwnedFile(expected, current)) return yield* checkpointFailure(`${label} changed identity.`);
+  });
+}
+
+function removeOwnedPath(fs: FileSystem.FileSystem, target: string, expected: OwnedFileIdentity) {
+  return Effect.gen(function* () {
+    if (Option.isSome(yield* fs.readLink(target).pipe(Effect.option))) return;
+    const current = yield* fs.stat(target).pipe(Effect.option);
+    if (Option.isNone(current)) return;
+    const identity = yield* requireOwnedFileIdentity(current.value, 'Checkpoint temporary');
+    if (sameOwnedFile(expected, identity)) yield* fs.remove(target, {force: true});
+  }).pipe(Effect.ignore);
+}
+
+function syncDirectory(fs: FileSystem.FileSystem, directory: string): Effect.Effect<void, never> {
+  return Effect.scoped(
+    fs.open(directory, {flag: 'r'}).pipe(
+      Effect.flatMap(file => file.sync),
+      Effect.ignore,
+    ),
+  );
+}
+
+function checkpointCommandCwd(value: string | undefined) {
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    const path = yield* Path.Path;
+    return path.resolve(value?.trim() || system.currentDirectory());
+  });
+}
+
+function checkpointRecordTotal(header: CodeGraphCheckpointHeaderV1): number {
+  return header.chunks.reduce((total, chunk) => total + chunk.recordCount, 0);
+}
+
+function publicationMessage(state: CodeGraphCheckpointImportResultV1['publication']): string {
+  switch (state) {
+    case 'activated':
+      return 'activated the exact clean root';
+    case 'rebuilt':
+      return 'built the current local graph from the imported base';
+    case 'stored':
+      return 'stored the verified clean root without changing the current view';
+  }
+}
+
+function attemptCheckpoint<A>(attempt: () => A) {
+  return Effect.try({
+    try: attempt,
+    catch: cause => checkpointCommandError('Code graph checkpoint operation failed.', cause),
+  });
+}
+
+function checkpointFailure(message: string): Effect.Effect<never, CodeGraphCheckpointCommandError> {
+  return Effect.fail(new CodeGraphCheckpointCommandError(message));
+}
+
+function checkpointCommandError(message: string, cause: unknown): CodeGraphCheckpointCommandError {
+  if (cause instanceof CodeGraphCheckpointCommandError) return cause;
+  return new CodeGraphCheckpointCommandError(
+    cause instanceof Error && cause.message.length > 0 ? `${message} ${cause.message}` : message,
+    {cause},
+  );
+}

--- a/src/code_graph/checkpoint/compatibility.ts
+++ b/src/code_graph/checkpoint/compatibility.ts
@@ -1,0 +1,78 @@
+import {CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION} from '../inventory_policy.js';
+import {codeGraphLanguagePackProvenance, type CodeGraphLanguagePackRegistryShape} from '../languages/registry.js';
+import {compareCodeUnits} from '../ordering.js';
+import {CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION} from '../store_build_core.js';
+import type {CodeGraphLanguagePackProvenance} from '../store_models.js';
+import {CODE_GRAPH_RESOLUTION_SURFACE_VERSION} from '../store/schema_revision.js';
+import {CODE_GRAPH_SCHEMA_VERSION} from '../types.js';
+import {CODE_GRAPH_WORKSPACE_MODEL_VERSION} from '../workspace.js';
+import {canonicalJson} from './canonical_json.js';
+import {
+  CODE_GRAPH_CHECKPOINT_PATH_POLICY,
+  CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION,
+  type CodeGraphCheckpointAbiInputV1,
+} from './schema.js';
+
+/**
+ * Semantic contracts that are not SQLite schema revisions. A change to either
+ * value means an imported logical graph must be rebuilt before current code can
+ * extend it.
+ */
+export const CODE_GRAPH_CHECKPOINT_REFERENCE_RESOLUTION_VERSION =
+  `resolution-surface-v${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}` as const;
+
+export type CodeGraphCheckpointCompatibilityV1 =
+  | {readonly compatible: true; readonly expected: CodeGraphCheckpointAbiInputV1}
+  | {
+      readonly compatible: false;
+      readonly code: 'abi-mismatch' | 'language-pack-unavailable';
+      readonly expected?: CodeGraphCheckpointAbiInputV1;
+      readonly unavailablePackIds?: readonly string[];
+    };
+
+/** Assemble the logical ABI from authoritative runtime contracts and the exact active pack set. */
+export function codeGraphCheckpointAbiInputV1(
+  languagePacks: readonly CodeGraphLanguagePackProvenance[],
+): CodeGraphCheckpointAbiInputV1 {
+  return {
+    checkpointSemanticVersion: CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION,
+    graphSchemaVersion: CODE_GRAPH_SCHEMA_VERSION,
+    inventoryPolicyVersion: CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
+    languagePacks: [...languagePacks]
+      .sort((left, right) => compareCodeUnits(left.id, right.id))
+      .map(pack => ({
+        cacheIdentity: pack.cacheIdentity,
+        derivationIdentity: pack.derivationIdentity,
+        id: pack.id,
+        resolutionDomain: pack.resolutionDomain,
+        resolutionVersion: pack.resolutionVersion,
+      })),
+    lexicalLogicalFormatVersion: CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION,
+    pathPolicy: CODE_GRAPH_CHECKPOINT_PATH_POLICY,
+    referenceResolutionVersion: CODE_GRAPH_CHECKPOINT_REFERENCE_RESOLUTION_VERSION,
+    workspaceModelVersion: CODE_GRAPH_WORKSPACE_MODEL_VERSION,
+  };
+}
+
+/**
+ * Compare an artifact ABI with the receiving runtime using only the packs the
+ * artifact actually used. Unrelated newly installed packs do not invalidate a
+ * checkpoint, while a missing or changed active pack does.
+ */
+export function inspectCodeGraphCheckpointCompatibilityV1(
+  actual: CodeGraphCheckpointAbiInputV1,
+  registry: CodeGraphLanguagePackRegistryShape,
+): CodeGraphCheckpointCompatibilityV1 {
+  const available = new Map(registry.packs.map(pack => [pack.id, codeGraphLanguagePackProvenance(pack)]));
+  const unavailablePackIds = actual.languagePacks
+    .map(pack => pack.id)
+    .filter(id => !available.has(id))
+    .sort(compareCodeUnits);
+  if (unavailablePackIds.length > 0) {
+    return {code: 'language-pack-unavailable', compatible: false, unavailablePackIds};
+  }
+  const expected = codeGraphCheckpointAbiInputV1(actual.languagePacks.map(pack => available.get(pack.id)!));
+  return canonicalJson(actual) === canonicalJson(expected)
+    ? {compatible: true, expected}
+    : {code: 'abi-mismatch', compatible: false, expected};
+}

--- a/src/code_graph/checkpoint/file_fact_identity.ts
+++ b/src/code_graph/checkpoint/file_fact_identity.ts
@@ -1,0 +1,10 @@
+import {sha256HexSync} from '../../crypto/sha256.js';
+import type {CodeGraphFileFacts} from '../types.js';
+import {canonicalJson} from './canonical_json.js';
+
+const CHECKPOINT_FILE_FACT_IDENTITY_DOMAIN = 'threadnote-code-graph-checkpoint-file-fact-v1\0';
+
+/** Exact portable identity for one already-validated materialized file fact. */
+export function codeGraphCheckpointFileFactCacheIdentity(facts: CodeGraphFileFacts): string {
+  return `cgfd_${sha256HexSync(`${CHECKPOINT_FILE_FACT_IDENTITY_DOMAIN}${canonicalJson(facts)}`).slice(0, 40)}`;
+}

--- a/src/code_graph/checkpoint/import_reuse.ts
+++ b/src/code_graph/checkpoint/import_reuse.ts
@@ -1,0 +1,199 @@
+import {Effect, FileSystem, Path} from 'effect';
+import {runBinaryCommandEffect} from '../../effect/command.js';
+import {SystemInfo} from '../../effect/system.js';
+import {codeGraphCommittedContentHash} from '../content_identity.js';
+import {codeGraphUtf8ByteLength} from '../disk_capacity.js';
+import {appearsBinary, decodeUtf8} from '../inventory_content.js';
+import {retainResolutionContext} from '../inventory_content.js';
+import {readCodeGraphInventoryReuseEnvironment} from '../inventory_reuse.js';
+import {parseGitCatFileBatch} from '../inventory.js';
+import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../languages/registry.js';
+import {
+  CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION,
+  type CodeGraphReusableBaseReceiptInput,
+  type CodeGraphAttributionContextFile,
+} from '../store_models.js';
+import {
+  CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
+  CODE_GRAPH_INVENTORY_EXCLUSION_REASONS,
+  type CodeGraphInventoryExclusionReason,
+} from '../inventory_policy.js';
+import type {RepositoryIdentity} from '../types.js';
+import {
+  CODE_GRAPH_CHECKPOINT_ATTRIBUTION_CONTENT_BYTES_MAXIMUM,
+  CODE_GRAPH_CHECKPOINT_ATTRIBUTION_FILES_MAXIMUM,
+  CODE_GRAPH_CHECKPOINT_ATTRIBUTION_SOURCE_BYTES_MAXIMUM,
+  type CodeGraphCheckpointAttributionFileV1,
+  type CodeGraphCheckpointHeaderV1,
+} from './schema.js';
+const CAT_FILE_BATCH_ENTRIES = 128;
+const CAT_FILE_BATCH_BYTES = 4 * 1_048_576;
+
+export class CodeGraphCheckpointReuseHydrationError extends Error {
+  override readonly name = 'CodeGraphCheckpointReuseHydrationError';
+}
+
+function hydrationError(message: string, cause?: unknown): CodeGraphCheckpointReuseHydrationError {
+  return new CodeGraphCheckpointReuseHydrationError(message, cause === undefined ? undefined : {cause});
+}
+
+function attributionBatches(
+  files: readonly CodeGraphCheckpointAttributionFileV1[],
+): readonly (readonly CodeGraphCheckpointAttributionFileV1[])[] {
+  const batches: CodeGraphCheckpointAttributionFileV1[][] = [];
+  let current: CodeGraphCheckpointAttributionFileV1[] = [];
+  let bytes = 0;
+  for (const file of files) {
+    if (
+      current.length > 0 &&
+      (current.length >= CAT_FILE_BATCH_ENTRIES || bytes + file.blobSize > CAT_FILE_BATCH_BYTES)
+    ) {
+      batches.push(current);
+      current = [];
+      bytes = 0;
+    }
+    current.push(file);
+    bytes += file.blobSize;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+/**
+ * Rebuild the receiver-local reusable-base receipt without trusting donor
+ * environment or source bytes. Declared Git blob identities are hydrated from
+ * the local object database with lazy fetching disabled and verified against
+ * every portable attribution tuple.
+ */
+export const hydrateCodeGraphCheckpointReusableBaseReceipt = Effect.fn(
+  'codeGraph.hydrateCheckpointReusableBaseReceipt',
+)(function* (identity: RepositoryIdentity, header: CodeGraphCheckpointHeaderV1) {
+  const reuse = header.reuse;
+  if (reuse === undefined) return undefined;
+  if (
+    header.repository.repositoryId !== identity.repositoryId ||
+    header.repository.objectFormat !== identity.objectFormat
+  ) {
+    return yield* Effect.fail(hydrationError('Checkpoint repository identity does not match the receiver.'));
+  }
+  const packProvenance = header.abi.input.languagePacks.map(pack => ({
+    cacheIdentity: pack.cacheIdentity,
+    derivationIdentity: pack.derivationIdentity,
+    id: pack.id,
+    resolutionDomain: pack.resolutionDomain,
+    resolutionVersion: pack.resolutionVersion,
+  }));
+  if (reuse.inventory === undefined) {
+    return {
+      fileSetFingerprint: reuse.fileSetFingerprint,
+      packProvenance,
+      workspaceFingerprint: reuse.workspaceFingerprint,
+    } satisfies CodeGraphReusableBaseReceiptInput;
+  }
+  const portable = reuse.inventory;
+  if (
+    portable.version !== CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION ||
+    portable.policyExclusions.policyVersion !== CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION ||
+    portable.policyExclusions.reasons.some(
+      reason => !CODE_GRAPH_INVENTORY_EXCLUSION_REASONS.includes(reason.reason as CodeGraphInventoryExclusionReason),
+    )
+  ) {
+    return yield* Effect.fail(hydrationError('Checkpoint inventory reuse contract is incompatible.'));
+  }
+  const totalContentBytes = portable.attributionFiles.reduce((total, file) => total + file.size, 0);
+  const totalSourceBytes = portable.attributionFiles.reduce((total, file) => total + file.blobSize, 0);
+  if (
+    portable.attributionFiles.length > CODE_GRAPH_CHECKPOINT_ATTRIBUTION_FILES_MAXIMUM ||
+    !Number.isSafeInteger(totalContentBytes) ||
+    !Number.isSafeInteger(totalSourceBytes) ||
+    totalContentBytes > CODE_GRAPH_CHECKPOINT_ATTRIBUTION_CONTENT_BYTES_MAXIMUM ||
+    totalSourceBytes > CODE_GRAPH_CHECKPOINT_ATTRIBUTION_SOURCE_BYTES_MAXIMUM
+  ) {
+    return yield* Effect.fail(hydrationError('Checkpoint attribution context exceeds the local reuse boundary.'));
+  }
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const environment = yield* readCodeGraphInventoryReuseEnvironment(identity, fs, path).pipe(
+    Effect.mapError(cause => hydrationError('Checkpoint reuse environment could not be inspected.', cause)),
+  );
+  const attributionFiles: CodeGraphAttributionContextFile[] = [];
+  for (const batch of attributionBatches(portable.attributionFiles)) {
+    const result = yield* runBinaryCommandEffect('git', ['-C', identity.repoRoot, 'cat-file', '--batch'], {
+      env: {...system.environment(), GIT_NO_LAZY_FETCH: '1', GIT_OPTIONAL_LOCKS: '0'},
+      input: new TextEncoder().encode(`${batch.map(file => file.blobId).join('\n')}\n`),
+      maxOutputBytes: batch.reduce((total, file) => total + file.blobSize + 256, 0),
+      timeoutMs: 0,
+    }).pipe(Effect.mapError(cause => hydrationError('Checkpoint attribution Git blobs are unavailable.', cause)));
+    const blobs = yield* Effect.try({
+      catch: cause => hydrationError('Checkpoint attribution Git response is invalid.', cause),
+      try: () => parseGitCatFileBatch(result.stdout, batch),
+    });
+    for (let index = 0; index < batch.length; index += 1) {
+      const declared = batch[index]!;
+      const bytes = blobs[index]!;
+      const sourceContent = decodeUtf8(bytes);
+      const retained =
+        sourceContent === undefined
+          ? undefined
+          : retainResolutionContext(
+              {
+                blobId: declared.blobId,
+                content: sourceContent,
+                contentHash: declared.contentHash,
+                language: declared.language,
+                mode: declared.mode,
+                path: declared.path,
+                size: declared.blobSize,
+                source: 'commit',
+              },
+              BUILTIN_LANGUAGE_PACK_REGISTRY,
+            );
+      const content = retained?.content;
+      if (
+        bytes.byteLength !== declared.blobSize ||
+        appearsBinary(bytes) ||
+        content === undefined ||
+        codeGraphUtf8ByteLength(content) !== declared.size ||
+        codeGraphCommittedContentHash(identity.objectFormat, declared.blobId) !== declared.contentHash
+      ) {
+        return yield* Effect.fail(
+          hydrationError(`Checkpoint attribution blob for ${declared.path} does not match its portable identity.`),
+        );
+      }
+      attributionFiles.push({
+        blobId: declared.blobId,
+        content,
+        contentHash: declared.contentHash,
+        language: declared.language,
+        mode: declared.mode,
+        path: declared.path,
+        size: declared.size,
+        source: 'commit',
+      });
+    }
+  }
+  return {
+    fileSetFingerprint: reuse.fileSetFingerprint,
+    inventory: {
+      attributionFiles,
+      contract: portable.contract,
+      diagnostics: portable.diagnostics ?? [],
+      environmentFingerprint: environment.fingerprint,
+      includeOpaqueCorpusAssets: portable.includeOpaqueCorpusAssets,
+      policyExclusions: {
+        ...portable.policyExclusions,
+        policyVersion: CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
+        reasons: portable.policyExclusions.reasons.map(reason => ({
+          ...reason,
+          reason: reason.reason as CodeGraphInventoryExclusionReason,
+        })),
+      },
+      skipped: portable.skipped,
+      version: CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION,
+      workspace: portable.workspace,
+    },
+    packProvenance,
+    workspaceFingerprint: reuse.workspaceFingerprint,
+  } satisfies CodeGraphReusableBaseReceiptInput;
+});

--- a/src/code_graph/checkpoint/pack.ts
+++ b/src/code_graph/checkpoint/pack.ts
@@ -1,0 +1,1144 @@
+import {Gunzip, gzipSync} from 'fflate';
+import {canonicalJson, parseCanonicalJson} from './canonical_json.js';
+import {
+  CODE_GRAPH_CHECKPOINT_FORMAT_VERSION,
+  CODE_GRAPH_CHECKPOINT_MEDIA_TYPE,
+  CODE_GRAPH_CHECKPOINT_RECORD_KINDS,
+  CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION,
+  CODE_GRAPH_CHECKPOINT_SCHEMA,
+  CODE_GRAPH_CHECKPOINT_COMPRESSION_PROFILE,
+  codeGraphCheckpointRecordOrderKey,
+  compareCodeGraphCheckpointRecordOrderKeys,
+  emptyCodeGraphCheckpointCounts,
+  parseCodeGraphCheckpointHeaderV1,
+  parseCodeGraphCheckpointMetadataV1,
+  parseCodeGraphCheckpointRecordV1,
+  type CodeGraphCheckpointChunkDescriptorV1,
+  type CodeGraphCheckpointAttributionFileV1,
+  type CodeGraphCheckpointCountsV1,
+  type CodeGraphCheckpointDescriptorV1,
+  type CodeGraphCheckpointDigestV1,
+  type CodeGraphCheckpointHeaderV1,
+  type CodeGraphCheckpointMetadataV1,
+  type CodeGraphCheckpointRecordOrderKeyV1,
+  type CodeGraphCheckpointRecordV1,
+  type CodeGraphCheckpointSha256,
+} from './schema.js';
+
+const UTF8 = new TextEncoder();
+const UTF8_FATAL = new TextDecoder('utf-8', {fatal: true});
+const CHECKPOINT_MAGIC = UTF8.encode('THREADNOTE-CGCP\n');
+const CHUNK_MAGIC = UTF8.encode('TCG1');
+const PRELUDE_BYTES = 24;
+const CHUNK_FRAME_HEADER_BYTES = 52;
+const UINT32_MAXIMUM = 0xffff_ffff;
+const STREAM_FEED_BYTES = 64 * 1_024;
+
+const ABI_DOMAIN = UTF8.encode('threadnote-code-graph-checkpoint-abi-v1\0');
+const LOGICAL_DOMAIN = UTF8.encode('threadnote-code-graph-checkpoint-logical-v1\0');
+const CHUNK_DOMAIN = UTF8.encode('threadnote-code-graph-checkpoint-chunk-v1\0');
+const PATH_SET_DOMAIN = UTF8.encode('threadnote-code-graph-checkpoint-file-paths-v1\0');
+const SPOOL_DOMAIN = UTF8.encode('threadnote-code-graph-checkpoint-spool-v1\0');
+
+export const DEFAULT_CODE_GRAPH_CHECKPOINT_PACK_LIMITS: CodeGraphCheckpointPackLimits = {
+  maximumArtifactBytes: 1_073_741_824,
+  maximumChunks: 16_384,
+  maximumCompressedChunkBytes: 20 * 1_048_576,
+  maximumHeaderBytes: 1_048_576,
+  maximumRecordBytes: 8 * 1_048_576,
+  maximumRecords: 5_000_000,
+  maximumUncompressedChunkBytes: 16 * 1_048_576,
+  targetUncompressedChunkBytes: 4 * 1_048_576,
+};
+
+export const CODE_GRAPH_CHECKPOINT_PRELUDE_BYTES = PRELUDE_BYTES;
+export const CODE_GRAPH_CHECKPOINT_CHUNK_FRAME_HEADER_BYTES = CHUNK_FRAME_HEADER_BYTES;
+
+export interface CodeGraphCheckpointPackLimits {
+  readonly maximumArtifactBytes: number;
+  readonly maximumChunks: number;
+  readonly maximumCompressedChunkBytes: number;
+  readonly maximumHeaderBytes: number;
+  readonly maximumRecordBytes: number;
+  readonly maximumRecords: number;
+  readonly maximumUncompressedChunkBytes: number;
+  readonly targetUncompressedChunkBytes: number;
+}
+
+export interface CodeGraphCheckpointExpectedArtifactV1 {
+  readonly expectedDescriptor?: CodeGraphCheckpointDescriptorV1;
+  readonly expectedDigest?: CodeGraphCheckpointSha256;
+}
+
+export interface CodeGraphCheckpointDecodeOptionsV1 extends CodeGraphCheckpointExpectedArtifactV1 {
+  readonly limits?: Partial<CodeGraphCheckpointPackLimits>;
+  readonly onRecord?: (record: CodeGraphCheckpointRecordV1) => void;
+  /** Called only after this compressed member and every logical record in it have been verified. */
+  readonly onVerifiedChunk?: (chunk: CodeGraphCheckpointVerifiedChunkV1) => void;
+}
+
+export interface CodeGraphCheckpointEncodeOptionsV1 {
+  readonly limits?: Partial<CodeGraphCheckpointPackLimits>;
+}
+
+export interface CodeGraphCheckpointEncodedChunkV1 {
+  readonly bytes: Uint8Array;
+  readonly ordinal: number;
+}
+
+export interface CodeGraphCheckpointVerifiedChunkV1 {
+  readonly descriptor: CodeGraphCheckpointChunkDescriptorV1;
+  readonly records: readonly CodeGraphCheckpointRecordV1[];
+}
+
+export interface CodeGraphCheckpointPreparedPackV1 {
+  readonly header: CodeGraphCheckpointHeaderV1;
+  readonly prefix: Uint8Array;
+  readonly spoolDigest: CodeGraphCheckpointDigestV1;
+}
+
+export interface CodeGraphCheckpointEncodedPackV1 {
+  readonly bytes: Uint8Array;
+  readonly descriptor: CodeGraphCheckpointDescriptorV1;
+  readonly header: CodeGraphCheckpointHeaderV1;
+}
+
+export interface CodeGraphCheckpointReadPlanV1 {
+  readonly chunks: readonly {readonly frameBytes: number; readonly ordinal: number}[];
+  readonly prefixBytes: number;
+}
+
+export interface CodeGraphCheckpointInspectionV1 {
+  readonly descriptor: CodeGraphCheckpointDescriptorV1;
+  readonly header: CodeGraphCheckpointHeaderV1;
+  /** Inspect validates exact artifact bytes and framing, but deliberately does not inflate logical chunks. */
+  readonly verification: 'artifact-and-framing';
+}
+
+export interface CodeGraphCheckpointDecodedPackV1 {
+  readonly descriptor: CodeGraphCheckpointDescriptorV1;
+  readonly header: CodeGraphCheckpointHeaderV1;
+  readonly records: readonly CodeGraphCheckpointRecordV1[];
+  readonly verification: 'full';
+}
+
+export interface CodeGraphCheckpointVerificationV1 {
+  readonly descriptor: CodeGraphCheckpointDescriptorV1;
+  readonly header: CodeGraphCheckpointHeaderV1;
+  readonly verification: 'full';
+}
+
+export class CodeGraphCheckpointPackError extends Error {
+  override readonly name = 'CodeGraphCheckpointPackError';
+}
+
+/** Exact bounded-read lengths for replaying one independently verifiable frame at a time. */
+export function codeGraphCheckpointReadPlanV1(header: CodeGraphCheckpointHeaderV1): CodeGraphCheckpointReadPlanV1 {
+  const parsed = parseCodeGraphCheckpointHeaderV1(header);
+  return {
+    chunks: parsed.chunks.map(chunk => ({
+      frameBytes: checkedAdd(CHUNK_FRAME_HEADER_BYTES, chunk.compressedBytes, 'Checkpoint chunk frame'),
+      ordinal: chunk.ordinal,
+    })),
+    prefixBytes: checkedAdd(PRELUDE_BYTES, canonicalBytes(parsed).byteLength, 'Checkpoint prefix'),
+  };
+}
+
+/** Hash an explicit ABI input. Runtime compatibility assembly intentionally lives outside the codec. */
+export function codeGraphCheckpointAbiDigestV1(
+  input: CodeGraphCheckpointMetadataV1['abi'],
+): CodeGraphCheckpointDigestV1 {
+  const metadata = parseCodeGraphCheckpointMetadataV1({
+    abi: input,
+    coverage: {eligibleFiles: 0, excludedFiles: 0, reasons: [], state: 'complete'},
+    repository: {
+      caseMode: 'sensitive',
+      displayName: 'abi-validation',
+      objectFormat: 'sha1',
+      repositoryId: '0'.repeat(64),
+    },
+    source: {commit: '0'.repeat(40), extractorSet: 'abi-validation', graphContentId: `cgc_${'0'.repeat(40)}`},
+  }).abi;
+  return digestParts(ABI_DOMAIN, canonicalBytes(metadata));
+}
+
+/**
+ * Streaming first pass. Records must already be in `compareCodeGraphCheckpointRecords` order.
+ * Emitted chunk frames can be spooled to disk and replayed after `finish` produces the header.
+ */
+export class CodeGraphCheckpointStreamEncoderV1 {
+  readonly #attributionFiles: Map<string, CodeGraphCheckpointAttributionFileV1>;
+  readonly #counts = emptyCodeGraphCheckpointCounts();
+  readonly #filePaths = domainHasher(PATH_SET_DOMAIN);
+  readonly #factPaths = domainHasher(PATH_SET_DOMAIN);
+  readonly #limits: CodeGraphCheckpointPackLimits;
+  readonly #logical: Bun.CryptoHasher;
+  readonly #metadata: CodeGraphCheckpointMetadataV1;
+  readonly #spool = domainHasher(SPOOL_DOMAIN);
+  readonly #chunkDescriptors: CodeGraphCheckpointChunkDescriptorV1[] = [];
+  #chunkBytes = 0;
+  #chunkFrames: Uint8Array[] = [];
+  #chunkRecords = 0;
+  #finished = false;
+  #previousFactPath: string | undefined;
+  #previousOrderKey: CodeGraphCheckpointRecordOrderKeyV1 | undefined;
+  #recordCount = 0;
+
+  constructor(metadata: CodeGraphCheckpointMetadataV1, options: CodeGraphCheckpointEncodeOptionsV1 = {}) {
+    this.#limits = resolveLimits(options.limits);
+    this.#metadata = parseCodeGraphCheckpointMetadataV1(metadata);
+    this.#attributionFiles = checkpointAttributionFiles(this.#metadata);
+    const anchor = canonicalBytes(this.#metadata, this.#limits.maximumHeaderBytes, 'Checkpoint logical metadata');
+    this.#logical = domainHasher(LOGICAL_DOMAIN);
+    this.#logical.update(u32(anchor.byteLength));
+    this.#logical.update(anchor);
+  }
+
+  write(
+    records: Iterable<CodeGraphCheckpointRecordV1>,
+    emit: (chunk: CodeGraphCheckpointEncodedChunkV1) => void,
+  ): void {
+    if (this.#finished) throw new CodeGraphCheckpointPackError('Checkpoint encoder is already finished.');
+    for (const candidate of records) {
+      const record = parseCodeGraphCheckpointRecordV1(candidate);
+      const orderKey = codeGraphCheckpointRecordOrderKey(record);
+      if (this.#previousOrderKey) {
+        const order = compareCodeGraphCheckpointRecordOrderKeys(this.#previousOrderKey, orderKey);
+        if (order === 0) throw new CodeGraphCheckpointPackError('Checkpoint contains a duplicate record identity.');
+        if (order > 0) throw new CodeGraphCheckpointPackError('Checkpoint records are not in canonical order.');
+      }
+      const recordBytes = canonicalBytes(record, this.#limits.maximumRecordBytes, 'Checkpoint record');
+      const framedBytes = checkedAdd(4, recordBytes.byteLength, 'Checkpoint record frame');
+      if (framedBytes > this.#limits.maximumUncompressedChunkBytes) {
+        throw new CodeGraphCheckpointPackError('Checkpoint record does not fit in a bounded chunk.');
+      }
+      if (this.#chunkRecords > 0 && this.#chunkBytes + framedBytes > this.#limits.targetUncompressedChunkBytes) {
+        this.#flush(emit);
+      }
+      if (this.#recordCount >= this.#limits.maximumRecords) {
+        throw new CodeGraphCheckpointPackError('Checkpoint exceeds the record-count limit.');
+      }
+      const frame = joinBytes([u32(recordBytes.byteLength), recordBytes]);
+      this.#chunkFrames.push(frame);
+      this.#chunkBytes += frame.byteLength;
+      this.#chunkRecords += 1;
+      this.#recordCount += 1;
+      this.#counts[record.kind] += 1;
+      this.#logical.update(frame);
+      this.#trackSemantics(record);
+      this.#previousOrderKey = orderKey;
+    }
+  }
+
+  finish(emit: (chunk: CodeGraphCheckpointEncodedChunkV1) => void): CodeGraphCheckpointPreparedPackV1 {
+    if (this.#finished) throw new CodeGraphCheckpointPackError('Checkpoint encoder is already finished.');
+    this.#finished = true;
+    if (this.#chunkRecords > 0) this.#flush(emit);
+    verifyFileFactParity(
+      this.#counts,
+      this.#metadata.coverage.eligibleFiles,
+      digestHex(this.#filePaths),
+      digestHex(this.#factPaths),
+    );
+    verifyAttributionFileCoverage(this.#attributionFiles);
+    const abi = codeGraphCheckpointAbiDigestV1(this.#metadata.abi);
+    const header = parseCodeGraphCheckpointHeaderV1({
+      abi: {...abi, input: this.#metadata.abi},
+      chunks: this.#chunkDescriptors,
+      compressionProfile: CODE_GRAPH_CHECKPOINT_COMPRESSION_PROFILE,
+      counts: this.#counts,
+      coverage: this.#metadata.coverage,
+      formatVersion: CODE_GRAPH_CHECKPOINT_FORMAT_VERSION,
+      logical: {algorithm: 'sha256', digest: digestHex(this.#logical)},
+      mediaType: CODE_GRAPH_CHECKPOINT_MEDIA_TYPE,
+      recordSchemaVersion: CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION,
+      repository: this.#metadata.repository,
+      ...(this.#metadata.reuse === undefined ? {} : {reuse: this.#metadata.reuse}),
+      schema: CODE_GRAPH_CHECKPOINT_SCHEMA,
+      source: this.#metadata.source,
+    });
+    const prefix = encodePrefix(header, this.#limits);
+    return {
+      header,
+      prefix,
+      spoolDigest: {algorithm: 'sha256', digest: digestHex(this.#spool)},
+    };
+  }
+
+  #flush(emit: (chunk: CodeGraphCheckpointEncodedChunkV1) => void): void {
+    if (this.#chunkDescriptors.length >= this.#limits.maximumChunks) {
+      throw new CodeGraphCheckpointPackError('Checkpoint exceeds the chunk-count limit.');
+    }
+    const ordinal = this.#chunkDescriptors.length;
+    const uncompressed = joinBytes(this.#chunkFrames, this.#chunkBytes);
+    if (uncompressed.byteLength > this.#limits.maximumUncompressedChunkBytes) {
+      throw new CodeGraphCheckpointPackError('Checkpoint chunk exceeds the uncompressed-byte limit.');
+    }
+    const compressed = gzipSync(uncompressed, {level: 6, mtime: 0});
+    if (compressed.byteLength > this.#limits.maximumCompressedChunkBytes) {
+      throw new CodeGraphCheckpointPackError('Checkpoint chunk exceeds the compressed-byte limit.');
+    }
+    const descriptor: CodeGraphCheckpointChunkDescriptorV1 = {
+      compressedBytes: compressed.byteLength,
+      digest: chunkDigest(ordinal, this.#chunkRecords, uncompressed),
+      ordinal,
+      recordCount: this.#chunkRecords,
+      uncompressedBytes: uncompressed.byteLength,
+    };
+    const bytes = encodeChunkFrame(descriptor, compressed);
+    this.#chunkDescriptors.push(descriptor);
+    this.#spool.update(bytes);
+    emit({bytes, ordinal});
+    this.#chunkBytes = 0;
+    this.#chunkFrames = [];
+    this.#chunkRecords = 0;
+  }
+
+  #trackSemantics(record: CodeGraphCheckpointRecordV1): void {
+    if (record.kind === 'file') {
+      updateFramedText(this.#filePaths, record.path);
+      consumeAttributionFile(this.#attributionFiles, record);
+    }
+    if (record.kind !== 'file-fact') return;
+    if (record.path === this.#previousFactPath) {
+      throw new CodeGraphCheckpointPackError('Checkpoint contains more than one materialized fact for a file.');
+    }
+    this.#previousFactPath = record.path;
+    updateFramedText(this.#factPaths, record.path);
+  }
+}
+
+/** Second pass over a verified local spool. This state object never retains the whole artifact. */
+export class CodeGraphCheckpointArtifactWriterV1 {
+  readonly #artifact = domainlessHasher();
+  readonly #expectedSpoolDigest: string;
+  readonly #header: CodeGraphCheckpointHeaderV1;
+  readonly #limits: CodeGraphCheckpointPackLimits;
+  readonly #prefix: Uint8Array;
+  readonly #spool = domainHasher(SPOOL_DOMAIN);
+  #artifactBytes = 0;
+  #finished = false;
+  #nextOrdinal = 0;
+
+  constructor(
+    prepared: CodeGraphCheckpointPreparedPackV1,
+    options: {limits?: Partial<CodeGraphCheckpointPackLimits>} = {},
+  ) {
+    this.#limits = resolveLimits(options.limits);
+    this.#header = parseCodeGraphCheckpointHeaderV1(prepared.header);
+    validateHeaderBounds(this.#header, this.#limits);
+    this.#prefix = encodePrefix(this.#header, this.#limits);
+    if (!equalBytes(this.#prefix, prepared.prefix)) {
+      throw new CodeGraphCheckpointPackError('Prepared checkpoint prefix does not match its header.');
+    }
+    this.#expectedSpoolDigest = parseBareDigest(prepared.spoolDigest, 'Prepared spool digest');
+    this.#appendArtifact(this.#prefix);
+  }
+
+  get prefix(): Uint8Array {
+    return this.#prefix.slice();
+  }
+
+  write(chunk: CodeGraphCheckpointEncodedChunkV1 | Uint8Array): Uint8Array {
+    if (this.#finished) throw new CodeGraphCheckpointPackError('Checkpoint artifact writer is already finished.');
+    const bytes = chunk instanceof Uint8Array ? chunk : chunk.bytes;
+    if (!(chunk instanceof Uint8Array) && chunk.ordinal !== this.#nextOrdinal) {
+      throw new CodeGraphCheckpointPackError('Spool chunk ordinal is out of order.');
+    }
+    const descriptor = this.#header.chunks[this.#nextOrdinal];
+    if (!descriptor) throw new CodeGraphCheckpointPackError('Checkpoint spool contains an extra chunk.');
+    validateChunkFrame(bytes, descriptor);
+    this.#spool.update(bytes);
+    this.#appendArtifact(bytes);
+    this.#nextOrdinal += 1;
+    return bytes;
+  }
+
+  finish(): CodeGraphCheckpointDescriptorV1 {
+    if (this.#finished) throw new CodeGraphCheckpointPackError('Checkpoint artifact writer is already finished.');
+    this.#finished = true;
+    if (this.#nextOrdinal !== this.#header.chunks.length) {
+      throw new CodeGraphCheckpointPackError('Checkpoint spool ended before every declared chunk.');
+    }
+    if (digestHex(this.#spool) !== this.#expectedSpoolDigest) {
+      throw new CodeGraphCheckpointPackError('Checkpoint spool digest does not match the prepared pack.');
+    }
+    return descriptor(this.#artifactBytes, digestHex(this.#artifact));
+  }
+
+  #appendArtifact(bytes: Uint8Array): void {
+    this.#artifactBytes = checkedAdd(this.#artifactBytes, bytes.byteLength, 'Checkpoint artifact size');
+    if (this.#artifactBytes > this.#limits.maximumArtifactBytes) {
+      throw new CodeGraphCheckpointPackError('Checkpoint artifact exceeds the byte limit.');
+    }
+    this.#artifact.update(bytes);
+  }
+}
+
+/** Test/small-artifact convenience. Production callers should spool encoder chunks and replay through the writer. */
+export function encodeCodeGraphCheckpointPackV1(
+  metadata: CodeGraphCheckpointMetadataV1,
+  records: readonly CodeGraphCheckpointRecordV1[],
+  options: CodeGraphCheckpointEncodeOptionsV1 = {},
+): CodeGraphCheckpointEncodedPackV1 {
+  const chunks: CodeGraphCheckpointEncodedChunkV1[] = [];
+  const encoder = new CodeGraphCheckpointStreamEncoderV1(metadata, options);
+  encoder.write(
+    [...records].map(parseCodeGraphCheckpointRecordV1).sort((left, right) => {
+      return compareCodeGraphCheckpointRecordOrderKeys(
+        codeGraphCheckpointRecordOrderKey(left),
+        codeGraphCheckpointRecordOrderKey(right),
+      );
+    }),
+    chunk => chunks.push(chunk),
+  );
+  const prepared = encoder.finish(chunk => chunks.push(chunk));
+  return assembleCodeGraphCheckpointPackV1(prepared, chunks, options);
+}
+
+/** Test/small-artifact convenience for replaying an already prepared spool into one byte array. */
+export function assembleCodeGraphCheckpointPackV1(
+  prepared: CodeGraphCheckpointPreparedPackV1,
+  chunks: Iterable<CodeGraphCheckpointEncodedChunkV1 | Uint8Array>,
+  options: {limits?: Partial<CodeGraphCheckpointPackLimits>} = {},
+): CodeGraphCheckpointEncodedPackV1 {
+  const writer = new CodeGraphCheckpointArtifactWriterV1(prepared, options);
+  const pieces: Uint8Array[] = [writer.prefix];
+  for (const chunk of chunks) pieces.push(writer.write(chunk));
+  const artifactDescriptor = writer.finish();
+  return {bytes: joinBytes(pieces, artifactDescriptor.size), descriptor: artifactDescriptor, header: prepared.header};
+}
+
+/**
+ * Bounded streaming verifier. It retains at most the visible header and one compressed/uncompressed logical chunk.
+ * `onVerifiedChunk` means the chunk digest and records are valid; whole-artifact logical verification completes at finish.
+ */
+export class CodeGraphCheckpointStreamDecoderV1 {
+  readonly #artifact = domainlessHasher();
+  readonly #counts = emptyCodeGraphCheckpointCounts();
+  readonly #expectedDescriptor: CodeGraphCheckpointDescriptorV1 | undefined;
+  readonly #expectedDigest: string | undefined;
+  readonly #factPaths = domainHasher(PATH_SET_DOMAIN);
+  readonly #filePaths = domainHasher(PATH_SET_DOMAIN);
+  readonly #limits: CodeGraphCheckpointPackLimits;
+  readonly #onRecord: ((record: CodeGraphCheckpointRecordV1) => void) | undefined;
+  readonly #onVerifiedChunk: ((chunk: CodeGraphCheckpointVerifiedChunkV1) => void) | undefined;
+  readonly #queue = new ByteQueue();
+  #artifactBytes = 0;
+  #attributionFiles: Map<string, CodeGraphCheckpointAttributionFileV1> | undefined;
+  #currentChunk: CodeGraphCheckpointChunkDescriptorV1 | undefined;
+  #finished = false;
+  #header: CodeGraphCheckpointHeaderV1 | undefined;
+  #headerBytes: number | undefined;
+  #logical: Bun.CryptoHasher | undefined;
+  #nextChunk = 0;
+  #previousFactPath: string | undefined;
+  #previousOrderKey: CodeGraphCheckpointRecordOrderKeyV1 | undefined;
+  #recordCount = 0;
+  #state: 'chunk-header' | 'chunk-payload' | 'done' | 'header' | 'prelude' = 'prelude';
+
+  constructor(options: CodeGraphCheckpointDecodeOptionsV1 = {}) {
+    this.#limits = resolveLimits(options.limits);
+    this.#expectedDescriptor = options.expectedDescriptor;
+    if (this.#expectedDescriptor) validateExpectedDescriptor(this.#expectedDescriptor, this.#limits);
+    this.#expectedDigest = options.expectedDigest
+      ? parsePrefixedDigest(options.expectedDigest, 'Expected digest')
+      : undefined;
+    if (
+      this.#expectedDescriptor &&
+      this.#expectedDigest &&
+      this.#expectedDescriptor.digest !== `sha256:${this.#expectedDigest}`
+    ) {
+      throw new CodeGraphCheckpointPackError('Expected checkpoint digests disagree.');
+    }
+    this.#onRecord = options.onRecord;
+    this.#onVerifiedChunk = options.onVerifiedChunk;
+  }
+
+  push(bytes: Uint8Array): void {
+    if (this.#finished) throw new CodeGraphCheckpointPackError('Checkpoint decoder is already finished.');
+    if (!(bytes instanceof Uint8Array)) throw new CodeGraphCheckpointPackError('Checkpoint input must be bytes.');
+    this.#artifactBytes = checkedAdd(this.#artifactBytes, bytes.byteLength, 'Checkpoint artifact size');
+    if (this.#artifactBytes > this.#limits.maximumArtifactBytes) {
+      throw new CodeGraphCheckpointPackError('Checkpoint artifact exceeds the byte limit.');
+    }
+    if (this.#expectedDescriptor && this.#artifactBytes > this.#expectedDescriptor.size) {
+      throw new CodeGraphCheckpointPackError('Checkpoint artifact exceeds its expected size.');
+    }
+    this.#artifact.update(bytes);
+    this.#feed(bytes);
+  }
+
+  finish(): CodeGraphCheckpointVerificationV1 {
+    if (this.#finished) throw new CodeGraphCheckpointPackError('Checkpoint decoder is already finished.');
+    this.#drain();
+    this.#finished = true;
+    if (this.#state !== 'done' || this.#queue.size !== 0 || !this.#header || !this.#logical) {
+      throw new CodeGraphCheckpointPackError('Checkpoint artifact ended before its declared framing.');
+    }
+    verifyFileFactParity(
+      this.#counts,
+      this.#header.coverage.eligibleFiles,
+      digestHex(this.#filePaths),
+      digestHex(this.#factPaths),
+    );
+    verifyAttributionFileCoverage(this.#attributionFiles ?? new Map());
+    for (const kind of CODE_GRAPH_CHECKPOINT_RECORD_KINDS) {
+      if (this.#counts[kind] !== this.#header.counts[kind]) {
+        throw new CodeGraphCheckpointPackError(`Checkpoint ${kind} count does not match its header.`);
+      }
+    }
+    if (digestHex(this.#logical) !== this.#header.logical.digest) {
+      throw new CodeGraphCheckpointPackError('Checkpoint logical digest does not match its records.');
+    }
+    const resultDescriptor = descriptor(this.#artifactBytes, digestHex(this.#artifact));
+    verifyExpectedArtifact(resultDescriptor, this.#expectedDescriptor, this.#expectedDigest);
+    return {descriptor: resultDescriptor, header: this.#header, verification: 'full'};
+  }
+
+  #drain(): void {
+    while (true) {
+      if (this.#state === 'prelude') {
+        const bytes = this.#queue.take(PRELUDE_BYTES);
+        if (!bytes) return;
+        if (!equalBytes(bytes.subarray(0, CHECKPOINT_MAGIC.byteLength), CHECKPOINT_MAGIC)) {
+          throw new CodeGraphCheckpointPackError('Checkpoint magic is invalid.');
+        }
+        const view = dataView(bytes);
+        if (view.getUint32(16, false) !== CODE_GRAPH_CHECKPOINT_FORMAT_VERSION) {
+          throw new CodeGraphCheckpointPackError('Checkpoint prelude version is unsupported.');
+        }
+        this.#headerBytes = view.getUint32(20, false);
+        if (this.#headerBytes === 0 || this.#headerBytes > this.#limits.maximumHeaderBytes) {
+          throw new CodeGraphCheckpointPackError('Checkpoint header exceeds the byte limit.');
+        }
+        this.#state = 'header';
+        continue;
+      }
+      if (this.#state === 'header') {
+        const bytes = this.#queue.take(this.#headerBytes!);
+        if (!bytes) return;
+        this.#header = decodeHeader(bytes, this.#limits);
+        const metadata = metadataFromHeader(this.#header);
+        this.#attributionFiles = checkpointAttributionFiles(metadata);
+        const anchor = canonicalBytes(metadata, this.#limits.maximumHeaderBytes, 'Checkpoint logical metadata');
+        this.#logical = domainHasher(LOGICAL_DOMAIN);
+        this.#logical.update(u32(anchor.byteLength));
+        this.#logical.update(anchor);
+        this.#state = this.#header.chunks.length === 0 ? 'done' : 'chunk-header';
+        continue;
+      }
+      if (this.#state === 'chunk-header') {
+        const bytes = this.#queue.take(CHUNK_FRAME_HEADER_BYTES);
+        if (!bytes) return;
+        const expected = this.#header!.chunks[this.#nextChunk];
+        if (!expected) throw new CodeGraphCheckpointPackError('Checkpoint contains an undeclared chunk.');
+        validateChunkFrameHeader(bytes, expected);
+        this.#currentChunk = expected;
+        this.#state = 'chunk-payload';
+        continue;
+      }
+      if (this.#state === 'chunk-payload') {
+        const descriptor = this.#currentChunk!;
+        const compressed = this.#queue.take(descriptor.compressedBytes);
+        if (!compressed) return;
+        const uncompressed = inflateSingleMember(compressed, descriptor.uncompressedBytes);
+        if (chunkDigest(descriptor.ordinal, descriptor.recordCount, uncompressed).digest !== descriptor.digest.digest) {
+          throw new CodeGraphCheckpointPackError('Checkpoint chunk digest does not match its payload.');
+        }
+        const records = this.#decodeRecords(uncompressed, descriptor);
+        this.#onVerifiedChunk?.({descriptor, records});
+        for (const record of records) this.#onRecord?.(record);
+        this.#nextChunk += 1;
+        this.#currentChunk = undefined;
+        this.#state = this.#nextChunk === this.#header!.chunks.length ? 'done' : 'chunk-header';
+        continue;
+      }
+      if (this.#queue.size > 0) throw new CodeGraphCheckpointPackError('Checkpoint artifact has trailing bytes.');
+      return;
+    }
+  }
+
+  #feed(bytes: Uint8Array): void {
+    for (let offset = 0; offset < bytes.byteLength; offset += STREAM_FEED_BYTES) {
+      this.#queue.push(bytes.subarray(offset, Math.min(bytes.byteLength, offset + STREAM_FEED_BYTES)));
+      this.#drain();
+    }
+  }
+
+  #decodeRecords(
+    bytes: Uint8Array,
+    descriptor: CodeGraphCheckpointChunkDescriptorV1,
+  ): readonly CodeGraphCheckpointRecordV1[] {
+    const records: CodeGraphCheckpointRecordV1[] = [];
+    let offset = 0;
+    for (let index = 0; index < descriptor.recordCount; index += 1) {
+      if (bytes.byteLength - offset < 4)
+        throw new CodeGraphCheckpointPackError('Checkpoint record frame is truncated.');
+      const length = dataView(bytes, offset, 4).getUint32(0, false);
+      offset += 4;
+      if (length === 0 || length > this.#limits.maximumRecordBytes || length > bytes.byteLength - offset) {
+        throw new CodeGraphCheckpointPackError('Checkpoint record length is invalid.');
+      }
+      const recordBytes = bytes.subarray(offset, offset + length);
+      offset += length;
+      const record = parseCodeGraphCheckpointRecordV1(parseCanonicalBytes(recordBytes, 'Checkpoint record'));
+      const orderKey = codeGraphCheckpointRecordOrderKey(record);
+      if (this.#previousOrderKey) {
+        const order = compareCodeGraphCheckpointRecordOrderKeys(this.#previousOrderKey, orderKey);
+        if (order === 0) throw new CodeGraphCheckpointPackError('Checkpoint contains a duplicate record identity.');
+        if (order > 0) throw new CodeGraphCheckpointPackError('Checkpoint records are not in canonical order.');
+      }
+      if (this.#recordCount >= this.#limits.maximumRecords) {
+        throw new CodeGraphCheckpointPackError('Checkpoint exceeds the record-count limit.');
+      }
+      this.#recordCount += 1;
+      this.#counts[record.kind] += 1;
+      this.#logical!.update(u32(length));
+      this.#logical!.update(recordBytes);
+      this.#trackSemantics(record);
+      this.#previousOrderKey = orderKey;
+      records.push(record);
+    }
+    if (offset !== bytes.byteLength) throw new CodeGraphCheckpointPackError('Checkpoint chunk has extra record bytes.');
+    return records;
+  }
+
+  #trackSemantics(record: CodeGraphCheckpointRecordV1): void {
+    if (record.kind === 'file') {
+      updateFramedText(this.#filePaths, record.path);
+      consumeAttributionFile(this.#attributionFiles!, record);
+    }
+    if (record.kind !== 'file-fact') return;
+    if (record.path === this.#previousFactPath) {
+      throw new CodeGraphCheckpointPackError('Checkpoint contains more than one materialized fact for a file.');
+    }
+    this.#previousFactPath = record.path;
+    updateFramedText(this.#factPaths, record.path);
+  }
+}
+
+/** Full small-artifact convenience that returns all records after bounded streaming validation. */
+export function decodeCodeGraphCheckpointPackV1(
+  bytes: Uint8Array,
+  options: CodeGraphCheckpointExpectedArtifactV1 & {limits?: Partial<CodeGraphCheckpointPackLimits>} = {},
+): CodeGraphCheckpointDecodedPackV1 {
+  const records: CodeGraphCheckpointRecordV1[] = [];
+  const decoder = new CodeGraphCheckpointStreamDecoderV1({...options, onRecord: record => records.push(record)});
+  decoder.push(bytes);
+  const inspection = decoder.finish();
+  return {...inspection, records, verification: 'full'};
+}
+
+/** Bounded, non-inflating inspector for CLI metadata and exact artifact-descriptor verification. */
+export class CodeGraphCheckpointStreamInspectorV1 {
+  readonly #artifact = domainlessHasher();
+  readonly #expectedDescriptor: CodeGraphCheckpointDescriptorV1 | undefined;
+  readonly #expectedDigest: string | undefined;
+  readonly #limits: CodeGraphCheckpointPackLimits;
+  readonly #queue = new ByteQueue();
+  #artifactBytes = 0;
+  #finished = false;
+  #gzipPrefix: number[] = [];
+  #header: CodeGraphCheckpointHeaderV1 | undefined;
+  #headerBytes: number | undefined;
+  #nextChunk = 0;
+  #payloadRemaining = 0;
+  #state: 'chunk-header' | 'chunk-payload' | 'done' | 'header' | 'prelude' = 'prelude';
+
+  constructor(options: CodeGraphCheckpointExpectedArtifactV1 & {limits?: Partial<CodeGraphCheckpointPackLimits>} = {}) {
+    this.#limits = resolveLimits(options.limits);
+    this.#expectedDescriptor = options.expectedDescriptor;
+    if (this.#expectedDescriptor) validateExpectedDescriptor(this.#expectedDescriptor, this.#limits);
+    this.#expectedDigest = options.expectedDigest
+      ? parsePrefixedDigest(options.expectedDigest, 'Expected digest')
+      : undefined;
+    if (
+      this.#expectedDescriptor &&
+      this.#expectedDigest &&
+      this.#expectedDescriptor.digest !== `sha256:${this.#expectedDigest}`
+    ) {
+      throw new CodeGraphCheckpointPackError('Expected checkpoint digests disagree.');
+    }
+  }
+
+  push(bytes: Uint8Array): void {
+    if (this.#finished) throw new CodeGraphCheckpointPackError('Checkpoint inspector is already finished.');
+    if (!(bytes instanceof Uint8Array)) throw new CodeGraphCheckpointPackError('Checkpoint input must be bytes.');
+    this.#artifactBytes = checkedAdd(this.#artifactBytes, bytes.byteLength, 'Checkpoint artifact size');
+    if (this.#artifactBytes > this.#limits.maximumArtifactBytes) {
+      throw new CodeGraphCheckpointPackError('Checkpoint artifact exceeds the byte limit.');
+    }
+    if (this.#expectedDescriptor && this.#artifactBytes > this.#expectedDescriptor.size) {
+      throw new CodeGraphCheckpointPackError('Checkpoint artifact exceeds its expected size.');
+    }
+    this.#artifact.update(bytes);
+    for (let offset = 0; offset < bytes.byteLength; offset += STREAM_FEED_BYTES) {
+      this.#queue.push(bytes.subarray(offset, Math.min(bytes.byteLength, offset + STREAM_FEED_BYTES)));
+      this.#drain();
+    }
+  }
+
+  finish(): CodeGraphCheckpointInspectionV1 {
+    if (this.#finished) throw new CodeGraphCheckpointPackError('Checkpoint inspector is already finished.');
+    this.#drain();
+    this.#finished = true;
+    if (this.#state !== 'done' || this.#queue.size !== 0 || !this.#header) {
+      throw new CodeGraphCheckpointPackError('Checkpoint artifact ended before its declared framing.');
+    }
+    const artifactDescriptor = descriptor(this.#artifactBytes, digestHex(this.#artifact));
+    verifyExpectedArtifact(artifactDescriptor, this.#expectedDescriptor, this.#expectedDigest);
+    return {descriptor: artifactDescriptor, header: this.#header, verification: 'artifact-and-framing'};
+  }
+
+  #drain(): void {
+    while (true) {
+      if (this.#state === 'prelude') {
+        const bytes = this.#queue.take(PRELUDE_BYTES);
+        if (!bytes) return;
+        if (!equalBytes(bytes.subarray(0, CHECKPOINT_MAGIC.byteLength), CHECKPOINT_MAGIC)) {
+          throw new CodeGraphCheckpointPackError('Checkpoint magic is invalid.');
+        }
+        const view = dataView(bytes);
+        if (view.getUint32(16, false) !== CODE_GRAPH_CHECKPOINT_FORMAT_VERSION) {
+          throw new CodeGraphCheckpointPackError('Checkpoint prelude version is unsupported.');
+        }
+        this.#headerBytes = view.getUint32(20, false);
+        if (this.#headerBytes === 0 || this.#headerBytes > this.#limits.maximumHeaderBytes) {
+          throw new CodeGraphCheckpointPackError('Checkpoint header exceeds the byte limit.');
+        }
+        this.#state = 'header';
+        continue;
+      }
+      if (this.#state === 'header') {
+        const bytes = this.#queue.take(this.#headerBytes!);
+        if (!bytes) return;
+        this.#header = decodeHeader(bytes, this.#limits);
+        this.#state = this.#header.chunks.length === 0 ? 'done' : 'chunk-header';
+        continue;
+      }
+      if (this.#state === 'chunk-header') {
+        const bytes = this.#queue.take(CHUNK_FRAME_HEADER_BYTES);
+        if (!bytes) return;
+        const expected = this.#header!.chunks[this.#nextChunk];
+        if (!expected) throw new CodeGraphCheckpointPackError('Checkpoint contains an undeclared chunk.');
+        validateChunkFrameHeader(bytes, expected);
+        this.#payloadRemaining = expected.compressedBytes;
+        this.#gzipPrefix = [];
+        this.#state = 'chunk-payload';
+        continue;
+      }
+      if (this.#state === 'chunk-payload') {
+        if (this.#queue.size === 0) return;
+        const consumed = Math.min(this.#queue.size, this.#payloadRemaining);
+        const bytes = this.#queue.take(consumed)!;
+        for (let index = 0; index < bytes.byteLength && this.#gzipPrefix.length < 3; index += 1) {
+          this.#gzipPrefix.push(bytes[index]!);
+        }
+        this.#payloadRemaining -= consumed;
+        if (this.#payloadRemaining > 0) continue;
+        if (this.#gzipPrefix[0] !== 0x1f || this.#gzipPrefix[1] !== 0x8b || this.#gzipPrefix[2] !== 8) {
+          throw new CodeGraphCheckpointPackError('Checkpoint chunk is not a gzip member.');
+        }
+        this.#nextChunk += 1;
+        this.#state = this.#nextChunk === this.#header!.chunks.length ? 'done' : 'chunk-header';
+        continue;
+      }
+      if (this.#queue.size > 0) throw new CodeGraphCheckpointPackError('Checkpoint artifact has trailing bytes.');
+      return;
+    }
+  }
+}
+
+/** Parse and authenticate exact framing without inflating any gzip member. */
+export function inspectCodeGraphCheckpointPackV1(
+  bytes: Uint8Array,
+  options: CodeGraphCheckpointExpectedArtifactV1 & {limits?: Partial<CodeGraphCheckpointPackLimits>} = {},
+): CodeGraphCheckpointInspectionV1 {
+  const inspector = new CodeGraphCheckpointStreamInspectorV1(options);
+  inspector.push(bytes);
+  return inspector.finish();
+}
+
+function encodePrefix(header: CodeGraphCheckpointHeaderV1, limits: CodeGraphCheckpointPackLimits): Uint8Array {
+  const headerBytes = canonicalBytes(header, limits.maximumHeaderBytes, 'Checkpoint header');
+  const prelude = new Uint8Array(PRELUDE_BYTES);
+  prelude.set(CHECKPOINT_MAGIC);
+  const view = dataView(prelude);
+  view.setUint32(16, CODE_GRAPH_CHECKPOINT_FORMAT_VERSION, false);
+  view.setUint32(20, headerBytes.byteLength, false);
+  return joinBytes([prelude, headerBytes]);
+}
+
+function encodeChunkFrame(descriptor: CodeGraphCheckpointChunkDescriptorV1, compressed: Uint8Array): Uint8Array {
+  const header = new Uint8Array(CHUNK_FRAME_HEADER_BYTES);
+  header.set(CHUNK_MAGIC);
+  const view = dataView(header);
+  view.setUint32(4, descriptor.ordinal, false);
+  view.setUint32(8, descriptor.compressedBytes, false);
+  view.setUint32(12, descriptor.uncompressedBytes, false);
+  view.setUint32(16, descriptor.recordCount, false);
+  header.set(hexBytes(descriptor.digest.digest), 20);
+  return joinBytes([header, compressed]);
+}
+
+function validateChunkFrame(bytes: Uint8Array, descriptor: CodeGraphCheckpointChunkDescriptorV1): void {
+  const expectedLength = checkedAdd(CHUNK_FRAME_HEADER_BYTES, descriptor.compressedBytes, 'Checkpoint chunk frame');
+  if (bytes.byteLength !== expectedLength)
+    throw new CodeGraphCheckpointPackError('Spool chunk frame length is invalid.');
+  validateChunkFrameHeader(bytes.subarray(0, CHUNK_FRAME_HEADER_BYTES), descriptor);
+}
+
+function validateChunkFrameHeader(bytes: Uint8Array, expected: CodeGraphCheckpointChunkDescriptorV1): void {
+  if (bytes.byteLength !== CHUNK_FRAME_HEADER_BYTES || !equalBytes(bytes.subarray(0, 4), CHUNK_MAGIC)) {
+    throw new CodeGraphCheckpointPackError('Checkpoint chunk magic is invalid.');
+  }
+  const view = dataView(bytes);
+  if (
+    view.getUint32(4, false) !== expected.ordinal ||
+    view.getUint32(8, false) !== expected.compressedBytes ||
+    view.getUint32(12, false) !== expected.uncompressedBytes ||
+    view.getUint32(16, false) !== expected.recordCount ||
+    !equalBytes(bytes.subarray(20, 52), hexBytes(expected.digest.digest))
+  ) {
+    throw new CodeGraphCheckpointPackError('Checkpoint chunk frame does not match its descriptor.');
+  }
+}
+
+function decodeHeader(bytes: Uint8Array, limits: CodeGraphCheckpointPackLimits): CodeGraphCheckpointHeaderV1 {
+  const header = parseCodeGraphCheckpointHeaderV1(parseCanonicalBytes(bytes, 'Checkpoint header'));
+  validateHeaderBounds(header, limits);
+  const actualAbi = codeGraphCheckpointAbiDigestV1(header.abi.input);
+  if (actualAbi.digest !== header.abi.digest) {
+    throw new CodeGraphCheckpointPackError('Checkpoint ABI digest does not match its input.');
+  }
+  return header;
+}
+
+function validateHeaderBounds(header: CodeGraphCheckpointHeaderV1, limits: CodeGraphCheckpointPackLimits): void {
+  if (header.chunks.length > limits.maximumChunks) {
+    throw new CodeGraphCheckpointPackError('Checkpoint header exceeds the chunk-count limit.');
+  }
+  let totalRecords = 0;
+  let lowerBoundBytes = PRELUDE_BYTES;
+  for (const chunk of header.chunks) {
+    if (chunk.compressedBytes > limits.maximumCompressedChunkBytes) {
+      throw new CodeGraphCheckpointPackError('Checkpoint declares an oversized compressed chunk.');
+    }
+    if (chunk.uncompressedBytes > limits.maximumUncompressedChunkBytes) {
+      throw new CodeGraphCheckpointPackError('Checkpoint declares an oversized uncompressed chunk.');
+    }
+    totalRecords = checkedAdd(totalRecords, chunk.recordCount, 'Checkpoint record count');
+    lowerBoundBytes = checkedAdd(
+      lowerBoundBytes,
+      checkedAdd(CHUNK_FRAME_HEADER_BYTES, chunk.compressedBytes, 'Checkpoint chunk frame'),
+      'Checkpoint artifact size',
+    );
+  }
+  if (totalRecords > limits.maximumRecords)
+    throw new CodeGraphCheckpointPackError('Checkpoint exceeds the record limit.');
+  if (lowerBoundBytes > limits.maximumArtifactBytes) {
+    throw new CodeGraphCheckpointPackError('Checkpoint declarations exceed the artifact byte limit.');
+  }
+}
+
+function inflateSingleMember(compressed: Uint8Array, expectedBytes: number): Uint8Array {
+  if (compressed.byteLength < 18) throw new CodeGraphCheckpointPackError('Checkpoint gzip member is truncated.');
+  const output = new Uint8Array(expectedBytes);
+  let offset = 0;
+  let final = false;
+  const gunzip = new Gunzip((data, isFinal) => {
+    if (data.byteLength > output.byteLength - offset) {
+      throw new CodeGraphCheckpointPackError('Checkpoint gzip member expands beyond its declared size.');
+    }
+    output.set(data, offset);
+    offset += data.byteLength;
+    final = isFinal;
+  });
+  gunzip.onmember = () => {
+    throw new CodeGraphCheckpointPackError('Checkpoint chunk contains concatenated gzip members.');
+  };
+  try {
+    gunzip.push(compressed, true);
+  } catch (cause) {
+    if (cause instanceof CodeGraphCheckpointPackError) throw cause;
+    throw new CodeGraphCheckpointPackError(
+      cause instanceof Error
+        ? `Checkpoint gzip member is invalid: ${cause.message}`
+        : 'Checkpoint gzip member is invalid.',
+    );
+  }
+  if (!final || offset !== expectedBytes) {
+    throw new CodeGraphCheckpointPackError('Checkpoint gzip member size does not match its descriptor.');
+  }
+  const trailer = dataView(compressed, compressed.byteLength - 8, 8);
+  if (trailer.getUint32(0, true) !== crc32(output) || trailer.getUint32(4, true) !== output.byteLength >>> 0) {
+    throw new CodeGraphCheckpointPackError('Checkpoint gzip member checksum or size is invalid.');
+  }
+  return output;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let value = 0xffff_ffff;
+  for (const byte of bytes) {
+    value ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) value = (value >>> 1) ^ (0xedb8_8320 & -(value & 1));
+  }
+  return (value ^ 0xffff_ffff) >>> 0;
+}
+
+function chunkDigest(ordinal: number, recordCount: number, bytes: Uint8Array): CodeGraphCheckpointDigestV1 {
+  return digestParts(CHUNK_DOMAIN, u32(ordinal), u32(recordCount), u32(bytes.byteLength), bytes);
+}
+
+function metadataFromHeader(header: CodeGraphCheckpointHeaderV1): CodeGraphCheckpointMetadataV1 {
+  return parseCodeGraphCheckpointMetadataV1({
+    abi: header.abi.input,
+    coverage: header.coverage,
+    repository: header.repository,
+    ...(header.reuse === undefined ? {} : {reuse: header.reuse}),
+    source: header.source,
+  });
+}
+
+function checkpointAttributionFiles(
+  metadata: CodeGraphCheckpointMetadataV1,
+): Map<string, CodeGraphCheckpointAttributionFileV1> {
+  return new Map((metadata.reuse?.inventory?.attributionFiles ?? []).map(file => [file.path, file]));
+}
+
+function consumeAttributionFile(
+  remaining: Map<string, CodeGraphCheckpointAttributionFileV1>,
+  record: Extract<CodeGraphCheckpointRecordV1, {readonly kind: 'file'}>,
+): void {
+  const expected = remaining.get(record.path);
+  if (expected === undefined) return;
+  if (
+    record.blobId !== expected.blobId ||
+    record.size !== expected.blobSize ||
+    record.contentHash !== expected.contentHash ||
+    record.language !== expected.language ||
+    record.mode !== expected.mode ||
+    record.source !== expected.source
+  ) {
+    throw new CodeGraphCheckpointPackError(
+      `Checkpoint attribution context does not match its file record: ${record.path}`,
+    );
+  }
+  remaining.delete(record.path);
+}
+
+function verifyAttributionFileCoverage(remaining: ReadonlyMap<string, CodeGraphCheckpointAttributionFileV1>): void {
+  if (remaining.size > 0) {
+    throw new CodeGraphCheckpointPackError(
+      'Checkpoint attribution context is not covered by exact graph file records.',
+    );
+  }
+}
+
+function verifyFileFactParity(
+  counts: CodeGraphCheckpointCountsV1,
+  eligibleFiles: number,
+  filePathDigest: string,
+  factPathDigest: string,
+): void {
+  if (counts.file !== eligibleFiles || counts['file-fact'] !== eligibleFiles) {
+    throw new CodeGraphCheckpointPackError('Checkpoint must contain one materialized fact for every eligible file.');
+  }
+  if (filePathDigest !== factPathDigest) {
+    throw new CodeGraphCheckpointPackError('Checkpoint file and materialized-fact path sets differ.');
+  }
+}
+
+function updateFramedText(hasher: Bun.CryptoHasher, value: string): void {
+  const bytes = UTF8.encode(value);
+  hasher.update(u32(bytes.byteLength));
+  hasher.update(bytes);
+}
+
+function parseCanonicalBytes(bytes: Uint8Array, label: string): unknown {
+  let text: string;
+  try {
+    text = UTF8_FATAL.decode(bytes);
+  } catch {
+    throw new CodeGraphCheckpointPackError(`${label} is not valid UTF-8.`);
+  }
+  try {
+    return parseCanonicalJson(text);
+  } catch (cause) {
+    throw new CodeGraphCheckpointPackError(
+      cause instanceof Error ? `${label} is invalid: ${cause.message}` : `${label} is invalid.`,
+    );
+  }
+}
+
+function canonicalBytes(value: unknown, maximumBytes = UINT32_MAXIMUM, label = 'Canonical JSON'): Uint8Array {
+  const bytes = UTF8.encode(canonicalJson(value));
+  if (bytes.byteLength === 0 || bytes.byteLength > maximumBytes || bytes.byteLength > UINT32_MAXIMUM) {
+    throw new CodeGraphCheckpointPackError(`${label} exceeds its UTF-8 byte limit.`);
+  }
+  return bytes;
+}
+
+function resolveLimits(overrides: Partial<CodeGraphCheckpointPackLimits> = {}): CodeGraphCheckpointPackLimits {
+  const limits = {...DEFAULT_CODE_GRAPH_CHECKPOINT_PACK_LIMITS, ...overrides};
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value <= 0 || value > UINT32_MAXIMUM) {
+      throw new CodeGraphCheckpointPackError(`${name} must be a positive uint32.`);
+    }
+  }
+  if (limits.targetUncompressedChunkBytes > limits.maximumUncompressedChunkBytes) {
+    throw new CodeGraphCheckpointPackError('Checkpoint target chunk size exceeds the maximum chunk size.');
+  }
+  if (limits.maximumRecordBytes + 4 > limits.maximumUncompressedChunkBytes) {
+    throw new CodeGraphCheckpointPackError('Checkpoint record limit does not fit within the chunk limit.');
+  }
+  return limits;
+}
+
+function validateExpectedDescriptor(
+  value: CodeGraphCheckpointDescriptorV1,
+  limits: CodeGraphCheckpointPackLimits,
+): void {
+  if (value.mediaType !== CODE_GRAPH_CHECKPOINT_MEDIA_TYPE) {
+    throw new CodeGraphCheckpointPackError('Expected checkpoint media type is invalid.');
+  }
+  if (!Number.isSafeInteger(value.size) || value.size <= 0 || value.size > limits.maximumArtifactBytes) {
+    throw new CodeGraphCheckpointPackError('Expected checkpoint size is invalid.');
+  }
+  parsePrefixedDigest(value.digest, 'Expected descriptor digest');
+}
+
+function verifyExpectedArtifact(
+  actual: CodeGraphCheckpointDescriptorV1,
+  expectedDescriptor: CodeGraphCheckpointDescriptorV1 | undefined,
+  expectedDigest: string | undefined,
+): void {
+  if (
+    expectedDescriptor &&
+    (actual.mediaType !== expectedDescriptor.mediaType ||
+      actual.size !== expectedDescriptor.size ||
+      actual.digest !== expectedDescriptor.digest)
+  ) {
+    throw new CodeGraphCheckpointPackError('Checkpoint artifact does not match its expected descriptor.');
+  }
+  if (expectedDigest && actual.digest !== `sha256:${expectedDigest}`) {
+    throw new CodeGraphCheckpointPackError('Checkpoint artifact does not match its expected digest.');
+  }
+}
+
+function parseBareDigest(value: CodeGraphCheckpointDigestV1, label: string): string {
+  if (value.algorithm !== 'sha256' || !/^[0-9a-f]{64}$/u.test(value.digest)) {
+    throw new CodeGraphCheckpointPackError(`${label} is invalid.`);
+  }
+  return value.digest;
+}
+
+function parsePrefixedDigest(value: string, label: string): string {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) throw new CodeGraphCheckpointPackError(`${label} is invalid.`);
+  return value.slice('sha256:'.length);
+}
+
+function descriptor(size: number, digest: string): CodeGraphCheckpointDescriptorV1 {
+  return {digest: `sha256:${digest}`, mediaType: CODE_GRAPH_CHECKPOINT_MEDIA_TYPE, size};
+}
+
+function digestParts(...parts: readonly Uint8Array[]): CodeGraphCheckpointDigestV1 {
+  const hasher = domainlessHasher();
+  for (const part of parts) hasher.update(part);
+  return {algorithm: 'sha256', digest: digestHex(hasher)};
+}
+
+function domainHasher(domain: Uint8Array): Bun.CryptoHasher {
+  return domainlessHasher().update(domain);
+}
+
+function domainlessHasher(): Bun.CryptoHasher {
+  return new Bun.CryptoHasher('sha256');
+}
+
+function digestHex(hasher: Bun.CryptoHasher): string {
+  return hasher.digest('hex');
+}
+
+function u32(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value) || value < 0 || value > UINT32_MAXIMUM) {
+    throw new CodeGraphCheckpointPackError('Checkpoint uint32 value is out of range.');
+  }
+  const bytes = new Uint8Array(4);
+  dataView(bytes).setUint32(0, value, false);
+  return bytes;
+}
+
+function hexBytes(value: string): Uint8Array {
+  if (!/^[0-9a-f]{64}$/u.test(value)) throw new CodeGraphCheckpointPackError('Checkpoint digest is invalid.');
+  return Uint8Array.from({length: 32}, (_, index) => Number.parseInt(value.slice(index * 2, index * 2 + 2), 16));
+}
+
+function dataView(bytes: Uint8Array, offset = 0, length = bytes.byteLength - offset): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, length);
+}
+
+function checkedAdd(left: number, right: number, label: string): number {
+  if (!Number.isSafeInteger(left) || !Number.isSafeInteger(right) || right > Number.MAX_SAFE_INTEGER - left) {
+    throw new CodeGraphCheckpointPackError(`${label} overflows.`);
+  }
+  return left + right;
+}
+
+function joinBytes(parts: readonly Uint8Array[], expected?: number): Uint8Array {
+  const length = expected ?? parts.reduce((total, part) => checkedAdd(total, part.byteLength, 'Byte sequence'), 0);
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    if (part.byteLength > output.byteLength - offset)
+      throw new CodeGraphCheckpointPackError('Byte sequence length is invalid.');
+    output.set(part, offset);
+    offset += part.byteLength;
+  }
+  if (offset !== output.byteLength) throw new CodeGraphCheckpointPackError('Byte sequence length is invalid.');
+  return output;
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index += 1) difference |= left[index]! ^ right[index]!;
+  return difference === 0;
+}
+
+class ByteQueue {
+  readonly #chunks: Uint8Array[] = [];
+  #firstOffset = 0;
+  #size = 0;
+
+  get size(): number {
+    return this.#size;
+  }
+
+  push(bytes: Uint8Array): void {
+    if (bytes.byteLength === 0) return;
+    this.#chunks.push(bytes.slice());
+    this.#size += bytes.byteLength;
+  }
+
+  take(size: number): Uint8Array | undefined {
+    if (size > this.#size) return undefined;
+    const output = new Uint8Array(size);
+    let outputOffset = 0;
+    while (outputOffset < size) {
+      const first = this.#chunks[0]!;
+      const available = first.byteLength - this.#firstOffset;
+      const copied = Math.min(available, size - outputOffset);
+      output.set(first.subarray(this.#firstOffset, this.#firstOffset + copied), outputOffset);
+      outputOffset += copied;
+      this.#firstOffset += copied;
+      this.#size -= copied;
+      if (this.#firstOffset === first.byteLength) {
+        this.#chunks.shift();
+        this.#firstOffset = 0;
+      }
+    }
+    return output;
+  }
+}

--- a/src/code_graph/checkpoint/projection.ts
+++ b/src/code_graph/checkpoint/projection.ts
@@ -1,0 +1,1486 @@
+import {Effect} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {sha256HexSync} from '../../crypto/sha256.js';
+import {runBinaryCommandEffect} from '../../effect/command.js';
+import {SystemInfo} from '../../effect/system.js';
+import {codeGraphCommittedContentHash} from '../content_identity.js';
+import {decodeStoredCodeGraphFact} from '../fact_storage.js';
+import {decodeCodeGraphInventoryReuseReceipt} from '../inventory_reuse.js';
+import {CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION} from '../inventory_policy.js';
+import {CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION} from '../store_build_core.js';
+import {
+  CODE_GRAPH_RESOLUTION_SURFACE_VERSION,
+  CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
+  type CodeGraphInventoryReuseReceipt,
+} from '../store_models.js';
+import {CodeGraphStore} from '../store.js';
+import {edgeFromRow, snapshotFromRow, symbolFromRow} from '../store_rows.js';
+import {type EdgeRow, type SnapshotRow, type SymbolRow} from '../store_internal_models.js';
+import {observeCleanRepositoryWorktree, revalidateRepositoryIdentityFence} from '../repository.js';
+import {
+  CODE_GRAPH_EXTRACTOR_GENERATION,
+  CODE_GRAPH_SCHEMA_VERSION,
+  type CodeGraphEdge,
+  type CodeGraphSnapshot,
+  type CodeGraphSymbol,
+  type RepositoryIdentity,
+} from '../types.js';
+import {compareCodeUnits} from '../ordering.js';
+import {codeGraphCheckpointFileFactCacheIdentity} from './file_fact_identity.js';
+import {
+  CODE_GRAPH_CHECKPOINT_ATTRIBUTION_CONTENT_BYTES_MAXIMUM,
+  CODE_GRAPH_CHECKPOINT_ATTRIBUTION_FILES_MAXIMUM,
+  CODE_GRAPH_CHECKPOINT_ATTRIBUTION_SOURCE_BYTES_MAXIMUM,
+  compareCodeGraphCheckpointRecordOrderKeys,
+  compareCodeGraphCheckpointRecords,
+  emptyCodeGraphCheckpointCounts,
+  isSafeCodeGraphCheckpointPath,
+  parseCodeGraphCheckpointMetadataV1,
+  parseCodeGraphCheckpointRecordV1,
+  type CodeGraphCheckpointAbiInputV1,
+  type CodeGraphCheckpointCountsV1,
+  type CodeGraphCheckpointCoverageV1,
+  type CodeGraphCheckpointMetadataV1,
+  type CodeGraphCheckpointPortableInventoryV1,
+  type CodeGraphCheckpointRecordV1,
+  type CodeGraphCheckpointReuseV1,
+  type CodeGraphCheckpointSpanV1,
+} from './schema.js';
+
+export const CODE_GRAPH_CHECKPOINT_PROJECTION_LEASE_MILLISECONDS = 30 * 60_000;
+export const CODE_GRAPH_CHECKPOINT_PROJECTION_LEASE_RENEWAL_INTERVAL_MILLISECONDS = 10 * 60_000;
+export const CODE_GRAPH_CHECKPOINT_PROJECTION_DEFAULT_PAGE_SIZE = 1_000;
+export const CODE_GRAPH_CHECKPOINT_PROJECTION_MAXIMUM_PAGE_SIZE = 1_000;
+
+const FILE_FACT_PAGE_SIZE_MAXIMUM = 8;
+const LANGUAGE_PACK_PROVENANCE_MAXIMUM = 1_024;
+export const CODE_GRAPH_CHECKPOINT_GIT_PATHSPEC_BYTES_MAXIMUM = 64 * 1_024;
+const GIT_TREE_OUTPUT_BYTES_MAXIMUM = 256 * 1_024;
+const GIT_TREE_FORMAT = '%(objectmode)%x09%(objecttype)%x09%(objectname)%x09%(objectsize)%x09%(path)';
+
+export class CodeGraphCheckpointProjectionError extends Error {
+  override readonly name = 'CodeGraphCheckpointProjectionError';
+}
+
+export interface CodeGraphCheckpointProjectionRequest<E = never, R = never> {
+  readonly abi: CodeGraphCheckpointAbiInputV1;
+  readonly databasePath: string;
+  readonly identity: RepositoryIdentity;
+  readonly pageSize?: number;
+  readonly snapshotId: string;
+  /** Called exactly once, inside the same SQLite read transaction as every record page. */
+  readonly writeMetadata: (metadata: CodeGraphCheckpointMetadataV1) => Effect.Effect<void, E, R>;
+  /** Receives non-empty pages in canonical checkpoint order. */
+  readonly writeRecords: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>;
+}
+
+export interface CodeGraphCheckpointProjectionSummary {
+  readonly counts: CodeGraphCheckpointCountsV1;
+  readonly metadata: CodeGraphCheckpointMetadataV1;
+  readonly snapshotId: string;
+}
+
+interface ProjectionFenceRow extends SnapshotRow {
+  readonly alias_count: number;
+  readonly file_set_fingerprint: string;
+  readonly generation: number;
+  readonly inventory_receipt_json: unknown;
+  readonly lexical_format_version: number;
+  readonly lexical_posting_count: number;
+  readonly lexical_symbol_count: number;
+  readonly lexical_term_count: number;
+  readonly lookup_count: number;
+  readonly repository_display_name: string;
+  readonly repository_object_format: string;
+  readonly reexport_count: number;
+  readonly reuse_extractor_set: string;
+  readonly reuse_format_version: number;
+  readonly resolution_surface_version: number;
+  readonly workspace_fingerprint: string;
+}
+
+interface PackProvenanceRow {
+  readonly cache_identity: string;
+  readonly derivation_identity: string;
+  readonly pack_id: string;
+  readonly resolution_domain: string;
+  readonly resolution_version: string;
+}
+
+interface SnapshotFileRow {
+  readonly content_hash: string;
+  readonly language: string;
+  readonly mode: string;
+  readonly path: string;
+  readonly raw_content_hash: unknown;
+  readonly size: number;
+  readonly source: string;
+}
+
+interface GitTreeEntry {
+  readonly blobId: string;
+  readonly mode: string;
+  readonly path: string;
+  readonly size: number;
+}
+
+interface FileFactRow {
+  readonly content_hash: string;
+  readonly extractor_set: string;
+  readonly facts_json: string;
+  readonly path: string;
+  readonly path_hint: string;
+  readonly shard_content_hash: string;
+}
+
+interface WorkspaceScopeRow {
+  readonly build_system: string;
+  readonly diagnostics_json: string;
+  readonly id: string;
+  readonly name: string;
+  readonly provenance: 'declared' | 'inferred';
+  readonly root: string;
+}
+
+interface WorkspaceComponentRow {
+  readonly build_system: string;
+  readonly diagnostics_json: string;
+  readonly id: string;
+  readonly kind: 'module' | 'package' | 'project' | 'target';
+  readonly languages_json: string;
+  readonly name: string;
+  readonly provenance: 'declared' | 'inferred';
+  readonly resolution_domain: string;
+  readonly root: string;
+  readonly source_roots_json: string;
+  readonly workspace_id: string;
+  readonly workspace_roots_json: string;
+}
+
+interface WorkspaceDependencyRow {
+  readonly evidence: unknown;
+  readonly provenance: 'declared' | 'inferred';
+  readonly source_component_id: string;
+  readonly target_component_id: string;
+}
+
+interface WorkspaceExternalDependencyRow {
+  readonly dependency_kind: 'development' | 'optional' | 'peer' | 'runtime';
+  readonly ecosystem: 'npm';
+  readonly evidence_path: string;
+  readonly evidence_span_json: unknown;
+  readonly import_alias: string;
+  readonly package_name: string;
+  readonly source_component_id: string;
+  readonly version_constraint: string;
+}
+
+interface SymbolLookupRow {
+  readonly evidence_edge_id: unknown;
+  readonly evidence_path: unknown;
+  readonly exported: number;
+  readonly lookup_key: string;
+  readonly provenance: 'alias' | 'symbol';
+  readonly resolution_domain: string;
+  readonly symbol_id: string;
+}
+
+interface ReexportRow {
+  readonly imported_name: string;
+  readonly local_name: string;
+  readonly source_path: string;
+  readonly target_path: string;
+}
+
+interface MonikerRow {
+  readonly component_id: unknown;
+  readonly dependency_kind: unknown;
+  readonly evidence_path: string;
+  readonly evidence_span_json: string;
+  readonly id: string;
+  readonly identity: string;
+  readonly import_path: unknown;
+  readonly kind: string;
+  readonly package_name: unknown;
+  readonly package_version: unknown;
+  readonly qualified_name: unknown;
+  readonly resolution_domain: string;
+  readonly role: 'export' | 'import';
+  readonly scheme: 'package' | 'protobuf';
+  readonly symbol_id: unknown;
+  readonly version: number;
+}
+
+interface LexicalRow {
+  readonly symbol_id: string;
+  readonly term: string;
+  readonly weight: number;
+}
+
+/**
+ * Streams one self-contained logical checkpoint projection without hydrating a graph in memory.
+ *
+ * The caller owns transport spooling and final output publication. This function owns the
+ * exact-clean Git fences, snapshot lease, one SQLite read transaction, bounded keyset pages,
+ * logical-row validation, and canonical record ordering.
+ */
+export function projectCodeGraphCheckpointV1<E, R>(request: CodeGraphCheckpointProjectionRequest<E, R>) {
+  return Effect.gen(function* () {
+    const pageSize = yield* attemptProjection('Checkpoint projection request is invalid.', () => {
+      validateProjectionIdentity(request.identity);
+      return normalizePageSize(request.pageSize);
+    });
+    const store = yield* CodeGraphStore;
+    yield* observeExactCleanRepository(request.identity, 'before');
+    const selected = yield* store.readySnapshotById(request.databasePath, request.snapshotId);
+    if (selected === undefined) {
+      return yield* Effect.fail(
+        new CodeGraphCheckpointProjectionError(`Ready snapshot ${request.snapshotId} was not found.`),
+      );
+    }
+    yield* attemptProjection('Checkpoint source snapshot is invalid.', () =>
+      validateSelectedSnapshot(selected, request.identity),
+    );
+    const lease = yield* store.acquireSnapshotLease(
+      request.databasePath,
+      selected.id,
+      CODE_GRAPH_CHECKPOINT_PROJECTION_LEASE_MILLISECONDS,
+    );
+    const renewLease = Effect.sleep(CODE_GRAPH_CHECKPOINT_PROJECTION_LEASE_RENEWAL_INTERVAL_MILLISECONDS).pipe(
+      Effect.andThen(
+        store.renewSnapshotLease(request.databasePath, lease, CODE_GRAPH_CHECKPOINT_PROJECTION_LEASE_MILLISECONDS),
+      ),
+      Effect.forever,
+    );
+    const projection = store
+      .withSession(request.databasePath, projectInReadTransaction(request, selected, pageSize), {readOnly: true})
+      .pipe(Effect.tap(() => observeExactCleanRepository(request.identity, 'after')));
+    return yield* Effect.raceFirst(projection, renewLease).pipe(
+      Effect.ensuring(store.releaseSnapshotLease(request.databasePath, lease).pipe(Effect.catch(() => Effect.void))),
+    );
+  });
+}
+
+function projectInReadTransaction<E, R>(
+  request: CodeGraphCheckpointProjectionRequest<E, R>,
+  selected: CodeGraphSnapshot,
+  pageSize: number,
+) {
+  return Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    return yield* sql.withTransaction(
+      Effect.gen(function* () {
+        const openingFence = yield* loadProjectionFence(sql, selected.id);
+        const snapshot = yield* attemptProjection('Checkpoint source snapshot is malformed.', () => {
+          const parsed = snapshotFromRow(openingFence);
+          validateSelectedSnapshot(parsed, request.identity);
+          return parsed;
+        });
+        const inventory = decodeCodeGraphInventoryReuseReceipt(openingFence.inventory_receipt_json);
+        if (inventory === undefined) {
+          return yield* projectionFailure('The selected snapshot has no valid reusable inventory receipt.');
+        }
+        const packs = yield* loadPackProvenance(sql, snapshot.id);
+        yield* attemptProjection('Checkpoint source fence is invalid.', () =>
+          validateFence(openingFence, snapshot, request.identity, request.abi, packs),
+        );
+        const attributionGitEntries = yield* loadGitTreeEntries(
+          request.identity,
+          snapshot.commit,
+          inventory.attributionFiles,
+        );
+        const metadata = yield* parseProjectionMetadata(
+          request.abi,
+          request.identity,
+          snapshot,
+          openingFence,
+          inventory,
+          attributionGitEntries,
+        );
+        yield* request.writeMetadata(metadata);
+
+        const counts = emptyCodeGraphCheckpointCounts();
+        let previous: CodeGraphCheckpointRecordV1 | undefined;
+        const emit = (records: readonly CodeGraphCheckpointRecordV1[]) =>
+          Effect.gen(function* () {
+            if (records.length === 0) return;
+            const parsed = yield* Effect.try({
+              try: () => records.map(parseCodeGraphCheckpointRecordV1),
+              catch: cause => projectionError('Checkpoint projection produced an invalid logical record.', cause),
+            });
+            for (const record of parsed) {
+              if (previous !== undefined && compareCodeGraphCheckpointRecords(previous, record) >= 0) {
+                return yield* projectionFailure(`Checkpoint projection record order changed at ${record.kind}.`);
+              }
+              counts[record.kind] += 1;
+              previous = record;
+            }
+            yield* request.writeRecords(parsed);
+          });
+
+        const filePathDigest = new Bun.CryptoHasher('sha256');
+        const factPathDigest = new Bun.CryptoHasher('sha256');
+        yield* streamFiles(sql, request.identity, snapshot, pageSize, filePathDigest, emit);
+        yield* streamFileFacts(sql, snapshot, Math.min(pageSize, FILE_FACT_PAGE_SIZE_MAXIMUM), factPathDigest, emit);
+        if (counts.file !== counts['file-fact'] || filePathDigest.digest('hex') !== factPathDigest.digest('hex')) {
+          return yield* projectionFailure('Checkpoint materialized file-fact coverage is incomplete.');
+        }
+        yield* streamWorkspaceScopes(sql, snapshot.id, pageSize, emit);
+        yield* streamWorkspaceComponents(sql, snapshot.id, pageSize, emit);
+        yield* streamWorkspaceDependencies(sql, snapshot.id, pageSize, emit);
+        yield* streamWorkspaceExternalDependencies(sql, snapshot.id, pageSize, emit);
+        yield* streamSymbols(sql, snapshot.id, pageSize, emit);
+        const aliases = yield* streamSymbolLookups(sql, snapshot.id, pageSize, emit);
+        yield* streamReexports(sql, snapshot.id, pageSize, emit);
+        yield* streamEdges(sql, snapshot.id, pageSize, emit);
+        yield* streamMonikers(sql, snapshot.id, pageSize, emit);
+        yield* streamLexical(sql, snapshot.id, pageSize, emit);
+        yield* emit(
+          packs.map(pack => ({
+            cacheIdentity: pack.cache_identity,
+            derivationIdentity: pack.derivation_identity,
+            id: pack.pack_id,
+            kind: 'pack-provenance' as const,
+            resolutionDomain: pack.resolution_domain,
+            resolutionVersion: pack.resolution_version,
+          })),
+        );
+
+        yield* attemptProjection('Checkpoint projection counts are invalid.', () =>
+          validateProjectedCounts(counts, aliases, openingFence, snapshot, packs.length),
+        );
+        yield* validateLexicalCounts(sql, snapshot.id, openingFence);
+        const closingFence = yield* loadProjectionFence(sql, selected.id);
+        const fenceChanged = yield* attemptProjection(
+          'Checkpoint source fence could not be compared.',
+          () => projectionFenceDigest(openingFence) !== projectionFenceDigest(closingFence),
+        );
+        if (fenceChanged) {
+          return yield* projectionFailure('The ready snapshot changed during checkpoint projection.');
+        }
+        return {
+          counts: {...counts},
+          metadata,
+          snapshotId: snapshot.id,
+        } satisfies CodeGraphCheckpointProjectionSummary;
+      }),
+    );
+  });
+}
+
+function normalizePageSize(value: number | undefined): number {
+  const pageSize = value ?? CODE_GRAPH_CHECKPOINT_PROJECTION_DEFAULT_PAGE_SIZE;
+  if (
+    !Number.isSafeInteger(pageSize) ||
+    pageSize < 1 ||
+    pageSize > CODE_GRAPH_CHECKPOINT_PROJECTION_MAXIMUM_PAGE_SIZE
+  ) {
+    throw new CodeGraphCheckpointProjectionError(
+      `Checkpoint projection page size must be an integer from 1 to ${CODE_GRAPH_CHECKPOINT_PROJECTION_MAXIMUM_PAGE_SIZE}.`,
+    );
+  }
+  return pageSize;
+}
+
+function validateProjectionIdentity(identity: RepositoryIdentity): void {
+  if (identity.remoteIdentity === undefined) {
+    throw new CodeGraphCheckpointProjectionError(
+      'Portable checkpoints require a credential-free remote repository identity.',
+    );
+  }
+  if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(identity.headCommit)) {
+    throw new CodeGraphCheckpointProjectionError('Checkpoint repository HEAD is not a Git object ID.');
+  }
+}
+
+function validateSelectedSnapshot(snapshot: CodeGraphSnapshot, identity: RepositoryIdentity): void {
+  if (
+    snapshot.state !== 'ready' ||
+    snapshot.dirty ||
+    snapshot.baseSnapshotId !== undefined ||
+    snapshot.repositoryId !== identity.repositoryId ||
+    snapshot.commit !== identity.headCommit
+  ) {
+    throw new CodeGraphCheckpointProjectionError(
+      'Checkpoint export requires the exact ready CLEAN root snapshot for the current repository HEAD.',
+    );
+  }
+  if (snapshot.graphContentId === undefined) {
+    throw new CodeGraphCheckpointProjectionError('Checkpoint source snapshot has no graph content identity.');
+  }
+}
+
+function observeExactCleanRepository(identity: RepositoryIdentity, phase: 'after' | 'before') {
+  return Effect.gen(function* () {
+    const observed = yield* revalidateRepositoryIdentityFence(identity.repoRoot, identity);
+    if (
+      observed.repositoryId !== identity.repositoryId ||
+      observed.checkoutId !== identity.checkoutId ||
+      observed.worktreeId !== identity.worktreeId ||
+      observed.headCommit !== identity.headCommit ||
+      observed.objectFormat !== identity.objectFormat
+    ) {
+      return yield* projectionFailure(`Repository identity changed ${phase} checkpoint projection.`);
+    }
+    if ((yield* observeCleanRepositoryWorktree(observed.repoRoot)) === undefined) {
+      return yield* projectionFailure(`Repository worktree was not clean ${phase} checkpoint projection.`);
+    }
+  });
+}
+
+function loadProjectionFence(sql: SqlClient.SqlClient, snapshotId: string) {
+  return Effect.gen(function* () {
+    const rows = yield* sql.unsafe<ProjectionFenceRow>(
+      `SELECT snapshot.*,
+              repository.display_name AS repository_display_name,
+              repository.object_format AS repository_object_format,
+              generation.generation,
+              receipt.format_version AS reuse_format_version,
+              receipt.resolution_surface_version,
+              receipt.extractor_set AS reuse_extractor_set,
+              receipt.workspace_fingerprint,
+              receipt.file_set_fingerprint,
+              receipt.lookup_count,
+              receipt.alias_count,
+              receipt.reexport_count,
+              receipt.inventory_receipt_json,
+              lexical.format_version AS lexical_format_version,
+              lexical.posting_count AS lexical_posting_count,
+              lexical.symbol_count AS lexical_symbol_count,
+              lexical.term_count AS lexical_term_count
+       FROM snapshots AS snapshot
+       JOIN repositories AS repository ON repository.id = snapshot.repository_id
+       JOIN snapshot_extractor_generations AS generation ON generation.snapshot_id = snapshot.id
+       JOIN snapshot_reuse_receipts AS receipt ON receipt.snapshot_id = snapshot.id
+       JOIN lexical_storage_formats AS lexical ON lexical.snapshot_id = snapshot.id
+       WHERE snapshot.id = ?
+       LIMIT 2`,
+      [snapshotId],
+    );
+    if (rows.length !== 1) {
+      return yield* projectionFailure('The selected snapshot is not a complete reusable checkpoint root.');
+    }
+    return rows[0]!;
+  });
+}
+
+function loadPackProvenance(sql: SqlClient.SqlClient, snapshotId: string) {
+  return Effect.gen(function* () {
+    const rows = yield* sql.unsafe<PackProvenanceRow>(
+      `SELECT pack_id, cache_identity, derivation_identity, resolution_domain, resolution_version
+       FROM snapshot_pack_provenance
+       WHERE snapshot_id = ?
+       ORDER BY pack_id COLLATE BINARY
+       LIMIT ?`,
+      [snapshotId, LANGUAGE_PACK_PROVENANCE_MAXIMUM + 1],
+    );
+    if (rows.length > LANGUAGE_PACK_PROVENANCE_MAXIMUM) {
+      return yield* projectionFailure('Checkpoint language-pack provenance exceeds the bounded maximum.');
+    }
+    return rows;
+  });
+}
+
+function validateFence(
+  row: ProjectionFenceRow,
+  snapshot: CodeGraphSnapshot,
+  identity: RepositoryIdentity,
+  abi: CodeGraphCheckpointAbiInputV1,
+  packs: readonly PackProvenanceRow[],
+): void {
+  if (
+    row.repository_display_name !== identity.displayName ||
+    row.repository_object_format !== identity.objectFormat ||
+    row.generation < CODE_GRAPH_EXTRACTOR_GENERATION ||
+    row.reuse_format_version !== CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION ||
+    row.resolution_surface_version !== CODE_GRAPH_RESOLUTION_SURFACE_VERSION ||
+    row.reuse_extractor_set !== snapshot.extractorSet ||
+    row.lexical_format_version !== CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION ||
+    abi.graphSchemaVersion !== CODE_GRAPH_SCHEMA_VERSION ||
+    abi.inventoryPolicyVersion !== CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION ||
+    abi.lexicalLogicalFormatVersion !== CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION
+  ) {
+    throw new CodeGraphCheckpointProjectionError('Checkpoint source ABI or reusable snapshot receipt is incompatible.');
+  }
+  const persistedPacks = packs.map(pack => ({
+    cacheIdentity: pack.cache_identity,
+    derivationIdentity: pack.derivation_identity,
+    id: pack.pack_id,
+    resolutionDomain: pack.resolution_domain,
+    resolutionVersion: pack.resolution_version,
+  }));
+  if (JSON.stringify(persistedPacks) !== JSON.stringify(abi.languagePacks)) {
+    throw new CodeGraphCheckpointProjectionError(
+      'Checkpoint ABI language-pack provenance does not match the ready snapshot.',
+    );
+  }
+}
+
+function parseProjectionMetadata(
+  abi: CodeGraphCheckpointAbiInputV1,
+  identity: RepositoryIdentity,
+  snapshot: CodeGraphSnapshot,
+  fence: ProjectionFenceRow,
+  inventory: CodeGraphInventoryReuseReceipt,
+  attributionGitEntries: ReadonlyMap<string, GitTreeEntry>,
+) {
+  return Effect.try({
+    try: () =>
+      parseCodeGraphCheckpointMetadataV1({
+        abi,
+        coverage: codeGraphCheckpointCoverage(snapshot.fileCount, inventory),
+        repository: {
+          caseMode: identity.caseMode,
+          displayName: identity.displayName,
+          objectFormat: identity.objectFormat,
+          repositoryId: identity.repositoryId,
+        },
+        reuse: portableReuse(fence, inventory, attributionGitEntries, identity.objectFormat),
+        source: {
+          commit: snapshot.commit,
+          extractorSet: snapshot.extractorSet,
+          graphContentId: snapshot.graphContentId!,
+        },
+      }),
+    catch: cause => projectionError('Checkpoint metadata could not be projected safely.', cause),
+  });
+}
+
+export function codeGraphCheckpointCoverage(
+  eligibleFiles: number,
+  inventory: Pick<CodeGraphInventoryReuseReceipt, 'policyExclusions' | 'skipped'>,
+): CodeGraphCheckpointCoverageV1 {
+  if (
+    !Number.isSafeInteger(eligibleFiles) ||
+    eligibleFiles < 0 ||
+    inventory.policyExclusions.files > inventory.skipped
+  ) {
+    throw new CodeGraphCheckpointProjectionError('Checkpoint inventory coverage is inconsistent.');
+  }
+  const reasons: Array<CodeGraphCheckpointCoverageV1['reasons'][number]> = inventory.policyExclusions.reasons
+    .filter(reason => reason.files > 0)
+    .map(reason => ({bytes: reason.bytes, code: reason.reason, files: reason.files}));
+  const residual = inventory.skipped - inventory.policyExclusions.files;
+  if (residual > 0) reasons.push({bytes: 0, code: 'inventory-other', files: residual});
+  reasons.sort((left, right) => compareCodeUnits(left.code, right.code));
+  return {
+    eligibleFiles,
+    excludedFiles: inventory.skipped,
+    reasons,
+    state: inventory.skipped === 0 ? 'complete' : 'partial',
+  };
+}
+
+function portableReuse(
+  fence: ProjectionFenceRow,
+  inventory: CodeGraphInventoryReuseReceipt,
+  attributionGitEntries: ReadonlyMap<string, GitTreeEntry>,
+  objectFormat: RepositoryIdentity['objectFormat'],
+): CodeGraphCheckpointReuseV1 {
+  const portable = portableInventory(inventory, attributionGitEntries, objectFormat);
+  const portableBytes = portable.attributionFiles.reduce(
+    (totals, file) => ({content: totals.content + file.size, source: totals.source + file.blobSize}),
+    {content: 0, source: 0},
+  );
+  const inventoryIsPortable =
+    portable.attributionFiles.length <= CODE_GRAPH_CHECKPOINT_ATTRIBUTION_FILES_MAXIMUM &&
+    portableBytes.content <= CODE_GRAPH_CHECKPOINT_ATTRIBUTION_CONTENT_BYTES_MAXIMUM &&
+    portableBytes.source <= CODE_GRAPH_CHECKPOINT_ATTRIBUTION_SOURCE_BYTES_MAXIMUM;
+  return {
+    fileSetFingerprint: fence.file_set_fingerprint,
+    formatVersion: fence.reuse_format_version,
+    ...(inventoryIsPortable ? {inventory: portable} : {}),
+    resolutionSurfaceVersion: fence.resolution_surface_version,
+    workspaceFingerprint: fence.workspace_fingerprint,
+  };
+}
+
+function portableInventory(
+  inventory: CodeGraphInventoryReuseReceipt,
+  attributionGitEntries: ReadonlyMap<string, GitTreeEntry>,
+  objectFormat: RepositoryIdentity['objectFormat'],
+): CodeGraphCheckpointPortableInventoryV1 {
+  return {
+    attributionFiles: inventory.attributionFiles.map(file => {
+      const git = attributionGitEntries.get(file.path);
+      if (
+        git === undefined ||
+        git.blobId !== file.blobId ||
+        git.mode !== file.mode ||
+        codeGraphCommittedContentHash(objectFormat, git.blobId) !== file.contentHash
+      ) {
+        throw new CodeGraphCheckpointProjectionError(
+          `Checkpoint attribution context does not match exact commit path ${file.path}.`,
+        );
+      }
+      return {
+        blobId: file.blobId,
+        blobSize: git.size,
+        contentHash: file.contentHash,
+        language: file.language,
+        mode: file.mode,
+        path: file.path,
+        size: file.size,
+        source: 'commit' as const,
+      };
+    }),
+    contract: inventory.contract,
+    ...(inventory.diagnostics.length === 0 ? {} : {diagnostics: inventory.diagnostics}),
+    includeOpaqueCorpusAssets: inventory.includeOpaqueCorpusAssets,
+    policyExclusions: {
+      ...inventory.policyExclusions,
+      reasons: [...inventory.policyExclusions.reasons].sort((left, right) =>
+        compareCodeUnits(left.reason, right.reason),
+      ),
+    },
+    skipped: inventory.skipped,
+    version: inventory.version,
+    workspace: {
+      ...inventory.workspace,
+      projects: [...inventory.workspace.projects].sort((left, right) => compareCodeUnits(left.id, right.id)),
+      workspaces: [...inventory.workspace.workspaces].sort((left, right) => compareCodeUnits(left.id, right.id)),
+    },
+  };
+}
+
+function streamFiles<E, R>(
+  sql: SqlClient.SqlClient,
+  identity: RepositoryIdentity,
+  snapshot: CodeGraphSnapshot,
+  pageSize: number,
+  pathDigest: Bun.CryptoHasher,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamSingleCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<SnapshotFileRow>(
+        `SELECT path, content_hash, raw_content_hash, language, mode, size, source
+         FROM snapshot_files
+         WHERE snapshot_id = ? AND (? IS NULL OR path > ? COLLATE BINARY)
+         ORDER BY path COLLATE BINARY
+         LIMIT ?`,
+        [snapshot.id, cursor ?? null, cursor ?? null, pageSize],
+      ),
+    row => row.path,
+    rows =>
+      Effect.gen(function* () {
+        const gitEntries = yield* loadGitTreeEntries(identity, snapshot.commit, rows);
+        const records = yield* attemptProjection('Checkpoint file metadata is malformed.', () =>
+          rows.map(row => {
+            const git = gitEntries.get(row.path);
+            if (
+              git === undefined ||
+              row.source !== 'commit' ||
+              git.mode !== row.mode ||
+              git.size !== Number(row.size) ||
+              codeGraphCommittedContentHash(identity.objectFormat, git.blobId) !== row.content_hash
+            ) {
+              throw new CodeGraphCheckpointProjectionError(
+                `Checkpoint file metadata does not match exact commit path ${row.path}.`,
+              );
+            }
+            updatePathDigest(pathDigest, row.path);
+            const rawContentHash = optionalText(row.raw_content_hash);
+            return {
+              blobId: git.blobId,
+              contentHash: row.content_hash,
+              kind: 'file' as const,
+              language: row.language,
+              mode: row.mode,
+              path: row.path,
+              ...(rawContentHash === undefined ? {} : {rawContentHash}),
+              size: Number(row.size),
+              source: 'commit' as const,
+            };
+          }),
+        );
+        yield* emit(records);
+      }),
+  );
+}
+
+function loadGitTreeEntries<T extends {readonly path: string}>(
+  identity: RepositoryIdentity,
+  commit: string,
+  files: readonly T[],
+) {
+  return Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    if (files.some(file => !isSafeCodeGraphCheckpointPath(file.path))) {
+      return yield* projectionFailure('Checkpoint source contains an unsafe repository path.');
+    }
+    const entries = new Map<string, GitTreeEntry>();
+    const batches = yield* attemptProjection('Checkpoint Git path batching failed.', () =>
+      codeGraphCheckpointGitPathBatches(files),
+    );
+    for (const batch of batches) {
+      const result = yield* runBinaryCommandEffect(
+        'git',
+        [
+          '-C',
+          identity.repoRoot,
+          'ls-tree',
+          '-z',
+          '--full-tree',
+          `--format=${GIT_TREE_FORMAT}`,
+          commit,
+          '--',
+          ...batch.map(file => file.path),
+        ],
+        {
+          env: {...system.environment(), GIT_LITERAL_PATHSPECS: '1'},
+          maxOutputBytes: GIT_TREE_OUTPUT_BYTES_MAXIMUM,
+          timeoutMs: 30_000,
+        },
+      );
+      const observed = yield* Effect.try({
+        try: () => parseGitTreeEntries(result.stdout, identity.objectFormat),
+        catch: cause => projectionError('Exact-commit Git file metadata is malformed.', cause),
+      });
+      for (const [path, entry] of observed) {
+        if (entries.has(path)) return yield* projectionFailure('Exact-commit Git file metadata is duplicated.');
+        entries.set(path, entry);
+      }
+    }
+    if (entries.size !== files.length || files.some(file => !entries.has(file.path))) {
+      return yield* projectionFailure('Exact-commit Git file metadata is incomplete.');
+    }
+    return entries;
+  });
+}
+
+/** Split literal Git pathspec arguments under a reviewed byte ceiling, independently of row-page tuning. */
+export function codeGraphCheckpointGitPathBatches<T extends {readonly path: string}>(
+  files: readonly T[],
+): readonly (readonly T[])[] {
+  const encoder = new TextEncoder();
+  const batches: T[][] = [];
+  let batch: T[] = [];
+  let bytes = 0;
+  for (const file of files) {
+    // One byte accounts for argv's terminating NUL. Fixed Git arguments stay
+    // outside this budget and leave ample space below the platform ARG_MAX.
+    const pathBytes = encoder.encode(file.path).byteLength + 1;
+    if (pathBytes > CODE_GRAPH_CHECKPOINT_GIT_PATHSPEC_BYTES_MAXIMUM) {
+      throw new CodeGraphCheckpointProjectionError('Checkpoint Git path exceeds the pathspec byte budget.');
+    }
+    if (batch.length > 0 && bytes > CODE_GRAPH_CHECKPOINT_GIT_PATHSPEC_BYTES_MAXIMUM - pathBytes) {
+      batches.push(batch);
+      batch = [];
+      bytes = 0;
+    }
+    batch.push(file);
+    bytes += pathBytes;
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches;
+}
+
+export function parseGitTreeEntries(
+  output: Uint8Array,
+  objectFormat: RepositoryIdentity['objectFormat'],
+): ReadonlyMap<string, GitTreeEntry> {
+  const text = new TextDecoder('utf-8', {fatal: true}).decode(output);
+  if (text.length === 0) return new Map();
+  if (!text.endsWith('\0')) throw new CodeGraphCheckpointProjectionError('Git tree output is not NUL terminated.');
+  const entries = new Map<string, GitTreeEntry>();
+  const objectIdPattern = objectFormat === 'sha1' ? /^[0-9a-f]{40}$/u : /^[0-9a-f]{64}$/u;
+  for (const encoded of text.slice(0, -1).split('\0')) {
+    const fields = encoded.split('\t');
+    if (fields.length !== 5) throw new CodeGraphCheckpointProjectionError('Git tree entry is malformed.');
+    const [mode, type, blobId, encodedSize, path] = fields as [string, string, string, string, string];
+    const size = Number(encodedSize);
+    if (
+      !/^\d{6}$/u.test(mode) ||
+      type !== 'blob' ||
+      !objectIdPattern.test(blobId) ||
+      !Number.isSafeInteger(size) ||
+      size < 0 ||
+      !isSafeCodeGraphCheckpointPath(path) ||
+      entries.has(path)
+    ) {
+      throw new CodeGraphCheckpointProjectionError('Git tree entry is invalid.');
+    }
+    entries.set(path, {blobId, mode, path, size});
+  }
+  return entries;
+}
+
+function streamFileFacts<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshot: CodeGraphSnapshot,
+  pageSize: number,
+  pathDigest: Bun.CryptoHasher,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamSingleCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<FileFactRow>(
+        `SELECT file.path, file.content_hash, shard.content_hash AS shard_content_hash,
+                shard.path_hint, shard.extractor_set, shard.facts_json
+         FROM snapshot_files AS file
+         JOIN snapshot_file_shards AS association
+           ON association.snapshot_id = file.snapshot_id AND association.path = file.path
+         JOIN materialized_file_shards AS shard ON shard.id = association.shard_id
+         WHERE file.snapshot_id = ? AND (? IS NULL OR file.path > ? COLLATE BINARY)
+         ORDER BY file.path COLLATE BINARY
+         LIMIT ?`,
+        [snapshot.id, cursor ?? null, cursor ?? null, pageSize],
+      ),
+    row => row.path,
+    rows =>
+      Effect.gen(function* () {
+        const records = yield* Effect.try({
+          try: () =>
+            rows.map(row => {
+              if (
+                row.path_hint !== row.path ||
+                row.extractor_set !== snapshot.extractorSet ||
+                row.shard_content_hash !== row.content_hash
+              ) {
+                throw new CodeGraphCheckpointProjectionError(
+                  `Materialized checkpoint fact provenance changed for ${row.path}.`,
+                );
+              }
+              const facts = decodeStoredCodeGraphFact(row.facts_json, row.path).facts;
+              updatePathDigest(pathDigest, row.path);
+              return {
+                cacheIdentity: codeGraphCheckpointFileFactCacheIdentity(facts),
+                factRole: 'materialized' as const,
+                facts,
+                kind: 'file-fact' as const,
+                path: row.path,
+              };
+            }),
+          catch: cause => projectionError('Materialized checkpoint file facts are invalid.', cause),
+        });
+        yield* emit(records);
+      }),
+  );
+}
+
+function streamWorkspaceScopes<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamSingleCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<WorkspaceScopeRow>(
+        `SELECT id, build_system, name, root, provenance, diagnostics_json
+         FROM workspace_scopes
+         WHERE snapshot_id = ? AND (? IS NULL OR id > ? COLLATE BINARY)
+         ORDER BY id COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor ?? null, cursor ?? null, pageSize],
+      ),
+    row => row.id,
+    rows =>
+      decodeAndEmit(
+        rows,
+        row => ({
+          buildSystem: row.build_system,
+          diagnostics: parseStringArray(row.diagnostics_json, 'workspace diagnostics'),
+          id: row.id,
+          kind: 'workspace-scope',
+          name: row.name,
+          provenance: row.provenance,
+          root: row.root,
+        }),
+        emit,
+        'workspace scopes',
+      ),
+  );
+}
+
+function streamWorkspaceComponents<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamSingleCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<WorkspaceComponentRow>(
+        `SELECT id, workspace_id, build_system, kind, name, root, resolution_domain,
+                languages_json, source_roots_json, workspace_roots_json, provenance, diagnostics_json
+         FROM workspace_components
+         WHERE snapshot_id = ? AND (? IS NULL OR id > ? COLLATE BINARY)
+         ORDER BY id COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor ?? null, cursor ?? null, pageSize],
+      ),
+    row => row.id,
+    rows =>
+      decodeAndEmit(
+        rows,
+        row => ({
+          buildSystem: row.build_system,
+          componentKind: row.kind,
+          diagnostics: parseStringArray(row.diagnostics_json, 'component diagnostics'),
+          id: row.id,
+          kind: 'workspace-component',
+          languages: parseStringArray(row.languages_json, 'component languages'),
+          name: row.name,
+          provenance: row.provenance,
+          resolutionDomain: row.resolution_domain,
+          root: row.root,
+          sourceRoots: parseStringArray(row.source_roots_json, 'component source roots'),
+          workspaceId: row.workspace_id,
+          workspaceRoots: parseStringArray(row.workspace_roots_json, 'component workspace roots'),
+        }),
+        emit,
+        'workspace components',
+      ),
+  );
+}
+
+function streamWorkspaceDependencies<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamCompositeCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<WorkspaceDependencyRow>(
+        `SELECT source_component_id, target_component_id, provenance, evidence
+         FROM workspace_component_dependencies
+         WHERE snapshot_id = ?
+           AND (? IS NULL OR (source_component_id, target_component_id, provenance) > (?, ?, ?))
+         ORDER BY source_component_id COLLATE BINARY, target_component_id COLLATE BINARY, provenance COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor?.[0] ?? null, ...(cursor ?? ['', '', '']), pageSize],
+      ),
+    row => [row.source_component_id, row.target_component_id, row.provenance],
+    rows =>
+      emit(
+        rows.map(row => {
+          const evidence = optionalText(row.evidence);
+          return {
+            ...(evidence === undefined ? {} : {evidence}),
+            kind: 'workspace-dependency' as const,
+            provenance: row.provenance,
+            sourceComponentId: row.source_component_id,
+            targetComponentId: row.target_component_id,
+          };
+        }),
+      ),
+  );
+}
+
+function streamWorkspaceExternalDependencies<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamCompositeCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<WorkspaceExternalDependencyRow>(
+        `SELECT source_component_id, ecosystem, package_name, import_alias, dependency_kind,
+                version_constraint, evidence_path, evidence_span_json
+         FROM workspace_external_dependencies
+         WHERE snapshot_id = ?
+           AND (? IS NULL OR (
+             source_component_id, ecosystem, package_name, import_alias,
+             dependency_kind, version_constraint, evidence_path
+           ) > (?, ?, ?, ?, ?, ?, ?))
+         ORDER BY source_component_id COLLATE BINARY, ecosystem COLLATE BINARY, package_name COLLATE BINARY,
+                  import_alias COLLATE BINARY, dependency_kind COLLATE BINARY,
+                  version_constraint COLLATE BINARY, evidence_path COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor?.[0] ?? null, ...(cursor ?? ['', '', '', '', '', '', '']), pageSize],
+      ),
+    row => [
+      row.source_component_id,
+      row.ecosystem,
+      row.package_name,
+      row.import_alias,
+      row.dependency_kind,
+      row.version_constraint,
+      row.evidence_path,
+    ],
+    rows =>
+      decodeAndEmit(
+        rows,
+        row => {
+          const evidenceSpan = parseOptionalSpan(row.evidence_span_json, 'external dependency evidence span');
+          return {
+            dependencyKind: row.dependency_kind,
+            ecosystem: row.ecosystem,
+            evidencePath: row.evidence_path,
+            ...(evidenceSpan === undefined ? {} : {evidenceSpan}),
+            importAlias: row.import_alias,
+            kind: 'workspace-external-dependency',
+            packageName: row.package_name,
+            sourceComponentId: row.source_component_id,
+            versionConstraint: row.version_constraint,
+          };
+        },
+        emit,
+        'workspace external dependencies',
+      ),
+  );
+}
+
+function streamSymbols<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamSingleCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<SymbolRow>(
+        `SELECT id, content_hash, kind, name, qualified_name, path, language, arity,
+                lookup_keys_json, resolution_domain, resolution_scope_id, package_name,
+                exported, signature, documentation, span_json
+         FROM symbols
+         WHERE snapshot_id = ? AND (? IS NULL OR id > ? COLLATE BINARY)
+         ORDER BY id COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor ?? null, cursor ?? null, pageSize],
+      ),
+    row => row.id,
+    rows => decodeAndEmit(rows, row => symbolRecord(symbolFromRow(row)), emit, 'symbols'),
+  );
+}
+
+function symbolRecord(symbol: CodeGraphSymbol): CodeGraphCheckpointRecordV1 {
+  return {
+    ...(symbol.arity === undefined ? {} : {arity: symbol.arity}),
+    contentHash: symbol.contentHash,
+    ...(symbol.documentation === undefined ? {} : {documentation: symbol.documentation}),
+    exported: symbol.exported,
+    id: symbol.id,
+    kind: 'symbol',
+    language: symbol.language,
+    ...(symbol.lookupKeys === undefined ? {} : {lookupKeys: symbol.lookupKeys}),
+    name: symbol.name,
+    ...(symbol.packageName === undefined ? {} : {packageName: symbol.packageName}),
+    path: symbol.path,
+    qualifiedName: symbol.qualifiedName,
+    ...(symbol.resolutionDomain === undefined ? {} : {resolutionDomain: symbol.resolutionDomain}),
+    ...(symbol.resolutionScopeId === undefined ? {} : {resolutionScopeId: symbol.resolutionScopeId}),
+    ...(symbol.signature === undefined ? {} : {signature: symbol.signature}),
+    span: symbol.span,
+    symbolKind: symbol.kind,
+  };
+}
+
+function streamSymbolLookups<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return Effect.gen(function* () {
+    let aliases = 0;
+    yield* streamCompositeCursorPages(
+      undefined,
+      cursor =>
+        sql.unsafe<SymbolLookupRow>(
+          `SELECT lookup_key, symbol_id, resolution_domain, exported, provenance,
+                  evidence_edge_id, evidence_path
+           FROM snapshot_symbol_lookup
+           WHERE snapshot_id = ? AND (? IS NULL OR (lookup_key, symbol_id) > (?, ?))
+           ORDER BY lookup_key COLLATE BINARY, symbol_id COLLATE BINARY
+           LIMIT ?`,
+          [snapshotId, cursor?.[0] ?? null, ...(cursor ?? ['', '']), pageSize],
+        ),
+      row => [row.lookup_key, row.symbol_id],
+      rows =>
+        Effect.gen(function* () {
+          aliases += rows.filter(row => row.provenance === 'alias').length;
+          yield* emit(
+            rows.map(row => {
+              const evidenceEdgeId = optionalText(row.evidence_edge_id);
+              const evidencePath = optionalText(row.evidence_path);
+              return {
+                ...(evidenceEdgeId === undefined ? {} : {evidenceEdgeId}),
+                ...(evidencePath === undefined ? {} : {evidencePath}),
+                exported: row.exported === 1,
+                kind: 'symbol-lookup' as const,
+                lookupKey: row.lookup_key,
+                provenance: row.provenance,
+                resolutionDomain: row.resolution_domain,
+                symbolId: row.symbol_id,
+              };
+            }),
+          );
+        }),
+    );
+    return aliases;
+  });
+}
+
+function streamReexports<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamCompositeCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<ReexportRow>(
+        `SELECT source_path, local_name, target_path, imported_name
+         FROM snapshot_reexport_provenance
+         WHERE snapshot_id = ?
+           AND (? IS NULL OR (source_path, local_name, target_path, imported_name) > (?, ?, ?, ?))
+         ORDER BY source_path COLLATE BINARY, local_name COLLATE BINARY,
+                  target_path COLLATE BINARY, imported_name COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor?.[0] ?? null, ...(cursor ?? ['', '', '', '']), pageSize],
+      ),
+    row => [row.source_path, row.local_name, row.target_path, row.imported_name],
+    rows =>
+      emit(
+        rows.map(row => ({
+          importedName: row.imported_name,
+          kind: 'reexport' as const,
+          localName: row.local_name,
+          sourcePath: row.source_path,
+          targetPath: row.target_path,
+        })),
+      ),
+  );
+}
+
+function streamEdges<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamSingleCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<EdgeRow>(
+        `SELECT id, source_id, source_name, relation, target_id, target_name,
+                provenance, confidence, evidence_path, evidence_span_json
+         FROM edges
+         WHERE snapshot_id = ? AND (? IS NULL OR id > ? COLLATE BINARY)
+         ORDER BY id COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor ?? null, cursor ?? null, pageSize],
+      ),
+    row => row.id,
+    rows => decodeAndEmit(rows, row => edgeRecord(edgeFromRow(row)), emit, 'edges'),
+  );
+}
+
+function edgeRecord(edge: CodeGraphEdge): CodeGraphCheckpointRecordV1 {
+  return {
+    confidence: edge.confidence,
+    evidencePath: edge.evidencePath,
+    evidenceSpan: edge.evidenceSpan,
+    id: edge.id,
+    kind: 'edge',
+    provenance: edge.provenance,
+    relation: edge.relation,
+    ...(edge.sourceId === undefined ? {} : {sourceId: edge.sourceId}),
+    sourceName: edge.sourceName,
+    ...(edge.targetId === undefined ? {} : {targetId: edge.targetId}),
+    targetName: edge.targetName,
+  };
+}
+
+function streamMonikers<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamSingleCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<MonikerRow>(
+        `SELECT id, version, scheme, role, kind, resolution_domain, identity,
+                package_name, package_version, import_path, qualified_name,
+                component_id, symbol_id, dependency_kind, evidence_path, evidence_span_json
+         FROM code_graph_monikers
+         WHERE snapshot_id = ? AND (? IS NULL OR id > ? COLLATE BINARY)
+         ORDER BY id COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor ?? null, cursor ?? null, pageSize],
+      ),
+    row => row.id,
+    rows =>
+      decodeAndEmit(
+        rows,
+        row => ({
+          ...optionalFields({
+            componentId: row.component_id,
+            dependencyKind: row.dependency_kind,
+            importPath: row.import_path,
+            packageName: row.package_name,
+            packageVersion: row.package_version,
+            qualifiedName: row.qualified_name,
+            symbolId: row.symbol_id,
+          }),
+          evidencePath: row.evidence_path,
+          evidenceSpan: parseRequiredSpan(row.evidence_span_json, 'moniker evidence span'),
+          id: row.id,
+          identity: row.identity,
+          kind: 'moniker',
+          monikerKind: row.kind,
+          resolutionDomain: row.resolution_domain,
+          role: row.role,
+          scheme: row.scheme,
+          version: Number(row.version),
+        }),
+        emit,
+        'monikers',
+      ),
+  );
+}
+
+function streamLexical<E, R>(
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  pageSize: number,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+) {
+  return streamCompositeCursorPages(
+    undefined,
+    cursor =>
+      sql.unsafe<LexicalRow>(
+        `SELECT term.term, symbol.symbol_id, posting.weight
+         FROM lexical_compact_snapshots AS compact
+         JOIN lexical_compact_postings AS posting ON posting.snapshot_key = compact.snapshot_key
+         JOIN lexical_compact_terms AS term
+           ON term.snapshot_key = compact.snapshot_key AND term.term_key = posting.term_key
+         JOIN lexical_compact_symbols AS symbol
+           ON symbol.snapshot_key = compact.snapshot_key AND symbol.symbol_key = posting.symbol_key
+         WHERE compact.snapshot_id = ? AND (? IS NULL OR (term.term, symbol.symbol_id) > (?, ?))
+         ORDER BY term.term COLLATE BINARY, symbol.symbol_id COLLATE BINARY
+         LIMIT ?`,
+        [snapshotId, cursor?.[0] ?? null, ...(cursor ?? ['', '']), pageSize],
+      ),
+    row => [row.term, row.symbol_id],
+    rows =>
+      emit(
+        rows.map(row => ({
+          kind: 'lexical' as const,
+          symbolId: row.symbol_id,
+          term: row.term,
+          weight: Number(row.weight),
+        })),
+      ),
+  );
+}
+
+function streamSingleCursorPages<Row, LoadE, LoadR, AcceptE, AcceptR>(
+  initialCursor: string | undefined,
+  load: (cursor: string | undefined) => Effect.Effect<readonly Row[], LoadE, LoadR>,
+  cursorOf: (row: Row) => string,
+  accept: (rows: readonly Row[]) => Effect.Effect<void, AcceptE, AcceptR>,
+) {
+  return Effect.gen(function* () {
+    let cursor = initialCursor;
+    for (;;) {
+      const rows = yield* load(cursor);
+      if (rows.length === 0) return;
+      yield* accept(rows);
+      const next = cursorOf(rows.at(-1)!);
+      if (cursor !== undefined && compareCheckpointTuples([next], [cursor]) <= 0) {
+        return yield* projectionFailure('Checkpoint keyset cursor did not advance.');
+      }
+      cursor = next;
+    }
+  });
+}
+
+function streamCompositeCursorPages<Row, Cursor extends readonly string[], LoadE, LoadR, AcceptE, AcceptR>(
+  initialCursor: Cursor | undefined,
+  load: (cursor: Cursor | undefined) => Effect.Effect<readonly Row[], LoadE, LoadR>,
+  cursorOf: (row: Row) => Cursor,
+  accept: (rows: readonly Row[]) => Effect.Effect<void, AcceptE, AcceptR>,
+) {
+  return Effect.gen(function* () {
+    let cursor = initialCursor;
+    for (;;) {
+      const rows = yield* load(cursor);
+      if (rows.length === 0) return;
+      yield* accept(rows);
+      const next = cursorOf(rows.at(-1)!);
+      if (cursor !== undefined && compareCheckpointTuples(next, cursor) <= 0) {
+        return yield* projectionFailure('Checkpoint composite keyset cursor did not advance.');
+      }
+      cursor = next;
+    }
+  });
+}
+
+function compareCheckpointTuples(left: readonly string[], right: readonly string[]): number {
+  return compareCodeGraphCheckpointRecordOrderKeys({identity: left, kind: 'file'}, {identity: right, kind: 'file'});
+}
+
+function decodeAndEmit<Row, E, R>(
+  rows: readonly Row[],
+  map: (row: Row) => CodeGraphCheckpointRecordV1,
+  emit: (records: readonly CodeGraphCheckpointRecordV1[]) => Effect.Effect<void, E, R>,
+  label: string,
+) {
+  return Effect.try({
+    try: () => rows.map(map),
+    catch: cause => projectionError(`Checkpoint ${label} are malformed.`, cause),
+  }).pipe(Effect.flatMap(emit));
+}
+
+function validateProjectedCounts(
+  counts: CodeGraphCheckpointCountsV1,
+  aliases: number,
+  fence: ProjectionFenceRow,
+  snapshot: CodeGraphSnapshot,
+  packCount: number,
+): void {
+  if (
+    counts.file !== snapshot.fileCount ||
+    counts.symbol !== snapshot.symbolCount ||
+    counts.edge !== snapshot.edgeCount ||
+    counts['symbol-lookup'] !== Number(fence.lookup_count) ||
+    aliases !== Number(fence.alias_count) ||
+    counts.reexport !== Number(fence.reexport_count) ||
+    counts.lexical !== Number(fence.lexical_posting_count) ||
+    counts['pack-provenance'] !== packCount
+  ) {
+    throw new CodeGraphCheckpointProjectionError('Checkpoint logical surface counts do not match ready receipts.');
+  }
+}
+
+function validateLexicalCounts(sql: SqlClient.SqlClient, snapshotId: string, fence: ProjectionFenceRow) {
+  return Effect.gen(function* () {
+    const rows = yield* sql.unsafe<{
+      readonly posting_count: number;
+      readonly symbol_count: number;
+      readonly term_count: number;
+    }>(
+      `SELECT
+         (SELECT COUNT(*) FROM lexical_compact_postings AS posting
+          WHERE posting.snapshot_key = compact.snapshot_key) AS posting_count,
+         (SELECT COUNT(*) FROM lexical_compact_symbols AS symbol
+          WHERE symbol.snapshot_key = compact.snapshot_key) AS symbol_count,
+         (SELECT COUNT(*) FROM lexical_compact_terms AS term
+          WHERE term.snapshot_key = compact.snapshot_key) AS term_count
+       FROM lexical_compact_snapshots AS compact
+       WHERE compact.snapshot_id = ?
+       LIMIT 2`,
+      [snapshotId],
+    );
+    const row = rows[0];
+    if (
+      rows.length !== 1 ||
+      Number(row?.posting_count) !== Number(fence.lexical_posting_count) ||
+      Number(row?.symbol_count) !== Number(fence.lexical_symbol_count) ||
+      Number(row?.term_count) !== Number(fence.lexical_term_count)
+    ) {
+      return yield* projectionFailure('Checkpoint compact lexical receipt is inconsistent.');
+    }
+  });
+}
+
+function projectionFenceDigest(row: ProjectionFenceRow): string {
+  return sha256HexSync(
+    JSON.stringify({
+      aliasCount: row.alias_count,
+      baseSnapshotId: row.base_snapshot_id,
+      commit: row.commit_id,
+      completedAt: row.completed_at,
+      dirty: row.dirty,
+      edgeCount: row.edge_count,
+      extractorSet: row.extractor_set,
+      fileCount: row.file_count,
+      fileSetFingerprint: row.file_set_fingerprint,
+      generation: row.generation,
+      graphContentId: row.graph_content_id,
+      id: row.id,
+      inventory: sha256HexSync(typeof row.inventory_receipt_json === 'string' ? row.inventory_receipt_json : ''),
+      lexicalFormat: row.lexical_format_version,
+      lexicalPostings: row.lexical_posting_count,
+      lexicalSymbols: row.lexical_symbol_count,
+      lexicalTerms: row.lexical_term_count,
+      lookupCount: row.lookup_count,
+      repositoryId: row.repository_id,
+      reexportCount: row.reexport_count,
+      resolutionSurfaceVersion: row.resolution_surface_version,
+      reuseFormatVersion: row.reuse_format_version,
+      state: row.state,
+      symbolCount: row.symbol_count,
+      workspaceFingerprint: row.workspace_fingerprint,
+    }),
+  );
+}
+
+function updatePathDigest(hasher: Bun.CryptoHasher, path: string): void {
+  hasher.update(`${new TextEncoder().encode(path).byteLength}:`);
+  hasher.update(path);
+  hasher.update('\0');
+}
+
+function parseStringArray(value: string, label: string): readonly string[] {
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed) || parsed.some(item => typeof item !== 'string')) {
+    throw new CodeGraphCheckpointProjectionError(`Checkpoint ${label} are invalid.`);
+  }
+  return parsed;
+}
+
+function parseOptionalJson(value: unknown, label: string): unknown | undefined {
+  const text = optionalText(value);
+  return text === undefined ? undefined : parseRequiredJson(text, label);
+}
+
+function parseOptionalSpan(value: unknown, label: string): CodeGraphCheckpointSpanV1 | undefined {
+  const parsed = parseOptionalJson(value, label);
+  return parsed === undefined ? undefined : (parsed as CodeGraphCheckpointSpanV1);
+}
+
+function parseRequiredSpan(value: string, label: string): CodeGraphCheckpointSpanV1 {
+  return parseRequiredJson(value, label) as CodeGraphCheckpointSpanV1;
+}
+
+function parseRequiredJson(value: string, label: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch (cause) {
+    throw projectionError(`Checkpoint ${label} is invalid.`, cause);
+  }
+}
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function optionalFields(values: Readonly<Record<string, unknown>>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(values).flatMap(([key, value]) => (typeof value === 'string' ? [[key, value]] : [])),
+  );
+}
+
+function projectionError(message: string, cause: unknown): CodeGraphCheckpointProjectionError {
+  return new CodeGraphCheckpointProjectionError(
+    cause instanceof Error && cause.message.length > 0 ? `${message} ${cause.message}` : message,
+  );
+}
+
+function attemptProjection<A>(message: string, attempt: () => A) {
+  return Effect.try({
+    try: attempt,
+    catch: cause => (cause instanceof CodeGraphCheckpointProjectionError ? cause : projectionError(message, cause)),
+  });
+}
+
+function projectionFailure(message: string): Effect.Effect<never, CodeGraphCheckpointProjectionError> {
+  return Effect.fail(new CodeGraphCheckpointProjectionError(message));
+}

--- a/src/code_graph/checkpoint/schema.ts
+++ b/src/code_graph/checkpoint/schema.ts
@@ -1,0 +1,1411 @@
+import type {CodeGraphWorkspace} from '../languages/types.js';
+import {parseCodeGraphFileFacts} from '../fact_validation.js';
+import {
+  CODE_GRAPH_CHECKPOINT_FORMAT_VERSION,
+  CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION,
+  CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION,
+} from '../store/schema_revision.js';
+import type {CodeGraphFileFacts} from '../types.js';
+import {canonicalJson} from './canonical_json.js';
+import {codeGraphCheckpointFileFactCacheIdentity} from './file_fact_identity.js';
+
+export const CODE_GRAPH_CHECKPOINT_SCHEMA = 'threadnote.code-graph-checkpoint' as const;
+export const CODE_GRAPH_CHECKPOINT_MEDIA_TYPE = 'application/vnd.threadnote.code-graph-checkpoint.v1' as const;
+export {
+  CODE_GRAPH_CHECKPOINT_FORMAT_VERSION,
+  CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION,
+  CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION,
+};
+export const CODE_GRAPH_CHECKPOINT_COMPRESSION_PROFILE = 'threadnote-gzip-v1' as const;
+export const CODE_GRAPH_CHECKPOINT_PATH_POLICY = 'repository-relative-posix-v1' as const;
+export const CODE_GRAPH_CHECKPOINT_ATTRIBUTION_FILES_MAXIMUM = 10_000;
+export const CODE_GRAPH_CHECKPOINT_ATTRIBUTION_CONTENT_BYTES_MAXIMUM = 16 * 1_048_576;
+export const CODE_GRAPH_CHECKPOINT_ATTRIBUTION_SOURCE_BYTES_MAXIMUM = 64 * 1_048_576;
+
+export const CODE_GRAPH_CHECKPOINT_RECORD_KINDS = [
+  'file',
+  'file-fact',
+  'workspace-scope',
+  'workspace-component',
+  'workspace-dependency',
+  'workspace-external-dependency',
+  'symbol',
+  'symbol-lookup',
+  'reexport',
+  'edge',
+  'moniker',
+  'lexical',
+  'pack-provenance',
+] as const;
+
+export type CodeGraphCheckpointRecordKind = (typeof CODE_GRAPH_CHECKPOINT_RECORD_KINDS)[number];
+export type CodeGraphCheckpointSha256 = `sha256:${string}`;
+
+const RECORD_KIND_ORDER = new Map(CODE_GRAPH_CHECKPOINT_RECORD_KINDS.map((kind, ordinal) => [kind, ordinal]));
+const SHA256 = /^[0-9a-f]{64}$/u;
+const GIT_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const GRAPH_CONTENT_ID = /^cgc_[0-9a-f]{40}$/u;
+const MATERIALIZED_FACT_IDENTITY = /^cgfd_[0-9a-f]{40}$/u;
+const MAXIMUM_ARRAY_LENGTH = 1_000_000;
+const MAXIMUM_SHORT_TEXT_LENGTH = 16_384;
+const MAXIMUM_PATH_LENGTH = 4_096;
+const UTF8 = new TextEncoder();
+
+export class CodeGraphCheckpointSchemaError extends Error {
+  override readonly name = 'CodeGraphCheckpointSchemaError';
+}
+
+export interface CodeGraphCheckpointDigestV1 {
+  readonly algorithm: 'sha256';
+  readonly digest: string;
+}
+
+export interface CodeGraphCheckpointDescriptorV1 {
+  readonly digest: CodeGraphCheckpointSha256;
+  readonly mediaType: typeof CODE_GRAPH_CHECKPOINT_MEDIA_TYPE;
+  readonly size: number;
+}
+
+export interface CodeGraphCheckpointSpanV1 {
+  readonly column: number;
+  readonly endColumn: number;
+  readonly endLine: number;
+  readonly line: number;
+}
+
+export interface CodeGraphCheckpointLanguagePackV1 {
+  readonly cacheIdentity: string;
+  readonly derivationIdentity: string;
+  readonly id: string;
+  readonly resolutionDomain: string;
+  readonly resolutionVersion: string;
+}
+
+export interface CodeGraphCheckpointAbiInputV1 {
+  readonly checkpointSemanticVersion: typeof CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION;
+  readonly graphSchemaVersion: number;
+  readonly inventoryPolicyVersion: number;
+  readonly languagePacks: readonly CodeGraphCheckpointLanguagePackV1[];
+  readonly lexicalLogicalFormatVersion: number;
+  readonly pathPolicy: typeof CODE_GRAPH_CHECKPOINT_PATH_POLICY;
+  readonly referenceResolutionVersion: string;
+  readonly workspaceModelVersion: string;
+}
+
+export interface CodeGraphCheckpointAbiV1 {
+  readonly algorithm: 'sha256';
+  readonly digest: string;
+  readonly input: CodeGraphCheckpointAbiInputV1;
+}
+
+export interface CodeGraphCheckpointCoverageReasonV1 {
+  readonly bytes: number;
+  readonly code: string;
+  readonly files: number;
+}
+
+export interface CodeGraphCheckpointCoverageV1 {
+  readonly eligibleFiles: number;
+  readonly excludedFiles: number;
+  readonly reasons: readonly CodeGraphCheckpointCoverageReasonV1[];
+  readonly state: 'complete' | 'partial';
+}
+
+export interface CodeGraphCheckpointAttributionFileV1 {
+  readonly blobId: string;
+  /** Exact byte size of the source Git blob before deterministic context compaction. */
+  readonly blobSize: number;
+  readonly contentHash: string;
+  readonly language: string;
+  readonly mode: string;
+  readonly path: string;
+  readonly size: number;
+  readonly source: 'commit';
+}
+
+export interface CodeGraphCheckpointPolicyExclusionReasonV1 {
+  readonly bytes: number;
+  readonly files: number;
+  readonly reason: string;
+}
+
+export interface CodeGraphCheckpointPolicyExclusionsV1 {
+  readonly bytes: number;
+  readonly files: number;
+  readonly policyVersion: number;
+  readonly reasons: readonly CodeGraphCheckpointPolicyExclusionReasonV1[];
+}
+
+export interface CodeGraphCheckpointPortableInventoryV1 {
+  readonly attributionFiles: readonly CodeGraphCheckpointAttributionFileV1[];
+  readonly contract: string;
+  readonly diagnostics?: readonly string[];
+  readonly includeOpaqueCorpusAssets: boolean;
+  readonly policyExclusions: CodeGraphCheckpointPolicyExclusionsV1;
+  readonly skipped: number;
+  readonly version: number;
+  readonly workspace: CodeGraphWorkspace;
+}
+
+export interface CodeGraphCheckpointReuseV1 {
+  readonly fileSetFingerprint: string;
+  readonly formatVersion: number;
+  readonly inventory?: CodeGraphCheckpointPortableInventoryV1;
+  readonly resolutionSurfaceVersion: number;
+  readonly workspaceFingerprint: string;
+}
+
+export interface CodeGraphCheckpointMetadataV1 {
+  readonly abi: CodeGraphCheckpointAbiInputV1;
+  readonly coverage: CodeGraphCheckpointCoverageV1;
+  readonly repository: {
+    readonly caseMode: 'insensitive' | 'sensitive';
+    readonly displayName: string;
+    readonly objectFormat: 'sha1' | 'sha256';
+    readonly repositoryId: string;
+  };
+  readonly reuse?: CodeGraphCheckpointReuseV1;
+  readonly source: {
+    readonly commit: string;
+    readonly extractorSet: string;
+    readonly graphContentId: string;
+  };
+}
+
+export interface CodeGraphCheckpointChunkDescriptorV1 {
+  readonly compressedBytes: number;
+  readonly digest: CodeGraphCheckpointDigestV1;
+  readonly ordinal: number;
+  readonly recordCount: number;
+  readonly uncompressedBytes: number;
+}
+
+export type CodeGraphCheckpointCountsV1 = Readonly<Record<CodeGraphCheckpointRecordKind, number>>;
+
+export interface CodeGraphCheckpointHeaderV1 {
+  readonly abi: CodeGraphCheckpointAbiV1;
+  readonly chunks: readonly CodeGraphCheckpointChunkDescriptorV1[];
+  readonly compressionProfile: typeof CODE_GRAPH_CHECKPOINT_COMPRESSION_PROFILE;
+  readonly counts: CodeGraphCheckpointCountsV1;
+  readonly coverage: CodeGraphCheckpointCoverageV1;
+  readonly formatVersion: typeof CODE_GRAPH_CHECKPOINT_FORMAT_VERSION;
+  readonly logical: CodeGraphCheckpointDigestV1;
+  readonly mediaType: typeof CODE_GRAPH_CHECKPOINT_MEDIA_TYPE;
+  readonly recordSchemaVersion: typeof CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION;
+  readonly repository: CodeGraphCheckpointMetadataV1['repository'];
+  readonly reuse?: CodeGraphCheckpointReuseV1;
+  readonly schema: typeof CODE_GRAPH_CHECKPOINT_SCHEMA;
+  readonly source: CodeGraphCheckpointMetadataV1['source'];
+}
+
+export interface CodeGraphCheckpointFileRecordV1 {
+  readonly blobId: string;
+  readonly contentHash: string;
+  readonly kind: 'file';
+  readonly language: string;
+  readonly mode: string;
+  readonly path: string;
+  readonly rawContentHash?: string;
+  readonly size: number;
+  readonly source: 'commit';
+}
+
+export interface CodeGraphCheckpointFileFactRecordV1 {
+  readonly cacheIdentity: string;
+  readonly factRole: 'materialized';
+  readonly facts: CodeGraphFileFacts;
+  readonly kind: 'file-fact';
+  readonly path: string;
+}
+
+export interface CodeGraphCheckpointWorkspaceScopeRecordV1 {
+  readonly buildSystem: string;
+  readonly diagnostics: readonly string[];
+  readonly id: string;
+  readonly kind: 'workspace-scope';
+  readonly name: string;
+  readonly provenance: 'declared' | 'inferred';
+  readonly root: string;
+}
+
+export interface CodeGraphCheckpointWorkspaceComponentRecordV1 {
+  readonly buildSystem: string;
+  readonly componentKind: 'module' | 'package' | 'project' | 'target';
+  readonly diagnostics: readonly string[];
+  readonly id: string;
+  readonly kind: 'workspace-component';
+  readonly languages: readonly string[];
+  readonly name: string;
+  readonly provenance: 'declared' | 'inferred';
+  readonly resolutionDomain: string;
+  readonly root: string;
+  readonly sourceRoots: readonly string[];
+  readonly workspaceId: string;
+  readonly workspaceRoots: readonly string[];
+}
+
+export interface CodeGraphCheckpointWorkspaceDependencyRecordV1 {
+  readonly evidence?: string;
+  readonly kind: 'workspace-dependency';
+  readonly provenance: 'declared' | 'inferred';
+  readonly sourceComponentId: string;
+  readonly targetComponentId: string;
+}
+
+export interface CodeGraphCheckpointWorkspaceExternalDependencyRecordV1 {
+  readonly dependencyKind: 'development' | 'optional' | 'peer' | 'runtime';
+  readonly ecosystem: 'npm';
+  readonly evidencePath: string;
+  readonly evidenceSpan?: CodeGraphCheckpointSpanV1;
+  readonly importAlias: string;
+  readonly kind: 'workspace-external-dependency';
+  readonly packageName: string;
+  readonly sourceComponentId: string;
+  readonly versionConstraint: string;
+}
+
+export interface CodeGraphCheckpointSymbolRecordV1 {
+  readonly arity?: number;
+  readonly contentHash: string;
+  readonly documentation?: string;
+  readonly exported: boolean;
+  readonly id: string;
+  readonly kind: 'symbol';
+  readonly language: string;
+  readonly lookupKeys?: readonly string[];
+  readonly name: string;
+  readonly packageName?: string;
+  readonly path: string;
+  readonly qualifiedName: string;
+  readonly resolutionDomain?: string;
+  readonly resolutionScopeId?: string;
+  readonly signature?: string;
+  readonly span: CodeGraphCheckpointSpanV1;
+  readonly symbolKind: string;
+}
+
+export interface CodeGraphCheckpointSymbolLookupRecordV1 {
+  readonly evidenceEdgeId?: string;
+  readonly evidencePath?: string;
+  readonly exported: boolean;
+  readonly kind: 'symbol-lookup';
+  readonly lookupKey: string;
+  readonly provenance: 'alias' | 'symbol';
+  readonly resolutionDomain: string;
+  readonly symbolId: string;
+}
+
+export interface CodeGraphCheckpointReexportRecordV1 {
+  readonly importedName: string;
+  readonly kind: 'reexport';
+  readonly localName: string;
+  readonly sourcePath: string;
+  readonly targetPath: string;
+}
+
+export interface CodeGraphCheckpointEdgeRecordV1 {
+  readonly confidence: number;
+  readonly evidencePath: string;
+  readonly evidenceSpan: CodeGraphCheckpointSpanV1;
+  readonly id: string;
+  readonly kind: 'edge';
+  readonly provenance: 'declared' | 'heuristic' | 'model' | 'resolved' | 'syntactic';
+  readonly relation:
+    | 'calls'
+    | 'configures'
+    | 'constructs'
+    | 'contains'
+    | 'declares'
+    | 'depends_on'
+    | 'documents'
+    | 'exports'
+    | 'extends'
+    | 'implements'
+    | 'imports'
+    | 'overrides'
+    | 'reads_or_writes'
+    | 'references'
+    | 'reexports'
+    | 'semantic_association'
+    | 'tests';
+  readonly sourceId?: string;
+  readonly sourceName: string;
+  readonly targetId?: string;
+  readonly targetName: string;
+}
+
+export interface CodeGraphCheckpointMonikerRecordV1 {
+  readonly componentId?: string;
+  readonly dependencyKind?: 'development' | 'optional' | 'peer' | 'runtime';
+  readonly evidencePath: string;
+  readonly evidenceSpan: CodeGraphCheckpointSpanV1;
+  readonly id: string;
+  readonly identity: string;
+  readonly importPath?: string;
+  readonly kind: 'moniker';
+  readonly monikerKind: string;
+  readonly packageName?: string;
+  readonly packageVersion?: string;
+  readonly qualifiedName?: string;
+  readonly resolutionDomain: string;
+  readonly role: 'export' | 'import';
+  readonly scheme: 'package' | 'protobuf';
+  readonly symbolId?: string;
+  readonly version: number;
+}
+
+export interface CodeGraphCheckpointLexicalRecordV1 {
+  readonly kind: 'lexical';
+  readonly symbolId: string;
+  readonly term: string;
+  readonly weight: number;
+}
+
+export interface CodeGraphCheckpointPackProvenanceRecordV1 {
+  readonly cacheIdentity: string;
+  readonly derivationIdentity: string;
+  readonly id: string;
+  readonly kind: 'pack-provenance';
+  readonly resolutionDomain: string;
+  readonly resolutionVersion: string;
+}
+
+export type CodeGraphCheckpointRecordV1 =
+  | CodeGraphCheckpointFileRecordV1
+  | CodeGraphCheckpointFileFactRecordV1
+  | CodeGraphCheckpointWorkspaceScopeRecordV1
+  | CodeGraphCheckpointWorkspaceComponentRecordV1
+  | CodeGraphCheckpointWorkspaceDependencyRecordV1
+  | CodeGraphCheckpointWorkspaceExternalDependencyRecordV1
+  | CodeGraphCheckpointSymbolRecordV1
+  | CodeGraphCheckpointSymbolLookupRecordV1
+  | CodeGraphCheckpointReexportRecordV1
+  | CodeGraphCheckpointEdgeRecordV1
+  | CodeGraphCheckpointMonikerRecordV1
+  | CodeGraphCheckpointLexicalRecordV1
+  | CodeGraphCheckpointPackProvenanceRecordV1;
+
+export interface CodeGraphCheckpointRecordOrderKeyV1 {
+  readonly identity: readonly string[];
+  readonly kind: CodeGraphCheckpointRecordKind;
+}
+
+export function emptyCodeGraphCheckpointCounts(): Record<CodeGraphCheckpointRecordKind, number> {
+  return Object.fromEntries(CODE_GRAPH_CHECKPOINT_RECORD_KINDS.map(kind => [kind, 0])) as Record<
+    CodeGraphCheckpointRecordKind,
+    number
+  >;
+}
+
+export function parseCodeGraphCheckpointMetadataV1(value: unknown): CodeGraphCheckpointMetadataV1 {
+  const input = object(value, 'Checkpoint metadata');
+  canonicalJson(input);
+  exactKeys(input, ['abi', 'coverage', 'repository', 'source'], ['reuse'], 'Checkpoint metadata');
+  const metadata: CodeGraphCheckpointMetadataV1 = {
+    abi: parseAbiInput(input.abi),
+    coverage: parseCoverage(input.coverage),
+    repository: parseRepository(input.repository),
+    ...(input.reuse === undefined ? {} : {reuse: parseReuse(input.reuse)}),
+    source: parseSource(input.source),
+  };
+  canonicalJson(metadata);
+  return metadata;
+}
+
+export function parseCodeGraphCheckpointHeaderV1(value: unknown): CodeGraphCheckpointHeaderV1 {
+  const input = object(value, 'Checkpoint header');
+  canonicalJson(input);
+  exactKeys(
+    input,
+    [
+      'abi',
+      'chunks',
+      'compressionProfile',
+      'counts',
+      'coverage',
+      'formatVersion',
+      'logical',
+      'mediaType',
+      'recordSchemaVersion',
+      'repository',
+      'schema',
+      'source',
+    ],
+    ['reuse'],
+    'Checkpoint header',
+  );
+  literal(input.schema, CODE_GRAPH_CHECKPOINT_SCHEMA, 'Checkpoint schema');
+  literal(input.mediaType, CODE_GRAPH_CHECKPOINT_MEDIA_TYPE, 'Checkpoint media type');
+  literal(input.formatVersion, CODE_GRAPH_CHECKPOINT_FORMAT_VERSION, 'Checkpoint format version');
+  literal(input.recordSchemaVersion, CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION, 'Checkpoint record schema version');
+  literal(input.compressionProfile, CODE_GRAPH_CHECKPOINT_COMPRESSION_PROFILE, 'Checkpoint compression profile');
+  const abi = parseAbi(input.abi);
+  const metadata = parseCodeGraphCheckpointMetadataV1({
+    abi: abi.input,
+    coverage: input.coverage,
+    repository: input.repository,
+    ...(input.reuse === undefined ? {} : {reuse: input.reuse}),
+    source: input.source,
+  });
+  const chunks = array(input.chunks, 'Checkpoint chunks').map((chunk, ordinal) => parseChunk(chunk, ordinal));
+  const counts = parseCounts(input.counts);
+  const chunkRecords = checkedSum(
+    chunks.map(chunk => chunk.recordCount),
+    'Checkpoint chunk record count',
+  );
+  const countedRecords = checkedSum(Object.values(counts), 'Checkpoint record count');
+  if (chunkRecords !== countedRecords) {
+    throw new CodeGraphCheckpointSchemaError('Checkpoint chunk and kind counts do not match.');
+  }
+  if (counts.file !== metadata.coverage.eligibleFiles) {
+    throw new CodeGraphCheckpointSchemaError('Checkpoint file count does not match eligible coverage.');
+  }
+  return {
+    abi,
+    chunks,
+    compressionProfile: CODE_GRAPH_CHECKPOINT_COMPRESSION_PROFILE,
+    counts,
+    coverage: metadata.coverage,
+    formatVersion: CODE_GRAPH_CHECKPOINT_FORMAT_VERSION,
+    logical: parseDigest(input.logical, 'Checkpoint logical digest'),
+    mediaType: CODE_GRAPH_CHECKPOINT_MEDIA_TYPE,
+    recordSchemaVersion: CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION,
+    repository: metadata.repository,
+    ...(metadata.reuse === undefined ? {} : {reuse: metadata.reuse}),
+    schema: CODE_GRAPH_CHECKPOINT_SCHEMA,
+    source: metadata.source,
+  };
+}
+
+export function parseCodeGraphCheckpointRecordV1(value: unknown): CodeGraphCheckpointRecordV1 {
+  const input = object(value, 'Checkpoint record');
+  canonicalJson(input);
+  const kind = text(input.kind, 'Checkpoint record kind');
+  switch (kind) {
+    case 'file':
+      exactKeys(
+        input,
+        ['blobId', 'contentHash', 'kind', 'language', 'mode', 'path', 'size', 'source'],
+        ['rawContentHash'],
+        'File record',
+      );
+      gitObjectId(input.blobId, 'File blob ID');
+      sha256(input.contentHash, 'File content hash');
+      optionalSha256(input.rawContentHash, 'File raw content hash');
+      shortText(input.language, 'File language');
+      mode(input.mode, 'File mode');
+      repositoryPath(input.path, 'File path');
+      nonNegativeInteger(input.size, 'File size');
+      literal(input.source, 'commit', 'File source');
+      break;
+    case 'file-fact':
+      exactKeys(input, ['cacheIdentity', 'factRole', 'facts', 'kind', 'path'], [], 'File-fact record');
+      if (typeof input.cacheIdentity !== 'string' || !MATERIALIZED_FACT_IDENTITY.test(input.cacheIdentity)) {
+        throw new CodeGraphCheckpointSchemaError('File-fact cache identity is not a materialized derivation ID.');
+      }
+      literal(input.factRole, 'materialized', 'File-fact role');
+      repositoryPath(input.path, 'File-fact path');
+      if (
+        input.cacheIdentity !==
+        codeGraphCheckpointFileFactCacheIdentity(parseFileFacts(input.facts, input.path as string))
+      ) {
+        throw new CodeGraphCheckpointSchemaError('File-fact cache identity does not match its payload.');
+      }
+      break;
+    case 'workspace-scope':
+      exactKeys(
+        input,
+        ['buildSystem', 'diagnostics', 'id', 'kind', 'name', 'provenance', 'root'],
+        [],
+        'Workspace-scope record',
+      );
+      workspaceBuildSystem(input.buildSystem, 'Workspace build system');
+      stringArray(input.diagnostics, 'Workspace diagnostics');
+      shortText(input.id, 'Workspace ID');
+      workspaceName(input.name, input.root, 'Workspace name');
+      workspaceProvenance(input.provenance, 'Workspace provenance');
+      workspaceRoot(input.root, 'Workspace root');
+      break;
+    case 'workspace-component':
+      exactKeys(
+        input,
+        [
+          'buildSystem',
+          'componentKind',
+          'diagnostics',
+          'id',
+          'kind',
+          'languages',
+          'name',
+          'provenance',
+          'resolutionDomain',
+          'root',
+          'sourceRoots',
+          'workspaceId',
+          'workspaceRoots',
+        ],
+        [],
+        'Workspace-component record',
+      );
+      workspaceBuildSystem(input.buildSystem, 'Component build system');
+      oneOf(input.componentKind, ['module', 'package', 'project', 'target'], 'Component kind');
+      stringArray(input.diagnostics, 'Component diagnostics');
+      shortText(input.id, 'Component ID');
+      stringArray(input.languages, 'Component languages');
+      shortText(input.name, 'Component name');
+      workspaceProvenance(input.provenance, 'Component provenance');
+      shortText(input.resolutionDomain, 'Component resolution domain');
+      workspaceRoot(input.root, 'Component root');
+      pathArray(input.sourceRoots, 'Component source roots', true);
+      shortText(input.workspaceId, 'Component workspace ID');
+      pathArray(input.workspaceRoots, 'Component workspace roots', true);
+      break;
+    case 'workspace-dependency':
+      exactKeys(
+        input,
+        ['kind', 'provenance', 'sourceComponentId', 'targetComponentId'],
+        ['evidence'],
+        'Workspace-dependency record',
+      );
+      optionalShortText(input.evidence, 'Workspace dependency evidence');
+      workspaceProvenance(input.provenance, 'Workspace dependency provenance');
+      shortText(input.sourceComponentId, 'Workspace dependency source');
+      shortText(input.targetComponentId, 'Workspace dependency target');
+      break;
+    case 'workspace-external-dependency':
+      exactKeys(
+        input,
+        [
+          'dependencyKind',
+          'ecosystem',
+          'evidencePath',
+          'importAlias',
+          'kind',
+          'packageName',
+          'sourceComponentId',
+          'versionConstraint',
+        ],
+        ['evidenceSpan'],
+        'Workspace external-dependency record',
+      );
+      dependencyKind(input.dependencyKind, 'External dependency kind');
+      literal(input.ecosystem, 'npm', 'External dependency ecosystem');
+      repositoryPath(input.evidencePath, 'External dependency evidence path');
+      if (input.evidenceSpan !== undefined) parseSpan(input.evidenceSpan, 'External dependency evidence span');
+      shortText(input.importAlias, 'External dependency alias');
+      shortText(input.packageName, 'External dependency package');
+      shortText(input.sourceComponentId, 'External dependency component');
+      shortText(input.versionConstraint, 'External dependency version');
+      break;
+    case 'symbol':
+      parseSymbol(input);
+      break;
+    case 'symbol-lookup':
+      exactKeys(
+        input,
+        ['exported', 'kind', 'lookupKey', 'provenance', 'resolutionDomain', 'symbolId'],
+        ['evidenceEdgeId', 'evidencePath'],
+        'Symbol-lookup record',
+      );
+      boolean(input.exported, 'Symbol lookup exported');
+      shortText(input.lookupKey, 'Symbol lookup key');
+      oneOf(input.provenance, ['alias', 'symbol'], 'Symbol lookup provenance');
+      shortText(input.resolutionDomain, 'Symbol lookup resolution domain');
+      shortText(input.symbolId, 'Symbol lookup symbol ID');
+      optionalShortText(input.evidenceEdgeId, 'Symbol lookup evidence edge');
+      if (input.evidencePath !== undefined) repositoryPath(input.evidencePath, 'Symbol lookup evidence path');
+      break;
+    case 'reexport':
+      exactKeys(input, ['importedName', 'kind', 'localName', 'sourcePath', 'targetPath'], [], 'Reexport record');
+      shortText(input.importedName, 'Reexport imported name');
+      shortText(input.localName, 'Reexport local name');
+      repositoryPath(input.sourcePath, 'Reexport source path');
+      repositoryPath(input.targetPath, 'Reexport target path');
+      break;
+    case 'edge':
+      parseEdge(input);
+      break;
+    case 'moniker':
+      parseMoniker(input);
+      break;
+    case 'lexical':
+      exactKeys(input, ['kind', 'symbolId', 'term', 'weight'], [], 'Lexical record');
+      shortText(input.symbolId, 'Lexical symbol ID');
+      shortText(input.term, 'Lexical term');
+      positiveInteger(input.weight, 'Lexical weight', 1_000);
+      break;
+    case 'pack-provenance':
+      exactKeys(
+        input,
+        ['cacheIdentity', 'derivationIdentity', 'id', 'kind', 'resolutionDomain', 'resolutionVersion'],
+        [],
+        'Pack-provenance record',
+      );
+      sha256(input.cacheIdentity, 'Pack cache identity');
+      sha256(input.derivationIdentity, 'Pack derivation identity');
+      shortText(input.id, 'Pack ID');
+      shortText(input.resolutionDomain, 'Pack resolution domain');
+      shortText(input.resolutionVersion, 'Pack resolution version');
+      break;
+    default:
+      throw new CodeGraphCheckpointSchemaError(`Unknown checkpoint record kind: ${kind}.`);
+  }
+  canonicalJson(input);
+  return input as unknown as CodeGraphCheckpointRecordV1;
+}
+
+export function codeGraphCheckpointRecordIdentity(record: CodeGraphCheckpointRecordV1): string {
+  return canonicalJson([record.kind, ...codeGraphCheckpointRecordIdentityTuple(record)]);
+}
+
+export function codeGraphCheckpointRecordIdentityTuple(record: CodeGraphCheckpointRecordV1): readonly string[] {
+  switch (record.kind) {
+    case 'file':
+      return [record.path];
+    case 'file-fact':
+      return [record.path, record.cacheIdentity];
+    case 'workspace-scope':
+    case 'workspace-component':
+    case 'symbol':
+    case 'edge':
+    case 'moniker':
+    case 'pack-provenance':
+      return [record.id];
+    case 'workspace-dependency':
+      return [record.sourceComponentId, record.targetComponentId, record.provenance];
+    case 'workspace-external-dependency':
+      return [
+        record.sourceComponentId,
+        record.ecosystem,
+        record.packageName,
+        record.importAlias,
+        record.dependencyKind,
+        record.versionConstraint,
+        record.evidencePath,
+      ];
+    case 'symbol-lookup':
+      return [record.lookupKey, record.symbolId];
+    case 'reexport':
+      return [record.sourcePath, record.localName, record.targetPath, record.importedName];
+    case 'lexical':
+      return [record.term, record.symbolId];
+  }
+}
+
+export function compareCodeGraphCheckpointRecords(
+  left: CodeGraphCheckpointRecordV1,
+  right: CodeGraphCheckpointRecordV1,
+): number {
+  return compareCodeGraphCheckpointRecordOrderKeys(
+    codeGraphCheckpointRecordOrderKey(left),
+    codeGraphCheckpointRecordOrderKey(right),
+  );
+}
+
+export function codeGraphCheckpointRecordOrderKey(
+  record: CodeGraphCheckpointRecordV1,
+): CodeGraphCheckpointRecordOrderKeyV1 {
+  return {identity: codeGraphCheckpointRecordIdentityTuple(record), kind: record.kind};
+}
+
+export function compareCodeGraphCheckpointRecordOrderKeys(
+  left: CodeGraphCheckpointRecordOrderKeyV1,
+  right: CodeGraphCheckpointRecordOrderKeyV1,
+): number {
+  const kind = RECORD_KIND_ORDER.get(left.kind)! - RECORD_KIND_ORDER.get(right.kind)!;
+  if (kind !== 0) return kind;
+  for (let index = 0; index < left.identity.length; index += 1) {
+    const order = compareUtf8(left.identity[index]!, right.identity[index]!);
+    if (order !== 0) return order;
+  }
+  return left.identity.length - right.identity.length;
+}
+
+export function isSafeCodeGraphCheckpointPath(value: string): boolean {
+  if (
+    value.length === 0 ||
+    value.length > MAXIMUM_PATH_LENGTH ||
+    value.startsWith('/') ||
+    value.startsWith('\\') ||
+    /^[A-Za-z]:/u.test(value) ||
+    value.includes('\\') ||
+    containsControlCharacter(value)
+  ) {
+    return false;
+  }
+  return !value.split('/').some(segment => segment === '' || segment === '.' || segment === '..');
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function parseAbiInput(value: unknown): CodeGraphCheckpointAbiInputV1 {
+  const input = object(value, 'Checkpoint ABI input');
+  exactKeys(
+    input,
+    [
+      'checkpointSemanticVersion',
+      'graphSchemaVersion',
+      'inventoryPolicyVersion',
+      'languagePacks',
+      'lexicalLogicalFormatVersion',
+      'pathPolicy',
+      'referenceResolutionVersion',
+      'workspaceModelVersion',
+    ],
+    [],
+    'Checkpoint ABI input',
+  );
+  literal(input.checkpointSemanticVersion, CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION, 'Checkpoint semantic version');
+  nonNegativeInteger(input.graphSchemaVersion, 'Graph schema version');
+  nonNegativeInteger(input.inventoryPolicyVersion, 'Inventory policy version');
+  const languagePacks = array(input.languagePacks, 'ABI language packs').map(parseLanguagePack);
+  ensureSortedUnique(languagePacks, pack => pack.id, 'ABI language packs');
+  nonNegativeInteger(input.lexicalLogicalFormatVersion, 'Lexical logical format version');
+  literal(input.pathPolicy, CODE_GRAPH_CHECKPOINT_PATH_POLICY, 'Checkpoint path policy');
+  shortText(input.referenceResolutionVersion, 'Reference resolution version');
+  shortText(input.workspaceModelVersion, 'Workspace model version');
+  return input as unknown as CodeGraphCheckpointAbiInputV1;
+}
+
+function parseAbi(value: unknown): CodeGraphCheckpointAbiV1 {
+  const input = object(value, 'Checkpoint ABI');
+  exactKeys(input, ['algorithm', 'digest', 'input'], [], 'Checkpoint ABI');
+  literal(input.algorithm, 'sha256', 'Checkpoint ABI algorithm');
+  sha256(input.digest, 'Checkpoint ABI digest');
+  return {algorithm: 'sha256', digest: input.digest as string, input: parseAbiInput(input.input)};
+}
+
+function parseLanguagePack(value: unknown): CodeGraphCheckpointLanguagePackV1 {
+  const input = object(value, 'ABI language pack');
+  exactKeys(
+    input,
+    ['cacheIdentity', 'derivationIdentity', 'id', 'resolutionDomain', 'resolutionVersion'],
+    [],
+    'ABI language pack',
+  );
+  sha256(input.cacheIdentity, 'Language-pack cache identity');
+  sha256(input.derivationIdentity, 'Language-pack derivation identity');
+  shortText(input.id, 'Language-pack ID');
+  shortText(input.resolutionDomain, 'Language-pack resolution domain');
+  shortText(input.resolutionVersion, 'Language-pack resolution version');
+  return input as unknown as CodeGraphCheckpointLanguagePackV1;
+}
+
+function parseRepository(value: unknown): CodeGraphCheckpointMetadataV1['repository'] {
+  const input = object(value, 'Checkpoint repository');
+  exactKeys(input, ['caseMode', 'displayName', 'objectFormat', 'repositoryId'], [], 'Checkpoint repository');
+  oneOf(input.caseMode, ['insensitive', 'sensitive'], 'Repository case mode');
+  shortText(input.displayName, 'Repository display name');
+  oneOf(input.objectFormat, ['sha1', 'sha256'], 'Repository object format');
+  sha256(input.repositoryId, 'Repository ID');
+  return input as unknown as CodeGraphCheckpointMetadataV1['repository'];
+}
+
+function parseSource(value: unknown): CodeGraphCheckpointMetadataV1['source'] {
+  const input = object(value, 'Checkpoint source');
+  exactKeys(input, ['commit', 'extractorSet', 'graphContentId'], [], 'Checkpoint source');
+  gitObjectId(input.commit, 'Checkpoint commit');
+  shortText(input.extractorSet, 'Checkpoint extractor set');
+  if (typeof input.graphContentId !== 'string' || !GRAPH_CONTENT_ID.test(input.graphContentId)) {
+    throw new CodeGraphCheckpointSchemaError('Checkpoint graph content ID is invalid.');
+  }
+  return input as unknown as CodeGraphCheckpointMetadataV1['source'];
+}
+
+function parseCoverage(value: unknown): CodeGraphCheckpointCoverageV1 {
+  const input = object(value, 'Checkpoint coverage');
+  exactKeys(input, ['eligibleFiles', 'excludedFiles', 'reasons', 'state'], [], 'Checkpoint coverage');
+  nonNegativeInteger(input.eligibleFiles, 'Coverage eligible files');
+  nonNegativeInteger(input.excludedFiles, 'Coverage excluded files');
+  const reasons = array(input.reasons, 'Coverage reasons').map(reason => {
+    const candidate = object(reason, 'Coverage reason');
+    exactKeys(candidate, ['bytes', 'code', 'files'], [], 'Coverage reason');
+    nonNegativeInteger(candidate.bytes, 'Coverage reason bytes');
+    shortText(candidate.code, 'Coverage reason code');
+    nonNegativeInteger(candidate.files, 'Coverage reason files');
+    return candidate as unknown as CodeGraphCheckpointCoverageReasonV1;
+  });
+  ensureSortedUnique(reasons, reason => reason.code, 'Coverage reasons');
+  oneOf(input.state, ['complete', 'partial'], 'Coverage state');
+  const explainedFiles = checkedSum(
+    reasons.map(reason => reason.files),
+    'Coverage reason file count',
+  );
+  if (explainedFiles !== input.excludedFiles) {
+    throw new CodeGraphCheckpointSchemaError('Coverage reasons do not account for every excluded file.');
+  }
+  if ((input.excludedFiles === 0) !== (input.state === 'complete')) {
+    throw new CodeGraphCheckpointSchemaError('Coverage state does not match the excluded-file count.');
+  }
+  return input as unknown as CodeGraphCheckpointCoverageV1;
+}
+
+function parseReuse(value: unknown): CodeGraphCheckpointReuseV1 {
+  const input = object(value, 'Checkpoint reuse');
+  exactKeys(
+    input,
+    ['fileSetFingerprint', 'formatVersion', 'resolutionSurfaceVersion', 'workspaceFingerprint'],
+    ['inventory'],
+    'Checkpoint reuse',
+  );
+  sha256(input.fileSetFingerprint, 'Reuse file-set fingerprint');
+  positiveInteger(input.formatVersion, 'Reuse format version');
+  positiveInteger(input.resolutionSurfaceVersion, 'Reuse resolution-surface version');
+  sha256(input.workspaceFingerprint, 'Reuse workspace fingerprint');
+  if (input.inventory !== undefined) {
+    const inventory = parsePortableInventory(input.inventory);
+    if (inventory.workspace.fingerprint !== input.workspaceFingerprint) {
+      throw new CodeGraphCheckpointSchemaError('Portable workspace fingerprint does not match reuse metadata.');
+    }
+  }
+  return input as unknown as CodeGraphCheckpointReuseV1;
+}
+
+function parsePortableInventory(value: unknown): CodeGraphCheckpointPortableInventoryV1 {
+  const input = object(value, 'Portable inventory');
+  exactKeys(
+    input,
+    [
+      'attributionFiles',
+      'contract',
+      'includeOpaqueCorpusAssets',
+      'policyExclusions',
+      'skipped',
+      'version',
+      'workspace',
+    ],
+    ['diagnostics'],
+    'Portable inventory',
+  );
+  const attributionFiles = array(input.attributionFiles, 'Attribution files').map(parseAttributionFile);
+  if (attributionFiles.length > CODE_GRAPH_CHECKPOINT_ATTRIBUTION_FILES_MAXIMUM) {
+    throw new CodeGraphCheckpointSchemaError('Attribution file count exceeds the portable boundary.');
+  }
+  ensureSortedUnique(attributionFiles, file => file.path, 'Attribution files');
+  const attributionContentBytes = checkedSum(
+    attributionFiles.map(file => file.size),
+    'Attribution compact content bytes',
+  );
+  const attributionSourceBytes = checkedSum(
+    attributionFiles.map(file => file.blobSize),
+    'Attribution source bytes',
+  );
+  if (
+    attributionContentBytes > CODE_GRAPH_CHECKPOINT_ATTRIBUTION_CONTENT_BYTES_MAXIMUM ||
+    attributionSourceBytes > CODE_GRAPH_CHECKPOINT_ATTRIBUTION_SOURCE_BYTES_MAXIMUM
+  ) {
+    throw new CodeGraphCheckpointSchemaError('Attribution context exceeds the portable byte boundary.');
+  }
+  sha256(input.contract, 'Inventory contract');
+  if (input.diagnostics !== undefined) stringArray(input.diagnostics, 'Inventory diagnostics');
+  boolean(input.includeOpaqueCorpusAssets, 'Inventory opaque-corpus policy');
+  parsePolicyExclusions(input.policyExclusions);
+  nonNegativeInteger(input.skipped, 'Inventory skipped files');
+  positiveInteger(input.version, 'Inventory version');
+  parseWorkspace(input.workspace);
+  return input as unknown as CodeGraphCheckpointPortableInventoryV1;
+}
+
+function parseAttributionFile(value: unknown): CodeGraphCheckpointAttributionFileV1 {
+  const input = object(value, 'Attribution file');
+  exactKeys(
+    input,
+    ['blobId', 'blobSize', 'contentHash', 'language', 'mode', 'path', 'size', 'source'],
+    [],
+    'Attribution file',
+  );
+  gitObjectId(input.blobId, 'Attribution blob ID');
+  nonNegativeInteger(input.blobSize, 'Attribution blob size');
+  sha256(input.contentHash, 'Attribution content hash');
+  shortText(input.language, 'Attribution language');
+  mode(input.mode, 'Attribution mode');
+  repositoryPath(input.path, 'Attribution path');
+  nonNegativeInteger(input.size, 'Attribution size');
+  literal(input.source, 'commit', 'Attribution source');
+  return input as unknown as CodeGraphCheckpointAttributionFileV1;
+}
+
+function parsePolicyExclusions(value: unknown): CodeGraphCheckpointPolicyExclusionsV1 {
+  const input = object(value, 'Policy exclusions');
+  exactKeys(input, ['bytes', 'files', 'policyVersion', 'reasons'], [], 'Policy exclusions');
+  nonNegativeInteger(input.bytes, 'Policy exclusion bytes');
+  nonNegativeInteger(input.files, 'Policy exclusion files');
+  positiveInteger(input.policyVersion, 'Policy exclusion version');
+  const reasons = array(input.reasons, 'Policy exclusion reasons').map(value => {
+    const reason = object(value, 'Policy exclusion reason');
+    exactKeys(reason, ['bytes', 'files', 'reason'], [], 'Policy exclusion reason');
+    nonNegativeInteger(reason.bytes, 'Policy exclusion reason bytes');
+    nonNegativeInteger(reason.files, 'Policy exclusion reason files');
+    shortText(reason.reason, 'Policy exclusion reason');
+    return reason as unknown as CodeGraphCheckpointPolicyExclusionReasonV1;
+  });
+  ensureSortedUnique(reasons, reason => reason.reason, 'Policy exclusion reasons');
+  return input as unknown as CodeGraphCheckpointPolicyExclusionsV1;
+}
+
+function parseWorkspace(value: unknown): CodeGraphWorkspace {
+  const input = object(value, 'Portable workspace');
+  exactKeys(input, ['diagnostics', 'fingerprint', 'projects', 'workspaces'], [], 'Portable workspace');
+  stringArray(input.diagnostics, 'Workspace diagnostics');
+  sha256(input.fingerprint, 'Workspace fingerprint');
+  const projects = array(input.projects, 'Workspace projects');
+  const workspaces = array(input.workspaces, 'Build workspaces');
+  for (const project of projects) parseWorkspaceProject(project);
+  for (const workspace of workspaces) parseBuildWorkspace(workspace);
+  ensureSortedUnique(
+    projects.map(project => project as {readonly id: string}),
+    project => project.id,
+    'Workspace projects',
+  );
+  ensureSortedUnique(
+    workspaces.map(workspace => workspace as {readonly id: string}),
+    workspace => workspace.id,
+    'Build workspaces',
+  );
+  canonicalJson(input);
+  return input as unknown as CodeGraphWorkspace;
+}
+
+function parseWorkspaceProject(value: unknown): void {
+  const input = object(value, 'Workspace project');
+  exactKeys(
+    input,
+    [
+      'buildSystem',
+      'dependencies',
+      'dependencyDetails',
+      'diagnostics',
+      'id',
+      'kind',
+      'languages',
+      'name',
+      'provenance',
+      'resolutionDomain',
+      'root',
+      'sourceRoots',
+      'workspaceId',
+      'workspaceRoots',
+    ],
+    ['externalDependencies', 'monikers'],
+    'Workspace project',
+  );
+  workspaceBuildSystem(input.buildSystem, 'Project build system');
+  stringArray(input.dependencies, 'Project dependencies');
+  for (const detail of array(input.dependencyDetails, 'Project dependency details')) {
+    const candidate = object(detail, 'Project dependency detail');
+    exactKeys(candidate, ['provenance', 'targetId'], ['evidence'], 'Project dependency detail');
+    workspaceProvenance(candidate.provenance, 'Project dependency provenance');
+    shortText(candidate.targetId, 'Project dependency target');
+    optionalShortText(candidate.evidence, 'Project dependency evidence');
+  }
+  stringArray(input.diagnostics, 'Project diagnostics');
+  shortText(input.id, 'Project ID');
+  oneOf(input.kind, ['module', 'package', 'project', 'target'], 'Project kind');
+  stringArray(input.languages, 'Project languages');
+  shortText(input.name, 'Project name');
+  workspaceProvenance(input.provenance, 'Project provenance');
+  shortText(input.resolutionDomain, 'Project resolution domain');
+  workspaceRoot(input.root, 'Project root');
+  pathArray(input.sourceRoots, 'Project source roots', true);
+  shortText(input.workspaceId, 'Project workspace ID');
+  pathArray(input.workspaceRoots, 'Project workspace roots', true);
+  if (input.externalDependencies !== undefined) {
+    for (const dependency of array(input.externalDependencies, 'Project external dependencies')) {
+      const candidate = object(dependency, 'Project external dependency');
+      exactKeys(
+        candidate,
+        ['ecosystem', 'evidence', 'importAlias', 'kind', 'name', 'versionConstraint'],
+        [],
+        'Project external dependency',
+      );
+      literal(candidate.ecosystem, 'npm', 'Project external dependency ecosystem');
+      const evidence = object(candidate.evidence, 'Project external dependency evidence');
+      exactKeys(evidence, ['path'], ['span'], 'Project external dependency evidence');
+      repositoryPath(evidence.path, 'Project external dependency path');
+      if (evidence.span !== undefined) parseSpan(evidence.span, 'Project external dependency span');
+      shortText(candidate.importAlias, 'Project external dependency alias');
+      dependencyKind(candidate.kind, 'Project external dependency kind');
+      shortText(candidate.name, 'Project external dependency name');
+      shortText(candidate.versionConstraint, 'Project external dependency version');
+    }
+  }
+  if (input.monikers !== undefined) {
+    for (const moniker of array(input.monikers, 'Project monikers')) canonicalJson(moniker);
+  }
+}
+
+function parseBuildWorkspace(value: unknown): void {
+  const input = object(value, 'Build workspace');
+  exactKeys(input, ['buildSystem', 'diagnostics', 'id', 'name', 'provenance', 'root'], [], 'Build workspace');
+  workspaceBuildSystem(input.buildSystem, 'Build workspace system');
+  stringArray(input.diagnostics, 'Build workspace diagnostics');
+  shortText(input.id, 'Build workspace ID');
+  workspaceName(input.name, input.root, 'Build workspace name');
+  workspaceProvenance(input.provenance, 'Build workspace provenance');
+  workspaceRoot(input.root, 'Build workspace root');
+}
+
+function parseChunk(value: unknown, expectedOrdinal: number): CodeGraphCheckpointChunkDescriptorV1 {
+  const input = object(value, 'Checkpoint chunk');
+  exactKeys(
+    input,
+    ['compressedBytes', 'digest', 'ordinal', 'recordCount', 'uncompressedBytes'],
+    [],
+    'Checkpoint chunk',
+  );
+  positiveInteger(input.compressedBytes, 'Chunk compressed bytes');
+  const digest = parseDigest(input.digest, 'Chunk digest');
+  nonNegativeInteger(input.ordinal, 'Chunk ordinal');
+  if (input.ordinal !== expectedOrdinal) throw new CodeGraphCheckpointSchemaError('Chunk ordinals are not contiguous.');
+  positiveInteger(input.recordCount, 'Chunk record count');
+  positiveInteger(input.uncompressedBytes, 'Chunk uncompressed bytes');
+  return {...(input as unknown as Omit<CodeGraphCheckpointChunkDescriptorV1, 'digest'>), digest};
+}
+
+function parseCounts(value: unknown): CodeGraphCheckpointCountsV1 {
+  const input = object(value, 'Checkpoint counts');
+  exactKeys(input, [...CODE_GRAPH_CHECKPOINT_RECORD_KINDS], [], 'Checkpoint counts');
+  for (const kind of CODE_GRAPH_CHECKPOINT_RECORD_KINDS) nonNegativeInteger(input[kind], `${kind} count`);
+  return input as CodeGraphCheckpointCountsV1;
+}
+
+function parseDigest(value: unknown, label: string): CodeGraphCheckpointDigestV1 {
+  const input = object(value, label);
+  exactKeys(input, ['algorithm', 'digest'], [], label);
+  literal(input.algorithm, 'sha256', `${label} algorithm`);
+  sha256(input.digest, label);
+  return input as unknown as CodeGraphCheckpointDigestV1;
+}
+
+function parseFileFacts(value: unknown, expectedPath: string): CodeGraphFileFacts {
+  let facts: CodeGraphFileFacts;
+  try {
+    facts = parseCodeGraphFileFacts(value);
+  } catch (cause) {
+    throw new CodeGraphCheckpointSchemaError('File-fact payload is invalid.', {cause});
+  }
+  if (facts.path !== expectedPath)
+    throw new CodeGraphCheckpointSchemaError('File-fact payload path does not match its key.');
+  canonicalJson(facts);
+  return facts;
+}
+
+function parseSymbol(input: Record<string, unknown>): void {
+  exactKeys(
+    input,
+    ['contentHash', 'exported', 'id', 'kind', 'language', 'name', 'path', 'qualifiedName', 'span', 'symbolKind'],
+    ['arity', 'documentation', 'lookupKeys', 'packageName', 'resolutionDomain', 'resolutionScopeId', 'signature'],
+    'Symbol record',
+  );
+  optionalNonNegativeInteger(input.arity, 'Symbol arity');
+  sha256(input.contentHash, 'Symbol content hash');
+  optionalText(input.documentation, 'Symbol documentation');
+  boolean(input.exported, 'Symbol exported');
+  shortText(input.id, 'Symbol ID');
+  shortText(input.language, 'Symbol language');
+  if (input.lookupKeys !== undefined) stringArray(input.lookupKeys, 'Symbol lookup keys');
+  shortText(input.name, 'Symbol name');
+  optionalShortText(input.packageName, 'Symbol package name');
+  repositoryPath(input.path, 'Symbol path');
+  shortText(input.qualifiedName, 'Symbol qualified name');
+  optionalShortText(input.resolutionDomain, 'Symbol resolution domain');
+  optionalShortText(input.resolutionScopeId, 'Symbol resolution scope');
+  optionalText(input.signature, 'Symbol signature');
+  parseSpan(input.span, 'Symbol span');
+  shortText(input.symbolKind, 'Symbol kind');
+}
+
+function parseEdge(input: Record<string, unknown>): void {
+  exactKeys(
+    input,
+    ['confidence', 'evidencePath', 'evidenceSpan', 'id', 'kind', 'provenance', 'relation', 'sourceName', 'targetName'],
+    ['sourceId', 'targetId'],
+    'Edge record',
+  );
+  finiteRange(input.confidence, 'Edge confidence', 0, 1);
+  repositoryPath(input.evidencePath, 'Edge evidence path');
+  parseSpan(input.evidenceSpan, 'Edge evidence span');
+  shortText(input.id, 'Edge ID');
+  oneOf(input.provenance, ['declared', 'heuristic', 'model', 'resolved', 'syntactic'], 'Edge provenance');
+  oneOf(
+    input.relation,
+    [
+      'calls',
+      'configures',
+      'constructs',
+      'contains',
+      'declares',
+      'depends_on',
+      'documents',
+      'exports',
+      'extends',
+      'implements',
+      'imports',
+      'overrides',
+      'reads_or_writes',
+      'references',
+      'reexports',
+      'semantic_association',
+      'tests',
+    ],
+    'Edge relation',
+  );
+  optionalShortText(input.sourceId, 'Edge source ID');
+  shortText(input.sourceName, 'Edge source name');
+  optionalShortText(input.targetId, 'Edge target ID');
+  shortText(input.targetName, 'Edge target name');
+}
+
+function parseMoniker(input: Record<string, unknown>): void {
+  exactKeys(
+    input,
+    [
+      'evidencePath',
+      'evidenceSpan',
+      'id',
+      'identity',
+      'kind',
+      'monikerKind',
+      'resolutionDomain',
+      'role',
+      'scheme',
+      'version',
+    ],
+    ['componentId', 'dependencyKind', 'importPath', 'packageName', 'packageVersion', 'qualifiedName', 'symbolId'],
+    'Moniker record',
+  );
+  optionalShortText(input.componentId, 'Moniker component ID');
+  if (input.dependencyKind !== undefined) dependencyKind(input.dependencyKind, 'Moniker dependency kind');
+  repositoryPath(input.evidencePath, 'Moniker evidence path');
+  parseSpan(input.evidenceSpan, 'Moniker evidence span');
+  shortText(input.id, 'Moniker ID');
+  shortText(input.identity, 'Moniker identity');
+  if (input.importPath !== undefined) repositoryPath(input.importPath, 'Moniker import path');
+  shortText(input.monikerKind, 'Moniker kind');
+  optionalShortText(input.packageName, 'Moniker package name');
+  optionalShortText(input.packageVersion, 'Moniker package version');
+  optionalShortText(input.qualifiedName, 'Moniker qualified name');
+  shortText(input.resolutionDomain, 'Moniker resolution domain');
+  oneOf(input.role, ['export', 'import'], 'Moniker role');
+  oneOf(input.scheme, ['package', 'protobuf'], 'Moniker scheme');
+  optionalShortText(input.symbolId, 'Moniker symbol ID');
+  positiveInteger(input.version, 'Moniker version');
+  if (input.scheme === 'package' && (input.componentId === undefined || input.packageName === undefined)) {
+    throw new CodeGraphCheckpointSchemaError('Package moniker is missing component or package identity.');
+  }
+  if (input.scheme === 'protobuf' && input.symbolId === undefined) {
+    throw new CodeGraphCheckpointSchemaError('Protobuf moniker is missing its symbol identity.');
+  }
+}
+
+function parseSpan(value: unknown, label: string): CodeGraphCheckpointSpanV1 {
+  const input = object(value, label);
+  exactKeys(input, ['column', 'endColumn', 'endLine', 'line'], [], label);
+  positiveInteger(input.column, `${label} column`);
+  positiveInteger(input.endColumn, `${label} end column`);
+  positiveInteger(input.endLine, `${label} end line`);
+  positiveInteger(input.line, `${label} line`);
+  if (
+    (input.endLine as number) < (input.line as number) ||
+    (input.endLine === input.line && (input.endColumn as number) < (input.column as number))
+  ) {
+    throw new CodeGraphCheckpointSchemaError(`${label} ends before it starts.`);
+  }
+  return input as unknown as CodeGraphCheckpointSpanV1;
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function array(value: unknown, label: string): readonly unknown[] {
+  if (!Array.isArray(value) || value.length > MAXIMUM_ARRAY_LENGTH) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a bounded array.`);
+  }
+  return value;
+}
+
+function exactKeys(
+  input: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[],
+  label: string,
+): void {
+  const allowed = new Set([...required, ...optional]);
+  for (const key of required) {
+    if (!Object.hasOwn(input, key)) throw new CodeGraphCheckpointSchemaError(`${label} is missing ${key}.`);
+  }
+  for (const key of Object.keys(input)) {
+    if (!allowed.has(key)) throw new CodeGraphCheckpointSchemaError(`${label} contains unknown field ${key}.`);
+  }
+}
+
+function literal<T extends boolean | number | string>(value: unknown, expected: T, label: string): asserts value is T {
+  if (value !== expected) throw new CodeGraphCheckpointSchemaError(`${label} is invalid.`);
+}
+
+function oneOf<const T extends readonly string[]>(
+  value: unknown,
+  options: T,
+  label: string,
+): asserts value is T[number] {
+  if (typeof value !== 'string' || !(options as readonly string[]).includes(value)) {
+    throw new CodeGraphCheckpointSchemaError(`${label} is invalid.`);
+  }
+}
+
+function text(value: unknown, label: string, maximum = 8 * 1_048_576): string {
+  if (typeof value !== 'string' || value.length > maximum) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a bounded string.`);
+  }
+  return value;
+}
+
+function shortText(value: unknown, label: string): string {
+  const result = text(value, label, MAXIMUM_SHORT_TEXT_LENGTH);
+  if (result.length === 0) throw new CodeGraphCheckpointSchemaError(`${label} cannot be empty.`);
+  return result;
+}
+
+function optionalText(value: unknown, label: string): void {
+  if (value !== undefined) text(value, label);
+}
+
+function optionalShortText(value: unknown, label: string): void {
+  if (value !== undefined) shortText(value, label);
+}
+
+function boolean(value: unknown, label: string): asserts value is boolean {
+  if (typeof value !== 'boolean') throw new CodeGraphCheckpointSchemaError(`${label} must be boolean.`);
+}
+
+function nonNegativeInteger(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a non-negative safe integer.`);
+  }
+}
+
+function positiveInteger(value: unknown, label: string, maximum = Number.MAX_SAFE_INTEGER): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0 || (value as number) > maximum) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a bounded positive safe integer.`);
+  }
+}
+
+function optionalNonNegativeInteger(value: unknown, label: string): void {
+  if (value !== undefined) nonNegativeInteger(value, label);
+}
+
+function finiteRange(value: unknown, label: string, minimum: number, maximum: number): void {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < minimum || value > maximum) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a finite number between ${minimum} and ${maximum}.`);
+  }
+}
+
+function sha256(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !SHA256.test(value)) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a lowercase SHA-256 digest.`);
+  }
+}
+
+function optionalSha256(value: unknown, label: string): void {
+  if (value !== undefined) sha256(value, label);
+}
+
+function gitObjectId(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !GIT_OBJECT_ID.test(value)) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a lowercase Git object ID.`);
+  }
+}
+
+function mode(value: unknown, label: string): void {
+  if (typeof value !== 'string' || !/^\d{6}$/u.test(value)) {
+    throw new CodeGraphCheckpointSchemaError(`${label} is invalid.`);
+  }
+}
+
+function repositoryPath(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !isSafeCodeGraphCheckpointPath(value)) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a safe repository-relative POSIX path.`);
+  }
+}
+
+function workspaceRoot(value: unknown, label: string): void {
+  // The workspace model uses the empty repository-relative path as its
+  // canonical repository root. Keep `.` readable for older/projected models,
+  // but never rewrite either representation at the checkpoint boundary.
+  if (value !== '' && value !== '.' && (typeof value !== 'string' || !isSafeCodeGraphCheckpointPath(value))) {
+    throw new CodeGraphCheckpointSchemaError(`${label} must be a safe repository-relative POSIX root.`);
+  }
+}
+
+function workspaceName(value: unknown, root: unknown, label: string): void {
+  // Existing workspace receipts represent the repository-wide build scope as
+  // the pair {root: '', name: ''}. Admit only that paired empty identity;
+  // nested workspace names remain non-empty bounded text.
+  if (value === '' && root === '') return;
+  shortText(value, label);
+}
+
+function stringArray(value: unknown, label: string): void {
+  for (const entry of array(value, label)) text(entry, `${label} entry`, MAXIMUM_SHORT_TEXT_LENGTH);
+}
+
+function pathArray(value: unknown, label: string, allowRoot: boolean): void {
+  for (const entry of array(value, label)) {
+    if (allowRoot) workspaceRoot(entry, `${label} entry`);
+    else repositoryPath(entry, `${label} entry`);
+  }
+}
+
+function workspaceBuildSystem(value: unknown, label: string): void {
+  oneOf(value, ['bazel', 'gradle', 'inferred', 'maven', 'node', 'nx', 'pnpm', 'swiftpm', 'typescript', 'xcode'], label);
+}
+
+function workspaceProvenance(value: unknown, label: string): void {
+  oneOf(value, ['declared', 'inferred'], label);
+}
+
+function dependencyKind(value: unknown, label: string): void {
+  oneOf(value, ['development', 'optional', 'peer', 'runtime'], label);
+}
+
+function ensureSortedUnique<T>(values: readonly T[], key: (value: T) => string, label: string): void {
+  let previous: string | undefined;
+  for (const value of values) {
+    const current = key(value);
+    if (previous !== undefined && current <= previous) {
+      throw new CodeGraphCheckpointSchemaError(`${label} must be strictly sorted and unique.`);
+    }
+    previous = current;
+  }
+}
+
+function checkedSum(values: readonly number[], label: string): number {
+  let total = 0;
+  for (const value of values) {
+    if (value > Number.MAX_SAFE_INTEGER - total) throw new CodeGraphCheckpointSchemaError(`${label} overflows.`);
+    total += value;
+  }
+  return total;
+}
+
+function compareUtf8(left: string, right: string): number {
+  if (left === right) return 0;
+  const leftBytes = UTF8.encode(left);
+  const rightBytes = UTF8.encode(right);
+  const length = Math.min(leftBytes.byteLength, rightBytes.byteLength);
+  for (let index = 0; index < length; index += 1) {
+    const difference = leftBytes[index]! - rightBytes[index]!;
+    if (difference !== 0) return difference;
+  }
+  return leftBytes.byteLength - rightBytes.byteLength;
+}

--- a/src/code_graph/checkpoint/terminal_text.ts
+++ b/src/code_graph/checkpoint/terminal_text.ts
@@ -1,0 +1,12 @@
+/** Makes untrusted checkpoint labels visible without emitting terminal controls. */
+export function checkpointTerminalText(value: string): string {
+  let output = '';
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    output +=
+      codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)
+        ? `\\u{${codePoint.toString(16).padStart(4, '0')}}`
+        : character;
+  }
+  return output;
+}

--- a/src/code_graph/fact_budget.ts
+++ b/src/code_graph/fact_budget.ts
@@ -9,6 +9,7 @@ import type {
 } from './types.js';
 import type {CodeGraphMonikerV1} from './cross_repository/types.js';
 import {canonicalCodeGraphMonikers} from './cross_repository/monikers.js';
+import {parseCodeGraphFileFacts} from './fact_validation.js';
 
 export const CODE_GRAPH_CACHED_FACT_BYTES_MAXIMUM = 8 * 1_048_576;
 export const CODE_GRAPH_REFERENCE_CANDIDATES_PER_REFERENCE_MAXIMUM = 100_000;
@@ -57,7 +58,7 @@ export function serializeBoundedCodeGraphFact(
   facts: CodeGraphFileFacts,
   maximumBytes = CODE_GRAPH_CACHED_FACT_BYTES_MAXIMUM,
 ): BoundedCodeGraphFact {
-  const measured = measureBoundedCodeGraphFactWithJson(facts, maximumBytes);
+  const measured = measureBoundedCodeGraphFactWithJson(parseCodeGraphFileFacts(facts), maximumBytes);
   return {
     [boundedCodeGraphFactBrand]: true,
     ...measured,

--- a/src/code_graph/fact_validation.ts
+++ b/src/code_graph/fact_validation.ts
@@ -44,7 +44,7 @@ export function parseCodeGraphFileFacts(value: unknown): CodeGraphFileFacts {
   const input = object(value, 'Code graph file facts');
   exactKeys(input, ['diagnostics', 'edges', 'path', 'symbols'], ['derivationInputs', 'monikers', 'references']);
   repositoryPath(input.path, 'File-fact path');
-  stringArray(input.diagnostics, 'File-fact diagnostics', false);
+  stringArray(input.diagnostics, 'File-fact diagnostics', TEXT_LENGTH_MAXIMUM);
   array(input.symbols, 'File-fact symbols').forEach((symbol, index) => parseSymbol(symbol, index));
   array(input.edges, 'File-fact edges').forEach((edge, index) => parseEdge(edge, index));
   if (input.references !== undefined) {
@@ -77,11 +77,11 @@ function parseSymbol(value: unknown, index: number): CodeGraphSymbol {
   shortText(input.id, 'Symbol ID');
   shortText(input.kind, 'Symbol kind');
   shortText(input.language, 'Symbol language');
-  if (input.lookupKeys !== undefined) stringArray(input.lookupKeys, 'Symbol lookup keys', true);
-  shortText(input.name, 'Symbol name');
-  optionalShortText(input.packageName, 'Symbol package name');
+  if (input.lookupKeys !== undefined) nonEmptyStringArray(input.lookupKeys, 'Symbol lookup keys', false);
+  boundedNonEmptyText(input.name, 'Symbol name');
+  optionalBoundedNonEmptyText(input.packageName, 'Symbol package name');
   repositoryPath(input.path, 'Symbol path');
-  shortText(input.qualifiedName, 'Symbol qualified name');
+  boundedNonEmptyText(input.qualifiedName, 'Symbol qualified name');
   optionalShortText(input.resolutionDomain, 'Symbol resolution domain');
   optionalShortText(input.resolutionScopeId, 'Symbol resolution scope');
   optionalText(input.signature, 'Symbol signature');
@@ -103,9 +103,9 @@ function parseEdge(value: unknown, index: number): CodeGraphEdge {
   provenance(input.provenance, 'Edge provenance');
   relation(input.relation, 'Edge relation');
   optionalShortText(input.sourceId, 'Edge source ID');
-  shortText(input.sourceName, 'Edge source name');
+  boundedNonEmptyText(input.sourceName, 'Edge source name');
   optionalShortText(input.targetId, 'Edge target ID');
-  shortText(input.targetName, 'Edge target name');
+  boundedNonEmptyText(input.targetName, 'Edge target name');
   return input as unknown as CodeGraphEdge;
 }
 
@@ -126,21 +126,23 @@ function parseReference(value: unknown, index: number): CodeGraphReference {
     ],
     ['aliasLookupKeys', 'arity', 'exportedOnly', 'sourceId'],
   );
-  if (input.aliasLookupKeys !== undefined) stringArray(input.aliasLookupKeys, 'Reference alias lookup keys', true);
+  if (input.aliasLookupKeys !== undefined) {
+    nonEmptyStringArray(input.aliasLookupKeys, 'Reference alias lookup keys', false);
+  }
   optionalNonNegativeInteger(input.arity, 'Reference arity');
   shortText(input.edgeId, 'Reference edge ID');
   repositoryPath(input.evidencePath, 'Reference evidence path');
   parseSpan(input.evidenceSpan, 'Reference evidence span');
   if (input.exportedOnly !== undefined) bool(input.exportedOnly, 'Reference exported-only state');
   array(input.lookupTiers, 'Reference lookup tiers').forEach((tier, tierIndex) =>
-    stringArray(tier, `Reference lookup tier ${tierIndex}`, true),
+    nonEmptyStringArray(tier, `Reference lookup tier ${tierIndex}`, false),
   );
   provenance(input.provenance, 'Reference provenance');
   relation(input.relation, 'Reference relation');
   shortText(input.resolutionDomain, 'Reference resolution domain');
   optionalShortText(input.sourceId, 'Reference source ID');
-  shortText(input.sourceName, 'Reference source name');
-  shortText(input.targetName, 'Reference target name');
+  boundedNonEmptyText(input.sourceName, 'Reference source name');
+  boundedNonEmptyText(input.targetName, 'Reference target name');
   return input as unknown as CodeGraphReference;
 }
 
@@ -154,7 +156,7 @@ function parseDerivationInputs(value: unknown): void {
     text(rationale.documentation, 'Rationale documentation');
     positiveInteger(rationale.line, 'Rationale line');
     shortText(rationale.marker, 'Rationale marker');
-    shortText(rationale.name, 'Rationale name');
+    boundedNonEmptyText(rationale.name, 'Rationale name');
   });
 }
 
@@ -205,10 +207,20 @@ function text(value: unknown, label: string, maximum = TEXT_LENGTH_MAXIMUM): ass
 }
 
 function shortText(value: unknown, label: string): asserts value is string {
-  text(value, label, SHORT_TEXT_LENGTH_MAXIMUM);
-  if (value.length === 0 || containsControlCharacter(value)) {
+  boundedNonEmptyText(value, label);
+  if (containsControlCharacter(value)) {
     throw new CodeGraphFactValidationError(`${label} must be non-empty and control-free.`);
   }
+}
+
+/**
+ * Repository-controlled semantic text may contain terminal controls. It is
+ * persisted verbatim for graph fidelity and sanitized only at presentation
+ * boundaries; structural IDs and paths remain control-free.
+ */
+function boundedNonEmptyText(value: unknown, label: string): asserts value is string {
+  text(value, label, SHORT_TEXT_LENGTH_MAXIMUM);
+  if (value.length === 0) throw new CodeGraphFactValidationError(`${label} must be non-empty.`);
 }
 
 function optionalText(value: unknown, label: string): void {
@@ -219,10 +231,20 @@ function optionalShortText(value: unknown, label: string): void {
   if (value !== undefined) shortText(value, label);
 }
 
-function stringArray(value: unknown, label: string, controlFree: boolean): void {
+function optionalBoundedNonEmptyText(value: unknown, label: string): void {
+  if (value !== undefined) boundedNonEmptyText(value, label);
+}
+
+function stringArray(value: unknown, label: string, maximum = SHORT_TEXT_LENGTH_MAXIMUM): void {
+  for (const entry of array(value, label)) {
+    text(entry, `${label} entry`, maximum);
+  }
+}
+
+function nonEmptyStringArray(value: unknown, label: string, controlFree: boolean): void {
   for (const entry of array(value, label)) {
     if (controlFree) shortText(entry, `${label} entry`);
-    else text(entry, `${label} entry`, SHORT_TEXT_LENGTH_MAXIMUM);
+    else boundedNonEmptyText(entry, `${label} entry`);
   }
 }
 

--- a/src/code_graph/fact_validation.ts
+++ b/src/code_graph/fact_validation.ts
@@ -1,0 +1,291 @@
+import {parseCodeGraphMonikerV1} from './cross_repository/monikers.js';
+import type {
+  CodeGraphEdge,
+  CodeGraphFileFacts,
+  CodeGraphProvenance,
+  CodeGraphReference,
+  CodeGraphRelation,
+  CodeGraphSpan,
+  CodeGraphSymbol,
+} from './types.js';
+
+const ARRAY_ENTRIES_MAXIMUM = 1_000_000;
+const PATH_LENGTH_MAXIMUM = 4_096;
+const SHORT_TEXT_LENGTH_MAXIMUM = 16_384;
+const TEXT_LENGTH_MAXIMUM = 8 * 1_048_576;
+const SHA256 = /^[0-9a-f]{64}$/u;
+const PROVENANCE = new Set<CodeGraphProvenance>(['declared', 'heuristic', 'model', 'resolved', 'syntactic']);
+const RELATIONS = new Set<CodeGraphRelation>([
+  'calls',
+  'configures',
+  'constructs',
+  'contains',
+  'declares',
+  'depends_on',
+  'documents',
+  'exports',
+  'extends',
+  'implements',
+  'imports',
+  'overrides',
+  'reads_or_writes',
+  'references',
+  'reexports',
+  'semantic_association',
+  'tests',
+]);
+
+export class CodeGraphFactValidationError extends Error {
+  override readonly name = 'CodeGraphFactValidationError';
+}
+
+/** Exact recursive validator for parser facts crossing a durable or portable boundary. */
+export function parseCodeGraphFileFacts(value: unknown): CodeGraphFileFacts {
+  const input = object(value, 'Code graph file facts');
+  exactKeys(input, ['diagnostics', 'edges', 'path', 'symbols'], ['derivationInputs', 'monikers', 'references']);
+  repositoryPath(input.path, 'File-fact path');
+  stringArray(input.diagnostics, 'File-fact diagnostics', false);
+  array(input.symbols, 'File-fact symbols').forEach((symbol, index) => parseSymbol(symbol, index));
+  array(input.edges, 'File-fact edges').forEach((edge, index) => parseEdge(edge, index));
+  if (input.references !== undefined) {
+    array(input.references, 'File-fact references').forEach((reference, index) => parseReference(reference, index));
+  }
+  if (input.monikers !== undefined) {
+    array(input.monikers, 'File-fact monikers').forEach((moniker, index) => {
+      try {
+        parseCodeGraphMonikerV1(moniker);
+      } catch (cause) {
+        throw new CodeGraphFactValidationError(`File-fact moniker ${index} is invalid.`, {cause});
+      }
+    });
+  }
+  if (input.derivationInputs !== undefined) parseDerivationInputs(input.derivationInputs);
+  return input as unknown as CodeGraphFileFacts;
+}
+
+function parseSymbol(value: unknown, index: number): CodeGraphSymbol {
+  const input = object(value, `File-fact symbol ${index}`);
+  exactKeys(
+    input,
+    ['contentHash', 'exported', 'id', 'kind', 'language', 'name', 'path', 'qualifiedName', 'span'],
+    ['arity', 'documentation', 'lookupKeys', 'packageName', 'resolutionDomain', 'resolutionScopeId', 'signature'],
+  );
+  optionalNonNegativeInteger(input.arity, 'Symbol arity');
+  digest(input.contentHash, 'Symbol content hash');
+  optionalText(input.documentation, 'Symbol documentation');
+  bool(input.exported, 'Symbol exported');
+  shortText(input.id, 'Symbol ID');
+  shortText(input.kind, 'Symbol kind');
+  shortText(input.language, 'Symbol language');
+  if (input.lookupKeys !== undefined) stringArray(input.lookupKeys, 'Symbol lookup keys', true);
+  shortText(input.name, 'Symbol name');
+  optionalShortText(input.packageName, 'Symbol package name');
+  repositoryPath(input.path, 'Symbol path');
+  shortText(input.qualifiedName, 'Symbol qualified name');
+  optionalShortText(input.resolutionDomain, 'Symbol resolution domain');
+  optionalShortText(input.resolutionScopeId, 'Symbol resolution scope');
+  optionalText(input.signature, 'Symbol signature');
+  parseSpan(input.span, 'Symbol span');
+  return input as unknown as CodeGraphSymbol;
+}
+
+function parseEdge(value: unknown, index: number): CodeGraphEdge {
+  const input = object(value, `File-fact edge ${index}`);
+  exactKeys(
+    input,
+    ['confidence', 'evidencePath', 'evidenceSpan', 'id', 'provenance', 'relation', 'sourceName', 'targetName'],
+    ['sourceId', 'targetId'],
+  );
+  finiteRange(input.confidence, 'Edge confidence', 0, 1);
+  repositoryPath(input.evidencePath, 'Edge evidence path');
+  parseSpan(input.evidenceSpan, 'Edge evidence span');
+  shortText(input.id, 'Edge ID');
+  provenance(input.provenance, 'Edge provenance');
+  relation(input.relation, 'Edge relation');
+  optionalShortText(input.sourceId, 'Edge source ID');
+  shortText(input.sourceName, 'Edge source name');
+  optionalShortText(input.targetId, 'Edge target ID');
+  shortText(input.targetName, 'Edge target name');
+  return input as unknown as CodeGraphEdge;
+}
+
+function parseReference(value: unknown, index: number): CodeGraphReference {
+  const input = object(value, `File-fact reference ${index}`);
+  exactKeys(
+    input,
+    [
+      'edgeId',
+      'evidencePath',
+      'evidenceSpan',
+      'lookupTiers',
+      'provenance',
+      'relation',
+      'resolutionDomain',
+      'sourceName',
+      'targetName',
+    ],
+    ['aliasLookupKeys', 'arity', 'exportedOnly', 'sourceId'],
+  );
+  if (input.aliasLookupKeys !== undefined) stringArray(input.aliasLookupKeys, 'Reference alias lookup keys', true);
+  optionalNonNegativeInteger(input.arity, 'Reference arity');
+  shortText(input.edgeId, 'Reference edge ID');
+  repositoryPath(input.evidencePath, 'Reference evidence path');
+  parseSpan(input.evidenceSpan, 'Reference evidence span');
+  if (input.exportedOnly !== undefined) bool(input.exportedOnly, 'Reference exported-only state');
+  array(input.lookupTiers, 'Reference lookup tiers').forEach((tier, tierIndex) =>
+    stringArray(tier, `Reference lookup tier ${tierIndex}`, true),
+  );
+  provenance(input.provenance, 'Reference provenance');
+  relation(input.relation, 'Reference relation');
+  shortText(input.resolutionDomain, 'Reference resolution domain');
+  optionalShortText(input.sourceId, 'Reference source ID');
+  shortText(input.sourceName, 'Reference source name');
+  shortText(input.targetName, 'Reference target name');
+  return input as unknown as CodeGraphReference;
+}
+
+function parseDerivationInputs(value: unknown): void {
+  const input = object(value, 'File-fact derivation inputs');
+  exactKeys(input, [], ['rationale']);
+  if (input.rationale === undefined) return;
+  array(input.rationale, 'File-fact rationale inputs').forEach((value, index) => {
+    const rationale = object(value, `File-fact rationale ${index}`);
+    exactKeys(rationale, ['documentation', 'line', 'marker', 'name'], []);
+    text(rationale.documentation, 'Rationale documentation');
+    positiveInteger(rationale.line, 'Rationale line');
+    shortText(rationale.marker, 'Rationale marker');
+    shortText(rationale.name, 'Rationale name');
+  });
+}
+
+function parseSpan(value: unknown, label: string): CodeGraphSpan {
+  const input = object(value, label);
+  exactKeys(input, ['column', 'endColumn', 'endLine', 'line'], []);
+  positiveInteger(input.column, `${label} column`);
+  positiveInteger(input.endColumn, `${label} end column`);
+  positiveInteger(input.endLine, `${label} end line`);
+  positiveInteger(input.line, `${label} line`);
+  if (
+    (input.endLine as number) < (input.line as number) ||
+    (input.endLine === input.line && (input.endColumn as number) < (input.column as number))
+  ) {
+    throw new CodeGraphFactValidationError(`${label} ends before it starts.`);
+  }
+  return input as unknown as CodeGraphSpan;
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new CodeGraphFactValidationError(`${label} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function array(value: unknown, label: string): readonly unknown[] {
+  if (!Array.isArray(value) || value.length > ARRAY_ENTRIES_MAXIMUM) {
+    throw new CodeGraphFactValidationError(`${label} must be a bounded array.`);
+  }
+  return value;
+}
+
+function exactKeys(input: Record<string, unknown>, required: readonly string[], optional: readonly string[]): void {
+  const allowed = new Set([...required, ...optional]);
+  for (const key of required) {
+    if (!Object.hasOwn(input, key)) throw new CodeGraphFactValidationError(`Code graph facts are missing ${key}.`);
+  }
+  for (const key of Object.keys(input)) {
+    if (!allowed.has(key)) throw new CodeGraphFactValidationError(`Code graph facts contain unknown field ${key}.`);
+  }
+}
+
+function text(value: unknown, label: string, maximum = TEXT_LENGTH_MAXIMUM): asserts value is string {
+  if (typeof value !== 'string' || value.length > maximum) {
+    throw new CodeGraphFactValidationError(`${label} must be a bounded string.`);
+  }
+}
+
+function shortText(value: unknown, label: string): asserts value is string {
+  text(value, label, SHORT_TEXT_LENGTH_MAXIMUM);
+  if (value.length === 0 || containsControlCharacter(value)) {
+    throw new CodeGraphFactValidationError(`${label} must be non-empty and control-free.`);
+  }
+}
+
+function optionalText(value: unknown, label: string): void {
+  if (value !== undefined) text(value, label);
+}
+
+function optionalShortText(value: unknown, label: string): void {
+  if (value !== undefined) shortText(value, label);
+}
+
+function stringArray(value: unknown, label: string, controlFree: boolean): void {
+  for (const entry of array(value, label)) {
+    if (controlFree) shortText(entry, `${label} entry`);
+    else text(entry, `${label} entry`, SHORT_TEXT_LENGTH_MAXIMUM);
+  }
+}
+
+function repositoryPath(value: unknown, label: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > PATH_LENGTH_MAXIMUM ||
+    value.startsWith('/') ||
+    value.startsWith('\\') ||
+    /^[A-Za-z]:/u.test(value) ||
+    value.includes('\\') ||
+    containsControlCharacter(value) ||
+    value.split('/').some(segment => segment.length === 0 || segment === '.' || segment === '..')
+  ) {
+    throw new CodeGraphFactValidationError(`${label} must be a safe repository-relative POSIX path.`);
+  }
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return true;
+  }
+  return false;
+}
+
+function digest(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !SHA256.test(value)) {
+    throw new CodeGraphFactValidationError(`${label} must be a lowercase SHA-256 digest.`);
+  }
+}
+
+function bool(value: unknown, label: string): asserts value is boolean {
+  if (typeof value !== 'boolean') throw new CodeGraphFactValidationError(`${label} must be boolean.`);
+}
+
+function positiveInteger(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new CodeGraphFactValidationError(`${label} must be a positive safe integer.`);
+  }
+}
+
+function optionalNonNegativeInteger(value: unknown, label: string): void {
+  if (value !== undefined && (!Number.isSafeInteger(value) || (value as number) < 0)) {
+    throw new CodeGraphFactValidationError(`${label} must be a non-negative safe integer.`);
+  }
+}
+
+function finiteRange(value: unknown, label: string, minimum: number, maximum: number): void {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < minimum || value > maximum) {
+    throw new CodeGraphFactValidationError(`${label} must be a finite number between ${minimum} and ${maximum}.`);
+  }
+}
+
+function provenance(value: unknown, label: string): asserts value is CodeGraphProvenance {
+  if (typeof value !== 'string' || !PROVENANCE.has(value as CodeGraphProvenance)) {
+    throw new CodeGraphFactValidationError(`${label} is invalid.`);
+  }
+}
+
+function relation(value: unknown, label: string): asserts value is CodeGraphRelation {
+  if (typeof value !== 'string' || !RELATIONS.has(value as CodeGraphRelation)) {
+    throw new CodeGraphFactValidationError(`${label} is invalid.`);
+  }
+}

--- a/src/code_graph/graph_identity.ts
+++ b/src/code_graph/graph_identity.ts
@@ -1,0 +1,75 @@
+import {sha256HexSync} from '../crypto/sha256.js';
+import {codeGraphInventorySha256Hex} from './inventory_identity.js';
+import {compareCodeUnits} from './ordering.js';
+import {CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION} from './store_build_core.js';
+import type {CodeGraphLanguagePackProvenance} from './store_models.js';
+import {CODE_GRAPH_EXTRACTOR_SET_VERSION} from './types.js';
+
+export interface CodeGraphContentIdentityFile {
+  readonly contentHash: string;
+  readonly language?: string;
+  readonly mode?: string;
+  readonly path: string;
+}
+
+export interface CodeGraphContentIdentityAccumulator {
+  readonly digest: () => string;
+  readonly update: (file: CodeGraphContentIdentityFile) => void;
+}
+
+export function codeGraphExtractorSetIdentityFromPackProvenance(
+  provenance: readonly CodeGraphLanguagePackProvenance[],
+): string {
+  return codeGraphExtractorSetIdentityFromIdentities(
+    [...new Set(provenance.map(pack => pack.cacheIdentity))],
+    [...new Set(provenance.map(pack => pack.derivationIdentity))],
+  );
+}
+
+export function codeGraphExtractorSetIdentityFromIdentities(
+  cacheIdentities: readonly string[],
+  derivationIdentities: readonly string[],
+): string {
+  const activeParsers = [...cacheIdentities].sort(compareCodeUnits).join('\n');
+  const activeDerivations = [...derivationIdentities].sort(compareCodeUnits).join('\n');
+  return sha256HexSync(
+    `${CODE_GRAPH_EXTRACTOR_SET_VERSION}\nactive-parser-packs:\n${activeParsers}\nactive-derivations:\n${activeDerivations}\nignore-policy:3\nresolution-context-policy:semantic-workspace-v1`,
+  );
+}
+
+export function codeGraphContentIdentity(extractorSet: string, files: readonly CodeGraphContentIdentityFile[]): string {
+  return `cgc_${codeGraphInventorySha256Hex(graphContentPrefix(extractorSet), files, graphContentLine).slice(0, 40)}`;
+}
+
+/** Hashes an already strict UTF-16-code-unit-ordered inventory without retaining it in memory. */
+export function createCodeGraphContentIdentityAccumulator(extractorSet: string): CodeGraphContentIdentityAccumulator {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(graphContentPrefix(extractorSet));
+  let completed: string | undefined;
+  let previousPath: string | undefined;
+  let rows = 0;
+  return {
+    digest: () => {
+      if (completed === undefined) completed = `cgc_${hasher.digest('hex').slice(0, 40)}`;
+      return completed;
+    },
+    update: file => {
+      if (completed !== undefined) throw new Error('Code graph content identity is already complete.');
+      if (file.path.includes('\0') || (previousPath !== undefined && compareCodeUnits(previousPath, file.path) >= 0)) {
+        throw new Error('Code graph content identity input is not in strict canonical order.');
+      }
+      if (rows > 0) hasher.update('\n');
+      hasher.update(graphContentLine(file));
+      previousPath = file.path;
+      rows += 1;
+    },
+  };
+}
+
+function graphContentPrefix(extractorSet: string): string {
+  return `graph-content-v1\nlexical-storage:${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}\n${extractorSet}\n`;
+}
+
+function graphContentLine(file: CodeGraphContentIdentityFile): string {
+  return `${file.path}\0${file.contentHash}\0${file.language ?? ''}\0${file.mode ?? ''}`;
+}

--- a/src/code_graph/indexer_incremental.ts
+++ b/src/code_graph/indexer_incremental.ts
@@ -38,6 +38,7 @@ import {
   type CodeGraphResolutionPublicationAssessment,
 } from './resolution_surface.js';
 import {
+  CODE_GRAPH_RESOLUTION_SURFACE_VERSION,
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   type CodeGraphLanguagePackProvenance,
   type CodeGraphReusableBaseReceipt,
@@ -118,7 +119,7 @@ export const assessIncrementalOverlay = Effect.fn('codeGraph.assessIncrementalOv
     if (
       !receipt ||
       receipt.formatVersion !== CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION ||
-      receipt.resolutionSurfaceVersion !== 1 ||
+      receipt.resolutionSurfaceVersion !== CODE_GRAPH_RESOLUTION_SURFACE_VERSION ||
       receipt.workspaceFingerprint !== preassessment.committedWorkspace.fingerprint ||
       (preassessment.resolutionClosure !== 'full' &&
         receipt.fileSetFingerprint !== preassessment.baseFileSetFingerprint)

--- a/src/code_graph/indexer_materialization.ts
+++ b/src/code_graph/indexer_materialization.ts
@@ -27,6 +27,11 @@ import {
   serializeBoundedCodeGraphFact,
   type BoundedCodeGraphFact,
 } from './fact_budget.js';
+import {
+  codeGraphContentIdentity,
+  codeGraphExtractorSetIdentityFromIdentities,
+  codeGraphExtractorSetIdentityFromPackProvenance,
+} from './graph_identity.js';
 import {CodeGraphIndexOperationError, sameOverlayState, WorktreeChangedDuringIndex} from './indexer_shared.js';
 import type {DirectPersistentCapacityProtection, IncrementalOverlayAssessment} from './indexer_types.js';
 import {
@@ -752,28 +757,14 @@ export function extractorSetIdentity(
   languagePacks: CodeGraphLanguagePackRegistryShape = BUILTIN_LANGUAGE_PACK_REGISTRY,
 ): string {
   const paths = files.map(file => file.path);
-  return extractorSetIdentityFromIdentities(
+  return codeGraphExtractorSetIdentityFromIdentities(
     languagePacks.activeCacheIdentities(paths),
     languagePacks.activeDerivationIdentities(paths),
   );
 }
 
 export function extractorSetIdentityFromPackProvenance(provenance: readonly CodeGraphLanguagePackProvenance[]): string {
-  return extractorSetIdentityFromIdentities(
-    [...new Set(provenance.map(pack => pack.cacheIdentity))],
-    [...new Set(provenance.map(pack => pack.derivationIdentity))],
-  );
-}
-
-function extractorSetIdentityFromIdentities(
-  cacheIdentities: readonly string[],
-  derivationIdentities: readonly string[],
-): string {
-  const activeParsers = [...cacheIdentities].sort(compareCodeUnits).join('\n');
-  const activeDerivations = [...derivationIdentities].sort(compareCodeUnits).join('\n');
-  return sha256HexSync(
-    `${CODE_GRAPH_EXTRACTOR_SET_VERSION}\nactive-parser-packs:\n${activeParsers}\nactive-derivations:\n${activeDerivations}\nignore-policy:3\nresolution-context-policy:semantic-workspace-v1`,
-  );
+  return codeGraphExtractorSetIdentityFromPackProvenance(provenance);
 }
 
 export function parserCacheIdentity(): string {
@@ -846,12 +837,7 @@ export function graphContentIdentity(
     readonly path: string;
   }[],
 ): string {
-  const prefix = `graph-content-v1\nlexical-storage:${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}\n${extractorSet}\n`;
-  return `cgc_${codeGraphInventorySha256Hex(
-    prefix,
-    files,
-    file => `${file.path}\0${file.contentHash}\0${file.language ?? ''}\0${file.mode ?? ''}`,
-  ).slice(0, 40)}`;
+  return codeGraphContentIdentity(extractorSet, files);
 }
 
 export function selectedDecodedFactBytes(

--- a/src/code_graph/maintenance.ts
+++ b/src/code_graph/maintenance.ts
@@ -15,7 +15,8 @@ import {
   withCodeGraphMaintenanceIntent,
 } from './maintenance_gate.js';
 import {CodeGraphStore, type CodeGraphDatabaseHealth} from './store.js';
-import {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION, CODE_GRAPH_SCHEMA_VERSION} from './types.js';
+import {CODE_GRAPH_SCHEMA_VERSION} from './types.js';
+import {CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR} from './store/schema_revision.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY} from './languages/registry.js';
 import {diagnoseCodeGraphDatabaseReadOnly} from './store_health.js';
 import {diagnoseCodeGraphDatabase} from './deep_diagnostics.js';
@@ -364,7 +365,7 @@ export const repairCodeGraphIndexes = Effect.fn('codeGraph.repairIndexes')(funct
                       diagnosed.value.snapshotFileCitationSchema === 'column-only-with-authority' ||
                       (diagnosed.value.snapshotFileCitationSchema === 'released-absent-with-authority' &&
                         diagnosed.value.persistentExtensionSchemaRevision !==
-                          CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION - 1))
+                          CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR.value))
                   ) {
                     return deep ? ('discard' as const) : ('schema-upgrade-on-use' as const);
                   }

--- a/src/code_graph/manager_catalog_revision.ts
+++ b/src/code_graph/manager_catalog_revision.ts
@@ -6,6 +6,7 @@ import {compareCodeUnits} from './ordering.js';
 import {CodeGraphStore} from './store.js';
 import {type CodeGraphActiveViewIdentity} from './store_models.js';
 import type {CodeGraphLifecycleOpportunityTarget} from './lifecycle_opportunity.js';
+import {CODE_GRAPH_MANAGER_CATALOG_REVISION_VERSION} from './store/schema_revision.js';
 
 export const MANAGER_CATALOG_REVISION_VISIBLE_VIEW_LIMIT = 32;
 
@@ -39,7 +40,9 @@ export function managerGraphCatalogRevision(databases: readonly ManagerGraphCata
       viewsTruncated: database.viewsTruncated,
     }))
     .sort((left, right) => compareCodeUnits(left.checkoutId, right.checkoutId));
-  return sha256HexSync(`threadnote-manager-graph-catalog-revision-v1\n${JSON.stringify(canonical)}`);
+  return sha256HexSync(
+    `threadnote-manager-graph-catalog-revision-v${CODE_GRAPH_MANAGER_CATALOG_REVISION_VERSION}\n${JSON.stringify(canonical)}`,
+  );
 }
 
 /** Read the visible active pointers and path-free missing-view status in one bounded pass. */

--- a/src/code_graph/presentation_text.ts
+++ b/src/code_graph/presentation_text.ts
@@ -1,0 +1,31 @@
+/** Replace terminal controls and bidi overrides while preserving code-point length. */
+export function sanitizeCodeGraphPresentationText(value: string, maximumCharacters = Number.MAX_SAFE_INTEGER): string {
+  const limit = Number.isFinite(maximumCharacters)
+    ? Math.max(0, Math.floor(maximumCharacters))
+    : Number.MAX_SAFE_INTEGER;
+  let output = '';
+  let length = 0;
+  for (const character of value) {
+    if (length >= limit) break;
+    const codePoint = character.codePointAt(0) ?? 0;
+    output +=
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      (codePoint >= 0x202a && codePoint <= 0x202e) ||
+      (codePoint >= 0x2066 && codePoint <= 0x2069)
+        ? ' '
+        : character;
+    length += 1;
+  }
+  return output;
+}
+
+/** Defensive projection for bounded public result objects assembled outside the analysis service. */
+export function sanitizeCodeGraphPresentationValue<Value>(value: Value): Value {
+  if (typeof value === 'string') return sanitizeCodeGraphPresentationText(value) as Value;
+  if (Array.isArray(value)) return value.map(item => sanitizeCodeGraphPresentationValue(item)) as Value;
+  if (value === null || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [key, sanitizeCodeGraphPresentationValue(item)]),
+  ) as Value;
+}

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -27,6 +27,7 @@ import {
   resolveAndRecordCodeGraphLocalAssociation,
 } from './local_provenance.js';
 import {compareCodeUnits} from './ordering.js';
+import {sanitizeCodeGraphPresentationText as sanitizeText} from './presentation_text.js';
 import {resolveRepositoryIdentity} from './repository.js';
 import {
   attachCodeGraphStatusObservation,
@@ -1946,21 +1947,6 @@ function sanitizeSelection(selection: {
       : {}),
     warnings: truncated ? [...warnings, 'Graph result reached its output byte budget; results are partial.'] : warnings,
   };
-}
-
-function sanitizeText(value: string, maximumCharacters: number): string {
-  return [...value]
-    .map(character => {
-      const codePoint = character.codePointAt(0) ?? 0;
-      return codePoint <= 0x1f ||
-        (codePoint >= 0x7f && codePoint <= 0x9f) ||
-        (codePoint >= 0x202a && codePoint <= 0x202e) ||
-        (codePoint >= 0x2066 && codePoint <= 0x2069)
-        ? ' '
-        : character;
-    })
-    .slice(0, maximumCharacters)
-    .join('');
 }
 
 function encodedSize(value: unknown): number {

--- a/src/code_graph/store.ts
+++ b/src/code_graph/store.ts
@@ -4,6 +4,7 @@ import {makeCodeGraphStoreDataMethods} from './store_service_data.js';
 import {makeCodeGraphStoreLifecycleMethods} from './store_service_lifecycle.js';
 import {makeCodeGraphStoreMaintenanceMethods} from './store_service_maintenance.js';
 import {makeCodeGraphStoreStagingMethods} from './store_service_staging.js';
+import {makeCodeGraphStoreCheckpointMethods} from './store_service_checkpoint.js';
 import {type CodeGraphStoreShape} from './store_shape.js';
 
 export {
@@ -140,6 +141,10 @@ export {codeGraphRemovedViewCleanupSchemaAdmission} from './store_schema_migrati
 export {type CodeGraphPersistentReferencePageLimits} from './store_staging_core.js';
 export {normalizedTerms, sanitizeCodeGraphStoreDiagnostic} from './store_utilities.js';
 export {
+  CodeGraphCheckpointReuseHydrationError,
+  hydrateCodeGraphCheckpointReusableBaseReceipt,
+} from './checkpoint/import_reuse.js';
+export {
   codeGraphVisualizationCatalogComponentStatement,
   codeGraphVisualizationScopeEndpointStatement,
   codeGraphVisualizationScopeSummaryStatementCount,
@@ -159,6 +164,7 @@ export class CodeGraphStore extends Context.Service<CodeGraphStore, CodeGraphSto
     Effect.gen(function* () {
       const runtime = yield* makeCodeGraphStoreRuntime;
       return CodeGraphStore.of({
+        ...makeCodeGraphStoreCheckpointMethods(runtime),
         ...makeCodeGraphStoreLifecycleMethods(runtime),
         ...makeCodeGraphStoreDataMethods(runtime),
         ...makeCodeGraphStoreMaintenanceMethods(runtime),

--- a/src/code_graph/store/schema_revision.ts
+++ b/src/code_graph/store/schema_revision.ts
@@ -1,0 +1,343 @@
+/**
+ * Named code-graph storage and protocol revisions.
+ *
+ * Persistent extension revisions are durable SQLite values. Keep their
+ * numbers here, at the serialization boundary, and use profiles or
+ * capabilities everywhere behavior depends on their meaning.
+ */
+
+export const CODE_GRAPH_CORE_SCHEMA_VERSION = 3 as const;
+
+export const CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_REVISION = {
+  citationAliasPredecessor: 2,
+  current: 3,
+} as const;
+export const CODE_GRAPH_SCHEMA_INITIALIZATION_CITATION_PREDECESSOR_CONTRACT_REVISION =
+  CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_REVISION.citationAliasPredecessor;
+export const CODE_GRAPH_SCHEMA_INITIALIZATION_CURRENT_CONTRACT_REVISION =
+  CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_REVISION.current;
+
+/** SQLite's schema cookie is a separate signed database-header counter. */
+export const CODE_GRAPH_SQLITE_SCHEMA_COOKIE = {
+  maximum: 2_147_483_647,
+  minimum: -2_147_483_648,
+} as const;
+
+/** Artifact and receipt protocols evolve independently from the SQLite schema. */
+export const CODE_GRAPH_PROTOCOL_VERSIONS = {
+  checkpointArtifact: 1,
+  checkpointImport: 1,
+  checkpointRecordSchema: 1,
+  checkpointSemantic: 1,
+  inventoryReuseReceipt: 2,
+  managerCatalogRevision: 1,
+  resolutionSurface: 1,
+  reusableBaseReceipt: 2,
+} as const;
+
+export const CODE_GRAPH_CHECKPOINT_FORMAT_VERSION = CODE_GRAPH_PROTOCOL_VERSIONS.checkpointArtifact;
+export const CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION = CODE_GRAPH_PROTOCOL_VERSIONS.checkpointImport;
+export const CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION = CODE_GRAPH_PROTOCOL_VERSIONS.checkpointRecordSchema;
+export const CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION = CODE_GRAPH_PROTOCOL_VERSIONS.checkpointSemantic;
+export const CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION = CODE_GRAPH_PROTOCOL_VERSIONS.inventoryReuseReceipt;
+export const CODE_GRAPH_MANAGER_CATALOG_REVISION_VERSION = CODE_GRAPH_PROTOCOL_VERSIONS.managerCatalogRevision;
+export const CODE_GRAPH_RESOLUTION_SURFACE_VERSION = CODE_GRAPH_PROTOCOL_VERSIONS.resolutionSurface;
+export const CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION = CODE_GRAPH_PROTOCOL_VERSIONS.reusableBaseReceipt;
+
+export const CODE_GRAPH_PERSISTENT_SCHEMA_CAPABILITIES = [
+  'background-migration',
+  'compact-lexical-authority',
+  'worktree-reconciliation-authority',
+  'removed-view-cleanup-authority',
+  'citation-released-predecessor-authority',
+  'citation-column-predecessor-authority',
+  'checkpoint-import',
+  'direct-current-contract-adoption',
+  'explicit-cleanup-preparation',
+] as const;
+
+export type CodeGraphPersistentSchemaCapability = (typeof CODE_GRAPH_PERSISTENT_SCHEMA_CAPABILITIES)[number];
+
+export type CodeGraphPersistentSchemaRevisionKey =
+  | 'build-owner-plan'
+  | 'reference-candidate'
+  | 'legacy-lexical'
+  | 'compact-lexical'
+  | 'content-shards'
+  | 'build-owner-instance'
+  | 'removed-view-cleanup'
+  | 'component-aggregates'
+  | 'query-indexes'
+  | 'evidence-cross-repository'
+  | 'file-blob-authority'
+  | 'inventory-reuse'
+  | 'transient-spool'
+  | 'sorted-spool-citation-predecessor'
+  | 'citation-alias-checkpoint-predecessor'
+  | 'checkpoint-import';
+
+export type CodeGraphPersistentSchemaUpgradeRoute =
+  | 'adopt-current-contract'
+  | 'bridge-build-owner-instance'
+  | 'current'
+  | 'extend-checkpoint-import'
+  | 'retire-legacy-references-and-rebuild'
+  | 'rebuild-extensions';
+
+export type CodeGraphPersistentSchemaCitationState = 'none' | 'released-predecessor' | 'column-predecessor' | 'current';
+
+export interface CodeGraphPersistentSchemaRevisionProfile {
+  readonly capabilities: readonly CodeGraphPersistentSchemaCapability[];
+  readonly citationState: CodeGraphPersistentSchemaCitationState;
+  readonly key: CodeGraphPersistentSchemaRevisionKey;
+  readonly lifecycle: 'background-readable' | 'current' | 'legacy';
+  readonly upgradeRoute: CodeGraphPersistentSchemaUpgradeRoute;
+  readonly value: number;
+}
+
+const compact = ['compact-lexical-authority'] as const satisfies readonly CodeGraphPersistentSchemaCapability[];
+const background = [...compact, 'background-migration'] as const;
+const reconciliation = [...compact, 'worktree-reconciliation-authority'] as const;
+const cleanup = [...reconciliation, 'removed-view-cleanup-authority'] as const;
+const citationReleased = [...cleanup, 'citation-released-predecessor-authority'] as const;
+const citationColumn = [...citationReleased, 'citation-column-predecessor-authority'] as const;
+
+function profile<
+  const Value extends number,
+  const Key extends CodeGraphPersistentSchemaRevisionKey,
+  const Lifecycle extends CodeGraphPersistentSchemaRevisionProfile['lifecycle'],
+  const Route extends CodeGraphPersistentSchemaUpgradeRoute,
+  const Capabilities extends readonly CodeGraphPersistentSchemaCapability[],
+>(
+  value: Value,
+  key: Key,
+  lifecycle: Lifecycle,
+  upgradeRoute: Route,
+  capabilities: Capabilities,
+  citationState: CodeGraphPersistentSchemaCitationState = 'none',
+): CodeGraphPersistentSchemaRevisionProfile & {
+  readonly capabilities: Capabilities;
+  readonly key: Key;
+  readonly lifecycle: Lifecycle;
+  readonly upgradeRoute: Route;
+  readonly value: Value;
+} {
+  return {capabilities, citationState, key, lifecycle, upgradeRoute, value};
+}
+
+/** Historical catalog: entries and routes are append-only compatibility data. */
+export const CODE_GRAPH_PERSISTENT_SCHEMA_REVISIONS = [
+  profile(2, 'build-owner-plan', 'legacy', 'rebuild-extensions', []),
+  profile(3, 'reference-candidate', 'legacy', 'retire-legacy-references-and-rebuild', []),
+  profile(4, 'legacy-lexical', 'legacy', 'rebuild-extensions', []),
+  profile(5, 'compact-lexical', 'legacy', 'rebuild-extensions', compact),
+  profile(6, 'content-shards', 'background-readable', 'bridge-build-owner-instance', background),
+  profile(7, 'build-owner-instance', 'background-readable', 'adopt-current-contract', [
+    ...reconciliation,
+    'direct-current-contract-adoption',
+    'explicit-cleanup-preparation',
+  ]),
+  profile(8, 'removed-view-cleanup', 'background-readable', 'adopt-current-contract', [
+    ...cleanup,
+    'direct-current-contract-adoption',
+    'explicit-cleanup-preparation',
+  ]),
+  profile(9, 'component-aggregates', 'background-readable', 'adopt-current-contract', [
+    ...cleanup,
+    'direct-current-contract-adoption',
+    'explicit-cleanup-preparation',
+  ]),
+  profile(10, 'query-indexes', 'background-readable', 'adopt-current-contract', [
+    ...cleanup,
+    'direct-current-contract-adoption',
+  ]),
+  profile(11, 'evidence-cross-repository', 'background-readable', 'adopt-current-contract', [
+    ...cleanup,
+    'direct-current-contract-adoption',
+  ]),
+  profile(12, 'file-blob-authority', 'background-readable', 'adopt-current-contract', [
+    ...cleanup,
+    'direct-current-contract-adoption',
+  ]),
+  // r13 cannot directly advertise today's extension contract even when a
+  // partial database happens to contain similarly named tables.
+  profile(13, 'inventory-reuse', 'background-readable', 'rebuild-extensions', cleanup),
+  profile(14, 'transient-spool', 'background-readable', 'adopt-current-contract', [
+    ...cleanup,
+    'direct-current-contract-adoption',
+  ]),
+  profile(
+    15,
+    'sorted-spool-citation-predecessor',
+    'background-readable',
+    'adopt-current-contract',
+    [...citationReleased, 'direct-current-contract-adoption'],
+    'released-predecessor',
+  ),
+  profile(
+    16,
+    'citation-alias-checkpoint-predecessor',
+    'background-readable',
+    'extend-checkpoint-import',
+    [...citationColumn, 'direct-current-contract-adoption'],
+    'column-predecessor',
+  ),
+  profile(
+    17,
+    'checkpoint-import',
+    'current',
+    'current',
+    [...citationColumn, 'checkpoint-import', 'direct-current-contract-adoption', 'explicit-cleanup-preparation'],
+    'current',
+  ),
+] as const satisfies readonly CodeGraphPersistentSchemaRevisionProfile[];
+
+type CatalogProfile = (typeof CODE_GRAPH_PERSISTENT_SCHEMA_REVISIONS)[number];
+const profilesByValue: ReadonlyMap<number, CatalogProfile> = new Map(
+  CODE_GRAPH_PERSISTENT_SCHEMA_REVISIONS.map(value => [value.value, value]),
+);
+
+function requiredProfile<const Key extends CodeGraphPersistentSchemaRevisionKey>(
+  key: Key,
+): Extract<CatalogProfile, {readonly key: Key}> {
+  const value = CODE_GRAPH_PERSISTENT_SCHEMA_REVISIONS.find(profile => profile.key === key) as
+    Extract<CatalogProfile, {readonly key: Key}> | undefined;
+  if (value === undefined) throw new Error(`Missing code graph persistent schema profile ${key}.`);
+  return value;
+}
+
+export const CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT = requiredProfile('checkpoint-import');
+export const CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR = requiredProfile('sorted-spool-citation-predecessor');
+export const CODE_GRAPH_PERSISTENT_SCHEMA_CHECKPOINT_PREDECESSOR = requiredProfile(
+  'citation-alias-checkpoint-predecessor',
+);
+export const CODE_GRAPH_PERSISTENT_SCHEMA_BACKGROUND_FLOOR = requiredProfile('content-shards');
+
+export const CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION = CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT.value;
+export const CODE_GRAPH_MINIMUM_BACKGROUND_SCHEMA_REVISION = CODE_GRAPH_PERSISTENT_SCHEMA_BACKGROUND_FLOOR.value;
+
+export type CodeGraphPersistentSchemaRevisionObservation =
+  | {readonly state: 'missing'}
+  | {readonly state: 'invalid'; readonly value: unknown}
+  | {readonly profile: CodeGraphPersistentSchemaRevisionProfile; readonly state: 'known'}
+  | {readonly state: 'unknown-legacy'; readonly value: number}
+  | {readonly state: 'newer'; readonly value: number};
+
+export type CodeGraphPersistentSchemaUpgradePlan =
+  | {readonly state: 'initialize'}
+  | {readonly state: 'reject-invalid'}
+  | {readonly state: 'reject-newer'; readonly value: number}
+  | {
+      readonly profile: CodeGraphPersistentSchemaRevisionProfile;
+      readonly route: 'current';
+      readonly state: 'ready';
+    }
+  | {
+      readonly profile?: CodeGraphPersistentSchemaRevisionProfile;
+      readonly route: Exclude<CodeGraphPersistentSchemaUpgradeRoute, 'current'>;
+      readonly state: 'upgrade';
+    };
+
+/** Parse either an in-memory integer or the canonical decimal SQLite value. */
+export function observeCodeGraphPersistentSchemaRevision(
+  value: number | string | undefined,
+): CodeGraphPersistentSchemaRevisionObservation {
+  if (value === undefined) return {state: 'missing'};
+  const parsed =
+    typeof value === 'string' && /^(?:0|[1-9][0-9]{0,14})$/u.test(value)
+      ? Number(value)
+      : typeof value === 'number'
+        ? value
+        : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return {state: 'invalid', value};
+  const known = profilesByValue.get(parsed);
+  if (known !== undefined) return {profile: known, state: 'known'};
+  return parsed > CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION
+    ? {state: 'newer', value: parsed}
+    : {state: 'unknown-legacy', value: parsed};
+}
+
+export function codeGraphPersistentSchemaProfile(
+  value: number | string | undefined,
+): CodeGraphPersistentSchemaRevisionProfile | undefined {
+  const observation = observeCodeGraphPersistentSchemaRevision(value);
+  return observation.state === 'known' ? observation.profile : undefined;
+}
+
+export function codeGraphPersistentSchemaRevisionValue(value: number | string | undefined): number | undefined {
+  const observation = observeCodeGraphPersistentSchemaRevision(value);
+  switch (observation.state) {
+    case 'known':
+      return observation.profile.value;
+    case 'newer':
+    case 'unknown-legacy':
+      return observation.value;
+    default:
+      return undefined;
+  }
+}
+
+export function planCodeGraphPersistentSchemaUpgrade(
+  value: number | string | undefined,
+): CodeGraphPersistentSchemaUpgradePlan {
+  const observation = observeCodeGraphPersistentSchemaRevision(value);
+  switch (observation.state) {
+    case 'missing':
+      return {state: 'initialize'};
+    case 'invalid':
+      return {state: 'reject-invalid'};
+    case 'newer':
+      return {state: 'reject-newer', value: observation.value};
+    case 'unknown-legacy':
+      return {route: 'rebuild-extensions', state: 'upgrade'};
+    case 'known':
+      return observation.profile.upgradeRoute === 'current'
+        ? {profile: observation.profile, route: 'current', state: 'ready'}
+        : {profile: observation.profile, route: observation.profile.upgradeRoute, state: 'upgrade'};
+  }
+}
+
+export function codeGraphPersistentSchemaSupports(
+  value: number | string | undefined,
+  capability: CodeGraphPersistentSchemaCapability,
+): boolean {
+  return codeGraphPersistentSchemaProfile(value)?.capabilities.includes(capability) === true;
+}
+
+export function codeGraphPersistentSchemaIsCurrent(value: number | string | undefined): boolean {
+  return codeGraphPersistentSchemaProfile(value)?.key === CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT.key;
+}
+
+/** Includes pre-catalog non-negative integer revisions for conservative rebuilds. */
+export function codeGraphPersistentSchemaIsOlder(value: number | string | undefined): boolean {
+  const observation = observeCodeGraphPersistentSchemaRevision(value);
+  return (
+    observation.state === 'unknown-legacy' ||
+    (observation.state === 'known' && observation.profile.value < CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION)
+  );
+}
+
+export function codeGraphPersistentSchemaIsCurrentOrNewer(value: number | string | undefined): boolean {
+  const observation = observeCodeGraphPersistentSchemaRevision(value);
+  return (
+    observation.state === 'newer' ||
+    (observation.state === 'known' && observation.profile.key === CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT.key)
+  );
+}
+
+export function codeGraphPersistentSchemaMigrationPending(value: number | string | undefined): boolean {
+  return codeGraphPersistentSchemaProfile(value)?.lifecycle === 'background-readable';
+}
+
+/** Positive newer-version evidence only; missing or malformed metadata fails through normal validation. */
+export function codeGraphRuntimeSchemaRequiresReconnect(
+  observedCoreSchemaVersion: number | undefined,
+  observedPersistentExtensionRevision: number | undefined,
+): boolean {
+  return (
+    (typeof observedCoreSchemaVersion === 'number' &&
+      Number.isSafeInteger(observedCoreSchemaVersion) &&
+      observedCoreSchemaVersion > CODE_GRAPH_CORE_SCHEMA_VERSION) ||
+    observeCodeGraphPersistentSchemaRevision(observedPersistentExtensionRevision).state === 'newer'
+  );
+}

--- a/src/code_graph/store_activation.ts
+++ b/src/code_graph/store_activation.ts
@@ -1,6 +1,7 @@
 import {Effect, Option} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {
+  CODE_GRAPH_RESOLUTION_SURFACE_VERSION,
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   type CodeGraphActivationProgressCallback,
   type CodeGraphLanguagePackProvenance,
@@ -51,7 +52,7 @@ const recordLayeredSnapshotInventoryReceipt = Effect.fn('codeGraph.recordLayered
         workspace_fingerprint, file_set_fingerprint, lookup_count, alias_count,
         reexport_count, inventory_receipt_json, created_at
       ) VALUES (
-        ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, 1, ${snapshot.extractorSet},
+        ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}, ${snapshot.extractorSet},
         ${receipt.workspaceFingerprint}, ${receipt.fileSetFingerprint}, 0, 0, 0,
         ${encodeCodeGraphInventoryReuseReceipt(receipt.inventory)}, ${createdAt}
       )
@@ -429,7 +430,7 @@ const activateStagedSnapshot = Effect.fn('codeGraph.activateStagedSnapshot')(fun
             reexport_count, inventory_receipt_json, created_at
           )
           SELECT
-            ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, 1, ${snapshot.extractorSet},
+            ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}, ${snapshot.extractorSet},
             ${reusableBaseReceipt.workspaceFingerprint}, ${reusableBaseReceipt.fileSetFingerprint},
             COUNT(*), COALESCE(SUM(CASE WHEN provenance = 'alias' THEN 1 ELSE 0 END), 0),
             (SELECT COUNT(*) FROM activation_reexport_provenance),

--- a/src/code_graph/store_activation_persistent.ts
+++ b/src/code_graph/store_activation_persistent.ts
@@ -6,9 +6,11 @@ import {
   type CodeGraphDirectPersistentCapacityBoundary,
 } from './disk_capacity.js';
 import {
+  CODE_GRAPH_RESOLUTION_SURFACE_VERSION,
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   type CodeGraphActivationProgressCallback,
   type CodeGraphDirectPersistentCapacityProtector,
+  type CodeGraphCheckpointImportReceiptInput,
   type CodeGraphLanguagePackProvenance,
   type CodeGraphReusableBaseReceiptInput,
 } from './store_models.js';
@@ -62,6 +64,11 @@ import {
   materializeSnapshotComponentEdgeAggregates,
   selectPersistedSnapshotComponentEdges,
 } from './store_component_aggregates.js';
+import {
+  assertCheckpointImportBuild,
+  publishCheckpointImportReceipt,
+  verifyCheckpointImportRecordCounts,
+} from './store_checkpoint_import.js';
 
 /**
  * Read-only linearization point for Manager's writer-busy fallback. A cached
@@ -348,7 +355,7 @@ const activateCleanStagedSnapshot = Effect.fn('codeGraph.activateCleanStagedSnap
             reexport_count, inventory_receipt_json, created_at
           )
           VALUES (
-            ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, 1, ${snapshot.extractorSet},
+            ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}, ${snapshot.extractorSet},
             ${reusableBaseReceipt.workspaceFingerprint}, ${reusableBaseReceipt.fileSetFingerprint},
             ${copiedLookupKeys.rows}, ${copiedLookupKeys.talliedRows}, ${copiedReexports.rows},
             ${encodeCodeGraphInventoryReuseReceipt(reusableBaseReceipt.inventory)},
@@ -627,6 +634,7 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
   persistentCapacityProtector?: CodeGraphDirectPersistentCapacityProtector,
   snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
   materializedFileShardAssociationsComplete = false,
+  checkpointImportReceipt?: CodeGraphCheckpointImportReceiptInput,
 ) {
   const runWrite: CodeGraphWriterGate = writerGate ?? (effect => effect);
   const observe = activationProgressObserver(onProgress);
@@ -647,6 +655,10 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
   }>`SELECT repository_id, state FROM snapshots WHERE id = ${snapshot.id} LIMIT 1`;
   if (stateRows[0]?.state !== 'building' || stateRows[0]?.repository_id !== identity.repositoryId) {
     return yield* Effect.fail(new CodeGraphStoreError('Persistent full-build snapshot is not active.'));
+  }
+  if (checkpointImportReceipt !== undefined) {
+    yield* assertCheckpointImportBuild(sql, snapshot.id, checkpointImportReceipt);
+    yield* verifyCheckpointImportRecordCounts(sql, snapshot.id);
   }
   yield* assertPersistentMaterializationComplete(sql, snapshot.id, ownerToken);
   const validatedEdges = yield* validatePersistedFullEdgeSymbols(sql, snapshot.id, observe);
@@ -715,7 +727,7 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
     // callers can still publish one v3 association per inventory file. The
     // Fixed rows cover lexical/extractor/reuse/lease receipts, the ready state
     // update, build-owner deletion, and pack-provenance delete/insert writes.
-    rowCount: shardPublicationPlan.rowCount,
+    rowCount: saturatingCapacityAdd(shardPublicationPlan.rowCount, checkpointImportReceipt === undefined ? 0 : 2),
   };
   let readyTransactionStartedAt = 0;
   const readyTransaction = Effect.suspend(() => {
@@ -725,6 +737,10 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
         Effect.gen(function* () {
           yield* assertPersistentBuildOwner(sql, snapshot.id, ownerToken);
           yield* assertPersistentMaterializationComplete(sql, snapshot.id, ownerToken);
+          if (checkpointImportReceipt !== undefined) {
+            yield* assertCheckpointImportBuild(sql, snapshot.id, checkpointImportReceipt);
+            yield* verifyCheckpointImportRecordCounts(sql, snapshot.id);
+          }
           yield* publishCompactLexicalFormat(sql, snapshot.id, compactLexicalReceipt);
           if (shardPublicationPlan.associateLegacyMaterializedFileShards) {
             yield* associateSnapshotFileShards(sql, snapshot, reusableBaseReceipt);
@@ -740,7 +756,7 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
             workspace_fingerprint, file_set_fingerprint, lookup_count, alias_count,
             reexport_count, inventory_receipt_json, created_at
           ) VALUES (
-            ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, 1, ${snapshot.extractorSet},
+            ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}, ${snapshot.extractorSet},
             ${reusableBaseReceipt.workspaceFingerprint}, ${reusableBaseReceipt.fileSetFingerprint},
             ${reuseRows.lookupCount}, ${reuseRows.aliasCount}, ${reuseRows.reexportCount},
             ${encodeCodeGraphInventoryReuseReceipt(reusableBaseReceipt.inventory)},
@@ -764,6 +780,9 @@ const activatePersistedFullSnapshot = Effect.fn('codeGraph.activatePersistedFull
       `;
           if (!completed[0]) {
             return yield* Effect.fail(new CodeGraphStoreError('Persistent full-build promotion lost ownership.'));
+          }
+          if (checkpointImportReceipt !== undefined) {
+            yield* publishCheckpointImportReceipt(sql, snapshot.id, checkpointImportReceipt, new Date().toISOString());
           }
           yield* sql`
         DELETE FROM snapshot_build_owners
@@ -859,7 +878,7 @@ const activateCleanSnapshotAlias = Effect.fn('codeGraph.activateCleanSnapshotAli
           workspace_fingerprint, file_set_fingerprint, lookup_count, alias_count,
           reexport_count, inventory_receipt_json, created_at
         ) VALUES (
-          ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, 1, ${snapshot.extractorSet},
+          ${snapshot.id}, ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}, ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}, ${snapshot.extractorSet},
           ${currentSnapshotReceipt.workspaceFingerprint}, ${currentSnapshotReceipt.fileSetFingerprint},
           0, 0, 0, ${encodeCodeGraphInventoryReuseReceipt(currentSnapshotReceipt.inventory)},
           ${completedAt}

--- a/src/code_graph/store_checkpoint_import.ts
+++ b/src/code_graph/store_checkpoint_import.ts
@@ -1,0 +1,1128 @@
+import {Effect} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {
+  CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION,
+  type CodeGraphCheckpointImportBuildInput,
+  type CodeGraphCheckpointCoverageSummary,
+  type CodeGraphCheckpointImportReceipt,
+  type CodeGraphCheckpointImportReceiptInput,
+  type CodeGraphCheckpointImportRecordPage,
+  type CodeGraphLanguagePackProvenance,
+} from './store_models.js';
+import {
+  CodeGraphStoreError,
+  type CodeGraphEdge,
+  type CodeGraphFileFacts,
+  type CodeGraphInventoryFile,
+  type CodeGraphSnapshot,
+  type CodeGraphSymbol,
+} from './types.js';
+import {
+  CODE_GRAPH_CHECKPOINT_RECORD_KINDS,
+  parseCodeGraphCheckpointRecordV1,
+  type CodeGraphCheckpointRecordKind,
+  type CodeGraphCheckpointRecordV1,
+} from './checkpoint/schema.js';
+import {canonicalJson} from './checkpoint/canonical_json.js';
+import type {CodeGraphMonikerV1} from './cross_repository/types.js';
+import {ensureBoundedCodeGraphFact} from './fact_budget.js';
+import {decodeStoredCodeGraphFact, encodeStoredCodeGraphFact} from './fact_storage.js';
+import {materializedFileShardIdentity} from './store_cache.js';
+import {stagePersistedFullFacts} from './store_resolution_core.js';
+
+interface CheckpointImportRow {
+  readonly abi_algorithm: unknown;
+  readonly abi_digest: unknown;
+  readonly artifact_algorithm: unknown;
+  readonly artifact_digest: unknown;
+  readonly artifact_media_type: unknown;
+  readonly artifact_size: unknown;
+  readonly base_logical_digest: unknown;
+  readonly coverage_json: unknown;
+  readonly format_version: unknown;
+  readonly logical_algorithm: unknown;
+  readonly logical_digest: unknown;
+  readonly recorded_at: unknown;
+  readonly snapshot_id: unknown;
+  readonly source_commit_id: unknown;
+  readonly source_graph_content_id: unknown;
+  readonly source_repository_id: unknown;
+  readonly trust: unknown;
+}
+
+interface CheckpointSnapshotAuthorityRow {
+  readonly base_snapshot_id: unknown;
+  readonly commit_id: unknown;
+  readonly dirty: unknown;
+  readonly graph_content_id: unknown;
+  readonly repository_id: unknown;
+  readonly state: unknown;
+}
+
+interface CheckpointImportBuildPlanRow {
+  readonly expected_batch_count: unknown;
+  readonly expected_counts_json: unknown;
+  readonly expected_pack_provenance_json: unknown;
+}
+
+const SHA256_HEX = /^[0-9a-f]{64}$/u;
+const COMMIT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const MAXIMUM_CHECKPOINT_TEXT_BYTES = 16 * 1_048_576;
+
+function invalid(message: string): CodeGraphStoreError {
+  return new CodeGraphStoreError(message);
+}
+
+function boundedNonEmptyText(value: string, maximumBytes: number): boolean {
+  return value.length > 0 && Buffer.byteLength(value, 'utf8') <= maximumBytes;
+}
+
+function validateCoverage(coverage: CodeGraphCheckpointCoverageSummary): void {
+  if (
+    (coverage.state !== 'complete' && coverage.state !== 'partial') ||
+    !Number.isSafeInteger(coverage.eligibleFiles) ||
+    coverage.eligibleFiles < 0 ||
+    !Number.isSafeInteger(coverage.excludedFiles) ||
+    coverage.excludedFiles < 0 ||
+    !Array.isArray(coverage.reasons) ||
+    coverage.reasons.length > 1_024
+  ) {
+    throw invalid('Code graph checkpoint coverage is invalid.');
+  }
+  const codes = new Set<string>();
+  let reasonFiles = 0;
+  for (const reason of coverage.reasons) {
+    if (
+      !boundedNonEmptyText(reason.code, 256) ||
+      codes.has(reason.code) ||
+      !Number.isSafeInteger(reason.files) ||
+      reason.files < 0 ||
+      !Number.isSafeInteger(reason.bytes) ||
+      reason.bytes < 0
+    ) {
+      throw invalid('Code graph checkpoint coverage reason is invalid.');
+    }
+    codes.add(reason.code);
+    if (reason.files > Number.MAX_SAFE_INTEGER - reasonFiles) {
+      throw invalid('Code graph checkpoint coverage reason totals overflow.');
+    }
+    reasonFiles += reason.files;
+  }
+  if (
+    reasonFiles !== coverage.excludedFiles ||
+    (coverage.excludedFiles === 0 ? coverage.state !== 'complete' : coverage.state !== 'partial')
+  ) {
+    throw invalid('Code graph checkpoint coverage totals are inconsistent.');
+  }
+}
+
+/** Codec-independent receipt validation at the local persistence boundary. */
+export function validateCodeGraphCheckpointImportReceiptInput(input: CodeGraphCheckpointImportReceiptInput): void {
+  if (
+    input.formatVersion !== CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION ||
+    input.abi.algorithm !== 'sha256' ||
+    !SHA256_HEX.test(input.abi.digest) ||
+    input.logical.algorithm !== 'sha256' ||
+    !SHA256_HEX.test(input.logical.digest) ||
+    input.artifact.algorithm !== 'sha256' ||
+    !SHA256_HEX.test(input.artifact.digest) ||
+    !Number.isSafeInteger(input.artifact.size) ||
+    input.artifact.size < 0 ||
+    !boundedNonEmptyText(input.artifact.mediaType, 512) ||
+    input.baseLogicalDigest !== null ||
+    !SHA256_HEX.test(input.source.repositoryId) ||
+    !COMMIT_ID.test(input.source.commit) ||
+    !boundedNonEmptyText(input.source.graphContentId, 512) ||
+    (input.trust !== 'local-unverified' && input.trust !== 'expected-descriptor-verified')
+  ) {
+    throw invalid('Code graph checkpoint import receipt is invalid.');
+  }
+  validateCoverage(input.coverage);
+}
+
+function encodedCoverage(coverage: CodeGraphCheckpointCoverageSummary): string {
+  const encoded = JSON.stringify({
+    state: coverage.state,
+    eligibleFiles: coverage.eligibleFiles,
+    excludedFiles: coverage.excludedFiles,
+    reasons: coverage.reasons.map(reason => ({code: reason.code, files: reason.files, bytes: reason.bytes})),
+  });
+  if (Buffer.byteLength(encoded, 'utf8') > MAXIMUM_CHECKPOINT_TEXT_BYTES) {
+    throw invalid('Code graph checkpoint coverage is too large.');
+  }
+  return encoded;
+}
+
+function decodedCoverage(value: unknown): CodeGraphCheckpointCoverageSummary {
+  if (typeof value !== 'string' || Buffer.byteLength(value, 'utf8') > MAXIMUM_CHECKPOINT_TEXT_BYTES) {
+    throw invalid('Stored code graph checkpoint coverage is invalid.');
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value) as unknown;
+  } catch {
+    throw invalid('Stored code graph checkpoint coverage is invalid.');
+  }
+  if (decoded === null || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    throw invalid('Stored code graph checkpoint coverage is invalid.');
+  }
+  const object = decoded as Record<string, unknown>;
+  const reasons = Array.isArray(object.reasons)
+    ? object.reasons.map(reason => {
+        if (reason === null || typeof reason !== 'object' || Array.isArray(reason)) {
+          throw invalid('Stored code graph checkpoint coverage is invalid.');
+        }
+        const entry = reason as Record<string, unknown>;
+        return {bytes: entry.bytes, code: entry.code, files: entry.files};
+      })
+    : object.reasons;
+  const coverage = {
+    eligibleFiles: object.eligibleFiles,
+    excludedFiles: object.excludedFiles,
+    reasons,
+    state: object.state,
+  } as CodeGraphCheckpointCoverageSummary;
+  validateCoverage(coverage);
+  return coverage;
+}
+
+function receiptColumns(input: CodeGraphCheckpointImportReceiptInput) {
+  validateCodeGraphCheckpointImportReceiptInput(input);
+  return {
+    abiAlgorithm: input.abi.algorithm,
+    abiDigest: input.abi.digest,
+    artifactAlgorithm: input.artifact.algorithm,
+    artifactDigest: input.artifact.digest,
+    artifactMediaType: input.artifact.mediaType,
+    artifactSize: input.artifact.size,
+    baseLogicalDigest: input.baseLogicalDigest,
+    coverageJson: encodedCoverage(input.coverage),
+    formatVersion: input.formatVersion,
+    logicalAlgorithm: input.logical.algorithm,
+    logicalDigest: input.logical.digest,
+    sourceCommitId: input.source.commit,
+    sourceGraphContentId: input.source.graphContentId,
+    sourceRepositoryId: input.source.repositoryId,
+    trust: input.trust,
+  } as const;
+}
+
+function encodedRecordCounts(input: CodeGraphCheckpointImportBuildInput): string {
+  if (!Number.isSafeInteger(input.batchCount) || input.batchCount < 0) {
+    throw invalid('Code graph checkpoint import batch count is invalid.');
+  }
+  const counts = Object.fromEntries(
+    CODE_GRAPH_CHECKPOINT_RECORD_KINDS.map(kind => {
+      const count = input.recordCounts[kind];
+      if (!Number.isSafeInteger(count) || count < 0) {
+        throw invalid(`Code graph checkpoint ${kind} record count is invalid.`);
+      }
+      return [kind, count];
+    }),
+  );
+  return JSON.stringify(counts);
+}
+
+function decodedRecordCounts(value: unknown): Readonly<Record<CodeGraphCheckpointRecordKind, number>> {
+  if (typeof value !== 'string' || Buffer.byteLength(value, 'utf8') > 4_096) {
+    throw invalid('Stored code graph checkpoint record counts are invalid.');
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value) as unknown;
+  } catch {
+    throw invalid('Stored code graph checkpoint record counts are invalid.');
+  }
+  if (decoded === null || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    throw invalid('Stored code graph checkpoint record counts are invalid.');
+  }
+  const object = decoded as Record<string, unknown>;
+  if (
+    Object.keys(object).length !== CODE_GRAPH_CHECKPOINT_RECORD_KINDS.length ||
+    CODE_GRAPH_CHECKPOINT_RECORD_KINDS.some(kind => !Number.isSafeInteger(object[kind]) || Number(object[kind]) < 0)
+  ) {
+    throw invalid('Stored code graph checkpoint record counts are invalid.');
+  }
+  return object as Readonly<Record<CodeGraphCheckpointRecordKind, number>>;
+}
+
+function encodedPackProvenance(input: CodeGraphCheckpointImportBuildInput): string {
+  const packs = validatePackProvenance(input.packProvenance);
+  const encoded = JSON.stringify(packs);
+  if (Buffer.byteLength(encoded, 'utf8') > MAXIMUM_CHECKPOINT_TEXT_BYTES) {
+    throw invalid('Code graph checkpoint pack provenance is too large.');
+  }
+  return encoded;
+}
+
+function decodedPackProvenance(value: unknown): readonly CodeGraphLanguagePackProvenance[] {
+  if (typeof value !== 'string' || Buffer.byteLength(value, 'utf8') > MAXIMUM_CHECKPOINT_TEXT_BYTES) {
+    throw invalid('Stored code graph checkpoint pack provenance is invalid.');
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value) as unknown;
+  } catch {
+    throw invalid('Stored code graph checkpoint pack provenance is invalid.');
+  }
+  return validatePackProvenance(decoded);
+}
+
+function validatePackProvenance(value: unknown): readonly CodeGraphLanguagePackProvenance[] {
+  if (!Array.isArray(value) || value.length > 1_024) {
+    throw invalid('Code graph checkpoint pack provenance is invalid.');
+  }
+  let previousId: string | undefined;
+  for (const candidate of value) {
+    if (candidate === null || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      throw invalid('Code graph checkpoint pack provenance is invalid.');
+    }
+    const pack = candidate as Record<string, unknown>;
+    if (
+      Object.keys(pack).sort().join(',') !== 'cacheIdentity,derivationIdentity,id,resolutionDomain,resolutionVersion' ||
+      typeof pack.id !== 'string' ||
+      !/^[a-z][a-z0-9-]*$/u.test(pack.id) ||
+      (previousId !== undefined && pack.id <= previousId) ||
+      typeof pack.cacheIdentity !== 'string' ||
+      !SHA256_HEX.test(pack.cacheIdentity) ||
+      typeof pack.derivationIdentity !== 'string' ||
+      !SHA256_HEX.test(pack.derivationIdentity) ||
+      typeof pack.resolutionDomain !== 'string' ||
+      !boundedNonEmptyText(pack.resolutionDomain, 16_384) ||
+      typeof pack.resolutionVersion !== 'string' ||
+      !boundedNonEmptyText(pack.resolutionVersion, 16_384)
+    ) {
+      throw invalid('Code graph checkpoint pack provenance is invalid.');
+    }
+    previousId = pack.id;
+  }
+  return value as readonly CodeGraphLanguagePackProvenance[];
+}
+
+function receiptFromRow(row: CheckpointImportRow): CodeGraphCheckpointImportReceipt {
+  const input = {
+    abi: {algorithm: row.abi_algorithm, digest: row.abi_digest},
+    artifact: {
+      algorithm: row.artifact_algorithm,
+      digest: row.artifact_digest,
+      mediaType: row.artifact_media_type,
+      size: Number(row.artifact_size),
+    },
+    baseLogicalDigest: row.base_logical_digest,
+    coverage: decodedCoverage(row.coverage_json),
+    formatVersion: Number(row.format_version),
+    logical: {algorithm: row.logical_algorithm, digest: row.logical_digest},
+    source: {
+      commit: row.source_commit_id,
+      graphContentId: row.source_graph_content_id,
+      repositoryId: row.source_repository_id,
+    },
+    trust: row.trust,
+  } as CodeGraphCheckpointImportReceiptInput;
+  validateCodeGraphCheckpointImportReceiptInput(input);
+  if (typeof row.snapshot_id !== 'string' || typeof row.recorded_at !== 'string') {
+    throw invalid('Stored code graph checkpoint import receipt is invalid.');
+  }
+  return {...input, importedAt: row.recorded_at, snapshotId: row.snapshot_id};
+}
+
+function sameReceiptInput(
+  left: CodeGraphCheckpointImportReceiptInput,
+  right: CodeGraphCheckpointImportReceiptInput,
+): boolean {
+  return JSON.stringify(receiptColumns(left)) === JSON.stringify(receiptColumns(right));
+}
+
+const selectCheckpointImportRow = Effect.fn('codeGraph.selectCheckpointImportRow')(function* (
+  sql: SqlClient.SqlClient,
+  table: 'checkpoint_import_builds' | 'checkpoint_import_receipts',
+  snapshotId: string,
+) {
+  const timestamp = table === 'checkpoint_import_builds' ? 'started_at' : 'imported_at';
+  const rows = yield* sql.unsafe<CheckpointImportRow>(
+    `SELECT snapshot_id, format_version, source_repository_id, source_commit_id,
+       source_graph_content_id, abi_algorithm, abi_digest, logical_algorithm, logical_digest,
+       base_logical_digest, artifact_algorithm, artifact_digest, artifact_size,
+       artifact_media_type, coverage_json, trust, ${timestamp} AS recorded_at
+     FROM ${table} WHERE snapshot_id = ? LIMIT 2`,
+    [snapshotId],
+  );
+  if (rows.length > 1) return yield* Effect.fail(invalid('Code graph checkpoint import authority is invalid.'));
+  return rows[0] ? receiptFromRow(rows[0]) : undefined;
+});
+
+const assertSnapshotAuthority = Effect.fn('codeGraph.assertCheckpointSnapshotAuthority')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  input: CodeGraphCheckpointImportReceiptInput,
+  acceptedState: 'building' | 'ready',
+) {
+  const rows = yield* sql.unsafe<CheckpointSnapshotAuthorityRow>(
+    `SELECT repository_id, commit_id, graph_content_id, base_snapshot_id, dirty, state
+     FROM snapshots WHERE id = ? LIMIT 2`,
+    [snapshotId],
+  );
+  const row = rows[0];
+  if (
+    rows.length !== 1 ||
+    row?.state !== acceptedState ||
+    Number(row.dirty) !== 0 ||
+    row.base_snapshot_id !== null ||
+    row.repository_id !== input.source.repositoryId ||
+    row.commit_id !== input.source.commit ||
+    row.graph_content_id !== input.source.graphContentId
+  ) {
+    return yield* Effect.fail(
+      invalid(`Code graph checkpoint receipt requires a matching ${acceptedState} clean root.`),
+    );
+  }
+});
+
+export const bindCheckpointImportBuild = Effect.fn('codeGraph.bindCheckpointImportBuild')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  input: CodeGraphCheckpointImportBuildInput,
+  startedAt: string,
+) {
+  const prepared = yield* Effect.try({
+    catch: cause =>
+      cause instanceof CodeGraphStoreError ? cause : invalid('Code graph checkpoint receipt is invalid.'),
+    try: () => ({
+      columns: receiptColumns(input),
+      countsJson: encodedRecordCounts(input),
+      packsJson: encodedPackProvenance(input),
+    }),
+  });
+  const {columns} = prepared;
+  yield* assertSnapshotAuthority(sql, snapshotId, input, 'building');
+  const owner = yield* sql<{readonly expected_batch_count: unknown}>`
+    UPDATE snapshot_build_owners
+    SET expected_batch_count = COALESCE(expected_batch_count, ${input.batchCount})
+    WHERE snapshot_id = ${snapshotId}
+      AND (expected_batch_count IS NULL OR expected_batch_count = ${input.batchCount})
+    RETURNING expected_batch_count
+  `;
+  if (owner.length !== 1 || Number(owner[0]?.expected_batch_count) !== input.batchCount) {
+    return yield* Effect.fail(invalid('Checkpoint import requires a matching persistent build owner plan.'));
+  }
+  yield* sql`
+    INSERT INTO building_lexical_counters (
+      snapshot_id, completed_batch_count, posting_count, symbol_count, term_count
+    ) VALUES (${snapshotId}, 0, 0, 0, 0)
+    ON CONFLICT(snapshot_id) DO NOTHING
+  `;
+  const existing = yield* selectCheckpointImportRow(sql, 'checkpoint_import_builds', snapshotId);
+  if (existing !== undefined) {
+    const plan = yield* sql.unsafe<{
+      readonly expected_batch_count: unknown;
+      readonly expected_counts_json: unknown;
+      readonly expected_pack_provenance_json: unknown;
+    }>(
+      `SELECT expected_batch_count, expected_counts_json, expected_pack_provenance_json
+       FROM checkpoint_import_builds WHERE snapshot_id = ? LIMIT 2`,
+      [snapshotId],
+    );
+    if (
+      plan.length === 1 &&
+      Number(plan[0]?.expected_batch_count) === input.batchCount &&
+      plan[0]?.expected_counts_json === prepared.countsJson &&
+      plan[0]?.expected_pack_provenance_json === prepared.packsJson &&
+      sameReceiptInput(existing, input)
+    ) {
+      return {state: 'already-bound'} as const;
+    }
+    return yield* Effect.fail(invalid(`Checkpoint import ${snapshotId} is already bound to different content.`));
+  }
+  yield* sql`
+    INSERT INTO checkpoint_import_builds (
+      snapshot_id, format_version, source_repository_id, source_commit_id, source_graph_content_id,
+      abi_algorithm, abi_digest, logical_algorithm, logical_digest, base_logical_digest,
+      artifact_algorithm, artifact_digest, artifact_size, artifact_media_type, coverage_json, trust,
+      expected_batch_count, expected_counts_json, expected_pack_provenance_json, started_at
+    ) VALUES (
+      ${snapshotId}, ${columns.formatVersion}, ${columns.sourceRepositoryId}, ${columns.sourceCommitId},
+      ${columns.sourceGraphContentId}, ${columns.abiAlgorithm}, ${columns.abiDigest},
+      ${columns.logicalAlgorithm}, ${columns.logicalDigest}, ${columns.baseLogicalDigest},
+      ${columns.artifactAlgorithm}, ${columns.artifactDigest}, ${columns.artifactSize},
+      ${columns.artifactMediaType}, ${columns.coverageJson}, ${columns.trust}, ${input.batchCount},
+      ${prepared.countsJson}, ${prepared.packsJson}, ${startedAt}
+    )
+  `;
+  return {state: 'bound'} as const;
+});
+
+/** Verify a building import binding before the existing relational publication checks run. */
+export const assertCheckpointImportBuild = Effect.fn('codeGraph.assertCheckpointImportBuild')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  input: CodeGraphCheckpointImportReceiptInput,
+) {
+  yield* Effect.try({
+    catch: cause =>
+      cause instanceof CodeGraphStoreError ? cause : invalid('Code graph checkpoint receipt is invalid.'),
+    try: () => validateCodeGraphCheckpointImportReceiptInput(input),
+  });
+  yield* assertSnapshotAuthority(sql, snapshotId, input, 'building');
+  const binding = yield* selectCheckpointImportRow(sql, 'checkpoint_import_builds', snapshotId);
+  if (binding === undefined || !sameReceiptInput(binding, input)) {
+    return yield* Effect.fail(invalid(`Checkpoint import ${snapshotId} has no matching build binding.`));
+  }
+});
+
+const checkpointImportBuildPlan = Effect.fn('codeGraph.checkpointImportBuildPlan')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+) {
+  const rows = yield* sql.unsafe<CheckpointImportBuildPlanRow>(
+    `SELECT expected_batch_count, expected_counts_json, expected_pack_provenance_json
+     FROM checkpoint_import_builds WHERE snapshot_id = ? LIMIT 2`,
+    [snapshotId],
+  );
+  if (rows.length !== 1) {
+    return yield* Effect.fail(invalid(`Checkpoint import ${snapshotId} has no unique build plan.`));
+  }
+  const expectedBatchCount = Number(rows[0]?.expected_batch_count);
+  if (!Number.isSafeInteger(expectedBatchCount) || expectedBatchCount < 0) {
+    return yield* Effect.fail(invalid('Stored code graph checkpoint batch count is invalid.'));
+  }
+  return {
+    expectedBatchCount,
+    packProvenance: decodedPackProvenance(rows[0]?.expected_pack_provenance_json),
+    recordCounts: decodedRecordCounts(rows[0]?.expected_counts_json),
+  };
+});
+
+function checkpointSymbol(record: Extract<CodeGraphCheckpointRecordV1, {readonly kind: 'symbol'}>): CodeGraphSymbol {
+  const {kind: _recordKind, symbolKind, ...symbol} = record;
+  return {...symbol, kind: symbolKind};
+}
+
+function checkpointEdge(record: Extract<CodeGraphCheckpointRecordV1, {readonly kind: 'edge'}>): CodeGraphEdge {
+  const {kind: _recordKind, ...edge} = record;
+  return edge;
+}
+
+function checkpointMoniker(
+  record: Extract<CodeGraphCheckpointRecordV1, {readonly kind: 'moniker'}>,
+): CodeGraphMonikerV1 {
+  const {evidencePath, evidenceSpan, kind: _recordKind, monikerKind, ...moniker} = record;
+  return {
+    ...moniker,
+    evidence: {path: evidencePath, span: evidenceSpan},
+    kind: monikerKind,
+  } as CodeGraphMonikerV1;
+}
+
+function samePackProvenance(
+  record: Extract<CodeGraphCheckpointRecordV1, {readonly kind: 'pack-provenance'}>,
+  expected: CodeGraphLanguagePackProvenance,
+): boolean {
+  return (
+    record.cacheIdentity === expected.cacheIdentity &&
+    record.derivationIdentity === expected.derivationIdentity &&
+    record.id === expected.id &&
+    record.resolutionDomain === expected.resolutionDomain &&
+    record.resolutionVersion === expected.resolutionVersion
+  );
+}
+
+const stageCheckpointSupplementalRecord = Effect.fn('codeGraph.stageCheckpointSupplementalRecord')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  extractorSet: string,
+  record: CodeGraphCheckpointRecordV1,
+  now: string,
+) {
+  switch (record.kind) {
+    case 'file': {
+      const file: CodeGraphInventoryFile = record;
+      yield* sql`
+        INSERT INTO snapshot_files (
+          snapshot_id, path, content_hash, raw_content_hash, language, mode, size, source
+        ) VALUES (
+          ${snapshotId}, ${file.path}, ${file.contentHash}, ${file.rawContentHash ?? null},
+          ${file.language}, ${file.mode}, ${file.size}, ${file.source}
+        )
+      `;
+      return;
+    }
+    case 'file-fact': {
+      const files = yield* sql<{
+        readonly content_hash: string;
+        readonly path: string;
+      }>`
+        SELECT path, content_hash FROM snapshot_files
+        WHERE snapshot_id = ${snapshotId} AND path = ${record.path} LIMIT 2
+      `;
+      if (files.length !== 1 || record.facts.path !== record.path) {
+        return yield* Effect.fail(invalid(`Checkpoint file fact ${record.path} has no matching inventory row.`));
+      }
+      const bounded = yield* Effect.try({
+        catch: () => invalid(`Checkpoint file fact ${record.path} exceeds the materialized fact boundary.`),
+        try: () => ensureBoundedCodeGraphFact(record.facts),
+      });
+      const encoded = encodeStoredCodeGraphFact(bounded);
+      const shardId = materializedFileShardIdentity(
+        files[0]!.content_hash,
+        extractorSet,
+        record.cacheIdentity,
+        record.path,
+      );
+      yield* sql`
+        INSERT INTO materialized_file_shards (
+          id, content_hash, extractor_set, derivation_identity, path_hint, facts_json, created_at, last_used_at
+        ) VALUES (
+          ${shardId}, ${files[0]!.content_hash}, ${extractorSet}, ${record.cacheIdentity}, ${record.path},
+          ${encoded.json}, ${now}, ${now}
+        )
+        ON CONFLICT(id) DO NOTHING
+      `;
+      const stored = yield* sql<{
+        readonly content_hash: string;
+        readonly derivation_identity: string;
+        readonly extractor_set: string;
+        readonly facts_json: string;
+        readonly path_hint: string;
+      }>`
+        SELECT content_hash, extractor_set, derivation_identity, path_hint, facts_json
+        FROM materialized_file_shards WHERE id = ${shardId} LIMIT 2
+      `;
+      const storedMetadataMatches =
+        stored.length === 1 &&
+        stored[0]?.content_hash === files[0]!.content_hash &&
+        stored[0]?.extractor_set === extractorSet &&
+        stored[0]?.derivation_identity === record.cacheIdentity &&
+        stored[0]?.path_hint === record.path;
+      if (
+        !storedMetadataMatches ||
+        !checkpointStoredFactMatches(stored[0]!.facts_json, encoded.json, bounded.facts, record.path)
+      ) {
+        return yield* Effect.fail(invalid(`Checkpoint file fact ${record.path} conflicts with cached content.`));
+      }
+      yield* sql`
+        INSERT INTO snapshot_file_shards (snapshot_id, path, shard_id)
+        VALUES (${snapshotId}, ${record.path}, ${shardId})
+      `;
+      return;
+    }
+    case 'workspace-scope':
+      yield* sql`
+        INSERT INTO workspace_scopes (
+          snapshot_id, id, build_system, name, root, provenance, diagnostics_json
+        ) VALUES (
+          ${snapshotId}, ${record.id}, ${record.buildSystem}, ${record.name}, ${record.root},
+          ${record.provenance}, ${JSON.stringify(record.diagnostics)}
+        )
+      `;
+      return;
+    case 'workspace-component':
+      yield* sql`
+        INSERT INTO workspace_components (
+          snapshot_id, id, workspace_id, build_system, kind, name, root, resolution_domain,
+          languages_json, source_roots_json, workspace_roots_json, provenance, diagnostics_json
+        ) VALUES (
+          ${snapshotId}, ${record.id}, ${record.workspaceId}, ${record.buildSystem}, ${record.componentKind},
+          ${record.name}, ${record.root}, ${record.resolutionDomain}, ${JSON.stringify(record.languages)},
+          ${JSON.stringify(record.sourceRoots)}, ${JSON.stringify(record.workspaceRoots)}, ${record.provenance},
+          ${JSON.stringify(record.diagnostics)}
+        )
+      `;
+      return;
+    case 'workspace-dependency':
+      yield* sql`
+        INSERT INTO workspace_component_dependencies (
+          snapshot_id, source_component_id, target_component_id, provenance, evidence
+        ) VALUES (
+          ${snapshotId}, ${record.sourceComponentId}, ${record.targetComponentId}, ${record.provenance},
+          ${record.evidence ?? null}
+        )
+      `;
+      return;
+    case 'workspace-external-dependency':
+      yield* sql`
+        INSERT INTO workspace_external_dependencies (
+          snapshot_id, source_component_id, ecosystem, package_name, import_alias, dependency_kind,
+          version_constraint, evidence_path, evidence_span_json
+        ) VALUES (
+          ${snapshotId}, ${record.sourceComponentId}, ${record.ecosystem}, ${record.packageName},
+          ${record.importAlias}, ${record.dependencyKind}, ${record.versionConstraint}, ${record.evidencePath},
+          ${record.evidenceSpan === undefined ? null : JSON.stringify(record.evidenceSpan)}
+        )
+      `;
+      return;
+    case 'symbol-lookup': {
+      yield* sql`
+        INSERT INTO snapshot_symbol_lookup (
+          snapshot_id, lookup_key, symbol_id, resolution_domain, exported, provenance,
+          evidence_edge_id, evidence_path
+        ) VALUES (
+          ${snapshotId}, ${record.lookupKey}, ${record.symbolId}, ${record.resolutionDomain},
+          ${record.exported ? 1 : 0}, ${record.provenance}, ${record.evidenceEdgeId ?? null},
+          ${record.evidencePath ?? null}
+        )
+        ON CONFLICT(snapshot_id, lookup_key, symbol_id) DO NOTHING
+      `;
+      const rows = yield* sql<{
+        readonly evidence_edge_id: string | null;
+        readonly evidence_path: string | null;
+        readonly exported: number;
+        readonly provenance: string;
+        readonly resolution_domain: string;
+      }>`
+        SELECT resolution_domain, exported, provenance, evidence_edge_id, evidence_path
+        FROM snapshot_symbol_lookup
+        WHERE snapshot_id = ${snapshotId} AND lookup_key = ${record.lookupKey} AND symbol_id = ${record.symbolId}
+        LIMIT 2
+      `;
+      if (
+        rows.length !== 1 ||
+        rows[0]?.resolution_domain !== record.resolutionDomain ||
+        Number(rows[0]?.exported) !== (record.exported ? 1 : 0) ||
+        rows[0]?.provenance !== record.provenance ||
+        rows[0]?.evidence_edge_id !== (record.evidenceEdgeId ?? null) ||
+        rows[0]?.evidence_path !== (record.evidencePath ?? null)
+      ) {
+        return yield* Effect.fail(invalid('Checkpoint symbol lookup conflicts with materialized graph facts.'));
+      }
+      return;
+    }
+    case 'reexport':
+      yield* sql`
+        INSERT INTO snapshot_reexport_provenance (
+          snapshot_id, source_path, local_name, target_path, imported_name
+        ) VALUES (
+          ${snapshotId}, ${record.sourcePath}, ${record.localName}, ${record.targetPath}, ${record.importedName}
+        )
+        ON CONFLICT(snapshot_id, source_path, local_name, target_path, imported_name) DO NOTHING
+      `;
+      return;
+    case 'lexical': {
+      const rows = yield* sql.unsafe<{readonly weight: unknown}>(
+        `SELECT posting.weight
+         FROM lexical_compact_snapshots AS snapshot
+         JOIN lexical_compact_terms AS term ON term.snapshot_key = snapshot.snapshot_key
+         JOIN lexical_compact_postings AS posting
+           ON posting.snapshot_key = snapshot.snapshot_key AND posting.term_key = term.term_key
+         JOIN lexical_compact_symbols AS symbol
+           ON symbol.snapshot_key = snapshot.snapshot_key AND symbol.symbol_key = posting.symbol_key
+         WHERE snapshot.snapshot_id = ? AND term.term = ? AND symbol.symbol_id = ?
+         LIMIT 2`,
+        [snapshotId, record.term, record.symbolId],
+      );
+      if (rows.length !== 1 || Number(rows[0]?.weight) !== record.weight) {
+        return yield* Effect.fail(invalid('Checkpoint lexical record differs from ABI-compatible materialization.'));
+      }
+      return;
+    }
+    case 'pack-provenance':
+      yield* sql`
+        INSERT INTO snapshot_pack_provenance (
+          snapshot_id, pack_id, cache_identity, derivation_identity, resolution_domain, resolution_version
+        ) VALUES (
+          ${snapshotId}, ${record.id}, ${record.cacheIdentity}, ${record.derivationIdentity},
+          ${record.resolutionDomain}, ${record.resolutionVersion}
+        )
+      `;
+      return;
+    case 'symbol':
+    case 'edge':
+    case 'moniker':
+      return;
+  }
+});
+
+export function checkpointStoredFactMatches(
+  existing: string,
+  incomingEncoded: string,
+  incomingFacts: CodeGraphFileFacts,
+  path: string,
+): boolean {
+  if (existing === incomingEncoded) return true;
+  try {
+    return canonicalJson(decodeStoredCodeGraphFact(existing, path).facts) === canonicalJson(incomingFacts);
+  } catch {
+    return false;
+  }
+}
+
+export const stageCheckpointImportRecordPage = Effect.fn('codeGraph.stageCheckpointImportRecordPage')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  ownerToken: string,
+  page: CodeGraphCheckpointImportRecordPage,
+  completedAt: string,
+) {
+  if (
+    !Number.isSafeInteger(page.batchIndex) ||
+    page.batchIndex < 0 ||
+    page.digest.algorithm !== 'sha256' ||
+    !SHA256_HEX.test(page.digest.digest)
+  ) {
+    return yield* Effect.fail(invalid('Code graph checkpoint import record page is invalid.'));
+  }
+  const records = yield* Effect.try({
+    catch: () => invalid('Code graph checkpoint import record page is invalid.'),
+    try: () => page.records.map(record => parseCodeGraphCheckpointRecordV1(record)),
+  });
+  if (records.length === 0) {
+    return yield* Effect.fail(invalid('Code graph checkpoint import record page must not be empty.'));
+  }
+  const plan = yield* checkpointImportBuildPlan(sql, snapshotId);
+  const expectedPacks = new Map(plan.packProvenance.map(pack => [pack.id, pack] as const));
+  for (const record of records) {
+    if (record.kind !== 'pack-provenance') continue;
+    const expected = expectedPacks.get(record.id);
+    if (expected === undefined || !samePackProvenance(record, expected)) {
+      return yield* Effect.fail(invalid('Checkpoint record pack provenance differs from its immutable build plan.'));
+    }
+  }
+  const existing = yield* sql.unsafe<{
+    readonly batch_digest: unknown;
+    readonly digest_algorithm: unknown;
+    readonly record_count: unknown;
+  }>(
+    `SELECT digest_algorithm, batch_digest, record_count
+     FROM checkpoint_import_batches WHERE snapshot_id = ? AND batch_index = ? LIMIT 2`,
+    [snapshotId, page.batchIndex],
+  );
+  if (existing.length > 0) {
+    if (
+      existing.length === 1 &&
+      existing[0]?.digest_algorithm === 'sha256' &&
+      existing[0]?.batch_digest === page.digest.digest &&
+      Number(existing[0]?.record_count) === records.length
+    ) {
+      return {records: records.length, state: 'already-staged'} as const;
+    }
+    return yield* Effect.fail(invalid(`Checkpoint import batch ${page.batchIndex} conflicts with durable content.`));
+  }
+  if (page.batchIndex >= plan.expectedBatchCount) {
+    return yield* Effect.fail(invalid(`Checkpoint import batch ${page.batchIndex} exceeds its build plan.`));
+  }
+  const authority = yield* sql.unsafe<{
+    readonly extractor_set: unknown;
+    readonly owner_token: unknown;
+    readonly state: unknown;
+  }>(
+    `SELECT snapshot.state, snapshot.extractor_set, owner.owner_token
+     FROM snapshots AS snapshot
+     JOIN snapshot_build_owners AS owner ON owner.snapshot_id = snapshot.id
+     JOIN checkpoint_import_builds AS import ON import.snapshot_id = snapshot.id
+     WHERE snapshot.id = ? LIMIT 2`,
+    [snapshotId],
+  );
+  if (
+    authority.length !== 1 ||
+    authority[0]?.state !== 'building' ||
+    authority[0]?.owner_token !== ownerToken ||
+    typeof authority[0]?.extractor_set !== 'string'
+  ) {
+    return yield* Effect.fail(invalid('Code graph checkpoint import build ownership changed.'));
+  }
+  const staged = yield* sql.unsafe<{
+    readonly count: unknown;
+    readonly maximum: unknown;
+    readonly minimum: unknown;
+  }>(
+    `SELECT COUNT(*) AS count, MIN(batch_index) AS minimum, MAX(batch_index) AS maximum
+     FROM checkpoint_import_batches WHERE snapshot_id = ?`,
+    [snapshotId],
+  );
+  const stagedCount = Number(staged[0]?.count ?? -1);
+  if (
+    stagedCount !== page.batchIndex ||
+    (stagedCount === 0
+      ? staged[0]?.minimum !== null || staged[0]?.maximum !== null
+      : Number(staged[0]?.minimum) !== 0 || Number(staged[0]?.maximum) !== stagedCount - 1)
+  ) {
+    return yield* Effect.fail(invalid('Checkpoint import batches must be staged in contiguous order.'));
+  }
+  const symbols = records.filter(
+    (record): record is Extract<CodeGraphCheckpointRecordV1, {readonly kind: 'symbol'}> => record.kind === 'symbol',
+  );
+  const edges = records.filter(
+    (record): record is Extract<CodeGraphCheckpointRecordV1, {readonly kind: 'edge'}> => record.kind === 'edge',
+  );
+  const monikers = records.filter(
+    (record): record is Extract<CodeGraphCheckpointRecordV1, {readonly kind: 'moniker'}> => record.kind === 'moniker',
+  );
+  yield* stagePersistedFullFacts(
+    sql,
+    snapshotId,
+    ownerToken,
+    page.batchIndex,
+    symbols.map(checkpointSymbol),
+    edges.map(checkpointEdge),
+    [],
+    () => Effect.void,
+    true,
+    undefined,
+    monikers.map(checkpointMoniker),
+  );
+  for (const record of records) {
+    yield* stageCheckpointSupplementalRecord(
+      sql,
+      snapshotId,
+      authority[0]!.extractor_set as string,
+      record,
+      completedAt,
+    );
+  }
+  yield* sql`
+    INSERT INTO checkpoint_import_batches (
+      snapshot_id, batch_index, digest_algorithm, batch_digest, record_count, completed_at
+    ) VALUES (
+      ${snapshotId}, ${page.batchIndex}, ${page.digest.algorithm}, ${page.digest.digest},
+      ${records.length}, ${completedAt}
+    )
+  `;
+  return {records: records.length, state: 'staged'} as const;
+});
+
+export const verifyCheckpointImportRecordCounts = Effect.fn('codeGraph.verifyCheckpointImportRecordCounts')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+) {
+  const plan = yield* checkpointImportBuildPlan(sql, snapshotId);
+  const rows = yield* sql.unsafe<Record<CodeGraphCheckpointRecordKind | 'batches', unknown>>(
+    `SELECT
+        (SELECT COUNT(*) FROM checkpoint_import_batches WHERE snapshot_id = ?) AS batches,
+        (SELECT COUNT(*) FROM snapshot_files WHERE snapshot_id = ?) AS file,
+        (SELECT COUNT(*) FROM snapshot_file_shards WHERE snapshot_id = ?) AS "file-fact",
+        (SELECT COUNT(*) FROM workspace_scopes WHERE snapshot_id = ?) AS "workspace-scope",
+        (SELECT COUNT(*) FROM workspace_components WHERE snapshot_id = ?) AS "workspace-component",
+        (SELECT COUNT(*) FROM workspace_component_dependencies WHERE snapshot_id = ?) AS "workspace-dependency",
+        (SELECT COUNT(*) FROM workspace_external_dependencies WHERE snapshot_id = ?) AS "workspace-external-dependency",
+        (SELECT COUNT(*) FROM symbols WHERE snapshot_id = ?) AS symbol,
+        (SELECT COUNT(*) FROM snapshot_symbol_lookup WHERE snapshot_id = ?) AS "symbol-lookup",
+        (SELECT COUNT(*) FROM snapshot_reexport_provenance WHERE snapshot_id = ?) AS reexport,
+        (SELECT COUNT(*) FROM edges WHERE snapshot_id = ?) AS edge,
+        (SELECT COUNT(*) FROM code_graph_monikers WHERE snapshot_id = ?) AS moniker,
+        (SELECT COUNT(*)
+           FROM lexical_compact_snapshots AS snapshot
+           JOIN lexical_compact_postings AS posting ON posting.snapshot_key = snapshot.snapshot_key
+          WHERE snapshot.snapshot_id = ?) AS lexical,
+        (SELECT COUNT(*) FROM snapshot_pack_provenance WHERE snapshot_id = ?) AS "pack-provenance"`,
+    Array.from({length: 14}, () => snapshotId),
+  );
+  const row = rows[0];
+  if (row === undefined || Number(row.batches) !== plan.expectedBatchCount) {
+    return yield* Effect.fail(invalid('Checkpoint import has incomplete record batches.'));
+  }
+  for (const kind of CODE_GRAPH_CHECKPOINT_RECORD_KINDS) {
+    if (Number(row[kind]) !== plan.recordCounts[kind]) {
+      return yield* Effect.fail(invalid(`Checkpoint import ${kind} record count does not match its header.`));
+    }
+  }
+  const persistedPacks = yield* sql<{
+    readonly cache_identity: string;
+    readonly derivation_identity: string;
+    readonly pack_id: string;
+    readonly resolution_domain: string;
+    readonly resolution_version: string;
+  }>`
+    SELECT pack_id, cache_identity, derivation_identity, resolution_domain, resolution_version
+    FROM snapshot_pack_provenance
+    WHERE snapshot_id = ${snapshotId}
+    ORDER BY pack_id
+  `;
+  if (
+    persistedPacks.length !== plan.packProvenance.length ||
+    persistedPacks.some((pack, index) => {
+      const expected = plan.packProvenance[index];
+      return (
+        expected === undefined ||
+        pack.pack_id !== expected.id ||
+        pack.cache_identity !== expected.cacheIdentity ||
+        pack.derivation_identity !== expected.derivationIdentity ||
+        pack.resolution_domain !== expected.resolutionDomain ||
+        pack.resolution_version !== expected.resolutionVersion
+      );
+    })
+  ) {
+    return yield* Effect.fail(invalid('Checkpoint import pack provenance does not match its immutable build plan.'));
+  }
+  const invalidEndpoints = yield* sql.unsafe<{readonly count: unknown}>(
+    `SELECT
+        (SELECT COUNT(*)
+           FROM workspace_components AS component
+           LEFT JOIN workspace_scopes AS workspace
+             ON workspace.snapshot_id = component.snapshot_id AND workspace.id = component.workspace_id
+          WHERE component.snapshot_id = ? AND workspace.id IS NULL)
+        + (SELECT COUNT(*)
+             FROM workspace_component_dependencies AS dependency
+             LEFT JOIN workspace_components AS source
+               ON source.snapshot_id = dependency.snapshot_id AND source.id = dependency.source_component_id
+             LEFT JOIN workspace_components AS target
+               ON target.snapshot_id = dependency.snapshot_id AND target.id = dependency.target_component_id
+            WHERE dependency.snapshot_id = ? AND (source.id IS NULL OR target.id IS NULL))
+        + (SELECT COUNT(*)
+             FROM workspace_external_dependencies AS dependency
+             LEFT JOIN workspace_components AS source
+               ON source.snapshot_id = dependency.snapshot_id AND source.id = dependency.source_component_id
+             LEFT JOIN snapshot_files AS evidence
+               ON evidence.snapshot_id = dependency.snapshot_id AND evidence.path = dependency.evidence_path
+            WHERE dependency.snapshot_id = ? AND (source.id IS NULL OR evidence.path IS NULL))
+        + (SELECT COUNT(*)
+             FROM symbols AS symbol
+             LEFT JOIN snapshot_files AS file
+               ON file.snapshot_id = symbol.snapshot_id AND file.path = symbol.path
+            WHERE symbol.snapshot_id = ? AND file.path IS NULL)
+        + (SELECT COUNT(*)
+             FROM snapshot_symbol_lookup AS lookup
+             LEFT JOIN symbols AS symbol
+               ON symbol.snapshot_id = lookup.snapshot_id AND symbol.id = lookup.symbol_id
+             LEFT JOIN edges AS evidence
+               ON evidence.snapshot_id = lookup.snapshot_id AND evidence.id = lookup.evidence_edge_id
+            WHERE lookup.snapshot_id = ?
+              AND (symbol.id IS NULL OR (lookup.evidence_edge_id IS NOT NULL AND evidence.id IS NULL)))
+        + (SELECT COUNT(*)
+             FROM snapshot_reexport_provenance AS reexport
+             LEFT JOIN snapshot_files AS source
+               ON source.snapshot_id = reexport.snapshot_id AND source.path = reexport.source_path
+             LEFT JOIN snapshot_files AS target
+               ON target.snapshot_id = reexport.snapshot_id AND target.path = reexport.target_path
+            WHERE reexport.snapshot_id = ? AND (source.path IS NULL OR target.path IS NULL))
+        + (SELECT COUNT(*)
+             FROM edges AS edge
+             LEFT JOIN snapshot_files AS evidence
+               ON evidence.snapshot_id = edge.snapshot_id AND evidence.path = edge.evidence_path
+            WHERE edge.snapshot_id = ? AND evidence.path IS NULL)
+        + (SELECT COUNT(*)
+             FROM code_graph_monikers AS moniker
+             LEFT JOIN snapshot_files AS evidence
+               ON evidence.snapshot_id = moniker.snapshot_id AND evidence.path = moniker.evidence_path
+             LEFT JOIN workspace_components AS component
+               ON component.snapshot_id = moniker.snapshot_id AND component.id = moniker.component_id
+             LEFT JOIN symbols AS symbol
+               ON symbol.snapshot_id = moniker.snapshot_id AND symbol.id = moniker.symbol_id
+            WHERE moniker.snapshot_id = ?
+              AND (evidence.path IS NULL
+                OR (moniker.component_id IS NOT NULL AND component.id IS NULL)
+                OR (moniker.symbol_id IS NOT NULL AND symbol.id IS NULL))) AS count`,
+    Array.from({length: 8}, () => snapshotId),
+  );
+  const invalidEndpointCount = Number(invalidEndpoints[0]?.count ?? -1);
+  if (!Number.isSafeInteger(invalidEndpointCount) || invalidEndpointCount !== 0) {
+    return yield* Effect.fail(invalid('Checkpoint import contains dangling relational endpoints.'));
+  }
+});
+
+function receiptInputFromReceipt(receipt: CodeGraphCheckpointImportReceipt): CodeGraphCheckpointImportReceiptInput {
+  const {importedAt: _importedAt, snapshotId: _snapshotId, ...input} = receipt;
+  return input;
+}
+
+/** Called inside the ready-state transaction after all relational invariants passed. */
+export const publishCheckpointImportReceipt = Effect.fn('codeGraph.publishCheckpointImportReceipt')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  input: CodeGraphCheckpointImportReceiptInput,
+  importedAt: string,
+) {
+  const columns = receiptColumns(input);
+  const existing = yield* selectCheckpointImportRow(sql, 'checkpoint_import_receipts', snapshotId);
+  if (existing !== undefined) {
+    if (sameReceiptInput(existing, input)) return existing;
+    return yield* Effect.fail(invalid(`Checkpoint import receipt ${snapshotId} conflicts with immutable content.`));
+  }
+  yield* sql`
+    INSERT INTO checkpoint_import_receipts (
+      snapshot_id, format_version, source_repository_id, source_commit_id, source_graph_content_id,
+      abi_algorithm, abi_digest, logical_algorithm, logical_digest, base_logical_digest,
+      artifact_algorithm, artifact_digest, artifact_size, artifact_media_type, coverage_json, trust, imported_at
+    ) VALUES (
+      ${snapshotId}, ${columns.formatVersion}, ${columns.sourceRepositoryId}, ${columns.sourceCommitId},
+      ${columns.sourceGraphContentId}, ${columns.abiAlgorithm}, ${columns.abiDigest},
+      ${columns.logicalAlgorithm}, ${columns.logicalDigest}, ${columns.baseLogicalDigest},
+      ${columns.artifactAlgorithm}, ${columns.artifactDigest}, ${columns.artifactSize},
+      ${columns.artifactMediaType}, ${columns.coverageJson}, ${columns.trust}, ${importedAt}
+    )
+  `;
+  yield* sql`DELETE FROM checkpoint_import_builds WHERE snapshot_id = ${snapshotId}`;
+  return {...input, importedAt, snapshotId} satisfies CodeGraphCheckpointImportReceipt;
+});
+
+export const recordReadyCheckpointImportReceipt = Effect.fn('codeGraph.recordReadyCheckpointImportReceipt')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+  input: CodeGraphCheckpointImportReceiptInput,
+  importedAt: string,
+) {
+  yield* assertSnapshotAuthority(sql, snapshotId, input, 'ready');
+  const existing = yield* selectCheckpointImportRow(sql, 'checkpoint_import_receipts', snapshotId);
+  if (existing !== undefined) {
+    if (!sameReceiptInput(receiptInputFromReceipt(existing), input)) {
+      return yield* Effect.fail(invalid(`Checkpoint import receipt ${snapshotId} conflicts with immutable content.`));
+    }
+    return {receipt: existing, state: 'already-recorded'} as const;
+  }
+  const receipt = yield* publishCheckpointImportReceipt(sql, snapshotId, input, importedAt);
+  return {receipt, state: 'recorded'} as const;
+});
+
+export const readCheckpointImportReceipt = Effect.fn('codeGraph.readCheckpointImportReceipt')(function* (
+  sql: SqlClient.SqlClient,
+  snapshotId: string,
+) {
+  return yield* selectCheckpointImportRow(sql, 'checkpoint_import_receipts', snapshotId);
+});
+
+export const selectReadySnapshotByLogicalDigest = Effect.fn('codeGraph.selectReadySnapshotByLogicalDigest')(function* (
+  sql: SqlClient.SqlClient,
+  repositoryId: string,
+  logicalDigest: string,
+  abiDigest?: string,
+) {
+  if (!SHA256_HEX.test(repositoryId) || !SHA256_HEX.test(logicalDigest) || (abiDigest && !SHA256_HEX.test(abiDigest))) {
+    return yield* Effect.fail(invalid('Code graph checkpoint logical-digest lookup is invalid.'));
+  }
+  const rows = yield* sql.unsafe<{
+    readonly base_snapshot_id: string | null;
+    readonly commit_id: string;
+    readonly completed_at: string | null;
+    readonly dirty: number;
+    readonly edge_count: number;
+    readonly extractor_set: string;
+    readonly file_count: number;
+    readonly graph_content_id: string | null;
+    readonly id: string;
+    readonly overlay_fingerprint: string | null;
+    readonly repository_id: string;
+    readonly state: CodeGraphSnapshot['state'];
+    readonly symbol_count: number;
+    readonly worktree_id: string;
+  }>(
+    `SELECT snapshot.*
+       FROM checkpoint_import_receipts AS receipt
+       JOIN snapshots AS snapshot ON snapshot.id = receipt.snapshot_id
+       WHERE receipt.source_repository_id = ?
+         AND receipt.logical_algorithm = 'sha256'
+         AND receipt.logical_digest = ?
+         AND (? IS NULL OR receipt.abi_digest = ?)
+         AND snapshot.state = 'ready'
+         AND snapshot.dirty = 0
+         AND snapshot.base_snapshot_id IS NULL
+       ORDER BY receipt.imported_at DESC, receipt.snapshot_id
+       LIMIT 1`,
+    [repositoryId, logicalDigest, abiDigest ?? null, abiDigest ?? null],
+  );
+  const row = rows[0];
+  if (!row) return undefined;
+  return {
+    baseSnapshotId: row.base_snapshot_id ?? undefined,
+    commit: row.commit_id,
+    completedAt: row.completed_at ?? undefined,
+    dirty: Number(row.dirty) === 1,
+    edgeCount: Number(row.edge_count),
+    extractorSet: row.extractor_set,
+    fileCount: Number(row.file_count),
+    graphContentId: row.graph_content_id ?? undefined,
+    id: row.id,
+    overlayFingerprint: row.overlay_fingerprint ?? undefined,
+    repositoryId: row.repository_id,
+    state: row.state,
+    symbolCount: Number(row.symbol_count),
+    worktreeId: row.worktree_id,
+  } satisfies CodeGraphSnapshot;
+});

--- a/src/code_graph/store_diagnostics.ts
+++ b/src/code_graph/store_diagnostics.ts
@@ -2,7 +2,8 @@ import {Effect} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {type CodeGraphDatabaseHealth} from './store_models.js';
 import {codeGraphPersistentExtensionSchemaCompatible} from './store_schema_inspection.js';
-import {type CodeGraphSnapshot, CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION} from './types.js';
+import {type CodeGraphSnapshot} from './types.js';
+import {codeGraphPersistentSchemaIsCurrent} from './store/schema_revision.js';
 import {codeGraphRemovedViewCleanupSchemaAdmission} from './store_schema_migration.js';
 import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconciliation.js';
 import {codeGraphDatabaseIntegrity} from './store_health.js';
@@ -21,7 +22,7 @@ const diagnoseDatabase = Effect.fn('codeGraph.diagnoseDatabase')(function* () {
   const persistentExtensionSchemaRevision = cleanupAdmission.persistentExtensionSchemaRevision;
   const snapshotFileCitation = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
   const persistentExtensionCurrent =
-    persistentExtensionSchemaRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION &&
+    codeGraphPersistentSchemaIsCurrent(persistentExtensionSchemaRevision) &&
     (yield* codeGraphPersistentExtensionSchemaCompatible(sql)) &&
     snapshotFileCitation.baseIndexes === 'current' &&
     snapshotFileCitation.state === 'current' &&

--- a/src/code_graph/store_file_alias_schema.ts
+++ b/src/code_graph/store_file_alias_schema.ts
@@ -10,13 +10,18 @@ import {
   nextCodeGraphSqliteSchemaVersion,
 } from './store_schema_receipt.js';
 import {
-  CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION,
-  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   CODE_GRAPH_SCHEMA_VERSION,
   type CodeGraphSnapshotFileCitationBaseIndexState,
   type CodeGraphSnapshotFileCitationSchemaState,
   CodeGraphStoreError,
 } from './types.js';
+import {
+  CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR,
+  CODE_GRAPH_SCHEMA_INITIALIZATION_CITATION_PREDECESSOR_CONTRACT_REVISION,
+  codeGraphPersistentSchemaMigrationPending,
+  codeGraphPersistentSchemaProfile,
+  codeGraphPersistentSchemaSupports,
+} from './store/schema_revision.js';
 
 interface CodeGraphReferenceIndex {
   readonly columns: readonly string[];
@@ -116,7 +121,8 @@ export function codeGraphSnapshotFileCitationSchemaMigrationPreserves(
   baseIndexes: CodeGraphSnapshotFileCitationBaseIndexState,
 ): boolean {
   if (baseIndexes === 'incompatible') return false;
-  if (revision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION - 1) {
+  const citationState = codeGraphPersistentSchemaProfile(revision)?.citationState;
+  if (citationState === 'released-predecessor') {
     return (
       state === 'released-absent' ||
       state === 'released-absent-with-authority' ||
@@ -125,7 +131,16 @@ export function codeGraphSnapshotFileCitationSchemaMigrationPreserves(
       state === 'current'
     );
   }
-  if (revision !== CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) return false;
+  if (citationState === 'column-predecessor') {
+    return (
+      state === 'released-absent' ||
+      state === 'released-absent-with-predecessor-authority' ||
+      state === 'column-only' ||
+      state === 'column-only-with-predecessor-authority' ||
+      state === 'current'
+    );
+  }
+  if (citationState !== 'current') return false;
   return (
     state === 'released-absent' ||
     state === 'released-absent-with-predecessor-authority' ||
@@ -144,16 +159,11 @@ export function codeGraphSnapshotFileCitationSchemaMigrationAdmitted(
   if (baseIndexes === 'incompatible') return false;
   switch (state) {
     case 'released-absent-with-authority':
-      return (
-        revision !== undefined &&
-        Number.isSafeInteger(revision) &&
-        revision >= CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION &&
-        revision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
-      );
+      return codeGraphPersistentSchemaMigrationPending(revision);
     case 'released-absent-with-predecessor-authority':
-      return revision === 15 || revision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION;
+      return codeGraphPersistentSchemaSupports(revision, 'citation-released-predecessor-authority');
     case 'column-only-with-predecessor-authority':
-      return revision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION;
+      return codeGraphPersistentSchemaSupports(revision, 'citation-column-predecessor-authority');
     case 'column-only-with-authority':
     case 'incompatible':
       return false;
@@ -327,11 +337,14 @@ const predecessorInitializationReceiptPresent = Effect.fn('codeGraph.predecessor
       receipt?.singleton_type === 'integer' &&
       receipt?.singleton === 1 &&
       receipt.contract_revision_type === 'integer' &&
-      receipt.contract_revision === 2 &&
+      receipt.contract_revision === CODE_GRAPH_SCHEMA_INITIALIZATION_CITATION_PREDECESSOR_CONTRACT_REVISION &&
       receipt.core_schema_version_type === 'integer' &&
       receipt.core_schema_version === CODE_GRAPH_SCHEMA_VERSION &&
       receipt.persistent_extension_revision_type === 'integer' &&
-      receipt.persistent_extension_revision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION - 1 &&
+      // The raw-content citation alias was introduced by revision 16. Its
+      // interruption receipt is therefore permanently bound to revision 15,
+      // even after later additive extension revisions are introduced.
+      receipt.persistent_extension_revision === CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR.value &&
       receipt.sqlite_schema_version_type === 'integer' &&
       typeof receiptSchemaVersion === 'number' &&
       Number.isSafeInteger(receiptSchemaVersion) &&

--- a/src/code_graph/store_health.ts
+++ b/src/code_graph/store_health.ts
@@ -6,12 +6,11 @@ import {codeGraphPersistentExtensionSchemaCompatible} from './store_schema_inspe
 import {codeGraphRemovedViewCleanupSchemaAdmission} from './store_schema_migration.js';
 import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconciliation.js';
 import {inspectCodeGraphSnapshotFileCitationSchema} from './store_file_alias_schema.js';
+import {CODE_GRAPH_SCHEMA_VERSION, type CodeGraphSnapshot} from './types.js';
 import {
-  CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION,
-  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
-  CODE_GRAPH_SCHEMA_VERSION,
-  type CodeGraphSnapshot,
-} from './types.js';
+  codeGraphPersistentSchemaIsCurrent,
+  codeGraphPersistentSchemaMigrationPending,
+} from './store/schema_revision.js';
 
 export type CodeGraphDatabaseIntegrity = 'corrupt' | 'incompatible' | 'migration-pending' | 'ok';
 
@@ -26,13 +25,9 @@ export function codeGraphDatabaseIntegrity(input: {
 }): CodeGraphDatabaseIntegrity {
   if (input.schemaVersion !== CODE_GRAPH_SCHEMA_VERSION) return 'incompatible';
   if (input.persistentExtensionCurrent) return input.integrityOk ? 'ok' : 'corrupt';
-  const revision = input.persistentExtensionSchemaRevision;
   const migrationPending =
     input.coreReadSchemaCompatible &&
-    revision !== undefined &&
-    Number.isSafeInteger(revision) &&
-    revision >= CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION &&
-    revision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION;
+    codeGraphPersistentSchemaMigrationPending(input.persistentExtensionSchemaRevision);
   if (migrationPending) return input.integrityOk ? 'migration-pending' : 'corrupt';
   return 'incompatible';
 }
@@ -56,7 +51,7 @@ export const diagnoseCodeGraphDatabaseReadOnly = Effect.fn('codeGraph.diagnoseDa
     const persistentExtensionSchemaRevision = cleanupAdmission.persistentExtensionSchemaRevision;
     const snapshotFileCitation = yield* inspectCodeGraphSnapshotFileCitationSchema(sql);
     const persistentExtensionCurrent =
-      persistentExtensionSchemaRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION &&
+      codeGraphPersistentSchemaIsCurrent(persistentExtensionSchemaRevision) &&
       (yield* codeGraphPersistentExtensionSchemaCompatible(sql)) &&
       snapshotFileCitation.baseIndexes === 'current' &&
       snapshotFileCitation.state === 'current' &&

--- a/src/code_graph/store_leases.ts
+++ b/src/code_graph/store_leases.ts
@@ -11,7 +11,11 @@ import {
   removedViewCleanupRecordedRevision,
 } from './store_removed_view_schema_inspection.js';
 import {configureConnection, tableExists} from './store_session.js';
-import {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION, CodeGraphStoreError} from './types.js';
+import {CodeGraphStoreError} from './types.js';
+import {
+  codeGraphPersistentSchemaIsCurrentOrNewer,
+  codeGraphPersistentSchemaMigrationPending,
+} from './store/schema_revision.js';
 import {
   boundedSnapshotLeaseProjection,
   type BoundedSnapshotLeaseRow,
@@ -33,7 +37,6 @@ import {type PersistentBuildOwnerCandidate} from './store_internal_models.js';
 import {codeGraphWorktreeReconciliationSchemaCompatible} from './store_reconciliation.js';
 import {lastStatementChangeCount} from './store_activation_core.js';
 import {retireReadySnapshotsIfUnused} from './store_cleanup_core.js';
-import {CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION} from './store_health.js';
 import {
   CODE_GRAPH_DETACHED_READY_COUNT_MAXIMUM,
   CODE_GRAPH_DETACHED_READY_ESTIMATED_BYTES_MAXIMUM,
@@ -69,12 +72,7 @@ const initializeRoutineMaintenanceSchema = Effect.fn('codeGraph.initializeRoutin
   const removedViewAuthority = yield* removedViewAuthorityTableState(sql);
   if (removedViewAuthority === 'incompatible') return false;
   if (removedViewAuthority === 'absent' && recordedRevision !== undefined) {
-    if (
-      recordedRevision < CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION ||
-      recordedRevision >= CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
-    ) {
-      return false;
-    }
+    if (!codeGraphPersistentSchemaMigrationPending(recordedRevision)) return false;
     yield* sql.unsafe(REMOVED_VIEWS_TABLE_SQL);
     if ((yield* removedViewAuthorityTableState(sql)) !== 'compatible') return false;
   }
@@ -90,9 +88,7 @@ const initializeRoutineMaintenanceSchema = Effect.fn('codeGraph.initializeRoutin
     : ('missing' as const);
   if (
     successorIndexState === 'incompatible' ||
-    (recordedRevision !== undefined &&
-      recordedRevision >= CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION &&
-      successorIndexState !== 'ready')
+    (codeGraphPersistentSchemaIsCurrentOrNewer(recordedRevision) && successorIndexState !== 'ready')
   ) {
     return false;
   }

--- a/src/code_graph/store_maintenance_core.ts
+++ b/src/code_graph/store_maintenance_core.ts
@@ -15,11 +15,8 @@ import {
   CODE_GRAPH_ABANDONED_BUILD_CURSOR_KEY,
   tableExists,
 } from './store_session.js';
-import {
-  CODE_GRAPH_EXTRACTOR_GENERATION,
-  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
-  CodeGraphStoreError,
-} from './types.js';
+import {CODE_GRAPH_EXTRACTOR_GENERATION, CodeGraphStoreError} from './types.js';
+import {codeGraphPersistentSchemaIsCurrent} from './store/schema_revision.js';
 import {type CodeGraphActivationLease, type PersistentBuildOwnerCandidate} from './store_internal_models.js';
 import {lastStatementChangeCount} from './store_activation_core.js';
 
@@ -324,7 +321,7 @@ const routineCacheSchemaCurrent = Effect.fn('codeGraph.routineCacheSchemaCurrent
   const revision = yield* removedViewCleanupRecordedRevision(sql);
   return (
     revision.state === 'recorded' &&
-    revision.value === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION &&
+    codeGraphPersistentSchemaIsCurrent(revision.value) &&
     (yield* tableExists(sql, 'file_blobs')) &&
     (yield* tableExists(sql, 'snapshot_files')) &&
     (yield* tableExists(sql, 'materialized_file_shards')) &&

--- a/src/code_graph/store_models.ts
+++ b/src/code_graph/store_models.ts
@@ -3,6 +3,7 @@ import type {CodeGraphBuildOwnerIdentity} from './build_owner.js';
 import type {CodeGraphDirectPersistentCapacityBoundary} from './disk_capacity.js';
 import type {CodeGraphCacheFactInput} from './fact_budget.js';
 import type {CodeGraphMonikerV1} from './cross_repository/types.js';
+import type {CodeGraphCheckpointRecordKind, CodeGraphCheckpointRecordV1} from './checkpoint/schema.js';
 import type {
   CodeGraphWorkspaceBuildSystem,
   CodeGraphWorkspaceComponentKind,
@@ -10,8 +11,6 @@ import type {
   CodeGraphWorkspace,
 } from './languages/types.js';
 import {
-  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
-  CODE_GRAPH_SCHEMA_VERSION,
   type CodeGraphSnapshotFileCitationBaseIndexState,
   type CodeGraphSnapshotFileCitationSchemaState,
   type CodeGraphEdge,
@@ -28,9 +27,99 @@ import {
   CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
   type CodeGraphInventoryExclusionReason,
 } from './inventory_policy.js';
+import {
+  CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION,
+  CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION,
+  CODE_GRAPH_RESOLUTION_SURFACE_VERSION,
+  CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
+  codeGraphRuntimeSchemaRequiresReconnect,
+} from './store/schema_revision.js';
 
-export const CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION = 2 as const;
-export const CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION = 2 as const;
+export {
+  CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION,
+  CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION,
+  CODE_GRAPH_RESOLUTION_SURFACE_VERSION,
+  CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
+  codeGraphRuntimeSchemaRequiresReconnect,
+};
+
+export type CodeGraphCheckpointTrust = 'expected-descriptor-verified' | 'local-unverified';
+
+export interface CodeGraphCheckpointSha256Digest {
+  readonly algorithm: 'sha256';
+  readonly digest: string;
+}
+
+export interface CodeGraphCheckpointArtifactDescriptor extends CodeGraphCheckpointSha256Digest {
+  readonly mediaType: string;
+  readonly size: number;
+}
+
+export interface CodeGraphCheckpointCoverageReason {
+  readonly bytes: number;
+  readonly code: string;
+  readonly files: number;
+}
+
+export interface CodeGraphCheckpointCoverageSummary {
+  readonly eligibleFiles: number;
+  readonly excludedFiles: number;
+  readonly reasons: readonly CodeGraphCheckpointCoverageReason[];
+  readonly state: 'complete' | 'partial';
+}
+
+/**
+ * Local provenance bound to a receiving clean root. Donor process, worktree,
+ * environment, and database snapshot identities are intentionally absent.
+ */
+export interface CodeGraphCheckpointImportReceiptInput {
+  readonly abi: CodeGraphCheckpointSha256Digest;
+  readonly artifact: CodeGraphCheckpointArtifactDescriptor;
+  /** Reserved for future delta formats; v1 self-contained roots require null. */
+  readonly baseLogicalDigest: string | null;
+  readonly coverage: CodeGraphCheckpointCoverageSummary;
+  readonly formatVersion: typeof CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION;
+  readonly logical: CodeGraphCheckpointSha256Digest;
+  readonly source: {
+    readonly commit: string;
+    readonly graphContentId: string;
+    readonly repositoryId: string;
+  };
+  readonly trust: CodeGraphCheckpointTrust;
+}
+
+export interface CodeGraphCheckpointImportReceipt extends CodeGraphCheckpointImportReceiptInput {
+  readonly importedAt: string;
+  /** Newly created local receiving snapshot, never a donor database identity. */
+  readonly snapshotId: string;
+}
+
+export interface CodeGraphCheckpointImportBuildInput extends CodeGraphCheckpointImportReceiptInput {
+  readonly batchCount: number;
+  readonly packProvenance: readonly CodeGraphLanguagePackProvenance[];
+  readonly recordCounts: Readonly<Record<CodeGraphCheckpointRecordKind, number>>;
+}
+
+export interface CodeGraphCheckpointImportRecordPage {
+  readonly batchIndex: number;
+  readonly digest: CodeGraphCheckpointSha256Digest;
+  readonly records: readonly CodeGraphCheckpointRecordV1[];
+}
+
+export type CodeGraphCheckpointImportRecordPageResult =
+  {readonly records: number; readonly state: 'already-staged'} | {readonly records: number; readonly state: 'staged'};
+
+export interface CodeGraphCheckpointImportFinalizeOptions {
+  readonly onProgress?: CodeGraphActivationProgressCallback;
+  readonly persistentCapacityProtector?: CodeGraphDirectPersistentCapacityProtector;
+  readonly reusableBaseReceipt?: CodeGraphReusableBaseReceiptInput;
+}
+
+export type CodeGraphCheckpointImportBuildBindingResult = {readonly state: 'already-bound'} | {readonly state: 'bound'};
+
+export type CodeGraphCheckpointImportReceiptRecordResult =
+  | {readonly receipt: CodeGraphCheckpointImportReceipt; readonly state: 'already-recorded'}
+  | {readonly receipt: CodeGraphCheckpointImportReceipt; readonly state: 'recorded'};
 
 export interface CodeGraphInventoryPolicyExclusionReasonSummary {
   readonly bytes: number;
@@ -782,19 +871,4 @@ export type CodeGraphSnapshotPurgeStoreResult =
 export interface CodeGraphSnapshotPurgeStoreOptions extends CodeGraphSnapshotLeaseWriterOptions {
   /** Final containment proof while the checkout writer gate is held and before SQLite opens. */
   readonly beforeDatabaseOpen?: () => Effect.Effect<void, unknown>;
-}
-
-/** True only for a positive, bounded observation of storage newer than this runtime. */
-export function codeGraphRuntimeSchemaRequiresReconnect(
-  observedSchemaVersion: number | undefined,
-  observedPersistentExtensionRevision: number | undefined,
-): boolean {
-  return (
-    (typeof observedSchemaVersion === 'number' &&
-      Number.isSafeInteger(observedSchemaVersion) &&
-      observedSchemaVersion > CODE_GRAPH_SCHEMA_VERSION) ||
-    (typeof observedPersistentExtensionRevision === 'number' &&
-      Number.isSafeInteger(observedPersistentExtensionRevision) &&
-      observedPersistentExtensionRevision > CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)
-  );
 }

--- a/src/code_graph/store_queries.ts
+++ b/src/code_graph/store_queries.ts
@@ -7,6 +7,7 @@ import {compareCodeUnits} from './ordering.js';
 import {decodeCodeGraphInventoryReuseReceipt} from './inventory_reuse.js';
 import {relocateStructuredSchemaFacts} from './languages/schemas/extractor.js';
 import {
+  CODE_GRAPH_RESOLUTION_SURFACE_VERSION,
   CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION,
   type CodeGraphEdgeCursor,
   type CodeGraphReusableBaseReceipt,
@@ -183,7 +184,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
         AND snapshot.base_snapshot_id IS NULL
         AND snapshot.graph_content_id = ${graphContentId}
         AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
-        AND receipt.resolution_surface_version = 1
+        AND receipt.resolution_surface_version = ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}
         AND receipt.workspace_fingerprint = ${workspaceFingerprint}
       ORDER BY
         CASE WHEN receipt.file_set_fingerprint = ${fileSetFingerprint} THEN 0 ELSE 1 END,
@@ -216,7 +217,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
         AND snapshot.dirty = 0
         AND snapshot.base_snapshot_id IS NULL
         AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
-        AND receipt.resolution_surface_version = 1
+        AND receipt.resolution_surface_version = ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}
         AND receipt.workspace_fingerprint = ${workspaceFingerprint}
         AND ${sql.in('commit_id', candidateCommits)}
     `;
@@ -237,7 +238,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
           AND snapshot.base_snapshot_id IS NULL
           AND snapshot.commit_id = ${matches[0]!}
           AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
-          AND receipt.resolution_surface_version = 1
+          AND receipt.resolution_surface_version = ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}
           AND receipt.workspace_fingerprint = ${workspaceFingerprint}
         ORDER BY
           CASE WHEN snapshot.extractor_set = ${extractorSet} THEN 0 ELSE 1 END,
@@ -261,7 +262,7 @@ const selectReusableCleanBase = Effect.fn('codeGraph.selectReusableCleanBase')(f
       AND snapshot.dirty = 0
       AND snapshot.base_snapshot_id IS NULL
       AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
-      AND receipt.resolution_surface_version = 1
+      AND receipt.resolution_surface_version = ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}
       AND receipt.workspace_fingerprint = ${workspaceFingerprint}
     ORDER BY
       CASE WHEN snapshot.extractor_set = ${extractorSet} THEN 0 ELSE 1 END,
@@ -289,7 +290,7 @@ const selectReusableCleanBaseForCommit = Effect.fn('codeGraph.selectReusableClea
       AND snapshot.dirty = 0
       AND snapshot.base_snapshot_id IS NULL
       AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
-      AND receipt.resolution_surface_version = 1
+      AND receipt.resolution_surface_version = ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}
       AND receipt.inventory_receipt_json IS NOT NULL
     ORDER BY snapshot.completed_at DESC, snapshot.id
     LIMIT 8
@@ -338,7 +339,7 @@ const selectReusableCleanBaseForCommitPaths = Effect.fn('codeGraph.selectReusabl
         AND snapshot.dirty = 0
         AND snapshot.base_snapshot_id IS NULL
         AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
-        AND receipt.resolution_surface_version = 1
+        AND receipt.resolution_surface_version = ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}
         AND receipt.inventory_receipt_json IS NOT NULL
       ORDER BY snapshot.completed_at DESC, snapshot.id
       LIMIT 8
@@ -428,7 +429,7 @@ const selectReusableOverlayBase = Effect.fn('codeGraph.selectReusableOverlayBase
       AND snapshot.dirty = 1
       AND snapshot.base_snapshot_id IS NULL
       AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
-      AND receipt.resolution_surface_version = 1
+      AND receipt.resolution_surface_version = ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}
     ORDER BY CASE WHEN snapshot.overlay_fingerprint = ${overlayFingerprint} THEN 0 ELSE 1 END,
              CASE WHEN EXISTS (
                SELECT 1 FROM snapshot_leases AS lease
@@ -546,7 +547,7 @@ const selectReusableBaseReceipt = Effect.fn('codeGraph.selectReusableBaseReceipt
     JOIN snapshots AS snapshot ON snapshot.id = receipt.snapshot_id
     WHERE receipt.snapshot_id = ${snapshotId}
       AND receipt.format_version = ${CODE_GRAPH_REUSABLE_BASE_RECEIPT_VERSION}
-      AND receipt.resolution_surface_version = 1
+      AND receipt.resolution_surface_version = ${CODE_GRAPH_RESOLUTION_SURFACE_VERSION}
       AND receipt.extractor_set = snapshot.extractor_set
       AND snapshot.state = 'ready'
       AND (${allowDirtyRoot ? 1 : 0} = 1 OR snapshot.dirty = 0)

--- a/src/code_graph/store_reconciliation.ts
+++ b/src/code_graph/store_reconciliation.ts
@@ -29,12 +29,12 @@ import {
   inspectBoundedSchemaMetadataValue,
 } from './store_schema_metadata.js';
 import {
-  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   CODE_GRAPH_SCHEMA_VERSION,
   CodeGraphStoreCorruptionError,
   CodeGraphStoreError,
   CodeGraphStoreIncompatibleSchemaError,
 } from './types.js';
+import {codeGraphPersistentSchemaIsCurrent} from './store/schema_revision.js';
 import {
   allocateRemovedViewCleanupEpoch,
   authorityPrimaryKeyBinary,
@@ -94,7 +94,7 @@ const admitOrRecoverWorktreeReconciliationSchema = Effect.fn('codeGraph.admitOrR
       sql,
       WORKTREE_RECONCILIATION_LEGACY_MAXIMUM_METADATA_ROWS,
     );
-    if (revision.state !== 'recorded' || revision.value !== CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) {
+    if (revision.state !== 'recorded' || !codeGraphPersistentSchemaIsCurrent(revision.value)) {
       return false;
     }
     const metadataRowCount = yield* inspectBoundedSchemaMetadataRowCount(

--- a/src/code_graph/store_reconciliation_preparation.ts
+++ b/src/code_graph/store_reconciliation_preparation.ts
@@ -6,7 +6,13 @@ import {
   removedViewCleanupSchemaState,
 } from './store_removed_view_schema_inspection.js';
 import {codeGraphPersistentExtensionSchemaCompatible} from './store_schema_inspection.js';
-import {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION, CodeGraphStoreError} from './types.js';
+import {CodeGraphStoreError} from './types.js';
+import {
+  CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION,
+  codeGraphPersistentSchemaIsCurrent,
+  codeGraphPersistentSchemaMigrationPending,
+  codeGraphPersistentSchemaSupports,
+} from './store/schema_revision.js';
 import {
   codeGraphRemovedViewCleanupSchemaAdmission,
   codeGraphSchemaMigrationPreservesIncompleteSnapshots,
@@ -21,7 +27,6 @@ import {
   codeGraphReconciliationIndexState,
 } from './store_reconciliation_core.js';
 import {initializeRoutineMaintenanceSchema} from './store_leases.js';
-import {CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION} from './store_health.js';
 import {prepareCodeGraphSnapshotFileCitationSchema} from './store_file_alias_schema.js';
 
 export const CODE_GRAPH_EXPLICIT_SCHEMA_PREPARATION_STEP_LIMIT = 8;
@@ -43,13 +48,7 @@ const prepareRemovedViewCleanupExtension = Effect.fn('codeGraph.prepareRemovedVi
     SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision'
   `;
   const revision = revisions[0]?.value;
-  if (
-    revisions.length !== 1 ||
-    (revision !== '7' &&
-      revision !== '8' &&
-      revision !== '9' &&
-      revision !== String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION))
-  ) {
+  if (revisions.length !== 1 || !codeGraphPersistentSchemaSupports(revision, 'explicit-cleanup-preparation')) {
     return {reason: 'incompatible-schema', state: 'deferred'} as const;
   }
   if (!(yield* codeGraphPersistentExtensionSchemaCompatible(sql))) {
@@ -63,10 +62,10 @@ const prepareRemovedViewCleanupExtension = Effect.fn('codeGraph.prepareRemovedVi
       VALUES (${REMOVED_VIEW_CLEANUP_EPOCH_SEQUENCE_KEY}, '0')
     `;
   }
-  if (revision !== String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)) {
+  if (!codeGraphPersistentSchemaIsCurrent(revision)) {
     yield* sql`
       UPDATE schema_metadata
-      SET value = ${String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)}
+      SET value = ${String(CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION)}
       WHERE key = 'persistent_extension_schema_revision' AND value = ${revision!}
     `;
     if ((yield* lastStatementChangeCount(sql)) !== 1) {
@@ -76,7 +75,7 @@ const prepareRemovedViewCleanupExtension = Effect.fn('codeGraph.prepareRemovedVi
   if (!(yield* codeGraphRemovedViewCleanupSchemaAdmission(sql)).current) {
     return yield* Effect.fail(new CodeGraphStoreError('Code graph removed view cleanup schema is unavailable.'));
   }
-  return wasCurrent && revision === String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)
+  return wasCurrent && codeGraphPersistentSchemaIsCurrent(revision)
     ? ({state: 'ready'} as const)
     : ({index: 'removed_view_cleanup_due', state: 'prepared'} as const);
 });
@@ -129,11 +128,7 @@ const prepareWorktreeReconciliationIndex = Effect.fn('codeGraph.prepareWorktreeR
     return {index: missing.index.name, state: 'prepared'} as const;
   }
   if (snapshotPreservingSchemaMigration) return {state: 'migration-ready'} as const;
-  if (
-    recordedRevision !== undefined &&
-    recordedRevision >= CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION &&
-    recordedRevision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
-  ) {
+  if (codeGraphPersistentSchemaMigrationPending(recordedRevision)) {
     return {state: 'migration-ready'} as const;
   }
   const cleanup = yield* prepareRemovedViewCleanupExtension(sql);

--- a/src/code_graph/store_schema_contracts.ts
+++ b/src/code_graph/store_schema_contracts.ts
@@ -1,7 +1,10 @@
-export type PersistentExtensionGroup = 'analysis' | 'build' | 'cross-repository' | 'lexical' | 'shards';
+import {CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION} from './store/schema_revision.js';
+
+export type PersistentExtensionGroup = 'analysis' | 'build' | 'checkpoint' | 'cross-repository' | 'lexical' | 'shards';
 
 export type CodeGraphPersistentSchemaMigrationPhase =
   | 'added-build-owner-instance'
+  | 'added-checkpoint-import'
   | 'added-materialization-plan'
   | 'added-removed-view-cleanup'
   | 'created-extensions'
@@ -658,6 +661,138 @@ export const PERSISTENT_EXTENSION_TABLES = [
     ],
     group: 'shards',
     name: 'snapshot_file_shards',
+  },
+  {
+    columns: [
+      requiredColumn('snapshot_id', 'TEXT', 1),
+      requiredColumn('format_version', 'INTEGER'),
+      requiredColumn('source_repository_id', 'TEXT'),
+      requiredColumn('source_commit_id', 'TEXT'),
+      requiredColumn('source_graph_content_id', 'TEXT'),
+      requiredColumn('abi_algorithm', 'TEXT'),
+      requiredColumn('abi_digest', 'TEXT'),
+      requiredColumn('logical_algorithm', 'TEXT'),
+      requiredColumn('logical_digest', 'TEXT'),
+      optionalColumn('base_logical_digest', 'TEXT'),
+      requiredColumn('artifact_algorithm', 'TEXT'),
+      requiredColumn('artifact_digest', 'TEXT'),
+      requiredColumn('artifact_size', 'INTEGER'),
+      requiredColumn('artifact_media_type', 'TEXT'),
+      requiredColumn('coverage_json', 'TEXT'),
+      requiredColumn('trust', 'TEXT'),
+      requiredColumn('expected_batch_count', 'INTEGER'),
+      requiredColumn('expected_counts_json', 'TEXT'),
+      requiredColumn('expected_pack_provenance_json', 'TEXT'),
+      requiredColumn('started_at', 'TEXT'),
+    ],
+    createSql: `CREATE TABLE IF NOT EXISTS checkpoint_import_builds (
+      snapshot_id TEXT PRIMARY KEY NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+      format_version INTEGER NOT NULL CHECK (format_version = ${CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION}),
+      source_repository_id TEXT NOT NULL CHECK (length(source_repository_id) = 64),
+      source_commit_id TEXT NOT NULL,
+      source_graph_content_id TEXT NOT NULL,
+      abi_algorithm TEXT NOT NULL CHECK (abi_algorithm = 'sha256'),
+      abi_digest TEXT NOT NULL CHECK (length(abi_digest) = 64),
+      logical_algorithm TEXT NOT NULL CHECK (logical_algorithm = 'sha256'),
+      logical_digest TEXT NOT NULL CHECK (length(logical_digest) = 64),
+      base_logical_digest TEXT CHECK (base_logical_digest IS NULL OR length(base_logical_digest) = 64),
+      artifact_algorithm TEXT NOT NULL CHECK (artifact_algorithm = 'sha256'),
+      artifact_digest TEXT NOT NULL CHECK (length(artifact_digest) = 64),
+      artifact_size INTEGER NOT NULL CHECK (artifact_size >= 0),
+      artifact_media_type TEXT NOT NULL,
+      coverage_json TEXT NOT NULL,
+      trust TEXT NOT NULL CHECK (trust IN ('local-unverified', 'expected-descriptor-verified')),
+      expected_batch_count INTEGER NOT NULL CHECK (expected_batch_count >= 0),
+      expected_counts_json TEXT NOT NULL,
+      expected_pack_provenance_json TEXT NOT NULL,
+      started_at TEXT NOT NULL
+    ) WITHOUT ROWID`,
+    group: 'checkpoint',
+    name: 'checkpoint_import_builds',
+    requiredDefinitionPatterns: [
+      new RegExp(`CHECK\\s*\\(\\s*format_version\\s*=\\s*${CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION}\\s*\\)`, 'i'),
+      /CHECK\s*\(\s*abi_algorithm\s*=\s*'sha256'\s*\)/i,
+      /CHECK\s*\(\s*logical_algorithm\s*=\s*'sha256'\s*\)/i,
+      /CHECK\s*\(\s*artifact_algorithm\s*=\s*'sha256'\s*\)/i,
+      /CHECK\s*\(\s*expected_batch_count\s*>=\s*0\s*\)/i,
+      /CHECK\s*\(\s*trust\s+IN\s*\(\s*'local-unverified'\s*,\s*'expected-descriptor-verified'\s*\)\s*\)/i,
+    ],
+  },
+  {
+    columns: [
+      requiredColumn('snapshot_id', 'TEXT', 1),
+      requiredColumn('batch_index', 'INTEGER', 2),
+      requiredColumn('digest_algorithm', 'TEXT'),
+      requiredColumn('batch_digest', 'TEXT'),
+      requiredColumn('record_count', 'INTEGER'),
+      requiredColumn('completed_at', 'TEXT'),
+    ],
+    createSql: `CREATE TABLE IF NOT EXISTS checkpoint_import_batches (
+      snapshot_id TEXT NOT NULL REFERENCES checkpoint_import_builds(snapshot_id) ON DELETE CASCADE,
+      batch_index INTEGER NOT NULL CHECK (batch_index >= 0),
+      digest_algorithm TEXT NOT NULL CHECK (digest_algorithm = 'sha256'),
+      batch_digest TEXT NOT NULL CHECK (length(batch_digest) = 64),
+      record_count INTEGER NOT NULL CHECK (record_count >= 0),
+      completed_at TEXT NOT NULL,
+      PRIMARY KEY (snapshot_id, batch_index)
+    ) WITHOUT ROWID`,
+    foreignKeys: [{from: 'snapshot_id', onDelete: 'CASCADE', table: 'checkpoint_import_builds', to: 'snapshot_id'}],
+    group: 'checkpoint',
+    name: 'checkpoint_import_batches',
+    requiredDefinitionPatterns: [
+      /CHECK\s*\(\s*batch_index\s*>=\s*0\s*\)/i,
+      /CHECK\s*\(\s*digest_algorithm\s*=\s*'sha256'\s*\)/i,
+      /CHECK\s*\(\s*record_count\s*>=\s*0\s*\)/i,
+    ],
+  },
+  {
+    columns: [
+      requiredColumn('snapshot_id', 'TEXT', 1),
+      requiredColumn('format_version', 'INTEGER'),
+      requiredColumn('source_repository_id', 'TEXT'),
+      requiredColumn('source_commit_id', 'TEXT'),
+      requiredColumn('source_graph_content_id', 'TEXT'),
+      requiredColumn('abi_algorithm', 'TEXT'),
+      requiredColumn('abi_digest', 'TEXT'),
+      requiredColumn('logical_algorithm', 'TEXT'),
+      requiredColumn('logical_digest', 'TEXT'),
+      optionalColumn('base_logical_digest', 'TEXT'),
+      requiredColumn('artifact_algorithm', 'TEXT'),
+      requiredColumn('artifact_digest', 'TEXT'),
+      requiredColumn('artifact_size', 'INTEGER'),
+      requiredColumn('artifact_media_type', 'TEXT'),
+      requiredColumn('coverage_json', 'TEXT'),
+      requiredColumn('trust', 'TEXT'),
+      requiredColumn('imported_at', 'TEXT'),
+    ],
+    createSql: `CREATE TABLE IF NOT EXISTS checkpoint_import_receipts (
+      snapshot_id TEXT PRIMARY KEY NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+      format_version INTEGER NOT NULL CHECK (format_version = ${CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION}),
+      source_repository_id TEXT NOT NULL CHECK (length(source_repository_id) = 64),
+      source_commit_id TEXT NOT NULL,
+      source_graph_content_id TEXT NOT NULL,
+      abi_algorithm TEXT NOT NULL CHECK (abi_algorithm = 'sha256'),
+      abi_digest TEXT NOT NULL CHECK (length(abi_digest) = 64),
+      logical_algorithm TEXT NOT NULL CHECK (logical_algorithm = 'sha256'),
+      logical_digest TEXT NOT NULL CHECK (length(logical_digest) = 64),
+      base_logical_digest TEXT CHECK (base_logical_digest IS NULL OR length(base_logical_digest) = 64),
+      artifact_algorithm TEXT NOT NULL CHECK (artifact_algorithm = 'sha256'),
+      artifact_digest TEXT NOT NULL CHECK (length(artifact_digest) = 64),
+      artifact_size INTEGER NOT NULL CHECK (artifact_size >= 0),
+      artifact_media_type TEXT NOT NULL,
+      coverage_json TEXT NOT NULL,
+      trust TEXT NOT NULL CHECK (trust IN ('local-unverified', 'expected-descriptor-verified')),
+      imported_at TEXT NOT NULL
+    ) WITHOUT ROWID`,
+    group: 'checkpoint',
+    name: 'checkpoint_import_receipts',
+    requiredDefinitionPatterns: [
+      new RegExp(`CHECK\\s*\\(\\s*format_version\\s*=\\s*${CODE_GRAPH_CHECKPOINT_IMPORT_FORMAT_VERSION}\\s*\\)`, 'i'),
+      /CHECK\s*\(\s*abi_algorithm\s*=\s*'sha256'\s*\)/i,
+      /CHECK\s*\(\s*logical_algorithm\s*=\s*'sha256'\s*\)/i,
+      /CHECK\s*\(\s*artifact_algorithm\s*=\s*'sha256'\s*\)/i,
+      /CHECK\s*\(\s*trust\s+IN\s*\(\s*'local-unverified'\s*,\s*'expected-descriptor-verified'\s*\)\s*\)/i,
+    ],
   },
 ] as const satisfies readonly PersistentExtensionTableContract[];
 

--- a/src/code_graph/store_schema_core.ts
+++ b/src/code_graph/store_schema_core.ts
@@ -17,7 +17,7 @@ import {
   inspectBoundedSchemaMetadataValue,
 } from './store_schema_metadata.js';
 import {tableExists} from './store_session.js';
-import {CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION} from './types.js';
+import {codeGraphPersistentSchemaIsCurrent} from './store/schema_revision.js';
 
 const removedViewCleanupSchemaCurrent = Effect.fn('codeGraph.removedViewCleanupSchemaCurrent')(function* (
   sql: SqlClient.SqlClient,
@@ -67,7 +67,7 @@ const codeGraphRemovedViewCleanupBaseSchemaAdmission: (
 )(function* (sql: SqlClient.SqlClient) {
   const revision = yield* removedViewCleanupRecordedRevision(sql);
   const persistentExtensionSchemaRevision = revision.state === 'recorded' ? revision.value : undefined;
-  if (persistentExtensionSchemaRevision !== CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) {
+  if (!codeGraphPersistentSchemaIsCurrent(persistentExtensionSchemaRevision)) {
     return {current: false, persistentExtensionSchemaRevision} as const;
   }
   if (!(yield* removedViewCleanupEpochSequenceCurrent(sql))) {

--- a/src/code_graph/store_schema_metadata.ts
+++ b/src/code_graph/store_schema_metadata.ts
@@ -1,6 +1,6 @@
 import {Effect} from 'effect';
 import * as SqlClient from 'effect/unstable/sql/SqlClient';
-import {codeGraphRuntimeSchemaRequiresReconnect} from './store_models.js';
+import {codeGraphRuntimeSchemaRequiresReconnect} from './store/schema_revision.js';
 import {tableExists} from './store_session.js';
 import {CodeGraphRuntimeReconnectRequiredError, CodeGraphStoreError} from './types.js';
 

--- a/src/code_graph/store_schema_migration.ts
+++ b/src/code_graph/store_schema_migration.ts
@@ -33,11 +33,19 @@ import {
 } from './store_schema_metadata.js';
 import {CodeGraphDatabaseSession, tableExists} from './store_session.js';
 import {
-  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
   type CodeGraphSnapshotFileCitationBaseIndexState,
   type CodeGraphSnapshotFileCitationSchemaState,
   CodeGraphStoreError,
 } from './types.js';
+import {
+  CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION,
+  codeGraphPersistentSchemaIsCurrent,
+  codeGraphPersistentSchemaIsOlder,
+  codeGraphPersistentSchemaRevisionValue,
+  codeGraphPersistentSchemaSupports,
+  observeCodeGraphPersistentSchemaRevision,
+  planCodeGraphPersistentSchemaUpgrade,
+} from './store/schema_revision.js';
 import {
   CODE_GRAPH_SNAPSHOT_LEASE_EXPIRY_INDEX,
   codeGraphReconciliationIndexState,
@@ -56,10 +64,7 @@ import {
   removedViewCleanupSchemaCurrent,
 } from './store_schema_core.js';
 
-/** Revision that first made the exact cleanup queue part of durable graph authority. */
-const REMOVED_VIEW_CLEANUP_EXTENSION_REVISION = 8;
-
-/** Revision 16 only adds the raw-content alias column/index after extension migration. */
+/** Additive revisions 16 and 17 preserve incomplete resumable-build rows. */
 export function codeGraphSchemaMigrationPreservesIncompleteSnapshots(
   revision: number | undefined,
   snapshotFileCitationSchema: CodeGraphSnapshotFileCitationSchemaState,
@@ -85,10 +90,11 @@ const preflightRemovedViewCleanupSchema = Effect.fn('codeGraph.preflightRemovedV
   }
   const revision = yield* removedViewCleanupRecordedRevision(sql);
   const recordedRevision = revision.state === 'recorded' ? revision.value : undefined;
-  if (recordedRevision !== undefined && recordedRevision > CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) {
+  const revisionObservation = observeCodeGraphPersistentSchemaRevision(recordedRevision);
+  if (revisionObservation.state === 'newer') {
     return yield* Effect.fail(
       new CodeGraphStoreError(
-        `Code graph persistent extension schema ${recordedRevision} is newer than ${CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION}.`,
+        `Code graph persistent extension schema ${revisionObservation.value} is newer than ${CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION}.`,
       ),
     );
   }
@@ -139,32 +145,28 @@ const preflightRemovedViewCleanupSchema = Effect.fn('codeGraph.preflightRemovedV
            LIMIT 1`,
         )
       : [];
-  const coreAuthorityCurrent =
-    recordedRevision !== undefined && recordedRevision >= 7
-      ? yield* codeGraphWorktreeReconciliationSchemaCompatible(
-          sql,
-          schema === 'compatible',
-          false,
-          removedViewAuthority === 'compatible',
-        )
-      : true;
+  const coreAuthorityCurrent = codeGraphPersistentSchemaSupports(recordedRevision, 'worktree-reconciliation-authority')
+    ? yield* codeGraphWorktreeReconciliationSchemaCompatible(
+        sql,
+        schema === 'compatible',
+        false,
+        removedViewAuthority === 'compatible',
+      )
+    : true;
   if (
     revision.state === 'invalid' ||
     metadataRowCount === undefined ||
     epochSequence.state === 'invalid' ||
     (epochSequence.state === 'recorded' && !epochSequenceCurrent) ||
     !cursorCurrent ||
-    (schema === 'absent' &&
-      recordedRevision !== undefined &&
-      recordedRevision >= REMOVED_VIEW_CLEANUP_EXTENSION_REVISION) ||
+    (schema === 'absent' && codeGraphPersistentSchemaSupports(recordedRevision, 'removed-view-cleanup-authority')) ||
     (schema === 'absent' && (epochSequence.state !== 'missing' || admissionCursor.state !== 'missing')) ||
     (schema === 'absent' &&
       metadataRowCount >
         REMOVED_VIEW_CLEANUP_LEGACY_MAXIMUM_METADATA_ROWS -
           (revision.state === 'missing' && revision.metadataPresent ? 1 : 0)) ||
     (schema === 'compatible' &&
-      (recordedRevision === undefined ||
-        recordedRevision < REMOVED_VIEW_CLEANUP_EXTENSION_REVISION ||
+      (!codeGraphPersistentSchemaSupports(recordedRevision, 'removed-view-cleanup-authority') ||
         !epochSequenceCurrent)) ||
     (schema === 'compatible' && removedViewAuthority !== 'compatible') ||
     (schema === 'compatible' &&
@@ -243,14 +245,12 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
       const revision = yield* sql<{readonly value: string}>`
         SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision' LIMIT 1
       `;
-      const recordedRevision = Number(revision[0]?.value);
-      if (
-        Number.isSafeInteger(recordedRevision) &&
-        recordedRevision > CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
-      ) {
+      const revisionPlan = planCodeGraphPersistentSchemaUpgrade(revision[0]?.value);
+      const recordedRevision = codeGraphPersistentSchemaRevisionValue(revision[0]?.value);
+      if (revisionPlan.state === 'reject-newer') {
         return yield* Effect.fail(
           new CodeGraphStoreError(
-            `Code graph persistent extension schema ${recordedRevision} is newer than ${CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION}.`,
+            `Code graph persistent extension schema ${revisionPlan.value} is newer than ${CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION}.`,
           ),
         );
       }
@@ -267,14 +267,11 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
         `;
         yield* observe?.('added-removed-view-cleanup') ?? Effect.void;
       }
-      if (
-        Number.isSafeInteger(recordedRevision) &&
-        recordedRevision < CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION
-      ) {
+      if (codeGraphPersistentSchemaIsOlder(recordedRevision)) {
         yield* ensureCurrentCodeGraphQueryIndexes(sql);
         yield* observe?.('migrated-query-indexes') ?? Effect.void;
       }
-      if (recordedRevision === 6) {
+      if (revisionPlan.state === 'upgrade' && revisionPlan.route === 'bridge-build-owner-instance') {
         const ownerInstances = PERSISTENT_EXTENSION_TABLES.find(
           table => table.name === 'snapshot_build_owner_instances',
         );
@@ -289,6 +286,19 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
           yield* sql.unsafe(ownerInstances.createSql);
           yield* observe?.('added-build-owner-instance') ?? Effect.void;
         }
+      }
+      if (revisionPlan.state === 'upgrade' && revisionPlan.route === 'extend-checkpoint-import') {
+        const checkpointTables = PERSISTENT_EXTENSION_TABLES.filter(table => table.group === 'checkpoint');
+        for (const table of checkpointTables) {
+          const inspection = yield* persistentExtensionTableInspection(sql, table);
+          if (inspection.exists && !inspection.compatible) {
+            return yield* Effect.fail(
+              new CodeGraphStoreError(`Code graph checkpoint import schema ${table.name} is incompatible.`),
+            );
+          }
+          if (!inspection.exists) yield* sql.unsafe(table.createSql);
+        }
+        yield* observe?.('added-checkpoint-import') ?? Effect.void;
       }
       const legacyBuildOwners = yield* persistentExtensionTableInspection(sql, LEGACY_SNAPSHOT_BUILD_OWNERS_CONTRACT);
       if (legacyBuildOwners.compatible) {
@@ -315,7 +325,7 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
         `);
         yield* observe?.('added-materialization-plan') ?? Effect.void;
       }
-      if (revision[0]?.value === '3') {
+      if (revisionPlan.state === 'upgrade' && revisionPlan.route === 'retire-legacy-references-and-rebuild') {
         const legacyReferences = yield* persistentExtensionTableInspection(sql, LEGACY_BUILDING_REFERENCES_V3_CONTRACT);
         const alreadyRenamed = yield* tableExists(sql, LEGACY_BUILDING_REFERENCES_V3_TABLE);
         if (legacyReferences.compatible && !alreadyRenamed) {
@@ -347,21 +357,13 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
       const inspections = yield* inspectPersistentExtensionTables(sql);
       const extensionSchemaCompatible = inspections.every(inspection => inspection.exists && inspection.compatible);
       if (
-        (recordedRevision === 7 ||
-          recordedRevision === 8 ||
-          recordedRevision === 9 ||
-          recordedRevision === 10 ||
-          recordedRevision === 11 ||
-          recordedRevision === 12 ||
-          recordedRevision === 14 ||
-          recordedRevision === 15 ||
-          recordedRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) &&
+        codeGraphPersistentSchemaSupports(recordedRevision, 'direct-current-contract-adoption') &&
         extensionSchemaCompatible
       ) {
-        if (recordedRevision !== CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION) {
+        if (!codeGraphPersistentSchemaIsCurrent(recordedRevision)) {
           yield* sql`
             INSERT INTO schema_metadata (key, value)
-            VALUES ('persistent_extension_schema_revision', ${String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)})
+            VALUES ('persistent_extension_schema_revision', ${String(CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION)})
             ON CONFLICT(key) DO UPDATE SET value = excluded.value
           `;
           yield* observe?.('recorded-revision') ?? Effect.void;
@@ -384,7 +386,8 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
         inspection => inspection.group === 'cross-repository' && (!inspection.exists || !inspection.compatible),
       );
       const crossRepositorySnapshotAuthorityLost =
-        crossRepositoryAuthorityUnavailable && Number.isSafeInteger(recordedRevision) && recordedRevision >= 7;
+        crossRepositoryAuthorityUnavailable &&
+        codeGraphPersistentSchemaSupports(recordedRevision, 'worktree-reconciliation-authority');
       const incomplete = yield* sql<{readonly count: number}>`
         SELECT COUNT(*) AS count FROM snapshots WHERE state IN ('building', 'failed')
       `;
@@ -441,7 +444,10 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
       // pointer atomically and let the normal snapshot-identity path rebuild it.
       // Revision 4 snapshots remain readable from legacy symbol_terms while the
       // new compact tables are introduced alongside them.
-      if (recordedRevision >= 5 && (incompatibleGroups.has('lexical') || lexicalReadSurfaceMissing)) {
+      if (
+        codeGraphPersistentSchemaSupports(recordedRevision, 'compact-lexical-authority') &&
+        (incompatibleGroups.has('lexical') || lexicalReadSurfaceMissing)
+      ) {
         if (yield* tableExists(sql, 'active_snapshots')) {
           yield* sql`
             DELETE FROM active_snapshots
@@ -474,7 +480,7 @@ const migratePersistentExtensionTables = Effect.fn('codeGraph.migratePersistentE
       yield* observe?.('validated') ?? Effect.void;
       yield* sql`
         INSERT INTO schema_metadata (key, value)
-        VALUES ('persistent_extension_schema_revision', ${String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)})
+        VALUES ('persistent_extension_schema_revision', ${String(CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION)})
         ON CONFLICT(key) DO UPDATE SET value = excluded.value
       `;
       yield* observe?.('recorded-revision') ?? Effect.void;

--- a/src/code_graph/store_schema_receipt.ts
+++ b/src/code_graph/store_schema_receipt.ts
@@ -12,20 +12,22 @@ import {
 } from './store_schema_metadata.js';
 import {tableExists} from './store_session.js';
 import {
-  CODE_GRAPH_EXTRACTOR_GENERATION,
-  CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
-  CODE_GRAPH_SCHEMA_VERSION,
-  CodeGraphStoreError,
-} from './types.js';
+  CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION,
+  CODE_GRAPH_SCHEMA_INITIALIZATION_CURRENT_CONTRACT_REVISION,
+  CODE_GRAPH_SQLITE_SCHEMA_COOKIE,
+  codeGraphPersistentSchemaIsCurrent,
+} from './store/schema_revision.js';
+import {CODE_GRAPH_EXTRACTOR_GENERATION, CODE_GRAPH_SCHEMA_VERSION, CodeGraphStoreError} from './types.js';
 
 // Bump when the full initializer gains a required invariant that is not
 // already represented by a main-schema DDL change or one of the exact mutable
 // metadata observations below.
-export const CODE_GRAPH_SCHEMA_INITIALIZATION_CONTRACT_REVISION = 3;
+export const CODE_GRAPH_SCHEMA_INITIALIZATION_CONTRACT_REVISION =
+  CODE_GRAPH_SCHEMA_INITIALIZATION_CURRENT_CONTRACT_REVISION;
 export const CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_TABLE = 'schema_initialization_receipt';
 // SQLite stores the schema cookie as a signed 32-bit database-header integer.
-export const CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM = 2_147_483_647;
-export const CODE_GRAPH_SQLITE_SCHEMA_VERSION_MINIMUM = -2_147_483_648;
+export const CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM = CODE_GRAPH_SQLITE_SCHEMA_COOKIE.maximum;
+export const CODE_GRAPH_SQLITE_SCHEMA_VERSION_MINIMUM = CODE_GRAPH_SQLITE_SCHEMA_COOKIE.minimum;
 
 /** @internal SQLite advances the signed 32-bit schema cookie with wraparound. */
 export function nextCodeGraphSqliteSchemaVersion(schemaVersion: number): number {
@@ -73,10 +75,10 @@ export function currentCodeGraphSchemaInitializationReceipt(
     observation.observedSqliteSchemaVersion <= CODE_GRAPH_SQLITE_SCHEMA_VERSION_MAXIMUM &&
     observation.receiptContractRevision === CODE_GRAPH_SCHEMA_INITIALIZATION_CONTRACT_REVISION &&
     observation.receiptCoreSchemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
-    observation.receiptPersistentExtensionRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION &&
+    codeGraphPersistentSchemaIsCurrent(observation.receiptPersistentExtensionRevision) &&
     observation.receiptSqliteSchemaVersion === observation.observedSqliteSchemaVersion &&
     observation.metadataCoreSchemaVersion === CODE_GRAPH_SCHEMA_VERSION &&
-    observation.metadataPersistentExtensionRevision === CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION &&
+    codeGraphPersistentSchemaIsCurrent(observation.metadataPersistentExtensionRevision) &&
     Number.isSafeInteger(observation.metadataMinimumExtractorGeneration) &&
     observation.metadataMinimumExtractorGeneration >= CODE_GRAPH_EXTRACTOR_GENERATION &&
     observation.metadataRemovedViewCleanupEpochCurrent &&
@@ -206,7 +208,7 @@ export const recordCodeGraphSchemaInitializationReceipt = Effect.fn('codeGraph.r
           [
             CODE_GRAPH_SCHEMA_INITIALIZATION_CONTRACT_REVISION,
             CODE_GRAPH_SCHEMA_VERSION,
-            CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+            CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION,
             sqliteSchemaVersion,
           ],
         );

--- a/src/code_graph/store_service_checkpoint.ts
+++ b/src/code_graph/store_service_checkpoint.ts
@@ -1,0 +1,155 @@
+import {Effect, Option} from 'effect';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {
+  bindCheckpointImportBuild,
+  readCheckpointImportReceipt,
+  recordReadyCheckpointImportReceipt,
+  selectReadySnapshotByLogicalDigest,
+  stageCheckpointImportRecordPage,
+} from './store_checkpoint_import.js';
+import {activatePersistedFullSnapshot} from './store_activation_persistent.js';
+import {type CodeGraphStoreRuntime} from './store_runtime.js';
+import {type CodeGraphStoreShape} from './store_shape.js';
+import {useDatabase, useReadOnlyDatabase} from './store_session.js';
+import {storeError} from './store_utilities.js';
+
+type CodeGraphStoreCheckpointMethods = Pick<
+  CodeGraphStoreShape,
+  | 'bindCheckpointImportBuild'
+  | 'checkpointImportReceipt'
+  | 'finalizeCheckpointImport'
+  | 'readySnapshotByLogicalDigest'
+  | 'recordCheckpointImportReceipt'
+  | 'stageCheckpointImportRecordPage'
+>;
+
+export function makeCodeGraphStoreCheckpointMethods(runtime: CodeGraphStoreRuntime): CodeGraphStoreCheckpointMethods {
+  const {ensureSchemaInitialized, fs, prepare, scheduleCompletedBuildCleanup, withWriterGate} = runtime;
+  return {
+    bindCheckpointImportBuild: (databasePath, snapshotId, input) =>
+      Effect.gen(function* () {
+        yield* prepare(databasePath);
+        yield* useDatabase(
+          databasePath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            yield* ensureSchemaInitialized(databasePath, sql);
+          }),
+        );
+        return yield* withWriterGate(
+          databasePath,
+          useDatabase(
+            databasePath,
+            Effect.gen(function* () {
+              const sql = yield* SqlClient.SqlClient;
+              return yield* sql.withTransaction(
+                bindCheckpointImportBuild(sql, snapshotId, input, new Date().toISOString()),
+              );
+            }),
+          ),
+        );
+      }).pipe(Effect.mapError(cause => storeError('bind code graph checkpoint import', cause))),
+    checkpointImportReceipt: (databasePath, snapshotId) =>
+      fs.exists(databasePath).pipe(
+        Effect.flatMap(exists =>
+          exists
+            ? useReadOnlyDatabase(
+                databasePath,
+                Effect.gen(function* () {
+                  const sql = yield* SqlClient.SqlClient;
+                  return yield* readCheckpointImportReceipt(sql, snapshotId);
+                }),
+              )
+            : Effect.succeed(undefined),
+        ),
+        Effect.mapError(cause => storeError('load code graph checkpoint import receipt', cause)),
+      ),
+    finalizeCheckpointImport: (databasePath, identity, snapshot, ownerToken, input, options) =>
+      Effect.gen(function* () {
+        yield* prepare(databasePath);
+        yield* useDatabase(
+          databasePath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            yield* ensureSchemaInitialized(databasePath, sql);
+            yield* activatePersistedFullSnapshot(
+              sql,
+              identity,
+              snapshot,
+              ownerToken,
+              options?.reusableBaseReceipt,
+              Option.none(),
+              options?.onProgress,
+              effect => withWriterGate(databasePath, effect),
+              options?.persistentCapacityProtector,
+              undefined,
+              true,
+              input,
+            );
+          }),
+        );
+        yield* scheduleCompletedBuildCleanup(databasePath, snapshot.id);
+      }).pipe(Effect.mapError(cause => storeError('finalize code graph checkpoint import', cause))),
+    readySnapshotByLogicalDigest: (databasePath, repositoryId, logicalDigest, abiDigest) =>
+      fs.exists(databasePath).pipe(
+        Effect.flatMap(exists =>
+          exists
+            ? useReadOnlyDatabase(
+                databasePath,
+                Effect.gen(function* () {
+                  const sql = yield* SqlClient.SqlClient;
+                  return yield* selectReadySnapshotByLogicalDigest(sql, repositoryId, logicalDigest, abiDigest);
+                }),
+              )
+            : Effect.succeed(undefined),
+        ),
+        Effect.mapError(cause => storeError('load code graph checkpoint by logical digest', cause)),
+      ),
+    recordCheckpointImportReceipt: (databasePath, snapshotId, input) =>
+      Effect.gen(function* () {
+        yield* prepare(databasePath);
+        yield* useDatabase(
+          databasePath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            yield* ensureSchemaInitialized(databasePath, sql);
+          }),
+        );
+        return yield* withWriterGate(
+          databasePath,
+          useDatabase(
+            databasePath,
+            Effect.gen(function* () {
+              const sql = yield* SqlClient.SqlClient;
+              return yield* sql.withTransaction(
+                recordReadyCheckpointImportReceipt(sql, snapshotId, input, new Date().toISOString()),
+              );
+            }),
+          ),
+        );
+      }).pipe(Effect.mapError(cause => storeError('record code graph checkpoint import receipt', cause))),
+    stageCheckpointImportRecordPage: (databasePath, snapshotId, ownerToken, page) =>
+      Effect.gen(function* () {
+        yield* prepare(databasePath);
+        yield* useDatabase(
+          databasePath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            yield* ensureSchemaInitialized(databasePath, sql);
+          }),
+        );
+        return yield* withWriterGate(
+          databasePath,
+          useDatabase(
+            databasePath,
+            Effect.gen(function* () {
+              const sql = yield* SqlClient.SqlClient;
+              return yield* sql.withTransaction(
+                stageCheckpointImportRecordPage(sql, snapshotId, ownerToken, page, new Date().toISOString()),
+              );
+            }),
+          ),
+        );
+      }).pipe(Effect.mapError(cause => storeError('stage code graph checkpoint import record page', cause))),
+  };
+}

--- a/src/code_graph/store_service_lifecycle.ts
+++ b/src/code_graph/store_service_lifecycle.ts
@@ -401,6 +401,7 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
       persistentCapacityProtector,
       snapshotPackProvenance,
       materializedFileShardAssociationsComplete,
+      checkpointImportReceipt,
     ) =>
       Effect.gen(function* () {
         const activationPackProvenance = snapshotPackProvenance ?? reusableBaseReceipt?.packProvenance;
@@ -418,6 +419,11 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
             const sql = yield* SqlClient.SqlClient;
             const mode = yield* activationMode(sql);
             if (mode?.mode === 'persisted-delta') {
+              if (checkpointImportReceipt !== undefined) {
+                return yield* Effect.fail(
+                  new CodeGraphStoreError('Checkpoint imports require a self-contained persistent full build.'),
+                );
+              }
               const publication = withWriterGate(
                 databasePath,
                 activatePersistedIncrementalSnapshot(
@@ -453,8 +459,14 @@ export function makeCodeGraphStoreLifecycleMethods(runtime: CodeGraphStoreRuntim
                 persistentCapacityProtector,
                 activationPackProvenance,
                 materializedFileShardAssociationsComplete,
+                checkpointImportReceipt,
               );
               return snapshot.id;
+            }
+            if (checkpointImportReceipt !== undefined) {
+              return yield* Effect.fail(
+                new CodeGraphStoreError('Checkpoint imports require a self-contained persistent full build.'),
+              );
             }
             const publication = withWriterGate(
               databasePath,

--- a/src/code_graph/store_shape.ts
+++ b/src/code_graph/store_shape.ts
@@ -19,6 +19,14 @@ import type {
   CodeGraphAnalysisEdgeAggregatePage,
   CodeGraphAnalysisSummary,
   CodeGraphAnalysisSymbolAggregatePage,
+  CodeGraphCheckpointImportBuildBindingResult,
+  CodeGraphCheckpointImportBuildInput,
+  CodeGraphCheckpointImportFinalizeOptions,
+  CodeGraphCheckpointImportReceipt,
+  CodeGraphCheckpointImportReceiptInput,
+  CodeGraphCheckpointImportReceiptRecordResult,
+  CodeGraphCheckpointImportRecordPage,
+  CodeGraphCheckpointImportRecordPageResult,
   CodeGraphDatabaseHealth,
   CodeGraphDatabaseRepair,
   CodeGraphDirectPersistentCapacityProtector,
@@ -101,6 +109,40 @@ export interface CodeGraphStoreShape {
   readonly shrinkMemory: (databasePath: string) => Effect.Effect<void, CodeGraphStoreError>;
   /** Read-only preflight used before a long-lived process starts an isolated builder. */
   readonly assertRuntimeSchemaCompatible: (databasePath: string) => Effect.Effect<void, CodeGraphStoreError>;
+  readonly bindCheckpointImportBuild: (
+    databasePath: string,
+    snapshotId: string,
+    input: CodeGraphCheckpointImportBuildInput,
+  ) => Effect.Effect<CodeGraphCheckpointImportBuildBindingResult, CodeGraphStoreError>;
+  readonly checkpointImportReceipt: (
+    databasePath: string,
+    snapshotId: string,
+  ) => Effect.Effect<CodeGraphCheckpointImportReceipt | undefined, CodeGraphStoreError>;
+  readonly finalizeCheckpointImport: (
+    databasePath: string,
+    identity: RepositoryIdentity,
+    snapshot: CodeGraphSnapshot,
+    ownerToken: string,
+    input: CodeGraphCheckpointImportReceiptInput,
+    options?: CodeGraphCheckpointImportFinalizeOptions,
+  ) => Effect.Effect<void, CodeGraphStoreError>;
+  readonly readySnapshotByLogicalDigest: (
+    databasePath: string,
+    repositoryId: string,
+    logicalDigest: string,
+    abiDigest?: string,
+  ) => Effect.Effect<CodeGraphSnapshot | undefined, CodeGraphStoreError>;
+  readonly recordCheckpointImportReceipt: (
+    databasePath: string,
+    snapshotId: string,
+    input: CodeGraphCheckpointImportReceiptInput,
+  ) => Effect.Effect<CodeGraphCheckpointImportReceiptRecordResult, CodeGraphStoreError>;
+  readonly stageCheckpointImportRecordPage: (
+    databasePath: string,
+    snapshotId: string,
+    ownerToken: string,
+    page: CodeGraphCheckpointImportRecordPage,
+  ) => Effect.Effect<CodeGraphCheckpointImportRecordPageResult, CodeGraphStoreError>;
   readonly activate: (
     databasePath: string,
     identity: RepositoryIdentity,
@@ -120,6 +162,7 @@ export interface CodeGraphStoreShape {
     persistentCapacityProtector?: CodeGraphDirectPersistentCapacityProtector,
     snapshotPackProvenance?: readonly CodeGraphLanguagePackProvenance[],
     materializedFileShardAssociationsComplete?: boolean,
+    checkpointImportReceipt?: CodeGraphCheckpointImportReceiptInput,
   ) => Effect.Effect<Option.Option<string>, CodeGraphStoreError>;
   readonly activateCleanSnapshotAlias?: (
     databasePath: string,

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -1,11 +1,11 @@
 import type {CodeGraphScanningMetrics, CodeGraphSourceSizeBucket} from './progress_telemetry.js';
 import type {CodeGraphMonikerV1} from './cross_repository/types.js';
 
-export const CODE_GRAPH_SCHEMA_VERSION = 3 as const;
-/** Additive persistent surfaces that preserve the public graph-v3 row contract. */
-export const CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION = 16 as const;
-/** Oldest released additive extension revision that the current reader can safely serve. */
-export const CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION = 6 as const;
+export {
+  CODE_GRAPH_CORE_SCHEMA_VERSION as CODE_GRAPH_SCHEMA_VERSION,
+  CODE_GRAPH_MINIMUM_BACKGROUND_SCHEMA_REVISION as CODE_GRAPH_MINIMUM_BACKGROUND_MIGRATION_REVISION,
+  CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION as CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+} from './store/schema_revision.js';
 export const CODE_GRAPH_RESULT_VERSION = 1 as const;
 export const CODE_GRAPH_EXTRACTOR_GENERATION = 13 as const;
 export const CODE_GRAPH_EXTRACTOR_SET_VERSION = `native-code-graph-${CODE_GRAPH_EXTRACTOR_GENERATION}` as const;

--- a/src/code_graph/workspace.ts
+++ b/src/code_graph/workspace.ts
@@ -35,6 +35,8 @@ interface WorkspaceProjectPathIndex {
 
 const workspaceProjectPathIndexes = new WeakMap<readonly CodeGraphWorkspaceProject[], WorkspaceProjectPathIndex>();
 
+export const CODE_GRAPH_WORKSPACE_MODEL_VERSION = 'code-graph-workspace-set-v2' as const;
+
 export const manifestWorkspaceDetector: CodeGraphWorkspaceDetector = {
   contextFiles: [],
   detect: files => Effect.succeed(discoverManifestWorkspace(files)),
@@ -237,7 +239,7 @@ function mergedWorkspaceFingerprint(
         project.workspaceRoots,
         project.diagnostics,
       ]),
-      version: 'code-graph-workspace-set-v2',
+      version: CODE_GRAPH_WORKSPACE_MODEL_VERSION,
       workspaces: workspaces.map(workspace => [
         workspace.id,
         workspace.buildSystem,

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -118,6 +118,12 @@ import {
   runCodeGraphWorksetTopology,
 } from '../code_graph/commands.js';
 import {
+  runCodeGraphCheckpointExport,
+  runCodeGraphCheckpointImport,
+  runCodeGraphCheckpointInspect,
+  runCodeGraphCheckpointVerify,
+} from '../code_graph/checkpoint/commands.js';
+import {
   CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS,
   CODE_GRAPH_WORKSET_EVIDENCE_MINIMUM_ESTIMATED_TOKENS,
 } from '../code_graph/workset_evidence.js';
@@ -953,6 +959,57 @@ const graphExport = Command.make(
   options => withRuntimeEffect(config => runCodeGraphExport(config, options)),
 ).pipe(Command.withDescription('Stream a portable JSON, GraphML, HTML, or SVG graph snapshot'));
 
+const graphCheckpointExport = Command.make(
+  'export',
+  {
+    cwd: graphBounds.cwd,
+    json: graphBounds.json,
+    output: requiredString('output', 'New checkpoint file; existing files are never overwritten'),
+  },
+  options => withRuntimeEffect(config => runCodeGraphCheckpointExport(config, options)),
+).pipe(Command.withDescription('Export an exact clean ready graph as a deterministic portable checkpoint'));
+
+const graphCheckpointInspect = Command.make(
+  'inspect',
+  {
+    expectedDigest: optionalString('expected-digest', 'Expected SHA-256 artifact digest'),
+    input: requiredString('input', 'Checkpoint file to inspect without inflating logical chunks'),
+    json: graphBounds.json,
+  },
+  options => withRuntimeEffect(() => runCodeGraphCheckpointInspect(options)),
+).pipe(Command.withDescription('Inspect checkpoint metadata and exact framing without inflating graph records'));
+
+const graphCheckpointVerify = Command.make(
+  'verify',
+  {
+    expectedDigest: optionalString('expected-digest', 'Expected SHA-256 artifact digest'),
+    input: requiredString('input', 'Checkpoint file to verify'),
+    json: graphBounds.json,
+  },
+  options => withRuntimeEffect(() => runCodeGraphCheckpointVerify(options)),
+).pipe(Command.withDescription('Fully verify checkpoint framing, chunks, records, ordering, and logical digest'));
+
+const graphCheckpointImport = Command.make(
+  'import',
+  {
+    cwd: graphBounds.cwd,
+    expectedDigest: optionalString('expected-digest', 'Expected SHA-256 artifact digest'),
+    input: requiredString('input', 'Checkpoint file to import'),
+    json: graphBounds.json,
+  },
+  options => withRuntimeEffect(config => runCodeGraphCheckpointImport(config, options)),
+).pipe(Command.withDescription('Verify and safely publish a compatible clean graph checkpoint for this repository'));
+
+const graphCheckpoint = Command.make('checkpoint').pipe(
+  Command.withDescription('Export, inspect, verify, and import portable native graph checkpoints'),
+  Command.withSubcommands([
+    graphCheckpointExport,
+    graphCheckpointInspect,
+    graphCheckpointVerify,
+    graphCheckpointImport,
+  ]),
+);
+
 const graphPurge = Command.make(
   'purge',
   {
@@ -1018,6 +1075,7 @@ const graphCommand = Command.make('graph').pipe(
     graphReport,
     graphWatch,
     graphExport,
+    graphCheckpoint,
     graphCompact,
     graphRemoveView,
     graphPurge,

--- a/src/mcp_server_code_graph.ts
+++ b/src/mcp_server_code_graph.ts
@@ -53,6 +53,7 @@ import {
   renderCodeGraphAnalysis,
   type CodeGraphAnalysisView,
 } from './code_graph/analysis_render.js';
+import {sanitizeCodeGraphPresentationText} from './code_graph/presentation_text.js';
 import {AgentResponseBudgetTooSmallError} from './evaluation/agent-response.js';
 import {codeGraphMcpResponse, compactCodeGraphMcpResult} from './mcp_code_graph_projection.js';
 import {argumentError, mcpErrorResult, requiredText, type RuntimeConfig} from './mcp_server_common.js';
@@ -1096,8 +1097,9 @@ function mutableAnalysisArray<Value>(value: readonly Value[]): Value[] {
 
 function compactCodeGraphAnalysisStrings(value: unknown, observation: CodeGraphMcpAnalysisStringObservation): unknown {
   if (typeof value === 'string') {
-    const compact = compactMcpUtf8Text(value, 512);
-    if (compact !== value) observation.truncated += 1;
+    const sanitized = sanitizeCodeGraphPresentationText(value);
+    const compact = compactMcpUtf8Text(sanitized, 512);
+    if (compact !== sanitized) observation.truncated += 1;
     return compact;
   }
   if (Array.isArray(value)) return value.map(item => compactCodeGraphAnalysisStrings(item, observation));

--- a/test/integration/code-graph.checkpoint-cli.test.ts
+++ b/test/integration/code-graph.checkpoint-cli.test.ts
@@ -361,6 +361,6 @@ async function commit(cwd: string, message: string): Promise<void> {
 function runCli(args: readonly string[]) {
   return execFilePromise(process.execPath, ['src/standalone.ts', ...args], {
     cwd: process.cwd(),
-    env: {...process.env, NO_COLOR: '1'},
+    env: {...process.env, NO_COLOR: '1', THREADNOTE_TELEMETRY: '0'},
   });
 }

--- a/test/integration/code-graph.checkpoint-cli.test.ts
+++ b/test/integration/code-graph.checkpoint-cli.test.ts
@@ -1,0 +1,366 @@
+import {execFile} from '../helpers/node-child-process.js';
+import {mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile} from '../helpers/node-fs-promises.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import {promisify} from '../helpers/node-util.js';
+import {describe, expect, it} from 'vitest';
+import {
+  decodeCodeGraphCheckpointPackV1,
+  encodeCodeGraphCheckpointPackV1,
+} from '../../src/code_graph/checkpoint/pack.js';
+import type {
+  CodeGraphCheckpointMetadataV1,
+  CodeGraphCheckpointRecordV1,
+} from '../../src/code_graph/checkpoint/schema.js';
+
+const execFilePromise = promisify(execFile);
+
+interface CheckpointImportResult {
+  readonly artifact: {readonly digest: string; readonly size: number};
+  readonly imported: 'created' | 'reused';
+  readonly publication: 'activated' | 'rebuilt' | 'stored';
+  readonly snapshotId: string;
+  readonly trust: 'expected-descriptor-verified' | 'local-unverified';
+}
+
+describe('code graph checkpoint CLI', () => {
+  it('exports once, verifies fully, and selects safe receiver publication from Git state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-checkpoint-cli-'));
+    const repository = join(root, 'repository');
+    const artifact = join(root, 'source.cgcp');
+    const importedArtifact = join(root, 'imported.cgcp');
+    const repeatedArtifact = join(root, 'source-repeated.cgcp');
+    const corruptedArtifact = join(root, 'corrupted.cgcp');
+    const forgedDisplayArtifact = join(root, 'forged-display.cgcp');
+    const falseGraphContentArtifact = join(root, 'false-graph-content.cgcp');
+    const falseExtractorArtifact = join(root, 'false-extractor.cgcp');
+    const falsePackArtifact = join(root, 'false-pack.cgcp');
+    try {
+      await mkdir(join(repository, 'src'), {recursive: true});
+      await writeFile(join(repository, 'package.json'), '{"name":"checkpoint-cli","private":true,"type":"module"}\n');
+      await writeFile(join(repository, 'src', 'index.ts'), 'export const base = 1;\n');
+      await git(repository, ['init', '-q', '--initial-branch=main']);
+      await git(repository, ['remote', 'add', 'origin', 'https://github.com/acme/checkpoint-cli.git']);
+      await git(repository, ['add', '.']);
+      await commit(repository, 'base');
+      await git(repository, ['checkout', '-qb', 'checkpoint-source']);
+      await writeFile(join(repository, 'src', 'source.ts'), 'export const checkpointSource = 2;\n');
+      await git(repository, ['add', '.']);
+      await commit(repository, 'checkpoint source');
+
+      const exportHome = join(root, 'export-home');
+      await runCli(['graph', 'index', '--home', exportHome, '--cwd', repository, '--json']);
+      const exported = JSON.parse(
+        (
+          await runCli([
+            'graph',
+            'checkpoint',
+            'export',
+            '--home',
+            exportHome,
+            '--cwd',
+            repository,
+            '--output',
+            artifact,
+            '--json',
+          ])
+        ).stdout,
+      ) as {readonly artifact: {readonly digest: string; readonly size: number}; readonly logicalDigest: string};
+      expect(exported.artifact.digest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+      expect(exported.artifact.size).toBeGreaterThan(0);
+      expect(exported.logicalDigest).toMatch(/^[0-9a-f]{64}$/u);
+
+      const originalBytes = await readFile(artifact);
+      const repeated = JSON.parse(
+        (
+          await runCli([
+            'graph',
+            'checkpoint',
+            'export',
+            '--home',
+            exportHome,
+            '--cwd',
+            repository,
+            '--output',
+            repeatedArtifact,
+            '--json',
+          ])
+        ).stdout,
+      ) as {readonly artifact: {readonly digest: string; readonly size: number}; readonly logicalDigest: string};
+      expect(repeated.artifact).toEqual(exported.artifact);
+      expect(repeated.logicalDigest).toBe(exported.logicalDigest);
+      expect(await readFile(repeatedArtifact)).toEqual(originalBytes);
+      await expect(
+        runCli(['graph', 'checkpoint', 'export', '--home', exportHome, '--cwd', repository, '--output', artifact]),
+      ).rejects.toMatchObject({code: 1, stderr: expect.stringContaining('already exists')});
+      expect(await readFile(artifact)).toEqual(originalBytes);
+
+      const inspected = JSON.parse(
+        (
+          await runCli([
+            'graph',
+            'checkpoint',
+            'inspect',
+            '--input',
+            artifact,
+            '--expected-digest',
+            exported.artifact.digest,
+            '--json',
+          ])
+        ).stdout,
+      ) as {readonly descriptor: {readonly digest: string}; readonly verification: string};
+      const verified = JSON.parse(
+        (
+          await runCli([
+            'graph',
+            'checkpoint',
+            'verify',
+            '--input',
+            artifact,
+            '--expected-digest',
+            exported.artifact.digest,
+            '--json',
+          ])
+        ).stdout,
+      ) as {readonly descriptor: {readonly digest: string}; readonly verification: string};
+      expect(inspected).toMatchObject({
+        descriptor: {digest: exported.artifact.digest},
+        verification: 'artifact-and-framing',
+      });
+      expect(verified).toMatchObject({descriptor: {digest: exported.artifact.digest}, verification: 'full'});
+
+      const decoded = decodeCodeGraphCheckpointPackV1(originalBytes);
+      await writeFile(
+        forgedDisplayArtifact,
+        rewriteCheckpoint(decoded, metadata => ({
+          ...metadata,
+          repository: {...metadata.repository, displayName: 'trusted\nFORGED\u001b]8;;https://invalid.local\u0007'},
+        })),
+      );
+      const safeInspection = await runCli(['graph', 'checkpoint', 'inspect', '--input', forgedDisplayArtifact]);
+      expect(safeInspection.stdout).not.toContain('\nFORGED');
+      expect(safeInspection.stdout).not.toContain('\u001b');
+      expect(safeInspection.stdout).not.toContain('\u0007');
+      expect(safeInspection.stdout).toContain('trusted\\u{000a}FORGED\\u{001b}]8;;https://invalid.local\\u{0007}');
+
+      await writeFile(
+        falseGraphContentArtifact,
+        rewriteCheckpoint(decoded, metadata => ({
+          ...metadata,
+          source: {...metadata.source, graphContentId: `cgc_${'f'.repeat(40)}`},
+        })),
+      );
+      await expect(
+        runCli(['graph', 'checkpoint', 'verify', '--input', falseGraphContentArtifact]),
+      ).rejects.toMatchObject({code: 1, stderr: expect.stringContaining('graph content identity')});
+      const rejectedHome = join(root, 'rejected-home');
+      await expect(
+        runCli([
+          'graph',
+          'checkpoint',
+          'import',
+          '--home',
+          rejectedHome,
+          '--cwd',
+          repository,
+          '--input',
+          falseGraphContentArtifact,
+        ]),
+      ).rejects.toMatchObject({code: 1});
+      expect((await recursiveFiles(rejectedHome)).some(file => file.endsWith('.sqlite'))).toBe(false);
+
+      await writeFile(
+        falseExtractorArtifact,
+        rewriteCheckpoint(decoded, metadata => ({
+          ...metadata,
+          source: {...metadata.source, extractorSet: 'forged-extractor'},
+        })),
+      );
+      await expect(runCli(['graph', 'checkpoint', 'verify', '--input', falseExtractorArtifact])).rejects.toMatchObject({
+        code: 1,
+        stderr: expect.stringContaining('extractor identity'),
+      });
+
+      const packRecordIndex = decoded.records.findIndex(record => record.kind === 'pack-provenance');
+      expect(packRecordIndex).toBeGreaterThanOrEqual(0);
+      await writeFile(
+        falsePackArtifact,
+        rewriteCheckpoint(
+          decoded,
+          metadata => metadata,
+          records =>
+            records.map((record, index) =>
+              index === packRecordIndex && record.kind === 'pack-provenance'
+                ? {...record, resolutionVersion: `${record.resolutionVersion}-forged`}
+                : record,
+            ),
+        ),
+      );
+      await expect(runCli(['graph', 'checkpoint', 'verify', '--input', falsePackArtifact])).rejects.toMatchObject({
+        code: 1,
+        stderr: expect.stringContaining('pack provenance'),
+      });
+      if (process.platform !== 'win32') {
+        const symbolicArtifact = join(root, 'symbolic.cgcp');
+        await symlink(artifact, symbolicArtifact);
+        await expect(
+          runCli(['graph', 'checkpoint', 'inspect', '--input', symbolicArtifact, '--json']),
+        ).rejects.toMatchObject({code: 1, stderr: expect.stringContaining('symbolic link')});
+      }
+
+      const populated = await importCheckpoint(repository, exportHome, artifact, exported.artifact.digest);
+      expect(populated).toMatchObject({imported: 'created', publication: 'activated'});
+      const importedExport = JSON.parse(
+        (
+          await runCli([
+            'graph',
+            'checkpoint',
+            'export',
+            '--home',
+            exportHome,
+            '--cwd',
+            repository,
+            '--output',
+            importedArtifact,
+            '--json',
+          ])
+        ).stdout,
+      ) as {readonly artifact: {readonly digest: string; readonly size: number}; readonly logicalDigest: string};
+      expect(importedExport).toMatchObject({
+        artifact: exported.artifact,
+        logicalDigest: exported.logicalDigest,
+      });
+      expect(await readFile(importedArtifact)).toEqual(originalBytes);
+
+      const exactHome = join(root, 'exact-home');
+      const exact = await importCheckpoint(repository, exactHome, artifact, exported.artifact.digest);
+      const reused = await importCheckpoint(repository, exactHome, artifact, exported.artifact.digest);
+      expect(exact).toMatchObject({
+        imported: 'created',
+        publication: 'activated',
+        trust: 'expected-descriptor-verified',
+      });
+      expect(reused).toMatchObject({
+        artifact: exact.artifact,
+        imported: 'reused',
+        publication: 'activated',
+        snapshotId: exact.snapshotId,
+      });
+
+      await writeFile(join(repository, 'src', 'dirty.ts'), 'export const dirty = true;\n');
+      const dirty = await importCheckpoint(repository, join(root, 'dirty-home'), artifact, exported.artifact.digest);
+      expect(dirty).toMatchObject({imported: 'created', publication: 'rebuilt'});
+      await rm(join(repository, 'src', 'dirty.ts'));
+
+      await writeFile(join(repository, 'src', 'descendant.ts'), 'export const descendant = 3;\n');
+      await git(repository, ['add', '.']);
+      await commit(repository, 'descendant');
+      const descendant = await importCheckpoint(
+        repository,
+        join(root, 'descendant-home'),
+        artifact,
+        exported.artifact.digest,
+      );
+      expect(descendant).toMatchObject({imported: 'created', publication: 'rebuilt'});
+      expect(descendant.snapshotId).not.toBe(exact.snapshotId);
+
+      await git(repository, ['checkout', '-q', 'main']);
+      await writeFile(join(repository, 'src', 'divergent.ts'), 'export const divergent = 4;\n');
+      await git(repository, ['add', '.']);
+      await commit(repository, 'divergent');
+      const divergent = await importCheckpoint(repository, join(root, 'divergent-home'), artifact);
+      expect(divergent).toMatchObject({
+        imported: 'created',
+        publication: 'stored',
+        snapshotId: exact.snapshotId,
+        trust: 'local-unverified',
+      });
+
+      const corrupted = Uint8Array.from(originalBytes);
+      corrupted[corrupted.length - 1] = corrupted[corrupted.length - 1]! ^ 0xff;
+      await writeFile(corruptedArtifact, corrupted);
+      const corruptInspection = JSON.parse(
+        (await runCli(['graph', 'checkpoint', 'inspect', '--input', corruptedArtifact, '--json'])).stdout,
+      ) as {readonly descriptor: {readonly digest: string}; readonly verification: string};
+      expect(corruptInspection.verification).toBe('artifact-and-framing');
+      expect(corruptInspection.descriptor.digest).not.toBe(exported.artifact.digest);
+      await expect(
+        runCli(['graph', 'checkpoint', 'verify', '--input', corruptedArtifact, '--json']),
+      ).rejects.toMatchObject({code: 1});
+    } finally {
+      await rm(root, {force: true, recursive: true});
+    }
+  }, 120_000);
+});
+
+function rewriteCheckpoint(
+  decoded: ReturnType<typeof decodeCodeGraphCheckpointPackV1>,
+  rewriteMetadata: (metadata: CodeGraphCheckpointMetadataV1) => CodeGraphCheckpointMetadataV1,
+  rewriteRecords: (
+    records: readonly CodeGraphCheckpointRecordV1[],
+  ) => readonly CodeGraphCheckpointRecordV1[] = records => records,
+): Uint8Array {
+  const header = decoded.header;
+  const metadata: CodeGraphCheckpointMetadataV1 = {
+    abi: header.abi.input,
+    coverage: header.coverage,
+    repository: header.repository,
+    ...(header.reuse === undefined ? {} : {reuse: header.reuse}),
+    source: header.source,
+  };
+  return encodeCodeGraphCheckpointPackV1(rewriteMetadata(metadata), rewriteRecords(decoded.records)).bytes;
+}
+
+async function recursiveFiles(root: string): Promise<readonly string[]> {
+  try {
+    return await readdir(root, {recursive: true});
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw cause;
+  }
+}
+
+async function importCheckpoint(
+  repository: string,
+  home: string,
+  artifact: string,
+  digest?: string,
+): Promise<CheckpointImportResult> {
+  const result = await runCli([
+    'graph',
+    'checkpoint',
+    'import',
+    '--home',
+    home,
+    '--cwd',
+    repository,
+    '--input',
+    artifact,
+    ...(digest === undefined ? [] : ['--expected-digest', digest]),
+    '--json',
+  ]);
+  return JSON.parse(result.stdout) as CheckpointImportResult;
+}
+
+async function git(cwd: string, args: readonly string[]): Promise<void> {
+  await execFilePromise('git', ['-C', cwd, ...args]);
+}
+
+async function commit(cwd: string, message: string): Promise<void> {
+  await git(cwd, [
+    '-c',
+    'user.name=Threadnote Test',
+    '-c',
+    'user.email=test@threadnote.local',
+    'commit',
+    '-qm',
+    message,
+  ]);
+}
+
+function runCli(args: readonly string[]) {
+  return execFilePromise(process.execPath, ['src/standalone.ts', ...args], {
+    cwd: process.cwd(),
+    env: {...process.env, NO_COLOR: '1'},
+  });
+}

--- a/test/integration/code-graph.checkpoint-projection.test.ts
+++ b/test/integration/code-graph.checkpoint-projection.test.ts
@@ -1,0 +1,156 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {execFileSync} from '../helpers/node-child-process.js';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from '../helpers/node-fs.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe, expect} from 'vitest';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {codeGraphCheckpointAbiInputV1} from '../../src/code_graph/checkpoint/compatibility.js';
+import {
+  CodeGraphCheckpointProjectionError,
+  projectCodeGraphCheckpointV1,
+} from '../../src/code_graph/checkpoint/projection.js';
+import {
+  compareCodeGraphCheckpointRecords,
+  type CodeGraphCheckpointMetadataV1,
+  type CodeGraphCheckpointRecordV1,
+} from '../../src/code_graph/checkpoint/schema.js';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+
+interface ProjectionCapture {
+  readonly metadata: CodeGraphCheckpointMetadataV1;
+  readonly records: readonly CodeGraphCheckpointRecordV1[];
+}
+
+describe('code graph checkpoint projection', () => {
+  effectIt.effect(
+    'projects one clean ready snapshot deterministically across page boundaries',
+    () => {
+      let fixtureRoot: string | undefined;
+      return Effect.gen(function* () {
+        const fixture = createRepository();
+        fixtureRoot = fixture.root;
+        const indexer = yield* CodeGraphIndexer;
+        const path = yield* Path.Path;
+        const store = yield* CodeGraphStore;
+        const indexed = yield* indexer.index({cwd: fixture.repository, threadnoteHome: fixture.home});
+        const databasePath = codeGraphLayout(
+          path,
+          fixture.home,
+          indexed.identity.checkoutId,
+          indexed.identity.worktreeId,
+        ).databasePath;
+        const provenance = yield* store.snapshotPackProvenance(databasePath, indexed.snapshot.id);
+        expect(provenance).toBeDefined();
+        const abi = codeGraphCheckpointAbiInputV1(provenance!);
+
+        const capture = (pageSize: number) => {
+          let metadata: CodeGraphCheckpointMetadataV1 | undefined;
+          const records: CodeGraphCheckpointRecordV1[] = [];
+          return projectCodeGraphCheckpointV1({
+            abi,
+            databasePath,
+            identity: indexed.identity,
+            pageSize,
+            snapshotId: indexed.snapshot.id,
+            writeMetadata: value => Effect.sync(() => (metadata = value)),
+            writeRecords: page => Effect.sync(() => records.push(...page)),
+          }).pipe(
+            Effect.map(summary => {
+              expect(metadata).toBeDefined();
+              expect(summary.counts.file).toBe(indexed.snapshot.fileCount);
+              expect(summary.counts['file-fact']).toBe(summary.counts.file);
+              return {metadata: metadata!, records} satisfies ProjectionCapture;
+            }),
+          );
+        };
+
+        const oneRowPages = yield* capture(1);
+        const maximumPages = yield* capture(1_000);
+        expect(oneRowPages).toEqual(maximumPages);
+        for (let index = 1; index < oneRowPages.records.length; index += 1) {
+          expect(
+            compareCodeGraphCheckpointRecords(oneRowPages.records[index - 1]!, oneRowPages.records[index]!),
+          ).toBeLessThan(0);
+        }
+        expect(oneRowPages.metadata.reuse?.inventory).toBeDefined();
+        expect(oneRowPages.metadata.reuse?.inventory).not.toHaveProperty('environmentFingerprint');
+        for (const file of oneRowPages.metadata.reuse?.inventory?.attributionFiles ?? []) {
+          expect(file).not.toHaveProperty('content');
+          expect(file.blobSize).toBeGreaterThanOrEqual(file.size);
+        }
+
+        writeFileSync(join(fixture.repository, 'src', 'math.ts'), 'export const double = () => 99;\n');
+        const dirtyError = yield* projectCodeGraphCheckpointV1({
+          abi,
+          databasePath,
+          identity: indexed.identity,
+          snapshotId: indexed.snapshot.id,
+          writeMetadata: () => Effect.void,
+          writeRecords: () => Effect.void,
+        }).pipe(Effect.flip);
+        expect(dirtyError).toBeInstanceOf(CodeGraphCheckpointProjectionError);
+        expect(String(dirtyError)).toContain('not clean before checkpoint projection');
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() =>
+            fixtureRoot === undefined ? undefined : rmSync(fixtureRoot, {force: true, recursive: true}),
+          ),
+        ),
+        provideTestLayer(ApplicationLayer),
+        TestClock.withLive,
+      );
+    },
+    60_000,
+  );
+});
+
+function createRepository(): {readonly home: string; readonly repository: string; readonly root: string} {
+  const root = mkdtempSync(join(tmpdir(), 'threadnote-checkpoint-projection-'));
+  const repository = join(root, 'repository');
+  const home = join(root, 'threadnote-home');
+  mkdirSync(join(repository, 'src'), {recursive: true});
+  mkdirSync(home, {recursive: true});
+  writeFileSync(
+    join(repository, 'package.json'),
+    `${JSON.stringify(
+      {
+        dependencies: {'left-pad': '^1.3.0'},
+        name: '@acme/checkpoint-projection',
+        private: true,
+        type: 'module',
+        version: '1.0.0',
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(repository, 'tsconfig.json'),
+    `${JSON.stringify({compilerOptions: {module: 'NodeNext', target: 'ES2022'}, include: ['src']}, null, 2)}\n`,
+  );
+  writeFileSync(join(repository, 'src', 'math.ts'), 'export const double = (value: number): number => value * 2;\n');
+  writeFileSync(join(repository, 'src', 'index.ts'), 'export {double} from "./math.js";\n');
+  git(repository, ['init', '-q']);
+  git(repository, ['remote', 'add', 'origin', 'https://github.com/acme/checkpoint-projection.git']);
+  git(repository, ['add', '.']);
+  git(repository, [
+    '-c',
+    'user.name=Threadnote Test',
+    '-c',
+    'user.email=test@threadnote.local',
+    'commit',
+    '-qm',
+    'checkpoint projection fixture',
+  ]);
+  return {home, repository, root};
+}
+
+function git(cwd: string, args: readonly string[]): void {
+  execFileSync('git', ['-C', cwd, ...args], {stdio: 'pipe'});
+}

--- a/test/unit/code-graph.analysis-render.test.ts
+++ b/test/unit/code-graph.analysis-render.test.ts
@@ -45,6 +45,41 @@ describe('code graph analysis rendering', () => {
     }),
   );
 
+  effectIt.effect('removes repository-controlled terminal and bidi controls from public analysis output', () =>
+    Effect.gen(function* () {
+      const repositoryText = 'danger\u001b\u009b\r\n\u202evalue';
+      const source = analysisSymbol('source-control', repositoryText, 'src/control.ts', {
+        name: repositoryText,
+        qualifiedName: repositoryText,
+      });
+      const target = analysisSymbol('target-control', repositoryText, 'src/control.ts', {
+        name: repositoryText,
+        qualifiedName: repositoryText,
+      });
+      const edge = analysisEdge('edge-control', source, target, 'calls', {
+        confidence: 0.1,
+        sourceName: repositoryText,
+        targetName: repositoryText,
+      });
+      const result = yield* analyzeCodeGraph(pagedAnalysisStore([source, target], [edge]), {
+        databasePath: ':memory:',
+        minimumHubDegree: 1,
+        snapshot: analysisSnapshot([source, target], [edge]),
+      });
+      const rendered = renderCodeGraphAnalysis(result, 'full');
+      const report = renderCodeGraphReport(result, {
+        displayName: repositoryText,
+        repositoryId: 'repository-control',
+      });
+
+      expect(containsUnsafePresentationText(result)).toBe(false);
+      expect(containsUnsafePresentationText(rendered, true)).toBe(false);
+      expect(containsUnsafePresentationText(report, true)).toBe(false);
+      expect(rendered).toContain('danger');
+      expect(report).toContain('danger');
+    }),
+  );
+
   effectIt.effect('renders the confidence audit with provenance and review reasons', () =>
     Effect.gen(function* () {
       const rendered = renderCodeGraphAnalysis(yield* analysisResultFixture(), 'confidence');
@@ -126,4 +161,22 @@ function analysisResultFixture() {
     minimumHubDegree: 1,
     snapshot: analysisSnapshot(symbols, edges),
   });
+}
+
+function containsUnsafePresentationText(value: unknown, allowLineFeed = false): boolean {
+  if (typeof value === 'string') {
+    return Array.from(value).some(character => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return (
+        !(allowLineFeed && codePoint === 0x0a) &&
+        (codePoint <= 0x1f ||
+          (codePoint >= 0x7f && codePoint <= 0x9f) ||
+          (codePoint >= 0x202a && codePoint <= 0x202e) ||
+          (codePoint >= 0x2066 && codePoint <= 0x2069))
+      );
+    });
+  }
+  if (Array.isArray(value)) return value.some(item => containsUnsafePresentationText(item, allowLineFeed));
+  if (value === null || typeof value !== 'object') return false;
+  return Object.values(value).some(item => containsUnsafePresentationText(item, allowLineFeed));
 }

--- a/test/unit/code-graph.checkpoint-authority.test.ts
+++ b/test/unit/code-graph.checkpoint-authority.test.ts
@@ -1,0 +1,105 @@
+import {BunFileSystem, BunPath} from '@effect/platform-bun';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, Layer} from 'effect';
+import {describe, expect} from 'vitest';
+import {sha256HexSync} from '../../src/crypto/sha256.js';
+import {withCodeGraphCheckpointAuthorityVerification} from '../../src/code_graph/checkpoint/authority.js';
+import {codeGraphCheckpointFileFactCacheIdentity} from '../../src/code_graph/checkpoint/file_fact_identity.js';
+import {encodeCodeGraphCheckpointPackV1} from '../../src/code_graph/checkpoint/pack.js';
+import {
+  CODE_GRAPH_CHECKPOINT_PATH_POLICY,
+  CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION,
+  type CodeGraphCheckpointFileFactRecordV1,
+  type CodeGraphCheckpointFileRecordV1,
+  type CodeGraphCheckpointMetadataV1,
+} from '../../src/code_graph/checkpoint/schema.js';
+import {
+  codeGraphContentIdentity,
+  codeGraphExtractorSetIdentityFromPackProvenance,
+} from '../../src/code_graph/graph_identity.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const authorityLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+describe('code graph checkpoint authority', () => {
+  effectIt.effect('orders the private SQLite spool canonically across its Unicode keyset boundary', () =>
+    Effect.gen(function* () {
+      const paths = [
+        ...Array.from({length: 999}, (_, index) => `src/a${index.toString().padStart(4, '0')}.ts`),
+        'src/\ue000.ts',
+        'src/\u{10000}.ts',
+      ];
+      const files = paths.map(fileRecord);
+      const records = files.flatMap(file => [file, factRecord(file.path)]);
+
+      expect(
+        yield* withCodeGraphCheckpointAuthorityVerification(headerFor(files), accept =>
+          accept([...records].reverse()).pipe(Effect.as(records.length)),
+        ),
+      ).toBe(2_002);
+
+      expect(
+        yield* withCodeGraphCheckpointAuthorityVerification(headerFor([]), accept =>
+          accept([]).pipe(Effect.as('empty')),
+        ),
+      ).toBe('empty');
+    }).pipe(provideTestLayer(authorityLayer)),
+  );
+});
+
+function headerFor(records: readonly CodeGraphCheckpointFileRecordV1[]) {
+  const extractorSet = codeGraphExtractorSetIdentityFromPackProvenance([]);
+  const metadata: CodeGraphCheckpointMetadataV1 = {
+    abi: {
+      checkpointSemanticVersion: CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION,
+      graphSchemaVersion: 1,
+      inventoryPolicyVersion: 1,
+      languagePacks: [],
+      lexicalLogicalFormatVersion: 1,
+      pathPolicy: CODE_GRAPH_CHECKPOINT_PATH_POLICY,
+      referenceResolutionVersion: 'resolution-v1',
+      workspaceModelVersion: 'workspace-v1',
+    },
+    coverage: {eligibleFiles: records.length, excludedFiles: 0, reasons: [], state: 'complete'},
+    repository: {
+      caseMode: 'sensitive',
+      displayName: 'authority-ordering-fixture',
+      objectFormat: 'sha1',
+      repositoryId: '0'.repeat(64),
+    },
+    source: {
+      commit: '0'.repeat(40),
+      extractorSet,
+      graphContentId: codeGraphContentIdentity(extractorSet, records),
+    },
+  };
+  return encodeCodeGraphCheckpointPackV1(
+    metadata,
+    records.flatMap(record => [record, factRecord(record.path)]),
+  ).header;
+}
+
+function fileRecord(path: string): CodeGraphCheckpointFileRecordV1 {
+  const contentHash = sha256HexSync(path);
+  return {
+    blobId: contentHash.slice(0, 40),
+    contentHash,
+    kind: 'file',
+    language: 'typescript',
+    mode: '100644',
+    path,
+    size: 0,
+    source: 'commit',
+  };
+}
+
+function factRecord(path: string): CodeGraphCheckpointFileFactRecordV1 {
+  const facts = {diagnostics: [], edges: [], path, symbols: []};
+  return {
+    cacheIdentity: codeGraphCheckpointFileFactCacheIdentity(facts),
+    factRole: 'materialized',
+    facts,
+    kind: 'file-fact',
+    path,
+  };
+}

--- a/test/unit/code-graph.checkpoint-compatibility.test.ts
+++ b/test/unit/code-graph.checkpoint-compatibility.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it} from 'vitest';
+import fc from 'fast-check';
+import {
+  codeGraphCheckpointAbiInputV1,
+  inspectCodeGraphCheckpointCompatibilityV1,
+} from '../../src/code_graph/checkpoint/compatibility.js';
+import {
+  BUILTIN_LANGUAGE_PACK_REGISTRY,
+  codeGraphLanguagePackProvenance,
+} from '../../src/code_graph/languages/registry.js';
+
+const provenance = BUILTIN_LANGUAGE_PACK_REGISTRY.packs.map(codeGraphLanguagePackProvenance);
+
+describe('code graph checkpoint compatibility', () => {
+  it('checks only the language packs active in the checkpoint', () => {
+    const actual = codeGraphCheckpointAbiInputV1(provenance.slice(0, 2));
+
+    expect(inspectCodeGraphCheckpointCompatibilityV1(actual, BUILTIN_LANGUAGE_PACK_REGISTRY)).toEqual({
+      compatible: true,
+      expected: actual,
+    });
+  });
+
+  it('distinguishes unavailable packs from a changed semantic ABI', () => {
+    const actual = codeGraphCheckpointAbiInputV1(provenance.slice(0, 1));
+    const unavailable = {
+      ...actual,
+      languagePacks: [{...actual.languagePacks[0]!, id: 'future-pack'}],
+    };
+    const changed = {...actual, workspaceModelVersion: 'future-workspace-model'};
+
+    expect(inspectCodeGraphCheckpointCompatibilityV1(unavailable, BUILTIN_LANGUAGE_PACK_REGISTRY)).toEqual({
+      code: 'language-pack-unavailable',
+      compatible: false,
+      unavailablePackIds: ['future-pack'],
+    });
+    expect(inspectCodeGraphCheckpointCompatibilityV1(changed, BUILTIN_LANGUAGE_PACK_REGISTRY)).toMatchObject({
+      code: 'abi-mismatch',
+      compatible: false,
+    });
+  });
+
+  it('assembles the same ABI for every input pack order', () => {
+    fc.assert(
+      fc.property(
+        fc.shuffledSubarray(provenance, {minLength: provenance.length, maxLength: provenance.length}),
+        value => {
+          expect(codeGraphCheckpointAbiInputV1(value)).toEqual(codeGraphCheckpointAbiInputV1(provenance));
+        },
+      ),
+      {numRuns: 32},
+    );
+  });
+});

--- a/test/unit/code-graph.checkpoint-import-store.test.ts
+++ b/test/unit/code-graph.checkpoint-import-store.test.ts
@@ -1,0 +1,677 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import fc from 'fast-check';
+import {describe, expect} from 'vitest';
+import {
+  CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION,
+  CodeGraphStore,
+  hydrateCodeGraphCheckpointReusableBaseReceipt,
+  materializedFileShardIdentity,
+  type CodeGraphCheckpointImportBuildInput,
+  type CodeGraphCheckpointImportReceiptInput,
+  type CodeGraphStoreShape,
+} from '../../src/code_graph/store.js';
+import {
+  checkpointStoredFactMatches,
+  validateCodeGraphCheckpointImportReceiptInput,
+} from '../../src/code_graph/store_checkpoint_import.js';
+import {codeGraphCheckpointFileFactCacheIdentity} from '../../src/code_graph/checkpoint/file_fact_identity.js';
+import type {CodeGraphFileFacts, CodeGraphSnapshot, RepositoryIdentity} from '../../src/code_graph/types.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {claimPersistentBuildForTest} from '../helpers/code-graph-build.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {mkdtempSync, rmSync, writeFileSync} from '../helpers/node-fs.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import {Database} from 'bun:sqlite';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {codeGraphCommittedContentHash} from '../../src/code_graph/content_identity.js';
+import {
+  CODE_GRAPH_CHECKPOINT_COMPRESSION_PROFILE,
+  CODE_GRAPH_CHECKPOINT_FORMAT_VERSION,
+  CODE_GRAPH_CHECKPOINT_MEDIA_TYPE,
+  CODE_GRAPH_CHECKPOINT_PATH_POLICY,
+  CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION,
+  CODE_GRAPH_CHECKPOINT_SCHEMA,
+  CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION,
+  emptyCodeGraphCheckpointCounts,
+  type CodeGraphCheckpointHeaderV1,
+} from '../../src/code_graph/checkpoint/schema.js';
+import {CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION} from '../../src/code_graph/inventory_policy.js';
+
+describe('code graph checkpoint import store', () => {
+  effectIt.effect('keeps staged records unreachable and atomically publishes an immutable receipt', () =>
+    TestClock.withLive(
+      withFixture(({databasePath, identity, snapshot, store}) =>
+        Effect.gen(function* () {
+          const ownerToken = yield* claimPersistentBuildForTest(store, databasePath, identity, snapshot);
+          const input = checkpointBuildInput();
+          expect(yield* store.bindCheckpointImportBuild(databasePath, snapshot.id, input)).toEqual({state: 'bound'});
+          expect(yield* store.bindCheckpointImportBuild(databasePath, snapshot.id, input)).toEqual({
+            state: 'already-bound',
+          });
+
+          const page = {
+            batchIndex: 0,
+            digest: {algorithm: 'sha256' as const, digest: 'd'.repeat(64)},
+            records: [
+              {
+                blobId: 'b'.repeat(40),
+                contentHash: 'c'.repeat(64),
+                kind: 'file' as const,
+                language: 'typescript',
+                mode: '100644',
+                path: 'src/value.ts',
+                size: 12,
+                source: 'commit' as const,
+              },
+              {
+                buildSystem: 'node',
+                diagnostics: [],
+                id: 'workspace-root',
+                kind: 'workspace-scope' as const,
+                name: 'checkpoint-import',
+                provenance: 'declared' as const,
+                root: '',
+              },
+            ],
+          };
+          expect(yield* store.stageCheckpointImportRecordPage(databasePath, snapshot.id, ownerToken, page)).toEqual({
+            records: 2,
+            state: 'staged',
+          });
+          expect(yield* store.stageCheckpointImportRecordPage(databasePath, snapshot.id, ownerToken, page)).toEqual({
+            records: 2,
+            state: 'already-staged',
+          });
+          expect(yield* store.readySnapshotById(databasePath, snapshot.id)).toBeUndefined();
+
+          const conflict = yield* Effect.exit(
+            store.stageCheckpointImportRecordPage(databasePath, snapshot.id, ownerToken, {
+              ...page,
+              digest: {...page.digest, digest: 'e'.repeat(64)},
+            }),
+          );
+          expect(conflict._tag).toBe('Failure');
+          expect(yield* store.readySnapshotById(databasePath, snapshot.id)).toBeUndefined();
+
+          const emptyPage = yield* Effect.exit(
+            store.stageCheckpointImportRecordPage(databasePath, snapshot.id, ownerToken, {
+              batchIndex: 1,
+              digest: {...page.digest, digest: '0'.repeat(64)},
+              records: [],
+            }),
+          );
+          expect(emptyPage._tag).toBe('Failure');
+
+          yield* store.finalizeCheckpointImport(databasePath, identity, snapshot, ownerToken, input);
+          expect(yield* store.readySnapshotById(databasePath, snapshot.id)).toMatchObject({
+            id: snapshot.id,
+            state: 'ready',
+          });
+          const receipt = yield* store.checkpointImportReceipt(databasePath, snapshot.id);
+          expect(receipt).toMatchObject({
+            artifact: input.artifact,
+            logical: input.logical,
+            snapshotId: snapshot.id,
+            trust: 'local-unverified',
+          });
+          expect(yield* store.recordCheckpointImportReceipt(databasePath, snapshot.id, input)).toMatchObject({
+            state: 'already-recorded',
+          });
+          expect(
+            yield* store.readySnapshotByLogicalDigest(
+              databasePath,
+              identity.repositoryId,
+              input.logical.digest,
+              input.abi.digest,
+            ),
+          ).toMatchObject({id: snapshot.id});
+
+          const conflictingReceipt = yield* Effect.exit(
+            store.recordCheckpointImportReceipt(databasePath, snapshot.id, {
+              ...input,
+              artifact: {...input.artifact, digest: 'f'.repeat(64)},
+            }),
+          );
+          expect(conflictingReceipt._tag).toBe('Failure');
+          const remaining = yield* store.withSession(
+            databasePath,
+            Effect.gen(function* () {
+              const sql = yield* SqlClient.SqlClient;
+              return yield* sql.unsafe<{
+                readonly batches: number;
+                readonly builds: number;
+                readonly workspace_root: string;
+              }>(
+                `SELECT
+                (SELECT COUNT(*) FROM checkpoint_import_builds WHERE snapshot_id = ?) AS builds,
+                (SELECT COUNT(*) FROM checkpoint_import_batches WHERE snapshot_id = ?) AS batches,
+                (SELECT root FROM workspace_scopes WHERE snapshot_id = ? AND id = 'workspace-root') AS workspace_root`,
+                [snapshot.id, snapshot.id, snapshot.id],
+              );
+            }),
+          );
+          expect(remaining).toEqual([{batches: 0, builds: 0, workspace_root: ''}]);
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'accepts exactly lowercase sha256 receipt identities (property)',
+    {
+      artifactSize: fc.integer({min: 0, max: 10_000_000}),
+      digest: fc
+        .array(fc.constantFrom(...'0123456789abcdef'), {minLength: 64, maxLength: 64})
+        .map(value => value.join('')),
+    },
+    ({artifactSize, digest}) =>
+      Effect.sync(() => {
+        const receipt = checkpointReceiptInput(digest, artifactSize);
+        expect(() => validateCodeGraphCheckpointImportReceiptInput(receipt)).not.toThrow();
+        expect(() =>
+          validateCodeGraphCheckpointImportReceiptInput({
+            ...receipt,
+            artifact: {...receipt.artifact, digest: `A${digest.slice(1)}`},
+          }),
+        ).toThrow('checkpoint import receipt is invalid');
+      }),
+    {fastCheck: {numRuns: 32}},
+  );
+
+  effectIt.effect('rejects internally inconsistent receipt coverage', () =>
+    Effect.sync(() => {
+      const receipt = checkpointReceiptInput();
+      expect(() =>
+        validateCodeGraphCheckpointImportReceiptInput({
+          ...receipt,
+          coverage: {eligibleFiles: 1, excludedFiles: 1, reasons: [], state: 'partial'},
+        }),
+      ).toThrow(/coverage totals/u);
+      expect(() =>
+        validateCodeGraphCheckpointImportReceiptInput({
+          ...receipt,
+          coverage: {
+            eligibleFiles: 1,
+            excludedFiles: 0,
+            reasons: [{bytes: 0, code: 'excluded', files: 0}],
+            state: 'partial',
+          },
+        }),
+      ).toThrow(/coverage totals/u);
+    }),
+  );
+
+  effectIt.effect('binds staged pack provenance to the immutable import plan', () =>
+    TestClock.withLive(
+      withFixture(({databasePath, identity, snapshot, store}) =>
+        Effect.gen(function* () {
+          const ownerToken = yield* claimPersistentBuildForTest(store, databasePath, identity, snapshot);
+          const pack = {
+            cacheIdentity: '4'.repeat(64),
+            derivationIdentity: '5'.repeat(64),
+            id: 'typescript',
+            resolutionDomain: 'typescript',
+            resolutionVersion: 'v1',
+          };
+          const counts = emptyCodeGraphCheckpointCounts();
+          counts['pack-provenance'] = 1;
+          const input = {...checkpointReceiptInput(), batchCount: 1, packProvenance: [pack], recordCounts: counts};
+          yield* store.bindCheckpointImportBuild(databasePath, snapshot.id, input);
+          const staged = yield* Effect.exit(
+            store.stageCheckpointImportRecordPage(databasePath, snapshot.id, ownerToken, {
+              batchIndex: 0,
+              digest: {algorithm: 'sha256', digest: 'd'.repeat(64)},
+              records: [{...pack, kind: 'pack-provenance', resolutionVersion: 'forged'}],
+            }),
+          );
+          expect(staged._tag).toBe('Failure');
+          expect(yield* store.readySnapshotById(databasePath, snapshot.id)).toBeUndefined();
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
+
+  effectIt.effect('reuses semantic cached facts across JSON key order but rejects changed payloads', () =>
+    TestClock.withLive(
+      withFixture(({databasePath, identity, snapshot, store}) =>
+        Effect.gen(function* () {
+          const path = 'src/value.ts';
+          const contentHash = 'c'.repeat(64);
+          const existingJson = JSON.stringify({path, symbols: [], edges: [], diagnostics: []});
+          const file = {
+            blobId: 'b'.repeat(40),
+            contentHash,
+            kind: 'file' as const,
+            language: 'typescript',
+            mode: '100644',
+            path,
+            size: 12,
+            source: 'commit' as const,
+          };
+          const facts = {diagnostics: [], edges: [], path, symbols: []};
+          const cacheIdentity = codeGraphCheckpointFileFactCacheIdentity(facts);
+          const fact = {
+            cacheIdentity,
+            factRole: 'materialized' as const,
+            facts,
+            kind: 'file-fact' as const,
+            path,
+          };
+          const ownerToken = yield* claimPersistentBuildForTest(store, databasePath, identity, snapshot);
+          yield* store.withSession(
+            databasePath,
+            Effect.gen(function* () {
+              const sql = yield* SqlClient.SqlClient;
+              yield* sql`
+                INSERT INTO materialized_file_shards (
+                  id, content_hash, extractor_set, derivation_identity, path_hint, facts_json,
+                  created_at, last_used_at
+                ) VALUES (
+                  ${materializedFileShardIdentity(contentHash, snapshot.extractorSet, cacheIdentity, path)},
+                  ${contentHash}, ${snapshot.extractorSet}, ${cacheIdentity}, ${path}, ${existingJson},
+                  ${'2026-01-01T00:00:00.000Z'}, ${'2026-01-01T00:00:00.000Z'}
+                )
+              `;
+            }),
+          );
+          const input = checkpointFactBuildInput();
+          yield* store.bindCheckpointImportBuild(databasePath, snapshot.id, input);
+          expect(
+            yield* store.stageCheckpointImportRecordPage(databasePath, snapshot.id, ownerToken, {
+              batchIndex: 0,
+              digest: {algorithm: 'sha256', digest: 'd'.repeat(64)},
+              records: [file, fact],
+            }),
+          ).toEqual({records: 2, state: 'staged'});
+          expect(
+            yield* store.withSession(
+              databasePath,
+              Effect.gen(function* () {
+                const sql = yield* SqlClient.SqlClient;
+                const rows = yield* sql<{readonly facts_json: string}>`
+                  SELECT facts_json FROM materialized_file_shards
+                  WHERE content_hash = ${contentHash} AND path_hint = ${path}
+                `;
+                return rows[0]?.facts_json;
+              }),
+            ),
+          ).toBe(existingJson);
+
+          yield* store.withSession(
+            databasePath,
+            Effect.gen(function* () {
+              const sql = yield* SqlClient.SqlClient;
+              yield* sql`
+                UPDATE materialized_file_shards
+                SET facts_json = ${JSON.stringify({...facts, diagnostics: ['forged']})}
+                WHERE content_hash = ${contentHash} AND path_hint = ${path}
+              `;
+            }),
+          );
+
+          const conflictingSnapshot = {
+            ...snapshot,
+            id: `cgsn_${'0'.repeat(40)}-full-${'5'.repeat(16)}`,
+          };
+          const conflictingOwner = yield* claimPersistentBuildForTest(
+            store,
+            databasePath,
+            identity,
+            conflictingSnapshot,
+          );
+          yield* store.bindCheckpointImportBuild(databasePath, conflictingSnapshot.id, input);
+          const conflict = yield* Effect.flip(
+            store.stageCheckpointImportRecordPage(databasePath, conflictingSnapshot.id, conflictingOwner, {
+              batchIndex: 0,
+              digest: {algorithm: 'sha256', digest: 'e'.repeat(64)},
+              records: [file, fact],
+            }),
+          );
+          expect(conflict.message).toBe(`Checkpoint file fact ${path} conflicts with cached content.`);
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'reuses valid cached facts under recursive object-key permutations (property)',
+    {facts: semanticFactArbitrary},
+    ({facts}) =>
+      Effect.sync(() => {
+        const incoming = JSON.stringify(facts);
+        const existing = JSON.stringify(reverseObjectKeys(facts));
+        const reordered = reverseObjectKeys(facts) as CodeGraphFileFacts;
+        expect(existing).not.toBe(incoming);
+        expect(codeGraphCheckpointFileFactCacheIdentity(reordered)).toBe(
+          codeGraphCheckpointFileFactCacheIdentity(facts),
+        );
+        expect(checkpointStoredFactMatches(existing, incoming, facts, facts.path)).toBe(true);
+      }),
+    {fastCheck: {numRuns: 32}},
+  );
+
+  effectIt.effect('adds revision-17 checkpoint tables without retiring revision-16 building snapshots', () =>
+    TestClock.withLive(
+      withFixture(({databasePath, identity, snapshot, store}) =>
+        Effect.gen(function* () {
+          yield* claimPersistentBuildForTest(store, databasePath, identity, snapshot);
+          yield* Effect.sync(() => {
+            const database = new Database(databasePath, {strict: true});
+            try {
+              database.exec('DROP TABLE checkpoint_import_receipts');
+              database.exec('DROP TABLE checkpoint_import_batches');
+              database.exec('DROP TABLE checkpoint_import_builds');
+              database
+                .query("UPDATE schema_metadata SET value = '16' WHERE key = 'persistent_extension_schema_revision'")
+                .run();
+            } finally {
+              database.close(false);
+            }
+          });
+
+          yield* store.initialize(databasePath);
+
+          expect(yield* store.resumableBuildById(databasePath, snapshot.id)).toMatchObject({
+            id: snapshot.id,
+            state: 'building',
+          });
+          const observation = yield* Effect.sync(() => {
+            const database = new Database(databasePath, {readonly: true, strict: true});
+            try {
+              return {
+                revision: database
+                  .query("SELECT value FROM schema_metadata WHERE key = 'persistent_extension_schema_revision'")
+                  .get(),
+                tables: database
+                  .query(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'checkpoint_import_%' ORDER BY name",
+                  )
+                  .all(),
+              };
+            } finally {
+              database.close(false);
+            }
+          });
+          expect(observation.revision).toEqual({value: '17'});
+          expect(observation.tables).toEqual([
+            {name: 'checkpoint_import_batches'},
+            {name: 'checkpoint_import_builds'},
+            {name: 'checkpoint_import_receipts'},
+          ]);
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
+
+  effectIt.effect('hydrates reusable attribution only from verified local Git blobs', () =>
+    TestClock.withLive(
+      Effect.acquireUseRelease(
+        Effect.sync(() => mkdtempSync(join(tmpdir(), 'threadnote-checkpoint-reuse-'))),
+        root =>
+          Effect.gen(function* () {
+            yield* runCommandEffect('git', ['init', '--quiet', root], {timeoutMs: 0});
+            const content = '{"name":"checkpoint-demo"}\n';
+            const compactContent = '{"name":"checkpoint-demo"}';
+            const attributionPath = join(root, 'package.json');
+            yield* Effect.sync(() => writeFileSync(attributionPath, content));
+            const hashed = yield* runCommandEffect('git', ['-C', root, 'hash-object', '-w', 'package.json'], {
+              timeoutMs: 0,
+            });
+            const blobId = hashed.stdout.trim();
+            const identity = repositoryIdentity(root);
+            const header = reusableHeader(
+              identity,
+              blobId,
+              Buffer.byteLength(compactContent),
+              Buffer.byteLength(content),
+            );
+
+            const hydrated = yield* hydrateCodeGraphCheckpointReusableBaseReceipt(identity, header);
+
+            expect(hydrated?.inventory?.attributionFiles).toEqual([
+              expect.objectContaining({blobId, content: compactContent, path: 'package.json', source: 'commit'}),
+            ]);
+            expect(hydrated?.inventory?.environmentFingerprint).toMatch(/^[0-9a-f]{64}$/u);
+
+            const mismatch = yield* Effect.exit(
+              hydrateCodeGraphCheckpointReusableBaseReceipt(identity, {
+                ...header,
+                reuse: {
+                  ...header.reuse!,
+                  inventory: {
+                    ...header.reuse!.inventory!,
+                    attributionFiles: [{...header.reuse!.inventory!.attributionFiles[0]!, contentHash: 'f'.repeat(64)}],
+                  },
+                },
+              }),
+            );
+            expect(mismatch._tag).toBe('Failure');
+
+            const sourceSizeMismatch = yield* Effect.exit(
+              hydrateCodeGraphCheckpointReusableBaseReceipt(identity, {
+                ...header,
+                reuse: {
+                  ...header.reuse!,
+                  inventory: {
+                    ...header.reuse!.inventory!,
+                    attributionFiles: [
+                      {
+                        ...header.reuse!.inventory!.attributionFiles[0]!,
+                        blobSize: header.reuse!.inventory!.attributionFiles[0]!.blobSize + 1,
+                      },
+                    ],
+                  },
+                },
+              }),
+            );
+            expect(sourceSizeMismatch._tag).toBe('Failure');
+          }),
+        root => Effect.sync(() => rmSync(root, {force: true, recursive: true})),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
+});
+
+function withFixture<A, E>(
+  use: (fixture: {
+    readonly databasePath: string;
+    readonly identity: RepositoryIdentity;
+    readonly snapshot: CodeGraphSnapshot;
+    readonly store: CodeGraphStoreShape;
+  }) => Effect.Effect<A, E>,
+) {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => mkdtempSync(join(tmpdir(), 'threadnote-checkpoint-import-'))),
+    root =>
+      Effect.gen(function* () {
+        const store = yield* CodeGraphStore;
+        const identity = repositoryIdentity(root);
+        return yield* use({
+          databasePath: join(root, 'graph-v3.sqlite'),
+          identity,
+          snapshot: checkpointSnapshot(identity),
+          store,
+        });
+      }),
+    root => Effect.sync(() => rmSync(root, {force: true, recursive: true})),
+  );
+}
+
+function repositoryIdentity(root: string): RepositoryIdentity {
+  return {
+    caseMode: 'sensitive',
+    checkoutId: 'c'.repeat(64),
+    displayName: 'checkpoint-import',
+    gitCommonDirectory: root,
+    headCommit: '1'.repeat(40),
+    objectFormat: 'sha1',
+    repoRoot: root,
+    repositoryId: 'a'.repeat(64),
+    worktreeId: '2'.repeat(64),
+  };
+}
+
+function checkpointSnapshot(identity: RepositoryIdentity): CodeGraphSnapshot {
+  return {
+    commit: identity.headCommit,
+    dirty: false,
+    edgeCount: 0,
+    extractorSet: 'native-code-graph-13',
+    fileCount: 1,
+    graphContentId: `cgc_${'3'.repeat(40)}`,
+    id: `cgsn_${'0'.repeat(40)}-full-${'4'.repeat(16)}`,
+    repositoryId: identity.repositoryId,
+    state: 'building',
+    symbolCount: 0,
+    worktreeId: identity.worktreeId,
+  };
+}
+
+function checkpointReceiptInput(digest = '5'.repeat(64), artifactSize = 1_024): CodeGraphCheckpointImportReceiptInput {
+  return {
+    abi: {algorithm: 'sha256', digest: '6'.repeat(64)},
+    artifact: {
+      algorithm: 'sha256',
+      digest,
+      mediaType: 'application/vnd.threadnote.code-graph-checkpoint.v1',
+      size: artifactSize,
+    },
+    baseLogicalDigest: null,
+    coverage: {eligibleFiles: 1, excludedFiles: 0, reasons: [], state: 'complete'},
+    formatVersion: 1,
+    logical: {algorithm: 'sha256', digest: '7'.repeat(64)},
+    source: {
+      commit: '1'.repeat(40),
+      graphContentId: `cgc_${'3'.repeat(40)}`,
+      repositoryId: 'a'.repeat(64),
+    },
+    trust: 'local-unverified',
+  };
+}
+
+function checkpointBuildInput(): CodeGraphCheckpointImportBuildInput {
+  const recordCounts = emptyCodeGraphCheckpointCounts();
+  recordCounts.file = 1;
+  recordCounts['workspace-scope'] = 1;
+  return {...checkpointReceiptInput(), batchCount: 1, packProvenance: [], recordCounts};
+}
+
+function checkpointFactBuildInput(): CodeGraphCheckpointImportBuildInput {
+  const recordCounts = emptyCodeGraphCheckpointCounts();
+  recordCounts.file = 1;
+  recordCounts['file-fact'] = 1;
+  return {...checkpointReceiptInput(), batchCount: 1, packProvenance: [], recordCounts};
+}
+
+const boundedText = fc.string({maxLength: 24, unit: fc.constantFrom(...'abc XYZ-_.')});
+const boundedNonEmptyText = fc.string({minLength: 1, maxLength: 16, unit: fc.constantFrom(...'abcXYZ-_.')});
+const semanticFactArbitrary = fc
+  .record({
+    diagnostics: fc.array(boundedText, {maxLength: 4}),
+    rationale: fc.array(
+      fc.record({
+        documentation: boundedText,
+        line: fc.integer({min: 1, max: 10_000}),
+        marker: boundedNonEmptyText,
+        name: boundedNonEmptyText,
+      }),
+      {maxLength: 4},
+    ),
+  })
+  .map(({diagnostics, rationale}): CodeGraphFileFacts => ({
+    derivationInputs: {rationale},
+    diagnostics,
+    edges: [],
+    path: 'src/value.ts',
+    symbols: [],
+  }));
+
+function reverseObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(reverseObjectKeys);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .reverse()
+      .map(([key, entry]) => [key, reverseObjectKeys(entry)]),
+  );
+}
+
+function reusableHeader(
+  identity: RepositoryIdentity,
+  blobId: string,
+  size: number,
+  blobSize: number,
+): CodeGraphCheckpointHeaderV1 {
+  const counts = emptyCodeGraphCheckpointCounts();
+  return {
+    abi: {
+      algorithm: 'sha256',
+      digest: '8'.repeat(64),
+      input: {
+        checkpointSemanticVersion: CODE_GRAPH_CHECKPOINT_SEMANTIC_VERSION,
+        graphSchemaVersion: 3,
+        inventoryPolicyVersion: CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
+        languagePacks: [],
+        lexicalLogicalFormatVersion: 1,
+        pathPolicy: CODE_GRAPH_CHECKPOINT_PATH_POLICY,
+        referenceResolutionVersion: 'references-v1',
+        workspaceModelVersion: 'workspace-v1',
+      },
+    },
+    chunks: [],
+    compressionProfile: CODE_GRAPH_CHECKPOINT_COMPRESSION_PROFILE,
+    counts,
+    coverage: {eligibleFiles: 0, excludedFiles: 0, reasons: [], state: 'complete'},
+    formatVersion: CODE_GRAPH_CHECKPOINT_FORMAT_VERSION,
+    logical: {algorithm: 'sha256', digest: '9'.repeat(64)},
+    mediaType: CODE_GRAPH_CHECKPOINT_MEDIA_TYPE,
+    recordSchemaVersion: CODE_GRAPH_CHECKPOINT_RECORD_SCHEMA_VERSION,
+    repository: {
+      caseMode: identity.caseMode,
+      displayName: identity.displayName,
+      objectFormat: identity.objectFormat,
+      repositoryId: identity.repositoryId,
+    },
+    reuse: {
+      fileSetFingerprint: 'files',
+      formatVersion: 2,
+      inventory: {
+        attributionFiles: [
+          {
+            blobId,
+            blobSize,
+            contentHash: codeGraphCommittedContentHash(identity.objectFormat, blobId),
+            language: 'json',
+            mode: '100644',
+            path: 'package.json',
+            size,
+            source: 'commit',
+          },
+        ],
+        contract: 'a'.repeat(64),
+        includeOpaqueCorpusAssets: false,
+        policyExclusions: {
+          bytes: 0,
+          files: 0,
+          policyVersion: CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
+          reasons: [],
+        },
+        skipped: 0,
+        version: CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION,
+        workspace: {diagnostics: [], fingerprint: 'workspace', projects: [], workspaces: []},
+      },
+      resolutionSurfaceVersion: 1,
+      workspaceFingerprint: 'workspace',
+    },
+    schema: CODE_GRAPH_CHECKPOINT_SCHEMA,
+    source: {
+      commit: identity.headCommit,
+      extractorSet: 'native-code-graph-13',
+      graphContentId: `cgc_${'3'.repeat(40)}`,
+    },
+  };
+}

--- a/test/unit/code-graph.checkpoint-pack.property.test.ts
+++ b/test/unit/code-graph.checkpoint-pack.property.test.ts
@@ -1,0 +1,416 @@
+import {describe, expect, it} from '@effect/vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {canonicalJson, CanonicalJsonError} from '../../src/code_graph/checkpoint/canonical_json.js';
+import {codeGraphCheckpointFileFactCacheIdentity} from '../../src/code_graph/checkpoint/file_fact_identity.js';
+import {
+  assembleCodeGraphCheckpointPackV1,
+  CodeGraphCheckpointArtifactWriterV1,
+  CodeGraphCheckpointPackError,
+  codeGraphCheckpointReadPlanV1,
+  CodeGraphCheckpointStreamDecoderV1,
+  CodeGraphCheckpointStreamEncoderV1,
+  CodeGraphCheckpointStreamInspectorV1,
+  decodeCodeGraphCheckpointPackV1,
+  encodeCodeGraphCheckpointPackV1,
+  inspectCodeGraphCheckpointPackV1,
+  type CodeGraphCheckpointEncodedPackV1,
+} from '../../src/code_graph/checkpoint/pack.js';
+import {
+  compareCodeGraphCheckpointRecords,
+  parseCodeGraphCheckpointRecordV1,
+  type CodeGraphCheckpointFileFactRecordV1,
+  type CodeGraphCheckpointFileRecordV1,
+  type CodeGraphCheckpointHeaderV1,
+  type CodeGraphCheckpointMetadataV1,
+  type CodeGraphCheckpointRecordV1,
+} from '../../src/code_graph/checkpoint/schema.js';
+
+const SHA256_ZERO = '0'.repeat(64);
+const SHA1_ZERO = '0'.repeat(40);
+const UTF8 = new TextEncoder();
+
+const pathArbitrary = FC.uniqueArray(
+  FC.array(FC.constantFrom('a', 'b', 'Z', '0', '-', '_', '~', '"', 'é', '🙂'), {maxLength: 10, minLength: 1}).map(
+    characters => `src/${characters.join('')}.ts`,
+  ),
+  {maxLength: 18, minLength: 1},
+);
+
+describe('code graph checkpoint canonical JSON', () => {
+  it('uses RFC 8785 primitive spelling and UTF-16 object-key ordering', () => {
+    expect(canonicalJson({z: -0, '\r': 1, '€': 2, '😀': 3})).toBe('{"\\r":1,"z":0,"€":2,"😀":3}');
+  });
+
+  it('pins the portable v1 file-fact identity contract', () => {
+    expect(
+      codeGraphCheckpointFileFactCacheIdentity({
+        diagnostics: [],
+        edges: [],
+        path: 'src/value.ts',
+        symbols: [],
+      }),
+    ).toBe('cgfd_5da64f881d3d24c06474d75175a038e01773ea5e');
+  });
+
+  it('rejects lone surrogates, sparse arrays, accessors, symbols, and extra array properties', () => {
+    expect(() => canonicalJson('\ud800')).toThrow(CanonicalJsonError);
+    expect(() => canonicalJson(new Array(1))).toThrow(CanonicalJsonError);
+
+    const accessor: unknown[] = [];
+    Object.defineProperty(accessor, '0', {enumerable: true, get: () => 'secret'});
+    Object.defineProperty(accessor, 'length', {value: 1});
+    expect(() => canonicalJson(accessor)).toThrow(CanonicalJsonError);
+
+    const extra = ['value'];
+    Object.defineProperty(extra, 'extra', {enumerable: true, value: true});
+    expect(() => canonicalJson(extra)).toThrow(CanonicalJsonError);
+
+    const symbolic = ['value'];
+    Object.defineProperty(symbolic, Symbol('extra'), {enumerable: true, value: true});
+    expect(() => canonicalJson(symbolic)).toThrow(CanonicalJsonError);
+  });
+
+  it.prop(
+    'gives recursively reordered file facts one identity and separates semantic changes',
+    {
+      diagnostics: FC.array(FC.string({maxLength: 20}), {maxLength: 4}),
+      path: pathArbitrary.map(paths => paths[0]!),
+    },
+    ({diagnostics, path}) => {
+      const facts = {derivationInputs: {rationale: []}, diagnostics, edges: [], path, symbols: []};
+      const reordered = {
+        symbols: [],
+        path,
+        edges: [],
+        diagnostics,
+        derivationInputs: {rationale: []},
+      };
+      expect(codeGraphCheckpointFileFactCacheIdentity(reordered)).toBe(codeGraphCheckpointFileFactCacheIdentity(facts));
+      expect(codeGraphCheckpointFileFactCacheIdentity({...facts, diagnostics: [...diagnostics, 'changed']})).not.toBe(
+        codeGraphCheckpointFileFactCacheIdentity(facts),
+      );
+    },
+    {fastCheck: {numRuns: 40}},
+  );
+});
+
+describe('code graph checkpoint pack', () => {
+  it.prop(
+    'is byte-deterministic across arbitrary input permutations and fully round-trips Unicode paths',
+    {paths: pathArbitrary},
+    ({paths}) => {
+      const canonicalRecords = recordsFor(paths);
+      const reversedRecords = [...canonicalRecords].reverse();
+      const first = encodeCodeGraphCheckpointPackV1(metadataFor(paths.length), canonicalRecords, {
+        limits: {targetUncompressedChunkBytes: 700},
+      });
+      const second = encodeCodeGraphCheckpointPackV1(metadataFor(paths.length), reversedRecords, {
+        limits: {targetUncompressedChunkBytes: 700},
+      });
+
+      expect(second.bytes).toEqual(first.bytes);
+      expect(second.descriptor).toEqual(first.descriptor);
+      const decoded = decodeCodeGraphCheckpointPackV1(first.bytes, {expectedDescriptor: first.descriptor});
+      expect(decoded.records).toEqual([...canonicalRecords].sort(compareCodeGraphCheckpointRecords));
+      expect(decoded.verification).toBe('full');
+    },
+    {fastCheck: {numRuns: 50}},
+  );
+
+  it.prop(
+    'accepts every input segmentation in both full verification and non-inflating inspection',
+    {
+      paths: pathArbitrary,
+      width: FC.integer({max: 97, min: 1}),
+    },
+    ({paths, width}) => {
+      const pack = encodeCodeGraphCheckpointPackV1(metadataFor(paths.length), recordsFor(paths), {
+        limits: {targetUncompressedChunkBytes: 600},
+      });
+      const verifiedChunks: number[] = [];
+      const decoder = new CodeGraphCheckpointStreamDecoderV1({
+        expectedDescriptor: pack.descriptor,
+        onVerifiedChunk: chunk => verifiedChunks.push(chunk.descriptor.ordinal),
+      });
+      const inspector = new CodeGraphCheckpointStreamInspectorV1({expectedDescriptor: pack.descriptor});
+      for (let offset = 0; offset < pack.bytes.byteLength; offset += width) {
+        const bytes = pack.bytes.subarray(offset, offset + width);
+        decoder.push(bytes);
+        inspector.push(bytes);
+      }
+
+      expect(decoder.finish().verification).toBe('full');
+      expect(inspector.finish().verification).toBe('artifact-and-framing');
+      expect(verifiedChunks).toEqual(pack.header.chunks.map(chunk => chunk.ordinal));
+    },
+    {fastCheck: {numRuns: 35}},
+  );
+
+  it('spools and replays independently bounded chunks through the public two-pass API', () => {
+    const paths = ['src/a.ts', 'src/b.ts', 'src/c.ts'];
+    const chunks: {readonly bytes: Uint8Array; readonly ordinal: number}[] = [];
+    const encoder = new CodeGraphCheckpointStreamEncoderV1(metadataFor(paths.length), {
+      limits: {targetUncompressedChunkBytes: 500},
+    });
+    const sorted = recordsFor(paths).sort(compareCodeGraphCheckpointRecords);
+    encoder.write(sorted.slice(0, 2), chunk => chunks.push(chunk));
+    encoder.write(sorted.slice(2), chunk => chunks.push(chunk));
+    const prepared = encoder.finish(chunk => chunks.push(chunk));
+    const plan = codeGraphCheckpointReadPlanV1(prepared.header);
+
+    expect(plan.prefixBytes).toBe(prepared.prefix.byteLength);
+    expect(plan.chunks.map(chunk => chunk.frameBytes)).toEqual(chunks.map(chunk => chunk.bytes.byteLength));
+    const writer = new CodeGraphCheckpointArtifactWriterV1(prepared);
+    const pieces = [writer.prefix, ...chunks.map(chunk => writer.write(chunk))];
+    const descriptor = writer.finish();
+    const assembled = assembleCodeGraphCheckpointPackV1(prepared, chunks);
+    expect(assembled.bytes).toEqual(join(pieces));
+    expect(assembled.descriptor).toEqual(descriptor);
+    expect(decodeCodeGraphCheckpointPackV1(assembled.bytes).records).toEqual(sorted);
+  });
+
+  it('keeps inspection non-inflating while full verification rejects corrupt gzip data', () => {
+    const pack = fixturePack();
+    const corrupted = pack.bytes.slice();
+    corrupted[corrupted.byteLength - 1] ^= 1;
+
+    expect(inspectCodeGraphCheckpointPackV1(corrupted).verification).toBe('artifact-and-framing');
+    expect(() => decodeCodeGraphCheckpointPackV1(corrupted)).toThrow(CodeGraphCheckpointPackError);
+  });
+
+  it('rejects concatenated gzip members even when framing and logical descriptors are self-consistent', () => {
+    const pack = fixturePack();
+    const concatenated = concatenateFirstGzipMember(pack);
+
+    expect(inspectCodeGraphCheckpointPackV1(concatenated).verification).toBe('artifact-and-framing');
+    expect(() => decodeCodeGraphCheckpointPackV1(concatenated)).toThrow(/concatenated gzip members/u);
+  });
+
+  it('rejects truncation, trailing bytes, descriptor mismatch, invalid magic, and hostile declared bounds', () => {
+    const pack = fixturePack();
+    expect(() => inspectCodeGraphCheckpointPackV1(pack.bytes.subarray(0, pack.bytes.byteLength - 1))).toThrow(
+      CodeGraphCheckpointPackError,
+    );
+    expect(() => inspectCodeGraphCheckpointPackV1(join([pack.bytes, Uint8Array.of(0)]))).toThrow(/trailing/u);
+    expect(() => decodeCodeGraphCheckpointPackV1(pack.bytes, {expectedDigest: `sha256:${'f'.repeat(64)}`})).toThrow(
+      /expected digest/u,
+    );
+
+    const badMagic = pack.bytes.slice();
+    badMagic[0] ^= 1;
+    expect(() => inspectCodeGraphCheckpointPackV1(badMagic)).toThrow(/magic/u);
+    expect(() => inspectCodeGraphCheckpointPackV1(pack.bytes, {limits: {maximumHeaderBytes: 16}})).toThrow(/header/u);
+    expect(() => decodeCodeGraphCheckpointPackV1(pack.bytes, {limits: {maximumRecords: 1}})).toThrow(/record/u);
+  });
+
+  it('rejects unknown kinds, unsafe paths, duplicate identities, unsorted streams, and incomplete fact coverage', () => {
+    expect(() => parseCodeGraphCheckpointRecordV1({kind: 'future-kind'})).toThrow(/Unknown/u);
+    expect(() => parseCodeGraphCheckpointRecordV1({...fileRecord('../escape.ts'), path: '../escape.ts'})).toThrow(
+      /safe repository/u,
+    );
+    expect(() =>
+      parseCodeGraphCheckpointRecordV1({
+        ...factRecord('src/a.ts'),
+        facts: {diagnostics: [], edges: [], path: 'src/a.ts', symbols: [{unexpected: true}]},
+      }),
+    ).toThrow(/File-fact payload is invalid/u);
+    expect(() =>
+      parseCodeGraphCheckpointRecordV1({
+        ...factRecord('src/a.ts'),
+        cacheIdentity: `cgfd_${'f'.repeat(40)}`,
+      }),
+    ).toThrow(/cache identity does not match/u);
+    expect(() =>
+      encodeCodeGraphCheckpointPackV1(metadataFor(2), [
+        fileRecord('src/a.ts'),
+        fileRecord('src/a.ts'),
+        factRecord('src/a.ts'),
+        factRecord('src/b.ts'),
+      ]),
+    ).toThrow(/duplicate/u);
+
+    const unsorted = new CodeGraphCheckpointStreamEncoderV1(metadataFor(1));
+    expect(() =>
+      unsorted.write([factRecord('src/a.ts'), fileRecord('src/a.ts')], () => {
+        throw new Error('No chunk should be emitted.');
+      }),
+    ).toThrow(/canonical order/u);
+
+    const missingFact = new CodeGraphCheckpointStreamEncoderV1(metadataFor(1));
+    missingFact.write([fileRecord('src/a.ts')], () => undefined);
+    expect(() => missingFact.finish(() => undefined)).toThrow(/materialized fact/u);
+  });
+
+  it('binds portable attribution context to an exact graph file record', () => {
+    const path = 'src/a.ts';
+    const metadata = metadataWithAttribution(path);
+    expect(() => encodeCodeGraphCheckpointPackV1(metadata, recordsFor([path]))).not.toThrow();
+    expect(() =>
+      encodeCodeGraphCheckpointPackV1(
+        {
+          ...metadata,
+          reuse: {
+            ...metadata.reuse!,
+            inventory: {
+              ...metadata.reuse!.inventory!,
+              attributionFiles: [
+                {...metadata.reuse!.inventory!.attributionFiles[0]!, blobSize: UTF8.encode(path).byteLength + 1},
+              ],
+            },
+          },
+        },
+        recordsFor([path]),
+      ),
+    ).toThrow(/attribution context does not match its file record/u);
+    expect(() =>
+      encodeCodeGraphCheckpointPackV1(
+        {
+          ...metadata,
+          reuse: {
+            ...metadata.reuse!,
+            inventory: {
+              ...metadata.reuse!.inventory!,
+              attributionFiles: [{...metadata.reuse!.inventory!.attributionFiles[0]!, path: 'src/missing.ts'}],
+            },
+          },
+        },
+        recordsFor([path]),
+      ),
+    ).toThrow(/not covered by exact graph file records/u);
+  });
+
+  it('rejects a mutated prepared spool before publishing an artifact descriptor', () => {
+    const chunks: {bytes: Uint8Array; ordinal: number}[] = [];
+    const encoder = new CodeGraphCheckpointStreamEncoderV1(metadataFor(1));
+    encoder.write(recordsFor(['src/a.ts']).sort(compareCodeGraphCheckpointRecords), chunk => chunks.push(chunk));
+    const prepared = encoder.finish(chunk => chunks.push(chunk));
+    const writer = new CodeGraphCheckpointArtifactWriterV1(prepared);
+    const mutated = chunks[0]!.bytes.slice();
+    mutated[mutated.byteLength - 1] ^= 1;
+    writer.write(mutated);
+    expect(() => writer.finish()).toThrow(/spool digest/u);
+  });
+});
+
+function metadataFor(eligibleFiles: number): CodeGraphCheckpointMetadataV1 {
+  return {
+    abi: {
+      checkpointSemanticVersion: 1,
+      graphSchemaVersion: 1,
+      inventoryPolicyVersion: 1,
+      languagePacks: [],
+      lexicalLogicalFormatVersion: 1,
+      pathPolicy: 'repository-relative-posix-v1',
+      referenceResolutionVersion: 'resolution-v1',
+      workspaceModelVersion: 'workspace-v1',
+    },
+    coverage: {eligibleFiles, excludedFiles: 0, reasons: [], state: 'complete'},
+    repository: {
+      caseMode: 'sensitive',
+      displayName: 'checkpoint-fixture',
+      objectFormat: 'sha1',
+      repositoryId: SHA256_ZERO,
+    },
+    source: {
+      commit: SHA1_ZERO,
+      extractorSet: 'typescript-v1',
+      graphContentId: `cgc_${SHA1_ZERO}`,
+    },
+  };
+}
+
+function metadataWithAttribution(path: string): CodeGraphCheckpointMetadataV1 {
+  return {
+    ...metadataFor(1),
+    reuse: {
+      fileSetFingerprint: SHA256_ZERO,
+      formatVersion: 2,
+      inventory: {
+        attributionFiles: [
+          {
+            blobId: SHA1_ZERO,
+            blobSize: UTF8.encode(path).byteLength,
+            contentHash: SHA256_ZERO,
+            language: 'typescript',
+            mode: '100644',
+            path,
+            size: 0,
+            source: 'commit',
+          },
+        ],
+        contract: SHA256_ZERO,
+        includeOpaqueCorpusAssets: false,
+        policyExclusions: {bytes: 0, files: 0, policyVersion: 1, reasons: []},
+        skipped: 0,
+        version: 2,
+        workspace: {diagnostics: [], fingerprint: SHA256_ZERO, projects: [], workspaces: []},
+      },
+      resolutionSurfaceVersion: 1,
+      workspaceFingerprint: SHA256_ZERO,
+    },
+  };
+}
+
+function recordsFor(paths: readonly string[]): CodeGraphCheckpointRecordV1[] {
+  return paths.flatMap(path => [fileRecord(path), factRecord(path)]);
+}
+
+function fileRecord(path: string): CodeGraphCheckpointFileRecordV1 {
+  return {
+    blobId: SHA1_ZERO,
+    contentHash: SHA256_ZERO,
+    kind: 'file',
+    language: 'typescript',
+    mode: '100644',
+    path,
+    size: UTF8.encode(path).byteLength,
+    source: 'commit',
+  };
+}
+
+function factRecord(path: string): CodeGraphCheckpointFileFactRecordV1 {
+  const facts = {diagnostics: [], edges: [], path, symbols: []};
+  return {
+    cacheIdentity: codeGraphCheckpointFileFactCacheIdentity(facts),
+    factRole: 'materialized',
+    facts,
+    kind: 'file-fact',
+    path,
+  };
+}
+
+function fixturePack(): CodeGraphCheckpointEncodedPackV1 {
+  return encodeCodeGraphCheckpointPackV1(metadataFor(1), recordsFor(['src/a.ts']));
+}
+
+function concatenateFirstGzipMember(pack: CodeGraphCheckpointEncodedPackV1): Uint8Array {
+  const originalHeaderBytes = UTF8.encode(canonicalJson(pack.header)).byteLength;
+  const payloadOffset = 24 + originalHeaderBytes + 52;
+  const originalPayload = pack.bytes.subarray(payloadOffset);
+  const payload = join([originalPayload, originalPayload]);
+  const chunk = pack.header.chunks[0]!;
+  const header: CodeGraphCheckpointHeaderV1 = {
+    ...pack.header,
+    chunks: [{...chunk, compressedBytes: payload.byteLength}],
+  };
+  const headerBytes = UTF8.encode(canonicalJson(header));
+  const prelude = new Uint8Array(24);
+  prelude.set(pack.bytes.subarray(0, 16));
+  const preludeView = new DataView(prelude.buffer);
+  preludeView.setUint32(16, 1, false);
+  preludeView.setUint32(20, headerBytes.byteLength, false);
+  const frame = new Uint8Array(52);
+  frame.set(pack.bytes.subarray(24 + originalHeaderBytes, payloadOffset));
+  new DataView(frame.buffer).setUint32(8, payload.byteLength, false);
+  return join([prelude, headerBytes, frame, payload]);
+}
+
+function join(parts: readonly Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(parts.reduce((total, part) => total + part.byteLength, 0));
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.byteLength;
+  }
+  return output;
+}

--- a/test/unit/code-graph.checkpoint-projection.test.ts
+++ b/test/unit/code-graph.checkpoint-projection.test.ts
@@ -1,0 +1,106 @@
+import {describe, expect, it} from '@effect/vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {
+  CODE_GRAPH_CHECKPOINT_GIT_PATHSPEC_BYTES_MAXIMUM,
+  CodeGraphCheckpointProjectionError,
+  codeGraphCheckpointCoverage,
+  codeGraphCheckpointGitPathBatches,
+  parseGitTreeEntries,
+} from '../../src/code_graph/checkpoint/projection.js';
+import {CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION} from '../../src/code_graph/inventory_policy.js';
+
+const safePathSegment = FC.string({
+  maxLength: 64,
+  minLength: 1,
+  unit: FC.constantFrom(...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-'),
+}).filter(segment => segment !== '.' && segment !== '..');
+
+const safePath = FC.array(safePathSegment, {maxLength: 8, minLength: 1}).map(segments => segments.join('/'));
+
+describe('code graph checkpoint projection', () => {
+  it.prop(
+    'partitions Git pathspecs without loss, reordering, empty pages, or byte-budget overruns',
+    {paths: FC.uniqueArray(safePath, {maxLength: 500})},
+    ({paths}) => {
+      const files = paths.map((path, ordinal) => ({ordinal, path}));
+      const batches = codeGraphCheckpointGitPathBatches(files);
+
+      expect(batches.flat()).toEqual(files);
+      expect(batches.every(batch => batch.length > 0)).toBe(true);
+      for (const batch of batches) {
+        expect(argvPathBytes(batch.map(file => file.path))).toBeLessThanOrEqual(
+          CODE_GRAPH_CHECKPOINT_GIT_PATHSPEC_BYTES_MAXIMUM,
+        );
+      }
+    },
+    {fastCheck: {numRuns: 150}},
+  );
+
+  it('keeps the normal 1,000-file page within two bounded Git processes', () => {
+    const files = Array.from({length: 1_000}, (_, index) => ({
+      path: `packages/example/src/generated/module-${index.toString().padStart(4, '0')}.ts`,
+    }));
+    const batches = codeGraphCheckpointGitPathBatches(files);
+
+    expect(batches.length).toBeLessThanOrEqual(2);
+    expect(batches.flat()).toEqual(files);
+  });
+
+  it.prop(
+    'accounts for every skipped file while preserving unknown non-policy bytes explicitly',
+    {
+      eligibleFiles: FC.integer({max: 1_000_000, min: 0}),
+      policyBytes: FC.integer({max: 1_000_000_000, min: 0}),
+      policyFiles: FC.integer({max: 100_000, min: 0}),
+      residualFiles: FC.integer({max: 100_000, min: 0}),
+    },
+    ({eligibleFiles, policyBytes, policyFiles, residualFiles}) => {
+      const coverage = codeGraphCheckpointCoverage(eligibleFiles, {
+        policyExclusions: {
+          bytes: policyBytes,
+          files: policyFiles,
+          policyVersion: CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
+          reasons: [{bytes: policyBytes, files: policyFiles, reason: 'svg'}],
+        },
+        skipped: policyFiles + residualFiles,
+      });
+
+      expect(coverage.eligibleFiles).toBe(eligibleFiles);
+      expect(coverage.excludedFiles).toBe(policyFiles + residualFiles);
+      expect(coverage.reasons.reduce((total, reason) => total + reason.files, 0)).toBe(coverage.excludedFiles);
+      expect(coverage.state).toBe(coverage.excludedFiles === 0 ? 'complete' : 'partial');
+      expect(coverage.reasons.find(reason => reason.code === 'inventory-other')?.bytes ?? 0).toBe(0);
+    },
+    {fastCheck: {numRuns: 200}},
+  );
+
+  it('parses exact NUL-framed Git tree metadata for both object formats', () => {
+    const sha1 = 'a'.repeat(40);
+    const sha256 = 'b'.repeat(64);
+    expect(parseGitTreeEntries(new TextEncoder().encode(`100644\tblob\t${sha1}\t12\tsrc/a file.ts\0`), 'sha1')).toEqual(
+      new Map([['src/a file.ts', {blobId: sha1, mode: '100644', path: 'src/a file.ts', size: 12}]]),
+    );
+    expect(parseGitTreeEntries(new TextEncoder().encode(`100755\tblob\t${sha256}\t7\tbin/tool\0`), 'sha256')).toEqual(
+      new Map([['bin/tool', {blobId: sha256, mode: '100755', path: 'bin/tool', size: 7}]]),
+    );
+  });
+
+  it('rejects missing terminators, non-blobs, unsafe paths, and wrong object widths', () => {
+    const cases = [
+      `100644\tblob\t${'a'.repeat(40)}\t1\tsrc/a.ts`,
+      `100644\ttree\t${'a'.repeat(40)}\t1\tsrc/a.ts\0`,
+      `100644\tblob\t${'a'.repeat(40)}\t1\t../escape.ts\0`,
+      `100644\tblob\t${'a'.repeat(64)}\t1\tsrc/a.ts\0`,
+    ];
+    for (const value of cases) {
+      expect(() => parseGitTreeEntries(new TextEncoder().encode(value), 'sha1')).toThrow(
+        CodeGraphCheckpointProjectionError,
+      );
+    }
+  });
+});
+
+function argvPathBytes(paths: readonly string[]): number {
+  const encoder = new TextEncoder();
+  return paths.reduce((total, path) => total + encoder.encode(path).byteLength + 1, 0);
+}

--- a/test/unit/code-graph.citation-schema-repair.test.ts
+++ b/test/unit/code-graph.citation-schema-repair.test.ts
@@ -198,7 +198,7 @@ describe('code graph snapshot-file citation schema repair', () => {
     }).pipe(provideTestLayer(ApplicationLayer)),
   );
 
-  effectIt.effect('rolls back a released revision-6 alias migration before publishing revision 16', () =>
+  effectIt.effect('rolls back a released revision-6 alias migration before publishing the current revision', () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -307,14 +307,13 @@ describe('code graph snapshot-file citation schema repair', () => {
         yield* fs.writeFile(spool, new Uint8Array([1]));
         expect(yield* store.diagnose(databasePath)).toMatchObject({
           buildingSnapshots: 1,
-          integrity: 'incompatible',
-          persistentExtensionSchemaRevision: CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
+          integrity: 'migration-pending',
+          persistentExtensionSchemaRevision: 16,
           snapshotFileCitationSchema:
             aliasState === 'released-absent'
               ? 'released-absent-with-predecessor-authority'
               : 'column-only-with-predecessor-authority',
         });
-
         const preview = yield* repairCodeGraphIndexes(home, true, undefined, undefined, {
           migrateSchema: true,
           mode: 'deep',

--- a/test/unit/code-graph.fact-storage.property.test.ts
+++ b/test/unit/code-graph.fact-storage.property.test.ts
@@ -113,4 +113,90 @@ describe('compact code graph fact storage', () => {
       decodeStoredCodeGraphFact(JSON.stringify({...envelope, payload: `${envelope.payload as string}\n`})),
     ).toThrow(/malformed|base64/);
   });
+
+  it('rejects malformed nested fact shapes at both persistence and decode boundaries', () => {
+    fc.assert(
+      fc.property(fc.integer({max: 6, min: 0}), mutation => {
+        const facts = richFacts();
+        const candidate = structuredClone(facts) as unknown as Record<string, unknown>;
+        const symbols = candidate.symbols as Array<Record<string, unknown>>;
+        const edges = candidate.edges as Array<Record<string, unknown>>;
+        const references = candidate.references as Array<Record<string, unknown>>;
+        switch (mutation) {
+          case 0:
+            symbols[0]!.unexpected = true;
+            break;
+          case 1:
+            symbols[0]!.span = {...(symbols[0]!.span as object), line: 0};
+            break;
+          case 2:
+            edges[0]!.confidence = 2;
+            break;
+          case 3:
+            edges[0]!.relation = 'future-relation';
+            break;
+          case 4:
+            references[0]!.lookupTiers = [['valid'], [1]];
+            break;
+          case 5:
+            references[0]!.evidencePath = '../escape.ts';
+            break;
+          case 6:
+            candidate.derivationInputs = {rationale: [{documentation: '', line: -1, marker: 'why', name: 'x'}]};
+            break;
+        }
+        expect(() => serializeBoundedCodeGraphFact(candidate as unknown as CodeGraphFileFacts)).toThrow();
+        expect(() => decodeStoredCodeGraphFact(JSON.stringify(candidate))).toThrow();
+      }),
+      {numRuns: 50},
+    );
+  });
 });
+
+function richFacts(): CodeGraphFileFacts {
+  const span = {column: 1, endColumn: 2, endLine: 1, line: 1};
+  return {
+    diagnostics: [],
+    edges: [
+      {
+        confidence: 1,
+        evidencePath: 'src/rich.ts',
+        evidenceSpan: span,
+        id: 'edge-1',
+        provenance: 'syntactic',
+        relation: 'calls',
+        sourceId: 'symbol-1',
+        sourceName: 'source',
+        targetName: 'target',
+      },
+    ],
+    path: 'src/rich.ts',
+    references: [
+      {
+        edgeId: 'edge-1',
+        evidencePath: 'src/rich.ts',
+        evidenceSpan: span,
+        lookupTiers: [['typescript:name:target']],
+        provenance: 'syntactic',
+        relation: 'calls',
+        resolutionDomain: 'typescript',
+        sourceId: 'symbol-1',
+        sourceName: 'source',
+        targetName: 'target',
+      },
+    ],
+    symbols: [
+      {
+        contentHash: '0'.repeat(64),
+        exported: true,
+        id: 'symbol-1',
+        kind: 'function',
+        language: 'typescript',
+        name: 'source',
+        path: 'src/rich.ts',
+        qualifiedName: 'source',
+        span,
+      },
+    ],
+  };
+}

--- a/test/unit/code-graph.fact-storage.property.test.ts
+++ b/test/unit/code-graph.fact-storage.property.test.ts
@@ -29,6 +29,10 @@ const factArbitrary = fc
     symbols: [],
   }));
 
+const repositoryTextArbitrary = fc
+  .array(fc.integer({max: 0x9f, min: 0}), {maxLength: 64, minLength: 1})
+  .map(codeUnits => String.fromCharCode(...codeUnits));
+
 describe('compact code graph fact storage', () => {
   it('round-trips legacy and compact rows deterministically without mutating facts', () => {
     fc.assert(
@@ -96,6 +100,68 @@ describe('compact code graph fact storage', () => {
     expect(decodeStoredCodeGraphFact(JSON.stringify(legacyEnvelope), facts.path).facts).toEqual(facts);
   });
 
+  it('round-trips bounded repository text while keeping presentation sanitization separate', () => {
+    fc.assert(
+      fc.property(repositoryTextArbitrary, repositoryText => {
+        const span = {column: 1, endColumn: 2, endLine: 1, line: 1};
+        const facts: CodeGraphFileFacts = {
+          derivationInputs: {
+            rationale: [{documentation: '', line: 1, marker: 'test', name: repositoryText}],
+          },
+          diagnostics: [repositoryText],
+          edges: [
+            {
+              confidence: 1,
+              evidencePath: 'docs/control.md',
+              evidenceSpan: span,
+              id: 'edge-control',
+              provenance: 'syntactic',
+              relation: 'contains',
+              sourceId: 'symbol-control',
+              sourceName: repositoryText,
+              targetName: repositoryText,
+            },
+          ],
+          path: 'docs/control.md',
+          references: [
+            {
+              aliasLookupKeys: [repositoryText],
+              edgeId: 'edge-control',
+              evidencePath: 'docs/control.md',
+              evidenceSpan: span,
+              lookupTiers: [[repositoryText]],
+              provenance: 'syntactic',
+              relation: 'contains',
+              resolutionDomain: 'document',
+              sourceId: 'symbol-control',
+              sourceName: repositoryText,
+              targetName: repositoryText,
+            },
+          ],
+          symbols: [
+            {
+              contentHash: '0'.repeat(64),
+              exported: true,
+              id: 'symbol-control',
+              kind: 'heading',
+              language: 'markdown',
+              lookupKeys: [repositoryText],
+              name: repositoryText,
+              packageName: repositoryText,
+              path: 'docs/control.md',
+              qualifiedName: repositoryText,
+              span,
+            },
+          ],
+        };
+
+        const bounded = serializeBoundedCodeGraphFact(facts);
+        expect(decodeStoredCodeGraphFact(bounded.json, facts.path).facts).toEqual(facts);
+      }),
+      {numRuns: 50},
+    );
+  });
+
   it('rejects corrupt, non-canonical, or path-mismatched envelopes', () => {
     const facts = serializeBoundedCodeGraphFact({
       diagnostics: Array.from({length: 200}, () => 'compress me'),
@@ -116,7 +182,7 @@ describe('compact code graph fact storage', () => {
 
   it('rejects malformed nested fact shapes at both persistence and decode boundaries', () => {
     fc.assert(
-      fc.property(fc.integer({max: 6, min: 0}), mutation => {
+      fc.property(fc.integer({max: 7, min: 0}), mutation => {
         const facts = richFacts();
         const candidate = structuredClone(facts) as unknown as Record<string, unknown>;
         const symbols = candidate.symbols as Array<Record<string, unknown>>;
@@ -143,6 +209,9 @@ describe('compact code graph fact storage', () => {
             break;
           case 6:
             candidate.derivationInputs = {rationale: [{documentation: '', line: -1, marker: 'why', name: 'x'}]};
+            break;
+          case 7:
+            candidate.derivationInputs = {rationale: [{documentation: '', line: 1, marker: 'why', name: ''}]};
             break;
         }
         expect(() => serializeBoundedCodeGraphFact(candidate as unknown as CodeGraphFileFacts)).toThrow();

--- a/test/unit/code-graph.inventory-identity.property.test.ts
+++ b/test/unit/code-graph.inventory-identity.property.test.ts
@@ -1,7 +1,12 @@
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
+import {
+  codeGraphContentIdentity,
+  createCodeGraphContentIdentityAccumulator,
+} from '../../src/code_graph/graph_identity.js';
 import {codeGraphInventorySha256Hex} from '../../src/code_graph/inventory_identity.js';
+import {compareCodeUnits} from '../../src/code_graph/ordering.js';
 
 describe('code graph inventory identity', () => {
   it('matches the canonical one-shot digest for arbitrary ordering and Unicode without mutating input', () => {
@@ -28,6 +33,28 @@ describe('code graph inventory identity', () => {
         },
       ),
       {numRuns: 150},
+    );
+  });
+
+  it('matches bounded streaming graph identity across UTF-16 and UTF-8 order boundaries', () => {
+    const path = fc
+      .array(fc.constantFrom('a', 'z', '\ud7ff', '\ue000', '\uffff', '🙂', '𐀀'), {maxLength: 12, minLength: 1})
+      .map(parts => `src/${parts.join('')}.ts`);
+    fc.assert(
+      fc.property(fc.uniqueArray(path, {maxLength: 100}), paths => {
+        const files = paths.map((value, index) => ({
+          contentHash: sha256HexSync(`content-${index}`),
+          language: 'typescript',
+          mode: '100644',
+          path: value,
+        }));
+        const accumulator = createCodeGraphContentIdentityAccumulator('extractor-set');
+        for (const file of [...files].sort((left, right) => compareCodeUnits(left.path, right.path))) {
+          accumulator.update(file);
+        }
+        expect(accumulator.digest()).toBe(codeGraphContentIdentity('extractor-set', [...files].reverse()));
+      }),
+      {numRuns: 100},
     );
   });
 });

--- a/test/unit/code-graph.materialization-store.test.ts
+++ b/test/unit/code-graph.materialization-store.test.ts
@@ -7,6 +7,7 @@ import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {afterEach, describe, expect, it} from 'vitest';
 import {TestClock} from 'effect/testing';
 import {codeGraphBlobReuseCacheKey} from '../../src/code_graph/blob_reuse.js';
+import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {CODE_GRAPH_CACHE_TRANSACTION_LIMITS} from '../../src/code_graph/cache_capacity.js';
 import {
   cachedCodeGraphFactBytes,
@@ -5912,7 +5913,7 @@ function structuredCacheFile(path: string, content: string): CodeGraphInventoryF
 
 function symbol(id: string, name: string, lookupKeys: readonly string[]): CodeGraphSymbol {
   return {
-    contentHash: `hash-${id}`,
+    contentHash: sha256HexSync(id),
     exported: true,
     id,
     kind: 'function',

--- a/test/unit/code-graph.parser-worker.test.ts
+++ b/test/unit/code-graph.parser-worker.test.ts
@@ -6,6 +6,7 @@ import * as FC from 'effect/testing/FastCheck';
 import {TestClock} from 'effect/testing';
 import {Effect, FileSystem, Fiber, Layer} from 'effect';
 import {cachedCodeGraphFactBytes, CODE_GRAPH_CACHED_FACT_BYTES_MAXIMUM} from '../../src/code_graph/fact_budget.js';
+import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../../src/code_graph/languages/registry.js';
 import {
   CODE_GRAPH_PARSER_RSS_BYTES_ENV,
@@ -734,7 +735,7 @@ function inventoryFile(path: string, content: string, language = 'typescript'): 
   return {
     blobId: `blob-${path}`,
     content,
-    contentHash: Bun.hash(content).toString(16),
+    contentHash: sha256HexSync(content),
     language,
     mode: '100644',
     path,

--- a/test/unit/code-graph.removed-view-cleanup-store.test.ts
+++ b/test/unit/code-graph.removed-view-cleanup-store.test.ts
@@ -137,7 +137,7 @@ describe('removed code graph view cleanup queue', () => {
           }
         });
 
-        expect(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION).toBe(16);
+        expect(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION).toBe(17);
         expect(observed.revision).toEqual({value: String(CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION)});
         expect(observed.ready).toEqual({state: 'ready'});
         expect(observed.building).toEqual({state: 'building'});

--- a/test/unit/code-graph.schema-revision.test.ts
+++ b/test/unit/code-graph.schema-revision.test.ts
@@ -1,0 +1,139 @@
+import {readFile} from '../helpers/node-fs-promises.js';
+import {dirname, join} from '../helpers/node-path.js';
+import {fileURLToPath} from '../helpers/node-url.js';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  CODE_GRAPH_CORE_SCHEMA_VERSION,
+  CODE_GRAPH_PERSISTENT_SCHEMA_CHECKPOINT_PREDECESSOR,
+  CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR,
+  CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT,
+  CODE_GRAPH_PERSISTENT_SCHEMA_REVISIONS,
+  CODE_GRAPH_PROTOCOL_VERSIONS,
+  CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_REVISION,
+  codeGraphPersistentSchemaIsCurrent,
+  codeGraphPersistentSchemaMigrationPending,
+  codeGraphPersistentSchemaSupports,
+  codeGraphRuntimeSchemaRequiresReconnect,
+  observeCodeGraphPersistentSchemaRevision,
+  planCodeGraphPersistentSchemaUpgrade,
+} from '../../src/code_graph/store/schema_revision.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const historicalProfiles = [
+  [2, 'build-owner-plan', 'rebuild-extensions'],
+  [3, 'reference-candidate', 'retire-legacy-references-and-rebuild'],
+  [4, 'legacy-lexical', 'rebuild-extensions'],
+  [5, 'compact-lexical', 'rebuild-extensions'],
+  [6, 'content-shards', 'bridge-build-owner-instance'],
+  [7, 'build-owner-instance', 'adopt-current-contract'],
+  [8, 'removed-view-cleanup', 'adopt-current-contract'],
+  [9, 'component-aggregates', 'adopt-current-contract'],
+  [10, 'query-indexes', 'adopt-current-contract'],
+  [11, 'evidence-cross-repository', 'adopt-current-contract'],
+  [12, 'file-blob-authority', 'adopt-current-contract'],
+  [13, 'inventory-reuse', 'rebuild-extensions'],
+  [14, 'transient-spool', 'adopt-current-contract'],
+  [15, 'sorted-spool-citation-predecessor', 'adopt-current-contract'],
+  [16, 'citation-alias-checkpoint-predecessor', 'extend-checkpoint-import'],
+  [17, 'checkpoint-import', 'current'],
+] as const;
+
+describe('code graph schema revision entity', () => {
+  it('pins every released persistent revision to its named upgrade route', () => {
+    expect(CODE_GRAPH_PERSISTENT_SCHEMA_REVISIONS.map(value => [value.value, value.key, value.upgradeRoute])).toEqual(
+      historicalProfiles,
+    );
+    expect(CODE_GRAPH_PERSISTENT_SCHEMA_CITATION_PREDECESSOR.value).toBe(15);
+    expect(CODE_GRAPH_PERSISTENT_SCHEMA_CHECKPOINT_PREDECESSOR.value).toBe(16);
+    expect(CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT.value).toBe(17);
+  });
+
+  it('keeps storage, receipt, artifact, reuse, resolution, and Manager versions distinct', () => {
+    expect(CODE_GRAPH_CORE_SCHEMA_VERSION).toBe(3);
+    expect(CODE_GRAPH_SCHEMA_INITIALIZATION_RECEIPT_REVISION).toEqual({
+      citationAliasPredecessor: 2,
+      current: 3,
+    });
+    expect(CODE_GRAPH_PROTOCOL_VERSIONS).toEqual({
+      checkpointArtifact: 1,
+      checkpointImport: 1,
+      checkpointRecordSchema: 1,
+      checkpointSemantic: 1,
+      inventoryReuseReceipt: 2,
+      managerCatalogRevision: 1,
+      resolutionSurface: 1,
+      reusableBaseReceipt: 2,
+    });
+  });
+
+  it('preserves the deliberately non-arithmetic r13 and predecessor behavior', () => {
+    expect(codeGraphPersistentSchemaSupports(12, 'direct-current-contract-adoption')).toBe(true);
+    expect(codeGraphPersistentSchemaSupports(13, 'direct-current-contract-adoption')).toBe(false);
+    expect(codeGraphPersistentSchemaSupports(14, 'direct-current-contract-adoption')).toBe(true);
+    expect(codeGraphPersistentSchemaSupports(15, 'citation-released-predecessor-authority')).toBe(true);
+    expect(codeGraphPersistentSchemaSupports(15, 'citation-column-predecessor-authority')).toBe(false);
+    expect(codeGraphPersistentSchemaSupports(16, 'citation-column-predecessor-authority')).toBe(true);
+  });
+
+  it('round-trips every historical integer and canonical SQLite string through one profile', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...CODE_GRAPH_PERSISTENT_SCHEMA_REVISIONS), profile => {
+        expect(observeCodeGraphPersistentSchemaRevision(profile.value)).toEqual({profile, state: 'known'});
+        expect(observeCodeGraphPersistentSchemaRevision(String(profile.value))).toEqual({profile, state: 'known'});
+        expect(codeGraphPersistentSchemaIsCurrent(profile.value)).toBe(profile.key === 'checkpoint-import');
+        expect(codeGraphPersistentSchemaMigrationPending(profile.value)).toBe(
+          profile.lifecycle === 'background-readable',
+        );
+        const plan = planCodeGraphPersistentSchemaUpgrade(profile.value);
+        expect(plan.state).toBe(profile.key === 'checkpoint-import' ? 'ready' : 'upgrade');
+        if (plan.state !== 'ready' && plan.state !== 'upgrade')
+          throw new Error('Historical revision plan unavailable.');
+        expect(plan.route).toBe(profile.upgradeRoute);
+      }),
+      {numRuns: 64},
+    );
+  });
+
+  it('classifies future observations monotonically without treating malformed values as newer', () => {
+    fc.assert(
+      fc.property(fc.integer({max: 1_000, min: 1}), increment => {
+        const future = CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT.value + increment;
+        expect(observeCodeGraphPersistentSchemaRevision(future)).toEqual({state: 'newer', value: future});
+        expect(planCodeGraphPersistentSchemaUpgrade(future)).toEqual({state: 'reject-newer', value: future});
+        expect(codeGraphRuntimeSchemaRequiresReconnect(CODE_GRAPH_CORE_SCHEMA_VERSION, future)).toBe(true);
+      }),
+      {numRuns: 64},
+    );
+    expect(observeCodeGraphPersistentSchemaRevision('016')).toEqual({state: 'invalid', value: '016'});
+    expect(observeCodeGraphPersistentSchemaRevision(-1)).toEqual({state: 'invalid', value: -1});
+    expect(codeGraphRuntimeSchemaRequiresReconnect(undefined, undefined)).toBe(false);
+  });
+
+  it('keeps semantic revision checks behind the revision entity', async () => {
+    const governedFiles = [
+      'maintenance.ts',
+      'store_diagnostics.ts',
+      'store_file_alias_schema.ts',
+      'store_health.ts',
+      'store_leases.ts',
+      'store_maintenance_core.ts',
+      'store_reconciliation.ts',
+      'store_reconciliation_preparation.ts',
+      'store_schema_core.ts',
+      'store_schema_migration.ts',
+      'store_schema_receipt.ts',
+    ];
+    const subject = String.raw`(?:recordedRevision|persistentExtensionSchemaRevision|revision\.value|receipt\.contract_revision|receipt\.persistent_extension_revision)`;
+    const numericRevision = String.raw`(?:[2-9]|1[0-7])`;
+    const leftComparison = new RegExp(String.raw`\b${subject}\s*(?:===|!==|<=|>=|<|>)\s*${numericRevision}\b`, 'u');
+    const rightComparison = new RegExp(String.raw`\b${numericRevision}\s*(?:===|!==|<=|>=|<|>)\s*${subject}\b`, 'u');
+    for (const file of governedFiles) {
+      const source = await readFile(join(repoRoot, 'src', 'code_graph', file), 'utf8');
+      expect(source, file).not.toMatch(leftComparison);
+      expect(source, file).not.toMatch(rightComparison);
+      expect(source, file).not.toMatch(/CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION\s*[+-]/u);
+    }
+  });
+});

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -543,6 +543,41 @@ describe('MCP code graph indexing progress', () => {
     }),
   );
 
+  effectIt.effect('sanitizes repository controls in MCP analysis text and structured content', () =>
+    Effect.gen(function* () {
+      const repositoryText = 'danger\u001b\u009b\r\n\u202evalue';
+      const source = analysisSymbol('mcp-control-source', repositoryText, 'src/control.ts', {
+        name: repositoryText,
+        qualifiedName: repositoryText,
+      });
+      const target = analysisSymbol('mcp-control-target', repositoryText, 'src/control.ts', {
+        name: repositoryText,
+        qualifiedName: repositoryText,
+      });
+      const edges = [
+        analysisEdge('mcp-control-edge', source, target, 'calls', {
+          confidence: 0.1,
+          sourceName: repositoryText,
+          targetName: repositoryText,
+        }),
+      ];
+      const analysis = yield* analyzeCodeGraph(pagedAnalysisStore([source, target], edges), {
+        databasePath: ':memory:',
+        minimumHubDegree: 1,
+        snapshot: analysisSnapshot([source, target], edges),
+      });
+      const response = codeGraphAnalysisMcpResponse(analysis, 'full', {
+        displayName: repositoryText,
+        repositoryId: 'repository-control',
+      });
+
+      expect(containsUnsafePresentationText(response.text, true)).toBe(false);
+      expect(containsUnsafePresentationText(response.structuredContent, true)).toBe(false);
+      expect(response.text).toContain('danger');
+      expect(JSON.stringify(response.structuredContent)).toContain('danger');
+    }),
+  );
+
   effectIt.effect('excludes unrelated topology arrays before stats truncation and byte accounting', () =>
     Effect.gen(function* () {
       const first = analysisSymbol('scoped-first', '@acme/scoped', 'src/scoped.ts');
@@ -808,4 +843,22 @@ function verboseCodeGraphResult(): CodeGraphQueryResult {
     version: 1,
     warnings: Array.from({length: 20}, (_, index) => `warning ${index} ${'w'.repeat(500)}`),
   };
+}
+
+function containsUnsafePresentationText(value: unknown, allowLineFeed = false): boolean {
+  if (typeof value === 'string') {
+    return Array.from(value).some(character => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return (
+        !(allowLineFeed && codePoint === 0x0a) &&
+        (codePoint <= 0x1f ||
+          (codePoint >= 0x7f && codePoint <= 0x9f) ||
+          (codePoint >= 0x202a && codePoint <= 0x202e) ||
+          (codePoint >= 0x2066 && codePoint <= 0x2069))
+      );
+    });
+  }
+  if (Array.isArray(value)) return value.some(item => containsUnsafePresentationText(item, allowLineFeed));
+  if (value === null || typeof value !== 'object') return false;
+  return Object.values(value).some(item => containsUnsafePresentationText(item, allowLineFeed));
 }

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -1,4 +1,5 @@
 import {cursorCloudDocsSection} from './docsCursorCloud.js';
+import {graphCheckpointsDocsArticle} from './docsGraphCheckpoints.js';
 import {
   handoffMemoryCitationCliExamples,
   rememberContextMemoryCitationInputs,
@@ -88,6 +89,9 @@ export const cliCommands: CliCommandReference[] = [
       'threadnote graph analyze --view full',
       'threadnote graph report --output architecture-report.md',
       'threadnote graph export --format graphml --output code-graph.graphml',
+      'threadnote graph checkpoint export --output threadnote-graph.cgcp',
+      'threadnote graph checkpoint verify --input threadnote-graph.cgcp --expected-digest sha256:…',
+      'threadnote graph checkpoint import --input threadnote-graph.cgcp --expected-digest sha256:…',
     ],
   },
   {
@@ -1370,6 +1374,7 @@ threadnote graph export --format svg --output code-graph.svg`,
           },
         ],
       },
+      graphCheckpointsDocsArticle,
       {
         id: 'graph-monorepos',
         title: 'Monorepos and nested workspaces',

--- a/website/src/content/docsGraphCheckpoints.ts
+++ b/website/src/content/docsGraphCheckpoints.ts
@@ -1,0 +1,61 @@
+import type {DocsArticle} from './docsTypes.js';
+
+export const graphCheckpointsDocsArticle: DocsArticle = {
+  id: 'graph-checkpoints',
+  title: 'Portable graph checkpoints',
+  summary: 'Move one deterministic verified clean graph between local installations without a Workset or cloud.',
+  keywords: [
+    'code graph checkpoint',
+    'portable graph',
+    'offline graph transfer',
+    'checkpoint verify',
+    'checkpoint import',
+  ],
+  body: [
+    {
+      type: 'code',
+      language: 'sh',
+      code: `threadnote graph index
+threadnote graph checkpoint export --output threadnote-graph.cgcp
+threadnote graph checkpoint inspect \\
+  --input threadnote-graph.cgcp \\
+  --expected-digest sha256:<digest>
+threadnote graph checkpoint verify \\
+  --input threadnote-graph.cgcp \\
+  --expected-digest sha256:<digest>
+threadnote graph checkpoint import \\
+  --input threadnote-graph.cgcp \\
+  --expected-digest sha256:<digest>`,
+    },
+    {
+      type: 'paragraph',
+      text: 'Checkpoints are a free, manual, offline transport. Export accepts only the exact ready clean root for the current commit and a credential-free repository identity. It reads one SQLite transaction in bounded pages, checks committed file identities against Git, excludes local paths, credentials, and raw source bytes, and never overwrites an existing destination. Canonical metadata, deterministic gzip chunks, and SHA-256 identities make the same compatible logical graph reproducible.',
+    },
+    {
+      type: 'paragraph',
+      text: 'Inspect validates bounded framing and computes the exact artifact digest without inflating records; pass an independently obtained expected digest to authenticate those bytes. Verify additionally checks compressed-member integrity, chunk and logical digests, canonical record schema, ordering, counts, and coverage. Both commands reject direct symbolic-link inputs and fail when the opened pathname identity or metadata changes.',
+    },
+    {
+      type: 'table',
+      headers: ['Receiver state', 'Import publication'],
+      rows: [
+        ['Exact source commit, clean', 'Activate the imported ready snapshot'],
+        ['Exact source commit, dirty', 'Build the current dirty graph from the compatible imported base'],
+        ['Current commit descends from source', 'Build the current graph from the compatible imported base'],
+        ['Divergent history', 'Store the verified snapshot inactive for later compatible reuse'],
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'Import never fetches Git objects or runs repository code. The same repository and source commit must already exist locally. Threadnote verifies the runtime ABI and every exact-commit file before staging any graph rows, then publishes the ready snapshot and immutable receipt transactionally. Repeated imports reuse the same logical snapshot.',
+    },
+    {
+      type: 'note',
+      text: 'No Workset is required. Portable checkpoints touch only disposable native graph storage; schema-v1 memories, uncited legacy memories, stable threadnote:// URIs, and ordinary recall remain available after upgrade.',
+    },
+    {
+      type: 'warning',
+      text: 'A digest computed from the same untrusted file proves integrity, not provenance. Obtain the expected SHA-256 digest independently, and treat derived graph structure and repository-relative identifiers as internal architecture data when sharing an artifact.',
+    },
+  ],
+};


### PR DESCRIPTION
## Outcome

Adds portable, offline code-graph checkpoints for Threadnote Phase 3. A clean graph snapshot can now be exported once, inspected or verified without mutation, and imported into another Threadnote home without rebuilding the graph or requiring a Workset.

## User stories

- As a free/local user, I can export an exact clean graph snapshot and carry it between machines without a hosted service.
- As a receiving user, I can inspect provenance and compatibility before trusting or activating an artifact.
- As an operator, I can verify transport integrity quickly or run full semantic and relational verification.
- As a user with an existing populated home, I can import idempotently without corrupting or replacing my active graph on failure.
- As an existing pre-4.4 user, I continue to recall legacy v1 memories; checkpoints do not gate memory recall and require no Workset.
- As a maintainer, I use named schema-revision capabilities and upgrade routes instead of scattered magic revision checks.

## Design

- Adds `graph checkpoint export`, `inspect`, `verify`, and `import`.
- Separates the artifact-byte SHA-256 from a versioned canonical logical digest, following the research plan derived from OCI descriptors, RFC 8785 canonical JSON, Git pack/commit-graph design, SQLite atomicity, Iceberg metadata, and incremental-dataflow literature.
- Uses a staged, fail-closed import with authority checks, bounded decoding, relational validation, immutable import planning, ready-inactive publication, receipts, and atomic activation.
- Gives checkpoint file facts a domain-separated canonical semantic identity so imported clean facts cannot alias a locally materialized shard with different semantic content.
- Centralizes graph schema revisions, capabilities, citation states, and upgrade routes in `schema_revision.ts`.
- Documents the format, trust model, compatibility contract, and CLI workflow in the repository and website docs.

## Verification

- Final focused matrix: 4 files / 23 tests passed (authority, pack properties, import store, CLI integration).
- Additional focused implementation suites covered projection, compatibility, schema revision, citation repair, fact storage, and identity properties.
- Source, test, and website typechecks passed.
- Strict lint, file-length policy, formatting, and diff checks passed.
- Dev-cycle completed with 0 critical and 0 important findings; its final minor golden-vector request was implemented and rechecked.
- Exact HEAD was installed globally and passed `threadnote doctor`.
- Dogfood on the full Threadnote graph (1,278 files, 68,306 symbols, 205,254 edges): exported a 73.3 MB checkpoint, passed inspect and full verification, imported into a populated home, re-imported as reuse of the same snapshot, and queried the activated imported graph successfully.
- Legacy-memory regression coverage remains green and live recall after the install returned existing memories.

The full suite is intentionally delegated to pull-request CI per repository policy.
