### PR TITLE
fix: keep MCP sessions connected across long recall

### DIFF
--- a/src/effect/production_log.ts
+++ b/src/effect/production_log.ts
@@ -63,6 +63,7 @@ const processProductionLogGates = new Map<string, {readonly semaphore: Semaphore
 export const PRODUCTION_LOG_PHASES = [
   'recall.shared-sync',
   'recall.obsidian-sync',
+  'recall.workspace-context',
   'recall.semantic-retrieval',
   'recall.lexical-ranking',
 ] as const;

--- a/src/effect/telemetry.ts
+++ b/src/effect/telemetry.ts
@@ -50,7 +50,6 @@ export const ANONYMOUS_TELEMETRY_PHASES = [
   'recall.obsidian-sync',
   'recall.semantic-retrieval',
   'recall.shared-sync',
-  'recall.workspace-context',
   'storage.reading',
   'storage.writing',
 ] as const;

--- a/src/effect/telemetry.ts
+++ b/src/effect/telemetry.ts
@@ -50,6 +50,7 @@ export const ANONYMOUS_TELEMETRY_PHASES = [
   'recall.obsidian-sync',
   'recall.semantic-retrieval',
   'recall.shared-sync',
+  'recall.workspace-context',
   'storage.reading',
   'storage.writing',
 ] as const;

--- a/src/mcp/broker.ts
+++ b/src/mcp/broker.ts
@@ -208,7 +208,18 @@ class McpBroker {
   }
 
   async #observeChild(active: ActiveBrokerChild): Promise<void> {
-    await Promise.all([this.#readChildOutput(active), active.child.exited.catch(() => -1)]).catch(() => undefined);
+    // Wait for the process to exit before failing in-flight requests. A
+    // stdout-pump error is not itself a runtime exit; stop the child so the
+    // observer can settle instead of reporting exit while work continues.
+    const outputPump = this.#readChildOutput(active).catch(() => {
+      if (this.#child !== active) return;
+      try {
+        active.child.kill('SIGTERM');
+      } catch {
+        // The child can already have exited.
+      }
+    });
+    await Promise.all([outputPump, active.child.exited.catch(() => -1)]);
     if (this.#child !== active) return;
     this.#reportFailure({area: 'child', reason: 'exit'});
     this.#child = undefined;
@@ -264,7 +275,11 @@ class McpBroker {
           outgoingLine = replaceCancelledRequestId(line, route.externalId);
         }
       }
-      await this.#queueOutput(outgoingLine);
+      // Keep pumping runtime output when the editor-owned stdout write fails.
+      // A dropped progress frame must not look like a child exit while work
+      // continues, and a later result can still be delivered if the client is
+      // still reading.
+      await this.#queueOutput(outgoingLine).catch(() => undefined);
     }
   }
 

--- a/src/mcp/server/recall.ts
+++ b/src/mcp/server/recall.ts
@@ -907,10 +907,7 @@ function runRecallTool(
     const workspaceContext = yield* withMcpProgressHeartbeat(
       progress,
       RECALL_MCP_PROGRESS.workspaceContext,
-      withAnonymousTelemetryPhase(
-        'recall.workspace-context',
-        withProductionPhaseTiming('recall.workspace-context', resolveRecallWorkspaceContext(config, params)),
-      ),
+      withProductionPhaseTiming('recall.workspace-context', resolveRecallWorkspaceContext(config, params)),
       progressTiming.heartbeatMilliseconds,
     );
     const query = workspaceContext.query;

--- a/src/mcp/server/recall.ts
+++ b/src/mcp/server/recall.ts
@@ -1,7 +1,5 @@
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {Clock, Crypto, Effect, FileSystem, Option, Predicate, Result} from 'effect';
-import {inferProjectFromQuery, inferWorksetFromQuery, requireWorkset} from '../../manifest.js';
-import type {ProjectManifest} from '../../types.js';
 import {
   activePersonalMemoryUrisFromText,
   existingReferencedUris,
@@ -10,18 +8,7 @@ import {
   referencedUrisFromRecords,
 } from '../../memory/hygiene.js';
 import {applyScrubber} from '../../share/index.js';
-import {
-  errorMessage,
-  enrichRecallQueryWithWorkspaceProjectContext,
-  exactRecallTerms,
-  type RecallHit,
-  recallQueryRequestsBranchContext,
-  recallScoreThresholdPolicy,
-  resolveWorkspaceBranch,
-  resolveWorkspaceComponentContext,
-  resolveWorkspaceRepoName,
-  trimTrailingSlash,
-} from '../../utils.js';
+import {errorMessage, resolveWorkspaceRepoName} from '../../utils.js';
 import {
   EffectMcpServerAdapter,
   McpInput,
@@ -38,7 +25,6 @@ import {
   selectExpandedRecallCandidatesEffect,
   shouldExpandRecall,
 } from '../../effect/ai/recall.js';
-import {resolveEffectAiConfiguration} from '../../effect/ai/consolidator.js';
 import {sha256Hex} from '../../effect/digest.js';
 import {withMemoryUriLocks} from '../../effect/memory_lock.js';
 import {SystemInfo} from '../../effect/system.js';
@@ -96,8 +82,6 @@ import {
   type CursorCloudMemoryScope,
 } from '../../cursor/cloud.js';
 import {memoryIdFromIdentityAlias} from '../../memory/identity_alias.js';
-import {loadRecallExactMatches} from '../../recall/index.js';
-import {deriveRecallEligibilityPolicy, type RecallEligibilityPolicy} from '../../recall/eligibility.js';
 import {RECALL_RANKER_VERSION} from '../../recall/rank.js';
 import {
   parseRecallMemoryConnectionInput,
@@ -109,11 +93,7 @@ import {
   RECALL_MCP_RESPONSE_MAXIMUM_ESTIMATED_TOKENS,
   RECALL_MCP_RESPONSE_MINIMUM_ESTIMATED_TOKENS,
 } from '../../recall/mcp_response.js';
-import {
-  lexicalIndexUnavailableWarning,
-  mergeRecallOperationalWarnings,
-  type RecallOperationalWarning,
-} from '../../recall/warning.js';
+import {mergeRecallOperationalWarnings} from '../../recall/warning.js';
 import {syncObsidianSourcesBeforeRecall} from '../../obsidian/source.js';
 import {withProductionPhaseTiming} from '../../effect/production_log.js';
 import {withAnonymousTelemetryPhase} from '../../effect/telemetry.js';
@@ -131,21 +111,17 @@ import {
 } from '../../recall/runtime.js';
 import {
   McpServerOperationError,
-  MAX_WORKSET_PASSES,
   type RecallProgressTiming,
   type RuntimeConfig,
   argumentError,
-  exactMemoryScopes,
   mcpErrorResult,
   normalizeOptionalMetadata,
   optionalResourceUri,
-  projectMemoryScopeUris,
   requiredResourceUri,
   requiredResourceUriList,
   requiredText,
   uriSegment,
   withStaleVersionNotice,
-  worksetScopeUris,
 } from './common.js';
 import {
   type WriteDurableMemoryParams,
@@ -159,6 +135,7 @@ import {
   writeDurableMemory,
 } from './memory.js';
 import {syncCursorCloudMemoryShares} from './cursor_cloud_memory.js';
+import {resolveRecallWorkspaceContext} from './recall_workspace_context.js';
 import {resourceIdIsWithin} from '../../storage/resource-id.js';
 
 function stringList(value: string | readonly string[] | undefined): readonly string[] {
@@ -927,109 +904,30 @@ function runRecallTool(
             return Effect.succeed([] as readonly string[]);
           }),
         );
-    yield* progress.report(RECALL_MCP_PROGRESS.workspaceContext);
-    const query = params.query;
-    const navigationOnly = query.length === 0;
-    const workspaceComponent =
-      !navigationOnly && !params.pinnedUri && !params.workset
-        ? yield* resolveWorkspaceComponentContext({cwd: params.callerCwd, includeProcessCwd: false})
-        : undefined;
-    const workspaceBranch =
-      !navigationOnly && !params.pinnedUri && !params.workset && recallQueryRequestsBranchContext(query)
-        ? yield* resolveWorkspaceBranch({cwd: params.callerCwd, includeProcessCwd: false})
-        : undefined;
-    const projectQuery = navigationOnly
-      ? ''
-      : yield* enrichRecallQueryWithWorkspaceProjectContext(query, {
-          cwd: params.callerCwd,
-          includeProcessCwd: false,
-        });
-    const explicitProjectName = params.pinnedUri ? undefined : params.project;
-    const queryProject = params.pinnedUri
-      ? undefined
-      : yield* inferProjectFromQuery(config.manifestPath, explicitProjectName ?? params.query);
-    const project =
-      queryProject ??
-      (navigationOnly || params.pinnedUri || explicitProjectName
-        ? undefined
-        : yield* inferProjectFromQuery(config.manifestPath, projectQuery));
-    const inferredProjectMemoryName = params.pinnedUri
-      ? undefined
-      : (project?.name ??
-        (navigationOnly
-          ? undefined
-          : yield* resolveWorkspaceRepoName({cwd: params.callerCwd, includeProcessCwd: false})));
-    const recallProjectName = explicitProjectName ?? inferredProjectMemoryName;
-    const thresholdPolicy =
-      params.threshold === undefined
-        ? yield* recallScoreThresholdPolicy()
-        : {source: 'call' as const, value: params.threshold};
-    const threshold = thresholdPolicy.value;
-    const thresholdConfigured = thresholdPolicy.source !== 'default';
-    const explicitWorkset = params.workset ? yield* requireWorkset(config.manifestPath, params.workset) : undefined;
-    const passes: Array<readonly RecallHit[]> = [];
-    const scopedRecallUris = new Set(
-      [params.pinnedUri, ...(params.allowedUriScopes ?? [])].filter((uri): uri is string => uri !== undefined),
+    const workspaceContext = yield* withMcpProgressHeartbeat(
+      progress,
+      RECALL_MCP_PROGRESS.workspaceContext,
+      withAnonymousTelemetryPhase(
+        'recall.workspace-context',
+        withProductionPhaseTiming('recall.workspace-context', resolveRecallWorkspaceContext(config, params)),
+      ),
+      progressTiming.heartbeatMilliseconds,
     );
-    for (const scope of projectMemoryScopeUris(config, recallProjectName, params.includeArchived)) {
-      if (!scopedRecallUris.has(scope)) {
-        scopedRecallUris.add(scope);
-      }
-    }
-    const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
-    if (seededUri?.startsWith('threadnote://') && seededUri !== params.pinnedUri) {
-      scopedRecallUris.add(seededUri);
-    }
-
-    const sections: string[] = [];
-    const workset = params.pinnedUri
-      ? undefined
-      : explicitWorkset
-        ? explicitWorkset
-        : navigationOnly
-          ? undefined
-          : yield* inferWorksetFromQuery(config.manifestPath, projectQuery);
-    if (workset && workset.projects.length > 0) {
-      sections.push(`Workset scope: ${workset.name} (${workset.projects.map(member => member.name).join(', ')})`);
-      const alreadyScoped = new Set(
-        [params.pinnedUri, seededUri, ...scopedRecallUris].filter((uri): uri is string => uri !== undefined),
-      );
-      const worksetScopes = worksetScopeUris(config, workset)
-        .filter(uri => !alreadyScoped.has(uri))
-        .slice(0, MAX_WORKSET_PASSES);
-      for (const scope of worksetScopes) {
-        scopedRecallUris.add(scope);
-      }
-    }
-
-    const eligibility = deriveRecallEligibilityPolicy({
-      explicitProject: params.project,
-      originalQuery: query,
-      pinnedHardUri: params.pinnedUri !== undefined,
-      worksetProjectNames: workset?.projects.map(member => member.name),
-    });
-
-    const exactLookup = yield* collectExactMemoryMatches(
-      config,
-      query,
-      params.includeArchived,
-      eligibility,
-      recallProjectName,
-      project,
-      params.allowedUriScopes,
-    );
-    const exactMatches = exactLookup.matches;
-    let operationalWarnings: readonly RecallOperationalWarning[] = exactLookup.operationalWarnings;
-    const effectAiResult = navigationOnly
-      ? undefined
-      : yield* resolveEffectAiConfiguration(config, (yield* SystemInfo).environment()).pipe(Effect.result);
-    const effectAi =
-      effectAiResult !== undefined && Result.isSuccess(effectAiResult) ? effectAiResult.success : undefined;
-    if (effectAiResult !== undefined && Result.isFailure(effectAiResult)) {
-      sections.push(
-        `Local AI recall unavailable: ${errorMessage(effectAiResult.failure)}. Deterministic recall continued.`,
-      );
-    }
+    const query = workspaceContext.query;
+    const navigationOnly = workspaceContext.navigationOnly;
+    const workspaceComponent = workspaceContext.workspaceComponent;
+    const workspaceBranch = workspaceContext.workspaceBranch;
+    const recallProjectName = workspaceContext.recallProjectName;
+    const threshold = workspaceContext.threshold;
+    const thresholdConfigured = workspaceContext.thresholdConfigured;
+    const passes = workspaceContext.passes;
+    const scopedRecallUris = workspaceContext.scopedRecallUris;
+    const seededUri = workspaceContext.seededUri;
+    const sections = workspaceContext.sections;
+    const eligibility = workspaceContext.eligibility;
+    const exactMatches = workspaceContext.exactMatches;
+    let operationalWarnings = workspaceContext.operationalWarnings;
+    const effectAi = workspaceContext.effectAi;
     let hybridMinimumScore = recallHybridMinimumScore(Number(threshold));
     const expansionQueries: string[] = [];
     const recallLimit = params.nodeLimit ?? 12;
@@ -1303,32 +1201,6 @@ const referencedContextSection = Effect.fn('mcpServer.referencedContext')(functi
   const candidates = referenced.slice(0, MAX_REFERENCED_CONTEXT);
   const existingRecords = yield* readMemoryRecordsByUri(config, candidates);
   return formatReferencedContextPointers(existingReferencedUris(candidates, existingRecords), MAX_REFERENCED_CONTEXT);
-});
-
-const collectExactMemoryMatches = Effect.fn('mcp_server.collectExactMemoryMatches')(function* (
-  config: RuntimeConfig,
-  query: string,
-  includeArchived: boolean,
-  eligibility: RecallEligibilityPolicy,
-  projectName: string | undefined,
-  project: ProjectManifest | undefined,
-  allowedUriScopes?: readonly string[],
-) {
-  const terms = exactRecallTerms(query);
-  if (terms.length === 0) {
-    return {matches: [], operationalWarnings: []};
-  }
-  const scopes = allowedUriScopes ?? exactMemoryScopes(config, includeArchived, query, projectName, project);
-  const result = yield* loadRecallExactMatches(config, {
-    eligibility,
-    includeInactive: includeArchived,
-    limitPerTerm: 25,
-    terms,
-    uriScopes: scopes,
-  }).pipe(Effect.result);
-  return Result.isSuccess(result)
-    ? {matches: result.success, operationalWarnings: []}
-    : {matches: [], operationalWarnings: [lexicalIndexUnavailableWarning()]};
 });
 
 export function registerReadTool(

--- a/src/mcp/server/recall_workspace_context.ts
+++ b/src/mcp/server/recall_workspace_context.ts
@@ -1,0 +1,190 @@
+import {Effect, Result} from 'effect';
+import {inferProjectFromQuery, inferWorksetFromQuery, requireWorkset} from '../../manifest.js';
+import type {ProjectManifest} from '../../types.js';
+import {
+  errorMessage,
+  enrichRecallQueryWithWorkspaceProjectContext,
+  exactRecallTerms,
+  type ExactMatch,
+  type RecallHit,
+  recallQueryRequestsBranchContext,
+  recallScoreThresholdPolicy,
+  resolveWorkspaceBranch,
+  resolveWorkspaceComponentContext,
+  resolveWorkspaceRepoName,
+  trimTrailingSlash,
+} from '../../utils.js';
+import {resolveEffectAiConfiguration} from '../../effect/ai/consolidator.js';
+import {SystemInfo} from '../../effect/system.js';
+import {loadRecallExactMatches} from '../../recall/index.js';
+import {deriveRecallEligibilityPolicy, type RecallEligibilityPolicy} from '../../recall/eligibility.js';
+import {lexicalIndexUnavailableWarning, type RecallOperationalWarning} from '../../recall/warning.js';
+import {
+  exactMemoryScopes,
+  MAX_WORKSET_PASSES,
+  projectMemoryScopeUris,
+  type RuntimeConfig,
+  worksetScopeUris,
+} from './common.js';
+
+export interface RecallWorkspaceContextParams {
+  readonly allowedUriScopes: readonly string[] | undefined;
+  readonly callerCwd: string | undefined;
+  readonly includeArchived: boolean;
+  readonly pinnedUri: string | undefined;
+  readonly project: string | undefined;
+  readonly query: string;
+  readonly threshold: string | undefined;
+  readonly workset: string | undefined;
+}
+
+export function resolveRecallWorkspaceContext(config: RuntimeConfig, params: RecallWorkspaceContextParams) {
+  return Effect.gen(function* () {
+    const query = params.query;
+    const navigationOnly = query.length === 0;
+    const workspaceComponent =
+      !navigationOnly && !params.pinnedUri && !params.workset
+        ? yield* resolveWorkspaceComponentContext({cwd: params.callerCwd, includeProcessCwd: false})
+        : undefined;
+    const workspaceBranch =
+      !navigationOnly && !params.pinnedUri && !params.workset && recallQueryRequestsBranchContext(query)
+        ? yield* resolveWorkspaceBranch({cwd: params.callerCwd, includeProcessCwd: false})
+        : undefined;
+    const projectQuery = navigationOnly
+      ? ''
+      : yield* enrichRecallQueryWithWorkspaceProjectContext(query, {
+          cwd: params.callerCwd,
+          includeProcessCwd: false,
+        });
+    const explicitProjectName = params.pinnedUri ? undefined : params.project;
+    const queryProject = params.pinnedUri
+      ? undefined
+      : yield* inferProjectFromQuery(config.manifestPath, explicitProjectName ?? params.query);
+    const project =
+      queryProject ??
+      (navigationOnly || params.pinnedUri || explicitProjectName
+        ? undefined
+        : yield* inferProjectFromQuery(config.manifestPath, projectQuery));
+    const inferredProjectMemoryName = params.pinnedUri
+      ? undefined
+      : (project?.name ??
+        (navigationOnly
+          ? undefined
+          : yield* resolveWorkspaceRepoName({cwd: params.callerCwd, includeProcessCwd: false})));
+    const recallProjectName = explicitProjectName ?? inferredProjectMemoryName;
+    const thresholdPolicy =
+      params.threshold === undefined
+        ? yield* recallScoreThresholdPolicy()
+        : {source: 'call' as const, value: params.threshold};
+    const threshold = thresholdPolicy.value;
+    const thresholdConfigured = thresholdPolicy.source !== 'default';
+    const explicitWorkset = params.workset ? yield* requireWorkset(config.manifestPath, params.workset) : undefined;
+    const passes: Array<readonly RecallHit[]> = [];
+    const scopedRecallUris = new Set(
+      [params.pinnedUri, ...(params.allowedUriScopes ?? [])].filter((uri): uri is string => uri !== undefined),
+    );
+    for (const scope of projectMemoryScopeUris(config, recallProjectName, params.includeArchived)) {
+      if (!scopedRecallUris.has(scope)) {
+        scopedRecallUris.add(scope);
+      }
+    }
+    const seededUri = project ? trimTrailingSlash(project.uri) : undefined;
+    if (seededUri?.startsWith('threadnote://') && seededUri !== params.pinnedUri) {
+      scopedRecallUris.add(seededUri);
+    }
+
+    const sections: string[] = [];
+    const workset = params.pinnedUri
+      ? undefined
+      : explicitWorkset
+        ? explicitWorkset
+        : navigationOnly
+          ? undefined
+          : yield* inferWorksetFromQuery(config.manifestPath, projectQuery);
+    if (workset && workset.projects.length > 0) {
+      sections.push(`Workset scope: ${workset.name} (${workset.projects.map(member => member.name).join(', ')})`);
+      const alreadyScoped = new Set(
+        [params.pinnedUri, seededUri, ...scopedRecallUris].filter((uri): uri is string => uri !== undefined),
+      );
+      const worksetScopes = worksetScopeUris(config, workset)
+        .filter(uri => !alreadyScoped.has(uri))
+        .slice(0, MAX_WORKSET_PASSES);
+      for (const scope of worksetScopes) {
+        scopedRecallUris.add(scope);
+      }
+    }
+
+    const eligibility = deriveRecallEligibilityPolicy({
+      explicitProject: params.project,
+      originalQuery: query,
+      pinnedHardUri: params.pinnedUri !== undefined,
+      worksetProjectNames: workset?.projects.map(member => member.name),
+    });
+
+    const exactLookup = yield* collectExactMemoryMatches(
+      config,
+      query,
+      params.includeArchived,
+      eligibility,
+      recallProjectName,
+      project,
+      params.allowedUriScopes,
+    );
+    const effectAiResult = navigationOnly
+      ? undefined
+      : yield* resolveEffectAiConfiguration(config, (yield* SystemInfo).environment()).pipe(Effect.result);
+    const effectAi =
+      effectAiResult !== undefined && Result.isSuccess(effectAiResult) ? effectAiResult.success : undefined;
+    if (effectAiResult !== undefined && Result.isFailure(effectAiResult)) {
+      sections.push(
+        `Local AI recall unavailable: ${errorMessage(effectAiResult.failure)}. Deterministic recall continued.`,
+      );
+    }
+    return {
+      effectAi,
+      eligibility,
+      exactMatches: exactLookup.matches,
+      navigationOnly,
+      operationalWarnings: exactLookup.operationalWarnings,
+      passes,
+      query,
+      recallProjectName,
+      scopedRecallUris,
+      sections,
+      seededUri,
+      threshold,
+      thresholdConfigured,
+      workspaceBranch,
+      workspaceComponent,
+    };
+  });
+}
+
+const collectExactMemoryMatches = Effect.fn('mcp_server.collectExactMemoryMatches')(function* (
+  config: RuntimeConfig,
+  query: string,
+  includeArchived: boolean,
+  eligibility: RecallEligibilityPolicy,
+  projectName: string | undefined,
+  project: ProjectManifest | undefined,
+  allowedUriScopes?: readonly string[],
+) {
+  const terms = exactRecallTerms(query);
+  if (terms.length === 0) {
+    return {
+      matches: [] as readonly ExactMatch[],
+      operationalWarnings: [] as readonly RecallOperationalWarning[],
+    };
+  }
+  const scopes = allowedUriScopes ?? exactMemoryScopes(config, includeArchived, query, projectName, project);
+  const result = yield* loadRecallExactMatches(config, {
+    eligibility,
+    includeInactive: includeArchived,
+    limitPerTerm: 25,
+    terms,
+    uriScopes: scopes,
+  }).pipe(Effect.result);
+  return Result.isSuccess(result)
+    ? {matches: result.success, operationalWarnings: []}
+    : {matches: [], operationalWarnings: [lexicalIndexUnavailableWarning()]};
+});

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -900,6 +900,7 @@ describe('Threadnote MCP toolsets', () => {
 
         expect(phaseTimings?.filter(timing => timing.phase === 'recall.shared-sync')).toHaveLength(1);
         expect(phaseTimings?.filter(timing => timing.phase === 'recall.obsidian-sync')).toHaveLength(1);
+        expect(phaseTimings?.filter(timing => timing.phase === 'recall.workspace-context')).toHaveLength(1);
         expect(phaseTimings?.filter(timing => timing.phase === 'recall.semantic-retrieval')).toHaveLength(1);
         expect(phaseTimings?.filter(timing => timing.phase === 'recall.lexical-ranking').length).toBeGreaterThanOrEqual(
           1,

--- a/test/unit/mcp-broker.test.ts
+++ b/test/unit/mcp-broker.test.ts
@@ -1,3 +1,4 @@
+import * as fc from 'fast-check';
 import {describe, expect, it} from 'vitest';
 import {
   runMcpBroker,
@@ -6,6 +7,7 @@ import {
   type McpBrokerFailureEvent,
 } from '../../src/mcp/broker.js';
 import type {StandaloneActiveRelease} from '../../src/process/standalone_lease.js';
+
 describe('MCP session broker', () => {
   it('reports a closed spawn failure without allowing the observer to alter recovery', async () => {
     const clientInput = new AsyncByteQueue();
@@ -484,7 +486,62 @@ describe('MCP session broker', () => {
     clientInput.end();
     await running;
   });
+
+  it('keeps an in-flight tool result when a progress write to the client fails', async () => {
+    await expectInFlightToolResultAfterDroppedProgress(1);
+  });
+
+  it('does not fail in-flight requests for any number of dropped progress frames while the runtime stays up', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.integer({min: 1, max: 8}), async progressFrames => {
+        await expectInFlightToolResultAfterDroppedProgress(progressFrames);
+      }),
+      {numRuns: 15},
+    );
+  });
 });
+
+async function expectInFlightToolResultAfterDroppedProgress(progressFrames: number): Promise<void> {
+  const clientInput = new AsyncByteQueue();
+  const clientOutput = new AsyncByteQueue();
+  const release = {releaseRoot: '/threadnote/versions/4.2.2', version: '4.2.2'};
+  const spawned: FakeMcpChild[] = [];
+  const failures: McpBrokerFailureEvent[] = [];
+  const running = runMcpBroker({
+    input: clientInput,
+    onFailure: event => failures.push(event),
+    readActiveRelease: async () => release,
+    spawn: () => {
+      const child = new FakeMcpChild(release.version, {progressFramesBeforeToolResult: progressFrames});
+      spawned.push(child);
+      return child;
+    },
+    writeOutput: async line => {
+      const envelope = JSON.parse(line) as {readonly method?: string};
+      if (envelope.method === 'notifications/progress') {
+        throw new Error('temporary client write failure');
+      }
+      clientOutput.pushLine(line);
+    },
+  });
+
+  clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+  expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({
+    result: {serverInfo: {version: '4.2.2'}},
+  });
+  clientInput.pushLine(JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'}));
+  clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+  expect(JSON.parse(await clientOutput.nextLine())).toEqual({
+    id: 2,
+    jsonrpc: '2.0',
+    result: {version: '4.2.2'},
+  });
+  expect(spawned).toHaveLength(1);
+  expect(failures).toEqual([]);
+
+  clientInput.end();
+  await running;
+}
 
 class FakeMcpChild implements McpBrokerChild {
   readonly #output = new AsyncByteQueue();
@@ -502,6 +559,7 @@ class FakeMcpChild implements McpBrokerChild {
     readonly options: {
       readonly exitBeforeFirstToolWrite?: boolean;
       readonly ignoreInitialize?: boolean;
+      readonly progressFramesBeforeToolResult?: number;
       readonly rejectInitialize?: boolean;
       readonly respondToTools?: boolean;
     } = {},
@@ -567,6 +625,16 @@ class FakeMcpChild implements McpBrokerChild {
       this.#end();
       throw new Error('Child exited before accepting the request.');
     } else if (envelope.method === 'tools/call' && this.options.respondToTools !== false) {
+      const progressFrames = this.options.progressFramesBeforeToolResult ?? 0;
+      for (let index = 0; index < progressFrames; index += 1) {
+        this.#output.pushLine(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'notifications/progress',
+            params: {progress: index + 1, progressToken: envelope.id},
+          }),
+        );
+      }
       this.#output.pushLine(JSON.stringify({id: envelope.id, jsonrpc: '2.0', result: {version: this.version}}));
     }
   }

--- a/test/unit/telemetry-gateway-contract.test.ts
+++ b/test/unit/telemetry-gateway-contract.test.ts
@@ -1,5 +1,6 @@
 import ts from 'typescript-compiler';
 import {describe, expect, it} from 'vitest';
+import {PRODUCTION_LOG_PHASES} from '../../src/effect/production_log.js';
 import {
   ANONYMOUS_TELEMETRY_AUTO_UPDATE_RESULTS,
   ANONYMOUS_TELEMETRY_CODE_ANCHOR_FINALIZATION_RESULTS,
@@ -268,6 +269,12 @@ describe('telemetry producer and production gateway schema', () => {
       expect(closedTelemetryErrorType(errorType)).toBe(errorType);
     }
     expect(closedTelemetryErrorType('PrivateCustomerError')).toBe('UnknownError');
+  });
+
+  it('keeps recall workspace-context production-timed without expanding the OTLP phase registry', () => {
+    expect(PRODUCTION_LOG_PHASES).toContain('recall.workspace-context');
+    expect(ANONYMOUS_TELEMETRY_PHASES).not.toContain('recall.workspace-context');
+    expect(schema.registries.phase).not.toContain('recall.workspace-context');
   });
 
   it('keeps bounded identifier, version, bucket, and numeric limits executable', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/Kashkovsky/threadnote/issues/352

Cursor could report `Mcp error: -32603: Threadnote MCP runtime exited before responding` while the same `recall_context` invocation later finished successfully. Two gaps combined to produce that:

1. The MCP session broker treated a failed write on editor-owned stdout as a child-runtime exit. Progress heartbeats that the client dropped aborted the output pump, the broker failed the in-flight request with `-32603`, and the MCP child kept working.
2. Recall sent one `recall.workspace-context` progress frame, then did untimed scope resolution, exact lookup, and local-AI setup with no further heartbeats. That gap can exceed the documented 30-second MCP envelope even though later phases are already heartbeated.

## Changes

- Keep pumping child NDJSON when a client stdout write fails. Do not report runtime exit until the child process actually exits; if the output pump fails unrecoverably, stop the child so the observer can settle.
- Heartbeat and production-log-time `recall.workspace-context` the same way as shared-sync, semantic retrieval, and lexical ranking. The phase stays off the OTLP registry so the frozen v6 telemetry contract is not expanded.
- Regression: in-flight tool results still reach the client after dropped progress frames (example + Fast-check, 15 runs). Integration recall phase timings now include `recall.workspace-context`. A new gateway-contract test asserts the phase is production-timed but excluded from `ANONYMOUS_TELEMETRY_PHASES` and the v6 schema registry.

## Testing

Focused `mcp-broker`, `mcp-broker-telemetry`, `telemetry-gateway-contract`, recall progress/phase-timing tests all pass. Global `dev:install-global` + `doctor` clean (0 failures). CI is the full suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5da558f8-8371-4e58-8a28-b7bd0d8f7b80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5da558f8-8371-4e58-8a28-b7bd0d8f7b80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

