### PR TITLE
fix: make recall freshness durable and bounded

### DIFF
--- a/src/effect/ai/mcp.ts
+++ b/src/effect/ai/mcp.ts
@@ -14,7 +14,7 @@ import {
   copyAnonymousTelemetryMetadata,
   readAnonymousTelemetryReportedOutcome,
 } from '../../telemetry/diagnostic.js';
-import {isMemoryReadRecoveryV1, type MemoryReadRecoveryV1} from '../../mcp/memory_read_recovery.js';
+import {isMemoryReadRecoveryV1, type MemoryReadRecoveryV1} from '../../memory/read_recovery.js';
 import {omitAnonymousTelemetryRecorder, withAnonymousTelemetry} from '../telemetry.js';
 
 // Windows antivirus and filesystem scheduling can make an otherwise healthy

--- a/src/effect/ai/mcp_resource.ts
+++ b/src/effect/ai/mcp_resource.ts
@@ -12,7 +12,7 @@ import {
   verifyResolvedMemoryIdentity,
 } from '../../recall/memory_identity.js';
 import {uriSegment} from '../../manifest.js';
-import {memoryReadRecoveryForError, memoryReadRecoveryText} from '../../mcp/memory_read_recovery.js';
+import {memoryReadRecoveryForError, memoryReadRecoveryText} from '../../memory/read_recovery.js';
 import {canonicalResourceUri, parseResourceId, resourceIdIsWithin} from '../../storage/resource-id.js';
 import {ResourceNotFound, ResourceStore} from '../resource-store.js';
 import {

--- a/src/effect/resource-store.ts
+++ b/src/effect/resource-store.ts
@@ -1,8 +1,21 @@
-import {Context, Crypto, Effect, FileSystem, Layer, Option, Path, PlatformError, Result, Schema} from 'effect';
+import {
+  Context,
+  Crypto,
+  Effect,
+  FileSystem,
+  Layer,
+  Option,
+  Path,
+  PlatformError,
+  Result,
+  Schedule,
+  Schema,
+} from 'effect';
 import {uriSegment} from '../manifest.js';
 import {globToRegExp} from '../utils.js';
 import {readExclusiveFileLockOwner, withExclusiveFileLock} from './file_lock.js';
 import {resourceAccountMutationLockPath} from './resource_lock.js';
+import {advanceCanonicalMutationGeneration} from './resource_mutation_generation.js';
 import {SystemInfo} from './system.js';
 import {
   canonicalResourceUri,
@@ -32,6 +45,13 @@ export interface ResourceStoreLayerOptions {
   readonly onMutationLockAcquired?: (event: ResourceMutationLockEvent) => Effect.Effect<void, never>;
   readonly onMutationLockCompleted?: (event: ResourceMutationLockEvent) => Effect.Effect<void, never>;
   readonly onMutationLockContention?: (event: ResourceMutationLockEvent) => Effect.Effect<void, never>;
+  readonly onRecallInvalidationFailed?: (event: ResourceRecallInvalidationFailureEvent) => Effect.Effect<void, never>;
+}
+
+export interface ResourceRecallInvalidationFailureEvent {
+  readonly account: string;
+  readonly includeInactive: boolean;
+  readonly invalidatedUriCount: number;
 }
 
 export interface ResourceStoreEntry {
@@ -202,18 +222,43 @@ function createResourceStoreOperations(
 ): ResourceStoreShape {
   const resolve = (location: ResourceStoreLocation, uri: string) =>
     resolveResourcePath(fs, path, location, uri).pipe(mapIoError('resolve', uri));
-  const invalidateRecall = (location: ResourceStoreLocation, invalidatedUris: readonly string[]) =>
+  const invalidateRecall = (
+    location: ResourceStoreLocation,
+    includeInactive: boolean,
+    invalidatedUris: readonly string[],
+    canonicalMutationGeneration: string,
+  ) =>
     provideLockServices(
-      Effect.all(
-        [
-          expireRecallIndexValidation(location.home, false, invalidatedUris),
-          expireRecallIndexValidation(location.home, true, invalidatedUris),
-        ],
-        {concurrency: 2},
-      ).pipe(Effect.provideService(FileSystem.FileSystem, fs)),
+      expireRecallIndexValidation(location.home, includeInactive, invalidatedUris, canonicalMutationGeneration).pipe(
+        Effect.provideService(FileSystem.FileSystem, fs),
+      ),
     );
-  const invalidateRecallBestEffort = (location: ResourceStoreLocation, invalidatedUris: readonly string[]) =>
-    invalidateRecall(location, invalidatedUris).pipe(Effect.catchCause(() => Effect.void));
+  const invalidateRecallBestEffort = (
+    location: ResourceStoreLocation,
+    invalidatedUris: readonly string[],
+    canonicalMutationGeneration: string,
+  ) =>
+    Effect.forEach(
+      [false, true],
+      includeInactive =>
+        invalidateRecall(location, includeInactive, invalidatedUris, canonicalMutationGeneration).pipe(
+          Effect.retry(Schedule.recurs(2)),
+          Effect.catchCause(() => {
+            const event = {
+              account: location.account,
+              includeInactive,
+              invalidatedUriCount: invalidatedUris.length,
+            } satisfies ResourceRecallInvalidationFailureEvent;
+            return Effect.logWarning(
+              `Recall index per-URI invalidation failed after a canonical mutation attempt (${includeInactive ? 'with-inactive' : 'active'} scope); the durable canonical generation will force recovery on the next read.`,
+            ).pipe(
+              Effect.andThen(layerOptions.onRecallInvalidationFailed?.(event) ?? Effect.void),
+              Effect.catchCause(() => Effect.void),
+            );
+          }),
+        ),
+      {concurrency: 2, discard: true},
+    ).pipe(Effect.uninterruptible);
   const withLock = <A, E, R>(location: ResourceStoreLocation, id: ResourceId, effect: Effect.Effect<A, E, R>) => {
     const lockPath = resourceAccountMutationLockPath(path, location.home, location.account);
     const event = {account: location.account, lockPath, uri: id.canonicalUri};
@@ -267,9 +312,17 @@ function createResourceStoreOperations(
         resolved.id,
         Effect.gen(function* () {
           yield* verifyExistingPath(fs, path, resolved);
-          yield* fs.remove(resolved.path, {recursive: options?.recursive === true});
-          yield* syncDirectory(fs, path.dirname(resolved.path));
-          yield* invalidateRecallBestEffort(location, [resolved.id.canonicalUri]);
+          const canonicalMutationGeneration = yield* provideLockServices(
+            advanceCanonicalMutationGeneration(fs, path, location.home, location.account),
+          );
+          yield* fs
+            .remove(resolved.path, {recursive: options?.recursive === true})
+            .pipe(
+              Effect.andThen(syncDirectory(fs, path.dirname(resolved.path))),
+              Effect.ensuring(
+                invalidateRecallBestEffort(location, [resolved.id.canonicalUri], canonicalMutationGeneration),
+              ),
+            );
         }),
       );
     }).pipe(mapIoError('remove', uri));
@@ -320,8 +373,14 @@ function createResourceStoreOperations(
               uri: resolved.id.canonicalUri,
             });
           }
-          yield* writeAtomically(fs, path, resolved, content, options.mode === 'create');
-          yield* invalidateRecallBestEffort(location, [resolved.id.canonicalUri]);
+          const canonicalMutationGeneration = yield* provideLockServices(
+            advanceCanonicalMutationGeneration(fs, path, location.home, location.account),
+          );
+          yield* writeAtomically(fs, path, resolved, content, options.mode === 'create').pipe(
+            Effect.ensuring(
+              invalidateRecallBestEffort(location, [resolved.id.canonicalUri], canonicalMutationGeneration),
+            ),
+          );
         }),
       );
       return {fingerprint, uri: resolved.id.canonicalUri};

--- a/src/effect/resource-store.ts
+++ b/src/effect/resource-store.ts
@@ -15,7 +15,10 @@ import {uriSegment} from '../manifest.js';
 import {globToRegExp} from '../utils.js';
 import {readExclusiveFileLockOwner, withExclusiveFileLock} from './file_lock.js';
 import {resourceAccountMutationLockPath} from './resource_lock.js';
-import {advanceCanonicalMutationGeneration} from './resource_mutation_generation.js';
+import {
+  advanceCanonicalMutationGeneration,
+  type CanonicalMutationGenerationTransition,
+} from './resource_mutation_generation.js';
 import {SystemInfo} from './system.js';
 import {
   canonicalResourceUri,
@@ -226,7 +229,7 @@ function createResourceStoreOperations(
     location: ResourceStoreLocation,
     includeInactive: boolean,
     invalidatedUris: readonly string[],
-    canonicalMutationGeneration: string,
+    canonicalMutationGeneration: CanonicalMutationGenerationTransition,
   ) =>
     provideLockServices(
       expireRecallIndexValidation(location.home, includeInactive, invalidatedUris, canonicalMutationGeneration).pipe(
@@ -236,7 +239,7 @@ function createResourceStoreOperations(
   const invalidateRecallBestEffort = (
     location: ResourceStoreLocation,
     invalidatedUris: readonly string[],
-    canonicalMutationGeneration: string,
+    canonicalMutationGeneration: CanonicalMutationGenerationTransition,
   ) =>
     Effect.forEach(
       [false, true],

--- a/src/effect/resource_lock.ts
+++ b/src/effect/resource_lock.ts
@@ -5,3 +5,8 @@ export function resourceAccountMutationLockPath(path: Path.Path, home: string, a
   validatePortableSegment(account, account);
   return path.join(home, 'locks', 'resources', account, 'mutations.lock');
 }
+
+export function resourceAccountMutationGenerationPath(path: Path.Path, home: string, account: string): string {
+  validatePortableSegment(account, account);
+  return path.join(home, 'locks', 'resources', account, 'canonical-generation-v1');
+}

--- a/src/effect/resource_mutation_generation.ts
+++ b/src/effect/resource_mutation_generation.ts
@@ -1,0 +1,83 @@
+import {Crypto, Effect, FileSystem, Option, Path, Schema} from 'effect';
+import {resourceAccountMutationGenerationPath} from './resource_lock.js';
+
+const CANONICAL_MUTATION_GENERATION_PATTERN =
+  /^v1:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MAXIMUM_CANONICAL_MUTATION_GENERATION_BYTES = 128;
+
+export class CanonicalMutationGenerationInvalid extends Schema.TaggedError<CanonicalMutationGenerationInvalid>()(
+  'CanonicalMutationGenerationInvalid',
+  {message: Schema.String},
+) {}
+
+/**
+ * Read the durable, account-scoped canonical mutation generation. Absence is
+ * the initial generation; a malformed marker fails closed instead of allowing
+ * an index to claim freshness against an untrustworthy clock.
+ */
+export const readCanonicalMutationGeneration = Effect.fn('resourceMutationGeneration.read')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  home: string,
+  account: string,
+) {
+  const generationPath = resourceAccountMutationGenerationPath(path, home, account);
+  if (!(yield* fs.exists(generationPath))) return '';
+  if (Option.isSome(yield* fs.readLink(generationPath).pipe(Effect.option))) {
+    return yield* new CanonicalMutationGenerationInvalid({
+      message: 'Canonical mutation generation must not be a symbolic link.',
+    });
+  }
+  const info = yield* fs.stat(generationPath);
+  if (info.type !== 'File' || Number(info.size) > MAXIMUM_CANONICAL_MUTATION_GENERATION_BYTES) {
+    return yield* new CanonicalMutationGenerationInvalid({
+      message: 'Canonical mutation generation is not a bounded regular file.',
+    });
+  }
+  const generation = (yield* fs.readFileString(generationPath)).trim();
+  if (!CANONICAL_MUTATION_GENERATION_PATTERN.test(generation)) {
+    return yield* new CanonicalMutationGenerationInvalid({message: 'Canonical mutation generation is malformed.'});
+  }
+  return generation;
+});
+
+/**
+ * Advance and fsync the durable generation before a canonical mutation while
+ * the caller owns the account mutation lock. A failed advance prevents the
+ * mutation, so every successful commit is discoverable even when derived
+ * recall-index marker I/O later fails.
+ */
+export const advanceCanonicalMutationGeneration = Effect.fn('resourceMutationGeneration.advance')(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  home: string,
+  account: string,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const generationPath = resourceAccountMutationGenerationPath(path, home, account);
+  const directory = path.dirname(generationPath);
+  const generation = `v1:${yield* crypto.randomUUIDv4}`;
+  const temporaryPath = `${generationPath}.${yield* crypto.randomUUIDv4}.tmp`;
+  yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
+  yield* Effect.scoped(
+    Effect.gen(function* () {
+      const file = yield* fs.open(temporaryPath, {flag: 'wx', mode: 0o600});
+      yield* file.writeAll(new TextEncoder().encode(`${generation}\n`));
+      yield* file.sync;
+    }),
+  ).pipe(
+    Effect.andThen(fs.rename(temporaryPath, generationPath)),
+    Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.catch(() => Effect.void))),
+  );
+  yield* syncMutationGenerationDirectory(fs, directory);
+  return generation;
+});
+
+function syncMutationGenerationDirectory(fs: FileSystem.FileSystem, directory: string): Effect.Effect<void, never> {
+  return Effect.scoped(
+    fs.open(directory, {flag: 'r'}).pipe(
+      Effect.flatMap(file => file.sync),
+      Effect.catch(() => Effect.void),
+    ),
+  );
+}

--- a/src/effect/resource_mutation_generation.ts
+++ b/src/effect/resource_mutation_generation.ts
@@ -10,6 +10,11 @@ export class CanonicalMutationGenerationInvalid extends Schema.TaggedError<Canon
   {message: Schema.String},
 ) {}
 
+export interface CanonicalMutationGenerationTransition {
+  readonly currentGeneration: string;
+  readonly previousGeneration: string;
+}
+
 /**
  * Read the durable, account-scoped canonical mutation generation. Absence is
  * the initial generation; a malformed marker fails closed instead of allowing
@@ -54,6 +59,7 @@ export const advanceCanonicalMutationGeneration = Effect.fn('resourceMutationGen
   account: string,
 ) {
   const crypto = yield* Crypto.Crypto;
+  const previousGeneration = yield* readCanonicalMutationGeneration(fs, path, home, account);
   const generationPath = resourceAccountMutationGenerationPath(path, home, account);
   const directory = path.dirname(generationPath);
   const generation = `v1:${yield* crypto.randomUUIDv4}`;
@@ -70,7 +76,10 @@ export const advanceCanonicalMutationGeneration = Effect.fn('resourceMutationGen
     Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.catch(() => Effect.void))),
   );
   yield* syncMutationGenerationDirectory(fs, directory);
-  return generation;
+  return {
+    currentGeneration: generation,
+    previousGeneration,
+  } satisfies CanonicalMutationGenerationTransition;
 });
 
 function syncMutationGenerationDirectory(fs: FileSystem.FileSystem, directory: string): Effect.Effect<void, never> {

--- a/src/mcp/server/memory_read_recovery.ts
+++ b/src/mcp/server/memory_read_recovery.ts
@@ -1,5 +1,5 @@
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
-import {memoryReadRecoveryForError, memoryReadRecoveryText} from '../memory_read_recovery.js';
+import {memoryReadRecoveryForError, memoryReadRecoveryText} from '../../memory/read_recovery.js';
 import type {RuntimeConfig} from '../../types.js';
 import {memoryIdentityAlias} from '../../memory/identity_alias.js';
 import {MemoryIdentityResolutionError} from '../../recall/memory_identity.js';

--- a/src/memory/commands.ts
+++ b/src/memory/commands.ts
@@ -71,6 +71,7 @@ import {
   readMemoryWithRelocations,
   recordMemoryRelocation,
 } from './relocation.js';
+import {memoryReadRecoveryForError, memoryReadRecoveryText} from './read_recovery.js';
 import type {StoreMemoryOptions} from './store_contract.js';
 import {
   attemptSync,
@@ -726,7 +727,12 @@ export const runRead = Effect.fn('runRead')(function* (config: RuntimeConfig, ur
   );
   const canonicalUri = identity!.canonicalUri;
   if (isMemoryRelocationUri(config, canonicalUri)) {
-    const resolved = yield* readMemoryWithRelocations(config, canonicalUri);
+    const resolved = yield* readMemoryWithRelocations(config, canonicalUri).pipe(
+      Effect.tapError(error => {
+        const recovery = memoryReadRecoveryForError(config, error);
+        return recovery === undefined ? Effect.void : Console.error(memoryReadRecoveryText(recovery));
+      }),
+    );
     yield* verifyResolvedMemoryIdentity(identity!, resolved.canonicalUri, resolved.content);
     if (identity!.requestedUri !== resolved.canonicalUri) {
       yield* Console.error(`Resolved memory: ${identity!.requestedUri} -> ${resolved.canonicalUri}`);

--- a/src/memory/read_recovery.ts
+++ b/src/memory/read_recovery.ts
@@ -1,7 +1,7 @@
-import {parsePersonalMemoryUri} from '../memory/hygiene.js';
-import {MemoryPointerNotFound} from '../memory/relocation.js';
 import {parseResourceId} from '../storage/resource-id.js';
 import type {RuntimeConfig} from '../types.js';
+import {parsePersonalMemoryUri} from './hygiene.js';
+import {MemoryPointerNotFound} from './relocation.js';
 
 export interface MemoryReadRecoveryV1 {
   readonly code: 'memory-resource-not-found';

--- a/src/migration/layout.ts
+++ b/src/migration/layout.ts
@@ -2,6 +2,7 @@ import {Crypto, Effect, FileSystem, Option, Path, Schema} from 'effect';
 import {sha256FileHex, sha256Hex} from '../effect/digest.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
 import {resourceAccountMutationLockPath} from '../effect/resource_lock.js';
+import {advanceCanonicalMutationGeneration} from '../effect/resource_mutation_generation.js';
 import {SystemInfo} from '../effect/system.js';
 import {
   LEGACY_THREADNOTE_DATA_DIRECTORY,
@@ -172,6 +173,7 @@ export const migrateThreadnoteStorageLayout = Effect.fn('storageLayoutMigration.
           (yield* hasBoundedMigrationTreeContent(fs, path, source, (candidate, type) =>
             shouldIncludeLegacyCanonicalStorePath(path, legacyRoot, candidate, type),
           ));
+        yield* advanceCanonicalMutationGeneration(fs, path, home, account.name);
         if (!sourceHasMaterial) {
           if (!targetExists) {
             return yield* new StorageLayoutMigrationConflict({

--- a/src/recall/index.ts
+++ b/src/recall/index.ts
@@ -4,6 +4,8 @@ import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {SEED_STATE_FILE} from '../constants.js';
 import {sha256Hex} from '../effect/digest.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
+import {resourceAccountMutationLockPath} from '../effect/resource_lock.js';
+import {readCanonicalMutationGeneration} from '../effect/resource_mutation_generation.js';
 import {SystemInfo} from '../effect/system.js';
 import {parseSeedManifest} from '../manifest.js';
 import {
@@ -51,6 +53,7 @@ import {
   type RecallCodeLinkQueryOptions,
 } from './code_links.js';
 import * as RecallIndexIdentity from './index_identity.js';
+import {recallIndexForegroundRefreshRequired} from './index_freshness.js';
 import {
   combineRecallSqlPredicates,
   recallUriMatchesScopes,
@@ -174,7 +177,6 @@ const RECALL_INDEX_POINTER_VERSION = 1;
 const RECALL_STALE_MARKER_VERSION = 1;
 const ACTIVE_DATABASE_FILENAME = `active-v${RECALL_INDEX_DATABASE_VERSION}.sqlite`;
 const INACTIVE_DATABASE_FILENAME = `with-inactive-v${RECALL_INDEX_DATABASE_VERSION}.sqlite`;
-const CACHE_VALIDATION_INTERVAL_MILLISECONDS = 30_000;
 const MAX_RECALL_INVALIDATED_URIS = 1_024;
 const DEFAULT_QUERY_RESULT_LIMIT = 100;
 const QUERY_POSTING_POOL_MULTIPLIER = 5;
@@ -188,6 +190,7 @@ interface RecallIndexPointer {
 }
 
 interface RecallStaleMarker {
+  readonly canonicalMutationGeneration?: string;
   readonly forceRefresh: boolean;
   readonly generation: string;
   readonly invalidatedUris: readonly string[];
@@ -503,6 +506,21 @@ export const recallIndexStatus = Effect.fn('recall.indexStatus')(function* (
           reason: 'integrity sequence mismatch; run `threadnote repair`',
         } satisfies RecallIndexStatus;
       }
+      const canonicalMutationGeneration = yield* readCanonicalMutationGeneration(
+        fs,
+        path,
+        config.agentContextHome,
+        config.account,
+      );
+      if ((metadata.get('canonical_mutation_generation') ?? '') !== canonicalMutationGeneration) {
+        return {
+          databasePath,
+          documentCount: numericMetadata(metadata, 'document_count'),
+          generation: metadata.get('content_generation'),
+          ready: false,
+          reason: 'canonical documents changed; run `threadnote repair`',
+        } satisfies RecallIndexStatus;
+      }
       const staleMarker = yield* readStaleMarker(fs, fixedDatabasePath);
       if (metadata.get('stale_generation') !== (staleMarker?.generation ?? '')) {
         return {
@@ -576,12 +594,13 @@ export const expireRecallIndexValidation = Effect.fn('recall.expireValidation')(
   agentContextHome: string,
   includeInactive: boolean,
   invalidatedUris?: readonly string[],
+  canonicalMutationGeneration?: string,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
   const databasePath = recallIndexDatabasePath(pathService, agentContextHome, includeInactive);
   yield* fs.makeDirectory(pathService.dirname(databasePath), {recursive: true, mode: 0o700});
-  yield* writeStaleGeneration(fs, databasePath, invalidatedUris);
+  yield* writeStaleGeneration(fs, databasePath, invalidatedUris, canonicalMutationGeneration);
 });
 
 const selectRecallIndexData = Effect.fn('recall.selectIndexData')(function* (
@@ -1044,47 +1063,77 @@ const ensureRecallDatabaseFresh = Effect.fn('recall.ensureDatabaseFresh')(functi
 ) {
   const metadata = yield* loadRecallMetadata(sql);
   const staleMarker = yield* readStaleMarker(fs, staleMarkerBasePath);
-  const now = yield* Clock.currentTimeMillis;
+  const canonicalMutationGeneration = yield* readCanonicalMutationGeneration(
+    fs,
+    path,
+    config.agentContextHome,
+    config.account,
+  );
   if (
-    options.forceRefresh !== true &&
-    RecallIndexIdentity.recallIndexMetadataIsCurrent(metadata) &&
-    metadata.get('initialized') === 'true' &&
-    metadata.get('stale_generation') === (staleMarker?.generation ?? '') &&
-    now - numericMetadata(metadata, 'validated_at') < CACHE_VALIDATION_INTERVAL_MILLISECONDS
+    !recallIndexForegroundRefreshRequired(
+      recallIndexForegroundFreshness(metadata, staleMarker, canonicalMutationGeneration, options),
+    )
   ) {
     return;
   }
-  const refresh = Effect.gen(function* () {
-    const lockedMetadata = yield* loadRecallMetadata(sql);
-    const lockedStaleMarker = yield* readStaleMarker(fs, staleMarkerBasePath);
-    const lockedNow = yield* Clock.currentTimeMillis;
-    if (
-      options.forceRefresh !== true &&
-      RecallIndexIdentity.recallIndexMetadataIsCurrent(lockedMetadata) &&
-      lockedMetadata.get('initialized') === 'true' &&
-      lockedMetadata.get('stale_generation') === (lockedStaleMarker?.generation ?? '') &&
-      lockedNow - numericMetadata(lockedMetadata, 'validated_at') < CACHE_VALIDATION_INTERVAL_MILLISECONDS
-    ) {
-      return;
-    }
-    const repairLogicalCorruption =
-      lockedMetadata.get('initialized') === 'true' && !RecallIndexIdentity.recallIndexMetadataIsCurrent(lockedMetadata);
-    yield* refreshRecallDatabase(
-      sql,
-      fs,
-      path,
-      databasePath,
-      staleMarkerBasePath,
-      config,
-      options.includeInactive,
-      options.forceRefresh === true || repairLogicalCorruption,
-      options.onProgress,
-    );
-  });
+  const refresh = withCanonicalResourceMutationLock(
+    fs,
+    path,
+    config.agentContextHome,
+    config.account,
+    Effect.gen(function* () {
+      const lockedMetadata = yield* loadRecallMetadata(sql);
+      const lockedStaleMarker = yield* readStaleMarker(fs, staleMarkerBasePath);
+      const lockedCanonicalMutationGeneration = yield* readCanonicalMutationGeneration(
+        fs,
+        path,
+        config.agentContextHome,
+        config.account,
+      );
+      if (
+        !recallIndexForegroundRefreshRequired(
+          recallIndexForegroundFreshness(lockedMetadata, lockedStaleMarker, lockedCanonicalMutationGeneration, options),
+        )
+      ) {
+        return;
+      }
+      const repairLogicalCorruption =
+        lockedMetadata.get('initialized') === 'true' &&
+        !RecallIndexIdentity.recallIndexMetadataIsCurrent(lockedMetadata);
+      yield* refreshRecallDatabase(
+        sql,
+        fs,
+        path,
+        databasePath,
+        staleMarkerBasePath,
+        config,
+        options.includeInactive,
+        options.forceRefresh === true || repairLogicalCorruption,
+        options.onProgress,
+      );
+    }),
+  );
   yield* indexLockHeld
     ? refresh
     : withRecallIndexLock(fs, path, config.agentContextHome, options.includeInactive, () => refresh);
 });
+
+function recallIndexForegroundFreshness(
+  metadata: ReadonlyMap<string, string>,
+  staleMarker: RecallStaleMarker | undefined,
+  canonicalMutationGeneration: string,
+  options: Pick<LoadRecallIndexOptions, 'forceRefresh'>,
+) {
+  return {
+    forceRefresh: options.forceRefresh === true,
+    initialized: metadata.get('initialized') === 'true',
+    integrityCurrent: RecallIndexIdentity.recallIndexMetadataIsCurrent(metadata),
+    observedCanonicalMutationGeneration: canonicalMutationGeneration,
+    observedStaleGeneration: staleMarker?.generation ?? '',
+    persistedCanonicalMutationGeneration: metadata.get('canonical_mutation_generation') ?? '',
+    persistedStaleGeneration: metadata.get('stale_generation') ?? '',
+  };
+}
 
 const refreshRecallDatabase = Effect.fn('recall.refreshDatabase')(function* (
   sql: SqlClient.SqlClient,
@@ -1099,9 +1148,17 @@ const refreshRecallDatabase = Effect.fn('recall.refreshDatabase')(function* (
 ) {
   const staleMarker = yield* readStaleMarker(fs, staleMarkerBasePath);
   const staleGeneration = staleMarker?.generation;
+  const canonicalMutationGeneration = yield* readCanonicalMutationGeneration(
+    fs,
+    path,
+    config.agentContextHome,
+    config.account,
+  );
   const canonicalResourcePolicy = yield* loadCanonicalResourcePolicy(config);
   const previousMetadata = yield* loadRecallMetadata(sql);
   const markerChanged = previousMetadata.get('stale_generation') !== (staleGeneration ?? '');
+  const canonicalMutationGenerationChanged =
+    (previousMetadata.get('canonical_mutation_generation') ?? '') !== canonicalMutationGeneration;
   const invalidatedUris = markerChanged ? new Set(staleMarker?.invalidatedUris ?? []) : new Set<string>();
   const forceFromMarker = markerChanged && staleMarker?.forceRefresh === true;
   const sourceScan = yield* scanRecallSources(
@@ -1113,7 +1170,11 @@ const refreshRecallDatabase = Effect.fn('recall.refreshDatabase')(function* (
     canonicalResourcePolicy,
     invalidatedUris,
   );
-  const forceAllSources = forceRefresh || forceFromMarker;
+  const forceAllSources =
+    forceRefresh ||
+    forceFromMarker ||
+    (canonicalMutationGenerationChanged &&
+      (staleMarker?.canonicalMutationGeneration ?? '') !== canonicalMutationGeneration);
   const refreshCounts = yield* countRecallSourceChanges(sql, forceAllSources);
   yield* onProgress?.({
     completed: 0,
@@ -1279,6 +1340,7 @@ const refreshRecallDatabase = Effect.fn('recall.refreshDatabase')(function* (
       const logicalDocumentCount = logicalAggregate[0]?.document_count ?? 0;
       const logicalTotalDocumentLength = logicalAggregate[0]?.total_document_length ?? 0;
       const metadataEntries = [
+        ['canonical_mutation_generation', canonicalMutationGeneration],
         ['content_generation', contentGeneration],
         ['document_count', String(documentCount)],
         ['include_inactive', includeInactive ? 'true' : 'false'],
@@ -1403,6 +1465,26 @@ function withRecallIndexLock<A, E, R>(
       waitTimeoutMilliseconds: 120_000,
     },
     Effect.suspend(effect),
+  );
+}
+
+function withCanonicalResourceMutationLock<A, E, R>(
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  home: string,
+  account: string,
+  effect: Effect.Effect<A, E, R>,
+) {
+  return withExclusiveFileLock(
+    fs,
+    resourceAccountMutationLockPath(path, home, account),
+    {
+      heartbeatIntervalMilliseconds: 10_000,
+      retryIntervalMilliseconds: 25,
+      staleAfterMilliseconds: 30_000,
+      waitTimeoutMilliseconds: 30_000,
+    },
+    effect,
   );
 }
 
@@ -1538,11 +1620,16 @@ function readStaleMarker(fs: FileSystem.FileSystem, path: string): Effect.Effect
       typeof (value as {readonly generation?: unknown}).generation === 'string' &&
       (value as {readonly generation: string}).generation.length > 0 &&
       typeof (value as {readonly forceRefresh?: unknown}).forceRefresh === 'boolean' &&
+      (!('canonicalMutationGeneration' in value) ||
+        typeof (value as {readonly canonicalMutationGeneration?: unknown}).canonicalMutationGeneration === 'string') &&
       Array.isArray((value as {readonly invalidatedUris?: unknown}).invalidatedUris) &&
       (value as {readonly invalidatedUris: readonly unknown[]}).invalidatedUris.every(uri => typeof uri === 'string')
     ) {
       const marker = value as RecallStaleMarker;
       return {
+        ...(marker.canonicalMutationGeneration === undefined
+          ? {}
+          : {canonicalMutationGeneration: marker.canonicalMutationGeneration}),
         forceRefresh: marker.forceRefresh,
         generation: marker.generation,
         invalidatedUris: [...new Set(marker.invalidatedUris.map(stripRecallAnchor))],
@@ -1562,6 +1649,7 @@ const writeStaleGeneration = Effect.fn('recall.writeStaleGeneration')(function* 
   fs: FileSystem.FileSystem,
   path: string,
   invalidatedUris?: readonly string[],
+  canonicalMutationGeneration?: string,
 ) {
   const system = yield* SystemInfo;
   const counter = yield* Effect.sync(() => {
@@ -1583,7 +1671,11 @@ const writeStaleGeneration = Effect.fn('recall.writeStaleGeneration')(function* 
     invalidatedUris === undefined ||
     previous?.forceRefresh === true ||
     mergedInvalidatedUris.length > MAX_RECALL_INVALIDATED_URIS;
+  const linkedCanonicalMutationGeneration = canonicalMutationGeneration ?? previous?.canonicalMutationGeneration;
   const marker: RecallStaleMarker = {
+    ...(linkedCanonicalMutationGeneration === undefined
+      ? {}
+      : {canonicalMutationGeneration: linkedCanonicalMutationGeneration}),
     forceRefresh,
     generation,
     invalidatedUris: forceRefresh ? [] : mergedInvalidatedUris,
@@ -1614,6 +1706,9 @@ const clearStaleMarkerInvalidations = Effect.fn('recall.clearStaleMarkerInvalida
   const stalePath = `${path}.stale`;
   const temporaryPath = `${stalePath}.${system.processId}.${counter}.tmp`;
   const cleared: RecallStaleMarker = {
+    ...(observed.canonicalMutationGeneration === undefined
+      ? {}
+      : {canonicalMutationGeneration: observed.canonicalMutationGeneration}),
     forceRefresh: false,
     generation: observed.generation,
     invalidatedUris: [],

--- a/src/recall/index.ts
+++ b/src/recall/index.ts
@@ -5,7 +5,10 @@ import {SEED_STATE_FILE} from '../constants.js';
 import {sha256Hex} from '../effect/digest.js';
 import {withExclusiveFileLock} from '../effect/file_lock.js';
 import {resourceAccountMutationLockPath} from '../effect/resource_lock.js';
-import {readCanonicalMutationGeneration} from '../effect/resource_mutation_generation.js';
+import {
+  readCanonicalMutationGeneration,
+  type CanonicalMutationGenerationTransition,
+} from '../effect/resource_mutation_generation.js';
 import {SystemInfo} from '../effect/system.js';
 import {parseSeedManifest} from '../manifest.js';
 import {
@@ -53,7 +56,16 @@ import {
   type RecallCodeLinkQueryOptions,
 } from './code_links.js';
 import * as RecallIndexIdentity from './index_identity.js';
-import {recallIndexForegroundRefreshRequired} from './index_freshness.js';
+import {
+  recallIndexCanonicalMutationContinuityAllowsIncrementalRefresh,
+  recallIndexForegroundRefreshRequired,
+} from './index_freshness.js';
+import {
+  clearRecallStaleMarkerInvalidations as clearStaleMarkerInvalidations,
+  readRecallStaleMarker as readStaleMarker,
+  type RecallStaleMarker,
+  writeRecallStaleGeneration as writeStaleGeneration,
+} from './index_stale_marker.js';
 import {
   combineRecallSqlPredicates,
   recallUriMatchesScopes,
@@ -174,10 +186,8 @@ interface RecallTermStatisticRow {
 
 const RECALL_INDEX_DATABASE_VERSION = 11;
 const RECALL_INDEX_POINTER_VERSION = 1;
-const RECALL_STALE_MARKER_VERSION = 1;
 const ACTIVE_DATABASE_FILENAME = `active-v${RECALL_INDEX_DATABASE_VERSION}.sqlite`;
 const INACTIVE_DATABASE_FILENAME = `with-inactive-v${RECALL_INDEX_DATABASE_VERSION}.sqlite`;
-const MAX_RECALL_INVALIDATED_URIS = 1_024;
 const DEFAULT_QUERY_RESULT_LIMIT = 100;
 const QUERY_POSTING_POOL_MULTIPLIER = 5;
 const MINIMUM_QUERY_POSTING_POOL = 500;
@@ -187,14 +197,6 @@ let staleGenerationCounter = 0;
 interface RecallIndexPointer {
   readonly database: string;
   readonly version: typeof RECALL_INDEX_POINTER_VERSION;
-}
-
-interface RecallStaleMarker {
-  readonly canonicalMutationGeneration?: string;
-  readonly forceRefresh: boolean;
-  readonly generation: string;
-  readonly invalidatedUris: readonly string[];
-  readonly version: typeof RECALL_STALE_MARKER_VERSION;
 }
 
 class RecallIndexCorrupt extends Error {
@@ -594,7 +596,7 @@ export const expireRecallIndexValidation = Effect.fn('recall.expireValidation')(
   agentContextHome: string,
   includeInactive: boolean,
   invalidatedUris?: readonly string[],
-  canonicalMutationGeneration?: string,
+  canonicalMutationGeneration?: CanonicalMutationGenerationTransition,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
@@ -1159,6 +1161,17 @@ const refreshRecallDatabase = Effect.fn('recall.refreshDatabase')(function* (
   const markerChanged = previousMetadata.get('stale_generation') !== (staleGeneration ?? '');
   const canonicalMutationGenerationChanged =
     (previousMetadata.get('canonical_mutation_generation') ?? '') !== canonicalMutationGeneration;
+  const canonicalMutationContinuityAllowsIncrementalRefresh =
+    recallIndexCanonicalMutationContinuityAllowsIncrementalRefresh({
+      ...(staleMarker?.canonicalMutationGeneration === undefined
+        ? {}
+        : {markerCurrentGeneration: staleMarker.canonicalMutationGeneration}),
+      ...(staleMarker?.previousCanonicalMutationGeneration === undefined
+        ? {}
+        : {markerPreviousGeneration: staleMarker.previousCanonicalMutationGeneration}),
+      observedGeneration: canonicalMutationGeneration,
+      persistedGeneration: previousMetadata.get('canonical_mutation_generation') ?? '',
+    });
   const invalidatedUris = markerChanged ? new Set(staleMarker?.invalidatedUris ?? []) : new Set<string>();
   const forceFromMarker = markerChanged && staleMarker?.forceRefresh === true;
   const sourceScan = yield* scanRecallSources(
@@ -1173,8 +1186,7 @@ const refreshRecallDatabase = Effect.fn('recall.refreshDatabase')(function* (
   const forceAllSources =
     forceRefresh ||
     forceFromMarker ||
-    (canonicalMutationGenerationChanged &&
-      (staleMarker?.canonicalMutationGeneration ?? '') !== canonicalMutationGeneration);
+    (canonicalMutationGenerationChanged && !canonicalMutationContinuityAllowsIncrementalRefresh);
   const refreshCounts = yield* countRecallSourceChanges(sql, forceAllSources);
   yield* onProgress?.({
     completed: 0,
@@ -1603,122 +1615,6 @@ function uriTopic(uri: string): string {
 function uriBasename(uri: string): string {
   return uri.slice(uri.lastIndexOf('/') + 1);
 }
-
-function readStaleMarker(fs: FileSystem.FileSystem, path: string): Effect.Effect<RecallStaleMarker | undefined, never> {
-  return Effect.gen(function* () {
-    const stalePath = `${path}.stale`;
-    if (!(yield* fs.exists(stalePath).pipe(Effect.catch(() => Effect.succeed(false))))) {
-      return undefined;
-    }
-    const raw = yield* fs.readFileString(stalePath).pipe(Effect.catch(() => Effect.succeed('present')));
-    const legacyGeneration = raw.trim() || 'present';
-    const value = Option.getOrUndefined(Option.liftThrowable((content: string): unknown => JSON.parse(content))(raw));
-    if (
-      typeof value === 'object' &&
-      value !== null &&
-      (value as {readonly version?: unknown}).version === RECALL_STALE_MARKER_VERSION &&
-      typeof (value as {readonly generation?: unknown}).generation === 'string' &&
-      (value as {readonly generation: string}).generation.length > 0 &&
-      typeof (value as {readonly forceRefresh?: unknown}).forceRefresh === 'boolean' &&
-      (!('canonicalMutationGeneration' in value) ||
-        typeof (value as {readonly canonicalMutationGeneration?: unknown}).canonicalMutationGeneration === 'string') &&
-      Array.isArray((value as {readonly invalidatedUris?: unknown}).invalidatedUris) &&
-      (value as {readonly invalidatedUris: readonly unknown[]}).invalidatedUris.every(uri => typeof uri === 'string')
-    ) {
-      const marker = value as RecallStaleMarker;
-      return {
-        ...(marker.canonicalMutationGeneration === undefined
-          ? {}
-          : {canonicalMutationGeneration: marker.canonicalMutationGeneration}),
-        forceRefresh: marker.forceRefresh,
-        generation: marker.generation,
-        invalidatedUris: [...new Set(marker.invalidatedUris.map(stripRecallAnchor))],
-        version: RECALL_STALE_MARKER_VERSION,
-      };
-    }
-    return {
-      forceRefresh: true,
-      generation: legacyGeneration,
-      invalidatedUris: [],
-      version: RECALL_STALE_MARKER_VERSION,
-    };
-  });
-}
-
-const writeStaleGeneration = Effect.fn('recall.writeStaleGeneration')(function* (
-  fs: FileSystem.FileSystem,
-  path: string,
-  invalidatedUris?: readonly string[],
-  canonicalMutationGeneration?: string,
-) {
-  const system = yield* SystemInfo;
-  const counter = yield* Effect.sync(() => {
-    staleGenerationCounter += 1;
-    return staleGenerationCounter;
-  });
-  const generation = `${yield* Clock.currentTimeMillis}:${system.processId}:${counter}`;
-  const stalePath = `${path}.stale`;
-  const previous = yield* readStaleMarker(fs, path);
-  const mergedInvalidatedUris = [
-    ...new Set(
-      [...(previous?.invalidatedUris ?? []), ...(invalidatedUris ?? [])]
-        .map(stripRecallAnchor)
-        .map(uri => uri.replace(/\/+$/, ''))
-        .filter(Boolean),
-    ),
-  ];
-  const forceRefresh =
-    invalidatedUris === undefined ||
-    previous?.forceRefresh === true ||
-    mergedInvalidatedUris.length > MAX_RECALL_INVALIDATED_URIS;
-  const linkedCanonicalMutationGeneration = canonicalMutationGeneration ?? previous?.canonicalMutationGeneration;
-  const marker: RecallStaleMarker = {
-    ...(linkedCanonicalMutationGeneration === undefined
-      ? {}
-      : {canonicalMutationGeneration: linkedCanonicalMutationGeneration}),
-    forceRefresh,
-    generation,
-    invalidatedUris: forceRefresh ? [] : mergedInvalidatedUris,
-    version: RECALL_STALE_MARKER_VERSION,
-  };
-  const temporaryPath = `${stalePath}.${system.processId}.${counter}.tmp`;
-  yield* fs.writeFileString(temporaryPath, `${JSON.stringify(marker)}\n`, {mode: 0o600});
-  yield* fs
-    .rename(temporaryPath, stalePath)
-    .pipe(Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.catch(() => Effect.void))));
-  return generation;
-});
-
-const clearStaleMarkerInvalidations = Effect.fn('recall.clearStaleMarkerInvalidations')(function* (
-  fs: FileSystem.FileSystem,
-  path: string,
-  observed: RecallStaleMarker,
-) {
-  const current = yield* readStaleMarker(fs, path);
-  if (current?.generation !== observed.generation) {
-    return;
-  }
-  const system = yield* SystemInfo;
-  const counter = yield* Effect.sync(() => {
-    staleGenerationCounter += 1;
-    return staleGenerationCounter;
-  });
-  const stalePath = `${path}.stale`;
-  const temporaryPath = `${stalePath}.${system.processId}.${counter}.tmp`;
-  const cleared: RecallStaleMarker = {
-    ...(observed.canonicalMutationGeneration === undefined
-      ? {}
-      : {canonicalMutationGeneration: observed.canonicalMutationGeneration}),
-    forceRefresh: false,
-    generation: observed.generation,
-    invalidatedUris: [],
-    version: RECALL_STALE_MARKER_VERSION,
-  };
-  yield* fs.writeFileString(temporaryPath, `${JSON.stringify(cleared)}\n`, {mode: 0o600});
-  yield* fs
-    .rename(temporaryPath, stalePath)
-    .pipe(Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.catch(() => Effect.void))));
-});
 
 function loadCanonicalResourcePolicy(
   config: RecallIndexConfig,

--- a/src/recall/index_freshness.ts
+++ b/src/recall/index_freshness.ts
@@ -8,6 +8,30 @@ export interface RecallIndexForegroundFreshness {
   readonly persistedStaleGeneration: string;
 }
 
+export interface RecallIndexCanonicalMutationContinuity {
+  readonly markerCurrentGeneration?: string;
+  readonly markerPreviousGeneration?: string;
+  readonly observedGeneration: string;
+  readonly persistedGeneration: string;
+}
+
+export interface RecallIndexCanonicalMutationTransition {
+  readonly currentGeneration: string;
+  readonly previousGeneration: string;
+}
+
+export interface RecallIndexPendingCanonicalMutationContinuity {
+  readonly currentGeneration?: string;
+  readonly pending: boolean;
+  readonly previousGeneration?: string;
+}
+
+export interface RecallIndexMergedCanonicalMutationContinuity {
+  readonly continuous: boolean;
+  readonly currentGeneration?: string;
+  readonly previousGeneration?: string;
+}
+
 /**
  * Keep ordinary recall reads independent of corpus size. Threadnote-managed
  * writes publish a new stale generation, while explicit maintenance can force
@@ -23,4 +47,50 @@ export function recallIndexForegroundRefreshRequired(input: RecallIndexForegroun
     input.persistedCanonicalMutationGeneration !== input.observedCanonicalMutationGeneration ||
     input.persistedStaleGeneration !== input.observedStaleGeneration
   );
+}
+
+/**
+ * A targeted marker may cover canonical changes only when it proves one
+ * unbroken transition from the generation indexed by SQLite to the current
+ * durable generation. Missing legacy endpoints and skipped mutations fail
+ * closed into a full reconciliation.
+ */
+export function recallIndexCanonicalMutationContinuityAllowsIncrementalRefresh(
+  input: RecallIndexCanonicalMutationContinuity,
+): boolean {
+  return (
+    input.persistedGeneration === input.observedGeneration ||
+    (input.markerPreviousGeneration === input.persistedGeneration &&
+      input.markerCurrentGeneration === input.observedGeneration)
+  );
+}
+
+/** Merge consecutive per-URI invalidations without hiding a missing mutation. */
+export function mergeRecallIndexCanonicalMutationContinuity(
+  previous: RecallIndexPendingCanonicalMutationContinuity | undefined,
+  transition: RecallIndexCanonicalMutationTransition | undefined,
+): RecallIndexMergedCanonicalMutationContinuity {
+  if (transition === undefined) {
+    return {
+      continuous: true,
+      ...(previous?.currentGeneration === undefined ? {} : {currentGeneration: previous.currentGeneration}),
+      ...(previous?.previousGeneration === undefined ? {} : {previousGeneration: previous.previousGeneration}),
+    };
+  }
+  if (previous?.pending !== true) {
+    return {
+      continuous: true,
+      currentGeneration: transition.currentGeneration,
+      previousGeneration: transition.previousGeneration,
+    };
+  }
+  const continuous =
+    previous.currentGeneration !== undefined &&
+    previous.previousGeneration !== undefined &&
+    previous.currentGeneration === transition.previousGeneration;
+  return {
+    continuous,
+    currentGeneration: transition.currentGeneration,
+    previousGeneration: continuous ? previous.previousGeneration : transition.previousGeneration,
+  };
 }

--- a/src/recall/index_freshness.ts
+++ b/src/recall/index_freshness.ts
@@ -1,0 +1,26 @@
+export interface RecallIndexForegroundFreshness {
+  readonly observedCanonicalMutationGeneration: string;
+  readonly forceRefresh: boolean;
+  readonly initialized: boolean;
+  readonly integrityCurrent: boolean;
+  readonly observedStaleGeneration: string;
+  readonly persistedCanonicalMutationGeneration: string;
+  readonly persistedStaleGeneration: string;
+}
+
+/**
+ * Keep ordinary recall reads independent of corpus size. Threadnote-managed
+ * writes publish a new stale generation, while explicit maintenance can force
+ * a source validation. Wall-clock age alone is not a foreground refresh
+ * signal: re-walking every canonical source would otherwise create periodic
+ * latency cliffs for unchanged large corpora.
+ */
+export function recallIndexForegroundRefreshRequired(input: RecallIndexForegroundFreshness): boolean {
+  return (
+    input.forceRefresh ||
+    !input.initialized ||
+    !input.integrityCurrent ||
+    input.persistedCanonicalMutationGeneration !== input.observedCanonicalMutationGeneration ||
+    input.persistedStaleGeneration !== input.observedStaleGeneration
+  );
+}

--- a/src/recall/index_stale_marker.ts
+++ b/src/recall/index_stale_marker.ts
@@ -1,0 +1,164 @@
+import {Clock, Effect, FileSystem, Option} from 'effect';
+import type {CanonicalMutationGenerationTransition} from '../effect/resource_mutation_generation.js';
+import {SystemInfo} from '../effect/system.js';
+import {mergeRecallIndexCanonicalMutationContinuity} from './index_freshness.js';
+import {stripRecallAnchor} from './index_lexical.js';
+
+const RECALL_STALE_MARKER_VERSION = 1;
+const MAX_RECALL_INVALIDATED_URIS = 1_024;
+let staleMarkerGenerationCounter = 0;
+
+export interface RecallStaleMarker {
+  readonly canonicalMutationGeneration?: string;
+  readonly forceRefresh: boolean;
+  readonly generation: string;
+  readonly invalidatedUris: readonly string[];
+  readonly previousCanonicalMutationGeneration?: string;
+  readonly version: typeof RECALL_STALE_MARKER_VERSION;
+}
+
+export function readRecallStaleMarker(
+  fs: FileSystem.FileSystem,
+  path: string,
+): Effect.Effect<RecallStaleMarker | undefined, never> {
+  return Effect.gen(function* () {
+    const stalePath = `${path}.stale`;
+    if (!(yield* fs.exists(stalePath).pipe(Effect.catch(() => Effect.succeed(false))))) {
+      return undefined;
+    }
+    const raw = yield* fs.readFileString(stalePath).pipe(Effect.catch(() => Effect.succeed('present')));
+    const legacyGeneration = raw.trim() || 'present';
+    const value = Option.getOrUndefined(Option.liftThrowable((content: string): unknown => JSON.parse(content))(raw));
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      (value as {readonly version?: unknown}).version === RECALL_STALE_MARKER_VERSION &&
+      typeof (value as {readonly generation?: unknown}).generation === 'string' &&
+      (value as {readonly generation: string}).generation.length > 0 &&
+      typeof (value as {readonly forceRefresh?: unknown}).forceRefresh === 'boolean' &&
+      (!('canonicalMutationGeneration' in value) ||
+        typeof (value as {readonly canonicalMutationGeneration?: unknown}).canonicalMutationGeneration === 'string') &&
+      (!('previousCanonicalMutationGeneration' in value) ||
+        typeof (value as {readonly previousCanonicalMutationGeneration?: unknown})
+          .previousCanonicalMutationGeneration === 'string') &&
+      Array.isArray((value as {readonly invalidatedUris?: unknown}).invalidatedUris) &&
+      (value as {readonly invalidatedUris: readonly unknown[]}).invalidatedUris.every(uri => typeof uri === 'string')
+    ) {
+      const marker = value as RecallStaleMarker;
+      return {
+        ...(marker.canonicalMutationGeneration === undefined
+          ? {}
+          : {canonicalMutationGeneration: marker.canonicalMutationGeneration}),
+        forceRefresh: marker.forceRefresh,
+        generation: marker.generation,
+        invalidatedUris: [...new Set(marker.invalidatedUris.map(stripRecallAnchor))],
+        ...(marker.previousCanonicalMutationGeneration === undefined
+          ? {}
+          : {previousCanonicalMutationGeneration: marker.previousCanonicalMutationGeneration}),
+        version: RECALL_STALE_MARKER_VERSION,
+      };
+    }
+    return {
+      forceRefresh: true,
+      generation: legacyGeneration,
+      invalidatedUris: [],
+      version: RECALL_STALE_MARKER_VERSION,
+    };
+  });
+}
+
+export const writeRecallStaleGeneration = Effect.fn('recall.writeStaleGeneration')(function* (
+  fs: FileSystem.FileSystem,
+  path: string,
+  invalidatedUris?: readonly string[],
+  canonicalMutationGeneration?: CanonicalMutationGenerationTransition,
+) {
+  const system = yield* SystemInfo;
+  const counter = yield* nextStaleMarkerGenerationCounter;
+  const generation = `${yield* Clock.currentTimeMillis}:${system.processId}:${counter}`;
+  const stalePath = `${path}.stale`;
+  const previous = yield* readRecallStaleMarker(fs, path);
+  const mergedInvalidatedUris = [
+    ...new Set(
+      [...(previous?.invalidatedUris ?? []), ...(invalidatedUris ?? [])]
+        .map(stripRecallAnchor)
+        .map(uri => uri.replace(/\/+$/, ''))
+        .filter(Boolean),
+    ),
+  ];
+  const previousHasPendingInvalidations =
+    previous !== undefined && (previous.forceRefresh || previous.invalidatedUris.length > 0);
+  const mutationContinuity = mergeRecallIndexCanonicalMutationContinuity(
+    previous === undefined
+      ? undefined
+      : {
+          ...(previous.canonicalMutationGeneration === undefined
+            ? {}
+            : {currentGeneration: previous.canonicalMutationGeneration}),
+          pending: previousHasPendingInvalidations,
+          ...(previous.previousCanonicalMutationGeneration === undefined
+            ? {}
+            : {previousGeneration: previous.previousCanonicalMutationGeneration}),
+        },
+    canonicalMutationGeneration,
+  );
+  const forceRefresh =
+    invalidatedUris === undefined ||
+    previous?.forceRefresh === true ||
+    mergedInvalidatedUris.length > MAX_RECALL_INVALIDATED_URIS ||
+    !mutationContinuity.continuous;
+  const marker: RecallStaleMarker = {
+    ...(mutationContinuity.currentGeneration === undefined
+      ? {}
+      : {canonicalMutationGeneration: mutationContinuity.currentGeneration}),
+    forceRefresh,
+    generation,
+    invalidatedUris: forceRefresh ? [] : mergedInvalidatedUris,
+    ...(mutationContinuity.previousGeneration === undefined
+      ? {}
+      : {previousCanonicalMutationGeneration: mutationContinuity.previousGeneration}),
+    version: RECALL_STALE_MARKER_VERSION,
+  };
+  const temporaryPath = `${stalePath}.${system.processId}.${counter}.tmp`;
+  yield* fs.writeFileString(temporaryPath, `${JSON.stringify(marker)}\n`, {mode: 0o600});
+  yield* fs
+    .rename(temporaryPath, stalePath)
+    .pipe(Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.catch(() => Effect.void))));
+  return generation;
+});
+
+export const clearRecallStaleMarkerInvalidations = Effect.fn('recall.clearStaleMarkerInvalidations')(function* (
+  fs: FileSystem.FileSystem,
+  path: string,
+  observed: RecallStaleMarker,
+) {
+  const current = yield* readRecallStaleMarker(fs, path);
+  if (current?.generation !== observed.generation) {
+    return;
+  }
+  const system = yield* SystemInfo;
+  const counter = yield* nextStaleMarkerGenerationCounter;
+  const stalePath = `${path}.stale`;
+  const temporaryPath = `${stalePath}.${system.processId}.${counter}.tmp`;
+  const cleared: RecallStaleMarker = {
+    ...(observed.canonicalMutationGeneration === undefined
+      ? {}
+      : {canonicalMutationGeneration: observed.canonicalMutationGeneration}),
+    forceRefresh: false,
+    generation: observed.generation,
+    invalidatedUris: [],
+    ...(observed.canonicalMutationGeneration === undefined
+      ? {}
+      : {previousCanonicalMutationGeneration: observed.canonicalMutationGeneration}),
+    version: RECALL_STALE_MARKER_VERSION,
+  };
+  yield* fs.writeFileString(temporaryPath, `${JSON.stringify(cleared)}\n`, {mode: 0o600});
+  yield* fs
+    .rename(temporaryPath, stalePath)
+    .pipe(Effect.ensuring(fs.remove(temporaryPath, {force: true}).pipe(Effect.catch(() => Effect.void))));
+});
+
+const nextStaleMarkerGenerationCounter = Effect.sync(() => {
+  staleMarkerGenerationCounter += 1;
+  return staleMarkerGenerationCounter;
+});

--- a/test/unit/effect-ai-mcp.test.ts
+++ b/test/unit/effect-ai-mcp.test.ts
@@ -31,7 +31,7 @@ import {
   type McpProgressNotificationPayload,
   withMcpProgressHeartbeat,
 } from '../../src/effect/ai/mcp.js';
-import {memoryReadRecoveryForRequestedUri} from '../../src/mcp/memory_read_recovery.js';
+import {memoryReadRecoveryForRequestedUri} from '../../src/memory/read_recovery.js';
 import {
   attachAnonymousTelemetryReportedOutcome,
   readAnonymousTelemetryDiagnostic,

--- a/test/unit/memory-native.test.ts
+++ b/test/unit/memory-native.test.ts
@@ -213,6 +213,46 @@ describe('native memory workflow', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
+  it.effect('prints canonical-recall recovery when a historical memory URI has no relocation receipt', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-native-missing-relocation-'});
+        const config: RuntimeConfig = {
+          account: 'local',
+          agentContextHome: home,
+          agentId: 'threadnote',
+          manifestPath: path.join(home, 'seed-manifest.yaml'),
+          user: 'tester',
+        };
+        const uri = 'threadnote://user/tester/memories/durable/projects/threadnote/historical-published-contract.md';
+
+        const observed = yield* captureConsole(runRead(config, uri, {}).pipe(Effect.exit));
+
+        expect(Exit.isFailure(observed.value)).toBe(true);
+        const recoveryLine = observed.output
+          .split('\n')
+          .find(line => line.startsWith('{"code":"memory-resource-not-found"'));
+        expect(recoveryLine).toBeDefined();
+        expect(JSON.parse(recoveryLine!)).toEqual({
+          code: 'memory-resource-not-found',
+          nextAction: {
+            arguments: {query: 'historical-published-contract'},
+            tool: 'recall_context',
+          },
+          recoveryAction: 'recall-canonical-uri',
+          requestedUri: uri,
+          retryable: false,
+          summary:
+            'The memory may have moved or been published before relocation receipts were available. Recall by its stable topic, then read the canonical URI returned.',
+          type: 'threadnote-memory-read-recovery',
+          version: 1,
+        });
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   it.effect('leaves pending-anchor memory revisions out of enrichment plans', () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/test/unit/recall-index-freshness.test.ts
+++ b/test/unit/recall-index-freshness.test.ts
@@ -1,0 +1,108 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {TestClock} from 'effect/testing';
+import {SystemInfo} from '../../src/effect/system.js';
+import {expireRecallIndexValidation, loadRecallIndexData} from '../../src/recall/index.js';
+import {recallIndexForegroundRefreshRequired} from '../../src/recall/index_freshness.js';
+
+const RecallIndexTestLayer = Layer.merge(BunServices.layer, SystemInfo.layer);
+
+describe('recall index foreground freshness', () => {
+  effectIt.effect.prop(
+    'requires refresh exactly for force, initialization, integrity, or generation changes',
+    {
+      canonicalGeneration: FC.string({maxLength: 48}),
+      forceRefresh: FC.boolean(),
+      generation: FC.string({maxLength: 48}),
+      initialized: FC.boolean(),
+      integrityCurrent: FC.boolean(),
+    },
+    ({canonicalGeneration, forceRefresh, generation, initialized, integrityCurrent}) =>
+      Effect.sync(() => {
+        const markerCurrent = recallIndexForegroundRefreshRequired({
+          forceRefresh,
+          initialized,
+          integrityCurrent,
+          observedCanonicalMutationGeneration: canonicalGeneration,
+          observedStaleGeneration: generation,
+          persistedCanonicalMutationGeneration: canonicalGeneration,
+          persistedStaleGeneration: generation,
+        });
+        const changed = recallIndexForegroundRefreshRequired({
+          forceRefresh: false,
+          initialized: true,
+          integrityCurrent: true,
+          observedCanonicalMutationGeneration: canonicalGeneration,
+          observedStaleGeneration: `${generation}:changed`,
+          persistedCanonicalMutationGeneration: canonicalGeneration,
+          persistedStaleGeneration: generation,
+        });
+        const canonicalChanged = recallIndexForegroundRefreshRequired({
+          forceRefresh: false,
+          initialized: true,
+          integrityCurrent: true,
+          observedCanonicalMutationGeneration: `${canonicalGeneration}:changed`,
+          observedStaleGeneration: generation,
+          persistedCanonicalMutationGeneration: canonicalGeneration,
+          persistedStaleGeneration: generation,
+        });
+
+        expect(markerCurrent).toBe(forceRefresh || !initialized || !integrityCurrent);
+        expect(changed).toBe(true);
+        expect(canonicalChanged).toBe(true);
+      }),
+    {fastCheck: {numRuns: 100}},
+  );
+
+  effectIt.layer(RecallIndexTestLayer)(layerIt => {
+    layerIt.effect('does not rescan an unchanged corpus after the former validation interval', () =>
+      withRecallHome((home, fs, path) =>
+        Effect.gen(function* () {
+          const resourceRoot = path.join(home, 'data', 'local', 'resources', 'repos', 'threadnote');
+          const resourcePath = path.join(resourceRoot, 'contract.md');
+          const config = {account: 'local', agentContextHome: home, user: 'freshness-user'};
+          yield* fs.makeDirectory(resourceRoot, {recursive: true});
+          yield* fs.writeFileString(resourcePath, '# Contract\n\nfirst-version-anchor\n');
+          yield* loadRecallIndexData(config, {forceRefresh: true, includeInactive: false});
+
+          yield* fs.writeFileString(resourcePath, '# Contract\n\nsecond-version-anchor\n');
+          yield* TestClock.adjust('31 seconds');
+          const foregroundProgress: string[] = [];
+          const cached = yield* loadRecallIndexData(config, {
+            includeInactive: false,
+            onProgress: progress =>
+              Effect.sync(() => {
+                foregroundProgress.push(progress.phase);
+              }),
+            query: 'first-version-anchor',
+          });
+
+          expect(foregroundProgress).toEqual([]);
+          expect(cached.candidates[0]?.text).toContain('first-version-anchor');
+
+          yield* expireRecallIndexValidation(home, false, ['threadnote://resources/repos/threadnote/contract.md']);
+          const refreshed = yield* loadRecallIndexData(config, {
+            includeInactive: false,
+            query: 'second-version-anchor',
+          });
+          expect(refreshed.candidates[0]?.text).toContain('second-version-anchor');
+        }),
+      ),
+    );
+  });
+});
+
+function withRecallHome<A, E, R>(
+  use: (home: string, fs: FileSystem.FileSystem, path: Path.Path) => Effect.Effect<A, E, R>,
+) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const home = yield* fs.makeTempDirectory({prefix: 'threadnote-recall-freshness-'});
+    return yield* use(home, fs, path).pipe(
+      Effect.ensuring(fs.remove(home, {force: true, recursive: true}).pipe(Effect.catch(() => Effect.void))),
+    );
+  });
+}

--- a/test/unit/recall-index-freshness.test.ts
+++ b/test/unit/recall-index-freshness.test.ts
@@ -5,7 +5,11 @@ import * as FC from 'effect/testing/FastCheck';
 import {TestClock} from 'effect/testing';
 import {SystemInfo} from '../../src/effect/system.js';
 import {expireRecallIndexValidation, loadRecallIndexData} from '../../src/recall/index.js';
-import {recallIndexForegroundRefreshRequired} from '../../src/recall/index_freshness.js';
+import {
+  mergeRecallIndexCanonicalMutationContinuity,
+  recallIndexCanonicalMutationContinuityAllowsIncrementalRefresh,
+  recallIndexForegroundRefreshRequired,
+} from '../../src/recall/index_freshness.js';
 
 const RecallIndexTestLayer = Layer.merge(BunServices.layer, SystemInfo.layer);
 
@@ -52,6 +56,98 @@ describe('recall index foreground freshness', () => {
         expect(markerCurrent).toBe(forceRefresh || !initialized || !integrityCurrent);
         expect(changed).toBe(true);
         expect(canonicalChanged).toBe(true);
+      }),
+    {fastCheck: {numRuns: 100}},
+  );
+
+  effectIt.effect.prop(
+    'allows canonical incremental refresh only for an exact end-to-end transition',
+    {
+      markerCurrent: FC.string({maxLength: 48}),
+      markerPrevious: FC.string({maxLength: 48}),
+      observed: FC.string({maxLength: 48}),
+      persisted: FC.string({maxLength: 48}),
+    },
+    ({markerCurrent, markerPrevious, observed, persisted}) =>
+      Effect.sync(() => {
+        expect(
+          recallIndexCanonicalMutationContinuityAllowsIncrementalRefresh({
+            markerCurrentGeneration: markerCurrent,
+            markerPreviousGeneration: markerPrevious,
+            observedGeneration: observed,
+            persistedGeneration: persisted,
+          }),
+        ).toBe(persisted === observed || (markerPrevious === persisted && markerCurrent === observed));
+      }),
+    {fastCheck: {numRuns: 100}},
+  );
+
+  effectIt.effect.prop(
+    'merges consecutive mutation transitions while preserving their earliest indexed base',
+    {
+      generations: FC.uniqueArray(FC.string({maxLength: 32}), {maxLength: 12, minLength: 2}),
+    },
+    ({generations}) =>
+      Effect.sync(() => {
+        let merged = mergeRecallIndexCanonicalMutationContinuity(undefined, {
+          currentGeneration: generations[1]!,
+          previousGeneration: generations[0]!,
+        });
+        for (let index = 2; index < generations.length; index += 1) {
+          merged = mergeRecallIndexCanonicalMutationContinuity(
+            {
+              ...(merged.currentGeneration === undefined ? {} : {currentGeneration: merged.currentGeneration}),
+              pending: true,
+              ...(merged.previousGeneration === undefined ? {} : {previousGeneration: merged.previousGeneration}),
+            },
+            {
+              currentGeneration: generations[index]!,
+              previousGeneration: generations[index - 1]!,
+            },
+          );
+        }
+
+        expect(merged).toEqual({
+          continuous: true,
+          currentGeneration: generations.at(-1),
+          previousGeneration: generations[0],
+        });
+        expect(
+          mergeRecallIndexCanonicalMutationContinuity(
+            {
+              currentGeneration: merged.currentGeneration!,
+              pending: true,
+              previousGeneration: merged.previousGeneration!,
+            },
+            undefined,
+          ),
+        ).toEqual(merged);
+      }),
+    {fastCheck: {numRuns: 100}},
+  );
+
+  effectIt.effect.prop(
+    'fails continuity closed when an intervening generation was not linked',
+    {generation: FC.string({maxLength: 32})},
+    ({generation}) =>
+      Effect.sync(() => {
+        const base = `${generation}:base`;
+        const missing = `${generation}:missing`;
+        const current = `${generation}:current`;
+        const merged = mergeRecallIndexCanonicalMutationContinuity(
+          {
+            currentGeneration: base,
+            pending: true,
+            previousGeneration: `${generation}:indexed`,
+          },
+          {currentGeneration: current, previousGeneration: missing},
+        );
+
+        expect(merged).toEqual({
+          continuous: false,
+          currentGeneration: current,
+          previousGeneration: missing,
+        });
       }),
     {fastCheck: {numRuns: 100}},
   );

--- a/test/unit/recall.index.test.ts
+++ b/test/unit/recall.index.test.ts
@@ -952,6 +952,17 @@ describe('local recall index', () => {
     expect(status.databasePath).toContain('/generations/');
   });
 
+  it('keeps a legacy current index ready when no canonical mutation generation exists yet', async () => {
+    const resourcePath = join(directory, 'data', 'local', 'resources', 'repos', 'threadnote', 'legacy.md');
+    await mkdir(join(resourcePath, '..'), {recursive: true});
+    await writeFile(resourcePath, '# Legacy\n\npre-generation-index-anchor', 'utf8');
+    await run(loadRecallIndex(config(), {includeInactive: false}));
+
+    executeDatabase("DELETE FROM metadata WHERE key = 'canonical_mutation_generation'");
+
+    await expect(run(recallIndexStatus(config()))).resolves.toMatchObject({documentCount: 1, ready: true});
+  });
+
   it('supports concurrent first opens without racing schema initialization', async () => {
     const resourcePath = join(directory, 'data', 'local', 'resources', 'repos', 'threadnote', 'doc.md');
     await mkdir(join(resourcePath, '..'), {recursive: true});

--- a/test/unit/resource-store.test.ts
+++ b/test/unit/resource-store.test.ts
@@ -441,6 +441,48 @@ describe('native ResourceStore', () => {
     ).pipe(provideTestLayer(resourceStoreDependencies)),
   );
 
+  it.effect('does not let a later successful marker hide an earlier failed invalidation', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-resource-invalidation-continuity-'});
+        const config = {account: 'local', agentContextHome: home, user: 'test-user'};
+        const firstUri = 'threadnote://resources/repos/threadnote/first.md';
+        const laterUri = 'threadnote://resources/repos/threadnote/later.md';
+        const firstPath = join(home, 'data', 'local', 'resources', 'repos', 'threadnote', 'first.md');
+        const store = yield* ResourceStore.pipe(provideTestLayer(ResourceStore.layerWith()));
+        yield* store.write(location(home), firstUri, '# First\n\nalpha-42', {mode: 'create'});
+        expect((yield* loadRecallIndex(config, {includeInactive: false}))[0]?.text).toContain('alpha-42');
+        const initialInfo = yield* fs.stat(firstPath);
+        const initialModifiedAt = Option.getOrThrow(initialInfo.mtime);
+
+        const failedDerivedMarkerFileSystem = FileSystem.FileSystem.of({
+          ...fs,
+          writeFileString: (target, content, options) =>
+            String(target).includes('.sqlite.stale.')
+              ? Effect.die(new Error('injected first-mutation marker failure'))
+              : fs.writeFileString(target, content, options),
+        });
+        const markerFailingStore = yield* ResourceStore.pipe(
+          provideTestLayer(ResourceStore.layerWith()),
+          Effect.provideService(FileSystem.FileSystem, failedDerivedMarkerFileSystem),
+        );
+        yield* markerFailingStore.write(location(home), firstUri, '# First\n\nomega-99', {mode: 'replace'});
+        yield* fs.utimes(firstPath, initialModifiedAt, initialModifiedAt);
+
+        yield* store.write(location(home), laterUri, '# Later\n\nlater-anchor', {mode: 'create'});
+        const refreshed = yield* loadRecallIndex(config, {includeInactive: false, query: 'omega-99'});
+
+        expect(refreshed[0]?.text).toContain('omega-99');
+        expect(refreshed[0]?.text).not.toContain('alpha-42');
+        expect((yield* loadRecallIndex(config, {includeInactive: false, query: 'later-anchor'}))[0]?.uri).toBe(
+          laterUri,
+        );
+        expect(yield* recallIndexStatus(config)).toMatchObject({documentCount: 2, ready: true});
+      }),
+    ).pipe(provideTestLayer(resourceStoreDependencies)),
+  );
+
   it('does not reuse a warm candidate after a same-size replacement with preserved timestamps', async () => {
     const home = await mkdtemp('threadnote-resource-index-replacement-');
     try {

--- a/test/unit/resource-store.test.ts
+++ b/test/unit/resource-store.test.ts
@@ -4,7 +4,7 @@ import {join} from '../helpers/node-path.js';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {describe, expect, it} from '@effect/vitest';
 import * as FC from 'effect/testing/FastCheck';
-import {Deferred, Effect, FileSystem, Layer, Option, Ref} from 'effect';
+import {Deferred, Effect, Fiber, FileSystem, Layer, Option, Ref} from 'effect';
 import {
   ResourceAlreadyExists,
   ResourceConflict,
@@ -15,7 +15,12 @@ import {
   resourceMutationLockFailureMessage,
 } from '../../src/effect/resource-store.js';
 import {SystemInfo} from '../../src/effect/system.js';
-import {loadRecallExactMatches, loadRecallIndex} from '../../src/recall/index.js';
+import {
+  loadRecallExactMatches,
+  loadRecallIndex,
+  recallIndexDatabaseFilename,
+  recallIndexStatus,
+} from '../../src/recall/index.js';
 import {InvalidResourceId, parseResourceId} from '../../src/storage/resource-id.js';
 import {mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile} from '../helpers/effect-filesystem.js';
 import {runEffect} from '../helpers/effect-runtime.js';
@@ -339,6 +344,103 @@ describe('native ResourceStore', () => {
     }
   });
 
+  it.effect('finishes derived invalidation when interrupted after a canonical commit', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-resource-invalidation-interrupt-'});
+        const invalidationStarted = yield* Deferred.make<void>();
+        const releaseInvalidation = yield* Deferred.make<void>();
+        const blockingFileSystem = FileSystem.FileSystem.of({
+          ...fs,
+          writeFileString: (target, content, options) =>
+            String(target).includes('.sqlite.stale.')
+              ? Deferred.succeed(invalidationStarted, undefined).pipe(
+                  Effect.andThen(Deferred.await(releaseInvalidation)),
+                  Effect.andThen(fs.writeFileString(target, content, options)),
+                )
+              : fs.writeFileString(target, content, options),
+        });
+        const store = yield* ResourceStore.pipe(
+          provideTestLayer(ResourceStore.layerWith()),
+          Effect.provideService(FileSystem.FileSystem, blockingFileSystem),
+        );
+        const uri = 'threadnote://resources/repos/threadnote/interrupted.md';
+        const write = yield* store
+          .write(location(home), uri, 'committed-before-interruption', {mode: 'create'})
+          .pipe(Effect.forkChild({startImmediately: true}));
+
+        yield* Deferred.await(invalidationStarted);
+        const interruption = yield* Fiber.interrupt(write).pipe(Effect.forkChild({startImmediately: true}));
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(releaseInvalidation, undefined);
+        yield* Fiber.join(interruption);
+
+        expect(yield* store.read(location(home), uri)).toBe('committed-before-interruption');
+        for (const includeInactive of [false, true]) {
+          expect(
+            yield* fs.exists(join(home, 'indexes', 'lexical', `${recallIndexDatabaseFilename(includeInactive)}.stale`)),
+          ).toBe(true);
+        }
+      }),
+    ).pipe(provideTestLayer(resourceStoreDependencies)),
+  );
+
+  it.effect('recovers from failed derived markers through the durable canonical generation', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-resource-invalidation-fallback-'});
+        const config = {account: 'local', agentContextHome: home, user: 'test-user'};
+        const uri = 'threadnote://resources/repos/threadnote/replaced-through-fallback.md';
+        const resourcePath = join(
+          home,
+          'data',
+          'local',
+          'resources',
+          'repos',
+          'threadnote',
+          'replaced-through-fallback.md',
+        );
+        const initialStore = yield* ResourceStore.pipe(provideTestLayer(ResourceStore.layerWith()));
+        yield* initialStore.write(location(home), uri, '# First\n\nalpha-42', {mode: 'create'});
+        expect((yield* loadRecallIndex(config, {includeInactive: false}))[0]?.text).toContain('alpha-42');
+        const initialInfo = yield* fs.stat(resourcePath);
+        const initialModifiedAt = Option.getOrThrow(initialInfo.mtime);
+
+        const failedScopes = yield* Ref.make<boolean[]>([]);
+        const failedDerivedMarkerFileSystem = FileSystem.FileSystem.of({
+          ...fs,
+          writeFileString: (target, content, options) =>
+            String(target).includes('.sqlite.stale.')
+              ? Effect.die(new Error('injected derived recall marker failure'))
+              : fs.writeFileString(target, content, options),
+        });
+        const fallbackStore = yield* ResourceStore.pipe(
+          provideTestLayer(
+            ResourceStore.layerWith({
+              onRecallInvalidationFailed: event =>
+                Ref.update(failedScopes, scopes => [...scopes, event.includeInactive]),
+            }),
+          ),
+          Effect.provideService(FileSystem.FileSystem, failedDerivedMarkerFileSystem),
+        );
+        yield* fallbackStore.write(location(home), uri, '# Other\n\nomega-99', {mode: 'replace'});
+        yield* fs.utimes(resourcePath, initialModifiedAt, initialModifiedAt);
+
+        expect((yield* Ref.get(failedScopes)).sort()).toEqual([false, true]);
+        expect(yield* recallIndexStatus(config)).toMatchObject({
+          ready: false,
+          reason: 'canonical documents changed; run `threadnote repair`',
+        });
+        const refreshed = yield* loadRecallIndex(config, {includeInactive: false, query: 'omega-99'});
+        expect(refreshed[0]?.text).toContain('omega-99');
+        expect(refreshed[0]?.text).not.toContain('alpha-42');
+        expect(yield* recallIndexStatus(config)).toMatchObject({documentCount: 1, ready: true});
+      }),
+    ).pipe(provideTestLayer(resourceStoreDependencies)),
+  );
+
   it('does not reuse a warm candidate after a same-size replacement with preserved timestamps', async () => {
     const home = await mkdtemp('threadnote-resource-index-replacement-');
     try {
@@ -394,8 +496,9 @@ describe('native ResourceStore', () => {
 
   it('keeps committed mutations successful when derived-index invalidation fails', async () => {
     const home = await mkdtemp('threadnote-resource-index-failure-');
+    const failedScopes: boolean[] = [];
     try {
-      await writeFile(join(home, 'cache'), 'blocks the derived cache directory');
+      await writeFile(join(home, 'indexes'), 'blocks the derived index directory');
       await runEffect(
         Effect.gen(function* () {
           const store = yield* ResourceStore;
@@ -404,8 +507,18 @@ describe('native ResourceStore', () => {
           expect(yield* store.read(location(home), uri)).toBe('committed despite cache failure');
           yield* store.remove(location(home), uri);
           expect(yield* Effect.exit(store.read(location(home), uri))).toMatchObject({_tag: 'Failure'});
-        }),
+        }).pipe(
+          provideTestLayer(
+            ResourceStore.layerWith({
+              onRecallInvalidationFailed: event =>
+                Effect.sync(() => {
+                  failedScopes.push(event.includeInactive);
+                }),
+            }),
+          ),
+        ),
       );
+      expect(failedScopes.sort()).toEqual([false, false, true, true]);
     } finally {
       await rm(home, {force: true, recursive: true});
     }

--- a/test/unit/storage-layout-migration.test.ts
+++ b/test/unit/storage-layout-migration.test.ts
@@ -3,6 +3,7 @@ import {expect, it} from '@effect/vitest';
 import {Effect, FileSystem, Path} from 'effect';
 import {describe} from 'vitest';
 import {sha256FileHex, sha256Hex} from '../../src/effect/digest.js';
+import {ResourceStore} from '../../src/effect/resource-store.js';
 import {readCanonicalMutationGeneration} from '../../src/effect/resource_mutation_generation.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
@@ -12,6 +13,7 @@ import {
   STORAGE_LAYOUT_MIGRATION_ID,
   StorageLayoutMigrationConflict,
 } from '../../src/migration/layout.js';
+import {loadRecallIndex} from '../../src/recall/index.js';
 
 describe('Threadnote storage layout migration', () => {
   it.effect('ignores empty beta layout scaffolds, including after a completed migration', () =>
@@ -225,6 +227,51 @@ describe('Threadnote storage layout migration', () => {
         expect(yield* fs.exists(source)).toBe(false);
         expect(yield* fs.exists(path.join(home, 'migration', `${STORAGE_LAYOUT_MIGRATION_ID}.json`))).toBe(true);
         expect(yield* isThreadnoteStorageLayoutMigrationPending({home})).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  it.effect('fully reconciles a migration generation before a later targeted mutation', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-layout-recall-continuity-'});
+        const currentRoot = path.join(home, 'data', 'local', 'resources', 'repos', 'threadnote');
+        const legacyRoot = path.join(home, 'data', 'viking', 'local', 'resources', 'repos', 'threadnote');
+        yield* fs.makeDirectory(currentRoot, {recursive: true});
+        yield* fs.makeDirectory(legacyRoot, {recursive: true});
+        yield* fs.writeFileString(path.join(currentRoot, 'first.md'), '# First\n\nfirst-anchor');
+        yield* fs.writeFileString(path.join(currentRoot, 'stable.md'), '# Stable\n\nstable-anchor');
+        yield* fs.writeFileString(path.join(legacyRoot, 'migrated.md'), '# Migrated\n\nmigrated-anchor');
+        const config = {account: 'local', agentContextHome: home, user: 'test-user'};
+        expect(yield* loadRecallIndex(config, {includeInactive: false})).toHaveLength(2);
+
+        expect(yield* migrateThreadnoteStorageLayout({apply: true, home})).toEqual({
+          accounts: 1,
+          action: 'migrated',
+        });
+        const store = yield* ResourceStore;
+        const laterUri = 'threadnote://resources/repos/threadnote/later.md';
+        yield* store.write({account: 'local', home, user: 'test-user'}, laterUri, '# Later\n\nlater-anchor', {
+          mode: 'create',
+        });
+        const indexingTotals: number[] = [];
+        const refreshed = yield* loadRecallIndex(config, {
+          includeInactive: false,
+          onProgress: progress =>
+            Effect.sync(() => {
+              if (progress.phase === 'indexing' && progress.completed === 0) indexingTotals.push(progress.total);
+            }),
+        });
+
+        expect(indexingTotals).toEqual([4]);
+        expect(refreshed.map(candidate => candidate.uri)).toEqual([
+          'threadnote://resources/repos/threadnote/first.md',
+          laterUri,
+          'threadnote://resources/repos/threadnote/migrated.md',
+          'threadnote://resources/repos/threadnote/stable.md',
+        ]);
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );

--- a/test/unit/storage-layout-migration.test.ts
+++ b/test/unit/storage-layout-migration.test.ts
@@ -3,6 +3,7 @@ import {expect, it} from '@effect/vitest';
 import {Effect, FileSystem, Path} from 'effect';
 import {describe} from 'vitest';
 import {sha256FileHex, sha256Hex} from '../../src/effect/digest.js';
+import {readCanonicalMutationGeneration} from '../../src/effect/resource_mutation_generation.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import {
@@ -82,6 +83,7 @@ describe('Threadnote storage layout migration', () => {
         expect(yield* fs.exists(path.join(home, 'data', 'viking'))).toBe(true);
         expect(yield* fs.exists(path.join(home, 'data', 'local', '.DS_Store'))).toBe(false);
         expect(yield* fs.exists(path.join(home, 'data', 'viking', 'local', '.DS_Store'))).toBe(true);
+        expect(yield* readCanonicalMutationGeneration(fs, path, home, 'local')).toMatch(/^v1:/);
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
@@ -326,6 +328,7 @@ describe('Threadnote storage layout migration', () => {
           action: 'resumed',
         });
         expect(yield* fs.readFileString(target)).toBe('already moved');
+        expect(yield* readCanonicalMutationGeneration(fs, path, home, 'local')).toMatch(/^v1:/);
         expect(yield* isThreadnoteStorageLayoutMigrationPending({home})).toBe(false);
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),


### PR DESCRIPTION
## Summary

- replace foreground 30-second recall source rescans with durable canonical-mutation generations plus targeted stale markers
- require an unbroken indexed-generation to current-generation marker chain; any failed marker, legacy gap, or migration gap forces one conservative full reconciliation
- make canonical writes/removals safe across interruption or derived-marker failure while preserving the normal per-URI fast path
- preserve legacy index compatibility and publish mutation generations through storage-layout migration/resume paths
- expose the same versioned relocation recovery contract from CLI memory read that MCP already returns for moved/published memory URIs

## Why this blocks 4.6

Candidate C passed ordinary dogfood but failed the hosted 100k/50/128 Context Brief scale gate because periodic full-source validation landed in foreground requests (brief p95 8.174s; memory retrieval p95 7.187s). A separate dogfood case showed that an old published-memory URI gave CLI callers only a bare failure even though MCP supplied an actionable canonical-recall path.

Independent review also found and this revision fixes a continuity hole: if mutation A advanced the durable generation but both marker writes failed, a later successful marker for mutation B could previously mask A.

## Verification

- focused Bun-native Vitest: 6 files, 154 tests passed
- source, test, and website TypeScript checks passed
- strict oxlint, production file-length lint, Prettier, and diff whitespace checks passed
- dev-cycle final re-review: Critical 0, Important 0
- exact historical URI recovery smoke: CLI returns versioned recovery JSON/nonzero; canonical URI and stable ID read byte-identical content
- graph-not-ready smoke: durable store and immediate recall succeed without starting graph indexing
- exact-head 100k local calibration ran 126 seconds past the old TTL with zero requests over 2 seconds; worst profile p95/max was 1.092 seconds; artifact SHA-256 d7a0c933a124b7d078de701df697cb7e73f84722c359c9e8f25eceaf4db658e7
- full PR CI is the authoritative suite and is rerunning on this revision

Property coverage includes the freshness decision matrix, exact endpoint authorization, arbitrary contiguous-chain accumulation, gap fail-closed behavior, interruption, missing-marker fallback, same-size/same-mtime replacement, legacy upgrade, and migration resume/gap regressions.