### PR TITLE
feat(graph): add authenticated read-only metadata control

### DIFF
--- a/src/code_graph/sharing/cli.ts
+++ b/src/code_graph/sharing/cli.ts
@@ -88,6 +88,10 @@ export function makeGraphSharingCommands(
   const graphPublisherServe = Command.make(
     'serve',
     {
+      authorizationPolicy: optionalString(
+        'authorization-policy',
+        'Policy file for authenticated frontier/status reads; disables artifact routes and contributor mutations',
+      ),
       cas: optionalString('cas', 'Digest-addressed CAS directory for signed frontier artifacts'),
       cwd: codeGraphCliBounds.cwd,
       json: codeGraphCliBounds.json,

--- a/src/code_graph/sharing/commands.ts
+++ b/src/code_graph/sharing/commands.ts
@@ -1,6 +1,7 @@
 import {Console, Effect} from 'effect';
 import {writeFinalCliOutput} from '../../effect/cli_output.js';
 import type {RuntimeConfig} from '../../types.js';
+import {graphSharingFailure} from './errors.js';
 import {
   runGraphContributeSet,
   runGraphContributeStatus,
@@ -105,6 +106,9 @@ export const runGraphPublisherServeCommand = Effect.fn('codeGraph.sharing.publis
   config: RuntimeConfig,
   options: GraphPublisherBootstrapOptions,
 ) {
+  if (options.authorizationPolicy !== undefined && !options.listen?.trim()) {
+    return yield* graphSharingFailure('Graph control authorization requires --listen.');
+  }
   if (options.listen !== undefined && options.listen.trim().length > 0) {
     return yield* runGraphPublisherListen(config, {
       ...options,

--- a/src/code_graph/sharing/control_authorization.ts
+++ b/src/code_graph/sharing/control_authorization.ts
@@ -1,0 +1,108 @@
+import {Effect, FileSystem, Option, Schema, Stream} from 'effect';
+import type {AccessTokenClaims} from '../../oauth/access_token.js';
+import {SHA256_DIGEST, SHA256_HEX} from './digest.js';
+import {graphSharingFailure} from './errors.js';
+
+const Text = Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(512));
+const Policy = Schema.Struct({
+  audience: Text,
+  grants: Schema.Array(
+    Schema.Struct({
+      expiresAt: Schema.Int.check(Schema.isGreaterThan(0)),
+      scopes: Schema.Array(Schema.Literal('graph:read')).check(Schema.isMaxLength(1)),
+      subject: Text,
+    }),
+  ).check(Schema.isMaxLength(1024)),
+  issuer: Text,
+  jwksUrl: Text,
+  organization: Schema.String.check(Schema.isPattern(/^[a-z0-9][a-z0-9._-]{0,127}$/u)),
+  profileDigest: Schema.String.check(Schema.isPattern(SHA256_DIGEST)),
+  repositoryId: Schema.String.check(Schema.isPattern(SHA256_HEX)),
+  schemaVersion: Schema.Literal(1),
+});
+
+export type GraphControlPolicy = typeof Policy.Type;
+export type GraphControlScope = Pick<GraphControlPolicy, 'organization' | 'profileDigest' | 'repositoryId'>;
+
+export function parseGraphControlPolicy(value: unknown): GraphControlPolicy {
+  try {
+    const policy = Schema.decodeUnknownSync(Policy, {onExcessProperty: 'error'})(value);
+    const issuer = policyUrl(policy.issuer);
+    const jwks = policyUrl(policy.jwksUrl);
+    policyUrl(policy.audience);
+    if (
+      issuer.origin !== jwks.origin ||
+      new Set(policy.grants.map(grant => grant.subject)).size !== policy.grants.length
+    ) {
+      throw new Error('Invalid policy binding');
+    }
+    return policy;
+  } catch {
+    throw graphSharingFailure('Graph control policy is invalid.');
+  }
+}
+
+function policyUrl(value: string): URL {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash)
+    throw new Error('Invalid URL');
+  return url;
+}
+
+export const readGraphControlPolicy = Effect.fn('codeGraph.sharing.readControlPolicy')(function* (file: string) {
+  const bytes = yield* readGraphControlBytes(file, 128 * 1024);
+  return yield* Effect.try({
+    try: () => parseGraphControlPolicy(JSON.parse(new TextDecoder('utf-8', {fatal: true}).decode(bytes))),
+    catch: () => graphSharingFailure('Graph control policy is invalid.'),
+  });
+});
+
+export const readGraphControlBytes = Effect.fn('codeGraph.sharing.readControlBytes')(function* (
+  file: string,
+  maximum: number,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  if (Option.isSome(yield* fs.readLink(file).pipe(Effect.option))) {
+    return yield* graphSharingFailure('Graph control metadata is unavailable.');
+  }
+  const chunks = yield* Stream.runCollect(fs.stream(file, {bytesToRead: maximum + 1}));
+  const bytes = Buffer.concat(chunks);
+  if (bytes.length > maximum) return yield* graphSharingFailure('Graph control metadata exceeds its size limit.');
+  return bytes;
+});
+
+export function graphControlGrantAllowsRead(
+  policy: GraphControlPolicy,
+  scope: GraphControlScope,
+  principal: Pick<AccessTokenClaims, 'issuer' | 'subject' | 'scopes'>,
+  nowSeconds: number,
+): boolean {
+  return (
+    Number.isFinite(nowSeconds) &&
+    policy.organization === scope.organization &&
+    policy.repositoryId === scope.repositoryId &&
+    policy.profileDigest === scope.profileDigest &&
+    policy.issuer === principal.issuer &&
+    principal.scopes.has('graph:read') &&
+    policy.grants.some(
+      grant =>
+        grant.subject === principal.subject && grant.expiresAt > nowSeconds && grant.scopes.includes('graph:read'),
+    )
+  );
+}
+
+export function makeGraphControlRateLimit(options = {maximumPrincipals: 1024, requestsPerMinute: 120}) {
+  const entries = new Map<string, {count: number; expiresAt: number}>();
+  return (principal: string, nowMilliseconds: number): boolean => {
+    for (const [key, value] of entries) if (value.expiresAt <= nowMilliseconds) entries.delete(key);
+    const current = entries.get(principal);
+    if (current) {
+      if (current.count >= options.requestsPerMinute) return false;
+      current.count += 1;
+      return true;
+    }
+    if (entries.size >= options.maximumPrincipals) return false;
+    entries.set(principal, {count: 1, expiresAt: nowMilliseconds + 60_000});
+    return true;
+  };
+}

--- a/src/code_graph/sharing/control_reader.ts
+++ b/src/code_graph/sharing/control_reader.ts
@@ -1,0 +1,219 @@
+import {Clock, Console, Effect, Path, Semaphore} from 'effect';
+import * as HttpServerRequest from 'effect/unstable/http/HttpServerRequest';
+import * as HttpServerResponse from 'effect/unstable/http/HttpServerResponse';
+import {
+  createRemoteAccessTokenVerifier,
+  parseBearerAccessToken,
+  type AccessTokenClaims,
+} from '../../oauth/access_token.js';
+import {
+  parseGraphShareFrontierManifest,
+  parseGraphShareFrontierPointer,
+  parseGraphShareSignatureEnvelope,
+  verifyGraphShareFrontier,
+} from './artifacts.js';
+import {decodeJsonBytes} from './atomic.js';
+import {casBlobPath} from './cas.js';
+import {
+  graphControlGrantAllowsRead,
+  makeGraphControlRateLimit,
+  readGraphControlBytes,
+  readGraphControlPolicy,
+  type GraphControlPolicy,
+  type GraphControlScope,
+} from './control_authorization.js';
+import {GRAPH_SHARE_CONTROL_MAX_BODY_BYTES} from './control_protocol.js';
+import {parseSha256Digest, sha256Digest} from './digest.js';
+import {graphSharingFailure} from './errors.js';
+import {graphSharingFrontierPointerPath, graphSharingLayout} from './layout.js';
+import {graphShareFrontierDiscoveryTag} from './namespace.js';
+import {
+  assertProfileMatchesEnrollment,
+  graphShareProfileDigest,
+  type GraphShareEnrollmentV1,
+  type GraphShareProfileV1,
+} from './profile.js';
+
+export interface GraphControlReaderOptions {
+  readonly casRoot: string;
+  readonly enrollment: GraphShareEnrollmentV1;
+  readonly policyFile: string;
+  readonly profile: GraphShareProfileV1;
+  readonly threadnoteHome: string;
+}
+
+type Operation = 'discovery' | 'frontier' | 'status' | 'unsupported';
+
+export const validateGraphControlPolicy = Effect.fn('codeGraph.sharing.validateControlPolicy')(function* (
+  options: GraphControlReaderOptions,
+) {
+  const scope = graphControlReaderScope(options);
+  const policy = yield* readGraphControlPolicy(options.policyFile);
+  if (
+    policy.organization !== scope.organization ||
+    policy.repositoryId !== scope.repositoryId ||
+    policy.profileDigest !== scope.profileDigest
+  ) {
+    return yield* graphSharingFailure('Graph control policy does not match the enrolled profile.');
+  }
+  return policy;
+});
+
+export const makeGraphControlReader = Effect.fn('codeGraph.sharing.makeControlReader')(function* (
+  options: GraphControlReaderOptions,
+  verifyToken?: (token: string) => Promise<AccessTokenClaims>,
+) {
+  const scope = graphControlReaderScope(options);
+  const initial = yield* validateGraphControlPolicy(options);
+  const verify = verifyToken ?? createRemoteAccessTokenVerifier({...initial, jwksUrl: new URL(initial.jwksUrl)});
+  const permits = yield* Semaphore.make(8);
+  const globalAdmission = makeGraphControlRateLimit({maximumPrincipals: 1, requestsPerMinute: 1200});
+  const principalAdmission = makeGraphControlRateLimit();
+  const currentPolicy = readGraphControlPolicy(options.policyFile).pipe(
+    Effect.filterOrFail(
+      policy => sameAuthority(initial, policy),
+      () => graphSharingFailure('Graph control authority changed; restart the listener.'),
+    ),
+  );
+
+  const handleRequest = Effect.gen(function* () {
+    const now = yield* Clock.currentTimeMillis;
+    if (!globalAdmission('listener', now)) return reply(429, {error: 'rate-limited'});
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const pathname = request.url.split('?', 1)[0] ?? '';
+    const operation: Operation =
+      pathname === '/.well-known/threadnote-graph'
+        ? 'discovery'
+        : pathname === '/v1/status'
+          ? 'status'
+          : /^\/v1\/frontiers\/[0-9a-f]{40}$/u.test(pathname)
+            ? 'frontier'
+            : 'unsupported';
+    let principalId: string | undefined;
+    const handle = Effect.gen(function* () {
+      if (request.method !== 'GET' && request.method !== 'HEAD') return reply(403, {error: 'operation-unavailable'});
+      if (request.headers['transfer-encoding'] || Number(request.headers['content-length'] ?? 0) !== 0) {
+        return reply(400, {error: 'invalid-request'});
+      }
+      if (operation === 'unsupported') return reply(404, {error: 'not-found'});
+      if (operation === 'discovery')
+        return reply(200, {
+          organization: scope.organization,
+          protocolVersions: ['v1'],
+          controlMode: 'authenticated-read-only',
+        });
+      const principal = yield* Effect.tryPromise({
+        try: () => verify(parseBearerAccessToken(request.headers.authorization)),
+        catch: () => graphSharingFailure('Graph control authentication failed.'),
+      }).pipe(Effect.option);
+      if (principal._tag === 'None') return reply(401, {error: 'unauthorized'});
+      principalId = sha256Digest(JSON.stringify([principal.value.issuer, principal.value.subject]));
+      const authorized = Effect.gen(function* () {
+        const policy = yield* currentPolicy;
+        const at = (yield* Clock.currentTimeMillis) / 1000;
+        return (
+          principal.value.expiresAt > at &&
+          request.headers['x-threadnote-repository-id'] === scope.repositoryId &&
+          request.headers['x-threadnote-profile-digest'] === scope.profileDigest &&
+          graphControlGrantAllowsRead(policy, scope, principal.value, at)
+        );
+      });
+      if (!(yield* authorized)) return reply(403, {error: 'forbidden'});
+      if (!principalAdmission(principalId, yield* Clock.currentTimeMillis)) return reply(429, {error: 'rate-limited'});
+      const frontier = yield* readGraphControlFrontier(options);
+      if (!(yield* authorized)) return reply(403, {error: 'forbidden'});
+      if (operation === 'frontier') {
+        const expected = graphShareFrontierDiscoveryTag(scope.repositoryId, frontier.manifest.branch).slice(
+          'tn-frontier-'.length,
+        );
+        if (pathname !== `/v1/frontiers/${expected}`) return reply(404, {error: 'not-found'});
+        return reply(200, {
+          envelopeDigest: frontier.pointer.envelopeDigest,
+          frontierDigest: frontier.pointer.manifestDigest,
+          manifestDigest: frontier.pointer.manifestDigest,
+        });
+      }
+      return reply(200, {
+        generation: frontier.manifest.generation,
+        organization: scope.organization,
+        phase: 'published',
+        profileDigest: scope.profileDigest,
+        publishedFrontier: frontier.manifest.sourceCommit,
+        receipts: [],
+        repositoryId: scope.repositoryId,
+      });
+    }).pipe(
+      Effect.timeout('10 seconds'),
+      Effect.catchDefect(() => Effect.succeed(reply(503, {error: 'unavailable'}))),
+      Effect.orElseSucceed(() => reply(503, {error: 'unavailable'})),
+    );
+    const response = yield* permits.withPermitsIfAvailable(1)(handle);
+    const selected = response._tag === 'Some' ? response.value : reply(503, {error: 'busy'});
+    yield* Console.log(
+      JSON.stringify({
+        event: 'graph-control-access',
+        operation,
+        ...(principalId === undefined ? {} : {principalId}),
+        status: selected.status,
+      }),
+    );
+    return selected;
+  });
+  return {handle: handleRequest};
+});
+
+function graphControlReaderScope(options: GraphControlReaderOptions): GraphControlScope {
+  const profileDigest = graphShareProfileDigest(options.profile);
+  assertProfileMatchesEnrollment(options.profile, options.enrollment, profileDigest);
+  return {organization: options.profile.organization, profileDigest, repositoryId: options.profile.repositoryId};
+}
+
+function sameAuthority(left: GraphControlPolicy, right: GraphControlPolicy): boolean {
+  return (
+    left.audience === right.audience &&
+    left.issuer === right.issuer &&
+    left.jwksUrl === right.jwksUrl &&
+    left.organization === right.organization &&
+    left.repositoryId === right.repositoryId &&
+    left.profileDigest === right.profileDigest
+  );
+}
+
+export const readGraphControlFrontier = Effect.fn('codeGraph.sharing.readControlFrontier')(function* (
+  options: GraphControlReaderOptions,
+) {
+  const scope = graphControlReaderScope(options);
+  const path = yield* Path.Path;
+  const layout = graphSharingLayout(path, options.threadnoteHome, options.casRoot);
+  const pointerFile = graphSharingFrontierPointerPath(path, layout.frontiersRoot, scope.repositoryId);
+  const pointer = parseGraphShareFrontierPointer(
+    yield* decodeJsonBytes(yield* readGraphControlBytes(pointerFile, GRAPH_SHARE_CONTROL_MAX_BODY_BYTES)),
+  );
+  const readBlob = (digest: string) =>
+    Effect.gen(function* () {
+      const bytes = yield* readGraphControlBytes(
+        yield* casBlobPath(options.casRoot, digest),
+        GRAPH_SHARE_CONTROL_MAX_BODY_BYTES,
+      );
+      if (sha256Digest(bytes) !== digest) return yield* graphSharingFailure('Graph control artifact digest mismatch.');
+      return yield* decodeJsonBytes(bytes);
+    });
+  const manifest = parseGraphShareFrontierManifest(yield* readBlob(pointer.manifestDigest));
+  const envelope = parseGraphShareSignatureEnvelope(yield* readBlob(pointer.envelopeDigest));
+  yield* verifyGraphShareFrontier(parseSha256Digest(options.enrollment.publisherKeyFingerprint), manifest, envelope);
+  if (
+    manifest.repositoryId !== scope.repositoryId ||
+    manifest.profileDigest !== scope.profileDigest ||
+    !options.profile.source.branches.includes(manifest.branch)
+  ) {
+    return yield* graphSharingFailure('Graph control frontier does not match the enrolled profile.');
+  }
+  return {manifest, pointer};
+});
+
+function reply(status: number, body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, {
+    status,
+    headers: {'cache-control': 'no-store', ...(status === 401 ? {'www-authenticate': 'Bearer'} : {})},
+  });
+}

--- a/src/code_graph/sharing/control_reader.ts
+++ b/src/code_graph/sharing/control_reader.ts
@@ -1,6 +1,7 @@
 import {Clock, Console, Effect, Path, Semaphore} from 'effect';
 import * as HttpServerRequest from 'effect/unstable/http/HttpServerRequest';
 import * as HttpServerResponse from 'effect/unstable/http/HttpServerResponse';
+import {fromPromiseInterruptible} from '../../effect/errors.js';
 import {
   createRemoteAccessTokenVerifier,
   parseBearerAccessToken,
@@ -102,10 +103,10 @@ export const makeGraphControlReader = Effect.fn('codeGraph.sharing.makeControlRe
           protocolVersions: ['v1'],
           controlMode: 'authenticated-read-only',
         });
-      const principal = yield* Effect.tryPromise({
-        try: () => verify(parseBearerAccessToken(request.headers.authorization)),
-        catch: () => graphSharingFailure('Graph control authentication failed.'),
-      }).pipe(Effect.option);
+      const principal = yield* fromPromiseInterruptible(
+        () => verify(parseBearerAccessToken(request.headers.authorization)),
+        () => graphSharingFailure('Graph control authentication failed.'),
+      ).pipe(Effect.option);
       if (principal._tag === 'None') return reply(401, {error: 'unauthorized'});
       principalId = sha256Digest(JSON.stringify([principal.value.issuer, principal.value.subject]));
       const authorized = Effect.gen(function* () {

--- a/src/code_graph/sharing/control_server.ts
+++ b/src/code_graph/sharing/control_server.ts
@@ -33,6 +33,7 @@ import {
 } from './oci.js';
 import {adoptPublishedFrontier} from './frontier.js';
 import {graphShareFrontierDiscoveryTag} from './namespace.js';
+import {makeGraphControlReader, type GraphControlReaderOptions} from './control_reader.js';
 
 export const GRAPH_SHARE_PUBLISHER_WATCH_INTERVAL = '5 seconds' as const;
 
@@ -68,6 +69,7 @@ export interface GraphSharePublishedFrontier {
 }
 
 export interface GraphShareControlServerOptions<E = never, R = never> {
+  readonly authorization?: Pick<GraphControlReaderOptions, 'enrollment' | 'policyFile' | 'profile'>;
   readonly casRoot: string;
   readonly listen: GraphShareListenAddress;
   readonly onListening?: (info: {readonly port: number; readonly url: string}) => Effect.Effect<void, E, R>;
@@ -94,13 +96,21 @@ export function parseGraphShareListenAddress(value: string): GraphShareListenAdd
 export const runGraphShareControlServer = Effect.fn('codeGraph.sharing.controlServer')(function* <E, R>(
   options: GraphShareControlServerOptions<E, R>,
 ) {
+  const authenticatedReader =
+    options.authorization === undefined
+      ? undefined
+      : yield* makeGraphControlReader({
+          ...options.authorization,
+          casRoot: options.casRoot,
+          threadnoteHome: options.threadnoteHome,
+        });
   return yield* Effect.scoped(
     Layer.build(BunHttpServer.layer({hostname: options.listen.hostname, port: options.listen.port})).pipe(
       Effect.flatMap(context =>
         Effect.gen(function* () {
           const server = yield* HttpServer.HttpServer;
           const stateRef = yield* Ref.make(yield* loadGraphShareCoordinatorState(options));
-          yield* server.serve(handleGraphShareHttp(options, stateRef));
+          yield* server.serve(authenticatedReader?.handle ?? handleGraphShareHttp(options, stateRef));
           const actualPort = server.address._tag === 'TcpAddress' ? server.address.port : options.listen.port;
           const url = `http://${options.listen.hostname}:${actualPort}`;
           yield* options.onListening?.({port: actualPort, url}) ?? Effect.void;

--- a/src/code_graph/sharing/publisher.ts
+++ b/src/code_graph/sharing/publisher.ts
@@ -36,6 +36,7 @@ import {
 } from './profile.js';
 import {advanceGraphPublisherFrontier, ensureGraphSharePublishedOciDescriptor} from './publisher_cycle.js';
 import {resolveGraphShareCasRoot, writeGraphShareClientState} from './trust.js';
+import {validateGraphControlPolicy} from './control_reader.js';
 
 export interface GraphShareInitOptions {
   readonly cas?: string;
@@ -47,6 +48,7 @@ export interface GraphShareInitOptions {
 }
 
 export interface GraphPublisherBootstrapOptions {
+  readonly authorizationPolicy?: string;
   readonly cas?: string;
   readonly cwd?: string;
   readonly json?: boolean;
@@ -203,7 +205,6 @@ export const runGraphPublisherListen = Effect.fn('codeGraph.sharing.publisherLis
     }) => Effect.Effect<void, unknown, CliOutput>;
   },
 ) {
-  const published = yield* runGraphPublisherServe(config, options);
   const path = yield* Path.Path;
   const cwd = yield* commandCwd(options.cwd);
   const identity = yield* resolveRepositoryIdentity(cwd);
@@ -211,6 +212,18 @@ export const runGraphPublisherListen = Effect.fn('codeGraph.sharing.publisherLis
   const enrollment = parseGraphShareEnrollment(yield* readJsonFile(graphShareEnrollmentPath(path, identity.repoRoot)));
   const pointer = parseGraphShareProfilePointer(enrollment.profile);
   const profile = parseGraphShareProfile(yield* decodeJsonBytes(yield* readVerifiedCasBlob(casRoot, pointer.digest)));
+  const authorization =
+    options.authorizationPolicy === undefined
+      ? undefined
+      : {
+          enrollment,
+          policyFile: path.resolve(options.authorizationPolicy),
+          profile,
+        };
+  if (authorization !== undefined) {
+    yield* validateGraphControlPolicy({...authorization, casRoot, threadnoteHome: config.agentContextHome});
+  }
+  const published = yield* runGraphPublisherServe(config, options);
   const branch = profile.source.branches[0] ?? 'refs/heads/main';
   const descriptorDigest =
     published.descriptorDigest ??
@@ -236,6 +249,7 @@ export const runGraphPublisherListen = Effect.fn('codeGraph.sharing.publisherLis
     },
   );
   return yield* runGraphShareControlServer({
+    ...(authorization === undefined ? {} : {authorization}),
     casRoot,
     listen: parseGraphShareListenAddress(options.listen),
     onListening: info =>

--- a/src/oauth/access_token.ts
+++ b/src/oauth/access_token.ts
@@ -1,0 +1,92 @@
+import {createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey} from 'jose';
+import {Schema} from 'effect';
+
+export const ACCESS_TOKEN_ERRORS = {
+  invalidBearer: 'The bearer access token is invalid.',
+  invalidLifetime: 'The access token lifetime is invalid.',
+  invalidTime: 'The access token time claims are invalid.',
+  missingBearer: 'A bearer access token is required.',
+  missingIdentity: 'The access token is missing its issuer or subject.',
+  unverifiable: 'The access token could not be verified.',
+} as const;
+
+export class AccessTokenError extends Schema.TaggedError<AccessTokenError>()('AccessTokenError', {
+  message: Schema.String,
+  reason: Schema.Literals([
+    'invalidBearer',
+    'invalidLifetime',
+    'invalidTime',
+    'missingBearer',
+    'missingIdentity',
+    'unverifiable',
+  ]),
+}) {
+  static of(reason: keyof typeof ACCESS_TOKEN_ERRORS) {
+    return AccessTokenError.make({message: ACCESS_TOKEN_ERRORS[reason], reason});
+  }
+}
+
+export interface AccessTokenClaims {
+  readonly expiresAt: number;
+  readonly issuer: string;
+  readonly scopes: ReadonlySet<string>;
+  readonly subject: string;
+}
+
+export interface AccessTokenConfig {
+  readonly audience: string;
+  readonly issuer: string;
+}
+
+export function parseBearerAccessToken(authorization: string | null | undefined): string {
+  if (!authorization) throw AccessTokenError.of('missingBearer');
+  const match = /^Bearer ([^\s]+)$/i.exec(authorization);
+  if (!match?.[1] || Buffer.byteLength(match[1], 'utf8') > 16 * 1024) {
+    throw AccessTokenError.of('invalidBearer');
+  }
+  return match[1];
+}
+
+export function createRemoteAccessTokenVerifier(config: AccessTokenConfig & {readonly jwksUrl: URL}) {
+  return createAccessTokenVerifier(
+    createRemoteJWKSet(config.jwksUrl, {cacheMaxAge: 5 * 60_000, timeoutDuration: 3000}),
+    config,
+  );
+}
+
+export function createAccessTokenVerifier(key: CryptoKey | JWTVerifyGetKey, config: AccessTokenConfig) {
+  return async (token: string): Promise<AccessTokenClaims> => {
+    let payload: JWTPayload;
+    try {
+      ({payload} = await jwtVerify(token, key, {
+        algorithms: ['RS256'],
+        audience: config.audience,
+        clockTolerance: 5,
+        issuer: config.issuer,
+        maxTokenAge: '10 minutes',
+        requiredClaims: ['sub', 'iat', 'exp'],
+      }));
+    } catch {
+      throw AccessTokenError.of('unverifiable');
+    }
+    if (!payload.iss || !payload.sub) throw AccessTokenError.of('missingIdentity');
+    const issuedAt = numericDate(payload.iat);
+    const expiresAt = numericDate(payload.exp);
+    const notBefore = payload.nbf === undefined ? issuedAt : numericDate(payload.nbf);
+    if (expiresAt <= issuedAt || expiresAt - issuedAt > 605 || notBefore > issuedAt + 5) {
+      throw AccessTokenError.of('invalidLifetime');
+    }
+    const rawScopes = typeof payload.scope === 'string' ? payload.scope.split(/\s+/) : payload.scp;
+    const scopes = new Set<string>(
+      Array.isArray(rawScopes)
+        ? rawScopes.filter((item): item is string => typeof item === 'string' && item.length > 0)
+        : [],
+    );
+    return {expiresAt, issuer: payload.iss, scopes, subject: payload.sub};
+  };
+}
+
+function numericDate(value: unknown): number {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) throw AccessTokenError.of('invalidTime');
+  return Number(value);
+}

--- a/src/remote_memory/oauth.ts
+++ b/src/remote_memory/oauth.ts
@@ -1,7 +1,13 @@
-import {createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey} from 'jose';
+import {
+  AccessTokenError,
+  ACCESS_TOKEN_ERRORS,
+  createAccessTokenVerifier,
+  createRemoteAccessTokenVerifier,
+  parseBearerAccessToken,
+  type AccessTokenClaims,
+} from '../oauth/access_token.js';
+import {Schema} from 'effect';
 import {remoteMemoryError} from './errors.js';
-
-const MAX_BEARER_TOKEN_BYTES = 16 * 1024;
 
 export const COMPOSER_OAUTH_SCOPES = ['memory:read', 'memory:write:durable', 'memory:write:handoff'] as const;
 
@@ -28,55 +34,39 @@ export interface LocalOAuthVerifierConfig {
 }
 
 export function bearerTokenFromRequest(request: Request): string {
-  const authorization = request.headers.get('authorization');
-  if (!authorization) throw remoteMemoryError('unauthorized', 'A bearer access token is required.');
-  const match = /^Bearer ([^\s]+)$/i.exec(authorization);
-  if (!match?.[1] || Buffer.byteLength(match[1], 'utf8') > MAX_BEARER_TOKEN_BYTES) {
-    throw remoteMemoryError('unauthorized', 'The bearer access token is invalid.');
+  try {
+    return parseBearerAccessToken(request.headers.get('authorization'));
+  } catch (error) {
+    throw memoryTokenError(error);
   }
-  return match[1];
 }
 
 export function createOAuthTokenVerifier(config: OAuthVerifierConfig): OAuthTokenVerifier {
-  const jwks = createRemoteJWKSet(config.jwksUrl, {cacheMaxAge: 5 * 60_000, timeoutDuration: 3000});
-  return createAccessTokenVerifier(jwks, config);
+  return memoryVerifier(createRemoteAccessTokenVerifier(config));
 }
 
 export function createLocalOAuthTokenVerifier(config: LocalOAuthVerifierConfig): OAuthTokenVerifier {
-  return createAccessTokenVerifier(config.publicKey, config);
+  return memoryVerifier(createAccessTokenVerifier(config.publicKey, config));
 }
 
-function createAccessTokenVerifier(
-  key: CryptoKey | JWTVerifyGetKey,
-  config: {readonly audience: string; readonly issuer: string},
-): OAuthTokenVerifier {
+function memoryVerifier(verify: (token: string) => Promise<AccessTokenClaims>): OAuthTokenVerifier {
   return {
     verify: async token => {
-      let payload: JWTPayload;
       try {
-        ({payload} = await jwtVerify(token, key, {
-          algorithms: ['RS256'],
-          audience: config.audience,
-          clockTolerance: 5,
-          issuer: config.issuer,
-          maxTokenAge: '10 minutes',
-          requiredClaims: ['sub', 'iat', 'exp'],
-        }));
-      } catch {
-        throw remoteMemoryError('unauthorized', 'The access token could not be verified.');
+        const {issuer, scopes, subject} = await verify(token);
+        return {issuer, scopes, subject};
+      } catch (error) {
+        throw memoryTokenError(error);
       }
-      if (!payload.iss || !payload.sub) {
-        throw remoteMemoryError('unauthorized', 'The access token is missing its issuer or subject.');
-      }
-      const issuedAt = numericDate(payload.iat);
-      const expiresAt = numericDate(payload.exp);
-      const notBefore = payload.nbf === undefined ? issuedAt : numericDate(payload.nbf);
-      if (expiresAt <= issuedAt || expiresAt - issuedAt > 605 || notBefore > issuedAt + 5) {
-        throw remoteMemoryError('unauthorized', 'The access token lifetime is invalid.');
-      }
-      return {issuer: payload.iss, scopes: parseScopes(payload), subject: payload.sub};
     },
   };
+}
+
+function memoryTokenError(error: unknown) {
+  return remoteMemoryError(
+    'unauthorized',
+    Schema.is(AccessTokenError)(error) ? ACCESS_TOKEN_ERRORS[error.reason] : 'The access token could not be verified.',
+  );
 }
 
 export function protectedResourceMetadata(publicBaseUrl: URL, authorizationServers: readonly string[]) {
@@ -92,18 +82,4 @@ export function protectedResourceMetadata(publicBaseUrl: URL, authorizationServe
 export function oauthChallenge(publicBaseUrl: URL): string {
   const metadata = new URL('/.well-known/oauth-protected-resource', publicBaseUrl);
   return `Bearer resource_metadata="${metadata.toString()}"`;
-}
-
-function parseScopes(payload: JWTPayload): ReadonlySet<string> {
-  const raw = typeof payload.scope === 'string' ? payload.scope.split(/\s+/) : payload.scp;
-  if (Array.isArray(raw))
-    return new Set(raw.filter((item): item is string => typeof item === 'string' && item.length > 0));
-  return new Set();
-}
-
-function numericDate(value: unknown): number {
-  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
-    throw remoteMemoryError('unauthorized', 'The access token time claims are invalid.');
-  }
-  return Number(value);
 }

--- a/test/unit/code-graph.control-authorization.test.ts
+++ b/test/unit/code-graph.control-authorization.test.ts
@@ -1,0 +1,94 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {parseBearerAccessToken} from '../../src/oauth/access_token.js';
+import {
+  graphControlGrantAllowsRead,
+  makeGraphControlRateLimit,
+  parseGraphControlPolicy,
+} from '../../src/code_graph/sharing/control_authorization.js';
+
+const scope = {organization: 'acme', profileDigest: `sha256:${'b'.repeat(64)}`, repositoryId: 'a'.repeat(64)};
+const principal = {issuer: 'https://identity.example.test/', scopes: new Set(['graph:read']), subject: 'reader'};
+const policy = {
+  ...scope,
+  audience: 'https://graph.example.test',
+  grants: [{expiresAt: 2000, scopes: ['graph:read'], subject: 'reader'}],
+  issuer: principal.issuer,
+  jwksUrl: 'https://identity.example.test/.well-known/jwks.json',
+  schemaVersion: 1,
+};
+
+describe('graph metadata authorization', () => {
+  it('rejects an oversized bearer before verification', () => {
+    expect(() => parseBearerAccessToken(`Bearer ${'x'.repeat(16 * 1024 + 1)}`)).toThrow(
+      'The bearer access token is invalid.',
+    );
+  });
+
+  it('requires the intersection of exact scope, verified identity, token scope and an unexpired grant', () => {
+    const parsed = parseGraphControlPolicy(policy);
+    expect(graphControlGrantAllowsRead(parsed, scope, principal, 1000)).toBe(true);
+    for (const changed of [
+      {...scope, organization: 'other'},
+      {...scope, repositoryId: 'c'.repeat(64)},
+      {...scope, profileDigest: `sha256:${'c'.repeat(64)}`},
+    ])
+      expect(graphControlGrantAllowsRead(parsed, changed, principal, 1000)).toBe(false);
+    for (const changed of [
+      {...principal, subject: 'other'},
+      {...principal, issuer: 'https://identity.example.test'},
+      {...principal, scopes: new Set(['memory:admin'])},
+      {...principal, scopes: new Set<string>()},
+    ])
+      expect(graphControlGrantAllowsRead(parsed, scope, changed, 1000)).toBe(false);
+    expect(graphControlGrantAllowsRead(parsed, scope, principal, 2000)).toBe(false);
+    expect(graphControlGrantAllowsRead({...parsed, grants: []}, scope, principal, 1000)).toBe(false);
+  });
+
+  it.each([
+    {unexpected: true},
+    {issuer: 'http://identity.example.test/'},
+    {jwksUrl: 'https://user:password@identity.example.test/jwks'},
+    {jwksUrl: 'https://other.example.test/jwks'},
+    {grants: [{expiresAt: 2000, scopes: ['memory:admin'], subject: 'reader'}]},
+    {grants: [{expiresAt: 2000, scopes: ['graph:read'], subject: 'reader', active: true}]},
+    {grants: [...policy.grants, ...policy.grants]},
+  ])('rejects unsafe or ambiguous policy %#', override => {
+    expect(() => parseGraphControlPolicy({...policy, ...override})).toThrow('Graph control policy is invalid.');
+  });
+
+  it('grant removal cannot create access, and authorization never mutates input', () => {
+    FC.assert(
+      FC.property(FC.array(FC.boolean(), {maxLength: 32}), flags => {
+        const grants = flags.map((enabled, index) => ({
+          expiresAt: 2000,
+          scopes: enabled ? ['graph:read'] : [],
+          subject: `reader-${index}`,
+        }));
+        const full = parseGraphControlPolicy({...policy, grants});
+        const reduced = {...full, grants: full.grants.filter((_grant, index) => index % 2 === 0)};
+        const before = JSON.stringify({full, reduced});
+        for (let index = 0; index < flags.length; index += 1) {
+          const candidate = {...principal, subject: `reader-${index}`};
+          const allowed = graphControlGrantAllowsRead(reduced, scope, candidate, 1000);
+          expect(!allowed || graphControlGrantAllowsRead(full, scope, candidate, 1000)).toBe(true);
+          expect(allowed).toBe(index % 2 === 0 && flags[index] === true);
+        }
+        expect(JSON.stringify({full, reduced})).toBe(before);
+      }),
+      {numRuns: 50},
+    );
+  });
+
+  it('bounds principal rate state without evicting an active principal to reset its limit', () => {
+    const admit = makeGraphControlRateLimit({maximumPrincipals: 2, requestsPerMinute: 2});
+    expect(admit('a', 0)).toBe(true);
+    expect(admit('a', 0)).toBe(true);
+    expect(admit('a', 1)).toBe(false);
+    expect(admit('b', 1)).toBe(true);
+    expect(admit('c', 1)).toBe(false);
+    expect(admit('a', 1)).toBe(false);
+    expect(admit('c', 60_001)).toBe(true);
+    expect(admit('a', 60_001)).toBe(true);
+  });
+});

--- a/test/unit/code-graph.control-reader.test.ts
+++ b/test/unit/code-graph.control-reader.test.ts
@@ -1,0 +1,330 @@
+import * as BunHttpClient from '@effect/platform-bun/BunHttpClient';
+import * as HttpClient from 'effect/unstable/http/HttpClient';
+import * as HttpClientRequest from 'effect/unstable/http/HttpClientRequest';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import * as BunHttpServer from '@effect/platform-bun/BunHttpServer';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Clock, Console, Effect, FileSystem, Layer, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as HttpServer from 'effect/unstable/http/HttpServer';
+import {generateKeyPair, SignJWT} from 'jose';
+import {createAccessTokenVerifier} from '../../src/oauth/access_token.js';
+import {
+  generateGraphSharePublisherKey,
+  signGraphShareFrontier,
+  type GraphShareFrontierManifestV1,
+} from '../../src/code_graph/sharing/artifacts.js';
+import {writePrivateJsonFile} from '../../src/code_graph/sharing/atomic.js';
+import {casBlobPath, putCasBytes} from '../../src/code_graph/sharing/cas.js';
+import {makeGraphControlReader, readGraphControlFrontier} from '../../src/code_graph/sharing/control_reader.js';
+import {readGraphControlPolicy} from '../../src/code_graph/sharing/control_authorization.js';
+import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {graphSharingFrontierPointerPath, graphSharingLayout} from '../../src/code_graph/sharing/layout.js';
+import {graphShareFrontierDiscoveryTag} from '../../src/code_graph/sharing/namespace.js';
+import {defaultGraphShareProfile, graphShareProfileDigest} from '../../src/code_graph/sharing/profile.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const ISSUER = 'https://identity.example.test/';
+const AUDIENCE = 'https://graph.example.test';
+const REPOSITORY = 'a'.repeat(64);
+
+const fixture = Effect.fn(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-control-reader-'});
+  const key = yield* generateGraphSharePublisherKey();
+  const profile = defaultGraphShareProfile({
+    branch: 'main',
+    canonicalRemote: 'github.com/acme/repo',
+    organization: 'acme',
+    publisherKeyFingerprint: key.fingerprint,
+    repositoryId: REPOSITORY,
+  });
+  const profileDigest = graphShareProfileDigest(profile);
+  const options = {
+    casRoot: path.join(home, 'cas'),
+    enrollment: {
+      profile: `cas://${profileDigest}`,
+      publisherKeyFingerprint: key.fingerprint,
+      repositoryId: REPOSITORY,
+      schemaVersion: 1 as const,
+    },
+    policyFile: path.join(home, 'policy.json'),
+    profile,
+    threadnoteHome: home,
+  };
+  const manifest: GraphShareFrontierManifestV1 = {
+    branch: 'refs/heads/main',
+    checkpoint: {
+      manifestDigest: sha256Digest('checkpoint'),
+      snapshotId: `cgsn_${'a'.repeat(40)}`,
+      sourceCommit: 'b'.repeat(40),
+    },
+    deltas: [],
+    generation: 1,
+    graphAbi: 'c'.repeat(64),
+    graphContentId: `cgc_${'d'.repeat(40)}`,
+    logicalGraphDigest: sha256Digest('logical'),
+    previousManifestDigest: null,
+    profileDigest,
+    publisherFence: 1,
+    repositoryId: REPOSITORY,
+    schemaVersion: 1,
+    snapshotId: `cgsn_${'a'.repeat(40)}`,
+    sourceCommit: 'b'.repeat(40),
+  };
+  const pointerFile = graphSharingFrontierPointerPath(
+    path,
+    graphSharingLayout(path, home, options.casRoot).frontiersRoot,
+    REPOSITORY,
+  );
+  const publish = (value: GraphShareFrontierManifestV1) =>
+    Effect.gen(function* () {
+      const signed = yield* signGraphShareFrontier(key, value);
+      const manifestDigest = yield* putCasBytes(
+        options.casRoot,
+        new TextEncoder().encode(JSON.stringify(signed.manifest)),
+      );
+      const envelopeDigest = yield* putCasBytes(
+        options.casRoot,
+        new TextEncoder().encode(JSON.stringify(signed.envelope)),
+      );
+      const pointer = {envelopeDigest, manifestDigest, schemaVersion: 1};
+      yield* writePrivateJsonFile(pointerFile, pointer);
+      return pointer;
+    });
+  const pointer = yield* publish(manifest);
+  const at = Math.floor((yield* Clock.currentTimeMillis) / 1000);
+  const policy = {
+    audience: AUDIENCE,
+    grants: [{expiresAt: at + 3600, scopes: ['graph:read'], subject: 'private-reader'}],
+    issuer: ISSUER,
+    jwksUrl: `${ISSUER}.well-known/jwks.json`,
+    organization: 'acme',
+    profileDigest,
+    repositoryId: REPOSITORY,
+    schemaVersion: 1,
+  };
+  yield* writePrivateJsonFile(options.policyFile, policy);
+  const jwtKey = yield* Effect.promise(() => generateKeyPair('RS256'));
+  const token = (overrides: Record<string, unknown> = {}) =>
+    Effect.gen(function* () {
+      const now = Math.floor((yield* Clock.currentTimeMillis) / 1000);
+      return yield* Effect.promise(() =>
+        new SignJWT({
+          aud: AUDIENCE,
+          exp: now + 300,
+          iat: now,
+          iss: ISSUER,
+          scope: 'graph:read',
+          sub: 'private-reader',
+          ...overrides,
+        })
+          .setProtectedHeader({alg: 'RS256'})
+          .sign(jwtKey.privateKey),
+      );
+    });
+  const validToken = yield* token();
+  const reader = yield* makeGraphControlReader(
+    options,
+    createAccessTokenVerifier(jwtKey.publicKey, {audience: AUDIENCE, issuer: ISSUER}),
+  );
+  const context = yield* Layer.build(BunHttpServer.layer({hostname: '127.0.0.1', port: 0}));
+  const server = yield* HttpServer.HttpServer.pipe(Effect.provide(context));
+  const audits: string[] = [];
+  const inherited = yield* Console.Console;
+  yield* server.serve(
+    reader.handle.pipe(
+      Effect.provideService(Console.Console, {
+        ...inherited,
+        log: (...values: readonly unknown[]) => {
+          audits.push(...values.map(String));
+        },
+      }),
+    ),
+  );
+  if (server.address._tag !== 'TcpAddress') throw new Error('Expected TCP');
+  const url = `http://127.0.0.1:${server.address.port}`;
+  const request = (pathname = '/v1/status', auth = validToken, headers: Record<string, string> = {}, method = 'GET') =>
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      const request = (
+        method === 'GET' ? HttpClientRequest.get(url + pathname) : HttpClientRequest.post(url + pathname)
+      ).pipe(
+        HttpClientRequest.setHeaders({
+          authorization: `Bearer ${auth}`,
+          'x-threadnote-repository-id': REPOSITORY,
+          'x-threadnote-profile-digest': profileDigest,
+          ...headers,
+        }),
+      );
+      const response = yield* client.execute(request);
+      return {body: yield* response.json, headers: response.headers, status: response.status};
+    });
+  return {
+    audits,
+    fs,
+    home,
+    manifest,
+    options,
+    pointer,
+    pointerFile,
+    policy,
+    profileDigest,
+    publish,
+    request,
+    token,
+    validToken,
+  };
+});
+
+describe('authenticated metadata-only graph reads', () => {
+  effectIt.effect(
+    'serves verified metadata while denying artifacts and every mutation without changing graph state',
+    () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const f = yield* fixture();
+          const before = yield* f.fs.readFileString(f.pointerFile);
+          const status = yield* f.request();
+          expect(status.status).toBe(200);
+          expect(status.body).toMatchObject({
+            generation: 1,
+            profileDigest: f.profileDigest,
+            receipts: [],
+            repositoryId: REPOSITORY,
+          });
+          expect(status.headers['cache-control']).toBe('no-store');
+          const branchHash = graphShareFrontierDiscoveryTag(REPOSITORY, 'refs/heads/main').slice('tn-frontier-'.length);
+          expect((yield* f.request(`/v1/frontiers/${branchHash}`)).body).toMatchObject({
+            envelopeDigest: f.pointer.envelopeDigest,
+            manifestDigest: f.pointer.manifestDigest,
+          });
+          expect((yield* f.request('/.well-known/threadnote-graph', '')).body).toEqual({
+            controlMode: 'authenticated-read-only',
+            organization: 'acme',
+            protocolVersions: ['v1'],
+          });
+          for (const route of [
+            '/v1/cas/sha256/' + 'a'.repeat(64),
+            '/v1/tags/tn-action-' + 'a'.repeat(64),
+            '/v1/work/' + 'a'.repeat(40),
+          ])
+            expect((yield* f.request(route)).status).toBe(404);
+          for (const route of ['/v1/enroll', '/v1/results', '/v1/claims', '/v1/assembly-leases'])
+            expect((yield* f.request(route, f.validToken, {}, 'POST')).status).toBe(403);
+          expect(yield* f.fs.readFileString(f.pointerFile)).toBe(before);
+          expect(f.audits.length).toBeGreaterThan(0);
+          for (const event of f.audits) {
+            const parsed = JSON.parse(event);
+            expect(Object.keys(parsed).sort()).toEqual(
+              parsed.principalId === undefined
+                ? ['event', 'operation', 'status']
+                : ['event', 'operation', 'principalId', 'status'],
+            );
+            expect(event).not.toContain(f.validToken);
+            expect(event).not.toContain('private-reader');
+            expect(event).not.toContain(f.home);
+          }
+        }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+      ),
+  );
+
+  effectIt.effect('rejects invalid JWTs, wrong scope and memory administrator tokens with bounded errors', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        for (const token of [
+          '',
+          'private-malformed-token',
+          yield* f.token({iss: ISSUER.slice(0, -1)}),
+          yield* f.token({aud: 'https://other.example.test'}),
+        ]) {
+          const result = yield* f.request('/v1/status', token);
+          expect(result.status).toBe(401);
+          expect(result.body).toEqual({error: 'unauthorized'});
+          expect(result.headers['www-authenticate']).toBe('Bearer');
+        }
+        for (const token of [yield* f.token({scope: 'memory:admin'}), yield* f.token({sub: 'other-reader'})])
+          expect((yield* f.request('/v1/status', token)).status).toBe(403);
+        for (const headers of [
+          {'x-threadnote-repository-id': 'b'.repeat(64)},
+          {'x-threadnote-profile-digest': sha256Digest('wrong')},
+        ] as Record<string, string>[])
+          expect((yield* f.request('/v1/status', f.validToken, headers)).status).toBe(403);
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+    ),
+  );
+
+  effectIt.effect('observes grant expiry/removal immediately and fails closed on malformed or changed authority', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        for (const grants of [[], [{...f.policy.grants[0], expiresAt: 1}]]) {
+          yield* writePrivateJsonFile(f.options.policyFile, {...f.policy, grants});
+          expect((yield* f.request()).status).toBe(403);
+        }
+        yield* writePrivateJsonFile(f.options.policyFile, f.policy);
+        expect((yield* f.request()).status).toBe(200);
+        yield* f.fs.writeFileString(f.options.policyFile, '{');
+        expect((yield* f.request()).body).toEqual({error: 'unavailable'});
+        yield* writePrivateJsonFile(f.options.policyFile, {...f.policy, audience: 'https://changed.example.test'});
+        expect((yield* f.request()).status).toBe(503);
+        yield* f.fs.remove(f.options.policyFile);
+        expect((yield* f.request()).status).toBe(503);
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+    ),
+  );
+
+  effectIt.effect('rejects a signed frontier from another profile, repository or branch', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        for (const manifest of [
+          {...f.manifest, profileDigest: sha256Digest('other')},
+          {...f.manifest, repositoryId: 'b'.repeat(64)},
+          {...f.manifest, branch: 'refs/heads/other'},
+        ]) {
+          yield* f.publish(manifest);
+          expect((yield* f.request()).status).toBe(503);
+        }
+        yield* f.publish(f.manifest);
+        expect((yield* readGraphControlFrontier(f.options)).manifest).toEqual(f.manifest);
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+    ),
+  );
+
+  effectIt.effect('rejects oversized policy files before decoding', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-policy-bound-'});
+      const file = `${directory}/policy.json`;
+      yield* fs.writeFileString(file, ' '.repeat(128 * 1024 + 1));
+      expect((yield* readGraphControlPolicy(file).pipe(Effect.result))._tag).toBe('Failure');
+    }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+  );
+
+  effectIt.effect('returns bounded errors for corrupt or oversized artifacts and invalid signatures', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        const envelopeFile = yield* casBlobPath(f.options.casRoot, f.pointer.envelopeDigest);
+        const envelope = JSON.parse(yield* f.fs.readFileString(envelopeFile));
+        for (const value of ['{', JSON.stringify({privateInvalidField: f.home}), ' '.repeat(64 * 1024 + 1)]) {
+          const manifestDigest = yield* putCasBytes(f.options.casRoot, new TextEncoder().encode(value));
+          yield* writePrivateJsonFile(f.pointerFile, {...f.pointer, manifestDigest});
+          const response = yield* f.request();
+          expect(response.status).toBe(503);
+          expect(response.body).toEqual({error: 'unavailable'});
+        }
+        const envelopeDigest = yield* putCasBytes(
+          f.options.casRoot,
+          new TextEncoder().encode(JSON.stringify({...envelope, signature: '0'.repeat(128)})),
+        );
+        yield* writePrivateJsonFile(f.pointerFile, {...f.pointer, envelopeDigest});
+        expect((yield* f.request()).body).toEqual({error: 'unavailable'});
+        expect(JSON.stringify(f.audits)).not.toContain(f.home);
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+    ),
+  );
+});


### PR DESCRIPTION
Graph publishers previously offered only the unauthenticated loopback development API. Add an explicit `graph publisher serve --listen ... --authorization-policy <file>` mode for authenticated frontier and status reads.

The reader requires a short-lived RS256 token with `graph:read`, an active issuer/subject grant, and exact repository/profile headers. It reloads grants on each read, verifies the enrolled publisher's signed frontier, and bounds admission, metadata reads, errors and audit fields. This mode disables artifact transfer and all contributor mutations; it is a foundation for subsequent client/enrollment and registry work. Existing development behavior remains available.

Extract shared JWT verification while preserving the memory OAuth adapter's claims and errors. Regression coverage includes scope intersection, immediate revocation, corrupt metadata, forbidden-route nonmutation, and a bounded grant-removal property.

Validation: 24 focused graph tests; 53 existing memory HTTP/OAuth and publisher freeze tests; type checking and lint. A normal CLI smoke uses a synthetic signed frontier and a real HTTPS JWKS issuer to verify token acceptance, denial and revocation. Full-suite CI is required before merge.
