### PR TITLE
feat: keep telemetry enabled across scope updates

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -6,11 +6,16 @@ Threadnote telemetry is disabled by default. It starts only after an explicit ap
 threadnote telemetry status
 threadnote telemetry enable
 threadnote telemetry enable --apply
+# Or opt in once and stay enabled when later releases expand the data contract:
+threadnote telemetry enable --auto-accept --apply
 ```
 
 `enable` is a preview. It describes the endpoint, the exact data categories, and the session model without writing
 configuration or making a network request. `--apply` stores consent under
-`~/.threadnote/telemetry/config.json`. Disable follows the same preview/apply contract:
+`~/.threadnote/telemetry/config.json`. Adding `--auto-accept` explicitly opts into future telemetry data-contract
+updates without another consent prompt. Omit it to keep the default fail-closed renewal behavior. Reapplying consent
+without `--auto-accept` turns automatic acceptance back off while leaving telemetry enabled. Disable follows the same
+preview/apply contract:
 
 ```sh
 threadnote telemetry disable
@@ -26,7 +31,10 @@ surface requires consent version 5. A version 1, version 2, version 3, or versio
 producer: telemetry remains off until the user reviews the current preview and explicitly runs
 `threadnote telemetry enable --apply` again.
 Threadnote never migrates an earlier opt-in silently, even though the gateway continues to admit the frozen v1, v2,
-v3, and v4 wire contracts for older supported producers.
+v3, and v4 wire contracts for older supported producers. The exception is an opt-in that explicitly stored
+`autoAccept: true`: Threadnote treats that as advance acceptance of later data-contract versions, keeps telemetry
+enabled, and lets newly started processes use the current contract. A consent version created by a newer Threadnote
+release still fails closed when read by an older release.
 
 When an upgrade finds an exact enabled v4 consent, its post-update action prints the complete current preview before
 asking interactively whether to apply v5 consent. `--yes` never answers this privacy prompt, and non-interactive or

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,7 +92,9 @@ older.
 For failures that are difficult to reproduce, optional anonymous telemetry can correlate allowlisted command and MCP
 tool outcomes during one agent session. It is off by default. Run `threadnote telemetry enable` to preview the data and
 destination, then rerun with `--apply` only if you consent. Use `threadnote telemetry status` to inspect the effective
-state and `threadnote telemetry disable --apply` to revoke it. Telemetry never replaces the local logs or an explicit
+state and `threadnote telemetry disable --apply` to revoke it. To keep telemetry enabled when future releases expand
+the versioned data contract, apply consent with `threadnote telemetry enable --auto-accept --apply`; without that flag,
+new data categories continue to fail closed until reviewed. Telemetry never replaces the local logs or an explicit
 support report; see [Optional anonymous telemetry](./telemetry.md).
 
 Create a Threadnote GitHub issue through an exact public preview:

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -325,11 +325,11 @@ const logs = Command.make('logs', {}, () => withRuntimeEffect(runProductionLogs)
 const telemetryStatus = Command.make('status', {}, () => withRuntimeEffect(config => runTelemetryStatus(config))).pipe(
   Command.withDescription('Show effective consent, endpoint, data categories, and environment opt-outs'),
 );
-
 const telemetryEnable = Command.make(
   'enable',
   {
     apply: boolean('apply', 'Persist explicit telemetry consent'),
+    autoAccept: boolean('auto-accept', 'Keep telemetry enabled through future data-contract updates'),
     endpoint: optionalString('endpoint', 'OTLP/HTTP traces endpoint; HTTPS required except for loopback'),
   },
   options => withRuntimeEffect(config => runTelemetryEnable(config, options)),

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -244,7 +244,7 @@ export const telemetryDoctorCheck = Effect.fn('lifecycle.telemetryDoctorCheck')(
   return {
     detail:
       optOut === undefined
-        ? `enabled by explicit consent; endpoint ${loaded.success.endpoint}`
+        ? `enabled by explicit consent${loaded.success.autoAccept === true ? ' with automatic future scope acceptance' : ''}; endpoint ${loaded.success.endpoint}`
         : `persisted consent enabled but suppressed by ${optOut}`,
     name: 'anonymous telemetry',
     status: 'ok' as const,

--- a/src/telemetry/commands.ts
+++ b/src/telemetry/commands.ts
@@ -17,6 +17,7 @@ import {SystemInfo} from '../effect/system.js';
 
 export interface TelemetryEnableOptions {
   readonly apply?: boolean;
+  readonly autoAccept?: boolean;
   readonly endpoint?: string;
 }
 
@@ -72,6 +73,11 @@ export const runTelemetryStatus = Effect.fn('telemetry.command.status')(function
   } else {
     yield* Console.log('Anonymous telemetry: enabled.');
   }
+  yield* Console.log(
+    configuration.autoAccept === true
+      ? 'Future telemetry data-contract updates: accepted automatically.'
+      : 'Future telemetry data-contract updates: require explicit consent.',
+  );
   yield* Console.log(`Endpoint: ${configuration.endpoint}`);
   yield* Console.log(telemetryDestinationSummary(configuration.endpoint));
   yield* Console.log(`Data contract: ${TELEMETRY_DATA_SUMMARY}`);
@@ -100,12 +106,22 @@ export const runTelemetryEnable = Effect.fn('telemetry.command.enable')(function
   yield* Console.log(telemetryDestinationSummary(endpoint));
   yield* Console.log(`Data sent: ${TELEMETRY_DATA_SUMMARY}`);
   yield* Console.log(`Data excluded: ${TELEMETRY_EXCLUSION_SUMMARY}`);
+  yield* Console.log(
+    options.autoAccept === true
+      ? 'Future telemetry data-contract updates will be accepted automatically without another consent prompt.'
+      : 'Future telemetry data-contract updates will require explicit consent; use --auto-accept to opt into automatic acceptance.',
+  );
   if (options.apply !== true) {
     yield* Console.log('No changes made. Re-run with --apply to record this consent.');
     return;
   }
   const current = yield* Effect.result(readTelemetryConfiguration(config));
-  if (Result.isSuccess(current) && current.success?.enabled === true && current.success.endpoint === endpoint) {
+  if (
+    Result.isSuccess(current) &&
+    current.success?.enabled === true &&
+    current.success.endpoint === endpoint &&
+    (current.success.autoAccept === true) === (options.autoAccept === true)
+  ) {
     yield* Console.log('Telemetry consent is already enabled for this endpoint.');
     const system = yield* SystemInfo;
     const optOut = telemetryEnvironmentOptOut(system.environment());
@@ -114,11 +130,14 @@ export const runTelemetryEnable = Effect.fn('telemetry.command.enable')(function
     }
     return;
   }
-  const configuration = yield* createEnabledTelemetryConfiguration(endpoint);
+  const configuration = yield* createEnabledTelemetryConfiguration(endpoint, options.autoAccept === true);
   const file = yield* writeTelemetryConfiguration(config, configuration);
   const system = yield* SystemInfo;
   const optOut = telemetryEnvironmentOptOut(system.environment());
   yield* Console.log(`Telemetry consent enabled in ${file}.`);
+  if (configuration.autoAccept === true) {
+    yield* Console.log('Automatic acceptance of future telemetry data-contract updates is enabled.');
+  }
   yield* Console.log('Restart connected MCP clients that started before this consent change.');
   if (optOut !== undefined) {
     yield* Console.log(`Telemetry remains disabled while ${optOut} is set.`);

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -16,6 +16,8 @@ export interface DisabledTelemetryConfiguration {
 }
 
 export interface EnabledTelemetryConfiguration {
+  /** Keep telemetry enabled when later releases expand the versioned data contract. */
+  readonly autoAccept?: true;
   readonly consentVersion: typeof TELEMETRY_CONSENT_VERSION;
   readonly enabled: true;
   readonly endpoint: string;
@@ -136,16 +138,23 @@ export const writeTelemetryConfiguration = Effect.fn('telemetry.writeConfigurati
 
 export const createEnabledTelemetryConfiguration = Effect.fn('telemetry.createEnabledConfiguration')(function* (
   endpoint = DEFAULT_TELEMETRY_ENDPOINT,
+  autoAccept = false,
 ) {
   const crypto = yield* Crypto.Crypto;
   return enabledTelemetryConfiguration(
     endpoint,
     Encoding.encodeBase64Url(yield* crypto.randomBytes(TELEMETRY_SESSION_SALT_BYTES)),
+    autoAccept,
   );
 });
 
-export function enabledTelemetryConfiguration(endpoint: string, sessionSalt: string): EnabledTelemetryConfiguration {
+export function enabledTelemetryConfiguration(
+  endpoint: string,
+  sessionSalt: string,
+  autoAccept = false,
+): EnabledTelemetryConfiguration {
   return {
+    ...(autoAccept ? {autoAccept: true as const} : {}),
     consentVersion: TELEMETRY_CONSENT_VERSION,
     enabled: true,
     endpoint: normalizeTelemetryEndpoint(endpoint),
@@ -189,13 +198,26 @@ export function parseTelemetryConsentRenewal(
     value.version !== TELEMETRY_CONFIGURATION_VERSION ||
     value.consentVersion !== TELEMETRY_RENEWABLE_CONSENT_VERSION ||
     value.enabled !== true ||
+    value.autoAccept === true ||
+    (value.autoAccept !== undefined && typeof value.autoAccept !== 'boolean') ||
     typeof value.endpoint !== 'string' ||
     typeof value.sessionSalt !== 'string'
   ) {
     return undefined;
   }
   try {
-    assertExactKeys(value, ['consentVersion', 'enabled', 'endpoint', 'sessionSalt', 'version'], source);
+    assertExactKeys(
+      value,
+      [
+        ...(value.autoAccept === undefined ? [] : ['autoAccept']),
+        'consentVersion',
+        'enabled',
+        'endpoint',
+        'sessionSalt',
+        'version',
+      ],
+      source,
+    );
     normalizeTelemetrySessionSalt(value.sessionSalt);
     return {
       consentVersion: TELEMETRY_RENEWABLE_CONSENT_VERSION,
@@ -265,25 +287,57 @@ function parseTelemetryConfigurationValue(value: unknown, source: string): Telem
       `Unsupported telemetry configuration version in ${source}. Expected ${TELEMETRY_CONFIGURATION_VERSION}.`,
     );
   }
-  if (value.consentVersion !== TELEMETRY_CONSENT_VERSION) {
-    throw new TelemetryConfigurationError(
-      `Unsupported telemetry consent version in ${source}. Expected ${TELEMETRY_CONSENT_VERSION}.`,
-    );
-  }
   if (value.enabled === false) {
+    assertCurrentTelemetryConsentVersion(value.consentVersion, source);
     assertExactKeys(value, ['consentVersion', 'enabled', 'version'], source);
     return disabledTelemetryConfiguration();
   }
   if (value.enabled === true) {
-    assertExactKeys(value, ['consentVersion', 'enabled', 'endpoint', 'sessionSalt', 'version'], source);
+    const autoAccept = value.autoAccept;
+    if (autoAccept !== undefined && typeof autoAccept !== 'boolean') {
+      throw new TelemetryConfigurationError(`Telemetry auto-accept must be a boolean: ${source}`);
+    }
+    if (
+      value.consentVersion !== TELEMETRY_CONSENT_VERSION &&
+      !(autoAccept === true && isEarlierTelemetryConsentVersion(value.consentVersion))
+    ) {
+      throw unsupportedTelemetryConsentVersion(source);
+    }
+    assertExactKeys(
+      value,
+      [
+        ...(autoAccept === undefined ? [] : ['autoAccept']),
+        'consentVersion',
+        'enabled',
+        'endpoint',
+        'sessionSalt',
+        'version',
+      ],
+      source,
+    );
     if (typeof value.endpoint !== 'string' || typeof value.sessionSalt !== 'string') {
       throw new TelemetryConfigurationError(
         `Enabled telemetry configuration requires an endpoint and local session salt: ${source}`,
       );
     }
-    return enabledTelemetryConfiguration(value.endpoint, value.sessionSalt);
+    return enabledTelemetryConfiguration(value.endpoint, value.sessionSalt, autoAccept === true);
   }
+  assertCurrentTelemetryConsentVersion(value.consentVersion, source);
   throw new TelemetryConfigurationError(`Telemetry configuration requires a boolean enabled field: ${source}`);
+}
+
+function assertCurrentTelemetryConsentVersion(value: unknown, source: string): void {
+  if (value !== TELEMETRY_CONSENT_VERSION) throw unsupportedTelemetryConsentVersion(source);
+}
+
+function isEarlierTelemetryConsentVersion(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 1 && Number(value) < TELEMETRY_CONSENT_VERSION;
+}
+
+function unsupportedTelemetryConsentVersion(source: string): TelemetryConfigurationError {
+  return new TelemetryConfigurationError(
+    `Unsupported telemetry consent version in ${source}. Expected ${TELEMETRY_CONSENT_VERSION}.`,
+  );
 }
 
 function assertExactKeys(value: Record<string, unknown>, expected: readonly string[], source: string): void {

--- a/test/integration/cli.effect.test.ts
+++ b/test/integration/cli.effect.test.ts
@@ -36,6 +36,7 @@ describe('Effect CLI', () => {
     expect(telemetry.stdout).toContain('enable');
     expect(telemetry.stdout).toContain('disable');
     expect(enable.stdout).toContain('--apply');
+    expect(enable.stdout).toContain('--auto-accept');
     expect(enable.stdout).toContain('--endpoint string');
     expect(disable.stdout).toContain('--apply');
   });

--- a/test/unit/lifecycle.doctor.test.ts
+++ b/test/unit/lifecycle.doctor.test.ts
@@ -151,6 +151,23 @@ describe('doctor report resilience', () => {
           name: 'anonymous telemetry',
           status: 'warn',
         });
+
+        yield* fs.writeFileString(
+          path.join(home, 'telemetry', 'config.json'),
+          `${JSON.stringify({
+            autoAccept: true,
+            consentVersion: 4,
+            enabled: true,
+            endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+            sessionSalt: Encoding.encodeBase64Url(new Uint8Array(32).fill(9)),
+            version: 1,
+          })}\n`,
+        );
+        expect(yield* telemetryDoctorCheck(config)).toEqual({
+          detail: `enabled by explicit consent with automatic future scope acceptance; endpoint ${DEFAULT_TELEMETRY_ENDPOINT}`,
+          name: 'anonymous telemetry',
+          status: 'ok',
+        });
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );

--- a/test/unit/telemetry-commands.test.ts
+++ b/test/unit/telemetry-commands.test.ts
@@ -46,6 +46,7 @@ describe('telemetry commands', () => {
         expect(preview.output).toContain('Grafana Cloud EU');
         expect(preview.output).toContain('14-day trace retention');
         expect(preview.output).toContain('transport providers process source IP addresses');
+        expect(preview.output).toContain('use --auto-accept to opt into automatic acceptance');
         expect(preview.output).toContain('No changes made. Re-run with --apply');
         expect(yield* fs.exists(yield* telemetryConfigurationPath(config))).toBe(false);
       }),
@@ -127,12 +128,16 @@ describe('telemetry commands', () => {
         expect(preview.output).toContain('No changes made. Re-run with --apply');
         expect(JSON.parse(yield* fs.readFileString(file))).toMatchObject({consentVersion: 4, enabled: true});
 
-        yield* runTelemetryEnable(config, {apply: true});
+        yield* runTelemetryEnable(config, {apply: true, autoAccept: true});
         expect(yield* readTelemetryConfiguration(config)).toMatchObject({
+          autoAccept: true,
           consentVersion: 5,
           enabled: true,
           endpoint: previousEndpoint,
         });
+
+        const statusAfterRenewal = yield* captureConsole(runTelemetryStatus(config));
+        expect(statusAfterRenewal.output).toContain('Future telemetry data-contract updates: accepted automatically');
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );

--- a/test/unit/telemetry-config.test.ts
+++ b/test/unit/telemetry-config.test.ts
@@ -27,7 +27,9 @@ const FIXED_SESSION_SALT = Encoding.encodeBase64Url(new Uint8Array(32).fill(7));
 describe('telemetry configuration', () => {
   it('accepts only the strict versioned consent schema', () => {
     const enabled = enabledTelemetryConfiguration(DEFAULT_TELEMETRY_ENDPOINT, FIXED_SESSION_SALT);
+    const autoAccepted = enabledTelemetryConfiguration(DEFAULT_TELEMETRY_ENDPOINT, FIXED_SESSION_SALT, true);
     expect(parseTelemetryConfiguration(renderTelemetryConfiguration(enabled))).toEqual(enabled);
+    expect(parseTelemetryConfiguration(renderTelemetryConfiguration(autoAccepted))).toEqual(autoAccepted);
     expect(parseTelemetryConfiguration(renderTelemetryConfiguration(disabledTelemetryConfiguration()))).toEqual(
       disabledTelemetryConfiguration(),
     );
@@ -38,6 +40,15 @@ describe('telemetry configuration', () => {
       {consentVersion: 2, enabled: false, endpoint: DEFAULT_TELEMETRY_ENDPOINT, version: 1},
       {
         consentVersion: 5,
+        autoAccept: 'yes',
+        enabled: true,
+        endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+        sessionSalt: FIXED_SESSION_SALT,
+        version: 1,
+      },
+      {
+        consentVersion: 6,
+        autoAccept: true,
         enabled: true,
         endpoint: DEFAULT_TELEMETRY_ENDPOINT,
         sessionSalt: FIXED_SESSION_SALT,
@@ -70,11 +81,15 @@ describe('telemetry configuration', () => {
   });
 
   effectIt.effect.prop(
-    'round-trips every canonical 32-byte local session salt',
-    {bytes: FC.uint8Array({maxLength: 32, minLength: 32})},
-    ({bytes}) =>
+    'round-trips every canonical 32-byte local session salt and acceptance mode',
+    {autoAccept: FC.boolean(), bytes: FC.uint8Array({maxLength: 32, minLength: 32})},
+    ({autoAccept, bytes}) =>
       Effect.sync(() => {
-        const value = enabledTelemetryConfiguration(DEFAULT_TELEMETRY_ENDPOINT, Encoding.encodeBase64Url(bytes));
+        const value = enabledTelemetryConfiguration(
+          DEFAULT_TELEMETRY_ENDPOINT,
+          Encoding.encodeBase64Url(bytes),
+          autoAccept,
+        );
         expect(parseTelemetryConfiguration(renderTelemetryConfiguration(value))).toEqual(value);
       }),
     {fastCheck: {numRuns: 50}},
@@ -83,6 +98,7 @@ describe('telemetry configuration', () => {
   effectIt.effect.prop(
     'recognizes only the exact renewable enabled-consent generation',
     {
+      autoAccept: FC.option(FC.boolean(), {nil: undefined}),
       consentVersion: FC.integer({max: 8, min: 1}),
       enabled: FC.boolean(),
       extraField: FC.boolean(),
@@ -90,10 +106,11 @@ describe('telemetry configuration', () => {
       validSalt: FC.boolean(),
       version: FC.integer({max: 2, min: 0}),
     },
-    ({consentVersion, enabled, extraField, validEndpoint, validSalt, version}) =>
+    ({autoAccept, consentVersion, enabled, extraField, validEndpoint, validSalt, version}) =>
       Effect.sync(() => {
         const renewal = parseTelemetryConsentRenewal(
           JSON.stringify({
+            ...(autoAccept === undefined ? {} : {autoAccept}),
             consentVersion,
             enabled,
             endpoint: validEndpoint ? DEFAULT_TELEMETRY_ENDPOINT : 'http://collector.example/v1/traces',
@@ -103,10 +120,51 @@ describe('telemetry configuration', () => {
           }),
         );
         expect(renewal).toEqual(
-          consentVersion === 4 && enabled && !extraField && validEndpoint && validSalt && version === 1
+          consentVersion === 4 &&
+            enabled &&
+            autoAccept !== true &&
+            !extraField &&
+            validEndpoint &&
+            validSalt &&
+            version === 1
             ? {consentVersion: 4, endpoint: DEFAULT_TELEMETRY_ENDPOINT}
             : undefined,
         );
+      }),
+    {fastCheck: {numRuns: 50}},
+  );
+
+  effectIt.effect.prop(
+    'accepts earlier consent generations only when future scope updates were auto-accepted',
+    {
+      autoAccept: FC.boolean(),
+      consentVersion: FC.integer({max: 8, min: 1}),
+    },
+    ({autoAccept, consentVersion}) =>
+      Effect.sync(() => {
+        const parse = () =>
+          parseTelemetryConfiguration(
+            JSON.stringify({
+              ...(autoAccept ? {autoAccept: true} : {}),
+              consentVersion,
+              enabled: true,
+              endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+              sessionSalt: FIXED_SESSION_SALT,
+              version: 1,
+            }),
+          );
+        if (consentVersion === 5 || (consentVersion < 5 && autoAccept)) {
+          expect(parse()).toEqual({
+            ...(autoAccept ? {autoAccept: true} : {}),
+            consentVersion: 5,
+            enabled: true,
+            endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+            sessionSalt: FIXED_SESSION_SALT,
+            version: 1,
+          });
+        } else {
+          expect(parse).toThrow(TelemetryConfigurationError);
+        }
       }),
     {fastCheck: {numRuns: 50}},
   );
@@ -165,7 +223,7 @@ describe('telemetry configuration', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
-  effectIt.effect('fails closed for enabled consent from the previous allowlist version', () =>
+  effectIt.effect('fails closed for manual consent but honors prior automatic scope acceptance', () =>
     Effect.scoped(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -192,6 +250,28 @@ describe('telemetry configuration', () => {
           consentVersion: 4,
           endpoint: DEFAULT_TELEMETRY_ENDPOINT,
         });
+
+        yield* fs.writeFileString(
+          file,
+          `${JSON.stringify({
+            autoAccept: true,
+            consentVersion: 4,
+            enabled: true,
+            endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+            sessionSalt: FIXED_SESSION_SALT,
+            version: 1,
+          })}\n`,
+          {mode: 0o600},
+        );
+        expect(yield* resolveTelemetryConfiguration(config)).toEqual({
+          autoAccept: true,
+          consentVersion: 5,
+          enabled: true,
+          endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+          sessionSalt: FIXED_SESSION_SALT,
+          version: 1,
+        });
+        expect(yield* readTelemetryConsentRenewal(config)).toBeUndefined();
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -1515,6 +1515,81 @@ describe('post-update validation', () => {
     }),
   );
 
+  effectIt.effect('keeps telemetry enabled when an earlier consent auto-accepts scope updates', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const temporaryRoot = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-post-update-auto-consent-'});
+        const fixtureRoot = path.join(temporaryRoot, 'tool');
+        const config = runtimeConfig(path.join(temporaryRoot, '.threadnote'));
+        yield* writePostUpdateFixture(fs, path, fixtureRoot, [
+          {
+            ...fixtureMigration('telemetry-consent-renewal', {
+              requiresExplicitTelemetryConsent: true,
+              requiresTelemetryConsentRenewal: true,
+            }),
+            commandArgs: ['telemetry', 'enable'],
+          },
+        ]);
+        yield* Effect.sync(() => {
+          vi.mocked(utils.toolRoot).mockImplementation(() => Effect.succeed(fixtureRoot));
+        });
+        const telemetryFile = yield* telemetryConfigurationPath(config);
+        yield* fs.makeDirectory(path.dirname(telemetryFile), {recursive: true});
+        yield* fs.writeFileString(
+          telemetryFile,
+          `${JSON.stringify({
+            autoAccept: true,
+            consentVersion: 4,
+            enabled: true,
+            endpoint: DEFAULT_TELEMETRY_ENDPOINT,
+            sessionSalt: Encoding.encodeBase64Url(new Uint8Array(32).fill(7)),
+            version: 1,
+          })}\n`,
+        );
+
+        let commandAttempts = 0;
+        const commandExecutor = CommandExecutor.of({
+          execute: () =>
+            Effect.sync(() => {
+              commandAttempts += 1;
+              return {exitCode: 0, stderr: '', stdout: ''};
+            }),
+          executeStreaming: () =>
+            Effect.sync(() => {
+              commandAttempts += 1;
+              return {exitCode: 0, stderr: '', stdout: ''};
+            }),
+        });
+        const output = yield* captureConsole(
+          runPostUpdate(config, {fromVersion: '4.4.3', toVersion: '4.4.4', yes: true}).pipe(
+            Effect.provideService(CommandExecutor, commandExecutor),
+            Effect.provideService(
+              SystemInfo,
+              SystemInfo.of({
+                ...baseSystem,
+                homeDirectory: temporaryRoot,
+                stdinIsTTY: false,
+                stdoutIsTTY: false,
+              }),
+            ),
+          ),
+        );
+
+        expect(output.output).toBe('');
+        expect(commandAttempts).toBe(0);
+        expect(yield* readTelemetryConfiguration(config)).toMatchObject({
+          autoAccept: true,
+          consentVersion: 5,
+          enabled: true,
+        });
+        expect(JSON.parse(yield* fs.readFileString(telemetryFile))).toMatchObject({consentVersion: 4});
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('does not announce an action when migration evidence disappears at the locked recheck', () =>
     Effect.gen(function* () {
       const result = yield* Effect.scoped(

--- a/website/src/content/docsTelemetry.ts
+++ b/website/src/content/docsTelemetry.ts
@@ -7,6 +7,7 @@ export const optionalAnonymousTelemetryCliCommand: CliCommandReference = {
     'threadnote telemetry status',
     'threadnote telemetry enable',
     'threadnote telemetry enable --apply',
+    'threadnote telemetry enable --auto-accept --apply',
     'threadnote telemetry disable --apply',
   ],
 };
@@ -24,6 +25,8 @@ export const optionalAnonymousTelemetryDocsArticle: DocsArticle = {
 threadnote telemetry enable
 # Review the preview, then opt in only if you agree:
 threadnote telemetry enable --apply
+# Or explicitly accept future data-contract updates too:
+threadnote telemetry enable --auto-accept --apply
 # Revoke persisted consent:
 threadnote telemetry disable --apply`,
     },
@@ -33,7 +36,7 @@ threadnote telemetry disable --apply`,
     },
     {
       type: 'paragraph',
-      text: 'Consent is versioned separately from the configuration format. If the allowlist gains a material category, earlier consent fails closed and telemetry remains off until the current preview is reviewed and explicitly applied again; Threadnote never migrates an older opt-in silently.',
+      text: 'Consent is versioned separately from the configuration format. By default, if the allowlist gains a material category, earlier consent fails closed and telemetry remains off until the current preview is reviewed and explicitly applied again. Users who apply consent with --auto-accept instead opt into future data-contract updates without another prompt, so telemetry stays enabled after those updates. A consent version from a newer Threadnote release still fails closed in an older release.',
     },
     {
       type: 'paragraph',
@@ -50,7 +53,7 @@ threadnote telemetry disable --apply`,
     },
     {
       type: 'note',
-      text: 'Run threadnote telemetry enable without --apply to review the exact current data and destination contract without writing configuration or making a request.',
+      text: 'Run threadnote telemetry enable without --apply to review the exact current data and destination contract without writing configuration or making a request. Add --auto-accept only if you also want to accept future telemetry scope changes automatically.',
     },
   ],
 };


### PR DESCRIPTION
## Summary

- add `threadnote telemetry enable --auto-accept --apply` as an explicit persisted opt-in for future telemetry data-contract updates
- keep the default consent path fail-closed, while normalizing older consent generations only when `autoAccept: true` is present
- skip post-update renewal prompts for opted-in users, preserve future-version downgrade safety, and surface the mode in status/doctor output
- document the new behavior in CLI help, telemetry docs, troubleshooting, and website content

## Verification

- focused Vitest: 164 tests across telemetry config/commands, doctor, post-update, CLI, and website content
- strict Oxlint on changed TypeScript
- source, test, and website TypeScript checks
- Prettier and production file-length gate
- bounded Fast-check properties cover configuration round trips and earlier/current/future consent-version acceptance

The full suite is intentionally left to PR CI per repository policy.