### PR TITLE
Preserve remote memory metadata and clarify MCP startup failures

### DIFF
--- a/src/mcp/broker.ts
+++ b/src/mcp/broker.ts
@@ -6,10 +6,17 @@ const MCP_BROKER_REPLAY_TIMEOUT_MILLISECONDS = 10_000;
 const MCP_BROKER_CHILD_STOP_WAIT_MILLISECONDS = 1_000;
 const MCP_BROKER_RUNTIME_EXIT_ERROR =
   'Threadnote MCP runtime exited before responding. The request outcome is unknown; inspect state before retrying a mutating operation.';
+const MCP_BROKER_NO_ACTIVE_RELEASE_ERROR =
+  'No valid active Threadnote release is installed. Run "threadnote install --no-start" with the downloaded executable, then reconnect this client. This request was not sent to a runtime.';
+const MCP_BROKER_STARTUP_ERROR =
+  'Threadnote could not start or select an MCP runtime. Check the Threadnote installation and reconnect this client. This request was not sent to a runtime.';
+
+type McpBrokerStartupFailure = 'no-active-release' | 'startup-failed';
 
 export class McpBrokerError extends Schema.TaggedError<McpBrokerError>()('McpBrokerError', {
   cause: Schema.optionalKey(Schema.Defect()),
   message: Schema.String,
+  reason: Schema.optionalKey(Schema.Literal('no-active-release')),
 }) {}
 
 interface McpBrokerChildInput {
@@ -144,12 +151,18 @@ class McpBroker {
         trackedRequest = true;
       }
       await this.#writeChildLine(current.child, line);
-    } catch {
+    } catch (cause) {
       const pending = [...this.#clientRequests.values()];
       this.#clientRequests.clear();
-      if (requestId !== undefined && !trackedRequest) pending.push(requestId);
       await this.#stopCurrentChild();
       for (const id of pending) await this.#queueRequestFailure(id);
+      if (requestId !== undefined && !trackedRequest) {
+        const reason =
+          Schema.is(McpBrokerError)(cause) && cause.reason === 'no-active-release'
+            ? 'no-active-release'
+            : 'startup-failed';
+        await this.#queueRequestFailure(requestId, reason);
+      }
     }
   }
 
@@ -169,7 +182,7 @@ class McpBroker {
     const active = await this.#dependencies.readActiveRelease();
     if (active === undefined) {
       if (this.#child !== undefined) return this.#child;
-      throw McpBrokerError.make({message: 'Threadnote has no valid active standalone release for the MCP broker.'});
+      throw McpBrokerError.make({message: MCP_BROKER_NO_ACTIVE_RELEASE_ERROR, reason: 'no-active-release'});
     }
     if (
       this.#child !== undefined &&
@@ -373,10 +386,21 @@ class McpBroker {
     await this.#queueOutput(JSON.stringify({jsonrpc: '2.0', method: 'notifications/resources/list_changed'}));
   }
 
-  #queueRequestFailure(id: string | number): Promise<void> {
+  #queueRequestFailure(id: string | number, startupFailure?: McpBrokerStartupFailure): Promise<void> {
     return this.#queueOutput(
       JSON.stringify({
-        error: {code: -32_603, message: MCP_BROKER_RUNTIME_EXIT_ERROR},
+        error: {
+          code: -32_603,
+          message:
+            startupFailure === undefined
+              ? MCP_BROKER_RUNTIME_EXIT_ERROR
+              : startupFailure === 'no-active-release'
+                ? MCP_BROKER_NO_ACTIVE_RELEASE_ERROR
+                : MCP_BROKER_STARTUP_ERROR,
+          ...(startupFailure === undefined
+            ? {}
+            : {data: {reason: startupFailure, requestDisposition: 'not-dispatched'}}),
+        },
         id,
         jsonrpc: '2.0',
       }),

--- a/src/remote_memory/document_compatibility.ts
+++ b/src/remote_memory/document_compatibility.ts
@@ -1,41 +1,36 @@
-import {assertMemoryDocumentSchemaWritable, parseMemoryDocument} from '../memory/document.js';
+import {assertMemoryDocumentSchemaWritable, formatMemoryDocument, parseMemoryDocument} from '../memory/document.js';
+import {memoryCodeCitationSharingBlocker} from '../memory/code_citation_policy.js';
 import {remoteMemoryError} from './errors.js';
-
-const BODY_REPLACEMENT_FIELDS = new Set([
-  'kind',
-  'status',
-  'project',
-  'topic',
-  'source_agent_client',
-  'timestamp',
-  'schema_version',
-  'memory_id',
-  'created_at',
-  'updated_at',
-  'visibility',
-]);
 
 export function assertRemoteBodyReplacementSupported(content: string): void {
   assertMemoryDocumentSchemaWritable(content);
   const normalized = content.trim().replace(/\r\n?/gu, '\n');
-  const header = normalized.split('\n\n', 1)[0];
-  const fields = header.split('\n').slice(1);
-  const seen = new Set<string>();
-  const unsupported = fields.some(line => {
-    const key = /^([a-z_]+):/u.exec(line)?.[1];
-    if (!key || !BODY_REPLACEMENT_FIELDS.has(key) || seen.has(key)) return true;
-    seen.add(key);
-    return false;
-  });
-  if (
-    unsupported ||
-    /\n\n<!-- MEMORY_FIELDS\n[\s\S]*?\n-->\s*$/u.test(normalized) ||
-    !parseMemoryDocument('threadnote://share/compatibility/memories/durable/project/topic.md', content)
-  ) {
-    throw remoteMemoryError(
-      'invalid_request',
-      'This document contains metadata the remote body editor cannot preserve. Edit it through the Git share until rich metadata editing is supported.',
-      {reason: 'unsupported_remote_metadata'},
-    );
+  if (/\n\n<!-- MEMORY_FIELDS\n[\s\S]*?\n-->\s*$/u.test(normalized)) unsupportedMetadata();
+  const record = parseMemoryDocument('threadnote://share/compatibility/memories/durable/project/topic.md', content);
+  if (!record) unsupportedMetadata();
+  if (memoryCodeCitationSharingBlocker(record.metadata)) unsupportedMetadata();
+  let formatted: string;
+  try {
+    formatted = formatMemoryDocument(record.headerTitle, record.metadata, '');
+  } catch {
+    unsupportedMetadata();
   }
+  const remaining = new Map<string, number>();
+  for (const line of formatted.split('\n\n', 1)[0].split('\n')) {
+    remaining.set(line, (remaining.get(line) ?? 0) + 1);
+  }
+  // Tolerant readers may discard unknown or malformed fields; a rewrite must preserve every occurrence.
+  for (const line of normalized.split('\n\n', 1)[0].split('\n')) {
+    const count = remaining.get(line) ?? 0;
+    if (count === 0) unsupportedMetadata();
+    remaining.set(line, count - 1);
+  }
+}
+
+function unsupportedMetadata(): never {
+  throw remoteMemoryError(
+    'invalid_request',
+    'This document contains metadata the remote body editor cannot preserve. Repair it through the Git share before editing remotely.',
+    {reason: 'unsupported_remote_metadata'},
+  );
 }

--- a/src/remote_memory/postgres_repository.ts
+++ b/src/remote_memory/postgres_repository.ts
@@ -1449,6 +1449,7 @@ function makeRemoteDocument(
   const prior = current && priorBody ? parseMemoryDocument(uri, priorBody) : undefined;
   if (current && priorBody) assertRemoteBodyReplacementSupported(priorBody);
   const metadata: MemoryMetadata = {
+    ...prior?.metadata,
     createdAt: prior?.metadata.createdAt ?? prior?.metadata.timestamp ?? timestamp,
     kind: input.kind,
     memoryId: prior?.metadata.memoryId ?? `tn_${randomUuidV4().replaceAll('-', '')}`,

--- a/test/helpers/remote-memory-document.ts
+++ b/test/helpers/remote-memory-document.ts
@@ -1,0 +1,54 @@
+import {createMemoryCodeCitation, MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
+import type {MemoryMetadata} from '../../src/memory/document.js';
+
+export function richRemoteMemoryMetadata(): MemoryMetadata {
+  const timestamp = '2026-09-01T10:00:00.000Z';
+  return {
+    archivedFrom: 'threadnote://memory/tn_previous',
+    authority: 'user_approved',
+    candidateId: 'candidate-1',
+    codeCitations: [
+      createMemoryCodeCitation({
+        extractorSet: 'native-code-graph-14',
+        fileContentHash: {algorithm: 'sha256', value: 'a'.repeat(64)},
+        path: 'src/example.ts',
+        repositoryId: '1'.repeat(64),
+        repositoryIdentityKind: 'remote',
+        sourceCommit: '2'.repeat(40),
+        sourceDirty: false,
+        sourceGraphContentId: `cgc_${'3'.repeat(40)}`,
+        sourceSnapshotId: `cgsn_${'4'.repeat(40)}`,
+        target: {kind: 'file'},
+        version: 1,
+      }),
+    ],
+    createdAt: timestamp,
+    evidence: ['session:turn-12', 'commit:abc123'],
+    kind: 'durable',
+    keywords: ['retained-keyword', 'second keyword', 'retained-keyword'],
+    lastReviewed: timestamp,
+    memoryId: 'tn_rich_memory',
+    project: 'restricted',
+    references: ['threadnote://memory/tn_first', 'threadnote://memory/tn_second'],
+    relations: [
+      {type: 'references', uri: 'threadnote://memory/tn_first'},
+      {type: 'depends_on', uri: 'threadnote://memory/tn_second'},
+    ],
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    sourceHash: 'sha256:abc123',
+    sourceAgentClient: 'codex',
+    sourceCommit: 'abc123',
+    sourceObservedAt: timestamp,
+    sourceSessionId: 'session-1',
+    status: 'active',
+    supersedes: 'threadnote://memory/tn_previous',
+    timestamp,
+    topic: 'rich',
+    trust: 'approved',
+    updatedAt: timestamp,
+    validFrom: timestamp,
+    validTo: '2027-09-01T10:00:00.000Z',
+    visibility: 'shared',
+    workspaceScope: 'packages/example',
+  };
+}

--- a/test/integration/remote-memory-git-authority.test.ts
+++ b/test/integration/remote-memory-git-authority.test.ts
@@ -7,6 +7,9 @@ import {GitCanonicalMemoryStore} from '../../src/remote_memory/git_canonical_sto
 import {PostgresRemoteControlPlane} from '../../src/remote_memory/postgres_control_plane.js';
 import {PostgresRemoteMemoryRepository} from '../../src/remote_memory/postgres_repository.js';
 import {RemoteMemoryIndexer} from '../../src/remote_memory/indexer.js';
+import {formatMemoryDocument, parseMemoryDocument} from '../../src/memory/document.js';
+import {richRemoteMemoryMetadata} from '../helpers/remote-memory-document.js';
+import {git} from '../helpers/git-share-worktree.js';
 
 const DATABASE = process.env.THREADNOTE_TEST_POSTGRES_URL;
 const postgresDescribe = DATABASE ? describe : describe.skip;
@@ -82,12 +85,12 @@ postgresDescribe('Git ingest system authority', () => {
     }
   });
 
-  it('rejects HTTP body replacement that would erase metadata from Git', async () => {
+  it('preserves rich Git metadata through CAS replacement, replay, and stale rejection', async () => {
     const f = await fixture();
     try {
       const path = 'durable/projects/restricted/rich.md';
-      const content =
-        'MEMORY\nkind: durable\nstatus: active\nproject: restricted\ntopic: rich\nkeywords: retained-keyword\n\nRetain the original body.';
+      const metadata = richRemoteMemoryMetadata();
+      const content = formatMemoryDocument('MEMORY', metadata, 'Retain the original body.');
       const committed = await f.store.commit({path, content, message: 'Rich Git memory'});
       await f.repository.ingestActiveGitShares('rich-ingest');
       const principal = await new PostgresRemoteControlPlane(f.database.sql).authorize(
@@ -97,29 +100,92 @@ postgresDescribe('Git ingest system authority', () => {
       if (!principal) throw new Error('Fixture principal missing');
       const uri = `threadnote://share/${f.input.shareId}/memories/durable/restricted/rich.md`;
       const original = await f.repository.read(principal, {version: 1, uri}, 'read-rich');
+      const input = {
+        version: 1 as const,
+        kind: 'durable' as const,
+        project: 'restricted',
+        topic: 'rich',
+        text: 'Changed body',
+        operationId: 'replace-rich',
+        baseRevision: original.receipt.revision,
+      };
+      const replaced = await f.repository.remember(principal, input, 'replace-rich');
+      const read = await f.repository.read(principal, {version: 1, uri}, 'read-replaced');
+      expect(read.receipt.revision).toBe(replaced.revision);
+      const parsed = parseMemoryDocument(uri, read.content);
+      expect(parsed?.body).toBe('Changed body');
+      expect(parsed?.metadata).toEqual({
+        ...metadata,
+        sourceAgentClient: 'remote',
+        timestamp: expect.any(String),
+        updatedAt: expect.any(String),
+      });
+      expect(parsed?.metadata.updatedAt).not.toBe(metadata.updatedAt);
+      const editedFields = /^(source_agent_client|timestamp|updated_at):/u;
+      const preservedLines = content
+        .split('\n\n', 1)[0]
+        .split('\n')
+        .filter(line => !editedFields.test(line));
+      expect(
+        read.content
+          .split('\n\n', 1)[0]
+          .split('\n')
+          .filter(line => !editedFields.test(line)),
+      ).toEqual(preservedLines);
+      expect(await git(['show', `HEAD:${path}`], f.git.remote)).toBe(read.content);
+      expect((await f.repository.remember(principal, input, 'replay-rich')).revision).toBe(replaced.revision);
       await expect(
-        f.repository.remember(
-          principal,
-          {
-            version: 1,
-            kind: 'durable',
-            project: 'restricted',
-            topic: 'rich',
-            text: 'Changed body',
-            operationId: 'replace-rich',
-            baseRevision: original.receipt.revision,
-          },
-          'replace-rich',
-        ),
-      ).rejects.toMatchObject({code: 'invalid_request', details: {reason: 'unsupported_remote_metadata'}});
-      expect((await f.store.listCanonicalPaths()).find(entry => entry.gitPath === path)?.gitCommit).toBe(
-        committed.gitCommit,
-      );
+        f.repository.remember(principal, {...input, operationId: 'stale-rich', text: 'Stale body'}, 'stale-rich'),
+      ).rejects.toMatchObject({code: 'conflict'});
+      expect((await f.repository.read(principal, {version: 1, uri}, 'read-after-stale')).content).toBe(read.content);
       expect(await f.store.read({commit: committed.gitCommit, path})).toBe(content);
     } finally {
       await f.dispose();
     }
   });
+
+  it.each(['x_extension: retained', 'code_citation: invalid', 'memory_id: tn_one\nmemory_id: tn_two'])(
+    'leaves Git and the revision unchanged when metadata cannot be preserved: %s',
+    async field => {
+      const f = await fixture();
+      try {
+        const path = 'durable/projects/restricted/unsupported.md';
+        const content = `MEMORY\nkind: durable\n${field}\n\nOriginal body`;
+        const committed = await f.store.commit({path, content, message: 'Unsupported metadata fixture'});
+        await f.repository.ingestActiveGitShares('unsupported-ingest');
+        const principal = await new PostgresRemoteControlPlane(f.database.sql).authorize(
+          {issuer: f.input.issuer, subject: f.input.subject, scopes: new Set(f.input.capabilities)},
+          f.input.shareId,
+        );
+        if (!principal) throw new Error('Fixture principal missing');
+        const uri = `threadnote://share/${f.input.shareId}/memories/durable/restricted/unsupported.md`;
+        const original = await f.repository.read(principal, {version: 1, uri}, 'read-unsupported');
+        await expect(
+          f.repository.remember(
+            principal,
+            {
+              version: 1,
+              kind: 'durable',
+              project: 'restricted',
+              topic: 'unsupported',
+              text: 'Changed body',
+              operationId: 'replace-unsupported',
+              baseRevision: original.receipt.revision,
+            },
+            'replace-unsupported',
+          ),
+        ).rejects.toMatchObject({code: 'invalid_request', details: {reason: 'unsupported_remote_metadata'}});
+        expect((await f.store.listCanonicalPaths()).find(entry => entry.gitPath === path)?.gitCommit).toBe(
+          committed.gitCommit,
+        );
+        const read = await f.repository.read(principal, {version: 1, uri}, 'read-after-rejection');
+        expect(read.content).toBe(original.content);
+        expect(read.receipt.revision).toBe(original.receipt.revision);
+      } finally {
+        await f.dispose();
+      }
+    },
+  );
 
   it('projects canonical Git independently of member order, scopes, and revocation', async () => {
     const f = await fixture();

--- a/test/unit/mcp-broker.test.ts
+++ b/test/unit/mcp-broker.test.ts
@@ -9,6 +9,104 @@ import {
 import type {StandaloneActiveRelease} from '../../src/process/standalone_lease.js';
 
 describe('MCP session broker', () => {
+  it('reports missing activation without dispatching any request or changing its id', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.oneof(fc.integer(), fc.string({maxLength: 40})), async id => {
+        const clientInput = new AsyncByteQueue();
+        const clientOutput = new AsyncByteQueue();
+        let spawned = 0;
+        const running = runMcpBroker({
+          input: clientInput,
+          readActiveRelease: async () => undefined,
+          spawn: () => {
+            spawned += 1;
+            throw new Error('Unexpected spawn');
+          },
+          writeOutput: async line => clientOutput.pushLine(line),
+        });
+        clientInput.pushLine(
+          JSON.stringify({id, jsonrpc: '2.0', method: 'tools/call', params: {name: 'remember_context'}}),
+        );
+        const failure = JSON.parse(await clientOutput.nextLine());
+        clientInput.end();
+        await running;
+        expect(failure).toMatchObject({
+          id,
+          error: {code: -32_603, data: {reason: 'no-active-release', requestDisposition: 'not-dispatched'}},
+        });
+        expect(failure.error.message).toContain('threadnote install --no-start');
+        expect(failure.error.message).not.toContain('outcome is unknown');
+        expect(spawned).toBe(0);
+        expect(clientOutput.availableLines()).toBe(0);
+      }),
+      {numRuns: 50},
+    );
+  });
+
+  it('recovers on the same transport after activation without replaying rejected work', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    let active: StandaloneActiveRelease | undefined;
+    const child = new FakeMcpChild('activated');
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => active,
+      spawn: () => child,
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(JSON.parse(await clientOutput.nextLine()).error.data.reason).toBe('no-active-release');
+    active = {releaseRoot: '/threadnote/versions/activated', version: 'activated'};
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({
+      id: 2,
+      result: {serverInfo: {version: 'activated'}},
+    });
+    active = undefined;
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({id: 3, result: {version: 'activated'}});
+    expect(child.received.map(line => JSON.parse(line).id)).toEqual([2, 3]);
+    clientInput.end();
+    await running;
+  });
+
+  it('keeps an outstanding mutation uncertain when a later request fails before dispatch', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const release = {releaseRoot: '/threadnote/versions/private-release', version: 'private-version'};
+    const child = new FakeMcpChild(release.version, {respondToTools: false});
+    let failRead = false;
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => {
+        if (failRead) throw new Error('Private lookup failure /Users/private/token');
+        return release;
+      },
+      spawn: () => child,
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(
+      JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'remember_context'}}),
+    );
+    await child.receivedCount(2);
+    failRead = true;
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/list'}));
+    const mutation = JSON.parse(await clientOutput.nextLine());
+    const lookup = JSON.parse(await clientOutput.nextLine());
+    clientInput.end();
+    await running;
+    expect(mutation).toMatchObject({id: 2, error: {message: expect.stringContaining('outcome is unknown')}});
+    expect(mutation.error.data).toBeUndefined();
+    expect(lookup).toMatchObject({
+      id: 3,
+      error: {data: {reason: 'startup-failed', requestDisposition: 'not-dispatched'}},
+    });
+    expect(JSON.stringify(lookup)).not.toContain('private');
+    expect(child.received).toHaveLength(2);
+  });
+
   it('reports a closed spawn failure without allowing the observer to alter recovery', async () => {
     const clientInput = new AsyncByteQueue();
     const clientOutput = new AsyncByteQueue();
@@ -28,7 +126,12 @@ describe('MCP session broker', () => {
     });
 
     clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
-    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({error: {code: -32_603}, id: 1});
+    const failure = JSON.parse(await clientOutput.nextLine());
+    expect(failure).toMatchObject({
+      error: {code: -32_603, data: {reason: 'startup-failed', requestDisposition: 'not-dispatched'}},
+      id: 1,
+    });
+    expect(JSON.stringify(failure)).not.toContain('private');
     clientInput.end();
     await running;
 

--- a/test/unit/remote-memory-document-compatibility.test.ts
+++ b/test/unit/remote-memory-document-compatibility.test.ts
@@ -1,6 +1,9 @@
 import {describe, expect, it} from 'vitest';
 import * as FC from 'effect/testing/FastCheck';
 import {assertRemoteBodyReplacementSupported} from '../../src/remote_memory/document_compatibility.js';
+import {formatMemoryDocument} from '../../src/memory/document.js';
+import {richRemoteMemoryMetadata} from '../helpers/remote-memory-document.js';
+import {createMemoryCodeCitation} from '../../src/memory/code_citation.js';
 
 describe('remote body replacement compatibility', () => {
   it('rejects unknown header fields without consuming or rewriting them', () => {
@@ -17,19 +20,47 @@ describe('remote body replacement compatibility', () => {
     );
   });
 
-  it('supports basic remote documents and rejects rich or malformed local ones', () => {
+  it('supports basic and rich documents without changing the source metadata', () => {
     expect(() =>
       assertRemoteBodyReplacementSupported('MEMORY\nkind: durable\n\nThe documentation mentions `<!-- MEMORY_FIELDS`.'),
     ).not.toThrow();
     expect(() =>
       assertRemoteBodyReplacementSupported('MEMORY\nkind: durable\nstatus: active\nmemory_id: tn_123\n\nBody'),
     ).not.toThrow();
+    const metadata = richRemoteMemoryMetadata();
+    const before = structuredClone(metadata);
+    const document = formatMemoryDocument('MEMORY', metadata, 'Original body');
+    for (const newline of ['\n', '\r\n', '\r']) {
+      expect(() => assertRemoteBodyReplacementSupported(document.replaceAll('\n', newline))).not.toThrow();
+    }
+    expect(metadata).toEqual(before);
+  });
+
+  it('accepts repeated list metadata including duplicate values', () => {
+    FC.assert(
+      FC.property(
+        FC.array(FC.stringMatching(/^[a-z][a-z0-9 -]{0,30}[a-z]$/u), {minLength: 1, maxLength: 20}),
+        keywords => {
+          const metadata = {...richRemoteMemoryMetadata(), keywords: [...keywords, ...keywords]};
+          const document = formatMemoryDocument('MEMORY', metadata, 'Original body');
+          expect(() => assertRemoteBodyReplacementSupported(document)).not.toThrow();
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  it('rejects metadata that tolerant parsing would discard or change', () => {
     for (const field of [
       'code_citation: invalid',
-      'relation: references threadnote://memory/tn_123',
-      'keywords: important',
-      'trust: approved',
-      'workspace_scope: src',
+      'relation: invalid threadnote://memory/tn_123',
+      'keywords:',
+      'trust: invented',
+      'status: invented',
+      'status: active\nstatus: active',
+      'memory_id: tn_first\nmemory_id: tn_second',
+      'workspace_scope:  src',
+      'schema_version: 999',
       'this header is malformed',
     ]) {
       expect(() => assertRemoteBodyReplacementSupported(`MEMORY\nkind: durable\n${field}\n\nBody`)).toThrow();
@@ -40,5 +71,17 @@ describe('remote body replacement compatibility', () => {
         'MEMORY\nkind: durable\n\nBody\n\n<!-- MEMORY_FIELDS\nreferences: legacy\n-->',
       ),
     ).toThrow();
+  });
+
+  it('rejects citations that cannot cross the sharing boundary', () => {
+    const metadata = richRemoteMemoryMetadata();
+    const {id: _id, ...citation} = metadata.codeCitations![0];
+    for (const unsafe of [
+      createMemoryCodeCitation({...citation, sourceDirty: true}),
+      createMemoryCodeCitation({...citation, repositoryIdentityKind: 'local'}),
+    ]) {
+      const document = formatMemoryDocument('MEMORY', {...metadata, codeCitations: [unsafe]}, 'Original body');
+      expect(() => assertRemoteBodyReplacementSupported(document)).toThrow('metadata');
+    }
   });
 });


### PR DESCRIPTION
Remote agents can now update memories published by local clients without losing supported metadata. Repeated keywords, references, typed relations, immutable code citations, and provenance survive body edits. A lossless header check rejects unknown/malformed metadata and duplicate singleton fields before Git changes; citations still obey sharing policy.

MCP startup from an unactivated release now explains the supported installation command and reports that the request was not dispatched. Other startup failures use closed diagnostics without exposing private exception details. Requests already sent to a runtime retain outcome-unknown handling, and rejected work is never automatically replayed.

Validation:

- Separate four-lane dev-cycle reviews for both changes, with zero findings.
- 20 document/compatibility tests and 35 PostgreSQL/Git integration cases, including metadata, CAS/replay/stale, Git persistence and rejection checks.
- 20 broker/telemetry tests, including a 50-case identity/no-dispatch property and activation recovery.
- Source and exact installed-runtime HTTP/Git smoke; isolated stdio startup smoke.
- Lint, typecheck and commit hooks pass. Full suite runs in CI on the combined head.
