### PR TITLE
test(graph): stabilize Windows hosted query quantiles

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -173,7 +173,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            hotQuerySamples: 25
+          - os: macos-latest
+            hotQuerySamples: 25
+          - os: windows-latest
+            hotQuerySamples: 100
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 
@@ -195,7 +201,7 @@ jobs:
           THREADNOTE_BENCHMARK_RUNNER_ID: ${{ runner.name }}
         run: >-
           bun run bench:code-graph --
-          --samples 25
+          --samples ${{ matrix.hotQuerySamples }}
           --warmups 5
           --fail-on-budget
           --output artifacts/code-graph-${{ runner.os }}-${{ runner.arch }}.json

--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -7896,6 +7896,7 @@ export function enforceCodeGraphBenchmarkBudget(
   const record = value as {
     readonly developmentPerformance?: unknown;
     readonly developmentPerformanceByPlatform?: Readonly<Record<string, unknown>>;
+    readonly developmentPerformanceByRunnerClass?: Readonly<Record<string, unknown>>;
     readonly scalePerformance?: Readonly<Record<string, unknown>>;
     readonly scalePerformanceByRunnerClass?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
     readonly vectorPerformance?: unknown;
@@ -7919,6 +7920,15 @@ export function enforceCodeGraphBenchmarkBudget(
     record.developmentPerformanceByPlatform[runtimePlatform] !== null
       ? record.developmentPerformanceByPlatform[runtimePlatform]
       : undefined;
+  const runnerDevelopmentOverride =
+    artifact.metadata.vectorEnabled !== true &&
+    scaleSymbols === undefined &&
+    typeof runnerClass === 'string' &&
+    benchmarkRunnerClassMatchesArtifact(runnerClass, runtimePlatform, artifact.environment.architecture) &&
+    typeof record.developmentPerformanceByRunnerClass?.[runnerClass] === 'object' &&
+    record.developmentPerformanceByRunnerClass[runnerClass] !== null
+      ? record.developmentPerformanceByRunnerClass[runnerClass]
+      : undefined;
   const runnerScalePerformance =
     typeof runnerClass === 'string' ? record.scalePerformanceByRunnerClass?.[runnerClass] : undefined;
   const runnerScaleOverride =
@@ -7932,7 +7942,12 @@ export function enforceCodeGraphBenchmarkBudget(
       : undefined;
   const selected =
     typeof baseSelected === 'object' && baseSelected !== null
-      ? {...baseSelected, ...(platformOverride ?? {}), ...(runnerScaleOverride ?? {})}
+      ? {
+          ...baseSelected,
+          ...(platformOverride ?? {}),
+          ...(runnerDevelopmentOverride ?? {}),
+          ...(runnerScaleOverride ?? {}),
+        }
       : baseSelected;
   if (typeof selected !== 'object' || selected === null) {
     throw new ScriptError(

--- a/test/evaluation/README.md
+++ b/test/evaluation/README.md
@@ -628,6 +628,13 @@ scans, RSS, and disk. Code-graph embeddings use paged SQLite generations so cand
 do not materialize a repository-sized sidecar. The platform workflow retains full artifacts rather than pretending
 shared-runner latency is machine-independent.
 
+The native GitHub-hosted Windows x64 query lane records 100 post-warmup samples; Linux, macOS, and local Windows retain 25. This runner-scoped sample floor increases the empirical p95 resolution after a 25-sample same-tree scheduler-tail
+failure. It does not widen the Windows 750 ms p50, 1,000 ms p95, 500 ms process-CPU p95, or existing 5% guarded p95
+allowance. Under the production percentile convention, 100 samples exclude four upper-order observations and a fifth
+wall breach fails. The retained rationale and artifact provenance are in
+`baselines/code-graph-v1/windows-native-hosted-query-quantile-calibration-v1.{json,md}`; a release candidate must pass
+that 100-sample native lane prospectively.
+
 The reviewed `production-large` profile is shaped after the beta.27 field investigation: approximately 48,000
 eligible files, 800,000 symbols, 2.7 million edges, 12 million lexical term rows, and 24 integrated and nested
 workspaces. One reusable workflow runs weekly, through the explicit `include_production_large` input, and from a

--- a/test/evaluation/baselines/code-graph-v1/budgets.json
+++ b/test/evaluation/baselines/code-graph-v1/budgets.json
@@ -38,6 +38,11 @@
       "wholeGraphAnalysisP95MillisecondsMaximum": 2000
     }
   },
+  "developmentPerformanceByRunnerClass": {
+    "github-hosted-windows-x64": {
+      "hotQuerySamplesMinimum": 100
+    }
+  },
   "vectorPerformance": {
     "coldIndexP95MillisecondsMaximum": 60000,
     "coldMaterializationP95MillisecondsMaximum": 10000,
@@ -109,6 +114,7 @@
     "The development hot-query wall p95 admits at most 5% scheduler-tail hysteresis only while its independent hard p50 and process-CPU ceilings both remain green; raw observations remain unchanged in the retained artifact.",
     "Hosted Windows uses explicit development-only scheduler and storage headroom for the native cold single-observation fuses, hot query, one-file indexing, and structural analysis; Linux and macOS retain the tighter reviewed fixture ceilings.",
     "The Windows 15-second cold-index and 8-second cold-materialization values are hard single-observation fuses, not p95 claims. They are 10%-headroom, whole-second-rounded envelopes over the first exact-candidate hosted storage tail; a prospective breach stops the release instead of automatically recalibrating.",
+    "The GitHub-hosted Windows x64 native fixture records 100 hot-query samples while retaining the 750-millisecond p50, 1-second p95 plus guarded 5% wall-tail allowance, and 500-millisecond process-CPU p95 limits. The larger sample makes the production p95 exclude four upper observations instead of letting the second-highest result dominate a 25-sample estimate; local Windows development runs retain the 25-sample minimum.",
     "The GitHub-hosted Windows x64 10k lexical lane uses a 1.2-second hard wall-p95 fuse over 100 samples, paired with unchanged 750-millisecond p50 and 500-millisecond process-CPU p95 guards and zero additional tolerance. The wall fuse remains 10% headroom over the first exact-candidate hosted scheduler tail, rounded to 100 milliseconds. Threadnote's empirical percentile convention selects rank 96 at 100 samples instead of the second-highest observation at 25; four upper observations are excluded and a fifth wall breach fails while the independent median and CPU guards still reject sustained or computational regressions. Local and non-Windows scale evidence retain the 1-second ceiling.",
     "The Windows overrides keep every quality, safety, RSS, disk, incremental, query, and analysis guard active instead of weakening vector or scale evidence.",
     "Pinned production-vector budgets gate the lexically disjoint development control plus full vector activation and scans at 10k and 100k symbols.",

--- a/test/evaluation/baselines/code-graph-v1/windows-native-hosted-query-quantile-calibration-v1.json
+++ b/test/evaluation/baselines/code-graph-v1/windows-native-hosted-query-quantile-calibration-v1.json
@@ -1,0 +1,232 @@
+{
+  "type": "threadnote-windows-native-hosted-query-quantile-calibration",
+  "version": 1,
+  "createdAt": "2026-09-01T02:03:27.392Z",
+  "observationOrder": "reverse-chronological within recentHostedControls",
+  "fixture": {
+    "architecture": "x64",
+    "fixtureHash": "c4c45a6bcc25517df1fdae711f19f4989e13fde6b4763d596d547c6757230e7d",
+    "operatingSystem": "Windows 10.0.26100",
+    "runnerClass": "github-hosted-windows-x64",
+    "runtime": "bun/1.3.14",
+    "runtimePlatform": "win32"
+  },
+  "governedInputs": {
+    "additionalToleranceRatio": 0,
+    "hotQueryP50MillisecondsMaximum": 750,
+    "hotQueryP95MillisecondsMaximum": 1000,
+    "hotQueryProcessCpuP95MillisecondsMaximum": 500,
+    "hotQueryWallP95ToleranceRatioMaximum": 0.05,
+    "previousSamples": 25,
+    "productionPercentileQuantile": 0.95,
+    "previousP95ExcludedUpperOrderStatistics": 1,
+    "prospectiveP95ExcludedUpperOrderStatistics": 4,
+    "prospectiveSamples": 100
+  },
+  "candidateFailure": {
+    "archiveDigest": "sha256:d7803cbe24e19bc38b18458be06d247f4685fca2a97f1cc4736118f7119b3c05",
+    "artifactId": 9783169868,
+    "conclusion": "failure",
+    "createdAt": "2026-09-01T02:03:27.392Z",
+    "cpu": "AMD64 Family 25 Model 17 Stepping 1, AuthenticAMD",
+    "headSha": "1ce43969b08a772cb19e712eb71d7d34c38b7b66",
+    "jobId": 99710382411,
+    "measurements": {
+      "hotQueryMaximumMilliseconds": 1488.6307,
+      "hotQueryP50Milliseconds": 752.8591,
+      "hotQueryP95Milliseconds": 1325.9255,
+      "hotQueryProcessCpuMaximumMilliseconds": 298,
+      "hotQueryProcessCpuP50Milliseconds": 218,
+      "hotQueryProcessCpuP95Milliseconds": 296,
+      "samples": 25
+    },
+    "rawJsonSha256": "eb2a535dd1c60335202b52db7a6fc819c5612108809961c8cde7de92c45b7949",
+    "runId": 33460824382,
+    "runnerIdentity": "runner-2641491da37430b5",
+    "sourceTreeSha": "b4a5f22dbe90284d4ec6c7da7a216be4f1627ad3"
+  },
+  "recentHostedControls": [
+    {
+      "archiveDigest": "sha256:8b61d95aed8c68cf5b45489df84cb9683d9bde1a9e003c8e629ac786fa91156a",
+      "artifactId": 9782882422,
+      "conclusion": "success",
+      "createdAt": "2026-09-01T01:49:19.271Z",
+      "cpu": "AMD64 Family 25 Model 1 Stepping 1, AuthenticAMD",
+      "headSha": "a4969ac636e905ea4cb6f03529ff2a132c5d5eb5",
+      "jobId": 99707838865,
+      "measurements": {
+        "hotQueryMaximumMilliseconds": 523.1797,
+        "hotQueryP50Milliseconds": 459.933,
+        "hotQueryP95Milliseconds": 506.1142,
+        "hotQueryProcessCpuMaximumMilliseconds": 235,
+        "hotQueryProcessCpuP50Milliseconds": 188,
+        "hotQueryProcessCpuP95Milliseconds": 234,
+        "samples": 25
+      },
+      "rawJsonSha256": "eadde585d3be9103f6e2776d914d8abf64e4e0b1cc1b6de13c1c8e26a17fab4a",
+      "role": "identical-tree-control",
+      "runId": 33459952495,
+      "runnerIdentity": "runner-a50195b86f01eb0d",
+      "sourceTreeSha": "b4a5f22dbe90284d4ec6c7da7a216be4f1627ad3"
+    },
+    {
+      "archiveDigest": "sha256:e63fad62f6c228184c95bc325e2855652c669328dbb5dba576656685584d6c91",
+      "artifactId": 9781805626,
+      "conclusion": "success",
+      "createdAt": "2026-09-01T01:01:13.168Z",
+      "cpu": "AMD64 Family 25 Model 17 Stepping 1, AuthenticAMD",
+      "headSha": "c8cc6a2264daee7ad2bba1d7fa93886a3e62f025",
+      "jobId": 99698563951,
+      "measurements": {
+        "hotQueryMaximumMilliseconds": 589.6781,
+        "hotQueryP50Milliseconds": 523.9516,
+        "hotQueryP95Milliseconds": 585.9893,
+        "hotQueryProcessCpuMaximumMilliseconds": 280,
+        "hotQueryProcessCpuP50Milliseconds": 203,
+        "hotQueryProcessCpuP95Milliseconds": 251,
+        "samples": 25
+      },
+      "rawJsonSha256": "223174828f6e8678a70ea0cc6d1c09843d9b7b88569c03b632620ce38132a911",
+      "role": "recent-hosted-control",
+      "runId": 33456858210,
+      "runnerIdentity": "runner-2fde0b6b9dad0c8f",
+      "sourceTreeSha": "4e9009d0c0b46ed61e2175497f9ddcc8faf668dd"
+    },
+    {
+      "archiveDigest": "sha256:bc676c05f4a628da1225e52c5d580ff69cc7023a16b0083f195832dbf2b75a3f",
+      "artifactId": 9781226672,
+      "conclusion": "success",
+      "createdAt": "2026-09-01T00:35:18.540Z",
+      "cpu": "Intel64 Family 6 Model 173 Stepping 1, GenuineIntel",
+      "headSha": "9126348fdce549b54036223f667efb24c4cfc123",
+      "jobId": 99692956882,
+      "measurements": {
+        "hotQueryMaximumMilliseconds": 4640.2379,
+        "hotQueryP50Milliseconds": 387.3226,
+        "hotQueryP95Milliseconds": 592.0333,
+        "hotQueryProcessCpuMaximumMilliseconds": 234,
+        "hotQueryProcessCpuP50Milliseconds": 155,
+        "hotQueryProcessCpuP95Milliseconds": 220,
+        "samples": 25
+      },
+      "rawJsonSha256": "d50b787427b3a04da42eb00bf1460079deae0306dd955fb0c00a1a87d4f12ae0",
+      "role": "recent-hosted-control",
+      "runId": 33454986359,
+      "runnerIdentity": "runner-ecd7cb6dc9dd977c",
+      "sourceTreeSha": "64a6b2d1910a28d5d27075143b9892b11c460da3"
+    },
+    {
+      "archiveDigest": "sha256:fe9285919b2f7d5ddc2757d512bd96e99e4ad783a2fdd8eb9106c98a9c987b0d",
+      "artifactId": 9780875526,
+      "conclusion": "success",
+      "createdAt": "2026-09-01T00:19:56.503Z",
+      "cpu": "Intel64 Family 6 Model 207 Stepping 2, GenuineIntel",
+      "headSha": "70d8e525931df343cc466f11c65cafa423d53d73",
+      "jobId": 99690084834,
+      "measurements": {
+        "hotQueryMaximumMilliseconds": 1128.7732,
+        "hotQueryP50Milliseconds": 376.8441,
+        "hotQueryP95Milliseconds": 883.9018,
+        "hotQueryProcessCpuMaximumMilliseconds": 249,
+        "hotQueryProcessCpuP50Milliseconds": 156,
+        "hotQueryProcessCpuP95Milliseconds": 218,
+        "samples": 25
+      },
+      "rawJsonSha256": "dcf986847dfd20e024b81319b79f627a9dbd46860a9f84959ee364f6d6bc6f47",
+      "role": "recent-hosted-control",
+      "runId": 33454049206,
+      "runnerIdentity": "runner-4112dc45bacb075a",
+      "sourceTreeSha": "64a6b2d1910a28d5d27075143b9892b11c460da3"
+    },
+    {
+      "archiveDigest": "sha256:2b3d27c23883d36f3fe97d6ac467e2d52067900a77bab3a87fea4d7bafb0a9ef",
+      "artifactId": 9780212185,
+      "conclusion": "success",
+      "createdAt": "2026-08-31T23:50:54.207Z",
+      "cpu": "AMD64 Family 25 Model 1 Stepping 1, AuthenticAMD",
+      "headSha": "55c9fecf0e2808e580f544c4a6a6b3b734b74c20",
+      "jobId": 99683952761,
+      "measurements": {
+        "hotQueryMaximumMilliseconds": 449.1413,
+        "hotQueryP50Milliseconds": 376.259,
+        "hotQueryP95Milliseconds": 443.2119,
+        "hotQueryProcessCpuMaximumMilliseconds": 281,
+        "hotQueryProcessCpuP50Milliseconds": 188,
+        "hotQueryProcessCpuP95Milliseconds": 266,
+        "samples": 25
+      },
+      "rawJsonSha256": "e8e41012cd87089ade224f088fe6ec63a143c42252877afb677a32a04a051eec",
+      "role": "recent-hosted-control",
+      "runId": 33452060622,
+      "runnerIdentity": "runner-c996a05676729521",
+      "sourceTreeSha": "75cebc848d14883c01679c6d751295823d5e7f3f"
+    },
+    {
+      "archiveDigest": "sha256:531353d5d3da437a125bbc09ce702772e510f7192142e68a2861953ac33ec64c",
+      "artifactId": 9779706009,
+      "conclusion": "success",
+      "createdAt": "2026-08-31T23:29:17.250Z",
+      "cpu": "Intel64 Family 6 Model 207 Stepping 2, GenuineIntel",
+      "headSha": "ada8afe9e2d5730de640b40f81e4a8bdd75f5e42",
+      "jobId": 99679696929,
+      "measurements": {
+        "hotQueryMaximumMilliseconds": 384.2338,
+        "hotQueryP50Milliseconds": 360.6885,
+        "hotQueryP95Milliseconds": 377.8,
+        "hotQueryProcessCpuMaximumMilliseconds": 282,
+        "hotQueryProcessCpuP50Milliseconds": 187,
+        "hotQueryProcessCpuP95Milliseconds": 266,
+        "samples": 25
+      },
+      "rawJsonSha256": "bf9437a67031eedc9cb6992a8a9776172d36dbd04aaa266c789dd8cd5ad180a0",
+      "role": "recent-hosted-control",
+      "runId": 33450699839,
+      "runnerIdentity": "runner-7b33a7346bb2db2a",
+      "sourceTreeSha": "88018183ef2776e4899e753a6be8e41c49f4c8c6"
+    }
+  ],
+  "recentHostedSummary": {
+    "observationCount": 6,
+    "hotQueryP50Milliseconds": {
+      "maximum": 523.9516,
+      "minimum": 360.6885,
+      "upperMiddle": 387.3226
+    },
+    "hotQueryP95Milliseconds": {
+      "maximum": 883.9018,
+      "minimum": 377.8,
+      "upperMiddle": 585.9893
+    },
+    "hotQueryProcessCpuP95Milliseconds": {
+      "maximum": 266,
+      "minimum": 218,
+      "upperMiddle": 251
+    }
+  },
+  "adjacentHundredSampleMethodControl": {
+    "archiveDigest": "sha256:83a2039443e6fcc8a45ae2e3ef779a29a167e000c2e038a0ce0d7d4a8e6cbe16",
+    "artifactId": 9783228149,
+    "conclusion": "success",
+    "createdAt": "2026-09-01T02:06:16.722Z",
+    "fixtureHash": "generated-code-graph-v1:10000",
+    "headSha": "1ce43969b08a772cb19e712eb71d7d34c38b7b66",
+    "jobId": 99710382464,
+    "measurements": {
+      "hotQueryMaximumMilliseconds": 495.2508,
+      "hotQueryP50Milliseconds": 374.4869,
+      "hotQueryP95Milliseconds": 426.8328,
+      "hotQueryProcessCpuMaximumMilliseconds": 297,
+      "hotQueryProcessCpuP50Milliseconds": 202,
+      "hotQueryProcessCpuP95Milliseconds": 281,
+      "samples": 100
+    },
+    "rawJsonSha256": "b0ef78d10366239ca57eb1c8298edbc3e9e0ac3e5d7187d1ac394e1d1a4b1bdf",
+    "runId": 33460824382,
+    "scope": "method-control-only-different-10k-fixture-and-runner",
+    "sourceTreeSha": "b4a5f22dbe90284d4ec6c7da7a216be4f1627ad3"
+  },
+  "releaseRequirement": {
+    "prospectiveNativeHostedObservationRequired": true,
+    "thresholdsChanged": false
+  }
+}

--- a/test/evaluation/baselines/code-graph-v1/windows-native-hosted-query-quantile-calibration-v1.md
+++ b/test/evaluation/baselines/code-graph-v1/windows-native-hosted-query-quantile-calibration-v1.md
@@ -1,0 +1,34 @@
+# Hosted Windows native query quantile calibration
+
+The exact release candidate `1ce43969b08a772cb19e712eb71d7d34c38b7b66` failed the native Windows query
+gate in workflow run `33460824382`, job `99710382411`, artifact `9783169868`. Its 25-sample hot-query wall
+p50/p95/max were 752.8591/1,325.9255/1,488.6307 ms. The p50 exceeded the unchanged 750 ms guard by only 2.8591 ms
+(0.381%), while p95 exceeded the unchanged 1,000 ms guard by 325.9255 ms. The existing 5% p95 wall allowance raises
+the effective boundary only to 1,050 ms, which this observation still exceeded by 275.9255 ms. Process-CPU
+p50/p95/max remained 218/296/298 ms against the independent unchanged 500 ms CPU-p95 guard.
+
+This is not source-level regression evidence. The immediately preceding observation at
+`a4969ac636e905ea4cb6f03529ff2a132c5d5eb5` has the exact same Git tree
+`b4a5f22dbe90284d4ec6c7da7a216be4f1627ad3`; workflow run `33459952495`, job `99707838865`, artifact
+`9782882422` passed with wall p50/p95/max 459.933/506.1142/523.1797 ms and CPU p95 234 ms. Across that observation
+and the five preceding normalized hosted Windows native observations, wall p50 ranged 360.6885–523.9516 ms, wall p95
+ranged 377.8–883.9018 ms, and CPU p95 ranged 218–266 ms. One of those controls retained a 4,640.2379 ms maximum yet
+still had a 592.0333 ms p95, demonstrating how a single hosted pause can be present without defining the distribution.
+
+The correction increases only the GitHub-hosted Windows x64 native query sample count from 25 to 100. Threadnote's
+production percentile convention selects zero-based index `floor(sampleCount * 0.95)`: the second-highest observation
+at 25 samples, excluding one upper-order value, and rank 96 at 100 samples, excluding four. A fifth slow query therefore
+fails p95; sustained latency still fails the unchanged median, and computational regression still fails the unchanged
+CPU guard. Linux, macOS, local Windows, every latency limit, and the existing 5% guarded Windows native p95 allowance
+remain unchanged.
+
+The same exact candidate also passed a separate 100-sample 10k fixture in job `99710382464`, artifact `9783228149`,
+with wall p50/p95/max 374.4869/426.8328/495.2508 ms and CPU p95 281 ms. This supports the measurement method only: it
+used a different generated fixture and runner, so it is not prospective native-gate evidence. The replacement release
+candidate must pass the native 100-sample hosted Windows lane before admission.
+
+The failed native archive digest is
+`sha256:d7803cbe24e19bc38b18458be06d247f4685fca2a97f1cc4736118f7119b3c05`; its raw JSON digest is
+`sha256:eb2a535dd1c60335202b52db7a6fc819c5612108809961c8cde7de92c45b7949`. The identical-tree control archive
+digest is `sha256:8b61d95aed8c68cf5b45489df84cb9683d9bde1a9e003c8e629ac786fa91156a`; its raw JSON digest is
+`sha256:eadde585d3be9103f6e2776d914d8abf64e4e0b1cc1b6de13c1c8e26a17fab4a`.

--- a/test/unit/benchmark-workflow.test.ts
+++ b/test/unit/benchmark-workflow.test.ts
@@ -22,6 +22,10 @@ interface WorkflowJob {
   }[];
   readonly strategy?: {
     readonly matrix?: {
+      readonly include?: readonly {
+        readonly hotQuerySamples?: number;
+        readonly os?: string;
+      }[];
       readonly scale?: readonly number[];
     };
   };
@@ -116,6 +120,12 @@ describe('platform benchmark workflow', () => {
       THREADNOTE_BENCHMARK_RUNNER_CLASS: 'github-hosted-${{ matrix.os }}-${{ runner.arch }}',
       THREADNOTE_BENCHMARK_RUNNER_ID: '${{ runner.name }}',
     });
+    expect(nativeJob.strategy?.matrix?.include).toEqual([
+      {hotQuerySamples: 25, os: 'ubuntu-latest'},
+      {hotQuerySamples: 25, os: 'macos-latest'},
+      {hotQuerySamples: 100, os: 'windows-latest'},
+    ]);
+    expect(nativeCapture?.run).toContain('--samples ${{ matrix.hotQuerySamples }}');
 
     for (const jobName of [
       'code-graph',

--- a/test/unit/code-graph-windows-hosted-tail-calibration.test.ts
+++ b/test/unit/code-graph-windows-hosted-tail-calibration.test.ts
@@ -5,6 +5,7 @@ import {enforceCodeGraphBenchmarkBudget} from '../../scripts/benchmark-code-grap
 import {
   BenchmarkEnvironmentSchemaV1,
   BenchmarkMeasurementSchemaV1,
+  benchmarkMeasurement,
   type BenchmarkArtifactV1,
 } from '../../src/evaluation/benchmark.js';
 
@@ -43,6 +44,11 @@ const budgetFile = Schema.decodeUnknownSync(
           hotQueryProcessCpuP95MillisecondsMaximum: PositiveFinite,
           oneFileIncrementalP95MillisecondsMaximum: PositiveFinite,
           wholeGraphAnalysisP95MillisecondsMaximum: PositiveFinite,
+        }),
+      }),
+      developmentPerformanceByRunnerClass: Schema.Struct({
+        'github-hosted-windows-x64': Schema.Struct({
+          hotQuerySamplesMinimum: Schema.Literal(100),
         }),
       }),
     }),
@@ -316,6 +322,62 @@ describe('hosted Windows native cold-tail calibration', () => {
     );
   });
 
+  it('requires 100 hot-query samples only on the matching hosted Windows runner class', () => {
+    const hosted = hostedCandidateArtifact(100);
+    expect(() => enforceCodeGraphBenchmarkBudget(hosted, budgetFile, undefined)).not.toThrow();
+    expect(() => enforceCodeGraphBenchmarkBudget(candidateArtifact(), budgetFile, undefined)).not.toThrow();
+    expect(() =>
+      enforceCodeGraphBenchmarkBudget(hostedCandidateArtifact(25, {architecture: 'arm64'}), budgetFile, undefined),
+    ).not.toThrow();
+    expect(budgetFailures(hostedCandidateArtifact(25, {runtimePlatform: 'linux'}), budgetFile)).not.toContain(
+      'hot-exact-lexical-query requires at least 100 samples for wall tolerance',
+    );
+    expect(() =>
+      enforceCodeGraphBenchmarkBudget(
+        hostedCandidateArtifact(25, {runnerClass: 'github-hosted-linux-x64'}),
+        budgetFile,
+        undefined,
+      ),
+    ).not.toThrow();
+
+    fc.assert(
+      fc.property(fc.integer({max: 99, min: 1}), samples => {
+        expect(() => enforceCodeGraphBenchmarkBudget(hostedCandidateArtifact(samples), budgetFile, undefined)).toThrow(
+          /requires at least 100 samples/u,
+        );
+      }),
+      {numRuns: 100},
+    );
+    fc.assert(
+      fc.property(fc.integer({max: 250, min: 100}), samples => {
+        expect(() =>
+          enforceCodeGraphBenchmarkBudget(hostedCandidateArtifact(samples), budgetFile, undefined),
+        ).not.toThrow();
+      }),
+      {numRuns: 100},
+    );
+  });
+
+  it('uses the production percentile at the four-versus-five guarded wall-tail boundary', () => {
+    const wallMaximum =
+      windowsBudget.hotQueryP95MillisecondsMaximum *
+      (1 + budgetFile.developmentPerformance.hotQueryWallP95ToleranceRatioMaximum);
+    const wallSamples = (breaches: 4 | 5) => [
+      ...Array.from({length: 95}, () => 500),
+      ...(breaches === 4 ? [wallMaximum] : []),
+      ...Array.from({length: breaches}, () => wallMaximum + 1),
+    ];
+    const withWall = (breaches: 4 | 5) =>
+      replaceMeasurement(hostedCandidateArtifact(100), 'hot-exact-lexical-query', () =>
+        benchmarkMeasurement('hot-exact-lexical-query', 'milliseconds', wallSamples(breaches)),
+      );
+
+    expect(() => enforceCodeGraphBenchmarkBudget(withWall(4), budgetFile, undefined)).not.toThrow();
+    expect(() => enforceCodeGraphBenchmarkBudget(withWall(5), budgetFile, undefined)).toThrow(
+      /hot-exact-lexical-query/u,
+    );
+  });
+
   it('keeps every unchanged independent budget strict above its boundary', () => {
     const unchangedGuards: readonly GuardMutation[] = [
       {
@@ -454,6 +516,27 @@ function candidateArtifact(
     ...calibration.candidateBudgetArtifact,
     measurements: calibration.candidateBudgetMeasurements,
     metadata: {...calibration.candidateBudgetArtifact.metadata, runtimePlatform},
+  };
+}
+
+function hostedCandidateArtifact(
+  samples: number,
+  overrides: {
+    readonly architecture?: string;
+    readonly runnerClass?: string;
+    readonly runtimePlatform?: string;
+  } = {},
+): BenchmarkArtifactV1 {
+  const artifact = candidateArtifact(overrides.runtimePlatform);
+  return {
+    ...artifact,
+    environment: {...artifact.environment, architecture: overrides.architecture ?? artifact.environment.architecture},
+    measurements: artifact.measurements.map(measurement =>
+      measurement.name === 'hot-exact-lexical-query' || measurement.name === 'hot-query-process-cpu'
+        ? {...measurement, samples}
+        : measurement,
+    ),
+    metadata: {...artifact.metadata, runnerClass: overrides.runnerClass ?? 'github-hosted-windows-x64'},
   };
 }
 

--- a/test/unit/code-graph-windows-native-quantile-calibration.test.ts
+++ b/test/unit/code-graph-windows-native-quantile-calibration.test.ts
@@ -1,0 +1,269 @@
+import {Schema} from 'effect';
+import {describe, expect, it} from 'vitest';
+
+import {benchmarkMeasurement} from '../../src/evaluation/benchmark.js';
+
+const PositiveFinite = Schema.Finite.check(Schema.isGreaterThan(0));
+const NonNegativeFinite = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0));
+const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0));
+const GitObject = Schema.String.check(Schema.isPattern(/^[0-9a-f]{40}$/u));
+const Sha256 = Schema.String.check(Schema.isPattern(/^[0-9a-f]{64}$/u));
+const ArchiveDigest = Schema.String.check(Schema.isPattern(/^sha256:[0-9a-f]{64}$/u));
+const IsoInstant = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u));
+const RunnerIdentity = Schema.String.check(Schema.isPattern(/^runner-[0-9a-f]{16}$/u));
+
+const Measurements = Schema.Struct({
+  hotQueryMaximumMilliseconds: PositiveFinite,
+  hotQueryP50Milliseconds: PositiveFinite,
+  hotQueryP95Milliseconds: PositiveFinite,
+  hotQueryProcessCpuMaximumMilliseconds: PositiveFinite,
+  hotQueryProcessCpuP50Milliseconds: PositiveFinite,
+  hotQueryProcessCpuP95Milliseconds: PositiveFinite,
+  samples: PositiveInteger,
+});
+
+const CandidateFailure = Schema.Struct({
+  archiveDigest: ArchiveDigest,
+  artifactId: PositiveInteger,
+  conclusion: Schema.Literal('failure'),
+  createdAt: IsoInstant,
+  cpu: Schema.String,
+  headSha: GitObject,
+  jobId: PositiveInteger,
+  measurements: Measurements,
+  rawJsonSha256: Sha256,
+  runId: PositiveInteger,
+  runnerIdentity: RunnerIdentity,
+  sourceTreeSha: GitObject,
+});
+
+const HostedControl = Schema.Struct({
+  archiveDigest: ArchiveDigest,
+  artifactId: PositiveInteger,
+  conclusion: Schema.Literal('success'),
+  createdAt: IsoInstant,
+  cpu: Schema.String,
+  headSha: GitObject,
+  jobId: PositiveInteger,
+  measurements: Measurements,
+  rawJsonSha256: Sha256,
+  role: Schema.Union([Schema.Literal('identical-tree-control'), Schema.Literal('recent-hosted-control')]),
+  runId: PositiveInteger,
+  runnerIdentity: RunnerIdentity,
+  sourceTreeSha: GitObject,
+});
+
+const Summary = Schema.Struct({
+  maximum: PositiveFinite,
+  minimum: PositiveFinite,
+  upperMiddle: PositiveFinite,
+});
+
+const calibration = Schema.decodeUnknownSync(
+  Schema.fromJsonString(
+    Schema.Struct({
+      adjacentHundredSampleMethodControl: Schema.Struct({
+        archiveDigest: ArchiveDigest,
+        artifactId: PositiveInteger,
+        conclusion: Schema.Literal('success'),
+        createdAt: IsoInstant,
+        fixtureHash: Schema.Literal('generated-code-graph-v1:10000'),
+        headSha: GitObject,
+        jobId: PositiveInteger,
+        measurements: Measurements,
+        rawJsonSha256: Sha256,
+        runId: PositiveInteger,
+        scope: Schema.Literal('method-control-only-different-10k-fixture-and-runner'),
+        sourceTreeSha: GitObject,
+      }),
+      candidateFailure: CandidateFailure,
+      createdAt: IsoInstant,
+      fixture: Schema.Struct({
+        architecture: Schema.Literal('x64'),
+        fixtureHash: Schema.Literal('c4c45a6bcc25517df1fdae711f19f4989e13fde6b4763d596d547c6757230e7d'),
+        operatingSystem: Schema.Literal('Windows 10.0.26100'),
+        runnerClass: Schema.Literal('github-hosted-windows-x64'),
+        runtime: Schema.Literal('bun/1.3.14'),
+        runtimePlatform: Schema.Literal('win32'),
+      }),
+      governedInputs: Schema.Struct({
+        additionalToleranceRatio: NonNegativeFinite,
+        hotQueryP50MillisecondsMaximum: PositiveFinite,
+        hotQueryP95MillisecondsMaximum: PositiveFinite,
+        hotQueryProcessCpuP95MillisecondsMaximum: PositiveFinite,
+        hotQueryWallP95ToleranceRatioMaximum: NonNegativeFinite,
+        previousP95ExcludedUpperOrderStatistics: PositiveInteger,
+        previousSamples: PositiveInteger,
+        productionPercentileQuantile: PositiveFinite,
+        prospectiveP95ExcludedUpperOrderStatistics: PositiveInteger,
+        prospectiveSamples: PositiveInteger,
+      }),
+      observationOrder: Schema.Literal('reverse-chronological within recentHostedControls'),
+      recentHostedControls: Schema.Array(HostedControl),
+      recentHostedSummary: Schema.Struct({
+        hotQueryP50Milliseconds: Summary,
+        hotQueryP95Milliseconds: Summary,
+        hotQueryProcessCpuP95Milliseconds: Summary,
+        observationCount: PositiveInteger,
+      }),
+      releaseRequirement: Schema.Struct({
+        prospectiveNativeHostedObservationRequired: Schema.Literal(true),
+        thresholdsChanged: Schema.Literal(false),
+      }),
+      type: Schema.Literal('threadnote-windows-native-hosted-query-quantile-calibration'),
+      version: Schema.Literal(1),
+    }),
+  ),
+)(
+  await Bun.file(
+    'test/evaluation/baselines/code-graph-v1/windows-native-hosted-query-quantile-calibration-v1.json',
+  ).text(),
+);
+
+const budget = Schema.decodeUnknownSync(
+  Schema.fromJsonString(
+    Schema.Struct({
+      developmentPerformance: Schema.Struct({
+        hotQuerySamplesMinimum: PositiveInteger,
+        hotQueryWallP95ToleranceRatioMaximum: NonNegativeFinite,
+      }),
+      developmentPerformanceByPlatform: Schema.Struct({
+        win32: Schema.Struct({
+          hotQueryP50MillisecondsMaximum: PositiveFinite,
+          hotQueryP95MillisecondsMaximum: PositiveFinite,
+          hotQueryProcessCpuP95MillisecondsMaximum: PositiveFinite,
+        }),
+      }),
+      developmentPerformanceByRunnerClass: Schema.Struct({
+        'github-hosted-windows-x64': Schema.Struct({hotQuerySamplesMinimum: PositiveInteger}),
+      }),
+    }),
+  ),
+)(await Bun.file('test/evaluation/baselines/code-graph-v1/budgets.json').text());
+
+describe('hosted Windows native query quantile calibration', () => {
+  it('binds the failure to unique retained artifacts and an identical-tree passing control', () => {
+    const candidate = calibration.candidateFailure;
+    const controls = calibration.recentHostedControls;
+    const identicalTreeControl = required(controls.find(control => control.role === 'identical-tree-control'));
+    const allNative = [candidate, ...controls];
+
+    expect(controls).toHaveLength(calibration.recentHostedSummary.observationCount);
+    expect(new Set(allNative.map(observation => observation.runId)).size).toBe(allNative.length);
+    expect(new Set(allNative.map(observation => observation.jobId)).size).toBe(allNative.length);
+    expect(new Set(allNative.map(observation => observation.artifactId)).size).toBe(allNative.length);
+    expect(new Set(allNative.map(observation => observation.archiveDigest)).size).toBe(allNative.length);
+    expect(new Set(allNative.map(observation => observation.rawJsonSha256)).size).toBe(allNative.length);
+    expect(candidate.headSha).toBe('1ce43969b08a772cb19e712eb71d7d34c38b7b66');
+    expect(identicalTreeControl.headSha).toBe('a4969ac636e905ea4cb6f03529ff2a132c5d5eb5');
+    expect(candidate.sourceTreeSha).toBe(identicalTreeControl.sourceTreeSha);
+    expect(candidate.measurements.hotQueryP50Milliseconds).toBeGreaterThan(
+      calibration.governedInputs.hotQueryP50MillisecondsMaximum,
+    );
+    expect(identicalTreeControl.measurements.hotQueryP50Milliseconds).toBeLessThan(
+      calibration.governedInputs.hotQueryP50MillisecondsMaximum,
+    );
+  });
+
+  it('rederives recent hosted distributions and preserves the independent CPU diagnosis', () => {
+    const controls = calibration.recentHostedControls;
+    const governed = calibration.governedInputs;
+    const guardedWallP95Maximum =
+      governed.hotQueryP95MillisecondsMaximum * (1 + governed.hotQueryWallP95ToleranceRatioMaximum);
+
+    expect(summary(controls.map(control => control.measurements.hotQueryP50Milliseconds))).toEqual(
+      calibration.recentHostedSummary.hotQueryP50Milliseconds,
+    );
+    expect(summary(controls.map(control => control.measurements.hotQueryP95Milliseconds))).toEqual(
+      calibration.recentHostedSummary.hotQueryP95Milliseconds,
+    );
+    expect(summary(controls.map(control => control.measurements.hotQueryProcessCpuP95Milliseconds))).toEqual(
+      calibration.recentHostedSummary.hotQueryProcessCpuP95Milliseconds,
+    );
+    expect(
+      controls.every(
+        control => control.measurements.hotQueryP50Milliseconds <= governed.hotQueryP50MillisecondsMaximum,
+      ),
+    ).toBe(true);
+    expect(controls.every(control => control.measurements.hotQueryP95Milliseconds <= guardedWallP95Maximum)).toBe(true);
+    expect(
+      controls.every(
+        control =>
+          control.measurements.hotQueryProcessCpuP95Milliseconds <= governed.hotQueryProcessCpuP95MillisecondsMaximum,
+      ),
+    ).toBe(true);
+    expect(calibration.candidateFailure.measurements.hotQueryP95Milliseconds).toBeGreaterThan(guardedWallP95Maximum);
+    expect(calibration.candidateFailure.measurements.hotQueryProcessCpuP95Milliseconds).toBeLessThan(
+      governed.hotQueryProcessCpuP95MillisecondsMaximum,
+    );
+  });
+
+  it('increases only hosted Windows quantile resolution and requires prospective native evidence', () => {
+    const governed = calibration.governedInputs;
+    const hostedWindows = budget.developmentPerformanceByRunnerClass['github-hosted-windows-x64'];
+    const win32 = budget.developmentPerformanceByPlatform.win32;
+
+    expect(governed.previousSamples).toBe(budget.developmentPerformance.hotQuerySamplesMinimum);
+    expect(governed.prospectiveSamples).toBe(hostedWindows.hotQuerySamplesMinimum);
+    expect(governed.hotQueryP50MillisecondsMaximum).toBe(win32.hotQueryP50MillisecondsMaximum);
+    expect(governed.hotQueryP95MillisecondsMaximum).toBe(win32.hotQueryP95MillisecondsMaximum);
+    expect(governed.hotQueryProcessCpuP95MillisecondsMaximum).toBe(win32.hotQueryProcessCpuP95MillisecondsMaximum);
+    expect(governed.hotQueryWallP95ToleranceRatioMaximum).toBe(
+      budget.developmentPerformance.hotQueryWallP95ToleranceRatioMaximum,
+    );
+    expect(governed.additionalToleranceRatio).toBe(0);
+    expect(excludedUpperOrderStatistics(governed.previousSamples, governed.productionPercentileQuantile)).toBe(
+      governed.previousP95ExcludedUpperOrderStatistics,
+    );
+    expect(excludedUpperOrderStatistics(governed.prospectiveSamples, governed.productionPercentileQuantile)).toBe(
+      governed.prospectiveP95ExcludedUpperOrderStatistics,
+    );
+
+    const guardedWallP95Maximum =
+      governed.hotQueryP95MillisecondsMaximum * (1 + governed.hotQueryWallP95ToleranceRatioMaximum);
+    const wallSamples = (breaches: 4 | 5) => [
+      ...Array.from({length: 95}, () => 500),
+      ...(breaches === 4 ? [guardedWallP95Maximum] : []),
+      ...Array.from({length: breaches}, () => guardedWallP95Maximum + 1),
+    ];
+    expect(benchmarkMeasurement('hot-exact-lexical-query', 'milliseconds', wallSamples(4)).p95).toBe(
+      guardedWallP95Maximum,
+    );
+    expect(benchmarkMeasurement('hot-exact-lexical-query', 'milliseconds', wallSamples(5)).p95).toBe(
+      guardedWallP95Maximum + 1,
+    );
+
+    const methodControl = calibration.adjacentHundredSampleMethodControl;
+    expect(methodControl.headSha).toBe(calibration.candidateFailure.headSha);
+    expect(methodControl.sourceTreeSha).toBe(calibration.candidateFailure.sourceTreeSha);
+    expect(methodControl.fixtureHash).not.toBe(calibration.fixture.fixtureHash);
+    expect(methodControl.measurements.samples).toBe(governed.prospectiveSamples);
+    expect(methodControl.measurements.hotQueryP50Milliseconds).toBeLessThan(governed.hotQueryP50MillisecondsMaximum);
+    expect(methodControl.measurements.hotQueryP95Milliseconds).toBeLessThan(guardedWallP95Maximum);
+    expect(methodControl.measurements.hotQueryProcessCpuP95Milliseconds).toBeLessThan(
+      governed.hotQueryProcessCpuP95MillisecondsMaximum,
+    );
+    expect(calibration.releaseRequirement).toEqual({
+      prospectiveNativeHostedObservationRequired: true,
+      thresholdsChanged: false,
+    });
+  });
+});
+
+function summary(values: readonly number[]) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    maximum: required(sorted.at(-1)),
+    minimum: required(sorted[0]),
+    upperMiddle: required(sorted[Math.floor(sorted.length / 2)]),
+  };
+}
+
+function excludedUpperOrderStatistics(samples: number, quantile: number): number {
+  return samples - (Math.floor(samples * quantile) + 1);
+}
+
+function required<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error('Windows native query calibration value is missing.');
+  return value;
+}


### PR DESCRIPTION
## Summary

- raise only the GitHub-hosted Windows x64 native hot-query sample count from 25 to 100
- enforce that runner-scoped evidence minimum without changing p50, p95, CPU, quality, work, or tolerance thresholds
- retain the failed exact-candidate artifact, six normalized hosted controls, an identical-tree passing control, and the adjacent 100-sample method control
- add regression, property, workflow, provenance, and quantile-boundary coverage

## Diagnosis

Exact candidate run 33460824382 failed the 25-sample native Windows wall gate while process CPU and all deterministic guards remained green. Its immediate predecessor had the identical Git tree and passed; recent hosted observations show the second-highest sample can dominate the 25-sample p95. At 100 samples the production percentile excludes four upper observations, while a fifth breach still fails. The existing strict median and CPU guards continue to reject sustained or computational regressions.

No local benchmark was run because another Threadnote task is actively chaos-testing the shared development runtime. This PR requires a prospective hosted Windows 100-sample pass before merge.

## Validation

- focused Vitest: 4 files, 64 tests passed
- typecheck passed
- lint passed
- Prettier passed
- diff check passed
- dev-cycle full review: zero findings

Property testing covers the runner-scoped 1..99 rejection and 100..250 admission invariant. The retained static calibration test independently rederives the hosted distributions and four-versus-five tail boundary.