### PR TITLE
Recover composer Git locks after process death

### DIFF
--- a/docs/remote-memory/operations.md
+++ b/docs/remote-memory/operations.md
@@ -48,6 +48,19 @@ with citations, relations, keywords, provenance, unknown headers, or legacy meta
 canonical write. Edit those records through the Git share until the remote API supports their metadata; this
 prevents silent loss of local product information. Basic remote documents retain their identity and creation time.
 
+The composer lock lives at `threadnote-composer.lock` in Git's resolved metadata directory. It records a
+random ownership token and process identity, refreshes its lease, and recovers a confirmed dead owner.
+Ordinary service shutdown drains accepted requests. If the lock adapter's owning scope is closed directly,
+it rejects queued requests and waits for its active operation before releasing the token.
+This serializes processes sharing one filesystem, not independent clones or machines.
+
+Older versions used an ownerless directory at the same path. An upgrade preserves that directory and refuses
+Git operations until an operator stops every old writer and its Git subprocesses, verifies the checkout and
+upstream state, and removes the confirmed empty directory with `rmdir`. Preserve unexpected contents or
+symbolic links for investigation. Never delete a live JSON lock to bypass contention. After a crash, verify
+readiness and upstream convergence before reopening writes; an unexpected dirty or divergent checkout
+requires operator recovery and is not reset automatically.
+
 ### Database roles
 
 The Compose stack demonstrates three separate database identities:

--- a/src/effect/composer_cli.ts
+++ b/src/effect/composer_cli.ts
@@ -1,3 +1,4 @@
+import {makeGitWorktreeLock} from './git_worktree_lock.js';
 import {Console, Effect, Schema} from 'effect';
 import {Command} from 'effect/unstable/cli';
 import {applicationError, fromPromiseInterruptibleAwaiting} from './errors.js';
@@ -72,30 +73,36 @@ export const runComposerServeCommand = Effect.fn('composer.serveCommand')(functi
       }),
   });
   const gitWorktree = options.gitWorktree?.trim() || team.config.worktree;
-  yield* Console.consoleWith(output =>
-    fromPromiseInterruptibleAwaiting(
-      signal =>
-        runComposerServe(
-          {
-            databaseUrl,
-            executablePath: system.executablePath,
-            gitCloneUrl: team.config.remote,
-            gitPush: options.push === true,
-            gitWorktree,
-            listen: options.listen?.trim() || LOCAL_COMPOSER_DEFAULT_LISTEN,
-            shareId,
-            subject: options.subject?.trim() || `local:${config.user}`,
-            tenantId: 'local-org',
-          },
-          {
-            error: message => {
-              output.error(message);
-            },
-            shutdownSignal: () => shutdownFromAbort(signal),
-          },
+  yield* Effect.scoped(
+    Effect.gen(function* () {
+      const worktreeLock = yield* makeGitWorktreeLock();
+      yield* Console.consoleWith(output =>
+        fromPromiseInterruptibleAwaiting(
+          signal =>
+            runComposerServe(
+              {
+                databaseUrl,
+                executablePath: system.executablePath,
+                gitCloneUrl: team.config.remote,
+                gitPush: options.push === true,
+                gitWorktree,
+                listen: options.listen?.trim() || LOCAL_COMPOSER_DEFAULT_LISTEN,
+                shareId,
+                subject: options.subject?.trim() || `local:${config.user}`,
+                tenantId: 'local-org',
+              },
+              {
+                error: message => {
+                  output.error(message);
+                },
+                shutdownSignal: () => shutdownFromAbort(signal),
+                worktreeLock,
+              },
+            ),
+          cause => applicationError('composer serve', cause),
         ),
-      cause => applicationError('composer serve', cause),
-    ),
+      );
+    }),
   );
 });
 

--- a/src/effect/git_worktree_lock.ts
+++ b/src/effect/git_worktree_lock.ts
@@ -1,0 +1,86 @@
+import {Cause, Crypto, Effect, Exit, FileSystem, Option, Path, Queue} from 'effect';
+import {fromPromiseInterruptibleAwaiting} from './errors.js';
+import {withExclusiveFileLock} from './file_lock.js';
+import {SystemInfo} from './system.js';
+import {publicRemoteMemoryError, remoteMemoryError} from '../remote_memory/errors.js';
+
+export type GitWorktreeLock = <A>(path: string, operation: () => Promise<A>) => Promise<A>;
+
+type LockServices = Crypto.Crypto | Path.Path | SystemInfo;
+interface LockRequest {
+  readonly run: Effect.Effect<void, never, LockServices>;
+  readonly reject: () => void;
+}
+
+/** Owns the Promise adapter for the service lifetime without starting a nested Effect runtime. */
+export const makeGitWorktreeLock = Effect.fn('gitWorktreeLock.make')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const queue = yield* Queue.bounded<LockRequest>(128);
+  const pending = new Set<LockRequest>();
+  let closed = false;
+  const unavailable = () => remoteMemoryError('service_unavailable', 'The composer Git lock service is unavailable.');
+  const stop = Effect.sync(() => {
+    closed = true;
+    for (const request of pending) request.reject();
+    pending.clear();
+  }).pipe(Effect.andThen(Queue.shutdown(queue)), Effect.asVoid);
+  yield* Effect.forkScoped(
+    Effect.forever(Queue.take(queue).pipe(Effect.flatMap(request => request.run))).pipe(Effect.ensuring(stop)),
+  );
+  yield* Effect.addFinalizer(() =>
+    Effect.sync(() => {
+      closed = true;
+    }),
+  );
+
+  const lock: GitWorktreeLock = <A>(path: string, operation: () => Promise<A>): Promise<A> => {
+    if (closed) return Promise.reject(unavailable());
+    const {promise, resolve, reject} = Promise.withResolvers<A>();
+    const run = Effect.gen(function* () {
+      const info = yield* fs.stat(path).pipe(
+        Effect.catchIf(
+          error => error.reason._tag === 'NotFound',
+          () => Effect.void,
+        ),
+      );
+      if (Option.isSome(yield* fs.readLink(path).pipe(Effect.option)) || (info !== undefined && info.type !== 'File')) {
+        return yield* remoteMemoryError(
+          'service_unavailable',
+          'The composer lock requires operator recovery; preserve legacy lock state until all old writers are stopped.',
+        );
+      }
+      return yield* withExclusiveFileLock(
+        fs,
+        path,
+        {
+          heartbeatIntervalMilliseconds: 1_000,
+          retryIntervalMilliseconds: 25,
+          staleAfterMilliseconds: 30_000,
+          useCanonicalProcessStartIdentity: true,
+          waitTimeoutMilliseconds: 10_000,
+        },
+        fromPromiseInterruptibleAwaiting(operation, publicRemoteMemoryError),
+      );
+    });
+    const request: LockRequest = {
+      reject: () => reject(unavailable()),
+      run: run.pipe(
+        Effect.onExit(exit =>
+          Effect.sync(() => {
+            pending.delete(request);
+            if (Exit.isSuccess(exit)) resolve(exit.value);
+            else reject(publicRemoteMemoryError(Cause.squash(exit.cause)));
+          }),
+        ),
+        Effect.ignore,
+      ),
+    };
+    pending.add(request);
+    if (!Queue.offerUnsafe(queue, request)) {
+      pending.delete(request);
+      request.reject();
+    }
+    return promise;
+  };
+  return lock;
+});

--- a/src/remote_memory/composer_serve.ts
+++ b/src/remote_memory/composer_serve.ts
@@ -139,6 +139,7 @@ export async function runComposerServe(
     if (config.autoMigrate) await migrateRemoteMemoryDatabase(sql, {executablePath: input.executablePath});
     await sql`SELECT 1 FROM remote_memory.shares LIMIT 0`;
     const gitStore = new GitCanonicalMemoryStore({
+      worktreeLock: runtime.worktreeLock,
       binding: config.gitBinding,
       branch: config.gitBranch,
       push: config.gitPush,

--- a/src/remote_memory/git_canonical_store.ts
+++ b/src/remote_memory/git_canonical_store.ts
@@ -1,3 +1,4 @@
+import type {GitWorktreeLock} from '../effect/git_worktree_lock.js';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {assertSafeShareRelativePath} from '../share/core.js';
 import {validatePortableSegment} from '../storage/resource-id.js';
@@ -7,14 +8,13 @@ import {requireGitMemoryBinding, type GitMemoryBinding} from './git_binding.js';
 
 const GIT_TIMEOUT_MILLISECONDS = 30_000;
 const GIT_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
-const LOCK_WAIT_MILLISECONDS = 10_000;
-const LOCK_RETRY_MILLISECONDS = 25;
 const COMPOSER_LOCK_NAME = 'threadnote-composer.lock';
 const COMPOSER_NAME = 'Threadnote Composer';
 const COMPOSER_EMAIL = 'threadnote-composer@invalid';
 
 export interface GitCanonicalMemoryStoreOptions {
   readonly binding?: GitMemoryBinding;
+  readonly worktreeLock?: GitWorktreeLock;
   readonly branch?: string;
   readonly push?: boolean;
   readonly remote?: string;
@@ -101,6 +101,7 @@ export function isAbsoluteGitWorktree(path: string): boolean {
 
 export class GitCanonicalMemoryStore {
   readonly binding?: GitMemoryBinding;
+  readonly worktreeLock?: GitWorktreeLock;
   readonly branch: string;
   readonly push: boolean;
   readonly remote: string;
@@ -117,6 +118,7 @@ export class GitCanonicalMemoryStore {
     this.branch = requireGitRefName(options.branch?.trim() || 'main', 'THREADNOTE_REMOTE_MEMORY_GIT_BRANCH');
     this.remote = requireGitRefName(options.remote?.trim() || 'origin', 'THREADNOTE_REMOTE_MEMORY_GIT_REMOTE');
     this.push = options.push !== false;
+    this.worktreeLock = options.worktreeLock;
   }
 
   commit(input: GitCanonicalCommitInput): Promise<GitCanonicalCommitResult> {
@@ -370,12 +372,13 @@ export class GitCanonicalMemoryStore {
   private async withLock<A>(operation: () => Promise<A>): Promise<A> {
     const gitDir = await this.absoluteGitDir();
     const lockPath = joinAbsolute(gitDir, COMPOSER_LOCK_NAME);
-    await acquireExclusiveLock(lockPath);
-    try {
-      return await operation();
-    } finally {
-      await runProcess(['rmdir', lockPath], true);
+    if (!this.worktreeLock) {
+      throw remoteMemoryError(
+        'service_unavailable',
+        'The composer Git store requires an application-scoped lock service.',
+      );
     }
+    return this.worktreeLock(lockPath, operation);
   }
 
   private async absoluteGitDir(): Promise<string> {
@@ -409,18 +412,6 @@ async function assertContainedWorktreePath(worktree: string, relativePath: strin
 async function isSymlink(path: string): Promise<boolean> {
   const result = await runProcess(['test', '-L', path], true);
   return result.exitCode === 0;
-}
-
-async function acquireExclusiveLock(lockPath: string): Promise<void> {
-  const deadline = Date.now() + LOCK_WAIT_MILLISECONDS;
-  for (;;) {
-    const created = await runProcess(['mkdir', lockPath], true);
-    if (created.exitCode === 0) return;
-    if (Date.now() >= deadline) {
-      throw remoteMemoryError('service_unavailable', 'The composer git worktree is busy.');
-    }
-    await Bun.sleep(LOCK_RETRY_MILLISECONDS);
-  }
 }
 
 function parseLsTreeBlobs(stdout: string): Map<string, string> {

--- a/src/remote_memory/main.ts
+++ b/src/remote_memory/main.ts
@@ -1,3 +1,4 @@
+import type {GitWorktreeLock} from '../effect/git_worktree_lock.js';
 import {remoteMemoryConfigFromEnvironment, redactedRemoteMemoryConfig} from './config.js';
 import {createCursorTokenVerifier} from './cursor_oidc.js';
 import {migrateRemoteMemoryDatabase} from './migrations.js';
@@ -18,6 +19,7 @@ import {
 import {startRemoteMemoryServer} from './server.js';
 
 export interface RemoteMemoryServiceRuntime {
+  readonly worktreeLock: GitWorktreeLock;
   readonly error: (message: string) => void;
   readonly executablePath?: string;
   readonly shutdownSignal: () => {readonly dispose: () => void; readonly promise: Promise<string>};
@@ -51,6 +53,7 @@ export async function runRemoteMemoryService(
             push: config.gitPush,
             remote: config.gitRemote,
             worktree: config.gitWorktree,
+            worktreeLock: runtime.worktreeLock,
           })
         : undefined;
     const server = startRemoteMemoryServer({

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -108,28 +108,38 @@ async function remoteMemoryOperatorProgram(arguments_: readonly string[]) {
 }
 
 async function remoteMemoryServiceProgram() {
-  const service = await import('./remote_memory/main.js');
-  return Console.consoleWith(output =>
-    fromPromiseInterruptibleAwaiting(
-      signal =>
-        service.runRemoteMemoryService(process.env, {
-          error: message => output.error(message),
-          executablePath: process.execPath,
-          shutdownSignal: () => remoteMemoryShutdownSignal(signal),
-        }),
-      cause => cause,
-    ).pipe(
-      Effect.catch(cause =>
-        Console.error(`Remote memory service failed: ${service.remoteMemoryFailureClass(cause)}.`).pipe(
-          Effect.tap(() =>
-            Effect.sync(() => {
-              process.exitCode = 1;
+  const [service, locks, system] = await Promise.all([
+    import('./remote_memory/main.js'),
+    import('./effect/git_worktree_lock.js'),
+    import('./effect/system.js'),
+  ]);
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const worktreeLock = yield* locks.makeGitWorktreeLock();
+      yield* Console.consoleWith(output =>
+        fromPromiseInterruptibleAwaiting(
+          signal =>
+            service.runRemoteMemoryService(process.env, {
+              error: message => output.error(message),
+              executablePath: process.execPath,
+              shutdownSignal: () => remoteMemoryShutdownSignal(signal),
+              worktreeLock,
             }),
+          cause => cause,
+        ).pipe(
+          Effect.catch(cause =>
+            Console.error(`Remote memory service failed: ${service.remoteMemoryFailureClass(cause)}.`).pipe(
+              Effect.tap(() =>
+                Effect.sync(() => {
+                  process.exitCode = 1;
+                }),
+              ),
+            ),
           ),
         ),
-      ),
-    ),
-  );
+      );
+    }),
+  ).pipe(Effect.provide(Layer.merge(system.SystemInfo.layer, BunServices.layer)));
 }
 
 function remoteMemoryShutdownSignal(effectSignal: AbortSignal): {

--- a/test/helpers/git-worktree-lock.ts
+++ b/test/helpers/git-worktree-lock.ts
@@ -1,0 +1,19 @@
+import {publicRemoteMemoryError} from '../../src/remote_memory/errors.js';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {Effect, Layer} from 'effect';
+import {SystemInfo} from '../../src/effect/system.js';
+import {makeGitWorktreeLock, type GitWorktreeLock} from '../../src/effect/git_worktree_lock.js';
+import {provideTestLayer} from './effect-layer.js';
+
+export const gitLockTestLayer = Layer.merge(SystemInfo.layer, BunServices.layer);
+
+/** Runs the production adapter for tests of the Promise/Git process boundary. */
+export const testGitWorktreeLock: GitWorktreeLock = (path, operation) =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const lock = yield* makeGitWorktreeLock();
+        return yield* Effect.tryPromise({try: () => lock(path, operation), catch: publicRemoteMemoryError});
+      }),
+    ).pipe(provideTestLayer(gitLockTestLayer)),
+  );

--- a/test/integration/remote-memory-git-authority.test.ts
+++ b/test/integration/remote-memory-git-authority.test.ts
@@ -1,3 +1,4 @@
+import {testGitWorktreeLock} from '../helpers/git-worktree-lock.js';
 import {describe, expect, it} from 'vitest';
 import {rm} from '../helpers/node-fs-promises.js';
 import {createGitShareWorktreeFixture} from '../helpers/git-share-worktree.js';
@@ -31,6 +32,7 @@ async function fixture() {
   };
   await operator.provision(input);
   const store = new GitCanonicalMemoryStore({
+    worktreeLock: testGitWorktreeLock,
     binding: {tenantId: input.tenantId, shareId: input.shareId},
     worktree: git.worktree,
   });

--- a/test/integration/remote-memory-git-binding.test.ts
+++ b/test/integration/remote-memory-git-binding.test.ts
@@ -1,3 +1,4 @@
+import {testGitWorktreeLock} from '../helpers/git-worktree-lock.js';
 import {rm} from '../helpers/node-fs-promises.js';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
 import type {AuthorizedRemotePrincipal} from '../../src/remote_memory/authorization.js';
@@ -65,7 +66,7 @@ postgresDescribe('organization Git deployment binding', () => {
       if (!principal) throw new Error('Fixture authorization failed.');
       principals.push(principal);
     }
-    gitStore = new GitCanonicalMemoryStore({binding, worktree: gitFixture.worktree});
+    gitStore = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, binding, worktree: gitFixture.worktree});
     repository = new PostgresRemoteMemoryRepository(fixture.sql, {gitStore});
   });
 
@@ -75,7 +76,7 @@ postgresDescribe('organization Git deployment binding', () => {
   });
 
   it('requires an explicit binding before a Git store can serve organization memory', () => {
-    const unbound = new GitCanonicalMemoryStore({worktree: gitFixture.worktree});
+    const unbound = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: gitFixture.worktree});
     expect(() => new PostgresRemoteMemoryRepository(fixture.sql, {gitStore: unbound})).toThrow('binding');
     expect(() => new RemoteMemoryIndexer(fixture.sql, unbound)).toThrow('binding');
     expect(() => new RemoteHandoffRetentionWorker(fixture.sql, {gitStore: unbound})).toThrow('binding');

--- a/test/integration/remote-memory-git-composer.test.ts
+++ b/test/integration/remote-memory-git-composer.test.ts
@@ -1,3 +1,4 @@
+import {testGitWorktreeLock} from '../helpers/git-worktree-lock.js';
 import {mkdir, rm, writeFile} from '../helpers/node-fs-promises.js';
 import {dirname, join} from '../helpers/node-path.js';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
@@ -71,6 +72,7 @@ postgresDescribe('git-backed remote memory composer', () => {
       tenantId: TENANT,
     });
     const gitStore = new GitCanonicalMemoryStore({
+      worktreeLock: testGitWorktreeLock,
       binding: {tenantId: TENANT, shareId: SHARE},
       worktree: gitFixture.worktree,
     });
@@ -333,6 +335,7 @@ postgresDescribe('composer serve ingest of git files without a provisioned catal
       `,
     );
     const gitStore = new GitCanonicalMemoryStore({
+      worktreeLock: testGitWorktreeLock,
       binding: {tenantId: TENANT, shareId: SHARE},
       worktree: gitFixture.worktree,
     });

--- a/test/unit/git-canonical-durability.test.ts
+++ b/test/unit/git-canonical-durability.test.ts
@@ -1,3 +1,4 @@
+import {testGitWorktreeLock} from '../helpers/git-worktree-lock.js';
 import {describe, expect, it} from 'vitest';
 import * as FC from 'effect/testing/FastCheck';
 import {chmod, readFile, rm, writeFile} from '../helpers/node-fs-promises.js';
@@ -20,7 +21,7 @@ describe('git canonical durability', () => {
       await writeFile(hook, '#!/bin/sh\nexit 1\n');
       await chmod(hook, 0o700);
       const before = await head(fixture.worktree);
-      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       for (let attempt = 0; attempt < 2; attempt++) {
         await expect(store.commit(input)).rejects.toMatchObject({code: expect.any(String)});
         expect(await head(fixture.worktree)).toBe(before);
@@ -55,7 +56,7 @@ describe('git canonical durability', () => {
           status: await git(['status', '--porcelain'], fixture.worktree),
           diff: await git(['diff', 'HEAD'], fixture.worktree),
         };
-        const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+        const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
         await expect(store.commit(input)).rejects.toMatchObject({code: 'conflict'});
         await expect(store.listCanonicalPaths()).rejects.toMatchObject({code: 'conflict'});
         expect(await head(fixture.worktree)).toBe(before.head);
@@ -74,7 +75,7 @@ describe('git canonical durability', () => {
     try {
       await git(['update-ref', '-d', 'refs/heads/main'], fixture.remote);
       const before = await head(fixture.worktree);
-      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       await expect(store.commit(input)).rejects.toMatchObject({code: 'service_unavailable'});
       expect(await head(fixture.worktree)).toBe(before);
     } finally {
@@ -91,7 +92,7 @@ describe('git canonical durability', () => {
         '#!/bin/sh\nread local_ref local_sha remote_ref remote_sha\ngit -c core.hooksPath=/dev/null push origin "$local_sha:$remote_ref" || exit 2\nexit 1\n',
       );
       await chmod(hook, 0o700);
-      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       const receipt = await store.commit(input);
       expect(await head(fixture.remote)).toBe(receipt.gitCommit);
       expect(await head(fixture.worktree)).toBe(receipt.gitCommit);
@@ -116,7 +117,7 @@ describe('git canonical durability', () => {
         `#!/bin/sh\nunset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE\ngit -C ${quotedLaptop} push origin main\n`,
       );
       await chmod(hook, 0o700);
-      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       await expect(store.commit(input)).rejects.toMatchObject({
         code: 'conflict',
         details: {reason: 'git_push_rejected'},
@@ -136,7 +137,11 @@ describe('git canonical durability', () => {
     const fixture = await createGitShareWorktreeFixture();
     try {
       const remoteBefore = await head(fixture.remote);
-      const store = new GitCanonicalMemoryStore({push: false, worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({
+        worktreeLock: testGitWorktreeLock,
+        push: false,
+        worktree: fixture.worktree,
+      });
       const first = await store.commit(input);
       const second = await store.commit({
         ...input,
@@ -156,7 +161,7 @@ describe('git canonical durability', () => {
       FC.asyncProperty(FC.string({maxLength: 200}), async content => {
         const fixture = await createGitShareWorktreeFixture();
         try {
-          const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+          const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
           const first = await store.commit({...input, content});
           expect(await git(['show', `refs/heads/main:${path}`], fixture.remote)).toBe(content);
           expect(await store.commit({...input, content})).toEqual(first);

--- a/test/unit/git-canonical-store.test.ts
+++ b/test/unit/git-canonical-store.test.ts
@@ -1,3 +1,4 @@
+import {testGitWorktreeLock} from '../helpers/git-worktree-lock.js';
 import {describe, expect, it} from 'vitest';
 import * as FC from 'effect/testing/FastCheck';
 import {mkdir, rm, writeFile} from '../helpers/node-fs-promises.js';
@@ -106,7 +107,7 @@ describe('git canonical memory store', () => {
       await expect(ensureLiveGitShareWorktree({cloneUrl: fixture.remote, worktree: emptyRepo})).rejects.toMatchObject({
         message: expect.stringContaining('no commits'),
       });
-      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       await expect(store.assertLiveShare()).resolves.toBeUndefined();
       await expect(ensureLiveGitShareWorktree({cloneUrl: fixture.remote, worktree: fixture.worktree})).resolves.toBe(
         fixture.worktree,
@@ -146,7 +147,7 @@ describe('git canonical memory store', () => {
   it('commits a memory body, hashes it, and reads the same blob back', async () => {
     const fixture = await createGitShareWorktreeFixture();
     try {
-      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       const path = gitCanonicalSharePath('durable', 'threadnote', 'composer-roundtrip');
       const content = '# MEMORY\n\nComposer wrote this body.\n';
       const committed = await store.commit({content, message: 'remember composer-roundtrip', path});
@@ -182,7 +183,7 @@ describe('git canonical memory store', () => {
     const fixture = await createGitShareWorktreeFixture();
     try {
       const path = gitCanonicalSharePath('durable', 'threadnote', 'cas-conflict');
-      const composer = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const composer = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       const first = await composer.commit({
         content: '# MEMORY\n\nFirst writer.\n',
         message: 'remember first',
@@ -221,7 +222,7 @@ describe('git canonical memory store', () => {
     const fixture = await createGitShareWorktreeFixture();
     try {
       const path = gitCanonicalSharePath('durable', 'threadnote', 'offline-read');
-      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       const committed = await store.commit({
         content: '# MEMORY\n\nReadable without fetch.\n',
         message: 'remember offline-read',
@@ -237,7 +238,7 @@ describe('git canonical memory store', () => {
   it('rejects a malformed git commit pointer before invoking git show', async () => {
     const fixture = await createGitShareWorktreeFixture();
     try {
-      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       await expect(
         store.read({
           commit: '--output=/tmp/threadnote-git-show',
@@ -257,7 +258,7 @@ describe('git canonical memory store', () => {
       await git(['clone', '--separate-git-dir', gitDir, '--branch', 'main', '--', fixture.remote, worktree]);
       await git(['config', 'user.email', 'threadnote-test@example.com'], worktree);
       await git(['config', 'user.name', 'Threadnote Test'], worktree);
-      const store = new GitCanonicalMemoryStore({worktree});
+      const store = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree});
       const path = gitCanonicalSharePath('handoff', 'threadnote', 'separated-lock');
       const committed = await store.commit({
         content: '# MEMORY\n\nSeparated git dir.\n',
@@ -274,7 +275,7 @@ describe('git canonical memory store', () => {
     const fixture = await createGitShareWorktreeFixture();
     try {
       const path = gitCanonicalSharePath('durable', 'threadnote', 'interleave');
-      const composer = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      const composer = new GitCanonicalMemoryStore({worktreeLock: testGitWorktreeLock, worktree: fixture.worktree});
       const first = await composer.commit({
         content: '# MEMORY\n\nComposer first.\n',
         message: 'remember composer first',

--- a/test/unit/git-worktree-lock-process.test.ts
+++ b/test/unit/git-worktree-lock-process.test.ts
@@ -1,0 +1,95 @@
+import {describe, expect, it} from 'vitest';
+import {readFile, rm} from '../helpers/node-fs-promises.js';
+import {join} from '../helpers/node-path.js';
+import {createGitShareWorktreeFixture, git} from '../helpers/git-share-worktree.js';
+import {testGitWorktreeLock} from '../helpers/git-worktree-lock.js';
+import {GitCanonicalMemoryStore} from '../../src/remote_memory/git_canonical_store.js';
+
+const path = 'durable/projects/fixture/crash-recovery.md';
+
+describe('Git worktree lock process boundary', () => {
+  it('recovers a freshly killed owner and confirms the next commit upstream', async () => {
+    const fixture = await createGitShareWorktreeFixture();
+    const lockPath = join(fixture.worktree, '.git', 'threadnote-composer.lock');
+    const moduleUrl = new URL('../../src/effect/git_worktree_lock.ts', import.meta.url).href;
+    const systemUrl = new URL('../../src/effect/system.ts', import.meta.url).href;
+    const script = `
+      import {Effect, Layer} from 'effect';
+      import * as BunServices from '@effect/platform-bun/BunServices';
+      import * as BunRuntime from '@effect/platform-bun/BunRuntime';
+      import {makeGitWorktreeLock} from ${JSON.stringify(moduleUrl)};
+      import {SystemInfo} from ${JSON.stringify(systemUrl)};
+      BunRuntime.runMain(Effect.scoped(Effect.gen(function* () {
+        const lock = yield* makeGitWorktreeLock();
+        yield* Effect.promise(() => lock(${JSON.stringify(lockPath)}, () => {
+          process.stdout.write('locked');
+          return new Promise(() => {});
+        }));
+      })).pipe(Effect.provide(Layer.merge(SystemInfo.layer, BunServices.layer))));
+    `;
+    const child = Bun.spawn({cmd: [process.execPath, '--eval', script], stdout: 'pipe', stderr: 'pipe'});
+    const stderr = new Response(child.stderr).text();
+    const reader = child.stdout.getReader();
+    try {
+      const first = await reader.read();
+      expect(new TextDecoder().decode(first.value)).toBe('locked');
+      const owner = JSON.parse(await readFile(lockPath, 'utf8')) as {processId: number};
+      expect(owner.processId).toBe(child.pid);
+      child.kill('SIGKILL');
+      await child.exited;
+      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree, worktreeLock: testGitWorktreeLock});
+      const receipt = await store.commit({path, content: 'Recovered after a killed owner.', message: 'crash recovery'});
+      expect((await git(['rev-parse', 'HEAD'], fixture.remote)).trim()).toBe(receipt.gitCommit);
+      expect(await Bun.file(lockPath).exists()).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL');
+      await child.exited;
+      reader.releaseLock();
+      await stderr;
+      await rm(fixture.root, {recursive: true, force: true});
+    }
+  });
+
+  it('serializes independent service scopes without stealing a live owner', async () => {
+    const fixture = await createGitShareWorktreeFixture();
+    const lockPath = join(fixture.worktree, '.git', 'threadnote-composer.lock');
+    let active = 0;
+    try {
+      const results = await Promise.all(
+        Array.from({length: 6}, (_, index) =>
+          testGitWorktreeLock(lockPath, async () => {
+            expect(active++).toBe(0);
+            const before = await readFile(lockPath, 'utf8');
+            await git(['status', '--porcelain'], fixture.worktree);
+            expect(await readFile(lockPath, 'utf8')).toBe(before);
+            active--;
+            return index;
+          }),
+        ),
+      );
+      expect(results).toEqual([0, 1, 2, 3, 4, 5]);
+      expect(active).toBe(0);
+      expect(await Bun.file(lockPath).exists()).toBe(false);
+    } finally {
+      await rm(fixture.root, {recursive: true, force: true});
+    }
+  });
+
+  it('fails closed for mutating paths when no service lock was supplied', async () => {
+    const fixture = await createGitShareWorktreeFixture();
+    try {
+      const store = new GitCanonicalMemoryStore({worktree: fixture.worktree});
+      await store.assertReady();
+      for (const operation of [
+        () => store.refresh(),
+        () => store.listCanonicalPaths(),
+        () => store.commit({path, content: 'Missing lock must fail.', message: 'fixture'}),
+        () => store.read({path, commit: 'f'.repeat(40)}),
+      ])
+        await expect(operation()).rejects.toMatchObject({code: 'service_unavailable'});
+      expect(await git(['status', '--porcelain'], fixture.worktree)).toBe('');
+    } finally {
+      await rm(fixture.root, {recursive: true, force: true});
+    }
+  });
+});

--- a/test/unit/git-worktree-lock.test.ts
+++ b/test/unit/git-worktree-lock.test.ts
@@ -1,0 +1,188 @@
+import {publicRemoteMemoryError} from '../../src/remote_memory/errors.js';
+import {it as effectIt} from '@effect/vitest';
+import {Deferred, Effect, Exit, Fiber, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FC from 'effect/testing/FastCheck';
+import {describe, expect} from 'vitest';
+import {makeGitWorktreeLock, type GitWorktreeLock} from '../../src/effect/git_worktree_lock.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {gitLockTestLayer} from '../helpers/git-worktree-lock.js';
+
+const attempt = <A>(operation: () => Promise<A>) => Effect.tryPromise({try: operation, catch: publicRemoteMemoryError});
+const fixture = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const directory = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-git-lock-'});
+  return {fs, lockPath: path.join(directory, 'threadnote-composer.lock')};
+});
+
+describe('scoped Git worktree lock', () => {
+  effectIt.effect('acquires when another owner removes the token during preflight', () =>
+    TestClock.withLive(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const {fs, lockPath} = yield* fixture;
+          yield* fs.writeFileString(lockPath, 'previous owner');
+          let removed = false;
+          const contenderFs: FileSystem.FileSystem = {
+            ...fs,
+            stat: path =>
+              path === lockPath && !removed
+                ? Effect.gen(function* () {
+                    removed = true;
+                    yield* fs.remove(path);
+                    return yield* fs.stat(path);
+                  })
+                : fs.stat(path),
+          };
+          const lock = yield* makeGitWorktreeLock().pipe(Effect.provideService(FileSystem.FileSystem, contenderFs));
+          expect(yield* attempt(() => lock(lockPath, () => Promise.resolve('acquired')))).toBe('acquired');
+          expect(removed).toBe(true);
+          expect(yield* fs.exists(lockPath)).toBe(false);
+        }),
+      ),
+    ).pipe(provideTestLayer(gitLockTestLayer)),
+  );
+
+  effectIt.effect.prop(
+    'serializes successful and failed operations in submission order without leaking the token',
+    [FC.array(FC.boolean(), {minLength: 1, maxLength: 12})],
+    ([failures]) =>
+      TestClock.withLive(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const {fs, lockPath} = yield* fixture;
+            const lock = yield* makeGitWorktreeLock();
+            const entered: number[] = [];
+            let active = 0;
+            const jobs = failures.map((fail, index) =>
+              lock(lockPath, async () => {
+                expect(active++).toBe(0);
+                entered.push(index);
+                await Promise.resolve();
+                active--;
+                if (fail) throw new Error('fixture rejection');
+                return index;
+              }).then(
+                value => ({value}),
+                () => ({failed: true}),
+              ),
+            );
+            const results = yield* attempt(() => Promise.all(jobs));
+            expect(results).toEqual(failures.map((fail, index) => (fail ? {failed: true} : {value: index})));
+            expect(entered).toEqual(failures.map((_, index) => index));
+            expect(active).toBe(0);
+            expect(yield* fs.exists(lockPath)).toBe(false);
+          }),
+        ),
+      ).pipe(provideTestLayer(gitLockTestLayer)),
+    {fastCheck: {numRuns: 12}},
+  );
+
+  effectIt.effect('preserves a dangling symbolic link instead of creating its target', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const {fs, lockPath} = yield* fixture;
+        const target = `${lockPath}.outside`;
+        yield* fs.symlink(target, lockPath);
+        const lock = yield* makeGitWorktreeLock();
+        let entered = false;
+        const exit = yield* Effect.exit(
+          attempt(() =>
+            lock(lockPath, async () => {
+              entered = true;
+            }),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(entered).toBe(false);
+        expect(yield* fs.readLink(lockPath)).toBe(target);
+        expect(yield* fs.exists(target)).toBe(false);
+      }),
+    ).pipe(provideTestLayer(gitLockTestLayer)),
+  );
+
+  effectIt.effect('releases the lock before resolving successful and rejected Promise operations', () =>
+    TestClock.withLive(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const {fs, lockPath} = yield* fixture;
+          const lock = yield* makeGitWorktreeLock();
+          expect(yield* attempt(() => lock(lockPath, () => Promise.resolve(42)))).toBe(42);
+          expect(yield* fs.exists(lockPath)).toBe(false);
+          const exit = yield* Effect.exit(
+            attempt(() => lock(lockPath, () => Promise.reject(new Error('fixture failure')))),
+          );
+          expect(Exit.isFailure(exit)).toBe(true);
+          expect(yield* fs.exists(lockPath)).toBe(false);
+          expect(yield* attempt(() => lock(lockPath, () => Promise.resolve('next')))).toBe('next');
+        }),
+      ),
+    ).pipe(provideTestLayer(gitLockTestLayer)),
+  );
+
+  effectIt.effect('preserves an ownerless legacy directory and refuses to enter the critical section', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const {fs, lockPath} = yield* fixture;
+        yield* fs.makeDirectory(lockPath);
+        const lock = yield* makeGitWorktreeLock();
+        let entered = false;
+        const exit = yield* Effect.exit(
+          attempt(() =>
+            lock(lockPath, async () => {
+              entered = true;
+            }),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(entered).toBe(false);
+        expect((yield* fs.stat(lockPath)).type).toBe('Directory');
+      }),
+    ).pipe(provideTestLayer(gitLockTestLayer)),
+  );
+
+  effectIt.effect('drains active work before releasing, and rejects queued and future calls during shutdown', () =>
+    TestClock.withLive(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const {fs, lockPath} = yield* fixture;
+          const opened = yield* Deferred.make<GitWorktreeLock>();
+          const started = Promise.withResolvers<void>();
+          const finish = Promise.withResolvers<void>();
+          let queuedEntered = false;
+          const owner = yield* Effect.forkChild(
+            Effect.scoped(
+              Effect.gen(function* () {
+                const lock = yield* makeGitWorktreeLock();
+                yield* Deferred.succeed(opened, lock);
+                return yield* Effect.never;
+              }),
+            ),
+          );
+          const lock = yield* Deferred.await(opened);
+          const active = lock(lockPath, async () => {
+            started.resolve();
+            await finish.promise;
+          });
+          void active.catch(() => undefined);
+          yield* attempt(() => started.promise);
+          const queued = lock(lockPath, async () => {
+            queuedEntered = true;
+          });
+          void queued.catch(() => undefined);
+          const interruption = yield* Effect.forkChild(Fiber.interrupt(owner));
+          yield* Effect.yieldNow;
+          expect(yield* fs.exists(lockPath)).toBe(true);
+          finish.resolve();
+          yield* Fiber.join(interruption);
+          expect(yield* fs.exists(lockPath)).toBe(false);
+          expect(queuedEntered).toBe(false);
+          expect(Exit.isFailure(yield* Effect.exit(attempt(() => queued)))).toBe(true);
+          expect(Exit.isFailure(yield* Effect.exit(attempt(() => lock(lockPath, async () => undefined))))).toBe(true);
+          yield* attempt(() => active.catch(() => undefined));
+        }),
+      ),
+    ).pipe(provideTestLayer(gitLockTestLayer)),
+  );
+});


### PR DESCRIPTION
A killed composer could leave an ownerless lock directory and permanently block Git operations. Git services now use the existing token-and-process-identity file lock through a scoped Promise adapter, allowing a later process to recover a confirmed dead owner. Both service entry points provide the adapter; mutation paths without it fail closed.

The adapter preserves legacy directories and symbolic links, holds ownership until active work settles, and rejects pending calls when its scope closes. The runbook explains legacy upgrade recovery and distinguishes ordinary service draining from adapter teardown.

Validation: 69 focused tests across 10 files, including restricted-runtime PostgreSQL integrations, killed-owner recovery with an upstream-confirmed commit, independent service scopes, shutdown, a deterministic preflight-release race, and a bounded property for submission order and cleanup across successful/failed jobs. Lint and type checks pass. Full dev-cycle review returned zero critical/important findings; both minors were fixed. A source service crash drill passed: SIGKILL during pre-receive, restart readiness, and a new write confirmed upstream. Exact-HEAD global installation and the same global service drill are recorded before opening this PR.

This lock coordinates processes on one filesystem. It does not add coordination between independent clones or machines. Unexpected checkout state remains preserved and fails closed.
