### PR TITLE
Keep identity-alias relations on share_publish

### DIFF
--- a/.github/release-notes/v4.6.5.md
+++ b/.github/release-notes/v4.6.5.md
@@ -1,0 +1,11 @@
+## What's new
+
+Threadnote 4.6.5 keeps stable memory relations when you publish a durable note to a team share.
+
+### Shared publish keeps identity aliases
+
+`share_publish` no longer strips `relation:` headers that already point at
+`threadnote://memory/tn_...` aliases. Teammates can follow those edges after
+publish the same way a later shared replace already did. Local `threadnote://user/...`
+projection URIs, candidate IDs, and other personal provenance are still removed
+because they do not resolve on another machine.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadnote",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "type": "module",
   "description": "Shared local context and handoffs for development agents",
   "license": "AGPL-3.0-or-later",

--- a/src/mcp/server/memory.ts
+++ b/src/mcp/server/memory.ts
@@ -19,7 +19,7 @@ import {
   applyScrubber,
   sharedMemoryUriParts,
   sharedTeamNameForUri,
-  stripPersonalProvenance,
+  stripPersonalProvenanceForSharedPublication,
   resourceUriToWorktreeRelative,
   setMemoryVisibility,
   sharedUriFor,
@@ -872,7 +872,7 @@ const writeSharedMemoryReplacement = Effect.fn('mcp_server.writeSharedMemoryRepl
       `Refusing to update shared memory ${targetUri}: ${memoryCodeCitationSharingBlockerMessage(citationBlocker)}.`,
     );
   }
-  const scrub = applyScrubber(stripPersonalProvenance(rawMemory, {preserveStableMemoryRelations: true}), {
+  const scrub = applyScrubber(stripPersonalProvenanceForSharedPublication(rawMemory), {
     redact: false,
   });
   if (scrub.blocker) {

--- a/src/mcp/server/share.ts
+++ b/src/mcp/server/share.ts
@@ -10,7 +10,7 @@ import {
   applyScrubber,
   setMemoryVisibility,
   sharedUriFor,
-  stripPersonalProvenance,
+  stripPersonalProvenanceForSharedPublication,
   resourceUriToWorktreeRelative,
   writeMemoryFile,
   writeSharedWorktreeFile,
@@ -207,7 +207,7 @@ export function runSharePublishTool(config: RuntimeConfig, sourceUri: string, op
         `Refusing to publish ${sourceUri}: ${memoryCodeCitationSharingBlockerMessage(citationBlocker)}.`,
       );
     }
-    const stripped = setMemoryVisibility(stripPersonalProvenance(sourceText), 'shared');
+    const stripped = setMemoryVisibility(stripPersonalProvenanceForSharedPublication(sourceText), 'shared');
     const scrub = applyScrubber(stripped, {redact: options.redact === true});
 
     if (options.preview === true) {
@@ -260,7 +260,10 @@ export function runSharePublishTool(config: RuntimeConfig, sourceUri: string, op
               return {blocker: currentCitationBlocker, kind: 'citation_blocked' as const};
             }
             const currentScrub = applyScrubber(
-              setMemoryVisibility(stripPersonalProvenance(canonicalMemoryDocumentContent(currentSourceText)), 'shared'),
+              setMemoryVisibility(
+                stripPersonalProvenanceForSharedPublication(canonicalMemoryDocumentContent(currentSourceText)),
+                'shared',
+              ),
               {
                 redact: options.redact === true,
               },

--- a/src/memory/commands.ts
+++ b/src/memory/commands.ts
@@ -170,7 +170,7 @@ import {
   resolveTeam,
   sharedMemoryUriParts,
   sharedTeamNameForUri,
-  stripPersonalProvenance,
+  stripPersonalProvenanceForSharedPublication,
   resourceUriToWorktreeRelative,
   writeMemoryFile,
   writeMemoryFileChecked,
@@ -1744,7 +1744,7 @@ const storeSharedMemoryReplacement = Effect.fn('memory.storeSharedMemoryReplacem
       ),
     );
   }
-  const scrub = applyScrubber(stripPersonalProvenance(rawMemory, {preserveStableMemoryRelations: true}), {
+  const scrub = applyScrubber(stripPersonalProvenanceForSharedPublication(rawMemory), {
     redact: false,
   });
   if (scrub.blocker) {

--- a/src/share/artifact_publish.ts
+++ b/src/share/artifact_publish.ts
@@ -81,7 +81,7 @@ import {
   rm,
   setMemoryVisibility,
   sharedUriFor,
-  stripPersonalProvenance,
+  stripPersonalProvenanceForSharedPublication,
   workfileToResourceUri,
   writeFile,
   writeMemoryFile,
@@ -116,7 +116,7 @@ export const runSharePublish = Effect.fn('share.runSharePublish')(function* (
       `Refusing to publish ${sourceUri}: ${memoryCodeCitationSharingBlockerMessage(citationBlocker)}.`,
     );
   }
-  const stripped = setMemoryVisibility(stripPersonalProvenance(rawContent), 'shared');
+  const stripped = setMemoryVisibility(stripPersonalProvenanceForSharedPublication(rawContent), 'shared');
   const scrub = applyScrubber(stripped, {redact: options.redact === true});
   const targetUri = sharedUriFor(config, sourceUri, team.name);
 
@@ -154,9 +154,12 @@ export const runSharePublish = Effect.fn('share.runSharePublish')(function* (
         `Refusing to publish ${sourceUri}: ${memoryCodeCitationSharingBlockerMessage(currentCitationBlocker)}.`,
       );
     }
-    const currentScrub = applyScrubber(setMemoryVisibility(stripPersonalProvenance(currentRawContent), 'shared'), {
-      redact: options.redact === true,
-    });
+    const currentScrub = applyScrubber(
+      setMemoryVisibility(stripPersonalProvenanceForSharedPublication(currentRawContent), 'shared'),
+      {
+        redact: options.redact === true,
+      },
+    );
     if (currentScrub.blocker) {
       throw new ShareOperationError(
         `Refusing to publish ${sourceUri}: possible ${currentScrub.blocker}. Strip the sensitive value or pass --redact for soft-leak patterns.`,

--- a/src/share/conflicts.ts
+++ b/src/share/conflicts.ts
@@ -45,7 +45,7 @@ import {
   sharedMemoryIdentityContinuityIssue,
   sharedMemoryContentsEquivalent,
   sharedTeamNameForUri,
-  stripPersonalProvenance,
+  stripPersonalProvenanceForSharedPublication,
   verifySharedMemoryIdentityContinuity,
   workfileToResourceUri,
   writeFile,
@@ -495,7 +495,7 @@ const conflictResolutionContent = Effect.fn('share.conflictResolutionContent')(f
       `Cannot resolve ${conflict.id}: local native canonical store content is unavailable.`,
     );
   }
-  const scrub = applyScrubber(stripPersonalProvenance(raw, {preserveStableMemoryRelations: true}), {redact: false});
+  const scrub = applyScrubber(stripPersonalProvenanceForSharedPublication(raw), {redact: false});
   if (scrub.blocker) {
     throw new ShareOperationError(
       `Refusing to resolve ${conflict.id}: possible ${scrub.blocker}. Strip the sensitive value before writing it to shared memory.`,

--- a/src/share/core.ts
+++ b/src/share/core.ts
@@ -833,11 +833,12 @@ const isRegularFileNoSymlink = Effect.fn('share.isRegularFileNoSymlink')(functio
 /**
  * Removes personal lifecycle, candidate, session, evidence, and relation
  * provenance from the header block before a memory is published to a team's
- * shared git repo. Callers that already validated a shared write may retain only
- * stable identity-alias relation headers. Personal threadnote:// URIs do not
- * resolve for teammates, and candidate/session IDs are local workflow state.
- * Defence-in-depth: even if a producer accidentally retains local provenance,
- * it stops here.
+ * shared git repo. Shared writers must call
+ * `stripPersonalProvenanceForSharedPublication` so already-valid
+ * `threadnote://memory/tn_...` relation headers survive. Personal
+ * `threadnote://user/...` URIs do not resolve for teammates, and
+ * candidate/session IDs are local workflow state. Defence-in-depth: even if a
+ * producer accidentally retains local provenance, it stops here.
  *
  * Operates only on the contiguous header block (everything up to the first
  * blank line). Prose mentions of "supersedes:" elsewhere in the body are
@@ -871,6 +872,11 @@ export function stripPersonalProvenance(
     cleaned.push(lines[index]);
   }
   return stripGeneratedMemoryHygieneSources(cleaned.join('\n'));
+}
+
+/** Shared publication, ingest, and replace: keep identity-alias relations, drop local projection URIs. */
+export function stripPersonalProvenanceForSharedPublication(content: string): string {
+  return stripPersonalProvenance(content, {preserveStableMemoryRelations: true});
 }
 
 function isStableMemoryRelationHeader(line: string): boolean {
@@ -1067,9 +1073,7 @@ const prepareSharedInboundContentEffect = Effect.fn('share.prepareSharedInboundC
 });
 
 function prepareSharedInboundContent(uri: string, rawContent: string): string {
-  const stripped = stripPersonalProvenance(canonicalMemoryDocumentContent(rawContent), {
-    preserveStableMemoryRelations: true,
-  });
+  const stripped = stripPersonalProvenanceForSharedPublication(canonicalMemoryDocumentContent(rawContent));
   const citationBlocker = memoryCodeCitationContentSharingBlocker(uri, stripped);
   if (citationBlocker) {
     throw new ShareOperationError(

--- a/src/share/index.ts
+++ b/src/share/index.ts
@@ -37,6 +37,7 @@ export {
   sharedUriFor,
   shareTeamAccess,
   stripPersonalProvenance,
+  stripPersonalProvenanceForSharedPublication,
   writeMemoryFile,
   writeMemoryFileChecked,
 } from './core.js';

--- a/test/unit/mcp-share-publish-policy.test.ts
+++ b/test/unit/mcp-share-publish-policy.test.ts
@@ -87,6 +87,85 @@ describe('MCP share-publish citation policy', () => {
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
+
+  it.effect('preview keeps identity-alias relations and drops local projection URIs', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mcp-share-relations-'});
+        const worktree = path.join(home, 'share', 'worktrees', 'default');
+        const gitdir = path.join(home, 'share', 'teams', 'default.gitdir');
+        const sourceUri = 'threadnote://user/tester/memories/durable/projects/threadnote/relations.md';
+        const sourcePath = path.join(
+          home,
+          'data',
+          'local',
+          'user',
+          'tester',
+          'memories',
+          'durable',
+          'projects',
+          'threadnote',
+          'relations.md',
+        );
+        const config: RuntimeConfig = {
+          account: 'local',
+          agentContextHome: home,
+          agentId: 'threadnote',
+          manifestPath: path.join(home, 'seed-manifest.yaml'),
+          user: 'tester',
+        };
+        yield* fs.makeDirectory(path.dirname(sourcePath), {recursive: true});
+        yield* fs.makeDirectory(worktree, {recursive: true});
+        yield* fs.makeDirectory(path.join(home, 'share'), {recursive: true});
+        yield* fs.writeFileString(
+          path.join(home, 'share', 'teams.json'),
+          `${JSON.stringify(
+            {
+              defaultTeam: 'default',
+              teams: {
+                default: {
+                  addedAt: '2026-08-26T20:00:00.000Z',
+                  gitdir,
+                  name: 'default',
+                  remote: 'git@example.com:team/memories.git',
+                  worktree,
+                },
+              },
+              version: 1,
+            },
+            undefined,
+            2,
+          )}\n`,
+        );
+        yield* fs.writeFileString(
+          sourcePath,
+          [
+            'MEMORY',
+            'kind: durable',
+            'status: active',
+            'project: threadnote',
+            'topic: relations',
+            'memory_id: tn_share_publish_relations',
+            'relation: related_to threadnote://memory/tn_1c56a4a00279466aa450ac4db78a1a72',
+            'relation: related_to threadnote://user/tester/memories/durable/projects/threadnote/private.md',
+            '',
+            'Body',
+            '',
+          ].join('\n'),
+        );
+
+        const result = yield* runSharePublishTool(config, sourceUri, {preview: true});
+        const text = result.content.map(item => (item.type === 'text' ? item.text : '')).join('\n');
+
+        expect(result.isError).toBeUndefined();
+        expect(text).toContain('relation: related_to threadnote://memory/tn_1c56a4a00279466aa450ac4db78a1a72');
+        expect(text).not.toContain('private.md');
+        expect(yield* fs.exists(sourcePath)).toBe(true);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
 });
 
 function citedMemory(sourceDirty: boolean): string {

--- a/test/unit/share.publish.test.ts
+++ b/test/unit/share.publish.test.ts
@@ -168,6 +168,73 @@ describe('runSharePublish transaction ordering', () => {
     });
   });
 
+  it('keeps identity-alias relations and drops local projection URIs in the published copy', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const sourceUri = 'threadnote://user/test-user/memories/durable/projects/foo/bar.md';
+    const sourcePath = join(
+      config.agentContextHome,
+      'data',
+      'local',
+      'user',
+      'test-user',
+      'memories',
+      'durable',
+      'projects',
+      'foo',
+      'bar.md',
+    );
+    const targetPath = join(
+      config.agentContextHome,
+      'data',
+      'local',
+      'user',
+      'test-user',
+      'memories',
+      'shared',
+      'default',
+      'durable',
+      'projects',
+      'foo',
+      'bar.md',
+    );
+    const worktreeTargetPath = join(
+      config.agentContextHome,
+      'shared',
+      'default',
+      'durable',
+      'projects',
+      'foo',
+      'bar.md',
+    );
+    await writeFile(
+      sourcePath,
+      [
+        'MEMORY',
+        'kind: durable',
+        'status: active',
+        'project: foo',
+        'topic: bar',
+        'memory_id: tn_share_publish',
+        'relation: related_to threadnote://memory/tn_e7d22dadd14756e7d665',
+        'relation: related_to threadnote://user/test-user/memories/durable/projects/foo/private.md',
+        'candidate_id: review-local-1',
+        '',
+        'Body',
+        '',
+      ].join('\n'),
+    );
+    mockPublishCommands(sourcePath, ok('pushed'), []);
+
+    await runSharePublish(config, sourceUri, {});
+
+    const published = await readFile(targetPath, 'utf8');
+    expect(published).toContain('relation: related_to threadnote://memory/tn_e7d22dadd14756e7d665');
+    expect(published).not.toContain('private.md');
+    expect(published).not.toMatch(/^candidate_id:/m);
+    expect(await readFile(worktreeTargetPath, 'utf8')).toBe(published);
+  });
+
   it('requires an explicit uncited choice before publishing a pending-anchor memory', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);

--- a/test/unit/share.scrubber.test.ts
+++ b/test/unit/share.scrubber.test.ts
@@ -1,5 +1,13 @@
-import {describe, expect, it} from 'vitest';
-import {applyScrubber, scrubberBlocker, setMemoryVisibility, stripPersonalProvenance} from '../../src/share/index.js';
+import {describe, expect, it} from '@effect/vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {MEMORY_RELATION_TYPES} from '../../src/memory/document.js';
+import {
+  applyScrubber,
+  scrubberBlocker,
+  setMemoryVisibility,
+  stripPersonalProvenance,
+  stripPersonalProvenanceForSharedPublication,
+} from '../../src/share/index.js';
 
 function fixture(...parts: readonly string[]): string {
   return parts.join('');
@@ -206,7 +214,7 @@ describe('stripPersonalProvenance', () => {
     expect(out).toContain('Reviewed body.');
   });
 
-  it('preserves only validated stable memory relations when explicitly requested', () => {
+  it('preserves only validated stable memory relations for shared publication', () => {
     const input = [
       'MEMORY',
       'kind: durable',
@@ -224,7 +232,7 @@ describe('stripPersonalProvenance', () => {
 
     expect(stripPersonalProvenance(input)).not.toMatch(/^relation:/m);
 
-    const shared = stripPersonalProvenance(input, {preserveStableMemoryRelations: true});
+    const shared = stripPersonalProvenanceForSharedPublication(input);
     expect(shared).toContain('relation: depends_on threadnote://memory/tn_shared_dependency');
     expect(shared).toContain('relation:references threadnote://memory/tn_compact_shared_dependency');
     expect(shared).not.toContain('private.md');
@@ -234,6 +242,40 @@ describe('stripPersonalProvenance', () => {
     expect(shared).not.toContain('not-a-memory-id');
     expect(shared).toContain('Shared body.');
   });
+
+  it.prop(
+    'shared publication keeps identity-alias relations and drops local projection URIs',
+    {
+      rows: FC.uniqueArray(
+        FC.record({
+          id: FC.stringMatching(/^[A-Za-z0-9]{8}$/u).map(suffix => `tn_${suffix}`),
+          kind: FC.constantFrom('alias' as const, 'local' as const),
+          type: FC.constantFrom(...MEMORY_RELATION_TYPES),
+        }),
+        {maxLength: 6, minLength: 1, selector: row => row.id},
+      ),
+    },
+    ({rows}) => {
+      const headers = rows.map(row =>
+        row.kind === 'alias'
+          ? `relation: ${row.type} threadnote://memory/${row.id}`
+          : `relation: ${row.type} threadnote://user/me/memories/durable/projects/foo/${row.id}.md`,
+      );
+      const input = ['MEMORY', 'kind: durable', ...headers, '', 'Body.'].join('\n');
+      const published = stripPersonalProvenanceForSharedPublication(input);
+
+      expect(stripPersonalProvenance(input)).not.toMatch(/^relation:/m);
+      for (const row of rows) {
+        if (row.kind === 'alias') {
+          expect(published).toContain(`relation: ${row.type} threadnote://memory/${row.id}`);
+        } else {
+          expect(published).not.toContain(`${row.id}.md`);
+        }
+      }
+      expect(published).toContain('Body.');
+    },
+    {fastCheck: {numRuns: 100}},
+  );
 
   it('leaves content unchanged when there is no header to strip', () => {
     const input = 'just a body\nwith no provenance';


### PR DESCRIPTION
## Summary
- `share_publish` (CLI and MCP) now keeps `relation:` headers that already use `threadnote://memory/tn_...` aliases, matching shared replace and inbound ingest.
- Local `threadnote://user/...` projection URIs and other personal provenance are still stripped.
- Prepares 4.6.5.

Fixes #349.

## Test plan
- [x] `bun --bun vitest run test/unit/share.scrubber.test.ts test/unit/share.publish.test.ts test/unit/mcp-share-publish-policy.test.ts`
- [ ] CI on this PR
- [ ] After merge, tag `v4.6.5` per `docs/releasing.md`