### PR TITLE
Share parse results across enrolled graph homes through a live HTTP coordinator

### DIFF
--- a/docs/code-graph-checkpoints.md
+++ b/docs/code-graph-checkpoints.md
@@ -94,19 +94,27 @@ A Workset remains optional and is used only for explicitly prepared multi-reposi
   material, and raw source-file bytes are omitted, but source-embedded secrets can still appear in derived fields.
 - Use `--json` on every checkpoint command for a versioned machine-readable receipt.
 
-## Organization graph sharing (Phase 0)
+## Organization graph sharing
 
 Companies can enroll a repository so developer clones download a verified portable checkpoint instead of rebuilding the
 clean graph from scratch. Graph packs are not memory Git: they live in a digest-addressed CAS next to a checked-in
-enrollment pointer.
+enrollment pointer. After join, a publisher can advance a signed generation chain; clients select the newest published
+ancestor of `HEAD`. Worker results land in a separate CAS namespace from canonical frontiers. The coordinator API
+accepts only bounded metadata: no source text or graph records. `graph publisher serve --listen 127.0.0.1:port` exposes
+that API and a digest CAS on loopback so additional homes can join with `--coordinator` instead of a shared CAS
+directory. Contributing joins enqueue parse-result artifacts after local parser batches commit and upload them after the
+graph writer lock is released.
 
 ```sh
-threadnote graph share init --write-config --organization acme
+threadnote graph share init --write-config --organization acme --coordinator http://127.0.0.1:18765
 git add .threadnote/graph-share.json && git commit -m "Enroll graph sharing"
 threadnote graph index --full
 threadnote graph publisher bootstrap
-threadnote graph share join --read-only
+threadnote graph publisher serve --listen 127.0.0.1:18765 --json
+threadnote graph share join --coordinator http://127.0.0.1:18765
 threadnote graph index
+threadnote graph contribute status
+threadnote graph worker --json
 threadnote graph share status
 threadnote graph share leave
 ```

--- a/src/code_graph/indexer_materialization.ts
+++ b/src/code_graph/indexer_materialization.ts
@@ -201,6 +201,11 @@ function codeGraphFileProgressDimensions(
 export function cacheContentBatch(options: {
   readonly databasePath: string;
   readonly languagePacks: CodeGraphLanguagePackRegistryShape;
+  readonly onCachedParserBatch?: (group: {
+    readonly cacheIdentity: string;
+    readonly facts: readonly BoundedCodeGraphFact[];
+    readonly files: readonly CodeGraphInventoryFile[];
+  }) => Effect.Effect<void, unknown>;
   readonly onProgress?: (progress: CodeGraphProgress) => Effect.Effect<void, unknown>;
   readonly parserPool: CodeGraphParserPoolShape;
   readonly persistentCapacityProtector: CodeGraphDirectPersistentCapacityProtector;
@@ -328,6 +333,13 @@ export function cacheContentBatch(options: {
         group.cacheIdentity,
         options.persistentCapacityProtector,
       );
+      yield* (
+        options.onCachedParserBatch?.({
+          cacheIdentity: group.cacheIdentity,
+          facts: group.facts,
+          files: group.files,
+        }) ?? Effect.void
+      ).pipe(Effect.ignore);
       const elapsed = Math.max(0, performance.now() - startedAt);
       persistenceMilliseconds += elapsed;
       pendingBytes -= group.payloadBytes;

--- a/src/code_graph/indexer_service.ts
+++ b/src/code_graph/indexer_service.ts
@@ -1,4 +1,5 @@
 import {Clock, Context, Crypto, Effect, Exit, FileSystem, Layer, Option, Path, Schema} from 'effect';
+import * as HttpClient from 'effect/unstable/http/HttpClient';
 import {CommandExecutor} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
 import {makeCodeGraphBuildReporter} from './build_status.js';
@@ -55,6 +56,7 @@ import type {
   IncrementalOverlayPreassessment,
 } from './indexer_types.js';
 import {codeGraphIndexEnsuresVectors} from './indexer_types.js';
+import type {BoundedCodeGraphFact} from './fact_budget.js';
 import {
   type CodeGraphInventory,
   type CodeGraphOverlayObservation,
@@ -71,10 +73,15 @@ import {codeGraphMaintenanceIntentActive, withCodeGraphMaintenanceRegistration} 
 import {CodeGraphParserPool} from './parser_worker.js';
 import {repositoryIdentityMatchesExpectation, resolveRepositoryIdentity} from './repository.js';
 import {maybeImportSharedGraphBase} from './sharing/client.js';
+import {
+  drainQueuedGraphShareContributions,
+  enqueueLocalGraphShareParseResults,
+  hydrateSharedParseCache,
+} from './sharing/parse_cache.js';
 import {graphShareEnrollmentPath} from './sharing/layout.js';
 import {CodeGraphStore} from './store.js';
 import {TreeSitterRuntime} from './tree_sitter/runtime.js';
-import type {CodeGraphIndexSummary, CodeGraphProgress, CodeGraphSnapshot} from './types.js';
+import type {CodeGraphIndexSummary, CodeGraphInventoryFile, CodeGraphProgress, CodeGraphSnapshot} from './types.js';
 import {
   makeCodeGraphBuildAnonymousTelemetryReporter,
   type CodeGraphBuildAnonymousTelemetryReporter,
@@ -98,6 +105,28 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
       const command = yield* CommandExecutor;
       const crypto = yield* Crypto.Crypto;
       const system = yield* SystemInfo;
+      const http = yield* HttpClient.HttpClient;
+      const enqueueSharedParserBatch = (
+        identity: {readonly headCommit: string; readonly repositoryId: string},
+        threadnoteHome: string,
+        group: {
+          readonly cacheIdentity: string;
+          readonly facts: readonly BoundedCodeGraphFact[];
+          readonly files: readonly CodeGraphInventoryFile[];
+        },
+      ) =>
+        enqueueLocalGraphShareParseResults({
+          extractorSet: group.cacheIdentity,
+          facts: group.facts,
+          files: group.files,
+          identity,
+          threadnoteHome,
+        }).pipe(
+          Effect.provideService(Crypto.Crypto, crypto),
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+          Effect.asVoid,
+        );
       const indexAttempt = (
         request: CodeGraphIndexOptions,
         anonymousTelemetry: CodeGraphBuildAnonymousTelemetryReporter,
@@ -186,6 +215,20 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
               temporaryDirectory: system.tempDirectory,
               walAutoCheckpointPages: options.sqliteWriterTuning?.walAutoCheckpointPages ?? 1_000,
             };
+            yield* hydrateSharedParseCache({
+              databasePath: layout.databasePath,
+              identity: initialIdentity,
+              persistentCapacityProtector: codeGraphDirectPersistentCapacityProtector({
+                capacityProtection,
+                fs,
+                identity: initialIdentity,
+                layout,
+                onProgress: options.onProgress,
+                threadnoteHome: options.threadnoteHome,
+              }),
+              store,
+              threadnoteHome: request.threadnoteHome,
+            }).pipe(Effect.ignore);
             const repositoryBuild = withCodeGraphProcessLock(
               fs,
               layout.lockPath,
@@ -304,6 +347,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       const cacheCoalescer = cacheContentBatch({
                         databasePath: layout.databasePath,
                         languagePacks,
+                        onCachedParserBatch: group => enqueueSharedParserBatch(identity, options.threadnoteHome, group),
                         onProgress: options.onProgress,
                         parserPool,
                         persistentCapacityProtector: codeGraphDirectPersistentCapacityProtector({
@@ -902,6 +946,10 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                 }).pipe(Effect.ignore),
               ),
             );
+            yield* drainQueuedGraphShareContributions({
+              identity: initialIdentity,
+              threadnoteHome: request.threadnoteHome,
+            }).pipe(Effect.ignore);
             return summary;
           }),
         ).pipe(
@@ -913,6 +961,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
           Effect.provideService(CodeGraphStore, store),
           Effect.provideService(CodeGraphLanguagePackRegistry, languagePacks),
           Effect.provideService(CodeGraphMaintenanceCoordinator, maintenance),
+          Effect.provideService(HttpClient.HttpClient, http),
           Effect.catchIf(
             cause => Schema.is(WorktreeChangedDuringIndex)(cause) && attempt === 0,
             () => indexAttempt(request, anonymousTelemetry, attempt + 1, bypassCachedFacts),
@@ -1043,6 +1092,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                       const cacheCoalescer = cacheContentBatch({
                         databasePath: layout.databasePath,
                         languagePacks,
+                        onCachedParserBatch: group => enqueueSharedParserBatch(identity, options.threadnoteHome, group),
                         onProgress: options.onProgress,
                         parserPool,
                         persistentCapacityProtector: codeGraphDirectPersistentCapacityProtector({
@@ -1129,6 +1179,10 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                 }).pipe(Effect.ignore),
               ),
             );
+            yield* drainQueuedGraphShareContributions({
+              identity: initialIdentity,
+              threadnoteHome: request.threadnoteHome,
+            }).pipe(Effect.ignore);
             return lease;
           }),
         ).pipe(
@@ -1137,6 +1191,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
           Effect.provideService(FileSystem.FileSystem, fs),
           Effect.provideService(Path.Path, path),
           Effect.provideService(SystemInfo, system),
+          Effect.provideService(HttpClient.HttpClient, http),
           Effect.catchIf(
             cause => Schema.is(CachedCodeGraphFactUnavailableDuringIndex)(cause) && !bypassCachedFacts,
             () => ensureCommitWithSummary(request, anonymousTelemetry, true),

--- a/src/code_graph/sharing/action.ts
+++ b/src/code_graph/sharing/action.ts
@@ -1,0 +1,54 @@
+import {sha256HexSync} from '../../crypto/sha256.js';
+
+export const GRAPH_SHARE_ACTION_DOMAIN = 'threadnote-graph-action-v1';
+export const GRAPH_SHARE_ACTION_KEY = /^[0-9a-f]{64}$/u;
+
+export type GraphShareActionKey = string;
+
+export interface GraphShareParseActionInput {
+  readonly contentHash: string;
+  readonly extractorSet: string;
+  readonly languageAndRole: string;
+  readonly normalizedPath: string;
+  readonly repositoryId: string;
+}
+
+export interface GraphShareMaterializedActionInput {
+  readonly contentHash: string;
+  readonly graphAbi: string;
+  readonly graphContentId: string;
+  readonly normalizedPath: string;
+  readonly parseResultDigest: string;
+  readonly repositoryId: string;
+  readonly workspaceFingerprint: string;
+}
+
+export function graphShareLanguageAndRole(language: string, role: string): string {
+  return `${language}:${role}`;
+}
+
+export function graphShareParseActionKey(input: GraphShareParseActionInput): GraphShareActionKey {
+  return domainSeparatedActionKey('parse', [
+    input.repositoryId,
+    input.extractorSet,
+    input.normalizedPath,
+    input.contentHash,
+    input.languageAndRole,
+  ]);
+}
+
+export function graphShareMaterializedActionKey(input: GraphShareMaterializedActionInput): GraphShareActionKey {
+  return domainSeparatedActionKey('materialize', [
+    input.repositoryId,
+    input.graphAbi,
+    input.graphContentId,
+    input.workspaceFingerprint,
+    input.normalizedPath,
+    input.contentHash,
+    input.parseResultDigest,
+  ]);
+}
+
+function domainSeparatedActionKey(kind: 'materialize' | 'parse', parts: readonly string[]): GraphShareActionKey {
+  return sha256HexSync([GRAPH_SHARE_ACTION_DOMAIN, kind, ...parts].join('\0'));
+}

--- a/src/code_graph/sharing/artifacts.ts
+++ b/src/code_graph/sharing/artifacts.ts
@@ -3,6 +3,7 @@ import {fromPromiseInterruptible} from '../../effect/errors.js';
 import {canonicalJson} from '../checkpoint/canonical_json.js';
 import {graphSharingFailure} from './errors.js';
 import {parseSha256Digest, sha256Digest, SHA256_HEX, type Sha256Digest} from './digest.js';
+import {isGraphShareGitObjectId} from './git.js';
 
 function asBufferSource(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
   return new Uint8Array(bytes);
@@ -11,23 +12,36 @@ function asBufferSource(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
 export const GRAPH_SHARE_FRONTIER_SCHEMA_VERSION = 1 as const;
 export const GRAPH_SHARE_SIGNATURE_ALGORITHM = 'ed25519' as const;
 
+export const GRAPH_SHARE_PROFILE_MEDIA_TYPE = 'application/vnd.threadnote.graph.profile.v1+json';
+export const GRAPH_SHARE_FRONTIER_MEDIA_TYPE = 'application/vnd.threadnote.graph.frontier.v1+json';
+export const GRAPH_SHARE_DELTA_MEDIA_TYPE = 'application/vnd.threadnote.graph.delta.v1+json';
+export const GRAPH_SHARE_RECORDS_MEDIA_TYPE = 'application/vnd.threadnote.graph.records.v1+gzip';
+export const GRAPH_SHARE_PARSE_RESULT_MEDIA_TYPE = 'application/vnd.threadnote.graph.parse-result.v1+json';
+
 export interface GraphShareFrontierCheckpointV1 {
   readonly manifestDigest: Sha256Digest;
   readonly snapshotId: string;
   readonly sourceCommit: string;
 }
 
+export interface GraphShareFrontierDeltaV1 {
+  readonly baseSnapshotId: string;
+  readonly manifestDigest: Sha256Digest;
+  readonly targetCommit: string;
+  readonly targetSnapshotId: string;
+}
+
 export interface GraphShareFrontierManifestV1 {
   readonly branch: string;
   readonly checkpoint: GraphShareFrontierCheckpointV1;
-  readonly deltas: readonly [];
-  readonly generation: 1;
+  readonly deltas: readonly GraphShareFrontierDeltaV1[];
+  readonly generation: number;
   readonly graphAbi: string;
   readonly graphContentId: string;
   readonly logicalGraphDigest: Sha256Digest;
-  readonly previousManifestDigest: null;
+  readonly previousManifestDigest: Sha256Digest | null;
   readonly profileDigest: Sha256Digest;
-  readonly publisherFence: 1;
+  readonly publisherFence: number;
   readonly repositoryId: string;
   readonly schemaVersion: typeof GRAPH_SHARE_FRONTIER_SCHEMA_VERSION;
   readonly snapshotId: string;
@@ -143,29 +157,31 @@ export function parseGraphShareFrontierManifest(value: unknown): GraphShareFront
   if (value.schemaVersion !== GRAPH_SHARE_FRONTIER_SCHEMA_VERSION) {
     throw graphSharingFailure('Frontier manifest schemaVersion is not supported.');
   }
-  if (value.generation !== 1 || value.previousManifestDigest !== null || value.publisherFence !== 1) {
-    throw graphSharingFailure('Phase 0 frontier manifests must be generation one.');
-  }
-  if (!Array.isArray(value.deltas) || value.deltas.length !== 0) {
-    throw graphSharingFailure('Phase 0 frontier manifests cannot include deltas.');
+  const generation = requiredGeneration(value.generation);
+  const previousManifestDigest = parsePreviousManifestDigest(value.previousManifestDigest, generation);
+  if (!Array.isArray(value.deltas) || value.deltas.length > 64) {
+    throw graphSharingFailure('Frontier delta list is invalid.');
   }
   const checkpoint = parseCheckpoint(value.checkpoint);
   const manifest: GraphShareFrontierManifestV1 = {
     branch: requiredText(value.branch, 'branch'),
     checkpoint,
-    deltas: [],
-    generation: 1,
+    deltas: value.deltas.map(parseDelta),
+    generation,
     graphAbi: requiredText(value.graphAbi, 'graphAbi'),
     graphContentId: requiredText(value.graphContentId, 'graphContentId'),
     logicalGraphDigest: parseSha256Digest(requiredText(value.logicalGraphDigest, 'logicalGraphDigest')),
-    previousManifestDigest: null,
+    previousManifestDigest,
     profileDigest: parseSha256Digest(requiredText(value.profileDigest, 'profileDigest')),
-    publisherFence: 1,
+    publisherFence: requiredFence(value.publisherFence),
     repositoryId: requiredHex(value.repositoryId, 'repositoryId'),
     schemaVersion: GRAPH_SHARE_FRONTIER_SCHEMA_VERSION,
     snapshotId: requiredText(value.snapshotId, 'snapshotId'),
-    sourceCommit: requiredText(value.sourceCommit, 'sourceCommit'),
+    sourceCommit: requiredGitObjectId(value.sourceCommit, 'sourceCommit'),
   };
+  if (manifest.sourceCommit !== checkpoint.sourceCommit) {
+    throw graphSharingFailure('Frontier sourceCommit must match the checkpoint sourceCommit.');
+  }
   if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(Object.keys(manifest).sort())) {
     throw graphSharingFailure('Frontier manifest contains unsupported fields.');
   }
@@ -219,8 +235,45 @@ function parseCheckpoint(value: unknown): GraphShareFrontierCheckpointV1 {
   return {
     manifestDigest: parseSha256Digest(requiredText(value.manifestDigest, 'checkpoint.manifestDigest')),
     snapshotId: requiredText(value.snapshotId, 'checkpoint.snapshotId'),
-    sourceCommit: requiredText(value.sourceCommit, 'checkpoint.sourceCommit'),
+    sourceCommit: requiredGitObjectId(value.sourceCommit, 'checkpoint.sourceCommit'),
   };
+}
+
+function parseDelta(value: unknown): GraphShareFrontierDeltaV1 {
+  if (!isRecord(value)) throw graphSharingFailure('Frontier delta descriptor is invalid.');
+  const delta: GraphShareFrontierDeltaV1 = {
+    baseSnapshotId: requiredText(value.baseSnapshotId, 'delta.baseSnapshotId'),
+    manifestDigest: parseSha256Digest(requiredText(value.manifestDigest, 'delta.manifestDigest')),
+    targetCommit: requiredGitObjectId(value.targetCommit, 'delta.targetCommit'),
+    targetSnapshotId: requiredText(value.targetSnapshotId, 'delta.targetSnapshotId'),
+  };
+  if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(Object.keys(delta).sort())) {
+    throw graphSharingFailure('Frontier delta descriptor contains unsupported fields.');
+  }
+  return delta;
+}
+
+function requiredGeneration(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 1_000_000) {
+    throw graphSharingFailure('Frontier generation is invalid.');
+  }
+  return value;
+}
+
+function requiredFence(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 1_000_000) {
+    throw graphSharingFailure('Frontier publisher fence is invalid.');
+  }
+  return value;
+}
+
+function parsePreviousManifestDigest(value: unknown, generation: number): Sha256Digest | null {
+  if (generation === 1) {
+    if (value !== null) throw graphSharingFailure('Generation-one frontiers cannot name a predecessor.');
+    return null;
+  }
+  if (typeof value !== 'string') throw graphSharingFailure('Frontier predecessor digest is invalid.');
+  return parseSha256Digest(value, 'previousManifestDigest');
 }
 
 function exportKeyBytes(key: CryptoKey, format: 'pkcs8' | 'raw') {
@@ -258,6 +311,14 @@ function requiredText(value: unknown, label: string): string {
     throw graphSharingFailure(`Frontier field ${label} is invalid.`);
   }
   return value;
+}
+
+function requiredGitObjectId(value: unknown, label: string): string {
+  const text = requiredText(value, label);
+  if (!isGraphShareGitObjectId(text)) {
+    throw graphSharingFailure(`Frontier field ${label} must be a Git object id.`);
+  }
+  return text;
 }
 
 function requiredHex(value: unknown, label: string): string {

--- a/src/code_graph/sharing/atomic.ts
+++ b/src/code_graph/sharing/atomic.ts
@@ -1,4 +1,4 @@
-import {Crypto, Effect, FileSystem, Option, Path} from 'effect';
+import {Crypto, Effect, FileSystem, Option, Path, Schema} from 'effect';
 import {graphSharingFailure} from './errors.js';
 
 export const writePrivateJsonFile = Effect.fn('codeGraph.sharing.writePrivateJsonFile')(function* (
@@ -44,9 +44,12 @@ export const readJsonFile = Effect.fn('codeGraph.sharing.readJsonFile')(function
   if (Option.isSome(yield* fs.readLink(target).pipe(Effect.option))) {
     return yield* graphSharingFailure(`Refusing to read a graph-sharing symbolic link: ${target}`);
   }
-  const text = yield* fs.readFileString(target);
-  return yield* Effect.try({
-    try: () => JSON.parse(text) as unknown,
-    catch: cause => graphSharingFailure('Graph-sharing metadata is not valid JSON.', cause),
-  });
+  return yield* decodeJsonText(yield* fs.readFileString(target));
 });
+
+export const decodeJsonBytes = (bytes: Uint8Array) => decodeJsonText(new TextDecoder().decode(bytes));
+
+const decodeJsonText = (text: string) =>
+  Schema.decodeEffect(Schema.fromJsonString(Schema.Json), {errors: 'all'})(text).pipe(
+    Effect.mapError(cause => graphSharingFailure('Graph-sharing metadata is not valid JSON.', cause)),
+  );

--- a/src/code_graph/sharing/cli.ts
+++ b/src/code_graph/sharing/cli.ts
@@ -1,9 +1,11 @@
 import {Command} from 'effect/unstable/cli';
 import type {Effect} from 'effect';
-import {boolean, optionalString} from '../../effect/cli_flags.js';
+import {boolean, optionalString, requiredChoice} from '../../effect/cli_flags.js';
 import {codeGraphCliBounds} from '../../effect/code_graph_cli_flags.js';
 import type {RuntimeConfig} from '../../types.js';
 import {
+  runGraphContributeSetCommand,
+  runGraphContributeStatusCommand,
   runGraphPublisherBootstrapCommand,
   runGraphPublisherServeCommand,
   runGraphPublisherStatusCommand,
@@ -11,6 +13,7 @@ import {
   runGraphShareJoinCommand,
   runGraphShareLeaveCommand,
   runGraphShareStatusCommand,
+  runGraphWorkerCommand,
 } from './commands.js';
 
 export function makeGraphSharingCommands(
@@ -20,6 +23,7 @@ export function makeGraphSharingCommands(
     'init',
     {
       cas: optionalString('cas', 'Digest-addressed CAS directory for organization-issued profiles'),
+      coordinator: optionalString('coordinator', 'HTTPS coordinator URL, or loopback HTTP for local publisher serve'),
       cwd: codeGraphCliBounds.cwd,
       json: codeGraphCliBounds.json,
       organization: optionalString('organization', 'Organization identity recorded in the issued profile'),
@@ -32,6 +36,10 @@ export function makeGraphSharingCommands(
     'join',
     {
       cas: optionalString('cas', 'Digest-addressed CAS directory that stores the enrolled profile'),
+      coordinator: optionalString(
+        'coordinator',
+        'Coordinator URL used to fetch the enrolled profile and later frontiers without a shared CAS directory',
+      ),
       cwd: codeGraphCliBounds.cwd,
       json: codeGraphCliBounds.json,
       readOnly: boolean(
@@ -83,9 +91,17 @@ export function makeGraphSharingCommands(
       cas: optionalString('cas', 'Digest-addressed CAS directory for signed frontier artifacts'),
       cwd: codeGraphCliBounds.cwd,
       json: codeGraphCliBounds.json,
+      listen: optionalString(
+        'listen',
+        'Loopback host:port for the live coordinator and digest CAS (for example 127.0.0.1:18765)',
+      ),
     },
     options => withRuntimeEffect(config => runGraphPublisherServeCommand(config, options)),
-  ).pipe(Command.withDescription('Publish generation-one frontier; continuous watch lands in a later phase'));
+  ).pipe(
+    Command.withDescription(
+      'Observe HEAD, publish the next signed generation when it advances, and optionally listen for contributors',
+    ),
+  );
 
   const graphPublisherStatus = Command.make(
     'status',
@@ -102,5 +118,43 @@ export function makeGraphSharingCommands(
     Command.withSubcommands([graphPublisherBootstrap, graphPublisherServe, graphPublisherStatus]),
   );
 
-  return {graphPublisher, graphShare};
+  const graphContributeStatus = Command.make(
+    'status',
+    {
+      cwd: codeGraphCliBounds.cwd,
+      json: codeGraphCliBounds.json,
+    },
+    options => withRuntimeEffect(config => runGraphContributeStatusCommand(config, options)),
+  ).pipe(Command.withDescription('Report local graph contribution mode without printing secrets'));
+
+  const graphContributeSet = Command.make(
+    'set',
+    {
+      cwd: codeGraphCliBounds.cwd,
+      json: codeGraphCliBounds.json,
+      mode: requiredChoice('mode', ['off', 'passive', 'idle', 'dedicated'], 'Contribution mode'),
+    },
+    options => withRuntimeEffect(config => runGraphContributeSetCommand(config, options)),
+  ).pipe(Command.withDescription('Set local graph contribution below the organization maximum'));
+
+  const graphContribute = Command.make('contribute').pipe(
+    Command.withDescription('Control opportunistic graph-sharing contribution from this checkout'),
+    Command.withSubcommands([graphContributeStatus, graphContributeSet]),
+  );
+
+  const graphWorker = Command.make(
+    'worker',
+    {
+      cas: optionalString('cas', 'Digest-addressed CAS directory for worker results'),
+      cwd: codeGraphCliBounds.cwd,
+      json: codeGraphCliBounds.json,
+    },
+    options => withRuntimeEffect(config => runGraphWorkerCommand(config, options)),
+  ).pipe(
+    Command.withDescription(
+      'Run a dedicated graph worker against the authorized Git checkout; never fetch source from graph CAS',
+    ),
+  );
+
+  return {graphContribute, graphPublisher, graphShare, graphWorker};
 }

--- a/src/code_graph/sharing/client.ts
+++ b/src/code_graph/sharing/client.ts
@@ -9,15 +9,27 @@ import {
   parseGraphShareFrontierPointer,
   parseGraphShareSignatureEnvelope,
   verifyGraphShareFrontier,
+  type GraphShareFrontierManifestV1,
 } from './artifacts.js';
-import {readJsonFile, writePrivateJsonFile} from './atomic.js';
+import {decodeJsonBytes, readJsonFile, writePrivateJsonFile} from './atomic.js';
 import {readVerifiedCasBlob, verifyCasBlob} from './cas.js';
 import {GraphSharingError, graphSharingFailure, graphSharingUnavailable} from './errors.js';
+import {graphShareBlobExists, graphShareCommitIsAncestor} from './git.js';
+import {graphShareControlGetFrontier, mirrorCoordinatorCasBlob} from './control_client.js';
+import {graphShareFrontierDiscoveryTag} from './namespace.js';
+import {
+  GRAPH_SHARE_CONTRIBUTION_MODES,
+  effectiveGraphShareContributionMode,
+  readGraphShareContributionQueue,
+  type GraphShareContributionMode,
+} from './contribution.js';
 import {graphShareEnrollmentPath, graphSharingFrontierPointerPath, graphSharingLayout} from './layout.js';
+import {planGraphWorkerActions, readAdvertisedGraphWorkerActions} from './worker.js';
 import {
   assertEnrollmentMatchesIdentity,
   assertProfileMatchesEnrollment,
   graphShareProfileDigest,
+  parseGraphShareCoordinatorUrl,
   parseGraphShareEnrollment,
   parseGraphShareProfile,
   parseGraphShareProfilePointer,
@@ -26,10 +38,13 @@ import {
 import {readSharedGraphProvenance, removeSharedGraphProvenance, writeSharedGraphProvenance} from './provenance.js';
 import {
   lookupGraphShareTrustReceipt,
+  readGraphShareClientState,
   removeGraphShareTrustReceipt,
   resolveGraphShareCasRoot,
   trustReceiptFromEnrollment,
   writeGraphShareClientState,
+  writeGraphShareContributionMode,
+  writeGraphShareCoordinatorUrl,
   writeGraphShareTrustReceipt,
   type GraphShareAccessMode,
   type GraphShareTrustReceiptV1,
@@ -37,6 +52,7 @@ import {
 
 export interface GraphShareJoinOptions {
   readonly cas?: string;
+  readonly coordinator?: string;
   readonly cwd?: string;
   readonly json?: boolean;
   readonly readOnly?: boolean;
@@ -78,6 +94,11 @@ export const runGraphShareJoin = Effect.fn('codeGraph.sharing.join')(function* (
   const enrollment = parseGraphShareEnrollment(yield* readJsonFile(graphShareEnrollmentPath(path, identity.repoRoot)));
   assertEnrollmentMatchesIdentity(enrollment, identity.repositoryId);
   const pointer = parseGraphShareProfilePointer(enrollment.profile);
+  if (options.coordinator !== undefined) {
+    const coordinatorUrl = parseGraphShareCoordinatorUrl(options.coordinator);
+    yield* writeGraphShareCoordinatorUrl(config.agentContextHome, coordinatorUrl);
+    yield* mirrorCoordinatorCasBlob(casRoot, coordinatorUrl, pointer.digest);
+  }
   const profile = yield* decodeJson(
     yield* readVerifiedCasBlob(casRoot, pointer.digest),
     parseGraphShareProfile,
@@ -85,11 +106,20 @@ export const runGraphShareJoin = Effect.fn('codeGraph.sharing.join')(function* (
   );
   const profileDigest = graphShareProfileDigest(profile);
   assertProfileMatchesEnrollment(profile, enrollment, profileDigest);
+  if (profile.coordinator?.url !== undefined) {
+    yield* writeGraphShareCoordinatorUrl(config.agentContextHome, profile.coordinator.url);
+  }
   const accessMode: GraphShareAccessMode = options.readOnly ? 'read-only' : 'join';
   const receipt = yield* writeGraphShareTrustReceipt(
     config.agentContextHome,
     trustReceiptFromEnrollment(enrollment, profile, profileDigest, accessMode),
   );
+  if (accessMode === 'join') {
+    const state = yield* readGraphShareClientState(config.agentContextHome);
+    if (state.contributionMode === undefined) {
+      yield* writeGraphShareContributionMode(config.agentContextHome, profile.contribution.defaultMode);
+    }
+  }
   return {
     accessMode: receipt.accessMode,
     organization: receipt.organization,
@@ -220,8 +250,9 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
     input.enrollment.profile,
     'Enrollment profile pointer is invalid.',
   );
+  const coordinatorHint = (yield* readGraphShareClientState(input.request.threadnoteHome)).coordinatorUrl;
   const profile = yield* decodeJson(
-    yield* readVerifiedCasBlob(input.casRoot, pointer.digest),
+    yield* ensureSharedCasBlob(input.casRoot, pointer.digest, coordinatorHint),
     parseGraphShareProfile,
     'Organization graph profile is invalid.',
   );
@@ -237,6 +268,18 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
   if (profileDigest !== input.trust.profileDigest) {
     return {imported: false as const, reason: 'trust-pin-mismatch' as const};
   }
+  const coordinatorUrl =
+    (yield* readGraphShareClientState(input.request.threadnoteHome)).coordinatorUrl ?? profile.coordinator?.url;
+  if (coordinatorUrl !== undefined) {
+    yield* writeGraphShareCoordinatorUrl(input.request.threadnoteHome, coordinatorUrl);
+    yield* refreshFrontierPointerFromCoordinator({
+      branch: profile.source.branches[0] ?? 'refs/heads/main',
+      casRoot: input.casRoot,
+      coordinatorUrl,
+      repositoryId: input.request.identity.repositoryId,
+      threadnoteHome: input.request.threadnoteHome,
+    }).pipe(Effect.catchIf(isUnavailableSharingFailure, () => Effect.void));
+  }
   const layout = graphSharingLayout(path, input.request.threadnoteHome, input.casRoot);
   const pointerPath = graphSharingFrontierPointerPath(path, layout.frontiersRoot, input.request.identity.repositoryId);
   if (!(yield* fs.exists(pointerPath))) {
@@ -248,12 +291,12 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
     'Frontier pointer is invalid.',
   );
   const manifest = yield* decodeJson(
-    yield* readVerifiedCasBlob(input.casRoot, frontierPointer.manifestDigest),
+    yield* ensureSharedCasBlob(input.casRoot, frontierPointer.manifestDigest, coordinatorUrl),
     parseGraphShareFrontierManifest,
     'Frontier manifest is invalid.',
   );
   const envelope = yield* decodeJson(
-    yield* readVerifiedCasBlob(input.casRoot, frontierPointer.envelopeDigest),
+    yield* ensureSharedCasBlob(input.casRoot, frontierPointer.envelopeDigest, coordinatorUrl),
     parseGraphShareSignatureEnvelope,
     'Frontier signature envelope is invalid.',
   );
@@ -261,36 +304,139 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
   if (manifest.repositoryId !== input.request.identity.repositoryId || manifest.profileDigest !== profileDigest) {
     return yield* graphSharingFailure('Frontier manifest does not match the enrolled repository profile.');
   }
+  const selected = yield* selectPublishedAncestorManifest(
+    input.casRoot,
+    input.request.identity,
+    manifest,
+    coordinatorUrl,
+  );
+  if (selected.deltas.length > 0) {
+    return yield* graphSharingFailure(
+      'Incremental frontier deltas are not applied until a checkpoint compaction is published.',
+    );
+  }
   const existing = yield* readSharedGraphProvenance(
     input.request.threadnoteHome,
     input.request.identity.checkoutId,
   ).pipe(Effect.orElseSucceed(() => undefined));
   if (
-    existing?.checkpointDigest === manifest.checkpoint.manifestDigest &&
+    existing?.checkpointDigest === selected.checkpoint.manifestDigest &&
     existing.repositoryId === input.request.identity.repositoryId &&
     existing.profileDigest === profileDigest
   ) {
     return {imported: false as const, reason: 'already-installed' as const, snapshotId: existing.snapshotId};
   }
-  const checkpointPath = yield* verifyCasBlob(input.casRoot, manifest.checkpoint.manifestDigest);
+  const checkpointPath = yield* verifyCasBlob(
+    input.casRoot,
+    yield* ensureSharedCasBlob(input.casRoot, selected.checkpoint.manifestDigest, coordinatorUrl).pipe(
+      Effect.as(selected.checkpoint.manifestDigest),
+    ),
+  );
   yield* sharingProgress(input.request.onProgress, 'applying-deltas');
   const imported = yield* importCodeGraphCheckpointSnapshot(runtimeConfigForHome(input.request.threadnoteHome), {
     cwd: input.request.cwd,
-    expectedDigest: manifest.checkpoint.manifestDigest,
+    expectedDigest: selected.checkpoint.manifestDigest,
     followOnIndex: false,
     input: checkpointPath,
     quiet: true,
   });
   yield* sharingProgress(input.request.onProgress, 'building-local-overlay');
   yield* writeSharedGraphProvenance(input.request.threadnoteHome, input.request.identity.checkoutId, {
-    checkpointDigest: manifest.checkpoint.manifestDigest,
-    frontierCommit: manifest.sourceCommit,
+    checkpointDigest: selected.checkpoint.manifestDigest,
+    frontierCommit: selected.sourceCommit,
     profileDigest,
     repositoryId: input.request.identity.repositoryId,
     schemaVersion: 1,
     snapshotId: imported.result.snapshotId,
   });
   return {imported: true as const, snapshotId: imported.result.snapshotId};
+});
+
+export interface GraphShareContributeStatusOptions {
+  readonly cwd?: string;
+  readonly json?: boolean;
+}
+
+export interface GraphShareContributeSetOptions {
+  readonly cwd?: string;
+  readonly json?: boolean;
+  readonly mode?: string;
+}
+
+export interface GraphWorkerOptions {
+  readonly cas?: string;
+  readonly cwd?: string;
+  readonly json?: boolean;
+}
+
+export const runGraphContributeStatus = Effect.fn('codeGraph.sharing.contributeStatus')(function* (
+  config: RuntimeConfig,
+  options: GraphShareContributeStatusOptions,
+) {
+  const cwd = yield* commandCwd(options.cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  const trust = yield* lookupGraphShareTrustReceipt(config.agentContextHome, identity.repositoryId);
+  const state = yield* readGraphShareClientState(config.agentContextHome);
+  const requested = state.contributionMode ?? 'off';
+  const mode = effectiveGraphShareContributionMode(trust?.accessMode, requested);
+  const queue = yield* readGraphShareContributionQueue(config.agentContextHome, identity.repositoryId, mode);
+  return {
+    accessMode: trust?.accessMode,
+    mode,
+    queued: queue.announcements.length,
+    repositoryId: identity.repositoryId,
+    type: 'code-graph-contribute-status' as const,
+    version: 1 as const,
+  };
+});
+
+export const runGraphContributeSet = Effect.fn('codeGraph.sharing.contributeSet')(function* (
+  config: RuntimeConfig,
+  options: GraphShareContributeSetOptions,
+) {
+  const cwd = yield* commandCwd(options.cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  const trust = yield* lookupGraphShareTrustReceipt(config.agentContextHome, identity.repositoryId);
+  const requested = yield* decodeContributionMode(options.mode);
+  const mode = effectiveGraphShareContributionMode(trust?.accessMode, requested);
+  yield* writeGraphShareContributionMode(config.agentContextHome, mode);
+  return {
+    accessMode: trust?.accessMode,
+    mode,
+    repositoryId: identity.repositoryId,
+    type: 'code-graph-contribute-set' as const,
+    version: 1 as const,
+  };
+});
+
+export const runGraphWorker = Effect.fn('codeGraph.sharing.worker')(function* (
+  config: RuntimeConfig,
+  options: GraphWorkerOptions,
+) {
+  const cwd = yield* commandCwd(options.cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  const trust = yield* lookupGraphShareTrustReceipt(config.agentContextHome, identity.repositoryId);
+  if (trust?.accessMode !== 'join') {
+    return {
+      eligible: 0,
+      skippedMissingBlob: 0,
+      type: 'code-graph-worker' as const,
+      version: 1 as const,
+    };
+  }
+  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas);
+  const advertised = yield* readAdvertisedGraphWorkerActions(config.agentContextHome, identity.repositoryId, casRoot);
+  const presentBlobIds = new Set<string>();
+  for (const action of advertised) {
+    if (yield* graphShareBlobExists(identity.repoRoot, action.gitBlobId)) presentBlobIds.add(action.gitBlobId);
+  }
+  const plan = planGraphWorkerActions(advertised, presentBlobIds);
+  return {
+    eligible: plan.eligible.length,
+    skippedMissingBlob: plan.skippedMissingBlob.length,
+    type: 'code-graph-worker' as const,
+    version: 1 as const,
+  };
 });
 
 const quarantineSharedFailure = Effect.fn('codeGraph.sharing.quarantine')(function* (
@@ -330,9 +476,90 @@ function commandCwd(value: string | undefined) {
   });
 }
 
-function decodeJson<A>(bytes: Uint8Array, parse: (value: unknown) => A, message: string) {
-  return decodeValue(text => parse(JSON.parse(new TextDecoder().decode(text)) as unknown), bytes, message);
+function decodeContributionMode(value: string | undefined) {
+  return Effect.try({
+    try: () => {
+      if (value === undefined || value.trim().length === 0) {
+        throw graphSharingFailure('Contribution mode must be off, passive, idle, or dedicated.');
+      }
+      const mode = value.trim();
+      if ((GRAPH_SHARE_CONTRIBUTION_MODES as readonly string[]).includes(mode)) {
+        return mode as GraphShareContributionMode;
+      }
+      throw graphSharingFailure('Contribution mode must be off, passive, idle, or dedicated.');
+    },
+    catch: cause =>
+      Schema.is(GraphSharingError)(cause) ? cause : graphSharingFailure('Contribution mode is invalid.', cause),
+  });
 }
+
+function decodeJson<A>(bytes: Uint8Array, parse: (value: unknown) => A, message: string) {
+  return decodeJsonBytes(bytes).pipe(
+    Effect.mapError(cause => graphSharingFailure(message, cause)),
+    Effect.flatMap(value => decodeValue(parse, value, message)),
+  );
+}
+
+export const GRAPH_SHARE_ANCESTOR_WALK_LIMIT = 64;
+
+export const selectPublishedAncestorManifest = Effect.fn('codeGraph.sharing.selectPublishedAncestor')(function* (
+  casRoot: string,
+  identity: RepositoryIdentity,
+  latest: GraphShareFrontierManifestV1,
+  coordinatorUrl?: string,
+) {
+  let current = latest;
+  for (let step = 0; step < GRAPH_SHARE_ANCESTOR_WALK_LIMIT; step += 1) {
+    if (yield* graphShareCommitIsAncestor(identity.repoRoot, current.sourceCommit, identity.headCommit)) {
+      return current;
+    }
+    if (current.previousManifestDigest === null) {
+      return yield* graphSharingUnavailable('No published ancestor frontier for this HEAD.');
+    }
+    current = yield* decodeJson(
+      yield* ensureSharedCasBlob(casRoot, current.previousManifestDigest, coordinatorUrl),
+      parseGraphShareFrontierManifest,
+      'Predecessor frontier manifest is invalid.',
+    );
+  }
+  return yield* graphSharingUnavailable('Published ancestor walk exceeded the generation limit.');
+});
+
+const refreshFrontierPointerFromCoordinator = Effect.fn('codeGraph.sharing.refreshFrontierPointer')(function* (input: {
+  readonly branch: string;
+  readonly casRoot: string;
+  readonly coordinatorUrl: string;
+  readonly repositoryId: string;
+  readonly threadnoteHome: string;
+}) {
+  const path = yield* Path.Path;
+  const branchHash = graphShareFrontierDiscoveryTag(input.repositoryId, input.branch).slice('tn-frontier-'.length);
+  const frontier = yield* graphShareControlGetFrontier(input.coordinatorUrl, branchHash);
+  yield* ensureSharedCasBlob(input.casRoot, frontier.manifestDigest, input.coordinatorUrl);
+  yield* ensureSharedCasBlob(input.casRoot, frontier.envelopeDigest, input.coordinatorUrl);
+  const layout = graphSharingLayout(path, input.threadnoteHome, input.casRoot);
+  yield* writePrivateJsonFile(graphSharingFrontierPointerPath(path, layout.frontiersRoot, input.repositoryId), {
+    envelopeDigest: frontier.envelopeDigest,
+    manifestDigest: frontier.manifestDigest,
+    schemaVersion: 1,
+  });
+});
+
+const ensureSharedCasBlob = Effect.fn('codeGraph.sharing.ensureSharedCasBlob')(function* (
+  casRoot: string,
+  digest: string,
+  coordinatorUrl: string | undefined,
+) {
+  return yield* readVerifiedCasBlob(casRoot, digest).pipe(
+    Effect.catchIf(isUnavailableSharingFailure, () =>
+      coordinatorUrl === undefined
+        ? graphSharingUnavailable(`CAS object is missing: ${digest}`)
+        : mirrorCoordinatorCasBlob(casRoot, coordinatorUrl, digest).pipe(
+            Effect.andThen(readVerifiedCasBlob(casRoot, digest)),
+          ),
+    ),
+  );
+});
 
 function decodeValue<A, I>(parse: (value: I) => A, value: I, message: string) {
   return Effect.try({

--- a/src/code_graph/sharing/commands.ts
+++ b/src/code_graph/sharing/commands.ts
@@ -2,15 +2,23 @@ import {Console, Effect} from 'effect';
 import {writeFinalCliOutput} from '../../effect/cli_output.js';
 import type {RuntimeConfig} from '../../types.js';
 import {
+  runGraphContributeSet,
+  runGraphContributeStatus,
   runGraphShareJoin,
   runGraphShareLeave,
   runGraphShareStatus,
+  runGraphWorker,
+  type GraphShareContributeSetOptions,
+  type GraphShareContributeStatusOptions,
   type GraphShareJoinOptions,
   type GraphShareLeaveOptions,
   type GraphShareStatusOptions,
+  type GraphWorkerOptions,
 } from './client.js';
 import {
   runGraphPublisherBootstrap,
+  runGraphPublisherListen,
+  runGraphPublisherServe,
   runGraphShareInit,
   type GraphPublisherBootstrapOptions,
   type GraphShareInitOptions,
@@ -91,6 +99,65 @@ export const runGraphPublisherBootstrapCommand = Effect.fn('codeGraph.sharing.pu
   return result;
 });
 
-export const runGraphPublisherServeCommand = runGraphPublisherBootstrapCommand;
+export const runGraphPublisherServeCommand = Effect.fn('codeGraph.sharing.publisherServeCommand')(function* (
+  config: RuntimeConfig,
+  options: GraphPublisherBootstrapOptions,
+) {
+  if (options.listen !== undefined && options.listen.trim().length > 0) {
+    return yield* runGraphPublisherListen(config, {
+      ...options,
+      listen: options.listen,
+      onReady: output => writeFinalCliOutput(JSON.stringify(output)),
+    });
+  }
+  const result = yield* runGraphPublisherServe(config, options);
+  if (options.json) {
+    yield* writeFinalCliOutput(JSON.stringify(result));
+    return result;
+  }
+  yield* Console.log(
+    `Published generation ${'generation' in result ? result.generation : 1} frontier ${result.manifestDigest} for ${result.sourceCommit}`,
+  );
+  return result;
+});
+
+export const runGraphContributeStatusCommand = Effect.fn('codeGraph.sharing.contributeStatusCommand')(function* (
+  config: RuntimeConfig,
+  options: GraphShareContributeStatusOptions,
+) {
+  const result = yield* runGraphContributeStatus(config, options);
+  if (options.json) {
+    yield* writeFinalCliOutput(JSON.stringify(result));
+    return result;
+  }
+  yield* Console.log(`Graph contribution mode ${result.mode}`);
+  return result;
+});
+
+export const runGraphContributeSetCommand = Effect.fn('codeGraph.sharing.contributeSetCommand')(function* (
+  config: RuntimeConfig,
+  options: GraphShareContributeSetOptions,
+) {
+  const result = yield* runGraphContributeSet(config, options);
+  if (options.json) {
+    yield* writeFinalCliOutput(JSON.stringify(result));
+    return result;
+  }
+  yield* Console.log(`Set graph contribution mode ${result.mode}`);
+  return result;
+});
+
+export const runGraphWorkerCommand = Effect.fn('codeGraph.sharing.workerCommand')(function* (
+  config: RuntimeConfig,
+  options: GraphWorkerOptions,
+) {
+  const result = yield* runGraphWorker(config, options);
+  if (options.json) {
+    yield* writeFinalCliOutput(JSON.stringify(result));
+    return result;
+  }
+  yield* Console.log(`Graph worker eligible ${result.eligible}; skipped missing blobs ${result.skippedMissingBlob}`);
+  return result;
+});
 
 export const runGraphPublisherStatusCommand = runGraphShareStatusCommand;

--- a/src/code_graph/sharing/contribution.ts
+++ b/src/code_graph/sharing/contribution.ts
@@ -1,0 +1,162 @@
+import {Effect, FileSystem, Path} from 'effect';
+import {readJsonFile, writePrivateJsonFile} from './atomic.js';
+import {SHA256_DIGEST} from './digest.js';
+import {graphSharingFailure} from './errors.js';
+import {graphSharingContributionQueuePath, graphSharingLayout} from './layout.js';
+import {GRAPH_SHARE_ACTION_KEY} from './action.js';
+import type {GraphShareResultAnnouncementV1} from './receipts.js';
+
+export const GRAPH_SHARE_CONTRIBUTION_MODES = ['off', 'passive', 'idle', 'dedicated'] as const;
+export type GraphShareContributionMode = (typeof GRAPH_SHARE_CONTRIBUTION_MODES)[number];
+
+export interface GraphShareContributionQueueV1 {
+  readonly announcements: readonly GraphShareResultAnnouncementV1[];
+  readonly mode: GraphShareContributionMode;
+  readonly schemaVersion: 1;
+}
+
+export function emptyGraphShareContributionQueue(
+  mode: GraphShareContributionMode = 'off',
+): GraphShareContributionQueueV1 {
+  return {announcements: [], mode, schemaVersion: 1};
+}
+
+export function effectiveGraphShareContributionMode(
+  accessMode: 'join' | 'read-only' | undefined,
+  requested: GraphShareContributionMode,
+): GraphShareContributionMode {
+  if (accessMode !== 'join') return 'off';
+  if (requested === 'dedicated') return 'passive';
+  return requested;
+}
+
+export function enqueueGraphShareContribution(
+  queue: GraphShareContributionQueueV1,
+  announcement: GraphShareResultAnnouncementV1,
+  accessMode: 'join' | 'read-only' | undefined,
+): {readonly conflict: boolean; readonly queued: boolean; readonly queue: GraphShareContributionQueueV1} {
+  const mode = effectiveGraphShareContributionMode(accessMode, queue.mode);
+  if (mode === 'off') return {conflict: false, queued: false, queue};
+  const duplicate = queue.announcements.some(
+    item =>
+      item.actionKey === announcement.actionKey &&
+      item.resultManifestDigest === announcement.resultManifestDigest &&
+      item.attestationDigest === announcement.attestationDigest &&
+      item.semanticDigest === announcement.semanticDigest,
+  );
+  if (duplicate) return {conflict: false, queued: false, queue};
+  const conflict = queue.announcements.some(
+    item => item.actionKey === announcement.actionKey && item.semanticDigest !== announcement.semanticDigest,
+  );
+  return {
+    conflict,
+    queued: true,
+    queue: {...queue, announcements: [...queue.announcements, announcement], mode},
+  };
+}
+
+export function drainGraphShareContribution(queue: GraphShareContributionQueueV1): {
+  readonly remaining: GraphShareContributionQueueV1;
+  readonly sent: readonly GraphShareResultAnnouncementV1[];
+} {
+  return {
+    remaining: {...queue, announcements: []},
+    sent: queue.announcements,
+  };
+}
+
+export function parseGraphShareContributionQueue(value: unknown): GraphShareContributionQueueV1 {
+  if (!isRecord(value) || value.schemaVersion !== 1) {
+    throw graphSharingFailure('Contribution queue is invalid.');
+  }
+  if (!isContributionMode(value.mode) || !Array.isArray(value.announcements)) {
+    throw graphSharingFailure('Contribution queue is invalid.');
+  }
+  return {
+    announcements: value.announcements.map(parseQueuedAnnouncement),
+    mode: value.mode,
+    schemaVersion: 1,
+  };
+}
+
+export const readGraphShareContributionQueue = Effect.fn('codeGraph.sharing.readContributionQueue')(function* (
+  threadnoteHome: string,
+  repositoryId: string,
+  mode: GraphShareContributionMode,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const queuePath = graphSharingContributionQueuePath(
+    path,
+    graphSharingLayout(path, threadnoteHome).root,
+    repositoryId,
+  );
+  if (!(yield* fs.exists(queuePath))) return emptyGraphShareContributionQueue(mode);
+  return parseGraphShareContributionQueue(yield* readJsonFile(queuePath));
+});
+
+export const writeGraphShareContributionQueue = Effect.fn('codeGraph.sharing.writeContributionQueue')(function* (
+  threadnoteHome: string,
+  repositoryId: string,
+  queue: GraphShareContributionQueueV1,
+) {
+  const path = yield* Path.Path;
+  yield* writePrivateJsonFile(
+    graphSharingContributionQueuePath(path, graphSharingLayout(path, threadnoteHome).root, repositoryId),
+    queue,
+  );
+  return queue;
+});
+
+export const enqueuePersistedGraphShareContribution = Effect.fn('codeGraph.sharing.enqueuePersistedContribution')(
+  function* (
+    threadnoteHome: string,
+    repositoryId: string,
+    accessMode: 'join' | 'read-only' | undefined,
+    announcement: GraphShareResultAnnouncementV1,
+    mode: GraphShareContributionMode,
+  ) {
+    const current = yield* readGraphShareContributionQueue(threadnoteHome, repositoryId, mode);
+    const next = enqueueGraphShareContribution({...current, mode}, announcement, accessMode);
+    if (next.queued) yield* writeGraphShareContributionQueue(threadnoteHome, repositoryId, next.queue);
+    return next;
+  },
+);
+
+function parseQueuedAnnouncement(value: unknown): GraphShareResultAnnouncementV1 {
+  if (!isRecord(value)) throw graphSharingFailure('Contribution announcement is invalid.');
+  const announcement: GraphShareResultAnnouncementV1 = {
+    actionKey: value.actionKey as GraphShareResultAnnouncementV1['actionKey'],
+    attestationDigest: value.attestationDigest as GraphShareResultAnnouncementV1['attestationDigest'],
+    batchId: value.batchId as string,
+    resultManifestDigest: value.resultManifestDigest as GraphShareResultAnnouncementV1['resultManifestDigest'],
+    semanticDigest: value.semanticDigest as GraphShareResultAnnouncementV1['semanticDigest'],
+  };
+  if (typeof value.actionKey !== 'string' || !GRAPH_SHARE_ACTION_KEY.test(value.actionKey)) {
+    throw graphSharingFailure('Contribution announcement action key is invalid.');
+  }
+  if (typeof value.batchId !== 'string' || !/^[0-9a-f]{40}$/u.test(value.batchId)) {
+    throw graphSharingFailure('Contribution announcement batch is invalid.');
+  }
+  if (typeof value.attestationDigest !== 'string' || !SHA256_DIGEST.test(value.attestationDigest)) {
+    throw graphSharingFailure('Contribution announcement attestation digest is invalid.');
+  }
+  if (typeof value.resultManifestDigest !== 'string' || !SHA256_DIGEST.test(value.resultManifestDigest)) {
+    throw graphSharingFailure('Contribution announcement result digest is invalid.');
+  }
+  if (typeof value.semanticDigest !== 'string' || !SHA256_DIGEST.test(value.semanticDigest)) {
+    throw graphSharingFailure('Contribution announcement semantic digest is invalid.');
+  }
+  if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(Object.keys(announcement).sort())) {
+    throw graphSharingFailure('Contribution announcement contains unsupported fields.');
+  }
+  return announcement;
+}
+
+function isContributionMode(value: unknown): value is GraphShareContributionMode {
+  return typeof value === 'string' && (GRAPH_SHARE_CONTRIBUTION_MODES as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/code_graph/sharing/control_client.ts
+++ b/src/code_graph/sharing/control_client.ts
@@ -1,0 +1,286 @@
+import {Effect, Schema} from 'effect';
+import * as FetchHttpClient from 'effect/unstable/http/FetchHttpClient';
+import * as HttpClient from 'effect/unstable/http/HttpClient';
+import * as HttpClientRequest from 'effect/unstable/http/HttpClientRequest';
+import * as HttpClientResponse from 'effect/unstable/http/HttpClientResponse';
+import {HttpRequestFailed, HttpStatusError} from '../../effect/http.js';
+import {GRAPH_SHARE_ACTION_KEY} from './action.js';
+import {putCasBytes} from './cas.js';
+import {GRAPH_SHARE_CONTROL_MAX_BODY_BYTES, type GraphShareControlResponse} from './control_protocol.js';
+import {
+  parseSha256Digest,
+  SHA256_DIGEST,
+  SHA256_HEX,
+  sha256Digest,
+  sha256HexFromDigest,
+  type Sha256Digest,
+} from './digest.js';
+import {graphSharingFailure, graphSharingUnavailable, GraphSharingError} from './errors.js';
+import {GRAPH_SHARE_HTTP_CAS_MAX_BYTES, graphSharePayloadLooksLikeGitObject} from './oci.js';
+import {parseGraphShareCoordinatorUrl} from './profile.js';
+import type {GraphShareResultAnnouncementV1} from './receipts.js';
+
+const dynamicFetch = Object.assign((...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args), {
+  preconnect: (...args: Parameters<typeof globalThis.fetch.preconnect>) => globalThis.fetch.preconnect(...args),
+}) satisfies typeof globalThis.fetch;
+
+const JSON_DECODE = {errors: 'all'} as const;
+const JSON_STATUS_DECODE = {errors: 'all', onExcessProperty: 'ignore'} as const;
+const DigestOrHex = Schema.Union([
+  Schema.String.check(Schema.isPattern(SHA256_DIGEST)),
+  Schema.String.check(Schema.isPattern(SHA256_HEX)),
+]);
+const DigestString = Schema.String.check(Schema.isPattern(SHA256_DIGEST));
+const ResultReceipt = Schema.Struct({
+  actionKey: Schema.String.check(Schema.isPattern(GRAPH_SHARE_ACTION_KEY)),
+  attestationDigest: DigestString,
+  batchId: Schema.String.check(Schema.isPattern(/^[0-9a-f]{40}$/u)),
+  resultManifestDigest: DigestString,
+  semanticDigest: DigestString,
+});
+const CoordinatorStatus = Schema.Struct({
+  generation: Schema.Finite,
+  organization: Schema.String,
+  phase: Schema.String,
+  receipts: Schema.Array(ResultReceipt),
+  repositoryId: Schema.String,
+});
+const CoordinatorFrontier = Schema.Struct({
+  envelopeDigest: DigestOrHex,
+  frontierDigest: Schema.optionalKey(DigestOrHex),
+  manifestDigest: Schema.optionalKey(DigestOrHex),
+});
+const CoordinatorTagBody = Schema.Struct({
+  digest: DigestString,
+});
+
+export interface GraphShareCoordinatorFrontierResponse {
+  readonly envelopeDigest: Sha256Digest;
+  readonly manifestDigest: Sha256Digest;
+}
+
+export interface GraphShareCoordinatorStatusResponse {
+  readonly generation: number;
+  readonly organization: string;
+  readonly phase: string;
+  readonly receipts: readonly GraphShareResultAnnouncementV1[];
+  readonly repositoryId: string;
+}
+
+export const graphShareControlGetJson = Effect.fn('codeGraph.sharing.controlGetJson')(function* (
+  coordinatorUrl: string,
+  pathname: string,
+) {
+  const url = coordinatorPath(coordinatorUrl, pathname);
+  const response = yield* execute(HttpClientRequest.get(url), url, 10_000);
+  if (response.status === 404) return yield* graphSharingUnavailable(`Coordinator path is missing: ${pathname}`);
+  if (response.status < 200 || response.status >= 300) {
+    return yield* graphSharingFailure(`Coordinator GET ${pathname} returned HTTP ${response.status}.`);
+  }
+  return yield* decodeResponseJson(Schema.JsonObject, response);
+});
+
+export const graphShareControlPostJson = Effect.fn('codeGraph.sharing.controlPostJson')(function* (
+  coordinatorUrl: string,
+  pathname: string,
+  body: unknown,
+) {
+  const url = coordinatorPath(coordinatorUrl, pathname);
+  const json = yield* Schema.decodeUnknownEffect(
+    Schema.Json,
+    JSON_DECODE,
+  )(body).pipe(Effect.mapError(cause => graphSharingFailure('Coordinator request is not JSON.', cause)));
+  const request = yield* HttpClientRequest.post(url).pipe(HttpClientRequest.schemaBodyJson(Schema.Json)(json));
+  if (request.body._tag !== 'Uint8Array') {
+    return yield* graphSharingFailure('Coordinator request could not be encoded.');
+  }
+  if (request.body.body.byteLength > GRAPH_SHARE_CONTROL_MAX_BODY_BYTES) {
+    return yield* graphSharingFailure('Coordinator request exceeds the 64 KiB control limit.');
+  }
+  const response = yield* execute(request, url, 10_000);
+  return {
+    body: yield* decodeResponseJson(Schema.Json, response).pipe(Effect.orElseSucceed(() => undefined)),
+    status: response.status,
+  } satisfies GraphShareControlResponse;
+});
+
+export const graphShareControlGetCas = Effect.fn('codeGraph.sharing.controlGetCas')(function* (
+  coordinatorUrl: string,
+  digest: string,
+) {
+  const expected = parseSha256Digest(digest);
+  const url = coordinatorPath(coordinatorUrl, `/v1/cas/sha256/${sha256HexFromDigest(expected)}`);
+  const response = yield* execute(HttpClientRequest.get(url), url, 60_000);
+  if (response.status === 404) return yield* graphSharingUnavailable(`CAS object is missing: ${expected}`);
+  if (response.status < 200 || response.status >= 300) {
+    return yield* graphSharingFailure(`CAS GET returned HTTP ${response.status}.`);
+  }
+  const bytes = yield* readResponseBytes(response, url);
+  if (graphSharePayloadLooksLikeGitObject(bytes)) {
+    return yield* graphSharingFailure('Graph CAS must not serve Git objects.');
+  }
+  if (sha256Digest(bytes) !== expected) {
+    return yield* graphSharingFailure(`CAS object digest mismatch: ${expected}`);
+  }
+  return bytes;
+});
+
+export const graphShareControlPutCas = Effect.fn('codeGraph.sharing.controlPutCas')(function* (
+  coordinatorUrl: string,
+  bytes: Uint8Array,
+) {
+  if (bytes.byteLength > GRAPH_SHARE_HTTP_CAS_MAX_BYTES) {
+    return yield* graphSharingFailure('CAS payload exceeds the HTTP transfer limit.');
+  }
+  if (graphSharePayloadLooksLikeGitObject(bytes)) {
+    return yield* graphSharingFailure('Graph CAS must not store Git objects.');
+  }
+  const digest = sha256Digest(bytes);
+  const url = coordinatorPath(coordinatorUrl, `/v1/cas/sha256/${sha256HexFromDigest(digest)}`);
+  const request = HttpClientRequest.put(url).pipe(HttpClientRequest.bodyUint8Array(bytes, 'application/octet-stream'));
+  const response = yield* execute(request, url, 60_000);
+  if (response.status < 200 || response.status >= 300) {
+    return yield* graphSharingFailure(`CAS PUT returned HTTP ${response.status}.`);
+  }
+  return digest;
+});
+
+export const graphShareControlPutTag = Effect.fn('codeGraph.sharing.controlPutTag')(function* (
+  coordinatorUrl: string,
+  name: string,
+  digest: Sha256Digest,
+) {
+  const url = coordinatorPath(coordinatorUrl, `/v1/tags/${name}`);
+  const request = yield* HttpClientRequest.put(url).pipe(
+    HttpClientRequest.schemaBodyJson(CoordinatorTagBody)({digest}),
+  );
+  const response = yield* execute(request, url, 10_000);
+  if (response.status !== 200 && response.status !== 201) {
+    return yield* graphSharingFailure(`Tag PUT returned HTTP ${response.status}.`);
+  }
+  return digest;
+});
+
+export const graphShareControlGetFrontier = Effect.fn('codeGraph.sharing.controlGetFrontier')(function* (
+  coordinatorUrl: string,
+  branchHash: string,
+) {
+  const url = coordinatorPath(coordinatorUrl, `/v1/frontiers/${branchHash}`);
+  const response = yield* execute(HttpClientRequest.get(url), url, 10_000);
+  if (response.status === 404)
+    return yield* graphSharingUnavailable(`Coordinator path is missing: /v1/frontiers/${branchHash}`);
+  if (response.status < 200 || response.status >= 300) {
+    return yield* graphSharingFailure(`Coordinator GET /v1/frontiers/${branchHash} returned HTTP ${response.status}.`);
+  }
+  const body = yield* decodeResponseJson(CoordinatorFrontier, response);
+  const manifest = body.manifestDigest ?? body.frontierDigest;
+  if (manifest === undefined) return yield* graphSharingFailure('Coordinator frontier response is invalid.');
+  return {
+    envelopeDigest: parseSha256Digest(body.envelopeDigest),
+    manifestDigest: parseSha256Digest(manifest),
+  } satisfies GraphShareCoordinatorFrontierResponse;
+});
+
+export const graphShareControlGetStatus = Effect.fn('codeGraph.sharing.controlGetStatus')(function* (
+  coordinatorUrl: string,
+) {
+  const url = coordinatorPath(coordinatorUrl, '/v1/status');
+  const response = yield* execute(HttpClientRequest.get(url), url, 10_000);
+  if (response.status < 200 || response.status >= 300) {
+    return yield* graphSharingFailure(`Coordinator GET /v1/status returned HTTP ${response.status}.`);
+  }
+  return yield* decodeResponseJson(CoordinatorStatus, response, JSON_STATUS_DECODE);
+});
+
+export const graphShareControlAnnounceResult = Effect.fn('codeGraph.sharing.controlAnnounceResult')(function* (
+  coordinatorUrl: string,
+  announcement: GraphShareResultAnnouncementV1,
+  idempotencyKey: string,
+) {
+  return yield* graphShareControlPostJson(coordinatorUrl, '/v1/results', {
+    ...announcement,
+    idempotencyKey,
+  });
+});
+
+export const mirrorCoordinatorCasBlob = Effect.fn('codeGraph.sharing.mirrorCoordinatorCasBlob')(function* (
+  casRoot: string,
+  coordinatorUrl: string,
+  digest: string,
+) {
+  const bytes = yield* graphShareControlGetCas(coordinatorUrl, digest);
+  const stored = yield* putCasBytes(casRoot, bytes);
+  if (stored !== parseSha256Digest(digest)) {
+    return yield* graphSharingFailure('Mirrored CAS digest does not match the coordinator object.');
+  }
+  return stored;
+});
+
+function coordinatorPath(coordinatorUrl: string, pathname: string): string {
+  return `${parseGraphShareCoordinatorUrl(coordinatorUrl)}${pathname.startsWith('/') ? pathname : `/${pathname}`}`;
+}
+
+function execute(request: HttpClientRequest.HttpClientRequest, urlText: string, timeoutMs: number) {
+  return Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    return yield* client.execute(request).pipe(
+      Effect.provideService(FetchHttpClient.Fetch, dynamicFetch),
+      Effect.mapError(cause =>
+        HttpRequestFailed.make({
+          cause,
+          message: `Graph share request failed: ${urlText}`,
+          method: request.method,
+          url: urlText,
+        }),
+      ),
+    );
+  }).pipe(
+    Effect.timeout(timeoutMs),
+    Effect.mapError(cause => {
+      if (Schema.is(HttpRequestFailed)(cause) || Schema.is(HttpStatusError)(cause)) return cause;
+      return graphSharingUnavailable(`Coordinator is unreachable: ${urlText}`);
+    }),
+    Effect.catchIf(
+      error => Schema.is(HttpRequestFailed)(error),
+      error => graphSharingUnavailable(error.message),
+    ),
+  );
+}
+
+function readResponseBytes(response: HttpClientResponse.HttpClientResponse, urlText: string) {
+  return response.arrayBuffer.pipe(
+    Effect.mapError(cause =>
+      HttpRequestFailed.make({
+        cause,
+        message: `Graph share response could not be read: ${urlText}`,
+        method: response.request.method,
+        url: urlText,
+      }),
+    ),
+    Effect.flatMap(buffer => {
+      const bytes = new Uint8Array(buffer);
+      return bytes.byteLength > GRAPH_SHARE_HTTP_CAS_MAX_BYTES
+        ? graphSharingFailure('Coordinator response exceeds the transfer limit.')
+        : Effect.succeed(bytes);
+    }),
+    Effect.catchIf(
+      error => Schema.is(HttpRequestFailed)(error),
+      error => graphSharingUnavailable(error.message),
+    ),
+  );
+}
+
+function decodeResponseJson<S extends Schema.Constraint>(
+  schema: S,
+  response: HttpClientResponse.HttpClientResponse,
+  options: typeof JSON_DECODE | typeof JSON_STATUS_DECODE = JSON_DECODE,
+) {
+  return HttpClientResponse.schemaBodyJson(
+    schema,
+    options,
+  )(response).pipe(
+    Effect.mapError(cause =>
+      Schema.is(GraphSharingError)(cause) ? cause : graphSharingFailure('Coordinator JSON is invalid.', cause),
+    ),
+  );
+}

--- a/src/code_graph/sharing/control_protocol.ts
+++ b/src/code_graph/sharing/control_protocol.ts
@@ -1,0 +1,261 @@
+import {Schema} from 'effect';
+import {GRAPH_SHARE_ACTION_KEY} from './action.js';
+import {SHA256_DIGEST, SHA256_HEX} from './digest.js';
+import {
+  announceGraphShareResult,
+  emptyGraphShareReceiptStore,
+  type GraphShareReceiptStoreV1,
+  type GraphShareResultAnnouncementV1,
+} from './receipts.js';
+import type {GraphShareFrontierMachineV1} from './frontier.js';
+import {idleGraphShareFrontier} from './frontier.js';
+
+export const GRAPH_SHARE_CONTROL_MAX_BODY_BYTES = 64 * 1024;
+export const GRAPH_SHARE_CONTROL_STATUS_RECEIPT_LIMIT = 256;
+export const GRAPH_SHARE_CONTROL_FORBIDDEN_FIELDS = [
+  'blob',
+  'files',
+  'gitTree',
+  'graph',
+  'graphRecords',
+  'markdownBody',
+  'records',
+  'registryDestination',
+  'source',
+  'sourceText',
+] as const;
+
+const STRICT = {errors: 'all', onExcessProperty: 'error'} as const;
+const HexId = Schema.String.check(Schema.isPattern(SHA256_HEX));
+const Digest = Schema.String.check(Schema.isPattern(SHA256_DIGEST));
+const ActionKey = Schema.String.check(Schema.isPattern(GRAPH_SHARE_ACTION_KEY));
+const BatchId = Schema.String.check(Schema.isPattern(/^[0-9a-f]{40}$/u));
+
+const EnrollRequest = Schema.Struct({
+  idempotencyKey: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(128)),
+  repositoryId: HexId,
+});
+
+const ResultAnnouncementRequest = Schema.Struct({
+  actionKey: ActionKey,
+  attestationDigest: Digest,
+  batchId: BatchId,
+  idempotencyKey: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(128)),
+  resultManifestDigest: Digest,
+  semanticDigest: Digest,
+});
+
+const ClaimRequest = Schema.Struct({
+  actionKey: ActionKey,
+  batchId: BatchId,
+  idempotencyKey: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(128)),
+});
+
+const AssemblyLeaseRequest = Schema.Struct({
+  batchId: BatchId,
+  idempotencyKey: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(128)),
+});
+
+export interface GraphShareControlRequest {
+  readonly body?: unknown;
+  readonly bodyBytes: number;
+  readonly method: 'GET' | 'POST';
+  readonly path: string;
+}
+
+export interface GraphShareControlResponse {
+  readonly body: unknown;
+  readonly status: number;
+}
+
+export interface GraphShareFrontierPointerDigestV1 {
+  readonly envelopeDigest: string;
+  readonly manifestDigest: string;
+}
+
+export interface GraphShareCoordinatorStateV1 {
+  readonly claims: Readonly<Record<string, string>>;
+  readonly enrollments: Readonly<Record<string, string>>;
+  readonly frontierByBranch: Readonly<Record<string, GraphShareFrontierPointerDigestV1>>;
+  readonly machine: GraphShareFrontierMachineV1;
+  readonly organization: string;
+  readonly receipts: GraphShareReceiptStoreV1;
+  readonly repositoryId: string;
+  readonly workByBatch: Readonly<Record<string, string>>;
+}
+
+export function emptyGraphShareCoordinatorState(input: {
+  readonly organization: string;
+  readonly repositoryId: string;
+}): GraphShareCoordinatorStateV1 {
+  return {
+    claims: {},
+    enrollments: {},
+    frontierByBranch: {},
+    machine: idleGraphShareFrontier(),
+    organization: input.organization,
+    receipts: emptyGraphShareReceiptStore(),
+    repositoryId: input.repositoryId,
+    workByBatch: {},
+  };
+}
+
+export function setGraphShareCoordinatorFrontier(
+  state: GraphShareCoordinatorStateV1,
+  branchHash: string,
+  pointer: GraphShareFrontierPointerDigestV1,
+): GraphShareCoordinatorStateV1 {
+  return {
+    ...state,
+    frontierByBranch: {...state.frontierByBranch, [branchHash]: pointer},
+  };
+}
+
+export function dispatchGraphShareControl(
+  state: GraphShareCoordinatorStateV1,
+  request: GraphShareControlRequest,
+): {readonly response: GraphShareControlResponse; readonly state: GraphShareCoordinatorStateV1} {
+  if (request.bodyBytes > GRAPH_SHARE_CONTROL_MAX_BODY_BYTES) {
+    return {response: {body: {error: 'payload-too-large'}, status: 413}, state};
+  }
+  const forbidden = forbiddenControlField(request.body);
+  if (forbidden !== undefined) {
+    return {response: {body: {error: 'source-or-graph-payload'}, status: 400}, state};
+  }
+  if (request.method === 'GET' && request.path === '/.well-known/threadnote-graph') {
+    return {
+      response: {
+        body: {organization: state.organization, protocolVersions: ['v1'], repositoryId: state.repositoryId},
+        status: 200,
+      },
+      state,
+    };
+  }
+  if (request.method === 'GET' && request.path === '/v1/status') {
+    return {
+      response: {
+        body: {
+          generation: state.machine.generation,
+          organization: state.organization,
+          phase: state.machine.phase,
+          publishedFrontier: state.machine.publishedFrontier,
+          receipts: state.receipts.receipts.slice(-GRAPH_SHARE_CONTROL_STATUS_RECEIPT_LIMIT),
+          repositoryId: state.repositoryId,
+        },
+        status: 200,
+      },
+      state,
+    };
+  }
+  const frontierMatch = request.method === 'GET' ? /^\/v1\/frontiers\/([0-9a-f]{40})$/u.exec(request.path) : null;
+  if (frontierMatch?.[1] !== undefined) {
+    const pointer = state.frontierByBranch[frontierMatch[1]];
+    if (pointer === undefined) return {response: {body: {error: 'not-found'}, status: 404}, state};
+    return {
+      response: {
+        body: {
+          envelopeDigest: pointer.envelopeDigest,
+          frontierDigest: pointer.manifestDigest,
+          manifestDigest: pointer.manifestDigest,
+        },
+        status: 200,
+      },
+      state,
+    };
+  }
+  const workMatch = request.method === 'GET' ? /^\/v1\/work\/([0-9a-f]{40})$/u.exec(request.path) : null;
+  if (workMatch?.[1] !== undefined) {
+    const digest = state.workByBatch[workMatch[1]];
+    if (digest === undefined) return {response: {body: {error: 'not-found'}, status: 404}, state};
+    return {response: {body: {cancelled: false, workManifestDigest: digest}, status: 200}, state};
+  }
+  if (request.method === 'POST' && request.path === '/v1/enroll') {
+    const body = decodeEnroll(request.body);
+    if (body === undefined) return {response: {body: {error: 'invalid-request'}, status: 400}, state};
+    if (body.repositoryId !== state.repositoryId) {
+      return {response: {body: {error: 'repository-scope'}, status: 403}, state};
+    }
+    const existing = state.enrollments[body.idempotencyKey];
+    const workerId = existing ?? `worker:${body.idempotencyKey}`;
+    return {
+      response: {body: {workerId}, status: existing === undefined ? 201 : 200},
+      state: {
+        ...state,
+        enrollments: {...state.enrollments, [body.idempotencyKey]: workerId},
+      },
+    };
+  }
+  if (request.method === 'POST' && request.path === '/v1/results') {
+    const body = decodeResultAnnouncement(request.body);
+    if (body === undefined) return {response: {body: {error: 'invalid-request'}, status: 400}, state};
+    const announcement: GraphShareResultAnnouncementV1 = {
+      actionKey: body.actionKey,
+      attestationDigest: body.attestationDigest as GraphShareResultAnnouncementV1['attestationDigest'],
+      batchId: body.batchId,
+      resultManifestDigest: body.resultManifestDigest as GraphShareResultAnnouncementV1['resultManifestDigest'],
+      semanticDigest: body.semanticDigest as GraphShareResultAnnouncementV1['semanticDigest'],
+    };
+    const announced = announceGraphShareResult(state.receipts, announcement);
+    const status = announced.status === 'duplicate' ? 200 : announced.status === 'quarantined' ? 409 : 201;
+    return {
+      response: {body: {status: announced.status}, status},
+      state: {...state, receipts: announced.store},
+    };
+  }
+  if (request.method === 'POST' && request.path === '/v1/claims') {
+    const body = decodeClaim(request.body);
+    if (body === undefined) return {response: {body: {error: 'invalid-request'}, status: 400}, state};
+    const existing = state.claims[body.idempotencyKey];
+    const claimId = existing ?? `${body.batchId}:${body.actionKey}`;
+    return {
+      response: {body: {claimId, soft: true}, status: 200},
+      state: {...state, claims: {...state.claims, [body.idempotencyKey]: claimId}},
+    };
+  }
+  if (request.method === 'POST' && request.path === '/v1/assembly-leases') {
+    const body = decodeAssemblyLease(request.body);
+    if (body === undefined) return {response: {body: {error: 'invalid-request'}, status: 400}, state};
+    return {response: {body: {batchId: body.batchId, leased: true}, status: 200}, state};
+  }
+  return {response: {body: {error: 'not-found'}, status: 404}, state};
+}
+
+function forbiddenControlField(body: unknown): string | undefined {
+  if (body === undefined || body === null || typeof body !== 'object' || Array.isArray(body)) return undefined;
+  for (const key of GRAPH_SHARE_CONTROL_FORBIDDEN_FIELDS) {
+    if (Object.hasOwn(body, key)) return key;
+  }
+  return undefined;
+}
+
+function decodeEnroll(body: unknown) {
+  try {
+    return Schema.decodeUnknownSync(EnrollRequest, STRICT)(body);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeResultAnnouncement(body: unknown) {
+  try {
+    return Schema.decodeUnknownSync(ResultAnnouncementRequest, STRICT)(body);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeClaim(body: unknown) {
+  try {
+    return Schema.decodeUnknownSync(ClaimRequest, STRICT)(body);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeAssemblyLease(body: unknown) {
+  try {
+    return Schema.decodeUnknownSync(AssemblyLeaseRequest, STRICT)(body);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/code_graph/sharing/control_server.ts
+++ b/src/code_graph/sharing/control_server.ts
@@ -1,0 +1,383 @@
+import * as BunHttpServer from '@effect/platform-bun/BunHttpServer';
+import {Effect, FileSystem, Layer, Path, Ref, Schema} from 'effect';
+import * as HttpServer from 'effect/unstable/http/HttpServer';
+import * as HttpServerRequest from 'effect/unstable/http/HttpServerRequest';
+import * as HttpServerResponse from 'effect/unstable/http/HttpServerResponse';
+import {readJsonFile, writePrivateJsonFile} from './atomic.js';
+import {putCasBytes, readVerifiedCasBlob, verifyCasBlob} from './cas.js';
+import {
+  dispatchGraphShareControl,
+  emptyGraphShareCoordinatorState,
+  setGraphShareCoordinatorFrontier,
+  GRAPH_SHARE_CONTROL_MAX_BODY_BYTES,
+  type GraphShareCoordinatorStateV1,
+  type GraphShareFrontierPointerDigestV1,
+} from './control_protocol.js';
+import {
+  parseSha256Digest,
+  SHA256_DIGEST,
+  SHA256_HEX,
+  sha256Digest,
+  sha256HexFromDigest,
+  type Sha256Digest,
+} from './digest.js';
+import {graphSharingFailure, GraphSharingError} from './errors.js';
+import {withExclusiveFileLock} from '../../effect/file_lock.js';
+import {graphSharingLayout, graphSharingTagPath} from './layout.js';
+import {
+  GRAPH_SHARE_HTTP_CAS_MAX_BYTES,
+  assertGraphShareDiscoveryTag,
+  graphSharePayloadLooksLikeGitObject,
+  parseGraphShareHttpCasPath,
+  parseGraphShareHttpTagPath,
+} from './oci.js';
+import {graphShareFrontierDiscoveryTag} from './namespace.js';
+
+export const GRAPH_SHARE_PUBLISHER_WATCH_INTERVAL = '5 seconds' as const;
+
+const GRAPH_SHARE_COORDINATOR_LOCK_OPTIONS = {
+  heartbeatIntervalMilliseconds: 10_000,
+  retryIntervalMilliseconds: 25,
+  staleAfterMilliseconds: 30_000,
+  waitTimeoutMilliseconds: 30_000,
+} as const;
+
+const STRICT = {errors: 'all', onExcessProperty: 'error'} as const;
+const GraphShareHttpTagBody = Schema.Struct({
+  digest: Schema.Union([
+    Schema.String.check(Schema.isPattern(SHA256_DIGEST)),
+    Schema.String.check(Schema.isPattern(SHA256_HEX)),
+  ]),
+});
+
+export interface GraphShareListenAddress {
+  readonly hostname: '127.0.0.1' | 'localhost';
+  readonly port: number;
+}
+
+export interface GraphSharePublishedFrontier {
+  readonly branch: string;
+  readonly envelopeDigest: Sha256Digest;
+  readonly manifestDigest: Sha256Digest;
+  readonly repositoryId: string;
+}
+
+export interface GraphShareControlServerOptions<E = never, R = never> {
+  readonly casRoot: string;
+  readonly listen: GraphShareListenAddress;
+  readonly onListening?: (info: {readonly port: number; readonly url: string}) => Effect.Effect<void, E, R>;
+  readonly organization: string;
+  readonly republish?: Effect.Effect<GraphSharePublishedFrontier, E, R>;
+  readonly repositoryId: string;
+  readonly threadnoteHome: string;
+}
+
+export function parseGraphShareListenAddress(value: string): GraphShareListenAddress {
+  const match = /^(127\.0\.0\.1|localhost):(\d{1,5})$/u.exec(value.trim());
+  if (match?.[1] === undefined || match[2] === undefined) {
+    throw graphSharingFailure('Listen address must be 127.0.0.1:port or localhost:port.');
+  }
+  const port = Number(match[2]);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw graphSharingFailure('Listen port is invalid.');
+  }
+  return {hostname: match[1] as GraphShareListenAddress['hostname'], port};
+}
+
+export const runGraphShareControlServer = Effect.fn('codeGraph.sharing.controlServer')(function* <E, R>(
+  options: GraphShareControlServerOptions<E, R>,
+) {
+  return yield* Effect.scoped(
+    Layer.build(BunHttpServer.layer({hostname: options.listen.hostname, port: options.listen.port})).pipe(
+      Effect.flatMap(context =>
+        Effect.gen(function* () {
+          const server = yield* HttpServer.HttpServer;
+          const stateRef = yield* Ref.make(yield* loadCoordinatorState(options));
+          yield* server.serve(handleGraphShareHttp(options, stateRef));
+          const actualPort = server.address._tag === 'TcpAddress' ? server.address.port : options.listen.port;
+          const url = `http://${options.listen.hostname}:${actualPort}`;
+          yield* options.onListening?.({port: actualPort, url}) ?? Effect.void;
+          if (options.republish !== undefined) {
+            yield* Effect.forkScoped(watchPublishedFrontier(options, stateRef, options.republish));
+          }
+          return yield* Effect.never;
+        }).pipe(Effect.provide(context)),
+      ),
+    ),
+  );
+});
+
+export const recordPublishedFrontier = Effect.fn('codeGraph.sharing.recordPublishedFrontier')(function* (
+  options: Pick<GraphShareControlServerOptions, 'casRoot' | 'organization' | 'repositoryId' | 'threadnoteHome'>,
+  published: {
+    readonly branch: string;
+    readonly envelopeDigest: Sha256Digest;
+    readonly manifestDigest: Sha256Digest;
+    readonly repositoryId: string;
+  },
+  stateRef?: Ref.Ref<GraphShareCoordinatorStateV1>,
+) {
+  const path = yield* Path.Path;
+  const branchHash = frontierBranchHash(published.repositoryId, published.branch);
+  const pointer: GraphShareFrontierPointerDigestV1 = {
+    envelopeDigest: published.envelopeDigest,
+    manifestDigest: published.manifestDigest,
+  };
+  yield* writePrivateJsonFile(graphSharingTagPath(path, options.casRoot, `tn-frontier-${branchHash}`), {
+    digest: published.manifestDigest,
+    envelopeDigest: published.envelopeDigest,
+    schemaVersion: 1,
+  });
+  if (stateRef === undefined) return pointer;
+  yield* withCoordinatorStateLock(
+    options,
+    Effect.gen(function* () {
+      const next = yield* Ref.modify(stateRef, current => {
+        const updated = setGraphShareCoordinatorFrontier(current, branchHash, pointer);
+        return [updated, updated] as const;
+      });
+      yield* persistCoordinatorState(options, next);
+    }),
+  );
+  return pointer;
+});
+
+const handleGraphShareHttp = (
+  options: Pick<GraphShareControlServerOptions, 'casRoot' | 'organization' | 'repositoryId' | 'threadnoteHome'>,
+  stateRef: Ref.Ref<GraphShareCoordinatorStateV1>,
+) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const pathname = requestUrlPath(request.url);
+    const method = request.method;
+    const casHex = parseGraphShareHttpCasPath(pathname);
+    if (casHex !== undefined) {
+      if (method === 'GET' || method === 'HEAD') return yield* serveCasBlob(options.casRoot, casHex, method === 'HEAD');
+      if (method === 'PUT') return yield* receiveCasBlob(options.casRoot, casHex, request);
+      return HttpServerResponse.jsonUnsafe({error: 'method-not-allowed'}, {status: 405});
+    }
+    const tagName = parseGraphShareHttpTagPath(pathname);
+    if (tagName !== undefined) {
+      if (method === 'GET' || method === 'HEAD') return yield* serveTag(options.casRoot, tagName);
+      if (method === 'PUT') return yield* receiveTag(options.casRoot, tagName, request);
+      return HttpServerResponse.jsonUnsafe({error: 'method-not-allowed'}, {status: 405});
+    }
+    if (method !== 'GET' && method !== 'POST' && method !== 'HEAD') {
+      return HttpServerResponse.jsonUnsafe({error: 'method-not-allowed'}, {status: 405});
+    }
+    const raw =
+      method === 'POST' ? yield* readBoundedBody(request, GRAPH_SHARE_CONTROL_MAX_BODY_BYTES) : new Uint8Array();
+    const parsed =
+      method === 'POST'
+        ? yield* HttpServerRequest.schemaBodyJson(Schema.Json, {errors: 'all'}).pipe(Effect.option)
+        : undefined;
+    if (parsed?._tag === 'None') {
+      return HttpServerResponse.jsonUnsafe({error: 'invalid-request'}, {status: 400});
+    }
+    const body = parsed?._tag === 'Some' ? parsed.value : undefined;
+    const controlRequest = {
+      ...(body === undefined ? {} : {body}),
+      bodyBytes: raw.byteLength,
+      method: method === 'HEAD' ? 'GET' : method,
+      path: pathname,
+    } as const;
+    if (method === 'GET' || method === 'HEAD') {
+      const dispatched = dispatchGraphShareControl(yield* Ref.get(stateRef), controlRequest);
+      return HttpServerResponse.jsonUnsafe(dispatched.response.body, {status: dispatched.response.status});
+    }
+    const dispatched = yield* commitCoordinatorDispatch(options, stateRef, controlRequest);
+    return HttpServerResponse.jsonUnsafe(dispatched.response.body, {status: dispatched.response.status});
+  }).pipe(
+    Effect.catch(error =>
+      Effect.succeed(
+        HttpServerResponse.jsonUnsafe(
+          {
+            error:
+              Schema.is(GraphSharingError)(error) && error.message.includes('exceeds')
+                ? 'payload-too-large'
+                : Schema.isSchemaError(error)
+                  ? 'invalid-request'
+                  : 'unavailable',
+          },
+          {
+            status:
+              Schema.is(GraphSharingError)(error) && error.message.includes('exceeds')
+                ? 413
+                : Schema.isSchemaError(error)
+                  ? 400
+                  : 500,
+          },
+        ),
+      ),
+    ),
+  );
+
+const watchPublishedFrontier = <E, R>(
+  options: GraphShareControlServerOptions<E, R>,
+  stateRef: Ref.Ref<GraphShareCoordinatorStateV1>,
+  republish: Effect.Effect<GraphSharePublishedFrontier, E, R>,
+) =>
+  Effect.forever(
+    Effect.sleep(GRAPH_SHARE_PUBLISHER_WATCH_INTERVAL).pipe(
+      Effect.andThen(
+        republish.pipe(
+          Effect.flatMap(published => recordPublishedFrontier(options, published, stateRef)),
+          Effect.ignore,
+        ),
+      ),
+    ),
+  );
+
+function requestUrlPath(url: string): string {
+  try {
+    return new URL(url, 'http://127.0.0.1').pathname;
+  } catch {
+    return url.split('?')[0] ?? url;
+  }
+}
+
+const serveCasBlob = Effect.fn('codeGraph.sharing.serveCasBlob')(function* (
+  casRoot: string,
+  hex: string,
+  head: boolean,
+) {
+  const bytes = yield* readVerifiedCasBlob(casRoot, `sha256:${hex}`).pipe(Effect.orElseSucceed(() => undefined));
+  if (bytes === undefined) return HttpServerResponse.jsonUnsafe({error: 'not-found'}, {status: 404});
+  if (graphSharePayloadLooksLikeGitObject(bytes)) {
+    return HttpServerResponse.jsonUnsafe({error: 'not-found'}, {status: 404});
+  }
+  if (head) return HttpServerResponse.empty({status: 200});
+  return HttpServerResponse.uint8Array(bytes, {contentType: 'application/octet-stream', status: 200});
+});
+
+const receiveCasBlob = Effect.fn('codeGraph.sharing.receiveCasBlob')(function* (
+  casRoot: string,
+  hex: string,
+  request: HttpServerRequest.HttpServerRequest,
+) {
+  const bytes = yield* readBoundedBody(request, GRAPH_SHARE_HTTP_CAS_MAX_BYTES);
+  if (graphSharePayloadLooksLikeGitObject(bytes)) {
+    return HttpServerResponse.jsonUnsafe({error: 'git-object-forbidden'}, {status: 400});
+  }
+  const digest = sha256Digest(bytes);
+  if (sha256HexFromDigest(digest) !== hex) {
+    return HttpServerResponse.jsonUnsafe({error: 'digest-mismatch'}, {status: 400});
+  }
+  yield* putCasBytes(casRoot, bytes);
+  yield* verifyCasBlob(casRoot, digest);
+  return HttpServerResponse.jsonUnsafe({digest}, {status: 201});
+});
+
+const serveTag = Effect.fn('codeGraph.sharing.serveTag')(function* (casRoot: string, name: string) {
+  const path = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
+  const tagPath = graphSharingTagPath(path, casRoot, name);
+  if (!(yield* fs.exists(tagPath))) return HttpServerResponse.jsonUnsafe({error: 'not-found'}, {status: 404});
+  const value = yield* readJsonFile(tagPath);
+  return HttpServerResponse.jsonUnsafe(value, {status: 200});
+});
+
+const receiveTag = Effect.fn('codeGraph.sharing.receiveTag')(function* (
+  casRoot: string,
+  name: string,
+  request: HttpServerRequest.HttpServerRequest,
+) {
+  assertGraphShareDiscoveryTag(name);
+  yield* readBoundedBody(request, GRAPH_SHARE_CONTROL_MAX_BODY_BYTES);
+  const decoded = yield* HttpServerRequest.schemaBodyJson(GraphShareHttpTagBody, STRICT).pipe(Effect.option);
+  if (decoded._tag === 'None') {
+    return HttpServerResponse.jsonUnsafe({error: 'invalid-request'}, {status: 400});
+  }
+  const digest = parseSha256Digest(decoded.value.digest);
+  const path = yield* Path.Path;
+  yield* writePrivateJsonFile(graphSharingTagPath(path, casRoot, name), {digest, schemaVersion: 1});
+  return HttpServerResponse.jsonUnsafe({digest}, {status: 201});
+});
+
+const readBoundedBody = (request: HttpServerRequest.HttpServerRequest, maximum: number) =>
+  Effect.gen(function* () {
+    const declared = Number(request.headers['content-length'] ?? '0');
+    if (Number.isFinite(declared) && declared > maximum) {
+      return yield* graphSharingFailure('Request body exceeds the transfer limit.');
+    }
+    const buffer = yield* request.arrayBuffer;
+    const bytes = new Uint8Array(buffer);
+    if (bytes.byteLength > maximum) {
+      return yield* graphSharingFailure('Request body exceeds the transfer limit.');
+    }
+    return bytes;
+  });
+
+const loadCoordinatorState = Effect.fn('codeGraph.sharing.loadCoordinatorState')(function* (
+  options: Pick<GraphShareControlServerOptions, 'organization' | 'repositoryId' | 'threadnoteHome'>,
+) {
+  const path = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
+  const layout = graphSharingLayout(path, options.threadnoteHome);
+  const empty = emptyGraphShareCoordinatorState({
+    organization: options.organization,
+    repositoryId: options.repositoryId,
+  });
+  if (!(yield* fs.exists(layout.coordinatorStatePath))) return empty;
+  const loaded = yield* readJsonFile(layout.coordinatorStatePath).pipe(Effect.option);
+  if (loaded._tag === 'None' || !isCoordinatorState(loaded.value, options.repositoryId)) return empty;
+  return loaded.value;
+});
+
+const persistCoordinatorState = Effect.fn('codeGraph.sharing.persistCoordinatorState')(function* (
+  options: Pick<GraphShareControlServerOptions, 'threadnoteHome'>,
+  state: GraphShareCoordinatorStateV1,
+) {
+  const path = yield* Path.Path;
+  const layout = graphSharingLayout(path, options.threadnoteHome);
+  yield* writePrivateJsonFile(layout.coordinatorStatePath, state);
+});
+
+const commitCoordinatorDispatch = (
+  options: Pick<GraphShareControlServerOptions, 'threadnoteHome'>,
+  stateRef: Ref.Ref<GraphShareCoordinatorStateV1>,
+  request: Parameters<typeof dispatchGraphShareControl>[1],
+) =>
+  withCoordinatorStateLock(
+    options,
+    Effect.gen(function* () {
+      const dispatched = yield* Ref.modify(stateRef, state => {
+        const next = dispatchGraphShareControl(state, request);
+        return [{persist: next.state !== state, response: next.response, state: next.state}, next.state] as const;
+      });
+      if (dispatched.persist) {
+        yield* persistCoordinatorState(options, dispatched.state);
+      }
+      return dispatched;
+    }),
+  );
+
+function withCoordinatorStateLock<A, E, R>(
+  options: Pick<GraphShareControlServerOptions, 'threadnoteHome'>,
+  effect: Effect.Effect<A, E, R>,
+) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const layout = graphSharingLayout(path, options.threadnoteHome);
+    return yield* withExclusiveFileLock(
+      fs,
+      layout.coordinatorStateLockPath,
+      GRAPH_SHARE_COORDINATOR_LOCK_OPTIONS,
+      effect,
+    );
+  });
+}
+
+function frontierBranchHash(repositoryId: string, branch: string): string {
+  return graphShareFrontierDiscoveryTag(repositoryId, branch).slice('tn-frontier-'.length);
+}
+
+function isCoordinatorState(value: unknown, repositoryId: string): value is GraphShareCoordinatorStateV1 {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'repositoryId' in value &&
+    (value as GraphShareCoordinatorStateV1).repositoryId === repositoryId
+  );
+}

--- a/src/code_graph/sharing/delta.ts
+++ b/src/code_graph/sharing/delta.ts
@@ -1,0 +1,98 @@
+import {canonicalJson} from '../checkpoint/canonical_json.js';
+import {compareCodeUnits} from '../ordering.js';
+import {sha256Digest, type Sha256Digest} from './digest.js';
+import {graphSharingFailure} from './errors.js';
+
+export interface GraphShareLogicalModel {
+  readonly records: ReadonlyMap<string, string>;
+}
+
+export interface GraphShareLogicalDeltaV1 {
+  readonly baseCommit: string;
+  readonly baseLogicalDigest: Sha256Digest;
+  readonly baseSnapshotId: string;
+  readonly deletions: readonly string[];
+  readonly graphAbi: string;
+  readonly targetCommit: string;
+  readonly targetLogicalDigest: Sha256Digest;
+  readonly upserts: readonly {readonly key: string; readonly value: string}[];
+}
+
+export function emptyLogicalGraph(): GraphShareLogicalModel {
+  return {records: new Map()};
+}
+
+export function setLogicalRecord(model: GraphShareLogicalModel, key: string, value: string): GraphShareLogicalModel {
+  const records = new Map(model.records);
+  records.set(key, value);
+  return {records};
+}
+
+export function deleteLogicalRecord(model: GraphShareLogicalModel, key: string): GraphShareLogicalModel {
+  const records = new Map(model.records);
+  records.delete(key);
+  return {records};
+}
+
+export function logicalGraphDigest(model: GraphShareLogicalModel): Sha256Digest {
+  return sha256Digest(
+    canonicalJson(
+      Object.fromEntries([...model.records.entries()].sort(([left], [right]) => compareCodeUnits(left, right))),
+    ),
+  );
+}
+
+export function diffLogicalGraphs(
+  base: GraphShareLogicalModel,
+  target: GraphShareLogicalModel,
+  meta: {
+    readonly baseCommit: string;
+    readonly baseSnapshotId: string;
+    readonly graphAbi: string;
+    readonly targetCommit: string;
+  },
+): GraphShareLogicalDeltaV1 {
+  const deletions = [...base.records.keys()].filter(key => !target.records.has(key)).sort(compareCodeUnits);
+  const upserts = [...target.records.entries()]
+    .filter(([key, value]) => base.records.get(key) !== value)
+    .sort(([left], [right]) => compareCodeUnits(left, right))
+    .map(([key, value]) => ({key, value}));
+  return {
+    ...meta,
+    baseLogicalDigest: logicalGraphDigest(base),
+    deletions,
+    targetLogicalDigest: logicalGraphDigest(target),
+    upserts,
+  };
+}
+
+export function applyLogicalDelta(
+  base: GraphShareLogicalModel,
+  delta: GraphShareLogicalDeltaV1,
+): GraphShareLogicalModel {
+  if (logicalGraphDigest(base) !== delta.baseLogicalDigest) {
+    throw graphSharingFailure('Delta base digest does not match the selected graph.');
+  }
+  let next = base;
+  for (const key of delta.deletions) next = deleteLogicalRecord(next, key);
+  for (const upsert of delta.upserts) next = setLogicalRecord(next, upsert.key, upsert.value);
+  if (logicalGraphDigest(next) !== delta.targetLogicalDigest) {
+    throw graphSharingFailure('Delta target digest does not match the applied records.');
+  }
+  return next;
+}
+
+export function compactLogicalGraph(model: GraphShareLogicalModel): GraphShareLogicalModel {
+  return {records: new Map(model.records)};
+}
+
+export function selectNewestPublishedAncestor<T extends {readonly sourceCommit: string}>(
+  published: readonly T[],
+  isAncestorOfHead: (commit: string) => boolean,
+): T | undefined {
+  for (let index = published.length - 1; index >= 0; index -= 1) {
+    const candidate = published[index];
+    if (candidate !== undefined && isAncestorOfHead(candidate.sourceCommit)) return candidate;
+  }
+  return undefined;
+}

--- a/src/code_graph/sharing/frontier.ts
+++ b/src/code_graph/sharing/frontier.ts
@@ -1,0 +1,157 @@
+import {sha256HexSync} from '../../crypto/sha256.js';
+import type {Sha256Digest} from './digest.js';
+
+export type GraphShareFrontierPhase =
+  'assembling' | 'collecting' | 'failed' | 'frozen' | 'idle' | 'published' | 'verifying';
+
+export interface GraphShareFrontierThresholds {
+  readonly maximumAgeSeconds: number;
+  readonly maximumChangedBytes: number;
+  readonly maximumChangedFiles: number;
+}
+
+export interface GraphShareFrontierMachineV1 {
+  readonly buildingFrontier: string | null;
+  readonly collectingStartedAtSeconds: number | null;
+  readonly frozenActionKeys: readonly string[];
+  readonly frozenBatchId: string | null;
+  readonly generation: number;
+  readonly observedHead: string | null;
+  readonly pendingRange: readonly string[];
+  readonly phase: GraphShareFrontierPhase;
+  readonly previousManifestDigest: Sha256Digest | null;
+  readonly publishedFrontier: string | null;
+}
+
+export function idleGraphShareFrontier(): GraphShareFrontierMachineV1 {
+  return {
+    buildingFrontier: null,
+    collectingStartedAtSeconds: null,
+    frozenActionKeys: [],
+    frozenBatchId: null,
+    generation: 0,
+    observedHead: null,
+    pendingRange: [],
+    phase: 'idle',
+    previousManifestDigest: null,
+    publishedFrontier: null,
+  };
+}
+
+export function observeCanonicalHead(
+  state: GraphShareFrontierMachineV1,
+  input: {readonly commit: string; readonly isDescendantOfPublished: boolean; readonly nowSeconds: number},
+): GraphShareFrontierMachineV1 {
+  if (!input.isDescendantOfPublished && state.publishedFrontier !== null && input.commit !== state.publishedFrontier) {
+    return {
+      ...idleGraphShareFrontier(),
+      observedHead: input.commit,
+      pendingRange: [input.commit],
+      phase: 'collecting',
+      collectingStartedAtSeconds: input.nowSeconds,
+      generation: state.generation,
+      previousManifestDigest: state.previousManifestDigest,
+      publishedFrontier: state.publishedFrontier,
+    };
+  }
+  if (state.phase === 'frozen' || state.phase === 'assembling' || state.phase === 'verifying') {
+    if (input.commit === state.observedHead || state.pendingRange.includes(input.commit)) return state;
+    return {...state, observedHead: input.commit, pendingRange: [...state.pendingRange, input.commit]};
+  }
+  if (input.commit === state.publishedFrontier || input.commit === state.observedHead) {
+    return {...state, observedHead: input.commit};
+  }
+  const pendingRange =
+    state.phase === 'collecting'
+      ? state.pendingRange.includes(input.commit)
+        ? state.pendingRange
+        : [...state.pendingRange, input.commit]
+      : [input.commit];
+  return {
+    ...state,
+    collectingStartedAtSeconds: state.collectingStartedAtSeconds ?? input.nowSeconds,
+    observedHead: input.commit,
+    pendingRange,
+    phase: 'collecting',
+  };
+}
+
+export function freezeGraphShareBatch(
+  state: GraphShareFrontierMachineV1,
+  input: {
+    readonly actionKeys: readonly string[];
+    readonly changedBytes: number;
+    readonly changedFiles: number;
+    readonly nowSeconds: number;
+    readonly thresholds: GraphShareFrontierThresholds;
+  },
+): GraphShareFrontierMachineV1 {
+  if (state.phase !== 'collecting' || state.observedHead === null || state.collectingStartedAtSeconds === null) {
+    return state;
+  }
+  const aged = input.nowSeconds - state.collectingStartedAtSeconds >= input.thresholds.maximumAgeSeconds;
+  const enoughFiles = input.changedFiles >= input.thresholds.maximumChangedFiles;
+  const enoughBytes = input.changedBytes >= input.thresholds.maximumChangedBytes;
+  if (!aged && !enoughFiles && !enoughBytes) return state;
+  const frozenRange = state.pendingRange;
+  return {
+    ...state,
+    buildingFrontier: state.observedHead,
+    frozenActionKeys: [...input.actionKeys],
+    frozenBatchId: graphShareBatchId(state.observedHead, frozenRange),
+    pendingRange: [],
+    phase: 'frozen',
+  };
+}
+
+export function assembleGraphShareBatch(state: GraphShareFrontierMachineV1): GraphShareFrontierMachineV1 {
+  if (state.phase !== 'frozen') return state;
+  return {...state, phase: 'assembling'};
+}
+
+export function verifyGraphShareBatch(state: GraphShareFrontierMachineV1): GraphShareFrontierMachineV1 {
+  if (state.phase !== 'assembling') return state;
+  return {...state, phase: 'verifying'};
+}
+
+export function publishGraphShareBatch(
+  state: GraphShareFrontierMachineV1,
+  manifestDigest: Sha256Digest,
+): GraphShareFrontierMachineV1 {
+  if (state.phase !== 'verifying' && state.phase !== 'frozen' && state.phase !== 'assembling') return state;
+  const published = state.buildingFrontier ?? state.observedHead;
+  return {
+    ...state,
+    buildingFrontier: null,
+    collectingStartedAtSeconds: null,
+    frozenActionKeys: [],
+    frozenBatchId: null,
+    generation: state.generation + 1,
+    pendingRange: state.pendingRange,
+    phase: state.pendingRange.length > 0 ? 'collecting' : 'published',
+    previousManifestDigest: manifestDigest,
+    publishedFrontier: published,
+  };
+}
+
+export function failGraphShareBatch(state: GraphShareFrontierMachineV1): GraphShareFrontierMachineV1 {
+  if (state.phase !== 'frozen' && state.phase !== 'assembling' && state.phase !== 'verifying') return state;
+  return {
+    ...state,
+    buildingFrontier: null,
+    frozenActionKeys: [],
+    frozenBatchId: null,
+    phase: 'failed',
+  };
+}
+
+export function lateResultAdmitted(state: GraphShareFrontierMachineV1, batchId: string): boolean {
+  return (
+    (state.phase === 'frozen' || state.phase === 'assembling' || state.phase === 'verifying') &&
+    state.frozenBatchId === batchId
+  );
+}
+
+export function graphShareBatchId(head: string, range: readonly string[]): string {
+  return sha256HexSync(['threadnote-graph-batch-v1', head, ...range].join('\0')).slice(0, 40);
+}

--- a/src/code_graph/sharing/git.ts
+++ b/src/code_graph/sharing/git.ts
@@ -1,0 +1,42 @@
+import {Effect} from 'effect';
+import {runCommandEffect} from '../../effect/command.js';
+import {SystemInfo} from '../../effect/system.js';
+
+export const GRAPH_SHARE_GIT_OBJECT_ID = /^[0-9a-f]{40}$|^[0-9a-f]{64}$/u;
+
+export function isGraphShareGitObjectId(value: string): boolean {
+  return GRAPH_SHARE_GIT_OBJECT_ID.test(value);
+}
+
+export function graphShareCommitIsAncestor(repoRoot: string, ancestor: string, descendant: string) {
+  return Effect.gen(function* () {
+    if (!isGraphShareGitObjectId(ancestor) || !isGraphShareGitObjectId(descendant)) return false;
+    if (ancestor === descendant) return true;
+    const system = yield* SystemInfo;
+    const result = yield* runCommandEffect(
+      'git',
+      ['-C', repoRoot, 'merge-base', '--is-ancestor', '--', ancestor, descendant],
+      {
+        allowFailure: true,
+        env: {...system.environment(), GIT_NO_LAZY_FETCH: '1', GIT_OPTIONAL_LOCKS: '0'},
+        maxOutputBytes: 4_096,
+        timeoutMs: 10_000,
+      },
+    );
+    return result.exitCode === 0;
+  });
+}
+
+export function graphShareBlobExists(repoRoot: string, blobId: string) {
+  return Effect.gen(function* () {
+    if (!isGraphShareGitObjectId(blobId)) return false;
+    const system = yield* SystemInfo;
+    const result = yield* runCommandEffect('git', ['-C', repoRoot, 'cat-file', '-e', '--', blobId], {
+      allowFailure: true,
+      env: {...system.environment(), GIT_NO_LAZY_FETCH: '1', GIT_OPTIONAL_LOCKS: '0'},
+      maxOutputBytes: 4_096,
+      timeoutMs: 10_000,
+    });
+    return result.exitCode === 0;
+  });
+}

--- a/src/code_graph/sharing/layout.ts
+++ b/src/code_graph/sharing/layout.ts
@@ -8,7 +8,10 @@ export const GRAPH_SHARING_PUBLISHER_KEY_FILE = 'publisher.ed25519.json';
 
 export interface GraphSharingLayout {
   readonly casRoot: string;
+  readonly clientStateLockPath: string;
   readonly clientStatePath: string;
+  readonly coordinatorStateLockPath: string;
+  readonly coordinatorStatePath: string;
   readonly frontiersRoot: string;
   readonly keysRoot: string;
   readonly profilesRoot: string;
@@ -18,6 +21,7 @@ export interface GraphSharingLayout {
   readonly root: string;
   readonly trustReceiptsLockPath: string;
   readonly trustReceiptsPath: string;
+  readonly workerRoot: string;
 }
 
 export function graphSharingLayout(path: Path.Path, threadnoteHome: string, casRoot?: string): GraphSharingLayout {
@@ -25,7 +29,10 @@ export function graphSharingLayout(path: Path.Path, threadnoteHome: string, casR
   const resolvedCas = casRoot ?? path.join(root, 'cas');
   return {
     casRoot: resolvedCas,
+    clientStateLockPath: path.join(root, `${GRAPH_SHARING_CLIENT_STATE_FILE}.lock`),
     clientStatePath: path.join(root, GRAPH_SHARING_CLIENT_STATE_FILE),
+    coordinatorStateLockPath: path.join(root, 'coordinator-state.json.lock'),
+    coordinatorStatePath: path.join(root, 'coordinator-state.json'),
     frontiersRoot: path.join(resolvedCas, 'frontiers'),
     keysRoot: path.join(root, 'keys'),
     profilesRoot: path.join(root, 'profiles'),
@@ -35,6 +42,7 @@ export function graphSharingLayout(path: Path.Path, threadnoteHome: string, casR
     root,
     trustReceiptsLockPath: path.join(root, `${GRAPH_SHARING_TRUST_RECEIPTS_FILE}.lock`),
     trustReceiptsPath: path.join(root, GRAPH_SHARING_TRUST_RECEIPTS_FILE),
+    workerRoot: path.join(resolvedCas, 'worker'),
   };
 }
 
@@ -46,10 +54,26 @@ export function graphSharingFrontierPointerPath(path: Path.Path, frontiersRoot: 
   return path.join(frontiersRoot, repositoryId, 'latest.json');
 }
 
+export function graphSharingContributionQueuePath(path: Path.Path, root: string, repositoryId: string): string {
+  return path.join(root, 'contribution', `${repositoryId}.json`);
+}
+
+export function graphSharingWorkerWorkPath(path: Path.Path, workerRoot: string, repositoryId: string): string {
+  return path.join(workerRoot, repositoryId, 'work.json');
+}
+
 export function graphSharingProvenancePath(path: Path.Path, provenanceRoot: string, checkoutId: string): string {
   return path.join(provenanceRoot, `${checkoutId}.json`);
 }
 
 export function graphSharingCasBlobPath(path: Path.Path, casRoot: string, hex: string): string {
   return path.join(casRoot, 'sha256', hex);
+}
+
+export function graphSharingCoordinatorStatePath(path: Path.Path, root: string): string {
+  return path.join(root, 'coordinator-state.json');
+}
+
+export function graphSharingTagPath(path: Path.Path, casRoot: string, name: string): string {
+  return path.join(casRoot, 'tags', name);
 }

--- a/src/code_graph/sharing/namespace.ts
+++ b/src/code_graph/sharing/namespace.ts
@@ -1,0 +1,34 @@
+import type {Path} from 'effect';
+import {sha256HexSync} from '../../crypto/sha256.js';
+import type {GraphShareActionKey} from './action.js';
+
+export const GRAPH_SHARE_CAS_CANONICAL = 'cas://local';
+export const GRAPH_SHARE_CAS_WORKER = 'cas://local/worker';
+
+export function graphShareFrontierDiscoveryTag(repositoryId: string, branchRef: string): string {
+  return `tn-frontier-${sha256HexSync(`${repositoryId}${branchRef}`).slice(0, 40)}`;
+}
+
+export function graphShareActionDiscoveryTag(actionKey: GraphShareActionKey): string {
+  return `tn-action-${actionKey}`;
+}
+
+export function graphShareWorkDiscoveryTag(batchId: string): string {
+  return `tn-work-${batchId.slice(0, 40)}`;
+}
+
+export function graphShareWorkerCasRoot(path: Path.Path, casRoot: string): string {
+  return path.join(casRoot, 'worker');
+}
+
+export function graphShareCanonicalCasRoot(path: Path.Path, casRoot: string): string {
+  return casRoot;
+}
+
+export function isGraphShareWorkerRegistry(value: string): boolean {
+  return value === GRAPH_SHARE_CAS_WORKER || value.endsWith('/worker');
+}
+
+export function isGraphShareCanonicalRegistry(value: string): boolean {
+  return value === GRAPH_SHARE_CAS_CANONICAL || value.endsWith('/canonical');
+}

--- a/src/code_graph/sharing/oci.ts
+++ b/src/code_graph/sharing/oci.ts
@@ -1,0 +1,33 @@
+import {SHA256_HEX} from './digest.js';
+import {graphSharingFailure} from './errors.js';
+
+export const GRAPH_SHARE_HTTP_CAS_MAX_BYTES = 32 * 1_048_576;
+export const GRAPH_SHARE_HTTP_CAS_PATH = /^\/v1\/cas\/sha256\/([0-9a-f]{64})$/u;
+export const GRAPH_SHARE_HTTP_TAG_PATH =
+  /^\/v1\/tags\/(tn-(?:frontier-[0-9a-f]{40}|action-[0-9a-f]{64}|work-[0-9a-f]{40}))$/u;
+export const GRAPH_SHARE_DISCOVERY_TAG = /^tn-(?:frontier-[0-9a-f]{40}|action-[0-9a-f]{64}|work-[0-9a-f]{40})$/u;
+
+const GIT_OBJECT_PREFIXES = ['blob ', 'commit ', 'tag ', 'tree '] as const;
+
+export function parseGraphShareHttpCasPath(pathname: string): string | undefined {
+  const match = GRAPH_SHARE_HTTP_CAS_PATH.exec(pathname);
+  return match?.[1] !== undefined && SHA256_HEX.test(match[1]) ? match[1] : undefined;
+}
+
+export function parseGraphShareHttpTagPath(pathname: string): string | undefined {
+  const match = GRAPH_SHARE_HTTP_TAG_PATH.exec(pathname);
+  return match?.[1];
+}
+
+export function assertGraphShareDiscoveryTag(name: string): string {
+  if (!GRAPH_SHARE_DISCOVERY_TAG.test(name)) {
+    throw graphSharingFailure('Graph share discovery tag is invalid.');
+  }
+  return name;
+}
+
+export function graphSharePayloadLooksLikeGitObject(bytes: Uint8Array): boolean {
+  if (bytes.byteLength < 5) return false;
+  const prefix = new TextDecoder().decode(bytes.subarray(0, 7));
+  return GIT_OBJECT_PREFIXES.some(candidate => prefix.startsWith(candidate));
+}

--- a/src/code_graph/sharing/parse_cache.ts
+++ b/src/code_graph/sharing/parse_cache.ts
@@ -1,0 +1,273 @@
+import {Effect, FileSystem, Path, Schema} from 'effect';
+import {canonicalJson} from '../checkpoint/canonical_json.js';
+import type {BoundedCodeGraphFact} from '../fact_budget.js';
+import type {CodeGraphStoreShape} from '../store_shape.js';
+import type {CodeGraphDirectPersistentCapacityProtector} from '../store_models.js';
+import type {CodeGraphInventoryFile, RepositoryIdentity} from '../types.js';
+import {graphShareLanguageAndRole, graphShareParseActionKey} from './action.js';
+import {decodeJsonBytes} from './atomic.js';
+import {putCasBytes} from './cas.js';
+import {
+  graphShareControlAnnounceResult,
+  graphShareControlGetCas,
+  graphShareControlGetStatus,
+  graphShareControlPutCas,
+  graphShareControlPutTag,
+  mirrorCoordinatorCasBlob,
+} from './control_client.js';
+import type {GraphShareResultAnnouncementV1} from './receipts.js';
+import {
+  enqueuePersistedGraphShareContribution,
+  effectiveGraphShareContributionMode,
+  readGraphShareContributionQueue,
+  writeGraphShareContributionQueue,
+} from './contribution.js';
+import {sha256HexFromDigest} from './digest.js';
+import {graphSharingFailure, GraphSharingError} from './errors.js';
+import {isGraphShareGitObjectId} from './git.js';
+import {graphShareActionDiscoveryTag} from './namespace.js';
+import {
+  graphShareParseResultArtifact,
+  parseGraphShareParseResult,
+  type GraphShareParseResultV1,
+} from './parse_result.js';
+import {readGraphShareClientState, lookupGraphShareTrustReceipt, resolveGraphShareCasRoot} from './trust.js';
+
+export const enqueueLocalGraphShareParseResults = Effect.fn('codeGraph.sharing.enqueueLocalParseResults')(
+  function* (input: {
+    readonly extractorSet: string;
+    readonly facts: readonly BoundedCodeGraphFact[];
+    readonly files: readonly CodeGraphInventoryFile[];
+    readonly identity: Pick<RepositoryIdentity, 'headCommit' | 'repositoryId'>;
+    readonly threadnoteHome: string;
+  }) {
+    const trust = yield* lookupGraphShareTrustReceipt(input.threadnoteHome, input.identity.repositoryId);
+    const state = yield* readGraphShareClientState(input.threadnoteHome);
+    const mode = effectiveGraphShareContributionMode(trust?.accessMode, state.contributionMode ?? 'off');
+    if (mode === 'off') return {queued: 0};
+    const casRoot = yield* resolveGraphShareCasRoot(input.threadnoteHome);
+    const factsByPath = new Map(input.facts.map(fact => [fact.facts.path, fact]));
+    const batchId = input.identity.headCommit.slice(0, 40);
+    if (!/^[0-9a-f]{40}$/u.test(batchId)) return {queued: 0};
+    let queued = 0;
+    for (const file of input.files) {
+      if (file.source !== 'commit' || !isGraphShareGitObjectId(file.blobId) || file.contentHash.length !== 64) continue;
+      const fact = factsByPath.get(file.path);
+      if (fact === undefined) continue;
+      const artifact = graphShareParseResultArtifact({
+        actionKey: graphShareParseActionKey({
+          contentHash: file.contentHash,
+          extractorSet: input.extractorSet,
+          languageAndRole: graphShareLanguageAndRole(file.language, 'source'),
+          normalizedPath: file.path,
+          repositoryId: input.identity.repositoryId,
+        }),
+        contentHash: file.contentHash,
+        extractorSet: input.extractorSet,
+        facts: fact.facts,
+        gitBlobId: file.blobId,
+        languageAndRole: graphShareLanguageAndRole(file.language, 'source'),
+        normalizedPath: file.path,
+        repositoryId: input.identity.repositoryId,
+      });
+      const resultBytes = new TextEncoder().encode(canonicalJson(artifact));
+      const resultManifestDigest = yield* putCasBytes(casRoot, resultBytes);
+      const attestationDigest = yield* putCasBytes(
+        casRoot,
+        new TextEncoder().encode(
+          canonicalJson({kind: 'contributor-self', payloadDigest: resultManifestDigest, schemaVersion: 1}),
+        ),
+      );
+      const enqueued = yield* enqueuePersistedGraphShareContribution(
+        input.threadnoteHome,
+        input.identity.repositoryId,
+        trust?.accessMode,
+        {
+          actionKey: artifact.actionKey,
+          attestationDigest,
+          batchId,
+          resultManifestDigest,
+          semanticDigest: artifact.semanticDigest,
+        },
+        mode,
+      );
+      if (enqueued.queued) queued += 1;
+    }
+    return {queued};
+  },
+);
+
+export const drainQueuedGraphShareContributions = Effect.fn('codeGraph.sharing.drainQueuedContributions')(
+  function* (input: {readonly identity: Pick<RepositoryIdentity, 'repositoryId'>; readonly threadnoteHome: string}) {
+    const trust = yield* lookupGraphShareTrustReceipt(input.threadnoteHome, input.identity.repositoryId);
+    const state = yield* readGraphShareClientState(input.threadnoteHome);
+    const mode = effectiveGraphShareContributionMode(trust?.accessMode, state.contributionMode ?? 'off');
+    if (mode === 'off' || state.coordinatorUrl === undefined) return {sent: 0};
+    const queue = yield* readGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, mode);
+    if (queue.announcements.length === 0) return {sent: 0};
+    const casRoot = yield* resolveGraphShareCasRoot(input.threadnoteHome);
+    const remaining = [];
+    let sent = 0;
+    for (const announcement of queue.announcements) {
+      const drained = yield* drainOneAnnouncement(casRoot, state.coordinatorUrl, announcement).pipe(
+        Effect.catchIf(
+          error => Schema.is(GraphSharingError)(error) && error.kind === 'unavailable',
+          () => Effect.succeed(false),
+        ),
+      );
+      if (drained) sent += 1;
+      else remaining.push(announcement);
+    }
+    yield* writeGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, {
+      ...queue,
+      announcements: remaining,
+    });
+    return {sent};
+  },
+);
+
+export const hydrateSharedParseCache = Effect.fn('codeGraph.sharing.hydrateSharedParseCache')(function* (input: {
+  readonly databasePath: string;
+  readonly identity: RepositoryIdentity;
+  readonly persistentCapacityProtector: CodeGraphDirectPersistentCapacityProtector;
+  readonly store: CodeGraphStoreShape;
+  readonly threadnoteHome: string;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  if (!(yield* fs.exists(input.databasePath))) return {hydrated: 0};
+  const state = yield* readGraphShareClientState(input.threadnoteHome);
+  if (state.coordinatorUrl === undefined) return {hydrated: 0};
+  const status = yield* graphShareControlGetStatus(state.coordinatorUrl).pipe(
+    Effect.catchIf(
+      error => Schema.is(GraphSharingError)(error) && error.kind === 'unavailable',
+      () => Effect.void,
+    ),
+  );
+  if (status === undefined || status.repositoryId !== input.identity.repositoryId) return {hydrated: 0};
+  const quarantinedActionKeys = quarantinedGraphShareActionKeys(status.receipts);
+  const casRoot = yield* resolveGraphShareCasRoot(input.threadnoteHome);
+  let hydrated = 0;
+  for (const receipt of status.receipts.slice(0, 256)) {
+    if (quarantinedActionKeys.has(receipt.actionKey)) continue;
+    const bytes = yield* graphShareControlGetCas(state.coordinatorUrl, receipt.resultManifestDigest).pipe(
+      Effect.catchIf(
+        error => Schema.is(GraphSharingError)(error),
+        () => Effect.void,
+      ),
+    );
+    if (bytes === undefined) continue;
+    const parsed = yield* decodeJsonBytes(bytes).pipe(
+      Effect.flatMap(value =>
+        Effect.try({
+          try: () => parseGraphShareParseResult(value),
+          catch: cause =>
+            Schema.is(GraphSharingError)(cause)
+              ? cause
+              : graphSharingFailure('Parse-result artifact is invalid.', cause),
+        }),
+      ),
+      Effect.orElseSucceed(() => undefined),
+    );
+    if (
+      parsed === undefined ||
+      !admitsSharedParseCacheHydrate({
+        identityRepositoryId: input.identity.repositoryId,
+        parsed,
+        quarantinedActionKeys,
+        receipt,
+      })
+    ) {
+      continue;
+    }
+    yield* putCasBytes(casRoot, bytes);
+    const language = parsed.languageAndRole.split(':')[0] ?? 'unknown';
+    yield* input.store.cacheFacts(
+      input.databasePath,
+      [
+        {
+          blobId: parsed.gitBlobId,
+          contentHash: parsed.contentHash,
+          language,
+          mode: '100644',
+          path: parsed.normalizedPath,
+          size: 1,
+          source: 'commit',
+        },
+      ],
+      [parsed.facts],
+      parsed.extractorSet,
+      input.persistentCapacityProtector,
+    );
+    hydrated += 1;
+  }
+  return {hydrated};
+});
+
+export function quarantinedGraphShareActionKeys(
+  receipts: readonly {readonly actionKey: string; readonly semanticDigest: string}[],
+): ReadonlySet<string> {
+  const digests = new Map<string, Set<string>>();
+  for (const receipt of receipts) {
+    const existing = digests.get(receipt.actionKey) ?? new Set<string>();
+    existing.add(receipt.semanticDigest);
+    digests.set(receipt.actionKey, existing);
+  }
+  return new Set(
+    [...digests].filter(([, semanticDigests]) => semanticDigests.size > 1).map(([actionKey]) => actionKey),
+  );
+}
+
+export function admitsSharedParseCacheHydrate(input: {
+  readonly identityRepositoryId: string;
+  readonly parsed: GraphShareParseResultV1;
+  readonly quarantinedActionKeys: ReadonlySet<string>;
+  readonly receipt: {readonly actionKey: string};
+}): boolean {
+  if (input.parsed.repositoryId !== input.identityRepositoryId) return false;
+  if (input.quarantinedActionKeys.has(input.receipt.actionKey)) return false;
+  const expected = graphShareParseActionKey({
+    contentHash: input.parsed.contentHash,
+    extractorSet: input.parsed.extractorSet,
+    languageAndRole: input.parsed.languageAndRole,
+    normalizedPath: input.parsed.normalizedPath,
+    repositoryId: input.parsed.repositoryId,
+  });
+  return input.parsed.actionKey === input.receipt.actionKey && input.parsed.actionKey === expected;
+}
+
+export const mirrorCoordinatorCasBlobs = Effect.fn('codeGraph.sharing.mirrorCoordinatorCasBlobs')(function* (
+  casRoot: string,
+  coordinatorUrl: string,
+  digests: readonly string[],
+) {
+  for (const digest of digests) {
+    yield* mirrorCoordinatorCasBlob(casRoot, coordinatorUrl, digest);
+  }
+});
+
+const drainOneAnnouncement = Effect.fn('codeGraph.sharing.drainOneAnnouncement')(function* (
+  casRoot: string,
+  coordinatorUrl: string,
+  announcement: GraphShareResultAnnouncementV1,
+) {
+  const path = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
+  const resultPath = path.join(casRoot, 'sha256', sha256HexFromDigest(announcement.resultManifestDigest));
+  const attestationPath = path.join(casRoot, 'sha256', sha256HexFromDigest(announcement.attestationDigest));
+  if (!(yield* fs.exists(resultPath)) || !(yield* fs.exists(attestationPath))) return false;
+  const resultBytes = yield* fs.readFile(resultPath);
+  const attestationBytes = yield* fs.readFile(attestationPath);
+  yield* graphShareControlPutCas(coordinatorUrl, resultBytes);
+  yield* graphShareControlPutCas(coordinatorUrl, attestationBytes);
+  yield* graphShareControlPutTag(
+    coordinatorUrl,
+    graphShareActionDiscoveryTag(announcement.actionKey),
+    announcement.resultManifestDigest,
+  ).pipe(Effect.ignore);
+  const announced = yield* graphShareControlAnnounceResult(
+    coordinatorUrl,
+    announcement,
+    announcement.resultManifestDigest,
+  );
+  return announced.status === 200 || announced.status === 201 || announced.status === 409;
+});

--- a/src/code_graph/sharing/parse_result.ts
+++ b/src/code_graph/sharing/parse_result.ts
@@ -1,0 +1,111 @@
+import {canonicalJson} from '../checkpoint/canonical_json.js';
+import {parseCodeGraphFileFacts} from '../fact_validation.js';
+import type {CodeGraphFileFacts} from '../types.js';
+import {GRAPH_SHARE_ACTION_KEY, type GraphShareActionKey} from './action.js';
+import {SHA256_DIGEST, SHA256_HEX, sha256Digest, type Sha256Digest} from './digest.js';
+import {graphSharingFailure} from './errors.js';
+import {GRAPH_SHARE_GIT_OBJECT_ID} from './git.js';
+
+export const GRAPH_SHARE_PARSE_RESULT_SCHEMA_VERSION = 1 as const;
+
+export interface GraphShareParseResultV1 {
+  readonly actionKey: GraphShareActionKey;
+  readonly contentHash: string;
+  readonly extractorSet: string;
+  readonly facts: CodeGraphFileFacts;
+  readonly gitBlobId: string;
+  readonly languageAndRole: string;
+  readonly normalizedPath: string;
+  readonly repositoryId: string;
+  readonly schemaVersion: typeof GRAPH_SHARE_PARSE_RESULT_SCHEMA_VERSION;
+  readonly semanticDigest: Sha256Digest;
+}
+
+export function graphShareParseResultSemanticDigest(facts: CodeGraphFileFacts): Sha256Digest {
+  return sha256Digest(canonicalJson(facts));
+}
+
+export function parseGraphShareParseResult(value: unknown): GraphShareParseResultV1 {
+  if (!isRecord(value) || value.schemaVersion !== GRAPH_SHARE_PARSE_RESULT_SCHEMA_VERSION) {
+    throw graphSharingFailure('Parse-result artifact is invalid.');
+  }
+  const facts = parseCodeGraphFileFacts(value.facts);
+  const result: GraphShareParseResultV1 = {
+    actionKey: requiredActionKey(value.actionKey),
+    contentHash: requiredHex(value.contentHash, 'contentHash'),
+    extractorSet: requiredHex(value.extractorSet, 'extractorSet'),
+    facts,
+    gitBlobId: requiredGitObjectId(value.gitBlobId),
+    languageAndRole: requiredText(value.languageAndRole, 'languageAndRole'),
+    normalizedPath: requiredText(value.normalizedPath, 'normalizedPath'),
+    repositoryId: requiredHex(value.repositoryId, 'repositoryId'),
+    schemaVersion: GRAPH_SHARE_PARSE_RESULT_SCHEMA_VERSION,
+    semanticDigest: parseDigest(value.semanticDigest, 'semanticDigest'),
+  };
+  if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(Object.keys(result).sort())) {
+    throw graphSharingFailure('Parse-result artifact contains unsupported fields.');
+  }
+  if (result.facts.path !== result.normalizedPath) {
+    throw graphSharingFailure('Parse-result path does not match the fact path.');
+  }
+  if (result.semanticDigest !== graphShareParseResultSemanticDigest(facts)) {
+    throw graphSharingFailure('Parse-result semantic digest does not match the facts.');
+  }
+  return result;
+}
+
+export function graphShareParseResultArtifact(input: {
+  readonly actionKey: GraphShareActionKey;
+  readonly contentHash: string;
+  readonly extractorSet: string;
+  readonly facts: CodeGraphFileFacts;
+  readonly gitBlobId: string;
+  readonly languageAndRole: string;
+  readonly normalizedPath: string;
+  readonly repositoryId: string;
+}): GraphShareParseResultV1 {
+  return parseGraphShareParseResult({
+    ...input,
+    schemaVersion: GRAPH_SHARE_PARSE_RESULT_SCHEMA_VERSION,
+    semanticDigest: graphShareParseResultSemanticDigest(input.facts),
+  });
+}
+
+function requiredActionKey(value: unknown): GraphShareActionKey {
+  if (typeof value !== 'string' || !GRAPH_SHARE_ACTION_KEY.test(value)) {
+    throw graphSharingFailure('Parse-result action key is invalid.');
+  }
+  return value;
+}
+
+function requiredGitObjectId(value: unknown): string {
+  if (typeof value !== 'string' || !GRAPH_SHARE_GIT_OBJECT_ID.test(value)) {
+    throw graphSharingFailure('Parse-result git blob id is invalid.');
+  }
+  return value;
+}
+
+function requiredHex(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !SHA256_HEX.test(value)) {
+    throw graphSharingFailure(`Parse-result ${label} is invalid.`);
+  }
+  return value;
+}
+
+function requiredText(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0 || value.length > 4_096) {
+    throw graphSharingFailure(`Parse-result ${label} is invalid.`);
+  }
+  return value;
+}
+
+function parseDigest(value: unknown, label: string): Sha256Digest {
+  if (typeof value !== 'string' || !SHA256_DIGEST.test(value)) {
+    throw graphSharingFailure(`Parse-result ${label} is invalid.`);
+  }
+  return value as Sha256Digest;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/code_graph/sharing/profile.ts
+++ b/src/code_graph/sharing/profile.ts
@@ -6,8 +6,9 @@ import {SHA256_DIGEST, SHA256_HEX, sha256Digest, type Sha256Digest} from './dige
 const STRICT = {errors: 'all', onExcessProperty: 'error'} as const;
 const ORGANIZATION = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
 const GIT_REF = /^refs\/heads\/[A-Za-z0-9._/-]{1,255}$/u;
-const COORDINATOR_URL = /^https:\/\/[a-z0-9.-]+(?::\d{2,5})?(?:\/[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=-]*)?$/u;
-const CAS_REGISTRY = /^cas:\/\/local$/u;
+const COORDINATOR_URL =
+  /^(?:https:\/\/[a-z0-9.-]+|http:\/\/(?:127\.0\.0\.1|localhost))(?::\d{1,5})?(?:\/[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=-]*)?$/u;
+const CAS_REGISTRY = /^cas:\/\/local(?:\/(?:canonical|worker))?$/u;
 const OCI_REGISTRY = /^oci:\/\/[a-z0-9.-]+(?:\/[A-Za-z0-9._-]+)+$/u;
 const CAS_PROFILE = /^cas:\/\/sha256:[0-9a-f]{64}$/u;
 const OCI_PROFILE = /^oci:\/\/[a-z0-9.-]+(?:\/[A-Za-z0-9._-]+)+@sha256:[0-9a-f]{64}$/u;
@@ -123,26 +124,55 @@ export function parseGraphShareProfilePointer(value: string): GraphShareProfileP
   throw graphSharingFailure('Enrollment profile pointer must be a digest-pinned cas:// or oci:// reference.');
 }
 
+export function parseGraphShareCoordinatorUrl(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/u, '');
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch (cause) {
+    throw graphSharingFailure('Coordinator URL is invalid.', cause);
+  }
+  const loopback = parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
+  if (parsed.protocol === 'http:' && !loopback) {
+    throw graphSharingFailure('HTTP coordinator URLs must be loopback.');
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw graphSharingFailure('Coordinator URL must be https or loopback http.');
+  }
+  if (!COORDINATOR_URL.test(trimmed)) {
+    throw graphSharingFailure('Coordinator URL is invalid.');
+  }
+  const port = parsed.port.length === 0 ? (parsed.protocol === 'https:' ? 443 : 80) : Number(parsed.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw graphSharingFailure('Coordinator URL port is invalid.');
+  }
+  return trimmed;
+}
+
 export function casProfilePointer(digest: Sha256Digest): string {
   return `cas://${digest}`;
 }
 
 export function defaultGraphShareProfile(input: {
+  readonly branch: string;
   readonly canonicalRemote: string;
+  readonly coordinatorUrl?: string;
   readonly organization: string;
   readonly publisherKeyFingerprint: Sha256Digest;
   readonly repositoryId: string;
-  readonly branch: string;
 }): GraphShareProfileV1 {
   return {
     contribution: {
       activeOnlyOnAcPower: true,
       activeOnlyWhenIdle: true,
-      defaultMode: 'off',
+      defaultMode: 'passive',
       maximumCpus: 2,
       maximumMemoryBytes: 4_294_967_296,
       maximumUploadBytesPerSecond: 1_048_576,
     },
+    ...(input.coordinatorUrl === undefined
+      ? {}
+      : {coordinator: {url: parseGraphShareCoordinatorUrl(input.coordinatorUrl)}}),
     frontier: {
       batchMaximumAgeSeconds: 30,
       batchMaximumChangedBytes: 104_857_600,
@@ -155,7 +185,7 @@ export function defaultGraphShareProfile(input: {
     organization: input.organization,
     registry: {
       canonical: 'cas://local',
-      worker: 'cas://local',
+      worker: 'cas://local/worker',
     },
     repositoryId: input.repositoryId,
     retention: {

--- a/src/code_graph/sharing/publisher.ts
+++ b/src/code_graph/sharing/publisher.ts
@@ -1,26 +1,33 @@
 import {Crypto, Effect, FileSystem, Path} from 'effect';
 import {canonicalJson} from '../checkpoint/canonical_json.js';
 import {runCodeGraphCheckpointExport} from '../checkpoint/commands.js';
+import type {CliOutput} from '../../effect/cli_output.js';
 import {SystemInfo} from '../../effect/system.js';
 import {resolveRepositoryIdentity} from '../repository.js';
 import type {RuntimeConfig} from '../../types.js';
 import {
   generateGraphSharePublisherKey,
   parseGraphSharePublisherKey,
+  parseGraphShareFrontierManifest,
+  parseGraphShareFrontierPointer,
   signGraphShareFrontier,
+  graphShareFrontierDigest,
   type GraphShareFrontierManifestV1,
   type GraphSharePublisherKeyV1,
 } from './artifacts.js';
-import {readJsonFile, writePrivateJsonFile} from './atomic.js';
+import {decodeJsonBytes, readJsonFile, writePrivateJsonFile} from './atomic.js';
 import {putCasBytes, putCasFile, readVerifiedCasBlob} from './cas.js';
-import {parseSha256Digest} from './digest.js';
+import {parseSha256Digest, type Sha256Digest} from './digest.js';
 import {graphSharingFailure} from './errors.js';
+import {parseGraphShareListenAddress, recordPublishedFrontier, runGraphShareControlServer} from './control_server.js';
+import {graphShareCommitIsAncestor} from './git.js';
 import {graphShareEnrollmentPath, graphSharingFrontierPointerPath, graphSharingLayout} from './layout.js';
 import {
   assertEnrollmentMatchesIdentity,
   casProfilePointer,
   defaultGraphShareProfile,
   graphShareProfileDigest,
+  parseGraphShareCoordinatorUrl,
   parseGraphShareEnrollment,
   parseGraphShareProfile,
   parseGraphShareProfilePointer,
@@ -31,6 +38,7 @@ import {resolveGraphShareCasRoot, writeGraphShareClientState} from './trust.js';
 
 export interface GraphShareInitOptions {
   readonly cas?: string;
+  readonly coordinator?: string;
   readonly cwd?: string;
   readonly json?: boolean;
   readonly organization?: string;
@@ -41,6 +49,7 @@ export interface GraphPublisherBootstrapOptions {
   readonly cas?: string;
   readonly cwd?: string;
   readonly json?: boolean;
+  readonly listen?: string;
 }
 
 export const runGraphShareInit = Effect.fn('codeGraph.sharing.init')(function* (
@@ -63,6 +72,7 @@ export const runGraphShareInit = Effect.fn('codeGraph.sharing.init')(function* (
   const profile = defaultGraphShareProfile({
     branch,
     canonicalRemote: identity.remoteIdentity,
+    ...(options.coordinator === undefined ? {} : {coordinatorUrl: parseGraphShareCoordinatorUrl(options.coordinator)}),
     organization: options.organization?.trim() || 'local',
     publisherKeyFingerprint: key.fingerprint,
     repositoryId: identity.repositoryId,
@@ -112,9 +122,7 @@ export const runGraphPublisherBootstrap = Effect.fn('codeGraph.sharing.publisher
     return yield* graphSharingFailure('Publisher key fingerprint does not match enrollment.');
   }
   const pointer = parseGraphShareProfilePointer(enrollment.profile);
-  const profile = parseGraphShareProfile(
-    JSON.parse(new TextDecoder().decode(yield* readVerifiedCasBlob(casRoot, pointer.digest))) as unknown,
-  );
+  const profile = parseGraphShareProfile(yield* decodeJsonBytes(yield* readVerifiedCasBlob(casRoot, pointer.digest)));
   const profileDigest = graphShareProfileDigest(profile);
   if (profileDigest !== pointer.digest || profile.repositoryId !== enrollment.repositoryId) {
     return yield* graphSharingFailure('Published profile digest does not match enrollment.');
@@ -126,28 +134,18 @@ export const runGraphPublisherBootstrap = Effect.fn('codeGraph.sharing.publisher
   if (checkpointDigest !== parseSha256Digest(exported.artifact.digest)) {
     return yield* graphSharingFailure('Checkpoint CAS digest does not match the exported artifact.');
   }
-  const manifest: GraphShareFrontierManifestV1 = {
-    branch: profile.source.branches[0] ?? 'refs/heads/main',
-    checkpoint: {
-      manifestDigest: checkpointDigest,
-      snapshotId: exported.snapshotId,
-      sourceCommit: exported.sourceCommit,
-    },
-    deltas: [],
-    generation: 1,
-    graphAbi: exported.graphAbi,
-    graphContentId: exported.graphContentId,
-    logicalGraphDigest: parseSha256Digest(exported.logicalDigest),
-    previousManifestDigest: null,
-    profileDigest,
-    publisherFence: 1,
-    repositoryId: identity.repositoryId,
-    schemaVersion: 1,
-    snapshotId: exported.snapshotId,
-    sourceCommit: exported.sourceCommit,
-  };
-  const signed = yield* signGraphShareFrontier(key, manifest);
-  const manifestDigest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(manifest)));
+  const signed = yield* signGraphShareFrontier(
+    key,
+    manifestFromExport(exported, checkpointDigest, {
+      branch: profile.source.branches[0] ?? 'refs/heads/main',
+      generation: 1,
+      previousManifestDigest: null,
+      profileDigest,
+      publisherFence: 1,
+      repositoryId: identity.repositoryId,
+    }),
+  );
+  const manifestDigest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(signed.manifest)));
   const envelopeDigest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(signed.envelope)));
   const layout = graphSharingLayout(path, config.agentContextHome, casRoot);
   yield* writePrivateJsonFile(graphSharingFrontierPointerPath(path, layout.frontiersRoot, identity.repositoryId), {
@@ -158,10 +156,184 @@ export const runGraphPublisherBootstrap = Effect.fn('codeGraph.sharing.publisher
   return {
     checkpointDigest,
     envelopeDigest,
+    generation: 1,
     manifestDigest,
     profileDigest,
     sourceCommit: exported.sourceCommit,
     type: 'code-graph-publisher-bootstrap' as const,
+    version: 1 as const,
+  };
+});
+
+export const runGraphPublisherServe = Effect.fn('codeGraph.sharing.publisherServe')(function* (
+  config: RuntimeConfig,
+  options: GraphPublisherBootstrapOptions,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const cwd = yield* commandCwd(options.cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas);
+  if (options.cas !== undefined) yield* writeGraphShareClientState(config.agentContextHome, casRoot);
+  const layout = graphSharingLayout(path, config.agentContextHome, casRoot);
+  const pointerPath = graphSharingFrontierPointerPath(path, layout.frontiersRoot, identity.repositoryId);
+  if (!(yield* fs.exists(pointerPath))) {
+    return yield* runGraphPublisherBootstrap(config, options);
+  }
+  const pointer = parseGraphShareFrontierPointer(yield* readJsonFile(pointerPath));
+  const current = parseGraphShareFrontierManifest(
+    yield* decodeJsonBytes(yield* readVerifiedCasBlob(casRoot, pointer.manifestDigest)),
+  );
+  if (current.sourceCommit === identity.headCommit) {
+    return {
+      checkpointDigest: current.checkpoint.manifestDigest,
+      envelopeDigest: pointer.envelopeDigest,
+      generation: current.generation,
+      manifestDigest: pointer.manifestDigest,
+      profileDigest: current.profileDigest,
+      sourceCommit: current.sourceCommit,
+      type: 'code-graph-publisher-serve' as const,
+      version: 1 as const,
+    };
+  }
+  const descendant = yield* graphShareCommitIsAncestor(identity.repoRoot, current.sourceCommit, identity.headCommit);
+  if (
+    !descendant &&
+    !(yield* graphShareCommitIsAncestor(identity.repoRoot, identity.headCommit, current.sourceCommit))
+  ) {
+    return yield* graphSharingFailure('Canonical HEAD is not related to the published frontier.');
+  }
+  if (!descendant) {
+    return {
+      checkpointDigest: current.checkpoint.manifestDigest,
+      envelopeDigest: pointer.envelopeDigest,
+      generation: current.generation,
+      manifestDigest: pointer.manifestDigest,
+      profileDigest: current.profileDigest,
+      sourceCommit: current.sourceCommit,
+      type: 'code-graph-publisher-serve' as const,
+      version: 1 as const,
+    };
+  }
+  const published = yield* publishNextGeneration(config, options, current);
+  return published;
+});
+
+export const runGraphPublisherListen = Effect.fn('codeGraph.sharing.publisherListen')(function* (
+  config: RuntimeConfig,
+  options: GraphPublisherBootstrapOptions & {
+    readonly listen: string;
+    readonly onReady: (output: {
+      readonly coordinatorUrl: string;
+      readonly envelopeDigest: string;
+      readonly generation: number;
+      readonly listening: true;
+      readonly manifestDigest: string;
+      readonly port: number;
+      readonly sourceCommit: string;
+      readonly type: 'code-graph-publisher-serve';
+      readonly version: 1;
+    }) => Effect.Effect<void, unknown, CliOutput>;
+  },
+) {
+  const published = yield* runGraphPublisherServe(config, options);
+  const path = yield* Path.Path;
+  const cwd = yield* commandCwd(options.cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas);
+  const enrollment = parseGraphShareEnrollment(yield* readJsonFile(graphShareEnrollmentPath(path, identity.repoRoot)));
+  const pointer = parseGraphShareProfilePointer(enrollment.profile);
+  const profile = parseGraphShareProfile(yield* decodeJsonBytes(yield* readVerifiedCasBlob(casRoot, pointer.digest)));
+  const branch = profile.source.branches[0] ?? 'refs/heads/main';
+  yield* recordPublishedFrontier(
+    {
+      casRoot,
+      organization: profile.organization,
+      repositoryId: identity.repositoryId,
+      threadnoteHome: config.agentContextHome,
+    },
+    {
+      branch,
+      envelopeDigest: published.envelopeDigest,
+      manifestDigest: published.manifestDigest,
+      repositoryId: identity.repositoryId,
+    },
+  );
+  return yield* runGraphShareControlServer({
+    casRoot,
+    listen: parseGraphShareListenAddress(options.listen),
+    onListening: info =>
+      options.onReady({
+        coordinatorUrl: info.url,
+        envelopeDigest: published.envelopeDigest,
+        generation: published.generation,
+        listening: true,
+        manifestDigest: published.manifestDigest,
+        port: info.port,
+        sourceCommit: published.sourceCommit,
+        type: 'code-graph-publisher-serve',
+        version: 1,
+      }),
+    organization: profile.organization,
+    republish: runGraphPublisherServe(config, options).pipe(
+      Effect.map(result => ({
+        branch,
+        envelopeDigest: result.envelopeDigest,
+        manifestDigest: result.manifestDigest,
+        repositoryId: identity.repositoryId,
+      })),
+    ),
+    repositoryId: identity.repositoryId,
+    threadnoteHome: config.agentContextHome,
+  });
+});
+
+const publishNextGeneration = Effect.fn('codeGraph.sharing.publishNextGeneration')(function* (
+  config: RuntimeConfig,
+  options: GraphPublisherBootstrapOptions,
+  current: GraphShareFrontierManifestV1,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const cwd = yield* commandCwd(options.cwd);
+  const identity = yield* resolveRepositoryIdentity(cwd);
+  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas);
+  const key = yield* loadOrCreatePublisherKey(config.agentContextHome);
+  const spool = path.join(casRoot, 'spool', `${yield* crypto.randomUUIDv4}.cgcp`);
+  const exported = yield* runCodeGraphCheckpointExport(config, {cwd, output: spool, quiet: true});
+  const checkpointDigest = yield* putCasFile(casRoot, spool);
+  yield* fs.remove(spool, {force: true});
+  if (checkpointDigest !== parseSha256Digest(exported.artifact.digest)) {
+    return yield* graphSharingFailure('Checkpoint CAS digest does not match the exported artifact.');
+  }
+  const signed = yield* signGraphShareFrontier(
+    key,
+    manifestFromExport(exported, checkpointDigest, {
+      branch: current.branch,
+      generation: current.generation + 1,
+      previousManifestDigest: graphShareFrontierDigest(current),
+      profileDigest: current.profileDigest,
+      publisherFence: current.publisherFence,
+      repositoryId: identity.repositoryId,
+    }),
+  );
+  const manifestDigest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(signed.manifest)));
+  const envelopeDigest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(signed.envelope)));
+  const layout = graphSharingLayout(path, config.agentContextHome, casRoot);
+  yield* writePrivateJsonFile(graphSharingFrontierPointerPath(path, layout.frontiersRoot, identity.repositoryId), {
+    envelopeDigest,
+    manifestDigest,
+    schemaVersion: 1,
+  });
+  return {
+    checkpointDigest,
+    envelopeDigest,
+    generation: current.generation + 1,
+    manifestDigest,
+    profileDigest: current.profileDigest,
+    sourceCommit: exported.sourceCommit,
+    type: 'code-graph-publisher-serve' as const,
     version: 1 as const,
   };
 });
@@ -179,6 +351,46 @@ export const loadOrCreatePublisherKey = Effect.fn('codeGraph.sharing.loadOrCreat
   yield* writePrivateJsonFile(layout.publisherKeyPath, key);
   return key;
 });
+
+function manifestFromExport(
+  exported: {
+    readonly graphAbi: string;
+    readonly graphContentId: string;
+    readonly logicalDigest: string;
+    readonly snapshotId: string;
+    readonly sourceCommit: string;
+  },
+  checkpointDigest: Sha256Digest,
+  meta: {
+    readonly branch: string;
+    readonly generation: number;
+    readonly previousManifestDigest: Sha256Digest | null;
+    readonly profileDigest: Sha256Digest;
+    readonly publisherFence: number;
+    readonly repositoryId: string;
+  },
+): GraphShareFrontierManifestV1 {
+  return {
+    branch: meta.branch,
+    checkpoint: {
+      manifestDigest: checkpointDigest,
+      snapshotId: exported.snapshotId,
+      sourceCommit: exported.sourceCommit,
+    },
+    deltas: [],
+    generation: meta.generation,
+    graphAbi: exported.graphAbi,
+    graphContentId: exported.graphContentId,
+    logicalGraphDigest: parseSha256Digest(exported.logicalDigest),
+    previousManifestDigest: meta.previousManifestDigest,
+    profileDigest: meta.profileDigest,
+    publisherFence: meta.publisherFence,
+    repositoryId: meta.repositoryId,
+    schemaVersion: 1,
+    snapshotId: exported.snapshotId,
+    sourceCommit: exported.sourceCommit,
+  };
+}
 
 function commandCwd(value: string | undefined) {
   return Effect.gen(function* () {

--- a/src/code_graph/sharing/receipts.ts
+++ b/src/code_graph/sharing/receipts.ts
@@ -1,0 +1,90 @@
+import {compareCodeUnits} from '../ordering.js';
+import type {Sha256Digest} from './digest.js';
+import type {GraphShareActionKey} from './action.js';
+
+export const GRAPH_SHARE_RECEIPT_SCHEMA_VERSION = 1 as const;
+
+export interface GraphShareResultAnnouncementV1 {
+  readonly actionKey: GraphShareActionKey;
+  readonly attestationDigest: Sha256Digest;
+  readonly batchId: string;
+  readonly resultManifestDigest: Sha256Digest;
+  readonly semanticDigest: Sha256Digest;
+}
+
+export interface GraphShareQuarantineV1 {
+  readonly actionKey: GraphShareActionKey;
+  readonly semanticDigests: readonly Sha256Digest[];
+}
+
+export interface GraphShareReceiptStoreV1 {
+  readonly quarantine: readonly GraphShareQuarantineV1[];
+  readonly receipts: readonly GraphShareResultAnnouncementV1[];
+  readonly schemaVersion: typeof GRAPH_SHARE_RECEIPT_SCHEMA_VERSION;
+}
+
+export type GraphShareAnnounceStatus = 'accepted' | 'duplicate' | 'quarantined';
+
+export function emptyGraphShareReceiptStore(): GraphShareReceiptStoreV1 {
+  return {quarantine: [], receipts: [], schemaVersion: GRAPH_SHARE_RECEIPT_SCHEMA_VERSION};
+}
+
+export function announceGraphShareResult(
+  store: GraphShareReceiptStoreV1,
+  announcement: GraphShareResultAnnouncementV1,
+): {readonly status: GraphShareAnnounceStatus; readonly store: GraphShareReceiptStoreV1} {
+  const identical = store.receipts.find(
+    receipt =>
+      receipt.actionKey === announcement.actionKey &&
+      receipt.resultManifestDigest === announcement.resultManifestDigest &&
+      receipt.attestationDigest === announcement.attestationDigest &&
+      receipt.semanticDigest === announcement.semanticDigest,
+  );
+  if (identical !== undefined) return {status: 'duplicate', store};
+  const receipts = [...store.receipts, announcement];
+  const semanticDigests = uniqueDigests(
+    receipts.filter(receipt => receipt.actionKey === announcement.actionKey).map(receipt => receipt.semanticDigest),
+  );
+  if (semanticDigests.length > 1) {
+    const quarantine = [
+      ...store.quarantine.filter(item => item.actionKey !== announcement.actionKey),
+      {actionKey: announcement.actionKey, semanticDigests},
+    ].sort((left, right) => compareCodeUnits(left.actionKey, right.actionKey));
+    return {status: 'quarantined', store: {quarantine, receipts, schemaVersion: GRAPH_SHARE_RECEIPT_SCHEMA_VERSION}};
+  }
+  return {
+    status: 'accepted',
+    store: {quarantine: store.quarantine, receipts, schemaVersion: GRAPH_SHARE_RECEIPT_SCHEMA_VERSION},
+  };
+}
+
+export function selectGraphShareResultsForFrozenBatch(
+  store: GraphShareReceiptStoreV1,
+  frozen: {readonly actionKeys: readonly string[]; readonly batchId: string},
+): {
+  readonly quarantined: readonly GraphShareActionKey[];
+  readonly selected: readonly GraphShareResultAnnouncementV1[];
+  readonly skippedLate: readonly GraphShareResultAnnouncementV1[];
+} {
+  const requested = new Set(frozen.actionKeys);
+  const quarantined = new Set(store.quarantine.map(item => item.actionKey));
+  const selected: GraphShareResultAnnouncementV1[] = [];
+  const skippedLate: GraphShareResultAnnouncementV1[] = [];
+  for (const receipt of store.receipts) {
+    if (!requested.has(receipt.actionKey) || quarantined.has(receipt.actionKey)) continue;
+    if (receipt.batchId !== frozen.batchId) {
+      skippedLate.push(receipt);
+      continue;
+    }
+    selected.push(receipt);
+  }
+  return {
+    quarantined: [...quarantined].sort(compareCodeUnits),
+    selected,
+    skippedLate,
+  };
+}
+
+function uniqueDigests(values: readonly Sha256Digest[]): readonly Sha256Digest[] {
+  return [...new Set(values)].sort();
+}

--- a/src/code_graph/sharing/trust.ts
+++ b/src/code_graph/sharing/trust.ts
@@ -4,7 +4,7 @@ import {readJsonFile, writePrivateJsonFile} from './atomic.js';
 import {graphSharingFailure} from './errors.js';
 import {parseSha256Digest, SHA256_DIGEST, SHA256_HEX, type Sha256Digest} from './digest.js';
 import {graphSharingLayout} from './layout.js';
-import type {GraphShareEnrollmentV1, GraphShareProfileV1} from './profile.js';
+import {parseGraphShareCoordinatorUrl, type GraphShareEnrollmentV1, type GraphShareProfileV1} from './profile.js';
 
 const GRAPH_SHARE_TRUST_LOCK_OPTIONS = {
   heartbeatIntervalMilliseconds: 10_000,
@@ -34,6 +34,8 @@ export interface GraphShareTrustDocumentV1 {
 
 export interface GraphShareClientStateV1 {
   readonly casRoot?: string;
+  readonly contributionMode?: 'dedicated' | 'idle' | 'off' | 'passive';
+  readonly coordinatorUrl?: string;
   readonly schemaVersion: 1;
 }
 
@@ -128,10 +130,52 @@ export const writeGraphShareClientState = Effect.fn('codeGraph.sharing.writeClie
   threadnoteHome: string,
   casRoot: string | undefined,
 ) {
-  const path = yield* Path.Path;
-  const layout = graphSharingLayout(path, threadnoteHome);
-  const state: GraphShareClientStateV1 = casRoot === undefined ? {schemaVersion: 1} : {casRoot, schemaVersion: 1};
-  yield* writePrivateJsonFile(layout.clientStatePath, state);
+  yield* patchGraphShareClientState(threadnoteHome, {casRoot});
+});
+
+export const writeGraphShareContributionMode = Effect.fn('codeGraph.sharing.writeContributionMode')(function* (
+  threadnoteHome: string,
+  contributionMode: GraphShareClientStateV1['contributionMode'],
+) {
+  return yield* patchGraphShareClientState(threadnoteHome, {contributionMode});
+});
+
+export const writeGraphShareCoordinatorUrl = Effect.fn('codeGraph.sharing.writeCoordinatorUrl')(function* (
+  threadnoteHome: string,
+  coordinatorUrl: string | undefined,
+) {
+  return yield* patchGraphShareClientState(threadnoteHome, {coordinatorUrl});
+});
+
+export const patchGraphShareClientState = Effect.fn('codeGraph.sharing.patchClientState')(function* (
+  threadnoteHome: string,
+  patch: {
+    readonly casRoot?: string | undefined;
+    readonly contributionMode?: GraphShareClientStateV1['contributionMode'];
+    readonly coordinatorUrl?: string | undefined;
+  },
+) {
+  return yield* withGraphShareClientStateLock(
+    threadnoteHome,
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const layout = graphSharingLayout(path, threadnoteHome);
+      const current = yield* readGraphShareClientState(threadnoteHome);
+      const casRoot = patch.casRoot !== undefined ? patch.casRoot : current.casRoot;
+      const contributionMode = patch.contributionMode !== undefined ? patch.contributionMode : current.contributionMode;
+      const coordinatorUrl = patch.coordinatorUrl !== undefined ? patch.coordinatorUrl : current.coordinatorUrl;
+      const state: GraphShareClientStateV1 = {
+        schemaVersion: 1,
+        ...(casRoot !== undefined && casRoot.trim().length > 0 ? {casRoot} : {}),
+        ...(contributionMode === undefined ? {} : {contributionMode}),
+        ...(coordinatorUrl === undefined || coordinatorUrl.trim().length === 0
+          ? {}
+          : {coordinatorUrl: parseGraphShareCoordinatorUrl(coordinatorUrl)}),
+      };
+      yield* writePrivateJsonFile(layout.clientStatePath, state);
+      return state;
+    }),
+  );
 });
 
 export const resolveGraphShareCasRoot = Effect.fn('codeGraph.sharing.resolveCasRoot')(function* (
@@ -151,6 +195,15 @@ function withGraphShareTrustReceiptsLock<A, E, R>(threadnoteHome: string, effect
     const path = yield* Path.Path;
     const layout = graphSharingLayout(path, threadnoteHome);
     return yield* withExclusiveFileLock(fs, layout.trustReceiptsLockPath, GRAPH_SHARE_TRUST_LOCK_OPTIONS, effect);
+  });
+}
+
+function withGraphShareClientStateLock<A, E, R>(threadnoteHome: string, effect: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const layout = graphSharingLayout(path, threadnoteHome);
+    return yield* withExclusiveFileLock(fs, layout.clientStateLockPath, GRAPH_SHARE_TRUST_LOCK_OPTIONS, effect);
   });
 }
 
@@ -189,7 +242,24 @@ function parseClientState(value: unknown): GraphShareClientStateV1 {
   if (value.casRoot !== undefined && (typeof value.casRoot !== 'string' || value.casRoot.trim().length === 0)) {
     throw graphSharingFailure('Graph-sharing CAS root is invalid.');
   }
-  return value.casRoot === undefined ? {schemaVersion: 1} : {casRoot: value.casRoot, schemaVersion: 1};
+  const contributionMode =
+    value.contributionMode === 'off' ||
+    value.contributionMode === 'passive' ||
+    value.contributionMode === 'idle' ||
+    value.contributionMode === 'dedicated'
+      ? value.contributionMode
+      : undefined;
+  if (value.contributionMode !== undefined && contributionMode === undefined) {
+    throw graphSharingFailure('Graph-sharing contribution mode is invalid.');
+  }
+  const coordinatorUrl =
+    value.coordinatorUrl === undefined ? undefined : parseGraphShareCoordinatorUrl(String(value.coordinatorUrl));
+  return {
+    schemaVersion: 1,
+    ...(value.casRoot === undefined ? {} : {casRoot: value.casRoot}),
+    ...(contributionMode === undefined ? {} : {contributionMode}),
+    ...(coordinatorUrl === undefined ? {} : {coordinatorUrl}),
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/code_graph/sharing/worker.ts
+++ b/src/code_graph/sharing/worker.ts
@@ -1,0 +1,68 @@
+import {Effect, FileSystem, Path} from 'effect';
+import {GRAPH_SHARE_ACTION_KEY, type GraphShareActionKey} from './action.js';
+import {readJsonFile} from './atomic.js';
+import {graphSharingFailure} from './errors.js';
+import {GRAPH_SHARE_GIT_OBJECT_ID} from './git.js';
+import {graphSharingLayout, graphSharingWorkerWorkPath} from './layout.js';
+
+export interface GraphShareWorkerAdvertisement {
+  readonly actionKey: GraphShareActionKey;
+  readonly gitBlobId: string;
+}
+
+export interface GraphShareWorkerPlan {
+  readonly eligible: readonly GraphShareWorkerAdvertisement[];
+  readonly skippedMissingBlob: readonly GraphShareWorkerAdvertisement[];
+}
+
+export function planGraphWorkerActions(
+  advertised: readonly GraphShareWorkerAdvertisement[],
+  presentBlobIds: ReadonlySet<string>,
+): GraphShareWorkerPlan {
+  const eligible: GraphShareWorkerAdvertisement[] = [];
+  const skippedMissingBlob: GraphShareWorkerAdvertisement[] = [];
+  for (const action of advertised) {
+    if (presentBlobIds.has(action.gitBlobId)) eligible.push(action);
+    else skippedMissingBlob.push(action);
+  }
+  return {eligible, skippedMissingBlob};
+}
+
+export const GRAPH_SHARE_WORKER_ADVERTISEMENT_LIMIT = 4_096;
+
+export function parseGraphShareWorkerAdvertisements(value: unknown): readonly GraphShareWorkerAdvertisement[] {
+  if (!Array.isArray(value) || value.length > GRAPH_SHARE_WORKER_ADVERTISEMENT_LIMIT) {
+    throw graphSharingFailure('Worker advertisement list is invalid.');
+  }
+  return value.map(parseAdvertisement);
+}
+
+export const readAdvertisedGraphWorkerActions = Effect.fn('codeGraph.sharing.readAdvertisedWorkerActions')(function* (
+  threadnoteHome: string,
+  repositoryId: string,
+  casRoot?: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const workPath = graphSharingWorkerWorkPath(
+    path,
+    graphSharingLayout(path, threadnoteHome, casRoot).workerRoot,
+    repositoryId,
+  );
+  if (!(yield* fs.exists(workPath))) return [];
+  return parseGraphShareWorkerAdvertisements(yield* readJsonFile(workPath));
+});
+
+function parseAdvertisement(value: unknown): GraphShareWorkerAdvertisement {
+  if (!isRecord(value) || typeof value.actionKey !== 'string' || typeof value.gitBlobId !== 'string') {
+    throw graphSharingFailure('Worker advertisement is invalid.');
+  }
+  if (!GRAPH_SHARE_ACTION_KEY.test(value.actionKey) || !GRAPH_SHARE_GIT_OBJECT_ID.test(value.gitBlobId)) {
+    throw graphSharingFailure('Worker advertisement is invalid.');
+  }
+  return {actionKey: value.actionKey, gitBlobId: value.gitBlobId};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -922,7 +922,7 @@ const graphCheckpoint = Command.make('checkpoint').pipe(
   ]),
 );
 
-const {graphPublisher, graphShare} = makeGraphSharingCommands(
+const {graphContribute, graphPublisher, graphShare, graphWorker} = makeGraphSharingCommands(
   withRuntimeEffect as <E, R>(
     effect: (config: RuntimeConfig) => Effect.Effect<void, E, R>,
   ) => Effect.Effect<void, E, R>,
@@ -996,6 +996,8 @@ const graphCommand = Command.make('graph').pipe(
     graphCheckpoint,
     graphShare,
     graphPublisher,
+    graphContribute,
+    graphWorker,
     graphCompact,
     graphRemoveView,
     graphPurge,

--- a/src/effect/runtime.ts
+++ b/src/effect/runtime.ts
@@ -1,3 +1,4 @@
+import * as BunHttpClient from '@effect/platform-bun/BunHttpClient';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {Crypto, Effect, Layer} from 'effect';
 import {succeedUndefined} from './optional.js';
@@ -91,7 +92,10 @@ const ApplicationServicesLayer = Layer.mergeAll(
   systemLayer,
 );
 
-export const ApplicationLayer = ApplicationServicesLayer.pipe(Layer.provideMerge(BunServices.layer));
+export const ApplicationLayer = ApplicationServicesLayer.pipe(
+  Layer.provideMerge(BunServices.layer),
+  Layer.provideMerge(BunHttpClient.layer),
+);
 
 /**
  * Runtime application layer with explicit-consent anonymous telemetry. The

--- a/test/integration/code-graph.sharing-contributors.test.ts
+++ b/test/integration/code-graph.sharing-contributors.test.ts
@@ -1,0 +1,260 @@
+import {spawn} from '../helpers/node-child-process.js';
+import {createServer} from '../helpers/node-net.js';
+import {mkdir, mkdtemp, rm, writeFile} from '../helpers/node-fs-promises.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import {promisify} from '../helpers/node-util.js';
+import {execFile} from '../helpers/node-child-process.js';
+import {describe, expect, it} from 'vitest';
+import {sha256HexFromDigest, sha256Digest} from '../../src/code_graph/sharing/digest.js';
+
+const execFilePromise = promisify(execFile);
+
+describe('code graph sharing multi-contributor HTTP', () => {
+  it('lets two homes build a remote graph over the coordinator and a third home use it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'threadnote-graph-share-http-e2e-'));
+    const repository = join(root, 'repository');
+    const publisherHome = join(root, 'publisher-home');
+    const contributorAHome = join(root, 'contributor-a');
+    const contributorBHome = join(root, 'contributor-b');
+    const consumerHome = join(root, 'consumer-home');
+    const localHome = join(root, 'local-home');
+    let listener: ReturnType<typeof spawn> | undefined;
+    try {
+      await mkdir(join(repository, 'src'), {recursive: true});
+      await writeFile(join(repository, 'package.json'), '{"name":"graph-share-http","private":true,"type":"module"}\n');
+      await writeFile(join(repository, 'src', 'index.ts'), 'export const shared = 1;\n');
+      await git(repository, ['init', '-q', '--initial-branch=main']);
+      await git(repository, ['remote', 'add', 'origin', 'https://github.com/acme/graph-share-http.git']);
+      await git(repository, ['add', '.']);
+      await commit(repository, 'base');
+
+      const port = await reservedPort();
+      const coordinator = `http://127.0.0.1:${port}`;
+      await runCli(['graph', 'index', '--home', publisherHome, '--cwd', repository, '--json']);
+      const initialized = JSON.parse(
+        (
+          await runCli([
+            'graph',
+            'share',
+            'init',
+            '--home',
+            publisherHome,
+            '--cwd',
+            repository,
+            '--organization',
+            'acme',
+            '--coordinator',
+            coordinator,
+            '--write-config',
+            '--json',
+          ])
+        ).stdout,
+      ) as {readonly profileDigest: string; readonly written: boolean};
+      expect(initialized.written).toBe(true);
+      await git(repository, ['add', '.threadnote/graph-share.json']);
+      await commit(repository, 'enroll graph sharing');
+      await runCli(['graph', 'index', '--full', '--home', publisherHome, '--cwd', repository, '--json']);
+      await runCli(['graph', 'publisher', 'bootstrap', '--home', publisherHome, '--cwd', repository, '--json']);
+
+      listener = spawn(
+        process.execPath,
+        [
+          'src/standalone.ts',
+          'graph',
+          'publisher',
+          'serve',
+          '--home',
+          publisherHome,
+          '--cwd',
+          repository,
+          '--listen',
+          `127.0.0.1:${port}`,
+          '--json',
+        ],
+        {
+          cwd: process.cwd(),
+          env: {...process.env, NO_COLOR: '1', THREADNOTE_TELEMETRY: '0'},
+        },
+      );
+      const served = await waitForJson(listener);
+      expect(served.listening).toBe(true);
+      expect(served.coordinatorUrl).toBe(coordinator);
+      expect(served.generation).toBe(1);
+
+      await runCli([
+        'graph',
+        'share',
+        'join',
+        '--home',
+        contributorAHome,
+        '--cwd',
+        repository,
+        '--coordinator',
+        coordinator,
+        '--json',
+      ]);
+      const contributed = JSON.parse(
+        (await runCli(['graph', 'index', '--home', contributorAHome, '--cwd', repository, '--json'])).stdout,
+      ) as {readonly snapshot: {readonly id: string}};
+      expect(contributed.snapshot.id).toMatch(/^cgsn_/);
+      const contributeStatus = JSON.parse(
+        (await runCli(['graph', 'contribute', 'status', '--home', contributorAHome, '--cwd', repository, '--json']))
+          .stdout,
+      ) as {readonly mode: string};
+      expect(contributeStatus.mode).toBe('passive');
+      const afterA = (await (await fetch(`${coordinator}/v1/status`)).json()) as {
+        readonly receipts: ReadonlyArray<{readonly resultManifestDigest: string}>;
+      };
+      expect(afterA.receipts.length).toBeGreaterThan(0);
+
+      await runCli([
+        'graph',
+        'share',
+        'join',
+        '--home',
+        contributorBHome,
+        '--cwd',
+        repository,
+        '--coordinator',
+        coordinator,
+        '--json',
+      ]);
+      await runCli(['graph', 'index', '--home', contributorBHome, '--cwd', repository, '--json']);
+
+      await runCli([
+        'graph',
+        'share',
+        'join',
+        '--home',
+        consumerHome,
+        '--cwd',
+        repository,
+        '--coordinator',
+        coordinator,
+        '--read-only',
+        '--json',
+      ]);
+      await runCli(['graph', 'index', '--home', consumerHome, '--cwd', repository, '--json']);
+      const queried = JSON.parse(
+        (await runCli(['graph', 'query', '--home', consumerHome, '--cwd', repository, '--query', 'shared', '--json']))
+          .stdout,
+      ) as {
+        readonly nodes: ReadonlyArray<{readonly name: string}>;
+        readonly source?: {readonly kind: string; readonly profileDigest: string};
+      };
+      expect(queried.source).toMatchObject({
+        kind: 'shared-base-plus-local-overlay',
+        profileDigest: initialized.profileDigest,
+      });
+      expect(queried.nodes.some(node => node.name === 'shared')).toBe(true);
+
+      const gitBlob = Buffer.from('blob 4\0test');
+      const treeResponse = await fetch(`${coordinator}/v1/cas/sha256/${sha256HexFromDigest(sha256Digest(gitBlob))}`, {
+        method: 'PUT',
+        body: gitBlob,
+      });
+      expect(treeResponse.status).toBe(400);
+      const missing = await fetch(`${coordinator}/v1/cas/sha256/${'0'.repeat(64)}`);
+      expect(missing.status).toBe(404);
+
+      listener.kill('SIGTERM');
+      listener = undefined;
+
+      const afterDown = JSON.parse(
+        (await runCli(['graph', 'query', '--home', consumerHome, '--cwd', repository, '--query', 'shared', '--json']))
+          .stdout,
+      ) as {readonly source?: {readonly kind: string}};
+      expect(afterDown.source?.kind).toBe('shared-base-plus-local-overlay');
+
+      const unenrolled = join(root, 'unenrolled');
+      await mkdir(join(unenrolled, 'src'), {recursive: true});
+      await writeFile(join(unenrolled, 'package.json'), '{"name":"local-only","private":true,"type":"module"}\n');
+      await writeFile(join(unenrolled, 'src', 'index.ts'), 'export const localOnly = 1;\n');
+      await git(unenrolled, ['init', '-q', '--initial-branch=main']);
+      await git(unenrolled, ['remote', 'add', 'origin', 'https://github.com/acme/local-only.git']);
+      await git(unenrolled, ['add', '.']);
+      await commit(unenrolled, 'local');
+      const localIndex = JSON.parse(
+        (await runCli(['graph', 'index', '--home', localHome, '--cwd', unenrolled, '--json'])).stdout,
+      ) as {readonly snapshot: {readonly id: string}};
+      expect(localIndex.snapshot.id).toMatch(/^cgsn_/);
+    } finally {
+      listener?.kill('SIGTERM');
+      await rm(root, {force: true, recursive: true});
+    }
+  }, 180_000);
+});
+
+function reservedPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address !== null ? address.port : 0;
+      server.close(error => (error ? reject(error) : resolve(port)));
+    });
+    server.on('error', reject);
+  });
+}
+
+function waitForJson(child: ReturnType<typeof spawn>): Promise<{
+  readonly coordinatorUrl: string;
+  readonly generation: number;
+  readonly listening: boolean;
+}> {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      reject(new Error(`publisher serve did not print JSON\n${stdout}\n${stderr}`));
+    }, 120_000);
+    child.stdout?.on('data', chunk => {
+      stdout += String(chunk);
+      const line = stdout
+        .split('\n')
+        .map(value => value.trim())
+        .find(value => value.startsWith('{') && value.includes('coordinatorUrl'));
+      if (line === undefined) return;
+      try {
+        clearTimeout(timer);
+        resolve(JSON.parse(line) as {coordinatorUrl: string; generation: number; listening: boolean});
+      } catch (cause) {
+        clearTimeout(timer);
+        reject(cause);
+      }
+    });
+    child.stderr?.on('data', chunk => {
+      stderr += String(chunk);
+    });
+    child.on('exit', code => {
+      if (code !== 0 && code !== null) {
+        clearTimeout(timer);
+        reject(new Error(`publisher serve exited ${code}\n${stdout}\n${stderr}`));
+      }
+    });
+  });
+}
+
+async function git(cwd: string, args: readonly string[]): Promise<void> {
+  await execFilePromise('git', ['-C', cwd, ...args]);
+}
+
+async function commit(cwd: string, message: string): Promise<void> {
+  await git(cwd, [
+    '-c',
+    'user.name=Threadnote Test',
+    '-c',
+    'user.email=test@threadnote.local',
+    'commit',
+    '-qm',
+    message,
+  ]);
+}
+
+function runCli(args: readonly string[]) {
+  return execFilePromise(process.execPath, ['src/standalone.ts', ...args], {
+    cwd: process.cwd(),
+    env: {...process.env, NO_COLOR: '1', THREADNOTE_TELEMETRY: '0'},
+  });
+}

--- a/test/integration/code-graph.sharing.test.ts
+++ b/test/integration/code-graph.sharing.test.ts
@@ -7,7 +7,7 @@ import {describe, expect, it} from 'vitest';
 
 const execFilePromise = promisify(execFile);
 
-describe('code graph sharing Phase 0', () => {
+describe('code graph sharing Phases 0–2', () => {
   it('imports a verified shared checkpoint on a second home and keeps local graphs without enrollment', async () => {
     const root = await mkdtemp(join(tmpdir(), 'threadnote-graph-share-'));
     const repository = join(root, 'repository');
@@ -173,6 +173,59 @@ describe('code graph sharing Phase 0', () => {
         await readFile(join(clientHome, 'graph-sharing', 'provenance', `${indexed.identity.checkoutId}.json`), 'utf8'),
       ) as {readonly snapshotId: string};
       expect(overlayProvenance.snapshotId).toBe(indexed.snapshot.id);
+
+      await rm(join(repository, 'src', 'dirty.ts'));
+      const contribution = JSON.parse(
+        (await runCli(['graph', 'contribute', 'status', '--home', clientHome, '--cwd', repository, '--json'])).stdout,
+      ) as {readonly mode: string; readonly queued: number};
+      expect(contribution).toMatchObject({mode: 'off', queued: 0});
+      const idleServe = JSON.parse(
+        (
+          await runCli([
+            'graph',
+            'publisher',
+            'serve',
+            '--home',
+            publisherHome,
+            '--cwd',
+            repository,
+            '--cas',
+            cas,
+            '--json',
+          ])
+        ).stdout,
+      ) as {readonly generation: number; readonly sourceCommit: string};
+      expect(idleServe.generation).toBe(1);
+      await writeFile(join(repository, 'src', 'next.ts'), 'export const next = 3;\n');
+      await git(repository, ['add', 'src/next.ts']);
+      await commit(repository, 'advance frontier');
+      await runCli(['graph', 'index', '--full', '--home', publisherHome, '--cwd', repository, '--json']);
+      const served = JSON.parse(
+        (
+          await runCli([
+            'graph',
+            'publisher',
+            'serve',
+            '--home',
+            publisherHome,
+            '--cwd',
+            repository,
+            '--cas',
+            cas,
+            '--json',
+          ])
+        ).stdout,
+      ) as {readonly generation: number; readonly sourceCommit: string};
+      expect(served.generation).toBe(2);
+      expect(served.sourceCommit).not.toBe(idleServe.sourceCommit);
+      const advanced = JSON.parse(
+        (await runCli(['graph', 'index', '--home', clientHome, '--cwd', repository, '--json'])).stdout,
+      ) as {readonly snapshot: {readonly id: string}};
+      expect(advanced.snapshot.id).toMatch(/^cgsn_/);
+      const worker = JSON.parse(
+        (await runCli(['graph', 'worker', '--json', '--home', clientHome, '--cwd', repository])).stdout,
+      ) as {readonly eligible: number; readonly skippedMissingBlob: number};
+      expect(worker).toMatchObject({eligible: 0, skippedMissingBlob: 0});
 
       const unenrolled = join(root, 'unenrolled');
       await mkdir(join(unenrolled, 'src'), {recursive: true});

--- a/test/unit/code-graph.sharing-actions.test.ts
+++ b/test/unit/code-graph.sharing-actions.test.ts
@@ -1,0 +1,89 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {
+  graphShareLanguageAndRole,
+  graphShareMaterializedActionKey,
+  graphShareParseActionKey,
+} from '../../src/code_graph/sharing/action.js';
+import {
+  GRAPH_SHARE_CAS_CANONICAL,
+  GRAPH_SHARE_CAS_WORKER,
+  graphShareActionDiscoveryTag,
+  graphShareFrontierDiscoveryTag,
+  isGraphShareCanonicalRegistry,
+  isGraphShareWorkerRegistry,
+} from '../../src/code_graph/sharing/namespace.js';
+
+const HEX = '0123456789abcdef';
+
+describe('graph share action keys and namespaces', () => {
+  it('keeps worker and canonical CAS namespaces distinct', () => {
+    expect(GRAPH_SHARE_CAS_CANONICAL).not.toBe(GRAPH_SHARE_CAS_WORKER);
+    expect(isGraphShareCanonicalRegistry(GRAPH_SHARE_CAS_CANONICAL)).toBe(true);
+    expect(isGraphShareWorkerRegistry(GRAPH_SHARE_CAS_WORKER)).toBe(true);
+    expect(isGraphShareWorkerRegistry(GRAPH_SHARE_CAS_CANONICAL)).toBe(false);
+    expect(graphShareActionDiscoveryTag('a'.repeat(64))).toBe(`tn-action-${'a'.repeat(64)}`);
+    expect(graphShareFrontierDiscoveryTag('b'.repeat(64), 'refs/heads/main').startsWith('tn-frontier-')).toBe(true);
+  });
+
+  it('is deterministic and changes when any parse-action input changes', () => {
+    FC.assert(
+      FC.property(
+        FC.tuple(
+          hexString(64),
+          hexString(64),
+          FC.string({maxLength: 40, minLength: 1}),
+          hexString(64),
+          FC.constantFrom('typescript:source', 'json:manifest'),
+        ),
+        FC.integer({max: 4, min: 0}),
+        (fields, index) => {
+          const [repositoryId, extractorSet, normalizedPath, contentHash, languageAndRole] = fields;
+          const input = {contentHash, extractorSet, languageAndRole, normalizedPath, repositoryId};
+          expect(graphShareParseActionKey(input)).toBe(graphShareParseActionKey({...input}));
+          const mutated = [...fields];
+          mutated[index] = `${mutated[index]}x`;
+          const [nextRepositoryId, nextExtractorSet, nextPath, nextHash, nextLanguage] = mutated;
+          expect(
+            graphShareParseActionKey({
+              contentHash: nextHash,
+              extractorSet: nextExtractorSet,
+              languageAndRole: nextLanguage,
+              normalizedPath: nextPath,
+              repositoryId: nextRepositoryId,
+            }),
+          ).not.toBe(graphShareParseActionKey(input));
+        },
+      ),
+      {numRuns: 40},
+    );
+  });
+
+  it('separates parse keys from materialized keys', () => {
+    const parseKey = graphShareParseActionKey({
+      contentHash: 'c'.repeat(64),
+      extractorSet: 'e'.repeat(64),
+      languageAndRole: graphShareLanguageAndRole('typescript', 'source'),
+      normalizedPath: 'src/index.ts',
+      repositoryId: 'r'.repeat(64),
+    });
+    const materialized = graphShareMaterializedActionKey({
+      contentHash: 'c'.repeat(64),
+      graphAbi: 'a'.repeat(64),
+      graphContentId: 'cgc_' + 'd'.repeat(40),
+      normalizedPath: 'src/index.ts',
+      parseResultDigest: 'p'.repeat(64),
+      repositoryId: 'r'.repeat(64),
+      workspaceFingerprint: 'w'.repeat(64),
+    });
+    expect(parseKey).toMatch(/^[0-9a-f]{64}$/u);
+    expect(materialized).toMatch(/^[0-9a-f]{64}$/u);
+    expect(parseKey).not.toBe(materialized);
+  });
+});
+
+function hexString(length: number) {
+  return FC.array(FC.constantFrom(...HEX), {maxLength: length, minLength: length}).map(characters =>
+    characters.join(''),
+  );
+}

--- a/test/unit/code-graph.sharing-client.test.ts
+++ b/test/unit/code-graph.sharing-client.test.ts
@@ -1,12 +1,14 @@
+import * as BunHttpClient from '@effect/platform-bun/BunHttpClient';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {describe, expect, it as effectIt} from '@effect/vitest';
 import {it} from 'vitest';
-import {Effect, FileSystem, Layer, Path} from 'effect';
+import {Effect, FileSystem, Layer, Path, Schema} from 'effect';
 import {readFile} from '../helpers/node-fs-promises.js';
 import {dirname, join} from '../helpers/node-path.js';
 import {fileURLToPath} from '../helpers/node-url.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {canonicalJson} from '../../src/code_graph/checkpoint/canonical_json.js';
+import {parseGraphShareFrontierManifest} from '../../src/code_graph/sharing/artifacts.js';
 import {
   generateGraphSharePublisherKey,
   signGraphShareFrontier,
@@ -14,8 +16,9 @@ import {
   type GraphShareSignatureEnvelopeV1,
 } from '../../src/code_graph/sharing/artifacts.js';
 import {putCasBytes} from '../../src/code_graph/sharing/cas.js';
-import {maybeImportSharedGraphBase} from '../../src/code_graph/sharing/client.js';
+import {maybeImportSharedGraphBase, selectPublishedAncestorManifest} from '../../src/code_graph/sharing/client.js';
 import {sha256Digest, sha256HexFromDigest} from '../../src/code_graph/sharing/digest.js';
+import {GraphSharingError} from '../../src/code_graph/sharing/errors.js';
 import {
   graphSharingCasBlobPath,
   graphSharingLayout,
@@ -38,7 +41,7 @@ import {
   writeGraphShareTrustReceipt,
 } from '../../src/code_graph/sharing/trust.js';
 import type {RepositoryIdentity} from '../../src/code_graph/types.js';
-import {CommandExecutor} from '../../src/effect/command.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import {CodeGraphLanguagePackRegistry} from '../../src/code_graph/languages/registry.js';
 import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
@@ -49,6 +52,7 @@ const sharingLayer = CodeGraphMaintenanceCoordinator.layer.pipe(
   Layer.provideMerge(Layer.merge(CodeGraphStore.layer, CommandExecutor.layer)),
   Layer.provideMerge(SystemInfo.layer),
   Layer.provideMerge(BunServices.layer),
+  Layer.provideMerge(BunHttpClient.layer),
 );
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -231,6 +235,97 @@ describe('graph share import and inspect source', () => {
       ).toBeUndefined();
     }).pipe(provideTestLayer(sharingLayer)),
   );
+
+  effectIt.effect('walks signed predecessor frontiers until HEAD is an ancestor', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-share-ancestor-'});
+      const repo = path.join(home, 'repo');
+      yield* fs.makeDirectory(path.join(repo, 'src'), {recursive: true});
+      yield* fs.writeFileString(path.join(repo, 'src', 'a.ts'), 'export const a = 1;\n');
+      yield* git(repo, ['init', '-q', '--initial-branch=main']);
+      yield* git(repo, ['add', '.']);
+      yield* git(repo, ['-c', 'user.name=Test', '-c', 'user.email=test@threadnote.local', 'commit', '-qm', 'one']);
+      const first = (yield* runCommandEffect('git', ['-C', repo, 'rev-parse', 'HEAD'])).stdout.trim();
+      yield* fs.writeFileString(path.join(repo, 'src', 'b.ts'), 'export const b = 2;\n');
+      yield* git(repo, ['add', '.']);
+      yield* git(repo, ['-c', 'user.name=Test', '-c', 'user.email=test@threadnote.local', 'commit', '-qm', 'two']);
+      const second = (yield* runCommandEffect('git', ['-C', repo, 'rev-parse', 'HEAD'])).stdout.trim();
+      const casRoot = path.join(home, 'cas');
+      const profileDigest = sha256Digest('profile');
+      const gen1 = parseGraphShareFrontierManifest({
+        branch: 'refs/heads/main',
+        checkpoint: {
+          manifestDigest: sha256Digest('c1'),
+          snapshotId: 'cgsn_one',
+          sourceCommit: first,
+        },
+        deltas: [],
+        generation: 1,
+        graphAbi: 'e'.repeat(64),
+        graphContentId: `cgc_${'d'.repeat(40)}`,
+        logicalGraphDigest: sha256Digest('g1'),
+        previousManifestDigest: null,
+        profileDigest,
+        publisherFence: 1,
+        repositoryId: 'b'.repeat(64),
+        schemaVersion: 1,
+        snapshotId: 'cgsn_one',
+        sourceCommit: first,
+      });
+      const gen1Digest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(gen1)));
+      const gen2 = parseGraphShareFrontierManifest({
+        branch: 'refs/heads/main',
+        checkpoint: {
+          manifestDigest: sha256Digest('c2'),
+          snapshotId: 'cgsn_two',
+          sourceCommit: second,
+        },
+        deltas: [],
+        generation: 2,
+        graphAbi: 'e'.repeat(64),
+        graphContentId: `cgc_${'d'.repeat(40)}`,
+        logicalGraphDigest: sha256Digest('g2'),
+        previousManifestDigest: gen1Digest,
+        profileDigest,
+        publisherFence: 1,
+        repositoryId: 'b'.repeat(64),
+        schemaVersion: 1,
+        snapshotId: 'cgsn_two',
+        sourceCommit: second,
+      });
+      yield* git(repo, ['checkout', '-q', first]);
+      const identity = {
+        branch: 'main',
+        caseMode: 'sensitive' as const,
+        checkoutId: 'c'.repeat(64),
+        displayName: 'graph-share',
+        gitCommonDirectory: repo,
+        headCommit: first,
+        objectFormat: 'sha1' as const,
+        remoteIdentity: 'github.com/acme/graph-share',
+        repoRoot: repo,
+        repositoryId: 'b'.repeat(64),
+        worktreeId: 'd'.repeat(64),
+      };
+      const selected = yield* selectPublishedAncestorManifest(casRoot, identity, gen2);
+      expect(selected.sourceCommit).toBe(first);
+      expect(selected.generation).toBe(1);
+      const unavailable = yield* selectPublishedAncestorManifest(
+        casRoot,
+        {...identity, headCommit: 'f'.repeat(40)},
+        gen1,
+      ).pipe(
+        Effect.as(false),
+        Effect.catchIf(
+          error => Schema.is(GraphSharingError)(error) && error.kind === 'unavailable',
+          () => Effect.succeed(true),
+        ),
+      );
+      expect(unavailable).toBe(true);
+    }).pipe(provideTestLayer(sharingLayer)),
+  );
 });
 
 function importRequest(repoRoot: string, home: string) {
@@ -342,4 +437,8 @@ function quarantineNames(home: string) {
 function flipHex(value: string): string {
   const last = value.at(-1) === 'a' ? 'b' : 'a';
   return `${value.slice(0, -1)}${last}`;
+}
+
+function git(repo: string, args: readonly string[]) {
+  return runCommandEffect('git', ['-C', repo, ...args]);
 }

--- a/test/unit/code-graph.sharing-contribute.test.ts
+++ b/test/unit/code-graph.sharing-contribute.test.ts
@@ -1,0 +1,50 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer} from 'effect';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {
+  enqueuePersistedGraphShareContribution,
+  readGraphShareContributionQueue,
+} from '../../src/code_graph/sharing/contribution.js';
+import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {SystemInfo} from '../../src/effect/system.js';
+
+const sharingLayer = SystemInfo.layer.pipe(Layer.provideMerge(BunServices.layer));
+
+const announcement = {
+  actionKey: 'a'.repeat(64),
+  attestationDigest: sha256Digest('1'),
+  batchId: 'b'.repeat(40),
+  resultManifestDigest: sha256Digest('2'),
+  semanticDigest: sha256Digest('3'),
+};
+
+describe('graph share contribution queue persistence', () => {
+  effectIt.effect('queues locally when the coordinator is down and round-trips the queue', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-share-queue-'});
+      const repositoryId = 'c'.repeat(64);
+      const first = yield* enqueuePersistedGraphShareContribution(home, repositoryId, 'join', announcement, 'passive');
+      expect(first.queued).toBe(true);
+      const duplicate = yield* enqueuePersistedGraphShareContribution(
+        home,
+        repositoryId,
+        'join',
+        announcement,
+        'passive',
+      );
+      expect(duplicate.queued).toBe(false);
+      const loaded = yield* readGraphShareContributionQueue(home, repositoryId, 'passive');
+      expect(loaded.announcements).toHaveLength(1);
+      const blocked = yield* enqueuePersistedGraphShareContribution(
+        home,
+        `${repositoryId.slice(0, -1)}d`,
+        'read-only',
+        announcement,
+        'passive',
+      );
+      expect(blocked.queued).toBe(false);
+    }).pipe(provideTestLayer(sharingLayer)),
+  );
+});

--- a/test/unit/code-graph.sharing-http.test.ts
+++ b/test/unit/code-graph.sharing-http.test.ts
@@ -1,0 +1,148 @@
+import * as BunHttpClient from '@effect/platform-bun/BunHttpClient';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Deferred, Effect, FileSystem, Layer, Path, Schema} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FC from 'effect/testing/FastCheck';
+import * as HttpClient from 'effect/unstable/http/HttpClient';
+import * as HttpClientRequest from 'effect/unstable/http/HttpClientRequest';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {decodeJsonBytes, readJsonFile} from '../../src/code_graph/sharing/atomic.js';
+import {
+  graphShareControlAnnounceResult,
+  graphShareControlGetCas,
+  graphShareControlGetJson,
+  graphShareControlGetStatus,
+  graphShareControlPostJson,
+  graphShareControlPutCas,
+} from '../../src/code_graph/sharing/control_client.js';
+import {runGraphShareControlServer} from '../../src/code_graph/sharing/control_server.js';
+import {sha256Digest, sha256HexFromDigest} from '../../src/code_graph/sharing/digest.js';
+import {GraphSharingError} from '../../src/code_graph/sharing/errors.js';
+import {graphSharingLayout} from '../../src/code_graph/sharing/layout.js';
+import {graphSharePayloadLooksLikeGitObject} from '../../src/code_graph/sharing/oci.js';
+import {SystemInfo} from '../../src/effect/system.js';
+
+const sharingLayer = Layer.mergeAll(BunServices.layer, BunHttpClient.layer, SystemInfo.layer);
+
+describe('graph share live coordinator and digest CAS', () => {
+  effectIt.effect('serves CAS blobs, rejects Git objects, and never accepts source on the control API', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-share-http-'});
+        const casRoot = path.join(home, 'cas');
+        yield* fs.makeDirectory(casRoot, {recursive: true, mode: 0o700});
+        const ready = yield* Deferred.make<{readonly port: number; readonly url: string}>();
+        yield* Effect.forkScoped(
+          runGraphShareControlServer({
+            casRoot,
+            listen: {hostname: '127.0.0.1', port: 0},
+            onListening: info => Deferred.succeed(ready, info).pipe(Effect.asVoid),
+            organization: 'acme',
+            repositoryId: 'a'.repeat(64),
+            threadnoteHome: home,
+          }),
+        );
+        const info = yield* Deferred.await(ready);
+        const payload = new TextEncoder().encode('{"kind":"parse-result"}');
+        const digest = yield* graphShareControlPutCas(info.url, payload);
+        expect(digest).toBe(sha256Digest(payload));
+        const fetched = yield* graphShareControlGetCas(info.url, digest);
+        expect(new TextDecoder().decode(fetched)).toBe('{"kind":"parse-result"}');
+        const gitBlob = new TextEncoder().encode('blob 4\0test');
+        expect(graphSharePayloadLooksLikeGitObject(gitBlob)).toBe(true);
+        const gitRejected = yield* graphShareControlPutCas(info.url, gitBlob).pipe(
+          Effect.as(false),
+          Effect.catchIf(
+            error => Schema.is(GraphSharingError)(error),
+            () => Effect.succeed(true),
+          ),
+        );
+        expect(gitRejected).toBe(true);
+        const treeHex = sha256HexFromDigest(sha256Digest(gitBlob));
+        const missingTree = yield* graphShareControlGetCas(info.url, `sha256:${treeHex}`).pipe(
+          Effect.as(false),
+          Effect.catchIf(
+            error => Schema.is(GraphSharingError)(error) && error.kind === 'unavailable',
+            () => Effect.succeed(true),
+          ),
+        );
+        expect(missingTree).toBe(true);
+        const wellKnown = yield* graphShareControlGetJson(info.url, '/.well-known/threadnote-graph');
+        expect(wellKnown).toMatchObject({organization: 'acme', protocolVersions: ['v1']});
+        const sourceRejected = yield* graphShareControlPostJson(info.url, '/v1/results', {
+          source: 'fn main() {}',
+        });
+        expect(sourceRejected.status).toBe(400);
+        const client = yield* HttpClient.HttpClient;
+        const malformed = yield* client.execute(
+          HttpClientRequest.post(`${info.url}/v1/results`).pipe(
+            HttpClientRequest.bodyUint8Array(new TextEncoder().encode('{'), 'application/json'),
+          ),
+        );
+        expect(malformed.status).toBe(400);
+      }).pipe(provideTestLayer(sharingLayer)),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'graph-sharing JSON bytes round-trip I-JSON objects independently of JSON.parse',
+    {
+      generation: FC.integer({max: 10_000, min: 0}),
+      organization: FC.array(FC.constantFrom(...'0123456789abcdef'), {maxLength: 16, minLength: 1}).map(characters =>
+        characters.join(''),
+      ),
+    },
+    ({generation, organization}) =>
+      Effect.gen(function* () {
+        const value = {generation, organization, protocolVersions: ['v1'] as const};
+        const decoded = yield* decodeJsonBytes(new TextEncoder().encode(JSON.stringify(value)));
+        expect(decoded).toEqual({...value, protocolVersions: ['v1']});
+      }),
+    {fastCheck: {numRuns: 20}},
+  );
+
+  effectIt.effect('commits concurrent result announcements without dropping receipts', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-share-race-'});
+        const casRoot = path.join(home, 'cas');
+        yield* fs.makeDirectory(casRoot, {recursive: true, mode: 0o700});
+        const ready = yield* Deferred.make<{readonly port: number; readonly url: string}>();
+        yield* Effect.forkScoped(
+          runGraphShareControlServer({
+            casRoot,
+            listen: {hostname: '127.0.0.1', port: 0},
+            onListening: info => Deferred.succeed(ready, info).pipe(Effect.asVoid),
+            organization: 'acme',
+            repositoryId: 'a'.repeat(64),
+            threadnoteHome: home,
+          }),
+        );
+        const info = yield* Deferred.await(ready);
+        const announcements = [0, 1, 2, 3, 4, 5, 6, 7].map(index => ({
+          actionKey: index.toString(16).repeat(64).slice(0, 64),
+          attestationDigest: sha256Digest(`att-${index}`),
+          batchId: 'b'.repeat(40),
+          resultManifestDigest: sha256Digest(`res-${index}`),
+          semanticDigest: sha256Digest(`sem-${index}`),
+        }));
+        yield* Effect.forEach(
+          announcements,
+          (announcement, index) => graphShareControlAnnounceResult(info.url, announcement, `k${index}`),
+          {concurrency: 'unbounded'},
+        );
+        const status = yield* graphShareControlGetStatus(info.url);
+        expect(status.receipts).toHaveLength(announcements.length);
+        const persisted = (yield* readJsonFile(graphSharingLayout(path, home).coordinatorStatePath)) as {
+          readonly receipts: {readonly receipts: readonly unknown[]};
+        };
+        expect(persisted.receipts.receipts).toHaveLength(announcements.length);
+      }).pipe(provideTestLayer(sharingLayer)),
+    ),
+  );
+});

--- a/test/unit/code-graph.sharing-phase12.test.ts
+++ b/test/unit/code-graph.sharing-phase12.test.ts
@@ -1,0 +1,349 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {
+  applyLogicalDelta,
+  compactLogicalGraph,
+  diffLogicalGraphs,
+  emptyLogicalGraph,
+  logicalGraphDigest,
+  selectNewestPublishedAncestor,
+  setLogicalRecord,
+  deleteLogicalRecord,
+} from '../../src/code_graph/sharing/delta.js';
+import {
+  GRAPH_SHARE_CONTROL_MAX_BODY_BYTES,
+  dispatchGraphShareControl,
+  emptyGraphShareCoordinatorState,
+} from '../../src/code_graph/sharing/control_protocol.js';
+import {
+  enqueueGraphShareContribution,
+  emptyGraphShareContributionQueue,
+  parseGraphShareContributionQueue,
+} from '../../src/code_graph/sharing/contribution.js';
+import {parseGraphShareWorkerAdvertisements, planGraphWorkerActions} from '../../src/code_graph/sharing/worker.js';
+import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {parseGraphShareFrontierManifest} from '../../src/code_graph/sharing/artifacts.js';
+import {graphShareLanguageAndRole, graphShareParseActionKey} from '../../src/code_graph/sharing/action.js';
+import {
+  admitsSharedParseCacheHydrate,
+  quarantinedGraphShareActionKeys,
+} from '../../src/code_graph/sharing/parse_cache.js';
+import {graphShareParseResultArtifact} from '../../src/code_graph/sharing/parse_result.js';
+
+describe('graph share deltas, coordinator, contribution, and workers', () => {
+  it('keeps checkpoint plus ordered deltas equal to an independent clean model', () => {
+    FC.assert(
+      FC.property(
+        FC.array(FC.tuple(FC.string({maxLength: 8, minLength: 1}), FC.string({maxLength: 8, minLength: 0})), {
+          maxLength: 8,
+        }),
+        FC.array(FC.string({maxLength: 8, minLength: 1}), {maxLength: 4}),
+        (upserts, deletions) => {
+          let clean = emptyLogicalGraph();
+          for (const [key, value] of upserts) clean = setLogicalRecord(clean, key, value);
+          for (const key of deletions) clean = deleteLogicalRecord(clean, key);
+          const base = emptyLogicalGraph();
+          const delta = diffLogicalGraphs(base, clean, {
+            baseCommit: '1'.repeat(40),
+            baseSnapshotId: 'cgsn_' + 'a'.repeat(40),
+            graphAbi: 'b'.repeat(64),
+            targetCommit: '2'.repeat(40),
+          });
+          const applied = applyLogicalDelta(base, delta);
+          expect(logicalGraphDigest(applied)).toBe(logicalGraphDigest(clean));
+          expect(logicalGraphDigest(compactLogicalGraph(applied))).toBe(logicalGraphDigest(clean));
+        },
+      ),
+      {numRuns: 40},
+    );
+  });
+
+  it('selects the newest published ancestor of HEAD', () => {
+    const published = [{sourceCommit: '1'.repeat(40)}, {sourceCommit: '2'.repeat(40)}, {sourceCommit: '3'.repeat(40)}];
+    const ancestors = new Set(['1'.repeat(40), '2'.repeat(40), 'head']);
+    expect(selectNewestPublishedAncestor(published, commit => ancestors.has(commit))?.sourceCommit).toBe(
+      '2'.repeat(40),
+    );
+  });
+
+  it('rejects oversize bodies, unknown fields, and source/graph payloads on the control API', () => {
+    const state = emptyGraphShareCoordinatorState({organization: 'acme', repositoryId: 'a'.repeat(64)});
+    expect(
+      dispatchGraphShareControl(state, {
+        body: {},
+        bodyBytes: GRAPH_SHARE_CONTROL_MAX_BODY_BYTES + 1,
+        method: 'POST',
+        path: '/v1/results',
+      }).response.status,
+    ).toBe(413);
+    expect(
+      dispatchGraphShareControl(state, {
+        body: {source: 'fn main() {}'},
+        bodyBytes: 16,
+        method: 'POST',
+        path: '/v1/results',
+      }).response.status,
+    ).toBe(400);
+    expect(
+      dispatchGraphShareControl(state, {
+        body: {
+          actionKey: 'b'.repeat(64),
+          attestationDigest: sha256Digest('att'),
+          batchId: 'c'.repeat(40),
+          extra: true,
+          idempotencyKey: 'k1',
+          resultManifestDigest: sha256Digest('res'),
+          semanticDigest: sha256Digest('sem'),
+        },
+        bodyBytes: 200,
+        method: 'POST',
+        path: '/v1/results',
+      }).response.status,
+    ).toBe(400);
+    const enrolled = dispatchGraphShareControl(state, {
+      body: {idempotencyKey: 'k1', repositoryId: 'a'.repeat(64)},
+      bodyBytes: 80,
+      method: 'POST',
+      path: '/v1/enroll',
+    });
+    expect(enrolled.response.status).toBe(201);
+    const replay = dispatchGraphShareControl(enrolled.state, {
+      body: {idempotencyKey: 'k1', repositoryId: 'a'.repeat(64)},
+      bodyBytes: 80,
+      method: 'POST',
+      path: '/v1/enroll',
+    });
+    expect(replay.response.status).toBe(200);
+    expect(
+      dispatchGraphShareControl(state, {bodyBytes: 0, method: 'GET', path: '/.well-known/threadnote-graph'}).response
+        .status,
+    ).toBe(200);
+    const firstResult = dispatchGraphShareControl(state, {
+      body: {
+        actionKey: 'b'.repeat(64),
+        attestationDigest: sha256Digest('att'),
+        batchId: 'c'.repeat(40),
+        idempotencyKey: 'r1',
+        resultManifestDigest: sha256Digest('res'),
+        semanticDigest: sha256Digest('sem-a'),
+      },
+      bodyBytes: 200,
+      method: 'POST',
+      path: '/v1/results',
+    });
+    expect(firstResult.response.status).toBe(201);
+    const quarantined = dispatchGraphShareControl(firstResult.state, {
+      body: {
+        actionKey: 'b'.repeat(64),
+        attestationDigest: sha256Digest('att-2'),
+        batchId: 'c'.repeat(40),
+        idempotencyKey: 'r2',
+        resultManifestDigest: sha256Digest('res-2'),
+        semanticDigest: sha256Digest('sem-b'),
+      },
+      bodyBytes: 200,
+      method: 'POST',
+      path: '/v1/results',
+    });
+    expect(quarantined.response.status).toBe(409);
+  });
+
+  it('queues contribution only after join and skips missing git blobs', () => {
+    const announcement = {
+      actionKey: 'a'.repeat(64),
+      attestationDigest: sha256Digest('1'),
+      batchId: 'b'.repeat(40),
+      resultManifestDigest: sha256Digest('2'),
+      semanticDigest: sha256Digest('3'),
+    };
+    expect(
+      enqueueGraphShareContribution(emptyGraphShareContributionQueue('passive'), announcement, 'read-only').queued,
+    ).toBe(false);
+    expect(enqueueGraphShareContribution(emptyGraphShareContributionQueue('off'), announcement, 'join').queued).toBe(
+      false,
+    );
+    const queued = enqueueGraphShareContribution(emptyGraphShareContributionQueue('passive'), announcement, 'join');
+    expect(queued.queued).toBe(true);
+    const coordinatorDown = enqueueGraphShareContribution(queued.queue, announcement, 'join');
+    expect(coordinatorDown.queued).toBe(false);
+    expect(coordinatorDown.queue.announcements).toHaveLength(1);
+    expect(parseGraphShareContributionQueue(JSON.parse(JSON.stringify(queued.queue)))).toEqual(queued.queue);
+    const presentBlob = 'a'.repeat(40);
+    const missingBlob = 'b'.repeat(40);
+    expect(
+      parseGraphShareWorkerAdvertisements([
+        {actionKey: 'a'.repeat(64), gitBlobId: presentBlob},
+        {actionKey: 'b'.repeat(64), gitBlobId: missingBlob},
+      ]),
+    ).toHaveLength(2);
+    const plan = planGraphWorkerActions(
+      [
+        {actionKey: 'a'.repeat(64), gitBlobId: presentBlob},
+        {actionKey: 'b'.repeat(64), gitBlobId: missingBlob},
+      ],
+      new Set([presentBlob]),
+    );
+    expect(plan.eligible).toHaveLength(1);
+    expect(plan.skippedMissingBlob).toHaveLength(1);
+    expect(() => parseGraphShareWorkerAdvertisements([{actionKey: 'a'.repeat(64), gitBlobId: 'c'.repeat(41)}])).toThrow(
+      /invalid/i,
+    );
+    expect(() =>
+      parseGraphShareContributionQueue({...queued.queue, announcements: [{...announcement, extra: true}]}),
+    ).toThrow(/unsupported|invalid/i);
+    const conflicted = enqueueGraphShareContribution(
+      queued.queue,
+      {...announcement, semanticDigest: sha256Digest('other')},
+      'join',
+    );
+    expect(conflicted.queued).toBe(true);
+    expect(conflicted.conflict).toBe(true);
+  });
+
+  it('rejects non-oid frontier sourceCommit values including HEAD', () => {
+    const digest = sha256Digest('x');
+    expect(() =>
+      parseGraphShareFrontierManifest({
+        branch: 'refs/heads/main',
+        checkpoint: {
+          manifestDigest: digest,
+          snapshotId: 'cgsn_imported',
+          sourceCommit: 'HEAD',
+        },
+        deltas: [],
+        generation: 1,
+        graphAbi: 'e'.repeat(64),
+        graphContentId: `cgc_${'d'.repeat(40)}`,
+        logicalGraphDigest: digest,
+        previousManifestDigest: null,
+        profileDigest: digest,
+        publisherFence: 1,
+        repositoryId: 'b'.repeat(64),
+        schemaVersion: 1,
+        snapshotId: 'cgsn_imported',
+        sourceCommit: 'HEAD',
+      }),
+    ).toThrow(/object id/i);
+  });
+
+  it('admits parse-cache hydrate only for matching action keys and skips quarantined keys', () => {
+    const repositoryId = 'b'.repeat(64);
+    const extractorSet = 'c'.repeat(64);
+    const contentHash = 'd'.repeat(64);
+    const normalizedPath = 'src/index.ts';
+    const languageAndRole = graphShareLanguageAndRole('typescript', 'source');
+    const actionKey = graphShareParseActionKey({
+      contentHash,
+      extractorSet,
+      languageAndRole,
+      normalizedPath,
+      repositoryId,
+    });
+    const parsed = graphShareParseResultArtifact({
+      actionKey,
+      contentHash,
+      extractorSet,
+      facts: {diagnostics: [], edges: [], path: normalizedPath, symbols: []},
+      gitBlobId: 'e'.repeat(40),
+      languageAndRole,
+      normalizedPath,
+      repositoryId,
+    });
+    const receipt = {
+      actionKey,
+      attestationDigest: sha256Digest('att'),
+      batchId: 'f'.repeat(40),
+      resultManifestDigest: sha256Digest('res'),
+      semanticDigest: parsed.semanticDigest,
+    };
+    expect(
+      admitsSharedParseCacheHydrate({
+        identityRepositoryId: repositoryId,
+        parsed,
+        quarantinedActionKeys: new Set(),
+        receipt,
+      }),
+    ).toBe(true);
+    expect(
+      admitsSharedParseCacheHydrate({
+        identityRepositoryId: repositoryId,
+        parsed,
+        quarantinedActionKeys: new Set(),
+        receipt: {...receipt, actionKey: 'a'.repeat(64)},
+      }),
+    ).toBe(false);
+    const spoofed = graphShareParseResultArtifact({
+      ...parsed,
+      actionKey: 'a'.repeat(64),
+    });
+    expect(
+      admitsSharedParseCacheHydrate({
+        identityRepositoryId: repositoryId,
+        parsed: spoofed,
+        quarantinedActionKeys: new Set(),
+        receipt: {...receipt, actionKey: spoofed.actionKey},
+      }),
+    ).toBe(false);
+    const conflicted = [
+      receipt,
+      {
+        ...receipt,
+        attestationDigest: sha256Digest('att-2'),
+        resultManifestDigest: sha256Digest('res-2'),
+        semanticDigest: sha256Digest('other'),
+      },
+    ];
+    expect([...quarantinedGraphShareActionKeys(conflicted)]).toEqual([actionKey]);
+    expect(
+      admitsSharedParseCacheHydrate({
+        identityRepositoryId: repositoryId,
+        parsed,
+        quarantinedActionKeys: quarantinedGraphShareActionKeys(conflicted),
+        receipt,
+      }),
+    ).toBe(false);
+    FC.assert(
+      FC.property(
+        FC.array(FC.constantFrom(...'abcdefghijklmnopqrstuvwxyz'), {maxLength: 12, minLength: 1}).map(
+          characters => `src/${characters.join('')}.ts`,
+        ),
+        normalizedPath => {
+          const key = graphShareParseActionKey({
+            contentHash,
+            extractorSet,
+            languageAndRole,
+            normalizedPath,
+            repositoryId,
+          });
+          const artifact = graphShareParseResultArtifact({
+            actionKey: key,
+            contentHash,
+            extractorSet,
+            facts: {diagnostics: [], edges: [], path: normalizedPath, symbols: []},
+            gitBlobId: 'e'.repeat(40),
+            languageAndRole,
+            normalizedPath,
+            repositoryId,
+          });
+          expect(
+            admitsSharedParseCacheHydrate({
+              identityRepositoryId: repositoryId,
+              parsed: artifact,
+              quarantinedActionKeys: new Set(),
+              receipt: {actionKey: key},
+            }),
+          ).toBe(true);
+          expect(
+            admitsSharedParseCacheHydrate({
+              identityRepositoryId: repositoryId,
+              parsed: {...artifact, actionKey: 'a'.repeat(64)},
+              quarantinedActionKeys: new Set(),
+              receipt: {actionKey: 'a'.repeat(64)},
+            }),
+          ).toBe(false);
+        },
+      ),
+      {numRuns: 20},
+    );
+  });
+});

--- a/test/unit/code-graph.sharing-profile.test.ts
+++ b/test/unit/code-graph.sharing-profile.test.ts
@@ -5,6 +5,7 @@ import {
   casProfilePointer,
   defaultGraphShareProfile,
   graphShareProfileDigest,
+  parseGraphShareCoordinatorUrl,
   parseGraphShareEnrollment,
   parseGraphShareProfile,
   parseGraphShareProfilePointer,
@@ -51,6 +52,13 @@ describe('graph share enrollment and profile', () => {
     });
     expect(() => assertEnrollmentMatchesIdentity(enrollment, 'd'.repeat(64))).toThrow(/repositoryId/);
     expect(() => assertEnrollmentMatchesIdentity(enrollment, PROFILE.repositoryId)).not.toThrow();
+  });
+
+  it('accepts loopback HTTP coordinator URLs and rejects non-loopback HTTP', () => {
+    expect(parseGraphShareCoordinatorUrl('http://127.0.0.1:18765')).toBe('http://127.0.0.1:18765');
+    expect(parseGraphShareCoordinatorUrl('http://localhost:9')).toBe('http://localhost:9');
+    expect(() => parseGraphShareCoordinatorUrl('http://example.com')).toThrow(/loopback/i);
+    expect(() => parseGraphShareCoordinatorUrl('ftp://127.0.0.1')).toThrow(/https or loopback/i);
   });
 
   it('keeps organization profile digest stable under key reorder', () => {

--- a/test/unit/code-graph.sharing-receipts.test.ts
+++ b/test/unit/code-graph.sharing-receipts.test.ts
@@ -1,0 +1,157 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {
+  announceGraphShareResult,
+  emptyGraphShareReceiptStore,
+  selectGraphShareResultsForFrozenBatch,
+  type GraphShareResultAnnouncementV1,
+} from '../../src/code_graph/sharing/receipts.js';
+import {
+  lateResultAdmitted,
+  observeCanonicalHead,
+  freezeGraphShareBatch,
+  idleGraphShareFrontier,
+  publishGraphShareBatch,
+  verifyGraphShareBatch,
+  assembleGraphShareBatch,
+} from '../../src/code_graph/sharing/frontier.js';
+import type {Sha256Digest} from '../../src/code_graph/sharing/digest.js';
+
+const digest = (character: string): Sha256Digest => `sha256:${character.repeat(64)}`;
+
+describe('graph share receipts and frozen batches', () => {
+  it('is order-independent and duplicate-idempotent for identical announcements', () => {
+    FC.assert(
+      FC.property(FC.array(announcementArb(), {maxLength: 6, minLength: 1}), announcements => {
+        const shuffled = [...announcements].reverse();
+        let left = emptyGraphShareReceiptStore();
+        let right = emptyGraphShareReceiptStore();
+        for (const announcement of announcements) {
+          left = announceGraphShareResult(left, announcement).store;
+          left = announceGraphShareResult(left, announcement).store;
+        }
+        for (const announcement of shuffled) {
+          right = announceGraphShareResult(right, announcement).store;
+        }
+        expect(left.receipts).toHaveLength(uniqueKeys(announcements).length);
+        expect(right.receipts.map(receiptKey).sort()).toEqual(left.receipts.map(receiptKey).sort());
+      }),
+      {numRuns: 25},
+    );
+  });
+
+  it('quarantines one action key with two semantic digests and never first-writer-wins', () => {
+    const first: GraphShareResultAnnouncementV1 = {
+      actionKey: 'a'.repeat(64),
+      attestationDigest: digest('1'),
+      batchId: 'b'.repeat(40),
+      resultManifestDigest: digest('2'),
+      semanticDigest: digest('3'),
+    };
+    const second = {
+      ...first,
+      attestationDigest: digest('4'),
+      resultManifestDigest: digest('5'),
+      semanticDigest: digest('6'),
+    };
+    const accepted = announceGraphShareResult(emptyGraphShareReceiptStore(), first);
+    expect(accepted.status).toBe('accepted');
+    const quarantined = announceGraphShareResult(accepted.store, second);
+    expect(quarantined.status).toBe('quarantined');
+    const collided = announceGraphShareResult(accepted.store, {...first, semanticDigest: digest('9')});
+    expect(collided.status).toBe('quarantined');
+    const selected = selectGraphShareResultsForFrozenBatch(quarantined.store, {
+      actionKeys: [first.actionKey],
+      batchId: first.batchId,
+    });
+    expect(selected.selected).toEqual([]);
+    expect(selected.quarantined).toEqual([first.actionKey]);
+  });
+
+  it('rejects late results from a different frozen batch', () => {
+    let machine = idleGraphShareFrontier();
+    machine = observeCanonicalHead(machine, {
+      commit: 'c'.repeat(40),
+      isDescendantOfPublished: true,
+      nowSeconds: 0,
+    });
+    machine = freezeGraphShareBatch(machine, {
+      actionKeys: ['a'.repeat(64)],
+      changedBytes: 1,
+      changedFiles: 1,
+      nowSeconds: 30,
+      thresholds: {maximumAgeSeconds: 30, maximumChangedBytes: 1, maximumChangedFiles: 1},
+    });
+    expect(machine.phase).toBe('frozen');
+    expect(lateResultAdmitted(machine, machine.frozenBatchId ?? '')).toBe(true);
+    expect(lateResultAdmitted(machine, 'd'.repeat(40))).toBe(false);
+    const late: GraphShareResultAnnouncementV1 = {
+      actionKey: 'a'.repeat(64),
+      attestationDigest: digest('1'),
+      batchId: 'd'.repeat(40),
+      resultManifestDigest: digest('2'),
+      semanticDigest: digest('3'),
+    };
+    const selected = selectGraphShareResultsForFrozenBatch(
+      announceGraphShareResult(emptyGraphShareReceiptStore(), late).store,
+      {
+        actionKeys: [late.actionKey],
+        batchId: machine.frozenBatchId ?? '',
+      },
+    );
+    expect(selected.skippedLate).toHaveLength(1);
+    expect(selected.selected).toEqual([]);
+  });
+
+  it('coalesces collecting commits into one frozen batch', () => {
+    let machine = idleGraphShareFrontier();
+    machine = observeCanonicalHead(machine, {commit: '1'.repeat(40), isDescendantOfPublished: true, nowSeconds: 0});
+    machine = observeCanonicalHead(machine, {commit: '2'.repeat(40), isDescendantOfPublished: true, nowSeconds: 1});
+    machine = observeCanonicalHead(machine, {commit: '3'.repeat(40), isDescendantOfPublished: true, nowSeconds: 2});
+    machine = freezeGraphShareBatch(machine, {
+      actionKeys: [],
+      changedBytes: 10,
+      changedFiles: 3,
+      nowSeconds: 2,
+      thresholds: {maximumAgeSeconds: 30, maximumChangedBytes: 1, maximumChangedFiles: 1},
+    });
+    expect(machine.phase).toBe('frozen');
+    expect(machine.buildingFrontier).toBe('3'.repeat(40));
+    machine = assembleGraphShareBatch(machine);
+    machine = verifyGraphShareBatch(machine);
+    machine = publishGraphShareBatch(machine, digest('9'));
+    expect(machine.generation).toBe(1);
+    expect(machine.publishedFrontier).toBe('3'.repeat(40));
+  });
+});
+
+function receiptKey(announcement: GraphShareResultAnnouncementV1): string {
+  return `${announcement.actionKey}:${announcement.resultManifestDigest}:${announcement.attestationDigest}:${announcement.semanticDigest}`;
+}
+
+function uniqueKeys(announcements: readonly GraphShareResultAnnouncementV1[]): string[] {
+  return [...new Set(announcements.map(receiptKey))];
+}
+
+function announcementArb() {
+  return FC.tuple(hex(64), hex(64), hex(40), hex(64), hex(64)).map(
+    ([actionKey, attestation, batchId, result, semantic]) =>
+      ({
+        actionKey,
+        attestationDigest: digestFromHex(attestation),
+        batchId,
+        resultManifestDigest: digestFromHex(result),
+        semanticDigest: digestFromHex(semantic),
+      }) satisfies GraphShareResultAnnouncementV1,
+  );
+}
+
+function hex(length: number) {
+  return FC.array(FC.constantFrom(...'0123456789abcdef'), {maxLength: length, minLength: length}).map(characters =>
+    characters.join(''),
+  );
+}
+
+function digestFromHex(value: string): Sha256Digest {
+  return `sha256:${value}`;
+}

--- a/test/unit/website-content.test.ts
+++ b/test/unit/website-content.test.ts
@@ -1048,6 +1048,8 @@ The body remains ordinary **Markdown**.
     expect(docs).toContain('source-derived names, signatures, and documentation');
     expect(docs).toContain('A secret embedded in source can appear');
     expect(commands).toContain('threadnote graph share init --write-config --organization acme');
+    expect(commands).toContain('threadnote graph contribute status');
+    expect(commands).toContain('threadnote graph worker --json');
     expect(docs).toContain('threadnote graph share join --read-only');
     expect(docs).toContain('The next `threadnote graph index` imports a verified shared base');
     expect(docs).toContain('shared-base-plus-local-overlay');

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -1,6 +1,6 @@
 import {cursorCloudDocsSection} from './docsCursorCloud.js';
 import {cursorCloudPersonalDocsSection} from './docsCursorCloudPersonal.js';
-import {graphCheckpointsDocsArticle} from './docsGraphCheckpoints.js';
+import {graphCheckpointsDocsArticle, graphCliCommand} from './docsGraphCheckpoints.js';
 import {
   contextBriefMcpTool,
   finalizeCodeRefsMcpTool,
@@ -76,33 +76,7 @@ export const cliCommands: CliCommandReference[] = [
       'threadnote share sync',
     ],
   },
-  {
-    command: 'graph',
-    summary: 'Build, inspect, analyze, report on, and export the current snapshot-aware polyglot code graph.',
-    examples: [
-      'threadnote graph query --query "session refresh"',
-      'threadnote graph query --workset commerce --query "checkout contract" --budget-tokens 1250',
-      'threadnote graph query --workset commerce --cursor cgwc_…',
-      'threadnote graph node --node-id cgs_…',
-      'threadnote graph neighbors --node-id cgs_… --direction incoming',
-      'threadnote graph explain --symbol RefreshSession',
-      'threadnote graph path --from LoginScreen --to TokenStore',
-      'threadnote graph path --workset commerce --from cgr_… --to cgr_…',
-      'threadnote graph impact --base origin/main',
-      'threadnote graph impact --workset commerce --query cgr_…',
-      'threadnote graph topology --workset commerce --json',
-      'threadnote graph analyze --view full',
-      'threadnote graph report --output architecture-report.md',
-      'threadnote graph export --format graphml --output code-graph.graphml',
-      'threadnote graph checkpoint export --output threadnote-graph.cgcp',
-      'threadnote graph checkpoint verify --input threadnote-graph.cgcp --expected-digest sha256:…',
-      'threadnote graph checkpoint import --input threadnote-graph.cgcp --expected-digest sha256:…',
-      'threadnote graph share init --write-config --organization acme',
-      'threadnote graph share join --read-only',
-      'threadnote graph index',
-      'threadnote graph publisher bootstrap',
-    ],
-  },
+  graphCliCommand,
   {
     command: 'seed / workset',
     summary: 'Import curated guidance, prepare named repository sets, and inspect their published graph coverage.',

--- a/website/src/content/docsGraphCheckpoints.ts
+++ b/website/src/content/docsGraphCheckpoints.ts
@@ -1,4 +1,37 @@
-import type {DocsArticle} from './docsTypes.js';
+import type {CliCommandReference, DocsArticle} from './docsTypes.js';
+
+export const graphCliCommand: CliCommandReference = {
+  command: 'graph',
+  summary: 'Build, inspect, analyze, report on, and export the current snapshot-aware polyglot code graph.',
+  examples: [
+    'threadnote graph query --query "session refresh"',
+    'threadnote graph query --workset commerce --query "checkout contract" --budget-tokens 1250',
+    'threadnote graph query --workset commerce --cursor cgwc_…',
+    'threadnote graph node --node-id cgs_…',
+    'threadnote graph neighbors --node-id cgs_… --direction incoming',
+    'threadnote graph explain --symbol RefreshSession',
+    'threadnote graph path --from LoginScreen --to TokenStore',
+    'threadnote graph path --workset commerce --from cgr_… --to cgr_…',
+    'threadnote graph impact --base origin/main',
+    'threadnote graph impact --workset commerce --query cgr_…',
+    'threadnote graph topology --workset commerce --json',
+    'threadnote graph analyze --view full',
+    'threadnote graph report --output architecture-report.md',
+    'threadnote graph export --format graphml --output code-graph.graphml',
+    'threadnote graph checkpoint export --output threadnote-graph.cgcp',
+    'threadnote graph checkpoint verify --input threadnote-graph.cgcp --expected-digest sha256:…',
+    'threadnote graph checkpoint import --input threadnote-graph.cgcp --expected-digest sha256:…',
+    'threadnote graph share init --write-config --organization acme',
+    'threadnote graph share join --read-only',
+    'threadnote graph share join --coordinator http://127.0.0.1:18765',
+    'threadnote graph publisher bootstrap',
+    'threadnote graph publisher serve',
+    'threadnote graph publisher serve --listen 127.0.0.1:18765',
+    'threadnote graph contribute status',
+    'threadnote graph worker --json',
+    'threadnote graph index',
+  ],
+};
 
 export const graphCheckpointsDocsArticle: DocsArticle = {
   id: 'graph-checkpoints',
@@ -53,7 +86,7 @@ threadnote graph checkpoint import \\
     },
     {
       type: 'paragraph',
-      text: 'Organization graph sharing reuses this checkpoint contract. A checked-in `.threadnote/graph-share.json` pointer names a digest-pinned profile and publisher key fingerprint. `threadnote graph share join --read-only` records local trust only. The next `threadnote graph index` imports a verified shared base and builds only the local overlay. MCP then reports `source.kind: shared-base-plus-local-overlay` with the profile digest, frontier commit, and local commit. Missing enrollment keeps ordinary local indexing. Invalid signatures stay fail-closed for the candidate and preserve the last ready local graph. Recall does not start this work.',
+      text: 'Organization graph sharing reuses this checkpoint contract. A checked-in `.threadnote/graph-share.json` pointer names a digest-pinned profile and publisher key fingerprint. `threadnote graph share join --read-only` records local trust only. The next `threadnote graph index` imports a verified shared base and builds only the local overlay. `graph publisher serve` publishes the next signed generation when HEAD advances; `graph publisher serve --listen 127.0.0.1:port` also serves the loopback coordinator and digest CAS so additional homes can join without sharing a filesystem CAS directory. Clients select the newest published ancestor. After a contributing join, local parse batches enqueue parse-result artifacts (never source text) and upload them once the coordinator is reachable. Worker CAS is separate from the canonical frontier, and the coordinator API never accepts source or graph records. MCP then reports `source.kind: shared-base-plus-local-overlay` with the profile digest, frontier commit, and local commit. Missing enrollment keeps ordinary local indexing. Invalid signatures stay fail-closed for the candidate and preserve the last ready local graph. Recall does not start this work.',
     },
     {
       type: 'note',


### PR DESCRIPTION
## Summary
- Add a live loopback HTTP coordinator and digest CAS on `graph publisher serve --listen` so enrolled homes can share parse results before packed checkpoints exist. Control JSON uses Effect `schemaBodyJson`.
- Hydrate the parse cache before the writer lock (fail-open) and admit only matching non-quarantined action keys (`repositoryId`, unique `semanticDigest`, `parsed.actionKey === receipt.actionKey === graphShareParseActionKey`). Concurrent `POST /v1/results` serializes with an exclusive lock on `coordinator-state.json` plus `Ref.modify`; GET/HEAD stay lock-free.
- Cover two contributing homes plus a read-only consumer (`source.kind=shared-base-plus-local-overlay`). Production publisher still compactes; empty deltas remain spec-allowed compaction, and the client still rejects non-empty deltas.

## Test plan
- [ ] `test/unit/code-graph.sharing-http.test.ts` and `test/unit/code-graph.sharing-phase12.test.ts` (lock retries via `SystemInfo` + `TestClock.withLive`)
- [ ] `test/unit/code-graph.sharing-*.test.ts` for parse-cache admission, receipts, contribute, and client delta rejection
- [ ] `test/integration/code-graph.sharing.test.ts` and `test/integration/code-graph.sharing-contributors.test.ts` (two-writer + read-only consumer)
- [ ] oxlint on touched files and `tsc` for `src` + `test`
- [ ] Confirm this PR is not #368 (W3 checkpoints already merged)