### PR TITLE
chore: approve 4.6 agent manifest

### DIFF
--- a/src/evaluation/code-memory-link-approvals.json
+++ b/src/evaluation/code-memory-link-approvals.json
@@ -1,6 +1,9 @@
 {
   "agentAbEvidenceHashes": [],
-  "agentAbManifestHashes": ["b01aadcdd828e5cb4c8877d75f10f385da047f79c47c289850c6eee441f84f3e"],
+  "agentAbManifestHashes": [
+    "b01aadcdd828e5cb4c8877d75f10f385da047f79c47c289850c6eee441f84f3e",
+    "f64630ab0a6403c39f24fb5ae83ba610baa9d6600b7f8bb444c7973e113d3bf8"
+  ],
   "dogfoodEvidenceHashes": [],
   "retainedEvidenceBundleHashes": [],
   "version": 1


### PR DESCRIPTION
## Governance scope

- approve preregistered manifest f64630ab0a6403c39f24fb5ae83ba610baa9d6600b7f8bb444c7973e113d3bf8
- candidate C2: 5bf330cfa976de9d18e47c52e17e5bff3363e950
- exact installed candidate executable SHA-256: 52320cac9a201286488423af8a0898d199ceda8e58f457b6ed16351fbfb010cb
- two reviewed Codex 0.144.5 client configurations, 12 hidden tasks, 16 negative controls, 168 balanced runs

This branch is the immediate child of C2 and changes only src/evaluation/code-memory-link-approvals.json by adding one manifest hash. No runtime, product, test, documentation, release-note, or evidence bytes change.

## Verification

- manifest parser independently rederived the printed hash
- candidate commit/build identity and dirty=false match exact C2 installation
- schedule has 84 runs per client and 56 runs per blind label/arm position
- focused agent-governance and release-verifier tests: 45 passed
- precommit lint, formatting, file-length, and all source/test/site typechecks passed

Main remains frozen through A, G, and the v4.6.0 tag.