### PR TITLE
fix(ci): sandwich production ratchet controls

### DIFF
--- a/.github/workflows/code-graph-production-ratchet.yml
+++ b/.github/workflows/code-graph-production-ratchet.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/code-graph-benchmark-sampler.ts'
       - 'scripts/code-graph-fixture.ts'
       - 'scripts/generate-code-graph-language-catalog.ts'
+      - 'test/ci/code-graph-production-ratchet-gate.ts'
       - 'test/ci/code-graph-production-ratchet-scope.ts'
       - 'src/code_graph/**'
       - 'src/crypto/**'
@@ -71,7 +72,7 @@ jobs:
     needs: classify
     if: always()
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Record strict release-metadata skip
@@ -80,6 +81,8 @@ jobs:
 
       - uses: actions/checkout@v7
         if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
+        with:
+          fetch-depth: '0'
 
       - uses: oven-sh/setup-bun@v2
         if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
@@ -89,7 +92,7 @@ jobs:
       - run: bun install --frozen-lockfile
         if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
 
-      - name: Gate the governed reduced production profile
+      - name: Measure the governed reduced production profile
         if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
         env:
           THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-ubuntu-24.04-${{ runner.arch }}
@@ -104,8 +107,51 @@ jobs:
           --samples 1
           --warmups 0
           --quiet
-          --ratchet test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
           --output artifacts/code-graph-production-ratchet-Linux-${{ runner.arch }}.json
+
+      - id: static-ratchet
+        name: Enforce the reviewed static ratchet
+        if: needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'
+        continue-on-error: true
+        run: >-
+          bun test/ci/code-graph-production-ratchet-gate.ts
+          --artifact artifacts/code-graph-production-ratchet-Linux-${{ runner.arch }}.json
+          --ratchet test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
+
+      - name: Measure the exact protected-base control on the same runner
+        if: steps.static-ratchet.outcome == 'failure'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-ubuntu-24.04-${{ runner.arch }}
+          THREADNOTE_BENCHMARK_RUNNER_ID: ${{ runner.name }}
+          THREADNOTE_CODE_GRAPH_PARSER_WORKERS: '4'
+        run: |
+          set -euo pipefail
+          candidate_root="$GITHUB_WORKSPACE"
+          control_root="$RUNNER_TEMP/threadnote-production-ratchet-control"
+          git worktree add --detach "$control_root" "$BASE_SHA"
+          cd "$control_root"
+          bun install --frozen-lockfile
+          GITHUB_WORKSPACE="$control_root" GITHUB_SHA="$BASE_SHA" bun run bench:code-graph -- \
+            --profile production-large \
+            --profile-files 3000 \
+            --profile-symbols 110000 \
+            --minimum-free-gib 20 \
+            --samples 1 \
+            --warmups 0 \
+            --quiet \
+            --output "$candidate_root/artifacts/code-graph-production-ratchet-control-Linux-${{ runner.arch }}.json"
+
+      - name: Enforce same-runner paired fallback without changing reviewed limits
+        if: steps.static-ratchet.outcome == 'failure'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          bun test/ci/code-graph-production-ratchet-gate.ts
+          --artifact artifacts/code-graph-production-ratchet-Linux-${{ runner.arch }}.json
+          --ratchet test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
+          --control artifacts/code-graph-production-ratchet-control-Linux-${{ runner.arch }}.json
+          --expected-control-commit "$BASE_SHA"
 
       - uses: actions/upload-artifact@v7
         if: >-

--- a/.github/workflows/code-graph-production-ratchet.yml
+++ b/.github/workflows/code-graph-production-ratchet.yml
@@ -72,7 +72,7 @@ jobs:
     needs: classify
     if: always()
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 40
 
     steps:
       - name: Record strict release-metadata skip
@@ -142,16 +142,35 @@ jobs:
             --quiet \
             --output "$candidate_root/artifacts/code-graph-production-ratchet-control-Linux-${{ runner.arch }}.json"
 
+      - name: Remeasure the exact candidate immediately after the control
+        if: steps.static-ratchet.outcome == 'failure'
+        env:
+          THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-ubuntu-24.04-${{ runner.arch }}
+          THREADNOTE_BENCHMARK_RUNNER_ID: ${{ runner.name }}
+          THREADNOTE_CODE_GRAPH_PARSER_WORKERS: '4'
+        run: >-
+          bun run bench:code-graph --
+          --profile production-large
+          --profile-files 3000
+          --profile-symbols 110000
+          --minimum-free-gib 20
+          --samples 1
+          --warmups 0
+          --quiet
+          --output artifacts/code-graph-production-ratchet-paired-candidate-Linux-${{ runner.arch }}.json
+
       - name: Enforce same-runner paired fallback without changing reviewed limits
         if: steps.static-ratchet.outcome == 'failure'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: >-
           bun test/ci/code-graph-production-ratchet-gate.ts
-          --artifact artifacts/code-graph-production-ratchet-Linux-${{ runner.arch }}.json
+          --artifact artifacts/code-graph-production-ratchet-paired-candidate-Linux-${{ runner.arch }}.json
           --ratchet test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
           --control artifacts/code-graph-production-ratchet-control-Linux-${{ runner.arch }}.json
+          --expected-candidate-commit "$GITHUB_SHA"
           --expected-control-commit "$BASE_SHA"
+          --initial-candidate artifacts/code-graph-production-ratchet-Linux-${{ runner.arch }}.json
 
       - uses: actions/upload-artifact@v7
         if: >-

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -6864,6 +6864,11 @@ export interface CodeGraphBenchmarkRatchetV1 {
   readonly version: 1;
 }
 
+export interface CodeGraphBenchmarkRatchetPairedControl {
+  readonly artifact: BenchmarkArtifactV1;
+  readonly expectedCommit: string;
+}
+
 const BENCHMARK_RATCHET_UNITS = new Set<BenchmarkMeasurementUnit>([
   'bytes',
   'count',
@@ -7288,7 +7293,11 @@ function productionDeterministicMeasurement(name: string, unit: BenchmarkMeasure
  * unrelated or partial artifacts fail closed instead of silently skipping a
  * threshold.
  */
-export function enforceCodeGraphBenchmarkRatchet(artifact: BenchmarkArtifactV1, value: unknown): void {
+export function enforceCodeGraphBenchmarkRatchet(
+  artifact: BenchmarkArtifactV1,
+  value: unknown,
+  pairedControl?: CodeGraphBenchmarkRatchetPairedControl,
+): void {
   const ratchet = parseCodeGraphBenchmarkRatchet(value);
   const failures: string[] = [];
   if (artifact.suite !== ratchet.suite) {
@@ -7333,6 +7342,9 @@ export function enforceCodeGraphBenchmarkRatchet(artifact: BenchmarkArtifactV1, 
     matches.push(measurement);
     measurementsByName.set(measurement.name, matches);
   }
+  const pairedMeasurementsByName = pairedControl
+    ? prepareCodeGraphBenchmarkRatchetPairedControl(artifact, pairedControl, ratchet, failures)
+    : undefined;
   for (const [name, limit] of Object.entries(ratchet.measurements).sort(([left], [right]) =>
     left.localeCompare(right),
   )) {
@@ -7350,31 +7362,167 @@ export function enforceCodeGraphBenchmarkRatchet(artifact: BenchmarkArtifactV1, 
       failures.push(`${name} unit ${measurement.unit} does not match ${limit.unit}`);
       continue;
     }
-    if (limit.samplesMinimum !== undefined && measurement.samples < limit.samplesMinimum) {
-      failures.push(`${name} has ${measurement.samples} samples, below ${limit.samplesMinimum}`);
+    const staticFailures = codeGraphBenchmarkMeasurementRatchetFailures(name, measurement, limit);
+    if (
+      staticFailures.length > 0 &&
+      pairedMeasurementsByName &&
+      productionHostSensitiveWallMeasurement(name, limit) &&
+      limit.p95Maximum !== undefined &&
+      measurement.p95 > limit.p95Maximum
+    ) {
+      const pairedMatches = pairedMeasurementsByName.get(name) ?? [];
+      if (pairedMatches.length !== 1) {
+        failures.push(
+          `paired control ${name} measurement occurs ${pairedMatches.length} times instead of exactly once`,
+        );
+        continue;
+      }
+      const pairedMeasurement = pairedMatches[0]!;
+      if (pairedMeasurement.unit !== measurement.unit || pairedMeasurement.samples !== measurement.samples) {
+        failures.push(`paired control ${name} unit or sample count does not match the candidate`);
+        continue;
+      }
+      if (pairedMeasurement.p95 > limit.p95Maximum) {
+        let pairedLimit: CodeGraphBenchmarkMeasurementRatchetV1;
+        try {
+          pairedLimit = productionMeasurementRatchet(name, measurement.unit, [pairedMeasurement.p95]);
+        } catch (error) {
+          failures.push(
+            `paired control ${name} is not admissible: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          continue;
+        }
+        failures.push(
+          ...codeGraphBenchmarkMeasurementRatchetFailures(name, measurement, pairedLimit).map(
+            failure => `${failure} against the exact protected-base control`,
+          ),
+        );
+        continue;
+      }
     }
-    if (limit.maximum !== undefined && measurement.maximum > limit.maximum) {
-      failures.push(`${name} maximum ${measurement.maximum} exceeds ${limit.maximum}`);
-    }
-    if (limit.meanMaximum !== undefined && measurement.mean > limit.meanMaximum) {
-      failures.push(`${name} mean ${measurement.mean} exceeds ${limit.meanMaximum}`);
-    }
-    if (limit.p50Maximum !== undefined && measurement.p50 > limit.p50Maximum) {
-      failures.push(`${name} p50 ${measurement.p50} exceeds ${limit.p50Maximum}`);
-    }
-    if (limit.p95Maximum !== undefined && measurement.p95 > limit.p95Maximum) {
-      failures.push(`${name} p95 ${measurement.p95} exceeds ${limit.p95Maximum}`);
-    }
-    if (limit.p99Maximum !== undefined && measurement.p99 > limit.p99Maximum) {
-      failures.push(`${name} p99 ${measurement.p99} exceeds ${limit.p99Maximum}`);
-    }
-    if (limit.minimum !== undefined && measurement.minimum < limit.minimum) {
-      failures.push(`${name} minimum ${measurement.minimum} is below ${limit.minimum}`);
-    }
+    failures.push(...staticFailures);
   }
   if (failures.length > 0) {
     throw new ScriptError(`Code graph performance ratchet failed: ${failures.join('; ')}`);
   }
+}
+
+const PRODUCTION_PAIRED_WALL_MEASUREMENT_PATTERNS = [
+  /^(?:cold|one-file-reindex|same-overlay-full-rebuild)-index$/u,
+  /^(?:cold|one-file-reindex|same-overlay-reference)-(?:activation-(?:and-vectors|lexical-only)|inventory-and-extraction|materialization|maximum-progress-heartbeat-gap-n1|post-committed-scan-overlay-and-workspace|pre-activation|pre-activation-validation|reference-resolution|registration-lock-and-database-setup|resolved-fact-accounting|snapshot-promotion|snapshot-write-and-checkpoint|vector-index)$/u,
+  /^(?:cold|one-file-reindex|same-overlay-reference)-activation-(?:checkpointing-snapshot|committing-snapshot|copying-(?:edges|files|lookup-keys|reexports|symbols|terms|workspace)|recording-completion|validating-input)-duration-n1$/u,
+  /^(?:cold|one-file-reindex|same-overlay-reference)-(?:activation|reference-resolution)-longest-transaction-n1$/u,
+  /^(?:first-repository-status-read|hot-build-sidecar-status-read|hot-deferred-ready-query-orchestration|hot-exact-lexical-query|hot-exact-ready-query-orchestration|hot-repository-status-read|whole-graph-structural-analysis)$/u,
+  /^mcp-(?:explain|impact|neighbors|node|path|query)-duration$/u,
+] as const;
+
+function productionHostSensitiveWallMeasurement(name: string, limit: CodeGraphBenchmarkMeasurementRatchetV1): boolean {
+  return (
+    limit.unit === 'milliseconds' &&
+    limit.samplesMinimum === 1 &&
+    limit.p95Maximum !== undefined &&
+    Object.keys(limit).every(key => key === 'p95Maximum' || key === 'samplesMinimum' || key === 'unit') &&
+    // Default every new millisecond metric to the static ratchet. Only
+    // explicitly reviewed elapsed intervals may use a same-runner control;
+    // cumulative parser, serialization, persistence, transaction, stage, and
+    // subphase work timers deliberately do not match this allowlist.
+    PRODUCTION_PAIRED_WALL_MEASUREMENT_PATTERNS.some(pattern => pattern.test(name))
+  );
+}
+
+function codeGraphBenchmarkMeasurementRatchetFailures(
+  name: string,
+  measurement: BenchmarkArtifactV1['measurements'][number],
+  limit: CodeGraphBenchmarkMeasurementRatchetV1,
+): readonly string[] {
+  const failures: string[] = [];
+  if (limit.samplesMinimum !== undefined && measurement.samples < limit.samplesMinimum) {
+    failures.push(`${name} has ${measurement.samples} samples, below ${limit.samplesMinimum}`);
+  }
+  if (limit.maximum !== undefined && measurement.maximum > limit.maximum) {
+    failures.push(`${name} maximum ${measurement.maximum} exceeds ${limit.maximum}`);
+  }
+  if (limit.meanMaximum !== undefined && measurement.mean > limit.meanMaximum) {
+    failures.push(`${name} mean ${measurement.mean} exceeds ${limit.meanMaximum}`);
+  }
+  if (limit.p50Maximum !== undefined && measurement.p50 > limit.p50Maximum) {
+    failures.push(`${name} p50 ${measurement.p50} exceeds ${limit.p50Maximum}`);
+  }
+  if (limit.p95Maximum !== undefined && measurement.p95 > limit.p95Maximum) {
+    failures.push(`${name} p95 ${measurement.p95} exceeds ${limit.p95Maximum}`);
+  }
+  if (limit.p99Maximum !== undefined && measurement.p99 > limit.p99Maximum) {
+    failures.push(`${name} p99 ${measurement.p99} exceeds ${limit.p99Maximum}`);
+  }
+  if (limit.minimum !== undefined && measurement.minimum < limit.minimum) {
+    failures.push(`${name} minimum ${measurement.minimum} is below ${limit.minimum}`);
+  }
+  return failures;
+}
+
+function prepareCodeGraphBenchmarkRatchetPairedControl(
+  artifact: BenchmarkArtifactV1,
+  pairedControl: CodeGraphBenchmarkRatchetPairedControl,
+  ratchet: CodeGraphBenchmarkRatchetV1,
+  failures: string[],
+): ReadonlyMap<string, BenchmarkArtifactV1['measurements'][number][]> | undefined {
+  if (!EXACT_GIT_COMMIT_PATTERN.test(pairedControl.expectedCommit)) {
+    failures.push('paired control expected commit is not an exact Git commit');
+    return undefined;
+  }
+  assertProductionLargeEvidence(artifact);
+  const control = parseBenchmarkArtifactV1(pairedControl.artifact);
+  assertProductionLargeEvidence(control);
+  if (control.environment.commit !== pairedControl.expectedCommit) {
+    failures.push(
+      `paired control commit ${JSON.stringify(control.environment.commit)} does not match ` +
+        JSON.stringify(pairedControl.expectedCommit),
+    );
+  }
+  if (control.environment.commit === artifact.environment.commit) {
+    failures.push('paired control must use a different protected-base commit');
+  }
+  if (control.suite !== ratchet.suite || control.suite !== artifact.suite) {
+    failures.push('paired control suite does not match the candidate and reviewed ratchet');
+  }
+  for (const [name, expected] of Object.entries(ratchet.environment)) {
+    const actual = control.environment[name as keyof BenchmarkArtifactV1['environment']];
+    if (actual !== expected) {
+      failures.push(
+        `paired control environment.${name} ${formatRatchetValue(actual)} does not match ` +
+          formatRatchetValue(expected),
+      );
+    }
+  }
+  for (const name of ['sameRunnerComparisonKey', 'runnerIdentity'] as const) {
+    if (
+      typeof control.metadata[name] !== 'string' ||
+      control.metadata[name] !== artifact.metadata[name] ||
+      control.metadata[name].length === 0
+    ) {
+      failures.push(`paired control metadata.${name} does not match the candidate`);
+    }
+  }
+  if (JSON.stringify(productionRatchetMetadata(control)) !== JSON.stringify(productionRatchetMetadata(artifact))) {
+    failures.push('paired control does not share the candidate fixture, output, runtime, and storage contract');
+  }
+  const controlNames = productionRatchetMeasurements(control)
+    .map(measurement => measurement.name)
+    .sort();
+  const candidateNames = productionRatchetMeasurements(artifact)
+    .map(measurement => measurement.name)
+    .sort();
+  if (JSON.stringify(controlNames) !== JSON.stringify(candidateNames)) {
+    failures.push('paired control assessed measurement set does not match the candidate');
+  }
+  if (failures.length > 0) return undefined;
+  const measurementsByName = new Map<string, BenchmarkArtifactV1['measurements'][number][]>();
+  for (const measurement of control.measurements) {
+    const matches = measurementsByName.get(measurement.name) ?? [];
+    matches.push(measurement);
+    measurementsByName.set(measurement.name, matches);
+  }
+  return measurementsByName;
 }
 
 export function validateCodeGraphBenchmarkRatchet(value: unknown): void {

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -6866,7 +6866,15 @@ export interface CodeGraphBenchmarkRatchetV1 {
 
 export interface CodeGraphBenchmarkRatchetPairedControl {
   readonly artifact: BenchmarkArtifactV1;
+  readonly expectedCandidateCommit: string;
   readonly expectedCommit: string;
+  readonly initialCandidateArtifact: BenchmarkArtifactV1;
+}
+
+interface PreparedCodeGraphBenchmarkRatchetSandwich {
+  readonly candidateInterpolationWeight: number;
+  readonly controlMeasurementsByName: ReadonlyMap<string, BenchmarkArtifactV1['measurements'][number][]>;
+  readonly initialCandidateMeasurementsByName: ReadonlyMap<string, BenchmarkArtifactV1['measurements'][number][]>;
 }
 
 const BENCHMARK_RATCHET_UNITS = new Set<BenchmarkMeasurementUnit>([
@@ -6886,6 +6894,7 @@ const PRODUCTION_RATCHET_DETAILED_MILLISECOND_RELATIVE_HEADROOM = 0.75;
 // end-to-end cold and incremental objectives this ratchet exists to protect.
 const PRODUCTION_RATCHET_MILLISECOND_NOISE_HEADROOM = 100;
 const PRODUCTION_RATCHET_DETAILED_MILLISECOND_NOISE_HEADROOM = 300;
+const PRODUCTION_RATCHET_SANDWICH_MAXIMUM_SPAN_MILLISECONDS = 40 * 60_000;
 // Cold registration includes two race-fenced Git status observations and
 // synchronous fresh SQLite setup on hosted virtual storage. Preserve a strict
 // sub-five-second wall objective while allowing the independently ratcheted
@@ -7336,13 +7345,8 @@ export function enforceCodeGraphBenchmarkRatchet(
       );
     }
   }
-  const measurementsByName = new Map<string, BenchmarkArtifactV1['measurements'][number][]>();
-  for (const measurement of artifact.measurements) {
-    const matches = measurementsByName.get(measurement.name) ?? [];
-    matches.push(measurement);
-    measurementsByName.set(measurement.name, matches);
-  }
-  const pairedMeasurementsByName = pairedControl
+  const measurementsByName = benchmarkMeasurementsByName(artifact);
+  const pairedEvidence = pairedControl
     ? prepareCodeGraphBenchmarkRatchetPairedControl(artifact, pairedControl, ratchet, failures)
     : undefined;
   for (const [name, limit] of Object.entries(ratchet.measurements).sort(([left], [right]) =>
@@ -7363,44 +7367,89 @@ export function enforceCodeGraphBenchmarkRatchet(
       continue;
     }
     const staticFailures = codeGraphBenchmarkMeasurementRatchetFailures(name, measurement, limit);
-    if (
-      staticFailures.length > 0 &&
-      pairedMeasurementsByName &&
-      productionHostSensitiveWallMeasurement(name, limit) &&
-      limit.p95Maximum !== undefined &&
-      measurement.p95 > limit.p95Maximum
-    ) {
-      const pairedMatches = pairedMeasurementsByName.get(name) ?? [];
-      if (pairedMatches.length !== 1) {
-        failures.push(
-          `paired control ${name} measurement occurs ${pairedMatches.length} times instead of exactly once`,
-        );
-        continue;
-      }
-      const pairedMeasurement = pairedMatches[0]!;
-      if (pairedMeasurement.unit !== measurement.unit || pairedMeasurement.samples !== measurement.samples) {
-        failures.push(`paired control ${name} unit or sample count does not match the candidate`);
-        continue;
-      }
-      if (pairedMeasurement.p95 > limit.p95Maximum) {
-        let pairedLimit: CodeGraphBenchmarkMeasurementRatchetV1;
-        try {
-          pairedLimit = productionMeasurementRatchet(name, measurement.unit, [pairedMeasurement.p95]);
-        } catch (error) {
-          failures.push(
-            `paired control ${name} is not admissible: ${error instanceof Error ? error.message : String(error)}`,
-          );
-          continue;
-        }
-        failures.push(
-          ...codeGraphBenchmarkMeasurementRatchetFailures(name, measurement, pairedLimit).map(
-            failure => `${failure} against the exact protected-base control`,
-          ),
-        );
-        continue;
-      }
+    if (!pairedEvidence) {
+      failures.push(...staticFailures);
+      continue;
     }
-    failures.push(...staticFailures);
+    const initialMatches = pairedEvidence.initialCandidateMeasurementsByName.get(name) ?? [];
+    if (initialMatches.length !== 1) {
+      failures.push(
+        `initial candidate ${name} measurement occurs ${initialMatches.length} times instead of exactly once`,
+      );
+      continue;
+    }
+    const initialMeasurement = initialMatches[0]!;
+    if (initialMeasurement.unit !== measurement.unit || initialMeasurement.samples !== measurement.samples) {
+      failures.push(`initial candidate ${name} unit or sample count does not match the remeasured candidate`);
+      continue;
+    }
+    const initialStaticFailures = codeGraphBenchmarkMeasurementRatchetFailures(name, initialMeasurement, limit);
+    const appendCandidateStaticFailures = () => {
+      failures.push(...initialStaticFailures.map(failure => `initial candidate ${failure}`));
+      failures.push(...staticFailures.map(failure => `remeasured candidate ${failure}`));
+    };
+    if (staticFailures.length === 0 && initialStaticFailures.length === 0) continue;
+    if (
+      !productionHostSensitiveWallMeasurement(name, limit) ||
+      limit.p95Maximum === undefined ||
+      !candidateHasOnlyStaticP95Failure(initialMeasurement, limit, initialStaticFailures) ||
+      !candidateHasOnlyStaticP95Failure(measurement, limit, staticFailures)
+    ) {
+      appendCandidateStaticFailures();
+      continue;
+    }
+    const controlMatches = pairedEvidence.controlMeasurementsByName.get(name) ?? [];
+    if (controlMatches.length !== 1) {
+      failures.push(`paired control ${name} measurement occurs ${controlMatches.length} times instead of exactly once`);
+      continue;
+    }
+    const controlMeasurement = controlMatches[0]!;
+    if (controlMeasurement.unit !== measurement.unit || controlMeasurement.samples !== measurement.samples) {
+      failures.push(`paired control ${name} unit or sample count does not match both candidates`);
+      continue;
+    }
+    if (controlMeasurement.p95 <= limit.p95Maximum) {
+      appendCandidateStaticFailures();
+      continue;
+    }
+    const lowerCandidateP95 = Math.min(initialMeasurement.p95, measurement.p95);
+    const upperCandidateP95 = Math.max(initialMeasurement.p95, measurement.p95);
+    let dispersionLimit: CodeGraphBenchmarkMeasurementRatchetV1;
+    try {
+      dispersionLimit = productionMeasurementRatchet(name, measurement.unit, [lowerCandidateP95]);
+    } catch (error) {
+      failures.push(
+        `candidate sandwich ${name} dispersion is not admissible: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    const dispersionFailures = codeGraphBenchmarkMeasurementRatchetFailures(
+      name,
+      benchmarkMeasurement(name, measurement.unit, [upperCandidateP95]),
+      dispersionLimit,
+    );
+    if (dispersionFailures.length > 0) {
+      failures.push(...dispersionFailures.map(failure => `candidate sandwich dispersion ${failure}`));
+      continue;
+    }
+    const sandwichP95 =
+      initialMeasurement.p95 + (measurement.p95 - initialMeasurement.p95) * pairedEvidence.candidateInterpolationWeight;
+    let pairedLimit: CodeGraphBenchmarkMeasurementRatchetV1;
+    try {
+      pairedLimit = productionMeasurementRatchet(name, measurement.unit, [controlMeasurement.p95]);
+    } catch (error) {
+      failures.push(
+        `paired control ${name} is not admissible: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    failures.push(
+      ...codeGraphBenchmarkMeasurementRatchetFailures(
+        name,
+        benchmarkMeasurement(name, measurement.unit, [sandwichP95]),
+        pairedLimit,
+      ).map(failure => `${failure} for the bounded candidate sandwich against the exact protected-base control`),
+    );
   }
   if (failures.length > 0) {
     throw new ScriptError(`Code graph performance ratchet failed: ${failures.join('; ')}`);
@@ -7412,6 +7461,7 @@ const PRODUCTION_PAIRED_WALL_MEASUREMENT_PATTERNS = [
   /^(?:cold|one-file-reindex|same-overlay-reference)-(?:activation-(?:and-vectors|lexical-only)|inventory-and-extraction|materialization|maximum-progress-heartbeat-gap-n1|post-committed-scan-overlay-and-workspace|pre-activation|pre-activation-validation|reference-resolution|registration-lock-and-database-setup|resolved-fact-accounting|snapshot-promotion|snapshot-write-and-checkpoint|vector-index)$/u,
   /^(?:cold|one-file-reindex|same-overlay-reference)-activation-(?:checkpointing-snapshot|committing-snapshot|copying-(?:edges|files|lookup-keys|reexports|symbols|terms|workspace)|recording-completion|validating-input)-duration-n1$/u,
   /^(?:cold|one-file-reindex|same-overlay-reference)-(?:activation|reference-resolution)-longest-transaction-n1$/u,
+  /^(?:cold|one-file-reindex|same-overlay-reference)-(?:inventory-cache-persistence|materialization-stage-committing)-n1$/u,
   /^(?:first-repository-status-read|hot-build-sidecar-status-read|hot-deferred-ready-query-orchestration|hot-exact-lexical-query|hot-exact-ready-query-orchestration|hot-repository-status-read|whole-graph-structural-analysis)$/u,
   /^mcp-(?:explain|impact|neighbors|node|path|query)-duration$/u,
 ] as const;
@@ -7424,10 +7474,39 @@ function productionHostSensitiveWallMeasurement(name: string, limit: CodeGraphBe
     Object.keys(limit).every(key => key === 'p95Maximum' || key === 'samplesMinimum' || key === 'unit') &&
     // Default every new millisecond metric to the static ratchet. Only
     // explicitly reviewed elapsed intervals may use a same-runner control;
-    // cumulative parser, serialization, persistence, transaction, stage, and
-    // subphase work timers deliberately do not match this allowlist.
+    // cumulative parser, serialization, transaction, and general stage or
+    // subphase work timers deliberately do not match this allowlist. The two
+    // named persistence/commit splits above are synchronous hosted-storage
+    // wall waits; independently ratcheted CPU, row/work, and byte/storage
+    // measurements continue to govern the amount of work they perform.
     PRODUCTION_PAIRED_WALL_MEASUREMENT_PATTERNS.some(pattern => pattern.test(name))
   );
+}
+
+function candidateHasOnlyStaticP95Failure(
+  measurement: BenchmarkArtifactV1['measurements'][number],
+  limit: CodeGraphBenchmarkMeasurementRatchetV1,
+  staticFailures: readonly string[],
+): boolean {
+  return (
+    staticFailures.length === 0 ||
+    (limit.p95Maximum !== undefined &&
+      measurement.p95 > limit.p95Maximum &&
+      (limit.samplesMinimum === undefined || measurement.samples >= limit.samplesMinimum) &&
+      staticFailures.length === 1)
+  );
+}
+
+function benchmarkMeasurementsByName(
+  artifact: BenchmarkArtifactV1,
+): ReadonlyMap<string, BenchmarkArtifactV1['measurements'][number][]> {
+  const measurementsByName = new Map<string, BenchmarkArtifactV1['measurements'][number][]>();
+  for (const measurement of artifact.measurements) {
+    const matches = measurementsByName.get(measurement.name) ?? [];
+    matches.push(measurement);
+    measurementsByName.set(measurement.name, matches);
+  }
+  return measurementsByName;
 }
 
 function codeGraphBenchmarkMeasurementRatchetFailures(
@@ -7465,14 +7544,32 @@ function prepareCodeGraphBenchmarkRatchetPairedControl(
   pairedControl: CodeGraphBenchmarkRatchetPairedControl,
   ratchet: CodeGraphBenchmarkRatchetV1,
   failures: string[],
-): ReadonlyMap<string, BenchmarkArtifactV1['measurements'][number][]> | undefined {
+): PreparedCodeGraphBenchmarkRatchetSandwich | undefined {
+  if (!EXACT_GIT_COMMIT_PATTERN.test(pairedControl.expectedCandidateCommit)) {
+    failures.push('paired candidate expected commit is not an exact Git commit');
+    return undefined;
+  }
   if (!EXACT_GIT_COMMIT_PATTERN.test(pairedControl.expectedCommit)) {
     failures.push('paired control expected commit is not an exact Git commit');
     return undefined;
   }
   assertProductionLargeEvidence(artifact);
   const control = parseBenchmarkArtifactV1(pairedControl.artifact);
+  const initialCandidate = parseBenchmarkArtifactV1(pairedControl.initialCandidateArtifact);
   assertProductionLargeEvidence(control);
+  assertProductionLargeEvidence(initialCandidate);
+  if (artifact.environment.commit !== pairedControl.expectedCandidateCommit) {
+    failures.push(
+      `paired candidate commit ${JSON.stringify(artifact.environment.commit)} does not match ` +
+        JSON.stringify(pairedControl.expectedCandidateCommit),
+    );
+  }
+  if (initialCandidate.environment.commit !== pairedControl.expectedCandidateCommit) {
+    failures.push(
+      `initial candidate commit ${JSON.stringify(initialCandidate.environment.commit)} does not match ` +
+        JSON.stringify(pairedControl.expectedCandidateCommit),
+    );
+  }
   if (control.environment.commit !== pairedControl.expectedCommit) {
     failures.push(
       `paired control commit ${JSON.stringify(control.environment.commit)} does not match ` +
@@ -7482,29 +7579,49 @@ function prepareCodeGraphBenchmarkRatchetPairedControl(
   if (control.environment.commit === artifact.environment.commit) {
     failures.push('paired control must use a different protected-base commit');
   }
-  if (control.suite !== ratchet.suite || control.suite !== artifact.suite) {
-    failures.push('paired control suite does not match the candidate and reviewed ratchet');
+  if (
+    control.suite !== ratchet.suite ||
+    control.suite !== artifact.suite ||
+    initialCandidate.suite !== artifact.suite
+  ) {
+    failures.push('paired sandwich suite does not match both candidates, the control, and reviewed ratchet');
   }
   for (const [name, expected] of Object.entries(ratchet.environment)) {
-    const actual = control.environment[name as keyof BenchmarkArtifactV1['environment']];
-    if (actual !== expected) {
-      failures.push(
-        `paired control environment.${name} ${formatRatchetValue(actual)} does not match ` +
-          formatRatchetValue(expected),
-      );
+    for (const [label, candidate] of [
+      ['paired control', control],
+      ['initial candidate', initialCandidate],
+    ] as const) {
+      const actual = candidate.environment[name as keyof BenchmarkArtifactV1['environment']];
+      if (actual !== expected) {
+        failures.push(
+          `${label} environment.${name} ${formatRatchetValue(actual)} does not match ` + formatRatchetValue(expected),
+        );
+      }
     }
   }
   for (const name of ['sameRunnerComparisonKey', 'runnerIdentity'] as const) {
-    if (
-      typeof control.metadata[name] !== 'string' ||
-      control.metadata[name] !== artifact.metadata[name] ||
-      control.metadata[name].length === 0
-    ) {
-      failures.push(`paired control metadata.${name} does not match the candidate`);
+    for (const [label, candidate] of [
+      ['paired control', control],
+      ['initial candidate', initialCandidate],
+    ] as const) {
+      if (
+        typeof candidate.metadata[name] !== 'string' ||
+        candidate.metadata[name] !== artifact.metadata[name] ||
+        candidate.metadata[name].length === 0
+      ) {
+        failures.push(`${label} metadata.${name} does not match the remeasured candidate`);
+      }
     }
   }
   if (JSON.stringify(productionRatchetMetadata(control)) !== JSON.stringify(productionRatchetMetadata(artifact))) {
     failures.push('paired control does not share the candidate fixture, output, runtime, and storage contract');
+  }
+  if (
+    JSON.stringify(productionRatchetMetadata(initialCandidate)) !== JSON.stringify(productionRatchetMetadata(artifact))
+  ) {
+    failures.push(
+      'initial candidate does not share the remeasured candidate fixture, output, runtime, and storage contract',
+    );
   }
   const controlNames = productionRatchetMeasurements(control)
     .map(measurement => measurement.name)
@@ -7512,17 +7629,37 @@ function prepareCodeGraphBenchmarkRatchetPairedControl(
   const candidateNames = productionRatchetMeasurements(artifact)
     .map(measurement => measurement.name)
     .sort();
+  const initialCandidateNames = productionRatchetMeasurements(initialCandidate)
+    .map(measurement => measurement.name)
+    .sort();
   if (JSON.stringify(controlNames) !== JSON.stringify(candidateNames)) {
     failures.push('paired control assessed measurement set does not match the candidate');
   }
-  if (failures.length > 0) return undefined;
-  const measurementsByName = new Map<string, BenchmarkArtifactV1['measurements'][number][]>();
-  for (const measurement of control.measurements) {
-    const matches = measurementsByName.get(measurement.name) ?? [];
-    matches.push(measurement);
-    measurementsByName.set(measurement.name, matches);
+  if (JSON.stringify(initialCandidateNames) !== JSON.stringify(candidateNames)) {
+    failures.push('initial candidate assessed measurement set does not match the remeasured candidate');
   }
-  return measurementsByName;
+  const initialCandidateTime = Date.parse(initialCandidate.createdAt);
+  const controlTime = Date.parse(control.createdAt);
+  const remeasuredCandidateTime = Date.parse(artifact.createdAt);
+  if (
+    !Number.isFinite(initialCandidateTime) ||
+    !Number.isFinite(controlTime) ||
+    !Number.isFinite(remeasuredCandidateTime) ||
+    initialCandidateTime >= controlTime ||
+    controlTime >= remeasuredCandidateTime ||
+    remeasuredCandidateTime - initialCandidateTime > PRODUCTION_RATCHET_SANDWICH_MAXIMUM_SPAN_MILLISECONDS
+  ) {
+    failures.push(
+      'paired sandwich creation times must be strictly ordered candidate-control-candidate within 40 minutes',
+    );
+  }
+  if (failures.length > 0) return undefined;
+  return {
+    candidateInterpolationWeight:
+      (controlTime - initialCandidateTime) / (remeasuredCandidateTime - initialCandidateTime),
+    controlMeasurementsByName: benchmarkMeasurementsByName(control),
+    initialCandidateMeasurementsByName: benchmarkMeasurementsByName(initialCandidate),
+  };
 }
 
 export function validateCodeGraphBenchmarkRatchet(value: unknown): void {

--- a/test/ci/code-graph-production-ratchet-gate.ts
+++ b/test/ci/code-graph-production-ratchet-gate.ts
@@ -1,0 +1,61 @@
+import {enforceCodeGraphBenchmarkRatchet} from '../../scripts/benchmark-code-graph.js';
+import {parseBenchmarkArtifactV1} from '../../src/evaluation/benchmark.js';
+
+interface GateArguments {
+  readonly artifactPath: string;
+  readonly controlPath?: string;
+  readonly expectedControlCommit?: string;
+  readonly ratchetPath: string;
+}
+
+function requiredValue(args: readonly string[], name: string): string {
+  const index = args.indexOf(name);
+  const value = index === -1 ? undefined : args[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value.`);
+  return value;
+}
+
+export function parseCodeGraphProductionRatchetGateArguments(args: readonly string[]): GateArguments {
+  const known = new Set(['--artifact', '--control', '--expected-control-commit', '--ratchet']);
+  for (let index = 0; index < args.length; index += 2) {
+    if (!known.has(args[index] ?? '') || args[index + 1] === undefined) {
+      throw new Error(`Unknown or incomplete production ratchet gate argument: ${args[index] ?? '<missing>'}`);
+    }
+  }
+  const artifactPath = requiredValue(args, '--artifact');
+  const ratchetPath = requiredValue(args, '--ratchet');
+  const controlPath = args.includes('--control') ? requiredValue(args, '--control') : undefined;
+  const expectedControlCommit = args.includes('--expected-control-commit')
+    ? requiredValue(args, '--expected-control-commit')
+    : undefined;
+  if ((controlPath === undefined) !== (expectedControlCommit === undefined)) {
+    throw new Error('--control and --expected-control-commit must be provided together.');
+  }
+  return {artifactPath, controlPath, expectedControlCommit, ratchetPath};
+}
+
+async function readJson(path: string): Promise<unknown> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) throw new Error(`Production ratchet gate input does not exist: ${path}`);
+  return file.json() as Promise<unknown>;
+}
+
+export async function runCodeGraphProductionRatchetGate(args: readonly string[]): Promise<void> {
+  const options = parseCodeGraphProductionRatchetGateArguments(args);
+  const [artifactValue, ratchet, controlValue] = await Promise.all([
+    readJson(options.artifactPath),
+    readJson(options.ratchetPath),
+    options.controlPath ? readJson(options.controlPath) : Promise.resolve(undefined),
+  ]);
+  const artifact = parseBenchmarkArtifactV1(artifactValue);
+  const pairedControl =
+    controlValue === undefined || options.expectedControlCommit === undefined
+      ? undefined
+      : {
+          artifact: parseBenchmarkArtifactV1(controlValue),
+          expectedCommit: options.expectedControlCommit,
+        };
+  enforceCodeGraphBenchmarkRatchet(artifact, ratchet, pairedControl);
+}
+
+if (import.meta.main) await runCodeGraphProductionRatchetGate(Bun.argv.slice(2));

--- a/test/ci/code-graph-production-ratchet-gate.ts
+++ b/test/ci/code-graph-production-ratchet-gate.ts
@@ -4,7 +4,9 @@ import {parseBenchmarkArtifactV1} from '../../src/evaluation/benchmark.js';
 interface GateArguments {
   readonly artifactPath: string;
   readonly controlPath?: string;
+  readonly expectedCandidateCommit?: string;
   readonly expectedControlCommit?: string;
+  readonly initialCandidatePath?: string;
   readonly ratchetPath: string;
 }
 
@@ -16,7 +18,14 @@ function requiredValue(args: readonly string[], name: string): string {
 }
 
 export function parseCodeGraphProductionRatchetGateArguments(args: readonly string[]): GateArguments {
-  const known = new Set(['--artifact', '--control', '--expected-control-commit', '--ratchet']);
+  const known = new Set([
+    '--artifact',
+    '--control',
+    '--expected-candidate-commit',
+    '--expected-control-commit',
+    '--initial-candidate',
+    '--ratchet',
+  ]);
   for (let index = 0; index < args.length; index += 2) {
     if (!known.has(args[index] ?? '') || args[index + 1] === undefined) {
       throw new Error(`Unknown or incomplete production ratchet gate argument: ${args[index] ?? '<missing>'}`);
@@ -25,13 +34,32 @@ export function parseCodeGraphProductionRatchetGateArguments(args: readonly stri
   const artifactPath = requiredValue(args, '--artifact');
   const ratchetPath = requiredValue(args, '--ratchet');
   const controlPath = args.includes('--control') ? requiredValue(args, '--control') : undefined;
+  const expectedCandidateCommit = args.includes('--expected-candidate-commit')
+    ? requiredValue(args, '--expected-candidate-commit')
+    : undefined;
   const expectedControlCommit = args.includes('--expected-control-commit')
     ? requiredValue(args, '--expected-control-commit')
     : undefined;
-  if ((controlPath === undefined) !== (expectedControlCommit === undefined)) {
-    throw new Error('--control and --expected-control-commit must be provided together.');
+  const initialCandidatePath = args.includes('--initial-candidate')
+    ? requiredValue(args, '--initial-candidate')
+    : undefined;
+  if (
+    (controlPath === undefined) !== (expectedCandidateCommit === undefined) ||
+    (controlPath === undefined) !== (expectedControlCommit === undefined) ||
+    (controlPath === undefined) !== (initialCandidatePath === undefined)
+  ) {
+    throw new Error(
+      '--control, --expected-candidate-commit, --expected-control-commit, and --initial-candidate must be provided together.',
+    );
   }
-  return {artifactPath, controlPath, expectedControlCommit, ratchetPath};
+  return {
+    artifactPath,
+    controlPath,
+    expectedCandidateCommit,
+    expectedControlCommit,
+    initialCandidatePath,
+    ratchetPath,
+  };
 }
 
 async function readJson(path: string): Promise<unknown> {
@@ -42,18 +70,24 @@ async function readJson(path: string): Promise<unknown> {
 
 export async function runCodeGraphProductionRatchetGate(args: readonly string[]): Promise<void> {
   const options = parseCodeGraphProductionRatchetGateArguments(args);
-  const [artifactValue, ratchet, controlValue] = await Promise.all([
+  const [artifactValue, ratchet, controlValue, initialCandidateValue] = await Promise.all([
     readJson(options.artifactPath),
     readJson(options.ratchetPath),
     options.controlPath ? readJson(options.controlPath) : Promise.resolve(undefined),
+    options.initialCandidatePath ? readJson(options.initialCandidatePath) : Promise.resolve(undefined),
   ]);
   const artifact = parseBenchmarkArtifactV1(artifactValue);
   const pairedControl =
-    controlValue === undefined || options.expectedControlCommit === undefined
+    controlValue === undefined ||
+    initialCandidateValue === undefined ||
+    options.expectedCandidateCommit === undefined ||
+    options.expectedControlCommit === undefined
       ? undefined
       : {
           artifact: parseBenchmarkArtifactV1(controlValue),
+          expectedCandidateCommit: options.expectedCandidateCommit,
           expectedCommit: options.expectedControlCommit,
+          initialCandidateArtifact: parseBenchmarkArtifactV1(initialCandidateValue),
         };
   enforceCodeGraphBenchmarkRatchet(artifact, ratchet, pairedControl);
 }

--- a/test/evaluation/README.md
+++ b/test/evaluation/README.md
@@ -121,6 +121,17 @@ reviewed repeated before/after evidence and rationale; do not widen a limit to m
 required with `--ratchet`; a provenance-valid artifact is written before a ratchet failure is reported so the
 regression remains reviewable.
 
+The pull-request production ratchet first applies those reviewed limits unchanged. If only that static gate fails, CI
+measures the exact protected-base commit in a detached worktree on the same runner and retries with the paired control.
+Pairing is admitted only when `sameRunnerComparisonKey`, privacy-safe `runnerIdentity`, fixture/output/runtime/storage
+metadata, and the assessed measurement set match. Non-wall CPU, work, storage, RSS, correctness, and shape limits stay
+static. Cumulative parser, serialization, persistence, transaction, materialization-stage, and subphase timers are work
+even though their unit is milliseconds, so they also stay static; new timings require explicit elapsed-wall
+classification before they can pair. An allowlisted wall limit becomes relative only when the protected-base control
+also misses that same static limit; the existing relative/absolute headroom and hard objectives then apply to the
+control observation. This separates hosted VM scheduling noise from branch regressions without widening the checked-in
+ratchet or accepting a candidate that is slower than a passing same-runner control.
+
 ### Cross-repository workset contract
 
 The workset fixture scales one deterministic set of repository archetypes into prefix worksets. Sizes 1, 8, 32, 64,

--- a/test/evaluation/README.md
+++ b/test/evaluation/README.md
@@ -122,15 +122,23 @@ required with `--ratchet`; a provenance-valid artifact is written before a ratch
 regression remains reviewable.
 
 The pull-request production ratchet first applies those reviewed limits unchanged. If only that static gate fails, CI
-measures the exact protected-base commit in a detached worktree on the same runner and retries with the paired control.
-Pairing is admitted only when `sameRunnerComparisonKey`, privacy-safe `runnerIdentity`, fixture/output/runtime/storage
-metadata, and the assessed measurement set match. Non-wall CPU, work, storage, RSS, correctness, and shape limits stay
-static. Cumulative parser, serialization, persistence, transaction, materialization-stage, and subphase timers are work
-even though their unit is milliseconds, so they also stay static; new timings require explicit elapsed-wall
-classification before they can pair. An allowlisted wall limit becomes relative only when the protected-base control
-also misses that same static limit; the existing relative/absolute headroom and hard objectives then apply to the
-control observation. This separates hosted VM scheduling noise from branch regressions without widening the checked-in
-ratchet or accepting a candidate that is slower than a passing same-runner control.
+keeps the initial candidate artifact as evidence, measures the exact protected-base commit in a detached worktree on
+the same runner, and then immediately remeasures the exact candidate. The paired gate binds all three artifacts in a
+strictly ordered, bounded candidate-control-candidate sandwich. For allowlisted wall p95 metrics, it linearly
+interpolates the two candidate observations at the control timestamp, which cancels linear runner drift instead of
+favoring whichever source happened to run second. Candidate dispersion beyond the existing relative/absolute
+headroom fails closed. Pairing is admitted only when the expected candidate and control commits,
+`sameRunnerComparisonKey`, privacy-safe `runnerIdentity`, fixture/output/runtime/storage metadata, and the assessed
+measurement set match. Non-wall CPU, work, storage, RSS, correctness, and shape failures from either candidate stay
+blocking. Cumulative parser, serialization, transaction, and general
+materialization-stage or subphase timers are work even though their unit is milliseconds, so they also stay static;
+new timings require explicit elapsed-wall classification before they can pair. The explicitly reviewed graph-cache
+persistence and SQLite commit splits may pair because they are synchronous hosted-storage wall waits, while their
+independent CPU, row/work, and byte/storage bounds remain static. An allowlisted wall limit becomes relative only when
+the protected-base control also misses that same static limit; the existing relative/absolute headroom bounds the
+interpolated candidate estimate, while hard objectives still bind the control and both candidate observations. This
+separates hosted VM scheduling noise from branch regressions
+without widening the checked-in ratchet or accepting a candidate that is slower than a passing same-runner control.
 
 ### Cross-repository workset contract
 

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -167,7 +167,7 @@ describe('platform benchmark workflow', () => {
     expect(paths).not.toContain('src/recall/**');
     expect(paths.join('\n').toLowerCase()).not.toContain('intellij');
     expect(job['runs-on']).toBe('ubuntu-24.04');
-    expect(job['timeout-minutes']).toBe(25);
+    expect(job['timeout-minutes']).toBe(40);
     expect(job.needs).toBe('classify');
     expect(job.if).toBe('always()');
     expect(classifier.outputs?.release_metadata_only).toBe('${{ steps.scope.outputs.release_metadata_only }}');
@@ -194,32 +194,44 @@ describe('platform benchmark workflow', () => {
       step => step.name === 'Measure the governed reduced production profile',
     );
     expect(candidateMeasurement?.run).not.toContain('--ratchet');
+    expect(candidateMeasurement?.run).toContain('code-graph-production-ratchet-Linux-');
     const staticGate = job.steps?.find(step => step.id === 'static-ratchet');
     expect(staticGate).toMatchObject({
       'continue-on-error': true,
       name: 'Enforce the reviewed static ratchet',
     });
     expect(staticGate?.run).toContain('test/ci/code-graph-production-ratchet-gate.ts');
-    const pairedMeasurement = job.steps?.find(
+    const controlMeasurement = job.steps?.find(
       step => step.name === 'Measure the exact protected-base control on the same runner',
     );
-    expect(pairedMeasurement?.if).toBe("steps.static-ratchet.outcome == 'failure'");
-    expect(pairedMeasurement?.run).toContain('git worktree add --detach "$control_root" "$BASE_SHA"');
-    expect(pairedMeasurement?.run).toContain('GITHUB_WORKSPACE="$control_root" GITHUB_SHA="$BASE_SHA"');
-    expect(pairedMeasurement?.run).toContain('code-graph-production-ratchet-control-Linux-');
+    expect(controlMeasurement?.if).toBe("steps.static-ratchet.outcome == 'failure'");
+    expect(controlMeasurement?.run).toContain('git worktree add --detach "$control_root" "$BASE_SHA"');
+    expect(controlMeasurement?.run).toContain('GITHUB_WORKSPACE="$control_root" GITHUB_SHA="$BASE_SHA"');
+    expect(controlMeasurement?.run).toContain('code-graph-production-ratchet-control-Linux-');
+    const pairedCandidateMeasurement = job.steps?.find(
+      step => step.name === 'Remeasure the exact candidate immediately after the control',
+    );
+    expect(pairedCandidateMeasurement?.if).toBe("steps.static-ratchet.outcome == 'failure'");
+    expect(pairedCandidateMeasurement?.run).toContain('code-graph-production-ratchet-paired-candidate-Linux-');
+    expect(job.steps?.indexOf(candidateMeasurement!)).toBeLessThan(job.steps?.indexOf(controlMeasurement!) ?? 0);
+    expect(job.steps?.indexOf(controlMeasurement!)).toBeLessThan(job.steps?.indexOf(pairedCandidateMeasurement!) ?? 0);
     const pairedGate = job.steps?.find(
       step => step.name === 'Enforce same-runner paired fallback without changing reviewed limits',
     );
     expect(pairedGate?.if).toBe("steps.static-ratchet.outcome == 'failure'");
+    expect(pairedGate?.run).toContain('--artifact artifacts/code-graph-production-ratchet-paired-candidate-Linux-');
+    expect(pairedGate?.run).toContain('--expected-candidate-commit "$GITHUB_SHA"');
     expect(pairedGate?.run).toContain('--expected-control-commit "$BASE_SHA"');
+    expect(pairedGate?.run).toContain('--initial-candidate artifacts/code-graph-production-ratchet-Linux-');
+    expect(job.steps?.indexOf(pairedCandidateMeasurement!)).toBeLessThan(job.steps?.indexOf(pairedGate!) ?? 0);
     expect(job.steps?.find(step => step.uses === 'actions/upload-artifact@v7')?.if).toContain(
       "needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'",
     );
-    expect(command.match(/--samples 1/g)).toHaveLength(2);
-    expect(command.match(/--profile production-large/g)).toHaveLength(2);
-    expect(command.match(/--profile-files 3000/g)).toHaveLength(2);
-    expect(command.match(/--profile-symbols 110000/g)).toHaveLength(2);
-    expect(command.match(/--minimum-free-gib 20/g)).toHaveLength(2);
+    expect(command.match(/--samples 1/g)).toHaveLength(3);
+    expect(command.match(/--profile production-large/g)).toHaveLength(3);
+    expect(command.match(/--profile-files 3000/g)).toHaveLength(3);
+    expect(command.match(/--profile-symbols 110000/g)).toHaveLength(3);
+    expect(command.match(/--minimum-free-gib 20/g)).toHaveLength(3);
     expect(
       command.match(/--ratchet test\/evaluation\/baselines\/code-graph-v1\/production-ratchet-github-linux-x64.json/g),
     ).toHaveLength(2);

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -150,6 +150,7 @@ describe('platform benchmark workflow', () => {
       expect.arrayContaining([
         '.github/workflows/code-graph-production-ratchet.yml',
         'scripts/benchmark-code-graph.ts',
+        'test/ci/code-graph-production-ratchet-gate.ts',
         'test/ci/code-graph-production-ratchet-scope.ts',
         'src/code_graph/**',
         'src/effect/errors.ts',
@@ -166,7 +167,7 @@ describe('platform benchmark workflow', () => {
     expect(paths).not.toContain('src/recall/**');
     expect(paths.join('\n').toLowerCase()).not.toContain('intellij');
     expect(job['runs-on']).toBe('ubuntu-24.04');
-    expect(job['timeout-minutes']).toBe(15);
+    expect(job['timeout-minutes']).toBe(25);
     expect(job.needs).toBe('classify');
     expect(job.if).toBe('always()');
     expect(classifier.outputs?.release_metadata_only).toBe('${{ steps.scope.outputs.release_metadata_only }}');
@@ -179,25 +180,49 @@ describe('platform benchmark workflow', () => {
         step.uses === 'actions/checkout@v7' ||
         step.uses === 'oven-sh/setup-bun@v2' ||
         step.run === 'bun install --frozen-lockfile' ||
-        step.name === 'Gate the governed reduced production profile',
+        step.name === 'Measure the governed reduced production profile' ||
+        step.name === 'Enforce the reviewed static ratchet',
     );
-    expect(guardedSteps).toHaveLength(4);
+    expect(guardedSteps).toHaveLength(5);
     for (const step of guardedSteps ?? []) {
       expect(step.if).toBe(
         "needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'",
       );
     }
+    expect(job.steps?.find(step => step.uses === 'actions/checkout@v7')?.with).toMatchObject({'fetch-depth': '0'});
+    const candidateMeasurement = job.steps?.find(
+      step => step.name === 'Measure the governed reduced production profile',
+    );
+    expect(candidateMeasurement?.run).not.toContain('--ratchet');
+    const staticGate = job.steps?.find(step => step.id === 'static-ratchet');
+    expect(staticGate).toMatchObject({
+      'continue-on-error': true,
+      name: 'Enforce the reviewed static ratchet',
+    });
+    expect(staticGate?.run).toContain('test/ci/code-graph-production-ratchet-gate.ts');
+    const pairedMeasurement = job.steps?.find(
+      step => step.name === 'Measure the exact protected-base control on the same runner',
+    );
+    expect(pairedMeasurement?.if).toBe("steps.static-ratchet.outcome == 'failure'");
+    expect(pairedMeasurement?.run).toContain('git worktree add --detach "$control_root" "$BASE_SHA"');
+    expect(pairedMeasurement?.run).toContain('GITHUB_WORKSPACE="$control_root" GITHUB_SHA="$BASE_SHA"');
+    expect(pairedMeasurement?.run).toContain('code-graph-production-ratchet-control-Linux-');
+    const pairedGate = job.steps?.find(
+      step => step.name === 'Enforce same-runner paired fallback without changing reviewed limits',
+    );
+    expect(pairedGate?.if).toBe("steps.static-ratchet.outcome == 'failure'");
+    expect(pairedGate?.run).toContain('--expected-control-commit "$BASE_SHA"');
     expect(job.steps?.find(step => step.uses === 'actions/upload-artifact@v7')?.if).toContain(
       "needs.classify.result != 'success' || needs.classify.outputs.release_metadata_only != 'true'",
     );
-    expect(command.match(/--samples 1/g)).toHaveLength(1);
-    expect(command).toContain('--profile production-large');
-    expect(command).toContain('--profile-files 3000');
-    expect(command).toContain('--profile-symbols 110000');
-    expect(command).toContain('--minimum-free-gib 20');
-    expect(command).toContain(
-      '--ratchet test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json',
-    );
+    expect(command.match(/--samples 1/g)).toHaveLength(2);
+    expect(command.match(/--profile production-large/g)).toHaveLength(2);
+    expect(command.match(/--profile-files 3000/g)).toHaveLength(2);
+    expect(command.match(/--profile-symbols 110000/g)).toHaveLength(2);
+    expect(command.match(/--minimum-free-gib 20/g)).toHaveLength(2);
+    expect(
+      command.match(/--ratchet test\/evaluation\/baselines\/code-graph-v1\/production-ratchet-github-linux-x64.json/g),
+    ).toHaveLength(2);
     expect(command).not.toContain('bench:code-graph:production:ratchet');
   });
 

--- a/test/unit/code-graph.production-ratchet-gate.test.ts
+++ b/test/unit/code-graph.production-ratchet-gate.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest';
+import {parseCodeGraphProductionRatchetGateArguments} from '../ci/code-graph-production-ratchet-gate.js';
+
+describe('code graph production ratchet gate', () => {
+  it('requires an explicit paired control contract', () => {
+    expect(
+      parseCodeGraphProductionRatchetGateArguments([
+        '--artifact',
+        'candidate.json',
+        '--ratchet',
+        'ratchet.json',
+        '--control',
+        'control.json',
+        '--expected-control-commit',
+        'a'.repeat(40),
+      ]),
+    ).toEqual({
+      artifactPath: 'candidate.json',
+      controlPath: 'control.json',
+      expectedControlCommit: 'a'.repeat(40),
+      ratchetPath: 'ratchet.json',
+    });
+    expect(() =>
+      parseCodeGraphProductionRatchetGateArguments([
+        '--artifact',
+        'candidate.json',
+        '--ratchet',
+        'ratchet.json',
+        '--control',
+        'control.json',
+      ]),
+    ).toThrow(/must be provided together/u);
+    expect(() =>
+      parseCodeGraphProductionRatchetGateArguments([
+        '--artifact',
+        'candidate.json',
+        '--ratchet',
+        'ratchet.json',
+        '--unexpected',
+        'value',
+      ]),
+    ).toThrow(/Unknown or incomplete/u);
+  });
+});

--- a/test/unit/code-graph.production-ratchet-gate.test.ts
+++ b/test/unit/code-graph.production-ratchet-gate.test.ts
@@ -11,13 +11,19 @@ describe('code graph production ratchet gate', () => {
         'ratchet.json',
         '--control',
         'control.json',
+        '--expected-candidate-commit',
+        'b'.repeat(40),
         '--expected-control-commit',
         'a'.repeat(40),
+        '--initial-candidate',
+        'initial-candidate.json',
       ]),
     ).toEqual({
       artifactPath: 'candidate.json',
       controlPath: 'control.json',
+      expectedCandidateCommit: 'b'.repeat(40),
       expectedControlCommit: 'a'.repeat(40),
+      initialCandidatePath: 'initial-candidate.json',
       ratchetPath: 'ratchet.json',
     });
     expect(() =>
@@ -28,6 +34,32 @@ describe('code graph production ratchet gate', () => {
         'ratchet.json',
         '--control',
         'control.json',
+      ]),
+    ).toThrow(/must be provided together/u);
+    expect(() =>
+      parseCodeGraphProductionRatchetGateArguments([
+        '--artifact',
+        'candidate.json',
+        '--ratchet',
+        'ratchet.json',
+        '--control',
+        'control.json',
+        '--expected-candidate-commit',
+        'b'.repeat(40),
+        '--expected-control-commit',
+        'a'.repeat(40),
+      ]),
+    ).toThrow(/must be provided together/u);
+    expect(() =>
+      parseCodeGraphProductionRatchetGateArguments([
+        '--artifact',
+        'candidate.json',
+        '--ratchet',
+        'ratchet.json',
+        '--control',
+        'control.json',
+        '--expected-candidate-commit',
+        'b'.repeat(40),
       ]),
     ).toThrow(/must be provided together/u);
     expect(() =>

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1364,6 +1364,136 @@ describe('code graph release evidence', () => {
     expect(githubHostedRatchet.metadata).not.toHaveProperty('benchmarkReferenceDiskFilesystem');
     expect(githubHostedRatchet.metadata).not.toHaveProperty('benchmarkReferenceDiskLocation');
     expect(githubHostedRatchet.metadata).not.toHaveProperty('benchmarkReferenceDiskMedium');
+    const pairedArtifact = (
+      artifact: BenchmarkArtifactV1,
+      commit: string,
+      measurementValues: Readonly<Record<string, number>>,
+    ): BenchmarkArtifactV1 => ({
+      ...artifact,
+      environment: {...artifact.environment, commit},
+      measurements: artifact.measurements.map(measurement =>
+        measurementValues[measurement.name] === undefined
+          ? measurement
+          : benchmarkMeasurement(measurement.name, measurement.unit, [measurementValues[measurement.name]!]),
+      ),
+      metadata: {
+        ...artifact.metadata,
+        benchmarkMeasuredSourceCommit: commit,
+        runnerIdentity: 'runner-0123456789abcdef',
+        sameRunnerComparisonKey: 'github-hosted-linux-x64|Linux|x64|Intel test|17179869184',
+      },
+    });
+    const controlCommit = 'a'.repeat(40);
+    const candidateCommit = 'b'.repeat(40);
+    const pairedControlArtifact = pairedArtifact(githubHostedArtifacts[0]!, controlCommit, {'cold-index': 1_000});
+    const noisyCandidate = pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {'cold-index': 1_200});
+    const pairedControl = {artifact: pairedControlArtifact, expectedCommit: controlCommit};
+
+    expect(() => enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet)).toThrow(/cold-index/u);
+    expect(() => enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, pairedControl)).not.toThrow();
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(
+        pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {'cold-index': 1_251}),
+        githubHostedRatchet,
+        pairedControl,
+      ),
+    ).toThrow(/cold-index.*exact protected-base control/u);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(
+        pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {'cold-index': 211}),
+        githubHostedRatchet,
+        {
+          artifact: pairedArtifact(githubHostedArtifacts[0]!, controlCommit, {'cold-index': 210}),
+          expectedCommit: controlCommit,
+        },
+      ),
+    ).toThrow(/cold-index/u);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(
+        pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {'one-file-reindex-index': 30_000}),
+        githubHostedRatchet,
+        {
+          artifact: pairedArtifact(githubHostedArtifacts[0]!, controlCommit, {'one-file-reindex-index': 30_000}),
+          expectedCommit: controlCommit,
+        },
+      ),
+    ).toThrow(/objective one-file-reindex-index has not been attained/u);
+    for (const [metadataName, value] of [
+      ['runnerIdentity', 'another-runner'],
+      ['sameRunnerComparisonKey', 'another-host'],
+    ] as const) {
+      expect(() =>
+        enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+          artifact: {
+            ...pairedControlArtifact,
+            metadata: {...pairedControlArtifact.metadata, [metadataName]: value},
+          },
+          expectedCommit: controlCommit,
+        }),
+      ).toThrow(new RegExp(`metadata\\.${metadataName}`));
+    }
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+        artifact: pairedControlArtifact,
+        expectedCommit: 'c'.repeat(40),
+      }),
+    ).toThrow(/paired control commit/u);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+        artifact: {
+          ...pairedControlArtifact,
+          environment: {...pairedControlArtifact.environment, fixtureHash: 'another-fixture'},
+        },
+        expectedCommit: controlCommit,
+      }),
+    ).toThrow(/paired control environment\.fixtureHash/u);
+    const invariantGuardNames = [
+      'cold-registration-process-cpu-n1',
+      'one-file-reindex-incremental-work-planned-rows-n1',
+      'cold-sqlite-wal-peak-observed',
+    ] as const;
+    fc.assert(
+      fc.property(fc.constantFrom(...invariantGuardNames), fc.integer({max: 10_000, min: 1}), (name, delta) => {
+        const limit = githubHostedRatchet.measurements[name]!;
+        const upperBound = limit.maximum ?? limit.p95Maximum;
+        expect(upperBound, name).toBeDefined();
+        const candidate = pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {
+          'cold-index': 1_200,
+          [name]: upperBound! + delta,
+        });
+        expect(() => enforceCodeGraphBenchmarkRatchet(candidate, githubHostedRatchet, pairedControl)).toThrow(
+          new RegExp(name),
+        );
+      }),
+      {numRuns: 30},
+    );
+    const cumulativeWorkTimingNames = [
+      'cold-inventory-cache-persistence-n1',
+      'cold-inventory-parser-extraction-summed-n1',
+      'cold-inventory-parser-fact-serialization-n1',
+      'cold-inventory-source-reading-n1',
+      'cold-materialization-stage-preparing-rows-n1',
+    ] as const;
+    fc.assert(
+      fc.property(fc.constantFrom(...cumulativeWorkTimingNames), fc.integer({max: 10_000, min: 1}), (name, delta) => {
+        const limit = githubHostedRatchet.measurements[name]!;
+        expect(limit.p95Maximum, name).toBeDefined();
+        const regressedValue = limit.p95Maximum! + delta;
+        const regressedControl = pairedArtifact(githubHostedArtifacts[0]!, controlCommit, {
+          [name]: regressedValue,
+        });
+        const regressedCandidate = pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {
+          [name]: regressedValue,
+        });
+        expect(() =>
+          enforceCodeGraphBenchmarkRatchet(regressedCandidate, githubHostedRatchet, {
+            artifact: regressedControl,
+            expectedCommit: controlCommit,
+          }),
+        ).toThrow(new RegExp(name));
+      }),
+      {numRuns: 30},
+    );
     expect(
       createCodeGraphProductionRatchet(
         githubHostedArtifacts.map((artifact, index) => {

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1011,6 +1011,9 @@ describe('code graph release evidence', () => {
           benchmarkMeasurement('same-overlay-reference-registration-lock-and-database-setup', 'milliseconds', [
             coldIndexMilliseconds + 10,
           ]),
+          benchmarkMeasurement('cold-materialization-stage-committing-n1', 'milliseconds', [100]),
+          benchmarkMeasurement('one-file-reindex-materialization-stage-committing-n1', 'milliseconds', [100]),
+          benchmarkMeasurement('same-overlay-reference-materialization-stage-committing-n1', 'milliseconds', [100]),
           benchmarkMeasurement('cold-materialization-stage-preparing-rows-n1', 'milliseconds', [100]),
           benchmarkMeasurement('cold-hosted-subphase-n1', 'milliseconds', [1_000]),
           benchmarkMeasurement('cold-hosted-microphase-n1', 'milliseconds', [128]),
@@ -1368,8 +1371,10 @@ describe('code graph release evidence', () => {
       artifact: BenchmarkArtifactV1,
       commit: string,
       measurementValues: Readonly<Record<string, number>>,
+      createdAt = artifact.createdAt,
     ): BenchmarkArtifactV1 => ({
       ...artifact,
+      createdAt,
       environment: {...artifact.environment, commit},
       measurements: artifact.measurements.map(measurement =>
         measurementValues[measurement.name] === undefined
@@ -1385,37 +1390,111 @@ describe('code graph release evidence', () => {
     });
     const controlCommit = 'a'.repeat(40);
     const candidateCommit = 'b'.repeat(40);
-    const pairedControlArtifact = pairedArtifact(githubHostedArtifacts[0]!, controlCommit, {'cold-index': 1_000});
-    const noisyCandidate = pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {'cold-index': 1_200});
-    const pairedControl = {artifact: pairedControlArtifact, expectedCommit: controlCommit};
+    const sandwichStart = Date.parse('2026-08-28T00:00:00.000Z');
+    const sandwichTime = (minutes: number) => new Date(sandwichStart + minutes * 60_000).toISOString();
+    const pairedInitialCandidateArtifact = pairedArtifact(
+      githubHostedArtifacts[0]!,
+      candidateCommit,
+      {'cold-index': 1_200},
+      sandwichTime(0),
+    );
+    const pairedControlArtifact = pairedArtifact(
+      githubHostedArtifacts[0]!,
+      controlCommit,
+      {'cold-index': 1_000},
+      sandwichTime(10),
+    );
+    const noisyCandidate = pairedArtifact(
+      githubHostedArtifacts[0]!,
+      candidateCommit,
+      {'cold-index': 1_200},
+      sandwichTime(20),
+    );
+    const pairedControl = {
+      artifact: pairedControlArtifact,
+      expectedCandidateCommit: candidateCommit,
+      expectedCommit: controlCommit,
+      initialCandidateArtifact: pairedInitialCandidateArtifact,
+    };
+    const sandwichCandidate = (measurementValues: Readonly<Record<string, number>>) =>
+      pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, measurementValues, sandwichTime(20));
+    const sandwichControl = (measurementValues: Readonly<Record<string, number>>) =>
+      pairedArtifact(githubHostedArtifacts[0]!, controlCommit, measurementValues, sandwichTime(10));
+    const sandwichEvidence = (
+      initialMeasurementValues: Readonly<Record<string, number>>,
+      controlArtifact = pairedControlArtifact,
+    ) => ({
+      artifact: controlArtifact,
+      expectedCandidateCommit: candidateCommit,
+      expectedCommit: controlCommit,
+      initialCandidateArtifact: pairedArtifact(
+        githubHostedArtifacts[0]!,
+        candidateCommit,
+        initialMeasurementValues,
+        sandwichTime(0),
+      ),
+    });
 
     expect(() => enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet)).toThrow(/cold-index/u);
     expect(() => enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, pairedControl)).not.toThrow();
+    fc.assert(
+      fc.property(fc.integer({max: 500, min: -500}), fc.integer({max: 50_000, min: 30_000}), (slope, regression) => {
+        const baseline = 100_000;
+        const remeasuredMinute = 25;
+        const initialValue = baseline;
+        const controlValue = baseline + slope * 10;
+        const remeasuredValue = baseline + slope * remeasuredMinute;
+        const linearControl = sandwichControl({'cold-index': controlValue});
+        const linearCandidate = (value: number) =>
+          pairedArtifact(
+            githubHostedArtifacts[0]!,
+            candidateCommit,
+            {'cold-index': value},
+            sandwichTime(remeasuredMinute),
+          );
+        expect(() =>
+          enforceCodeGraphBenchmarkRatchet(
+            linearCandidate(remeasuredValue),
+            githubHostedRatchet,
+            sandwichEvidence({'cold-index': initialValue}, linearControl),
+          ),
+        ).not.toThrow();
+        expect(() =>
+          enforceCodeGraphBenchmarkRatchet(
+            linearCandidate(remeasuredValue + regression),
+            githubHostedRatchet,
+            sandwichEvidence({'cold-index': initialValue + regression}, linearControl),
+          ),
+        ).toThrow(/cold-index.*bounded candidate sandwich.*exact protected-base control/u);
+      }),
+      {numRuns: 30},
+    );
     expect(() =>
       enforceCodeGraphBenchmarkRatchet(
-        pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {'cold-index': 1_251}),
+        sandwichCandidate({'cold-index': 140_000}),
         githubHostedRatchet,
-        pairedControl,
+        sandwichEvidence({'cold-index': 80_000}, sandwichControl({'cold-index': 100_000})),
+      ),
+    ).toThrow(/candidate sandwich dispersion cold-index/u);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(
+        sandwichCandidate({'cold-index': 1_251}),
+        githubHostedRatchet,
+        sandwichEvidence({'cold-index': 1_251}),
       ),
     ).toThrow(/cold-index.*exact protected-base control/u);
     expect(() =>
       enforceCodeGraphBenchmarkRatchet(
-        pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {'cold-index': 211}),
+        sandwichCandidate({'cold-index': 211}),
         githubHostedRatchet,
-        {
-          artifact: pairedArtifact(githubHostedArtifacts[0]!, controlCommit, {'cold-index': 210}),
-          expectedCommit: controlCommit,
-        },
+        sandwichEvidence({'cold-index': 211}, sandwichControl({'cold-index': 210})),
       ),
     ).toThrow(/cold-index/u);
     expect(() =>
       enforceCodeGraphBenchmarkRatchet(
-        pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {'one-file-reindex-index': 30_000}),
+        sandwichCandidate({'one-file-reindex-index': 30_000}),
         githubHostedRatchet,
-        {
-          artifact: pairedArtifact(githubHostedArtifacts[0]!, controlCommit, {'one-file-reindex-index': 30_000}),
-          expectedCommit: controlCommit,
-        },
+        sandwichEvidence({'one-file-reindex-index': 30_000}, sandwichControl({'one-file-reindex-index': 30_000})),
       ),
     ).toThrow(/objective one-file-reindex-index has not been attained/u);
     for (const [metadataName, value] of [
@@ -1424,27 +1503,69 @@ describe('code graph release evidence', () => {
     ] as const) {
       expect(() =>
         enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+          ...pairedControl,
           artifact: {
             ...pairedControlArtifact,
             metadata: {...pairedControlArtifact.metadata, [metadataName]: value},
           },
-          expectedCommit: controlCommit,
         }),
       ).toThrow(new RegExp(`metadata\\.${metadataName}`));
+      expect(() =>
+        enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+          ...pairedControl,
+          initialCandidateArtifact: {
+            ...pairedInitialCandidateArtifact,
+            metadata: {...pairedInitialCandidateArtifact.metadata, [metadataName]: value},
+          },
+        }),
+      ).toThrow(new RegExp(`initial candidate metadata\\.${metadataName}`));
     }
     expect(() =>
       enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
-        artifact: pairedControlArtifact,
+        ...pairedControl,
         expectedCommit: 'c'.repeat(40),
       }),
     ).toThrow(/paired control commit/u);
     expect(() =>
       enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+        ...pairedControl,
+        expectedCandidateCommit: 'c'.repeat(40),
+      }),
+    ).toThrow(/paired candidate commit/u);
+    const anotherCandidateCommit = 'c'.repeat(40);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+        ...pairedControl,
+        initialCandidateArtifact: {
+          ...pairedInitialCandidateArtifact,
+          environment: {...pairedInitialCandidateArtifact.environment, commit: anotherCandidateCommit},
+          metadata: {
+            ...pairedInitialCandidateArtifact.metadata,
+            benchmarkMeasuredSourceCommit: anotherCandidateCommit,
+          },
+        },
+      }),
+    ).toThrow(/initial candidate commit/u);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+        ...pairedControl,
+        initialCandidateArtifact: {...pairedInitialCandidateArtifact, createdAt: sandwichTime(10)},
+      }),
+    ).toThrow(/creation times.*strictly ordered/u);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(
+        {...noisyCandidate, createdAt: sandwichTime(41)},
+        githubHostedRatchet,
+        pairedControl,
+      ),
+    ).toThrow(/creation times.*within 40 minutes/u);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, {
+        ...pairedControl,
         artifact: {
           ...pairedControlArtifact,
           environment: {...pairedControlArtifact.environment, fixtureHash: 'another-fixture'},
         },
-        expectedCommit: controlCommit,
       }),
     ).toThrow(/paired control environment\.fixtureHash/u);
     const invariantGuardNames = [
@@ -1457,7 +1578,7 @@ describe('code graph release evidence', () => {
         const limit = githubHostedRatchet.measurements[name]!;
         const upperBound = limit.maximum ?? limit.p95Maximum;
         expect(upperBound, name).toBeDefined();
-        const candidate = pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {
+        const candidate = sandwichCandidate({
           'cold-index': 1_200,
           [name]: upperBound! + delta,
         });
@@ -1467,8 +1588,22 @@ describe('code graph release evidence', () => {
       }),
       {numRuns: 30},
     );
+    fc.assert(
+      fc.property(fc.constantFrom(...invariantGuardNames), fc.integer({max: 10_000, min: 1}), (name, delta) => {
+        const limit = githubHostedRatchet.measurements[name]!;
+        const upperBound = limit.maximum ?? limit.p95Maximum;
+        expect(upperBound, name).toBeDefined();
+        const initialOnlyRegression = sandwichEvidence({
+          'cold-index': 1_200,
+          [name]: upperBound! + delta,
+        });
+        expect(() =>
+          enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, initialOnlyRegression),
+        ).toThrow(new RegExp(`initial candidate ${name}`));
+      }),
+      {numRuns: 30},
+    );
     const cumulativeWorkTimingNames = [
-      'cold-inventory-cache-persistence-n1',
       'cold-inventory-parser-extraction-summed-n1',
       'cold-inventory-parser-fact-serialization-n1',
       'cold-inventory-source-reading-n1',
@@ -1479,19 +1614,47 @@ describe('code graph release evidence', () => {
         const limit = githubHostedRatchet.measurements[name]!;
         expect(limit.p95Maximum, name).toBeDefined();
         const regressedValue = limit.p95Maximum! + delta;
-        const regressedControl = pairedArtifact(githubHostedArtifacts[0]!, controlCommit, {
-          [name]: regressedValue,
-        });
-        const regressedCandidate = pairedArtifact(githubHostedArtifacts[0]!, candidateCommit, {
-          [name]: regressedValue,
-        });
+        const regressedControl = sandwichControl({[name]: regressedValue});
+        const regressedCandidate = sandwichCandidate({[name]: regressedValue});
         expect(() =>
-          enforceCodeGraphBenchmarkRatchet(regressedCandidate, githubHostedRatchet, {
-            artifact: regressedControl,
-            expectedCommit: controlCommit,
-          }),
+          enforceCodeGraphBenchmarkRatchet(
+            regressedCandidate,
+            githubHostedRatchet,
+            sandwichEvidence({[name]: regressedValue}, regressedControl),
+          ),
         ).toThrow(new RegExp(name));
       }),
+      {numRuns: 30},
+    );
+    const hostedStorageWallTimingNames = [
+      'cold-inventory-cache-persistence-n1',
+      'cold-materialization-stage-committing-n1',
+      'one-file-reindex-inventory-cache-persistence-n1',
+      'one-file-reindex-materialization-stage-committing-n1',
+      'same-overlay-reference-inventory-cache-persistence-n1',
+      'same-overlay-reference-materialization-stage-committing-n1',
+    ] as const;
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...hostedStorageWallTimingNames),
+        fc.integer({max: 10_000, min: 1}),
+        (name, delta) => {
+          const limit = githubHostedRatchet.measurements[name]!;
+          expect(limit.p95Maximum, name).toBeDefined();
+          const controlValue = limit.p95Maximum! + delta;
+          const control = sandwichControl({[name]: controlValue});
+          const candidate = sandwichCandidate({[name]: controlValue});
+          const boundedPair = sandwichEvidence({[name]: controlValue}, control);
+          expect(() => enforceCodeGraphBenchmarkRatchet(candidate, githubHostedRatchet, boundedPair)).not.toThrow();
+          expect(() =>
+            enforceCodeGraphBenchmarkRatchet(
+              sandwichCandidate({[name]: controlValue * 4 + 1_000}),
+              githubHostedRatchet,
+              sandwichEvidence({[name]: controlValue * 4 + 1_000}, control),
+            ),
+          ).toThrow(new RegExp(`${name}.*exact protected-base control`));
+        },
+      ),
       {numRuns: 30},
     );
     expect(


### PR DESCRIPTION
## Summary

- keep the reviewed production ratchet as the first, unchanged gate
- only after a static failure, measure an exact protected-base control and then remeasure the exact candidate on the same GitHub-hosted runner, producing an A1–B–A2 sandwich
- admit fallback only for an explicit allowlist of genuine single-sample elapsed-wall p95 metrics where B also misses the static bound
- estimate candidate wall time at B by timestamp-weighted interpolation of A1 and A2, with strict A1 < B < A2 ordering, a 40-minute span cap, and fail-closed candidate-dispersion limits
- retain static CPU, RSS, cumulative work timing, work-count, storage, correctness, graph-shape, and hard-objective guards from both candidate observations

## Diagnosis

Run 33182609070 passed on Intel 8370C, while attempts 1 and 2 of run 33183511274 failed the exact payload on Intel 8573C and 6973P-C hosts. Wall time inflated across the failed hosts while paired process CPU stayed equal or lower. The TypeScript-only fixture did not load the dependency WASM changed by the PR.

The first same-runner fallback then exposed a second bias in run 33188007126 / job 98905989443: candidate-first versus base-second was not adjacent or order-neutral, and identical runtime behavior produced 15 failures. The final gate therefore uses both candidate observations around the base. Linear runner drift cancels at the control timestamp; excessive A1/A2 disagreement still fails closed.

No checked-in threshold is raised. All three artifacts bind exact expected commits, suite, runner identity, same-runner host key, environment/fixture contract, runtime/storage/output metadata, assessed measurement set, and bounded timestamp order. New millisecond metrics default to static. Only the reviewed wall-p95 allowlist can interpolate; non-wall failures from either A1 or A2 remain blocking. B and candidate dispersion must also be admissible under the existing relative/absolute headroom and hard objectives.

## Verification

- focused Vitest: 54/54
- bounded Fast-check property: linear runner drift is neutralized while a true candidate regression still fails
- bounded Fast-check properties: A1-only and A2-only CPU/work-count/storage regressions remain blocking
- bounded Fast-check properties: cumulative millisecond work regressions remain static and hosted-storage wall fallback remains bounded
- strict lint and file-length guard
- full Prettier check
- source, test, and website typechecks
- exact head/base: `a6f1b35e0f6b4bb4417c47c0bfb10c198e448a1f` / `91cd08547efccbdaa76e27e9ac6ee9c028e272ca`
- independent exact-head Critical/Important review: clean (0 findings)
- fresh strict-current CI: 43 successes, 18 expected skips, 0 pending/failing
- governed production ratchet: run 33191657814 / job 98918441411 passed the unchanged static gate in 5m24s and retained its artifact; the fallback correctly remained dormant

CI is terminal and authoritative for the full suite. This PR remains unmerged.
