### PR TITLE
fix: recover deferred backlinks within the first Context Brief

### DIFF
--- a/src/context_brief/memory_evidence.ts
+++ b/src/context_brief/memory_evidence.ts
@@ -3,7 +3,10 @@ import {resolveRepositoryIdentity} from '../code_graph/repository.js';
 import {sha256HexSync} from '../crypto/sha256.js';
 import {readMemoryRecordsByUri} from '../memory/index.js';
 import {captureMemoryCodeCitations, MemoryCodeCitationCaptureError} from '../memory/code_citation_capture.js';
-import {finalizeDeferredCodeAnchorsForRoute} from '../memory/deferred_code_anchor.js';
+import {
+  finalizeDeferredCodeAnchorsForRoute,
+  type DeferredCodeAnchorRouteFinalizationReceiptV1,
+} from '../memory/deferred_code_anchor.js';
 import type {MemoryRecord} from '../memory/document.js';
 import {isMemoryId} from '../memory/identity_alias.js';
 import {uriSegment} from '../manifest.js';
@@ -28,6 +31,7 @@ import type {
 const MEMORY_EXCERPT_BYTES = 240;
 const MEMORY_RETRIEVAL_MULTIPLIER = 4;
 const CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_FINALIZE_LIMIT = 4;
+const CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_FINALIZE_PASSES = 2;
 const CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_WAIT_MILLISECONDS = 1_000;
 const CONTEXT_BRIEF_CODE_ANCHOR_READ_RETRIES = 2;
 const CONTEXT_BRIEF_CODE_ANCHOR_RETRY_MILLISECONDS = 25;
@@ -144,7 +148,14 @@ export const retrieveContextBriefMemoryEvidence = Effect.fn('contextBrief.retrie
 
 /** Resolve explicit local anchors against ready-current code and retrieve their private citation backlinks. */
 export const retrieveContextBriefCodeLinkedMemoryEvidence = Effect.fn('contextBrief.retrieveCodeLinkedMemoryEvidence')(
-  function* (config: RuntimeConfig, plan: ContextBriefPlanV1['codeAnchors']) {
+  function* (
+    config: RuntimeConfig,
+    plan: ContextBriefPlanV1['codeAnchors'],
+    options: {
+      /** @internal Privacy-safe receipts for diagnosing first-read recovery. */
+      readonly onFinalizationReceipt?: (receipt: DeferredCodeAnchorRouteFinalizationReceiptV1) => void;
+    } = {},
+  ) {
     const requested = plan.codeRefs.length;
     if (requested === 0) {
       return {
@@ -223,38 +234,62 @@ export const retrieveContextBriefCodeLinkedMemoryEvidence = Effect.fn('contextBr
     const resolvedOrdinals = resolvedAnchors.map(anchor => anchor.anchorOrdinal);
     const identity = yield* resolveRepositoryIdentity(callerCwd).pipe(Effect.option);
     const attemptedUris: string[] = [];
+    let finalizationUnavailable = false;
+    let refreshAfterContention = false;
     if (identity._tag === 'Some') {
-      yield* withCodeAnchorFinalizationAnonymousTelemetry(
-        'context-brief',
-        finalizeDeferredCodeAnchorsForRoute(
-          config,
-          {
-            callerCwd,
-            kind: 'repository',
-            repositoryId: identity.value.repositoryId,
-            worktreeId: identity.value.worktreeId,
-          },
-          {
-            limit: CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_FINALIZE_LIMIT,
-            onAttemptedUri: uri => {
-              attemptedUris.push(uri);
+      let remainingLimit = CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_FINALIZE_LIMIT;
+      for (let pass = 0; pass < CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_FINALIZE_PASSES; pass++) {
+        const previousAttemptCount = attemptedUris.length;
+        const receipt = yield* withCodeAnchorFinalizationAnonymousTelemetry(
+          'context-brief',
+          finalizeDeferredCodeAnchorsForRoute(
+            config,
+            {
+              callerCwd,
+              kind: 'repository',
+              repositoryId: identity.value.repositoryId,
+              worktreeId: identity.value.worktreeId,
             },
-            preferredCodeRefs: plan.codeRefs,
-            waitTimeoutMilliseconds: CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_WAIT_MILLISECONDS,
-          },
-        ),
-      ).pipe(
-        Effect.catchCause(() => Effect.void),
-        Effect.asVoid,
-      );
+            {
+              limit: remainingLimit,
+              onAttemptedUri: uri => {
+                attemptedUris.push(uri);
+              },
+              preferredCodeRefs: plan.codeRefs,
+              waitTimeoutMilliseconds: CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_WAIT_MILLISECONDS,
+            },
+          ),
+        ).pipe(
+          Effect.asSome,
+          Effect.catchCause(() => Effect.succeedNone),
+        );
+        finalizationUnavailable = receipt._tag === 'None' || receipt.value.state !== 'completed';
+        if (receipt._tag === 'None') break;
+        yield* Effect.sync(() => options.onFinalizationReceipt?.(receipt.value)).pipe(Effect.ignoreCause);
+        // Admission is counted even if the deadline interrupted the attempt
+        // before it produced a completed-item receipt.
+        remainingLimit -= Math.max(receipt.value.scannedCount, attemptedUris.length - previousAttemptCount);
+        // Another owner can commit without invoking our attempted-URI hook.
+        refreshAfterContention ||= receipt.value.state === 'contended';
+        // Retry a deadline before admission or a contended route once, with
+        // the same per-pass deadline and remaining admitted-memory budget.
+        if (
+          receipt.value.state !== 'contended' ||
+          receipt.value.pendingCount > 0 ||
+          receipt.value.failedCount > 0 ||
+          remainingLimit <= 0
+        )
+          break;
+      }
     }
-    const forceRecallRefresh =
+    const invalidationFailed =
       attemptedUris.length === 0
         ? false
         : yield* expireRecallIndexValidation(config.agentContextHome, false, attemptedUris).pipe(
             Effect.as(false),
             Effect.catchCause(() => Effect.succeed(true)),
           );
+    const forceRecallRefresh = refreshAfterContention || invalidationFailed;
     let truncatedSelectorCount = 0;
     const linked = yield* loadRecallCodeLinks(config, {
       allowedUriScopes: [contextBriefMemoryUriScope(config.user)],
@@ -310,7 +345,10 @@ export const retrieveContextBriefCodeLinkedMemoryEvidence = Effect.fn('contextBr
       candidates,
       consideredCandidates: linked.value.length,
       gaps: stableUnique([
-        ...contextBriefCodeLinkRecallGaps(complete, candidates.length, truncatedSelectorCount),
+        ...contextBriefCodeLinkRecallGaps(complete, candidates.length, truncatedSelectorCount).filter(
+          gap => !finalizationUnavailable || gap !== 'code-anchor-recall-no-active-memory',
+        ),
+        ...(finalizationUnavailable ? ['code-anchor-recall-unavailable'] : []),
         ...(captureUnavailable ? ['code-anchor-resolution-unavailable'] : []),
         ...(readCandidates.stableIdentityUnavailable ? ['stable-memory-identity-unavailable'] : []),
       ]),

--- a/src/context_brief/memory_evidence.ts
+++ b/src/context_brief/memory_evidence.ts
@@ -234,7 +234,7 @@ export const retrieveContextBriefCodeLinkedMemoryEvidence = Effect.fn('contextBr
     const resolvedOrdinals = resolvedAnchors.map(anchor => anchor.anchorOrdinal);
     const identity = yield* resolveRepositoryIdentity(callerCwd).pipe(Effect.option);
     const attemptedUris: string[] = [];
-    let finalizationUnavailable = false;
+    let finalizationUnavailable = identity._tag === 'None';
     let refreshAfterContention = false;
     if (identity._tag === 'Some') {
       let remainingLimit = CONTEXT_BRIEF_DEFERRED_CODE_ANCHOR_FINALIZE_LIMIT;

--- a/test/integration/context-brief-deferred-autoheal.test.ts
+++ b/test/integration/context-brief-deferred-autoheal.test.ts
@@ -1,5 +1,5 @@
 import {it as effectIt} from '@effect/vitest';
-import {Effect, FileSystem, Path} from 'effect';
+import {Deferred, Effect, Fiber, FileSystem, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {describe, expect} from 'vitest';
 import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
@@ -11,6 +11,7 @@ import {ApplicationLayer} from '../../src/effect/runtime.js';
 import {
   isDeferredCodeAnchorIntentFilename,
   stageDeferredCodeAnchorIntent,
+  type DeferredCodeAnchorRouteFinalizationReceiptV1,
 } from '../../src/memory/deferred_code_anchor.js';
 import {MEMORY_SCHEMA_VERSION} from '../../src/memory/code_citation.js';
 import {formatMemoryDocument, parseMemoryDocument, type MemoryMetadata} from '../../src/memory/document.js';
@@ -18,148 +19,187 @@ import type {RuntimeConfig} from '../../src/types.js';
 import {provideTestLayer} from '../helpers/effect-layer.js';
 
 describe('Context Brief deferred code-anchor recovery', () => {
-  effectIt.effect(
-    'returns the backlink in the first brief after a direct graph publication bypassed the CLI hook',
-    () =>
-      Effect.scoped(
-        Effect.gen(function* () {
-          const fs = yield* FileSystem.FileSystem;
-          const path = yield* Path.Path;
-          const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-context-brief-autoheal-'});
-          const repository = path.join(root, 'repository');
-          const home = path.join(root, 'home');
-          const manifestPath = path.join(home, 'seed-manifest.yaml');
-          yield* fs.makeDirectory(path.join(repository, 'src'), {recursive: true});
-          yield* fs.makeDirectory(home, {recursive: true});
-          yield* fs.writeFileString(
-            path.join(repository, 'src', 'index.ts'),
-            'export function deferredBacklinkTarget(): string { return "ready"; }\n',
-          );
-          yield* fs.writeFileString(path.join(repository, 'package.json'), '{"name":"autoheal-fixture"}\n');
-          yield* fs.writeFileString(manifestPath, 'version: 1\nprojects: []\n');
-          yield* runCommandEffect('git', ['init', '--quiet'], {cwd: repository});
-          yield* runCommandEffect('git', ['add', '.'], {cwd: repository});
-          yield* runCommandEffect(
-            'git',
-            [
-              '-c',
-              'user.name=Threadnote Test',
-              '-c',
-              'user.email=test@threadnote.local',
-              'commit',
-              '--quiet',
-              '--message',
-              'fixture',
-            ],
-            {cwd: repository},
-          );
+  for (const interruptFirstAdmission of [false, true]) {
+    effectIt.effect(
+      interruptFirstAdmission
+        ? 'recovers a pre-write deadline in the first brief after direct graph publication'
+        : 'returns the backlink in the first brief after a direct graph publication bypassed the CLI hook',
+      () =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-context-brief-autoheal-'});
+            const repository = path.join(root, 'repository');
+            const home = path.join(root, 'home');
+            const manifestPath = path.join(home, 'seed-manifest.yaml');
+            yield* fs.makeDirectory(path.join(repository, 'src'), {recursive: true});
+            yield* fs.makeDirectory(home, {recursive: true});
+            yield* fs.writeFileString(
+              path.join(repository, 'src', 'index.ts'),
+              'export function deferredBacklinkTarget(): string { return "ready"; }\n',
+            );
+            yield* fs.writeFileString(path.join(repository, 'package.json'), '{"name":"autoheal-fixture"}\n');
+            yield* fs.writeFileString(manifestPath, 'version: 1\nprojects: []\n');
+            yield* runCommandEffect('git', ['init', '--quiet'], {cwd: repository}).pipe(TestClock.withLive);
+            yield* runCommandEffect('git', ['add', '.'], {cwd: repository}).pipe(TestClock.withLive);
+            yield* runCommandEffect(
+              'git',
+              [
+                '-c',
+                'user.name=Threadnote Test',
+                '-c',
+                'user.email=test@threadnote.local',
+                'commit',
+                '--quiet',
+                '--message',
+                'fixture',
+              ],
+              {cwd: repository},
+            ).pipe(TestClock.withLive);
 
-          const config: RuntimeConfig = {
-            account: 'local',
-            agentContextHome: home,
-            agentId: 'threadnote',
-            manifestPath,
-            user: 'tester',
-          };
-          const memoryUri = 'threadnote://user/tester/memories/durable/projects/threadnote/context-brief-autoheal.md';
-          const metadata: MemoryMetadata = {
-            kind: 'durable',
-            memoryId: 'tn_context_brief_autoheal',
-            project: 'threadnote',
-            schemaVersion: MEMORY_SCHEMA_VERSION,
-            sourceAgentClient: 'test',
-            status: 'active',
-            timestamp: '2026-08-30T00:00:00.000Z',
-            topic: 'context-brief-autoheal',
-            visibility: 'personal',
-          };
-          const body = 'The deferred backlink must appear in the first post-ready Context Brief.';
-          const content = formatMemoryDocument('MEMORY', metadata, body);
-          yield* stageDeferredCodeAnchorIntent(config, {
-            memoryContent: content,
-            memoryMetadata: metadata,
-            memoryUri,
-            request: {
-              callerCwd: repository,
-              codeRefs: ['src/index.ts'],
-              recovery: {
-                code: 'ready-graph-unavailable',
-                indexingStarted: false,
-                observedGraph: {freshness: 'stale', readySnapshot: 'absent', stale: true},
-                preparation: {
-                  action: 'index-current-graph',
-                  arguments: [],
-                  command: 'threadnote graph index --no-vectors',
-                  target: 'callerCwd',
+            const config: RuntimeConfig = {
+              account: 'local',
+              agentContextHome: home,
+              agentId: 'threadnote',
+              manifestPath,
+              user: 'tester',
+            };
+            const memoryUri = 'threadnote://user/tester/memories/durable/projects/threadnote/context-brief-autoheal.md';
+            const metadata: MemoryMetadata = {
+              kind: 'durable',
+              memoryId: 'tn_context_brief_autoheal',
+              project: 'threadnote',
+              schemaVersion: MEMORY_SCHEMA_VERSION,
+              sourceAgentClient: 'test',
+              status: 'active',
+              timestamp: '2026-08-30T00:00:00.000Z',
+              topic: 'context-brief-autoheal',
+              visibility: 'personal',
+            };
+            const body = 'The deferred backlink must appear in the first post-ready Context Brief.';
+            const content = formatMemoryDocument('MEMORY', metadata, body);
+            yield* stageDeferredCodeAnchorIntent(config, {
+              memoryContent: content,
+              memoryMetadata: metadata,
+              memoryUri,
+              request: {
+                callerCwd: repository,
+                codeRefs: ['src/index.ts'],
+                recovery: {
+                  code: 'ready-graph-unavailable',
+                  indexingStarted: false,
+                  observedGraph: {freshness: 'stale', readySnapshot: 'absent', stale: true},
+                  preparation: {
+                    action: 'index-current-graph',
+                    arguments: [],
+                    command: 'threadnote graph index --no-vectors',
+                    target: 'callerCwd',
+                  },
+                  recovery: 'prepare-current-graph',
+                  retryCondition: 'after-current-graph-ready',
+                  retryable: true,
+                  type: 'memory-code-citation-capture-recovery',
+                  version: 1,
                 },
-                recovery: 'prepare-current-graph',
-                retryCondition: 'after-current-graph-ready',
-                retryable: true,
-                type: 'memory-code-citation-capture-recovery',
-                version: 1,
               },
-            },
-          });
-          const store = yield* ResourceStore;
-          const location = {account: config.account, home, user: config.user} as const;
-          yield* store.write(location, memoryUri, content, {mode: 'create'});
-          // The service-level indexer deliberately bypasses the CLI graph-index
-          // opportunity, leaving the consumer-side missed-wakeup fallback to prove.
-          const indexer = yield* CodeGraphIndexer;
-          yield* indexer.index({cwd: repository, ensureVectors: false, threadnoteHome: home});
-          const pendingRoot = path.join(
-            home,
-            'data',
-            'local',
-            'user',
-            'tester',
-            'private',
-            'deferred-code-anchors',
-            'v1',
-          );
-          expect(
-            (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
-              isDeferredCodeAnchorIntentFilename(path.basename(name)),
-            ),
-          ).toHaveLength(1);
+            });
+            const store = yield* ResourceStore;
+            const location = {account: config.account, home, user: config.user} as const;
+            yield* store.write(location, memoryUri, content, {mode: 'create'});
+            // The service-level indexer deliberately bypasses the CLI graph-index
+            // opportunity, leaving the consumer-side missed-wakeup fallback to prove.
+            const indexer = yield* CodeGraphIndexer;
+            yield* indexer
+              .index({cwd: repository, ensureVectors: false, threadnoteHome: home})
+              .pipe(TestClock.withLive);
+            const pendingRoot = path.join(
+              home,
+              'data',
+              'local',
+              'user',
+              'tester',
+              'private',
+              'deferred-code-anchors',
+              'v1',
+            );
+            expect(
+              (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
+                isDeferredCodeAnchorIntentFilename(path.basename(name)),
+              ),
+            ).toHaveLength(1);
 
-          const plan = planContextBrief({
-            codeRefs: ['src/index.ts'],
-            scope: {callerCwd: repository, kind: 'repository'},
-            task: 'Find the decision attached to deferredBacklinkTarget.',
-          });
-          const first = yield* retrieveContextBriefCodeLinkedMemoryEvidence(config, plan.codeAnchors);
-          expect(first.codeAnchorCoverage).toEqual({complete: true, matchedMemories: 1, requested: 1, resolved: 1});
-          expect(first.candidates).toMatchObject([
-            {
-              codeLinkMatches: [{anchorOrdinal: 0, anchorPath: 'src/index.ts', matchKind: 'file-path'}],
-              uri: memoryUri,
-            },
-          ]);
-          expect(
-            (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
-              isDeferredCodeAnchorIntentFilename(path.basename(name)),
-            ),
-          ).toEqual([]);
-          const finalized = parseMemoryDocument(memoryUri, yield* store.read(location, memoryUri));
-          expect(finalized?.body).toBe(body);
-          expect(finalized?.metadata).toMatchObject({
-            codeCitations: [{path: 'src/index.ts'}],
-            memoryId: metadata.memoryId,
-            status: metadata.status,
-            timestamp: metadata.timestamp,
-            visibility: metadata.visibility,
-          });
+            const plan = planContextBrief({
+              codeRefs: ['src/index.ts'],
+              scope: {callerCwd: repository, kind: 'repository'},
+              task: 'Find the decision attached to deferredBacklinkTarget.',
+            });
+            const entered = yield* Deferred.make<void>();
+            let interruptedAdmission = false;
+            const contendedStore = ResourceStore.of({
+              ...store,
+              read: (location, uri) =>
+                Effect.suspend(() => {
+                  if (interruptFirstAdmission && !interruptedAdmission && uri === memoryUri) {
+                    interruptedAdmission = true;
+                    return Deferred.succeed(entered, undefined).pipe(Effect.andThen(Effect.never));
+                  }
+                  return store.read(location, uri);
+                }),
+            });
+            const receipts: DeferredCodeAnchorRouteFinalizationReceiptV1[] = [];
+            const firstFiber = yield* retrieveContextBriefCodeLinkedMemoryEvidence(config, plan.codeAnchors, {
+              onFinalizationReceipt: receipt => {
+                receipts.push(receipt);
+              },
+            }).pipe(Effect.provideService(ResourceStore, contendedStore), Effect.forkScoped);
+            if (interruptFirstAdmission) {
+              yield* Deferred.await(entered);
+              yield* TestClock.adjust('750 millis');
+            }
+            const first = yield* Fiber.join(firstFiber);
+            // Count/state-only receipts retain the failed boundary without exposing memory content or locators.
+            expect(first.codeAnchorCoverage, JSON.stringify(receipts)).toEqual({
+              complete: true,
+              matchedMemories: 1,
+              requested: 1,
+              resolved: 1,
+            });
+            expect(receipts.map(receipt => receipt.state)).toEqual(
+              interruptFirstAdmission ? ['contended', 'completed'] : ['completed'],
+            );
+            expect(first.gaps).not.toContain('code-anchor-recall-unavailable');
+            expect(first.candidates).toMatchObject([
+              {
+                codeLinkMatches: [{anchorOrdinal: 0, anchorPath: 'src/index.ts', matchKind: 'file-path'}],
+                uri: memoryUri,
+              },
+            ]);
+            expect(
+              (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
+                isDeferredCodeAnchorIntentFilename(path.basename(name)),
+              ),
+            ).toEqual([]);
+            const finalized = parseMemoryDocument(memoryUri, yield* store.read(location, memoryUri));
+            expect(finalized?.body).toBe(body);
+            expect(finalized?.metadata).toMatchObject({
+              codeCitations: [{path: 'src/index.ts'}],
+              memoryId: metadata.memoryId,
+              status: metadata.status,
+              timestamp: metadata.timestamp,
+              visibility: metadata.visibility,
+            });
 
-          const second = yield* retrieveContextBriefCodeLinkedMemoryEvidence(config, plan.codeAnchors);
-          expect(second.candidates.map(candidate => candidate.uri)).toEqual([memoryUri]);
-          expect(
-            (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
-              isDeferredCodeAnchorIntentFilename(path.basename(name)),
-            ),
-          ).toEqual([]);
-        }),
-      ).pipe(provideTestLayer(ApplicationLayer), TestClock.withLive),
-    60_000,
-  );
+            const second = yield* retrieveContextBriefCodeLinkedMemoryEvidence(config, plan.codeAnchors);
+            expect(second.candidates.map(candidate => candidate.uri)).toEqual([memoryUri]);
+            expect(
+              (yield* fs.readDirectory(pendingRoot, {recursive: true})).filter(name =>
+                isDeferredCodeAnchorIntentFilename(path.basename(name)),
+              ),
+            ).toEqual([]);
+          }),
+        ).pipe(provideTestLayer(ApplicationLayer)),
+      60_000,
+    );
+  }
 });

--- a/test/unit/context-brief-memory-recovery.test.ts
+++ b/test/unit/context-brief-memory-recovery.test.ts
@@ -72,10 +72,10 @@ describe('Context Brief code-linked memory recovery', () => {
     mocks.loadRecallMemoryIdentities.mockReturnValue(Effect.succeed([]));
     mocks.readMemoryRecordsByUri.mockReturnValue(Effect.succeed([]));
     mocks.resolveRepositoryIdentity.mockReturnValue(
-      Effect.fail(TestError.make({message: 'identity intentionally unavailable'})),
+      Effect.succeed({repositoryId: 'a'.repeat(64), worktreeId: 'b'.repeat(64)}),
     );
     mocks.expireRecallIndexValidation.mockReturnValue(Effect.void);
-    mocks.finalizeDeferredCodeAnchorsForRoute.mockReturnValue(Effect.void);
+    mocks.finalizeDeferredCodeAnchorsForRoute.mockReturnValue(Effect.succeed(finalizationReceipt('completed', 0)));
     mocks.withCodeAnchorFinalizationAnonymousTelemetry.mockImplementation(
       (_route: string, effect: Effect.Effect<unknown, unknown, unknown>) => effect,
     );
@@ -194,6 +194,30 @@ describe('Context Brief code-linked memory recovery', () => {
         );
         expect(empty.gaps).toEqual(['code-anchor-recall-unavailable']);
       }),
+  );
+
+  effectIt.effect('reports unavailable recovery when repository identity cannot be observed after anchor capture', () =>
+    Effect.gen(function* () {
+      mocks.resolveRepositoryIdentity.mockReturnValue(Effect.fail(TestError.make({message: 'identity unavailable'})));
+      const citation = codeCitation('src/first.ts');
+      mocks.loadRecallCodeLinks.mockReturnValue(
+        Effect.succeed([{anchorOrdinal: 0, citationId: citation.id, matchKind: 'file-path', uri: MEMORY_URI}]),
+      );
+      mocks.readMemoryRecordsByUri.mockReturnValue(Effect.succeed([memoryRecord(citation)]));
+      const result = yield* contextBriefRecoveryTestEffect(
+        retrieveContextBriefCodeLinkedMemoryEvidence(CONFIG, codeAnchorPlan(['src/first.ts'])),
+      );
+      expect(result.codeAnchorCoverage).toMatchObject({requested: 1, resolved: 1, matchedMemories: 1});
+      expect(result.candidates.map(candidate => candidate.uri)).toEqual([MEMORY_URI]);
+      expect(result.gaps).toContain('code-anchor-recall-unavailable');
+      expect(mocks.finalizeDeferredCodeAnchorsForRoute).not.toHaveBeenCalled();
+      mocks.loadRecallCodeLinks.mockReturnValue(Effect.succeed([]));
+      mocks.readMemoryRecordsByUri.mockReturnValue(Effect.succeed([]));
+      const empty = yield* contextBriefRecoveryTestEffect(
+        retrieveContextBriefCodeLinkedMemoryEvidence(CONFIG, codeAnchorPlan(['src/first.ts'])),
+      );
+      expect(empty.gaps).toEqual(['code-anchor-recall-unavailable']);
+    }),
   );
 
   effectIt.effect('preserves resolved anchor ordinals when canonical memory reads fail after capture', () =>

--- a/test/unit/context-brief-memory-recovery.test.ts
+++ b/test/unit/context-brief-memory-recovery.test.ts
@@ -1,8 +1,10 @@
 import {it as effectIt} from '@effect/vitest';
 import {Effect, Result} from 'effect';
 import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
 import {beforeEach, describe, expect, vi} from 'vitest';
 import type {MemoryCodeCitationV1} from '../../src/memory/code_citation.js';
+import type {DeferredCodeAnchorRouteFinalizationReceiptV1} from '../../src/memory/deferred_code_anchor.js';
 import type {MemoryRecord} from '../../src/memory/document.js';
 import type {RuntimeConfig} from '../../src/types.js';
 import type {ContextBriefPlanV1} from '../../src/context_brief/types.js';
@@ -78,6 +80,121 @@ describe('Context Brief code-linked memory recovery', () => {
       (_route: string, effect: Effect.Effect<unknown, unknown, unknown>) => effect,
     );
   });
+
+  effectIt.effect.prop(
+    'bounds contention recovery to two passes and four admissions while retaining unavailable evidence',
+    {
+      completedBeforeInterruption: fc.integer({min: 0, max: 4}),
+      interruptedAdmission: fc.boolean(),
+      stillContended: fc.boolean(),
+    },
+    ({completedBeforeInterruption, interruptedAdmission, stillContended}) =>
+      Effect.gen(function* () {
+        mocks.resolveRepositoryIdentity.mockReturnValue(
+          Effect.succeed({repositoryId: 'a'.repeat(64), worktreeId: 'b'.repeat(64)}),
+        );
+        const limits: number[] = [];
+        let totalAdmissions = 0;
+        const firstAdmissions = Math.min(4, completedBeforeInterruption + Number(interruptedAdmission));
+        mocks.finalizeDeferredCodeAnchorsForRoute.mockImplementation(
+          (
+            _config: RuntimeConfig,
+            _route: unknown,
+            options: {readonly limit: number; readonly onAttemptedUri: (uri: string) => void},
+          ) =>
+            Effect.sync(() => {
+              limits.push(options.limit);
+              const admissions = limits.length === 1 ? firstAdmissions : options.limit;
+              for (let index = 0; index < admissions; index++) {
+                options.onAttemptedUri(MEMORY_URI);
+                totalAdmissions++;
+              }
+              return limits.length === 1
+                ? finalizationReceipt('contended', completedBeforeInterruption)
+                : finalizationReceipt(stillContended ? 'contended' : 'completed', admissions - Number(stillContended));
+            }),
+        );
+        const receipts: DeferredCodeAnchorRouteFinalizationReceiptV1[] = [];
+        const result = yield* contextBriefRecoveryTestEffect(
+          retrieveContextBriefCodeLinkedMemoryEvidence(CONFIG, codeAnchorPlan(['src/first.ts']), {
+            onFinalizationReceipt: receipt => {
+              receipts.push(receipt);
+            },
+          }),
+        );
+        expect(limits).toEqual(firstAdmissions < 4 ? [4, 4 - firstAdmissions] : [4]);
+        expect(totalAdmissions).toBeLessThanOrEqual(4);
+        expect(receipts.reduce((count, receipt) => count + receipt.scannedCount, 0)).toBeLessThanOrEqual(4);
+        expect(result.codeAnchorCoverage).toMatchObject({requested: 1, resolved: 1});
+        expect(result.gaps.includes('code-anchor-recall-unavailable')).toBe(firstAdmissions === 4 || stillContended);
+        expect(mocks.loadRecallCodeLinks).toHaveBeenLastCalledWith(
+          CONFIG,
+          expect.objectContaining({
+            forceRefresh: true,
+          }),
+        );
+      }),
+    {fastCheck: {numRuns: 20}},
+  );
+
+  effectIt.effect('does not retry pending graph readiness or a failed finalization and preserves recall', () =>
+    Effect.gen(function* () {
+      mocks.resolveRepositoryIdentity.mockReturnValue(
+        Effect.succeed({repositoryId: 'a'.repeat(64), worktreeId: 'b'.repeat(64)}),
+      );
+      for (const field of ['pendingCount', 'failedCount'] as const) {
+        let passes = 0;
+        mocks.finalizeDeferredCodeAnchorsForRoute.mockImplementation(() =>
+          Effect.sync(() => {
+            passes++;
+            return {...finalizationReceipt('contended', 0), [field]: 1, scannedCount: 1};
+          }),
+        );
+        const result = yield* contextBriefRecoveryTestEffect(
+          retrieveContextBriefCodeLinkedMemoryEvidence(CONFIG, codeAnchorPlan(['src/first.ts'])),
+        );
+        expect(passes).toBe(1);
+        expect(result.gaps).toContain('code-anchor-recall-unavailable');
+        expect(mocks.loadRecallCodeLinks).toHaveBeenLastCalledWith(
+          CONFIG,
+          expect.objectContaining({forceRefresh: true}),
+        );
+      }
+      mocks.finalizeDeferredCodeAnchorsForRoute.mockReturnValue(Effect.die('finalizer unavailable'));
+      const failed = yield* contextBriefRecoveryTestEffect(
+        retrieveContextBriefCodeLinkedMemoryEvidence(CONFIG, codeAnchorPlan(['src/first.ts'])),
+      );
+      expect(failed.gaps).toContain('code-anchor-recall-unavailable');
+    }),
+  );
+
+  effectIt.effect(
+    'retains existing backlinks when deferred recovery fails and never presents unknown absence as empty',
+    () =>
+      Effect.gen(function* () {
+        mocks.resolveRepositoryIdentity.mockReturnValue(
+          Effect.succeed({repositoryId: 'a'.repeat(64), worktreeId: 'b'.repeat(64)}),
+        );
+        mocks.finalizeDeferredCodeAnchorsForRoute.mockReturnValue(Effect.succeed(finalizationReceipt('failed', 0)));
+        const citation = codeCitation('src/first.ts');
+        mocks.loadRecallCodeLinks.mockReturnValue(
+          Effect.succeed([{anchorOrdinal: 0, citationId: citation.id, matchKind: 'file-path', uri: MEMORY_URI}]),
+        );
+        mocks.readMemoryRecordsByUri.mockReturnValue(Effect.succeed([memoryRecord(citation)]));
+        const result = yield* contextBriefRecoveryTestEffect(
+          retrieveContextBriefCodeLinkedMemoryEvidence(CONFIG, codeAnchorPlan(['src/first.ts'])),
+        );
+        expect(result.candidates.map(candidate => candidate.uri)).toEqual([MEMORY_URI]);
+        expect(result.gaps).toContain('code-anchor-recall-unavailable');
+        expect(result.gaps).not.toContain('code-anchor-recall-no-active-memory');
+        mocks.loadRecallCodeLinks.mockReturnValue(Effect.succeed([]));
+        mocks.readMemoryRecordsByUri.mockReturnValue(Effect.succeed([]));
+        const empty = yield* contextBriefRecoveryTestEffect(
+          retrieveContextBriefCodeLinkedMemoryEvidence(CONFIG, codeAnchorPlan(['src/first.ts'])),
+        );
+        expect(empty.gaps).toEqual(['code-anchor-recall-unavailable']);
+      }),
+  );
 
   effectIt.effect('preserves resolved anchor ordinals when canonical memory reads fail after capture', () =>
     Effect.gen(function* () {
@@ -303,4 +420,21 @@ function contextBriefRecoveryTestEffect<A, E>(effect: Effect.Effect<A, E, unknow
   // Every required boundary is replaced above with an Effect that requires no services.
   // oxlint-disable-next-line effecttsgo/unsafe-effect-type-assertion -- fully mocked focused unit boundary
   return effect as Effect.Effect<A, E>;
+}
+
+function finalizationReceipt(
+  state: DeferredCodeAnchorRouteFinalizationReceiptV1['state'],
+  finalizedCount: number,
+): DeferredCodeAnchorRouteFinalizationReceiptV1 {
+  return {
+    conflictCount: 0,
+    failedCount: 0,
+    finalizedCount,
+    matchedCount: state === 'contended' ? finalizedCount + 1 : finalizedCount,
+    pendingCount: 0,
+    scannedCount: finalizedCount,
+    state,
+    type: 'threadnote-deferred-code-anchor-route-finalization',
+    version: 1,
+  };
 }


### PR DESCRIPTION
A deferred citation can remain unwritten when the first Context Brief's 750 ms finalization pass expires before canonical admission. The brief previously ignored the finalization receipt and returned no backlink without distinguishing unfinished recovery from absent memory.

Retry one contended pass within the first brief, retaining the existing per-pass deadline and a total cap of four admissions, including interrupted attempts. Refresh recall after any contention so a competing finalizer's writes are visible. Persistent contention, unavailable repository identity, and finalization failures now preserve existing backlinks and report unavailable recall instead of claiming an empty result. Count/state-only receipts are available for first-read failure diagnostics.

Validation:
- Deterministic TestClock regression reproduces the reported `resolved: 1, matchedMemories: 0` failure on the original code and passes with this fix.
- Focused deferred-anchor integration, unit, and property group passed 45 tests; updated integration/recovery tests passed 11 tests after review refinements.
- Bounded property covers two-pass/four-admission limits, interrupted admissions, exhausted budget, and unavailable evidence.
- `bun run lint`, `bun run typecheck`, targeted Prettier, and `git diff --check` passed.
- Full suite is delegated to PR CI. Exact-HEAD global install and doctor verification passed at `ded0abd8`; installed CLI first-read smoke returned one resolved anchor/one linked memory and cleared pending intents from one to zero in an isolated home. Independent review found no remaining blocking findings.

Fixes #402
