### PR TITLE
Serve a loopback Git composer with local OAuth and project MCP attach

### DIFF
--- a/src/cursor/cloud.ts
+++ b/src/cursor/cloud.ts
@@ -9,6 +9,14 @@ import {canonicalResourceUri, resourceIdIsWithin} from '../storage/resource-id.j
 import {uriSegment} from '../mcp/server/common.js';
 import {installCursorCloudAgentIntegration} from '../agent_integration/index.js';
 import {persistCursorCloudIdentityProfile} from './profile.js';
+import {
+  ORG_COMPOSER_POLICY,
+  THREADNOTE_ORG_MCP_NAME,
+  buildComposerHttpMcpEntry,
+  composerMcpUrl,
+  composerShareId,
+  type ComposerHttpMcpEntry,
+} from '../mcp/composer_attach.js';
 
 /** Legacy selector retained for Threadnote 4.2 Dashboard configurations. */
 export const CURSOR_CLOUD_MCP_TOOLSET = 'cursor-cloud' as const;
@@ -17,6 +25,7 @@ export const CURSOR_CLOUD_PERSONAL_MCP_TOOLSET = 'cursor-cloud-personal' as cons
 export const CURSOR_CLOUD_LOCAL_MCP_TOOLSET = 'cursor-cloud-local' as const;
 export const CURSOR_CLOUD_MEMORY_ENDPOINT_ENV = 'THREADNOTE_CURSOR_MEMORY_ENDPOINT';
 export const CURSOR_CLOUD_MEMORY_SHARE_ID_ENV = 'THREADNOTE_CURSOR_MEMORY_SHARE_ID';
+export const CURSOR_CLOUD_MODE_ENV = 'THREADNOTE_CURSOR_CLOUD_MODE';
 export const CURSOR_CLOUD_TEAM_ENV = 'THREADNOTE_CURSOR_CLOUD_TEAM';
 export const CURSOR_CLOUD_TEAMS_ENV = 'THREADNOTE_CURSOR_CLOUD_TEAMS';
 export const DEFAULT_CURSOR_CLOUD_IDENTITY = 'cursor-cloud';
@@ -24,7 +33,7 @@ export const DEFAULT_CURSOR_CLOUD_IDENTITY = 'cursor-cloud';
 const CURSOR_CLOUD_SHARE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 export const MAX_CURSOR_CLOUD_TEAMS = 16;
 
-export type CursorCloudMode = 'personal' | 'remote-hybrid';
+export type CursorCloudMode = 'org' | 'personal' | 'remote-hybrid';
 
 export class CursorCloudOperationError extends Schema.TaggedError<CursorCloudOperationError>()(
   'CursorCloudOperationError',
@@ -67,6 +76,7 @@ export interface CursorCloudLocalMcpConfig {
   readonly env: Readonly<{
     THREADNOTE_ACCOUNT: string;
     THREADNOTE_AGENT_ID: string;
+    THREADNOTE_CURSOR_CLOUD_MODE?: 'org';
     THREADNOTE_CURSOR_MEMORY_ENDPOINT: string;
     THREADNOTE_CURSOR_MEMORY_SHARE_ID: string;
     THREADNOTE_MCP_TOOLSET: typeof CURSOR_CLOUD_LOCAL_MCP_TOOLSET;
@@ -83,6 +93,14 @@ export interface CursorCloudRemoteHybridMcpConfig {
       readonly url: string;
     }>;
   }>;
+}
+
+export interface OrgCloudHybridMcpConfig {
+  readonly mcpServers: Readonly<{
+    'threadnote-local': CursorCloudLocalMcpConfig;
+    'threadnote-org': ComposerHttpMcpEntry;
+  }>;
+  readonly policy: typeof ORG_COMPOSER_POLICY;
 }
 
 export interface CursorCloudShareScope {
@@ -138,6 +156,22 @@ export interface CursorCloudRemoteHybridVerifyReceiptV1 {
   readonly provider: 'cursor-cloud';
   readonly shareId: string;
   readonly status: 'fail' | 'ok';
+  readonly version: 1;
+}
+
+export interface OrgCloudHybridVerifyReceiptV1 {
+  readonly canonicalStore: 'git';
+  readonly checks: readonly CursorCloudVerifyCheck[];
+  readonly cursorOidc: 'optional-attribution';
+  readonly endpoint: string;
+  readonly localMemoryFallback: 'disabled';
+  readonly mode: 'org';
+  readonly oauth: 'org-idp';
+  readonly provider: 'cursor-cloud';
+  readonly shareBinding: 'header';
+  readonly shareId: string;
+  readonly status: 'fail' | 'ok';
+  readonly stdioGitShare: false;
   readonly version: 1;
 }
 
@@ -244,21 +278,47 @@ export function buildCursorCloudRemoteHybridMcpConfig(
   const boundShareId = cursorCloudRemoteShareId(shareId);
   return {
     mcpServers: {
-      'threadnote-local': {
-        args: ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'],
-        command: '/bin/sh',
-        env: {
-          THREADNOTE_ACCOUNT: profile.account,
-          THREADNOTE_AGENT_ID: profile.agentId,
-          THREADNOTE_CURSOR_MEMORY_ENDPOINT: url,
-          THREADNOTE_CURSOR_MEMORY_SHARE_ID: boundShareId,
-          THREADNOTE_MCP_TOOLSET: CURSOR_CLOUD_LOCAL_MCP_TOOLSET,
-          THREADNOTE_USER: profile.user,
-        },
-        type: 'stdio',
-      },
-      'threadnote-memory': {headers: {'threadnote-share-id': boundShareId}, url},
+      'threadnote-local': buildCursorCloudLocalGraphMcpConfig(profile, url, boundShareId),
+      'threadnote-memory': buildComposerHttpMcpEntry(url, boundShareId),
     },
+  };
+}
+
+export function buildOrgCloudHybridMcpConfig(
+  profile: CursorCloudProfileV1,
+  endpoint: string,
+  shareId: string,
+): OrgCloudHybridMcpConfig {
+  const url = composerMcpUrl(endpoint);
+  const boundShareId = composerShareId(shareId);
+  return {
+    mcpServers: {
+      'threadnote-local': buildCursorCloudLocalGraphMcpConfig(profile, url, boundShareId, 'org'),
+      [THREADNOTE_ORG_MCP_NAME]: buildComposerHttpMcpEntry(url, boundShareId),
+    },
+    policy: ORG_COMPOSER_POLICY,
+  };
+}
+
+function buildCursorCloudLocalGraphMcpConfig(
+  profile: CursorCloudProfileV1,
+  endpoint: string,
+  shareId: string,
+  mode?: 'org',
+): CursorCloudLocalMcpConfig {
+  return {
+    args: ['-lc', 'exec "$HOME/.local/bin/threadnote-mcp-server"'],
+    command: '/bin/sh',
+    env: {
+      THREADNOTE_ACCOUNT: profile.account,
+      THREADNOTE_AGENT_ID: profile.agentId,
+      ...(mode === 'org' ? {THREADNOTE_CURSOR_CLOUD_MODE: 'org'} : {}),
+      THREADNOTE_CURSOR_MEMORY_ENDPOINT: endpoint,
+      THREADNOTE_CURSOR_MEMORY_SHARE_ID: shareId,
+      THREADNOTE_MCP_TOOLSET: CURSOR_CLOUD_LOCAL_MCP_TOOLSET,
+      THREADNOTE_USER: profile.user,
+    },
+    type: 'stdio',
   };
 }
 
@@ -419,13 +479,19 @@ export const runCursorCloudConfig = Effect.fn('cursorCloud.config')(function* (
     user: options.user ?? config.user,
   });
   const output =
-    options.mode === 'remote-hybrid'
-      ? buildCursorCloudRemoteHybridMcpConfig(
+    options.mode === 'org'
+      ? buildOrgCloudHybridMcpConfig(
           profile,
-          requiredRemoteEndpoint(options.endpoint),
+          requiredHybridEndpoint(options.endpoint, 'org'),
           requiredRemoteShareId(options.shareId),
         )
-      : buildCursorCloudMcpConfig(profile, teams);
+      : options.mode === 'remote-hybrid'
+        ? buildCursorCloudRemoteHybridMcpConfig(
+            profile,
+            requiredHybridEndpoint(options.endpoint, 'remote-hybrid'),
+            requiredRemoteShareId(options.shareId),
+          )
+        : buildCursorCloudMcpConfig(profile, teams);
   yield* Console.log(JSON.stringify(output, undefined, 2));
 });
 
@@ -433,11 +499,12 @@ export const runCursorCloudBootstrap = Effect.fn('cursorCloud.bootstrap')(functi
   config: RuntimeConfig,
   options: CursorCloudBootstrapOptions,
 ) {
-  if (options.mode === 'remote-hybrid') {
+  if (options.mode === 'remote-hybrid' || options.mode === 'org') {
     return yield* runCursorCloudRemoteHybridBootstrap(config, {
       cwd: requiredRemoteCheckout(options.cwd),
       dryRun: options.dryRun,
-      endpoint: requiredRemoteEndpoint(options.endpoint),
+      endpoint: requiredHybridEndpoint(options.endpoint, options.mode),
+      mode: options.mode,
       shareId: requiredRemoteShareId(options.shareId),
     });
   }
@@ -485,10 +552,11 @@ export const runCursorCloudVerify = Effect.fn('cursorCloud.verify')(function* (
     readonly teams?: readonly string[];
   },
 ) {
-  if (options.mode === 'remote-hybrid') {
+  if (options.mode === 'remote-hybrid' || options.mode === 'org') {
     const receipt = yield* cursorCloudRemoteHybridStatus(config, {
       cwd: options.cwd,
-      endpoint: requiredRemoteEndpoint(options.endpoint),
+      endpoint: requiredHybridEndpoint(options.endpoint, options.mode),
+      mode: options.mode,
       shareId: requiredRemoteShareId(options.shareId),
     });
     yield* printCursorCloudVerifyReceipt(receipt, options.json);
@@ -560,14 +628,20 @@ export const runCursorCloudVerify = Effect.fn('cursorCloud.verify')(function* (
 
 export const cursorCloudRemoteHybridStatus = Effect.fn('cursorCloud.remoteHybridStatus')(function* (
   config: RuntimeConfig,
-  options: {readonly cwd: string; readonly endpoint: string; readonly shareId?: string},
+  options: {
+    readonly cwd: string;
+    readonly endpoint: string;
+    readonly mode?: 'org' | 'remote-hybrid';
+    readonly shareId?: string;
+  },
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
   const graph = yield* CodeGraphQueryService;
-  const endpoint = cursorCloudMemoryEndpoint(options.endpoint);
   const environment = system.environment();
+  const org = options.mode === 'org' || environment[CURSOR_CLOUD_MODE_ENV]?.trim() === 'org';
+  const endpoint = org ? composerMcpUrl(options.endpoint) : cursorCloudMemoryEndpoint(options.endpoint);
   const environmentShareId = environment[CURSOR_CLOUD_MEMORY_SHARE_ID_ENV]?.trim();
   const shareId = requiredRemoteShareId(options.shareId ?? environmentShareId);
   const shareBindingMatches =
@@ -631,7 +705,7 @@ export const cursorCloudRemoteHybridStatus = Effect.fn('cursorCloud.remoteHybrid
   checks.push(
     {
       detail: endpoint,
-      name: 'managed MCP endpoint',
+      name: org ? 'organization composer MCP endpoint' : 'managed MCP endpoint',
       plane: 'remote-memory',
       status: 'ok',
     },
@@ -644,18 +718,37 @@ export const cursorCloudRemoteHybridStatus = Effect.fn('cursorCloud.remoteHybrid
       status: shareBindingMatches ? 'ok' : 'fail',
     },
     {
-      detail: 'OAuth is owned by Cursor and must be confirmed in Dashboard MCP status',
-      name: 'remote OAuth',
+      detail: org
+        ? 'Organization IdP OAuth is discovered from composer protected-resource metadata and was not probed'
+        : 'OAuth is owned by Cursor and must be confirmed in Dashboard MCP status',
+      name: org ? 'composer OAuth' : 'remote OAuth',
       plane: 'remote-memory',
       status: 'warn',
     },
     {
-      detail: 'local personal and Git-backed memory are not registered',
+      detail: org
+        ? 'Git-backed composer is canonical; Postgres bodies are not the organization memory store'
+        : 'local personal and Git-backed memory are not registered',
       name: 'memory fallback',
       plane: 'remote-memory',
       status: 'ok',
     },
   );
+  const status = checks.some(check => check.status === 'fail') ? ('fail' as const) : ('ok' as const);
+  if (org) {
+    return {
+      ...ORG_COMPOSER_POLICY,
+      checks,
+      endpoint,
+      localMemoryFallback: 'disabled',
+      mode: 'org',
+      provider: 'cursor-cloud',
+      shareId,
+      status,
+      stdioGitShare: false,
+      version: 1,
+    } satisfies OrgCloudHybridVerifyReceiptV1;
+  }
   return {
     checks,
     endpoint,
@@ -663,18 +756,25 @@ export const cursorCloudRemoteHybridStatus = Effect.fn('cursorCloud.remoteHybrid
     mode: 'remote-hybrid',
     provider: 'cursor-cloud',
     shareId,
-    status: checks.some(check => check.status === 'fail') ? 'fail' : 'ok',
+    status,
     version: 1,
   } satisfies CursorCloudRemoteHybridVerifyReceiptV1;
 });
 
 const runCursorCloudRemoteHybridBootstrap = Effect.fn('cursorCloud.remoteHybridBootstrap')(function* (
   config: RuntimeConfig,
-  options: {readonly cwd: string; readonly dryRun?: boolean; readonly endpoint: string; readonly shareId: string},
+  options: {
+    readonly cwd: string;
+    readonly dryRun?: boolean;
+    readonly endpoint: string;
+    readonly mode: 'org' | 'remote-hybrid';
+    readonly shareId: string;
+  },
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  cursorCloudMemoryEndpoint(options.endpoint);
+  if (options.mode === 'org') composerMcpUrl(options.endpoint);
+  else cursorCloudMemoryEndpoint(options.endpoint);
   const shareId = cursorCloudRemoteShareId(options.shareId);
   if (!path.isAbsolute(options.cwd) || !(yield* fs.exists(options.cwd))) {
     throw CursorCloudOperationError.make({
@@ -686,13 +786,19 @@ const runCursorCloudRemoteHybridBootstrap = Effect.fn('cursorCloud.remoteHybridB
   } else {
     yield* fs.makeDirectory(config.agentContextHome, {recursive: true, mode: 0o700});
   }
+  if (options.mode === 'org') {
+    yield* Console.log('Organization cloud hybrid local graph adapter is ready; indexing starts on demand.');
+    yield* Console.log(`Git-backed composer memory is bound exclusively to share ${shareId}.`);
+    yield* Console.log('Cursor OIDC attribution is optional; local Git memory share was not configured.');
+    return;
+  }
   yield* Console.log('Cursor Cloud remote-hybrid local graph adapter is ready; indexing starts on demand.');
   yield* Console.log(`Managed remote memory is bound exclusively to share ${shareId}.`);
   yield* Console.log('Managed remote memory remains exclusive; no local Git memory share was configured.');
 });
 
 const printCursorCloudVerifyReceipt = Effect.fn('cursorCloud.printVerifyReceipt')(function* (
-  receipt: CursorCloudVerifyReceiptV2 | CursorCloudRemoteHybridVerifyReceiptV1,
+  receipt: CursorCloudVerifyReceiptV2 | CursorCloudRemoteHybridVerifyReceiptV1 | OrgCloudHybridVerifyReceiptV1,
   json?: boolean,
 ) {
   if (json === true) {
@@ -707,11 +813,16 @@ const printCursorCloudVerifyReceipt = Effect.fn('cursorCloud.printVerifyReceipt'
   yield* Console.log(`Status: ${receipt.status}`);
 });
 
-function requiredRemoteEndpoint(endpoint: string | undefined): string {
+function requiredHybridEndpoint(endpoint: string | undefined, mode: 'org' | 'remote-hybrid'): string {
   if (!endpoint?.trim()) {
-    throw CursorCloudOperationError.make({message: 'Cursor Cloud remote-hybrid mode requires --endpoint.'});
+    throw CursorCloudOperationError.make({
+      message:
+        mode === 'org'
+          ? 'Organization cloud hybrid mode requires --endpoint.'
+          : 'Cursor Cloud remote-hybrid mode requires --endpoint.',
+    });
   }
-  return cursorCloudMemoryEndpoint(endpoint);
+  return mode === 'org' ? composerMcpUrl(endpoint) : cursorCloudMemoryEndpoint(endpoint);
 }
 
 function requiredRemoteShareId(shareId: string | undefined): string {

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -124,6 +124,7 @@ import {
   runCodeGraphCheckpointInspect,
   runCodeGraphCheckpointVerify,
 } from '../code_graph/checkpoint/commands.js';
+import {makeComposerCommands} from './composer_cli.js';
 import {makeGraphSharingCommands} from '../code_graph/sharing/cli.js';
 import {
   CODE_GRAPH_WORKSET_EVIDENCE_MAXIMUM_ESTIMATED_TOKENS,
@@ -922,11 +923,10 @@ const graphCheckpoint = Command.make('checkpoint').pipe(
   ]),
 );
 
-const {graphContribute, graphPublisher, graphShare, graphWorker} = makeGraphSharingCommands(
-  withRuntimeEffect as <E, R>(
-    effect: (config: RuntimeConfig) => Effect.Effect<void, E, R>,
-  ) => Effect.Effect<void, E, R>,
-);
+const withScopedRuntime = withRuntimeEffect as <E, R>(
+  effect: (config: RuntimeConfig) => Effect.Effect<void, E, R>,
+) => Effect.Effect<void, E, R>;
+const {graphContribute, graphPublisher, graphShare, graphWorker} = makeGraphSharingCommands(withScopedRuntime);
 
 const graphPurge = Command.make(
   'purge',
@@ -1193,8 +1193,11 @@ const mcpInstall = Command.make(
       Argument.withDescription('codex, claude, cursor, or copilot'),
     ),
     apply: boolean('apply', 'Actually modify the selected agent config'),
+    composerUrl: optionalString('composer-url', 'Organization composer Streamable HTTP MCP URL'),
     name: defaultString('name', 'MCP server name', THREADNOTE_MCP_NAME),
+    project: optionalString('project', 'Write Cursor/Copilot MCP into this repository .cursor/mcp.json'),
     scope: defaultChoice('scope', ['user', 'local', 'project'], 'Claude MCP config scope', 'user'),
+    shareId: optionalString('share-id', 'Organization composer share binding'),
     toolset: optionalChoice('toolset', ['core', 'full'], 'Stdio adapter toolset'),
   },
   ({agent, ...options}) => withRuntimeEffect(config => runMcpInstall(config, agent, options)),
@@ -1914,6 +1917,7 @@ const topLevelCommandRegistrations = [
   registerTopLevelCommand('models', models),
   registerTopLevelCommand('index', indexCommand),
   registerTopLevelCommand('graph', graphCommand),
+  registerTopLevelCommand('composer', makeComposerCommands(withScopedRuntime)),
   registerTopLevelCommand('local-ai', localAi),
   registerTopLevelCommand('source', source, {
     productionLog: {

--- a/src/effect/composer_cli.ts
+++ b/src/effect/composer_cli.ts
@@ -1,0 +1,113 @@
+import {Console, Effect, Schema} from 'effect';
+import {Command} from 'effect/unstable/cli';
+import {applicationError, fromPromiseInterruptibleAwaiting} from './errors.js';
+import {boolean, optionalString} from './cli_flags.js';
+import {SystemInfo} from './system.js';
+import {resolveTeam} from '../share/core.js';
+import {resolveComposerServeShareId} from '../mcp/composer_attach.js';
+import {LOCAL_COMPOSER_DEFAULT_LISTEN} from '../remote_memory/local_idp.js';
+import {runComposerServe} from '../remote_memory/composer_serve.js';
+import type {RuntimeConfig} from '../types.js';
+
+class ComposerServeError extends Schema.TaggedError<ComposerServeError>()('ComposerServeError', {
+  cause: Schema.optionalKey(Schema.Defect()),
+  message: Schema.String,
+}) {}
+
+export function makeComposerCommands(
+  withRuntimeEffect: <E, R>(effect: (config: RuntimeConfig) => Effect.Effect<void, E, R>) => Effect.Effect<void, E, R>,
+) {
+  const composerServe = Command.make(
+    'serve',
+    {
+      databaseUrl: optionalString('database-url', 'PostgreSQL URL for the composer control plane and search index'),
+      gitWorktree: optionalString('git-worktree', 'Absolute git worktree of the existing team memory share'),
+      listen: optionalString(
+        'listen',
+        'Loopback host:port for the Git composer and local OAuth issuer (default 127.0.0.1:18788)',
+      ),
+      push: boolean('push', 'Push Git memory commits to the configured team remote (default off)'),
+      shareId: optionalString('share-id', 'Control-plane share id bound to the Git team share'),
+      subject: optionalString('subject', 'OAuth subject provisioned for the local issuer'),
+      team: optionalString('team', 'Existing Git memory team; defaults to the teams.json default team'),
+    },
+    options => withRuntimeEffect(config => runComposerServeCommand(config, options)),
+  ).pipe(
+    Command.withDescription(
+      'Serve a loopback Git-backed organization composer with a local OAuth issuer against the existing team share',
+    ),
+  );
+
+  return Command.make('composer').pipe(
+    Command.withDescription('Serve the organization Git memory composer for credential-less agents'),
+    Command.withSubcommands([composerServe]),
+  );
+}
+
+export const runComposerServeCommand = Effect.fn('composer.serveCommand')(function* (
+  config: RuntimeConfig,
+  options: {
+    readonly databaseUrl?: string;
+    readonly gitWorktree?: string;
+    readonly listen?: string;
+    readonly push?: boolean;
+    readonly shareId?: string;
+    readonly subject?: string;
+    readonly team?: string;
+  },
+) {
+  const system = yield* SystemInfo;
+  const team = yield* resolveTeam(config, options.team);
+  const databaseUrl = options.databaseUrl?.trim() || system.environment().THREADNOTE_REMOTE_DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    return yield* ComposerServeError.make({
+      message: 'Composer serve requires --database-url or THREADNOTE_REMOTE_DATABASE_URL.',
+    });
+  }
+  const shareId = yield* Effect.try({
+    try: () => resolveComposerServeShareId(team.name, options.shareId),
+    catch: cause =>
+      ComposerServeError.make({
+        message: cause instanceof Error ? cause.message : String(cause),
+      }),
+  });
+  const gitWorktree = options.gitWorktree?.trim() || team.config.worktree;
+  yield* Console.consoleWith(output =>
+    fromPromiseInterruptibleAwaiting(
+      signal =>
+        runComposerServe(
+          {
+            databaseUrl,
+            gitCloneUrl: team.config.remote,
+            gitPush: options.push === true,
+            gitWorktree,
+            listen: options.listen?.trim() || LOCAL_COMPOSER_DEFAULT_LISTEN,
+            shareId,
+            subject: options.subject?.trim() || `local:${config.user}`,
+            tenantId: 'local-org',
+          },
+          {
+            error: message => {
+              output.error(message);
+            },
+            shutdownSignal: () => shutdownFromAbort(signal),
+          },
+        ),
+      cause => applicationError('composer serve', cause),
+    ),
+  );
+});
+
+function shutdownFromAbort(signal: AbortSignal): {
+  readonly dispose: () => void;
+  readonly promise: Promise<string>;
+} {
+  const {promise, resolve} = Promise.withResolvers<string>();
+  const onAbort = () => resolve('runtime interruption');
+  signal.addEventListener('abort', onAbort, {once: true});
+  if (signal.aborted) onAbort();
+  return {
+    dispose: () => signal.removeEventListener('abort', onAbort),
+    promise,
+  };
+}

--- a/src/effect/cursor_cloud_cli.ts
+++ b/src/effect/cursor_cloud_cli.ts
@@ -16,7 +16,7 @@ interface CursorCloudAttestFlagBuilders {
   readonly requiredString: (name: string, description: string) => Flag.Flag<string>;
 }
 
-type CursorCloudMode = 'personal' | 'remote-hybrid';
+type CursorCloudMode = 'org' | 'personal' | 'remote-hybrid';
 
 export function makeCursorCloudIdentityFlags(
   defaultString: (name: string, description: string, value: string) => Flag.Flag<string>,
@@ -38,12 +38,12 @@ export function makeCursorCloudIdentityFlags(
 export function makeCursorCloudModeFlag(
   defaultChoice: (
     name: string,
-    choices: readonly ['personal', 'remote-hybrid'],
+    choices: readonly ['org', 'personal', 'remote-hybrid'],
     description: string,
     value: 'personal',
   ) => Flag.Flag<CursorCloudMode>,
 ) {
-  return defaultChoice('mode', ['personal', 'remote-hybrid'], 'Cursor Cloud memory transport mode', 'personal');
+  return defaultChoice('mode', ['org', 'personal', 'remote-hybrid'], 'Cursor Cloud memory transport mode', 'personal');
 }
 
 export function makeCursorCloudAttestCommand<E, R>(

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -23,6 +23,7 @@ import {
 } from './installations.js';
 import {
   inferConfiguredMcpClients,
+  isPersonalThreadnoteHome,
   mcpConfigurationChecks,
   removeMcpConfigs,
   removeMcpSnippets,
@@ -189,7 +190,7 @@ export const collectDoctorChecks = Effect.fn('lifecycle.collectDoctorChecks')(fu
     yield* telemetryDoctorCheck(config),
     yield* imageProjectionDoctorCheck(config),
   );
-  const inferredMcpClients = yield* inferConfiguredMcpClients().pipe(Effect.orElseSucceed(() => []));
+  const inferredMcpClients = yield* inferConfiguredMcpClients(config).pipe(Effect.orElseSucceed(() => []));
   checks.push(...(yield* safeDoctorChecks('MCP configuration', mcpConfigurationChecks(config, inferredMcpClients))));
   checks.push(
     recallIndexCheck(lexicalStatus),
@@ -410,7 +411,7 @@ export const runRepair = Effect.fn('lifecycle.repair')(function* (config: Runtim
   } else {
     yield* Console.log('Would validate and rebuild the derived lexical and vector recall indexes.');
   }
-  const inferredMcpClients = yield* inferConfiguredMcpClients();
+  const inferredMcpClients = yield* inferConfiguredMcpClients(config);
   yield* migrateLegacyAgentIntegrations(config, inferredMcpClients, dryRun);
   const repairedIntegrationClients = yield* repairAgentIntegrations(config, dryRun);
   const registry = yield* readAgentIntegrationRegistry(config);
@@ -450,8 +451,17 @@ export const repairRegisteredMcpClients = Effect.fn('lifecycle.repairRegisteredM
   mcpClients: readonly AgentClient[],
   dryRun: boolean,
 ) {
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const personalHome = isPersonalThreadnoteHome(config.agentContextHome, system.homeDirectory, (...parts) =>
+    path.resolve(...parts),
+  );
   for (const client of mcpClients) {
     const receipt = registry?.hosts[client];
+    if (!personalHome && (client === 'cursor' || client === 'copilot')) {
+      yield* Console.log(`Skipping ${client} MCP repair for non-personal THREADNOTE_HOME.`);
+      continue;
+    }
     if (receipt?.mcp.repair !== true || receipt.mcp.toolset === undefined) {
       yield* Console.log(
         `WARN ${client} MCP settings predate repair receipts; run threadnote mcp-install ${client} --apply to manage them.`,
@@ -463,6 +473,7 @@ export const repairRegisteredMcpClients = Effect.fn('lifecycle.repairRegisteredM
       cwd: receipt.mcp.cwd,
       dryRunApplyCommand: 'threadnote repair',
       name: receipt.mcp.name,
+      project: client === 'cursor' || client === 'copilot' ? receipt.mcp.cwd : undefined,
       scope: receipt.mcp.scope,
       toolset: receipt.mcp.toolset,
     });

--- a/src/mcp/composer_attach.ts
+++ b/src/mcp/composer_attach.ts
@@ -1,0 +1,175 @@
+import {Schema} from 'effect';
+import {THREADNOTE_MCP_NAME} from '../constants.js';
+import {COMPOSER_OAUTH_CLIENT_ID} from '../remote_memory/local_idp.js';
+import {COMPOSER_OAUTH_SCOPES} from '../remote_memory/oauth.js';
+import type {JsonObject} from '../types.js';
+
+export const THREADNOTE_ORG_MCP_NAME = 'threadnote-org' as const;
+export const THREADNOTE_COMPOSER_SHARE_ID_HEADER = 'threadnote-share-id';
+const COMPOSER_SHARE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+
+export const ORG_COMPOSER_POLICY = {
+  canonicalStore: 'git',
+  cursorOidc: 'optional-attribution',
+  oauth: 'org-idp',
+  shareBinding: 'header',
+} as const;
+
+export class ComposerAttachError extends Schema.TaggedError<ComposerAttachError>()('ComposerAttachError', {
+  cause: Schema.optionalKey(Schema.Defect()),
+  message: Schema.String,
+}) {}
+
+export interface ComposerShareBinding {
+  readonly shareId: string;
+  readonly url: string;
+}
+
+export interface ComposerMcpOAuthAuth {
+  readonly CLIENT_ID: typeof COMPOSER_OAUTH_CLIENT_ID;
+  readonly scopes: readonly (typeof COMPOSER_OAUTH_SCOPES)[number][];
+}
+
+export interface ComposerHttpMcpEntry {
+  readonly [key: string]: unknown;
+  readonly auth: ComposerMcpOAuthAuth;
+  readonly headers: Readonly<{readonly [THREADNOTE_COMPOSER_SHARE_ID_HEADER]: string}>;
+  readonly url: string;
+}
+
+export interface ComposerAttachOptions {
+  readonly composerUrl?: string;
+  readonly shareId?: string;
+}
+
+export function resolveComposerAttach(options: ComposerAttachOptions): ComposerShareBinding | undefined {
+  const composerUrl = options.composerUrl?.trim();
+  const shareId = options.shareId?.trim();
+  if (!composerUrl && !shareId) return undefined;
+  if (!composerUrl || !shareId) {
+    throw ComposerAttachError.make({
+      message: 'Organization composer attach requires both --composer-url and --share-id.',
+    });
+  }
+  return {shareId: composerShareId(shareId), url: composerMcpUrl(composerUrl)};
+}
+
+export function resolveComposerServeShareId(teamName: string, shareId?: string): string {
+  return composerShareId(shareId?.trim() || teamName);
+}
+
+export function composerShareId(shareId: string): string {
+  const normalized = shareId.trim();
+  if (!COMPOSER_SHARE_ID_PATTERN.test(normalized)) {
+    throw ComposerAttachError.make({
+      message:
+        'The organization composer share ID must be an opaque identifier containing only letters, digits, dot, underscore, or hyphen.',
+    });
+  }
+  return normalized;
+}
+
+export function composerMcpUrl(endpoint: string): string {
+  const normalized = endpoint.trim();
+  const hasUnsafeCharacter = [...normalized].some(character => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return /\s/u.test(character) || codePoint <= 0x1f || codePoint === 0x7f;
+  });
+  if (!normalized || hasUnsafeCharacter) {
+    throw ComposerAttachError.make({message: 'The organization composer endpoint must be a valid MCP URL.'});
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw ComposerAttachError.make({message: 'The organization composer endpoint must be a valid MCP URL.'});
+  }
+  const loopback = parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
+  if (
+    (parsed.protocol !== 'https:' && !(loopback && parsed.protocol === 'http:')) ||
+    parsed.hostname.length === 0 ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0 ||
+    parsed.hash.length > 0 ||
+    parsed.search.length > 0 ||
+    parsed.pathname !== '/mcp'
+  ) {
+    throw ComposerAttachError.make({
+      message:
+        'The organization composer endpoint must be the credential-free /mcp URL without a query or fragment; HTTPS is required outside loopback.',
+    });
+  }
+  if (parsed.hostname === 'localhost') parsed.hostname = '127.0.0.1';
+  return parsed.toString();
+}
+
+export function buildComposerHttpMcpEntry(url: string, shareId: string): ComposerHttpMcpEntry {
+  return {
+    auth: {
+      CLIENT_ID: COMPOSER_OAUTH_CLIENT_ID,
+      scopes: [...COMPOSER_OAUTH_SCOPES],
+    },
+    headers: {[THREADNOTE_COMPOSER_SHARE_ID_HEADER]: composerShareId(shareId)},
+    url: composerMcpUrl(url),
+  };
+}
+
+export function withComposerHttpMcpEntry(
+  servers: Readonly<Record<string, JsonObject>>,
+  stdioName: string,
+  stdio: JsonObject,
+  attach: ComposerShareBinding | undefined,
+): Record<string, JsonObject> {
+  if (attach && stdioName === THREADNOTE_ORG_MCP_NAME) {
+    throw ComposerAttachError.make({
+      message: 'Organization composer attach cannot use the reserved HTTP server name for the stdio Git adapter.',
+    });
+  }
+  const next: Record<string, JsonObject> = {...servers, [stdioName]: stdio};
+  if (attach) next[THREADNOTE_ORG_MCP_NAME] = buildComposerHttpMcpEntry(attach.url, attach.shareId);
+  return next;
+}
+
+export function teamStdioServers(
+  stdio: JsonObject,
+  attach: ComposerShareBinding | undefined,
+): Record<string, JsonObject> {
+  return withComposerHttpMcpEntry({}, THREADNOTE_MCP_NAME, stdio, attach);
+}
+
+export function stdioEnvironmentCallsComposer(env: Readonly<Record<string, unknown>>): boolean {
+  return typeof env.THREADNOTE_CURSOR_MEMORY_ENDPOINT === 'string' && env.THREADNOTE_CURSOR_MEMORY_ENDPOINT.length > 0;
+}
+
+export function composerHttpEntryMatches(actual: unknown, expected: ComposerHttpMcpEntry): boolean {
+  return (
+    isManagedComposerHttpEntry(actual) &&
+    actual.url === expected.url &&
+    actual.headers[THREADNOTE_COMPOSER_SHARE_ID_HEADER] === expected.headers[THREADNOTE_COMPOSER_SHARE_ID_HEADER] &&
+    actual.auth.CLIENT_ID === expected.auth.CLIENT_ID &&
+    actual.auth.scopes.length === expected.auth.scopes.length &&
+    actual.auth.scopes.every((scope, index) => scope === expected.auth.scopes[index])
+  );
+}
+
+export function isManagedComposerHttpEntry(actual: unknown): actual is ComposerHttpMcpEntry {
+  if (!isRecord(actual) || typeof actual.url !== 'string' || !isRecord(actual.headers) || !isRecord(actual.auth)) {
+    return false;
+  }
+  const shareId = actual.headers[THREADNOTE_COMPOSER_SHARE_ID_HEADER];
+  if (typeof shareId !== 'string' || Object.keys(actual.headers).length !== 1) return false;
+  if (actual.auth.CLIENT_ID !== COMPOSER_OAUTH_CLIENT_ID || !Array.isArray(actual.auth.scopes)) return false;
+  if (actual.auth.scopes.length !== COMPOSER_OAUTH_SCOPES.length) return false;
+  if (actual.auth.scopes.some((scope, index) => scope !== COMPOSER_OAUTH_SCOPES[index])) return false;
+  try {
+    composerMcpUrl(actual.url);
+    composerShareId(shareId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,2 +1,3 @@
 /** Stable public entrypoint for MCP installation and configuration. */
+export * from './composer_attach.js';
 export * from './install.js';

--- a/src/mcp/install.ts
+++ b/src/mcp/install.ts
@@ -12,6 +12,17 @@ import {THREADNOTE_MCP_CLIENT_ENV, THREADNOTE_MCP_NAME} from '../constants.js';
 import {maybeRunEffect, runCommandEffect} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
 import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset} from './toolset.js';
+import {
+  ComposerAttachError,
+  THREADNOTE_ORG_MCP_NAME,
+  buildComposerHttpMcpEntry,
+  composerHttpEntryMatches,
+  resolveComposerAttach,
+  withComposerHttpMcpEntry,
+  isManagedComposerHttpEntry,
+  type ComposerHttpMcpEntry,
+  type ComposerShareBinding,
+} from './composer_attach.js';
 import type {AgentClient, ClaudeMcpScope, DoctorCheck, JsonObject, McpInstallOptions, RuntimeConfig} from '../types.js';
 import {
   ensureDirectory,
@@ -27,6 +38,20 @@ import {
   removePathIfExists,
 } from '../utils.js';
 
+export function isPersonalThreadnoteHome(
+  agentContextHome: string,
+  userHome: string,
+  resolvePath: (...parts: string[]) => string,
+): boolean {
+  return resolvePath(agentContextHome) === resolvePath(userHome, '.threadnote');
+}
+
+const isPersonalThreadnoteHomeEffect = Effect.fn('mcp.isPersonalHome')(function* (config: RuntimeConfig) {
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  return isPersonalThreadnoteHome(config.agentContextHome, system.homeDirectory, (...parts) => path.resolve(...parts));
+});
+
 export function runMcpInstall(config: RuntimeConfig, agent: AgentClient, options: McpInstallOptions) {
   const install = runMcpInstallInTransaction(config, agent, options);
   return options.apply === true ? withAgentIntegrationLock(config, install) : install;
@@ -40,29 +65,86 @@ const runMcpInstallInTransaction = Effect.fn('mcp.runInstallInTransaction')(func
   const name = options.name ?? THREADNOTE_MCP_NAME;
   const apply = options.apply === true;
   const toolset = options.toolset ?? DEFAULT_MCP_TOOLSET;
+  const attach = yield* Effect.try({
+    try: () => resolveComposerAttach({composerUrl: options.composerUrl, shareId: options.shareId}),
+    catch: cause =>
+      Schema.is(ComposerAttachError)(cause)
+        ? cause
+        : McpOperationError.make({
+            cause,
+            message: cause instanceof Error ? cause.message : String(cause),
+          }),
+  });
+  const personalHome = yield* isPersonalThreadnoteHomeEffect(config);
+  const project = options.project?.trim() || (agent === 'claude' ? undefined : options.cwd);
+  if (attach && (agent === 'cursor' || agent === 'copilot') && !project) {
+    return yield* McpOperationError.make({
+      message:
+        agent === 'copilot'
+          ? 'Organization composer attach must write a project .vscode/mcp.json; pass --project so the user Copilot mcp.json is not rewritten.'
+          : 'Organization composer attach must write a project .cursor/mcp.json; pass --project so personal ~/.cursor/mcp.json is not rewritten.',
+    });
+  }
+  if (!personalHome && (agent === 'cursor' || agent === 'copilot') && !project) {
+    return yield* McpOperationError.make({
+      message:
+        agent === 'copilot'
+          ? 'This THREADNOTE_HOME is not the personal ~/.threadnote home; pass --project to write project .vscode/mcp.json instead of rewriting the user Copilot mcp.json.'
+          : 'This THREADNOTE_HOME is not the personal ~/.threadnote home; pass --project to write project MCP config instead of rewriting ~/.cursor/mcp.json.',
+    });
+  }
   const scope = agent === 'claude' ? (options.scope ?? 'user') : undefined;
   const cwd = options.cwd ?? (agent === 'claude' && scope !== 'user' ? yield* getInvocationCwd() : undefined);
   const legacyInferredClients =
     apply && (yield* readAgentIntegrationRegistry(config)) === undefined
-      ? yield* inferConfiguredMcpClients()
+      ? yield* inferConfiguredMcpClients(config)
       : undefined;
+
+  if (attach && name === THREADNOTE_ORG_MCP_NAME) {
+    return yield* McpOperationError.make({
+      message:
+        'Organization composer attach cannot use --name threadnote-org; that name is reserved for the HTTP composer entry.',
+    });
+  }
+
+  if (attach && agent !== 'cursor' && agent !== 'copilot') {
+    return yield* McpOperationError.make({
+      message: 'Organization composer attach writes a second HTTP MCP entry for cursor and copilot.',
+    });
+  }
 
   if (agent === 'cursor') {
     yield* runCursorMcpInstall(config, name, {
       apply,
+      attach,
       dryRunApplyCommand: options.dryRunApplyCommand,
+      project,
       toolset,
     });
-    yield* finishAgentIntegrationInstall(config, agent, {apply, legacyInferredClients, name, toolset});
+    yield* finishAgentIntegrationInstall(config, agent, {
+      apply,
+      cwd: project,
+      legacyInferredClients,
+      name,
+      toolset,
+    });
     return;
   }
   if (agent === 'copilot') {
     yield* runCopilotMcpInstall(config, name, {
       apply,
+      attach,
       dryRunApplyCommand: options.dryRunApplyCommand,
+      project,
       toolset,
     });
-    yield* finishAgentIntegrationInstall(config, agent, {apply, legacyInferredClients, name, toolset});
+    yield* finishAgentIntegrationInstall(config, agent, {
+      apply,
+      cwd: project,
+      legacyInferredClients,
+      name,
+      toolset,
+    });
     return;
   }
 
@@ -157,8 +239,9 @@ export const mcpConfigurationChecks = Effect.fn('mcp.configurationChecks')(funct
 ) {
   const checks: DoctorCheck[] = [];
   const registry = yield* readAgentIntegrationRegistry(config);
-  const inferred = registry === undefined ? (inferredClients ?? (yield* inferConfiguredMcpClients())) : [];
+  const inferred = registry === undefined ? (inferredClients ?? (yield* inferConfiguredMcpClients(config))) : [];
   const clients = registry === undefined ? inferred : registeredAgentClients(registry);
+  const personalHome = yield* isPersonalThreadnoteHomeEffect(config);
   for (const agent of clients) {
     const receipt = registry?.hosts[agent];
     const name = receipt?.mcp.name ?? THREADNOTE_MCP_NAME;
@@ -171,15 +254,36 @@ export const mcpConfigurationChecks = Effect.fn('mcp.configurationChecks')(funct
       });
       continue;
     }
+    if (!personalHome && (agent === 'cursor' || agent === 'copilot')) {
+      const project = receipt?.mcp.cwd?.trim();
+      if (!project) continue;
+      const containerKey = agent === 'cursor' ? 'mcpServers' : 'servers';
+      const configPath =
+        agent === 'cursor' ? yield* cursorMcpConfigPath(project) : yield* copilotMcpConfigPath(project);
+      checks.push(yield* orgComposerConfigurationCheck(`${agent} org composer`, configPath, containerKey));
+      continue;
+    }
     if (agent === 'cursor') {
       checks.push(
-        yield* jsonMcpConfigurationCheck('cursor MCP', yield* cursorMcpConfigPath(), 'mcpServers', name, repair),
+        yield* jsonMcpConfigurationCheck(
+          'cursor MCP',
+          yield* cursorMcpConfigPath(receipt?.mcp.cwd),
+          'mcpServers',
+          name,
+          repair,
+        ),
       );
       continue;
     }
     if (agent === 'copilot') {
       checks.push(
-        yield* jsonMcpConfigurationCheck('copilot MCP', yield* copilotMcpConfigPath(), 'servers', name, repair),
+        yield* jsonMcpConfigurationCheck(
+          'copilot MCP',
+          yield* copilotMcpConfigPath(receipt?.mcp.cwd),
+          'servers',
+          name,
+          repair,
+        ),
       );
       continue;
     }
@@ -216,6 +320,23 @@ export const mcpConfigurationChecks = Effect.fn('mcp.configurationChecks')(funct
   return checks;
 });
 
+function orgComposerConfigurationCheck(checkName: string, configPath: string, containerKey: 'mcpServers' | 'servers') {
+  return Effect.gen(function* () {
+    const raw = yield* readFileIfExists(configPath);
+    const parsed = raw ? parseJsonConfigObject(raw) : undefined;
+    const container = parsed?.[containerKey];
+    const entry = isJsonObject(container) ? container[THREADNOTE_ORG_MCP_NAME] : undefined;
+    const configured = isManagedComposerHttpEntry(entry);
+    return {
+      detail: configured
+        ? `${THREADNOTE_ORG_MCP_NAME} attached in ${configPath}`
+        : `${configPath} missing ${THREADNOTE_ORG_MCP_NAME} composer entry`,
+      name: checkName,
+      status: configured ? ('ok' as const) : ('warn' as const),
+    };
+  });
+}
+
 function jsonMcpConfigurationCheck(
   checkName: string,
   configPath: string,
@@ -246,7 +367,7 @@ function jsonMcpConfigurationCheck(
   });
 }
 
-export const inferConfiguredMcpClients = Effect.fn('mcp.inferConfiguredClients')(function* () {
+export const inferConfiguredMcpClients = Effect.fn('mcp.inferConfiguredClients')(function* (config: RuntimeConfig) {
   const clients: AgentClient[] = [];
   for (const agent of ['codex', 'claude'] as const) {
     const executable = yield* findMcpAgentExecutable(agent);
@@ -258,10 +379,12 @@ export const inferConfiguredMcpClients = Effect.fn('mcp.inferConfiguredClients')
     }).pipe(Effect.option);
     if (result._tag === 'Some' && result.value.exitCode === 0) clients.push(agent);
   }
-  const cursor = yield* readJsonMcpServer(yield* cursorMcpConfigPath(), 'mcpServers', THREADNOTE_MCP_NAME);
-  if (cursor !== undefined) clients.push('cursor');
-  const copilot = yield* readJsonMcpServer(yield* copilotMcpConfigPath(), 'servers', THREADNOTE_MCP_NAME);
-  if (copilot !== undefined) clients.push('copilot');
+  if (yield* isPersonalThreadnoteHomeEffect(config)) {
+    const cursor = yield* readJsonMcpServer(yield* cursorMcpConfigPath(), 'mcpServers', THREADNOTE_MCP_NAME);
+    if (cursor !== undefined) clients.push('cursor');
+    const copilot = yield* readJsonMcpServer(yield* copilotMcpConfigPath(), 'servers', THREADNOTE_MCP_NAME);
+    if (copilot !== undefined) clients.push('copilot');
+  }
   return clients;
 });
 
@@ -404,24 +527,43 @@ function jsonMcpConfigurationMatches(
   );
 }
 
+function jsonComposerConfigurationMatches(
+  currentContent: string | undefined,
+  containerKey: 'mcpServers' | 'servers',
+  expected: ComposerHttpMcpEntry,
+): boolean {
+  if (currentContent === undefined) return false;
+  const parsed = parseJsonConfigObject(currentContent);
+  const container = parsed?.[containerKey];
+  const actual = isJsonObject(container) ? container[THREADNOTE_ORG_MCP_NAME] : undefined;
+  return composerHttpEntryMatches(actual, expected);
+}
+
 const runCursorMcpInstall = Effect.fn('mcp.runCursorInstall')(function* (
   config: RuntimeConfig,
   name: string,
   options: {
     readonly apply: boolean;
+    readonly attach?: ComposerShareBinding;
     readonly dryRunApplyCommand?: string;
+    readonly project?: string;
     readonly toolset: McpToolset;
   },
 ) {
   const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
-  const path = yield* cursorMcpConfigPath();
+  const path = yield* cursorMcpConfigPath(options.project);
   const serverConfig = yield* buildCursorMcpServerConfig(config, {
     toolset: options.toolset,
   });
+  const composerEntry = options.attach
+    ? buildComposerHttpMcpEntry(options.attach.url, options.attach.shareId)
+    : undefined;
   const currentContent = yield* readFileIfExists(path);
-  const current = jsonMcpConfigurationMatches(currentContent, 'mcpServers', name, serverConfig);
-  const nextContent = renderCursorMcpConfig(path, currentContent, name, serverConfig);
+  const current =
+    jsonMcpConfigurationMatches(currentContent, 'mcpServers', name, serverConfig) &&
+    (composerEntry === undefined || jsonComposerConfigurationMatches(currentContent, 'mcpServers', composerEntry));
+  const nextContent = renderCursorMcpConfig(path, currentContent, name, serverConfig, composerEntry);
 
   if (!options.apply) {
     yield* Console.log(
@@ -430,6 +572,8 @@ const runCursorMcpInstall = Effect.fn('mcp.runCursorInstall')(function* (
         : 'Dry run. Re-run with --apply to modify Cursor MCP config.',
     );
     yield* printCursorMcpSnippet(config, name, {
+      attach: options.attach,
+      project: options.project,
       toolset: options.toolset,
     });
     return;
@@ -451,19 +595,34 @@ const runCopilotMcpInstall = Effect.fn('mcp.runCopilotInstall')(function* (
   name: string,
   options: {
     readonly apply: boolean;
+    readonly attach?: ComposerShareBinding;
     readonly dryRunApplyCommand?: string;
+    readonly project?: string;
     readonly toolset: McpToolset;
   },
 ) {
+  if (options.attach && !options.project) {
+    return yield* McpOperationError.make({
+      message:
+        'Organization composer attach must write a project MCP config; pass --project so the user Copilot mcp.json is not rewritten.',
+    });
+  }
   const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
-  const path = yield* copilotMcpConfigPath();
+  const path = options.project
+    ? pathService.join(pathService.resolve(options.project), '.vscode', 'mcp.json')
+    : yield* copilotMcpConfigPath();
   const serverConfig = yield* buildCopilotMcpServerConfig(config, {
     toolset: options.toolset,
   });
+  const composerEntry = options.attach
+    ? buildComposerHttpMcpEntry(options.attach.url, options.attach.shareId)
+    : undefined;
   const currentContent = yield* readFileIfExists(path);
-  const current = jsonMcpConfigurationMatches(currentContent, 'servers', name, serverConfig);
-  const nextContent = renderCopilotMcpConfig(path, currentContent, name, serverConfig);
+  const current =
+    jsonMcpConfigurationMatches(currentContent, 'servers', name, serverConfig) &&
+    (composerEntry === undefined || jsonComposerConfigurationMatches(currentContent, 'servers', composerEntry));
+  const nextContent = renderCopilotMcpConfig(path, currentContent, name, serverConfig, composerEntry);
 
   if (!options.apply) {
     yield* Console.log(
@@ -472,6 +631,8 @@ const runCopilotMcpInstall = Effect.fn('mcp.runCopilotInstall')(function* (
         : 'Dry run. Re-run with --apply to modify GitHub Copilot MCP config.',
     );
     yield* printCopilotMcpSnippet(config, name, {
+      attach: options.attach,
+      project: options.project,
       toolset: options.toolset,
     });
     return;
@@ -701,11 +862,21 @@ function isEmptyConfigContent(content: string | undefined): boolean {
   return content === undefined || content.trim().length === 0;
 }
 
+function withoutManagedComposerEntry(servers: Record<string, unknown>, name: string): Record<string, unknown> {
+  const next = {...servers};
+  delete next[name];
+  if (isManagedComposerHttpEntry(next[THREADNOTE_ORG_MCP_NAME])) {
+    delete next[THREADNOTE_ORG_MCP_NAME];
+  }
+  return next;
+}
+
 function renderCursorMcpConfig(
   configPath: string,
   currentContent: string | undefined,
   name: string,
   serverConfig: JsonObject,
+  composerEntry?: ComposerHttpMcpEntry,
 ): string {
   const parsed = isEmptyConfigContent(currentContent) ? {} : parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
@@ -717,6 +888,7 @@ function renderCursorMcpConfig(
   const nextConfig: Record<string, unknown> = {...parsed};
   const mcpServers = isJsonObject(parsed.mcpServers) ? {...parsed.mcpServers} : {};
   mcpServers[name] = serverConfig;
+  if (composerEntry) mcpServers[THREADNOTE_ORG_MCP_NAME] = composerEntry;
   nextConfig.mcpServers = mcpServers;
   return `${JSON.stringify(nextConfig, null, 2)}\n`;
 }
@@ -726,6 +898,7 @@ function renderCopilotMcpConfig(
   currentContent: string | undefined,
   name: string,
   serverConfig: JsonObject,
+  composerEntry?: ComposerHttpMcpEntry,
 ): string {
   const parsed = isEmptyConfigContent(currentContent) ? {} : parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
@@ -737,6 +910,7 @@ function renderCopilotMcpConfig(
   const nextConfig: Record<string, unknown> = {...parsed};
   const servers = isJsonObject(parsed.servers) ? {...parsed.servers} : {};
   servers[name] = serverConfig;
+  if (composerEntry) servers[THREADNOTE_ORG_MCP_NAME] = composerEntry;
   nextConfig.servers = servers;
   return `${JSON.stringify(nextConfig, null, 2)}\n`;
 }
@@ -759,9 +933,7 @@ const removeCursorMcpConfig = Effect.fn('mcp.removeCursorConfig')(function* (nam
     return true;
   }
   const nextConfig: Record<string, unknown> = {...parsed};
-  const mcpServers = {...parsed.mcpServers};
-  delete mcpServers[name];
-  nextConfig.mcpServers = mcpServers;
+  nextConfig.mcpServers = withoutManagedComposerEntry({...parsed.mcpServers}, name);
   const nextContent = `${JSON.stringify(nextConfig, null, 2)}\n`;
   if (dryRun) {
     yield* Console.log(`Would update Cursor MCP config: ${path}`);
@@ -790,9 +962,7 @@ const removeCopilotMcpConfig = Effect.fn('mcp.removeCopilotConfig')(function* (n
     return true;
   }
   const nextConfig: Record<string, unknown> = {...parsed};
-  const servers = {...parsed.servers};
-  delete servers[name];
-  nextConfig.servers = servers;
+  nextConfig.servers = withoutManagedComposerEntry({...parsed.servers}, name);
   const nextContent = `${JSON.stringify(nextConfig, null, 2)}\n`;
   if (dryRun) {
     yield* Console.log(`Would update GitHub Copilot MCP config: ${path}`);
@@ -842,31 +1012,52 @@ const printCursorMcpSnippet = Effect.fn('mcp.printCursorSnippet')(function* (
   config: RuntimeConfig,
   name: string,
   options: {
+    readonly attach?: ComposerShareBinding;
+    readonly project?: string;
     readonly toolset: McpToolset;
   },
 ) {
   const path = yield* Path.Path;
   const snippetPath = path.join(config.agentContextHome, 'mcp', `${name}.cursor.json`);
-  const snippet = JSON.stringify({mcpServers: {[name]: yield* buildCursorMcpServerConfig(config, options)}}, null, 2);
-  yield* Console.log(`\nSnippet (${snippetPath}; merge into ${yield* cursorMcpConfigPath()}):\n${snippet}`);
+  const stdio = yield* buildCursorMcpServerConfig(config, options);
+  const mcpServers = withComposerHttpMcpEntry({}, name, stdio, options.attach);
+  const snippet = JSON.stringify({mcpServers}, null, 2);
+  const target = yield* cursorMcpConfigPath(options.project);
+  yield* Console.log(`\nSnippet (${snippetPath}; merge into ${target}):\n${snippet}`);
 });
 
 const printCopilotMcpSnippet = Effect.fn('mcp.printCopilotSnippet')(function* (
   config: RuntimeConfig,
   name: string,
   options: {
+    readonly attach?: ComposerShareBinding;
+    readonly project?: string;
     readonly toolset: McpToolset;
   },
 ) {
   const path = yield* Path.Path;
   const snippetPath = path.join(config.agentContextHome, 'mcp', `${name}.copilot.json`);
-  const snippet = JSON.stringify({servers: {[name]: yield* buildCopilotMcpServerConfig(config, options)}}, null, 2);
-  yield* Console.log(`\nSnippet (${snippetPath}; merge into ${yield* copilotMcpConfigPath()}):\n${snippet}`);
+  const stdio = yield* buildCopilotMcpServerConfig(config, options);
+  const servers = withComposerHttpMcpEntry({}, name, stdio, options.attach);
+  const snippet = JSON.stringify({servers}, null, 2);
+  yield* Console.log(
+    `\nSnippet (${snippetPath}; merge into ${yield* copilotMcpConfigPath(options.project)}):\n${snippet}`,
+  );
 });
 
-const cursorMcpConfigPath = Effect.fn('mcp.cursorConfigPath')(() => expandPath('~/.cursor/mcp.json'));
+const cursorMcpConfigPath = Effect.fn('mcp.cursorConfigPath')(function* (project?: string) {
+  if (project?.trim()) {
+    const path = yield* Path.Path;
+    return path.join(path.resolve(project.trim()), '.cursor', 'mcp.json');
+  }
+  return yield* expandPath('~/.cursor/mcp.json');
+});
 
-const copilotMcpConfigPath = Effect.fn('mcp.copilotConfigPath')(function* () {
+const copilotMcpConfigPath = Effect.fn('mcp.copilotConfigPath')(function* (project?: string) {
+  if (project?.trim()) {
+    const path = yield* Path.Path;
+    return path.join(path.resolve(project.trim()), '.vscode', 'mcp.json');
+  }
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const system = yield* SystemInfo;

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -26,6 +26,7 @@ import {withAnonymousTelemetry} from '../../effect/telemetry.js';
 import {
   CURSOR_CLOUD_LOCAL_MCP_TOOLSET,
   CURSOR_CLOUD_MEMORY_ENDPOINT_ENV,
+  CURSOR_CLOUD_MODE_ENV,
   cursorCloudRemoteHybridStatus,
   cursorCloudScopeRoots,
   resolveCursorCloudMemoryScope,
@@ -177,13 +178,19 @@ function registerCursorCloudLocalTools(server: EffectMcpServerAdapter, config: R
       });
       if (!checkedCwd.ok) return checkedCwd.error;
       const system = yield* SystemInfo;
-      const endpoint = system.environment()[CURSOR_CLOUD_MEMORY_ENDPOINT_ENV]?.trim();
+      const environment = system.environment();
+      const endpoint = environment[CURSOR_CLOUD_MEMORY_ENDPOINT_ENV]?.trim();
       if (!endpoint) {
         throw McpServerOperationError.make({
           message: `${CURSOR_CLOUD_MEMORY_ENDPOINT_ENV} is required when ${CURSOR_CLOUD_LOCAL_MCP_TOOLSET} is selected.`,
         });
       }
-      const receipt = yield* cursorCloudRemoteHybridStatus(config, {cwd: checkedCwd.value, endpoint});
+      const mode = environment[CURSOR_CLOUD_MODE_ENV]?.trim() === 'org' ? 'org' : undefined;
+      const receipt = yield* cursorCloudRemoteHybridStatus(config, {
+        cwd: checkedCwd.value,
+        endpoint,
+        ...(mode ? {mode} : {}),
+      });
       return {
         content: [{type: 'text' as const, text: JSON.stringify(receipt)}],
         structuredContent: receipt,

--- a/src/remote_memory/composer_serve.ts
+++ b/src/remote_memory/composer_serve.ts
@@ -1,0 +1,290 @@
+import {createCursorTokenVerifier} from './cursor_oidc.js';
+import {remoteMemoryConfigFromEnvironment, redactedRemoteMemoryConfig} from './config.js';
+import {COMPOSER_OAUTH_SCOPES} from './oauth.js';
+import {createLocalIdp, COMPOSER_OAUTH_CLIENT_ID, LOCAL_COMPOSER_DEFAULT_LISTEN} from './local_idp.js';
+import {remoteMemoryError} from './errors.js';
+import {GitCanonicalMemoryStore, ensureLiveGitShareWorktree} from './git_canonical_store.js';
+import {migrateRemoteMemoryDatabase} from './migrations.js';
+import {createRemoteMemorySql, PostgresRemoteControlPlane} from './postgres_control_plane.js';
+import {PostgresRemoteMemoryRepository} from './postgres_repository.js';
+import {PostgresRemoteRateLimiter} from './rate_limit.js';
+import {RemoteMemoryIndexer} from './indexer.js';
+import {RemoteHandoffRetentionWorker} from './handoff_retention.js';
+import {startRemoteMemoryServer, type RemoteMemoryServer} from './server.js';
+import {
+  createRemoteMemoryWorkerHealth,
+  remoteMemoryWorkerRowsReady,
+  type RemoteMemoryWorkerHealthRow,
+} from './worker_health.js';
+import {remoteMemoryFailureClass, superviseRemoteMemoryService, type RemoteMemoryServiceRuntime} from './main.js';
+
+export interface ComposerListenAddress {
+  readonly hostname: '127.0.0.1';
+  readonly port: number;
+}
+
+export interface ComposerServeInput {
+  readonly databaseUrl: string;
+  readonly gitBranch?: string;
+  readonly gitCloneUrl: string;
+  readonly gitPush?: boolean;
+  readonly gitRemoteName?: string;
+  readonly gitWorktree: string;
+  readonly listen?: string;
+  readonly shareId: string;
+  readonly subject: string;
+  readonly tenantId?: string;
+}
+
+export interface ComposerServeReceipt {
+  readonly canonicalStore: 'git';
+  readonly clientId: string;
+  readonly gitWorktree: string;
+  readonly issuer: string;
+  readonly mcpUrl: string;
+  readonly oauth: {
+    readonly authorizationServer: string;
+    readonly jwks: string;
+    readonly scopes: readonly string[];
+  };
+  readonly shareId: string;
+  readonly url: string;
+}
+
+export function parseComposerListenAddress(value: string): ComposerListenAddress {
+  const match = /^(127\.0\.0\.1|localhost):(\d+)$/u.exec(value.trim());
+  const port = match ? Number(match[2]) : Number.NaN;
+  if (!match || !Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw remoteMemoryError('invalid_request', 'Composer listen must be loopback host:port such as 127.0.0.1:18788.');
+  }
+  if (port === 8787) {
+    throw remoteMemoryError(
+      'invalid_request',
+      'Composer listen cannot use port 8787; Cursor MCP OAuth uses http://localhost:8787/callback.',
+    );
+  }
+  return {hostname: '127.0.0.1', port};
+}
+
+export function composerServeEnvironment(
+  input: ComposerServeInput & {readonly listenAddress: ComposerListenAddress},
+): Record<string, string> {
+  const origin = `http://${input.listenAddress.hostname}:${input.listenAddress.port}`;
+  const port = String(input.listenAddress.port);
+  const hosts = [...new Set([`${input.listenAddress.hostname}:${port}`, `127.0.0.1:${port}`, `localhost:${port}`])];
+  return {
+    THREADNOTE_REMOTE_ALLOWED_HOSTS: hosts.join(','),
+    THREADNOTE_REMOTE_ALLOWED_ORIGINS: [
+      'https://cursor.com',
+      'http://127.0.0.1:8787',
+      'http://localhost:8787',
+      origin,
+    ].join(','),
+    THREADNOTE_REMOTE_CANONICAL_STORE: 'git',
+    THREADNOTE_REMOTE_DATABASE_URL: input.databaseUrl,
+    THREADNOTE_REMOTE_ENABLED: 'true',
+    THREADNOTE_REMOTE_HOST: input.listenAddress.hostname,
+    THREADNOTE_REMOTE_MEMORY_GIT_BRANCH: input.gitBranch?.trim() || 'main',
+    THREADNOTE_REMOTE_MEMORY_GIT_PUSH: input.gitPush === true ? 'true' : 'false',
+    THREADNOTE_REMOTE_MEMORY_GIT_REMOTE: input.gitRemoteName?.trim() || 'origin',
+    THREADNOTE_REMOTE_MEMORY_GIT_WORKTREE: input.gitWorktree,
+    THREADNOTE_REMOTE_OAUTH_ISSUER: origin,
+    THREADNOTE_REMOTE_OAUTH_JWKS_URL: `${origin}/.well-known/jwks.json`,
+    THREADNOTE_REMOTE_PORT: port,
+    THREADNOTE_REMOTE_PUBLIC_URL: origin,
+  };
+}
+
+export async function runComposerServe(
+  input: ComposerServeInput,
+  runtime: RemoteMemoryServiceRuntime,
+): Promise<ComposerServeReceipt> {
+  const listenAddress = parseComposerListenAddress(input.listen?.trim() || LOCAL_COMPOSER_DEFAULT_LISTEN);
+  const gitWorktree = await ensureLiveGitShareWorktree({
+    branch: input.gitBranch,
+    cloneUrl: input.gitCloneUrl,
+    remoteName: input.gitRemoteName,
+    worktree: input.gitWorktree,
+  });
+  const environment = composerServeEnvironment({...input, gitWorktree, listenAddress});
+  const config = remoteMemoryConfigFromEnvironment(environment);
+  if (config.canonicalStore !== 'git' || !config.gitWorktree) {
+    throw remoteMemoryError(
+      'invalid_request',
+      'Organization composer serve requires THREADNOTE_REMOTE_CANONICAL_STORE=git.',
+    );
+  }
+  const idp = await createLocalIdp({
+    audience: config.accessTokenAudience,
+    issuer: config.accessTokenIssuer,
+    subject: input.subject,
+  });
+  const sql = createRemoteMemorySql(config.databaseUrl);
+  const controlPlane = new PostgresRemoteControlPlane(sql);
+  const workers = new AbortController();
+  const workerHealth = createRemoteMemoryWorkerHealth(
+    (name, cause) => {
+      if (!workers.signal.aborted)
+        runtime.error(`Threadnote composer ${name} worker failed: ${remoteMemoryFailureClass(cause)}.`);
+    },
+    () => workers.signal.aborted,
+  );
+  let workerTasks: readonly Promise<void>[] = [];
+  let stopping: Promise<void> | undefined;
+  let server: RemoteMemoryServer | undefined;
+  try {
+    if (config.autoMigrate) await migrateRemoteMemoryDatabase(sql);
+    await sql`SELECT 1 FROM remote_memory.shares LIMIT 0`;
+    const gitStore = new GitCanonicalMemoryStore({
+      branch: config.gitBranch,
+      push: config.gitPush,
+      remote: config.gitRemote,
+      worktree: config.gitWorktree,
+    });
+    await gitStore.assertLiveShare();
+    await provisionGitTeamShare(controlPlane, {
+      issuer: idp.issuer,
+      shareId: input.shareId,
+      subject: idp.subject,
+      tenantId: input.tenantId?.trim() || 'local-org',
+    });
+    const listening = startRemoteMemoryServer({
+      config,
+      dependencies: {
+        attestations: controlPlane,
+        authorization: controlPlane,
+        cursorTokens: createCursorTokenVerifier({
+          audience: config.attestationAudience,
+          issuer: config.cursorIssuer,
+          jwksUrl: config.cursorJwksUrl,
+        }),
+        oauthTokens: idp.verifier(),
+        readiness: async () => {
+          try {
+            await gitStore.assertLiveShare();
+            workerHealth.assertReady();
+            return remoteMemoryWorkersReady(sql);
+          } catch {
+            return false;
+          }
+        },
+        rateLimits: new PostgresRemoteRateLimiter(sql, {
+          readRequestsPerMinute: config.readRequestsPerMinute,
+          writeRequestsPerMinute: config.writeRequestsPerMinute,
+        }),
+        repository: new PostgresRemoteMemoryRepository(sql, {gitStore}),
+      },
+      localIdp: idp,
+    });
+    server = listening;
+    const indexer = new RemoteMemoryIndexer(sql, gitStore);
+    const retention = new RemoteHandoffRetentionWorker(sql, {gitStore});
+    workerTasks = [indexer.run({signal: workers.signal}), retention.run({signal: workers.signal})];
+    workerHealth.supervise('indexer', workerTasks[0]);
+    workerHealth.supervise('retention', workerTasks[1]);
+    const receipt: ComposerServeReceipt = {
+      canonicalStore: 'git',
+      clientId: COMPOSER_OAUTH_CLIENT_ID,
+      gitWorktree,
+      issuer: idp.issuer,
+      mcpUrl: new URL('/mcp', config.publicBaseUrl).toString(),
+      oauth: {
+        authorizationServer: idp.issuer,
+        jwks: `${idp.issuer}/.well-known/jwks.json`,
+        scopes: [...COMPOSER_OAUTH_SCOPES],
+      },
+      shareId: input.shareId,
+      url: listening.url.toString(),
+    };
+    const shutdown = (reason: string) => {
+      stopping ??= (async () => {
+        runtime.error(`Threadnote composer stopping after ${reason}; draining requests.`);
+        workers.abort();
+        await listening.stop(false);
+        await Promise.allSettled(workerTasks);
+        await controlPlane.close();
+      })();
+      return stopping;
+    };
+    runtime.error(`Threadnote composer listening on ${receipt.url}`);
+    runtime.error(JSON.stringify({...redactedRemoteMemoryConfig(config), ...receipt}));
+    const processSignal = runtime.shutdownSignal();
+    try {
+      await superviseRemoteMemoryService({
+        shutdown,
+        signal: processSignal.promise,
+        workerHealth,
+      });
+    } finally {
+      processSignal.dispose();
+    }
+    return receipt;
+  } catch (cause) {
+    await releaseFailedComposerStart({
+      closeControlPlane: () => controlPlane.close(),
+      server,
+      stopping,
+      workerTasks,
+      workers,
+    });
+    throw cause;
+  }
+}
+
+export async function releaseFailedComposerStart(input: {
+  readonly closeControlPlane: () => Promise<void>;
+  readonly server?: Pick<RemoteMemoryServer, 'stop'>;
+  readonly stopping?: Promise<void>;
+  readonly workerTasks: readonly Promise<void>[];
+  readonly workers: AbortController;
+}): Promise<void> {
+  input.workers.abort();
+  await Promise.allSettled(input.workerTasks);
+  if (input.stopping) return;
+  if (input.server) await input.server.stop(true).catch(() => undefined);
+  await input.closeControlPlane().catch(() => undefined);
+}
+
+export async function provisionGitTeamShare(
+  controlPlane: PostgresRemoteControlPlane,
+  input: {
+    readonly issuer: string;
+    readonly shareId: string;
+    readonly subject: string;
+    readonly tenantId: string;
+  },
+): Promise<void> {
+  await controlPlane.provision({
+    capabilities: [...COMPOSER_OAUTH_SCOPES],
+    cursorAttestationRequired: false,
+    displayName: `Git team share ${input.shareId}`,
+    featureFlags: [
+      'remote_memory_read',
+      'remote_memory_durable_write',
+      'remote_memory_handoff_write',
+      'remote_memory_ga',
+    ],
+    issuer: input.issuer,
+    policyVersion: 'local-v1',
+    principalId: 'local-composer',
+    region: 'local',
+    shareId: input.shareId,
+    sharePolicyVersion: 'local-share-v1',
+    subject: input.subject,
+    tenantId: input.tenantId,
+  });
+}
+
+async function remoteMemoryWorkersReady(sql: ReturnType<typeof createRemoteMemorySql>): Promise<boolean> {
+  const rows = (await sql.begin(async transaction => {
+    await transaction`SELECT set_config('statement_timeout', '2000', true)`;
+    await transaction`SELECT set_config('lock_timeout', '1000', true)`;
+    await transaction`SELECT set_config('transaction_timeout', '2000', true)`;
+    return transaction<RemoteMemoryWorkerHealthRow[]>`
+      SELECT worker_name, heartbeat_at, last_success_at, failure_class, oldest_pending_at
+      FROM remote_memory.worker_health
+      WHERE worker_name IN ('indexer', 'retention')
+    `;
+  })) as RemoteMemoryWorkerHealthRow[];
+  return remoteMemoryWorkerRowsReady(rows);
+}

--- a/src/remote_memory/config.ts
+++ b/src/remote_memory/config.ts
@@ -54,8 +54,8 @@ export function remoteMemoryConfigFromEnvironment(
     );
   }
   const allowedHosts = csv(environment.THREADNOTE_REMOTE_ALLOWED_HOSTS, [publicBaseUrl.host]).map(validateHostValue);
-  const allowedOrigins = csv(environment.THREADNOTE_REMOTE_ALLOWED_ORIGINS, ['https://cursor.com']).map(
-    validateOriginValue,
+  const allowedOrigins = csv(environment.THREADNOTE_REMOTE_ALLOWED_ORIGINS, ['https://cursor.com']).map(value =>
+    validateOriginValue(value, localService),
   );
   const accessTokenAudience = audienceValue(
     environment.THREADNOTE_REMOTE_OAUTH_AUDIENCE?.trim() || new URL('/mcp', publicBaseUrl).toString(),
@@ -174,8 +174,7 @@ function required(environment: Readonly<Record<string, string | undefined>>, key
 
 function httpsUrl(value: string, key: string): URL {
   const url = configuredUrl(value, undefined, key);
-  const loopback = url.hostname === '127.0.0.1' || url.hostname === 'localhost';
-  if (url.protocol !== 'https:' && !(loopback && url.protocol === 'http:')) {
+  if (url.protocol !== 'https:' && !(isLoopbackHostname(url.hostname) && url.protocol === 'http:')) {
     throw remoteMemoryError('invalid_request', `${key} must use HTTPS outside localhost.`);
   }
   if (url.username || url.password || url.hash) {
@@ -263,15 +262,24 @@ function validateHostValue(value: string): string {
   return parsed.host;
 }
 
-function validateOriginValue(value: string): string {
+function validateOriginValue(value: string, localService: boolean): string {
   let url: URL;
   try {
     url = new URL(value);
   } catch {
     throw remoteMemoryError('invalid_request', 'Allowed Origin entries must be absolute origins.');
   }
-  if (url.protocol !== 'https:' || url.origin !== value.replace(/\/$/u, '') || url.username || url.password) {
-    throw remoteMemoryError('invalid_request', 'Allowed Origin entries must be credential-free HTTPS origins.');
+  const loopbackHttp = isLoopbackHostname(url.hostname) && url.protocol === 'http:';
+  if (
+    (url.protocol !== 'https:' && !(localService && loopbackHttp)) ||
+    url.origin !== value.replace(/\/$/u, '') ||
+    url.username ||
+    url.password
+  ) {
+    throw remoteMemoryError(
+      'invalid_request',
+      'Allowed Origin entries must be credential-free HTTPS origins, or loopback HTTP on a loopback public URL.',
+    );
   }
   return url.origin;
 }
@@ -290,6 +298,10 @@ function booleanValue(value: string | undefined, fallback: boolean): boolean {
   if (value === 'true') return true;
   if (value === 'false') return false;
   throw remoteMemoryError('invalid_request', 'Expected true or false.');
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === '127.0.0.1' || hostname === 'localhost';
 }
 
 function isAbsoluteWorktree(path: string): boolean {

--- a/src/remote_memory/git_canonical_store.ts
+++ b/src/remote_memory/git_canonical_store.ts
@@ -158,6 +158,17 @@ export class GitCanonicalMemoryStore {
     }
   }
 
+  async assertLiveShare(): Promise<void> {
+    await this.assertReady();
+    const head = await this.git(['rev-parse', '--verify', 'HEAD'], true);
+    if (head.exitCode !== 0 || !head.stdout.trim()) {
+      throw remoteMemoryError(
+        'service_unavailable',
+        'THREADNOTE_REMOTE_MEMORY_GIT_WORKTREE has no commits; clone the live team share.',
+      );
+    }
+  }
+
   private serialize<A>(operation: () => Promise<A>): Promise<A> {
     const run = this.queue.then(operation, operation);
     this.queue = run.then(
@@ -453,6 +464,95 @@ function joinAbsolute(root: string, ...segments: string[]): string {
   const trimmed = root.replace(/[\\/]+$/u, '');
   const separator = trimmed.includes('\\') && !trimmed.includes('/') ? '\\' : '/';
   return [trimmed, ...segments].join(separator);
+}
+
+export interface LiveGitShareWorktreeOptions {
+  readonly branch?: string;
+  readonly cloneUrl: string;
+  readonly remoteName?: string;
+  readonly worktree: string;
+}
+
+export async function ensureLiveGitShareWorktree(options: LiveGitShareWorktreeOptions): Promise<string> {
+  const worktree = options.worktree.trim().replace(/[\\/]+$/u, '');
+  if (!worktree || !isAbsoluteGitWorktree(worktree)) {
+    throw remoteMemoryError('invalid_request', 'THREADNOTE_REMOTE_MEMORY_GIT_WORKTREE must be an absolute path.');
+  }
+  const branch = requireGitRefName(options.branch?.trim() || 'main', 'THREADNOTE_REMOTE_MEMORY_GIT_BRANCH');
+  const cloneUrl = options.cloneUrl.trim();
+  if (!cloneUrl) {
+    throw remoteMemoryError('invalid_request', 'The live team git remote is required.');
+  }
+  const exists = (await runProcess(['test', '-d', worktree], true)).exitCode === 0;
+  if (!exists || (await isEmptyDirectory(worktree))) {
+    await cloneLiveShare(cloneUrl, worktree, branch);
+  }
+  const remoteName = requireGitRefName(options.remoteName?.trim() || 'origin', 'THREADNOTE_REMOTE_MEMORY_GIT_REMOTE');
+  const store = new GitCanonicalMemoryStore({branch, remote: remoteName, worktree});
+  await store.assertLiveShare();
+  await assertWorktreeRemoteMatches(worktree, remoteName, cloneUrl);
+  return worktree;
+}
+
+export function gitRemoteUrlsMatch(left: string, right: string): boolean {
+  const normalizedLeft = normalizeGitRemoteUrl(left);
+  return normalizedLeft.length > 0 && normalizedLeft === normalizeGitRemoteUrl(right);
+}
+
+export function normalizeGitRemoteUrl(value: string): string {
+  const trimmed = value.trim().replaceAll('\\', '/');
+  if (!trimmed) return '';
+  const stripped = trimmed.replace(/\.git$/u, '').replace(/\/+$/u, '');
+  if (stripped.startsWith('/') || /^[A-Za-z]:\//u.test(stripped)) {
+    return stripped.toLowerCase();
+  }
+  const scp = /^[^:/]+@([^:]+):(.+)$/u.exec(stripped);
+  if (scp && !stripped.includes('://')) {
+    return `${scp[1].toLowerCase()}/${scp[2].replace(/^\/+/u, '')}`;
+  }
+  try {
+    const parsed = new URL(stripped);
+    if (parsed.protocol === 'file:') {
+      return decodeURIComponent(parsed.pathname).replace(/\/+$/u, '').toLowerCase();
+    }
+    const host = parsed.hostname.toLowerCase();
+    const path = parsed.pathname
+      .replace(/^\/+/u, '')
+      .replace(/\/+$/u, '')
+      .replace(/\.git$/u, '');
+    return path ? `${host}/${path}` : host;
+  } catch {
+    return stripped.toLowerCase();
+  }
+}
+
+async function assertWorktreeRemoteMatches(worktree: string, remoteName: string, cloneUrl: string): Promise<void> {
+  const result = await runGit(worktree, ['remote', 'get-url', remoteName], true);
+  if (result.exitCode !== 0 || !gitRemoteUrlsMatch(result.stdout.trim(), cloneUrl)) {
+    throw remoteMemoryError('invalid_request', 'The existing git worktree remote does not match the live team share.');
+  }
+}
+
+async function cloneLiveShare(cloneUrl: string, worktree: string, branch: string): Promise<void> {
+  const parent = parentDirectory(worktree);
+  const created = await runProcess(['mkdir', '-p', parent], true, 'mkdir');
+  if (created.exitCode !== 0) {
+    throw remoteMemoryError('service_unavailable', 'The composer git worktree parent could not be created.');
+  }
+  const cloned = await runProcess(['git', 'clone', '--branch', branch, '--', cloneUrl, worktree], true, 'git clone');
+  if (cloned.exitCode !== 0) {
+    throw remoteMemoryError('service_unavailable', 'Could not clone the live team git share.');
+  }
+}
+
+async function isEmptyDirectory(path: string): Promise<boolean> {
+  const listing = await runProcess(['ls', '-A', path], true, 'ls');
+  return listing.exitCode === 0 && listing.stdout.trim().length === 0;
+}
+
+function parentDirectory(path: string): string {
+  const index = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  return index <= 0 ? path : path.slice(0, index);
 }
 
 function runGit(

--- a/src/remote_memory/http_transport.ts
+++ b/src/remote_memory/http_transport.ts
@@ -5,6 +5,8 @@ import {authorizeRemoteRequest, requestedRemoteShare, type AuthorizedRemotePrinc
 import {completeCursorAttestation} from './cursor_oidc.js';
 import {publicRemoteMemoryError, remoteMemoryError, type RemoteMemoryError} from './errors.js';
 import {bearerTokenFromRequest, oauthChallenge, protectedResourceMetadata} from './oauth.js';
+import type {LocalIdp} from './local_idp.js';
+import {isLocalIdpPath} from './local_idp.js';
 import type {RemoteMemoryServiceDependencies} from './service_types.js';
 import {createRemoteMemoryMcpServer} from './tools.js';
 import type {RemoteMemoryRequestExecution} from './request_execution.js';
@@ -15,6 +17,7 @@ const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u;
 export interface RemoteMemoryHttpHandlerOptions {
   readonly config: RemoteMemoryServiceConfig;
   readonly dependencies: RemoteMemoryServiceDependencies;
+  readonly localIdp?: LocalIdp;
 }
 
 export function createRemoteMemoryHttpHandler(
@@ -47,6 +50,10 @@ export async function handleRemoteMemoryHttpRequest(
         protectedResourceMetadata(options.config.publicBaseUrl, [options.config.accessTokenIssuer]),
         requestId,
       );
+    }
+    if (options.localIdp && isLocalIdpPath(path)) {
+      const idpResponse = await options.localIdp.handle(request);
+      if (idpResponse) return withRequestHeaders(idpResponse, requestId);
     }
     if (path === '/mcp') return await handleMcpRequest(options, request, requestId);
     if (path === '/attest/cursor/complete') {
@@ -187,8 +194,9 @@ function validateOrigin(request: Request, allowedOrigins: readonly string[], req
   let origin: string;
   try {
     const parsed = new URL(raw);
+    const loopback = parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
     if (
-      parsed.protocol !== 'https:' ||
+      (parsed.protocol !== 'https:' && !(loopback && parsed.protocol === 'http:')) ||
       parsed.username ||
       parsed.password ||
       parsed.pathname !== '/' ||

--- a/src/remote_memory/local_idp.ts
+++ b/src/remote_memory/local_idp.ts
@@ -1,0 +1,298 @@
+import {exportJWK, generateKeyPair, SignJWT, type CryptoKey, type JWK} from 'jose';
+import {sha256HexSync} from '../crypto/sha256.js';
+import {randomUuidV4} from '../crypto/uuid.js';
+import {COMPOSER_OAUTH_SCOPES, createLocalOAuthTokenVerifier, type OAuthTokenVerifier} from './oauth.js';
+import {remoteMemoryError} from './errors.js';
+
+export const COMPOSER_OAUTH_CLIENT_ID = 'threadnote-composer';
+export const LOCAL_COMPOSER_DEFAULT_LISTEN = '127.0.0.1:18788';
+export const COMPOSER_OAUTH_REDIRECT_URIS = [
+  'http://127.0.0.1:8787/callback',
+  'http://localhost:8787/callback',
+  'cursor://anysphere.cursor-mcp/oauth/callback',
+] as const;
+const AUTHORIZATION_CODE_TTL_SECONDS = 60;
+const ACCESS_TOKEN_TTL_SECONDS = 300;
+const MAX_OUTSTANDING_AUTHORIZATION_CODES = 32;
+const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
+
+export interface LocalIdp {
+  readonly audience: string;
+  readonly clientId: string;
+  readonly handle: (request: Request) => Promise<Response | undefined>;
+  readonly issuer: string;
+  readonly issueAccessToken: (input?: {readonly scope?: string; readonly subject?: string}) => Promise<string>;
+  readonly publicKey: CryptoKey;
+  readonly publicJwk: JWK;
+  readonly subject: string;
+  readonly verifier: () => OAuthTokenVerifier;
+}
+
+export interface LocalIdpOptions {
+  readonly audience: string;
+  readonly issuer: string;
+  readonly subject: string;
+}
+
+interface AuthorizationCode {
+  readonly challenge: string;
+  readonly expiresAt: number;
+  readonly redirectUri: string;
+  readonly scope: string;
+  readonly subject: string;
+}
+
+export async function createLocalIdp(options: LocalIdpOptions): Promise<LocalIdp> {
+  const issuer = canonicalizeIssuer(options.issuer);
+  const audience = options.audience.trim();
+  const subject = options.subject.trim();
+  if (!audience || !subject) {
+    throw remoteMemoryError('invalid_request', 'The local OAuth issuer requires an audience and subject.');
+  }
+  const {privateKey, publicKey} = await generateKeyPair('RS256', {extractable: true});
+  const publicJwk = await exportJWK(publicKey);
+  const kid = randomUuidV4();
+  publicJwk.alg = 'RS256';
+  publicJwk.kid = kid;
+  publicJwk.use = 'sig';
+  const codes = new Map<string, AuthorizationCode>();
+  const verifier = createLocalOAuthTokenVerifier({audience, issuer, publicKey});
+  const defaultScope = COMPOSER_OAUTH_SCOPES.join(' ');
+
+  const issueAccessToken = async (input?: {readonly scope?: string; readonly subject?: string}) => {
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({
+      aud: audience,
+      exp: now + ACCESS_TOKEN_TTL_SECONDS,
+      iat: now,
+      iss: issuer,
+      nbf: now,
+      scope: input?.scope?.trim() || defaultScope,
+      sub: input?.subject?.trim() || subject,
+    })
+      .setProtectedHeader({alg: 'RS256', kid, typ: 'at+jwt'})
+      .sign(privateKey);
+  };
+
+  return {
+    audience,
+    clientId: COMPOSER_OAUTH_CLIENT_ID,
+    handle: async request => {
+      const path = new URL(request.url).pathname;
+      if (path === '/.well-known/oauth-authorization-server') {
+        if (request.method !== 'GET') return methodNotAllowed('GET');
+        return jsonResponse(200, authorizationServerMetadata(issuer));
+      }
+      if (path === '/.well-known/jwks.json') {
+        if (request.method !== 'GET') return methodNotAllowed('GET');
+        return jsonResponse(200, {keys: [publicJwk]});
+      }
+      if (path === '/authorize') {
+        if (request.method !== 'GET') return methodNotAllowed('GET');
+        return authorize(request, codes, subject, defaultScope);
+      }
+      if (path === '/token') {
+        if (request.method !== 'POST') return methodNotAllowed('POST');
+        return token(request, codes, issueAccessToken);
+      }
+      if (path === '/register') {
+        if (request.method !== 'POST') return methodNotAllowed('POST');
+        return registerClient();
+      }
+      return undefined;
+    },
+    issuer,
+    issueAccessToken,
+    publicKey,
+    publicJwk,
+    subject,
+    verifier: () => verifier,
+  };
+}
+
+export function isLocalIdpPath(path: string): boolean {
+  return (
+    path === '/.well-known/oauth-authorization-server' ||
+    path === '/.well-known/jwks.json' ||
+    path === '/authorize' ||
+    path === '/token' ||
+    path === '/register'
+  );
+}
+
+export function authorizationServerMetadata(issuer: string) {
+  return {
+    authorization_endpoint: `${issuer}/authorize`,
+    code_challenge_methods_supported: ['S256'],
+    grant_types_supported: ['authorization_code'],
+    issuer,
+    jwks_uri: `${issuer}/.well-known/jwks.json`,
+    registration_endpoint: `${issuer}/register`,
+    response_types_supported: ['code'],
+    scopes_supported: [...COMPOSER_OAUTH_SCOPES],
+    token_endpoint: `${issuer}/token`,
+    token_endpoint_auth_methods_supported: ['none'],
+  } as const;
+}
+
+function authorize(
+  request: Request,
+  codes: Map<string, AuthorizationCode>,
+  subject: string,
+  defaultScope: string,
+): Response {
+  const url = new URL(request.url);
+  const clientId = url.searchParams.get('client_id') ?? '';
+  const redirectUri = url.searchParams.get('redirect_uri') ?? '';
+  const responseType = url.searchParams.get('response_type') ?? '';
+  const challenge = url.searchParams.get('code_challenge') ?? '';
+  const method = url.searchParams.get('code_challenge_method') ?? '';
+  const state = url.searchParams.get('state') ?? '';
+  const scope = url.searchParams.get('scope')?.trim() || defaultScope;
+  if (clientId !== COMPOSER_OAUTH_CLIENT_ID) return oauthError(400, 'invalid_client');
+  if (responseType !== 'code') return oauthError(400, 'unsupported_response_type');
+  if (!isAllowedRedirect(redirectUri)) return oauthError(400, 'invalid_request', 'redirect_uri is not allowed');
+  if (method !== 'S256' || !isPkceChallenge(challenge)) {
+    return oauthError(400, 'invalid_request', 'PKCE S256 is required');
+  }
+  const now = Date.now();
+  for (const [storedCode, stored] of codes) {
+    if (stored.expiresAt <= now) codes.delete(storedCode);
+  }
+  if (codes.size >= MAX_OUTSTANDING_AUTHORIZATION_CODES) {
+    const oldest = [...codes.entries()].reduce((current, candidate) =>
+      candidate[1].expiresAt < current[1].expiresAt ? candidate : current,
+    );
+    codes.delete(oldest[0]);
+  }
+  const code = randomUrlSafe(32);
+  codes.set(code, {
+    challenge,
+    expiresAt: now + AUTHORIZATION_CODE_TTL_SECONDS * 1000,
+    redirectUri,
+    scope,
+    subject,
+  });
+  const location = new URL(redirectUri);
+  location.searchParams.set('code', code);
+  if (state) location.searchParams.set('state', state);
+  return new Response(null, {headers: {location: location.toString()}, status: 302});
+}
+
+async function token(
+  request: Request,
+  codes: Map<string, AuthorizationCode>,
+  issueAccessToken: (input?: {readonly scope?: string; readonly subject?: string}) => Promise<string>,
+): Promise<Response> {
+  const body = await request.text();
+  if (Buffer.byteLength(body, 'utf8') > 16 * 1024) return oauthError(400, 'invalid_request');
+  const params = new URLSearchParams(body);
+  const grant = params.get('grant_type') ?? '';
+  const clientId = params.get('client_id') ?? '';
+  if (clientId !== COMPOSER_OAUTH_CLIENT_ID) return oauthError(401, 'invalid_client');
+  if (grant !== 'authorization_code') return oauthError(400, 'unsupported_grant_type');
+  const code = params.get('code') ?? '';
+  const redirectUri = params.get('redirect_uri') ?? '';
+  const verifier = params.get('code_verifier') ?? '';
+  const stored = codes.get(code);
+  codes.delete(code);
+  if (!stored || stored.expiresAt <= Date.now()) return oauthError(400, 'invalid_grant');
+  if (stored.redirectUri !== redirectUri) return oauthError(400, 'invalid_grant');
+  if (!isPkceVerifier(verifier) || !equalSecret(pkceS256Challenge(verifier), stored.challenge)) {
+    return oauthError(400, 'invalid_grant');
+  }
+  const accessToken = await issueAccessToken({scope: stored.scope, subject: stored.subject});
+  return jsonResponse(200, tokenResponse(accessToken, stored.scope));
+}
+
+function registerClient(): Response {
+  return jsonResponse(201, {
+    client_id: COMPOSER_OAUTH_CLIENT_ID,
+    grant_types: ['authorization_code'],
+    redirect_uris: [...COMPOSER_OAUTH_REDIRECT_URIS],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  });
+}
+
+function tokenResponse(accessToken: string, scope: string) {
+  return {
+    access_token: accessToken,
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+    scope,
+    token_type: 'Bearer',
+  };
+}
+
+function isAllowedRedirect(redirectUri: string): boolean {
+  return (COMPOSER_OAUTH_REDIRECT_URIS as readonly string[]).includes(redirectUri);
+}
+
+function isPkceChallenge(value: string): boolean {
+  return /^[A-Za-z0-9_-]{43,128}$/u.test(value);
+}
+
+function isPkceVerifier(value: string): boolean {
+  return /^[A-Za-z0-9-._~]{43,128}$/u.test(value);
+}
+
+export function pkceS256Challenge(verifier: string): string {
+  return base64UrlEncode(hexToBytes(sha256HexSync(verifier)));
+}
+
+function randomUrlSafe(bytes: number): string {
+  return base64UrlEncode(globalThis.crypto.getRandomValues(new Uint8Array(bytes)));
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function equalSecret(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  let diff = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return diff === 0;
+}
+
+function canonicalizeIssuer(value: string): string {
+  const url = new URL(value);
+  const loopback = url.hostname === '127.0.0.1' || url.hostname === 'localhost';
+  if (url.protocol !== 'https:' && !(loopback && url.protocol === 'http:')) {
+    throw remoteMemoryError('invalid_request', 'The local OAuth issuer must use HTTPS outside loopback.');
+  }
+  if (url.username || url.password || url.search || url.hash || url.pathname !== '/') {
+    throw remoteMemoryError('invalid_request', 'The local OAuth issuer must be a credential-free origin.');
+  }
+  return url.toString().replace(/\/$/u, '');
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'cache-control': 'no-store',
+      'content-type': JSON_CONTENT_TYPE,
+    },
+    status,
+  });
+}
+
+function oauthError(status: number, error: string, description?: string): Response {
+  return jsonResponse(status, description ? {error, error_description: description} : {error});
+}
+
+function methodNotAllowed(allow: string): Response {
+  return new Response(null, {headers: {allow}, status: 405});
+}

--- a/src/remote_memory/oauth.ts
+++ b/src/remote_memory/oauth.ts
@@ -1,7 +1,9 @@
-import {createRemoteJWKSet, jwtVerify, type JWTPayload} from 'jose';
+import {createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey} from 'jose';
 import {remoteMemoryError} from './errors.js';
 
 const MAX_BEARER_TOKEN_BYTES = 16 * 1024;
+
+export const COMPOSER_OAUTH_SCOPES = ['memory:read', 'memory:write:durable', 'memory:write:handoff'] as const;
 
 export interface OAuthPrincipalClaims {
   readonly issuer: string;
@@ -19,6 +21,12 @@ export interface OAuthVerifierConfig {
   readonly jwksUrl: URL;
 }
 
+export interface LocalOAuthVerifierConfig {
+  readonly audience: string;
+  readonly issuer: string;
+  readonly publicKey: CryptoKey;
+}
+
 export function bearerTokenFromRequest(request: Request): string {
   const authorization = request.headers.get('authorization');
   if (!authorization) throw remoteMemoryError('unauthorized', 'A bearer access token is required.');
@@ -31,11 +39,22 @@ export function bearerTokenFromRequest(request: Request): string {
 
 export function createOAuthTokenVerifier(config: OAuthVerifierConfig): OAuthTokenVerifier {
   const jwks = createRemoteJWKSet(config.jwksUrl, {cacheMaxAge: 5 * 60_000, timeoutDuration: 3000});
+  return createAccessTokenVerifier(jwks, config);
+}
+
+export function createLocalOAuthTokenVerifier(config: LocalOAuthVerifierConfig): OAuthTokenVerifier {
+  return createAccessTokenVerifier(config.publicKey, config);
+}
+
+function createAccessTokenVerifier(
+  key: CryptoKey | JWTVerifyGetKey,
+  config: {readonly audience: string; readonly issuer: string},
+): OAuthTokenVerifier {
   return {
     verify: async token => {
       let payload: JWTPayload;
       try {
-        ({payload} = await jwtVerify(token, jwks, {
+        ({payload} = await jwtVerify(token, key, {
           algorithms: ['RS256'],
           audience: config.audience,
           clockTolerance: 5,
@@ -66,7 +85,7 @@ export function protectedResourceMetadata(publicBaseUrl: URL, authorizationServe
     bearer_methods_supported: ['header'],
     resource: new URL('/mcp', publicBaseUrl).toString(),
     resource_documentation: new URL('/docs/remote-memory', publicBaseUrl).toString(),
-    scopes_supported: ['memory:read', 'memory:write:durable', 'memory:write:handoff', 'memory:admin'],
+    scopes_supported: [...COMPOSER_OAUTH_SCOPES, 'memory:admin'],
   } as const;
 }
 

--- a/src/remote_memory/postgres_control_plane.ts
+++ b/src/remote_memory/postgres_control_plane.ts
@@ -838,15 +838,19 @@ function validateProvisioningIdentity(issuer: string, subject: string): void {
   } catch {
     throw remoteMemoryError('invalid_request', 'Provisioning issuer is invalid.');
   }
+  const loopback = parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
   if (
-    parsed.protocol !== 'https:' ||
+    (parsed.protocol !== 'https:' && !(loopback && parsed.protocol === 'http:')) ||
     parsed.username ||
     parsed.password ||
     parsed.search ||
     parsed.hash ||
     issuer !== parsed.toString().replace(/\/$/u, '')
   ) {
-    throw remoteMemoryError('invalid_request', 'Provisioning issuer must be one canonical credential-free HTTPS URL.');
+    throw remoteMemoryError(
+      'invalid_request',
+      'Provisioning issuer must be one canonical credential-free HTTPS URL, or loopback HTTP.',
+    );
   }
   const hasControlCharacter = [...subject].some(character => {
     const codePoint = character.codePointAt(0) ?? 0;

--- a/src/remote_memory/server.ts
+++ b/src/remote_memory/server.ts
@@ -1,5 +1,6 @@
 import type {RemoteMemoryServiceConfig} from './config.js';
 import {createRemoteMemoryHttpHandler} from './http_transport.js';
+import type {LocalIdp} from './local_idp.js';
 import type {RemoteMemoryServiceDependencies} from './service_types.js';
 
 export interface RemoteMemoryServer {
@@ -12,11 +13,16 @@ export interface RemoteMemoryServer {
 export interface StartRemoteMemoryServerOptions {
   readonly config: RemoteMemoryServiceConfig;
   readonly dependencies: RemoteMemoryServiceDependencies;
+  readonly localIdp?: LocalIdp;
   readonly serve?: typeof Bun.serve;
 }
 
 export function startRemoteMemoryServer(options: StartRemoteMemoryServerOptions): RemoteMemoryServer {
-  const fetch = createRemoteMemoryHttpHandler(options);
+  const fetch = createRemoteMemoryHttpHandler({
+    config: options.config,
+    dependencies: options.dependencies,
+    ...(options.localIdp ? {localIdp: options.localIdp} : {}),
+  });
   const server = (options.serve ?? Bun.serve)({
     fetch,
     hostname: options.config.host,

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,11 +170,14 @@ export interface SeedOptions {
 
 export interface McpInstallOptions {
   readonly apply?: boolean;
+  readonly composerUrl?: string;
   /** @internal Recorded Claude project/local installation directory used by repair. */
   readonly cwd?: string;
   readonly dryRunApplyCommand?: string;
   readonly name?: string;
+  readonly project?: string;
   readonly scope?: ClaudeMcpScope;
+  readonly shareId?: string;
   readonly toolset?: McpToolset;
 }
 

--- a/test/e2e/local-bins.e2e.ts
+++ b/test/e2e/local-bins.e2e.ts
@@ -55,8 +55,8 @@ function installedLauncher(
 
 beforeAll(async () => {
   temporaryRoot = await mkdtemp(join(tmpdir(), 'threadnote-native-e2e-'));
-  home = join(temporaryRoot, 'threadnote-home');
   userHome = join(temporaryRoot, 'user-home');
+  home = join(userHome, '.threadnote');
   graphRepository = join(temporaryRoot, 'code-graph-repository');
   await mkdir(join(home, 'cache'), {recursive: true});
   await mkdir(userHome, {recursive: true});

--- a/test/unit/composer-serve.test.ts
+++ b/test/unit/composer-serve.test.ts
@@ -1,0 +1,86 @@
+import {describe, expect, it} from 'vitest';
+import {resolveComposerServeShareId} from '../../src/mcp/composer_attach.js';
+import {remoteMemoryConfigFromEnvironment} from '../../src/remote_memory/config.js';
+import {
+  composerServeEnvironment,
+  parseComposerListenAddress,
+  releaseFailedComposerStart,
+} from '../../src/remote_memory/composer_serve.js';
+import {LOCAL_COMPOSER_DEFAULT_LISTEN} from '../../src/remote_memory/local_idp.js';
+
+const listenAddress = {hostname: '127.0.0.1' as const, port: 18788};
+
+describe('composer serve', () => {
+  it('parses loopback listen addresses and refuses Cursor OAuth callback port 8787', () => {
+    expect(parseComposerListenAddress(LOCAL_COMPOSER_DEFAULT_LISTEN)).toEqual(listenAddress);
+    expect(parseComposerListenAddress('localhost:18788')).toEqual({hostname: '127.0.0.1', port: 18788});
+    expect(() => parseComposerListenAddress('127.0.0.1:8787')).toThrow('8787');
+    expect(() => parseComposerListenAddress('0.0.0.0:18788')).toThrow('loopback');
+    expect(() => parseComposerListenAddress('example.test:18788')).toThrow('loopback');
+  });
+
+  it('forces git canonical bodies and a loopback OAuth issuer', () => {
+    const environment = composerServeEnvironment({
+      databaseUrl: 'postgres://threadnote@127.0.0.1/threadnote',
+      gitCloneUrl: 'git@github.com:Kashkovsky/threadnote-share.git',
+      gitWorktree: '/tmp/threadnote-share-default',
+      listenAddress,
+      shareId: 'default',
+      subject: 'local:tester',
+    });
+    expect(environment.THREADNOTE_REMOTE_CANONICAL_STORE).toBe('git');
+    expect(environment.THREADNOTE_REMOTE_OAUTH_ISSUER).toBe('http://127.0.0.1:18788');
+    expect(environment.THREADNOTE_REMOTE_ALLOWED_HOSTS.split(',')).toEqual(
+      expect.arrayContaining(['127.0.0.1:18788', 'localhost:18788']),
+    );
+    const config = remoteMemoryConfigFromEnvironment(environment);
+    expect(config.canonicalStore).toBe('git');
+    expect(config.gitWorktree).toBe('/tmp/threadnote-share-default');
+    expect(config.accessTokenIssuer).toBe('http://127.0.0.1:18788');
+    expect(config.accessTokenAudience).toBe('http://127.0.0.1:18788/mcp');
+    expect(config.allowedOrigins).toEqual(
+      expect.arrayContaining(['https://cursor.com', 'http://127.0.0.1:8787', 'http://localhost:8787']),
+    );
+    expect(config.gitPush).toBe(false);
+    expect(
+      remoteMemoryConfigFromEnvironment(
+        composerServeEnvironment({
+          databaseUrl: 'postgres://threadnote@127.0.0.1/threadnote',
+          gitCloneUrl: 'git@github.com:Kashkovsky/threadnote-share.git',
+          gitPush: true,
+          gitWorktree: '/tmp/threadnote-share-default',
+          listenAddress,
+          shareId: 'default',
+          subject: 'local:tester',
+        }),
+      ).gitPush,
+    ).toBe(true);
+  });
+
+  it('stops a started composer listener when startup fails after listen', async () => {
+    const workers = new AbortController();
+    let stopped = false;
+    let closed = false;
+    await releaseFailedComposerStart({
+      closeControlPlane: async () => {
+        closed = true;
+      },
+      server: {
+        stop: async () => {
+          stopped = true;
+        },
+      },
+      workerTasks: [],
+      workers,
+    });
+    expect(workers.signal.aborted).toBe(true);
+    expect(stopped).toBe(true);
+    expect(closed).toBe(true);
+  });
+
+  it('binds the provisioned control-plane share id to the existing Git team name', () => {
+    expect(resolveComposerServeShareId('default')).toBe('default');
+    expect(resolveComposerServeShareId('default', ' share-engineering ')).toBe('share-engineering');
+    expect(() => resolveComposerServeShareId('default', 'share:other')).toThrow('opaque identifier');
+  });
+});

--- a/test/unit/cursor-cloud.test.ts
+++ b/test/unit/cursor-cloud.test.ts
@@ -131,6 +131,10 @@ describe('Cursor Cloud profile', () => {
           type: 'stdio',
         },
         'threadnote-memory': {
+          auth: {
+            CLIENT_ID: 'threadnote-composer',
+            scopes: ['memory:read', 'memory:write:durable', 'memory:write:handoff'],
+          },
           headers: {'threadnote-share-id': 'share-engineering'},
           url: 'https://memory.threadnote.io/mcp',
         },
@@ -138,7 +142,7 @@ describe('Cursor Cloud profile', () => {
     });
     expect(Object.keys(config.mcpServers['threadnote-memory'].headers)).toEqual(['threadnote-share-id']);
     expect(new URL(config.mcpServers['threadnote-memory'].url).search).toBe('');
-    expect(JSON.stringify(config)).not.toMatch(/authorization|bearer|token|secret/i);
+    expect(JSON.stringify(config)).not.toMatch(/authorization|bearer|CLIENT_SECRET|secret/i);
   });
 
   it('accepts only the server-supported opaque remote share ID grammar without reflecting rejected values', () => {

--- a/test/unit/git-canonical-store.test.ts
+++ b/test/unit/git-canonical-store.test.ts
@@ -5,7 +5,9 @@ import {dirname, join} from '../helpers/node-path.js';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
 import {
   GitCanonicalMemoryStore,
+  ensureLiveGitShareWorktree,
   gitCanonicalSharePath,
+  gitRemoteUrlsMatch,
   parseGitCanonicalSharePath,
 } from '../../src/remote_memory/git_canonical_store.js';
 import {cloneGitShareWorktree, createGitShareWorktreeFixture, git} from '../helpers/git-share-worktree.js';
@@ -32,6 +34,58 @@ describe('git canonical memory store', () => {
     expect(parseGitCanonicalSharePath('durable/projects/x')).toBeUndefined();
     expect(parseGitCanonicalSharePath('durable/projects/x/y.txt')).toBeUndefined();
     expect(parseGitCanonicalSharePath('../durable/projects/x/y.md')).toBeUndefined();
+  });
+
+  it('refuses an empty git worktree and clones a live team share instead', async () => {
+    const fixture = await createGitShareWorktreeFixture();
+    try {
+      const missing = join(fixture.root, 'missing');
+      expect(await ensureLiveGitShareWorktree({cloneUrl: fixture.remote, worktree: missing})).toBe(missing);
+      expect((await git(['rev-parse', '--verify', 'HEAD'], missing)).trim()).toMatch(/^[0-9a-f]{40}$/u);
+      const emptyDir = join(fixture.root, 'empty-dir');
+      await mkdir(emptyDir, {recursive: true});
+      expect(await ensureLiveGitShareWorktree({cloneUrl: fixture.remote, worktree: emptyDir})).toBe(emptyDir);
+      const emptyRepo = join(fixture.root, 'empty-repo');
+      await mkdir(emptyRepo, {recursive: true});
+      await git(['init'], emptyRepo);
+      await expect(ensureLiveGitShareWorktree({cloneUrl: fixture.remote, worktree: emptyRepo})).rejects.toMatchObject({
+        message: expect.stringContaining('no commits'),
+      });
+      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      await expect(store.assertLiveShare()).resolves.toBeUndefined();
+      await expect(ensureLiveGitShareWorktree({cloneUrl: fixture.remote, worktree: fixture.worktree})).resolves.toBe(
+        fixture.worktree,
+      );
+      const mismatched = join(fixture.root, 'mismatched');
+      await cloneGitShareWorktree(fixture.remote, mismatched);
+      await git(['remote', 'set-url', 'origin', join(fixture.root, 'other.git')], mismatched);
+      await expect(ensureLiveGitShareWorktree({cloneUrl: fixture.remote, worktree: mismatched})).rejects.toMatchObject({
+        message: expect.stringContaining('does not match the live team share'),
+      });
+    } finally {
+      await rm(fixture.root, {force: true, recursive: true});
+    }
+  });
+
+  it('treats ssh, https, and file aliases of the same remote as equal', () => {
+    expect(
+      gitRemoteUrlsMatch(
+        'git@github.com:Kashkovsky/threadnote-share.git',
+        'https://github.com/Kashkovsky/threadnote-share.git',
+      ),
+    ).toBe(true);
+    expect(gitRemoteUrlsMatch('file:///tmp/share.git', '/tmp/share.git')).toBe(true);
+    expect(gitRemoteUrlsMatch('git@github.com:Kashkovsky/threadnote-share.git', 'git@github.com:other/repo.git')).toBe(
+      false,
+    );
+    FC.assert(
+      FC.property(portableSegment, portableSegment, (owner, repo) => {
+        const https = `https://github.com/${owner}/${repo}.git`;
+        expect(gitRemoteUrlsMatch(`git@github.com:${owner}/${repo}.git`, https)).toBe(true);
+        expect(gitRemoteUrlsMatch(`ssh://git@github.com/${owner}/${repo}`, https)).toBe(true);
+        expect(gitRemoteUrlsMatch(https, `https://github.com/${owner}/${repo}/`)).toBe(true);
+      }),
+    );
   });
 
   it('commits a memory body, hashes it, and reads the same blob back', async () => {

--- a/test/unit/local-idp.test.ts
+++ b/test/unit/local-idp.test.ts
@@ -1,0 +1,199 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {createOAuthTokenVerifier, createLocalOAuthTokenVerifier} from '../../src/remote_memory/oauth.js';
+import {
+  COMPOSER_OAUTH_CLIENT_ID,
+  COMPOSER_OAUTH_REDIRECT_URIS,
+  createLocalIdp,
+  pkceS256Challenge,
+} from '../../src/remote_memory/local_idp.js';
+
+const ISSUER = 'http://127.0.0.1:18788';
+const AUDIENCE = 'http://127.0.0.1:18788/mcp';
+const SUBJECT = 'local:tester';
+const REDIRECT = COMPOSER_OAUTH_REDIRECT_URIS[0];
+const PKCE_VERIFIER = FC.stringMatching(/^[A-Za-z0-9-._~]{43,96}$/u);
+
+async function localIdp() {
+  return createLocalIdp({audience: AUDIENCE, issuer: ISSUER, subject: SUBJECT});
+}
+
+async function jsonBody(response: Response | undefined): Promise<Record<string, unknown>> {
+  expect(response).toBeInstanceOf(Response);
+  return (await (response as Response).json()) as Record<string, unknown>;
+}
+
+describe('local composer OAuth issuer', () => {
+  it('rejects a non-loopback HTTP issuer', async () => {
+    await expect(
+      createLocalIdp({audience: AUDIENCE, issuer: 'http://identity.example.test', subject: SUBJECT}),
+    ).rejects.toMatchObject({message: expect.stringContaining('HTTPS')});
+  });
+
+  it('issues an RS256 access token that both verifiers accept', async () => {
+    const idp = await localIdp();
+    const token = await idp.issueAccessToken();
+    const claims = await idp.verifier().verify(token);
+    expect(claims).toEqual({
+      issuer: ISSUER,
+      scopes: new Set(['memory:read', 'memory:write:durable', 'memory:write:handoff']),
+      subject: SUBJECT,
+    });
+    expect(
+      await createLocalOAuthTokenVerifier({audience: AUDIENCE, issuer: ISSUER, publicKey: idp.publicKey}).verify(token),
+    ).toEqual(claims);
+  });
+
+  it('advertises authorization-server metadata, JWKS, and a static public client', async () => {
+    const idp = await localIdp();
+    const metadata = await idp.handle(new Request(`${ISSUER}/.well-known/oauth-authorization-server`));
+    const jwks = await idp.handle(new Request(`${ISSUER}/.well-known/jwks.json`));
+    const registered = await idp.handle(new Request(`${ISSUER}/register`, {method: 'POST', body: '{}'}));
+    expect(metadata?.status).toBe(200);
+    expect(await jsonBody(metadata)).toMatchObject({
+      authorization_endpoint: `${ISSUER}/authorize`,
+      code_challenge_methods_supported: ['S256'],
+      grant_types_supported: ['authorization_code'],
+      issuer: ISSUER,
+      jwks_uri: `${ISSUER}/.well-known/jwks.json`,
+      token_endpoint: `${ISSUER}/token`,
+      token_endpoint_auth_methods_supported: ['none'],
+    });
+    expect((await jsonBody(jwks)).keys).toEqual([expect.objectContaining({alg: 'RS256'})]);
+    expect(registered?.status).toBe(201);
+    expect(await jsonBody(registered)).toMatchObject({
+      client_id: COMPOSER_OAUTH_CLIENT_ID,
+      token_endpoint_auth_method: 'none',
+    });
+  });
+
+  it('completes authorization-code PKCE and rejects client-credentials grants', async () => {
+    const idp = await localIdp();
+    const verifier = 'a'.repeat(43);
+    const authorize = await idp.handle(
+      new Request(
+        `${ISSUER}/authorize?client_id=${COMPOSER_OAUTH_CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT)}&response_type=code&code_challenge=${pkceS256Challenge(verifier)}&code_challenge_method=S256&state=xyz`,
+      ),
+    );
+    expect(authorize?.status).toBe(302);
+    const location = new URL(authorize?.headers.get('location') ?? '');
+    expect(location.origin + location.pathname).toBe(REDIRECT);
+    expect(location.searchParams.get('state')).toBe('xyz');
+    const code = location.searchParams.get('code');
+    expect(code).toBeTruthy();
+    const token = await idp.handle(
+      new Request(`${ISSUER}/token`, {
+        body: new URLSearchParams({
+          client_id: COMPOSER_OAUTH_CLIENT_ID,
+          code: code ?? '',
+          code_verifier: verifier,
+          grant_type: 'authorization_code',
+          redirect_uri: REDIRECT,
+        }).toString(),
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+        method: 'POST',
+      }),
+    );
+    expect(token?.status).toBe(200);
+    const body = (await token?.json()) as {access_token: string; token_type: string};
+    expect(body.token_type).toBe('Bearer');
+    expect(await idp.verifier().verify(body.access_token)).toMatchObject({subject: SUBJECT});
+
+    const credentials = await idp.handle(
+      new Request(`${ISSUER}/token`, {
+        body: new URLSearchParams({
+          client_id: COMPOSER_OAUTH_CLIENT_ID,
+          grant_type: 'client_credentials',
+        }).toString(),
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+        method: 'POST',
+      }),
+    );
+    expect(credentials?.status).toBe(400);
+    expect(await credentials?.json()).toEqual({error: 'unsupported_grant_type'});
+
+    const missingClient = await idp.handle(
+      new Request(`${ISSUER}/token`, {
+        body: new URLSearchParams({
+          code: code ?? '',
+          code_verifier: verifier,
+          grant_type: 'authorization_code',
+          redirect_uri: REDIRECT,
+        }).toString(),
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+        method: 'POST',
+      }),
+    );
+    expect(missingClient?.status).toBe(401);
+    expect(await missingClient?.json()).toEqual({error: 'invalid_client'});
+
+    const extraLoopback = await idp.handle(
+      new Request(
+        `${ISSUER}/authorize?client_id=${COMPOSER_OAUTH_CLIENT_ID}&redirect_uri=${encodeURIComponent('http://127.0.0.1:9999/callback')}&response_type=code&code_challenge=${pkceS256Challenge(verifier)}&code_challenge_method=S256`,
+      ),
+    );
+    expect(extraLoopback?.status).toBe(400);
+    expect(await extraLoopback?.json()).toMatchObject({error: 'invalid_request'});
+  });
+
+  it('rejects a PKCE verifier that does not match the authorization challenge', async () => {
+    const idp = await localIdp();
+    const authorize = await idp.handle(
+      new Request(
+        `${ISSUER}/authorize?client_id=${COMPOSER_OAUTH_CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT)}&response_type=code&code_challenge=${pkceS256Challenge('a'.repeat(43))}&code_challenge_method=S256`,
+      ),
+    );
+    const code = new URL(authorize?.headers.get('location') ?? '').searchParams.get('code');
+    const token = await idp.handle(
+      new Request(`${ISSUER}/token`, {
+        body: new URLSearchParams({
+          client_id: COMPOSER_OAUTH_CLIENT_ID,
+          code: code ?? '',
+          code_verifier: 'b'.repeat(43),
+          grant_type: 'authorization_code',
+          redirect_uri: REDIRECT,
+        }).toString(),
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+        method: 'POST',
+      }),
+    );
+    expect(token?.status).toBe(400);
+    expect(await token?.json()).toEqual({error: 'invalid_grant'});
+  });
+
+  it('lets createOAuthTokenVerifier fetch the local JWKS', async () => {
+    const idp = await localIdp();
+    const server = Bun.serve({
+      fetch(request) {
+        if (new URL(request.url).pathname !== '/.well-known/jwks.json') {
+          return new Response('not found', {status: 404});
+        }
+        return Response.json({keys: [idp.publicJwk]});
+      },
+      hostname: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      const token = await idp.issueAccessToken();
+      await expect(
+        createOAuthTokenVerifier({
+          audience: AUDIENCE,
+          issuer: ISSUER,
+          jwksUrl: new URL('/.well-known/jwks.json', server.url),
+        }).verify(token),
+      ).resolves.toMatchObject({issuer: ISSUER, subject: SUBJECT});
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  it('computes a deterministic S256 challenge for any legal PKCE verifier', () => {
+    FC.assert(
+      FC.property(PKCE_VERIFIER, verifier => {
+        const challenge = pkceS256Challenge(verifier);
+        expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/u);
+        expect(pkceS256Challenge(verifier)).toBe(challenge);
+      }),
+    );
+  });
+});

--- a/test/unit/mcp-json-idempotence.property.test.ts
+++ b/test/unit/mcp-json-idempotence.property.test.ts
@@ -33,6 +33,7 @@ it.effect.prop(
         const baseSystem = yield* SystemInfo;
         const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-json-mcp-property-'});
         const user = path.join(root, 'user');
+        const home = path.join(user, '.threadnote');
         const bin = path.join(root, 'bin');
         const broker = path.join(bin, 'threadnote-mcp-server');
         const configPath = path.join(user, '.cursor', 'mcp.json');
@@ -40,10 +41,15 @@ it.effect.prop(
           EXTRA_USER_VALUE: extraEnvironmentValue,
           THREADNOTE_ACCOUNT: 'local',
           THREADNOTE_AGENT_ID: 'threadnote',
-          THREADNOTE_HOME: '/tmp/threadnote-test',
+          THREADNOTE_HOME: home,
           THREADNOTE_MCP_CLIENT: 'cursor',
           THREADNOTE_MCP_TOOLSET: 'core',
           THREADNOTE_USER: 'test-user',
+        };
+        const testRuntime: RuntimeConfig = {
+          ...runtime,
+          agentContextHome: home,
+          manifestPath: path.join(home, 'seed-manifest.yaml'),
         };
         const server = reverseEntryOrder
           ? {userMetadata: extraFieldValue, env: environment, args: [], command: broker}
@@ -64,7 +70,7 @@ it.effect.prop(
         yield* fs.makeDirectory(path.dirname(configPath), {recursive: true});
         yield* fs.writeFileString(configPath, original);
 
-        yield* runMcpInstall(runtime, 'cursor', {apply: true}).pipe(Effect.provideService(SystemInfo, testSystem));
+        yield* runMcpInstall(testRuntime, 'cursor', {apply: true}).pipe(Effect.provideService(SystemInfo, testSystem));
 
         expect(yield* fs.readFileString(configPath)).toBe(original);
       }),

--- a/test/unit/mcp.doctor.test.ts
+++ b/test/unit/mcp.doctor.test.ts
@@ -158,7 +158,7 @@ describe('MCP doctor checks', () => {
           platform: 'linux',
         });
 
-        const checks = yield* mcpConfigurationChecks(runtime(path.join(root, '.threadnote'))).pipe(
+        const checks = yield* mcpConfigurationChecks(runtime(path.join(user, '.threadnote'))).pipe(
           Effect.provideService(SystemInfo, testSystem),
         );
         for (const name of ['codex MCP', 'cursor MCP']) {
@@ -195,7 +195,7 @@ describe('MCP doctor checks', () => {
         );
         const testSystem = SystemInfo.of({...system, homeDirectory: user, platform: 'win32'});
 
-        const checks = yield* mcpConfigurationChecks(runtime(path.join(root, '.threadnote'))).pipe(
+        const checks = yield* mcpConfigurationChecks(runtime(path.join(user, '.threadnote'))).pipe(
           Effect.provideService(SystemInfo, testSystem),
         );
         expect(checks).toContainEqual({
@@ -203,6 +203,40 @@ describe('MCP doctor checks', () => {
           name: 'cursor MCP',
           status: 'ok',
         });
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  it.effect('does not inspect Cursor MCP when THREADNOTE_HOME is not the personal home', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mcp-doctor-enterprise-'});
+        const user = path.join(root, 'user');
+        const enterpriseHome = path.join(root, 'homes', 'contributor-a');
+        const cursorConfig = path.join(user, '.cursor', 'mcp.json');
+        yield* fs.makeDirectory(path.dirname(cursorConfig), {recursive: true});
+        yield* fs.makeDirectory(enterpriseHome, {recursive: true});
+        yield* fs.writeFileString(
+          cursorConfig,
+          JSON.stringify({
+            mcpServers: {
+              threadnote: {command: '/home/test/.local/bin/threadnote-mcp-server'},
+              'threadnote-org': {
+                headers: {'threadnote-share-id': 'default'},
+                url: 'http://127.0.0.1:18788/mcp',
+              },
+            },
+          }),
+        );
+        const testSystem = SystemInfo.of({...system, homeDirectory: user, platform: 'linux'});
+        const checks = yield* mcpConfigurationChecks(runtime(enterpriseHome)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(checks.filter(check => check.name === 'cursor MCP' || check.name === 'copilot MCP')).toEqual([]);
+        expect(JSON.stringify(yield* fs.readFileString(cursorConfig))).toContain('threadnote-org');
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -102,17 +102,20 @@ describe('MCP toolsets', () => {
       const path = yield* Path.Path;
       const binDirectory = '/opt/threadnote/bin';
       const brokerLauncher = path.join(binDirectory, 'threadnote-mcp-server');
+      const userHome = '/tmp/threadnote-mcp-host-user';
+      const testRuntime = runtime(path.join(userHome, '.threadnote'));
       const testSystem = SystemInfo.of({
         ...baseSystem,
         environment: () => ({
           ...baseSystem.environment(),
           THREADNOTE_BIN_DIR: binDirectory,
         }),
+        homeDirectory: userHome,
         platform: 'linux',
       });
 
       for (const agent of ['codex', 'claude', 'cursor', 'copilot'] as const) {
-        const result = yield* captureConsole(runMcpInstall(runtime(), agent, {})).pipe(
+        const result = yield* captureConsole(runMcpInstall(testRuntime, agent, {})).pipe(
           Effect.provideService(SystemInfo, testSystem),
         );
         const renderedBrokerLauncher =

--- a/test/unit/org-mcp-attach.test.ts
+++ b/test/unit/org-mcp-attach.test.ts
@@ -1,0 +1,624 @@
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {TestClock} from 'effect/testing';
+import {afterEach, describe as vitestDescribe, it, vi} from 'vitest';
+import {captureConsole} from '../../src/effect/console.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {THREADNOTE_MCP_NAME} from '../../src/constants.js';
+import {
+  CURSOR_CLOUD_LOCAL_MCP_TOOLSET,
+  CURSOR_CLOUD_MEMORY_ENDPOINT_ENV,
+  CURSOR_CLOUD_MODE_ENV,
+  buildCursorCloudProfile,
+  buildOrgCloudHybridMcpConfig,
+  cursorCloudMemoryEndpoint,
+  cursorCloudRemoteHybridStatus,
+} from '../../src/cursor/cloud.js';
+import {isPersonalThreadnoteHome, removeMcpConfigs, runMcpInstall} from '../../src/mcp/index.js';
+import {
+  ORG_COMPOSER_POLICY,
+  THREADNOTE_COMPOSER_SHARE_ID_HEADER,
+  THREADNOTE_ORG_MCP_NAME,
+  buildComposerHttpMcpEntry,
+  composerHttpEntryMatches,
+  composerMcpUrl,
+  composerShareId,
+  isManagedComposerHttpEntry,
+  resolveComposerAttach,
+  stdioEnvironmentCallsComposer,
+  teamStdioServers,
+  withComposerHttpMcpEntry,
+} from '../../src/mcp/composer_attach.js';
+import {mcpToolCapabilities, parseMcpToolset} from '../../src/mcp/toolset.js';
+import {runRemember} from '../../src/memory/index.js';
+import {runSharePublishTool} from '../../src/mcp/server/share.js';
+import type {JsonObject, RuntimeConfig} from '../../src/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const runtimeConfig = (home: string): RuntimeConfig => ({
+  account: 'local',
+  agentContextHome: home,
+  agentId: 'threadnote',
+  manifestPath: `${home}/seed-manifest.yaml`,
+  user: 'tester',
+});
+
+const profile = buildCursorCloudProfile(runtimeConfig('/tmp/threadnote-org-mcp'), {
+  agentId: 'cloud-agent',
+  user: 'cloud-user',
+});
+
+const SHARE_ID = FC.stringMatching(/^[A-Za-z0-9][A-Za-z0-9._-]{0,40}$/u);
+const HOST = FC.constantFrom('composer.example.test', 'memory.example.test', 'org.example.test');
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('organization composer attach', () => {
+  effectIt.effect.prop(
+    'keeps stdio core Git share and binds composer share only in the HTTP header',
+    {host: HOST, shareId: SHARE_ID},
+    ({host, shareId}) =>
+      Effect.sync(() => {
+        const url = `https://${host}/mcp`;
+        const stdio = {
+          command: '/bin/threadnote-mcp-server',
+          env: {
+            THREADNOTE_MCP_TOOLSET: 'core',
+            THREADNOTE_USER: 'tester',
+          },
+        } satisfies JsonObject;
+        const servers = teamStdioServers(stdio, resolveComposerAttach({composerUrl: url, shareId}));
+        const capabilities = mcpToolCapabilities(parseMcpToolset('core'));
+        expect(capabilities.graphLocal).toBe(true);
+        expect(capabilities.memoryPublish).toBe(true);
+        expect(servers[THREADNOTE_MCP_NAME]).toEqual(stdio);
+        expect(stdioEnvironmentCallsComposer(stdio.env)).toBe(false);
+        expect(
+          composerHttpEntryMatches(servers[THREADNOTE_ORG_MCP_NAME], buildComposerHttpMcpEntry(url, shareId)),
+        ).toBe(true);
+        expect(JSON.stringify(servers[THREADNOTE_ORG_MCP_NAME])).not.toMatch(
+          /authorization|bearer|CLIENT_SECRET|secret/i,
+        );
+        expect(new URL((servers[THREADNOTE_ORG_MCP_NAME] as {url: string}).url).search).toBe('');
+        expect(ORG_COMPOSER_POLICY).toEqual({
+          canonicalStore: 'git',
+          cursorOidc: 'optional-attribution',
+          oauth: 'org-idp',
+          shareBinding: 'header',
+        });
+        expect(isManagedComposerHttpEntry(servers[THREADNOTE_ORG_MCP_NAME])).toBe(true);
+        expect(() =>
+          withComposerHttpMcpEntry(
+            {},
+            THREADNOTE_ORG_MCP_NAME,
+            stdio,
+            resolveComposerAttach({composerUrl: url, shareId}),
+          ),
+        ).toThrow('reserved HTTP server name');
+      }),
+  );
+
+  it('rejects invalid share IDs without reflecting them', () => {
+    for (const shareId of ['share:other', '-leading-hyphen', `${'a'.repeat(128)}b`]) {
+      let message = '';
+      try {
+        composerShareId(shareId);
+      } catch (cause) {
+        message = cause instanceof Error ? cause.message : String(cause);
+      }
+      expect(message).toContain('opaque identifier');
+      expect(message).not.toContain(shareId);
+    }
+  });
+
+  it('rejects credential-bearing composer URLs without reflecting them', () => {
+    const endpoint = 'https://owner:credential@composer.example.test/mcp';
+    expect(() => composerMcpUrl(endpoint)).toThrow('credential-free');
+    try {
+      composerMcpUrl(endpoint);
+    } catch (cause) {
+      expect(String(cause)).not.toContain(endpoint);
+      expect(String(cause)).not.toContain('credential@');
+    }
+    expect(() => composerMcpUrl('https://composer.example.test/mcp?share=other')).toThrow('query');
+    expect(() => resolveComposerAttach({composerUrl: 'https://composer.example.test/mcp'})).toThrow(
+      '--composer-url and --share-id',
+    );
+  });
+
+  it('allows loopback HTTP for local composer attach and requires HTTPS otherwise', () => {
+    expect(composerMcpUrl('http://127.0.0.1:18788/mcp')).toBe('http://127.0.0.1:18788/mcp');
+    expect(composerMcpUrl('http://localhost:18788/mcp')).toBe('http://127.0.0.1:18788/mcp');
+    expect(() => composerMcpUrl('http://composer.example.test/mcp')).toThrow('HTTPS');
+  });
+
+  it('treats only ~/.threadnote as the personal home', () => {
+    const resolve = (...parts: string[]) => parts.join('/');
+    expect(isPersonalThreadnoteHome('/Users/denys/.threadnote', '/Users/denys', resolve)).toBe(true);
+    expect(isPersonalThreadnoteHome('/homes/contributor-a', '/Users/denys', resolve)).toBe(false);
+  });
+});
+
+vitestDescribe('organization cloud hybrid MCP', () => {
+  it('binds memory HTTP to the Git-backed composer with org IdP OAuth', () => {
+    const config = buildOrgCloudHybridMcpConfig(profile, 'https://composer.example.test/mcp', 'share-engineering');
+    expect(config.policy).toEqual(ORG_COMPOSER_POLICY);
+    expect(config.mcpServers['threadnote-local'].env.THREADNOTE_MCP_TOOLSET).toBe(CURSOR_CLOUD_LOCAL_MCP_TOOLSET);
+    expect(config.mcpServers['threadnote-local'].env.THREADNOTE_CURSOR_CLOUD_MODE).toBe('org');
+    expect(mcpToolCapabilities(parseMcpToolset(CURSOR_CLOUD_LOCAL_MCP_TOOLSET)).memoryPublish).toBe(false);
+    expect(mcpToolCapabilities(parseMcpToolset(CURSOR_CLOUD_LOCAL_MCP_TOOLSET)).graphLocal).toBe(true);
+    expect(config.mcpServers[THREADNOTE_ORG_MCP_NAME]).toEqual({
+      auth: {
+        CLIENT_ID: 'threadnote-composer',
+        scopes: ['memory:read', 'memory:write:durable', 'memory:write:handoff'],
+      },
+      headers: {[THREADNOTE_COMPOSER_SHARE_ID_HEADER]: 'share-engineering'},
+      url: 'https://composer.example.test/mcp',
+    });
+    expect(JSON.stringify(config)).not.toMatch(/postgres|markdown_body/i);
+    expect(JSON.stringify(config)).not.toMatch(/authorization|bearer|CLIENT_SECRET|secret/i);
+  });
+});
+
+describe('Team MCP install composer attach', () => {
+  effectIt.effect('stdio-only Team install never writes a composer URL or endpoint', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-stdio-only-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const cursorPath = path.join(user, '.cursor', 'mcp.json');
+        const testRuntime = runtimeConfig(path.join(user, '.threadnote'));
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        yield* captureConsole(runMcpInstall(testRuntime, 'cursor', {apply: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        const installed = JSON.parse(yield* fs.readFileString(cursorPath)) as {
+          mcpServers: Record<string, {env?: Record<string, string>; url?: string}>;
+        };
+        expect(installed.mcpServers[THREADNOTE_MCP_NAME]?.env?.THREADNOTE_MCP_TOOLSET).toBe('core');
+        expect(stdioEnvironmentCallsComposer(installed.mcpServers[THREADNOTE_MCP_NAME]?.env ?? {})).toBe(false);
+        expect(installed.mcpServers[THREADNOTE_ORG_MCP_NAME]).toBeUndefined();
+        expect(JSON.stringify(installed)).not.toContain(CURSOR_CLOUD_MEMORY_ENDPOINT_ENV);
+        expect(JSON.stringify(installed)).not.toContain('composer.example.test');
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('attaches composer HTTP without removing stdio Git share or calling composer from stdio', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-attach-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const project = path.join(root, 'fixture-repo');
+        const cursorPath = path.join(project, '.cursor', 'mcp.json');
+        const personalCursorPath = path.join(user, '.cursor', 'mcp.json');
+        const home = path.join(user, '.threadnote');
+        const testRuntime = runtimeConfig(home);
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.makeDirectory(home, {recursive: true});
+        yield* fs.makeDirectory(project, {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        yield* fs.writeFileString(path.join(home, 'seed-manifest.yaml'), 'version: 1\nprojects: []\n');
+        yield* captureConsole(
+          runMcpInstall(testRuntime, 'cursor', {
+            apply: true,
+            composerUrl: 'https://composer.example.test/mcp',
+            project,
+            shareId: 'share-engineering',
+          }),
+        ).pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(yield* fs.exists(personalCursorPath)).toBe(false);
+        const installed = JSON.parse(yield* fs.readFileString(cursorPath)) as {
+          mcpServers: Record<string, {env?: Record<string, string>; headers?: Record<string, string>; url?: string}>;
+        };
+        const stdio = installed.mcpServers[THREADNOTE_MCP_NAME];
+        const composer = installed.mcpServers[THREADNOTE_ORG_MCP_NAME];
+        expect(stdio?.env?.THREADNOTE_MCP_TOOLSET).toBe('core');
+        expect(stdioEnvironmentCallsComposer(stdio?.env ?? {})).toBe(false);
+        expect(JSON.stringify(stdio?.env ?? {})).not.toMatch(/attest|oidc|CURSOR_AGENT_SOCKET/i);
+        expect(composer).toEqual(buildComposerHttpMcpEntry('https://composer.example.test/mcp', 'share-engineering'));
+        expect(mcpToolCapabilities(parseMcpToolset('core')).memoryPublish).toBe(true);
+
+        const fetchSpy = vi.fn(() => Promise.reject(new Error('composer down')));
+        vi.stubGlobal('fetch', fetchSpy);
+        yield* TestClock.setTime(Date.parse('2026-09-05T08:00:00.000Z'));
+        yield* runRemember(testRuntime, {
+          kind: 'durable',
+          project: 'threadnote',
+          sourceAgentClient: 'test',
+          text: 'Team laptop remembers while composer is down.',
+          topic: 'org-mcp-attach',
+        }).pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(
+          yield* fs.exists(
+            path.join(
+              home,
+              'data',
+              'local',
+              'user',
+              'tester',
+              'memories',
+              'durable',
+              'projects',
+              'threadnote',
+              'org-mcp-attach.md',
+            ),
+          ),
+        ).toBe(true);
+
+        const worktree = path.join(home, 'share', 'worktrees', 'default');
+        yield* fs.makeDirectory(worktree, {recursive: true});
+        yield* fs.makeDirectory(path.join(home, 'share'), {recursive: true});
+        yield* fs.writeFileString(
+          path.join(home, 'share', 'teams.json'),
+          `${JSON.stringify(
+            {
+              defaultTeam: 'default',
+              teams: {
+                default: {
+                  addedAt: '2026-09-05T08:00:00.000Z',
+                  gitdir: path.join(home, 'share', 'teams', 'default.gitdir'),
+                  name: 'default',
+                  remote: 'git@example.com:team/memories.git',
+                  worktree,
+                },
+              },
+              version: 1,
+            },
+            undefined,
+            2,
+          )}\n`,
+        );
+        const published = yield* runSharePublishTool(
+          testRuntime,
+          'threadnote://user/tester/memories/durable/projects/threadnote/org-mcp-attach.md',
+          {preview: true},
+        );
+        expect(published.isError).toBeUndefined();
+        expect(fetchSpy).not.toHaveBeenCalled();
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('stdio-only reinstall preserves an existing composer HTTP entry', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-preserve-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const cursorPath = path.join(user, '.cursor', 'mcp.json');
+        const testRuntime = runtimeConfig(path.join(user, '.threadnote'));
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(path.dirname(cursorPath), {recursive: true});
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        yield* fs.writeFileString(
+          cursorPath,
+          `${JSON.stringify(
+            {
+              mcpServers: {
+                [THREADNOTE_ORG_MCP_NAME]: {
+                  headers: {[THREADNOTE_COMPOSER_SHARE_ID_HEADER]: 'share-engineering'},
+                  url: 'https://composer.example.test/mcp',
+                },
+              },
+            },
+            undefined,
+            2,
+          )}\n`,
+        );
+        yield* captureConsole(runMcpInstall(testRuntime, 'cursor', {apply: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        const installed = JSON.parse(yield* fs.readFileString(cursorPath)) as {
+          mcpServers: Record<string, unknown>;
+        };
+        expect(installed.mcpServers[THREADNOTE_MCP_NAME]).toMatchObject({
+          env: {THREADNOTE_MCP_TOOLSET: 'core'},
+        });
+        expect(installed.mcpServers[THREADNOTE_ORG_MCP_NAME]).toEqual({
+          headers: {[THREADNOTE_COMPOSER_SHARE_ID_HEADER]: 'share-engineering'},
+          url: 'https://composer.example.test/mcp',
+        });
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('rejects --name threadnote-org when attaching composer', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-name-collision-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const testRuntime = runtimeConfig(path.join(user, '.threadnote'));
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        const error = yield* runMcpInstall(testRuntime, 'cursor', {
+          apply: true,
+          composerUrl: 'https://composer.example.test/mcp',
+          name: THREADNOTE_ORG_MCP_NAME,
+          project: path.join(root, 'fixture-repo'),
+          shareId: 'share-engineering',
+        }).pipe(Effect.provideService(SystemInfo, testSystem), Effect.flip);
+        expect(error).toMatchObject({message: expect.stringContaining('reserved for the HTTP composer entry')});
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('refuses composer attach that would rewrite personal ~/.cursor/mcp.json', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-no-global-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const personalCursorPath = path.join(user, '.cursor', 'mcp.json');
+        const testRuntime = runtimeConfig(path.join(user, '.threadnote'));
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        const error = yield* runMcpInstall(testRuntime, 'cursor', {
+          apply: true,
+          composerUrl: 'https://composer.example.test/mcp',
+          shareId: 'share-engineering',
+        }).pipe(Effect.provideService(SystemInfo, testSystem), Effect.flip);
+        expect(error).toMatchObject({message: expect.stringContaining('--project')});
+        expect(yield* fs.exists(personalCursorPath)).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('refuses Cursor MCP writes from a non-personal THREADNOTE_HOME without --project', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-enterprise-home-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const enterpriseHome = path.join(root, 'homes', 'contributor-a');
+        const personalCursorPath = path.join(user, '.cursor', 'mcp.json');
+        const testRuntime = runtimeConfig(enterpriseHome);
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        const error = yield* runMcpInstall(testRuntime, 'cursor', {apply: true}).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+          Effect.flip,
+        );
+        expect(error).toMatchObject({message: expect.stringContaining('--project')});
+        expect(yield* fs.exists(personalCursorPath)).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('uninstall of personal Cursor MCP leaves project composer attach in place', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-uninstall-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const project = path.join(root, 'fixture-repo');
+        const cursorPath = path.join(project, '.cursor', 'mcp.json');
+        const personalCursorPath = path.join(user, '.cursor', 'mcp.json');
+        const testRuntime = runtimeConfig(path.join(user, '.threadnote'));
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.makeDirectory(path.dirname(personalCursorPath), {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        yield* fs.writeFileString(
+          personalCursorPath,
+          `${JSON.stringify({mcpServers: {[THREADNOTE_MCP_NAME]: {command: 'personal-stdio'}}}, undefined, 2)}\n`,
+        );
+        yield* captureConsole(
+          runMcpInstall(testRuntime, 'cursor', {
+            apply: true,
+            composerUrl: 'https://composer.example.test/mcp',
+            project,
+            shareId: 'share-engineering',
+          }),
+        ).pipe(Effect.provideService(SystemInfo, testSystem));
+        yield* captureConsole(removeMcpConfigs('cursor', false)).pipe(Effect.provideService(SystemInfo, testSystem));
+        const remaining = JSON.parse(yield* fs.readFileString(cursorPath)) as {
+          mcpServers: Record<string, unknown>;
+        };
+        expect(remaining.mcpServers[THREADNOTE_ORG_MCP_NAME]).toEqual(
+          buildComposerHttpMcpEntry('https://composer.example.test/mcp', 'share-engineering'),
+        );
+        const personal = JSON.parse(yield* fs.readFileString(personalCursorPath)) as {
+          mcpServers: Record<string, unknown>;
+        };
+        expect(personal.mcpServers[THREADNOTE_ORG_MCP_NAME]).toBeUndefined();
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('uninstall leaves a non-matching threadnote-org entry', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-keep-custom-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const cursorPath = path.join(user, '.cursor', 'mcp.json');
+        const testRuntime = runtimeConfig(path.join(user, '.threadnote'));
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(path.dirname(cursorPath), {recursive: true});
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        yield* fs.writeFileString(
+          cursorPath,
+          `${JSON.stringify(
+            {
+              mcpServers: {
+                [THREADNOTE_MCP_NAME]: {command: 'placeholder'},
+                [THREADNOTE_ORG_MCP_NAME]: {command: 'operator-owned'},
+              },
+            },
+            undefined,
+            2,
+          )}\n`,
+        );
+        yield* captureConsole(runMcpInstall(testRuntime, 'cursor', {apply: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        yield* captureConsole(removeMcpConfigs('cursor', false)).pipe(Effect.provideService(SystemInfo, testSystem));
+        const remaining = JSON.parse(yield* fs.readFileString(cursorPath)) as {
+          mcpServers: Record<string, unknown>;
+        };
+        expect(remaining.mcpServers[THREADNOTE_MCP_NAME]).toBeUndefined();
+        expect(remaining.mcpServers[THREADNOTE_ORG_MCP_NAME]).toEqual({command: 'operator-owned'});
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+});
+
+vitestDescribe('organization cloud hybrid verify', () => {
+  effectIt.effect('reports unverified composer OAuth as warn and optional Cursor OIDC', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-verify-'});
+        const home = path.join(root, 'home');
+        const cwd = path.join(root, 'checkout');
+        yield* fs.makeDirectory(home, {recursive: true});
+        yield* fs.makeDirectory(cwd, {recursive: true});
+        const receipt = yield* cursorCloudRemoteHybridStatus(runtimeConfig(home), {
+          cwd,
+          endpoint: 'https://composer.example.test/mcp',
+          mode: 'org',
+          shareId: 'share-engineering',
+        }).pipe(
+          Effect.provideService(
+            SystemInfo,
+            SystemInfo.of({
+              ...baseSystem,
+              environment: () => ({...baseSystem.environment()}),
+              homeDirectory: root,
+              platform: 'linux',
+            }),
+          ),
+        );
+        expect(receipt.mode).toBe('org');
+        if (receipt.mode !== 'org') {
+          throw new Error('expected organization cloud hybrid receipt');
+        }
+        expect(receipt.cursorOidc).toBe('optional-attribution');
+        expect(receipt.oauth).toBe('org-idp');
+        expect(receipt.checks.find(check => check.name === 'composer OAuth')).toMatchObject({
+          status: 'warn',
+        });
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
+  effectIt.effect('accepts loopback HTTP when the org local-graph env is set without an explicit mode', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-status-loopback-'});
+        const home = path.join(root, 'home');
+        const cwd = path.join(root, 'checkout');
+        yield* fs.makeDirectory(home, {recursive: true});
+        yield* fs.makeDirectory(cwd, {recursive: true});
+        const receipt = yield* cursorCloudRemoteHybridStatus(runtimeConfig(home), {
+          cwd,
+          endpoint: 'http://127.0.0.1:18788/mcp',
+        }).pipe(
+          Effect.provideService(
+            SystemInfo,
+            SystemInfo.of({
+              ...baseSystem,
+              environment: () => ({
+                ...baseSystem.environment(),
+                [CURSOR_CLOUD_MEMORY_ENDPOINT_ENV]: 'http://127.0.0.1:18788/mcp',
+                [CURSOR_CLOUD_MODE_ENV]: 'org',
+                THREADNOTE_CURSOR_MEMORY_SHARE_ID: 'share-engineering',
+              }),
+              homeDirectory: root,
+              platform: 'linux',
+            }),
+          ),
+        );
+        expect(receipt.mode).toBe('org');
+        expect(receipt.endpoint).toBe('http://127.0.0.1:18788/mcp');
+        expect(() => cursorCloudMemoryEndpoint('http://127.0.0.1:18788/mcp')).toThrow('HTTPS');
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+});

--- a/test/unit/remote-memory-auth-config.test.ts
+++ b/test/unit/remote-memory-auth-config.test.ts
@@ -85,6 +85,16 @@ describe('remote memory service configuration', () => {
     expect(config.autoMigrate).toBe(true);
   });
 
+  it('accepts loopback HTTP origins for the local composer OAuth callback', () => {
+    const config = remoteMemoryConfigFromEnvironment({
+      THREADNOTE_REMOTE_ALLOWED_ORIGINS: 'https://cursor.com,http://127.0.0.1:8787,http://localhost:8787',
+      THREADNOTE_REMOTE_DATABASE_URL: 'postgres://threadnote@localhost/threadnote',
+      THREADNOTE_REMOTE_OAUTH_ISSUER: 'http://127.0.0.1:18788',
+      THREADNOTE_REMOTE_PUBLIC_URL: 'http://127.0.0.1:18788',
+    });
+    expect(config.allowedOrigins).toEqual(['https://cursor.com', 'http://127.0.0.1:8787', 'http://localhost:8787']);
+  });
+
   it('accepts only an explicit environment-wide enablement switch', () => {
     const config = remoteMemoryConfigFromEnvironment({...productionEnvironment, THREADNOTE_REMOTE_ENABLED: 'true'});
     expect(config.globallyEnabled).toBe(true);
@@ -111,6 +121,10 @@ describe('remote memory service configuration', () => {
     [{...productionEnvironment, THREADNOTE_REMOTE_ALLOWED_HOSTS: 'memory..example.test'}, 'Host'],
     [{...productionEnvironment, THREADNOTE_REMOTE_ALLOWED_ORIGINS: 'https://cursor.com/path'}, 'Origin'],
     [{...productionEnvironment, THREADNOTE_REMOTE_ALLOWED_ORIGINS: 'http://cursor.com'}, 'Origin'],
+    [
+      {...productionEnvironment, THREADNOTE_REMOTE_ALLOWED_ORIGINS: 'https://cursor.com,http://127.0.0.1:8787'},
+      'Origin',
+    ],
     [{...productionEnvironment, THREADNOTE_REMOTE_OAUTH_JWKS_URL: 'http://identity.example.test/jwks'}, 'HTTPS'],
     [{...productionEnvironment, THREADNOTE_REMOTE_CURSOR_JWKS_URL: 'http://api.cursor.com/jwks'}, 'HTTPS'],
     [{...productionEnvironment, THREADNOTE_REMOTE_PUBLIC_URL: 'https://memory.example.test/path'}, 'origin'],

--- a/test/unit/remote-memory-http.test.ts
+++ b/test/unit/remote-memory-http.test.ts
@@ -4,6 +4,8 @@ import type {AuthorizedRemotePrincipal} from '../../src/remote_memory/authorizat
 import type {RemoteMemoryServiceConfig} from '../../src/remote_memory/config.js';
 import {remoteMemoryError} from '../../src/remote_memory/errors.js';
 import {createRemoteMemoryHttpHandler} from '../../src/remote_memory/http_transport.js';
+import {createLocalIdp} from '../../src/remote_memory/local_idp.js';
+import type {LocalIdp} from '../../src/remote_memory/local_idp.js';
 import type {OAuthPrincipalClaims} from '../../src/remote_memory/oauth.js';
 import type {RemoteMemoryRecallResult} from '../../src/remote_memory/postgres_repository.js';
 import type {
@@ -22,8 +24,11 @@ interface Fixture {
 
 function fixture(
   options: {
+    readonly allowedHosts?: readonly string[];
+    readonly allowedOrigins?: readonly string[];
     readonly allowedProjects?: ReadonlySet<string> | 'all';
     readonly capabilities?: readonly string[];
+    readonly localIdp?: LocalIdp;
     readonly rateLimitFailure?: boolean;
     readonly recallResults?: readonly RemoteMemoryRecallResult[];
     readonly readContent?: string;
@@ -142,8 +147,14 @@ function fixture(
   return {
     calls,
     handler: createRemoteMemoryHttpHandler({
-      config: {...configFixture(), globallyEnabled: options.serviceEnabled ?? true},
+      config: {
+        ...configFixture(),
+        globallyEnabled: options.serviceEnabled ?? true,
+        ...(options.allowedHosts ? {allowedHosts: options.allowedHosts} : {}),
+        ...(options.allowedOrigins ? {allowedOrigins: options.allowedOrigins} : {}),
+      },
       dependencies,
+      ...(options.localIdp ? {localIdp: options.localIdp} : {}),
     }),
     readInputs,
   };
@@ -665,5 +676,45 @@ describe('remote memory HTTP transport', () => {
     expect(serialized).toContain('unsupported fields');
     expect(serialized).not.toContain(token);
     expect(test.calls).toEqual([]);
+  });
+
+  it('serves the in-process OAuth issuer next to protected-resource metadata', async () => {
+    const idp = await createLocalIdp({
+      audience: 'https://memory.example.test/mcp',
+      issuer: 'https://memory.example.test',
+      subject: 'local:tester',
+    });
+    const test = fixture({localIdp: idp});
+    const headers = {host: 'memory.example.test'};
+    const metadata = await test.handler(
+      new Request('https://memory.example.test/.well-known/oauth-authorization-server', {headers}),
+    );
+    const jwks = await test.handler(new Request('https://memory.example.test/.well-known/jwks.json', {headers}));
+    const protectedResource = await test.handler(
+      new Request('https://memory.example.test/.well-known/oauth-protected-resource', {headers}),
+    );
+
+    expect(metadata.status).toBe(200);
+    expect(await json(metadata)).toMatchObject({
+      authorization_endpoint: 'https://memory.example.test/authorize',
+      issuer: 'https://memory.example.test',
+      jwks_uri: 'https://memory.example.test/.well-known/jwks.json',
+      token_endpoint: 'https://memory.example.test/token',
+    });
+    expect((await json(jwks)).keys).toEqual([expect.objectContaining({alg: 'RS256', kid: expect.any(String)})]);
+    expect(await json(protectedResource)).toMatchObject({
+      authorization_servers: ['https://auth.example.test'],
+      resource: 'https://memory.example.test/mcp',
+    });
+  });
+
+  it('accepts the Cursor OAuth callback Origin on loopback when listed', async () => {
+    const test = fixture({allowedOrigins: ['https://cursor.com', 'http://127.0.0.1:8787']});
+    const response = await test.handler(
+      mcpRequest({id: 31, method: 'tools/list', params: {}}, {origin: 'http://127.0.0.1:8787'}),
+    );
+
+    expect(response.status).toBe(200);
+    expect(test.calls).toContain('oauth:fixture-token');
   });
 });

--- a/test/unit/remote-memory-provisioning.test.ts
+++ b/test/unit/remote-memory-provisioning.test.ts
@@ -49,6 +49,15 @@ describe('remote memory provisioning boundary', () => {
     expect(() => validateRemoteMemoryProvisioningInput({...validProvisioning, ...invalid})).toThrow();
   });
 
+  it('accepts a loopback HTTP issuer for the local composer IdP', () => {
+    expect(() =>
+      validateRemoteMemoryProvisioningInput({...validProvisioning, issuer: 'http://127.0.0.1:18788'}),
+    ).not.toThrow();
+    expect(() =>
+      validateRemoteMemoryProvisioningInput({...validProvisioning, issuer: 'http://localhost:18788'}),
+    ).not.toThrow();
+  });
+
   it('decodes bounded JSONB text without relying on the PostgreSQL driver JSON representation', () => {
     const json = '{"displayName": "Threadnote managed memory", "projects": ["threadnote"]}';
 


### PR DESCRIPTION
## Summary
- Add `threadnote composer serve` for a loopback Git-canonical memory composer plus an in-process RS256 OAuth issuer (authorization_code + PKCE only; no client_credentials; redirects pinned; Git push off unless `--push`).
- Attach organization memory as a second HTTP MCP entry with OAuth-shaped public-client metadata, writing project `.cursor/mcp.json` / `.vscode/mcp.json` so personal `~/.cursor/mcp.json` is not rewritten.
- Fail closed on a live worktree whose origin does not match the team remote, canonicalize loopback URLs to `127.0.0.1`, and pass `THREADNOTE_CURSOR_CLOUD_MODE=org` so local-graph status accepts loopback HTTP.

## Test plan
- [x] Focused unit tests: local IdP, composer serve, git canonical store, org MCP attach, remote-memory auth/HTTP/provisioning, MCP doctor/install, Cursor Cloud
- [x] lint + typecheck
- [ ] Required PR CI