### PR TITLE
fix: harden 100k vector release evidence

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,7 +57,7 @@ on:
   workflow_dispatch:
     inputs:
       include_100k:
-        description: Run the 100k scale-boundary suite on Linux
+        description: Run the 100k scale-boundary suites (lexical Linux and pinned-vector macOS ARM64)
         required: false
         type: boolean
         default: false
@@ -540,10 +540,10 @@ jobs:
           retention-days: 30
 
   code-graph-vectors-100k:
-    name: Code graph pinned vectors 100k · Linux
+    name: Code graph pinned vectors 100k · macOS ARM64
     if: github.event_name == 'schedule' || inputs.include_100k
     needs: prepare-code-graph-vector-model
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     timeout-minutes: 60
 
     steps:
@@ -562,6 +562,10 @@ jobs:
           path: artifacts/code-graph-model-home/models/embedding/${{ env.CODE_GRAPH_EMBEDDING_MODEL_ID }}
 
       - name: Gate 100k production-vector activation and scans
+        timeout-minutes: 50
+        env:
+          THREADNOTE_BENCHMARK_RUNNER_CLASS: github-hosted-macos-15-ARM64
+          THREADNOTE_BENCHMARK_RUNNER_ID: ${{ runner.name }}
         run: >-
           bun run bench:code-graph --
           --vectors
@@ -570,13 +574,14 @@ jobs:
           --samples 3
           --warmups 1
           --fail-on-budget
-          --output artifacts/code-graph-vectors-100k-Linux-${{ runner.arch }}.json
+          --output artifacts/code-graph-vectors-100k-${{ runner.os }}-${{ runner.arch }}.json
 
       - uses: actions/upload-artifact@v7
         if: always()
+        timeout-minutes: 5
         with:
-          name: code-graph-vector-benchmark-100k-Linux-${{ runner.arch }}
-          path: artifacts/code-graph-vectors-100k-Linux-${{ runner.arch }}.json
+          name: code-graph-vector-benchmark-100k-${{ runner.os }}-${{ runner.arch }}
+          path: artifacts/code-graph-vectors-100k-${{ runner.os }}-${{ runner.arch }}.json*
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/benchmark-code-graph-heavy-tail.ts
+++ b/scripts/benchmark-code-graph-heavy-tail.ts
@@ -10,7 +10,12 @@ import {CodeGraphStore, type StoredCodeGraph} from '../src/code_graph/store.js';
 import type {CodeGraphProgress} from '../src/code_graph/types.js';
 import {runCommandEffect} from '../src/effect/command.js';
 import {ApplicationLayer} from '../src/effect/runtime.js';
-import {SystemInfo, type SystemInfoShape} from '../src/effect/system.js';
+import {
+  processResourceUsageMaxRssBytes,
+  SystemInfo,
+  type ProcessResourceUsageRuntime,
+  type SystemInfoShape,
+} from '../src/effect/system.js';
 import {
   BENCHMARK_ARTIFACT_VERSION,
   benchmarkMeasurement,
@@ -1270,7 +1275,8 @@ function boundedOutput(label: string, output: string): string {
 
 function processPeakRssBytes(): number {
   const maxRss = process.resourceUsage().maxRSS;
-  return 'bun' in process.versions ? maxRss : maxRss * 1_024;
+  const runtime: ProcessResourceUsageRuntime = 'bun' in process.versions ? 'bun' : 'node';
+  return processResourceUsageMaxRssBytes(maxRss, process.platform, runtime);
 }
 
 const git = Effect.fn('benchmarkCodeGraphHeavyTail.git')((cwd: string, args: readonly string[]) =>

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -43,7 +43,7 @@ import {sha256FileHex} from '../src/effect/digest.js';
 import {ApplicationLayer, type ApplicationServices} from '../src/effect/runtime.js';
 import {THREADNOTE_EMBEDDING_CONTEXTS_ENV, type EmbeddingContextPoolSize} from '../src/effect/ai/node-llama-cpp.js';
 import {LocalModelRuntime} from '../src/effect/ai/local-model-runtime.js';
-import {SystemInfo} from '../src/effect/system.js';
+import {processResourceUsageMaxRssBytes, SystemInfo, type ProcessResourceUsageRuntime} from '../src/effect/system.js';
 import {CORE_EMBEDDING_MODEL_ID} from '../src/models/builtin.js';
 import {LocalModelCatalog} from '../src/models/catalog.js';
 import {selectLocalModel} from '../src/models/selection.js';
@@ -1730,7 +1730,9 @@ const benchmarkCodeGraph = Effect.scoped(
           : {}),
         ...(runtimeProvenance ? benchmarkRuntimeProvenanceMetadata(runtimeProvenance) : {}),
         rssMeasurement:
-          'boundary RSS plus process-lifetime resourceUsage.maxRSS; peak is cumulative, not phase-isolated',
+          'boundary RSS plus process-lifetime resourceUsage.maxRSS normalized to bytes; ' +
+          'Bun 1.3.14 Darwin is bytes, while Bun Linux/Windows and Node KiB are multiplied by 1024; ' +
+          'peak is cumulative, not phase-isolated',
         statusSamples,
         sqliteDurableStorageMeasurement:
           'SQLite durable database allocated-page high-water from direct materialization progress; WAL and SHM remain separately sampled filesystem artifacts',
@@ -3014,21 +3016,6 @@ export interface ProcessTelemetry {
   readonly cpuUserMicroseconds: number;
   readonly peakRssBytes: number;
   readonly rssBytes: number;
-}
-
-export type ProcessResourceUsageRuntime = 'bun' | 'node';
-
-/**
- * Node normalizes resourceUsage().maxRSS to KiB on every platform. The
- * release-pinned Bun runtime follows the native Darwin byte unit but reports
- * KiB on Linux; revalidate this branch whenever the pinned Bun version changes.
- */
-export function processMaxRssBytes(
-  maxRss: number,
-  platform: NodeJS.Platform,
-  runtime: ProcessResourceUsageRuntime,
-): number {
-  return runtime === 'bun' && platform === 'darwin' ? maxRss : maxRss * 1_024;
 }
 
 function processTelemetry(): ProcessTelemetry {
@@ -7973,7 +7960,7 @@ export function enforceCodeGraphBenchmarkBudget(
 function processPeakRssBytes(): number {
   const maxRss = process.resourceUsage().maxRSS;
   const runtime: ProcessResourceUsageRuntime = 'bun' in process.versions ? 'bun' : 'node';
-  return processMaxRssBytes(maxRss, process.platform, runtime);
+  return processResourceUsageMaxRssBytes(maxRss, process.platform, runtime);
 }
 
 export function requiresLongScaleBenchmarkEvidence(scaleSymbols: number | undefined): boolean {

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -560,10 +560,9 @@ const benchmarkCodeGraph = Effect.scoped(
     const threadnoteSourceRoot = yield* path.fromFileUrl(new URL('..', import.meta.url));
     const ratchet = options.ratchetPath ? yield* readJsonFile(options.ratchetPath) : undefined;
     if (ratchet !== undefined) validateCodeGraphBenchmarkRatchet(ratchet);
+    const longScaleEvidenceRun = requiresLongScaleBenchmarkEvidence(options.scaleSymbols);
     const runtimeProvenanceRequired =
-      options.profile === 'production-large' ||
-      options.repository !== undefined ||
-      (options.scaleSymbols ?? 0) >= LONG_SCALE_PROVENANCE_THRESHOLD;
+      options.profile === 'production-large' || options.repository !== undefined || longScaleEvidenceRun;
     const runtimeProvenance = runtimeProvenanceRequired
       ? yield* validateBenchmarkRuntimeProvenance(threadnoteSourceRoot)
       : undefined;
@@ -573,7 +572,8 @@ const benchmarkCodeGraph = Effect.scoped(
       process.env.THREADNOTE_BENCHMARK_RELEASE_SHA?.trim() || undefined,
     );
     const largeEvidenceRun = options.profile === 'production-large' || options.repository !== undefined;
-    const sampleProcessTree = largeEvidenceRun || options.embeddingContexts !== undefined;
+    const checkpointedEvidenceRun = largeEvidenceRun || longScaleEvidenceRun;
+    const sampleProcessTree = checkpointedEvidenceRun || options.embeddingContexts !== undefined;
     const externalPrepared =
       options.repository !== undefined ? yield* prepareExternalCodeGraphFixture(options) : undefined;
     if (externalPrepared && releaseEvidenceSource) {
@@ -623,7 +623,7 @@ const benchmarkCodeGraph = Effect.scoped(
         Effect.fail(new ScriptError('External benchmark homes could not be retained after preflight.'));
     }
     const runCheckpoint =
-      largeEvidenceRun && options.outputPath
+      checkpointedEvidenceRun && options.outputPath
         ? yield* Effect.acquireRelease(
             makeBenchmarkRunCheckpoint(`${options.outputPath}.run.json`),
             (checkpoint, exit) => checkpoint.finish(Exit.isSuccess(exit) ? 'complete' : 'failed'),
@@ -3014,6 +3014,21 @@ export interface ProcessTelemetry {
   readonly cpuUserMicroseconds: number;
   readonly peakRssBytes: number;
   readonly rssBytes: number;
+}
+
+export type ProcessResourceUsageRuntime = 'bun' | 'node';
+
+/**
+ * Node normalizes resourceUsage().maxRSS to KiB on every platform. The
+ * release-pinned Bun runtime follows the native Darwin byte unit but reports
+ * KiB on Linux; revalidate this branch whenever the pinned Bun version changes.
+ */
+export function processMaxRssBytes(
+  maxRss: number,
+  platform: NodeJS.Platform,
+  runtime: ProcessResourceUsageRuntime,
+): number {
+  return runtime === 'bun' && platform === 'darwin' ? maxRss : maxRss * 1_024;
 }
 
 function processTelemetry(): ProcessTelemetry {
@@ -6562,6 +6577,7 @@ function benchmarkRunnerLabel(
     if (normalized === 'local-unclassified') return normalized;
     if (/^github-hosted-ubuntu-[a-z0-9.]+-x64$/.test(normalized)) return 'github-hosted-linux-x64';
     if (/^github-hosted-ubuntu-[a-z0-9.]+-arm64$/.test(normalized)) return 'github-hosted-linux-arm64';
+    if (/^github-hosted-macos-[a-z0-9.]+-arm64$/.test(normalized)) return 'github-hosted-macos-arm64';
     return 'other';
   }
   const digest = new Bun.CryptoHasher('sha256').update(value).digest('hex');
@@ -7956,7 +7972,12 @@ export function enforceCodeGraphBenchmarkBudget(
 
 function processPeakRssBytes(): number {
   const maxRss = process.resourceUsage().maxRSS;
-  return 'bun' in process.versions ? maxRss : maxRss * 1_024;
+  const runtime: ProcessResourceUsageRuntime = 'bun' in process.versions ? 'bun' : 'node';
+  return processMaxRssBytes(maxRss, process.platform, runtime);
+}
+
+export function requiresLongScaleBenchmarkEvidence(scaleSymbols: number | undefined): boolean {
+  return (scaleSymbols ?? 0) >= LONG_SCALE_PROVENANCE_THRESHOLD;
 }
 
 const prepareBenchmarkEmbedding = Effect.fn('benchmarkCodeGraph.prepareEmbedding')(function* (

--- a/src/code_graph/tree_sitter/extractor.ts
+++ b/src/code_graph/tree_sitter/extractor.ts
@@ -13,6 +13,7 @@ import type {
 } from '../types.js';
 import {CodeGraphLanguagePackError} from '../languages/types.js';
 import type {CodeGraphExtractionContext, VerifiedLanguageAsset} from '../languages/types.js';
+import {createSourceLineIndex, sourceSpan} from '../languages/source_line_index.js';
 import {TreeSitterRuntime} from './runtime.js';
 
 export interface TreeSitterImport {
@@ -45,7 +46,7 @@ export interface TreeSitterReferenceInput {
 }
 
 export const TREE_SITTER_EXTRACTOR_POLICY_VERSION =
-  'tree-sitter-extractor-v3-unified-source-spans-unique-symbol-identities';
+  'tree-sitter-extractor-v4-unified-crlf-safe-source-spans-unique-symbol-identities';
 
 type NodeSpan = (node: Node) => CodeGraphSpan;
 
@@ -542,33 +543,8 @@ function leadingDocumentation(node: Node): string | undefined {
 }
 
 function createNodeSpan(content: string): NodeSpan {
-  const lineStarts = [0];
-  for (let cursor = 0; cursor < content.length; cursor += 1) {
-    const character = content[cursor];
-    if (character === '\r') {
-      if (content[cursor + 1] === '\n') cursor += 1;
-      lineStarts.push(cursor + 1);
-    } else if (character === '\n' || character === '\u2028' || character === '\u2029') {
-      lineStarts.push(cursor + 1);
-    }
-  }
-  const positionAt = (rawOffset: number): {readonly column: number; readonly line: number} => {
-    const offset = Math.max(0, Math.min(content.length, rawOffset));
-    let lower = 0;
-    let upper = lineStarts.length;
-    while (lower < upper) {
-      const middle = lower + Math.floor((upper - lower) / 2);
-      if (lineStarts[middle]! <= offset) lower = middle + 1;
-      else upper = middle;
-    }
-    const lineIndex = Math.max(0, lower - 1);
-    return {column: offset - lineStarts[lineIndex]! + 1, line: lineIndex + 1};
-  };
-  return node => {
-    const from = positionAt(node.startIndex);
-    const to = positionAt(node.endIndex);
-    return {column: from.column, endColumn: to.column, endLine: to.line, line: from.line};
-  };
+  const lineIndex = createSourceLineIndex(content);
+  return node => sourceSpan(lineIndex, node.startIndex, node.endIndex);
 }
 
 function treeSitterSymbolId(

--- a/src/effect/system.ts
+++ b/src/effect/system.ts
@@ -126,6 +126,22 @@ const nativeFileSystemModule = process.getBuiltinModule('fs') as NativeFileSyste
 const nativeFileSystemPromises = nativeFileSystemModule.promises;
 const nativePathModule = process.getBuiltinModule('path') as NativePathModuleShape;
 
+export type ProcessResourceUsageRuntime = 'bun' | 'node';
+
+/**
+ * Node exposes process.resourceUsage().maxRSS in KiB on every platform. The
+ * release-pinned Bun 1.3.14 exposes bytes on Darwin and KiB on its other
+ * supported platforms. Revalidate this adapter whenever the pinned Bun
+ * version moves.
+ */
+export function processResourceUsageMaxRssBytes(
+  maxRss: number,
+  platform: NodeJS.Platform,
+  runtime: ProcessResourceUsageRuntime,
+): number {
+  return runtime === 'bun' && platform === 'darwin' ? maxRss : maxRss * 1_024;
+}
+
 export function platformPathFor(platform: NodeJS.Platform): PlatformPathShape {
   return platform === 'win32' ? nativePathModule.win32 : nativePathModule.posix;
 }
@@ -419,10 +435,11 @@ export class SystemInfo extends Context.Service<SystemInfo, SystemInfoShape>()('
         memoryUsage: () => {
           const usage = process.memoryUsage();
           const runtimePeakRss = process.resourceUsage().maxRSS;
+          const runtime: ProcessResourceUsageRuntime = 'bun' in process.versions ? 'bun' : 'node';
           return {
             external: usage.external,
             heapUsed: usage.heapUsed,
-            peakRss: 'bun' in process.versions ? runtimePeakRss : runtimePeakRss * 1_024,
+            peakRss: processResourceUsageMaxRssBytes(runtimePeakRss, runtimePlatform, runtime),
             rss: usage.rss,
           };
         },

--- a/test/evaluation/baselines/code-graph-v1/budgets.json
+++ b/test/evaluation/baselines/code-graph-v1/budgets.json
@@ -96,6 +96,7 @@
     "Hosted Windows uses explicit development-only scheduler headroom for hot query, one-file indexing, and structural analysis; Linux and macOS retain the tighter reviewed fixture ceilings.",
     "The Windows overrides still reject multi-second hot queries and minute-scale one-file rebuilds instead of weakening vector, scale, quality, or safety gates.",
     "Pinned production-vector budgets gate the lexically disjoint development control plus full vector activation and scans at 10k and 100k symbols.",
+    "The 100k real-model vector lane uses the explicit hosted macOS ARM64 runner class; the 10k Linux lane retains cross-platform model coverage without making the 100k gate depend on a two-context CPU runner that cannot finish the reviewed workload.",
     "The 10k pinned-vector cold-index wall ceiling is 600 seconds: twice the prior 300-second hosted-runner envelope and about 20% above the reviewed 498-second slow-host tail; materialization, incremental, query, analysis, RSS, and disk guards remain unchanged.",
     "Generated 10k and 100k lexical artifacts are budget-gated on graph/runtime pull requests in Linux and on scheduled runners; production-shaped repositories remain a separate soak gate.",
     "Reviewed lexical incremental ceilings retain substantial cross-runner headroom over the stored baselines while rejecting minute-scale one-file rebuild regressions.",

--- a/test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
+++ b/test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json
@@ -824,7 +824,7 @@
     "cold-process-peak-rss": {
       "samplesMinimum": 1,
       "unit": "bytes",
-      "p95Maximum": 1195010
+      "p95Maximum": 1223690240
     },
     "cold-reference-resolution": {
       "samplesMinimum": 1,
@@ -1072,7 +1072,7 @@
     "incremental-process-peak-rss": {
       "samplesMinimum": 1,
       "unit": "bytes",
-      "p95Maximum": 1195010
+      "p95Maximum": 1223690240
     },
     "incremental-sqlite-journal-peak-observed": {
       "samplesMinimum": 1,

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -285,6 +285,29 @@ describe('platform benchmark workflow', () => {
       name: 'code-graph-vector-benchmark-10k-Linux-${{ runner.arch }}',
       path: 'artifacts/code-graph-vectors-10k-Linux-${{ runner.arch }}.json',
     });
+
+    const vector100k = workflow.jobs['code-graph-vectors-100k']!;
+    const vector100kCapture = vector100k.steps?.find(step => step.run?.includes('--scale-symbols 100000'));
+    const vector100kCommand = vector100kCapture?.run;
+    const vector100kArtifact = vector100k.steps?.find(step => step.uses === 'actions/upload-artifact@v7');
+    expect(vector100k['runs-on']).toBe('macos-15');
+    expect(vector100k['timeout-minutes']).toBe(60);
+    expect(vector100k.env).toBeUndefined();
+    expect(vector100kCapture?.['timeout-minutes']).toBe(50);
+    expect(vector100kCapture?.env).toEqual({
+      THREADNOTE_BENCHMARK_RUNNER_CLASS: 'github-hosted-macos-15-ARM64',
+      THREADNOTE_BENCHMARK_RUNNER_ID: '${{ runner.name }}',
+    });
+    expect(vector100kCommand).toContain(
+      '--output artifacts/code-graph-vectors-100k-${{ runner.os }}-${{ runner.arch }}.json',
+    );
+    expect(vector100kArtifact?.with).toMatchObject({
+      'if-no-files-found': 'error',
+      name: 'code-graph-vector-benchmark-100k-${{ runner.os }}-${{ runner.arch }}',
+      path: 'artifacts/code-graph-vectors-100k-${{ runner.os }}-${{ runner.arch }}.json*',
+    });
+    expect(vector100kArtifact?.if).toBe('always()');
+    expect(vector100kArtifact?.['timeout-minutes']).toBe(5);
   });
 
   it('bounds the shared production-large n=1 workflow for schedule, opt-in, and release evidence', () => {

--- a/test/unit/code-graph.benchmark-harness.test.ts
+++ b/test/unit/code-graph.benchmark-harness.test.ts
@@ -3,7 +3,7 @@ import {provideTestLayer} from '../helpers/effect-layer.js';
 import {readFileSync} from '../helpers/node-fs.js';
 import {it as effectIt} from '@effect/vitest';
 import {Database} from 'bun:sqlite';
-import {Clock, Effect, FileSystem, Path, PlatformError, Schedule} from 'effect';
+import {Clock, Effect, FileSystem, Path, PlatformError, Schedule, Schema} from 'effect';
 import {TestClock} from 'effect/testing';
 import fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
@@ -25,7 +25,6 @@ import {
   measureBenchmarkIndex,
   measureSampledBenchmarkIndex,
   parseCodeGraphBenchmarkArguments,
-  processMaxRssBytes,
   productionBenchmarkStorageGoverned,
   requiresLongScaleBenchmarkEvidence,
   restoreBenchmarkOverlay,
@@ -362,17 +361,34 @@ describe('code graph external benchmark harness', () => {
     expect(source.match(/sampler\s*\? Effect\.void\s*:\s*observeSqliteStoragePeak/g)).toHaveLength(3);
   });
 
-  it.each([
-    {expected: 544_440, platform: 'darwin', runtime: 'bun'},
-    {expected: 557_506_560, platform: 'linux', runtime: 'bun'},
-    {expected: 557_506_560, platform: 'darwin', runtime: 'node'},
-    {expected: 557_506_560, platform: 'linux', runtime: 'node'},
-  ] satisfies ReadonlyArray<{
-    readonly expected: number;
-    readonly platform: NodeJS.Platform;
-    readonly runtime: 'bun' | 'node';
-  }>)('normalizes $runtime maxRSS on $platform to bytes', ({expected, platform, runtime}) => {
-    expect(processMaxRssBytes(544_440, platform, runtime)).toBe(expected);
+  it('uses the centralized process maxRSS byte normalizer', () => {
+    const source = readFileSync('scripts/benchmark-code-graph.ts', 'utf8');
+
+    expect(source).toContain('processResourceUsageMaxRssBytes(maxRss, process.platform, runtime)');
+    expect(source).not.toContain("return 'bun' in process.versions ? maxRss : maxRss * 1_024");
+  });
+
+  it('preserves the governed Linux RSS ceiling while expressing it in bytes', () => {
+    const ratchet = Schema.decodeUnknownSync(
+      Schema.fromJsonString(
+        Schema.Struct({
+          measurements: Schema.Struct({
+            'cold-process-peak-rss': Schema.Struct({
+              p95Maximum: Schema.Number,
+              unit: Schema.Literal('bytes'),
+            }),
+            'incremental-process-peak-rss': Schema.Struct({
+              p95Maximum: Schema.Number,
+              unit: Schema.Literal('bytes'),
+            }),
+          }),
+        }),
+      ),
+    )(readFileSync('test/evaluation/baselines/code-graph-v1/production-ratchet-github-linux-x64.json', 'utf8'));
+    const governedCeilingBytes = 1_195_010 * 1_024;
+
+    expect(ratchet.measurements['cold-process-peak-rss'].p95Maximum).toBe(governedCeilingBytes);
+    expect(ratchet.measurements['incremental-process-peak-rss'].p95Maximum).toBe(governedCeilingBytes);
   });
 
   it('retains provenance-valid artifact evidence before reporting a budget or ratchet regression', () => {

--- a/test/unit/code-graph.benchmark-harness.test.ts
+++ b/test/unit/code-graph.benchmark-harness.test.ts
@@ -25,7 +25,9 @@ import {
   measureBenchmarkIndex,
   measureSampledBenchmarkIndex,
   parseCodeGraphBenchmarkArguments,
+  processMaxRssBytes,
   productionBenchmarkStorageGoverned,
+  requiresLongScaleBenchmarkEvidence,
   restoreBenchmarkOverlay,
   sanitizedBenchmarkEnvironmentProvenance,
   semanticBenchmarkOverlay,
@@ -334,11 +336,43 @@ describe('code graph external benchmark harness', () => {
     expect(source).not.toContain('const sameOverlayReferenceStarted = yield* Clock.currentTimeNanos');
   });
 
-  it('enables recursive process sampling for explicit embedding-context candidates', () => {
+  it('checkpoints and samples 100k evidence without enabling unrelated large-evidence behavior', () => {
     const source = readFileSync('scripts/benchmark-code-graph.ts', 'utf8');
-    expect(source).toContain('const sampleProcessTree = largeEvidenceRun || options.embeddingContexts !== undefined');
+    expect(requiresLongScaleBenchmarkEvidence(99_999)).toBe(false);
+    expect(requiresLongScaleBenchmarkEvidence(100_000)).toBe(true);
+    expect(requiresLongScaleBenchmarkEvidence(250_000)).toBe(true);
+    fc.assert(
+      fc.property(fc.integer({max: 200_000, min: 0}), fc.integer({max: 200_000, min: 0}), (first, second) => {
+        const lower = Math.min(first, second);
+        const upper = Math.max(first, second);
+        expect(Number(requiresLongScaleBenchmarkEvidence(lower))).toBeLessThanOrEqual(
+          Number(requiresLongScaleBenchmarkEvidence(upper)),
+        );
+      }),
+      {numRuns: 100},
+    );
+    expect(source).toContain('const checkpointedEvidenceRun = largeEvidenceRun || longScaleEvidenceRun');
+    expect(source).toContain(
+      'const sampleProcessTree = checkpointedEvidenceRun || options.embeddingContexts !== undefined',
+    );
+    expect(source).toContain('checkpointedEvidenceRun && options.outputPath');
+    expect(source).toContain('const mcpOperationMatrix = largeEvidenceRun');
+    expect(source).toContain('Math.min(options.samples, largeEvidenceRun ? 3 : 10)');
     expect(source.match(/sampleProcessTree\s*\? startExternalSampler/g)).toHaveLength(3);
     expect(source.match(/sampler\s*\? Effect\.void\s*:\s*observeSqliteStoragePeak/g)).toHaveLength(3);
+  });
+
+  it.each([
+    {expected: 544_440, platform: 'darwin', runtime: 'bun'},
+    {expected: 557_506_560, platform: 'linux', runtime: 'bun'},
+    {expected: 557_506_560, platform: 'darwin', runtime: 'node'},
+    {expected: 557_506_560, platform: 'linux', runtime: 'node'},
+  ] satisfies ReadonlyArray<{
+    readonly expected: number;
+    readonly platform: NodeJS.Platform;
+    readonly runtime: 'bun' | 'node';
+  }>)('normalizes $runtime maxRSS on $platform to bytes', ({expected, platform, runtime}) => {
+    expect(processMaxRssBytes(544_440, platform, runtime)).toBe(expected);
   });
 
   it('retains provenance-valid artifact evidence before reporting a budget or ratchet regression', () => {
@@ -874,6 +908,15 @@ describe('code graph external benchmark harness', () => {
       }),
     ).toMatchObject({
       THREADNOTE_BENCHMARK_RUNNER_CLASS: 'github-hosted-linux-x64',
+      THREADNOTE_BENCHMARK_RUNNER_ID: expect.stringMatching(/^runner-[0-9a-f]{16}$/),
+    });
+    expect(
+      sanitizedBenchmarkEnvironmentProvenance({
+        THREADNOTE_BENCHMARK_RUNNER_CLASS: 'github-hosted-macos-15-ARM64',
+        THREADNOTE_BENCHMARK_RUNNER_ID: 'macos-arm64-runner',
+      }),
+    ).toMatchObject({
+      THREADNOTE_BENCHMARK_RUNNER_CLASS: 'github-hosted-macos-arm64',
       THREADNOTE_BENCHMARK_RUNNER_ID: expect.stringMatching(/^runner-[0-9a-f]{16}$/),
     });
   });

--- a/test/unit/code-graph.heavy-tail-benchmark.test.ts
+++ b/test/unit/code-graph.heavy-tail-benchmark.test.ts
@@ -30,6 +30,13 @@ import {
 } from '../../scripts/code-graph-heavy-tail-fixture.js';
 
 describe('code graph large-monorepo heavy-tail benchmark', () => {
+  it('uses the centralized process maxRSS byte normalizer', async () => {
+    const source = await readFile('scripts/benchmark-code-graph-heavy-tail.ts', 'utf8');
+
+    expect(source).toContain('processResourceUsageMaxRssBytes(maxRss, process.platform, runtime)');
+    expect(source).not.toContain("return 'bun' in process.versions ? maxRss : maxRss * 1_024");
+  });
+
   it('keeps the checked profile synchronized with the reviewed workload shape', async () => {
     const baseline = (await Bun.file('test/evaluation/baselines/code-graph-v1/heavy-tail-profile.json').json()) as {
       readonly profile: unknown;

--- a/test/unit/code-graph.languages.property.test.ts
+++ b/test/unit/code-graph.languages.property.test.ts
@@ -127,6 +127,14 @@ describe('polyglot code graph extractor properties', () => {
           },
         );
       }
+
+      layerIt.effect('bounds malformed Swift import spans at a CRLF boundary', () =>
+        Effect.gen(function* () {
+          const file = inventoryFile('src/fuzz.swift', 'import// comment\r\n');
+          const facts = yield* BUILTIN_LANGUAGE_PACK_REGISTRY.extractFile(file);
+          assertFacts(file, facts, 'swift');
+        }),
+      );
     });
 
     layerIt.effect.prop(

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1007,6 +1007,8 @@ describe('code graph release evidence', () => {
           benchmarkMeasurement('cold-index', 'milliseconds', [coldIndexMilliseconds]),
           benchmarkMeasurement('cold-registration-lock-and-database-setup', 'milliseconds', [coldIndexMilliseconds]),
           benchmarkMeasurement('cold-registration-process-cpu-n1', 'milliseconds', [coldIndexMilliseconds]),
+          benchmarkMeasurement('cold-process-peak-rss', 'bytes', [512 * 1_048_576 + coldIndexMilliseconds]),
+          benchmarkMeasurement('incremental-process-peak-rss', 'bytes', [512 * 1_048_576 + coldIndexMilliseconds]),
           benchmarkMeasurement('cold-sqlite-wal-peak-observed', 'bytes', [coldIndexMilliseconds]),
           benchmarkMeasurement('same-overlay-reference-registration-lock-and-database-setup', 'milliseconds', [
             coldIndexMilliseconds + 10,
@@ -1437,6 +1439,41 @@ describe('code graph release evidence', () => {
 
     expect(() => enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet)).toThrow(/cold-index/u);
     expect(() => enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, pairedControl)).not.toThrow();
+    const correctedRssCandidate = sandwichCandidate({
+      'cold-index': 1_200,
+      'cold-process-peak-rss': 930_451_456,
+      'incremental-process-peak-rss': 930_451_456,
+    });
+    const mixedEraRssEvidence = sandwichEvidence(
+      {
+        'cold-index': 1_200,
+        'cold-process-peak-rss': 935_190_528,
+        'incremental-process-peak-rss': 935_190_528,
+      },
+      sandwichControl({
+        'cold-index': 1_000,
+        // The protected-base artifact predates byte normalization and retains native Linux KiB numerics.
+        'cold-process-peak-rss': 915_952,
+        'incremental-process-peak-rss': 915_952,
+      }),
+    );
+    const mixedEraRssRatchet = {
+      ...githubHostedRatchet,
+      measurements: {
+        ...githubHostedRatchet.measurements,
+        'cold-process-peak-rss': {
+          ...githubHostedRatchet.measurements['cold-process-peak-rss']!,
+          p95Maximum: 1_223_690_240,
+        },
+        'incremental-process-peak-rss': {
+          ...githubHostedRatchet.measurements['incremental-process-peak-rss']!,
+          p95Maximum: 1_223_690_240,
+        },
+      },
+    };
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(correctedRssCandidate, mixedEraRssRatchet, mixedEraRssEvidence),
+    ).not.toThrow();
     fc.assert(
       fc.property(fc.integer({max: 500, min: -500}), fc.integer({max: 50_000, min: 30_000}), (slope, regression) => {
         const baseline = 100_000;
@@ -1569,7 +1606,9 @@ describe('code graph release evidence', () => {
       }),
     ).toThrow(/paired control environment\.fixtureHash/u);
     const invariantGuardNames = [
+      'cold-process-peak-rss',
       'cold-registration-process-cpu-n1',
+      'incremental-process-peak-rss',
       'one-file-reindex-incremental-work-planned-rows-n1',
       'cold-sqlite-wal-peak-observed',
     ] as const;

--- a/test/unit/effect-system.test.ts
+++ b/test/unit/effect-system.test.ts
@@ -33,6 +33,7 @@ import {
   parseProcessStartIdentityOutput,
   parseWindowsAvailableDiskBytes,
   platformPathFor,
+  processResourceUsageMaxRssBytes,
   probeAvailableDiskBytes,
   probeRuntimeAvailableDiskBytes,
   readCanonicalProcessStartIdentity,
@@ -48,6 +49,23 @@ import {
 } from '../../src/effect/system.js';
 
 describe('SystemInfo structural path adapter', () => {
+  it.each([
+    {expected: 544_440, platform: 'darwin', runtime: 'bun'},
+    {expected: 557_506_560, platform: 'freebsd', runtime: 'bun'},
+    {expected: 557_506_560, platform: 'linux', runtime: 'bun'},
+    {expected: 557_506_560, platform: 'win32', runtime: 'bun'},
+    {expected: 557_506_560, platform: 'darwin', runtime: 'node'},
+    {expected: 557_506_560, platform: 'freebsd', runtime: 'node'},
+    {expected: 557_506_560, platform: 'linux', runtime: 'node'},
+    {expected: 557_506_560, platform: 'win32', runtime: 'node'},
+  ] satisfies ReadonlyArray<{
+    readonly expected: number;
+    readonly platform: NodeJS.Platform;
+    readonly runtime: 'bun' | 'node';
+  }>)('normalizes $runtime process maxRSS on $platform to bytes', ({expected, platform, runtime}) => {
+    expect(processResourceUsageMaxRssBytes(544_440, platform, runtime)).toBe(expected);
+  });
+
   effectIt.effect.prop(
     'enforces group and other privacy bits only on platforms with POSIX modes',
     {
@@ -1024,6 +1042,16 @@ function waitForRecordedProcessIds(path: string, expectedCount: number, timeoutM
 }
 
 describe('SystemInfo benchmark metadata', () => {
+  effectIt.effect('reports process peak RSS in bytes', () =>
+    Effect.gen(function* () {
+      const memory = (yield* SystemInfo).memoryUsage();
+      const peakRss = memory.peakRss ?? 0;
+
+      expect(peakRss).toBeGreaterThan(1_048_576);
+      expect(peakRss).toBeGreaterThanOrEqual(memory.rss);
+    }).pipe(provideTestLayer(SystemInfo.layer)),
+  );
+
   effectIt.effect('reports real CPU, memory, and operating-system values', () =>
     Effect.gen(function* () {
       const hardware = yield* (yield* SystemInfo).hardwareInfo;


### PR DESCRIPTION
## Summary

- run the pinned 100k real-vector lane on the standard hosted macOS ARM64 runner while retaining Linux real-model coverage at 10k
- checkpoint and sample all 100k scale runs, and upload partial telemetry if the benchmark times out
- normalize process max RSS to bytes for the release-pinned Bun runtime and Node
- preserve every existing performance budget and ratchet threshold

## Evidence

The current Linux 100k lane has timed out at 60 minutes in five independent hosted runs. Its retained 10k artifact spent about 439 seconds in each of two full embedding passes with only two effective contexts, projecting the 100k workload far beyond both the job timeout and the unchanged 900-second cold-index budget. Current GitHub runner specifications identify macos-15 as a 3-core M1 ARM64 runner; focused local 10k evidence on Apple Silicon completed the cold index in about 32 seconds. Hosted 100k evidence remains the deciding gate.

## Validation

- 74 focused tests passed
- full lint and file-length policy passed
- source, test, and site typechecks passed
- Prettier and git diff hygiene passed
- dev-cycle: 0 critical, 0 important; one minor operator-copy issue fixed

Property coverage now checks monotonic admission of long-scale checkpointing. No full suite was run locally; PR CI is authoritative.