### PR TITLE
feat(graph): import verified shared frontiers from OCI registries

### DIFF
--- a/src/code_graph/sharing/atomic.ts
+++ b/src/code_graph/sharing/atomic.ts
@@ -1,4 +1,4 @@
-import {Crypto, Effect, FileSystem, Option, Path, Schema} from 'effect';
+import {Crypto, Effect, FileSystem, Option, Path, Schema, Stream} from 'effect';
 import {graphSharingFailure} from './errors.js';
 
 export const writePrivateJsonFile = Effect.fn('codeGraph.sharing.writePrivateJsonFile')(function* (
@@ -45,6 +45,19 @@ export const readJsonFile = Effect.fn('codeGraph.sharing.readJsonFile')(function
     return yield* graphSharingFailure(`Refusing to read a graph-sharing symbolic link: ${target}`);
   }
   return yield* decodeJsonText(yield* fs.readFileString(target));
+});
+
+export const readBoundedPrivateBytes = Effect.fn('codeGraph.sharing.readBoundedPrivateBytes')(function* (
+  target: string,
+  maximum: number,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  if (Option.isSome(yield* fs.readLink(target).pipe(Effect.option))) {
+    return yield* graphSharingFailure('Graph-sharing metadata must not be a symbolic link.');
+  }
+  const bytes = Buffer.concat(yield* Stream.runCollect(fs.stream(target, {bytesToRead: maximum + 1})));
+  if (bytes.length > maximum) return yield* graphSharingFailure('Graph-sharing metadata exceeds its size limit.');
+  return bytes;
 });
 
 export const decodeJsonBytes = (bytes: Uint8Array) => decodeJsonText(new TextDecoder().decode(bytes));

--- a/src/code_graph/sharing/checkpoint_cas.ts
+++ b/src/code_graph/sharing/checkpoint_cas.ts
@@ -9,7 +9,7 @@ import {
 import {GRAPH_SHARE_CHECKPOINT_MEDIA_TYPE, GRAPH_SHARE_DELTA_MEDIA_TYPE} from './artifacts.js';
 import {decodeJsonBytes} from './atomic.js';
 import {putCasBytes, putCasFile, readVerifiedCasBlob, verifyCasBlob} from './cas.js';
-import {mirrorCoordinatorCasBlob} from './control_client.js';
+import {ensureSharedGraphBlob as ensureSharedLayerBlob, type GraphShareBlobSource} from './shared_blob.js';
 import {parseSha256Digest, type Sha256Digest} from './digest.js';
 import {graphSharingFailure, graphSharingUnavailable, GraphSharingError} from './errors.js';
 import {GRAPH_SHARE_HTTP_CAS_MAX_BYTES} from './oci.js';
@@ -144,6 +144,7 @@ export const ensureGraphShareCheckpointArtifact = Effect.fn('codeGraph.sharing.e
     readonly casRoot: string;
     readonly coordinatorUrl?: string;
     readonly metadataDigest?: string;
+    readonly blobSource?: GraphShareBlobSource;
   }) {
     const artifactDigest = parseSha256Digest(input.artifactDigest);
     return yield* verifyCasBlob(input.casRoot, artifactDigest).pipe(
@@ -157,18 +158,24 @@ const materializeSharedCheckpoint = Effect.fn('codeGraph.sharing.materializeChec
     readonly casRoot: string;
     readonly coordinatorUrl?: string;
     readonly metadataDigest?: string;
+    readonly blobSource?: GraphShareBlobSource;
   },
   artifactDigest: Sha256Digest,
 ) {
   if (input.metadataDigest !== undefined) {
-    const metadataBytes = yield* ensureSharedLayerBlob(input.casRoot, input.metadataDigest, input.coordinatorUrl);
+    const metadataBytes = yield* ensureSharedLayerBlob(
+      input.casRoot,
+      input.metadataDigest,
+      input.coordinatorUrl,
+      input.blobSource,
+    );
     const metadata = yield* decodeMetadata(metadataBytes);
     if (metadata.artifactDigest !== artifactDigest) {
       return yield* graphSharingFailure('Checkpoint metadata does not cover the assembled artifact digest.');
     }
-    yield* ensureSharedLayerBlob(input.casRoot, metadata.prefixDigest, input.coordinatorUrl);
+    yield* ensureSharedLayerBlob(input.casRoot, metadata.prefixDigest, input.coordinatorUrl, input.blobSource);
     for (const chunk of metadata.chunks) {
-      yield* ensureSharedLayerBlob(input.casRoot, chunk.digest, input.coordinatorUrl);
+      yield* ensureSharedLayerBlob(input.casRoot, chunk.digest, input.coordinatorUrl, input.blobSource);
     }
     const crypto = yield* Crypto.Crypto;
     const fs = yield* FileSystem.FileSystem;
@@ -188,8 +195,8 @@ const materializeSharedCheckpoint = Effect.fn('codeGraph.sharing.materializeChec
       spoolPath => fs.remove(spoolPath, {force: true}).pipe(Effect.ignore),
     );
   }
-  if (input.coordinatorUrl !== undefined) {
-    yield* mirrorCoordinatorCasBlob(input.casRoot, input.coordinatorUrl, artifactDigest).pipe(
+  if (input.coordinatorUrl !== undefined || input.blobSource !== undefined) {
+    yield* ensureSharedLayerBlob(input.casRoot, artifactDigest, input.coordinatorUrl, input.blobSource).pipe(
       Effect.catchIf(
         error =>
           Schema.is(GraphSharingError)(error) &&
@@ -204,22 +211,6 @@ const materializeSharedCheckpoint = Effect.fn('codeGraph.sharing.materializeChec
     return yield* verifyCasBlob(input.casRoot, artifactDigest);
   }
   return yield* graphSharingUnavailable(`CAS object is missing: ${artifactDigest}`);
-});
-
-const ensureSharedLayerBlob = Effect.fn('codeGraph.sharing.ensureLayerBlob')(function* (
-  casRoot: string,
-  digest: string,
-  coordinatorUrl: string | undefined,
-) {
-  return yield* readVerifiedCasBlob(casRoot, digest).pipe(
-    Effect.catchIf(isUnavailableSharingFailure, () =>
-      coordinatorUrl === undefined
-        ? graphSharingUnavailable(`CAS object is missing: ${digest}`)
-        : mirrorCoordinatorCasBlob(casRoot, coordinatorUrl, digest).pipe(
-            Effect.andThen(readVerifiedCasBlob(casRoot, digest)),
-          ),
-    ),
-  );
 });
 
 const inspectCheckpointFile = Effect.fn('codeGraph.sharing.inspectCheckpointFile')(function* (artifactPath: string) {

--- a/src/code_graph/sharing/client.ts
+++ b/src/code_graph/sharing/client.ts
@@ -8,8 +8,6 @@ import type {RuntimeConfig} from '../../types.js';
 import {
   parseGraphShareFrontierManifest,
   parseGraphShareFrontierPointer,
-  parseGraphShareSignatureEnvelope,
-  verifyGraphShareFrontier,
   type GraphShareFrontierManifestV1,
 } from './artifacts.js';
 import {decodeJsonBytes, readJsonFile, writePrivateJsonFile} from './atomic.js';
@@ -66,6 +64,13 @@ import {
   type GraphShareTrustReceiptV1,
 } from './trust.js';
 import {legacyGraphShareContributionMode, resolveGraphShareRepositoryClient} from './client_state.js';
+import {
+  acceptGraphShareFrontier,
+  assertGraphSharePredecessor,
+  readAcceptedGraphShareFrontier,
+  readAuthenticatedGraphShareFrontier,
+  type GraphShareFrontierScope,
+} from './frontier_acceptance.js';
 
 export interface GraphShareJoinOptions {
   readonly cas?: string;
@@ -239,7 +244,36 @@ export const runGraphShareStatus = Effect.fn('codeGraph.sharing.status')(functio
   const casRoot = yield* resolveGraphShareCasRoot(config.agentContextHome, options.cas ?? trust?.client?.casRoot);
   const layout = graphSharingLayout(path, config.agentContextHome, casRoot);
   const pointerPath = graphSharingFrontierPointerPath(path, layout.frontiersRoot, identity.repositoryId);
-  const frontier = enrolled && (yield* fs.exists(pointerPath)) ? yield* readJsonFile(pointerPath) : undefined;
+  let frontier: unknown;
+  if (trust !== undefined && enrollmentValid) {
+    const profile = yield* readVerifiedCasBlob(casRoot, trust.profileDigest).pipe(
+      Effect.flatMap(bytes => decodeJson(bytes, parseGraphShareProfile, 'Organization graph profile is invalid.')),
+      Effect.option,
+    );
+    if (
+      Option.isSome(profile) &&
+      graphShareProfileDigest(profile.value) === trust.profileDigest &&
+      profile.value.repositoryId === identity.repositoryId &&
+      profile.value.trust.publisherKeys.includes(trust.publisherKeyFingerprint)
+    ) {
+      const accepted = yield* readAcceptedGraphShareFrontier(config.agentContextHome, {
+        branch: profile.value.source.branches[0] ?? 'refs/heads/main',
+        profileDigest: trust.profileDigest,
+        publisherKeyFingerprint: trust.publisherKeyFingerprint,
+        repositoryId: identity.repositoryId,
+      });
+      if (accepted !== undefined) {
+        frontier = {
+          envelopeDigest: accepted.envelopeDigest,
+          manifestDigest: accepted.manifestDigest,
+          schemaVersion: accepted.schemaVersion,
+        };
+      }
+    }
+  }
+  if (frontier === undefined && enrolled && (yield* fs.exists(pointerPath))) {
+    frontier = yield* readJsonFile(pointerPath);
+  }
   const lastImport = yield* readSharedGraphImportAttempt(config.agentContextHome, identity.checkoutId).pipe(
     Effect.orElseSucceed(() => undefined),
   );
@@ -357,39 +391,66 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
     return {imported: false as const, reason: 'trust-pin-mismatch' as const};
   }
   const coordinatorUrl = client.coordinatorUrl;
-  if (coordinatorUrl !== undefined) {
-    yield* refreshFrontierPointerFromCoordinator({
-      branch: profile.source.branches[0] ?? 'refs/heads/main',
-      casRoot: input.casRoot,
-      coordinatorUrl,
-      repositoryId: input.request.identity.repositoryId,
-      threadnoteHome: input.request.threadnoteHome,
-    }).pipe(Effect.catchIf(isUnavailableSharingFailure, () => Effect.void));
-  }
+  const scope: GraphShareFrontierScope = {
+    branch: profile.source.branches[0] ?? 'refs/heads/main',
+    profileDigest,
+    publisherKeyFingerprint: input.trust.publisherKeyFingerprint,
+    repositoryId: input.request.identity.repositoryId,
+  };
+  let accepted = yield* readAcceptedGraphShareFrontier(input.request.threadnoteHome, scope);
   const layout = graphSharingLayout(path, input.request.threadnoteHome, input.casRoot);
   const pointerPath = graphSharingFrontierPointerPath(path, layout.frontiersRoot, input.request.identity.repositoryId);
-  if (!(yield* fs.exists(pointerPath))) {
+  let legacyFailure: GraphSharingError | undefined;
+  if (yield* fs.exists(pointerPath)) {
+    const legacy = yield* Effect.gen(function* () {
+      const legacy = yield* decodeValue(
+        parseGraphShareFrontierPointer,
+        yield* readJsonFile(pointerPath),
+        'Frontier pointer is invalid.',
+      );
+      yield* readAuthenticatedGraphShareFrontier(input.casRoot, scope, legacy);
+      return legacy;
+    }).pipe(
+      Effect.catch(error => {
+        legacyFailure = Schema.is(GraphSharingError)(error)
+          ? error
+          : graphSharingFailure('Legacy frontier is unavailable.');
+        return Effect.void;
+      }),
+    );
+    if (legacy !== undefined) {
+      accepted = yield* acceptGraphShareFrontier({
+        casRoot: input.casRoot,
+        home: input.request.threadnoteHome,
+        legacy: true,
+        pointer: legacy,
+        scope,
+      });
+    }
+  }
+  if (coordinatorUrl !== undefined) {
+    yield* Effect.gen(function* () {
+      const candidate = yield* refreshFrontierPointerFromCoordinator({
+        branch: scope.branch,
+        casRoot: input.casRoot,
+        coordinatorUrl,
+        repositoryId: scope.repositoryId,
+      });
+      accepted = yield* acceptGraphShareFrontier({
+        casRoot: input.casRoot,
+        home: input.request.threadnoteHome,
+        pointer: candidate,
+        scope,
+      });
+    }).pipe(Effect.catchIf(isUnavailableSharingFailure, () => Effect.void));
+  }
+  if (accepted === undefined) {
+    if (legacyFailure !== undefined) return yield* legacyFailure;
     return yield* graphSharingUnavailable('Shared frontier pointer is missing.');
   }
-  const frontierPointer = yield* decodeValue(
-    parseGraphShareFrontierPointer,
-    yield* readJsonFile(pointerPath),
-    'Frontier pointer is invalid.',
-  );
-  const manifest = yield* decodeJson(
-    yield* ensureSharedCasBlob(input.casRoot, frontierPointer.manifestDigest, coordinatorUrl),
-    parseGraphShareFrontierManifest,
-    'Frontier manifest is invalid.',
-  );
-  const envelope = yield* decodeJson(
-    yield* ensureSharedCasBlob(input.casRoot, frontierPointer.envelopeDigest, coordinatorUrl),
-    parseGraphShareSignatureEnvelope,
-    'Frontier signature envelope is invalid.',
-  );
-  yield* verifyGraphShareFrontier(input.trust.publisherKeyFingerprint, manifest, envelope);
-  if (manifest.repositoryId !== input.request.identity.repositoryId || manifest.profileDigest !== profileDigest) {
-    return yield* graphSharingFailure('Frontier manifest does not match the enrolled repository profile.');
-  }
+  yield* ensureSharedCasBlob(input.casRoot, accepted.manifestDigest, coordinatorUrl);
+  yield* ensureSharedCasBlob(input.casRoot, accepted.envelopeDigest, coordinatorUrl);
+  const manifest = yield* readAuthenticatedGraphShareFrontier(input.casRoot, scope, accepted);
   const selected = yield* selectPublishedAncestorManifest(
     input.casRoot,
     input.request.identity,
@@ -719,11 +780,17 @@ export const selectPublishedAncestorManifest = Effect.fn('codeGraph.sharing.sele
     if (current.previousManifestDigest === null) {
       return yield* graphSharingUnavailable('No published ancestor frontier for this HEAD.');
     }
-    current = yield* decodeJson(
+    const predecessor = yield* decodeJson(
       yield* ensureSharedCasBlob(casRoot, current.previousManifestDigest, coordinatorUrl),
       parseGraphShareFrontierManifest,
       'Predecessor frontier manifest is invalid.',
     );
+    yield* decodeValue(
+      () => assertGraphSharePredecessor(current, predecessor),
+      undefined,
+      'Predecessor frontier lineage is invalid.',
+    );
+    current = predecessor;
   }
   return yield* graphSharingUnavailable('Published ancestor walk exceeded the generation limit.');
 });
@@ -733,9 +800,7 @@ const refreshFrontierPointerFromCoordinator = Effect.fn('codeGraph.sharing.refre
   readonly casRoot: string;
   readonly coordinatorUrl: string;
   readonly repositoryId: string;
-  readonly threadnoteHome: string;
 }) {
-  const path = yield* Path.Path;
   const tagName = graphShareFrontierDiscoveryTag(input.repositoryId, input.branch);
   const fromDescriptor = yield* refreshFrontierPointerFromOciTag({
     casRoot: input.casRoot,
@@ -748,12 +813,11 @@ const refreshFrontierPointerFromCoordinator = Effect.fn('codeGraph.sharing.refre
       : yield* graphShareControlGetFrontier(input.coordinatorUrl, tagName.slice('tn-frontier-'.length));
   yield* ensureSharedCasBlob(input.casRoot, frontier.manifestDigest, input.coordinatorUrl);
   yield* ensureSharedCasBlob(input.casRoot, frontier.envelopeDigest, input.coordinatorUrl);
-  const layout = graphSharingLayout(path, input.threadnoteHome, input.casRoot);
-  yield* writePrivateJsonFile(graphSharingFrontierPointerPath(path, layout.frontiersRoot, input.repositoryId), {
+  return {
     envelopeDigest: frontier.envelopeDigest,
     manifestDigest: frontier.manifestDigest,
-    schemaVersion: 1,
-  });
+    schemaVersion: 1 as const,
+  };
 });
 
 const refreshFrontierPointerFromOciTag = Effect.fn('codeGraph.sharing.refreshFrontierFromOciTag')(function* (input: {

--- a/src/code_graph/sharing/client.ts
+++ b/src/code_graph/sharing/client.ts
@@ -26,6 +26,8 @@ import {assertGraphShareCommitChain, graphShareBlobExists, graphShareCommitIsAnc
 import {graphShareControlGetFrontier, graphShareControlGetTag, mirrorCoordinatorCasBlob} from './control_client.js';
 import {graphShareFrontierPointerFromOciDescriptor, parseGraphShareOciDescriptor} from './descriptor.js';
 import {graphShareFrontierDiscoveryTag} from './namespace.js';
+import {discoverGraphShareRegistryFrontier, makeGraphShareRegistryReader} from './registry_reader.js';
+import {ensureSharedGraphBlob as ensureSharedCasBlob, type GraphShareBlobSource} from './shared_blob.js';
 import {
   GRAPH_SHARE_CONTRIBUTION_MODES,
   effectiveGraphShareContributionMode,
@@ -153,6 +155,7 @@ export const runGraphShareJoin = Effect.fn('codeGraph.sharing.join')(function* (
     enrollment.profile,
     'Enrollment profile pointer is invalid.',
   );
+  if (pointer.kind === 'oci') return yield* graphSharingUnavailable('Remote OCI profile enrollment is not supported.');
   if (options.coordinator !== undefined) {
     const coordinatorUrl = parseGraphShareCoordinatorUrl(options.coordinator);
     yield* mirrorCoordinatorCasBlob(casRoot, coordinatorUrl, pointer.digest);
@@ -371,6 +374,7 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
     input.enrollment.profile,
     'Enrollment profile pointer is invalid.',
   );
+  if (pointer.kind === 'oci') return yield* graphSharingUnavailable('Remote OCI profile enrollment is not supported.');
   const client = yield* resolveGraphShareRepositoryClient(input.request.threadnoteHome, input.trust);
   const coordinatorHint = client.coordinatorUrl;
   const profile = yield* decodeJson(
@@ -390,7 +394,11 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
   if (profileDigest !== input.trust.profileDigest) {
     return {imported: false as const, reason: 'trust-pin-mismatch' as const};
   }
-  const coordinatorUrl = client.coordinatorUrl;
+  const registry = profile.registry.canonical.startsWith('oci://')
+    ? yield* makeGraphShareRegistryReader(profile.registry.canonical)
+    : undefined;
+  const blobSource = registry?.readBlob;
+  const coordinatorUrl = registry === undefined ? client.coordinatorUrl : undefined;
   const scope: GraphShareFrontierScope = {
     branch: profile.source.branches[0] ?? 'refs/heads/main',
     profileDigest,
@@ -428,14 +436,20 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
       });
     }
   }
-  if (coordinatorUrl !== undefined) {
+  if (registry !== undefined || coordinatorUrl !== undefined) {
     yield* Effect.gen(function* () {
-      const candidate = yield* refreshFrontierPointerFromCoordinator({
-        branch: scope.branch,
-        casRoot: input.casRoot,
-        coordinatorUrl,
-        repositoryId: scope.repositoryId,
-      });
+      const candidate = yield* registry !== undefined
+        ? discoverGraphShareRegistryFrontier(
+            input.casRoot,
+            registry,
+            graphShareFrontierDiscoveryTag(scope.repositoryId, scope.branch),
+          )
+        : refreshFrontierPointerFromCoordinator({
+            branch: scope.branch,
+            casRoot: input.casRoot,
+            coordinatorUrl: coordinatorUrl!,
+            repositoryId: scope.repositoryId,
+          });
       accepted = yield* acceptGraphShareFrontier({
         casRoot: input.casRoot,
         home: input.request.threadnoteHome,
@@ -448,14 +462,15 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
     if (legacyFailure !== undefined) return yield* legacyFailure;
     return yield* graphSharingUnavailable('Shared frontier pointer is missing.');
   }
-  yield* ensureSharedCasBlob(input.casRoot, accepted.manifestDigest, coordinatorUrl);
-  yield* ensureSharedCasBlob(input.casRoot, accepted.envelopeDigest, coordinatorUrl);
+  yield* ensureSharedCasBlob(input.casRoot, accepted.manifestDigest, coordinatorUrl, blobSource);
+  yield* ensureSharedCasBlob(input.casRoot, accepted.envelopeDigest, coordinatorUrl, blobSource);
   const manifest = yield* readAuthenticatedGraphShareFrontier(input.casRoot, scope, accepted);
   const selected = yield* selectPublishedAncestorManifest(
     input.casRoot,
     input.request.identity,
     manifest,
     coordinatorUrl,
+    blobSource,
   );
   yield* assertGraphShareCommitChain(input.request.identity.repoRoot, [
     selected.checkpoint.sourceCommit,
@@ -493,6 +508,7 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
       artifactDigest: selected.checkpoint.manifestDigest,
       casRoot: input.casRoot,
       ...(coordinatorUrl === undefined ? {} : {coordinatorUrl}),
+      ...(blobSource === undefined ? {} : {blobSource}),
       ...(selected.checkpoint.metadataDigest === undefined ? {} : {metadataDigest: selected.checkpoint.metadataDigest}),
     });
     yield* sharingProgress(input.request.onProgress, 'applying-deltas');
@@ -524,6 +540,7 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
     artifactDigest: selected.checkpoint.manifestDigest,
     casRoot: input.casRoot,
     ...(coordinatorUrl === undefined ? {} : {coordinatorUrl}),
+    ...(blobSource === undefined ? {} : {blobSource}),
     ...(selected.checkpoint.metadataDigest === undefined ? {} : {metadataDigest: selected.checkpoint.metadataDigest}),
   });
   const deltaPaths = [];
@@ -533,6 +550,7 @@ const importVerifiedSharedCheckpoint = Effect.fn('codeGraph.sharing.importVerifi
         artifactDigest: delta.manifestDigest,
         casRoot: input.casRoot,
         ...(coordinatorUrl === undefined ? {} : {coordinatorUrl}),
+        ...(blobSource === undefined ? {} : {blobSource}),
         ...(delta.metadataDigest === undefined ? {} : {metadataDigest: delta.metadataDigest}),
       }),
     );
@@ -771,6 +789,7 @@ export const selectPublishedAncestorManifest = Effect.fn('codeGraph.sharing.sele
   identity: RepositoryIdentity,
   latest: GraphShareFrontierManifestV1,
   coordinatorUrl?: string,
+  blobSource?: GraphShareBlobSource,
 ) {
   let current = latest;
   for (let step = 0; step < GRAPH_SHARE_ANCESTOR_WALK_LIMIT; step += 1) {
@@ -781,7 +800,7 @@ export const selectPublishedAncestorManifest = Effect.fn('codeGraph.sharing.sele
       return yield* graphSharingUnavailable('No published ancestor frontier for this HEAD.');
     }
     const predecessor = yield* decodeJson(
-      yield* ensureSharedCasBlob(casRoot, current.previousManifestDigest, coordinatorUrl),
+      yield* ensureSharedCasBlob(casRoot, current.previousManifestDigest, coordinatorUrl, blobSource),
       parseGraphShareFrontierManifest,
       'Predecessor frontier manifest is invalid.',
     );
@@ -834,22 +853,6 @@ const refreshFrontierPointerFromOciTag = Effect.fn('codeGraph.sharing.refreshFro
   const pointer = graphShareFrontierPointerFromOciDescriptor(descriptor);
   yield* ensureSharedCasBlob(input.casRoot, pointer.metadataDigest, input.coordinatorUrl);
   return pointer;
-});
-
-const ensureSharedCasBlob = Effect.fn('codeGraph.sharing.ensureSharedCasBlob')(function* (
-  casRoot: string,
-  digest: string,
-  coordinatorUrl: string | undefined,
-) {
-  return yield* readVerifiedCasBlob(casRoot, digest).pipe(
-    Effect.catchIf(isUnavailableSharingFailure, () =>
-      coordinatorUrl === undefined
-        ? graphSharingUnavailable(`CAS object is missing: ${digest}`)
-        : mirrorCoordinatorCasBlob(casRoot, coordinatorUrl, digest).pipe(
-            Effect.andThen(readVerifiedCasBlob(casRoot, digest)),
-          ),
-    ),
-  );
 });
 
 function decodeValue<A, I>(parse: (value: I) => A, value: I, message: string) {

--- a/src/code_graph/sharing/frontier_acceptance.ts
+++ b/src/code_graph/sharing/frontier_acceptance.ts
@@ -1,0 +1,187 @@
+import {Effect, FileSystem, Path, Schema} from 'effect';
+import {withExclusiveFileLock} from '../../effect/file_lock.js';
+import {
+  parseGraphShareFrontierManifest,
+  parseGraphShareSignatureEnvelope,
+  verifyGraphShareFrontier,
+  type GraphShareFrontierManifestV1,
+  type GraphShareFrontierPointerV1,
+} from './artifacts.js';
+import {decodeJsonBytes, readBoundedPrivateBytes, writePrivateJsonFile} from './atomic.js';
+import {casBlobPath} from './cas.js';
+import {sha256Digest, sha256HexFromDigest, SHA256_DIGEST, type Sha256Digest} from './digest.js';
+import {graphSharingFailure, graphSharingUnavailable} from './errors.js';
+import {graphSharingLayout} from './layout.js';
+import {lookupGraphShareTrustReceipt} from './trust.js';
+
+const Digest = Schema.String.check(Schema.isPattern(SHA256_DIGEST));
+const Generation = Schema.Int.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(1_000_000));
+const AcceptedFrontier = Schema.Struct({
+  authority: Digest,
+  envelopeDigest: Digest,
+  generation: Generation,
+  manifestDigest: Digest,
+  publisherFence: Generation,
+  schemaVersion: Schema.Literal(1),
+});
+export type GraphShareAcceptedFrontier = Omit<typeof AcceptedFrontier.Type, 'envelopeDigest' | 'manifestDigest'> &
+  GraphShareFrontierPointerV1;
+
+export interface GraphShareFrontierScope {
+  readonly branch: string;
+  readonly profileDigest: Sha256Digest;
+  readonly publisherKeyFingerprint: Sha256Digest;
+  readonly repositoryId: string;
+}
+
+function authorityDigest(scope: GraphShareFrontierScope): Sha256Digest {
+  return sha256Digest(
+    JSON.stringify([scope.repositoryId, scope.profileDigest, scope.branch, scope.publisherKeyFingerprint]),
+  );
+}
+
+export const graphShareAcceptedFrontierPath = Effect.fn('codeGraph.sharing.acceptedFrontierPath')(function* (
+  home: string,
+  scope: GraphShareFrontierScope,
+) {
+  const path = yield* Path.Path;
+  return path.join(
+    graphSharingLayout(path, home).root,
+    'accepted-frontiers',
+    `${sha256HexFromDigest(authorityDigest(scope))}.json`,
+  );
+});
+
+export const readAcceptedGraphShareFrontier = Effect.fn('codeGraph.sharing.readAcceptedFrontier')(function* (
+  home: string,
+  scope: GraphShareFrontierScope,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const target = yield* graphShareAcceptedFrontierPath(home, scope);
+  if (!(yield* fs.exists(target))) return undefined;
+  const bytes = yield* readBoundedPrivateBytes(target, 4096);
+  const text = yield* Effect.try({
+    try: () => new TextDecoder('utf-8', {fatal: true}).decode(bytes),
+    catch: () => graphSharingFailure('Accepted frontier state is invalid.'),
+  });
+  const state = yield* Schema.decodeEffect(Schema.fromJsonString(AcceptedFrontier), {onExcessProperty: 'error'})(
+    text,
+  ).pipe(Effect.mapError(() => graphSharingFailure('Accepted frontier state is invalid.')));
+  if (state.authority !== authorityDigest(scope))
+    return yield* graphSharingFailure('Accepted frontier authority is invalid.');
+  return state as GraphShareAcceptedFrontier;
+});
+
+export const readAuthenticatedGraphShareFrontier = Effect.fn('codeGraph.sharing.readAuthenticatedFrontier')(function* (
+  casRoot: string,
+  scope: GraphShareFrontierScope,
+  pointer: GraphShareFrontierPointerV1,
+) {
+  const body = yield* readFrontierJson(casRoot, pointer.manifestDigest);
+  const envelopeBody = yield* readFrontierJson(casRoot, pointer.envelopeDigest);
+  const manifest = yield* Effect.try({
+    try: () => parseGraphShareFrontierManifest(body),
+    catch: () => graphSharingFailure('Frontier manifest is invalid.'),
+  });
+  const envelope = yield* Effect.try({
+    try: () => parseGraphShareSignatureEnvelope(envelopeBody),
+    catch: () => graphSharingFailure('Frontier signature envelope is invalid.'),
+  });
+  const signedDigest = yield* verifyGraphShareFrontier(scope.publisherKeyFingerprint, manifest, envelope);
+  if (
+    signedDigest !== pointer.manifestDigest ||
+    manifest.repositoryId !== scope.repositoryId ||
+    manifest.profileDigest !== scope.profileDigest ||
+    manifest.branch !== scope.branch
+  )
+    return yield* graphSharingFailure('Frontier does not match the enrolled repository, profile and branch.');
+  return manifest;
+});
+
+export const acceptGraphShareFrontier = Effect.fn('codeGraph.sharing.acceptFrontier')(function* (input: {
+  readonly casRoot: string;
+  readonly home: string;
+  readonly pointer: GraphShareFrontierPointerV1;
+  readonly scope: GraphShareFrontierScope;
+  /** A legacy local pointer may lag a newer accepted remote discovery. */
+  readonly legacy?: boolean;
+}) {
+  const manifest = yield* readAuthenticatedGraphShareFrontier(input.casRoot, input.scope, input.pointer);
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const target = yield* graphShareAcceptedFrontierPath(input.home, input.scope);
+  yield* fs.makeDirectory(path.dirname(target), {recursive: true, mode: 0o700});
+  return yield* withExclusiveFileLock(
+    fs,
+    `${target}.lock`,
+    {
+      retryIntervalMilliseconds: 25,
+      staleAfterMilliseconds: 30_000,
+      waitTimeoutMilliseconds: 2_000,
+    },
+    Effect.gen(function* () {
+      const previous = yield* readAcceptedGraphShareFrontier(input.home, input.scope);
+      const trust = yield* lookupGraphShareTrustReceipt(input.home, input.scope.repositoryId);
+      if (
+        trust?.profileDigest !== input.scope.profileDigest ||
+        trust.publisherKeyFingerprint !== input.scope.publisherKeyFingerprint
+      ) {
+        return yield* graphSharingFailure('Frontier trust changed before acceptance.');
+      }
+      if (previous !== undefined && input.legacy === true && manifest.generation < previous.generation) return previous;
+      const candidate: GraphShareAcceptedFrontier = {
+        authority: authorityDigest(input.scope),
+        envelopeDigest: input.pointer.envelopeDigest,
+        generation: manifest.generation,
+        manifestDigest: input.pointer.manifestDigest,
+        publisherFence: manifest.publisherFence,
+        schemaVersion: 1,
+      };
+      if (previous !== undefined) {
+        if (candidate.generation < previous.generation || candidate.publisherFence < previous.publisherFence) {
+          return yield* graphSharingFailure(
+            'Frontier discovery attempted to roll back an authenticated generation or fence.',
+          );
+        }
+        if (candidate.generation === previous.generation) {
+          if (
+            candidate.manifestDigest !== previous.manifestDigest ||
+            candidate.publisherFence !== previous.publisherFence
+          ) {
+            return yield* graphSharingFailure('Frontier discovery conflicts with an authenticated generation.');
+          }
+          return previous;
+        }
+      }
+      yield* writePrivateJsonFile(target, candidate);
+      return candidate;
+    }),
+  );
+});
+
+export function assertGraphSharePredecessor(
+  current: GraphShareFrontierManifestV1,
+  predecessor: GraphShareFrontierManifestV1,
+): void {
+  if (
+    predecessor.repositoryId !== current.repositoryId ||
+    predecessor.profileDigest !== current.profileDigest ||
+    predecessor.branch !== current.branch ||
+    predecessor.generation >= current.generation ||
+    predecessor.publisherFence > current.publisherFence
+  )
+    throw graphSharingFailure('Predecessor frontier does not belong to the authenticated lineage.');
+}
+
+const readFrontierJson = Effect.fn('codeGraph.sharing.readFrontierJson')(function* (
+  casRoot: string,
+  digest: Sha256Digest,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const target = yield* casBlobPath(casRoot, digest);
+  if (!(yield* fs.exists(target)))
+    return yield* graphSharingUnavailable('Authenticated frontier metadata is unavailable.');
+  const bytes = yield* readBoundedPrivateBytes(target, 65_536);
+  if (sha256Digest(bytes) !== digest) return yield* graphSharingFailure('Frontier metadata digest is invalid.');
+  return yield* decodeJsonBytes(bytes);
+});

--- a/src/code_graph/sharing/profile.ts
+++ b/src/code_graph/sharing/profile.ts
@@ -2,6 +2,7 @@ import {Schema} from 'effect';
 import {canonicalJson} from '../checkpoint/canonical_json.js';
 import {graphSharingFailure} from './errors.js';
 import {SHA256_DIGEST, SHA256_HEX, sha256Digest, type Sha256Digest} from './digest.js';
+import {isGraphShareRegistryReference} from './registry_reference.js';
 
 const STRICT = {errors: 'all', onExcessProperty: 'error'} as const;
 const ORGANIZATION = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
@@ -9,7 +10,6 @@ const GIT_REF = /^refs\/heads\/[A-Za-z0-9._/-]{1,255}$/u;
 const COORDINATOR_URL =
   /^(?:https:\/\/[a-z0-9.-]+|http:\/\/(?:127\.0\.0\.1|localhost))(?::\d{1,5})?(?:\/[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=-]*)?$/u;
 const CAS_REGISTRY = /^cas:\/\/local(?:\/(?:canonical|worker))?$/u;
-const OCI_REGISTRY = /^oci:\/\/[a-z0-9.-]+(?:\/[A-Za-z0-9._-]+)+$/u;
 const CAS_PROFILE = /^cas:\/\/sha256:[0-9a-f]{64}$/u;
 const OCI_PROFILE = /^oci:\/\/[a-z0-9.-]+(?:\/[A-Za-z0-9._-]+)+@sha256:[0-9a-f]{64}$/u;
 const CANONICAL_REMOTE = /^[a-z0-9.-]+\/[A-Za-z0-9._/-]+$/u;
@@ -31,7 +31,7 @@ export const GraphShareEnrollmentSchemaV1 = Schema.Struct({
 export type GraphShareEnrollmentV1 = typeof GraphShareEnrollmentSchemaV1.Type;
 
 const RegistryReference = Schema.String.check(
-  Schema.isPattern(new RegExp(`${CAS_REGISTRY.source}|${OCI_REGISTRY.source}`, 'u')),
+  Schema.makeFilter(value => CAS_REGISTRY.test(value) || isGraphShareRegistryReference(value)),
 );
 
 export const GraphShareProfileSchemaV1 = Schema.Struct({

--- a/src/code_graph/sharing/registry_auth.ts
+++ b/src/code_graph/sharing/registry_auth.ts
@@ -1,0 +1,57 @@
+import {graphSharingFailure} from './errors.js';
+import type {GraphShareRegistryTarget} from './registry_reference.js';
+
+export type GraphShareRegistryChallenge =
+  {readonly kind: 'basic'} | {readonly kind: 'bearer'; readonly realm: string; readonly service?: string};
+
+export function parseGraphShareRegistryChallenge(
+  value: string | undefined,
+  target: GraphShareRegistryTarget,
+): GraphShareRegistryChallenge {
+  if (
+    value === undefined ||
+    value.length > 4096 ||
+    [...value].some(character => character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127)
+  )
+    throw graphSharingFailure('Registry authentication is unsupported.');
+  const head = /^(Basic|Bearer) +(.+)$/iu.exec(value);
+  if (head === null) throw graphSharingFailure('Registry authentication is unsupported.');
+  const fields = new Map<string, string>();
+  let remaining = head[2];
+  while (remaining.length > 0) {
+    const field = /^([a-z_]+)="([^"\\]*)"(?:, *|$)/iu.exec(remaining);
+    if (field === null || fields.has(field[1].toLowerCase())) {
+      throw graphSharingFailure('Registry authentication challenge is invalid.');
+    }
+    fields.set(field[1].toLowerCase(), field[2]);
+    remaining = remaining.slice(field[0].length);
+  }
+  if (head[1].toLowerCase() === 'basic') return {kind: 'basic'};
+  const realm = fields.get('realm');
+  if (realm === undefined) throw graphSharingFailure('Registry token realm is missing.');
+  let url: URL;
+  try {
+    url = new URL(realm);
+  } catch {
+    throw graphSharingFailure('Registry token realm is invalid.');
+  }
+  if (
+    url.origin !== target.origin ||
+    url.username !== '' ||
+    url.password !== '' ||
+    url.search !== '' ||
+    url.hash !== '' ||
+    !/^\/[A-Za-z0-9/_-]*$/u.test(url.pathname) ||
+    realm !== `${url.origin}${url.pathname}`
+  )
+    throw graphSharingFailure('Registry token realm is outside the trusted origin.');
+  const service = fields.get('service');
+  if (service !== undefined && !/^[A-Za-z0-9._:-]{1,256}$/u.test(service)) {
+    throw graphSharingFailure('Registry token service is invalid.');
+  }
+  const scope = fields.get('scope');
+  if (scope !== undefined && scope !== target.pullScope) {
+    throw graphSharingFailure('Registry authentication requested a different scope.');
+  }
+  return {kind: 'bearer', realm, ...(service === undefined ? {} : {service})};
+}

--- a/src/code_graph/sharing/registry_credentials.ts
+++ b/src/code_graph/sharing/registry_credentials.ts
@@ -1,0 +1,83 @@
+import {Effect, FileSystem, Path, Redacted, Schema} from 'effect';
+import {CommandExecutor} from '../../effect/command.js';
+import {SystemInfo} from '../../effect/system.js';
+import {readBoundedPrivateBytes} from './atomic.js';
+import {graphSharingFailure} from './errors.js';
+import type {GraphShareRegistryTarget} from './registry_reference.js';
+
+const HelperName = Schema.String.check(Schema.isPattern(/^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$/u));
+const DockerConfig = Schema.Struct({
+  credHelpers: Schema.optionalKey(Schema.Record(Schema.String, HelperName)),
+  credsStore: Schema.optionalKey(HelperName),
+});
+const HelperResponse = Schema.Struct({
+  Secret: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(8192)),
+  ServerURL: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(512))),
+  Username: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(256)),
+});
+
+export interface GraphShareRegistryCredential {
+  readonly username: Redacted.Redacted<string>;
+  readonly authorization: Redacted.Redacted<string>;
+}
+
+/** Called only after the registry target is covered by the caller's profile trust. */
+export const makeGraphShareRegistryCredentialLoader = Effect.fn('codeGraph.sharing.registryCredentialLoader')(
+  function* (target: GraphShareRegistryTarget) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const system = yield* SystemInfo;
+    const command = yield* CommandExecutor;
+    const directory = system.environment().DOCKER_CONFIG ?? path.join(system.homeDirectory, '.docker');
+    if (!path.isAbsolute(directory)) return yield* graphSharingFailure('Docker credential config must be absolute.');
+    const configPath = path.join(directory, 'config.json');
+    let helper: string | undefined;
+    if (yield* fs.exists(configPath)) {
+      const bytes = yield* readBoundedPrivateBytes(configPath, 65_536).pipe(
+        Effect.mapError(() => graphSharingFailure('Docker credential config is unavailable.')),
+      );
+      const config = yield* Schema.decodeEffect(Schema.fromJsonString(DockerConfig))(
+        new TextDecoder().decode(bytes),
+      ).pipe(Effect.mapError(() => graphSharingFailure('Docker credential config is invalid.')));
+      helper = config.credHelpers?.[target.registry] ?? config.credsStore;
+    }
+    const selected = helper;
+    let username: Redacted.Redacted<string> | undefined;
+    return () =>
+      Effect.gen(function* () {
+        if (selected === undefined) return undefined;
+        const result = yield* command
+          .execute(`docker-credential-${selected}`, ['get'], {
+            allowFailure: true,
+            input: new TextEncoder().encode(`${target.registry}\n`),
+            maxOutputBytes: 16_384,
+            timeoutMs: 5_000,
+          })
+          .pipe(Effect.mapError(() => graphSharingFailure('Registry credential helper is unavailable.')));
+        if (result.exitCode !== 0) return yield* graphSharingFailure('Registry credential helper denied access.');
+        const credential = yield* Schema.decodeEffect(Schema.fromJsonString(HelperResponse))(result.stdout).pipe(
+          Effect.mapError(() => graphSharingFailure('Registry credential helper response is invalid.')),
+        );
+        if (
+          credential.Username === '<token>' ||
+          [...credential.Username].some(
+            character => character === ':' || character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127,
+          ) ||
+          (credential.ServerURL !== undefined &&
+            credential.ServerURL !== target.registry &&
+            credential.ServerURL !== target.origin)
+        )
+          return yield* graphSharingFailure('Registry credential helper identity is unsupported.');
+        if (username !== undefined && Redacted.value(username) !== credential.Username) {
+          return yield* graphSharingFailure('Registry credential helper changed the selected identity.');
+        }
+        username = Redacted.make(credential.Username);
+        return {
+          username,
+          authorization: Redacted.make(
+            `Basic ${Buffer.from(`${credential.Username}:${credential.Secret}`).toString('base64')}`,
+          ),
+        } satisfies GraphShareRegistryCredential;
+      });
+  },
+);

--- a/src/code_graph/sharing/registry_http.ts
+++ b/src/code_graph/sharing/registry_http.ts
@@ -84,7 +84,11 @@ export const makeGraphShareRegistryHttp = Effect.fn('codeGraph.sharing.registryH
     url.searchParams.set('scope', target.pullScope);
     if (challenge.service !== undefined) url.searchParams.set('service', challenge.service);
     const response = yield* request(url.href, 32_768, 'application/json', credential?.authorization);
-    if (response.status !== 200) return yield* graphSharingHttpFailure(response.status);
+    if (response.status !== 200)
+      return yield* graphSharingHttpFailure(
+        response.status,
+        graphShareRetryAfterMilliseconds(response.headers['retry-after'], yield* Clock.currentTimeMillis),
+      );
     const token = yield* Schema.decodeEffect(Schema.fromJsonString(TokenResponse))(
       new TextDecoder().decode(response.bytes),
     ).pipe(Effect.mapError(() => graphSharingFailure('Registry token response is invalid.')));

--- a/src/code_graph/sharing/registry_http.ts
+++ b/src/code_graph/sharing/registry_http.ts
@@ -1,0 +1,134 @@
+import {Clock, Effect, Redacted, Schema, Stream} from 'effect';
+import * as FetchHttpClient from 'effect/unstable/http/FetchHttpClient';
+import * as HttpClient from 'effect/unstable/http/HttpClient';
+import * as HttpClientRequest from 'effect/unstable/http/HttpClientRequest';
+import {
+  GraphSharingError,
+  graphSharingFailure,
+  graphSharingHttpFailure,
+  graphSharingUnavailable,
+  graphShareRetryAfterMilliseconds,
+} from './errors.js';
+import {parseGraphShareRegistryChallenge, type GraphShareRegistryChallenge} from './registry_auth.js';
+import {makeGraphShareRegistryCredentialLoader} from './registry_credentials.js';
+import type {GraphShareRegistryTarget} from './registry_reference.js';
+
+const TokenText = Schema.String.check(
+  Schema.isMinLength(1),
+  Schema.isMaxLength(16_384),
+  Schema.isPattern(/^[\x21-\x7e]+$/u),
+);
+const TokenResponse = Schema.Struct({
+  access_token: Schema.optionalKey(TokenText),
+  expires_in: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
+  token: Schema.optionalKey(TokenText),
+});
+
+/** One reader owns one trusted origin, repository and selected credential provider. */
+export const makeGraphShareRegistryHttp = Effect.fn('codeGraph.sharing.registryHttp')(function* (
+  target: GraphShareRegistryTarget,
+) {
+  const client = HttpClient.withScope(yield* HttpClient.HttpClient);
+  const fetch = yield* FetchHttpClient.Fetch;
+  const credentials = yield* makeGraphShareRegistryCredentialLoader(target);
+  const request = (url: string, maximum: number, accept: string, authorization?: Redacted.Redacted<string>) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let request = HttpClientRequest.get(url).pipe(HttpClientRequest.setHeader('accept', accept));
+        if (authorization !== undefined)
+          request = HttpClientRequest.setHeader(request, 'authorization', Redacted.value(authorization));
+        const response = yield* client
+          .execute(request)
+          .pipe(
+            Effect.provideService(FetchHttpClient.RequestInit, {redirect: 'manual', credentials: 'omit'}),
+            Effect.provideService(FetchHttpClient.Fetch, fetch),
+          );
+        const chunks: Uint8Array[] = [];
+        let size = 0;
+        if (response.status === 200) {
+          const length = response.headers['content-length'];
+          if (length !== undefined && (!/^\d+$/u.test(length) || Number(length) > maximum)) {
+            return yield* graphSharingFailure('Registry response exceeds its size limit.');
+          }
+          yield* Stream.runForEach(response.stream, chunk =>
+            Effect.gen(function* () {
+              size += chunk.byteLength;
+              if (size > maximum) return yield* graphSharingFailure('Registry response exceeds its size limit.');
+              chunks.push(chunk);
+            }),
+          );
+        }
+        return {bytes: Buffer.concat(chunks, size), headers: response.headers, status: response.status};
+      }),
+    ).pipe(
+      Effect.timeout(60_000),
+      Effect.mapError(error =>
+        Schema.is(GraphSharingError)(error) ? error : graphSharingUnavailable('Registry request failed.'),
+      ),
+    );
+
+  let challenge: GraphShareRegistryChallenge | undefined;
+  let authorization: Redacted.Redacted<string> | undefined;
+  let expiresAt = 0;
+  const authorize = Effect.gen(function* () {
+    if (challenge === undefined) return;
+    const credential = yield* credentials();
+    if (challenge.kind === 'basic') {
+      if (credential === undefined)
+        return yield* graphSharingFailure('Registry requires a configured credential helper.');
+      authorization = credential.authorization;
+      expiresAt = (yield* Clock.currentTimeMillis) + 300_000;
+      return;
+    }
+    const url = new URL(challenge.realm);
+    url.searchParams.set('scope', target.pullScope);
+    if (challenge.service !== undefined) url.searchParams.set('service', challenge.service);
+    const response = yield* request(url.href, 32_768, 'application/json', credential?.authorization);
+    if (response.status !== 200) return yield* graphSharingHttpFailure(response.status);
+    const token = yield* Schema.decodeEffect(Schema.fromJsonString(TokenResponse))(
+      new TextDecoder().decode(response.bytes),
+    ).pipe(Effect.mapError(() => graphSharingFailure('Registry token response is invalid.')));
+    const value = token.token ?? token.access_token;
+    if (
+      value === undefined ||
+      (token.token !== undefined && token.access_token !== undefined && token.token !== token.access_token)
+    ) {
+      return yield* graphSharingFailure('Registry token response is invalid.');
+    }
+    authorization = Redacted.make(`Bearer ${value}`);
+    expiresAt = (yield* Clock.currentTimeMillis) + Math.min(token.expires_in ?? 60, 300) * 1000;
+  });
+
+  return (pathname: string, maximum: number, accept: string) =>
+    Effect.gen(function* () {
+      const prefix = `/v2/${target.repository}/`;
+      if (
+        !pathname.startsWith(prefix) ||
+        !/^(?:manifests|blobs)\/[A-Za-z0-9_.:-]+$/u.test(pathname.slice(prefix.length))
+      ) {
+        return yield* graphSharingFailure('Registry read path is outside the trusted repository.');
+      }
+      if (challenge !== undefined && expiresAt <= (yield* Clock.currentTimeMillis)) yield* authorize;
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const response = yield* request(target.origin + pathname, maximum, accept, authorization);
+        if (response.status === 200) return response;
+        if (response.status !== 401 || attempt === 2) {
+          if (response.status === 404) return yield* graphSharingUnavailable('Registry artifact is missing.');
+          return yield* graphSharingHttpFailure(
+            response.status,
+            graphShareRetryAfterMilliseconds(response.headers['retry-after'], yield* Clock.currentTimeMillis),
+          );
+        }
+        const next = yield* Effect.try({
+          try: () => parseGraphShareRegistryChallenge(response.headers['www-authenticate'], target),
+          catch: () => graphSharingFailure('Registry authentication challenge is not trusted.'),
+        });
+        if (challenge !== undefined && JSON.stringify(next) !== JSON.stringify(challenge)) {
+          return yield* graphSharingFailure('Registry authentication authority changed.');
+        }
+        challenge = next;
+        yield* authorize;
+      }
+      return yield* graphSharingFailure('Registry authentication retry limit reached.');
+    });
+});

--- a/src/code_graph/sharing/registry_reader.ts
+++ b/src/code_graph/sharing/registry_reader.ts
@@ -1,0 +1,120 @@
+import {Effect} from 'effect';
+import {GRAPH_SHARE_OCI_IMAGE_MANIFEST_MEDIA_TYPE, parseGraphShareFrontierManifest} from './artifacts.js';
+import {decodeJsonBytes} from './atomic.js';
+import {putCasBytes} from './cas.js';
+import {parseGraphShareCheckpointMetadata} from './checkpoint_cas.js';
+import {graphShareFrontierPointerFromOciDescriptor, parseGraphShareOciDescriptor} from './descriptor.js';
+import {parseSha256Digest, sha256Digest} from './digest.js';
+import {graphSharingFailure} from './errors.js';
+import {
+  GRAPH_SHARE_HTTP_CAS_MAX_BYTES,
+  assertGraphShareDiscoveryTag,
+  graphSharePayloadLooksLikeGitObject,
+} from './oci.js';
+import {makeGraphShareRegistryHttp} from './registry_http.js';
+import {parseGraphShareRegistryTarget} from './registry_reference.js';
+
+export const makeGraphShareRegistryReader = Effect.fn('codeGraph.sharing.registryReader')(function* (
+  reference: string,
+) {
+  const target = yield* Effect.try({
+    try: () => parseGraphShareRegistryTarget(reference),
+    catch: () => graphSharingFailure('OCI registry reference is invalid.'),
+  });
+  const request = yield* makeGraphShareRegistryHttp(target);
+  return {
+    readBlob: (digest: string, expectedSize?: number) =>
+      Effect.gen(function* () {
+        const expected = yield* Effect.try({
+          try: () => parseSha256Digest(digest),
+          catch: () => graphSharingFailure('Registry blob digest is invalid.'),
+        });
+        if (
+          expectedSize !== undefined &&
+          (!Number.isSafeInteger(expectedSize) || expectedSize < 0 || expectedSize > GRAPH_SHARE_HTTP_CAS_MAX_BYTES)
+        ) {
+          return yield* graphSharingFailure('Registry blob size is invalid.');
+        }
+        const response = yield* request(
+          `/v2/${target.repository}/blobs/${expected}`,
+          expectedSize ?? GRAPH_SHARE_HTTP_CAS_MAX_BYTES,
+          'application/octet-stream',
+        );
+        if (
+          sha256Digest(response.bytes) !== expected ||
+          (expectedSize !== undefined && response.bytes.byteLength !== expectedSize) ||
+          (response.headers['docker-content-digest'] !== undefined &&
+            response.headers['docker-content-digest'] !== expected) ||
+          graphSharePayloadLooksLikeGitObject(response.bytes)
+        ) {
+          return yield* graphSharingFailure('Registry blob verification failed.');
+        }
+        return response.bytes;
+      }),
+    readManifest: (tag: string) =>
+      Effect.gen(function* () {
+        yield* Effect.try({
+          try: () => assertGraphShareDiscoveryTag(tag),
+          catch: () => graphSharingFailure('Registry discovery tag is invalid.'),
+        });
+        const response = yield* request(
+          `/v2/${target.repository}/manifests/${tag}`,
+          1_048_576,
+          GRAPH_SHARE_OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+        );
+        const digest = sha256Digest(response.bytes);
+        if (
+          response.headers['content-type']?.split(';')[0]?.trim() !== GRAPH_SHARE_OCI_IMAGE_MANIFEST_MEDIA_TYPE ||
+          (response.headers['docker-content-digest'] !== undefined &&
+            response.headers['docker-content-digest'] !== digest)
+        ) {
+          return yield* graphSharingFailure('Registry manifest verification failed.');
+        }
+        const json = yield* decodeJsonBytes(response.bytes).pipe(
+          Effect.mapError(() => graphSharingFailure('Registry manifest is invalid.')),
+        );
+        const descriptor = yield* Effect.try({
+          try: () => parseGraphShareOciDescriptor(json),
+          catch: () => graphSharingFailure('Registry manifest is unsupported.'),
+        });
+        return {bytes: response.bytes, descriptor, digest};
+      }),
+  };
+});
+
+export type GraphShareRegistryReader = Effect.Success<ReturnType<typeof makeGraphShareRegistryReader>>;
+
+export const discoverGraphShareRegistryFrontier = Effect.fn('codeGraph.sharing.discoverRegistryFrontier')(function* (
+  casRoot: string,
+  reader: GraphShareRegistryReader,
+  tag: string,
+) {
+  const manifest = yield* reader.readManifest(tag);
+  const blobs: Uint8Array[] = [];
+  for (const entry of [manifest.descriptor.config, ...manifest.descriptor.layers]) {
+    const bytes = yield* reader.readBlob(entry.digest, entry.size);
+    if (bytes.byteLength !== entry.size)
+      return yield* graphSharingFailure('Registry layer size does not match its descriptor.');
+    yield* putCasBytes(casRoot, bytes);
+    blobs.push(bytes);
+  }
+  const pointer = graphShareFrontierPointerFromOciDescriptor(manifest.descriptor);
+  const frontierJson = yield* decodeJsonBytes(blobs[1]);
+  const metadataJson = yield* decodeJsonBytes(blobs[3]);
+  const frontier = yield* Effect.try({
+    try: () => parseGraphShareFrontierManifest(frontierJson),
+    catch: () => graphSharingFailure('Registry frontier is invalid.'),
+  });
+  const metadata = yield* Effect.try({
+    try: () => parseGraphShareCheckpointMetadata(metadataJson),
+    catch: () => graphSharingFailure('Registry checkpoint metadata is invalid.'),
+  });
+  if (
+    metadata.artifactDigest !== frontier.checkpoint.manifestDigest ||
+    (frontier.checkpoint.metadataDigest !== undefined && frontier.checkpoint.metadataDigest !== pointer.metadataDigest)
+  ) {
+    return yield* graphSharingFailure('Registry checkpoint metadata is not covered by the frontier.');
+  }
+  yield* putCasBytes(casRoot, manifest.bytes);
+  return {...pointer, schemaVersion: 1 as const};
+});

--- a/src/code_graph/sharing/registry_reference.ts
+++ b/src/code_graph/sharing/registry_reference.ts
@@ -1,0 +1,46 @@
+import {graphSharingFailure} from './errors.js';
+
+const HOST_LABEL = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?';
+const COMPONENT = '[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*';
+export const GRAPH_SHARE_OCI_REGISTRY = new RegExp(
+  `^oci://(${HOST_LABEL}(?:\\.${HOST_LABEL})*)(?::([1-9][0-9]{0,4}))?/(${COMPONENT}(?:/${COMPONENT})*)$`,
+  'u',
+);
+
+export interface GraphShareRegistryTarget {
+  readonly origin: string;
+  readonly registry: string;
+  readonly repository: string;
+  readonly pullScope: string;
+}
+
+export function parseGraphShareRegistryTarget(value: string): GraphShareRegistryTarget {
+  const match = GRAPH_SHARE_OCI_REGISTRY.exec(value);
+  if (
+    match === null ||
+    value.length > 512 ||
+    match[1].length > 253 ||
+    match[3].length > 255 ||
+    (match[2] !== undefined && Number(match[2]) > 65_535)
+  )
+    throw graphSharingFailure('OCI registry reference is invalid.');
+  let url: URL;
+  try {
+    url = new URL(`https://${match[1]}${match[2] === undefined ? '' : `:${match[2]}`}`);
+  } catch {
+    throw graphSharingFailure('OCI registry reference is invalid.');
+  }
+  if (url.hostname !== match[1]) throw graphSharingFailure('OCI registry host must be canonical.');
+  const origin = url.origin;
+  const repository = match[3];
+  return {origin, registry: origin.slice('https://'.length), repository, pullScope: `repository:${repository}:pull`};
+}
+
+export function isGraphShareRegistryReference(value: string): boolean {
+  try {
+    parseGraphShareRegistryTarget(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/code_graph/sharing/shared_blob.ts
+++ b/src/code_graph/sharing/shared_blob.ts
@@ -1,0 +1,33 @@
+import {Effect, Schema} from 'effect';
+import {putCasBytes, readVerifiedCasBlob} from './cas.js';
+import {graphShareControlGetCas} from './control_client.js';
+import {parseSha256Digest, sha256Digest} from './digest.js';
+import {GraphSharingError, graphSharingFailure, graphSharingUnavailable} from './errors.js';
+
+export type GraphShareBlobSource = (digest: string) => Effect.Effect<Uint8Array, GraphSharingError>;
+
+export const ensureSharedGraphBlob = Effect.fn('codeGraph.sharing.ensureSharedBlob')(function* (
+  casRoot: string,
+  digest: string,
+  coordinatorUrl: string | undefined,
+  source?: GraphShareBlobSource,
+) {
+  return yield* readVerifiedCasBlob(casRoot, digest).pipe(
+    Effect.catchIf(
+      error => Schema.is(GraphSharingError)(error) && error.kind === 'unavailable',
+      () =>
+        Effect.gen(function* () {
+          const bytes = yield* source !== undefined
+            ? source(digest)
+            : coordinatorUrl !== undefined
+              ? graphShareControlGetCas(coordinatorUrl, digest)
+              : graphSharingUnavailable('Shared graph artifact is missing.');
+          if (sha256Digest(bytes) !== parseSha256Digest(digest)) {
+            return yield* graphSharingFailure('Shared graph artifact digest is invalid.');
+          }
+          yield* putCasBytes(casRoot, bytes);
+          return bytes;
+        }),
+    ),
+  );
+});

--- a/test/integration/code-graph.sharing-oci.test.ts
+++ b/test/integration/code-graph.sharing-oci.test.ts
@@ -1,0 +1,164 @@
+import {expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FetchHttpClient from 'effect/unstable/http/FetchHttpClient';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {canonicalJson} from '../../src/code_graph/checkpoint/canonical_json.js';
+import {resolveRepositoryIdentity} from '../../src/code_graph/repository.js';
+import {parseGraphShareFrontierManifest} from '../../src/code_graph/sharing/artifacts.js';
+import {decodeJsonBytes, writePrivateJsonFile} from '../../src/code_graph/sharing/atomic.js';
+import {putCasBytes, readVerifiedCasBlob} from '../../src/code_graph/sharing/cas.js';
+import {parseGraphShareCheckpointMetadata} from '../../src/code_graph/sharing/checkpoint_cas.js';
+import {maybeImportSharedGraphBase, runGraphShareJoin} from '../../src/code_graph/sharing/client.js';
+import {parseSha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {readAcceptedGraphShareFrontier} from '../../src/code_graph/sharing/frontier_acceptance.js';
+import {graphShareFrontierDiscoveryTag} from '../../src/code_graph/sharing/namespace.js';
+import {parseGraphShareProfile} from '../../src/code_graph/sharing/profile.js';
+import {readSharedGraphProvenance} from '../../src/code_graph/sharing/provenance.js';
+import {runGraphPublisherBootstrap, runGraphShareInit} from '../../src/code_graph/sharing/publisher.js';
+import {advanceGraphPublisherFrontier} from '../../src/code_graph/sharing/publisher_cycle.js';
+import {runCommandEffect} from '../../src/effect/command.js';
+import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+
+effectIt.effect(
+  'imports cold checkpoint chunks, deltas and predecessors from OCI without coordinator artifacts',
+  () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const system = yield* SystemInfo;
+        const indexer = yield* CodeGraphIndexer;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-sharing-oci-'});
+        const repository = path.join(root, 'repository');
+        const cas = path.join(root, 'publisher-cas');
+        const publisher = config(path.join(root, 'publisher'));
+        const dockerConfig = path.join(root, 'docker');
+        yield* fs.makeDirectory(repository);
+        yield* fs.makeDirectory(dockerConfig);
+        yield* fs.writeFileString(path.join(dockerConfig, 'config.json'), '{}');
+        const git = (args: readonly string[]) => runCommandEffect('git', ['-C', repository, ...args]);
+        const commit = (message: string) =>
+          git(['-c', 'user.name=Threadnote Test', '-c', 'user.email=test@threadnote.local', 'commit', '-qm', message]);
+        yield* git(['init', '-q', '--initial-branch=main']);
+        yield* git(['config', 'core.ignorecase', 'false']);
+        yield* git(['remote', 'add', 'origin', 'https://github.com/acme/oci-test.git']);
+        yield* fs.writeFileString(path.join(repository, '.gitignore'), '.threadnote/\n');
+        yield* fs.writeFileString(path.join(repository, 'index.ts'), 'export const shared = 1;\n');
+        yield* git(['add', '.']);
+        yield* commit('base');
+        const initial = yield* runGraphShareInit(publisher, {
+          cas,
+          cwd: repository,
+          organization: 'acme',
+          writeConfig: true,
+        });
+        const previousProfile = parseGraphShareProfile(
+          yield* decodeJsonBytes(yield* readVerifiedCasBlob(cas, initial.enrollment.profile.slice('cas://'.length))),
+        );
+        const profile = {
+          ...previousProfile,
+          coordinator: {url: 'http://127.0.0.1:1'},
+          registry: {canonical: 'oci://registry.example.test/acme/canonical', worker: 'cas://local/worker'},
+        };
+        const profileBytes = new TextEncoder().encode(canonicalJson(profile));
+        const profileDigest = yield* putCasBytes(cas, profileBytes);
+        const enrollment = {...initial.enrollment, profile: `cas://${profileDigest}`};
+        yield* writePrivateJsonFile(path.join(repository, '.threadnote', 'graph-share.json'), enrollment);
+        yield* indexer.index({cwd: repository, ensureVectors: false, threadnoteHome: publisher.agentContextHome});
+        const base = yield* runGraphPublisherBootstrap(publisher, {cas, cwd: repository});
+        const firstIdentity = yield* resolveRepositoryIdentity(repository);
+        yield* fs.writeFileString(path.join(repository, 'next.ts'), 'export const next = 2;\n');
+        yield* git(['add', '.']);
+        yield* commit('advance');
+        yield* indexer.index({cwd: repository, ensureVectors: false, threadnoteHome: publisher.agentContextHome});
+        const advanced = yield* advanceGraphPublisherFrontier(publisher, {cas, cwd: repository, forceFreeze: true});
+        expect(advanced.published).toBe(true);
+        const frontier = parseGraphShareFrontierManifest(
+          yield* decodeJsonBytes(yield* readVerifiedCasBlob(cas, advanced.manifestDigest)),
+        );
+        expect(frontier.deltas).toHaveLength(1);
+        const tag = graphShareFrontierDiscoveryTag(enrollment.repositoryId, 'refs/heads/main');
+        expect(advanced.descriptorDigest).toBeDefined();
+        const descriptor = yield* readVerifiedCasBlob(cas, advanced.descriptorDigest!);
+        const blobs = new Map<string, Uint8Array>();
+        for (const name of yield* fs.readDirectory(path.join(cas, 'sha256'))) {
+          blobs.set(`sha256:${name}`, yield* fs.readFile(path.join(cas, 'sha256', name)));
+        }
+        const requiredChunks: string[] = [];
+        for (const artifact of [frontier.checkpoint, ...frontier.deltas]) {
+          expect(artifact.metadataDigest).toBeDefined();
+          const metadata = parseGraphShareCheckpointMetadata(
+            yield* decodeJsonBytes(yield* readVerifiedCasBlob(cas, artifact.metadataDigest!)),
+          );
+          requiredChunks.push(metadata.prefixDigest, ...metadata.chunks.map(chunk => chunk.digest));
+          blobs.delete(artifact.manifestDigest);
+        }
+        const requests: string[] = [];
+        const fetch = Object.assign(
+          async (input: string | URL | Request) => {
+            const url = new URL(String(input));
+            requests.push(url.href);
+            expect(url.origin).toBe('https://registry.example.test');
+            const manifestPath = `/v2/acme/canonical/manifests/${tag}`;
+            if (url.pathname === manifestPath) {
+              return new Response(Uint8Array.from(descriptor), {
+                headers: {'content-type': 'application/vnd.oci.image.manifest.v1+json'},
+              });
+            }
+            expect(url.pathname).toMatch(/^\/v2\/acme\/canonical\/blobs\/sha256:[0-9a-f]{64}$/u);
+            const bytes = blobs.get(url.pathname.slice('/v2/acme/canonical/blobs/'.length));
+            return bytes === undefined ? new Response(null, {status: 404}) : new Response(Uint8Array.from(bytes));
+          },
+          {preconnect: () => undefined},
+        ) as typeof globalThis.fetch;
+        for (const [label, expectedGeneration, deltaCount] of [
+          ['current', 2, 1],
+          ['older', 1, 0],
+        ] as const) {
+          if (label === 'older') yield* git(['checkout', '--detach', firstIdentity.headCommit]);
+          const home = path.join(root, label);
+          const clientCas = path.join(root, `${label}-cas`);
+          yield* putCasBytes(clientCas, profileBytes);
+          yield* runGraphShareJoin(config(home), {cas: clientCas, cwd: repository, readOnly: true});
+          expect(yield* fs.readDirectory(path.join(clientCas, 'sha256'))).toHaveLength(1);
+          const identity = yield* resolveRepositoryIdentity(repository);
+          const imported = yield* maybeImportSharedGraphBase({cwd: repository, identity, threadnoteHome: home}).pipe(
+            Effect.provideService(FetchHttpClient.Fetch, fetch),
+            Effect.provideService(SystemInfo, {...system, environment: () => ({DOCKER_CONFIG: dockerConfig})}),
+          );
+          expect(imported).toMatchObject({
+            imported: true,
+            atGeneration: expectedGeneration,
+            checkpointDigest: base.checkpointDigest,
+          });
+          expect(yield* readSharedGraphProvenance(home, identity.checkoutId)).toMatchObject({deltaCount});
+          expect(
+            yield* readAcceptedGraphShareFrontier(home, {
+              repositoryId: enrollment.repositoryId,
+              profileDigest,
+              publisherKeyFingerprint: parseSha256Digest(enrollment.publisherKeyFingerprint),
+              branch: 'refs/heads/main',
+            }),
+          ).toMatchObject({generation: 2});
+        }
+        expect(requiredChunks.length).toBeGreaterThan(2);
+        for (const digest of requiredChunks) {
+          expect(requests).toContain(`https://registry.example.test/v2/acme/canonical/blobs/${digest}`);
+        }
+      }).pipe(provideTestLayer(ApplicationLayer)),
+    ),
+  180_000,
+);
+
+function config(home: string) {
+  return {
+    account: 'local' as const,
+    agentContextHome: home,
+    agentId: 'threadnote',
+    manifestPath: `${home}/seed-manifest.yaml`,
+    user: 'local',
+  };
+}

--- a/test/unit/code-graph.frontier-acceptance.test.ts
+++ b/test/unit/code-graph.frontier-acceptance.test.ts
@@ -1,0 +1,280 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path, Result} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FC from 'effect/testing/FastCheck';
+import {SystemInfo} from '../../src/effect/system.js';
+import {canonicalJson} from '../../src/code_graph/checkpoint/canonical_json.js';
+import {
+  generateGraphSharePublisherKey,
+  signGraphShareFrontier,
+  type GraphShareFrontierManifestV1,
+} from '../../src/code_graph/sharing/artifacts.js';
+import {putCasBytes, casBlobPath} from '../../src/code_graph/sharing/cas.js';
+import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {graphSharingFailure} from '../../src/code_graph/sharing/errors.js';
+import {
+  acceptGraphShareFrontier,
+  assertGraphSharePredecessor,
+  graphShareAcceptedFrontierPath,
+  readAcceptedGraphShareFrontier,
+} from '../../src/code_graph/sharing/frontier_acceptance.js';
+import {
+  defaultGraphShareProfile,
+  graphShareProfileDigest,
+  parseGraphShareEnrollment,
+  casProfilePointer,
+} from '../../src/code_graph/sharing/profile.js';
+import {
+  trustReceiptFromEnrollment,
+  writeGraphShareTrustReceipt,
+  removeGraphShareTrustReceipt,
+} from '../../src/code_graph/sharing/trust.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const layer = SystemInfo.layer.pipe(Layer.provideMerge(BunServices.layer));
+const fixture = Effect.fn('test.frontierAcceptance.fixture')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-frontier-acceptance-'});
+  const casRoot = path.join(home, 'cas');
+  const key = yield* generateGraphSharePublisherKey();
+  const profile = defaultGraphShareProfile({
+    branch: 'refs/heads/main',
+    canonicalRemote: 'github.com/acme/example',
+    organization: 'acme',
+    publisherKeyFingerprint: key.fingerprint,
+    repositoryId: 'a'.repeat(64),
+  });
+  const profileDigest = graphShareProfileDigest(profile);
+  const enrollment = parseGraphShareEnrollment({
+    profile: casProfilePointer(profileDigest),
+    publisherKeyFingerprint: key.fingerprint,
+    repositoryId: profile.repositoryId,
+    schemaVersion: 1,
+  });
+  yield* writeGraphShareTrustReceipt(home, trustReceiptFromEnrollment(enrollment, profile, profileDigest, 'read-only'));
+  const scope = {
+    branch: profile.source.branches[0],
+    profileDigest,
+    publisherKeyFingerprint: key.fingerprint,
+    repositoryId: profile.repositoryId,
+  };
+  const candidate = Effect.fn('test.frontierAcceptance.candidate')(function* (
+    generation: number,
+    fence = 1,
+    overrides: Partial<GraphShareFrontierManifestV1> = {},
+  ) {
+    const manifest: GraphShareFrontierManifestV1 = {
+      branch: scope.branch,
+      checkpoint: {
+        manifestDigest: sha256Digest('checkpoint'),
+        snapshotId: 'cgsn_fixture',
+        sourceCommit: 'b'.repeat(40),
+      },
+      deltas: [],
+      generation,
+      graphAbi: 'c'.repeat(64),
+      graphContentId: 'cgc_' + 'd'.repeat(40),
+      logicalGraphDigest: sha256Digest('graph'),
+      previousManifestDigest: generation === 1 ? null : sha256Digest('previous'),
+      profileDigest,
+      publisherFence: fence,
+      repositoryId: scope.repositoryId,
+      schemaVersion: 1,
+      snapshotId: 'cgsn_fixture',
+      sourceCommit: 'b'.repeat(40),
+      ...overrides,
+    };
+    const signed = yield* signGraphShareFrontier(key, manifest);
+    const manifestDigest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(manifest)));
+    const envelopeDigest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(signed.envelope)));
+    return {manifest, pointer: {manifestDigest, envelopeDigest, schemaVersion: 1 as const}};
+  });
+  return {fs, home, casRoot, scope, candidate, target: yield* graphShareAcceptedFrontierPath(home, scope)};
+});
+
+describe('authenticated frontier acceptance', () => {
+  effectIt.effect(
+    'rejects rollback, equivocation, wrong scope and bad signatures without changing the accepted pointer',
+    () =>
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        const baseline = yield* f.candidate(4, 3);
+        const input = {casRoot: f.casRoot, home: f.home, scope: f.scope};
+        const accepted = yield* acceptGraphShareFrontier({...input, pointer: baseline.pointer});
+        const before = yield* f.fs.readFileString(f.target);
+        const candidates = [
+          yield* f.candidate(3, 3),
+          yield* f.candidate(5, 2),
+          yield* f.candidate(4, 3, {logicalGraphDigest: sha256Digest('different graph')}),
+          yield* f.candidate(5, 3, {branch: 'refs/heads/unrelated'}),
+          yield* f.candidate(5, 3, {profileDigest: sha256Digest('different profile')}),
+          yield* f.candidate(5, 3, {repositoryId: 'e'.repeat(64)}),
+        ];
+        const unsigned = yield* f.candidate(5, 3);
+        candidates.push({...unsigned, pointer: {...unsigned.pointer, envelopeDigest: baseline.pointer.envelopeDigest}});
+        for (const candidate of candidates) {
+          expect(
+            Result.isFailure(
+              yield* acceptGraphShareFrontier({...input, pointer: candidate.pointer}).pipe(Effect.result),
+            ),
+          ).toBe(true);
+          expect(yield* f.fs.readFileString(f.target)).toBe(before);
+        }
+        expect(yield* acceptGraphShareFrontier({...input, pointer: baseline.pointer})).toEqual(accepted);
+        expect(
+          (yield* acceptGraphShareFrontier({...input, pointer: (yield* f.candidate(6, 3)).pointer})).generation,
+        ).toBe(6);
+      }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('keeps an intact watermark when its cached payload is missing and ignores a stale legacy seed', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const input = {casRoot: f.casRoot, home: f.home, scope: f.scope};
+      const newest = yield* f.candidate(10, 3);
+      yield* acceptGraphShareFrontier({...input, pointer: newest.pointer});
+      yield* f.fs.remove(yield* casBlobPath(f.casRoot, newest.pointer.manifestDigest));
+      const older = yield* f.candidate(5, 2);
+      expect((yield* acceptGraphShareFrontier({...input, legacy: true, pointer: older.pointer})).generation).toBe(10);
+      expect(
+        Result.isFailure(yield* acceptGraphShareFrontier({...input, pointer: older.pointer}).pipe(Effect.result)),
+      ).toBe(true);
+      expect((yield* readAcceptedGraphShareFrontier(f.home, f.scope))?.generation).toBe(10);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('serializes competing sessions so a slow candidate cannot replace a higher generation', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        const input = {casRoot: f.casRoot, home: f.home, scope: f.scope};
+        const candidates = yield* Effect.forEach([2, 7, 3, 6, 4, 5, 1, 8], generation => f.candidate(generation));
+        yield* Effect.forEach(
+          candidates,
+          candidate => acceptGraphShareFrontier({...input, pointer: candidate.pointer}).pipe(Effect.result),
+          {concurrency: 8},
+        );
+        expect((yield* readAcceptedGraphShareFrontier(f.home, f.scope))?.generation).toBe(8);
+      }).pipe(provideTestLayer(layer)),
+    ),
+  );
+
+  effectIt.effect('denies acceptance after trust removal and on a failed persistence commit', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const input = {casRoot: f.casRoot, home: f.home, scope: f.scope, pointer: (yield* f.candidate(1)).pointer};
+      const failing = {
+        ...f.fs,
+        rename: (from: string, to: string) =>
+          to === f.target ? graphSharingFailure('Synthetic persistence failure.') : f.fs.rename(from, to),
+      };
+      expect(
+        Result.isFailure(
+          yield* acceptGraphShareFrontier(input).pipe(
+            Effect.provideService(FileSystem.FileSystem, failing),
+            Effect.result,
+          ),
+        ),
+      ).toBe(true);
+      expect(yield* f.fs.exists(f.target)).toBe(false);
+      yield* removeGraphShareTrustReceipt(f.home, f.scope.repositoryId);
+      expect(Result.isFailure(yield* acceptGraphShareFrontier(input).pipe(Effect.result))).toBe(true);
+      expect(yield* f.fs.exists(f.target)).toBe(false);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('does not reset corrupt or oversized accepted state', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const input = {casRoot: f.casRoot, home: f.home, scope: f.scope, pointer: (yield* f.candidate(1)).pointer};
+      yield* acceptGraphShareFrontier(input);
+      for (const invalid of ['{invalid', 'x'.repeat(4097)]) {
+        yield* f.fs.writeFileString(f.target, invalid);
+        expect(Result.isFailure(yield* acceptGraphShareFrontier(input).pipe(Effect.result))).toBe(true);
+        expect(yield* f.fs.readFileString(f.target)).toBe(invalid);
+      }
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('rechecks trust after reading state inside the acceptance lease', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const input = {casRoot: f.casRoot, home: f.home, scope: f.scope};
+      yield* acceptGraphShareFrontier({...input, pointer: (yield* f.candidate(1)).pointer});
+      const before = yield* f.fs.readFileString(f.target);
+      const revoking = {
+        ...f.fs,
+        exists: (target: string) =>
+          target === f.target
+            ? removeGraphShareTrustReceipt(f.home, f.scope.repositoryId).pipe(Effect.andThen(f.fs.exists(target)))
+            : f.fs.exists(target),
+      };
+      const result = yield* acceptGraphShareFrontier({...input, pointer: (yield* f.candidate(2)).pointer}).pipe(
+        Effect.provideService(FileSystem.FileSystem, revoking),
+        Effect.result,
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      expect(yield* f.fs.readFileString(f.target)).toBe(before);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('allows only decreasing in-scope predecessor metadata', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const older = yield* f.candidate(1);
+      const newer = yield* f.candidate(2, 2, {previousManifestDigest: older.pointer.manifestDigest});
+      expect(() => assertGraphSharePredecessor(newer.manifest, older.manifest)).not.toThrow();
+      for (const change of [
+        {branch: 'refs/heads/other'},
+        {profileDigest: sha256Digest('other')},
+        {repositoryId: 'f'.repeat(64)},
+        {generation: 2},
+        {publisherFence: 3},
+      ]) {
+        expect(() => assertGraphSharePredecessor(newer.manifest, {...older.manifest, ...change})).toThrow();
+      }
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect.prop(
+    'accepted generation and fence never decrease and denied transitions leave state unchanged',
+    {
+      candidates: FC.array(FC.tuple(FC.integer({min: 1, max: 8}), FC.integer({min: 1, max: 4})), {
+        minLength: 1,
+        maxLength: 12,
+      }),
+    },
+    ({candidates}) =>
+      Effect.gen(function* () {
+        const f = yield* fixture();
+        let generation = 0;
+        let fence = 0;
+        let body: string | undefined;
+        for (const [nextGeneration, nextFence] of candidates) {
+          const candidate = yield* f.candidate(nextGeneration, nextFence);
+          const allowed =
+            (nextGeneration > generation && nextFence >= fence) ||
+            (nextGeneration === generation && nextFence === fence);
+          const result = yield* acceptGraphShareFrontier({
+            casRoot: f.casRoot,
+            home: f.home,
+            scope: f.scope,
+            pointer: candidate.pointer,
+          }).pipe(Effect.result);
+          expect(Result.isSuccess(result)).toBe(allowed);
+          const after = yield* f.fs.readFileString(f.target);
+          if (allowed) {
+            generation = nextGeneration;
+            fence = nextFence;
+            body = after;
+          } else expect(after).toBe(body);
+          const current = yield* readAcceptedGraphShareFrontier(f.home, f.scope);
+          expect(current?.generation).toBe(generation);
+          expect(current?.publisherFence).toBe(fence);
+        }
+      }).pipe(provideTestLayer(layer)),
+    {fastCheck: {numRuns: 30}},
+  );
+});

--- a/test/unit/code-graph.registry-http.test.ts
+++ b/test/unit/code-graph.registry-http.test.ts
@@ -1,0 +1,308 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {describe, expect, it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import * as FetchHttpClient from 'effect/unstable/http/FetchHttpClient';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {CommandExecutor} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {makeGraphShareRegistryHttp} from '../../src/code_graph/sharing/registry_http.js';
+import {parseGraphShareRegistryTarget} from '../../src/code_graph/sharing/registry_reference.js';
+import {makeGraphShareRegistryReader} from '../../src/code_graph/sharing/registry_reader.js';
+import {graphShareOciDescriptorFromLayers} from '../../src/code_graph/sharing/descriptor.js';
+import {sha256Digest} from '../../src/code_graph/sharing/digest.js';
+import {canonicalJson} from '../../src/code_graph/checkpoint/canonical_json.js';
+
+const layer = Layer.mergeAll(BunServices.layer, SystemInfo.layer, FetchHttpClient.layer);
+const target = parseGraphShareRegistryTarget('oci://registry.example.test/acme/canonical');
+const pathname = '/v2/acme/canonical/blobs/sha256:' + 'a'.repeat(64);
+const secret = 'synthetic-helper-output';
+const basic = 'Basic ' + Buffer.from('synthetic-reader:' + secret).toString('base64');
+type Request = {readonly url: URL; readonly headers: Headers; readonly signal: AbortSignal | null | undefined};
+
+const fixture = Effect.fn('test.registry.fixture')(function* (options: {
+  readonly helper?: boolean;
+  readonly helperDenied?: boolean;
+  readonly helperResponse?: (call: number) => unknown;
+  readonly handler: (request: Request) => Response;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const system = yield* SystemInfo;
+  const directory = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-registry-auth-'});
+  yield* fs.writeFileString(
+    path.join(directory, 'config.json'),
+    JSON.stringify(
+      options.helper
+        ? {
+            credHelpers: {[target.registry]: 'fixture'},
+            credsStore: 'unused',
+            auths: {[target.registry]: {auth: 'must-not-use'}},
+          }
+        : {auths: {[target.registry]: {auth: 'must-not-use'}}},
+    ),
+  );
+  const requests: Request[] = [];
+  let helperCalls = 0;
+  const fetch = Object.assign(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      const request = {url: new URL(String(url)), headers: new Headers(init?.headers), signal: init?.signal};
+      expect(init?.redirect).toBe('manual');
+      expect(init?.credentials).toBe('omit');
+      requests.push(request);
+      return options.handler(request);
+    },
+    {preconnect: () => undefined},
+  ) as typeof globalThis.fetch;
+  const reader = yield* Effect.all({
+    http: makeGraphShareRegistryHttp(target),
+    registry: makeGraphShareRegistryReader('oci://registry.example.test/acme/canonical'),
+  }).pipe(
+    Effect.provideService(SystemInfo, {...system, environment: () => ({DOCKER_CONFIG: directory})}),
+    Effect.provideService(CommandExecutor, {
+      execute: (executable, args, input) =>
+        Effect.sync(() => {
+          helperCalls++;
+          expect(executable).toBe('docker-credential-fixture');
+          expect(args).toEqual(['get']);
+          expect(new TextDecoder().decode(input?.input)).toBe(target.registry + '\n');
+          expect(input?.maxOutputBytes).toBe(16384);
+          expect(input?.timeoutMs).toBe(5000);
+          return {
+            exitCode: options.helperDenied ? 1 : 0,
+            stderr: secret,
+            stdout: JSON.stringify(
+              options.helperResponse?.(helperCalls) ?? {Username: 'synthetic-reader', Secret: secret},
+            ),
+          };
+        }),
+      executeStreaming: () => Effect.succeed({exitCode: 1, stdout: '', stderr: ''}),
+    }),
+    Effect.provideService(FetchHttpClient.Fetch, fetch),
+  );
+  return {
+    read: (maximum = 1024) => reader.http(pathname, maximum, 'application/octet-stream'),
+    registry: reader.registry,
+    requests,
+    helperCalls: () => helperCalls,
+  };
+});
+
+describe('registry authentication and bounded transport', () => {
+  effectIt.effect('uses anonymous reads without falling back to plaintext Docker auths', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture({
+        handler: request => {
+          expect(request.headers.get('authorization')).toBeNull();
+          return new Response('bytes');
+        },
+      });
+      expect(new TextDecoder().decode((yield* f.read()).bytes)).toBe('bytes');
+      expect(f.helperCalls()).toBe(0);
+      expect(f.requests).toHaveLength(1);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('uses the selected helper only after an exact-origin Basic challenge', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture({
+        helper: true,
+        handler: request =>
+          request.headers.get('authorization') === basic
+            ? new Response('bytes')
+            : new Response(null, {status: 401, headers: {'www-authenticate': 'Basic realm="synthetic"'}}),
+      });
+      yield* f.read();
+      yield* f.read();
+      expect(f.helperCalls()).toBe(1);
+      expect(f.requests).toHaveLength(3);
+      expect(f.requests[0]?.headers.get('authorization')).toBeNull();
+      expect(f.requests.slice(1).every(request => request.headers.get('authorization') === basic)).toBe(true);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('requests only the exact pull scope and renews short-lived bearer tokens automatically', () =>
+    Effect.gen(function* () {
+      let issued = 0;
+      const f = yield* fixture({
+        helper: true,
+        handler: request => {
+          if (request.url.pathname === '/token') {
+            expect(request.url.origin).toBe(target.origin);
+            expect(request.url.searchParams.get('scope')).toBe(target.pullScope);
+            expect([...request.url.searchParams.keys()].sort()).toEqual(['scope', 'service']);
+            expect(request.headers.get('authorization')).toBe(basic);
+            return Response.json({token: 'synthetic-token-' + ++issued, expires_in: 1});
+          }
+          return request.headers.get('authorization') === 'Bearer synthetic-token-' + issued && issued > 0
+            ? new Response('bytes')
+            : new Response(null, {
+                status: 401,
+                headers: {
+                  'www-authenticate': `Bearer realm="${target.origin}/token",service="registry",scope="${target.pullScope}"`,
+                },
+              });
+        },
+      });
+      yield* f.read();
+      yield* f.read();
+      expect(issued).toBe(1);
+      expect(f.helperCalls()).toBe(1);
+      yield* TestClock.adjust(1001);
+      yield* f.read();
+      expect(issued).toBe(2);
+      expect(f.helperCalls()).toBe(2);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('denied helpers stop without anonymous or alternate-identity fallback and redact output', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture({
+        helper: true,
+        helperDenied: true,
+        handler: () => new Response(null, {status: 401, headers: {'www-authenticate': 'Basic realm="synthetic"'}}),
+      });
+      const exit = yield* Effect.exit(f.read());
+      expect(exit._tag).toBe('Failure');
+      expect(JSON.stringify(exit)).not.toContain(secret);
+      expect(f.requests).toHaveLength(1);
+      expect(f.helperCalls()).toBe(1);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('rejects foreign realms, scope widening and redirects before credential use', () =>
+    Effect.gen(function* () {
+      for (const challenge of [
+        'Bearer realm="https://foreign.example.test/token"',
+        `Bearer realm="${target.origin}/token",scope="repository:acme/canonical:pull,push"`,
+        `Bearer realm="${target.origin}/token?redirect=secret"`,
+      ]) {
+        const f = yield* fixture({
+          helper: true,
+          handler: () => new Response(null, {status: 401, headers: {'www-authenticate': challenge}}),
+        });
+        expect((yield* Effect.exit(f.read()))._tag).toBe('Failure');
+        expect(f.requests).toHaveLength(1);
+        expect(f.helperCalls()).toBe(0);
+      }
+      const f = yield* fixture({
+        helper: true,
+        handler: () =>
+          new Response(null, {status: 307, headers: {location: 'https://foreign.example.test/blob?secret=signed'}}),
+      });
+      const exit = yield* Effect.exit(f.read());
+      expect(exit._tag).toBe('Failure');
+      expect(JSON.stringify(exit)).not.toContain('signed');
+      expect(f.requests).toHaveLength(1);
+      expect(f.helperCalls()).toBe(0);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('bounds authentication retries and aborts every completed request scope', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture({
+        helper: true,
+        handler: () => new Response(null, {status: 401, headers: {'www-authenticate': 'Basic realm="synthetic"'}}),
+      });
+      expect((yield* Effect.exit(f.read()))._tag).toBe('Failure');
+      expect(f.requests).toHaveLength(3);
+      expect(f.helperCalls()).toBe(2);
+      expect(f.requests.every(request => request.signal?.aborted)).toBe(true);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('stops an oversized streaming response without Content-Length', () =>
+    Effect.gen(function* () {
+      let cancelled = false;
+      const f = yield* fixture({
+        handler: () =>
+          new Response(
+            new ReadableStream({
+              pull(controller) {
+                controller.enqueue(new Uint8Array(8));
+              },
+              cancel() {
+                cancelled = true;
+              },
+            }),
+          ),
+      });
+      expect((yield* Effect.exit(f.read(12)))._tag).toBe('Failure');
+      expect(cancelled).toBe(true);
+      expect(f.requests[0]?.signal?.aborted).toBe(true);
+    }).pipe(provideTestLayer(layer)),
+  );
+  effectIt.effect('rejects unsupported helper identities and identity changes without exposing helper contents', () =>
+    Effect.gen(function* () {
+      for (const response of [
+        {Username: '<token>', Secret: secret},
+        {Username: 'user:other', Secret: secret},
+        {Username: 'synthetic-reader', Secret: secret, ServerURL: 'foreign.example.test'},
+      ]) {
+        const f = yield* fixture({
+          helper: true,
+          helperResponse: () => response,
+          handler: () => new Response(null, {status: 401, headers: {'www-authenticate': 'Basic realm="fixture"'}}),
+        });
+        const exit = yield* Effect.exit(f.read());
+        expect(exit._tag).toBe('Failure');
+        expect(JSON.stringify(exit)).not.toContain(secret);
+        expect(f.requests).toHaveLength(1);
+      }
+      const f = yield* fixture({
+        helper: true,
+        helperResponse: call => ({Username: call === 1 ? 'first' : 'second', Secret: secret}),
+        handler: () => new Response(null, {status: 401, headers: {'www-authenticate': 'Basic realm="fixture"'}}),
+      });
+      expect((yield* Effect.exit(f.read()))._tag).toBe('Failure');
+      expect(f.helperCalls()).toBe(2);
+      expect(f.requests).toHaveLength(2);
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('verifies exact blob bytes, digest headers and descriptor size bounds', () =>
+    Effect.gen(function* () {
+      const bytes = new TextEncoder().encode('synthetic graph bytes'),
+        digest = sha256Digest(bytes);
+      const valid = yield* fixture({handler: () => new Response(bytes, {headers: {'docker-content-digest': digest}})});
+      expect(new Uint8Array(yield* valid.registry.readBlob(digest, bytes.length))).toEqual(bytes);
+      expect((yield* Effect.exit(valid.registry.readBlob(digest, bytes.length - 1)))._tag).toBe('Failure');
+      for (const handler of [
+        () => new Response('tampered'),
+        () => new Response(bytes, {headers: {'docker-content-digest': sha256Digest('different')}}),
+        () => new Response(null, {status: 404}),
+      ]) {
+        const invalid = yield* fixture({handler});
+        expect((yield* Effect.exit(invalid.registry.readBlob(digest)))._tag).toBe('Failure');
+      }
+    }).pipe(provideTestLayer(layer)),
+  );
+
+  effectIt.effect('resolves a tag to the exact immutable OCI manifest bytes and refuses invalid headers', () =>
+    Effect.gen(function* () {
+      const bytes = new TextEncoder().encode('fixture');
+      const descriptor = graphShareOciDescriptorFromLayers({frontier: bytes, envelope: bytes, metadata: bytes});
+      const body = new TextEncoder().encode(canonicalJson(descriptor)),
+        digest = sha256Digest(body);
+      const valid = yield* fixture({
+        handler: () =>
+          new Response(body, {headers: {'content-type': descriptor.mediaType, 'docker-content-digest': digest}}),
+      });
+      const resolved = yield* valid.registry.readManifest('tn-frontier-' + 'a'.repeat(40));
+      expect(resolved).toMatchObject({
+        descriptor,
+        digest,
+      });
+      expect(new Uint8Array(resolved.bytes)).toEqual(body);
+      for (const headers of [
+        {'content-type': 'application/json', 'docker-content-digest': digest},
+        {'content-type': descriptor.mediaType, 'docker-content-digest': sha256Digest('different')},
+      ]) {
+        const invalid = yield* fixture({handler: () => new Response(body, {headers})});
+        expect((yield* Effect.exit(invalid.registry.readManifest('tn-frontier-' + 'a'.repeat(40))))._tag).toBe(
+          'Failure',
+        );
+      }
+    }).pipe(provideTestLayer(layer)),
+  );
+});

--- a/test/unit/code-graph.registry-http.test.ts
+++ b/test/unit/code-graph.registry-http.test.ts
@@ -170,6 +170,25 @@ describe('registry authentication and bounded transport', () => {
     }).pipe(provideTestLayer(layer)),
   );
 
+  effectIt.effect('preserves token endpoint retry hints without retrying immediately', () =>
+    Effect.gen(function* () {
+      const f = yield* fixture({
+        handler: request =>
+          request.url.pathname === '/token'
+            ? new Response(null, {status: 429, headers: {'retry-after': '17'}})
+            : new Response(null, {
+                status: 401,
+                headers: {'www-authenticate': `Bearer realm="${target.origin}/token"`},
+              }),
+      });
+      const result = yield* Effect.result(f.read());
+      expect(result).toMatchObject({
+        failure: {httpStatus: 429, kind: 'unavailable', retryAfterMilliseconds: 17_000},
+      });
+      expect(f.requests).toHaveLength(2);
+    }).pipe(provideTestLayer(layer)),
+  );
+
   effectIt.effect('rejects foreign realms, scope widening and redirects before credential use', () =>
     Effect.gen(function* () {
       for (const challenge of [

--- a/test/unit/code-graph.registry-reference.test.ts
+++ b/test/unit/code-graph.registry-reference.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from 'vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {parseGraphShareRegistryTarget} from '../../src/code_graph/sharing/registry_reference.js';
+import {parseGraphShareRegistryChallenge} from '../../src/code_graph/sharing/registry_auth.js';
+
+const name = FC.array(FC.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789'), {minLength: 1, maxLength: 20}).map(
+  chars => chars.join(''),
+);
+describe('trusted registry targets', () => {
+  it('keeps generated repositories and token scopes confined to their exact authority', () => {
+    FC.assert(
+      FC.property(
+        name,
+        FC.array(name, {minLength: 1, maxLength: 5}),
+        FC.integer({min: 1, max: 65535}),
+        (host, parts, port) => {
+          const reference = `oci://registry-${host}.example.test:${port}/${parts.join('/')}`;
+          const target = parseGraphShareRegistryTarget(reference);
+          expect(target.repository).toBe(parts.join('/'));
+          expect(target.origin).toBe(new URL(`https://registry-${host}.example.test:${port}`).origin);
+          expect(target.pullScope).toBe(`repository:${parts.join('/')}:pull`);
+          expect(new URL(`/v2/${target.repository}/blobs/sha256:abc`, target.origin).pathname).toBe(
+            `/v2/${parts.join('/')}/blobs/sha256:abc`,
+          );
+          expect(
+            parseGraphShareRegistryChallenge(
+              `Bearer realm="${target.origin}/token",scope="${target.pullScope}"`,
+              target,
+            ),
+          ).toEqual({kind: 'bearer', realm: `${target.origin}/token`});
+          expect(() =>
+            parseGraphShareRegistryChallenge(
+              `Bearer realm="${target.origin}/token",scope="${target.pullScope},push"`,
+              target,
+            ),
+          ).toThrow();
+        },
+      ),
+      {numRuns: 80},
+    );
+  });
+  it('rejects credentials, path aliases, unsupported schemes, case changes and invalid ports', () => {
+    for (const value of [
+      'https://registry.example.test/repo',
+      'oci://127.1/repo',
+      'oci://900.555.66/repo',
+      'oci://user@registry.example.test/repo',
+      'oci://registry.example.test/a/../other',
+      'oci://registry.example.test/a/%2e%2e/other',
+      'oci://registry.example.test/a//b',
+      'oci://registry.example.test/A',
+      'oci://registry.example.test/repo?other',
+      'oci://registry.example.test/repo#tag',
+      'oci://registry.example.test:0/repo',
+      'oci://registry.example.test:65536/repo',
+      'oci://registry.example.test:0443/repo',
+      'oci://registry.example.test/' + 'a'.repeat(256),
+    ])
+      expect(() => parseGraphShareRegistryTarget(value)).toThrow();
+  });
+  it('rejects ambiguous, malformed and foreign authentication challenges', () => {
+    const target = parseGraphShareRegistryTarget('oci://registry.example.test/repo');
+    for (const value of [
+      undefined,
+      'Digest realm="fixture"',
+      'Bearer realm="https://foreign.example.test/token"',
+      'Bearer realm="https://registry.example.test/token",realm="https://foreign.example.test/token"',
+      'Bearer realm="https://registry.example.test/../token"',
+      'Bearer realm="https://registry.example.test/%74oken"',
+      'Bearer realm="https://registry.example.test/token#fragment"',
+      'Bearer realm="https://user@registry.example.test/token"',
+    ])
+      expect(() => parseGraphShareRegistryChallenge(value, target)).toThrow();
+  });
+});

--- a/test/unit/code-graph.sharing-client.test.ts
+++ b/test/unit/code-graph.sharing-client.test.ts
@@ -1,9 +1,14 @@
 import * as BunHttpClient from '@effect/platform-bun/BunHttpClient';
+import * as BunHttpServer from '@effect/platform-bun/BunHttpServer';
+import * as HttpServer from 'effect/unstable/http/HttpServer';
+import * as HttpServerRequest from 'effect/unstable/http/HttpServerRequest';
+import * as HttpServerResponse from 'effect/unstable/http/HttpServerResponse';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import {describe, expect, it as effectIt} from '@effect/vitest';
 import {it} from 'vitest';
 import {Effect, FileSystem, Layer, Path, Schema} from 'effect';
 import * as FC from 'effect/testing/FastCheck';
+import {TestClock} from 'effect/testing';
 import {readFile} from '../helpers/node-fs-promises.js';
 import {dirname, join} from '../helpers/node-path.js';
 import {fileURLToPath} from '../helpers/node-url.js';
@@ -16,6 +21,7 @@ import {
   parseGraphShareFrontierManifest,
   signGraphShareFrontier,
   type GraphShareFrontierManifestV1,
+  type GraphShareFrontierPointerV1,
   type GraphShareSignatureEnvelopeV1,
 } from '../../src/code_graph/sharing/artifacts.js';
 import {putCasBytes, putCasFile} from '../../src/code_graph/sharing/cas.js';
@@ -27,7 +33,11 @@ import {
   selectPublishedAncestorManifest,
 } from '../../src/code_graph/sharing/client.js';
 import {sha256Digest, sha256HexFromDigest} from '../../src/code_graph/sharing/digest.js';
-import {GraphSharingError} from '../../src/code_graph/sharing/errors.js';
+import {GraphSharingError, graphSharingFailure} from '../../src/code_graph/sharing/errors.js';
+import {
+  acceptGraphShareFrontier,
+  readAcceptedGraphShareFrontier,
+} from '../../src/code_graph/sharing/frontier_acceptance.js';
 import {
   graphSharingCasBlobPath,
   graphSharingLayout,
@@ -289,6 +299,47 @@ describe('graph share import and inspect source', () => {
     }).pipe(provideTestLayer(sharingLayer)),
   );
 
+  effectIt.effect('rejects a validly signed frontier for another branch before using prior provenance', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-graph-share-branch-'});
+      const enrolled = yield* enrolledHome(home, {includeFrontier: true, skipCheckpoint: true});
+      yield* writeSharedGraphProvenance(home, CHECKOUT_ID, {
+        checkpointDigest: enrolled.checkpointDigest,
+        deltaCount: 0,
+        frontierCommit: enrolled.manifest.sourceCommit,
+        profileDigest: enrolled.profileDigest,
+        repositoryId: REPOSITORY_ID,
+        schemaVersion: 1,
+        snapshotId: enrolled.manifest.snapshotId,
+      });
+      const signed = yield* signGraphShareFrontier(enrolled.key, {
+        ...enrolled.manifest,
+        branch: 'refs/heads/unrelated',
+      });
+      const manifestDigest = yield* putCasBytes(
+        enrolled.casRoot,
+        new TextEncoder().encode(canonicalJson(signed.manifest)),
+      );
+      const envelopeDigest = yield* putCasBytes(
+        enrolled.casRoot,
+        new TextEncoder().encode(canonicalJson(signed.envelope)),
+      );
+      const pointer = path.join(
+        graphSharingLayout(path, home, enrolled.casRoot).frontiersRoot,
+        REPOSITORY_ID,
+        'latest.json',
+      );
+      yield* fs.writeFileString(pointer, JSON.stringify({envelopeDigest, manifestDigest, schemaVersion: 1}));
+      expect(yield* maybeImportSharedGraphBase(importRequest(enrolled.repo, home))).toEqual({
+        imported: false,
+        reason: 'quarantined',
+      });
+      expect((yield* readSharedGraphProvenance(home, CHECKOUT_ID))?.snapshotId).toBe(enrolled.manifest.snapshotId);
+    }).pipe(provideTestLayer(sharingLayer)),
+  );
+
   effectIt.effect('quarantines a mutated checkpoint blob and leaves prior provenance snapshot id unchanged', () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -322,6 +373,172 @@ describe('graph share import and inspect source', () => {
         }),
       ).toBeUndefined();
     }).pipe(provideTestLayer(sharingLayer)),
+  );
+
+  effectIt.effect('seeds the legacy baseline before remote discovery and never publishes rejected candidates', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-frontier-upgrade-'});
+        const f = yield* enrolledHome(home, {includeFrontier: true, skipCheckpoint: true});
+        const store = (generation: number, branch = 'refs/heads/main') =>
+          Effect.gen(function* () {
+            const signed = yield* signGraphShareFrontier(f.key, {
+              ...f.manifest,
+              branch,
+              generation,
+              previousManifestDigest: f.manifestDigest,
+            });
+            return {
+              envelopeDigest: yield* putCasBytes(f.casRoot, new TextEncoder().encode(canonicalJson(signed.envelope))),
+              manifestDigest: yield* putCasBytes(f.casRoot, new TextEncoder().encode(canonicalJson(signed.manifest))),
+              schemaVersion: 1 as const,
+            };
+          });
+        const baseline = yield* store(10);
+        let remote: GraphShareFrontierPointerV1 = yield* store(5);
+        const pointerPath = path.join(
+          graphSharingLayout(path, home, f.casRoot).frontiersRoot,
+          REPOSITORY_ID,
+          'latest.json',
+        );
+        const legacy = JSON.stringify(baseline);
+        yield* fs.writeFileString(pointerPath, legacy);
+        const context = yield* Layer.build(BunHttpServer.layer({hostname: '127.0.0.1', port: 0}));
+        const server = yield* HttpServer.HttpServer.pipe(Effect.provide(context));
+        let remoteRequests = 0;
+        yield* server.serve(
+          Effect.gen(function* () {
+            const request = yield* HttpServerRequest.HttpServerRequest;
+            remoteRequests += 1;
+            return request.url.startsWith('/v1/frontiers/')
+              ? HttpServerResponse.jsonUnsafe(remote)
+              : HttpServerResponse.empty({status: 404});
+          }),
+        );
+        if (server.address._tag !== 'TcpAddress') return yield* graphSharingFailure('Expected TCP fixture.');
+        yield* writeGraphShareTrustReceipt(home, {
+          ...trustReceiptFromEnrollment(f.enrollment, f.profile, f.profileDigest, 'read-only'),
+          client: {
+            casRoot: f.casRoot,
+            contributionMode: 'off',
+            coordinatorUrl: 'http://127.0.0.1:' + server.address.port,
+          },
+        });
+        yield* writeSharedGraphProvenance(home, CHECKOUT_ID, {
+          checkpointDigest: f.checkpointDigest,
+          deltaCount: 0,
+          frontierCommit: f.manifest.sourceCommit,
+          profileDigest: f.profileDigest,
+          repositoryId: REPOSITORY_ID,
+          schemaVersion: 1,
+          snapshotId: f.manifest.snapshotId,
+        });
+        const scope = {
+          branch: f.manifest.branch,
+          profileDigest: f.profileDigest,
+          repositoryId: REPOSITORY_ID,
+          publisherKeyFingerprint: f.key.fingerprint,
+        };
+        let failedCommit = false;
+        const failingOnce = {
+          ...fs,
+          rename: (from: string, to: string) => {
+            if (!failedCommit && to.startsWith(path.join(home, 'graph-sharing', 'accepted-frontiers'))) {
+              failedCommit = true;
+              return graphSharingFailure('Synthetic baseline persistence failure.');
+            }
+            return fs.rename(from, to);
+          },
+        };
+        expect(
+          yield* maybeImportSharedGraphBase(importRequest(f.repo, home)).pipe(
+            Effect.provideService(FileSystem.FileSystem, failingOnce),
+          ),
+        ).toEqual({imported: false, reason: 'quarantined'});
+        expect(failedCommit).toBe(true);
+        expect(remoteRequests).toBe(0);
+        expect(yield* readAcceptedGraphShareFrontier(home, scope)).toBeUndefined();
+        expect(yield* maybeImportSharedGraphBase(importRequest(f.repo, home))).toEqual({
+          imported: false,
+          reason: 'quarantined',
+        });
+        expect((yield* readAcceptedGraphShareFrontier(home, scope))?.generation).toBe(10);
+        expect(yield* fs.readFileString(pointerPath)).toBe(legacy);
+        yield* fs.remove(graphSharingCasBlobPath(path, f.casRoot, sha256HexFromDigest(baseline.manifestDigest)));
+        expect(yield* maybeImportSharedGraphBase(importRequest(f.repo, home))).toEqual({
+          imported: false,
+          reason: 'quarantined',
+        });
+        expect((yield* readAcceptedGraphShareFrontier(home, scope))?.generation).toBe(10);
+        remote = yield* store(11, 'refs/heads/other');
+        expect(yield* maybeImportSharedGraphBase(importRequest(f.repo, home))).toEqual({
+          imported: false,
+          reason: 'quarantined',
+        });
+        expect((yield* readAcceptedGraphShareFrontier(home, scope))?.generation).toBe(10);
+        remote = yield* store(12);
+        expect(yield* maybeImportSharedGraphBase(importRequest(f.repo, home))).toMatchObject({
+          imported: false,
+          reason: 'already-installed',
+          atGeneration: 12,
+        });
+        expect((yield* readAcceptedGraphShareFrontier(home, scope))?.generation).toBe(12);
+        expect(yield* fs.readFileString(pointerPath)).toBe(legacy);
+      }).pipe(provideTestLayer(sharingLayer)),
+    ),
+  );
+
+  effectIt.effect('reports accepted discovery ahead of legacy metadata and independently of last import', () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-frontier-status-'});
+        const repo = path.join(home, 'repository');
+        yield* fs.makeDirectory(repo);
+        yield* git(repo, ['init', '-q', '--initial-branch=main']);
+        yield* git(repo, ['remote', 'add', 'origin', 'https://github.com/acme/graph-share.git']);
+        const identity = yield* resolveRepositoryIdentity(repo);
+        const f = yield* enrolledHome(home, {includeFrontier: true, repositoryId: identity.repositoryId});
+        const pointerPath = path.join(
+          graphSharingLayout(path, home, f.casRoot).frontiersRoot,
+          identity.repositoryId,
+          'latest.json',
+        );
+        const status = () => runGraphShareStatus(runtimeConfig(home), {cwd: repo, json: true});
+        const legacy = JSON.parse(yield* fs.readFileString(pointerPath));
+        expect((yield* status()).frontier).toEqual(legacy);
+        const signed = yield* signGraphShareFrontier(f.key, {
+          ...f.manifest,
+          generation: 12,
+          previousManifestDigest: f.manifestDigest,
+        });
+        const next = {
+          envelopeDigest: yield* putCasBytes(f.casRoot, new TextEncoder().encode(canonicalJson(signed.envelope))),
+          manifestDigest: yield* putCasBytes(f.casRoot, new TextEncoder().encode(canonicalJson(signed.manifest))),
+          schemaVersion: 1 as const,
+        };
+        yield* acceptGraphShareFrontier({
+          casRoot: f.casRoot,
+          home,
+          pointer: next,
+          scope: {
+            branch: f.manifest.branch,
+            profileDigest: f.profileDigest,
+            publisherKeyFingerprint: f.key.fingerprint,
+            repositoryId: identity.repositoryId,
+          },
+        });
+        yield* writeSharedGraphImportAttempt(home, identity.checkoutId, {imported: false, reason: 'unavailable'});
+        expect(yield* status()).toMatchObject({frontier: next, lastImport: {imported: false, reason: 'unavailable'}});
+        yield* fs.writeFileString(pointerPath, '{invalid legacy');
+        expect((yield* status()).frontier).toEqual(next);
+        yield* fs.remove(pointerPath);
+        expect((yield* status()).frontier).toEqual(next);
+      }).pipe(provideTestLayer(sharingLayer)),
+    ),
   );
 
   effectIt.effect('walks signed predecessor frontiers until HEAD is an ancestor', () =>
@@ -587,12 +804,18 @@ function identity(repo: string): RepositoryIdentity {
 
 const enrolledHome = Effect.fn('test.graphShare.enrolledHome')(function* (
   home: string,
-  options: {readonly includeFrontier: boolean; readonly skipCheckpoint?: boolean; readonly snapshotId?: string},
+  options: {
+    readonly includeFrontier: boolean;
+    readonly skipCheckpoint?: boolean;
+    readonly snapshotId?: string;
+    readonly repositoryId?: string;
+  },
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const repo = path.join(home, 'repository');
   const casRoot = path.join(home, 'cas');
+  const repositoryId = options.repositoryId ?? REPOSITORY_ID;
   yield* fs.makeDirectory(path.join(repo, '.threadnote'), {recursive: true});
   yield* writeGraphShareClientState(home, casRoot);
   const key = yield* generateGraphSharePublisherKey();
@@ -601,14 +824,14 @@ const enrolledHome = Effect.fn('test.graphShare.enrolledHome')(function* (
     canonicalRemote: 'github.com/acme/graph-share',
     organization: 'acme',
     publisherKeyFingerprint: key.fingerprint,
-    repositoryId: REPOSITORY_ID,
+    repositoryId,
   });
   const profileDigest = graphShareProfileDigest(profile);
   yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(profile)));
   const enrollment = parseGraphShareEnrollment({
     profile: casProfilePointer(profileDigest),
     publisherKeyFingerprint: key.fingerprint,
-    repositoryId: REPOSITORY_ID,
+    repositoryId,
     schemaVersion: 1,
   });
   yield* fs.writeFileString(path.join(repo, '.threadnote/graph-share.json'), `${JSON.stringify(enrollment)}\n`);
@@ -630,7 +853,7 @@ const enrolledHome = Effect.fn('test.graphShare.enrolledHome')(function* (
     previousManifestDigest: null,
     profileDigest,
     publisherFence: 1,
-    repositoryId: REPOSITORY_ID,
+    repositoryId,
     schemaVersion: 1,
     snapshotId,
     sourceCommit: 'a'.repeat(40),
@@ -640,9 +863,9 @@ const enrolledHome = Effect.fn('test.graphShare.enrolledHome')(function* (
   const envelopeDigest = yield* putCasBytes(casRoot, new TextEncoder().encode(canonicalJson(signed.envelope)));
   if (options.includeFrontier) {
     const layout = graphSharingLayout(path, home, casRoot);
-    yield* fs.makeDirectory(path.join(layout.frontiersRoot, REPOSITORY_ID), {recursive: true});
+    yield* fs.makeDirectory(path.join(layout.frontiersRoot, repositoryId), {recursive: true});
     yield* fs.writeFileString(
-      path.join(layout.frontiersRoot, REPOSITORY_ID, 'latest.json'),
+      path.join(layout.frontiersRoot, repositoryId, 'latest.json'),
       `${JSON.stringify({envelopeDigest, manifestDigest, schemaVersion: 1})}\n`,
     );
     if (!options.skipCheckpoint) yield* putCasBytes(casRoot, CHECKPOINT_BYTES);
@@ -653,6 +876,7 @@ const enrolledHome = Effect.fn('test.graphShare.enrolledHome')(function* (
     enrollment,
     envelope: signed.envelope,
     key,
+    manifest,
     manifestDigest,
     profile,
     profileDigest,


### PR DESCRIPTION
Shared graph discovery now imports the complete artifact set from the canonical OCI registry named in a trusted organization profile. A cold client fetches checkpoints, chunks, deltas and predecessor graphs independently of the coordinator. Ordinary MCP graph use can trigger the import automatically.

The client verifies exact artifact bytes, descriptor sizes/media types, publisher signatures and enrolled repository/profile/branch. An atomic per-authority record prevents generation/fence rollback and conflicting same-generation discoveries; verified legacy state seeds that record before remote discovery. Older checkouts can use authenticated predecessors while preserving the highest accepted generation. Status distinguishes accepted discovery from the last import attempt.

Registry access supports anonymous pulls or explicitly configured Docker credential helpers, challenge-based Basic and bearer authentication, bounded renewal/retries, and interrupted/size-bounded reads. Requests stay within the trusted registry/repository. Existing CAS profile pins and local mode remain supported; remote OCI profile enrollment and redirected blob downloads are explicitly unsupported in this slice.

Validation: 54 focused/integration tests, including bounded authority/path/scope and monotonic-acceptance properties; lint/type checks. An actual TLS Distribution registry smoke uploads a complete retention root, runs registry garbage collection, then verifies cold checkpoint+delta/predecessor imports, automatic import from one MCP graph query, tampered-frontier rejection and registry-outage cached fallback. Exact final commit 4ec0f7c5 passed this smoke through the globally installed CLI and MCP runtime, with doctor verification. CI runs the full suite.

The earlier frontier-only head hit the registration timing gate despite a passing same-runner confirmation; issue #406 preserves its measurements and deterministic gate replay. No thresholds or gate policy changed. This head adds the reviewed OCI implementation and receives a new full CI run.
