### PR TITLE
fix: bind Context Brief scale evidence to candidate package version

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -104,7 +104,12 @@ creates a GitHub prerelease; do not use an unnumbered `-beta` suffix.
    The absolute latency gate runs on the reviewed `macos-15`/ARM64/Apple-M1 class. Its artifact must bind the explicit
    candidate argument to the observed clean checkout; require observed Git status, GitHub Actions,
    `RUNNER_ENVIRONMENT=github-hosted`, `RUNNER_OS=macOS`, runner class `github-hosted-macos-15-ARM64`, arm64, an
-   Apple-M1-class CPU, `bun/1.3.14`, and `threadnote-4.6.0`. Do not substitute a pass from the heterogeneous Ubuntu x64
+   Apple-M1-class CPU and `bun/1.3.14`. The built `sourceVersion` must equal `threadnote-` plus the package version
+   read independently from `git show C:package.json`. The benchmark verifies that binding before fixture setup;
+   retained-artifact review must pass the same independently derived `{commit: C, sourceVersion}` binding to
+   `parseContextBriefCitationScaleArtifactV2`. Never derive the expected version from the artifact itself. Omitting
+   that binding retains the historical `threadnote-4.6.0` validation contract and rejects later versions.
+   Do not substitute a pass from the heterogeneous Ubuntu x64
    pool or normalize two failed absolute observations through a parent-relative comparison.
    Also require `bun run eval:code-memory-link-bench` to pass on that SHA for changes to code-anchored retrieval. Treat
    its 256-noise-memory latency result as the deterministic CI smoke only; do not relabel it as the 100,000-memory
@@ -347,7 +352,7 @@ creates a GitHub prerelease; do not use an unnumbered `-beta` suffix.
    build, and the reusable publisher to that tag-event Git object and rechecks that the remote tag still peels to the
    same protected-main commit before creating the immutable release.
 7. Wait for `Publish standalone release`. Do not create a GitHub Release manually. Every channel publishes after all
-   four enabled archives are verified while its bounded production-large observation continues independently.
+   six enabled archives are verified while its bounded production-large observation continues independently.
 
 The main-branch website build includes the prepared stable `package.json` version when its matching release note is
 checked in but its tag does not exist yet. Merge only a ready-to-tag release commit and push the matching tag promptly.

--- a/scripts/benchmark-context-brief-citations-target.ts
+++ b/scripts/benchmark-context-brief-citations-target.ts
@@ -12,13 +12,15 @@ import {
 import {CodeGraphMaintenanceCoordinator} from '../src/code_graph/maintenance_coordinator.js';
 import {CodeGraphQueryService} from '../src/code_graph/query.js';
 import {CodeGraphStore} from '../src/code_graph/store.js';
-import {CommandExecutor} from '../src/effect/command.js';
+import {CommandExecutor, runCommandEffect} from '../src/effect/command.js';
 import {sha256FileHex} from '../src/effect/digest.js';
 import {SystemInfo} from '../src/effect/system.js';
+import {getThreadnoteVersion} from '../src/release/runtime_version.js';
 import {
   CONTEXT_BRIEF_CITATION_SCALE_PROFILE_IDS,
   CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SAMPLES,
   CONTEXT_BRIEF_CITATION_SCALE_RELEASE_WARMUPS,
+  contextBriefCitationScaleCandidateBinding,
   parseContextBriefCitationScaleArtifactV2,
   parseContextBriefCitationScaleBudgetV1,
   type ContextBriefCitationScaleProfileId,
@@ -94,6 +96,51 @@ export interface ContextBriefCitationScaleBenchmarkOptions {
   readonly warmups: number;
 }
 
+/** Bind the embedded build version to the reviewed package bytes before any scale fixture work. */
+export const readContextBriefCitationScaleCandidate = Effect.fn('contextBriefCitationScale.readCandidate')(function* (
+  candidateCommit: string,
+  observedSourceVersion: string,
+  cwd?: string,
+) {
+  if (!/^[0-9a-f]{40}$/u.test(candidateCommit)) {
+    return yield* ScriptError.make({message: 'Release-scale evidence requires an exact candidate Git SHA-1.'});
+  }
+  const options = {cwd, maxOutputBytes: 128 * 1024, timeoutMs: 10_000};
+  const head = yield* runCommandEffect('git', ['rev-parse', 'HEAD'], options);
+  if (head.stdout.trim() !== candidateCommit) {
+    return yield* ScriptError.make({message: 'Release-scale evidence requires the exact candidate checkout.'});
+  }
+  const status = yield* runCommandEffect(
+    'git',
+    [
+      '-c',
+      'core.fsmonitor=false',
+      '-c',
+      'core.untrackedCache=false',
+      'status',
+      '--porcelain=v1',
+      '--untracked-files=all',
+      '--ignore-submodules=none',
+      '--no-renames',
+    ],
+    options,
+  );
+  if (status.stdout.trim()) {
+    return yield* ScriptError.make({message: 'Release-scale evidence requires an exact clean candidate checkout.'});
+  }
+  const manifest = yield* runCommandEffect('git', ['show', `${candidateCommit}:package.json`], options);
+  const candidate = yield* Effect.try({
+    try: () => contextBriefCitationScaleCandidateBinding(candidateCommit, JSON.parse(manifest.stdout)),
+    catch: cause => ScriptError.make({message: 'Could not validate the candidate package version.', cause}),
+  });
+  if (observedSourceVersion !== candidate.sourceVersion) {
+    return yield* ScriptError.make({
+      message: `Built source version ${observedSourceVersion}; required candidate package version ${candidate.sourceVersion}.`,
+    });
+  }
+  return candidate;
+});
+
 const program = Effect.scoped(
   Effect.gen(function* () {
     const options = parseContextBriefCitationScaleBenchmarkArguments(yield* scriptArguments());
@@ -110,6 +157,12 @@ const program = Effect.scoped(
         message: `--fail-on-budget requires an exact candidate commit, the reviewed 100k corpus, all three profiles, exactly ${CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SAMPLES} samples, and exactly ${CONTEXT_BRIEF_CITATION_SCALE_RELEASE_WARMUPS} warmups.`,
       });
     }
+    const candidate = options.failOnBudget
+      ? yield* readContextBriefCitationScaleCandidate(
+          options.candidateCommit!,
+          `threadnote-${yield* getThreadnoteVersion()}`,
+        )
+      : undefined;
     const evaluatedArtifact = yield* evaluateContextBriefCitationScale({
       budget,
       builtArtifactSha256: options.builtArtifactSha256,
@@ -117,11 +170,12 @@ const program = Effect.scoped(
       memoryCandidates: options.memoryCandidates,
       profileIds: options.profileIds,
       ...(options.candidateCommit === undefined ? {} : {releaseCandidateCommit: options.candidateCommit}),
+      ...(candidate === undefined ? {} : {releaseCandidateBinding: candidate}),
       samples: options.samples,
       startRssObserver: startContextBriefCitationRssObserver(options.builtArtifactSha256),
       warmups: options.warmups,
     });
-    const artifact = parseContextBriefCitationScaleArtifactV2(evaluatedArtifact, budget);
+    const artifact = parseContextBriefCitationScaleArtifactV2(evaluatedArtifact, budget, candidate);
     if (options.outputPath !== undefined) {
       yield* atomicWrite(options.outputPath, `${JSON.stringify(artifact, undefined, 2)}\n`);
     }

--- a/src/evaluation/context-brief-citation-scale-contract.ts
+++ b/src/evaluation/context-brief-citation-scale-contract.ts
@@ -9,6 +9,8 @@ export const CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SOURCE_VERSION = 'threadnote-4
 export const CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE = 'context-brief-citations-scale-v2' as const;
 export const CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SAMPLES = 100 as const;
 export const CONTEXT_BRIEF_CITATION_SCALE_RELEASE_WARMUPS = 5 as const;
+const CANDIDATE_PACKAGE_VERSION =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
 export const CONTEXT_BRIEF_CITATION_RSS_SAMPLING_SCHEDULE = 'absolute-monotonic-deadline-v1' as const;
 export const CONTEXT_BRIEF_CITATION_RSS_SAMPLE_GAP_POLICY_V2 = {
   breachThresholdMilliseconds: 100,
@@ -218,6 +220,25 @@ export interface ContextBriefCitationScaleReleaseIdentityV1 {
   readonly runnerOperatingSystem: string;
   readonly runtime: string;
   readonly sourceVersion: string;
+}
+
+/** External review context, read from the exact candidate Git object rather than the artifact. */
+export interface ContextBriefCitationScaleCandidateBinding {
+  readonly commit: string;
+  readonly sourceVersion: string;
+}
+
+export function contextBriefCitationScaleCandidateBinding(
+  commit: string,
+  packageManifest: unknown,
+): ContextBriefCitationScaleCandidateBinding {
+  if (!/^[0-9a-f]{40}$/u.test(commit)) invalid('candidate binding requires an exact lowercase Git SHA-1');
+  const manifest = record(packageManifest, 'candidate package manifest');
+  const version = boundedString(manifest.version, 'candidate package version');
+  if (!CANDIDATE_PACKAGE_VERSION.test(version)) {
+    invalid('candidate package version must be an explicit version');
+  }
+  return {commit, sourceVersion: `threadnote-${version}`};
 }
 
 export type ContextBriefCitationScaleEvidenceClass = 'development-smoke' | 'release-scale';
@@ -457,6 +478,7 @@ export function contextBriefCitationScaleGate(failures: readonly string[]): Cont
 export function parseContextBriefCitationScaleArtifactV2(
   value: unknown,
   budgetInput: ContextBriefCitationScaleBudgetV1 | unknown,
+  candidate?: ContextBriefCitationScaleCandidateBinding,
 ): ContextBriefCitationScaleArtifactV2 {
   const budget = parseContextBriefCitationScaleBudgetV1(budgetInput);
   const artifact = record(value, 'scale artifact');
@@ -504,6 +526,7 @@ export function parseContextBriefCitationScaleArtifactV2(
   const claimedGate = parseArtifactGate(artifact.gate);
   const failures = rederiveArtifactFailures({
     budget,
+    candidate,
     environment,
     evidenceClass,
     execution,
@@ -1214,6 +1237,7 @@ function validateMemoryObserverSummary(
 
 function rederiveArtifactFailures(input: {
   readonly budget: ContextBriefCitationScaleBudgetV1;
+  readonly candidate?: ContextBriefCitationScaleCandidateBinding;
   readonly environment: ContextBriefCitationScaleEnvironmentV2;
   readonly evidenceClass: ContextBriefCitationScaleEvidenceClass;
   readonly execution: ContextBriefCitationScaleExecutionV2;
@@ -1256,7 +1280,7 @@ function rederiveArtifactFailures(input: {
       : 'benchmark execution artifact digest is missing or malformed',
   ];
   if (input.evidenceClass === 'release-scale') {
-    failures.push(...contextBriefCitationScaleReleaseIdentityFailures(input.environment));
+    failures.push(...contextBriefCitationScaleReleaseIdentityFailures(input.environment, input.candidate));
     if (
       input.memoryObserver.source !== 'darwin-ps' ||
       input.memoryObserver.rootIdentityValidation !== 'darwin-ps-lstart' ||
@@ -1280,8 +1304,24 @@ export function contextBriefCitationScaleRetainedRootRssGrowthBytes(baselines: r
 /** Fail closed when hosted release evidence is relabeled or detached from its exact candidate. */
 export function contextBriefCitationScaleReleaseIdentityFailures(
   identity: ContextBriefCitationScaleReleaseIdentityV1,
+  candidate?: ContextBriefCitationScaleCandidateBinding,
 ): readonly string[] {
+  // Omitting external review context preserves the immutable historical 4.6.0
+  // artifact contract. New releases must supply a candidate-bound expectation.
+  const expectedSourceVersion = candidate?.sourceVersion ?? CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SOURCE_VERSION;
   return [
+    candidate === undefined || /^[0-9a-f]{40}$/u.test(candidate.commit)
+      ? ''
+      : 'candidate binding commit is not exact lowercase Git SHA-1',
+    candidate === undefined ||
+    (typeof candidate.sourceVersion === 'string' &&
+      candidate.sourceVersion.startsWith('threadnote-') &&
+      CANDIDATE_PACKAGE_VERSION.test(candidate.sourceVersion.slice('threadnote-'.length)))
+      ? ''
+      : 'candidate binding source version must name an explicit package version',
+    candidate === undefined || identity.candidateCommit === candidate.commit
+      ? ''
+      : `claimed candidate ${identity.candidateCommit}; required reviewed candidate ${candidate.commit}`,
     /^[0-9a-f]{40}$/u.test(identity.candidateCommit) ? '' : 'release candidate commit is not exact lowercase Git SHA-1',
     identity.commit === identity.candidateCommit
       ? ''
@@ -1309,9 +1349,9 @@ export function contextBriefCitationScaleReleaseIdentityFailures(
     identity.runtime === CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNTIME
       ? ''
       : `runtime ${identity.runtime}; required ${CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNTIME}`,
-    identity.sourceVersion === CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SOURCE_VERSION
+    identity.sourceVersion === expectedSourceVersion
       ? ''
-      : `source version ${identity.sourceVersion}; required ${CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SOURCE_VERSION}`,
+      : `source version ${identity.sourceVersion}; required ${expectedSourceVersion}`,
   ].filter(Boolean);
 }
 

--- a/src/evaluation/context-brief-citation-scale.ts
+++ b/src/evaluation/context-brief-citation-scale.ts
@@ -22,6 +22,7 @@ import {
   contextBriefCitationScaleReleaseIdentityFailures,
   evaluateContextBriefCitationScaleProfile,
   type ContextBriefCitationScaleBudgetV1,
+  type ContextBriefCitationScaleCandidateBinding,
   type ContextBriefCitationScaleCountersV1,
   type ContextBriefCitationScaleMeasuredObservationV2,
   type ContextBriefCitationScaleMemoryObservationV2,
@@ -42,6 +43,7 @@ export interface ContextBriefCitationScaleRunOptions {
   readonly memoryCandidates: number;
   readonly profileIds: readonly ContextBriefCitationScaleProfileId[];
   readonly releaseCandidateCommit?: string;
+  readonly releaseCandidateBinding?: ContextBriefCitationScaleCandidateBinding;
   readonly startRssObserver: Effect.Effect<
     ContextBriefCitationScaleRssObserver,
     Error,
@@ -312,10 +314,10 @@ export const evaluateContextBriefCitationScale = Effect.fn('evaluation.contextBr
   };
   if (options.invocationMode === 'release-scale') {
     failures.push(
-      ...contextBriefCitationScaleReleaseIdentityFailures({
-        ...environment,
-        candidateCommit: options.releaseCandidateCommit ?? '',
-      }),
+      ...contextBriefCitationScaleReleaseIdentityFailures(
+        {...environment, candidateCommit: options.releaseCandidateCommit ?? ''},
+        options.releaseCandidateBinding,
+      ),
     );
     if (
       rssEvidence.source !== 'darwin-ps' ||

--- a/test/unit/context-brief-citation-candidate.test.ts
+++ b/test/unit/context-brief-citation-candidate.test.ts
@@ -1,0 +1,152 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path, Result} from 'effect';
+import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {readContextBriefCitationScaleCandidate} from '../../scripts/benchmark-context-brief-citations-target.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {
+  contextBriefCitationScaleCandidateBinding,
+  contextBriefCitationScaleReleaseIdentityFailures,
+  type ContextBriefCitationScaleReleaseIdentityV1,
+} from '../../src/evaluation/context-brief-citation-scale-contract.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const COMMIT = 'a'.repeat(40);
+const identity: ContextBriefCitationScaleReleaseIdentityV1 = {
+  architecture: 'arm64',
+  candidateCommit: COMMIT,
+  commit: COMMIT,
+  cpu: 'Apple M1 (Virtual)',
+  dirty: false,
+  gitStatusObserved: true,
+  githubActions: true,
+  operatingSystem: 'macOS 15.6.1',
+  runnerArchitecture: 'ARM64',
+  runnerClass: 'github-hosted-macos-15-ARM64',
+  runnerEnvironment: 'github-hosted',
+  runnerOperatingSystem: 'macOS',
+  runtime: 'bun/1.3.14',
+  sourceVersion: 'threadnote-4.6.0',
+};
+const commandLayer = CommandExecutor.layer.pipe(Layer.provide(SystemInfo.layer));
+const candidateLayer = commandLayer.pipe(Layer.provideMerge(BunServices.layer));
+
+describe('Context Brief release candidate version binding', () => {
+  it('retains historical 4.6.0 validation and requires external binding for later versions', () => {
+    expect(contextBriefCitationScaleReleaseIdentityFailures(identity)).toEqual([]);
+    const current = {...identity, sourceVersion: 'threadnote-4.6.8'};
+    expect(contextBriefCitationScaleReleaseIdentityFailures(current)).toContain(
+      'source version threadnote-4.6.8; required threadnote-4.6.0',
+    );
+    expect(
+      contextBriefCitationScaleReleaseIdentityFailures(
+        current,
+        contextBriefCitationScaleCandidateBinding(COMMIT, {version: '4.6.8'}),
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects malformed package versions and directly constructed malformed bindings', () => {
+    for (const manifest of [
+      null,
+      {},
+      {version: ''},
+      {version: 4.6},
+      {version: 'latest'},
+      {version: '04.6.8'},
+      {version: '4.6.8-..'},
+      {version: '4.6.8+.'},
+      {version: '4.6.8-01'},
+      {version: '4.6.8-rc..1'},
+    ]) {
+      expect(() => contextBriefCitationScaleCandidateBinding(COMMIT, manifest)).toThrow();
+    }
+    expect(
+      contextBriefCitationScaleReleaseIdentityFailures(
+        {...identity, sourceVersion: 'garbage'},
+        {commit: COMMIT, sourceVersion: 'garbage'},
+      ),
+    ).toContain('candidate binding source version must name an explicit package version');
+  });
+
+  it('accepts explicit prerelease and build metadata versions', () => {
+    for (const version of ['0.0.0', '4.6.8-rc.1', '4.6.8-0', '4.6.8+build.01', '4.6.8-rc.1+build.2']) {
+      expect(contextBriefCitationScaleCandidateBinding(COMMIT, {version}).sourceVersion).toBe(`threadnote-${version}`);
+    }
+  });
+
+  it('accepts exactly the independently supplied candidate commit and package version', () => {
+    fc.assert(
+      fc.property(
+        fc.record({major: fc.integer({min: 1, max: 20}), minor: fc.nat(30), patch: fc.nat(100)}),
+        fc.boolean(),
+        fc.boolean(),
+        ({major, minor, patch}, commitMatches, versionMatches) => {
+          const version = `${major}.${minor}.${patch}`;
+          const candidate = contextBriefCitationScaleCandidateBinding(COMMIT, {version});
+          const observed = {
+            ...identity,
+            candidateCommit: commitMatches ? COMMIT : 'b'.repeat(40),
+            commit: commitMatches ? COMMIT : 'b'.repeat(40),
+            sourceVersion: `threadnote-${major}.${minor}.${versionMatches ? patch : patch + 1}`,
+          };
+          expect(contextBriefCitationScaleReleaseIdentityFailures(observed, candidate).length === 0).toBe(
+            commitMatches && versionMatches,
+          );
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  // provideTestLayer owns the Effect scope, including the temporary Git checkout.
+  effectIt.effect('reads committed package bytes and rejects dirty, wrong-commit, and wrong-build observations', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-citation-candidate-'});
+      const manifestPath = path.join(root, 'package.json');
+      yield* fs.writeFileString(manifestPath, '{"version":"4.6.8"}\n');
+      yield* runCommandEffect('git', ['init', '--quiet'], {cwd: root});
+      yield* runCommandEffect('git', ['add', 'package.json'], {cwd: root});
+      yield* runCommandEffect(
+        'git',
+        [
+          '-c',
+          'commit.gpgSign=false',
+          '-c',
+          'user.name=Threadnote Test',
+          '-c',
+          'user.email=test@threadnote.local',
+          'commit',
+          '--quiet',
+          '-m',
+          'candidate',
+        ],
+        {cwd: root},
+      );
+      const commit = (yield* runCommandEffect('git', ['rev-parse', 'HEAD'], {cwd: root})).stdout.trim();
+      expect(yield* readContextBriefCitationScaleCandidate(commit, 'threadnote-4.6.8', root)).toEqual({
+        commit,
+        sourceVersion: 'threadnote-4.6.8',
+      });
+      const wrongBuild = yield* readContextBriefCitationScaleCandidate(commit, 'threadnote-4.6.0', root).pipe(
+        Effect.result,
+      );
+      expect(Result.isFailure(wrongBuild)).toBe(true);
+      if (Result.isFailure(wrongBuild))
+        expect(wrongBuild.failure.message).toContain('required candidate package version threadnote-4.6.8');
+      const wrongCommit = yield* readContextBriefCitationScaleCandidate(COMMIT, 'threadnote-4.6.8', root).pipe(
+        Effect.result,
+      );
+      expect(Result.isFailure(wrongCommit)).toBe(true);
+      yield* fs.writeFileString(manifestPath, '{"version":"4.6.9"}\n');
+      const dirty = yield* readContextBriefCitationScaleCandidate(commit, 'threadnote-4.6.9', root).pipe(Effect.result);
+      expect(Result.isFailure(dirty)).toBe(true);
+      if (Result.isFailure(dirty)) expect(dirty.failure.message).toContain('clean candidate checkout');
+    }).pipe(provideTestLayer(candidateLayer), TestClock.withLive),
+  );
+});

--- a/test/unit/context-brief-citation-scale-benchmark.test.ts
+++ b/test/unit/context-brief-citation-scale-benchmark.test.ts
@@ -14,6 +14,7 @@ import {
   CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SAMPLES,
   CONTEXT_BRIEF_CITATION_SCALE_RELEASE_WARMUPS,
   contextBriefCitationScaleGate,
+  contextBriefCitationScaleCandidateBinding,
   contextBriefCitationRssSampleGapFailures,
   contextBriefCitationRssSampleGapSummary,
   contextBriefCitationScaleReleaseIdentityFailures,
@@ -828,6 +829,35 @@ describe('Context Brief citation scale benchmark', () => {
     );
   });
 
+  it('rederives retained release evidence against the independently reviewed commit and package version', () => {
+    const candidate = contextBriefCitationScaleCandidateBinding('a'.repeat(40), {version: '4.6.8'});
+    const artifact = releaseScaleArtifact(candidate.sourceVersion);
+    expect(parseContextBriefCitationScaleArtifactV2(artifact, budget, candidate)).toEqual(artifact);
+    expect(() => parseContextBriefCitationScaleArtifactV2(artifact, budget)).toThrow();
+    for (const mismatch of [
+      {...candidate, commit: 'b'.repeat(40)},
+      {...candidate, sourceVersion: 'threadnote-4.6.9'},
+      {...candidate, sourceVersion: 'threadnote-4.6.8-..'},
+    ]) {
+      expect(() => parseContextBriefCitationScaleArtifactV2(artifact, budget, mismatch)).toThrow();
+    }
+    const historical = releaseScaleArtifact('threadnote-4.6.0');
+    expect(parseContextBriefCitationScaleArtifactV2(historical, budget)).toEqual(historical);
+  });
+
+  it('keeps development smoke evidence non-release even with a valid candidate binding', () => {
+    const candidate = contextBriefCitationScaleCandidateBinding('a'.repeat(40), {version: '4.6.8'});
+    const smoke = scaleArtifact();
+    const artifact = {...smoke, environment: {...smoke.environment, sourceVersion: candidate.sourceVersion}};
+    const parsed = parseContextBriefCitationScaleArtifactV2(artifact, budget, candidate);
+    expect(parsed.evidenceClass).toBe('development-smoke');
+    expect(parsed.gate.passed).toBe(false);
+    expect(parsed.gate.failures).toContain('artifact is a development smoke, not release-scale evidence');
+    expect(() =>
+      parseContextBriefCitationScaleArtifactV2({...artifact, gate: {passed: true, failures: []}}, budget, candidate),
+    ).toThrow();
+  });
+
   it('runs first-use memory evidence before observer-free timing', () => {
     const memoryPhase = scaleEvaluationSource.indexOf('const rssEvidence = yield* Effect.acquireUseRelease');
     const timingPhase = scaleEvaluationSource.indexOf('const timingProfiles = new Map');
@@ -961,6 +991,44 @@ function scaleArtifact(): ContextBriefCitationScaleArtifactV2 {
     suite: CONTEXT_BRIEF_CITATION_SCALE_ARTIFACT_SUITE,
     version: 2,
     warmups: 0,
+  };
+}
+
+function releaseScaleArtifact(sourceVersion: string): ContextBriefCitationScaleArtifactV2 {
+  const base = scaleArtifact();
+  const profiles = budget.profiles.map(profile => {
+    const observations = Array.from({length: CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SAMPLES}, (_, ordinal) =>
+      scaleObservation(profile, {}, {}, {observationId: `context-rss-${profile.id}-${ordinal}`, ordinal}),
+    );
+    return evaluateContextBriefCitationScaleProfile(budget, profile.id, observations[0].memoryWorkload, observations)
+      .result;
+  });
+  const observationCount = profiles.length * CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SAMPLES;
+  return {
+    ...base,
+    environment: {
+      ...base.environment,
+      candidateCommit: 'a'.repeat(40),
+      dirty: false,
+      githubActions: true,
+      runnerArchitecture: 'ARM64',
+      runnerClass: CONTEXT_BRIEF_CITATION_SCALE_RELEASE_RUNNER_CLASS,
+      runnerEnvironment: 'github-hosted',
+      runnerOperatingSystem: 'macOS',
+      sourceVersion,
+    },
+    evidenceClass: 'release-scale',
+    fixture: {...base.fixture, indexedMemoryCandidates: 100_000, requestedMemoryCandidates: 100_000},
+    gate: {passed: true, failures: []},
+    memoryObserver: {
+      ...base.memoryObserver,
+      observationCount,
+      sampleAttempts: observationCount * 3 + 1,
+      successfulSamples: observationCount * 3 + 1,
+    },
+    profiles,
+    samples: CONTEXT_BRIEF_CITATION_SCALE_RELEASE_SAMPLES,
+    warmups: CONTEXT_BRIEF_CITATION_SCALE_RELEASE_WARMUPS,
   };
 }
 


### PR DESCRIPTION
Context Brief's pinned release-scale gate required `threadnote-4.6.0` even though the benchmark embeds the current package version, so later patch candidates could never satisfy release identity checks. Read the package manifest from the exact candidate Git object, verify the clean checkout and built version before fixture setup, and pass that independent commit/version binding through evaluation and retained-artifact validation.

The v2 artifact schema, fixture, performance budgets, RSS protocol, runtime, and runner checks remain unchanged. Validation without an external binding retains the historical 4.6.0 contract; newer versions require an explicit binding. Release documentation describes artifact revalidation and corrects the enabled archive count to six.

Validation:
- 27 focused tests, including real Git checkout, malformed-version, parser mismatch, legacy, and development-smoke regressions; bounded property checks exact commit/version equality.
- Lint, source/test/website typechecks, formatting, and diff checks pass.
- Exact-HEAD global development install and doctor pass; isolated Context Brief CLI smoke resolves its deferred backlink on the first read.
- Built benchmark wrapper rejects a wrong candidate before fixture setup. Pinned hosted scale evidence will run on the final merged release candidate.
