### PR TITLE
fix(code-graph): distinguish recycled worktree admins

### DIFF
--- a/src/code_graph/git_worktree_backlink.ts
+++ b/src/code_graph/git_worktree_backlink.ts
@@ -1,0 +1,92 @@
+import {
+  platformPathFor,
+  runtimeLstat,
+  runtimePlatform,
+  runtimeReadBoundedStableRegularFile,
+  type RuntimeBigIntStats,
+} from '../effect/system.js';
+
+export const CODE_GRAPH_GITDIR_BACKLINK_BYTES_LIMIT = 16 * 1_024;
+
+/**
+ * Inspect only the bounded `gitdir` backlink inside one matching Git admin entry.
+ * `undefined` is fail-closed: the entry, backlink, or their identities were not stable.
+ */
+export async function observeCodeGraphGitdirBacklinkMatches(
+  registryRoot: string,
+  adminNameBytes: Uint8Array,
+  canonicalWorktreePaths: readonly string[],
+): Promise<readonly boolean[] | undefined> {
+  try {
+    const path = platformPathFor(runtimePlatform);
+    const adminName = new TextDecoder('utf-8', {fatal: true, ignoreBOM: true}).decode(adminNameBytes);
+    if (!adminName || path.basename(adminName) !== adminName || adminName === '.' || adminName === '..') {
+      return undefined;
+    }
+    const adminEntry = path.join(registryRoot, adminName);
+    if (path.dirname(adminEntry) !== registryRoot) return undefined;
+    const entryBefore = await stableDirectory(adminEntry);
+    const gitdir = path.join(adminEntry, 'gitdir');
+    if (path.dirname(gitdir) !== adminEntry) return undefined;
+    const content = await runtimeReadBoundedStableRegularFile(gitdir, CODE_GRAPH_GITDIR_BACKLINK_BYTES_LIMIT);
+    const entryAfter = await stableDirectory(adminEntry);
+    if (!sameStableDirectory(entryBefore, entryAfter)) return undefined;
+    const matches = canonicalWorktreePaths.map(canonicalWorktreePath =>
+      codeGraphGitdirBacklinkMatchesCanonicalWorktree(content, canonicalWorktreePath, adminEntry, runtimePlatform),
+    );
+    return matches.some(match => match === undefined) ? undefined : (matches as readonly boolean[]);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse Git's LF/CRLF backlink without opening the referenced private path. */
+export function codeGraphGitdirBacklinkMatchesCanonicalWorktree(
+  content: Uint8Array,
+  canonicalWorktreePath: string,
+  adminEntry: string,
+  platform: NodeJS.Platform,
+): boolean | undefined {
+  if (content.byteLength === 0 || content.byteLength > CODE_GRAPH_GITDIR_BACKLINK_BYTES_LIMIT) return undefined;
+  try {
+    const decoded = new TextDecoder('utf-8', {fatal: true, ignoreBOM: true}).decode(content);
+    if (!decoded.endsWith('\n')) return undefined;
+    const backlink = decoded.endsWith('\r\n') ? decoded.slice(0, -2) : decoded.slice(0, -1);
+    if (!backlink || backlink.includes('\0') || backlink.includes('\r') || backlink.includes('\n')) return undefined;
+    const path = platformPathFor(platform);
+    if (!path.isAbsolute(canonicalWorktreePath) || !path.isAbsolute(adminEntry)) return undefined;
+    const observedPath = path.isAbsolute(backlink) ? path.normalize(backlink) : path.resolve(adminEntry, backlink);
+    const observed = comparablePath(observedPath, platform);
+    const expected = comparablePath(path.join(canonicalWorktreePath, '.git'), platform);
+    return observed === expected;
+  } catch {
+    return undefined;
+  }
+}
+
+async function stableDirectory(candidate: string): Promise<RuntimeBigIntStats> {
+  const info = await runtimeLstat(candidate);
+  if (!info.isDirectory() || info.isSymbolicLink() || info.dev === 0n || info.ino === 0n) {
+    throw new Error('Git worktree admin entry is not a stable directory.');
+  }
+  return info;
+}
+
+function sameStableDirectory(left: RuntimeBigIntStats, right: RuntimeBigIntStats): boolean {
+  return (
+    left.isDirectory() &&
+    right.isDirectory() &&
+    !left.isSymbolicLink() &&
+    !right.isSymbolicLink() &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function comparablePath(value: string, platform: NodeJS.Platform): string {
+  return platform === 'win32' ? value.normalize('NFC').toLowerCase() : value;
+}

--- a/src/code_graph/git_worktree_registration.ts
+++ b/src/code_graph/git_worktree_registration.ts
@@ -11,6 +11,7 @@ import {
   type SystemInfoShape,
 } from '../effect/system.js';
 import {CODE_GRAPH_GIT_WORKTREE_REGISTRATION_WORKER_ARGUMENT} from '../worker_protocol.js';
+import {observeCodeGraphGitdirBacklinkMatches} from './git_worktree_backlink.js';
 import type {RepositoryIdentity} from './types.js';
 
 const PROTOCOL_VERSION = 1 as const;
@@ -383,6 +384,7 @@ export async function scanCodeGraphWorktreeAuthorityWorkerRequest(
     request.checkoutId,
     request.gitCommonDirectory,
     request.targets.map(target => target.adminNameKeys),
+    request.targets.map(target => target.canonicalWorktreePath),
   );
   if (registry.state === 'unknown') return registry;
   return {
@@ -430,7 +432,11 @@ async function scanCodeGraphGitWorktreeRegistryTargetSets(
   checkoutId: string,
   gitCommonDirectory: string,
   adminNameKeySets: readonly (readonly string[])[],
+  canonicalWorktreePaths?: readonly string[],
 ): Promise<CodeGraphGitWorktreeRegistryBatchObservation> {
+  if (canonicalWorktreePaths !== undefined && canonicalWorktreePaths.length !== adminNameKeySets.length) {
+    return {reason: 'invalid', state: 'unknown'};
+  }
   try {
     const path = platformPathFor(runtimePlatform);
     const commonBefore = await lstatStableDirectory(gitCommonDirectory);
@@ -481,8 +487,23 @@ async function scanCodeGraphGitWorktreeRegistryTargetSets(
       }
       const keys = codeGraphGitWorktreeAdminNameKeys(checkoutId, nameBytes);
       exactEntryKeys.push(keys[0]!);
+      const matchingTargetIndexes = new Set<number>();
       for (const key of keys) {
-        for (const index of targetIndexesByKey.get(key) ?? []) targetPresence[index] = true;
+        for (const index of targetIndexesByKey.get(key) ?? []) matchingTargetIndexes.add(index);
+      }
+      if (canonicalWorktreePaths === undefined) {
+        for (const index of matchingTargetIndexes) targetPresence[index] = true;
+      } else if (matchingTargetIndexes.size > 0) {
+        const indexes = [...matchingTargetIndexes];
+        const matches = await observeCodeGraphGitdirBacklinkMatches(
+          registryRoot,
+          nameBytes,
+          indexes.map(index => canonicalWorktreePaths[index]!),
+        );
+        if (matches === undefined) return {reason: 'ambiguous', state: 'unknown'};
+        for (const [matchIndex, matchesTarget] of matches.entries()) {
+          if (matchesTarget) targetPresence[indexes[matchIndex]!] = true;
+        }
       }
     }
 

--- a/src/effect/system.ts
+++ b/src/effect/system.ts
@@ -26,12 +26,33 @@ export interface PlatformPathShape {
 
 interface NativeFileSystemPromisesShape {
   readonly lstat: (path: string, options: {readonly bigint: true}) => Promise<RuntimeBigIntStats>;
+  readonly open: (path: string, flags: number) => Promise<RuntimeFileHandle>;
   readonly opendir: (
     path: string,
     options: {readonly bufferSize: number; readonly encoding: 'buffer' | 'utf8'},
   ) => Promise<RuntimeDirectoryHandle>;
   readonly stat: (path: string, options: {readonly bigint: true}) => Promise<RuntimeBigIntStats>;
   readonly statfs?: (path: string, options: {readonly bigint: true}) => Promise<unknown>;
+}
+
+interface RuntimeFileHandle {
+  readonly close: () => Promise<void>;
+  readonly read: (
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    position: null,
+  ) => Promise<{readonly bytesRead: number}>;
+  readonly stat: (options: {readonly bigint: true}) => Promise<RuntimeBigIntStats>;
+}
+
+interface NativeFileSystemModuleShape {
+  readonly constants: {
+    readonly O_NOFOLLOW?: number;
+    readonly O_NONBLOCK?: number;
+    readonly O_RDONLY: number;
+  };
+  readonly promises: NativeFileSystemPromisesShape;
 }
 
 interface NativePathModuleShape {
@@ -101,8 +122,8 @@ export const runtimeArchitecture = process.arch;
 export const runtimePlatform = process.platform;
 const nativeOperatingSystemModule = process.getBuiltinModule('os') as NativeOperatingSystemModuleShape;
 export const runtimeOperatingSystemRelease = nativeOperatingSystemModule.release();
-const nativeFileSystemPromises = (process.getBuiltinModule('fs') as {readonly promises: NativeFileSystemPromisesShape})
-  .promises;
+const nativeFileSystemModule = process.getBuiltinModule('fs') as NativeFileSystemModuleShape;
+const nativeFileSystemPromises = nativeFileSystemModule.promises;
 const nativePathModule = process.getBuiltinModule('path') as NativePathModuleShape;
 
 export function platformPathFor(platform: NodeJS.Platform): PlatformPathShape {
@@ -127,9 +148,76 @@ export function runtimeLstat(path: string): Promise<RuntimeBigIntStats> {
   return nativeFileSystemPromises.lstat(path, {bigint: true});
 }
 
+/** Read one regular file without following a stable symbolic-link target and reject path/file races. */
+export async function runtimeReadBoundedStableRegularFile(path: string, maximumBytes: number): Promise<Uint8Array> {
+  if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 0 || maximumBytes >= Number.MAX_SAFE_INTEGER) {
+    throw new SystemOperationError('Invalid read bound.');
+  }
+  const pathBefore = await nativeFileSystemPromises.lstat(path, {bigint: true});
+  if (!stableRegularFile(pathBefore) || pathBefore.size > BigInt(maximumBytes)) {
+    throw new SystemOperationError('Target is not a bounded stable regular file.');
+  }
+  const flags =
+    nativeFileSystemModule.constants.O_RDONLY |
+    (nativeFileSystemModule.constants.O_NONBLOCK ?? 0) |
+    (runtimePlatform === 'win32' ? 0 : (nativeFileSystemModule.constants.O_NOFOLLOW ?? 0));
+  const opened = await nativeFileSystemPromises.open(path, flags);
+  try {
+    const [openedBefore, pathOpened] = await Promise.all([
+      opened.stat({bigint: true}),
+      nativeFileSystemPromises.lstat(path, {bigint: true}),
+    ]);
+    if (!sameStableRegularFile(pathBefore, openedBefore) || !sameStableRegularFile(pathBefore, pathOpened)) {
+      throw new SystemOperationError('Target changed while opening.');
+    }
+    const bytes = new Uint8Array(maximumBytes + 1);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const {bytesRead} = await opened.read(bytes, offset, bytes.length - offset, null);
+      if (!Number.isSafeInteger(bytesRead) || bytesRead < 0 || bytesRead > bytes.length - offset) {
+        throw new SystemOperationError('Target returned an invalid read size.');
+      }
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    const [openedAfter, pathAfter] = await Promise.all([
+      opened.stat({bigint: true}),
+      nativeFileSystemPromises.lstat(path, {bigint: true}),
+    ]);
+    if (
+      !sameStableRegularFile(pathBefore, openedAfter) ||
+      !sameStableRegularFile(pathBefore, pathAfter) ||
+      offset > maximumBytes ||
+      BigInt(offset) !== pathBefore.size
+    ) {
+      throw new SystemOperationError('Target changed during bounded read.');
+    }
+    return bytes.slice(0, offset);
+  } finally {
+    await opened.close();
+  }
+}
+
 /** Follows links while retaining exact device/inode identity beyond JavaScript's safe-integer range. */
 export function runtimeStat(path: string): Promise<RuntimeBigIntStats> {
   return nativeFileSystemPromises.stat(path, {bigint: true});
+}
+
+function stableRegularFile(info: RuntimeBigIntStats): boolean {
+  return info.isFile() && !info.isSymbolicLink() && info.dev !== 0n && info.ino !== 0n;
+}
+
+function sameStableRegularFile(left: RuntimeBigIntStats, right: RuntimeBigIntStats): boolean {
+  return (
+    stableRegularFile(left) &&
+    stableRegularFile(right) &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
 }
 
 /** Raw POSIX directory names stay bytes; enumeration stops immediately after the first over-limit entry. */

--- a/test/unit/code-graph.git-worktree-registration.property.test.ts
+++ b/test/unit/code-graph.git-worktree-registration.property.test.ts
@@ -1,6 +1,6 @@
-import {mkdirSync, mkdtempSync, rmSync} from '../helpers/node-fs.js';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from '../helpers/node-fs.js';
 import {tmpdir} from '../helpers/node-os.js';
-import {join} from '../helpers/node-path.js';
+import {join, relative} from '../helpers/node-path.js';
 import {it as effectIt} from '@effect/vitest';
 import {Effect} from 'effect';
 import fc from 'fast-check';
@@ -9,6 +9,7 @@ import {
   codeGraphGitWorktreeAdminNameKeys,
   scanCodeGraphGitWorktreeRegistry,
   scanCodeGraphGitWorktreeRegistryBatch,
+  scanCodeGraphWorktreeAuthorityWorkerRequest,
   type CodeGraphGitWorktreeRegistryRequest,
 } from '../../src/code_graph/git_worktree_registration.js';
 
@@ -93,6 +94,64 @@ describe('code graph common-gitdir authority properties', () => {
         registry => Effect.sync(() => rmSync(registry, {force: true, recursive: true})),
       );
     },
+  );
+
+  effectIt.effect.prop(
+    'classifies a recycled admin name by its exact backlink target for either Git line ending',
+    {
+      lineEnding: fc.constantFrom('\n', '\r\n'),
+      relativeBacklink: fc.boolean(),
+      segments: fc.uniqueArray(fc.stringMatching(/^[A-Za-z0-9][A-Za-z0-9._-]{0,15}$/), {
+        maxLength: 2,
+        minLength: 2,
+      }),
+      targetMatches: fc.boolean(),
+    },
+    ({lineEnding, relativeBacklink, segments, targetMatches}) =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => {
+          const common = registryFixture([]);
+          const adminName = 'recycled-admin';
+          const adminEntry = join(common, 'worktrees', adminName);
+          mkdirSync(adminEntry);
+          const target = join(common, 'removed', segments[0]!);
+          const replacement = join(common, 'replacement', segments[1]!);
+          const pointedAt = join(targetMatches ? target : replacement, '.git');
+          writeFileSync(
+            join(adminEntry, 'gitdir'),
+            `${relativeBacklink ? relative(adminEntry, pointedAt) : pointedAt}${lineEnding}`,
+          );
+          return {adminName, common, target};
+        }),
+        ({adminName, common, target}) =>
+          Effect.promise(() =>
+            scanCodeGraphWorktreeAuthorityWorkerRequest({
+              checkoutId: CHECKOUT_ID,
+              gitCommonDirectory: common,
+              kind: 'reconciliation-authority',
+              protocol: 3,
+              targets: [
+                {
+                  adminNameKeys: codeGraphGitWorktreeAdminNameKeys(CHECKOUT_ID, adminName),
+                  canonicalWorktreePath: target,
+                  evidenceToken: 'b'.repeat(64),
+                },
+              ],
+            }),
+          ).pipe(
+            Effect.tap(observation =>
+              Effect.sync(() => {
+                expect(observation).toMatchObject({
+                  pathStates: ['missing'],
+                  registryStates: [targetMatches ? 'present' : 'absent'],
+                  state: 'complete',
+                });
+              }),
+            ),
+            Effect.asVoid,
+          ),
+        ({common}) => Effect.sync(() => rmSync(common, {force: true, recursive: true})),
+      ),
   );
 });
 

--- a/test/unit/code-graph.git-worktree-registration.test.ts
+++ b/test/unit/code-graph.git-worktree-registration.test.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from '../helpers/node-fs.js';
 import {tmpdir} from '../helpers/node-os.js';
-import {join} from '../helpers/node-path.js';
+import {join, relative} from '../helpers/node-path.js';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {it as effectIt} from '@effect/vitest';
 import {Effect, Fiber, Layer} from 'effect';
@@ -30,6 +30,7 @@ import {
   parseCodeGraphWorktreeReconciliationAuthorityResponse,
   scanCodeGraphGitWorktreeRegistry,
   scanCodeGraphGitWorktreeRegistryBatch,
+  scanCodeGraphWorktreeAuthorityWorkerRequest,
   validCodeGraphWorktreeAuthorityWorkerRequest,
   type CodeGraphGitWorktreeRegistryRequest,
   type CodeGraphWorktreeReconciliationAuthorityRequest,
@@ -38,6 +39,7 @@ import {CommandExecutor} from '../../src/effect/command.js';
 import {runtimeDirectoryNamePage, SystemInfo} from '../../src/effect/system.js';
 import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
 import {CODE_GRAPH_GIT_WORKTREE_REGISTRATION_WORKER_ARGUMENT} from '../../src/worker_protocol.js';
+import {codeGraphGitdirBacklinkMatchesCanonicalWorktree} from '../../src/code_graph/git_worktree_backlink.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
 const roots: string[] = [];
@@ -127,8 +129,22 @@ describe('code graph common-gitdir worktree authority', () => {
       gitCommonDirectory: linkedIdentity.gitCommonDirectory,
       protocol: 1,
     });
+    const authority = await scanCodeGraphWorktreeAuthorityWorkerRequest({
+      checkoutId: linkedIdentity.checkoutId,
+      gitCommonDirectory: linkedIdentity.gitCommonDirectory,
+      kind: 'reconciliation-authority',
+      protocol: 3,
+      targets: [
+        {
+          adminNameKeys: registration.kind === 'linked' ? registration.adminNameKeys : [],
+          canonicalWorktreePath: linkedIdentity.repoRoot,
+          evidenceToken: '1'.repeat(64),
+        },
+      ],
+    });
 
     expect(observation).toMatchObject({state: 'present'});
+    expect(authority).toMatchObject({pathStates: ['missing'], registryStates: ['present'], state: 'complete'});
     expect(JSON.stringify(observation)).not.toContain(linked);
     renameSync(unavailable, linked);
     roots.splice(roots.indexOf(unavailable), 1);
@@ -316,6 +332,151 @@ describe('code graph common-gitdir worktree authority', () => {
       expect(targets.every(target => !serialized.includes(target.canonicalWorktreePath))).toBe(true);
     }).pipe(provideTestLayer(authorityWorkerLayer)),
   );
+
+  effectIt.effect(
+    'treats a reused admin name as absent unless its stable gitdir backlink targets the recorded worktree',
+    () =>
+      Effect.gen(function* () {
+        const common = commonDirectoryFixture();
+        const adminName = 'threadnote9';
+        const adminEntry = join(common, 'worktrees', adminName);
+        mkdirSync(adminEntry);
+        const targetRoot = temporaryRoot('threadnote-recycled-admin-targets-');
+        const removedWorktree = join(targetRoot, 'removed-worktree');
+        const replacementWorktree = join(targetRoot, 'replacement-worktree');
+        const targets = [
+          {
+            adminNameKeys: codeGraphGitWorktreeAdminNameKeys(CHECKOUT_ID, adminName),
+            canonicalWorktreePath: removedWorktree,
+            evidenceToken: '3'.repeat(64),
+          },
+        ];
+
+        writeFileSync(join(adminEntry, 'gitdir'), `${join(replacementWorktree, '.git')}\n`);
+        const reused = yield* observeCodeGraphWorktreeReconciliationAuthority(
+          {checkoutId: CHECKOUT_ID, gitCommonDirectory: common},
+          targets,
+        );
+        expect(reused).toMatchObject({pathStates: ['missing'], registryStates: ['absent'], state: 'complete'});
+
+        writeFileSync(join(adminEntry, 'gitdir'), `${relative(adminEntry, join(removedWorktree, '.git'))}\r\n`);
+        const original = yield* observeCodeGraphWorktreeReconciliationAuthority(
+          {checkoutId: CHECKOUT_ID, gitCommonDirectory: common},
+          targets,
+        );
+        expect(original).toMatchObject({pathStates: ['missing'], registryStates: ['present'], state: 'complete'});
+        expect(JSON.stringify([reused, original])).not.toContain(targetRoot);
+      }).pipe(provideTestLayer(authorityWorkerLayer)),
+  );
+
+  it('fails closed when a matching admin entry has no stable regular gitdir backlink', async () => {
+    const common = commonDirectoryFixture();
+    const adminName = 'partial-reused-admin';
+    mkdirSync(join(common, 'worktrees', adminName));
+    const request = {
+      checkoutId: CHECKOUT_ID,
+      gitCommonDirectory: common,
+      kind: 'reconciliation-authority',
+      protocol: 3,
+      targets: [
+        {
+          adminNameKeys: codeGraphGitWorktreeAdminNameKeys(CHECKOUT_ID, adminName),
+          canonicalWorktreePath: join(temporaryRoot('threadnote-partial-admin-target-'), 'missing'),
+          evidenceToken: '4'.repeat(64),
+        },
+      ],
+    } satisfies CodeGraphWorktreeReconciliationAuthorityRequest;
+
+    expect(await scanCodeGraphWorktreeAuthorityWorkerRequest(request)).toEqual({
+      reason: 'ambiguous',
+      state: 'unknown',
+    });
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'fails closed instead of following a matching admin entry or gitdir symlink',
+    async () => {
+      const targetRoot = temporaryRoot('threadnote-symlink-admin-target-');
+      const canonicalWorktreePath = join(targetRoot, 'missing');
+      const external = temporaryRoot('threadnote-external-admin-entry-');
+      writeFileSync(join(external, 'gitdir'), `${join(canonicalWorktreePath, '.git')}\n`);
+      for (const kind of ['admin', 'gitdir'] as const) {
+        const common = commonDirectoryFixture();
+        const adminName = `symlink-${kind}`;
+        const adminEntry = join(common, 'worktrees', adminName);
+        if (kind === 'admin') symlinkSync(external, adminEntry);
+        else {
+          mkdirSync(adminEntry);
+          symlinkSync(join(external, 'gitdir'), join(adminEntry, 'gitdir'));
+        }
+        const observation = await scanCodeGraphWorktreeAuthorityWorkerRequest({
+          checkoutId: CHECKOUT_ID,
+          gitCommonDirectory: common,
+          kind: 'reconciliation-authority',
+          protocol: 3,
+          targets: [
+            {
+              adminNameKeys: codeGraphGitWorktreeAdminNameKeys(CHECKOUT_ID, adminName),
+              canonicalWorktreePath,
+              evidenceToken: '5'.repeat(64),
+            },
+          ],
+        });
+        expect(observation).toEqual({reason: 'ambiguous', state: 'unknown'});
+      }
+    },
+  );
+
+  it('normalizes Git LF/CRLF backlink spelling across supported platform path formats', () => {
+    expect(
+      codeGraphGitdirBacklinkMatchesCanonicalWorktree(
+        Buffer.from('/private/worktree/.git\n'),
+        '/private/worktree',
+        '/private/repository/.git/worktrees/threadnote',
+        'linux',
+      ),
+    ).toBe(true);
+    expect(
+      codeGraphGitdirBacklinkMatchesCanonicalWorktree(
+        Buffer.from('c:/Private/Worktree/.git\r\n'),
+        'C:\\private\\worktree',
+        'C:\\repository\\.git\\worktrees\\threadnote',
+        'win32',
+      ),
+    ).toBe(true);
+    expect(
+      codeGraphGitdirBacklinkMatchesCanonicalWorktree(
+        Buffer.from('/private/replacement/.git\n'),
+        '/private/worktree',
+        '/private/repository/.git/worktrees/threadnote',
+        'linux',
+      ),
+    ).toBe(false);
+    expect(
+      codeGraphGitdirBacklinkMatchesCanonicalWorktree(
+        Buffer.from('/private/worktree/.git'),
+        '/private/worktree',
+        '/private/repository/.git/worktrees/threadnote',
+        'linux',
+      ),
+    ).toBeUndefined();
+    expect(
+      codeGraphGitdirBacklinkMatchesCanonicalWorktree(
+        Buffer.from('../../../../worktree/.git\n'),
+        '/private/worktree',
+        '/private/repository/.git/worktrees/threadnote',
+        'linux',
+      ),
+    ).toBe(true);
+    expect(
+      codeGraphGitdirBacklinkMatchesCanonicalWorktree(
+        Buffer.from('..\\..\\..\\..\\worktree\\.git\r\n'),
+        'C:\\private\\worktree',
+        'C:\\private\\repository\\.git\\worktrees\\threadnote',
+        'win32',
+      ),
+    ).toBe(true);
+  });
 
   effectIt.effect('rejects over-page authority before spawning and strictly parses malformed responses', () =>
     Effect.gen(function* () {

--- a/test/unit/code-graph.worktree-reconciliation.test.ts
+++ b/test/unit/code-graph.worktree-reconciliation.test.ts
@@ -1504,7 +1504,7 @@ describe('automatic missing-worktree reconciliation', () => {
     ),
   );
 
-  effectIt.effect('preserves a real graph view when the linked admin child reappears as a raw file', () =>
+  effectIt.effect('defers and preserves a real graph view when the linked admin child reappears as a raw file', () =>
     TestClock.withLive(
       Effect.gen(function* () {
         const fixture = yield* createLiveReconciliationFixture('threadnote-reconciliation-live-admin-');
@@ -1517,7 +1517,7 @@ describe('automatic missing-worktree reconciliation', () => {
 
         const result = yield* observed.reconciler.tick(liveTick(fixture));
 
-        expect(result).toMatchObject({reason: 'registered', state: 'preserved'});
+        expect(result).toMatchObject({reason: 'registry-unavailable', state: 'deferred'});
         expect(yield* Ref.get(observed.workerCalls)).toBe(1);
         expect(readViewState(fixture)).toEqual({
           activeSnapshotId: fixture.snapshotId,


### PR DESCRIPTION
## Summary

- make protocol-v3 reconciliation authority distinguish an exact linked-worktree registration from a reused Git admin-directory name
- inspect only matching admin entries and require a bounded, stable, regular gitdir backlink with before/after identity checks
- support absolute and Git relative-worktree backlinks with LF or CRLF while keeping protocol-v1/v2 name-only observations unchanged
- keep malformed, partial, symlinked, raced, or unavailable matches fail-closed and path-free

## Why

Git can recycle an administrative worktree directory name after an old linked worktree disappears. Threadnote previously treated the checkout-bound hash of that name as sufficient presence proof, which could strand an orphan provenance sidecar forever when the recycled entry belonged to a different live worktree.

## Verification

- focused registration and reconciliation matrix: 116/116 passed
- bounded Fast-check property varies exact vs recycled targets, absolute vs relative backlinks, and LF vs CRLF
- source and test TypeScript checks passed
- strict lint, formatting, production file-length lint, and diff checks passed
- independent critical/important review: clean

The real orphan provenance record was not mutated. Full CI remains authoritative.