### PR TITLE
Lock the local personal floor without a remote composer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ nearest checked-in guidance remain authoritative.
 - Use stable project/topic identities and update an existing memory with `replaceUri`; do not create timestamped
   duplicates. Never store secrets, credentials, customer data, or raw production logs.
 - Prefer the Threadnote MCP tools. If they are unavailable, use the `threadnote` CLI as the fallback and treat the
-  unavailability as a dogfooding issue under the policy below.
+  unavailability as a dogfooding issue: file a privacy-safe GitHub issue rather than a Threadnote issue ledger.
 
 ## Use Effect-aware test tooling
 
@@ -96,11 +96,12 @@ Any unexpected behavior encountered while using Threadnote itself is product evi
 Do not silently bypass it or omit it from closeout.
 
 - Reproduce it with the smallest safe case, investigate the responsible code or state, and fix it when it is in scope.
-  If it cannot be fixed in the current task, record the blocker and the safest bounded workaround.
-- Maintain one active issues memory with `kind: durable`, `project: threadnote`, and `topic: dogfood-issues`. Recall and
-  read it first, then update it with `replaceUri` rather than creating another issue ledger.
-- For every issue, record the affected commit/version, symptom, minimal reproduction, expected versus actual behavior,
-  diagnosis, status, workaround if any, fix commit or PR when available, and verification performed. Keep evidence
-  privacy-safe and bounded.
+  If it cannot be fixed in the current task, record the blocker and the safest bounded workaround in the task handoff
+  and in a privacy-safe GitHub issue.
+- GitHub issues are the source of truth for product and dogfood defects. Do not maintain a Threadnote
+  `topic: dogfood-issues` ledger. The previous durable ledger is archived.
+- Keep issue evidence privacy-safe and bounded: affected commit/version, symptom, minimal reproduction, expected versus
+  actual behavior, diagnosis, workaround if any, and verification. Do not paste secrets, credentials, customer data, or
+  raw production logs.
 - If Threadnote returns an error, also prepare a privacy-safe `threadnote report-issue` preview after investigation.
-  Create a public issue only with explicit user approval.
+  Create a public GitHub issue only with explicit user approval.

--- a/docs/share.md
+++ b/docs/share.md
@@ -1,6 +1,9 @@
 # Team sharing
 
-Threadnote shares reviewed durable memories and agent artifacts through a user-provided Git repository. Canonical
+Threadnote shares reviewed durable memories and agent artifacts through a user-provided Git repository. Local stdio
+MCP, personal native-file memory, and `share publish` / `share sync` work without
+`THREADNOTE_CURSOR_MEMORY_ENDPOINT`, an organization composer, or an identity provider. Organization HTTP memory is
+additive: a laptop with only Git and the Threadnote binary remains a complete personal product. Canonical
 shared resources remain under `~/.threadnote/data/.../memories/shared/<team>/`; git metadata and checked-out files are
 isolated under `~/.threadnote/share/teams/` and `~/.threadnote/share/worktrees/`. Their exact paths are recorded in
 `~/.threadnote/share/teams.json`.

--- a/test/integration/share.two-home-roundtrip.test.ts
+++ b/test/integration/share.two-home-roundtrip.test.ts
@@ -1,0 +1,118 @@
+import {mkdir, mkdtemp, readFile, rm, writeFile} from '../helpers/node-fs-promises.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {dirname, join} from '../helpers/node-path.js';
+import {afterEach, describe, expect, it} from 'vitest';
+import {parseMemoryDocument} from '../../src/memory/document.js';
+import {runSharePublish as runSharePublishEffect, runShareSync as runShareSyncEffect} from '../../src/effect/share.js';
+import {sharedUriFor} from '../../src/share/index.js';
+import type {ShareRuntime, ShareTeamsFile} from '../../src/types.js';
+import {runCommand} from '../../src/utils.js';
+import {runEffect} from '../helpers/effect-runtime.js';
+
+const runSharePublish = (...args: Parameters<typeof runSharePublishEffect>) =>
+  runEffect(runSharePublishEffect(...args));
+const runShareSync = (...args: Parameters<typeof runShareSyncEffect>) => runEffect(runShareSyncEffect(...args));
+
+const homes: string[] = [];
+
+async function git(args: readonly string[], cwd?: string): Promise<void> {
+  await runEffect(runCommand('git', args, {cwd}));
+}
+
+function canonicalResourceFile(home: string, uri: string): string {
+  return join(home, 'data', 'local', ...uri.slice('threadnote://'.length).split('/'));
+}
+
+async function writeCanonicalResource(home: string, uri: string, content: string): Promise<void> {
+  const file = canonicalResourceFile(home, uri);
+  await mkdir(dirname(file), {recursive: true});
+  await writeFile(file, content, 'utf8');
+}
+
+async function cloneShareHome(
+  root: string,
+  remote: string,
+  user: string,
+): Promise<{
+  readonly config: ShareRuntime;
+  readonly home: string;
+  readonly worktree: string;
+}> {
+  const home = join(root, `home-${user}`);
+  const worktree = join(home, 'share', 'worktrees', 'default');
+  const gitdir = join(home, 'share', 'teams', 'default.gitdir');
+  await mkdir(dirname(worktree), {recursive: true});
+  await mkdir(dirname(gitdir), {recursive: true});
+  await git(['clone', `--separate-git-dir=${gitdir}`, '--branch', 'main', '--', remote, worktree]);
+  await git(['config', 'user.email', 'threadnote-test@example.com'], worktree);
+  await git(['config', 'user.name', 'Threadnote Test'], worktree);
+  const config: ShareRuntime = {account: 'local', agentContextHome: home, agentId: 'threadnote', user};
+  const teams: ShareTeamsFile = {
+    defaultTeam: 'default',
+    teams: {
+      default: {
+        addedAt: new Date(0).toISOString(),
+        gitdir,
+        name: 'default',
+        remote,
+        worktree,
+      },
+    },
+    version: 1,
+  };
+  await mkdir(join(home, 'share'), {recursive: true});
+  await writeFile(join(home, 'share', 'teams.json'), `${JSON.stringify(teams, undefined, 2)}\n`, 'utf8');
+  return {config, home, worktree};
+}
+
+describe('share two-home round trip', () => {
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map(path => rm(path, {force: true, recursive: true})));
+  });
+
+  it('publishes from one home and recalls the same canonical identity after sync on another', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-share-two-home-'));
+    homes.push(root);
+    const remote = join(root, 'remote.git');
+    const seed = join(root, 'seed');
+    await mkdir(seed, {recursive: true});
+    await git(['init', '--bare', remote]);
+    await git(['init'], seed);
+    await git(['checkout', '-b', 'main'], seed);
+    await git(['config', 'user.email', 'threadnote-test@example.com'], seed);
+    await git(['config', 'user.name', 'Threadnote Test'], seed);
+    await writeFile(join(seed, 'README.md'), '# Shared memories\n', 'utf8');
+    await git(['add', 'README.md'], seed);
+    await git(['commit', '-m', 'initial'], seed);
+    await git(['remote', 'add', 'origin', remote], seed);
+    await git(['push', '-u', 'origin', 'main'], seed);
+    await git(['--git-dir', remote, 'symbolic-ref', 'HEAD', 'refs/heads/main']);
+
+    const publisher = await cloneShareHome(root, remote, 'denys');
+    const subscriber = await cloneShareHome(root, remote, 'teammate');
+    const sourceUri = 'threadnote://user/denys/memories/durable/projects/threadnote/two-home-roundtrip.md';
+    const publisherSharedUri = sharedUriFor(publisher.config, sourceUri, 'default');
+    const subscriberSharedUri = sharedUriFor(
+      subscriber.config,
+      'threadnote://user/teammate/memories/durable/projects/threadnote/two-home-roundtrip.md',
+      'default',
+    );
+    await writeCanonicalResource(
+      publisher.home,
+      sourceUri,
+      'MEMORY\nkind: durable\nstatus: active\nproject: threadnote\ntopic: two-home-roundtrip\nmemory_id: tn_two_home_roundtrip_fixture\n\nTwo-home Git share body.\n',
+    );
+
+    await runSharePublish(publisher.config, sourceUri, {team: 'default'});
+    const published = await readFile(canonicalResourceFile(publisher.home, publisherSharedUri), 'utf8');
+    const publishedDoc = parseMemoryDocument(publisherSharedUri, published);
+    expect(publishedDoc?.metadata.memoryId).toBe('tn_two_home_roundtrip_fixture');
+
+    await runShareSync(subscriber.config, {push: false});
+    const ingested = await readFile(canonicalResourceFile(subscriber.home, subscriberSharedUri), 'utf8');
+    const ingestedDoc = parseMemoryDocument(subscriberSharedUri, ingested);
+    expect(ingestedDoc?.metadata.memoryId).toBe(publishedDoc?.metadata.memoryId);
+    expect(ingestedDoc?.body).toBe(publishedDoc?.body);
+    expect(ingestedDoc?.metadata.topic).toBe(publishedDoc?.metadata.topic);
+  });
+});

--- a/test/unit/shared-first-local-floor.test.ts
+++ b/test/unit/shared-first-local-floor.test.ts
@@ -1,0 +1,120 @@
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {TestClock} from 'effect/testing';
+import {captureConsole} from '../../src/effect/console.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {runMcpInstall} from '../../src/mcp/index.js';
+import {
+  DEFAULT_MCP_TOOLSET,
+  isCursorCloudPersonalToolset,
+  mcpToolCapabilities,
+  parseMcpToolset,
+  type McpToolset,
+} from '../../src/mcp/toolset.js';
+import {runRecall, runRemember} from '../../src/memory/index.js';
+import type {RuntimeConfig} from '../../src/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const PERSONAL_STDIO_TOOLSETS = ['core', 'full'] as const satisfies readonly McpToolset[];
+
+const PERSONAL_STDIO_CAPABILITIES = {
+  graphLocal: true,
+  memoryPublish: true,
+  memoryRead: true,
+  memoryWrite: true,
+} as const;
+
+function runtime(home: string): RuntimeConfig {
+  return {
+    account: 'local',
+    agentContextHome: home,
+    agentId: 'threadnote',
+    manifestPath: `${home}/seed-manifest.yaml`,
+    user: 'tester',
+  };
+}
+
+describe('shared-first local personal floor', () => {
+  effectIt.effect('defaults stdio MCP to core without a remote memory endpoint', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-local-floor-mcp-'});
+        expect(DEFAULT_MCP_TOOLSET).toBe('core');
+        const output = yield* captureConsole(runMcpInstall(runtime(home), 'codex', {})).pipe(
+          Effect.map(result => result.output),
+        );
+        expect(output).toContain('THREADNOTE_MCP_TOOLSET=core');
+        expect(output).not.toContain('THREADNOTE_CURSOR_MEMORY_ENDPOINT');
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect.prop(
+    'personal stdio toolsets keep local graph and Git-publishable memory',
+    {toolset: FC.constantFrom(...PERSONAL_STDIO_TOOLSETS)},
+    ({toolset}) =>
+      Effect.sync(() => {
+        const capabilities = mcpToolCapabilities(parseMcpToolset(toolset));
+        expect(isCursorCloudPersonalToolset(toolset)).toBe(false);
+        expect(capabilities).toEqual(expect.objectContaining(PERSONAL_STDIO_CAPABILITIES));
+      }),
+  );
+
+  effectIt.effect('keeps Cursor Cloud local graph-only and independent of personal namespaces', () =>
+    Effect.sync(() => {
+      expect(mcpToolCapabilities(parseMcpToolset('cursor-cloud-local'))).toEqual({
+        contextBrief: false,
+        graphLocal: true,
+        graphWorkset: false,
+        maintenance: false,
+        memoryPublish: false,
+        memoryRead: false,
+        memoryReview: false,
+        memoryWrite: false,
+      });
+    }),
+  );
+
+  effectIt.effect('remembers and recalls locally when the cloud memory endpoint is unreachable', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-local-floor-memory-'});
+        yield* fs.writeFileString(path.join(home, 'seed-manifest.yaml'), 'version: 1\nprojects: []\n');
+        const config = runtime(home);
+        const testSystem = SystemInfo.of({
+          ...system,
+          environment: () => ({
+            ...system.environment(),
+            THREADNOTE_CURSOR_MEMORY_ENDPOINT: 'https://127.0.0.1:1/mcp',
+            THREADNOTE_MCP_TOOLSET: 'core',
+          }),
+        });
+
+        yield* TestClock.setTime(Date.parse('2026-09-04T12:00:00.000Z'));
+        yield* runRemember(config, {
+          kind: 'durable',
+          project: 'threadnote',
+          sourceAgentClient: 'test',
+          text: 'Local personal floor remembers without a composer.',
+          topic: 'local-personal-floor',
+        }).pipe(Effect.provideService(SystemInfo, testSystem));
+
+        const recall = yield* captureConsole(
+          runRecall(config, {
+            inferScope: false,
+            query: 'Local personal floor remembers without a composer',
+          }).pipe(Effect.provideService(SystemInfo, testSystem)),
+        );
+        expect(recall.output).toContain(
+          'threadnote://user/tester/memories/durable/projects/threadnote/local-personal-floor.md',
+        );
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+});


### PR DESCRIPTION
## Summary
- Keep GitHub issues as the dogfood source of truth instead of a Threadnote issue ledger.
- Document that local stdio MCP, personal memory, and Git share stay complete without `THREADNOTE_CURSOR_MEMORY_ENDPOINT`.
- Add Effect tests for the personal stdio toolset floor and an integration round-trip that publishes from one home and syncs the same `memory_id` onto another.

## Test plan
- [x] `bun --bun vitest run test/unit/shared-first-local-floor.test.ts test/integration/share.two-home-roundtrip.test.ts`
- [x] `bun run lint && bun run typecheck` (pre-commit)
- [x] Dogfood on this machine with no `THREADNOTE_CURSOR_MEMORY_ENDPOINT`: `threadnote recall --project threadnote --query "shared-first local personal floor composer"` and `threadnote share status`
- [ ] PR CI full suite
- [ ] Merge after CI is green