### PR TITLE
Verify checkpoint receiver admission before activation

### DIFF
--- a/src/code_graph/checkpoint/commands.ts
+++ b/src/code_graph/checkpoint/commands.ts
@@ -47,6 +47,7 @@ import {
   type CodeGraphCheckpointSha256,
 } from './schema.js';
 import {checkpointTerminalText} from './terminal_text.js';
+import {prepareCodeGraphCheckpointReceiverAdmission} from './receiver_admission.js';
 
 const CHECKPOINT_IO_CHUNK_BYTES = 64 * 1_024;
 const CHECKPOINT_GIT_OUTPUT_BYTES_MAXIMUM = 16 * 1_024 * 1_024;
@@ -266,23 +267,40 @@ export const importCodeGraphCheckpointSnapshot = Effect.fn('codeGraph.checkpoint
       const inspection = yield* inspectCheckpointInput(input, options);
       yield* attemptCheckpoint(() => validateCheckpointReceiver(inspection.header, identity, registry));
       yield* requireCheckpointCommit(identity, inspection.header.source.commit);
-      const attribution = checkpointAttributionRecordVerifier(inspection.header);
-      yield* withCodeGraphCheckpointAuthorityVerification(inspection.header, accept =>
-        decodeCheckpointInput(input, inspection, chunk =>
-          verifyCheckpointFiles(identity, inspection.header.source.commit, chunk).pipe(
-            Effect.andThen(attribution.accept(chunk)),
-            Effect.andThen(accept(chunk.records)),
+      const admission = yield* prepareCodeGraphCheckpointReceiverAdmission(identity, inspection.header, registry).pipe(
+        Effect.mapError(cause =>
+          checkpointCommandError(
+            'Checkpoint receiver admission could not be verified. Run `threadnote graph index` locally.',
+            cause,
           ),
         ),
       );
+      const attribution = checkpointAttributionRecordVerifier(inspection.header);
+      yield* withCodeGraphCheckpointAuthorityVerification(inspection.header, accept =>
+        decodeCheckpointInput(input, inspection, chunk =>
+          Effect.gen(function* () {
+            for (const record of chunk.records) {
+              if (record.kind === 'file') admission.files.accept(record);
+            }
+            yield* verifyCheckpointFiles(identity, inspection.header.source.commit, chunk);
+          }).pipe(Effect.andThen(attribution.accept(chunk)), Effect.andThen(accept(chunk.records))),
+        ),
+      );
       yield* attribution.finish;
-      return {input, inspection};
+      if (!admission.files.complete) {
+        return yield* checkpointFailure(
+          'Checkpoint file set does not match receiver admission. Run `threadnote graph index` locally.',
+        );
+      }
+      yield* admission.verifyEnvironment;
+      return {input, inspection, admission};
     }),
   );
   const receipt = checkpointImportReceipt(validated.inspection, options.expectedDigest !== undefined);
   const reusableBaseReceipt = yield* hydrateCodeGraphCheckpointReusableBaseReceipt(
     identity,
     validated.inspection.header,
+    validated.admission,
   );
   const snapshotId = checkpointSnapshotId(validated.inspection.header);
   const building = checkpointBuildingSnapshot(snapshotId, identity, validated.inspection.header);
@@ -308,6 +326,7 @@ export const importCodeGraphCheckpointSnapshot = Effect.fn('codeGraph.checkpoint
     () => Effect.void,
     'checkpoint-import',
     Effect.gen(function* () {
+      yield* validated.admission.verifyEnvironment;
       const reusable = yield* store.readySnapshotByLogicalDigest(
         layout.databasePath,
         identity.repositoryId,
@@ -401,6 +420,7 @@ export const importCodeGraphCheckpointSnapshot = Effect.fn('codeGraph.checkpoint
             ) {
               return {snapshotId: snapshot.id, state: 'stored' as const};
             }
+            yield* validated.admission.verifyEnvironment;
             yield* store.promote(databasePath, finalIdentity, snapshot.id, {persistentCapacityProtector});
             return {snapshotId: snapshot.id, state: 'activated' as const};
           }),

--- a/src/code_graph/checkpoint/import_reuse.ts
+++ b/src/code_graph/checkpoint/import_reuse.ts
@@ -1,11 +1,10 @@
-import {Effect, FileSystem, Path, Schema} from 'effect';
+import {Effect, Schema} from 'effect';
 import {runBinaryCommandEffect} from '../../effect/command.js';
 import {SystemInfo} from '../../effect/system.js';
 import {codeGraphCommittedContentHash} from '../content_identity.js';
 import {codeGraphUtf8ByteLength} from '../disk_capacity.js';
 import {appearsBinary, decodeUtf8} from '../inventory_content.js';
 import {retainResolutionContext} from '../inventory_content.js';
-import {readCodeGraphInventoryReuseEnvironment} from '../inventory_reuse.js';
 import {parseGitCatFileBatch} from '../inventory.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../languages/registry.js';
 import {
@@ -74,7 +73,11 @@ function attributionBatches(
  */
 export const hydrateCodeGraphCheckpointReusableBaseReceipt = Effect.fn(
   'codeGraph.hydrateCheckpointReusableBaseReceipt',
-)(function* (identity: RepositoryIdentity, header: CodeGraphCheckpointHeaderV1) {
+)(function* (
+  identity: RepositoryIdentity,
+  header: CodeGraphCheckpointHeaderV1,
+  receiverAdmission: {readonly environmentFingerprint: string},
+) {
   const reuse = header.reuse;
   if (reuse === undefined) return undefined;
   if (
@@ -116,12 +119,7 @@ export const hydrateCodeGraphCheckpointReusableBaseReceipt = Effect.fn(
   ) {
     return yield* hydrationError('Checkpoint attribution context exceeds the local reuse boundary.');
   }
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
   const system = yield* SystemInfo;
-  const environment = yield* readCodeGraphInventoryReuseEnvironment(identity, fs, path).pipe(
-    Effect.mapError(cause => hydrationError('Checkpoint reuse environment could not be inspected.', cause)),
-  );
   const attributionFiles: CodeGraphAttributionContextFile[] = [];
   for (const batch of attributionBatches(portable.attributionFiles)) {
     const result = yield* runBinaryCommandEffect('git', ['-C', identity.repoRoot, 'cat-file', '--batch'], {
@@ -184,7 +182,7 @@ export const hydrateCodeGraphCheckpointReusableBaseReceipt = Effect.fn(
       attributionFiles,
       contract: portable.contract,
       diagnostics: portable.diagnostics ?? [],
-      environmentFingerprint: environment.fingerprint,
+      environmentFingerprint: receiverAdmission.environmentFingerprint,
       includeOpaqueCorpusAssets: portable.includeOpaqueCorpusAssets,
       policyExclusions: {
         ...portable.policyExclusions,

--- a/src/code_graph/checkpoint/receiver_admission.ts
+++ b/src/code_graph/checkpoint/receiver_admission.ts
@@ -1,0 +1,111 @@
+import {Effect, FileSystem, Path, Schema} from 'effect';
+import {CommandExecutor, type CommandOptions} from '../../effect/command.js';
+import {SystemInfo} from '../../effect/system.js';
+import {inventoryRepository} from '../inventory.js';
+import {readCodeGraphInventoryReuseEnvironment} from '../inventory_reuse.js';
+import type {CodeGraphLanguagePackRegistryShape} from '../languages/registry.js';
+import {isOpaqueCorpusMediaPath} from '../languages/corpus/policy.js';
+import type {CodeGraphInventoryFile, RepositoryIdentity} from '../types.js';
+import type {CodeGraphCheckpointFileRecordV1, CodeGraphCheckpointHeaderV1} from './schema.js';
+
+export class CodeGraphCheckpointReceiverAdmissionError extends Schema.TaggedError<CodeGraphCheckpointReceiverAdmissionError>()(
+  'CodeGraphCheckpointReceiverAdmissionError',
+  {message: Schema.String},
+) {}
+
+type FileIdentity = Pick<CodeGraphInventoryFile, 'path' | 'blobId' | 'contentHash' | 'language' | 'mode'>;
+
+/** Compare the complete input sets, including receiver-admitted files absent from the donor. */
+export class CodeGraphCheckpointReceiverFileVerifier {
+  readonly #remaining: Map<string, FileIdentity>;
+  #valid = true;
+  #acceptedOpaque = false;
+  readonly #allowStructuralOnly: boolean;
+
+  constructor(files: readonly FileIdentity[], options?: {readonly allowStructuralOnly?: boolean}) {
+    this.#remaining = new Map(files.map(file => [file.path, file]));
+    this.#allowStructuralOnly = options?.allowStructuralOnly === true;
+  }
+
+  accept(file: CodeGraphCheckpointFileRecordV1): boolean {
+    const expected = this.#remaining.get(file.path);
+    if (
+      expected === undefined ||
+      file.blobId !== expected.blobId ||
+      file.contentHash !== expected.contentHash ||
+      file.language !== expected.language ||
+      file.mode !== expected.mode
+    ) {
+      this.#valid = false;
+      return false;
+    }
+    this.#remaining.delete(file.path);
+    if (isOpaqueCorpusMediaPath(file.path)) this.#acceptedOpaque = true;
+    return true;
+  }
+
+  get complete(): boolean {
+    return (
+      this.#valid &&
+      (this.#remaining.size === 0 ||
+        (this.#allowStructuralOnly &&
+          !this.#acceptedOpaque &&
+          [...this.#remaining.keys()].every(isOpaqueCorpusMediaPath)))
+    );
+  }
+}
+
+export const prepareCodeGraphCheckpointReceiverAdmission = Effect.fn('codeGraph.prepareCheckpointReceiverAdmission')(
+  function* (
+    identity: RepositoryIdentity,
+    header: CodeGraphCheckpointHeaderV1,
+    languagePacks: CodeGraphLanguagePackRegistryShape,
+  ) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
+    const command = yield* CommandExecutor;
+    const environment = yield* readCodeGraphInventoryReuseEnvironment(identity, fs, path);
+    const localOptions = (options?: CommandOptions): CommandOptions => ({
+      ...options,
+      env: {...system.environment(), ...options?.env, GIT_NO_LAZY_FETCH: '1', GIT_OPTIONAL_LOCKS: '0'},
+    });
+    const inventory = yield* inventoryRepository(
+      {...identity, headCommit: header.source.commit},
+      {
+        includeOverlay: false,
+        includeOpaqueCorpusAssets: header.reuse?.inventory?.includeOpaqueCorpusAssets,
+        languagePacks,
+        onContentBatch: () => Effect.void,
+      },
+    ).pipe(
+      Effect.provideService(CommandExecutor, {
+        ...command,
+        execute: (executable, args, options) => command.execute(executable, args, localOptions(options)),
+        ...(command.executeBytes === undefined
+          ? {}
+          : {
+              executeBytes: (executable, args, options) =>
+                command.executeBytes!(executable, args, localOptions(options)),
+            }),
+      }),
+    );
+    const verifyEnvironment = Effect.gen(function* () {
+      const closing = yield* readCodeGraphInventoryReuseEnvironment(identity, fs, path);
+      if (closing.fingerprint !== environment.fingerprint) {
+        return yield* CodeGraphCheckpointReceiverAdmissionError.make({
+          message:
+            'Checkpoint receiver admission policy changed during import. Retry or run `threadnote graph index` locally.',
+        });
+      }
+    });
+    yield* verifyEnvironment;
+    return {
+      environmentFingerprint: environment.fingerprint,
+      files: new CodeGraphCheckpointReceiverFileVerifier(inventory.files, {
+        allowStructuralOnly: header.reuse?.inventory === undefined,
+      }),
+      verifyEnvironment,
+    };
+  },
+);

--- a/src/code_graph/inventory_reuse.ts
+++ b/src/code_graph/inventory_reuse.ts
@@ -1,6 +1,7 @@
 import {Effect, FileSystem, Path, Predicate} from 'effect';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {runCommandEffect} from '../effect/command.js';
+import {SystemInfo} from '../effect/system.js';
 import {readOptionalText} from './inventory_contained_file.js';
 import {CodeGraphInventoryError} from './inventory_error.js';
 import {
@@ -84,7 +85,16 @@ export const readCodeGraphInventoryReuseEnvironment = Effect.fn('codeGraph.readI
   const gitInfoExcludePath = path.isAbsolute(observedGitInfoExcludePath)
     ? observedGitInfoExcludePath
     : path.resolve(identity.repoRoot, observedGitInfoExcludePath);
-  const globalExcludePath = globalExcludeResult.stdout.trim();
+  const system = yield* SystemInfo;
+  const environment = system.environment();
+  const defaultGlobalExcludePath = path.join(
+    environment.XDG_CONFIG_HOME || path.join(environment.HOME || system.homeDirectory, '.config'),
+    'git',
+    'ignore',
+  );
+  // An explicitly empty config disables global excludes; only an absent key uses Git's default.
+  const globalExcludePath =
+    globalExcludeResult.exitCode === 1 ? defaultGlobalExcludePath : globalExcludeResult.stdout.trim();
   const [gitInfoExclude, globalExclude] = yield* Effect.all(
     [
       readOptionalText(fs, gitInfoExcludePath),

--- a/src/mcp/broker.ts
+++ b/src/mcp/broker.ts
@@ -6,10 +6,17 @@ const MCP_BROKER_REPLAY_TIMEOUT_MILLISECONDS = 10_000;
 const MCP_BROKER_CHILD_STOP_WAIT_MILLISECONDS = 1_000;
 const MCP_BROKER_RUNTIME_EXIT_ERROR =
   'Threadnote MCP runtime exited before responding. The request outcome is unknown; inspect state before retrying a mutating operation.';
+const MCP_BROKER_NO_ACTIVE_RELEASE_ERROR =
+  'No valid active Threadnote release is installed. Run "threadnote install --no-start" with the downloaded executable, then reconnect this client. This request was not sent to a runtime.';
+const MCP_BROKER_STARTUP_ERROR =
+  'Threadnote could not start or select an MCP runtime. Check the Threadnote installation and reconnect this client. This request was not sent to a runtime.';
+
+type McpBrokerStartupFailure = 'no-active-release' | 'startup-failed';
 
 export class McpBrokerError extends Schema.TaggedError<McpBrokerError>()('McpBrokerError', {
   cause: Schema.optionalKey(Schema.Defect()),
   message: Schema.String,
+  reason: Schema.optionalKey(Schema.Literal('no-active-release')),
 }) {}
 
 interface McpBrokerChildInput {
@@ -144,12 +151,18 @@ class McpBroker {
         trackedRequest = true;
       }
       await this.#writeChildLine(current.child, line);
-    } catch {
+    } catch (cause) {
       const pending = [...this.#clientRequests.values()];
       this.#clientRequests.clear();
-      if (requestId !== undefined && !trackedRequest) pending.push(requestId);
       await this.#stopCurrentChild();
       for (const id of pending) await this.#queueRequestFailure(id);
+      if (requestId !== undefined && !trackedRequest) {
+        const reason =
+          Schema.is(McpBrokerError)(cause) && cause.reason === 'no-active-release'
+            ? 'no-active-release'
+            : 'startup-failed';
+        await this.#queueRequestFailure(requestId, reason);
+      }
     }
   }
 
@@ -169,7 +182,7 @@ class McpBroker {
     const active = await this.#dependencies.readActiveRelease();
     if (active === undefined) {
       if (this.#child !== undefined) return this.#child;
-      throw McpBrokerError.make({message: 'Threadnote has no valid active standalone release for the MCP broker.'});
+      throw McpBrokerError.make({message: MCP_BROKER_NO_ACTIVE_RELEASE_ERROR, reason: 'no-active-release'});
     }
     if (
       this.#child !== undefined &&
@@ -373,10 +386,21 @@ class McpBroker {
     await this.#queueOutput(JSON.stringify({jsonrpc: '2.0', method: 'notifications/resources/list_changed'}));
   }
 
-  #queueRequestFailure(id: string | number): Promise<void> {
+  #queueRequestFailure(id: string | number, startupFailure?: McpBrokerStartupFailure): Promise<void> {
     return this.#queueOutput(
       JSON.stringify({
-        error: {code: -32_603, message: MCP_BROKER_RUNTIME_EXIT_ERROR},
+        error: {
+          code: -32_603,
+          message:
+            startupFailure === undefined
+              ? MCP_BROKER_RUNTIME_EXIT_ERROR
+              : startupFailure === 'no-active-release'
+                ? MCP_BROKER_NO_ACTIVE_RELEASE_ERROR
+                : MCP_BROKER_STARTUP_ERROR,
+          ...(startupFailure === undefined
+            ? {}
+            : {data: {reason: startupFailure, requestDisposition: 'not-dispatched'}}),
+        },
         id,
         jsonrpc: '2.0',
       }),

--- a/src/remote_memory/document_compatibility.ts
+++ b/src/remote_memory/document_compatibility.ts
@@ -1,41 +1,36 @@
-import {assertMemoryDocumentSchemaWritable, parseMemoryDocument} from '../memory/document.js';
+import {assertMemoryDocumentSchemaWritable, formatMemoryDocument, parseMemoryDocument} from '../memory/document.js';
+import {memoryCodeCitationSharingBlocker} from '../memory/code_citation_policy.js';
 import {remoteMemoryError} from './errors.js';
-
-const BODY_REPLACEMENT_FIELDS = new Set([
-  'kind',
-  'status',
-  'project',
-  'topic',
-  'source_agent_client',
-  'timestamp',
-  'schema_version',
-  'memory_id',
-  'created_at',
-  'updated_at',
-  'visibility',
-]);
 
 export function assertRemoteBodyReplacementSupported(content: string): void {
   assertMemoryDocumentSchemaWritable(content);
   const normalized = content.trim().replace(/\r\n?/gu, '\n');
-  const header = normalized.split('\n\n', 1)[0];
-  const fields = header.split('\n').slice(1);
-  const seen = new Set<string>();
-  const unsupported = fields.some(line => {
-    const key = /^([a-z_]+):/u.exec(line)?.[1];
-    if (!key || !BODY_REPLACEMENT_FIELDS.has(key) || seen.has(key)) return true;
-    seen.add(key);
-    return false;
-  });
-  if (
-    unsupported ||
-    /\n\n<!-- MEMORY_FIELDS\n[\s\S]*?\n-->\s*$/u.test(normalized) ||
-    !parseMemoryDocument('threadnote://share/compatibility/memories/durable/project/topic.md', content)
-  ) {
-    throw remoteMemoryError(
-      'invalid_request',
-      'This document contains metadata the remote body editor cannot preserve. Edit it through the Git share until rich metadata editing is supported.',
-      {reason: 'unsupported_remote_metadata'},
-    );
+  if (/\n\n<!-- MEMORY_FIELDS\n[\s\S]*?\n-->\s*$/u.test(normalized)) unsupportedMetadata();
+  const record = parseMemoryDocument('threadnote://share/compatibility/memories/durable/project/topic.md', content);
+  if (!record) unsupportedMetadata();
+  if (memoryCodeCitationSharingBlocker(record.metadata)) unsupportedMetadata();
+  let formatted: string;
+  try {
+    formatted = formatMemoryDocument(record.headerTitle, record.metadata, '');
+  } catch {
+    unsupportedMetadata();
   }
+  const remaining = new Map<string, number>();
+  for (const line of formatted.split('\n\n', 1)[0].split('\n')) {
+    remaining.set(line, (remaining.get(line) ?? 0) + 1);
+  }
+  // Tolerant readers may discard unknown or malformed fields; a rewrite must preserve every occurrence.
+  for (const line of normalized.split('\n\n', 1)[0].split('\n')) {
+    const count = remaining.get(line) ?? 0;
+    if (count === 0) unsupportedMetadata();
+    remaining.set(line, count - 1);
+  }
+}
+
+function unsupportedMetadata(): never {
+  throw remoteMemoryError(
+    'invalid_request',
+    'This document contains metadata the remote body editor cannot preserve. Repair it through the Git share before editing remotely.',
+    {reason: 'unsupported_remote_metadata'},
+  );
 }

--- a/src/remote_memory/postgres_repository.ts
+++ b/src/remote_memory/postgres_repository.ts
@@ -1449,6 +1449,7 @@ function makeRemoteDocument(
   const prior = current && priorBody ? parseMemoryDocument(uri, priorBody) : undefined;
   if (current && priorBody) assertRemoteBodyReplacementSupported(priorBody);
   const metadata: MemoryMetadata = {
+    ...prior?.metadata,
     createdAt: prior?.metadata.createdAt ?? prior?.metadata.timestamp ?? timestamp,
     kind: input.kind,
     memoryId: prior?.metadata.memoryId ?? `tn_${randomUuidV4().replaceAll('-', '')}`,

--- a/test/helpers/remote-memory-document.ts
+++ b/test/helpers/remote-memory-document.ts
@@ -1,0 +1,54 @@
+import {createMemoryCodeCitation, MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
+import type {MemoryMetadata} from '../../src/memory/document.js';
+
+export function richRemoteMemoryMetadata(): MemoryMetadata {
+  const timestamp = '2026-09-01T10:00:00.000Z';
+  return {
+    archivedFrom: 'threadnote://memory/tn_previous',
+    authority: 'user_approved',
+    candidateId: 'candidate-1',
+    codeCitations: [
+      createMemoryCodeCitation({
+        extractorSet: 'native-code-graph-14',
+        fileContentHash: {algorithm: 'sha256', value: 'a'.repeat(64)},
+        path: 'src/example.ts',
+        repositoryId: '1'.repeat(64),
+        repositoryIdentityKind: 'remote',
+        sourceCommit: '2'.repeat(40),
+        sourceDirty: false,
+        sourceGraphContentId: `cgc_${'3'.repeat(40)}`,
+        sourceSnapshotId: `cgsn_${'4'.repeat(40)}`,
+        target: {kind: 'file'},
+        version: 1,
+      }),
+    ],
+    createdAt: timestamp,
+    evidence: ['session:turn-12', 'commit:abc123'],
+    kind: 'durable',
+    keywords: ['retained-keyword', 'second keyword', 'retained-keyword'],
+    lastReviewed: timestamp,
+    memoryId: 'tn_rich_memory',
+    project: 'restricted',
+    references: ['threadnote://memory/tn_first', 'threadnote://memory/tn_second'],
+    relations: [
+      {type: 'references', uri: 'threadnote://memory/tn_first'},
+      {type: 'depends_on', uri: 'threadnote://memory/tn_second'},
+    ],
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    sourceHash: 'sha256:abc123',
+    sourceAgentClient: 'codex',
+    sourceCommit: 'abc123',
+    sourceObservedAt: timestamp,
+    sourceSessionId: 'session-1',
+    status: 'active',
+    supersedes: 'threadnote://memory/tn_previous',
+    timestamp,
+    topic: 'rich',
+    trust: 'approved',
+    updatedAt: timestamp,
+    validFrom: timestamp,
+    validTo: '2027-09-01T10:00:00.000Z',
+    visibility: 'shared',
+    workspaceScope: 'packages/example',
+  };
+}

--- a/test/integration/code-graph.checkpoint-admission.test.ts
+++ b/test/integration/code-graph.checkpoint-admission.test.ts
@@ -1,0 +1,155 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Path, Schema} from 'effect';
+import {TestClock} from 'effect/testing';
+import {
+  importCodeGraphCheckpointSnapshot,
+  CodeGraphCheckpointCommandError,
+  runCodeGraphCheckpointExport,
+} from '../../src/code_graph/checkpoint/commands.js';
+import {
+  decodeCodeGraphCheckpointPackV1,
+  encodeCodeGraphCheckpointPackV1,
+} from '../../src/code_graph/checkpoint/pack.js';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('checkpoint receiver admission', () => {
+  it.effect(
+    'rejects both stricter and looser receiver inventories without replacing ready state',
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const command = yield* CommandExecutor;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-checkpoint-admission-'});
+        const repo = path.join(root, 'repository');
+        yield* fs.makeDirectory(path.join(repo, 'src'), {recursive: true});
+        yield* fs.writeFileString(path.join(repo, 'package.json'), '{"name":"checkpoint-admission","type":"module"}\n');
+        yield* fs.writeFileString(path.join(repo, 'src/included.ts'), 'export const included = 1;\n');
+        yield* fs.writeFileString(path.join(repo, 'src/excluded.ts'), 'export const excluded = 2;\n');
+        yield* fs.makeDirectory(path.join(repo, 'assets'));
+        yield* fs.writeFile(path.join(repo, 'assets/icon.png'), new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]));
+        yield* git(repo, ['init', '-q', '--initial-branch=main']);
+        yield* git(repo, ['remote', 'add', 'origin', 'https://github.com/acme/checkpoint-admission.git']);
+        yield* git(repo, ['add', '.']);
+        yield* git(repo, ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']);
+        const exclude = path.join(repo, '.git/info/exclude');
+        for (const donorExcludes of [false, true]) {
+          const donorHome = path.join(root, `donor-${donorExcludes}`);
+          const receiverHome = path.join(root, `receiver-${donorExcludes}`);
+          const artifact = path.join(root, `checkpoint-${donorExcludes}.cgcp`);
+          yield* fs.writeFileString(exclude, donorExcludes ? 'src/excluded.ts\n' : '');
+          const donor = yield* indexer.index({cwd: repo, threadnoteHome: donorHome, ensureVectors: false});
+          yield* runCodeGraphCheckpointExport(config(donorHome), {cwd: repo, output: artifact, quiet: true});
+          const bytes = yield* fs.readFile(artifact);
+          const decoded = decodeCodeGraphCheckpointPackV1(bytes);
+          const withoutReuse = path.join(root, `without-reuse-${donorExcludes}.cgcp`);
+          yield* fs.writeFile(
+            withoutReuse,
+            encodeCodeGraphCheckpointPackV1(
+              {
+                abi: decoded.header.abi.input,
+                coverage: decoded.header.coverage,
+                repository: decoded.header.repository,
+                source: decoded.header.source,
+              },
+              decoded.records,
+            ).bytes,
+          );
+
+          yield* fs.writeFileString(exclude, donorExcludes ? '' : 'src/excluded.ts\n');
+          const receiver = yield* indexer.index({cwd: repo, threadnoteHome: receiverHome, ensureVectors: false});
+          const identity = yield* resolveRepositoryIdentity(repo);
+          const database = codeGraphLayout(path, receiverHome, identity.checkoutId, identity.worktreeId).databasePath;
+          for (const input of [artifact, withoutReuse]) {
+            const result = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {cwd: repo, input}).pipe(
+              Effect.result,
+            );
+            expect(result._tag).toBe('Failure');
+            if (result._tag === 'Failure') {
+              expect(result.failure).toMatchObject({
+                _tag: 'CodeGraphCheckpointCommandError',
+              });
+              expect(Schema.is(CodeGraphCheckpointCommandError)(result.failure)).toBe(true);
+              if (Schema.is(CodeGraphCheckpointCommandError)(result.failure)) {
+                expect(result.failure.message).toContain('receiver admission');
+              }
+            }
+            expect((yield* store.readySnapshot(database, identity.worktreeId))?.id).toBe(receiver.snapshot.id);
+          }
+
+          yield* fs.writeFileString(
+            exclude,
+            donorExcludes ? '# receiver comment\nsrc/excluded.ts\n' : '# receiver comment\n',
+          );
+          const accepted = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {cwd: repo, input: artifact});
+          expect(accepted.result.publication).toBe('activated');
+          expect(accepted.snapshot.graphContentId).toBe(donor.snapshot.graphContentId);
+          const acceptedWithoutReuse = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {
+            cwd: repo,
+            input: withoutReuse,
+          });
+          expect(acceptedWithoutReuse.result.publication).toBe('activated');
+          expect(acceptedWithoutReuse.snapshot.graphContentId).toBe(donor.snapshot.graphContentId);
+          let changedPolicy = false;
+          const raced = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {
+            cwd: repo,
+            input: artifact,
+          }).pipe(
+            Effect.provideService(CommandExecutor, {
+              ...command,
+              execute: (executable, args, options) =>
+                command.execute(executable, args, options).pipe(
+                  Effect.tap(() =>
+                    Effect.gen(function* () {
+                      if (executable === 'git' && args.includes('ls-tree') && args.includes('-r') && !changedPolicy) {
+                        expect(options?.env?.GIT_NO_LAZY_FETCH).toBe('1');
+                        expect(options?.env?.GIT_OPTIONAL_LOCKS).toBe('0');
+                        changedPolicy = true;
+                        yield* fs.writeFileString(exclude, donorExcludes ? '' : 'src/excluded.ts\n');
+                      }
+                    }),
+                  ),
+                ),
+            }),
+            Effect.result,
+          );
+          expect(changedPolicy).toBe(true);
+          expect(raced._tag).toBe('Failure');
+          if (raced._tag === 'Failure') {
+            expect(Schema.is(CodeGraphCheckpointCommandError)(raced.failure)).toBe(true);
+            if (Schema.is(CodeGraphCheckpointCommandError)(raced.failure)) {
+              expect(raced.failure.message).toContain('receiver admission');
+            }
+          }
+          expect((yield* store.readySnapshot(database, identity.worktreeId))?.id).toBe(
+            acceptedWithoutReuse.snapshot.id,
+          );
+          expect(yield* fs.readFile(artifact)).toEqual(bytes);
+          expect((yield* git(repo, ['status', '--porcelain'])).stdout).toBe('');
+        }
+      }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    60_000,
+  );
+});
+
+function config(home: string) {
+  return {
+    account: 'local' as const,
+    agentContextHome: home,
+    agentId: 'threadnote',
+    manifestPath: `${home}/seed-manifest.yaml`,
+    user: 'local',
+  };
+}
+
+function git(repo: string, args: readonly string[]) {
+  return runCommandEffect('git', ['-C', repo, ...args]);
+}

--- a/test/integration/code-graph.inventory-environment.test.ts
+++ b/test/integration/code-graph.inventory-environment.test.ts
@@ -1,0 +1,69 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {readCodeGraphInventoryReuseEnvironment} from '../../src/code_graph/inventory_reuse.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const testLayer = CommandExecutor.layer.pipe(Layer.provideMerge(Layer.mergeAll(BunServices.layer, SystemInfo.layer)));
+
+describe('inventory environment observes Git global excludes', () => {
+  it.effect(
+    'tracks Git defaults, explicit paths, and explicit disabling without changing the process environment',
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const command = yield* CommandExecutor;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-inventory-environment-'});
+        const repo = path.join(root, 'repository');
+        const privateHome = path.join(root, 'private-home');
+        const xdg = path.join(root, 'xdg');
+        const configured = path.join(root, 'configured-ignore');
+        yield* fs.makeDirectory(repo);
+        yield* runCommandEffect('git', ['init', '-q', repo]);
+        const identity = yield* resolveRepositoryIdentity(repo);
+        for (const xdgValue of [undefined, '', xdg]) {
+          const environment = {
+            ...system.environment(),
+            HOME: privateHome,
+            XDG_CONFIG_HOME: xdgValue,
+            GIT_CONFIG_NOSYSTEM: '1',
+            GIT_CONFIG_GLOBAL: path.join(root, 'empty-global-config'),
+          };
+          const defaultIgnore = path.join(xdgValue || path.join(privateHome, '.config'), 'git', 'ignore');
+          yield* fs.makeDirectory(path.dirname(defaultIgnore), {recursive: true});
+          yield* fs.writeFileString(defaultIgnore, 'first.ts\n');
+          const read = readCodeGraphInventoryReuseEnvironment(identity, fs, path).pipe(
+            Effect.provideService(SystemInfo, {...system, environment: () => environment}),
+            Effect.provideService(CommandExecutor, {
+              ...command,
+              execute: (executable, args, options) => command.execute(executable, args, {...options, env: environment}),
+            }),
+          );
+          const git = (args: readonly string[]) => command.execute('git', ['-C', repo, ...args], {env: environment});
+          yield* git(['config', '--unset', 'core.excludesFile']).pipe(Effect.ignore);
+          const before = yield* read;
+          yield* fs.writeFileString(defaultIgnore, 'second.ts\n');
+          expect((yield* read).fingerprint).not.toBe(before.fingerprint);
+
+          yield* git(['config', 'core.excludesFile', '']);
+          const disabled = yield* read;
+          yield* fs.writeFileString(defaultIgnore, 'third.ts\n');
+          expect((yield* read).fingerprint).toBe(disabled.fingerprint);
+
+          yield* fs.writeFileString(configured, 'configured-first.ts\n');
+          yield* git(['config', 'core.excludesFile', configured]);
+          const explicit = yield* read;
+          yield* fs.writeFileString(defaultIgnore, 'fourth.ts\n');
+          expect((yield* read).fingerprint).toBe(explicit.fingerprint);
+          yield* fs.writeFileString(configured, 'configured-second.ts\n');
+          expect((yield* read).fingerprint).not.toBe(explicit.fingerprint);
+        }
+      }).pipe(provideTestLayer(testLayer), TestClock.withLive),
+  );
+});

--- a/test/integration/remote-memory-git-authority.test.ts
+++ b/test/integration/remote-memory-git-authority.test.ts
@@ -7,6 +7,9 @@ import {GitCanonicalMemoryStore} from '../../src/remote_memory/git_canonical_sto
 import {PostgresRemoteControlPlane} from '../../src/remote_memory/postgres_control_plane.js';
 import {PostgresRemoteMemoryRepository} from '../../src/remote_memory/postgres_repository.js';
 import {RemoteMemoryIndexer} from '../../src/remote_memory/indexer.js';
+import {formatMemoryDocument, parseMemoryDocument} from '../../src/memory/document.js';
+import {richRemoteMemoryMetadata} from '../helpers/remote-memory-document.js';
+import {git} from '../helpers/git-share-worktree.js';
 
 const DATABASE = process.env.THREADNOTE_TEST_POSTGRES_URL;
 const postgresDescribe = DATABASE ? describe : describe.skip;
@@ -82,12 +85,12 @@ postgresDescribe('Git ingest system authority', () => {
     }
   });
 
-  it('rejects HTTP body replacement that would erase metadata from Git', async () => {
+  it('preserves rich Git metadata through CAS replacement, replay, and stale rejection', async () => {
     const f = await fixture();
     try {
       const path = 'durable/projects/restricted/rich.md';
-      const content =
-        'MEMORY\nkind: durable\nstatus: active\nproject: restricted\ntopic: rich\nkeywords: retained-keyword\n\nRetain the original body.';
+      const metadata = richRemoteMemoryMetadata();
+      const content = formatMemoryDocument('MEMORY', metadata, 'Retain the original body.');
       const committed = await f.store.commit({path, content, message: 'Rich Git memory'});
       await f.repository.ingestActiveGitShares('rich-ingest');
       const principal = await new PostgresRemoteControlPlane(f.database.sql).authorize(
@@ -97,29 +100,92 @@ postgresDescribe('Git ingest system authority', () => {
       if (!principal) throw new Error('Fixture principal missing');
       const uri = `threadnote://share/${f.input.shareId}/memories/durable/restricted/rich.md`;
       const original = await f.repository.read(principal, {version: 1, uri}, 'read-rich');
+      const input = {
+        version: 1 as const,
+        kind: 'durable' as const,
+        project: 'restricted',
+        topic: 'rich',
+        text: 'Changed body',
+        operationId: 'replace-rich',
+        baseRevision: original.receipt.revision,
+      };
+      const replaced = await f.repository.remember(principal, input, 'replace-rich');
+      const read = await f.repository.read(principal, {version: 1, uri}, 'read-replaced');
+      expect(read.receipt.revision).toBe(replaced.revision);
+      const parsed = parseMemoryDocument(uri, read.content);
+      expect(parsed?.body).toBe('Changed body');
+      expect(parsed?.metadata).toEqual({
+        ...metadata,
+        sourceAgentClient: 'remote',
+        timestamp: expect.any(String),
+        updatedAt: expect.any(String),
+      });
+      expect(parsed?.metadata.updatedAt).not.toBe(metadata.updatedAt);
+      const editedFields = /^(source_agent_client|timestamp|updated_at):/u;
+      const preservedLines = content
+        .split('\n\n', 1)[0]
+        .split('\n')
+        .filter(line => !editedFields.test(line));
+      expect(
+        read.content
+          .split('\n\n', 1)[0]
+          .split('\n')
+          .filter(line => !editedFields.test(line)),
+      ).toEqual(preservedLines);
+      expect(await git(['show', `HEAD:${path}`], f.git.remote)).toBe(read.content);
+      expect((await f.repository.remember(principal, input, 'replay-rich')).revision).toBe(replaced.revision);
       await expect(
-        f.repository.remember(
-          principal,
-          {
-            version: 1,
-            kind: 'durable',
-            project: 'restricted',
-            topic: 'rich',
-            text: 'Changed body',
-            operationId: 'replace-rich',
-            baseRevision: original.receipt.revision,
-          },
-          'replace-rich',
-        ),
-      ).rejects.toMatchObject({code: 'invalid_request', details: {reason: 'unsupported_remote_metadata'}});
-      expect((await f.store.listCanonicalPaths()).find(entry => entry.gitPath === path)?.gitCommit).toBe(
-        committed.gitCommit,
-      );
+        f.repository.remember(principal, {...input, operationId: 'stale-rich', text: 'Stale body'}, 'stale-rich'),
+      ).rejects.toMatchObject({code: 'conflict'});
+      expect((await f.repository.read(principal, {version: 1, uri}, 'read-after-stale')).content).toBe(read.content);
       expect(await f.store.read({commit: committed.gitCommit, path})).toBe(content);
     } finally {
       await f.dispose();
     }
   });
+
+  it.each(['x_extension: retained', 'code_citation: invalid', 'memory_id: tn_one\nmemory_id: tn_two'])(
+    'leaves Git and the revision unchanged when metadata cannot be preserved: %s',
+    async field => {
+      const f = await fixture();
+      try {
+        const path = 'durable/projects/restricted/unsupported.md';
+        const content = `MEMORY\nkind: durable\n${field}\n\nOriginal body`;
+        const committed = await f.store.commit({path, content, message: 'Unsupported metadata fixture'});
+        await f.repository.ingestActiveGitShares('unsupported-ingest');
+        const principal = await new PostgresRemoteControlPlane(f.database.sql).authorize(
+          {issuer: f.input.issuer, subject: f.input.subject, scopes: new Set(f.input.capabilities)},
+          f.input.shareId,
+        );
+        if (!principal) throw new Error('Fixture principal missing');
+        const uri = `threadnote://share/${f.input.shareId}/memories/durable/restricted/unsupported.md`;
+        const original = await f.repository.read(principal, {version: 1, uri}, 'read-unsupported');
+        await expect(
+          f.repository.remember(
+            principal,
+            {
+              version: 1,
+              kind: 'durable',
+              project: 'restricted',
+              topic: 'unsupported',
+              text: 'Changed body',
+              operationId: 'replace-unsupported',
+              baseRevision: original.receipt.revision,
+            },
+            'replace-unsupported',
+          ),
+        ).rejects.toMatchObject({code: 'invalid_request', details: {reason: 'unsupported_remote_metadata'}});
+        expect((await f.store.listCanonicalPaths()).find(entry => entry.gitPath === path)?.gitCommit).toBe(
+          committed.gitCommit,
+        );
+        const read = await f.repository.read(principal, {version: 1, uri}, 'read-after-rejection');
+        expect(read.content).toBe(original.content);
+        expect(read.receipt.revision).toBe(original.receipt.revision);
+      } finally {
+        await f.dispose();
+      }
+    },
+  );
 
   it('projects canonical Git independently of member order, scopes, and revocation', async () => {
     const f = await fixture();

--- a/test/unit/code-graph.checkpoint-import-store.test.ts
+++ b/test/unit/code-graph.checkpoint-import-store.test.ts
@@ -519,43 +519,54 @@ describe('code graph checkpoint import store', () => {
               Buffer.byteLength(content),
             );
 
-            const hydrated = yield* hydrateCodeGraphCheckpointReusableBaseReceipt(identity, header);
+            const admission = {environmentFingerprint: 'a'.repeat(64)};
+            const hydrated = yield* hydrateCodeGraphCheckpointReusableBaseReceipt(identity, header, admission);
 
             expect(hydrated?.inventory?.attributionFiles).toEqual([
               expect.objectContaining({blobId, content: compactContent, path: 'package.json', source: 'commit'}),
             ]);
-            expect(hydrated?.inventory?.environmentFingerprint).toMatch(/^[0-9a-f]{64}$/u);
+            expect(hydrated?.inventory?.environmentFingerprint).toBe(admission.environmentFingerprint);
 
             const mismatch = yield* Effect.exit(
-              hydrateCodeGraphCheckpointReusableBaseReceipt(identity, {
-                ...header,
-                reuse: {
-                  ...header.reuse!,
-                  inventory: {
-                    ...header.reuse!.inventory!,
-                    attributionFiles: [{...header.reuse!.inventory!.attributionFiles[0], contentHash: 'f'.repeat(64)}],
+              hydrateCodeGraphCheckpointReusableBaseReceipt(
+                identity,
+                {
+                  ...header,
+                  reuse: {
+                    ...header.reuse!,
+                    inventory: {
+                      ...header.reuse!.inventory!,
+                      attributionFiles: [
+                        {...header.reuse!.inventory!.attributionFiles[0], contentHash: 'f'.repeat(64)},
+                      ],
+                    },
                   },
                 },
-              }),
+                admission,
+              ),
             );
             expect(mismatch._tag).toBe('Failure');
 
             const sourceSizeMismatch = yield* Effect.exit(
-              hydrateCodeGraphCheckpointReusableBaseReceipt(identity, {
-                ...header,
-                reuse: {
-                  ...header.reuse!,
-                  inventory: {
-                    ...header.reuse!.inventory!,
-                    attributionFiles: [
-                      {
-                        ...header.reuse!.inventory!.attributionFiles[0],
-                        blobSize: header.reuse!.inventory!.attributionFiles[0].blobSize + 1,
-                      },
-                    ],
+              hydrateCodeGraphCheckpointReusableBaseReceipt(
+                identity,
+                {
+                  ...header,
+                  reuse: {
+                    ...header.reuse!,
+                    inventory: {
+                      ...header.reuse!.inventory!,
+                      attributionFiles: [
+                        {
+                          ...header.reuse!.inventory!.attributionFiles[0],
+                          blobSize: header.reuse!.inventory!.attributionFiles[0].blobSize + 1,
+                        },
+                      ],
+                    },
                   },
                 },
-              }),
+                admission,
+              ),
             );
             expect(sourceSizeMismatch._tag).toBe('Failure');
           }),

--- a/test/unit/code-graph.checkpoint-receiver-admission.property.test.ts
+++ b/test/unit/code-graph.checkpoint-receiver-admission.property.test.ts
@@ -1,0 +1,72 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {CodeGraphCheckpointReceiverFileVerifier} from '../../src/code_graph/checkpoint/receiver_admission.js';
+import type {CodeGraphCheckpointFileRecordV1} from '../../src/code_graph/checkpoint/schema.js';
+
+function file(id: number): CodeGraphCheckpointFileRecordV1 {
+  return {
+    blobId: id.toString(16).padStart(40, '0'),
+    contentHash: id.toString(16).padStart(64, '0'),
+    kind: 'file',
+    language: 'typescript',
+    mode: '100644',
+    path: `src/file-${id}.ts`,
+    size: 10,
+    source: 'commit',
+  };
+}
+
+describe('checkpoint receiver file admission', () => {
+  it('accepts exactly equal file sets regardless of traversal order', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.integer({min: 0, max: 50}), {maxLength: 12}),
+        fc.uniqueArray(fc.integer({min: 0, max: 50}), {maxLength: 12}),
+        (receiver, donor) => {
+          const verify = (ids: readonly number[]) => {
+            const verifier = new CodeGraphCheckpointReceiverFileVerifier(receiver.map(file));
+            return ids.every(id => verifier.accept(file(id))) && verifier.complete;
+          };
+          expect(verify([...receiver].reverse())).toBe(true);
+          expect(verify(donor)).toBe(receiver.length === donor.length && donor.every(id => receiver.includes(id)));
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it('rejects duplicate records and changed identities', () => {
+    const original = file(1);
+    const duplicate = new CodeGraphCheckpointReceiverFileVerifier([original]);
+    expect(duplicate.accept(original)).toBe(true);
+    expect(duplicate.accept(original)).toBe(false);
+    expect(duplicate.complete).toBe(false);
+    for (const changed of [
+      {...original, blobId: 'a'.repeat(40)},
+      {...original, contentHash: 'a'.repeat(64)},
+      {...original, language: 'javascript'},
+      {...original, mode: '100755'},
+    ]) {
+      const verifier = new CodeGraphCheckpointReceiverFileVerifier([original]);
+      expect(verifier.accept(changed)).toBe(false);
+      expect(verifier.complete).toBe(false);
+    }
+  });
+
+  it('admits receiptless full or structural sets without admitting partial media or missing source', () => {
+    const source = file(1);
+    const images = [
+      {...file(2), path: 'assets/one.png'},
+      {...file(3), path: 'assets/two.png'},
+    ];
+    const complete = (records: readonly CodeGraphCheckpointFileRecordV1[]) => {
+      const verifier = new CodeGraphCheckpointReceiverFileVerifier([source, ...images], {allowStructuralOnly: true});
+      return records.every(record => verifier.accept(record)) && verifier.complete;
+    };
+    expect(complete([source])).toBe(true);
+    expect(complete([...images, source])).toBe(true);
+    expect(complete([source, images[0]])).toBe(false);
+    expect(complete(images)).toBe(false);
+    expect(complete([])).toBe(false);
+  });
+});

--- a/test/unit/mcp-broker.test.ts
+++ b/test/unit/mcp-broker.test.ts
@@ -9,6 +9,104 @@ import {
 import type {StandaloneActiveRelease} from '../../src/process/standalone_lease.js';
 
 describe('MCP session broker', () => {
+  it('reports missing activation without dispatching any request or changing its id', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.oneof(fc.integer(), fc.string({maxLength: 40})), async id => {
+        const clientInput = new AsyncByteQueue();
+        const clientOutput = new AsyncByteQueue();
+        let spawned = 0;
+        const running = runMcpBroker({
+          input: clientInput,
+          readActiveRelease: async () => undefined,
+          spawn: () => {
+            spawned += 1;
+            throw new Error('Unexpected spawn');
+          },
+          writeOutput: async line => clientOutput.pushLine(line),
+        });
+        clientInput.pushLine(
+          JSON.stringify({id, jsonrpc: '2.0', method: 'tools/call', params: {name: 'remember_context'}}),
+        );
+        const failure = JSON.parse(await clientOutput.nextLine());
+        clientInput.end();
+        await running;
+        expect(failure).toMatchObject({
+          id,
+          error: {code: -32_603, data: {reason: 'no-active-release', requestDisposition: 'not-dispatched'}},
+        });
+        expect(failure.error.message).toContain('threadnote install --no-start');
+        expect(failure.error.message).not.toContain('outcome is unknown');
+        expect(spawned).toBe(0);
+        expect(clientOutput.availableLines()).toBe(0);
+      }),
+      {numRuns: 50},
+    );
+  });
+
+  it('recovers on the same transport after activation without replaying rejected work', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    let active: StandaloneActiveRelease | undefined;
+    const child = new FakeMcpChild('activated');
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => active,
+      spawn: () => child,
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(JSON.parse(await clientOutput.nextLine()).error.data.reason).toBe('no-active-release');
+    active = {releaseRoot: '/threadnote/versions/activated', version: 'activated'};
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({
+      id: 2,
+      result: {serverInfo: {version: 'activated'}},
+    });
+    active = undefined;
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({id: 3, result: {version: 'activated'}});
+    expect(child.received.map(line => JSON.parse(line).id)).toEqual([2, 3]);
+    clientInput.end();
+    await running;
+  });
+
+  it('keeps an outstanding mutation uncertain when a later request fails before dispatch', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const release = {releaseRoot: '/threadnote/versions/private-release', version: 'private-version'};
+    const child = new FakeMcpChild(release.version, {respondToTools: false});
+    let failRead = false;
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => {
+        if (failRead) throw new Error('Private lookup failure /Users/private/token');
+        return release;
+      },
+      spawn: () => child,
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(
+      JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'remember_context'}}),
+    );
+    await child.receivedCount(2);
+    failRead = true;
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/list'}));
+    const mutation = JSON.parse(await clientOutput.nextLine());
+    const lookup = JSON.parse(await clientOutput.nextLine());
+    clientInput.end();
+    await running;
+    expect(mutation).toMatchObject({id: 2, error: {message: expect.stringContaining('outcome is unknown')}});
+    expect(mutation.error.data).toBeUndefined();
+    expect(lookup).toMatchObject({
+      id: 3,
+      error: {data: {reason: 'startup-failed', requestDisposition: 'not-dispatched'}},
+    });
+    expect(JSON.stringify(lookup)).not.toContain('private');
+    expect(child.received).toHaveLength(2);
+  });
+
   it('reports a closed spawn failure without allowing the observer to alter recovery', async () => {
     const clientInput = new AsyncByteQueue();
     const clientOutput = new AsyncByteQueue();
@@ -28,7 +126,12 @@ describe('MCP session broker', () => {
     });
 
     clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
-    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({error: {code: -32_603}, id: 1});
+    const failure = JSON.parse(await clientOutput.nextLine());
+    expect(failure).toMatchObject({
+      error: {code: -32_603, data: {reason: 'startup-failed', requestDisposition: 'not-dispatched'}},
+      id: 1,
+    });
+    expect(JSON.stringify(failure)).not.toContain('private');
     clientInput.end();
     await running;
 

--- a/test/unit/remote-memory-document-compatibility.test.ts
+++ b/test/unit/remote-memory-document-compatibility.test.ts
@@ -1,6 +1,9 @@
 import {describe, expect, it} from 'vitest';
 import * as FC from 'effect/testing/FastCheck';
 import {assertRemoteBodyReplacementSupported} from '../../src/remote_memory/document_compatibility.js';
+import {formatMemoryDocument} from '../../src/memory/document.js';
+import {richRemoteMemoryMetadata} from '../helpers/remote-memory-document.js';
+import {createMemoryCodeCitation} from '../../src/memory/code_citation.js';
 
 describe('remote body replacement compatibility', () => {
   it('rejects unknown header fields without consuming or rewriting them', () => {
@@ -17,19 +20,47 @@ describe('remote body replacement compatibility', () => {
     );
   });
 
-  it('supports basic remote documents and rejects rich or malformed local ones', () => {
+  it('supports basic and rich documents without changing the source metadata', () => {
     expect(() =>
       assertRemoteBodyReplacementSupported('MEMORY\nkind: durable\n\nThe documentation mentions `<!-- MEMORY_FIELDS`.'),
     ).not.toThrow();
     expect(() =>
       assertRemoteBodyReplacementSupported('MEMORY\nkind: durable\nstatus: active\nmemory_id: tn_123\n\nBody'),
     ).not.toThrow();
+    const metadata = richRemoteMemoryMetadata();
+    const before = structuredClone(metadata);
+    const document = formatMemoryDocument('MEMORY', metadata, 'Original body');
+    for (const newline of ['\n', '\r\n', '\r']) {
+      expect(() => assertRemoteBodyReplacementSupported(document.replaceAll('\n', newline))).not.toThrow();
+    }
+    expect(metadata).toEqual(before);
+  });
+
+  it('accepts repeated list metadata including duplicate values', () => {
+    FC.assert(
+      FC.property(
+        FC.array(FC.stringMatching(/^[a-z][a-z0-9 -]{0,30}[a-z]$/u), {minLength: 1, maxLength: 20}),
+        keywords => {
+          const metadata = {...richRemoteMemoryMetadata(), keywords: [...keywords, ...keywords]};
+          const document = formatMemoryDocument('MEMORY', metadata, 'Original body');
+          expect(() => assertRemoteBodyReplacementSupported(document)).not.toThrow();
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  it('rejects metadata that tolerant parsing would discard or change', () => {
     for (const field of [
       'code_citation: invalid',
-      'relation: references threadnote://memory/tn_123',
-      'keywords: important',
-      'trust: approved',
-      'workspace_scope: src',
+      'relation: invalid threadnote://memory/tn_123',
+      'keywords:',
+      'trust: invented',
+      'status: invented',
+      'status: active\nstatus: active',
+      'memory_id: tn_first\nmemory_id: tn_second',
+      'workspace_scope:  src',
+      'schema_version: 999',
       'this header is malformed',
     ]) {
       expect(() => assertRemoteBodyReplacementSupported(`MEMORY\nkind: durable\n${field}\n\nBody`)).toThrow();
@@ -40,5 +71,17 @@ describe('remote body replacement compatibility', () => {
         'MEMORY\nkind: durable\n\nBody\n\n<!-- MEMORY_FIELDS\nreferences: legacy\n-->',
       ),
     ).toThrow();
+  });
+
+  it('rejects citations that cannot cross the sharing boundary', () => {
+    const metadata = richRemoteMemoryMetadata();
+    const {id: _id, ...citation} = metadata.codeCitations![0];
+    for (const unsafe of [
+      createMemoryCodeCitation({...citation, sourceDirty: true}),
+      createMemoryCodeCitation({...citation, repositoryIdentityKind: 'local'}),
+    ]) {
+      const document = formatMemoryDocument('MEMORY', {...metadata, codeCitations: [unsafe]}, 'Original body');
+      expect(() => assertRemoteBodyReplacementSupported(document)).toThrow('metadata');
+    }
   });
 });


### PR DESCRIPTION
Checkpoint import could activate a donor graph containing files excluded by the receiver, or omitting files the receiver admits. Imports now compare the complete committed file inventory against receiver policy before staging, retain the admission fingerprint for reuse hydration, and recheck it before publication. Rejection preserves the current graph and directs the user to index locally.

The policy fingerprint now observes Git's default global ignore file as well as explicitly configured paths. Checkpoints without optional inventory metadata remain compatible with both complete and structural inventories; partial media coverage and missing source files are rejected.

Validation: 32 focused cases across checkpoint import/projection/CLI, inventory policy/cache, receiver policy changes and bounded file-set properties; lint and type checks pass. Dev-cycle review resolved both important findings and has no remaining blockers. Exact installed-runtime smoke is recorded before opening this PR. Full-suite CI remains the merge gate.

This PR builds on #396 and targets main so the repository’s full CI runs. Until #396 merges, the diff also includes its already-reviewed remote-memory metadata preservation and broker startup diagnostics. Merge #396 first; the new checkpoint change is commit 0547e671. Local ready-query freshness after subsequent exclusion-policy changes is a separate follow-up; this PR repairs the import boundary.
