### PR TITLE
Give Git ingestion explicit authority and protect memory metadata

### DIFF
--- a/docs/org-productization.md
+++ b/docs/org-productization.md
@@ -4,6 +4,12 @@ Status: reviewed with zero blocking findings after two dev-cycle iterations, 202
 Baseline: main `9b63eb0b` (4.6.7). Implementation starts with P1a, tenant/share isolation; the remaining P1
 storage contracts and subsequent gates remain open until separately verified.
 
+Execution evidence: P1a is implemented in #378 with 102 focused tests, zero dev-cycle findings, and an
+exact-HEAD global smoke returning 200 for the bound share and 403 for an authorized sibling share. The next
+slice adds dedicated Git ingestion authority, persistent ingestion readiness failure, and rejection of HTTP
+body edits that would discard rich metadata. Git push/crash recovery and external lifecycle/removal convergence
+remain open P1 gates.
+
 The outcome is a deployable organization product and a real single-member deployment at
 `https://threadnote-org.fly.dev/mcp`. Our laptops retain local stdio, personal memory, exact-worktree graphs,
 and the existing Git share. The org composer writes the same Git memory repository. A successful deployment

--- a/docs/remote-memory/operations.md
+++ b/docs/remote-memory/operations.md
@@ -35,6 +35,19 @@ share, even if another share is provisioned in the same database. Local `compose
 from its tenant/share options. Existing Git-mode deployments must add these values before upgrading; missing
 bindings fail startup. The Postgres canonical-body flavor continues to support its existing multi-share model.
 
+Operator provisioning also creates a dedicated `system:git-ingest` identity for each tenant/share. Re-run the
+existing provisioning document once when upgrading a Git deployment; runtime credentials cannot create this
+identity. Its grant follows share feature flags and active projects, independently of interactive members.
+Git may add previously unknown projects to the catalog but cannot reactivate an archived project. Member
+permissions still govern every client read and write. Re-provisioning does not undo an explicit revocation of
+the ingestion identity. Missing or revoked ingestion authority fails ingestion; `git_ingest_failed` keeps
+readiness unhealthy until a subsequent ingestion succeeds, including across intervening projection-only passes.
+
+Remote body replacement currently accepts only the metadata emitted by the basic remote editor. A Git memory
+with citations, relations, keywords, provenance, unknown headers, or legacy metadata is rejected before any
+canonical write. Edit those records through the Git share until the remote API supports their metadata; this
+prevents silent loss of local product information. Basic remote documents retain their identity and creation time.
+
 ### Database roles
 
 The Compose stack demonstrates three separate database identities:

--- a/src/remote_memory/document_compatibility.ts
+++ b/src/remote_memory/document_compatibility.ts
@@ -1,0 +1,41 @@
+import {assertMemoryDocumentSchemaWritable, parseMemoryDocument} from '../memory/document.js';
+import {remoteMemoryError} from './errors.js';
+
+const BODY_REPLACEMENT_FIELDS = new Set([
+  'kind',
+  'status',
+  'project',
+  'topic',
+  'source_agent_client',
+  'timestamp',
+  'schema_version',
+  'memory_id',
+  'created_at',
+  'updated_at',
+  'visibility',
+]);
+
+export function assertRemoteBodyReplacementSupported(content: string): void {
+  assertMemoryDocumentSchemaWritable(content);
+  const normalized = content.trim().replace(/\r\n?/gu, '\n');
+  const header = normalized.split('\n\n', 1)[0];
+  const fields = header.split('\n').slice(1);
+  const seen = new Set<string>();
+  const unsupported = fields.some(line => {
+    const key = /^([a-z_]+):/u.exec(line)?.[1];
+    if (!key || !BODY_REPLACEMENT_FIELDS.has(key) || seen.has(key)) return true;
+    seen.add(key);
+    return false;
+  });
+  if (
+    unsupported ||
+    /\n\n<!-- MEMORY_FIELDS\n[\s\S]*?\n-->\s*$/u.test(normalized) ||
+    !parseMemoryDocument('threadnote://share/compatibility/memories/durable/project/topic.md', content)
+  ) {
+    throw remoteMemoryError(
+      'invalid_request',
+      'This document contains metadata the remote body editor cannot preserve. Edit it through the Git share until rich metadata editing is supported.',
+      {reason: 'unsupported_remote_metadata'},
+    );
+  }
+}

--- a/src/remote_memory/git_ingest_principal.ts
+++ b/src/remote_memory/git_ingest_principal.ts
@@ -1,0 +1,50 @@
+import type {TransactionSql} from 'postgres';
+import {sha256HexSync} from '../crypto/sha256.js';
+import {remoteMemoryError} from './errors.js';
+
+export function remoteGitIngestPrincipalId(tenantId: string, shareId: string): string {
+  return `system:git-ingest:${sha256HexSync(JSON.stringify([tenantId, shareId])).slice(0, 32)}`;
+}
+
+export async function provisionGitIngestPrincipal(
+  transaction: TransactionSql,
+  input: {readonly tenantId: string; readonly shareId: string},
+): Promise<void> {
+  const principalId = remoteGitIngestPrincipalId(input.tenantId, input.shareId);
+  const capabilities = ['memory:read', 'memory:write:durable', 'memory:write:handoff'];
+  const document = {capabilities, internal: 'git-ingest'};
+  const digest = sha256HexSync(JSON.stringify(document));
+  await transaction`
+    INSERT INTO remote_memory.principals(tenant_id, id, status)
+    VALUES (${input.tenantId}, ${principalId}, 'active') ON CONFLICT (tenant_id, id) DO NOTHING
+  `;
+  await transaction`
+    INSERT INTO remote_memory.tenant_memberships(tenant_id, principal_id, status)
+    VALUES (${input.tenantId}, ${principalId}, 'active') ON CONFLICT (tenant_id, principal_id) DO NOTHING
+  `;
+  await transaction`
+    INSERT INTO remote_memory.grant_policy_versions(
+      tenant_id, share_id, version, principal_id, policy_document, policy_digest
+    ) VALUES (
+      ${input.tenantId}, ${input.shareId}, 'git-ingest-v1', ${principalId},
+      ${transaction.json(document)}, ${digest}
+    ) ON CONFLICT (tenant_id, share_id, version, principal_id) DO NOTHING
+  `;
+  const policies = await transaction<{policy_digest: string}[]>`
+    SELECT policy_digest FROM remote_memory.grant_policy_versions
+    WHERE tenant_id = ${input.tenantId} AND share_id = ${input.shareId}
+      AND version = 'git-ingest-v1' AND principal_id = ${principalId}
+  `;
+  if (policies[0]?.policy_digest !== digest) {
+    throw remoteMemoryError('conflict', 'The internal Git ingest policy version has conflicting content.');
+  }
+  await transaction`
+    INSERT INTO remote_memory.share_grants(
+      tenant_id, share_id, principal_id, status, capabilities, allowed_projects,
+      cursor_owner_ids, cursor_subjects, cursor_attestation_required, policy_version, policy_digest
+    ) VALUES (
+      ${input.tenantId}, ${input.shareId}, ${principalId}, 'active', ${transaction.array(capabilities)}, NULL,
+      ${transaction.array([])}, ${transaction.array([])}, false, 'git-ingest-v1', ${digest}
+    ) ON CONFLICT (tenant_id, share_id, principal_id) DO NOTHING
+  `;
+}

--- a/src/remote_memory/indexer.ts
+++ b/src/remote_memory/indexer.ts
@@ -61,6 +61,7 @@ export interface RemoteMemoryIndexPassResult {
  * commits. A SKIP LOCKED miss is never counted as progress.
  */
 export class RemoteMemoryIndexer {
+  private gitIngestFailed = false;
   private nextGitIngestAt = 0;
   private nextShareKey: string | undefined;
 
@@ -104,8 +105,10 @@ export class RemoteMemoryIndexer {
         await new PostgresRemoteMemoryRepository(this.sql, {gitStore: this.gitStore}).ingestActiveGitShares(
           `indexer-ingest:${Date.now()}`,
         );
+        this.gitIngestFailed = false;
       } catch {
-        // Git ingest is not outbox progress; run() backs off independently.
+        this.gitIngestFailed = true;
+        failed += 1;
       }
     }
     if (shares.length > 0) {
@@ -245,7 +248,13 @@ export class RemoteMemoryIndexer {
         oldestPendingAt = row.oldest_pending_at;
       }
     }
-    const failureClass = result.failed > 0 ? 'projection_failed' : deadLetters > 0 ? 'dead_lettered_event' : undefined;
+    const failureClass = this.gitIngestFailed
+      ? 'git_ingest_failed'
+      : result.failed > 0
+        ? 'projection_failed'
+        : deadLetters > 0
+          ? 'dead_lettered_event'
+          : undefined;
     await this.sql`
       UPDATE remote_memory.worker_health SET
         heartbeat_at = now(),

--- a/src/remote_memory/postgres_control_plane.ts
+++ b/src/remote_memory/postgres_control_plane.ts
@@ -16,6 +16,7 @@ import type {
 } from './cursor_oidc.js';
 import {canonicalCursorRepositoryBinding, cursorAttestationMaximumAttempts} from './cursor_oidc.js';
 import {remoteMemoryError} from './errors.js';
+import {provisionGitIngestPrincipal} from './git_ingest_principal.js';
 import {isJsonObject} from './json.js';
 import {validatePortableSegment} from '../storage/resource-id.js';
 import {
@@ -637,6 +638,7 @@ export class PostgresRemoteControlPlane implements RemoteAuthorizationStore, Cur
           cursor_owner_ids = EXCLUDED.cursor_owner_ids, cursor_subjects = EXCLUDED.cursor_subjects,
           cursor_attestation_required = false
       `;
+      await provisionGitIngestPrincipal(transaction, input);
       if (replaceSharePolicy) {
         const configuredProjects = [...new Set(input.projects ?? Object.keys(input.repositoryBindings ?? {}))];
         for (const project of configuredProjects) {

--- a/src/remote_memory/postgres_repository.ts
+++ b/src/remote_memory/postgres_repository.ts
@@ -3,12 +3,7 @@ import type {Sql, TransactionSql} from 'postgres';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {randomUuidV4} from '../crypto/uuid.js';
 import {MEMORY_SCHEMA_VERSION} from '../memory/code_citation.js';
-import {
-  assertMemoryDocumentSchemaWritable,
-  formatMemoryDocument,
-  parseMemoryDocument,
-  type MemoryMetadata,
-} from '../memory/document.js';
+import {formatMemoryDocument, parseMemoryDocument, type MemoryMetadata} from '../memory/document.js';
 import {formatRemoteMemoryUri, parseRemoteShareAddress} from '../memory_domain/address.js';
 import {inspectRemoteMemoryContent} from '../memory_domain/content.js';
 import type {RemoteReadInputV1, RemoteRecallInputV1, RemoteRememberInputV1} from '../memory_domain/contracts.js';
@@ -31,6 +26,8 @@ import {RemoteMemoryError, remoteMemoryError, type RemoteMemoryErrorCode} from '
 import {GitCanonicalMemoryStore, gitCanonicalSharePath, gitIngestProjectsToEnsure} from './git_canonical_store.js';
 import {requireJsonValue} from './json.js';
 import {assertGitMemoryBinding, requireGitMemoryBinding} from './git_binding.js';
+import {remoteGitIngestPrincipalId} from './git_ingest_principal.js';
+import {assertRemoteBodyReplacementSupported} from './document_compatibility.js';
 import {
   remoteMemoryDatabaseTimeoutMilliseconds,
   requireActiveRemoteMemoryRequest,
@@ -683,8 +680,13 @@ export class PostgresRemoteMemoryRepository {
     for (const share of shares) {
       const principal = await this.loadGitIngestPrincipal(share.tenant_id, share.share_id);
       if (!principal) {
-        skipped += 1;
-        continue;
+        throw remoteMemoryError(
+          'service_unavailable',
+          'The Git ingest service identity is unavailable; check operator provisioning and revocation.',
+          {
+            reason: 'git_ingest_identity_unavailable',
+          },
+        );
       }
       const result = await this.ingestGitShare(principal, `${requestId}:${share.share_id}`, now);
       ingested += result.ingested;
@@ -1394,12 +1396,12 @@ export class PostgresRemoteMemoryRepository {
         FROM remote_memory.shares s
         JOIN remote_memory.share_grants g
           ON g.tenant_id = s.tenant_id AND g.share_id = s.id AND g.status = 'active'
+        JOIN remote_memory.principals p
+          ON p.tenant_id = g.tenant_id AND p.id = g.principal_id AND p.status = 'active'
+        JOIN remote_memory.tenant_memberships m
+          ON m.tenant_id = g.tenant_id AND m.principal_id = g.principal_id AND m.status = 'active'
         WHERE s.tenant_id = ${tenantId} AND s.id = ${shareId} AND s.status = 'active'
-          AND (
-            g.capabilities && ARRAY['memory:write:durable', 'memory:write:handoff', 'memory:admin']::text[]
-          )
-        ORDER BY g.principal_id
-        LIMIT 1
+          AND g.principal_id = ${remoteGitIngestPrincipalId(tenantId, shareId)}
       `;
       const row = rows[0];
       if (!row) return undefined;
@@ -1709,7 +1711,7 @@ function makeRemoteDocument(
 ): {readonly content: string; readonly contentHash: string} {
   const timestamp = now.toISOString();
   const prior = current && priorBody ? parseMemoryDocument(uri, priorBody) : undefined;
-  if (current && priorBody) assertMemoryDocumentSchemaWritable(priorBody);
+  if (current && priorBody) assertRemoteBodyReplacementSupported(priorBody);
   const metadata: MemoryMetadata = {
     createdAt: prior?.metadata.createdAt ?? prior?.metadata.timestamp ?? timestamp,
     kind: input.kind,

--- a/test/integration/remote-memory-git-authority.test.ts
+++ b/test/integration/remote-memory-git-authority.test.ts
@@ -1,0 +1,171 @@
+import {describe, expect, it} from 'vitest';
+import {rm} from '../helpers/node-fs-promises.js';
+import {createGitShareWorktreeFixture} from '../helpers/git-share-worktree.js';
+import {createRemoteMemoryPostgresFixture} from '../helpers/remote-memory-postgres.js';
+import {GitCanonicalMemoryStore} from '../../src/remote_memory/git_canonical_store.js';
+import {PostgresRemoteControlPlane} from '../../src/remote_memory/postgres_control_plane.js';
+import {PostgresRemoteMemoryRepository} from '../../src/remote_memory/postgres_repository.js';
+import {RemoteMemoryIndexer} from '../../src/remote_memory/indexer.js';
+
+const DATABASE = process.env.THREADNOTE_TEST_POSTGRES_URL;
+const postgresDescribe = DATABASE ? describe : describe.skip;
+
+async function fixture() {
+  const database = await createRemoteMemoryPostgresFixture(DATABASE!);
+  const git = await createGitShareWorktreeFixture();
+  const operator = new PostgresRemoteControlPlane(database.migratorSql);
+  const input = {
+    tenantId: 'authority',
+    shareId: 'authority-share',
+    principalId: 'member',
+    issuer: 'https://authority.test',
+    subject: 'member',
+    displayName: 'Authority test',
+    region: 'test',
+    policyVersion: 'v1',
+    capabilities: ['memory:read', 'memory:write:durable'] as const,
+    allowedProjects: ['restricted'],
+    projects: ['restricted'],
+    cursorAttestationRequired: false,
+    featureFlags: ['remote_memory_read', 'remote_memory_durable_write', 'remote_memory_ga'] as const,
+  };
+  await operator.provision(input);
+  const store = new GitCanonicalMemoryStore({
+    binding: {tenantId: input.tenantId, shareId: input.shareId},
+    worktree: git.worktree,
+  });
+  const repository = new PostgresRemoteMemoryRepository(database.sql, {gitStore: store});
+  return {
+    database,
+    git,
+    input,
+    operator,
+    repository,
+    store,
+    dispose: async () => {
+      await database.dispose();
+      await rm(git.root, {recursive: true, force: true});
+    },
+  };
+}
+
+postgresDescribe('Git ingest system authority', () => {
+  it('keeps readiness failed until a failed Git ingest actually recovers', async () => {
+    const f = await fixture();
+    try {
+      const indexer = new RemoteMemoryIndexer(f.database.sql, f.store);
+      const setStatus = async (status: 'active' | 'revoked') =>
+        f.database.migratorSql.begin(async tx => {
+          await tx`SELECT set_config('threadnote.tenant_id', ${f.input.tenantId}, true)`;
+          await tx`UPDATE remote_memory.share_grants SET status = ${status} WHERE principal_id LIKE 'system:git-ingest:%'`;
+        });
+      const health = async () =>
+        (
+          await f.database.sql<
+            {failure_class: string | null}[]
+          >`SELECT failure_class FROM remote_memory.worker_health WHERE worker_name = 'indexer'`
+        )[0]?.failure_class;
+      await setStatus('revoked');
+      expect(await indexer.runPass()).toEqual({failed: 1, processed: 0});
+      expect(await health()).toBe('git_ingest_failed');
+      await indexer.runPass({ingest: false});
+      expect(await health()).toBe('git_ingest_failed');
+      await setStatus('active');
+      await indexer.runPass({ingest: false});
+      expect(await health()).toBe('git_ingest_failed');
+      expect(await indexer.runPass()).toEqual({failed: 0, processed: 0});
+      expect(await health()).toBeNull();
+    } finally {
+      await f.dispose();
+    }
+  });
+
+  it('rejects HTTP body replacement that would erase metadata from Git', async () => {
+    const f = await fixture();
+    try {
+      const path = 'durable/projects/restricted/rich.md';
+      const content =
+        'MEMORY\nkind: durable\nstatus: active\nproject: restricted\ntopic: rich\nkeywords: retained-keyword\n\nRetain the original body.';
+      const committed = await f.store.commit({path, content, message: 'Rich Git memory'});
+      await f.repository.ingestActiveGitShares('rich-ingest');
+      const principal = await new PostgresRemoteControlPlane(f.database.sql).authorize(
+        {issuer: f.input.issuer, subject: f.input.subject, scopes: new Set(f.input.capabilities)},
+        f.input.shareId,
+      );
+      if (!principal) throw new Error('Fixture principal missing');
+      const uri = `threadnote://share/${f.input.shareId}/memories/durable/restricted/rich.md`;
+      const original = await f.repository.read(principal, {version: 1, uri}, 'read-rich');
+      await expect(
+        f.repository.remember(
+          principal,
+          {
+            version: 1,
+            kind: 'durable',
+            project: 'restricted',
+            topic: 'rich',
+            text: 'Changed body',
+            operationId: 'replace-rich',
+            baseRevision: original.receipt.revision,
+          },
+          'replace-rich',
+        ),
+      ).rejects.toMatchObject({code: 'invalid_request', details: {reason: 'unsupported_remote_metadata'}});
+      expect((await f.store.listCanonicalPaths()).find(entry => entry.gitPath === path)?.gitCommit).toBe(
+        committed.gitCommit,
+      );
+      expect(await f.store.read({commit: committed.gitCommit, path})).toBe(content);
+    } finally {
+      await f.dispose();
+    }
+  });
+
+  it('projects canonical Git independently of member order, scopes, and revocation', async () => {
+    const f = await fixture();
+    try {
+      for (const member of ['aaa-member', 'zzz-member']) {
+        await f.operator.provision({...f.input, principalId: member, subject: member});
+      }
+      for (const phase of ['active', 'revoked']) {
+        if (phase === 'revoked')
+          await f.database.migratorSql.begin(async tx => {
+            await tx`SELECT set_config('threadnote.tenant_id', ${f.input.tenantId}, true)`;
+            await tx`UPDATE remote_memory.tenant_memberships SET status = 'revoked' WHERE principal_id NOT LIKE 'system:%'`;
+          });
+        await f.store.commit({
+          path: `durable/projects/canonical/${phase}.md`,
+          content: `Canonical ${phase} body.`,
+          message: 'Git authority fixture',
+        });
+        expect((await f.repository.ingestActiveGitShares(`ingest-${phase}`)).ingested).toBe(1);
+      }
+      const actors = await f.database.migratorSql.begin(async tx => {
+        await tx`SELECT set_config('threadnote.tenant_id', ${f.input.tenantId}, true)`;
+        return tx<{oauth_principal_id: string}[]>`SELECT oauth_principal_id FROM remote_memory.memory_revisions`;
+      });
+      expect(actors).toHaveLength(2);
+      for (const actor of actors) expect(actor.oauth_principal_id).toMatch(/^system:git-ingest:/u);
+    } finally {
+      await f.dispose();
+    }
+  });
+
+  it('fails closed when the provisioned ingest identity is missing or revoked', async () => {
+    const f = await fixture();
+    try {
+      await f.database.migratorSql.begin(async tx => {
+        await tx`SELECT set_config('threadnote.tenant_id', ${f.input.tenantId}, true)`;
+        await tx`UPDATE remote_memory.share_grants SET status = 'revoked' WHERE principal_id LIKE 'system:git-ingest:%'`;
+      });
+      await expect(f.repository.ingestActiveGitShares('revoked-system')).rejects.toMatchObject({
+        code: 'service_unavailable',
+        details: {reason: 'git_ingest_identity_unavailable'},
+      });
+      await f.operator.provision(f.input);
+      await expect(f.repository.ingestActiveGitShares('still-revoked')).rejects.toMatchObject({
+        code: 'service_unavailable',
+      });
+    } finally {
+      await f.dispose();
+    }
+  });
+});

--- a/test/integration/remote-memory-git-composer.test.ts
+++ b/test/integration/remote-memory-git-composer.test.ts
@@ -211,12 +211,12 @@ postgresDescribe('git-backed remote memory composer', () => {
           topic: 'ignored',
           visibility: 'shared',
         },
-        'Unauthorized project must be skipped.',
+        'Canonical project is indexed independently of this member permission.',
       ),
       'utf8',
     );
     await git(['add', '--', otherPath], laptop);
-    await git(['commit', '-m', 'unauthorized project'], laptop);
+    await git(['commit', '-m', 'another canonical project'], laptop);
     await git(['push', 'origin', 'main'], laptop);
 
     expect(await indexer.runPass({batchSize: 8})).toMatchObject({failed: 0});
@@ -235,7 +235,20 @@ postgresDescribe('git-backed remote memory composer', () => {
         ORDER BY h.topic
       `,
     );
-    expect(stored).toEqual([{markdown_body: '', topic}]);
+    expect(stored).toEqual([
+      {markdown_body: '', topic: 'ignored'},
+      {markdown_body: '', topic},
+    ]);
+    await expect(
+      repository.read(
+        principal,
+        {
+          uri: formatRemoteMemoryUri({kind: 'durable', project: 'other-project', shareId: SHARE, topic: 'ignored'}),
+          version: 1,
+        },
+        'restricted-member-read',
+      ),
+    ).rejects.toMatchObject({code: 'forbidden'});
   });
 
   it('does not resurrect a terminal handoff during git ingest', async () => {

--- a/test/unit/remote-memory-document-compatibility.test.ts
+++ b/test/unit/remote-memory-document-compatibility.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {assertRemoteBodyReplacementSupported} from '../../src/remote_memory/document_compatibility.js';
+
+describe('remote body replacement compatibility', () => {
+  it('rejects unknown header fields without consuming or rewriting them', () => {
+    FC.assert(
+      FC.property(
+        FC.stringMatching(/^[a-z]{1,24}$/u),
+        FC.string({maxLength: 40}).filter(value => !/[\r\n]/u.test(value)),
+        (key, value) => {
+          const document = `MEMORY\nkind: durable\nx_${key}: ${value}\n\nOriginal body`;
+          expect(() => assertRemoteBodyReplacementSupported(document)).toThrow('metadata');
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it('supports basic remote documents and rejects rich or malformed local ones', () => {
+    expect(() =>
+      assertRemoteBodyReplacementSupported('MEMORY\nkind: durable\n\nThe documentation mentions `<!-- MEMORY_FIELDS`.'),
+    ).not.toThrow();
+    expect(() =>
+      assertRemoteBodyReplacementSupported('MEMORY\nkind: durable\nstatus: active\nmemory_id: tn_123\n\nBody'),
+    ).not.toThrow();
+    for (const field of [
+      'code_citation: invalid',
+      'relation: references threadnote://memory/tn_123',
+      'keywords: important',
+      'trust: approved',
+      'workspace_scope: src',
+      'this header is malformed',
+    ]) {
+      expect(() => assertRemoteBodyReplacementSupported(`MEMORY\nkind: durable\n${field}\n\nBody`)).toThrow();
+    }
+    expect(() => assertRemoteBodyReplacementSupported('Plain Git document')).toThrow();
+    expect(() =>
+      assertRemoteBodyReplacementSupported(
+        'MEMORY\nkind: durable\n\nBody\n\n<!-- MEMORY_FIELDS\nreferences: legacy\n-->',
+      ),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
Git ingestion previously borrowed the first writable member's grant, so member ordering, project restrictions, or revocation could change the organization's canonical projection. Provision a dedicated per-share system identity, enforce its active principal/membership/grant, and keep ingestion failure visible in readiness until a successful ingestion recovers it.

HTTP body replacement now rejects rich, unknown, or legacy metadata before changing Git, preventing silent loss of citations, relations, keywords, and provenance until the remote editor supports them. Basic remote memories remain editable. Upgrade instructions explain the one-time operator provisioning and system identity revocation behavior.

Validation: 64 focused tests across seven files passed, including restricted-runtime PostgreSQL integration and a bounded unknown-header property. The review's minor legacy-marker false positive was fixed and its focused regression passed. Lint, formatting, typecheck, and full dev-cycle review passed with zero blocking findings. CI supplies the full-suite result. Git push/crash recovery and external lifecycle/removal remain the next productization gate.
