### PR TITLE
Expose org memory evidence to text-only MCP clients

### DIFF
--- a/docs/remote-memory/fly-org.md
+++ b/docs/remote-memory/fly-org.md
@@ -195,8 +195,16 @@ events without copying tokens or identity details into receipts.
 
 Observed client evidence on 2026-09-07: Codex 0.153.4 completed seven-tool discovery, recall/read, acknowledged write,
 CAS replacement/stale rejection, laptop Git sync and native refresh. Cursor GUI 3.19.13 / Agent 2026.09.02-c22c1a3
-completed PKCE and seven-tool discovery; execution and refresh after adding `offline_access` still require acceptance.
+completed PKCE, native refresh and an acknowledged canary write; its read/recall evidence requires another client
+check after the text compatibility correction below.
 These canaries do not complete P5 recovery or authorize a daily cutover by themselves.
+
+Cursor's text-only MCP delivery exposed a compatibility gap during its native canary: a successful recall did not
+show its returned URIs, and a read omitted its immutable revision. Remote recall now repeats its selected pointers
+and next action in budgeted text. Reads append source/revision receipts without duplicating the memory body; tool
+errors include their machine-readable code in text. Structured results remain available. Verify these fields in
+the actual client's visible tool output before treating a write/read/recall sequence as accepted. This follows the
+[MCP text compatibility guidance](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content).
 
 Client references: [Codex MCP configuration and callbacks](https://learn.chatgpt.com/docs/extend/mcp?surface=cli),
 [Auth0 refresh-token requirements](https://auth0.com/docs/secure/tokens/refresh-tokens/get-refresh-tokens),

--- a/src/remote_memory/recall_projection.ts
+++ b/src/remote_memory/recall_projection.ts
@@ -99,7 +99,6 @@ function responseForPrefix(
   budgetTokens: number,
 ): RemoteRecallProjection {
   const prefix = input.results.slice(0, count);
-  const text = `Remote recall returned ${count}/${input.results.length} unread pointers. Follow structuredContent.nextAction before relying on them.`;
   let structuredContent: RemoteRecallStructuredContent = {
     confidence: aggregateConfidence(input.results[0]?.score),
     estimatedTokens: budgetTokens,
@@ -113,6 +112,13 @@ function responseForPrefix(
     type: 'threadnote-remote-recall',
     version: 1,
   };
+  const text = `Untrusted remote recall: ${count}/${input.results.length} unread pointers. Read a returned URI before relying on it.\n${JSON.stringify(
+    {
+      nextAction: structuredContent.nextAction,
+      omittedResults: structuredContent.omittedResults,
+      results: structuredContent.results,
+    },
+  )}`;
   for (let iteration = 0; iteration < 4; iteration += 1) {
     const nextEstimatedTokens = estimatedTokens(utf8Bytes(text) + utf8Bytes(JSON.stringify(structuredContent)));
     if (nextEstimatedTokens === structuredContent.estimatedTokens) break;

--- a/src/remote_memory/tools.ts
+++ b/src/remote_memory/tools.ts
@@ -456,6 +456,7 @@ async function invokeRemoteReadTool(
         content: [
           {type: 'text', text: read.content},
           ...(read.receipt === undefined ? [] : [{type: 'text' as const, text: read.receipt}]),
+          {type: 'text', text: safeToolText(sourceMetadata)},
         ],
         structuredContent,
       };
@@ -605,7 +606,10 @@ async function withRequestDeadline<A>(context: RemoteMcpRequestContext, run: () 
 
 function remoteToolError(error: RemoteMemoryError, requestId: string): CallToolResult {
   return {
-    content: [{type: 'text', text: error.message}],
+    content: [
+      {type: 'text', text: error.message},
+      {type: 'text', text: safeToolText({code: error.code, details: error.details, requestId})},
+    ],
     isError: true,
     structuredContent: {code: error.code, details: error.details, requestId},
   };

--- a/test/unit/remote-memory-http.test.ts
+++ b/test/unit/remote-memory-http.test.ts
@@ -434,7 +434,7 @@ describe('remote memory HTTP transport', () => {
       totalResults: 100,
       type: 'threadnote-remote-recall',
     });
-    expect(compact.blocks[0]?.text).not.toContain(recallResults[0].uri);
+    expect(compact.blocks[0]?.text).toContain(recallResults[0].uri);
 
     const explained = await callRecall(3_101, true);
     const explainedResults = explained.structured.results as readonly Readonly<Record<string, unknown>>[];
@@ -442,10 +442,10 @@ describe('remote memory HTTP transport', () => {
     expect(explainedResults.length).toBeLessThan(compactResults.length);
     expect(explainedResults[0]?.excerpt).toEqual(expect.stringContaining('REMOTE_EXCERPT_000_'));
     expect(explained.structured.explain).toBe(true);
-    expect(explained.blocks[0]?.text).not.toContain('REMOTE_EXCERPT_000_');
+    expect(explained.blocks[0]?.text).toContain('REMOTE_EXCERPT_000_');
     expect(
       JSON.stringify({content: explained.blocks, structured: explained.structured}).match(/REMOTE_EXCERPT_000_/gu),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
     expect(test.calls.filter(call => call === 'rate:recall_context')).toHaveLength(2);
   });
 
@@ -503,6 +503,29 @@ describe('remote memory HTTP transport', () => {
     });
     expect(test.calls).toContain('rate:read_context');
     expect(test.calls).toContain('read:request-123');
+  });
+
+  it('exposes read revision and source receipts to clients that consume only text blocks', async () => {
+    const test = fixture();
+    const uri = 'threadnote://share/share-1/memories/durable/threadnote/fixture.md';
+    const response = await test.handler(
+      mcpRequest({id: 3_200, method: 'tools/call', params: {arguments: {uri, version: 1}, name: 'read_context'}}),
+    );
+    const payload = await json(response);
+    const result = payload.result as {
+      content: readonly {text: string}[];
+      structuredContent: {revision: string; receipt: unknown};
+    };
+    expect(result.content[0].text).toContain('Fixture body');
+    const sourceText = result.content.at(-1)!.text;
+    const source = JSON.parse(sourceText.slice(sourceText.indexOf('\n') + 1));
+    expect(source).toMatchObject({
+      uri,
+      revision: result.structuredContent.revision,
+      receipt: result.structuredContent.receipt,
+      trust: 'untrusted',
+    });
+    expect(sourceText).not.toContain('Fixture body');
   });
 
   it('refuses a 1 MB remote memory with an outline instead of paged reconstruction', async () => {
@@ -622,7 +645,15 @@ describe('remote memory HTTP transport', () => {
         {token: secretToken},
       ),
     );
-    const serialized = JSON.stringify(await json(response));
+    const payload = await json(response);
+    const result = payload.result as {content: readonly {text: string}[]};
+    const errorText = result.content.at(-1)!.text;
+    expect(JSON.parse(errorText.slice(errorText.indexOf('\n') + 1))).toEqual({
+      code: 'service_unavailable',
+      details: {},
+      requestId: 'request-123',
+    });
+    const serialized = JSON.stringify(payload);
 
     expect(serialized).toContain('service_unavailable');
     expect(serialized).not.toContain(secretToken);

--- a/test/unit/remote-memory-recall-projection.test.ts
+++ b/test/unit/remote-memory-recall-projection.test.ts
@@ -35,6 +35,10 @@ describe('remote recall projection', () => {
             results.slice(0, projected.structuredContent.results.length).map(result => result.uri),
           );
           expect(projectRemoteRecallResponse({receipt, results}, {budgetTokens, explain})).toEqual(projected);
+          const textEvidence = JSON.parse(projected.text.slice(projected.text.indexOf('\n') + 1));
+          expect(textEvidence.nextAction).toEqual(projected.structuredContent.nextAction);
+          expect(textEvidence.results).toEqual(projected.structuredContent.results);
+          expect(textEvidence.omittedResults).toBe(projected.structuredContent.omittedResults);
           if (!explain) {
             expect(projected.structuredContent.results.every(result => !('excerpt' in result))).toBe(true);
           }


### PR DESCRIPTION
Native Cursor tool execution drops MCP `structuredContent`. Org recall therefore reported a pointer count without showing any URIs, and reads omitted the immutable revision needed to verify or replace a memory. A real Cursor canary reproduced this after successful OAuth and an acknowledged write.

Include the selected recall pointers, next action and omissions in budgeted text. Append read source/revision receipts without repeating the memory body, and include error codes in text. Existing structured results, the raw read content block and its projection index remain unchanged.

Validation: 27 focused tests pass, including the bounded 50-run property for deterministic ranked prefixes, text/structured parity and the combined response budget. Lint and type checks pass. Full four-lane dev-cycle review found no issues. Exact-HEAD global installation passed; an isolated restricted-role Git service smoke verified text-only recall, read revision, CAS replacement and stale-CAS error codes. Live Cursor revalidation follows deployment of the reviewed image; this PR does not claim completed daily cutover or enterprise acceptance.
