### PR TITLE
fix(ci): distinguish screening misses from hard objectives

### DIFF
--- a/scripts/benchmark-code-graph.ts
+++ b/scripts/benchmark-code-graph.ts
@@ -7631,11 +7631,14 @@ function productionConfirmatoryWallP95Acceptance(
   initialStaticFailures: readonly string[],
   remeasuredStaticFailures: readonly string[],
 ): 'bounded-confirmatory-tail' | 'screening-cleared' | undefined {
-  if (PRODUCTION_RATCHET_MILLISECOND_TARGETS.has(name)) return undefined;
   // The screening observation exists to trigger this sequence. A passing
   // protected-base control followed by a passing confirmatory candidate is
-  // sufficient evidence that an initial wall-only spike was transient.
+  // sufficient to clear an initial wall-only static miss. The caller has
+  // already enforced every hard objective on all three observations; having
+  // an objective does not make a stricter static screening limit an objective.
   if (remeasuredStaticFailures.length === 0) return 'screening-cleared';
+  // Objective-bearing metrics never receive confirmatory tail tolerance.
+  if (PRODUCTION_RATCHET_MILLISECOND_TARGETS.has(name)) return undefined;
   if (initialStaticFailures.length !== 0 || limit.p95Maximum === undefined) return undefined;
   const tolerance = Math.min(
     limit.p95Maximum * PRODUCTION_RATCHET_CONFIRMATORY_WALL_TAIL_RELATIVE_TOLERANCE,

--- a/test/evaluation/baselines/code-graph-v1/production-ratchet-linux-paired-wall-calibration-v1.md
+++ b/test/evaluation/baselines/code-graph-v1/production-ratchet-linux-paired-wall-calibration-v1.md
@@ -27,10 +27,38 @@ candidate-control-candidate sequence:
 - when screening and control pass, at most one confirmatory wall observation in the entire sequence may exceed the
   static boundary by the smaller of `1%` and `5 ms`; a second crossing fails;
 - two candidate failures still fail, as does any confirmatory excess beyond that cap;
-- hard elapsed-time objectives are ineligible for both forms of confirmatory forgiveness;
+- hard elapsed-time objectives remain mandatory in all three observations; objective-bearing metrics may clear a
+  stricter screening-only static miss but are ineligible for confirmatory tail tolerance;
 - CPU, RSS, work, storage, deterministic, cumulative-work, and every other non-wall measurement remain strict in both
   candidate observations.
 
 The companion JSON binds the exact commits, timestamps, runner identity, artifact digest, payload digests, raw
 measurements, and policy boundary needed to reproduce the adjudication. It is calibration evidence for a prespecified
 confirmatory gate, not permission to raise the production budgets or retry until a run passes.
+
+## Objective-bearing screening clarification (#406)
+
+The original implementation excluded any metric with a hard objective before checking whether the control and
+confirmatory candidate passed static. Issue [#406](https://github.com/Kashkovsky/threadnote/issues/406) exposed the
+distinction: `same-overlay-reference-registration-lock-and-database-setup` has a reviewed static p95 limit of `888 ms`
+and a separate hard objective of `4,999 ms`. In PR #405 [run 34262147162, job 102182573837](https://github.com/Kashkovsky/threadnote/actions/runs/34262147162/job/102182573837),
+the screening candidate measured `966.326097 ms`, protected-base control `269.651538 ms`, and confirmatory candidate
+`319.786313 ms`. These are three n=1 observations. They support clearing this isolated screening miss under the
+confirmatory policy; they do not establish its cause or rule out all regressions.
+
+The clarification applies screening clearance after enforcing the hard objective on every observation. An objective
+miss in the initial candidate, control, or confirmatory candidate still fails. A confirmatory static miss on an
+objective-bearing metric still cannot receive the `1%` / `5 ms` tail tolerance. Exact commits, runner identity,
+fixture/runtime/storage and measurement-set agreement, ordered timestamps, and both candidates' independently
+ratcheted resource/work/structural evidence remain prerequisites. No static limit, objective, or measurement changes.
+
+Reproduction uses the run's `code-graph-production-ratchet-Linux-X64` artifact, the checked-in Linux ratchet, candidate
+commit `60cda3256ac3af8c767e9bb6f5e91ff32c0f843e`, and protected-base commit
+`81dfd7083ed70ed25b2e2d08ba8a73eb528fb25f`. The gate rejected the original payloads before this change and accepts
+the same payloads afterward. Their SHA-256 digests are:
+
+| Payload                | SHA-256                                                            |
+| ---------------------- | ------------------------------------------------------------------ |
+| Initial candidate      | `dfb2624a0341d740e40b3b5a203bcc36517800f17b3074e2d0cc35e5fbfb3f33` |
+| Protected-base control | `a1936e4515b52d384df5645d4a3d5bd50352f46740ad9081e6ab568ea8116ba4` |
+| Confirmatory candidate | `aaed37d3506e29f7fa497691731241e1a754b1b3bcdb7a492bd0afbe61aac5f4` |

--- a/test/unit/code-graph.release-evidence.test.ts
+++ b/test/unit/code-graph.release-evidence.test.ts
@@ -1587,6 +1587,92 @@ describe('code graph release evidence', () => {
       {[confirmatoryWallName]: 295.779441},
       sandwichControl({[confirmatoryWallName]: 319.953012}),
     );
+    const registrationName = 'same-overlay-reference-registration-lock-and-database-setup';
+    const registrationRatchet = {
+      ...githubHostedRatchet,
+      measurements: {...githubHostedRatchet.measurements, [registrationName]: confirmatoryWallLimit(888)},
+    };
+    const registrationCandidate = sandwichCandidate({[registrationName]: 319.786313});
+    const registrationEvidence = sandwichEvidence(
+      {[registrationName]: 966.326097},
+      sandwichControl({[registrationName]: 269.651538}),
+    );
+    // PR #405: the screening registration observation missed static 888 ms,
+    // but all three observations met the independent 4,999 ms objective.
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(registrationEvidence.initialCandidateArtifact, registrationRatchet),
+    ).toThrow(/same-overlay-reference-registration-lock-and-database-setup p95/u);
+    expect(() =>
+      enforceCodeGraphBenchmarkRatchet(registrationCandidate, registrationRatchet, registrationEvidence),
+    ).not.toThrow();
+    for (const role of ['initialCandidateArtifact', 'artifact'] as const) {
+      const observation = registrationEvidence[role];
+      for (const [mutated, expectedFailure] of [
+        [{...observation, createdAt: registrationCandidate.createdAt}, /creation times/u],
+        [{...observation, metadata: {...observation.metadata, runnerIdentity: 'another-runner'}}, /runnerIdentity/u],
+        [{...observation, environment: {...observation.environment, fixtureHash: 'another-fixture'}}, /fixtureHash/u],
+        [
+          {
+            ...observation,
+            environment: {...observation.environment, commit: 'c'.repeat(40)},
+            metadata: {...observation.metadata, benchmarkMeasuredSourceCommit: 'c'.repeat(40)},
+          },
+          /candidate commit|control commit/u,
+        ],
+      ] as const) {
+        expect(() =>
+          enforceCodeGraphBenchmarkRatchet(registrationCandidate, registrationRatchet, {
+            ...registrationEvidence,
+            [role]: mutated,
+          }),
+        ).toThrow(expectedFailure);
+      }
+    }
+    const objectiveWallMetrics = [
+      ['cold-index', 3_599_999],
+      ['cold-registration-lock-and-database-setup', 4_999],
+      ['cold-reference-resolution-longest-transaction-n1', 14_999],
+      ['one-file-reindex-index', 29_999],
+      ['one-file-reindex-post-committed-scan-overlay-and-workspace', 4_999],
+      ['one-file-reindex-registration-lock-and-database-setup', 4_999],
+      ['one-file-reindex-reference-resolution-longest-transaction-n1', 14_999],
+      [registrationName, 4_999],
+      ['same-overlay-reference-reference-resolution-longest-transaction-n1', 14_999],
+    ] as const;
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...objectiveWallMetrics),
+        fc.integer({max: 90, min: 10}),
+        ([name, hardMaximum], percent) => {
+          const staticMaximum = Math.floor((hardMaximum * percent) / 100);
+          const objectiveRatchet = {
+            ...githubHostedRatchet,
+            measurements: {...githubHostedRatchet.measurements, [name]: confirmatoryWallLimit(staticMaximum)},
+          };
+          const enforce = (initial: number, control: number, repeat: number) =>
+            enforceCodeGraphBenchmarkRatchet(
+              sandwichCandidate({[name]: repeat}),
+              objectiveRatchet,
+              sandwichEvidence({[name]: initial}, sandwichControl({[name]: control})),
+            );
+          // The hard boundary remains inclusive even when static is much lower.
+          expect(() => enforce(hardMaximum, staticMaximum, staticMaximum)).not.toThrow();
+          for (const role of [0, 1, 2]) {
+            const observations = [staticMaximum, staticMaximum, staticMaximum];
+            observations[role] = hardMaximum + 1;
+            expect(() => enforce(observations[0], observations[1], observations[2])).toThrow(
+              new RegExp(`objective ${name} has not been attained`),
+            );
+          }
+          // Passing screening cannot grant objective metrics even a tiny tail.
+          expect(() => enforce(staticMaximum, staticMaximum, staticMaximum + 0.001)).toThrow(
+            new RegExp(`remeasured candidate ${name}`),
+          );
+          expect(() => enforce(staticMaximum + 1, staticMaximum, staticMaximum + 1)).toThrow(new RegExp(name));
+        },
+      ),
+      {numRuns: 40},
+    );
     expect(() =>
       enforceCodeGraphBenchmarkRatchet(
         sandwichCandidate({[confirmatoryWallName]: 492.101135}),
@@ -1868,6 +1954,7 @@ describe('code graph release evidence', () => {
       }),
     ).toThrow(/paired control environment\.fixtureHash/u);
     const invariantGuardNames = [
+      'cold-materialized-file-rows',
       'cold-process-peak-rss',
       'cold-registration-process-cpu-n1',
       'incremental-process-peak-rss',
@@ -1901,6 +1988,21 @@ describe('code graph release evidence', () => {
         expect(() =>
           enforceCodeGraphBenchmarkRatchet(noisyCandidate, githubHostedRatchet, initialOnlyRegression),
         ).toThrow(new RegExp(`initial candidate ${name}`));
+        for (const role of ['initial', 'repeat'] as const) {
+          expect(() =>
+            enforceCodeGraphBenchmarkRatchet(
+              sandwichCandidate({
+                [registrationName]: 319.786313,
+                ...(role === 'repeat' ? {[name]: upperBound! + delta} : {}),
+              }),
+              registrationRatchet,
+              sandwichEvidence(
+                {[registrationName]: 966.326097, ...(role === 'initial' ? {[name]: upperBound! + delta} : {})},
+                registrationEvidence.artifact,
+              ),
+            ),
+          ).toThrow(new RegExp(`${role === 'initial' ? 'initial' : 'remeasured'} candidate ${name}`));
+        }
       }),
       {numRuns: 30},
     );


### PR DESCRIPTION
The production ratchet retained an initial registration screening miss even though its protected-base control and confirmatory candidate passed the static limit, because the metric also has a separate hard objective. Apply screening clearance after the existing hard-objective checks. Every observation must still meet its hard objective, and objective-bearing metrics remain ineligible for confirmatory tail tolerance.

The original #405 CI payloads reproduce the reported `966.326097 > 888 ms` failure before the fix and pass afterward with the same ratchet and exact commits. The calibration record documents the policy clarification and payload digests.

Validation:
- 50 focused tests pass across release evidence, production gate arguments, and paired-wall calibration.
- Bounded properties cover all nine hard-objective wall metrics, inclusive objective boundaries, objective failures in every observation, strict confirmatory tails, and CPU/RSS/work/storage/structural failures in either candidate.
- Regression checks preserve commit, runner, fixture, and timestamp provenance requirements.
- Lint, formatting, source/test/site typechecks, and original-artifact replay pass. Full suite remains delegated to PR CI.

Fixes #406
