### PR TITLE
fix(org): preserve provider OAuth issuer identity

### DIFF
--- a/docs/org-productization.md
+++ b/docs/org-productization.md
@@ -121,6 +121,10 @@ An HTTP edit cannot silently remove metadata used by the local product; broad re
 
 ### P2 — Real OAuth and supported client attach
 
+The provider compatibility slice preserves exact OAuth issuer identifiers and accepts an absent optional `nbf`
+claim while retaining signature, audience, expiry and lifetime checks. Regression examples and a bounded issuer
+preservation property cover this contract. Provider provisioning and actual client login remain separate gates.
+
 - Configure the selected Auth0 tenant/API/client and one user's subject grant through operator provisioning.
 - Match issuer exactly, support standards-valid optional claims without relaxing audience/signature/lifetime
   checks, and retain negative tests for expired/wrong issuer/wrong audience/wrong scope tokens.

--- a/docs/remote-memory/operations.md
+++ b/docs/remote-memory/operations.md
@@ -128,6 +128,18 @@ Adding or replacing a member grant does not replace that catalog. A share-wide c
 `expectedCurrentPolicyVersion`; an omitted `allowedProjects` means every active project in the share catalog, not an
 unprovisioned project name.
 
+## OAuth provider configuration
+
+Set `THREADNOTE_REMOTE_OAUTH_ISSUER` to the provider's exact issuer identifier, including any trailing slash.
+The same string must appear in the signed token's `iss` claim and the operator-provisioned member identity.
+For an Auth0 tenant this is typically `https://<tenant>.<region>.auth0.com/`. Issuer comparison is exact; do not
+remove the slash to match an origin. JWKS must stay on the issuer's origin.
+
+The API audience must equal the public `/mcp` URL. Configure RS256 access tokens with a five-minute lifetime;
+the verifier requires `sub`, `iat`, and `exp`, caps lifetime at ten minutes plus five seconds of clock tolerance,
+and validates `nbf` when present. A missing optional `nbf` claim is accepted; malformed or inconsistent time
+claims are rejected. The loopback demo issuer remains restricted to local development.
+
 ## Health and safe telemetry
 
 - `/healthz`: process liveness only.

--- a/src/remote_memory/config.ts
+++ b/src/remote_memory/config.ts
@@ -37,15 +37,14 @@ export function remoteMemoryConfigFromEnvironment(
   if (publicBaseUrl.pathname !== '/' || publicBaseUrl.search || publicBaseUrl.hash) {
     throw remoteMemoryError('invalid_request', 'THREADNOTE_REMOTE_PUBLIC_URL must be an origin without a path.');
   }
-  const accessTokenIssuer = issuerValue(
-    httpsUrl(required(environment, 'THREADNOTE_REMOTE_OAUTH_ISSUER'), 'THREADNOTE_REMOTE_OAUTH_ISSUER'),
+  const accessTokenIssuer = required(environment, 'THREADNOTE_REMOTE_OAUTH_ISSUER');
+  assertIssuerUrl(httpsUrl(accessTokenIssuer, 'THREADNOTE_REMOTE_OAUTH_ISSUER'));
+  const cursorIssuerUrl = httpsUrl(
+    environment.THREADNOTE_REMOTE_CURSOR_ISSUER?.trim() || 'https://api.cursor.com',
+    'THREADNOTE_REMOTE_CURSOR_ISSUER',
   );
-  const cursorIssuer = issuerValue(
-    httpsUrl(
-      environment.THREADNOTE_REMOTE_CURSOR_ISSUER?.trim() || 'https://api.cursor.com',
-      'THREADNOTE_REMOTE_CURSOR_ISSUER',
-    ),
-  );
+  assertIssuerUrl(cursorIssuerUrl);
+  const cursorIssuer = cursorIssuerUrl.toString().replace(/\/$/u, '');
   const databaseUrl = databaseConnectionUrl(required(environment, 'THREADNOTE_REMOTE_DATABASE_URL'));
   const localService = publicBaseUrl.hostname === 'localhost' || publicBaseUrl.hostname === '127.0.0.1';
   const autoMigrate = booleanValue(environment.THREADNOTE_REMOTE_AUTO_MIGRATE, localService);
@@ -221,10 +220,9 @@ function databaseConnectionUrl(value: string): string {
   return value;
 }
 
-function issuerValue(url: URL): string {
+function assertIssuerUrl(url: URL): void {
   if (url.search || url.hash)
     throw remoteMemoryError('invalid_request', 'Issuer URLs cannot contain a query or fragment.');
-  return url.toString().replace(/\/$/u, '');
 }
 
 function configuredUrl(value: string | undefined, fallback: URL | undefined, key: string): URL {

--- a/src/remote_memory/oauth.ts
+++ b/src/remote_memory/oauth.ts
@@ -60,7 +60,7 @@ function createAccessTokenVerifier(
           clockTolerance: 5,
           issuer: config.issuer,
           maxTokenAge: '10 minutes',
-          requiredClaims: ['sub', 'iat', 'nbf', 'exp'],
+          requiredClaims: ['sub', 'iat', 'exp'],
         }));
       } catch {
         throw remoteMemoryError('unauthorized', 'The access token could not be verified.');
@@ -70,7 +70,7 @@ function createAccessTokenVerifier(
       }
       const issuedAt = numericDate(payload.iat);
       const expiresAt = numericDate(payload.exp);
-      const notBefore = numericDate(payload.nbf);
+      const notBefore = payload.nbf === undefined ? issuedAt : numericDate(payload.nbf);
       if (expiresAt <= issuedAt || expiresAt - issuedAt > 605 || notBefore > issuedAt + 5) {
         throw remoteMemoryError('unauthorized', 'The access token lifetime is invalid.');
       }

--- a/src/remote_memory/postgres_control_plane.ts
+++ b/src/remote_memory/postgres_control_plane.ts
@@ -847,7 +847,7 @@ function validateProvisioningIdentity(issuer: string, subject: string): void {
     parsed.password ||
     parsed.search ||
     parsed.hash ||
-    issuer !== parsed.toString().replace(/\/$/u, '')
+    (issuer !== parsed.toString() && issuer !== parsed.toString().replace(/\/$/u, ''))
   ) {
     throw remoteMemoryError(
       'invalid_request',

--- a/test/integration/remote-memory-oauth-provider.test.ts
+++ b/test/integration/remote-memory-oauth-provider.test.ts
@@ -1,0 +1,62 @@
+import {generateKeyPair, SignJWT} from 'jose';
+import {describe, expect, it} from 'vitest';
+import {remoteMemoryConfigFromEnvironment} from '../../src/remote_memory/config.js';
+import {createLocalOAuthTokenVerifier} from '../../src/remote_memory/oauth.js';
+import {PostgresRemoteControlPlane} from '../../src/remote_memory/postgres_control_plane.js';
+import {createRemoteMemoryPostgresFixture} from '../helpers/remote-memory-postgres.js';
+
+const TEST_DATABASE_URL = process.env.THREADNOTE_TEST_POSTGRES_URL;
+const postgresDescribe = TEST_DATABASE_URL ? describe.sequential : describe.skip;
+
+postgresDescribe('remote memory OAuth provider identity', () => {
+  it('provisions, verifies and authorizes an exact issuer without conflating its slashless identity', async () => {
+    const fixture = await createRemoteMemoryPostgresFixture(TEST_DATABASE_URL!);
+    try {
+      const config = remoteMemoryConfigFromEnvironment({
+        THREADNOTE_REMOTE_PUBLIC_URL: 'https://memory.example.test',
+        THREADNOTE_REMOTE_OAUTH_ISSUER: 'https://identity.example.test/',
+        THREADNOTE_REMOTE_DATABASE_URL: 'postgresql://runtime@localhost/threadnote',
+      });
+      const operator = new PostgresRemoteControlPlane(fixture.migratorSql);
+      const control = new PostgresRemoteControlPlane(fixture.sql);
+      await operator.provision({
+        tenantId: 'oauth-tenant',
+        shareId: 'oauth-share',
+        principalId: 'oauth-member',
+        issuer: config.accessTokenIssuer,
+        subject: 'same-subject',
+        displayName: 'OAuth fixture',
+        region: 'eu-test',
+        policyVersion: 'grant-v1',
+        sharePolicyVersion: 'share-v1',
+        capabilities: ['memory:read'],
+        cursorAttestationRequired: false,
+        featureFlags: ['remote_memory_read', 'remote_memory_ga'],
+        projects: ['threadnote'],
+      });
+      const {publicKey, privateKey} = await generateKeyPair('RS256');
+      const tokenVerifier = createLocalOAuthTokenVerifier({
+        audience: config.accessTokenAudience,
+        issuer: config.accessTokenIssuer,
+        publicKey,
+      });
+      const now = Math.floor(Date.now() / 1000);
+      const token = await new SignJWT({scope: 'memory:read'})
+        .setProtectedHeader({alg: 'RS256', typ: 'at+jwt'})
+        .setIssuer(config.accessTokenIssuer)
+        .setAudience(config.accessTokenAudience)
+        .setSubject('same-subject')
+        .setIssuedAt(now)
+        .setExpirationTime(now + 300)
+        .sign(privateKey);
+      const claims = await tokenVerifier.verify(token);
+
+      expect(await control.authorize(claims, 'oauth-share')).toMatchObject({principalId: 'oauth-member'});
+      expect(
+        await control.authorize({...claims, issuer: 'https://identity.example.test'}, 'oauth-share'),
+      ).toBeUndefined();
+    } finally {
+      await fixture.dispose();
+    }
+  });
+});

--- a/test/unit/remote-memory-auth-config.test.ts
+++ b/test/unit/remote-memory-auth-config.test.ts
@@ -59,7 +59,7 @@ describe('remote memory service configuration', () => {
     const config = remoteMemoryConfigFromEnvironment(productionEnvironment);
 
     expect(config.publicBaseUrl.toString()).toBe('https://memory.example.test/');
-    expect(config.accessTokenIssuer).toBe('https://identity.example.test/tenant');
+    expect(config.accessTokenIssuer).toBe('https://identity.example.test/tenant/');
     expect(config.allowedHosts).toEqual(['memory.example.test', 'memory.internal.test:8443']);
     expect(config.allowedOrigins).toEqual(['https://cursor.com', 'https://app.cursor.com']);
     expect(config.accessTokenAudience).toBe('https://memory.example.test/mcp');
@@ -71,6 +71,22 @@ describe('remote memory service configuration', () => {
     expect(config.maxBodyBytes).toBe(256 * 1024);
     expect(config.readRequestsPerMinute).toBe(300);
     expect(config.writeRequestsPerMinute).toBe(60);
+  });
+
+  it('preserves the exact OAuth issuer identifier after trimming environment whitespace', () => {
+    fc.assert(
+      fc.property(fc.webUrl({validSchemes: ['https']}), fc.boolean(), (url, trailingSlash) => {
+        const issuer = `${new URL(url).origin}${trailingSlash ? '/' : ''}`;
+        const config = remoteMemoryConfigFromEnvironment({
+          ...productionEnvironment,
+          THREADNOTE_REMOTE_OAUTH_ISSUER: `  ${issuer}  `,
+          THREADNOTE_REMOTE_OAUTH_JWKS_URL: `${new URL(issuer).origin}/.well-known/jwks.json`,
+        });
+
+        expect(config.accessTokenIssuer).toBe(issuer);
+      }),
+      {numRuns: 100},
+    );
   });
 
   it('permits an explicit localhost development service without database TLS', () => {
@@ -150,7 +166,7 @@ describe('remote memory service configuration', () => {
     expect(redacted).not.toHaveProperty('databaseUrl');
     expect(redacted).not.toHaveProperty('accessTokenJwksUrl');
     expect(redacted).toMatchObject({
-      accessTokenIssuer: 'https://identity.example.test/tenant',
+      accessTokenIssuer: 'https://identity.example.test/tenant/',
       canonicalStore: 'postgres',
       publicBaseUrl: 'https://memory.example.test/',
     });

--- a/test/unit/remote-memory-auth-oauth.test.ts
+++ b/test/unit/remote-memory-auth-oauth.test.ts
@@ -33,10 +33,10 @@ afterAll(async () => {
   await jwksServer.stop(true);
 });
 
-function verifier() {
+function verifier(issuer = ISSUER) {
   return createOAuthTokenVerifier({
     audience: AUDIENCE,
-    issuer: ISSUER,
+    issuer,
     jwksUrl: new URL('/jwks', jwksServer.url),
   });
 }
@@ -95,12 +95,31 @@ describe('remote memory OAuth access tokens', () => {
     expect((await verifier().verify(token)).scopes).toEqual(new Set(['memory:read', 'memory:admin']));
   });
 
+  it('accepts a bounded access token without the optional not-before claim', async () => {
+    const token = await accessToken({nbf: undefined});
+
+    expect(await verifier().verify(token)).toMatchObject({issuer: ISSUER, subject: 'oauth-subject'});
+  });
+
+  it.each([false, true])('matches the exact issuer identifier with trailing slash=%s', async trailingSlash => {
+    const issuer = `https://threadnote-org.eu.auth0.com${trailingSlash ? '/' : ''}`;
+    const otherIssuer = `https://threadnote-org.eu.auth0.com${trailingSlash ? '' : '/'}`;
+    const token = await accessToken({iss: issuer, nbf: undefined});
+
+    expect((await verifier(issuer).verify(token)).issuer).toBe(issuer);
+    await expect(verifier(otherIssuer).verify(token)).rejects.toMatchObject({code: 'unauthorized'});
+  });
+
+  it.each([null, 'invalid', 0, -1, 0.5])('rejects a malformed optional not-before claim %#', async nbf => {
+    await expectUnauthorized(await accessToken({nbf}));
+  });
+
   it.each([
     ['wrong issuer', {iss: 'https://attacker.example.test'}],
     ['wrong audience', {aud: 'https://other.example.test/mcp'}],
     ['missing subject', {sub: undefined}],
     ['missing issued-at', {iat: undefined}],
-    ['missing not-before', {nbf: undefined}],
+    ['missing expiry', {exp: undefined}],
   ])('rejects %s', async (_label, overrides) => {
     await expectUnauthorized(await accessToken(overrides));
   });

--- a/test/unit/remote-memory-provisioning.test.ts
+++ b/test/unit/remote-memory-provisioning.test.ts
@@ -42,7 +42,11 @@ describe('remote memory provisioning boundary', () => {
       {repositoryBindings: {threadnote: ['https://github.com:8443/example/threadnote']}},
     ],
     ['scheme-free repository', {repositoryBindings: {threadnote: ['github.com/example/threadnote']}}],
-    ['noncanonical issuer', {issuer: 'https://identity.example.test/'}],
+    ['noncanonical issuer', {issuer: 'https://IDENTITY.example.test'}],
+    ['issuer credentials', {issuer: 'https://user:credential@identity.example.test/'}],
+    ['issuer query', {issuer: 'https://identity.example.test/?query=value'}],
+    ['issuer fragment', {issuer: 'https://identity.example.test/#fragment'}],
+    ['issuer whitespace', {issuer: ' https://identity.example.test/ '}],
     ['insecure issuer', {issuer: 'http://identity.example.test'}],
     ['blank subject', {subject: '  '}],
   ] as const)('rejects an unaddressable %s before storage', (_label, invalid) => {
@@ -57,6 +61,13 @@ describe('remote memory provisioning boundary', () => {
       validateRemoteMemoryProvisioningInput({...validProvisioning, issuer: 'http://localhost:18788'}),
     ).not.toThrow();
   });
+
+  it.each(['https://identity.example.test/', 'https://identity.example.test/tenant/'])(
+    'accepts the exact provider issuer %s',
+    issuer => {
+      expect(() => validateRemoteMemoryProvisioningInput({...validProvisioning, issuer})).not.toThrow();
+    },
+  );
 
   it('decodes bounded JSONB text without relying on the PostgreSQL driver JSON representation', () => {
     const json = '{"displayName": "Threadnote managed memory", "projects": ["threadnote"]}';


### PR DESCRIPTION
Auth0 access tokens could not authorize organization members: configuration removed the issuer's trailing slash, provisioning rejected it, and the verifier required the optional `nbf` claim.

Preserve the exact issuer through configuration, provisioning, and identity matching, and accept absent `nbf` while retaining signature, audience, expiry, and bounded lifetime checks. Add a provision → signed-token verification → restricted-runtime authorization regression with slash-mismatch denial, plus issuer-preservation property coverage and operator guidance.

Validation: 110 focused tests across five files passed, including PostgreSQL integration; lint and typecheck passed. Dev-cycle full review found one provisioning mismatch; the fix passed incremental review with zero blocking findings. CI runs the full suite.
