### PR TITLE
Support registered OAuth clients in org attach

### DIFF
--- a/docs/remote-memory/operations.md
+++ b/docs/remote-memory/operations.md
@@ -140,6 +140,49 @@ the verifier requires `sub`, `iat`, and `exp`, caps lifetime at ten minutes plus
 and validates `nbf` when present. A missing optional `nbf` claim is accepted; malformed or inconsistent time
 claims are rejected. The loopback demo issuer remains restricted to local development.
 
+Register a public OAuth client for each agent and use authorization code with S256 PKCE. A public client has
+no client secret in the agent configuration. Pass its ID when attaching Cursor on a laptop:
+
+```sh
+threadnote mcp-install cursor --project /absolute/repository \
+  --composer-url https://memory.example.test/mcp --share-id engineering \
+  --composer-client-id REGISTERED_PUBLIC_CLIENT_ID --apply
+```
+
+For Cursor Cloud, `threadnote cloud cursor config --mode org --endpoint https://memory.example.test/mcp
+--share-id engineering --client-id REGISTERED_PUBLIC_CLIENT_ID` prints the corresponding configuration.
+Both commands retain the existing stdio/graph split and bind the share in the HTTP header. Omitting the client ID
+retains the legacy `threadnote-composer` demo ID; use that default only with the loopback demo issuer. Production
+issuers require their registered ID. These commands do not obtain or persist tokens; complete OAuth login in the agent.
+
+Cursor's published callbacks are `http://localhost:8787/callback` for desktop and
+`https://www.cursor.com/agents/mcp/oauth/callback` for web/cloud. Register only the surfaces in use and validate an
+actual login after installation. Configuration shape alone does not establish provider or agent compatibility.
+
+VS Code/Copilot uses `type: "http"` and `oauth.clientId`; the installer and dry-run output select that schema
+for `mcp-install copilot`. Cursor uses `auth.CLIENT_ID` and explicit scopes. Register a separate public client
+with the callback URLs required by the selected application. See the
+[VS Code MCP configuration reference](https://code.visualstudio.com/docs/agents/reference/mcp-configuration).
+
+Codex has its own HTTP OAuth configuration; do not copy Cursor's `auth.CLIENT_ID` object into it. Register the
+client with `codex mcp add threadnote-org --url https://memory.example.test/mcp --oauth-client-id
+REGISTERED_PUBLIC_CLIENT_ID --oauth-resource https://memory.example.test/mcp`, then configure its share header
+and registered callback in the existing `mcp_servers.threadnote-org` entry:
+
+```toml
+http_headers = { threadnote-share-id = "engineering" }
+oauth = { client_id = "REGISTERED_PUBLIC_CLIENT_ID", callback_url = "http://127.0.0.1:18789/callback", callback_port = 18789 }
+```
+
+The listener port must match the registered callback, and the issuer must advertise issuer-response support for a
+fixed callback without Codex's server-specific suffix. Complete `codex mcp login threadnote-org --scopes
+memory:read,memory:write:durable,memory:write:handoff`. Keep the local Threadnote stdio entry enabled.
+Threadnote's `mcp-install --composer-url` workflow currently automates Cursor/Copilot JSON configuration only.
+
+References: [Cursor static OAuth](https://prod.cursor.com/docs/mcp#static-oauth-for-remote-servers),
+[Codex configuration](https://learn.chatgpt.com/docs/config-file/config-reference), and
+[Auth0 MCP setup](https://auth0.com/ai/docs/mcp/get-started/authorization-for-your-mcp-server).
+
 ## Health and safe telemetry
 
 - `/healthz`: process liveness only.

--- a/src/cursor/cloud.ts
+++ b/src/cursor/cloud.ts
@@ -273,13 +273,14 @@ export function buildCursorCloudRemoteHybridMcpConfig(
   profile: CursorCloudProfileV1,
   endpoint: string,
   shareId: string,
+  clientId?: string,
 ): CursorCloudRemoteHybridMcpConfig {
   const url = cursorCloudMemoryEndpoint(endpoint);
   const boundShareId = cursorCloudRemoteShareId(shareId);
   return {
     mcpServers: {
       'threadnote-local': buildCursorCloudLocalGraphMcpConfig(profile, url, boundShareId),
-      'threadnote-memory': buildComposerHttpMcpEntry(url, boundShareId),
+      'threadnote-memory': buildComposerHttpMcpEntry(url, boundShareId, clientId),
     },
   };
 }
@@ -288,13 +289,14 @@ export function buildOrgCloudHybridMcpConfig(
   profile: CursorCloudProfileV1,
   endpoint: string,
   shareId: string,
+  clientId?: string,
 ): OrgCloudHybridMcpConfig {
   const url = composerMcpUrl(endpoint);
   const boundShareId = composerShareId(shareId);
   return {
     mcpServers: {
       'threadnote-local': buildCursorCloudLocalGraphMcpConfig(profile, url, boundShareId, 'org'),
-      [THREADNOTE_ORG_MCP_NAME]: buildComposerHttpMcpEntry(url, boundShareId),
+      [THREADNOTE_ORG_MCP_NAME]: buildComposerHttpMcpEntry(url, boundShareId, clientId),
     },
     policy: ORG_COMPOSER_POLICY,
   };
@@ -464,6 +466,7 @@ export const runCursorCloudConfig = Effect.fn('cursorCloud.config')(function* (
   config: RuntimeConfig,
   options: {
     readonly agentId?: string;
+    readonly clientId?: string;
     readonly endpoint?: string;
     readonly mode?: CursorCloudMode;
     readonly shareId?: string;
@@ -484,12 +487,14 @@ export const runCursorCloudConfig = Effect.fn('cursorCloud.config')(function* (
           profile,
           requiredHybridEndpoint(options.endpoint, 'org'),
           requiredRemoteShareId(options.shareId),
+          options.clientId,
         )
       : options.mode === 'remote-hybrid'
         ? buildCursorCloudRemoteHybridMcpConfig(
             profile,
             requiredHybridEndpoint(options.endpoint, 'remote-hybrid'),
             requiredRemoteShareId(options.shareId),
+            options.clientId,
           )
         : buildCursorCloudMcpConfig(profile, teams);
   yield* Console.log(JSON.stringify(output, undefined, 2));

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -1193,6 +1193,10 @@ const mcpInstall = Command.make(
       Argument.withDescription('codex, claude, cursor, or copilot'),
     ),
     apply: boolean('apply', 'Actually modify the selected agent config'),
+    composerClientId: optionalString(
+      'composer-client-id',
+      'Registered public OAuth client ID for the organization composer',
+    ),
     composerUrl: optionalString('composer-url', 'Organization composer Streamable HTTP MCP URL'),
     name: defaultString('name', 'MCP server name', THREADNOTE_MCP_NAME),
     project: optionalString('project', 'Write Cursor/Copilot MCP into this repository .cursor/mcp.json'),
@@ -1563,6 +1567,7 @@ const cursorCloudConfig = Command.make(
   'config',
   {
     ...cursorCloudBaseIdentityFlags,
+    clientId: optionalString('client-id', 'Registered public OAuth client ID for the organization composer'),
     endpoint: optionalString('endpoint', 'Managed remote Streamable HTTP MCP endpoint'),
     memoryMode: defaultChoice(
       'memory-mode',
@@ -1574,16 +1579,9 @@ const cursorCloudConfig = Command.make(
     shareId: optionalString('share-id', 'Opaque managed remote memory share identifier'),
     teams: repeatedString('team', 'Personal Git memory share; repeat to expose several through one MCP'),
   },
-  ({agentId, endpoint, mode, shareId, teams, user}) =>
+  options =>
     withRuntimeEffect(config =>
-      runCursorCloudConfig(cursorCloudRuntime(config, agentId, user), {
-        agentId,
-        endpoint,
-        mode,
-        shareId,
-        teams,
-        user,
-      }),
+      runCursorCloudConfig(cursorCloudRuntime(config, options.agentId, options.user), options),
     ),
 ).pipe(Command.withDescription('Print a deterministic Cursor Dashboard MCP configuration'));
 

--- a/src/mcp/composer_attach.ts
+++ b/src/mcp/composer_attach.ts
@@ -21,23 +21,36 @@ export class ComposerAttachError extends Schema.TaggedError<ComposerAttachError>
 }) {}
 
 export interface ComposerShareBinding {
+  readonly clientId?: string;
   readonly shareId: string;
   readonly url: string;
 }
 
 export interface ComposerMcpOAuthAuth {
-  readonly CLIENT_ID: typeof COMPOSER_OAUTH_CLIENT_ID;
+  readonly CLIENT_ID: string;
   readonly scopes: readonly (typeof COMPOSER_OAUTH_SCOPES)[number][];
 }
 
 export interface ComposerHttpMcpEntry {
   readonly [key: string]: unknown;
+  readonly type?: never;
   readonly auth: ComposerMcpOAuthAuth;
   readonly headers: Readonly<{readonly [THREADNOTE_COMPOSER_SHARE_ID_HEADER]: string}>;
   readonly url: string;
 }
 
+export interface CopilotComposerHttpMcpEntry {
+  readonly [key: string]: unknown;
+  readonly type: 'http';
+  readonly oauth: Readonly<{clientId: string}>;
+  readonly headers: ComposerHttpMcpEntry['headers'];
+  readonly url: string;
+}
+
+export type ComposerClientHttpMcpEntry = ComposerHttpMcpEntry | CopilotComposerHttpMcpEntry;
+
 export interface ComposerAttachOptions {
+  readonly composerClientId?: string;
   readonly composerUrl?: string;
   readonly shareId?: string;
 }
@@ -45,13 +58,17 @@ export interface ComposerAttachOptions {
 export function resolveComposerAttach(options: ComposerAttachOptions): ComposerShareBinding | undefined {
   const composerUrl = options.composerUrl?.trim();
   const shareId = options.shareId?.trim();
-  if (!composerUrl && !shareId) return undefined;
+  if (!composerUrl && !shareId && options.composerClientId === undefined) return undefined;
   if (!composerUrl || !shareId) {
     throw ComposerAttachError.make({
       message: 'Organization composer attach requires both --composer-url and --share-id.',
     });
   }
-  return {shareId: composerShareId(shareId), url: composerMcpUrl(composerUrl)};
+  return {
+    ...(options.composerClientId === undefined ? {} : {clientId: composerOAuthClientId(options.composerClientId)}),
+    shareId: composerShareId(shareId),
+    url: composerMcpUrl(composerUrl),
+  };
 }
 
 export function resolveComposerServeShareId(teamName: string, shareId?: string): string {
@@ -103,10 +120,14 @@ export function composerMcpUrl(endpoint: string): string {
   return parsed.toString();
 }
 
-export function buildComposerHttpMcpEntry(url: string, shareId: string): ComposerHttpMcpEntry {
+export function buildComposerHttpMcpEntry(
+  url: string,
+  shareId: string,
+  clientId: string = COMPOSER_OAUTH_CLIENT_ID,
+): ComposerHttpMcpEntry {
   return {
     auth: {
-      CLIENT_ID: COMPOSER_OAUTH_CLIENT_ID,
+      CLIENT_ID: composerOAuthClientId(clientId),
       scopes: [...COMPOSER_OAUTH_SCOPES],
     },
     headers: {[THREADNOTE_COMPOSER_SHARE_ID_HEADER]: composerShareId(shareId)},
@@ -114,11 +135,21 @@ export function buildComposerHttpMcpEntry(url: string, shareId: string): Compose
   };
 }
 
+export function buildCopilotComposerHttpMcpEntry(
+  url: string,
+  shareId: string,
+  clientId: string = COMPOSER_OAUTH_CLIENT_ID,
+): CopilotComposerHttpMcpEntry {
+  const entry = buildComposerHttpMcpEntry(url, shareId, clientId);
+  return {type: 'http', url: entry.url, headers: entry.headers, oauth: {clientId: entry.auth.CLIENT_ID}};
+}
+
 export function withComposerHttpMcpEntry(
   servers: Readonly<Record<string, JsonObject>>,
   stdioName: string,
   stdio: JsonObject,
   attach: ComposerShareBinding | undefined,
+  client: 'cursor' | 'copilot' = 'cursor',
 ): Record<string, JsonObject> {
   if (attach && stdioName === THREADNOTE_ORG_MCP_NAME) {
     throw ComposerAttachError.make({
@@ -126,7 +157,10 @@ export function withComposerHttpMcpEntry(
     });
   }
   const next: Record<string, JsonObject> = {...servers, [stdioName]: stdio};
-  if (attach) next[THREADNOTE_ORG_MCP_NAME] = buildComposerHttpMcpEntry(attach.url, attach.shareId);
+  if (attach) {
+    const build = client === 'copilot' ? buildCopilotComposerHttpMcpEntry : buildComposerHttpMcpEntry;
+    next[THREADNOTE_ORG_MCP_NAME] = build(attach.url, attach.shareId, attach.clientId);
+  }
   return next;
 }
 
@@ -141,29 +175,48 @@ export function stdioEnvironmentCallsComposer(env: Readonly<Record<string, unkno
   return typeof env.THREADNOTE_CURSOR_MEMORY_ENDPOINT === 'string' && env.THREADNOTE_CURSOR_MEMORY_ENDPOINT.length > 0;
 }
 
-export function composerHttpEntryMatches(actual: unknown, expected: ComposerHttpMcpEntry): boolean {
+export function composerHttpEntryMatches(actual: unknown, expected: ComposerClientHttpMcpEntry): boolean {
+  if (
+    !isComposerHttpEntry(actual) ||
+    actual.url !== expected.url ||
+    actual.headers[THREADNOTE_COMPOSER_SHARE_ID_HEADER] !== expected.headers[THREADNOTE_COMPOSER_SHARE_ID_HEADER]
+  )
+    return false;
+  return actual.type === 'http'
+    ? expected.type === 'http' && actual.oauth.clientId === expected.oauth.clientId
+    : expected.type !== 'http' && actual.auth.CLIENT_ID === expected.auth.CLIENT_ID;
+}
+
+export function isManagedComposerHttpEntry(actual: unknown): boolean {
   return (
-    isManagedComposerHttpEntry(actual) &&
-    actual.url === expected.url &&
-    actual.headers[THREADNOTE_COMPOSER_SHARE_ID_HEADER] === expected.headers[THREADNOTE_COMPOSER_SHARE_ID_HEADER] &&
-    actual.auth.CLIENT_ID === expected.auth.CLIENT_ID &&
-    actual.auth.scopes.length === expected.auth.scopes.length &&
-    actual.auth.scopes.every((scope, index) => scope === expected.auth.scopes[index])
+    isComposerHttpEntry(actual) &&
+    (actual.type === 'http' ? actual.oauth.clientId : actual.auth.CLIENT_ID) === COMPOSER_OAUTH_CLIENT_ID
   );
 }
 
-export function isManagedComposerHttpEntry(actual: unknown): actual is ComposerHttpMcpEntry {
-  if (!isRecord(actual) || typeof actual.url !== 'string' || !isRecord(actual.headers) || !isRecord(actual.auth)) {
-    return false;
-  }
+export function isComposerHttpEntry(actual: unknown): actual is ComposerClientHttpMcpEntry {
+  if (!isRecord(actual) || typeof actual.url !== 'string' || !isRecord(actual.headers)) return false;
   const shareId = actual.headers[THREADNOTE_COMPOSER_SHARE_ID_HEADER];
   if (typeof shareId !== 'string' || Object.keys(actual.headers).length !== 1) return false;
-  if (actual.auth.CLIENT_ID !== COMPOSER_OAUTH_CLIENT_ID || !Array.isArray(actual.auth.scopes)) return false;
-  if (actual.auth.scopes.length !== COMPOSER_OAUTH_SCOPES.length) return false;
-  if (actual.auth.scopes.some((scope, index) => scope !== COMPOSER_OAUTH_SCOPES[index])) return false;
+  let clientId: string;
+  if (actual.type === 'http') {
+    if (Object.keys(actual).some(key => !['type', 'url', 'headers', 'oauth'].includes(key))) return false;
+    if (!isRecord(actual.oauth) || typeof actual.oauth.clientId !== 'string') return false;
+    if (Object.keys(actual.oauth).length !== 1) return false;
+    clientId = actual.oauth.clientId;
+  } else {
+    if (Object.keys(actual).some(key => !['url', 'headers', 'auth'].includes(key))) return false;
+    if (!isRecord(actual.auth) || typeof actual.auth.CLIENT_ID !== 'string' || !Array.isArray(actual.auth.scopes))
+      return false;
+    if (Object.keys(actual.auth).some(key => key !== 'CLIENT_ID' && key !== 'scopes')) return false;
+    if (actual.auth.scopes.length !== COMPOSER_OAUTH_SCOPES.length) return false;
+    if (actual.auth.scopes.some((scope, index) => scope !== COMPOSER_OAUTH_SCOPES[index])) return false;
+    clientId = actual.auth.CLIENT_ID;
+  }
   try {
     composerMcpUrl(actual.url);
     composerShareId(shareId);
+    composerOAuthClientId(clientId);
     return true;
   } catch {
     return false;
@@ -172,4 +225,13 @@ export function isManagedComposerHttpEntry(actual: unknown): actual is ComposerH
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function composerOAuthClientId(value: string): string {
+  if (!/^[\x21-\x7e]{1,512}$/u.test(value)) {
+    throw ComposerAttachError.make({
+      message: 'The organization OAuth client ID must be 1–512 visible ASCII characters.',
+    });
+  }
+  return value;
 }

--- a/src/mcp/install.ts
+++ b/src/mcp/install.ts
@@ -16,11 +16,15 @@ import {
   ComposerAttachError,
   THREADNOTE_ORG_MCP_NAME,
   buildComposerHttpMcpEntry,
+  buildCopilotComposerHttpMcpEntry,
+  isComposerHttpEntry,
   composerHttpEntryMatches,
   resolveComposerAttach,
   withComposerHttpMcpEntry,
   isManagedComposerHttpEntry,
   type ComposerHttpMcpEntry,
+  type ComposerClientHttpMcpEntry,
+  type CopilotComposerHttpMcpEntry,
   type ComposerShareBinding,
 } from './composer_attach.js';
 import type {AgentClient, ClaudeMcpScope, DoctorCheck, JsonObject, McpInstallOptions, RuntimeConfig} from '../types.js';
@@ -66,7 +70,7 @@ const runMcpInstallInTransaction = Effect.fn('mcp.runInstallInTransaction')(func
   const apply = options.apply === true;
   const toolset = options.toolset ?? DEFAULT_MCP_TOOLSET;
   const attach = yield* Effect.try({
-    try: () => resolveComposerAttach({composerUrl: options.composerUrl, shareId: options.shareId}),
+    try: () => resolveComposerAttach(options),
     catch: cause =>
       Schema.is(ComposerAttachError)(cause)
         ? cause
@@ -326,7 +330,7 @@ function orgComposerConfigurationCheck(checkName: string, configPath: string, co
     const parsed = raw ? parseJsonConfigObject(raw) : undefined;
     const container = parsed?.[containerKey];
     const entry = isJsonObject(container) ? container[THREADNOTE_ORG_MCP_NAME] : undefined;
-    const configured = isManagedComposerHttpEntry(entry);
+    const configured = isComposerHttpEntry(entry);
     return {
       detail: configured
         ? `${THREADNOTE_ORG_MCP_NAME} attached in ${configPath}`
@@ -530,7 +534,7 @@ function jsonMcpConfigurationMatches(
 function jsonComposerConfigurationMatches(
   currentContent: string | undefined,
   containerKey: 'mcpServers' | 'servers',
-  expected: ComposerHttpMcpEntry,
+  expected: ComposerClientHttpMcpEntry,
 ): boolean {
   if (currentContent === undefined) return false;
   const parsed = parseJsonConfigObject(currentContent);
@@ -557,7 +561,7 @@ const runCursorMcpInstall = Effect.fn('mcp.runCursorInstall')(function* (
     toolset: options.toolset,
   });
   const composerEntry = options.attach
-    ? buildComposerHttpMcpEntry(options.attach.url, options.attach.shareId)
+    ? buildComposerHttpMcpEntry(options.attach.url, options.attach.shareId, options.attach.clientId)
     : undefined;
   const currentContent = yield* readFileIfExists(path);
   const current =
@@ -616,7 +620,7 @@ const runCopilotMcpInstall = Effect.fn('mcp.runCopilotInstall')(function* (
     toolset: options.toolset,
   });
   const composerEntry = options.attach
-    ? buildComposerHttpMcpEntry(options.attach.url, options.attach.shareId)
+    ? buildCopilotComposerHttpMcpEntry(options.attach.url, options.attach.shareId, options.attach.clientId)
     : undefined;
   const currentContent = yield* readFileIfExists(path);
   const current =
@@ -898,7 +902,7 @@ function renderCopilotMcpConfig(
   currentContent: string | undefined,
   name: string,
   serverConfig: JsonObject,
-  composerEntry?: ComposerHttpMcpEntry,
+  composerEntry?: CopilotComposerHttpMcpEntry,
 ): string {
   const parsed = isEmptyConfigContent(currentContent) ? {} : parseJsonConfigObject(currentContent ?? '');
   if (parsed === undefined) {
@@ -1038,7 +1042,7 @@ const printCopilotMcpSnippet = Effect.fn('mcp.printCopilotSnippet')(function* (
   const path = yield* Path.Path;
   const snippetPath = path.join(config.agentContextHome, 'mcp', `${name}.copilot.json`);
   const stdio = yield* buildCopilotMcpServerConfig(config, options);
-  const servers = withComposerHttpMcpEntry({}, name, stdio, options.attach);
+  const servers = withComposerHttpMcpEntry({}, name, stdio, options.attach, 'copilot');
   const snippet = JSON.stringify({servers}, null, 2);
   yield* Console.log(
     `\nSnippet (${snippetPath}; merge into ${yield* copilotMcpConfigPath(options.project)}):\n${snippet}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,7 @@ export interface SeedOptions {
 
 export interface McpInstallOptions {
   readonly apply?: boolean;
+  readonly composerClientId?: string;
   readonly composerUrl?: string;
   /** @internal Recorded Claude project/local installation directory used by repair. */
   readonly cwd?: string;

--- a/test/unit/org-mcp-attach.test.ts
+++ b/test/unit/org-mcp-attach.test.ts
@@ -12,6 +12,7 @@ import {
   CURSOR_CLOUD_MEMORY_ENDPOINT_ENV,
   CURSOR_CLOUD_MODE_ENV,
   buildCursorCloudProfile,
+  buildCursorCloudRemoteHybridMcpConfig,
   buildOrgCloudHybridMcpConfig,
   cursorCloudMemoryEndpoint,
   cursorCloudRemoteHybridStatus,
@@ -23,6 +24,8 @@ import {
   THREADNOTE_ORG_MCP_NAME,
   buildComposerHttpMcpEntry,
   composerHttpEntryMatches,
+  isComposerHttpEntry,
+  buildCopilotComposerHttpMcpEntry,
   composerMcpUrl,
   composerShareId,
   isManagedComposerHttpEntry,
@@ -61,8 +64,8 @@ afterEach(() => {
 describe('organization composer attach', () => {
   effectIt.effect.prop(
     'keeps stdio core Git share and binds composer share only in the HTTP header',
-    {host: HOST, shareId: SHARE_ID},
-    ({host, shareId}) =>
+    {clientId: SHARE_ID, host: HOST, shareId: SHARE_ID},
+    ({clientId, host, shareId}) =>
       Effect.sync(() => {
         const url = `https://${host}/mcp`;
         const stdio = {
@@ -72,18 +75,20 @@ describe('organization composer attach', () => {
             THREADNOTE_USER: 'tester',
           },
         } satisfies JsonObject;
-        const servers = teamStdioServers(stdio, resolveComposerAttach({composerUrl: url, shareId}));
+        const servers = teamStdioServers(
+          stdio,
+          resolveComposerAttach({composerUrl: url, shareId, composerClientId: clientId}),
+        );
         const capabilities = mcpToolCapabilities(parseMcpToolset('core'));
         expect(capabilities.graphLocal).toBe(true);
         expect(capabilities.memoryPublish).toBe(true);
         expect(servers[THREADNOTE_MCP_NAME]).toEqual(stdio);
         expect(stdioEnvironmentCallsComposer(stdio.env)).toBe(false);
         expect(
-          composerHttpEntryMatches(servers[THREADNOTE_ORG_MCP_NAME], buildComposerHttpMcpEntry(url, shareId)),
+          composerHttpEntryMatches(servers[THREADNOTE_ORG_MCP_NAME], buildComposerHttpMcpEntry(url, shareId, clientId)),
         ).toBe(true);
-        expect(JSON.stringify(servers[THREADNOTE_ORG_MCP_NAME])).not.toMatch(
-          /authorization|bearer|CLIENT_SECRET|secret/i,
-        );
+        expect(servers[THREADNOTE_ORG_MCP_NAME]).toMatchObject({auth: {CLIENT_ID: clientId}});
+        expect(JSON.stringify(servers[THREADNOTE_ORG_MCP_NAME])).not.toMatch(/"(?:authorization|CLIENT_SECRET)"\s*:/i);
         expect(new URL((servers[THREADNOTE_ORG_MCP_NAME] as {url: string}).url).search).toBe('');
         expect(ORG_COMPOSER_POLICY).toEqual({
           canonicalStore: 'git',
@@ -91,7 +96,8 @@ describe('organization composer attach', () => {
           oauth: 'org-idp',
           shareBinding: 'header',
         });
-        expect(isManagedComposerHttpEntry(servers[THREADNOTE_ORG_MCP_NAME])).toBe(true);
+        expect(isComposerHttpEntry(servers[THREADNOTE_ORG_MCP_NAME])).toBe(true);
+        expect(isManagedComposerHttpEntry(servers[THREADNOTE_ORG_MCP_NAME])).toBe(clientId === 'threadnote-composer');
         expect(() =>
           withComposerHttpMcpEntry(
             {},
@@ -114,6 +120,60 @@ describe('organization composer attach', () => {
       expect(message).toContain('opaque identifier');
       expect(message).not.toContain(shareId);
     }
+  });
+
+  it('carries a registered public OAuth client through the additive attach configuration', () => {
+    const url = 'https://composer.example.test/mcp';
+    const attach = resolveComposerAttach({
+      composerUrl: url,
+      shareId: 'engineering',
+      composerClientId: 'registered-client',
+    });
+    const servers = teamStdioServers({command: '/bin/threadnote-mcp-server'}, attach);
+
+    expect(servers[THREADNOTE_ORG_MCP_NAME]).toEqual(
+      buildComposerHttpMcpEntry(url, 'engineering', 'registered-client'),
+    );
+    expect(servers[THREADNOTE_ORG_MCP_NAME]).toMatchObject({auth: {CLIENT_ID: 'registered-client'}});
+    expect(isManagedComposerHttpEntry(servers[THREADNOTE_ORG_MCP_NAME])).toBe(false);
+    expect(
+      isManagedComposerHttpEntry({
+        ...servers[THREADNOTE_ORG_MCP_NAME],
+        auth: {
+          CLIENT_ID: 'registered-client',
+          CLIENT_SECRET: 'must-preserve',
+          scopes: ['memory:read', 'memory:write:durable', 'memory:write:handoff'],
+        },
+      }),
+    ).toBe(false);
+    expect(
+      composerHttpEntryMatches(
+        servers[THREADNOTE_ORG_MCP_NAME],
+        buildComposerHttpMcpEntry(url, 'engineering', 'different-client'),
+      ),
+    ).toBe(false);
+  });
+
+  it('matches each client schema and preserves custom OAuth configuration', () => {
+    const cursor = buildComposerHttpMcpEntry('https://composer.example.test/mcp', 'engineering', 'registered');
+    const copilot = buildCopilotComposerHttpMcpEntry(cursor.url, 'engineering', 'registered');
+    expect(composerHttpEntryMatches(copilot, copilot)).toBe(true);
+    expect(composerHttpEntryMatches(cursor, copilot)).toBe(false);
+    expect(composerHttpEntryMatches(copilot, cursor)).toBe(false);
+    expect(isManagedComposerHttpEntry(copilot)).toBe(false);
+    expect(isComposerHttpEntry({...copilot, oauth: {...copilot.oauth, enterpriseManaged: true}})).toBe(false);
+  });
+
+  it('rejects an OAuth client ID without a composer binding', () => {
+    expect(() => resolveComposerAttach({composerClientId: 'registered-client'})).toThrow(
+      '--composer-url and --share-id',
+    );
+  });
+
+  it.each(['', ' ', 'client\nother', 'x'.repeat(513)])('rejects an invalid registered OAuth client ID %#', clientId => {
+    expect(() => buildComposerHttpMcpEntry('https://composer.example.test/mcp', 'engineering', clientId)).toThrow(
+      'OAuth client ID',
+    );
   });
 
   it('rejects credential-bearing composer URLs without reflecting them', () => {
@@ -145,6 +205,20 @@ describe('organization composer attach', () => {
 });
 
 vitestDescribe('organization cloud hybrid MCP', () => {
+  it('uses a registered OAuth client for org and remote-hybrid cloud configurations', () => {
+    expect(
+      buildOrgCloudHybridMcpConfig(profile, 'https://composer.example.test/mcp', 'engineering', 'registered-client')
+        .mcpServers[THREADNOTE_ORG_MCP_NAME],
+    ).toMatchObject({auth: {CLIENT_ID: 'registered-client'}});
+    expect(
+      buildCursorCloudRemoteHybridMcpConfig(
+        profile,
+        'https://composer.example.test/mcp',
+        'engineering',
+        'registered-client',
+      ).mcpServers['threadnote-memory'],
+    ).toMatchObject({auth: {CLIENT_ID: 'registered-client'}});
+  });
   it('binds memory HTTP to the Git-backed composer with org IdP OAuth', () => {
     const config = buildOrgCloudHybridMcpConfig(profile, 'https://composer.example.test/mcp', 'share-engineering');
     expect(config.policy).toEqual(ORG_COMPOSER_POLICY);
@@ -200,6 +274,60 @@ describe('Team MCP install composer attach', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
+  effectIt.effect('installs and previews a registered Copilot client using the VS Code OAuth schema', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-org-copilot-'});
+        const user = path.join(root, 'user');
+        const bin = path.join(root, 'bin');
+        const project = path.join(root, 'repo');
+        const configPath = path.join(project, '.vscode', 'mcp.json');
+        const testRuntime = runtimeConfig(path.join(user, '.threadnote'));
+        const testSystem = SystemInfo.of({
+          ...baseSystem,
+          environment: () => ({...baseSystem.environment(), THREADNOTE_BIN_DIR: bin}),
+          homeDirectory: user,
+          platform: 'linux',
+        });
+        yield* fs.makeDirectory(bin, {recursive: true});
+        yield* fs.makeDirectory(project, {recursive: true});
+        yield* fs.writeFileString(path.join(bin, 'threadnote-mcp-server'), '');
+        const options = {
+          composerClientId: 'registered-copilot',
+          composerUrl: 'https://composer.example.test/mcp',
+          project,
+          shareId: 'engineering',
+        };
+        const preview = yield* captureConsole(runMcpInstall(testRuntime, 'copilot', options)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(preview.output).toContain('"clientId": "registered-copilot"');
+        expect(preview.output).not.toContain('"CLIENT_ID"');
+        expect(yield* fs.exists(configPath)).toBe(false);
+        yield* captureConsole(runMcpInstall(testRuntime, 'copilot', {...options, apply: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        const before = yield* fs.readFileString(configPath);
+        const installed = JSON.parse(before);
+        expect(installed.servers[THREADNOTE_ORG_MCP_NAME]).toEqual({
+          type: 'http',
+          url: options.composerUrl,
+          headers: {'threadnote-share-id': options.shareId},
+          oauth: {clientId: options.composerClientId},
+        });
+        expect(installed.servers[THREADNOTE_MCP_NAME].type).toBe('stdio');
+        const repeated = yield* captureConsole(runMcpInstall(testRuntime, 'copilot', {...options, apply: true})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(repeated.output).toContain('Already configured:');
+        expect(yield* fs.readFileString(configPath)).toBe(before);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+
   effectIt.effect('attaches composer HTTP without removing stdio Git share or calling composer from stdio', () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -228,6 +356,7 @@ describe('Team MCP install composer attach', () => {
         yield* captureConsole(
           runMcpInstall(testRuntime, 'cursor', {
             apply: true,
+            composerClientId: 'registered-client',
             composerUrl: 'https://composer.example.test/mcp',
             project,
             shareId: 'share-engineering',
@@ -242,7 +371,21 @@ describe('Team MCP install composer attach', () => {
         expect(stdio?.env?.THREADNOTE_MCP_TOOLSET).toBe('core');
         expect(stdioEnvironmentCallsComposer(stdio?.env ?? {})).toBe(false);
         expect(JSON.stringify(stdio?.env ?? {})).not.toMatch(/attest|oidc|CURSOR_AGENT_SOCKET/i);
-        expect(composer).toEqual(buildComposerHttpMcpEntry('https://composer.example.test/mcp', 'share-engineering'));
+        expect(composer).toEqual(
+          buildComposerHttpMcpEntry('https://composer.example.test/mcp', 'share-engineering', 'registered-client'),
+        );
+        const beforeRepeat = yield* fs.readFileString(cursorPath);
+        const repeated = yield* captureConsole(
+          runMcpInstall(testRuntime, 'cursor', {
+            apply: true,
+            composerClientId: 'registered-client',
+            composerUrl: 'https://composer.example.test/mcp',
+            project,
+            shareId: 'share-engineering',
+          }),
+        ).pipe(Effect.provideService(SystemInfo, testSystem));
+        expect(repeated.output).toContain('Already configured:');
+        expect(yield* fs.readFileString(cursorPath)).toBe(beforeRepeat);
         expect(mcpToolCapabilities(parseMcpToolset('core')).memoryPublish).toBe(true);
 
         const fetchSpy = vi.fn(() => Promise.reject(new Error('composer down')));
@@ -497,7 +640,7 @@ describe('Team MCP install composer attach', () => {
     ).pipe(provideTestLayer(ApplicationLayer)),
   );
 
-  effectIt.effect('uninstall leaves a non-matching threadnote-org entry', () =>
+  effectIt.effect('uninstall preserves an operator-registered threadnote-org entry', () =>
     Effect.scoped(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -523,7 +666,11 @@ describe('Team MCP install composer attach', () => {
             {
               mcpServers: {
                 [THREADNOTE_MCP_NAME]: {command: 'placeholder'},
-                [THREADNOTE_ORG_MCP_NAME]: {command: 'operator-owned'},
+                [THREADNOTE_ORG_MCP_NAME]: buildComposerHttpMcpEntry(
+                  'https://composer.example.test/mcp',
+                  'engineering',
+                  'operator-registered',
+                ),
               },
             },
             undefined,
@@ -538,7 +685,9 @@ describe('Team MCP install composer attach', () => {
           mcpServers: Record<string, unknown>;
         };
         expect(remaining.mcpServers[THREADNOTE_MCP_NAME]).toBeUndefined();
-        expect(remaining.mcpServers[THREADNOTE_ORG_MCP_NAME]).toEqual({command: 'operator-owned'});
+        expect(remaining.mcpServers[THREADNOTE_ORG_MCP_NAME]).toEqual(
+          buildComposerHttpMcpEntry('https://composer.example.test/mcp', 'engineering', 'operator-registered'),
+        );
       }),
     ).pipe(provideTestLayer(ApplicationLayer)),
   );


### PR DESCRIPTION
Org attach previously always emitted the loopback demo OAuth client ID, so registered external-provider clients could not sign in. Add `--composer-client-id` for laptop setup and `--client-id` for cloud configuration, emitting Cursor's `auth.CLIENT_ID` or VS Code/Copilot's native `oauth.clientId` as appropriate. Keep local stdio additive and preserve operator-registered HTTP entries during personal uninstall.

Document static client registration and Codex's separate OAuth setup. Real Auth0 PKCE sign-in has verified provider compatibility; deployed Codex/Cursor end-to-end acceptance remains a later productization gate.

Validation: 65 focused tests across attach, cloud, MCP, doctor and configuration idempotence; bounded client-ID/property coverage; lint and typecheck. Dev-cycle full review found one important and one minor issue; both were fixed and incremental review is clear with zero findings. Exact-HEAD global installation passed on retry; global smoke passed cloud configuration, Cursor preview/apply/reinstall and Copilot preview. Copilot apply correctly preserved an existing unmanaged instruction file and therefore did not complete; isolated fixture apply coverage passed. The recurring development-repair failure on that optional integration is tracked for the next slice. CI runs the full suite.
