### PR TITLE
feat(graph): automate contribution retries and enroll authenticated workers

### DIFF
--- a/src/code_graph/sharing/cli.ts
+++ b/src/code_graph/sharing/cli.ts
@@ -90,7 +90,7 @@ export function makeGraphSharingCommands(
     {
       authorizationPolicy: optionalString(
         'authorization-policy',
-        'Policy file for authenticated frontier/status reads; disables artifact routes and contributor mutations',
+        'Policy file for authenticated metadata reads and worker enrollment; disables artifact and result routes',
       ),
       cas: optionalString('cas', 'Digest-addressed CAS directory for signed frontier artifacts'),
       cwd: codeGraphCliBounds.cwd,

--- a/src/code_graph/sharing/contribution.ts
+++ b/src/code_graph/sharing/contribution.ts
@@ -1,4 +1,4 @@
-import {Effect, FileSystem, Path} from 'effect';
+import {Clock, Effect, FileSystem, Option, Path} from 'effect';
 import {withExclusiveFileLock} from '../../effect/file_lock.js';
 import {readJsonFile, writePrivateJsonFile} from './atomic.js';
 import {SHA256_DIGEST} from './digest.js';
@@ -9,10 +9,14 @@ import type {GraphShareResultAnnouncementV1} from './receipts.js';
 
 export const GRAPH_SHARE_CONTRIBUTION_MODES = ['off', 'passive', 'idle', 'dedicated'] as const;
 export type GraphShareContributionMode = (typeof GRAPH_SHARE_CONTRIBUTION_MODES)[number];
+export const GRAPH_SHARE_QUEUE_MAXIMUM_ANNOUNCEMENTS = 512;
+export const GRAPH_SHARE_QUEUE_MAXIMUM_BYTES = 512 * 1_024;
+export const GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS = 7 * 24 * 60 * 60 * 1_000;
 
 export interface GraphShareContributionQueueV1 {
   readonly announcements: readonly GraphShareResultAnnouncementV1[];
   readonly mode: GraphShareContributionMode;
+  readonly queuedAtMilliseconds?: readonly number[];
   readonly schemaVersion: 1;
 }
 
@@ -35,6 +39,7 @@ export function enqueueGraphShareContribution(
   queue: GraphShareContributionQueueV1,
   announcement: GraphShareResultAnnouncementV1,
   accessMode: 'join' | 'read-only' | undefined,
+  nowMilliseconds?: number,
 ): {readonly conflict: boolean; readonly queued: boolean; readonly queue: GraphShareContributionQueueV1} {
   const mode = effectiveGraphShareContributionMode(accessMode, queue.mode);
   if (mode === 'off') return {conflict: false, queued: false, queue};
@@ -49,11 +54,49 @@ export function enqueueGraphShareContribution(
   const conflict = queue.announcements.some(
     item => item.actionKey === announcement.actionKey && item.semanticDigest !== announcement.semanticDigest,
   );
+  const timestamp = nowMilliseconds ?? queue.queuedAtMilliseconds?.at(-1);
   return {
     conflict,
     queued: true,
-    queue: {...queue, announcements: [...queue.announcements, announcement], mode},
+    queue: {
+      ...queue,
+      announcements: [...queue.announcements, announcement],
+      mode,
+      ...(timestamp === undefined
+        ? {}
+        : {
+            queuedAtMilliseconds: [
+              ...(queue.queuedAtMilliseconds ?? queue.announcements.map(() => timestamp)),
+              timestamp,
+            ],
+          }),
+    },
   };
+}
+
+export function pruneGraphShareContributionQueue(
+  queue: GraphShareContributionQueueV1,
+  nowMilliseconds: number,
+): GraphShareContributionQueueV1 {
+  const timestamps = queue.queuedAtMilliseconds ?? queue.announcements.map(() => nowMilliseconds);
+  let retained = queue.announcements
+    .map((announcement, index) => ({announcement, timestamp: Math.min(nowMilliseconds, timestamps[index])}))
+    .filter(item => item.timestamp >= nowMilliseconds - GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS)
+    .slice(-GRAPH_SHARE_QUEUE_MAXIMUM_ANNOUNCEMENTS);
+  const materialize = (): GraphShareContributionQueueV1 => ({
+    ...queue,
+    announcements: retained.map(item => item.announcement),
+    queuedAtMilliseconds: retained.map(item => item.timestamp),
+  });
+  let result = materialize();
+  while (
+    retained.length > 0 &&
+    new TextEncoder().encode(JSON.stringify(result)).byteLength > GRAPH_SHARE_QUEUE_MAXIMUM_BYTES
+  ) {
+    retained = retained.slice(1);
+    result = materialize();
+  }
+  return result;
 }
 
 export function drainGraphShareContribution(queue: GraphShareContributionQueueV1): {
@@ -61,7 +104,11 @@ export function drainGraphShareContribution(queue: GraphShareContributionQueueV1
   readonly sent: readonly GraphShareResultAnnouncementV1[];
 } {
   return {
-    remaining: {...queue, announcements: []},
+    remaining: {
+      ...queue,
+      announcements: [],
+      ...(queue.queuedAtMilliseconds === undefined ? {} : {queuedAtMilliseconds: []}),
+    },
     sent: queue.announcements,
   };
 }
@@ -73,10 +120,20 @@ export function parseGraphShareContributionQueue(value: unknown): GraphShareCont
   if (!isContributionMode(value.mode) || !Array.isArray(value.announcements)) {
     throw graphSharingFailure('Contribution queue is invalid.');
   }
+  if (
+    value.queuedAtMilliseconds !== undefined &&
+    (!Array.isArray(value.queuedAtMilliseconds) ||
+      value.queuedAtMilliseconds.length !== value.announcements.length ||
+      value.queuedAtMilliseconds.some(
+        timestamp => typeof timestamp !== 'number' || !Number.isSafeInteger(timestamp) || timestamp < 0,
+      ))
+  )
+    throw graphSharingFailure('Contribution queue timestamps are invalid.');
   return {
     announcements: value.announcements.map(parseQueuedAnnouncement),
     mode: value.mode,
     schemaVersion: 1,
+    ...(value.queuedAtMilliseconds === undefined ? {} : {queuedAtMilliseconds: value.queuedAtMilliseconds as number[]}),
   };
 }
 
@@ -84,6 +141,18 @@ export const readGraphShareContributionQueue = Effect.fn('codeGraph.sharing.read
   threadnoteHome: string,
   repositoryId: string,
   mode: GraphShareContributionMode,
+) {
+  return pruneGraphShareContributionQueue(
+    yield* readContributionQueueDocument(threadnoteHome, repositoryId, mode),
+    yield* Clock.currentTimeMillis,
+  );
+});
+
+const readContributionQueueDocument = Effect.fn('codeGraph.sharing.readContributionQueueDocument')(function* (
+  threadnoteHome: string,
+  repositoryId: string,
+  mode: GraphShareContributionMode,
+  recoverOversized = false,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -93,8 +162,40 @@ export const readGraphShareContributionQueue = Effect.fn('codeGraph.sharing.read
     repositoryId,
   );
   if (!(yield* fs.exists(queuePath))) return emptyGraphShareContributionQueue(mode);
-  return parseGraphShareContributionQueue(yield* readJsonFile(queuePath));
+  const stat = yield* fs.stat(queuePath);
+  if (Number(stat.size) > 4 * 1_024 * 1_024) {
+    if (!recoverOversized) return yield* graphSharingFailure('Contribution queue exceeds the metadata read limit.');
+    // Callers enabling recovery hold the queue mutation lock. Preserve one legacy backlog without decoding it.
+    yield* fs.rename(queuePath, `${queuePath}.oversized`);
+    yield* fs.chmod(`${queuePath}.oversized`, 0o600);
+    const empty = emptyGraphShareContributionQueue(mode);
+    yield* writeGraphShareContributionQueue(threadnoteHome, repositoryId, empty);
+    return empty;
+  }
+  const queue = parseGraphShareContributionQueue(yield* readJsonFile(queuePath));
+  const now = yield* Clock.currentTimeMillis;
+  const modified = Option.isSome(stat.mtime) ? Math.min(now, stat.mtime.value.getTime()) : now;
+  return {
+    ...queue,
+    queuedAtMilliseconds: queue.queuedAtMilliseconds ?? queue.announcements.map(() => Math.max(0, modified)),
+  };
 });
+
+export const prunePersistedGraphShareContributionQueue = Effect.fn('codeGraph.sharing.pruneContributionQueue')(
+  function* (threadnoteHome: string, repositoryId: string, mode: GraphShareContributionMode) {
+    yield* withContributionQueueLock(
+      threadnoteHome,
+      repositoryId,
+      Effect.gen(function* () {
+        const current = yield* readContributionQueueDocument(threadnoteHome, repositoryId, mode, true);
+        const pruned = pruneGraphShareContributionQueue(current, yield* Clock.currentTimeMillis);
+        if (current.announcements.length > 0 && JSON.stringify(current) !== JSON.stringify(pruned)) {
+          yield* writeGraphShareContributionQueue(threadnoteHome, repositoryId, pruned);
+        }
+      }),
+    );
+  },
+);
 
 export const writeGraphShareContributionQueue = Effect.fn('codeGraph.sharing.writeContributionQueue')(function* (
   threadnoteHome: string,
@@ -121,8 +222,13 @@ export const enqueuePersistedGraphShareContribution = Effect.fn('codeGraph.shari
       threadnoteHome,
       repositoryId,
       Effect.gen(function* () {
-        const current = yield* readGraphShareContributionQueue(threadnoteHome, repositoryId, mode);
-        const next = enqueueGraphShareContribution({...current, mode}, announcement, accessMode);
+        const current = pruneGraphShareContributionQueue(
+          yield* readContributionQueueDocument(threadnoteHome, repositoryId, mode, true),
+          yield* Clock.currentTimeMillis,
+        );
+        const now = yield* Clock.currentTimeMillis;
+        const enqueued = enqueueGraphShareContribution({...current, mode}, announcement, accessMode, now);
+        const next = {...enqueued, queue: pruneGraphShareContributionQueue(enqueued.queue, now)};
         if (next.queued) yield* writeGraphShareContributionQueue(threadnoteHome, repositoryId, next.queue);
         return next;
       }),
@@ -141,7 +247,10 @@ export const acknowledgeGraphShareContributions = Effect.fn('codeGraph.sharing.a
     threadnoteHome,
     repositoryId,
     Effect.gen(function* () {
-      const current = yield* readGraphShareContributionQueue(threadnoteHome, repositoryId, mode);
+      const current = pruneGraphShareContributionQueue(
+        yield* readContributionQueueDocument(threadnoteHome, repositoryId, mode, true),
+        yield* Clock.currentTimeMillis,
+      );
       const remaining = removeAcknowledgedGraphShareContributions(current, sent);
       if (remaining.announcements.length !== current.announcements.length) {
         yield* writeGraphShareContributionQueue(threadnoteHome, repositoryId, remaining);
@@ -155,7 +264,16 @@ export function removeAcknowledgedGraphShareContributions(
   sent: readonly GraphShareResultAnnouncementV1[],
 ): GraphShareContributionQueueV1 {
   const acknowledged = new Set(sent.map(announcementIdentity));
-  return {...queue, announcements: queue.announcements.filter(item => !acknowledged.has(announcementIdentity(item)))};
+  const retained = queue.announcements
+    .map((item, index) => ({item, index}))
+    .filter(({item}) => !acknowledged.has(announcementIdentity(item)));
+  return {
+    ...queue,
+    announcements: retained.map(({item}) => item),
+    ...(queue.queuedAtMilliseconds === undefined
+      ? {}
+      : {queuedAtMilliseconds: retained.map(({index}) => queue.queuedAtMilliseconds![index])}),
+  };
 }
 
 function announcementIdentity(item: GraphShareResultAnnouncementV1): string {

--- a/src/code_graph/sharing/contribution_retry.ts
+++ b/src/code_graph/sharing/contribution_retry.ts
@@ -1,0 +1,37 @@
+import {Effect} from 'effect';
+import {drainQueuedGraphShareContributions} from './parse_cache.js';
+import {readGraphShareTrustDocument} from './trust.js';
+
+export const GRAPH_SHARE_RETRY_TICK_MILLISECONDS = 5_000;
+
+export const monitorGraphShareContributions = Effect.fn('codeGraph.sharing.monitorContributions')(function* (
+  threadnoteHome: string,
+) {
+  let cursor = 0;
+  for (;;) {
+    yield* Effect.sleep(GRAPH_SHARE_RETRY_TICK_MILLISECONDS);
+    const document = yield* readGraphShareTrustDocument(threadnoteHome).pipe(
+      Effect.orElseSucceed(() => undefined),
+      Effect.catchDefect(() => Effect.void),
+    );
+    if (document === undefined) continue;
+    const selected = Array.from(
+      {length: Math.min(8, document.receipts.length)},
+      (_, offset) => document.receipts[(cursor + offset) % document.receipts.length],
+    );
+    cursor = document.receipts.length === 0 ? 0 : (cursor + selected.length) % document.receipts.length;
+    yield* Effect.forEach(
+      selected,
+      receipt =>
+        drainQueuedGraphShareContributions({
+          identity: receipt,
+          threadnoteHome,
+          propagateUnavailable: true,
+        }).pipe(
+          Effect.ignore,
+          Effect.catchDefect(() => Effect.void),
+        ),
+      {concurrency: 2, discard: true},
+    );
+  }
+});

--- a/src/code_graph/sharing/contribution_retry_state.ts
+++ b/src/code_graph/sharing/contribution_retry_state.ts
@@ -1,0 +1,60 @@
+import {Effect, FileSystem, Path} from 'effect';
+import {readJsonFile, writePrivateJsonFile} from './atomic.js';
+import {graphSharingContributionQueuePath, graphSharingLayout} from './layout.js';
+import {graphSharingFailure} from './errors.js';
+import {SHA256_DIGEST} from './digest.js';
+
+interface ContributionRetryState {
+  readonly failures: number;
+  readonly identity: string;
+  readonly nextAttempt: number;
+}
+
+export function graphShareContributionRetryDelay(failures: number, jitter: number, retryAfterMilliseconds = 0): number {
+  const backoff = Math.min(300_000, 5_000 * 2 ** Math.min(6, Math.max(0, failures - 1)));
+  return Math.max(retryAfterMilliseconds, Math.round(backoff * (1 + Math.max(0, Math.min(1, jitter)) * 0.2)));
+}
+
+const retryPath = Effect.fn('codeGraph.sharing.contributionRetryPath')(function* (home: string, repositoryId: string) {
+  const path = yield* Path.Path;
+  return `${graphSharingContributionQueuePath(path, graphSharingLayout(path, home).root, repositoryId)}.retry.json`;
+});
+
+export const readContributionRetryState = Effect.fn('codeGraph.sharing.readContributionRetryState')(function* (
+  home: string,
+  repositoryId: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const target = yield* retryPath(home, repositoryId);
+  if (!(yield* fs.exists(target))) return undefined;
+  if (Number((yield* fs.stat(target)).size) > 4_096)
+    return yield* graphSharingFailure('Contribution retry state exceeds the read limit.');
+  const value = (yield* readJsonFile(target)) as Partial<ContributionRetryState> | null;
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    typeof value.identity !== 'string' ||
+    !SHA256_DIGEST.test(value.identity) ||
+    typeof value.failures !== 'number' ||
+    !Number.isInteger(value.failures) ||
+    value.failures < 1 ||
+    value.failures > 7 ||
+    typeof value.nextAttempt !== 'number' ||
+    !Number.isSafeInteger(value.nextAttempt) ||
+    value.nextAttempt < 0
+  ) {
+    return yield* graphSharingFailure('Contribution retry state is invalid.');
+  }
+  return value as ContributionRetryState;
+});
+
+// The repository delivery lease serializes this state across foreground and background runtimes.
+export const writeContributionRetryState = Effect.fn('codeGraph.sharing.writeContributionRetryState')(function* (
+  home: string,
+  repositoryId: string,
+  state: ContributionRetryState | undefined,
+) {
+  const target = yield* retryPath(home, repositoryId);
+  if (state === undefined) yield* (yield* FileSystem.FileSystem).remove(target, {force: true});
+  else yield* writePrivateJsonFile(target, state);
+});

--- a/src/code_graph/sharing/control_authorization.ts
+++ b/src/code_graph/sharing/control_authorization.ts
@@ -9,7 +9,7 @@ const Policy = Schema.Struct({
   grants: Schema.Array(
     Schema.Struct({
       expiresAt: Schema.Int.check(Schema.isGreaterThan(0)),
-      scopes: Schema.Array(Schema.Literal('graph:read')).check(Schema.isMaxLength(1)),
+      scopes: Schema.Array(Schema.Literals(['graph:read', 'graph:contribute'])).check(Schema.isMaxLength(2)),
       subject: Text,
     }),
   ).check(Schema.isMaxLength(1024)),
@@ -77,18 +77,28 @@ export function graphControlGrantAllowsRead(
   principal: Pick<AccessTokenClaims, 'issuer' | 'subject' | 'scopes'>,
   nowSeconds: number,
 ): boolean {
-  return (
-    Number.isFinite(nowSeconds) &&
-    policy.organization === scope.organization &&
-    policy.repositoryId === scope.repositoryId &&
-    policy.profileDigest === scope.profileDigest &&
-    policy.issuer === principal.issuer &&
-    principal.scopes.has('graph:read') &&
-    policy.grants.some(
-      grant =>
-        grant.subject === principal.subject && grant.expiresAt > nowSeconds && grant.scopes.includes('graph:read'),
-    )
-  );
+  return graphControlGrantExpiry(policy, scope, principal, 'graph:read', nowSeconds) !== undefined;
+}
+
+export function graphControlGrantExpiry(
+  policy: GraphControlPolicy,
+  scope: GraphControlScope,
+  principal: Pick<AccessTokenClaims, 'issuer' | 'subject' | 'scopes'>,
+  capability: 'graph:read' | 'graph:contribute',
+  nowSeconds: number,
+): number | undefined {
+  if (
+    !Number.isFinite(nowSeconds) ||
+    policy.organization !== scope.organization ||
+    policy.repositoryId !== scope.repositoryId ||
+    policy.profileDigest !== scope.profileDigest ||
+    policy.issuer !== principal.issuer ||
+    !principal.scopes.has(capability)
+  )
+    return undefined;
+  return policy.grants.find(
+    grant => grant.subject === principal.subject && grant.expiresAt > nowSeconds && grant.scopes.includes(capability),
+  )?.expiresAt;
 }
 
 export function makeGraphControlRateLimit(options = {maximumPrincipals: 1024, requestsPerMinute: 120}) {

--- a/src/code_graph/sharing/control_client.ts
+++ b/src/code_graph/sharing/control_client.ts
@@ -1,4 +1,4 @@
-import {Effect, Schema} from 'effect';
+import {Clock, Effect, Schema} from 'effect';
 import * as FetchHttpClient from 'effect/unstable/http/FetchHttpClient';
 import * as HttpClient from 'effect/unstable/http/HttpClient';
 import * as HttpClientRequest from 'effect/unstable/http/HttpClientRequest';
@@ -15,7 +15,13 @@ import {
   sha256HexFromDigest,
   type Sha256Digest,
 } from './digest.js';
-import {graphSharingFailure, graphSharingUnavailable, GraphSharingError} from './errors.js';
+import {
+  graphSharingFailure,
+  graphSharingUnavailable,
+  GraphSharingError,
+  graphSharingHttpFailure,
+  graphShareRetryAfterMilliseconds,
+} from './errors.js';
 import {GRAPH_SHARE_HTTP_CAS_MAX_BYTES, graphSharePayloadLooksLikeGitObject} from './oci.js';
 import {parseGraphShareCoordinatorUrl} from './profile.js';
 import type {GraphShareResultAnnouncementV1} from './receipts.js';
@@ -100,6 +106,19 @@ export const graphShareControlPostJson = Effect.fn('codeGraph.sharing.controlPos
     return yield* graphSharingFailure('Coordinator request exceeds the 64 KiB control limit.');
   }
   const response = yield* execute(request, url, 10_000);
+  if (
+    response.status === 401 ||
+    response.status === 403 ||
+    response.status === 408 ||
+    response.status === 425 ||
+    response.status === 429 ||
+    response.status >= 500
+  ) {
+    return yield* graphSharingHttpFailure(
+      response.status,
+      graphShareRetryAfterMilliseconds(response.headers['retry-after'], yield* Clock.currentTimeMillis),
+    );
+  }
   return {
     body: yield* decodeResponseJson(Schema.Json, response).pipe(Effect.orElseSucceed(() => undefined)),
     status: response.status,
@@ -145,7 +164,10 @@ export const graphShareControlPutCas = Effect.fn('codeGraph.sharing.controlPutCa
   const request = HttpClientRequest.put(url).pipe(HttpClientRequest.bodyUint8Array(bytes, 'application/octet-stream'));
   const response = yield* execute(request, url, 60_000);
   if (response.status < 200 || response.status >= 300) {
-    return yield* graphSharingFailure(`CAS PUT returned HTTP ${response.status}.`);
+    return yield* graphSharingHttpFailure(
+      response.status,
+      graphShareRetryAfterMilliseconds(response.headers['retry-after'], yield* Clock.currentTimeMillis),
+    );
   }
   return digest;
 });
@@ -175,7 +197,10 @@ export const graphShareControlPutTag = Effect.fn('codeGraph.sharing.controlPutTa
   );
   const response = yield* execute(request, url, 10_000);
   if (response.status !== 200 && response.status !== 201) {
-    return yield* graphSharingFailure(`Tag PUT returned HTTP ${response.status}.`);
+    return yield* graphSharingHttpFailure(
+      response.status,
+      graphShareRetryAfterMilliseconds(response.headers['retry-after'], yield* Clock.currentTimeMillis),
+    );
   }
   return digest;
 });

--- a/src/code_graph/sharing/control_enrollment.ts
+++ b/src/code_graph/sharing/control_enrollment.ts
@@ -1,0 +1,195 @@
+import {Clock, Crypto, Effect, FileSystem, Path, Schema, Stream} from 'effect';
+import {withExclusiveFileLock} from '../../effect/file_lock.js';
+import type {AccessTokenClaims} from '../../oauth/access_token.js';
+import {writePrivateJsonFile} from './atomic.js';
+import {graphControlGrantExpiry, readGraphControlBytes, type GraphControlPolicy} from './control_authorization.js';
+import {sha256Digest, sha256HexFromDigest, SHA256_DIGEST, SHA256_HEX} from './digest.js';
+import {graphSharingFailure} from './errors.js';
+import {GRAPH_SHARE_CONTROL_MAX_BODY_BYTES} from './control_protocol.js';
+import {graphSharingLayout} from './layout.js';
+
+const Digest = Schema.String.check(Schema.isPattern(SHA256_DIGEST));
+const PositiveTime = Schema.Int.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(Number.MAX_SAFE_INTEGER));
+const EnrollmentRequest = Schema.Struct({
+  idempotencyKey: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(128)),
+  profileDigest: Digest,
+  repositoryId: Schema.String.check(Schema.isPattern(SHA256_HEX)),
+});
+const Worker = Schema.Struct({
+  expiresAt: PositiveTime,
+  operationId: Digest,
+  principalId: Digest,
+  workerId: Schema.String.check(Schema.isPattern(/^gw_[0-9a-f]{32}$/u)),
+});
+const Document = Schema.Struct({
+  authority: Digest,
+  records: Schema.Array(Worker).check(Schema.isMaxLength(1024)),
+  schemaVersion: Schema.Literal(1),
+});
+export type GraphWorkerEnrollmentRequest = typeof EnrollmentRequest.Type;
+type EnrollmentDocument = typeof Document.Type;
+
+export class GraphControlEnrollmentError extends Schema.TaggedError<GraphControlEnrollmentError>()(
+  'GraphControlEnrollmentError',
+  {
+    code: Schema.Literals(['forbidden', 'capacity-exceeded']),
+  },
+) {}
+
+export function parseGraphWorkerEnrollmentRequest(value: unknown): GraphWorkerEnrollmentRequest {
+  return Schema.decodeUnknownSync(EnrollmentRequest, {onExcessProperty: 'error'})(value);
+}
+
+export const readGraphWorkerEnrollmentRequest = Effect.fn('codeGraph.sharing.readWorkerEnrollmentRequest')(function* <
+  E,
+  R,
+>(stream: Stream.Stream<Uint8Array, E, R>) {
+  const collected = yield* Stream.runFoldEffect(
+    stream,
+    () => ({bytes: new Uint8Array(GRAPH_SHARE_CONTROL_MAX_BODY_BYTES), length: 0}),
+    (collected, chunk) =>
+      Effect.gen(function* () {
+        if (collected.length + chunk.byteLength > collected.bytes.byteLength)
+          return yield* graphSharingFailure('Graph worker enrollment request exceeds the body limit.');
+        collected.bytes.set(chunk, collected.length);
+        collected.length += chunk.byteLength;
+        return collected;
+      }),
+  );
+  return yield* Effect.try({
+    try: () =>
+      parseGraphWorkerEnrollmentRequest(
+        JSON.parse(new TextDecoder('utf-8', {fatal: true}).decode(collected.bytes.subarray(0, collected.length))),
+      ),
+    catch: () => graphSharingFailure('Graph worker enrollment request is invalid.'),
+  });
+});
+
+function authorityDigest(policy: GraphControlPolicy): string {
+  return sha256Digest(
+    JSON.stringify([
+      policy.issuer,
+      policy.audience,
+      policy.jwksUrl,
+      policy.organization,
+      policy.repositoryId,
+      policy.profileDigest,
+    ]),
+  );
+}
+
+export const graphWorkerEnrollmentStatePath = Effect.fn('codeGraph.sharing.workerEnrollmentStatePath')(function* (
+  home: string,
+  policy: GraphControlPolicy,
+) {
+  const path = yield* Path.Path;
+  return path.join(
+    graphSharingLayout(path, home).root,
+    'control',
+    'enrollments',
+    `${sha256HexFromDigest(authorityDigest(policy))}.json`,
+  );
+});
+
+export const enrollGraphControlWorker = Effect.fn('codeGraph.sharing.enrollControlWorker')(function* <E, R>(input: {
+  readonly home: string;
+  readonly initialPolicy: GraphControlPolicy;
+  readonly principal: AccessTokenClaims;
+  readonly readCurrentPolicy: Effect.Effect<GraphControlPolicy, E, R>;
+  readonly request: GraphWorkerEnrollmentRequest;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const target = yield* graphWorkerEnrollmentStatePath(input.home, input.initialPolicy);
+  const authority = authorityDigest(input.initialPolicy);
+  const principalId = sha256Digest(JSON.stringify([input.principal.issuer, input.principal.subject]));
+  const operationId = sha256Digest(JSON.stringify(['enroll', authority, principalId, input.request.idempotencyKey]));
+  yield* fs.makeDirectory(path.dirname(target), {recursive: true, mode: 0o700});
+  return yield* withExclusiveFileLock(
+    fs,
+    `${target}.lock`,
+    {
+      retryIntervalMilliseconds: 25,
+      staleAfterMilliseconds: 30_000,
+      waitTimeoutMilliseconds: 2_000,
+    },
+    Effect.gen(function* () {
+      const current = yield* input.readCurrentPolicy;
+      const now = Math.floor((yield* Clock.currentTimeMillis) / 1000);
+      const expiresAt = graphControlGrantExpiry(current, input.initialPolicy, input.principal, 'graph:contribute', now);
+      if (
+        authorityDigest(current) !== authority ||
+        expiresAt === undefined ||
+        input.principal.expiresAt <= now ||
+        input.request.repositoryId !== current.repositoryId ||
+        input.request.profileDigest !== current.profileDigest
+      ) {
+        return yield* GraphControlEnrollmentError.make({code: 'forbidden'});
+      }
+      let document: EnrollmentDocument = {authority, records: [], schemaVersion: 1};
+      if (yield* fs.exists(target)) {
+        const bytes = yield* readGraphControlBytes(target, 1_048_576);
+        const text = yield* Effect.try({
+          try: () => new TextDecoder('utf-8', {fatal: true}).decode(bytes),
+          catch: () => graphSharingFailure('Graph worker enrollment state is invalid.'),
+        });
+        document = yield* Schema.decodeEffect(Schema.fromJsonString(Document), {onExcessProperty: 'error'})(text).pipe(
+          Effect.mapError(() => graphSharingFailure('Graph worker enrollment state is invalid.')),
+        );
+        if (
+          document.authority !== authority ||
+          new Set(document.records.map(record => record.operationId)).size !== document.records.length ||
+          new Set(document.records.map(record => record.workerId)).size !== document.records.length
+        ) {
+          return yield* graphSharingFailure('Graph worker enrollment state does not match its authority.');
+        }
+      }
+      const retained = document.records.filter(record => record.expiresAt > now);
+      const previous = retained.find(record => record.operationId === operationId);
+      if (previous !== undefined && previous.principalId !== principalId)
+        return yield* graphSharingFailure('Graph worker enrollment ownership is invalid.');
+      if (
+        previous === undefined &&
+        (retained.length >= 1024 || retained.filter(record => record.principalId === principalId).length >= 32)
+      ) {
+        return yield* GraphControlEnrollmentError.make({code: 'capacity-exceeded'});
+      }
+      const worker = previous ?? {
+        expiresAt: Math.min(expiresAt, now + 3600),
+        operationId,
+        principalId,
+        workerId: `gw_${(yield* (yield* Crypto.Crypto).randomUUIDv4).replaceAll('-', '')}`,
+      };
+      // Recheck after state I/O and immediately before a durable write or replay acknowledgement.
+      const latest = yield* input.readCurrentPolicy;
+      const atCommit = Math.floor((yield* Clock.currentTimeMillis) / 1000);
+      const grant = graphControlGrantExpiry(latest, input.initialPolicy, input.principal, 'graph:contribute', atCommit);
+      if (
+        authorityDigest(latest) !== authority ||
+        grant === undefined ||
+        input.principal.expiresAt <= atCommit ||
+        worker.expiresAt <= atCommit
+      ) {
+        return yield* GraphControlEnrollmentError.make({code: 'forbidden'});
+      }
+      const committed = previous === undefined ? {...worker, expiresAt: Math.min(worker.expiresAt, grant)} : worker;
+      if (previous === undefined || retained.length !== document.records.length) {
+        yield* writePrivateJsonFile(target, {
+          authority,
+          records: previous === undefined ? [...retained, committed] : retained,
+          schemaVersion: 1,
+        });
+      }
+      return {
+        created: previous === undefined,
+        body: {
+          expiresAt: committed.expiresAt,
+          profileDigest: input.initialPolicy.profileDigest,
+          repositoryId: input.initialPolicy.repositoryId,
+          schemaVersion: 1 as const,
+          workerId: committed.workerId,
+        },
+      };
+    }),
+  );
+});

--- a/src/code_graph/sharing/control_reader.ts
+++ b/src/code_graph/sharing/control_reader.ts
@@ -1,4 +1,4 @@
-import {Clock, Console, Effect, Path, Semaphore} from 'effect';
+import {Clock, Console, Effect, Path, Schema, Semaphore} from 'effect';
 import * as HttpServerRequest from 'effect/unstable/http/HttpServerRequest';
 import * as HttpServerResponse from 'effect/unstable/http/HttpServerResponse';
 import {fromPromiseInterruptible} from '../../effect/errors.js';
@@ -16,13 +16,18 @@ import {
 import {decodeJsonBytes} from './atomic.js';
 import {casBlobPath} from './cas.js';
 import {
-  graphControlGrantAllowsRead,
+  graphControlGrantExpiry,
   makeGraphControlRateLimit,
   readGraphControlBytes,
   readGraphControlPolicy,
   type GraphControlPolicy,
   type GraphControlScope,
 } from './control_authorization.js';
+import {
+  enrollGraphControlWorker,
+  GraphControlEnrollmentError,
+  readGraphWorkerEnrollmentRequest,
+} from './control_enrollment.js';
 import {GRAPH_SHARE_CONTROL_MAX_BODY_BYTES} from './control_protocol.js';
 import {parseSha256Digest, sha256Digest} from './digest.js';
 import {graphSharingFailure} from './errors.js';
@@ -43,7 +48,7 @@ export interface GraphControlReaderOptions {
   readonly threadnoteHome: string;
 }
 
-type Operation = 'discovery' | 'frontier' | 'status' | 'unsupported';
+type Operation = 'discovery' | 'frontier' | 'status' | 'enroll' | 'unsupported';
 
 export const validateGraphControlPolicy = Effect.fn('codeGraph.sharing.validateControlPolicy')(function* (
   options: GraphControlReaderOptions,
@@ -87,13 +92,19 @@ export const makeGraphControlReader = Effect.fn('codeGraph.sharing.makeControlRe
         ? 'discovery'
         : pathname === '/v1/status'
           ? 'status'
-          : /^\/v1\/frontiers\/[0-9a-f]{40}$/u.test(pathname)
-            ? 'frontier'
-            : 'unsupported';
+          : pathname === '/v1/enroll'
+            ? 'enroll'
+            : /^\/v1\/frontiers\/[0-9a-f]{40}$/u.test(pathname)
+              ? 'frontier'
+              : 'unsupported';
     let principalId: string | undefined;
     const handle = Effect.gen(function* () {
-      if (request.method !== 'GET' && request.method !== 'HEAD') return reply(403, {error: 'operation-unavailable'});
-      if (request.headers['transfer-encoding'] || Number(request.headers['content-length'] ?? 0) !== 0) {
+      if (operation === 'enroll' ? request.method !== 'POST' : request.method !== 'GET' && request.method !== 'HEAD')
+        return reply(403, {error: 'operation-unavailable'});
+      if (
+        operation !== 'enroll' &&
+        (request.headers['transfer-encoding'] || Number(request.headers['content-length'] ?? 0) !== 0)
+      ) {
         return reply(400, {error: 'invalid-request'});
       }
       if (operation === 'unsupported') return reply(404, {error: 'not-found'});
@@ -101,7 +112,7 @@ export const makeGraphControlReader = Effect.fn('codeGraph.sharing.makeControlRe
         return reply(200, {
           organization: scope.organization,
           protocolVersions: ['v1'],
-          controlMode: 'authenticated-read-only',
+          controlMode: 'authenticated-metadata',
         });
       const principal = yield* fromPromiseInterruptible(
         () => verify(parseBearerAccessToken(request.headers.authorization)),
@@ -116,11 +127,40 @@ export const makeGraphControlReader = Effect.fn('codeGraph.sharing.makeControlRe
           principal.value.expiresAt > at &&
           request.headers['x-threadnote-repository-id'] === scope.repositoryId &&
           request.headers['x-threadnote-profile-digest'] === scope.profileDigest &&
-          graphControlGrantAllowsRead(policy, scope, principal.value, at)
+          graphControlGrantExpiry(
+            policy,
+            scope,
+            principal.value,
+            operation === 'enroll' ? 'graph:contribute' : 'graph:read',
+            at,
+          ) !== undefined
         );
       });
       if (!(yield* authorized)) return reply(403, {error: 'forbidden'});
       if (!principalAdmission(principalId, yield* Clock.currentTimeMillis)) return reply(429, {error: 'rate-limited'});
+      if (operation === 'enroll') {
+        const declared = Number(request.headers['content-length'] ?? 0);
+        if (!Number.isSafeInteger(declared) || declared < 0 || declared > GRAPH_SHARE_CONTROL_MAX_BODY_BYTES)
+          return reply(413, {error: 'invalid-request'});
+        if (request.headers['content-type']?.split(';')[0]?.trim().toLowerCase() !== 'application/json')
+          return reply(400, {error: 'invalid-request'});
+        const decoded = yield* readGraphWorkerEnrollmentRequest(request.stream).pipe(Effect.option);
+        if (decoded._tag === 'None') return reply(400, {error: 'invalid-request'});
+        const enrolled = yield* enrollGraphControlWorker({
+          home: options.threadnoteHome,
+          initialPolicy: initial,
+          principal: principal.value,
+          readCurrentPolicy: currentPolicy,
+          request: decoded.value,
+        }).pipe(
+          Effect.map(result => reply(result.created ? 201 : 200, result.body)),
+          Effect.catchIf(
+            error => Schema.is(GraphControlEnrollmentError)(error),
+            error => Effect.succeed(reply(error.code === 'forbidden' ? 403 : 429, {error: error.code})),
+          ),
+        );
+        return enrolled;
+      }
       const frontier = yield* readGraphControlFrontier(options);
       if (!(yield* authorized)) return reply(403, {error: 'forbidden'});
       if (operation === 'frontier') {

--- a/src/code_graph/sharing/errors.ts
+++ b/src/code_graph/sharing/errors.ts
@@ -7,6 +7,8 @@ export class GraphSharingError extends Schema.TaggedError<GraphSharingError>()('
   cause: Schema.optionalKey(Schema.Defect()),
   kind: Schema.Literals(['unavailable', 'verification-failed']),
   message: Schema.String,
+  httpStatus: Schema.optionalKey(Schema.Int),
+  retryAfterMilliseconds: Schema.optionalKey(Schema.Finite),
 }) {}
 
 export function graphSharingFailure(
@@ -19,4 +21,26 @@ export function graphSharingFailure(
 
 export function graphSharingUnavailable(message: string): GraphSharingError {
   return GraphSharingError.make({kind: 'unavailable', message});
+}
+
+export function graphSharingHttpFailure(status: number, retryAfterMilliseconds?: number): GraphSharingError {
+  return GraphSharingError.make({
+    kind: status === 408 || status === 425 || status === 429 || status >= 500 ? 'unavailable' : 'verification-failed',
+    message: `Graph-sharing endpoint returned HTTP ${status}.`,
+    httpStatus: status,
+    ...(retryAfterMilliseconds === undefined ? {} : {retryAfterMilliseconds}),
+  });
+}
+
+export function graphShareRetryAfterMilliseconds(
+  value: string | undefined,
+  nowMilliseconds: number,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const seconds = /^\d+$/u.test(value.trim()) ? Number(value.trim()) : undefined;
+  if (seconds === undefined && !/^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)/iu.test(value.trim())) return undefined;
+  const delay = seconds === undefined ? Date.parse(value) - nowMilliseconds : seconds * 1_000;
+  return Number.isFinite(delay) && delay >= 0
+    ? Math.min(delay, Number.MAX_SAFE_INTEGER - Math.max(0, nowMilliseconds))
+    : undefined;
 }

--- a/src/code_graph/sharing/parse_cache.ts
+++ b/src/code_graph/sharing/parse_cache.ts
@@ -1,4 +1,5 @@
-import {Effect, FileSystem, Path, Schema} from 'effect';
+import {Clock, Effect, FileSystem, Path, Random, Schema} from 'effect';
+import {isFileLockTimeout, withExclusiveFileLock} from '../../effect/file_lock.js';
 import {canonicalJson} from '../checkpoint/canonical_json.js';
 import type {BoundedCodeGraphFact} from '../fact_budget.js';
 import type {CodeGraphStoreShape} from '../store_shape.js';
@@ -21,9 +22,11 @@ import {
   acknowledgeGraphShareContributions,
   effectiveGraphShareContributionMode,
   readGraphShareContributionQueue,
+  prunePersistedGraphShareContributionQueue,
 } from './contribution.js';
 import {sha256Digest, sha256HexFromDigest} from './digest.js';
-import {graphSharingFailure, GraphSharingError} from './errors.js';
+import {GRAPH_SHARE_HTTP_CAS_MAX_BYTES} from './oci.js';
+import {graphSharingFailure, graphSharingHttpFailure, GraphSharingError} from './errors.js';
 import {isGraphShareGitObjectId} from './git.js';
 import {graphShareActionDiscoveryTag} from './namespace.js';
 import {
@@ -33,6 +36,12 @@ import {
 } from './parse_result.js';
 import {lookupGraphShareTrustReceipt} from './trust.js';
 import {resolveGraphShareRepositoryClient} from './client_state.js';
+import {graphSharingContributionQueuePath, graphSharingLayout} from './layout.js';
+import {
+  graphShareContributionRetryDelay,
+  readContributionRetryState,
+  writeContributionRetryState,
+} from './contribution_retry_state.js';
 
 export const enqueueLocalGraphShareParseResults = Effect.fn('codeGraph.sharing.enqueueLocalParseResults')(
   function* (input: {
@@ -100,29 +109,116 @@ export const enqueueLocalGraphShareParseResults = Effect.fn('codeGraph.sharing.e
 );
 
 export const drainQueuedGraphShareContributions = Effect.fn('codeGraph.sharing.drainQueuedContributions')(
-  function* (input: {readonly identity: Pick<RepositoryIdentity, 'repositoryId'>; readonly threadnoteHome: string}) {
+  function* (input: {
+    readonly identity: Pick<RepositoryIdentity, 'repositoryId'>;
+    readonly threadnoteHome: string;
+    readonly propagateUnavailable?: boolean;
+  }) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const root = graphSharingLayout(path, input.threadnoteHome).root;
+    const lockPath = `${graphSharingContributionQueuePath(path, root, input.identity.repositoryId)}.delivery.lock`;
     const trust = yield* lookupGraphShareTrustReceipt(input.threadnoteHome, input.identity.repositoryId);
-    if (trust?.accessMode !== 'join') return {sent: 0};
-    const state = yield* resolveGraphShareRepositoryClient(input.threadnoteHome, trust);
-    const mode = effectiveGraphShareContributionMode(trust?.accessMode, state.contributionMode ?? 'off');
-    if (mode === 'off' || state.coordinatorUrl === undefined) return {sent: 0};
-    const queue = yield* readGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, mode);
-    if (queue.announcements.length === 0) return {sent: 0};
-    const casRoot = state.casRoot;
-    const sent: GraphShareResultAnnouncementV1[] = [];
-    for (const announcement of queue.announcements) {
-      const drained = yield* drainOneAnnouncement(casRoot, state.coordinatorUrl, announcement).pipe(
-        Effect.catchIf(
-          error => Schema.is(GraphSharingError)(error) && error.kind === 'unavailable',
-          () => Effect.succeed(false),
-        ),
-      );
-      if (drained) sent.push(announcement);
+    if (trust === undefined) return {sent: 0};
+    if (trust.accessMode === 'read-only') {
+      yield* prunePersistedGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, 'off');
+      return {sent: 0};
     }
-    yield* acknowledgeGraphShareContributions(input.threadnoteHome, input.identity.repositoryId, sent, mode);
-    return {sent: sent.length};
+    yield* fs.makeDirectory(path.dirname(lockPath), {recursive: true, mode: 0o700});
+    return yield* withExclusiveFileLock(
+      fs,
+      lockPath,
+      {
+        heartbeatIntervalMilliseconds: 10_000,
+        retryIntervalMilliseconds: 25,
+        staleAfterMilliseconds: 30_000,
+        waitTimeoutMilliseconds: 0,
+      },
+      drainContributionBatch(input).pipe(Effect.timeout(30_000)),
+    ).pipe(Effect.catchIf(isFileLockTimeout, () => Effect.succeed({sent: 0})));
   },
 );
+
+const drainContributionBatch = Effect.fn('codeGraph.sharing.drainContributionBatch')(function* (input: {
+  readonly identity: Pick<RepositoryIdentity, 'repositoryId'>;
+  readonly threadnoteHome: string;
+  readonly propagateUnavailable?: boolean;
+}) {
+  const trust = yield* lookupGraphShareTrustReceipt(input.threadnoteHome, input.identity.repositoryId);
+  if (trust?.accessMode !== 'join') return {sent: 0};
+  const state = yield* resolveGraphShareRepositoryClient(input.threadnoteHome, trust);
+  const mode = effectiveGraphShareContributionMode(trust.accessMode, state.contributionMode);
+  yield* prunePersistedGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, mode);
+  if (mode === 'off' || state.coordinatorUrl === undefined) return {sent: 0};
+  const queue = yield* readGraphShareContributionQueue(input.threadnoteHome, input.identity.repositoryId, mode);
+  if (queue.announcements.length === 0) return {sent: 0};
+  const identity = sha256Digest(JSON.stringify({trust, state}));
+  const retry = yield* readContributionRetryState(input.threadnoteHome, input.identity.repositoryId);
+  const previous = retry?.identity === identity ? retry : undefined;
+  if (previous !== undefined && previous.nextAttempt > (yield* Clock.currentTimeMillis)) return {sent: 0};
+  const casRoot = state.casRoot;
+  const coordinatorUrl = state.coordinatorUrl;
+  const sent: GraphShareResultAnnouncementV1[] = [];
+  const discarded: GraphShareResultAnnouncementV1[] = [];
+  const stillAuthorized = Effect.gen(function* () {
+    const currentTrust = yield* lookupGraphShareTrustReceipt(input.threadnoteHome, input.identity.repositoryId);
+    if (currentTrust?.accessMode !== 'join' || currentTrust.profileDigest !== trust.profileDigest) return false;
+    const current = yield* resolveGraphShareRepositoryClient(input.threadnoteHome, currentTrust);
+    return (
+      current.contributionMode !== 'off' && current.coordinatorUrl === coordinatorUrl && current.casRoot === casRoot
+    );
+  });
+  return yield* Effect.gen(function* () {
+    for (const announcement of queue.announcements.slice(0, 8)) {
+      if (!(yield* stillAuthorized)) break;
+      const prepared = yield* prepareContributionArtifacts(casRoot, input.identity.repositoryId, announcement).pipe(
+        Effect.catchIf(
+          error => Schema.is(GraphSharingError)(error),
+          () => Effect.void,
+        ),
+      );
+      if (prepared === undefined) {
+        discarded.push(announcement);
+        continue;
+      }
+      const drained = yield* drainOneAnnouncement(prepared, coordinatorUrl, announcement, stillAuthorized);
+      if (drained) sent.push(announcement);
+      else break;
+    }
+    if (retry !== undefined)
+      yield* writeContributionRetryState(input.threadnoteHome, input.identity.repositoryId, undefined);
+    return {sent: sent.length};
+  }).pipe(
+    Effect.timeout(25_000),
+    Effect.catch(error =>
+      Effect.gen(function* () {
+        const failure = Schema.is(GraphSharingError)(error) ? error : undefined;
+        const failures = Math.min(7, (previous?.failures ?? 0) + 1);
+        const authorizationFailed = failure?.httpStatus === 401 || failure?.httpStatus === 403;
+        const delay = authorizationFailed
+          ? Math.max(3_600_000, failure?.retryAfterMilliseconds ?? 0)
+          : graphShareContributionRetryDelay(failures, yield* Random.next, failure?.retryAfterMilliseconds);
+        yield* writeContributionRetryState(input.threadnoteHome, input.identity.repositoryId, {
+          identity,
+          failures,
+          nextAttempt: Math.min(Number.MAX_SAFE_INTEGER, (yield* Clock.currentTimeMillis) + delay),
+        });
+        if (!input.propagateUnavailable && failure?.kind === 'unavailable') return {sent: sent.length};
+        return yield* Effect.fail(error);
+      }),
+    ),
+    Effect.ensuring(
+      Effect.suspend(() =>
+        acknowledgeGraphShareContributions(
+          input.threadnoteHome,
+          input.identity.repositoryId,
+          [...sent, ...discarded],
+          mode,
+        ),
+      ).pipe(Effect.orDie),
+    ),
+  );
+});
 
 export const hydrateSharedParseCache = Effect.fn('codeGraph.sharing.hydrateSharedParseCache')(function* (input: {
   readonly databasePath: string;
@@ -222,7 +318,7 @@ export interface VerifiedGraphShareParseReceipt {
   readonly parsed: GraphShareParseResultV1;
 }
 
-export const verifyGraphShareParseReceipt = Effect.fn('codeGraph.sharing.verifyParseReceipt')(function* (input: {
+const readVerifiedGraphShareParseReceipt = Effect.fn('codeGraph.sharing.readVerifiedParseReceipt')(function* (input: {
   readonly announcement: GraphShareResultAnnouncementV1;
   readonly casRoot: string;
   readonly graphAbi?: string;
@@ -232,7 +328,11 @@ export const verifyGraphShareParseReceipt = Effect.fn('codeGraph.sharing.verifyP
   if (sha256Digest(resultBytes) !== input.announcement.resultManifestDigest) {
     return yield* graphSharingFailure('Parse-result CAS digest does not match the receipt.');
   }
-  const parsed = parseGraphShareParseResult(yield* decodeJsonBytes(resultBytes));
+  const value = yield* decodeJsonBytes(resultBytes);
+  const parsed = yield* Effect.try({
+    try: () => parseGraphShareParseResult(value),
+    catch: () => graphSharingFailure('Parse-result artifact is invalid.'),
+  });
   if (
     !admitsSharedParseCacheHydrate({
       identityRepositoryId: input.repositoryId,
@@ -248,14 +348,29 @@ export const verifyGraphShareParseReceipt = Effect.fn('codeGraph.sharing.verifyP
   }
   const attestationBytes = yield* readVerifiedCasBlob(input.casRoot, input.announcement.attestationDigest);
   const attestation = yield* decodeJsonBytes(attestationBytes);
-  if (!isContributorSelfAttestation(attestation, input.announcement.resultManifestDigest)) {
+  if (
+    sha256Digest(attestationBytes) !== input.announcement.attestationDigest ||
+    !isContributorSelfAttestation(attestation, input.announcement.resultManifestDigest)
+  ) {
     return yield* graphSharingFailure('Parse-result attestation does not match the receipt.');
   }
   if (input.graphAbi !== undefined && !/^[0-9a-f]{64}$/u.test(input.graphAbi)) {
     return yield* graphSharingFailure('Publisher graph ABI is invalid.');
   }
-  return {announcement: input.announcement, parsed} satisfies VerifiedGraphShareParseReceipt;
+  return {announcement: input.announcement, parsed, resultBytes, attestationBytes};
 });
+
+export const verifyGraphShareParseReceipt = Effect.fn('codeGraph.sharing.verifyParseReceipt')(
+  (input: {
+    readonly announcement: GraphShareResultAnnouncementV1;
+    readonly casRoot: string;
+    readonly graphAbi?: string;
+    readonly repositoryId: string;
+  }) =>
+    readVerifiedGraphShareParseReceipt(input).pipe(
+      Effect.map(({announcement, parsed}): VerifiedGraphShareParseReceipt => ({announcement, parsed})),
+    ),
+);
 
 export const hydratePublisherParseCache = Effect.fn('codeGraph.sharing.hydratePublisherParseCache')(function* (input: {
   readonly databasePath: string;
@@ -330,29 +445,62 @@ export const mirrorCoordinatorCasBlobs = Effect.fn('codeGraph.sharing.mirrorCoor
   }
 });
 
-const drainOneAnnouncement = Effect.fn('codeGraph.sharing.drainOneAnnouncement')(function* (
+const prepareContributionArtifacts = Effect.fn('codeGraph.sharing.prepareContributionArtifacts')(function* (
   casRoot: string,
-  coordinatorUrl: string,
+  repositoryId: string,
   announcement: GraphShareResultAnnouncementV1,
 ) {
-  const path = yield* Path.Path;
   const fs = yield* FileSystem.FileSystem;
-  const resultPath = path.join(casRoot, 'sha256', sha256HexFromDigest(announcement.resultManifestDigest));
-  const attestationPath = path.join(casRoot, 'sha256', sha256HexFromDigest(announcement.attestationDigest));
-  if (!(yield* fs.exists(resultPath)) || !(yield* fs.exists(attestationPath))) return false;
-  const resultBytes = yield* fs.readFile(resultPath);
-  const attestationBytes = yield* fs.readFile(attestationPath);
+  const path = yield* Path.Path;
+  for (const [digest, limit] of [
+    [announcement.resultManifestDigest, GRAPH_SHARE_HTTP_CAS_MAX_BYTES],
+    [announcement.attestationDigest, 65_536],
+  ] as const) {
+    const target = path.join(casRoot, 'sha256', sha256HexFromDigest(digest));
+    if (!(yield* fs.exists(target))) return undefined;
+    if (Number((yield* fs.stat(target)).size) > limit)
+      return yield* graphSharingFailure('Contribution artifact exceeds the upload read limit.');
+  }
+  return yield* readVerifiedGraphShareParseReceipt({
+    casRoot,
+    repositoryId,
+    announcement,
+  });
+});
+
+const drainOneAnnouncement = Effect.fn('codeGraph.sharing.drainOneAnnouncement')(function* (
+  prepared: {readonly resultBytes: Uint8Array; readonly attestationBytes: Uint8Array},
+  coordinatorUrl: string,
+  announcement: GraphShareResultAnnouncementV1,
+  stillAuthorized: Effect.Effect<boolean, unknown, FileSystem.FileSystem | Path.Path>,
+) {
+  const {resultBytes, attestationBytes} = prepared;
+  if (!(yield* stillAuthorized)) return false;
   yield* graphShareControlPutCas(coordinatorUrl, resultBytes);
+  if (!(yield* stillAuthorized)) return false;
   yield* graphShareControlPutCas(coordinatorUrl, attestationBytes);
+  if (!(yield* stillAuthorized)) return false;
   yield* graphShareControlPutTag(
     coordinatorUrl,
     graphShareActionDiscoveryTag(announcement.actionKey),
     announcement.resultManifestDigest,
-  ).pipe(Effect.ignore);
+  ).pipe(
+    Effect.catchIf(
+      error =>
+        Schema.is(GraphSharingError)(error) &&
+        error.kind === 'verification-failed' &&
+        error.httpStatus !== 401 &&
+        error.httpStatus !== 403,
+      () => Effect.void,
+    ),
+  );
+  if (!(yield* stillAuthorized)) return false;
   const announced = yield* graphShareControlAnnounceResult(
     coordinatorUrl,
     announcement,
     announcement.resultManifestDigest,
   );
-  return announced.status === 200 || announced.status === 201 || announced.status === 409;
+  if (announced.status !== 200 && announced.status !== 201 && announced.status !== 409)
+    return yield* graphSharingHttpFailure(announced.status);
+  return true;
 });

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -20,6 +20,7 @@ import {LocalModelRuntime} from '../../effect/ai/local-model-runtime.js';
 import {SystemInfo} from '../../effect/system.js';
 import {captureConsole} from '../../effect/console.js';
 import {monitorSharedRepositories} from '../../effect/share.js';
+import {monitorGraphShareContributions} from '../../code_graph/sharing/contribution_retry.js';
 import {runObsidianProjectionPublish} from '../../obsidian/projection.js';
 import {withProductionLogging} from '../../effect/production_log.js';
 import {withAnonymousTelemetry} from '../../effect/telemetry.js';
@@ -132,6 +133,9 @@ export const mcpServerEffect = withAnonymousTelemetry(
         }
         if (!memoryScope && toolset !== CURSOR_CLOUD_LOCAL_MCP_TOOLSET) {
           yield* Effect.forkScoped(monitorSharedRepositories(config));
+        }
+        if (mcpToolCapabilities(toolset).graphLocal) {
+          yield* Effect.forkScoped(monitorGraphShareContributions(config.agentContextHome));
         }
         yield* Console.error('Threadnote local MCP adapter running');
         return yield* server.run();

--- a/test/helpers/graph-share-contribution.ts
+++ b/test/helpers/graph-share-contribution.ts
@@ -1,0 +1,36 @@
+import {canonicalJson} from '../../src/code_graph/checkpoint/canonical_json.js';
+import {graphShareParseActionKey} from '../../src/code_graph/sharing/action.js';
+import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {graphShareParseResultArtifact} from '../../src/code_graph/sharing/parse_result.js';
+
+export function graphShareContributionFixture(repositoryId: string, normalizedPath = 'src/fixture.ts') {
+  const input = {
+    repositoryId,
+    contentHash: 'a'.repeat(64),
+    extractorSet: 'b'.repeat(64),
+    languageAndRole: 'typescript:source',
+    normalizedPath,
+  };
+  const artifact = graphShareParseResultArtifact({
+    ...input,
+    actionKey: graphShareParseActionKey(input),
+    gitBlobId: 'c'.repeat(40),
+    facts: {path: input.normalizedPath, diagnostics: [], edges: [], symbols: []},
+  });
+  const resultBytes = new TextEncoder().encode(canonicalJson(artifact));
+  const resultManifestDigest = sha256Digest(resultBytes);
+  const attestationBytes = new TextEncoder().encode(
+    canonicalJson({kind: 'contributor-self', payloadDigest: resultManifestDigest, schemaVersion: 1}),
+  );
+  return {
+    resultBytes,
+    attestationBytes,
+    announcement: {
+      actionKey: artifact.actionKey,
+      batchId: 'd'.repeat(40),
+      semanticDigest: artifact.semanticDigest,
+      resultManifestDigest,
+      attestationDigest: sha256Digest(attestationBytes),
+    },
+  };
+}

--- a/test/integration/code-graph.contribution-retry.test.ts
+++ b/test/integration/code-graph.contribution-retry.test.ts
@@ -1,0 +1,184 @@
+import {execFile} from '../helpers/node-child-process.js';
+import {promisify} from '../helpers/node-util.js';
+import {graphShareContributionFixture} from '../helpers/graph-share-contribution.js';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import {describe, expect, it} from 'vitest';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from '../helpers/node-fs-promises.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import {sha256Digest, sha256HexFromDigest} from '../../src/code_graph/sharing/digest.js';
+
+describe('MCP-owned passive graph contribution retries', () => {
+  it.each(['persisted queue', 'ordinary graph query'] as const)(
+    'recovers automatically after an outage from %s',
+    async source => {
+      const root = await mkdtemp(join(tmpdir(), 'threadnote-mcp-contribution-retry-'));
+      const home = join(root, 'home');
+      const cas = join(root, 'cas');
+      const repository = join(root, 'repository');
+      const repositoryId = sha256HexFromDigest(sha256Digest('repository-v1\ngithub.com/acme/automatic-contribution'));
+      const command = promisify(execFile);
+      let healthy = false;
+      let refusedRequests = 0;
+      let deliveredRequests = 0;
+      let refused!: () => void;
+      let delivered!: () => void;
+      const firstRefusal = new Promise<void>(resolve => {
+        refused = resolve;
+      });
+      const firstDelivery = new Promise<void>(resolve => {
+        delivered = resolve;
+      });
+      const server = Bun.serve({
+        hostname: '127.0.0.1',
+        port: 0,
+        fetch: async request => {
+          await request.arrayBuffer();
+          if (request.method === 'GET')
+            return Response.json({
+              generation: 1,
+              organization: 'acme',
+              phase: 'idle',
+              publishedFrontier: null,
+              repositoryId,
+              receipts: [],
+            });
+          if (!healthy) {
+            refusedRequests += 1;
+            refused();
+            return Response.json({}, {status: 503, headers: {'Retry-After': '1'}});
+          }
+          if (new URL(request.url).pathname === '/v1/results') {
+            deliveredRequests += 1;
+            delivered();
+          }
+          return Response.json({});
+        },
+      });
+      let client: Client | undefined;
+      try {
+        await mkdir(join(home, 'graph-sharing', 'contribution'), {recursive: true});
+        await mkdir(join(cas, 'sha256'), {recursive: true});
+        await writeFile(join(home, 'seed-manifest.yaml'), 'version: 1\nprojects: []\n');
+        if (source === 'ordinary graph query') {
+          await mkdir(join(repository, 'src'), {recursive: true});
+          await writeFile(
+            join(repository, 'src', 'index.ts'),
+            'export function automaticContributionTarget() { return 42; }\n',
+          );
+          await command('git', ['init', '-q', '--initial-branch=main', repository]);
+          await command('git', [
+            '-C',
+            repository,
+            'remote',
+            'add',
+            'origin',
+            'https://github.com/acme/automatic-contribution.git',
+          ]);
+          await command('git', ['-C', repository, 'add', '.']);
+          await command('git', [
+            '-C',
+            repository,
+            '-c',
+            'user.name=Fixture',
+            '-c',
+            'user.email=fixture@example.invalid',
+            'commit',
+            '-qm',
+            'fixture',
+          ]);
+        }
+        const {announcement, resultBytes, attestationBytes} = graphShareContributionFixture(repositoryId);
+        const {resultManifestDigest, attestationDigest} = announcement;
+        await writeFile(join(cas, 'sha256', sha256HexFromDigest(resultManifestDigest)), resultBytes);
+        await writeFile(join(cas, 'sha256', sha256HexFromDigest(attestationDigest)), attestationBytes);
+        await writeFile(
+          join(home, 'graph-sharing', 'trust-receipts.json'),
+          JSON.stringify({
+            schemaVersion: 1,
+            receipts: [
+              {
+                accessMode: 'join',
+                organization: 'acme',
+                policyVersion: 1,
+                profileDigest: sha256Digest('profile'),
+                publisherKeyFingerprint: sha256Digest('publisher'),
+                registryCanonical: 'cas://local',
+                repositoryId,
+                client: {casRoot: cas, contributionMode: 'passive', coordinatorUrl: `http://127.0.0.1:${server.port}`},
+              },
+            ],
+          }),
+        );
+        const queuePath = join(home, 'graph-sharing', 'contribution', `${repositoryId}.json`);
+        if (source === 'persisted queue')
+          await writeFile(
+            queuePath,
+            JSON.stringify({
+              schemaVersion: 1,
+              mode: 'passive',
+              announcements: [announcement],
+            }),
+          );
+        const transport = new StdioClientTransport({
+          command: process.execPath,
+          args: [join(process.cwd(), 'src/standalone.ts'), 'mcp-server'],
+          cwd: process.cwd(),
+          stderr: 'pipe',
+          env: {
+            ...process.env,
+            THREADNOTE_HOME: home,
+            THREADNOTE_MANIFEST: join(home, 'seed-manifest.yaml'),
+            THREADNOTE_ACCOUNT: 'local',
+            THREADNOTE_USER: 'tester',
+            THREADNOTE_TELEMETRY: '0',
+            THREADNOTE_MCP_TOOLSET: 'cursor-cloud-local',
+          },
+        });
+        client = new Client({name: 'contribution-retry-fixture', version: '1'});
+        await client.connect(transport);
+        if (source === 'ordinary graph query') {
+          const result = await client.callTool({
+            name: 'inspect_code_graph',
+            arguments: {
+              callerCwd: repository,
+              operation: 'query',
+              query: 'automaticContributionTarget',
+              budgetTokens: 800,
+            },
+          });
+          expect(result.isError).not.toBe(true);
+        }
+        await within(firstRefusal, 20_000);
+        expect(refusedRequests).toBe(1);
+        expect(JSON.parse(await readFile(queuePath, 'utf8')).announcements.length).toBeGreaterThan(0);
+        healthy = true;
+        await within(firstDelivery, 20_000);
+        expect(deliveredRequests).toBeGreaterThan(0);
+      } finally {
+        await client?.close();
+        await server.stop(true);
+        await rm(root, {recursive: true, force: true});
+      }
+    },
+    45_000,
+  );
+});
+
+async function within<A>(promise: Promise<A>, milliseconds: number): Promise<A> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('Timed out waiting for automatic contribution progress.')),
+          milliseconds,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/test/unit/code-graph.contribution-delivery.test.ts
+++ b/test/unit/code-graph.contribution-delivery.test.ts
@@ -1,0 +1,183 @@
+import * as BunHttpClient from '@effect/platform-bun/BunHttpClient';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Clock, Effect, FileSystem, Layer, Result} from 'effect';
+import {TestClock} from 'effect/testing';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {graphShareContributionFixture} from '../helpers/graph-share-contribution.js';
+import {putCasBytes} from '../../src/code_graph/sharing/cas.js';
+import {
+  enqueuePersistedGraphShareContribution,
+  readGraphShareContributionQueue,
+} from '../../src/code_graph/sharing/contribution.js';
+import {
+  readContributionRetryState,
+  writeContributionRetryState,
+} from '../../src/code_graph/sharing/contribution_retry_state.js';
+import {sha256Digest, sha256HexFromDigest} from '../../src/code_graph/sharing/digest.js';
+import {drainQueuedGraphShareContributions} from '../../src/code_graph/sharing/parse_cache.js';
+import {writeGraphShareTrustReceipt} from '../../src/code_graph/sharing/trust.js';
+import {SystemInfo} from '../../src/effect/system.js';
+
+const layer = SystemInfo.layer.pipe(Layer.provideMerge(BunServices.layer), Layer.provideMerge(BunHttpClient.layer));
+
+const fixture = Effect.fn('test.contributionDeliveryFixture')(function* (
+  reply: (request: Request) => Response | Promise<Response>,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-contribution-delivery-'});
+  const cas = `${home}/cas`;
+  const repositoryId = 'a'.repeat(64);
+  const server = yield* Effect.acquireRelease(
+    Effect.sync(() => Bun.serve({hostname: '127.0.0.1', port: 0, fetch: reply})),
+    server => Effect.promise(() => server.stop(true)),
+  );
+  const trust = {
+    accessMode: 'join' as const,
+    organization: 'acme',
+    policyVersion: 1 as const,
+    profileDigest: sha256Digest('profile'),
+    publisherKeyFingerprint: sha256Digest('publisher'),
+    registryCanonical: 'cas://local',
+    repositoryId,
+    client: {casRoot: cas, contributionMode: 'passive' as const, coordinatorUrl: `http://127.0.0.1:${server.port}`},
+  };
+  yield* writeGraphShareTrustReceipt(home, trust);
+  const contribution = graphShareContributionFixture(repositoryId);
+  yield* putCasBytes(cas, contribution.resultBytes);
+  yield* putCasBytes(cas, contribution.attestationBytes);
+  yield* enqueuePersistedGraphShareContribution(home, repositoryId, 'join', contribution.announcement, 'passive');
+  return {
+    home,
+    cas,
+    repositoryId,
+    trust,
+    contribution,
+    drain: drainQueuedGraphShareContributions({
+      identity: {repositoryId},
+      threadnoteHome: home,
+      propagateUnavailable: true,
+    }),
+  };
+});
+
+describe('automatic contribution delivery boundaries', () => {
+  effectIt.effect('persists server backpressure across independent rounds and pauses authorization failures', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        let requests = 0;
+        let status = 429;
+        const f = yield* fixture(async request => {
+          await request.arrayBuffer();
+          requests++;
+          return Response.json({}, {status, headers: {'Retry-After': '120'}});
+        });
+        const before = yield* Clock.currentTimeMillis;
+        expect(Result.isFailure(yield* f.drain.pipe(Effect.result))).toBe(true);
+        const backoff = (yield* readContributionRetryState(f.home, f.repositoryId))!;
+        expect(backoff.nextAttempt).toBeGreaterThanOrEqual(before + 120_000);
+        expect(yield* drainQueuedGraphShareContributions({identity: f.trust, threadnoteHome: f.home})).toEqual({
+          sent: 0,
+        });
+        expect(requests).toBe(1);
+        status = 401;
+        yield* writeContributionRetryState(f.home, f.repositoryId, {...backoff, nextAttempt: 0});
+        expect(Result.isFailure(yield* f.drain.pipe(Effect.result))).toBe(true);
+        expect((yield* readContributionRetryState(f.home, f.repositoryId))?.nextAttempt).toBeGreaterThanOrEqual(
+          before + 3_600_000,
+        );
+        expect((yield* readGraphShareContributionQueue(f.home, f.repositoryId, 'passive')).announcements).toHaveLength(
+          1,
+        );
+        expect(yield* f.drain).toEqual({sent: 0});
+        expect(requests).toBe(2);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('refuses corrupted artifact bytes before making any outbound request', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        let requests = 0;
+        const f = yield* fixture(() => {
+          requests++;
+          return Response.json({});
+        });
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.writeFileString(
+          `${f.cas}/sha256/${sha256HexFromDigest(f.contribution.announcement.resultManifestDigest)}`,
+          '{"raw":"untrusted content"}',
+        );
+        expect(yield* f.drain).toEqual({sent: 0});
+        expect(requests).toBe(0);
+        expect((yield* readGraphShareContributionQueue(f.home, f.repositoryId, 'passive')).announcements).toEqual([]);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('discards obsolete local cache references while delivering newer valid work', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        let requests = 0;
+        const f = yield* fixture(async request => {
+          await request.arrayBuffer();
+          requests++;
+          return Response.json({});
+        });
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.remove(`${f.cas}/sha256/${sha256HexFromDigest(f.contribution.announcement.resultManifestDigest)}`);
+        for (let index = 0; index < 8; index++) {
+          yield* enqueuePersistedGraphShareContribution(
+            f.home,
+            f.repositoryId,
+            'join',
+            {...f.contribution.announcement, actionKey: index.toString(16).padStart(64, '0')},
+            'passive',
+          );
+        }
+        const fresh = graphShareContributionFixture(f.repositoryId, 'src/new.ts');
+        yield* putCasBytes(f.cas, fresh.resultBytes);
+        yield* putCasBytes(f.cas, fresh.attestationBytes);
+        yield* enqueuePersistedGraphShareContribution(f.home, f.repositoryId, 'join', fresh.announcement, 'passive');
+        expect(yield* f.drain).toEqual({sent: 0});
+        expect(yield* f.drain).toEqual({sent: 1});
+        expect(requests).toBe(4);
+        expect((yield* readGraphShareContributionQueue(f.home, f.repositoryId, 'passive')).announcements).toEqual([]);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('serializes competing delivery rounds without duplicate uploads', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        let requests = 0;
+        const f = yield* fixture(async request => {
+          await request.arrayBuffer();
+          requests++;
+          return Response.json({});
+        });
+        const rounds = yield* Effect.all([f.drain, f.drain, f.drain], {concurrency: 3});
+        expect(rounds.reduce((sum, round) => sum + round.sent, 0)).toBe(1);
+        expect(requests).toBe(4);
+        expect((yield* readGraphShareContributionQueue(f.home, f.repositoryId, 'passive')).announcements).toEqual([]);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('honors off and read-only without sending queued work', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        let requests = 0;
+        const f = yield* fixture(() => {
+          requests++;
+          return Response.json({});
+        });
+        yield* writeGraphShareTrustReceipt(f.home, {...f.trust, client: {...f.trust.client, contributionMode: 'off'}});
+        expect(yield* f.drain).toEqual({sent: 0});
+        yield* writeGraphShareTrustReceipt(f.home, {...f.trust, accessMode: 'read-only'});
+        expect(yield* f.drain).toEqual({sent: 0});
+        expect(requests).toBe(0);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+});

--- a/test/unit/code-graph.contribution-retry.test.ts
+++ b/test/unit/code-graph.contribution-retry.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {graphShareContributionRetryDelay} from '../../src/code_graph/sharing/contribution_retry_state.js';
+import {graphShareRetryAfterMilliseconds} from '../../src/code_graph/sharing/errors.js';
+
+describe('automatic graph contribution retry timing', () => {
+  it('backs off monotonically, bounds jitter and respects a server retry delay', () => {
+    FC.assert(
+      FC.property(
+        FC.integer({min: 1, max: 20}),
+        FC.double({min: 0, max: 1, noNaN: true}),
+        FC.integer({min: 0, max: 86_400_000}),
+        (failures, jitter, retryAfter) => {
+          const delay = graphShareContributionRetryDelay(failures, jitter, retryAfter);
+          expect(delay).toBeGreaterThanOrEqual(retryAfter);
+          expect(delay).toBeGreaterThanOrEqual(5_000);
+          expect(delay).toBeLessThanOrEqual(Math.max(retryAfter, 360_000));
+          expect(graphShareContributionRetryDelay(failures + 1, jitter, retryAfter)).toBeGreaterThanOrEqual(delay);
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  it('accepts delta-seconds and HTTP dates but ignores malformed retry hints', () => {
+    expect(graphShareRetryAfterMilliseconds('12', 0)).toBe(12_000);
+    expect(graphShareRetryAfterMilliseconds('Thu, 01 Jan 1970 00:00:30 GMT', 10_000)).toBe(20_000);
+    expect(graphShareRetryAfterMilliseconds('not a date', 0)).toBeUndefined();
+    expect(graphShareRetryAfterMilliseconds('-2', 0)).toBeUndefined();
+  });
+});

--- a/test/unit/code-graph.control-enrollment.test.ts
+++ b/test/unit/code-graph.control-enrollment.test.ts
@@ -1,0 +1,241 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Clock, Effect, FileSystem, Layer, Result, Stream} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FC from 'effect/testing/FastCheck';
+import {SystemInfo} from '../../src/effect/system.js';
+import {
+  enrollGraphControlWorker,
+  graphWorkerEnrollmentStatePath,
+  readGraphWorkerEnrollmentRequest,
+} from '../../src/code_graph/sharing/control_enrollment.js';
+import {parseGraphControlPolicy} from '../../src/code_graph/sharing/control_authorization.js';
+import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {graphSharingFailure} from '../../src/code_graph/sharing/errors.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const layer = SystemInfo.layer.pipe(Layer.provideMerge(BunServices.layer));
+const fixture = Effect.fn('test.graphEnrollmentFixture')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-enrollment-'});
+  const now = Math.floor((yield* Clock.currentTimeMillis) / 1000);
+  const policy = parseGraphControlPolicy({
+    audience: 'https://graph.example.test',
+    issuer: 'https://id.example.test/',
+    jwksUrl: 'https://id.example.test/jwks',
+    organization: 'acme',
+    repositoryId: 'a'.repeat(64),
+    profileDigest: sha256Digest('profile'),
+    schemaVersion: 1,
+    grants: ['private-a', 'private-b'].map(subject => ({expiresAt: now + 600, scopes: ['graph:contribute'], subject})),
+  });
+  const principal = {
+    expiresAt: now + 300,
+    issuer: policy.issuer,
+    subject: 'private-a',
+    scopes: new Set(['graph:contribute']),
+  };
+  const request = {idempotencyKey: 'same-key', repositoryId: policy.repositoryId, profileDigest: policy.profileDigest};
+  const input = {home, initialPolicy: policy, principal, readCurrentPolicy: Effect.succeed(policy), request};
+  return {
+    fs,
+    home,
+    now,
+    policy,
+    principal,
+    request,
+    input,
+    target: yield* graphWorkerEnrollmentStatePath(home, policy),
+  };
+});
+
+describe('principal-owned graph worker enrollment', () => {
+  effectIt.effect('stops reading an oversized streamed body before consuming its tail', () =>
+    Effect.gen(function* () {
+      let consumedTail = false;
+      const stream = Stream.concat(
+        Stream.make(new Uint8Array(65_537)),
+        Stream.fromEffect(
+          Effect.sync(() => {
+            consumedTail = true;
+            return new Uint8Array(1);
+          }),
+        ),
+      );
+      expect(Result.isFailure(yield* readGraphWorkerEnrollmentRequest(stream).pipe(Effect.result))).toBe(true);
+      expect(consumedTail).toBe(false);
+    }),
+  );
+
+  effectIt.effect.prop(
+    'decodes the same bounded request across arbitrary stream chunk boundaries',
+    {sizes: FC.array(FC.integer({min: 1, max: 40}), {maxLength: 30})},
+    ({sizes}) =>
+      Effect.gen(function* () {
+        const request = {
+          idempotencyKey: 'clé-🔐',
+          repositoryId: 'a'.repeat(64),
+          profileDigest: sha256Digest('profile'),
+        };
+        const bytes = new TextEncoder().encode(JSON.stringify(request));
+        const chunks: Uint8Array[] = [];
+        let offset = 0;
+        for (const size of sizes) {
+          chunks.push(bytes.slice(offset, offset + size));
+          offset = Math.min(bytes.length, offset + size);
+        }
+        chunks.push(bytes.slice(offset));
+        expect(yield* readGraphWorkerEnrollmentRequest(Stream.fromIterable(chunks))).toEqual(request);
+      }),
+    {fastCheck: {numRuns: 50}},
+  );
+
+  effectIt.effect('persists one identity under concurrent replay and stores no raw caller identity or key', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        const responses = yield* Effect.forEach(Array.from({length: 12}), () => enrollGraphControlWorker(f.input), {
+          concurrency: 12,
+        });
+        expect(responses.filter(response => response.created)).toHaveLength(1);
+        expect(new Set(responses.map(response => response.body.workerId)).size).toBe(1);
+        expect(responses[0].body.expiresAt).toBeLessThanOrEqual(f.now + 600);
+        const body = yield* f.fs.readFileString(f.target);
+        expect(JSON.parse(body).records).toHaveLength(1);
+        expect(body).not.toContain('private-a');
+        expect(body).not.toContain('same-key');
+        expect((yield* enrollGraphControlWorker({...f.input})).body).toEqual(responses[0].body);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect.prop(
+    'replay identity remains isolated by principal and operation key',
+    {operations: FC.array(FC.tuple(FC.boolean(), FC.integer({min: 0, max: 5})), {minLength: 1, maxLength: 12})},
+    ({operations}) =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const f = yield* fixture();
+          const expected = new Map<string, string>();
+          for (const [other, key] of operations) {
+            const subject = other ? 'private-b' : 'private-a';
+            const result = yield* enrollGraphControlWorker({
+              ...f.input,
+              principal: {...f.principal, subject},
+              request: {...f.request, idempotencyKey: String(key)},
+            });
+            const identity = `${subject}:${key}`;
+            if (expected.has(identity)) {
+              expect(result.created).toBe(false);
+              expect(result.body.workerId).toBe(expected.get(identity));
+            } else {
+              expect(result.created).toBe(true);
+              expect([...expected.values()]).not.toContain(result.body.workerId);
+              expected.set(identity, result.body.workerId);
+            }
+          }
+          expect(JSON.parse(yield* f.fs.readFileString(f.target)).records).toHaveLength(expected.size);
+        }).pipe(provideTestLayer(layer)),
+      ),
+    {fastCheck: {numRuns: 20}},
+  );
+
+  effectIt.effect('rejects a grant revoked during state preparation without persisting an identity', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        let reads = 0;
+        const result = yield* enrollGraphControlWorker({
+          ...f.input,
+          readCurrentPolicy: Effect.sync(() => (++reads === 1 ? f.policy : {...f.policy, grants: []})),
+        }).pipe(Effect.result);
+        expect(Result.isFailure(result)).toBe(true);
+        expect(yield* f.fs.exists(f.target)).toBe(false);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('denies corrupt state instead of resetting it and caps each principal without breaking replay', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        const first = yield* enrollGraphControlWorker(f.input);
+        for (let key = 1; key < 32; key++)
+          yield* enrollGraphControlWorker({...f.input, request: {...f.request, idempotencyKey: String(key)}});
+        expect(
+          Result.isFailure(
+            yield* enrollGraphControlWorker({...f.input, request: {...f.request, idempotencyKey: 'over-limit'}}).pipe(
+              Effect.result,
+            ),
+          ),
+        ).toBe(true);
+        expect((yield* enrollGraphControlWorker(f.input)).body).toEqual(first.body);
+        yield* f.fs.writeFileString(f.target, '{"invalid":true}');
+        expect(Result.isFailure(yield* enrollGraphControlWorker(f.input).pipe(Effect.result))).toBe(true);
+        expect(yield* f.fs.readFileString(f.target)).toBe('{"invalid":true}');
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+  effectIt.effect('bounds total active identities and replaces expired records without extending a replay', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        const first = yield* enrollGraphControlWorker(f.input);
+        const saved = JSON.parse(yield* f.fs.readFileString(f.target));
+        const original = saved.records[0];
+        saved.records = [
+          original,
+          ...Array.from({length: 1023}, (_, index) => ({
+            ...original,
+            operationId: sha256Digest(`operation-${index}`),
+            principalId: sha256Digest(`principal-${index}`),
+            workerId: `gw_${index.toString(16).padStart(32, '0')}`,
+          })),
+        ];
+        yield* f.fs.writeFileString(f.target, JSON.stringify(saved));
+        const before = yield* f.fs.readFileString(f.target);
+        expect(
+          Result.isFailure(
+            yield* enrollGraphControlWorker({
+              ...f.input,
+              request: {...f.request, idempotencyKey: 'new-operation'},
+            }).pipe(Effect.result),
+          ),
+        ).toBe(true);
+        expect(yield* f.fs.readFileString(f.target)).toBe(before);
+        expect((yield* enrollGraphControlWorker(f.input)).body).toEqual(first.body);
+        yield* f.fs.writeFileString(
+          f.target,
+          JSON.stringify({
+            ...saved,
+            records: saved.records.map((record: Record<string, unknown>) => ({...record, expiresAt: f.now - 1})),
+          }),
+        );
+        const renewed = yield* enrollGraphControlWorker(f.input);
+        expect(renewed.created).toBe(true);
+        expect(renewed.body.workerId).not.toBe(first.body.workerId);
+        expect(JSON.parse(yield* f.fs.readFileString(f.target)).records).toHaveLength(1);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('does not acknowledge a failed durable commit', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        const broken = {
+          ...f.fs,
+          rename: (from: string, to: string) =>
+            to === f.target ? Effect.fail(graphSharingFailure('Synthetic persistence failure')) : f.fs.rename(from, to),
+        };
+        const failed = yield* enrollGraphControlWorker(f.input).pipe(
+          Effect.provideService(FileSystem.FileSystem, broken),
+          Effect.result,
+        );
+        expect(Result.isFailure(failed)).toBe(true);
+        expect(yield* f.fs.exists(f.target)).toBe(false);
+        expect((yield* enrollGraphControlWorker(f.input)).created).toBe(true);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+});

--- a/test/unit/code-graph.control-reader.test.ts
+++ b/test/unit/code-graph.control-reader.test.ts
@@ -22,6 +22,7 @@ import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
 import {graphSharingFrontierPointerPath, graphSharingLayout} from '../../src/code_graph/sharing/layout.js';
 import {graphShareFrontierDiscoveryTag} from '../../src/code_graph/sharing/namespace.js';
 import {defaultGraphShareProfile, graphShareProfileDigest} from '../../src/code_graph/sharing/profile.js';
+import {SystemInfo} from '../../src/effect/system.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 
 const ISSUER = 'https://identity.example.test/';
@@ -145,7 +146,13 @@ const fixture = Effect.fn(function* () {
   );
   if (server.address._tag !== 'TcpAddress') throw new Error('Expected TCP');
   const url = `http://127.0.0.1:${server.address.port}`;
-  const request = (pathname = '/v1/status', auth = validToken, headers: Record<string, string> = {}, method = 'GET') =>
+  const request = (
+    pathname = '/v1/status',
+    auth = validToken,
+    headers: Record<string, string> = {},
+    method = 'GET',
+    body?: unknown,
+  ) =>
     Effect.gen(function* () {
       const client = yield* HttpClient.HttpClient;
       const request = (
@@ -158,7 +165,13 @@ const fixture = Effect.fn(function* () {
           ...headers,
         }),
       );
-      const response = yield* client.execute(request);
+      const outbound =
+        body === undefined
+          ? request
+          : request.pipe(
+              HttpClientRequest.bodyUint8Array(new TextEncoder().encode(JSON.stringify(body)), 'application/json'),
+            );
+      const response = yield* client.execute(outbound);
       return {body: yield* response.json, headers: response.headers, status: response.status};
     });
   return {
@@ -201,7 +214,7 @@ describe('authenticated metadata-only graph reads', () => {
             manifestDigest: f.pointer.manifestDigest,
           });
           expect((yield* f.request('/.well-known/threadnote-graph', '')).body).toEqual({
-            controlMode: 'authenticated-read-only',
+            controlMode: 'authenticated-metadata',
             organization: 'acme',
             protocolVersions: ['v1'],
           });
@@ -226,8 +239,55 @@ describe('authenticated metadata-only graph reads', () => {
             expect(event).not.toContain('private-reader');
             expect(event).not.toContain(f.home);
           }
-        }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+        }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer, SystemInfo.layer))),
       ),
+  );
+
+  effectIt.effect('enrolls only the authenticated contributor and replays the same bounded identity', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        yield* writePrivateJsonFile(f.options.policyFile, {
+          ...f.policy,
+          grants: [{...f.policy.grants[0], scopes: ['graph:read', 'graph:contribute']}],
+        });
+        const token = yield* f.token({scope: 'graph:contribute'});
+        const body = {idempotencyKey: 'same-operation', repositoryId: REPOSITORY, profileDigest: f.profileDigest};
+        expect((yield* f.request('/v1/enroll', f.validToken, {}, 'POST', body)).status).toBe(403);
+        const first = yield* f.request('/v1/enroll', token, {}, 'POST', body);
+        expect(first.status).toBe(201);
+        expect(first.body).toMatchObject({
+          repositoryId: REPOSITORY,
+          profileDigest: f.profileDigest,
+          workerId: expect.stringMatching(/^gw_[0-9a-f]{32}$/u),
+          expiresAt: expect.any(Number),
+        });
+        expect(
+          (yield* f.request('/v1/enroll', token, {}, 'POST', {...body, profileDigest: sha256Digest('wrong-profile')}))
+            .status,
+        ).toBe(403);
+        expect(
+          (yield* f.request('/v1/enroll', token, {}, 'POST', {...body, idempotencyKey: 'x'.repeat(65_536)})).status,
+        ).toBe(413);
+        const replay = yield* f.request('/v1/enroll', token, {}, 'POST', body);
+        expect(replay.status).toBe(200);
+        expect(replay.body).toEqual(first.body);
+        for (const override of [
+          {workerId: 'selected'},
+          {role: 'publisher'},
+          {source: 'secret'},
+          {expiresAt: 9999999999},
+        ])
+          expect((yield* f.request('/v1/enroll', token, {}, 'POST', {...body, ...override})).status).toBe(400);
+        expect((yield* f.request('/v1/status', token)).status).toBe(403);
+        yield* writePrivateJsonFile(f.options.policyFile, {...f.policy, grants: []});
+        expect((yield* f.request('/v1/enroll', token, {}, 'POST', body)).status).toBe(403);
+        for (const text of f.audits) {
+          expect(text).not.toContain(token);
+          expect(text).not.toContain('same-operation');
+        }
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer, SystemInfo.layer))),
+    ),
   );
 
   effectIt.effect('rejects invalid JWTs, wrong scope and memory administrator tokens with bounded errors', () =>
@@ -252,7 +312,7 @@ describe('authenticated metadata-only graph reads', () => {
           {'x-threadnote-profile-digest': sha256Digest('wrong')},
         ] as Record<string, string>[])
           expect((yield* f.request('/v1/status', f.validToken, headers)).status).toBe(403);
-      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer, SystemInfo.layer))),
     ),
   );
 
@@ -272,7 +332,7 @@ describe('authenticated metadata-only graph reads', () => {
         expect((yield* f.request()).status).toBe(503);
         yield* f.fs.remove(f.options.policyFile);
         expect((yield* f.request()).status).toBe(503);
-      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer, SystemInfo.layer))),
     ),
   );
 
@@ -290,7 +350,7 @@ describe('authenticated metadata-only graph reads', () => {
         }
         yield* f.publish(f.manifest);
         expect((yield* readGraphControlFrontier(f.options)).manifest).toEqual(f.manifest);
-      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer, SystemInfo.layer))),
     ),
   );
 
@@ -301,7 +361,7 @@ describe('authenticated metadata-only graph reads', () => {
       const file = `${directory}/policy.json`;
       yield* fs.writeFileString(file, ' '.repeat(128 * 1024 + 1));
       expect((yield* readGraphControlPolicy(file).pipe(Effect.result))._tag).toBe('Failure');
-    }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+    }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer, SystemInfo.layer))),
   );
 
   effectIt.effect('returns bounded errors for corrupt or oversized artifacts and invalid signatures', () =>
@@ -324,7 +384,7 @@ describe('authenticated metadata-only graph reads', () => {
         yield* writePrivateJsonFile(f.pointerFile, {...f.pointer, envelopeDigest});
         expect((yield* f.request()).body).toEqual({error: 'unavailable'});
         expect(JSON.stringify(f.audits)).not.toContain(f.home);
-      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer))),
+      }).pipe(provideTestLayer(Layer.mergeAll(BunServices.layer, BunHttpClient.layer, SystemInfo.layer))),
     ),
   );
 });

--- a/test/unit/code-graph.sharing-contribute.test.ts
+++ b/test/unit/code-graph.sharing-contribute.test.ts
@@ -10,6 +10,12 @@ import {
   acknowledgeGraphShareContributions,
   readGraphShareContributionQueue,
   removeAcknowledgedGraphShareContributions,
+  pruneGraphShareContributionQueue,
+  GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS,
+  GRAPH_SHARE_QUEUE_MAXIMUM_ANNOUNCEMENTS,
+  GRAPH_SHARE_QUEUE_MAXIMUM_BYTES,
+  prunePersistedGraphShareContributionQueue,
+  writeGraphShareContributionQueue,
 } from '../../src/code_graph/sharing/contribution.js';
 import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
 import {SystemInfo} from '../../src/effect/system.js';
@@ -25,6 +31,85 @@ const announcement = {
 };
 
 describe('graph share contribution queue persistence', () => {
+  it('bounds metadata retention while preserving the newest unexpired announcements', () => {
+    const now = GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS + 1_000;
+    const announcements = Array.from({length: GRAPH_SHARE_QUEUE_MAXIMUM_ANNOUNCEMENTS + 10}, (_, index) => ({
+      ...announcement,
+      actionKey: index.toString(16).padStart(64, '0'),
+    }));
+    const queue = {
+      announcements,
+      mode: 'passive' as const,
+      schemaVersion: 1 as const,
+      queuedAtMilliseconds: announcements.map((_, index) => (index < 5 ? 0 : now)),
+    };
+    const before = JSON.stringify(queue);
+    const pruned = pruneGraphShareContributionQueue(queue, now);
+    expect(pruned.announcements).toEqual(announcements.slice(-GRAPH_SHARE_QUEUE_MAXIMUM_ANNOUNCEMENTS));
+    expect(pruneGraphShareContributionQueue(pruned, now)).toEqual(pruned);
+    expect(JSON.stringify(queue)).toBe(before);
+    expect(
+      pruneGraphShareContributionQueue(pruned, now + GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS + 1).announcements,
+    ).toEqual([]);
+  });
+
+  it('pruning is idempotent, immutable and retains only unexpired entries within count and byte bounds', () => {
+    FC.assert(
+      FC.property(
+        FC.array(FC.integer({min: 0, max: 2 * GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS}), {maxLength: 600}),
+        timestamps => {
+          const now = GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS + 100;
+          const queue = {
+            announcements: timestamps.map((_, index) => ({
+              ...announcement,
+              batchId: index.toString(16).padStart(40, '0'),
+            })),
+            mode: 'passive' as const,
+            schemaVersion: 1 as const,
+            queuedAtMilliseconds: timestamps,
+          };
+          const before = JSON.stringify(queue);
+          const pruned = pruneGraphShareContributionQueue(queue, now);
+          const expected = queue.announcements
+            .filter((_, index) => timestamps[index] >= now - GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS)
+            .slice(-GRAPH_SHARE_QUEUE_MAXIMUM_ANNOUNCEMENTS);
+          expect(pruned.announcements).toEqual(expected);
+          expect(
+            pruned.queuedAtMilliseconds?.every(
+              timestamp => timestamp <= now && timestamp >= now - GRAPH_SHARE_QUEUE_MAXIMUM_AGE_MILLISECONDS,
+            ),
+          ).toBe(true);
+          expect(new TextEncoder().encode(JSON.stringify(pruned)).byteLength).toBeLessThanOrEqual(
+            GRAPH_SHARE_QUEUE_MAXIMUM_BYTES,
+          );
+          expect(pruneGraphShareContributionQueue(pruned, now)).toEqual(pruned);
+          expect(JSON.stringify(queue)).toBe(before);
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  effectIt.effect('removes aged announcements from disk even when contributions are off', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-queue-retention-'});
+        const repositoryId = 'c'.repeat(64);
+        yield* writeGraphShareContributionQueue(home, repositoryId, {
+          announcements: [announcement],
+          mode: 'off',
+          schemaVersion: 1,
+          queuedAtMilliseconds: [0],
+        });
+        yield* prunePersistedGraphShareContributionQueue(home, repositoryId, 'off');
+        expect(
+          JSON.parse(yield* fs.readFileString(`${home}/graph-sharing/contribution/${repositoryId}.json`)).announcements,
+        ).toEqual([]);
+      }).pipe(provideTestLayer(sharingLayer)),
+    ),
+  );
+
   it('acknowledgement preserves unsent order and is idempotent without mutating its inputs', () => {
     FC.assert(
       FC.property(FC.array(FC.boolean(), {maxLength: 32}), flags => {
@@ -32,17 +117,52 @@ describe('graph share contribution queue persistence', () => {
           ...announcement,
           batchId: index.toString(16).padStart(40, '0'),
         }));
-        const queue = {announcements, mode: 'passive' as const, schemaVersion: 1 as const};
+        const queue = {
+          announcements,
+          mode: 'passive' as const,
+          schemaVersion: 1 as const,
+          queuedAtMilliseconds: flags.map((_, index) => index * 1_000),
+        };
         const sent = announcements.filter((_, index) => flags[index]);
         const before = JSON.stringify({queue, sent});
         const remaining = removeAcknowledgedGraphShareContributions(queue, sent);
         expect(remaining.announcements).toEqual(announcements.filter((_, index) => !flags[index]));
+        expect(remaining.queuedAtMilliseconds).toEqual(queue.queuedAtMilliseconds.filter((_, index) => !flags[index]));
         expect(removeAcknowledgedGraphShareContributions(remaining, sent)).toEqual(remaining);
         expect(JSON.stringify({queue, sent})).toBe(before);
       }),
       {numRuns: 50},
     );
   });
+
+  effectIt.effect('quarantines an oversized legacy backlog and admits fresh bounded work', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-queue-upgrade-'});
+        const repositoryId = 'c'.repeat(64);
+        const legacy = {
+          announcements: Array.from({length: 12_000}, (_, index) => ({
+            ...announcement,
+            actionKey: index.toString(16).padStart(64, '0'),
+          })),
+          mode: 'passive' as const,
+          schemaVersion: 1 as const,
+        };
+        yield* writeGraphShareContributionQueue(home, repositoryId, legacy);
+        const target = `${home}/graph-sharing/contribution/${repositoryId}.json`;
+        const oldSize = Number((yield* fs.stat(target)).size);
+        expect(oldSize).toBeGreaterThan(4 * 1_024 * 1_024);
+        const fresh = {...announcement, actionKey: 'f'.repeat(64)};
+        expect(
+          (yield* enqueuePersistedGraphShareContribution(home, repositoryId, 'join', fresh, 'passive')).queued,
+        ).toBe(true);
+        expect((yield* readGraphShareContributionQueue(home, repositoryId, 'passive')).announcements).toEqual([fresh]);
+        expect(Number((yield* fs.stat(`${target}.oversized`)).size)).toBe(oldSize);
+        expect(Number((yield* fs.stat(target)).size)).toBeLessThanOrEqual(GRAPH_SHARE_QUEUE_MAXIMUM_BYTES);
+      }).pipe(provideTestLayer(sharingLayer)),
+    ),
+  );
 
   effectIt.effect('acknowledges a drained snapshot without dropping contributions queued during upload', () =>
     TestClock.withLive(

--- a/test/unit/code-graph.sharing-repository-settings.test.ts
+++ b/test/unit/code-graph.sharing-repository-settings.test.ts
@@ -1,3 +1,4 @@
+import {graphShareContributionFixture} from '../helpers/graph-share-contribution.js';
 import * as BunHttpClient from '@effect/platform-bun/BunHttpClient';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {describe, expect, it as effectIt} from '@effect/vitest';
@@ -106,13 +107,9 @@ describe('repository-scoped graph sharing settings', () => {
         const b = yield* fixture(root, 'b', `http://127.0.0.1:${servers[1].port}`);
         yield* runGraphShareJoin(config, {cwd: a.repo, cas: a.cas});
         yield* runGraphShareJoin(config, {cwd: b.repo, cas: b.cas});
-        const announcement = {
-          actionKey: 'c'.repeat(64),
-          batchId: 'd'.repeat(40),
-          semanticDigest: sha256Digest('semantic'),
-          resultManifestDigest: yield* putCasBytes(a.cas, new TextEncoder().encode('{"repository":"a"}')),
-          attestationDigest: yield* putCasBytes(a.cas, new TextEncoder().encode('{"attestation":"a"}')),
-        };
+        const {announcement, resultBytes, attestationBytes} = graphShareContributionFixture(a.repositoryId);
+        yield* putCasBytes(a.cas, resultBytes);
+        yield* putCasBytes(a.cas, attestationBytes);
         const enqueue = enqueuePersistedGraphShareContribution(
           config.agentContextHome,
           a.repositoryId,


### PR DESCRIPTION
An org client should contribute through ordinary graph use without a per-task command. This change adds automatic retry for passive contributions in graph-capable MCP sessions and a bounded, authenticated worker-enrollment endpoint for the enterprise control API.

Queued contributions now retry after an outage or process restart without another graph, index, worker, or contribution command. Foreground completion and MCP sessions share a per-repository delivery lease and durable backoff, including Retry-After and authorization pauses. Delivery validates repository-bound result and attestation bytes, rechecks current trust before outbound operations, and skips invalid local cache references. Queues are bounded by count, size and retention; oversized legacy backlogs are retained in one private backup before fresh admission resumes. Passive mode schedules no speculative graph builds.

Authenticated enrollment requires graph:contribute in both the verified token and the current repository/profile grant. Server-generated worker identifiers are bound to the verified principal, expire within one hour or the grant lifetime, and replay durably across listener restarts. Mutation reloads the grant under the state lock; corrupt or full state fails closed. Closed request bodies are streamed with a hard 64 KiB bound, and neither caller-selected roles nor raw identity/token text enter persisted metadata. A worker identifier is not a bearer credential. Artifact, result, claim and assembly routes remain disabled in authenticated mode pending their corresponding authority and OCI implementation.

Validation: focused Effect and HTTP regressions cover retry/backpressure, competing delivery rounds, off/read-only policy, queue recovery, signed-token enrollment, principal isolation, concurrent replay, grant revocation and persistence failures. Bounded properties cover retry timing, retention, acknowledgement, request chunk boundaries and enrollment replay. Both slices passed full dev-cycle review with fixes re-reviewed. Lint and typecheck pass. The exact committed global binary passes real MCP outage/restart recovery tests and real CLI HTTPS-JWKS enrollment/restart/revocation smoke tests.

External principal/OCI client integration, total CAS cache quota and the final automatic laptop/Cloud campaign remain separate productization gates. The prior head's production performance failure and its failing same-runner protected-main comparison are preserved in #404; no threshold or assertion was weakened.

