### PR TITLE
chore: approve Threadnote 4.6 agent manifest

### DIFF
--- a/src/evaluation/code-memory-link-approvals.json
+++ b/src/evaluation/code-memory-link-approvals.json
@@ -2,7 +2,8 @@
   "agentAbEvidenceHashes": [],
   "agentAbManifestHashes": [
     "b01aadcdd828e5cb4c8877d75f10f385da047f79c47c289850c6eee441f84f3e",
-    "f64630ab0a6403c39f24fb5ae83ba610baa9d6600b7f8bb444c7973e113d3bf8"
+    "f64630ab0a6403c39f24fb5ae83ba610baa9d6600b7f8bb444c7973e113d3bf8",
+    "d1a5cb0c86d649cafec1ece67f1d4a772f168297fe97f529d05cf4f49771a3f5"
   ],
   "dogfoodEvidenceHashes": [],
   "retainedEvidenceBundleHashes": [],


### PR DESCRIPTION
## Summary
- approve the independently reviewed sealed CodeMemoryLinkBench manifest for Threadnote 4.6
- preserve the required governance-only C → A chronology

## Bound identity
- candidate C: `23d3ac7f70b0e2524b5afb25a01cc05e266ba734`
- manifest SHA-256: `d1a5cb0c86d649cafec1ece67f1d4a772f168297fe97f529d05cf4f49771a3f5`
- candidate executable SHA-256: `4336db318e90d5a1fb527b3999464d06e6bba3edfde206eeccb7450056e58021`

## Scope and checks
- only `src/evaluation/code-memory-link-approvals.json` changes
- JSON parse and Prettier check pass
- commit hooks passed lint, typecheck, and formatting
- no property test applies to this single reviewed governance hash

After merge, this signed squash commit must be the immediate child A of C. The frozen 168-trial matrix will name A; no runtime reinstall is required.