### PR TITLE
Reject unsafe database runtime credentials before remote startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Run isolated PostgreSQL integration coverage
-        run: bun --bun vitest run test/integration/remote-memory-postgres.test.ts
+        run: bun --bun vitest run test/integration/remote-memory-*.test.ts
         env:
           THREADNOTE_TEST_POSTGRES_URL: postgres://postgres:postgres@127.0.0.1:5432/threadnote_ci
 

--- a/docs/remote-memory/operations.md
+++ b/docs/remote-memory/operations.md
@@ -78,6 +78,15 @@ updated that contract. The runtime cannot modify schema migrations, control-plan
 import receipts. Each identity has a different password and URL; URL-encode password characters in a connection URL.
 The `.env.example` values are local placeholders, not secret-management guidance.
 
+With automatic migration disabled, startup checks the account's effective privileges before listening. It rejects
+schema/table owners, database creation or administrative authority, usable/assumable role memberships, delegable
+grants, administrative parameter grants, disabled ordinary triggers, and table/column privileges outside the versioned
+runtime allowlist. It checks the authenticated backend identity as well as the effective and session roles, so role
+switching cannot disguise an administrator login. PUBLIC grants count toward this check.
+Use a separately created SQL role when a managed provider's built-in writer role has broader access. Keep
+`src/remote_memory/runtime_privileges.ts` aligned with the grants file when changing the schema contract. The
+loopback-only automatic-migration development mode retains its existing owner-account behavior.
+
 `THREADNOTE_REMOTE_ENABLED=false` is the environment-wide kill switch. Keep it false until the selected tenant/share
 canary is approved; both this switch and the share-scoped `remote_memory_ga` flag must be enabled for MCP traffic.
 

--- a/src/remote_memory/main.ts
+++ b/src/remote_memory/main.ts
@@ -1,4 +1,5 @@
 import type {GitWorktreeLock} from '../effect/git_worktree_lock.js';
+import {assertRemoteMemoryRuntimePrivileges} from './runtime_privileges.js';
 import {remoteMemoryConfigFromEnvironment, redactedRemoteMemoryConfig} from './config.js';
 import {createCursorTokenVerifier} from './cursor_oidc.js';
 import {migrateRemoteMemoryDatabase} from './migrations.js';
@@ -44,6 +45,7 @@ export async function runRemoteMemoryService(
   let stopping: Promise<void> | undefined;
   try {
     if (config.autoMigrate) await migrateRemoteMemoryDatabase(sql, {executablePath: runtime.executablePath});
+    else await assertRemoteMemoryRuntimePrivileges(sql);
     await assertRuntimeSchemaAccess(sql);
     const gitStore =
       config.canonicalStore === 'git' && config.gitWorktree

--- a/src/remote_memory/migrations.ts
+++ b/src/remote_memory/migrations.ts
@@ -34,6 +34,10 @@ const MIGRATIONS = [
 ] as const;
 const MIGRATION_LOCK = 7_427_190_041;
 
+export function remoteMemoryMigrationVersions(): readonly number[] {
+  return MIGRATIONS.map(migration => migration.version);
+}
+
 export async function migrateRemoteMemoryDatabase(
   sql: Sql,
   options: {readonly executablePath?: string} = {},

--- a/src/remote_memory/operator_postgres.ts
+++ b/src/remote_memory/operator_postgres.ts
@@ -4,7 +4,7 @@ import {randomUuidV4} from '../crypto/uuid.js';
 import {parseRemoteShareAddress} from '../memory_domain/address.js';
 import {parseRemoteCanonicalMemoryDocument} from '../memory_domain/content.js';
 import {parseResourceId} from '../storage/resource-id.js';
-import {migrateRemoteMemoryDatabase} from './migrations.js';
+import {migrateRemoteMemoryDatabase, remoteMemoryMigrationVersions} from './migrations.js';
 import {PostgresRemoteControlPlane, type RemoteMemoryProvisioningInput} from './postgres_control_plane.js';
 import {
   REMOTE_MEMORY_OPERATOR_CONTRACT_VERSION,
@@ -58,7 +58,11 @@ export class PostgresRemoteMemoryOperatorAdapter implements RemoteMemoryOperator
 
   readonly migrateSchema = async () => {
     await migrateRemoteMemoryDatabase(this.sql, {executablePath: this.options.executablePath});
-    return {readyVersions: [1], status: 'ready' as const, version: REMOTE_MEMORY_OPERATOR_CONTRACT_VERSION};
+    return {
+      readyVersions: remoteMemoryMigrationVersions(),
+      status: 'ready' as const,
+      version: REMOTE_MEMORY_OPERATOR_CONTRACT_VERSION,
+    };
   };
 
   readonly provisionControlPlane = async (input: RemoteMemoryProvisioningInput): Promise<void> => {

--- a/src/remote_memory/runtime_privileges.ts
+++ b/src/remote_memory/runtime_privileges.ts
@@ -1,0 +1,234 @@
+import type {Sql, TransactionSql} from 'postgres';
+import {remoteMemoryError} from './errors.js';
+
+interface RuntimeGrant {
+  readonly privilege: string;
+  readonly tables: readonly string[];
+  readonly columns?: readonly string[];
+}
+
+// Keep this boundary aligned with deploy/remote-memory/grants/001-runtime.sql.
+const RUNTIME_GRANTS: readonly RuntimeGrant[] = [
+  {
+    privilege: 'SELECT',
+    tables: [
+      'share_directory',
+      'challenge_directory',
+      'worker_health',
+      'tenant_memberships',
+      'shares',
+      'share_grants',
+      'projects',
+      'grant_policy_versions',
+      'share_policy_versions',
+      'project_repository_bindings',
+      'memory_heads',
+      'workload_attestations',
+      'attestation_challenges',
+      'memory_revisions',
+      'idempotency_records',
+      'outbox_events',
+      'rate_limit_windows',
+      'uri_aliases',
+      'search_documents',
+    ],
+  },
+  {
+    privilege: 'SELECT',
+    tables: ['tenants'],
+    columns: ['id', 'status'],
+  },
+  {
+    privilege: 'SELECT',
+    tables: ['principals'],
+    columns: ['tenant_id', 'id', 'status'],
+  },
+  {
+    privilege: 'SELECT',
+    tables: ['external_identities'],
+    columns: ['tenant_id', 'issuer', 'subject', 'principal_id'],
+  },
+  {
+    privilege: 'INSERT',
+    tables: [
+      'challenge_directory',
+      'memory_heads',
+      'workload_attestations',
+      'attestation_challenges',
+      'memory_revisions',
+      'idempotency_records',
+      'outbox_events',
+      'audit_events',
+      'rate_limit_windows',
+      'search_documents',
+      'projects',
+    ],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['shares'],
+    columns: ['share_generation', 'indexed_generation'],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['memory_heads'],
+    columns: ['current_revision_id', 'status', 'retention_class', 'expires_at', 'updated_at'],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['workload_attestations'],
+    columns: ['issuer', 'subject', 'jwt_id', 'cloud_agent_id', 'turn_id', 'team_id', 'owner_id', 'repository_urls'],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['attestation_challenges'],
+    columns: ['attempts', 'consumed_at'],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['idempotency_records'],
+    columns: ['outcome'],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['worker_health'],
+    columns: [
+      'heartbeat_at',
+      'last_success_at',
+      'last_failure_at',
+      'failure_class',
+      'pending_work',
+      'oldest_pending_at',
+      'updated_at',
+    ],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['outbox_events'],
+    columns: ['attempts', 'available_at', 'processed_at', 'dead_lettered_at', 'last_error_class'],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['rate_limit_windows'],
+    columns: ['window_started_at', 'request_count'],
+  },
+  {
+    privilege: 'UPDATE',
+    tables: ['search_documents'],
+    columns: ['revision_id', 'generation', 'project', 'topic', 'kind', 'searchable', 'updated_at'],
+  },
+  {
+    privilege: 'DELETE',
+    tables: ['challenge_directory', 'attestation_challenges', 'uri_aliases'],
+  },
+];
+
+interface GrantedPrivilege {
+  readonly table_name: string;
+  readonly column_name: string | null;
+  readonly privilege: string;
+  readonly can_delegate: boolean;
+  readonly granted: boolean;
+}
+
+/** Checks effective privileges, including PUBLIC grants, before accepting runtime traffic. */
+export async function assertRemoteMemoryRuntimePrivileges(sql: Sql): Promise<void> {
+  await sql.begin(async transaction => {
+    await transaction`SELECT pg_catalog.set_config('search_path', 'pg_catalog', true)`;
+    await transaction`SELECT set_config('statement_timeout', '5000', true)`;
+    await transaction`SELECT set_config('transaction_timeout', '5000', true)`;
+    await inspectRuntimePrivileges(transaction);
+  });
+}
+
+async function inspectRuntimePrivileges(sql: TransactionSql): Promise<void> {
+  const [role] = await sql<{unsafe: boolean}[]>`
+    SELECT (
+      r.oid <> backend.usesysid OR current_user <> session_user
+      OR r.rolsuper OR r.rolcreatedb OR r.rolcreaterole OR r.rolbypassrls OR r.rolreplication
+      OR current_setting('session_replication_role') <> 'origin'
+      OR EXISTS (
+        SELECT 1 FROM pg_parameter_acl p
+        WHERE has_parameter_privilege(current_user, p.parname, 'SET, ALTER SYSTEM')
+      )
+      OR has_database_privilege(current_user, current_database(), 'CREATE')
+      OR EXISTS (
+        SELECT 1 FROM pg_roles other WHERE other.oid <> r.oid
+          AND (pg_has_role(current_user, other.oid, 'USAGE')
+            OR pg_has_role(current_user, other.oid, 'SET')
+            OR pg_has_role(current_user, other.oid, 'MEMBER WITH ADMIN OPTION'))
+      )
+      OR EXISTS (
+        SELECT 1 FROM pg_namespace n WHERE n.nspname IN ('public', 'remote_memory')
+          AND (n.nspowner = r.oid OR has_schema_privilege(current_user, n.oid, 'CREATE'))
+      )
+      OR EXISTS (
+        SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'remote_memory' AND c.relowner = r.oid
+      )
+    ) AS unsafe FROM pg_roles r
+    JOIN pg_stat_activity backend ON backend.pid = pg_backend_pid()
+    WHERE r.rolname = current_user
+  `;
+  if (!role || role.unsafe) throw runtimePrivilegeError();
+
+  const columns = await sql<GrantedPrivilege[]>`
+    SELECT c.relname AS table_name, a.attname AS column_name, p.privilege,
+      has_column_privilege(current_user, c.oid, a.attnum, p.privilege) AS granted,
+      has_column_privilege(current_user, c.oid, a.attnum, p.privilege || ' WITH GRANT OPTION') AS can_delegate
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+    CROSS JOIN unnest(ARRAY['SELECT', 'INSERT', 'UPDATE', 'REFERENCES']) AS p(privilege)
+    WHERE n.nspname = 'remote_memory' AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+  `;
+  const tables = await sql<GrantedPrivilege[]>`
+    SELECT c.relname AS table_name, NULL::text AS column_name, p.privilege,
+      has_table_privilege(current_user, c.oid, p.privilege) AS granted,
+      has_table_privilege(current_user, c.oid, p.privilege || ' WITH GRANT OPTION') AS can_delegate
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    CROSS JOIN unnest(ARRAY['DELETE', 'TRUNCATE', 'TRIGGER', 'MAINTAIN']) AS p(privilege)
+    WHERE n.nspname = 'remote_memory' AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+  `;
+  const [sequences] = await sql<{unsafe: boolean}[]>`
+    SELECT EXISTS (
+      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'remote_memory' AND c.relkind = 'S'
+        AND has_sequence_privilege(current_user, c.oid, 'USAGE, SELECT, UPDATE')
+    ) AS unsafe
+  `;
+  const presentTables = new Set(columns.map(column => column.table_name));
+  if (
+    sequences?.unsafe ||
+    RUNTIME_GRANTS.some(grant =>
+      grant.tables.some(
+        table =>
+          !presentTables.has(table) ||
+          grant.columns?.some(
+            column => !columns.some(actual => actual.table_name === table && actual.column_name === column),
+          ),
+      ),
+    ) ||
+    [...columns, ...tables].some(privilege => privilege.granted !== runtimeGrantAllows(privilege))
+  ) {
+    throw runtimePrivilegeError();
+  }
+}
+
+function runtimeGrantAllows(privilege: GrantedPrivilege): boolean {
+  if (privilege.can_delegate) return false;
+  return RUNTIME_GRANTS.some(
+    grant =>
+      grant.privilege === privilege.privilege &&
+      grant.tables.includes(privilege.table_name) &&
+      (grant.columns === undefined ||
+        (privilege.column_name !== null && grant.columns.includes(privilege.column_name))),
+  );
+}
+
+function runtimePrivilegeError() {
+  return remoteMemoryError(
+    'service_unavailable',
+    'The database account does not match the runtime privilege contract. Use a dedicated runtime role and the versioned grants.',
+    {reason: 'unsafe_runtime_database_role'},
+  );
+}

--- a/test/helpers/remote-memory-postgres.ts
+++ b/test/helpers/remote-memory-postgres.ts
@@ -8,6 +8,7 @@ export interface RemoteMemoryPostgresFixture {
   readonly migratorRoleName: string;
   readonly migratorSql: Sql;
   readonly runtimeRoleName: string;
+  readonly runtimeDatabaseUrl: string;
   readonly sql: Sql;
   readonly dispose: () => Promise<void>;
 }
@@ -58,6 +59,7 @@ export async function createRemoteMemoryPostgresFixture(databaseUrl: string): Pr
       migratorRoleName,
       migratorSql,
       runtimeRoleName,
+      runtimeDatabaseUrl: runtimeUrl,
       sql,
       dispose: async () => {
         await sql?.end({timeout: 5});

--- a/test/integration/remote-memory-runtime-privileges.test.ts
+++ b/test/integration/remote-memory-runtime-privileges.test.ts
@@ -1,0 +1,172 @@
+import postgres from 'postgres';
+import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {
+  createRemoteMemoryPostgresFixture,
+  type RemoteMemoryPostgresFixture,
+} from '../helpers/remote-memory-postgres.js';
+import {assertRemoteMemoryRuntimePrivileges} from '../../src/remote_memory/runtime_privileges.js';
+import {PostgresRemoteMemoryOperatorAdapter} from '../../src/remote_memory/operator_postgres.js';
+
+const databaseUrl = process.env.THREADNOTE_TEST_POSTGRES_URL;
+const postgresDescribe = databaseUrl ? describe.sequential : describe.skip;
+const excessGrants = [
+  'UPDATE (status) ON remote_memory.shares',
+  'SELECT ON remote_memory.audit_events',
+  'UPDATE ON remote_memory.share_grants',
+  'DELETE ON remote_memory.memory_revisions',
+  'TRUNCATE ON remote_memory.memory_heads',
+  'INSERT ON remote_memory.external_identities',
+] as const;
+
+postgresDescribe('remote runtime database privilege preflight', () => {
+  let fixture: RemoteMemoryPostgresFixture;
+  let admin: ReturnType<typeof postgres>;
+  beforeAll(async () => {
+    fixture = await createRemoteMemoryPostgresFixture(databaseUrl!);
+    admin = postgres(databaseUrl!, {max: 1, onnotice: () => undefined});
+    const grants = (await Bun.file('deploy/remote-memory/grants/001-runtime.sql').text())
+      .replace(/^\\set .*$/gm, '')
+      .replaceAll('threadnote_remote_runtime', fixture.runtimeRoleName);
+    await fixture.migratorSql.unsafe(grants);
+  });
+  afterAll(async () => {
+    await admin?.end({timeout: 5});
+    await fixture?.dispose();
+  });
+
+  it('accepts the deployed table/column allowlist and reports every applied migration', async () => {
+    await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).resolves.toBeUndefined();
+    const receipt = await new PostgresRemoteMemoryOperatorAdapter(fixture.migratorSql).migrateSchema();
+    expect(receipt.readyVersions).toEqual([1, 2]);
+  });
+
+  it('rejects the schema owner and the bootstrap superuser', async () => {
+    await expect(assertRemoteMemoryRuntimePrivileges(fixture.migratorSql)).rejects.toMatchObject({
+      code: 'service_unavailable',
+    });
+    await expect(assertRemoteMemoryRuntimePrivileges(admin)).rejects.toMatchObject({code: 'service_unavailable'});
+  });
+
+  it.each(['role', 'session_authorization', 'overridden-user'])(
+    'rejects privileged authentication hidden by %s',
+    async disguise => {
+      const url = new URL(databaseUrl!);
+      url.pathname = `/${fixture.databaseName}`;
+      if (disguise === 'overridden-user') {
+        url.searchParams.set('user', decodeURIComponent(url.username));
+        url.username = fixture.runtimeRoleName;
+      }
+      url.searchParams.set('role', fixture.runtimeRoleName);
+      const disguised = postgres(url.toString(), {max: 1, onnotice: () => undefined});
+      try {
+        if (disguise !== 'role') await disguised.unsafe(`SET SESSION AUTHORIZATION ${fixture.runtimeRoleName}`);
+        const [identity] = await disguised`SELECT current_user AS name, session_user AS session_name`;
+        expect(identity.name).toBe(fixture.runtimeRoleName);
+        if (disguise !== 'role') expect(identity.session_name).toBe(fixture.runtimeRoleName);
+        await expect(assertRemoteMemoryRuntimePrivileges(disguised)).rejects.toMatchObject({
+          code: 'service_unavailable',
+        });
+      } finally {
+        await disguised.end({timeout: 5});
+      }
+    },
+  );
+
+  it.each(['SET', 'ALTER SYSTEM'])('rejects %s parameter authority', async privilege => {
+    try {
+      await admin.unsafe(`GRANT ${privilege} ON PARAMETER session_replication_role TO ${fixture.runtimeRoleName}`);
+      await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).rejects.toMatchObject({
+        code: 'service_unavailable',
+      });
+    } finally {
+      await admin.unsafe(`REVOKE ${privilege} ON PARAMETER session_replication_role FROM ${fixture.runtimeRoleName}`);
+    }
+    await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).resolves.toBeUndefined();
+  });
+
+  it('rejects a trigger-disabling role default even without a parameter grant', async () => {
+    let unsafe: ReturnType<typeof postgres> | undefined;
+    try {
+      await admin.unsafe(`ALTER ROLE ${fixture.runtimeRoleName} SET session_replication_role = replica`);
+      unsafe = postgres(fixture.runtimeDatabaseUrl, {max: 1, onnotice: () => undefined});
+      const [setting] = await unsafe`SELECT current_setting('session_replication_role') AS value`;
+      expect(setting.value).toBe('replica');
+      await expect(assertRemoteMemoryRuntimePrivileges(unsafe)).rejects.toMatchObject({code: 'service_unavailable'});
+    } finally {
+      await unsafe?.end({timeout: 5});
+      await admin.unsafe(`ALTER ROLE ${fixture.runtimeRoleName} RESET session_replication_role`);
+    }
+  });
+
+  it('rejects missing write permissions before accepting traffic', async () => {
+    try {
+      await fixture.migratorSql.unsafe(
+        `REVOKE INSERT ON remote_memory.memory_revisions FROM ${fixture.runtimeRoleName}`,
+      );
+      await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).rejects.toMatchObject({
+        code: 'service_unavailable',
+      });
+    } finally {
+      await fixture.migratorSql.unsafe(`GRANT INSERT ON remote_memory.memory_revisions TO ${fixture.runtimeRoleName}`);
+    }
+  });
+
+  it('rejects every bounded combination of excess runtime grants', async () => {
+    await FC.assert(
+      FC.asyncProperty(FC.uniqueArray(FC.constantFrom(...excessGrants), {minLength: 1, maxLength: 3}), async grants => {
+        try {
+          for (const grant of grants) await fixture.migratorSql.unsafe(`GRANT ${grant} TO ${fixture.runtimeRoleName}`);
+          await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).rejects.toMatchObject({
+            code: 'service_unavailable',
+          });
+        } finally {
+          for (const grant of grants)
+            await fixture.migratorSql.unsafe(`REVOKE ${grant} FROM ${fixture.runtimeRoleName}`);
+        }
+        await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).resolves.toBeUndefined();
+      }),
+      {numRuns: 10},
+    );
+  });
+
+  it.each(['CREATEROLE', 'CREATEDB', 'BYPASSRLS', 'REPLICATION'])('rejects runtime %s authority', async attribute => {
+    try {
+      await admin.unsafe(`ALTER ROLE ${fixture.runtimeRoleName} ${attribute}`);
+      await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).rejects.toMatchObject({
+        code: 'service_unavailable',
+      });
+    } finally {
+      await admin.unsafe(`ALTER ROLE ${fixture.runtimeRoleName} NO${attribute}`);
+    }
+  });
+
+  it.each(['pg_write_all_data', 'pg_read_all_data', 'pg_read_server_files'])(
+    'rejects a role it can assume: %s',
+    async role => {
+      try {
+        await admin.unsafe(`GRANT ${role} TO ${fixture.runtimeRoleName} WITH INHERIT FALSE, SET TRUE`);
+        await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).rejects.toMatchObject({
+          code: 'service_unavailable',
+        });
+      } finally {
+        await admin.unsafe(`REVOKE ${role} FROM ${fixture.runtimeRoleName}`);
+      }
+    },
+  );
+
+  it('rejects delegation of an otherwise allowed column privilege', async () => {
+    try {
+      await fixture.migratorSql.unsafe(
+        `GRANT UPDATE (share_generation) ON remote_memory.shares TO ${fixture.runtimeRoleName} WITH GRANT OPTION`,
+      );
+      await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).rejects.toMatchObject({
+        code: 'service_unavailable',
+      });
+    } finally {
+      await fixture.migratorSql.unsafe(
+        `REVOKE GRANT OPTION FOR UPDATE (share_generation) ON remote_memory.shares FROM ${fixture.runtimeRoleName}`,
+      );
+    }
+  });
+});

--- a/test/unit/ci-workflow.test.ts
+++ b/test/unit/ci-workflow.test.ts
@@ -133,9 +133,7 @@ describe('dependency-aware CI workflow', () => {
       if: "needs.changes.outputs.code == 'true'",
     });
     expect(remotePostgres.steps?.filter(step => step.uses?.startsWith('actions/checkout@'))).toHaveLength(1);
-    expect(
-      stepForRun(remotePostgres, 'bun --bun vitest run test/integration/remote-memory-postgres.test.ts').env,
-    ).toEqual({
+    expect(stepForRun(remotePostgres, 'bun --bun vitest run test/integration/remote-memory-*.test.ts').env).toEqual({
       THREADNOTE_TEST_POSTGRES_URL: 'postgres://postgres:postgres@127.0.0.1:5432/threadnote_ci',
     });
     expect(primary.steps?.[0]?.env).toMatchObject({


### PR DESCRIPTION
Remote service startup previously accepted database credentials with schema ownership or broader privileges than the runtime contract. With automatic migration disabled, startup now rejects unsafe authenticated identities, role memberships, administrative parameter authority, disabled guard triggers, and missing, excessive, or delegable table/column grants before listening. Loopback automatic-migration development mode retains its existing behavior.

The operator migration receipt now reports all registered, checksum-verified migrations instead of the hardcoded version 1. CI runs every remote PostgreSQL integration file against PostgreSQL 17.

Validation: 111 focused tests passed, including a bounded property over combinations of excess grants and six security regression cases; lint/typecheck passed; dev-cycle full review plus incremental fixes ended with zero blockers. The exact commit was installed globally. The global service smoke rejected the schema owner and an extra policy-writing grant before listening, accepted the live Neon runtime with MCP traffic disabled, and reported migrations 1 and 2. Full-suite validation is delegated to this PR's CI.
