### PR TITLE
docs(site): clarify 4.4 source and graph contracts

### DIFF
--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -936,7 +936,8 @@ The body remains ordinary **Markdown**.
     expect(faqSource).toContain('v1 and other uncited memories stay recallable');
     expect(faqSource).toContain('Do I need a Workset to use code citations or Context Brief?');
     expect(faqSource).toContain('That warning is about the link, not the memory');
-    expect(faqSource).toContain('never fan out cold graph builds or silently start indexing');
+    expect(faqSource).toContain('Citation writes never start indexing implicitly');
+    expect(faqSource).toContain('never fan out cold graph builds');
   });
 
   it('surfaces the shipped 4.4 graph isolation contract across Home, Pro Tips, and FAQ', async () => {

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -922,14 +922,32 @@ The body remains ordinary **Markdown**.
 
     expect(landingSource).toContain('Optional citations · stale-link warnings · legacy recall');
     expect(landingSource).toContain('older uncited memories stay recallable');
+    expect(landingSource).toContain('A stale-link warning means the evidence moved—not that the memory');
     expect(tips).toContain('codeRefs');
     expect(tips).toContain('Memory fresh · citation relocated · warning stale-link');
+    expect(tips).toContain('stale-link warns about the locator, not the memory');
     expect(proTipsSource).toContain('source-aware memory');
     expect(proTipsSource).toContain('same memory, citation, and graph-search');
     expect(faqSource).toContain('Will my existing memories disappear after upgrading to 4.4?');
     expect(faqSource).toContain('v1 and other uncited memories stay recallable');
     expect(faqSource).toContain('Do I need a Workset to use code citations or Context Brief?');
-    expect(faqSource).toContain('queries never fan out cold graph builds');
+    expect(faqSource).toContain('That warning is about the link, not the memory');
+    expect(faqSource).toContain('never fan out cold graph builds or silently start indexing');
+  });
+
+  it('surfaces the shipped 4.4 graph isolation contract across Home, Pro Tips, and FAQ', async () => {
+    const [landingSource, faqSource] = await Promise.all([
+      readFile(join(root, 'website', 'src', 'pages', 'LandingPage.tsx'), 'utf8'),
+      readFile(join(root, 'website', 'src', 'pages', 'FaqPage.tsx'), 'utf8'),
+    ]);
+    const tips = JSON.stringify(proTips);
+
+    expect(landingSource).toContain('Threadnote 4.4 · self-contained');
+    expect(landingSource).toContain('Manager-launched indexing and Workset preparation run in isolated processes');
+    expect(tips).toContain('Manager-triggered indexing and Workset preparation run in isolated processes');
+    expect(tips).toContain('repository members prepared at bounded concurrency');
+    expect(faqSource).toContain('How does Manager keep long graph work responsive?');
+    expect(faqSource).toContain('Workset repositories prepare with bounded concurrency');
   });
 
   it('renders a connected, scale-stable Manager graph preview', async () => {

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -775,6 +775,7 @@ The body remains ordinary **Markdown**.
         'resume-later',
         'graph-operations',
         'memory-plus-graph',
+        'portable-graph-checkpoints',
       ]),
     );
     expect(operations.some(operation => operation.includes('recall_context'))).toBe(true);
@@ -783,6 +784,7 @@ The body remains ordinary **Markdown**.
     expect(operations.some(operation => operation.includes('share_publish'))).toBe(true);
     expect(JSON.stringify(proTips)).toContain('stale-link');
     expect(JSON.stringify(proTips)).toContain('no Workset required');
+    expect(JSON.stringify(proTips)).toContain('threadnote graph checkpoint export');
   });
 
   it('uses fictional, generic examples in public graph simulations', async () => {
@@ -910,6 +912,8 @@ The body remains ordinary **Markdown**.
     expect(landingSource).not.toMatch(/13\.2×|9\.9×/);
     expect(scenarios).toContain('current commit + isolated dirty overlay');
     expect(scenarios).toContain('paged SQLite analysis · no repository admission cap');
+    expect(landingSource).toContain('Free · manual · offline');
+    expect(landingSource).toContain("docsArticleHref('graph-checkpoints')");
   });
 
   it('explains the 4.4 citation contract across Home, Pro Tips, and FAQ', async () => {
@@ -948,6 +952,31 @@ The body remains ordinary **Markdown**.
     expect(tips).toContain('repository members prepared at bounded concurrency');
     expect(faqSource).toContain('How does Manager keep long graph work responsive?');
     expect(faqSource).toContain('Workset repositories prepare with bounded concurrency');
+  });
+
+  it('explains the portable checkpoint workflow across Home, Pro Tips, and FAQ', async () => {
+    const [landingSource, faqSource] = await Promise.all([
+      readFile(join(root, 'website', 'src', 'pages', 'LandingPage.tsx'), 'utf8'),
+      readFile(join(root, 'website', 'src', 'pages', 'FaqPage.tsx'), 'utf8'),
+    ]);
+    const tips = JSON.stringify(proTips);
+
+    expect(landingSource).toContain('Export the exact ready, clean graph for the current commit');
+    expect(landingSource).toContain('No account, hosted service, or Workset is required');
+    expect(tips).toContain('threadnote graph checkpoint export --output threadnote-graph.cgcp');
+    expect(tips).toContain(
+      'threadnote graph checkpoint inspect --input threadnote-graph.cgcp --expected-digest sha256:<digest>',
+    );
+    expect(tips).toContain(
+      'threadnote graph checkpoint verify --input threadnote-graph.cgcp --expected-digest sha256:<digest>',
+    );
+    expect(tips).toContain(
+      'threadnote graph checkpoint import --input threadnote-graph.cgcp --expected-digest sha256:<digest>',
+    );
+    expect(tips).toContain('Existing schema-v1 and uncited legacy memories remain recallable');
+    expect(faqSource).toContain('Can I move a graph to another machine without a Workset or cloud?');
+    expect(faqSource).toContain('Portable graph checkpoints are free, manual, offline files');
+    expect(faqSource).toContain('schema-v1 or uncited legacy memories are unaffected');
   });
 
   it('renders a connected, scale-stable Manager graph preview', async () => {

--- a/website/src/content/proTips.ts
+++ b/website/src/content/proTips.ts
@@ -510,4 +510,79 @@ export const proTips: ProTip[] = [
       ],
     },
   },
+  {
+    id: 'portable-graph-checkpoints',
+    number: '09',
+    category: 'graph',
+    title: 'Carry a verified graph across machines.',
+    summary:
+      'Move one deterministic clean graph between local installations when the receiver is offline or a rebuild would waste time.',
+    why: 'The checkpoint carries disposable derived graph data—not source or memory—and an independently obtained digest authenticates the exact artifact bytes.',
+    practice: [
+      'Export only after the current commit has an exact ready, clean root graph and a credential-free repository identity.',
+      'Transfer the checkpoint file and its expected SHA-256 digest through independent trusted paths.',
+      'On the receiver, inspect with the expected digest, run the full verify, then import from a checkout of the same repository where the source commit already exists.',
+      'No account, hosted service, or Workset is required. Existing schema-v1 and uncited legacy memories remain recallable.',
+    ],
+    scenario: {
+      eyebrow: 'Offline graph portability',
+      title: 'Verify before importing on the offline machine',
+      description:
+        'The sender exports one exact clean graph; the receiver authenticates the file, verifies every logical record, and imports it locally.',
+      steps: [
+        {
+          kind: 'user',
+          actor: 'You',
+          text: 'Prepare this repository graph for an offline development machine without creating a Workset.',
+        },
+        {
+          kind: 'action',
+          actor: 'Source machine',
+          text: 'Index the clean current commit.',
+          meta: 'threadnote graph index',
+        },
+        {
+          kind: 'action',
+          actor: 'Source machine',
+          text: 'Export the exact ready graph to a new local artifact.',
+          meta: 'threadnote graph checkpoint export --output threadnote-graph.cgcp',
+        },
+        {
+          kind: 'result',
+          actor: 'Threadnote',
+          text: 'Exported checkpoint · sha256:<digest>',
+          evidence: ['threadnote-graph.cgcp', 'sha256:<digest>'],
+        },
+        {
+          kind: 'action',
+          actor: 'Transfer',
+          text: 'Move the artifact and independently obtained digest to the offline machine.',
+          meta: 'manual file transfer · no account or Workset',
+        },
+        {
+          kind: 'action',
+          actor: 'Offline machine',
+          text: 'Authenticate the artifact framing before inflating graph records.',
+          meta: 'threadnote graph checkpoint inspect --input threadnote-graph.cgcp --expected-digest sha256:<digest>',
+        },
+        {
+          kind: 'action',
+          actor: 'Offline machine',
+          text: 'Fully verify chunks, schema, ordering, coverage, and the logical digest.',
+          meta: 'threadnote graph checkpoint verify --input threadnote-graph.cgcp --expected-digest sha256:<digest>',
+        },
+        {
+          kind: 'action',
+          actor: 'Offline machine',
+          text: 'Import from a checkout of the same repository with the source commit already available.',
+          meta: 'threadnote graph checkpoint import --input threadnote-graph.cgcp --expected-digest sha256:<digest>',
+        },
+        {
+          kind: 'assistant',
+          actor: 'Agent',
+          text: 'The verified graph is ready locally. No Workset was created, and existing v1 and uncited memories were not migrated or filtered.',
+        },
+      ],
+    },
+  },
 ];

--- a/website/src/content/proTips.ts
+++ b/website/src/content/proTips.ts
@@ -157,6 +157,7 @@ export const proTips: ProTip[] = [
     practice: [
       'Pass each agent’s absolute worktree path as callerCwd on recall and graph calls.',
       'Let the first graph call start immediately: a graph-equivalent commit can reuse ready content, while a compatible clean commit builds a bounded delta.',
+      'Manager-triggered indexing and Workset preparation run in isolated processes, with repository members prepared at bounded concurrency.',
       'Use a distinct handoff topic for each independent task; share a topic only when agents intentionally update one record.',
       'Let Threadnote coordinate graph publication and maintenance—do not copy or share derived index files between worktrees.',
     ],
@@ -441,12 +442,12 @@ export const proTips: ProTip[] = [
     category: 'graph',
     title: 'Cite the code behind consequential memory.',
     summary:
-      'Give Context Brief enough evidence to distinguish an unchanged move from code that changed, disappeared, or cannot be verified.',
+      'Give Context Brief enough evidence to distinguish a stale locator from memory backed by code that changed, disappeared, or cannot be verified.',
     why: 'A citation binds a claim to observed code without pretending that unchanged bytes automatically prove the prose.',
     practice: [
       'Add codeRefs only to consequential source-backed claims; uncited memory remains valid and recallable.',
       'For one repository, pass callerCwd. Use a prepared Workset only when the evidence really spans repositories.',
-      'Treat relocated evidence as fresh with a stale-link warning; changed or deleted evidence is stale, and unknown means Threadnote abstained.',
+      'Treat relocated evidence as fresh: stale-link warns about the locator, not the memory. Changed or deleted evidence is stale, and unknown means Threadnote abstained.',
       'When replacing cited memory, pass codeRefs again to recapture it. Omitting them deliberately clears the old citations.',
     ],
     scenario: {
@@ -504,7 +505,7 @@ export const proTips: ProTip[] = [
         {
           kind: 'assistant',
           actor: 'Agent',
-          text: 'The cited source is byte-identical at one new locator, so the memory remains fresh but its link is stale. I’ll review the claim, then replace the memory with the current code reference.',
+          text: 'The cited source is byte-identical at one new locator. The stale-link warning is about that locator, not the memory, so I’ll review the claim and then recapture the current code reference.',
         },
       ],
     },

--- a/website/src/pages/FaqPage.tsx
+++ b/website/src/pages/FaqPage.tsx
@@ -26,7 +26,7 @@ const questions = [
   {
     question: 'What do memory-to-code citations and stale-link warnings mean?',
     answer:
-      'Code citations are optional capture-time evidence for exact files or symbols. Context Brief checks selected citations against an already-ready current graph: exact or uniquely relocated evidence keeps the memory fresh, relocation adds a stale-link warning so you can recapture the new locator, changed or deleted evidence makes the memory stale, and unavailable or ambiguous evidence stays unknown. Even an exact citation proves that the cited bytes survived—not that the memory prose is automatically correct.',
+      'Code citations are optional capture-time evidence for exact files or symbols. Context Brief checks selected citations against an already-ready current graph: exact or uniquely relocated evidence keeps the memory fresh, while relocation adds a stale-link warning so you can recapture the new locator. That warning is about the link, not the memory. Changed or deleted evidence makes the memory stale, and unavailable or ambiguous evidence stays unknown. Even an exact citation proves that the cited bytes survived—not that the memory prose is automatically correct.',
   },
   {
     question: 'Will my existing memories disappear after upgrading to 4.4?',
@@ -36,7 +36,7 @@ const questions = [
   {
     question: 'Do I need a Workset to use code citations or Context Brief?',
     answer:
-      'No. For an ordinary one-repository task, pass the absolute callerCwd—or run the CLI from that checkout—and use its ready current graph. A named, explicitly prepared Workset is only for bounded multi-repository evidence; queries never fan out cold graph builds.',
+      'No. For an ordinary one-repository task, pass the absolute callerCwd—or run the CLI from that checkout—and use its ready current graph. A named, explicitly prepared Workset is only for bounded multi-repository evidence. Citation validation and queries never fan out cold graph builds or silently start indexing.',
   },
   {
     question: 'Which agents can use it?',
@@ -62,6 +62,11 @@ const questions = [
     question: 'Will every new worktree rebuild its graph from scratch?',
     answer:
       'No. Linked worktrees share one checkout graph store. Threadnote 4.1 can immediately alias a graph-equivalent commit, build a compatible clean commit as a bounded delta from a ready full anchor, or construct an already-dirty worktree directly from that anchor. Extractor, workspace, manifest, or unbounded resolution changes still fall back to a full build for correctness.',
+  },
+  {
+    question: 'How does Manager keep long graph work responsive?',
+    answer:
+      'In Threadnote 4.4, Manager launches graph indexing and Workset preparation in isolated processes instead of running those builds inside the UI service. Workset repositories prepare with bounded concurrency and report progress independently. Queries still read only a ready, atomically published generation rather than partial build state.',
   },
   {
     question: 'Can agents query a graph while it is still indexing?',

--- a/website/src/pages/FaqPage.tsx
+++ b/website/src/pages/FaqPage.tsx
@@ -31,7 +31,7 @@ const questions = [
   {
     question: 'Will my existing memories disappear after upgrading to 4.4?',
     answer:
-      'No. v1 and other uncited memories stay recallable and can appear in Context Brief. They keep conservative commit-level freshness when Threadnote can resolve it and otherwise show unknown; Threadnote does not invent precise citations or require a migration just to keep recall working.',
+      'No. v1 and other uncited memories stay recallable and can appear in Context Brief. They keep conservative commit-level freshness when Threadnote can resolve it and otherwise show unknown; Threadnote does not invent precise citations or require a migration just to keep recall working. Portable checkpoint operations touch only disposable graph storage, so they do not migrate or filter existing memory either.',
   },
   {
     question: 'Do I need a Workset to use code citations or Context Brief?',
@@ -67,6 +67,11 @@ const questions = [
     question: 'How does Manager keep long graph work responsive?',
     answer:
       'In Threadnote 4.4, Manager launches graph indexing and Workset preparation in isolated processes instead of running those builds inside the UI service. Workset repositories prepare with bounded concurrency and report progress independently. Queries still read only a ready, atomically published generation rather than partial build state.',
+  },
+  {
+    question: 'Can I move a graph to another machine without a Workset or cloud?',
+    answer:
+      'Yes. Portable graph checkpoints are free, manual, offline files. Export the exact ready, clean graph for the current commit, transfer the artifact plus an independently obtained expected SHA-256 digest, run inspect and then the full verify with that digest, and import from a local checkout of the same repository where the source commit already exists. No account, hosted service, or Workset is required, and schema-v1 or uncited legacy memories are unaffected.',
   },
   {
     question: 'Can agents query a graph while it is still indexing?',

--- a/website/src/pages/FaqPage.tsx
+++ b/website/src/pages/FaqPage.tsx
@@ -36,7 +36,7 @@ const questions = [
   {
     question: 'Do I need a Workset to use code citations or Context Brief?',
     answer:
-      'No. For an ordinary one-repository task, pass the absolute callerCwd—or run the CLI from that checkout—and use its ready current graph. A named, explicitly prepared Workset is only for bounded multi-repository evidence. Citation validation and queries never fan out cold graph builds or silently start indexing.',
+      'No. For an ordinary one-repository task, pass the absolute callerCwd—or run the CLI from that checkout—and use its ready current graph. A named, explicitly prepared Workset is only for bounded multi-repository evidence. Citation writes never start indexing implicitly: unavailable evidence returns a recovery receipt. Queries against a prepared Workset use only its published ready generation and never fan out cold graph builds.',
   },
   {
     question: 'Which agents can use it?',

--- a/website/src/pages/LandingPage.tsx
+++ b/website/src/pages/LandingPage.tsx
@@ -130,6 +130,12 @@ const graphCapabilities = [
   },
   {
     number: '06',
+    label: 'Free · manual · offline',
+    title: 'Move one verified graph without a cloud.',
+    body: 'Export the exact ready, clean graph for the current commit, inspect and fully verify the artifact against an independently obtained SHA-256 digest, then import it from a local checkout of the same repository. No account, hosted service, or Workset is required.',
+  },
+  {
+    number: '07',
     label: 'Manager visualization',
     title: 'Explore the graph without reading raw rows.',
     body: 'The local Manager lets you search and walk current symbols, inspect relationship provenance, and request architecture signals on demand with mocked-data demos available publicly.',
@@ -241,6 +247,9 @@ function GraphSearchShowcase() {
             </a>
             <a className="button button--ghost" href={docsArticleHref('graph-operations')}>
               Graph search docs
+            </a>
+            <a className="button button--ghost" href={docsArticleHref('graph-checkpoints')}>
+              Graph checkpoint docs
             </a>
           </div>
         </div>

--- a/website/src/pages/LandingPage.tsx
+++ b/website/src/pages/LandingPage.tsx
@@ -101,8 +101,8 @@ const graphCapabilities = [
   {
     number: '01',
     label: 'Current-worktree truth',
-    title: 'Reuse the graph work. Keep the checkout truth.',
-    body: 'Graph-equivalent commits reuse ready content, and compatible clean commits build a bounded delta. Staged, unstaged, renamed, deleted, and eligible untracked files still become an isolated overlay for this linked worktree—even when an orchestrator is running other agents beside it.',
+    title: 'Reuse graph work without pinning the control plane.',
+    body: 'Graph-equivalent commits reuse ready content, while compatible clean commits build bounded deltas. Manager-launched indexing and Workset preparation run in isolated processes, with bounded member concurrency; dirty overlays remain scoped to their own linked worktree.',
   },
   {
     number: '02',
@@ -204,7 +204,7 @@ function GraphSearchShowcase() {
 
       <a className="graph-showcase__performance-cta" href={siteHref('performance/')}>
         <div>
-          <span className="eyebrow">Large repositories · fast worktrees</span>
+          <span className="eyebrow">4.4 graph pipeline · large repositories · fast worktrees</span>
           <h3>Inspect the exact-release evidence behind proportional graph updates.</h3>
         </div>
         <p>
@@ -316,7 +316,7 @@ export default function LandingPage() {
         <div className="hero__copy">
           <div className="hero__version">
             <span className="status-dot" />
-            Threadnote 4 · self-contained
+            Threadnote 4.4 · self-contained
           </div>
           <h1>
             Your team remembers.
@@ -389,8 +389,9 @@ export default function LandingPage() {
           <h2>One prompt. Memory, current code, and honest freshness.</h2>
           <p>
             Memory explains what people learned and decided. The graph explains what the current worktree contains.
-            Optional citations let Context Brief keep warnings beside moved, changed, deleted, or unverifiable evidence;
-            uncited memories still participate in recall.
+            Optional citations let Context Brief distinguish evidence that moved unchanged from evidence that changed,
+            disappeared, or could not be verified. A stale-link warning means the evidence moved—not that the memory
+            became stale—and older uncited memories still participate in recall.
           </p>
         </header>
         <AgentTrace scenario={heroScenario} />

--- a/website/src/pages/ProTipsPage.tsx
+++ b/website/src/pages/ProTipsPage.tsx
@@ -63,11 +63,11 @@ export default function ProTipsPage() {
     <SiteShell page="pro-tips" fullBleed>
       <section className="subpage-hero">
         <div>
-          <span className="eyebrow">Field guide</span>
+          <span className="eyebrow">Threadnote 4.4 field guide</span>
           <h1>Keep context moving at the speed of the work.</h1>
           <p>
-            Practical patterns for turning individual agent sessions into durable team leverage—with explicit
-            boundaries, source-aware memory, and evidence you can inspect.
+            Practical patterns for turning individual agent sessions into durable team leverage—with source-aware
+            memory, optional code citations, reusable graph work, and explicit trust boundaries.
           </p>
         </div>
         <div className="subpage-hero__metric">


### PR DESCRIPTION
## Summary

- distinguish stale citation locators from stale memory more explicitly across Home, Pro Tips, and FAQ
- surface shipped 4.4 Manager graph-index and Workset preparation process isolation, including bounded member concurrency
- document the merged portable graph-checkpoint workflow across Home, Pro Tips, and FAQ: export an exact ready clean graph; carry the artifact and independently obtained digest; inspect, fully verify, and import locally
- make the portability boundary explicit: free, manual, offline, no account or hosted service, no Workset required, and existing schema-v1 or uncited legacy memories unaffected
- preserve the existing Pro Tips mobile containment fix; responsive CSS is unchanged

## Verification

- `bun run site:check` (78 tests)
- `bun run site:build` (49 crawler-visible docs pages, 2 articles, 34 release posts)
- commit hook: lint, Prettier, and full typecheck

Fresh browser screenshots remain unavailable because no browser backend is connected; the existing narrow-width Pro Tips containment regression passed and no CSS changed.