### PR TITLE
fix: preserve Windows git path roles

### DIFF
--- a/.github/release-notes/v4.6.3.md
+++ b/.github/release-notes/v4.6.3.md
@@ -1,0 +1,18 @@
+## What's new
+
+Threadnote 4.6.3 makes shared-repository git command output readable on Windows without exposing local paths.
+
+### Git command paths keep their roles
+
+`threadnote share status` and `threadnote share init --dry-run` no longer collapse the resolved git executable,
+worktree, and separate git directory to the same `<local-path>` token. Sensitive Windows paths now retain their role
+in the displayed command:
+
+```text
+Running: '<git>' -C '<worktree>' status --short --branch
+Would run: '<git>' clone -c core.symlinks=false '--separate-git-dir=<gitdir>' -- <url> '<worktree>'
+```
+
+Local clone sources use a separate `<repository>` placeholder. Non-sensitive values, including ordinary HTTPS remote
+URLs, remain visible, while credentials and local paths continue to be scrubbed. Paths containing spaces are replaced
+as a whole, preventing a suffix such as the remainder of `Program Files` from leaking into the command echo.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/effect/command.ts
+++ b/src/effect/command.ts
@@ -629,7 +629,50 @@ export function commandEnvironment(
 }
 
 export function formatShellCommand(executable: string, args: readonly string[]): string {
-  return redactSensitiveText([executable, ...args].map(shellQuote).join(' '));
+  const values = isGitExecutable(executable) ? formatGitCommandValues(executable, args) : [executable, ...args];
+  return redactSensitiveText(values.map(shellQuote).join(' '));
+}
+
+const GIT_PATH_ARGUMENT_ROLES = new Map<string, 'gitdir' | 'worktree'>([
+  ['-C', 'worktree'],
+  ['--git-dir', 'gitdir'],
+  ['--separate-git-dir', 'gitdir'],
+  ['--work-tree', 'worktree'],
+]);
+
+function formatGitCommandValues(executable: string, args: readonly string[]): readonly string[] {
+  const formattedArgs = [...args];
+  const separatorIndex = args.indexOf('--');
+  const optionLimit = separatorIndex >= 0 ? separatorIndex : args.length;
+  for (let index = 0; index < optionLimit; index += 1) {
+    const argument = args[index];
+    const role = GIT_PATH_ARGUMENT_ROLES.get(argument);
+    if (role !== undefined && index + 1 < optionLimit) {
+      formattedArgs[index + 1] = replaceSensitiveValueWithRole(args[index + 1]!, role);
+      index += 1;
+      continue;
+    }
+    for (const [option, optionRole] of GIT_PATH_ARGUMENT_ROLES) {
+      const prefix = `${option}=`;
+      if (argument.startsWith(prefix)) {
+        formattedArgs[index] = `${prefix}${replaceSensitiveValueWithRole(argument.slice(prefix.length), optionRole)}`;
+        break;
+      }
+    }
+  }
+
+  if (args[0] === 'clone' && separatorIndex > 0 && separatorIndex + 1 < args.length) {
+    formattedArgs[separatorIndex + 1] = replaceSensitiveValueWithRole(args[separatorIndex + 1]!, 'repository');
+    if (separatorIndex + 2 < args.length) {
+      formattedArgs[separatorIndex + 2] = replaceSensitiveValueWithRole(args[separatorIndex + 2]!, 'worktree');
+    }
+  }
+
+  return [replaceSensitiveValueWithRole(executable, 'git'), ...formattedArgs];
+}
+
+function replaceSensitiveValueWithRole(value: string, role: 'git' | 'gitdir' | 'repository' | 'worktree'): string {
+  return redactSensitiveText(value) === value ? value : `<${role}>`;
 }
 
 export function shellQuote(value: string): string {

--- a/test/unit/effect-command-format.property.test.ts
+++ b/test/unit/effect-command-format.property.test.ts
@@ -1,0 +1,93 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {formatShellCommand} from '../../src/effect/command.js';
+
+const windowsPathSegment = fc
+  .array(fc.constantFrom('a', 'B', '3', ' ', '_', '-'), {maxLength: 20, minLength: 1})
+  .map(characters => characters.join('').trim() || 'repo');
+
+const windowsPath = fc
+  .tuple(fc.constantFrom('C', 'D', 'E'), fc.array(windowsPathSegment, {maxLength: 5, minLength: 2}))
+  .map(([drive, segments]) => `${drive}:\\${segments.join('\\')}`);
+
+describe('git command formatting', () => {
+  it('uses role-specific placeholders for Windows share paths, including paths with spaces', () => {
+    const git = 'C:\\Program Files\\Git\\cmd\\git.exe';
+    const repository = 'C:\\Users\\alice\\Customer Repo';
+    const worktree = 'C:\\Users\\alice\\.threadnote\\share\\worktrees\\team';
+    const gitdir = 'C:\\Users\\alice\\.threadnote\\share\\gitdirs\\team.git';
+
+    expect(formatShellCommand(git, ['-C', worktree, 'status', '--short', '--branch'])).toBe(
+      "'<git>' -C '<worktree>' status --short --branch",
+    );
+    expect(
+      formatShellCommand(git, [
+        'clone',
+        '-c',
+        'core.symlinks=false',
+        `--separate-git-dir=${gitdir}`,
+        '--',
+        'https://example.com/team.git',
+        worktree,
+      ]),
+    ).toBe(
+      "'<git>' clone -c core.symlinks=false '--separate-git-dir=<gitdir>' -- https://example.com/team.git '<worktree>'",
+    );
+    expect(formatShellCommand(git, ['clone', '--', repository])).toBe("'<git>' clone -- '<repository>'");
+    expect(formatShellCommand(git, ['clone', '--', repository, worktree])).toBe(
+      "'<git>' clone -- '<repository>' '<worktree>'",
+    );
+  });
+
+  it('formats every recognized git path option without leaking its Windows path', () => {
+    const separatedOptions = [
+      {option: '-C', role: 'worktree'},
+      {option: '--git-dir', role: 'gitdir'},
+      {option: '--separate-git-dir', role: 'gitdir'},
+      {option: '--work-tree', role: 'worktree'},
+    ] as const;
+    const attachedOptions = separatedOptions.filter(({option}) => option.startsWith('--'));
+
+    fc.assert(
+      fc.property(windowsPath, windowsPath, (gitRoot, path) => {
+        const git = `${gitRoot}\\git.exe`;
+        for (const {option, role} of separatedOptions) {
+          expect(formatShellCommand(git, [option, path, 'status'])).toBe(`'<git>' ${option} '<${role}>' status`);
+        }
+        for (const {option, role} of attachedOptions) {
+          expect(formatShellCommand(git, [`${option}=${path}`, 'status'])).toBe(`'<git>' '${option}=<${role}>' status`);
+        }
+      }),
+      {numRuns: 100},
+    );
+  });
+
+  it('preserves clone operand roles without leaking generated Windows paths', () => {
+    fc.assert(
+      fc.property(windowsPath, windowsPath, windowsPath, (gitRoot, repository, worktree) => {
+        const git = `${gitRoot}\\git.exe`;
+        const sourceOnly = formatShellCommand(git, ['clone', '--', repository]);
+        const sourceAndDestination = formatShellCommand(git, ['clone', '--', repository, worktree]);
+
+        expect(sourceOnly).toBe("'<git>' clone -- '<repository>'");
+        expect(sourceAndDestination).toBe("'<git>' clone -- '<repository>' '<worktree>'");
+        for (const path of [git, repository, worktree]) {
+          expect(sourceOnly).not.toContain(path);
+          expect(sourceAndDestination).not.toContain(path);
+        }
+        expect(sourceOnly).not.toContain('<local-path>');
+        expect(sourceAndDestination).not.toContain('<local-path>');
+      }),
+      {numRuns: 100},
+    );
+  });
+
+  it('does not assign option roles to operands after the separator', () => {
+    expect(formatShellCommand('git', ['show', '--', '--git-dir=C:\\Users\\alice\\repo'])).toBe(
+      "git show -- '--git-dir=<local-path>'",
+    );
+    expect(formatShellCommand('git', ['show', 'clone', '--', 'C:\\Users\\alice\\repo'])).toBe(
+      "git show clone -- '<local-path>'",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- preserve semantic roles when sensitive git command paths are redacted: `<git>`, `<worktree>`, `<gitdir>`, and `<repository>`
- replace Windows paths containing spaces before shell quoting so no suffix remains visible
- keep non-sensitive values readable and retain the existing credential scrubber
- prepare the `4.6.3` patch release and curated release notes

## Validation

- dev-cycle completed in 2 iterations with 0 critical/important findings
- focused command/share/scrubber tests: 185 passed
- release/package/website boundary tests: 102 passed
- lint, Prettier, file-length checks, source TypeScript, test TypeScript, and site TypeScript passed
- exact `8ecc73db540c551ef8fb42ae04420c0cedb1d6ad` installed globally as `4.6.3-local.g8ecc73db540c551ef8fb42ae04420c0cedb1d6ad`
- installed CLI `share init --dry-run` smoke confirmed distinct `<gitdir>` and `<worktree>` output

The complete test suite is left to pull-request CI per repository policy.

## Property testing

A bounded Fast-check suite generates Windows paths and verifies every supported git path option form plus clone source/destination roles, full non-leakage, and separator behavior.
