### PR TITLE
test: harden Context Brief citation release gate

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -241,13 +241,16 @@ jobs:
           retention-days: 30
 
   context-brief-citations-scale:
-    name: Context Brief citations 100k memories / 50 / 128 · pinned Linux class
+    name: Context Brief citations 100k memories / 50 / 128 · release macOS class
     if: github.event_name == 'schedule' || inputs.include_context_brief_citations_scale
-    runs-on: ubuntu-24.04
+    runs-on: macos-15
     timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -257,9 +260,10 @@ jobs:
 
       - name: Build and gate warm-ready Context Brief citation scale evidence
         env:
-          THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-ubuntu-24.04-${{ runner.arch }}
+          THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-macos-15-ARM64
         run: >-
           bun run bench:context-brief-citations --
+          --candidate-commit "${{ github.sha }}"
           --memory-candidates 100000
           --samples 25
           --warmups 5

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -65,9 +65,37 @@ creates a GitHub prerelease; do not use an unnumbered `-beta` suffix.
 2. Merge the release source and ensure ordinary CI is green.
 3. Dispatch `Platform benchmarks` on exact clean candidate **C** with
    `include_context_brief_citations_scale=true` and `include_code_memory_link_scale=true`. Before tagging, require its Context Brief citation artifact to report
-   `gate.passed=true`, the exact candidate commit, `dirty=false`, 100,000 indexed memory candidates, 25 samples, five
-   warmups, and the `local-100k`, `workset-50`, and `workset-128` profiles. This gate is mandatory for a release that
-   changes Context Brief, recall, citation, or graph-validation behavior; production-large evidence is not a substitute.
+   v2 `evidenceClass=release-scale`, `gate.passed=true`, the exact candidate commit, `dirty=false`, 100,000 indexed
+   memory candidates, exactly 25 samples, exactly five warmups, and the `local-100k`, `workset-50`, and `workset-128`
+   profiles. A development-smoke artifact is deliberately release-failing regardless of its measurements. This gate is
+   mandatory for a release that changes Context Brief, recall, citation, or graph-validation behavior;
+   production-large evidence is not a substitute.
+   Require the deterministic fixture hash to match repeated construction of the same reviewed inputs. The artifact
+   separately retains the actual 50- and 128-member workset generation digests because their checkout/worktree-bound
+   routing identities are intentionally materialization-specific and must not make the semantic fixture hash unstable.
+   The untimed memory series runs before any production timing invocation so first-use caches cannot disappear into its
+   initial baseline. It resets instrumentation and performs full GC before each acknowledged begin barrier, then runs
+   and retains the production workload before its end barrier. After the last workload, another full GC precedes the
+   required stop-barrier sample. The observer exits before the latency series begins, so timing has no observer or
+   boundary-RSS instrumentation. The exact bundled target recomputes its own wrapper-supplied
+   SHA-256 and launches that same bundle as the observer; the observer and its descendants are excluded from the
+   recursive process tree. Each memory observation must have at least three successful samples, no failed samples, a
+   maximum 100 ms sample gap, a root-only baseline, and valid root/tree baseline, peak, and growth arithmetic. The
+   single-repository profile must sample a workload descendant at least once; each sustained multi-repository Workset
+   profile must do so in at least 80% of its observations. This avoids pretending that the roughly 45 ms macOS `ps`
+   cadence can reliably catch every short-lived local Git child while preserving a strong fan-out coverage gate.
+   Apply the fixed 64 MiB ceiling independently to the maximum sampled transient process-tree growth and retained root
+   growth across memory-pass baselines plus the post-final-GC sample. That final sample must contain only the benchmark
+   root. Boundary-sampled current-process RSS comes from the memory workload and remains
+   diagnostic only. The retained `memoryWorkload` must independently pass the same selection, citation, fan-out, lease,
+   and no-cold-work correctness checks. This is probabilistic sampled process-tree high-water evidence: it recursively
+   accounts for processes present at each sample, but it is not exhaustive accounting of every short-lived child or an
+   unsampled peak.
+   The absolute latency gate runs on the reviewed `macos-15`/ARM64/Apple-M1 class. Its artifact must bind the explicit
+   candidate argument to the observed clean checkout; require observed Git status, GitHub Actions,
+   `RUNNER_ENVIRONMENT=github-hosted`, `RUNNER_OS=macOS`, runner class `github-hosted-macos-15-ARM64`, arm64, an
+   Apple-M1-class CPU, `bun/1.3.14`, and `threadnote-4.6.0`. Do not substitute a pass from the heterogeneous Ubuntu x64
+   pool or normalize two failed absolute observations through a parent-relative comparison.
    Also require `bun run eval:code-memory-link-bench` to pass on that SHA for changes to code-anchored retrieval. Treat
    its 256-noise-memory latency result as the deterministic CI smoke only; do not relabel it as the 100,000-memory
    inverse-selector scale gate.

--- a/scripts/benchmark-context-brief-citations-target.ts
+++ b/scripts/benchmark-context-brief-citations-target.ts
@@ -2,7 +2,7 @@
 
 import * as BunRuntime from '@effect/platform-bun/BunRuntime';
 import * as BunServices from '@effect/platform-bun/BunServices';
-import {Effect, Layer} from 'effect';
+import {Clock, Effect, FileSystem, Layer} from 'effect';
 import {CodeGraphEmbeddingIndex} from '../src/code_graph/embedding.js';
 import {CodeGraphIndexer} from '../src/code_graph/indexer.js';
 import {
@@ -13,9 +13,11 @@ import {CodeGraphMaintenanceCoordinator} from '../src/code_graph/maintenance_coo
 import {CodeGraphQueryService} from '../src/code_graph/query.js';
 import {CodeGraphStore} from '../src/code_graph/store.js';
 import {CommandExecutor} from '../src/effect/command.js';
+import {sha256FileHex} from '../src/effect/digest.js';
 import {SystemInfo} from '../src/effect/system.js';
 import {
   CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS,
+  parseContextBriefCitationScaleArtifactV2,
   parseContextBriefCitationScaleBudgetV1,
   type ContextBriefCitationScaleProfileId,
 } from '../src/evaluation/context-brief-citation-scale-contract.js';
@@ -23,15 +25,64 @@ import {
   ContextBriefCitationScaleGraphInstrumentation,
   evaluateContextBriefCitationScale,
   makeContextBriefCitationScaleGraphInstrumentation,
+  type ContextBriefCitationScaleRssObserver,
 } from '../src/evaluation/context-brief-citation-scale.js';
+import {
+  contextBriefCitationRssObserverArguments,
+  isContextBriefCitationRssObserverMode,
+  parseContextBriefCitationRssArtifact,
+  parseContextBriefCitationRssReady,
+  runContextBriefCitationRssObserverMode,
+  waitForContextBriefCitationRssAcknowledgement,
+  writeContextBriefCitationRssRequest,
+  type ContextBriefCitationRssAcknowledgementV1,
+  type ContextBriefCitationRssArtifactV1,
+  type ContextBriefCitationRssReadyV1,
+  type ContextBriefCitationRssRequestV1,
+} from './context-brief-citation-rss-observer.js';
 import {provideScriptLayer, ScriptError} from './effect/errors.js';
 import {atomicWrite, printJson, readJsonFile, scriptArguments} from './effect/script.js';
 
 const DEFAULT_BUDGET = 'test/evaluation/baselines/context-brief-citations-v1/scale-budgets.json';
+const RSS_OBSERVER_BARRIER_TIMEOUT_MILLISECONDS = 30_000;
+const RSS_OBSERVER_EXIT_TIMEOUT_MILLISECONDS = 30_000;
+const RSS_OBSERVER_KILL_TIMEOUT_MILLISECONDS = 5_000;
+const RSS_OBSERVER_MAXIMUM_STDERR_BYTES = 64 * 1_024;
+const RSS_OBSERVER_READY_TIMEOUT_MILLISECONDS = 30_000;
+
+type ContextBriefCitationRssBarrierRequest =
+  {readonly observationId: string; readonly operation: 'begin' | 'end'} | {readonly operation: 'stop'};
+
+export interface ContextBriefCitationRssReadyProbe {
+  readonly childExitCode: () => number | null;
+  readonly readReady: Effect.Effect<ContextBriefCitationRssReadyV1 | undefined, Error>;
+  readonly stderr: Promise<string>;
+  readonly timeoutMilliseconds?: number;
+}
+
+export interface ContextBriefCitationRssTerminationControl {
+  readonly exitCode: () => number | null;
+  readonly kill: (signal?: number) => void;
+  readonly waitForExit: () => Promise<number | undefined>;
+}
+
+export interface ContextBriefCitationRssControllerAdapter {
+  readonly barrier: (
+    request: ContextBriefCitationRssBarrierRequest,
+    expected: ContextBriefCitationRssAcknowledgementV1['state'],
+  ) => Effect.Effect<void, Error>;
+  readonly childExitCode: () => number | null;
+  readonly exitWithin: Effect.Effect<number | undefined>;
+  readonly readArtifact: Effect.Effect<ContextBriefCitationRssArtifactV1, Error>;
+  readonly ready: ContextBriefCitationRssReadyV1;
+  readonly stderr: Promise<string>;
+  readonly terminate: Effect.Effect<void, Error>;
+}
 
 export interface ContextBriefCitationScaleBenchmarkOptions {
   readonly budgetPath: string;
   readonly builtArtifactSha256: string;
+  readonly candidateCommit?: string;
   readonly failOnBudget: boolean;
   readonly memoryCandidates: number;
   readonly outputPath?: string;
@@ -47,24 +98,29 @@ const program = Effect.scoped(
     if (
       options.failOnBudget &&
       (options.memoryCandidates !== budget.corpusMemoryCandidates ||
-        options.samples < 25 ||
-        options.warmups < 5 ||
-        JSON.stringify(options.profileIds) !== JSON.stringify(CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS))
+        options.samples !== 25 ||
+        options.warmups !== 5 ||
+        JSON.stringify(options.profileIds) !== JSON.stringify(CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS) ||
+        !/^[0-9a-f]{40}$/u.test(options.candidateCommit ?? ''))
     ) {
       return yield* Effect.fail(
         new ScriptError(
-          '--fail-on-budget requires the reviewed 100k corpus, all three profiles, at least 25 samples, and 5 warmups.',
+          '--fail-on-budget requires an exact candidate commit, the reviewed 100k corpus, all three profiles, exactly 25 samples, and exactly 5 warmups.',
         ),
       );
     }
-    const artifact = yield* evaluateContextBriefCitationScale({
+    const evaluatedArtifact = yield* evaluateContextBriefCitationScale({
       budget,
       builtArtifactSha256: options.builtArtifactSha256,
+      invocationMode: options.failOnBudget ? 'release-scale' : 'development-smoke',
       memoryCandidates: options.memoryCandidates,
       profileIds: options.profileIds,
+      ...(options.candidateCommit === undefined ? {} : {releaseCandidateCommit: options.candidateCommit}),
       samples: options.samples,
+      startRssObserver: startContextBriefCitationRssObserver(options.builtArtifactSha256),
       warmups: options.warmups,
     });
+    const artifact = parseContextBriefCitationScaleArtifactV2(evaluatedArtifact, budget);
     if (options.outputPath !== undefined) {
       yield* atomicWrite(options.outputPath, `${JSON.stringify(artifact, undefined, 2)}\n`);
     }
@@ -80,6 +136,7 @@ export function parseContextBriefCitationScaleBenchmarkArguments(
 ): ContextBriefCitationScaleBenchmarkOptions {
   let budgetPath = DEFAULT_BUDGET;
   let builtArtifactSha256 = '';
+  let candidateCommit: string | undefined;
   let failOnBudget = false;
   let memoryCandidates = 100_000;
   let outputPath: string | undefined;
@@ -90,6 +147,7 @@ export function parseContextBriefCitationScaleBenchmarkArguments(
     const argument = args[index]!;
     if (argument === '--budget') budgetPath = required(args[++index], argument);
     else if (argument === '--built-artifact-sha256') builtArtifactSha256 = required(args[++index], argument);
+    else if (argument === '--candidate-commit') candidateCommit = required(args[++index], argument);
     else if (argument === '--fail-on-budget') failOnBudget = true;
     else if (argument === '--memory-candidates') memoryCandidates = positiveInteger(args[++index], argument);
     else if (argument === '--output') outputPath = required(args[++index], argument);
@@ -101,6 +159,7 @@ export function parseContextBriefCitationScaleBenchmarkArguments(
   return {
     budgetPath,
     builtArtifactSha256,
+    ...(candidateCommit === undefined ? {} : {candidateCommit}),
     failOnBudget,
     memoryCandidates,
     ...(outputPath === undefined ? {} : {outputPath}),
@@ -142,6 +201,290 @@ function required(value: string | undefined, option: string): string {
   if (!value?.trim()) throw new ScriptError(`${option} requires a value.`);
   return value;
 }
+
+export const validateContextBriefCitationRssBundleDigest = Effect.fn(
+  'contextBriefCitationScale.validateRssBundleDigest',
+)(function* (observed: string, expected: string) {
+  if (observed === expected) return;
+  return yield* Effect.fail(
+    new ScriptError(`Context Brief benchmark target digest ${observed}; expected ${expected}.`),
+  );
+});
+
+export const validateContextBriefCitationRssAcknowledgement = Effect.fn(
+  'contextBriefCitationScale.validateRssAcknowledgement',
+)(function* (
+  request: ContextBriefCitationRssRequestV1,
+  expected: ContextBriefCitationRssAcknowledgementV1['state'],
+  acknowledgement: ContextBriefCitationRssAcknowledgementV1,
+) {
+  if (
+    acknowledgement.sequence === request.sequence &&
+    acknowledgement.version === request.version &&
+    acknowledgement.state === expected &&
+    (!('observationId' in request) ||
+      ('observationId' in acknowledgement && acknowledgement.observationId === request.observationId))
+  ) {
+    return;
+  }
+  return yield* Effect.fail(new ScriptError('Context Brief RSS observer returned a mismatched barrier.'));
+});
+
+export const validateContextBriefCitationRssReadyArtifact = Effect.fn(
+  'contextBriefCitationScale.validateRssReadyArtifact',
+)(function* (ready: ContextBriefCitationRssReadyV1, artifact: ContextBriefCitationRssArtifactV1) {
+  if (
+    artifact.intervalMilliseconds === ready.intervalMilliseconds &&
+    artifact.observerExcluded === ready.observerExcluded &&
+    artifact.rootIdentityValidation === ready.rootIdentityValidation &&
+    artifact.rootStartIdentity === ready.rootStartIdentity &&
+    artifact.scope === ready.scope &&
+    artifact.source === ready.source &&
+    artifact.version === ready.version
+  ) {
+    return;
+  }
+  return yield* Effect.fail(new ScriptError('Context Brief RSS observer artifact changed its ready contract.'));
+});
+
+export function makeContextBriefCitationRssObserverController(
+  adapter: ContextBriefCitationRssControllerAdapter,
+): ContextBriefCitationScaleRssObserver {
+  let activeObservationId: string | undefined;
+  let finished = false;
+  const observe: ContextBriefCitationScaleRssObserver['observe'] = (observationId, effect) =>
+    Effect.acquireUseRelease(
+      Effect.gen(function* () {
+        if (finished || activeObservationId !== undefined) {
+          return yield* Effect.fail(new ScriptError('Context Brief RSS observer received overlapping work.'));
+        }
+        yield* adapter.barrier({observationId, operation: 'begin'}, 'begun');
+        activeObservationId = observationId;
+      }),
+      () => effect,
+      () =>
+        Effect.gen(function* () {
+          if (activeObservationId !== observationId) {
+            return yield* Effect.fail(new ScriptError('Context Brief RSS observer lost its active observation.'));
+          }
+          yield* adapter.barrier({observationId, operation: 'end'}, 'ended');
+          activeObservationId = undefined;
+        }),
+    );
+  const finish = Effect.gen(function* () {
+    if (finished || activeObservationId !== undefined) {
+      return yield* Effect.fail(new ScriptError('Context Brief RSS observer cannot finish in its current state.'));
+    }
+    yield* adapter.barrier({operation: 'stop'}, 'stopped');
+    const exitCode = yield* adapter.exitWithin;
+    if (exitCode === undefined) {
+      yield* adapter.terminate;
+      return yield* Effect.fail(new ScriptError('Context Brief RSS observer did not exit after its stop barrier.'));
+    }
+    if (exitCode !== 0) {
+      return yield* Effect.fail(
+        new ScriptError(
+          `Context Brief RSS observer exited with ${exitCode}: ${yield* boundedObserverStderr(adapter.stderr)}`,
+        ),
+      );
+    }
+    const artifact = yield* adapter.readArtifact;
+    yield* validateContextBriefCitationRssReadyArtifact(adapter.ready, artifact);
+    finished = true;
+    return artifact;
+  });
+  const close = Effect.gen(function* () {
+    if (adapter.childExitCode() !== null) return;
+    yield* adapter.terminate;
+  });
+  return {close, finish, observe};
+}
+
+const startContextBriefCitationRssObserver = Effect.fn('contextBriefCitationScale.startRssObserver')(function* (
+  expectedBuiltArtifactSha256: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
+  if (system.platform !== 'darwin' && system.platform !== 'linux') {
+    return yield* Effect.fail(new ScriptError(`Context Brief RSS observation does not support ${system.platform}.`));
+  }
+  const bundlePath = system.processArguments[1];
+  if (bundlePath === undefined || bundlePath.length === 0) {
+    return yield* Effect.fail(new ScriptError('Context Brief RSS observer could not resolve the benchmark target.'));
+  }
+  const observedBuiltArtifactSha256 = yield* sha256FileHex(bundlePath);
+  yield* validateContextBriefCitationRssBundleDigest(observedBuiltArtifactSha256, expectedBuiltArtifactSha256);
+  const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-context-brief-rss-observer-'});
+  const paths = {
+    acknowledgementPath: `${root}/acknowledgement.json`,
+    outputPath: `${root}/artifact.json`,
+    readyPath: `${root}/ready.json`,
+    requestPath: `${root}/request.json`,
+  };
+  const intervalMilliseconds = system.platform === 'darwin' ? 25 : 10;
+  const child = yield* Effect.try({
+    try: () =>
+      Bun.spawn({
+        cmd: [
+          system.executablePath,
+          bundlePath,
+          ...contextBriefCitationRssObserverArguments({
+            ...paths,
+            barrierTimeoutMilliseconds: RSS_OBSERVER_BARRIER_TIMEOUT_MILLISECONDS,
+            intervalMilliseconds,
+            rootProcessId: system.processId,
+          }),
+        ],
+        maxBuffer: RSS_OBSERVER_MAXIMUM_STDERR_BYTES,
+        stderr: 'pipe',
+        stdin: 'ignore',
+        stdout: 'ignore',
+      }),
+    catch: cause => new ScriptError('Could not start the Context Brief RSS observer.', {cause}),
+  });
+  const stderr = contextBriefCitationRssObserverStderr(child);
+  const ready = yield* waitForContextBriefCitationRssReady({
+    childExitCode: () => child.exitCode,
+    readReady: Effect.gen(function* () {
+      if (!(yield* fs.exists(paths.readyPath))) return undefined;
+      const value = yield* readJsonFile(paths.readyPath).pipe(Effect.provideService(FileSystem.FileSystem, fs));
+      return yield* Effect.try({
+        try: () => parseContextBriefCitationRssReady(value),
+        catch: cause => new ScriptError('Context Brief RSS observer ready evidence is invalid.', {cause}),
+      });
+    }),
+    stderr,
+  }).pipe(Effect.tapError(() => terminateContextBriefCitationRssObserver(child)));
+  if (ready.intervalMilliseconds !== intervalMilliseconds) {
+    yield* terminateContextBriefCitationRssObserver(child);
+    return yield* Effect.fail(new ScriptError('Context Brief RSS observer acknowledged the wrong sample interval.'));
+  }
+  let sequence = 0;
+  const barrier = (
+    request: ContextBriefCitationRssBarrierRequest,
+    expected: ContextBriefCitationRssAcknowledgementV1['state'],
+  ) =>
+    Effect.gen(function* () {
+      sequence += 1;
+      const sequenced = {...request, sequence, version: 1 as const} as ContextBriefCitationRssRequestV1;
+      yield* writeContextBriefCitationRssRequest(paths.requestPath, sequenced).pipe(
+        Effect.provideService(FileSystem.FileSystem, fs),
+      );
+      const acknowledgement = yield* waitForContextBriefCitationRssAcknowledgement(
+        paths.acknowledgementPath,
+        sequence,
+        RSS_OBSERVER_BARRIER_TIMEOUT_MILLISECONDS,
+      ).pipe(Effect.provideService(FileSystem.FileSystem, fs));
+      yield* validateContextBriefCitationRssAcknowledgement(sequenced, expected, acknowledgement);
+    });
+  return makeContextBriefCitationRssObserverController({
+    barrier,
+    childExitCode: () => child.exitCode,
+    exitWithin: Effect.promise(() =>
+      contextBriefCitationRssObserverExitWithin(child, RSS_OBSERVER_EXIT_TIMEOUT_MILLISECONDS),
+    ),
+    readArtifact: readJsonFile(paths.outputPath).pipe(
+      Effect.provideService(FileSystem.FileSystem, fs),
+      Effect.flatMap(value =>
+        Effect.try({
+          try: () => parseContextBriefCitationRssArtifact(value),
+          catch: cause => new ScriptError('Context Brief RSS observer artifact is invalid.', {cause}),
+        }),
+      ),
+    ),
+    ready,
+    stderr,
+    terminate: terminateContextBriefCitationRssObserver(child),
+  });
+});
+
+export const waitForContextBriefCitationRssReady = Effect.fn('contextBriefCitationScale.waitForRssReady')(function* (
+  probe: ContextBriefCitationRssReadyProbe,
+) {
+  const timeoutMilliseconds = probe.timeoutMilliseconds ?? RSS_OBSERVER_READY_TIMEOUT_MILLISECONDS;
+  const startedAt = yield* Clock.currentTimeMillis;
+  while (true) {
+    const ready = yield* probe.readReady;
+    if (ready !== undefined && probe.childExitCode() === null) return ready;
+    if (probe.childExitCode() !== null) {
+      return yield* Effect.fail(
+        new ScriptError(
+          `Context Brief RSS observer exited before ready: ${yield* boundedObserverStderr(probe.stderr)}`,
+        ),
+      );
+    }
+    if ((yield* Clock.currentTimeMillis) - startedAt >= timeoutMilliseconds) {
+      return yield* Effect.fail(
+        new ScriptError('Timed out waiting for the Context Brief RSS observer to become ready.'),
+      );
+    }
+    yield* Effect.sleep(10);
+  }
+});
+
+export const terminateContextBriefCitationRssProcess = Effect.fn('contextBriefCitationScale.terminateRssProcess')(
+  function* (control: ContextBriefCitationRssTerminationControl) {
+    if (control.exitCode() !== null) return;
+    yield* Effect.try({
+      try: () => control.kill(),
+      catch: cause => new ScriptError('Could not terminate the Context Brief RSS observer.', {cause}),
+    });
+    const terminated = yield* Effect.promise(control.waitForExit);
+    if (terminated !== undefined || control.exitCode() !== null) return;
+    yield* Effect.try({
+      try: () => control.kill(9),
+      catch: cause => new ScriptError('Could not kill the Context Brief RSS observer.', {cause}),
+    });
+    const killed = yield* Effect.promise(control.waitForExit);
+    if (killed === undefined && control.exitCode() === null) {
+      return yield* Effect.fail(new ScriptError('Context Brief RSS observer could not be confirmed stopped.'));
+    }
+  },
+);
+
+const terminateContextBriefCitationRssObserver = Effect.fn('contextBriefCitationScale.terminateRssObserver')(function* (
+  child: ReturnType<typeof Bun.spawn>,
+) {
+  return yield* terminateContextBriefCitationRssProcess({
+    exitCode: () => child.exitCode,
+    kill: signal => child.kill(signal),
+    waitForExit: () => contextBriefCitationRssObserverExitWithin(child, RSS_OBSERVER_KILL_TIMEOUT_MILLISECONDS),
+  });
+});
+
+function contextBriefCitationRssObserverExitWithin(
+  child: ReturnType<typeof Bun.spawn>,
+  timeoutMilliseconds: number,
+): Promise<number | undefined> {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  return new Promise(resolve => {
+    const timeout = setTimeout(() => resolve(undefined), timeoutMilliseconds);
+    timeout.unref?.();
+    void child.exited.then(
+      exitCode => {
+        clearTimeout(timeout);
+        resolve(exitCode);
+      },
+      () => {
+        clearTimeout(timeout);
+        resolve(undefined);
+      },
+    );
+  });
+}
+
+function contextBriefCitationRssObserverStderr(child: ReturnType<typeof Bun.spawn>): Promise<string> {
+  const stream = child.stderr;
+  if (!(stream instanceof ReadableStream)) return Promise.resolve('');
+  return new Response(stream).text().catch(() => '');
+}
+
+const boundedObserverStderr = Effect.fn('contextBriefCitationScale.boundedRssObserverStderr')(function* (
+  stderr: Promise<string>,
+) {
+  const text = yield* Effect.promise(() => stderr);
+  return text.trim().slice(0, 4_096) || 'no diagnostic';
+});
 
 const systemLayer = SystemInfo.layer;
 const commandLayer = CommandExecutor.layer.pipe(Layer.provide(systemLayer));
@@ -195,4 +538,11 @@ const queryDependencies = Layer.mergeAll(
 );
 const targetLayer = CodeGraphQueryService.layer.pipe(Layer.provideMerge(queryDependencies));
 
-if (import.meta.main) BunRuntime.runMain(provideScriptLayer(program, targetLayer));
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  BunRuntime.runMain(
+    isContextBriefCitationRssObserverMode(args)
+      ? provideScriptLayer(runContextBriefCitationRssObserverMode(args), platformLayer)
+      : provideScriptLayer(program, targetLayer),
+  );
+}

--- a/scripts/code-graph-benchmark-sampler.ts
+++ b/scripts/code-graph-benchmark-sampler.ts
@@ -372,7 +372,15 @@ const samplerMain = Effect.gen(function* () {
   const processSampleIntervalMilliseconds = system.platform === 'darwin' ? 250 : options.intervalMilliseconds;
   const openFileSampleIntervalMilliseconds =
     system.platform === 'darwin' ? DARWIN_OPEN_FILE_SAMPLE_INTERVAL_MILLISECONDS : options.intervalMilliseconds;
-  const initialProcessSample = yield* readProcessTreeSample(options.processId, clockTicksPerSecond);
+  const initialUnfilteredProcessSample = yield* readProcessTreeSample(options.processId, clockTicksPerSecond);
+  const samplerProcessTreeExclusions = benchmarkSamplerProcessTreeExclusions(
+    initialUnfilteredProcessSample,
+    system.processId,
+  );
+  const initialProcessSample =
+    samplerProcessTreeExclusions.length === 0
+      ? initialUnfilteredProcessSample
+      : yield* readProcessTreeSample(options.processId, clockTicksPerSecond, samplerProcessTreeExclusions);
   const processTelemetry = samplerProcessTelemetryContract(
     system.platform,
     initialProcessSample?.rootStartIdentity,
@@ -420,7 +428,7 @@ const samplerMain = Effect.gen(function* () {
           processSampleDue
             ? pendingInitialProcessSample !== undefined
               ? Effect.succeed(pendingInitialProcessSample)
-              : readProcessTreeSample(options.processId, clockTicksPerSecond)
+              : readProcessTreeSample(options.processId, clockTicksPerSecond, samplerProcessTreeExclusions)
             : Effect.succeed(undefined),
         ],
         {concurrency: 'unbounded'},
@@ -654,6 +662,8 @@ interface BenchmarkProcessCounters {
 export interface BenchmarkProcessTreeSample {
   readonly processIds: readonly number[];
   readonly processes: ReadonlyMap<string, BenchmarkProcessCounters>;
+  /** Current RSS of the observed root alone, excluding every descendant. */
+  readonly rootRssBytes: number;
   readonly rootStartIdentity: string;
   readonly rssBytes: number;
 }
@@ -664,12 +674,32 @@ export interface BenchmarkProcessTreeDelta {
   readonly ioWriteBytes: number;
 }
 
+/** Exclude sampler instrumentation only when it is actually inside the observed process tree. */
+export function benchmarkSamplerProcessTreeExclusions(
+  initialSample: BenchmarkProcessTreeSample | undefined,
+  samplerProcessId: number,
+): readonly number[] {
+  return initialSample?.processIds.includes(samplerProcessId) ? [samplerProcessId] : [];
+}
+
+/**
+ * Aggregate one root while removing complete instrumentation subtrees. Every
+ * excluded PID must be a unique strict descendant in this same snapshot;
+ * otherwise no sample is returned.
+ */
 export function aggregateProcessTree(
   entries: readonly BenchmarkProcessTreeEntry[],
   rootProcessId: number,
   expectedRootStartIdentity?: string,
-  excludedProcessId?: number,
+  excludedDescendantRootProcessIds: readonly number[] = [],
 ): BenchmarkProcessTreeSample | undefined {
+  if (
+    excludedDescendantRootProcessIds.some(processId => !Number.isSafeInteger(processId) || processId <= 0) ||
+    new Set(excludedDescendantRootProcessIds).size !== excludedDescendantRootProcessIds.length ||
+    excludedDescendantRootProcessIds.includes(rootProcessId)
+  ) {
+    return undefined;
+  }
   const byProcessId = new Map<number, BenchmarkProcessTreeEntry>();
   for (const entry of entries) {
     if (
@@ -700,6 +730,16 @@ export function aggregateProcessTree(
     siblings.push(entry.processId);
     children.set(entry.parentProcessId, siblings);
   }
+  const reachableProcessIds = new Set<number>();
+  const reachablePending = [rootProcessId];
+  while (reachablePending.length > 0) {
+    const processId = reachablePending.shift();
+    if (processId === undefined || reachableProcessIds.has(processId)) continue;
+    reachableProcessIds.add(processId);
+    reachablePending.push(...(children.get(processId) ?? []));
+  }
+  if (excludedDescendantRootProcessIds.some(processId => !reachableProcessIds.has(processId))) return undefined;
+  const excludedDescendantRoots = new Set(excludedDescendantRootProcessIds);
   const pending = [rootProcessId];
   const visited = new Set<number>();
   const processes = new Map<string, BenchmarkProcessCounters>();
@@ -707,7 +747,7 @@ export function aggregateProcessTree(
   while (pending.length > 0) {
     const processId = pending.shift();
     if (processId === undefined || visited.has(processId)) continue;
-    if (processId === excludedProcessId) continue;
+    if (excludedDescendantRoots.has(processId)) continue;
     visited.add(processId);
     const entry = byProcessId.get(processId);
     if (!entry) continue;
@@ -719,7 +759,13 @@ export function aggregateProcessTree(
     rssBytes = safeAdd(rssBytes, entry.rssBytes);
     pending.push(...(children.get(processId) ?? []));
   }
-  return {processIds: [...visited], processes, rootStartIdentity: root.startIdentity, rssBytes};
+  return {
+    processIds: [...visited],
+    processes,
+    rootRssBytes: root.rssBytes,
+    rootStartIdentity: root.startIdentity,
+    rssBytes,
+  };
 }
 
 export function processTreeDelta(
@@ -748,22 +794,25 @@ export function processTreeDelta(
   return {cpuMilliseconds, ioReadBytes, ioWriteBytes};
 }
 
-const readProcessTreeSample = Effect.fn('codeGraphBenchmarkSampler.readProcessTreeSample')(function* (
+export const readProcessTreeSample = Effect.fn('codeGraphBenchmarkSampler.readProcessTreeSample')(function* (
   processId: number,
   clockTicksPerSecond: number,
+  excludedDescendantRootProcessIds: readonly number[] = [],
 ) {
   const system = yield* SystemInfo;
   if (system.platform === 'linux') {
-    return yield* readLinuxProcessTreeSample(processId, clockTicksPerSecond, system.processId);
+    return yield* readLinuxProcessTreeSample(processId, clockTicksPerSecond, excludedDescendantRootProcessIds);
   }
-  if (system.platform === 'darwin') return yield* readDarwinProcessTreeSample(processId, system.processId);
+  if (system.platform === 'darwin') {
+    return yield* readDarwinProcessTreeSample(processId, excludedDescendantRootProcessIds);
+  }
   return undefined;
 });
 
 const readLinuxProcessTreeSample = Effect.fn('codeGraphBenchmarkSampler.readLinuxProcessTreeSample')(function* (
   rootProcessId: number,
   clockTicksPerSecond: number,
-  excludedProcessId: number,
+  excludedDescendantRootProcessIds: readonly number[],
 ) {
   const pending: Array<{readonly expectedParent?: number; readonly processId: number}> = [{processId: rootProcessId}];
   const entries: BenchmarkProcessTreeEntry[] = [];
@@ -779,7 +828,7 @@ const readLinuxProcessTreeSample = Effect.fn('codeGraphBenchmarkSampler.readLinu
     entries.push(observed.entry);
     pending.push(...observed.childProcessIds.map(processId => ({expectedParent: observed.entry.processId, processId})));
   }
-  return aggregateProcessTree(entries, rootProcessId, undefined, excludedProcessId);
+  return aggregateProcessTree(entries, rootProcessId, undefined, excludedDescendantRootProcessIds);
 });
 
 const readLinuxProcessEntry = Effect.fn('codeGraphBenchmarkSampler.readLinuxProcessEntry')(function* (
@@ -843,7 +892,7 @@ export function parseLinuxProcessIo(
 
 const readDarwinProcessTreeSample = Effect.fn('codeGraphBenchmarkSampler.readDarwinProcessTreeSample')(function* (
   rootProcessId: number,
-  excludedProcessId: number,
+  excludedDescendantRootProcessIds: readonly number[],
 ) {
   return yield* Effect.try({
     try: () => {
@@ -857,7 +906,7 @@ const readDarwinProcessTreeSample = Effect.fn('codeGraphBenchmarkSampler.readDar
         parseDarwinProcessList(new TextDecoder().decode(result.stdout)),
         rootProcessId,
         undefined,
-        excludedProcessId,
+        excludedDescendantRootProcessIds,
       );
     },
     catch: scriptError,
@@ -1305,7 +1354,7 @@ export function samplerParentExited(
   );
 }
 
-const linuxClockTicksPerSecond = Effect.fn('codeGraphBenchmarkSampler.linuxClockTicksPerSecond')(function* () {
+export const linuxClockTicksPerSecond = Effect.fn('codeGraphBenchmarkSampler.linuxClockTicksPerSecond')(function* () {
   const system = yield* SystemInfo;
   if (system.platform !== 'linux') return 100;
   return yield* Effect.try({

--- a/scripts/context-brief-citation-rss-observer.ts
+++ b/scripts/context-brief-citation-rss-observer.ts
@@ -1,0 +1,944 @@
+import {Clock, Effect, FileSystem, Option} from 'effect';
+import {SystemInfo} from '../src/effect/system.js';
+import {
+  linuxClockTicksPerSecond,
+  readProcessTreeSample,
+  samplerProcessTelemetryContract,
+  type BenchmarkProcessTreeSample,
+} from './code-graph-benchmark-sampler.js';
+import {ScriptError} from './effect/errors.js';
+
+export const CONTEXT_BRIEF_CITATION_RSS_OBSERVER_MODE = '--internal-context-brief-citation-rss-observer';
+
+const ARTIFACT_VERSION = 1 as const;
+const MAXIMUM_OBSERVATIONS = 256;
+const MAXIMUM_PROTOCOL_SEQUENCE = MAXIMUM_OBSERVATIONS * 2 + 1;
+const MAXIMUM_REQUEST_BYTES = 4 * 1_024;
+const MAXIMUM_RUNTIME_MILLISECONDS = 3 * 60 * 60 * 1_000;
+
+export type ContextBriefCitationRssSource = 'darwin-ps' | 'linux-proc';
+export type ContextBriefCitationRssRootIdentityValidation = 'darwin-ps-lstart' | 'linux-proc-starttime';
+
+export type ContextBriefCitationRssRequestV1 =
+  | {
+      readonly observationId: string;
+      readonly operation: 'begin' | 'end';
+      readonly sequence: number;
+      readonly version: typeof ARTIFACT_VERSION;
+    }
+  | {
+      readonly operation: 'stop';
+      readonly sequence: number;
+      readonly version: typeof ARTIFACT_VERSION;
+    };
+
+export type ContextBriefCitationRssAcknowledgementV1 =
+  | {
+      readonly observationId: string;
+      readonly sequence: number;
+      readonly state: 'begun' | 'ended';
+      readonly version: typeof ARTIFACT_VERSION;
+    }
+  | {
+      readonly sequence: number;
+      readonly state: 'stopped';
+      readonly version: typeof ARTIFACT_VERSION;
+    };
+
+export interface ContextBriefCitationRssReadyV1 {
+  readonly intervalMilliseconds: number;
+  readonly observerExcluded: true;
+  readonly rootIdentityValidation: ContextBriefCitationRssRootIdentityValidation;
+  readonly rootStartIdentity: string;
+  readonly scope: 'recursive-process-tree';
+  readonly source: ContextBriefCitationRssSource;
+  readonly state: 'ready';
+  readonly version: typeof ARTIFACT_VERSION;
+}
+
+export interface ContextBriefCitationRssObservationV1 {
+  readonly durationMilliseconds: number;
+  readonly maximumSampleGapMilliseconds: number;
+  readonly observationId: string;
+  readonly processCountBaseline: number;
+  readonly processCountPeakObserved: number;
+  readonly rootRssBaselineBytes: number;
+  readonly rootRssGrowthObservedBytes: number;
+  readonly rootRssPeakObservedBytes: number;
+  readonly sampleAttempts: number;
+  readonly sampleFailures: number;
+  readonly successfulSamples: number;
+  readonly treeRssBaselineBytes: number;
+  readonly treeRssGrowthObservedBytes: number;
+  readonly treeRssPeakObservedBytes: number;
+}
+
+export interface ContextBriefCitationRssFinalSampleV1 {
+  readonly processCount: number;
+  readonly rootRssBytes: number;
+  readonly sampleAttempts: number;
+  readonly sampleFailures: number;
+  readonly treeRssBytes: number;
+}
+
+export interface ContextBriefCitationRssArtifactV1 {
+  readonly finalSample: ContextBriefCitationRssFinalSampleV1;
+  readonly intervalMilliseconds: number;
+  readonly maximumSampleGapMilliseconds: number;
+  readonly observations: readonly ContextBriefCitationRssObservationV1[];
+  readonly observerExcluded: true;
+  readonly processCountPeakObserved: number;
+  readonly rootIdentityValidation: ContextBriefCitationRssRootIdentityValidation;
+  readonly rootStartIdentity: string;
+  readonly sampleAttempts: number;
+  readonly sampleFailures: number;
+  readonly scope: 'recursive-process-tree';
+  readonly source: ContextBriefCitationRssSource;
+  readonly successfulSamples: number;
+  readonly version: typeof ARTIFACT_VERSION;
+}
+
+export interface ContextBriefCitationRssSampleAttempt {
+  readonly attempts: number;
+  readonly failures: number;
+  readonly observedAtMilliseconds: number;
+  readonly sample?: BenchmarkProcessTreeSample;
+}
+
+interface ActiveObservation {
+  readonly lastSuccessfulSampleAtMilliseconds: number;
+  readonly maximumSampleGapMilliseconds: number;
+  readonly observationId: string;
+  readonly processCountBaseline: number;
+  readonly processCountPeakObserved: number;
+  readonly rootRssBaselineBytes: number;
+  readonly rootRssPeakObservedBytes: number;
+  readonly sampleAttempts: number;
+  readonly sampleFailures: number;
+  readonly startedAtMilliseconds: number;
+  readonly successfulSamples: number;
+  readonly treeRssBaselineBytes: number;
+  readonly treeRssPeakObservedBytes: number;
+}
+
+export interface ContextBriefCitationRssObserverState {
+  readonly active?: ActiveObservation;
+  readonly finalSample?: ContextBriefCitationRssFinalSampleV1;
+  readonly intervalMilliseconds: number;
+  readonly lastAcknowledgement?: ContextBriefCitationRssAcknowledgementV1;
+  readonly lastRequest?: ContextBriefCitationRssRequestV1;
+  readonly nextSequence: number;
+  readonly observations: readonly ContextBriefCitationRssObservationV1[];
+  readonly rootIdentityValidation: ContextBriefCitationRssRootIdentityValidation;
+  readonly rootStartIdentity: string;
+  readonly source: ContextBriefCitationRssSource;
+  readonly stopped: boolean;
+}
+
+export interface ContextBriefCitationRssProtocolTransition {
+  readonly acknowledgement: ContextBriefCitationRssAcknowledgementV1;
+  readonly replayed: boolean;
+  readonly state: ContextBriefCitationRssObserverState;
+}
+
+export interface ContextBriefCitationRssObserverProcessOptions {
+  readonly acknowledgementPath: string;
+  readonly barrierTimeoutMilliseconds: number;
+  readonly intervalMilliseconds: number;
+  readonly outputPath: string;
+  readonly readyPath: string;
+  readonly requestPath: string;
+  readonly rootProcessId: number;
+}
+
+/** Return true only for the reserved child mode dispatched by the bundled benchmark target. */
+export function isContextBriefCitationRssObserverMode(args: readonly string[]): boolean {
+  return args[0] === CONTEXT_BRIEF_CITATION_RSS_OBSERVER_MODE;
+}
+
+/** Build arguments for spawning the exact same bundled target as its observer child. */
+export function contextBriefCitationRssObserverArguments(
+  options: ContextBriefCitationRssObserverProcessOptions,
+): readonly string[] {
+  return [
+    CONTEXT_BRIEF_CITATION_RSS_OBSERVER_MODE,
+    '--pid',
+    String(options.rootProcessId),
+    '--request',
+    options.requestPath,
+    '--acknowledgement',
+    options.acknowledgementPath,
+    '--ready',
+    options.readyPath,
+    '--output',
+    options.outputPath,
+    '--interval-ms',
+    String(options.intervalMilliseconds),
+    '--barrier-timeout-ms',
+    String(options.barrierTimeoutMilliseconds),
+  ];
+}
+
+export function parseContextBriefCitationRssRequest(value: unknown): ContextBriefCitationRssRequestV1 {
+  const request = record(value, 'RSS observer request');
+  const operation = request.operation;
+  if (operation !== 'begin' && operation !== 'end' && operation !== 'stop') {
+    invalid('RSS observer request operation is invalid.');
+  }
+  exactKeys(
+    request,
+    operation === 'stop' ? ['operation', 'sequence', 'version'] : ['observationId', 'operation', 'sequence', 'version'],
+    'RSS observer request',
+  );
+  if (request.version !== ARTIFACT_VERSION) invalid('RSS observer request version is invalid.');
+  const sequence = protocolSequence(request.sequence, 'RSS observer request sequence');
+  if (operation === 'stop') return {operation, sequence, version: ARTIFACT_VERSION};
+  const observationId = boundedIdentifier(request.observationId, 'RSS observer observation ID');
+  return {observationId, operation, sequence, version: ARTIFACT_VERSION};
+}
+
+export function parseContextBriefCitationRssAcknowledgement(value: unknown): ContextBriefCitationRssAcknowledgementV1 {
+  const acknowledgement = record(value, 'RSS observer acknowledgement');
+  if (acknowledgement.state !== 'begun' && acknowledgement.state !== 'ended' && acknowledgement.state !== 'stopped') {
+    invalid('RSS observer acknowledgement state is invalid.');
+  }
+  exactKeys(
+    acknowledgement,
+    acknowledgement.state === 'stopped'
+      ? ['sequence', 'state', 'version']
+      : ['observationId', 'sequence', 'state', 'version'],
+    'RSS observer acknowledgement',
+  );
+  if (acknowledgement.version !== ARTIFACT_VERSION) invalid('RSS observer acknowledgement version is invalid.');
+  const sequence = protocolSequence(acknowledgement.sequence, 'RSS observer acknowledgement sequence');
+  if (acknowledgement.state === 'stopped') {
+    return {sequence, state: 'stopped', version: ARTIFACT_VERSION};
+  }
+  return {
+    observationId: boundedIdentifier(acknowledgement.observationId, 'RSS observer observation ID'),
+    sequence,
+    state: acknowledgement.state,
+    version: ARTIFACT_VERSION,
+  };
+}
+
+export function parseContextBriefCitationRssReady(value: unknown): ContextBriefCitationRssReadyV1 {
+  const ready = record(value, 'RSS observer ready evidence');
+  exactKeys(
+    ready,
+    [
+      'intervalMilliseconds',
+      'observerExcluded',
+      'rootIdentityValidation',
+      'rootStartIdentity',
+      'scope',
+      'source',
+      'state',
+      'version',
+    ],
+    'RSS observer ready evidence',
+  );
+  const contract = parseObserverContract(ready);
+  if (ready.state !== 'ready') invalid('RSS observer ready state is invalid.');
+  return {...contract, state: 'ready'};
+}
+
+export function parseContextBriefCitationRssArtifact(value: unknown): ContextBriefCitationRssArtifactV1 {
+  const artifact = record(value, 'RSS observer artifact');
+  exactKeys(
+    artifact,
+    [
+      'intervalMilliseconds',
+      'finalSample',
+      'maximumSampleGapMilliseconds',
+      'observations',
+      'observerExcluded',
+      'processCountPeakObserved',
+      'rootIdentityValidation',
+      'rootStartIdentity',
+      'sampleAttempts',
+      'sampleFailures',
+      'scope',
+      'source',
+      'successfulSamples',
+      'version',
+    ],
+    'RSS observer artifact',
+  );
+  const contract = parseObserverContract(artifact);
+  if (!Array.isArray(artifact.observations) || artifact.observations.length > MAXIMUM_OBSERVATIONS) {
+    invalid('RSS observer artifact observations are invalid.');
+  }
+  const observations = artifact.observations.map(parseObservation);
+  if (new Set(observations.map(observation => observation.observationId)).size !== observations.length) {
+    invalid('RSS observer artifact observation IDs must be unique.');
+  }
+  const finalSample = parseFinalSample(artifact.finalSample);
+  const expected = observationTotals(observations, finalSample);
+  for (const [key, value] of Object.entries(expected)) {
+    if (artifact[key] !== value) invalid(`RSS observer artifact ${key} is inconsistent.`);
+  }
+  return {...contract, ...expected, finalSample, observations};
+}
+
+export function makeContextBriefCitationRssObserverState(
+  ready: Omit<ContextBriefCitationRssReadyV1, 'observerExcluded' | 'scope' | 'state' | 'version'>,
+): ContextBriefCitationRssObserverState {
+  const parsed = parseContextBriefCitationRssReady({
+    ...ready,
+    observerExcluded: true,
+    scope: 'recursive-process-tree',
+    state: 'ready',
+    version: ARTIFACT_VERSION,
+  });
+  return {
+    intervalMilliseconds: parsed.intervalMilliseconds,
+    nextSequence: 1,
+    observations: [],
+    rootIdentityValidation: parsed.rootIdentityValidation,
+    rootStartIdentity: parsed.rootStartIdentity,
+    source: parsed.source,
+    stopped: false,
+  };
+}
+
+/**
+ * Apply one acknowledged protocol barrier. Replaying the exact last request is
+ * idempotent; a conflicting duplicate, gap, stale sequence, or invalid state
+ * transition fails closed.
+ */
+export function applyContextBriefCitationRssRequest(
+  current: ContextBriefCitationRssObserverState,
+  input: ContextBriefCitationRssRequestV1,
+  barrierSample?: ContextBriefCitationRssSampleAttempt,
+): ContextBriefCitationRssProtocolTransition {
+  const request = parseContextBriefCitationRssRequest(input);
+  if (current.lastRequest && request.sequence === current.lastRequest.sequence) {
+    if (stableJson(request) !== stableJson(current.lastRequest) || current.lastAcknowledgement === undefined) {
+      invalid('RSS observer protocol received a conflicting duplicate sequence.');
+    }
+    return {acknowledgement: current.lastAcknowledgement, replayed: true, state: current};
+  }
+  if (current.stopped) invalid('RSS observer protocol is already stopped.');
+  if (request.sequence !== current.nextSequence) invalid('RSS observer protocol sequence is not contiguous.');
+  let state: ContextBriefCitationRssObserverState;
+  let acknowledgement: ContextBriefCitationRssAcknowledgementV1;
+  if (request.operation === 'begin') {
+    if (current.active !== undefined) invalid('RSS observer cannot begin while another observation is active.');
+    if (current.observations.length >= MAXIMUM_OBSERVATIONS) invalid('RSS observer observation bound exceeded.');
+    if (current.observations.some(observation => observation.observationId === request.observationId)) {
+      invalid('RSS observer observation ID was reused.');
+    }
+    const attempted = requiredBarrierSample(current, barrierSample);
+    const sample = attempted.sample!;
+    state = {
+      ...current,
+      active: {
+        lastSuccessfulSampleAtMilliseconds: attempted.observedAtMilliseconds,
+        maximumSampleGapMilliseconds: 0,
+        observationId: request.observationId,
+        processCountBaseline: sample.processIds.length,
+        processCountPeakObserved: sample.processIds.length,
+        rootRssBaselineBytes: sample.rootRssBytes,
+        rootRssPeakObservedBytes: sample.rootRssBytes,
+        sampleAttempts: attempted.attempts,
+        sampleFailures: attempted.failures,
+        startedAtMilliseconds: attempted.observedAtMilliseconds,
+        successfulSamples: 1,
+        treeRssBaselineBytes: sample.rssBytes,
+        treeRssPeakObservedBytes: sample.rssBytes,
+      },
+    };
+    acknowledgement = {
+      observationId: request.observationId,
+      sequence: request.sequence,
+      state: 'begun',
+      version: ARTIFACT_VERSION,
+    };
+  } else if (request.operation === 'end') {
+    if (current.active?.observationId !== request.observationId) {
+      invalid('RSS observer end barrier does not match the active observation.');
+    }
+    const withFinalSample = observeContextBriefCitationRssSample(
+      current,
+      requiredBarrierSample(current, barrierSample),
+    );
+    const active = withFinalSample.active!;
+    const observation = finalizeObservation(active, barrierSample!.observedAtMilliseconds);
+    state = {
+      ...withFinalSample,
+      active: undefined,
+      observations: [...current.observations, observation],
+    };
+    acknowledgement = {
+      observationId: request.observationId,
+      sequence: request.sequence,
+      state: 'ended',
+      version: ARTIFACT_VERSION,
+    };
+  } else {
+    if (current.active !== undefined) invalid('RSS observer cannot stop with an active observation.');
+    const attempted = requiredBarrierSample(current, barrierSample);
+    state = {
+      ...current,
+      finalSample: parseFinalSample({
+        processCount: attempted.sample.processIds.length,
+        rootRssBytes: attempted.sample.rootRssBytes,
+        sampleAttempts: attempted.attempts,
+        sampleFailures: attempted.failures,
+        treeRssBytes: attempted.sample.rssBytes,
+      }),
+      stopped: true,
+    };
+    acknowledgement = {sequence: request.sequence, state: 'stopped', version: ARTIFACT_VERSION};
+  }
+  state = {
+    ...state,
+    lastAcknowledgement: acknowledgement,
+    lastRequest: request,
+    nextSequence: request.sequence + 1,
+  };
+  return {acknowledgement, replayed: false, state};
+}
+
+/** Add one scheduled external sample attempt to the active observation. */
+export function observeContextBriefCitationRssSample(
+  current: ContextBriefCitationRssObserverState,
+  attempt: ContextBriefCitationRssSampleAttempt,
+): ContextBriefCitationRssObserverState {
+  if (current.active === undefined) return current;
+  const parsed = parseSampleAttempt(current, attempt, false);
+  const active = current.active;
+  if (parsed.observedAtMilliseconds < active.lastSuccessfulSampleAtMilliseconds) {
+    invalid('RSS observer sample time moved backwards.');
+  }
+  if (parsed.sample === undefined) {
+    return {
+      ...current,
+      active: {
+        ...active,
+        sampleAttempts: active.sampleAttempts + parsed.attempts,
+        sampleFailures: active.sampleFailures + parsed.failures,
+      },
+    };
+  }
+  const gap = parsed.observedAtMilliseconds - active.lastSuccessfulSampleAtMilliseconds;
+  return {
+    ...current,
+    active: {
+      ...active,
+      lastSuccessfulSampleAtMilliseconds: parsed.observedAtMilliseconds,
+      maximumSampleGapMilliseconds: Math.max(active.maximumSampleGapMilliseconds, gap),
+      processCountPeakObserved: Math.max(active.processCountPeakObserved, parsed.sample.processIds.length),
+      rootRssPeakObservedBytes: Math.max(active.rootRssPeakObservedBytes, parsed.sample.rootRssBytes),
+      sampleAttempts: active.sampleAttempts + parsed.attempts,
+      sampleFailures: active.sampleFailures + parsed.failures,
+      successfulSamples: active.successfulSamples + 1,
+      treeRssPeakObservedBytes: Math.max(active.treeRssPeakObservedBytes, parsed.sample.rssBytes),
+    },
+  };
+}
+
+export function contextBriefCitationRssArtifact(
+  state: ContextBriefCitationRssObserverState,
+): ContextBriefCitationRssArtifactV1 {
+  if (!state.stopped || state.active !== undefined || state.finalSample === undefined) {
+    invalid('RSS observer artifact requires a sampled clean stop barrier.');
+  }
+  return parseContextBriefCitationRssArtifact({
+    finalSample: state.finalSample,
+    intervalMilliseconds: state.intervalMilliseconds,
+    observations: state.observations,
+    observerExcluded: true,
+    rootIdentityValidation: state.rootIdentityValidation,
+    rootStartIdentity: state.rootStartIdentity,
+    scope: 'recursive-process-tree',
+    source: state.source,
+    version: ARTIFACT_VERSION,
+    ...observationTotals(state.observations, state.finalSample),
+  });
+}
+
+/** Write one request atomically so the observer never parses a partial barrier. */
+export const writeContextBriefCitationRssRequest = Effect.fn('contextBriefCitationRss.writeRequest')(function* (
+  requestPath: string,
+  input: ContextBriefCitationRssRequestV1,
+) {
+  const request = parseContextBriefCitationRssRequest(input);
+  yield* atomicWrite(requestPath, `${JSON.stringify(request)}\n`);
+});
+
+/** Wait for the exact sequence acknowledgement; stale acks are ignored and future acks fail closed. */
+export const waitForContextBriefCitationRssAcknowledgement = Effect.fn(
+  'contextBriefCitationRss.waitForAcknowledgement',
+)(function* (acknowledgementPath: string, sequence: number, timeoutMilliseconds: number) {
+  protocolSequence(sequence, 'RSS observer acknowledgement sequence');
+  positiveSafeInteger(timeoutMilliseconds, 'RSS observer acknowledgement timeout');
+  const startedAt = yield* Clock.currentTimeMillis;
+  while (true) {
+    const text = yield* readOptionalText(acknowledgementPath);
+    if (text !== undefined) {
+      if (text.length > MAXIMUM_REQUEST_BYTES) invalid('RSS observer acknowledgement exceeds its byte bound.');
+      const acknowledgement = parseContextBriefCitationRssAcknowledgement(parseJson(text, 'acknowledgement'));
+      if (acknowledgement.sequence === sequence) return acknowledgement;
+      if (acknowledgement.sequence > sequence) invalid('RSS observer acknowledgement skipped the expected sequence.');
+    }
+    if ((yield* Clock.currentTimeMillis) - startedAt >= timeoutMilliseconds) {
+      return yield* Effect.fail(new ScriptError('Timed out waiting for the RSS observer acknowledgement.'));
+    }
+    yield* Effect.sleep(5);
+  }
+});
+
+/** Run the reserved observer child mode from the exact same bundled target. */
+export const runContextBriefCitationRssObserverMode = Effect.fn('contextBriefCitationRss.runObserverMode')(function* (
+  args: readonly string[],
+) {
+  const options = parseObserverArguments(args);
+  const fs = yield* FileSystem.FileSystem;
+  const system = yield* SystemInfo;
+  if (options.rootProcessId === system.processId) {
+    return yield* Effect.fail(new ScriptError('RSS observer cannot observe itself as the benchmark root.'));
+  }
+  if (system.platform !== 'linux' && system.platform !== 'darwin') {
+    return yield* Effect.fail(new ScriptError(`RSS observer does not support ${system.platform}.`));
+  }
+  const clockTicksPerSecond = yield* linuxClockTicksPerSecond();
+  const initial = yield* requiredProcessTreeSample(
+    options.rootProcessId,
+    clockTicksPerSecond,
+    undefined,
+    options.barrierTimeoutMilliseconds,
+    [system.processId],
+  );
+  const telemetry = samplerProcessTelemetryContract(
+    system.platform,
+    initial.sample!.rootStartIdentity,
+    options.intervalMilliseconds,
+  );
+  if (
+    telemetry.availability !== 'available' ||
+    telemetry.scope !== 'recursive-process-tree' ||
+    (telemetry.source !== 'linux-proc' && telemetry.source !== 'darwin-ps')
+  ) {
+    return yield* Effect.fail(new ScriptError('RSS observer process-tree inspection is unavailable.'));
+  }
+  const ready = parseContextBriefCitationRssReady({
+    intervalMilliseconds: options.intervalMilliseconds,
+    observerExcluded: true,
+    rootIdentityValidation: telemetry.parentIdentityValidation,
+    rootStartIdentity: initial.sample!.rootStartIdentity,
+    scope: 'recursive-process-tree',
+    source: telemetry.source,
+    state: 'ready',
+    version: ARTIFACT_VERSION,
+  });
+  let state = makeContextBriefCitationRssObserverState(ready);
+  let lastRequestText: string | undefined;
+  const startedAt = yield* Clock.currentTimeMillis;
+  yield* atomicWrite(options.readyPath, `${JSON.stringify(ready)}\n`);
+  while (!state.stopped) {
+    if ((yield* Clock.currentTimeMillis) - startedAt > MAXIMUM_RUNTIME_MILLISECONDS) {
+      return yield* Effect.fail(new ScriptError('RSS observer exceeded its bounded runtime.'));
+    }
+    if (!system.isProcessRunning(options.rootProcessId)) {
+      return yield* Effect.fail(new ScriptError('RSS observer benchmark root exited before the stop barrier.'));
+    }
+    const requestText = yield* readOptionalText(options.requestPath);
+    let handledBarrier = false;
+    if (requestText !== undefined && requestText !== lastRequestText) {
+      if (requestText.length > MAXIMUM_REQUEST_BYTES) {
+        return yield* Effect.fail(new ScriptError('RSS observer request exceeds its byte bound.'));
+      }
+      const request = parseContextBriefCitationRssRequest(parseJson(requestText, 'request'));
+      const barrierSample = yield* requiredProcessTreeSample(
+        options.rootProcessId,
+        clockTicksPerSecond,
+        state.rootStartIdentity,
+        options.barrierTimeoutMilliseconds,
+        [system.processId],
+      );
+      const transition = applyContextBriefCitationRssRequest(state, request, barrierSample);
+      state = transition.state;
+      lastRequestText = requestText;
+      handledBarrier = request.operation !== 'stop';
+      yield* atomicWrite(options.acknowledgementPath, `${JSON.stringify(transition.acknowledgement)}\n`);
+      if (state.stopped) {
+        const artifact = contextBriefCitationRssArtifact(state);
+        yield* atomicWrite(options.outputPath, `${JSON.stringify(artifact)}\n`);
+        break;
+      }
+    }
+    if (state.active !== undefined && !handledBarrier) {
+      const sample = yield* readProcessTreeSample(options.rootProcessId, clockTicksPerSecond, [system.processId]);
+      const observedAtMilliseconds = yield* Clock.currentTimeMillis;
+      if (sample !== undefined && sample.rootStartIdentity !== state.rootStartIdentity) {
+        return yield* Effect.fail(new ScriptError('RSS observer benchmark root identity changed.'));
+      }
+      state = observeContextBriefCitationRssSample(state, {
+        attempts: 1,
+        failures: sample === undefined ? 1 : 0,
+        observedAtMilliseconds,
+        ...(sample === undefined ? {} : {sample}),
+      });
+    }
+    yield* Effect.sleep(options.intervalMilliseconds);
+  }
+  // Keep the dependency explicit for bundlers and ensure the final path exists.
+  yield* fs.stat(options.outputPath);
+});
+
+function requiredBarrierSample(
+  state: ContextBriefCitationRssObserverState,
+  attempt: ContextBriefCitationRssSampleAttempt | undefined,
+): ContextBriefCitationRssSampleAttempt & {readonly sample: BenchmarkProcessTreeSample} {
+  if (attempt === undefined) invalid('RSS observer barriers require a process-tree sample.');
+  const parsed = parseSampleAttempt(state, attempt, true);
+  return parsed as ContextBriefCitationRssSampleAttempt & {readonly sample: BenchmarkProcessTreeSample};
+}
+
+function parseSampleAttempt(
+  state: ContextBriefCitationRssObserverState,
+  attempt: ContextBriefCitationRssSampleAttempt,
+  requireSample: boolean,
+): ContextBriefCitationRssSampleAttempt {
+  const attempts = positiveSafeInteger(attempt.attempts, 'RSS observer sample attempts');
+  const failures = nonNegativeSafeInteger(attempt.failures, 'RSS observer sample failures');
+  const observedAtMilliseconds = nonNegativeSafeInteger(
+    attempt.observedAtMilliseconds,
+    'RSS observer sample timestamp',
+  );
+  if (failures > attempts || (attempt.sample === undefined ? failures !== attempts : failures !== attempts - 1)) {
+    invalid('RSS observer sample attempt accounting is inconsistent.');
+  }
+  if (requireSample && attempt.sample === undefined)
+    invalid('RSS observer barrier did not obtain a process-tree sample.');
+  if (attempt.sample !== undefined) validateProcessTreeSample(state, attempt.sample);
+  return {attempts, failures, observedAtMilliseconds, ...(attempt.sample ? {sample: attempt.sample} : {})};
+}
+
+function validateProcessTreeSample(
+  state: ContextBriefCitationRssObserverState,
+  sample: BenchmarkProcessTreeSample,
+): void {
+  if (sample.rootStartIdentity !== state.rootStartIdentity) invalid('RSS observer benchmark root identity changed.');
+  if (
+    !Array.isArray(sample.processIds) ||
+    sample.processIds.length < 1 ||
+    new Set(sample.processIds).size !== sample.processIds.length ||
+    sample.processIds.some(processId => !Number.isSafeInteger(processId) || processId <= 0)
+  ) {
+    invalid('RSS observer process-tree membership is invalid.');
+  }
+  const rootRssBytes = nonNegativeSafeInteger(sample.rootRssBytes, 'RSS observer root RSS');
+  const treeRssBytes = nonNegativeSafeInteger(sample.rssBytes, 'RSS observer tree RSS');
+  if (rootRssBytes > treeRssBytes) invalid('RSS observer root RSS exceeds its process-tree RSS.');
+}
+
+function finalizeObservation(
+  active: ActiveObservation,
+  endedAtMilliseconds: number,
+): ContextBriefCitationRssObservationV1 {
+  if (endedAtMilliseconds < active.startedAtMilliseconds) invalid('RSS observer observation time moved backwards.');
+  return parseObservation({
+    durationMilliseconds: endedAtMilliseconds - active.startedAtMilliseconds,
+    maximumSampleGapMilliseconds: active.maximumSampleGapMilliseconds,
+    observationId: active.observationId,
+    processCountBaseline: active.processCountBaseline,
+    processCountPeakObserved: active.processCountPeakObserved,
+    rootRssBaselineBytes: active.rootRssBaselineBytes,
+    rootRssGrowthObservedBytes: Math.max(0, active.rootRssPeakObservedBytes - active.rootRssBaselineBytes),
+    rootRssPeakObservedBytes: active.rootRssPeakObservedBytes,
+    sampleAttempts: active.sampleAttempts,
+    sampleFailures: active.sampleFailures,
+    successfulSamples: active.successfulSamples,
+    treeRssBaselineBytes: active.treeRssBaselineBytes,
+    treeRssGrowthObservedBytes: Math.max(0, active.treeRssPeakObservedBytes - active.treeRssBaselineBytes),
+    treeRssPeakObservedBytes: active.treeRssPeakObservedBytes,
+  });
+}
+
+function parseObservation(value: unknown): ContextBriefCitationRssObservationV1 {
+  const observation = record(value, 'RSS observer observation');
+  const keys = [
+    'durationMilliseconds',
+    'maximumSampleGapMilliseconds',
+    'observationId',
+    'processCountBaseline',
+    'processCountPeakObserved',
+    'rootRssBaselineBytes',
+    'rootRssGrowthObservedBytes',
+    'rootRssPeakObservedBytes',
+    'sampleAttempts',
+    'sampleFailures',
+    'successfulSamples',
+    'treeRssBaselineBytes',
+    'treeRssGrowthObservedBytes',
+    'treeRssPeakObservedBytes',
+  ] as const;
+  exactKeys(observation, keys, 'RSS observer observation');
+  const parsed = Object.fromEntries(
+    keys
+      .filter(key => key !== 'observationId')
+      .map(key => [key, nonNegativeSafeInteger(observation[key], `RSS observer observation ${key}`)]),
+  ) as unknown as Omit<ContextBriefCitationRssObservationV1, 'observationId'>;
+  const result = {
+    ...parsed,
+    observationId: boundedIdentifier(observation.observationId, 'RSS observer observation ID'),
+  };
+  if (result.processCountBaseline < 1 || result.processCountPeakObserved < result.processCountBaseline) {
+    invalid('RSS observer observation process counts are invalid.');
+  }
+  if (
+    result.rootRssBaselineBytes > result.treeRssBaselineBytes ||
+    result.rootRssPeakObservedBytes > result.treeRssPeakObservedBytes ||
+    result.rootRssPeakObservedBytes < result.rootRssBaselineBytes ||
+    result.treeRssPeakObservedBytes < result.treeRssBaselineBytes
+  ) {
+    invalid('RSS observer observation RSS ordering is invalid.');
+  }
+  if (
+    result.rootRssGrowthObservedBytes !== result.rootRssPeakObservedBytes - result.rootRssBaselineBytes ||
+    result.treeRssGrowthObservedBytes !== result.treeRssPeakObservedBytes - result.treeRssBaselineBytes
+  ) {
+    invalid('RSS observer observation growth is inconsistent.');
+  }
+  if (
+    result.successfulSamples < 2 ||
+    result.sampleAttempts !== result.successfulSamples + result.sampleFailures ||
+    result.maximumSampleGapMilliseconds > result.durationMilliseconds
+  ) {
+    invalid('RSS observer observation sample accounting is invalid.');
+  }
+  return result;
+}
+
+function parseFinalSample(value: unknown): ContextBriefCitationRssFinalSampleV1 {
+  const sample = record(value, 'RSS observer final sample');
+  exactKeys(
+    sample,
+    ['processCount', 'rootRssBytes', 'sampleAttempts', 'sampleFailures', 'treeRssBytes'],
+    'RSS observer final sample',
+  );
+  const result = {
+    processCount: positiveSafeInteger(sample.processCount, 'RSS observer final process count'),
+    rootRssBytes: nonNegativeSafeInteger(sample.rootRssBytes, 'RSS observer final root RSS'),
+    sampleAttempts: positiveSafeInteger(sample.sampleAttempts, 'RSS observer final sample attempts'),
+    sampleFailures: nonNegativeSafeInteger(sample.sampleFailures, 'RSS observer final sample failures'),
+    treeRssBytes: nonNegativeSafeInteger(sample.treeRssBytes, 'RSS observer final tree RSS'),
+  };
+  if (result.rootRssBytes > result.treeRssBytes) invalid('RSS observer final root RSS exceeds tree RSS.');
+  if (result.sampleFailures !== result.sampleAttempts - 1) {
+    invalid('RSS observer final sample accounting is inconsistent.');
+  }
+  return result;
+}
+
+function observationTotals(
+  observations: readonly ContextBriefCitationRssObservationV1[],
+  finalSample: ContextBriefCitationRssFinalSampleV1,
+) {
+  return {
+    maximumSampleGapMilliseconds: Math.max(0, ...observations.map(value => value.maximumSampleGapMilliseconds)),
+    processCountPeakObserved: Math.max(
+      finalSample.processCount,
+      ...observations.map(value => value.processCountPeakObserved),
+    ),
+    sampleAttempts: boundedSum([...observations.map(value => value.sampleAttempts), finalSample.sampleAttempts]),
+    sampleFailures: boundedSum([...observations.map(value => value.sampleFailures), finalSample.sampleFailures]),
+    successfulSamples: boundedSum([...observations.map(value => value.successfulSamples), 1]),
+  };
+}
+
+function parseObserverContract(value: Readonly<Record<string, unknown>>) {
+  if (value.version !== ARTIFACT_VERSION) invalid('RSS observer evidence version is invalid.');
+  if (value.scope !== 'recursive-process-tree' || value.observerExcluded !== true) {
+    invalid('RSS observer scope is invalid.');
+  }
+  const intervalMilliseconds = positiveSafeInteger(value.intervalMilliseconds, 'RSS observer interval');
+  if (intervalMilliseconds < 10 || intervalMilliseconds > 1_000) invalid('RSS observer interval is out of bounds.');
+  const source = value.source;
+  const rootIdentityValidation = value.rootIdentityValidation;
+  if (
+    (source !== 'linux-proc' && source !== 'darwin-ps') ||
+    (source === 'linux-proc' && rootIdentityValidation !== 'linux-proc-starttime') ||
+    (source === 'darwin-ps' && rootIdentityValidation !== 'darwin-ps-lstart')
+  ) {
+    invalid('RSS observer source and root identity validation do not match.');
+  }
+  const rootStartIdentity = boundedText(value.rootStartIdentity, 'RSS observer root identity', 128);
+  return {
+    intervalMilliseconds,
+    observerExcluded: true as const,
+    rootIdentityValidation: rootIdentityValidation as ContextBriefCitationRssRootIdentityValidation,
+    rootStartIdentity,
+    scope: 'recursive-process-tree' as const,
+    source: source as ContextBriefCitationRssSource,
+    version: ARTIFACT_VERSION,
+  };
+}
+
+const requiredProcessTreeSample = Effect.fn('contextBriefCitationRss.requiredProcessTreeSample')(function* (
+  rootProcessId: number,
+  clockTicksPerSecond: number,
+  expectedRootStartIdentity: string | undefined,
+  timeoutMilliseconds: number,
+  excludedDescendantRootProcessIds: readonly number[],
+) {
+  const startedAt = yield* Clock.currentTimeMillis;
+  let attempts = 0;
+  let failures = 0;
+  while (true) {
+    attempts += 1;
+    const sample = yield* readProcessTreeSample(rootProcessId, clockTicksPerSecond, excludedDescendantRootProcessIds);
+    const observedAtMilliseconds = yield* Clock.currentTimeMillis;
+    if (sample !== undefined) {
+      if (expectedRootStartIdentity !== undefined && sample.rootStartIdentity !== expectedRootStartIdentity) {
+        return yield* Effect.fail(new ScriptError('RSS observer benchmark root identity changed.'));
+      }
+      return {attempts, failures, observedAtMilliseconds, sample} satisfies ContextBriefCitationRssSampleAttempt;
+    }
+    failures += 1;
+    if (observedAtMilliseconds - startedAt >= timeoutMilliseconds) {
+      return yield* Effect.fail(new ScriptError('RSS observer could not complete a process-tree barrier sample.'));
+    }
+    yield* Effect.sleep(10);
+  }
+});
+
+function parseObserverArguments(args: readonly string[]): ContextBriefCitationRssObserverProcessOptions {
+  if (!isContextBriefCitationRssObserverMode(args)) invalid('RSS observer mode flag is missing.');
+  const values = new Map<string, string>();
+  for (let index = 1; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith('--') || value === undefined || values.has(flag)) {
+      invalid(`RSS observer argument ${flag ?? '<missing>'} is invalid.`);
+    }
+    values.set(flag, value);
+  }
+  const required = (flag: string) => {
+    const value = values.get(flag);
+    if (!value) invalid(`RSS observer argument ${flag} is missing.`);
+    return value;
+  };
+  const allowed = new Set([
+    '--acknowledgement',
+    '--barrier-timeout-ms',
+    '--interval-ms',
+    '--output',
+    '--pid',
+    '--ready',
+    '--request',
+  ]);
+  if (values.size !== allowed.size || [...values.keys()].some(key => !allowed.has(key))) {
+    invalid('RSS observer arguments do not match the bounded protocol.');
+  }
+  const paths = {
+    acknowledgementPath: required('--acknowledgement'),
+    outputPath: required('--output'),
+    readyPath: required('--ready'),
+    requestPath: required('--request'),
+  };
+  if (new Set(Object.values(paths)).size !== Object.keys(paths).length) {
+    invalid('RSS observer protocol paths must be distinct.');
+  }
+  const intervalMilliseconds = positiveSafeInteger(Number(required('--interval-ms')), 'RSS observer interval');
+  const barrierTimeoutMilliseconds = positiveSafeInteger(
+    Number(required('--barrier-timeout-ms')),
+    'RSS observer barrier timeout',
+  );
+  if (intervalMilliseconds < 10 || intervalMilliseconds > 1_000) invalid('RSS observer interval is out of bounds.');
+  if (barrierTimeoutMilliseconds < 100 || barrierTimeoutMilliseconds > 30_000) {
+    invalid('RSS observer barrier timeout is out of bounds.');
+  }
+  return {
+    ...paths,
+    barrierTimeoutMilliseconds,
+    intervalMilliseconds,
+    rootProcessId: positiveSafeInteger(Number(required('--pid')), 'RSS observer root PID'),
+  };
+}
+
+const atomicWrite = Effect.fn('contextBriefCitationRss.atomicWrite')(function* (outputPath: string, contents: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const temporaryPath = `${outputPath}.tmp`;
+  yield* fs.writeFileString(temporaryPath, contents, {mode: 0o600});
+  yield* fs.rename(temporaryPath, outputPath);
+});
+
+const readOptionalText = Effect.fn('contextBriefCitationRss.readOptionalText')(function* (file: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readFileString(file).pipe(Effect.option, Effect.map(Option.getOrUndefined));
+});
+
+function parseJson(text: string, label: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (cause) {
+    throw new ScriptError(`RSS observer ${label} is not valid JSON.`, {cause});
+  }
+}
+
+function record(value: unknown, label: string): Readonly<Record<string, unknown>> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) invalid(`${label} must be an object.`);
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function exactKeys(value: Readonly<Record<string, unknown>>, expected: readonly string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    invalid(`${label} fields are invalid.`);
+  }
+}
+
+function boundedIdentifier(value: unknown, label: string): string {
+  const text = boundedText(value, label, 64);
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/u.test(text)) invalid(`${label} is invalid.`);
+  return text;
+}
+
+function boundedText(value: unknown, label: string, maximumLength: number): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    Array.from(value).some(character => {
+      const codePoint = character.codePointAt(0)!;
+      return codePoint <= 0x1f || codePoint === 0x7f;
+    })
+  ) {
+    invalid(`${label} is invalid.`);
+  }
+  return value;
+}
+
+function positiveSafeInteger(value: unknown, label: string): number {
+  const parsed = nonNegativeSafeInteger(value, label);
+  if (parsed < 1) invalid(`${label} must be positive.`);
+  return parsed;
+}
+
+function protocolSequence(value: unknown, label: string): number {
+  const sequence = positiveSafeInteger(value, label);
+  if (sequence > MAXIMUM_PROTOCOL_SEQUENCE) invalid(`${label} exceeds the protocol bound.`);
+  return sequence;
+}
+
+function nonNegativeSafeInteger(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) invalid(`${label} is invalid.`);
+  return value;
+}
+
+function boundedSum(values: readonly number[]): number {
+  return values.reduce((total, value) => Math.min(Number.MAX_SAFE_INTEGER, total + value), 0);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function invalid(message: string): never {
+  throw new ScriptError(message);
+}

--- a/src/evaluation/context-brief-citation-scale-contract.ts
+++ b/src/evaluation/context-brief-citation-scale-contract.ts
@@ -2,6 +2,23 @@ import {benchmarkMeasurement, type BenchmarkMeasurementV1} from './benchmark.js'
 
 export const CONTEXT_BRIEF_CITATION_SCALE_VERSION = 1 as const;
 export const CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS = ['local-100k', 'workset-50', 'workset-128'] as const;
+export const CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNNER_CLASS = 'github-hosted-macos-15-ARM64' as const;
+export const CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNTIME = 'bun/1.3.14' as const;
+export const CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SOURCE_VERSION = 'threadnote-4.6.0' as const;
+export const CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE = 'context-brief-citations-scale-v2' as const;
+
+export const CONTEXT_BRIEF_CITATION_SCALE_EXECUTION_V2 = {
+  citationReceiptCache: 'cold-per-sample',
+  coldGraphBuilds: 0,
+  graphDatabaseSessionCounter:
+    'instruments calls that reach the production CodeGraphStore.withSession implementation against real prebuilt SQLite files; OS file-descriptor opens are not separately counted',
+  graphSnapshots: 'real-sqlite-prebuilt-ready',
+  memoryMeasurement:
+    'a first-use untimed pass runs before timing, uses begin/end barriers around each production observation and an observer-excluded external recursive process-tree sampler, then records a post-final-GC stop sample; the hard gates use observed tree peak minus its immediate baseline and retained root growth through that final sample, while boundary RSS remains diagnostic',
+  recallIndex: 'real-sqlite-prebuilt-before-timing',
+  timingScope:
+    'observer-free warm real SQLite recall retrieval after first-use memory evidence, plus production Git identity/status observation, graph SQLite session/lease/evidence reads, citation grouping/validation, Context Brief assembly, and projection; every sample uses unseen citation IDs; fixture creation, recall indexing, ready-snapshot activation, catalog publication, and cold graph indexing are excluded',
+} as const;
 
 export type ContextBriefCitationScaleProfileId = (typeof CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS)[number];
 
@@ -18,7 +35,7 @@ export interface ContextBriefCitationScaleProfileV1 {
 export interface ContextBriefCitationScaleBudgetV1 {
   readonly corpusMemoryCandidates: number;
   readonly id: string;
-  readonly maximumAddedRssBytes: number;
+  readonly maximumObservedAddedProcessTreeRssBytes: number;
   readonly maximumCitationsPerBrief: number;
   readonly maximumEstimatedTokens: number;
   readonly profiles: readonly ContextBriefCitationScaleProfileV1[];
@@ -40,8 +57,9 @@ export interface ContextBriefCitationScaleCountersV1 {
   readonly statusObservations: number;
 }
 
-export interface ContextBriefCitationScaleObservationV1 {
-  readonly addedRssBytes: number;
+export interface ContextBriefCitationScaleObservationV2 {
+  /** Boundary-sampled current-process RSS retained as non-gating allocator diagnostics. */
+  readonly boundaryAddedRssBytes: number;
   readonly contextBriefMilliseconds: number;
   readonly counters: ContextBriefCitationScaleCountersV1;
   readonly estimatedTokens: number;
@@ -53,8 +71,36 @@ export interface ContextBriefCitationScaleObservationV1 {
   readonly validationReceipts: number;
 }
 
-export interface ContextBriefCitationScaleProfileResultV1 {
-  readonly coldReadyGraphObservation: ContextBriefCitationScaleObservationV1;
+export interface ContextBriefCitationScaleMemoryObservationV2 {
+  readonly baselineProcessCount: number;
+  readonly maximumSampleGapMilliseconds: number;
+  readonly observedAddedProcessTreeRssBytes: number;
+  readonly observedAddedRootRssBytes: number;
+  readonly observedProcessTreeRssBaselineBytes: number;
+  readonly observedProcessTreeRssPeakBytes: number;
+  readonly observedRootRssBaselineBytes: number;
+  readonly observedRootRssPeakBytes: number;
+  readonly observationId: string;
+  readonly ordinal: number;
+  readonly peakProcessCount: number;
+  readonly profile: ContextBriefCitationScaleProfileId;
+  readonly rootStartIdentity: string;
+  readonly sampleAttempts: number;
+  readonly sampleFailures: number;
+  readonly sampleIntervalMilliseconds: number;
+  readonly samples: number;
+  readonly source: 'darwin-ps' | 'linux-proc';
+}
+
+export interface ContextBriefCitationScaleMeasuredObservationV2 extends ContextBriefCitationScaleObservationV2 {
+  /** Separate observer-excluded memory pass; its latency is never pooled into the timing distribution. */
+  readonly memory: ContextBriefCitationScaleMemoryObservationV2;
+  /** Production-workload result from the separate memory pass, retained for independent correctness verification. */
+  readonly memoryWorkload: ContextBriefCitationScaleObservationV2;
+}
+
+export interface ContextBriefCitationScaleProfileResultV2 {
+  readonly coldReadyGraphObservation: ContextBriefCitationScaleObservationV2;
   readonly counters: {
     readonly maximumActiveViewFenceObservations: number;
     readonly maximumDistinctGraphDatabasePaths: number;
@@ -66,12 +112,19 @@ export interface ContextBriefCitationScaleProfileResultV1 {
     readonly maximumStatusObservations: number;
   };
   readonly measurements: {
-    readonly addedRssBytes: BenchmarkMeasurementV1;
+    readonly boundaryAddedRssBytes: BenchmarkMeasurementV1;
     readonly contextBriefMilliseconds: BenchmarkMeasurementV1;
     readonly memoryRetrievalMilliseconds: BenchmarkMeasurementV1;
     readonly validationMilliseconds: BenchmarkMeasurementV1;
+    readonly observedAddedProcessTreeRssBytes: BenchmarkMeasurementV1;
   };
-  readonly observations: readonly ContextBriefCitationScaleObservationV1[];
+  readonly memoryCoverage: {
+    readonly descendantObservationCount: number;
+    readonly descendantObservationRate: number;
+    readonly maximumPeakProcessCount: number;
+    readonly minimumSuccessfulSamples: number;
+  };
+  readonly observations: readonly ContextBriefCitationScaleMeasuredObservationV2[];
   readonly profile: ContextBriefCitationScaleProfileV1;
   readonly samples: number;
 }
@@ -79,6 +132,83 @@ export interface ContextBriefCitationScaleProfileResultV1 {
 export interface ContextBriefCitationScaleGateV1 {
   readonly failures: readonly string[];
   readonly passed: boolean;
+}
+
+export interface ContextBriefCitationScaleReleaseIdentityV1 {
+  readonly architecture: string;
+  readonly candidateCommit: string;
+  readonly commit: string;
+  readonly cpu: string;
+  readonly dirty: boolean;
+  readonly gitStatusObserved: boolean;
+  readonly githubActions: boolean;
+  readonly operatingSystem: string;
+  readonly runnerClass: string;
+  readonly runnerArchitecture: string;
+  readonly runnerEnvironment: string;
+  readonly runnerOperatingSystem: string;
+  readonly runtime: string;
+  readonly sourceVersion: string;
+}
+
+export type ContextBriefCitationScaleEvidenceClass = 'development-smoke' | 'release-scale';
+
+export interface ContextBriefCitationScaleEnvironmentV2 extends ContextBriefCitationScaleReleaseIdentityV1 {
+  readonly memoryBytes: number;
+}
+
+export type ContextBriefCitationScaleExecutionV2 = typeof CONTEXT_BRIEF_CITATION_SCALE_EXECUTION_V2 & {
+  readonly builtArtifactSha256: string;
+};
+
+export interface ContextBriefCitationScaleFixtureV2 {
+  readonly hash: string;
+  readonly indexedMemoryCandidates: number;
+  readonly legacyV1MemoryCandidates: number;
+  readonly readyGraphSetupMilliseconds: number;
+  readonly recallIndexBuildMilliseconds: number;
+  readonly requestedMemoryCandidates: number;
+  readonly worksetGenerationDigests: readonly [string, string];
+  readonly worksetRepositoryIdentities: readonly [50, 128];
+}
+
+export interface ContextBriefCitationScaleMemoryObserverV2 {
+  readonly finalSample: {
+    readonly processCount: number;
+    readonly rootRssBytes: number;
+    readonly sampleAttempts: number;
+    readonly sampleFailures: number;
+    readonly treeRssBytes: number;
+  };
+  readonly intervalMilliseconds: number;
+  readonly maximumSampleGapMilliseconds: number;
+  readonly observationCount: number;
+  readonly observerExcluded: true;
+  readonly processCountPeakObserved: number;
+  readonly retainedRootRssGrowthBytes: number;
+  readonly rootIdentityValidation: 'darwin-ps-lstart' | 'linux-proc-starttime';
+  readonly rootStartIdentity: string;
+  readonly sampleAttempts: number;
+  readonly sampleFailures: number;
+  readonly scope: 'recursive-process-tree';
+  readonly source: 'darwin-ps' | 'linux-proc';
+  readonly successfulSamples: number;
+  readonly version: 1;
+}
+
+export interface ContextBriefCitationScaleArtifactV2 {
+  readonly createdAt: string;
+  readonly evidenceClass: ContextBriefCitationScaleEvidenceClass;
+  readonly environment: ContextBriefCitationScaleEnvironmentV2;
+  readonly execution: ContextBriefCitationScaleExecutionV2;
+  readonly fixture: ContextBriefCitationScaleFixtureV2;
+  readonly gate: ContextBriefCitationScaleGateV1;
+  readonly memoryObserver: ContextBriefCitationScaleMemoryObserverV2;
+  readonly profiles: readonly ContextBriefCitationScaleProfileResultV2[];
+  readonly samples: number;
+  readonly suite: typeof CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE;
+  readonly version: 2;
+  readonly warmups: number;
 }
 
 const EXACT_PROFILE_SHAPES: Readonly<
@@ -101,7 +231,7 @@ export function parseContextBriefCitationScaleBudgetV1(value: unknown): ContextB
   exactKeys(budget, [
     'corpusMemoryCandidates',
     'id',
-    'maximumAddedRssBytes',
+    'maximumObservedAddedProcessTreeRssBytes',
     'maximumCitationsPerBrief',
     'maximumEstimatedTokens',
     'profiles',
@@ -112,7 +242,9 @@ export function parseContextBriefCitationScaleBudgetV1(value: unknown): ContextB
   if (budget.corpusMemoryCandidates !== 100_000) invalid('corpusMemoryCandidates must be 100000');
   if (budget.maximumCitationsPerBrief !== 96) invalid('maximumCitationsPerBrief must be 96');
   if (budget.maximumEstimatedTokens !== 1_500) invalid('maximumEstimatedTokens must be 1500');
-  if (budget.maximumAddedRssBytes !== 64 * 1_024 * 1_024) invalid('maximumAddedRssBytes must be 64 MiB');
+  if (budget.maximumObservedAddedProcessTreeRssBytes !== 64 * 1_024 * 1_024) {
+    invalid('maximumObservedAddedProcessTreeRssBytes must be 64 MiB');
+  }
   if (!Array.isArray(budget.profiles) || budget.profiles.length !== CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS.length) {
     invalid('profiles must contain the three reviewed profiles');
   }
@@ -123,7 +255,7 @@ export function parseContextBriefCitationScaleBudgetV1(value: unknown): ContextB
   return {
     corpusMemoryCandidates: 100_000,
     id: 'context-brief-citations-scale-v1',
-    maximumAddedRssBytes: 64 * 1_024 * 1_024,
+    maximumObservedAddedProcessTreeRssBytes: 64 * 1_024 * 1_024,
     maximumCitationsPerBrief: 96,
     maximumEstimatedTokens: 1_500,
     profiles: CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS.map(id => profiles.find(profile => profile.id === id)!),
@@ -135,17 +267,22 @@ export function parseContextBriefCitationScaleBudgetV1(value: unknown): ContextB
 export function evaluateContextBriefCitationScaleProfile(
   budget: ContextBriefCitationScaleBudgetV1,
   profileId: ContextBriefCitationScaleProfileId,
-  coldReadyGraphObservation: ContextBriefCitationScaleObservationV1,
-  observations: readonly ContextBriefCitationScaleObservationV1[],
-): {readonly failures: readonly string[]; readonly result: ContextBriefCitationScaleProfileResultV1} {
+  coldReadyGraphObservation: ContextBriefCitationScaleObservationV2,
+  observations: readonly ContextBriefCitationScaleMeasuredObservationV2[],
+): {readonly failures: readonly string[]; readonly result: ContextBriefCitationScaleProfileResultV2} {
   const profile = budget.profiles.find(candidate => candidate.id === profileId);
   if (!profile) throw new Error(`Unknown scale profile ${profileId}`);
   if (observations.length === 0) throw new Error(`Scale profile ${profileId} requires measured samples.`);
   const all = [coldReadyGraphObservation, ...observations];
+  const memoryOrdinals = observations
+    .map(observation => observation.memory.ordinal)
+    .sort((left, right) => left - right);
+  const expectedMemoryOrdinals = observations.map((_, index) => index);
+  const memoryObservationIds = observations.map(observation => observation.memory.observationId);
   const measurements = {
-    addedRssBytes: measurement(
-      'added-rss',
-      observations.map(observation => observation.addedRssBytes),
+    boundaryAddedRssBytes: measurement(
+      'boundary-added-rss-diagnostic',
+      observations.map(observation => observation.memoryWorkload.boundaryAddedRssBytes),
       'bytes',
     ),
     contextBriefMilliseconds: measurement(
@@ -163,6 +300,23 @@ export function evaluateContextBriefCitationScaleProfile(
       observations.map(observation => observation.validationMilliseconds),
       'milliseconds',
     ),
+    observedAddedProcessTreeRssBytes: measurement(
+      'observed-added-process-tree-rss',
+      observations.map(observation => observation.memory.observedAddedProcessTreeRssBytes),
+      'bytes',
+    ),
+  };
+  const descendantObservationCount = observations.filter(
+    observation => observation.memory.peakProcessCount >= 2,
+  ).length;
+  const minimumDescendantObservations = profile.worksetMembers === 1 ? 1 : Math.ceil(observations.length * 0.8);
+  const descendantCoverageRequirement =
+    profile.worksetMembers === 1 ? 'required at least one sampled descendant' : 'required at least 80%';
+  const memoryCoverage = {
+    descendantObservationCount,
+    descendantObservationRate: descendantObservationCount / observations.length,
+    maximumPeakProcessCount: Math.max(...observations.map(observation => observation.memory.peakProcessCount)),
+    minimumSuccessfulSamples: Math.min(...observations.map(observation => observation.memory.samples)),
   };
   const counters = {
     maximumActiveViewFenceObservations: maximum(all, observation => observation.counters.activeViewFenceObservations),
@@ -175,7 +329,24 @@ export function evaluateContextBriefCitationScaleProfile(
     maximumStatusObservations: maximum(all, observation => observation.counters.statusObservations),
   };
   const failures = [
-    ...all.flatMap((observation, index) => observationFailures(profile, budget, observation, index)),
+    ...all.flatMap((observation, index) =>
+      contextBriefCitationScaleObservationFailures(profile, budget, observation, index),
+    ),
+    ...observations.flatMap((observation, index) => memoryObservationFailures(profile, observation, index)),
+    ...observations.flatMap((observation, index) =>
+      contextBriefCitationScaleObservationFailures(profile, budget, observation.memoryWorkload, index).map(
+        failure => `${failure} during the external RSS pass`,
+      ),
+    ),
+    JSON.stringify(memoryOrdinals) === JSON.stringify(expectedMemoryOrdinals)
+      ? ''
+      : `${profile.id} memory ordinals are not the complete measured range`,
+    new Set(memoryObservationIds).size === memoryObservationIds.length
+      ? ''
+      : `${profile.id} memory observation IDs are not unique`,
+    descendantObservationCount >= minimumDescendantObservations
+      ? ''
+      : `${profile.id} observed workload descendants in ${descendantObservationCount}/${observations.length} memory observations; ${descendantCoverageRequirement}`,
     coldReadyGraphObservation.counters.effectiveEvidenceBatches === profile.citedRepositories
       ? ''
       : `${profile.id} cold ready-graph evidence batches ${coldReadyGraphObservation.counters.effectiveEvidenceBatches}; expected ${profile.citedRepositories}`,
@@ -185,19 +356,840 @@ export function evaluateContextBriefCitationScaleProfile(
     measurements.contextBriefMilliseconds.p95 <= profile.maximumBriefP95Milliseconds
       ? ''
       : `${profile.id} brief p95 ${measurements.contextBriefMilliseconds.p95.toFixed(1)}ms exceeds ${profile.maximumBriefP95Milliseconds}ms`,
-    measurements.addedRssBytes.maximum <= budget.maximumAddedRssBytes
+    measurements.observedAddedProcessTreeRssBytes.maximum <= budget.maximumObservedAddedProcessTreeRssBytes
       ? ''
-      : `${profile.id} added RSS ${measurements.addedRssBytes.maximum} exceeds ${budget.maximumAddedRssBytes}`,
+      : `${profile.id} observed added process-tree RSS ${measurements.observedAddedProcessTreeRssBytes.maximum} exceeds ${budget.maximumObservedAddedProcessTreeRssBytes}`,
   ].filter(Boolean);
   return {
     failures,
-    result: {coldReadyGraphObservation, counters, measurements, observations, profile, samples: observations.length},
+    result: {
+      coldReadyGraphObservation,
+      counters,
+      measurements,
+      memoryCoverage,
+      observations,
+      profile,
+      samples: observations.length,
+    },
   };
 }
 
 export function contextBriefCitationScaleGate(failures: readonly string[]): ContextBriefCitationScaleGateV1 {
   const stable = [...new Set(failures)].sort();
   return {failures: stable, passed: stable.length === 0};
+}
+
+/** Parse retained v2 JSON and independently rederive every evidenced profile aggregate and gate decision. */
+export function parseContextBriefCitationScaleArtifactV2(
+  value: unknown,
+  budgetInput: ContextBriefCitationScaleBudgetV1 | unknown,
+): ContextBriefCitationScaleArtifactV2 {
+  const budget = parseContextBriefCitationScaleBudgetV1(budgetInput);
+  const artifact = record(value, 'scale artifact');
+  exactKeys(artifact, [
+    'createdAt',
+    'environment',
+    'evidenceClass',
+    'execution',
+    'fixture',
+    'gate',
+    'memoryObserver',
+    'profiles',
+    'samples',
+    'suite',
+    'version',
+    'warmups',
+  ]);
+  if (artifact.version !== 2) invalid('artifact version must be 2');
+  if (artifact.suite !== CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE) {
+    invalid(`artifact suite must be ${CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE}`);
+  }
+  const createdAt = isoInstant(artifact.createdAt, 'artifact createdAt');
+  const evidenceClass = parseEvidenceClass(artifact.evidenceClass);
+  const environment = parseArtifactEnvironment(artifact.environment);
+  const execution = parseArtifactExecution(artifact.execution);
+  const fixture = parseArtifactFixture(artifact.fixture);
+  const memoryObserver = parseArtifactMemoryObserver(artifact.memoryObserver);
+  const samples = positiveInteger(artifact.samples, 'artifact samples');
+  const warmups = nonNegativeSafeInteger(artifact.warmups, 'artifact warmups');
+  if (!Array.isArray(artifact.profiles) || artifact.profiles.length === 0 || artifact.profiles.length > 3) {
+    invalid('artifact profiles must contain between one and three profiles');
+  }
+  const evaluatedProfiles = artifact.profiles.map((profile, index) =>
+    parseArtifactProfileResult(profile, budget, index),
+  );
+  assertUnique(
+    evaluatedProfiles.map(evaluated => evaluated.result.profile.id),
+    'artifact profile ids',
+  );
+  const profiles = evaluatedProfiles.map(evaluated => evaluated.result);
+  for (const profile of profiles) {
+    if (profile.samples !== samples) invalid(`${profile.profile.id} samples do not match artifact samples`);
+  }
+  validateMemoryObserverSummary(memoryObserver, profiles);
+  const claimedGate = parseArtifactGate(artifact.gate);
+  const failures = rederiveArtifactFailures({
+    budget,
+    environment,
+    evidenceClass,
+    execution,
+    fixture,
+    memoryObserver,
+    profileFailures: evaluatedProfiles.flatMap(evaluated => evaluated.failures),
+    profiles,
+    samples,
+    warmups,
+  });
+  const expectedGate = contextBriefCitationScaleGate(failures);
+  if (!sameJson(claimedGate, expectedGate)) invalid('artifact gate does not match the retained evidence');
+  return {
+    createdAt,
+    environment,
+    evidenceClass,
+    execution,
+    fixture,
+    gate: expectedGate,
+    memoryObserver,
+    profiles,
+    samples,
+    suite: CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE,
+    version: 2,
+    warmups,
+  };
+}
+
+function parseEvidenceClass(value: unknown): ContextBriefCitationScaleEvidenceClass {
+  if (value !== 'development-smoke' && value !== 'release-scale') {
+    invalid('artifact evidenceClass must be development-smoke or release-scale');
+  }
+  return value;
+}
+
+function parseArtifactEnvironment(value: unknown): ContextBriefCitationScaleEnvironmentV2 {
+  const environment = record(value, 'artifact environment');
+  exactKeys(environment, [
+    'architecture',
+    'candidateCommit',
+    'commit',
+    'cpu',
+    'dirty',
+    'gitStatusObserved',
+    'githubActions',
+    'memoryBytes',
+    'operatingSystem',
+    'runnerArchitecture',
+    'runnerClass',
+    'runnerEnvironment',
+    'runnerOperatingSystem',
+    'runtime',
+    'sourceVersion',
+  ]);
+  return {
+    architecture: boundedString(environment.architecture, 'environment architecture'),
+    candidateCommit: boundedString(environment.candidateCommit, 'environment candidate commit'),
+    commit: boundedString(environment.commit, 'environment commit'),
+    cpu: boundedString(environment.cpu, 'environment cpu'),
+    dirty: booleanValue(environment.dirty, 'environment dirty'),
+    gitStatusObserved: booleanValue(environment.gitStatusObserved, 'environment gitStatusObserved'),
+    githubActions: booleanValue(environment.githubActions, 'environment githubActions'),
+    memoryBytes: positiveInteger(environment.memoryBytes, 'environment memory bytes'),
+    operatingSystem: boundedString(environment.operatingSystem, 'environment operating system'),
+    runnerArchitecture: boundedString(environment.runnerArchitecture, 'environment runner architecture'),
+    runnerClass: boundedString(environment.runnerClass, 'environment runner class'),
+    runnerEnvironment: boundedString(environment.runnerEnvironment, 'environment runner environment'),
+    runnerOperatingSystem: boundedString(environment.runnerOperatingSystem, 'environment runner operating system'),
+    runtime: boundedString(environment.runtime, 'environment runtime'),
+    sourceVersion: boundedString(environment.sourceVersion, 'environment source version'),
+  };
+}
+
+function parseArtifactExecution(value: unknown): ContextBriefCitationScaleExecutionV2 {
+  const execution = record(value, 'artifact execution');
+  exactKeys(execution, ['builtArtifactSha256', ...Object.keys(CONTEXT_BRIEF_CITATION_SCALE_EXECUTION_V2)]);
+  for (const [key, expected] of Object.entries(CONTEXT_BRIEF_CITATION_SCALE_EXECUTION_V2)) {
+    if (execution[key] !== expected) invalid(`artifact execution ${key} does not match the reviewed path`);
+  }
+  return {
+    builtArtifactSha256: stringValue(execution.builtArtifactSha256, 'built artifact digest', 256),
+    ...CONTEXT_BRIEF_CITATION_SCALE_EXECUTION_V2,
+  };
+}
+
+function parseArtifactFixture(value: unknown): ContextBriefCitationScaleFixtureV2 {
+  const fixture = record(value, 'artifact fixture');
+  exactKeys(fixture, [
+    'hash',
+    'indexedMemoryCandidates',
+    'legacyV1MemoryCandidates',
+    'readyGraphSetupMilliseconds',
+    'recallIndexBuildMilliseconds',
+    'requestedMemoryCandidates',
+    'worksetGenerationDigests',
+    'worksetRepositoryIdentities',
+  ]);
+  if (!Array.isArray(fixture.worksetGenerationDigests) || fixture.worksetGenerationDigests.length !== 2) {
+    invalid('fixture workset generation digests must contain the 50- and 128-member generations');
+  }
+  if (
+    !Array.isArray(fixture.worksetRepositoryIdentities) ||
+    fixture.worksetRepositoryIdentities.length !== 2 ||
+    fixture.worksetRepositoryIdentities[0] !== 50 ||
+    fixture.worksetRepositoryIdentities[1] !== 128
+  ) {
+    invalid('fixture workset repository identities must be [50,128]');
+  }
+  return {
+    hash: lowercaseHex(fixture.hash, 64, 'fixture hash'),
+    indexedMemoryCandidates: positiveInteger(fixture.indexedMemoryCandidates, 'indexed memory candidates'),
+    legacyV1MemoryCandidates: nonNegativeSafeInteger(fixture.legacyV1MemoryCandidates, 'legacy v1 memory candidates'),
+    readyGraphSetupMilliseconds: nonNegativeFinite(
+      fixture.readyGraphSetupMilliseconds,
+      'ready graph setup milliseconds',
+    ),
+    recallIndexBuildMilliseconds: nonNegativeFinite(
+      fixture.recallIndexBuildMilliseconds,
+      'recall index build milliseconds',
+    ),
+    requestedMemoryCandidates: positiveInteger(fixture.requestedMemoryCandidates, 'requested memory candidates'),
+    worksetGenerationDigests: [
+      lowercaseHex(fixture.worksetGenerationDigests[0], 64, 'workset-50 generation digest'),
+      lowercaseHex(fixture.worksetGenerationDigests[1], 64, 'workset-128 generation digest'),
+    ],
+    worksetRepositoryIdentities: [50, 128],
+  };
+}
+
+function parseArtifactMemoryObserver(value: unknown): ContextBriefCitationScaleMemoryObserverV2 {
+  const observer = record(value, 'artifact memory observer');
+  exactKeys(observer, [
+    'finalSample',
+    'intervalMilliseconds',
+    'maximumSampleGapMilliseconds',
+    'observationCount',
+    'observerExcluded',
+    'processCountPeakObserved',
+    'retainedRootRssGrowthBytes',
+    'rootIdentityValidation',
+    'rootStartIdentity',
+    'sampleAttempts',
+    'sampleFailures',
+    'scope',
+    'source',
+    'successfulSamples',
+    'version',
+  ]);
+  if (observer.version !== 1) invalid('memory observer version must be 1');
+  if (observer.observerExcluded !== true) invalid('memory observer must exclude its own subtree');
+  if (observer.scope !== 'recursive-process-tree') invalid('memory observer scope must be recursive-process-tree');
+  if (observer.source !== 'darwin-ps' && observer.source !== 'linux-proc') {
+    invalid('memory observer source is unsupported');
+  }
+  const rootIdentityValidation = observer.rootIdentityValidation;
+  if (
+    (observer.source === 'darwin-ps' && rootIdentityValidation !== 'darwin-ps-lstart') ||
+    (observer.source === 'linux-proc' && rootIdentityValidation !== 'linux-proc-starttime')
+  ) {
+    invalid('memory observer source and root identity validation do not match');
+  }
+  const intervalMilliseconds = positiveInteger(observer.intervalMilliseconds, 'memory observer interval');
+  if (intervalMilliseconds < 10 || intervalMilliseconds > 1_000) {
+    invalid('memory observer interval must be between 10 and 1000 milliseconds');
+  }
+  const finalSample = parseMemoryObserverFinalSample(observer.finalSample);
+  return {
+    finalSample,
+    intervalMilliseconds,
+    maximumSampleGapMilliseconds: nonNegativeSafeInteger(
+      observer.maximumSampleGapMilliseconds,
+      'memory observer maximum sample gap',
+    ),
+    observationCount: positiveInteger(observer.observationCount, 'memory observer observation count'),
+    observerExcluded: true,
+    processCountPeakObserved: positiveInteger(observer.processCountPeakObserved, 'memory observer peak process count'),
+    retainedRootRssGrowthBytes: nonNegativeSafeInteger(
+      observer.retainedRootRssGrowthBytes,
+      'memory observer retained root RSS growth',
+    ),
+    rootIdentityValidation:
+      rootIdentityValidation as ContextBriefCitationScaleMemoryObserverV2['rootIdentityValidation'],
+    rootStartIdentity: boundedString(observer.rootStartIdentity, 'memory observer root identity'),
+    sampleAttempts: positiveInteger(observer.sampleAttempts, 'memory observer sample attempts'),
+    sampleFailures: nonNegativeSafeInteger(observer.sampleFailures, 'memory observer sample failures'),
+    scope: 'recursive-process-tree',
+    source: observer.source,
+    successfulSamples: positiveInteger(observer.successfulSamples, 'memory observer successful samples'),
+    version: 1,
+  };
+}
+
+function parseMemoryObserverFinalSample(value: unknown): ContextBriefCitationScaleMemoryObserverV2['finalSample'] {
+  const sample = record(value, 'memory observer final sample');
+  exactKeys(sample, ['processCount', 'rootRssBytes', 'sampleAttempts', 'sampleFailures', 'treeRssBytes']);
+  const result = {
+    processCount: positiveInteger(sample.processCount, 'memory observer final process count'),
+    rootRssBytes: nonNegativeSafeInteger(sample.rootRssBytes, 'memory observer final root RSS'),
+    sampleAttempts: positiveInteger(sample.sampleAttempts, 'memory observer final sample attempts'),
+    sampleFailures: nonNegativeSafeInteger(sample.sampleFailures, 'memory observer final sample failures'),
+    treeRssBytes: nonNegativeSafeInteger(sample.treeRssBytes, 'memory observer final tree RSS'),
+  };
+  if (result.rootRssBytes > result.treeRssBytes) invalid('memory observer final root RSS exceeds tree RSS');
+  if (result.sampleFailures !== result.sampleAttempts - 1) {
+    invalid('memory observer final sample accounting is inconsistent');
+  }
+  return result;
+}
+
+function parseArtifactGate(value: unknown): ContextBriefCitationScaleGateV1 {
+  const gate = record(value, 'artifact gate');
+  exactKeys(gate, ['failures', 'passed']);
+  if (!Array.isArray(gate.failures) || gate.failures.length > 1_024) invalid('artifact gate failures are invalid');
+  const failures = gate.failures.map((failure, index) => boundedString(failure, `gate failure ${index}`, 4_096));
+  const stableFailures = [...new Set(failures)].sort();
+  if (JSON.stringify(failures) !== JSON.stringify(stableFailures)) {
+    invalid('artifact gate failures must be sorted and unique');
+  }
+  const passed = booleanValue(gate.passed, 'artifact gate passed');
+  if (passed !== (failures.length === 0)) invalid('artifact gate passed value is inconsistent with its failures');
+  return {failures, passed};
+}
+
+function parseArtifactProfileResult(
+  value: unknown,
+  budget: ContextBriefCitationScaleBudgetV1,
+  profileIndex: number,
+): {readonly failures: readonly string[]; readonly result: ContextBriefCitationScaleProfileResultV2} {
+  const result = record(value, `artifact profile ${profileIndex}`);
+  exactKeys(result, [
+    'coldReadyGraphObservation',
+    'counters',
+    'measurements',
+    'memoryCoverage',
+    'observations',
+    'profile',
+    'samples',
+  ]);
+  const profile = parseProfile(result.profile);
+  if (!Array.isArray(result.observations) || result.observations.length === 0 || result.observations.length > 256) {
+    invalid(`${profile.id} observations must contain between one and 256 samples`);
+  }
+  const observations = result.observations.map((observation, index) =>
+    parseMeasuredObservation(observation, profile.id, index),
+  );
+  const claimed: ContextBriefCitationScaleProfileResultV2 = {
+    coldReadyGraphObservation: parseTimingObservation(
+      result.coldReadyGraphObservation,
+      `${profile.id} cold ready-graph observation`,
+    ),
+    counters: parseAggregateCounters(result.counters, profile.id),
+    measurements: parseProfileMeasurements(result.measurements, profile.id),
+    memoryCoverage: parseMemoryCoverage(result.memoryCoverage, profile.id),
+    observations,
+    profile,
+    samples: positiveInteger(result.samples, `${profile.id} samples`),
+  };
+  const evaluated = evaluateContextBriefCitationScaleProfile(
+    budget,
+    profile.id,
+    claimed.coldReadyGraphObservation,
+    observations,
+  );
+  if (!sameJson(claimed, evaluated.result)) {
+    invalid(`${profile.id} aggregates do not match its retained timing, memory workload, and RSS observations`);
+  }
+  return evaluated;
+}
+
+function parseAggregateCounters(
+  value: unknown,
+  profile: ContextBriefCitationScaleProfileId,
+): ContextBriefCitationScaleProfileResultV2['counters'] {
+  const counters = record(value, `${profile} aggregate counters`);
+  exactKeys(counters, [
+    'maximumActiveViewFenceObservations',
+    'maximumDistinctGraphDatabasePaths',
+    'maximumEffectiveEvidenceBatches',
+    'maximumLeaseBalance',
+    'maximumMaintenanceRequests',
+    'maximumPeakLeaseBalance',
+    'maximumProductionStoreSessionCalls',
+    'maximumStatusObservations',
+  ]);
+  return {
+    maximumActiveViewFenceObservations: nonNegativeSafeInteger(
+      counters.maximumActiveViewFenceObservations,
+      `${profile} maximum active-view fence observations`,
+    ),
+    maximumDistinctGraphDatabasePaths: nonNegativeSafeInteger(
+      counters.maximumDistinctGraphDatabasePaths,
+      `${profile} maximum distinct graph database paths`,
+    ),
+    maximumEffectiveEvidenceBatches: nonNegativeSafeInteger(
+      counters.maximumEffectiveEvidenceBatches,
+      `${profile} maximum effective evidence batches`,
+    ),
+    maximumLeaseBalance: nonNegativeSafeInteger(counters.maximumLeaseBalance, `${profile} maximum lease balance`),
+    maximumMaintenanceRequests: nonNegativeSafeInteger(
+      counters.maximumMaintenanceRequests,
+      `${profile} maximum maintenance requests`,
+    ),
+    maximumPeakLeaseBalance: nonNegativeSafeInteger(
+      counters.maximumPeakLeaseBalance,
+      `${profile} maximum peak lease balance`,
+    ),
+    maximumProductionStoreSessionCalls: nonNegativeSafeInteger(
+      counters.maximumProductionStoreSessionCalls,
+      `${profile} maximum production store session calls`,
+    ),
+    maximumStatusObservations: nonNegativeSafeInteger(
+      counters.maximumStatusObservations,
+      `${profile} maximum status observations`,
+    ),
+  };
+}
+
+function parseProfileMeasurements(
+  value: unknown,
+  profile: ContextBriefCitationScaleProfileId,
+): ContextBriefCitationScaleProfileResultV2['measurements'] {
+  const measurements = record(value, `${profile} measurements`);
+  exactKeys(measurements, [
+    'boundaryAddedRssBytes',
+    'contextBriefMilliseconds',
+    'memoryRetrievalMilliseconds',
+    'observedAddedProcessTreeRssBytes',
+    'validationMilliseconds',
+  ]);
+  return {
+    boundaryAddedRssBytes: parseBenchmarkMeasurement(measurements.boundaryAddedRssBytes, `${profile} boundary RSS`),
+    contextBriefMilliseconds: parseBenchmarkMeasurement(
+      measurements.contextBriefMilliseconds,
+      `${profile} Context Brief latency`,
+    ),
+    memoryRetrievalMilliseconds: parseBenchmarkMeasurement(
+      measurements.memoryRetrievalMilliseconds,
+      `${profile} memory retrieval latency`,
+    ),
+    validationMilliseconds: parseBenchmarkMeasurement(
+      measurements.validationMilliseconds,
+      `${profile} validation latency`,
+    ),
+    observedAddedProcessTreeRssBytes: parseBenchmarkMeasurement(
+      measurements.observedAddedProcessTreeRssBytes,
+      `${profile} process-tree RSS`,
+    ),
+  };
+}
+
+function parseBenchmarkMeasurement(value: unknown, label: string): BenchmarkMeasurementV1 {
+  const measurement = record(value, label);
+  exactKeys(measurement, ['maximum', 'mean', 'minimum', 'name', 'p50', 'p95', 'p99', 'samples', 'unit']);
+  const unit = measurement.unit;
+  if (
+    unit !== 'bytes' &&
+    unit !== 'count' &&
+    unit !== 'milliseconds' &&
+    unit !== 'operations_per_second' &&
+    unit !== 'percent'
+  ) {
+    invalid(`${label} unit is unsupported`);
+  }
+  const parsed = {
+    maximum: nonNegativeFinite(measurement.maximum, `${label} maximum`),
+    mean: nonNegativeFinite(measurement.mean, `${label} mean`),
+    minimum: nonNegativeFinite(measurement.minimum, `${label} minimum`),
+    name: boundedString(measurement.name, `${label} name`),
+    p50: nonNegativeFinite(measurement.p50, `${label} p50`),
+    p95: nonNegativeFinite(measurement.p95, `${label} p95`),
+    p99: nonNegativeFinite(measurement.p99, `${label} p99`),
+    samples: positiveInteger(measurement.samples, `${label} samples`),
+    unit,
+  } satisfies BenchmarkMeasurementV1;
+  if (
+    parsed.minimum > parsed.p50 ||
+    parsed.p50 > parsed.p95 ||
+    parsed.p95 > parsed.p99 ||
+    parsed.p99 > parsed.maximum ||
+    parsed.mean < parsed.minimum ||
+    parsed.mean > parsed.maximum
+  ) {
+    invalid(`${label} summary is internally inconsistent`);
+  }
+  return parsed;
+}
+
+function parseMemoryCoverage(
+  value: unknown,
+  profile: ContextBriefCitationScaleProfileId,
+): ContextBriefCitationScaleProfileResultV2['memoryCoverage'] {
+  const coverage = record(value, `${profile} memory coverage`);
+  exactKeys(coverage, [
+    'descendantObservationCount',
+    'descendantObservationRate',
+    'maximumPeakProcessCount',
+    'minimumSuccessfulSamples',
+  ]);
+  const descendantObservationRate = nonNegativeFinite(
+    coverage.descendantObservationRate,
+    `${profile} descendant observation rate`,
+  );
+  if (descendantObservationRate > 1) invalid(`${profile} descendant observation rate exceeds one`);
+  return {
+    descendantObservationCount: nonNegativeSafeInteger(
+      coverage.descendantObservationCount,
+      `${profile} descendant observation count`,
+    ),
+    descendantObservationRate,
+    maximumPeakProcessCount: positiveInteger(coverage.maximumPeakProcessCount, `${profile} maximum peak process count`),
+    minimumSuccessfulSamples: positiveInteger(
+      coverage.minimumSuccessfulSamples,
+      `${profile} minimum successful samples`,
+    ),
+  };
+}
+
+const OBSERVATION_KEYS = [
+  'boundaryAddedRssBytes',
+  'contextBriefMilliseconds',
+  'counters',
+  'estimatedTokens',
+  'exactValidationReceipts',
+  'memoryRetrievalMilliseconds',
+  'profile',
+  'selectedMemories',
+  'validationMilliseconds',
+  'validationReceipts',
+] as const;
+
+function parseMeasuredObservation(
+  value: unknown,
+  expectedProfile: ContextBriefCitationScaleProfileId,
+  index: number,
+): ContextBriefCitationScaleMeasuredObservationV2 {
+  const observation = record(value, `${expectedProfile} measured observation ${index}`);
+  exactKeys(observation, [...OBSERVATION_KEYS, 'memory', 'memoryWorkload']);
+  const timing = parseTimingObservationRecord(observation, `${expectedProfile} measured observation ${index}`);
+  const memory = parseMemoryObservation(observation.memory, expectedProfile, index);
+  return {
+    ...timing,
+    memory,
+    memoryWorkload: parseTimingObservation(
+      observation.memoryWorkload,
+      `${expectedProfile} memory workload observation ${index}`,
+    ),
+  };
+}
+
+function parseTimingObservation(value: unknown, label: string): ContextBriefCitationScaleObservationV2 {
+  const observation = record(value, label);
+  exactKeys(observation, OBSERVATION_KEYS);
+  return parseTimingObservationRecord(observation, label);
+}
+
+function parseTimingObservationRecord(
+  observation: Readonly<Record<string, unknown>>,
+  label: string,
+): ContextBriefCitationScaleObservationV2 {
+  return {
+    boundaryAddedRssBytes: nonNegativeSafeInteger(observation.boundaryAddedRssBytes, `${label} boundary RSS`),
+    contextBriefMilliseconds: nonNegativeFinite(
+      observation.contextBriefMilliseconds,
+      `${label} Context Brief milliseconds`,
+    ),
+    counters: parseObservationCounters(observation.counters, label),
+    estimatedTokens: nonNegativeSafeInteger(observation.estimatedTokens, `${label} estimated tokens`),
+    exactValidationReceipts: nonNegativeSafeInteger(
+      observation.exactValidationReceipts,
+      `${label} exact validation receipts`,
+    ),
+    memoryRetrievalMilliseconds: nonNegativeFinite(
+      observation.memoryRetrievalMilliseconds,
+      `${label} memory retrieval milliseconds`,
+    ),
+    profile: parseProfileId(observation.profile, `${label} profile`),
+    selectedMemories: nonNegativeSafeInteger(observation.selectedMemories, `${label} selected memories`),
+    validationMilliseconds: nonNegativeFinite(observation.validationMilliseconds, `${label} validation milliseconds`),
+    validationReceipts: nonNegativeSafeInteger(observation.validationReceipts, `${label} validation receipts`),
+  };
+}
+
+function parseObservationCounters(value: unknown, label: string): ContextBriefCitationScaleCountersV1 {
+  const counters = record(value, `${label} counters`);
+  exactKeys(counters, [
+    'activeViewFenceObservations',
+    'coldGraphBuilds',
+    'distinctGraphDatabasePaths',
+    'effectiveEvidenceBatches',
+    'leaseBalance',
+    'maintenanceRequests',
+    'peakLeaseBalance',
+    'productionStoreSessionCalls',
+    'snapshotLeaseAcquisitions',
+    'snapshotLeaseReleases',
+    'statusObservations',
+  ]);
+  return {
+    activeViewFenceObservations: nonNegativeSafeInteger(
+      counters.activeViewFenceObservations,
+      `${label} active-view fence observations`,
+    ),
+    coldGraphBuilds: nonNegativeSafeInteger(counters.coldGraphBuilds, `${label} cold graph builds`),
+    distinctGraphDatabasePaths: nonNegativeSafeInteger(
+      counters.distinctGraphDatabasePaths,
+      `${label} distinct graph database paths`,
+    ),
+    effectiveEvidenceBatches: nonNegativeSafeInteger(
+      counters.effectiveEvidenceBatches,
+      `${label} effective evidence batches`,
+    ),
+    leaseBalance: nonNegativeSafeInteger(counters.leaseBalance, `${label} lease balance`),
+    maintenanceRequests: nonNegativeSafeInteger(counters.maintenanceRequests, `${label} maintenance requests`),
+    peakLeaseBalance: nonNegativeSafeInteger(counters.peakLeaseBalance, `${label} peak lease balance`),
+    productionStoreSessionCalls: nonNegativeSafeInteger(
+      counters.productionStoreSessionCalls,
+      `${label} production store session calls`,
+    ),
+    snapshotLeaseAcquisitions: nonNegativeSafeInteger(
+      counters.snapshotLeaseAcquisitions,
+      `${label} snapshot lease acquisitions`,
+    ),
+    snapshotLeaseReleases: nonNegativeSafeInteger(counters.snapshotLeaseReleases, `${label} snapshot lease releases`),
+    statusObservations: nonNegativeSafeInteger(counters.statusObservations, `${label} status observations`),
+  };
+}
+
+function parseMemoryObservation(
+  value: unknown,
+  expectedProfile: ContextBriefCitationScaleProfileId,
+  index: number,
+): ContextBriefCitationScaleMemoryObservationV2 {
+  const memory = record(value, `${expectedProfile} memory observation ${index}`);
+  exactKeys(memory, [
+    'baselineProcessCount',
+    'maximumSampleGapMilliseconds',
+    'observedAddedProcessTreeRssBytes',
+    'observedAddedRootRssBytes',
+    'observedProcessTreeRssBaselineBytes',
+    'observedProcessTreeRssPeakBytes',
+    'observedRootRssBaselineBytes',
+    'observedRootRssPeakBytes',
+    'observationId',
+    'ordinal',
+    'peakProcessCount',
+    'profile',
+    'rootStartIdentity',
+    'sampleAttempts',
+    'sampleFailures',
+    'sampleIntervalMilliseconds',
+    'samples',
+    'source',
+  ]);
+  if (memory.source !== 'darwin-ps' && memory.source !== 'linux-proc') {
+    invalid(`${expectedProfile} memory observation ${index} source is unsupported`);
+  }
+  const observationId = boundedString(memory.observationId, `${expectedProfile} memory observation ${index} id`);
+  const expectedId = `context-rss-${expectedProfile}-${index}`;
+  if (observationId !== expectedId) invalid(`${expectedProfile} memory observation ${index} id must be ${expectedId}`);
+  return {
+    baselineProcessCount: positiveInteger(memory.baselineProcessCount, `${expectedProfile} baseline process count`),
+    maximumSampleGapMilliseconds: nonNegativeSafeInteger(
+      memory.maximumSampleGapMilliseconds,
+      `${expectedProfile} maximum sample gap`,
+    ),
+    observedAddedProcessTreeRssBytes: nonNegativeSafeInteger(
+      memory.observedAddedProcessTreeRssBytes,
+      `${expectedProfile} added process-tree RSS`,
+    ),
+    observedAddedRootRssBytes: nonNegativeSafeInteger(
+      memory.observedAddedRootRssBytes,
+      `${expectedProfile} added root RSS`,
+    ),
+    observedProcessTreeRssBaselineBytes: nonNegativeSafeInteger(
+      memory.observedProcessTreeRssBaselineBytes,
+      `${expectedProfile} process-tree RSS baseline`,
+    ),
+    observedProcessTreeRssPeakBytes: nonNegativeSafeInteger(
+      memory.observedProcessTreeRssPeakBytes,
+      `${expectedProfile} process-tree RSS peak`,
+    ),
+    observedRootRssBaselineBytes: nonNegativeSafeInteger(
+      memory.observedRootRssBaselineBytes,
+      `${expectedProfile} root RSS baseline`,
+    ),
+    observedRootRssPeakBytes: nonNegativeSafeInteger(
+      memory.observedRootRssPeakBytes,
+      `${expectedProfile} root RSS peak`,
+    ),
+    observationId,
+    ordinal: nonNegativeSafeInteger(memory.ordinal, `${expectedProfile} memory ordinal`),
+    peakProcessCount: positiveInteger(memory.peakProcessCount, `${expectedProfile} peak process count`),
+    profile: parseProfileId(memory.profile, `${expectedProfile} memory profile`),
+    rootStartIdentity: boundedString(memory.rootStartIdentity, `${expectedProfile} root start identity`),
+    sampleAttempts: positiveInteger(memory.sampleAttempts, `${expectedProfile} sample attempts`),
+    sampleFailures: nonNegativeSafeInteger(memory.sampleFailures, `${expectedProfile} sample failures`),
+    sampleIntervalMilliseconds: positiveInteger(
+      memory.sampleIntervalMilliseconds,
+      `${expectedProfile} sample interval`,
+    ),
+    samples: positiveInteger(memory.samples, `${expectedProfile} successful samples`),
+    source: memory.source,
+  };
+}
+
+function validateMemoryObserverSummary(
+  observer: ContextBriefCitationScaleMemoryObserverV2,
+  profiles: readonly ContextBriefCitationScaleProfileResultV2[],
+): void {
+  const observations = profiles.flatMap(profile => profile.observations.map(observation => observation.memory));
+  if (observer.observationCount !== observations.length) {
+    invalid('memory observer observation count does not match the retained profile observations');
+  }
+  const expectedMaximumGap = Math.max(0, ...observations.map(observation => observation.maximumSampleGapMilliseconds));
+  const expectedPeakProcessCount = Math.max(
+    observer.finalSample.processCount,
+    ...observations.map(observation => observation.peakProcessCount),
+  );
+  const expectedAttempts = safeSum(
+    [...observations.map(observation => observation.sampleAttempts), observer.finalSample.sampleAttempts],
+    'memory observer sample attempts',
+  );
+  const expectedFailures = safeSum(
+    [...observations.map(observation => observation.sampleFailures), observer.finalSample.sampleFailures],
+    'memory observer sample failures',
+  );
+  const expectedSuccessfulSamples = safeSum(
+    [...observations.map(observation => observation.samples), 1],
+    'memory observer successful samples',
+  );
+  const expectedRetainedGrowth = contextBriefCitationScaleRetainedRootRssGrowthBytes([
+    ...observations.map(observation => observation.observedRootRssBaselineBytes),
+    observer.finalSample.rootRssBytes,
+  ]);
+  if (observer.maximumSampleGapMilliseconds !== expectedMaximumGap) {
+    invalid('memory observer maximum sample gap does not match the retained observations');
+  }
+  if (observer.processCountPeakObserved !== expectedPeakProcessCount) {
+    invalid('memory observer peak process count does not match the retained observations');
+  }
+  if (observer.sampleAttempts !== expectedAttempts) {
+    invalid('memory observer sample attempts do not match the retained observations');
+  }
+  if (observer.sampleFailures !== expectedFailures) {
+    invalid('memory observer sample failures do not match the retained observations');
+  }
+  if (observer.successfulSamples !== expectedSuccessfulSamples) {
+    invalid('memory observer successful samples do not match the retained observations');
+  }
+  if (observer.retainedRootRssGrowthBytes !== expectedRetainedGrowth) {
+    invalid('memory observer retained root RSS growth does not match the retained observations');
+  }
+  for (const observation of observations) {
+    if (observation.sampleIntervalMilliseconds !== observer.intervalMilliseconds) {
+      invalid('memory observer interval does not match a retained observation');
+    }
+    if (observation.source !== observer.source) {
+      invalid('memory observer source does not match a retained observation');
+    }
+    if (observation.rootStartIdentity !== observer.rootStartIdentity) {
+      invalid('memory observer root identity does not match a retained observation');
+    }
+  }
+}
+
+function rederiveArtifactFailures(input: {
+  readonly budget: ContextBriefCitationScaleBudgetV1;
+  readonly environment: ContextBriefCitationScaleEnvironmentV2;
+  readonly evidenceClass: ContextBriefCitationScaleEvidenceClass;
+  readonly execution: ContextBriefCitationScaleExecutionV2;
+  readonly fixture: ContextBriefCitationScaleFixtureV2;
+  readonly memoryObserver: ContextBriefCitationScaleMemoryObserverV2;
+  readonly profileFailures: readonly string[];
+  readonly profiles: readonly ContextBriefCitationScaleProfileResultV2[];
+  readonly samples: number;
+  readonly warmups: number;
+}): readonly string[] {
+  const failures = [
+    input.evidenceClass === 'release-scale' ? '' : 'artifact is a development smoke, not release-scale evidence',
+    input.memoryObserver.sampleFailures === 0
+      ? ''
+      : `external RSS observer recorded ${input.memoryObserver.sampleFailures} failed samples`,
+    input.memoryObserver.finalSample.processCount === 1
+      ? ''
+      : `external RSS observer final retained-root sample contained ${input.memoryObserver.finalSample.processCount} processes; expected the benchmark root only`,
+    input.memoryObserver.retainedRootRssGrowthBytes <= input.budget.maximumObservedAddedProcessTreeRssBytes
+      ? ''
+      : `retained root RSS growth ${input.memoryObserver.retainedRootRssGrowthBytes} exceeds ${input.budget.maximumObservedAddedProcessTreeRssBytes}`,
+    ...input.profileFailures,
+    sameJson(
+      input.profiles.map(profile => profile.profile.id),
+      input.budget.profiles.map(profile => profile.id),
+    )
+      ? ''
+      : 'reviewed scale evidence must execute local-100k, workset-50, and workset-128 in order',
+    input.fixture.indexedMemoryCandidates === input.budget.corpusMemoryCandidates
+      ? ''
+      : `indexed memory corpus ${input.fixture.indexedMemoryCandidates}; required ${input.budget.corpusMemoryCandidates}`,
+    input.evidenceClass !== 'release-scale' || (input.samples === 25 && input.warmups === 5)
+      ? ''
+      : `release evidence requires exactly 25 samples and 5 warmups; received ${input.samples}/${input.warmups}`,
+    /^[0-9a-f]{64}$/u.test(input.execution.builtArtifactSha256)
+      ? ''
+      : 'benchmark execution artifact digest is missing or malformed',
+  ];
+  if (input.evidenceClass === 'release-scale') {
+    failures.push(...contextBriefCitationScaleReleaseIdentityFailures(input.environment));
+    if (
+      input.memoryObserver.source !== 'darwin-ps' ||
+      input.memoryObserver.rootIdentityValidation !== 'darwin-ps-lstart' ||
+      input.memoryObserver.intervalMilliseconds !== 25
+    ) {
+      failures.push('release RSS evidence must use the reviewed observer-excluded Darwin 25ms process-tree sampler');
+    }
+  }
+  return failures.filter(Boolean);
+}
+
+/** Measure retained root growth independently from each request's transient peak. */
+export function contextBriefCitationScaleRetainedRootRssGrowthBytes(baselines: readonly number[]): number {
+  if (baselines.length === 0) return 0;
+  return Math.max(0, Math.max(...baselines) - baselines[0]!);
+}
+
+/** Fail closed when hosted release evidence is relabeled or detached from its exact candidate. */
+export function contextBriefCitationScaleReleaseIdentityFailures(
+  identity: ContextBriefCitationScaleReleaseIdentityV1,
+): readonly string[] {
+  return [
+    /^[0-9a-f]{40}$/u.test(identity.candidateCommit) ? '' : 'release candidate commit is not exact lowercase Git SHA-1',
+    identity.commit === identity.candidateCommit
+      ? ''
+      : `observed commit ${identity.commit}; required candidate ${identity.candidateCommit}`,
+    identity.dirty ? 'release candidate checkout is dirty' : '',
+    identity.gitStatusObserved ? '' : 'release candidate Git status could not be observed',
+    identity.githubActions ? '' : 'release evidence was not produced by GitHub Actions',
+    identity.runnerClass === CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNNER_CLASS
+      ? ''
+      : `runner class ${identity.runnerClass}; required ${CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNNER_CLASS}`,
+    identity.runnerArchitecture === 'ARM64'
+      ? ''
+      : `runner architecture label ${identity.runnerArchitecture}; required ARM64`,
+    identity.runnerEnvironment === 'github-hosted'
+      ? ''
+      : `runner environment ${identity.runnerEnvironment}; required github-hosted`,
+    identity.runnerOperatingSystem === 'macOS'
+      ? ''
+      : `runner operating system label ${identity.runnerOperatingSystem}; required macOS`,
+    identity.architecture === 'arm64' ? '' : `runner architecture ${identity.architecture}; required arm64`,
+    /^Apple M1(?:$|\s)/u.test(identity.cpu) ? '' : `runner CPU ${identity.cpu}; required Apple M1 class`,
+    identity.operatingSystem.startsWith('macOS ')
+      ? ''
+      : `runner operating system ${identity.operatingSystem}; required macOS`,
+    identity.runtime === CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNTIME
+      ? ''
+      : `runtime ${identity.runtime}; required ${CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNTIME}`,
+    identity.sourceVersion === CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SOURCE_VERSION
+      ? ''
+      : `source version ${identity.sourceVersion}; required ${CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SOURCE_VERSION}`,
+  ].filter(Boolean);
 }
 
 function parseProfile(value: unknown): ContextBriefCitationScaleProfileV1 {
@@ -228,10 +1220,10 @@ function parseProfile(value: unknown): ContextBriefCitationScaleProfileV1 {
   return {...expected, id, maximumBriefP95Milliseconds, maximumValidationP95Milliseconds};
 }
 
-function observationFailures(
+export function contextBriefCitationScaleObservationFailures(
   profile: ContextBriefCitationScaleProfileV1,
   budget: ContextBriefCitationScaleBudgetV1,
-  observation: ContextBriefCitationScaleObservationV1,
+  observation: ContextBriefCitationScaleObservationV2,
   index: number,
 ): readonly string[] {
   const prefix = `${profile.id} observation ${index}`;
@@ -278,6 +1270,45 @@ function observationFailures(
   ].filter(Boolean);
 }
 
+function memoryObservationFailures(
+  profile: ContextBriefCitationScaleProfileV1,
+  observation: ContextBriefCitationScaleMeasuredObservationV2,
+  index: number,
+): readonly string[] {
+  const prefix = `${profile.id} memory observation ${index}`;
+  const memory = observation.memory;
+  return [
+    memory.profile === profile.id ? '' : `${prefix} has wrong profile ${memory.profile}`,
+    memory.observationId.length > 0 ? '' : `${prefix} has no observation ID`,
+    memory.rootStartIdentity.length > 0 ? '' : `${prefix} has no root start identity`,
+    memory.sampleIntervalMilliseconds >= 10 ? '' : `${prefix} sampling interval is below 10ms`,
+    memory.samples >= 3 ? '' : `${prefix} has fewer than three successful samples`,
+    memory.sampleAttempts === memory.samples + memory.sampleFailures
+      ? ''
+      : `${prefix} sample accounting is inconsistent`,
+    memory.sampleFailures === 0 ? '' : `${prefix} has ${memory.sampleFailures} failed samples`,
+    memory.maximumSampleGapMilliseconds <= 100
+      ? ''
+      : `${prefix} sample gap ${memory.maximumSampleGapMilliseconds}ms exceeds 100ms`,
+    memory.baselineProcessCount === 1
+      ? ''
+      : `${prefix} baseline process count ${memory.baselineProcessCount}; expected root only`,
+    memory.observedRootRssBaselineBytes <= memory.observedProcessTreeRssBaselineBytes &&
+    memory.observedRootRssPeakBytes <= memory.observedProcessTreeRssPeakBytes
+      ? ''
+      : `${prefix} root RSS exceeds process-tree RSS`,
+    memory.observedRootRssPeakBytes >= memory.observedRootRssBaselineBytes &&
+    memory.observedAddedRootRssBytes === memory.observedRootRssPeakBytes - memory.observedRootRssBaselineBytes
+      ? ''
+      : `${prefix} has inconsistent root RSS evidence`,
+    memory.observedProcessTreeRssPeakBytes >= memory.observedProcessTreeRssBaselineBytes &&
+    memory.observedAddedProcessTreeRssBytes ===
+      memory.observedProcessTreeRssPeakBytes - memory.observedProcessTreeRssBaselineBytes
+      ? ''
+      : `${prefix} has inconsistent process-tree RSS evidence`,
+  ].filter(Boolean);
+}
+
 function measurement(
   suffix: string,
   values: readonly number[],
@@ -287,8 +1318,8 @@ function measurement(
 }
 
 function maximum(
-  values: readonly ContextBriefCitationScaleObservationV1[],
-  select: (value: ContextBriefCitationScaleObservationV1) => number,
+  values: readonly ContextBriefCitationScaleObservationV2[],
+  select: (value: ContextBriefCitationScaleObservationV2) => number,
 ): number {
   return Math.max(0, ...values.map(select));
 }
@@ -296,6 +1327,74 @@ function maximum(
 function positiveInteger(value: unknown, label: string): number {
   if (!Number.isSafeInteger(value) || (value as number) < 1) invalid(`${label} must be a positive integer`);
   return value as number;
+}
+
+function nonNegativeSafeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) invalid(`${label} must be a non-negative integer`);
+  return value as number;
+}
+
+function nonNegativeFinite(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    invalid(`${label} must be a non-negative finite number`);
+  }
+  return value;
+}
+
+function safeSum(values: readonly number[], label: string): number {
+  const result = values.reduce((total, value) => total + value, 0);
+  if (!Number.isSafeInteger(result)) invalid(`${label} total exceeds the safe integer range`);
+  return result;
+}
+
+function boundedString(value: unknown, label: string, maximumLength = 2_048): string {
+  const parsed = stringValue(value, label, maximumLength);
+  if (parsed.length === 0) invalid(`${label} must not be empty`);
+  return parsed;
+}
+
+function stringValue(value: unknown, label: string, maximumLength: number): string {
+  if (typeof value !== 'string' || value.length > maximumLength) {
+    invalid(`${label} must be a string no longer than ${maximumLength} characters`);
+  }
+  return value;
+}
+
+function booleanValue(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') invalid(`${label} must be a boolean`);
+  return value;
+}
+
+function lowercaseHex(value: unknown, length: number, label: string): string {
+  const parsed = stringValue(value, label, length);
+  if (parsed.length !== length || !/^[0-9a-f]+$/u.test(parsed)) {
+    invalid(`${label} must be exactly ${length} lowercase hexadecimal characters`);
+  }
+  return parsed;
+}
+
+function parseProfileId(value: unknown, label: string): ContextBriefCitationScaleProfileId {
+  if (!CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS.includes(value as ContextBriefCitationScaleProfileId)) {
+    invalid(`${label} is unsupported`);
+  }
+  return value as ContextBriefCitationScaleProfileId;
+}
+
+function isoInstant(value: unknown, label: string): string {
+  const parsed = boundedString(value, label, 64);
+  const timestamp = Date.parse(parsed);
+  if (!Number.isFinite(timestamp) || new Date(timestamp).toISOString() !== parsed) {
+    invalid(`${label} must be a canonical ISO instant`);
+  }
+  return parsed;
+}
+
+function assertUnique(values: readonly string[], label: string): void {
+  if (new Set(values).size !== values.length) invalid(`${label} must be unique`);
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function exactKeys(value: Readonly<Record<string, unknown>>, expected: readonly string[]): void {

--- a/src/evaluation/context-brief-citation-scale-fixture.ts
+++ b/src/evaluation/context-brief-citation-scale-fixture.ts
@@ -51,6 +51,7 @@ export interface ContextBriefCitationScalePreparedProfile {
 
 export interface ContextBriefCitationScalePreparedFixture {
   readonly config: RuntimeConfig;
+  readonly fixtureHash: string;
   readonly indexedMemoryCandidates: number;
   readonly legacyV1MemoryCandidates: number;
   readonly profiles: ReadonlyMap<ContextBriefCitationScaleProfileId, ContextBriefCitationScalePreparedProfile>;
@@ -196,8 +197,18 @@ export const prepareContextBriefCitationScaleFixture = Effect.fn('evaluation.pre
         }),
       );
     }
+    const fixtureHash = contextBriefCitationScaleFixtureHash(
+      path,
+      home,
+      options,
+      preparedProfiles,
+      selectedRecords,
+      legacyV1MemoryCandidates,
+      status.documentCount,
+    );
     return {
       config,
+      fixtureHash,
       indexedMemoryCandidates: status.documentCount,
       legacyV1MemoryCandidates,
       profiles: preparedProfiles,
@@ -256,7 +267,10 @@ function prepareRepositories(
               '-m',
               'Prepare ready graph fixture',
             ],
-            {timeoutMs: 30_000},
+            {
+              env: {GIT_AUTHOR_DATE: FIXED_INSTANT, GIT_COMMITTER_DATE: FIXED_INSTANT},
+              timeoutMs: 30_000,
+            },
           );
           const identity = yield* resolveRepositoryIdentity(repositoryRoot);
           const snapshotId = `cgsn_${sha256HexSync(`scale-snapshot\0${name}`).slice(0, 40)}`;
@@ -412,18 +426,7 @@ function writeLegacyNoise(fs: FileSystem.FileSystem, path: Path.Path, home: stri
     PROJECT,
     'noise',
   );
-  const content = [
-    'MEMORY',
-    'kind: durable',
-    'status: active',
-    `project: ${PROJECT}`,
-    'topic: legacy-scale-noise',
-    'source_agent_client: benchmark',
-    `timestamp: ${FIXED_INSTANT}`,
-    'schema_version: 1',
-    '',
-    'Unrelated legacy memory fixture about ceramic glazing and coastal weather.',
-  ].join('\n');
+  const content = legacyNoiseContent();
   return Effect.gen(function* () {
     for (let offset = 0; offset < count; offset += 1_000) {
       const end = Math.min(count, offset + 1_000);
@@ -440,6 +443,67 @@ function writeLegacyNoise(fs: FileSystem.FileSystem, path: Path.Path, home: stri
       );
     }
   });
+}
+
+function legacyNoiseContent(): string {
+  return [
+    'MEMORY',
+    'kind: durable',
+    'status: active',
+    `project: ${PROJECT}`,
+    'topic: legacy-scale-noise',
+    'source_agent_client: benchmark',
+    `timestamp: ${FIXED_INSTANT}`,
+    'schema_version: 1',
+    '',
+    'Unrelated legacy memory fixture about ceramic glazing and coastal weather.',
+  ].join('\n');
+}
+
+function contextBriefCitationScaleFixtureHash(
+  path: Path.Path,
+  home: string,
+  options: ContextBriefCitationScaleFixtureOptions,
+  preparedProfiles: ReadonlyMap<ContextBriefCitationScaleProfileId, ContextBriefCitationScalePreparedProfile>,
+  selectedRecords: readonly {readonly content: string; readonly path: string}[],
+  legacyV1MemoryCandidates: number,
+  indexedMemoryCandidates: number,
+): string {
+  return sha256HexSync(
+    JSON.stringify({
+      budget: options.budget,
+      extractorSet: EXTRACTOR_SET,
+      fixedInstant: FIXED_INSTANT,
+      indexedMemoryCandidates,
+      legacyNoise: {
+        contentHash: sha256HexSync(legacyNoiseContent()),
+        count: legacyV1MemoryCandidates,
+        pathContract: 'noise/<thousand-shard>/<six-digit-ordinal>.md',
+      },
+      profiles: options.budget.profiles.map(profile => {
+        const prepared = preparedProfiles.get(profile.id)!;
+        return {
+          id: profile.id,
+          repositories: prepared.repositories.map((repository, ordinal) => ({
+            commit: repository.status.identity.headCommit,
+            graphContentId: repository.status.readySnapshot!.graphContentId,
+            name: repository.name,
+            repositoryId: repository.repositoryId,
+            snapshotId: repository.snapshotId,
+            sourcePathsHash: sha256HexSync(repositorySourcePaths(profile, ordinal, options.runCount).join('\0')),
+          })),
+        };
+      }),
+      requestedMemoryCandidates: options.memoryCandidates,
+      runCount: options.runCount,
+      selectedRecords: selectedRecords.map(record => ({
+        contentHash: sha256HexSync(record.content),
+        path: path.relative(home, record.path).split(path.sep).join('/'),
+      })),
+      selectedProfiles: options.profileIds,
+      version: 2,
+    }),
+  );
 }
 
 function runToken(profile: ContextBriefCitationScaleProfileId, ordinal: number): string {

--- a/src/evaluation/context-brief-citation-scale.ts
+++ b/src/evaluation/context-brief-citation-scale.ts
@@ -1,7 +1,6 @@
-import {Clock, Context, Effect, FileSystem} from 'effect';
+import {Clock, Context, Effect, FileSystem, Scope} from 'effect';
 import {CodeGraphStore} from '../code_graph/store.js';
 import type {CodeGraphStoreShape} from '../code_graph/store_shape.js';
-import {sha256HexSync} from '../crypto/sha256.js';
 import {SystemInfo} from '../effect/system.js';
 import {
   compileContextBriefWith,
@@ -14,10 +13,14 @@ import {
 import {getThreadnoteVersion} from '../version.js';
 import {
   contextBriefCitationScaleGate,
+  contextBriefCitationScaleRetainedRootRssGrowthBytes,
+  contextBriefCitationScaleReleaseIdentityFailures,
   evaluateContextBriefCitationScaleProfile,
   type ContextBriefCitationScaleBudgetV1,
   type ContextBriefCitationScaleCountersV1,
-  type ContextBriefCitationScaleObservationV1,
+  type ContextBriefCitationScaleMeasuredObservationV2,
+  type ContextBriefCitationScaleMemoryObservationV2,
+  type ContextBriefCitationScaleObservationV2,
   type ContextBriefCitationScaleProfileId,
 } from './context-brief-citation-scale-contract.js';
 import {
@@ -30,22 +33,81 @@ import {
 export interface ContextBriefCitationScaleRunOptions {
   readonly budget: ContextBriefCitationScaleBudgetV1;
   readonly builtArtifactSha256: string;
+  readonly invocationMode: 'development-smoke' | 'release-scale';
   readonly memoryCandidates: number;
   readonly profileIds: readonly ContextBriefCitationScaleProfileId[];
+  readonly releaseCandidateCommit?: string;
+  readonly startRssObserver: Effect.Effect<
+    ContextBriefCitationScaleRssObserver,
+    Error,
+    FileSystem.FileSystem | Scope.Scope | SystemInfo
+  >;
   readonly samples: number;
   readonly warmups: number;
 }
 
-export interface ContextBriefCitationScaleArtifactV1 {
+export interface ContextBriefCitationScaleRssObservation {
+  readonly maximumSampleGapMilliseconds: number;
+  readonly observationId: string;
+  readonly processCountBaseline: number;
+  readonly processCountPeakObserved: number;
+  readonly rootRssBaselineBytes: number;
+  readonly rootRssGrowthObservedBytes: number;
+  readonly rootRssPeakObservedBytes: number;
+  readonly sampleAttempts: number;
+  readonly sampleFailures: number;
+  readonly successfulSamples: number;
+  readonly treeRssBaselineBytes: number;
+  readonly treeRssGrowthObservedBytes: number;
+  readonly treeRssPeakObservedBytes: number;
+}
+
+export interface ContextBriefCitationScaleRssArtifact {
+  readonly finalSample: {
+    readonly processCount: number;
+    readonly rootRssBytes: number;
+    readonly sampleAttempts: number;
+    readonly sampleFailures: number;
+    readonly treeRssBytes: number;
+  };
+  readonly intervalMilliseconds: number;
+  readonly maximumSampleGapMilliseconds: number;
+  readonly observations: readonly ContextBriefCitationScaleRssObservation[];
+  readonly observerExcluded: true;
+  readonly processCountPeakObserved: number;
+  readonly rootIdentityValidation: 'darwin-ps-lstart' | 'linux-proc-starttime';
+  readonly rootStartIdentity: string;
+  readonly sampleAttempts: number;
+  readonly sampleFailures: number;
+  readonly scope: 'recursive-process-tree';
+  readonly source: 'darwin-ps' | 'linux-proc';
+  readonly successfulSamples: number;
+  readonly version: 1;
+}
+
+export interface ContextBriefCitationScaleRssObserver {
+  readonly close: Effect.Effect<void, Error>;
+  readonly finish: Effect.Effect<ContextBriefCitationScaleRssArtifact, Error>;
+  readonly observe: <A, E, R>(observationId: string, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E | Error, R>;
+}
+
+export interface ContextBriefCitationScaleArtifactV2 {
   readonly createdAt: string;
+  readonly evidenceClass: 'development-smoke' | 'release-scale';
   readonly environment: {
     readonly architecture: string;
+    readonly candidateCommit: string;
     readonly commit: string;
     readonly cpu: string;
     readonly dirty: boolean;
+    readonly gitStatusObserved: boolean;
+    readonly githubActions: boolean;
     readonly memoryBytes: number;
     readonly operatingSystem: string;
     readonly runnerClass: string;
+    readonly runnerArchitecture: string;
+    readonly runnerEnvironment: string;
+    readonly runnerOperatingSystem: string;
     readonly runtime: string;
     readonly sourceVersion: string;
   };
@@ -55,6 +117,7 @@ export interface ContextBriefCitationScaleArtifactV1 {
     readonly coldGraphBuilds: 0;
     readonly graphDatabaseSessionCounter: string;
     readonly graphSnapshots: 'real-sqlite-prebuilt-ready';
+    readonly memoryMeasurement: string;
     readonly recallIndex: 'real-sqlite-prebuilt-before-timing';
     readonly timingScope: string;
   };
@@ -65,13 +128,18 @@ export interface ContextBriefCitationScaleArtifactV1 {
     readonly readyGraphSetupMilliseconds: number;
     readonly recallIndexBuildMilliseconds: number;
     readonly requestedMemoryCandidates: number;
+    readonly worksetGenerationDigests: readonly [string, string];
     readonly worksetRepositoryIdentities: readonly [50, 128];
   };
   readonly gate: {readonly failures: readonly string[]; readonly passed: boolean};
+  readonly memoryObserver: Omit<ContextBriefCitationScaleRssArtifact, 'observations'> & {
+    readonly observationCount: number;
+    readonly retainedRootRssGrowthBytes: number;
+  };
   readonly profiles: readonly ReturnType<typeof evaluateContextBriefCitationScaleProfile>['result'][];
   readonly samples: number;
-  readonly suite: 'context-brief-citations-scale-v1';
-  readonly version: 1;
+  readonly suite: 'context-brief-citations-scale-v2';
+  readonly version: 2;
   readonly warmups: number;
 }
 
@@ -87,21 +155,103 @@ export const evaluateContextBriefCitationScale = Effect.fn('evaluation.contextBr
     budget: options.budget,
     memoryCandidates: options.memoryCandidates,
     profileIds: options.profileIds,
-    runCount: 1 + options.warmups + options.samples,
+    runCount: options.warmups + options.samples * 2,
   });
-  const profileResults: ContextBriefCitationScaleArtifactV1['profiles'][number][] = [];
   const failures: string[] = [];
-  for (const profileId of options.profileIds) {
-    const cold = yield* runObservation(fixture, graph, profileId, 0);
-    for (let index = 0; index < options.warmups; index += 1) {
-      yield* runObservation(fixture, graph, profileId, index + 1);
+  if (options.invocationMode !== 'release-scale') {
+    failures.push('artifact is a development smoke, not release-scale evidence');
+  }
+  const memoryWorkloads = new Map<string, ContextBriefCitationScaleObservationV2>();
+  const rssEvidence = yield* Effect.acquireUseRelease(
+    options.startRssObserver,
+    observer =>
+      Effect.gen(function* () {
+        for (const profileId of options.profileIds) {
+          for (let index = 0; index < options.samples; index += 1) {
+            const observationId = rssObservationId(profileId, index);
+            prepareContextBriefCitationScaleObservation(graph);
+            const memoryRun = yield* observer.observe(
+              observationId,
+              runObservation(fixture, graph, profileId, index, {
+                captureBoundaryRss: true,
+                prepare: false,
+              }),
+            );
+            memoryWorkloads.set(observationId, memoryRun);
+          }
+        }
+        prepareContextBriefCitationScaleObservation(graph);
+        return yield* observer.finish;
+      }),
+    observer => observer.close,
+  );
+  const timingProfiles = new Map<
+    ContextBriefCitationScaleProfileId,
+    {
+      readonly cold: ContextBriefCitationScaleObservationV2;
+      readonly observations: readonly ContextBriefCitationScaleObservationV2[];
     }
-    const observations: ContextBriefCitationScaleObservationV1[] = [];
+  >();
+  for (const profileId of options.profileIds) {
+    const cold = memoryWorkloads.get(rssObservationId(profileId, 0))!;
+    for (let index = 0; index < options.warmups; index += 1) {
+      yield* runObservation(fixture, graph, profileId, options.samples + index, {
+        captureBoundaryRss: false,
+        prepare: true,
+      });
+    }
+    const observations: ContextBriefCitationScaleObservationV2[] = [];
     for (let index = 0; index < options.samples; index += 1) {
-      observations.push(yield* runObservation(fixture, graph, profileId, 1 + options.warmups + index));
+      observations.push(
+        yield* runObservation(fixture, graph, profileId, options.samples + options.warmups + index, {
+          captureBoundaryRss: false,
+          prepare: true,
+        }),
+      );
       yield* Effect.yieldNow;
     }
-    const evaluated = evaluateContextBriefCitationScaleProfile(options.budget, profileId, cold, observations);
+    timingProfiles.set(profileId, {cold, observations});
+  }
+  const rssById = new Map(rssEvidence.observations.map(observation => [observation.observationId, observation]));
+  const expectedRssIds = options.profileIds.flatMap(profileId =>
+    Array.from({length: options.samples}, (_, index) => rssObservationId(profileId, index)),
+  );
+  if (
+    rssEvidence.observations.length !== expectedRssIds.length ||
+    expectedRssIds.some(id => !rssById.has(id)) ||
+    rssEvidence.observations.some(observation => !expectedRssIds.includes(observation.observationId))
+  ) {
+    failures.push('external RSS observations do not match the complete profile/sample schedule');
+  }
+  if (rssEvidence.sampleFailures !== 0) {
+    failures.push(`external RSS observer recorded ${rssEvidence.sampleFailures} failed samples`);
+  }
+  if (rssEvidence.finalSample.processCount !== 1) {
+    failures.push(
+      `external RSS observer final retained-root sample contained ${rssEvidence.finalSample.processCount} processes; expected the benchmark root only`,
+    );
+  }
+  const retainedRootRssGrowthBytes = contextBriefCitationScaleRetainedRootRssGrowthBytes([
+    ...rssEvidence.observations.map(observation => observation.rootRssBaselineBytes),
+    rssEvidence.finalSample.rootRssBytes,
+  ]);
+  if (retainedRootRssGrowthBytes > options.budget.maximumObservedAddedProcessTreeRssBytes) {
+    failures.push(
+      `retained root RSS growth ${retainedRootRssGrowthBytes} exceeds ${options.budget.maximumObservedAddedProcessTreeRssBytes}`,
+    );
+  }
+  const profileResults: ContextBriefCitationScaleArtifactV2['profiles'][number][] = [];
+  for (const profileId of options.profileIds) {
+    const timing = timingProfiles.get(profileId)!;
+    const observations = timing.observations.map((observation, index) => {
+      const observationId = rssObservationId(profileId, index);
+      return {
+        ...observation,
+        memory: normalizeRssObservation(rssEvidence, rssById.get(observationId), profileId, index),
+        memoryWorkload: memoryWorkloads.get(observationId)!,
+      };
+    }) satisfies readonly ContextBriefCitationScaleMeasuredObservationV2[];
+    const evaluated = evaluateContextBriefCitationScaleProfile(options.budget, profileId, timing.cold, observations);
     profileResults.push(evaluated.result);
     failures.push(...evaluated.failures);
   }
@@ -114,38 +264,56 @@ export const evaluateContextBriefCitationScale = Effect.fn('evaluation.contextBr
       `indexed memory corpus ${fixture.indexedMemoryCandidates}; required ${options.budget.corpusMemoryCandidates}`,
     );
   }
-  if (options.samples < 25 || options.warmups < 5) {
+  if (options.invocationMode === 'release-scale' && (options.samples !== 25 || options.warmups !== 5)) {
     failures.push(
-      `release-quality p95 requires at least 25 samples and 5 warmups; received ${options.samples}/${options.warmups}`,
+      `release evidence requires exactly 25 samples and 5 warmups; received ${options.samples}/${options.warmups}`,
     );
   }
   if (!/^[0-9a-f]{64}$/u.test(options.builtArtifactSha256)) {
     failures.push('benchmark execution artifact digest is missing or malformed');
   }
   const [hardware, sourceVersion] = yield* Effect.all([system.hardwareInfo, getThreadnoteVersion()]);
-  const commit = gitText(['rev-parse', 'HEAD']) || 'unknown';
-  const dirty = gitText(['status', '--porcelain']).length > 0;
-  const hash = sha256HexSync(
-    JSON.stringify({
-      budget: options.budget,
-      indexedMemoryCandidates: fixture.indexedMemoryCandidates,
-      legacyV1MemoryCandidates: fixture.legacyV1MemoryCandidates,
-      profiles: profileResults.map(result => result.profile),
-    }),
-  );
+  const commitObservation = gitObservation(['rev-parse', 'HEAD']);
+  const statusObservation = gitObservation(['status', '--porcelain']);
+  const commit = commitObservation.success ? commitObservation.text || 'unknown' : 'unknown';
+  const dirty = !statusObservation.success || statusObservation.text.length > 0;
+  const runtimeEnvironment = system.environment();
+  const environment = {
+    architecture: system.architecture,
+    candidateCommit: options.releaseCandidateCommit ?? 'unclaimed',
+    commit,
+    cpu: hardware.cpuModel,
+    dirty,
+    gitStatusObserved: statusObservation.success,
+    githubActions: runtimeEnvironment.GITHUB_ACTIONS === 'true',
+    memoryBytes: hardware.memoryBytes,
+    operatingSystem: hardware.operatingSystem,
+    runnerClass: runtimeEnvironment.THREADNOTE_BENCHMARK_RUNNER_CLASS ?? 'local-unpinned',
+    runnerArchitecture: runtimeEnvironment.RUNNER_ARCH ?? system.architecture,
+    runnerEnvironment: runtimeEnvironment.RUNNER_ENVIRONMENT ?? 'local',
+    runnerOperatingSystem: runtimeEnvironment.RUNNER_OS ?? system.platform,
+    runtime: `bun/${system.runtimeVersion}`,
+    sourceVersion: `threadnote-${sourceVersion}`,
+  };
+  if (options.invocationMode === 'release-scale') {
+    failures.push(
+      ...contextBriefCitationScaleReleaseIdentityFailures({
+        ...environment,
+        candidateCommit: options.releaseCandidateCommit ?? '',
+      }),
+    );
+    if (
+      rssEvidence.source !== 'darwin-ps' ||
+      rssEvidence.rootIdentityValidation !== 'darwin-ps-lstart' ||
+      rssEvidence.intervalMilliseconds !== 25
+    ) {
+      failures.push('release RSS evidence must use the reviewed observer-excluded Darwin 25ms process-tree sampler');
+    }
+  }
   return {
     createdAt: new Date().toISOString(),
-    environment: {
-      architecture: system.architecture,
-      commit,
-      cpu: hardware.cpuModel,
-      dirty,
-      memoryBytes: hardware.memoryBytes,
-      operatingSystem: hardware.operatingSystem,
-      runnerClass: system.environment().THREADNOTE_BENCHMARK_RUNNER_CLASS ?? 'local-unpinned',
-      runtime: `bun/${system.runtimeVersion}`,
-      sourceVersion: `threadnote-${sourceVersion}`,
-    },
+    evidenceClass: options.invocationMode,
+    environment,
     execution: {
       builtArtifactSha256: options.builtArtifactSha256,
       citationReceiptCache: 'cold-per-sample',
@@ -153,26 +321,49 @@ export const evaluateContextBriefCitationScale = Effect.fn('evaluation.contextBr
       graphDatabaseSessionCounter:
         'instruments calls that reach the production CodeGraphStore.withSession implementation against real prebuilt SQLite files; OS file-descriptor opens are not separately counted',
       graphSnapshots: 'real-sqlite-prebuilt-ready',
+      memoryMeasurement:
+        'a first-use untimed pass runs before timing, uses begin/end barriers around each production observation and an observer-excluded external recursive process-tree sampler, then records a post-final-GC stop sample; the hard gates use observed tree peak minus its immediate baseline and retained root growth through that final sample, while boundary RSS remains diagnostic',
       recallIndex: 'real-sqlite-prebuilt-before-timing',
       timingScope:
-        'warm real SQLite recall retrieval plus production Git identity/status observation, graph SQLite session/lease/evidence reads, citation grouping/validation, Context Brief assembly, and projection; every sample uses unseen citation IDs; fixture creation, recall indexing, ready-snapshot activation, catalog publication, and cold graph indexing are excluded',
+        'observer-free warm real SQLite recall retrieval after first-use memory evidence, plus production Git identity/status observation, graph SQLite session/lease/evidence reads, citation grouping/validation, Context Brief assembly, and projection; every sample uses unseen citation IDs; fixture creation, recall indexing, ready-snapshot activation, catalog publication, and cold graph indexing are excluded',
     },
     fixture: {
-      hash,
+      hash: fixture.fixtureHash,
       indexedMemoryCandidates: fixture.indexedMemoryCandidates,
       legacyV1MemoryCandidates: fixture.legacyV1MemoryCandidates,
       readyGraphSetupMilliseconds: fixture.readyGraphSetupMilliseconds,
       recallIndexBuildMilliseconds: fixture.recallIndexBuildMilliseconds,
       requestedMemoryCandidates: options.memoryCandidates,
+      worksetGenerationDigests: [
+        fixture.profiles.get('workset-50')!.generation!.digest,
+        fixture.profiles.get('workset-128')!.generation!.digest,
+      ],
       worksetRepositoryIdentities: [50, 128],
     },
     gate: contextBriefCitationScaleGate(failures),
+    memoryObserver: {
+      finalSample: rssEvidence.finalSample,
+      intervalMilliseconds: rssEvidence.intervalMilliseconds,
+      maximumSampleGapMilliseconds: rssEvidence.maximumSampleGapMilliseconds,
+      observationCount: rssEvidence.observations.length,
+      observerExcluded: rssEvidence.observerExcluded,
+      processCountPeakObserved: rssEvidence.processCountPeakObserved,
+      rootIdentityValidation: rssEvidence.rootIdentityValidation,
+      rootStartIdentity: rssEvidence.rootStartIdentity,
+      retainedRootRssGrowthBytes,
+      sampleAttempts: rssEvidence.sampleAttempts,
+      sampleFailures: rssEvidence.sampleFailures,
+      scope: rssEvidence.scope,
+      source: rssEvidence.source,
+      successfulSamples: rssEvidence.successfulSamples,
+      version: rssEvidence.version,
+    },
     profiles: profileResults,
     samples: options.samples,
-    suite: 'context-brief-citations-scale-v1',
-    version: 1,
+    suite: 'context-brief-citations-scale-v2',
+    version: 2,
     warmups: options.warmups,
-  } satisfies ContextBriefCitationScaleArtifactV1;
+  } satisfies ContextBriefCitationScaleArtifactV2;
 });
 
 const runObservation = Effect.fn('evaluation.contextBriefCitationScaleObservation')(function* (
@@ -180,21 +371,22 @@ const runObservation = Effect.fn('evaluation.contextBriefCitationScaleObservatio
   graph: ContextBriefCitationScaleGraphInstrumentationShape,
   profileId: ContextBriefCitationScaleProfileId,
   ordinal: number,
+  options: {readonly captureBoundaryRss: boolean; readonly prepare: boolean},
 ) {
   const system = yield* SystemInfo;
   const prepared = fixture.profiles.get(profileId)!;
   const token = fixture.runToken(profileId, ordinal);
-  graph.reset();
-  Bun.gc(true);
-  const rssBefore = system.memoryUsage().rss;
-  let peakRss = rssBefore;
+  if (options.prepare) prepareContextBriefCitationScaleObservation(graph);
+  const rssBefore = options.captureBoundaryRss ? system.memoryUsage().rss : 0;
+  let boundaryPeakRss = rssBefore;
   let memoryRetrievalMilliseconds = 0;
   let validationMilliseconds = 0;
   let selectedMemories = 0;
   let validationReceipts = 0;
   let exactValidationReceipts = 0;
   const observeRss = () => {
-    peakRss = Math.max(peakRss, system.memoryUsage().rss);
+    if (!options.captureBoundaryRss) return;
+    boundaryPeakRss = Math.max(boundaryPeakRss, system.memoryUsage().rss);
   };
   const started = yield* Clock.currentTimeNanos;
   const brief = yield* compileContextBriefWith(
@@ -241,7 +433,7 @@ const runObservation = Effect.fn('evaluation.contextBriefCitationScaleObservatio
   const finished = yield* Clock.currentTimeNanos;
   observeRss();
   return {
-    addedRssBytes: Math.max(0, peakRss - rssBefore),
+    boundaryAddedRssBytes: Math.max(0, boundaryPeakRss - rssBefore),
     contextBriefMilliseconds: Number(finished - started) / 1_000_000,
     counters: graph.snapshot(),
     estimatedTokens: brief.measurement.estimatedTokens,
@@ -251,8 +443,67 @@ const runObservation = Effect.fn('evaluation.contextBriefCitationScaleObservatio
     selectedMemories,
     validationMilliseconds,
     validationReceipts,
-  } satisfies ContextBriefCitationScaleObservationV1;
+  } satisfies ContextBriefCitationScaleObservationV2;
 });
+
+function prepareContextBriefCitationScaleObservation(graph: ContextBriefCitationScaleGraphInstrumentationShape): void {
+  graph.reset();
+  Bun.gc(true);
+}
+
+function rssObservationId(profileId: ContextBriefCitationScaleProfileId, ordinal: number): string {
+  return `context-rss-${profileId}-${ordinal}`;
+}
+
+function normalizeRssObservation(
+  artifact: ContextBriefCitationScaleRssArtifact,
+  observation: ContextBriefCitationScaleRssObservation | undefined,
+  profile: ContextBriefCitationScaleProfileId,
+  ordinal: number,
+): ContextBriefCitationScaleMemoryObservationV2 {
+  if (observation === undefined) {
+    return {
+      maximumSampleGapMilliseconds: Number.MAX_SAFE_INTEGER,
+      observedAddedProcessTreeRssBytes: 0,
+      observedAddedRootRssBytes: 0,
+      observedProcessTreeRssBaselineBytes: 0,
+      observedProcessTreeRssPeakBytes: 0,
+      observedRootRssBaselineBytes: 0,
+      observedRootRssPeakBytes: 0,
+      observationId: rssObservationId(profile, ordinal),
+      ordinal,
+      baselineProcessCount: 0,
+      peakProcessCount: 0,
+      profile,
+      rootStartIdentity: '',
+      sampleAttempts: 0,
+      sampleFailures: 1,
+      sampleIntervalMilliseconds: artifact.intervalMilliseconds,
+      samples: 0,
+      source: artifact.source,
+    };
+  }
+  return {
+    maximumSampleGapMilliseconds: observation.maximumSampleGapMilliseconds,
+    observedAddedProcessTreeRssBytes: observation.treeRssGrowthObservedBytes,
+    observedAddedRootRssBytes: observation.rootRssGrowthObservedBytes,
+    observedProcessTreeRssBaselineBytes: observation.treeRssBaselineBytes,
+    observedProcessTreeRssPeakBytes: observation.treeRssPeakObservedBytes,
+    observedRootRssBaselineBytes: observation.rootRssBaselineBytes,
+    observedRootRssPeakBytes: observation.rootRssPeakObservedBytes,
+    observationId: observation.observationId,
+    ordinal,
+    baselineProcessCount: observation.processCountBaseline,
+    peakProcessCount: observation.processCountPeakObserved,
+    profile,
+    rootStartIdentity: artifact.rootStartIdentity,
+    sampleAttempts: observation.sampleAttempts,
+    sampleFailures: observation.sampleFailures,
+    sampleIntervalMilliseconds: artifact.intervalMilliseconds,
+    samples: observation.successfulSamples,
+    source: artifact.source,
+  };
+}
 
 interface MutableCounters {
   activeViewFenceObservations: number;
@@ -421,7 +672,10 @@ function emptyCounters(): MutableCounters {
   };
 }
 
-function gitText(arguments_: readonly string[]): string {
+function gitObservation(arguments_: readonly string[]): {readonly success: boolean; readonly text: string} {
   const result = Bun.spawnSync({cmd: ['git', ...arguments_], stderr: 'ignore', stdout: 'pipe'});
-  return result.exitCode === 0 && result.stdout ? new TextDecoder().decode(result.stdout).trim() : '';
+  return {
+    success: result.exitCode === 0,
+    text: result.stdout ? new TextDecoder().decode(result.stdout).trim() : '',
+  };
 }

--- a/src/recall/index_refresh.ts
+++ b/src/recall/index_refresh.ts
@@ -70,6 +70,7 @@ const RECALL_REFRESH_INDEX_PAGE_SIZE = 8;
 const RECALL_REFRESH_GENERATION_PAGE_SIZE = 16;
 const RECALL_REFRESH_CODE_LINK_GENERATION_PAGE_SIZE = 256;
 const RECALL_REFRESH_SOURCE_PAGE_SIZE = 256;
+const RECALL_REFRESH_SOURCE_GC_INTERVAL = RECALL_REFRESH_SOURCE_PAGE_SIZE * 32;
 const MAX_INDEXED_FILE_BYTES = 512 * 1_024;
 const TEXT_EXTENSIONS = new Set(['.json', '.md', '.mdx', '.txt', '.yaml', '.yml']);
 
@@ -141,7 +142,15 @@ export const scanRecallSources = Effect.fn('recall.scanSources')(function* (
             uri,
           });
           scannedSourceCount += 1;
-          if (pendingSources.length >= RECALL_REFRESH_SOURCE_PAGE_SIZE) yield* flushPendingSources();
+          if (pendingSources.length >= RECALL_REFRESH_SOURCE_PAGE_SIZE) {
+            yield* flushPendingSources();
+            // A 100k-source validation otherwise allocates faster than JSC's
+            // normal collection cadence and retains an avoidable RSS spike.
+            if (scannedSourceCount % RECALL_REFRESH_SOURCE_GC_INTERVAL === 0) {
+              Bun.gc(true);
+              yield* Effect.yieldNow;
+            }
+          }
         }),
     );
   }

--- a/test/evaluation/README.md
+++ b/test/evaluation/README.md
@@ -355,7 +355,7 @@ continuity. It requires zero false-fresh results, zero false deletion from incom
 authoritative leakage, a complete legacy recall result, and responses within the 1,500-token ceiling. Its measured p95
 limits are bounded runtime-smoke ratchets for this small CI fixture. They are not evidence for the separate 100k-symbol,
 50-member, or 128-member scale profiles; governed scale claims require repeated built-artifact benchmark samples on the
-pinned runner.
+reviewed `macos-15`/ARM64/Apple-M1/Bun runner class.
 
 ### Memory-code citation scale gate
 
@@ -366,27 +366,62 @@ SQLite stores before timing. The measured path executes the production query/sto
 validation, Context Brief assembly, and projection. Workset routing uses real published catalog generations; no cold
 repository indexing runs.
 
+The fixture hash covers the stable reviewed budget, source/citation content, repository commits and repository IDs,
+graph content and snapshot IDs, selected memory records, and legacy-noise contract. It deliberately excludes the
+published workset generation digests because those include checkout/worktree IDs derived from each temporary
+materialization path. Both actual generation digests remain separate retained artifact fields, preserving exact run
+provenance without making like-for-like fixture identity nondeterministic.
+
 The profiles are local/96 citations, workset-50/16 cited repositories/64 citations, and workset-128/32 cited
 repositories/96 citations. Every warmup and measured sample selects a different set of canonical schema-v4 memories,
-so validation receipts are not process-cache hits. The artifact records 25-sample p95 latency after five warmups, added
-RSS, selected memories, all validation receipts, distinct graph database paths, production graph-store sessions,
-snapshot leases, effective-evidence batches, snapshot-status observations, active-view fence observations, maintenance
-requests, and cold graph builds. The
-session counter wraps calls that reach the real `CodeGraphStore.withSession` implementation against the prebuilt SQLite
-files; OS file-descriptor opens are not separately counted. The production query boundary owns that session across the
-snapshot selection, lease, evidence read, two-sided active-view fence, and release. Lease, evidence, snapshot-status,
-and active-view-fence operations remain separate counters so session reuse cannot hide fan-out or skipped work.
+so validation receipts are not process-cache hits. Release-scale evidence requires exactly 25 measured samples after
+exactly five warmups. The first-use memory series completes before timing begins, and the observer exits before the
+timing warmups and measured samples run. Timing therefore has no observer or boundary-RSS instrumentation; it records
+p95 latency, selected-memory counts, validation receipts, distinct graph database paths, production
+graph-store sessions, snapshot leases, effective-evidence batches, snapshot-status observations, active-view fence
+observations, maintenance requests, and cold graph builds. The session counter wraps calls that reach the real
+`CodeGraphStore.withSession` implementation against the prebuilt SQLite files; OS file-descriptor opens are not
+separately counted. The production query boundary owns that session across snapshot selection, lease, evidence read,
+two-sided active-view fence, and release. Lease, evidence, snapshot-status, and active-view-fence operations remain
+separate counters so session reuse cannot hide fan-out or skipped work.
+
+Memory uses a distinct untimed production-workload series before any production timing invocation. Before every begin barrier, the benchmark resets graph
+instrumentation and completes a full GC; only then does the external observer acknowledge the immediate baseline. The
+workload runs between acknowledged begin and end barriers. Its complete `memoryWorkload` result is retained and must
+independently pass the same selected-memory, receipt, token, store-session, graph-database, evidence-batch, status,
+active-view, lease, concurrency, maintenance, and no-cold-indexing checks as a timing observation. Boundary-sampled
+current-process RSS is collected only in this memory workload and remains a non-gating allocator diagnostic. After the
+last workload, the benchmark resets instrumentation, completes another full GC, and obtains a required root-only stop
+sample before the observer exits.
+
+The wrapper hashes the built target, and the running target recomputes that SHA-256 before launching the exact same
+bundle in its reserved observer mode. The observer recursively samples the benchmark root and its current descendants
+while excluding its own complete subtree. Every memory observation fails unless its begin baseline contains only the
+root, it has at least three successful samples and no failures, its longest successful-sample gap is at most 100 ms, and
+its root and process-tree peak-minus-immediate-baseline arithmetic is internally consistent. The single-repository
+profile must observe a workload descendant at least once, while each sustained multi-repository Workset profile must do
+so in at least 80% of its 25 memory observations. This distinction keeps the fan-out coverage gate strong without
+claiming that the roughly 45 ms macOS `ps` cadence reliably catches every short-lived local Git child. The fixed 64 MiB ceiling applies independently to
+the maximum sampled transient process-tree growth and to retained root growth, computed from every immediate begin
+baseline plus the post-final-GC stop sample relative to the first baseline.
+
+These measurements are sampled high-water evidence, not exhaustive process-lifetime accounting. A successful snapshot
+recursively accounts for the root and every descendant visible at that instant, excluding the observer subtree, but a
+short-lived child or RSS peak entirely between samples can remain unseen. The three-sample, 100 ms gap, local-capture,
+and Workset 80% descendant-coverage gates bound that risk; they do not justify a claim that every child process or
+absolute peak was observed.
 
 ```sh
 # Scheduled/manual release-quality distribution; ordinary pull-request CI does not run this job.
 bun run bench:context-brief-citations -- \
+  --candidate-commit <exact-40-character-sha> \
   --memory-candidates 100000 \
   --samples 25 \
   --warmups 5 \
   --fail-on-budget \
   --output artifacts/context-brief-citations-scale.json
 
-# Fast orchestration smoke. It records non-comparable evidence and does not pass the frozen scale gate.
+# Fast orchestration smoke. It records development-smoke evidence whose release gate always fails.
 bun run bench:context-brief-citations -- \
   --memory-candidates 200 \
   --profiles local-100k,workset-50,workset-128 \
@@ -397,6 +432,14 @@ bun run bench:context-brief-citations -- \
 The timing label is deliberately narrow: real prebuilt recall and graph SQLite plus the production Context Brief path.
 Git/graph fixture creation, ready-snapshot activation, recall-index construction, workset catalog publication, and cold
 graph indexing are setup evidence, not included in p95. Results must not be presented as cold-indexing performance.
+Release-quality execution also requires an explicit exact candidate commit and proves the checkout is clean, the
+observed commit matches, Git status was successfully observed, and execution is in GitHub Actions on a hosted
+`macos-15` runner with `RUNNER_ENVIRONMENT=github-hosted`, `RUNNER_OS=macOS`, runner class
+`github-hosted-macos-15-ARM64`, arm64 architecture, an Apple-M1-class CPU, `bun/1.3.14`, and `threadnote-4.6.0`. Release
+mode rejects any sample or warmup count other than 25/5. Without `--fail-on-budget`, the artifact is classified as
+`development-smoke` and receives an unconditional gate failure, so local evidence cannot be relabeled as release-scale
+evidence. The fixed-class absolute gate remains an agent-latency objective; a parent-relative same-runner comparison
+cannot replace it.
 
 ## Native code graph contract
 

--- a/test/evaluation/baselines/context-brief-citations-v1/scale-budgets.json
+++ b/test/evaluation/baselines/context-brief-citations-v1/scale-budgets.json
@@ -4,7 +4,7 @@
   "corpusMemoryCandidates": 100000,
   "maximumCitationsPerBrief": 96,
   "maximumEstimatedTokens": 1500,
-  "maximumAddedRssBytes": 67108864,
+  "maximumObservedAddedProcessTreeRssBytes": 67108864,
   "profiles": [
     {
       "id": "local-100k",

--- a/test/unit/code-graph.benchmark-sampler.test.ts
+++ b/test/unit/code-graph.benchmark-sampler.test.ts
@@ -7,6 +7,7 @@ import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {
   aggregateProcessTree,
+  benchmarkSamplerProcessTreeExclusions,
   isOpenTemporaryFilePath,
   mergeTemporaryFileSnapshots,
   observeTemporaryOpenInspection,
@@ -524,9 +525,82 @@ describe('code graph benchmark sampler artifact', () => {
 
     const sample = aggregateProcessTree(entries, 10, 'root');
     expect(sample?.rssBytes).toBe(6_000);
+    expect(sample?.rootRssBytes).toBe(1_000);
     expect([...sample!.processes.keys()]).toEqual(['10:root', '11:child', '12:grandchild']);
     expect(aggregateProcessTree(entries, 10, 'reused-root')).toBeUndefined();
-    expect([...aggregateProcessTree(entries, 10, 'root', 11)!.processes.keys()]).toEqual(['10:root']);
+    expect([...aggregateProcessTree(entries, 10, 'root', [11])!.processes.keys()]).toEqual(['10:root']);
+  });
+
+  it('excludes a verified observer root and its complete subtree from process and RSS evidence', () => {
+    const sample = aggregateProcessTree(
+      [
+        processEntry(10, 1, 'root', 100, 1_000, 10, 20),
+        processEntry(11, 10, 'workload', 50, 2_000, 30, 40),
+        processEntry(12, 11, 'workload-child', 25, 3_000, 50, 60),
+        processEntry(20, 10, 'observer', 5_000, 4_000, 70, 80),
+        processEntry(21, 20, 'observer-child', 6_000, 5_000, 90, 100),
+        processEntry(30, 10, 'second-observer', 7_000, 6_000, 110, 120),
+      ],
+      10,
+      'root',
+      [20, 30],
+    );
+
+    expect(sample).toMatchObject({processIds: [10, 11, 12], rootRssBytes: 1_000, rssBytes: 6_000});
+    expect([...sample!.processes.keys()]).toEqual(['10:root', '11:workload', '12:workload-child']);
+  });
+
+  it('excludes sampler instrumentation only when it belongs to the observed tree', () => {
+    const sample = aggregateProcessTree(
+      [processEntry(10, 1, 'root', 100, 1_000, 10, 20), processEntry(11, 10, 'sampler', 50, 2_000, 30, 40)],
+      10,
+      'root',
+    );
+    expect(benchmarkSamplerProcessTreeExclusions(sample, 11)).toEqual([11]);
+    expect(benchmarkSamplerProcessTreeExclusions(sample, 99)).toEqual([]);
+    expect(benchmarkSamplerProcessTreeExclusions(undefined, 11)).toEqual([]);
+  });
+
+  it('fails closed when an exclusion is invalid, duplicated, the root, or not a descendant', () => {
+    const entries = [
+      processEntry(10, 1, 'root', 100, 1_000, 10, 20),
+      processEntry(11, 10, 'observer', 50, 2_000, 30, 40),
+      processEntry(99, 1, 'unrelated', 25, 3_000, 50, 60),
+    ];
+
+    for (const exclusions of [[0], [-1], [Number.MAX_SAFE_INTEGER + 1], [11, 11], [10], [99], [404]]) {
+      expect(aggregateProcessTree(entries, 10, 'root', exclusions)).toBeUndefined();
+    }
+  });
+
+  it('keeps workload accounting invariant under arbitrary excluded observer subtrees', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({max: 1_000_000, min: 0}),
+        fc.integer({max: 1_000_000, min: 0}),
+        fc.integer({max: 1_000_000, min: 0}),
+        fc.integer({max: 1_000_000, min: 0}),
+        (rootRss, workloadRss, observerRss, observerChildRss) => {
+          const sample = aggregateProcessTree(
+            [
+              processEntry(10, 1, 'root', 100, rootRss, 10, 20),
+              processEntry(11, 10, 'workload', 50, workloadRss, 30, 40),
+              processEntry(20, 10, 'observer', 5_000, observerRss, 70, 80),
+              processEntry(21, 20, 'observer-child', 6_000, observerChildRss, 90, 100),
+            ],
+            10,
+            'root',
+            [20],
+          );
+
+          expect(sample?.processIds).toEqual([10, 11]);
+          expect(sample?.rootRssBytes).toBe(rootRss);
+          expect(sample?.rssBytes).toBe(rootRss + workloadRss);
+          expect([...sample!.processes.keys()]).toEqual(['10:root', '11:workload']);
+        },
+      ),
+      {numRuns: 200},
+    );
   });
 
   it('does not subtract disappeared descendants and counts a reused child PID as a new identity', () => {

--- a/test/unit/context-brief-citation-rss-observer.test.ts
+++ b/test/unit/context-brief-citation-rss-observer.test.ts
@@ -1,0 +1,275 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import type {BenchmarkProcessTreeSample} from '../../scripts/code-graph-benchmark-sampler.js';
+import {
+  CONTEXT_BRIEF_CITATION_RSS_OBSERVER_MODE,
+  applyContextBriefCitationRssRequest,
+  contextBriefCitationRssArtifact,
+  contextBriefCitationRssObserverArguments,
+  isContextBriefCitationRssObserverMode,
+  makeContextBriefCitationRssObserverState,
+  observeContextBriefCitationRssSample,
+  parseContextBriefCitationRssAcknowledgement,
+  parseContextBriefCitationRssArtifact,
+  parseContextBriefCitationRssReady,
+  parseContextBriefCitationRssRequest,
+  type ContextBriefCitationRssObserverState,
+} from '../../scripts/context-brief-citation-rss-observer.js';
+
+describe('Context Brief citation RSS observer protocol', () => {
+  it('round-trips acknowledged begin/end/stop barriers into bounded root and tree evidence', () => {
+    const initial = state();
+    const beginRequest = request('begin', 1, 'workset-128-memory-001');
+    const begun = applyContextBriefCitationRssRequest(initial, beginRequest, attempt(100, sample(100, 100)));
+    expect(begun.acknowledgement).toEqual({
+      observationId: 'workset-128-memory-001',
+      sequence: 1,
+      state: 'begun',
+      version: 1,
+    });
+    expect(
+      applyContextBriefCitationRssRequest(begun.state, beginRequest, attempt(999, sample(999, 999))),
+    ).toMatchObject({replayed: true, state: begun.state});
+
+    const sampled = observeContextBriefCitationRssSample(begun.state, attempt(110, sample(125, 170, 2)));
+    const failed = observeContextBriefCitationRssSample(sampled, {
+      attempts: 1,
+      failures: 1,
+      observedAtMilliseconds: 115,
+    });
+    const ended = applyContextBriefCitationRssRequest(
+      failed,
+      request('end', 2, 'workset-128-memory-001'),
+      attempt(120, sample(120, 150), 2, 1),
+    );
+    expect(() =>
+      applyContextBriefCitationRssRequest(ended.state, {operation: 'stop', sequence: 3, version: 1}),
+    ).toThrow(/barriers require a process-tree sample/u);
+    const stopped = applyContextBriefCitationRssRequest(
+      ended.state,
+      {operation: 'stop', sequence: 3, version: 1},
+      attempt(130, sample(110, 110)),
+    );
+    const artifact = contextBriefCitationRssArtifact(stopped.state);
+
+    expect(artifact).toMatchObject({
+      maximumSampleGapMilliseconds: 10,
+      finalSample: {
+        processCount: 1,
+        rootRssBytes: 110,
+        sampleAttempts: 1,
+        sampleFailures: 0,
+        treeRssBytes: 110,
+      },
+      observerExcluded: true,
+      processCountPeakObserved: 2,
+      rootIdentityValidation: 'linux-proc-starttime',
+      rootStartIdentity: '4242',
+      sampleAttempts: 6,
+      sampleFailures: 2,
+      scope: 'recursive-process-tree',
+      source: 'linux-proc',
+      successfulSamples: 4,
+      version: 1,
+    });
+    expect(artifact.observations).toEqual([
+      {
+        durationMilliseconds: 20,
+        maximumSampleGapMilliseconds: 10,
+        observationId: 'workset-128-memory-001',
+        processCountBaseline: 1,
+        processCountPeakObserved: 2,
+        rootRssBaselineBytes: 100,
+        rootRssGrowthObservedBytes: 25,
+        rootRssPeakObservedBytes: 125,
+        sampleAttempts: 5,
+        sampleFailures: 2,
+        successfulSamples: 3,
+        treeRssBaselineBytes: 100,
+        treeRssGrowthObservedBytes: 70,
+        treeRssPeakObservedBytes: 170,
+      },
+    ]);
+    expect(parseContextBriefCitationRssArtifact(JSON.parse(JSON.stringify(artifact)))).toEqual(artifact);
+  });
+
+  it('fails closed on sequence gaps, conflicting duplicates, cross-observation ends, and active stops', () => {
+    const initial = state();
+    expect(() =>
+      applyContextBriefCitationRssRequest(
+        initial,
+        request('begin', 2, 'local-100k-memory-001'),
+        attempt(1, sample(10, 10)),
+      ),
+    ).toThrow(/sequence is not contiguous/u);
+    const begun = applyContextBriefCitationRssRequest(
+      initial,
+      request('begin', 1, 'local-100k-memory-001'),
+      attempt(1, sample(10, 10)),
+    );
+    expect(() =>
+      applyContextBriefCitationRssRequest(begun.state, request('begin', 1, 'local-100k-memory-002')),
+    ).toThrow(/conflicting duplicate/u);
+    expect(() =>
+      applyContextBriefCitationRssRequest(
+        begun.state,
+        request('end', 2, 'local-100k-memory-002'),
+        attempt(2, sample(10, 10)),
+      ),
+    ).toThrow(/does not match/u);
+    expect(() =>
+      applyContextBriefCitationRssRequest(begun.state, {operation: 'stop', sequence: 2, version: 1}),
+    ).toThrow(/active observation/u);
+    expect(() => observeContextBriefCitationRssSample(begun.state, attempt(0, sample(10, 10)))).toThrow(
+      /time moved backwards/u,
+    );
+  });
+
+  it('rejects malformed or internally inconsistent wire evidence', () => {
+    expect(() =>
+      parseContextBriefCitationRssRequest({...request('begin', 1, 'local-100k-memory-001'), extra: 1}),
+    ).toThrow(/fields are invalid/u);
+    expect(() => parseContextBriefCitationRssAcknowledgement({sequence: 1, state: 'begun', version: 1})).toThrow(
+      /fields are invalid/u,
+    );
+    expect(() => parseContextBriefCitationRssAcknowledgement({sequence: 514, state: 'stopped', version: 1})).toThrow(
+      /protocol bound/u,
+    );
+    expect(() =>
+      parseContextBriefCitationRssReady({
+        intervalMilliseconds: 10,
+        observerExcluded: true,
+        rootIdentityValidation: 'darwin-ps-lstart',
+        rootStartIdentity: '4242',
+        scope: 'recursive-process-tree',
+        source: 'linux-proc',
+        state: 'ready',
+        version: 1,
+      }),
+    ).toThrow(/do not match/u);
+
+    const artifact = oneObservationArtifact();
+    expect(() =>
+      parseContextBriefCitationRssArtifact({...artifact, sampleAttempts: artifact.sampleAttempts + 1}),
+    ).toThrow(/sampleAttempts is inconsistent/u);
+    expect(() =>
+      parseContextBriefCitationRssArtifact({
+        ...artifact,
+        observations: [{...artifact.observations[0], treeRssGrowthObservedBytes: 999}],
+      }),
+    ).toThrow(/growth is inconsistent/u);
+    expect(() =>
+      parseContextBriefCitationRssArtifact({
+        ...artifact,
+        finalSample: {...artifact.finalSample, rootRssBytes: artifact.finalSample.treeRssBytes + 1},
+      }),
+    ).toThrow(/final root RSS exceeds tree RSS/u);
+  });
+
+  it('keeps observed growth translation-invariant and equal to the independent maximum model', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({max: 1_000_000_000, min: 1}),
+        fc.integer({max: 1_000_000, min: 0}),
+        fc.array(
+          fc.record({
+            childBytes: fc.integer({max: 8_000_000, min: 0}),
+            rootGrowthBytes: fc.integer({max: 8_000_000, min: 0}),
+          }),
+          {maxLength: 20, minLength: 1},
+        ),
+        (translation, baseline, observations) => {
+          const original = modeledArtifact(baseline, observations);
+          const translated = modeledArtifact(baseline + translation, observations);
+          const maximumRootGrowth = Math.max(0, ...observations.map(value => value.rootGrowthBytes));
+          const maximumTreeGrowth = Math.max(0, ...observations.map(value => value.rootGrowthBytes + value.childBytes));
+          expect(original.observations[0]?.rootRssGrowthObservedBytes).toBe(maximumRootGrowth);
+          expect(original.observations[0]?.treeRssGrowthObservedBytes).toBe(maximumTreeGrowth);
+          expect(translated.observations[0]?.rootRssGrowthObservedBytes).toBe(maximumRootGrowth);
+          expect(translated.observations[0]?.treeRssGrowthObservedBytes).toBe(maximumTreeGrowth);
+          expect(translated.sampleAttempts).toBe(original.sampleAttempts);
+          expect(translated.maximumSampleGapMilliseconds).toBe(original.maximumSampleGapMilliseconds);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it('builds a reserved same-bundle observer invocation without serializing paths into evidence', () => {
+    const args = contextBriefCitationRssObserverArguments({
+      acknowledgementPath: '/tmp/private-ack',
+      barrierTimeoutMilliseconds: 5_000,
+      intervalMilliseconds: 10,
+      outputPath: '/tmp/private-output',
+      readyPath: '/tmp/private-ready',
+      requestPath: '/tmp/private-request',
+      rootProcessId: 42,
+    });
+    expect(args[0]).toBe(CONTEXT_BRIEF_CITATION_RSS_OBSERVER_MODE);
+    expect(isContextBriefCitationRssObserverMode(args)).toBe(true);
+    expect(isContextBriefCitationRssObserverMode(['--user-option'])).toBe(false);
+    expect(JSON.stringify(oneObservationArtifact())).not.toContain('/tmp/private');
+  });
+});
+
+function modeledArtifact(
+  baseline: number,
+  observations: readonly {readonly childBytes: number; readonly rootGrowthBytes: number}[],
+) {
+  let current = applyContextBriefCitationRssRequest(
+    state(),
+    request('begin', 1, 'local-100k-memory-001'),
+    attempt(0, sample(baseline, baseline)),
+  ).state;
+  for (const [index, observation] of observations.entries()) {
+    const root = baseline + observation.rootGrowthBytes;
+    current = observeContextBriefCitationRssSample(
+      current,
+      attempt(index + 1, sample(root, root + observation.childBytes, observation.childBytes > 0 ? 2 : 1)),
+    );
+  }
+  const endAt = observations.length + 1;
+  current = applyContextBriefCitationRssRequest(
+    current,
+    request('end', 2, 'local-100k-memory-001'),
+    attempt(endAt, sample(baseline, baseline)),
+  ).state;
+  current = applyContextBriefCitationRssRequest(
+    current,
+    {operation: 'stop', sequence: 3, version: 1},
+    attempt(endAt + 1, sample(baseline, baseline)),
+  ).state;
+  return contextBriefCitationRssArtifact(current);
+}
+
+function oneObservationArtifact() {
+  return modeledArtifact(100, [{childBytes: 50, rootGrowthBytes: 25}]);
+}
+
+function state(): ContextBriefCitationRssObserverState {
+  return makeContextBriefCitationRssObserverState({
+    intervalMilliseconds: 10,
+    rootIdentityValidation: 'linux-proc-starttime',
+    rootStartIdentity: '4242',
+    source: 'linux-proc',
+  });
+}
+
+function request(operation: 'begin' | 'end', sequence: number, observationId: string) {
+  return {observationId, operation, sequence, version: 1 as const};
+}
+
+function attempt(observedAtMilliseconds: number, observed: BenchmarkProcessTreeSample, attempts = 1, failures = 0) {
+  return {attempts, failures, observedAtMilliseconds, sample: observed};
+}
+
+function sample(rootRssBytes: number, rssBytes: number, processCount = 1): BenchmarkProcessTreeSample {
+  const processIds = Array.from({length: processCount}, (_, index) => index + 10);
+  return {
+    processIds,
+    processes: new Map(processIds.map(processId => [`${processId}:${processId}`, {cpuMilliseconds: 0}])),
+    rootRssBytes,
+    rootStartIdentity: '4242',
+    rssBytes,
+  };
+}

--- a/test/unit/context-brief-citation-rss-parent.test.ts
+++ b/test/unit/context-brief-citation-rss-parent.test.ts
@@ -1,0 +1,227 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, Exit, Fiber} from 'effect';
+import {TestClock} from 'effect/testing';
+import {
+  makeContextBriefCitationRssObserverController,
+  terminateContextBriefCitationRssProcess,
+  validateContextBriefCitationRssAcknowledgement,
+  validateContextBriefCitationRssBundleDigest,
+  waitForContextBriefCitationRssReady,
+} from '../../scripts/benchmark-context-brief-citations-target.js';
+import type {
+  ContextBriefCitationRssAcknowledgementV1,
+  ContextBriefCitationRssArtifactV1,
+  ContextBriefCitationRssReadyV1,
+} from '../../scripts/context-brief-citation-rss-observer.js';
+import {ScriptError} from '../../scripts/effect/errors.js';
+
+describe('Context Brief citation RSS parent controller', () => {
+  it.effect('rejects a same-bundle digest mismatch before controller startup', () =>
+    Effect.gen(function* () {
+      const observed = 'a'.repeat(64);
+      const expected = 'b'.repeat(64);
+      const error = yield* validateContextBriefCitationRssBundleDigest(observed, expected).pipe(Effect.flip);
+
+      expect(error.message).toContain(`target digest ${observed}; expected ${expected}`);
+      yield* validateContextBriefCitationRssBundleDigest(expected, expected);
+    }),
+  );
+
+  it.effect('fails immediately on early child exit and deterministically on ready timeout', () =>
+    Effect.gen(function* () {
+      const earlyExit = yield* waitForContextBriefCitationRssReady({
+        childExitCode: () => 17,
+        readReady: Effect.succeed(undefined),
+        stderr: Promise.resolve('early diagnostic'),
+        timeoutMilliseconds: 100,
+      }).pipe(Effect.flip);
+      expect(earlyExit.message).toContain('exited before ready: early diagnostic');
+
+      let polls = 0;
+      const timeoutFiber = yield* waitForContextBriefCitationRssReady({
+        childExitCode: () => null,
+        readReady: Effect.sync(() => {
+          polls += 1;
+          return undefined;
+        }),
+        stderr: Promise.resolve(''),
+        timeoutMilliseconds: 100,
+      }).pipe(Effect.flip, Effect.forkChild({startImmediately: true}));
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust(100);
+      const timeout = yield* Fiber.join(timeoutFiber);
+
+      expect(timeout.message).toContain('Timed out waiting');
+      expect(polls).toBeGreaterThan(1);
+    }),
+  );
+
+  it.effect('rejects every non-exact acknowledgement dimension', () =>
+    Effect.gen(function* () {
+      const request = {observationId: 'local-100k-0', operation: 'begin', sequence: 1, version: 1} as const;
+      const valid = {
+        observationId: request.observationId,
+        sequence: request.sequence,
+        state: 'begun',
+        version: 1,
+      } as const;
+      yield* validateContextBriefCitationRssAcknowledgement(request, 'begun', valid);
+
+      const mismatches: readonly ContextBriefCitationRssAcknowledgementV1[] = [
+        {...valid, sequence: 2},
+        {...valid, state: 'ended'},
+        {...valid, observationId: 'local-100k-1'},
+      ];
+      for (const acknowledgement of mismatches) {
+        const error = yield* validateContextBriefCitationRssAcknowledgement(request, 'begun', acknowledgement).pipe(
+          Effect.flip,
+        );
+        expect(error.message).toContain('mismatched barrier');
+      }
+    }),
+  );
+
+  it.effect('closes the child after begin, use, or end failure while preserving end cleanup after use begins', () =>
+    Effect.gen(function* () {
+      for (const failure of ['begin', 'use', 'end'] as const) {
+        const harness = controllerHarness({barrierFailure: failure === 'use' ? undefined : failure});
+        const use = Effect.gen(function* () {
+          harness.events.push('use');
+          if (failure === 'use') return yield* Effect.fail(new ScriptError('use failed'));
+        });
+        const result = yield* Effect.acquireUseRelease(
+          Effect.succeed(harness.controller),
+          controller => controller.observe('local-100k-0', use),
+          controller => controller.close,
+        ).pipe(Effect.exit);
+
+        expect(Exit.isFailure(result)).toBe(true);
+        expect(harness.events.at(-1)).toBe('terminate');
+        if (failure === 'begin') {
+          expect(harness.events).toEqual(['barrier:begin', 'terminate']);
+        } else {
+          expect(harness.events).toEqual(['barrier:begin', 'use', 'barrier:end', 'terminate']);
+        }
+      }
+    }),
+  );
+
+  it.effect('orders stop, confirmed exit, and artifact read and rejects ready-contract drift', () =>
+    Effect.gen(function* () {
+      const successful = controllerHarness();
+      expect(yield* successful.controller.finish).toEqual(artifact());
+      expect(successful.events).toEqual(['barrier:stop', 'wait-exit', 'read-artifact']);
+      yield* successful.controller.close;
+      expect(successful.events).not.toContain('terminate');
+
+      const drifted = controllerHarness({artifact: artifact({rootStartIdentity: 'different-root'})});
+      const error = yield* drifted.controller.finish.pipe(Effect.flip);
+      expect(error.message).toContain('changed its ready contract');
+      expect(drifted.events).toEqual(['barrier:stop', 'wait-exit', 'read-artifact']);
+    }),
+  );
+
+  it.effect('escalates TERM to KILL and succeeds only after confirmed child exit', () =>
+    Effect.gen(function* () {
+      let exitCode: number | null = null;
+      let waits = 0;
+      const signals: Array<'TERM' | 9> = [];
+      yield* terminateContextBriefCitationRssProcess({
+        exitCode: () => exitCode,
+        kill: signal => signals.push(signal === 9 ? 9 : 'TERM'),
+        waitForExit: async () => {
+          waits += 1;
+          if (waits === 1) return undefined;
+          exitCode = 137;
+          return exitCode;
+        },
+      });
+      expect(signals).toEqual(['TERM', 9]);
+      expect(exitCode).toBe(137);
+
+      const unconfirmedSignals: Array<'TERM' | 9> = [];
+      const error = yield* terminateContextBriefCitationRssProcess({
+        exitCode: () => null,
+        kill: signal => unconfirmedSignals.push(signal === 9 ? 9 : 'TERM'),
+        waitForExit: () => Promise.resolve(undefined),
+      }).pipe(Effect.flip);
+      expect(unconfirmedSignals).toEqual(['TERM', 9]);
+      expect(error.message).toContain('could not be confirmed stopped');
+    }),
+  );
+});
+
+function controllerHarness(
+  options: {
+    readonly artifact?: ContextBriefCitationRssArtifactV1;
+    readonly barrierFailure?: 'begin' | 'end';
+  } = {},
+) {
+  const events: string[] = [];
+  let exitCode: number | null = null;
+  const controller = makeContextBriefCitationRssObserverController({
+    barrier: request =>
+      Effect.gen(function* () {
+        events.push(`barrier:${request.operation}`);
+        if (request.operation === options.barrierFailure) {
+          return yield* Effect.fail(new ScriptError(`${request.operation} failed`));
+        }
+      }),
+    childExitCode: () => exitCode,
+    exitWithin: Effect.sync(() => {
+      events.push('wait-exit');
+      exitCode = 0;
+      return 0;
+    }),
+    readArtifact: Effect.sync(() => {
+      events.push('read-artifact');
+      return options.artifact ?? artifact();
+    }),
+    ready: ready(),
+    stderr: Promise.resolve(''),
+    terminate: Effect.sync(() => {
+      events.push('terminate');
+      exitCode = 143;
+    }),
+  });
+  return {controller, events};
+}
+
+function ready(): ContextBriefCitationRssReadyV1 {
+  return {
+    intervalMilliseconds: 10,
+    observerExcluded: true,
+    rootIdentityValidation: 'linux-proc-starttime',
+    rootStartIdentity: '4242',
+    scope: 'recursive-process-tree',
+    source: 'linux-proc',
+    state: 'ready',
+    version: 1,
+  };
+}
+
+function artifact(overrides: Partial<ContextBriefCitationRssArtifactV1> = {}): ContextBriefCitationRssArtifactV1 {
+  return {
+    finalSample: {
+      processCount: 1,
+      rootRssBytes: 100,
+      sampleAttempts: 1,
+      sampleFailures: 0,
+      treeRssBytes: 100,
+    },
+    intervalMilliseconds: 10,
+    maximumSampleGapMilliseconds: 0,
+    observations: [],
+    observerExcluded: true,
+    processCountPeakObserved: 1,
+    rootIdentityValidation: 'linux-proc-starttime',
+    rootStartIdentity: '4242',
+    sampleAttempts: 1,
+    sampleFailures: 0,
+    scope: 'recursive-process-tree',
+    source: 'linux-proc',
+    successfulSamples: 1,
+    version: 1,
+    ...overrides,
+  };
+}

--- a/test/unit/context-brief-citation-scale-benchmark.test.ts
+++ b/test/unit/context-brief-citation-scale-benchmark.test.ts
@@ -2,13 +2,23 @@ import * as yaml from 'js-yaml';
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {
+  CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE,
+  CONTEXT_BRIEF_CITATION_SCALE_EXECUTION_V2,
   CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS,
+  CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNNER_CLASS,
   contextBriefCitationScaleGate,
+  contextBriefCitationScaleReleaseIdentityFailures,
+  contextBriefCitationScaleRetainedRootRssGrowthBytes,
   evaluateContextBriefCitationScaleProfile,
+  parseContextBriefCitationScaleArtifactV2,
   parseContextBriefCitationScaleBudgetV1,
+  type ContextBriefCitationScaleArtifactV2,
   type ContextBriefCitationScaleCountersV1,
-  type ContextBriefCitationScaleObservationV1,
+  type ContextBriefCitationScaleMeasuredObservationV2,
+  type ContextBriefCitationScaleMemoryObservationV2,
+  type ContextBriefCitationScaleObservationV2,
   type ContextBriefCitationScaleProfileV1,
+  type ContextBriefCitationScaleReleaseIdentityV1,
 } from '../../src/evaluation/context-brief-citation-scale-contract.js';
 import {parseContextBriefCitationScaleBenchmarkArguments} from '../../scripts/benchmark-context-brief-citations-target.js';
 
@@ -18,6 +28,7 @@ const budget = parseContextBriefCitationScaleBudgetV1(
   ) as unknown,
 );
 const benchmarkWorkflow = await Bun.file('.github/workflows/benchmarks.yml').text();
+const scaleEvaluationSource = await Bun.file('src/evaluation/context-brief-citation-scale.ts').text();
 
 describe('Context Brief citation scale benchmark', () => {
   it('pins the reviewed 100k / 50 / 128 envelope and built-target defaults', () => {
@@ -25,6 +36,7 @@ describe('Context Brief citation scale benchmark', () => {
       corpusMemoryCandidates: 100_000,
       maximumCitationsPerBrief: 96,
       maximumEstimatedTokens: 1_500,
+      maximumObservedAddedProcessTreeRssBytes: 64 * 1_024 * 1_024,
       profiles: [
         {citationCount: 96, citedRepositories: 1, id: 'local-100k', worksetMembers: 1},
         {citationCount: 64, citedRepositories: 16, id: 'workset-50', worksetMembers: 50},
@@ -38,6 +50,222 @@ describe('Context Brief citation scale benchmark', () => {
         samples: 25,
         warmups: 5,
       },
+    );
+    expect(
+      parseContextBriefCitationScaleBenchmarkArguments([
+        '--built-artifact-sha256',
+        'a'.repeat(64),
+        '--candidate-commit',
+        'b'.repeat(40),
+      ]),
+    ).toMatchObject({candidateCommit: 'b'.repeat(40)});
+  });
+
+  it('fails closed when any release-runner identity field is relabeled', () => {
+    const identity: ContextBriefCitationScaleReleaseIdentityV1 = {
+      architecture: 'arm64',
+      candidateCommit: 'a'.repeat(40),
+      commit: 'a'.repeat(40),
+      cpu: 'Apple M1',
+      dirty: false,
+      gitStatusObserved: true,
+      githubActions: true,
+      operatingSystem: 'macOS 15.6.1',
+      runnerClass: CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNNER_CLASS,
+      runnerArchitecture: 'ARM64',
+      runnerEnvironment: 'github-hosted',
+      runnerOperatingSystem: 'macOS',
+      runtime: 'bun/1.3.14',
+      sourceVersion: 'threadnote-4.6.0',
+    };
+    expect(contextBriefCitationScaleReleaseIdentityFailures(identity)).toEqual([]);
+    fc.assert(
+      fc.property(
+        fc.constantFrom<keyof ContextBriefCitationScaleReleaseIdentityV1>(
+          'architecture',
+          'candidateCommit',
+          'commit',
+          'cpu',
+          'dirty',
+          'gitStatusObserved',
+          'githubActions',
+          'operatingSystem',
+          'runnerClass',
+          'runnerArchitecture',
+          'runnerEnvironment',
+          'runnerOperatingSystem',
+          'runtime',
+          'sourceVersion',
+        ),
+        key => {
+          const invalid = {
+            ...identity,
+            [key]:
+              key === 'dirty'
+                ? true
+                : key === 'gitStatusObserved' || key === 'githubActions'
+                  ? false
+                  : key === 'commit'
+                    ? 'b'.repeat(40)
+                    : 'invalid',
+          } as ContextBriefCitationScaleReleaseIdentityV1;
+          expect(contextBriefCitationScaleReleaseIdentityFailures(invalid).length).toBeGreaterThan(0);
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  it('gates externally observed process-tree RSS while retaining boundary RSS as diagnostics', () => {
+    const profile = budget.profiles.find(candidate => candidate.id === 'local-100k')!;
+    const boundaryOutlier = scaleObservation(
+      profile,
+      {},
+      {boundaryAddedRssBytes: 512 * 1_024 * 1_024},
+      {observedAddedProcessTreeRssBytes: 32 * 1_024 * 1_024},
+    );
+    const accepted = evaluateContextBriefCitationScaleProfile(budget, profile.id, boundaryOutlier, [boundaryOutlier]);
+    expect(accepted.failures).toEqual([]);
+    expect(accepted.result.measurements.boundaryAddedRssBytes.maximum).toBe(512 * 1_024 * 1_024);
+
+    const peakRegression = scaleObservation(
+      profile,
+      {},
+      {},
+      {observedAddedProcessTreeRssBytes: 64 * 1_024 * 1_024 + 1},
+    );
+    const rejected = evaluateContextBriefCitationScaleProfile(budget, profile.id, peakRegression, [peakRegression]);
+    expect(rejected.failures).toContain(
+      `local-100k observed added process-tree RSS ${64 * 1_024 * 1_024 + 1} exceeds ${64 * 1_024 * 1_024}`,
+    );
+  });
+
+  it('fails closed when a claimed OS peak growth is not derivable from its fixed baseline', () => {
+    const profile = budget.profiles.find(candidate => candidate.id === 'local-100k')!;
+    fc.assert(
+      fc.property(
+        fc.integer({min: 1, max: 2_000_000_000}),
+        fc.integer({min: 0, max: 64 * 1_024 * 1_024}),
+        (baseline, growth) => {
+          const valid = scaleObservation(
+            profile,
+            {},
+            {},
+            {
+              observedAddedProcessTreeRssBytes: growth,
+              observedAddedRootRssBytes: 0,
+              observedProcessTreeRssBaselineBytes: baseline,
+              observedProcessTreeRssPeakBytes: baseline + growth,
+              observedRootRssBaselineBytes: baseline,
+              observedRootRssPeakBytes: baseline,
+            },
+          );
+          expect(evaluateContextBriefCitationScaleProfile(budget, profile.id, valid, [valid]).failures).toEqual([]);
+          const tampered = {
+            ...valid,
+            memory: {
+              ...valid.memory,
+              observedAddedProcessTreeRssBytes: growth === 0 ? 1 : growth - 1,
+            },
+          };
+          expect(evaluateContextBriefCitationScaleProfile(budget, profile.id, tampered, [tampered]).failures).toContain(
+            'local-100k memory observation 0 has inconsistent process-tree RSS evidence',
+          );
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  it('requires a local descendant capture and 80% coverage for sustained workset fan-out', () => {
+    const localProfile = budget.profiles.find(candidate => candidate.id === 'local-100k')!;
+    const observations = Array.from({length: 5}, (_, ordinal) =>
+      scaleObservation(
+        localProfile,
+        {},
+        {},
+        {
+          observationId: `local-100k-${ordinal}`,
+          ordinal,
+          peakProcessCount: ordinal === 0 ? 1 : 2,
+        },
+      ),
+    );
+    const accepted = evaluateContextBriefCitationScaleProfile(
+      budget,
+      localProfile.id,
+      scaleObservation(localProfile),
+      observations,
+    );
+    expect(accepted.failures).toEqual([]);
+    expect(accepted.result.memoryCoverage).toMatchObject({
+      descendantObservationCount: 4,
+      descendantObservationRate: 0.8,
+    });
+
+    const noLocalDescendants = observations.map(observation => ({
+      ...observation,
+      memory: {...observation.memory, peakProcessCount: 1},
+    }));
+    expect(
+      evaluateContextBriefCitationScaleProfile(
+        budget,
+        localProfile.id,
+        scaleObservation(localProfile),
+        noLocalDescendants,
+      ).failures,
+    ).toContain(
+      'local-100k observed workload descendants in 0/5 memory observations; required at least one sampled descendant',
+    );
+
+    const worksetProfile = budget.profiles.find(candidate => candidate.id === 'workset-50')!;
+    const worksetObservations = observations.map((_, ordinal) =>
+      scaleObservation(
+        worksetProfile,
+        {},
+        {},
+        {
+          observationId: `workset-50-${ordinal}`,
+          ordinal,
+          peakProcessCount: ordinal === 0 ? 1 : 2,
+        },
+      ),
+    );
+    expect(
+      evaluateContextBriefCitationScaleProfile(
+        budget,
+        worksetProfile.id,
+        scaleObservation(worksetProfile),
+        worksetObservations,
+      ).failures,
+    ).toEqual([]);
+    const underObservedWorkset = worksetObservations.map((observation, ordinal) =>
+      ordinal === 1 ? {...observation, memory: {...observation.memory, peakProcessCount: 1}} : observation,
+    );
+    expect(
+      evaluateContextBriefCitationScaleProfile(
+        budget,
+        worksetProfile.id,
+        scaleObservation(worksetProfile),
+        underObservedWorkset,
+      ).failures,
+    ).toContain('workset-50 observed workload descendants in 3/5 memory observations; required at least 80%');
+  });
+
+  it('measures retained root growth from the first memory baseline and is offset-invariant', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.integer({min: 0, max: 1_000_000}), {maxLength: 50, minLength: 1}),
+        fc.integer({min: 0, max: 1_000_000}),
+        (baselines, offset) => {
+          const expected = Math.max(0, Math.max(...baselines) - baselines[0]!);
+          expect(contextBriefCitationScaleRetainedRootRssGrowthBytes(baselines)).toBe(expected);
+          expect(contextBriefCitationScaleRetainedRootRssGrowthBytes(baselines.map(value => value + offset))).toBe(
+            expected,
+          );
+        },
+      ),
+      {numRuns: 100},
     );
   });
 
@@ -65,8 +293,13 @@ describe('Context Brief citation scale benchmark', () => {
     const profile = budget.profiles.find(candidate => candidate.id === 'workset-50')!;
     fc.assert(
       fc.property(fc.shuffledSubarray([1, 2, 3, 4, 5], {maxLength: 5, minLength: 5}), order => {
-        const observations = order.map(value =>
-          scaleObservation(profile, {}, {contextBriefMilliseconds: value * 10, validationMilliseconds: value}),
+        const observations = order.map((value, index) =>
+          scaleObservation(
+            profile,
+            {},
+            {contextBriefMilliseconds: value * 10, validationMilliseconds: value},
+            {observationId: `workset-50-${index}`, ordinal: index},
+          ),
         );
         const forward = evaluateContextBriefCitationScaleProfile(
           budget,
@@ -90,23 +323,72 @@ describe('Context Brief citation scale benchmark', () => {
     );
   });
 
+  it('accepts a complete v2 artifact and rejects bounded single-field evidence tampering', () => {
+    const artifact = scaleArtifact();
+    expect(parseContextBriefCitationScaleArtifactV2(artifact, budget)).toEqual(artifact);
+
+    fc.assert(
+      fc.property(
+        fc.constantFrom<ArtifactTamperTarget>(
+          'claimed-profile-aggregate',
+          'execution-contract',
+          'final-retained-sample',
+          'gate-decision',
+          'memory-observation',
+          'memory-observer-summary',
+          'memory-workload',
+          'workset-generation-digest',
+        ),
+        fc.integer({max: CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS.length - 1, min: 0}),
+        fc.integer({max: 1_000_000, min: 1}),
+        (target, profileIndex, delta) => {
+          expect(() =>
+            parseContextBriefCitationScaleArtifactV2(
+              tamperScaleArtifact(artifact, target, profileIndex, delta),
+              budget,
+            ),
+          ).toThrow();
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it('runs first-use memory evidence before observer-free timing', () => {
+    const memoryPhase = scaleEvaluationSource.indexOf('const rssEvidence = yield* Effect.acquireUseRelease');
+    const timingPhase = scaleEvaluationSource.indexOf('const timingProfiles = new Map');
+    expect(memoryPhase).toBeGreaterThan(-1);
+    expect(timingPhase).toBeGreaterThan(memoryPhase);
+  });
+
   it('runs only by schedule or explicit opt-in and retains the built scale artifact', () => {
     const workflow = yaml.load(benchmarkWorkflow) as {
-      readonly jobs: Readonly<Record<string, {readonly if?: string; readonly steps?: readonly WorkflowStep[]}>>;
+      readonly jobs: Readonly<
+        Record<string, {readonly if?: string; readonly 'runs-on'?: string; readonly steps?: readonly WorkflowStep[]}>
+      >;
       readonly on: {readonly workflow_dispatch?: {readonly inputs?: Readonly<Record<string, unknown>>}};
     };
     const job = workflow.jobs['context-brief-citations-scale']!;
     const benchmarkStep = job.steps?.find(step => step.run?.includes('bench:context-brief-citations'));
+    const checkout = job.steps?.find(step => step.uses === 'actions/checkout@v7');
     const command = benchmarkStep?.run ?? '';
     const upload = job.steps?.find(step => step.uses?.startsWith('actions/upload-artifact'));
     expect(workflow.on.workflow_dispatch?.inputs).toHaveProperty('include_context_brief_citations_scale');
     expect(job.if).toContain("github.event_name == 'schedule'");
     expect(job.if).toContain('inputs.include_context_brief_citations_scale');
+    expect(job['runs-on']).toBe('macos-15');
+    expect(checkout?.with).toMatchObject({
+      'persist-credentials': false,
+      ref: '${{ github.sha }}',
+    });
+    expect(command).toContain('--candidate-commit "${{ github.sha }}"');
     expect(command).toContain('--memory-candidates 100000');
     expect(command).toContain('--samples 25');
     expect(command).toContain('--warmups 5');
     expect(command).toContain('--fail-on-budget');
-    expect(benchmarkStep?.env?.THREADNOTE_BENCHMARK_RUNNER_CLASS).toBe('github-hosted-ubuntu-24.04-${{ runner.arch }}');
+    expect(benchmarkStep?.env?.THREADNOTE_BENCHMARK_RUNNER_CLASS).toBe(
+      CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNNER_CLASS,
+    );
     expect(upload?.with?.['retention-days']).toBe(90);
   });
 });
@@ -118,13 +400,201 @@ interface WorkflowStep {
   readonly with?: Readonly<Record<string, unknown>>;
 }
 
+type ArtifactTamperTarget =
+  | 'claimed-profile-aggregate'
+  | 'execution-contract'
+  | 'final-retained-sample'
+  | 'gate-decision'
+  | 'memory-observation'
+  | 'memory-observer-summary'
+  | 'memory-workload'
+  | 'workset-generation-digest';
+
+function scaleArtifact(): ContextBriefCitationScaleArtifactV2 {
+  const profiles = budget.profiles.map(profile => {
+    const observation = scaleObservation(profile, {}, {}, {observationId: `context-rss-${profile.id}-0`});
+    return evaluateContextBriefCitationScaleProfile(budget, profile.id, observation.memoryWorkload, [observation])
+      .result;
+  });
+  return {
+    createdAt: '2026-08-29T00:00:00.000Z',
+    environment: {
+      architecture: 'arm64',
+      candidateCommit: 'unclaimed',
+      commit: 'a'.repeat(40),
+      cpu: 'Apple M1 Max',
+      dirty: true,
+      gitStatusObserved: true,
+      githubActions: false,
+      memoryBytes: 64 * 1_024 * 1_024 * 1_024,
+      operatingSystem: 'macOS 27.0',
+      runnerArchitecture: 'arm64',
+      runnerClass: 'local-unpinned',
+      runnerEnvironment: 'local',
+      runnerOperatingSystem: 'darwin',
+      runtime: 'bun/1.3.14',
+      sourceVersion: 'threadnote-4.6.0',
+    },
+    evidenceClass: 'development-smoke',
+    execution: {builtArtifactSha256: 'b'.repeat(64), ...CONTEXT_BRIEF_CITATION_SCALE_EXECUTION_V2},
+    fixture: {
+      hash: 'c'.repeat(64),
+      indexedMemoryCandidates: 200,
+      legacyV1MemoryCandidates: 128,
+      readyGraphSetupMilliseconds: 1,
+      recallIndexBuildMilliseconds: 1,
+      requestedMemoryCandidates: 200,
+      worksetGenerationDigests: ['d'.repeat(64), 'e'.repeat(64)],
+      worksetRepositoryIdentities: [50, 128],
+    },
+    gate: contextBriefCitationScaleGate([
+      'artifact is a development smoke, not release-scale evidence',
+      'indexed memory corpus 200; required 100000',
+    ]),
+    memoryObserver: {
+      finalSample: {
+        processCount: 1,
+        rootRssBytes: 512 * 1_024 * 1_024,
+        sampleAttempts: 1,
+        sampleFailures: 0,
+        treeRssBytes: 512 * 1_024 * 1_024,
+      },
+      intervalMilliseconds: 25,
+      maximumSampleGapMilliseconds: 25,
+      observationCount: 3,
+      observerExcluded: true,
+      processCountPeakObserved: 2,
+      retainedRootRssGrowthBytes: 0,
+      rootIdentityValidation: 'darwin-ps-lstart',
+      rootStartIdentity: 'root-start',
+      sampleAttempts: 10,
+      sampleFailures: 0,
+      scope: 'recursive-process-tree',
+      source: 'darwin-ps',
+      successfulSamples: 10,
+      version: 1,
+    },
+    profiles,
+    samples: 1,
+    suite: CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE,
+    version: 2,
+    warmups: 0,
+  };
+}
+
+function tamperScaleArtifact(
+  artifact: ContextBriefCitationScaleArtifactV2,
+  target: ArtifactTamperTarget,
+  profileIndex: number,
+  delta: number,
+): unknown {
+  if (target === 'claimed-profile-aggregate') {
+    return {
+      ...artifact,
+      profiles: artifact.profiles.map((candidate, index) =>
+        index === profileIndex
+          ? {
+              ...candidate,
+              measurements: {
+                ...candidate.measurements,
+                contextBriefMilliseconds: {
+                  ...candidate.measurements.contextBriefMilliseconds,
+                  maximum: candidate.measurements.contextBriefMilliseconds.maximum + delta,
+                },
+              },
+            }
+          : candidate,
+      ),
+    };
+  }
+  if (target === 'execution-contract') {
+    return {...artifact, execution: {...artifact.execution, timingScope: `${artifact.execution.timingScope} tampered`}};
+  }
+  if (target === 'final-retained-sample') {
+    return {
+      ...artifact,
+      memoryObserver: {
+        ...artifact.memoryObserver,
+        finalSample: {
+          ...artifact.memoryObserver.finalSample,
+          rootRssBytes: artifact.memoryObserver.finalSample.rootRssBytes + delta,
+          treeRssBytes: artifact.memoryObserver.finalSample.treeRssBytes + delta,
+        },
+      },
+    };
+  }
+  if (target === 'gate-decision') return {...artifact, gate: {failures: [], passed: true}};
+  if (target === 'memory-observation') {
+    return {
+      ...artifact,
+      profiles: artifact.profiles.map((candidate, index) =>
+        index === profileIndex
+          ? {
+              ...candidate,
+              observations: candidate.observations.map((observation, observationIndex) =>
+                observationIndex === 0
+                  ? {
+                      ...observation,
+                      memory: {...observation.memory, sampleAttempts: observation.memory.sampleAttempts + delta},
+                    }
+                  : observation,
+              ),
+            }
+          : candidate,
+      ),
+    };
+  }
+  if (target === 'memory-observer-summary') {
+    return {
+      ...artifact,
+      memoryObserver: {...artifact.memoryObserver, sampleAttempts: artifact.memoryObserver.sampleAttempts + delta},
+    };
+  }
+  if (target === 'memory-workload') {
+    return {
+      ...artifact,
+      profiles: artifact.profiles.map((candidate, index) =>
+        index === profileIndex
+          ? {
+              ...candidate,
+              observations: candidate.observations.map((observation, observationIndex) =>
+                observationIndex === 0
+                  ? {
+                      ...observation,
+                      memoryWorkload: {
+                        ...observation.memoryWorkload,
+                        selectedMemories: observation.memoryWorkload.selectedMemories + delta,
+                      },
+                    }
+                  : observation,
+              ),
+            }
+          : candidate,
+      ),
+    };
+  }
+  return {
+    ...artifact,
+    fixture: {
+      ...artifact.fixture,
+      worksetGenerationDigests: ['not-a-digest', artifact.fixture.worksetGenerationDigests[1]],
+    },
+  };
+}
+
 function scaleObservation(
   profile: ContextBriefCitationScaleProfileV1,
   counters: Partial<ContextBriefCitationScaleCountersV1> = {},
-  values: Partial<ContextBriefCitationScaleObservationV1> = {},
-): ContextBriefCitationScaleObservationV1 {
-  return {
-    addedRssBytes: 1_024,
+  values: Partial<ContextBriefCitationScaleObservationV2> = {},
+  memoryValues: Partial<ContextBriefCitationScaleMemoryObservationV2> = {},
+): ContextBriefCitationScaleMeasuredObservationV2 {
+  const observedRootRssBaselineBytes = memoryValues.observedRootRssBaselineBytes ?? 512 * 1_024 * 1_024;
+  const observedAddedRootRssBytes = memoryValues.observedAddedRootRssBytes ?? 1_024;
+  const observedProcessTreeRssBaselineBytes =
+    memoryValues.observedProcessTreeRssBaselineBytes ?? observedRootRssBaselineBytes + 1_024;
+  const observedAddedProcessTreeRssBytes = memoryValues.observedAddedProcessTreeRssBytes ?? 2_048;
+  const timing: ContextBriefCitationScaleObservationV2 = {
+    boundaryAddedRssBytes: 1_024,
     contextBriefMilliseconds: 10,
     counters: {
       activeViewFenceObservations: profile.id === 'local-100k' ? 0 : profile.citedRepositories * 2,
@@ -148,5 +618,30 @@ function scaleObservation(
     validationMilliseconds: 4,
     validationReceipts: profile.citationCount,
     ...values,
+  };
+  return {
+    ...timing,
+    memory: {
+      baselineProcessCount: 1,
+      maximumSampleGapMilliseconds: 25,
+      observedAddedProcessTreeRssBytes,
+      observedAddedRootRssBytes,
+      observedProcessTreeRssBaselineBytes,
+      observedProcessTreeRssPeakBytes: observedProcessTreeRssBaselineBytes + observedAddedProcessTreeRssBytes,
+      observedRootRssBaselineBytes,
+      observedRootRssPeakBytes: observedRootRssBaselineBytes + observedAddedRootRssBytes,
+      observationId: `${profile.id}-0`,
+      ordinal: 0,
+      peakProcessCount: 2,
+      profile: profile.id,
+      rootStartIdentity: 'root-start',
+      sampleAttempts: 3,
+      sampleFailures: 0,
+      sampleIntervalMilliseconds: 25,
+      samples: 3,
+      source: 'darwin-ps',
+      ...memoryValues,
+    },
+    memoryWorkload: timing,
   };
 }

--- a/test/unit/recall-code-links.test.ts
+++ b/test/unit/recall-code-links.test.ts
@@ -554,7 +554,7 @@ describe('recall code links', () => {
   });
 
   effectIt.effect.prop(
-    'matches an independent citation-winner and round-robin reference model (property)',
+    'matches an independent bounded citation-winner and round-robin reference model (property)',
     {
       documents: fc.array(fc.uniqueArray(fc.integer({max: 2, min: 0}), {maxLength: 3, minLength: 1}), {
         maxLength: 10,
@@ -572,7 +572,7 @@ describe('recall code links', () => {
         const anchors = Array.from({length: 3}, (_, index) =>
           citation({path: `src/target-${index}.ts`, repositoryId, symbolSeed: String(index + 1)}),
         );
-        const modeled: RecallCodeLinkReferenceRow[] = [];
+        const modeled: Array<RecallCodeLinkReferenceRow & {readonly assignments: readonly number[]}> = [];
         for (const [documentIndex, assignments] of documents.entries()) {
           const topic = `document-${String(documentIndex).padStart(2, '0')}`;
           yield* writeMemory(
@@ -586,14 +586,22 @@ describe('recall code links', () => {
           );
           modeled.push({
             anchorOrdinal: assignments[0]!,
+            assignments,
             citationId: anchors[assignments[0]!]!.id,
             citationOrdinal: 0,
             matchKind: 'symbol-node',
             uri: `threadnote://user/${user}/memories/durable/projects/threadnote/${topic}.md`,
           });
         }
+        const scanLimit = limit * 4;
+        const boundedModeled = anchors.flatMap((_, anchorOrdinal) =>
+          modeled
+            .filter(row => row.assignments.includes(anchorOrdinal))
+            .slice(0, scanLimit)
+            .filter(row => row.anchorOrdinal === anchorOrdinal),
+        );
         const anchorRanks = new Map<number, number>();
-        const expected = [...modeled]
+        const expected = boundedModeled
           .sort((left, right) => left.anchorOrdinal - right.anchorOrdinal || compareReferenceText(left.uri, right.uri))
           .map(row => {
             const anchorRank = (anchorRanks.get(row.anchorOrdinal) ?? 0) + 1;
@@ -607,7 +615,7 @@ describe('recall code links', () => {
               compareReferenceText(left.uri, right.uri),
           )
           .slice(0, limit)
-          .map(({anchorRank: _anchorRank, ...row}) => row);
+          .map(({anchorRank: _anchorRank, assignments: _assignments, ...row}) => row);
         const actual = yield* loadRecallCodeLinks(
           {account: 'local', agentContextHome: home, user},
           {anchors, forceRefresh: true, includeInactive: false, limit, project: 'threadnote'},


### PR DESCRIPTION
## Summary

- replace lifetime RSS with an external observer-excluded recursive process-tree protocol
- run first-use memory evidence before observer-free timing and include a post-final-GC retained-root sample
- make the v2 artifact parser fail closed with rederived measurements, coverage, hashes, and gate failures
- pin release-scale evidence to hosted macOS ARM64 and retain exact materialization provenance
- bound periodic 100k recall-source validation allocations without weakening freshness semantics or the 64 MiB objective

## Evidence

- dev-cycle converged after four iterations with zero critical or important findings
- Context Brief/RSS focus: 4 files, 74 tests
- recall-index focus: 3 files, 47 tests
- source/test/site typechecks, strict lint, Prettier, file-length, and diff hygiene pass
- 100k / 25 samples per profile / 5 warmups local calibration passes every substantive gate: 1,628 successful observer samples, zero failures, root-only final sample, 6.06 MB retained growth; max transient tree growth 27.46 MB local, 53.35 MB Workset-50, 51.81 MB Workset-128
- exact global runtime installed at 41d7db6463d244eeb8c69d076167c289e6d3df77; doctor has zero failures; global recall smoke passes

The local full suite was intentionally not run; pull-request CI is authoritative per repository policy.