### PR TITLE
chore: approve Code Memory Link manifest

### DIFF
--- a/src/evaluation/code-memory-link-approvals.json
+++ b/src/evaluation/code-memory-link-approvals.json
@@ -1,6 +1,6 @@
 {
   "agentAbEvidenceHashes": [],
-  "agentAbManifestHashes": [],
+  "agentAbManifestHashes": ["b01aadcdd828e5cb4c8877d75f10f385da047f79c47c289850c6eee441f84f3e"],
   "dogfoodEvidenceHashes": [],
   "retainedEvidenceBundleHashes": [],
   "version": 1


### PR DESCRIPTION
Approves the independently reviewed merged-C preregistration manifest for the governed 4.6 Code Memory Link experiment.\n\nManifest: `b01aadcdd828e5cb4c8877d75f10f385da047f79c47c289850c6eee441f84f3e`\n\nThis PR changes only the manifest-hash allowlist, as required by the C→A→G release contract.