### PR TITLE
fix: validate code memory lifecycle paths

### DIFF
--- a/scripts/prepare-code-memory-link-agent-ab.ts
+++ b/scripts/prepare-code-memory-link-agent-ab.ts
@@ -75,6 +75,7 @@ import {
   codeMemoryLinkAgentSuitePredicateId,
   codeMemoryLinkAgentSuiteRemoteUrl,
   createCodeMemoryLinkAgentSuiteCorpusV1,
+  type CodeMemoryLinkAgentSuiteMemorySeedV1,
   type CodeMemoryLinkAgentSuiteTaskDefinitionV1,
 } from '../src/evaluation/code-memory-link-agent-suite.js';
 import {
@@ -223,7 +224,7 @@ interface PreparedBinaryFile {
   readonly mode: number;
 }
 
-interface PreparedGraphIdentity {
+export interface PreparedGraphIdentity {
   readonly commit: string;
   readonly graphContentId: string;
   readonly origin: string;
@@ -394,6 +395,31 @@ export async function prepareCodeMemoryLinkAgentAb(options: Options, candidate: 
 
 export function codeMemoryLinkAgentPreparationSourceRoot(moduleUrl = import.meta.url): string {
   return resolve(fileURLToPath(new URL('../', moduleUrl)));
+}
+
+export function codeMemoryLinkAgentPreparedMemoryDirectory(
+  status: CodeMemoryLinkAgentSuiteMemorySeedV1['status'],
+): string {
+  let lifecycle: 'archived' | 'projects' | 'superseded';
+  switch (status) {
+    case 'active':
+      lifecycle = 'projects';
+      break;
+    case 'archived':
+      lifecycle = 'archived';
+      break;
+    case 'superseded':
+      lifecycle = 'superseded';
+      break;
+  }
+  return `data/${CODE_MEMORY_LINK_AGENT_SUITE_ACCOUNT}/user/${CODE_MEMORY_LINK_AGENT_SUITE_USER}/memories/durable/${lifecycle}/${CODE_MEMORY_LINK_AGENT_SUITE_PROJECT}`;
+}
+
+export function codeMemoryLinkAgentPreparedMemoryDestinationMatches(
+  destination: string,
+  status: CodeMemoryLinkAgentSuiteMemorySeedV1['status'],
+): boolean {
+  return posix.dirname(destination) === codeMemoryLinkAgentPreparedMemoryDirectory(status);
 }
 
 export function assembleCodeMemoryLinkSealedSuiteV1(input: {
@@ -827,7 +853,7 @@ async function prepareTask(
   if (memories.length !== definition.memorySeeds.length) {
     throw new Error(`Task ${definition.taskId} did not produce exactly one canonical memory per seed.`);
   }
-  validatePreparedMemories(memories, definition, localGraph, foreignGraph);
+  validateCodeMemoryLinkPreparedMemories(memories, definition, localGraph, foreignGraph);
   const sealedMemories =
     definition.controlScenario === 'malformed-citation'
       ? memories.map(file => ({...file, content: injectMalformedLegacyCitation(file.content)}))
@@ -1456,15 +1482,15 @@ function memoryCitationIds(content: string): readonly string[] {
   return ids;
 }
 
-function validatePreparedMemories(
+export function validateCodeMemoryLinkPreparedMemories(
   memories: readonly {readonly content: string; readonly destination: string}[],
   definition: CodeMemoryLinkAgentSuiteTaskDefinitionV1,
   localGraph: PreparedGraphIdentity,
   foreignGraph: PreparedGraphIdentity | null,
 ): void {
-  const expectedPrefix = `data/${CODE_MEMORY_LINK_AGENT_SUITE_ACCOUNT}/user/${CODE_MEMORY_LINK_AGENT_SUITE_USER}/memories/durable/projects/${CODE_MEMORY_LINK_AGENT_SUITE_PROJECT}/`;
+  const identityRoot = `data/${CODE_MEMORY_LINK_AGENT_SUITE_ACCOUNT}/user/${CODE_MEMORY_LINK_AGENT_SUITE_USER}/memories/durable/`;
   const records = memories.map((memory, index) => {
-    if (!memory.destination.startsWith(expectedPrefix)) {
+    if (!memory.destination.startsWith(identityRoot)) {
       throw new Error(`Task ${definition.taskId} memory ${index} is outside the canonical managed identity path.`);
     }
     let record: MemoryRecord | undefined;
@@ -1477,6 +1503,11 @@ function validatePreparedMemories(
       throw new Error(`Task ${definition.taskId} memory ${index} is not a canonical managed memory.`, {cause});
     }
     if (!record) throw new Error(`Task ${definition.taskId} memory ${index} is not parseable.`);
+    const seed = definition.memorySeeds.find(candidate => candidate.topic === record.metadata.topic);
+    if (!seed) throw new Error(`Task ${definition.taskId} produced an unexpected memory topic.`);
+    if (!codeMemoryLinkAgentPreparedMemoryDestinationMatches(memory.destination, seed.status)) {
+      throw new Error(`Task ${definition.taskId} memory ${index} is outside its canonical lifecycle path.`);
+    }
     return record;
   });
   unique(

--- a/test/unit/code-memory-link-agent-matrix.property.test.ts
+++ b/test/unit/code-memory-link-agent-matrix.property.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../../src/evaluation/code-memory-link-client-descriptor.js';
 import {
   assembleCalibrationPlanV1,
+  codeMemoryLinkAgentPreparedMemoryDirectory,
   type CodeMemoryLinkPreparedClientV1,
   type CodeMemoryLinkPreparedTaskV1,
 } from '../../scripts/prepare-code-memory-link-agent-ab.js';
@@ -208,9 +209,9 @@ function preparedTask(
   return {
     citationDigests,
     definition,
-    homeFiles: definition.memorySeeds.map((_, index) => ({
+    homeFiles: definition.memorySeeds.map((seed, index) => ({
       content: `task=${definition.taskId}_${index}\n`,
-      destination: `data/local/user/code-memory-link/memories/durable/projects/code-memory-link-gate/${definition.taskId}-${index}.md`,
+      destination: `${codeMemoryLinkAgentPreparedMemoryDirectory(seed.status)}/${definition.taskId}-${index}.md`,
     })),
     preflightExpectedCitationDigests: citationDigests,
     preflightExpectedResponses: expectedResponses(),

--- a/test/unit/code-memory-link-agent-preparer.property.test.ts
+++ b/test/unit/code-memory-link-agent-preparer.property.test.ts
@@ -13,6 +13,7 @@ import {
   codeMemoryLinkAgentSuiteGuardValueV1,
   codeMemoryLinkAgentSuiteOutputArtifactId,
   createCodeMemoryLinkAgentSuiteCorpusV1,
+  type CodeMemoryLinkAgentSuiteTaskDefinitionV1,
 } from '../../src/evaluation/code-memory-link-agent-suite.js';
 import {
   CODE_MEMORY_LINK_CANONICAL_EMPTY_CONTEXT_BRIEF_V1,
@@ -21,10 +22,16 @@ import {
   evaluateCodeMemoryLinkStaticArtifactsV1,
   type CodeMemoryLinkStaticArtifactInputV1,
 } from '../../src/evaluation/code-memory-link-agent-protocol.js';
+import {MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
+import {formatMemoryDocument} from '../../src/memory/document.js';
 import {
   assembleCalibrationPlanV1,
   assembleCodeMemoryLinkSealedSuiteV1,
+  codeMemoryLinkAgentPreparedMemoryDestinationMatches,
+  codeMemoryLinkAgentPreparedMemoryDirectory,
   codeMemoryLinkAgentPreparationSourceRoot,
+  validateCodeMemoryLinkPreparedMemories,
+  type PreparedGraphIdentity,
   type CodeMemoryLinkPreparedTaskV1,
 } from '../../scripts/prepare-code-memory-link-agent-ab.js';
 import {parseCodeMemoryLinkCodexSuiteLayoutV1} from '../../scripts/code-memory-link-codex-suite.js';
@@ -36,6 +43,119 @@ describe('Code Memory Link sealed preparation', () => {
 
     expect(sourceRoot).toBe(moduleDerivedRoot.replace(/[\\/]+$/u, ''));
     expect(sourceRoot).not.toMatch(/[\\/]$/u);
+  });
+
+  it('maps prepared memories to their exact canonical lifecycle directories', () => {
+    const statuses = ['active', 'archived', 'superseded'] as const;
+    const expectedLifecycle = {
+      active: 'projects',
+      archived: 'archived',
+      superseded: 'superseded',
+    } as const;
+
+    for (const expectedStatus of statuses) {
+      expect(codeMemoryLinkAgentPreparedMemoryDirectory(expectedStatus)).toBe(
+        `data/local/user/code-memory-link/memories/durable/${expectedLifecycle[expectedStatus]}/code-memory-link-gate`,
+      );
+      for (const actualStatus of statuses) {
+        const destination = `${codeMemoryLinkAgentPreparedMemoryDirectory(actualStatus)}/fixture.md`;
+        expect(codeMemoryLinkAgentPreparedMemoryDestinationMatches(destination, expectedStatus)).toBe(
+          actualStatus === expectedStatus,
+        );
+      }
+    }
+
+    fc.assert(
+      fc.property(fc.constantFrom(...statuses), fc.stringMatching(/^[a-z][a-z0-9-]{0,31}$/u), (status, filename) => {
+        const directory = codeMemoryLinkAgentPreparedMemoryDirectory(status);
+
+        expect(codeMemoryLinkAgentPreparedMemoryDestinationMatches(`${directory}/${filename}.md`, status)).toBe(true);
+        expect(codeMemoryLinkAgentPreparedMemoryDestinationMatches(`${directory}/nested/${filename}.md`, status)).toBe(
+          false,
+        );
+      }),
+      {numRuns: 30},
+    );
+
+    const activeDirectory = codeMemoryLinkAgentPreparedMemoryDirectory('active');
+    for (const invalid of [
+      `${activeDirectory}-evil/fixture.md`,
+      `${activeDirectory}/nested/fixture.md`,
+      `${activeDirectory}/../fixture.md`,
+      `${activeDirectory.replace('data/local/', 'data/foreign/')}/fixture.md`,
+      `${activeDirectory.replace('/user/code-memory-link/', '/user/other/')}/fixture.md`,
+      `${activeDirectory.replace('/durable/projects/', '/durable/expired/')}/fixture.md`,
+    ]) {
+      expect(codeMemoryLinkAgentPreparedMemoryDestinationMatches(invalid, 'active')).toBe(false);
+    }
+  });
+
+  it('validates lifecycle destinations by parsed topic rather than file order', () => {
+    const base = createCodeMemoryLinkAgentSuiteCorpusV1().releaseTasks[0]!;
+    const memorySeeds = (['active', 'archived', 'superseded'] as const).map((status, index) => ({
+      citationPath: null,
+      foreignRepository: false,
+      malformedCitationProbe: false,
+      role: 'primary' as const,
+      status,
+      text: `lifecycle-${status}-body`,
+      topic: `lifecycle-${status}-${index}`,
+    }));
+    const definition: CodeMemoryLinkAgentSuiteTaskDefinitionV1 = {...base, memorySeeds};
+    const contentFor = (seed: (typeof memorySeeds)[number], status = seed.status) =>
+      formatMemoryDocument(
+        'MEMORY',
+        {
+          kind: 'durable',
+          project: 'code-memory-link-gate',
+          schemaVersion: MEMORY_SCHEMA_VERSION,
+          sourceAgentClient: 'code-memory-link-gate',
+          status,
+          timestamp: '2000-01-01T00:00:00.000Z',
+          topic: seed.topic,
+        },
+        seed.text,
+      );
+    const files = [memorySeeds[2]!, memorySeeds[0]!, memorySeeds[1]!].map(seed => ({
+      content: contentFor(seed),
+      destination: `${codeMemoryLinkAgentPreparedMemoryDirectory(seed.status)}/${seed.topic}.md`,
+    }));
+    const graph: PreparedGraphIdentity = {
+      commit: '1'.repeat(40),
+      graphContentId: `cgc_${'2'.repeat(40)}`,
+      origin: 'https://example.invalid/threadnote.git',
+      repositoryId: '3'.repeat(64),
+      snapshotId: `cgsn_${'4'.repeat(40)}`,
+    };
+
+    expect(() => validateCodeMemoryLinkPreparedMemories(files, definition, graph, null)).not.toThrow();
+
+    const activeFile = files.find(file => file.content.includes('topic: lifecycle-active-0'))!;
+    expect(() =>
+      validateCodeMemoryLinkPreparedMemories(
+        files.map(file =>
+          file === activeFile
+            ? {
+                ...file,
+                destination: `${codeMemoryLinkAgentPreparedMemoryDirectory('superseded')}/wrong-lifecycle.md`,
+              }
+            : file,
+        ),
+        definition,
+        graph,
+        null,
+      ),
+    ).toThrow('outside its canonical lifecycle path');
+
+    const archivedFile = files.find(file => file.content.includes('topic: lifecycle-archived-1'))!;
+    expect(() =>
+      validateCodeMemoryLinkPreparedMemories(
+        files.map(file => (file === archivedFile ? {...file, content: contentFor(memorySeeds[1]!, 'active')} : file)),
+        definition,
+        graph,
+        null,
+      ),
+    ).toThrow('differs from its exact contract');
   });
 
   it('assembles one fully bound 28-task suite with task-private fixture mappings', () => {
@@ -175,12 +295,12 @@ function preparedTask(
   return {
     citationDigests,
     definition,
-    homeFiles: definition.memorySeeds.map((_, index) => ({
+    homeFiles: definition.memorySeeds.map((seed, index) => ({
       content:
         definition.controlScenario === 'malformed-citation'
           ? `task=${definition.taskId}_${index}\ncode_citation: {not-canonical-json\n`
           : `task=${definition.taskId}_${index}\n`,
-      destination: `data/local/user/code-memory-link/memories/durable/projects/code-memory-link-gate/${definition.taskId}-${index}.md`,
+      destination: `${codeMemoryLinkAgentPreparedMemoryDirectory(seed.status)}/${definition.taskId}-${index}.md`,
     })),
     preflightExpectedCitationDigests:
       definition.taskKind === 'hidden-constraint' ||

--- a/test/unit/code-memory-link-retained-replay.test.ts
+++ b/test/unit/code-memory-link-retained-replay.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest';
 import {assertRetainedBundleBindings} from '../../scripts/verify-code-memory-link-release.js';
 import {
   assembleCodeMemoryLinkSealedSuiteV1,
+  codeMemoryLinkAgentPreparedMemoryDirectory,
   type CodeMemoryLinkPreparedTaskV1,
 } from '../../scripts/prepare-code-memory-link-agent-ab.js';
 import {
@@ -231,12 +232,12 @@ function preparedTask(
   return {
     citationDigests,
     definition,
-    homeFiles: definition.memorySeeds.map((_, index) => ({
+    homeFiles: definition.memorySeeds.map((seed, index) => ({
       content:
         definition.controlScenario === 'malformed-citation'
           ? `task=${definition.taskId}_${index}\ncode_citation: {not-canonical-json\n`
           : `task=${definition.taskId}_${index}\n`,
-      destination: `data/local/user/code-memory-link/memories/durable/projects/code-memory-link-gate/${definition.taskId}-${index}.md`,
+      destination: `${codeMemoryLinkAgentPreparedMemoryDirectory(seed.status)}/${definition.taskId}-${index}.md`,
     })),
     preflightExpectedCitationDigests:
       definition.taskKind === 'hidden-constraint' ||


### PR DESCRIPTION
## Summary

- validate prepared agent memories against the canonical directory for their active, archived, or superseded lifecycle status
- preserve exact account, user, project, topic, status, schema, source-agent, and citation-provenance binding
- reject lifecycle mismatches, nested destinations, prefix collisions, traversal, and expired managed paths

## Dogfood failure fixed

Exact release preparation at candidate `80e6d822361f9181f6b2154449d92a4911fe339a` failed closed on the first superseded control task because runtime storage correctly wrote under `durable/superseded/...` while the preparer validator hard-coded `durable/projects/...`. No release output was promoted.

## Verification

- 39/39 focused lifecycle/preparer/matrix/replay tests passed
- exhaustive 3x3 lifecycle cross-product plus bounded Fast-check path properties
- validator-level shuffled multi-status regression and mismatch regressions
- `bun run typecheck` passed
- targeted lint, formatting, and diff checks passed
- fresh dev-cycle: 0 critical, 0 important; its one minor test-wiring finding was addressed before commit