### PR TITLE
Make graph checkpoints portable across Git case settings

### DIFF
--- a/src/code_graph/checkpoint/commands.ts
+++ b/src/code_graph/checkpoint/commands.ts
@@ -50,7 +50,6 @@ import {checkpointTerminalText} from './terminal_text.js';
 
 const CHECKPOINT_IO_CHUNK_BYTES = 64 * 1_024;
 const CHECKPOINT_GIT_OUTPUT_BYTES_MAXIMUM = 16 * 1_024 * 1_024;
-const CHECKPOINT_GIT_TREE_FORMAT = '%(objectmode)%x09%(objecttype)%x09%(objectname)%x09%(objectsize)%x09%(path)';
 const CHECKPOINT_SNAPSHOT_DOMAIN = 'threadnote-code-graph-checkpoint-local-snapshot-v1\0';
 
 export class CodeGraphCheckpointCommandError extends Schema.TaggedError<CodeGraphCheckpointCommandError>()(
@@ -265,7 +264,7 @@ export const importCodeGraphCheckpointSnapshot = Effect.fn('codeGraph.checkpoint
   const validated = yield* withCheckpointInput(options.input, input =>
     Effect.gen(function* () {
       const inspection = yield* inspectCheckpointInput(input, options);
-      validateCheckpointReceiver(inspection.header, identity, registry);
+      yield* attemptCheckpoint(() => validateCheckpointReceiver(inspection.header, identity, registry));
       yield* requireCheckpointCommit(identity, inspection.header.source.commit);
       const attribution = checkpointAttributionRecordVerifier(inspection.header);
       yield* withCodeGraphCheckpointAuthorityVerification(inspection.header, accept =>
@@ -520,17 +519,7 @@ function verifyCheckpointFiles(
     for (const batch of codeGraphCheckpointGitPathBatches(files)) {
       const result = yield* runBinaryCommandEffect(
         'git',
-        [
-          '-C',
-          identity.repoRoot,
-          'ls-tree',
-          '-z',
-          '--full-tree',
-          `--format=${CHECKPOINT_GIT_TREE_FORMAT}`,
-          commit,
-          '--',
-          ...batch.map(file => file.path),
-        ],
+        ['-C', identity.repoRoot, 'ls-tree', '-l', '-z', '--full-tree', commit, '--', ...batch.map(file => file.path)],
         {
           env: {...system.environment(), GIT_LITERAL_PATHSPECS: '1', GIT_NO_LAZY_FETCH: '1'},
           maxOutputBytes: CHECKPOINT_GIT_OUTPUT_BYTES_MAXIMUM,
@@ -601,8 +590,7 @@ function validateCheckpointReceiver(
 ): void {
   if (
     header.repository.repositoryId !== identity.repositoryId ||
-    header.repository.objectFormat !== identity.objectFormat ||
-    header.repository.caseMode !== identity.caseMode
+    header.repository.objectFormat !== identity.objectFormat
   ) {
     throw CodeGraphCheckpointCommandError.make({
       message: 'Checkpoint repository identity does not match this checkout.',

--- a/src/code_graph/checkpoint/projection.ts
+++ b/src/code_graph/checkpoint/projection.ts
@@ -64,7 +64,6 @@ const FILE_FACT_PAGE_SIZE_MAXIMUM = 8;
 const LANGUAGE_PACK_PROVENANCE_MAXIMUM = 1_024;
 export const CODE_GRAPH_CHECKPOINT_GIT_PATHSPEC_BYTES_MAXIMUM = 64 * 1_024;
 const GIT_TREE_OUTPUT_BYTES_MAXIMUM = 256 * 1_024;
-const GIT_TREE_FORMAT = '%(objectmode)%x09%(objecttype)%x09%(objectname)%x09%(objectsize)%x09%(path)';
 
 export class CodeGraphCheckpointProjectionError extends Schema.TaggedError<CodeGraphCheckpointProjectionError>()(
   'CodeGraphCheckpointProjectionError',
@@ -733,17 +732,7 @@ function loadGitTreeEntries<T extends {readonly path: string}>(
     for (const batch of batches) {
       const result = yield* runBinaryCommandEffect(
         'git',
-        [
-          '-C',
-          identity.repoRoot,
-          'ls-tree',
-          '-z',
-          '--full-tree',
-          `--format=${GIT_TREE_FORMAT}`,
-          commit,
-          '--',
-          ...batch.map(file => file.path),
-        ],
+        ['-C', identity.repoRoot, 'ls-tree', '-l', '-z', '--full-tree', commit, '--', ...batch.map(file => file.path)],
         {
           env: {...system.environment(), GIT_LITERAL_PATHSPECS: '1'},
           maxOutputBytes: GIT_TREE_OUTPUT_BYTES_MAXIMUM,
@@ -804,18 +793,13 @@ export function parseGitTreeEntries(
   const entries = new Map<string, GitTreeEntry>();
   const objectIdPattern = objectFormat === 'sha1' ? /^[0-9a-f]{40}$/u : /^[0-9a-f]{64}$/u;
   for (const encoded of text.slice(0, -1).split('\0')) {
-    const fields = encoded.split('\t');
-    if (fields.length !== 5) throw CodeGraphCheckpointProjectionError.make({message: 'Git tree entry is malformed.'});
-    const [mode, type, blobId, encodedSize, path] = fields;
-    if (
-      mode === undefined ||
-      type === undefined ||
-      blobId === undefined ||
-      encodedSize === undefined ||
-      path === undefined
-    ) {
+    const separator = encoded.indexOf('\t');
+    const metadata = /^(\d{6}) ([a-z]+) ([0-9a-f]+) +(\d+)$/u.exec(encoded.slice(0, separator));
+    if (separator < 0 || metadata === null) {
       throw CodeGraphCheckpointProjectionError.make({message: 'Git tree entry is malformed.'});
     }
+    const [, mode, type, blobId, encodedSize] = metadata;
+    const path = encoded.slice(separator + 1);
     const size = Number(encodedSize);
     if (
       !/^\d{6}$/u.test(mode) ||

--- a/src/code_graph/inventory.ts
+++ b/src/code_graph/inventory.ts
@@ -1311,10 +1311,10 @@ function compileIgnorePattern(pattern: string): RegExp | undefined {
 
 function ignoredPaths(repoRoot: string, paths: readonly string[]) {
   if (paths.length === 0) return Effect.succeed(new Set<string>());
-  const input = new TextEncoder().encode(`${paths.join('\0')}\0`);
-  return runCommandEffect('git', ['-C', repoRoot, 'check-ignore', '--no-index', '-z', '--stdin'], {
+  const gitOptions = ['-C', repoRoot, '-c', 'core.ignorecase=false'];
+  return runCommandEffect('git', [...gitOptions, 'check-ignore', '--no-index', '-z', '--stdin'], {
     allowFailure: true,
-    input,
+    input: new TextEncoder().encode(`${paths.join('\0')}\0`),
     maxOutputBytes: 0,
     timeoutMs: 0,
   }).pipe(Effect.map(result => new Set(result.stdout.split('\0').filter(Boolean).map(normalizeRepositoryPath))));

--- a/src/code_graph/inventory_policy.ts
+++ b/src/code_graph/inventory_policy.ts
@@ -5,7 +5,7 @@ import {isLowSignalStructuredPath, isRecognizedStructuredPath} from './languages
  * bumped alongside it so facts produced under an older admission policy cannot
  * be reused by a new snapshot.
  */
-export const CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION = 1 as const;
+export const CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION = 2 as const;
 
 /** Generic JSON at or above this boundary is low-value graph input. */
 export const CODE_GRAPH_GENERIC_JSON_EXCLUSION_BYTES = 256 * 1_024;

--- a/src/code_graph/types.ts
+++ b/src/code_graph/types.ts
@@ -8,7 +8,7 @@ export {
   CODE_GRAPH_PERSISTENT_SCHEMA_CURRENT_REVISION as CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
 } from './store/schema_revision.js';
 export const CODE_GRAPH_RESULT_VERSION = 1 as const;
-export const CODE_GRAPH_EXTRACTOR_GENERATION = 13 as const;
+export const CODE_GRAPH_EXTRACTOR_GENERATION = 14 as const;
 export const CODE_GRAPH_EXTRACTOR_SET_VERSION = `native-code-graph-${CODE_GRAPH_EXTRACTOR_GENERATION}` as const;
 
 export type CodeGraphSnapshotFileCitationSchemaState =

--- a/test/integration/code-graph.checkpoint-case-mode.test.ts
+++ b/test/integration/code-graph.checkpoint-case-mode.test.ts
@@ -1,0 +1,139 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {
+  importCodeGraphCheckpointSnapshot,
+  runCodeGraphCheckpointExport,
+} from '../../src/code_graph/checkpoint/commands.js';
+import {
+  decodeCodeGraphCheckpointPackV1,
+  encodeCodeGraphCheckpointPackV1,
+} from '../../src/code_graph/checkpoint/pack.js';
+import type {CodeGraphCheckpointMetadataV1} from '../../src/code_graph/checkpoint/schema.js';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('checkpoint portability across Git case settings', () => {
+  it.effect(
+    'imports in both directions with exact path fidelity and preserves ready state on typed rejection',
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-checkpoint-case-'});
+        const repo = path.join(root, 'repository');
+        const spacedPath = process.platform === 'win32' ? 'src/a spaced file.ts' : 'src/a "quoted" file.ts';
+        yield* fs.makeDirectory(path.join(repo, 'src'), {recursive: true});
+        yield* fs.writeFileString(path.join(repo, 'package.json'), '{"name":"checkpoint-case","type":"module"}\n');
+        yield* fs.writeFileString(path.join(repo, 'src/Value.ts'), 'export const value = 1;\n');
+        yield* fs.writeFileString(path.join(repo, 'src/文.ts'), 'export const unicode = 2;\n');
+        yield* fs.writeFileString(path.join(repo, spacedPath), 'export const quoted = 3;\n');
+        yield* fs.writeFileString(path.join(repo, '.gitignore'), 'src/value.ts\n');
+        yield* git(repo, ['init', '-q', '--initial-branch=main']);
+        yield* git(repo, ['remote', 'add', 'origin', 'https://github.com/acme/checkpoint-case.git']);
+        yield* git(repo, ['add', '-f', 'package.json', '.gitignore', 'src/Value.ts', 'src/文.ts', spacedPath]);
+        yield* git(repo, ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']);
+
+        for (const donorMode of ['false', 'true']) {
+          const receiverMode = donorMode === 'false' ? 'true' : 'false';
+          const donorHome = path.join(root, `donor-${donorMode}`);
+          const receiverHome = path.join(root, `receiver-${receiverMode}`);
+          const independentHome = path.join(root, `independent-${receiverMode}`);
+          const artifact = path.join(root, `checkpoint-${donorMode}.cgcp`);
+          yield* git(repo, ['config', 'core.ignorecase', donorMode]);
+          const source = yield* indexer.index({cwd: repo, threadnoteHome: donorHome, ensureVectors: false});
+          const exported = yield* runCodeGraphCheckpointExport(config(donorHome), {
+            cwd: repo,
+            output: artifact,
+            quiet: true,
+          });
+          const originalBytes = yield* fs.readFile(artifact);
+          const decoded = decodeCodeGraphCheckpointPackV1(originalBytes);
+          expect(decoded.header.repository.caseMode).toBe(donorMode === 'true' ? 'insensitive' : 'sensitive');
+          expect(decoded.records.filter(record => record.kind === 'file').map(record => record.path)).toEqual([
+            'package.json',
+            'src/Value.ts',
+            spacedPath,
+            'src/文.ts',
+          ]);
+
+          yield* git(repo, ['config', 'core.ignorecase', receiverMode]);
+          const imported = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {
+            cwd: repo,
+            input: artifact,
+            expectedDigest: exported.artifact.digest,
+          });
+          expect(imported.result).toMatchObject({
+            imported: 'created',
+            publication: 'activated',
+            trust: 'expected-descriptor-verified',
+          });
+          const independent = yield* indexer.index({cwd: repo, threadnoteHome: independentHome, ensureVectors: false});
+          expect(imported.snapshot.graphContentId).toBe(source.snapshot.graphContentId);
+          expect(imported.snapshot.graphContentId).toBe(independent.snapshot.graphContentId);
+          const identity = yield* resolveRepositoryIdentity(repo);
+          const database = codeGraphLayout(path, receiverHome, identity.checkoutId, identity.worktreeId).databasePath;
+          expect(yield* store.checkpointImportReceipt(database, imported.snapshot.id)).toMatchObject({
+            trust: 'expected-descriptor-verified',
+          });
+
+          const metadata: CodeGraphCheckpointMetadataV1 = {
+            abi: decoded.header.abi.input,
+            coverage: decoded.header.coverage,
+            repository: decoded.header.repository,
+            source: decoded.header.source,
+            ...(decoded.header.reuse === undefined ? {} : {reuse: decoded.header.reuse}),
+          };
+          const invalid = [
+            {...metadata, repository: {...metadata.repository, repositoryId: '0'.repeat(64)}},
+            {...metadata, repository: {...metadata.repository, objectFormat: 'sha256' as const}},
+            {...metadata, abi: {...metadata.abi, inventoryPolicyVersion: metadata.abi.inventoryPolicyVersion - 1}},
+          ];
+          for (const [index, changed] of invalid.entries()) {
+            const badArtifact = path.join(root, `invalid-${donorMode}-${index}.cgcp`);
+            yield* fs.writeFile(badArtifact, encodeCodeGraphCheckpointPackV1(changed, decoded.records).bytes);
+            const error = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {
+              cwd: repo,
+              input: badArtifact,
+            }).pipe(Effect.flip);
+            expect(error).toMatchObject({
+              _tag: 'CodeGraphCheckpointCommandError',
+              message: expect.stringContaining(
+                index === 2 ? 'runtime ABI is incompatible' : 'repository identity does not match',
+              ),
+            });
+            expect((yield* store.readySnapshot(database, identity.worktreeId))?.id).toBe(imported.snapshot.id);
+          }
+          yield* fs.writeFileString(path.join(repo, 'src/Value.ts'), 'export const value = 3;\n');
+          const dirty = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {cwd: repo, input: artifact});
+          expect(dirty.result.publication).toBe('stored');
+          yield* fs.writeFileString(path.join(repo, 'src/Value.ts'), 'export const value = 1;\n');
+          expect((yield* git(repo, ['config', '--get', 'core.ignorecase'])).stdout.trim()).toBe(receiverMode);
+          expect((yield* git(repo, ['status', '--porcelain'])).stdout).toBe('');
+          expect(yield* fs.readFile(artifact)).toEqual(originalBytes);
+        }
+      }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    60_000,
+  );
+});
+
+function config(home: string) {
+  return {
+    account: 'local' as const,
+    agentContextHome: home,
+    agentId: 'threadnote',
+    manifestPath: `${home}/seed-manifest.yaml`,
+    user: 'local',
+  };
+}
+
+function git(repo: string, args: readonly string[]) {
+  return runCommandEffect('git', ['-C', repo, ...args]);
+}

--- a/test/integration/code-graph.inventory-case-mode.test.ts
+++ b/test/integration/code-graph.inventory-case-mode.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
+import {inventoryRepository, previewCodeGraphInventory} from '../../src/code_graph/inventory.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {StandaloneBrokerLayer} from '../../src/effect/runtime.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('portable Git ignore matching', () => {
+  it.effect.prop(
+    'keeps committed inventory and preview invariant under the local Git case setting',
+    {suffix: fc.array(fc.constantFrom(...'abcdef'), {maxLength: 6}).map(chars => chars.join(''))},
+    ({suffix}) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-inventory-case-'});
+        yield* fs.makeDirectory(path.join(root, 'src'));
+        const admitted = `src/Value${suffix}.ts`;
+        const excluded = `src/ignored${suffix}.ts`;
+        yield* fs.writeFileString(path.join(root, 'src/always.ts'), 'export const always = true;\n');
+        yield* fs.writeFileString(path.join(root, admitted), 'export const value = 1;\n');
+        yield* fs.writeFileString(path.join(root, excluded), 'export const ignored = 2;\n');
+        yield* fs.writeFileString(path.join(root, '.gitignore'), `${admitted.toLowerCase()}\n${excluded}\n`);
+        yield* git(root, ['init', '-q']);
+        yield* git(root, ['add', '-f', admitted, excluded, 'src/always.ts', '.gitignore']);
+        yield* git(root, ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']);
+        const observations = [];
+        for (const mode of ['false', 'true']) {
+          yield* git(root, ['config', 'core.ignorecase', mode]);
+          const identity = yield* resolveRepositoryIdentity(root);
+          const inventory = yield* inventoryRepository(identity);
+          const preview = yield* previewCodeGraphInventory(identity, {includeOverlay: false});
+          expect(inventory.dirty).toBe(false);
+          expect(inventory.files.map(file => file.path)).toEqual([admitted, 'src/always.ts']);
+          expect((yield* git(root, ['config', '--get', 'core.ignorecase'])).stdout.trim()).toBe(mode);
+          expect((yield* git(root, ['status', '--porcelain'])).stdout).toBe('');
+          observations.push({
+            files: inventory.files,
+            skipped: inventory.skipped,
+            groups: preview.groups,
+            totals: preview.totals,
+          });
+        }
+        expect(observations[1]).toEqual(observations[0]);
+      }).pipe(provideTestLayer(StandaloneBrokerLayer), TestClock.withLive),
+    {fastCheck: {numRuns: 12}},
+  );
+});
+
+function git(repo: string, args: readonly string[]) {
+  return runCommandEffect('git', ['-C', repo, ...args]);
+}

--- a/test/integration/code-graph.inventory-policy.test.ts
+++ b/test/integration/code-graph.inventory-policy.test.ts
@@ -54,7 +54,7 @@ describe('code graph inventory admission policy', () => {
       expect(clean.policyExclusions).toEqual({
         bytes: cleanExcludedBytes,
         files: 4,
-        policyVersion: 1,
+        policyVersion: 2,
         reasons: [
           {bytes: statSync(join(root, 'assets/logo.SVG')).size, files: 1, reason: 'svg'},
           {bytes: statSync(join(root, 'SCHEMAS/__SNAPSHOTS__/PROJECT.JSON')).size, files: 1, reason: 'low-signal-json'},
@@ -139,78 +139,78 @@ describe('code graph inventory admission policy', () => {
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
-  it('previews exact aggregate admission decisions without reading excluded blobs', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'threadnote-inventory-preview-'));
-    roots.push(root);
-    git(root, ['init', '-q']);
-    for (const directory of [['apps', 'mobile'], ['assets'], ['data'], ['src']]) {
-      mkdirSync(join(root, ...directory), {recursive: true});
-    }
-    writeFileSync(join(root, 'package.json'), '{"name":"inventory-preview"}\n');
-    writeFileSync(join(root, 'tsconfig.json'), '{"compilerOptions":{}}\n');
-    writeFileSync(join(root, 'apps', 'mobile', 'project.json'), '{}\n');
-    writeFileSync(join(root, 'src', 'active.ts'), 'export const active = true;\n');
-    writeFileSync(join(root, 'src', 'ignored.ts'), 'export const ignored = true;\n');
-    writeFileSync(join(root, '.threadnoteignore'), 'src/ignored.ts\n');
-    writeFileSync(join(root, 'assets', 'icon.svg'), '<svg/>');
-    writeSizedFile(join(root, 'data', 'heavy.json'), CODE_GRAPH_GENERIC_JSON_EXCLUSION_BYTES);
-    git(root, ['add', '.']);
-    git(root, [
-      '-c',
-      'user.name=Threadnote Test',
-      '-c',
-      'user.email=test@threadnote.local',
-      'commit',
-      '-qm',
-      'fixture',
-    ]);
-    const excludedBlobIds = new Set([
-      git(root, ['rev-parse', 'HEAD:assets/icon.svg']),
-      git(root, ['rev-parse', 'HEAD:data/heavy.json']),
-    ]);
-    const requestedBlobIds: string[] = [];
+  effectIt.effect('previews exact aggregate admission decisions without reading excluded blobs', () =>
+    Effect.gen(function* () {
+      const root = mkdtempSync(join(tmpdir(), 'threadnote-inventory-preview-'));
+      roots.push(root);
+      git(root, ['init', '-q']);
+      for (const directory of [['apps', 'mobile'], ['assets'], ['data'], ['src']]) {
+        mkdirSync(join(root, ...directory), {recursive: true});
+      }
+      writeFileSync(join(root, 'package.json'), '{"name":"inventory-preview"}\n');
+      writeFileSync(join(root, 'tsconfig.json'), '{"compilerOptions":{}}\n');
+      writeFileSync(join(root, 'apps', 'mobile', 'project.json'), '{}\n');
+      writeFileSync(join(root, 'src', 'active.ts'), 'export const active = true;\n');
+      writeFileSync(join(root, 'src', 'ignored.ts'), 'export const ignored = true;\n');
+      writeFileSync(join(root, '.threadnoteignore'), 'src/ignored.ts\n');
+      writeFileSync(join(root, 'assets', 'icon.svg'), '<svg/>');
+      writeSizedFile(join(root, 'data', 'heavy.json'), CODE_GRAPH_GENERIC_JSON_EXCLUSION_BYTES);
+      git(root, ['add', '.']);
+      git(root, [
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=test@threadnote.local',
+        'commit',
+        '-qm',
+        'fixture',
+      ]);
+      const excludedBlobIds = new Set([
+        git(root, ['rev-parse', 'HEAD:assets/icon.svg']),
+        git(root, ['rev-parse', 'HEAD:data/heavy.json']),
+      ]);
+      const requestedBlobIds: string[] = [];
 
-    const preview = await runEffect(
-      Effect.gen(function* () {
-        const identity = yield* resolveRepositoryIdentity(root);
-        const command = yield* CommandExecutor;
-        const observedCommand = CommandExecutor.of({
-          ...command,
-          executeBytes: (executable, args, options) => {
-            if (executable === 'git' && args.includes('cat-file') && args.includes('--batch')) {
-              requestedBlobIds.push(
-                ...new TextDecoder()
-                  .decode(options?.input ?? new Uint8Array())
-                  .split('\n')
-                  .filter(Boolean),
-              );
-            }
-            return command.executeBytes!(executable, args, options);
-          },
-        });
-        return yield* previewCodeGraphInventory(identity).pipe(Effect.provideService(CommandExecutor, observedCommand));
-      }),
-    );
-    const group = (reason: string, language: string) =>
-      preview.groups.find(candidate => candidate.reason === reason && candidate.language === language);
+      const identity = yield* resolveRepositoryIdentity(root);
+      const command = yield* CommandExecutor;
+      const observedCommand = CommandExecutor.of({
+        ...command,
+        executeBytes: (executable, args, options) => {
+          if (executable === 'git' && args.includes('cat-file') && args.includes('--batch')) {
+            requestedBlobIds.push(
+              ...new TextDecoder()
+                .decode(options?.input ?? new Uint8Array())
+                .split('\n')
+                .filter(Boolean),
+            );
+          }
+          return command.executeBytes!(executable, args, options);
+        },
+      });
+      const preview = yield* previewCodeGraphInventory(identity).pipe(
+        Effect.provideService(CommandExecutor, observedCommand),
+      );
+      const group = (reason: string, language: string) =>
+        preview.groups.find(candidate => candidate.reason === reason && candidate.language === language);
 
-    expect(requestedBlobIds.filter(blobId => excludedBlobIds.has(blobId))).toEqual([]);
-    expect(preview).toMatchObject({dirty: false, policyVersion: 1, scope: 'head-and-worktree'});
-    expect(group('svg', 'document')).toMatchObject({classifier: 'corpus', disposition: 'skipped'});
-    expect(group('generic-json-size', 'json')).toMatchObject({classifier: 'schemas', disposition: 'skipped'});
-    expect(group('threadnote-ignore', 'typescript')).toMatchObject({
-      classifier: 'typescript',
-      disposition: 'skipped',
-    });
-    expect(group('admitted', 'typescript')).toMatchObject({disposition: 'eligible', role: 'source'});
-    expect(group('admitted', 'npm-manifest')).toMatchObject({disposition: 'eligible', role: 'manifest'});
-    expect(group('admitted', 'typescript-config')).toMatchObject({disposition: 'eligible', role: 'workspace'});
-    expect(group('admitted', 'json')).toMatchObject({classifier: 'schemas', disposition: 'eligible'});
-    expect(JSON.stringify(preview)).not.toContain(root);
-    for (const repositoryPath of ['src/active.ts', 'src/ignored.ts', 'assets/icon.svg', 'data/heavy.json']) {
-      expect(JSON.stringify(preview)).not.toContain(repositoryPath);
-    }
-  });
+      expect(requestedBlobIds.filter(blobId => excludedBlobIds.has(blobId))).toEqual([]);
+      expect(preview).toMatchObject({dirty: false, policyVersion: 2, scope: 'head-and-worktree'});
+      expect(group('svg', 'document')).toMatchObject({classifier: 'corpus', disposition: 'skipped'});
+      expect(group('generic-json-size', 'json')).toMatchObject({classifier: 'schemas', disposition: 'skipped'});
+      expect(group('threadnote-ignore', 'typescript')).toMatchObject({
+        classifier: 'typescript',
+        disposition: 'skipped',
+      });
+      expect(group('admitted', 'typescript')).toMatchObject({disposition: 'eligible', role: 'source'});
+      expect(group('admitted', 'npm-manifest')).toMatchObject({disposition: 'eligible', role: 'manifest'});
+      expect(group('admitted', 'typescript-config')).toMatchObject({disposition: 'eligible', role: 'workspace'});
+      expect(group('admitted', 'json')).toMatchObject({classifier: 'schemas', disposition: 'eligible'});
+      expect(JSON.stringify(preview)).not.toContain(root);
+      for (const repositoryPath of ['src/active.ts', 'src/ignored.ts', 'assets/icon.svg', 'data/heavy.json']) {
+        expect(JSON.stringify(preview)).not.toContain(repositoryPath);
+      }
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
 
   it('bounds Git ignore checks and stable metadata inspection to relevant changed paths', async () => {
     const root = mkdtempSync(join(tmpdir(), 'threadnote-inventory-policy-changed-paths-'));

--- a/test/integration/code-graph.sharing-deltas.test.ts
+++ b/test/integration/code-graph.sharing-deltas.test.ts
@@ -42,6 +42,7 @@ describe('graph share TCG1 delta publication and apply', () => {
           );
           yield* fs.writeFileString(path.join(repository, 'src', 'index.ts'), 'export const shared = 1;\n');
           yield* git(repository, ['init', '-q', '--initial-branch=main']);
+          yield* git(repository, ['config', 'core.ignorecase', 'false']);
           yield* git(repository, ['remote', 'add', 'origin', 'https://github.com/acme/graph-share-deltas.git']);
           yield* git(repository, ['add', '.']);
           yield* git(repository, [
@@ -78,7 +79,15 @@ describe('graph share TCG1 delta publication and apply', () => {
             threadnoteHome: publisherHome,
           });
           const bootstrapped = yield* runGraphPublisherBootstrap(config(publisherHome), {cas, cwd: repository});
+          yield* git(repository, ['config', 'core.ignorecase', 'true']);
           yield* runGraphShareJoin(config(clientHome), {cas, cwd: repository});
+          expect(
+            yield* maybeImportSharedGraphBase({
+              cwd: repository,
+              identity: yield* resolveRepositoryIdentity(repository),
+              threadnoteHome: clientHome,
+            }),
+          ).toMatchObject({imported: true, checkpointDigest: bootstrapped.checkpointDigest});
           const firstImport = yield* indexer.index({
             cwd: repository,
             ensureVectors: false,
@@ -96,6 +105,7 @@ describe('graph share TCG1 delta publication and apply', () => {
             '-qm',
             'advance',
           ]);
+          yield* git(repository, ['config', 'core.ignorecase', 'false']);
           yield* indexer.index({
             cwd: repository,
             ensureVectors: false,
@@ -115,6 +125,7 @@ describe('graph share TCG1 delta publication and apply', () => {
           expect(frontier.deltas).toHaveLength(1);
           expect(frontier.deltas[0]?.targetCommit).toBe(identity.headCommit);
           expect(frontier.sourceCommit).toBe(identity.headCommit);
+          yield* git(repository, ['config', 'core.ignorecase', 'true']);
           const clientApplied = yield* indexer.index({
             cwd: repository,
             ensureVectors: false,

--- a/test/unit/code-graph.checkpoint-projection.test.ts
+++ b/test/unit/code-graph.checkpoint-projection.test.ts
@@ -77,20 +77,22 @@ describe('code graph checkpoint projection', () => {
   it('parses exact NUL-framed Git tree metadata for both object formats', () => {
     const sha1 = 'a'.repeat(40);
     const sha256 = 'b'.repeat(64);
-    expect(parseGitTreeEntries(new TextEncoder().encode(`100644\tblob\t${sha1}\t12\tsrc/a file.ts\0`), 'sha1')).toEqual(
-      new Map([['src/a file.ts', {blobId: sha1, mode: '100644', path: 'src/a file.ts', size: 12}]]),
-    );
-    expect(parseGitTreeEntries(new TextEncoder().encode(`100755\tblob\t${sha256}\t7\tbin/tool\0`), 'sha256')).toEqual(
-      new Map([['bin/tool', {blobId: sha256, mode: '100755', path: 'bin/tool', size: 7}]]),
-    );
+    expect(
+      parseGitTreeEntries(new TextEncoder().encode(`100644 blob ${sha1}      12\tsrc/a file.ts\0`), 'sha1'),
+    ).toEqual(new Map([['src/a file.ts', {blobId: sha1, mode: '100644', path: 'src/a file.ts', size: 12}]]));
+    expect(
+      parseGitTreeEntries(new TextEncoder().encode(`100755 blob ${sha256}       7\tbin/tool\0`), 'sha256'),
+    ).toEqual(new Map([['bin/tool', {blobId: sha256, mode: '100755', path: 'bin/tool', size: 7}]]));
   });
 
   it('rejects missing terminators, non-blobs, unsafe paths, and wrong object widths', () => {
     const cases = [
-      `100644\tblob\t${'a'.repeat(40)}\t1\tsrc/a.ts`,
-      `100644\ttree\t${'a'.repeat(40)}\t1\tsrc/a.ts\0`,
-      `100644\tblob\t${'a'.repeat(40)}\t1\t../escape.ts\0`,
-      `100644\tblob\t${'a'.repeat(64)}\t1\tsrc/a.ts\0`,
+      `100644 blob ${'a'.repeat(40)}       1\tsrc/a.ts`,
+      `100644 tree ${'a'.repeat(40)}       1\tsrc/a.ts\0`,
+      `100644 blob ${'a'.repeat(40)}       1\t../escape.ts\0`,
+      `100644 blob ${'a'.repeat(64)}       1\tsrc/a.ts\0`,
+      `100644 blob ${'a'.repeat(40)}     1e2\tsrc/a.ts\0`,
+      `100644 blob ${'a'.repeat(40)}      0x1\tsrc/a.ts\0`,
     ];
     for (const value of cases) {
       expect(() => parseGitTreeEntries(new TextEncoder().encode(value), 'sha1')).toThrow(
@@ -98,6 +100,31 @@ describe('code graph checkpoint projection', () => {
       );
     }
   });
+
+  it.prop(
+    'preserves raw Unicode, quote and space characters in native Git tree paths',
+    {
+      names: FC.uniqueArray(
+        FC.array(FC.constantFrom('a', 'Z', '文', 'é', ' ', '"', "'"), {minLength: 1, maxLength: 20}).map(
+          chars => `src/${chars.join('')}.ts`,
+        ),
+        {minLength: 1, maxLength: 20},
+      ),
+      size: FC.integer({min: 0, max: 1_000_000}),
+    },
+    ({names, size}) => {
+      const blobId = 'a'.repeat(40);
+      const bytes = new TextEncoder().encode(
+        names.map(name => `100644 blob ${blobId} ${String(size).padStart(7)}\t${name}\0`).join(''),
+      );
+      const before = bytes.slice();
+      const entries = parseGitTreeEntries(bytes, 'sha1');
+      expect([...entries]).toEqual(names.map(path => [path, {blobId, mode: '100644', path, size}]));
+      expect(parseGitTreeEntries(bytes, 'sha1')).toEqual(entries);
+      expect(bytes).toEqual(before);
+    },
+    {fastCheck: {numRuns: 50}},
+  );
 });
 
 function argvPathBytes(paths: readonly string[]): number {

--- a/test/unit/code-graph.citation-primitives.test.ts
+++ b/test/unit/code-graph.citation-primitives.test.ts
@@ -752,7 +752,7 @@ function completeInventoryReuseReceipt(workspace = mergeCodeGraphWorkspaces([]))
     policyExclusions: {
       bytes: 0,
       files: 0,
-      policyVersion: 1 as const,
+      policyVersion: 2 as const,
       reasons: CODE_GRAPH_INVENTORY_EXCLUSION_REASONS.map(reason => ({bytes: 0, files: 0, reason})),
     },
     skipped: 0,

--- a/test/unit/code-graph.inventory-reuse.property.test.ts
+++ b/test/unit/code-graph.inventory-reuse.property.test.ts
@@ -63,7 +63,7 @@ describe('code graph inventory reuse receipts', () => {
         policyExclusions: {
           bytes: 0,
           files: 0,
-          policyVersion: 1,
+          policyVersion: 2,
           reasons: CODE_GRAPH_INVENTORY_EXCLUSION_REASONS.map(reason => ({bytes: 0, files: 0, reason})),
         },
         skipped,

--- a/test/unit/code-graph.ready-query-evidence.test.ts
+++ b/test/unit/code-graph.ready-query-evidence.test.ts
@@ -367,7 +367,7 @@ function validArtifact(): MutableReadyQueryEvidence {
     runner: 'dedicated-preprovisioned-linux-x64',
     runtime: {
       compatible: true,
-      extractorSet: 'native-code-graph-13',
+      extractorSet: 'native-code-graph-14',
       persistentExtensionRevision: CODE_GRAPH_PERSISTENT_EXTENSION_SCHEMA_REVISION,
       resultVersion: 1,
       schemaVersion: 3,
@@ -376,7 +376,7 @@ function validArtifact(): MutableReadyQueryEvidence {
       commit: READY_QUERY_REPOSITORY_COMMIT,
       dirty: false,
       edgeCount: 1,
-      extractorSet: 'native-code-graph-13',
+      extractorSet: 'native-code-graph-14',
       fileCount: READY_QUERY_MINIMUM_FILES,
       idSha256: SNAPSHOT_DIGEST,
       state: 'ready',


### PR DESCRIPTION
Checkpoints for the same Git repository and commit could be rejected when producer and receiver had different `core.ignorecase` settings. Ignore matching could also change the admitted graph, and custom Git tree formatting prevented Unicode checkpoint paths from exporting or importing correctly.

Use case-sensitive Git ignore matching with a new inventory policy and extractor generation, treat checkout case mode as producer metadata, and return receiver validation failures through the typed error channel. Read native NUL-framed Git tree metadata so Unicode, spaces and quotes retain their exact identities. Repository, ABI, source, integrity and clean-publication checks remain enforced; older inventory-policy checkpoints require a rebuild.

Validation: focused inventory/checkpoint/store/signed-delta regressions, 12 generated case-setting parity examples and 50 raw-path parser properties; lint, typecheck and formatting pass. Full four-lane dev-cycle review is clear, with the Windows fixture minor corrected. The exact installed commit passed a CLI smoke with 79 identical graph records across donor, imported copy and independent build; the original import digest, artifact bytes and checkout configuration were preserved. A Linux image built from the same clean commit also passed its isolated graph smoke. All 43 PR CI checks passed (22 intentionally skipped). A separate Linux publisher-to-Mac import matched all 176 graph records against an independent build, and a signed delta carried a new source function through the same case-setting boundary.
