### PR TITLE
docs: keep jose attribution current

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -11,7 +11,7 @@ Direct runtime software and packages bundled into the published JavaScript retai
 - Bun (MIT), embedded into each compiled executable
 - `effect`, `@effect/platform-bun`, `@effect/ai-openai-compat`, `@effect/sql-sqlite-bun`, and `@effect/vitest` (MIT)
 - `@modelcontextprotocol/sdk` 1.30.0 (MIT), pinned for the Streamable HTTP and stdio MCP protocol boundary
-- `jose` 6.2.3 (MIT), used for OAuth and Cursor workload JWT/JWKS verification
+- `jose` 6.2.10 (MIT), used for OAuth and Cursor workload JWT/JWKS verification
 - `postgres` 3.4.7 (MIT), used by the managed remote-memory PostgreSQL service and operator
 - `zod` 4.4.3 (MIT), used for strict remote MCP and operator request schemas
 - `react`, `react-dom`, and `react-markdown` (MIT)

--- a/test/unit/bun-package-contract.test.ts
+++ b/test/unit/bun-package-contract.test.ts
@@ -71,4 +71,16 @@ describe('Bun distribution contract', () => {
     expect(coverageLockEntry?.[1]).toBe(vitestVersion);
     expect(coverageLockEntry?.[0]).toContain(`"peerDependencies": { "vitest": "${vitestVersion}" }`);
   });
+
+  it('keeps the direct jose attribution aligned with the runtime dependency', async () => {
+    const [manifestText, thirdPartyNotice] = await Promise.all([
+      readFile(join(process.cwd(), 'package.json'), 'utf8'),
+      readFile(join(process.cwd(), 'THIRD_PARTY.md'), 'utf8'),
+    ]);
+    const manifest = JSON.parse(manifestText) as PackageManifest;
+    const noticeVersion = thirdPartyNotice.match(/^- `jose` ([^\s]+) \(MIT\),/mu)?.[1];
+
+    expect(manifest.dependencies?.jose).toMatch(/^\d+\.\d+\.\d+$/u);
+    expect(noticeVersion).toBe(manifest.dependencies?.jose);
+  });
 });


### PR DESCRIPTION
## Summary

- update the bundled JOSE attribution from 6.2.3 to the direct runtime version 6.2.10
- add a release-smoke contract that keeps the notice aligned with package.json

## Verification

- `bun run test:smoke:release` (14/14)
- `bun --bun vitest run test/unit/bun-package-contract.test.ts` (4/4)
- `bun --bun prettier --check THIRD_PARTY.md test/unit/bun-package-contract.test.ts`
- source, test, and site typechecks via the commit hook
- strict lint and file-length checks via the commit hook

Property testing was assessed but is not appropriate for this static one-value attribution contract.