### PR TITLE
fix(graph): isolate and preserve automatic contribution queues

### DIFF
--- a/src/code_graph/indexer_service.ts
+++ b/src/code_graph/indexer_service.ts
@@ -126,6 +126,7 @@ export class CodeGraphIndexer extends Context.Service<CodeGraphIndexer, CodeGrap
           Effect.provideService(Crypto.Crypto, crypto),
           Effect.provideService(FileSystem.FileSystem, fs),
           Effect.provideService(Path.Path, path),
+          Effect.provideService(SystemInfo, system),
           Effect.asVoid,
         );
       const indexAttempt = (

--- a/src/code_graph/sharing/client.ts
+++ b/src/code_graph/sharing/client.ts
@@ -60,13 +60,12 @@ import {
   removeGraphShareTrustReceipt,
   resolveGraphShareCasRoot,
   trustReceiptFromEnrollment,
-  writeGraphShareClientState,
-  writeGraphShareContributionMode,
-  writeGraphShareCoordinatorUrl,
+  writeGraphShareRepositoryContributionMode,
   writeGraphShareTrustReceipt,
   type GraphShareAccessMode,
   type GraphShareTrustReceiptV1,
 } from './trust.js';
+import {legacyGraphShareContributionMode, resolveGraphShareRepositoryClient} from './client_state.js';
 
 export interface GraphShareJoinOptions {
   readonly cas?: string;
@@ -132,14 +131,25 @@ export const runGraphShareJoin = Effect.fn('codeGraph.sharing.join')(function* (
   const path = yield* Path.Path;
   const cwd = yield* commandCwd(options.cwd);
   const identity = yield* resolveRepositoryIdentity(cwd);
-  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas);
-  if (options.cas !== undefined) yield* writeGraphShareClientState(config.agentContextHome, casRoot);
-  const enrollment = parseGraphShareEnrollment(yield* readJsonFile(graphShareEnrollmentPath(path, identity.repoRoot)));
-  assertEnrollmentMatchesIdentity(enrollment, identity.repositoryId);
-  const pointer = parseGraphShareProfilePointer(enrollment.profile);
+  const previous = yield* lookupGraphShareTrustReceipt(config.agentContextHome, identity.repositoryId);
+  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas ?? previous?.client?.casRoot);
+  const enrollment = yield* decodeValue(
+    parseGraphShareEnrollment,
+    yield* readJsonFile(graphShareEnrollmentPath(path, identity.repoRoot)),
+    'Enrollment pointer is invalid.',
+  );
+  yield* decodeValue(
+    () => assertEnrollmentMatchesIdentity(enrollment, identity.repositoryId),
+    undefined,
+    'Enrollment repository identity is invalid.',
+  );
+  const pointer = yield* decodeValue(
+    parseGraphShareProfilePointer,
+    enrollment.profile,
+    'Enrollment profile pointer is invalid.',
+  );
   if (options.coordinator !== undefined) {
     const coordinatorUrl = parseGraphShareCoordinatorUrl(options.coordinator);
-    yield* writeGraphShareCoordinatorUrl(config.agentContextHome, coordinatorUrl);
     yield* mirrorCoordinatorCasBlob(casRoot, coordinatorUrl, pointer.digest);
   }
   const profile = yield* decodeJson(
@@ -148,21 +158,36 @@ export const runGraphShareJoin = Effect.fn('codeGraph.sharing.join')(function* (
     'Organization graph profile is invalid.',
   );
   const profileDigest = graphShareProfileDigest(profile);
-  assertProfileMatchesEnrollment(profile, enrollment, profileDigest);
-  if (profile.coordinator?.url !== undefined) {
-    yield* writeGraphShareCoordinatorUrl(config.agentContextHome, profile.coordinator.url);
-  }
+  yield* decodeValue(
+    () => assertProfileMatchesEnrollment(profile, enrollment, profileDigest),
+    undefined,
+    'Profile does not match the enrollment pointer.',
+  );
+  const coordinatorUrl =
+    profile.coordinator?.url ??
+    options.coordinator ??
+    (previous?.profileDigest === profileDigest ? previous.client?.coordinatorUrl : undefined);
   const accessMode: GraphShareAccessMode = options.readOnly ? 'read-only' : 'join';
+  const contributionMode =
+    previous?.accessMode === 'join' && previous.profileDigest === profileDigest && previous.client === undefined
+      ? legacyGraphShareContributionMode(
+          accessMode,
+          (yield* readGraphShareClientState(config.agentContextHome)).contributionMode,
+          profile.contribution.defaultMode,
+        )
+      : effectiveGraphShareContributionMode(accessMode, profile.contribution.defaultMode);
   const receipt = yield* writeGraphShareTrustReceipt(
     config.agentContextHome,
-    trustReceiptFromEnrollment(enrollment, profile, profileDigest, accessMode),
+    {
+      ...trustReceiptFromEnrollment(enrollment, profile, profileDigest, accessMode),
+      client: {
+        casRoot,
+        contributionMode,
+        ...(coordinatorUrl === undefined ? {} : {coordinatorUrl: parseGraphShareCoordinatorUrl(coordinatorUrl)}),
+      },
+    },
+    {preserveContributionMode: true},
   );
-  if (accessMode === 'join') {
-    const state = yield* readGraphShareClientState(config.agentContextHome);
-    if (state.contributionMode === undefined) {
-      yield* writeGraphShareContributionMode(config.agentContextHome, profile.contribution.defaultMode);
-    }
-  }
   return {
     accessMode: receipt.accessMode,
     organization: receipt.organization,
@@ -211,7 +236,7 @@ export const runGraphShareStatus = Effect.fn('codeGraph.sharing.status')(functio
     : Option.none();
   const enrollmentValid = Option.isSome(enrollment) && enrollment.value.repositoryId === identity.repositoryId;
   const trust = yield* lookupGraphShareTrustReceipt(config.agentContextHome, identity.repositoryId);
-  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas);
+  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas ?? trust?.client?.casRoot);
   const layout = graphSharingLayout(path, config.agentContextHome, casRoot);
   const pointerPath = graphSharingFrontierPointerPath(path, layout.frontiersRoot, identity.repositoryId);
   const frontier = enrolled && (yield* fs.exists(pointerPath)) ? yield* readJsonFile(pointerPath) : undefined;
@@ -265,7 +290,7 @@ export const maybeImportSharedGraphBase = Effect.fn('codeGraph.sharing.maybeImpo
   ) {
     return {imported: false as const, reason: 'trust-pin-mismatch' as const};
   }
-  const casRoot = yield* resolveGraphShareCasRoot(request.threadnoteHome);
+  const casRoot = yield* resolveGraphShareCasRoot(request.threadnoteHome, trust.client?.casRoot);
   yield* sharingProgress(request.onProgress, 'downloading-checkpoint');
   return yield* importVerifiedSharedCheckpoint({
     casRoot,
@@ -312,7 +337,8 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
     input.enrollment.profile,
     'Enrollment profile pointer is invalid.',
   );
-  const coordinatorHint = (yield* readGraphShareClientState(input.request.threadnoteHome)).coordinatorUrl;
+  const client = yield* resolveGraphShareRepositoryClient(input.request.threadnoteHome, input.trust);
+  const coordinatorHint = client.coordinatorUrl;
   const profile = yield* decodeJson(
     yield* ensureSharedCasBlob(input.casRoot, pointer.digest, coordinatorHint),
     parseGraphShareProfile,
@@ -330,10 +356,8 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
   if (profileDigest !== input.trust.profileDigest) {
     return {imported: false as const, reason: 'trust-pin-mismatch' as const};
   }
-  const coordinatorUrl =
-    (yield* readGraphShareClientState(input.request.threadnoteHome)).coordinatorUrl ?? profile.coordinator?.url;
+  const coordinatorUrl = client.coordinatorUrl;
   if (coordinatorUrl !== undefined) {
-    yield* writeGraphShareCoordinatorUrl(input.request.threadnoteHome, coordinatorUrl);
     yield* refreshFrontierPointerFromCoordinator({
       branch: profile.source.branches[0] ?? 'refs/heads/main',
       casRoot: input.casRoot,
@@ -546,8 +570,9 @@ export const runGraphContributeStatus = Effect.fn('codeGraph.sharing.contributeS
   const cwd = yield* commandCwd(options.cwd);
   const identity = yield* resolveRepositoryIdentity(cwd);
   const trust = yield* lookupGraphShareTrustReceipt(config.agentContextHome, identity.repositoryId);
-  const state = yield* readGraphShareClientState(config.agentContextHome);
-  const requested = state.contributionMode ?? 'off';
+  const state =
+    trust === undefined ? undefined : yield* resolveGraphShareRepositoryClient(config.agentContextHome, trust);
+  const requested = state?.contributionMode ?? 'off';
   const mode = effectiveGraphShareContributionMode(trust?.accessMode, requested);
   const queue = yield* readGraphShareContributionQueue(config.agentContextHome, identity.repositoryId, mode);
   return {
@@ -568,8 +593,15 @@ export const runGraphContributeSet = Effect.fn('codeGraph.sharing.contributeSet'
   const identity = yield* resolveRepositoryIdentity(cwd);
   const trust = yield* lookupGraphShareTrustReceipt(config.agentContextHome, identity.repositoryId);
   const requested = yield* decodeContributionMode(options.mode);
-  const mode = effectiveGraphShareContributionMode(trust?.accessMode, requested);
-  yield* writeGraphShareContributionMode(config.agentContextHome, mode);
+  const mode =
+    trust === undefined
+      ? 'off'
+      : yield* writeGraphShareRepositoryContributionMode(
+          config.agentContextHome,
+          trust,
+          yield* resolveGraphShareRepositoryClient(config.agentContextHome, trust),
+          effectiveGraphShareContributionMode(trust.accessMode, requested),
+        );
   return {
     accessMode: trust?.accessMode,
     mode,
@@ -594,7 +626,8 @@ export const runGraphWorker = Effect.fn('codeGraph.sharing.worker')(function* (
       version: 1 as const,
     };
   }
-  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas);
+  const client = yield* resolveGraphShareRepositoryClient(config.agentContextHome, trust);
+  const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas ?? client.casRoot);
   const advertised = yield* readAdvertisedGraphWorkerActions(config.agentContextHome, identity.repositoryId, casRoot);
   const presentBlobIds = new Set<string>();
   for (const action of advertised) {

--- a/src/code_graph/sharing/client_state.ts
+++ b/src/code_graph/sharing/client_state.ts
@@ -1,0 +1,52 @@
+import {Effect} from 'effect';
+import {decodeJsonBytes} from './atomic.js';
+import {readVerifiedCasBlob} from './cas.js';
+import {graphSharingFailure} from './errors.js';
+import {graphShareProfileDigest, parseGraphShareProfile} from './profile.js';
+import {
+  readGraphShareClientState,
+  resolveGraphShareCasRoot,
+  type GraphShareAccessMode,
+  type GraphShareRepositoryClientV1,
+  type GraphShareTrustReceiptV1,
+} from './trust.js';
+
+export const resolveGraphShareRepositoryClient = Effect.fn('codeGraph.sharing.resolveRepositoryClient')(function* (
+  threadnoteHome: string,
+  trust: GraphShareTrustReceiptV1,
+) {
+  if (trust.client !== undefined) return trust.client;
+  const casRoot = yield* resolveGraphShareCasRoot(threadnoteHome);
+  const value = yield* decodeJsonBytes(yield* readVerifiedCasBlob(casRoot, trust.profileDigest));
+  const profile = yield* Effect.try({
+    try: () => parseGraphShareProfile(value),
+    catch: () => graphSharingFailure('The trusted repository profile is invalid.'),
+  });
+  if (
+    graphShareProfileDigest(profile) !== trust.profileDigest ||
+    profile.repositoryId !== trust.repositoryId ||
+    profile.organization !== trust.organization ||
+    profile.registry.canonical !== trust.registryCanonical ||
+    !profile.trust.publisherKeys.includes(trust.publisherKeyFingerprint)
+  ) {
+    return yield* graphSharingFailure('The local repository profile does not match its trust receipt.');
+  }
+  const legacy = yield* readGraphShareClientState(threadnoteHome);
+  return {
+    casRoot,
+    contributionMode: legacyGraphShareContributionMode(
+      trust.accessMode,
+      legacy.contributionMode,
+      profile.contribution.defaultMode,
+    ),
+    ...(profile.coordinator === undefined ? {} : {coordinatorUrl: profile.coordinator.url}),
+  } satisfies GraphShareRepositoryClientV1;
+});
+
+export function legacyGraphShareContributionMode(
+  accessMode: GraphShareAccessMode,
+  requested: GraphShareRepositoryClientV1['contributionMode'] | undefined,
+  defaultMode: GraphShareRepositoryClientV1['contributionMode'],
+): 'off' | 'passive' {
+  return accessMode !== 'join' || requested === 'off' || defaultMode === 'off' ? 'off' : 'passive';
+}

--- a/src/code_graph/sharing/contribution.ts
+++ b/src/code_graph/sharing/contribution.ts
@@ -1,4 +1,5 @@
 import {Effect, FileSystem, Path} from 'effect';
+import {withExclusiveFileLock} from '../../effect/file_lock.js';
 import {readJsonFile, writePrivateJsonFile} from './atomic.js';
 import {SHA256_DIGEST} from './digest.js';
 import {graphSharingFailure} from './errors.js';
@@ -116,12 +117,79 @@ export const enqueuePersistedGraphShareContribution = Effect.fn('codeGraph.shari
     announcement: GraphShareResultAnnouncementV1,
     mode: GraphShareContributionMode,
   ) {
-    const current = yield* readGraphShareContributionQueue(threadnoteHome, repositoryId, mode);
-    const next = enqueueGraphShareContribution({...current, mode}, announcement, accessMode);
-    if (next.queued) yield* writeGraphShareContributionQueue(threadnoteHome, repositoryId, next.queue);
-    return next;
+    return yield* withContributionQueueLock(
+      threadnoteHome,
+      repositoryId,
+      Effect.gen(function* () {
+        const current = yield* readGraphShareContributionQueue(threadnoteHome, repositoryId, mode);
+        const next = enqueueGraphShareContribution({...current, mode}, announcement, accessMode);
+        if (next.queued) yield* writeGraphShareContributionQueue(threadnoteHome, repositoryId, next.queue);
+        return next;
+      }),
+    );
   },
 );
+
+export const acknowledgeGraphShareContributions = Effect.fn('codeGraph.sharing.acknowledgeContributions')(function* (
+  threadnoteHome: string,
+  repositoryId: string,
+  sent: readonly GraphShareResultAnnouncementV1[],
+  mode: GraphShareContributionMode,
+) {
+  if (sent.length === 0) return;
+  yield* withContributionQueueLock(
+    threadnoteHome,
+    repositoryId,
+    Effect.gen(function* () {
+      const current = yield* readGraphShareContributionQueue(threadnoteHome, repositoryId, mode);
+      const remaining = removeAcknowledgedGraphShareContributions(current, sent);
+      if (remaining.announcements.length !== current.announcements.length) {
+        yield* writeGraphShareContributionQueue(threadnoteHome, repositoryId, remaining);
+      }
+    }),
+  );
+});
+
+export function removeAcknowledgedGraphShareContributions(
+  queue: GraphShareContributionQueueV1,
+  sent: readonly GraphShareResultAnnouncementV1[],
+): GraphShareContributionQueueV1 {
+  const acknowledged = new Set(sent.map(announcementIdentity));
+  return {...queue, announcements: queue.announcements.filter(item => !acknowledged.has(announcementIdentity(item)))};
+}
+
+function announcementIdentity(item: GraphShareResultAnnouncementV1): string {
+  return JSON.stringify([
+    item.actionKey,
+    item.attestationDigest,
+    item.batchId,
+    item.resultManifestDigest,
+    item.semanticDigest,
+  ]);
+}
+
+function withContributionQueueLock<A, E, R>(
+  threadnoteHome: string,
+  repositoryId: string,
+  effect: Effect.Effect<A, E, R>,
+) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const queuePath = graphSharingContributionQueuePath(
+      path,
+      graphSharingLayout(path, threadnoteHome).root,
+      repositoryId,
+    );
+    yield* fs.makeDirectory(path.dirname(queuePath), {recursive: true, mode: 0o700});
+    return yield* withExclusiveFileLock(
+      fs,
+      `${queuePath}.lock`,
+      {retryIntervalMilliseconds: 25, staleAfterMilliseconds: 30_000, waitTimeoutMilliseconds: 30_000},
+      effect,
+    );
+  });
+}
 
 function parseQueuedAnnouncement(value: unknown): GraphShareResultAnnouncementV1 {
   if (!isRecord(value)) throw graphSharingFailure('Contribution announcement is invalid.');

--- a/src/code_graph/sharing/parse_cache.ts
+++ b/src/code_graph/sharing/parse_cache.ts
@@ -31,7 +31,8 @@ import {
   parseGraphShareParseResult,
   type GraphShareParseResultV1,
 } from './parse_result.js';
-import {readGraphShareClientState, lookupGraphShareTrustReceipt, resolveGraphShareCasRoot} from './trust.js';
+import {lookupGraphShareTrustReceipt} from './trust.js';
+import {resolveGraphShareRepositoryClient} from './client_state.js';
 
 export const enqueueLocalGraphShareParseResults = Effect.fn('codeGraph.sharing.enqueueLocalParseResults')(
   function* (input: {
@@ -42,10 +43,11 @@ export const enqueueLocalGraphShareParseResults = Effect.fn('codeGraph.sharing.e
     readonly threadnoteHome: string;
   }) {
     const trust = yield* lookupGraphShareTrustReceipt(input.threadnoteHome, input.identity.repositoryId);
-    const state = yield* readGraphShareClientState(input.threadnoteHome);
+    if (trust?.accessMode !== 'join') return {queued: 0};
+    const state = yield* resolveGraphShareRepositoryClient(input.threadnoteHome, trust);
     const mode = effectiveGraphShareContributionMode(trust?.accessMode, state.contributionMode ?? 'off');
     if (mode === 'off') return {queued: 0};
-    const casRoot = yield* resolveGraphShareCasRoot(input.threadnoteHome);
+    const casRoot = state.casRoot;
     const factsByPath = new Map(input.facts.map(fact => [fact.facts.path, fact]));
     const batchId = input.identity.headCommit.slice(0, 40);
     if (!/^[0-9a-f]{40}$/u.test(batchId)) return {queued: 0};
@@ -100,12 +102,13 @@ export const enqueueLocalGraphShareParseResults = Effect.fn('codeGraph.sharing.e
 export const drainQueuedGraphShareContributions = Effect.fn('codeGraph.sharing.drainQueuedContributions')(
   function* (input: {readonly identity: Pick<RepositoryIdentity, 'repositoryId'>; readonly threadnoteHome: string}) {
     const trust = yield* lookupGraphShareTrustReceipt(input.threadnoteHome, input.identity.repositoryId);
-    const state = yield* readGraphShareClientState(input.threadnoteHome);
+    if (trust?.accessMode !== 'join') return {sent: 0};
+    const state = yield* resolveGraphShareRepositoryClient(input.threadnoteHome, trust);
     const mode = effectiveGraphShareContributionMode(trust?.accessMode, state.contributionMode ?? 'off');
     if (mode === 'off' || state.coordinatorUrl === undefined) return {sent: 0};
     const queue = yield* readGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, mode);
     if (queue.announcements.length === 0) return {sent: 0};
-    const casRoot = yield* resolveGraphShareCasRoot(input.threadnoteHome);
+    const casRoot = state.casRoot;
     const sent: GraphShareResultAnnouncementV1[] = [];
     for (const announcement of queue.announcements) {
       const drained = yield* drainOneAnnouncement(casRoot, state.coordinatorUrl, announcement).pipe(
@@ -130,7 +133,9 @@ export const hydrateSharedParseCache = Effect.fn('codeGraph.sharing.hydrateShare
 }) {
   const fs = yield* FileSystem.FileSystem;
   if (!(yield* fs.exists(input.databasePath))) return {hydrated: 0};
-  const state = yield* readGraphShareClientState(input.threadnoteHome);
+  const trust = yield* lookupGraphShareTrustReceipt(input.threadnoteHome, input.identity.repositoryId);
+  if (trust === undefined) return {hydrated: 0};
+  const state = yield* resolveGraphShareRepositoryClient(input.threadnoteHome, trust);
   if (state.coordinatorUrl === undefined) return {hydrated: 0};
   const status = yield* graphShareControlGetStatus(state.coordinatorUrl).pipe(
     Effect.catchIf(
@@ -140,7 +145,7 @@ export const hydrateSharedParseCache = Effect.fn('codeGraph.sharing.hydrateShare
   );
   if (status === undefined || status.repositoryId !== input.identity.repositoryId) return {hydrated: 0};
   const quarantinedActionKeys = quarantinedGraphShareActionKeys(status.receipts);
-  const casRoot = yield* resolveGraphShareCasRoot(input.threadnoteHome);
+  const casRoot = state.casRoot;
   let hydrated = 0;
   for (const receipt of status.receipts.slice(0, 256)) {
     if (quarantinedActionKeys.has(receipt.actionKey)) continue;

--- a/src/code_graph/sharing/parse_cache.ts
+++ b/src/code_graph/sharing/parse_cache.ts
@@ -18,9 +18,9 @@ import {
 import type {GraphShareResultAnnouncementV1} from './receipts.js';
 import {
   enqueuePersistedGraphShareContribution,
+  acknowledgeGraphShareContributions,
   effectiveGraphShareContributionMode,
   readGraphShareContributionQueue,
-  writeGraphShareContributionQueue,
 } from './contribution.js';
 import {sha256Digest, sha256HexFromDigest} from './digest.js';
 import {graphSharingFailure, GraphSharingError} from './errors.js';
@@ -106,8 +106,7 @@ export const drainQueuedGraphShareContributions = Effect.fn('codeGraph.sharing.d
     const queue = yield* readGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, mode);
     if (queue.announcements.length === 0) return {sent: 0};
     const casRoot = yield* resolveGraphShareCasRoot(input.threadnoteHome);
-    const remaining = [];
-    let sent = 0;
+    const sent: GraphShareResultAnnouncementV1[] = [];
     for (const announcement of queue.announcements) {
       const drained = yield* drainOneAnnouncement(casRoot, state.coordinatorUrl, announcement).pipe(
         Effect.catchIf(
@@ -115,14 +114,10 @@ export const drainQueuedGraphShareContributions = Effect.fn('codeGraph.sharing.d
           () => Effect.succeed(false),
         ),
       );
-      if (drained) sent += 1;
-      else remaining.push(announcement);
+      if (drained) sent.push(announcement);
     }
-    yield* writeGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, {
-      ...queue,
-      announcements: remaining,
-    });
-    return {sent};
+    yield* acknowledgeGraphShareContributions(input.threadnoteHome, input.identity.repositoryId, sent, mode);
+    return {sent: sent.length};
   },
 );
 

--- a/src/code_graph/sharing/trust.ts
+++ b/src/code_graph/sharing/trust.ts
@@ -19,6 +19,7 @@ export type GraphShareAccessMode = (typeof GRAPH_SHARE_ACCESS_MODES)[number];
 
 export interface GraphShareTrustReceiptV1 {
   readonly accessMode: GraphShareAccessMode;
+  readonly client?: GraphShareRepositoryClientV1;
   readonly organization: string;
   readonly policyVersion: 1;
   readonly profileDigest: Sha256Digest;
@@ -37,6 +38,12 @@ export interface GraphShareClientStateV1 {
   readonly contributionMode?: 'dedicated' | 'idle' | 'off' | 'passive';
   readonly coordinatorUrl?: string;
   readonly schemaVersion: 1;
+}
+
+export interface GraphShareRepositoryClientV1 {
+  readonly casRoot: string;
+  readonly contributionMode: NonNullable<GraphShareClientStateV1['contributionMode']>;
+  readonly coordinatorUrl?: string;
 }
 
 export const readGraphShareTrustDocument = Effect.fn('codeGraph.sharing.readTrustDocument')(function* (
@@ -62,6 +69,7 @@ export const lookupGraphShareTrustReceipt = Effect.fn('codeGraph.sharing.lookupT
 export const writeGraphShareTrustReceipt = Effect.fn('codeGraph.sharing.writeTrustReceipt')(function* (
   threadnoteHome: string,
   receipt: GraphShareTrustReceiptV1,
+  options?: {readonly preserveContributionMode?: boolean},
 ) {
   return yield* withGraphShareTrustReceiptsLock(
     threadnoteHome,
@@ -69,17 +77,53 @@ export const writeGraphShareTrustReceipt = Effect.fn('codeGraph.sharing.writeTru
       const path = yield* Path.Path;
       const layout = graphSharingLayout(path, threadnoteHome);
       const document = yield* readGraphShareTrustDocument(threadnoteHome);
-      const receipts = [...document.receipts.filter(item => item.repositoryId !== receipt.repositoryId), receipt].sort(
+      const previous = document.receipts.find(item => item.repositoryId === receipt.repositoryId);
+      const stored =
+        options?.preserveContributionMode &&
+        previous?.accessMode === 'join' &&
+        receipt.accessMode === 'join' &&
+        previous.profileDigest === receipt.profileDigest &&
+        previous.client !== undefined &&
+        receipt.client !== undefined
+          ? {...receipt, client: {...receipt.client, contributionMode: previous.client.contributionMode}}
+          : receipt;
+      const receipts = [...document.receipts.filter(item => item.repositoryId !== receipt.repositoryId), stored].sort(
         (left, right) => (left.repositoryId < right.repositoryId ? -1 : left.repositoryId > right.repositoryId ? 1 : 0),
       );
       yield* writePrivateJsonFile(layout.trustReceiptsPath, {
         receipts,
         schemaVersion: GRAPH_SHARE_TRUST_SCHEMA_VERSION,
       } satisfies GraphShareTrustDocumentV1);
-      return receipt;
+      return stored;
     }),
   );
 });
+
+export const writeGraphShareRepositoryContributionMode = Effect.fn('codeGraph.sharing.writeRepositoryContributionMode')(
+  function* (
+    threadnoteHome: string,
+    expected: GraphShareTrustReceiptV1,
+    client: GraphShareRepositoryClientV1,
+    requested: GraphShareRepositoryClientV1['contributionMode'],
+  ) {
+    return yield* withGraphShareTrustReceiptsLock(
+      threadnoteHome,
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const document = yield* readGraphShareTrustDocument(threadnoteHome);
+        const current = document.receipts.find(item => item.repositoryId === expected.repositoryId);
+        if (current === undefined || current.profileDigest !== expected.profileDigest) return 'off' as const;
+        const mode = current.accessMode === 'join' ? requested : 'off';
+        const updated = {...current, client: {...(current.client ?? client), contributionMode: mode}};
+        yield* writePrivateJsonFile(graphSharingLayout(path, threadnoteHome).trustReceiptsPath, {
+          ...document,
+          receipts: document.receipts.map(item => (item.repositoryId === current.repositoryId ? updated : item)),
+        });
+        return mode;
+      }),
+    );
+  },
+);
 
 export const removeGraphShareTrustReceipt = Effect.fn('codeGraph.sharing.removeTrustReceipt')(function* (
   threadnoteHome: string,
@@ -133,20 +177,6 @@ export const writeGraphShareClientState = Effect.fn('codeGraph.sharing.writeClie
   yield* patchGraphShareClientState(threadnoteHome, {casRoot});
 });
 
-export const writeGraphShareContributionMode = Effect.fn('codeGraph.sharing.writeContributionMode')(function* (
-  threadnoteHome: string,
-  contributionMode: GraphShareClientStateV1['contributionMode'],
-) {
-  return yield* patchGraphShareClientState(threadnoteHome, {contributionMode});
-});
-
-export const writeGraphShareCoordinatorUrl = Effect.fn('codeGraph.sharing.writeCoordinatorUrl')(function* (
-  threadnoteHome: string,
-  coordinatorUrl: string | undefined,
-) {
-  return yield* patchGraphShareClientState(threadnoteHome, {coordinatorUrl});
-});
-
 export const patchGraphShareClientState = Effect.fn('codeGraph.sharing.patchClientState')(function* (
   threadnoteHome: string,
   patch: {
@@ -194,6 +224,7 @@ function withGraphShareTrustReceiptsLock<A, E, R>(threadnoteHome: string, effect
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const layout = graphSharingLayout(path, threadnoteHome);
+    yield* fs.makeDirectory(layout.root, {recursive: true, mode: 0o700});
     return yield* withExclusiveFileLock(fs, layout.trustReceiptsLockPath, GRAPH_SHARE_TRUST_LOCK_OPTIONS, effect);
   });
 }
@@ -226,12 +257,26 @@ function parseTrustReceipt(value: unknown): GraphShareTrustReceiptV1 {
   }
   return {
     accessMode: value.accessMode,
+    ...(value.client === undefined ? {} : {client: parseRepositoryClient(value.client)}),
     organization: requiredText(value.organization),
     policyVersion: 1,
     profileDigest: requiredDigest(value.profileDigest),
     publisherKeyFingerprint: requiredDigest(value.publisherKeyFingerprint),
     registryCanonical: requiredText(value.registryCanonical),
     repositoryId: requiredHex(value.repositoryId),
+  };
+}
+
+function parseRepositoryClient(value: unknown): GraphShareRepositoryClientV1 {
+  if (!isRecord(value)) throw graphSharingFailure('Repository graph-sharing settings are invalid.');
+  const parsed = parseClientState({...value, schemaVersion: 1});
+  if (parsed.casRoot === undefined || parsed.contributionMode === undefined) {
+    throw graphSharingFailure('Repository graph-sharing settings are incomplete.');
+  }
+  return {
+    casRoot: parsed.casRoot,
+    contributionMode: parsed.contributionMode,
+    ...(parsed.coordinatorUrl === undefined ? {} : {coordinatorUrl: parsed.coordinatorUrl}),
   };
 }
 

--- a/test/integration/code-graph.sharing-publication-evidence.test.ts
+++ b/test/integration/code-graph.sharing-publication-evidence.test.ts
@@ -9,7 +9,7 @@ import {CodeGraphStore} from '../../src/code_graph/store.js';
 import {codeGraphLayout} from '../../src/code_graph/layout.js';
 import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
 import {runCodeGraphCheckpointExport} from '../../src/code_graph/checkpoint/commands.js';
-import {runGraphShareJoin} from '../../src/code_graph/sharing/client.js';
+import {runGraphShareJoin, runGraphShareLeave} from '../../src/code_graph/sharing/client.js';
 import {graphShareControlGetStatus} from '../../src/code_graph/sharing/control_client.js';
 import {parseSha256Digest} from '../../src/code_graph/sharing/digest.js';
 import {
@@ -22,7 +22,7 @@ import {canonicalJson} from '../../src/code_graph/checkpoint/canonical_json.js';
 import {graphShareParseResultArtifact} from '../../src/code_graph/sharing/parse_result.js';
 import {readJsonFile, writePrivateJsonFile} from '../../src/code_graph/sharing/atomic.js';
 import {loadGraphShareCoordinatorState} from '../../src/code_graph/sharing/control_server.js';
-import {writeGraphShareCoordinatorUrl, writeGraphShareContributionMode} from '../../src/code_graph/sharing/trust.js';
+import {lookupGraphShareTrustReceipt, writeGraphShareTrustReceipt} from '../../src/code_graph/sharing/trust.js';
 import {announceGraphShareResult} from '../../src/code_graph/sharing/receipts.js';
 import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
 import {advanceGraphPublisherFrontier} from '../../src/code_graph/sharing/publisher_cycle.js';
@@ -158,8 +158,14 @@ describe('publisher contribution evidence with an independent clean control', ()
               server => Effect.promise(() => server.stop(true)),
             );
             for (const targetHome of [home, controlHome]) {
-              yield* writeGraphShareCoordinatorUrl(targetHome, `http://127.0.0.1:${sentinel.port}`);
-              yield* writeGraphShareContributionMode(targetHome, 'passive');
+              yield* runGraphShareJoin(config(targetHome), {cas: targetHome === home ? cas : controlCas, cwd: repo});
+              const trust = yield* lookupGraphShareTrustReceipt(targetHome, identity.repositoryId);
+              expect(trust?.client).toBeDefined();
+              if (trust?.client === undefined) return yield* Effect.die('Missing graph-sharing fixture settings');
+              yield* writeGraphShareTrustReceipt(targetHome, {
+                ...trust,
+                client: {...trust.client, coordinatorUrl: `http://127.0.0.1:${sentinel.port}`},
+              });
             }
             const control = yield* advanceGraphPublisherFrontier(config(controlHome), {
               cas: controlCas,
@@ -303,7 +309,7 @@ describe('publisher contribution evidence with an independent clean control', ()
             });
             expect(actual.logicalDigest).toBe(clean.logicalDigest);
             expect(sharingRequests).toBe(0);
-            yield* writeGraphShareCoordinatorUrl(home, undefined);
+            yield* runGraphShareLeave(config(home), {cwd: repo});
             const forced = yield* indexer.index({cwd: repo, force: true, ensureVectors: false, threadnoteHome: home});
             expect(forced.reusedFiles).toBe(0);
             const unchanged = yield* advanceGraphPublisherFrontier(config(home), {cas, cwd: repo, forceFreeze: true});

--- a/test/integration/code-graph.sharing.test.ts
+++ b/test/integration/code-graph.sharing.test.ts
@@ -301,12 +301,23 @@ describe('code graph sharing Phases 0–2', () => {
         '--read-only',
         '--json',
       ]);
-      const clientStatePath = join(clientHome, 'graph-sharing', 'client-state.json');
-      const clientState = JSON.parse(await readFile(clientStatePath, 'utf8')) as {
-        readonly casRoot?: string;
+      const trustPath = join(clientHome, 'graph-sharing', 'trust-receipts.json');
+      const trust = JSON.parse(await readFile(trustPath, 'utf8')) as {
+        readonly receipts: readonly {readonly client: {readonly casRoot: string; readonly contributionMode: string}}[];
         readonly schemaVersion: 1;
       };
-      await writeFile(clientStatePath, `${JSON.stringify({...clientState, coordinatorUrl: 'http://127.0.0.1:1'})}\n`);
+      expect(trust.receipts).toHaveLength(1);
+      expect(trust.receipts[0].client.casRoot).toBe(cas);
+      await writeFile(
+        trustPath,
+        `${JSON.stringify({
+          ...trust,
+          receipts: trust.receipts.map(receipt => ({
+            ...receipt,
+            client: {...receipt.client, coordinatorUrl: 'http://127.0.0.1:1'},
+          })),
+        })}\n`,
+      );
       const indexed = JSON.parse(
         (await runCli(['graph', 'index', '--home', clientHome, '--cwd', repository, '--json'])).stdout,
       ) as {

--- a/test/unit/code-graph.sharing-contribute.test.ts
+++ b/test/unit/code-graph.sharing-contribute.test.ts
@@ -1,10 +1,15 @@
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {describe, expect, it as effectIt} from '@effect/vitest';
 import {Effect, FileSystem, Layer} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FC from 'effect/testing/FastCheck';
+import {it} from 'vitest';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 import {
   enqueuePersistedGraphShareContribution,
+  acknowledgeGraphShareContributions,
   readGraphShareContributionQueue,
+  removeAcknowledgedGraphShareContributions,
 } from '../../src/code_graph/sharing/contribution.js';
 import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
 import {SystemInfo} from '../../src/effect/system.js';
@@ -20,6 +25,65 @@ const announcement = {
 };
 
 describe('graph share contribution queue persistence', () => {
+  it('acknowledgement preserves unsent order and is idempotent without mutating its inputs', () => {
+    FC.assert(
+      FC.property(FC.array(FC.boolean(), {maxLength: 32}), flags => {
+        const announcements = flags.map((_, index) => ({
+          ...announcement,
+          batchId: index.toString(16).padStart(40, '0'),
+        }));
+        const queue = {announcements, mode: 'passive' as const, schemaVersion: 1 as const};
+        const sent = announcements.filter((_, index) => flags[index]);
+        const before = JSON.stringify({queue, sent});
+        const remaining = removeAcknowledgedGraphShareContributions(queue, sent);
+        expect(remaining.announcements).toEqual(announcements.filter((_, index) => !flags[index]));
+        expect(removeAcknowledgedGraphShareContributions(remaining, sent)).toEqual(remaining);
+        expect(JSON.stringify({queue, sent})).toBe(before);
+      }),
+      {numRuns: 50},
+    );
+  });
+
+  effectIt.effect('acknowledges a drained snapshot without dropping contributions queued during upload', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-queue-ack-'});
+        const repositoryId = 'c'.repeat(64);
+        yield* enqueuePersistedGraphShareContribution(home, repositoryId, 'join', announcement, 'passive');
+        const snapshot = yield* readGraphShareContributionQueue(home, repositoryId, 'passive');
+        const added = {...announcement, actionKey: 'd'.repeat(64)};
+        yield* enqueuePersistedGraphShareContribution(home, repositoryId, 'join', added, 'passive');
+        yield* acknowledgeGraphShareContributions(home, repositoryId, snapshot.announcements, 'passive');
+        yield* acknowledgeGraphShareContributions(home, repositoryId, snapshot.announcements, 'passive');
+        expect((yield* readGraphShareContributionQueue(home, repositoryId, 'passive')).announcements).toEqual([added]);
+      }).pipe(provideTestLayer(sharingLayer)),
+    ),
+  );
+
+  effectIt.effect('retains every distinct contribution from concurrent producers', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-queue-concurrent-'});
+        const repositoryId = 'c'.repeat(64);
+        const additions = Array.from({length: 12}, (_, index) => ({
+          ...announcement,
+          actionKey: index.toString(16).padStart(64, '0'),
+        }));
+        yield* Effect.forEach(
+          additions,
+          item => enqueuePersistedGraphShareContribution(home, repositoryId, 'join', item, 'passive'),
+          {concurrency: 12},
+        );
+        const persisted = yield* readGraphShareContributionQueue(home, repositoryId, 'passive');
+        expect(new Set(persisted.announcements.map(item => item.actionKey))).toEqual(
+          new Set(additions.map(item => item.actionKey)),
+        );
+      }).pipe(provideTestLayer(sharingLayer)),
+    ),
+  );
+
   effectIt.effect('queues locally when the coordinator is down and round-trips the queue', () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -27,6 +91,9 @@ describe('graph share contribution queue persistence', () => {
       const repositoryId = 'c'.repeat(64);
       const first = yield* enqueuePersistedGraphShareContribution(home, repositoryId, 'join', announcement, 'passive');
       expect(first.queued).toBe(true);
+      if ((yield* SystemInfo).platform !== 'win32') {
+        expect((yield* fs.stat(`${home}/graph-sharing/contribution`)).mode & 0o777).toBe(0o700);
+      }
       const duplicate = yield* enqueuePersistedGraphShareContribution(
         home,
         repositoryId,

--- a/test/unit/code-graph.sharing-repository-settings.test.ts
+++ b/test/unit/code-graph.sharing-repository-settings.test.ts
@@ -1,0 +1,292 @@
+import * as BunHttpClient from '@effect/platform-bun/BunHttpClient';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path, Result} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FC from 'effect/testing/FastCheck';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {canonicalJson} from '../../src/code_graph/checkpoint/canonical_json.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {putCasBytes} from '../../src/code_graph/sharing/cas.js';
+import {
+  runGraphContributeSet,
+  runGraphContributeStatus,
+  runGraphShareJoin,
+  runGraphShareLeave,
+} from '../../src/code_graph/sharing/client.js';
+import {casProfilePointer, defaultGraphShareProfile} from '../../src/code_graph/sharing/profile.js';
+import {
+  lookupGraphShareTrustReceipt,
+  readGraphShareClientState,
+  patchGraphShareClientState,
+  trustReceiptFromEnrollment,
+  writeGraphShareTrustReceipt,
+  writeGraphShareRepositoryContributionMode,
+} from '../../src/code_graph/sharing/trust.js';
+import {resolveGraphShareRepositoryClient} from '../../src/code_graph/sharing/client_state.js';
+import {drainQueuedGraphShareContributions} from '../../src/code_graph/sharing/parse_cache.js';
+import {enqueuePersistedGraphShareContribution} from '../../src/code_graph/sharing/contribution.js';
+import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+
+const layer = CommandExecutor.layer.pipe(
+  Layer.provideMerge(SystemInfo.layer),
+  Layer.provideMerge(BunServices.layer),
+  Layer.provideMerge(BunHttpClient.layer),
+);
+
+describe('repository-scoped graph sharing settings', () => {
+  effectIt.effect.prop(
+    'updates only the selected repository under arbitrary contribution-mode changes',
+    {
+      changes: FC.array(FC.tuple(FC.boolean(), FC.constantFrom('off', 'passive', 'idle', 'dedicated')), {
+        maxLength: 12,
+      }),
+    },
+    ({changes}) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-mode-property-'});
+        const receipts = ['a', 'b'].map(id => ({
+          accessMode: 'join' as const,
+          client: {
+            casRoot: `${home}/${id}`,
+            contributionMode: 'passive' as const,
+            coordinatorUrl: `https://${id}.example.invalid`,
+          },
+          organization: 'acme',
+          policyVersion: 1 as const,
+          profileDigest: sha256Digest(id),
+          publisherKeyFingerprint: sha256Digest('publisher'),
+          registryCanonical: 'cas://local',
+          repositoryId: id.repeat(64),
+        }));
+        for (const receipt of receipts) yield* writeGraphShareTrustReceipt(home, receipt);
+        const expected = ['passive', 'passive'];
+        for (const [first, mode] of changes) {
+          const index = first ? 0 : 1;
+          const receipt = receipts[index];
+          yield* writeGraphShareRepositoryContributionMode(home, receipt, receipt.client, mode);
+          expected[index] = mode;
+          for (const [ordinal, entry] of receipts.entries()) {
+            expect(yield* lookupGraphShareTrustReceipt(home, entry.repositoryId)).toEqual({
+              ...entry,
+              client: {...entry.client, contributionMode: expected[ordinal]},
+            });
+          }
+        }
+      }).pipe(provideTestLayer(layer)),
+    {fastCheck: {numRuns: 20}},
+  );
+
+  effectIt.effect('delivers each queue only to its repository endpoint and safely resolves legacy settings', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-repository-delivery-'});
+        const config = runtimeConfig(root);
+        const destinations: string[][] = [[], []];
+        const servers = yield* Effect.forEach(destinations, requests =>
+          Effect.acquireRelease(
+            Effect.sync(() =>
+              Bun.serve({
+                hostname: '127.0.0.1',
+                port: 0,
+                fetch: async request => {
+                  requests.push(await request.text());
+                  return Response.json({});
+                },
+              }),
+            ),
+            server => Effect.promise(() => server.stop(true)),
+          ),
+        );
+        const a = yield* fixture(root, 'a', `http://127.0.0.1:${servers[0].port}`);
+        const b = yield* fixture(root, 'b', `http://127.0.0.1:${servers[1].port}`);
+        yield* runGraphShareJoin(config, {cwd: a.repo, cas: a.cas});
+        yield* runGraphShareJoin(config, {cwd: b.repo, cas: b.cas});
+        const announcement = {
+          actionKey: 'c'.repeat(64),
+          batchId: 'd'.repeat(40),
+          semanticDigest: sha256Digest('semantic'),
+          resultManifestDigest: yield* putCasBytes(a.cas, new TextEncoder().encode('{"repository":"a"}')),
+          attestationDigest: yield* putCasBytes(a.cas, new TextEncoder().encode('{"attestation":"a"}')),
+        };
+        const enqueue = enqueuePersistedGraphShareContribution(
+          config.agentContextHome,
+          a.repositoryId,
+          'join',
+          announcement,
+          'passive',
+        );
+        const drain = drainQueuedGraphShareContributions({identity: a, threadnoteHome: config.agentContextHome});
+        yield* enqueue;
+        expect(yield* drain).toEqual({sent: 1});
+        expect(destinations[0]).toHaveLength(4);
+        expect(destinations[1]).toEqual([]);
+        const receipt = (yield* lookupGraphShareTrustReceipt(config.agentContextHome, a.repositoryId))!;
+        const {client: _client, ...legacyReceipt} = receipt;
+        yield* writeGraphShareTrustReceipt(config.agentContextHome, legacyReceipt);
+        yield* patchGraphShareClientState(config.agentContextHome, {
+          casRoot: a.cas,
+          coordinatorUrl: b.coordinator,
+          contributionMode: 'dedicated',
+        });
+        expect(yield* resolveGraphShareRepositoryClient(config.agentContextHome, legacyReceipt)).toMatchObject({
+          coordinatorUrl: a.coordinator,
+          contributionMode: 'passive',
+        });
+        yield* enqueue;
+        expect(yield* drain).toEqual({sent: 1});
+        expect(destinations[0]).toHaveLength(8);
+        expect(destinations[1]).toEqual([]);
+        yield* patchGraphShareClientState(config.agentContextHome, {contributionMode: 'off'});
+        yield* enqueue;
+        expect(yield* drain).toEqual({sent: 0});
+        yield* runGraphShareJoin(config, {cwd: a.repo});
+        expect((yield* runGraphContributeStatus(config, {cwd: a.repo})).mode).toBe('off');
+        expect(yield* drain).toEqual({sent: 0});
+        yield* runGraphShareLeave(config, {cwd: a.repo});
+        expect(yield* drain).toEqual({sent: 0});
+        expect(destinations[0]).toHaveLength(8);
+        expect(destinations[1]).toEqual([]);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('refuses a legacy profile whose content does not match the repository trust pins', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-legacy-pins-'});
+      const a = yield* fixture(root, 'a');
+      const b = yield* fixture(root, 'b');
+      const config = runtimeConfig(root);
+      const receipt = trustReceiptFromEnrollment(
+        {
+          schemaVersion: 1,
+          repositoryId: b.repositoryId,
+          profile: casProfilePointer(a.digest),
+          publisherKeyFingerprint: a.profile.trust.publisherKeys[0],
+        },
+        a.profile,
+        a.digest,
+        'join',
+      );
+      yield* patchGraphShareClientState(config.agentContextHome, {casRoot: a.cas, coordinatorUrl: b.coordinator});
+      expect(
+        Result.isFailure(
+          yield* resolveGraphShareRepositoryClient(config.agentContextHome, receipt).pipe(Effect.result),
+        ),
+      ).toBe(true);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('keeps joined repositories transport and contribution choices independent', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-repository-settings-'});
+        const config = runtimeConfig(root);
+        const a = yield* fixture(root, 'a');
+        const b = yield* fixture(root, 'b');
+        yield* runGraphShareJoin(config, {cwd: a.repo, cas: a.cas});
+        yield* runGraphContributeSet(config, {cwd: a.repo, mode: 'off'});
+        yield* runGraphShareJoin(config, {cwd: b.repo, cas: b.cas});
+        expect((yield* runGraphContributeStatus(config, {cwd: b.repo})).mode).toBe('passive');
+        expect((yield* runGraphContributeSet(config, {cwd: b.repo, mode: 'dedicated'})).mode).toBe('passive');
+        expect((yield* runGraphContributeStatus(config, {cwd: b.repo})).mode).toBe('passive');
+        expect((yield* runGraphContributeStatus(config, {cwd: a.repo})).mode).toBe('off');
+        expect(yield* readGraphShareClientState(config.agentContextHome)).toEqual({schemaVersion: 1});
+        for (const item of [a, b]) {
+          expect(yield* lookupGraphShareTrustReceipt(config.agentContextHome, item.repositoryId)).toMatchObject({
+            profileDigest: item.digest,
+            client: {casRoot: item.cas, coordinatorUrl: item.coordinator},
+          });
+        }
+        yield* runGraphShareJoin(config, {cwd: a.repo});
+        expect((yield* runGraphContributeStatus(config, {cwd: a.repo})).mode).toBe('off');
+        yield* runGraphShareJoin(config, {cwd: b.repo, readOnly: true});
+        yield* runGraphContributeSet(config, {cwd: b.repo, mode: 'dedicated'});
+        expect((yield* runGraphContributeStatus(config, {cwd: b.repo})).mode).toBe('off');
+        yield* runGraphShareLeave(config, {cwd: b.repo});
+        yield* runGraphContributeSet(config, {cwd: b.repo, mode: 'passive'});
+        expect(yield* lookupGraphShareTrustReceipt(config.agentContextHome, b.repositoryId)).toBeUndefined();
+        expect((yield* runGraphContributeStatus(config, {cwd: a.repo})).mode).toBe('off');
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('leaves all existing settings intact when another join fails', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-repository-join-failure-'});
+        const config = runtimeConfig(root);
+        const a = yield* fixture(root, 'a');
+        const b = yield* fixture(root, 'b');
+        yield* runGraphShareJoin(config, {cwd: a.repo, cas: a.cas});
+        const before = yield* readGraphShareClientState(config.agentContextHome);
+        yield* fs.writeFileString(`${b.repo}/.threadnote/graph-share.json`, '{}');
+        expect(Result.isFailure(yield* runGraphShareJoin(config, {cwd: b.repo, cas: b.cas}).pipe(Effect.result))).toBe(
+          true,
+        );
+        expect(yield* readGraphShareClientState(config.agentContextHome)).toEqual(before);
+        expect((yield* runGraphContributeStatus(config, {cwd: a.repo})).mode).toBe('passive');
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+});
+
+function runtimeConfig(root: string) {
+  return {
+    account: 'local' as const,
+    agentContextHome: `${root}/home`,
+    agentId: 'threadnote',
+    manifestPath: `${root}/home/seed-manifest.yaml`,
+    user: 'local',
+  };
+}
+
+const fixture = Effect.fn('test.sharing.repositoryFixture')(function* (root: string, name: string, endpoint?: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const repo = path.join(root, name);
+  const cas = path.join(root, `${name}-cas`);
+  yield* fs.makeDirectory(path.join(repo, '.threadnote'), {recursive: true});
+  const git = (args: readonly string[]) => runCommandEffect('git', ['-C', repo, ...args]);
+  yield* git(['init', '-q', '--initial-branch=main']);
+  yield* git(['remote', 'add', 'origin', `https://github.com/acme/${name}.git`]);
+  yield* git([
+    '-c',
+    'user.name=Fixture',
+    '-c',
+    'user.email=fixture@example.invalid',
+    'commit',
+    '-q',
+    '--allow-empty',
+    '-m',
+    'base',
+  ]);
+  const identity = yield* resolveRepositoryIdentity(repo);
+  const coordinator = endpoint ?? `https://${name}.example.invalid`;
+  const profile = defaultGraphShareProfile({
+    branch: 'main',
+    canonicalRemote: `github.com/acme/${name}`,
+    coordinatorUrl: coordinator,
+    organization: 'acme',
+    publisherKeyFingerprint: `sha256:${'a'.repeat(64)}`,
+    repositoryId: identity.repositoryId,
+  });
+  const digest = yield* putCasBytes(cas, new TextEncoder().encode(canonicalJson(profile)));
+  yield* fs.writeFileString(
+    path.join(repo, '.threadnote/graph-share.json'),
+    JSON.stringify({
+      profile: casProfilePointer(digest),
+      publisherKeyFingerprint: profile.trust.publisherKeys[0],
+      repositoryId: identity.repositoryId,
+      schemaVersion: 1,
+    }),
+  );
+  return {cas, coordinator, digest, profile, repo, repositoryId: identity.repositoryId};
+});


### PR DESCRIPTION
Concurrent graph contributors could overwrite each other's queued results, and joining a second repository could change the coordinator and mode used by the first repository. Contributions now preserve concurrent queue updates and use transport settings bound to the exact repository/profile trust receipt.

Queue mutation uses short per-repository locks. Uploads run outside the lock; acknowledgement re-reads current state and removes only the exact delivered announcements, preserving arrivals during upload. Repository settings are written only after successful profile verification. Rejoin preserves explicit off, including legacy receipts; read-only and leave stop contribution. Legacy global coordinators no longer authorize egress.

Validation includes the reproduced 12-producer lost-update regression, 50-case acknowledgement property, 20-case repository-mode isolation property, real two-endpoint delivery test, focused sharing/import/publication tests, and source plus exact installed CLI multi-home contribution/shared-query smoke. Full and incremental dev-cycle reviews are clear. Full suite runs in CI.

An earlier head failed the static serialization performance gate; the unchanged protected-base control also exceeded both thresholds on that runner. Original measurements are retained; the gate and thresholds remain unchanged. Merge requires green CI for this updated head.

These fixes prepare automatic delivery retries. They do not yet add an independent retry loop or active background graph builds.
