### PR TITLE
fix(org): reconcile external Git memory lifecycle safely

### DIFF
--- a/deploy/remote-memory/grants/001-runtime.sql
+++ b/deploy/remote-memory/grants/001-runtime.sql
@@ -46,7 +46,7 @@ GRANT INSERT ON
   remote_memory.projects
 TO threadnote_remote_runtime;
 
-GRANT UPDATE (share_generation, indexed_generation) ON remote_memory.shares TO threadnote_remote_runtime;
+GRANT UPDATE (share_generation, indexed_generation, git_ingest_snapshot_commit, git_ingest_cursor, git_ingest_rejected_path) ON remote_memory.shares TO threadnote_remote_runtime;
 GRANT UPDATE (current_revision_id, status, retention_class, expires_at, updated_at)
   ON remote_memory.memory_heads TO threadnote_remote_runtime;
 GRANT UPDATE (issuer, subject, jwt_id, cloud_agent_id, turn_id, team_id, owner_id, repository_urls)

--- a/docs/org-productization.md
+++ b/docs/org-productization.md
@@ -1,14 +1,28 @@
 # Organization productization and dogfood deployment
 
 Status: reviewed with zero blocking findings after two dev-cycle iterations, 2026-09-07.
-Baseline: main `9b63eb0b` (4.6.7). Implementation starts with P1a, tenant/share isolation; the remaining P1
-storage contracts and subsequent gates remain open until separately verified.
+Audit baseline: main `9b63eb0b` (4.6.7). The implementation audit below records the original findings;
+the execution evidence here tracks which have since been addressed. Deployment and client acceptance gates remain open.
 
-Execution evidence: P1a is implemented in #378 with 102 focused tests, zero dev-cycle findings, and an
-exact-HEAD global smoke returning 200 for the bound share and 403 for an authorized sibling share. The next
-slice adds dedicated Git ingestion authority, persistent ingestion readiness failure, and rejection of HTTP
-body edits that would discard rich metadata. Git push/crash recovery and external lifecycle/removal convergence
-remain open P1 gates.
+Execution evidence as of 2026-09-07:
+
+- #378 binds Git to one tenant/share; #379 adds dedicated ingestion authority, persistent failure readiness, and
+  rejection of body edits that cannot preserve rich metadata.
+- #380 preserves exact OAuth issuers and supports optional `nbf`; #381 supports registered external client IDs.
+  Auth0's dedicated tenant and native clients have passed a real PKCE exchange. Actual agent MCP canaries remain open.
+- #382 isolates development installation repair. #383 confirms upstream Git persistence before acknowledgement;
+  #384 recovers crashed worktree-lock owners. Isolated global service smokes covered rejected pushes and crash/restart.
+- #385 rejects unsafe database credentials before listening and reports every applied migration. It passed 111
+  focused tests, dev-cycle review, global startup smoke against PostgreSQL/Neon, and full PR CI.
+- The lifecycle slice adds monotonic snapshot admission, immutable observation provenance, external lifecycle/removal
+  reconciliation, strict managed metadata validation, bounded legacy progress, and persistent rejection recovery.
+  It passed 142 focused tests, lint/types, two dev-cycle iterations with zero remaining findings, and the source
+  lifecycle smoke. Global installation and release checks remain separate gates.
+
+Neon PostgreSQL 17 in Frankfurt supports the required separate SQL-created migration/runtime roles and strict TLS.
+The incompatible, empty Fly Managed Postgres trial was removed. The Fly app is reserved; its org image, persistent
+clone, restricted Git credential, live deployment, and recovery acceptance are still P3–P5 work. Daily org writes
+remain disabled until those gates pass.
 
 The outcome is a deployable organization product and a real single-member deployment at
 `https://threadnote-org.fly.dev/mcp`. Our laptops retain local stdio, personal memory, exact-worktree graphs,

--- a/docs/remote-memory/operations.md
+++ b/docs/remote-memory/operations.md
@@ -87,6 +87,29 @@ Use a separately created SQL role when a managed provider's built-in writer role
 `src/remote_memory/runtime_privileges.ts` aligned with the grants file when changing the schema contract. The
 loopback-only automatic-migration development mode retains its existing owner-account behavior.
 
+Git deployments apply migration 3 and the updated runtime grants before starting the lifecycle-aware ingester. Its
+share snapshot commit is an admission fence, not a completed-index checkpoint. Empty and unchanged snapshots advance
+the fence; a delayed older scan cannot then mutate a head. Each revision retains a separate Git observation commit
+when the snapshot that justified its status differs from the commit containing its body. The ingester performs Git
+ancestry and body reads outside database transactions and checks both the expected head revision and snapshot fence
+when committing a change.
+
+External managed documents supply their active, archived, expired, or superseded status. Removing a canonical file
+appends an inactive revision that preserves the last accepted body and history. A later changed or restored valid
+publication may reactivate it; an unrelated commit cannot. Git publication does not renew elapsed remote handoff
+expiry or erase its retention settings. Plain Markdown remains supported. Malformed or ambiguous managed identity or
+lifecycle metadata, future schemas, rejected content, and unsupported Git entry modes fail ingestion visibly. A prior
+active head becomes archived with its retained body; a newly rejected path creates no active head. Correct or remove
+the rejected publication to resume ingestion.
+
+Ingestion visits at most 256 candidates and hydrates at most 256 bodies per pass. A persisted rotating path cursor
+advances once per batch so initialized unchanged shares avoid per-record database writes. Larger and legacy snapshots
+make progress, including same-commit records that older versions had not validated. A remembered rejected path is
+checked first on subsequent passes, so a partial batch cannot erase a known failure. The current outer read result is
+the lifecycle authority: a retained historical document may still contain `status: active` while the result is archived.
+Explicit URI/history reads and the default all-status list remain available; inactive heads are excluded from recall
+and `list(status: active)` as soon as the lifecycle transaction commits.
+
 `THREADNOTE_REMOTE_ENABLED=false` is the environment-wide kill switch. Keep it false until the selected tenant/share
 canary is approved; both this switch and the share-scoped `remote_memory_ga` flag must be enabled for MCP traffic.
 

--- a/src/remote_memory/git_canonical_store.ts
+++ b/src/remote_memory/git_canonical_store.ts
@@ -53,6 +53,11 @@ export interface GitCanonicalListedFile extends GitCanonicalListedPath {
   readonly contentHash: string;
 }
 
+export interface GitCanonicalSnapshot {
+  readonly gitCommit: string;
+  readonly paths: readonly (GitCanonicalListedPath & {readonly readable: boolean})[];
+}
+
 export function gitCanonicalSharePath(kind: 'durable' | 'handoff', project: string, topic: string): string {
   const projectSegment = validatePortableSegment(project);
   const topicSegment = validatePortableSegment(topic);
@@ -140,6 +145,22 @@ export class GitCanonicalMemoryStore {
 
   listCanonicalPaths(): Promise<readonly GitCanonicalListedPath[]> {
     return this.serialize(() => this.withLock(() => this.listCanonicalPathsExclusive()));
+  }
+
+  snapshot(): Promise<GitCanonicalSnapshot> {
+    return this.serialize(() => this.withLock(() => this.snapshotExclusive()));
+  }
+
+  isAncestor(ancestor: string, descendant: string): Promise<boolean> {
+    return this.serialize(async () => {
+      const result = await this.git(
+        ['merge-base', '--is-ancestor', requireGitCommit(ancestor), requireGitCommit(descendant)],
+        true,
+      );
+      if (result.exitCode > 1)
+        throw remoteMemoryError('service_unavailable', 'Git observation ancestry could not be verified.');
+      return result.exitCode === 0;
+    });
   }
 
   listBlobIds(commit: string): Promise<ReadonlyMap<string, string>> {
@@ -242,16 +263,22 @@ export class GitCanonicalMemoryStore {
   }
 
   private async listCanonicalPathsExclusive(): Promise<readonly GitCanonicalListedPath[]> {
+    const snapshot = await this.snapshotExclusive();
+    return snapshot.paths.filter(path => path.readable).map(({readable: _readable, ...path}) => path);
+  }
+
+  private async snapshotExclusive(): Promise<GitCanonicalSnapshot> {
     await this.refreshExclusive();
     const gitCommit = await this.headCommit();
-    const blobs = await this.lsTreeBlobsExclusive(gitCommit);
-    const files: GitCanonicalListedPath[] = [];
-    for (const [gitPath, blobId] of blobs) {
+    const listed = await this.git(['ls-tree', '-r', '-z', gitCommit]);
+    const blobs = parseLsTreeBlobs(listed.stdout);
+    const files: (GitCanonicalListedPath & {readonly readable: boolean})[] = [];
+    for (const [gitPath, blobId] of parseLsTreeBlobs(listed.stdout, true)) {
       const parsed = parseGitCanonicalSharePath(gitPath);
       if (!parsed) continue;
-      files.push({...parsed, blobId, gitCommit, gitPath});
+      files.push({...parsed, blobId, gitCommit, gitPath, readable: blobs.has(gitPath)});
     }
-    return files;
+    return {gitCommit, paths: files};
   }
 
   private async lsTreeBlobsExclusive(commit: string): Promise<Map<string, string>> {
@@ -414,7 +441,7 @@ async function isSymlink(path: string): Promise<boolean> {
   return result.exitCode === 0;
 }
 
-function parseLsTreeBlobs(stdout: string): Map<string, string> {
+function parseLsTreeBlobs(stdout: string, includeUnsupported = false): Map<string, string> {
   const blobs = new Map<string, string>();
   for (const record of stdout.split('\0').filter(Boolean)) {
     const tab = record.indexOf('\t');
@@ -423,8 +450,7 @@ function parseLsTreeBlobs(stdout: string): Map<string, string> {
     const gitPath = record.slice(tab + 1);
     const blobId = meta[2];
     if (
-      !['100644', '100755'].includes(meta[0] ?? '') ||
-      meta[1] !== 'blob' ||
+      (!includeUnsupported && (!['100644', '100755'].includes(meta[0] ?? '') || meta[1] !== 'blob')) ||
       !blobId ||
       !/^[0-9a-f]{40,64}$/u.test(blobId)
     )

--- a/src/remote_memory/git_ingest.ts
+++ b/src/remote_memory/git_ingest.ts
@@ -1,0 +1,388 @@
+import type {TransactionSql} from 'postgres';
+import {sha256HexSync} from '../crypto/sha256.js';
+import {randomUuidV4} from '../crypto/uuid.js';
+import {formatRemoteMemoryUri} from '../memory_domain/address.js';
+import {formatRemoteMemoryLogicalKey, REMOTE_MEMORY_REVISION_VERSION} from '../memory_domain/revisions.js';
+import type {AuthorizedRemotePrincipal} from './authorization.js';
+import {remoteMemoryError} from './errors.js';
+import {
+  GitCanonicalMemoryStore,
+  gitIngestProjectsToEnsure,
+  parseGitCanonicalSharePath,
+  type GitCanonicalSnapshot,
+} from './git_canonical_store.js';
+import {classifyGitIngestDocument, type GitIngestRejection, type GitIngestStatus} from './git_ingest_document.js';
+import {principalAllows, principalAllowsProject, requireActiveProject, requireShareState} from './repository_policy.js';
+
+const CANDIDATE_LIMIT = 256;
+type WithTenant = <A>(use: (transaction: TransactionSql) => Promise<A>) => Promise<A>;
+type Path = GitCanonicalSnapshot['paths'][number];
+interface Head {
+  readonly head_id: string;
+  readonly current_revision_id: string;
+  readonly content_hash: string;
+  readonly git_commit: string | null;
+  readonly git_observed_commit: string | null;
+  readonly git_path: string | null;
+  readonly kind: 'durable' | 'handoff';
+  readonly project: string;
+  readonly topic: string;
+  readonly status: GitIngestStatus;
+  readonly expires_at: Date | null;
+}
+interface Progress {
+  readonly git_ingest_snapshot_commit: string | null;
+  readonly git_ingest_cursor: string | null;
+  readonly git_ingest_rejected_path: string | null;
+}
+interface Candidate {
+  readonly gitPath: string;
+  readonly kind: 'durable' | 'handoff';
+  readonly project: string;
+  readonly topic: string;
+  readonly path?: Path;
+  readonly current?: Head;
+}
+interface Mutation {
+  readonly contentHash: string;
+  readonly gitCommit: string;
+  readonly status: GitIngestStatus;
+}
+interface Plan {
+  readonly mutation?: Mutation;
+  readonly rejected?: GitIngestRejection;
+}
+
+export async function ingestGitShare(input: {
+  readonly gitStore: GitCanonicalMemoryStore;
+  readonly principal: AuthorizedRemotePrincipal;
+  readonly requestId: string;
+  readonly now: Date;
+  readonly withTenant: WithTenant;
+}): Promise<{readonly ingested: number; readonly skipped: number}> {
+  const {gitStore, principal, withTenant} = input;
+  const snapshot = await gitStore.snapshot();
+  const progress = await admitSnapshot(withTenant, gitStore, principal, snapshot.gitCommit);
+  const loaded = await withTenant(async transaction => {
+    await requireShareState(transaction, principal);
+    const knownProjects = await transaction<{name: string}[]>`
+      SELECT name FROM remote_memory.projects WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId}
+    `;
+    for (const project of gitIngestProjectsToEnsure({
+      allowedProjects: principal.allowedProjects,
+      gitProjects: snapshot.paths.map(path => path.project),
+      knownProjects: new Set(knownProjects.map(project => project.name)),
+    })) {
+      await transaction`
+        INSERT INTO remote_memory.projects(tenant_id, share_id, name, status)
+        VALUES (${principal.tenantId}, ${principal.shareId}, ${project}, 'active')
+        ON CONFLICT (tenant_id, share_id, name) DO NOTHING
+      `;
+    }
+    const heads = await transaction<Head[]>`
+      SELECT h.id AS head_id, h.current_revision_id, h.kind, h.project, h.topic, h.status, h.expires_at,
+        r.content_hash, r.git_commit, r.git_path, r.git_observed_commit
+      FROM remote_memory.memory_heads h JOIN remote_memory.memory_revisions r
+        ON r.tenant_id = h.tenant_id AND r.share_id = h.share_id AND r.id = h.current_revision_id
+      WHERE h.tenant_id = ${principal.tenantId} AND h.share_id = ${principal.shareId}
+    `;
+    const projects = await transaction<{name: string}[]>`
+      SELECT name FROM remote_memory.projects
+      WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId} AND status = 'active'
+    `;
+    return {heads, projects: new Set(projects.map(project => project.name))};
+  });
+  const candidates = new Map<string, Candidate>();
+  for (const path of snapshot.paths) candidates.set(path.gitPath, {...path, path});
+  for (const current of loaded.heads) {
+    if (!current.git_path) continue;
+    const parsed = parseGitCanonicalSharePath(current.git_path);
+    if (!parsed) continue;
+    candidates.set(current.git_path, {
+      ...parsed,
+      ...candidates.get(current.git_path),
+      gitPath: current.git_path,
+      current,
+    });
+  }
+  const rejectedPath = progress.git_ingest_rejected_path;
+  if (rejectedPath && !candidates.has(rejectedPath)) {
+    const parsed = parseGitCanonicalSharePath(rejectedPath);
+    if (!parsed) throw remoteMemoryError('service_unavailable', 'The Git ingestion rejection path is invalid.');
+    candidates.set(rejectedPath, {...parsed, gitPath: rejectedPath});
+  }
+  const ordered = [...candidates.values()].sort((left, right) =>
+    left.gitPath < right.gitPath ? -1 : left.gitPath > right.gitPath ? 1 : 0,
+  );
+  const afterCursor = ordered.findIndex(
+    candidate => progress.git_ingest_cursor === null || candidate.gitPath > progress.git_ingest_cursor,
+  );
+  const rotated = afterCursor < 0 ? ordered : [...ordered.slice(afterCursor), ...ordered.slice(0, afterCursor)];
+  const prioritized = rejectedPath
+    ? [candidates.get(rejectedPath)!, ...rotated.filter(candidate => candidate.gitPath !== rejectedPath)]
+    : rotated;
+  const blobCache = new Map<string, ReadonlyMap<string, string>>();
+  const verifiedAncestors = new Set([snapshot.gitCommit]);
+  const blobsAt = async (commit: string) => {
+    let blobs = blobCache.get(commit);
+    if (!blobs) {
+      blobs = await gitStore.listBlobIds(commit);
+      blobCache.set(commit, blobs);
+    }
+    return blobs;
+  };
+  let cursor = progress.git_ingest_cursor;
+  let expectedRejection = rejectedPath;
+  let ingested = 0;
+  let skipped = 0;
+  for (const candidate of prioritized.slice(0, CANDIDATE_LIMIT)) {
+    if (!canIngest(principal, candidate) || !loaded.projects.has(candidate.project)) {
+      if (candidate.gitPath === rejectedPath) throw ingestionRejected('metadata');
+      skipped += 1;
+    } else {
+      const observation = candidate.current?.git_observed_commit ?? candidate.current?.git_commit;
+      if (observation && !verifiedAncestors.has(observation)) {
+        if (!(await gitStore.isAncestor(observation, snapshot.gitCommit))) throw supersededSnapshot();
+        verifiedAncestors.add(observation);
+      }
+      const priorBlob = observation ? (await blobsAt(observation)).get(candidate.gitPath) : undefined;
+      const needsValidation =
+        candidate.path !== undefined &&
+        (candidate.gitPath === rejectedPath ||
+          !candidate.path.readable ||
+          !candidate.current?.git_observed_commit ||
+          priorBlob !== candidate.path.blobId);
+      let plan: Plan = {};
+      if (needsValidation && candidate.path) {
+        const content = candidate.path.readable
+          ? await gitStore.read({commit: snapshot.gitCommit, path: candidate.gitPath})
+          : '';
+        const classification = candidate.path.readable
+          ? classifyGitIngestDocument(content, candidate)
+          : {accepted: false as const, reason: 'unsupported_entry' as const};
+        if (!classification.accepted) {
+          plan = {
+            rejected: classification.reason,
+            mutation: preservedMutation(
+              candidate.current,
+              priorBlob !== undefined && priorBlob !== candidate.path.blobId,
+            ),
+          };
+        } else {
+          const contentHash = sha256HexSync(content);
+          const expired = candidate.current?.expires_at && candidate.current.expires_at <= input.now;
+          const status =
+            expired && classification.status === 'active'
+              ? candidate.current.status === 'active'
+                ? 'expired'
+                : candidate.current.status
+              : classification.status;
+          if (
+            candidate.current?.content_hash !== contentHash ||
+            candidate.current.status !== status ||
+            priorBlob === undefined
+          ) {
+            plan = {mutation: {contentHash, gitCommit: snapshot.gitCommit, status}};
+          }
+        }
+      } else if (!candidate.path && priorBlob !== undefined) {
+        plan = {mutation: preservedMutation(candidate.current, true)};
+      }
+      if (plan.mutation || plan.rejected) {
+        const changed = await applyPlan({
+          ...input,
+          candidate,
+          plan,
+          snapshotCommit: snapshot.gitCommit,
+          expectedRejectedPath: expectedRejection,
+        });
+        if (changed) ingested += 1;
+        else skipped += 1;
+      } else skipped += 1;
+      if (plan.rejected) throw ingestionRejected(plan.rejected);
+    }
+    if (candidate.gitPath === expectedRejection) {
+      await withTenant(async transaction => {
+        await requireShareState(transaction, principal);
+        const rows = await transaction<{id: string}[]>`
+          UPDATE remote_memory.shares SET git_ingest_rejected_path = NULL
+          WHERE tenant_id = ${principal.tenantId} AND id = ${principal.shareId}
+            AND git_ingest_snapshot_commit = ${snapshot.gitCommit}
+            AND git_ingest_rejected_path = ${expectedRejection}
+            AND git_ingest_cursor IS NOT DISTINCT FROM ${progress.git_ingest_cursor}::text
+          RETURNING id
+        `;
+        if (!rows[0]) throw supersededSnapshot();
+      });
+      expectedRejection = null;
+    }
+    cursor = candidate.gitPath;
+  }
+  if (prioritized.length > 0) {
+    await withTenant(async transaction => {
+      await requireShareState(transaction, principal);
+      const rows = await transaction<{id: string}[]>`
+        UPDATE remote_memory.shares SET git_ingest_cursor = ${cursor}
+        WHERE tenant_id = ${principal.tenantId} AND id = ${principal.shareId}
+          AND git_ingest_snapshot_commit = ${snapshot.gitCommit}
+          AND git_ingest_cursor IS NOT DISTINCT FROM ${progress.git_ingest_cursor}::text
+          AND git_ingest_rejected_path IS NOT DISTINCT FROM ${expectedRejection}::text
+        RETURNING id
+      `;
+      if (!rows[0]) throw supersededSnapshot();
+    });
+  }
+  return {ingested, skipped};
+}
+
+function canIngest(principal: AuthorizedRemotePrincipal, candidate: Candidate): boolean {
+  return (
+    principalAllowsProject(principal, candidate.project) &&
+    (candidate.kind === 'durable'
+      ? principalAllows(principal, 'memory:write:durable', 'remote_memory_durable_write')
+      : principalAllows(principal, 'memory:write:handoff', 'remote_memory_handoff_write'))
+  );
+}
+
+function preservedMutation(current: Head | undefined, presenceChanged: boolean): Mutation | undefined {
+  if (!current?.git_commit || (current.status !== 'active' && !presenceChanged)) return undefined;
+  return {
+    contentHash: current.content_hash,
+    gitCommit: current.git_commit,
+    status: current.status === 'active' ? 'archived' : current.status,
+  };
+}
+
+async function admitSnapshot(
+  withTenant: WithTenant,
+  gitStore: GitCanonicalMemoryStore,
+  principal: AuthorizedRemotePrincipal,
+  commit: string,
+): Promise<Progress> {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const prior = await withTenant(async transaction => {
+      await requireShareState(transaction, principal);
+      const [row] = await transaction<Progress[]>`
+        SELECT git_ingest_snapshot_commit, git_ingest_cursor, git_ingest_rejected_path
+        FROM remote_memory.shares WHERE tenant_id = ${principal.tenantId} AND id = ${principal.shareId}
+      `;
+      return row;
+    });
+    const previousCommit = prior.git_ingest_snapshot_commit;
+    if (previousCommit && previousCommit !== commit && !(await gitStore.isAncestor(previousCommit, commit))) {
+      if (await gitStore.isAncestor(commit, previousCommit)) throw supersededSnapshot();
+      throw remoteMemoryError('service_unavailable', 'The Git ingestion history diverged from the admitted snapshot.');
+    }
+    const admitted = await withTenant(async transaction => {
+      await requireShareState(transaction, principal);
+      return transaction<Progress[]>`
+        UPDATE remote_memory.shares SET git_ingest_snapshot_commit = ${commit}
+        WHERE tenant_id = ${principal.tenantId} AND id = ${principal.shareId}
+          AND git_ingest_snapshot_commit IS NOT DISTINCT FROM ${previousCommit}::text
+        RETURNING git_ingest_snapshot_commit, git_ingest_cursor, git_ingest_rejected_path
+      `;
+    });
+    if (admitted[0]) return admitted[0];
+  }
+  throw supersededSnapshot();
+}
+
+async function applyPlan(input: {
+  readonly withTenant: WithTenant;
+  readonly principal: AuthorizedRemotePrincipal;
+  readonly candidate: Candidate;
+  readonly plan: Plan;
+  readonly snapshotCommit: string;
+  readonly expectedRejectedPath: string | null;
+  readonly requestId: string;
+  readonly now: Date;
+}): Promise<boolean> {
+  const {principal, candidate, plan} = input;
+  return input.withTenant(async transaction => {
+    await requireShareState(transaction, principal);
+    await requireActiveProject(transaction, principal, candidate.project);
+    const logicalKey = formatRemoteMemoryLogicalKey({
+      kind: candidate.kind,
+      project: candidate.project,
+      topic: candidate.topic,
+      tenantId: principal.tenantId,
+      shareId: principal.shareId,
+      version: REMOTE_MEMORY_REVISION_VERSION,
+    });
+    await transaction`SELECT pg_advisory_xact_lock(hashtextextended(${logicalKey}, 0))`;
+    const [current] = await transaction<{id: string; current_revision_id: string}[]>`
+      SELECT id, current_revision_id FROM remote_memory.memory_heads
+      WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId}
+        AND kind = ${candidate.kind} AND project = ${candidate.project} AND topic = ${candidate.topic}
+      FOR UPDATE
+    `;
+    if (current?.current_revision_id !== candidate.current?.current_revision_id) throw supersededSnapshot();
+    const [generation] = await transaction<{share_generation: string | number}[]>`
+      UPDATE remote_memory.shares SET share_generation = share_generation + ${plan.mutation ? 1 : 0},
+        git_ingest_rejected_path = CASE WHEN ${plan.rejected !== undefined} THEN ${candidate.gitPath} ELSE git_ingest_rejected_path END
+      WHERE tenant_id = ${principal.tenantId} AND id = ${principal.shareId} AND status = 'active'
+        AND policy_version = ${principal.sharePolicyVersion} AND policy_digest = ${principal.sharePolicyDigest}
+        AND git_ingest_snapshot_commit = ${input.snapshotCommit}
+        AND git_ingest_rejected_path IS NOT DISTINCT FROM ${input.expectedRejectedPath}::text
+      RETURNING share_generation
+    `;
+    if (!generation) throw supersededSnapshot();
+    const committed = await requireShareState(transaction, principal);
+    if (!plan.mutation) return false;
+    const headId = current?.id ?? randomUuidV4();
+    const revisionId = randomUuidV4();
+    const canonicalUri = formatRemoteMemoryUri({
+      kind: candidate.kind,
+      project: candidate.project,
+      topic: candidate.topic,
+      shareId: principal.shareId,
+    });
+    if (!current) {
+      await transaction`
+        INSERT INTO remote_memory.memory_heads(tenant_id, share_id, id, kind, project, topic, canonical_uri, status)
+        VALUES (${principal.tenantId}, ${principal.shareId}, ${headId}, ${candidate.kind}, ${candidate.project}, ${candidate.topic}, ${canonicalUri}, ${plan.mutation.status})
+      `;
+    }
+    await transaction`
+      INSERT INTO remote_memory.memory_revisions(
+        tenant_id, share_id, id, head_id, base_revision_id, generation, status,
+        markdown_body, content_hash, git_commit, git_path, git_observed_commit, oauth_principal_id, operation_id
+      ) VALUES (
+        ${principal.tenantId}, ${principal.shareId}, ${revisionId}, ${headId}, ${current?.current_revision_id ?? null},
+        ${Number(generation.share_generation)}, ${plan.mutation.status}, ${''}, ${plan.mutation.contentHash},
+        ${plan.mutation.gitCommit}, ${candidate.gitPath}, ${input.snapshotCommit}, ${principal.principalId},
+        ${`git-ingest:${input.snapshotCommit}:${candidate.gitPath}`}
+      )
+    `;
+    await transaction`
+      UPDATE remote_memory.memory_heads SET current_revision_id = ${revisionId}, status = ${plan.mutation.status}, updated_at = ${input.now.toISOString()}
+      WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId} AND id = ${headId}
+    `;
+    await transaction`
+      INSERT INTO remote_memory.outbox_events(tenant_id, share_id, id, generation, event_type, aggregate_id)
+      VALUES (${principal.tenantId}, ${principal.shareId}, ${randomUuidV4()}, ${Number(generation.share_generation)}, 'memory_head_changed', ${headId})
+    `;
+    await transaction`
+      INSERT INTO remote_memory.audit_events(tenant_id, share_id, id, request_id, principal_id, operation, result, policy_version, share_policy_version, generation)
+      VALUES (${principal.tenantId}, ${principal.shareId}, ${randomUuidV4()}, ${input.requestId}, ${principal.principalId},
+        'ingest_git_share', ${plan.rejected ? `rejected_${plan.rejected}` : 'committed'}, ${principal.policyVersion}, ${committed.policy_version}, ${Number(generation.share_generation)})
+    `;
+    return true;
+  });
+}
+
+function supersededSnapshot() {
+  return remoteMemoryError(
+    'service_unavailable',
+    'The Git ingestion snapshot or memory head changed; retry the current snapshot.',
+    {reason: 'git_ingest_snapshot_superseded'},
+  );
+}
+
+function ingestionRejected(reason: GitIngestRejection) {
+  return remoteMemoryError(
+    'service_unavailable',
+    'A canonical Git memory was rejected; correct the source publication before continuing ingestion.',
+    {reason: `git_ingest_${reason}`},
+  );
+}

--- a/src/remote_memory/git_ingest_document.ts
+++ b/src/remote_memory/git_ingest_document.ts
@@ -1,0 +1,49 @@
+import {MEMORY_SCHEMA_VERSION} from '../memory/code_citation.js';
+import {parseMemoryDocument} from '../memory/document.js';
+import {inspectRemoteMemoryContent} from '../memory_domain/content.js';
+import type {GitCanonicalListedPath} from './git_canonical_store.js';
+
+export type GitIngestStatus = 'active' | 'archived' | 'expired' | 'superseded';
+export type GitIngestRejection = 'content_policy' | 'metadata' | 'unsupported_entry';
+export type GitIngestDocument =
+  | {readonly accepted: true; readonly status: GitIngestStatus}
+  | {readonly accepted: false; readonly reason: GitIngestRejection};
+
+const statuses = new Set<GitIngestStatus>(['active', 'archived', 'expired', 'superseded']);
+const criticalFields = new Set(['kind', 'status', 'project', 'repo', 'topic', 'schema_version']);
+
+export function classifyGitIngestDocument(
+  content: string,
+  path: Pick<GitCanonicalListedPath, 'kind' | 'project' | 'topic'>,
+): GitIngestDocument {
+  if (!inspectRemoteMemoryContent(content).allowed) return {accepted: false, reason: 'content_policy'};
+  const header = content.trim().replace(/\r\n?/gu, '\n').split('\n\n', 1)[0];
+  const lines = header.split('\n');
+  const marker = lines[0]?.trim();
+  if (marker !== 'MEMORY' && marker !== 'HANDOFF') return {accepted: true, status: 'active'};
+  const fields = new Map<string, string>();
+  for (const line of lines.slice(1)) {
+    const match = /^([a-z_]+):\s*(.*)$/u.exec(line.trim());
+    if (!match) return {accepted: false, reason: 'metadata'};
+    const [, key, value] = match;
+    if (!criticalFields.has(key)) continue;
+    if (fields.has(key) || !value.trim()) return {accepted: false, reason: 'metadata'};
+    fields.set(key, value.trim());
+  }
+  const schema = fields.get('schema_version');
+  const status = fields.get('status');
+  if (
+    (schema !== undefined && (!/^[1-9][0-9]*$/u.test(schema) || Number(schema) > MEMORY_SCHEMA_VERSION)) ||
+    (status !== undefined && !statuses.has(status as GitIngestStatus)) ||
+    (fields.has('project') && fields.has('repo')) ||
+    (fields.has('kind') && fields.get('kind') !== path.kind) ||
+    (fields.has('project') && fields.get('project') !== path.project) ||
+    (fields.has('repo') && fields.get('repo') !== path.project) ||
+    (fields.has('topic') && fields.get('topic') !== path.topic) ||
+    marker !== (path.kind === 'handoff' ? 'HANDOFF' : 'MEMORY')
+  )
+    return {accepted: false, reason: 'metadata'};
+  const parsed = parseMemoryDocument('threadnote://share/ingest/memories/durable/project/topic.md', content);
+  if (!parsed || parsed.metadata.kind !== path.kind) return {accepted: false, reason: 'metadata'};
+  return {accepted: true, status: (status ?? 'active') as GitIngestStatus};
+}

--- a/src/remote_memory/migrations.ts
+++ b/src/remote_memory/migrations.ts
@@ -31,6 +31,7 @@ function migrationFile(name: string, executablePath: string | undefined): string
 const MIGRATIONS = [
   {name: '001_initial.sql', version: 1},
   {name: '002_git_canonical_pointers.sql', version: 2},
+  {name: '003_git_ingest_observations.sql', version: 3},
 ] as const;
 const MIGRATION_LOCK = 7_427_190_041;
 

--- a/src/remote_memory/migrations/003_git_ingest_observations.sql
+++ b/src/remote_memory/migrations/003_git_ingest_observations.sql
@@ -1,0 +1,13 @@
+ALTER TABLE remote_memory.shares
+  ADD COLUMN git_ingest_snapshot_commit text,
+  ADD COLUMN git_ingest_cursor text,
+  ADD COLUMN git_ingest_rejected_path text,
+  ADD CONSTRAINT shares_git_ingest_commit_shape CHECK (
+    git_ingest_snapshot_commit IS NULL OR git_ingest_snapshot_commit ~ '^[0-9a-f]{40,64}$'
+  );
+
+ALTER TABLE remote_memory.memory_revisions
+  ADD COLUMN git_observed_commit text,
+  ADD CONSTRAINT memory_revisions_git_observation_shape CHECK (
+    git_observed_commit IS NULL OR (git_commit IS NOT NULL AND git_observed_commit ~ '^[0-9a-f]{40,64}$')
+  );

--- a/src/remote_memory/postgres_repository.ts
+++ b/src/remote_memory/postgres_repository.ts
@@ -1,3 +1,12 @@
+import {ingestGitShare} from './git_ingest.js';
+import {
+  requireShareState,
+  requireActiveProject,
+  principalAllows,
+  requirePrincipalProject,
+  type ShareStateRow,
+  type GrantStateRow,
+} from './repository_policy.js';
 import {Schema} from 'effect';
 import type {Sql, TransactionSql} from 'postgres';
 import {sha256HexSync} from '../crypto/sha256.js';
@@ -23,7 +32,7 @@ import {
 import type {AuthorizedRemotePrincipal, RemoteMemoryFeatureFlag, RemoteMemoryScope} from './authorization.js';
 import {authorizeCursorClaims, type CursorWorkloadAttestation} from './cursor_oidc.js';
 import {RemoteMemoryError, remoteMemoryError, type RemoteMemoryErrorCode} from './errors.js';
-import {GitCanonicalMemoryStore, gitCanonicalSharePath, gitIngestProjectsToEnsure} from './git_canonical_store.js';
+import {GitCanonicalMemoryStore, gitCanonicalSharePath} from './git_canonical_store.js';
 import {requireJsonValue} from './json.js';
 import {assertGitMemoryBinding, requireGitMemoryBinding} from './git_binding.js';
 import {remoteGitIngestPrincipalId} from './git_ingest_principal.js';
@@ -34,21 +43,6 @@ import {
   withRemoteMemoryRequestCancellation,
   type RemoteMemoryRequestExecution,
 } from './request_execution.js';
-
-interface ShareStateRow {
-  readonly indexed_generation: string | number;
-  readonly policy_digest: string;
-  readonly policy_version: string;
-  readonly share_generation: string | number;
-}
-
-interface GrantStateRow extends ShareStateRow {
-  readonly allowed_projects: string[] | null;
-  readonly capabilities: string[];
-  readonly feature_flags: string[];
-  readonly grant_policy_version: string;
-  readonly grant_policy_digest: string;
-}
 
 interface HeadRow {
   readonly canonical_uri: string;
@@ -93,7 +87,6 @@ type OperationReservation =
   {readonly kind: 'execute'} | {readonly kind: 'replay'; readonly receipt: RemoteMemoryReceiptV1};
 
 const IDEMPOTENCY_REPLAY_WINDOW_MILLISECONDS = 24 * 60 * 60_000;
-const GIT_INGEST_HYDRATE_LIMIT = 256;
 
 export interface RemoteMemoryReadResult {
   readonly content: string;
@@ -701,222 +694,13 @@ export class PostgresRemoteMemoryRepository {
     now = new Date(),
   ): Promise<{readonly ingested: number; readonly skipped: number}> {
     assertGitMemoryBinding(this.gitStore?.binding, principal);
-    const gitStore = this.gitStore;
-    if (!gitStore) {
-      throw remoteMemoryError('invalid_request', 'Git share ingest requires a git canonical store.');
-    }
-    const paths = await gitStore.listCanonicalPaths();
-    const blobCache = new Map<string, ReadonlyMap<string, string>>();
-    const blobsAt = async (commit: string): Promise<ReadonlyMap<string, string>> => {
-      const cached = blobCache.get(commit);
-      if (cached) return cached;
-      const blobs = await gitStore.listBlobIds(commit);
-      blobCache.set(commit, blobs);
-      return blobs;
-    };
-    const snapshot = await this.withTenant(principal.tenantId, async transaction => {
-      await requireShareState(transaction, principal);
-      const knownProjects = await transaction<{name: string}[]>`
-        SELECT name FROM remote_memory.projects
-        WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId}
-      `;
-      const toEnsure = gitIngestProjectsToEnsure({
-        allowedProjects: principal.allowedProjects,
-        gitProjects: paths.map(path => path.project),
-        knownProjects: new Set(knownProjects.map(project => project.name)),
-      });
-      for (const project of toEnsure) {
-        await transaction`
-          INSERT INTO remote_memory.projects(tenant_id, share_id, name, status)
-          VALUES (${principal.tenantId}, ${principal.shareId}, ${project}, 'active')
-          ON CONFLICT (tenant_id, share_id, name) DO NOTHING
-        `;
-      }
-      const heads = await transaction<
-        {
-          readonly content_hash: string;
-          readonly git_commit: string | null;
-          readonly git_path: string | null;
-          readonly kind: 'durable' | 'handoff';
-          readonly project: string;
-          readonly status: HeadRow['status'];
-          readonly topic: string;
-        }[]
-      >`
-        SELECT h.kind, h.project, h.topic, h.status, r.content_hash, r.git_commit, r.git_path
-        FROM remote_memory.memory_heads h
-        JOIN remote_memory.memory_revisions r
-          ON r.tenant_id = h.tenant_id AND r.share_id = h.share_id AND r.id = h.current_revision_id
-        WHERE h.tenant_id = ${principal.tenantId} AND h.share_id = ${principal.shareId}
-      `;
-      const projects = await transaction<{name: string}[]>`
-        SELECT name FROM remote_memory.projects
-        WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId} AND status = 'active'
-      `;
-      return {heads, projects: new Set(projects.map(project => project.name))};
-    });
-    const heads = new Map(snapshot.heads.map(head => [`${head.kind}:${head.project}:${head.topic}`, head] as const));
-    let ingested = 0;
-    let skipped = 0;
-    let hydrates = 0;
-    for (const path of paths) {
-      if (!principalAllowsProject(principal, path.project) || !snapshot.projects.has(path.project)) {
-        skipped += 1;
-        continue;
-      }
-      if (
-        (path.kind === 'durable' &&
-          !principalAllows(principal, 'memory:write:durable', 'remote_memory_durable_write')) ||
-        (path.kind === 'handoff' && !principalAllows(principal, 'memory:write:handoff', 'remote_memory_handoff_write'))
-      ) {
-        skipped += 1;
-        continue;
-      }
-      const current = heads.get(`${path.kind}:${path.project}:${path.topic}`);
-      if (current && current.status !== 'active') {
-        skipped += 1;
-        continue;
-      }
-      if (current?.git_commit === path.gitCommit && current.git_path === path.gitPath) {
-        skipped += 1;
-        continue;
-      }
-      if (current?.git_commit && current.git_path === path.gitPath) {
-        const priorBlob = (await blobsAt(current.git_commit)).get(path.gitPath);
-        if (priorBlob === path.blobId) {
-          skipped += 1;
-          continue;
-        }
-      }
-      if (hydrates >= GIT_INGEST_HYDRATE_LIMIT) {
-        skipped += 1;
-        continue;
-      }
-      hydrates += 1;
-      const content = await gitStore.read({commit: path.gitCommit, path: path.gitPath});
-      const inspected = inspectRemoteMemoryContent(content);
-      if (!inspected.allowed) {
-        skipped += 1;
-        continue;
-      }
-      const changed = await this.ingestGitFile(
-        principal,
-        {...path, contentHash: sha256HexSync(content)},
-        requestId,
-        now,
-      );
-      if (changed) ingested += 1;
-      else skipped += 1;
-    }
-    return {ingested, skipped};
-  }
-
-  private async ingestGitFile(
-    principal: AuthorizedRemotePrincipal,
-    file: {
-      readonly contentHash: string;
-      readonly gitCommit: string;
-      readonly gitPath: string;
-      readonly kind: 'durable' | 'handoff';
-      readonly project: string;
-      readonly topic: string;
-    },
-    requestId: string,
-    now: Date,
-  ): Promise<boolean> {
-    return this.withTenant(principal.tenantId, async transaction => {
-      await requireShareState(transaction, principal);
-      await requireActiveProject(transaction, principal, file.project);
-      const logicalKey = formatRemoteMemoryLogicalKey({
-        kind: file.kind,
-        project: file.project,
-        shareId: principal.shareId,
-        tenantId: principal.tenantId,
-        topic: file.topic,
-        version: REMOTE_MEMORY_REVISION_VERSION,
-      });
-      await transaction`SELECT pg_advisory_xact_lock(hashtextextended(${logicalKey}, 0))`;
-      const currentRows = await transaction<HeadRow[]>`
-        SELECT h.canonical_uri, h.id AS head_id, h.kind, h.project, h.topic, h.current_revision_id,
-          h.status, r.markdown_body, r.content_hash, r.git_commit, r.git_path, h.retention_class, h.expires_at,
-          h.created_at, h.updated_at
-        FROM remote_memory.memory_heads h
-        JOIN remote_memory.memory_revisions r
-          ON r.tenant_id = h.tenant_id AND r.share_id = h.share_id AND r.id = h.current_revision_id
-        WHERE h.tenant_id = ${principal.tenantId} AND h.share_id = ${principal.shareId}
-          AND h.kind = ${file.kind} AND h.project = ${file.project} AND h.topic = ${file.topic}
-        FOR UPDATE OF h
-      `;
-      const current = currentRows[0];
-      if (current && current.status !== 'active') return false;
-      if (current?.git_commit === file.gitCommit && current.git_path === file.gitPath) return false;
-      if (current?.content_hash === file.contentHash) return false;
-      const canonicalUri = formatRemoteMemoryUri({
-        kind: file.kind,
-        project: file.project,
-        shareId: principal.shareId,
-        topic: file.topic,
-      });
-      const headId = current?.head_id ?? randomUuidV4();
-      const proposedRevision = randomUuidV4();
-      if (!current) {
-        await transaction`
-          INSERT INTO remote_memory.memory_heads(
-            tenant_id, share_id, id, kind, project, topic, canonical_uri, status
-          ) VALUES (
-            ${principal.tenantId}, ${principal.shareId}, ${headId}, ${file.kind}, ${file.project},
-            ${file.topic}, ${canonicalUri}, 'active'
-          )
-        `;
-      }
-      const generationRows = await transaction<ShareStateRow[]>`
-        UPDATE remote_memory.shares SET share_generation = share_generation + 1
-        WHERE tenant_id = ${principal.tenantId} AND id = ${principal.shareId} AND status = 'active'
-          AND policy_version = ${principal.sharePolicyVersion}
-          AND policy_digest = ${principal.sharePolicyDigest}
-        RETURNING share_generation, indexed_generation, policy_version, policy_digest
-      `;
-      const committedGeneration = generationRows[0];
-      if (!committedGeneration) throw remoteMemoryError('forbidden', 'The memory share is no longer active.');
-      const committed = await requireShareState(transaction, principal);
-      if (numeric(committed.share_generation) !== numeric(committedGeneration.share_generation)) {
-        throw remoteMemoryError('service_unavailable', 'The committed memory generation could not be verified.');
-      }
-      await transaction`
-        INSERT INTO remote_memory.memory_revisions(
-          tenant_id, share_id, id, head_id, base_revision_id, generation, status,
-          markdown_body, content_hash, git_commit, git_path, oauth_principal_id, operation_id
-        ) VALUES (
-          ${principal.tenantId}, ${principal.shareId}, ${proposedRevision}, ${headId},
-          ${current?.current_revision_id ?? null}, ${numeric(committed.share_generation)}, 'active',
-          ${''}, ${file.contentHash}, ${file.gitCommit}, ${file.gitPath},
-          ${principal.principalId}, ${`git-ingest:${file.gitCommit}:${file.gitPath}`}
-        )
-      `;
-      await transaction`
-        UPDATE remote_memory.memory_heads SET
-          current_revision_id = ${proposedRevision}, status = 'active', updated_at = ${now.toISOString()}
-        WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId} AND id = ${headId}
-      `;
-      await transaction`
-        INSERT INTO remote_memory.outbox_events(
-          tenant_id, share_id, id, generation, event_type, aggregate_id
-        ) VALUES (
-          ${principal.tenantId}, ${principal.shareId}, ${randomUuidV4()},
-          ${numeric(committed.share_generation)}, 'memory_head_changed', ${headId}
-        )
-      `;
-      await transaction`
-        INSERT INTO remote_memory.audit_events(
-          tenant_id, share_id, id, request_id, principal_id, operation, result,
-          policy_version, share_policy_version, generation
-        ) VALUES (
-          ${principal.tenantId}, ${principal.shareId}, ${randomUuidV4()}, ${requestId},
-          ${principal.principalId}, 'ingest_git_share', 'committed',
-          ${principal.policyVersion}, ${committed.policy_version}, ${numeric(committed.share_generation)}
-        )
-      `;
-      return true;
+    if (!this.gitStore) throw remoteMemoryError('invalid_request', 'Git share ingest requires a git canonical store.');
+    return ingestGitShare({
+      gitStore: this.gitStore,
+      principal,
+      requestId,
+      now,
+      withTenant: use => this.withTenant(principal.tenantId, use),
     });
   }
 
@@ -1623,54 +1407,6 @@ async function resolveCanonicalUri(
   return canonicalUri;
 }
 
-async function requireShareState(
-  transaction: TransactionSql,
-  principal: AuthorizedRemotePrincipal,
-): Promise<GrantStateRow> {
-  const rows = await transaction<GrantStateRow[]>`
-    SELECT s.share_generation, s.indexed_generation, s.policy_version, s.policy_digest,
-      s.feature_flags, g.capabilities, g.allowed_projects, g.policy_version AS grant_policy_version,
-      g.policy_digest AS grant_policy_digest
-    FROM remote_memory.shares s
-    JOIN remote_memory.tenants t ON t.id = s.tenant_id AND t.status = 'active'
-    JOIN remote_memory.tenant_memberships m
-      ON m.tenant_id = s.tenant_id AND m.principal_id = ${principal.principalId} AND m.status = 'active'
-    JOIN remote_memory.share_grants g
-      ON g.tenant_id = s.tenant_id AND g.share_id = s.id
-      AND g.principal_id = m.principal_id AND g.status = 'active'
-    JOIN remote_memory.principals p
-      ON p.tenant_id = m.tenant_id AND p.id = m.principal_id AND p.status = 'active'
-    WHERE s.tenant_id = ${principal.tenantId} AND s.id = ${principal.shareId} AND s.status = 'active'
-  `;
-  const state = rows[0];
-  if (!state) throw remoteMemoryError('forbidden', 'The memory share grant is not active.');
-  const allowedProjects = state.allowed_projects === null ? 'all' : new Set(state.allowed_projects);
-  if (!sameSetOrAll(principal.allowedProjects, allowedProjects)) {
-    throw remoteMemoryError('forbidden', 'The memory share grant changed; authenticate again.');
-  }
-  if (
-    state.grant_policy_version !== principal.policyVersion ||
-    state.grant_policy_digest !== principal.policyDigest ||
-    state.policy_version !== principal.sharePolicyVersion ||
-    state.policy_digest !== principal.sharePolicyDigest ||
-    !setContains(state.capabilities, principal.capabilities) ||
-    !setContains(state.feature_flags, principal.featureFlags)
-  ) {
-    throw remoteMemoryError('forbidden', 'The memory share policy changed; authenticate again.');
-  }
-  return state;
-}
-
-function sameSetOrAll(left: ReadonlySet<string> | 'all', right: ReadonlySet<string> | 'all'): boolean {
-  if (left === 'all' || right === 'all') return left === right;
-  return left.size === right.size && [...left].every(value => right.has(value));
-}
-
-function setContains(current: readonly string[], authorized: ReadonlySet<string>): boolean {
-  const values = new Set(current);
-  return [...authorized].every(value => values.has(value));
-}
-
 function receipt(
   principal: AuthorizedRemotePrincipal,
   state: ShareStateRow,
@@ -1843,42 +1579,6 @@ function mutationActor(
         ...(attestation.turnId ? {turnId: attestation.turnId} : {}),
       }
     : {principalId: principal.principalId};
-}
-
-function principalAllowsProject(principal: AuthorizedRemotePrincipal, project: string): boolean {
-  return principal.allowedProjects === 'all' || principal.allowedProjects.has(project);
-}
-
-function requirePrincipalProject(principal: AuthorizedRemotePrincipal, project: string): void {
-  if (principal.allowedProjects !== 'all' && !principal.allowedProjects.has(project)) {
-    throw remoteMemoryError('forbidden', 'The project is outside the authorized share grant.');
-  }
-}
-
-async function requireActiveProject(
-  transaction: TransactionSql,
-  principal: AuthorizedRemotePrincipal,
-  project: string,
-): Promise<void> {
-  const rows = await transaction<{name: string}[]>`
-    SELECT name FROM remote_memory.projects
-    WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId}
-      AND name = ${project} AND status = 'active'
-  `;
-  if (!rows[0]) throw remoteMemoryError('forbidden', 'The project is not active in the authorized memory share.');
-}
-
-function principalAllows(
-  principal: AuthorizedRemotePrincipal,
-  scope: RemoteMemoryScope,
-  feature: RemoteMemoryFeatureFlag,
-): boolean {
-  return (
-    (principal.OAuth.scopes.has(scope) || principal.OAuth.scopes.has('memory:admin')) &&
-    (principal.capabilities.has(scope) || principal.capabilities.has('memory:admin')) &&
-    principal.featureFlags.has(feature) &&
-    principal.featureFlags.has('remote_memory_ga')
-  );
 }
 
 function requireFreshAttestationPolicy(

--- a/src/remote_memory/repository_policy.ts
+++ b/src/remote_memory/repository_policy.ts
@@ -1,0 +1,102 @@
+import type {TransactionSql} from 'postgres';
+import type {AuthorizedRemotePrincipal, RemoteMemoryFeatureFlag, RemoteMemoryScope} from './authorization.js';
+import {remoteMemoryError} from './errors.js';
+
+export interface ShareStateRow {
+  readonly indexed_generation: string | number;
+  readonly policy_digest: string;
+  readonly policy_version: string;
+  readonly share_generation: string | number;
+}
+
+export interface GrantStateRow extends ShareStateRow {
+  readonly allowed_projects: string[] | null;
+  readonly capabilities: string[];
+  readonly feature_flags: string[];
+  readonly grant_policy_version: string;
+  readonly grant_policy_digest: string;
+}
+
+export async function requireShareState(
+  transaction: TransactionSql,
+  principal: AuthorizedRemotePrincipal,
+): Promise<GrantStateRow> {
+  const rows = await transaction<GrantStateRow[]>`
+    SELECT s.share_generation, s.indexed_generation, s.policy_version, s.policy_digest,
+      s.feature_flags, g.capabilities, g.allowed_projects, g.policy_version AS grant_policy_version,
+      g.policy_digest AS grant_policy_digest
+    FROM remote_memory.shares s
+    JOIN remote_memory.tenants t ON t.id = s.tenant_id AND t.status = 'active'
+    JOIN remote_memory.tenant_memberships m
+      ON m.tenant_id = s.tenant_id AND m.principal_id = ${principal.principalId} AND m.status = 'active'
+    JOIN remote_memory.share_grants g
+      ON g.tenant_id = s.tenant_id AND g.share_id = s.id
+      AND g.principal_id = m.principal_id AND g.status = 'active'
+    JOIN remote_memory.principals p
+      ON p.tenant_id = m.tenant_id AND p.id = m.principal_id AND p.status = 'active'
+    WHERE s.tenant_id = ${principal.tenantId} AND s.id = ${principal.shareId} AND s.status = 'active'
+  `;
+  const state = rows[0];
+  if (!state) throw remoteMemoryError('forbidden', 'The memory share grant is not active.');
+  const allowedProjects = state.allowed_projects === null ? 'all' : new Set(state.allowed_projects);
+  if (!sameSetOrAll(principal.allowedProjects, allowedProjects)) {
+    throw remoteMemoryError('forbidden', 'The memory share grant changed; authenticate again.');
+  }
+  if (
+    state.grant_policy_version !== principal.policyVersion ||
+    state.grant_policy_digest !== principal.policyDigest ||
+    state.policy_version !== principal.sharePolicyVersion ||
+    state.policy_digest !== principal.sharePolicyDigest ||
+    !setContains(state.capabilities, principal.capabilities) ||
+    !setContains(state.feature_flags, principal.featureFlags)
+  ) {
+    throw remoteMemoryError('forbidden', 'The memory share policy changed; authenticate again.');
+  }
+  return state;
+}
+
+function sameSetOrAll(left: ReadonlySet<string> | 'all', right: ReadonlySet<string> | 'all'): boolean {
+  if (left === 'all' || right === 'all') return left === right;
+  return left.size === right.size && [...left].every(value => right.has(value));
+}
+
+function setContains(current: readonly string[], authorized: ReadonlySet<string>): boolean {
+  const values = new Set(current);
+  return [...authorized].every(value => values.has(value));
+}
+
+export function principalAllowsProject(principal: AuthorizedRemotePrincipal, project: string): boolean {
+  return principal.allowedProjects === 'all' || principal.allowedProjects.has(project);
+}
+
+export function requirePrincipalProject(principal: AuthorizedRemotePrincipal, project: string): void {
+  if (principal.allowedProjects !== 'all' && !principal.allowedProjects.has(project)) {
+    throw remoteMemoryError('forbidden', 'The project is outside the authorized share grant.');
+  }
+}
+
+export async function requireActiveProject(
+  transaction: TransactionSql,
+  principal: AuthorizedRemotePrincipal,
+  project: string,
+): Promise<void> {
+  const rows = await transaction<{name: string}[]>`
+    SELECT name FROM remote_memory.projects
+    WHERE tenant_id = ${principal.tenantId} AND share_id = ${principal.shareId}
+      AND name = ${project} AND status = 'active'
+  `;
+  if (!rows[0]) throw remoteMemoryError('forbidden', 'The project is not active in the authorized memory share.');
+}
+
+export function principalAllows(
+  principal: AuthorizedRemotePrincipal,
+  scope: RemoteMemoryScope,
+  feature: RemoteMemoryFeatureFlag,
+): boolean {
+  return (
+    (principal.OAuth.scopes.has(scope) || principal.OAuth.scopes.has('memory:admin')) &&
+    (principal.capabilities.has(scope) || principal.capabilities.has('memory:admin')) &&
+    principal.featureFlags.has(feature) &&
+    principal.featureFlags.has('remote_memory_ga')
+  );
+}

--- a/src/remote_memory/runtime_privileges.ts
+++ b/src/remote_memory/runtime_privileges.ts
@@ -67,7 +67,13 @@ const RUNTIME_GRANTS: readonly RuntimeGrant[] = [
   {
     privilege: 'UPDATE',
     tables: ['shares'],
-    columns: ['share_generation', 'indexed_generation'],
+    columns: [
+      'share_generation',
+      'indexed_generation',
+      'git_ingest_snapshot_commit',
+      'git_ingest_cursor',
+      'git_ingest_rejected_path',
+    ],
   },
   {
     privilege: 'UPDATE',

--- a/test/helpers/remote-memory-postgres.ts
+++ b/test/helpers/remote-memory-postgres.ts
@@ -162,7 +162,16 @@ async function grantRuntimePrivileges(migratorSql: Sql, databaseName: string, ru
     );
   }
   const updateGrants = [
-    {columns: ['share_generation', 'indexed_generation'], table: 'shares'},
+    {
+      columns: [
+        'share_generation',
+        'indexed_generation',
+        'git_ingest_snapshot_commit',
+        'git_ingest_cursor',
+        'git_ingest_rejected_path',
+      ],
+      table: 'shares',
+    },
     {
       columns: ['current_revision_id', 'status', 'retention_class', 'expires_at', 'updated_at'],
       table: 'memory_heads',

--- a/test/integration/remote-memory-git-composer.test.ts
+++ b/test/integration/remote-memory-git-composer.test.ts
@@ -253,7 +253,7 @@ postgresDescribe('git-backed remote memory composer', () => {
     ).rejects.toMatchObject({code: 'forbidden'});
   });
 
-  it('does not resurrect a terminal handoff during git ingest', async () => {
+  it('keeps an archived handoff inactive until a later explicit Git publication', async () => {
     const created = await repository.remember(
       principal,
       {
@@ -277,6 +277,10 @@ postgresDescribe('git-backed remote memory composer', () => {
       'request-git-expired-archive',
     );
     expect(archived.revision).toBeTruthy();
+    expect(await indexer.runPass({batchSize: 8})).toMatchObject({failed: 0});
+    expect(
+      (await repository.read(principal, {uri: created.uri!, version: 1}, 'archived-before-republish')).status,
+    ).toBe('archived');
     const path = gitCanonicalSharePath('handoff', PROJECT, 'git-expired');
     const laptop = join(gitFixture.root, 'laptop-expired');
     await cloneGitShareWorktree(gitFixture.remote, laptop);
@@ -295,7 +299,7 @@ postgresDescribe('git-backed remote memory composer', () => {
           topic: 'git-expired',
           visibility: 'shared',
         },
-        'Should not resurrect expired handoff.',
+        'Explicit later publication reactivates the handoff.',
       ),
       'utf8',
     );
@@ -304,8 +308,8 @@ postgresDescribe('git-backed remote memory composer', () => {
     await git(['push', 'origin', 'main'], laptop);
     expect(await indexer.runPass({batchSize: 8})).toMatchObject({failed: 0});
     const read = await repository.read(principal, {uri: created.uri!, version: 1}, 'request-git-expired-read');
-    expect(read.status).toBe('archived');
-    expect(read.content).toContain('Active handoff body.');
+    expect(read.status).toBe('active');
+    expect(read.content).toContain('Explicit later publication reactivates the handoff.');
   });
 });
 

--- a/test/integration/remote-memory-git-lifecycle.test.ts
+++ b/test/integration/remote-memory-git-lifecycle.test.ts
@@ -1,0 +1,636 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {sha256HexSync} from '../../src/crypto/sha256.js';
+import type {TransactionSql} from 'postgres';
+import {ingestGitShare} from '../../src/remote_memory/git_ingest.js';
+import {mkdir, rm, writeFile} from '../helpers/node-fs-promises.js';
+import {dirname, join} from '../helpers/node-path.js';
+import {testGitWorktreeLock} from '../helpers/git-worktree-lock.js';
+import {
+  cloneGitShareWorktree,
+  createGitShareWorktreeFixture,
+  git,
+  type GitShareWorktreeFixture,
+} from '../helpers/git-share-worktree.js';
+import {
+  createRemoteMemoryPostgresFixture,
+  type RemoteMemoryPostgresFixture,
+} from '../helpers/remote-memory-postgres.js';
+import {formatMemoryDocument} from '../../src/memory/document.js';
+import {formatRemoteMemoryUri} from '../../src/memory_domain/address.js';
+import {provisionGitTeamShare} from '../../src/remote_memory/composer_serve.js';
+import {GitCanonicalMemoryStore, gitCanonicalSharePath} from '../../src/remote_memory/git_canonical_store.js';
+import {PostgresRemoteControlPlane} from '../../src/remote_memory/postgres_control_plane.js';
+import {PostgresRemoteMemoryRepository} from '../../src/remote_memory/postgres_repository.js';
+import {RemoteMemoryIndexer} from '../../src/remote_memory/indexer.js';
+import type {AuthorizedRemotePrincipal} from '../../src/remote_memory/authorization.js';
+
+const databaseUrl = process.env.THREADNOTE_TEST_POSTGRES_URL;
+const postgresDescribe = databaseUrl ? describe.sequential : describe.skip;
+const tenantId = 'lifecycle-tenant';
+const shareId = 'lifecycle-share';
+const project = 'threadnote';
+const topic = 'lifecycle';
+const path = gitCanonicalSharePath('durable', project, topic);
+const uri = formatRemoteMemoryUri({kind: 'durable', project, shareId, topic});
+
+postgresDescribe('external Git lifecycle convergence', () => {
+  let fixture: RemoteMemoryPostgresFixture;
+  let gitFixture: GitShareWorktreeFixture;
+  let laptop: string;
+  let store: GitCanonicalMemoryStore;
+  let repository: PostgresRemoteMemoryRepository;
+  let principal: AuthorizedRemotePrincipal;
+
+  beforeEach(async () => {
+    fixture = await createRemoteMemoryPostgresFixture(databaseUrl!);
+    gitFixture = await createGitShareWorktreeFixture('threadnote-git-lifecycle-');
+    laptop = await cloneGitShareWorktree(gitFixture.remote, join(gitFixture.root, 'laptop'));
+    const issuer = 'https://lifecycle.test/';
+    await provisionGitTeamShare(new PostgresRemoteControlPlane(fixture.migratorSql), {
+      issuer,
+      subject: 'lifecycle-user',
+      shareId,
+      tenantId,
+    });
+    const authorized = await new PostgresRemoteControlPlane(fixture.sql).authorize(
+      {
+        issuer,
+        subject: 'lifecycle-user',
+        scopes: new Set(['memory:read', 'memory:write:durable', 'memory:write:handoff']),
+      },
+      shareId,
+    );
+    if (!authorized) throw new Error('Lifecycle fixture authorization failed.');
+    principal = authorized;
+    store = new GitCanonicalMemoryStore({
+      binding: {tenantId, shareId},
+      worktree: gitFixture.worktree,
+      worktreeLock: testGitWorktreeLock,
+    });
+    repository = new PostgresRemoteMemoryRepository(fixture.sql, {gitStore: store});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fixture?.dispose();
+    if (gitFixture) await rm(gitFixture.root, {recursive: true, force: true});
+  });
+
+  async function publish(content: string | null, relativePath = path): Promise<string> {
+    const target = join(laptop, relativePath);
+    if (content === null) await rm(target);
+    else {
+      await mkdir(dirname(target), {recursive: true});
+      await writeFile(target, content, 'utf8');
+    }
+    await git(['add', '--', relativePath], laptop);
+    await git(['commit', '-m', 'lifecycle fixture publication'], laptop);
+    await git(['push', 'origin', 'main'], laptop);
+    return (await git(['rev-parse', 'HEAD'], laptop)).trim();
+  }
+
+  const ingest = () => repository.ingestGitShare(principal, 'lifecycle-ingest');
+  const read = () => repository.read(principal, {uri, version: 1}, 'lifecycle-read');
+
+  it('cannot erase a rejection committed by another scan of the same snapshot', async () => {
+    await publish(document('active'));
+    await ingest();
+    await publish(document('active').replace('status: active', 'status: invalid'));
+    const beforeHeads = Promise.withResolvers<void>();
+    const resume = Promise.withResolvers<void>();
+    let transactions = 0;
+    const delayed = ingestGitShare({
+      gitStore: store,
+      principal,
+      requestId: 'stale-rejection-state',
+      now: new Date(),
+      withTenant: async <A>(use: (transaction: TransactionSql) => Promise<A>) => {
+        transactions += 1;
+        if (transactions === 3) {
+          beforeHeads.resolve();
+          await resume.promise;
+        }
+        return fixture.sql.begin<Promise<A>>(async transaction => {
+          await transaction`SELECT set_config('threadnote.tenant_id', ${tenantId}, true)`;
+          return use(transaction);
+        });
+      },
+    }).then(
+      () => 'accepted',
+      error => error.details?.reason,
+    );
+    try {
+      await beforeHeads.promise;
+      await expect(ingest()).rejects.toMatchObject({details: {reason: 'git_ingest_metadata'}});
+    } finally {
+      resume.resolve();
+    }
+    expect(await delayed).toBe('git_ingest_snapshot_superseded');
+    await expect(ingest()).rejects.toMatchObject({details: {reason: 'git_ingest_metadata'}});
+  });
+
+  it('bounds initialized no-op work and commits cursor progress once per batch', async () => {
+    for (let index = 0; index < 257; index += 1) {
+      const target = join(laptop, gitCanonicalSharePath('durable', project, `ready-${index}`));
+      await mkdir(dirname(target), {recursive: true});
+      await writeFile(target, `Initialized safe body ${index}.`, 'utf8');
+    }
+    await git(['add', 'durable'], laptop);
+    await git(['commit', '-m', 'initialized bounded snapshot'], laptop);
+    await git(['push', 'origin', 'main'], laptop);
+    await ingest();
+    await ingest();
+    const reads = vi.spyOn(store, 'read');
+    let transactions = 0;
+    const result = await ingestGitShare({
+      gitStore: store,
+      principal,
+      requestId: 'bounded-noop',
+      now: new Date(),
+      withTenant: async <A>(use: (transaction: TransactionSql) => Promise<A>) => {
+        transactions += 1;
+        return fixture.sql.begin<Promise<A>>(async transaction => {
+          await transaction`SELECT set_config('threadnote.tenant_id', ${tenantId}, true)`;
+          return use(transaction);
+        });
+      },
+    });
+    expect(result).toEqual({ingested: 0, skipped: 256});
+    expect(reads).not.toHaveBeenCalled();
+    expect(transactions).toBeLessThanOrEqual(5);
+  });
+
+  it("cannot replace another concurrent scan's rejected path or partially archive its own candidate", async () => {
+    const alphaPath = gitCanonicalSharePath('durable', 'alpha', topic);
+    const betaPath = gitCanonicalSharePath('durable', 'beta', topic);
+    const alpha = document('active').replace('project: threadnote', 'project: alpha');
+    const beta = document('active').replace('project: threadnote', 'project: beta');
+    await publish(alpha, alphaPath);
+    await publish(beta, betaPath);
+    await ingest();
+    const controlPlane = new PostgresRemoteControlPlane(fixture.migratorSql);
+    const limited: AuthorizedRemotePrincipal[] = [];
+    for (const name of ['alpha', 'beta']) {
+      await controlPlane.provision({
+        tenantId,
+        shareId,
+        principalId: `limited-${name}`,
+        issuer: principal.OAuth.issuer,
+        subject: name,
+        displayName: `Git team share ${shareId}`,
+        region: 'local',
+        policyVersion: 'local-v1',
+        allowedProjects: [name],
+        cursorAttestationRequired: false,
+        capabilities: ['memory:read', 'memory:write:durable', 'memory:write:handoff'],
+        featureFlags: [
+          'remote_memory_read',
+          'remote_memory_durable_write',
+          'remote_memory_handoff_write',
+          'remote_memory_ga',
+        ],
+      });
+      const authorized = await new PostgresRemoteControlPlane(fixture.sql).authorize(
+        {issuer: principal.OAuth.issuer, subject: name, scopes: principal.OAuth.scopes},
+        shareId,
+      );
+      if (!authorized) throw new Error('Scoped fixture authorization failed.');
+      limited.push(authorized);
+    }
+    await publish(alpha.replace('status: active', 'status: invalid'), alphaPath);
+    await publish(beta.replace('status: active', 'status: invalid'), betaPath);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const readBlob = store.read.bind(store);
+    vi.spyOn(store, 'read').mockImplementation(async pointer => {
+      if (pointer.path === alphaPath) {
+        entered.resolve();
+        await release.promise;
+      }
+      return readBlob(pointer);
+    });
+    const delayed = repository.ingestGitShare(limited[0], 'reject-alpha').then(
+      () => 'accepted',
+      error => error.details?.reason,
+    );
+    try {
+      await entered.promise;
+      await expect(repository.ingestGitShare(limited[1], 'reject-beta')).rejects.toMatchObject({
+        details: {reason: 'git_ingest_metadata'},
+      });
+    } finally {
+      release.resolve();
+    }
+    expect(await delayed).toBe('git_ingest_snapshot_superseded');
+    const alphaUri = formatRemoteMemoryUri({kind: 'durable', project: 'alpha', shareId, topic});
+    expect((await repository.read(limited[0], {uri: alphaUri, version: 1}, 'alpha-read')).status).toBe('active');
+    await fixture.sql.begin(async transaction => {
+      await transaction`SELECT set_config('threadnote.tenant_id', ${tenantId}, true)`;
+      const [progress] = await transaction<{git_ingest_rejected_path: string}[]>`
+        SELECT git_ingest_rejected_path FROM remote_memory.shares WHERE tenant_id = ${tenantId} AND id = ${shareId}
+      `;
+      expect(progress.git_ingest_rejected_path).toBe(betaPath);
+    });
+  });
+
+  it('does not manufacture a rejection revision for an unrelated descendant commit', async () => {
+    await publish(document('active'));
+    await ingest();
+    await publish(document('active').replace('status: active', 'status: invalid'));
+    await expect(ingest()).rejects.toMatchObject({code: 'service_unavailable'});
+    const rejected = await read();
+    await publish('Unrelated documentation.', 'README.md');
+    await expect(ingest()).rejects.toMatchObject({code: 'service_unavailable'});
+    expect((await read()).receipt.revision).toBe(rejected.receipt.revision);
+  });
+
+  it('rejects an unsupported Git mode even when its blob is identical to the previously accepted file', async () => {
+    const safe = document('active');
+    await publish(safe);
+    await ingest();
+    const blob = (await git(['rev-parse', `HEAD:${path}`], laptop)).trim();
+    await git(['update-index', '--cacheinfo', '120000', blob, path], laptop);
+    await git(['commit', '-m', 'replace file with unsupported mode'], laptop);
+    await git(['push', 'origin', 'main'], laptop);
+    await expect(ingest()).rejects.toMatchObject({details: {reason: 'git_ingest_unsupported_entry'}});
+    expect(await read()).toMatchObject({status: 'archived', content: safe});
+  });
+
+  it('does not activate a newly rejected path and clears its failure after removal', async () => {
+    await publish(document('active').replace('status: active', 'status: invalid'));
+    await expect(ingest()).rejects.toMatchObject({code: 'service_unavailable'});
+    expect((await repository.list(principal, {limit: 10}, 'rejected-new-list')).entries).toHaveLength(0);
+    await publish(null);
+    await expect(ingest()).resolves.toMatchObject({ingested: 0});
+    await publish(document('active'));
+    expect((await ingest()).ingested).toBe(1);
+  });
+
+  it('does not renew an elapsed remote handoff expiry through Git republication', async () => {
+    await publish(document('active'));
+    await ingest();
+    const expiresAt = '2026-09-07T01:00:00.000Z';
+    const handoff = await repository.remember(
+      principal,
+      {
+        kind: 'handoff',
+        project,
+        topic: 'expiring',
+        text: 'Expiring handoff.',
+        lifecycle: {expiresAt, retentionClass: 'short'},
+        operationId: 'expiring-create',
+        version: 1,
+      },
+      'expiring-create',
+      undefined,
+      new Date('2026-09-07T00:00:00.000Z'),
+    );
+    await git(['pull', '--ff-only'], laptop);
+    const handoffPath = gitCanonicalSharePath('handoff', project, 'expiring');
+    await publish(
+      formatMemoryDocument(
+        'HANDOFF',
+        {
+          kind: 'handoff',
+          status: 'active',
+          project,
+          topic: 'expiring',
+          sourceAgentClient: 'test',
+          timestamp: '2026-09-07T02:00:00.000Z',
+        },
+        'Explicit publication after expiry.',
+      ),
+      handoffPath,
+    );
+    await repository.ingestGitShare(principal, 'expired-ingest', new Date('2026-09-07T02:00:00.000Z'));
+    expect((await repository.read(principal, {uri: handoff.uri!, version: 1}, 'expired-read')).status).toBe('expired');
+    await fixture.sql.begin(async transaction => {
+      await transaction`SELECT set_config('threadnote.tenant_id', ${tenantId}, true)`;
+      const [head] = await transaction<{expires_at: Date; retention_class: string}[]>`
+        SELECT expires_at, retention_class FROM remote_memory.memory_heads WHERE canonical_uri = ${handoff.uri!}
+      `;
+      expect(head.expires_at.toISOString()).toBe(expiresAt);
+      expect(head.retention_class).toBe('short');
+    });
+  });
+
+  it('checks the expected head revision when HTTP commits after ingestion planning', async () => {
+    await publish(document('active').replace('keywords: lifecycleproof\n', ''));
+    await ingest();
+    const original = await read();
+    const gitWritten = Promise.withResolvers<void>();
+    const finishHttp = Promise.withResolvers<void>();
+    const bodyRead = Promise.withResolvers<void>();
+    const finishIngest = Promise.withResolvers<void>();
+    const commit = store.commit.bind(store);
+    const readBlob = store.read.bind(store);
+    let writtenCommit: string | undefined;
+    vi.spyOn(store, 'commit').mockImplementation(async input => {
+      const result = await commit(input);
+      writtenCommit = result.gitCommit;
+      gitWritten.resolve();
+      await finishHttp.promise;
+      return result;
+    });
+    vi.spyOn(store, 'read').mockImplementation(async pointer => {
+      if (pointer.commit === writtenCommit) {
+        bodyRead.resolve();
+        await finishIngest.promise;
+      }
+      return readBlob(pointer);
+    });
+    const http = repository.remember(
+      principal,
+      {
+        kind: 'durable',
+        project,
+        topic,
+        text: 'HTTP winner body.',
+        baseRevision: original.receipt.revision,
+        operationId: 'http-head-race',
+        version: 1,
+      },
+      'http-race',
+    );
+    let delayed: Promise<string> | undefined;
+    try {
+      await gitWritten.promise;
+      delayed = ingest().then(
+        () => 'accepted',
+        error => error.details?.reason,
+      );
+      await bodyRead.promise;
+      finishHttp.resolve();
+      const winner = await http;
+      finishIngest.resolve();
+      expect(await delayed).toBe('git_ingest_snapshot_superseded');
+      expect((await read()).receipt.revision).toBe(winner.revision);
+    } finally {
+      finishHttp.resolve();
+      finishIngest.resolve();
+      await http;
+      await delayed;
+    }
+  });
+
+  it('validates legacy same-commit heads past the hydration bound without manufacturing no-op revisions', async () => {
+    const records: {name: string; gitPath: string; content: string; index: number}[] = [];
+    for (let index = 0; index < 257; index += 1) {
+      const name = `legacy-${String(index).padStart(3, '0')}`;
+      const gitPath = gitCanonicalSharePath('durable', project, name);
+      const content = document(index === 256 ? 'archived' : 'active').replace('topic: lifecycle', `topic: ${name}`);
+      const target = join(laptop, gitPath);
+      await mkdir(dirname(target), {recursive: true});
+      await writeFile(target, content, 'utf8');
+      records.push({name, gitPath, content, index});
+    }
+    await git(['add', 'durable'], laptop);
+    await git(['commit', '-m', 'legacy snapshot'], laptop);
+    await git(['push', 'origin', 'main'], laptop);
+    const commit = (await git(['rev-parse', 'HEAD'], laptop)).trim();
+    await fixture.migratorSql.begin(async transaction => {
+      await transaction`SELECT set_config('threadnote.tenant_id', ${tenantId}, true)`;
+      await transaction`INSERT INTO remote_memory.projects(tenant_id, share_id, name, status) VALUES (${tenantId}, ${shareId}, ${project}, 'active')`;
+      for (const record of records) {
+        const address = formatRemoteMemoryUri({kind: 'durable', project, shareId, topic: record.name});
+        await transaction`
+          INSERT INTO remote_memory.memory_heads(tenant_id, share_id, id, kind, project, topic, canonical_uri, status, current_revision_id)
+          VALUES (${tenantId}, ${shareId}, ${`head-${record.index}`}, 'durable', ${project}, ${record.name}, ${address}, 'active', ${`revision-${record.index}`})
+        `;
+        await transaction`
+          INSERT INTO remote_memory.memory_revisions(tenant_id, share_id, id, head_id, generation, status, markdown_body, content_hash, git_commit, git_path, oauth_principal_id, operation_id)
+          VALUES (${tenantId}, ${shareId}, ${`revision-${record.index}`}, ${`head-${record.index}`}, ${record.index + 1}, 'active', '', ${sha256HexSync(record.content)}, ${commit}, ${record.gitPath}, ${principal.principalId}, ${`legacy-${record.index}`})
+        `;
+      }
+      await transaction`UPDATE remote_memory.shares SET share_generation = 257 WHERE tenant_id = ${tenantId} AND id = ${shareId}`;
+    });
+    const readSpy = vi.spyOn(store, 'read');
+    expect((await ingest()).ingested).toBe(0);
+    expect(readSpy).toHaveBeenCalledTimes(256);
+    readSpy.mockClear();
+    expect((await ingest()).ingested).toBe(1);
+    expect(readSpy).toHaveBeenCalledTimes(256);
+    const last = formatRemoteMemoryUri({kind: 'durable', project, shareId, topic: 'legacy-256'});
+    expect((await repository.read(principal, {uri: last, version: 1}, 'legacy-last')).status).toBe('archived');
+    const first = formatRemoteMemoryUri({kind: 'durable', project, shareId, topic: 'legacy-000'});
+    expect((await repository.read(principal, {uri: first, version: 1}, 'legacy-first')).receipt.revision).toBe(
+      'revision-0',
+    );
+  });
+
+  it('keeps a known rejection unhealthy even when a newer snapshot inserts more than one batch before it', async () => {
+    await publish(document('active'));
+    await ingest();
+    await publish(document('active').replace('status: active', 'status: invalid'));
+    await expect(ingest()).rejects.toMatchObject({code: 'service_unavailable'});
+    for (let index = 0; index < 257; index += 1) {
+      const name = `ahead-${String(index).padStart(3, '0')}`;
+      await writeFile(
+        join(laptop, gitCanonicalSharePath('durable', project, name)),
+        `Safe earlier file ${index}.`,
+        'utf8',
+      );
+    }
+    await git(['add', 'durable'], laptop);
+    await git(['commit', '-m', 'insert earlier batch'], laptop);
+    await git(['push', 'origin', 'main'], laptop);
+    const readSpy = vi.spyOn(store, 'read');
+    await expect(ingest()).rejects.toMatchObject({code: 'service_unavailable'});
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    expect((await read()).status).toBe('archived');
+  });
+
+  it('keeps current state and revision stable under permutations of older linear snapshots', async () => {
+    let run = 0;
+    await FC.assert(
+      FC.asyncProperty(
+        FC.array(FC.constantFrom('active', 'archived', 'removed', 'restored', 'unrelated'), {
+          minLength: 4,
+          maxLength: 4,
+        }),
+        FC.shuffledSubarray([0, 1, 2, 3], {minLength: 4, maxLength: 4}),
+        async (changes, order) => {
+          run += 1;
+          await publish(`${document('active')}\nInitial run ${run}`);
+          await ingest();
+          let present = true;
+          let expected: 'active' | 'archived' = 'active';
+          const snapshots = [];
+          for (const [index, change] of changes.entries()) {
+            if (change === 'removed') {
+              if (present) await publish(null);
+              present = false;
+              expected = 'archived';
+            } else if (change === 'unrelated') {
+              await publish(`Unrelated ${index} run ${run}`, 'README.md');
+            } else {
+              expected = change === 'archived' ? 'archived' : 'active';
+              await publish(`${document(expected)}\nPublication ${index}.`);
+              present = true;
+            }
+            snapshots.push(await store.snapshot());
+          }
+          await ingest();
+          const accepted = await read();
+          expect(accepted.status).toBe(expected);
+          for (const index of order) {
+            vi.spyOn(store, 'snapshot').mockResolvedValueOnce(snapshots[index]);
+            try {
+              await ingest();
+            } catch (error) {
+              expect(error).toMatchObject({details: {reason: 'git_ingest_snapshot_superseded'}});
+            }
+            expect((await read()).receipt.revision).toBe(accepted.receipt.revision);
+          }
+        },
+      ),
+      {numRuns: 4},
+    );
+  });
+
+  it('fences a delayed removal when a newer identical restoration is a no-op against the current head', async () => {
+    const initialCommit = await publish(document('active'));
+    await ingest();
+    const original = await read();
+    await publish(null);
+    const removedSnapshot = await store.snapshot();
+    await publish(document('active'));
+    await store.refresh();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const listBlobs = store.listBlobIds.bind(store);
+    let pause = true;
+    vi.spyOn(store, 'snapshot').mockResolvedValueOnce(removedSnapshot);
+    vi.spyOn(store, 'listBlobIds').mockImplementation(async commit => {
+      if (pause && commit === initialCommit) {
+        pause = false;
+        entered.resolve();
+        await release.promise;
+      }
+      return listBlobs(commit);
+    });
+    const delayed = ingest().then(
+      () => 'accepted',
+      error => error.details?.reason,
+    );
+    try {
+      await entered.promise;
+      expect((await ingest()).ingested).toBe(0);
+    } finally {
+      release.resolve();
+    }
+    expect(await delayed).toBe('git_ingest_snapshot_superseded');
+    expect(await read()).toMatchObject({status: 'active', receipt: {revision: original.receipt.revision}});
+  });
+
+  it('fences an older new-key publication after a newer empty canonical snapshot is admitted', async () => {
+    const oldCommit = await publish(document('active'));
+    const oldSnapshot = await store.snapshot();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const readBlob = store.read.bind(store);
+    vi.spyOn(store, 'snapshot').mockResolvedValueOnce(oldSnapshot);
+    vi.spyOn(store, 'read').mockImplementation(async pointer => {
+      if (pointer.commit === oldCommit) {
+        entered.resolve();
+        await release.promise;
+      }
+      return readBlob(pointer);
+    });
+    const delayed = ingest().then(
+      () => 'accepted',
+      error => error.details?.reason,
+    );
+    try {
+      await entered.promise;
+      await publish(null);
+      expect((await ingest()).ingested).toBe(0);
+    } finally {
+      release.resolve();
+    }
+    expect(await delayed).toBe('git_ingest_snapshot_superseded');
+    expect((await repository.list(principal, {limit: 10}, 'empty-newer-list')).entries).toHaveLength(0);
+  });
+
+  it.each(['archived', 'expired', 'superseded'] as const)(
+    'imports an external %s status and preserves raw bytes',
+    async status => {
+      await publish(document('active'));
+      await ingest();
+      const raw = `${document(status)}\n`;
+      await publish(raw);
+      await ingest();
+      expect(await read()).toMatchObject({status, content: raw});
+      expect((await repository.list(principal, {status: 'active', limit: 10}, 'list-active')).entries).toHaveLength(0);
+      expect((await repository.list(principal, {limit: 10}, 'list-all')).entries).toHaveLength(1);
+      expect(
+        (await repository.recall(principal, {project, query: 'lifecycleproof', version: 1}, 'recall-overlay')).results,
+      ).toHaveLength(0);
+      await new RemoteMemoryIndexer(fixture.sql, store).runPass({ingest: false});
+      expect(
+        (await repository.recall(principal, {project, query: 'lifecycleproof', version: 1}, 'recall-indexed')).results,
+      ).toHaveLength(0);
+    },
+  );
+
+  it('archives removal of the last canonical file, keeps history, and restores an identical publication', async () => {
+    const raw = document('active');
+    await publish(raw);
+    await ingest();
+    const original = await read();
+    await publish(null);
+    expect((await ingest()).ingested).toBe(1);
+    const removed = await read();
+    expect(removed).toMatchObject({status: 'archived', content: raw});
+    expect(removed.receipt.revision).not.toBe(original.receipt.revision);
+    expect((await ingest()).ingested).toBe(0);
+    const historical = await repository.read(
+      principal,
+      {uri, revision: original.receipt.revision, version: 1},
+      'history',
+    );
+    expect(historical).toMatchObject({status: 'active', content: raw});
+    await publish(raw);
+    expect((await ingest()).ingested).toBe(1);
+    expect(await read()).toMatchObject({status: 'active', content: raw});
+    expect((await ingest()).ingested).toBe(0);
+  });
+
+  it.each([
+    ['invalid status', 'status: broken'],
+    ['empty status', 'status:'],
+    ['duplicate status', 'status: active\nstatus: archived'],
+    ['future schema', 'status: active\nschema_version: 999'],
+    ['wrong kind', 'status: active\nkind: handoff'],
+    ['wrong project', 'status: active\nproject: elsewhere'],
+  ])('rejects %s visibly and suppresses the previous active head', async (_label, header) => {
+    const safe = document('active');
+    await publish(safe);
+    await ingest();
+    await publish(safe.replace('status: active', header));
+    await expect(ingest()).rejects.toMatchObject({code: 'service_unavailable'});
+    expect(await read()).toMatchObject({status: 'archived', content: safe});
+    await expect(ingest()).rejects.toMatchObject({code: 'service_unavailable'});
+    await publish(`${safe}\nRecovered publication.`);
+    await ingest();
+    expect((await read()).status).toBe('active');
+  });
+});
+
+function document(status: 'active' | 'archived' | 'expired' | 'superseded'): string {
+  return formatMemoryDocument(
+    'MEMORY',
+    {
+      kind: 'durable',
+      status,
+      project,
+      topic,
+      sourceAgentClient: 'test',
+      timestamp: '2026-09-07T00:00:00.000Z',
+      keywords: ['lifecycleproof'],
+      visibility: 'shared',
+    },
+    'External lifecycleproof body.',
+  );
+}

--- a/test/integration/remote-memory-postgres.test.ts
+++ b/test/integration/remote-memory-postgres.test.ts
@@ -148,7 +148,7 @@ postgresDescribe('remote memory PostgreSQL service', () => {
     const before = await fixture.migratorSql<{checksum: string; version: number}[]>`
       SELECT version, checksum FROM remote_memory.schema_migrations ORDER BY version
     `;
-    expect(before).toHaveLength(2);
+    expect(before).toHaveLength(3);
     expect(before[0]?.checksum).toMatch(/^[a-f0-9]{64}$/u);
 
     await migrateRemoteMemoryDatabase(fixture.migratorSql);

--- a/test/integration/remote-memory-runtime-privileges.test.ts
+++ b/test/integration/remote-memory-runtime-privileges.test.ts
@@ -38,7 +38,7 @@ postgresDescribe('remote runtime database privilege preflight', () => {
   it('accepts the deployed table/column allowlist and reports every applied migration', async () => {
     await expect(assertRemoteMemoryRuntimePrivileges(fixture.sql)).resolves.toBeUndefined();
     const receipt = await new PostgresRemoteMemoryOperatorAdapter(fixture.migratorSql).migrateSchema();
-    expect(receipt.readyVersions).toEqual([1, 2]);
+    expect(receipt.readyVersions).toEqual([1, 2, 3]);
   });
 
   it('rejects the schema owner and the bootstrap superuser', async () => {

--- a/test/unit/git-ingest-document.test.ts
+++ b/test/unit/git-ingest-document.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {formatMemoryDocument} from '../../src/memory/document.js';
+import {classifyGitIngestDocument} from '../../src/remote_memory/git_ingest_document.js';
+
+const path = {kind: 'durable' as const, project: 'threadnote', topic: 'contract'};
+const header = 'MEMORY\nkind: durable\nproject: threadnote\ntopic: contract';
+
+describe('Git ingestion metadata boundary', () => {
+  it.each(['# MEMORY\nPlain Markdown.', 'A normal memory.', ''])('keeps plain Markdown active: %s', content => {
+    expect(classifyGitIngestDocument(content, path)).toEqual({accepted: true, status: 'active'});
+  });
+
+  it.each([
+    'status:',
+    'status: invalid',
+    'status: active\nstatus: active',
+    'kind: durable',
+    'project: other',
+    'project:',
+    'repo: threadnote',
+    'topic: wrong',
+    'topic:',
+    'schema_version:',
+    'schema_version: 0',
+    'schema_version: 1.2',
+    'schema_version: 999',
+    'schema_version: 4\nschema_version: 4',
+  ])('rejects ambiguous or unsupported critical metadata: %s', field => {
+    expect(classifyGitIngestDocument(`${header}\n${field}\n\nSafe body.`, path)).toEqual({
+      accepted: false,
+      reason: 'metadata',
+    });
+  });
+
+  it('supports omitted legacy status and the project alias', () => {
+    expect(classifyGitIngestDocument(`${header.replace('project:', 'repo:')}\n\nSafe body.`, path)).toEqual({
+      accepted: true,
+      status: 'active',
+    });
+  });
+
+  it('preserves lifecycle classification across supported kinds, statuses, and portable identities', () => {
+    FC.assert(
+      FC.property(
+        FC.constantFrom('durable' as const, 'handoff' as const),
+        FC.constantFrom('active' as const, 'archived' as const, 'expired' as const, 'superseded' as const),
+        FC.stringMatching(/^[a-z][a-z0-9]{0,12}$/),
+        FC.stringMatching(/^[a-z][a-z0-9]{0,12}$/),
+        (kind, status, project, topic) => {
+          const content = formatMemoryDocument(
+            kind === 'durable' ? 'MEMORY' : 'HANDOFF',
+            {
+              kind,
+              status,
+              project,
+              topic,
+              schemaVersion: 4,
+              sourceAgentClient: 'test',
+              timestamp: '2026-09-07T00:00:00.000Z',
+              keywords: ['preserved metadata'],
+              references: ['https://example.com/contract'],
+            },
+            'Safe content.',
+          );
+          expect(classifyGitIngestDocument(content, {kind, project, topic})).toEqual({accepted: true, status});
+        },
+      ),
+      {numRuns: 64},
+    );
+  });
+});

--- a/test/unit/remote-memory-migrations.test.ts
+++ b/test/unit/remote-memory-migrations.test.ts
@@ -80,6 +80,7 @@ describe('remote memory PostgreSQL migrations', () => {
       'bootstrap',
       ...appliedMigrationCycle,
       ...appliedMigrationCycle,
+      ...appliedMigrationCycle,
       'unlock',
       'release',
     ]);
@@ -126,7 +127,11 @@ describe('remote memory PostgreSQL migrations', () => {
 
   it('resolves standalone migrations beside the compiled executable instead of bunfs', () => {
     const executableRoot = FC.array(FC.stringMatching(/^[a-z][a-z0-9-]{0,12}$/u), {minLength: 1, maxLength: 4});
-    const migrationName = FC.constantFrom('001_initial.sql', '002_git_canonical_pointers.sql');
+    const migrationName = FC.constantFrom(
+      '001_initial.sql',
+      '002_git_canonical_pointers.sql',
+      '003_git_ingest_observations.sql',
+    );
     FC.assert(
       FC.property(executableRoot, migrationName, (segments, name) => {
         const executablePath = join('/', ...segments, 'threadnote');

--- a/test/unit/remote-memory-portability-deploy.test.ts
+++ b/test/unit/remote-memory-portability-deploy.test.ts
@@ -22,7 +22,9 @@ describe('remote memory reference deployment', () => {
     expect(grants).toContain('REVOKE ALL ON ALL TABLES IN SCHEMA remote_memory');
     expect(grants).toContain('remote_memory.grant_policy_versions');
     expect(grants).toContain('remote_memory.share_policy_versions');
-    expect(grants).toContain('GRANT UPDATE (share_generation, indexed_generation) ON remote_memory.shares');
+    expect(grants).toContain(
+      'GRANT UPDATE (share_generation, indexed_generation, git_ingest_snapshot_commit, git_ingest_cursor, git_ingest_rejected_path) ON remote_memory.shares',
+    );
     expect(grants).not.toMatch(/GRANT UPDATE ON remote_memory\.shares/u);
     expect(grants).toContain('remote_memory.worker_health');
     expect(grants).toContain('GRANT UPDATE (heartbeat_at, last_success_at, last_failure_at, failure_class');
@@ -63,5 +65,6 @@ describe('remote memory reference deployment', () => {
     expect(migrations).toContain('new URL(`./migrations/${name}`, import.meta.url)');
     expect(migrations).toContain("name: '001_initial.sql'");
     expect(migrations).toContain("name: '002_git_canonical_pointers.sql'");
+    expect(migrations).toContain("name: '003_git_ingest_observations.sql'");
   });
 });


### PR DESCRIPTION
External Git archives, removals, and malformed publications could remain active in org recall. Reconcile lifecycle from complete Git snapshots while keeping the exact historical body pointer and an independent immutable observation commit. A later deliberate restoration can reactivate the record; older or unchanged snapshots cannot resurrect it or extend expired handoff retention.

Migration 3 adds a monotonic share snapshot fence and resumable ingestion progress. Head/rejection compare-and-swap guards reject concurrent stale scans, including empty-tree and identical-restoration races. Every pass processes at most 256 candidates, and an unresolved rejected path remains first until it is corrected or removed. Strict managed metadata validation preserves raw rich document bytes; rejected publications suppress prior active heads without deleting history.

Validation: 142 focused tests passed across targeted runs, including real PostgreSQL/Git concurrency regressions and bounded classifier/history properties; lint and typecheck passed. Dev-cycle completed two iterations with zero remaining findings. Source and exact-commit global CLI service smokes verified archive, removal, immutable history, identical restoration, and upstream synchronization with the restricted runtime role. Exact commit cf5aa40fd370 was installed and doctor-verified globally. Full-suite validation is delegated to PR CI.
