### PR TITLE
fix(cursor): support managed desktop and hosted Cloud hooks

### DIFF
--- a/src/cursor_hook_runner.ts
+++ b/src/cursor_hook_runner.ts
@@ -1,0 +1,57 @@
+import {Console, Effect, Path} from 'effect';
+import {captureConsole} from './effect/console.js';
+import {SystemInfo} from './effect/system.js';
+import {readHookPayload, runPreCompactHook, runSessionStartHook} from './hooks.js';
+import type {CursorHookEvent} from './cursor_hooks.js';
+import type {HookRunnerOptions, RuntimeConfig} from './types.js';
+
+export const runCursorHook = Effect.fn('hooks.runCursor')(function* (
+  config: RuntimeConfig,
+  event: CursorHookEvent,
+  options: HookRunnerOptions = {},
+) {
+  yield* runCursorHookWith(event, readHookPayload(), sessionId =>
+    Effect.gen(function* () {
+      if (event === 'sessionStart') yield* runSessionStartHook(config, options);
+      else yield* runPreCompactHook(config, {...options, sourceAgentClient: 'cursor', sessionId});
+    }),
+  );
+});
+
+/** User hooks run in ~/.cursor, so scope must come from the provider payload. */
+export const runCursorHookWith = Effect.fn('hooks.runCursorWith')(function* <E, R, PE, PR>(
+  event: CursorHookEvent,
+  readPayload: Effect.Effect<
+    | {
+        readonly workspaceRoots?: readonly string[];
+        readonly sessionId?: string;
+      }
+    | undefined,
+    PE,
+    PR
+  >,
+  action: (sessionId: string | undefined) => Effect.Effect<void, E, R>,
+) {
+  const response = yield* Effect.gen(function* () {
+    const payload = yield* readPayload;
+    const path = yield* Path.Path;
+    const cwd = payload?.workspaceRoots?.[0];
+    if (!cwd || !path.isAbsolute(cwd)) return {};
+    const system = yield* SystemInfo;
+    const scopedSystem = SystemInfo.of({
+      ...system,
+      currentDirectory: () => cwd,
+      environment: () => ({...system.environment(), THREADNOTE_CALLER_CWD: cwd}),
+    });
+    const captured = yield* captureConsole(
+      action(payload?.sessionId).pipe(Effect.provideService(SystemInfo, scopedSystem)),
+    );
+    // preCompact is observational: its response cannot inject context. Never send
+    // the handoff command's human-readable output as Cursor's JSON protocol.
+    return event === 'sessionStart' && captured.output ? {additional_context: captured.output} : {};
+  }).pipe(
+    Effect.timeoutOrElse({duration: '12 seconds', orElse: () => Effect.succeed({})}),
+    Effect.orElseSucceed(() => ({})),
+  );
+  yield* Console.log(JSON.stringify(response));
+});

--- a/src/cursor_hooks.ts
+++ b/src/cursor_hooks.ts
@@ -1,0 +1,115 @@
+import {Console, Effect, FileSystem, Path, Schema} from 'effect';
+import {THREADNOTE_HOOK_MARKER, THREADNOTE_HOOK_MARKER_VALUE} from './constants.js';
+import {expandPath, getInvocationCwd, isJsonObject, parseJsonConfigObject} from './utils.js';
+import type {HooksInstallOptions, JsonObject} from './types.js';
+
+export type CursorHookTarget = 'desktop' | 'cloud';
+export type CursorHookEvent = 'sessionStart' | 'preCompact';
+
+class CursorHooksConfigError extends Schema.TaggedError<CursorHooksConfigError>()('CursorHooksConfigError', {
+  message: Schema.String,
+}) {}
+
+// Cursor uses flat command entries, unlike Claude's nested matcher/hook groups.
+// https://cursor.com/docs/hooks (verified 2026-09-08).
+const managedEvents = (target: CursorHookTarget): readonly CursorHookEvent[] =>
+  target === 'cloud' ? ['preCompact'] : ['sessionStart', 'preCompact'];
+
+function isManaged(value: unknown): boolean {
+  return isJsonObject(value) && value[THREADNOTE_HOOK_MARKER] === THREADNOTE_HOOK_MARKER_VALUE;
+}
+
+/** Preserve unrelated entries and config fields, including empty user event arrays. */
+export function withCursorHooks(input: JsonObject, target: CursorHookTarget, remove = false): JsonObject {
+  const hooks = isJsonObject(input.hooks) ? {...input.hooks} : {};
+  for (const [event, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries) || !entries.some(isManaged)) continue;
+    const remaining = entries.filter(entry => !isManaged(entry));
+    hooks[event] = remaining;
+  }
+  if (!remove) {
+    for (const event of managedEvents(target)) {
+      const entries = Array.isArray(hooks[event]) ? hooks[event] : [];
+      hooks[event] = [
+        ...entries,
+        {
+          [THREADNOTE_HOOK_MARKER]: THREADNOTE_HOOK_MARKER_VALUE,
+          type: 'command',
+          command: `threadnote cursor-hook ${event}`,
+          timeout: 15,
+        },
+      ];
+    }
+  }
+  const next = {...input};
+  if (Object.keys(hooks).length || isJsonObject(input.hooks)) next.hooks = hooks;
+  if (!remove) {
+    next.version = input.version ?? 1;
+    next.hooks = hooks;
+  }
+  return next;
+}
+
+export const runCursorHooksInstall = Effect.fn('hooks.installCursor')(function* (options: HooksInstallOptions) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const target = options.target ?? 'desktop';
+  if (target === 'cloud' && !options.project) {
+    return yield* CursorHooksConfigError.make({
+      message:
+        'Cursor Cloud hooks require --project <repository>; local ~/.cursor/hooks.json is unavailable in hosted Cloud VMs.',
+    });
+  }
+  const configPath = options.project
+    ? path.resolve(yield* getInvocationCwd(), options.project, '.cursor/hooks.json')
+    : yield* expandPath('~/.cursor/hooks.json');
+  const exists = yield* fs.exists(configPath);
+  const raw = exists ? yield* fs.readFileString(configPath) : '{}';
+  const parsed = parseJsonConfigObject(raw);
+  if (
+    !parsed ||
+    (parsed.version !== undefined && parsed.version !== 1) ||
+    (parsed.hooks !== undefined && !isJsonObject(parsed.hooks)) ||
+    (isJsonObject(parsed.hooks) && Object.values(parsed.hooks).some(entries => !Array.isArray(entries)))
+  ) {
+    return yield* CursorHooksConfigError.make({
+      message: `Refusing to modify invalid or unsupported Cursor hooks config at ${configPath}. Expected version 1 with event arrays.`,
+    });
+  }
+  const remove = options.remove === true;
+  const apply = options.apply === true && options.dryRun !== true;
+  const next = withCursorHooks(parsed, target, remove);
+  yield* Console.log(
+    target === 'cloud'
+      ? 'Cursor hosted Cloud: managed project preCompact command hook. sessionStart, sessionEnd, and workspaceOpen are unavailable; hooks begin only in a writable environment.'
+      : 'Cursor desktop: managed sessionStart and preCompact command hooks. workspaceOpen is supported by Cursor but is not used by Threadnote.',
+  );
+  yield* Console.log(
+    'Local user hooks do not carry into Cloud VMs. For hosted Cloud use --target cloud --project <repository>; commit .cursor/hooks.json and provision threadnote on the VM PATH. Cloud session recall remains instruction-driven.',
+  );
+  if (JSON.stringify(parsed) === JSON.stringify(next)) {
+    yield* Console.log(`Cursor hooks already ${remove ? 'absent' : 'managed'} in ${configPath}.`);
+    return;
+  }
+  yield* Console.log(`${apply ? 'Updating' : 'Would update'} ${configPath}:`);
+  yield* Console.log(remove ? '  - threadnote-managed Cursor hooks' : JSON.stringify(next, undefined, 2));
+  if (!apply) {
+    yield* Console.log('\nRe-run with --apply to actually modify the file.');
+    return;
+  }
+  yield* fs.makeDirectory(path.dirname(configPath), {recursive: true});
+  yield* fs.writeFileString(configPath, `${JSON.stringify(next, undefined, 2)}\n`, {mode: 0o600});
+  yield* Console.log(`${remove ? 'Removed' : 'Installed'} threadnote-managed Cursor hooks.`);
+});
+
+export const hasManagedCursorHooks = Effect.fn('hooks.hasManagedCursorHooks')(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* expandPath('~/.cursor/hooks.json');
+  if (!(yield* fs.exists(path))) return false;
+  const parsed = parseJsonConfigObject(yield* fs.readFileString(path));
+  return (
+    !!parsed &&
+    isJsonObject(parsed.hooks) &&
+    Object.values(parsed.hooks).some(entries => Array.isArray(entries) && entries.some(isManaged))
+  );
+});

--- a/src/effect/cli.ts
+++ b/src/effect/cli.ts
@@ -1,3 +1,5 @@
+import {makeCursorHookCommand, makeInstallHooksCommand} from './hooks_cli.js';
+import {runCursorHook} from '../cursor_hook_runner.js';
 import {Console, Effect, Schema} from 'effect';
 import {Argument, CliError, Command, Flag} from 'effect/unstable/cli';
 import {THREADNOTE_MCP_NAME} from '../constants.js';
@@ -1203,18 +1205,12 @@ const mcpInstall = Command.make(
   ({agent, ...options}) => withRuntimeEffect(config => runMcpInstall(config, agent, options)),
 ).pipe(Command.withDescription('Install the Threadnote MCP config, instructions, and skills for one supported agent'));
 
-const installHooks = Command.make(
-  'install-hooks',
-  {
-    agent: Argument.choice('agent', ['codex', 'claude', 'cursor', 'copilot']).pipe(
-      Argument.withDescription('codex, claude, cursor, or copilot'),
-    ),
-    apply: boolean('apply', 'Actually modify the selected agent config'),
-    dryRun: boolean('dry-run', 'Print the planned change without applying it'),
-    remove: boolean('remove', 'Remove threadnote-managed hook entries instead of adding them'),
-  },
-  ({agent, ...options}) => withRuntimeEffect(config => runHooksInstall(config, agent, options)),
-).pipe(Command.withDescription('Install deterministic agent lifecycle hooks'));
+const installHooks = makeInstallHooksCommand((agent, options) =>
+  withRuntimeEffect(config => runHooksInstall(config, agent, options)),
+);
+const cursorHook = makeCursorHookCommand((event, options) =>
+  withRuntimeEffect(config => runCursorHook(config, event, options)),
+);
 
 const preCompactHook = Command.make(
   'pre-compact-hook',
@@ -1938,6 +1934,7 @@ const topLevelCommandRegistrations = [
   registerTopLevelCommand('mcp-install', mcpInstall, {productionLog: {mode: 'requires-apply'}}),
   registerTopLevelCommand('install-hooks', installHooks, {productionLog: {mode: 'requires-apply'}}),
   registerTopLevelCommand('pre-compact-hook', preCompactHook),
+  registerTopLevelCommand('cursor-hook', cursorHook),
   registerTopLevelCommand('session-start-hook', sessionStartHook),
   registerTopLevelCommand('remember', remember),
   registerTopLevelCommand('finalize-code-refs', finalizeCodeRefs),

--- a/src/effect/hooks_cli.ts
+++ b/src/effect/hooks_cli.ts
@@ -1,0 +1,37 @@
+import type {Effect} from 'effect';
+import {Argument, Command} from 'effect/unstable/cli';
+import type {AgentClient, HookRunnerOptions, HooksInstallOptions} from '../types.js';
+import type {CursorHookEvent} from '../cursor_hooks.js';
+import {boolean, optionalChoice, optionalString} from './cli_flags.js';
+
+export function makeInstallHooksCommand<E, R>(
+  handler: (agent: AgentClient, options: HooksInstallOptions) => Effect.Effect<void, E, R>,
+) {
+  return Command.make(
+    'install-hooks',
+    {
+      agent: Argument.choice('agent', ['codex', 'claude', 'cursor', 'copilot']).pipe(
+        Argument.withDescription('codex, claude, cursor, or copilot'),
+      ),
+      apply: boolean('apply', 'Actually modify the selected agent config'),
+      dryRun: boolean('dry-run', 'Print the planned change without applying it'),
+      remove: boolean('remove', 'Remove threadnote-managed hook entries instead of adding them'),
+      target: optionalChoice('target', ['desktop', 'cloud'], 'Cursor hook environment (default: desktop)'),
+      project: optionalString('project', 'Cursor project repository root; required for hosted Cloud hooks'),
+    },
+    ({agent, ...options}) => handler(agent, options),
+  ).pipe(Command.withDescription('Install deterministic agent lifecycle hooks'));
+}
+
+export function makeCursorHookCommand<E, R>(
+  handler: (event: CursorHookEvent, options: HookRunnerOptions) => Effect.Effect<void, E, R>,
+) {
+  return Command.make(
+    'cursor-hook',
+    {
+      event: Argument.choice('event', ['sessionStart', 'preCompact']),
+      dryRun: boolean('dry-run', 'Preview the hook action without storing memory'),
+    },
+    ({event, ...options}) => handler(event, options),
+  ).pipe(Command.withDescription('Run a managed Cursor JSON lifecycle hook'), Command.unlisted);
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,6 +7,7 @@ import {
   THREADNOTE_HOOK_MARKER,
   THREADNOTE_HOOK_MARKER_VALUE,
 } from './constants.js';
+import {runCursorHooksInstall} from './cursor_hooks.js';
 import {parseAgentClient} from './mcp/index.js';
 import {captureConsole} from './effect/console.js';
 import {SystemInfo} from './effect/system.js';
@@ -54,7 +55,7 @@ export function runHooksInstall(config: RuntimeConfig, agent: AgentClient, optio
         yield* printCodexHooksNotice(remove);
         return;
       case 'cursor':
-        yield* printNoHooksSupported('cursor', remove);
+        yield* runCursorHooksInstall(options);
         return;
       case 'copilot':
         yield* printNoHooksSupported('copilot', remove);
@@ -193,12 +194,18 @@ export const hasManagedClaudeHooks = Effect.fn('hooks.hasManagedClaudeHooks')(fu
   return false;
 });
 
-export function runPreCompactHook(config: RuntimeConfig, options: HookRunnerOptions = {}) {
+export function runPreCompactHook(
+  config: RuntimeConfig,
+  options: HookRunnerOptions & {readonly sourceAgentClient?: 'claude' | 'cursor'; readonly sessionId?: string} = {},
+) {
   // Hooks must never block compaction. Anything that throws here gets swallowed
   // and the process still exits 0 — the worst-case is a missed snapshot.
   return Effect.gen(function* () {
     const project = (yield* resolveRepoName()) ?? 'general';
-    const {sessionId, trace} = yield* captureTraceContext();
+    const sourceAgentClient = options.sourceAgentClient ?? 'claude';
+    // Cursor transcripts use a different format; keep its snapshot state-only.
+    const {sessionId, trace}: TraceContext =
+      sourceAgentClient === 'cursor' ? {sessionId: options.sessionId} : yield* captureTraceContext();
     yield* runHandoff(config, {
       blockers: '- none recorded',
       dryRun: options.dryRun === true,
@@ -206,8 +213,8 @@ export function runPreCompactHook(config: RuntimeConfig, options: HookRunnerOpti
         'Continue from this auto-snapshot. A manual `threadnote handoff` will produce a richer write-up if you have more context.',
       project,
       sessionId,
-      sourceAgentClient: 'claude',
-      task: 'Auto-snapshot captured at Claude PreCompact (deterministic safety net before context compaction).',
+      sourceAgentClient,
+      task: `Auto-snapshot captured at ${sourceAgentClient === 'cursor' ? 'Cursor preCompact' : 'Claude PreCompact'} (deterministic safety net before context compaction).`,
       tests: '- not recorded (auto-snapshot)',
       topic: HOOK_AUTO_PRECOMPACT_TOPIC,
       trace,
@@ -358,7 +365,7 @@ function scrubTrace(trace: string): string | undefined {
   return result.blocker ? undefined : result.cleaned;
 }
 
-const readHookPayload = Effect.fn('hooks.readPayload')(function* () {
+export const readHookPayload = Effect.fn('hooks.readPayload')(function* () {
   const system = yield* SystemInfo;
   if (system.stdinIsTTY) {
     return undefined;
@@ -376,7 +383,16 @@ const readHookPayload = Effect.fn('hooks.readPayload')(function* () {
     return undefined;
   }
   return {
-    sessionId: typeof parsed.session_id === 'string' ? parsed.session_id : undefined,
+    sessionId:
+      typeof parsed.session_id === 'string'
+        ? parsed.session_id
+        : typeof parsed.conversation_id === 'string'
+          ? parsed.conversation_id
+          : undefined,
+    workspaceRoots:
+      Array.isArray(parsed.workspace_roots) && parsed.workspace_roots.every(root => typeof root === 'string')
+        ? parsed.workspace_roots
+        : undefined,
     transcriptPath: typeof parsed.transcript_path === 'string' ? parsed.transcript_path : undefined,
   };
 });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,3 +1,4 @@
+import {hasManagedCursorHooks} from './cursor_hooks.js';
 import {Console, Effect, FileSystem, Path, Result, Schema} from 'effect';
 import {
   agentIntegrationDoctorChecks,
@@ -672,6 +673,9 @@ const runUninstallInTransaction = Effect.fn('lifecycle.uninstallInTransaction')(
   yield* removeMcpSnippets(config, dryRun);
   if (yield* hasManagedClaudeHooks()) {
     yield* runHooksInstall(config, 'claude', {apply: !dryRun, dryRun, remove: true});
+  }
+  if (yield* hasManagedCursorHooks()) {
+    yield* runHooksInstall(config, 'cursor', {apply: !dryRun, dryRun, remove: true});
   }
   yield* removeCommandShim(dryRun);
   yield* removeAgentIntegrationsInTransaction(config, dryRun);

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,8 @@ export interface InstallOptions {
 }
 
 export interface HooksInstallOptions {
+  readonly target?: 'desktop' | 'cloud';
+  readonly project?: string;
   readonly apply?: boolean;
   readonly dryRun?: boolean;
   readonly remove?: boolean;

--- a/test/integration/cli.cursor-hooks.test.ts
+++ b/test/integration/cli.cursor-hooks.test.ts
@@ -20,7 +20,7 @@ it('runs the actual Cursor CLI protocol from a user-hook cwd, recalls the payloa
     // Prevent the hook's optional update banner from needing the network.
     await writeFile(
       join(home, '.update-state.json'),
-      JSON.stringify({version: 3, channel: 'stable', checkedAt: new Date().toISOString(), latestVersion: '0.0.0'}),
+      JSON.stringify({version: 3, channel: 'latest', checkedAt: new Date().toISOString(), latestVersion: '0.0.0'}),
     );
     const memoryRoot = join(home, 'data/local/user/local/memories/handoffs/active/cursor-hook-workspace');
     await mkdir(memoryRoot, {recursive: true});

--- a/test/integration/cli.cursor-hooks.test.ts
+++ b/test/integration/cli.cursor-hooks.test.ts
@@ -1,0 +1,90 @@
+import {execFile} from '../helpers/node-child-process.js';
+import {mkdir, mkdtemp, readFile, readdir, rm, writeFile} from '../helpers/node-fs-promises.js';
+import {tmpdir} from '../helpers/node-os.js';
+import {join} from '../helpers/node-path.js';
+import {promisify} from '../helpers/node-util.js';
+import {expect, it} from 'vitest';
+
+const execute = promisify(execFile);
+const entry = join(process.cwd(), 'src/standalone.ts');
+
+it('runs the actual Cursor CLI protocol from a user-hook cwd, recalls the payload repo, and stores a Cursor snapshot', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'threadnote-cursor-cli-'));
+  try {
+    const home = join(root, 'threadnote-home');
+    const userHookCwd = join(root, 'user-home', '.cursor');
+    const repo = join(root, 'cursor-hook-workspace');
+    await mkdir(userHookCwd, {recursive: true});
+    await mkdir(home, {recursive: true});
+    await execute('git', ['init', '--initial-branch=cursor-smoke', repo]);
+    // Prevent the hook's optional update banner from needing the network.
+    await writeFile(
+      join(home, '.update-state.json'),
+      JSON.stringify({version: 3, channel: 'stable', checkedAt: new Date().toISOString(), latestVersion: '0.0.0'}),
+    );
+    const memoryRoot = join(home, 'data/local/user/local/memories/handoffs/active/cursor-hook-workspace');
+    await mkdir(memoryRoot, {recursive: true});
+    await writeFile(
+      join(memoryRoot, 'current.md'),
+      [
+        'MEMORY',
+        'kind: handoff',
+        'status: active',
+        'project: cursor-hook-workspace',
+        'topic: current',
+        'source_agent_client: test',
+        'timestamp: 2026-09-08T00:00:00.000Z',
+        'memory_id: tn_cursor_hook_cli_seed',
+        '',
+        'Current branch latest handoff for cursor-hook-workspace.',
+      ].join('\n'),
+    );
+    const payload = {
+      conversation_id: 'cursor-conversation',
+      workspace_roots: [repo],
+      transcript_path: join(root, 'must-not-parse.txt'),
+    };
+    await writeFile(payload.transcript_path, 'This text is deliberately outside the managed snapshot.');
+    const env = {
+      ...process.env,
+      HOME: join(root, 'user-home'),
+      USERPROFILE: join(root, 'user-home'),
+      THREADNOTE_HOME: home,
+      THREADNOTE_USER: 'local',
+      THREADNOTE_CALLER_CWD: userHookCwd,
+      THREADNOTE_AUTO_UPDATE: '0',
+      NO_COLOR: '1',
+    };
+    const run = (args: string[]) =>
+      new Promise<{stdout: string; stderr: string}>((resolve, reject) => {
+        const child = execFile(
+          process.execPath,
+          [entry, ...args],
+          {cwd: userHookCwd, env, timeout: 20_000},
+          (error, stdout, stderr) => {
+            if (error) reject(error);
+            else resolve({stdout, stderr});
+          },
+        );
+        child.stdin!.end(JSON.stringify(payload));
+      });
+    const session = await run(['cursor-hook', 'sessionStart']);
+    const response = JSON.parse(session.stdout);
+    expect(response.additional_context).toContain('unread context queue for cursor-hook-workspace');
+    expect(response.additional_context).toContain(
+      'threadnote://user/local/memories/handoffs/active/cursor-hook-workspace/current.md',
+    );
+    expect(JSON.parse((await run(['cursor-hook', 'preCompact', '--dry-run'])).stdout)).toEqual({});
+    expect(await readdir(memoryRoot)).toEqual(['current.md']);
+    expect(JSON.parse((await run(['cursor-hook', 'preCompact'])).stdout)).toEqual({});
+    const snapshotNames = (await readdir(memoryRoot)).filter(name => name !== 'current.md');
+    expect(snapshotNames).toHaveLength(1);
+    const snapshot = await readFile(join(memoryRoot, snapshotNames[0]), 'utf8');
+    expect(snapshot).toContain('source_agent_client: cursor');
+    expect(snapshot).toContain('session_id: cursor-conversation');
+    expect(snapshot).toContain('Auto-snapshot captured at Cursor preCompact');
+    expect(snapshot).not.toContain('deliberately outside');
+  } finally {
+    await rm(root, {recursive: true, force: true});
+  }
+}, 45_000);

--- a/test/unit/cursor-hook-payload.test.ts
+++ b/test/unit/cursor-hook-payload.test.ts
@@ -1,0 +1,51 @@
+import {it as effectIt} from '@effect/vitest';
+import {Effect, Stdio, Stream} from 'effect';
+import {expect} from 'vitest';
+import {readHookPayload} from '../../src/hooks.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const read = (raw: string) =>
+  Effect.gen(function* () {
+    const system = yield* SystemInfo;
+    return yield* readHookPayload().pipe(
+      Effect.provideService(SystemInfo, {...system, stdinIsTTY: false}),
+      provideTestLayer(Stdio.layerTest({stdin: Stream.make(new TextEncoder().encode(raw))})),
+    );
+  }).pipe(provideTestLayer(SystemInfo.layer));
+
+effectIt.effect('reads Cursor conversation identity and workspace roots from real stdin JSON', () =>
+  Effect.gen(function* () {
+    const payload = yield* read(
+      JSON.stringify({
+        conversation_id: 'cursor-id',
+        workspace_roots: ['/repo/one', '/repo/two'],
+        transcript_path: '/repo/session.txt',
+      }),
+    );
+    expect(payload).toEqual({
+      sessionId: 'cursor-id',
+      workspaceRoots: ['/repo/one', '/repo/two'],
+      transcriptPath: '/repo/session.txt',
+    });
+    expect(yield* read(JSON.stringify({session_id: 'claude-id', transcript_path: '/claude/transcript.jsonl'}))).toEqual(
+      {sessionId: 'claude-id', transcriptPath: '/claude/transcript.jsonl', workspaceRoots: undefined},
+    );
+  }),
+);
+
+effectIt.effect.each(['{broken', '[]', '', 'null'])('ignores malformed hook input %s', raw =>
+  Effect.gen(function* () {
+    expect(yield* read(raw)).toBeUndefined();
+  }),
+);
+
+effectIt.effect('ignores invalid root arrays without leaking unrelated payload fields', () =>
+  Effect.gen(function* () {
+    expect(
+      yield* read(
+        JSON.stringify({workspace_roots: ['/repo', 3], conversation_id: 5, user_email: 'ignored@example.com'}),
+      ),
+    ).toEqual({workspaceRoots: undefined, sessionId: undefined, transcriptPath: undefined});
+  }),
+);

--- a/test/unit/cursor-hook-runner.test.ts
+++ b/test/unit/cursor-hook-runner.test.ts
@@ -1,0 +1,81 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {BunPath} from '@effect/platform-bun';
+import {it as effectIt} from '@effect/vitest';
+import {Console, Effect, Fiber, Layer} from 'effect';
+import {TestClock} from 'effect/testing';
+import {describe, expect} from 'vitest';
+import {captureConsole} from '../../src/effect/console.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {runCursorHookWith} from '../../src/cursor_hook_runner.js';
+
+const TestLayer = Layer.merge(BunPath.layer, SystemInfo.layer);
+
+describe('Cursor hook protocol', () => {
+  effectIt.effect('scopes user hooks to the first workspace and emits session context as one JSON object', () =>
+    Effect.gen(function* () {
+      const payload = Effect.succeed({sessionId: 'conversation', workspaceRoots: ['/repo/first', '/repo/second']});
+      const result = yield* captureConsole(
+        runCursorHookWith('sessionStart', payload, sessionId =>
+          Effect.gen(function* () {
+            expect(sessionId).toBe('conversation');
+            const system = yield* SystemInfo;
+            expect(system.currentDirectory()).toBe('/repo/first');
+            expect(system.environment().THREADNOTE_CALLER_CWD).toBe('/repo/first');
+            yield* Console.log('## Threadnote unread queue\n- [unread] threadnote://memory/example');
+          }),
+        ),
+      );
+      expect(JSON.parse(result.output)).toEqual({
+        additional_context: '## Threadnote unread queue\n- [unread] threadnote://memory/example',
+      });
+    }).pipe(provideTestLayer(TestLayer)),
+  );
+
+  effectIt.effect('passes the conversation identity and keeps preCompact output outside the JSON response', () =>
+    Effect.gen(function* () {
+      const payload = Effect.succeed({sessionId: 'cursor-conversation', workspaceRoots: ['/repo']});
+      let called = false;
+      const result = yield* captureConsole(
+        runCursorHookWith('preCompact', payload, sessionId =>
+          Effect.gen(function* () {
+            expect(sessionId).toBe('cursor-conversation');
+            called = true;
+            yield* Console.log('Stored snapshot output');
+          }),
+        ),
+      );
+      expect(called).toBe(true);
+      expect(JSON.parse(result.output)).toEqual({});
+    }).pipe(provideTestLayer(TestLayer)),
+  );
+
+  effectIt.effect.each([undefined, [], ['relative']])('ignores missing or non-absolute workspace roots %s', roots =>
+    Effect.gen(function* () {
+      const payload = Effect.succeed({workspaceRoots: roots});
+      const result = yield* captureConsole(
+        runCursorHookWith('sessionStart', payload, () => Effect.die('must not run')),
+      );
+      expect(JSON.parse(result.output)).toEqual({});
+    }).pipe(provideTestLayer(TestLayer)),
+  );
+
+  effectIt.effect('bounds slow hooks and emits a harmless response', () =>
+    Effect.gen(function* () {
+      const payload = Effect.succeed({workspaceRoots: ['/repo']});
+      const fiber = yield* captureConsole(runCursorHookWith('sessionStart', payload, () => Effect.never)).pipe(
+        Effect.forkChild,
+      );
+      yield* TestClock.adjust('12 seconds');
+      const result = yield* Fiber.join(fiber);
+      expect(JSON.parse(result.output)).toEqual({});
+    }).pipe(provideTestLayer(TestLayer)),
+  );
+
+  effectIt.effect('fails open with valid JSON when the action fails', () =>
+    Effect.gen(function* () {
+      const payload = Effect.succeed({workspaceRoots: ['/repo']});
+      const result = yield* captureConsole(runCursorHookWith('preCompact', payload, () => Effect.fail('unavailable')));
+      expect(JSON.parse(result.output)).toEqual({});
+    }).pipe(provideTestLayer(TestLayer)),
+  );
+});

--- a/test/unit/cursor-hooks.test.ts
+++ b/test/unit/cursor-hooks.test.ts
@@ -1,0 +1,140 @@
+import {provideTestLayer} from '../helpers/effect-layer.js';
+import {BunFileSystem, BunPath} from '@effect/platform-bun';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path, Result} from 'effect';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {hasManagedCursorHooks, runCursorHooksInstall, withCursorHooks} from '../../src/cursor_hooks.js';
+import {captureConsole} from '../../src/effect/console.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import type {JsonObject} from '../../src/types.js';
+
+const TestLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer, SystemInfo.layer);
+const managed = {_threadnote: 'managed', command: 'old threadnote command'};
+
+const fixture = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-cursor-hooks-'});
+  const configPath = path.join(root, '.cursor', 'hooks.json');
+  const system = yield* SystemInfo;
+  return {
+    fs,
+    root,
+    configPath,
+    system: SystemInfo.of({...system, homeDirectory: root, currentDirectory: () => root, environment: () => ({})}),
+  };
+});
+
+describe('Cursor hook config', () => {
+  it('uses Cursor flat commands and restricts hosted Cloud to preCompact', () => {
+    expect(withCursorHooks({}, 'desktop')).toEqual({
+      version: 1,
+      hooks: {
+        sessionStart: [
+          {_threadnote: 'managed', type: 'command', command: 'threadnote cursor-hook sessionStart', timeout: 15},
+        ],
+        preCompact: [
+          {_threadnote: 'managed', type: 'command', command: 'threadnote cursor-hook preCompact', timeout: 15},
+        ],
+      },
+    });
+    const cloud = withCursorHooks(withCursorHooks({}, 'desktop'), 'cloud');
+    expect(cloud.hooks).toMatchObject({sessionStart: [], preCompact: [{command: 'threadnote cursor-hook preCompact'}]});
+    expect(cloud.hooks).not.toHaveProperty('workspaceOpen');
+  });
+
+  it('preserves unrelated hooks through idempotent installs, target changes, and removal', () => {
+    fc.assert(
+      fc.property(
+        fc.dictionary(
+          fc.constantFrom('sessionStart', 'preCompact', 'workspaceOpen', 'stop', 'custom'),
+          fc.array(fc.record({command: fc.string(), timeout: fc.nat({max: 120})}), {maxLength: 5}),
+        ),
+        fc.jsonValue(),
+        (hooks, metadata) => {
+          const original: JsonObject = {version: 1, hooks, metadata};
+          const before = structuredClone(original);
+          const desktop = withCursorHooks(original, 'desktop');
+          expect(withCursorHooks(desktop, 'desktop')).toEqual(desktop);
+          const cloud = withCursorHooks(desktop, 'cloud');
+          expect(withCursorHooks(cloud, 'cloud')).toEqual(cloud);
+          const removed = withCursorHooks(cloud, 'cloud', true);
+          expect(withCursorHooks(removed, 'cloud', true)).toEqual(removed);
+          const remaining = removed.hooks as Record<string, unknown>;
+          for (const [event, entries] of Object.entries(hooks)) expect(remaining[event]).toEqual(entries);
+          expect(removed.metadata).toEqual(metadata);
+          expect(original).toEqual(before);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  effectIt.effect('previews without writing, installs once, and removes only managed entries', () =>
+    Effect.gen(function* () {
+      const {fs, root, configPath, system} = yield* fixture;
+      const run = (options: Parameters<typeof runCursorHooksInstall>[0]) =>
+        captureConsole(runCursorHooksInstall(options).pipe(Effect.provideService(SystemInfo, system)));
+      const preview = yield* run({apply: true, dryRun: true});
+      expect(preview.output).toContain('Would update');
+      expect(preview.output).toContain('Local user hooks do not carry into Cloud VMs');
+      expect(yield* fs.exists(configPath)).toBe(false);
+      yield* fs.makeDirectory(`${root}/.cursor`);
+      const user = {command: 'custom-audit', matcher: 'Shell'};
+      yield* fs.writeFileString(
+        configPath,
+        JSON.stringify({version: 1, metadata: {preserve: true}, hooks: {sessionStart: [user, managed], stop: []}}),
+      );
+      yield* run({apply: true});
+      expect(yield* hasManagedCursorHooks().pipe(Effect.provideService(SystemInfo, system))).toBe(true);
+      const once = yield* fs.readFileString(configPath);
+      const second = yield* run({apply: true});
+      expect(second.output).toContain('already managed');
+      expect(yield* fs.readFileString(configPath)).toBe(once);
+      yield* run({apply: true, remove: true});
+      expect(yield* hasManagedCursorHooks().pipe(Effect.provideService(SystemInfo, system))).toBe(false);
+      expect(JSON.parse(yield* fs.readFileString(configPath))).toEqual({
+        version: 1,
+        metadata: {preserve: true},
+        hooks: {sessionStart: [user], preCompact: [], stop: []},
+      });
+    }).pipe(provideTestLayer(TestLayer)),
+  );
+
+  effectIt.effect('requires a project for hosted Cloud and writes only that project', () =>
+    Effect.gen(function* () {
+      const {fs, root, configPath, system} = yield* fixture;
+      const rejected = yield* runCursorHooksInstall({target: 'cloud', apply: true}).pipe(Effect.result);
+      expect(Result.isFailure(rejected)).toBe(true);
+      const project = `${root}/project`;
+      const installed = yield* captureConsole(
+        runCursorHooksInstall({target: 'cloud', project, apply: true}).pipe(Effect.provideService(SystemInfo, system)),
+      );
+      expect(installed.output).toContain('sessionStart, sessionEnd, and workspaceOpen are unavailable');
+      expect(yield* fs.exists(configPath)).toBe(false);
+      const saved = JSON.parse(yield* fs.readFileString(`${project}/.cursor/hooks.json`));
+      expect(Object.keys(saved.hooks)).toEqual(['preCompact']);
+      yield* runCursorHooksInstall({target: 'cloud', project, apply: true, remove: true});
+      expect(JSON.parse(yield* fs.readFileString(`${project}/.cursor/hooks.json`)).hooks).toEqual({preCompact: []});
+    }).pipe(provideTestLayer(TestLayer)),
+  );
+
+  effectIt.effect.each(['{broken', '[]', '{"version":2}', '{"hooks":[]}', '{"hooks":{"preCompact":{}}}'])(
+    'preserves unsupported or invalid config %s',
+    raw =>
+      Effect.gen(function* () {
+        const {fs, root, configPath, system} = yield* fixture;
+        yield* fs.makeDirectory(`${root}/.cursor`);
+        yield* fs.writeFileString(configPath, raw);
+        for (const remove of [false, true]) {
+          const result = yield* runCursorHooksInstall({apply: true, remove}).pipe(
+            Effect.provideService(SystemInfo, system),
+            Effect.result,
+          );
+          expect(Result.isFailure(result)).toBe(true);
+          expect(yield* fs.readFileString(configPath)).toBe(raw);
+        }
+      }).pipe(provideTestLayer(TestLayer)),
+  );
+});

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -502,12 +502,18 @@ threadnote doctor`,
             language: 'sh',
             code: `threadnote install-hooks claude --dry-run
 threadnote install-hooks claude --apply
-# Or install home, instructions, and hooks together:
+threadnote install-hooks cursor --dry-run
+threadnote install-hooks cursor --apply
+# Project hooks for hosted Cursor Cloud:
+threadnote install-hooks cursor --target cloud --project . --apply
+# Remove only Threadnote entries with the same target/project selection:
+threadnote install-hooks cursor --target cloud --project . --remove --apply
+# Or install home, instructions, and Claude hooks together:
 threadnote install --with-hooks`,
           },
           {
             type: 'paragraph',
-            text: 'Managed SessionStart and PreCompact lifecycle hooks are currently available for Claude Code only. Every supported host uses its native user-level instruction and skill surfaces. The optional Cursor Marketplace plugin can provide Cursor instructions instead. Threadnote never injects a Cursor plugin under ~/.cursor/plugins/local. Hooks do not replace agent judgment or start a Threadnote daemon.',
+            text: 'Claude Code supports managed SessionStart and PreCompact hooks. Cursor desktop supports managed sessionStart and preCompact hooks in ~/.cursor/hooks.json, or in a repository with --project. Cursor hosted Cloud uses --target cloud --project: only the preCompact command hook is installed. Commit .cursor/hooks.json and provision threadnote on the Cloud VM PATH. Local user hooks do not carry into Cloud VMs; sessionStart, sessionEnd, and workspaceOpen are unavailable there, and hooks begin only once the environment is writable. Cloud session recall remains instruction-driven. Cursor snapshots are state-only; its transcript format is not parsed. Desktop session recall uses additional_context, with the first workspace_roots entry selecting the repository in multi-root workspaces. Installation is explicit and preserves unrelated hooks; --remove removes only Threadnote entries. See the [Cursor hook reference](https://cursor.com/docs/hooks) for provider capabilities. Every supported host uses its native user-level instruction and skill surfaces. The optional Cursor Marketplace plugin can provide Cursor instructions instead. Threadnote never injects a Cursor plugin under ~/.cursor/plugins/local. Hooks do not replace agent judgment or start a Threadnote daemon.',
           },
         ],
       },


### PR DESCRIPTION
`install-hooks cursor` incorrectly described Cursor as having no agent hooks. It now installs managed desktop `sessionStart` / `preCompact` commands into the user or selected project configuration, and supports an explicit hosted Cloud target that installs only the project `preCompact` hook. Configuration merges, repeated installation, target changes, and removal preserve unrelated hooks; unsupported or malformed configs are left untouched. Normal uninstall removes managed user hooks.

The Cursor runner reads `workspace_roots` and the conversation identity, scopes recall to the first workspace, emits `additional_context` as JSON, and writes Cursor-attributed pre-compaction handoffs without attempting to parse Cursor transcripts. Hosted Cloud documentation explains project distribution, writable-environment timing, missing session/workspace lifecycle events, and the VM runtime requirement. Provider contracts were checked against [Cursor's official hooks reference](https://cursor.com/docs/hooks).

Validation:
- 28 focused hook configuration, protocol, stdin, and recall-queue tests; generated preservation/idempotence/non-mutation checks run 100 cases.
- Actual CLI integration verifies JSON stdout, the intended repository despite a user-hook cwd, dry-run non-mutation, Cursor session attribution, and exclusion of transcript content.
- Website content, CLI registration, and lifecycle checks pass.
- `bun run lint`, `bun run typecheck`, formatting, and `git diff --check` pass. Full suite is delegated to PR CI.
- Installed exact HEAD `173e7b0ebb21bfccb51ffaec03a00563bfc6a571` globally as `4.6.7-local.g173e7b0ebb21bfccb51ffaec03a00563bfc6a571`; installer doctor verification and superseded-process cleanup passed. Eight installed CLI smoke checks passed in temporary fixtures: desktop dry-run, idempotent install, preserved user hooks on removal, hosted Cloud preCompact-only install/removal, actual session-start repository recall with JSON stdout, preCompact dry-run, and Cursor-attributed state-only snapshot.
- Independent code review found no blocking issues.

Fixes #400
