### PR TITLE
Support registered org OAuth scopes and additive Codex attach

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "pxpipe-proxy": "0.13.2",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "smol-toml": "1.8.0",
         "three": "^0.185.1",
         "typescript-compiler": "npm:typescript@5.9.3",
         "unpdf": "1.8.1",
@@ -1155,6 +1156,8 @@
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
     "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
 

--- a/docs/org-productization.md
+++ b/docs/org-productization.md
@@ -9,7 +9,9 @@ Execution evidence as of 2026-09-07:
 - #378 binds Git to one tenant/share; #379 adds dedicated ingestion authority, persistent failure readiness, and
   rejection of body edits that cannot preserve rich metadata.
 - #380 preserves exact OAuth issuers and supports optional `nbf`; #381 supports registered external client IDs.
-  Auth0's dedicated tenant and native clients have passed a real PKCE exchange. Actual agent MCP canaries remain open.
+  Auth0's dedicated tenant and native clients have passed real PKCE. Codex 0.153.4 has completed authenticated
+  recall/read, canary creation, CAS replacement/stale rejection, laptop Git synchronization, and native refresh.
+  Cursor Agent 2026.09.02-c22c1a3 has authenticated and discovered seven tools; tool execution and refresh remain open.
 - #382 isolates development installation repair. #383 confirms upstream Git persistence before acknowledgement;
   #384 recovers crashed worktree-lock owners. Isolated global service smokes covered rejected pushes and crash/restart.
 - #385 rejects unsafe database credentials before listening and reports every applied migration. It passed 111
@@ -18,15 +20,22 @@ Execution evidence as of 2026-09-07:
   reconciliation, strict managed metadata validation, bounded legacy progress, and persistent rejection recovery.
   It passed 142 focused tests, lint/types, two dev-cycle iterations with zero remaining findings, source and exact
   global lifecycle smokes, and full PR CI.
-- The dedicated Fly bootstrap/image passed 100 focused tests, full dev-cycle review without findings, and container
+- #387's dedicated Fly bootstrap/image passed 101 focused tests, two dev-cycle iterations without remaining findings, and container
   checks for nonroot credentials, SSH trust, Neon TLS, fresh clone and restart persistence. Runtime dependency
-  packaging defects were repaired. Live deployment and actual client acceptance remain open; the runbook is
+  packaging defects were repaired. Full PR CI passed and the image is deployed on one Frankfurt Machine with one
+  persistent encrypted volume. Health/readiness, unauthorized MCP denial and restart persistence passed. The runbook is
   [Fly organization deployment](remote-memory/fly-org.md).
 
 Neon PostgreSQL 17 in Frankfurt supports the required separate SQL-created migration/runtime roles and strict TLS.
-The incompatible, empty Fly Managed Postgres trial was removed. The Fly app is reserved. Its dedicated image and bootstrap are implemented; the repository-scoped SSH credential
-has passed pinned-host clone verification. Live deployment and recovery acceptance remain P3–P5 work. Daily org writes
-remain disabled until those gates pass.
+The incompatible, empty Fly Managed Postgres trial was removed. Fly is enabled for bounded canaries; its repository-scoped
+SSH credential has passed pinned-host clone and acknowledged push verification. Daily org use remains gated on paid
+Neon capacity/restore history and P5 recovery acceptance. The user's Codex org entry remains disabled outside explicit
+canary sessions; personal stdio and the existing Git share are preserved.
+
+The next client slice adds explicit provider scopes for Cursor and org-only native Codex attach. Review narrowed
+Codex to append/no-op/conflict handling before stdio or receipt mutation, with an explicit initial-login command.
+Persisted scopes alone do not prove fresh automatic login or refresh. The client setup and evidence boundaries are
+documented in the [Fly runbook](remote-memory/fly-org.md#registered-client-setup).
 
 The outcome is a deployable organization product and a real single-member deployment at
 `https://threadnote-org.fly.dev/mcp`. Our laptops retain local stdio, personal memory, exact-worktree graphs,

--- a/docs/remote-memory/fly-org.md
+++ b/docs/remote-memory/fly-org.md
@@ -113,6 +113,68 @@ additive. An enabled endpoint or written configuration file alone does not prove
 To close HTTP access, stage `THREADNOTE_REMOTE_ENABLED=false` and restart the sole Machine. To stop all background
 Git/database activity as well, stop the Machine. Preserve the volume and authoritative Git repository.
 
+## Registered client setup
+
+Use a public native application registered with the organization IdP, authorization code with S256 PKCE, and the
+exact callback URI used by the client. Keep issuer checks enabled. Auth0 refresh tokens require both API offline
+access and a requested `offline_access` scope. Configure this explicitly; the installer retains the three required
+memory scopes and does not add provider consent scopes implicitly.
+
+For Cursor, target the intended project and supply that client's public registration:
+
+```sh
+threadnote mcp-install cursor --project /absolute/repository \
+  --composer-url https://threadnote-org.fly.dev/mcp --share-id default \
+  --composer-client-id CURSOR_PUBLIC_CLIENT_ID --composer-oauth-scope offline_access --apply
+cursor-agent mcp login threadnote-org
+cursor-agent mcp list-tools threadnote-org
+```
+
+Repeat `--composer-oauth-scope` for additional deliberate provider scopes. Tokens are case-sensitive, bounded to
+256 ASCII characters, and cannot contain whitespace, quotes or backslashes; the combined set is at most 32 scopes
+and 2048 bytes. Equivalent scope sets produce the same managed configuration. Explicit reattach updates Cursor's
+requested scopes; ordinary repair preserves existing provider scopes. Customized scopes do not expand the local
+demo's removal ownership. Copilot does not yet have a verified mapping for these additional scope options.
+
+For Codex, **0.153.4 is the minimum verified version for this Auth0 flow**. Version 0.144.5 drops the callback issuer
+parameter and fails issuer validation. Update through the client's supported installation channel; Threadnote does
+not replace Codex. Configure the exact registered direct-loopback URL and matching listener port, including any
+client-specific callback path. The example below requires that exact URI to be registered:
+
+```sh
+threadnote mcp-install codex \
+  --composer-url https://threadnote-org.fly.dev/mcp --share-id default \
+  --composer-client-id CODEX_PUBLIC_CLIENT_ID --composer-oauth-scope offline_access \
+  --composer-callback-url http://127.0.0.1:18789/callback --composer-callback-port 18789 --apply
+codex mcp login threadnote-org \
+  --scopes memory:read,memory:write:durable,memory:write:handoff,offline_access
+```
+
+Codex attach adds only `mcp_servers.threadnote-org` to `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`).
+It preserves personal stdio, instructions, integration receipts, global callback settings, unrelated configuration
+and comments. A compatible existing entry is left byte-for-byte unchanged, including `enabled=false`; explicitly
+enable it when ready for cutover. Conflicting bindings/scopes/callbacks and incompatible inline TOML require manual
+resolution. New entries require the callback pair; omitting it on a compatible existing entry preserves its callback.
+Symbolic links, nonregular or unreadable files are preserved and require manual configuration; regular-file permissions
+are retained. Codex's native login syntax cannot preserve commas inside individual scopes, so Codex attach rejects them.
+The installer rejects detected concurrent edits and never stores OAuth credentials. Protected-resource discovery
+supplies the audience/resource; do not add a redundant `oauth_resource` to this flow.
+
+Run the printed **explicit initial-login command** so requested provider scopes are part of consent. Fresh automatic
+login honoring persisted provider scopes has not been proven. Let the CLI open its authorization flow once, complete
+it, then exercise authenticated MCP requests through the actual client. Discovery alone is insufficient: verify a
+read, designated write, reconnect and refresh after the short access token expires. Inspect bounded provider exchange
+events without copying tokens or identity details into receipts.
+
+Observed client evidence on 2026-09-07: Codex 0.153.4 completed seven-tool discovery, recall/read, acknowledged write,
+CAS replacement/stale rejection, laptop Git sync and native refresh. Cursor GUI 3.19.13 / Agent 2026.09.02-c22c1a3
+completed PKCE and seven-tool discovery; execution and refresh after adding `offline_access` still require acceptance.
+These canaries do not complete P5 recovery or authorize a daily cutover by themselves.
+
+Client references: [Codex MCP configuration and callbacks](https://learn.chatgpt.com/docs/extend/mcp?surface=cli),
+[Auth0 refresh-token requirements](https://auth0.com/docs/secure/tokens/refresh-tokens/get-refresh-tokens),
+[OAuth scope-token grammar](https://www.rfc-editor.org/rfc/rfc6749#section-3.3).
+
 ## Recovery and release evidence
 
 Back up Git history and PostgreSQL control-plane state together. Recovery must preserve immutable revision pointers,

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "pxpipe-proxy": "0.13.2",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "smol-toml": "1.8.0",
     "three": "^0.185.1",
     "typescript-compiler": "npm:typescript@5.9.3",
     "unpdf": "1.8.1",

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -1,6 +1,7 @@
 import {Console, Effect, Schema} from 'effect';
 import {Argument, CliError, Command, Flag} from 'effect/unstable/cli';
 import {THREADNOTE_MCP_NAME} from '../constants.js';
+import {makeComposerAttachFlags} from './composer_attach_flags.js';
 import {runHooksInstall, runPreCompactHook, runSessionStartHook} from '../hooks.js';
 import {
   runDevelopmentInstallRepair,
@@ -1193,15 +1194,10 @@ const mcpInstall = Command.make(
       Argument.withDescription('codex, claude, cursor, or copilot'),
     ),
     apply: boolean('apply', 'Actually modify the selected agent config'),
-    composerClientId: optionalString(
-      'composer-client-id',
-      'Registered public OAuth client ID for the organization composer',
-    ),
-    composerUrl: optionalString('composer-url', 'Organization composer Streamable HTTP MCP URL'),
+    ...makeComposerAttachFlags(),
     name: defaultString('name', 'MCP server name', THREADNOTE_MCP_NAME),
     project: optionalString('project', 'Write Cursor/Copilot MCP into this repository .cursor/mcp.json'),
     scope: defaultChoice('scope', ['user', 'local', 'project'], 'Claude MCP config scope', 'user'),
-    shareId: optionalString('share-id', 'Organization composer share binding'),
     toolset: optionalChoice('toolset', ['core', 'full'], 'Stdio adapter toolset'),
   },
   ({agent, ...options}) => withRuntimeEffect(config => runMcpInstall(config, agent, options)),

--- a/src/effect/composer_attach_flags.ts
+++ b/src/effect/composer_attach_flags.ts
@@ -1,0 +1,22 @@
+import {describeFlag, integerFlag, optional, optionalString, repeatedString} from './cli_flags.js';
+
+export const makeComposerAttachFlags = () => ({
+  composerClientId: optionalString(
+    'composer-client-id',
+    'Registered public OAuth client ID for the organization composer',
+  ),
+  composerUrl: optionalString('composer-url', 'Organization composer Streamable HTTP MCP URL'),
+  composerOAuthScopes: repeatedString(
+    'composer-oauth-scope',
+    'Additional provider OAuth scope (Cursor/Codex); repeat for multiple',
+    32,
+  ),
+  composerCallbackUrl: optionalString('composer-callback-url', 'Registered Codex direct-loopback OAuth callback URL'),
+  composerCallbackPort: optional(
+    describeFlag(
+      integerFlag('composer-callback-port'),
+      'Codex OAuth callback listener port matching the registered URL',
+    ),
+  ),
+  shareId: optionalString('share-id', 'Organization composer share binding'),
+});

--- a/src/mcp/codex_org_attach.ts
+++ b/src/mcp/codex_org_attach.ts
@@ -1,6 +1,7 @@
 import {Console, Effect, FileSystem, Path} from 'effect';
 import {parse, stringify} from 'smol-toml';
 import {runCommandEffect} from '../effect/command.js';
+import {fromPromise} from '../effect/errors.js';
 import {runtimeLstat, SystemInfo, type RuntimeBigIntStats} from '../effect/system.js';
 import {expandPath, findWorkingExecutable, formatShellCommand, isJsonObject} from '../utils.js';
 import {
@@ -102,14 +103,9 @@ interface CodexConfiguration {
 
 const readCodexConfiguration = Effect.fn('mcp.readCodexConfiguration')(function* (configPath: string) {
   const fs = yield* FileSystem.FileSystem;
-  const info = yield* Effect.tryPromise({
-    try: () => runtimeLstat(configPath),
-    catch: cause => ({
-      missing: typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'ENOENT',
-    }),
-  }).pipe(
-    Effect.catch(failure =>
-      failure.missing
+  const info = yield* fromPromise('mcp.lstatCodexConfiguration', () => runtimeLstat(configPath)).pipe(
+    Effect.catch(({cause}) =>
+      typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'ENOENT'
         ? Effect.void
         : Effect.fail(
             ComposerAttachError.make({

--- a/src/mcp/codex_org_attach.ts
+++ b/src/mcp/codex_org_attach.ts
@@ -1,0 +1,245 @@
+import {Console, Effect, FileSystem, Path} from 'effect';
+import {parse, stringify} from 'smol-toml';
+import {runCommandEffect} from '../effect/command.js';
+import {runtimeLstat, SystemInfo, type RuntimeBigIntStats} from '../effect/system.js';
+import {expandPath, findWorkingExecutable, formatShellCommand, isJsonObject} from '../utils.js';
+import {
+  ComposerAttachError,
+  composerOAuthScopes,
+  composerOAuthScopesMatch,
+  THREADNOTE_ORG_MCP_NAME,
+  type ComposerShareBinding,
+} from './composer_attach.js';
+
+export const CODEX_ORG_MINIMUM_VERIFIED_VERSION = '0.153.4';
+
+export function supportsCodexOrgOAuth(versionOutput: string): boolean {
+  const match = /^codex(?:-cli)? (\d+)\.(\d+)\.(\d+)\s*$/u.exec(versionOutput.trim());
+  if (!match) return false;
+  const [major, minor, patch] = match.slice(1).map(Number);
+  return major > 0 || minor > 153 || (minor === 153 && patch >= 4);
+}
+
+function parseConfig(content: string): Record<string, unknown> {
+  try {
+    return parse(content, {integersAsBigInt: 'asNeeded'});
+  } catch {
+    throw ComposerAttachError.make({
+      message: 'Codex config cannot be safely extended as TOML; preserve it and configure threadnote-org manually.',
+    });
+  }
+}
+
+export function renderCodexOrgMcpConfig(content: string, attach: ComposerShareBinding): string {
+  if (!attach.clientId) {
+    throw ComposerAttachError.make({
+      message: 'Codex organization attach requires an explicitly registered --composer-client-id.',
+    });
+  }
+  const parsed = parseConfig(content);
+  if (parsed.mcp_servers !== undefined && !isJsonObject(parsed.mcp_servers)) {
+    throw ComposerAttachError.make({message: 'Codex mcp_servers is not a table; preserving the existing config.'});
+  }
+  const scopes = composerOAuthScopes(attach.additionalScopes);
+  if (scopes.some(scope => scope.includes(','))) {
+    throw ComposerAttachError.make({
+      message:
+        'Codex native login cannot preserve a comma inside one OAuth scope token; remove that scope or configure the client manually.',
+    });
+  }
+  const current = isJsonObject(parsed.mcp_servers) ? parsed.mcp_servers[THREADNOTE_ORG_MCP_NAME] : undefined;
+  if (current !== undefined) {
+    if (
+      !isJsonObject(current) ||
+      current.url !== attach.url ||
+      !isJsonObject(current.http_headers) ||
+      Object.keys(current.http_headers).length !== 1 ||
+      current.http_headers['threadnote-share-id'] !== attach.shareId ||
+      !isJsonObject(current.oauth) ||
+      current.oauth.client_id !== attach.clientId ||
+      Object.keys(current.oauth).some(key => !['client_id', 'callback_url', 'callback_port'].includes(key)) ||
+      !Array.isArray(current.scopes) ||
+      !current.scopes.every(scope => typeof scope === 'string') ||
+      !composerOAuthScopesMatch(current.scopes, scopes) ||
+      ['command', 'args', 'env', 'bearer_token', 'bearer_token_env_var', 'env_http_headers', 'oauth_resource'].some(
+        key => key in current,
+      ) ||
+      (attach.callback &&
+        (current.oauth.callback_url !== attach.callback.url || current.oauth.callback_port !== attach.callback.port))
+    ) {
+      throw ComposerAttachError.make({
+        message:
+          'Existing Codex threadnote-org configuration conflicts with the requested binding, scopes, or callback; preserving it. Resolve the entry manually and retry.',
+      });
+    }
+    return content;
+  }
+  if (!attach.callback) {
+    throw ComposerAttachError.make({
+      message:
+        'New Codex organization attach requires --composer-callback-url and --composer-callback-port matching the provider registration.',
+    });
+  }
+  const addition = stringify({
+    mcp_servers: {
+      [THREADNOTE_ORG_MCP_NAME]: {
+        url: attach.url,
+        http_headers: {'threadnote-share-id': attach.shareId},
+        scopes,
+        oauth: {client_id: attach.clientId, callback_url: attach.callback.url, callback_port: attach.callback.port},
+      },
+    },
+  });
+  const proposed = `${content}${content.endsWith('\n') || !content ? '' : '\n'}\n${addition}`;
+  parseConfig(proposed);
+  return proposed;
+}
+
+interface CodexConfiguration {
+  readonly content: string;
+  readonly info: RuntimeBigIntStats;
+}
+
+const readCodexConfiguration = Effect.fn('mcp.readCodexConfiguration')(function* (configPath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const info = yield* Effect.tryPromise({
+    try: () => runtimeLstat(configPath),
+    catch: cause => ({
+      missing: typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'ENOENT',
+    }),
+  }).pipe(
+    Effect.catch(failure =>
+      failure.missing
+        ? Effect.void
+        : Effect.fail(
+            ComposerAttachError.make({
+              message: 'Cannot inspect Codex config; preserving it. Resolve filesystem access before retrying.',
+            }),
+          ),
+    ),
+  );
+  if (!info) return undefined;
+  if (!info.isFile() || info.isSymbolicLink()) {
+    return yield* ComposerAttachError.make({
+      message:
+        'Codex config must be a regular file; symbolic links and other file types are preserved. Configure the organization entry manually in the intended target.',
+    });
+  }
+  if (info.size > 4n * 1024n * 1024n) {
+    return yield* ComposerAttachError.make({
+      message: 'Codex config exceeds the 4 MiB attach limit; configure the organization entry manually.',
+    });
+  }
+  const content = yield* fs.readFileString(configPath).pipe(
+    Effect.mapError(() =>
+      ComposerAttachError.make({
+        message: 'Cannot read Codex config; preserving it. Resolve filesystem access before retrying.',
+      }),
+    ),
+  );
+  return {content, info} satisfies CodexConfiguration;
+});
+
+function sameCodexConfiguration(
+  before: CodexConfiguration | undefined,
+  after: CodexConfiguration | undefined,
+): boolean {
+  if (!before || !after) return before === after;
+  return (
+    before.content === after.content &&
+    before.info.dev === after.info.dev &&
+    before.info.ino === after.info.ino &&
+    before.info.mode === after.info.mode &&
+    before.info.size === after.info.size &&
+    before.info.mtimeNs === after.info.mtimeNs &&
+    before.info.ctimeNs === after.info.ctimeNs
+  );
+}
+
+export const runCodexOrgMcpInstall = Effect.fn('mcp.runCodexOrgInstall')(function* (
+  attach: ComposerShareBinding,
+  apply: boolean,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const codexHome = system.environment().CODEX_HOME;
+  const configPath = path.join(
+    codexHome ? yield* expandPath(codexHome) : path.join(system.homeDirectory, '.codex'),
+    'config.toml',
+  );
+  const current = yield* readCodexConfiguration(configPath);
+  const proposed = yield* Effect.try({
+    try: () => renderCodexOrgMcpConfig(current?.content ?? '', attach),
+    catch: cause =>
+      ComposerAttachError.make({
+        message: cause instanceof Error ? cause.message : 'Unable to validate Codex organization config.',
+      }),
+  });
+  const login = formatShellCommand('codex', [
+    'mcp',
+    'login',
+    THREADNOTE_ORG_MCP_NAME,
+    '--scopes',
+    composerOAuthScopes(attach.additionalScopes).join(','),
+  ]);
+  if (!apply) {
+    yield* Console.log(
+      `Dry run. Re-run with --apply to add threadnote-org to ${configPath}. Requires Codex ${CODEX_ORG_MINIMUM_VERIFIED_VERSION} or later.\nInitial login: ${login}`,
+    );
+    yield* Console.log(
+      proposed === current?.content
+        ? 'Already configured; the existing entry will be preserved.'
+        : proposed.slice((current?.content ?? '').length),
+    );
+    return;
+  }
+  const executable = yield* findWorkingExecutable(['codex']);
+  const version = executable
+    ? yield* runCommandEffect(executable, ['--version'], {timeoutMs: 5000, maxOutputBytes: 4096})
+    : undefined;
+  if (!version || !supportsCodexOrgOAuth(version.stdout)) {
+    return yield* ComposerAttachError.make({
+      message: `Organization OAuth requires a working Codex CLI ${CODEX_ORG_MINIMUM_VERIFIED_VERSION} or later in PATH; update Codex and retry. No config was changed.`,
+    });
+  }
+  if (proposed !== current?.content) {
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        yield* fs.makeDirectory(path.dirname(configPath), {recursive: true});
+        const lockPath = path.join(path.dirname(configPath), '.threadnote-org-attach.lock');
+        yield* Effect.acquireRelease(
+          fs.makeDirectory(lockPath).pipe(
+            Effect.mapError(() =>
+              ComposerAttachError.make({
+                message:
+                  'Codex organization attach lock is unavailable. Finish any other attach; if it crashed, inspect and remove the stale .threadnote-org-attach.lock directory before retrying.',
+              }),
+            ),
+          ),
+          () => fs.remove(lockPath, {recursive: true}).pipe(Effect.orDie),
+        );
+        const temporaryDirectory = yield* fs.makeTempDirectoryScoped({
+          directory: path.dirname(configPath),
+          prefix: '.threadnote-org-',
+        });
+        const temporaryPath = path.join(temporaryDirectory, 'config.toml');
+        const mode = current ? Number(current.info.mode & 0o777n) : 0o600;
+        yield* fs.writeFileString(temporaryPath, proposed, {mode});
+        yield* fs.chmod(temporaryPath, mode);
+        if (!sameCodexConfiguration(current, yield* readCodexConfiguration(configPath))) {
+          return yield* ComposerAttachError.make({
+            message: 'Codex config changed during attach; preserving the concurrent edit. Retry the command.',
+          });
+        }
+        yield* fs.rename(temporaryPath, configPath);
+      }),
+    );
+    yield* Console.log(`Added Codex threadnote-org: ${configPath}`);
+  } else {
+    yield* Console.log(`Already configured: ${configPath}`);
+  }
+  yield* Console.log(
+    `Initial login: ${login}\nNative Codex manages OAuth credentials. Verify reconnect and refresh with your provider.`,
+  );
+});

--- a/src/mcp/composer_attach.ts
+++ b/src/mcp/composer_attach.ts
@@ -22,13 +22,15 @@ export class ComposerAttachError extends Schema.TaggedError<ComposerAttachError>
 
 export interface ComposerShareBinding {
   readonly clientId?: string;
+  readonly additionalScopes?: readonly string[];
+  readonly callback?: {readonly url: string; readonly port: number};
   readonly shareId: string;
   readonly url: string;
 }
 
 export interface ComposerMcpOAuthAuth {
   readonly CLIENT_ID: string;
-  readonly scopes: readonly (typeof COMPOSER_OAUTH_SCOPES)[number][];
+  readonly scopes: readonly string[];
 }
 
 export interface ComposerHttpMcpEntry {
@@ -51,6 +53,9 @@ export type ComposerClientHttpMcpEntry = ComposerHttpMcpEntry | CopilotComposerH
 
 export interface ComposerAttachOptions {
   readonly composerClientId?: string;
+  readonly composerOAuthScopes?: readonly string[];
+  readonly composerCallbackUrl?: string;
+  readonly composerCallbackPort?: number;
   readonly composerUrl?: string;
   readonly shareId?: string;
 }
@@ -58,7 +63,15 @@ export interface ComposerAttachOptions {
 export function resolveComposerAttach(options: ComposerAttachOptions): ComposerShareBinding | undefined {
   const composerUrl = options.composerUrl?.trim();
   const shareId = options.shareId?.trim();
-  if (!composerUrl && !shareId && options.composerClientId === undefined) return undefined;
+  if (
+    !composerUrl &&
+    !shareId &&
+    options.composerClientId === undefined &&
+    !options.composerOAuthScopes?.length &&
+    options.composerCallbackUrl === undefined &&
+    options.composerCallbackPort === undefined
+  )
+    return undefined;
   if (!composerUrl || !shareId) {
     throw ComposerAttachError.make({
       message: 'Organization composer attach requires both --composer-url and --share-id.',
@@ -66,6 +79,18 @@ export function resolveComposerAttach(options: ComposerAttachOptions): ComposerS
   }
   return {
     ...(options.composerClientId === undefined ? {} : {clientId: composerOAuthClientId(options.composerClientId)}),
+    ...(options.composerOAuthScopes?.length
+      ? {
+          additionalScopes: composerOAuthScopes(options.composerOAuthScopes).filter(
+            scope => !COMPOSER_OAUTH_SCOPES.some(required => required === scope),
+          ),
+        }
+      : {}),
+    ...(options.composerCallbackUrl === undefined && options.composerCallbackPort === undefined
+      ? {}
+      : {
+          callback: composerOAuthCallback(options.composerCallbackUrl, options.composerCallbackPort),
+        }),
     shareId: composerShareId(shareId),
     url: composerMcpUrl(composerUrl),
   };
@@ -124,11 +149,12 @@ export function buildComposerHttpMcpEntry(
   url: string,
   shareId: string,
   clientId: string = COMPOSER_OAUTH_CLIENT_ID,
+  additionalScopes: readonly string[] = [],
 ): ComposerHttpMcpEntry {
   return {
     auth: {
       CLIENT_ID: composerOAuthClientId(clientId),
-      scopes: [...COMPOSER_OAUTH_SCOPES],
+      scopes: composerOAuthScopes(additionalScopes),
     },
     headers: {[THREADNOTE_COMPOSER_SHARE_ID_HEADER]: composerShareId(shareId)},
     url: composerMcpUrl(url),
@@ -158,8 +184,15 @@ export function withComposerHttpMcpEntry(
   }
   const next: Record<string, JsonObject> = {...servers, [stdioName]: stdio};
   if (attach) {
-    const build = client === 'copilot' ? buildCopilotComposerHttpMcpEntry : buildComposerHttpMcpEntry;
-    next[THREADNOTE_ORG_MCP_NAME] = build(attach.url, attach.shareId, attach.clientId);
+    if (client === 'copilot' && (attach.additionalScopes?.length || attach.callback)) {
+      throw ComposerAttachError.make({
+        message: 'Additional OAuth scopes and callbacks are not supported for Copilot attach.',
+      });
+    }
+    next[THREADNOTE_ORG_MCP_NAME] =
+      client === 'copilot'
+        ? buildCopilotComposerHttpMcpEntry(attach.url, attach.shareId, attach.clientId)
+        : buildComposerHttpMcpEntry(attach.url, attach.shareId, attach.clientId, attach.additionalScopes);
   }
   return next;
 }
@@ -184,13 +217,18 @@ export function composerHttpEntryMatches(actual: unknown, expected: ComposerClie
     return false;
   return actual.type === 'http'
     ? expected.type === 'http' && actual.oauth.clientId === expected.oauth.clientId
-    : expected.type !== 'http' && actual.auth.CLIENT_ID === expected.auth.CLIENT_ID;
+    : expected.type !== 'http' &&
+        actual.auth.CLIENT_ID === expected.auth.CLIENT_ID &&
+        composerOAuthScopesMatch(actual.auth.scopes, expected.auth.scopes);
 }
 
 export function isManagedComposerHttpEntry(actual: unknown): boolean {
   return (
     isComposerHttpEntry(actual) &&
-    (actual.type === 'http' ? actual.oauth.clientId : actual.auth.CLIENT_ID) === COMPOSER_OAUTH_CLIENT_ID
+    (actual.type === 'http' ? actual.oauth.clientId : actual.auth.CLIENT_ID) === COMPOSER_OAUTH_CLIENT_ID &&
+    (actual.type === 'http' ||
+      (actual.auth.scopes.length === COMPOSER_OAUTH_SCOPES.length &&
+        actual.auth.scopes.every((scope, index) => scope === COMPOSER_OAUTH_SCOPES[index])))
   );
 }
 
@@ -209,8 +247,7 @@ export function isComposerHttpEntry(actual: unknown): actual is ComposerClientHt
     if (!isRecord(actual.auth) || typeof actual.auth.CLIENT_ID !== 'string' || !Array.isArray(actual.auth.scopes))
       return false;
     if (Object.keys(actual.auth).some(key => key !== 'CLIENT_ID' && key !== 'scopes')) return false;
-    if (actual.auth.scopes.length !== COMPOSER_OAUTH_SCOPES.length) return false;
-    if (actual.auth.scopes.some((scope, index) => scope !== COMPOSER_OAUTH_SCOPES[index])) return false;
+    if (!validComposerOAuthScopes(actual.auth.scopes)) return false;
     clientId = actual.auth.CLIENT_ID;
   }
   try {
@@ -234,4 +271,69 @@ function composerOAuthClientId(value: string): string {
     });
   }
   return value;
+}
+
+export function composerOAuthScopes(additionalScopes: readonly string[] = []): readonly string[] {
+  if (
+    additionalScopes.length > 32 ||
+    additionalScopes.some(scope => !/^[\x21\x23-\x5b\x5d-\x7e]{1,256}$/u.test(scope))
+  ) {
+    throw ComposerAttachError.make({
+      message:
+        'OAuth scopes require at most 32 non-empty RFC 6749 scope tokens of at most 256 ASCII characters each (no spaces, quotes, or backslashes).',
+    });
+  }
+  const extras = [...new Set(additionalScopes)]
+    .filter(scope => !COMPOSER_OAUTH_SCOPES.some(required => required === scope))
+    .sort();
+  const scopes = [...COMPOSER_OAUTH_SCOPES, ...extras];
+  if (scopes.length > 32 || scopes.join(' ').length > 2048) {
+    throw ComposerAttachError.make({
+      message: 'The complete OAuth scope set must contain at most 32 tokens and 2048 bytes.',
+    });
+  }
+  return scopes;
+}
+
+export function composerOAuthScopesMatch(actual: readonly string[], expected: readonly string[]): boolean {
+  return (
+    actual.length === expected.length &&
+    new Set(actual).size === actual.length &&
+    expected.every(scope => actual.includes(scope))
+  );
+}
+
+function validComposerOAuthScopes(scopes: readonly unknown[]): scopes is readonly string[] {
+  if (!scopes.every(scope => typeof scope === 'string')) return false;
+  try {
+    return composerOAuthScopesMatch(scopes, composerOAuthScopes(scopes));
+  } catch {
+    return false;
+  }
+}
+
+function composerOAuthCallback(url: string | undefined, port: number | undefined): {url: string; port: number} {
+  const message =
+    'Codex OAuth callback requires both a credential-free http://127.0.0.1 callback URL and a matching --composer-callback-port between 1024 and 65535, without query or fragment.';
+  if (!url || port === undefined || !Number.isInteger(port) || port < 1024 || port > 65535 || /\s/u.test(url)) {
+    throw ComposerAttachError.make({message});
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw ComposerAttachError.make({message});
+  }
+  if (
+    parsed.protocol !== 'http:' ||
+    parsed.hostname !== '127.0.0.1' ||
+    Number(parsed.port) !== port ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw ComposerAttachError.make({message});
+  }
+  return {url, port};
 }

--- a/src/mcp/install.ts
+++ b/src/mcp/install.ts
@@ -12,6 +12,7 @@ import {THREADNOTE_MCP_CLIENT_ENV, THREADNOTE_MCP_NAME} from '../constants.js';
 import {maybeRunEffect, runCommandEffect} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
 import {DEFAULT_MCP_TOOLSET, MCP_TOOLSET_ENV, type McpToolset} from './toolset.js';
+import {runCodexOrgMcpInstall} from './codex_org_attach.js';
 import {
   ComposerAttachError,
   THREADNOTE_ORG_MCP_NAME,
@@ -57,8 +58,32 @@ const isPersonalThreadnoteHomeEffect = Effect.fn('mcp.isPersonalHome')(function*
 });
 
 export function runMcpInstall(config: RuntimeConfig, agent: AgentClient, options: McpInstallOptions) {
-  const install = runMcpInstallInTransaction(config, agent, options);
-  return options.apply === true ? withAgentIntegrationLock(config, install) : install;
+  return Effect.gen(function* () {
+    const attach = yield* Effect.try({
+      try: () => resolveComposerAttach(options),
+      catch: cause =>
+        Schema.is(ComposerAttachError)(cause)
+          ? cause
+          : McpOperationError.make({message: 'Invalid organization attach options.'}),
+    });
+    if (attach && options.name === THREADNOTE_ORG_MCP_NAME) {
+      return yield* McpOperationError.make({
+        message:
+          'Organization composer attach cannot use --name threadnote-org; that name is reserved for the HTTP composer entry.',
+      });
+    }
+    if (attach?.callback && agent !== 'codex') {
+      return yield* McpOperationError.make({message: 'Organization callback options are supported only for Codex.'});
+    }
+    if (options.composerOAuthScopes?.length && agent !== 'cursor' && agent !== 'codex') {
+      return yield* McpOperationError.make({
+        message: 'Additional organization OAuth scopes are supported only for Cursor and Codex.',
+      });
+    }
+    if (attach && agent === 'codex') return yield* runCodexOrgMcpInstall(attach, options.apply === true);
+    const install = runMcpInstallInTransaction(config, agent, options);
+    return yield* options.apply === true ? withAgentIntegrationLock(config, install) : install;
+  });
 }
 
 const runMcpInstallInTransaction = Effect.fn('mcp.runInstallInTransaction')(function* (
@@ -561,7 +586,12 @@ const runCursorMcpInstall = Effect.fn('mcp.runCursorInstall')(function* (
     toolset: options.toolset,
   });
   const composerEntry = options.attach
-    ? buildComposerHttpMcpEntry(options.attach.url, options.attach.shareId, options.attach.clientId)
+    ? buildComposerHttpMcpEntry(
+        options.attach.url,
+        options.attach.shareId,
+        options.attach.clientId,
+        options.attach.additionalScopes,
+      )
     : undefined;
   const currentContent = yield* readFileIfExists(path);
   const current =

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,9 @@ export interface SeedOptions {
 export interface McpInstallOptions {
   readonly apply?: boolean;
   readonly composerClientId?: string;
+  readonly composerOAuthScopes?: readonly string[];
+  readonly composerCallbackUrl?: string;
+  readonly composerCallbackPort?: number;
   readonly composerUrl?: string;
   /** @internal Recorded Claude project/local installation directory used by repair. */
   readonly cwd?: string;

--- a/test/unit/codex-org-attach.test.ts
+++ b/test/unit/codex-org-attach.test.ts
@@ -1,0 +1,260 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path, PlatformError} from 'effect';
+import {describe, expect, it} from 'vitest';
+import {parse} from 'smol-toml';
+import {captureConsole} from '../../src/effect/console.js';
+import {CommandExecutor} from '../../src/effect/command.js';
+import {ApplicationLayer, StandaloneBrokerLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {renderCodexOrgMcpConfig, runCodexOrgMcpInstall, supportsCodexOrgOAuth} from '../../src/mcp/codex_org_attach.js';
+import {resolveComposerAttach, type ComposerShareBinding} from '../../src/mcp/composer_attach.js';
+import {runMcpInstall} from '../../src/mcp/install.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const attach: ComposerShareBinding = {
+  clientId: 'registered-codex',
+  url: 'https://composer.example.test/mcp',
+  shareId: 'engineering',
+  additionalScopes: ['offline_access'],
+  callback: {url: 'http://127.0.0.1:18789/callback/client-specific', port: 18789},
+};
+const original =
+  '# keep comments\nmodel = "configured-model"\nmcp_oauth_callback_port = 12345\n[mcp_servers."threadnote"]\ncommand = "personal-stdio"\nargs = ["mcp"]\n[mcp_servers.threadnote.env]\nTHREADNOTE_HOME = "/personal/home"\n[projects."/repo"]\ntrust_level = "trusted"\n';
+
+describe('Codex organization attach', () => {
+  effectIt.effect.each([
+    'apply',
+    'legacy',
+    'concurrent',
+    'unreadable-initial',
+    'unreadable-final',
+    'unreadable-always',
+  ] as const)('native install handles %s without touching personal stdio', mode =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const baseCommands = yield* CommandExecutor;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'codex-org-install-'});
+        const configPath = path.join(root, 'config.toml');
+        const bin = path.join(root, 'bin');
+        yield* fs.makeDirectory(bin);
+        yield* fs.writeFileString(path.join(bin, 'codex'), '', {mode: 0o755});
+        yield* fs.writeFileString(configPath, original);
+        yield* fs.chmod(configPath, 0o640);
+        let configReads = 0;
+        const guardedFs = FileSystem.FileSystem.of({
+          ...fs,
+          readFileString: (file, encoding) =>
+            Effect.gen(function* () {
+              if (file === configPath) {
+                configReads++;
+                if (
+                  (mode === 'unreadable-initial' && configReads === 1) ||
+                  (mode === 'unreadable-final' && configReads === 2) ||
+                  mode === 'unreadable-always'
+                ) {
+                  return yield* PlatformError.systemError({
+                    _tag: 'PermissionDenied',
+                    module: 'FileSystem',
+                    method: 'readFileString',
+                    pathOrDescriptor: file,
+                  });
+                }
+              }
+              return yield* fs.readFileString(file, encoding);
+            }),
+        });
+        const calls: (readonly string[])[] = [];
+        const commands = CommandExecutor.of({
+          ...baseCommands,
+          execute: (_executable, args) =>
+            Effect.gen(function* () {
+              calls.push(args);
+              if (mode === 'concurrent')
+                yield* fs.writeFileString(configPath, `${original}# concurrent edit\n`).pipe(Effect.orDie);
+              return {exitCode: 0, stderr: '', stdout: `codex-cli ${mode === 'legacy' ? '0.144.5' : '0.153.4'}\n`};
+            }),
+        });
+        const system = SystemInfo.of({
+          ...baseSystem,
+          platform: 'linux',
+          environment: () => ({PATH: bin, CODEX_HOME: root}),
+        });
+        const install = captureConsole(runCodexOrgMcpInstall(attach, true)).pipe(
+          Effect.provideService(SystemInfo, system),
+          Effect.provideService(CommandExecutor, commands),
+          Effect.provideService(FileSystem.FileSystem, guardedFs),
+        );
+        const result = yield* install.pipe(Effect.result);
+        const after = yield* fs.readFileString(configPath);
+        if (mode === 'apply') {
+          expect(result._tag).toBe('Success');
+          expect(after).toBe(renderCodexOrgMcpConfig(original, attach));
+          const repeated = yield* install;
+          expect(repeated.output).toContain('Already configured:');
+          expect(yield* fs.readFileString(configPath)).toBe(after);
+        } else {
+          expect(result._tag).toBe('Failure');
+          expect(after).toBe(mode === 'concurrent' ? `${original}# concurrent edit\n` : original);
+        }
+        if (baseSystem.platform !== 'win32') expect((yield* fs.stat(configPath)).mode & 0o777).toBe(0o640);
+        expect(calls.every(args => args.length === 1 && args[0] === '--version')).toBe(true);
+        if (mode === 'unreadable-initial' || mode === 'unreadable-always') expect(calls).toEqual([]);
+        expect((yield* fs.readDirectory(root)).filter(name => name.startsWith('.threadnote-org'))).toEqual([]);
+      }),
+    ).pipe(provideTestLayer(StandaloneBrokerLayer)),
+  );
+
+  effectIt.effect.each(['readable', 'dangling'] as const)('preserves a %s config symlink and its target', mode =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        if (baseSystem.platform === 'win32') return;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'codex-org-link-'});
+        const configPath = path.join(root, 'config.toml');
+        const target = path.join(root, 'managed-config.toml');
+        if (mode === 'readable') yield* fs.writeFileString(target, original);
+        yield* fs.symlink(target, configPath);
+        const result = yield* runCodexOrgMcpInstall(attach, true).pipe(
+          Effect.provideService(SystemInfo, SystemInfo.of({...baseSystem, environment: () => ({CODEX_HOME: root})})),
+          Effect.result,
+        );
+        expect(result._tag).toBe('Failure');
+        expect(yield* fs.readLink(configPath)).toBe(target);
+        if (mode === 'readable') expect(yield* fs.readFileString(target)).toBe(original);
+        else expect(yield* fs.exists(target)).toBe(false);
+        expect((yield* fs.readDirectory(root)).filter(name => name.startsWith('.threadnote-org'))).toEqual([]);
+      }),
+    ).pipe(provideTestLayer(StandaloneBrokerLayer)),
+  );
+
+  it('rejects comma-bearing scopes only at the Codex native login boundary', () => {
+    expect(() => renderCodexOrgMcpConfig(original, {...attach, additionalScopes: ['custom,scope']})).toThrow('comma');
+    expect(
+      resolveComposerAttach({composerUrl: attach.url, shareId: attach.shareId, composerOAuthScopes: ['custom,scope']})
+        ?.additionalScopes,
+    ).toEqual(['custom,scope']);
+  });
+
+  it('appends native configuration and preserves every prior byte and value', () => {
+    const proposed = renderCodexOrgMcpConfig(original, attach);
+    expect(proposed.startsWith(original)).toBe(true);
+    const actual = parse(proposed);
+    const servers = actual.mcp_servers as Record<string, unknown>;
+    expect(servers.threadnote).toEqual((parse(original).mcp_servers as Record<string, unknown>).threadnote);
+    expect(actual.mcp_oauth_callback_port).toBe(12345);
+    expect(servers['threadnote-org']).toMatchObject({
+      url: attach.url,
+      http_headers: {'threadnote-share-id': attach.shareId},
+      oauth: {client_id: attach.clientId, callback_url: attach.callback?.url, callback_port: 18789},
+    });
+    expect(servers['threadnote-org']).not.toHaveProperty('oauth_resource');
+    expect(renderCodexOrgMcpConfig(proposed, attach)).toBe(proposed);
+    expect(renderCodexOrgMcpConfig(proposed, {...attach, callback: undefined})).toBe(proposed);
+  });
+
+  it('preserves compatible extra settings and disabled state without rewriting', () => {
+    const proposed = renderCodexOrgMcpConfig(original, attach).replace(
+      '[mcp_servers.threadnote-org]',
+      '[mcp_servers.threadnote-org]\nenabled = false\ntool_timeout_sec = 45',
+    );
+    expect(renderCodexOrgMcpConfig(proposed, attach)).toBe(proposed);
+  });
+
+  it('rejects parse, inline table and conflicting binding/scope/callback changes', () => {
+    for (const content of [
+      'invalid = [',
+      'mcp_servers = "wrong"',
+      'mcp_servers = { threadnote = {command = "keep"} }',
+    ]) {
+      expect(() => renderCodexOrgMcpConfig(content, attach)).toThrow();
+    }
+    const proposed = renderCodexOrgMcpConfig(original, attach);
+    for (const changed of [
+      {...attach, shareId: 'other'},
+      {...attach, additionalScopes: []},
+      {...attach, callback: {url: 'http://127.0.0.1:18790/callback', port: 18790}},
+    ]) {
+      expect(() => renderCodexOrgMcpConfig(proposed, changed)).toThrow('conflicts');
+    }
+    expect(() => renderCodexOrgMcpConfig('', {...attach, callback: undefined})).toThrow('callback');
+    expect(() => renderCodexOrgMcpConfig('', {...attach, clientId: undefined})).toThrow('registered');
+  });
+
+  it.each([
+    'http://localhost:18789/callback',
+    'https://127.0.0.1:18789/callback',
+    'http://127.0.0.1:18788/callback',
+    'http://user@127.0.0.1:18789/callback',
+    'http://127.0.0.1:18789/callback?x=1',
+  ])('rejects an invalid direct callback %#', composerCallbackUrl => {
+    expect(() =>
+      resolveComposerAttach({
+        composerUrl: attach.url,
+        shareId: attach.shareId,
+        composerCallbackUrl,
+        composerCallbackPort: 18789,
+      }),
+    ).toThrow('callback');
+  });
+
+  it('requires a stable supported version', () => {
+    expect(supportsCodexOrgOAuth('codex-cli 0.153.4\n')).toBe(true);
+    expect(supportsCodexOrgOAuth('codex-cli 0.154.0')).toBe(true);
+    for (const version of ['codex-cli 0.144.5', 'codex-cli 0.153.3', 'codex-cli 0.153.4-alpha.1', 'unknown'])
+      expect(supportsCodexOrgOAuth(version)).toBe(false);
+  });
+
+  effectIt.effect('dry run and rejected options leave config and receipts absent', () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseSystem = yield* SystemInfo;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'codex-org-preview-'});
+        const home = path.join(root, 'team-home');
+        const system = SystemInfo.of({
+          ...baseSystem,
+          homeDirectory: root,
+          environment: () => ({CODEX_HOME: path.join(root, 'codex')}),
+        });
+        const config = {
+          account: 'local',
+          agentContextHome: home,
+          agentId: 'test',
+          manifestPath: path.join(home, 'seed.yaml'),
+          user: 'test',
+        };
+        const options = {
+          composerClientId: attach.clientId,
+          composerUrl: attach.url,
+          shareId: attach.shareId,
+          composerOAuthScopes: attach.additionalScopes,
+          composerCallbackUrl: attach.callback?.url,
+          composerCallbackPort: attach.callback?.port,
+        };
+        const preview = yield* captureConsole(runMcpInstall(config, 'codex', options)).pipe(
+          Effect.provideService(SystemInfo, system),
+        );
+        expect(preview.output).toContain('mcp login threadnote-org --scopes');
+        expect(preview.output).toContain('offline_access');
+        expect(yield* fs.exists(home)).toBe(false);
+        expect(yield* fs.exists(path.join(root, 'codex'))).toBe(false);
+        for (const agent of ['cursor', 'copilot', 'claude'] as const) {
+          const result = yield* runMcpInstall(config, agent, {...options, apply: true, project: root}).pipe(
+            Effect.provideService(SystemInfo, system),
+            Effect.result,
+          );
+          expect(result._tag).toBe('Failure');
+        }
+        expect(yield* fs.exists(home)).toBe(false);
+        expect(yield* fs.exists(path.join(root, '.cursor'))).toBe(false);
+        expect(yield* fs.exists(path.join(root, '.vscode'))).toBe(false);
+      }),
+    ).pipe(provideTestLayer(ApplicationLayer)),
+  );
+});

--- a/test/unit/org-mcp-attach.test.ts
+++ b/test/unit/org-mcp-attach.test.ts
@@ -28,6 +28,7 @@ import {
   buildCopilotComposerHttpMcpEntry,
   composerMcpUrl,
   composerShareId,
+  composerOAuthScopes,
   isManagedComposerHttpEntry,
   resolveComposerAttach,
   stdioEnvironmentCallsComposer,
@@ -62,6 +63,54 @@ afterEach(() => {
 });
 
 describe('organization composer attach', () => {
+  effectIt.effect.prop(
+    'scope union preserves required scopes and is idempotent and permutation invariant',
+    {
+      extras: FC.array(FC.stringMatching(/^[A-Za-z][A-Za-z0-9_:.-]{0,30}$/u), {maxLength: 10}),
+    },
+    ({extras}) =>
+      Effect.sync(() => {
+        const scopes = composerOAuthScopes(extras);
+        expect(scopes.slice(0, 3)).toEqual(['memory:read', 'memory:write:durable', 'memory:write:handoff']);
+        expect(new Set(scopes)).toEqual(
+          new Set(['memory:read', 'memory:write:durable', 'memory:write:handoff', ...extras]),
+        );
+        expect(composerOAuthScopes(scopes)).toEqual(scopes);
+        expect(composerOAuthScopes([...extras].reverse())).toEqual(scopes);
+        expect(composerOAuthScopes([...extras, ...extras])).toEqual(scopes);
+      }),
+  );
+
+  it.each(['', ' offline_access', 'openid profile', 'a"b', 'a\\b', 'é', '\n', 'a'.repeat(257)])(
+    'rejects invalid provider scopes %#',
+    scope => {
+      expect(() => composerOAuthScopes([scope])).toThrow('RFC 6749');
+    },
+  );
+
+  it('bounds provider scope count and serialized size', () => {
+    expect(() => composerOAuthScopes(Array.from({length: 33}, () => 'offline_access'))).toThrow('32');
+    expect(() => composerOAuthScopes(Array.from({length: 30}, (_, i) => `scope${i}`))).toThrow('32');
+    expect(() => composerOAuthScopes(Array.from({length: 10}, (_, i) => `${i}${'a'.repeat(255)}`))).toThrow('2048');
+  });
+
+  it('compares explicit scopes while keeping customized demo entries outside removal ownership', () => {
+    const base = buildComposerHttpMcpEntry('https://composer.example.test/mcp', 'engineering');
+    const refresh = buildComposerHttpMcpEntry(base.url, 'engineering', undefined, ['offline_access']);
+    expect(isComposerHttpEntry(refresh)).toBe(true);
+    expect(isManagedComposerHttpEntry(refresh)).toBe(false);
+    expect(composerHttpEntryMatches(base, refresh)).toBe(false);
+    expect(
+      composerHttpEntryMatches(
+        {...refresh, auth: {...refresh.auth, scopes: [...refresh.auth.scopes].reverse()}},
+        refresh,
+      ),
+    ).toBe(true);
+    expect(isComposerHttpEntry({...refresh, auth: {...refresh.auth, scopes: ['offline_access']}})).toBe(false);
+    expect(
+      isComposerHttpEntry({...refresh, auth: {...refresh.auth, scopes: [...refresh.auth.scopes, 'offline_access']}}),
+    ).toBe(false);
+  });
   effectIt.effect.prop(
     'keeps stdio core Git share and binds composer share only in the HTTP header',
     {clientId: SHARE_ID, host: HOST, shareId: SHARE_ID},
@@ -386,6 +435,27 @@ describe('Team MCP install composer attach', () => {
         ).pipe(Effect.provideService(SystemInfo, testSystem));
         expect(repeated.output).toContain('Already configured:');
         expect(yield* fs.readFileString(cursorPath)).toBe(beforeRepeat);
+        const refreshOptions = {
+          apply: true,
+          composerClientId: 'registered-client',
+          composerUrl: 'https://composer.example.test/mcp',
+          project,
+          shareId: 'share-engineering',
+          composerOAuthScopes: ['offline_access'],
+        };
+        yield* captureConsole(runMcpInstall(testRuntime, 'cursor', refreshOptions)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        const withRefresh = yield* fs.readFileString(cursorPath);
+        expect(JSON.parse(withRefresh).mcpServers['threadnote-org'].auth.scopes).toContain('offline_access');
+        const repeatRefresh = yield* captureConsole(runMcpInstall(testRuntime, 'cursor', refreshOptions)).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(repeatRefresh.output).toContain('Already configured:');
+        yield* captureConsole(runMcpInstall(testRuntime, 'cursor', {apply: true, project})).pipe(
+          Effect.provideService(SystemInfo, testSystem),
+        );
+        expect(yield* fs.readFileString(cursorPath)).toBe(withRefresh);
         expect(mcpToolCapabilities(parseMcpToolset('core')).memoryPublish).toBe(true);
 
         const fetchSpy = vi.fn(() => Promise.reject(new Error('composer down')));


### PR DESCRIPTION
Registered organization clients need provider-specific OAuth scopes and a supported Codex callback configuration. The installer now accepts bounded additional scopes (including `offline_access`) and adds a native Codex HTTP/OAuth entry while preserving existing personal stdio, comments, unrelated configuration, disabled state, and file permissions. Conflicting, unreadable, symlinked, and concurrently changed configurations fail before replacement.

Codex apply requires the verified minimum CLI version 0.153.4 and an explicitly registered client/callback; output includes the native login command. Cursor matching and repair preserve the intended scope set. Unsupported client options fail before mutation. The deployment runbook records the supported setup and remaining acceptance gates.

Validation: 73 focused tests across six files, lint, and typecheck passed. Property tests cover scope union determinism, deduplication, and preservation of required scopes. Dev-cycle completed two iterations with zero blocking findings; final minor coverage improvement passed. Exact commits881096f8 and the CI correctionc95b2b15 were installed globally and doctor-verified. Installed-command smoke proved fresh Codex dry-run/apply/repeat behavior, byte-identical preservation of the existing Codex config and mode 0600, and actual Cursor refresh-scope attach with personal stdio retained.

The separate live org sustained-load test exposed a server-side write timeout after eleven verified acknowledgements. That deployment acceptance gate remains open and is not resolved or claimed by this client configuration change.

CI found the raw Promise lifting architecture guard; c95b2b15 uses the shared Effect adapter with unchanged ENOENT-only behavior. The fix passed34 focused tests including the architecture guard, lint/types, an incremental zero-finding review, and another installed-command smoke.
