### PR TITLE
perf: reuse unchanged graph contract digests

### DIFF
--- a/src/code_graph/cached_contract_hash.ts
+++ b/src/code_graph/cached_contract_hash.ts
@@ -1,0 +1,16 @@
+import {sha256HexSync} from '../crypto/sha256.js';
+
+const MAXIMUM_CACHED_INPUT_CODE_UNITS = 64 * 1_024;
+
+/** Cache only a pure digest; callers still rebuild and compare every contract input. */
+export function createCachedCodeGraphContractHash(): (owner: object, input: string) => string {
+  const cache = new WeakMap<object, {readonly input: string; readonly digest: string}>();
+  return (owner, input) => {
+    const previous = cache.get(owner);
+    if (previous?.input === input) return previous.digest;
+    const digest = sha256HexSync(input);
+    if (input.length <= MAXIMUM_CACHED_INPUT_CODE_UNITS) cache.set(owner, {input, digest});
+    else cache.delete(owner);
+    return digest;
+  };
+}

--- a/src/code_graph/inventory_reuse.ts
+++ b/src/code_graph/inventory_reuse.ts
@@ -21,9 +21,12 @@ import {codeGraphUtf8ByteLength} from './disk_capacity.js';
 import {compareCodeUnits} from './ordering.js';
 import type {CodeGraphAttributionContextFile} from './store_models.js';
 import {isRepositoryFactAttributionContextPath} from './extractor_context.js';
+import {createCachedCodeGraphContractHash} from './cached_contract_hash.js';
 
 const ATTRIBUTION_CONTEXT_FILES_MAXIMUM = 10_000;
 const ATTRIBUTION_CONTEXT_BYTES_MAXIMUM = 16 * 1_048_576;
+const inventoryContractHash = createCachedCodeGraphContractHash();
+const opaqueInventoryContractHash = createCachedCodeGraphContractHash();
 
 export function codeGraphAttributionContextFilesForReceipt(
   files: readonly CodeGraphInventoryFile[],
@@ -132,7 +135,9 @@ export function codeGraphInventoryReuseContract(
       id: pack.id,
     }))
     .sort((left, right) => left.id.localeCompare(right.id));
-  return sha256HexSync(
+  const hashContract = includeOpaqueCorpusAssets ? opaqueInventoryContractHash : inventoryContractHash;
+  return hashContract(
+    languagePacks,
     JSON.stringify({
       admissionPolicy: CODE_GRAPH_INVENTORY_ADMISSION_POLICY_VERSION,
       contractVersion: CODE_GRAPH_INVENTORY_REUSE_CONTRACT_VERSION,

--- a/src/code_graph/languages/registry.ts
+++ b/src/code_graph/languages/registry.ts
@@ -1,5 +1,5 @@
 import {Context, Effect, Layer, Option} from 'effect';
-import {sha256HexSync} from '../../crypto/sha256.js';
+import {createCachedCodeGraphContractHash} from '../cached_contract_hash.js';
 import {CODE_GRAPH_PARSER_FACTS_VERSION} from '../fact_budget.js';
 import {BUILTIN_CODE_GRAPH_LANGUAGE_PACKS} from './catalog.generated.js';
 import {
@@ -23,6 +23,9 @@ import {
 } from '../rationale.js';
 
 export {CODE_GRAPH_PARSER_FACTS_VERSION} from '../fact_budget.js';
+
+const cacheIdentityHash = createCachedCodeGraphContractHash();
+const derivationIdentityHash = createCachedCodeGraphContractHash();
 
 export interface CodeGraphLanguagePackRegistryShape {
   readonly activeCacheIdentities: (paths: readonly string[]) => readonly string[];
@@ -172,7 +175,8 @@ export function packCacheIdentity(pack: CodeGraphLanguagePack): string {
     .map(asset => `${asset.relativePath}:${asset.sha256}:${asset.abi}:${asset.version}`)
     .sort()
     .join('\n');
-  return sha256HexSync(
+  return cacheIdentityHash(
+    pack,
     [
       'code-graph-language-pack-v3',
       CODE_GRAPH_PARSER_FACTS_VERSION,
@@ -191,7 +195,8 @@ export function packDerivationIdentity(pack: CodeGraphLanguagePack): string {
     .map(matcher => `${matcher.kind}:${matcher.value.toLowerCase()}:${matcher.language}:${matcher.role}`)
     .sort()
     .join('\n');
-  return sha256HexSync(
+  return derivationIdentityHash(
+    pack,
     [
       'code-graph-language-pack-derivation-v1',
       `postprocessors:${CODE_GRAPH_RATIONALE_EXTRACTOR_VERSION}`,

--- a/test/unit/code-graph.contract-hash-cache.property.test.ts
+++ b/test/unit/code-graph.contract-hash-cache.property.test.ts
@@ -1,0 +1,130 @@
+import {createHash} from 'node:crypto';
+import fc from 'fast-check';
+import {describe, expect, it} from 'vitest';
+import {createCachedCodeGraphContractHash} from '../../src/code_graph/cached_contract_hash.js';
+import {codeGraphInventoryReuseContract} from '../../src/code_graph/inventory_reuse.js';
+import {
+  BUILTIN_LANGUAGE_PACK_REGISTRY,
+  packCacheIdentity,
+  packDerivationIdentity,
+} from '../../src/code_graph/languages/registry.js';
+import type {CodeGraphLanguagePack} from '../../src/code_graph/languages/types.js';
+
+const nativeHash = (input: string) => createHash('sha256').update(input).digest('hex');
+const fixturePack = BUILTIN_LANGUAGE_PACK_REGISTRY.packs[0];
+const mutableFixturePack = BUILTIN_LANGUAGE_PACK_REGISTRY.packs.find(pack => pack.assets.length > 0)!;
+
+function clonePack(pack: CodeGraphLanguagePack) {
+  return {
+    ...pack,
+    assets: pack.assets.map(asset => ({...asset})),
+    capabilities: new Set(pack.capabilities),
+    extractor: {...pack.extractor},
+    files: pack.files.map(file => ({...file})),
+    resolutionStrategy: {...pack.resolutionStrategy},
+  };
+}
+
+function packState(pack: CodeGraphLanguagePack): string {
+  return JSON.stringify({...pack, capabilities: [...pack.capabilities]});
+}
+
+describe('code graph pure contract digest caches', () => {
+  it('preserves retained catalog contract and language-pack digests', () => {
+    expect(fixturePack.id).toBe('apex');
+    expect(packCacheIdentity(fixturePack)).toBe('fbf422bfd91437e705e1eb2ee583487b40b27719a6be49f8e014fb44d4faecd3');
+    expect(packDerivationIdentity(fixturePack)).toBe(
+      'caacde722edfe4f0f411f12dfc71b5a592c2c6a4e9218cc0415301af80c17a22',
+    );
+    expect(codeGraphInventoryReuseContract(BUILTIN_LANGUAGE_PACK_REGISTRY, false)).toBe(
+      '0dfda8c81dfdb76e49efe5ba28377987206430886a1ccb8252b3516c2b7b4919',
+    );
+    expect(codeGraphInventoryReuseContract(BUILTIN_LANGUAGE_PACK_REGISTRY, true)).toBe(
+      'f09ceb40f50c5e59db7ca46679b4e7b2b141be2d3959aac67427294108cc076e',
+    );
+  });
+
+  it('matches native SHA-256 across owner reuse, changed inputs, and restored inputs', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.record({owner: fc.integer({min: 0, max: 3}), input: fc.string({maxLength: 250})}), {
+          minLength: 1,
+          maxLength: 20,
+        }),
+        operations => {
+          const hash = createCachedCodeGraphContractHash();
+          const owners = Array.from({length: 4}, (_, id) => Object.freeze({id}));
+          for (const {owner, input} of [...operations, ...[...operations].reverse()]) {
+            expect(hash(owners[owner], input)).toBe(nativeHash(input));
+            expect(hash(owners[owner], input)).toBe(nativeHash(input));
+          }
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  it('preserves exact UTF-8 hashing across the cache limit and oversized fallback', () => {
+    const hash = createCachedCodeGraphContractHash();
+    const owner = Object.freeze({});
+    for (const input of [
+      'before',
+      '\u0000\ud800\udfff\ud83d\ude80',
+      'x'.repeat(65_536),
+      'y'.repeat(65_537),
+      'before',
+    ]) {
+      expect(hash(owner, input)).toBe(nativeHash(input));
+      expect(hash(owner, input)).toBe(nativeHash(input));
+    }
+  });
+
+  it('detects in-place policy and pack mutations without changing the input objects', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            field: fc.constantFrom('matcher', 'role', 'asset', 'extractor', 'version', 'resolver', 'capability', 'id'),
+            suffix: fc.integer({min: 0, max: 100_000}),
+            opaque: fc.boolean(),
+          }),
+          {minLength: 1, maxLength: 15},
+        ),
+        mutations => {
+          const pack = clonePack(mutableFixturePack);
+          const registry = {...BUILTIN_LANGUAGE_PACK_REGISTRY, packs: [pack]};
+          const original = packState(pack);
+          const originalHashes = [packCacheIdentity(pack), packDerivationIdentity(pack)];
+          const originalContracts = [false, true].map(opaque => codeGraphInventoryReuseContract(registry, opaque));
+          for (const {field, suffix, opaque} of mutations) {
+            if (field === 'matcher') pack.files[0].value = `.changed-${suffix}`;
+            else if (field === 'role') pack.files[0].role = suffix % 2 === 0 ? 'manifest' : 'source';
+            else if (field === 'asset') pack.assets[0].version = `asset-${suffix}`;
+            else if (field === 'extractor') pack.extractor.version = `extractor-${suffix}`;
+            else if (field === 'version') pack.version = `version-${suffix}`;
+            else if (field === 'resolver') pack.resolutionStrategy.version = `resolver-${suffix}`;
+            else if (field === 'capability') {
+              if (suffix % 2 === 0) pack.capabilities.add('declarations');
+              else pack.capabilities.delete('declarations');
+            } else pack.id = `identity-${suffix}`;
+            const before = packState(pack);
+            const fresh = clonePack(pack);
+            expect(packCacheIdentity(pack)).toBe(packCacheIdentity(fresh));
+            expect(packDerivationIdentity(pack)).toBe(packDerivationIdentity(fresh));
+            expect(codeGraphInventoryReuseContract(registry, opaque)).toBe(
+              codeGraphInventoryReuseContract({...registry, packs: [fresh]}, opaque),
+            );
+            expect(packState(pack)).toBe(before);
+          }
+          Object.assign(pack, clonePack(mutableFixturePack));
+          expect(packState(pack)).toBe(original);
+          expect([packCacheIdentity(pack), packDerivationIdentity(pack)]).toEqual(originalHashes);
+          expect([false, true].map(opaque => codeGraphInventoryReuseContract(registry, opaque))).toEqual(
+            originalContracts,
+          );
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+});


### PR DESCRIPTION
Graph freshness checks repeatedly hash identical language-pack and inventory-admission contracts. Reuse only the SHA-256 result when the complete canonical input string still matches. Each digest domain retains one bounded entry per live registry or pack through a WeakMap; oversized input evicts that entry and hashes normally.

Every call still rebuilds its canonical input, so in-place matcher, asset, resolver, capability, and policy changes invalidate the cache. Existing digest bytes, both admission-environment observations, receipt reads, Git/file mutation checks, snapshot selection, and strict final freshness checks are preserved.

Validation:
- 23 focused tests passed after normally merging current main into `d705d406d723ecec7dde438f5186e2bed6aa92c6`, including native SHA-256 equivalence, Unicode/size boundaries, retained digest compatibility, same-owner mutations and restoration, admission receipts, inventory/parser-budget properties, and the merged Context Brief scale fixture. Lint, formatting, and source/test/website typechecks passed.
- Independent review of exact `fdee84c72f330c30b79f124368210054c1ba0ed7` found no blockers.
- Exact-HEAD global install and doctor verification passed again at `d705d406d723ecec7dde438f5186e2bed6aa92c6`; superseded processes were cleaned up. Installed CLI indexed a two-file fixture and verified current results across adding/removing an exclusion policy; the excluded symbol disappeared and returned while the retained symbol remained.
- Five alternating digest microbenchmark batches (100 catalog-wide iterations each) measured 850–877 ms before and 13–16 ms after. This measures the targeted digest work only.
- Clean baseline `83d35bf6` and original candidate `fdee84c7` default 25-sample/5-warmup fixture benchmarks both passed unchanged budgets. Observed hot-query p50/p95 was 70.195/75.597 ms before and 101.755/111.010 ms after; these local observations do not establish end-to-end latency improvement. Hosted release qualification must run on the final merged candidate.

No budget, runner, sample-count, or freshness-policy changes.
