### PR TITLE
chore(release): prepare v4.5.0

### DIFF
--- a/.github/release-notes/v4.5.0.md
+++ b/.github/release-notes/v4.5.0.md
@@ -1,0 +1,94 @@
+## What's new
+
+Threadnote 4.5 makes native code graphs portable between local installations and makes source-backed memory easier to
+recover when graph evidence is missing, moved, or being rebuilt. It also hardens large Workset catalogs, stale-worktree
+cleanup, Manager naming, performance gates, telemetry renewal, and development installs while keeping legacy recall
+intact.
+
+### Carry a verified graph between machines
+
+Portable graph checkpoints are manual, offline, and account-free:
+
+```sh
+threadnote graph index
+threadnote graph checkpoint export --output ./threadnote-graph.cgcp
+threadnote graph checkpoint inspect \
+  --input ./threadnote-graph.cgcp \
+  --expected-digest sha256:<digest>
+threadnote graph checkpoint verify \
+  --input ./threadnote-graph.cgcp \
+  --expected-digest sha256:<digest>
+threadnote graph checkpoint import \
+  --input ./threadnote-graph.cgcp \
+  --expected-digest sha256:<digest>
+```
+
+- Export produces deterministic, credential-free artifacts from an exact ready graph at a clean commit. Checkpoints
+  exclude raw source, local paths, credentials, and worktree identities.
+- `inspect` authenticates the artifact and its bounded framing without inflating graph records; `verify` additionally
+  checks compressed records, ordering, counts, coverage, and logical integrity.
+- Import never fetches source or executes repository code. The source commit must already exist in the same local
+  repository.
+- An exact clean checkout activates the imported graph directly. Dirty or descendant checkouts rebuild with the
+  imported graph as a compatible base; divergent history keeps it inactive for later reuse.
+
+Obtain the expected digest independently from the checkpoint file, just as you would for a release archive.
+
+### Recover explicitly when evidence or cached state is unavailable
+
+- An MCP citation write that reaches a missing, stale, or deferred graph now fails before changing memory and returns a
+  structured `memory-code-citation-write-recovery` receipt with `writeApplied: false` and
+  `indexingStarted: false`.
+- Local citation recovery directs the caller to `threadnote graph index --no-vectors`; Workset-routed references return
+  an explicit `threadnote workset prepare <name>` action. Retry the same write after the selected graph is ready.
+- A uniquely relocated citation keeps its memory fresh while returning a `stale-link` warning. Changed or deleted
+  evidence makes the memory stale; unavailable, ambiguous, or incomplete evidence remains `unknown`.
+- Graph indexing automatically falls back to extraction without cached-fact reuse when a cached fact has disappeared,
+  avoiding an unnecessary manual full rebuild.
+- MCP schemas now advertise the same eight-code-reference limit enforced by memory writes, so clients can reject an
+  oversized `codeRefs` array before invoking `remember_context` or `review_session_context`.
+- Deleted-worktree snapshots are reclaimed even if Git later recycles the same administrative worktree name.
+  Ambiguous or malformed state remains protected rather than guessed at.
+
+### Keep Worksets bounded and Manager understandable
+
+- Streaming and full-catalog Workset writers now share one lazy routing-projection paginator. It preserves order,
+  enforces the 8 MiB and 512-symbol page limits consistently, computes each symbol's storage charge once, and rejects
+  a single oversized symbol instead of emitting an invalid page.
+- The 8 MiB boundary regression now exercises the production paginator directly. Remaining SQLite-heavy projection
+  coverage runs in the serialized `heavy-state` lane without longer timeouts or weaker assertions.
+- Manager labels a repository-root workspace with its declared project name instead of `"."`; nested workspace labels
+  remain unchanged.
+- The website Home, Pro Tips, and FAQ explain portable checkpoints, stale-link semantics, legacy recall, optional
+  Worksets, and Manager's isolated graph preparation and bounded member concurrency.
+
+### Keep upgrades and performance evidence explicit
+
+- An opt-in from an earlier telemetry schema no longer silently carries forward to schema v5. Threadnote surfaces the
+  renewal after update, while noninteractive updates keep telemetry off until the user explicitly runs:
+
+  ```sh
+  threadnote telemetry enable --apply
+  ```
+
+- The development installer tolerates one bounded recall-index projection race during strict doctor verification while
+  continuing to fail closed for unrelated doctor errors.
+- The governed production performance ratchet still applies every reviewed static limit first. If a single-observation
+  wall-clock gate fails on a heterogeneous hosted runner, CI measures the exact protected base on that same runner;
+  CPU, RSS, work, storage, correctness, graph-shape, relative, and hard-objective guards remain fail-closed.
+- Reviewed maintenance updates refresh JOSE, PostgreSQL, node-llama-cpp, Vite and React build tooling, `happy-dom`,
+  Vitest, coverage, and React DOM types while keeping Bun runtime and Bun types aligned at 1.3.14.
+
+### Upgrade to Threadnote 4.5
+
+Existing standalone installations upgrade with:
+
+```sh
+threadnote update
+```
+
+Portable checkpoint operations affect only Threadnote's disposable graph store. Existing schema-v1, schema-v2,
+schema-v3, unversioned, and otherwise uncited memories continue through normal recall; no citation migration is
+required, and missing precise citations yield coarse or unknown freshness instead of empty results. A Workset remains
+optional for local repository recall, graph use, citation capture, Context Brief, and checkpoints. It is an explicit
+prepared boundary for cross-repository evidence.

--- a/.github/release-notes/v4.5.0.md
+++ b/.github/release-notes/v4.5.0.md
@@ -45,6 +45,8 @@ Obtain the expected digest independently from the checkpoint file, just as you w
   evidence makes the memory stale; unavailable, ambiguous, or incomplete evidence remains `unknown`.
 - Graph indexing automatically falls back to extraction without cached-fact reuse when a cached fact has disappeared,
   avoiding an unnecessary manual full rebuild.
+- Repository-relative citation paths are graph locators, not arbitrary tracked-file readers. A tracked file outside the
+  exact-current graph inventory is rejected with bounded guidance to choose a graph-indexed path or stable handle.
 - MCP schemas now advertise the same eight-code-reference limit enforced by memory writes, so clients can reject an
   oversized `codeRefs` array before invoking `remember_context` or `review_session_context`.
 - Deleted-worktree snapshots are reclaimed even if Git later recycles the same administrative worktree name.
@@ -73,9 +75,10 @@ Obtain the expected digest independently from the checkpoint file, just as you w
 
 - The development installer tolerates one bounded recall-index projection race during strict doctor verification while
   continuing to fail closed for unrelated doctor errors.
-- The governed production performance ratchet still applies every reviewed static limit first. If a single-observation
-  wall-clock gate fails on a heterogeneous hosted runner, CI measures the exact protected base on that same runner;
-  CPU, RSS, work, storage, correctness, graph-shape, relative, and hard-objective guards remain fail-closed.
+- The governed production performance ratchet still applies every reviewed static limit first. If an allowlisted
+  single-observation wall-clock gate fails on a heterogeneous hosted runner, CI brackets the exact protected base with
+  candidate measurements on that runner and applies a bounded drift-corrected comparison. CPU, RSS, work, storage,
+  correctness, graph-shape, dispersion, relative, and hard-objective guards remain fail-closed.
 - Reviewed maintenance updates refresh JOSE, PostgreSQL, node-llama-cpp, Vite and React build tooling, `happy-dom`,
   Vitest, coverage, and React DOM types while keeping Bun runtime and Bun types aligned at 1.3.14.
 

--- a/.github/release-notes/v4.5.0.md
+++ b/.github/release-notes/v4.5.0.md
@@ -23,8 +23,9 @@ threadnote graph checkpoint import \
   --expected-digest sha256:<digest>
 ```
 
-- Export produces deterministic, credential-free artifacts from an exact ready graph at a clean commit. Checkpoints
-  exclude raw source, local paths, credentials, and worktree identities.
+- Export produces deterministic artifacts from an exact ready graph at a clean commit. Checkpoints omit raw
+  source-file bytes, absolute local paths, configured remote credential material, and worktree identities, but they do
+  contain source-derived names, signatures, and documentation. Treat them as potentially sensitive architecture data.
 - `inspect` authenticates the artifact and its bounded framing without inflating graph records; `verify` additionally
   checks compressed records, ordering, counts, coverage, and logical integrity.
 - Import never fetches source or executes repository code. The source commit must already exist in the same local

--- a/docs/code-graph-checkpoints.md
+++ b/docs/code-graph-checkpoints.md
@@ -13,8 +13,10 @@ threadnote graph checkpoint export --output ./threadnote-graph.cgcp
 ```
 
 Export accepts only the exact ready, clean root snapshot for the current `HEAD`. The repository must have a
-credential-free remote identity such as `github.com/org/repository`; local paths, remote credentials, dirty source,
-worktree identifiers, and source file contents are not embedded. Existing output files are never overwritten.
+credential-free remote identity such as `github.com/org/repository`; absolute local paths, configured remote credential
+material, dirty source state, worktree identifiers, and raw source-file bytes are not embedded. Checkpoints do contain
+source-derived names, signatures, and documentation, so a secret embedded in source can be carried into the artifact.
+Existing output files are never overwritten.
 
 The v1 artifact uses canonical JSON metadata, independently compressed deterministic chunks, and SHA-256 identities
 for the artifact, every chunk, the logical record stream, and its runtime ABI. Export reads SQLite through one
@@ -87,6 +89,7 @@ A Workset remains optional and is used only for explicitly prepared multi-reposi
 
 - Treat the expected artifact digest like a release checksum and obtain it independently from the checkpoint file.
 - Keep the source commit locally available; import deliberately disables lazy Git fetching.
-- Checkpoints contain derived source structure and identifiers. Review their destination as you would any internal
-  architecture artifact, even though local paths, credentials, and raw source bytes are excluded.
+- Checkpoints contain derived source structure, names, signatures, and documentation. Review their destination as you
+  would any potentially sensitive internal architecture artifact. Absolute local paths, configured remote credential
+  material, and raw source-file bytes are omitted, but source-embedded secrets can still appear in derived fields.
 - Use `--json` on every checkpoint command for a versioned machine-readable receipt.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -963,6 +963,7 @@ The body remains ordinary **Markdown**.
       readFile(join(root, 'website', 'src', 'pages', 'LandingPage.tsx'), 'utf8'),
       readFile(join(root, 'website', 'src', 'pages', 'FaqPage.tsx'), 'utf8'),
     ]);
+    const docs = JSON.stringify(docsSections);
     const tips = JSON.stringify(proTips);
 
     expect(landingSource).toContain('Export the exact ready, clean graph for the current commit');
@@ -977,6 +978,9 @@ The body remains ordinary **Markdown**.
     expect(tips).toContain(
       'threadnote graph checkpoint import --input threadnote-graph.cgcp --expected-digest sha256:<digest>',
     );
+    expect(tips).toContain('derived names, signatures, and documentation');
+    expect(docs).toContain('source-derived names, signatures, and documentation');
+    expect(docs).toContain('A secret embedded in source can appear');
     expect(tips).toContain('Existing schema-v1 and uncited legacy memories remain recallable');
     expect(faqSource).toContain('Can I move a graph to another machine without a Workset or cloud?');
     expect(faqSource).toContain('Portable graph checkpoints are free, manual, offline files');

--- a/website/src/content/docsGraphCheckpoints.ts
+++ b/website/src/content/docsGraphCheckpoints.ts
@@ -29,7 +29,7 @@ threadnote graph checkpoint import \\
     },
     {
       type: 'paragraph',
-      text: 'Checkpoints are a free, manual, offline transport. Export accepts only the exact ready clean root for the current commit and a credential-free repository identity. It reads one SQLite transaction in bounded pages, checks committed file identities against Git, excludes local paths, credentials, and raw source bytes, and never overwrites an existing destination. Canonical metadata, deterministic gzip chunks, and SHA-256 identities make the same compatible logical graph reproducible.',
+      text: 'Checkpoints are a free, manual, offline transport. Export accepts only the exact ready clean root for the current commit and a credential-free repository identity. It reads one SQLite transaction in bounded pages, checks committed file identities against Git, omits absolute local paths, configured remote credential material, and raw source-file bytes, and never overwrites an existing destination. Checkpoints still contain source-derived names, signatures, and documentation. Canonical metadata, deterministic gzip chunks, and SHA-256 identities make the same compatible logical graph reproducible.',
     },
     {
       type: 'paragraph',
@@ -55,7 +55,7 @@ threadnote graph checkpoint import \\
     },
     {
       type: 'warning',
-      text: 'A digest computed from the same untrusted file proves integrity, not provenance. Obtain the expected SHA-256 digest independently, and treat derived graph structure and repository-relative identifiers as internal architecture data when sharing an artifact.',
+      text: 'A digest computed from the same untrusted file proves integrity, not provenance. Obtain the expected SHA-256 digest independently, and treat derived graph structure, names, signatures, and documentation as potentially sensitive internal architecture data. A secret embedded in source can appear in those derived fields even though raw source-file bytes and configured remote credential material are omitted.',
     },
   ],
 };

--- a/website/src/content/proTips.ts
+++ b/website/src/content/proTips.ts
@@ -517,9 +517,10 @@ export const proTips: ProTip[] = [
     title: 'Carry a verified graph across machines.',
     summary:
       'Move one deterministic clean graph between local installations when the receiver is offline or a rebuild would waste time.',
-    why: 'The checkpoint carries disposable derived graph data—not source or memory—and an independently obtained digest authenticates the exact artifact bytes.',
+    why: 'The checkpoint carries disposable derived graph data—not raw source-file bytes or memory—and an independently obtained digest authenticates the exact artifact bytes.',
     practice: [
       'Export only after the current commit has an exact ready, clean root graph and a credential-free repository identity.',
+      'Treat the artifact as potentially sensitive architecture data: derived names, signatures, and documentation can carry strings embedded in source.',
       'Transfer the checkpoint file and its expected SHA-256 digest through independent trusted paths.',
       'On the receiver, inspect with the expected digest, run the full verify, then import from a checkout of the same repository where the source commit already exists.',
       'No account, hosted service, or Workset is required. Existing schema-v1 and uncited legacy memories remain recallable.',


### PR DESCRIPTION
## Summary
- bump the standalone package version to 4.5.0
- publish the finalized 4.5 release notes for portable graph checkpoints, citation recovery, legacy recall continuity, optional Worksets, telemetry renewal, Manager/Workset hardening, and performance guardrails
- clarify that checkpoint artifacts omit raw source-file bytes and configured credential material but can contain sensitive source-derived names, signatures, and documentation
- add website content assertions for that checkpoint sensitivity contract

## Local evidence
- frozen install: no changes
- release smoke: 15/15
- website contract suite: 78/78
- website production build: pass
- standalone build: threadnote v4.5.0
- lint, file-length, Prettier, source/test/site typechecks: pass
- dev-cycle: 2 iterations, 0 final critical/important findings; one important security-doc finding fixed and one minor test-organization nit polished

Full suite is delegated to PR CI per repository policy.