### PR TITLE
Fail CLEAN-root freeze export and omit dangling checkpoint monikers

### DIFF
--- a/src/code_graph/checkpoint/projection.ts
+++ b/src/code_graph/checkpoint/projection.ts
@@ -1231,12 +1231,24 @@ function streamMonikers<E, R>(
     undefined,
     cursor =>
       sql.unsafe<MonikerRow>(
-        `SELECT id, version, scheme, role, kind, resolution_domain, identity,
-                package_name, package_version, import_path, qualified_name,
-                component_id, symbol_id, dependency_kind, evidence_path, evidence_span_json
-         FROM code_graph_monikers
-         WHERE snapshot_id = ? AND (? IS NULL OR id > ? COLLATE BINARY)
-         ORDER BY id COLLATE BINARY
+        `SELECT moniker.id, moniker.version, moniker.scheme, moniker.role, moniker.kind,
+                moniker.resolution_domain, moniker.identity, moniker.package_name,
+                moniker.package_version, moniker.import_path, moniker.qualified_name,
+                moniker.component_id, moniker.symbol_id, moniker.dependency_kind,
+                moniker.evidence_path, moniker.evidence_span_json
+         FROM code_graph_monikers AS moniker
+         LEFT JOIN snapshot_files AS evidence
+           ON evidence.snapshot_id = moniker.snapshot_id AND evidence.path = moniker.evidence_path
+         LEFT JOIN workspace_components AS component
+           ON component.snapshot_id = moniker.snapshot_id AND component.id = moniker.component_id
+         LEFT JOIN symbols AS symbol
+           ON symbol.snapshot_id = moniker.snapshot_id AND symbol.id = moniker.symbol_id
+         WHERE moniker.snapshot_id = ?
+           AND evidence.path IS NOT NULL
+           AND (moniker.component_id IS NULL OR component.id IS NOT NULL)
+           AND (moniker.symbol_id IS NULL OR symbol.id IS NOT NULL)
+           AND (? IS NULL OR moniker.id > ? COLLATE BINARY)
+         ORDER BY moniker.id COLLATE BINARY
          LIMIT ?`,
         [snapshotId, cursor ?? null, cursor ?? null, pageSize],
       ),

--- a/src/code_graph/inventory.ts
+++ b/src/code_graph/inventory.ts
@@ -36,6 +36,7 @@ import {
   type CodeGraphInventoryExclusionReason,
 } from './inventory_policy.js';
 import {compareCodeUnits} from './ordering.js';
+import {workspaceHasUninventoriedMonikerEvidence} from './workspace.js';
 import {
   codeGraphExtractionPlanMetrics,
   codeGraphSourceSizeBucket,
@@ -488,7 +489,8 @@ export const inventoryRepository = Effect.fn('codeGraph.inventoryRepository')(fu
           },
         }),
     skipped,
-    ...([...overlay.changed].some(relative => languagePacks.isResolutionContext(relative))
+    ...([...overlay.changed].some(relative => languagePacks.isResolutionContext(relative)) ||
+    workspaceHasUninventoriedMonikerEvidence(declaredWorkspace.workspace, new Set(files.map(file => file.path)))
       ? {}
       : {workspace: declaredWorkspace.workspace}),
   } satisfies CodeGraphInventory;

--- a/src/code_graph/sharing/client.ts
+++ b/src/code_graph/sharing/client.ts
@@ -421,6 +421,7 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
     yield* sharingProgress(input.request.onProgress, 'building-local-overlay');
     yield* writeSharedGraphProvenance(input.request.threadnoteHome, input.request.identity.checkoutId, {
       checkpointDigest: selected.checkpoint.manifestDigest,
+      deltaCount: selected.deltas.length,
       frontierCommit: selected.sourceCommit,
       profileDigest,
       repositoryId: input.request.identity.repositoryId,
@@ -506,6 +507,7 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
   yield* sharingProgress(input.request.onProgress, 'building-local-overlay');
   yield* writeSharedGraphProvenance(input.request.threadnoteHome, input.request.identity.checkoutId, {
     checkpointDigest: selected.checkpoint.manifestDigest,
+    deltaCount: selected.deltas.length,
     frontierCommit: selected.sourceCommit,
     profileDigest,
     repositoryId: input.request.identity.repositoryId,

--- a/src/code_graph/sharing/frontier.ts
+++ b/src/code_graph/sharing/frontier.ts
@@ -54,6 +54,27 @@ export function observeCanonicalHead(
       publishedFrontier: state.publishedFrontier,
     };
   }
+  if (state.phase === 'failed') {
+    if (input.commit === state.publishedFrontier) {
+      return {
+        ...state,
+        collectingStartedAtSeconds:
+          state.pendingRange.length > 0 ? (state.collectingStartedAtSeconds ?? input.nowSeconds) : null,
+        observedHead: input.commit,
+        phase: state.pendingRange.length > 0 ? 'collecting' : 'published',
+      };
+    }
+    const pendingRange = state.pendingRange.includes(input.commit)
+      ? state.pendingRange
+      : [...state.pendingRange, input.commit];
+    return {
+      ...state,
+      collectingStartedAtSeconds: state.collectingStartedAtSeconds ?? input.nowSeconds,
+      observedHead: input.commit,
+      pendingRange,
+      phase: 'collecting',
+    };
+  }
   if (state.phase === 'frozen' || state.phase === 'assembling' || state.phase === 'verifying') {
     if (input.commit === state.observedHead || state.pendingRange.includes(input.commit)) return state;
     return {...state, observedHead: input.commit, pendingRange: [...state.pendingRange, input.commit]};

--- a/src/code_graph/sharing/provenance.ts
+++ b/src/code_graph/sharing/provenance.ts
@@ -7,6 +7,7 @@ import {lookupGraphShareTrustReceipt} from './trust.js';
 
 export interface SharedGraphProvenanceV1 {
   readonly checkpointDigest: Sha256Digest;
+  readonly deltaCount: number;
   readonly frontierCommit: string;
   readonly profileDigest: Sha256Digest;
   readonly repositoryId: string;
@@ -124,7 +125,7 @@ export function sharedGraphQuerySource(
   readonly profileDigest: Sha256Digest;
 } {
   return {
-    deltaCount: 0,
+    deltaCount: provenance.deltaCount,
     frontierCommit: provenance.frontierCommit,
     kind: 'shared-base-plus-local-overlay',
     localCommit,
@@ -181,8 +182,18 @@ function parseProvenance(value: unknown): SharedGraphProvenanceV1 {
   if (typeof record.repositoryId !== 'string' || !SHA256_HEX.test(record.repositoryId)) {
     throw graphSharingFailure('Shared graph provenance repository identity is invalid.');
   }
+  const deltaCount =
+    record.deltaCount === undefined
+      ? 0
+      : typeof record.deltaCount === 'number' && Number.isSafeInteger(record.deltaCount) && record.deltaCount >= 0
+        ? record.deltaCount
+        : undefined;
+  if (record.deltaCount !== undefined && deltaCount === undefined) {
+    throw graphSharingFailure('Shared graph provenance is invalid.');
+  }
   return {
     checkpointDigest: parseSha256Digest(String(record.checkpointDigest)),
+    deltaCount: deltaCount ?? 0,
     frontierCommit: record.frontierCommit,
     profileDigest: parseSha256Digest(String(record.profileDigest)),
     repositoryId: record.repositoryId,

--- a/src/code_graph/sharing/publisher_cycle.ts
+++ b/src/code_graph/sharing/publisher_cycle.ts
@@ -183,13 +183,33 @@ export const advanceGraphPublisherFrontier = Effect.fn('codeGraph.sharing.advanc
     verified.push(receipt.value);
   }
   yield* hydratePublisherFacts(config, identity, verified).pipe(Effect.ignore);
-  const indexer = yield* CodeGraphIndexer;
-  yield* indexer.index({cwd, ensureVectors: false, threadnoteHome: config.agentContextHome});
-  machine = assembleGraphShareBatch(machine);
-  yield* persistMachine(coordinatorOptions, machine, options.onMachine, options.stateRef);
-  machine = verifyGraphShareBatch(machine);
-  yield* persistMachine(coordinatorOptions, machine, options.onMachine, options.stateRef);
-  const published = yield* exportSignedGeneration(config, options, current, identity.repositoryId, profile);
+  const published = yield* Effect.gen(function* () {
+    const indexer = yield* CodeGraphIndexer;
+    const store = yield* CodeGraphStore;
+    yield* indexer.index({cwd, ensureVectors: false, force: true, threadnoteHome: config.agentContextHome});
+    const layout = codeGraphLayout(path, config.agentContextHome, identity.checkoutId, identity.worktreeId);
+    const ready = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+    if (
+      ready === undefined ||
+      ready.dirty ||
+      ready.baseSnapshotId !== undefined ||
+      ready.commit !== identity.headCommit
+    ) {
+      return yield* graphSharingFailure(
+        'Checkpoint export requires the exact ready CLEAN root snapshot for the current repository HEAD.',
+      );
+    }
+    machine = assembleGraphShareBatch(machine);
+    yield* persistMachine(coordinatorOptions, machine, options.onMachine, options.stateRef);
+    machine = verifyGraphShareBatch(machine);
+    yield* persistMachine(coordinatorOptions, machine, options.onMachine, options.stateRef);
+    return yield* exportSignedGeneration(config, options, current, identity.repositoryId, profile);
+  }).pipe(
+    Effect.tapError(() => {
+      machine = failGraphShareBatch(machine);
+      return persistMachine(coordinatorOptions, machine, options.onMachine, options.stateRef);
+    }),
+  );
   machine = publishGraphShareBatch(machine, published.manifestDigest);
   yield* persistMachine(coordinatorOptions, machine, options.onMachine, options.stateRef);
   return {

--- a/src/code_graph/workspace.ts
+++ b/src/code_graph/workspace.ts
@@ -28,6 +28,15 @@ import {
 
 export {discoverBazelWorkspace} from './workspace_bazel.js';
 
+export function workspaceHasUninventoriedMonikerEvidence(
+  workspace: CodeGraphWorkspace,
+  filePaths: ReadonlySet<string>,
+): boolean {
+  return workspace.projects.some(project =>
+    (project.monikers ?? []).some(moniker => !filePaths.has(moniker.evidence.path)),
+  );
+}
+
 interface WorkspaceProjectPathIndex {
   readonly projectsByRoot: ReadonlyMap<string, readonly CodeGraphWorkspaceProject[]>;
   readonly projectsBySourceRoot: ReadonlyMap<string, readonly CodeGraphWorkspaceProject[]>;

--- a/test/integration/code-graph.checkpoint-projection.test.ts
+++ b/test/integration/code-graph.checkpoint-projection.test.ts
@@ -6,6 +6,7 @@ import {join} from '../helpers/node-path.js';
 import {it as effectIt} from '@effect/vitest';
 import {Effect, Path} from 'effect';
 import {TestClock} from 'effect/testing';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
 import {describe, expect} from 'vitest';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {codeGraphCheckpointAbiInputV1} from '../../src/code_graph/checkpoint/compatibility.js';
@@ -108,14 +109,167 @@ describe('code graph checkpoint projection', () => {
     },
     60_000,
   );
+
+  effectIt.effect(
+    'omits planted dangling monikers whose evidence file is not in the snapshot',
+    () => {
+      let fixtureRoot: string | undefined;
+      return Effect.gen(function* () {
+        const fixture = createRepository();
+        fixtureRoot = fixture.root;
+        const indexer = yield* CodeGraphIndexer;
+        const path = yield* Path.Path;
+        const store = yield* CodeGraphStore;
+        const indexed = yield* indexer.index({cwd: fixture.repository, threadnoteHome: fixture.home});
+        const databasePath = codeGraphLayout(
+          path,
+          fixture.home,
+          indexed.identity.checkoutId,
+          indexed.identity.worktreeId,
+        ).databasePath;
+        const provenance = yield* store.snapshotPackProvenance(databasePath, indexed.snapshot.id);
+        expect(provenance).toBeDefined();
+        if (provenance === undefined) return;
+        yield* store.withSession(
+          databasePath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            const components = yield* sql<{readonly id: string}>`
+              SELECT id FROM workspace_components WHERE snapshot_id = ${indexed.snapshot.id} LIMIT 1
+            `;
+            const component = components[0];
+            expect(component).toBeDefined();
+            if (component === undefined) return;
+            yield* sql`
+              INSERT INTO code_graph_monikers (
+                snapshot_id, id, version, scheme, role, kind, resolution_domain, identity,
+                package_name, component_id, evidence_path, evidence_span_json
+              ) VALUES (
+                ${indexed.snapshot.id},
+                ${`cgm_${'d'.repeat(64)}`},
+                ${1},
+                ${'package'},
+                ${'export'},
+                ${'package'},
+                ${'package:npm'},
+                ${'package:npm:scratchpad'},
+                ${'scratchpad'},
+                ${component.id},
+                ${'scratchpad/package.json'},
+                ${'{"column":1,"endColumn":1,"endLine":1,"line":1}'}
+              )
+            `;
+          }),
+        );
+        const records: CodeGraphCheckpointRecordV1[] = [];
+        yield* projectCodeGraphCheckpointV1({
+          abi: codeGraphCheckpointAbiInputV1(provenance),
+          databasePath,
+          identity: indexed.identity,
+          snapshotId: indexed.snapshot.id,
+          writeMetadata: () => Effect.void,
+          writeRecords: page => Effect.sync(() => records.push(...page)),
+        });
+        expect(
+          records.filter(record => record.kind === 'moniker' && record.evidencePath === 'scratchpad/package.json'),
+        ).toEqual([]);
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() =>
+            fixtureRoot === undefined ? undefined : rmSync(fixtureRoot, {force: true, recursive: true}),
+          ),
+        ),
+        provideTestLayer(ApplicationLayer),
+        TestClock.withLive,
+      );
+    },
+    60_000,
+  );
+
+  effectIt.effect(
+    'does not index ignored package-export monikers that declared workspace discovery would otherwise keep',
+    () => {
+      let fixtureRoot: string | undefined;
+      return Effect.gen(function* () {
+        const fixture = createRepository({ignoreScratchpad: true});
+        fixtureRoot = fixture.root;
+        const indexer = yield* CodeGraphIndexer;
+        const path = yield* Path.Path;
+        const store = yield* CodeGraphStore;
+        const indexed = yield* indexer.index({cwd: fixture.repository, threadnoteHome: fixture.home});
+        const databasePath = codeGraphLayout(
+          path,
+          fixture.home,
+          indexed.identity.checkoutId,
+          indexed.identity.worktreeId,
+        ).databasePath;
+        const dangling = yield* store.withSession(
+          databasePath,
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            const rows = yield* sql<{readonly count: number}>`
+              SELECT COUNT(*) AS count
+              FROM code_graph_monikers AS moniker
+              LEFT JOIN snapshot_files AS evidence
+                ON evidence.snapshot_id = moniker.snapshot_id AND evidence.path = moniker.evidence_path
+              WHERE moniker.snapshot_id = ${indexed.snapshot.id} AND evidence.path IS NULL
+            `;
+            return Number(rows[0]?.count ?? -1);
+          }),
+        );
+        expect(dangling).toBe(0);
+        const provenance = yield* store.snapshotPackProvenance(databasePath, indexed.snapshot.id);
+        expect(provenance).toBeDefined();
+        if (provenance === undefined) return;
+        const records: CodeGraphCheckpointRecordV1[] = [];
+        yield* projectCodeGraphCheckpointV1({
+          abi: codeGraphCheckpointAbiInputV1(provenance),
+          databasePath,
+          identity: indexed.identity,
+          snapshotId: indexed.snapshot.id,
+          writeMetadata: () => Effect.void,
+          writeRecords: page => Effect.sync(() => records.push(...page)),
+        });
+        expect(
+          records.some(
+            record =>
+              'evidencePath' in record &&
+              typeof record.evidencePath === 'string' &&
+              record.evidencePath.startsWith('scratchpad/'),
+          ),
+        ).toBe(false);
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() =>
+            fixtureRoot === undefined ? undefined : rmSync(fixtureRoot, {force: true, recursive: true}),
+          ),
+        ),
+        provideTestLayer(ApplicationLayer),
+        TestClock.withLive,
+      );
+    },
+    60_000,
+  );
 });
 
-function createRepository(): {readonly home: string; readonly repository: string; readonly root: string} {
+function createRepository(options: {readonly ignoreScratchpad?: boolean} = {}): {
+  readonly home: string;
+  readonly repository: string;
+  readonly root: string;
+} {
   const root = mkdtempSync(join(tmpdir(), 'threadnote-checkpoint-projection-'));
   const repository = join(root, 'repository');
   const home = join(root, 'threadnote-home');
   mkdirSync(join(repository, 'src'), {recursive: true});
   mkdirSync(home, {recursive: true});
+  if (options.ignoreScratchpad === true) {
+    mkdirSync(join(repository, 'scratchpad'), {recursive: true});
+    writeFileSync(join(repository, '.threadnoteignore'), 'scratchpad/package.json\n');
+    writeFileSync(
+      join(repository, 'scratchpad', 'package.json'),
+      `${JSON.stringify({name: 'scratchpad', private: true}, null, 2)}\n`,
+    );
+  }
   writeFileSync(
     join(repository, 'package.json'),
     `${JSON.stringify(

--- a/test/integration/code-graph.sharing-deltas.test.ts
+++ b/test/integration/code-graph.sharing-deltas.test.ts
@@ -15,7 +15,7 @@ import {maybeImportSharedGraphBase, runGraphShareJoin} from '../../src/code_grap
 import {graphSharingFrontierPointerPath, graphSharingLayout} from '../../src/code_graph/sharing/layout.js';
 import {advanceGraphPublisherFrontier} from '../../src/code_graph/sharing/publisher_cycle.js';
 import {runGraphPublisherBootstrap, runGraphShareInit} from '../../src/code_graph/sharing/publisher.js';
-import {writeSharedGraphProvenance} from '../../src/code_graph/sharing/provenance.js';
+import {loadSharedGraphQuerySource, writeSharedGraphProvenance} from '../../src/code_graph/sharing/provenance.js';
 import {CodeGraphStore} from '../../src/code_graph/store.js';
 import {runCommandEffect} from '../../src/effect/command.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
@@ -125,6 +125,24 @@ describe('graph share TCG1 delta publication and apply', () => {
           expect(clientApplied.snapshot.fileCount).toBe(clean.snapshot.fileCount);
           expect(clientApplied.snapshot.symbolCount).toBe(clean.snapshot.symbolCount);
           expect(clientApplied.snapshot.graphContentId).toBe(clean.snapshot.graphContentId);
+          expect(
+            yield* loadSharedGraphQuerySource({
+              checkoutId: identity.checkoutId,
+              localCommit: identity.headCommit,
+              repositoryId: identity.repositoryId,
+              snapshot: clientApplied.snapshot,
+              threadnoteHome: clientHome,
+            }),
+          ).toMatchObject({deltaCount: 1, kind: 'shared-base-plus-local-overlay'});
+          expect(
+            yield* loadSharedGraphQuerySource({
+              checkoutId: identity.checkoutId,
+              localCommit: identity.headCommit,
+              repositoryId: identity.repositoryId,
+              snapshot: clean.snapshot,
+              threadnoteHome: cleanHome,
+            }),
+          ).toBeUndefined();
           const reapply = yield* maybeImportSharedGraphBase({
             cwd: repository,
             identity,
@@ -138,6 +156,7 @@ describe('graph share TCG1 delta publication and apply', () => {
           });
           yield* writeSharedGraphProvenance(clientHome, identity.checkoutId, {
             checkpointDigest: `sha256:${'9'.repeat(64)}`,
+            deltaCount: 0,
             frontierCommit: frontier.sourceCommit,
             profileDigest: frontier.profileDigest,
             repositoryId: identity.repositoryId,

--- a/test/integration/code-graph.sharing-publisher-freeze.test.ts
+++ b/test/integration/code-graph.sharing-publisher-freeze.test.ts
@@ -3,10 +3,12 @@ import {Deferred, Effect, FileSystem, Path, Ref} from 'effect';
 import {TestClock} from 'effect/testing';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
 import {runCommandEffect} from '../../src/effect/command.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {runGraphShareJoin} from '../../src/code_graph/sharing/client.js';
 import {graphShareControlGetStatus} from '../../src/code_graph/sharing/control_client.js';
+import {loadGraphShareCoordinatorState} from '../../src/code_graph/sharing/control_server.js';
 import {advanceGraphPublisherFrontier} from '../../src/code_graph/sharing/publisher_cycle.js';
 import {
   runGraphPublisherBootstrap,
@@ -200,6 +202,178 @@ describe('graph share publisher freeze cycle', () => {
           expect(served.manifestDigest).toBe(bootstrapped.manifestDigest);
           expect(served.type).toBe('code-graph-publisher-serve');
           if (served.type === 'code-graph-publisher-serve') expect(served.published).toBe(false);
+        }).pipe(provideTestLayer(ApplicationLayer)),
+      ),
+    180_000,
+  );
+
+  effectIt.effect(
+    'publishes a descendant freeze from an incremental ready snapshot without a prior full index',
+    () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-share-clean-export-'});
+          const repository = path.join(root, 'repository');
+          const cas = path.join(root, 'cas');
+          const publisherHome = path.join(root, 'publisher-home');
+          yield* fs.makeDirectory(path.join(repository, 'src'), {recursive: true});
+          yield* fs.writeFileString(
+            path.join(repository, 'package.json'),
+            '{"name":"graph-share-clean-export","private":true,"type":"module"}\n',
+          );
+          yield* fs.writeFileString(path.join(repository, 'src', 'index.ts'), 'export const shared = 1;\n');
+          yield* git(repository, ['init', '-q', '--initial-branch=main']);
+          yield* git(repository, ['remote', 'add', 'origin', 'https://github.com/acme/graph-share-clean-export.git']);
+          yield* git(repository, ['add', '.']);
+          yield* git(repository, [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '-qm',
+            'base',
+          ]);
+          const indexer = yield* CodeGraphIndexer;
+          yield* indexer.index({cwd: repository, ensureVectors: false, threadnoteHome: publisherHome});
+          yield* runGraphShareInit(config(publisherHome), {
+            cas,
+            cwd: repository,
+            organization: 'acme',
+            writeConfig: true,
+          });
+          yield* git(repository, ['add', '.threadnote/graph-share.json']);
+          yield* git(repository, [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '-qm',
+            'enroll',
+          ]);
+          yield* indexer.index({
+            cwd: repository,
+            ensureVectors: false,
+            force: true,
+            threadnoteHome: publisherHome,
+          });
+          const bootstrapped = yield* runGraphPublisherBootstrap(config(publisherHome), {cas, cwd: repository});
+          yield* fs.writeFileString(path.join(repository, 'src', 'next.ts'), 'export const next = 2;\n');
+          yield* git(repository, ['add', 'src/next.ts']);
+          yield* git(repository, [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '-qm',
+            'advance',
+          ]);
+          yield* indexer.index({cwd: repository, ensureVectors: false, threadnoteHome: publisherHome});
+          const advanced = yield* advanceGraphPublisherFrontier(config(publisherHome), {
+            cas,
+            cwd: repository,
+            forceFreeze: true,
+          });
+          expect(advanced.published).toBe(true);
+          expect(advanced.generation).toBe(bootstrapped.generation + 1);
+          expect(advanced.phase === 'published' || advanced.phase === 'collecting').toBe(true);
+        }).pipe(provideTestLayer(ApplicationLayer)),
+      ),
+    180_000,
+  );
+
+  effectIt.effect(
+    'fails a frozen batch instead of leaving verifying when checkpoint export cannot run',
+    () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-share-export-fail-'});
+          const repository = path.join(root, 'repository');
+          const cas = path.join(root, 'cas');
+          const publisherHome = path.join(root, 'publisher-home');
+          yield* fs.makeDirectory(path.join(repository, 'src'), {recursive: true});
+          yield* fs.writeFileString(
+            path.join(repository, 'package.json'),
+            '{"name":"graph-share-export-fail","private":true,"type":"module"}\n',
+          );
+          yield* fs.writeFileString(path.join(repository, 'src', 'index.ts'), 'export const shared = 1;\n');
+          yield* git(repository, ['init', '-q', '--initial-branch=main']);
+          yield* git(repository, ['remote', 'add', 'origin', 'https://github.com/acme/graph-share-export-fail.git']);
+          yield* git(repository, ['add', '.']);
+          yield* git(repository, [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '-qm',
+            'base',
+          ]);
+          const indexer = yield* CodeGraphIndexer;
+          yield* indexer.index({cwd: repository, ensureVectors: false, threadnoteHome: publisherHome});
+          yield* runGraphShareInit(config(publisherHome), {
+            cas,
+            cwd: repository,
+            organization: 'acme',
+            writeConfig: true,
+          });
+          yield* git(repository, ['add', '.threadnote/graph-share.json']);
+          yield* git(repository, [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '-qm',
+            'enroll',
+          ]);
+          yield* indexer.index({
+            cwd: repository,
+            ensureVectors: false,
+            force: true,
+            threadnoteHome: publisherHome,
+          });
+          const bootstrapped = yield* runGraphPublisherBootstrap(config(publisherHome), {cas, cwd: repository});
+          yield* fs.writeFileString(path.join(repository, 'src', 'next.ts'), 'export const next = 2;\n');
+          yield* git(repository, ['add', 'src/next.ts']);
+          yield* git(repository, [
+            '-c',
+            'user.name=Threadnote Test',
+            '-c',
+            'user.email=test@threadnote.local',
+            'commit',
+            '-qm',
+            'advance',
+          ]);
+          yield* fs.writeFileString(path.join(repository, 'src', 'dirty.ts'), 'export const dirty = 1;\n');
+          const phases = yield* Ref.make<string[]>([]);
+          const failed = yield* advanceGraphPublisherFrontier(config(publisherHome), {
+            cas,
+            cwd: repository,
+            forceFreeze: true,
+            onMachine: machine => Ref.update(phases, current => [...current, machine.phase]),
+          }).pipe(Effect.exit);
+          expect(failed._tag).toBe('Failure');
+          const walked = yield* Ref.get(phases);
+          expect(walked).toContain('frozen');
+          expect(walked.at(-1)).toBe('failed');
+          expect(walked).not.toContain('published');
+          expect(walked).not.toContain('verifying');
+          const identity = yield* resolveRepositoryIdentity(repository);
+          const coordinator = yield* loadGraphShareCoordinatorState({
+            organization: 'acme',
+            repositoryId: identity.repositoryId,
+            threadnoteHome: publisherHome,
+          });
+          expect(coordinator.machine.phase).toBe('failed');
+          expect(coordinator.machine.generation).toBe(bootstrapped.generation);
+          expect(coordinator.machine.publishedFrontier).toBe(bootstrapped.sourceCommit);
         }).pipe(provideTestLayer(ApplicationLayer)),
       ),
     180_000,

--- a/test/unit/code-graph.checkpoint-import-store.test.ts
+++ b/test/unit/code-graph.checkpoint-import-store.test.ts
@@ -7,6 +7,7 @@ import {describe, expect} from 'vitest';
 import {
   CODE_GRAPH_INVENTORY_REUSE_RECEIPT_VERSION,
   CodeGraphStore,
+  codeGraphPackageMoniker,
   hydrateCodeGraphCheckpointReusableBaseReceipt,
   materializedFileShardIdentity,
   type CodeGraphCheckpointImportBuildInput,
@@ -229,6 +230,94 @@ describe('code graph checkpoint import store', () => {
             }),
           );
           expect(staged._tag).toBe('Failure');
+          expect(yield* store.readySnapshotById(databasePath, snapshot.id)).toBeUndefined();
+        }),
+      ).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  );
+
+  effectIt.effect('rejects checkpoint import when a moniker evidence path is not inventoried', () =>
+    TestClock.withLive(
+      withFixture(({databasePath, identity, snapshot, store}) =>
+        Effect.gen(function* () {
+          const ownerToken = yield* claimPersistentBuildForTest(store, databasePath, identity, snapshot);
+          const counts = emptyCodeGraphCheckpointCounts();
+          counts.file = 1;
+          counts['workspace-scope'] = 1;
+          counts['workspace-component'] = 1;
+          counts.moniker = 1;
+          const input = {...checkpointReceiptInput(), batchCount: 1, packProvenance: [], recordCounts: counts};
+          yield* store.bindCheckpointImportBuild(databasePath, snapshot.id, input);
+          const componentId = `cgp_${'1'.repeat(32)}`;
+          const moniker = codeGraphPackageMoniker({
+            componentId,
+            evidence: {
+              path: 'scratchpad/package.json',
+              span: {column: 1, endColumn: 1, endLine: 1, line: 1},
+            },
+            packageName: 'scratchpad',
+            role: 'export',
+          });
+          expect(
+            yield* store.stageCheckpointImportRecordPage(databasePath, snapshot.id, ownerToken, {
+              batchIndex: 0,
+              digest: {algorithm: 'sha256', digest: 'd'.repeat(64)},
+              records: [
+                {
+                  blobId: 'b'.repeat(40),
+                  contentHash: 'c'.repeat(64),
+                  kind: 'file',
+                  language: 'typescript',
+                  mode: '100644',
+                  path: 'src/value.ts',
+                  size: 12,
+                  source: 'commit',
+                },
+                {
+                  buildSystem: 'node',
+                  diagnostics: [],
+                  id: 'workspace-root',
+                  kind: 'workspace-scope',
+                  name: 'checkpoint-import',
+                  provenance: 'declared',
+                  root: '',
+                },
+                {
+                  buildSystem: 'node',
+                  componentKind: 'package',
+                  diagnostics: [],
+                  id: componentId,
+                  kind: 'workspace-component',
+                  languages: ['typescript'],
+                  name: 'scratchpad',
+                  provenance: 'declared',
+                  resolutionDomain: 'typescript',
+                  root: 'scratchpad',
+                  sourceRoots: ['scratchpad'],
+                  workspaceId: 'workspace-root',
+                  workspaceRoots: [''],
+                },
+                {
+                  componentId: moniker.componentId,
+                  evidencePath: moniker.evidence.path,
+                  evidenceSpan: moniker.evidence.span,
+                  id: moniker.id,
+                  identity: moniker.identity,
+                  kind: 'moniker',
+                  monikerKind: moniker.kind,
+                  packageName: moniker.packageName,
+                  resolutionDomain: moniker.resolutionDomain,
+                  role: moniker.role,
+                  scheme: moniker.scheme,
+                  version: moniker.version,
+                },
+              ],
+            }),
+          ).toEqual({records: 4, state: 'staged'});
+          const failed = yield* Effect.flip(
+            store.finalizeCheckpointImport(databasePath, identity, snapshot, ownerToken, input),
+          );
+          expect(failed.message).toBe('Checkpoint import contains dangling relational endpoints.');
           expect(yield* store.readySnapshotById(databasePath, snapshot.id)).toBeUndefined();
         }),
       ).pipe(provideTestLayer(ApplicationLayer)),

--- a/test/unit/code-graph.sharing-client.test.ts
+++ b/test/unit/code-graph.sharing-client.test.ts
@@ -115,6 +115,7 @@ describe('graph share import and inspect source', () => {
       const enrolled = yield* enrolledHome(home, {includeFrontier: false});
       yield* writeSharedGraphProvenance(home, CHECKOUT_ID, {
         checkpointDigest: sha256Digest(CHECKPOINT_BYTES),
+        deltaCount: 2,
         frontierCommit: 'a'.repeat(40),
         profileDigest: enrolled.profileDigest,
         repositoryId: REPOSITORY_ID,
@@ -138,7 +139,11 @@ describe('graph share import and inspect source', () => {
           snapshot: {baseSnapshotId: 'cgsn_imported', id: 'cgsn_overlay'},
           threadnoteHome: home,
         }),
-      ).toMatchObject({kind: 'shared-base-plus-local-overlay', profileDigest: enrolled.profileDigest});
+      ).toMatchObject({
+        deltaCount: 2,
+        kind: 'shared-base-plus-local-overlay',
+        profileDigest: enrolled.profileDigest,
+      });
     }).pipe(provideTestLayer(sharingLayer)),
   );
 
@@ -153,6 +158,7 @@ describe('graph share import and inspect source', () => {
       const published = yield* enrolledHome(home, {includeFrontier: true, skipCheckpoint: true});
       yield* writeSharedGraphProvenance(home, CHECKOUT_ID, {
         checkpointDigest: published.checkpointDigest,
+        deltaCount: 0,
         frontierCommit: 'a'.repeat(40),
         profileDigest: published.profileDigest,
         repositoryId: REPOSITORY_ID,
@@ -179,6 +185,7 @@ describe('graph share import and inspect source', () => {
       const published = yield* enrolledHome(home, {includeFrontier: true, skipCheckpoint: true});
       yield* writeSharedGraphProvenance(home, CHECKOUT_ID, {
         checkpointDigest: published.checkpointDigest,
+        deltaCount: 0,
         frontierCommit: 'a'.repeat(40),
         profileDigest: published.profileDigest,
         repositoryId: REPOSITORY_ID,
@@ -294,6 +301,7 @@ describe('graph share import and inspect source', () => {
       );
       yield* writeSharedGraphProvenance(home, CHECKOUT_ID, {
         checkpointDigest: `sha256:${'9'.repeat(64)}`,
+        deltaCount: 0,
         frontierCommit: 'a'.repeat(40),
         profileDigest: enrolled.profileDigest,
         repositoryId: REPOSITORY_ID,
@@ -473,6 +481,7 @@ describe('graph share import and inspect source', () => {
       const enrolled = yield* enrolledHome(home, {includeFrontier: false});
       yield* writeSharedGraphProvenance(home, CHECKOUT_ID, {
         checkpointDigest: sha256Digest(CHECKPOINT_BYTES),
+        deltaCount: 0,
         frontierCommit: 'a'.repeat(40),
         profileDigest: enrolled.profileDigest,
         repositoryId: REPOSITORY_ID,
@@ -514,6 +523,7 @@ describe('graph share import and inspect source', () => {
         const published = yield* enrolledHome(home, {includeFrontier: true, skipCheckpoint: true, snapshotId});
         yield* writeSharedGraphProvenance(home, CHECKOUT_ID, {
           checkpointDigest: published.checkpointDigest,
+          deltaCount: 0,
           frontierCommit: 'a'.repeat(40),
           profileDigest: published.profileDigest,
           repositoryId: REPOSITORY_ID,

--- a/test/unit/code-graph.sharing-receipts.test.ts
+++ b/test/unit/code-graph.sharing-receipts.test.ts
@@ -162,6 +162,39 @@ describe('graph share receipts and frozen batches', () => {
     expect(machine.publishedFrontier).toBe(published);
   });
 
+  it('retries freeze after a failed verifying batch without moving the pointer', () => {
+    const commit = 'b'.repeat(40);
+    let machine = idleGraphShareFrontier();
+    machine = observeCanonicalHead(machine, {commit, isDescendantOfPublished: true, nowSeconds: 0});
+    machine = freezeGraphShareBatch(machine, {
+      actionKeys: [],
+      changedBytes: 1,
+      changedFiles: 1,
+      nowSeconds: 30,
+      thresholds: {maximumAgeSeconds: 30, maximumChangedBytes: 1, maximumChangedFiles: 1},
+    });
+    machine = assembleGraphShareBatch(machine);
+    machine = verifyGraphShareBatch(machine);
+    const generation = machine.generation;
+    const published = machine.publishedFrontier;
+    machine = failGraphShareBatch(machine);
+    expect(machine.phase).toBe('failed');
+    machine = observeCanonicalHead(machine, {commit, isDescendantOfPublished: true, nowSeconds: 40});
+    expect(machine.phase).toBe('collecting');
+    expect(machine.generation).toBe(generation);
+    expect(machine.publishedFrontier).toBe(published);
+    machine = freezeGraphShareBatch(machine, {
+      actionKeys: [],
+      changedBytes: 1,
+      changedFiles: 1,
+      nowSeconds: 40,
+      thresholds: {maximumAgeSeconds: 0, maximumChangedBytes: 1, maximumChangedFiles: 1},
+    });
+    expect(machine.phase).toBe('frozen');
+    expect(machine.generation).toBe(generation);
+    expect(machine.publishedFrontier).toBe(published);
+  });
+
   it('keeps the last published frontier when HEAD is unrelated', () => {
     let machine = idleGraphShareFrontier();
     const published = 'a'.repeat(40);

--- a/test/unit/code-graph.workspace.property.test.ts
+++ b/test/unit/code-graph.workspace.property.test.ts
@@ -10,6 +10,7 @@ import {
   createWorkspaceAttributor,
   discoverManifestWorkspace,
   mergeCodeGraphWorkspaces,
+  workspaceHasUninventoriedMonikerEvidence,
 } from '../../src/code_graph/workspace.js';
 
 const files = [
@@ -123,6 +124,17 @@ const workspaceFragmentArbitrary = FC.record({
 );
 
 describe('code graph workspace properties', () => {
+  it('treats package export monikers as inventoried only when their evidence file is present', () => {
+    const workspace = discoverManifestWorkspace([
+      workspaceFile('package.json', JSON.stringify({name: 'root', private: true}), 'npm-manifest'),
+      workspaceFile('scratchpad/package.json', JSON.stringify({name: 'scratchpad', private: true}), 'npm-manifest'),
+    ]);
+    expect(
+      workspaceHasUninventoriedMonikerEvidence(workspace, new Set(['package.json', 'scratchpad/package.json'])),
+    ).toBe(false);
+    expect(workspaceHasUninventoriedMonikerEvidence(workspace, new Set(['package.json']))).toBe(true);
+  });
+
   it.prop(
     'discovers identical nested and integrated workspace models regardless of inventory order',
     {permuted: permutedFiles},


### PR DESCRIPTION
## Summary
- Publisher freeze now force-indexes a CLEAN root, fails the batch (instead of leaving `verifying`) when checkpoint export cannot run, and recovers `failed` into `collecting` so listen/serve can retry without moving the canonical pointer.
- Checkpoint projection and inventory skip uninventoried package-export monikers (the Effect-scale dangling-endpoint quarantine), without raising the 32 MiB CAS cap or adding a second pack.
- Shared-graph provenance records `deltaCount` from applied TCG1 deltas; query `source` still omits on local rebuild / fail-open.

## Test plan
- [x] `test/integration/code-graph.sharing-publisher-freeze.test.ts` — descendant freeze without a prior `--full` index; dirty-worktree export fails to `failed` (not `verifying`) with pointer unchanged
- [x] `test/unit/code-graph.sharing-receipts.test.ts` — retry freeze after a failed verifying batch
- [x] `test/integration/code-graph.checkpoint-projection.test.ts` — planted dangling moniker omitted; ignored `scratchpad/package.json` indexes with zero dangling endpoints
- [x] `test/unit/code-graph.checkpoint-import-store.test.ts` — import still quarantines dangling moniker evidence
- [x] `test/unit/code-graph.workspace.property.test.ts` — uninventoried moniker evidence helper
- [x] `test/unit/code-graph.sharing-client.test.ts` and `test/integration/code-graph.sharing-deltas.test.ts` — `source.deltaCount` after apply; omit `source` on local rebuild
- [ ] PR CI full suite
- [ ] Residual: Effect-scale (~92 MiB) overlay import still needs a live join smoke on a disposable Effect checkout (not this PR's product-repo enrollment)