### PR TITLE
fix: preserve candidate runtime in agent matrix

### DIFF
--- a/scripts/development-runtime.ts
+++ b/scripts/development-runtime.ts
@@ -373,7 +373,7 @@ export const resolveManagedDevelopmentExecutableForSource = Effect.fn('developme
     if (JSON.stringify(after) !== JSON.stringify(before)) {
       return yield* Effect.fail(new ScriptError('The managed Threadnote active release changed during resolution.'));
     }
-    return {evidence: after, executable};
+    return {evidence: after, executable, installRoot: realInstallRoot};
   },
 );
 

--- a/scripts/run-code-memory-link-agent-matrix.ts
+++ b/scripts/run-code-memory-link-agent-matrix.ts
@@ -52,6 +52,7 @@ import {
 import {provideScriptLayer, ScriptError} from './effect/errors.js';
 import {scriptArguments} from './effect/script.js';
 import {captureCodeMemoryLinkProcessGroup} from './code-memory-link-process-boundary.js';
+import {resolveManagedDevelopmentExecutableForSource} from './development-runtime.js';
 
 export const CODE_MEMORY_LINK_MATRIX_VERSION = 1 as const;
 export const CODE_MEMORY_LINK_CALIBRATION_RESULT_VERSION = 1 as const;
@@ -64,6 +65,7 @@ const MAXIMUM_TRIAL_LEDGER_BYTES = 16 * 1_024 * 1_024;
 const MAXIMUM_EVIDENCE_LEDGER_BYTES = 128 * 1_024 * 1_024;
 const MAXIMUM_CALIBRATION_LEDGER_BYTES = 4 * 1_024 * 1_024;
 const MAXIMUM_PENDING_BYTES = 32 * 1_024 * 1_024;
+const MAXIMUM_CHILD_FAILURE_DIAGNOSTIC_CHARACTERS = 2_048;
 const CALIBRATION_FORBIDDEN_FIELDS = new Set([
   'approvalCommit',
   'attestation',
@@ -118,14 +120,25 @@ interface ClientRegistryV1 {
 
 const program = Effect.gen(function* () {
   const options = parseArguments(yield* scriptArguments());
+  if (options.mode === 'release') {
+    const candidateRuntime = yield* resolveManagedDevelopmentExecutableForSource(options.candidateCommit);
+    return yield* Effect.tryPromise({
+      try: () => runReleaseMatrix(options, candidateRuntime.installRoot),
+      catch: cause => new ScriptError('Code Memory Link matrix execution stopped.', {cause}),
+    });
+  }
   yield* Effect.tryPromise({
-    try: () => (options.mode === 'release' ? runReleaseMatrix(options) : runCalibrationMatrix(options)),
+    try: () => runCalibrationMatrix(options),
     catch: cause => new ScriptError('Code Memory Link matrix execution stopped.', {cause}),
   });
 });
 
-export async function runReleaseMatrix(options: ReleaseOptions): Promise<void> {
+export async function runReleaseMatrix(options: ReleaseOptions, candidateInstallRootInput: string): Promise<void> {
   const root = await canonicalDirectory(options.root, 'prepared experiment root');
+  const candidateInstallRoot = await canonicalDirectory(
+    candidateInstallRootInput,
+    'verified candidate installation root',
+  );
   const [assignmentInput, manifestInput, registryInput] = await Promise.all([
     readJson(joinRoot(root, 'assignment.json')),
     readJson(joinRoot(root, 'manifest.json')),
@@ -169,7 +182,7 @@ export async function runReleaseMatrix(options: ReleaseOptions): Promise<void> {
   const invoke = (client: CodeMemoryLinkPreparedClientV1) =>
     capture(runnerCommand, releaseInvocationArguments({client, options: invocationOptions, root, runnerScript}), {
       cwd: dirname(runnerScript),
-      environment: minimalEnvironment(),
+      environment: codeMemoryLinkReleaseRunnerEnvironment(candidateInstallRoot),
       maxOutputBytes: 2 * 1_024 * 1_024,
       timeoutMilliseconds: options.timeoutMilliseconds + 5 * 60_000,
     });
@@ -191,7 +204,7 @@ export async function runReleaseMatrix(options: ReleaseOptions): Promise<void> {
       const recovery = await invoke(pendingClient);
       if (recovery.exitCode !== 0) {
         throw new Error(
-          `Pending commit recovery failed without rerunning or skipping the measured trial: ${recovery.stderr.slice(-2_048)}`,
+          `Pending commit recovery failed without rerunning or skipping the measured trial: ${boundedCodeMemoryLinkChildFailureDiagnostic(recovery)}`,
         );
       }
       const afterRecovery = await readReleaseState({
@@ -284,7 +297,7 @@ export async function runReleaseMatrix(options: ReleaseOptions): Promise<void> {
       const retry = afterFailure.requiredRetry;
       throw new Error(
         retry === null
-          ? `Trial runner failed without a canonical retry state: ${result.stderr.slice(-2_048)}`
+          ? `Trial runner failed without a canonical retry state: ${boundedCodeMemoryLinkChildFailureDiagnostic(result)}`
           : `Trial runner failed at run ${scheduled.runOrder}. Matrix stopped without retrying. Required acknowledgement: --retry-of ${retry.attemptId} --retry-reason ${retry.reason}.`,
       );
     }
@@ -1230,6 +1243,40 @@ async function capture(
 
 function minimalEnvironment(): Readonly<Record<string, string>> {
   return {HOME: '/nonexistent', LANG: 'C.UTF-8', LC_ALL: 'C.UTF-8', PATH: '/usr/bin:/bin', TMPDIR: '/tmp'};
+}
+
+export function codeMemoryLinkReleaseRunnerEnvironment(
+  candidateInstallRootInput: string,
+): Readonly<Record<string, string>> {
+  const candidateInstallRoot = normalizedAbsolute(candidateInstallRootInput, 'verified candidate installation root');
+  return {...minimalEnvironment(), THREADNOTE_INSTALL_ROOT: candidateInstallRoot};
+}
+
+export function boundedCodeMemoryLinkChildFailureDiagnostic(input: {
+  readonly stderr: string;
+  readonly stdout: string;
+}): string {
+  const streams = [
+    ...(input.stderr ? [{label: 'stderr', value: input.stderr}] : []),
+    ...(input.stdout ? [{label: 'stdout', value: input.stdout}] : []),
+  ];
+  if (streams.length === 0) return '(child produced no stdout or stderr)';
+  const headers = streams.map(stream => `${stream.label}:\n`);
+  const payloadBudget = MAXIMUM_CHILD_FAILURE_DIAGNOSTIC_CHARACTERS - headers.join('\n').length;
+  const fairShare = Math.floor(payloadBudget / streams.length);
+  const budgets = streams.map(stream => Math.min(stream.value.length, fairShare));
+  let remaining = payloadBudget - budgets.reduce((total, budget) => total + budget, 0);
+  for (let index = streams.length - 1; index >= 0 && remaining > 0; index -= 1) {
+    const available = streams[index]!.value.length - budgets[index]!;
+    const granted = Math.min(available, remaining);
+    budgets[index]! += granted;
+    remaining -= granted;
+  }
+  return streams
+    .map((stream, index) => {
+      return `${headers[index]}${stream.value.slice(-budgets[index]!)}`;
+    })
+    .join('\n');
 }
 
 function delay(milliseconds: number): Promise<void> {

--- a/test/unit/code-memory-link-agent-matrix.property.test.ts
+++ b/test/unit/code-memory-link-agent-matrix.property.test.ts
@@ -23,7 +23,9 @@ import {
 } from '../../scripts/prepare-code-memory-link-agent-ab.js';
 import {
   assertCodeMemoryLinkCalibrationPrefixV1,
+  boundedCodeMemoryLinkChildFailureDiagnostic,
   calibrationResultDigest,
+  codeMemoryLinkReleaseRunnerEnvironment,
   codeMemoryLinkReleaseLedgerPathsV1,
   createCalibrationResult,
   materializeCodeMemoryLinkCalibrationSandboxV1,
@@ -118,6 +120,64 @@ describe('Code Memory Link sequential matrix', () => {
     expect(evidenceIndex).toBeGreaterThan(0);
     expect(arguments_[evidenceIndex + 1]).toBe(evidence);
     expect(arguments_.filter(argument => argument === '--evidence')).toHaveLength(1);
+  });
+
+  it('projects arbitrary verified install roots into the exact trusted runner environment', () => {
+    fc.assert(
+      fc.property(fc.array(fc.stringMatching(/^[a-z][a-z0-9-]{0,12}$/u), {minLength: 1, maxLength: 5}), segments => {
+        const installRoot = `/private/${segments.join('/')}`;
+
+        expect(codeMemoryLinkReleaseRunnerEnvironment(installRoot)).toEqual({
+          HOME: '/nonexistent',
+          LANG: 'C.UTF-8',
+          LC_ALL: 'C.UTF-8',
+          PATH: '/usr/bin:/bin',
+          THREADNOTE_INSTALL_ROOT: installRoot,
+          TMPDIR: '/tmp',
+        });
+      }),
+      {numRuns: 60},
+    );
+    expect(() => codeMemoryLinkReleaseRunnerEnvironment('relative/threadnote')).toThrow(
+      'must be a normalized absolute path',
+    );
+  });
+
+  it('retains bounded stdout-only Effect failures and both child streams', () => {
+    const stdoutOnly = boundedCodeMemoryLinkChildFailureDiagnostic({
+      stderr: '',
+      stdout: 'The managed Threadnote active release pointer is missing or invalid.',
+    });
+    expect(stdoutOnly).toContain('stdout:');
+    expect(stdoutOnly).toContain('active release pointer is missing or invalid');
+    expect(boundedCodeMemoryLinkChildFailureDiagnostic({stderr: '', stdout: ''})).toBe(
+      '(child produced no stdout or stderr)',
+    );
+
+    fc.assert(
+      fc.property(fc.string({maxLength: 5_000}), fc.string({maxLength: 5_000}), (stderr, stdout) => {
+        const diagnostic = boundedCodeMemoryLinkChildFailureDiagnostic({stderr, stdout});
+        expect(diagnostic.length).toBeLessThanOrEqual(2_048);
+        if (stderr) expect(diagnostic).toContain('stderr:');
+        if (stdout) expect(diagnostic).toContain('stdout:');
+      }),
+      {numRuns: 60},
+    );
+
+    fc.assert(
+      fc.property(fc.string({maxLength: 5_000}), fc.string({maxLength: 5_000}), (stderr, stdout) => {
+        const stderrTail = 'stderr-tail-marker';
+        const stdoutTail = 'stdout-tail-marker';
+        const diagnostic = boundedCodeMemoryLinkChildFailureDiagnostic({
+          stderr: `${stderr}${stderrTail}`,
+          stdout: `${stdout}${stdoutTail}`,
+        });
+        expect(diagnostic).toContain(stderrTail);
+        expect(diagnostic).toContain(stdoutTail);
+        expect(diagnostic.length).toBeLessThanOrEqual(2_048);
+      }),
+      {numRuns: 60},
+    );
   });
 
   it('resolves the matrix trial runner through the same canonical file check used by release execution', async () => {


### PR DESCRIPTION
## Summary

- carry the verified managed install root into the trusted outer trial runner while retaining the minimal environment
- keep the measured client environment unchanged
- surface bounded stdout and stderr for pre-attempt failures
- centralize managed install-root ownership in the runtime resolver

## Evidence

- dev-cycle: 0 critical, 0 important; all 3 minors polished
- focused tests: 43 passed across matrix, runner entrypoints, and development runtime
- full source/test/site typechecks passed
- strict focused lint, file-length check, formatting, and diff check passed
- isolated HOME=/nonexistent preflight resolved exact candidate 2ebf0a78 and executable SHA-256 319162cd

This repairs a pre-attempt harness failure. No governed attempt, nonce, ledger, or provider call was created by the failed invocation. Because release-control source changes, final Code Memory Link evidence will be regenerated from the signed squash merge candidate.