### PR TITLE
Fix standalone composer migrations and ingest existing git shares

### DIFF
--- a/deploy/remote-memory/grants/001-runtime.sql
+++ b/deploy/remote-memory/grants/001-runtime.sql
@@ -42,7 +42,8 @@ GRANT INSERT ON
   remote_memory.outbox_events,
   remote_memory.audit_events,
   remote_memory.rate_limit_windows,
-  remote_memory.search_documents
+  remote_memory.search_documents,
+  remote_memory.projects
 TO threadnote_remote_runtime;
 
 GRANT UPDATE (share_generation, indexed_generation) ON remote_memory.shares TO threadnote_remote_runtime;

--- a/src/effect/composer_cli.ts
+++ b/src/effect/composer_cli.ts
@@ -78,6 +78,7 @@ export const runComposerServeCommand = Effect.fn('composer.serveCommand')(functi
         runComposerServe(
           {
             databaseUrl,
+            executablePath: system.executablePath,
             gitCloneUrl: team.config.remote,
             gitPush: options.push === true,
             gitWorktree,

--- a/src/remote_memory/composer_serve.ts
+++ b/src/remote_memory/composer_serve.ts
@@ -148,6 +148,10 @@ export async function runComposerServe(
       subject: idp.subject,
       tenantId: input.tenantId?.trim() || 'local-org',
     });
+    const repository = new PostgresRemoteMemoryRepository(sql, {gitStore});
+    await repository.ingestActiveGitShares(`composer-start:${input.shareId}`);
+    const indexer = new RemoteMemoryIndexer(sql, gitStore);
+    await indexer.runPass({batchSize: 256, ingest: false});
     const listening = startRemoteMemoryServer({
       config,
       dependencies: {
@@ -172,12 +176,11 @@ export async function runComposerServe(
           readRequestsPerMinute: config.readRequestsPerMinute,
           writeRequestsPerMinute: config.writeRequestsPerMinute,
         }),
-        repository: new PostgresRemoteMemoryRepository(sql, {gitStore}),
+        repository,
       },
       localIdp: idp,
     });
     server = listening;
-    const indexer = new RemoteMemoryIndexer(sql, gitStore);
     const retention = new RemoteHandoffRetentionWorker(sql, {gitStore});
     workerTasks = [indexer.run({signal: workers.signal}), retention.run({signal: workers.signal})];
     workerHealth.supervise('indexer', workerTasks[0]);

--- a/src/remote_memory/composer_serve.ts
+++ b/src/remote_memory/composer_serve.ts
@@ -25,6 +25,7 @@ export interface ComposerListenAddress {
 
 export interface ComposerServeInput {
   readonly databaseUrl: string;
+  readonly executablePath?: string;
   readonly gitBranch?: string;
   readonly gitCloneUrl: string;
   readonly gitPush?: boolean;
@@ -133,7 +134,7 @@ export async function runComposerServe(
   let stopping: Promise<void> | undefined;
   let server: RemoteMemoryServer | undefined;
   try {
-    if (config.autoMigrate) await migrateRemoteMemoryDatabase(sql);
+    if (config.autoMigrate) await migrateRemoteMemoryDatabase(sql, {executablePath: input.executablePath});
     await sql`SELECT 1 FROM remote_memory.shares LIMIT 0`;
     const gitStore = new GitCanonicalMemoryStore({
       branch: config.gitBranch,

--- a/src/remote_memory/git_canonical_store.ts
+++ b/src/remote_memory/git_canonical_store.ts
@@ -78,6 +78,20 @@ export function parseGitCanonicalSharePath(
   return undefined;
 }
 
+export function gitIngestProjectsToEnsure(input: {
+  readonly allowedProjects: ReadonlySet<string> | 'all';
+  readonly gitProjects: Iterable<string>;
+  readonly knownProjects: ReadonlySet<string>;
+}): readonly string[] {
+  const unique = new Set<string>();
+  for (const project of input.gitProjects) {
+    if (input.knownProjects.has(project)) continue;
+    if (input.allowedProjects !== 'all' && !input.allowedProjects.has(project)) continue;
+    unique.add(project);
+  }
+  return [...unique].sort();
+}
+
 export function isAbsoluteGitWorktree(path: string): boolean {
   return path.startsWith('/') || /^[A-Za-z]:[\\/]/u.test(path);
 }

--- a/src/remote_memory/main.ts
+++ b/src/remote_memory/main.ts
@@ -19,6 +19,7 @@ import {startRemoteMemoryServer} from './server.js';
 
 export interface RemoteMemoryServiceRuntime {
   readonly error: (message: string) => void;
+  readonly executablePath?: string;
   readonly shutdownSignal: () => {readonly dispose: () => void; readonly promise: Promise<string>};
 }
 
@@ -40,7 +41,7 @@ export async function runRemoteMemoryService(
   let workerTasks: readonly Promise<void>[] = [];
   let stopping: Promise<void> | undefined;
   try {
-    if (config.autoMigrate) await migrateRemoteMemoryDatabase(sql);
+    if (config.autoMigrate) await migrateRemoteMemoryDatabase(sql, {executablePath: runtime.executablePath});
     await assertRuntimeSchemaAccess(sql);
     const gitStore =
       config.canonicalStore === 'git' && config.gitWorktree

--- a/src/remote_memory/migrations.ts
+++ b/src/remote_memory/migrations.ts
@@ -2,9 +2,22 @@ import type {Sql} from 'postgres';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {remoteMemoryError} from './errors.js';
 
-function migrationFile(name: string): URL {
+export const STANDALONE_REMOTE_MEMORY_MIGRATION_DIRECTORY = 'remote-memory/migrations';
+
+export function standaloneMigrationFilePath(executablePath: string, name: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*\.sql$/u.test(name)) {
+    throw remoteMemoryError('invalid_request', 'Remote memory migration file name is invalid.');
+  }
+  const trimmed = executablePath.replace(/[\\/]+$/u, '');
+  const separator = trimmed.includes('\\') && !trimmed.includes('/') ? '\\' : '/';
+  const slash = trimmed.lastIndexOf(separator);
+  const root = slash <= 0 ? trimmed : trimmed.slice(0, slash);
+  return [root, ...STANDALONE_REMOTE_MEMORY_MIGRATION_DIRECTORY.split('/'), name].join(separator);
+}
+
+function migrationFile(name: string): string | URL {
   return typeof THREADNOTE_STANDALONE !== 'undefined' && THREADNOTE_STANDALONE
-    ? new URL(`./remote-memory/migrations/${name}`, import.meta.url)
+    ? standaloneMigrationFilePath(process.execPath, name)
     : new URL(`./migrations/${name}`, import.meta.url);
 }
 

--- a/src/remote_memory/migrations.ts
+++ b/src/remote_memory/migrations.ts
@@ -15,19 +15,29 @@ export function standaloneMigrationFilePath(executablePath: string, name: string
   return [root, ...STANDALONE_REMOTE_MEMORY_MIGRATION_DIRECTORY.split('/'), name].join(separator);
 }
 
-function migrationFile(name: string): string | URL {
-  return typeof THREADNOTE_STANDALONE !== 'undefined' && THREADNOTE_STANDALONE
-    ? standaloneMigrationFilePath(process.execPath, name)
-    : new URL(`./migrations/${name}`, import.meta.url);
+function migrationFile(name: string, executablePath: string | undefined): string | URL {
+  if (typeof THREADNOTE_STANDALONE !== 'undefined' && THREADNOTE_STANDALONE) {
+    if (!executablePath) {
+      throw remoteMemoryError(
+        'service_unavailable',
+        'Standalone remote memory migrations require the executable path.',
+      );
+    }
+    return standaloneMigrationFilePath(executablePath, name);
+  }
+  return new URL(`./migrations/${name}`, import.meta.url);
 }
 
 const MIGRATIONS = [
-  {file: migrationFile('001_initial.sql'), version: 1},
-  {file: migrationFile('002_git_canonical_pointers.sql'), version: 2},
+  {name: '001_initial.sql', version: 1},
+  {name: '002_git_canonical_pointers.sql', version: 2},
 ] as const;
 const MIGRATION_LOCK = 7_427_190_041;
 
-export async function migrateRemoteMemoryDatabase(sql: Sql): Promise<void> {
+export async function migrateRemoteMemoryDatabase(
+  sql: Sql,
+  options: {readonly executablePath?: string} = {},
+): Promise<void> {
   const connection = await sql.reserve();
   await connection`SELECT pg_advisory_lock(${MIGRATION_LOCK})`;
   try {
@@ -36,7 +46,7 @@ export async function migrateRemoteMemoryDatabase(sql: Sql): Promise<void> {
         '(version integer PRIMARY KEY, checksum text NOT NULL, applied_at timestamptz NOT NULL DEFAULT now())',
     );
     for (const migration of MIGRATIONS) {
-      const source = await Bun.file(migration.file).text();
+      const source = await Bun.file(migrationFile(migration.name, options.executablePath)).text();
       const checksum = sha256HexSync(source);
       const applied = await connection<{checksum: string}[]>`
         SELECT checksum FROM remote_memory.schema_migrations WHERE version = ${migration.version}

--- a/src/remote_memory/operator_main.ts
+++ b/src/remote_memory/operator_main.ts
@@ -73,16 +73,21 @@ class RemoteMemoryOperatorInvocationError extends Schema.TaggedError<RemoteMemor
 
 export interface RemoteMemoryOperatorRuntime {
   readonly createAdapter: (databaseUrl: string) => RemoteMemoryOperatorAdapter & {readonly close?: () => Promise<void>};
+  readonly executablePath?: string;
 }
 
-const defaultRuntime: RemoteMemoryOperatorRuntime = {
-  createAdapter: databaseUrl => new PostgresRemoteMemoryOperatorAdapter(createRemoteMemorySql(databaseUrl)),
-};
+export function createRemoteMemoryOperatorRuntime(executablePath?: string): RemoteMemoryOperatorRuntime {
+  return {
+    createAdapter: databaseUrl =>
+      new PostgresRemoteMemoryOperatorAdapter(createRemoteMemorySql(databaseUrl), {executablePath}),
+    ...(executablePath === undefined ? {} : {executablePath}),
+  };
+}
 
 export const runRemoteMemoryOperator = Effect.fn('remoteMemory.operator.run')(function* (
   arguments_: readonly string[],
   environment: Readonly<Record<string, string | undefined>>,
-  runtime: RemoteMemoryOperatorRuntime = defaultRuntime,
+  runtime: RemoteMemoryOperatorRuntime = createRemoteMemoryOperatorRuntime(),
 ): Effect.fn.Return<number, never, RemoteMemoryOperatorFileServices> {
   // FileSystem and Path requirements are supplied only by the hidden
   // src/standalone.ts application entrypoint.

--- a/src/remote_memory/operator_postgres.ts
+++ b/src/remote_memory/operator_postgres.ts
@@ -49,12 +49,15 @@ export class PostgresRemoteMemoryOperatorAdapter implements RemoteMemoryOperator
 
   private readonly controlPlane: PostgresRemoteControlPlane;
 
-  constructor(readonly sql: Sql) {
+  constructor(
+    readonly sql: Sql,
+    readonly options: {readonly executablePath?: string} = {},
+  ) {
     this.controlPlane = new PostgresRemoteControlPlane(sql);
   }
 
   readonly migrateSchema = async () => {
-    await migrateRemoteMemoryDatabase(this.sql);
+    await migrateRemoteMemoryDatabase(this.sql, {executablePath: this.options.executablePath});
     return {readyVersions: [1], status: 'ready' as const, version: REMOTE_MEMORY_OPERATOR_CONTRACT_VERSION};
   };
 

--- a/src/remote_memory/postgres_repository.ts
+++ b/src/remote_memory/postgres_repository.ts
@@ -28,7 +28,7 @@ import {
 import type {AuthorizedRemotePrincipal, RemoteMemoryFeatureFlag, RemoteMemoryScope} from './authorization.js';
 import {authorizeCursorClaims, type CursorWorkloadAttestation} from './cursor_oidc.js';
 import {RemoteMemoryError, remoteMemoryError, type RemoteMemoryErrorCode} from './errors.js';
-import {GitCanonicalMemoryStore, gitCanonicalSharePath} from './git_canonical_store.js';
+import {GitCanonicalMemoryStore, gitCanonicalSharePath, gitIngestProjectsToEnsure} from './git_canonical_store.js';
 import {requireJsonValue} from './json.js';
 import {
   remoteMemoryDatabaseTimeoutMilliseconds,
@@ -701,6 +701,22 @@ export class PostgresRemoteMemoryRepository {
     };
     const snapshot = await this.withTenant(principal.tenantId, async transaction => {
       await requireShareState(transaction, principal);
+      const knownProjects = await transaction<{name: string}[]>`
+        SELECT name FROM remote_memory.projects
+        WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId}
+      `;
+      const toEnsure = gitIngestProjectsToEnsure({
+        allowedProjects: principal.allowedProjects,
+        gitProjects: paths.map(path => path.project),
+        knownProjects: new Set(knownProjects.map(project => project.name)),
+      });
+      for (const project of toEnsure) {
+        await transaction`
+          INSERT INTO remote_memory.projects(tenant_id, share_id, name, status)
+          VALUES (${principal.tenantId}, ${principal.shareId}, ${project}, 'active')
+          ON CONFLICT (tenant_id, share_id, name) DO NOTHING
+        `;
+      }
       const heads = await transaction<
         {
           readonly content_hash: string;

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -95,7 +95,9 @@ async function windowsDiskCapacityWorkerProgram() {
 
 async function remoteMemoryOperatorProgram(arguments_: readonly string[]) {
   const operator = await import('./remote_memory/operator_main.js');
-  return operator.runRemoteMemoryOperator(arguments_, process.env).pipe(
+  return operator
+    .runRemoteMemoryOperator(arguments_, process.env, operator.createRemoteMemoryOperatorRuntime(process.execPath))
+    .pipe(
     Effect.flatMap(code =>
       Effect.sync(() => {
         process.exitCode = code;
@@ -112,6 +114,7 @@ async function remoteMemoryServiceProgram() {
       signal =>
         service.runRemoteMemoryService(process.env, {
           error: message => output.error(message),
+          executablePath: process.execPath,
           shutdownSignal: () => remoteMemoryShutdownSignal(signal),
         }),
       cause => cause,

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -98,13 +98,13 @@ async function remoteMemoryOperatorProgram(arguments_: readonly string[]) {
   return operator
     .runRemoteMemoryOperator(arguments_, process.env, operator.createRemoteMemoryOperatorRuntime(process.execPath))
     .pipe(
-    Effect.flatMap(code =>
-      Effect.sync(() => {
-        process.exitCode = code;
-      }),
-    ),
-    Effect.provide(BunServices.layer),
-  );
+      Effect.flatMap(code =>
+        Effect.sync(() => {
+          process.exitCode = code;
+        }),
+      ),
+      Effect.provide(BunServices.layer),
+    );
 }
 
 async function remoteMemoryServiceProgram() {

--- a/test/helpers/remote-memory-postgres.ts
+++ b/test/helpers/remote-memory-postgres.ts
@@ -136,6 +136,7 @@ async function grantRuntimePrivileges(migratorSql: Sql, databaseName: string, ru
         'audit_events',
         'rate_limit_windows',
         'search_documents',
+        'projects',
       ],
     },
     {

--- a/test/integration/remote-memory-git-composer.test.ts
+++ b/test/integration/remote-memory-git-composer.test.ts
@@ -6,6 +6,7 @@ import {formatRemoteMemoryUri} from '../../src/memory_domain/address.js';
 import {formatMemoryDocument} from '../../src/memory/document.js';
 import type {RemoteRememberInputV1} from '../../src/memory_domain/contracts.js';
 import type {AuthorizedRemotePrincipal, RemoteMemoryScope} from '../../src/remote_memory/authorization.js';
+import {provisionGitTeamShare} from '../../src/remote_memory/composer_serve.js';
 import {GitCanonicalMemoryStore, gitCanonicalSharePath} from '../../src/remote_memory/git_canonical_store.js';
 import type {OAuthPrincipalClaims} from '../../src/remote_memory/oauth.js';
 import {PostgresRemoteControlPlane} from '../../src/remote_memory/postgres_control_plane.js';
@@ -290,6 +291,86 @@ postgresDescribe('git-backed remote memory composer', () => {
   });
 });
 
+postgresDescribe('composer serve ingest of git files without a provisioned catalog', () => {
+  let fixture: RemoteMemoryPostgresFixture;
+  let gitFixture: GitShareWorktreeFixture;
+  let repository: PostgresRemoteMemoryRepository;
+  let principal: AuthorizedRemotePrincipal;
+
+  beforeAll(async () => {
+    if (!TEST_DATABASE_URL) throw new Error('THREADNOTE_TEST_POSTGRES_URL is required.');
+    fixture = await createRemoteMemoryPostgresFixture(TEST_DATABASE_URL);
+    gitFixture = await createGitShareWorktreeFixture('threadnote-git-composer-uncataloged-');
+    await provisionGitTeamShare(new PostgresRemoteControlPlane(fixture.migratorSql), {
+      issuer: ISSUER,
+      shareId: SHARE,
+      subject: 'subject-git',
+      tenantId: TENANT,
+    });
+    await withTenant(
+      fixture.migratorSql,
+      TENANT,
+      transaction =>
+        transaction`
+        INSERT INTO remote_memory.projects(tenant_id, share_id, name, status)
+        VALUES (${TENANT}, ${SHARE}, 'retired-project', 'archived')
+      `,
+    );
+    const gitStore = new GitCanonicalMemoryStore({worktree: gitFixture.worktree});
+    repository = new PostgresRemoteMemoryRepository(fixture.sql, {gitStore});
+    const authorized = await new PostgresRemoteControlPlane(fixture.sql).authorize(claims(), SHARE);
+    if (!authorized) throw new Error('Uncataloged composer fixture authorization failed.');
+    principal = authorized;
+  });
+
+  afterAll(async () => {
+    await fixture?.dispose();
+    if (gitFixture) await rm(gitFixture.root, {force: true, recursive: true});
+  });
+
+  it('creates project rows from the git layout and indexes existing markdown without postgres bodies', async () => {
+    const topic = 'preexisting-share';
+    const project = 'existing-share';
+    const laptop = join(gitFixture.root, 'existing-share-writer');
+    await cloneGitShareWorktree(gitFixture.remote, laptop);
+    await writeCanonicalMemory(laptop, 'durable', project, topic, 'Existing team markdown reached composer.');
+    await writeCanonicalMemory(
+      laptop,
+      'durable',
+      'retired-project',
+      'ignored-retired',
+      'Archived catalog entries must stay skipped.',
+    );
+
+    const ingested = await repository.ingestActiveGitShares('request-uncataloged-ingest');
+    expect(ingested.ingested).toBe(1);
+    const listed = await repository.list(principal, {limit: 10}, 'request-uncataloged-list');
+    expect(listed.entries).toEqual([expect.objectContaining({kind: 'durable', project, status: 'active', topic})]);
+    const uri = formatRemoteMemoryUri({kind: 'durable', project, shareId: SHARE, topic});
+    const read = await repository.read(principal, {uri, version: 1}, 'request-uncataloged-read');
+    expect(read.content).toContain('Existing team markdown reached composer.');
+    const stored = await withTenant(
+      fixture.sql,
+      TENANT,
+      transaction =>
+        transaction<{markdown_body: string; name: string; status: string}[]>`
+        SELECT p.name, p.status, COALESCE(r.markdown_body, '') AS markdown_body
+        FROM remote_memory.projects p
+        LEFT JOIN remote_memory.memory_heads h
+          ON h.tenant_id = p.tenant_id AND h.share_id = p.share_id AND h.project = p.name
+        LEFT JOIN remote_memory.memory_revisions r
+          ON r.tenant_id = h.tenant_id AND r.share_id = h.share_id AND r.id = h.current_revision_id
+        WHERE p.share_id = ${SHARE}
+        ORDER BY p.name
+      `,
+    );
+    expect(stored).toEqual([
+      {markdown_body: '', name: project, status: 'active'},
+      {markdown_body: '', name: 'retired-project', status: 'archived'},
+    ]);
+  });
+});
+
 function claims(): OAuthPrincipalClaims {
   return {issuer: ISSUER, scopes: new Set(ALL_SCOPES), subject: 'subject-git'};
 }
@@ -309,6 +390,39 @@ function rememberInput(input: {
     topic: input.topic,
     version: 1,
   };
+}
+
+async function writeCanonicalMemory(
+  worktree: string,
+  kind: 'durable' | 'handoff',
+  project: string,
+  topic: string,
+  text: string,
+): Promise<string> {
+  const path = gitCanonicalSharePath(kind, project, topic);
+  const target = join(worktree, ...path.split('/'));
+  await mkdir(dirname(target), {recursive: true});
+  await writeFile(
+    target,
+    formatMemoryDocument(
+      kind === 'durable' ? 'MEMORY' : 'HANDOFF',
+      {
+        kind,
+        project,
+        sourceAgentClient: 'share',
+        status: 'active',
+        timestamp: '2026-09-04T12:00:00.000Z',
+        topic,
+        visibility: 'shared',
+      },
+      text,
+    ),
+    'utf8',
+  );
+  await git(['add', '--', path], worktree);
+  await git(['commit', '-m', `share ${kind} ${project}/${topic}`], worktree);
+  await git(['push', 'origin', 'main'], worktree);
+  return path;
 }
 
 async function withTenant<A>(sql: Sql, tenantId: string, use: (transaction: TransactionSql) => Promise<A>): Promise<A> {

--- a/test/unit/git-canonical-store.test.ts
+++ b/test/unit/git-canonical-store.test.ts
@@ -7,6 +7,7 @@ import {
   GitCanonicalMemoryStore,
   ensureLiveGitShareWorktree,
   gitCanonicalSharePath,
+  gitIngestProjectsToEnsure,
   gitRemoteUrlsMatch,
   parseGitCanonicalSharePath,
 } from '../../src/remote_memory/git_canonical_store.js';
@@ -34,6 +35,60 @@ describe('git canonical memory store', () => {
     expect(parseGitCanonicalSharePath('durable/projects/x')).toBeUndefined();
     expect(parseGitCanonicalSharePath('durable/projects/x/y.txt')).toBeUndefined();
     expect(parseGitCanonicalSharePath('../durable/projects/x/y.md')).toBeUndefined();
+  });
+
+  it('catalogs unknown allowed git projects and never un-archives known ones', () => {
+    FC.assert(
+      FC.property(
+        FC.array(portableSegment, {maxLength: 8}),
+        FC.array(portableSegment, {maxLength: 8}),
+        FC.boolean(),
+        (gitProjects, knownProjects, restrict) => {
+          const known = new Set(knownProjects);
+          const allowed = restrict ? new Set(gitProjects.filter((_, index) => index % 2 === 0)) : 'all';
+          const ensured = gitIngestProjectsToEnsure({
+            allowedProjects: allowed,
+            gitProjects,
+            knownProjects: known,
+          });
+          expect(ensured).toEqual([...ensured].sort());
+          expect(new Set(ensured).size).toBe(ensured.length);
+          for (const project of ensured) {
+            expect(known.has(project)).toBe(false);
+            expect(gitProjects).toContain(project);
+            if (allowed !== 'all') expect(allowed.has(project)).toBe(true);
+          }
+          expect(
+            gitIngestProjectsToEnsure({
+              allowedProjects: allowed,
+              gitProjects,
+              knownProjects: new Set([...known, ...ensured]),
+            }),
+          ).toEqual([]);
+        },
+      ),
+    );
+    expect(
+      gitIngestProjectsToEnsure({
+        allowedProjects: 'all',
+        gitProjects: ['beta', 'alpha', 'beta'],
+        knownProjects: new Set(),
+      }),
+    ).toEqual(['alpha', 'beta']);
+    expect(
+      gitIngestProjectsToEnsure({
+        allowedProjects: new Set(['alpha']),
+        gitProjects: ['alpha', 'other-project'],
+        knownProjects: new Set(),
+      }),
+    ).toEqual(['alpha']);
+    expect(
+      gitIngestProjectsToEnsure({
+        allowedProjects: 'all',
+        gitProjects: ['alpha', 'retired'],
+        knownProjects: new Set(['retired']),
+      }),
+    ).toEqual(['alpha']);
   });
 
   it('refuses an empty git worktree and clones a live team share instead', async () => {

--- a/test/unit/remote-memory-migrations.test.ts
+++ b/test/unit/remote-memory-migrations.test.ts
@@ -1,6 +1,8 @@
 import type {Sql} from 'postgres';
 import {describe, expect, it} from 'vitest';
-import {migrateRemoteMemoryDatabase} from '../../src/remote_memory/migrations.js';
+import * as FC from 'effect/testing/FastCheck';
+import {dirname, join} from '../helpers/node-path.js';
+import {migrateRemoteMemoryDatabase, standaloneMigrationFilePath} from '../../src/remote_memory/migrations.js';
 
 interface FakeMigrationOptions {
   readonly conflictingChecksum?: string;
@@ -120,5 +122,21 @@ describe('remote memory PostgreSQL migrations', () => {
       'unlock',
       'release',
     ]);
+  });
+
+  it('resolves standalone migrations beside the compiled executable instead of bunfs', () => {
+    const executableRoot = FC.array(FC.stringMatching(/^[a-z][a-z0-9-]{0,12}$/u), {minLength: 1, maxLength: 4});
+    const migrationName = FC.constantFrom('001_initial.sql', '002_git_canonical_pointers.sql');
+    FC.assert(
+      FC.property(executableRoot, migrationName, (segments, name) => {
+        const executablePath = join('/', ...segments, 'threadnote');
+        const resolved = standaloneMigrationFilePath(executablePath, name);
+        expect(resolved).toBe(join(dirname(executablePath), 'remote-memory', 'migrations', name));
+        expect(resolved).not.toContain('bunfs');
+      }),
+    );
+    expect(() => standaloneMigrationFilePath('/opt/threadnote/threadnote', '../001_initial.sql')).toThrow(
+      'migration file name is invalid',
+    );
   });
 });

--- a/test/unit/remote-memory-portability-deploy.test.ts
+++ b/test/unit/remote-memory-portability-deploy.test.ts
@@ -54,7 +54,10 @@ describe('remote memory reference deployment', () => {
 
     expect(build).toContain("const REMOTE_MEMORY_MIGRATION_DIRECTORY = 'remote-memory/migrations'");
     expect(build).toContain("path.join(root, 'src', 'remote_memory', 'migrations')");
-    expect(migrations).toContain('new URL(`./remote-memory/migrations/${name}`, import.meta.url)');
+    expect(migrations).toContain("STANDALONE_REMOTE_MEMORY_MIGRATION_DIRECTORY = 'remote-memory/migrations'");
+    expect(migrations).toContain('standaloneMigrationFilePath(process.execPath, name)');
+    expect(migrations).not.toContain('new URL(`./remote-memory/migrations/${name}`, import.meta.url)');
+    expect(migrations).toContain('new URL(`./migrations/${name}`, import.meta.url)');
     expect(migrations).toContain("migrationFile('001_initial.sql')");
     expect(migrations).toContain("migrationFile('002_git_canonical_pointers.sql')");
   });

--- a/test/unit/remote-memory-portability-deploy.test.ts
+++ b/test/unit/remote-memory-portability-deploy.test.ts
@@ -29,6 +29,8 @@ describe('remote memory reference deployment', () => {
     const selectGrant = /GRANT SELECT ON(?<tables>[\s\S]*?)TO threadnote_remote_runtime;/u.exec(grants)?.groups?.tables;
     expect(selectGrant).toBeDefined();
     expect(selectGrant).not.toContain('remote_memory.audit_events');
+    const insertGrant = /GRANT INSERT ON(?<tables>[\s\S]*?)TO threadnote_remote_runtime;/u.exec(grants)?.groups?.tables;
+    expect(insertGrant).toContain('remote_memory.projects');
     expect(grants).not.toMatch(/GRANT (?:INSERT|UPDATE|DELETE)[\s\S]*remote_memory\.schema_migrations/u);
     expect(grants).not.toMatch(/GRANT (?:INSERT|UPDATE|DELETE)[\s\S]*remote_memory\.git_beta_import_receipts/u);
   });

--- a/test/unit/remote-memory-portability-deploy.test.ts
+++ b/test/unit/remote-memory-portability-deploy.test.ts
@@ -57,10 +57,11 @@ describe('remote memory reference deployment', () => {
     expect(build).toContain("const REMOTE_MEMORY_MIGRATION_DIRECTORY = 'remote-memory/migrations'");
     expect(build).toContain("path.join(root, 'src', 'remote_memory', 'migrations')");
     expect(migrations).toContain("STANDALONE_REMOTE_MEMORY_MIGRATION_DIRECTORY = 'remote-memory/migrations'");
-    expect(migrations).toContain('standaloneMigrationFilePath(process.execPath, name)');
+    expect(migrations).toContain('standaloneMigrationFilePath(executablePath, name)');
+    expect(migrations).not.toMatch(/\bprocess\.execPath\b/);
     expect(migrations).not.toContain('new URL(`./remote-memory/migrations/${name}`, import.meta.url)');
     expect(migrations).toContain('new URL(`./migrations/${name}`, import.meta.url)');
-    expect(migrations).toContain("migrationFile('001_initial.sql')");
-    expect(migrations).toContain("migrationFile('002_git_canonical_pointers.sql')");
+    expect(migrations).toContain("name: '001_initial.sql'");
+    expect(migrations).toContain("name: '002_git_canonical_pointers.sql'");
   });
 });


### PR DESCRIPTION
## Summary
- Load compiled composer SQL migrations from the executable directory so standalone `composer serve` no longer looks them up inside bunfs.
- Catalog `remote_memory.projects` from the Git share layout during ingest (and at composer start) so existing team Markdown becomes visible without dual-writing bodies to Postgres.

## Test plan
- [x] Focused unit tests: standalone migration path, git ingest project catalog property, runtime INSERT grant
- [x] Integration: composer-like empty catalog ingests existing Git markdown with empty Postgres bodies; archived projects stay skipped
- [ ] Required CI on this PR
- [ ] After squash-merge: `dev:install-global` of the merged SHA, restart loopback composer, confirm `list_context` is non-empty (privacy-safe counts)