### PR TITLE
perf(recall): avoid dense neighborhood sorting before bounded selection

### DIFF
--- a/.github/release-notes/v4.6.8.md
+++ b/.github/release-notes/v4.6.8.md
@@ -12,6 +12,8 @@ Hosted Cloud agents use project hooks: `threadnote install-hooks cursor --target
 
 Graph fact serialization reuses its exact JSON byte measurement, reducing indexing work while preserving the same storage budgets and graph structure. Context Brief retries interrupted deferred-link finalization within bounded limits and reports unavailable recall coverage when recovery cannot complete.
 
+Memory Connections selects bounded neighborhoods directly in canonical order, avoiding a full neighborhood sort for heavily linked memories. Authorization and live source verification remain in place.
+
 The production performance gate distinguishes an initial wall-timing screening miss from a hard-objective failure. A protected-base control and confirmatory candidate that both pass the static limit can clear an allowlisted screening miss only when every observation still meets its hard objective.
 
 ### Shared graph preview improvements

--- a/src/recall/index.ts
+++ b/src/recall/index.ts
@@ -194,7 +194,7 @@ interface RecallTermStatisticRow {
   readonly term: string;
 }
 
-const RECALL_INDEX_DATABASE_VERSION = 12;
+const RECALL_INDEX_DATABASE_VERSION = 13;
 const RECALL_INDEX_POINTER_VERSION = 1;
 const ACTIVE_DATABASE_FILENAME = `active-v${RECALL_INDEX_DATABASE_VERSION}.sqlite`;
 const INACTIVE_DATABASE_FILENAME = `with-inactive-v${RECALL_INDEX_DATABASE_VERSION}.sqlite`;
@@ -1083,6 +1083,7 @@ const initializeRecallDatabase = Effect.fn('recall.initializeDatabase')(function
   yield* sql.unsafe(`
     CREATE TABLE IF NOT EXISTS memory_links (
       source_document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+      source_uri TEXT NOT NULL,
       source_memory_id TEXT NOT NULL,
       target_memory_id TEXT NOT NULL,
       target_locator_digest TEXT NOT NULL CHECK (
@@ -1144,10 +1145,10 @@ const initializeRecallDatabase = Effect.fn('recall.initializeDatabase')(function
     'CREATE INDEX IF NOT EXISTS code_links_selector_uri ON code_links(selector_kind, selector_digest, document_uri COLLATE BINARY, citation_ordinal, document_id)',
   );
   yield* sql.unsafe(
-    'CREATE INDEX IF NOT EXISTS memory_links_source ON memory_links(source_memory_id, relation_type, source_document_id, relation_origin, relation_ordinal)',
+    'CREATE INDEX IF NOT EXISTS memory_links_source ON memory_links(source_memory_id, relation_type, source_uri COLLATE BINARY, relation_origin, relation_ordinal, target_memory_id, target_locator_digest, source_document_id)',
   );
   yield* sql.unsafe(
-    "CREATE INDEX IF NOT EXISTS memory_links_target ON memory_links(target_memory_id, relation_type, source_document_id, relation_origin, relation_ordinal) WHERE target_memory_id <> ''",
+    "CREATE INDEX IF NOT EXISTS memory_links_target ON memory_links(target_memory_id, relation_type, source_uri COLLATE BINARY, relation_origin, relation_ordinal, target_locator_digest, source_document_id) WHERE target_memory_id <> ''",
   );
   yield* sql.unsafe(
     "CREATE INDEX IF NOT EXISTS memory_links_locator ON memory_links(target_locator_digest, relation_type, source_document_id, relation_origin, relation_ordinal) WHERE target_locator_digest <> ''",
@@ -1440,6 +1441,7 @@ const refreshRecallDatabase = Effect.fn('recall.refreshDatabase')(function* (
       yield* sql.unsafe(`
         INSERT INTO memory_links (
           source_document_id,
+          source_uri,
           source_memory_id,
           target_memory_id,
           target_locator_digest,
@@ -1449,6 +1451,7 @@ const refreshRecallDatabase = Effect.fn('recall.refreshDatabase')(function* (
         )
         SELECT
           document.id,
+          document.uri,
           memory_link.source_memory_id,
           memory_link.target_memory_id,
           memory_link.target_locator_digest,

--- a/src/recall/memory_links.ts
+++ b/src/recall/memory_links.ts
@@ -549,6 +549,9 @@ function buildBoundedRecallMemoryLinkRawQueryWithContext(
   queryLimit: number,
 ): RecallMemoryLinkRawSelectionQuery | undefined {
   if (!Number.isSafeInteger(queryLimit) || queryLimit < 1 || seeds.length === 0) return undefined;
+  // The private cached source URI follows the same canonical ordering as the
+  // selector index. Sorting a joined document URI would visit an entire dense
+  // neighborhood before LIMIT; the equality join still verifies the cached URI.
   const selectorColumn = direction === 'outgoing' ? 'source_memory_id' : 'target_memory_id';
   const selectorIndex = direction === 'outgoing' ? 'memory_links_source' : 'memory_links_target';
   // SQLite requires the explicit partial-index predicate; equality to a
@@ -572,6 +575,7 @@ function buildBoundedRecallMemoryLinkRawQueryWithContext(
         ? AS requested_memory_id
       FROM memory_links AS memory_link INDEXED BY ${selectorIndex}
       INNER JOIN documents AS document ON document.id = memory_link.source_document_id
+        AND document.uri = memory_link.source_uri
       WHERE memory_link.${selectorColumn} = ?
         ${selectorIndexPredicate}
         AND ${context.scope.sql}
@@ -579,7 +583,7 @@ function buildBoundedRecallMemoryLinkRawQueryWithContext(
         AND ${context.sourcePredicate}
       ORDER BY
         memory_link.relation_type COLLATE BINARY,
-        document.uri COLLATE BINARY,
+        memory_link.source_uri COLLATE BINARY,
         memory_link.relation_origin COLLATE BINARY,
         memory_link.relation_ordinal,
         memory_link.target_memory_id COLLATE BINARY,

--- a/test/evaluation/README.md
+++ b/test/evaluation/README.md
@@ -5,7 +5,7 @@ developer home, network access, local canonical data, and model-generated releva
 
 ## MemoryConnectionsBench v1 (A+B)
 
-`fixtures/memory-connections-bench-v1/fixture.json` freezes the typed-authoring and schema-v12 projection contract.
+`fixtures/memory-connections-bench-v1/fixture.json` freezes the typed-authoring and memory-link selector projection contract introduced in schema v12. The private recall cache now uses schema v13: source URIs are copied from indexed documents to order bounded neighborhoods directly in the source/target indexes. Selector values, canonical proof requirements, fixture inputs, and result ordering are unchanged.
 Its operation traces exercise all five planned knowledge abilities, strict relation normalization and rejection,
 legacy target add/change/delete, stable-identity target moves, source replacement/deletion, and logical clean-rebuild
 parity:

--- a/test/unit/memory-connections-bench.test.ts
+++ b/test/unit/memory-connections-bench.test.ts
@@ -141,6 +141,7 @@ const executeProjectionTrace = Effect.fn('test.executeMemoryConnectionsProjectio
     if (!schemaChecked) {
       expect(memoryLinksColumns(home)).toEqual([
         'source_document_id',
+        'source_uri',
         'source_memory_id',
         'target_memory_id',
         'target_locator_digest',

--- a/test/unit/recall-memory-links.property.test.ts
+++ b/test/unit/recall-memory-links.property.test.ts
@@ -162,7 +162,7 @@ function readProjection(home: string): readonly Record<string, unknown>[] {
     return database
       .query<Record<string, unknown>, []>(
         `SELECT
-          source.uri AS source_uri,
+          link.source_uri,
           link.source_memory_id,
           link.target_memory_id,
           link.target_locator_digest,

--- a/test/unit/recall-memory-links.selection.test.ts
+++ b/test/unit/recall-memory-links.selection.test.ts
@@ -1,0 +1,195 @@
+import {Database} from 'bun:sqlite';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import {describe, expect} from 'vitest';
+import {SystemInfo} from '../../src/effect/system.js';
+import {formatMemoryDocument, MEMORY_RELATION_TYPES} from '../../src/memory/document.js';
+import {memoryIdentityAlias} from '../../src/memory/identity_alias.js';
+import {loadRecallIndexData, recallIndexDatabaseFilename} from '../../src/recall/index.js';
+import {buildBoundedRecallMemoryLinkRawQuery} from '../../src/recall/memory_links.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const RecallIndexTestLayer = Layer.merge(BunServices.layer, SystemInfo.layer);
+const user = 'ordered-memory-selector';
+const prefix = `threadnote://user/${user}/memories/durable/projects/threadnote`;
+interface Source {
+  readonly active: boolean;
+  readonly allowed: boolean;
+  readonly relation: (typeof MEMORY_RELATION_TYPES)[number];
+}
+interface SelectedRow {
+  readonly relation_ordinal: number;
+  readonly relation_origin: string;
+  readonly relation_type: string;
+  readonly source_uri: string;
+  readonly target_memory_id: string;
+}
+interface PlanRow {
+  readonly detail: string;
+  readonly id: number;
+  readonly parent: number;
+}
+const source = FC.record({
+  active: FC.boolean(),
+  allowed: FC.boolean(),
+  relation: FC.constantFrom(...MEMORY_RELATION_TYPES),
+});
+
+describe('bounded memory-link selector order', () => {
+  effectIt.effect(
+    'limits dense incoming and outgoing neighborhoods before the final bounded sort',
+    () =>
+      Effect.gen(function* () {
+        const sources = Array.from({length: 320}, () => ({
+          active: true,
+          allowed: true,
+          relation: 'related_to' as const,
+        }));
+        const home = yield* createFixture(sources);
+        yield* withDatabase(home, database => {
+          // Reassign cache row IDs without changing any source or link. URI order
+          // must not accidentally depend on insertion order or integer IDs.
+          database.transaction(() => {
+            database.exec('UPDATE documents SET id = 10000 - id');
+            database.exec('UPDATE memory_links SET source_document_id = 10000 - source_document_id');
+          })();
+          for (const direction of ['incoming', 'outgoing'] as const) {
+            const query = buildBoundedRecallMemoryLinkRawQuery(
+              direction,
+              [{memoryId: direction === 'incoming' ? 'tn_hub' : 'tn_shared_source', requestedOrdinal: 0}],
+              {allowedUriScopes: [prefix], includeInactive: true},
+              257,
+            )!;
+            const plan = database
+              .query<PlanRow, Array<number | string>>(`EXPLAIN QUERY PLAN ${query.sql}`)
+              .all(...query.params);
+            const selector = plan.find(row =>
+              row.detail.includes(`INDEX memory_links_${direction === 'incoming' ? 'target' : 'source'}`),
+            );
+            expect(selector).toBeDefined();
+            expect(plan.filter(row => row.detail.includes('TEMP B-TREE')).every(row => row.parent === 0)).toBe(true);
+            expect(plan.some(row => row.detail.startsWith('SCAN memory_link'))).toBe(false);
+            const rows = database.query<SelectedRow, Array<number | string>>(query.sql).all(...query.params);
+            expect(rows).toHaveLength(257);
+            expect(rows.map(row => row.source_uri)).toEqual(sources.slice(0, 257).map((_, index) => uri(index)));
+          }
+        });
+      }).pipe(provideTestLayer(RecallIndexTestLayer)),
+    30_000,
+  );
+
+  effectIt.effect.prop(
+    'matches an independent filtered and ordered model before each per-seed limit',
+    {
+      sources: FC.array(source, {minLength: 1, maxLength: 20}),
+      includeInactive: FC.boolean(),
+      limit: FC.integer({min: 1, max: 8}),
+      relationTypes: FC.subarray([...MEMORY_RELATION_TYPES]),
+    },
+    ({sources, includeInactive, limit, relationTypes}) =>
+      Effect.gen(function* () {
+        const home = yield* createFixture(sources);
+        yield* withDatabase(home, database => {
+          const allowedUriScopes = [
+            `${prefix}/missing.md`,
+            ...sources.flatMap((entry, index) => (entry.allowed ? [uri(index)] : [])),
+          ];
+          for (const direction of ['incoming', 'outgoing'] as const) {
+            const query = buildBoundedRecallMemoryLinkRawQuery(
+              direction,
+              [{memoryId: direction === 'incoming' ? 'tn_hub' : 'tn_shared_source', requestedOrdinal: 0}],
+              {allowedUriScopes, includeInactive, relationTypes},
+              limit,
+            )!;
+            const actual = database
+              .query<SelectedRow, Array<number | string>>(query.sql)
+              .all(...query.params)
+              .map(projectRow);
+            const expected = sources
+              .flatMap((entry, index) =>
+                entry.allowed &&
+                (includeInactive || entry.active) &&
+                (relationTypes.length === 0 || relationTypes.includes(entry.relation))
+                  ? [
+                      {
+                        relation_ordinal: 0,
+                        relation_origin: 'relation',
+                        relation_type: entry.relation,
+                        source_uri: uri(index),
+                        target_memory_id: 'tn_hub',
+                      },
+                    ]
+                  : [],
+              )
+              .sort(
+                (a, b) => compareBinary(a.relation_type, b.relation_type) || compareBinary(a.source_uri, b.source_uri),
+              )
+              .slice(0, limit);
+            expect(actual).toEqual(expected);
+          }
+        });
+      }).pipe(provideTestLayer(RecallIndexTestLayer)),
+    {fastCheck: {numRuns: 32}, timeout: 30_000},
+  );
+});
+
+function compareBinary(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left), Buffer.from(right));
+}
+
+function projectRow(row: SelectedRow): SelectedRow {
+  return {
+    relation_ordinal: row.relation_ordinal,
+    relation_origin: row.relation_origin,
+    relation_type: row.relation_type,
+    source_uri: row.source_uri,
+    target_memory_id: row.target_memory_id,
+  };
+}
+
+function uri(index: number): string {
+  return `${prefix}/source-${String(index).padStart(4, '0')}.md`;
+}
+
+const createFixture = Effect.fn('test.createOrderedMemoryLinkFixture')(function* (sources: readonly Source[]) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const home = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-memory-link-order-'});
+  const directory = path.join(home, 'data', 'local', 'user', user, 'memories', 'durable', 'projects', 'threadnote');
+  yield* fs.makeDirectory(directory, {recursive: true});
+  for (const [index, entry] of sources.entries()) {
+    const topic = `source-${String(index).padStart(4, '0')}`;
+    yield* fs.writeFileString(
+      path.join(directory, `${topic}.md`),
+      formatMemoryDocument(
+        'MEMORY',
+        {
+          kind: 'durable',
+          memoryId: 'tn_shared_source',
+          project: 'threadnote',
+          relations: [{type: entry.relation, uri: memoryIdentityAlias('tn_hub')}],
+          sourceAgentClient: 'test',
+          status: entry.active ? 'active' : 'archived',
+          timestamp: '2026-09-08T00:00:00.000Z',
+          topic,
+        },
+        `${topic} body`,
+      ),
+    );
+  }
+  yield* loadRecallIndexData(
+    {account: 'local', agentContextHome: home, user},
+    {forceRefresh: true, includeInactive: true},
+  );
+  return home;
+});
+
+function withDatabase<A>(home: string, use: (database: Database) => A) {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => new Database(`${home}/indexes/lexical/${recallIndexDatabaseFilename(true)}`)),
+    database => Effect.sync(() => use(database)),
+    database => Effect.sync(() => database.close()),
+  );
+}

--- a/test/unit/recall-memory-links.test.ts
+++ b/test/unit/recall-memory-links.test.ts
@@ -29,7 +29,7 @@ interface MemoryLinkRow {
 }
 
 describe('recall memory links', () => {
-  effectIt.effect('projects every canonical origin into opaque schema-v12 selectors', () =>
+  effectIt.effect('projects canonical origins into schema-v13 selectors with private source ordering', () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -104,6 +104,7 @@ describe('recall memory links', () => {
       const schema = yield* Effect.sync(() => inspectMemoryLinkSchema(home));
       expect(schema.columns).toEqual([
         'source_document_id',
+        'source_uri',
         'source_memory_id',
         'target_memory_id',
         'target_locator_digest',
@@ -114,9 +115,12 @@ describe('recall memory links', () => {
       expect(schema.sourceIndex).toEqual([
         'source_memory_id',
         'relation_type',
-        'source_document_id',
+        'source_uri',
         'relation_origin',
         'relation_ordinal',
+        'target_memory_id',
+        'target_locator_digest',
+        'source_document_id',
       ]);
       expect(schema.targetIndex[0]).toBe('target_memory_id');
       expect(schema.locatorIndex[0]).toBe('target_locator_digest');
@@ -268,6 +272,24 @@ describe('recall memory links', () => {
       yield* loadRecallIndexData(runtime, {includeInactive: false});
       expect(readMemoryLinks(home)).toEqual(expected);
 
+      mutateMemoryLinks(home, "UPDATE memory_links SET source_uri = 'threadnote://user/other/memories/source.md'");
+      const query = buildBoundedRecallMemoryLinkRawQuery(
+        'incoming',
+        [{memoryId: 'tn_integrity_target', requestedOrdinal: 0}],
+        {allowedUriScopes: [`threadnote://user/${user}/memories`]},
+        5,
+      )!;
+      const selected = yield* Effect.acquireUseRelease(
+        Effect.sync(
+          () => new Database(`${home}/indexes/lexical/${recallIndexDatabaseFilename(false)}`, {readonly: true}),
+        ),
+        database => Effect.sync(() => database.query(query.sql).all(...query.params)),
+        database => Effect.sync(() => database.close()),
+      );
+      expect(selected).toEqual([]);
+      yield* loadRecallIndexData(runtime, {includeInactive: false});
+      expect(readMemoryLinks(home)).toEqual(expected);
+
       mutateMemoryLinks(home, 'DELETE FROM memory_links');
       expect(readMemoryLinks(home)).toEqual([]);
       yield* loadRecallIndexData(runtime, {includeInactive: false});
@@ -349,7 +371,7 @@ function readMemoryLinks(home: string, includeInactive = false): readonly Memory
     return database
       .query<MemoryLinkRow, []>(
         `SELECT
-          source.uri AS source_uri,
+          link.source_uri,
           link.source_memory_id,
           link.target_memory_id,
           link.target_locator_digest,


### PR DESCRIPTION
A required 4.6.8 qualification run returned correct Memory Connections results but failed lookup p95: 389.912 ms against the unchanged 250 ms limit. Dense incoming neighborhoods repeatedly sorted nearly 100,000 joined rows before taking the bounded prefix.

Recall cache schema v13 stores the already-private canonical source URI beside memory-link selectors and orders the source/target indexes by the existing complete selection order. The selector verifies that cached URI against the joined document and takes its per-seed limit directly from index order. Authorization, eligibility, currentness, canonical rereads, deterministic result ordering, truncation, fixture inputs, and all budgets remain unchanged. Old derived caches rebuild from canonical memory documents.

Validation:
- 54 focused tests at the final PR head cover selectors, incremental versus clean projection, corruption repair, canonical retrieval, frozen authoring/retrieval/scale contracts, and the integrated graph-contract digest and fixture-admission regressions. A new 32-run property checks filtering and canonical ordering against an independent model; a 320-neighbor regression reverses row IDs and rejects sorting inside the limited selector.
- Full precommit checks passed: lint, repository formatting, and source/test/website typechecks. Independent agent review found no blockers.
- An isolated 100,000-link SQL reproduction on the same local machine returned the same 257 rows while p95 fell from 149.112 ms to 0.614 ms. This measures the selector only; hosted release qualification must establish the full lookup result.

Exact clean 90d489005da273505561eedff472f3d23a918914 global installation, doctor verification, and superseded-process cleanup passed. The installed CLI resolved the canonical hub, returned exactly neighbors 00–07 from 12 active incoming links with explicit truncation, excluded archived and out-of-scope neighbors, and produced identical cold/warm output; schema-v13 cached URIs and integrity sequences matched. All fixtures were isolated and removed. The built local 100,000-memory development workload completed at clean b116d8ae8f6b23ce42ad9b01ec7097757449fe64 with 25 samples and 5 warmups per scenario; the final PR head retains the identical eight-file selector patch after integrating current main. Its semantic fixture hash matches the failed hosted candidate. Independent metric rederivation matches exactly; all correctness, performance, and resource requirements pass (pooled p95 22.094 ms, maximum 22.856 ms, 257 raw rows, 65 canonical rereads, 426.8 MB recall storage). Its sole gate rejection is the expected development-smoke provenance; it is not hosted release qualification. Full-suite validation runs in this PR's CI; no full suite was run locally. This addresses an additional release blocker discovered after the four original issues were fixed.
