### PR TITLE
fix: expose MCP code reference limit

### DIFF
--- a/src/effect/ai/mcp.ts
+++ b/src/effect/ai/mcp.ts
@@ -1174,8 +1174,18 @@ export const McpInput = {
   number: (description?: string, options: {readonly maximum?: number; readonly minimum?: number} = {}) =>
     Schema.optionalKey(numberSchema(description, options)),
   string: (description?: string) => Schema.optionalKey(annotate(Schema.String, description)),
-  stringOrStrings: (description?: string) =>
-    Schema.optionalKey(annotate(Schema.Union([Schema.String, Schema.Array(Schema.String)]), description)),
+  stringOrStrings: (description?: string, options: {readonly maximumItems?: number} = {}) =>
+    Schema.optionalKey(
+      annotate(
+        Schema.Union([
+          Schema.String,
+          options.maximumItems === undefined
+            ? Schema.Array(Schema.String)
+            : Schema.Array(Schema.String).check(Schema.isMaxLength(options.maximumItems)),
+        ]),
+        description,
+      ),
+    ),
 } as const;
 
 const stdioWithInstructionsLayer = (instructions: string): Layer.Layer<Stdio.Stdio> =>

--- a/src/mcp_server_recall.ts
+++ b/src/mcp_server_recall.ts
@@ -52,7 +52,7 @@ import {
   type MemoryMetadata,
 } from './memory_document.js';
 import {captureMemoryCodeCitationsForMcp} from './mcp/memory_code_citation.js';
-import {MEMORY_SCHEMA_VERSION} from './memory_code_citation.js';
+import {MAX_MEMORY_CODE_CITATIONS, MEMORY_SCHEMA_VERSION} from './memory_code_citation.js';
 import {
   memoryCodeCitationSharingBlocker,
   memoryCodeCitationSharingBlockerMessage,
@@ -157,7 +157,8 @@ export function registerCandidateMemoryTools(server: EffectMcpServerAdapter, con
       inputSchema: {
         callerCwd: McpInput.string('Absolute cwd; infers project'),
         codeRefs: McpInput.stringOrStrings(
-          'Repository-relative path, cgs_ symbol, or cgr_ qualified ref to carry into approved candidates',
+          `Repository-relative path, cgs_ symbol, or cgr_ qualified ref to carry into approved candidates; max ${MAX_MEMORY_CODE_CITATIONS}`,
+          {maximumItems: MAX_MEMORY_CODE_CITATIONS},
         ),
         decisions: McpInput.stringOrStrings('Reusable decisions'),
         evidence: McpInput.stringOrStrings('Bounded file, commit, or session pointers'),
@@ -1449,7 +1450,8 @@ export function registerStoreTool(
       inputSchema: {
         callerCwd: McpInput.string('Absolute cwd for nested package/app scope'),
         codeRefs: McpInput.stringOrStrings(
-          'Repository-relative path, cgs_ symbol, or cgr_ qualified ref to capture as immutable code evidence',
+          `Repository-relative path, cgs_ symbol, or cgr_ qualified ref to capture as immutable code evidence; max ${MAX_MEMORY_CODE_CITATIONS}`,
+          {maximumItems: MAX_MEMORY_CODE_CITATIONS},
         ),
         kind: McpInput.literals(['durable', 'handoff', 'incident', 'preference', 'smoke'], 'Memory lifecycle kind'),
         project: McpInput.string('Project/repo namespace'),

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -9,7 +9,11 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 import {describe, expect, it} from 'vitest';
 import {renderSessionStartRecallQueue} from '../../src/hooks.js';
-import {createMemoryCodeCitation, MEMORY_SCHEMA_VERSION} from '../../src/memory_code_citation.js';
+import {
+  createMemoryCodeCitation,
+  MAX_MEMORY_CODE_CITATIONS,
+  MEMORY_SCHEMA_VERSION,
+} from '../../src/memory_code_citation.js';
 import {formatMemoryDocument, parseMemoryDocument} from '../../src/memory_document.js';
 import {recallIndexDatabaseFilename} from '../../src/recall/index.js';
 
@@ -423,7 +427,7 @@ describe('Threadnote MCP toolsets', () => {
 
   it('emits and enforces Effect Schema inputs over stdio', async () => {
     await withMcpClient(
-      async client => {
+      async (client, fixture) => {
         const tools = await client.listTools();
         const recall = tools.tools.find(tool => tool.name === 'recall_context');
         expect(recall?.inputSchema).toMatchObject({
@@ -442,12 +446,36 @@ describe('Threadnote MCP toolsets', () => {
         expect(JSON.stringify(recall?.inputSchema)).not.toContain('null');
         const read = tools.tools.find(tool => tool.name === 'read_context');
         expect(read?.inputSchema.properties).not.toHaveProperty('full');
+        for (const name of ['remember_context', 'review_session_context']) {
+          const codeReferenceTool = tools.tools.find(tool => tool.name === name);
+          expect(codeReferenceTool?.inputSchema).toMatchObject({
+            properties: {
+              codeRefs: {
+                anyOf: [
+                  {type: 'string'},
+                  {
+                    items: {type: 'string'},
+                    maxItems: MAX_MEMORY_CODE_CITATIONS,
+                    type: 'array',
+                  },
+                ],
+                description: expect.stringContaining(`max ${MAX_MEMORY_CODE_CITATIONS}`),
+              },
+            },
+          });
+        }
 
         const validationError = await callErrorText(client, 'recall_context', {
           nodeLimit: 0,
           query: 'threadnote',
         });
         expect(validationError).toContain('greater than or equal to 1');
+        const tooManyCodeRefs = await callErrorText(client, 'remember_context', {
+          callerCwd: fixture.root,
+          codeRefs: Array.from({length: MAX_MEMORY_CODE_CITATIONS + 1}, (_, index) => `src/${index}.ts`),
+          text: 'This memory must not be stored.',
+        });
+        expect(tooManyCodeRefs).toContain(`at most ${MAX_MEMORY_CODE_CITATIONS}`);
       },
       {toolset: 'core'},
     );


### PR DESCRIPTION
## Summary

- extend string-or-array MCP inputs with an optional array-item bound while preserving existing unconstrained callers
- advertise and enforce the shared eight-reference limit for remember_context and review_session_context
- cover tools/list schema projection and ninth-item transport rejection

## Verification

- focused MCP stdio schema integration: 1 passed, 42 skipped
- Effect MCP unit suite: 37 passed
- full lint, repository formatting, file-length, and source/test/site typechecks passed
- independent exact-head critical/important review: clean

No property test was added: this is a fixed schema projection boundary, while the existing citation property already exercises bounded sets and the ninth citation rejection.

## Integration note

Rebased onto exact main 67a7c34b6da62f938756dbf6acc9735bbeb8b4a2 after #307; exact PR head is 32a739040f7fa1a19f8b023dba87329ac4ae31a3. The diff remains limited to the intended three files. The global development runtime remains owned by the final 4.5 candidate; this PR will not take over or install it.