### PR TITLE
fix: write POSIX launchers for Git Bash on Windows

### DIFF
--- a/.github/release-notes/v4.6.4.md
+++ b/.github/release-notes/v4.6.4.md
@@ -1,0 +1,12 @@
+## What's new
+
+Threadnote 4.6.4 makes `threadnote` work in Git Bash on Windows, so agent harnesses can find the CLI without the `.cmd` suffix.
+
+### Git Bash finds the Windows CLI
+
+Windows installs now write an extensionless `threadnote` launcher beside `threadnote.cmd`, and the same pair for
+`threadnote-mcp-server`, under `%LOCALAPPDATA%\Threadnote\bin`. Git Bash does not apply PATHEXT, so `threadnote`,
+`which threadnote`, and `command -v threadnote` failed while `threadnote.cmd` still worked.
+
+`threadnote repair` recreates a missing managed launcher. Existing Windows installs pick up the new files on the next
+`threadnote.cmd install`, `threadnote.cmd update`, or a rerun of the PowerShell installer.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,7 @@ jobs:
       - run: >-
           bun --bun vitest run
           test/unit/windows-support.test.ts
+          test/unit/command-shim.test.ts
           test/unit/effect-command.test.ts
           test/unit/effect-system.test.ts
           test/unit/local-ai.test.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ nearest checked-in guidance remain authoritative.
 
 ## Use Effect-aware test tooling
 
+When writing Effect code, inspect `@repos/effect/` for examples of idiomatic usage, tests, module structure, and API
+design. Treat it as the source of truth for Effect patterns.
+
 Threadnote application and runtime behavior is predominantly Effect code. Tests whose primary program under test is an
 `Effect` must use the Effect Vitest integration from `@effect/vitest` rather than wrapping the program with
 `Effect.runPromise`, `runEffect`, or another Promise bridge inside a plain async Vitest test.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,6 +52,12 @@ The absolute command printed at the end of installation also works immediately, 
 `"$HOME/.local/bin/threadnote" doctor --dry-run`. A custom `THREADNOTE_BIN_DIR` is never added to a profile
 automatically; add that directory to `PATH` yourself or use its absolute launcher path.
 
+On Windows, launchers live in `%LOCALAPPDATA%\Threadnote\bin` (or `THREADNOTE_BIN_DIR`). The installer writes
+`threadnote.cmd` for cmd.exe and PowerShell plus an extensionless `threadnote` for Git Bash and other MSYS shells, and
+the same pair for `threadnote-mcp-server`. Git Bash does not apply PATHEXT, so `threadnote` needs that extensionless
+file. `threadnote repair` recreates a missing managed launcher. After install, open a new terminal if `threadnote` is
+still not found; the installer also prepends the default bin directory to the Windows user `PATH`.
+
 ## Start and stop do not launch a service
 
 Threadnote 4 owns no daemon. `threadnote start` verifies the on-demand runtime and `threadnote stop` is a compatibility

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/scripts/install-local-standalone.ts
+++ b/scripts/install-local-standalone.ts
@@ -2,7 +2,13 @@ import {provideScriptLayer, ScriptError} from './effect/errors.js';
 import * as BunRuntime from '@effect/platform-bun/BunRuntime';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {Cause, Console, Crypto, Effect, Exit, FileSystem, Layer, Option, Path} from 'effect';
-import {commandLauncherPath, installCommandShim, renderCommandShim} from '../src/command-shim.js';
+import {
+  commandLauncherPath,
+  installCommandShim,
+  managedCommandLauncherKinds,
+  primaryCommandLauncherKind,
+  renderCommandShim,
+} from '../src/command-shim.js';
 import {CommandExecutor, runCommandEffect} from '../src/effect/command.js';
 import {captureConsole} from '../src/effect/console.js';
 import {sha256FileHex, sha256Hex} from '../src/effect/digest.js';
@@ -403,17 +409,26 @@ export const activateLocalStandaloneRelease = Effect.fn('developmentInstall.acti
           new ScriptError('The installed development executable did not complete doctor verification.'),
         );
       }
-      return yield* Effect.all([
-        captureFileSnapshot(fs, yield* commandLauncherPath('cli'), 'CLI launcher', 0o755),
-        captureFileSnapshot(fs, yield* commandLauncherPath('mcp'), 'MCP launcher', 0o755),
-        captureFileSnapshot(fs, path.join(installRoot, 'active-release.json'), 'active release pointer', 0o600),
-        captureFileSnapshot(
+      const managedFileSnapshots: LocalFileSnapshot[] = [];
+      for (const mode of ['cli', 'mcp'] as const) {
+        for (const kind of managedCommandLauncherKinds(system.platform)) {
+          managedFileSnapshots.push(
+            yield* captureFileSnapshot(fs, yield* commandLauncherPath(mode, kind), `${mode} ${kind} launcher`, 0o755),
+          );
+        }
+      }
+      managedFileSnapshots.push(
+        yield* captureFileSnapshot(fs, path.join(installRoot, 'active-release.json'), 'active release pointer', 0o600),
+      );
+      managedFileSnapshots.push(
+        yield* captureFileSnapshot(
           fs,
           path.join(installRoot, DEVELOPMENT_RUNTIME_OWNER_FILE),
           'development runtime owner',
           0o600,
         ),
-      ]);
+      );
+      return managedFileSnapshots;
     }).pipe(
       Effect.catchCause(validationCause =>
         promotedByThisInstall
@@ -831,22 +846,32 @@ const verifyLaunchers = Effect.fn('developmentInstall.verifyLaunchers')(function
   const system = yield* SystemInfo;
   let cliLauncher = '';
   for (const mode of ['cli', 'mcp'] as const) {
-    const [launcher, expected] = yield* Effect.all([commandLauncherPath(mode), renderCommandShim(releaseRoot, mode)]);
-    const actual = yield* fs.readFileString(launcher);
-    if (actual !== expected) {
-      return yield* Effect.fail(
-        new ScriptError(`The managed ${mode} launcher did not activate the development release.`),
-      );
-    }
-    if (system.platform !== 'win32') {
-      const info = yield* fs.stat(launcher);
-      if ((info.mode & 0o777) !== 0o755) yield* fs.chmod(launcher, 0o755);
-      const repaired = yield* fs.stat(launcher);
-      if ((repaired.mode & 0o777) !== 0o755) {
-        return yield* Effect.fail(new ScriptError(`The managed ${mode} launcher does not have safe executable mode.`));
+    for (const kind of managedCommandLauncherKinds(system.platform)) {
+      const [launcher, expected] = yield* Effect.all([
+        commandLauncherPath(mode, kind),
+        renderCommandShim(releaseRoot, mode, kind),
+      ]);
+      const actual = yield* fs.readFileString(launcher);
+      if (actual !== expected) {
+        return yield* Effect.fail(
+          new ScriptError(`The managed ${mode} ${kind} launcher did not activate the development release.`),
+        );
       }
+      if (system.platform !== 'win32') {
+        const info = yield* fs.stat(launcher);
+        if ((info.mode & 0o777) !== 0o755) yield* fs.chmod(launcher, 0o755);
+        const repaired = yield* fs.stat(launcher);
+        if ((repaired.mode & 0o777) !== 0o755) {
+          return yield* Effect.fail(
+            new ScriptError(`The managed ${mode} ${kind} launcher does not have safe executable mode.`),
+          );
+        }
+      }
+      if (mode === 'cli' && kind === primaryCommandLauncherKind(system.platform)) cliLauncher = launcher;
     }
-    if (mode === 'cli') cliLauncher = launcher;
+  }
+  if (cliLauncher === '') {
+    return yield* Effect.fail(new ScriptError('No primary CLI launcher was verified for this platform.'));
   }
   const version = yield* runCommandEffect(cliLauncher, ['--version'], {
     env: {...system.environment(), THREADNOTE_INSTALL_ROOT: installationRoot(path, system)},

--- a/src/command-shim.ts
+++ b/src/command-shim.ts
@@ -9,39 +9,54 @@ const THREADNOTE_COMMAND = 'threadnote';
 const THREADNOTE_MCP_COMMAND = 'threadnote-mcp-server';
 type LauncherMode = 'cli' | 'mcp';
 
-export function shouldManageCommandShim(_currentPlatform: NodeJS.Platform): boolean {
-  return true;
+export type CommandLauncherKind = 'cmd' | 'posix';
+
+export function managedCommandLauncherKinds(platform: NodeJS.Platform): readonly CommandLauncherKind[] {
+  return platform === 'win32' ? ['cmd', 'posix'] : ['posix'];
 }
 
-export const commandLauncherPath = Effect.fn('commandShim.launcherPath')((mode: LauncherMode = 'cli') =>
-  managedCommandShimPath(mode),
+export function primaryCommandLauncherKind(platform: NodeJS.Platform): CommandLauncherKind {
+  const [primary] = managedCommandLauncherKinds(platform);
+  return primary ?? 'posix';
+}
+
+/** Omitting `kind` selects the platform-primary launcher (`.cmd` on Windows). Pass `'posix'` for Git Bash. */
+export const commandLauncherPath = Effect.fn('commandShim.launcherPath')(
+  (mode: LauncherMode = 'cli', kind?: CommandLauncherKind) => managedCommandShimPath(mode, kind),
 );
 
 export const commandShimCheck = Effect.fn('commandShim.check')(function* () {
-  const shimPath = yield* managedCommandShimPath('cli');
-  const content = yield* readFileIfExists(shimPath);
-  if (content === undefined) {
-    return {
-      detail: `${shimPath} missing; repair will create it`,
-      name: 'threadnote launcher',
-      status: 'warn',
-    } satisfies DoctorCheck;
+  const system = yield* SystemInfo;
+  const paths: string[] = [];
+  for (const mode of ['cli', 'mcp'] as const) {
+    for (const kind of managedCommandLauncherKinds(system.platform)) {
+      const shimPath = yield* managedCommandShimPath(mode, kind);
+      const content = yield* readFileIfExists(shimPath);
+      if (content === undefined) {
+        return {
+          detail: `${shimPath} missing; repair will create it`,
+          name: 'threadnote launcher',
+          status: 'warn',
+        } satisfies DoctorCheck;
+      }
+      if (!isManagedCommandShim(content)) {
+        return {
+          detail: `${shimPath} exists but is not managed by Threadnote; repair will not overwrite it`,
+          name: 'threadnote launcher',
+          status: 'warn',
+        } satisfies DoctorCheck;
+      }
+      if (content !== (yield* renderCommandShim(undefined, mode, kind))) {
+        return {
+          detail: `${shimPath} points at a different standalone release; repair will rewrite it`,
+          name: 'threadnote launcher',
+          status: 'warn',
+        } satisfies DoctorCheck;
+      }
+      paths.push(shimPath);
+    }
   }
-  if (!isManagedCommandShim(content)) {
-    return {
-      detail: `${shimPath} exists but is not managed by Threadnote; repair will not overwrite it`,
-      name: 'threadnote launcher',
-      status: 'warn',
-    } satisfies DoctorCheck;
-  }
-  if (content !== (yield* renderCommandShim())) {
-    return {
-      detail: `${shimPath} points at a different standalone release; repair will rewrite it`,
-      name: 'threadnote launcher',
-      status: 'warn',
-    } satisfies DoctorCheck;
-  }
-  return {detail: shimPath, name: 'threadnote launcher', status: 'ok'} satisfies DoctorCheck;
+  return {detail: paths.join('; '), name: 'threadnote launcher', status: 'ok'} satisfies DoctorCheck;
 });
 
 export const installCommandShim = Effect.fn('commandShim.install')(function* (dryRun: boolean, releaseRoot?: string) {
@@ -81,10 +96,22 @@ const installLauncher = Effect.fn('commandShim.installLauncher')(function* (
   dryRun: boolean,
   releaseRoot?: string,
 ) {
+  const system = yield* SystemInfo;
+  for (const kind of managedCommandLauncherKinds(system.platform)) {
+    yield* installLauncherFile(mode, kind, dryRun, releaseRoot);
+  }
+});
+
+const installLauncherFile = Effect.fn('commandShim.installLauncherFile')(function* (
+  mode: LauncherMode,
+  kind: CommandLauncherKind,
+  dryRun: boolean,
+  releaseRoot?: string,
+) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
-  const shimPath = yield* managedCommandShimPath(mode);
+  const shimPath = yield* managedCommandShimPath(mode, kind);
   const existingContent = yield* readFileIfExists(shimPath);
   if (existingContent === undefined && (yield* pathEntryExists(fs, shimPath))) {
     yield* Console.warn(`WARN not overwriting unreadable command launcher: ${shimPath}`);
@@ -94,7 +121,7 @@ const installLauncher = Effect.fn('commandShim.installLauncher')(function* (
     yield* Console.warn(`WARN not overwriting unmanaged command launcher: ${shimPath}`);
     return;
   }
-  const content = yield* renderCommandShim(releaseRoot, mode);
+  const content = yield* renderCommandShim(releaseRoot, mode, kind);
   if (existingContent === content) {
     yield* Console.log(`Command launcher already current: ${shimPath}`);
     return;
@@ -115,31 +142,36 @@ const installLauncher = Effect.fn('commandShim.installLauncher')(function* (
 });
 
 export const removeCommandShim = Effect.fn('commandShim.remove')(function* (dryRun: boolean) {
+  const system = yield* SystemInfo;
   for (const mode of ['cli', 'mcp'] as const) {
-    const shimPath = yield* managedCommandShimPath(mode);
-    const content = yield* readFileIfExists(shimPath);
-    if (content === undefined) {
-      yield* Console.log(`Command launcher already absent: ${shimPath}`);
-      continue;
+    for (const kind of managedCommandLauncherKinds(system.platform)) {
+      const shimPath = yield* managedCommandShimPath(mode, kind);
+      const content = yield* readFileIfExists(shimPath);
+      if (content === undefined) {
+        yield* Console.log(`Command launcher already absent: ${shimPath}`);
+        continue;
+      }
+      if (!isManagedCommandShim(content)) {
+        yield* Console.warn(`WARN not removing unmanaged command launcher: ${shimPath}`);
+        continue;
+      }
+      yield* removePath(shimPath, 'command launcher', dryRun);
     }
-    if (!isManagedCommandShim(content)) {
-      yield* Console.warn(`WARN not removing unmanaged command launcher: ${shimPath}`);
-      continue;
-    }
-    yield* removePath(shimPath, 'command launcher', dryRun);
   }
 });
 
 export const renderCommandShim = Effect.fn('commandShim.render')(function* (
   releaseRoot?: string,
   mode: LauncherMode = 'cli',
+  kind?: CommandLauncherKind,
 ) {
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
   const root = releaseRoot ?? (yield* toolRoot());
   const executable = path.join(root, system.platform === 'win32' ? 'threadnote.exe' : 'threadnote');
+  const resolvedKind = kind ?? primaryCommandLauncherKind(system.platform);
   const modeArguments = mode === 'mcp' ? ['mcp-broker'] : [];
-  if (system.platform === 'win32') {
+  if (resolvedKind === 'cmd') {
     const command = [cmdQuote(executable), ...modeArguments, '%*'].join(' ');
     return [
       '@echo off',
@@ -151,11 +183,12 @@ export const renderCommandShim = Effect.fn('commandShim.render')(function* (
       '',
     ].join('\r\n');
   }
+  const posixExecutable = system.platform === 'win32' ? executable.replaceAll('\\', '/') : executable;
   return [
     '#!/usr/bin/env sh',
     `# ${SHIM_MARKER}`,
     'set -eu',
-    `THREADNOTE_ENTRY=${shellQuote(executable)}`,
+    `THREADNOTE_ENTRY=${shellQuote(posixExecutable)}`,
     'if [ ! -x "$THREADNOTE_ENTRY" ]; then',
     '  echo "Threadnote standalone executable is missing: $THREADNOTE_ENTRY" >&2',
     '  echo "Reinstall Threadnote from a stable or beta GitHub release." >&2',
@@ -179,7 +212,10 @@ function isManagedCommandShim(content: string): boolean {
   );
 }
 
-const managedCommandShimPath = Effect.fn('commandShim.path')(function* (mode: LauncherMode) {
+const managedCommandShimPath = Effect.fn('commandShim.path')(function* (
+  mode: LauncherMode,
+  kind?: CommandLauncherKind,
+) {
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
   const environment = system.environment();
@@ -191,7 +227,8 @@ const managedCommandShimPath = Effect.fn('commandShim.path')(function* (mode: La
       ? path.join(localAppData, 'Threadnote', 'bin')
       : yield* expandPath('~/.local/bin');
   const command = mode === 'mcp' ? THREADNOTE_MCP_COMMAND : THREADNOTE_COMMAND;
-  return path.join(binDirectory, system.platform === 'win32' ? `${command}.cmd` : command);
+  const resolvedKind = kind ?? primaryCommandLauncherKind(system.platform);
+  return path.join(binDirectory, resolvedKind === 'cmd' ? `${command}.cmd` : command);
 });
 
 function cmdQuote(value: string): string {

--- a/test/ci/ci-scopes.ts
+++ b/test/ci/ci-scopes.ts
@@ -100,7 +100,7 @@ function isQualityPath(path: string): boolean {
 function isReleaseTestPath(path: string): boolean {
   return (
     path.startsWith('test/e2e/') ||
-    /^test\/(?:integration|unit)\/(?:build-code-sanitization|bun-package-contract|development-runtime|effect-system|installations|legacy-installation|lifecycle|process-diagnostics|release_notes|update|windows-support)/u.test(
+    /^test\/(?:integration|unit)\/(?:build-code-sanitization|bun-package-contract|command-shim|development-runtime|effect-system|installations|legacy-installation|lifecycle|process-diagnostics|release_notes|update|windows-support)/u.test(
       path,
     ) ||
     path === 'vitest.e2e.config.ts' ||

--- a/test/e2e/local-bins.e2e.ts
+++ b/test/e2e/local-bins.e2e.ts
@@ -41,11 +41,16 @@ let initialVectorRevision: string;
 let installOutput: string;
 let installedFiles: string[];
 
-function installedLauncher(mode: 'cli' | 'mcp' = 'cli'): string {
+function installedLauncher(
+  mode: 'cli' | 'mcp' = 'cli',
+  kind: 'cmd' | 'posix' = process.platform === 'win32' ? 'cmd' : 'posix',
+): string {
   const command = mode === 'mcp' ? 'threadnote-mcp-server' : 'threadnote';
-  return process.platform === 'win32'
-    ? join(userHome, 'AppData', 'Local', 'Threadnote', 'bin', `${command}.cmd`)
-    : join(userHome, '.local', 'bin', command);
+  const binDirectory =
+    process.platform === 'win32'
+      ? join(userHome, 'AppData', 'Local', 'Threadnote', 'bin')
+      : join(userHome, '.local', 'bin');
+  return join(binDirectory, kind === 'cmd' ? `${command}.cmd` : command);
 }
 
 beforeAll(async () => {
@@ -126,6 +131,15 @@ describe('built self-contained distribution', () => {
     expect(await readFile(commandShim, 'utf8')).toContain(
       process.platform === 'win32' ? 'THREADNOTE_CALLER_CWD' : 'Threadnote standalone executable is missing',
     );
+    if (process.platform === 'win32') {
+      const posixShim = installedLauncher('cli', 'posix');
+      expect(installOutput).toContain(`Wrote command launcher: ${posixShim}`);
+      const posixContent = await readFile(posixShim, 'utf8');
+      expect(posixContent.startsWith('#!/usr/bin/env sh\n')).toBe(true);
+      expect(posixContent).toContain('threadnote.exe');
+      expect(posixContent).not.toContain('\r');
+      expect(posixContent).not.toContain('\\');
+    }
   });
 
   it('ships the Manager UI as a classic browser bundle', async () => {

--- a/test/e2e/local-bins.e2e.ts
+++ b/test/e2e/local-bins.e2e.ts
@@ -791,7 +791,7 @@ describe('built self-contained distribution', () => {
     expect(output).toMatch(new RegExp(`OK\\s+embedding model: ${coreEmbeddingModelId}`));
     expect(output).toMatch(/OK\s+vector recall index:/);
     expect(output).toMatch(/OK\s+native code graph:/);
-    expect(output).not.toMatch(/(?:OK|WARN)\s+.*MCP/i);
+    expect(output).not.toMatch(/(?:OK|WARN)\s+(?:MCP configuration|(?:codex|claude|cursor|copilot) MCP):/i);
     expect(output).not.toMatch(/agent integration|user instructions|Threadnote skill/i);
   });
 

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -219,7 +219,7 @@ windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release
       if (process.env.GITHUB_ACTIONS === 'true') {
         expect(gitBash, 'Git Bash is required on Windows CI to cover issue 347').toBeDefined();
       } else if (gitBash === undefined) {
-        console.warn('Git Bash not found; skipping Git Bash launcher execution for issue 347.');
+        process.stderr.write('Git Bash not found; skipping Git Bash launcher execution for issue 347.\n');
       }
       if (gitBash !== undefined) {
         const gitBashVersion = await execute(gitBash, [posixLauncher, '--version'], {

--- a/test/e2e/windows-install.windows.e2e.ts
+++ b/test/e2e/windows-install.windows.e2e.ts
@@ -205,6 +205,55 @@ windowsIt('PowerShell bootstrap verifies and installs the standalone Bun release
         },
       });
       expect(launcherVersion.stdout).toContain(packageManifest.version);
+      const posixLauncher = join(binRoot, 'threadnote');
+      const posixMcpLauncher = join(binRoot, 'threadnote-mcp-server');
+      const posixLauncherContent = await readFile(posixLauncher, 'utf8');
+      expect(posixLauncherContent.startsWith('#!/usr/bin/env sh\n')).toBe(true);
+      expect(posixLauncherContent).toContain('threadnote.exe');
+      expect(posixLauncherContent).not.toContain('\r');
+      expect(posixLauncherContent).not.toContain('\\');
+      const posixMcpLauncherContent = await readFile(posixMcpLauncher, 'utf8');
+      expect(posixMcpLauncherContent.startsWith('#!/usr/bin/env sh\n')).toBe(true);
+      expect(posixMcpLauncherContent).toContain('mcp-broker');
+      const gitBash = await windowsGitBashExecutable();
+      if (process.env.GITHUB_ACTIONS === 'true') {
+        expect(gitBash, 'Git Bash is required on Windows CI to cover issue 347').toBeDefined();
+      } else if (gitBash === undefined) {
+        console.warn('Git Bash not found; skipping Git Bash launcher execution for issue 347.');
+      }
+      if (gitBash !== undefined) {
+        const gitBashVersion = await execute(gitBash, [posixLauncher, '--version'], {
+          env: {
+            ...process.env,
+            HOME: userHome,
+            LOCALAPPDATA: join(userHome, 'AppData', 'Local'),
+            THREADNOTE_HOME: join(userHome, '.threadnote'),
+            USERPROFILE: userHome,
+          },
+        });
+        expect(gitBashVersion.stdout).toContain(packageManifest.version);
+        const gitBashWhich = await execute(
+          gitBash,
+          ['-c', 'command -v threadnote && command -v threadnote-mcp-server'],
+          {
+            env: {
+              ...process.env,
+              HOME: userHome,
+              LOCALAPPDATA: join(userHome, 'AppData', 'Local'),
+              PATH: `${binRoot}${delimiter}${process.env.PATH ?? ''}`,
+              THREADNOTE_HOME: join(userHome, '.threadnote'),
+              USERPROFILE: userHome,
+            },
+          },
+        );
+        const resolved = gitBashWhich.stdout
+          .trim()
+          .split(/\r?\n/u)
+          .map(line => line.trim());
+        expect(gitBashWhich.stdout).not.toContain('.cmd');
+        expect(resolved[0]).toMatch(/\/threadnote$/);
+        expect(resolved[1]).toMatch(/\/threadnote-mcp-server$/);
+      }
       const transport = new StdioClientTransport({
         args: ['/d', '/c', join(binRoot, 'threadnote-mcp-server.cmd')],
         command: join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'cmd.exe'),
@@ -318,4 +367,23 @@ function expectInstallerFailure(
 
 function boundedFailureOutput(output: string): string {
   return output.length <= failureOutputLimit ? output : `${output.slice(0, failureOutputLimit)}\n[output truncated]`;
+}
+
+async function windowsGitBashExecutable(): Promise<string | undefined> {
+  const candidates = [
+    join(process.env.ProgramFiles ?? 'C:\\Program Files', 'Git', 'bin', 'bash.exe'),
+    join(process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'),
+    Bun.which('bash') ?? undefined,
+  ];
+  for (const candidate of candidates) {
+    if (candidate === undefined) continue;
+    try {
+      await stat(candidate);
+    } catch {
+      continue;
+    }
+    const identity = await execute(candidate, ['-c', 'uname -s'], {timeout: 10_000}).catch(() => undefined);
+    if (identity !== undefined && /^(MINGW|MSYS)/u.test(identity.stdout.trim())) return candidate;
+  }
+  return undefined;
 }

--- a/test/unit/ci-scopes.property.test.ts
+++ b/test/unit/ci-scopes.property.test.ts
@@ -86,6 +86,7 @@ describe('CI changed-path scope properties', () => {
 
   it('maps representative repository paths to the expected expensive scopes', () => {
     expect(enabledScopes(['test/unit/utils.test.ts'])).toEqual(['code']);
+    expect(enabledScopes(['test/unit/command-shim.test.ts'])).toEqual(['code', 'release', 'windows']);
     expect(enabledScopes(['src/installations.ts'])).toEqual(['code', 'release', 'windows']);
     expect(enabledScopes(['src/recall/index.ts'])).toEqual(['code', 'quality', 'release', 'windows']);
     expect(enabledScopes(['src/context_brief/citation_validation.ts'])).toEqual([

--- a/test/unit/command-shim.test.ts
+++ b/test/unit/command-shim.test.ts
@@ -1,0 +1,344 @@
+import {it as effectIt} from '@effect/vitest';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {Effect, FileSystem, Path} from 'effect';
+import fc from 'fast-check';
+import {describe, expect} from 'vitest';
+import {
+  commandLauncherPath,
+  commandShimCheck,
+  installCommandShim,
+  managedCommandLauncherKinds,
+  primaryCommandLauncherKind,
+  removeCommandShim,
+  renderCommandShim,
+} from '../../src/command-shim.js';
+import {captureConsole} from '../../src/effect/console.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo, type SystemInfoShape} from '../../src/effect/system.js';
+
+describe('Windows Git Bash command launchers', () => {
+  effectIt.effect('installs cmd and extensionless POSIX launchers for CLI and MCP on Windows', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const root = yield* FileSystem.FileSystem.pipe(
+          Effect.flatMap(fs => fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shims-'})),
+        );
+        const {releaseRoot, testSystem} = yield* windowsShimFixture(root);
+        const installed = yield* captureConsole(installCommandShim(false, releaseRoot)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+
+        expect(managedCommandLauncherKinds('win32')).toEqual(['cmd', 'posix']);
+        expect(managedCommandLauncherKinds('linux')).toEqual(['posix']);
+        expect(managedCommandLauncherKinds('darwin')).toEqual(['posix']);
+        expect(primaryCommandLauncherKind('win32')).toBe('cmd');
+        expect(primaryCommandLauncherKind('linux')).toBe('posix');
+        expect(primaryCommandLauncherKind('darwin')).toBe('posix');
+        expect(yield* commandLauncherPath('cli').pipe(Effect.provideService(SystemInfo, testSystem))).toMatch(
+          /threadnote\.cmd$/,
+        );
+        expect(yield* commandLauncherPath('mcp').pipe(Effect.provideService(SystemInfo, testSystem))).toMatch(
+          /threadnote-mcp-server\.cmd$/,
+        );
+
+        const files = {
+          cliCmd: yield* readLauncher(testSystem, 'cli', 'cmd'),
+          cliPosix: yield* readLauncher(testSystem, 'cli', 'posix'),
+          mcpCmd: yield* readLauncher(testSystem, 'mcp', 'cmd'),
+          mcpPosix: yield* readLauncher(testSystem, 'mcp', 'posix'),
+        };
+        expect(installed.output).toContain(`Wrote command launcher: ${files.cliCmd.path}`);
+        expect(installed.output).toContain(`Wrote command launcher: ${files.cliPosix.path}`);
+        expect(installed.output).toContain(`Wrote command launcher: ${files.mcpCmd.path}`);
+        expect(installed.output).toContain(`Wrote command launcher: ${files.mcpPosix.path}`);
+        expect(path.basename(files.cliPosix.path)).toBe('threadnote');
+        expect(path.basename(files.mcpPosix.path)).toBe('threadnote-mcp-server');
+        expect(files.cliCmd.content).toBe(yield* renderFor(testSystem, releaseRoot, 'cli', 'cmd'));
+        expect(files.cliPosix.content).toBe(yield* renderFor(testSystem, releaseRoot, 'cli', 'posix'));
+        expect(files.mcpCmd.content).toBe(yield* renderFor(testSystem, releaseRoot, 'mcp', 'cmd'));
+        expect(files.mcpPosix.content).toBe(yield* renderFor(testSystem, releaseRoot, 'mcp', 'posix'));
+        expect(files.cliPosix.content.startsWith('#!/usr/bin/env sh\n')).toBe(true);
+        expect(files.cliPosix.content).toContain('THREADNOTE_CALLER_CWD="$PWD"');
+        expect(files.cliPosix.content).toContain('export THREADNOTE_CALLER_CWD');
+        expect(files.cliPosix.content).toContain('exec "$THREADNOTE_ENTRY" "$@"');
+        expect(files.mcpPosix.content).toContain('exec "$THREADNOTE_ENTRY" mcp-broker "$@"');
+        expect(files.cliCmd.content.startsWith('@echo off\r\n')).toBe(true);
+        expect(files.cliCmd.content).toContain('%*');
+
+        const repeat = yield* captureConsole(installCommandShim(false, releaseRoot)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(repeat.output).toContain(`Command launcher already current: ${files.cliPosix.path}`);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('doctor warns when the Git Bash launcher is missing beside a current cmd launcher', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shim-doctor-'});
+        const {testSystem} = yield* windowsShimFixture(root);
+        const cmdPath = yield* commandLauncherPath('cli', 'cmd').pipe(Effect.provideService(SystemInfo, testSystem));
+        const posixPath = yield* commandLauncherPath('cli', 'posix').pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        yield* fs.writeFileString(
+          cmdPath,
+          yield* renderCommandShim(undefined, 'cli', 'cmd').pipe(Effect.provideService(SystemInfo, testSystem)),
+          {mode: 0o755},
+        );
+
+        const check = yield* commandShimCheck().pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(check.status).toBe('warn');
+        expect(check.detail).toBe(`${posixPath} missing; repair will create it`);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('doctor warns when the cmd launcher is missing beside a current Git Bash launcher', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shim-doctor-cmd-'});
+        const {testSystem} = yield* windowsShimFixture(root);
+        const cmdPath = yield* commandLauncherPath('cli', 'cmd').pipe(Effect.provideService(SystemInfo, testSystem));
+        const posixPath = yield* commandLauncherPath('cli', 'posix').pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        yield* fs.writeFileString(
+          posixPath,
+          yield* renderCommandShim(undefined, 'cli', 'posix').pipe(Effect.provideService(SystemInfo, testSystem)),
+          {mode: 0o755},
+        );
+
+        const check = yield* commandShimCheck().pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(check.status).toBe('warn');
+        expect(check.detail).toBe(`${cmdPath} missing; repair will create it`);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('doctor warns when the Git Bash launcher points at a different standalone release', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shim-stale-'});
+        const {testSystem} = yield* windowsShimFixture(root);
+        const cmdPath = yield* commandLauncherPath('cli', 'cmd').pipe(Effect.provideService(SystemInfo, testSystem));
+        const posixPath = yield* commandLauncherPath('cli', 'posix').pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        yield* fs.writeFileString(
+          cmdPath,
+          yield* renderCommandShim(undefined, 'cli', 'cmd').pipe(Effect.provideService(SystemInfo, testSystem)),
+          {mode: 0o755},
+        );
+        yield* fs.writeFileString(
+          posixPath,
+          yield* renderCommandShim(path.join(root, 'stale-release'), 'cli', 'posix').pipe(
+            Effect.provideService(SystemInfo, testSystem),
+          ),
+          {mode: 0o755},
+        );
+
+        const check = yield* commandShimCheck().pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(check.status).toBe('warn');
+        expect(check.detail).toBe(`${posixPath} points at a different standalone release; repair will rewrite it`);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('doctor reports all Windows CLI and MCP launchers current after a default install', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const root = yield* FileSystem.FileSystem.pipe(
+          Effect.flatMap(fs => fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shim-doctor-ok-'})),
+        );
+        const {testSystem} = yield* windowsShimFixture(root);
+        yield* installCommandShim(false).pipe(Effect.provideService(SystemInfo, testSystem));
+        const cliCmd = yield* commandLauncherPath('cli', 'cmd').pipe(Effect.provideService(SystemInfo, testSystem));
+        const cliPosix = yield* commandLauncherPath('cli', 'posix').pipe(Effect.provideService(SystemInfo, testSystem));
+        const mcpCmd = yield* commandLauncherPath('mcp', 'cmd').pipe(Effect.provideService(SystemInfo, testSystem));
+        const mcpPosix = yield* commandLauncherPath('mcp', 'posix').pipe(Effect.provideService(SystemInfo, testSystem));
+        const check = yield* commandShimCheck().pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(check.status).toBe('ok');
+        expect(check.detail).toBe(`${cliCmd}; ${cliPosix}; ${mcpCmd}; ${mcpPosix}`);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('doctor warns when the Git Bash MCP launcher is missing beside current CLI launchers', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shim-doctor-mcp-'});
+        const {testSystem} = yield* windowsShimFixture(root);
+        yield* installCommandShim(false).pipe(Effect.provideService(SystemInfo, testSystem));
+        const mcpPosix = yield* commandLauncherPath('mcp', 'posix').pipe(Effect.provideService(SystemInfo, testSystem));
+        yield* fs.remove(mcpPosix);
+        const check = yield* commandShimCheck().pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(check.status).toBe('warn');
+        expect(check.detail).toBe(`${mcpPosix} missing; repair will create it`);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('does not overwrite an unmanaged Git Bash launcher and still writes the cmd launcher', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shim-unmanaged-'});
+        const {releaseRoot, testSystem} = yield* windowsShimFixture(root);
+        const posixPath = yield* commandLauncherPath('cli', 'posix').pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        const unmanaged = '#!/usr/bin/env bash\necho "Generated by threadnote is documentation, not ownership"\n';
+        yield* fs.writeFileString(posixPath, unmanaged, {mode: 0o755});
+
+        const installed = yield* captureConsole(installCommandShim(false, releaseRoot)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(installed.output).toContain(`WARN not overwriting unmanaged command launcher: ${posixPath}`);
+        expect(yield* fs.readFileString(posixPath)).toBe(unmanaged);
+        const cmd = yield* readLauncher(testSystem, 'cli', 'cmd');
+        expect(cmd.content).toBe(yield* renderFor(testSystem, releaseRoot, 'cli', 'cmd'));
+        expect(path.basename(posixPath)).toBe('threadnote');
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('removes a managed Git Bash launcher without touching an unmanaged cmd launcher', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shim-mixed-remove-'});
+        const {releaseRoot, testSystem} = yield* windowsShimFixture(root);
+        const cmdPath = yield* commandLauncherPath('cli', 'cmd').pipe(Effect.provideService(SystemInfo, testSystem));
+        const posixPath = yield* commandLauncherPath('cli', 'posix').pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        const unmanaged = '@echo off\r\necho unmanaged\r\n';
+        yield* fs.writeFileString(cmdPath, unmanaged, {mode: 0o755});
+        yield* installCommandShim(false, releaseRoot).pipe(Effect.provideService(SystemInfo, testSystem));
+        const removed = yield* captureConsole(removeCommandShim(false)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+
+        expect(removed.output).toContain(`WARN not removing unmanaged command launcher: ${cmdPath}`);
+        expect(yield* fs.readFileString(cmdPath)).toBe(unmanaged);
+        expect(yield* fs.exists(posixPath)).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('removes managed Windows cmd and POSIX launchers together', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-win-shim-remove-'});
+        const {releaseRoot, testSystem} = yield* windowsShimFixture(root);
+        yield* installCommandShim(false, releaseRoot).pipe(Effect.provideService(SystemInfo, testSystem));
+        yield* removeCommandShim(false).pipe(Effect.provideService(SystemInfo, testSystem));
+        for (const mode of ['cli', 'mcp'] as const) {
+          for (const kind of managedCommandLauncherKinds('win32')) {
+            const launcher = yield* commandLauncherPath(mode, kind).pipe(Effect.provideService(SystemInfo, testSystem));
+            expect(yield* fs.exists(launcher)).toBe(false);
+          }
+        }
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect.prop(
+    'Windows POSIX shims are LF shebang scripts that exec the same release exe as the cmd launcher',
+    {
+      mode: fc.constantFrom('cli' as const, 'mcp' as const),
+      variant: fc.constantFrom('plain' as const, 'spaced' as const),
+      version: fc.stringMatching(/^[0-9]+\.[0-9]+\.[0-9]+$/),
+    },
+    ({mode, variant, version}) =>
+      Effect.gen(function* () {
+        const baseSystem = yield* SystemInfo;
+        const releaseRoot =
+          variant === 'plain'
+            ? `C:\\Threadnote\\versions\\${version}`
+            : `C:\\Users\\John Doe\\Threadnote\\versions\\${version}`;
+        const testSystem = SystemInfo.of({...baseSystem, platform: 'win32'});
+        const [cmd, posix] = yield* Effect.all([
+          renderCommandShim(releaseRoot, mode, 'cmd'),
+          renderCommandShim(releaseRoot, mode, 'posix'),
+        ]).pipe(Effect.provideService(SystemInfo, testSystem));
+        const posixEntry = posixEntryPath(posix);
+        const cmdEntry = cmdEntryPath(cmd);
+        expect(cmd.includes('\r\n')).toBe(true);
+        expect(posix.includes('\r')).toBe(false);
+        expect(posix.includes('\\')).toBe(false);
+        expect(posix.startsWith('#!/usr/bin/env sh\n')).toBe(true);
+        expect(posix).toContain('THREADNOTE_CALLER_CWD="$PWD"');
+        expect(posixEntry).toBe(cmdEntry.replaceAll('\\', '/'));
+        expect(posixEntry).toContain(`/${version}/threadnote.exe`);
+        expect(cmdEntry.replaceAll('\\', '/')).toContain(`/${version}/threadnote.exe`);
+        if (variant === 'plain') {
+          expect(posix).toContain(`THREADNOTE_ENTRY=C:/Threadnote/versions/${version}/threadnote.exe`);
+        } else {
+          expect(posix).toContain(`THREADNOTE_ENTRY='C:/Users/John Doe/Threadnote/versions/${version}/threadnote.exe'`);
+        }
+        expect(posix).toContain('exec "$THREADNOTE_ENTRY"');
+        if (mode === 'mcp') {
+          expect(posix).toContain('mcp-broker');
+          expect(cmd).toContain('mcp-broker');
+        } else {
+          expect(posix).not.toContain('mcp-broker');
+          expect(cmd).not.toContain('mcp-broker');
+        }
+      }).pipe(provideTestLayer(ApplicationLayer)),
+    {fastCheck: {numRuns: 40}},
+  );
+});
+
+const windowsShimFixture = Effect.fn('test.windowsShimFixture')(function* (root: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const baseSystem = yield* SystemInfo;
+  const binDirectory = path.join(root, 'bin');
+  const releaseRoot = path.join(root, 'versions', '4.6.3');
+  yield* fs.makeDirectory(binDirectory, {recursive: true});
+  const testSystem = SystemInfo.of({
+    ...baseSystem,
+    environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: binDirectory}),
+    platform: 'win32',
+  });
+  return {binDirectory, releaseRoot, testSystem};
+});
+
+const renderFor = (testSystem: SystemInfoShape, releaseRoot: string, mode: 'cli' | 'mcp', kind: 'cmd' | 'posix') =>
+  renderCommandShim(releaseRoot, mode, kind).pipe(Effect.provideService(SystemInfo, testSystem));
+
+const readLauncher = Effect.fn('test.readLauncher')(function* (
+  testSystem: SystemInfoShape,
+  mode: 'cli' | 'mcp',
+  kind: 'cmd' | 'posix',
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const launcherPath = yield* commandLauncherPath(mode, kind).pipe(Effect.provideService(SystemInfo, testSystem));
+  return {content: yield* fs.readFileString(launcherPath), path: launcherPath};
+});
+
+function posixEntryPath(posix: string): string {
+  const match = /^THREADNOTE_ENTRY=(.*)$/m.exec(posix);
+  expect(match?.[1]).toEqual(expect.any(String));
+  const raw = match?.[1] ?? '';
+  return raw.startsWith("'") && raw.endsWith("'") ? raw.slice(1, -1).replaceAll("'\"'\"'", "'") : raw;
+}
+
+function cmdEntryPath(cmd: string): string {
+  const line = cmd.split(/\r?\n/u).find(candidate => candidate.includes('threadnote.exe'));
+  expect(line).toEqual(expect.any(String));
+  const match = /^"([^"]*)"/u.exec(line ?? '');
+  expect(match?.[1]).toEqual(expect.any(String));
+  return (match?.[1] ?? '').replaceAll('%%', '%').replaceAll('""', '"');
+}

--- a/test/unit/development-runtime.test.ts
+++ b/test/unit/development-runtime.test.ts
@@ -1488,7 +1488,7 @@ describe('exact-head development runtime', () => {
         }),
       ).pipe(provideTestLayer(ApplicationLayer));
 
-      expect(result.failure).toContain('managed mcp launcher did not activate');
+      expect(result.failure).toContain('managed mcp posix launcher did not activate');
       expect(result.activePointer).toBe(result.priorPointer);
       expect(result.cli).toBe(result.priorCli);
       expect(result.mcp).toBe('unmanaged launcher\n');


### PR DESCRIPTION
## Summary

- write an extensionless POSIX `threadnote` launcher beside `threadnote.cmd` on Windows so Git Bash can resolve the CLI without PATHEXT
- do the same for `threadnote-mcp-server`; MCP hosts still spawn via `cmd.exe` and `.cmd`
- doctor now checks both CLI and MCP launcher kinds; `threadnote repair` recreates a missing managed launcher
- prepare the `4.6.4` patch release and curated release notes
- point Effect work in `AGENTS.md` at `@repos/effect/`

Fixes https://github.com/Kashkovsky/threadnote/issues/347

## Validation

- focused command-shim, lifecycle, development-runtime, and ci-scopes tests passed
- lint, Prettier, file-length checks, source TypeScript, test TypeScript, and site TypeScript passed on commit
- Windows Git Bash e2e is left to pull-request CI on `windows-latest`

The complete test suite is left to pull-request CI per repository policy.

## Property testing

A bounded Fast-check suite renders cmd and POSIX shims from Windows-shaped release roots, including spaced paths, and asserts they exec the same `threadnote.exe` with LF shebang scripts and no backslashes in the POSIX entry.