### PR TITLE
fix(ci): isolate workset projection boundary test

### DIFF
--- a/src/code_graph/workset_catalog/projection_storage.ts
+++ b/src/code_graph/workset_catalog/projection_storage.ts
@@ -3,6 +3,12 @@ import {codeGraphWorksetRoutingExactKeys} from './routing_normalization.js';
 import type {CodeGraphWorksetRoutingSymbolV1} from './types.js';
 
 const ROUTING_ROW_STORAGE_CHARGE_BYTES = 256;
+export const CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM = 512;
+
+export interface CodeGraphWorksetRoutingProjectionPageOptions {
+  readonly pageBytesMaximum?: number;
+  readonly pageSymbolsMaximum?: number;
+}
 
 /** Canonical additive charge for every routing row and derived exact-key row. */
 export function codeGraphWorksetRoutingProjectionLogicalBytes(
@@ -41,6 +47,55 @@ export function codeGraphWorksetRoutingProjectionLogicalBytesAppend(
     }
   }
   return bytes;
+}
+
+/** Lazily partition one source page by both catalog writer bounds. */
+export function* codeGraphWorksetRoutingProjectionPages(
+  symbols: readonly CodeGraphWorksetRoutingSymbolV1[],
+  options: CodeGraphWorksetRoutingProjectionPageOptions = {},
+): Generator<readonly CodeGraphWorksetRoutingSymbolV1[]> {
+  const pageBytesMaximum = boundedPageLimit(
+    options.pageBytesMaximum,
+    CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionPageBytesMaximum,
+    'byte',
+  );
+  const pageSymbolsMaximum = boundedPageLimit(
+    options.pageSymbolsMaximum,
+    CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM,
+    'symbol',
+  );
+  let page: CodeGraphWorksetRoutingSymbolV1[] = [];
+  let pageBytes = 0;
+  for (const symbol of symbols) {
+    // The charge is additive, so calculate each symbol once instead of
+    // serializing its complete routing surface twice at every boundary.
+    const symbolBytes = codeGraphWorksetRoutingProjectionLogicalBytes([symbol]);
+    if (symbolBytes > pageBytesMaximum) {
+      throw new CodeGraphWorksetCatalogError(
+        'capacity',
+        'A routing symbol exceeds the supported projection page bound.',
+      );
+    }
+    if (page.length > 0 && (page.length === pageSymbolsMaximum || pageBytes > pageBytesMaximum - symbolBytes)) {
+      yield page;
+      page = [];
+      pageBytes = 0;
+    }
+    page.push(symbol);
+    pageBytes += symbolBytes;
+  }
+  if (page.length > 0) yield page;
+}
+
+function boundedPageLimit(value: number | undefined, maximum: number, label: string): number {
+  const selected = value ?? maximum;
+  if (!Number.isSafeInteger(selected) || selected < 1 || selected > maximum) {
+    throw new CodeGraphWorksetCatalogError(
+      'invalid-input',
+      `Workset routing projection page ${label} bound is invalid.`,
+    );
+  }
+  return selected;
 }
 
 function projectionCapacityError(): CodeGraphWorksetCatalogError {

--- a/src/code_graph/workset_catalog/snapshot_projection.ts
+++ b/src/code_graph/workset_catalog/snapshot_projection.ts
@@ -13,7 +13,11 @@ import {
   createCodeGraphWorksetRoutingProjection,
   normalizeCodeGraphWorksetRoutingSymbol,
 } from './projection.js';
-import {codeGraphWorksetRoutingProjectionLogicalBytesAppend} from './projection_storage.js';
+import {
+  CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM,
+  codeGraphWorksetRoutingProjectionLogicalBytesAppend,
+  codeGraphWorksetRoutingProjectionPages,
+} from './projection_storage.js';
 import {
   CODE_GRAPH_WORKSET_CATALOG_LIMITS,
   CODE_GRAPH_WORKSET_CATALOG_PROJECTOR_VERSION,
@@ -26,7 +30,7 @@ import {
 } from './types.js';
 
 const DEFAULT_PAGE_SIZE = 256;
-const MAXIMUM_PAGE_SIZE = 512;
+const MAXIMUM_PAGE_SIZE = CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM;
 const DEFAULT_LEASE_MILLISECONDS = 2 * 60_000;
 const MINIMUM_LEASE_MILLISECONDS = 30_000;
 const MAXIMUM_LEASE_MILLISECONDS = 10 * 60_000;
@@ -718,24 +722,9 @@ function appendBoundedProjectionPages<E, R>(
   symbols: readonly CodeGraphWorksetRoutingSymbolV1[],
 ) {
   return Effect.gen(function* () {
-    let page: CodeGraphWorksetRoutingSymbolV1[] = [];
-    let pageBytes = 0;
-    for (const symbol of symbols) {
-      const nextBytes = codeGraphWorksetRoutingProjectionLogicalBytesAppend(pageBytes, [symbol]);
-      if (page.length > 0 && nextBytes > CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionPageBytesMaximum) {
-        yield* sink.append(projectionDigest, stagingToken, page);
-        page = [];
-        pageBytes = 0;
-      }
-      pageBytes = codeGraphWorksetRoutingProjectionLogicalBytesAppend(pageBytes, [symbol]);
-      if (pageBytes > CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionPageBytesMaximum) {
-        return yield* Effect.fail(
-          new CodeGraphWorksetCatalogError('capacity', 'A routing symbol exceeds the supported projection page bound.'),
-        );
-      }
-      page.push(symbol);
+    for (const page of codeGraphWorksetRoutingProjectionPages(symbols)) {
+      yield* sink.append(projectionDigest, stagingToken, page);
     }
-    if (page.length > 0) yield* sink.append(projectionDigest, stagingToken, page);
   });
 }
 

--- a/src/code_graph/workset_catalog/store.ts
+++ b/src/code_graph/workset_catalog/store.ts
@@ -98,8 +98,9 @@ import {
   corrupt,
 } from './store_support.js';
 import {
+  CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM,
   codeGraphWorksetRoutingProjectionLogicalBytes,
-  codeGraphWorksetRoutingProjectionLogicalBytesAppend,
+  codeGraphWorksetRoutingProjectionPages,
 } from './projection_storage.js';
 import {
   codeGraphWorksetCatalogWriteRequiredFreeBytes,
@@ -113,7 +114,7 @@ const CATALOG_LOCK_OPTIONS = {
   staleAfterMilliseconds: 30_000,
   waitTimeoutMilliseconds: 30_000,
 } as const;
-export const CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM = 512;
+export {CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM} from './projection_storage.js';
 const GENERATION_ID = /^cgwg_[0-9a-f]{40}$/u;
 const QUALIFIED_REF = /^cgr_[0-9a-f]{40}$/u;
 const CONTINUATION_CURSOR = /^cgwc_[0-9a-f]{40}$/u;
@@ -527,32 +528,7 @@ function appendFullProjectionPages(
   symbols: readonly CodeGraphWorksetRoutingSymbolV1[],
 ) {
   return Effect.gen(function* () {
-    let page: CodeGraphWorksetRoutingSymbolV1[] = [];
-    let pageBytes = 0;
-    for (const symbol of symbols) {
-      const nextBytes = codeGraphWorksetRoutingProjectionLogicalBytesAppend(pageBytes, [symbol]);
-      if (
-        page.length > 0 &&
-        (page.length === CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM ||
-          nextBytes > CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionPageBytesMaximum)
-      ) {
-        yield* appendCodeGraphWorksetCatalogProjectionPage(threadnoteHome, {
-          projectionDigest,
-          stagingToken,
-          symbols: page,
-        });
-        page = [];
-        pageBytes = 0;
-      }
-      pageBytes = codeGraphWorksetRoutingProjectionLogicalBytesAppend(pageBytes, [symbol]);
-      if (pageBytes > CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionPageBytesMaximum) {
-        return yield* Effect.fail(
-          new CodeGraphWorksetCatalogError('capacity', 'A routing symbol exceeds the supported projection page bound.'),
-        );
-      }
-      page.push(symbol);
-    }
-    if (page.length > 0) {
+    for (const page of codeGraphWorksetRoutingProjectionPages(symbols)) {
       yield* appendCodeGraphWorksetCatalogProjectionPage(threadnoteHome, {
         projectionDigest,
         stagingToken,

--- a/src/code_graph/workset_catalog/store_support.ts
+++ b/src/code_graph/workset_catalog/store_support.ts
@@ -48,7 +48,7 @@ const CATALOG_LOCK_OPTIONS = {
   waitTimeoutMilliseconds: 30_000,
 } as const;
 const PROJECTION_INSERT_BATCH_SIZE = 256;
-export const CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM = 512;
+export {CODE_GRAPH_WORKSET_CATALOG_PROJECTION_PAGE_MAXIMUM} from './projection_storage.js';
 const CATALOG_RETIREMENT_LIMIT_MAXIMUM = 1_000;
 const GENERATION_ID = /^cgwg_[0-9a-f]{40}$/u;
 const QUALIFIED_REF = /^cgr_[0-9a-f]{40}$/u;

--- a/test/ci/vitest-plan.ts
+++ b/test/ci/vitest-plan.ts
@@ -39,6 +39,7 @@ export const ciLongRunningTestGroups = {
     'test/unit/code-graph.languages.test.ts',
   ],
   'heavy-state': [
+    'test/unit/code-graph.workset-catalog-projection.test.ts',
     'test/unit/code-graph.removed-view-cleanup.property.test.ts',
     'test/unit/code-graph.view-removal.property.test.ts',
     'test/unit/code-graph.worktree-reconciliation.test.ts',

--- a/test/ci/vitest-plan.ts
+++ b/test/ci/vitest-plan.ts
@@ -1,3 +1,5 @@
+export const CI_STANDARD_TEST_TIMEOUT_MILLISECONDS = 30_000;
+
 export const ciLongRunningTestGroups = {
   'lifecycle-alpha': ['test/integration/code-graph.lifecycle.test.ts'],
   'lifecycle-beta': ['test/integration/code-graph.lifecycle.test.ts'],

--- a/test/unit/ci-workflow.test.ts
+++ b/test/unit/ci-workflow.test.ts
@@ -3,6 +3,7 @@ import {JSON_SCHEMA, load} from 'js-yaml';
 import {describe, expect, it} from 'vitest';
 import {ciScopeKeys} from '../ci/ci-scopes.js';
 import {
+  CI_STANDARD_TEST_TIMEOUT_MILLISECONDS,
   ciLongRunningTestGroupNames,
   ciLongRunningTestGroups,
   ciRequiredLongRunningTestGroupNames,
@@ -166,9 +167,10 @@ describe('dependency-aware CI workflow', () => {
     ]);
   });
 
-  it('serializes the SQLite-heavy workset projection suite outside ordinary shards', () => {
+  it('serializes the SQLite-heavy workset projection suite without relaxing its ordinary timeout', () => {
     expect(ciLongRunningTestGroups['heavy-state']).toContain('test/unit/code-graph.workset-catalog-projection.test.ts');
     expect(ciSerializedLongRunningTestGroups.has('heavy-state')).toBe(true);
+    expect(CI_STANDARD_TEST_TIMEOUT_MILLISECONDS).toBe(30_000);
   });
 
   it('runs the actual-runtime citation gate on quality-relevant changes', () => {

--- a/test/unit/ci-workflow.test.ts
+++ b/test/unit/ci-workflow.test.ts
@@ -166,6 +166,11 @@ describe('dependency-aware CI workflow', () => {
     ]);
   });
 
+  it('serializes the SQLite-heavy workset projection suite outside ordinary shards', () => {
+    expect(ciLongRunningTestGroups['heavy-state']).toContain('test/unit/code-graph.workset-catalog-projection.test.ts');
+    expect(ciSerializedLongRunningTestGroups.has('heavy-state')).toBe(true);
+  });
+
   it('runs the actual-runtime citation gate on quality-relevant changes', () => {
     const ci = workflow('.github/workflows/ci.yml');
     const recallQuality = ci.jobs['recall-quality']!;

--- a/test/unit/code-graph.workset-catalog-projection.test.ts
+++ b/test/unit/code-graph.workset-catalog-projection.test.ts
@@ -13,6 +13,10 @@ import {
   stageCodeGraphWorksetRoutingProjectionScoped,
 } from '../../src/code_graph/workset_catalog/projection_builder.js';
 import {
+  codeGraphWorksetRoutingProjectionLogicalBytes,
+  codeGraphWorksetRoutingProjectionPages,
+} from '../../src/code_graph/workset_catalog/projection_storage.js';
+import {
   configureCodeGraphWorksetProjectionTemporaryStorage,
   inspectCodeGraphWorksetProjectionPreparationQueryPlan,
   prepareCodeGraphWorksetProjectionRoutingSurface,
@@ -20,6 +24,7 @@ import {
 import {
   CODE_GRAPH_WORKSET_CATALOG_LIMITS,
   CodeGraphWorksetCatalogError,
+  type CodeGraphWorksetRoutingSymbolV1,
 } from '../../src/code_graph/workset_catalog/types.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
@@ -329,38 +334,84 @@ describe('code graph ready-snapshot workset routing projections', () => {
     );
   });
 
-  it('splits a source page when its derived routing storage charge exceeds the catalog page bound', async () => {
-    const home = await temporaryHome(homes);
-    const identity = repositoryIdentity('storage-page-split');
-    const snapshotId = snapshotIdentity('storage-page-split');
+  it('splits a source page when its derived routing storage charge exceeds the catalog page bound', () => {
     const symbols = Array.from({length: 40}, (_, symbolIndex) =>
-      symbol(`wide${symbolIndex.toString().padStart(2, '0')}`, {
-        lookupKeys: Array.from(
+      routingSymbol(
+        `wide${symbolIndex.toString().padStart(2, '0')}`,
+        Array.from(
           {length: 64},
           (_, lookupIndex) =>
             `wide.${symbolIndex.toString().padStart(2, '0')}.${lookupIndex.toString().padStart(2, '0')}.${'x'.repeat(1_800)}`,
         ),
-      }),
-    );
-    await initializeGraph(home, identity.checkoutId);
-    seedGraph(
-      home,
-      identity,
-      [{effectiveSymbolCount: symbols.length, id: snapshotId, symbols, worktreeId: identity.worktreeId}],
-      [{snapshotId, worktreeId: identity.worktreeId}],
-    );
-
-    const staged = await runEffect(
-      Effect.scoped(
-        stageCodeGraphWorksetRoutingProjectionScoped({
-          identity,
-          pageSize: 512,
-          snapshotId,
-          threadnoteHome: home,
-        }),
       ),
     );
-    expect(staged.receipt.symbolCount).toBe(symbols.length);
+    const pages = [...codeGraphWorksetRoutingProjectionPages(symbols)];
+
+    expect(codeGraphWorksetRoutingProjectionLogicalBytes(symbols)).toBeGreaterThan(
+      CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionPageBytesMaximum,
+    );
+    expect(pages.length).toBeGreaterThan(1);
+    expect(pages.flat()).toEqual(symbols);
+    for (const page of pages) {
+      expect(codeGraphWorksetRoutingProjectionLogicalBytes(page)).toBeLessThanOrEqual(
+        CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionPageBytesMaximum,
+      );
+    }
+  });
+
+  it('greedily partitions arbitrary routing surfaces without reordering or overflowing a page', () => {
+    const shapes = fc.array(
+      fc.record({
+        lookupKeyCount: fc.integer({min: 1, max: 8}),
+        lookupKeyPayloadBytes: fc.integer({min: 1, max: 128}),
+      }),
+      {minLength: 1, maxLength: 48},
+    );
+
+    fc.assert(
+      fc.property(
+        shapes,
+        fc.integer({min: 0, max: 16_384}),
+        fc.integer({min: 1, max: 16}),
+        (entries, extraPageBytes, pageSymbolsMaximum) => {
+          const symbols = entries.map((entry, symbolIndex) =>
+            routingSymbol(
+              `property${symbolIndex.toString().padStart(2, '0')}`,
+              Array.from(
+                {length: entry.lookupKeyCount},
+                (_, lookupIndex) => `property.${symbolIndex}.${lookupIndex}.${'x'.repeat(entry.lookupKeyPayloadBytes)}`,
+              ),
+            ),
+          );
+          const largestSymbolBytes = Math.max(
+            ...symbols.map(symbol => codeGraphWorksetRoutingProjectionLogicalBytes([symbol])),
+          );
+          const pageBytesMaximum = Math.min(
+            CODE_GRAPH_WORKSET_CATALOG_LIMITS.projectionPageBytesMaximum,
+            largestSymbolBytes + extraPageBytes,
+          );
+          const options = {pageBytesMaximum, pageSymbolsMaximum};
+          const pages = [...codeGraphWorksetRoutingProjectionPages(symbols, options)];
+
+          expect(pages.flat()).toEqual(symbols);
+          expect([...codeGraphWorksetRoutingProjectionPages(symbols, options)]).toEqual(pages);
+          for (const page of pages) {
+            expect(page).not.toHaveLength(0);
+            expect(page.length).toBeLessThanOrEqual(pageSymbolsMaximum);
+            expect(codeGraphWorksetRoutingProjectionLogicalBytes(page)).toBeLessThanOrEqual(pageBytesMaximum);
+          }
+          for (let index = 0; index + 1 < pages.length; index += 1) {
+            const page = pages[index]!;
+            const next = pages[index + 1]!;
+            expect(
+              page.length === pageSymbolsMaximum ||
+                codeGraphWorksetRoutingProjectionLogicalBytes([...page, next[0]!]) > pageBytesMaximum,
+            ).toBe(true);
+          }
+        },
+      ),
+      {numRuns: 80},
+    );
   });
 
   effectIt.effect('prepares compact routing once per streamed pass instead of once per symbol page', () =>
@@ -879,6 +930,22 @@ function symbol(
     path: options.path ?? `src/${key}.ts`,
     qualifiedName: `fixture.${name}`,
     terms: options.terms ?? [{term: name.toLowerCase(), weight: 5}],
+  };
+}
+
+function routingSymbol(key: string, lookupKeys: readonly string[]): CodeGraphWorksetRoutingSymbolV1 {
+  return {
+    exported: true,
+    kind: 'function',
+    language: 'typescript',
+    lookupKeys,
+    name: key,
+    nodeId: nodeIdentity(key),
+    packageName: '@fixture/api',
+    path: `src/${key}.ts`,
+    qualifiedName: `fixture.${key}`,
+    span: {column: 1, endColumn: 2, endLine: 1, line: 1},
+    terms: [{term: key.toLowerCase(), weight: 5}],
   };
 }
 

--- a/test/unit/code-graph.workset-catalog-projection.test.ts
+++ b/test/unit/code-graph.workset-catalog-projection.test.ts
@@ -27,11 +27,14 @@ import {
   type CodeGraphWorksetRoutingSymbolV1,
 } from '../../src/code_graph/workset_catalog/types.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {CI_STANDARD_TEST_TIMEOUT_MILLISECONDS} from '../ci/vitest-plan.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {join, mkdtemp, rm} from '../helpers/effect-filesystem.js';
 import {runEffect} from '../helpers/effect-runtime.js';
 
-describe('code graph ready-snapshot workset routing projections', () => {
+// This suite is serialized in CI but deliberately keeps the ordinary regression ceiling.
+// prettier-ignore
+describe('code graph ready-snapshot workset routing projections', {timeout: CI_STANDARD_TEST_TIMEOUT_MILLISECONDS}, () => {
   const homes: string[] = [];
 
   afterEach(async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import {defineConfig} from 'vitest/config';
 import {
+  CI_STANDARD_TEST_TIMEOUT_MILLISECONDS,
   ciLongRunningTestGroups,
   ciSerializedLongRunningTestGroups,
   type CiLongRunningTestGroupName,
@@ -58,7 +59,12 @@ export default defineConfig({
     testNamePattern: ciLongRunningGroupName ? ciLongRunningTestPatterns[ciLongRunningGroupName] : undefined,
     // Long groups are independently bounded jobs; ordinary shards retain the
     // same fast timeout as local runs so new regressions fail promptly.
-    testTimeout: ciLongRunningGroupName === 'load-evidence' ? 600_000 : ciLongRunningGroupName ? 180_000 : 30_000,
+    testTimeout:
+      ciLongRunningGroupName === 'load-evidence'
+        ? 600_000
+        : ciLongRunningGroupName
+          ? 180_000
+          : CI_STANDARD_TEST_TIMEOUT_MILLISECONDS,
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

- centralize the lazy routing-projection page partitioner and reuse it in both catalog writers
- calculate each routing symbol charge once per partitioning pass
- replace the 8 MiB SQLite-heavy boundary fixture with a direct production-bound regression and a bounded Fast-check property
- run the remaining SQLite-heavy projection suite in the existing serialized `heavy-state` lane while explicitly retaining the ordinary 30-second per-test ceiling

## Root cause

In run 33175910154 job 98864446109, the exact test timed out after 33.5 seconds while its whole file took 104 seconds and the sibling workset catalog file took 55 seconds on the same two-worker shard. Eight preceding successful runs completed the exact test in 2.3-4.2 seconds and the file in 11-22 seconds. This was broad runner starvation amplified by two concurrent SQLite-heavy suites, not a routing writer deadlock.

The old regression wrote more than 8 MiB of derived rows through SQLite to test a pure partitioning boundary, and it only asserted the resulting symbol count. The new regression exercises the real 8 MiB default directly, preserves order, and verifies every page stays within the storage bound. No timeout was increased and no assertion was weakened.

## Verification

- exact post-#298 frozen dependencies installed (`vitest` 4.1.11)
- `bun --bun vitest run test/unit/code-graph.workset-catalog-projection.test.ts test/unit/code-graph.workset-catalog.test.ts test/unit/ci-workflow.test.ts --reporter=verbose` (39 passed)
- `THREADNOTE_VITEST_LONG_GROUP=heavy-state bun --bun vitest run test/unit/code-graph.workset-catalog-projection.test.ts --reporter=verbose` (12 passed under the retained 30-second ceiling)
- CI test-plan discovery confirms the suite is absent from ordinary shards and present in serialized `heavy-state`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `git diff --check`

The focused boundary regression now completes in about 35-40 ms locally, versus 1.2-1.9 seconds with the former SQLite fixture. Independent final review at `0fdb1a12` found 0 critical and 0 important issues.

## Coordination

Rebased onto exact post-#298 `main` commit `73185ed5`. This PR is ready for review but remains intentionally unmerged.