### PR TITLE
fix: stabilize Personal Cursor Cloud bootstrap

### DIFF
--- a/.github/release-notes/v4.6.2.md
+++ b/.github/release-notes/v4.6.2.md
@@ -1,0 +1,46 @@
+## What's new
+
+Threadnote 4.6.2 fixes two Personal Cursor Cloud provisioning races discovered in a real multi-share environment.
+
+### MCP discovery stays available during share bootstrap
+
+The Personal Cursor Cloud MCP server no longer requires every declared Git memory share to be configured read-write
+before it advertises tools. Cursor can start the MCP process while a saved-environment Build is still cloning several
+shares, so that boot-time requirement could terminate the server and make the entire `threadnote` namespace disappear.
+
+The MCP now establishes its bounded share scope from the declared configuration immediately. Memory operations check
+share readiness when they run and return an actionable temporary warning until bootstrap finishes. The same process
+can use the shares as soon as they become ready; MCP discovery and local code-graph tools remain available throughout.
+
+### Personal identity no longer falls back to the Cloud VM user
+
+Personal bootstrap now atomically saves the selected account, user, and agent identity in
+`~/.threadnote/cursor-cloud/profile.json` before cloning the first share. Later CLI, index, doctor, verify, and MCP
+processes inherit that profile when explicit environment variables are absent, instead of resolving the generic Cloud
+Agent OS user such as `ubuntu`.
+
+Explicit `THREADNOTE_*` identity variables and command flags still take precedence. Threadnote refuses to silently
+replace a saved profile with another user in the same home because doing so would strand the existing canonical memory
+cache. Use the same `--user` and `--agent-id` for every share, or use a separate `THREADNOTE_HOME` for an intentionally
+separate identity.
+
+To repair an affected environment, update Threadnote and rerun every existing bootstrap command once with the identity
+that owns the populated canonical memory tree, then regenerate the one personal MCP configuration with those same
+values. For example:
+
+```sh
+threadnote update
+
+threadnote cloud cursor bootstrap \
+  --remote https://github.com/you/threadnote-memory.git \
+  --team personal \
+  --user your-stable-threadnote-user \
+  --agent-id cursor-cloud
+
+threadnote cloud cursor config \
+  --team personal \
+  --user your-stable-threadnote-user \
+  --agent-id cursor-cloud
+```
+
+Repeat `--team` in the configuration command and rerun bootstrap once per remote when the MCP exposes multiple shares.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/cursor/cloud.ts
+++ b/src/cursor/cloud.ts
@@ -8,6 +8,7 @@ import {SystemInfo} from '../effect/system.js';
 import {canonicalResourceUri, resourceIdIsWithin} from '../storage/resource-id.js';
 import {uriSegment} from '../mcp/server/common.js';
 import {installCursorCloudAgentIntegration} from '../agent_integration/index.js';
+import {persistCursorCloudIdentityProfile} from './profile.js';
 
 /** Legacy selector retained for Threadnote 4.2 Dashboard configurations. */
 export const CURSOR_CLOUD_MCP_TOOLSET = 'cursor-cloud' as const;
@@ -302,8 +303,17 @@ export function cursorCloudRuntimeConfig(
   config: RuntimeConfig,
   options: {readonly agentId?: string; readonly user?: string},
 ): RuntimeConfig {
-  const profile = buildCursorCloudProfile(config, options);
-  return {...config, agentId: profile.agentId, user: profile.user};
+  const profile = buildCursorCloudProfile(config, {
+    agentId: options.agentId ?? cursorCloudDefaultIdentity(config.agentId, config.agentIdSource),
+    user: options.user ?? cursorCloudDefaultIdentity(config.user, config.userSource),
+  });
+  return {
+    ...config,
+    agentId: profile.agentId,
+    agentIdSource: options.agentId ? 'cursor-cloud-command' : config.agentIdSource,
+    user: profile.user,
+    userSource: options.user ? 'cursor-cloud-command' : config.userSource,
+  };
 }
 
 export function credentialFreeGitRemote(remote: string): string {
@@ -344,29 +354,37 @@ export function planCursorCloudBootstrap(
   return {action: 'reuse', remote, team};
 }
 
-export const resolveCursorCloudMemoryScope = Effect.fn('cursorCloud.resolveMemoryScope')(function* (
+export const resolveCursorCloudMemoryScope = Effect.fn('cursorCloud.resolveMemoryScope')(function (
   config: RuntimeConfig,
   environment: Readonly<Record<string, string | undefined>>,
 ) {
-  const teams = cursorCloudTeamsFromEnvironment(environment);
+  return Effect.sync(() => {
+    const teams = cursorCloudTeamsFromEnvironment(environment);
+    return {
+      mode: 'shared-read-write',
+      shares: teams.map(team => ({root: cursorCloudMemoryRoot(config.user, team), team})),
+    } satisfies CursorCloudMemoryScope;
+  });
+});
+
+export const assertCursorCloudMemoryTeamsReady = Effect.fn('cursorCloud.assertMemoryTeamsReady')(function* (
+  config: RuntimeConfig,
+  teams: readonly string[],
+) {
   const teamsFile = yield* readTeamsFile(config);
   for (const team of teams) {
     const configured = teamsFile.teams[team];
     if (!configured) {
       throw new CursorCloudOperationError(
-        `Cursor Cloud memory team "${team}" is not configured. Run threadnote cloud cursor bootstrap --team ${team} first.`,
+        `Cursor Cloud memory team "${team}" is not configured yet. MCP discovery remains available while bootstrap runs; wait for the environment Build to finish, then retry. If bootstrap is not running, run threadnote cloud cursor bootstrap --team ${team} first.`,
       );
     }
     if (shareTeamAccess(configured) !== 'read-write') {
       throw new CursorCloudOperationError(
-        `Cursor Cloud memory team "${team}" must be read-write before the MCP profile can start.`,
+        `Cursor Cloud memory team "${team}" is not read-write yet. MCP discovery remains available while bootstrap runs; wait for the environment Build to finish, then retry.`,
       );
     }
   }
-  return {
-    mode: 'shared-read-write',
-    shares: teams.map(team => ({root: cursorCloudMemoryRoot(config.user, team), team})),
-  } satisfies CursorCloudMemoryScope;
 });
 
 export const runCursorCloudConfig = Effect.fn('cursorCloud.config')(function* (
@@ -381,7 +399,12 @@ export const runCursorCloudConfig = Effect.fn('cursorCloud.config')(function* (
   },
 ) {
   const teams = normalizeCursorCloudTeams(options.teams);
-  const profile = buildCursorCloudProfile(config, {...options, team: teams[0]});
+  const profile = buildCursorCloudProfile(config, {
+    ...options,
+    agentId: options.agentId ?? config.agentId,
+    team: teams[0],
+    user: options.user ?? config.user,
+  });
   const output =
     options.mode === 'remote-hybrid'
       ? buildCursorCloudRemoteHybridMcpConfig(
@@ -412,6 +435,9 @@ export const runCursorCloudBootstrap = Effect.fn('cursorCloud.bootstrap')(functi
   yield* withSharedRepositoryLock(
     config,
     Effect.gen(function* () {
+      if (options.dryRun !== true) {
+        yield* persistCursorCloudIdentityProfile(config);
+      }
       const plan = planCursorCloudBootstrap(yield* readTeamsFile(config), remote, options.team);
       if (plan.action === 'initialize') {
         yield* runShareInit(config, plan.remote, {
@@ -701,6 +727,13 @@ function requiredIdentity(value: string, label: string): string {
     throw new CursorCloudOperationError(`Cursor Cloud ${label} must contain a portable identifier.`);
   }
   return normalized;
+}
+
+function cursorCloudDefaultIdentity(
+  configured: string,
+  source: RuntimeConfig['userSource'] | RuntimeConfig['agentIdSource'],
+): string {
+  return source === 'cursor-cloud-profile' || source === 'environment' ? configured : DEFAULT_CURSOR_CLOUD_IDENTITY;
 }
 
 function assertEquivalentWritableTeam(existing: ShareTeamConfig, remote: string, team: string): void {

--- a/src/cursor/profile.ts
+++ b/src/cursor/profile.ts
@@ -1,0 +1,122 @@
+import {Crypto, Effect, FileSystem, Option, Path, Result} from 'effect';
+import {validatePortableSegment} from '../storage/resource-id.js';
+import type {RuntimeConfig} from '../types.js';
+
+export const CURSOR_CLOUD_PROFILE_VERSION = 1 as const;
+
+export interface CursorCloudIdentityProfileV1 {
+  readonly account: string;
+  readonly agentId: string;
+  readonly provider: 'cursor-cloud';
+  readonly user: string;
+  readonly version: typeof CURSOR_CLOUD_PROFILE_VERSION;
+}
+
+export class CursorCloudIdentityProfileError extends Error {
+  readonly _tag = 'CursorCloudIdentityProfileError' as const;
+}
+
+export const cursorCloudIdentityProfilePath = Effect.fn('cursorCloud.identityProfilePath')(function* (
+  agentContextHome: string,
+) {
+  const path = yield* Path.Path;
+  return path.join(agentContextHome, 'cursor-cloud', 'profile.json');
+});
+
+export const readCursorCloudIdentityProfile = Effect.fn('cursorCloud.readIdentityProfile')(function* (
+  agentContextHome: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const file = yield* cursorCloudIdentityProfilePath(agentContextHome);
+  if (!(yield* fs.exists(file))) return undefined;
+  if (Option.isSome(yield* fs.readLink(file).pipe(Effect.option))) {
+    return yield* Effect.fail(
+      new CursorCloudIdentityProfileError('Personal Cursor Cloud profile must not be a symlink.'),
+    );
+  }
+  const raw = yield* fs.readFileString(file);
+  const parsed = Result.try(() => JSON.parse(raw) as unknown);
+  if (Result.isFailure(parsed) || !isCursorCloudIdentityProfile(parsed.success)) {
+    return yield* Effect.fail(
+      new CursorCloudIdentityProfileError(
+        'Personal Cursor Cloud profile is invalid. Move ~/.threadnote/cursor-cloud/profile.json aside and rerun bootstrap with the intended --user and --agent-id.',
+      ),
+    );
+  }
+  return parsed.success;
+});
+
+export const persistCursorCloudIdentityProfile = Effect.fn('cursorCloud.persistIdentityProfile')(function* (
+  config: Pick<RuntimeConfig, 'account' | 'agentContextHome' | 'agentId' | 'user'>,
+) {
+  const existing = yield* readCursorCloudIdentityProfile(config.agentContextHome);
+  const profile = cursorCloudIdentityProfile(config);
+  if (existing) {
+    if (sameCursorCloudIdentity(existing, profile)) return existing;
+    return yield* Effect.fail(
+      new CursorCloudIdentityProfileError(
+        `Personal Cursor Cloud already uses user "${existing.user}" and agent "${existing.agentId}" in this Threadnote home. Reuse that identity or use a separate THREADNOTE_HOME; changing it would strand the existing canonical memory cache.`,
+      ),
+    );
+  }
+
+  const crypto = yield* Crypto.Crypto;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const target = yield* cursorCloudIdentityProfilePath(config.agentContextHome);
+  const directory = path.dirname(target);
+  const temporary = path.join(directory, `.profile.${yield* crypto.randomUUIDv4}.tmp`);
+  yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
+  yield* fs.writeFileString(temporary, `${JSON.stringify(profile, undefined, 2)}\n`, {mode: 0o600});
+  yield* fs
+    .rename(temporary, target)
+    .pipe(Effect.ensuring(fs.remove(temporary, {force: true}).pipe(Effect.catch(() => Effect.void))));
+  yield* fs.chmod(target, 0o600);
+  yield* fs.chmod(directory, 0o700);
+  return profile;
+});
+
+function cursorCloudIdentityProfile(
+  config: Pick<RuntimeConfig, 'account' | 'agentId' | 'user'>,
+): CursorCloudIdentityProfileV1 {
+  return {
+    account: validateIdentity(config.account, 'account'),
+    agentId: validateIdentity(config.agentId, 'agent id'),
+    provider: 'cursor-cloud',
+    user: validateIdentity(config.user, 'user'),
+    version: CURSOR_CLOUD_PROFILE_VERSION,
+  };
+}
+
+function isCursorCloudIdentityProfile(value: unknown): value is CursorCloudIdentityProfileV1 {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<CursorCloudIdentityProfileV1>;
+  if (
+    candidate.version !== CURSOR_CLOUD_PROFILE_VERSION ||
+    candidate.provider !== 'cursor-cloud' ||
+    typeof candidate.account !== 'string' ||
+    typeof candidate.agentId !== 'string' ||
+    typeof candidate.user !== 'string'
+  ) {
+    return false;
+  }
+  return [candidate.account, candidate.agentId, candidate.user].every(value => {
+    try {
+      return validatePortableSegment(value) === value;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function validateIdentity(value: string, label: string): string {
+  try {
+    return validatePortableSegment(value);
+  } catch (cause) {
+    throw new CursorCloudIdentityProfileError(`Personal Cursor Cloud ${label} is not a portable identity.`, {cause});
+  }
+}
+
+function sameCursorCloudIdentity(left: CursorCloudIdentityProfileV1, right: CursorCloudIdentityProfileV1): boolean {
+  return left.account === right.account && left.agentId === right.agentId && left.user === right.user;
+}

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -1526,13 +1526,13 @@ const finalizeCodeRefs = Command.make(
   options => withRuntimeEffect(config => runFinalizeCodeRefs(config, options)),
 ).pipe(Command.withDescription('Finalize private pending memory code citations from exact-current ready graphs'));
 
-const cursorCloudIdentityFlags = makeCursorCloudIdentityFlags(defaultString);
+const cursorCloudIdentityFlags = makeCursorCloudIdentityFlags(defaultString, optionalString);
 const cursorCloudBaseIdentityFlags = {
   agentId: cursorCloudIdentityFlags.agentId,
   user: cursorCloudIdentityFlags.user,
 };
 const cursorCloudMode = makeCursorCloudModeFlag(defaultChoice);
-const cursorCloudRuntime = (config: RuntimeConfig, agentId: string, user: string) =>
+const cursorCloudRuntime = (config: RuntimeConfig, agentId: string | undefined, user: string | undefined) =>
   cursorCloudRuntimeConfig(config, {agentId, user});
 
 const cursorCloudConfig = Command.make(

--- a/src/effect/cursor_cloud_cli.ts
+++ b/src/effect/cursor_cloud_cli.ts
@@ -20,11 +20,18 @@ type CursorCloudMode = 'personal' | 'remote-hybrid';
 
 export function makeCursorCloudIdentityFlags(
   defaultString: (name: string, description: string, value: string) => Flag.Flag<string>,
+  optionalString: (name: string, description: string) => Flag.Flag<string | undefined>,
 ) {
   return {
-    agentId: defaultString('agent-id', 'Stable agent identity used by Cursor Cloud', 'cursor-cloud'),
+    agentId: optionalString(
+      'agent-id',
+      'Stable agent identity; defaults to the saved Personal Cursor Cloud profile or cursor-cloud',
+    ),
     team: defaultString('team', 'Shared-memory team reserved for Cursor Cloud', 'cursor-cloud'),
-    user: defaultString('user', 'Stable Threadnote user identity used by Cursor Cloud', 'cursor-cloud'),
+    user: optionalString(
+      'user',
+      'Stable Threadnote user identity; defaults to the saved Personal Cursor Cloud profile or cursor-cloud',
+    ),
   } as const;
 }
 

--- a/src/mcp/server/cursor_cloud_memory.ts
+++ b/src/mcp/server/cursor_cloud_memory.ts
@@ -1,4 +1,9 @@
-import {cursorCloudScopeTeams, type CursorCloudMemoryScope} from '../../cursor/cloud.js';
+import {Effect} from 'effect';
+import {
+  assertCursorCloudMemoryTeamsReady,
+  cursorCloudScopeTeams,
+  type CursorCloudMemoryScope,
+} from '../../cursor/cloud.js';
 import {syncSharedReposBeforeAgentRead} from '../../effect/share.js';
 import type {RuntimeConfig} from './common.js';
 
@@ -14,5 +19,7 @@ export function syncCursorCloudMemoryShares(
       : typeof teamSelector === 'string'
         ? [teamSelector]
         : teamSelector;
-  return syncSharedReposBeforeAgentRead(config, teams);
+  return assertCursorCloudMemoryTeamsReady(config, teams).pipe(
+    Effect.andThen(syncSharedReposBeforeAgentRead(config, teams)),
+  );
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,5 +1,6 @@
 import {Effect, FileSystem, Path} from 'effect';
 import {DEFAULT_ACCOUNT, DEFAULT_AGENT_ID, USER_MANIFEST_NAME} from './constants.js';
+import {readCursorCloudIdentityProfile} from './cursor/profile.js';
 import {expandPath, toolRoot} from './utils.js';
 import {SystemInfo} from './effect/system.js';
 
@@ -15,14 +16,27 @@ export const getRuntimeConfig = Effect.fn('runtime.getRuntimeConfig')(function* 
   const system = yield* SystemInfo;
   const environment = system.environment();
   const threadnoteHome = yield* expandPath(options.home ?? environment.THREADNOTE_HOME ?? '~/.threadnote');
+  const cursorCloudProfile = yield* readCursorCloudIdentityProfile(threadnoteHome);
   const configuredManifest = manifestOverride ?? options.manifest ?? environment.THREADNOTE_MANIFEST;
   const manifestPath = yield* expandPath(configuredManifest ?? (yield* defaultManifestPath(threadnoteHome)));
+  const environmentAgentId = environment.THREADNOTE_AGENT_ID;
+  const environmentUser = environment.THREADNOTE_USER;
   return {
-    account: environment.THREADNOTE_ACCOUNT ?? DEFAULT_ACCOUNT,
+    account: environment.THREADNOTE_ACCOUNT ?? cursorCloudProfile?.account ?? DEFAULT_ACCOUNT,
     agentContextHome: threadnoteHome,
-    agentId: environment.THREADNOTE_AGENT_ID ?? DEFAULT_AGENT_ID,
+    agentId: environmentAgentId ?? cursorCloudProfile?.agentId ?? DEFAULT_AGENT_ID,
+    agentIdSource: environmentAgentId
+      ? ('environment' as const)
+      : cursorCloudProfile
+        ? ('cursor-cloud-profile' as const)
+        : ('system' as const),
     manifestPath,
-    user: environment.THREADNOTE_USER ?? system.userName,
+    user: environmentUser ?? cursorCloudProfile?.user ?? system.userName,
+    userSource: environmentUser
+      ? ('environment' as const)
+      : cursorCloudProfile
+        ? ('cursor-cloud-profile' as const)
+        : ('system' as const),
   };
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,13 +6,16 @@ export type ClaudeMcpScope = 'local' | 'project' | 'user';
 export type CommandStatus = 'fail' | 'ok' | 'warn';
 export type MemoryKind = 'durable' | 'handoff' | 'incident' | 'preference' | 'smoke';
 export type MemoryStatus = 'active' | 'archived' | 'expired' | 'superseded';
+export type RuntimeIdentitySource = 'cursor-cloud-command' | 'cursor-cloud-profile' | 'environment' | 'system';
 
 export interface RuntimeConfig {
   readonly account: string;
   readonly agentContextHome: string;
   readonly agentId: string;
+  readonly agentIdSource?: RuntimeIdentitySource;
   readonly manifestPath: string;
   readonly user: string;
+  readonly userSource?: RuntimeIdentitySource;
 }
 
 export interface ProjectManifest {

--- a/test/integration/cursor-cloud.test.ts
+++ b/test/integration/cursor-cloud.test.ts
@@ -93,6 +93,57 @@ describe('Cursor Cloud integration', () => {
         defaultTeam: 'engineering',
         teams: {engineering: {name: 'engineering', remote: fixture.remote}},
       });
+      expect(JSON.parse(await readFile(join(fixture.home, 'cursor-cloud', 'profile.json'), 'utf8'))).toEqual({
+        account: 'local',
+        agentId: 'cloud-agent',
+        provider: 'cursor-cloud',
+        user: 'cloud-user',
+        version: 1,
+      });
+      const implicitConfig = await runCli(
+        ['cloud', 'cursor', 'config', '--home', fixture.home, '--team', 'engineering'],
+        {HOME: fixture.userHome},
+      );
+      expect(JSON.parse(implicitConfig.stdout)).toMatchObject({
+        env: {THREADNOTE_AGENT_ID: 'cloud-agent', THREADNOTE_USER: 'cloud-user'},
+      });
+      const implicitRemember = await runCli(
+        [
+          'remember',
+          '--home',
+          fixture.home,
+          '--kind',
+          'handoff',
+          '--project',
+          'threadnote',
+          '--topic',
+          'cursor-cloud-profile-fallback',
+          '--text',
+          'The saved Cursor Cloud profile selects the canonical user.',
+        ],
+        {HOME: fixture.userHome},
+      );
+      expect(implicitRemember.stdout).toContain('threadnote://user/cloud-user/memories/handoffs/active/');
+      await expect(
+        runCli(
+          [
+            'cloud',
+            'cursor',
+            'bootstrap',
+            '--home',
+            fixture.home,
+            '--remote',
+            fixture.remote,
+            '--team',
+            'engineering',
+            '--user',
+            'different-user',
+            '--agent-id',
+            'cloud-agent',
+          ],
+          {HOME: fixture.userHome},
+        ),
+      ).rejects.toMatchObject({stderr: expect.stringContaining('already uses user "cloud-user"')});
       expect(await readFile(join(fixture.userHome, '.cursor', 'rules', 'threadnote.mdc'), 'utf8')).toContain(
         'Personal Cursor Cloud',
       );
@@ -124,6 +175,24 @@ describe('Cursor Cloud integration', () => {
         memoryRoot: 'threadnote://user/cloud-user/memories/shared/engineering',
         profile: 'shared-read-write',
         status: 'ok',
+      });
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('keeps MCP discovery available while declared shares are still bootstrapping', async () => {
+    const fixture = await cloudFixture();
+    try {
+      await withCloudMcp(fixture, ['engineering', 'docs'], async client => {
+        const tools = await client.listTools();
+        expect(tools.tools.map(tool => tool.name)).toEqual(CLOUD_TOOL_NAMES);
+        const recallError = await callError(client, 'recall_context', {
+          callerCwd: process.cwd(),
+          query: 'bootstrap race sentinel',
+        });
+        expect(recallError).toContain('is not configured yet');
+        expect(recallError).toContain('MCP discovery remains available');
       });
     } finally {
       await rm(fixture.root, {force: true, recursive: true});

--- a/test/unit/cursor-cloud.test.ts
+++ b/test/unit/cursor-cloud.test.ts
@@ -8,6 +8,7 @@ import {
   cursorCloudMemoryEndpoint,
   cursorCloudMemoryRoot,
   cursorCloudRemoteShareId,
+  cursorCloudRuntimeConfig,
   normalizeCursorCloudTeams,
   planCursorCloudBootstrap,
 } from '../../src/cursor/cloud.js';
@@ -71,6 +72,35 @@ describe('Cursor Cloud profile', () => {
         (teams, order) => {
           const reordered = order.map(index => teams[index % teams.length]!).concat(teams);
           expect(normalizeCursorCloudTeams(reordered)).toEqual([...teams].sort());
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it('preserves a saved Personal Cursor Cloud identity unless a command explicitly overrides it', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[a-z][a-z0-9]{0,20}$/u),
+        fc.stringMatching(/^[a-z][a-z0-9]{0,20}$/u),
+        fc.stringMatching(/^[a-z][a-z0-9]{0,20}$/u),
+        (savedUser, savedAgent, overrideUser) => {
+          const savedRuntime: RuntimeConfig = {
+            ...runtime,
+            agentId: savedAgent,
+            agentIdSource: 'cursor-cloud-profile',
+            user: savedUser,
+            userSource: 'cursor-cloud-profile',
+          };
+          expect(cursorCloudRuntimeConfig(savedRuntime, {})).toMatchObject({
+            agentId: savedAgent,
+            user: savedUser,
+          });
+          expect(cursorCloudRuntimeConfig(savedRuntime, {user: overrideUser})).toMatchObject({
+            agentId: savedAgent,
+            user: overrideUser,
+            userSource: 'cursor-cloud-command',
+          });
         },
       ),
       {numRuns: 100},

--- a/website/src/content/docsCursorCloudPersonal.ts
+++ b/website/src/content/docsCursorCloudPersonal.ts
@@ -100,7 +100,7 @@ test -f "$HOME/.cursor/skills/threadnote-memory/SKILL.md"`,
         },
         {
           type: 'paragraph',
-          text: 'Trigger a Build, inspect its install log, and make the successful Build active. Bootstrap is safe to rerun when a share already points at the same credential-free remote with read-write access. Cursor’s install command runs during the Build and the resulting disk state is saved for later agents.',
+          text: 'Trigger a Build, inspect its install log, and make the successful Build active. The first non-dry-run bootstrap persists the selected account, user, and agent identity in `~/.threadnote/cursor-cloud/profile.json` before cloning the share. Later CLI commands and an MCP process without explicit identity variables inherit that profile instead of the Cloud VM’s generic `ubuntu` user. Use the same `--user` and `--agent-id` for every share in one Threadnote home. Bootstrap is safe to rerun when a share already points at the same credential-free remote with read-write access. Cursor’s install command runs during the Build and the resulting disk state is saved for later agents.',
         },
         {type: 'heading', text: 'Why bootstrap installs skills'},
         {
@@ -200,7 +200,11 @@ threadnote doctor --dry-run`,
           rows: [
             [
               '`team … is not configured` or MCP discovery fails',
-              'The MCP share set and bootstrapped environment disagree. Rerun bootstrap for that exact `--team`, rebuild the environment, then regenerate the one MCP configuration with the same repeated team set.',
+              'On current releases MCP discovery remains available while bootstrap is still cloning shares, and recall reports a temporary readiness warning. Wait for the Build to finish and retry. If the warning remains, rerun bootstrap for that exact `--team`, rebuild the environment, then regenerate the one MCP configuration with the same repeated team set.',
+            ],
+            [
+              '`0 canonical documents` or `Resource user scope does not match`',
+              'The share was ingested under one Threadnote user but this process selected another. Rerun each bootstrap with the original stable `--user` and `--agent-id`, then regenerate the MCP configuration with those same values. Bootstrap persists that identity so later CLI, index, doctor, and MCP processes do not fall back to `ubuntu`.',
             ],
             [
               '`repository not found`',


### PR DESCRIPTION
## Summary

- keep the Personal Cursor Cloud MCP namespace discoverable while declared Git shares are still bootstrapping
- atomically persist the selected cloud account/user/agent identity so CLI, index, doctor, verify, and MCP do not fall back to the VM OS user
- add recovery docs and v4.6.2 release notes

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun --bun vitest run test/unit/cursor-cloud.test.ts test/integration/cursor-cloud.test.ts test/unit/website-content.test.ts test/unit/website-release-boundary.test.ts test/unit/bun-package-contract.test.ts test/unit/publish-workflow.test.ts` (114 passed)
- `bun run dev:install-global` at exact HEAD
- installed-binary profile fallback smoke
- installed MCP discovery-before-bootstrap smoke (7 tools; bounded readiness error)