### PR TITLE
fix: normalize code memory preparer source root

### DIFF
--- a/scripts/prepare-code-memory-link-agent-ab.ts
+++ b/scripts/prepare-code-memory-link-agent-ab.ts
@@ -264,7 +264,7 @@ const program = Effect.gen(function* () {
 export async function prepareCodeMemoryLinkAgentAb(options: Options, candidate: CandidateRuntime): Promise<void> {
   assertCandidate(options, candidate);
   validateSafeExecutablePath(options.safeExecutablePath);
-  const sourceRoot = await canonicalDirectory(fileURLToPath(new URL('../', import.meta.url)), 'source root');
+  const sourceRoot = await canonicalDirectory(codeMemoryLinkAgentPreparationSourceRoot(), 'source root');
   await assertCleanSourceCheckout(
     sourceRoot,
     options.candidateCommit,
@@ -390,6 +390,10 @@ export async function prepareCodeMemoryLinkAgentAb(options: Options, candidate: 
     await rm(workRoot, {force: true, maxRetries: 3, recursive: true});
     if (!promoted) await rm(stagingRoot, {force: true, maxRetries: 3, recursive: true});
   }
+}
+
+export function codeMemoryLinkAgentPreparationSourceRoot(moduleUrl = import.meta.url): string {
+  return resolve(fileURLToPath(new URL('../', moduleUrl)));
 }
 
 export function assembleCodeMemoryLinkSealedSuiteV1(input: {

--- a/test/unit/code-memory-link-agent-preparer.property.test.ts
+++ b/test/unit/code-memory-link-agent-preparer.property.test.ts
@@ -1,5 +1,6 @@
 import {createHash} from '../helpers/node-crypto.js';
 import fc from 'fast-check';
+import {fileURLToPath} from 'node:url';
 import {describe, expect, it} from 'vitest';
 import {
   CODE_MEMORY_LINK_AGENT_AB_SCHEDULE_ALGORITHM_VERSION,
@@ -23,11 +24,20 @@ import {
 import {
   assembleCalibrationPlanV1,
   assembleCodeMemoryLinkSealedSuiteV1,
+  codeMemoryLinkAgentPreparationSourceRoot,
   type CodeMemoryLinkPreparedTaskV1,
 } from '../../scripts/prepare-code-memory-link-agent-ab.js';
 import {parseCodeMemoryLinkCodexSuiteLayoutV1} from '../../scripts/code-memory-link-codex-suite.js';
 
 describe('Code Memory Link sealed preparation', () => {
+  it('normalizes the module-derived source root before canonical validation', () => {
+    const sourceRoot = codeMemoryLinkAgentPreparationSourceRoot();
+    const moduleDerivedRoot = fileURLToPath(new URL('../../', import.meta.url));
+
+    expect(sourceRoot).toBe(moduleDerivedRoot.replace(/[\\/]+$/u, ''));
+    expect(sourceRoot).not.toMatch(/[\\/]$/u);
+  });
+
   it('assembles one fully bound 28-task suite with task-private fixture mappings', () => {
     const prepared = releaseTasks();
     const first = assemble(prepared);


### PR DESCRIPTION
## Summary
- normalize the preparer's module-derived repository root before strict canonical-path validation
- add a regression test for the trailing-separator file-URL case

## Release-blocking dogfood evidence
On the exact clean 4.6 candidate `a309f3a5db2b4da87ca1f13e28f67dede0c02a6f`, the preregistered agent A/B preparation failed before emitting a manifest:

```
source root must be a normalized absolute path
```

`new URL('../', import.meta.url)` necessarily produced a directory path ending in a separator, while `canonicalDirectory` correctly rejected non-normalized input. Resolving that module-derived path first preserves strict validation of caller-provided paths and makes the built-in root canonical.

## Verification
- focused preparer/unit suite: 34/34 passed
- `bun run typecheck`
- targeted strict lint and formatting
- fresh `$dev-cycle`: four independent review lanes, zero critical/important/minor/informational findings

Property-testing assessment: this is static module-URL wiring with no useful varying input model; the existing bounded preparer property tests remain in place, and the concrete regression covers the production failure exactly.
