### PR TITLE
Reduce repeated graph query and citation validation work

### DIFF
--- a/src/code_graph/repository.ts
+++ b/src/code_graph/repository.ts
@@ -424,29 +424,17 @@ const resolveExpectedRepositoryIdentity = Effect.fn('codeGraph.resolveExpectedRe
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const system = yield* SystemInfo;
-  const branchOrWorktree = observeWorktree
-    ? runCommandEffect(
-        'git',
-        ['--no-optional-locks', '-C', cwd, 'status', '--porcelain=v2', '-z', '--branch', '--untracked-files=normal'],
-        {maxOutputBytes: REPOSITORY_STATUS_OBSERVATION_BYTES_MAXIMUM, timeoutMs: 10_000},
-      ).pipe(Effect.map(result => ({kind: 'worktree' as const, output: result.stdout})))
-    : observeRepositoryBranch(cwd).pipe(Effect.map(branch => ({branch, kind: 'branch' as const})));
-  const [metadataResult, ignoreCaseResult, remoteResult, observed] = yield* Effect.all(
-    [
-      runGit(cwd, [
-        'rev-parse',
-        '--path-format=absolute',
-        '--show-toplevel',
-        '--git-common-dir',
-        '--show-object-format',
-        'HEAD',
-      ]),
-      runGit(cwd, ['config', '--bool', 'core.ignorecase'], true),
-      runGit(cwd, ['remote', 'get-url', 'origin'], true),
-      branchOrWorktree,
-    ],
-    {concurrency: 4},
-  ).pipe(
+  // Bind every later observation to the checkout selected by this metadata read.
+  // Running remote/config against the caller in parallel can mix an ABA-retargeted
+  // caller's values with this checkout even when both checkouts share the same HEAD.
+  const metadataResult = yield* runGit(cwd, [
+    'rev-parse',
+    '--path-format=absolute',
+    '--show-toplevel',
+    '--git-common-dir',
+    '--show-object-format',
+    'HEAD',
+  ]).pipe(
     Effect.mapError(() => CodeGraphRepositoryError.make({message: 'Repository identity could not be revalidated.'})),
   );
   const metadata = metadataResult.stdout.replace(/\r?\n$/u, '').split(/\r?\n/u);
@@ -469,11 +457,28 @@ const resolveExpectedRepositoryIdentity = Effect.fn('codeGraph.resolveExpectedRe
   if (objectFormat !== 'sha1' && objectFormat !== 'sha256') {
     return yield* CodeGraphRepositoryError.make({message: `Unsupported Git object format: ${objectFormat}`});
   }
-  const worktree =
-    observed.kind === 'worktree'
-      ? parseRepositoryIdentityWorktreeObservation(observed.output, objectFormat)
-      : undefined;
-  if (observed.kind === 'worktree' && (worktree === undefined || worktree.headCommit !== metadata[3])) {
+  const branchOrWorktree = observeWorktree
+    ? observeRepositoryReadFenceClosingWorktree(cwd, objectFormat).pipe(
+        Effect.map(worktree => ({kind: 'worktree' as const, worktree})),
+      )
+    : observeRepositoryBranch(repoRoot).pipe(Effect.map(branch => ({branch, kind: 'branch' as const})));
+  const [ignoreCaseResult, remoteResult, observed] = yield* Effect.all(
+    [
+      runGit(repoRoot, ['config', '--bool', 'core.ignorecase'], true),
+      runGit(repoRoot, ['remote', 'get-url', 'origin'], true),
+      branchOrWorktree,
+    ],
+    {concurrency: 3},
+  ).pipe(
+    Effect.mapError(() => CodeGraphRepositoryError.make({message: 'Repository identity could not be revalidated.'})),
+  );
+  const worktree = observed.kind === 'worktree' ? observed.worktree : undefined;
+  if (
+    worktree !== undefined &&
+    (worktree.headCommit !== metadata[3] ||
+      worktree.repoRoot !== repoRoot ||
+      worktree.gitCommonDirectory !== gitCommonDirectory)
+  ) {
     return yield* CodeGraphRepositoryError.make({
       message: 'Repository identity changed during the worktree observation.',
     });

--- a/src/code_graph/store_schema_normalization.ts
+++ b/src/code_graph/store_schema_normalization.ts
@@ -1,4 +1,32 @@
+const normalizedDefinitions = new Map<string, string>();
+const MAXIMUM_CACHED_DEFINITIONS = 128;
+const MAXIMUM_CACHED_DEFINITION_CODE_UNITS = 16 * 1_024;
+const MAXIMUM_CACHED_CODE_UNITS = 256 * 1_024;
+let cachedCodeUnits = 0;
+
 export function normalizeSchemaDefinition(value: string): string {
+  const cached = normalizedDefinitions.get(value);
+  if (cached !== undefined) return cached;
+  const normalized = normalizeUncachedSchemaDefinition(value);
+  const codeUnits = value.length + normalized.length;
+  // Cache only this pure transformation. Callers still read every schema
+  // observation, and changed SQL must match its own exact string key.
+  if (codeUnits > MAXIMUM_CACHED_DEFINITION_CODE_UNITS) return normalized;
+  while (
+    normalizedDefinitions.size >= MAXIMUM_CACHED_DEFINITIONS ||
+    cachedCodeUnits + codeUnits > MAXIMUM_CACHED_CODE_UNITS
+  ) {
+    const oldest = normalizedDefinitions.keys().next();
+    if (oldest.done) break;
+    cachedCodeUnits -= oldest.value.length + normalizedDefinitions.get(oldest.value)!.length;
+    normalizedDefinitions.delete(oldest.value);
+  }
+  normalizedDefinitions.set(value, normalized);
+  cachedCodeUnits += codeUnits;
+  return normalized;
+}
+
+function normalizeUncachedSchemaDefinition(value: string): string {
   const quoted: string[] = [];
   let unquoted = '';
   for (let index = 0; index < value.length; index += 1) {

--- a/src/context_brief/citation_validation.ts
+++ b/src/context_brief/citation_validation.ts
@@ -399,15 +399,20 @@ const statusRepositoryFinalFence = (
         ),
       );
     }
-    const after = yield* repository.expected === undefined
+    // A locally discovered identity also supplies the expected routing IDs. Reobserve
+    // identity, policy, runtime and worktree state without recording its association twice.
+    // Keep legacy custom query services on their full status path.
+    const after = yield* repository.expected === undefined && typeof query.statusForPublishedIdentity !== 'function'
       ? query.status(config.agentContextHome, repository.cwd, {
           observeWorktree: true,
           requestMaintenance: false,
         })
-      : query.statusForPublishedIdentity(config.agentContextHome, repository.cwd, repository.expected, {
-          observeWorktree: true,
-          requestMaintenance: false,
-        });
+      : query.statusForPublishedIdentity(
+          config.agentContextHome,
+          repository.cwd,
+          repository.expected ?? repository.status.identity,
+          {observeWorktree: true, requestMaintenance: false},
+        );
     return sameExactSnapshot(repository.status, after);
   });
 

--- a/src/share/scrubber.ts
+++ b/src/share/scrubber.ts
@@ -135,9 +135,24 @@ export function redactSensitiveText(content: string): string {
   return redacted;
 }
 
+const globalPatterns = new WeakMap<RegExp, {readonly source: string; readonly flags: string; readonly regex: RegExp}>();
+const MAXIMUM_CACHED_PATTERN_CODE_UNITS = 64 * 1_024;
+
 function globalize(regex: RegExp): RegExp {
-  const flags = regex.flags.includes('g') ? regex.flags : `${regex.flags}g`;
-  return new RegExp(regex.source, flags);
+  // Patterns are public and may be recompiled in place. Observe both inputs
+  // on every use, and keep the stateful matching clone private.
+  const flags = regex.flags;
+  const source = regex.source;
+  const cached = globalPatterns.get(regex);
+  if (cached?.source === source && cached.flags === flags) {
+    cached.regex.lastIndex = 0;
+    return cached.regex;
+  }
+  const globalRegex = new RegExp(source, flags.includes('g') ? flags : `${flags}g`);
+  if (source.length <= MAXIMUM_CACHED_PATTERN_CODE_UNITS)
+    globalPatterns.set(regex, {source, flags, regex: globalRegex});
+  else globalPatterns.delete(regex);
+  return globalRegex;
 }
 
 function matchesPattern(regex: RegExp, content: string): boolean {

--- a/test/unit/code-graph.repository-expected-identity.test.ts
+++ b/test/unit/code-graph.repository-expected-identity.test.ts
@@ -1,6 +1,9 @@
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- Effect's symlink API lacks the junction type required for unprivileged Windows fixtures.
+import {symlinkSync} from 'node:fs';
 import {it as effectIt} from '@effect/vitest';
+import * as BunServices from '@effect/platform-bun/BunServices';
 import fc from 'fast-check';
-import {Effect, FileSystem, Path} from 'effect';
+import {Effect, FileSystem, Layer, Path} from 'effect';
 import {TestClock} from 'effect/testing';
 import {describe, expect, it} from 'vitest';
 import {
@@ -14,6 +17,8 @@ import {
 } from '../../src/code_graph/repository.js';
 import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
 import {ApplicationLayer} from '../../src/effect/runtime.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
 
 describe('code graph expected repository identity', () => {
   effectIt.layer(ApplicationLayer)(it => {
@@ -262,6 +267,131 @@ describe('code graph expected repository identity', () => {
     );
   });
 
+  effectIt.effect('binds expected identity observations to one checkout across same-HEAD caller retargets', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const command = yield* CommandExecutor;
+      const parent = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-expected-route-'});
+      const first = path.join(parent, 'first with spaces');
+      const clone = path.join(parent, 'clone');
+      const caller = path.join(parent, 'caller');
+      yield* fs.makeDirectory(first);
+      yield* git(first, ['init', '-q']);
+      yield* fs.writeFileString(path.join(first, 'tracked.ts'), 'original');
+      yield* git(first, ['add', '.']);
+      yield* git(first, [
+        '-c',
+        'commit.gpgsign=false',
+        '-c',
+        'user.name=Threadnote Test',
+        '-c',
+        'user.email=test@threadnote.local',
+        'commit',
+        '-qm',
+        'fixture',
+      ]);
+      yield* git(first, ['remote', 'add', 'origin', 'https://example.invalid/original.git']);
+      yield* git(first, ['config', 'core.ignorecase', 'false']);
+      yield* git(parent, ['clone', '--quiet', first, clone]);
+      yield* git(clone, ['remote', 'set-url', 'origin', 'https://example.invalid/original.git']);
+      yield* git(clone, ['config', 'core.ignorecase', 'false']);
+      yield* directoryLink(first, caller);
+      const identity = yield* resolveRepositoryIdentity(caller);
+      const expected = {
+        checkoutId: identity.checkoutId,
+        repositoryId: identity.repositoryId,
+        worktreeId: identity.worktreeId,
+      };
+      const canonicalFirst = yield* fs.realPath(first);
+      for (const mode of ['unchanged', 'retarget', 'aba-remote', 'aba-config'] as const) {
+        let metadataCompleted = false;
+        const invocations: string[][] = [];
+        const recording = CommandExecutor.of({
+          ...command,
+          execute: (executable, args, options) =>
+            Effect.gen(function* () {
+              const metadata = args.includes('--show-toplevel');
+              const status = args.includes('status');
+              invocations.push([...args]);
+              if (!metadata) {
+                expect(metadataCompleted).toBe(true);
+                expect(args[args.indexOf('-C') + 1]).toBe(status ? caller : canonicalFirst);
+              }
+              if (status && (mode === 'aba-remote' || mode === 'aba-config')) {
+                yield* fs.remove(caller);
+                yield* directoryLink(first, caller);
+              }
+              const result = yield* command.execute(executable, args, options);
+              if (metadata) {
+                metadataCompleted = true;
+                if (mode !== 'unchanged') {
+                  yield* fs.remove(caller);
+                  yield* directoryLink(clone, caller);
+                  if (mode === 'retarget') yield* fs.writeFileString(path.join(first, 'tracked.ts'), 'dirty original');
+                  if (mode === 'aba-config')
+                    yield* command.execute('git', ['-C', first, 'config', 'core.ignorecase', 'true']);
+                  if (mode === 'aba-remote')
+                    yield* command.execute('git', [
+                      '-C',
+                      first,
+                      'remote',
+                      'set-url',
+                      'origin',
+                      'https://example.invalid/replaced.git',
+                    ]);
+                }
+              }
+              return result;
+            }).pipe(Effect.orDie),
+        });
+        const observation = resolveRepositoryIdentityForExpectationAndWorktree(caller, expected).pipe(
+          Effect.provideService(CommandExecutor, recording),
+        );
+        if (mode === 'unchanged') expect(yield* observation).toEqual({identity, worktreeChanged: false});
+        else if (mode === 'aba-config')
+          expect(yield* observation).toEqual({
+            identity: {...identity, caseMode: 'insensitive'},
+            worktreeChanged: false,
+          });
+        else expect(yield* observation.pipe(Effect.flip)).toBeInstanceOf(Error);
+        expect(invocations).toHaveLength(4);
+        expect(invocations[0]).toContain('--show-toplevel');
+        expect(invocations.filter(args => args.includes('status'))).toHaveLength(1);
+        yield* fs.remove(caller);
+        yield* directoryLink(first, caller);
+        yield* fs.writeFileString(path.join(first, 'tracked.ts'), 'original');
+        yield* git(first, ['remote', 'set-url', 'origin', 'https://example.invalid/original.git']);
+        yield* git(first, ['config', 'core.ignorecase', 'false']);
+      }
+      for (const corrupt of ['missing', 'duplicate', 'control', 'bidi', 'wrong-root', 'wrong-common'] as const) {
+        const recording = CommandExecutor.of({
+          ...command,
+          execute: (executable, args, options) =>
+            command.execute(executable, args, options).pipe(
+              Effect.map(result => {
+                if (!args.includes('status')) return result;
+                const prefix = '00:00:00.000000 trace.c:1 setup: ';
+                const stderr =
+                  corrupt === 'missing'
+                    ? ''
+                    : corrupt === 'duplicate'
+                      ? result.stderr + result.stderr
+                      : `${prefix}git_common_dir: ${corrupt === 'wrong-common' ? path.join(clone, '.git') : identity.gitCommonDirectory}\n${prefix}worktree: ${corrupt === 'wrong-root' ? clone : canonicalFirst + (corrupt === 'control' ? '\0' : corrupt === 'bidi' ? '\u202e' : '')}\n`;
+                return {...result, stderr};
+              }),
+            ),
+        });
+        expect(
+          yield* resolveRepositoryIdentityForExpectationAndWorktree(caller, expected).pipe(
+            Effect.provideService(CommandExecutor, recording),
+            Effect.flip,
+          ),
+        ).toBeInstanceOf(Error);
+      }
+    }).pipe(provideTestLayer(expectedIdentityPlatformLayer), TestClock.withLive),
+  );
+
   it('never classifies a porcelain-v2 change record as a clean worktree', () => {
     const head = 'a'.repeat(40);
     fc.assert(
@@ -283,6 +413,11 @@ describe('code graph expected repository identity', () => {
         `${prefix}git_common_dir: /repo/.git\n${prefix}worktree: /repo with spaces\n`,
       ),
     ).toEqual({gitCommonDirectory: '/repo/.git', worktree: '/repo with spaces'});
+    for (const root of ['/repo with spaces', 'C:\\work tree\\repo', '//server/share/repo']) {
+      expect(
+        parseRepositoryReadFenceSetupObservation(`${prefix}git_common_dir: ${root}/.git\n${prefix}worktree: ${root}\n`),
+      ).toEqual({gitCommonDirectory: `${root}/.git`, worktree: root});
+    }
     expect(parseRepositoryReadFenceSetupObservation(`${prefix}worktree: /repo\n`)).toBeUndefined();
     expect(
       parseRepositoryReadFenceSetupObservation(
@@ -320,3 +455,12 @@ describe('code graph expected repository identity', () => {
 const git = Effect.fn('codeGraphExpectedIdentityTest.git')((cwd: string, args: readonly string[]) =>
   runCommandEffect('git', ['-C', cwd, ...args], {maxOutputBytes: 1_048_576, timeoutMs: 30_000}),
 );
+
+const expectedIdentityPlatformLayer = Layer.mergeAll(
+  SystemInfo.layer,
+  CommandExecutor.layer.pipe(Layer.provide(SystemInfo.layer)),
+).pipe(Layer.provideMerge(BunServices.layer));
+
+function directoryLink(target: string, link: string) {
+  return Effect.sync(() => symlinkSync(target, link, 'junction'));
+}

--- a/test/unit/code-graph.schema-normalization-cache.test.ts
+++ b/test/unit/code-graph.schema-normalization-cache.test.ts
@@ -1,0 +1,119 @@
+import * as SqliteClient from '@effect/sql-sqlite-bun/SqliteClient';
+import {describe, expect, it} from '@effect/vitest';
+import {Effect, Result} from 'effect';
+import * as FC from 'effect/testing/FastCheck';
+import * as SqlClient from 'effect/unstable/sql/SqlClient';
+import {inspectCodeGraphQueryIndexes} from '../../src/code_graph/store_query_indexes.js';
+import {normalizeSchemaDefinition} from '../../src/code_graph/store_schema_normalization.js';
+import {normalizeSchemaDefinition as normalizeUncachedVectorSchema} from '../../src/code_graph/vector_retirement_inspection.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const literal = FC.array(FC.constantFrom('A', 'a', ' ', '\n', "'", '"', '`', '[', ']', ',', 'İ', '😀'), {
+  maxLength: 40,
+}).map(characters => characters.join(''));
+const definition = FC.record({
+  identifierQuote: FC.constantFrom('"', '`', '['),
+  literal,
+  optional: FC.boolean(),
+  space: FC.constantFrom(' ', '\n', '\t', '  \n  '),
+  suffix: FC.nat(100_000),
+});
+
+describe('bounded pure schema normalization', () => {
+  it.prop(
+    'preserves the SQL grammar model and quoted bytes across changed inputs and repetition',
+    {definitions: FC.array(definition, {maxLength: 30, minLength: 1})},
+    ({definitions}) => {
+      for (const item of [...definitions, ...definitions.slice().reverse()]) {
+        const quote = item.identifierQuote;
+        const identifier = `${quote}Mixed_${item.suffix}${quote === '[' ? ']' : quote}`;
+        const quotedLiteral = `'${item.literal.replaceAll("'", "''")}'`;
+        const s = item.space;
+        const input = `${s}CREATE${s}TABLE${s}${item.optional ? `IF NOT EXISTS${s}` : ''}${identifier}${s}(${s}value${s}TEXT${s}CHECK${s}(${s}value${s}=${s}${quotedLiteral}${s})${s})${s}`;
+        const expected = `create table ${identifier}(value text check(value = ${quotedLiteral}))`;
+        expect(normalizeSchemaDefinition(input)).toBe(expected);
+        expect(normalizeSchemaDefinition(input)).toBe(expected);
+      }
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
+  it.prop(
+    'retains byte parity with the independent uncached vector-schema normalizer',
+    {
+      inputs: FC.array(
+        FC.array(
+          FC.constantFrom(
+            'CREATE ',
+            'IF NOT EXISTS',
+            'Ab',
+            '\u0000',
+            '\n',
+            'İ',
+            '😀',
+            "'",
+            '"',
+            '`',
+            '[',
+            ']',
+            '(',
+            ')',
+            ',',
+          ),
+          {
+            maxLength: 40,
+          },
+        ).map(parts => parts.join('')),
+        {maxLength: 15, minLength: 1},
+      ),
+    },
+    ({inputs}) => {
+      for (const value of [...inputs, ...inputs.slice().reverse()]) {
+        expect(normalizeSchemaDefinition(value)).toBe(normalizeUncachedVectorSchema(value));
+      }
+    },
+    {fastCheck: {numRuns: 100}},
+  );
+
+  it('keeps results stable under entry churn, byte-budget pressure and oversized inputs', () => {
+    const inputs = [
+      '',
+      ...Array.from({length: 160}, (_, index) => `CREATE TABLE short_${index}(value TEXT)`),
+      ...Array.from(
+        {length: 160},
+        (_, index) => `CREATE TABLE churn_${index}(value TEXT DEFAULT '${'A'.repeat(4_000)}')`,
+      ),
+      `CREATE TABLE oversized(value TEXT DEFAULT '${'Q'.repeat(100_000)}')`,
+    ];
+    const expected = inputs.map(normalizeUncachedVectorSchema);
+    for (const order of [inputs.map((_, index) => index), inputs.map((_, index) => index).reverse()]) {
+      for (const index of order) expect(normalizeSchemaDefinition(inputs[index])).toBe(expected[index]);
+    }
+  });
+
+  it.effect('rereads removed, corrupt and restored index definitions after warming normalization', () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const definition = {
+        createSql: 'CREATE INDEX IF NOT EXISTS symbols_path ON symbols(snapshot_id, path)',
+        name: 'symbols_path',
+        table: 'symbols' as const,
+      };
+      const inspect = () => inspectCodeGraphQueryIndexes(sql, [definition]);
+      yield* sql.unsafe('CREATE TABLE symbols(snapshot_id TEXT, path TEXT)');
+      yield* sql.unsafe(definition.createSql);
+      expect(yield* inspect()).toEqual({missing: []});
+      expect(yield* inspect()).toEqual({missing: []});
+      yield* sql.unsafe('DROP INDEX symbols_path');
+      expect(yield* inspect()).toEqual({missing: [definition]});
+      yield* sql.unsafe('CREATE INDEX symbols_path ON symbols(path, snapshot_id)');
+      expect(Result.isFailure(yield* inspect().pipe(Effect.result))).toBe(true);
+      yield* sql.unsafe('DROP INDEX symbols_path');
+      yield* sql.unsafe(definition.createSql);
+      expect(yield* inspect()).toEqual({missing: []});
+      yield* sql.unsafe('DROP INDEX symbols_path');
+      yield* sql.unsafe('CREATE INDEX symbols_path ON symbols(snapshot_id, path COLLATE NOCASE)');
+      expect(Result.isFailure(yield* inspect().pipe(Effect.result))).toBe(true);
+    }).pipe(provideTestLayer(SqliteClient.layer({disableWAL: true, filename: ':memory:'}))),
+  );
+});

--- a/test/unit/context-brief-citation-local-fence.test.ts
+++ b/test/unit/context-brief-citation-local-fence.test.ts
@@ -1,0 +1,266 @@
+// oxlint-disable-next-line effecttsgo/node-builtin-import -- Effect's symlink API lacks the junction type required for unprivileged Windows fixtures.
+import {symlinkSync} from 'node:fs';
+import * as BunServices from '@effect/platform-bun/BunServices';
+import {it as effectIt} from '@effect/vitest';
+import {Effect, FileSystem, Layer, Path} from 'effect';
+import {TestClock} from 'effect/testing';
+import fc from 'fast-check';
+import {describe, expect} from 'vitest';
+import {CodeGraphEmbeddingIndex} from '../../src/code_graph/embedding.js';
+import {CodeGraphIndexer} from '../../src/code_graph/indexer.js';
+import {
+  CodeGraphLanguagePackRegistry,
+  createCodeGraphLanguagePackRegistry,
+} from '../../src/code_graph/languages/registry.js';
+import {codeGraphLayout} from '../../src/code_graph/layout.js';
+import {CodeGraphMaintenanceCoordinator} from '../../src/code_graph/maintenance_coordinator.js';
+import {CodeGraphQueryService} from '../../src/code_graph/query.js';
+import {CodeGraphStore} from '../../src/code_graph/store.js';
+import type {RepositoryIdentityExpectation} from '../../src/code_graph/types.js';
+import {validateContextBriefMemoryCitations} from '../../src/context_brief/citation_validation.js';
+import {sha256HexSync} from '../../src/crypto/sha256.js';
+import {CommandExecutor, runCommandEffect} from '../../src/effect/command.js';
+import {SystemInfo} from '../../src/effect/system.js';
+import {
+  contextBriefCitationScaleExtractorSet,
+  prepareContextBriefCitationScaleRepositories,
+} from '../../src/evaluation/context-brief-citation-scale-fixture.js';
+import {createMemoryCodeCitation} from '../../src/memory/code_citation.js';
+import {provideTestLayer} from '../helpers/effect-layer.js';
+
+const systemLayer = SystemInfo.layer;
+const commandLayer = CommandExecutor.layer.pipe(Layer.provide(systemLayer));
+const platformLayer = Layer.mergeAll(systemLayer, commandLayer).pipe(Layer.provideMerge(BunServices.layer));
+const fixtureLayer = Layer.mergeAll(
+  CodeGraphStore.layer.pipe(Layer.provideMerge(platformLayer)),
+  Layer.succeed(CodeGraphLanguagePackRegistry, createCodeGraphLanguagePackRegistry([])),
+);
+const SOURCE_PATH = 'src/context-brief-scale/local-100k/tnscalelocal100krun000/000.ts';
+const mutations = [
+  'worktree',
+  'head',
+  'remote',
+  'caller-route',
+  'checkout-route',
+  'policy',
+  'receipt',
+  'provenance',
+] as const;
+type Mutation = (typeof mutations)[number] | 'none' | 'legacy-service';
+
+const scenario = (mutation: Mutation, suffix = 0) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const store = yield* CodeGraphStore;
+    const packs = yield* CodeGraphLanguagePackRegistry;
+    const command = yield* CommandExecutor;
+    const root = yield* fs.makeTempDirectoryScoped({prefix: 'threadnote-citation-local-fence-'});
+    const home = path.join(root, 'home');
+    const [repository] = yield* prepareContextBriefCitationScaleRepositories(
+      fs,
+      path,
+      home,
+      root,
+      {
+        citationCount: 1,
+        citedRepositories: 1,
+        id: 'local-100k',
+        maximumBriefP95Milliseconds: 1_500,
+        maximumValidationP95Milliseconds: 250,
+        selectedMemories: 1,
+        worksetMembers: 1,
+      },
+      1,
+    );
+    const caller = path.join(root, 'caller');
+    // A junction is also available without elevated symlink privileges on Windows.
+    yield* directoryLink(repository.root, caller);
+    const clone = path.join(root, 'clone');
+    if (mutation === 'caller-route' || mutation === 'checkout-route') {
+      yield* git(root, ['clone', '--quiet', repository.root, clone]);
+      yield* git(clone, ['remote', 'set-url', 'origin', repository.status.identity.remoteIdentity!]);
+    }
+    const citation = createMemoryCodeCitation({
+      extractorSet: contextBriefCitationScaleExtractorSet(),
+      fileContentHash: {algorithm: 'sha256', value: sha256HexSync(SOURCE_PATH)},
+      path: SOURCE_PATH,
+      repositoryId: repository.repositoryId,
+      repositoryIdentityKind: 'remote',
+      sourceCommit: repository.status.identity.headCommit,
+      sourceDirty: false,
+      sourceGraphContentId: repository.status.readySnapshot.graphContentId,
+      sourceSnapshotId: repository.snapshotId,
+      target: {kind: 'file'},
+      version: 1,
+    });
+    const config = {
+      account: 'local',
+      agentContextHome: home,
+      agentId: 'test',
+      manifestPath: path.join(home, 'manifest.yaml'),
+      user: 'test',
+    };
+    let evidenceRead = false;
+    let sessions = 0;
+    let leases = 0;
+    let expectedCalls = 0;
+    let ordinaryFinalCalls = 0;
+    const mutate = Effect.gen(function* () {
+      evidenceRead = true;
+      if (mutation === 'worktree') yield* fs.writeFileString(path.join(repository.root, SOURCE_PATH), 'changed');
+      if (mutation === 'head')
+        yield* git(repository.root, [
+          '-c',
+          'commit.gpgsign=false',
+          '-c',
+          'user.name=Threadnote Test',
+          '-c',
+          'user.email=test@threadnote.local',
+          'commit',
+          '--allow-empty',
+          '-qm',
+          'next',
+        ]);
+      if (mutation === 'remote')
+        yield* git(repository.root, ['remote', 'set-url', 'origin', `https://example.invalid/changed-${suffix}.git`]);
+      if (mutation === 'caller-route') {
+        yield* fs.remove(caller);
+        yield* directoryLink(clone, caller);
+      }
+      if (mutation === 'checkout-route') {
+        yield* fs.rename(path.join(repository.root, '.git'), path.join(root, 'saved-git'));
+        yield* fs.writeFileString(path.join(repository.root, '.git'), `gitdir: ${path.join(clone, '.git')}\n`);
+      }
+      if (mutation === 'policy')
+        yield* fs.writeFileString(path.join(repository.root, '.git', 'info', 'exclude'), `changed-${suffix}.ts\n`);
+      if (mutation === 'receipt')
+        yield* fs.remove(
+          path.join(
+            codeGraphLayout(path, home, repository.checkoutId, repository.worktreeId).repositoryRoot,
+            'admission',
+          ),
+          {recursive: true},
+        );
+    });
+    const observedStore = CodeGraphStore.of({
+      ...store,
+      acquireSnapshotLease: (...args) =>
+        store.acquireSnapshotLease(...args).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              leases += 1;
+            }),
+          ),
+        ),
+      releaseSnapshotLease: (...args) =>
+        store.releaseSnapshotLease(...args).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              leases -= 1;
+            }),
+          ),
+        ),
+      effectiveSnapshotCitationEvidence: (...args) =>
+        store
+          .effectiveSnapshotCitationEvidence(...args)
+          .pipe(Effect.tap(() => mutate.pipe(Effect.provideService(CommandExecutor, command), Effect.orDie))),
+      snapshotPackProvenance: (...args) =>
+        store
+          .snapshotPackProvenance(...args)
+          .pipe(Effect.map(provenance => (evidenceRead && mutation === 'provenance' ? undefined : provenance))),
+      withSession: (databasePath, effect, options) =>
+        Effect.sync(() => {
+          sessions += 1;
+        }).pipe(Effect.andThen(store.withSession(databasePath, effect, options))),
+    });
+    const unexpected = () => Effect.die(new Error('Citation validation must not index or maintain graphs.'));
+    const dependencies = Layer.mergeAll(
+      platformLayer,
+      Layer.succeed(CodeGraphStore, observedStore),
+      Layer.succeed(CodeGraphLanguagePackRegistry, packs),
+      Layer.succeed(CodeGraphIndexer, CodeGraphIndexer.of({ensureCommit: unexpected, index: unexpected})),
+      Layer.succeed(
+        CodeGraphMaintenanceCoordinator,
+        CodeGraphMaintenanceCoordinator.of({
+          kickOrdinary: unexpected,
+          kickReconciliation: unexpected,
+          kickResidual: unexpected,
+          request: unexpected,
+          tick: unexpected,
+        }),
+      ),
+      Layer.succeed(
+        CodeGraphEmbeddingIndex,
+        CodeGraphEmbeddingIndex.of({check: unexpected, ensure: unexpected, search: () => Effect.succeed(new Map())}),
+      ),
+    );
+    const validations = yield* Effect.gen(function* () {
+      const query = yield* CodeGraphQueryService;
+      const expected: RepositoryIdentityExpectation = repository.status.identity;
+      const observed = {
+        ...query,
+        status: (...args: Parameters<typeof query.status>) =>
+          Effect.sync(() => {
+            ordinaryFinalCalls += 1;
+          }).pipe(Effect.andThen(query.status(...args))),
+        statusForPublishedIdentity: (...args: Parameters<typeof query.statusForPublishedIdentity>) =>
+          Effect.sync(() => {
+            expectedCalls += 1;
+            expect(evidenceRead).toBe(true);
+            expect(leases).toBe(1);
+            expect(args[1]).toBe(caller);
+            expect(args[2]).toMatchObject(expected);
+            expect(args[3]).toMatchObject({observeWorktree: true, requestMaintenance: false});
+          }).pipe(Effect.andThen(query.statusForPublishedIdentity(...args))),
+      };
+      const custom =
+        mutation === 'legacy-service'
+          ? Object.fromEntries(Object.entries(observed).filter(([name]) => name !== 'statusForPublishedIdentity'))
+          : observed;
+      return yield* validateContextBriefMemoryCitations(config, {callerCwd: caller, kind: 'repository'}, [
+        {
+          citationErrorCount: 0,
+          codeCitations: [citation],
+          excerpt: 'fixture',
+          kind: 'durable',
+          rank: 0,
+          uri: `threadnote://user/test/memories/durable/projects/fixture/${mutation}-${suffix}.md`,
+        },
+      ]).pipe(Effect.provideService(CodeGraphQueryService, CodeGraphQueryService.of(custom as typeof query)));
+    }).pipe(provideTestLayer(CodeGraphQueryService.layer.pipe(Layer.provideMerge(dependencies))));
+    const receipts = validations.flatMap(value => value.receipts);
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].status).toBe(mutation === 'none' || mutation === 'legacy-service' ? 'exact' : 'unknown');
+    if (mutation === 'none' || mutation === 'legacy-service') expect(receipts[0].coverage).toBe('current-complete');
+    expect(expectedCalls).toBe(mutation === 'legacy-service' ? 0 : 1);
+    expect(ordinaryFinalCalls).toBe(mutation === 'legacy-service' ? 1 : 0);
+    expect(sessions).toBe(1);
+    expect(leases).toBe(0);
+  }).pipe(provideTestLayer(fixtureLayer), TestClock.withLive);
+
+describe('Context Brief local citation closing observation', () => {
+  effectIt.effect('reobserves a locally discovered identity after evidence within its lease and session', () =>
+    scenario('none'),
+  );
+  effectIt.effect('preserves full status fallback for custom services without expected-identity support', () =>
+    scenario('legacy-service'),
+  );
+  for (const mutation of mutations) {
+    effectIt.effect(`rejects a between-observation ${mutation} change`, () => scenario(mutation));
+  }
+  effectIt.effect.prop(
+    'rejects independently changed remote identities',
+    {suffix: fc.nat(100_000)},
+    ({suffix}) => scenario('remote', suffix),
+    {fastCheck: {numRuns: 5}},
+  );
+});
+
+function git(cwd: string, args: readonly string[]) {
+  return runCommandEffect('git', ['-C', cwd, ...args], {maxOutputBytes: 16_384, timeoutMs: 10_000});
+}
+
+function directoryLink(target: string, link: string) {
+  return Effect.sync(() => symlinkSync(target, link, 'junction'));
+}

--- a/test/unit/share.scrubber-cache.property.test.ts
+++ b/test/unit/share.scrubber-cache.property.test.ts
@@ -1,0 +1,91 @@
+import {describe, expect, it} from '@effect/vitest';
+import * as FC from 'effect/testing/FastCheck';
+import {applyScrubber, redactSensitiveText, SCRUBBER_PATTERNS} from '../../src/share/scrubber.js';
+
+const text = FC.array(FC.constantFrom('a', 'b', 'c', 'A', 'B', 'C', '0', '1', ' ', '\n', 'é', '😀'), {
+  maxLength: 60,
+}).map(characters => characters.join(''));
+const flags = FC.constantFrom('', 'g', 'i', 'gi', 'm', 'gm', 's', 'gs', 'y', 'gy', 'iy', 'giy', 'u', 'gu', 'uy', 'guy');
+const source = FC.constantFrom('[a-c]+', 'a|b', '(?=a)', '^a', 'a$', '\\s+', '[é😀]', 'a.*?b', '[01]');
+
+function uncachedCustomRedaction(content: string, regex: RegExp, placeholder: string) {
+  if (!new RegExp(regex.source, regex.flags).test(content)) return {cleaned: content, redactions: []};
+  const global = new RegExp(regex.source, regex.flags.includes('g') ? regex.flags : `${regex.flags}g`);
+  return {
+    cleaned: content.replace(global, placeholder),
+    redactions: [{count: (content.match(global) ?? []).length, name: 'custom'}],
+  };
+}
+
+describe('private scrubber matching clones', () => {
+  it.prop(
+    'matches fresh native regexes across same-owner mutation, repetition and restoration',
+    {
+      steps: FC.array(FC.record({flags, lastIndex: FC.integer({max: 100, min: 0}), source, text}), {
+        maxLength: 12,
+        minLength: 1,
+      }),
+      placeholder: FC.constantFrom('<mask>', '$&', '$$', '$`', "$'"),
+    },
+    ({steps, placeholder}) => {
+      const regex = /a/;
+      for (const step of [...steps, steps[0]]) {
+        regex.compile(step.source, step.flags);
+        regex.lastIndex = step.lastIndex;
+        const expected = uncachedCustomRedaction(step.text, regex, placeholder);
+        for (let repeat = 0; repeat < 2; repeat += 1) {
+          expect(
+            applyScrubber(step.text, {additionalPatterns: [{name: 'custom', placeholder, regex}], redact: true}),
+          ).toEqual(expected);
+          expect(regex.lastIndex).toBe(step.lastIndex);
+          expect(regex.source).toBe(step.source);
+          expect(regex.flags).toBe(new RegExp(step.source, step.flags).flags);
+        }
+      }
+    },
+    {fastCheck: {numRuns: 75}},
+  );
+
+  it('observes catalog regex recompilation without changing caller-owned state', () => {
+    const regex = SCRUBBER_PATTERNS[0].regex;
+    const initial = {flags: regex.flags, lastIndex: regex.lastIndex, source: regex.source};
+    try {
+      regex.compile('ALPHA', 'g');
+      regex.lastIndex = 50;
+      expect(redactSensitiveText('ALPHA BETA ALPHA')).toBe('<secret> BETA <secret>');
+      expect(regex.lastIndex).toBe(50);
+      regex.compile('beta', 'gi');
+      regex.lastIndex = 25;
+      expect(redactSensitiveText('ALPHA BETA ALPHA')).toBe('ALPHA <secret> ALPHA');
+      expect(regex.lastIndex).toBe(25);
+      regex.compile('ALPHA', 'g');
+      expect(redactSensitiveText('ALPHA BETA ALPHA')).toBe('<secret> BETA <secret>');
+    } finally {
+      regex.compile(initial.source, initial.flags);
+      regex.lastIndex = initial.lastIndex;
+    }
+    expect(redactSensitiveText('-----BEGIN RSA PRIVATE KEY-----')).toBe('<secret>');
+  });
+
+  it('keeps repeated credential and local-path redaction byte-compatible', () => {
+    const token = ['ghp_', 'abcdefghijklmnopqrst'].join('');
+    const input = `token=value ${token} /Users/example/work C:\\Users\\example\\work`;
+    for (let repeat = 0; repeat < 3; repeat += 1) {
+      expect(redactSensitiveText(input)).toBe('token=[REDACTED] <secret> <local-path> <local-path>');
+      expect(applyScrubber(input, {redact: true})).toEqual({blocker: 'GitHub token', cleaned: input, redactions: []});
+    }
+  });
+
+  it('preserves output when an oversized pattern evicts the retained clone', () => {
+    const regex = /a/;
+    for (const pattern of ['a', 'a'.repeat(65_537), 'a']) {
+      regex.compile(pattern, 'g');
+      regex.lastIndex = 7;
+      const content = pattern;
+      expect(
+        applyScrubber(content, {additionalPatterns: [{name: 'custom', placeholder: '<mask>', regex}], redact: true}),
+      ).toEqual(uncachedCustomRedaction(content, regex, '<mask>'));
+      expect(regex.lastIndex).toBe(7);
+    }
+  });
+});


### PR DESCRIPTION
Graph status and citation validation repeatedly rebuild redaction regexes, normalize identical SQL definitions, and record the same local association again when closing a citation read. This removes that repeated work while preserving fresh repository, worktree, policy, admission, runtime, and schema observations.

Redaction now reuses private, mutation-aware regex clones without changing caller state. SQL normalization uses a bounded cache keyed by the complete input string. Local citation validation reobserves its verified identity without a second association write; the closing Git status is bound to the actual repository root, common directory, and HEAD, including same-commit caller retargets.

Validation:

- 159 focused tests pass, including native-model regex properties, SQL normalization properties and real SQLite corruption checks, and real Git routing/currentness regressions. Full precommit passes; independent review is complete.
- Clean local Context Brief comparison: mean validation 92.02 → 74.75 ms, process CPU 76.81 → 60.40 ms, and final Git commands 10 → 6. Every receipt remains exact/current-complete, with the same session, evidence batch, two status observations, and balanced lease. This is a bounded 672-file diagnostic with five measured samples, not release qualification.
- Both clean default graph runs pass local budgets at 100 samples / five warmups. Parent CPU medians improve 4–7%, while wall times increase (hot median 68.97 → 88.79 ms); this pair does not establish a general query wall-time improvement.
- Exact commit `44450a2d` installed globally and passed the isolated Context Brief CLI smoke: one resolved anchor and matched memory, an exact/current-complete citation, no pending intent, and fixture cleanup. Full PR CI and new final-commit hosted release qualification remain required; thresholds, runners, samples, and release policy are unchanged.
