### PR TITLE
fix: publish admission proof for Context Brief scale fixtures

### DIFF
--- a/src/evaluation/context-brief-citation-scale-fixture.ts
+++ b/src/evaluation/context-brief-citation-scale-fixture.ts
@@ -1,4 +1,9 @@
 import {Clock, Data, Effect, FileSystem, Path} from 'effect';
+import {
+  observeCodeGraphAdmissionEnvironment,
+  recordCodeGraphSnapshotAdmission,
+} from '../code_graph/admission_freshness.js';
+import {CodeGraphLanguagePackRegistry} from '../code_graph/languages/registry.js';
 import {extractorSetIdentityFromPackProvenance} from '../code_graph/indexer.js';
 import {codeGraphLayout} from '../code_graph/layout.js';
 import {CodeGraphQueryService} from '../code_graph/query.js';
@@ -84,7 +89,14 @@ export const prepareContextBriefCitationScaleFixture = Effect.fn('evaluation.pre
     const worksets: Array<{readonly name: string; readonly projects: readonly string[]}> = [];
     const readyGraphSetupStarted = yield* Clock.currentTimeNanos;
     for (const profile of options.budget.profiles) {
-      const repositories = yield* prepareRepositories(fs, path, home, root, profile, options.runCount);
+      const repositories = yield* prepareContextBriefCitationScaleRepositories(
+        fs,
+        path,
+        home,
+        root,
+        profile,
+        options.runCount,
+      );
       projects.push(...repositories.map(repositoryProject));
       if (profile.id === 'local-100k') {
         preparedProfiles.set(profile.id, {profile, repositories});
@@ -215,7 +227,7 @@ export const prepareContextBriefCitationScaleFixture = Effect.fn('evaluation.pre
   },
 );
 
-function prepareRepositories(
+export function prepareContextBriefCitationScaleRepositories(
   fs: FileSystem.FileSystem,
   path: Path.Path,
   home: string,
@@ -225,6 +237,7 @@ function prepareRepositories(
 ) {
   return Effect.gen(function* () {
     const store = yield* CodeGraphStore;
+    const languagePacks = yield* CodeGraphLanguagePackRegistry;
     return yield* Effect.forEach(
       Array.from({length: profile.worksetMembers}, (_, ordinal) => ordinal),
       ordinal =>
@@ -270,7 +283,8 @@ function prepareRepositories(
           );
           const identity = yield* resolveRepositoryIdentity(repositoryRoot);
           const snapshotId = `cgsn_${sha256HexSync(`scale-snapshot\0${name}`).slice(0, 40)}`;
-          const databasePath = codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId).databasePath;
+          const layout = codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId);
+          const databasePath = layout.databasePath;
           const files = sourcePaths.map(codeGraphInventoryFile);
           const snapshot = {
             commit: identity.headCommit,
@@ -286,8 +300,15 @@ function prepareRepositories(
             symbolCount: 0,
             worktreeId: identity.worktreeId,
           } satisfies CodeGraphSnapshot;
+          const admissionEnvironment = yield* observeCodeGraphAdmissionEnvironment(identity);
           yield* store.activate(databasePath, identity, snapshot, files, [], [], []);
           yield* store.promote(databasePath, identity, snapshot.id);
+          if ((yield* observeCodeGraphAdmissionEnvironment(identity)) !== admissionEnvironment) {
+            return yield* new ContextBriefCitationScaleFixtureError({
+              message: `Prebuilt scale graph admission policy changed during publication: ${name}.`,
+            });
+          }
+          yield* recordCodeGraphSnapshotAdmission(layout, snapshot, admissionEnvironment, languagePacks, false);
           const status = {
             databasePath,
             freshness: 'current',

--- a/test/unit/context-brief-citation-scale-fixture.test.ts
+++ b/test/unit/context-brief-citation-scale-fixture.test.ts
@@ -1,0 +1,122 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path, Result} from 'effect';
+import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
+import {describe, expect} from 'vitest';
+import {
+  observeCodeGraphAdmissionEnvironment,
+  recordCodeGraphSnapshotAdmission,
+} from '../../src/code_graph/admission_freshness.js';
+import {
+  CodeGraphLanguagePackRegistry,
+  createCodeGraphLanguagePackRegistry,
+} from '../../src/code_graph/languages/registry.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {codeGraphSnapshotRuntimeCurrent} from '../../src/code_graph/query_snapshot_runtime.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import {CommandExecutor} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {parseContextBriefCitationScaleBudgetV1} from '../../src/evaluation/context-brief-citation-scale-contract.js';
+import {prepareContextBriefCitationScaleRepositories} from '../../src/evaluation/context-brief-citation-scale-fixture.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const budget = parseContextBriefCitationScaleBudgetV1(
+  JSON.parse(
+    await Bun.file(
+      new URL('../evaluation/baselines/context-brief-citations-v1/scale-budgets.json', import.meta.url),
+    ).text(),
+  ),
+);
+const systemLayer = SystemInfo.layer;
+const commandLayer = CommandExecutor.layer.pipe(Layer.provide(systemLayer));
+const platformLayer = Layer.mergeAll(systemLayer, commandLayer).pipe(Layer.provideMerge(BunServices.layer));
+const storeLayer = CodeGraphStore.layer.pipe(Layer.provideMerge(platformLayer));
+const fixtureLayer = Layer.mergeAll(
+  storeLayer,
+  Layer.succeed(CodeGraphLanguagePackRegistry, createCodeGraphLanguagePackRegistry([])),
+);
+
+describe('Context Brief prebuilt scale fixture admission', () => {
+  effectIt.effect.prop(
+    'publishes current evidence, requires its receipt, and binds it to the observed policy',
+    {suffix: fc.nat(100_000)},
+    ({suffix}) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const store = yield* CodeGraphStore;
+        const packs = yield* CodeGraphLanguagePackRegistry;
+        const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-scale-admission-'});
+        const home = path.join(root, 'home');
+        const [repository] = yield* prepareContextBriefCitationScaleRepositories(
+          fs,
+          path,
+          home,
+          root,
+          budget.profiles[0],
+          1,
+        );
+        const identity = repository.status.identity;
+        const snapshot = (yield* store.readySnapshot(repository.databasePath, identity.worktreeId))!;
+        const layout = codeGraphLayout(path, home, identity.checkoutId, identity.worktreeId);
+        const current = () =>
+          codeGraphSnapshotRuntimeCurrent(store, repository.databasePath, snapshot, packs, {layout, identity});
+        expect(snapshot.id).toBe(repository.snapshotId);
+        expect(yield* current()).toBe(true);
+        yield* fs.remove(path.join(layout.repositoryRoot, 'admission'), {recursive: true});
+        expect(yield* current()).toBe(false);
+        yield* recordCodeGraphSnapshotAdmission(
+          layout,
+          snapshot,
+          yield* observeCodeGraphAdmissionEnvironment(identity),
+          packs,
+          false,
+        );
+        expect(yield* current()).toBe(true);
+        const exclude = path.join(repository.root, '.git', 'info', 'exclude');
+        const original = yield* fs.readFileString(exclude);
+        yield* fs.writeFileString(exclude, `excluded-${suffix}.ts\n`);
+        expect(yield* current()).toBe(false);
+        yield* fs.writeFileString(exclude, original);
+        expect(yield* current()).toBe(true);
+      }).pipe(provideTestLayer(fixtureLayer), TestClock.withLive),
+    {fastCheck: {numRuns: 8}},
+  );
+
+  effectIt.effect('rejects admission policy changes during snapshot publication', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const store = yield* CodeGraphStore;
+      const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-scale-admission-race-'});
+      const home = path.join(root, 'home');
+      const changingStore = CodeGraphStore.of({
+        ...store,
+        promote: (databasePath, identity, snapshotId, options) =>
+          store
+            .promote(databasePath, identity, snapshotId, options)
+            .pipe(
+              Effect.tap(() =>
+                fs
+                  .writeFileString(
+                    path.join(identity.repoRoot, '.git', 'info', 'exclude'),
+                    'changed-during-publication.ts\n',
+                  )
+                  .pipe(Effect.orDie),
+              ),
+            ),
+      });
+      const result = yield* prepareContextBriefCitationScaleRepositories(
+        fs,
+        path,
+        home,
+        root,
+        budget.profiles[0],
+        1,
+      ).pipe(Effect.provideService(CodeGraphStore, changingStore), Effect.result);
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) expect(result.failure.message).toContain('admission policy changed');
+    }).pipe(provideTestLayer(fixtureLayer), TestClock.withLive),
+  );
+});


### PR DESCRIPTION
The mandatory Context Brief release benchmark failed before measurements because its prebuilt SQLite snapshots lacked the admission receipts now required by production graph freshness checks. A matching snapshot was correctly reported stale, so both independent hosted runs produced no performance artifact.

Capture the fixture repository's admission environment before snapshot publication, reject policy drift after activation/promotion, and record the normal production admission receipt with the injected language registry. Strict currentness checks and all fixture data, hashes, sample counts, runner requirements, latency budgets, and RSS gates remain unchanged.

Validation:
- The minimal real Git/SQLite fixture reproduced missing currentness before the fix.
- 26 focused tests pass, including an eight-run property covering missing receipts and policy changes, and deterministic rejection of policy drift during publication.
- Lint, source/test/website typechecks, formatting, and diff checks pass; independent review found no blockers.
- Exact-HEAD global installation and doctor pass. A built 200-memory smoke completed all three profiles with all 179 prebuilt graphs current; only the expected development-smoke/corpus-size gate gaps remain. Isolated installed Context Brief CLI smoke also passes. Full 100k qualification will run on the next merged release candidate.
