### PR TITLE
Reduce parser-fact serialization work without changing graph budgets

### DIFF
--- a/src/code_graph/fact_budget.ts
+++ b/src/code_graph/fact_budget.ts
@@ -141,6 +141,13 @@ export function budgetCachedCodeGraphFacts(
   if (cachedCodeGraphFactByteUpperBound(compacted) <= maximumBytes) return compacted;
   if (cachedCodeGraphFactBytes(compacted) <= maximumBytes) return compacted;
 
+  return selectCachedCodeGraphFactsWithinBudget(compacted, maximumBytes);
+}
+
+function selectCachedCodeGraphFactsWithinBudget(
+  compacted: CodeGraphFileFacts,
+  maximumBytes: number,
+): CodeGraphFileFacts {
   const symbolsById = new Map<string, CodeGraphSymbol>();
   for (const symbol of compacted.symbols) {
     if (symbolsById.has(symbol.id)) continue;
@@ -438,7 +445,13 @@ function measureBoundedCodeGraphFactWithJson(
   facts: CodeGraphFileFacts,
   maximumBytes: number,
 ): {readonly bytes: number; readonly facts: CodeGraphFileFacts; readonly json: string} {
-  const bounded = budgetCachedCodeGraphFacts(facts, maximumBytes);
+  const compacted = budgetCodeGraphReferenceCandidates(compactCachedFileRelationships(facts));
+  // This boundary needs JSON anyway: reuse its exact bytes instead of walking
+  // every property first to calculate a conservative serialization upper bound.
+  const compactedJson = JSON.stringify(compacted);
+  const compactedBytes = cachedFactEncoder.encode(compactedJson).byteLength;
+  if (compactedBytes <= maximumBytes) return {bytes: compactedBytes, facts: compacted, json: compactedJson};
+  const bounded = selectCachedCodeGraphFactsWithinBudget(compacted, maximumBytes);
   const json = JSON.stringify(bounded);
   return {bytes: cachedFactEncoder.encode(json).byteLength, facts: bounded, json};
 }

--- a/test/unit/code-graph.fact-storage.property.test.ts
+++ b/test/unit/code-graph.fact-storage.property.test.ts
@@ -6,7 +6,8 @@ import {
   decodeStoredCodeGraphFact,
   encodeStoredCodeGraphFact,
 } from '../../src/code_graph/fact_storage.js';
-import {serializeBoundedCodeGraphFact} from '../../src/code_graph/fact_budget.js';
+import {budgetCachedCodeGraphFacts, serializeBoundedCodeGraphFact} from '../../src/code_graph/fact_budget.js';
+import {parseCodeGraphFileFacts} from '../../src/code_graph/fact_validation.js';
 import {sha256HexSync} from '../../src/crypto/sha256.js';
 import type {CodeGraphFileFacts} from '../../src/code_graph/types.js';
 
@@ -34,6 +35,41 @@ const repositoryTextArbitrary = fc
   .map(codeUnits => String.fromCharCode(...codeUnits));
 
 describe('compact code graph fact storage', () => {
+  it('matches independent budgeting across exact UTF-8 boundaries without mutating or reordering facts', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.constantFrom('a', '"', '\\', '\0', '\n', 'é', '漢', '🙂', '\ud800'), {maxLength: 160}),
+        fc.integer({min: 128, max: 4_096}),
+        fc.boolean(),
+        (characters, ceiling, duplicates) => {
+          const base = richFacts();
+          const documentation = characters.join('');
+          const facts: CodeGraphFileFacts = {
+            ...base,
+            diagnostics: [documentation],
+            edges: duplicates ? [...base.edges, ...base.edges] : base.edges,
+            references: duplicates ? [...base.references!, ...base.references!] : base.references,
+            symbols: base.symbols.map(symbol => ({...symbol, documentation})),
+          };
+          const before = structuredClone(facts);
+          const parsed = parseCodeGraphFileFacts(facts);
+          const exact = factEncoder.encode(JSON.stringify(budgetCachedCodeGraphFacts(parsed))).byteLength;
+          for (const maximumBytes of [ceiling, exact - 1, exact, exact + 1]) {
+            const expected = budgetCachedCodeGraphFacts(parsed, maximumBytes);
+            const actual = serializeBoundedCodeGraphFact(facts, maximumBytes);
+            expect(actual.facts).toEqual(expected);
+            expect(actual.json).toBe(JSON.stringify(expected));
+            expect(actual.bytes).toBe(factEncoder.encode(actual.json).byteLength);
+            expect(actual.bytes).toBeLessThanOrEqual(maximumBytes);
+            expect(serializeBoundedCodeGraphFact(actual.facts, maximumBytes).json).toBe(actual.json);
+          }
+          expect(facts).toEqual(before);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
   it('round-trips legacy and compact rows deterministically without mutating facts', () => {
     fc.assert(
       fc.property(factArbitrary, facts => {


### PR DESCRIPTION
Parser-fact serialization walked every property to estimate an upper byte bound, then serialized the same facts to compute exact bytes. The JSON-requiring path now measures once and reuses that JSON when it fits; oversized facts use the unchanged priority/closure selector. The budget-only API retains its allocation-light fast path.

This addresses #404 by reducing work inside the existing serialization timer without changing production thresholds, hard objectives, timing boundaries, structural parity, or resource checks. Replaying the reported Linux artifacts reproduces the original failure, including the failing protected-main control. That evidence alone does not identify the runner slowdown's cause.

Validation: 57 focused fact-budget, storage, cache-coalescer, source-verification, and project-closure tests pass; lint and source/test/site typechecks pass. A bounded property compares serialization with the existing budgeting API across exact UTF-8 boundaries, Unicode/escaping, duplicate relationships, idempotence, and non-mutation. Independent review found no blocking issues. Exact-HEAD local 3,000-file/110,000-symbol production profiles measured cold serialization 1,875.73 → 1,454.91 ms (-22.4%) and reference serialization 1,853.03 → 1,393.83 ms (-24.8%), with primary-query and full structural-digest parity retained. These are n=1 macOS diagnostics, not Linux gate evidence or an overall indexing speed claim: cold-index wall time varied 79.77 → 101.23 s under concurrent local work. Both baseline b6563f63 and candidate 77436ba8 were installed and doctor-verified at exact HEAD. The candidate's globally installed CLI indexed a synthetic Unicode repository and found the expected serializer symbol and caller relationship. The governed Linux run 34272972500 passed the unchanged static ratchet on the initial candidate: cold serialization 2,829.06 ms < 4,960 ms and reference serialization 2,822.69 ms < 5,286 ms. Full-suite CI is still completing.

Fixes #404.
