### PR TITLE
fix: distinguish fresh MCP installs from legacy hosts

### DIFF
--- a/src/agent-integrations.ts
+++ b/src/agent-integrations.ts
@@ -127,7 +127,9 @@ export const migrateLegacyAgentIntegrationsInTransaction = Effect.fn('agentInteg
       yield* removeOrphanedLegacyInstructions(selected, false);
       for (const agent of selected) yield* installAgentIntegrationInTransaction(config, agent, unknownMcp, false);
     }
-    if (dryRun) {
+    if (selected.length === 0) {
+      yield* Console.log('No legacy agent integrations found.');
+    } else if (dryRun) {
       yield* Console.log(`Would migrate ${selected.length} legacy agent integration(s).`);
     } else {
       yield* Console.log(`Migrated ${selected.length} legacy agent integration(s).`);

--- a/src/mcp/install.ts
+++ b/src/mcp/install.ts
@@ -42,6 +42,10 @@ const runMcpInstallInTransaction = Effect.fn('mcp.runInstallInTransaction')(func
   const toolset = options.toolset ?? DEFAULT_MCP_TOOLSET;
   const scope = agent === 'claude' ? (options.scope ?? 'user') : undefined;
   const cwd = options.cwd ?? (agent === 'claude' && scope !== 'user' ? yield* getInvocationCwd() : undefined);
+  const legacyInferredClients =
+    apply && (yield* readAgentIntegrationRegistry(config)) === undefined
+      ? yield* inferConfiguredMcpClients()
+      : undefined;
 
   if (agent === 'cursor') {
     yield* runCursorMcpInstall(config, name, {
@@ -49,7 +53,7 @@ const runMcpInstallInTransaction = Effect.fn('mcp.runInstallInTransaction')(func
       dryRunApplyCommand: options.dryRunApplyCommand,
       toolset,
     });
-    yield* finishAgentIntegrationInstall(config, agent, {apply, name, toolset});
+    yield* finishAgentIntegrationInstall(config, agent, {apply, legacyInferredClients, name, toolset});
     return;
   }
   if (agent === 'copilot') {
@@ -58,7 +62,7 @@ const runMcpInstallInTransaction = Effect.fn('mcp.runInstallInTransaction')(func
       dryRunApplyCommand: options.dryRunApplyCommand,
       toolset,
     });
-    yield* finishAgentIntegrationInstall(config, agent, {apply, name, toolset});
+    yield* finishAgentIntegrationInstall(config, agent, {apply, legacyInferredClients, name, toolset});
     return;
   }
 
@@ -106,6 +110,7 @@ const runMcpInstallInTransaction = Effect.fn('mcp.runInstallInTransaction')(func
   yield* finishAgentIntegrationInstall(config, agent, {
     apply,
     cwd,
+    legacyInferredClients,
     name,
     scope,
     toolset,
@@ -118,6 +123,7 @@ const finishAgentIntegrationInstall = Effect.fn('mcp.finishAgentIntegrationInsta
   options: {
     readonly apply: boolean;
     readonly cwd?: string;
+    readonly legacyInferredClients?: readonly AgentClient[];
     readonly name: string;
     readonly scope?: ClaudeMcpScope;
     readonly toolset: McpToolset;
@@ -134,8 +140,9 @@ const finishAgentIntegrationInstall = Effect.fn('mcp.finishAgentIntegrationInsta
     yield* installAgentIntegrationInTransaction(config, agent, receipt, true);
     return;
   }
-  const inferred = yield* inferConfiguredMcpClients();
-  yield* migrateLegacyAgentIntegrationsInTransaction(config, [...new Set<AgentClient>([...inferred, agent])], false);
+  if (options.legacyInferredClients !== undefined) {
+    yield* migrateLegacyAgentIntegrationsInTransaction(config, options.legacyInferredClients, false);
+  }
   yield* installAgentIntegrationInTransaction(config, agent, receipt, false);
 });
 

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -386,6 +386,38 @@ describe('JSON MCP host configuration', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
+  effectIt.effect('does not classify a fresh Cursor MCP install as a legacy integration', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-fresh-cursor-install-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const testRuntime = runtime(path.join(user, '.threadnote'));
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), PATH: bin, THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+
+        const result = yield* captureConsole(
+          runMcpInstall(testRuntime, 'cursor', {apply: true}).pipe(Effect.provideService(SystemInfo, testSystem)),
+        );
+
+        expect(result.output).toContain('No legacy agent integrations found.');
+        expect(result.output).not.toContain('Migrated 1 legacy agent integration');
+        expect(result.output.match(/Wrote instructions:/g)).toHaveLength(1);
+        expect(yield* readAgentIntegrationRegistry(testRuntime)).toMatchObject({
+          hosts: {cursor: {mcp: {name: 'threadnote', repair: true}, status: 'current'}},
+          legacyInstructionsMigrated: true,
+        });
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('serializes concurrent MCP install and uninstall into a consistent winning state', () =>
     Effect.scoped(
       Effect.gen(function* () {


### PR DESCRIPTION
Follow-up to #321 after exact-HEAD global dogfooding.

A fresh host install inferred configured MCP clients only after writing the selected host entry. That caused the newly created entry to be classified as legacy, repeated the instruction and skill installation, and printed a misleading migration count.

This snapshots legacy MCP inference before modifying the selected host configuration, preserves migration for genuinely pre-existing hosts, and reports the zero-legacy case accurately.

Verification:
- focused MCP and agent-integration tests: 31 passed
- local-binary E2E: 24 passed, 1 skipped
- typecheck, lint, Prettier, and self-contained checks passed
- exact-HEAD global install and superseded-process cleanup passed
- fresh isolated Cursor installed-binary smoke passed with one artifact write per target
- real repair migrated Codex, Cursor, and Copilot; left unconfigured Claude unregistered; doctor: 0 failures, 1 unrelated graph-maintenance warning

Property testing: no useful input-space property was added; this regression is ordering/classification behavior covered by the concrete fresh-home case.