### PR TITLE
fix: skip memory-share scrubber on agent artifact publish

### DIFF
--- a/docs/share.md
+++ b/docs/share.md
@@ -90,5 +90,7 @@ Use `--take local` only after reviewing the scrubbed content, or provide an expl
 before conflict mutation.
 
 Skills, commands, and constellation packs are namespaced by agent and kind. Bundle manifests list every member and
-path rewrite. Unsafe traversal, binary content without explicit permission, embedded credentials, reserved tokens,
-and locally modified installs are blocked.
+path rewrite. The memory-share scrubber does not run on these artifacts; `--redact` is ignored. Unsafe traversal,
+binary content without explicit permission, embedded binary credentials, machine-local paths in binaries, reserved
+tokens, and locally modified installs are blocked. Declared pack `pathRewrites` still tokenize repo-root paths for
+portable install.

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -1709,9 +1709,20 @@ const sharePublish = Command.make(
 ).pipe(Command.withDescription('Move a personal memory into the shared team namespace, commit and push'));
 
 const artifactFlags = {
-  ...publishFlags,
+  dryRun: publishFlags.dryRun,
+  message: publishFlags.message,
+  preview: publishFlags.preview,
+  push: publishFlags.push,
+  redact: boolean(
+    'redact',
+    'Ignored for agent artifacts; the memory-share scrubber does not run on skills, commands, or packs',
+  ),
+  team: publishFlags.team,
   agent: optionalChoice('agent', ['codex', 'claude'], 'Agent owner'),
-  allowBinary: boolean('allow-binary', 'Include binary files that the scrubber cannot scan'),
+  allowBinary: boolean(
+    'allow-binary',
+    'Include binary files; embedded binary credentials and machine-local paths in binaries still block',
+  ),
   force: boolean('force', 'Replace existing shared files with different content'),
   kind: optionalChoice('kind', ['skill', 'command', 'pack'], 'Shared artifact kind'),
   name: optionalString('name', 'Shared artifact name'),

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -643,7 +643,9 @@ function registerTools(
         "Publish a local Codex/Claude skill or Claude command markdown file into a team's shared artifact catalog. Path inference handles ~/.codex/skills/**/SKILL.md, ~/.claude/skills/**/SKILL.md, and ~/.claude/commands/**/*.md; pass agent/kind/name when sharing from another path. A skill is shared as its whole directory: companion files (scripts, references, assets) beside the SKILL.md travel with it. Default team is used unless team is provided. Pass preview=true to inspect what would land without writing or committing.",
       inputSchema: {
         agent: McpInput.literals(['codex', 'claude'], 'Agent owner when path inference is ambiguous'),
-        allowBinary: McpInput.boolean('Include binary skill files (unscannable by the scrubber); blocked by default'),
+        allowBinary: McpInput.boolean(
+          'Include binary skill files; embedded binary credentials and machine-local paths in binaries still block',
+        ),
         force: McpInput.boolean('Replace an existing shared artifact with different content'),
         kind: McpInput.literals(['skill', 'command'], 'Artifact kind when path inference is ambiguous'),
         message: McpInput.string('Commit message override; defaults to "share: publish <path>"'),
@@ -652,7 +654,7 @@ function registerTools(
         preview: McpInput.boolean('Return the bytes that would land in the shared git repo'),
         push: McpInput.boolean('Push to remote after committing; defaults to true'),
         redact: McpInput.boolean(
-          'Replace soft-leak matches (local paths) with placeholders and continue; credentials still block.',
+          'Ignored for agent artifacts. The memory-share scrubber does not run on skills, commands, or packs.',
         ),
         team: McpInput.string('Team name; defaults to the configured default team'),
       },
@@ -686,14 +688,16 @@ function registerTools(
       description:
         "Publish a multi-skill constellation (pack) into a team's shared artifact catalog from a threadnote-bundle.json manifest. Use this when several skills share code that lives outside any single skill directory (e.g. repo-root scripts/lib). The manifest declares name, agent, skills, include paths, external deps, and pathRewrites. Hardcoded repo-root paths are rewritten to a portable token and expanded on install. Pass preview=true to inspect what would land without writing or committing.",
       inputSchema: {
-        allowBinary: McpInput.boolean('Include binary files (unscannable by the scrubber); blocked by default'),
+        allowBinary: McpInput.boolean(
+          'Include binary files; embedded binary credentials and machine-local paths in binaries still block',
+        ),
         force: McpInput.boolean('Replace existing shared pack files with different content'),
         message: McpInput.string('Commit message override'),
         path: McpInput.string('Required local path to a threadnote-bundle.json manifest'),
         preview: McpInput.boolean('Return what would land in the shared git repo without writing'),
         push: McpInput.boolean('Push to remote after committing; defaults to true'),
         redact: McpInput.boolean(
-          'Replace soft-leak matches (local paths) with placeholders and continue; credentials still block.',
+          'Ignored for agent artifacts. The memory-share scrubber does not run on skills, commands, or packs.',
         ),
         team: McpInput.string('Team name; defaults to the configured default team'),
       },

--- a/src/share/artifact_publish.ts
+++ b/src/share/artifact_publish.ts
@@ -280,7 +280,9 @@ const shareSingleArtifact = Effect.fn('share.shareSingleArtifact')(function* (
   if (!rawContent.trim()) {
     throw new ShareOperationError(`Refusing to share empty agent artifact: ${resolvedSourcePath}`);
   }
-  const scrub = applyScrubber(rawContent, {redact: options.redact === true});
+  // Agent artifacts are published byte-for-byte. The memory-share scrubber stays
+  // on durable `share publish`; --redact is ignored here.
+  const content = rawContent;
   const relativePath = sharedArtifactRelativePath(artifact);
   const targetPath = yield* pathJoin(team.config.worktree, ...relativePath.split('/'));
   const targetUri = yield* workfileToResourceUri(config, team.config, targetPath);
@@ -289,42 +291,19 @@ const shareSingleArtifact = Effect.fn('share.shareSingleArtifact')(function* (
     `Source: ${yield* portablePath(resolvedSourcePath)}`,
     `Destination: ${targetUri}`,
   ];
+  appendIgnoredArtifactRedactNote(messages, options);
 
   if (preview) {
-    if (scrub.blocker) {
-      messages.push(`PREVIEW BLOCKED: ${scrub.blocker}. Strip the sensitive value or pass --redact.`);
-      return {
-        artifact,
-        gitMessages: [],
-        messages,
-        sourcePath: resolvedSourcePath,
-        targetPath,
-        targetUri,
-      };
-    }
-    for (const redaction of scrub.redactions) {
-      messages.push(`PREVIEW redact: ${redaction.count}× ${redaction.name}`);
-    }
     return {
       artifact,
       gitMessages: [],
       messages,
-      previewContent: scrub.cleaned,
+      previewContent: content,
       sourcePath: resolvedSourcePath,
       targetPath,
       targetUri,
     };
   }
-
-  if (scrub.blocker) {
-    throw new ShareOperationError(
-      `Refusing to share ${resolvedSourcePath}: possible ${scrub.blocker}. Strip the sensitive value or pass --redact for soft-leak patterns.`,
-    );
-  }
-  for (const redaction of scrub.redactions) {
-    messages.push(`Redacted ${redaction.count}× ${redaction.name} before sharing.`);
-  }
-  const content = scrub.cleaned;
   const existingContent = (yield* readFileIfExists(targetPath)) ?? undefined;
   if (existingContent !== undefined && existingContent !== content && options.force !== true) {
     throw new ShareOperationError(
@@ -354,11 +333,16 @@ interface PreparedBundleMember {
   readonly binary: boolean;
   readonly blocker?: string;
   readonly content: Uint8Array | string;
-  readonly redactions: ReadonlyArray<{readonly count: number; readonly name: string}>;
   readonly relativePath: string;
   readonly sha256: string;
   readonly targetPath: string;
   readonly targetUri: string;
+}
+
+function appendIgnoredArtifactRedactNote(messages: string[], options: SharePublishArtifactOptions): void {
+  if (options.redact === true) {
+    messages.push('Note: --redact is ignored for agent artifacts; content is published unchanged.');
+  }
 }
 
 const shareBundleArtifact = Effect.fn('share.shareBundleArtifact')(function* (
@@ -394,14 +378,12 @@ const shareBundleArtifact = Effect.fn('share.shareBundleArtifact')(function* (
     `Source: ${yield* portablePath(skillDir)}`,
     `Destination: ${skillRootTargetUri}/`,
   ];
+  appendIgnoredArtifactRedactNote(messages, options);
 
   const blockers = prepared.filter(entry => entry.blocker !== undefined);
   if (preview) {
     for (const entry of prepared) {
       const flags = entry.binary ? ['binary'] : [];
-      for (const redaction of entry.redactions) {
-        flags.push(`redact ${redaction.count}× ${redaction.name}`);
-      }
       const note = entry.blocker !== undefined ? ` BLOCKED: ${entry.blocker}` : '';
       messages.push(`  ${entry.relativePath}${flags.length > 0 ? ` [${flags.join(', ')}]` : ''}${note}`);
     }
@@ -420,13 +402,8 @@ const shareBundleArtifact = Effect.fn('share.shareBundleArtifact')(function* (
     throw new ShareOperationError(
       `Refusing to share skill ${artifact.agent}/${artifact.name}: ${blockers
         .map(entry => `${entry.relativePath} (${entry.blocker})`)
-        .join('; ')}. Strip the value, pass --redact for local paths, or --allow-binary for binary files.`,
+        .join('; ')}. Strip the value or pass --allow-binary for binary files.`,
     );
-  }
-  for (const entry of prepared) {
-    for (const redaction of entry.redactions) {
-      messages.push(`Redacted ${redaction.count}× ${redaction.name} in ${entry.relativePath} before sharing.`);
-    }
   }
 
   for (const entry of prepared) {
@@ -528,21 +505,18 @@ const prepareBundleMember = Effect.fn('share.prepareBundleMember')(function* (
       binary: true,
       blocker,
       content: buffer,
-      redactions: [],
       relativePath: member.relativePath,
       sha256: yield* sha256(buffer),
       targetPath,
       targetUri,
     };
   }
-  const scrub = applyScrubber(new TextDecoder().decode(buffer), {redact: options.redact === true});
+  const text = new TextDecoder().decode(buffer);
   return {
     binary: false,
-    blocker: scrub.blocker,
-    content: scrub.cleaned,
-    redactions: scrub.redactions,
+    content: text,
     relativePath: member.relativePath,
-    sha256: yield* sha256(scrub.cleaned),
+    sha256: yield* sha256(text),
     targetPath,
     targetUri,
   };
@@ -717,14 +691,6 @@ function tokenizePackPaths(text: string, rewriteRoots: readonly string[]): strin
   return out;
 }
 
-// A declared rewrite root still present after tokenization (e.g. followed by a
-// non-boundary char like '-' so the prefix wasn't rewritten) is a residual
-// machine-local path. Text members rely on this to match the substring check
-// detectBinaryLocalPath already applies to binary members.
-function residualRewriteRoot(content: string, rewriteRoots: readonly string[]): string | undefined {
-  return rewriteRoots.find(root => root.length > 0 && content.includes(root));
-}
-
 // Absolute path prefixes that are portable across machines (system/tool paths),
 // so a surviving reference to them is not flagged as a machine-local leak.
 const PORTABLE_PATH_PREFIXES: readonly string[] = [
@@ -747,10 +713,9 @@ const PORTABLE_PATH_PREFIXES: readonly string[] = [
   '/Applications/',
 ];
 
-// Best-effort detector of machine-local absolute paths that tokenization and the
-// scrubber do not catch (anything that isn't /Users, /home, a rewrite root, or a
-// portable system prefix). Advisory only — used to WARN, never to block, because
-// many absolute paths (/usr/bin, /bin/sh) are legitimately portable.
+// Advisory leftover-path detector after tokenization. /Users and /home are not
+// portable prefixes, so they warn here. PORTABLE_PATH_PREFIXES (/tmp, /usr, …)
+// are skipped. Never blocks — many remaining absolute paths are still portable.
 function unportableAbsolutePaths(content: string): readonly string[] {
   // Drop the portable pack-root token (and the path that follows it) so paths
   // anchored to the install root are not mistaken for machine-local leaks.
@@ -796,7 +761,6 @@ const preparePackMember = Effect.fn('share.preparePackMember')(function* (
       binary: true,
       blocker,
       content: buffer,
-      redactions: [],
       relativePath: member.relativePath,
       sha256: yield* sha256(buffer),
       targetPath,
@@ -811,35 +775,21 @@ const preparePackMember = Effect.fn('share.preparePackMember')(function* (
       binary: false,
       blocker: `contains the reserved ${PACK_ROOT_TOKEN} token`,
       content: text,
-      redactions: [],
       relativePath: member.relativePath,
       sha256: yield* sha256(text),
       targetPath,
       targetUri,
     };
   }
-  // Rewrite hardcoded repo-root paths to the portable token BEFORE scrubbing.
-  // The residual net is PARTIAL: a surviving declared/auto rewrite root
-  // (residualRewriteRoot) and /Users or /home paths (scrubber) block the publish,
-  // but other machine-local absolute paths (/opt, /srv, /Volumes, Windows C:\\)
-  // are NOT auto-detected — authors must declare them in pathRewrites or strip
-  // them. See docs/share.md and the known-limitations follow-up.
+  // Declared/auto rewrite roots become the portable pack token. The memory-share
+  // scrubber and residual rewrite-root blocking do not run on pack members;
+  // leftover machine-local paths are advisory only.
   const tokenized = tokenizePackPaths(text, rewriteRoots);
-  // Honor --redact only for prose (.md). Redacting a soft-leak path inside an
-  // executable member would silently rewrite it to <local-path> and break the
-  // file at runtime, so code members always block on a residual path instead.
-  const isMarkdown = member.relativePath.toLowerCase().endsWith('.md');
-  const scrub = applyScrubber(tokenized, {redact: isMarkdown && options.redact === true});
-  const residual = residualRewriteRoot(scrub.cleaned, rewriteRoots);
-  const blocker =
-    scrub.blocker ?? (residual !== undefined ? `machine-local path "${residual}" not rewritten` : undefined);
   return {
     binary: false,
-    blocker,
-    content: scrub.cleaned,
-    redactions: scrub.redactions,
+    content: tokenized,
     relativePath: member.relativePath,
-    sha256: yield* sha256(scrub.cleaned),
+    sha256: yield* sha256(tokenized),
     targetPath,
     targetUri,
   };
@@ -947,23 +897,20 @@ export const shareBundlePack = Effect.fn('share.shareBundlePack')(function* (
   );
   // Tokenize the generated index + manifest too (not just member files) so an
   // author repo-root path embedded in description/deps is normalized to the
-  // portable token rather than leaking or noisily blocking.
+  // portable token. The memory-share scrubber does not run on these files.
   const indexContent = tokenizePackPaths(buildPackIndex(artifact, manifest, skillNames, prepared.length), rewriteRoots);
-  const indexScrub = applyScrubber(indexContent, {redact: options.redact === true});
 
   const messages: string[] = [
     `${preview ? 'Previewing' : dryRun ? 'Would share' : 'Sharing'} pack ${artifact.agent}/${artifact.name} (${prepared.length} files, ${skillNames.length} skills)`,
     `Source: ${yield* portablePath(manifestDir)}`,
     `Destination: ${indexTargetUri}`,
   ];
+  appendIgnoredArtifactRedactNote(messages, options);
 
   const blockers = prepared.filter(entry => entry.blocker !== undefined);
   if (preview) {
     for (const entry of prepared) {
       const flags = entry.binary ? ['binary'] : [];
-      for (const redaction of entry.redactions) {
-        flags.push(`redact ${redaction.count}× ${redaction.name}`);
-      }
       const note = entry.blocker !== undefined ? ` BLOCKED: ${entry.blocker}` : '';
       messages.push(`  ${entry.relativePath}${flags.length > 0 ? ` [${flags.join(', ')}]` : ''}${note}`);
     }
@@ -971,45 +918,24 @@ export const shareBundlePack = Effect.fn('share.shareBundlePack')(function* (
       artifact,
       gitMessages: [],
       messages,
-      previewContent: indexScrub.cleaned,
+      previewContent: indexContent,
       sourcePath: resolvedManifest,
       targetPath: indexTargetPath,
       targetUri: indexTargetUri,
     };
   }
 
-  const indexResidual = residualRewriteRoot(indexScrub.cleaned, rewriteRoots);
-  if (indexScrub.blocker !== undefined || indexResidual !== undefined) {
-    throw new ShareOperationError(
-      `Refusing to share pack ${artifact.agent}/${artifact.name}: index ${indexScrub.blocker ?? `machine-local path "${indexResidual}" not rewritten`}.`,
-    );
-  }
   if (blockers.length > 0) {
     throw new ShareOperationError(
       `Refusing to share pack ${artifact.agent}/${artifact.name}: ${blockers
         .map(entry => `${entry.relativePath} (${entry.blocker})`)
-        .join('; ')}. Strip the value, pass --redact for local paths, or --allow-binary for binary files.`,
+        .join('; ')}. Strip the value or pass --allow-binary for binary files.`,
     );
   }
-  // The generated .pack.json is shared text too — tokenize then route it through
-  // the scrubber so no field can leak a secret or local path past the chokepoint.
-  const packJson = applyScrubber(tokenizePackPaths(buildPackManifestJson(artifact, manifest, prepared), rewriteRoots), {
-    redact: options.redact === true,
-  });
-  const packJsonResidual = residualRewriteRoot(packJson.cleaned, rewriteRoots);
-  if (packJson.blocker !== undefined || packJsonResidual !== undefined) {
-    throw new ShareOperationError(
-      `Refusing to share pack ${artifact.agent}/${artifact.name}: manifest ${packJson.blocker ?? `machine-local path "${packJsonResidual}" not rewritten`}.`,
-    );
-  }
-  for (const entry of prepared) {
-    for (const redaction of entry.redactions) {
-      messages.push(`Redacted ${redaction.count}× ${redaction.name} in ${entry.relativePath} before sharing.`);
-    }
-  }
-  // Advisory: surface machine-local absolute paths the rewriter/scrubber cannot
-  // auto-detect (e.g. /opt, /srv, /Volumes, Windows C:\) so the author can add a
-  // pathRewrite or strip them. Non-blocking — many absolute paths are portable.
+  const packJson = tokenizePackPaths(buildPackManifestJson(artifact, manifest, prepared), rewriteRoots);
+  // Advisory: surface machine-local absolute paths that pathRewrites did not
+  // tokenize (e.g. /opt, /srv, /Volumes, Windows C:\) so the author can add a
+  // rewrite or strip them. Non-blocking — many absolute paths are portable.
   const unportable = new Set<string>();
   for (const entry of prepared) {
     if (!entry.binary && typeof entry.content === 'string') {
@@ -1018,10 +944,10 @@ export const shareBundlePack = Effect.fn('share.shareBundlePack')(function* (
       }
     }
   }
-  for (const path of unportableAbsolutePaths(indexScrub.cleaned)) {
+  for (const path of unportableAbsolutePaths(indexContent)) {
     unportable.add(`${artifact.name}${PACK_INDEX_SUFFIX}: ${path}`);
   }
-  for (const path of unportableAbsolutePaths(packJson.cleaned)) {
+  for (const path of unportableAbsolutePaths(packJson)) {
     unportable.add(`${artifact.name}${PACK_MANIFEST_SUFFIX}: ${path}`);
   }
   if (unportable.size > 0) {
@@ -1099,7 +1025,7 @@ export const shareBundlePack = Effect.fn('share.shareBundlePack')(function* (
           }),
         );
       });
-      yield* writeMarkdownMember(indexTargetUri, indexScrub.cleaned, indexTargetPath);
+      yield* writeMarkdownMember(indexTargetUri, indexContent, indexTargetPath);
       for (const entry of prepared.filter(member => member.relativePath.endsWith('.md'))) {
         yield* writeMarkdownMember(entry.targetUri, entry.content as string, entry.targetPath);
       }
@@ -1124,7 +1050,7 @@ export const shareBundlePack = Effect.fn('share.shareBundlePack')(function* (
       }
       yield* ensureDirectory(packRootTargetDir, false);
       const priorManifest = yield* readFileBytesIfExists(manifestTargetPath);
-      yield* writeFile(manifestTargetPath, packJson.cleaned, {encoding: 'utf8', mode: 0o600});
+      yield* writeFile(manifestTargetPath, packJson, {encoding: 'utf8', mode: 0o600});
       rollbacks.push(
         Effect.fn('share.callback')(function* () {
           if (priorManifest !== undefined) {

--- a/test/unit/share.artifacts.test.ts
+++ b/test/unit/share.artifacts.test.ts
@@ -2,6 +2,7 @@ import {mkdtemp, mkdir, readFile, rm, writeFile} from '../helpers/node-fs-promis
 import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import {Effect} from 'effect';
+import * as fc from 'fast-check';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {shareAgentArtifact, shareBundlePack} from '../../src/share/index.js';
 import {
@@ -537,18 +538,63 @@ describe('shared agent artifacts', () => {
     ).rejects.toThrow(/embedded in binary file/);
   });
 
-  it('scrubs companion files and blocks a leaked credential in a script', async () => {
+  it('publishes a companion script with a credential-shaped token unchanged', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     const skillDir = join(config.agentContextHome, '.codex', 'skills', 'reviewer');
+    const script = `const token = "ghp_${'b'.repeat(36)}";\n`;
     await mkdir(join(skillDir, 'scripts'), {recursive: true});
     await writeFile(join(skillDir, 'SKILL.md'), '# Reviewer\n');
-    await writeFile(join(skillDir, 'scripts', 'run.ts'), `const token = "ghp_${'b'.repeat(36)}";\n`);
+    await writeFile(join(skillDir, 'scripts', 'run.ts'), script);
     mockPublishCommands();
 
-    await expect(runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {}))).rejects.toThrow(
-      /scripts\/run\.ts/,
-    );
+    await runEffect(shareAgentArtifact(config, join(skillDir, 'SKILL.md'), {}));
+    await expect(
+      readFile(
+        join(
+          config.agentContextHome,
+          'shared',
+          'default',
+          'agent-artifacts',
+          'skills',
+          'codex',
+          'reviewer',
+          'scripts',
+          'run.ts',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe(script);
+  });
+
+  it('publishes skill markdown that mentions /tmp and JS escapes unchanged', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const sourcePath = join(config.agentContextHome, '.claude', 'skills', 'reviewer', 'SKILL.md');
+    const body =
+      '# Reviewer\n\nRun `bun scripts/digest-stats.ts > /tmp/digest-prompt.md`.\n\n' +
+      "Normalize with `str.replace(/\\\\/g, '\\\\\\\\')`.\n";
+    await mkdir(join(sourcePath, '..'), {recursive: true});
+    await writeFile(sourcePath, body);
+    mockPublishCommands();
+
+    const result = await runEffect(shareAgentArtifact(config, sourcePath, {redact: true}));
+    expect(result.messages.join('\n')).toMatch(/--redact is ignored/);
+    await expect(
+      readFile(
+        join(
+          config.agentContextHome,
+          'shared',
+          'default',
+          'agent-artifacts',
+          'skills',
+          'claude',
+          'reviewer',
+          'SKILL.md',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe(body);
   });
 
   it('does not materialize bundle companions when the native SKILL.md write fails', async () => {
@@ -734,16 +780,32 @@ describe('shared agent artifacts', () => {
     expect(addArgs).toContain('agent-artifacts/packs/claude/reviewer/files/scripts/vcs.ts');
   });
 
-  it('blocks a residual local path that no pathRewrite covers', async () => {
+  it('publishes a residual local path that no pathRewrite covers unchanged', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     const repo = await makeReviewerManifestRepo();
-    await writeFile(join(repo, 'scripts', 'leak.ts'), 'const home = "/Users/someone/secret/notes";\n');
+    const leak = 'const home = "/Users/someone/secret/notes";\n';
+    await writeFile(join(repo, 'scripts', 'leak.ts'), leak);
     mockPublishCommands();
 
-    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
-      /scripts\/leak\.ts/,
-    );
+    await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
+    await expect(
+      readFile(
+        join(
+          config.agentContextHome,
+          'shared',
+          'default',
+          'agent-artifacts',
+          'packs',
+          'claude',
+          'reviewer',
+          'files',
+          'scripts',
+          'leak.ts',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe(leak);
   });
 
   async function seedSharedPack(config: ShareRuntime): Promise<string> {
@@ -1061,28 +1123,99 @@ describe('shared agent artifacts', () => {
     expect(result.artifacts.map(entry => entry.artifact.name)).toContain('reviewer');
   });
 
-  it('blocks a residual /home path in a pack member', async () => {
+  it('publishes a residual /home path in a pack member unchanged', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     const repo = await makeReviewerManifestRepo();
-    await writeFile(join(repo, 'scripts', 'deploy.ts'), 'const key = "/home/deploy/.ssh/id_rsa";\n');
+    const deploy = 'const key = "/home/deploy/.ssh/id_rsa";\n';
+    await writeFile(join(repo, 'scripts', 'deploy.ts'), deploy);
     mockPublishCommands();
 
-    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
-      /scripts\/deploy\.ts/,
-    );
+    await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
+    await expect(
+      readFile(
+        join(
+          config.agentContextHome,
+          'shared',
+          'default',
+          'agent-artifacts',
+          'packs',
+          'claude',
+          'reviewer',
+          'files',
+          'scripts',
+          'deploy.ts',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe(deploy);
   });
 
-  it('blocks a residual local path in a code member even with --redact', async () => {
+  it('treats --redact as a no-op and publishes a residual local path unchanged', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     const repo = await makeReviewerManifestRepo();
-    await writeFile(join(repo, 'scripts', 'leak.ts'), 'const home = "/Users/someone/secret/x";\n');
+    const leak = 'const home = "/Users/someone/secret/x";\n';
+    await writeFile(join(repo, 'scripts', 'leak.ts'), leak);
     mockPublishCommands();
 
+    const result = await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {redact: true}));
+    expect(result.messages.join('\n')).toMatch(/--redact is ignored/);
     await expect(
-      runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {redact: true})),
-    ).rejects.toThrow(/scripts\/leak\.ts/);
+      readFile(
+        join(
+          config.agentContextHome,
+          'shared',
+          'default',
+          'agent-artifacts',
+          'packs',
+          'claude',
+          'reviewer',
+          'files',
+          'scripts',
+          'leak.ts',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe(leak);
+  });
+
+  it('publishes skill markdown with path-shaped literals unchanged', async () => {
+    const fragment = fc.oneof(
+      fc.constant('/tmp/digest-prompt.md'),
+      fc.constant('/Users/someone/secret/notes'),
+      fc.constant('/home/deploy/.ssh/id_rsa'),
+      fc.constant("str.replace(/\\\\/g, '\\\\\\\\')"),
+      fc.string({maxLength: 24}).map(value => `/tmp/${value.replaceAll(/[/\\\0]/g, '_') || 'x'}`),
+    );
+    await fc.assert(
+      fc.asyncProperty(fragment, async value => {
+        const config = await makeRuntime();
+        homes.push(config.agentContextHome);
+        const sourcePath = join(config.agentContextHome, '.codex', 'skills', 'reviewer', 'SKILL.md');
+        const body = `# Reviewer\n\nSee ${value}\n`;
+        await mkdir(join(sourcePath, '..'), {recursive: true});
+        await writeFile(sourcePath, body);
+        mockPublishCommands();
+        await runEffect(shareAgentArtifact(config, sourcePath, {}));
+        await expect(
+          readFile(
+            join(
+              config.agentContextHome,
+              'shared',
+              'default',
+              'agent-artifacts',
+              'skills',
+              'codex',
+              'reviewer',
+              'SKILL.md',
+            ),
+            'utf8',
+          ),
+        ).resolves.toBe(body);
+      }),
+      {numRuns: 15},
+    );
   });
 
   it('flags a locally-edited member removed upstream as a conflict, not a silent update', async () => {
@@ -1227,18 +1360,34 @@ describe('shared agent artifacts', () => {
     await expect(readFile(join(installRoot, 'scripts', 'vcs.ts'), 'utf8')).resolves.toContain('/scripts-v2');
   });
 
-  it('blocks a text member whose residual rewrite-root path the tokenizer leaves intact', async () => {
+  it('publishes a residual rewrite-root path the tokenizer leaves intact', async () => {
     const config = await makeRuntime();
     homes.push(config.agentContextHome);
     const repo = await makeReviewerManifestRepo();
     // `${repo}-logs` is a sibling of the repo root: the tokenizer will not rewrite
-    // it (the `-` is not a path boundary), so the residual-root check must block.
-    await writeFile(join(repo, 'scripts', 'log.ts'), `const dir = "${repo}-logs/run";\n`);
+    // it (the `-` is not a path boundary). Residual-root blocking no longer applies.
+    const log = `const dir = "${repo}-logs/run";\n`;
+    await writeFile(join(repo, 'scripts', 'log.ts'), log);
     mockPublishCommands();
 
-    await expect(runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}))).rejects.toThrow(
-      /scripts\/log\.ts/,
-    );
+    await runEffect(shareBundlePack(config, join(repo, 'threadnote-bundle.json'), {}));
+    await expect(
+      readFile(
+        join(
+          config.agentContextHome,
+          'shared',
+          'default',
+          'agent-artifacts',
+          'packs',
+          'claude',
+          'reviewer',
+          'files',
+          'scripts',
+          'log.ts',
+        ),
+        'utf8',
+      ),
+    ).resolves.toBe(log);
   });
 
   it('accepts a skill entry given as a path to SKILL.md', async () => {

--- a/test/unit/share.publish.test.ts
+++ b/test/unit/share.publish.test.ts
@@ -390,4 +390,29 @@ describe('runSharePublish transaction ordering', () => {
 
     expect(existsSync(sourcePath)).toBe(true);
   });
+
+  it('still blocks a machine-local path on durable memory publish', async () => {
+    const config = await makeRuntime();
+    homes.push(config.agentContextHome);
+    const sourceUri = 'threadnote://user/test-user/memories/durable/projects/foo/bar.md';
+    const sourcePath = join(
+      config.agentContextHome,
+      'data',
+      'local',
+      'user',
+      'test-user',
+      'memories',
+      'durable',
+      'projects',
+      'foo',
+      'bar.md',
+    );
+    await writeFile(
+      sourcePath,
+      'MEMORY\nkind: durable\nstatus: active\nproject: foo\ntopic: bar\nmemory_id: tn_share_publish\n\nSee /Users/jane/work/notes.md\n',
+    );
+    mockPublishCommands(sourcePath, ok('pushed'), []);
+
+    await expect(runSharePublish(config, sourceUri, {})).rejects.toThrow(/macOS home path/);
+  });
 });

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -1016,8 +1016,8 @@ threadnote share conflict resolve <id> --take shared`,
           {
             type: 'list',
             items: [
-              'Unsafe traversal, credentials, reserved tokens, and locally modified installs are blocked.',
-              'Binary files require an explicit opt-in because the scrubber cannot inspect them.',
+              'The memory-share scrubber does not run on skills, commands, or packs; redact is ignored.',
+              'Unsafe traversal, reserved tokens, binary files without opt-in, embedded binary credentials, machine-local paths in binaries, and locally modified installs are blocked.',
               'Preview the exact bundle before commit and push.',
               'List shared artifacts before installing so agent, kind, and name are unambiguous.',
             ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #351.

`share publish-artifact` / `publish-bundle` no longer run `applyScrubber` or residual rewrite-root blocking on skills, commands, or packs. Path-shaped literals in skill code (`/tmp/`, `/Users`, `/home`, JS string escapes) publish unchanged. Durable `share publish` still scrubs.

`--redact` on artifact publish is a documented no-op and now prints a notice. Pack `pathRewrites` still tokenize repo-root paths. Binary credential and pack binary local-path blockers remain.

## Checks
- Focused: `test/unit/share.artifacts.test.ts`, `test/unit/share.publish.test.ts`, `test/unit/website-content.test.ts`
- Property: skill markdown with path-shaped literals publishes unchanged (15 runs)
- Durable memory publish still blocks a macOS home path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5da558f8-8371-4e58-8a28-b7bd0d8f7b80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5da558f8-8371-4e58-8a28-b7bd0d8f7b80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

