### PR TITLE
chore: reset invalid Threadnote 4.6 preregistration

### DIFF
--- a/src/evaluation/code-memory-link-approvals.json
+++ b/src/evaluation/code-memory-link-approvals.json
@@ -2,8 +2,7 @@
   "agentAbEvidenceHashes": [],
   "agentAbManifestHashes": [
     "b01aadcdd828e5cb4c8877d75f10f385da047f79c47c289850c6eee441f84f3e",
-    "f64630ab0a6403c39f24fb5ae83ba610baa9d6600b7f8bb444c7973e113d3bf8",
-    "d1a5cb0c86d649cafec1ece67f1d4a772f168297fe97f529d05cf4f49771a3f5"
+    "f64630ab0a6403c39f24fb5ae83ba610baa9d6600b7f8bb444c7973e113d3bf8"
   ],
   "dogfoodEvidenceHashes": [],
   "retainedEvidenceBundleHashes": [],


### PR DESCRIPTION
## Summary
- remove the manifest hash whose first governed trial failed closed
- establish a forward-only replacement candidate C2 without rewriting protected history
- restore the complete source tree byte-for-byte to the already-qualified original C tree

## Evidence
- parent: signed A `60d003b190ce802db325af1fc46217a6e128aac1`
- original qualified C: `23d3ac7f70b0e2524b5afb25a01cc05e266ba734`
- `git diff 23d3ac7f... HEAD -- .` is empty
- only branch delta from A removes failed manifest hash `d1a5cb...71a3f5`
- commit hooks passed lint, typecheck, and formatting

After signed squash merge, the resulting main commit is replacement candidate C2. It will be installed and independently qualified under its exact new build identity before a fresh preregistration. No failed attempt is retried or included in canonical evidence.