### PR TITLE
Refresh current graphs when receiver admission policy changes

### DIFF
--- a/src/code_graph/admission_freshness.ts
+++ b/src/code_graph/admission_freshness.ts
@@ -111,10 +111,14 @@ export const recordCodeGraphSnapshotAdmission = Effect.fn('codeGraph.recordSnaps
   environmentFingerprint: string,
   languagePacks: CodeGraphLanguagePackRegistryShape,
   includeOpaqueCorpusAssets: boolean,
+  options?: {readonly cleanOnly?: boolean},
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const crypto = yield* Crypto.Crypto;
+  if (options?.cleanOnly && snapshot.dirty) {
+    return yield* CodeGraphAdmissionError.make({message: 'Dirty snapshots cannot establish clean-base admission.'});
+  }
   if (!/^[0-9a-f]{64}$/u.test(layout.worktreeId)) {
     return yield* CodeGraphAdmissionError.make({message: 'Invalid graph admission worktree identity.'});
   }
@@ -135,7 +139,7 @@ export const recordCodeGraphSnapshotAdmission = Effect.fn('codeGraph.recordSnaps
   };
   // Retain the last verified clean base while its producer works on a dirty overlay.
   // Two bounded files per worktree avoid retaining proof for every historical snapshot.
-  for (const clean of snapshot.dirty ? [false] : [false, true]) {
+  for (const clean of options?.cleanOnly ? [true] : snapshot.dirty ? [false] : [false, true]) {
     const destination = receiptPath(path, layout, layout.worktreeId, clean);
     const temporary = `${destination}.${yield* crypto.randomUUIDv4}.tmp`;
     yield* Effect.gen(function* () {

--- a/src/code_graph/admission_freshness.ts
+++ b/src/code_graph/admission_freshness.ts
@@ -1,0 +1,186 @@
+import {Crypto, Effect, FileSystem, Option, Path, Schema} from 'effect';
+import {codeGraphInventoryReuseContract, readCodeGraphInventoryReuseEnvironment} from './inventory_reuse.js';
+import type {CodeGraphLanguagePackRegistryShape} from './languages/registry.js';
+import type {CodeGraphLayout} from './layout.js';
+import type {CodeGraphSnapshot, RepositoryIdentity} from './types.js';
+
+const hash = Schema.String.pipe(Schema.check(Schema.isPattern(/^[0-9a-f]{64}$/u)));
+const receiptSchema = Schema.Struct({
+  contract: hash,
+  environmentFingerprint: hash,
+  includeOpaqueCorpusAssets: Schema.Boolean,
+  repositoryId: hash,
+  snapshotId: Schema.String,
+  version: Schema.Literal(1),
+  worktreeId: hash,
+});
+type AdmissionReceipt = typeof receiptSchema.Type;
+
+class CodeGraphAdmissionError extends Schema.TaggedError<CodeGraphAdmissionError>()('CodeGraphAdmissionError', {
+  message: Schema.String,
+}) {}
+
+function receiptPath(path: Path.Path, layout: CodeGraphLayout, worktreeId: string, clean: boolean): string {
+  return path.join(layout.repositoryRoot, 'admission', `${worktreeId}${clean ? '.clean' : ''}.json`);
+}
+
+/** Missing cache evidence can deny freshness, but never substitutes for a ready SQLite snapshot. */
+const readReceipt = Effect.fn('codeGraph.readAdmissionReceipt')(function* (
+  layout: CodeGraphLayout,
+  worktreeId: string,
+  clean = false,
+) {
+  if (!/^[0-9a-f]{64}$/u.test(worktreeId)) return undefined;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const target = receiptPath(path, layout, worktreeId, clean);
+  for (const file of [path.dirname(target), target]) {
+    if (Option.isSome(yield* fs.readLink(file).pipe(Effect.option))) return undefined;
+  }
+  const info = yield* fs.stat(target);
+  if (info.type !== 'File' || Number(info.size) > 4_096) return undefined;
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const file = yield* fs.open(target, {flag: 'r'});
+      const bytes = new Uint8Array(4_097);
+      let length = 0;
+      while (length < bytes.length) {
+        const count = Number(yield* file.read(bytes.subarray(length)));
+        if (count === 0) break;
+        length += count;
+      }
+      if (length > 4_096) return undefined;
+      const parsed = yield* Effect.try(() =>
+        JSON.parse(new TextDecoder('utf-8', {fatal: true}).decode(bytes.subarray(0, length))),
+      );
+      return Option.getOrUndefined(Schema.decodeUnknownOption(receiptSchema)(parsed));
+    }),
+  );
+});
+
+export const codeGraphSnapshotAdmissionCurrent = Effect.fn('codeGraph.snapshotAdmissionCurrent')(function* (
+  layout: CodeGraphLayout,
+  snapshot: CodeGraphSnapshot,
+  environmentFingerprint: string,
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+  producingWorktree = false,
+) {
+  const worktreeId = producingWorktree ? snapshot.worktreeId : layout.worktreeId;
+  return (
+    (yield* matchingReceipt(layout, worktreeId, snapshot, environmentFingerprint, languagePacks, producingWorktree)) !==
+    undefined
+  );
+});
+
+const matchingReceipt = Effect.fn('codeGraph.matchingAdmissionReceipt')(function* (
+  layout: CodeGraphLayout,
+  worktreeId: string,
+  snapshot: CodeGraphSnapshot,
+  environment: string,
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+  includeClean: boolean,
+) {
+  for (const clean of includeClean && !snapshot.dirty ? [false, true] : [false]) {
+    const receipt = yield* readReceipt(layout, worktreeId, clean).pipe(Effect.orElseSucceed(() => undefined));
+    if (receiptMatches(receipt, worktreeId, snapshot, environment, languagePacks)) return receipt;
+  }
+  return undefined;
+});
+
+function receiptMatches(
+  receipt: AdmissionReceipt | undefined,
+  worktreeId: string,
+  snapshot: CodeGraphSnapshot,
+  environmentFingerprint: string,
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+): boolean {
+  return (
+    receipt !== undefined &&
+    receipt.worktreeId === worktreeId &&
+    receipt.repositoryId === snapshot.repositoryId &&
+    receipt.snapshotId === snapshot.id &&
+    receipt.environmentFingerprint === environmentFingerprint &&
+    receipt.contract === codeGraphInventoryReuseContract(languagePacks, receipt.includeOpaqueCorpusAssets)
+  );
+}
+
+/** Caller owns target-worktree publication and has fenced the captured admission environment. */
+export const recordCodeGraphSnapshotAdmission = Effect.fn('codeGraph.recordSnapshotAdmission')(function* (
+  layout: CodeGraphLayout,
+  snapshot: CodeGraphSnapshot,
+  environmentFingerprint: string,
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+  includeOpaqueCorpusAssets: boolean,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const crypto = yield* Crypto.Crypto;
+  if (!/^[0-9a-f]{64}$/u.test(layout.worktreeId)) {
+    return yield* CodeGraphAdmissionError.make({message: 'Invalid graph admission worktree identity.'});
+  }
+  const target = receiptPath(path, layout, layout.worktreeId, false);
+  const directory = path.dirname(target);
+  yield* fs.makeDirectory(directory, {recursive: true, mode: 0o700});
+  if (Option.isSome(yield* fs.readLink(directory).pipe(Effect.option))) {
+    return yield* CodeGraphAdmissionError.make({message: 'Graph admission directory must not be a symbolic link.'});
+  }
+  const receipt: AdmissionReceipt = {
+    contract: codeGraphInventoryReuseContract(languagePacks, includeOpaqueCorpusAssets),
+    environmentFingerprint,
+    includeOpaqueCorpusAssets,
+    repositoryId: snapshot.repositoryId,
+    snapshotId: snapshot.id,
+    version: 1,
+    worktreeId: layout.worktreeId,
+  };
+  // Retain the last verified clean base while its producer works on a dirty overlay.
+  // Two bounded files per worktree avoid retaining proof for every historical snapshot.
+  for (const clean of snapshot.dirty ? [false] : [false, true]) {
+    const destination = receiptPath(path, layout, layout.worktreeId, clean);
+    const temporary = `${destination}.${yield* crypto.randomUUIDv4}.tmp`;
+    yield* Effect.gen(function* () {
+      yield* fs.writeFileString(temporary, `${JSON.stringify(receipt)}\n`, {flag: 'wx', mode: 0o600});
+      yield* fs.rename(temporary, destination);
+    }).pipe(Effect.ensuring(fs.remove(temporary, {force: true}).pipe(Effect.ignore)));
+  }
+});
+
+export const observeCodeGraphAdmissionEnvironment = Effect.fn('codeGraph.observeAdmissionEnvironment')(function* (
+  identity: RepositoryIdentity,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  return (yield* readCodeGraphInventoryReuseEnvironment(identity, fs, path)).fingerprint;
+});
+
+export const codeGraphSnapshotAdmissionCurrentForIdentity = Effect.fn('codeGraph.snapshotAdmissionCurrentForIdentity')(
+  function* (
+    layout: CodeGraphLayout,
+    snapshot: CodeGraphSnapshot,
+    identity: RepositoryIdentity,
+    languagePacks: CodeGraphLanguagePackRegistryShape,
+    producingWorktree = false,
+  ) {
+    const environment = yield* observeCodeGraphAdmissionEnvironment(identity);
+    return yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, environment, languagePacks, producingWorktree);
+  },
+);
+
+export const adoptCodeGraphSnapshotAdmission = Effect.fn('codeGraph.adoptSnapshotAdmission')(function* (
+  layout: CodeGraphLayout,
+  snapshot: CodeGraphSnapshot,
+  identity: RepositoryIdentity,
+  languagePacks: CodeGraphLanguagePackRegistryShape,
+) {
+  const environment = yield* observeCodeGraphAdmissionEnvironment(identity);
+  const receipt = yield* matchingReceipt(layout, snapshot.worktreeId, snapshot, environment, languagePacks, true);
+  if (receipt === undefined) return false;
+  yield* recordCodeGraphSnapshotAdmission(
+    layout,
+    snapshot,
+    environment,
+    languagePacks,
+    receipt.includeOpaqueCorpusAssets,
+  );
+  return true;
+});

--- a/src/code_graph/checkpoint/commands.ts
+++ b/src/code_graph/checkpoint/commands.ts
@@ -47,6 +47,7 @@ import {
   type CodeGraphCheckpointSha256,
 } from './schema.js';
 import {checkpointTerminalText} from './terminal_text.js';
+import {prepareCodeGraphCheckpointReceiverAdmission} from './receiver_admission.js';
 
 const CHECKPOINT_IO_CHUNK_BYTES = 64 * 1_024;
 const CHECKPOINT_GIT_OUTPUT_BYTES_MAXIMUM = 16 * 1_024 * 1_024;
@@ -266,23 +267,40 @@ export const importCodeGraphCheckpointSnapshot = Effect.fn('codeGraph.checkpoint
       const inspection = yield* inspectCheckpointInput(input, options);
       yield* attemptCheckpoint(() => validateCheckpointReceiver(inspection.header, identity, registry));
       yield* requireCheckpointCommit(identity, inspection.header.source.commit);
-      const attribution = checkpointAttributionRecordVerifier(inspection.header);
-      yield* withCodeGraphCheckpointAuthorityVerification(inspection.header, accept =>
-        decodeCheckpointInput(input, inspection, chunk =>
-          verifyCheckpointFiles(identity, inspection.header.source.commit, chunk).pipe(
-            Effect.andThen(attribution.accept(chunk)),
-            Effect.andThen(accept(chunk.records)),
+      const admission = yield* prepareCodeGraphCheckpointReceiverAdmission(identity, inspection.header, registry).pipe(
+        Effect.mapError(cause =>
+          checkpointCommandError(
+            'Checkpoint receiver admission could not be verified. Run `threadnote graph index` locally.',
+            cause,
           ),
         ),
       );
+      const attribution = checkpointAttributionRecordVerifier(inspection.header);
+      yield* withCodeGraphCheckpointAuthorityVerification(inspection.header, accept =>
+        decodeCheckpointInput(input, inspection, chunk =>
+          Effect.gen(function* () {
+            for (const record of chunk.records) {
+              if (record.kind === 'file') admission.files.accept(record);
+            }
+            yield* verifyCheckpointFiles(identity, inspection.header.source.commit, chunk);
+          }).pipe(Effect.andThen(attribution.accept(chunk)), Effect.andThen(accept(chunk.records))),
+        ),
+      );
       yield* attribution.finish;
-      return {input, inspection};
+      if (!admission.files.complete) {
+        return yield* checkpointFailure(
+          'Checkpoint file set does not match receiver admission. Run `threadnote graph index` locally.',
+        );
+      }
+      yield* admission.verifyEnvironment;
+      return {input, inspection, admission};
     }),
   );
   const receipt = checkpointImportReceipt(validated.inspection, options.expectedDigest !== undefined);
   const reusableBaseReceipt = yield* hydrateCodeGraphCheckpointReusableBaseReceipt(
     identity,
     validated.inspection.header,
+    validated.admission,
   );
   const snapshotId = checkpointSnapshotId(validated.inspection.header);
   const building = checkpointBuildingSnapshot(snapshotId, identity, validated.inspection.header);
@@ -308,6 +326,7 @@ export const importCodeGraphCheckpointSnapshot = Effect.fn('codeGraph.checkpoint
     () => Effect.void,
     'checkpoint-import',
     Effect.gen(function* () {
+      yield* validated.admission.verifyEnvironment;
       const reusable = yield* store.readySnapshotByLogicalDigest(
         layout.databasePath,
         identity.repositoryId,
@@ -401,6 +420,7 @@ export const importCodeGraphCheckpointSnapshot = Effect.fn('codeGraph.checkpoint
             ) {
               return {snapshotId: snapshot.id, state: 'stored' as const};
             }
+            yield* validated.admission.verifyEnvironment;
             yield* store.promote(databasePath, finalIdentity, snapshot.id, {persistentCapacityProtector});
             return {snapshotId: snapshot.id, state: 'activated' as const};
           }),

--- a/src/code_graph/checkpoint/commands.ts
+++ b/src/code_graph/checkpoint/commands.ts
@@ -48,6 +48,7 @@ import {
 } from './schema.js';
 import {checkpointTerminalText} from './terminal_text.js';
 import {prepareCodeGraphCheckpointReceiverAdmission} from './receiver_admission.js';
+import {recordCodeGraphSnapshotAdmission} from '../admission_freshness.js';
 
 const CHECKPOINT_IO_CHUNK_BYTES = 64 * 1_024;
 const CHECKPOINT_GIT_OUTPUT_BYTES_MAXIMUM = 16 * 1_024 * 1_024;
@@ -422,6 +423,15 @@ export const importCodeGraphCheckpointSnapshot = Effect.fn('codeGraph.checkpoint
             }
             yield* validated.admission.verifyEnvironment;
             yield* store.promote(databasePath, finalIdentity, snapshot.id, {persistentCapacityProtector});
+            yield* validated.admission.verifyEnvironment;
+            yield* recordCodeGraphSnapshotAdmission(
+              layout,
+              snapshot,
+              validated.admission.environmentFingerprint,
+              registry,
+              validated.inspection.header.reuse?.inventory?.includeOpaqueCorpusAssets ??
+                validated.admission.files.includesOpaqueAssets,
+            );
             return {snapshotId: snapshot.id, state: 'activated' as const};
           }),
         );

--- a/src/code_graph/checkpoint/import_reuse.ts
+++ b/src/code_graph/checkpoint/import_reuse.ts
@@ -1,11 +1,10 @@
-import {Effect, FileSystem, Path, Schema} from 'effect';
+import {Effect, Schema} from 'effect';
 import {runBinaryCommandEffect} from '../../effect/command.js';
 import {SystemInfo} from '../../effect/system.js';
 import {codeGraphCommittedContentHash} from '../content_identity.js';
 import {codeGraphUtf8ByteLength} from '../disk_capacity.js';
 import {appearsBinary, decodeUtf8} from '../inventory_content.js';
 import {retainResolutionContext} from '../inventory_content.js';
-import {readCodeGraphInventoryReuseEnvironment} from '../inventory_reuse.js';
 import {parseGitCatFileBatch} from '../inventory.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../languages/registry.js';
 import {
@@ -74,7 +73,11 @@ function attributionBatches(
  */
 export const hydrateCodeGraphCheckpointReusableBaseReceipt = Effect.fn(
   'codeGraph.hydrateCheckpointReusableBaseReceipt',
-)(function* (identity: RepositoryIdentity, header: CodeGraphCheckpointHeaderV1) {
+)(function* (
+  identity: RepositoryIdentity,
+  header: CodeGraphCheckpointHeaderV1,
+  receiverAdmission: {readonly environmentFingerprint: string},
+) {
   const reuse = header.reuse;
   if (reuse === undefined) return undefined;
   if (
@@ -116,12 +119,7 @@ export const hydrateCodeGraphCheckpointReusableBaseReceipt = Effect.fn(
   ) {
     return yield* hydrationError('Checkpoint attribution context exceeds the local reuse boundary.');
   }
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
   const system = yield* SystemInfo;
-  const environment = yield* readCodeGraphInventoryReuseEnvironment(identity, fs, path).pipe(
-    Effect.mapError(cause => hydrationError('Checkpoint reuse environment could not be inspected.', cause)),
-  );
   const attributionFiles: CodeGraphAttributionContextFile[] = [];
   for (const batch of attributionBatches(portable.attributionFiles)) {
     const result = yield* runBinaryCommandEffect('git', ['-C', identity.repoRoot, 'cat-file', '--batch'], {
@@ -184,7 +182,7 @@ export const hydrateCodeGraphCheckpointReusableBaseReceipt = Effect.fn(
       attributionFiles,
       contract: portable.contract,
       diagnostics: portable.diagnostics ?? [],
-      environmentFingerprint: environment.fingerprint,
+      environmentFingerprint: receiverAdmission.environmentFingerprint,
       includeOpaqueCorpusAssets: portable.includeOpaqueCorpusAssets,
       policyExclusions: {
         ...portable.policyExclusions,

--- a/src/code_graph/checkpoint/receiver_admission.ts
+++ b/src/code_graph/checkpoint/receiver_admission.ts
@@ -1,0 +1,111 @@
+import {Effect, FileSystem, Path, Schema} from 'effect';
+import {CommandExecutor, type CommandOptions} from '../../effect/command.js';
+import {SystemInfo} from '../../effect/system.js';
+import {inventoryRepository} from '../inventory.js';
+import {readCodeGraphInventoryReuseEnvironment} from '../inventory_reuse.js';
+import type {CodeGraphLanguagePackRegistryShape} from '../languages/registry.js';
+import {isOpaqueCorpusMediaPath} from '../languages/corpus/policy.js';
+import type {CodeGraphInventoryFile, RepositoryIdentity} from '../types.js';
+import type {CodeGraphCheckpointFileRecordV1, CodeGraphCheckpointHeaderV1} from './schema.js';
+
+export class CodeGraphCheckpointReceiverAdmissionError extends Schema.TaggedError<CodeGraphCheckpointReceiverAdmissionError>()(
+  'CodeGraphCheckpointReceiverAdmissionError',
+  {message: Schema.String},
+) {}
+
+type FileIdentity = Pick<CodeGraphInventoryFile, 'path' | 'blobId' | 'contentHash' | 'language' | 'mode'>;
+
+/** Compare the complete input sets, including receiver-admitted files absent from the donor. */
+export class CodeGraphCheckpointReceiverFileVerifier {
+  readonly #remaining: Map<string, FileIdentity>;
+  #valid = true;
+  #acceptedOpaque = false;
+  readonly #allowStructuralOnly: boolean;
+
+  constructor(files: readonly FileIdentity[], options?: {readonly allowStructuralOnly?: boolean}) {
+    this.#remaining = new Map(files.map(file => [file.path, file]));
+    this.#allowStructuralOnly = options?.allowStructuralOnly === true;
+  }
+
+  accept(file: CodeGraphCheckpointFileRecordV1): boolean {
+    const expected = this.#remaining.get(file.path);
+    if (
+      expected === undefined ||
+      file.blobId !== expected.blobId ||
+      file.contentHash !== expected.contentHash ||
+      file.language !== expected.language ||
+      file.mode !== expected.mode
+    ) {
+      this.#valid = false;
+      return false;
+    }
+    this.#remaining.delete(file.path);
+    if (isOpaqueCorpusMediaPath(file.path)) this.#acceptedOpaque = true;
+    return true;
+  }
+
+  get complete(): boolean {
+    return (
+      this.#valid &&
+      (this.#remaining.size === 0 ||
+        (this.#allowStructuralOnly &&
+          !this.#acceptedOpaque &&
+          [...this.#remaining.keys()].every(isOpaqueCorpusMediaPath)))
+    );
+  }
+}
+
+export const prepareCodeGraphCheckpointReceiverAdmission = Effect.fn('codeGraph.prepareCheckpointReceiverAdmission')(
+  function* (
+    identity: RepositoryIdentity,
+    header: CodeGraphCheckpointHeaderV1,
+    languagePacks: CodeGraphLanguagePackRegistryShape,
+  ) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
+    const command = yield* CommandExecutor;
+    const environment = yield* readCodeGraphInventoryReuseEnvironment(identity, fs, path);
+    const localOptions = (options?: CommandOptions): CommandOptions => ({
+      ...options,
+      env: {...system.environment(), ...options?.env, GIT_NO_LAZY_FETCH: '1', GIT_OPTIONAL_LOCKS: '0'},
+    });
+    const inventory = yield* inventoryRepository(
+      {...identity, headCommit: header.source.commit},
+      {
+        includeOverlay: false,
+        includeOpaqueCorpusAssets: header.reuse?.inventory?.includeOpaqueCorpusAssets,
+        languagePacks,
+        onContentBatch: () => Effect.void,
+      },
+    ).pipe(
+      Effect.provideService(CommandExecutor, {
+        ...command,
+        execute: (executable, args, options) => command.execute(executable, args, localOptions(options)),
+        ...(command.executeBytes === undefined
+          ? {}
+          : {
+              executeBytes: (executable, args, options) =>
+                command.executeBytes!(executable, args, localOptions(options)),
+            }),
+      }),
+    );
+    const verifyEnvironment = Effect.gen(function* () {
+      const closing = yield* readCodeGraphInventoryReuseEnvironment(identity, fs, path);
+      if (closing.fingerprint !== environment.fingerprint) {
+        return yield* CodeGraphCheckpointReceiverAdmissionError.make({
+          message:
+            'Checkpoint receiver admission policy changed during import. Retry or run `threadnote graph index` locally.',
+        });
+      }
+    });
+    yield* verifyEnvironment;
+    return {
+      environmentFingerprint: environment.fingerprint,
+      files: new CodeGraphCheckpointReceiverFileVerifier(inventory.files, {
+        allowStructuralOnly: header.reuse?.inventory === undefined,
+      }),
+      verifyEnvironment,
+    };
+  },
+);

--- a/src/code_graph/checkpoint/receiver_admission.ts
+++ b/src/code_graph/checkpoint/receiver_admission.ts
@@ -53,6 +53,10 @@ export class CodeGraphCheckpointReceiverFileVerifier {
           [...this.#remaining.keys()].every(isOpaqueCorpusMediaPath)))
     );
   }
+
+  get includesOpaqueAssets(): boolean {
+    return this.#acceptedOpaque;
+  }
 }
 
 export const prepareCodeGraphCheckpointReceiverAdmission = Effect.fn('codeGraph.prepareCheckpointReceiverAdmission')(

--- a/src/code_graph/indexer_build.ts
+++ b/src/code_graph/indexer_build.ts
@@ -216,12 +216,13 @@ export function codeGraphBuildRequestKey(
   languagePacks: CodeGraphLanguagePackRegistryShape,
   incrementalOverlay: boolean | undefined,
   ensureVectors: boolean,
+  environmentFingerprint: string,
 ): string {
   const parserIdentities = languagePacks.cacheIdentities.join('\n');
   const derivationIdentities = languagePacks.packs.map(packDerivationIdentity).sort(compareCodeUnits).join('\n');
   return sha256HexSync(
     [
-      'code-graph-build-request-v4',
+      'code-graph-build-request-v5',
       CODE_GRAPH_EXTRACTOR_SET_VERSION,
       `lexical-storage:${CODE_GRAPH_LEXICAL_COMPACT_FORMAT_VERSION}`,
       identity.repositoryId,
@@ -232,6 +233,7 @@ export function codeGraphBuildRequestKey(
       overlay.dirty && incrementalOverlay === false ? 'direct-full' : 'default',
       ensureVectors ? 'vectors:required' : 'vectors:structural-only',
       'ignore-policy:3',
+      environmentFingerprint,
       parserIdentities,
       derivationIdentities,
     ].join('\n'),

--- a/src/code_graph/indexer_service.ts
+++ b/src/code_graph/indexer_service.ts
@@ -753,6 +753,17 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                               store,
                               threadnoteHome: options.threadnoteHome,
                             });
+                            if ((yield* observeCodeGraphAdmissionEnvironment(identity)) !== admissionEnvironment) {
+                              return yield* WorktreeChangedDuringIndex.make({});
+                            }
+                            yield* recordCodeGraphSnapshotAdmission(
+                              layout,
+                              committedBase.snapshot,
+                              admissionEnvironment,
+                              languagePacks,
+                              ensureVectors,
+                              {cleanOnly: true},
+                            );
                           }
                         }
                         if (preassessment.mode === 'fallback') {

--- a/src/code_graph/indexer_service.ts
+++ b/src/code_graph/indexer_service.ts
@@ -2,6 +2,7 @@ import {Clock, Context, Crypto, Effect, Exit, FileSystem, Layer, Option, Path, S
 import * as HttpClient from 'effect/unstable/http/HttpClient';
 import {CommandExecutor} from '../effect/command.js';
 import {SystemInfo} from '../effect/system.js';
+import {observeCodeGraphAdmissionEnvironment, recordCodeGraphSnapshotAdmission} from './admission_freshness.js';
 import {makeCodeGraphBuildReporter} from './build_status.js';
 import {CODE_GRAPH_BUILDER_ADMISSION_CLASS_ENV, withCodeGraphBuilderAdmission} from './builder_admission.js';
 import {isCodeGraphCapacityPause} from './disk_capacity.js';
@@ -136,6 +137,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
         Effect.scoped(
           Effect.gen(function* () {
             const initialIdentity = yield* resolveRepositoryIdentity(request.cwd);
+            const admissionEnvironment = yield* observeCodeGraphAdmissionEnvironment(initialIdentity);
             if (
               request.expectedIdentity &&
               !repositoryIdentityMatchesExpectation(initialIdentity, request.expectedIdentity)
@@ -176,6 +178,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                   languagePacks,
                   request.incrementalOverlay,
                   ensureVectors,
+                  admissionEnvironment,
                 );
             const reporter = yield* withCodeGraphMaintenanceRegistration(
               request.threadnoteHome,
@@ -295,6 +298,9 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                         },
                       );
                       yield* store.initialize(layout.databasePath);
+                      if ((yield* observeCodeGraphAdmissionEnvironment(identity)) !== admissionEnvironment) {
+                        return yield* WorktreeChangedDuringIndex.make({});
+                      }
                       let inventoryOverlayObservation: CodeGraphOverlayObservation;
                       {
                         const currentBuildRequest = yield* worktreeBuildRequestObservation(
@@ -926,6 +932,20 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
                   .pipe(
                     Effect.onInterrupt(() =>
                       reporter.fail(CodeGraphIndexOperationError.make({message: CODE_GRAPH_INTERRUPTED_BUILD_SUMMARY})),
+                    ),
+                    Effect.tap(summary =>
+                      Effect.gen(function* () {
+                        if ((yield* observeCodeGraphAdmissionEnvironment(initialIdentity)) !== admissionEnvironment) {
+                          return yield* WorktreeChangedDuringIndex.make({});
+                        }
+                        yield* recordCodeGraphSnapshotAdmission(
+                          layout,
+                          summary.snapshot,
+                          admissionEnvironment,
+                          languagePacks,
+                          ensureVectors,
+                        );
+                      }),
                     ),
                     Effect.tap(summary => reporter.complete(summary)),
                     Effect.tapError(cause => reporter.fail(cause)),

--- a/src/code_graph/inventory_reuse.ts
+++ b/src/code_graph/inventory_reuse.ts
@@ -1,6 +1,7 @@
 import {Effect, FileSystem, Path, Predicate} from 'effect';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {runCommandEffect} from '../effect/command.js';
+import {SystemInfo} from '../effect/system.js';
 import {readOptionalText} from './inventory_contained_file.js';
 import {CodeGraphInventoryError} from './inventory_error.js';
 import {
@@ -84,7 +85,16 @@ export const readCodeGraphInventoryReuseEnvironment = Effect.fn('codeGraph.readI
   const gitInfoExcludePath = path.isAbsolute(observedGitInfoExcludePath)
     ? observedGitInfoExcludePath
     : path.resolve(identity.repoRoot, observedGitInfoExcludePath);
-  const globalExcludePath = globalExcludeResult.stdout.trim();
+  const system = yield* SystemInfo;
+  const environment = system.environment();
+  const defaultGlobalExcludePath = path.join(
+    environment.XDG_CONFIG_HOME || path.join(environment.HOME || system.homeDirectory, '.config'),
+    'git',
+    'ignore',
+  );
+  // An explicitly empty config disables global excludes; only an absent key uses Git's default.
+  const globalExcludePath =
+    globalExcludeResult.exitCode === 1 ? defaultGlobalExcludePath : globalExcludeResult.stdout.trim();
   const [gitInfoExclude, globalExclude] = yield* Effect.all(
     [
       readOptionalText(fs, gitInfoExcludePath),

--- a/src/code_graph/isolated_index.ts
+++ b/src/code_graph/isolated_index.ts
@@ -1,4 +1,5 @@
 import {Clock, Effect, Path} from 'effect';
+import {observeCodeGraphAdmissionEnvironment} from './admission_freshness.js';
 import {codeGraphBuildRequestKey} from './indexer_build.js';
 import {codeGraphIndexEnsuresVectors, type CodeGraphIndexOptions} from './indexer_types.js';
 import {CodeGraphIndexOperationError, WorktreeChangedDuringIndex} from './indexer_shared.js';
@@ -85,10 +86,18 @@ export const runIsolatedCodeGraphIndexSnapshot = Effect.fn('codeGraph.isolatedIn
     });
   }
   const requestedOverlay = yield* worktreeBuildRequestState(identity, options.threadnoteHome);
+  const admissionEnvironment = yield* observeCodeGraphAdmissionEnvironment(identity);
   const ensureVectors = codeGraphIndexEnsuresVectors(options);
   const requestKey = options.force
     ? undefined
-    : codeGraphBuildRequestKey(identity, requestedOverlay, languagePacks, options.incrementalOverlay, ensureVectors);
+    : codeGraphBuildRequestKey(
+        identity,
+        requestedOverlay,
+        languagePacks,
+        options.incrementalOverlay,
+        ensureVectors,
+        admissionEnvironment,
+      );
   const startedAt = yield* Clock.currentTimeMillis;
   const result = yield* runIsolatedCodeGraphIndex({
     admissionClass: options.admissionClass,
@@ -102,6 +111,8 @@ export const runIsolatedCodeGraphIndexSnapshot = Effect.fn('codeGraph.isolatedIn
     threadnoteHome: options.threadnoteHome,
   });
   const completedIdentity = yield* resolveRepositoryIdentity(options.cwd);
+  const completedEnvironment = yield* observeCodeGraphAdmissionEnvironment(completedIdentity);
+  if (completedEnvironment !== admissionEnvironment) return yield* WorktreeChangedDuringIndex.make({});
   const completedRequestKey =
     requestKey === undefined ||
     !repositoryIdentityMatchesExpectation(completedIdentity, identity) ||
@@ -113,6 +124,7 @@ export const runIsolatedCodeGraphIndexSnapshot = Effect.fn('codeGraph.isolatedIn
           languagePacks,
           options.incrementalOverlay,
           ensureVectors,
+          completedEnvironment,
         );
   const layout = codeGraphLayout(path, options.threadnoteHome, identity.checkoutId, identity.worktreeId);
   const recovered = yield* recoverIsolatedCodeGraphIndexSnapshot({

--- a/src/code_graph/query.ts
+++ b/src/code_graph/query.ts
@@ -31,7 +31,9 @@ import {sanitizeCodeGraphPresentationText as sanitizeText} from './presentation_
 import {resolveRepositoryIdentity} from './repository.js';
 import {
   attachCodeGraphStatusObservation,
+  codeGraphSnapshotMatchesWorktree as snapshotMatches,
   observationFromCodeGraphStatus,
+  observeCodeGraphQueryWorktree as observeWorktree,
   shouldAttachSharedReadySnapshot,
   skipCodeGraphQueryTelemetryStage,
   withCodeGraphQueryTelemetryStage,
@@ -43,6 +45,7 @@ import {
   type CodeGraphTraversalTimeBudgets,
 } from './query_contract.js';
 import {codeGraphSnapshotRuntimeCurrent} from './query_snapshot_runtime.js';
+import {adoptCodeGraphSnapshotAdmission, codeGraphSnapshotAdmissionCurrentForIdentity} from './admission_freshness.js';
 import {
   codeGraphEndpointMatches,
   exactCodeGraphImpactSelectorMatches,
@@ -200,7 +203,13 @@ export class CodeGraphQueryService extends Context.Service<
           const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
           const readySnapshot = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
           const runtimeCurrent = readySnapshot
-            ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, readySnapshot, languagePacks)
+            ? yield* codeGraphSnapshotRuntimeCurrent(
+                store,
+                layout.databasePath,
+                readySnapshot,
+                languagePacks,
+                options?.observeWorktree === false ? undefined : {layout, identity},
+              )
             : false;
           const telemetryPhase = options?.telemetryPhase ?? 'graph.query.status';
           const overlay =
@@ -243,6 +252,7 @@ export class CodeGraphQueryService extends Context.Service<
         Effect.gen(function* () {
           // statusForIdentity already attaches a non-writable observation; never re-attach
           // onto the same object (Object.defineProperty would throw).
+          const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
           const observation = observedStatus && observationFromCodeGraphStatus(observedStatus);
           const reusableStatus =
             observedStatus !== undefined &&
@@ -252,12 +262,21 @@ export class CodeGraphQueryService extends Context.Service<
               ? observedStatus
               : undefined;
           const status =
-            reusableStatus ??
-            (yield* statusForIdentity(threadnoteHome, identity, {
-              telemetry: interlock?.telemetry,
-              telemetryPhase: 'graph.query.snapshot',
-              telemetryWorktreeDisposition: 'fallback',
-            }));
+            reusableStatus &&
+            (reusableStatus.stale ||
+              (reusableStatus.readySnapshot &&
+                (yield* codeGraphSnapshotAdmissionCurrentForIdentity(
+                  layout,
+                  reusableStatus.readySnapshot,
+                  identity,
+                  languagePacks,
+                ))))
+              ? reusableStatus
+              : yield* statusForIdentity(threadnoteHome, identity, {
+                  telemetry: interlock?.telemetry,
+                  telemetryPhase: 'graph.query.snapshot',
+                  telemetryWorktreeDisposition: 'fallback',
+                });
           if (!status.stale && status.readySnapshot?.commit === identity.headCommit) return status;
           const overlay =
             observationFromCodeGraphStatus(status)?.overlay ??
@@ -269,14 +288,17 @@ export class CodeGraphQueryService extends Context.Service<
               'fallback',
             ));
           if (overlay.dirty) return status;
-          const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
           const candidate = yield* store.readySnapshotForCommit(
             layout.databasePath,
             identity.repositoryId,
             identity.headCommit,
           );
           const candidateRuntimeCurrent = candidate
-            ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, candidate, languagePacks)
+            ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, candidate, languagePacks, {
+                layout,
+                identity,
+                producingWorktree: true,
+              })
             : false;
           if (
             candidate === undefined ||
@@ -321,7 +343,11 @@ export class CodeGraphQueryService extends Context.Service<
                 identity.headCommit,
               );
               const lockedCandidateRuntimeCurrent = lockedCandidate
-                ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, lockedCandidate, languagePacks)
+                ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, lockedCandidate, languagePacks, {
+                    layout,
+                    identity,
+                    producingWorktree: true,
+                  })
                 : false;
               if (
                 lockedCandidate === undefined ||
@@ -402,7 +428,14 @@ export class CodeGraphQueryService extends Context.Service<
                   : lockedStatus;
               }
               const finalOverlay = published.overlay;
-              const stale = finalOverlay?.dirty !== false;
+              const stale =
+                finalOverlay?.dirty !== false ||
+                !(yield* adoptCodeGraphSnapshotAdmission(
+                  layout,
+                  lockedCandidate,
+                  promotionIdentity.value,
+                  languagePacks,
+                ));
               return attachCodeGraphStatusObservation(
                 {
                   ...lockedStatus,
@@ -500,7 +533,10 @@ export class CodeGraphQueryService extends Context.Service<
                     ? yield* store.readySnapshotById(layout.databasePath, statusObservation.borrowedSnapshotId)
                     : yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
               const runtimeCurrent = existing
-                ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, existing, languagePacks)
+                ? yield* codeGraphSnapshotRuntimeCurrent(store, layout.databasePath, existing, languagePacks, {
+                    layout,
+                    identity,
+                  })
                 : false;
               const strictFreshness =
                 options.strictFreshness ??
@@ -1219,15 +1255,6 @@ const deadlineReached = Effect.fn('codeGraph.deadlineReached')(function* (deadli
   return (yield* Clock.currentTimeMillis) >= deadline;
 });
 
-const observeWorktree = Effect.fn('codeGraph.observeWorktree')(function* (
-  identity: RepositoryIdentity,
-  interlock: CodeGraphQueryInterlock | undefined,
-) {
-  const observation = yield* worktreeOverlayState(identity);
-  yield* interlock?.afterObservation?.() ?? Effect.void;
-  return observation;
-});
-
 const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (input: {
   readonly baseSnapshotId?: string;
   readonly borrowedSnapshotId?: string;
@@ -1283,6 +1310,7 @@ const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (in
     input.layout.databasePath,
     snapshot,
     input.languagePacks,
+    overlay === undefined ? undefined : {layout: input.layout, identity},
   );
   yield* input.options.interlock?.afterSnapshotSelected?.() ?? Effect.void;
   const lease = yield* input.store.acquireSnapshotLease(input.layout.databasePath, snapshot.id, 2 * 60_000);
@@ -1419,15 +1447,19 @@ const inspectReadyGraph = Effect.fn('codeGraph.inspectReadyGraph')(function* (in
         ).pipe(Effect.as({identity, overlay}));
     const finalIdentity = finalObservation.identity;
     const finalOverlay = finalObservation.overlay;
-    const freshness = !runtimeCurrent
-      ? 'stale'
-      : finalOverlay === undefined
-        ? snapshot.commit === finalIdentity.headCommit
-          ? 'deferred'
-          : 'stale'
-        : snapshotMatches(snapshot, finalIdentity.headCommit, finalOverlay)
-          ? 'current'
-          : 'stale';
+    const admissionCurrent =
+      !input.strictFreshness ||
+      (yield* codeGraphSnapshotAdmissionCurrentForIdentity(input.layout, snapshot, finalIdentity, input.languagePacks));
+    const freshness =
+      !runtimeCurrent || !admissionCurrent
+        ? 'stale'
+        : finalOverlay === undefined
+          ? snapshot.commit === finalIdentity.headCommit
+            ? 'deferred'
+            : 'stale'
+          : snapshotMatches(snapshot, finalIdentity.headCommit, finalOverlay)
+            ? 'current'
+            : 'stale';
     const source = yield* loadSharedGraphQuerySource({
       checkoutId: identity.checkoutId,
       localCommit: finalIdentity.headCommit,
@@ -1864,18 +1896,6 @@ function sameRepositoryIdentity(left: RepositoryIdentity, right: RepositoryIdent
     left.repositoryId === right.repositoryId &&
     left.headCommit === right.headCommit &&
     left.objectFormat === right.objectFormat
-  );
-}
-
-function snapshotMatches(
-  snapshot: {readonly commit: string; readonly dirty: boolean; readonly overlayFingerprint?: string},
-  headCommit: string,
-  overlay: {readonly dirty: boolean; readonly fingerprint?: string},
-): boolean {
-  return (
-    snapshot.commit === headCommit &&
-    snapshot.dirty === overlay.dirty &&
-    (!overlay.dirty || snapshot.overlayFingerprint === overlay.fingerprint)
   );
 }
 

--- a/src/code_graph/query_contract.ts
+++ b/src/code_graph/query_contract.ts
@@ -1,6 +1,19 @@
 import {Effect} from 'effect';
 import type {CodeGraphDirectPersistentCapacityBoundary} from './disk_capacity.js';
 import type {CodeGraphStatus, RepositoryIdentity} from './types.js';
+import {worktreeOverlayState} from './inventory.js';
+
+export function codeGraphSnapshotMatchesWorktree(
+  snapshot: {readonly commit: string; readonly dirty: boolean; readonly overlayFingerprint?: string},
+  headCommit: string,
+  overlay: {readonly dirty: boolean; readonly fingerprint?: string},
+): boolean {
+  return (
+    snapshot.commit === headCommit &&
+    snapshot.dirty === overlay.dirty &&
+    (!overlay.dirty || snapshot.overlayFingerprint === overlay.fingerprint)
+  );
+}
 
 export interface CodeGraphStatusOptions {
   /** @internal Run after the owned identity resolution and before reading graph status. */
@@ -41,6 +54,15 @@ export interface CodeGraphQueryInterlock {
   /** @internal Deterministic barrier used to verify that leases cover the complete read session. */
   readonly beforeReadCompletion?: () => Effect.Effect<void>;
 }
+
+export const observeCodeGraphQueryWorktree = Effect.fn('codeGraph.observeWorktree')(function* (
+  identity: RepositoryIdentity,
+  interlock: CodeGraphQueryInterlock | undefined,
+) {
+  const observation = yield* worktreeOverlayState(identity);
+  yield* interlock?.afterObservation?.() ?? Effect.void;
+  return observation;
+});
 
 export interface CodeGraphTraversalTimeBudgets {
   readonly semanticMilliseconds?: number;

--- a/src/code_graph/query_snapshot_runtime.ts
+++ b/src/code_graph/query_snapshot_runtime.ts
@@ -1,8 +1,10 @@
 import {Effect} from 'effect';
+import {codeGraphSnapshotAdmissionCurrentForIdentity} from './admission_freshness.js';
+import type {CodeGraphLayout} from './layout.js';
 import {extractorSetIdentityFromPackProvenance} from './indexer.js';
 import {codeGraphLanguagePackProvenance, type CodeGraphLanguagePackRegistryShape} from './languages/registry.js';
 import type {CodeGraphLanguagePackProvenance, CodeGraphStoreShape} from './store.js';
-import type {CodeGraphSnapshot} from './types.js';
+import type {CodeGraphSnapshot, RepositoryIdentity} from './types.js';
 
 /** Prove that a snapshot's recorded extractor contract still matches the current language-pack catalog. */
 export function codeGraphSnapshotMatchesCurrentLanguagePacks(
@@ -28,9 +30,26 @@ export function codeGraphSnapshotRuntimeCurrent(
   databasePath: string,
   snapshot: CodeGraphSnapshot,
   languagePacks: CodeGraphLanguagePackRegistryShape,
+  admission?: {
+    readonly layout: CodeGraphLayout;
+    readonly identity: RepositoryIdentity;
+    readonly producingWorktree?: boolean;
+  },
 ) {
   return store.snapshotPackProvenance(databasePath, snapshot.id).pipe(
-    Effect.map(provenance => codeGraphSnapshotMatchesCurrentLanguagePacks(snapshot, provenance, languagePacks)),
+    Effect.flatMap(provenance => {
+      if (!codeGraphSnapshotMatchesCurrentLanguagePacks(snapshot, provenance, languagePacks))
+        return Effect.succeed(false);
+      return admission === undefined
+        ? Effect.succeed(true)
+        : codeGraphSnapshotAdmissionCurrentForIdentity(
+            admission.layout,
+            snapshot,
+            admission.identity,
+            languagePacks,
+            admission.producingWorktree,
+          );
+    }),
     Effect.orElseSucceed(() => false),
   );
 }

--- a/src/code_graph/watcher.ts
+++ b/src/code_graph/watcher.ts
@@ -18,6 +18,7 @@ import {
   Schema,
 } from 'effect';
 import {CodeGraphIndexer, type CodeGraphIndexerShape} from './indexer.js';
+import {observeCodeGraphAdmissionEnvironment} from './admission_freshness.js';
 import {worktreeBuildRequestState, worktreeOverlayState} from './inventory.js';
 import {CodeGraphMaintenanceCoordinator} from './maintenance_coordinator.js';
 import {CodeGraphStore, type CodeGraphRoutineMaintenanceResult, type CodeGraphStoreShape} from './store.js';
@@ -308,7 +309,19 @@ export class CodeGraphWatcher extends Context.Service<CodeGraphWatcher, CodeGrap
               assertRuntimeSchemaCompatible: databasePath => store.assertRuntimeSchemaCompatible(databasePath),
               cwd: options.cwd,
               onProgress: options.onProgress,
-              requestKey: codeGraphBuildRequestKey(identity, requestedOverlay, languagePacks, undefined, false),
+              requestKey: codeGraphBuildRequestKey(
+                identity,
+                requestedOverlay,
+                languagePacks,
+                undefined,
+                false,
+                yield* observeCodeGraphAdmissionEnvironment(identity).pipe(
+                  Effect.provideService(CommandExecutor, commandExecutor),
+                  Effect.provideService(FileSystem.FileSystem, fs),
+                  Effect.provideService(Path.Path, path),
+                  Effect.provideService(SystemInfo, systemInfo),
+                ),
+              ),
               threadnoteHome: options.threadnoteHome,
             }).pipe(
               Effect.provideService(CommandExecutor, commandExecutor),

--- a/src/mcp/broker.ts
+++ b/src/mcp/broker.ts
@@ -6,10 +6,17 @@ const MCP_BROKER_REPLAY_TIMEOUT_MILLISECONDS = 10_000;
 const MCP_BROKER_CHILD_STOP_WAIT_MILLISECONDS = 1_000;
 const MCP_BROKER_RUNTIME_EXIT_ERROR =
   'Threadnote MCP runtime exited before responding. The request outcome is unknown; inspect state before retrying a mutating operation.';
+const MCP_BROKER_NO_ACTIVE_RELEASE_ERROR =
+  'No valid active Threadnote release is installed. Run "threadnote install --no-start" with the downloaded executable, then reconnect this client. This request was not sent to a runtime.';
+const MCP_BROKER_STARTUP_ERROR =
+  'Threadnote could not start or select an MCP runtime. Check the Threadnote installation and reconnect this client. This request was not sent to a runtime.';
+
+type McpBrokerStartupFailure = 'no-active-release' | 'startup-failed';
 
 export class McpBrokerError extends Schema.TaggedError<McpBrokerError>()('McpBrokerError', {
   cause: Schema.optionalKey(Schema.Defect()),
   message: Schema.String,
+  reason: Schema.optionalKey(Schema.Literal('no-active-release')),
 }) {}
 
 interface McpBrokerChildInput {
@@ -144,12 +151,18 @@ class McpBroker {
         trackedRequest = true;
       }
       await this.#writeChildLine(current.child, line);
-    } catch {
+    } catch (cause) {
       const pending = [...this.#clientRequests.values()];
       this.#clientRequests.clear();
-      if (requestId !== undefined && !trackedRequest) pending.push(requestId);
       await this.#stopCurrentChild();
       for (const id of pending) await this.#queueRequestFailure(id);
+      if (requestId !== undefined && !trackedRequest) {
+        const reason =
+          Schema.is(McpBrokerError)(cause) && cause.reason === 'no-active-release'
+            ? 'no-active-release'
+            : 'startup-failed';
+        await this.#queueRequestFailure(requestId, reason);
+      }
     }
   }
 
@@ -169,7 +182,7 @@ class McpBroker {
     const active = await this.#dependencies.readActiveRelease();
     if (active === undefined) {
       if (this.#child !== undefined) return this.#child;
-      throw McpBrokerError.make({message: 'Threadnote has no valid active standalone release for the MCP broker.'});
+      throw McpBrokerError.make({message: MCP_BROKER_NO_ACTIVE_RELEASE_ERROR, reason: 'no-active-release'});
     }
     if (
       this.#child !== undefined &&
@@ -373,10 +386,21 @@ class McpBroker {
     await this.#queueOutput(JSON.stringify({jsonrpc: '2.0', method: 'notifications/resources/list_changed'}));
   }
 
-  #queueRequestFailure(id: string | number): Promise<void> {
+  #queueRequestFailure(id: string | number, startupFailure?: McpBrokerStartupFailure): Promise<void> {
     return this.#queueOutput(
       JSON.stringify({
-        error: {code: -32_603, message: MCP_BROKER_RUNTIME_EXIT_ERROR},
+        error: {
+          code: -32_603,
+          message:
+            startupFailure === undefined
+              ? MCP_BROKER_RUNTIME_EXIT_ERROR
+              : startupFailure === 'no-active-release'
+                ? MCP_BROKER_NO_ACTIVE_RELEASE_ERROR
+                : MCP_BROKER_STARTUP_ERROR,
+          ...(startupFailure === undefined
+            ? {}
+            : {data: {reason: startupFailure, requestDisposition: 'not-dispatched'}}),
+        },
         id,
         jsonrpc: '2.0',
       }),

--- a/src/mcp/server/code_graph.ts
+++ b/src/mcp/server/code_graph.ts
@@ -21,6 +21,7 @@ import {
   IsolatedCodeGraphImpactQueryTimedOut,
 } from '../../code_graph/isolated_impact_query.js';
 import type {CodeGraphProgress, CodeGraphQueryResult} from '../../code_graph/types.js';
+import type {CodeGraphStatusObservation} from '../../code_graph/query_contract.js';
 import type {CodeGraphWorksetQueryResult} from '../../code_graph/workset_query.js';
 import {
   continueCodeGraphWorksetQueryV2,
@@ -529,7 +530,7 @@ export function registerCodeGraphTool(
                 query: queryText,
                 refresh: false,
                 requestMaintenance: false,
-                statusObservation: observationFromCodeGraphStatus(status),
+                statusObservation: codeGraphInspectionObservation(observationFromCodeGraphStatus(status), operation),
                 symbol,
                 telemetry: queryStageTelemetry,
                 threadnoteHome: config.agentContextHome,
@@ -1565,6 +1566,18 @@ export function codeGraphInspectionObservesWorktree(
   operation: 'explain' | 'impact' | 'neighbors' | 'node' | 'path' | 'query',
 ): boolean {
   return !codeGraphInspectionAllowsStaleReady(operation);
+}
+
+/** Shared/cold discovery may observe an overlay; ordinary inspections still defer its freshness. */
+export function codeGraphInspectionObservation(
+  observation: CodeGraphStatusObservation | undefined,
+  operation: Parameters<typeof codeGraphInspectionObservesWorktree>[0],
+): CodeGraphStatusObservation | undefined {
+  if (observation === undefined || codeGraphInspectionObservesWorktree(operation)) return observation;
+  return {
+    identity: observation.identity,
+    ...(observation.borrowedSnapshotId === undefined ? {} : {borrowedSnapshotId: observation.borrowedSnapshotId}),
+  };
 }
 
 /**

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -764,6 +764,7 @@ export {
   codeGraphAnalysisRefreshResult,
   codeGraphInspectionAllowsStaleReady,
   codeGraphInspectionObservesWorktree,
+  codeGraphInspectionObservation,
   codeGraphInspectionStartsRefresh,
   codeGraphMcpAnalysisBudget,
   codeGraphMcpAnalysisLimits,

--- a/src/remote_memory/document_compatibility.ts
+++ b/src/remote_memory/document_compatibility.ts
@@ -1,41 +1,36 @@
-import {assertMemoryDocumentSchemaWritable, parseMemoryDocument} from '../memory/document.js';
+import {assertMemoryDocumentSchemaWritable, formatMemoryDocument, parseMemoryDocument} from '../memory/document.js';
+import {memoryCodeCitationSharingBlocker} from '../memory/code_citation_policy.js';
 import {remoteMemoryError} from './errors.js';
-
-const BODY_REPLACEMENT_FIELDS = new Set([
-  'kind',
-  'status',
-  'project',
-  'topic',
-  'source_agent_client',
-  'timestamp',
-  'schema_version',
-  'memory_id',
-  'created_at',
-  'updated_at',
-  'visibility',
-]);
 
 export function assertRemoteBodyReplacementSupported(content: string): void {
   assertMemoryDocumentSchemaWritable(content);
   const normalized = content.trim().replace(/\r\n?/gu, '\n');
-  const header = normalized.split('\n\n', 1)[0];
-  const fields = header.split('\n').slice(1);
-  const seen = new Set<string>();
-  const unsupported = fields.some(line => {
-    const key = /^([a-z_]+):/u.exec(line)?.[1];
-    if (!key || !BODY_REPLACEMENT_FIELDS.has(key) || seen.has(key)) return true;
-    seen.add(key);
-    return false;
-  });
-  if (
-    unsupported ||
-    /\n\n<!-- MEMORY_FIELDS\n[\s\S]*?\n-->\s*$/u.test(normalized) ||
-    !parseMemoryDocument('threadnote://share/compatibility/memories/durable/project/topic.md', content)
-  ) {
-    throw remoteMemoryError(
-      'invalid_request',
-      'This document contains metadata the remote body editor cannot preserve. Edit it through the Git share until rich metadata editing is supported.',
-      {reason: 'unsupported_remote_metadata'},
-    );
+  if (/\n\n<!-- MEMORY_FIELDS\n[\s\S]*?\n-->\s*$/u.test(normalized)) unsupportedMetadata();
+  const record = parseMemoryDocument('threadnote://share/compatibility/memories/durable/project/topic.md', content);
+  if (!record) unsupportedMetadata();
+  if (memoryCodeCitationSharingBlocker(record.metadata)) unsupportedMetadata();
+  let formatted: string;
+  try {
+    formatted = formatMemoryDocument(record.headerTitle, record.metadata, '');
+  } catch {
+    unsupportedMetadata();
   }
+  const remaining = new Map<string, number>();
+  for (const line of formatted.split('\n\n', 1)[0].split('\n')) {
+    remaining.set(line, (remaining.get(line) ?? 0) + 1);
+  }
+  // Tolerant readers may discard unknown or malformed fields; a rewrite must preserve every occurrence.
+  for (const line of normalized.split('\n\n', 1)[0].split('\n')) {
+    const count = remaining.get(line) ?? 0;
+    if (count === 0) unsupportedMetadata();
+    remaining.set(line, count - 1);
+  }
+}
+
+function unsupportedMetadata(): never {
+  throw remoteMemoryError(
+    'invalid_request',
+    'This document contains metadata the remote body editor cannot preserve. Repair it through the Git share before editing remotely.',
+    {reason: 'unsupported_remote_metadata'},
+  );
 }

--- a/src/remote_memory/postgres_repository.ts
+++ b/src/remote_memory/postgres_repository.ts
@@ -1449,6 +1449,7 @@ function makeRemoteDocument(
   const prior = current && priorBody ? parseMemoryDocument(uri, priorBody) : undefined;
   if (current && priorBody) assertRemoteBodyReplacementSupported(priorBody);
   const metadata: MemoryMetadata = {
+    ...prior?.metadata,
     createdAt: prior?.metadata.createdAt ?? prior?.metadata.timestamp ?? timestamp,
     kind: input.kind,
     memoryId: prior?.metadata.memoryId ?? `tn_${randomUuidV4().replaceAll('-', '')}`,

--- a/test/helpers/remote-memory-document.ts
+++ b/test/helpers/remote-memory-document.ts
@@ -1,0 +1,54 @@
+import {createMemoryCodeCitation, MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
+import type {MemoryMetadata} from '../../src/memory/document.js';
+
+export function richRemoteMemoryMetadata(): MemoryMetadata {
+  const timestamp = '2026-09-01T10:00:00.000Z';
+  return {
+    archivedFrom: 'threadnote://memory/tn_previous',
+    authority: 'user_approved',
+    candidateId: 'candidate-1',
+    codeCitations: [
+      createMemoryCodeCitation({
+        extractorSet: 'native-code-graph-14',
+        fileContentHash: {algorithm: 'sha256', value: 'a'.repeat(64)},
+        path: 'src/example.ts',
+        repositoryId: '1'.repeat(64),
+        repositoryIdentityKind: 'remote',
+        sourceCommit: '2'.repeat(40),
+        sourceDirty: false,
+        sourceGraphContentId: `cgc_${'3'.repeat(40)}`,
+        sourceSnapshotId: `cgsn_${'4'.repeat(40)}`,
+        target: {kind: 'file'},
+        version: 1,
+      }),
+    ],
+    createdAt: timestamp,
+    evidence: ['session:turn-12', 'commit:abc123'],
+    kind: 'durable',
+    keywords: ['retained-keyword', 'second keyword', 'retained-keyword'],
+    lastReviewed: timestamp,
+    memoryId: 'tn_rich_memory',
+    project: 'restricted',
+    references: ['threadnote://memory/tn_first', 'threadnote://memory/tn_second'],
+    relations: [
+      {type: 'references', uri: 'threadnote://memory/tn_first'},
+      {type: 'depends_on', uri: 'threadnote://memory/tn_second'},
+    ],
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    sourceHash: 'sha256:abc123',
+    sourceAgentClient: 'codex',
+    sourceCommit: 'abc123',
+    sourceObservedAt: timestamp,
+    sourceSessionId: 'session-1',
+    status: 'active',
+    supersedes: 'threadnote://memory/tn_previous',
+    timestamp,
+    topic: 'rich',
+    trust: 'approved',
+    updatedAt: timestamp,
+    validFrom: timestamp,
+    validTo: '2027-09-01T10:00:00.000Z',
+    visibility: 'shared',
+    workspaceScope: 'packages/example',
+  };
+}

--- a/test/integration/code-graph.admission-freshness.test.ts
+++ b/test/integration/code-graph.admission-freshness.test.ts
@@ -1,0 +1,203 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {runIsolatedCodeGraphIndexSnapshot} from '../../src/code_graph/isolated_index.js';
+import {CodeGraphQueryService} from '../../src/code_graph/query.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('current graph admission freshness', () => {
+  it.effect(
+    'recovers real isolated child builds with the same policy-bound request identity',
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const query = yield* CodeGraphQueryService;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-isolated-admission-'});
+        const repo = path.join(root, 'repository');
+        const home = path.join(root, 'home');
+        yield* fs.makeDirectory(repo);
+        yield* fs.writeFileString(path.join(repo, 'included.ts'), 'export const includedSymbol = 1;\n');
+        yield* fs.writeFileString(path.join(repo, 'excluded.ts'), 'export const excludedSymbol = 2;\n');
+        const git = (args: readonly string[]) => runCommandEffect('git', ['-C', repo, ...args]);
+        yield* git(['init', '-q', '--initial-branch=main']);
+        yield* git(['add', '.']);
+        yield* git(['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']);
+        const first = yield* runIsolatedCodeGraphIndexSnapshot({cwd: repo, threadnoteHome: home, ensureVectors: false});
+        expect(first.snapshot.fileCount).toBe(2);
+        yield* fs.writeFileString(path.join(repo, '.git/info/exclude'), 'excluded.ts\n');
+        const second = yield* runIsolatedCodeGraphIndexSnapshot({
+          cwd: repo,
+          threadnoteHome: home,
+          ensureVectors: false,
+        });
+        expect(second.snapshot.fileCount).toBe(1);
+        const inspected = yield* query.inspect({
+          cwd: repo,
+          threadnoteHome: home,
+          operation: 'query',
+          query: 'excludedSymbol',
+          refresh: true,
+          requestMaintenance: false,
+        });
+        expect(inspected.freshness).toBe('current');
+        expect(inspected.nodes.some(node => node.name === 'excludedSymbol')).toBe(false);
+      }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    60_000,
+  );
+
+  it.effect(
+    'refreshes clean and dirty graphs after policy changes, including changes during a query',
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const indexer = yield* CodeGraphIndexer;
+        const query = yield* CodeGraphQueryService;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-admission-freshness-'});
+        const repo = path.join(root, 'repository');
+        const home = path.join(root, 'home');
+        yield* fs.makeDirectory(path.join(repo, 'src'), {recursive: true});
+        yield* fs.writeFileString(path.join(repo, 'package.json'), '{"name":"admission-freshness","type":"module"}\n');
+        yield* fs.writeFileString(path.join(repo, 'src/included.ts'), 'export const includedSymbol = 1;\n');
+        yield* fs.writeFileString(path.join(repo, 'src/excluded.ts'), 'export const excludedSymbol = 2;\n');
+        const git = (args: readonly string[]) => runCommandEffect('git', ['-C', repo, ...args]);
+        yield* git(['init', '-q', '--initial-branch=main']);
+        yield* git(['add', '.']);
+        yield* git(['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']);
+        const exclude = path.join(repo, '.git/info/exclude');
+        const inspect = () =>
+          query.inspect({
+            cwd: repo,
+            threadnoteHome: home,
+            operation: 'query',
+            query: 'excludedSymbol',
+            refresh: true,
+            requestMaintenance: false,
+          });
+        for (const dirty of [false, true]) {
+          yield* fs.writeFileString(exclude, '');
+          if (dirty)
+            yield* fs.writeFileString(path.join(repo, 'src/included.ts'), 'export const includedSymbol = 3;\n');
+          const indexed = yield* indexer.index({cwd: repo, threadnoteHome: home, ensureVectors: false});
+          expect(indexed.snapshot.dirty).toBe(dirty);
+          if (!dirty) {
+            const peer = path.join(root, 'peer');
+            const restricted = path.join(root, 'restricted');
+            yield* git(['config', 'extensions.worktreeConfig', 'true']);
+            yield* git(['worktree', 'add', '-q', '-b', 'peer', peer]);
+            yield* git(['worktree', 'add', '-q', '-b', 'restricted', restricted]);
+            const peerIdentity = yield* resolveRepositoryIdentity(peer);
+            const shared = yield* query.attachSharedReadySnapshot(home, peerIdentity, undefined, {
+              requestMaintenance: false,
+            });
+            expect(shared.freshness).toBe('current');
+            expect(shared.readySnapshot?.id).toBe(indexed.snapshot.id);
+            yield* fs.writeFileString(exclude, 'src/excluded.ts\n');
+            const reobserved = yield* query.attachSharedReadySnapshot(home, peerIdentity, shared, {
+              requestMaintenance: false,
+            });
+            expect(reobserved.freshness).toBe('stale');
+            yield* fs.writeFileString(exclude, '');
+            const peerExcludes = path.join(root, 'peer-excludes');
+            yield* fs.writeFileString(peerExcludes, 'src/excluded.ts\n');
+            yield* runCommandEffect('git', [
+              '-C',
+              restricted,
+              'config',
+              '--worktree',
+              'core.excludesFile',
+              peerExcludes,
+            ]);
+            const restrictedIdentity = yield* resolveRepositoryIdentity(restricted);
+            const denied = yield* query.attachSharedReadySnapshot(home, restrictedIdentity, undefined, {
+              requestMaintenance: false,
+            });
+            expect(denied.freshness).toBe('stale');
+            expect(denied.readySnapshot).toBeUndefined();
+            const concurrent = yield* Effect.all(
+              [
+                indexer.index({cwd: repo, threadnoteHome: home, ensureVectors: false}),
+                indexer.index({cwd: restricted, threadnoteHome: home, ensureVectors: false}),
+              ],
+              {concurrency: 2},
+            );
+            expect(concurrent[0].snapshot.graphContentId).not.toBe(concurrent[1].snapshot.graphContentId);
+            const restrictedQuery = yield* query.inspect({
+              cwd: restricted,
+              threadnoteHome: home,
+              operation: 'query',
+              query: 'excludedSymbol',
+              refresh: true,
+              requestMaintenance: false,
+            });
+            expect(restrictedQuery.freshness).toBe('current');
+            expect(restrictedQuery.nodes.some(node => node.name === 'excludedSymbol')).toBe(false);
+          }
+          yield* fs.writeFileString(exclude, 'src/excluded.ts\n');
+          const excluded = yield* inspect();
+          expect(excluded.freshness).toBe('current');
+          expect(excluded.nodes.some(node => node.name === 'excludedSymbol')).toBe(false);
+          yield* fs.writeFileString(exclude, '# comment-only policy\n');
+          const restored = yield* inspect();
+          expect(restored.freshness).toBe('current');
+          expect(restored.nodes.some(node => node.name === 'excludedSymbol')).toBe(true);
+          yield* fs.writeFileString(exclude, '# different comment, same admission\n');
+          expect((yield* inspect()).freshness).toBe('current');
+        }
+        let changed = false;
+        const raced = yield* query.inspect({
+          cwd: repo,
+          threadnoteHome: home,
+          operation: 'query',
+          query: 'excludedSymbol',
+          refresh: true,
+          requestMaintenance: false,
+          interlock: {
+            afterSnapshotSelected: () =>
+              Effect.gen(function* () {
+                if (!changed) {
+                  changed = true;
+                  yield* fs.writeFileString(exclude, 'src/excluded.ts\n');
+                }
+              }).pipe(Effect.orDie),
+          },
+        });
+        expect(raced.freshness).toBe('current');
+        expect(raced.nodes.some(node => node.name === 'excludedSymbol')).toBe(false);
+        yield* fs.writeFileString(exclude, '');
+        let changedDuringIndex = false;
+        yield* indexer.index({
+          cwd: repo,
+          threadnoteHome: home,
+          ensureVectors: false,
+          onProgress: progress =>
+            Effect.gen(function* () {
+              if (!changedDuringIndex && progress.phase === 'activating' && progress.subphase === 'complete') {
+                changedDuringIndex = true;
+                yield* fs.writeFileString(exclude, 'src/excluded.ts\n');
+              }
+            }),
+        });
+        expect(changedDuringIndex).toBe(true);
+        const afterLateIndexChange = yield* inspect();
+        expect(afterLateIndexChange.freshness).toBe('current');
+        expect(afterLateIndexChange.nodes.some(node => node.name === 'excludedSymbol')).toBe(false);
+        yield* fs.writeFileString(exclude, '');
+        yield* git(['add', 'src/included.ts']);
+        yield* git(['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'next layer']);
+        const layered = yield* indexer.index({cwd: repo, threadnoteHome: home, ensureVectors: false});
+        expect(layered.snapshot.dirty).toBe(false);
+        expect(layered.snapshot.baseSnapshotId).toBeDefined();
+        yield* fs.writeFileString(exclude, 'src/excluded.ts\n');
+        const afterLayerPolicyChange = yield* inspect();
+        expect(afterLayerPolicyChange.freshness).toBe('current');
+        expect(afterLayerPolicyChange.nodes.some(node => node.name === 'excludedSymbol')).toBe(false);
+      }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    60_000,
+  );
+});

--- a/test/integration/code-graph.checkpoint-admission.test.ts
+++ b/test/integration/code-graph.checkpoint-admission.test.ts
@@ -1,0 +1,155 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Path, Schema} from 'effect';
+import {TestClock} from 'effect/testing';
+import {
+  importCodeGraphCheckpointSnapshot,
+  CodeGraphCheckpointCommandError,
+  runCodeGraphCheckpointExport,
+} from '../../src/code_graph/checkpoint/commands.js';
+import {
+  decodeCodeGraphCheckpointPackV1,
+  encodeCodeGraphCheckpointPackV1,
+} from '../../src/code_graph/checkpoint/pack.js';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('checkpoint receiver admission', () => {
+  it.effect(
+    'rejects both stricter and looser receiver inventories without replacing ready state',
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const indexer = yield* CodeGraphIndexer;
+        const store = yield* CodeGraphStore;
+        const command = yield* CommandExecutor;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-checkpoint-admission-'});
+        const repo = path.join(root, 'repository');
+        yield* fs.makeDirectory(path.join(repo, 'src'), {recursive: true});
+        yield* fs.writeFileString(path.join(repo, 'package.json'), '{"name":"checkpoint-admission","type":"module"}\n');
+        yield* fs.writeFileString(path.join(repo, 'src/included.ts'), 'export const included = 1;\n');
+        yield* fs.writeFileString(path.join(repo, 'src/excluded.ts'), 'export const excluded = 2;\n');
+        yield* fs.makeDirectory(path.join(repo, 'assets'));
+        yield* fs.writeFile(path.join(repo, 'assets/icon.png'), new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]));
+        yield* git(repo, ['init', '-q', '--initial-branch=main']);
+        yield* git(repo, ['remote', 'add', 'origin', 'https://github.com/acme/checkpoint-admission.git']);
+        yield* git(repo, ['add', '.']);
+        yield* git(repo, ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']);
+        const exclude = path.join(repo, '.git/info/exclude');
+        for (const donorExcludes of [false, true]) {
+          const donorHome = path.join(root, `donor-${donorExcludes}`);
+          const receiverHome = path.join(root, `receiver-${donorExcludes}`);
+          const artifact = path.join(root, `checkpoint-${donorExcludes}.cgcp`);
+          yield* fs.writeFileString(exclude, donorExcludes ? 'src/excluded.ts\n' : '');
+          const donor = yield* indexer.index({cwd: repo, threadnoteHome: donorHome, ensureVectors: false});
+          yield* runCodeGraphCheckpointExport(config(donorHome), {cwd: repo, output: artifact, quiet: true});
+          const bytes = yield* fs.readFile(artifact);
+          const decoded = decodeCodeGraphCheckpointPackV1(bytes);
+          const withoutReuse = path.join(root, `without-reuse-${donorExcludes}.cgcp`);
+          yield* fs.writeFile(
+            withoutReuse,
+            encodeCodeGraphCheckpointPackV1(
+              {
+                abi: decoded.header.abi.input,
+                coverage: decoded.header.coverage,
+                repository: decoded.header.repository,
+                source: decoded.header.source,
+              },
+              decoded.records,
+            ).bytes,
+          );
+
+          yield* fs.writeFileString(exclude, donorExcludes ? '' : 'src/excluded.ts\n');
+          const receiver = yield* indexer.index({cwd: repo, threadnoteHome: receiverHome, ensureVectors: false});
+          const identity = yield* resolveRepositoryIdentity(repo);
+          const database = codeGraphLayout(path, receiverHome, identity.checkoutId, identity.worktreeId).databasePath;
+          for (const input of [artifact, withoutReuse]) {
+            const result = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {cwd: repo, input}).pipe(
+              Effect.result,
+            );
+            expect(result._tag).toBe('Failure');
+            if (result._tag === 'Failure') {
+              expect(result.failure).toMatchObject({
+                _tag: 'CodeGraphCheckpointCommandError',
+              });
+              expect(Schema.is(CodeGraphCheckpointCommandError)(result.failure)).toBe(true);
+              if (Schema.is(CodeGraphCheckpointCommandError)(result.failure)) {
+                expect(result.failure.message).toContain('receiver admission');
+              }
+            }
+            expect((yield* store.readySnapshot(database, identity.worktreeId))?.id).toBe(receiver.snapshot.id);
+          }
+
+          yield* fs.writeFileString(
+            exclude,
+            donorExcludes ? '# receiver comment\nsrc/excluded.ts\n' : '# receiver comment\n',
+          );
+          const accepted = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {cwd: repo, input: artifact});
+          expect(accepted.result.publication).toBe('activated');
+          expect(accepted.snapshot.graphContentId).toBe(donor.snapshot.graphContentId);
+          const acceptedWithoutReuse = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {
+            cwd: repo,
+            input: withoutReuse,
+          });
+          expect(acceptedWithoutReuse.result.publication).toBe('activated');
+          expect(acceptedWithoutReuse.snapshot.graphContentId).toBe(donor.snapshot.graphContentId);
+          let changedPolicy = false;
+          const raced = yield* importCodeGraphCheckpointSnapshot(config(receiverHome), {
+            cwd: repo,
+            input: artifact,
+          }).pipe(
+            Effect.provideService(CommandExecutor, {
+              ...command,
+              execute: (executable, args, options) =>
+                command.execute(executable, args, options).pipe(
+                  Effect.tap(() =>
+                    Effect.gen(function* () {
+                      if (executable === 'git' && args.includes('ls-tree') && args.includes('-r') && !changedPolicy) {
+                        expect(options?.env?.GIT_NO_LAZY_FETCH).toBe('1');
+                        expect(options?.env?.GIT_OPTIONAL_LOCKS).toBe('0');
+                        changedPolicy = true;
+                        yield* fs.writeFileString(exclude, donorExcludes ? '' : 'src/excluded.ts\n');
+                      }
+                    }),
+                  ),
+                ),
+            }),
+            Effect.result,
+          );
+          expect(changedPolicy).toBe(true);
+          expect(raced._tag).toBe('Failure');
+          if (raced._tag === 'Failure') {
+            expect(Schema.is(CodeGraphCheckpointCommandError)(raced.failure)).toBe(true);
+            if (Schema.is(CodeGraphCheckpointCommandError)(raced.failure)) {
+              expect(raced.failure.message).toContain('receiver admission');
+            }
+          }
+          expect((yield* store.readySnapshot(database, identity.worktreeId))?.id).toBe(
+            acceptedWithoutReuse.snapshot.id,
+          );
+          expect(yield* fs.readFile(artifact)).toEqual(bytes);
+          expect((yield* git(repo, ['status', '--porcelain'])).stdout).toBe('');
+        }
+      }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    60_000,
+  );
+});
+
+function config(home: string) {
+  return {
+    account: 'local' as const,
+    agentContextHome: home,
+    agentId: 'threadnote',
+    manifestPath: `${home}/seed-manifest.yaml`,
+    user: 'local',
+  };
+}
+
+function git(repo: string, args: readonly string[]) {
+  return runCommandEffect('git', ['-C', repo, ...args]);
+}

--- a/test/integration/code-graph.clean-base-admission.test.ts
+++ b/test/integration/code-graph.clean-base-admission.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {CodeGraphQueryService} from '../../src/code_graph/query.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('first dirty index clean-base admission', () => {
+  it.effect(
+    'shares its verified committed base while keeping dirty symbols local',
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const indexer = yield* CodeGraphIndexer;
+        const query = yield* CodeGraphQueryService;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-first-dirty-admission-'});
+        const repo = path.join(root, 'repository');
+        const peer = path.join(root, 'peer');
+        const home = path.join(root, 'home');
+        yield* fs.makeDirectory(repo);
+        yield* fs.writeFileString(path.join(repo, 'package.json'), '{"name":"first-dirty","type":"module"}\n');
+        for (let i = 0; i < 12; i++) {
+          yield* fs.writeFileString(path.join(repo, `file${i}.ts`), `export const cleanSymbol${i} = ${i};\n`);
+        }
+        const git = (args: readonly string[]) => runCommandEffect('git', ['-C', repo, ...args]);
+        yield* git(['init', '-q', '--initial-branch=main']);
+        yield* git(['add', '.']);
+        yield* git(['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']);
+        yield* git(['worktree', 'add', '-q', '-b', 'peer', peer]);
+        yield* fs.writeFileString(path.join(repo, 'file0.ts'), 'export const dirtyOnlyCanary = 42;\n');
+        const dirty = yield* indexer.index({cwd: repo, threadnoteHome: home, ensureVectors: false});
+        expect(dirty.snapshot.dirty).toBe(true);
+        expect(dirty.snapshot.baseSnapshotId).toBeDefined();
+        const peerIdentity = yield* resolveRepositoryIdentity(peer);
+        const attached = yield* query.attachSharedReadySnapshot(home, peerIdentity, undefined, {
+          requestMaintenance: false,
+        });
+        expect(attached.freshness).toBe('current');
+        expect(attached.readySnapshot?.id).toBe(dirty.snapshot.baseSnapshotId);
+        const clean = yield* query.inspect({
+          cwd: peer,
+          threadnoteHome: home,
+          operation: 'query',
+          query: 'cleanSymbol0',
+          refresh: false,
+          requestMaintenance: false,
+        });
+        expect(clean.nodes.some(node => node.name === 'cleanSymbol0')).toBe(true);
+        expect(clean.nodes.some(node => node.name === 'dirtyOnlyCanary')).toBe(false);
+        const current = yield* query.inspect({
+          cwd: repo,
+          threadnoteHome: home,
+          operation: 'query',
+          query: 'dirtyOnlyCanary',
+          refresh: true,
+          requestMaintenance: false,
+        });
+        expect(current.freshness).toBe('current');
+        expect(current.snapshot.id).toBe(dirty.snapshot.id);
+        expect(current.nodes.some(node => node.name === 'dirtyOnlyCanary')).toBe(true);
+        const restricted = path.join(root, 'restricted');
+        yield* git(['worktree', 'add', '-q', '-b', 'restricted', restricted]);
+        yield* fs.writeFileString(path.join(repo, '.git/info/exclude'), 'file1.ts\n');
+        const denied = yield* query.attachSharedReadySnapshot(
+          home,
+          yield* resolveRepositoryIdentity(restricted),
+          undefined,
+          {requestMaintenance: false},
+        );
+        expect(denied.freshness).toBe('stale');
+        expect(denied.readySnapshot).toBeUndefined();
+      }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+    60_000,
+  );
+});

--- a/test/integration/code-graph.inventory-environment.test.ts
+++ b/test/integration/code-graph.inventory-environment.test.ts
@@ -1,0 +1,69 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import {readCodeGraphInventoryReuseEnvironment} from '../../src/code_graph/inventory_reuse.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const testLayer = CommandExecutor.layer.pipe(Layer.provideMerge(Layer.mergeAll(BunServices.layer, SystemInfo.layer)));
+
+describe('inventory environment observes Git global excludes', () => {
+  it.effect(
+    'tracks Git defaults, explicit paths, and explicit disabling without changing the process environment',
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const command = yield* CommandExecutor;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-inventory-environment-'});
+        const repo = path.join(root, 'repository');
+        const privateHome = path.join(root, 'private-home');
+        const xdg = path.join(root, 'xdg');
+        const configured = path.join(root, 'configured-ignore');
+        yield* fs.makeDirectory(repo);
+        yield* runCommandEffect('git', ['init', '-q', repo]);
+        const identity = yield* resolveRepositoryIdentity(repo);
+        for (const xdgValue of [undefined, '', xdg]) {
+          const environment = {
+            ...system.environment(),
+            HOME: privateHome,
+            XDG_CONFIG_HOME: xdgValue,
+            GIT_CONFIG_NOSYSTEM: '1',
+            GIT_CONFIG_GLOBAL: path.join(root, 'empty-global-config'),
+          };
+          const defaultIgnore = path.join(xdgValue || path.join(privateHome, '.config'), 'git', 'ignore');
+          yield* fs.makeDirectory(path.dirname(defaultIgnore), {recursive: true});
+          yield* fs.writeFileString(defaultIgnore, 'first.ts\n');
+          const read = readCodeGraphInventoryReuseEnvironment(identity, fs, path).pipe(
+            Effect.provideService(SystemInfo, {...system, environment: () => environment}),
+            Effect.provideService(CommandExecutor, {
+              ...command,
+              execute: (executable, args, options) => command.execute(executable, args, {...options, env: environment}),
+            }),
+          );
+          const git = (args: readonly string[]) => command.execute('git', ['-C', repo, ...args], {env: environment});
+          yield* git(['config', '--unset', 'core.excludesFile']).pipe(Effect.ignore);
+          const before = yield* read;
+          yield* fs.writeFileString(defaultIgnore, 'second.ts\n');
+          expect((yield* read).fingerprint).not.toBe(before.fingerprint);
+
+          yield* git(['config', 'core.excludesFile', '']);
+          const disabled = yield* read;
+          yield* fs.writeFileString(defaultIgnore, 'third.ts\n');
+          expect((yield* read).fingerprint).toBe(disabled.fingerprint);
+
+          yield* fs.writeFileString(configured, 'configured-first.ts\n');
+          yield* git(['config', 'core.excludesFile', configured]);
+          const explicit = yield* read;
+          yield* fs.writeFileString(defaultIgnore, 'fourth.ts\n');
+          expect((yield* read).fingerprint).toBe(explicit.fingerprint);
+          yield* fs.writeFileString(configured, 'configured-second.ts\n');
+          expect((yield* read).fingerprint).not.toBe(explicit.fingerprint);
+        }
+      }).pipe(provideTestLayer(testLayer), TestClock.withLive),
+  );
+});

--- a/test/integration/code-graph.view-attach-lock.test.ts
+++ b/test/integration/code-graph.view-attach-lock.test.ts
@@ -1,12 +1,11 @@
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {execFileSync} from '../helpers/node-child-process.js';
-import {mkdtempSync, rmSync, writeFileSync} from '../helpers/node-fs.js';
-import {tmpdir} from '../helpers/node-os.js';
+import {writeFileSync} from '../helpers/node-fs.js';
 import {join} from '../helpers/node-path.js';
 import {Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {it as effectIt} from '@effect/vitest';
-import {afterEach, describe, expect, it} from 'vitest';
+import {describe, expect} from 'vitest';
 import {CodeGraphDiskCapacityPressureError} from '../../src/code_graph/disk_capacity.js';
 import {extractorSetIdentityFromPackProvenance} from '../../src/code_graph/indexer.js';
 import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../../src/code_graph/languages/registry.js';
@@ -18,19 +17,17 @@ import type {CodeGraphSnapshot, RepositoryIdentity} from '../../src/code_graph/t
 import {CommandExecutor} from '../../src/effect/command.js';
 import {withExclusiveFileLock} from '../../src/effect/file_lock.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
-import {runEffect} from '../helpers/effect-runtime.js';
+import {
+  observeCodeGraphAdmissionEnvironment,
+  recordCodeGraphSnapshotAdmission,
+} from '../../src/code_graph/admission_freshness.js';
 
-const temporaryRoots: string[] = [];
 const fixturePackProvenance = BUILTIN_LANGUAGE_PACK_REGISTRY.activePackProvenance(['main.ts']);
-
-afterEach(() => {
-  for (const root of temporaryRoots.splice(0).reverse()) rmSync(root, {force: true, recursive: true});
-});
 
 describe('shared ready view attachment locking', () => {
   effectIt.effect('protects shared-ready promotion and retries the exact candidate after capacity returns', () =>
     Effect.gen(function* () {
-      const root = temporaryRepository();
+      const root = yield* temporaryRepository();
       const repositoryRoot = join(root, 'repository');
       const threadnoteHome = join(root, 'threadnote-home');
       const path = yield* Path.Path;
@@ -40,6 +37,13 @@ describe('shared ready view attachment locking', () => {
       const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
       const snapshot = readySnapshot(identity);
       yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
+      yield* recordCodeGraphSnapshotAdmission(
+        layout,
+        snapshot,
+        yield* observeCodeGraphAdmissionEnvironment(identity),
+        BUILTIN_LANGUAGE_PACK_REGISTRY,
+        false,
+      );
       yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
       const before = yield* graph.statusForIdentity(threadnoteHome, identity);
       let promotionProbes = 0;
@@ -68,198 +72,218 @@ describe('shared ready view attachment locking', () => {
     }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
   );
 
-  it('defers without mutation when the target builder is active, then attaches after release', async () => {
-    const root = temporaryRepository();
-    const repositoryRoot = join(root, 'repository');
-    const threadnoteHome = join(root, 'threadnote-home');
+  effectIt.effect('defers without mutation when the target builder is active, then attaches after release', () =>
+    Effect.gen(function* () {
+      const root = yield* temporaryRepository();
+      const repositoryRoot = join(root, 'repository');
+      const threadnoteHome = join(root, 'threadnote-home');
 
-    const observed = await runEffect(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const command = yield* CommandExecutor;
-        const graph = yield* CodeGraphQueryService;
-        const store = yield* CodeGraphStore;
-        const identity = yield* resolveRepositoryIdentity(repositoryRoot);
-        const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
-        const snapshot = readySnapshot(identity);
-        yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
-        yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
-        const before = yield* graph.statusForIdentity(threadnoteHome, identity);
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const command = yield* CommandExecutor;
+      const graph = yield* CodeGraphQueryService;
+      const store = yield* CodeGraphStore;
+      const identity = yield* resolveRepositoryIdentity(repositoryRoot);
+      const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
+      const snapshot = readySnapshot(identity);
+      yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
+      yield* recordCodeGraphSnapshotAdmission(
+        layout,
+        snapshot,
+        yield* observeCodeGraphAdmissionEnvironment(identity),
+        BUILTIN_LANGUAGE_PACK_REGISTRY,
+        false,
+      );
+      yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
+      const before = yield* graph.statusForIdentity(threadnoteHome, identity);
 
-        const acquired = yield* Deferred.make<void>();
-        const release = yield* Deferred.make<void>();
-        const owner = yield* Effect.forkChild(
-          withExclusiveFileLock(
-            fs,
-            layout.lockPath,
-            {
-              onAcquired: () => Deferred.succeed(acquired, undefined).pipe(Effect.asVoid),
-              retryIntervalMilliseconds: 5,
-              staleAfterMilliseconds: 120_000,
-              waitTimeoutMilliseconds: 5_000,
-            },
-            Deferred.await(release),
-          ),
-        );
-        yield* Deferred.await(acquired);
-        const startedAt = performance.now();
-        const deferred = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, before);
-        const elapsedMilliseconds = performance.now() - startedAt;
-        const pointerWhileBusy = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
-        yield* Deferred.succeed(release, undefined);
-        yield* Fiber.join(owner);
+      const acquired = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const owner = yield* Effect.forkChild(
+        withExclusiveFileLock(
+          fs,
+          layout.lockPath,
+          {
+            onAcquired: () => Deferred.succeed(acquired, undefined).pipe(Effect.asVoid),
+            retryIntervalMilliseconds: 5,
+            staleAfterMilliseconds: 120_000,
+            waitTimeoutMilliseconds: 5_000,
+          },
+          Deferred.await(release),
+        ),
+      );
+      yield* Deferred.await(acquired);
+      const startedAt = performance.now();
+      const deferred = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, before);
+      const elapsedMilliseconds = performance.now() - startedAt;
+      const pointerWhileBusy = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+      yield* Deferred.succeed(release, undefined);
+      yield* Fiber.join(owner);
 
-        const counts = {branchObservation: 0, fullIdentity: 0, git: 0, publicationProof: 0, status: 0};
-        const mutableCommand = command as {
-          execute: typeof command.execute;
-          executeBytes?: NonNullable<typeof command.executeBytes>;
-        };
-        const execute = command.execute;
-        const executeBytes = command.executeBytes;
-        const observeInvocation = (executable: string, args: readonly string[]) => {
-          if (executable !== 'git') return;
-          counts.git += 1;
-          if (args.includes('symbolic-ref')) counts.branchObservation += 1;
-          if (args[2] === 'rev-parse' && args[3] === '--show-toplevel') counts.fullIdentity += 1;
-          if (args[2] === 'status') {
-            counts.status += 1;
-            if (args.includes('--porcelain=v2')) counts.publicationProof += 1;
-          }
-        };
-        const attached = yield* Effect.acquireUseRelease(
-          Effect.sync(() => {
-            mutableCommand.execute = (executable, args, options) => {
+      const counts = {branchObservation: 0, fullIdentity: 0, git: 0, publicationProof: 0, status: 0};
+      const mutableCommand = command as {
+        execute: typeof command.execute;
+        executeBytes?: NonNullable<typeof command.executeBytes>;
+      };
+      const execute = command.execute;
+      const executeBytes = command.executeBytes;
+      const observeInvocation = (executable: string, args: readonly string[]) => {
+        if (executable !== 'git') return;
+        counts.git += 1;
+        if (args.includes('symbolic-ref')) counts.branchObservation += 1;
+        if (args[2] === 'rev-parse' && args[3] === '--show-toplevel') counts.fullIdentity += 1;
+        if (args[2] === 'status') {
+          counts.status += 1;
+          if (args.includes('--porcelain=v2')) counts.publicationProof += 1;
+        }
+      };
+      const attached = yield* Effect.acquireUseRelease(
+        Effect.sync(() => {
+          mutableCommand.execute = (executable, args, options) => {
+            observeInvocation(executable, args);
+            return execute(executable, args, options);
+          };
+          if (executeBytes) {
+            mutableCommand.executeBytes = (executable, args, options) => {
               observeInvocation(executable, args);
-              return execute(executable, args, options);
+              return executeBytes(executable, args, options);
             };
-            if (executeBytes) {
-              mutableCommand.executeBytes = (executable, args, options) => {
-                observeInvocation(executable, args);
-                return executeBytes(executable, args, options);
-              };
-            }
+          }
+        }),
+        () => graph.attachSharedReadySnapshot(threadnoteHome, identity, before),
+        () =>
+          Effect.sync(() => {
+            mutableCommand.execute = execute;
+            mutableCommand.executeBytes = executeBytes;
           }),
-          () => graph.attachSharedReadySnapshot(threadnoteHome, identity, before),
-          () =>
-            Effect.sync(() => {
-              mutableCommand.execute = execute;
-              mutableCommand.executeBytes = executeBytes;
-            }),
-        );
-        return {attached, before, counts, deferred, elapsedMilliseconds, pointerWhileBusy, snapshot};
-      }),
-    );
+      );
+      const observed = {attached, before, counts, deferred, elapsedMilliseconds, pointerWhileBusy, snapshot};
 
-    expect(observed.before.readySnapshot).toBeUndefined();
-    expect(observed.deferred.readySnapshot).toBeUndefined();
-    expect(observed.pointerWhileBusy).toBeUndefined();
-    expect(observed.elapsedMilliseconds).toBeLessThan(500);
-    expect(observed.attached.readySnapshot?.id).toBe(observed.snapshot.id);
-    expect(observed.attached.stale).toBe(false);
-    expect(observed.counts).toEqual({branchObservation: 1, fullIdentity: 1, git: 9, publicationProof: 1, status: 2});
-  });
+      expect(observed.before.readySnapshot).toBeUndefined();
+      expect(observed.deferred.readySnapshot).toBeUndefined();
+      expect(observed.pointerWhileBusy).toBeUndefined();
+      expect(observed.elapsedMilliseconds).toBeLessThan(500);
+      expect(observed.attached.readySnapshot?.id).toBe(observed.snapshot.id);
+      expect(observed.attached.stale).toBe(false);
+      expect(observed.counts).toEqual({branchObservation: 1, fullIdentity: 1, git: 15, publicationProof: 1, status: 2});
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
 
-  it('does not promote an optimistic candidate after HEAD moves before target-lock acquisition', async () => {
-    const root = temporaryRepository();
-    const repositoryRoot = join(root, 'repository');
-    const threadnoteHome = join(root, 'threadnote-home');
-    const nextCommit = createNextCommit(repositoryRoot);
-    git(repositoryRoot, ['reset', '--hard', 'HEAD~1']);
+  effectIt.effect('does not promote an optimistic candidate after HEAD moves before target-lock acquisition', () =>
+    Effect.gen(function* () {
+      const root = yield* temporaryRepository();
+      const repositoryRoot = join(root, 'repository');
+      const threadnoteHome = join(root, 'threadnote-home');
+      const nextCommit = createNextCommit(repositoryRoot);
+      git(repositoryRoot, ['reset', '--hard', 'HEAD~1']);
 
-    const observed = await runEffect(
-      Effect.gen(function* () {
-        const path = yield* Path.Path;
-        const graph = yield* CodeGraphQueryService;
-        const store = yield* CodeGraphStore;
-        const identity = yield* resolveRepositoryIdentity(repositoryRoot);
-        const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
-        const snapshot = readySnapshot(identity);
-        yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
-        yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
-        const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
-          afterOptimisticCandidate: () => Effect.sync(() => git(repositoryRoot, ['reset', '--hard', nextCommit])),
-        });
-        const pointer = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
-        return {attached, identity, pointer};
-      }),
-    );
+      const path = yield* Path.Path;
+      const graph = yield* CodeGraphQueryService;
+      const store = yield* CodeGraphStore;
+      const identity = yield* resolveRepositoryIdentity(repositoryRoot);
+      const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
+      const snapshot = readySnapshot(identity);
+      yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
+      yield* recordCodeGraphSnapshotAdmission(
+        layout,
+        snapshot,
+        yield* observeCodeGraphAdmissionEnvironment(identity),
+        BUILTIN_LANGUAGE_PACK_REGISTRY,
+        false,
+      );
+      yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
+      const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
+        afterOptimisticCandidate: () => Effect.sync(() => git(repositoryRoot, ['reset', '--hard', nextCommit])),
+      });
+      const pointer = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+      const observed = {attached, identity, pointer};
 
-    expect(observed.attached.identity.headCommit).toBe(nextCommit);
-    expect(observed.attached.identity.headCommit).not.toBe(observed.identity.headCommit);
-    expect(observed.attached.readySnapshot).toBeUndefined();
-    expect(observed.attached.stale).toBe(true);
-    expect(observed.pointer).toBeUndefined();
-  });
+      expect(observed.attached.identity.headCommit).toBe(nextCommit);
+      expect(observed.attached.identity.headCommit).not.toBe(observed.identity.headCommit);
+      expect(observed.attached.readySnapshot).toBeUndefined();
+      expect(observed.attached.stale).toBe(true);
+      expect(observed.pointer).toBeUndefined();
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
 
-  it('reports the new identity as stale when HEAD moves immediately after promotion', async () => {
-    const root = temporaryRepository();
-    const repositoryRoot = join(root, 'repository');
-    const threadnoteHome = join(root, 'threadnote-home');
-    let nextCommit: string | undefined;
+  effectIt.effect('reports the new identity as stale when HEAD moves immediately after promotion', () =>
+    Effect.gen(function* () {
+      const root = yield* temporaryRepository();
+      const repositoryRoot = join(root, 'repository');
+      const threadnoteHome = join(root, 'threadnote-home');
+      let nextCommit: string | undefined;
 
-    const observed = await runEffect(
-      Effect.gen(function* () {
-        const path = yield* Path.Path;
-        const graph = yield* CodeGraphQueryService;
-        const store = yield* CodeGraphStore;
-        const identity = yield* resolveRepositoryIdentity(repositoryRoot);
-        const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
-        const snapshot = readySnapshot(identity);
-        yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
-        yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
-        const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
-          afterPromotion: () =>
-            Effect.sync(() => {
-              nextCommit = createNextCommit(repositoryRoot);
-            }),
-        });
-        const pointer = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
-        return {attached, pointer, snapshot};
-      }),
-    );
+      const path = yield* Path.Path;
+      const graph = yield* CodeGraphQueryService;
+      const store = yield* CodeGraphStore;
+      const identity = yield* resolveRepositoryIdentity(repositoryRoot);
+      const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
+      const snapshot = readySnapshot(identity);
+      yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
+      yield* recordCodeGraphSnapshotAdmission(
+        layout,
+        snapshot,
+        yield* observeCodeGraphAdmissionEnvironment(identity),
+        BUILTIN_LANGUAGE_PACK_REGISTRY,
+        false,
+      );
+      yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
+      const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
+        afterPromotion: () =>
+          Effect.sync(() => {
+            nextCommit = createNextCommit(repositoryRoot);
+          }),
+      });
+      const pointer = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+      const observed = {attached, pointer, snapshot};
 
-    expect(nextCommit).toBeDefined();
-    expect(observed.attached.identity.headCommit).toBe(nextCommit);
-    expect(observed.attached.readySnapshot?.id).toBe(observed.snapshot.id);
-    expect(observed.attached.stale).toBe(true);
-    expect(observed.pointer?.id).toBe(observed.snapshot.id);
-  });
+      expect(nextCommit).toBeDefined();
+      expect(observed.attached.identity.headCommit).toBe(nextCommit);
+      expect(observed.attached.readySnapshot?.id).toBe(observed.snapshot.id);
+      expect(observed.attached.stale).toBe(true);
+      expect(observed.pointer?.id).toBe(observed.snapshot.id);
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
 
-  it('reports stale when a tracked file changes immediately after promotion without moving HEAD', async () => {
-    const root = temporaryRepository();
-    const repositoryRoot = join(root, 'repository');
-    const threadnoteHome = join(root, 'threadnote-home');
+  effectIt.effect('reports stale when a tracked file changes immediately after promotion without moving HEAD', () =>
+    Effect.gen(function* () {
+      const root = yield* temporaryRepository();
+      const repositoryRoot = join(root, 'repository');
+      const threadnoteHome = join(root, 'threadnote-home');
 
-    const observed = await runEffect(
-      Effect.gen(function* () {
-        const path = yield* Path.Path;
-        const graph = yield* CodeGraphQueryService;
-        const store = yield* CodeGraphStore;
-        const identity = yield* resolveRepositoryIdentity(repositoryRoot);
-        const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
-        const snapshot = readySnapshot(identity);
-        yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
-        yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
-        const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
-          afterPromotion: () =>
-            Effect.sync(() => writeFileSync(join(repositoryRoot, 'main.ts'), 'export const attached = "dirty";\n')),
-        });
-        const pointer = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
-        return {attached, identity, pointer, snapshot};
-      }),
-    );
+      const path = yield* Path.Path;
+      const graph = yield* CodeGraphQueryService;
+      const store = yield* CodeGraphStore;
+      const identity = yield* resolveRepositoryIdentity(repositoryRoot);
+      const layout = codeGraphLayout(path, threadnoteHome, identity.checkoutId, identity.worktreeId);
+      const snapshot = readySnapshot(identity);
+      yield* store.activate(layout.databasePath, identity, snapshot, [], [], [], fixturePackProvenance);
+      yield* recordCodeGraphSnapshotAdmission(
+        layout,
+        snapshot,
+        yield* observeCodeGraphAdmissionEnvironment(identity),
+        BUILTIN_LANGUAGE_PACK_REGISTRY,
+        false,
+      );
+      yield* store.acquireSnapshotLease(layout.databasePath, snapshot.id, 60_000);
+      const attached = yield* graph.attachSharedReadySnapshot(threadnoteHome, identity, undefined, {
+        afterPromotion: () =>
+          Effect.sync(() => writeFileSync(join(repositoryRoot, 'main.ts'), 'export const attached = "dirty";\n')),
+      });
+      const pointer = yield* store.readySnapshot(layout.databasePath, identity.worktreeId);
+      const observed = {attached, identity, pointer, snapshot};
 
-    expect(observed.attached.identity.headCommit).toBe(observed.identity.headCommit);
-    expect(observed.attached.readySnapshot?.id).toBe(observed.snapshot.id);
-    expect(observed.attached.stale).toBe(true);
-    expect(observed.pointer?.id).toBe(observed.snapshot.id);
-  });
+      expect(observed.attached.identity.headCommit).toBe(observed.identity.headCommit);
+      expect(observed.attached.readySnapshot?.id).toBe(observed.snapshot.id);
+      expect(observed.attached.stale).toBe(true);
+      expect(observed.pointer?.id).toBe(observed.snapshot.id);
+    }).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
+  );
 });
 
-function temporaryRepository(): string {
-  const root = mkdtempSync(join(tmpdir(), 'threadnote-view-attach-lock-'));
-  temporaryRoots.push(root);
+const temporaryRepository = Effect.fn('test.temporaryViewAttachRepository')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-view-attach-lock-'});
   const repositoryRoot = join(root, 'repository');
   execFileSync('git', ['init', repositoryRoot], {stdio: 'ignore'});
   execFileSync('git', ['-C', repositoryRoot, 'config', 'user.email', 'threadnote-test@example.invalid']);
@@ -268,7 +292,7 @@ function temporaryRepository(): string {
   git(repositoryRoot, ['add', 'main.ts']);
   git(repositoryRoot, ['commit', '-m', 'fixture']);
   return root;
-}
+});
 
 function createNextCommit(repositoryRoot: string): string {
   writeFileSync(join(repositoryRoot, 'main.ts'), 'export const attached = "new-head";\n');

--- a/test/integration/mcp.native-tools.test.ts
+++ b/test/integration/mcp.native-tools.test.ts
@@ -3142,9 +3142,9 @@ describe('Threadnote MCP toolsets', () => {
               }
             | undefined;
           expect(firstStructured).toMatchObject({
+            freshness: 'deferred',
             nodes: expect.arrayContaining([expect.objectContaining({name: repositoryFixture.before})]),
           });
-          expect(['current', 'deferred']).toContain(firstStructured?.freshness);
           expect(typeof firstStructured?.snapshot?.id).toBe('string');
 
           const branch = `${repositoryFixture.name}-linked`;
@@ -3164,7 +3164,7 @@ describe('Threadnote MCP toolsets', () => {
           expect(Date.now() - attachedStartedAt).toBeLessThan(5_000);
           expect(attached.isError).not.toBe(true);
           expect(attached.structuredContent).toMatchObject({
-            freshness: 'current',
+            freshness: 'deferred',
             nodes: expect.arrayContaining([expect.objectContaining({name: repositoryFixture.before})]),
             snapshot: {id: firstStructured?.snapshot?.id},
           });

--- a/test/integration/remote-memory-git-authority.test.ts
+++ b/test/integration/remote-memory-git-authority.test.ts
@@ -7,6 +7,9 @@ import {GitCanonicalMemoryStore} from '../../src/remote_memory/git_canonical_sto
 import {PostgresRemoteControlPlane} from '../../src/remote_memory/postgres_control_plane.js';
 import {PostgresRemoteMemoryRepository} from '../../src/remote_memory/postgres_repository.js';
 import {RemoteMemoryIndexer} from '../../src/remote_memory/indexer.js';
+import {formatMemoryDocument, parseMemoryDocument} from '../../src/memory/document.js';
+import {richRemoteMemoryMetadata} from '../helpers/remote-memory-document.js';
+import {git} from '../helpers/git-share-worktree.js';
 
 const DATABASE = process.env.THREADNOTE_TEST_POSTGRES_URL;
 const postgresDescribe = DATABASE ? describe : describe.skip;
@@ -82,12 +85,12 @@ postgresDescribe('Git ingest system authority', () => {
     }
   });
 
-  it('rejects HTTP body replacement that would erase metadata from Git', async () => {
+  it('preserves rich Git metadata through CAS replacement, replay, and stale rejection', async () => {
     const f = await fixture();
     try {
       const path = 'durable/projects/restricted/rich.md';
-      const content =
-        'MEMORY\nkind: durable\nstatus: active\nproject: restricted\ntopic: rich\nkeywords: retained-keyword\n\nRetain the original body.';
+      const metadata = richRemoteMemoryMetadata();
+      const content = formatMemoryDocument('MEMORY', metadata, 'Retain the original body.');
       const committed = await f.store.commit({path, content, message: 'Rich Git memory'});
       await f.repository.ingestActiveGitShares('rich-ingest');
       const principal = await new PostgresRemoteControlPlane(f.database.sql).authorize(
@@ -97,29 +100,92 @@ postgresDescribe('Git ingest system authority', () => {
       if (!principal) throw new Error('Fixture principal missing');
       const uri = `threadnote://share/${f.input.shareId}/memories/durable/restricted/rich.md`;
       const original = await f.repository.read(principal, {version: 1, uri}, 'read-rich');
+      const input = {
+        version: 1 as const,
+        kind: 'durable' as const,
+        project: 'restricted',
+        topic: 'rich',
+        text: 'Changed body',
+        operationId: 'replace-rich',
+        baseRevision: original.receipt.revision,
+      };
+      const replaced = await f.repository.remember(principal, input, 'replace-rich');
+      const read = await f.repository.read(principal, {version: 1, uri}, 'read-replaced');
+      expect(read.receipt.revision).toBe(replaced.revision);
+      const parsed = parseMemoryDocument(uri, read.content);
+      expect(parsed?.body).toBe('Changed body');
+      expect(parsed?.metadata).toEqual({
+        ...metadata,
+        sourceAgentClient: 'remote',
+        timestamp: expect.any(String),
+        updatedAt: expect.any(String),
+      });
+      expect(parsed?.metadata.updatedAt).not.toBe(metadata.updatedAt);
+      const editedFields = /^(source_agent_client|timestamp|updated_at):/u;
+      const preservedLines = content
+        .split('\n\n', 1)[0]
+        .split('\n')
+        .filter(line => !editedFields.test(line));
+      expect(
+        read.content
+          .split('\n\n', 1)[0]
+          .split('\n')
+          .filter(line => !editedFields.test(line)),
+      ).toEqual(preservedLines);
+      expect(await git(['show', `HEAD:${path}`], f.git.remote)).toBe(read.content);
+      expect((await f.repository.remember(principal, input, 'replay-rich')).revision).toBe(replaced.revision);
       await expect(
-        f.repository.remember(
-          principal,
-          {
-            version: 1,
-            kind: 'durable',
-            project: 'restricted',
-            topic: 'rich',
-            text: 'Changed body',
-            operationId: 'replace-rich',
-            baseRevision: original.receipt.revision,
-          },
-          'replace-rich',
-        ),
-      ).rejects.toMatchObject({code: 'invalid_request', details: {reason: 'unsupported_remote_metadata'}});
-      expect((await f.store.listCanonicalPaths()).find(entry => entry.gitPath === path)?.gitCommit).toBe(
-        committed.gitCommit,
-      );
+        f.repository.remember(principal, {...input, operationId: 'stale-rich', text: 'Stale body'}, 'stale-rich'),
+      ).rejects.toMatchObject({code: 'conflict'});
+      expect((await f.repository.read(principal, {version: 1, uri}, 'read-after-stale')).content).toBe(read.content);
       expect(await f.store.read({commit: committed.gitCommit, path})).toBe(content);
     } finally {
       await f.dispose();
     }
   });
+
+  it.each(['x_extension: retained', 'code_citation: invalid', 'memory_id: tn_one\nmemory_id: tn_two'])(
+    'leaves Git and the revision unchanged when metadata cannot be preserved: %s',
+    async field => {
+      const f = await fixture();
+      try {
+        const path = 'durable/projects/restricted/unsupported.md';
+        const content = `MEMORY\nkind: durable\n${field}\n\nOriginal body`;
+        const committed = await f.store.commit({path, content, message: 'Unsupported metadata fixture'});
+        await f.repository.ingestActiveGitShares('unsupported-ingest');
+        const principal = await new PostgresRemoteControlPlane(f.database.sql).authorize(
+          {issuer: f.input.issuer, subject: f.input.subject, scopes: new Set(f.input.capabilities)},
+          f.input.shareId,
+        );
+        if (!principal) throw new Error('Fixture principal missing');
+        const uri = `threadnote://share/${f.input.shareId}/memories/durable/restricted/unsupported.md`;
+        const original = await f.repository.read(principal, {version: 1, uri}, 'read-unsupported');
+        await expect(
+          f.repository.remember(
+            principal,
+            {
+              version: 1,
+              kind: 'durable',
+              project: 'restricted',
+              topic: 'unsupported',
+              text: 'Changed body',
+              operationId: 'replace-unsupported',
+              baseRevision: original.receipt.revision,
+            },
+            'replace-unsupported',
+          ),
+        ).rejects.toMatchObject({code: 'invalid_request', details: {reason: 'unsupported_remote_metadata'}});
+        expect((await f.store.listCanonicalPaths()).find(entry => entry.gitPath === path)?.gitCommit).toBe(
+          committed.gitCommit,
+        );
+        const read = await f.repository.read(principal, {version: 1, uri}, 'read-after-rejection');
+        expect(read.content).toBe(original.content);
+        expect(read.receipt.revision).toBe(original.receipt.revision);
+      } finally {
+        await f.dispose();
+      }
+    },
+  );
 
   it('projects canonical Git independently of member order, scopes, and revocation', async () => {
     const f = await fixture();

--- a/test/unit/code-graph.admission-freshness.test.ts
+++ b/test/unit/code-graph.admission-freshness.test.ts
@@ -1,0 +1,108 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {
+  codeGraphSnapshotAdmissionCurrent,
+  recordCodeGraphSnapshotAdmission,
+} from '../../src/code_graph/admission_freshness.js';
+import {codeGraphBuildRequestKey} from '../../src/code_graph/indexer_build.js';
+import {BUILTIN_LANGUAGE_PACK_REGISTRY} from '../../src/code_graph/languages/registry.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import type {CodeGraphSnapshot} from '../../src/code_graph/types.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+describe('snapshot admission cache', () => {
+  it.effect.prop(
+    'binds current evidence to exactly one snapshot and environment per worktree',
+    {
+      dirty: FC.boolean(),
+      layered: FC.boolean(),
+      suffix: FC.integer({min: 1, max: 100_000}),
+    },
+    ({dirty, layered, suffix}) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-admission-cache-'});
+        const layout = codeGraphLayout(path, home, 'c'.repeat(64), 'd'.repeat(64));
+        const snapshot: CodeGraphSnapshot = {
+          ...(layered ? {baseSnapshotId: `cgsn_${'0'.repeat(40)}`} : {}),
+          commit: 'e'.repeat(40),
+          dirty,
+          edgeCount: 0,
+          extractorSet: 'f'.repeat(64),
+          fileCount: 1,
+          id: `cgsn_${suffix.toString(16).padStart(40, '0')}`,
+          repositoryId: 'a'.repeat(64),
+          state: 'ready',
+          symbolCount: 1,
+          worktreeId: layout.worktreeId,
+        };
+        const packs = BUILTIN_LANGUAGE_PACK_REGISTRY;
+        const first = '1'.repeat(64),
+          second = '2'.repeat(64);
+        expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs)).toBe(false);
+        yield* recordCodeGraphSnapshotAdmission(layout, snapshot, first, packs, false);
+        expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs)).toBe(true);
+        expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, second, packs)).toBe(false);
+        if (!dirty) {
+          yield* recordCodeGraphSnapshotAdmission(
+            layout,
+            {...snapshot, dirty: true, id: `${snapshot.id}-dirty`},
+            first,
+            packs,
+            false,
+          );
+          expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs)).toBe(false);
+          expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs, true)).toBe(true);
+          expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, second, packs, true)).toBe(false);
+          yield* recordCodeGraphSnapshotAdmission(layout, snapshot, first, packs, false);
+        }
+        const replacement = {...snapshot, id: `${snapshot.id}-next`};
+        expect(yield* codeGraphSnapshotAdmissionCurrent(layout, replacement, first, packs)).toBe(false);
+        expect(
+          yield* codeGraphSnapshotAdmissionCurrent(layout, {...snapshot, repositoryId: 'b'.repeat(64)}, first, packs),
+        ).toBe(false);
+        yield* recordCodeGraphSnapshotAdmission(layout, replacement, second, packs, true);
+        expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs)).toBe(false);
+        expect(yield* codeGraphSnapshotAdmissionCurrent(layout, replacement, second, packs)).toBe(true);
+        const target = path.join(layout.repositoryRoot, 'admission', `${layout.worktreeId}.json`);
+        for (const broken of ['{"version":', ' '.repeat(4_097)]) {
+          yield* fs.writeFileString(target, broken);
+          expect(yield* codeGraphSnapshotAdmissionCurrent(layout, replacement, second, packs)).toBe(false);
+        }
+      }).pipe(provideTestLayer(BunServices.layer)),
+    {fastCheck: {numRuns: 20}},
+  );
+
+  it.prop(
+    'deduplicates only build requests with the same policy environment',
+    {
+      suffix: FC.integer({min: 0, max: 1_000_000}),
+      dirty: FC.boolean(),
+    },
+    ({suffix, dirty}) => {
+      const identity = {
+        checkoutId: 'c'.repeat(64),
+        headCommit: 'e'.repeat(40),
+        repositoryId: 'a'.repeat(64),
+        worktreeId: 'd'.repeat(64),
+      };
+      const environment = suffix.toString(16).padStart(64, '0');
+      const changed = (suffix + 1).toString(16).padStart(64, '0');
+      const key = (value: string) =>
+        codeGraphBuildRequestKey(
+          identity,
+          {dirty, fingerprint: 'overlay'},
+          BUILTIN_LANGUAGE_PACK_REGISTRY,
+          undefined,
+          false,
+          value,
+        );
+      expect(key(environment)).toBe(key(environment));
+      expect(key(environment)).not.toBe(key(changed));
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+});

--- a/test/unit/code-graph.admission-freshness.test.ts
+++ b/test/unit/code-graph.admission-freshness.test.ts
@@ -47,16 +47,19 @@ describe('snapshot admission cache', () => {
         expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs)).toBe(true);
         expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, second, packs)).toBe(false);
         if (!dirty) {
-          yield* recordCodeGraphSnapshotAdmission(
-            layout,
-            {...snapshot, dirty: true, id: `${snapshot.id}-dirty`},
-            first,
-            packs,
-            false,
-          );
+          const overlay = {...snapshot, dirty: true, id: `${snapshot.id}-dirty`};
+          yield* recordCodeGraphSnapshotAdmission(layout, overlay, first, packs, false);
           expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs)).toBe(false);
           expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs, true)).toBe(true);
           expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, second, packs, true)).toBe(false);
+          yield* recordCodeGraphSnapshotAdmission(layout, snapshot, first, packs, false, {cleanOnly: true});
+          expect(yield* codeGraphSnapshotAdmissionCurrent(layout, overlay, first, packs)).toBe(true);
+          expect(yield* codeGraphSnapshotAdmissionCurrent(layout, snapshot, first, packs)).toBe(false);
+          const rejected = yield* recordCodeGraphSnapshotAdmission(layout, overlay, first, packs, false, {
+            cleanOnly: true,
+          }).pipe(Effect.flip);
+          expect(rejected).toMatchObject({_tag: 'CodeGraphAdmissionError'});
+          expect(yield* codeGraphSnapshotAdmissionCurrent(layout, overlay, first, packs)).toBe(true);
           yield* recordCodeGraphSnapshotAdmission(layout, snapshot, first, packs, false);
         }
         const replacement = {...snapshot, id: `${snapshot.id}-next`};

--- a/test/unit/code-graph.checkpoint-import-store.test.ts
+++ b/test/unit/code-graph.checkpoint-import-store.test.ts
@@ -519,43 +519,54 @@ describe('code graph checkpoint import store', () => {
               Buffer.byteLength(content),
             );
 
-            const hydrated = yield* hydrateCodeGraphCheckpointReusableBaseReceipt(identity, header);
+            const admission = {environmentFingerprint: 'a'.repeat(64)};
+            const hydrated = yield* hydrateCodeGraphCheckpointReusableBaseReceipt(identity, header, admission);
 
             expect(hydrated?.inventory?.attributionFiles).toEqual([
               expect.objectContaining({blobId, content: compactContent, path: 'package.json', source: 'commit'}),
             ]);
-            expect(hydrated?.inventory?.environmentFingerprint).toMatch(/^[0-9a-f]{64}$/u);
+            expect(hydrated?.inventory?.environmentFingerprint).toBe(admission.environmentFingerprint);
 
             const mismatch = yield* Effect.exit(
-              hydrateCodeGraphCheckpointReusableBaseReceipt(identity, {
-                ...header,
-                reuse: {
-                  ...header.reuse!,
-                  inventory: {
-                    ...header.reuse!.inventory!,
-                    attributionFiles: [{...header.reuse!.inventory!.attributionFiles[0], contentHash: 'f'.repeat(64)}],
+              hydrateCodeGraphCheckpointReusableBaseReceipt(
+                identity,
+                {
+                  ...header,
+                  reuse: {
+                    ...header.reuse!,
+                    inventory: {
+                      ...header.reuse!.inventory!,
+                      attributionFiles: [
+                        {...header.reuse!.inventory!.attributionFiles[0], contentHash: 'f'.repeat(64)},
+                      ],
+                    },
                   },
                 },
-              }),
+                admission,
+              ),
             );
             expect(mismatch._tag).toBe('Failure');
 
             const sourceSizeMismatch = yield* Effect.exit(
-              hydrateCodeGraphCheckpointReusableBaseReceipt(identity, {
-                ...header,
-                reuse: {
-                  ...header.reuse!,
-                  inventory: {
-                    ...header.reuse!.inventory!,
-                    attributionFiles: [
-                      {
-                        ...header.reuse!.inventory!.attributionFiles[0],
-                        blobSize: header.reuse!.inventory!.attributionFiles[0].blobSize + 1,
-                      },
-                    ],
+              hydrateCodeGraphCheckpointReusableBaseReceipt(
+                identity,
+                {
+                  ...header,
+                  reuse: {
+                    ...header.reuse!,
+                    inventory: {
+                      ...header.reuse!.inventory!,
+                      attributionFiles: [
+                        {
+                          ...header.reuse!.inventory!.attributionFiles[0],
+                          blobSize: header.reuse!.inventory!.attributionFiles[0].blobSize + 1,
+                        },
+                      ],
+                    },
                   },
                 },
-              }),
+                admission,
+              ),
             );
             expect(sourceSizeMismatch._tag).toBe('Failure');
           }),

--- a/test/unit/code-graph.checkpoint-receiver-admission.property.test.ts
+++ b/test/unit/code-graph.checkpoint-receiver-admission.property.test.ts
@@ -1,0 +1,72 @@
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {CodeGraphCheckpointReceiverFileVerifier} from '../../src/code_graph/checkpoint/receiver_admission.js';
+import type {CodeGraphCheckpointFileRecordV1} from '../../src/code_graph/checkpoint/schema.js';
+
+function file(id: number): CodeGraphCheckpointFileRecordV1 {
+  return {
+    blobId: id.toString(16).padStart(40, '0'),
+    contentHash: id.toString(16).padStart(64, '0'),
+    kind: 'file',
+    language: 'typescript',
+    mode: '100644',
+    path: `src/file-${id}.ts`,
+    size: 10,
+    source: 'commit',
+  };
+}
+
+describe('checkpoint receiver file admission', () => {
+  it('accepts exactly equal file sets regardless of traversal order', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.integer({min: 0, max: 50}), {maxLength: 12}),
+        fc.uniqueArray(fc.integer({min: 0, max: 50}), {maxLength: 12}),
+        (receiver, donor) => {
+          const verify = (ids: readonly number[]) => {
+            const verifier = new CodeGraphCheckpointReceiverFileVerifier(receiver.map(file));
+            return ids.every(id => verifier.accept(file(id))) && verifier.complete;
+          };
+          expect(verify([...receiver].reverse())).toBe(true);
+          expect(verify(donor)).toBe(receiver.length === donor.length && donor.every(id => receiver.includes(id)));
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  it('rejects duplicate records and changed identities', () => {
+    const original = file(1);
+    const duplicate = new CodeGraphCheckpointReceiverFileVerifier([original]);
+    expect(duplicate.accept(original)).toBe(true);
+    expect(duplicate.accept(original)).toBe(false);
+    expect(duplicate.complete).toBe(false);
+    for (const changed of [
+      {...original, blobId: 'a'.repeat(40)},
+      {...original, contentHash: 'a'.repeat(64)},
+      {...original, language: 'javascript'},
+      {...original, mode: '100755'},
+    ]) {
+      const verifier = new CodeGraphCheckpointReceiverFileVerifier([original]);
+      expect(verifier.accept(changed)).toBe(false);
+      expect(verifier.complete).toBe(false);
+    }
+  });
+
+  it('admits receiptless full or structural sets without admitting partial media or missing source', () => {
+    const source = file(1);
+    const images = [
+      {...file(2), path: 'assets/one.png'},
+      {...file(3), path: 'assets/two.png'},
+    ];
+    const complete = (records: readonly CodeGraphCheckpointFileRecordV1[]) => {
+      const verifier = new CodeGraphCheckpointReceiverFileVerifier([source, ...images], {allowStructuralOnly: true});
+      return records.every(record => verifier.accept(record)) && verifier.complete;
+    };
+    expect(complete([source])).toBe(true);
+    expect(complete([...images, source])).toBe(true);
+    expect(complete([source, images[0]])).toBe(false);
+    expect(complete(images)).toBe(false);
+    expect(complete([])).toBe(false);
+  });
+});

--- a/test/unit/code-graph.isolated-index.test.ts
+++ b/test/unit/code-graph.isolated-index.test.ts
@@ -52,8 +52,22 @@ const result = {
 describe('isolated index snapshot recovery', () => {
   it('never attaches a vector-required request to an active or completed structural-only build', () => {
     const languagePacks = {cacheIdentities: [], packs: []} as unknown as CodeGraphLanguagePackRegistryShape;
-    const structuralOnlyKey = codeGraphBuildRequestKey(identity, {dirty: false}, languagePacks, undefined, false);
-    const vectorRequiredKey = codeGraphBuildRequestKey(identity, {dirty: false}, languagePacks, undefined, true);
+    const structuralOnlyKey = codeGraphBuildRequestKey(
+      identity,
+      {dirty: false},
+      languagePacks,
+      undefined,
+      false,
+      'f'.repeat(64),
+    );
+    const vectorRequiredKey = codeGraphBuildRequestKey(
+      identity,
+      {dirty: false},
+      languagePacks,
+      undefined,
+      true,
+      'f'.repeat(64),
+    );
 
     expect(vectorRequiredKey).not.toBe(structuralOnlyKey);
     for (const liveness of ['active', 'completed'] as const) {

--- a/test/unit/code-graph.query.test.ts
+++ b/test/unit/code-graph.query.test.ts
@@ -6,7 +6,7 @@ import {tmpdir} from '../helpers/node-os.js';
 import {join} from '../helpers/node-path.js';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {expect, it} from '@effect/vitest';
-import {Effect, Fiber, Layer, Ref} from 'effect';
+import {Effect, Fiber, Layer, Path, Ref} from 'effect';
 import {TestClock} from 'effect/testing';
 import {describe} from 'vitest';
 import type {CodeGraphEmbeddingIndexShape} from '../../src/code_graph/embedding.js';
@@ -15,7 +15,11 @@ import {CommandExecutor} from '../../src/effect/command.js';
 import {SystemInfo} from '../../src/effect/system.js';
 import {CodeGraphIndexer, extractorSetIdentityFromPackProvenance} from '../../src/code_graph/indexer.js';
 import {CodeGraphLanguagePackRegistry} from '../../src/code_graph/languages/registry.js';
-import type {CodeGraphLayout} from '../../src/code_graph/layout.js';
+import {codeGraphLayout, type CodeGraphLayout} from '../../src/code_graph/layout.js';
+import {
+  observeCodeGraphAdmissionEnvironment,
+  recordCodeGraphSnapshotAdmission,
+} from '../../src/code_graph/admission_freshness.js';
 import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
 import {
   CodeGraphQueryService,
@@ -283,6 +287,13 @@ describe('code graph query budgets', () => {
             worktreeId: identity.worktreeId,
           } satisfies CodeGraphSnapshot;
           yield* Ref.set(snapshotRef, snapshot);
+          yield* recordCodeGraphSnapshotAdmission(
+            codeGraphLayout(yield* Path.Path, fixtureRoot.home, identity.checkoutId, identity.worktreeId),
+            snapshot,
+            yield* observeCodeGraphAdmissionEnvironment(identity),
+            yield* CodeGraphLanguagePackRegistry,
+            false,
+          );
           const sessionResult = yield* query.withStatusSession!(
             fixtureRoot.home,
             fixtureRoot.repository,

--- a/test/unit/mcp-broker.test.ts
+++ b/test/unit/mcp-broker.test.ts
@@ -9,6 +9,104 @@ import {
 import type {StandaloneActiveRelease} from '../../src/process/standalone_lease.js';
 
 describe('MCP session broker', () => {
+  it('reports missing activation without dispatching any request or changing its id', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.oneof(fc.integer(), fc.string({maxLength: 40})), async id => {
+        const clientInput = new AsyncByteQueue();
+        const clientOutput = new AsyncByteQueue();
+        let spawned = 0;
+        const running = runMcpBroker({
+          input: clientInput,
+          readActiveRelease: async () => undefined,
+          spawn: () => {
+            spawned += 1;
+            throw new Error('Unexpected spawn');
+          },
+          writeOutput: async line => clientOutput.pushLine(line),
+        });
+        clientInput.pushLine(
+          JSON.stringify({id, jsonrpc: '2.0', method: 'tools/call', params: {name: 'remember_context'}}),
+        );
+        const failure = JSON.parse(await clientOutput.nextLine());
+        clientInput.end();
+        await running;
+        expect(failure).toMatchObject({
+          id,
+          error: {code: -32_603, data: {reason: 'no-active-release', requestDisposition: 'not-dispatched'}},
+        });
+        expect(failure.error.message).toContain('threadnote install --no-start');
+        expect(failure.error.message).not.toContain('outcome is unknown');
+        expect(spawned).toBe(0);
+        expect(clientOutput.availableLines()).toBe(0);
+      }),
+      {numRuns: 50},
+    );
+  });
+
+  it('recovers on the same transport after activation without replaying rejected work', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    let active: StandaloneActiveRelease | undefined;
+    const child = new FakeMcpChild('activated');
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => active,
+      spawn: () => child,
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(JSON.parse(await clientOutput.nextLine()).error.data.reason).toBe('no-active-release');
+    active = {releaseRoot: '/threadnote/versions/activated', version: 'activated'};
+    clientInput.pushLine(JSON.stringify({id: 2, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({
+      id: 2,
+      result: {serverInfo: {version: 'activated'}},
+    });
+    active = undefined;
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/call', params: {name: 'health'}}));
+    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({id: 3, result: {version: 'activated'}});
+    expect(child.received.map(line => JSON.parse(line).id)).toEqual([2, 3]);
+    clientInput.end();
+    await running;
+  });
+
+  it('keeps an outstanding mutation uncertain when a later request fails before dispatch', async () => {
+    const clientInput = new AsyncByteQueue();
+    const clientOutput = new AsyncByteQueue();
+    const release = {releaseRoot: '/threadnote/versions/private-release', version: 'private-version'};
+    const child = new FakeMcpChild(release.version, {respondToTools: false});
+    let failRead = false;
+    const running = runMcpBroker({
+      input: clientInput,
+      readActiveRelease: async () => {
+        if (failRead) throw new Error('Private lookup failure /Users/private/token');
+        return release;
+      },
+      spawn: () => child,
+      writeOutput: async line => clientOutput.pushLine(line),
+    });
+    clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
+    await clientOutput.nextLine();
+    clientInput.pushLine(
+      JSON.stringify({id: 2, jsonrpc: '2.0', method: 'tools/call', params: {name: 'remember_context'}}),
+    );
+    await child.receivedCount(2);
+    failRead = true;
+    clientInput.pushLine(JSON.stringify({id: 3, jsonrpc: '2.0', method: 'tools/list'}));
+    const mutation = JSON.parse(await clientOutput.nextLine());
+    const lookup = JSON.parse(await clientOutput.nextLine());
+    clientInput.end();
+    await running;
+    expect(mutation).toMatchObject({id: 2, error: {message: expect.stringContaining('outcome is unknown')}});
+    expect(mutation.error.data).toBeUndefined();
+    expect(lookup).toMatchObject({
+      id: 3,
+      error: {data: {reason: 'startup-failed', requestDisposition: 'not-dispatched'}},
+    });
+    expect(JSON.stringify(lookup)).not.toContain('private');
+    expect(child.received).toHaveLength(2);
+  });
+
   it('reports a closed spawn failure without allowing the observer to alter recovery', async () => {
     const clientInput = new AsyncByteQueue();
     const clientOutput = new AsyncByteQueue();
@@ -28,7 +126,12 @@ describe('MCP session broker', () => {
     });
 
     clientInput.pushLine(JSON.stringify({id: 1, jsonrpc: '2.0', method: 'initialize', params: {}}));
-    expect(JSON.parse(await clientOutput.nextLine())).toMatchObject({error: {code: -32_603}, id: 1});
+    const failure = JSON.parse(await clientOutput.nextLine());
+    expect(failure).toMatchObject({
+      error: {code: -32_603, data: {reason: 'startup-failed', requestDisposition: 'not-dispatched'}},
+      id: 1,
+    });
+    expect(JSON.stringify(failure)).not.toContain('private');
     clientInput.end();
     await running;
 

--- a/test/unit/mcp-code-graph-progress.test.ts
+++ b/test/unit/mcp-code-graph-progress.test.ts
@@ -8,6 +8,7 @@ import {
   codeGraphAnalysisRefreshResult,
   codeGraphInspectionAllowsStaleReady,
   codeGraphInspectionObservesWorktree,
+  codeGraphInspectionObservation,
   codeGraphInspectionStartsRefresh,
   codeGraphMcpAnalysisBudget,
   codeGraphMcpAnalysisLimits,
@@ -24,6 +25,7 @@ import {
 import {analyzeCodeGraph} from '../../src/code_graph/analysis.js';
 import type {CodeGraphProgress, CodeGraphQueryResult} from '../../src/code_graph/types.js';
 import type {CodeGraphRefreshStatus} from '../../src/code_graph/watcher.js';
+import type {CodeGraphStatusObservation} from '../../src/code_graph/query_contract.js';
 import {measureAgentToolResponse} from '../../src/evaluation/agent-response.js';
 import {analysisEdge, analysisSnapshot, analysisSymbol, pagedAnalysisStore} from '../helpers/code-graph-analysis.js';
 import {
@@ -32,6 +34,51 @@ import {
 } from '../../src/telemetry/diagnostic.js';
 
 describe('MCP code graph indexing progress', () => {
+  it.prop(
+    'preserves selected evidence without letting fallback observations change an operation freshness contract',
+    {
+      operation: FC.constantFrom(
+        'query' as const,
+        'node' as const,
+        'neighbors' as const,
+        'explain' as const,
+        'path' as const,
+        'impact' as const,
+      ),
+      borrowedSnapshotId: FC.option(FC.string({maxLength: 40}), {nil: undefined}),
+      dirty: FC.boolean(),
+      observed: FC.boolean(),
+      fingerprint: FC.string({maxLength: 64}),
+    },
+    ({operation, borrowedSnapshotId, dirty, observed, fingerprint}) => {
+      const observation: CodeGraphStatusObservation = {
+        identity: {
+          caseMode: 'sensitive',
+          checkoutId: 'checkout',
+          displayName: 'fixture',
+          gitCommonDirectory: '/fixture/.git',
+          headCommit: 'head',
+          objectFormat: 'sha1',
+          repoRoot: '/fixture',
+          repositoryId: 'repository',
+          worktreeId: 'worktree',
+        },
+        ...(borrowedSnapshotId === undefined ? {} : {borrowedSnapshotId}),
+        ...(observed ? {overlay: {dirty, fingerprint}} : {}),
+      };
+      const before = JSON.stringify(observation);
+      const projected = codeGraphInspectionObservation(observation, operation);
+      expect(projected?.identity).toBe(observation.identity);
+      expect(projected?.borrowedSnapshotId).toBe(borrowedSnapshotId);
+      if (operation === 'path' || operation === 'impact') expect(projected).toBe(observation);
+      else expect(projected?.overlay).toBeUndefined();
+      expect(codeGraphInspectionObservation(projected, operation)).toEqual(projected);
+      expect(JSON.stringify(observation)).toBe(before);
+      expect(codeGraphInspectionObservation(undefined, operation)).toBeUndefined();
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
   it('allows stale ready evidence for non-strict operations only', () => {
     expect(
       Object.fromEntries(

--- a/test/unit/remote-memory-document-compatibility.test.ts
+++ b/test/unit/remote-memory-document-compatibility.test.ts
@@ -1,6 +1,9 @@
 import {describe, expect, it} from 'vitest';
 import * as FC from 'effect/testing/FastCheck';
 import {assertRemoteBodyReplacementSupported} from '../../src/remote_memory/document_compatibility.js';
+import {formatMemoryDocument} from '../../src/memory/document.js';
+import {richRemoteMemoryMetadata} from '../helpers/remote-memory-document.js';
+import {createMemoryCodeCitation} from '../../src/memory/code_citation.js';
 
 describe('remote body replacement compatibility', () => {
   it('rejects unknown header fields without consuming or rewriting them', () => {
@@ -17,19 +20,47 @@ describe('remote body replacement compatibility', () => {
     );
   });
 
-  it('supports basic remote documents and rejects rich or malformed local ones', () => {
+  it('supports basic and rich documents without changing the source metadata', () => {
     expect(() =>
       assertRemoteBodyReplacementSupported('MEMORY\nkind: durable\n\nThe documentation mentions `<!-- MEMORY_FIELDS`.'),
     ).not.toThrow();
     expect(() =>
       assertRemoteBodyReplacementSupported('MEMORY\nkind: durable\nstatus: active\nmemory_id: tn_123\n\nBody'),
     ).not.toThrow();
+    const metadata = richRemoteMemoryMetadata();
+    const before = structuredClone(metadata);
+    const document = formatMemoryDocument('MEMORY', metadata, 'Original body');
+    for (const newline of ['\n', '\r\n', '\r']) {
+      expect(() => assertRemoteBodyReplacementSupported(document.replaceAll('\n', newline))).not.toThrow();
+    }
+    expect(metadata).toEqual(before);
+  });
+
+  it('accepts repeated list metadata including duplicate values', () => {
+    FC.assert(
+      FC.property(
+        FC.array(FC.stringMatching(/^[a-z][a-z0-9 -]{0,30}[a-z]$/u), {minLength: 1, maxLength: 20}),
+        keywords => {
+          const metadata = {...richRemoteMemoryMetadata(), keywords: [...keywords, ...keywords]};
+          const document = formatMemoryDocument('MEMORY', metadata, 'Original body');
+          expect(() => assertRemoteBodyReplacementSupported(document)).not.toThrow();
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  it('rejects metadata that tolerant parsing would discard or change', () => {
     for (const field of [
       'code_citation: invalid',
-      'relation: references threadnote://memory/tn_123',
-      'keywords: important',
-      'trust: approved',
-      'workspace_scope: src',
+      'relation: invalid threadnote://memory/tn_123',
+      'keywords:',
+      'trust: invented',
+      'status: invented',
+      'status: active\nstatus: active',
+      'memory_id: tn_first\nmemory_id: tn_second',
+      'workspace_scope:  src',
+      'schema_version: 999',
       'this header is malformed',
     ]) {
       expect(() => assertRemoteBodyReplacementSupported(`MEMORY\nkind: durable\n${field}\n\nBody`)).toThrow();
@@ -40,5 +71,17 @@ describe('remote body replacement compatibility', () => {
         'MEMORY\nkind: durable\n\nBody\n\n<!-- MEMORY_FIELDS\nreferences: legacy\n-->',
       ),
     ).toThrow();
+  });
+
+  it('rejects citations that cannot cross the sharing boundary', () => {
+    const metadata = richRemoteMemoryMetadata();
+    const {id: _id, ...citation} = metadata.codeCitations![0];
+    for (const unsafe of [
+      createMemoryCodeCitation({...citation, sourceDirty: true}),
+      createMemoryCodeCitation({...citation, repositoryIdentityKind: 'local'}),
+    ]) {
+      const document = formatMemoryDocument('MEMORY', {...metadata, codeCitations: [unsafe]}, 'Original body');
+      expect(() => assertRemoteBodyReplacementSupported(document)).toThrow('metadata');
+    }
   });
 });


### PR DESCRIPTION
Changes to local Git exclusions could leave a ready graph reporting current while returning files the receiver now excludes. Bind current queries and shared-worktree attachment to admission evidence captured by indexing or checkpoint validation; policy changes trigger the existing bounded refresh path.

Retain bounded current and last-clean evidence per worktree, including a verified clean base created during the first dirty index. Bind local, isolated-child, and watcher request keys to the captured policy and recheck it at publication and strict query completion. Ordinary MCP reads retain deferred freshness across cold/shared discovery while strict reads still require complete evidence.

Validation: focused clean/dirty/layered and isolated-child regressions; sibling attachment and policy races; checkpoint, lifecycle, telemetry, watcher, workset and impact coverage; bounded receipt/request-key/observation properties; lint and typecheck. All dev-cycle review passes ended with zero blockers. Global CLI checks cover policy changes, independent graph-content parity and first-dirty base attachment without a peer build. The original native cold-build CI failure was reproduced and fixed without changing its assertions or CI gates. Exact commit e9b18952 is installed globally; real MCP smoke verifies bounded cold progress, first-ready deferred freshness, and retained stale evidence after a new commit. The full 49-case native MCP file passes, including three-language shared-worktree coverage now requiring exact deferred freshness while retaining strict impact=current assertions. Fresh full-suite CI is required.

Dependencies #396 and #397 are merged. This PR targets main and requires the complete CI workflows.
