### PR TITLE
docs: add Cursor Cloud organization bootstrap

### DIFF
--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -2267,70 +2267,99 @@ Measure the system before changing its implementation language.
     expect(content).not.toContain('Cursor, and Copilot rely on the user-level instructions Threadnote installs');
   });
 
-  it('documents Cursor Cloud Agents with an exclusive writable shared-memory contract', () => {
+  it('documents the Cursor organization remote-hybrid bootstrap contract', () => {
     const article = docsSections
       .flatMap(section => section.articles)
       .find(candidate => candidate.id === 'cursor-cloud-agents');
     const content = JSON.stringify(article);
     const mcpConfiguration = article?.body.find(
-      block => block.type === 'code' && block.language === 'json' && block.code.includes('THREADNOTE_MCP_TOOLSET'),
+      block => block.type === 'code' && block.language === 'json' && block.code.includes('"threadnote-local"'),
+    );
+    const provisioning = article?.body.find(
+      block => block.type === 'code' && block.language === 'json' && block.code.includes('"tenantId"'),
     );
     const recallPayload = article?.body.find(
-      block => block.type === 'code' && block.language === 'json' && block.code.includes('callerCwd'),
+      block => block.type === 'code' && block.language === 'json' && block.code.includes('"query"'),
     );
     const cloudVerification = article?.body.find(
       block => block.type === 'code' && block.language === 'sh' && block.code.includes('cloud cursor verify'),
     );
 
     expect(article).toBeDefined();
-    expect(article?.title).toBe('Use Threadnote with Cursor Cloud Agents');
-    expect(content).toContain('Available in [Threadnote 4.2]');
-    expect(content).toContain('The managed first-class integration is still in development');
-    expect(content).toContain('Beyond 4.2: what the full integration will add');
-    expect(content).toContain('writable Git-backed share for durable memory');
-    expect(content).toContain('--team cursor-cloud');
+    expect(article?.title).toBe('Bootstrap Threadnote for a Cursor organization');
+    expect(content).toContain('deployable reference implementation, not a hosted Threadnote GA service');
+    expect(content).toContain('two explicit MCP planes');
+    expect(content).toContain('Threadnote service operator');
+    expect(content).toContain('Identity administrator');
+    expect(content).toContain('Cursor team admin');
+    expect(content).toContain('THREADNOTE_REMOTE_ENABLED=false');
+    expect(content).toContain('THREADNOTE_REMOTE_AUTO_MIGRATE=false');
+    expect(content).toContain('NOSUPERUSER NOBYPASSRLS');
+    expect(content).toContain('remote-memory-operator provision');
+    expect(content).toContain('memory:write:durable');
+    expect(content).toContain('cursor_oidc_required');
+    expect(content).toContain('https://api.cursor.com/keys');
+    expect(content).toContain('complete `repo_urls`/`repo_count` set');
+    expect(content).toContain('--mode remote-hybrid');
+    expect(content).toContain('--share-id sh_acme_engineering');
     expect(content).toContain('cloud cursor bootstrap');
     expect(content).toContain('cloud cursor verify');
-    expect(content).toContain('threadnote://user/cursor-cloud/memories/shared/cursor-cloud/');
+    expect(content).toContain('Dashboard → Integrations & MCP');
+    expect(content).toContain('OAuth is per-user');
+    expect(content).toContain('threadnote-share-id');
+    expect(content).toContain('checked-in `.cursor/environment.json`, personal saved environment, then team saved');
+    expect(content).toContain('begin_cursor_attestation');
+    expect(content).toContain('complete_cursor_attestation');
+    expect(content).toContain('unique operationId');
+    expect(content).toContain('There is no personal-memory, Git-share, or alternate-share fallback');
     expect(content).toContain('Do not run `threadnote mcp-install cursor --apply`');
-    expect(content).toContain('remember_context kind=durable');
-    expect(content).toContain('kind=handoff');
-    expect(content).toContain('commits and pushes');
-    expect(content).toContain('capability-enforced cloud profile');
-    expect(content).toContain('stable `threadnote-mcp-server` launcher brokers');
-    expect(content).toContain('MCP registration scope and cloud-VM provisioning are independent');
-    expect(content).toContain('checked-in `.cursor/environment.json`, a personal saved environment, then a team saved');
-    expect(content).toContain('complete override rather than an overlay');
-    expect(content).toContain('CLI `&` handoff has no documented environment or Build selector');
-    expect(content).toContain('adds user secrets only when an agent starts');
-    expect(content).toContain("personal environment's idempotent `install` command");
-    expect(content).toContain('changes made in an ordinary agent VM do not prepare later Builds');
-    expect(content).toContain('make that latest successful Build active before starting agents');
-    expect(content).toContain('add and enable it as a personal MCP server');
-    expect(content).toContain('Registration does not install the stdio executable in the cloud VM');
+    expect(content).toContain('Import never deletes the source, never dual-writes');
 
     if (!mcpConfiguration || mcpConfiguration.type !== 'code') {
       throw new TestError('Missing Cursor Cloud MCP configuration.');
     }
-    expect(JSON.parse(mcpConfiguration.code)).toMatchObject({
-      args: ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'],
-      command: '/bin/sh',
-      env: {
-        THREADNOTE_ACCOUNT: 'local',
-        THREADNOTE_AGENT_ID: 'cursor-cloud',
-        THREADNOTE_CURSOR_CLOUD_TEAM: 'cursor-cloud',
-        THREADNOTE_MCP_TOOLSET: 'cursor-cloud',
-        THREADNOTE_USER: 'cursor-cloud',
+    const parsedMcpConfiguration = JSON.parse(mcpConfiguration.code);
+    expect(parsedMcpConfiguration).toEqual({
+      mcpServers: {
+        'threadnote-local': {
+          type: 'stdio',
+          command: '/bin/sh',
+          args: ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'],
+          env: {
+            THREADNOTE_ACCOUNT: 'local',
+            THREADNOTE_AGENT_ID: 'cursor-cloud',
+            THREADNOTE_CURSOR_MEMORY_ENDPOINT: 'https://memory.example.com/mcp',
+            THREADNOTE_CURSOR_MEMORY_SHARE_ID: 'sh_acme_engineering',
+            THREADNOTE_MCP_TOOLSET: 'cursor-cloud-local',
+            THREADNOTE_USER: 'cursor-cloud',
+          },
+        },
+        'threadnote-memory': {
+          url: 'https://memory.example.com/mcp',
+          headers: {'threadnote-share-id': 'sh_acme_engineering'},
+        },
       },
-      type: 'stdio',
+    });
+    expect(JSON.stringify(parsedMcpConfiguration)).not.toMatch(/authorization|bearer|token|secret/i);
+
+    if (!provisioning || provisioning.type !== 'code') {
+      throw new TestError('Missing remote-memory provisioning document.');
+    }
+    expect(JSON.parse(provisioning.code)).toMatchObject({
+      tenantId: 'tenant-acme',
+      shareId: 'sh_acme_engineering',
+      cursorAttestationRequired: true,
+      cursorTeamId: '6789',
+      repositoryBindings: {platform: ['https://github.com/acme/platform']},
     });
 
     if (!recallPayload || recallPayload.type !== 'code') {
-      throw new TestError('Missing Cursor Cloud scoped recall payload.');
+      throw new TestError('Missing remote-memory recall payload.');
     }
-    expect(JSON.parse(recallPayload.code)).toMatchObject({
-      callerCwd: '/workspace/your-repository',
-      project: 'your-project',
+    expect(JSON.parse(recallPayload.code)).toEqual({
+      version: 1,
+      query: 'the task or decision to recover',
+      project: 'platform',
     });
 
     if (!cloudVerification || cloudVerification.type !== 'code') {
@@ -2344,9 +2373,11 @@ Measure the system before changing its implementation language.
     expect(cloudVerification.code.indexOf('test -d "$HOME/.threadnote"')).toBeLessThan(
       cloudVerification.code.indexOf('cloud cursor verify'),
     );
-    expect(searchDocs(createDocsSearchIndex(docsSections), 'Cursor Cloud Agents shared memory')[0]?.article.id).toBe(
-      'cursor-cloud-agents',
-    );
+    expect(cloudVerification.code).toContain('--mode remote-hybrid');
+    expect(cloudVerification.code).toContain('--share-id sh_acme_engineering');
+    expect(
+      searchDocs(createDocsSearchIndex(docsSections), 'Cursor organization managed remote memory')[0]?.article.id,
+    ).toBe('cursor-cloud-agents');
   });
 
   it('uses the real Manager labels and share status fields in the mock data', () => {

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -491,7 +491,7 @@ threadnote doctor`,
           },
           {
             type: 'note',
-            text: 'Threadnote 4.2 includes a beta Cursor Cloud Agents profile using Dashboard-owned MCP configuration and one exclusive writable memory share. See [Use Threadnote with Cursor Cloud Agents](cursor-cloud-agents/).',
+            text: 'Threadnote supports a Cursor Cloud remote-hybrid profile with local checkout evidence and an explicitly bound organization-operated remote memory share. The legacy 4.2 Git-backed beta remains separate. See [Bootstrap Threadnote for a Cursor organization](cursor-cloud-agents/).',
           },
         ],
       },

--- a/website/src/content/docsCursorCloud.ts
+++ b/website/src/content/docsCursorCloud.ts
@@ -3,124 +3,239 @@ import type {DocsSection} from './docsTypes.js';
 export const cursorCloudDocsSection: DocsSection = {
   id: 'cloud-agents',
   title: 'Cloud agents',
-  description: 'Run Threadnote in disposable cloud environments without treating VM-local memory as durable.',
+  description: 'Give disposable cloud environments local code evidence and an explicitly scoped durable memory plane.',
   articles: [
     {
       id: 'cursor-cloud-agents',
-      title: 'Use Threadnote with Cursor Cloud Agents',
+      title: 'Bootstrap Threadnote for a Cursor organization',
       summary:
-        'Use the Threadnote 4.2 beta profile inside each Cursor cloud VM while one writable Git share remains its durable memory plane.',
+        'Deploy the managed-memory reference service, provision one authorized share, and register the local and remote MCP planes for Cursor Cloud Agents.',
       keywords: [
-        'Threadnote 4.2',
+        'Cursor organization',
         'Cursor Cloud Agents',
-        'Cursor cloud MCP',
-        'cloud agent memory',
-        'ephemeral agent memory',
-        'writable shared memory',
-        'Git memory share',
-        'stdio MCP',
+        'Cursor team MCP',
+        'managed remote memory',
+        'remote-hybrid MCP',
+        'Cursor OIDC',
+        'OAuth MCP',
+        'PostgreSQL memory service',
+        'organization bootstrap',
       ],
       body: [
         {
-          type: 'note',
-          text: 'Available in [Threadnote 4.2](https://github.com/Kashkovsky/threadnote/releases/tag/v4.2.0) as a beta integration. The released capability-enforced cloud profile uses a local stdio MCP server, an idempotent bootstrap command, and one writable Git-backed memory share. Durable memories are committed and pushed; local handoffs remain transient.',
-        },
-        {
           type: 'warning',
-          text: 'The managed first-class integration is still in development. Threadnote 4.2 does not yet include managed remote memory, provider-backed workload authorization, durable cross-session handoffs, or the complete cloud canary program.',
-        },
-        {
-          type: 'paragraph',
-          text: 'The released 4.2 profile runs beside the checked-out repository in each isolated Cursor Cloud Ubuntu VM. It uses custom stdio MCP for current-source graph work and scopes historical context to the configured share. Do not rely on ~/.threadnote memories being available to a later run: use the designated writable Git-backed share for durable memory, and treat local handoffs as workspace-local coordination.',
+          text: 'Managed remote memory is a deployable reference implementation, not a hosted Threadnote GA service. Your organization must operate the HTTPS service, PostgreSQL, OAuth integration, keys, backups, monitoring, security review, and live Cursor canaries. Do not advertise availability beyond the regions, recovery policy, and support path your operators have actually approved.',
         },
         {
           type: 'note',
-          text: 'This guide uses the shared team name `cursor-cloud` and the stable Threadnote user `cursor-cloud`. Together they make the exclusive memory root `threadnote://user/cursor-cloud/memories/shared/cursor-cloud/` predictable in every VM.',
+          text: 'The current remote-hybrid integration replaces the old one-server design with two explicit MCP planes: `threadnote-local` runs over stdio in the Cursor VM for checkout-specific code evidence and workload attestation, while `threadnote-memory` uses Streamable HTTP for durable memories and handoffs. The remote share is the only persistent memory source. There is no personal-memory, Git-share, or alternate-share fallback.',
         },
-        {type: 'heading', text: 'Choose the environment scope'},
+        {type: 'heading', text: 'Architecture and ownership'},
+        {
+          type: 'table',
+          headers: ['Owner', 'Bootstrap responsibility'],
+          rows: [
+            [
+              'Threadnote service operator',
+              'Deploy TLS, PostgreSQL, migrations, least-privilege runtime grants, workers, backups, health checks, and canaries.',
+            ],
+            [
+              'Identity administrator',
+              'Configure the OAuth issuer, exact MCP audience and scopes, JWKS rotation, revocation, and principal mapping.',
+            ],
+            [
+              'Cursor team admin',
+              'Create the team environment and active Build, register both shared MCP servers, and control who can enable them.',
+            ],
+            [
+              'Repository owner',
+              'Approve the project catalog, complete repository binding set, cloud-only agent instructions, and rollout canaries.',
+            ],
+          ],
+        },
         {
           type: 'paragraph',
-          text: 'MCP registration scope and cloud-VM provisioning are independent. A personal MCP registration controls who can enable the server, but Threadnote 4.2 uses stdio, so `$HOME/.local/bin/threadnote-mcp-server` and the bootstrapped `$HOME/.threadnote` state must already exist inside the selected cloud environment. A local `threadnote: ready` result does not verify either path in a cloud VM.',
+          text: 'Use one opaque share ID for the complete path from provisioning to Dashboard configuration. The service authorizes that share from the OAuth grant and requires the same `threadnote-share-id` header; the model never chooses a tenant or share. Decide the tenant ID, share ID, region, projects, exact repository set, Cursor team ID, allowed owners or service accounts, OAuth subjects, capabilities, retention policy, and incident owner before changing Cursor.',
         },
-        {
-          type: 'paragraph',
-          text: 'Cursor resolves an environment for a repository or repository group in this order: checked-in `.cursor/environment.json`, a personal saved environment, then a team saved environment. To add Threadnote for one user without changing the team environment, create a personal saved environment for the same repository or repository group. Treat it as a complete override rather than an overlay: preserve the project toolchain and setup from the team environment, then add Threadnote. A checked-in `.cursor/environment.json` still wins. See [Cursor Cloud Environment Setup](https://cursor.com/docs/cloud-agent/setup) for the current resolution contract.',
-        },
-        {
-          type: 'note',
-          text: 'Cursor CLI `&` handoff has no documented environment or Build selector. It uses the authenticated user and repository to resolve the environment automatically. For explicit testing, start an agent from a specific Build in the Cloud Agents Dashboard; the [Cloud Agents API](https://cursor.com/docs/cloud-agent/api/endpoints) can create a new agent in a named environment, but that does not continue the existing CLI conversation. See [Cursor CLI handoff](https://cursor.com/docs/cli/using) for the documented handoff surface.',
-        },
-        {type: 'heading', text: 'Before you start'},
+        {type: 'heading', text: 'Prerequisites'},
         {
           type: 'list',
           items: [
-            'Create a dedicated Git repository for durable Threadnote memories. You can seed it from a trusted, persistent Threadnote installation using the [team sharing workflow](sharing-setup/).',
-            'Give the cloud environment narrowly scoped read/write Git credentials for that repository. Keep tokens and private keys in Cursor environment settings or the Git provider; never place them in the repository, MCP JSON, remote URL, or agent instructions.',
-            "Use Cursor environment Builds for installation state. Put Threadnote installation and share bootstrap in the personal environment's idempotent `install` command. Both must write below the same `$HOME` that the stdio MCP uses; print it during the Build and first agent run to verify the boundary. Saved Builds persist disk state rather than running processes.",
-            'Add the cloud-only instruction block below to the repository guidance read by your agents, such as AGENTS.md. Repository files remain authoritative.',
+            'A Cursor team with Cloud Agents enabled, connected source control, a team admin who can manage Dashboard → Integrations & MCP, and a saved environment for the intended repository or repository group.',
+            'A production HTTPS origin such as `https://memory.example.com`; the MCP URL must be exactly `/mcp`, credential-free, and have no query or fragment.',
+            'A standards-compatible OAuth authorization server and JWKS. Its access tokens must use the exact public MCP URL as audience and grant only the Threadnote scopes the member needs.',
+            'Managed PostgreSQL in one approved region, with distinct bootstrap, migrator/operator, and runtime identities; encrypted backups and a rehearsed restore path.',
+            'A secret manager, private database networking, signed and scanned service images, restricted operator access, privacy-safe monitoring, and an explicit kill-switch owner.',
+            'Outbound access from the local Cloud Agent adapter to the Threadnote HTTPS origin for attestation completion. If egress is restricted, allow the Threadnote origin and the identity endpoints required by your OAuth flow.',
           ],
         },
-        {type: 'heading', text: '1. Install or update to Threadnote 4.2'},
+        {type: 'heading', text: '1. Deploy the remote-memory service'},
         {
           type: 'paragraph',
-          text: 'For an existing standalone installation, upgrade on the stable channel and confirm that the active release is 4.2:',
+          text: 'Start from the repository reference deployment in `deploy/remote-memory`, but treat Docker Compose as a loopback development example only. Production needs managed TLS at the edge and to PostgreSQL, network isolation, managed secrets, immutable images, regional backups, and supervised HTTP, indexer, and retention work. Follow the full [remote-memory operations runbook](https://github.com/Kashkovsky/threadnote/blob/main/docs/remote-memory/operations.md) and [threat model](https://github.com/Kashkovsky/threadnote/blob/main/docs/remote-memory/threat-model.md).',
         },
         {
           type: 'code',
           language: 'sh',
-          code: `threadnote update
-threadnote version`,
-        },
-        {
-          type: 'paragraph',
-          text: "For a fresh Cursor environment, add the latest standalone Linux release installation to the personal environment's idempotent `install` command. You can prototype it in Cursor's guided setup terminal, but changes made in an ordinary agent VM do not prepare later Builds. `--no-start` avoids a readiness message; Threadnote does not need a daemon.",
-        },
-        {
-          type: 'code',
-          language: 'sh',
-          code: `curl -fsSL https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.sh | \\
-  sh -s -- --no-start
+          code: `THREADNOTE_REMOTE_PUBLIC_URL=https://memory.example.com
+THREADNOTE_REMOTE_ENABLED=false
+THREADNOTE_REMOTE_ALLOWED_HOSTS=memory.example.com
+THREADNOTE_REMOTE_ALLOWED_ORIGINS=https://cursor.com
 
-printf 'Threadnote Build HOME=%s\\n' "$HOME"
-test -x "$HOME/.local/bin/threadnote-mcp-server"
-"$HOME/.local/bin/threadnote" doctor --dry-run`,
-        },
-        {type: 'heading', text: '2. Bootstrap the exclusive memory share'},
-        {
-          type: 'paragraph',
-          text: 'Set `THREADNOTE_MEMORY_SHARE_URL` in the Cursor environment to the credential-free Git remote URL. Keep authentication separate from the URL. The bootstrap command initializes a missing share, reuses an equivalent writable share, synchronizes it, and rejects conflicting remotes or access modes without mutation.',
-        },
-        {
-          type: 'code',
-          language: 'sh',
-          code: `"$HOME/.local/bin/threadnote" cloud cursor bootstrap \\
-  --remote "$THREADNOTE_MEMORY_SHARE_URL" \\
-  --team cursor-cloud \\
-  --user cursor-cloud \\
-  --agent-id cursor-cloud`,
-        },
-        {
-          type: 'paragraph',
-          text: 'Keep this bootstrap in the same personal-environment `install` command as the Threadnote installation. Trigger a Build, confirm it succeeds, and make that latest successful Build active before starting agents. It is safe to rerun the command in a later Build: exact configuration is reused, while a different remote or non-writable team fails closed for explicit review.',
+THREADNOTE_REMOTE_OAUTH_ISSUER=https://identity.example.com
+THREADNOTE_REMOTE_OAUTH_AUDIENCE=https://memory.example.com/mcp
+THREADNOTE_REMOTE_OAUTH_JWKS_URL=https://identity.example.com/.well-known/jwks.json
+
+THREADNOTE_REMOTE_CURSOR_ISSUER=https://api.cursor.com
+THREADNOTE_REMOTE_CURSOR_AUDIENCE=https://memory.example.com/attest/cursor
+THREADNOTE_REMOTE_CURSOR_JWKS_URL=https://api.cursor.com/keys
+
+THREADNOTE_REMOTE_AUTO_MIGRATE=false
+THREADNOTE_REMOTE_DATABASE_URL=postgresql://threadnote_remote_runtime:REDACTED@db.internal/threadnote_remote?sslmode=verify-full`,
         },
         {
           type: 'warning',
-          text: 'Cursor makes team and environment-scoped secrets available during Builds, but adds user secrets only when an agent starts. If bootstrap needs Git credentials during the Build, use supported source-control access or a narrowly scoped environment secret. Keep the remote URL credential-free and never capture a token in the Build snapshot. See [Cloud Agent Builds](https://cursor.com/docs/cloud-agent/builds) for the current secret boundary.',
+          text: 'Keep `THREADNOTE_REMOTE_ENABLED=false` during initial deployment. Never inject the PostgreSQL bootstrap superuser or migrator URL into the HTTP service, workers, canary, Cursor, or repository. The runtime role must be `NOSUPERUSER NOBYPASSRLS`, must not own tables, and must not have DDL or control-plane mutation privileges.',
         },
-        {
-          type: 'note',
-          text: 'The cloud profile writes only durable memories to this share. Each successful durable `remember_context` call updates canonical storage, commits the matching Git path, and pushes it. A `kind=handoff` write stays local and may disappear with the cloud workspace.',
-        },
-        {type: 'heading', text: '3. Register Threadnote as a cloud MCP server'},
         {
           type: 'paragraph',
-          text: 'Generate the Cursor-ready configuration below. For one user, add and enable it as a personal MCP server from the MCP dropdown at `cursor.com/agents`. Team admins can instead add a shared server under Dashboard → Integrations & MCP. Both scopes run the same stdio command inside the selected VM:',
+          text: 'Run migrations once with the migrator/operator identity, then apply `deploy/remote-memory/grants/001-runtime.sql` as a separate reviewed job. The runtime deliberately refuses automatic migration. A changed checksum for an applied migration or a schema change missing from the grant allowlist is a release blocker.',
         },
         {
           type: 'code',
           language: 'sh',
-          code: `"$HOME/.local/bin/threadnote" cloud cursor config \\
-  --team cursor-cloud \\
+          code: `THREADNOTE_REMOTE_DATABASE_URL="$THREADNOTE_REMOTE_MIGRATOR_DATABASE_URL" \\
+  bun src/standalone.ts remote-memory-operator migrate
+
+# Run this with the migrator identity in your one-shot database job.
+psql --set=ON_ERROR_STOP=1 \\
+  --file=deploy/remote-memory/grants/001-runtime.sql`,
+        },
+        {
+          type: 'paragraph',
+          text: 'Before client traffic, require `/healthz` for process liveness and `/readyz` for constant-time worker readiness. Verify that the runtime role cannot bypass row-level security with a two-tenant negative test. Record the image digest, migration result, runtime-grant result, region, restore point, and rollback owner without recording connection strings, tokens, memory text, queries, URIs, or source paths.',
+        },
+        {type: 'heading', text: '2. Configure OAuth and Cursor workload identity'},
+        {
+          type: 'paragraph',
+          text: 'OAuth and Cursor OIDC have different jobs. Cursor-managed MCP OAuth authenticates each human or service principal to `threadnote-memory`; OAuth remains per-user even when the MCP server is shared at team level. The local adapter separately completes a short-lived, nonce-bound Cursor OIDC challenge before a protected write. That attestation attributes the Cloud Agent run but cannot widen the OAuth grant or share policy.',
+        },
+        {
+          type: 'list',
+          items: [
+            'Register `https://memory.example.com/mcp` as the only resource audience. Configure only `memory:read`, `memory:write:durable`, `memory:write:handoff`, or operator-only `memory:admin` scopes.',
+            'Map the OAuth issuer and immutable `sub` to one active Threadnote principal. Do not authorize by display name or email.',
+            'Trust Cursor workload tokens only from issuer `https://api.cursor.com`, JWKS `https://api.cursor.com/keys`, algorithm RS256, and exact audience `https://memory.example.com/attest/cursor`.',
+            'Pin `agent_runtime: managed`, the allowed default Cursor subject, team ID, owner user or service-account IDs, and the complete `repo_urls`/`repo_count` set. Do not treat the primary `repo_url` as proof of a single-repository workspace.',
+            'Keep bearer and raw Cursor OIDC tokens transient. Threadnote stores only the verified bounded claim subset and never returns the raw workload JWT.',
+            'Exercise JWKS rotation, revocation, wrong audience, wrong team, wrong owner, incomplete repository set, expired nonce, and clock-skew failures before enabling writes.',
+          ],
+        },
+        {
+          type: 'note',
+          text: 'Cursor documents the current token socket, claims, issuer, and five-minute token lifetime in [OIDC tokens](https://cursor.com/docs/cloud-agent/identity). The token identifies the whole VM run, not a trusted process inside it; scope the share grant to what the complete run may access.',
+        },
+        {type: 'heading', text: '3. Provision one organization share'},
+        {
+          type: 'paragraph',
+          text: 'Create one versioned provisioning document per OAuth principal. Keep it in an access-controlled operator workspace and delete it according to your normal change record. It must not contain an access token, client secret, database password, private key, or memory content.',
+        },
+        {
+          type: 'code',
+          language: 'json',
+          code: `{
+  "tenantId": "tenant-acme",
+  "shareId": "sh_acme_engineering",
+  "principalId": "principal-12345",
+  "issuer": "https://identity.example.com",
+  "subject": "opaque-oauth-subject",
+  "displayName": "Acme engineering memory",
+  "region": "eu-example-1",
+  "sharePolicyVersion": "share-v1",
+  "policyVersion": "grant-v1",
+  "projects": ["platform"],
+  "repositoryBindings": {
+    "platform": ["https://github.com/acme/platform"]
+  },
+  "allowedProjects": ["platform"],
+  "capabilities": [
+    "memory:read",
+    "memory:write:durable",
+    "memory:write:handoff"
+  ],
+  "cursorSubjects": ["user:12345"],
+  "cursorOwnerIds": ["12345"],
+  "cursorTeamId": "6789",
+  "cursorAttestationRequired": true,
+  "featureFlags": [
+    "remote_memory_read",
+    "remote_memory_durable_write",
+    "remote_memory_handoff_write",
+    "cursor_oidc_required",
+    "remote_memory_ga"
+  ]
+}`,
+        },
+        {
+          type: 'code',
+          language: 'sh',
+          code: `chmod 600 ./provision.v1.json
+THREADNOTE_REMOTE_DATABASE_URL="$THREADNOTE_REMOTE_MIGRATOR_DATABASE_URL" \\
+  bun src/standalone.ts remote-memory-operator provision \\
+  --input ./provision.v1.json`,
+        },
+        {
+          type: 'warning',
+          text: 'Provisioning is desired-state and versioned. A later share-wide change must provide a new `sharePolicyVersion`, the exact `expectedCurrentSharePolicyVersion`, and the complete projects, repository bindings, and feature flags. A member-grant change uses its own `policyVersion` and `expectedCurrentPolicyVersion`. Never add a member by replaying a stale document or by editing PostgreSQL directly.',
+        },
+        {
+          type: 'paragraph',
+          text: 'For a read-only first stage, grant only `memory:read` and enable only `remote_memory_read`, `cursor_oidc_required`, and `remote_memory_ga`. Add each write capability and its matching feature flag only after the protected read canary is healthy. Once the isolated share is provisioned and readiness is green, enable `THREADNOTE_REMOTE_ENABLED=true` for the intended environment; both the global switch and share-level `remote_memory_ga` gate must be on for MCP traffic.',
+        },
+        {type: 'heading', text: '4. Install the local adapter in the team environment'},
+        {
+          type: 'paragraph',
+          text: 'Create or update the saved team environment for the exact repository or repository group. Cursor resolves environments in this order: checked-in `.cursor/environment.json`, personal saved environment, then team saved environment. Audit the first two layers before rollout or they can legitimately override the organization default. See [Cloud Environment Setup](https://cursor.com/docs/cloud-agent/setup) and [Cloud Agent Builds](https://cursor.com/docs/cloud-agent/builds).',
+        },
+        {
+          type: 'paragraph',
+          text: 'Put the standalone installation and remote-hybrid bootstrap in the environment `install` command. The command must be idempotent because Cursor runs it for every Build and may reuse prepared disk. Builds preserve disk state, not running processes or shell exports. The endpoint and share ID are identifiers rather than bearer credentials; keep all actual credentials in Cursor or the identity provider.',
+        },
+        {
+          type: 'code',
+          language: 'sh',
+          code: `set -eu
+
+curl -fsSL https://raw.githubusercontent.com/Kashkovsky/threadnote/main/scripts/install.sh | \\
+  sh -s -- --no-start
+
+"$HOME/.local/bin/threadnote" cloud cursor bootstrap \\
+  --mode remote-hybrid \\
+  --endpoint https://memory.example.com/mcp \\
+  --share-id sh_acme_engineering \\
+  --cwd "$PWD" \\
+  --user cursor-cloud \\
+  --agent-id cursor-cloud
+
+test -x "$HOME/.local/bin/threadnote-mcp-server"
+"$HOME/.local/bin/threadnote" doctor --dry-run`,
+        },
+        {
+          type: 'paragraph',
+          text: 'Trigger a new Build, inspect its log, and make the latest successful Build active. A failed Build does not replace the last good one. For a multi-repository environment, ensure every repository in the environment matches the provisioned complete repository binding; use an existing absolute checkout as `--cwd`, and let each graph call supply the relevant checkout path.',
+        },
+        {type: 'heading', text: '5. Register both organization MCP servers'},
+        {
+          type: 'paragraph',
+          text: 'Generate the deterministic configuration from a trusted Threadnote installation. The command changes no service or Cursor state:',
+        },
+        {
+          type: 'code',
+          language: 'sh',
+          code: `threadnote cloud cursor config \\
+  --mode remote-hybrid \\
+  --endpoint https://memory.example.com/mcp \\
+  --share-id sh_acme_engineering \\
   --user cursor-cloud \\
   --agent-id cursor-cloud`,
         },
@@ -128,77 +243,71 @@ test -x "$HOME/.local/bin/threadnote-mcp-server"
           type: 'code',
           language: 'json',
           code: `{
-  "type": "stdio",
-  "command": "/bin/sh",
-  "args": ["-lc", "exec \\"$HOME/.local/bin/threadnote-mcp-server\\""],
-  "env": {
-    "THREADNOTE_ACCOUNT": "local",
-    "THREADNOTE_USER": "cursor-cloud",
-    "THREADNOTE_AGENT_ID": "cursor-cloud",
-    "THREADNOTE_CURSOR_CLOUD_TEAM": "cursor-cloud",
-    "THREADNOTE_MCP_TOOLSET": "cursor-cloud"
+  "mcpServers": {
+    "threadnote-local": {
+      "type": "stdio",
+      "command": "/bin/sh",
+      "args": ["-lc", "exec \\"$HOME/.local/bin/threadnote-mcp-server\\""],
+      "env": {
+        "THREADNOTE_ACCOUNT": "local",
+        "THREADNOTE_AGENT_ID": "cursor-cloud",
+        "THREADNOTE_CURSOR_MEMORY_ENDPOINT": "https://memory.example.com/mcp",
+        "THREADNOTE_CURSOR_MEMORY_SHARE_ID": "sh_acme_engineering",
+        "THREADNOTE_MCP_TOOLSET": "cursor-cloud-local",
+        "THREADNOTE_USER": "cursor-cloud"
+      }
+    },
+    "threadnote-memory": {
+      "url": "https://memory.example.com/mcp",
+      "headers": {
+        "threadnote-share-id": "sh_acme_engineering"
+      }
+    }
   }
 }`,
         },
         {
-          type: 'paragraph',
-          text: 'The stable `threadnote-mcp-server` launcher brokers the Dashboard-owned stdio session. After a standalone update activates a new runtime, the next MCP request uses that runtime without changing this configuration.',
+          type: 'list',
+          items: [
+            'In Cursor Dashboard, open Integrations & MCP as a team admin and add `threadnote-local` as a shared stdio server and `threadnote-memory` as a shared HTTP server. Keep the names distinct so failures identify the plane.',
+            'Copy the endpoint and share ID exactly. The HTTP URL carries no credentials, and the only static header is `threadnote-share-id`. Never add an Authorization, bearer, database, or Git credential to this JSON.',
+            'Configure OAuth on `threadnote-memory` and have each intended user complete their own sign-in. Cursor OAuth is per-user even for a shared team server.',
+            'Enable the pair only for the intended team and repositories. Linking to the team marketplace is optional and broadens discoverability; it does not replace the Cloud Agent environment Build.',
+            'Do not run `threadnote mcp-install cursor --apply` for this setup. That command owns a local desktop Cursor configuration, not organization-scoped Cloud Agent MCP registration.',
+          ],
         },
         {
-          type: 'warning',
-          text: 'Do not run `threadnote mcp-install cursor --apply` for this cloud setup. That command manages a local Cursor configuration under the current machine home; Cursor Cloud MCP configuration is owned by the personal or team integration at `cursor.com/agents`. Registration does not install the stdio executable in the cloud VM.',
+          type: 'note',
+          text: 'Cursor recommends HTTP for remotely operated MCP because its backend proxies calls and keeps refresh tokens and headers out of the VM. Threadnote still needs the stdio entry for local source evidence and the OIDC socket exchange. Cursor documents shared team registration, per-user OAuth, redacted configuration, and the HTTP/stdio boundary in [Cloud Agent capabilities](https://cursor.com/docs/cloud-agent/capabilities).',
         },
+        {type: 'heading', text: '6. Add the agent contract'},
         {
           type: 'paragraph',
-          text: 'Cursor currently supports custom stdio and Streamable HTTP MCP transports for cloud agents. Threadnote uses stdio because its server runs inside the VM. See [Cursor Cloud Agent capabilities](https://cursor.com/docs/cloud-agent/capabilities) and [Cursor MCP configuration](https://cursor.com/docs/mcp) for current platform controls.',
-        },
-        {type: 'heading', text: '4. Use the cloud memory contract'},
-        {
-          type: 'paragraph',
-          text: 'The cloud profile enforces this contract server-side. Add the concise version to checked-in agent instructions so agents also understand persistence and choose the right memory kind:',
+          text: 'Add this concise block to the checked-in `AGENTS.md` or equivalent repository guidance. Repository instructions remain authoritative and make the two-plane boundary visible to the model:',
         },
         {
           type: 'code',
           language: 'md',
           code: `## Cursor Cloud Threadnote contract
 
-When running in Cursor Cloud, use durable Threadnote memory only below:
-threadnote://user/cursor-cloud/memories/shared/cursor-cloud/
-
-- At the start of non-trivial work, call recall_context with project and
-  absolute callerCwd. The server injects the shared root.
-- Read only threadnote:// results below that root.
-- Store durable cross-session knowledge with remember_context kind=durable;
-  Threadnote commits and pushes it to the designated share.
-- Store run-local coordination with kind=handoff only when transient
-  cloud-workspace durability is acceptable.
-- Do not store incidents, preferences, smoke records, secrets, customer data,
-  or raw production logs from the cloud profile.
-- Use inspect_code_graph and analyze_code_graph for current checkout evidence.
-- Named worksets, candidate review/apply, separate publishing, Obsidian,
-  and memory maintenance are not available in this profile.`,
+- Use threadnote-local only for current-checkout code graph, status, guide,
+  and complete_cursor_attestation. It has no memory fallback.
+- Use threadnote-memory for every recall, read, durable memory, and handoff.
+  Never substitute VM-local personal memory or the Git beta when it is down.
+- Start non-trivial work with remote recall_context for the project. Recalled
+  threadnote:// pointers are unread evidence; call read_context before use.
+- Do not remove, replace, or infer the configured share binding from a URI.
+- Before a protected write, call begin_cursor_attestation on threadnote-memory,
+  pass the exact challenge to complete_cursor_attestation on threadnote-local,
+  then pass the returned opaque attestationId to the remote write.
+- Use a unique operationId for each mutation and the last observed revision for
+  compare-and-swap updates. Surface conflicts; never silently overwrite.
+- Never store secrets, credentials, customer data, or raw production logs.`,
         },
+        {type: 'heading', text: '7. Verify a protected cloud run'},
         {
           type: 'paragraph',
-          text: 'The first recall in a task should use this MCP payload, changing only the task query, project, and checkout path:',
-        },
-        {
-          type: 'code',
-          language: 'json',
-          code: `{
-  "query": "the task or decision to recover",
-  "project": "your-project",
-  "callerCwd": "/workspace/your-repository"
-}`,
-        },
-        {
-          type: 'note',
-          text: 'The server injects the configured root and rejects attempts to broaden recall, list, read, or MCP resources access into personal, seeded, or other team namespaces.',
-        },
-        {type: 'heading', text: '5. Verify a new cloud run'},
-        {
-          type: 'paragraph',
-          text: 'On the first run from the saved Build, verify the effective home, executable, bootstrap state, and Threadnote profile before relying on MCP discovery. The run page records the environment and Build used, so compare that provenance when a personal override unexpectedly falls back to a team environment.',
+          text: 'Start the first agent from the exact successful Build. Compare the run’s environment and Build provenance in the Dashboard, then verify the local plane inside the VM:',
         },
         {
           type: 'code',
@@ -208,56 +317,98 @@ test -x "$HOME/.local/bin/threadnote-mcp-server"
 test -d "$HOME/.threadnote"
 
 "$HOME/.local/bin/threadnote" cloud cursor verify \\
-  --team cursor-cloud \\
+  --mode remote-hybrid \\
+  --endpoint https://memory.example.com/mcp \\
+  --share-id sh_acme_engineering \\
+  --cwd "$PWD" \\
   --user cursor-cloud \\
   --agent-id cursor-cloud \\
-  --cwd "$PWD"`,
+  --json`,
+        },
+        {
+          type: 'table',
+          headers: ['Plane', 'Expected tools'],
+          rows: [
+            [
+              '`threadnote-local`',
+              '`inspect_code_graph`, `analyze_code_graph`, `cursor_cloud_status`, `complete_cursor_attestation`, `threadnote_guide`',
+            ],
+            [
+              '`threadnote-memory`',
+              '`recall_context`, `read_context`, `list_context`, `remember_context`, `memory_status`, `begin_cursor_attestation`, `transition_handoff`',
+            ],
+          ],
+        },
+        {
+          type: 'paragraph',
+          text: 'The CLI receipt verifies the local home, absolute checkout, platform, graph readiness, endpoint, share binding, optional Cursor socket, and disabled local fallback. It deliberately reports remote OAuth as a warning because OAuth is owned by Cursor; confirm authentication and the server’s `memory_status` from the Dashboard MCP state.',
+        },
+        {
+          type: 'code',
+          language: 'json',
+          code: `{
+  "version": 1,
+  "query": "the task or decision to recover",
+  "project": "platform"
+}`,
         },
         {
           type: 'list',
           items: [
-            'Verification reports the exclusive root, writable share, credential-free remote, worktree, gitdir, and absolute local graph checkout. A non-Linux development host is only a warning.',
-            'Cursor lists exactly `recall_context`, `read_context`, `list_context`, `remember_context`, `inspect_code_graph`, `analyze_code_graph`, and `threadnote_guide`.',
-            'Recall, list, read, and MCP resources access reject URIs outside `threadnote://user/cursor-cloud/memories/shared/cursor-cloud/`.',
-            'A durable test memory is committed and pushed, then a fresh VM can recall it.',
-            'A local handoff is stored with a transient-durability receipt and does not appear in the Git share.',
+            'Run `memory_status` and confirm the expected share, policy version, committed/indexed generations, and writable capabilities.',
+            'Recall and read a durable fixture, then verify a request for another project or share fails closed.',
+            'For write stages, run the remote `begin_cursor_attestation` → local `complete_cursor_attestation` → remote write sequence. Confirm the challenge audience and completion URL use the configured Threadnote origin.',
+            'Write one durable memory and one handoff with unique operation IDs, then recall both from a fresh VM and a fresh OAuth-backed MCP session.',
+            'Race two agents on the same base revision and require one commit plus one explicit conflict or idempotent replay; write different topics concurrently and require both to progress.',
+            'Disable the remote service and confirm local graph inspection still works while every memory operation fails—without selecting local or Git memory.',
+          ],
+        },
+        {type: 'heading', text: '8. Roll out and operate it safely'},
+        {
+          type: 'paragraph',
+          text: 'Roll out one isolated fixture share first, then internal read-only, protected durable writes, handoffs, selected external canaries, and only then broader availability. At every stage record the owner, region, backup/deletion policy, OAuth client policy, alert route, observation window, success threshold, and exact switches to disable. Follow the [canary and staged-release matrix](https://github.com/Kashkovsky/threadnote/blob/main/docs/remote-memory/canaries-and-release.md).',
+        },
+        {
+          type: 'list',
+          items: [
+            'Kill traffic with `THREADNOTE_REMOTE_ENABLED=false`; narrow a share with its feature flags or revoke the principal grant. Revocation must win over a concurrent stale authorization before commit.',
+            'Page on authorization failure classes, request latency, conflicts/replays, outbox age, indexing lag, worker health, database saturation, backup/restore evidence, and canary state—never on memory bodies or raw identity tokens.',
+            'Back up every authoritative table. Rehearse point-in-time restore, content-hash and head/revision reconciliation, two-tenant RLS, alias/idempotency behavior, and a full derived-index rebuild.',
+            'Keep Git-beta migration explicit and one-way. Import never deletes the source, never dual-writes, and still requires a reviewed Dashboard transport switch.',
+            'Rollback after cutover requires a verified export to a new restricted Git checkout and an explicit Dashboard change. Never make the old pre-cutover checkout writable again.',
           ],
         },
         {type: 'heading', text: 'What persists'},
         {
           type: 'table',
-          headers: ['State', 'Cloud contract'],
+          headers: ['State', 'Remote-hybrid contract'],
           rows: [
             [
-              'Shared durable memories',
-              'Committed and pushed to the designated Git memory repository; recalled through the exclusive URI scope.',
+              'Durable memories',
+              'Immutable PostgreSQL revisions in the authorized remote share; available to later VMs after authorization.',
             ],
             [
-              'Local handoffs',
-              'VM-local only; useful for active-workspace coordination, not cross-session continuity.',
+              'Handoffs',
+              'Remote, revisioned, and durable across sessions, with explicit supersede, archive, and expiry transitions.',
             ],
-            ['Other personal memory kinds', 'Rejected by the cloud profile.'],
             [
               'Code graph',
-              'Derived inside the VM from the current checkout and dirty overlay; rebuildable, not durable memory.',
+              'Derived inside each VM from the current checkout and dirty overlay; rebuildable and never uploaded by the memory service.',
+            ],
+            [
+              'OAuth and Cursor OIDC',
+              'OAuth is per-user in Cursor; raw tokens remain transient. Threadnote retains only bounded verified attribution.',
             ],
             [
               'Repository changes',
-              'Persist through the normal branch, commit, pull request, and task-system workflow.',
+              'Persist through the normal branch, commit, pull request, and task workflow—not through Threadnote memory.',
             ],
-            ['Secrets and Git credentials', 'Remain in Cursor or the Git provider and never enter Threadnote memory.'],
           ],
         },
-        {type: 'heading', text: 'Beyond 4.2: what the full integration will add'},
+        {type: 'heading', text: 'Legacy Git beta'},
         {
-          type: 'list',
-          items: [
-            'A managed remote memory transport that does not require a VM-local Git checkout.',
-            "Cloud-provider identity and authorization beyond the 4.2 profile's stable user, agent, and team identifiers.",
-            'A durable remote handoff path with explicit lifecycle and concurrency contracts.',
-            'Automated clean-VM, resumed-Build, write-concurrency, and multi-agent canary coverage.',
-            'A future hybrid transport: local stdio for checkout-specific graph evidence and remote Streamable HTTP for durable shared memory.',
-          ],
+          type: 'paragraph',
+          text: 'The Threadnote 4.2 Git-backed Cursor Cloud profile remains a separate beta mode for organizations that are not operating remote memory. It uses `--mode git-beta` and one writable Git share; durable memories are committed and pushed, while handoffs stay VM-local. Never register Git beta and remote-hybrid memory in the same environment, and never use Git as an automatic fallback for a managed-service outage. Migration requires the explicit [plan, import, cutover, export, and rollback workflow](https://github.com/Kashkovsky/threadnote/blob/main/docs/remote-memory/migration.md).',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- replace the legacy Cursor Cloud beta guide with an organization bootstrap runbook
- document the local and managed-memory MCP architecture, identity, provisioning, rollout, and rollback
- validate embedded JSON and command contracts in the website content test

## Validation
- bun run site:check
- bun run site:build
- commit-hook lint, Prettier, and TypeScript checks
- git diff --check

Property testing was assessed and is not useful for static documentation; the focused test parses and asserts the exact JSON examples.