### PR TITLE
test: synchronize deferred watcher cold graph setup

### DIFF
--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -2373,14 +2373,11 @@ describe('Threadnote MCP toolsets', () => {
         execFileSync('git', ['add', '.'], {cwd: repository});
         execFileSync('git', ['commit', '-qm', 'fixture'], {cwd: repository});
 
-        const first = await client.callTool(
-          {
-            arguments: {callerCwd: repository, operation: 'query', query: 'beforeSessionWatch'},
-            name: 'inspect_code_graph',
-          },
-          undefined,
-          {timeout: 30_000},
-        );
+        const first = await callCodeGraphUntilReady(client, {
+          callerCwd: repository,
+          operation: 'query',
+          query: 'beforeSessionWatch',
+        });
         expect(first.structuredContent).toMatchObject({
           nodes: expect.arrayContaining([expect.objectContaining({name: 'beforeSessionWatch'})]),
         });


### PR DESCRIPTION
## Summary

- retry the cold watched-repository query through the existing structured indexing-state helper
- preserve the ready node, snapshot identity, and deferred-read assertions after cold setup completes
- leave MCP runtime behavior, timeouts, and assertions unchanged

## Root cause

A first inspection of a cold repository starts the required graph build and gives it a five-second foreground opportunity. Under heavy runner contention, the tool correctly returned a retryable state=indexing response before the tiny graph became ready. This fixture alone asserted nodes on that first response instead of consuming the retry protocol already used by neighboring cold graph integration cases.

## Verification

- reproduced unchanged failure under 40 local CPU saturators with state=indexing during scanning
- patched focused test passed under the same contention (26.49s)
- patched focused test passed without contention
- full MCP native-tools file plus focused progress policy: 70/70 passed
- pre-commit lint, formatting, source/test/site typechecks passed
- no new property test: the finite MCP fixture synchronization has no useful generated input space; existing progress-policy properties cover the state matrix

This is test-only, so no global runtime install is required.