### PR TITLE
Fix release preparer citation identity

### DIFF
--- a/scripts/prepare-code-memory-link-agent-ab.ts
+++ b/scripts/prepare-code-memory-link-agent-ab.ts
@@ -22,6 +22,7 @@ import {delimiter, dirname, extname, isAbsolute, join, posix, relative, resolve,
 import {spawn} from 'node:child_process';
 import {fileURLToPath} from 'node:url';
 import {Effect} from 'effect';
+import {codeGraphCommittedFileContentHash} from '../src/code_graph/content_identity.js';
 import {
   CODE_MEMORY_LINK_AGENT_AB_SCHEDULE_ALGORITHM_VERSION,
   codeMemoryLinkAgentAbAssignmentHash,
@@ -226,11 +227,15 @@ interface PreparedBinaryFile {
 
 export interface PreparedGraphIdentity {
   readonly commit: string;
+  readonly extractorSet: string;
   readonly graphContentId: string;
+  readonly objectFormat: 'sha1';
   readonly origin: string;
   readonly repositoryId: string;
   readonly snapshotId: string;
 }
+
+type GitObjectFormat = 'sha1' | 'sha256';
 
 interface FixtureMapping {
   readonly artifactId: string;
@@ -807,7 +812,12 @@ async function prepareTask(
     taskId: definition.taskId,
   });
   const environment = candidateEnvironment(home, options.safeExecutablePath, options.temporaryRoot);
-  const localGraph = await indexGraph(candidate.executable, repository, home, environment, {commit, origin});
+  const localGraph = await indexGraph(candidate.executable, repository, home, environment, {
+    commit,
+    gitExecutable: options.gitExecutable,
+    origin,
+    safeExecutablePath: options.safeExecutablePath,
+  });
   let foreignGraph: PreparedGraphIdentity | null = null;
 
   if (definition.memorySeeds.some(seed => seed.foreignRepository)) {
@@ -824,7 +834,9 @@ async function prepareTask(
     });
     foreignGraph = await indexGraph(candidate.executable, foreign, home, environment, {
       commit: foreignCommit,
+      gitExecutable: options.gitExecutable,
       origin: foreignOrigin,
+      safeExecutablePath: options.safeExecutablePath,
     });
     for (const seed of definition.memorySeeds.filter(seed => seed.foreignRepository)) {
       await rememberSeed(candidate.executable, foreign, home, seed, environment);
@@ -889,7 +901,12 @@ async function prepareTask(
   // written, while the production preflight must exercise the final public checkout.
   // Rebuilding here is what makes stale/changed/deleted controls representative of the
   // runtime adapter, which also indexes its freshly copied final repository.
-  await indexGraph(candidate.executable, repository, home, environment, {commit: finalCommit, origin});
+  await indexGraph(candidate.executable, repository, home, environment, {
+    commit: finalCommit,
+    gitExecutable: options.gitExecutable,
+    origin,
+    safeExecutablePath: options.safeExecutablePath,
+  });
   const anchoredBrief = await runPreparedContextBrief(candidate.executable, definition, repository, home, environment, [
     'policy.json',
   ]);
@@ -1260,7 +1277,7 @@ async function initializeRepository(input: {
       maxOutputBytes: 64 * 1_024,
       timeoutMilliseconds: 30_000,
     });
-  await run(['-c', 'init.defaultBranch=main', 'init', '--quiet']);
+  await run(['-c', 'init.defaultBranch=main', 'init', '--object-format=sha1', '--quiet']);
   await run(['remote', 'add', 'origin', input.remote]);
   await run(['add', '--all']);
   await capture(input.gitExecutable, ['commit', '--quiet', '--no-gpg-sign', '-m', `fixture ${input.taskId}`], {
@@ -1327,7 +1344,12 @@ async function indexGraph(
   repository: string,
   home: string,
   environment: Readonly<Record<string, string>>,
-  expected: {readonly commit: string; readonly origin: string},
+  expected: {
+    readonly commit: string;
+    readonly gitExecutable: string;
+    readonly origin: string;
+    readonly safeExecutablePath: string;
+  },
 ): Promise<PreparedGraphIdentity> {
   await capture(
     candidateExecutable,
@@ -1357,14 +1379,58 @@ async function indexGraph(
   });
   const statusRecord = object(parsed, 'prepared graph status');
   const identity = object(statusRecord.identity, 'prepared graph identity');
+  const readySnapshot = object(statusRecord.readySnapshot, 'prepared ready graph snapshot');
+  const extractorSet = matching(readySnapshot.extractorSet, HASH, 'prepared graph extractor set');
+  const repositoryObjectFormat = await readRepositoryObjectFormat(
+    expected.gitExecutable,
+    repository,
+    expected.safeExecutablePath,
+  );
+  const objectFormat = assertPreparedGraphObjectFormat(identity.objectFormat, repositoryObjectFormat);
   const repositoryId = boundedText(identity.repositoryId, 'prepared graph repository id', 256);
   return {
     commit: expected.commit,
+    extractorSet,
     graphContentId: validated.graphContentId,
+    objectFormat,
     origin: expected.origin,
     repositoryId,
     snapshotId: validated.snapshotId,
   };
+}
+
+export function assertPreparedGraphObjectFormat(
+  reported: unknown,
+  repositoryObjectFormat: GitObjectFormat,
+): PreparedGraphIdentity['objectFormat'] {
+  if (reported !== 'sha1' && reported !== 'sha256') {
+    throw new Error('Prepared fixture graph has an unsupported Git object format.');
+  }
+  if (repositoryObjectFormat !== 'sha1') {
+    throw new Error('Prepared fixture repository must use the SHA-1 object format.');
+  }
+  if (reported !== repositoryObjectFormat) {
+    throw new Error('Prepared fixture graph Git object format differs from the repository.');
+  }
+  return 'sha1';
+}
+
+async function readRepositoryObjectFormat(
+  gitExecutable: string,
+  repository: string,
+  safeExecutablePath: string,
+): Promise<GitObjectFormat> {
+  const result = await capture(gitExecutable, ['rev-parse', '--show-object-format'], {
+    cwd: repository,
+    environment: gitEnvironment(safeExecutablePath, dirname(repository)),
+    maxOutputBytes: 64 * 1_024,
+    timeoutMilliseconds: 30_000,
+  });
+  const objectFormat = result.stdout.trim();
+  if (objectFormat !== 'sha1' && objectFormat !== 'sha256') {
+    throw new Error('Prepared fixture repository has an unsupported Git object format.');
+  }
+  return objectFormat;
 }
 
 async function rememberSeed(
@@ -1553,8 +1619,10 @@ export function validateCodeMemoryLinkPreparedMemories(
       citation.sourceDirty !== false ||
       citation.sourceSnapshotId !== graph.snapshotId ||
       citation.sourceGraphContentId !== graph.graphContentId ||
+      citation.extractorSet !== graph.extractorSet ||
       citation.fileContentHash.algorithm !== 'sha256' ||
-      citation.fileContentHash.value !== sha256(source.content) ||
+      citation.fileContentHash.value !==
+        codeGraphCommittedFileContentHash(graph.objectFormat, new TextEncoder().encode(source.content)) ||
       citation.target.kind !== 'file' ||
       metadata.sourceCommit !== graph.commit
     ) {

--- a/test/unit/code-memory-link-agent-preparer.property.test.ts
+++ b/test/unit/code-memory-link-agent-preparer.property.test.ts
@@ -22,11 +22,17 @@ import {
   evaluateCodeMemoryLinkStaticArtifactsV1,
   type CodeMemoryLinkStaticArtifactInputV1,
 } from '../../src/evaluation/code-memory-link-agent-protocol.js';
-import {MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
+import {codeGraphCommittedFileContentHash} from '../../src/code_graph/content_identity.js';
+import {
+  createMemoryCodeCitation,
+  MEMORY_CODE_CITATION_VERSION,
+  MEMORY_SCHEMA_VERSION,
+} from '../../src/memory/code_citation.js';
 import {formatMemoryDocument} from '../../src/memory/document.js';
 import {
   assembleCalibrationPlanV1,
   assembleCodeMemoryLinkSealedSuiteV1,
+  assertPreparedGraphObjectFormat,
   codeMemoryLinkAgentPreparedMemoryDestinationMatches,
   codeMemoryLinkAgentPreparedMemoryDirectory,
   codeMemoryLinkAgentPreparationSourceRoot,
@@ -37,6 +43,15 @@ import {
 import {parseCodeMemoryLinkCodexSuiteLayoutV1} from '../../scripts/code-memory-link-codex-suite.js';
 
 describe('Code Memory Link sealed preparation', () => {
+  it('binds candidate graph object format to the repository observed through Git', () => {
+    expect(assertPreparedGraphObjectFormat('sha1', 'sha1')).toBe('sha1');
+    expect(() => assertPreparedGraphObjectFormat('sha256', 'sha1')).toThrow(
+      'Git object format differs from the repository',
+    );
+    expect(() => assertPreparedGraphObjectFormat('sha1', 'sha256')).toThrow('repository must use the SHA-1');
+    expect(() => assertPreparedGraphObjectFormat('md5', 'sha1')).toThrow('unsupported Git object format');
+  });
+
   it('normalizes the module-derived source root before canonical validation', () => {
     const sourceRoot = codeMemoryLinkAgentPreparationSourceRoot();
     const moduleDerivedRoot = fileURLToPath(new URL('../../', import.meta.url));
@@ -122,7 +137,9 @@ describe('Code Memory Link sealed preparation', () => {
     }));
     const graph: PreparedGraphIdentity = {
       commit: '1'.repeat(40),
+      extractorSet: '5'.repeat(64),
       graphContentId: `cgc_${'2'.repeat(40)}`,
+      objectFormat: 'sha1',
       origin: 'https://example.invalid/threadnote.git',
       repositoryId: '3'.repeat(64),
       snapshotId: `cgsn_${'4'.repeat(40)}`,
@@ -156,6 +173,132 @@ describe('Code Memory Link sealed preparation', () => {
         null,
       ),
     ).toThrow('differs from its exact contract');
+  });
+
+  it('validates exact prepared citations with committed Git-object content identities', () => {
+    const base = createCodeMemoryLinkAgentSuiteCorpusV1().releaseTasks.find(
+      task => task.slug === 'control-superseded-mica',
+    )!;
+    const seed = base.memorySeeds[0]!;
+    const fixtureSource = base.initialFiles.find(file => file.path === seed.citationPath)!.content;
+    const prepared = (
+      sourceContent: string,
+      contentHash = codeGraphCommittedFileContentHash('sha1', new TextEncoder().encode(sourceContent)),
+      citationExtractorSet?: string,
+      identityVariant: 'local' | 'foreign' = 'local',
+    ) => {
+      const marker = identityVariant === 'local' ? '1' : '8';
+      const graph: PreparedGraphIdentity = {
+        commit: marker.repeat(40),
+        extractorSet: marker.repeat(64),
+        graphContentId: `cgc_${marker.repeat(40)}`,
+        objectFormat: 'sha1',
+        origin: 'https://example.invalid/threadnote.git',
+        repositoryId: marker.repeat(64),
+        snapshotId: `cgsn_${marker.repeat(40)}`,
+      };
+      const definition: CodeMemoryLinkAgentSuiteTaskDefinitionV1 = {
+        ...base,
+        initialFiles: base.initialFiles.map(file =>
+          file.path === seed.citationPath ? {...file, content: sourceContent} : file,
+        ),
+      };
+      const citation = createMemoryCodeCitation({
+        extractorSet: citationExtractorSet ?? graph.extractorSet,
+        fileContentHash: {algorithm: 'sha256', value: contentHash},
+        path: seed.citationPath!,
+        repositoryId: graph.repositoryId,
+        repositoryIdentityKind: 'remote',
+        sourceCommit: graph.commit,
+        sourceDirty: false,
+        sourceGraphContentId: graph.graphContentId,
+        sourceSnapshotId: graph.snapshotId,
+        target: {kind: 'file'},
+        version: MEMORY_CODE_CITATION_VERSION,
+      });
+      const content = formatMemoryDocument(
+        'MEMORY',
+        {
+          codeCitations: [citation],
+          kind: 'durable',
+          project: 'code-memory-link-gate',
+          schemaVersion: MEMORY_SCHEMA_VERSION,
+          sourceAgentClient: 'code-memory-link-gate',
+          sourceCommit: graph.commit,
+          status: seed.status,
+          timestamp: '2000-01-01T00:00:00.000Z',
+          topic: seed.topic,
+        },
+        seed.text,
+      );
+      return {
+        definition,
+        graph,
+        memory: {
+          content,
+          destination: `${codeMemoryLinkAgentPreparedMemoryDirectory(seed.status)}/${seed.topic}.md`,
+        },
+      };
+    };
+
+    const current = prepared(fixtureSource);
+    expect(() =>
+      validateCodeMemoryLinkPreparedMemories([current.memory], current.definition, current.graph, null),
+    ).not.toThrow();
+
+    const rawByteHash = digest(fixtureSource);
+    const staleContract = prepared(fixtureSource, rawByteHash);
+    expect(() =>
+      validateCodeMemoryLinkPreparedMemories(
+        [staleContract.memory],
+        staleContract.definition,
+        staleContract.graph,
+        null,
+      ),
+    ).toThrow('citation differs from exact graph provenance');
+
+    const wrongExtractor = prepared(fixtureSource, undefined, '7'.repeat(64));
+    expect(() =>
+      validateCodeMemoryLinkPreparedMemories(
+        [wrongExtractor.memory],
+        wrongExtractor.definition,
+        wrongExtractor.graph,
+        null,
+      ),
+    ).toThrow('citation differs from exact graph provenance');
+
+    const local = prepared(fixtureSource);
+    const foreign = prepared(fixtureSource, undefined, undefined, 'foreign');
+    const foreignDefinition: CodeMemoryLinkAgentSuiteTaskDefinitionV1 = {
+      ...foreign.definition,
+      memorySeeds: foreign.definition.memorySeeds.map(candidate => ({...candidate, foreignRepository: true})),
+    };
+    expect(() =>
+      validateCodeMemoryLinkPreparedMemories([foreign.memory], foreignDefinition, local.graph, foreign.graph),
+    ).not.toThrow();
+    expect(() =>
+      validateCodeMemoryLinkPreparedMemories([local.memory], foreignDefinition, local.graph, foreign.graph),
+    ).toThrow('citation differs from exact graph provenance');
+
+    fc.assert(
+      fc.property(fc.string({maxLength: 256}), sourceContent => {
+        const current = prepared(sourceContent);
+        expect(() =>
+          validateCodeMemoryLinkPreparedMemories([current.memory], current.definition, current.graph, null),
+        ).not.toThrow();
+
+        const changed = {
+          ...current.definition,
+          initialFiles: current.definition.initialFiles.map(file =>
+            file.path === seed.citationPath ? {...file, content: `${sourceContent}!`} : file,
+          ),
+        };
+        expect(() => validateCodeMemoryLinkPreparedMemories([current.memory], changed, current.graph, null)).toThrow(
+          'citation differs from exact graph provenance',
+        );
+      }),
+      {numRuns: 30},
+    );
   });
 
   it('assembles one fully bound 28-task suite with task-private fixture mappings', () => {


### PR DESCRIPTION
## Summary

- validate prepared citation content with the same committed Git-object identity used by code-graph capture
- bind candidate-reported object format to the fixture repository format observed through the reviewed Git executable
- require the exact graph extractor set and make the release fixture contract explicitly SHA-1
- preserve canonical active, archived, and superseded lifecycle validation

## Why

Exact-candidate preregistration found that the production citation captured the committed Git-blob identity while the release preparer compared a raw byte SHA-256. The result was a correct memory being rejected on the superseded lifecycle task. No governed output was promoted.

## Verification

- focused preparer regression: 10/10
- related citation and graph tests: 27/27
- typecheck
- lint, Prettier, oxlint, diff check
- exact-HEAD development install and doctor: 0 failures
- dev-cycle: 2 iterations, 0 remaining critical/important findings
- Fast-check: 30 source-content mutation cases prove exact acceptance and changed-content rejection

CI remains authoritative for the full suite.