### PR TITLE
fix: canonicalize release runtime attestations

### DIFF
--- a/src/evaluation/code-memory-link-attestation.ts
+++ b/src/evaluation/code-memory-link-attestation.ts
@@ -13,6 +13,15 @@ export interface CodeMemoryLinkRuntimeIdentityV1 {
   readonly sourceCommit: string;
 }
 
+export function projectCodeMemoryLinkRuntimeIdentityV1(
+  runtime: CodeMemoryLinkRuntimeIdentityV1,
+): CodeMemoryLinkRuntimeIdentityV1 {
+  return {
+    executableSha256: runtime.executableSha256,
+    sourceCommit: runtime.sourceCommit,
+  };
+}
+
 export interface CodeMemoryLinkInvocationAttestationV1 {
   readonly harnessCommit: string;
   readonly harnessVersion: typeof CODE_MEMORY_LINK_HARNESS_VERSION;
@@ -42,8 +51,8 @@ export function createCodeMemoryLinkInvocationAttestationV1(input: {
   const candidate = parseCandidate(input.candidate);
   const harnessCommit = matching(input.harnessCommit, COMMIT, 'harness commit');
   const invocationNonce = matching(input.invocationNonce, INVOCATION_NONCE, 'invocation nonce');
-  const preRuntime = parseRuntime(input.preRuntime, 'pre-run runtime');
-  const postRuntime = parseRuntime(input.postRuntime, 'post-run runtime');
+  const preRuntime = parseRuntime(projectCodeMemoryLinkRuntimeIdentityV1(input.preRuntime), 'pre-run runtime');
+  const postRuntime = parseRuntime(projectCodeMemoryLinkRuntimeIdentityV1(input.postRuntime), 'post-run runtime');
   assertRuntime(candidate, preRuntime, 'pre-run runtime');
   assertRuntime(candidate, postRuntime, 'post-run runtime');
   const invocationDigest = digest({

--- a/test/unit/code-memory-link-attestation.test.ts
+++ b/test/unit/code-memory-link-attestation.test.ts
@@ -1,0 +1,62 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {
+  createCodeMemoryLinkInvocationAttestationV1,
+  parseCodeMemoryLinkInvocationAttestationV1,
+  projectCodeMemoryLinkRuntimeIdentityV1,
+} from '../../src/evaluation/code-memory-link-attestation.js';
+import type {DevelopmentRuntimeEvidence} from '../../scripts/development-runtime.js';
+
+const EXECUTABLE_SHA256 = 'a'.repeat(64);
+const SOURCE_COMMIT = 'b'.repeat(40);
+
+describe('Code Memory Link runtime attestation', () => {
+  it('projects arbitrary verified development evidence to the exact attested identity', () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string({maxLength: 32}), fc.jsonValue()), additionalEvidence => {
+        const runtime = {
+          ...additionalEvidence,
+          dependencyInstallation: 'bun install --frozen-lockfile',
+          executableSha256: EXECUTABLE_SHA256,
+          payloadBytes: 1,
+          payloadFileCount: 1,
+          payloadManifestSha256: 'c'.repeat(64),
+          releaseMetadataSha256: 'd'.repeat(64),
+          runtime: 'bun-1.3.14',
+          sourceCommit: SOURCE_COMMIT,
+          sourceLockfileSha256: 'e'.repeat(64),
+          sourcePackageManifestSha256: 'f'.repeat(64),
+          target: 'bun-darwin-arm64',
+          version: `4.6.0-local.g${SOURCE_COMMIT}`,
+        } satisfies DevelopmentRuntimeEvidence;
+
+        const identity = {
+          executableSha256: EXECUTABLE_SHA256,
+          sourceCommit: SOURCE_COMMIT,
+        };
+        expect(projectCodeMemoryLinkRuntimeIdentityV1(runtime)).toEqual(identity);
+        const verificationInput = {
+          candidate: {buildIdentityHash: EXECUTABLE_SHA256, commit: SOURCE_COMMIT, dirty: false as const},
+          harnessCommit: 'c'.repeat(40),
+          invocation: {kind: 'test'},
+          outputProjection: {passed: true},
+          summary: {passed: true},
+        };
+        const attestation = createCodeMemoryLinkInvocationAttestationV1({
+          ...verificationInput,
+          invocationNonce: `inv_${'d'.repeat(16)}`,
+          postRuntime: runtime,
+          preRuntime: runtime,
+        });
+        expect(attestation).toMatchObject({postRuntime: identity, preRuntime: identity});
+        expect(() =>
+          parseCodeMemoryLinkInvocationAttestationV1(
+            {...attestation, postRuntime: {...attestation.postRuntime, runtime: 'bun-1.3.14'}},
+            verificationInput,
+          ),
+        ).toThrow(/post-run runtime has unsupported or missing fields/);
+      }),
+      {numRuns: 60},
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- project verified development runtime evidence to the exact two-field attestation identity
- keep persisted/untrusted receipt decoding exact-key strict
- cover arbitrary extra verified runtime fields with a bounded Fast-check property

This fixes the exact-build dogfood failure found before any governed agent trial ran, and also fixes the same boundary in the governed agent-trial creator.

## Verification

- `bun --bun vitest run test/unit/code-memory-link-attestation.test.ts test/unit/code-memory-link-dogfood.test.ts test/unit/code-memory-link-agent-ab.test.ts test/unit/code-memory-link-runner-entrypoints.test.ts` (38 passed)
- `bun run lint`
- `bun run typecheck`
- Prettier and `git diff --check`

The failed first dogfood attempt stopped before the governed 168-trial matrix; no preregistered trial ledger was consumed.