### PR TITLE
fix: clarify graph-indexed citation paths

### DIFF
--- a/.github/release-notes/v4.4.0.md
+++ b/.github/release-notes/v4.4.0.md
@@ -8,7 +8,8 @@ evidence, abstains when validation is incomplete, and keeps existing uncited mem
 
 - CLI `remember` and `handoff` accept repeatable `--code-ref` values. MCP `remember_context` and
   `review_session_context` accept `codeRefs` with an absolute `callerCwd`.
-- References may be repository-relative paths, local `cgs_` symbol handles, or repository-qualified `cgr_` handles.
+- References may be graph-indexed repository-relative paths, local `cgs_` symbol handles, or repository-qualified
+  `cgr_` handles.
   Threadnote resolves them against an already-published exact-current graph and derives repository, snapshot, file, and
   source-fragment evidence internally; callers never supply hashes or validation status.
 - Capture is atomic, deduplicated, and bounded to eight citations per memory. An invalid, absent, ambiguous,

--- a/config/agent-instructions.md
+++ b/config/agent-instructions.md
@@ -30,7 +30,7 @@ and `topic` identities; update memories with `replaceUri`. Store routine durable
 directly; use `review_session_context` only for additional session-extracted candidates requiring explicit approval.
 Before pausing or ending meaningful work, leave a concise handoff.
 
-For consequential source-backed claims, cite repo-relative paths/returned `cgs_`/`cgr_` handles via MCP `codeRefs` or
+For consequential source claims, cite graph-indexed repo paths or returned `cgs_`/`cgr_` handles via MCP `codeRefs` or
 repeated CLI `--code-ref`. Capture needs a ready exact-current graph; it never indexes. Replacement without refs clears
 citations. Legacy uncited memories stay recallable at coarse/unknown freshness; see
 [Citations](https://threadnote.io/docs/code-citations/).

--- a/cursor-plugin/rules/threadnote.mdc
+++ b/cursor-plugin/rules/threadnote.mdc
@@ -36,7 +36,7 @@ and `topic` identities; update memories with `replaceUri`. Store routine durable
 directly; use `review_session_context` only for additional session-extracted candidates requiring explicit approval.
 Before pausing or ending meaningful work, leave a concise handoff.
 
-For consequential source-backed claims, cite repo-relative paths/returned `cgs_`/`cgr_` handles via MCP `codeRefs` or
+For consequential source claims, cite graph-indexed repo paths or returned `cgs_`/`cgr_` handles via MCP `codeRefs` or
 repeated CLI `--code-ref`. Capture needs a ready exact-current graph; it never indexes. Replacement without refs clears
 citations. Legacy uncited memories stay recallable at coarse/unknown freshness; see
 [Citations](https://threadnote.io/docs/code-citations/).

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -30,7 +30,7 @@ and `topic` identities; update memories with `replaceUri`. Store routine durable
 directly; use `review_session_context` only for additional session-extracted candidates requiring explicit approval.
 Before pausing or ending meaningful work, leave a concise handoff.
 
-For consequential source-backed claims, cite repo-relative paths/returned `cgs_`/`cgr_` handles via MCP `codeRefs` or
+For consequential source claims, cite graph-indexed repo paths or returned `cgs_`/`cgr_` handles via MCP `codeRefs` or
 repeated CLI `--code-ref`. Capture needs a ready exact-current graph; it never indexes. Replacement without refs clears
 citations. Legacy uncited memories stay recallable at coarse/unknown freshness; see
 [Citations](https://threadnote.io/docs/code-citations/).

--- a/docs/memory-code-citations.md
+++ b/docs/memory-code-citations.md
@@ -45,13 +45,16 @@ when references are present:
 
 Pass that payload to `remember_context`. Supported references are:
 
-- a safe repository-relative POSIX path, which creates a file citation;
+- a safe repository-relative POSIX path present in the exact-current graph, which creates a file citation;
 - a local `cgs_` graph handle, which normally creates a symbol citation;
 - a repository-qualified `cgr_` handle, which selects its bound repository and symbol.
 
 Callers supply locators, not hashes, status, snapshot data, or raw citation JSON. Threadnote resolves every reference
 against an exact-current ready graph and derives the citation internally. Capture is deduplicated and atomic: if one
 explicit reference is invalid, absent, ambiguous, non-current, or changes during capture, the memory is not written.
+
+Path references are graph locators, not arbitrary tracked-file readers. A tracked file that is outside the graph
+inventory cannot be cited by path; choose a path or stable handle that is present in the exact-current graph.
 
 Capture never starts or refreshes indexing. Check the graph first and prepare it explicitly when needed:
 

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -1308,7 +1308,7 @@ const remember = Command.make(
   {
     codeRefs: repeatedString(
       'code-ref',
-      'Repository-relative path, cgs_ symbol, or cgr_ qualified ref to cite; repeat for multiple',
+      'Graph-indexed repository-relative path, cgs_ symbol, or cgr_ qualified ref to cite; repeat for multiple',
     ),
     dryRun: boolean('dry-run', 'Print memory and native operation without storing'),
     kind: defaultChoice(
@@ -1534,7 +1534,7 @@ const handoff = Command.make(
     ci: optionalString('ci', 'Captured CI status snapshot'),
     codeRefs: repeatedString(
       'code-ref',
-      'Repository-relative path, cgs_ symbol, or cgr_ qualified ref to cite; repeat for multiple',
+      'Graph-indexed repository-relative path, cgs_ symbol, or cgr_ qualified ref to cite; repeat for multiple',
     ),
     dryRun: boolean('dry-run', 'Print handoff without storing'),
     issue: optionalString('issue', 'Related issue reference'),

--- a/src/mcp_server_recall.ts
+++ b/src/mcp_server_recall.ts
@@ -157,7 +157,7 @@ export function registerCandidateMemoryTools(server: EffectMcpServerAdapter, con
       inputSchema: {
         callerCwd: McpInput.string('Absolute cwd; infers project'),
         codeRefs: McpInput.stringOrStrings(
-          `Repository-relative path, cgs_ symbol, or cgr_ qualified ref to carry into approved candidates; max ${MAX_MEMORY_CODE_CITATIONS}`,
+          `Graph-indexed repository-relative path, cgs_ symbol, or cgr_ qualified ref to carry into approved candidates; max ${MAX_MEMORY_CODE_CITATIONS}`,
           {maximumItems: MAX_MEMORY_CODE_CITATIONS},
         ),
         decisions: McpInput.stringOrStrings('Reusable decisions'),
@@ -1450,7 +1450,7 @@ export function registerStoreTool(
       inputSchema: {
         callerCwd: McpInput.string('Absolute cwd for nested package/app scope'),
         codeRefs: McpInput.stringOrStrings(
-          `Repository-relative path, cgs_ symbol, or cgr_ qualified ref to capture as immutable code evidence; max ${MAX_MEMORY_CODE_CITATIONS}`,
+          `Graph-indexed repository-relative path, cgs_ symbol, or cgr_ qualified ref to capture as immutable code evidence; max ${MAX_MEMORY_CODE_CITATIONS}`,
           {maximumItems: MAX_MEMORY_CODE_CITATIONS},
         ),
         kind: McpInput.literals(['durable', 'handoff', 'incident', 'preference', 'smoke'], 'Memory lifecycle kind'),

--- a/src/memory_code_citation_capture.ts
+++ b/src/memory_code_citation_capture.ts
@@ -308,7 +308,7 @@ const captureRepositoryGroup = Effect.fn('memoryCodeCitation.captureRepositoryGr
               if (!file) {
                 return yield* Effect.fail(
                   new MemoryCodeCitationCaptureError(
-                    `Code citation path is absent from the exact current graph: ${target.target.path}.`,
+                    `Code citation path is not present in the exact current graph: ${target.target.path}. Use a graph-indexed repository-relative path.`,
                   ),
                 );
               }

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,7 +174,7 @@ export interface McpInstallOptions {
 }
 
 export interface RememberOptions {
-  /** Repository-relative paths or stable code-graph refs captured as immutable code citations. */
+  /** Graph-indexed repository-relative paths or stable code-graph refs captured as immutable code citations. */
   readonly codeRefs?: readonly string[];
   readonly dryRun?: boolean;
   readonly kind?: MemoryKind;
@@ -250,7 +250,7 @@ export interface ListOptions {
 export interface HandoffOptions {
   readonly blockers?: string;
   readonly ci?: string;
-  /** Repository-relative paths or stable code-graph refs captured as immutable code citations. */
+  /** Graph-indexed repository-relative paths or stable code-graph refs captured as immutable code citations. */
   readonly codeRefs?: readonly string[];
   readonly dryRun?: boolean;
   readonly issue?: string;

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -40,6 +40,14 @@ describe('Effect CLI', () => {
     expect(disable.stdout).toContain('--apply');
   });
 
+  it('describes citation paths as exact-current graph locators', async () => {
+    const remember = await runCli(['remember', '--help']);
+    const handoff = await runCli(['handoff', '--help']);
+
+    expect(remember.stdout).toContain('Graph-indexed repository-relative path');
+    expect(handoff.stdout).toContain('Graph-indexed repository-relative path');
+  });
+
   it('keeps regular and negated boolean flags optional with their historical defaults', async () => {
     const root = await mkdtemp(join(tmpdir(), 'threadnote-effect-cli-boolean-defaults-'));
     const environment = {

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -463,6 +463,7 @@ describe('Threadnote MCP toolsets', () => {
               },
             },
           });
+          expect(JSON.stringify(codeReferenceTool?.inputSchema)).toContain('Graph-indexed repository-relative path');
         }
 
         const validationError = await callErrorText(client, 'recall_context', {

--- a/test/unit/agent-instructions.test.ts
+++ b/test/unit/agent-instructions.test.ts
@@ -50,6 +50,7 @@ describe('agent instructions', () => {
       'If graph tooling is unavailable, say so',
       'Before pausing or ending meaningful work',
       '`threadnote` CLI',
+      'graph-indexed repo paths',
     ]) {
       expect(instructions).toContain(requiredText);
     }

--- a/test/unit/memory-code-citation-capture.test.ts
+++ b/test/unit/memory-code-citation-capture.test.ts
@@ -112,6 +112,28 @@ describe('memory code citation capture and validation', () => {
     }).pipe(provideTestLayer(StandaloneBrokerLayer)),
   );
 
+  effectIt.effect('requires path references to be present in the exact-current graph', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-citation-unindexed-path-'});
+      const fixture = citationFixture(root);
+
+      const failure = yield* captureMemoryCodeCitations(CONFIG, {
+        callerCwd: root,
+        refs: ['.github/workflows/ci.yml'],
+      }).pipe(provideTestLayer(fixture.layer), Effect.flip);
+
+      expect(failure).toBeInstanceOf(MemoryCodeCitationCaptureError);
+      if (!(failure instanceof MemoryCodeCitationCaptureError)) return;
+      expect(failure.message).toBe(
+        'Code citation path is not present in the exact current graph: .github/workflows/ci.yml. Use a graph-indexed repository-relative path.',
+      );
+      expect(failure.message).not.toContain(root);
+      expect(failure.recovery).toBeUndefined();
+      expect(fixture.leases()).toEqual({acquired: 1, released: 1});
+    }).pipe(provideTestLayer(StandaloneBrokerLayer)),
+  );
+
   effectIt.effect('routes qualified-reference recovery through its published Workset before unchanged retry', () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -922,12 +922,15 @@ The body remains ordinary **Markdown**.
       readFile(join(root, 'website', 'src', 'pages', 'ProTipsPage.tsx'), 'utf8'),
       readFile(join(root, 'website', 'src', 'pages', 'FaqPage.tsx'), 'utf8'),
     ]);
+    const docs = JSON.stringify(docsSections);
     const tips = JSON.stringify(proTips);
 
     expect(landingSource).toContain('Optional citations · stale-link warnings · legacy recall');
     expect(landingSource).toContain('older uncited memories stay recallable');
     expect(landingSource).toContain('A stale-link warning means the evidence moved—not that the memory');
     expect(tips).toContain('codeRefs');
+    expect(docs).toContain('graph-indexed repository-relative path');
+    expect(docs).toContain('Tracked files outside the exact-current graph inventory');
     expect(tips).toContain('Memory fresh · citation relocated · warning stale-link');
     expect(tips).toContain('stale-link warns about the locator, not the memory');
     expect(proTipsSource).toContain('source-aware memory');

--- a/website/articles/2026-08-26T20-30-00Z--memory-that-can-check-its-sources.md
+++ b/website/articles/2026-08-26T20-30-00Z--memory-that-can-check-its-sources.md
@@ -23,7 +23,7 @@ where Threadnote deliberately refuses to guess.
 
 ## Capture a receipt, not a verdict
 
-A citation starts with something the caller is allowed to know: a repository-relative path or a stable `cgs_`/`cgr_`
+A citation starts with something the caller is allowed to know: a graph-indexed repository-relative path or a stable `cgs_`/`cgr_`
 graph handle.
 
 ```sh

--- a/website/src/content/docsMemoryWorkflows.ts
+++ b/website/src/content/docsMemoryWorkflows.ts
@@ -63,7 +63,7 @@ export const memoryWorkflowsDocsSection: DocsSection = {
       body: [
         {
           type: 'paragraph',
-          text: 'Use a repeatable --code-ref in CLI remember or handoff, or codeRefs in remember_context and review_session_context, when a memory makes a consequential claim about source. A reference may be a safe repository-relative path, a local cgs_ symbol handle, or a repository-qualified cgr_ handle. A path captures the file; a symbol handle captures the indexed source fragment.',
+          text: 'Use a repeatable --code-ref in CLI remember or handoff, or codeRefs in remember_context and review_session_context, when a memory makes a consequential claim about source. A reference may be a safe graph-indexed repository-relative path, a local cgs_ symbol handle, or a repository-qualified cgr_ handle. A path captures the indexed file; a symbol handle captures the indexed source fragment. Tracked files outside the exact-current graph inventory are not valid path references.',
         },
         {
           type: 'code',


### PR DESCRIPTION
## Summary

- clarify that repository-path `codeRefs` must already be present in the exact-current graph
- make the graph-absent path error actionable without exposing absolute paths or inventory exclusion reasons
- align MCP schema, CLI help, packaged agent guidance, release/docs, and website copy
- add focused capture, transport-schema/help, instruction, and website regressions

## Verification

- 73 focused unit/content/instruction tests passed
- targeted CLI transport: 1 passed, 33 skipped
- targeted MCP transport: 1 passed, 42 skipped
- strict lint, production file-length, Prettier, source/test/site typechecks passed
- commit hook full lint/format/typechecks passed
- no property test added because locator acceptance behavior is unchanged; this patch clarifies the contract and error surface, with the concrete graph-absent regression covering the defect

## Scope

Exact base at implementation start: `5a7ac621815111661920b8a652cc8f5ac5df160e`. No graph inventory policy change, global runtime installation, merge, or release action.